### PR TITLE
fix: detect bun.lock (text format) in package manager detection

### DIFF
--- a/packages/vinext/src/utils/project.ts
+++ b/packages/vinext/src/utils/project.ts
@@ -82,6 +82,7 @@ export function renameCJSConfigs(root: string): Array<[string, string]> {
 export function detectPackageManager(root: string): string {
   if (fs.existsSync(path.join(root, "pnpm-lock.yaml"))) return "pnpm add -D";
   if (fs.existsSync(path.join(root, "yarn.lock"))) return "yarn add -D";
+  if (fs.existsSync(path.join(root, "bun.lock"))) return "bun add -D";
   if (fs.existsSync(path.join(root, "bun.lockb"))) return "bun add -D";
   return "npm install -D";
 }
@@ -93,6 +94,7 @@ export function detectPackageManager(root: string): string {
 export function detectPackageManagerName(root: string): string {
   if (fs.existsSync(path.join(root, "pnpm-lock.yaml"))) return "pnpm";
   if (fs.existsSync(path.join(root, "yarn.lock"))) return "yarn";
+  if (fs.existsSync(path.join(root, "bun.lock"))) return "bun";
   if (fs.existsSync(path.join(root, "bun.lockb"))) return "bun";
   return "npm";
 }


### PR DESCRIPTION
## Summary

- Adds detection for `bun.lock` (Bun 1.2+ text-based lockfile) in `detectPackageManager` and `detectPackageManagerName`
- The new text format is checked before the legacy binary `bun.lockb`, since newer Bun projects will have `bun.lock`
- Related to #139 but intentionally smaller / more targeted for a faster review/merge