### PR TITLE
feat(cli): load .env files with Next.js precedence

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,8 +313,37 @@ Every `next/*` import is shimmed to a Vite-compatible implementation.
 |---------|---|-------|
 | `next.config.js` / `.ts` / `.mjs` | ✅ | Function configs, phase argument |
 | `rewrites` / `redirects` / `headers` | ✅ | All phases, param interpolation |
-| Environment variables (`NEXT_PUBLIC_*`) | ✅ | Inlined at build time via Vite |
+| Environment variables (`.env*`, `NEXT_PUBLIC_*`) | ✅ | Auto-loads Next.js-style dotenv files; only public vars are inlined |
 | `images` config | 🟡 | Parsed but not used for optimization |
+
+### Environment variable loading (`.env*`)
+
+vinext automatically loads dotenv files for `dev`, `build`, `start`, and `deploy`.
+
+Load order matches Next.js (highest priority first):
+
+1. Existing `process.env` values (shell/CI)
+2. `.env.<mode>.local`
+3. `.env.local` (skipped when mode is `test`)
+4. `.env.<mode>`
+5. `.env`
+
+Modes:
+
+- `vinext dev` uses `development`
+- `vinext build`, `vinext start`, and `vinext deploy` use `production`
+
+Variable expansion (`$VAR` / `${VAR}`) is supported.
+
+Client exposure remains explicit:
+
+- `NEXT_PUBLIC_*` variables are inlined for browser usage
+- `next.config.js` `env` entries are also inlined
+- Other env vars stay server-only unless you explicitly expose them through Vite (for example `VITE_*` + `import.meta.env`)
+
+Override behavior:
+
+- To override any `.env*` value, set it in your shell/CI environment before running vinext. Existing `process.env` always wins.
 
 ### Caching
 

--- a/packages/vinext/src/cli.ts
+++ b/packages/vinext/src/cli.ts
@@ -21,6 +21,7 @@ import { execSync } from "node:child_process";
 import { deploy as runDeploy } from "./deploy.js";
 import { runCheck, formatReport } from "./check.js";
 import { init as runInit } from "./init.js";
+import { loadDotenv } from "./config/dotenv.js";
 
 // ─── Resolve Vite from the project root ────────────────────────────────────────
 //
@@ -191,6 +192,11 @@ async function dev() {
   const parsed = parseArgs(rawArgs);
   if (parsed.help) return printHelp("dev");
 
+  loadDotenv({
+    root: process.cwd(),
+    mode: "development",
+  });
+
   const vite = await loadVite();
 
   const port = parsed.port ?? 3000;
@@ -210,6 +216,11 @@ async function dev() {
 async function buildApp() {
   const parsed = parseArgs(rawArgs);
   if (parsed.help) return printHelp("build");
+
+  loadDotenv({
+    root: process.cwd(),
+    mode: "production",
+  });
 
   const vite = await loadVite();
 
@@ -264,6 +275,11 @@ async function buildApp() {
 async function start() {
   const parsed = parseArgs(rawArgs);
   if (parsed.help) return printHelp("start");
+
+  loadDotenv({
+    root: process.cwd(),
+    mode: "production",
+  });
 
   const port = parsed.port ?? parseInt(process.env.PORT ?? "3000", 10);
   const host = parsed.hostname ?? "0.0.0.0";

--- a/packages/vinext/src/config/dotenv.ts
+++ b/packages/vinext/src/config/dotenv.ts
@@ -1,0 +1,112 @@
+import fs from "node:fs";
+import path from "node:path";
+import { parseEnv } from "node:util";
+
+export type VinextEnvMode = "development" | "production" | "test";
+
+export interface LoadDotenvOptions {
+  root: string;
+  mode: VinextEnvMode;
+  processEnv?: NodeJS.ProcessEnv;
+}
+
+export interface LoadDotenvResult {
+  mode: VinextEnvMode;
+  loadedFiles: string[];
+  loadedEnv: Record<string, string>;
+}
+
+/**
+ * Next.js-compatible dotenv lookup order (highest priority first).
+ */
+export function getDotenvFiles(mode: VinextEnvMode): string[] {
+  return [
+    `.env.${mode}.local`,
+    ...(mode === "test" ? [] : [".env.local"]),
+    `.env.${mode}`,
+    ".env",
+  ];
+}
+
+/**
+ * Load .env files into processEnv with Next.js-like precedence:
+ * process.env > .env.<mode>.local > .env.local > .env.<mode> > .env.
+ *
+ * This mutates processEnv (defaults to process.env).
+ */
+export function loadDotenv({
+  root,
+  mode,
+  processEnv = process.env,
+}: LoadDotenvOptions): LoadDotenvResult {
+  const loadedFiles: string[] = [];
+  const loadedEnv: Record<string, string> = {};
+
+  for (const relativeFile of getDotenvFiles(mode)) {
+    const filePath = path.join(root, relativeFile);
+    if (!fs.existsSync(filePath)) continue;
+
+    const fileContent = fs.readFileSync(filePath, "utf-8");
+    const parsed = parseEnv(fileContent);
+    const expanded = expandEnv(parsed, processEnv);
+
+    for (const [key, value] of Object.entries(expanded)) {
+      if (processEnv[key] !== undefined) continue;
+      processEnv[key] = value;
+      loadedEnv[key] = value;
+    }
+
+    loadedFiles.push(relativeFile);
+  }
+
+  return {
+    mode,
+    loadedFiles,
+    loadedEnv,
+  };
+}
+
+const ENV_REF_RE = /(\\)?\$(?:\{([A-Za-z_][A-Za-z0-9_]*)\}|([A-Za-z_][A-Za-z0-9_]*))/g;
+
+function expandEnv(
+  parsed: Record<string, string>,
+  processEnv: NodeJS.ProcessEnv,
+): Record<string, string> {
+  const expanded: Record<string, string> = {};
+  const resolving = new Set<string>();
+  const context: Record<string, string | undefined> = {
+    ...parsed,
+    ...processEnv,
+  };
+
+  function resolveValue(key: string): string {
+    const cached = expanded[key];
+    if (cached !== undefined) return cached;
+
+    if (resolving.has(key)) {
+      return context[key] ?? "";
+    }
+
+    const raw = context[key];
+    if (raw === undefined) return "";
+
+    resolving.add(key);
+    const value = raw.replace(ENV_REF_RE, (match, escaped, braced, bare) => {
+      if (escaped) return match.slice(1);
+
+      const refKey = (braced || bare) as string;
+      return resolveValue(refKey);
+    });
+    resolving.delete(key);
+
+    expanded[key] = value;
+    context[key] = value;
+    return value;
+  }
+
+  for (const key of Object.keys(parsed)) {
+    resolveValue(key);
+  }
+
+  return expanded;
+}

--- a/packages/vinext/src/deploy.ts
+++ b/packages/vinext/src/deploy.ts
@@ -24,6 +24,7 @@ import {
   detectPackageManager as _detectPackageManager,
 } from "./utils/project.js";
 import { runTPR } from "./cloudflare/tpr.js";
+import { loadDotenv } from "./config/dotenv.js";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -697,6 +698,7 @@ function runWranglerDeploy(root: string, preview: boolean): string {
 
 export async function deploy(options: DeployOptions): Promise<void> {
   const root = path.resolve(options.root);
+  loadDotenv({ root, mode: "production" });
 
   console.log("\n  vinext deploy\n");
 

--- a/tests/dotenv.test.ts
+++ b/tests/dotenv.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { loadDotenv } from "../packages/vinext/src/config/dotenv.js";
+
+let tmpDir: string;
+
+function writeFile(relativePath: string, content: string): void {
+  const fullPath = path.join(tmpDir, relativePath);
+  fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+  fs.writeFileSync(fullPath, content, "utf-8");
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-dotenv-test-"));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("loadDotenv", () => {
+  it("applies Next.js precedence for development mode", () => {
+    writeFile(".env", "ORDER=env\nSECOND=env\n");
+    writeFile(".env.development", "ORDER=mode\nSECOND=mode\n");
+    writeFile(".env.local", "ORDER=local\nSECOND=local\n");
+    writeFile(".env.development.local", "ORDER=mode-local\n");
+
+    const env: NodeJS.ProcessEnv = {
+      ORDER: "process",
+      FROM_PROCESS: "yes",
+    };
+
+    loadDotenv({
+      root: tmpDir,
+      mode: "development",
+      processEnv: env,
+    });
+
+    expect(env.ORDER).toBe("process");
+    expect(env.SECOND).toBe("local");
+    expect(env.FROM_PROCESS).toBe("yes");
+  });
+
+  it("skips .env.local in test mode", () => {
+    writeFile(".env.local", "TEST_VALUE=from-local\n");
+    writeFile(".env.test", "TEST_VALUE=from-test\n");
+    writeFile(".env", "TEST_VALUE=from-env\n");
+
+    const env: NodeJS.ProcessEnv = {};
+    const result = loadDotenv({
+      root: tmpDir,
+      mode: "test",
+      processEnv: env,
+    });
+
+    expect(env.TEST_VALUE).toBe("from-test");
+    expect(result.loadedFiles).not.toContain(".env.local");
+  });
+
+  it("expands variables and respects existing process env values", () => {
+    writeFile(
+      ".env.development.local",
+      "BASE_URL=https://from-file.example.com\nAPI_URL=$BASE_URL/v1\n",
+    );
+
+    const env: NodeJS.ProcessEnv = {
+      BASE_URL: "https://from-process.example.com",
+    };
+
+    loadDotenv({
+      root: tmpDir,
+      mode: "development",
+      processEnv: env,
+    });
+
+    expect(env.BASE_URL).toBe("https://from-process.example.com");
+    expect(env.API_URL).toBe("https://from-process.example.com/v1");
+  });
+});


### PR DESCRIPTION
Addresses #24.

- Implement Next.js-like dotenv loading precedence (.env, .env.local, .env.<mode>, .env.<mode>.local)
- Document behavior and how it relates to Vite's env exposure rules
- Add unit tests