### PR TITLE
fix(init): detect src/app as App Router

### DIFF
--- a/packages/vinext/src/utils/project.ts
+++ b/packages/vinext/src/utils/project.ts
@@ -114,5 +114,8 @@ export function hasViteConfig(root: string): boolean {
  * Check if the project uses App Router (has an app/ directory).
  */
 export function hasAppDir(root: string): boolean {
-  return fs.existsSync(path.join(root, "app"));
+  return (
+    fs.existsSync(path.join(root, "app")) ||
+    fs.existsSync(path.join(root, "src", "app"))
+  );
 }

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -469,6 +469,23 @@ describe("init — dependency installation", () => {
     expect(result.installedDeps).toContain("@vitejs/plugin-rsc");
   });
 
+  it("treats src/app projects as App Router", async () => {
+    setupProject(tmpDir, { router: "pages" });
+    fs.rmSync(path.join(tmpDir, "pages"), { recursive: true, force: true });
+    mkdir(tmpDir, "src/app");
+    writeFile(tmpDir, "src/app/page.tsx", 'export default function Home() { return <div>hi</div> }');
+    writeFile(
+      tmpDir,
+      "src/app/layout.tsx",
+      "export default function Layout({ children }) { return <html><body>{children}</body></html> }",
+    );
+
+    const { result } = await runInit(tmpDir);
+
+    expect(result.installedDeps).toContain("@vitejs/plugin-rsc");
+    expect(result.installedDeps).toContain("react-server-dom-webpack");
+  });
+
   it("detects missing react-server-dom-webpack for App Router", async () => {
     setupProject(tmpDir, { router: "app" });
 


### PR DESCRIPTION
## Summary
- align hasAppDir with Next.js by checking both app/ and src/app/
- add regression test in tests/init.test.ts for src/app projects

## Testing
- pnpm exec vitest run tests/init.test.ts