### PR TITLE
fix(middleware-codegen): allow hyphens in path param names in generated matcher

### DIFF
--- a/packages/vinext/src/server/middleware-codegen.ts
+++ b/packages/vinext/src/server/middleware-codegen.ts
@@ -160,7 +160,7 @@ function matchMiddlewarePattern(pathname, pattern) {
   // Single-pass tokenizer (avoids chained .replace() flagged by CodeQL as
   // incomplete sanitization — later passes could re-process earlier outputs).
   ${l} regexStr = "";
-  ${v} tokenRe = /\\/:([\\w]+)\\*|\\/:([\\w]+)\\+|:([\\w]+)|[.]|[^/:.]+|./g;
+  ${v} tokenRe = /\\/:([\\w-]+)\\*|\\/:([\\w-]+)\\+|:([\\w-]+)|[.]|[^/:.]+|./g;
   ${l} tok;
   while ((tok = tokenRe.exec(pattern)) !== null) {
     if (tok[1] !== undefined) { regexStr += "(?:/.*)?"; }


### PR DESCRIPTION
## Summary

  `middleware-codegen.ts` generates the `matchMiddlewarePattern()` function that
  is inlined into the production RSC entry (`worker/index.ts`). The `tokenRe`
  regex used `[\w]+` for path parameter capture groups, which does not match
  hyphens — so middleware matchers with hyphenated param names silently failed
  in production.

  ```diff
  - ${v} tokenRe = /\\/:([\\w]+)\\*|\\/:([\\w]+)\\+|:([\\w]+)|[.]|[^/:.]+|./g;
  + ${v} tokenRe = /\\/:([\\w-]+)\\*|\\/:([\\w-]+)\\+|:([\\w-]+)|[.]|[^/:.]+|./g;
```
 ## Problem

  A middleware config.matcher like "/:sign-in*" or "/auth/:reset-password"
  would not be recognised as a param pattern and treated as a literal string,
  causing the matcher to never fire in production.

  This is a production-only gap. The dev path executes matchPattern() from
  middleware.ts directly; the production RSC entry uses the generated string
  from middleware-codegen.ts — and only the generated version had the bug.

  Relation to PR #78

  PR #78 fixes the same \w+ issue in middleware.ts (the dev path) and several
  routing files, but middleware-codegen.ts was added to main after PR #78
  was opened, so it was not included in that scope.

  The file's own comment states:

  The pattern matching logic must be identical to matchPattern() in
  middleware.ts. Any changes here must be mirrored there and vice versa.

  This PR applies that mirroring proactively, so dev and prod stay consistent
  when PR #78 lands.