### PR TITLE
fix: validate module paths during client-side navigation

### DIFF
--- a/packages/vinext/src/client/entry.ts
+++ b/packages/vinext/src/client/entry.ts
@@ -14,24 +14,13 @@ import { hydrateRoot } from "react-dom/client";
 // registered.  Without this, browser back/forward buttons do nothing because
 // navigateClient() is never invoked on history changes.
 import "next/router";
+import { isValidModulePath } from "./validate-module-path.js";
 
 // Read the SSR data injected by the server
 const nextData = (window as any).__NEXT_DATA__;
 const { pageProps } = nextData?.props ?? { pageProps: {} };
 const pageModulePath = nextData?.__pageModule;
 const appModulePath = nextData?.__appModule;
-
-/** Defense-in-depth: validate module paths from __NEXT_DATA__. */
-function isValidModulePath(p: unknown): p is string {
-  if (typeof p !== "string" || p.length === 0) return false;
-  // Must start with / or ./ (relative Vite module paths)
-  if (!p.startsWith("/") && !p.startsWith("./")) return false;
-  // Must not contain protocol (prevents importing from external URLs)
-  if (p.includes("://")) return false;
-  // Must not traverse directories
-  if (p.includes("..")) return false;
-  return true;
-}
 
 async function hydrate() {
   if (!isValidModulePath(pageModulePath)) {

--- a/packages/vinext/src/client/validate-module-path.ts
+++ b/packages/vinext/src/client/validate-module-path.ts
@@ -1,0 +1,25 @@
+/**
+ * Defense-in-depth: validate module paths before passing them to dynamic import().
+ *
+ * Shared between entry.ts (initial hydration) and router.ts (client-side navigation)
+ * to ensure all dynamic imports of page/app modules go through the same validation.
+ *
+ * Blocks:
+ * - Non-string or empty values
+ * - Paths that don't start with `/` or `./` (e.g., `https://evil.com/...`)
+ * - Protocol URLs (`://`)
+ * - Protocol-relative URLs (`//...`)
+ * - Directory traversal (`..`)
+ */
+export function isValidModulePath(p: unknown): p is string {
+  if (typeof p !== "string" || p.length === 0) return false;
+  // Must start with / or ./ (relative Vite module paths)
+  if (!p.startsWith("/") && !p.startsWith("./")) return false;
+  // Block protocol-relative URLs (e.g., "//evil.com/script.js")
+  if (p.startsWith("//")) return false;
+  // Must not contain protocol (prevents importing from external URLs)
+  if (p.includes("://")) return false;
+  // Must not traverse directories
+  if (p.includes("..")) return false;
+  return true;
+}

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import path from "node:path";
 import { PAGES_FIXTURE_DIR } from "./helpers.js";
 import { isExternalUrl, isHashOnlyChange } from "../packages/vinext/src/shims/router.js";
+import { isValidModulePath } from "../packages/vinext/src/client/validate-module-path.js";
 
 const FIXTURE_DIR = PAGES_FIXTURE_DIR;
 
@@ -5830,5 +5831,66 @@ describe("next/head SSR security", () => {
       expect(html).toContain(`<${tag}`);
       expect(html).toContain('data-vinext-head="true"');
     }
+  });
+});
+
+describe("isValidModulePath", () => {
+  it("accepts valid absolute paths", () => {
+    expect(isValidModulePath("/src/pages/index.tsx")).toBe(true);
+    expect(isValidModulePath("/pages/about.js")).toBe(true);
+    expect(isValidModulePath("/src/pages/posts/[id].tsx")).toBe(true);
+  });
+
+  it("accepts valid relative paths starting with ./", () => {
+    expect(isValidModulePath("./src/pages/index.tsx")).toBe(true);
+    expect(isValidModulePath("./pages/about.js")).toBe(true);
+  });
+
+  it("rejects external https:// URLs", () => {
+    expect(isValidModulePath("https://evil.com/steal-cookies.js")).toBe(false);
+  });
+
+  it("rejects external http:// URLs", () => {
+    expect(isValidModulePath("http://evil.com/steal-cookies.js")).toBe(false);
+  });
+
+  it("rejects protocol-relative URLs (//)", () => {
+    expect(isValidModulePath("//evil.com/steal-cookies.js")).toBe(false);
+    expect(isValidModulePath("//cdn.example.com/script.js")).toBe(false);
+  });
+
+  it("rejects directory traversal", () => {
+    expect(isValidModulePath("/src/../../../etc/passwd")).toBe(false);
+    expect(isValidModulePath("./../../secret.js")).toBe(false);
+    expect(isValidModulePath("/pages/..%2F..%2Fsecret.js")).toBe(false);
+  });
+
+  it("rejects data: URLs", () => {
+    expect(isValidModulePath("data:text/javascript,alert(1)")).toBe(false);
+  });
+
+  it("rejects blob: URLs", () => {
+    expect(isValidModulePath("blob:http://localhost/abc")).toBe(false);
+  });
+
+  it("rejects bare specifiers", () => {
+    expect(isValidModulePath("evil-package")).toBe(false);
+    expect(isValidModulePath("@evil/package")).toBe(false);
+  });
+
+  it("rejects non-string values", () => {
+    expect(isValidModulePath(null)).toBe(false);
+    expect(isValidModulePath(undefined)).toBe(false);
+    expect(isValidModulePath(42)).toBe(false);
+    expect(isValidModulePath({})).toBe(false);
+    expect(isValidModulePath("")).toBe(false);
+  });
+
+  it("rejects javascript: protocol", () => {
+    expect(isValidModulePath("javascript:alert(1)")).toBe(false);
+  });
+
+  it("rejects ftp:// protocol", () => {
+    expect(isValidModulePath("ftp://evil.com/script.js")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Applies the existing `isValidModulePath()` guard to `navigateClient()` in the Pages Router client and fixes it to also reject protocol-relative paths.

- Extracts `isValidModulePath()` from `entry.ts` into a shared `validate-module-path.ts` module
- Adds a check for protocol-relative URLs (`//...`) that the original inline version missed
- Guards both `pageModuleUrl` and `appModuleUrl` in `navigateClient()` before calling `import()`, falling back to full page navigation on invalid paths