### PR TITLE
fix: add missing react-server-dom-webpack to App Router examples

### DIFF
--- a/examples/app-router-cloudflare/package.json
+++ b/examples/app-router-cloudflare/package.json
@@ -13,6 +13,7 @@
     "vite": "^7.3.1",
     "vinext": "workspace:*",
     "@vitejs/plugin-rsc": "^0.5.19",
+    "react-server-dom-webpack": "^19.2.4",
     "@cloudflare/vite-plugin": "^1.25.0",
     "wrangler": "^4.65.0"
   }

--- a/examples/app-router-playground/package.json
+++ b/examples/app-router-playground/package.json
@@ -18,6 +18,7 @@
     "react-dom": "^19.0.0",
     "use-count-up": "3.0.1",
     "vinext": "workspace:*",
+    "react-server-dom-webpack": "^19.2.4",
     "zod": "3.24.3"
   },
   "devDependencies": {

--- a/examples/benchmarks/package.json
+++ b/examples/benchmarks/package.json
@@ -13,6 +13,7 @@
     "vite": "^7.3.1",
     "vinext": "workspace:*",
     "@vitejs/plugin-rsc": "^0.5.19",
+    "react-server-dom-webpack": "^19.2.4",
     "@cloudflare/vite-plugin": "^1.25.0",
     "@cloudflare/kumo": "^1.6.0",
     "@phosphor-icons/react": "^2.1.7",

--- a/examples/hackernews/package.json
+++ b/examples/hackernews/package.json
@@ -15,6 +15,7 @@
     "vite": "^7.3.1",
     "vinext": "workspace:*",
     "@vitejs/plugin-rsc": "^0.5.19",
+    "react-server-dom-webpack": "^19.2.4",
     "@cloudflare/vite-plugin": "^1.25.0",
     "wrangler": "^4.65.0"
   }

--- a/examples/nextra-docs-template/package.json
+++ b/examples/nextra-docs-template/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-server-dom-webpack": "^19.2.4",
     "vinext": "workspace:*"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       react-dom:
         specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
+      react-server-dom-webpack:
+        specifier: ^19.2.4
+        version: 19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       vinext:
         specifier: workspace:*
         version: link:../../packages/vinext
@@ -111,6 +114,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.2.4(react@19.2.4)
+      react-server-dom-webpack:
+        specifier: ^19.2.4
+        version: 19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       use-count-up:
         specifier: 3.0.1
         version: 3.0.1(react@19.2.4)
@@ -187,6 +193,9 @@ importers:
       react-dom:
         specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
+      react-server-dom-webpack:
+        specifier: ^19.2.4
+        version: 19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tailwindcss:
         specifier: ^4.1.0
         version: 4.1.4
@@ -217,6 +226,9 @@ importers:
       react-dom:
         specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
+      react-server-dom-webpack:
+        specifier: ^19.2.4
+        version: 19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       server-only:
         specifier: ^0.0.1
         version: 0.0.1
@@ -238,6 +250,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.2.4(react@19.2.4)
+      react-server-dom-webpack:
+        specifier: ^19.2.4
+        version: 19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       vinext:
         specifier: workspace:*
         version: link:../../packages/vinext


### PR DESCRIPTION
## Summary

- Add `react-server-dom-webpack` as an explicit dependency to all App Router examples that were missing it: `app-router-cloudflare`, `app-router-playground`, `benchmarks`, `hackernews`, `nextra-docs-template`
- Fixes client-side hydration being completely broken in dev mode — `"use client"` components rendered as static HTML with no interactivity

Closes #28

## Root Cause

`@vitejs/plugin-rsc` correctly adds `react-server-dom-webpack/client.browser` to `optimizeDeps.include` for the client environment, but pnpm's strict module resolution prevents Vite from resolving it unless the package is explicitly listed in the project's `package.json`. This caused:

```
Failed to resolve dependency: react-server-dom-webpack/client.browser, present in client 'optimizeDeps.include'
```

The CJS file was served raw to the browser, resulting in `ReferenceError: module is not defined`, which broke React's RSC client integration and all hydration.

## Test plan

- [x] Start `examples/app-router-cloudflare` with `vite dev`
- [x] Verify no `Failed to resolve dependency` warnings in console
- [x] Verify no `ReferenceError: module is not defined` in browser console
- [x] Verify `"use client"` Counter component increments on click