### PR TITLE
fix: strip internal routing headers from dev server responses

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -692,7 +692,9 @@ export async function runMiddleware(request) {
   if (response.headers.get("x-middleware-next") === "1") {
     var rHeaders = new Headers();
     for (var [key, value] of response.headers) {
-      if (key !== "x-middleware-next" && key !== "x-middleware-rewrite") rHeaders.set(key, value);
+      // Strip ALL x-middleware-* headers — they are internal routing signals
+      // and must never reach clients.
+      if (!key.startsWith("x-middleware-")) rHeaders.set(key, value);
     }
     return { continue: true, responseHeaders: rHeaders };
   }
@@ -705,7 +707,7 @@ export async function runMiddleware(request) {
   var rewriteUrl = response.headers.get("x-middleware-rewrite");
   if (rewriteUrl) {
     var rwHeaders = new Headers();
-    for (var [k, v] of response.headers) { if (k !== "x-middleware-rewrite") rwHeaders.set(k, v); }
+    for (var [k, v] of response.headers) { if (!k.startsWith("x-middleware-")) rwHeaders.set(k, v); }
     var rewritePath;
     try { var parsed = new URL(rewriteUrl, request.url); rewritePath = parsed.pathname + parsed.search; }
     catch { rewritePath = rewriteUrl; }

--- a/packages/vinext/src/server/app-dev-server.ts
+++ b/packages/vinext/src/server/app-dev-server.ts
@@ -1305,7 +1305,11 @@ async function _handleRequest(request) {
       if (mwResponse) {
         // Check for x-middleware-next (continue)
         if (mwResponse.headers.get("x-middleware-next") === "1") {
-          // Middleware wants to continue - save headers to merge into final response
+          // Middleware wants to continue — collect all headers except the two
+          // control headers we've already consumed.  x-middleware-request-*
+          // headers are kept so applyMiddlewareRequestHeaders() can unpack them;
+          // the blanket strip loop after that call removes every remaining
+          // x-middleware-* header before the set is merged into the response.
           _middlewareResponseHeaders = new Headers();
           for (const [key, value] of mwResponse.headers) {
             if (key !== "x-middleware-next" && key !== "x-middleware-rewrite") {


### PR DESCRIPTION
## Summary

- Strips all `x-middleware-*` prefixed headers from responses in both the App Router and Pages Router dev servers
- These are internal routing signals (`x-middleware-next`, `x-middleware-rewrite`, `x-middleware-override-headers`) that should not be visible to clients
- The prod server already handled this correctly; this brings the dev servers into parity
- Adds test verifying no `x-middleware-*` headers appear in client responses