### PR TITLE
fix: use fileURLToPath for metadata-routes import in RSC entry

### DIFF
--- a/packages/vinext/src/server/app-dev-server.ts
+++ b/packages/vinext/src/server/app-dev-server.ts
@@ -7,6 +7,7 @@
  * the SSR entry for HTML generation.
  */
 import fs from "node:fs";
+import { fileURLToPath } from "node:url";
 import type { AppRoute } from "../routing/app-router.js";
 import type { MetadataFileRoute } from "./metadata-routes.js";
 import type { NextRedirect, NextRewrite, NextHeader } from "../config/next-config.js";
@@ -217,7 +218,7 @@ import { ErrorBoundary, NotFoundBoundary } from "vinext/error-boundary";
 import { LayoutSegmentProvider } from "vinext/layout-segment-context";
 import { MetadataHead, mergeMetadata, resolveModuleMetadata, ViewportHead, mergeViewport, resolveModuleViewport } from "vinext/metadata";
 ${middlewarePath ? `import * as middlewareModule from ${JSON.stringify(middlewarePath.replace(/\\/g, "/"))};` : ""}
-${effectiveMetaRoutes.length > 0 ? `import { sitemapToXml, robotsToText, manifestToJson } from ${JSON.stringify(new URL("./metadata-routes.js", import.meta.url).pathname.replace(/\\/g, "/"))};` : ""}
+${effectiveMetaRoutes.length > 0 ? `import { sitemapToXml, robotsToText, manifestToJson } from ${JSON.stringify(fileURLToPath(new URL("./metadata-routes.js", import.meta.url)).replace(/\\/g, "/"))};` : ""}
 import { _consumeRequestScopedCacheLife, _runWithCacheState } from "next/cache";
 import { runWithFetchCache } from "vinext/fetch-cache";
 import { runWithPrivateCache as _runWithPrivateCache } from "vinext/cache-runtime";


### PR DESCRIPTION
## Summary
- Use `fileURLToPath()` instead of `URL.pathname` when generating the metadata-routes import path in the virtual RSC entry
- `URL.pathname` returns percent-encoded strings (e.g. `%20` for spaces), which Vite cannot resolve as filesystem paths
- This caused **all App Router / RSC / nextjs-compat tests to fail** (19/50 test files, 271 tests) when the project lives in a directory with spaces — common on macOS with iCloud Drive, Google Drive, OneDrive, etc.

## Change
One-line fix in `packages/vinext/src/server/app-dev-server.ts`:

```diff
-new URL("./metadata-routes.js", import.meta.url).pathname.replace(/\\/g, "/")
+fileURLToPath(new URL("./metadata-routes.js", import.meta.url)).replace(/\\/g, "/")
```

This pattern is already used correctly elsewhere in the codebase (`cloudflare/tpr.ts:613`).

## Test plan
- [x] Verified all 50 test files pass (2011 tests) on a path without spaces
- [x] Verified all 50 test files pass (2011 tests) on a path **with** spaces (`~/Code/test spaces/vinext`)
- [x] Confirmed this was the root cause by tracing the Vite error: `Failed to load url .../metadata-routes.js in virtual:vinext-rsc-entry`

Fixes #129