### PR TITLE
fix: sanitize redirect destinations and digest parsing

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -3327,6 +3327,16 @@ export function matchConfigPattern(
 }
 
 /**
+ * Sanitize a redirect/rewrite destination by collapsing leading // to /
+ * for non-external URLs, preventing unintended protocol-relative redirects.
+ */
+function sanitizeDestinationLocal(dest: string): string {
+  if (dest.startsWith("http://") || dest.startsWith("https://")) return dest;
+  if (dest.startsWith("//")) dest = dest.replace(/^\/\/+/, "/");
+  return dest;
+}
+
+/**
  * Apply redirect rules from next.config.js.
  * Returns true if a redirect was applied.
  */
@@ -3344,6 +3354,8 @@ function applyRedirects(
         dest = dest.replace(`:${key}+`, value);
         dest = dest.replace(`:${key}`, value);
       }
+      // Sanitize to prevent open redirect via protocol-relative URLs
+      dest = sanitizeDestinationLocal(dest);
       res.writeHead(redirect.permanent ? 308 : 307, { Location: dest });
       res.end();
       return true;
@@ -3434,6 +3446,8 @@ function applyRewrites(
         dest = dest.replace(`:${key}+`, value);
         dest = dest.replace(`:${key}`, value);
       }
+      // Sanitize to prevent open redirect via protocol-relative URLs
+      dest = sanitizeDestinationLocal(dest);
       return dest;
     }
   }

--- a/packages/vinext/src/server/app-dev-server.ts
+++ b/packages/vinext/src/server/app-dev-server.ts
@@ -1026,6 +1026,12 @@ function __buildRequestContext(request) {
   };
 }
 
+function __sanitizeDestination(dest) {
+  if (dest.startsWith("http://") || dest.startsWith("https://")) return dest;
+  if (dest.startsWith("//")) dest = dest.replace(/^\\/\\/+/, "/");
+  return dest;
+}
+
 function __applyConfigRedirects(pathname, ctx) {
   for (const rule of __configRedirects) {
     const params = __matchConfigPattern(pathname, rule.source);
@@ -1033,6 +1039,7 @@ function __applyConfigRedirects(pathname, ctx) {
       if (ctx && (rule.has || rule.missing)) { if (!__checkHasConditions(rule.has, rule.missing, ctx)) continue; }
       let dest = rule.destination;
       for (const [key, value] of Object.entries(params)) { dest = dest.replace(":" + key + "*", value); dest = dest.replace(":" + key + "+", value); dest = dest.replace(":" + key, value); }
+      dest = __sanitizeDestination(dest);
       return { destination: dest, permanent: rule.permanent };
     }
   }
@@ -1046,6 +1053,7 @@ function __applyConfigRewrites(pathname, rules, ctx) {
       if (ctx && (rule.has || rule.missing)) { if (!__checkHasConditions(rule.has, rule.missing, ctx)) continue; }
       let dest = rule.destination;
       for (const [key, value] of Object.entries(params)) { dest = dest.replace(":" + key + "*", value); dest = dest.replace(":" + key + "+", value); dest = dest.replace(":" + key, value); }
+      dest = __sanitizeDestination(dest);
       return dest;
     }
   }
@@ -1166,9 +1174,11 @@ async function _handleRequest(request) {
   if (__configRedirects.length) {
     const __redir = __applyConfigRedirects(pathname, __reqCtx);
     if (__redir) {
-      const __redirDest = __basePath && !__redir.destination.startsWith(__basePath)
-        ? __basePath + __redir.destination
-        : __redir.destination;
+      const __redirDest = __sanitizeDestination(
+        __basePath && !__redir.destination.startsWith(__basePath)
+          ? __basePath + __redir.destination
+          : __redir.destination
+      );
       return new Response(null, {
         status: __redir.permanent ? 308 : 307,
         headers: { Location: __redirDest },
@@ -1346,12 +1356,14 @@ async function _handleRequest(request) {
       } catch (e) {
         // Detect redirect() / permanentRedirect() called inside the action.
         // These throw errors with digest "NEXT_REDIRECT;replace;url[;status]".
+        // The URL is encodeURIComponent-encoded to prevent semicolons in the URL
+        // from corrupting the delimiter-based digest format.
         if (e && typeof e === "object" && "digest" in e) {
           const digest = String(e.digest);
           if (digest.startsWith("NEXT_REDIRECT;")) {
             const parts = digest.split(";");
             actionRedirect = {
-              url: parts[2],
+              url: decodeURIComponent(parts[2]),
               type: parts[1] || "replace",       // "push" or "replace"
               status: parts[3] ? parseInt(parts[3], 10) : 307,
             };
@@ -1574,7 +1586,7 @@ async function _handleRequest(request) {
           const digest = String(err.digest);
           if (digest.startsWith("NEXT_REDIRECT;")) {
             const parts = digest.split(";");
-            const redirectUrl = parts[2];
+            const redirectUrl = decodeURIComponent(parts[2]);
             const statusCode = parts[3] ? parseInt(parts[3], 10) : 307;
             setHeadersContext(null);
             setNavigationContext(null);
@@ -1741,7 +1753,7 @@ async function _handleRequest(request) {
       const digest = String(buildErr.digest);
       if (digest.startsWith("NEXT_REDIRECT;")) {
         const parts = digest.split(";");
-        const redirectUrl = parts[2];
+        const redirectUrl = decodeURIComponent(parts[2]);
         const statusCode = parts[3] ? parseInt(parts[3], 10) : 307;
         setHeadersContext(null);
         setNavigationContext(null);
@@ -1772,7 +1784,7 @@ async function _handleRequest(request) {
       const digest = String(err.digest);
       if (digest.startsWith("NEXT_REDIRECT;")) {
         const parts = digest.split(";");
-        const redirectUrl = parts[2];
+        const redirectUrl = decodeURIComponent(parts[2]);
         const statusCode = parts[3] ? parseInt(parts[3], 10) : 307;
         setHeadersContext(null);
         setNavigationContext(null);
@@ -1814,13 +1826,13 @@ async function _handleRequest(request) {
       } catch (layoutErr) {
         if (layoutErr && typeof layoutErr === "object" && "digest" in layoutErr) {
           const digest = String(layoutErr.digest);
-          if (digest.startsWith("NEXT_REDIRECT;")) {
-            const parts = digest.split(";");
-            const redirectUrl = parts[2];
-            const statusCode = parts[3] ? parseInt(parts[3], 10) : 307;
-            setHeadersContext(null);
-            setNavigationContext(null);
-            return Response.redirect(new URL(redirectUrl, request.url), statusCode);
+           if (digest.startsWith("NEXT_REDIRECT;")) {
+             const parts = digest.split(";");
+             const redirectUrl = decodeURIComponent(parts[2]);
+             const statusCode = parts[3] ? parseInt(parts[3], 10) : 307;
+             setHeadersContext(null);
+             setNavigationContext(null);
+             return Response.redirect(new URL(redirectUrl, request.url), statusCode);
           }
           if (digest === "NEXT_NOT_FOUND" || digest.startsWith("NEXT_HTTP_ERROR_FALLBACK;")) {
             const statusCode = digest === "NEXT_NOT_FOUND" ? 404 : parseInt(digest.split(";")[1], 10);

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -23,7 +23,7 @@ import { pathToFileURL } from "node:url";
 import fs from "node:fs";
 import path from "node:path";
 import zlib from "node:zlib";
-import { matchRedirect, matchRewrite, matchHeaders, requestContextFromRequest, isExternalUrl, proxyExternalRequest } from "../config/config-matchers.js";
+import { matchRedirect, matchRewrite, matchHeaders, requestContextFromRequest, isExternalUrl, proxyExternalRequest, sanitizeDestination } from "../config/config-matchers.js";
 import type { RequestContext } from "../config/config-matchers.js";
 import { IMAGE_OPTIMIZATION_PATH, parseImageParams } from "./image-optimization.js";
 import { computeLazyChunks } from "../index.js";
@@ -729,9 +729,12 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
         if (redirect) {
           // Guard against double-prefixing: only add basePath if destination
           // doesn't already start with it.
-          const dest = basePath && !redirect.destination.startsWith(basePath)
-            ? basePath + redirect.destination
-            : redirect.destination;
+          // Sanitize the final destination to prevent protocol-relative URL open redirects.
+          const dest = sanitizeDestination(
+            basePath && !redirect.destination.startsWith(basePath)
+              ? basePath + redirect.destination
+              : redirect.destination,
+          );
           res.writeHead(redirect.permanent ? 308 : 307, { Location: dest });
           res.end();
           return;

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -687,7 +687,7 @@ export enum RedirectType {
  */
 export function redirect(url: string, type?: "replace" | "push" | RedirectType): never {
   const error = new Error(`NEXT_REDIRECT:${url}`);
-  (error as any).digest = `NEXT_REDIRECT;${type ?? "replace"};${url}`;
+  (error as any).digest = `NEXT_REDIRECT;${type ?? "replace"};${encodeURIComponent(url)}`;
   throw error;
 }
 
@@ -696,7 +696,7 @@ export function redirect(url: string, type?: "replace" | "push" | RedirectType):
  */
 export function permanentRedirect(url: string): never {
   const error = new Error(`NEXT_REDIRECT:${url}`);
-  (error as any).digest = `NEXT_REDIRECT;replace;${url};308`;
+  (error as any).digest = `NEXT_REDIRECT;replace;${encodeURIComponent(url)};308`;
   throw error;
 }
 


### PR DESCRIPTION
## Summary

- Prevents protocol-relative URLs in redirect destinations by normalizing double slashes. After parameter substitution, a catch-all redirect like `/:path*` can produce `//evil.com` when the captured segment starts with `/` (from a decoded `%2F`). A new `sanitizeDestination()` function collapses leading `//` to `/` for non-external URLs.
- Fixes redirect digest parsing to handle URLs containing semicolons. The `NEXT_REDIRECT;type;url;status` digest format uses `;` as a delimiter, so URLs with semicolons would corrupt the parsed fields. The URL is now `encodeURIComponent`-encoded when creating the digest and decoded when parsing it.

Applied consistently across all entry points (App Router dev, Pages Router dev/prod, config matchers).