### PR TITLE
ci: add pkg.pr.new preview releases for PRs

### DIFF
--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -1,0 +1,23 @@
+name: Preview Release
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install
+      - run: pnpm run build
+      - run: pnpm dlx pkg-pr-new publish './packages/vinext'


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow that publishes preview releases of the `vinext` package via [pkg.pr.new](https://github.com/stackblitz-labs/pkg.pr.new) on every push to `main` and every PR.
- Once CI runs, PRs will get a comment with an install link like `npm i https://pkg.pr.new/vinext@<pr-number>`, making it easy to test changes without publishing to npm.