### PR TITLE
fix: read CLI version from package.json instead of hardcoded value

### DIFF
--- a/packages/vinext/src/cli.ts
+++ b/packages/vinext/src/cli.ts
@@ -76,7 +76,9 @@ function getViteVersion(): string {
   return _viteModule?.version ?? "unknown";
 }
 
-const VERSION = "0.0.1";
+const VERSION = JSON.parse(
+  fs.readFileSync(new URL("../package.json", import.meta.url), "utf-8"),
+).version as string;
 
 // ─── CLI Argument Parsing ──────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- The CLI help and `--version` output was hardcoded to `v0.0.1` — now reads from `package.json` at runtime so it always matches the published version.

Note: for users installing from npm this works immediately (the published tarball has the correct version in package.json). For the git repo to stay in sync, we'll need a separate PR to wire up the version commit-back in the publish workflow.