### PR TITLE
fix: resolve CodeQL security alerts (ReDoS, incomplete sanitization)

### DIFF
--- a/packages/vinext/src/config/config-matchers.ts
+++ b/packages/vinext/src/config/config-matchers.ts
@@ -156,6 +156,68 @@ export function safeRegExp(pattern: string, flags?: string): RegExp | null {
 }
 
 /**
+ * Convert a Next.js header/rewrite/redirect source pattern into a regex string.
+ *
+ * Regex groups in the source (e.g. `(\d+)`) are extracted first, the remaining
+ * text is escaped/converted in a **single pass** (avoiding chained `.replace()`
+ * which CodeQL flags as incomplete sanitization), then groups are restored.
+ */
+export function escapeHeaderSource(source: string): string {
+  // Sentinel character for group placeholders. Uses a Unicode private-use-area
+  // codepoint that will never appear in real source patterns.
+  const S = "\uE000";
+
+  // Step 1: extract regex groups and replace with numbered placeholders.
+  const groups: string[] = [];
+  const withPlaceholders = source.replace(/\(([^)]+)\)/g, (_m, inner) => {
+    groups.push(inner);
+    return `${S}G${groups.length - 1}${S}`;
+  });
+
+  // Step 2: single-pass conversion of the placeholder-bearing string.
+  // Match named params (:\w+), sentinel group placeholders, metacharacters, and literal text.
+  // The regex uses non-overlapping alternatives to avoid backtracking:
+  //   :\w+  — named parameter (constraint sentinel is checked procedurally)
+  //   sentinel group — standalone regex group placeholder
+  //   [.+?*] — single metachar to escape/convert
+  //   [^.+?*:\uE000]+ — literal text (excludes all chars that start other alternatives)
+  let result = "";
+  const re = new RegExp(
+    `${S}G(\\d+)${S}|:\\w+|[.+?*]|[^.+?*:\\uE000]+`, // lgtm[js/redos] — alternatives are non-overlapping
+    "g",
+  );
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(withPlaceholders)) !== null) {
+    if (m[1] !== undefined) {
+      // Standalone regex group — restore as-is
+      result += `(${groups[Number(m[1])]})`;
+    } else if (m[0].startsWith(":")) {
+      // Named parameter — check if followed by a constraint group placeholder
+      const afterParam = withPlaceholders.slice(re.lastIndex);
+      const constraintMatch = afterParam.match(new RegExp(`^${S}G(\\d+)${S}`));
+      if (constraintMatch) {
+        // :param(constraint) — use the constraint as the capture group
+        re.lastIndex += constraintMatch[0].length;
+        result += `(${groups[Number(constraintMatch[1])]})`;
+      } else {
+        // Plain named parameter → match one segment
+        result += "[^/]+";
+      }
+    } else {
+      switch (m[0]) {
+        case ".": result += "\\."; break;
+        case "+": result += "\\+"; break;
+        case "?": result += "\\?"; break;
+        case "*": result += ".*"; break;
+        default: result += m[0]; break;
+      }
+    }
+  }
+
+  return result;
+}
+
+/**
  * Request context needed for evaluating has/missing conditions.
  * Callers extract the relevant parts from the incoming Request.
  */
@@ -270,6 +332,26 @@ export function checkHasConditions(
 }
 
 /**
+ * If the current position in `str` starts with a parenthesized group, consume
+ * it and advance `re.lastIndex` past the closing `)`. Returns the group
+ * contents or null if no group is present.
+ */
+function extractConstraint(str: string, re: RegExp): string | null {
+  if (str[re.lastIndex] !== "(") return null;
+  const start = re.lastIndex + 1;
+  let depth = 1;
+  let i = start;
+  while (i < str.length && depth > 0) {
+    if (str[i] === "(") depth++;
+    else if (str[i] === ")") depth--;
+    i++;
+  }
+  if (depth !== 0) return null;
+  re.lastIndex = i;
+  return str.slice(start, i - 1);
+}
+
+/**
  * Match a Next.js config pattern (from redirects/rewrites sources) against a pathname.
  * Returns matched params or null.
  *
@@ -296,28 +378,40 @@ export function matchConfigPattern(
   ) {
     try {
       const paramNames: string[] = [];
-      const regexStr = pattern
-        .replace(/\./g, "\\.")
-        // :param* with optional constraint
-        .replace(/:(\w+)\*(?:\(([^)]+)\))?/g, (_m, name, constraint) => {
-          paramNames.push(name);
-          return constraint ? `(${constraint})` : "(.*)";
-        })
-        // :param+ with optional constraint
-        .replace(/:(\w+)\+(?:\(([^)]+)\))?/g, (_m, name, constraint) => {
-          paramNames.push(name);
-          return constraint ? `(${constraint})` : "(.+)";
-        })
-        // :param(constraint) - named param with inline regex constraint
-        .replace(/:(\w+)\(([^)]+)\)/g, (_m, name, constraint) => {
-          paramNames.push(name);
-          return `(${constraint})`;
-        })
-        // :param - plain named param
-        .replace(/:(\w+)/g, (_m, name) => {
-          paramNames.push(name);
-          return "([^/]+)";
-        });
+      // Single-pass conversion with procedural suffix handling. The tokenizer
+      // matches only simple, non-overlapping tokens; quantifier/constraint
+      // suffixes after :param are consumed procedurally to avoid polynomial
+      // backtracking in the regex engine.
+      let regexStr = "";
+      const tokenRe = /:(\w+)|[.]|[^:.]+/g; // lgtm[js/redos] — alternatives are non-overlapping (`:` and `.` excluded from `[^:.]+`)
+      let tok: RegExpExecArray | null;
+      while ((tok = tokenRe.exec(pattern)) !== null) {
+        if (tok[1] !== undefined) {
+          const name = tok[1];
+          const rest = pattern.slice(tokenRe.lastIndex);
+          // Check for quantifier (* or +) with optional constraint
+          if (rest.startsWith("*") || rest.startsWith("+")) {
+            const quantifier = rest[0];
+            tokenRe.lastIndex += 1;
+            const constraint = extractConstraint(pattern, tokenRe);
+            paramNames.push(name);
+            if (constraint !== null) {
+              regexStr += `(${constraint})`;
+            } else {
+              regexStr += quantifier === "*" ? "(.*)" : "(.+)";
+            }
+          } else {
+            // Check for inline constraint without quantifier
+            const constraint = extractConstraint(pattern, tokenRe);
+            paramNames.push(name);
+            regexStr += constraint !== null ? `(${constraint})` : "([^/]+)";
+          }
+        } else if (tok[0] === ".") {
+          regexStr += "\\.";
+        } else {
+          regexStr += tok[0];
+        }
+      }
       const re = safeRegExp("^" + regexStr + "$");
       if (!re) return null;
       const match = re.exec(pathname);
@@ -553,19 +647,7 @@ export function matchHeaders(
 ): Array<{ key: string; value: string }> {
   const result: Array<{ key: string; value: string }> = [];
   for (const rule of headers) {
-    // Extract regex groups first, process the rest, then restore groups.
-    const groups: string[] = [];
-    const withPlaceholders = rule.source.replace(/\(([^)]+)\)/g, (_m, inner) => {
-      groups.push(inner);
-      return `___GROUP_${groups.length - 1}___`;
-    });
-    const escaped = withPlaceholders
-      .replace(/\./g, "\\.")
-      .replace(/\+/g, "\\+")
-      .replace(/\?/g, "\\?")
-      .replace(/\*/g, ".*")
-      .replace(/:\w+/g, "[^/]+")
-      .replace(/___GROUP_(\d+)___/g, (_m, idx) => `(${groups[Number(idx)]})`);
+    const escaped = escapeHeaderSource(rule.source);
     const sourceRegex = safeRegExp("^" + escaped + "$");
     if (sourceRegex && sourceRegex.test(pathname)) {
       result.push(...rule.headers);

--- a/packages/vinext/src/server/middleware.ts
+++ b/packages/vinext/src/server/middleware.ts
@@ -130,18 +130,27 @@ export function matchPattern(pathname: string, pattern: string): boolean {
     // Fall through to simple matching
   }
 
-  // Convert Next.js path patterns to regex.
-  // Escape dots FIRST (before replacements that produce regex metacharacters
-  // like .* and .+ which must not be escaped).
-  const regexStr = pattern
-    // Escape dots in the literal path segments
-    .replace(/\./g, "\\.")
-    // /:path* -> optionally match slash + zero or more segments
-    .replace(/\/:(\w+)\*/g, "(?:/.*)?")
-    // /:path+ -> match slash + one or more segments
-    .replace(/\/:(\w+)\+/g, "(?:/.+)")
-    // :param -> match one segment
-    .replace(/:(\w+)/g, "([^/]+)");
+  // Convert Next.js path patterns to regex in a single pass.
+  // Matches /:param*, /:param+, :param, dots, and literal text.
+  let regexStr = "";
+  const tokenRe = /\/:(\w+)\*|\/:(\w+)\+|:(\w+)|[.]|[^/:.]+|./g;
+  let tok: RegExpExecArray | null;
+  while ((tok = tokenRe.exec(pattern)) !== null) {
+    if (tok[1] !== undefined) {
+      // /:param* → optionally match slash + zero or more segments
+      regexStr += "(?:/.*)?";
+    } else if (tok[2] !== undefined) {
+      // /:param+ → match slash + one or more segments
+      regexStr += "(?:/.+)";
+    } else if (tok[3] !== undefined) {
+      // :param → match one segment
+      regexStr += "([^/]+)";
+    } else if (tok[0] === ".") {
+      regexStr += "\\.";
+    } else {
+      regexStr += tok[0];
+    }
+  }
 
   const re = safeRegExp("^" + regexStr + "$");
   if (re) return re.test(pathname);

--- a/tests/e2e/app-router/isr.spec.ts
+++ b/tests/e2e/app-router/isr.spec.ts
@@ -144,6 +144,7 @@ test.describe("ISR dynamicParams cache headers", () => {
       const html = await res.text();
       // React SSR inserts <!-- --> comment nodes between text and expressions,
       // so "Product 1" may appear as "Product <!-- -->1" in raw HTML.
+      // lgtm[js/redos] — applied to trusted SSR output, not user input
       expect(html).toMatch(/Product\s*(?:<!--.*?-->)*\s*1/);
     });
 
@@ -238,7 +239,8 @@ test.describe("revalidateTag / revalidatePath lifecycle (OpenNext compat)", () =
     expect(res1.status()).toBe(200);
     const html1 = await res1.text();
     // React SSR may insert <!-- --> comment nodes between text and expressions,
-    // so use a flexible regex that allows anything between the tag and content
+    // so use a flexible regex that allows anything between the tag and content.
+    // lgtm[js/redos] — applied to trusted SSR output, not user input
     const reqId1 = html1.match(/data-testid="request-id"[^>]*>(?:<!--.*?-->)*RequestID:\s*(?:<!--.*?-->)*([a-z0-9]+)/)?.[1]
       ?? html1.match(/request-id[^>]*>[^<]*?([a-z0-9]{6,})/)?.[1];
     expect(reqId1).toBeDefined();
@@ -246,6 +248,7 @@ test.describe("revalidateTag / revalidatePath lifecycle (OpenNext compat)", () =
     // Load again to confirm it's cached (same request ID)
     const res2 = await request.get(`${BASE}/revalidate-tag-test`);
     const html2 = await res2.text();
+    // lgtm[js/redos] — applied to trusted SSR output, not user input
     const reqId2 = html2.match(/data-testid="request-id"[^>]*>(?:<!--.*?-->)*RequestID:\s*(?:<!--.*?-->)*([a-z0-9]+)/)?.[1]
       ?? html2.match(/request-id[^>]*>[^<]*?([a-z0-9]{6,})/)?.[1];
     const cacheHeader = res2.headers()["x-vinext-cache"];
@@ -263,6 +266,7 @@ test.describe("revalidateTag / revalidatePath lifecycle (OpenNext compat)", () =
     // Reload — content should be different (cache was invalidated)
     const res3 = await request.get(`${BASE}/revalidate-tag-test`);
     const html3 = await res3.text();
+    // lgtm[js/redos] — applied to trusted SSR output, not user input
     const reqId3 = html3.match(/data-testid="request-id"[^>]*>(?:<!--.*?-->)*RequestID:\s*(?:<!--.*?-->)*([a-z0-9]+)/)?.[1]
       ?? html3.match(/request-id[^>]*>[^<]*?([a-z0-9]{6,})/)?.[1];
 
@@ -284,6 +288,7 @@ test.describe("revalidateTag / revalidatePath lifecycle (OpenNext compat)", () =
     const res1 = await request.get(`${BASE}/revalidate-tag-test`);
     expect(res1.status()).toBe(200);
     const html1 = await res1.text();
+    // lgtm[js/redos] — applied to trusted SSR output, not user input
     const reqId1 = html1.match(/data-testid="request-id"[^>]*>(?:<!--.*?-->)*RequestID:\s*(?:<!--.*?-->)*([a-z0-9]+)/)?.[1]
       ?? html1.match(/request-id[^>]*>[^<]*?([a-z0-9]{6,})/)?.[1];
     expect(reqId1).toBeDefined();
@@ -298,6 +303,7 @@ test.describe("revalidateTag / revalidatePath lifecycle (OpenNext compat)", () =
     // Reload — content should be different
     const res2 = await request.get(`${BASE}/revalidate-tag-test`);
     const html2 = await res2.text();
+    // lgtm[js/redos] — applied to trusted SSR output, not user input
     const reqId2 = html2.match(/data-testid="request-id"[^>]*>(?:<!--.*?-->)*RequestID:\s*(?:<!--.*?-->)*([a-z0-9]+)/)?.[1]
       ?? html2.match(/request-id[^>]*>[^<]*?([a-z0-9]{6,})/)?.[1];
 

--- a/tests/font-google.test.ts
+++ b/tests/font-google.test.ts
@@ -359,6 +359,7 @@ describe("vinext:google-fonts plugin", () => {
     const result = await transform.call(plugin, code, "/app/layout.tsx");
     expect(result).not.toBeNull();
     expect(result.code).toContain("_selfHostedCSS");
+    // lgtm[js/incomplete-sanitization] — escaping quotes for test assertion, not sanitization
     expect(result.code).toContain(fakeCSS.replace(/"/g, '\\"'));
 
     plugin._fontCache.clear();

--- a/tests/rsc-streaming.test.ts
+++ b/tests/rsc-streaming.test.ts
@@ -669,6 +669,7 @@ describe("Tick-buffered RSC streaming (behavioral)", () => {
     // The raw string "</script>" should NOT appear outside of the proper
     // script tags we control. Count actual <script> and </script> tags —
     // they should be balanced (our tags only, not the malicious payload).
+    // lgtm[js/bad-tag-filter] — counting tags to verify XSS protection, not filtering HTML
     const openScripts = (output.match(/<script>/g) || []).length;
     const closeScripts = (output.match(/<\/script>/g) || []).length;
     expect(openScripts).toBe(closeScripts);

--- a/tests/safe-json.test.ts
+++ b/tests/safe-json.test.ts
@@ -342,7 +342,8 @@ describe("safeJsonStringify", () => {
 
       const scriptContent = `<script>window.__NEXT_DATA__ = ${safeJsonStringify(nextData)}</script>`;
 
-      // Count script tags — there should be exactly one open and one close
+      // Count script tags — there should be exactly one open and one close.
+      // lgtm[js/bad-tag-filter] — counting tags to verify XSS protection, not filtering HTML
       const openTags = scriptContent.match(/<script>/g);
       const closeTags = scriptContent.match(/<\/script>/g);
       expect(openTags).toHaveLength(1);
@@ -357,6 +358,7 @@ describe("safeJsonStringify", () => {
 
       const scriptContent = `<script>self.__VINEXT_RSC__=${safeJsonStringify(embedData)}</script>`;
 
+      // lgtm[js/bad-tag-filter] — counting tags to verify XSS protection, not filtering HTML
       const openTags = scriptContent.match(/<script>/g);
       const closeTags = scriptContent.match(/<\/script>/g);
       expect(openTags).toHaveLength(1);
@@ -369,6 +371,7 @@ describe("safeJsonStringify", () => {
 
       const script = `<script>window.__VINEXT_LOCALE__=${safeJsonStringify(locale)};window.__VINEXT_LOCALES__=${safeJsonStringify(locales)}</script>`;
 
+      // lgtm[js/bad-tag-filter] — counting tags to verify XSS protection, not filtering HTML
       const openTags = script.match(/<script>/g);
       const closeTags = script.match(/<\/script>/g);
       expect(openTags).toHaveLength(1);


### PR DESCRIPTION
## Summary

Resolves all 26 open CodeQL code scanning alerts from https://github.com/cloudflare/vinext/security/code-scanning.

### Production code fixes (3 files)

**Single-pass tokenizers replace chained `.replace()`** — CodeQL flagged chained string replacements as incomplete sanitization since later passes could re-process earlier outputs. Refactored to single-pass regex tokenizer loops in:

- `matchConfigPattern()` in both `config-matchers.ts` and `index.ts` (alerts #25-28, #30-33, #50)
- `matchMiddlewarePattern()` inlined in the prod server entry template (same pattern as alert #29)
- `matchPattern()` in `middleware.ts` (alert #29)

**New `escapeHeaderSource()` helper** — shared single-pass converter for Next.js header/rewrite/redirect source patterns, used by `matchHeaders()` and `applyHeaders()`. Correctly handles `:param(constraint)` patterns (improvement over old code which silently dropped constraints).

**Additional fixes:**
- `decodeURIComponent` parity: `index.ts` catch-all matcher now decodes percent-encoded values, matching `config-matchers.ts` behavior
- Redundant dot in middleware tokenizer char class: `[^/:..]+` → `[^/:.]+`
- `lgtm` suppression + safety comment for `JSON.stringify` code gen (alert #35)

### Test file suppressions (5 files)

Added `lgtm[js/redos]`, `lgtm[js/bad-tag-filter]`, and `lgtm[js/incomplete-sanitization]` comments for confirmed false positives:
- Deliberate pathological regex in ReDoS guard tests
- Script tag counting for XSS protection verification
- Quote escaping in font test assertions

### New tests

9 unit tests for `escapeHeaderSource` covering literal paths, dot escaping, named params, glob star, plus/question escaping, constrained params, alternation groups, standalone groups, and multiple groups.

### Verification

- `pnpm run typecheck` — clean
- `pnpm run lint` — clean
- `pnpm vitest run` — 731 tests pass across affected suites