### PR TITLE
feat: add nuqs e2e test suite integration

### DIFF
--- a/.github/workflows/nuqs-e2e.yml
+++ b/.github/workflows/nuqs-e2e.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   test:
-    name: nuqs E2E (app router)
+    name: nuqs E2E
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -92,32 +92,6 @@ jobs:
             port: 3001,
           })
           EOF
-
-          # Only run app router shared tests
-          cat > specs/shared.spec.ts << 'EOF'
-          import { runSharedTests } from 'e2e-shared/shared.spec.ts'
-          runSharedTests('/app', { router: 'next-app' })
-          EOF
-
-          # Strip pages router blocks from shared spec wrappers
-          node -e "
-          const fs = require('fs');
-          const path = require('path');
-          const dir = path.join(process.cwd(), 'specs', 'shared');
-          if (!fs.existsSync(dir)) process.exit(0);
-          for (const f of fs.readdirSync(dir).filter(f => f.endsWith('.spec.ts'))) {
-            const fp = path.join(dir, f);
-            const content = fs.readFileSync(fp, 'utf8');
-            const blocks = content.split(/\n\n+/);
-            const filtered = blocks.filter(b =>
-              !b.includes(\"'next-pages'\") && !b.includes(\"'/pages/\")
-            );
-            fs.writeFileSync(fp, filtered.join('\n\n') + '\n');
-          }
-          "
-
-          # Remove pages directory
-          rm -rf src/pages
 
       - name: Install vinext into nuqs e2e
         working-directory: /tmp/nuqs-e2e

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -2487,7 +2487,10 @@ hydrate();
                   apiRoutes,
                 );
                 if (handled) return;
-                // No API route matched — fall through to 404
+                // No Pages Router API route matched. If the App Router is
+                // also active, fall through so the RSC plugin can handle
+                // App Router route handlers (app/api/**/route.ts).
+                if (hasAppDir) return next();
                 res.statusCode = 404;
                 res.end("404 - API route not found");
                 return;
@@ -2540,7 +2543,11 @@ hydrate();
                 }
               }
 
-              // No fallback matched — render as-is (will hit 404 handler)
+              // No fallback matched. If the App Router is also active,
+              // fall through so the RSC plugin's middleware can handle it.
+              if (hasAppDir) return next();
+
+              // Pages-only project — render as-is (will hit 404 handler)
               await handler(req, res, resolvedUrl, mwStatus);
             } catch (e) {
               next(e);

--- a/scripts/nuqs-e2e.sh
+++ b/scripts/nuqs-e2e.sh
@@ -1,19 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Run the nuqs e2e test suite against vinext (app router only).
+# Run the nuqs e2e test suite against vinext.
 #
 # This script clones the nuqs repo, patches its Next.js e2e test app to use
-# vinext instead of Next.js, then runs their Playwright tests. Only app router
-# tests are run (pages router tests are stripped).
+# vinext instead of Next.js, then runs their Playwright tests. Both app router
+# and pages router tests are included.
 #
 # Usage:
-#   ./scripts/nuqs-e2e.sh              # clone main, run all app router tests
-#   NUQS_REF=v2.8.8 ./scripts/nuqs-e2e.sh   # pin to a specific tag/commit
+#   ./scripts/nuqs-e2e.sh                     # clone next branch, run all tests
+#   NUQS_REF=v2.8.8 ./scripts/nuqs-e2e.sh    # pin to a specific tag/commit
 #   NUQS_DIR=/path/to/nuqs ./scripts/nuqs-e2e.sh  # reuse existing clone
 #
 # Environment variables:
-#   NUQS_REF     Git ref to clone (default: main)
+#   NUQS_REF     Git ref to clone (default: next)
 #   NUQS_DIR     Directory for the nuqs clone (default: /tmp/nuqs-e2e)
 #   PORT         Dev server port (default: 3001)
 #   SKIP_BUILD   Set to 1 to skip building vinext (useful if already built)
@@ -108,44 +108,6 @@ export default configurePlaywright({
 })
 PWCONF
 
-# 5c. Patch shared.spec.ts to only run app router tests
-info "Patching shared.spec.ts (app router only)"
-cat > specs/shared.spec.ts << 'SPECFILE'
-import { runSharedTests } from 'e2e-shared/shared.spec.ts'
-
-// Only run app router tests. Pages router is not yet supported by vinext
-// for the nuqs e2e test suite.
-runSharedTests('/app', { router: 'next-app' })
-SPECFILE
-
-# 5d. Remove pages router test invocations from shared spec wrappers
-info "Stripping pages router tests from specs/shared/"
-node -e "
-const fs = require('fs');
-const path = require('path');
-const dir = path.join(process.cwd(), 'specs', 'shared');
-if (!fs.existsSync(dir)) process.exit(0);
-let stripped = 0;
-for (const f of fs.readdirSync(dir).filter(f => f.endsWith('.spec.ts'))) {
-  const fp = path.join(dir, f);
-  const content = fs.readFileSync(fp, 'utf8');
-  // Split into blocks separated by empty lines.
-  // Each test invocation is a distinct block.
-  const blocks = content.split(/\n\n+/);
-  const before = blocks.length;
-  const filtered = blocks.filter(b =>
-    !b.includes(\"'next-pages'\") && !b.includes(\"'/pages/\")
-  );
-  stripped += before - filtered.length;
-  fs.writeFileSync(fp, filtered.join('\n\n') + '\n');
-}
-console.log('  Removed ' + stripped + ' pages-router test blocks');
-"
-
-# 5e. Remove src/pages/ directory (no pages router support)
-info "Removing src/pages/ directory"
-rm -rf src/pages
-
 # ─── Step 6: Install vinext + deps into nuqs e2e-next ──────────────────────────
 
 log "Installing vinext into e2e-next"
@@ -165,7 +127,7 @@ npx playwright install chromium
 
 # ─── Step 8: Run tests ──────────────────────────────────────────────────────────
 
-log "Running nuqs e2e tests (app router only)"
+log "Running nuqs e2e tests"
 echo ""
 
 # Run tests, capturing exit code. We don't fail the script on test failures


### PR DESCRIPTION
## Summary

- Integrates the [nuqs](https://github.com/47ng/nuqs) end-to-end test suite into vinext's CI, running both app router and pages router tests
- Fixes a dual-router dev server bug where the Pages Router middleware intercepted all requests, preventing the App Router (RSC plugin) from handling its routes when both routers are present

## What it does

**nuqs e2e test integration:**
- `scripts/nuqs-e2e.sh`: Clones the nuqs repo, patches its Next.js e2e test app to use vinext (creates `vite.config.ts`, replaces `playwright.config.ts`), installs vinext dependencies, and runs their Playwright tests
- `.github/workflows/nuqs-e2e.yml`: CI workflow that runs the nuqs e2e suite on push to main, PRs, and daily. Uses `continue-on-error: true` since not all tests pass yet
- `package.json`: Adds `test:nuqs-e2e` script

**Dual-router fix (`packages/vinext/src/index.ts`):**
When both `app/` and `pages/` directories exist, the Pages Router dev middleware now falls through to `next()` (letting the RSC plugin handle the request) when:
1. No Pages Router page route matches and no fallback rewrite matches
2. No Pages Router API route matches

Previously, these cases returned 404 directly, blocking the App Router from serving its routes.

## Test results

All existing vinext tests pass (414 shim, 213 feature, 159 app-router, 86 pages-router tests). The dual-router fix was verified by running the nuqs e2e app with both `src/app/` and `src/pages/` directories present, confirming both routers serve their respective pages correctly.