### PR TITLE
harden CI workflows: frozen-lockfile, checksum verification

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -30,10 +30,11 @@ jobs:
       - name: Install hyperfine
         run: |
           wget https://github.com/sharkdp/hyperfine/releases/download/v1.19.0/hyperfine_1.19.0_amd64.deb
+          echo "5ffe6996aefbbf547f383116eea53569263cc7cf6598ee53f0081e37b702055d  hyperfine_1.19.0_amd64.deb" | sha256sum -c
           sudo dpkg -i hyperfine_1.19.0_amd64.deb
 
       # Install monorepo deps (builds vinext plugin via pnpm run build)
-      - run: pnpm install
+      - run: pnpm install --frozen-lockfile
       - name: Build vinext plugin
         run: pnpm run build
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           node-version: 24
           cache: pnpm
-      - run: pnpm install
+      - run: pnpm install --frozen-lockfile
       - run: pnpm run lint
 
   typecheck:
@@ -38,7 +38,7 @@ jobs:
         with:
           node-version: 24
           cache: pnpm
-      - run: pnpm install
+      - run: pnpm install --frozen-lockfile
       - run: pnpm run typecheck
 
   test:
@@ -51,7 +51,7 @@ jobs:
         with:
           node-version: 24
           cache: pnpm
-      - run: pnpm install
+      - run: pnpm install --frozen-lockfile
       - name: Build plugin (needed by ecosystem fixtures)
         run: pnpm run build
       - run: pnpm test
@@ -70,7 +70,7 @@ jobs:
         with:
           node-version: 24
           cache: pnpm
-      - run: pnpm install
+      - run: pnpm install --frozen-lockfile
       - name: Build plugin
         run: pnpm run build
       - name: Pack vinext for local install
@@ -146,7 +146,7 @@ jobs:
         with:
           node-version: 24
           cache: pnpm
-      - run: pnpm install
+      - run: pnpm install --frozen-lockfile
       - name: Build plugin
         run: pnpm run build
       - run: pnpm exec playwright install chromium

--- a/.github/workflows/deploy-examples.yml
+++ b/.github/workflows/deploy-examples.yml
@@ -48,7 +48,7 @@ jobs:
           node-version: 24
           cache: pnpm
 
-      - run: pnpm install
+      - run: pnpm install --frozen-lockfile
 
       - name: Build vinext plugin
         run: pnpm run build

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -18,6 +18,6 @@ jobs:
         with:
           node-version: 24
           cache: pnpm
-      - run: pnpm install
+      - run: pnpm install --frozen-lockfile
       - run: pnpm run build
       - run: pnpm dlx pkg-pr-new publish --pnpm './packages/vinext'


### PR DESCRIPTION
## Supply-chain hardening for CI workflows

- **Add `--frozen-lockfile`** to all `pnpm install` calls in `ci.yml`, `deploy-examples.yml`, `benchmarks.yml`, `preview-release.yml` — ensures reproducible builds and prevents silent dependency drift between runs
- **Add SHA256 checksum verification** for the hyperfine `.deb` download in `benchmarks.yml` — defense-in-depth against tampered binaries