### PR TITLE
chore: rebuild pages-basic fixture dist

### DIFF
--- a/tests/fixtures/pages-basic/dist/server/entry.js
+++ b/tests/fixtures/pages-basic/dist/server/entry.js
@@ -4093,7 +4093,13 @@ async function runMiddleware(request) {
   var config$1 = config;
   var matcher = config$1 && config$1.matcher;
   var url = new URL(request.url);
-  var normalizedPathname = __normalizePath(decodeURIComponent(url.pathname));
+  var decodedPathname;
+  try {
+    decodedPathname = decodeURIComponent(url.pathname);
+  } catch (e) {
+    return { continue: false, response: new Response("Bad Request", { status: 400 }) };
+  }
+  var normalizedPathname = __normalizePath(decodedPathname);
   if (!matchesMiddleware(normalizedPathname, matcher)) return { continue: true };
   var nextRequest = request instanceof NextRequest ? request : new NextRequest(request);
   var response;


### PR DESCRIPTION
Syncs the checked-in build artifact with current source. The previous version was stale from PR #106.

Notable change: middleware runner now wraps `decodeURIComponent` in a try/catch to return 400 on malformed percent-encoding instead of throwing.