### PR TITLE
fix: inline source content in sourcemaps to prevent missing source warnings

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
+    "inlineSources": true,
     "outDir": "dist"
   },
   "exclude": ["node_modules", "dist", "fixtures", "tests/fixtures", "benchmarks", "examples"]


### PR DESCRIPTION
## Problem

When vinext is installed from npm, Vite logs many warnings during dev:

```
Sourcemap for ".../node_modules/vinext/dist/server/image-optimization.js" points to missing source files
Sourcemap for ".../node_modules/vinext/dist/shims/navigation.js" points to missing source files
...
```

The published `dist/` includes `.js.map` files that reference the original `.ts` source files via `"sources"`, but the `.ts` files aren't included in the npm package.

## Fix

Adds `"inlineSources": true` to `tsconfig.json`. This tells `tsc` to embed the original TypeScript source content directly in the `.js.map` files via `sourcesContent`, so no separate source files are needed.

Verified: after building, `.js.map` files now contain `sourcesContent` with the full original source.

Fixes #2