### PR TITLE
chore: bump version to 0.0.3

### DIFF
--- a/packages/vinext/package.json
+++ b/packages/vinext/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vinext",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Run Next.js apps on Vite. Drop-in replacement for the next CLI.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Matches what's published on npm. Includes Fred's init fixes (#15) and the check messaging fix (#14).