### PR TITLE
ci: test pkg.pr.new with app access

### DIFF
--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -20,4 +20,4 @@ jobs:
           cache: pnpm
       - run: pnpm install
       - run: pnpm run build
-      - run: pnpm dlx pkg-pr-new publish './packages/vinext'
+      - run: pnpm dlx pkg-pr-new publish --pnpm './packages/vinext'


### PR DESCRIPTION
Testing pkg.pr.new now that the GitHub App has access to vinext. Adds --pnpm flag to match workers-sdk setup.