### PR TITLE
feat: type aware linting with tsgolint

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsgo --noEmit",
-    "lint": "oxlint --deny-warnings",
+    "lint": "oxlint --deny-warnings --type-aware",
     "test:e2e": "playwright test"
   },
   "devDependencies": {
@@ -19,6 +19,7 @@
     "@vitejs/plugin-rsc": "^0.5.19",
     "image-size": "2.0.2",
     "oxlint": "^1.47.0",
+    "oxlint-tsgolint": "^0.15.0",
     "playwright": "^1.52.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/packages/vinext/src/client/entry.ts
+++ b/packages/vinext/src/client/entry.ts
@@ -87,4 +87,4 @@ async function hydrate() {
   (window as any).__VINEXT_ROOT__ = root;
 }
 
-hydrate();
+void hydrate();

--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -295,7 +295,7 @@ export async function resolveNextConfig(
 
   const output = config.output ?? "";
   if (output && output !== "export" && output !== "standalone") {
-    console.warn(`[vinext] Unknown output mode "${output}", ignoring`);
+    console.warn(`[vinext] Unknown output mode "${output as string}", ignoring`);
   }
 
   // Parse i18n config

--- a/packages/vinext/src/shims/cache-runtime.ts
+++ b/packages/vinext/src/shims/cache-runtime.ts
@@ -148,7 +148,8 @@ export async function replyToCacheKey(reply: string | FormData): Promise<string>
   // Collect entries in stable order (sorted by name, then by value for
   // entries with the same name) so the hash is deterministic.
   const entries: [string, FormDataEntryValue][] = [...reply.entries()];
-  entries.sort((a, b) => a[0].localeCompare(b[0]) || String(a[1]).localeCompare(String(b[1])));
+  const valStr = (v: FormDataEntryValue): string => typeof v === "string" ? v : v.name;
+  entries.sort((a, b) => a[0].localeCompare(b[0]) || valStr(a[1]).localeCompare(valStr(b[1])));
 
   const parts: string[] = [];
   for (const [name, value] of entries) {

--- a/packages/vinext/src/shims/form.tsx
+++ b/packages/vinext/src/shims/form.tsx
@@ -69,7 +69,7 @@ const Form = forwardRef(function Form(
       }
     }
 
-    const url = `${action}?${params.toString()}`;
+    const url = `${action as string}?${params.toString()}`;
 
     // Navigate client-side
     const win = window as any;

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -393,12 +393,12 @@ function restoreScrollPosition(state: unknown): void {
     // Defer to allow other popstate listeners (browser entry) to run first
     // and set __VINEXT_RSC_PENDING__. Promise.resolve() schedules a microtask
     // that runs after all synchronous event listeners have completed.
-    Promise.resolve().then(() => {
+    void Promise.resolve().then(() => {
       const pending: Promise<void> | null = (window as any).__VINEXT_RSC_PENDING__ ?? null;
 
       if (pending) {
         // Wait for the RSC navigation to finish rendering, then scroll.
-        pending.then(() => {
+        void pending.then(() => {
           requestAnimationFrame(() => {
             window.scrollTo(x, y);
           });
@@ -488,11 +488,11 @@ export function useRouter() {
   const router = {
     push(href: string, options?: { scroll?: boolean }): void {
       if (isServer) return;
-      navigateImpl(href, "push", options?.scroll !== false);
+      void navigateImpl(href, "push", options?.scroll !== false);
     },
     replace(href: string, options?: { scroll?: boolean }): void {
       if (isServer) return;
-      navigateImpl(href, "replace", options?.scroll !== false);
+      void navigateImpl(href, "replace", options?.scroll !== false);
     },
     back(): void {
       if (isServer) return;

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -395,7 +395,7 @@ export function useRouter(): NextRouter {
     const onPopState = (e: PopStateEvent) => {
       setState(getPathnameAndQuery());
       // Re-render with the new page on back/forward navigation
-      navigateClient(window.location.pathname + window.location.search).then(() => {
+      void navigateClient(window.location.pathname + window.location.search).then(() => {
         restoreScrollPosition(e.state);
       });
     };
@@ -579,7 +579,7 @@ if (typeof window !== "undefined") {
     }
 
     routerEvents.emit("routeChangeStart", appUrl);
-    navigateClient(browserUrl).then(() => {
+    void navigateClient(browserUrl).then(() => {
       routerEvents.emit("routeChangeComplete", appUrl);
       restoreScrollPosition(e.state);
       window.dispatchEvent(new CustomEvent("vinext:navigate"));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,7 +41,10 @@ importers:
         version: 2.0.2
       oxlint:
         specifier: ^1.47.0
-        version: 1.48.0
+        version: 1.48.0(oxlint-tsgolint@0.15.0)
+      oxlint-tsgolint:
+        specifier: ^0.15.0
+        version: 0.15.0
       playwright:
         specifier: ^1.52.0
         version: 1.58.2
@@ -1081,6 +1084,36 @@ packages:
   '@noble/hashes@2.0.1':
     resolution: {integrity: sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==}
     engines: {node: '>= 20.19.0'}
+
+  '@oxlint-tsgolint/darwin-arm64@0.15.0':
+    resolution: {integrity: sha512-d7Ch+A6hic+RYrm32+Gh1o4lOrQqnFsHi721ORdHUDBiQPea+dssKUEMwIbA6MKmCy6TVJ02sQyi24OEfCiGzw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxlint-tsgolint/darwin-x64@0.15.0':
+    resolution: {integrity: sha512-Aoai2wAkaUJqp/uEs1gml6TbaPW4YmyO5Ai/vOSkiizgHqVctjhjKqmRiWTX2xuPY94VkwOLqp+Qr3y/0qSpWQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxlint-tsgolint/linux-arm64@0.15.0':
+    resolution: {integrity: sha512-4og13a7ec4Vku5t2Y7s3zx6YJP6IKadb1uA9fOoRH6lm/wHWoCnxjcfJmKHXRZJII81WmbdJMSPxaBfwN/S68Q==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxlint-tsgolint/linux-x64@0.15.0':
+    resolution: {integrity: sha512-9b9xzh/1Harn3a+XiKTK/8LrWw3VcqLfYp/vhV5/zAVR2Mt0d63WSp4FL+wG7DKnI2T/CbMFUFHwc7kCQjDMzQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxlint-tsgolint/win32-arm64@0.15.0':
+    resolution: {integrity: sha512-nNac5hewHdkk5mowOwTqB1ZD76zB/FsUiyUvdCyupq5cG54XyKqSLEp9QGbx7wFJkWCkeWmuwRed4sfpAlKaeA==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxlint-tsgolint/win32-x64@0.15.0':
+    resolution: {integrity: sha512-ioAY2XLpy83E2EqOLH9p1cEgj0G2qB1lmAn0a3yFV1jHQB29LIPIKGNsu/tYCClpwmHN79pT5KZAHZOgWxxqNg==}
+    cpu: [x64]
+    os: [win32]
 
   '@oxlint/binding-android-arm-eabi@1.48.0':
     resolution: {integrity: sha512-1Pz/stJvveO9ZO7ll4ZoEY3f6j2FiUgBLBcCRCiW6ylId9L9UKs+gn3X28m3eTnoiFCkhKwmJJ+VO6vwsu7Qtg==}
@@ -2767,6 +2800,10 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
+  oxlint-tsgolint@0.15.0:
+    resolution: {integrity: sha512-iwvFmhKQVZzVTFygUVI4t2S/VKEm+Mqkw3jQRJwfDuTcUYI5LCIYzdO5Dbuv4mFOkXZCcXaRRh0m+uydB5xdqw==}
+    hasBin: true
+
   oxlint@1.48.0:
     resolution: {integrity: sha512-m5vyVBgPtPhVCJc3xI//8je9lRc8bYuYB4R/1PH3VPGOjA4vjVhkHtyJukdEjYEjwrw4Qf1eIf+pP9xvfhfMow==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -3750,6 +3787,24 @@ snapshots:
   '@noble/ciphers@2.1.1': {}
 
   '@noble/hashes@2.0.1': {}
+
+  '@oxlint-tsgolint/darwin-arm64@0.15.0':
+    optional: true
+
+  '@oxlint-tsgolint/darwin-x64@0.15.0':
+    optional: true
+
+  '@oxlint-tsgolint/linux-arm64@0.15.0':
+    optional: true
+
+  '@oxlint-tsgolint/linux-x64@0.15.0':
+    optional: true
+
+  '@oxlint-tsgolint/win32-arm64@0.15.0':
+    optional: true
+
+  '@oxlint-tsgolint/win32-x64@0.15.0':
+    optional: true
 
   '@oxlint/binding-android-arm-eabi@1.48.0':
     optional: true
@@ -5299,7 +5354,16 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
-  oxlint@1.48.0:
+  oxlint-tsgolint@0.15.0:
+    optionalDependencies:
+      '@oxlint-tsgolint/darwin-arm64': 0.15.0
+      '@oxlint-tsgolint/darwin-x64': 0.15.0
+      '@oxlint-tsgolint/linux-arm64': 0.15.0
+      '@oxlint-tsgolint/linux-x64': 0.15.0
+      '@oxlint-tsgolint/win32-arm64': 0.15.0
+      '@oxlint-tsgolint/win32-x64': 0.15.0
+
+  oxlint@1.48.0(oxlint-tsgolint@0.15.0):
     optionalDependencies:
       '@oxlint/binding-android-arm-eabi': 1.48.0
       '@oxlint/binding-android-arm64': 1.48.0
@@ -5320,6 +5384,7 @@ snapshots:
       '@oxlint/binding-win32-arm64-msvc': 1.48.0
       '@oxlint/binding-win32-ia32-msvc': 1.48.0
       '@oxlint/binding-win32-x64-msvc': 1.48.0
+      oxlint-tsgolint: 0.15.0
 
   package-json-from-dist@1.0.1: {}
 

--- a/tests/e2e/app-router/nextjs-compat/external-redirect.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/external-redirect.spec.ts
@@ -25,7 +25,7 @@ test.describe("Next.js compat: external-redirect (browser)", () => {
     let externalRedirectUrl = "";
     await page.route("https://example.com/**", (route) => {
       externalRedirectUrl = route.request().url();
-      route.fulfill({
+      return route.fulfill({
         status: 200,
         contentType: "text/html",
         body: "<html><body>External page</body></html>",

--- a/tests/fixtures/app-basic/tsconfig.json
+++ b/tests/fixtures/app-basic/tsconfig.json
@@ -7,7 +7,6 @@
     "strict": true,
     "skipLibCheck": true,
     "types": ["vite/client", "@vitejs/plugin-rsc/types"],
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./*"]
     }

--- a/tests/fixtures/pages-basic/tsconfig.json
+++ b/tests/fixtures/pages-basic/tsconfig.json
@@ -6,7 +6,6 @@
     "jsx": "react-jsx",
     "strict": true,
     "skipLibCheck": true,
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./*"]
     }

--- a/tests/safe-json.test.ts
+++ b/tests/safe-json.test.ts
@@ -220,7 +220,7 @@ describe("safeJsonStringify", () => {
       // We use Function() here intentionally in the test to verify the output
       // is valid JS — this is the exact context where it will be used (inside
       // a <script> tag).
-      // eslint-disable-next-line no-new-func
+      // eslint-disable-next-line no-new-func, typescript-eslint/no-implied-eval
       const parsed = new Function(`return (${result})`)();
       expect(parsed).toEqual(data);
     });
@@ -242,7 +242,7 @@ describe("safeJsonStringify", () => {
       const result = safeJsonStringify(data);
 
       // Must be valid JS
-      // eslint-disable-next-line no-new-func
+      // eslint-disable-next-line no-new-func, typescript-eslint/no-implied-eval
       const parsed = new Function(`return (${result})`)();
       expect(parsed).toEqual(data);
     });
@@ -264,7 +264,7 @@ describe("safeJsonStringify", () => {
         emoji: "\uD83D\uDE00", // grinning face
       };
       const result = safeJsonStringify(data);
-      // eslint-disable-next-line no-new-func
+      // eslint-disable-next-line no-new-func, typescript-eslint/no-implied-eval
       const parsed = new Function(`return (${result})`)();
       expect(parsed).toEqual(data);
     });
@@ -290,7 +290,7 @@ describe("safeJsonStringify", () => {
       const long = "x".repeat(100000) + "</script>" + "y".repeat(100000);
       const result = safeJsonStringify(long);
       expect(result).not.toContain("</script>");
-      // eslint-disable-next-line no-new-func
+      // eslint-disable-next-line no-new-func, typescript-eslint/no-implied-eval
       const parsed = new Function(`return (${result})`)();
       expect(parsed).toBe(long);
     });
@@ -301,7 +301,7 @@ describe("safeJsonStringify", () => {
       // should remain as-is in the JSON (JSON.stringify already escapes the backslash).
       const input = "already escaped: \\u003c";
       const result = safeJsonStringify(input);
-      // eslint-disable-next-line no-new-func
+      // eslint-disable-next-line no-new-func, typescript-eslint/no-implied-eval
       const parsed = new Function(`return (${result})`)();
       expect(parsed).toBe(input);
     });
@@ -313,7 +313,7 @@ describe("safeJsonStringify", () => {
         count: 42,
       };
       const result = safeJsonStringify(data);
-      // eslint-disable-next-line no-new-func
+      // eslint-disable-next-line no-new-func, typescript-eslint/no-implied-eval
       const parsed = new Function(`return (${result})`)();
       expect(parsed).toEqual(data);
     });


### PR DESCRIPTION
https://oxc.rs/docs/guide/usage/linter/type-aware.html


I've fixed some lint warnings

```
$ pnpm run lint

> vinext-monorepo@ lint /Users/nishimura/projects/oss/ubugeeei/vinex
> oxlint --deny-warnings --type-aware


  × typescript(tsconfig-error): Invalid tsconfig
    ╭─[tests/fixtures/app-basic/tsconfig.json:10:5]
  9 │     "types": ["vite/client", "@vitejs/plugin-rsc/types"],
 10 │     "baseUrl": ".",
    ·     ─────────
 11 │     "paths": {
    ╰────
  help: Option 'baseUrl' has been removed. Please remove it from your configuration.
        See https://github.com/oxc-project/tsgolint/issues/351 for more information.

  ⚠ typescript-eslint(restrict-template-expressions): Invalid type used in template literal expression.
     ╭─[packages/vinext/src/config/next-config.ts:298:51]
 297 │   if (output && output !== "export" && output !== "standalone") {
 298 │     console.warn(`[vinext] Unknown output mode "${output}", ignoring`);
     ·                                                   ───┬───
     ·                                                      ╰── Type: never
 299 │   }
     ╰────

  ⚠ typescript-eslint(no-base-to-string): 'a[1]' may use Object's default stringification format ('[object Object]') when stringified.
     ╭─[packages/vinext/src/shims/cache-runtime.ts:151:61]
 150 │   const entries: [string, FormDataEntryValue][] = [...reply.entries()];
 151 │   entries.sort((a, b) => a[0].localeCompare(b[0]) || String(a[1]).localeCompare(String(b[1])));
     ·                                                             ────
 152 │
     ╰────
  help: Consider picking a property (e.g. `user.name`), using a formatter (or `JSON.stringify`), or implementing a custom `toString()`/`toLocaleString()` on the type.

  ⚠ typescript-eslint(no-base-to-string): 'b[1]' may use Object's default stringification format ('[object Object]') when stringified.
     ╭─[packages/vinext/src/shims/cache-runtime.ts:151:88]
 150 │   const entries: [string, FormDataEntryValue][] = [...reply.entries()];
 151 │   entries.sort((a, b) => a[0].localeCompare(b[0]) || String(a[1]).localeCompare(String(b[1])));
     ·                                                                                        ────
 152 │
     ╰────
  help: Consider picking a property (e.g. `user.name`), using a formatter (or `JSON.stringify`), or implementing a custom `toString()`/`toLocaleString()` on the type.

  ⚠ typescript-eslint(restrict-template-expressions): Invalid type used in template literal expression.
    ╭─[packages/vinext/src/shims/form.tsx:72:20]
 71 │
 72 │     const url = `${action}?${params.toString()}`;
    ·                    ───┬───
    ·                       ╰── Type: string | ((formData: FormData) => void | Promise<void>)
 73 │
    ╰────

  ⚠ typescript-eslint(no-floating-promises): Promises must be awaited, add void operator to ignore.
     ╭─[packages/vinext/src/shims/navigation.ts:396:5]
 395 │         // that runs after all synchronous event listeners have completed.
 396 │ ╭─▶     Promise.resolve().then(() => {
 397 │ │         const pending: Promise<void> | null = (window as any).__VINEXT_RSC_PENDING__ ?? null;
 398 │ │
 399 │ │         if (pending) {
 400 │ │           // Wait for the RSC navigation to finish rendering, then scroll.
 401 │ │           pending.then(() => {
 402 │ │             requestAnimationFrame(() => {
 403 │ │               window.scrollTo(x, y);
 404 │ │             });
 405 │ │           });
 406 │ │         } else {
 407 │ │           // No RSC navigation in flight (Pages Router or already settled).
 408 │ │           requestAnimationFrame(() => {
 409 │ │             window.scrollTo(x, y);
 410 │ │           });
 411 │ │         }
 412 │ ╰─▶     });
 413 │       }
     ╰────
  help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.

  ⚠ typescript-eslint(no-floating-promises): Promises must be awaited, add void operator to ignore.
     ╭─[packages/vinext/src/shims/navigation.ts:401:9]
 400 │             // Wait for the RSC navigation to finish rendering, then scroll.
 401 │ ╭─▶         pending.then(() => {
 402 │ │             requestAnimationFrame(() => {
 403 │ │               window.scrollTo(x, y);
 404 │ │             });
 405 │ ╰─▶         });
 406 │           } else {
     ╰────
  help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.

  ⚠ typescript-eslint(no-floating-promises): Promises must be awaited, add void operator to ignore.
     ╭─[packages/vinext/src/shims/navigation.ts:491:7]
 490 │       if (isServer) return;
 491 │       navigateImpl(href, "push", options?.scroll !== false);
     ·       ──────────────────────────────────────────────────────
 492 │     },
     ╰────
  help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.

  ⚠ typescript-eslint(no-floating-promises): Promises must be awaited, add void operator to ignore.
     ╭─[packages/vinext/src/shims/navigation.ts:495:7]
 494 │       if (isServer) return;
 495 │       navigateImpl(href, "replace", options?.scroll !== false);
     ·       ─────────────────────────────────────────────────────────
 496 │     },
     ╰────
  help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.

  ⚠ typescript-eslint(no-floating-promises): Promises must be awaited, add void operator to ignore.
     ╭─[packages/vinext/src/shims/router.ts:398:7]
 397 │           // Re-render with the new page on back/forward navigation
 398 │ ╭─▶       navigateClient(window.location.pathname + window.location.search).then(() => {
 399 │ │           restoreScrollPosition(e.state);
 400 │ ╰─▶       });
 401 │         };
     ╰────
  help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.

  ⚠ typescript-eslint(no-floating-promises): Promises must be awaited, add void operator to ignore.
     ╭─[packages/vinext/src/shims/router.ts:582:5]
 581 │         routerEvents.emit("routeChangeStart", appUrl);
 582 │ ╭─▶     navigateClient(browserUrl).then(() => {
 583 │ │         routerEvents.emit("routeChangeComplete", appUrl);
 584 │ │         restoreScrollPosition(e.state);
 585 │ │         window.dispatchEvent(new CustomEvent("vinext:navigate"));
 586 │ ╰─▶     });
 587 │       });
     ╰────
  help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.

  ⚠ typescript-eslint(no-floating-promises): Promises must be awaited, add void operator to ignore.
    ╭─[packages/vinext/src/client/entry.ts:90:1]
 89 │
 90 │ hydrate();
    · ──────────
    ╰────
  help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.

  ⚠ typescript-eslint(no-implied-eval): Implied eval. Do not use the Function constructor to create functions.
     ╭─[tests/safe-json.test.ts:224:22]
 223 │       // eslint-disable-next-line no-new-func
 224 │       const parsed = new Function(`return (${result})`)();
     ·                      ──────────────────────────────────
 225 │       expect(parsed).toEqual(data);
     ╰────

  ⚠ typescript-eslint(no-implied-eval): Implied eval. Do not use the Function constructor to create functions.
     ╭─[tests/safe-json.test.ts:246:22]
 245 │       // eslint-disable-next-line no-new-func
 246 │       const parsed = new Function(`return (${result})`)();
     ·                      ──────────────────────────────────
 247 │       expect(parsed).toEqual(data);
     ╰────

  ⚠ typescript-eslint(no-implied-eval): Implied eval. Do not use the Function constructor to create functions.
     ╭─[tests/safe-json.test.ts:268:22]
 267 │       // eslint-disable-next-line no-new-func
 268 │       const parsed = new Function(`return (${result})`)();
     ·                      ──────────────────────────────────
 269 │       expect(parsed).toEqual(data);
     ╰────

  ⚠ typescript-eslint(no-implied-eval): Implied eval. Do not use the Function constructor to create functions.
     ╭─[tests/safe-json.test.ts:294:22]
 293 │       // eslint-disable-next-line no-new-func
 294 │       const parsed = new Function(`return (${result})`)();
     ·                      ──────────────────────────────────
 295 │       expect(parsed).toBe(long);
     ╰────

  ⚠ typescript-eslint(no-implied-eval): Implied eval. Do not use the Function constructor to create functions.
     ╭─[tests/safe-json.test.ts:305:22]
 304 │       // eslint-disable-next-line no-new-func
 305 │       const parsed = new Function(`return (${result})`)();
     ·                      ──────────────────────────────────
 306 │       expect(parsed).toBe(input);
     ╰────

  ⚠ typescript-eslint(no-implied-eval): Implied eval. Do not use the Function constructor to create functions.
     ╭─[tests/safe-json.test.ts:317:22]
 316 │       // eslint-disable-next-line no-new-func
 317 │       const parsed = new Function(`return (${result})`)();
     ·                      ──────────────────────────────────
 318 │       expect(parsed).toEqual(data);
     ╰────

  ⚠ typescript-eslint(no-floating-promises): Promises must be awaited, add void operator to ignore.
    ╭─[tests/e2e/app-router/nextjs-compat/external-redirect.spec.ts:28:7]
 27 │           externalRedirectUrl = route.request().url();
 28 │ ╭─▶       route.fulfill({
 29 │ │           status: 200,
 30 │ │           contentType: "text/html",
 31 │ │           body: "<html><body>External page</body></html>",
 32 │ ╰─▶       });
 33 │         });
    ╰────
  help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.

  × typescript(tsconfig-error): Invalid tsconfig
    ╭─[tests/fixtures/pages-basic/tsconfig.json:9:5]
  8 │     "skipLibCheck": true,
  9 │     "baseUrl": ".",
    ·     ─────────
 10 │     "paths": {
    ╰────
  help: Option 'baseUrl' has been removed. Please remove it from your configuration.
        See https://github.com/oxc-project/tsgolint/issues/351 for more information.

Found 18 warnings and 2 errors.
Finished in 1.4s on 465 files with 107 rules using 10 threads.
 ELIFECYCLE  Command failed with exit code 1.
```