### PR TITLE
fix: pre-bundle react/jsx-runtime to prevent CJS-in-browser errors

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -2008,11 +2008,15 @@ hydrate();
             client: {
               optimizeDeps: {
                 exclude: ["vinext"],
-                // react and react-dom are framework dependencies used for
-                // hydration. They aren't crawled from app/ source files so
-                // must be pre-included to prevent late discovery and page
-                // reloads during development.
-                include: ["react", "react-dom", "react-dom/client"],
+                // React packages aren't crawled from app/ source files,
+                // so must be pre-included to avoid late discovery (#25).
+                include: [
+                  "react",
+                  "react-dom",
+                  "react-dom/client",
+                  "react/jsx-runtime",
+                  "react/jsx-dev-runtime",
+                ],
               },
               build: {
                 // When targeting Cloudflare Workers, enable manifest generation


### PR DESCRIPTION
## Summary

- Adds `react/jsx-runtime` and `react/jsx-dev-runtime` to `optimizeDeps.include` in the client environment config

## Problem

Vite's dependency scanner can miss `react/jsx-runtime` during initial crawl when entry points are virtual modules (as vinext uses). When this happens, the raw CJS file is served to the browser, producing:

```
SyntaxError: The requested module '/node_modules/react/jsx-runtime.js' does not provide an export named 'jsx'
```

This affects all JSX in the app — user components and vinext shims alike.

## Fix

Explicitly listing these modules in `optimizeDeps.include` ensures Vite always pre-bundles them into proper ESM. This is the same pattern already used for `react`, `react-dom`, and `react-dom/client`.

This is the correct root-cause fix for #25, superseding the approach in #45 and #136 which worked around the issue by converting individual shim files from JSX to `React.createElement`. That approach only fixed vinext's own shims while leaving user code broken.

Fixes #25