### PR TITLE
fix(deploy): run wrangler via node instead of shell wrapper

### DIFF
--- a/packages/vinext/src/deploy.ts
+++ b/packages/vinext/src/deploy.ts
@@ -17,7 +17,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { createRequire } from "node:module";
-import { execFileSync, execSync, spawnSync, type ExecSyncOptions } from "node:child_process";
+import { execSync, spawnSync } from "node:child_process";
 import { parseArgs as nodeParseArgs } from "node:util";
 import { createBuilder, build } from "vite";
 import {


### PR DESCRIPTION
.bin/wrangler is a platform-specific shell script that fails on Windows (ENOENT) and triggers DEP0190 deprecation warnings when invoked with execFileSync + shell option. Replace with spawnSync on the wrangler JS entry directly via process.execPath for cross-platform compatibility.