### PR TITLE
fix(shims): copy request headers into mutable Headers in headersContextFromRequest

### DIFF
--- a/packages/vinext/src/shims/headers.ts
+++ b/packages/vinext/src/shims/headers.ts
@@ -190,7 +190,10 @@ export function headersContextFromRequest(request: Request): HeadersContext {
     }
   }
   return {
-    headers: request.headers,
+    // Copy into a mutable Headers instance. In Cloudflare Workers the original
+    // Request.headers is immutable; applyMiddlewareRequestHeaders() needs to
+    // call .set() on this object after middleware runs.
+    headers: new Headers(request.headers),
     cookies,
   };
 }

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -266,6 +266,29 @@ describe("next/headers shim", () => {
     expect(ctx.headers.get("cookie")).toBe("a=1; b=2");
   });
 
+  it("headersContextFromRequest returns mutable headers (not the immutable Request.headers)", async () => {
+    // In Cloudflare Workers, Request.headers is immutable. applyMiddlewareRequestHeaders
+    // needs ctx.headers.set() after middleware runs, so the context must hold a mutable
+    // copy, not the original Headers reference.
+    const { headersContextFromRequest } = await import(
+      "../packages/vinext/src/shims/headers.js"
+    );
+    const req = new Request("https://example.com", {
+      headers: { "x-custom": "original" },
+    });
+    const ctx = headersContextFromRequest(req);
+
+    // Must be a separate, mutable copy — not the same reference
+    expect(ctx.headers).not.toBe(req.headers);
+
+    // Must be writable without throwing
+    expect(() => ctx.headers.set("x-custom", "modified")).not.toThrow();
+    expect(ctx.headers.get("x-custom")).toBe("modified");
+
+    // Original request headers must be unaffected
+    expect(req.headers.get("x-custom")).toBe("original");
+  });
+
   it("throws when called outside request context", async () => {
     const { headers, cookies } = await import(
       "../packages/vinext/src/shims/headers.js"


### PR DESCRIPTION
## Summary

In Cloudflare Workers, `Request.headers` is immutable per the Fetch API spec. `headersContextFromRequest` was storing the original `request.headers` reference directly in `HeadersContext`, so when `applyMiddlewareRequestHeaders` later called `ctx.headers.set()` (to propagate middleware-modified headers into server component context), Workers threw:

```
TypeError: Can't modify immutable headers.
```

This is triggered on every request when middleware returns `NextResponse.next({ request: { headers } })` — a common pattern for passing data like `x-request-url` from middleware to server components.

## Fix

Wrap with `new Headers(request.headers)`, which creates an independent mutable copy while preserving all header values.

```diff
- headers: request.headers,
+ headers: new Headers(request.headers),
```

## Test plan

- [x] New test asserting the context holds a mutable copy, not the original `Request.headers` reference
- [x] All 2026 existing tests pass
- [x] Lint: 0 warnings/errors (`oxlint`)
- [x] Typecheck: clean (`tsgo --noEmit`)

/bonk