### PR TITLE
Fix binary response handling in Pages Router prod server

### DIFF
--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -762,7 +762,7 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
         }
 
         // Merge middleware + config headers into the response
-        const responseBody = await response.text();
+        const responseBody = Buffer.from(await response.arrayBuffer());
         const ct = response.headers.get("content-type") ?? "text/html";
         const responseHeaders: Record<string, string> = { ...middlewareHeaders };
         response.headers.forEach((v, k) => { responseHeaders[k] = v; });
@@ -811,7 +811,7 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
       }
 
       // Merge middleware + config headers into the response
-      const responseBody = await response.text();
+      const responseBody = Buffer.from(await response.arrayBuffer());
       const ct = response.headers.get("content-type") ?? "text/html";
       const responseHeaders: Record<string, string> = { ...middlewareHeaders };
       response.headers.forEach((v, k) => { responseHeaders[k] = v; });

--- a/tests/fixtures/pages-basic/pages/api/binary.ts
+++ b/tests/fixtures/pages-basic/pages/api/binary.ts
@@ -1,0 +1,9 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export default function handler(_req: NextApiRequest, res: NextApiResponse) {
+  // Leading bytes are intentionally invalid UTF-8; if a text decode/encode
+  // path is introduced, this payload will be visibly corrupted.
+  const body = Buffer.from([0xff, 0xfe, 0xfd, 0x00, 0x61, 0x62, 0x63]);
+  res.setHeader("Content-Type", "application/octet-stream");
+  res.status(200).end(body);
+}


### PR DESCRIPTION
Fixes a Pages Router prod-server response handling bug where `response.text()` could corrupt binary payloads.

### Changes
- Switch Pages Router prod response reads from `response.text()` to `Buffer.from(await response.arrayBuffer())`
- Add `/api/binary` fixture route returning known bytes
- Add regression test asserting exact byte preservation for `/api/binary`

### Why
API routes can return raw bytes (`res.end(Buffer)`). Decoding as text before writing can mangle non-UTF8 bytes.

