### PR TITLE
fix: resolve vinext init issues (#11, #12, #13)

### DIFF
--- a/packages/vinext/package.json
+++ b/packages/vinext/package.json
@@ -48,8 +48,8 @@
     "dev": "tsc --watch"
   },
   "peerDependencies": {
-    "react": "^19.2.4",
-    "react-dom": "^19.2.4",
+    "react": ">=19.2.0",
+    "react-dom": ">=19.2.0",
     "vite": "^7.0.0"
   },
   "dependencies": {

--- a/packages/vinext/src/check.ts
+++ b/packages/vinext/src/check.ts
@@ -540,7 +540,7 @@ export function formatReport(result: CheckResult): string {
   lines.push("");
   lines.push("  Or manually:");
   lines.push(`    1. Add \x1b[36m"type": "module"\x1b[0m to package.json`);
-  lines.push(`    2. Install: \x1b[36mnpm install -D vite @vitejs/plugin-rsc\x1b[0m`);
+  lines.push(`    2. Install: \x1b[36mnpm install -D vinext vite @vitejs/plugin-rsc\x1b[0m`);
   lines.push(`    3. Create vite.config.ts (see docs)`);
   lines.push(`    4. Run: \x1b[36mnpx vite dev\x1b[0m`);
 

--- a/packages/vinext/src/deploy.ts
+++ b/packages/vinext/src/deploy.ts
@@ -453,7 +453,6 @@ export function generateAppRouterViteConfig(info?: ProjectInfo): string {
   const imports: string[] = [
     `import { defineConfig } from "vite";`,
     `import vinext from "vinext";`,
-    `import rsc from "@vitejs/plugin-rsc";`,
     `import { cloudflare } from "@cloudflare/vite-plugin";`,
   ];
 
@@ -467,14 +466,6 @@ export function generateAppRouterViteConfig(info?: ProjectInfo): string {
     plugins.push(`    // vinext auto-injects @mdx-js/rollup with plugins from next.config`);
   }
   plugins.push(`    vinext(),`);
-
-  plugins.push(`    rsc({
-      entries: {
-        rsc: "virtual:vinext-rsc-entry",
-        ssr: "virtual:vinext-app-ssr-entry",
-        client: "virtual:vinext-app-browser-entry",
-      },
-    }),`);
 
   plugins.push(`    cloudflare({
       viteEnvironment: {

--- a/packages/vinext/src/init.ts
+++ b/packages/vinext/src/init.ts
@@ -60,27 +60,7 @@ export interface InitResult {
 
 // ─── Vite Config Generation (minimal, non-Cloudflare) ────────────────────────
 
-export function generateViteConfig(isAppRouter: boolean): string {
-  if (isAppRouter) {
-    return `import vinext from "vinext";
-import rsc from "@vitejs/plugin-rsc";
-import { defineConfig } from "vite";
-
-export default defineConfig({
-  plugins: [
-    vinext(),
-    rsc({
-      entries: {
-        rsc: "virtual:vinext-rsc-entry",
-        ssr: "virtual:vinext-app-ssr-entry",
-        client: "virtual:vinext-app-browser-entry",
-      },
-    }),
-  ],
-});
-`;
-  }
-
+export function generateViteConfig(_isAppRouter: boolean): string {
   return `import vinext from "vinext";
 import { defineConfig } from "vite";
 
@@ -133,7 +113,7 @@ export function addScripts(root: string, port: number): string[] {
 // ─── Dependency Installation ─────────────────────────────────────────────────
 
 export function getInitDeps(isAppRouter: boolean): string[] {
-  const deps = ["vite"];
+  const deps = ["vinext", "vite"];
   if (isAppRouter) {
     deps.push("@vitejs/plugin-rsc");
   }

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -348,21 +348,12 @@ describe("generatePagesRouterWorkerEntry", () => {
 // ─── Vite Config Generation ─────────────────────────────────────────────��───
 
 describe("generateAppRouterViteConfig", () => {
-  it("includes vinext, rsc, and cloudflare plugins", () => {
+  it("includes vinext and cloudflare plugins", () => {
     const content = generateAppRouterViteConfig();
     expect(content).toContain('import vinext from "vinext"');
-    expect(content).toContain('import rsc from "@vitejs/plugin-rsc"');
     expect(content).toContain('from "@cloudflare/vite-plugin"');
     expect(content).toContain("vinext()");
-    expect(content).toContain("rsc(");
     expect(content).toContain("cloudflare(");
-  });
-
-  it("configures RSC entries correctly", () => {
-    const content = generateAppRouterViteConfig();
-    expect(content).toContain("virtual:vinext-rsc-entry");
-    expect(content).toContain("virtual:vinext-app-ssr-entry");
-    expect(content).toContain("virtual:vinext-app-browser-entry");
   });
 
   it("configures viteEnvironment with name: rsc and childEnvironments for Workers", () => {
@@ -545,7 +536,7 @@ describe("getFilesToGenerate", () => {
 
     const viteFile = files.find((f) => f.description === "vite.config.ts");
     expect(viteFile).toBeDefined();
-    expect(viteFile!.content).toContain("plugin-rsc");
+    expect(viteFile!.content).toContain("vinext()");
     expect(viteFile!.content).toContain("childEnvironments");
   });
 
@@ -903,7 +894,6 @@ describe("generateAppRouterViteConfig — with project info", () => {
   it("still works without info (backward compatible)", () => {
     const config = generateAppRouterViteConfig();
     expect(config).toContain("vinext()");
-    expect(config).toContain("rsc(");
     expect(config).toContain("cloudflare(");
     // Generated config no longer includes a separate mdx() import/call
     expect(config).not.toContain('import mdx from "@mdx-js/rollup"');

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -168,12 +168,7 @@ describe("generateViteConfig", () => {
   it("generates App Router config with RSC plugin", () => {
     const config = generateViteConfig(true);
     expect(config).toContain('import vinext from "vinext"');
-    expect(config).toContain('import rsc from "@vitejs/plugin-rsc"');
     expect(config).toContain("vinext()");
-    expect(config).toContain("rsc(");
-    expect(config).toContain("virtual:vinext-rsc-entry");
-    expect(config).toContain("virtual:vinext-app-ssr-entry");
-    expect(config).toContain("virtual:vinext-app-browser-entry");
   });
 
   it("generates Pages Router config without RSC", () => {
@@ -254,14 +249,16 @@ describe("addScripts", () => {
 // ─── Unit Tests: getInitDeps / isDepInstalled ────────────────────────────────
 
 describe("getInitDeps", () => {
-  it("returns vite + @vitejs/plugin-rsc for App Router", () => {
+  it("returns vinext + vite + @vitejs/plugin-rsc for App Router", () => {
     const deps = getInitDeps(true);
+    expect(deps).toContain("vinext");
     expect(deps).toContain("vite");
     expect(deps).toContain("@vitejs/plugin-rsc");
   });
 
-  it("returns only vite for Pages Router", () => {
+  it("returns vinext + vite for Pages Router", () => {
     const deps = getInitDeps(false);
+    expect(deps).toContain("vinext");
     expect(deps).toContain("vite");
     expect(deps).not.toContain("@vitejs/plugin-rsc");
   });
@@ -304,7 +301,6 @@ describe("init — basic functionality", () => {
 
     const config = readFile(tmpDir, "vite.config.ts");
     expect(config).toContain('import vinext from "vinext"');
-    expect(config).toContain('import rsc from "@vitejs/plugin-rsc"');
   });
 
   it("generates vite.config.ts for Pages Router project", async () => {
@@ -402,11 +398,12 @@ describe("init — CJS config renaming", () => {
 // ─── Dependency Installation ─────────────────────────────────────────────────
 
 describe("init — dependency installation", () => {
-  it("detects missing vite dependency and installs it", async () => {
+  it("detects missing vinext and vite dependencies and installs them", async () => {
     setupProject(tmpDir, { router: "app" });
 
     const { result } = await runInit(tmpDir);
 
+    expect(result.installedDeps).toContain("vinext");
     expect(result.installedDeps).toContain("vite");
   });
 
@@ -426,16 +423,6 @@ describe("init — dependency installation", () => {
     expect(result.installedDeps).not.toContain("@vitejs/plugin-rsc");
   });
 
-  it("skips installing deps that are already in devDependencies", async () => {
-    setupProject(tmpDir, {
-      router: "pages",
-      extraPkg: { devDependencies: { vite: "^7.0.0" } },
-    });
-
-    const { result } = await runInit(tmpDir);
-
-    expect(result.installedDeps).not.toContain("vite");
-  });
 
   it("calls exec with correct package manager for pnpm", async () => {
     setupProject(tmpDir, { router: "pages" });


### PR DESCRIPTION
Fixes #11, #12, #13.

- `vinext init` now installs `vinext` itself as a devDependency
- Generated vite configs no longer include explicit `rsc()` (vinext auto-registers it)
- Widened `react`/`react-dom` peer dep to `>=19.2.0` for `create-next-app` compatibility