### PR TITLE
fix: detect src/app App Router

### DIFF
--- a/packages/vinext/src/utils/project.ts
+++ b/packages/vinext/src/utils/project.ts
@@ -114,5 +114,8 @@ export function hasViteConfig(root: string): boolean {
  * Check if the project uses App Router (has an app/ directory).
  */
 export function hasAppDir(root: string): boolean {
-  return fs.existsSync(path.join(root, "app"));
+  return (
+    fs.existsSync(path.join(root, "app")) ||
+    fs.existsSync(path.join(root, "src", "app"))
+  );
 }

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -469,6 +469,24 @@ describe("init — dependency installation", () => {
     expect(result.installedDeps).toContain("@vitejs/plugin-rsc");
   });
 
+  it("treats src/app projects as App Router", async () => {
+    setupProject(tmpDir);
+    fs.rmSync(path.join(tmpDir, "app"), { recursive: true, force: true });
+    
+    mkdir(tmpDir, "src/app");
+    writeFile(tmpDir, "src/app/page.tsx", 'export default function Home() { return <div>hi</div> }');
+    writeFile(
+      tmpDir,
+      "src/app/layout.tsx",
+      "export default function Layout({ children }) { return <html><body>{children}</body></html> }",
+    );
+
+    const { result } = await runInit(tmpDir);
+
+    expect(result.installedDeps).toContain("@vitejs/plugin-rsc");
+    expect(result.installedDeps).toContain("react-server-dom-webpack");
+  });
+
   it("detects missing react-server-dom-webpack for App Router", async () => {
     setupProject(tmpDir, { router: "app" });
 


### PR DESCRIPTION

   ## Summary
   - Align `hasAppDir` with Next.js behavior by checking both `app/` and `src/app/`.
   - Fix `vinext init` misclassification for projects that use `src/app`.
   - Add a regression test in `tests/init.test.ts` to ensure `src/app` projects are treated as App Router projects and install App Router dependencies.

   ## Why
   Next.js supports both `app/` and `src/app/`; matching this behavior improves compatibility and avoids incorrect setup during `vinext init`.

   ## Testing
   - `pnpm exec vitest run tests/init.test.ts`