### PR TITLE
fix(rsc): include cookies in RSC navigation and prefetch requests

### DIFF
--- a/packages/vinext/src/server/app-dev-server.ts
+++ b/packages/vinext/src/server/app-dev-server.ts
@@ -2839,6 +2839,7 @@ async function main() {
       if (!navResponse) {
         navResponse = await fetch(rscUrl, {
           headers: { Accept: "text/x-component" },
+          credentials: "include",
         });
       }
 

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -165,6 +165,7 @@ function prefetchUrl(href: string): void {
       // App Router: prefetch the RSC payload and store in cache
       fetch(rscUrl, {
         headers: { Accept: "text/x-component" },
+        credentials: "include",
         priority: "low" as any,
         // @ts-expect-error — purpose is a valid fetch option in some browsers
         purpose: "prefetch",

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -519,6 +519,7 @@ export function useRouter() {
       prefetched.add(rscUrl);
       fetch(rscUrl, {
         headers: { Accept: "text/x-component" },
+        credentials: "include",
         priority: "low" as RequestInit["priority"],
       }).then((response) => {
         if (response.ok) {


### PR DESCRIPTION
  ## Summary

  RSC navigation and prefetch requests were missing `credentials: 'include'`,
  causing browsers to silently omit cookies from these requests. This broke
  cookie-based authentication (Better Auth, NextAuth, etc.) during client-side
  navigation.

  **Root cause:** A full-page reload works correctly — the browser always sends
  cookies with HTML navigation requests. But when a user clicks a `<Link>`, vinext
  fetches the RSC payload via `fetch()`, and without `credentials: 'include'` the
  browser omits all cookies from the request. The server receives no session cookie
  and authentication fails.

  **Three call sites fixed:**

  | File | Context |
  |---|---|
  | `server/app-dev-server.ts` | `__VINEXT_RSC_NAVIGATE__` — actual navigation fetch |
  | `shims/link.tsx` | `<Link>` prefetch triggered on viewport intersection |
  | `shims/navigation.ts` | `router.prefetch()` programmatic prefetch |

  ```diff
  - navResponse = await fetch(rscUrl, {
  -   headers: { Accept: "text/x-component" },
  - });
  + navResponse = await fetch(rscUrl, {
  +   headers: { Accept: "text/x-component" },
  +   credentials: "include",
  + });
```
  Reproduction

  1. Set up cookie-based auth (e.g., Better Auth or NextAuth)
  2. Have a protected route that calls cookies() on the server
  3. Navigate to a public page, then click a <Link> to the protected route
  4. Before: Auth fails — session cookie not sent with the RSC fetch
  5. After: Auth succeeds — cookies included in all RSC requests

  A full page refresh on the protected route always worked correctly. Only
  client-side <Link> navigation was affected.

  Notes

  - credentials: 'include' is the correct choice here: RSC fetches are always
  same-origin (they go to the same vinext dev server / production host), so this
  cannot cause credential leakage to third parties. Rewrites to external origins
  are handled by the server-side proxy which already strips cookies before
  forwarding.
  - Prefetch requests with stale/unauthorised responses are discarded when
  consumed — no change to that logic.

  Fixes #85