### PR TITLE
fix: make publish chat notification non-fatal

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -85,10 +85,11 @@ jobs:
 
       - name: Notify Google Chat
         if: success()
+        continue-on-error: true
         env:
           GOOGLE_CHAT_WEBHOOK: ${{ secrets.GOOGLE_CHAT_WEBHOOK }}
         run: |
           VERSION="v${{ steps.version.outputs.version }}"
-          curl -sf -X POST "$GOOGLE_CHAT_WEBHOOK" \
-            -H "Content-Type: application/json" \
+          curl -fSs -o /dev/null -w "HTTP %{http_code}" -X POST "$GOOGLE_CHAT_WEBHOOK" \
+            -H "Content-Type: application/json; charset=UTF-8" \
             -d "$(jq -n --arg text "vinext@${VERSION} published to npm: https://www.npmjs.com/package/vinext/v/${VERSION#v}" '{text: $text}')"


### PR DESCRIPTION
## Summary

The Google Chat notification step failed on the first publish run ([logs](https://github.com/cloudflare/vinext/actions/runs/22404152202/job/64859480279#step:10:13)), which marked the entire workflow as failed even though the npm publish succeeded.

Two fixes:
- **`continue-on-error: true`** — a failed notification should never fail the publish workflow
- **`Content-Type: application/json; charset=UTF-8`** — Google Chat API requires the charset; this is likely why the request was rejected (HTTP 4xx)
- **`-fSs -o /dev/null -w "HTTP %{http_code}"`** — shows the HTTP status code in logs on failure instead of silently swallowing errors