### PR TITLE
fix(app-router): decode metadata helper import path on Windows

### DIFF
--- a/packages/vinext/src/server/app-dev-server.ts
+++ b/packages/vinext/src/server/app-dev-server.ts
@@ -213,7 +213,7 @@ import { ErrorBoundary, NotFoundBoundary } from "vinext/error-boundary";
 import { LayoutSegmentProvider } from "vinext/layout-segment-context";
 import { MetadataHead, mergeMetadata, resolveModuleMetadata, ViewportHead, mergeViewport, resolveModuleViewport } from "vinext/metadata";
 ${middlewarePath ? `import * as middlewareModule from ${JSON.stringify(middlewarePath.replace(/\\/g, "/"))};` : ""}
-${effectiveMetaRoutes.length > 0 ? `import { sitemapToXml, robotsToText, manifestToJson } from ${JSON.stringify(new URL("./metadata-routes.js", import.meta.url).pathname.replace(/\\/g, "/"))};` : ""}
+${effectiveMetaRoutes.length > 0 ? `import { sitemapToXml, robotsToText, manifestToJson } from ${JSON.stringify(decodeURIComponent(new URL("./metadata-routes.js", import.meta.url).pathname).replace(/\\/g, "/"))};` : ""}
 import { _consumeRequestScopedCacheLife, _initRequestScopedCacheState } from "next/cache";
 import { runWithFetchCache } from "vinext/fetch-cache";
 import { clearPrivateCache as _clearPrivateCache } from "vinext/cache-runtime";

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -1959,6 +1959,27 @@ describe("App Router next.config.js features (generateRscEntry)", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes, null, [], null, "", false);
     expect(code).toContain("__allowedOrigins = []");
   });
+
+  it("decodes metadata helper import paths for Windows directories with spaces", () => {
+    const code = generateRscEntry(
+      "/tmp/test/app",
+      minimalRoutes,
+      null,
+      [{
+        type: "sitemap",
+        isDynamic: true,
+        servedUrl: "/sitemap.xml",
+        contentType: "application/xml",
+        filePath: "/tmp/test/app/sitemap.ts",
+      }] as any,
+      null,
+      "",
+      false,
+    );
+    const match = code.match(/import \{ sitemapToXml, robotsToText, manifestToJson \} from "([^"]*metadata-routes\.js)";/);
+    expect(match).not.toBeNull();
+    expect(match?.[1]).not.toContain("%20");
+  });
 });
 
 describe("App Router middleware with NextRequest", () => {


### PR DESCRIPTION
## Summary
- fix App Router dev RSC entry generation to decode the metadata-routes.js file URL pathname before embedding it as an import path
- prevents %20-encoded Windows paths (directories with spaces) from being treated as literal filesystem segments
- add a regression test in 	ests/app-router.test.ts to ensure generated metadata helper import paths do not contain encoded %20`n
## Validation
- pnpm test -- tests/app-router.test.ts (pass in this branch)
- full checks (pnpm run lint, pnpm run typecheck, pnpm test, pnpm run test:e2e) were run by the local contributor before opening this PR

## Context
This addresses a Windows-only dev server failure where metadata helper imports could resolve to encoded paths and trigger a 500 when project directories include spaces.