### PR TITLE
fix: include /api routes in default middleware matcher

### DIFF
--- a/packages/vinext/src/server/middleware.ts
+++ b/packages/vinext/src/server/middleware.ts
@@ -92,10 +92,10 @@ export function matchesMiddleware(
   matcher: MatcherConfig | undefined,
 ): boolean {
   if (!matcher) {
-    // Default: match all paths except static files, _next, and favicon
+    // Default: match all paths except /_next internals, static files (paths with a file extension), and /favicon.ico — matching Next.js behaviour.
+    // Note: /api routes ARE included by default, consistent with Next.js.
     return (
       !pathname.startsWith("/_next") &&
-      !pathname.startsWith("/api") &&
       !pathname.includes(".") &&
       pathname !== "/favicon.ico"
     );

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -1481,14 +1481,15 @@ describe("middleware matcher patterns", () => {
     const { matchesMiddleware } = await import(
       "../packages/vinext/src/server/middleware.js"
     );
-    // Default: matches most paths
+    // Default: matches most paths, including /api routes (Next.js behaviour)
     expect(matchesMiddleware("/", undefined)).toBe(true);
     expect(matchesMiddleware("/about", undefined)).toBe(true);
     expect(matchesMiddleware("/dashboard/settings", undefined)).toBe(true);
+    expect(matchesMiddleware("/api/hello", undefined)).toBe(true);
+    expect(matchesMiddleware("/api/users/123", undefined)).toBe(true);
 
-    // Default: excludes /_next, /api, files with dots, /favicon.ico
+    // Default: excludes /_next internals, static files (extension), /favicon.ico
     expect(matchesMiddleware("/_next/static/chunk.js", undefined)).toBe(false);
-    expect(matchesMiddleware("/api/hello", undefined)).toBe(false);
     expect(matchesMiddleware("/favicon.ico", undefined)).toBe(false);
     expect(matchesMiddleware("/image.png", undefined)).toBe(false);
   });


### PR DESCRIPTION
## Intro
Before reviewing this PR, I have a quick question. I've modified the default behavior of `matchesMiddleware` so that middleware is now applied to `/api` routes by default. 
Was the previous behavior—excluding `/api` routes by default—an intentional design choice for this project?
- If it **was not intended**, could you please review if my fix is the right approach? 
- Conversely, if it **was intended**, it seems the comment in [packages/vinext/src/server/middleware.ts](cci:7://file:///Users/seoljaehyeok/projects/open-source/vinext/packages/vinext/src/server/middleware.ts:0:0-0:0) might be outdated or misleading regarding the current behavior. I would appreciate it if you could verify this as well.

 ## Summary
   - The default `matchesMiddleware` behaviour (no `matcher` config) was incorrectly excluding `/api`-prefixed routes from middleware execution
   - Next.js runs middleware on **all** routes by default, including `/api` — only `/_next` internals, static files (paths with a file extension), and `/favicon.ico` are excluded
   - This silent skip meant any app relying on middleware for auth, logging, or header injection on API routes would have middleware not applied, unless the user explicitly added a matcher that re-included
   `/api`

   **Changed files:**
   - `packages/vinext/src/server/middleware.ts` — removed `!pathname.startsWith("/api")` from the no-matcher default, updated comment
   - `tests/shims.test.ts` — updated test assertions to reflect correct Next.js-compatible behaviour (`/api/hello` and `/api/users/123` now expected to return `true`)

   ## Test plan

   - [x] `pnpm test` passes — all middleware matcher pattern tests updated and green
   - [x] Existing middleware integration tests unaffected

   ## References

   - [Next.js proxy docs](https://nextjs.org/docs/app/api-reference/file-conventions/proxy#matching-paths#execution-order): *"Proxy will be invoked for every route in your project*"