### PR TITLE
chore: bump version to 0.0.2

### DIFF
--- a/packages/vinext/package.json
+++ b/packages/vinext/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vinext",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Run Next.js apps on Vite. Drop-in replacement for the next CLI.",
   "license": "MIT",
   "repository": {
@@ -11,7 +11,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {
-    "vinext": "./dist/cli.js"
+    "vinext": "dist/cli.js"
   },
   "exports": {
     ".": {


### PR DESCRIPTION
## Summary
- Bump version to 0.0.2 (matches what's published on npm)
- Fix bin path format (`dist/cli.js` instead of `./dist/cli.js`)

Includes Sunil's three fixes: optimizeDeps exclusion (#3), inline sourcemaps (#5), and dynamic `"use client"` (#7).