### PR TITLE
fix(windows): use file:// URLs for absolute path imports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,23 @@ jobs:
         run: pnpm run build
       - run: pnpm test
 
+  windows-minimal:
+    name: Windows Minimal
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install
+      - name: Build plugin (needed by ecosystem fixtures)
+        run: pnpm run build
+      - run: pnpm run lint
+      - run: pnpm run typecheck
+      - run: pnpm test
+
   e2e:
     name: E2E (${{ matrix.project }})
     runs-on: ubuntu-latest

--- a/packages/vinext/src/cli.ts
+++ b/packages/vinext/src/cli.ts
@@ -21,6 +21,7 @@ import { execSync } from "node:child_process";
 import { deploy as runDeploy } from "./deploy.js";
 import { runCheck, formatReport } from "./check.js";
 import { init as runInit } from "./init.js";
+import { importModule } from "./utils/import-path.js";
 
 // ─── Resolve Vite from the project root ────────────────────────────────────────
 //
@@ -60,7 +61,7 @@ async function loadVite(): Promise<ViteModule> {
     vitePath = "vite";
   }
 
-  const vite = (await import(/* @vite-ignore */ vitePath)) as ViteModule;
+  const vite = await importModule<ViteModule>(vitePath);
   _viteModule = vite;
   return vite;
 }

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -22,6 +22,7 @@ import { findInstrumentationFile, runInstrumentation } from "./server/instrument
 import { safeRegExp, isExternalUrl, proxyExternalRequest } from "./config/config-matchers.js";
 import { scanMetadataFiles } from "./server/metadata-routes.js";
 import { staticExportPages } from "./build/static-export.js";
+import { toImportSpecifier } from "./utils/import-path.js";
 import tsconfigPaths from "vite-tsconfig-paths";
 import MagicString from "magic-string";
 import path from "node:path";
@@ -270,7 +271,7 @@ async function resolvePostcssStringPlugins(
         return undefined;
       }
     }
-    const mod = await import(configPath);
+    const mod = await import(toImportSpecifier(configPath));
     config = mod.default ?? mod;
   } catch {
     // If we can't load the config, let Vite/postcss-load-config handle it
@@ -293,7 +294,7 @@ async function resolvePostcssStringPlugins(
     config.plugins.filter(Boolean).map(async (plugin: any) => {
       if (typeof plugin === "string") {
         const resolved = req.resolve(plugin);
-        const mod = await import(resolved);
+        const mod = await import(toImportSpecifier(resolved));
         const fn = mod.default ?? mod;
         // If the export is a function, call it to get the plugin instance
         return typeof fn === "function" ? fn() : fn;
@@ -302,7 +303,7 @@ async function resolvePostcssStringPlugins(
       if (Array.isArray(plugin) && typeof plugin[0] === "string") {
         const [name, options] = plugin;
         const resolved = req.resolve(name);
-        const mod = await import(resolved);
+        const mod = await import(toImportSpecifier(resolved));
         const fn = mod.default ?? mod;
         return typeof fn === "function" ? fn(options) : fn;
       }
@@ -1677,7 +1678,7 @@ hydrate();
         "Run: npm install -D @vitejs/plugin-rsc",
       );
     }
-    const rscImport = import(resolvedRscPath);
+    const rscImport = import(toImportSpecifier(resolvedRscPath));
     rscPluginPromise = rscImport
       .then((mod) => {
         const rsc = mod.default;
@@ -2907,7 +2908,9 @@ hydrate();
               "Run: npm install -D @vitejs/plugin-rsc",
             );
           }
-          const { transformWrapExport, transformHoistInlineDirective } = await import(resolvedRscTransformsPath);
+          const { transformWrapExport, transformHoistInlineDirective } = await import(
+            toImportSpecifier(resolvedRscTransformsPath),
+          );
           const ast = parseAst(code);
 
           // Check for file-level "use cache" directive
@@ -2935,9 +2938,10 @@ hydrate();
             const isLayoutOrTemplate = /\/(layout|template)\.(tsx?|jsx?|mjs)$/.test(id);
 
             const runtimeModulePath = path.join(shimsDir, "cache-runtime.js");
+            const runtimeModuleSpecifier = toImportSpecifier(runtimeModulePath);
             const result = transformWrapExport(code, ast as any, {
               runtime: (value: any, name: any) =>
-                `(await import(${JSON.stringify(runtimeModulePath)})).registerCachedFunction(${value}, ${JSON.stringify(id + ":" + name)}, ${JSON.stringify(variant)})`,
+                `(await import(${JSON.stringify(runtimeModuleSpecifier)})).registerCachedFunction(${value}, ${JSON.stringify(id + ":" + name)}, ${JSON.stringify(variant)})`,
               rejectNonAsyncFunction: false,
               filter: (name: any, meta: any) => {
                 // Skip non-functions (constants, types, etc.)
@@ -2976,6 +2980,7 @@ hydrate();
           const hasInlineCache = code.includes("use cache") && !cacheDirective;
           if (hasInlineCache) {
             const runtimeModulePath = path.join(shimsDir, "cache-runtime.js");
+            const runtimeModuleSpecifier = toImportSpecifier(runtimeModulePath);
 
             try {
               const result = transformHoistInlineDirective(code, ast as any, {
@@ -2983,7 +2988,7 @@ hydrate();
                 runtime: (value: any, name: any, meta: any) => {
                   const directiveMatch = meta.directiveMatch[0];
                   const variant = directiveMatch === "use cache" ? "" : directiveMatch.replace("use cache:", "").replace("use cache: ", "").trim();
-                  return `(await import(${JSON.stringify(runtimeModulePath)})).registerCachedFunction(${value}, ${JSON.stringify(id + ":" + name)}, ${JSON.stringify(variant)})`;
+                  return `(await import(${JSON.stringify(runtimeModuleSpecifier)})).registerCachedFunction(${value}, ${JSON.stringify(id + ":" + name)}, ${JSON.stringify(variant)})`;
                 },
                 rejectNonAsyncFunction: false,
               });

--- a/packages/vinext/src/utils/import-path.ts
+++ b/packages/vinext/src/utils/import-path.ts
@@ -1,0 +1,32 @@
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+/**
+ * Convert absolute filesystem paths into dynamic-import-safe specifiers.
+ * Node ESM requires file:// URLs for Windows drive-letter paths.
+ */
+export function toImportSpecifier(specifier: string): string {
+  if (
+    specifier.startsWith("file:") ||
+    specifier.startsWith("node:") ||
+    specifier.startsWith("data:")
+  ) {
+    return specifier;
+  }
+
+  if (path.isAbsolute(specifier)) {
+    return pathToFileURL(specifier).href;
+  }
+
+  // Support Windows drive-letter paths in cross-platform tests/tools.
+  if (path.win32.isAbsolute(specifier)) {
+    const normalized = specifier.replace(/\\/g, "/");
+    return new URL(`file:///${normalized}`).href;
+  }
+
+  return specifier;
+}
+
+export function importModule<T = unknown>(specifier: string): Promise<T> {
+  return import(/* @vite-ignore */ toImportSpecifier(specifier)) as Promise<T>;
+}

--- a/tests/import-path.test.ts
+++ b/tests/import-path.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
+import { importModule, toImportSpecifier } from "../packages/vinext/src/utils/import-path.js";
+
+describe("import path helpers", () => {
+  it("leaves bare module specifiers unchanged", () => {
+    expect(toImportSpecifier("vite")).toBe("vite");
+  });
+
+  it("converts absolute paths to file URLs", () => {
+    const absolutePath = path.join(process.cwd(), "fixtures", "entry.mjs");
+    expect(toImportSpecifier(absolutePath)).toBe(pathToFileURL(absolutePath).href);
+  });
+
+  it("converts Windows drive-letter paths to file URLs", () => {
+    expect(toImportSpecifier("C:\\repo\\app\\entry.mjs")).toBe(
+      "file:///C:/repo/app/entry.mjs",
+    );
+  });
+
+  it("imports modules from absolute paths", async () => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "vinext-import-path-"));
+    const modulePath = path.join(tmpDir, "entry.mjs");
+    await writeFile(modulePath, 'export const value = 42; export default "ok";\n');
+
+    try {
+      const mod = await importModule<{ default: string; value: number }>(modulePath);
+      expect(mod.default).toBe("ok");
+      expect(mod.value).toBe(42);
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -2,10 +2,15 @@ import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
 import { createServer, build, type ViteDevServer } from "vite";
 import path from "node:path";
 import fs from "node:fs";
+import { pathToFileURL } from "node:url";
 import vinext from "../packages/vinext/src/index.js";
 import { PAGES_FIXTURE_DIR, startFixtureServer } from "./helpers.js";
 
 const FIXTURE_DIR = PAGES_FIXTURE_DIR;
+
+function importFromPath(modulePath: string): Promise<any> {
+  return import(pathToFileURL(modulePath).href);
+}
 
 describe("Pages Router integration", () => {
   let server: ViteDevServer;
@@ -712,7 +717,7 @@ describe("Production build", () => {
     }
 
     // Import the server entry
-    const serverEntry = await import(serverEntryPath);
+    const serverEntry = await importFromPath(serverEntryPath);
     const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf-8"));
 
     // Create a minimal HTTP server using the built entry.
@@ -790,13 +795,13 @@ describe("Production build", () => {
 
   it("server entry exports runMiddleware function", async () => {
     const serverEntryPath = path.join(outDir, "server", "entry.js");
-    const serverEntry = await import(serverEntryPath);
+    const serverEntry = await importFromPath(serverEntryPath);
     expect(typeof serverEntry.runMiddleware).toBe("function");
   });
 
   it("runMiddleware skips non-matching paths", async () => {
     const serverEntryPath = path.join(outDir, "server", "entry.js");
-    const serverEntry = await import(serverEntryPath);
+    const serverEntry = await importFromPath(serverEntryPath);
     // The middleware matcher is /((?!api|_next|favicon\.ico).*) so /api should not match
     const request = new Request("http://localhost/api/hello");
     const result = await serverEntry.runMiddleware(request);
@@ -806,7 +811,7 @@ describe("Production build", () => {
 
   it("runMiddleware handles redirect (/old-page -> /about)", async () => {
     const serverEntryPath = path.join(outDir, "server", "entry.js");
-    const serverEntry = await import(serverEntryPath);
+    const serverEntry = await importFromPath(serverEntryPath);
     const request = new Request("http://localhost/old-page");
     const result = await serverEntry.runMiddleware(request);
     expect(result.continue).toBe(false);
@@ -816,7 +821,7 @@ describe("Production build", () => {
 
   it("runMiddleware handles rewrite (/rewritten -> /ssr)", async () => {
     const serverEntryPath = path.join(outDir, "server", "entry.js");
-    const serverEntry = await import(serverEntryPath);
+    const serverEntry = await importFromPath(serverEntryPath);
     const request = new Request("http://localhost/rewritten");
     const result = await serverEntry.runMiddleware(request);
     expect(result.continue).toBe(true);
@@ -825,7 +830,7 @@ describe("Production build", () => {
 
   it("runMiddleware handles block (/blocked -> 403)", async () => {
     const serverEntryPath = path.join(outDir, "server", "entry.js");
-    const serverEntry = await import(serverEntryPath);
+    const serverEntry = await importFromPath(serverEntryPath);
     const request = new Request("http://localhost/blocked");
     const result = await serverEntry.runMiddleware(request);
     expect(result.continue).toBe(false);
@@ -835,7 +840,7 @@ describe("Production build", () => {
 
   it("runMiddleware sets x-middleware-test header on matched paths", async () => {
     const serverEntryPath = path.join(outDir, "server", "entry.js");
-    const serverEntry = await import(serverEntryPath);
+    const serverEntry = await importFromPath(serverEntryPath);
     // /about matches the middleware but doesn't redirect/rewrite/block
     const request = new Request("http://localhost/about");
     const result = await serverEntry.runMiddleware(request);
@@ -846,7 +851,7 @@ describe("Production build", () => {
 
   it("runMiddleware returns 500 when middleware throws", async () => {
     const serverEntryPath = path.join(outDir, "server", "entry.js");
-    const serverEntry = await import(serverEntryPath);
+    const serverEntry = await importFromPath(serverEntryPath);
     const request = new Request("http://localhost/middleware-throw");
     const result = await serverEntry.runMiddleware(request);
     expect(result.continue).toBe(false);
@@ -1023,7 +1028,7 @@ describe("Production server next.config.js features (Pages Router)", () => {
 
   it("server entry exports vinextConfig with correct shape", async () => {
     const serverEntryPath = path.join(outDir, "server", "entry.js");
-    const serverEntry = await import(serverEntryPath);
+    const serverEntry = await importFromPath(serverEntryPath);
     expect(serverEntry.vinextConfig).toBeDefined();
     expect(serverEntry.vinextConfig.redirects).toBeInstanceOf(Array);
     expect(serverEntry.vinextConfig.rewrites).toBeDefined();


### PR DESCRIPTION
Addresses #23.\n\n- Use pathToFileURL for Windows drive-letter absolute paths during dynamic import/module loading\n- Add unit tests for path conversion\n- Add windows-latest CI job (lint/typecheck/unit) to prevent regressions