### PR TITLE
docs: add SECURITY.md with vulnerability reporting info

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Security Policy
+
+https://www.cloudflare.com/disclosure
+
+## Reporting a Vulnerability
+
+* https://hackerone.com/cloudflare
+  * All Cloudflare products are in scope for reporting. If you submit a valid report on bounty-eligible assets through our disclosure program, we will transfer your report to our private bug bounty program and invite you as a participant.
+* `mailto:security@cloudflare.com`
+  * If you'd like to encrypt your message, please do so within the the body of the message. Our email system doesn't handle PGP-MIME well.
+  * https://www.cloudflare.com/gpg/security-at-cloudflare-pubkey-06A67236.txt
+
+All abuse reports should be submitted to our Trust & Safety team through our dedicated page: https://www.cloudflare.com/abuse/


### PR DESCRIPTION
## Summary

- Adds a `SECURITY.md` file with vulnerability reporting guidance, matching the style used in [cloudflare/workerd](https://github.com/cloudflare/workerd/blob/main/SECURITY.md)
- Includes Cloudflare disclosure policy link, HackerOne program, security email with GPG key, and abuse reporting link