### PR TITLE
ci: commit version bump back to main after publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -78,10 +78,15 @@ jobs:
         working-directory: packages/vinext
         run: npm publish --access public --provenance
 
-      - name: Tag release
+      - name: Commit version bump and tag
         run: |
-          git tag "v${{ steps.version.outputs.version }}"
-          git push origin "v${{ steps.version.outputs.version }}"
+          VERSION="v${{ steps.version.outputs.version }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add packages/vinext/package.json
+          git commit -m "chore: release vinext@${VERSION}"
+          git tag "$VERSION"
+          git push origin HEAD:main "$VERSION"
 
       - name: Notify Google Chat
         if: success()


### PR DESCRIPTION
## Summary

- After a successful npm publish, commits the bumped `package.json` back to main alongside the git tag
- Without this, the repo stays at `0.0.5` forever while npm has newer versions

## Note

If branch protection blocks the bot push, you'll need to add `github-actions[bot]` to the bypass list in your ruleset/branch protection settings.