### PR TITLE
Skip deploy previews for fork PRs

### DIFF
--- a/.github/workflows/deploy-examples.yml
+++ b/.github/workflows/deploy-examples.yml
@@ -76,7 +76,7 @@ jobs:
           command: deploy --config ${{ matrix.example.wrangler_config }}
 
       - name: Deploy Preview Version
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -96,14 +96,14 @@ jobs:
         run: ./scripts/smoke-test.sh
 
       - name: Smoke test (preview)
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         run: ./scripts/smoke-test.sh --preview pr-${{ github.event.pull_request.number }}
 
   comment:
     name: Comment Preview URLs
     runs-on: ubuntu-latest
     needs: deploy
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       pull-requests: write
     steps:


### PR DESCRIPTION
## Summary

- Fork PRs don't have access to repository secrets (`CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`), causing all deploy jobs to fail with red X's whenever an external contributor opens a PR
- Adds `github.event.pull_request.head.repo.full_name == github.repository` condition to the deploy preview step, smoke test preview step, and comment job
- Example builds still run for fork PRs (validates the code compiles), only the deploy/smoke-test/comment steps are skipped

This matches the workers-sdk pattern where preview deploys are only run for internal branches.