### PR TITLE
fix: dev sanitizeDestination now normalizes leading backslashes

### DIFF
--- a/packages/vinext/src/server/app-dev-server.ts
+++ b/packages/vinext/src/server/app-dev-server.ts
@@ -1012,7 +1012,7 @@ function __buildRequestContext(request) {
 
 function __sanitizeDestination(dest) {
   if (dest.startsWith("http://") || dest.startsWith("https://")) return dest;
-  if (dest.startsWith("//")) dest = dest.replace(/^\\/\\/+/, "/");
+  dest = dest.replace(/^[\\\\/]+/, "/");
   return dest;
 }
 


### PR DESCRIPTION
The dev server's `__sanitizeDestination` only collapsed leading `//` but ignored leading backslashes (e.g. `\evil.com`). The prod version in `config-matchers.ts` already used `/^[\\/]+/` to handle both.

This aligns the dev codegen to match, closing a minor open-redirect vector where a rewrite destination starting with `\` could be interpreted as a protocol-relative URL by the browser.

**Risk: LOW** — redirect destinations are developer-configured via `next.config.js`, and a request-level guard already blocks protocol-relative incoming paths. This fix ensures defense-in-depth parity between dev and prod.