### PR TITLE
fix: handle malformed percent-encoded URLs gracefully

### DIFF
--- a/packages/vinext/src/server/app-dev-server.ts
+++ b/packages/vinext/src/server/app-dev-server.ts
@@ -1224,7 +1224,11 @@ async function _handleRequest(request) {
   // Decode percent-encoding and normalize pathname to canonical form.
   // decodeURIComponent prevents /%61dmin from bypassing /admin matchers.
   // __normalizePath collapses //foo///bar → /foo/bar, resolves . and .. segments.
-  let pathname = __normalizePath(decodeURIComponent(url.pathname));
+  let decodedUrlPathname;
+  try { decodedUrlPathname = decodeURIComponent(url.pathname); } catch (e) {
+    return new Response("Bad Request", { status: 400 });
+  }
+  let pathname = __normalizePath(decodedUrlPathname);
 
   ${bp ? `
   // Strip basePath prefix

--- a/packages/vinext/src/server/app-router-entry.ts
+++ b/packages/vinext/src/server/app-router-entry.ts
@@ -29,7 +29,13 @@ export default {
     }
 
     // Decode percent-encoding and normalize the path for middleware/route matching.
-    const normalizedPathname = normalizePath(decodeURIComponent(rawPathname));
+    let normalizedPathname: string;
+    try {
+      normalizedPathname = normalizePath(decodeURIComponent(rawPathname));
+    } catch {
+      // Malformed percent-encoding (e.g. /%E0%A4%A) — return 400 instead of throwing.
+      return new Response("Bad Request", { status: 400 });
+    }
 
     // Construct a new Request with normalized pathname so the RSC entry
     // sees the canonical path for middleware and route matching.

--- a/packages/vinext/src/server/middleware.ts
+++ b/packages/vinext/src/server/middleware.ts
@@ -205,7 +205,14 @@ export async function runMiddleware(
 
   // Normalize the pathname before middleware matching to prevent bypasses
   // via percent-encoding (/%61dmin → /admin) or double slashes (/dashboard//settings).
-  const normalizedPathname = normalizePath(decodeURIComponent(url.pathname));
+  let decodedPathname: string;
+  try {
+    decodedPathname = decodeURIComponent(url.pathname);
+  } catch {
+    // Malformed percent-encoding (e.g. /%E0%A4%A) — return 400 instead of throwing.
+    return { continue: false, response: new Response("Bad Request", { status: 400 }) };
+  }
+  const normalizedPathname = normalizePath(decodedPathname);
 
   if (!matchesMiddleware(normalizedPathname, matcher)) {
     return { continue: true };

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -479,7 +479,15 @@ async function startAppRouterServer(options: AppRouterServerOptions) {
     const url = req.url ?? "/";
     // Normalize backslashes (browsers treat /\ as //), then decode and normalize path.
     const rawPathname = url.split("?")[0].replaceAll("\\", "/");
-    const pathname = normalizePath(decodeURIComponent(rawPathname));
+    let pathname: string;
+    try {
+      pathname = normalizePath(decodeURIComponent(rawPathname));
+    } catch {
+      // Malformed percent-encoding (e.g. /%E0%A4%A) — return 400 instead of crashing.
+      res.writeHead(400);
+      res.end("Bad Request");
+      return;
+    }
 
     // Guard against protocol-relative URL open redirect attacks.
     // Check rawPathname before normalizePath collapses //.
@@ -620,7 +628,15 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
     let url = rawUrl;
     // Normalize backslashes (browsers treat /\ as //), then decode and normalize path.
     const rawPagesPathname = url.split("?")[0].replaceAll("\\", "/");
-    let pathname = normalizePath(decodeURIComponent(rawPagesPathname));
+    let pathname: string;
+    try {
+      pathname = normalizePath(decodeURIComponent(rawPagesPathname));
+    } catch {
+      // Malformed percent-encoding (e.g. /%E0%A4%A) — return 400 instead of crashing.
+      res.writeHead(400);
+      res.end("Bad Request");
+      return;
+    }
 
     // Guard against protocol-relative URL open redirect attacks.
     // Check rawPagesPathname before normalizePath collapses //.

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -1026,6 +1026,20 @@ describe("Production server middleware (Pages Router)", () => {
     const html = await res.text();
     expect(html).toContain("Hello, vinext!");
   });
+
+  it("returns 400 for malformed percent-encoded path (not crash)", async () => {
+    const res = await fetch(`${prodUrl}/%E0%A4%A`);
+    expect(res.status).toBe(400);
+    const body = await res.text();
+    expect(body).toContain("Bad Request");
+  });
+
+  it("returns 400 for bare percent sign in path (not crash)", async () => {
+    const res = await fetch(`${prodUrl}/%`);
+    expect(res.status).toBe(400);
+    const body = await res.text();
+    expect(body).toContain("Bad Request");
+  });
 });
 
 describe("Production server next.config.js features (Pages Router)", () => {


### PR DESCRIPTION
## Problem

`decodeURIComponent()` on attacker-controlled request paths throws `URIError: URI malformed` for invalid percent sequences (e.g. `/%E0%A4%A`). When this happens outside a try/catch in a request handler, the uncaught exception terminates the Node process — a single malformed request causes full service outage.

## Fix

Wrap all `decodeURIComponent` calls on user-controlled input in try/catch across every server entry point. On decode failure, return **400 Bad Request** and continue serving.

### Files changed

| File | Fix |
|------|-----|
| `prod-server.ts` | App Router + Pages Router request handlers |
| `app-router-entry.ts` | Cloudflare Worker entry |
| `app-dev-server.ts` | Generated RSC entry handler |
| `index.ts` | Dev server connect middleware, generated middleware runner, NEXT_LOCALE cookie parser |
| `middleware.ts` | Pages Router dev middleware runner |

### Tests

11 regression tests added across three test files:
- `app-router.test.ts` — App Router prod server + dev server (5 tests)
- `pages-router.test.ts` — Pages Router prod server (2 tests)
- `features.test.ts` — Pages Router dev server (4 tests)