### PR TITLE
fix(shims): harden jsx-runtime compatibility across remaining shim modules

### DIFF
--- a/packages/vinext/src/shims/document.tsx
+++ b/packages/vinext/src/shims/document.tsx
@@ -1,3 +1,7 @@
+/** @jsxRuntime classic */
+/** @jsx React.createElement */
+/** @jsxFrag React.Fragment */
+
 /**
  * next/document shim
  *

--- a/packages/vinext/src/shims/form.tsx
+++ b/packages/vinext/src/shims/form.tsx
@@ -1,5 +1,9 @@
 "use client";
 
+/** @jsxRuntime classic */
+/** @jsx React.createElement */
+/** @jsxFrag React.Fragment */
+
 /**
  * next/form shim
  *
@@ -18,7 +22,7 @@
  *   </Form>
  */
 
-import {
+import React, {
   forwardRef,
   useActionState,
   type FormHTMLAttributes,

--- a/packages/vinext/src/shims/image.tsx
+++ b/packages/vinext/src/shims/image.tsx
@@ -1,3 +1,7 @@
+/** @jsxRuntime classic */
+/** @jsx React.createElement */
+/** @jsxFrag React.Fragment */
+
 /**
  * next/image shim
  *

--- a/packages/vinext/src/shims/legacy-image.tsx
+++ b/packages/vinext/src/shims/legacy-image.tsx
@@ -1,3 +1,7 @@
+/** @jsxRuntime classic */
+/** @jsx React.createElement */
+/** @jsxFrag React.Fragment */
+
 /**
  * next/legacy/image shim
  *

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -1,5 +1,9 @@
 "use client";
 
+/** @jsxRuntime classic */
+/** @jsx React.createElement */
+/** @jsxFrag React.Fragment */
+
 /**
  * next/link shim
  *

--- a/packages/vinext/src/shims/metadata.tsx
+++ b/packages/vinext/src/shims/metadata.tsx
@@ -1,3 +1,7 @@
+/** @jsxRuntime classic */
+/** @jsx React.createElement */
+/** @jsxFrag React.Fragment */
+
 /**
  * Metadata support for App Router.
  *

--- a/tests/jsx-runtime-compat.test.ts
+++ b/tests/jsx-runtime-compat.test.ts
@@ -1,0 +1,60 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { createServer } from "vite";
+import { describe, it, expect } from "vitest";
+
+describe("shim JSX runtime compatibility", () => {
+  it("loads shim modules when react/jsx-runtime only exposes a default export", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "vinext-jsx-runtime-"));
+    const jsxRuntimePath = path.join(tmpDir, "jsx-runtime-default-only.mjs");
+    const jsxDevRuntimePath = path.join(tmpDir, "jsx-dev-runtime-default-only.mjs");
+    const repoRoot = path.resolve(import.meta.dirname, "..");
+    const shimPaths = [
+      "../packages/vinext/src/shims/link.tsx",
+      "../packages/vinext/src/shims/metadata.tsx",
+      "../packages/vinext/src/shims/legacy-image.tsx",
+      "../packages/vinext/src/shims/form.tsx",
+      "../packages/vinext/src/shims/document.tsx",
+      "../packages/vinext/src/shims/image.tsx",
+    ].map((p) => path.resolve(import.meta.dirname, p));
+
+    await fs.writeFile(
+      jsxRuntimePath,
+      "const jsx = () => null; const jsxs = () => null; const Fragment = 'div'; export default { jsx, jsxs, Fragment };\n",
+    );
+    await fs.writeFile(
+      jsxDevRuntimePath,
+      "const jsxDEV = () => null; const Fragment = 'div'; export default { jsxDEV, Fragment };\n",
+    );
+
+    let server: Awaited<ReturnType<typeof createServer>> | undefined;
+    try {
+      server = await createServer({
+        root: repoRoot,
+        configFile: false,
+        server: { port: 0 },
+        logLevel: "silent",
+        plugins: [
+          {
+            name: "vinext:jsx-runtime-default-only-test",
+            enforce: "pre",
+            resolveId(id) {
+              if (id === "react/jsx-runtime") return jsxRuntimePath;
+              if (id === "react/jsx-dev-runtime") return jsxDevRuntimePath;
+              return null;
+            },
+          },
+        ],
+      });
+
+      for (const shimPath of shimPaths) {
+        const mod = await server.ssrLoadModule(shimPath);
+        expect(Object.keys(mod).length).toBeGreaterThan(0);
+      }
+    } finally {
+      await server?.close();
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Follow-up to #45 / #135: harden JSX-runtime compatibility for remaining shim `.tsx` modules that could still depend on named exports from `react/jsx-runtime`.

## What changed
- Switched these shims to classic JSX runtime via per-file pragmas:
  - `packages/vinext/src/shims/link.tsx`
  - `packages/vinext/src/shims/metadata.tsx`
  - `packages/vinext/src/shims/legacy-image.tsx`
  - `packages/vinext/src/shims/form.tsx`
  - `packages/vinext/src/shims/document.tsx`
  - `packages/vinext/src/shims/image.tsx`
- Added missing `React` default import in `next/form` shim (required for classic JSX transform).
- Added regression test `tests/jsx-runtime-compat.test.ts` that verifies these shim modules load when `react/jsx-runtime` and `react/jsx-dev-runtime` only expose default exports.

## Why
This closes the gap called out in review on #45: even if `error-boundary.tsx` is fixed, other shim modules could still fail under packaging setups where `react/jsx-runtime` named exports are not available.

Closes #135

## Validation
- `pnpm -s test tests/jsx-runtime-compat.test.ts tests/link.test.ts tests/form.test.ts tests/image-component.test.ts tests/metadata-routes.test.ts tests/shims.test.ts`
