### PR TITLE
fix(init): install App Router RSC deps by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ npx vinext init
 This will:
 
 1. Run `vinext check` to scan for compatibility issues
-2. Install `vite` (and `@vitejs/plugin-rsc` for App Router projects) as devDependencies
+2. Install `vite`/`vinext` as devDependencies, plus App Router RSC deps (`@vitejs/plugin-rsc` in `devDependencies` and `react-server-dom-webpack` in `dependencies`)
 3. Rename CJS config files (e.g. `postcss.config.js` -> `.cjs`) to avoid ESM conflicts
 4. Add `"type": "module"` to `package.json`
 5. Add `dev:vinext` and `build:vinext` scripts to `package.json`

--- a/packages/vinext/src/check.ts
+++ b/packages/vinext/src/check.ts
@@ -541,9 +541,10 @@ export function formatReport(result: CheckResult, opts?: { calledFromInit?: bool
     lines.push("");
     lines.push("  Or manually:");
     lines.push(`    1. Add \x1b[36m"type": "module"\x1b[0m to package.json`);
-    lines.push(`    2. Install: \x1b[36mnpm install -D vinext vite @vitejs/plugin-rsc\x1b[0m`);
-    lines.push(`    3. Create vite.config.ts (see docs)`);
-    lines.push(`    4. Run: \x1b[36mnpx vite dev\x1b[0m`);
+    lines.push(`    2. Install dev deps: \x1b[36mnpm install -D vinext vite @vitejs/plugin-rsc\x1b[0m`);
+    lines.push(`    3. Install runtime deps: \x1b[36mnpm install react-server-dom-webpack\x1b[0m`);
+    lines.push(`    4. Create vite.config.ts (see docs)`);
+    lines.push(`    5. Run: \x1b[36mnpx vite dev\x1b[0m`);
   }
 
   lines.push("");

--- a/packages/vinext/src/deploy.ts
+++ b/packages/vinext/src/deploy.ts
@@ -5,7 +5,7 @@
  *
  *   1. Detects App Router vs Pages Router
  *   2. Auto-generates missing config files (wrangler.jsonc, worker/index.ts, vite.config.ts)
- *   3. Ensures dependencies are installed (@cloudflare/vite-plugin, wrangler, @vitejs/plugin-rsc)
+ *   3. Ensures dependencies are installed (@cloudflare/vite-plugin, wrangler, App Router RSC deps)
  *   4. Runs the Vite build
  *   5. Deploys to Cloudflare Workers via wrangler
  *
@@ -21,7 +21,7 @@ import { createBuilder, build } from "vite";
 import {
   ensureESModule as _ensureESModule,
   renameCJSConfigs as _renameCJSConfigs,
-  detectPackageManager as _detectPackageManager,
+  detectPackageManagerName as _detectPackageManagerName,
 } from "./utils/project.js";
 import { runTPR } from "./cloudflare/tpr.js";
 
@@ -57,6 +57,7 @@ interface ProjectInfo {
   hasWorkerEntry: boolean;
   hasCloudflarePlugin: boolean;
   hasRscPlugin: boolean;
+  hasReactServerDomWebpack: boolean;
   hasWrangler: boolean;
   projectName: string;
   /** Pages that use `revalidate` (ISR) */
@@ -105,6 +106,9 @@ export function detectProject(root: string): ProjectInfo {
   );
   const hasRscPlugin = fs.existsSync(
     path.join(root, "node_modules", "@vitejs", "plugin-rsc"),
+  );
+  const hasReactServerDomWebpack = fs.existsSync(
+    path.join(root, "node_modules", "react-server-dom-webpack"),
   );
   const hasWrangler = fs.existsSync(
     path.join(root, "node_modules", ".bin", "wrangler"),
@@ -170,6 +174,7 @@ export function detectProject(root: string): ProjectInfo {
     hasWorkerEntry,
     hasCloudflarePlugin,
     hasRscPlugin,
+    hasReactServerDomWebpack,
     hasWrangler,
     projectName,
     hasISR,
@@ -542,19 +547,39 @@ export default defineConfig({
 interface MissingDep {
   name: string;
   version: string;
+  target: "dependencies" | "devDependencies";
 }
 
 export function getMissingDeps(info: ProjectInfo): MissingDep[] {
   const missing: MissingDep[] = [];
 
   if (!info.hasCloudflarePlugin) {
-    missing.push({ name: "@cloudflare/vite-plugin", version: "latest" });
+    missing.push({
+      name: "@cloudflare/vite-plugin",
+      version: "latest",
+      target: "devDependencies",
+    });
   }
   if (!info.hasWrangler) {
-    missing.push({ name: "wrangler", version: "latest" });
+    missing.push({
+      name: "wrangler",
+      version: "latest",
+      target: "devDependencies",
+    });
   }
   if (info.isAppRouter && !info.hasRscPlugin) {
-    missing.push({ name: "@vitejs/plugin-rsc", version: "latest" });
+    missing.push({
+      name: "@vitejs/plugin-rsc",
+      version: "latest",
+      target: "devDependencies",
+    });
+  }
+  if (info.isAppRouter && !info.hasReactServerDomWebpack) {
+    missing.push({
+      name: "react-server-dom-webpack",
+      version: "latest",
+      target: "dependencies",
+    });
   }
   if (info.hasMDX) {
     // Check if @mdx-js/rollup is already installed
@@ -562,7 +587,11 @@ export function getMissingDeps(info: ProjectInfo): MissingDep[] {
       path.join(info.root, "node_modules", "@mdx-js", "rollup"),
     );
     if (!hasMdxRollup) {
-      missing.push({ name: "@mdx-js/rollup", version: "latest" });
+      missing.push({
+        name: "@mdx-js/rollup",
+        version: "latest",
+        target: "devDependencies",
+      });
     }
   }
 
@@ -572,17 +601,47 @@ export function getMissingDeps(info: ProjectInfo): MissingDep[] {
 function installDeps(root: string, deps: MissingDep[]): void {
   if (deps.length === 0) return;
 
-  const depsStr = deps.map((d) => `${d.name}@${d.version}`).join(" ");
-  const installCmd = detectPackageManager(root);
+  const groups: Record<"dependencies" | "devDependencies", MissingDep[]> = {
+    dependencies: [],
+    devDependencies: [],
+  };
+  for (const dep of deps) {
+    groups[dep.target].push(dep);
+  }
 
-  console.log(`  Installing: ${deps.map((d) => d.name).join(", ")}`);
-  execSync(`${installCmd} ${depsStr}`, {
-    cwd: root,
-    stdio: "inherit",
-  });
+  for (const [target, targetDeps] of Object.entries(groups) as Array<
+    [keyof typeof groups, MissingDep[]]
+  >) {
+    if (targetDeps.length === 0) continue;
+    const depsStr = targetDeps.map((d) => `${d.name}@${d.version}`).join(" ");
+    const installCmd = getInstallCommand(root, target);
+
+    console.log(`  Installing: ${targetDeps.map((d) => d.name).join(", ")}`);
+    execSync(`${installCmd} ${depsStr}`, {
+      cwd: root,
+      stdio: "inherit",
+    });
+  }
 }
 
-const detectPackageManager = _detectPackageManager;
+function getInstallCommand(
+  root: string,
+  target: "dependencies" | "devDependencies",
+): string {
+  const pm = detectPackageManagerName(root);
+  switch (pm) {
+    case "pnpm":
+      return target === "devDependencies" ? "pnpm add -D" : "pnpm add";
+    case "yarn":
+      return target === "devDependencies" ? "yarn add -D" : "yarn add";
+    case "bun":
+      return target === "devDependencies" ? "bun add -d" : "bun add";
+    default:
+      return target === "devDependencies" ? "npm install -D" : "npm install";
+  }
+}
+
+const detectPackageManagerName = _detectPackageManagerName;
 
 // ─── File Writing ────────────────────────────────────────────────────────────
 
@@ -726,7 +785,10 @@ export async function deploy(options: DeployOptions): Promise<void> {
     // Re-detect after install
     info.hasCloudflarePlugin = true;
     info.hasWrangler = true;
-    if (info.isAppRouter) info.hasRscPlugin = true;
+    if (info.isAppRouter) {
+      info.hasRscPlugin = true;
+      info.hasReactServerDomWebpack = true;
+    }
   }
 
   // Step 3: Ensure ESM + rename CJS configs

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -1658,12 +1658,19 @@ hydrate();
   const earlyRequire = createRequire(path.join(earlyBaseDir, "package.json"));
   let resolvedRscPath: string | null = null;
   let resolvedRscTransformsPath: string | null = null;
+  let hasReactServerDomWebpack = false;
   try {
     resolvedRscPath = earlyRequire.resolve("@vitejs/plugin-rsc");
     resolvedRscTransformsPath = earlyRequire.resolve("@vitejs/plugin-rsc/transforms");
   } catch {
     // @vitejs/plugin-rsc not installed — that's fine for Pages Router
     // projects. If App Router is detected, the error is thrown below.
+  }
+  try {
+    earlyRequire.resolve("react-server-dom-webpack/package.json");
+    hasReactServerDomWebpack = true;
+  } catch {
+    // react-server-dom-webpack is only required for App Router projects.
   }
 
   // If app/ exists and auto-RSC is enabled, create a lazy Promise that
@@ -1675,6 +1682,12 @@ hydrate();
       throw new Error(
         "vinext: App Router detected but @vitejs/plugin-rsc is not installed.\n" +
         "Run: npm install -D @vitejs/plugin-rsc",
+      );
+    }
+    if (!hasReactServerDomWebpack) {
+      throw new Error(
+        "vinext: App Router detected but react-server-dom-webpack is not installed.\n" +
+        "Run: npm install react-server-dom-webpack",
       );
     }
     const rscImport = import(resolvedRscPath);

--- a/packages/vinext/src/init.ts
+++ b/packages/vinext/src/init.ts
@@ -4,7 +4,7 @@
  * Automates the steps needed to run a Next.js app under vinext:
  *
  *   1. Run `vinext check` to show compatibility report
- *   2. Install dependencies (vite, @vitejs/plugin-rsc for App Router)
+ *   2. Install dependencies (vite/vinext, plus App Router RSC deps)
  *   3. Add "type": "module" to package.json
  *   4. Rename CJS config files to .cjs
  *   5. Add vinext scripts to package.json
@@ -22,7 +22,6 @@ import { runCheck, formatReport } from "./check.js";
 import {
   ensureESModule,
   renameCJSConfigs,
-  detectPackageManager,
   detectPackageManagerName,
   hasViteConfig,
   hasAppDir,
@@ -57,6 +56,8 @@ export interface InitResult {
   /** Whether vite.config.ts generation was skipped (already exists) */
   skippedViteConfig: boolean;
 }
+
+type DependencyTarget = "dependencies" | "devDependencies";
 
 // ─── Vite Config Generation (minimal, non-Cloudflare) ────────────────────────
 
@@ -112,12 +113,22 @@ export function addScripts(root: string, port: number): string[] {
 
 // ─── Dependency Installation ─────────────────────────────────────────────────
 
+export function getInitDepsByTarget(
+  isAppRouter: boolean,
+): Record<DependencyTarget, string[]> {
+  return {
+    dependencies: isAppRouter ? ["react-server-dom-webpack"] : [],
+    devDependencies: [
+      "vinext",
+      "vite",
+      ...(isAppRouter ? ["@vitejs/plugin-rsc"] : []),
+    ],
+  };
+}
+
 export function getInitDeps(isAppRouter: boolean): string[] {
-  const deps = ["vinext", "vite"];
-  if (isAppRouter) {
-    deps.push("@vitejs/plugin-rsc");
-  }
-  return deps;
+  const depsByTarget = getInitDepsByTarget(isAppRouter);
+  return [...depsByTarget.devDependencies, ...depsByTarget.dependencies];
 }
 
 export function isDepInstalled(root: string, dep: string): boolean {
@@ -139,17 +150,32 @@ export function isDepInstalled(root: string, dep: string): boolean {
 function installDeps(
   root: string,
   deps: string[],
+  target: DependencyTarget,
   exec: (cmd: string, opts: { cwd: string; stdio: string }) => void,
 ): void {
   if (deps.length === 0) return;
 
-  const installCmd = detectPackageManager(root);
+  const installCmd = getInstallCommand(root, target);
   const depsStr = deps.join(" ");
 
   exec(`${installCmd} ${depsStr}`, {
     cwd: root,
     stdio: "inherit",
   });
+}
+
+function getInstallCommand(root: string, target: DependencyTarget): string {
+  const pm = detectPackageManagerName(root);
+  switch (pm) {
+    case "pnpm":
+      return target === "devDependencies" ? "pnpm add -D" : "pnpm add";
+    case "yarn":
+      return target === "devDependencies" ? "yarn add -D" : "yarn add";
+    case "bun":
+      return target === "devDependencies" ? "bun add -d" : "bun add";
+    default:
+      return target === "devDependencies" ? "npm install -D" : "npm install";
+  }
 }
 
 // ─── Main Entry ──────────────────────────────────────────────────────────────
@@ -188,12 +214,20 @@ export async function init(options: InitOptions): Promise<InitResult> {
 
   // ── Step 2: Install dependencies ───────────────────────────────────────
 
-  const neededDeps = getInitDeps(isApp);
-  const missingDeps = neededDeps.filter((dep) => !isDepInstalled(root, dep));
+  const depsByTarget = getInitDepsByTarget(isApp);
+  const missingDevDeps = depsByTarget.devDependencies.filter((dep) => !isDepInstalled(root, dep));
+  const missingRuntimeDeps = depsByTarget.dependencies.filter((dep) => !isDepInstalled(root, dep));
+  const missingDeps = [...missingDevDeps, ...missingRuntimeDeps];
 
+  if (missingDevDeps.length > 0) {
+    console.log(`  Installing ${missingDevDeps.join(", ")}...`);
+    installDeps(root, missingDevDeps, "devDependencies", exec);
+  }
+  if (missingRuntimeDeps.length > 0) {
+    console.log(`  Installing ${missingRuntimeDeps.join(", ")}...`);
+    installDeps(root, missingRuntimeDeps, "dependencies", exec);
+  }
   if (missingDeps.length > 0) {
-    console.log(`  Installing ${missingDeps.join(", ")}...`);
-    installDeps(root, missingDeps, exec);
     console.log();
   }
 
@@ -221,8 +255,11 @@ export async function init(options: InitOptions): Promise<InitResult> {
 
   console.log("  vinext init complete!\n");
 
-  if (missingDeps.length > 0) {
-    console.log(`    \u2713 Added ${missingDeps.join(", ")} to devDependencies`);
+  if (missingDevDeps.length > 0) {
+    console.log(`    \u2713 Added ${missingDevDeps.join(", ")} to devDependencies`);
+  }
+  if (missingRuntimeDeps.length > 0) {
+    console.log(`    \u2713 Added ${missingRuntimeDeps.join(", ")} to dependencies`);
   }
   if (addedTypeModule) {
     console.log(`    \u2713 Added "type": "module" to package.json`);

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -2286,6 +2286,46 @@ describe("RSC plugin auto-registration", () => {
     }
   });
 
+  it("throws a clear error before optimizeDeps when react-server-dom-webpack is missing", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-missing-rsdw-"));
+    try {
+      fs.mkdirSync(path.join(tmpDir, "app"), { recursive: true });
+      fs.mkdirSync(path.join(tmpDir, "node_modules", "@vitejs", "plugin-rsc"), {
+        recursive: true,
+      });
+
+      fs.writeFileSync(
+        path.join(tmpDir, "package.json"),
+        JSON.stringify({ name: "tmp-app", private: true, type: "module" }, null, 2),
+      );
+      fs.writeFileSync(
+        path.join(tmpDir, "app", "page.tsx"),
+        "export default function Home() { return <div>ok</div>; }",
+      );
+      fs.writeFileSync(
+        path.join(tmpDir, "app", "layout.tsx"),
+        "export default function RootLayout({ children }) { return <html><body>{children}</body></html>; }",
+      );
+
+      // Minimal module files so createRequire.resolve("@vitejs/plugin-rsc")
+      // and createRequire.resolve("@vitejs/plugin-rsc/transforms") succeed.
+      fs.writeFileSync(
+        path.join(tmpDir, "node_modules", "@vitejs", "plugin-rsc", "index.js"),
+        "export default function rsc() { return []; }",
+      );
+      fs.writeFileSync(
+        path.join(tmpDir, "node_modules", "@vitejs", "plugin-rsc", "transforms.js"),
+        "export {};",
+      );
+
+      expect(() => vinext({ appDir: tmpDir })).toThrow(
+        "react-server-dom-webpack is not installed",
+      );
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it("does NOT auto-inject RSC plugin when neither app/ nor src/app/ exists", () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-no-app-"));
     try {

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -177,6 +177,13 @@ describe("detectProject", () => {
     const info = detectProject(tmpDir);
     expect(info.hasISR).toBe(false);
   });
+
+  it("detects react-server-dom-webpack when installed in node_modules", () => {
+    mkdir(tmpDir, "app");
+    mkdir(tmpDir, "node_modules/react-server-dom-webpack");
+    const info = detectProject(tmpDir);
+    expect(info.hasReactServerDomWebpack).toBe(true);
+  });
 });
 
 // ─── generateWranglerConfig ─────────────────────────────────────────────────
@@ -384,6 +391,7 @@ describe("getMissingDeps", () => {
     info.hasCloudflarePlugin = false;
     info.hasWrangler = true;
     info.hasRscPlugin = true;
+    info.hasReactServerDomWebpack = true;
 
     const missing = getMissingDeps(info);
     expect(missing).toContainEqual(
@@ -397,6 +405,7 @@ describe("getMissingDeps", () => {
     info.hasCloudflarePlugin = true;
     info.hasWrangler = false;
     info.hasRscPlugin = true;
+    info.hasReactServerDomWebpack = true;
 
     const missing = getMissingDeps(info);
     expect(missing).toContainEqual(
@@ -410,10 +419,11 @@ describe("getMissingDeps", () => {
     info.hasCloudflarePlugin = true;
     info.hasWrangler = true;
     info.hasRscPlugin = false;
+    info.hasReactServerDomWebpack = true;
 
     const missing = getMissingDeps(info);
     expect(missing).toContainEqual(
-      expect.objectContaining({ name: "@vitejs/plugin-rsc" }),
+      expect.objectContaining({ name: "@vitejs/plugin-rsc", target: "devDependencies" }),
     );
   });
 
@@ -423,10 +433,39 @@ describe("getMissingDeps", () => {
     info.hasCloudflarePlugin = true;
     info.hasWrangler = true;
     info.hasRscPlugin = false;
+    info.hasReactServerDomWebpack = false;
 
     const missing = getMissingDeps(info);
     expect(missing).not.toContainEqual(
       expect.objectContaining({ name: "@vitejs/plugin-rsc" }),
+    );
+  });
+
+  it("reports missing react-server-dom-webpack for App Router", () => {
+    mkdir(tmpDir, "app");
+    const info = detectProject(tmpDir);
+    info.hasCloudflarePlugin = true;
+    info.hasWrangler = true;
+    info.hasRscPlugin = true;
+    info.hasReactServerDomWebpack = false;
+
+    const missing = getMissingDeps(info);
+    expect(missing).toContainEqual(
+      expect.objectContaining({ name: "react-server-dom-webpack", target: "dependencies" }),
+    );
+  });
+
+  it("does not require react-server-dom-webpack for Pages Router", () => {
+    mkdir(tmpDir, "pages");
+    const info = detectProject(tmpDir);
+    info.hasCloudflarePlugin = true;
+    info.hasWrangler = true;
+    info.hasRscPlugin = true;
+    info.hasReactServerDomWebpack = false;
+
+    const missing = getMissingDeps(info);
+    expect(missing).not.toContainEqual(
+      expect.objectContaining({ name: "react-server-dom-webpack" }),
     );
   });
 
@@ -436,6 +475,7 @@ describe("getMissingDeps", () => {
     info.hasCloudflarePlugin = true;
     info.hasWrangler = true;
     info.hasRscPlugin = true;
+    info.hasReactServerDomWebpack = true;
 
     const missing = getMissingDeps(info);
     expect(missing).toHaveLength(0);
@@ -934,6 +974,7 @@ describe("getMissingDeps — MDX", () => {
     info.hasCloudflarePlugin = true;
     info.hasWrangler = true;
     info.hasRscPlugin = true;
+    info.hasReactServerDomWebpack = true;
     const missing = getMissingDeps(info);
     expect(missing).toContainEqual(expect.objectContaining({ name: "@mdx-js/rollup" }));
   });

--- a/tests/fixtures/create-next-app-app-router/app/layout.tsx
+++ b/tests/fixtures/create-next-app-app-router/app/layout.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from "react";
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/tests/fixtures/create-next-app-app-router/app/page.tsx
+++ b/tests/fixtures/create-next-app-app-router/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Home() {
+  return <main>Hello from create-next-app fixture</main>;
+}

--- a/tests/fixtures/create-next-app-app-router/package.json.template
+++ b/tests/fixtures/create-next-app-app-router/package.json.template
@@ -1,0 +1,16 @@
+{
+  "name": "create-next-app-fixture",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "^16.0.0",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0"
+  }
+}

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -7,6 +7,7 @@ import {
   generateViteConfig,
   addScripts,
   getInitDeps,
+  getInitDepsByTarget,
   isDepInstalled,
   type InitOptions,
 } from "../packages/vinext/src/init.js";
@@ -14,6 +15,10 @@ import {
 // ─── Test Helpers ────────────────────────────────────────────────────────────
 
 let tmpDir: string;
+const CREATE_NEXT_APP_FIXTURE = path.resolve(
+  import.meta.dirname,
+  "./fixtures/create-next-app-app-router",
+);
 
 function createTmpDir(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), "vinext-init-test-"));
@@ -249,11 +254,12 @@ describe("addScripts", () => {
 // ─── Unit Tests: getInitDeps / isDepInstalled ────────────────────────────────
 
 describe("getInitDeps", () => {
-  it("returns vinext + vite + @vitejs/plugin-rsc for App Router", () => {
+  it("returns vinext + vite + @vitejs/plugin-rsc + react-server-dom-webpack for App Router", () => {
     const deps = getInitDeps(true);
     expect(deps).toContain("vinext");
     expect(deps).toContain("vite");
     expect(deps).toContain("@vitejs/plugin-rsc");
+    expect(deps).toContain("react-server-dom-webpack");
   });
 
   it("returns vinext + vite for Pages Router", () => {
@@ -261,6 +267,20 @@ describe("getInitDeps", () => {
     expect(deps).toContain("vinext");
     expect(deps).toContain("vite");
     expect(deps).not.toContain("@vitejs/plugin-rsc");
+  });
+});
+
+describe("getInitDepsByTarget", () => {
+  it("splits App Router deps across devDependencies and dependencies", () => {
+    const deps = getInitDepsByTarget(true);
+    expect(deps.devDependencies).toEqual(["vinext", "vite", "@vitejs/plugin-rsc"]);
+    expect(deps.dependencies).toEqual(["react-server-dom-webpack"]);
+  });
+
+  it("returns only devDependencies for Pages Router", () => {
+    const deps = getInitDepsByTarget(false);
+    expect(deps.devDependencies).toEqual(["vinext", "vite"]);
+    expect(deps.dependencies).toEqual([]);
   });
 });
 
@@ -415,6 +435,14 @@ describe("init — dependency installation", () => {
     expect(result.installedDeps).toContain("@vitejs/plugin-rsc");
   });
 
+  it("detects missing react-server-dom-webpack for App Router", async () => {
+    setupProject(tmpDir, { router: "app" });
+
+    const { result } = await runInit(tmpDir);
+
+    expect(result.installedDeps).toContain("react-server-dom-webpack");
+  });
+
   it("does not require @vitejs/plugin-rsc for Pages Router", async () => {
     setupProject(tmpDir, { router: "pages" });
 
@@ -443,6 +471,35 @@ describe("init — dependency installation", () => {
     const installCall = execCalls.find((c) => c.cmd.includes("install -D") || c.cmd.includes("add -D"));
     expect(installCall).toBeDefined();
     expect(installCall!.cmd).toMatch(/^npm install -D/);
+  });
+
+  it("installs react-server-dom-webpack as a dependency (not devDependency)", async () => {
+    setupProject(tmpDir, { router: "app" });
+
+    const { execCalls } = await runInit(tmpDir);
+
+    const runtimeInstall = execCalls.find((c) =>
+      c.cmd.includes("react-server-dom-webpack") && !c.cmd.includes(" -D "),
+    );
+    expect(runtimeInstall).toBeDefined();
+    expect(runtimeInstall!.cmd).toMatch(/^npm install react-server-dom-webpack$/);
+  });
+
+  it("installs missing RSC deps for a create-next-app App Router project", async () => {
+    fs.cpSync(CREATE_NEXT_APP_FIXTURE, tmpDir, { recursive: true });
+    fs.copyFileSync(
+      path.join(tmpDir, "package.json.template"),
+      path.join(tmpDir, "package.json"),
+    );
+
+    const { result, execCalls } = await runInit(tmpDir);
+
+    expect(result.installedDeps).toContain("@vitejs/plugin-rsc");
+    expect(result.installedDeps).toContain("react-server-dom-webpack");
+    const runtimeInstall = execCalls.find((c) =>
+      c.cmd.includes("react-server-dom-webpack") && !c.cmd.includes(" -D "),
+    );
+    expect(runtimeInstall).toBeDefined();
   });
 });
 


### PR DESCRIPTION
Addresses #22 and part of #28 (missing RSC deps / react-server-dom-webpack).\n\n- Ensure vinext init/deploy installs required RSC runtime deps for App Router projects\n- Add create-next-app style fixture + regression tests for init/deploy\n\nCI should validate across platforms.