### PR TITLE
ci: disable scheduled tip workflow

### DIFF
--- a/.github/workflows/tip.yml
+++ b/.github/workflows/tip.yml
@@ -1,9 +1,7 @@
 name: "Next.js tip"
 
 on:
-  schedule:
-    - cron: "0 */6 * * *"
-  workflow_dispatch:
+  workflow_dispatch: # disabled schedule — re-enable once ecosystem tests are stable
 
 permissions:
   contents: read


### PR DESCRIPTION
The Next.js canary ecosystem test (`tip.yml`) runs every 6 hours and is failing on main, creating noise. Disable the schedule for now — keep `workflow_dispatch` so it can still be run manually. Re-enable once ecosystem tests are stable.