### PR TITLE
docs: add Ecosystem section with community projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -540,3 +540,13 @@ Even a partial diagnosis helps — stack traces, which `next/*` import is involv
 ## License
 
 MIT
+
+## Ecosystem
+
+Projects building on vinext:
+
+| Project | Description |
+|---------|-------------|
+| [**FABRK Framework**](https://github.com/jpoindexter/fabrk-framework) | Full-stack AI-first framework with 109+ components, 18 themes, auth, payments, AI cost tracking, and security — built on vinext |
+
+_Building something on vinext? Open a PR to add it here._


### PR DESCRIPTION
## Summary

Adds an **Ecosystem** section to the README to highlight community projects building on vinext.

The first entry is [FABRK Framework](https://github.com/jpoindexter/fabrk-framework) — a full-stack AI-first framework with 109+ components, 18 themes, auth, payments, AI cost tracking, and security built on vinext.

The section includes an open invitation for other projects to add themselves via PR.

## Why

As vinext grows, having a visible ecosystem helps:
- **Users** discover batteries-included options built on vinext
- **Contributors** see real-world usage patterns
- **The project** demonstrate community adoption

## Changes

- Added `## Ecosystem` section at the end of `README.md`
- Table format for easy scanning and future additions
- Call-to-action for other projects to submit PRs

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)