### PR TITLE
fix: use Host header for server action origin check

### DIFF
--- a/packages/vinext/src/server/app-dev-server.ts
+++ b/packages/vinext/src/server/app-dev-server.ts
@@ -837,8 +837,12 @@ function __validateCsrfOrigin(request) {
     return new Response("Forbidden", { status: 403, headers: { "Content-Type": "text/plain" } });
   }
 
+  // Only use the Host header for origin comparison — never trust
+  // X-Forwarded-Host here, since it can be freely set by the client
+  // and would allow the check to be bypassed if it matched a spoofed
+  // Origin. The prod server's resolveHost() handles trusted proxy
+  // scenarios separately.
   const hostHeader = (
-    request.headers.get("x-forwarded-host") ||
     request.headers.get("host") ||
     ""
   ).split(",")[0].trim().toLowerCase();


### PR DESCRIPTION
## Summary

Changes the server action origin validation to prefer the Host header over X-Forwarded-Host, matching the trusted-host logic already used in the production server.

X-Forwarded-Host can be freely set by the client, so using it in the origin comparison allows the check to be bypassed by sending a matching Origin and X-Forwarded-Host pair. The Host header is set by the HTTP stack and is the correct value to compare against.