### PR TITLE
ci: wire up npm publishing with OIDC trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_call: # allow other workflows to run CI as a gate
 
 permissions:
   contents: read

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,17 +1,34 @@
 name: Publish to npm
 
 on:
-  workflow_dispatch: # manual trigger only for now
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Version bump type"
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: patch
 
 concurrency:
   group: npm-publish
   cancel-in-progress: true
 
 permissions:
+  contents: write
   id-token: write
 
 jobs:
+  ci:
+    name: CI Gate
+    uses: ./.github/workflows/ci.yml
+
   publish:
+    name: Publish
+    needs: ci
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -31,17 +48,37 @@ jobs:
         working-directory: packages/vinext
 
       - name: Bump version
+        id: version
         working-directory: packages/vinext
         run: |
-          # Get the latest published version from npm, default to 0.0.0 if none
           LATEST=$(npm view vinext version 2>/dev/null || echo "0.0.0")
-          # Bump patch: 0.0.0 -> 0.0.1, 0.0.1 -> 0.0.2, etc.
           IFS='.' read -r MAJOR MINOR PATCH <<< "$LATEST"
-          NEXT_PATCH=$((PATCH + 1))
-          VERSION="${MAJOR}.${MINOR}.${NEXT_PATCH}"
+
+          case "${{ inputs.bump }}" in
+            major)
+              MAJOR=$((MAJOR + 1))
+              MINOR=0
+              PATCH=0
+              ;;
+            minor)
+              MINOR=$((MINOR + 1))
+              PATCH=0
+              ;;
+            patch)
+              PATCH=$((PATCH + 1))
+              ;;
+          esac
+
+          VERSION="${MAJOR}.${MINOR}.${PATCH}"
           npm version "$VERSION" --no-git-tag-version
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Publishing vinext@${VERSION} (was ${LATEST})"
 
-      - name: Publish
+      - name: Publish (OIDC trusted publishing)
         working-directory: packages/vinext
         run: npm publish --access public --provenance
+
+      - name: Tag release
+        run: |
+          git tag "v${{ steps.version.outputs.version }}"
+          git push origin "v${{ steps.version.outputs.version }}"

--- a/packages/vinext/package.json
+++ b/packages/vinext/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cloudflare/vinext"
+    "url": "git+https://github.com/cloudflare/vinext.git"
   },
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- Adds version bump input (patch/minor/major) to the manual publish workflow
- Gates publish on the full CI suite (lint, typecheck, vitest, all 5 e2e projects)
- Uses npm OIDC trusted publishing instead of a long-lived `NPM_TOKEN` secret
- Tags releases in git after publish (`v0.0.6`, etc.)

## Changes

- **`.github/workflows/publish.yml`** — rewrote with version input, CI gate via reusable workflow, OIDC auth (no secrets needed), and git tagging
- **`.github/workflows/ci.yml`** — added `workflow_call` trigger so publish can reuse it
- **`packages/vinext/package.json`** — fixed `repository.url` to canonical `git+https://...git` format for OIDC validation

## Setup required

After merging, configure trusted publishing on npmjs.com:

1. Go to https://www.npmjs.com/package/vinext/access
2. Under **Trusted Publisher**, click **GitHub Actions**
3. Set **Organization** = `cloudflare`, **Repository** = `vinext`, **Workflow filename** = `publish.yml`
4. Save