### PR TITLE
feat: add vinext migrate-env command

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Replace `next` with `vinext` in your scripts:
 vinext dev          # Development server with HMR
 vinext build        # Production build
 vinext deploy       # Build and deploy to Cloudflare Workers
+vinext migrate-env  # Migrate env vars from Vercel to Cloudflare
 ```
 
 vinext auto-detects your `app/` or `pages/` directory, loads `next.config.js`, and configures Vite automatically. No `vite.config.ts` required for basic usage.
@@ -58,6 +59,7 @@ Your existing `pages/`, `app/`, `next.config.js`, and `public/` directories work
 | `vinext build` | Production build (multi-environment for App Router: RSC + SSR + client) |
 | `vinext start` | Start local production server for testing |
 | `vinext deploy` | Build and deploy to Cloudflare Workers |
+| `vinext migrate-env` | Migrate environment variables from Vercel to Cloudflare |
 | `vinext init` | Migrate a Next.js project to run under vinext |
 | `vinext check` | Scan your Next.js app for compatibility issues before migrating |
 | `vinext lint` | Delegate to eslint or oxlint |
@@ -65,6 +67,8 @@ Your existing `pages/`, `app/`, `next.config.js`, and `public/` directories work
 Options: `-p / --port <port>`, `-H / --hostname <host>`, `--turbopack` (accepted, no-op).
 
 `vinext deploy` options: `--preview`, `--env <name>`, `--name <name>`, `--skip-build`, `--dry-run`, `--experimental-tpr`.
+
+`vinext migrate-env` options: `--vercel-token <token>`, `--project <id|name>`, `--team <id>`, `--target <env>`, `--dry-run`, `--include-system`, `--env-file`.
 
 `vinext init` options: `--port <port>` (default: 3001), `--skip-check`, `--force`.
 
@@ -99,6 +103,20 @@ npm run dev           # Still runs Next.js as before
 ```
 
 Use `--force` to overwrite an existing `vite.config.ts`, or `--skip-check` to skip the compatibility report.
+
+### Migrating environment variables from Vercel
+
+If your Next.js project uses Vercel environment variables, `vinext migrate-env` pulls them and uploads them to Cloudflare Workers. Secrets are encrypted via `wrangler secret bulk`, and `NEXT_PUBLIC_*` vars are injected into `wrangler.jsonc` as plain variables (needed at build time).
+
+```bash
+vinext deploy --dry-run   # Generate config files first (no build/deploy)
+vinext migrate-env        # Pull from Vercel, upload to Cloudflare
+vinext deploy             # Build and deploy with all env vars in place
+```
+
+Vercel authentication is auto-detected from the Vercel CLI, `VERCEL_TOKEN` env var, or prompted interactively. Cloudflare authentication uses `wrangler login` (launched automatically if needed).
+
+Use `--dry-run` to preview the migration without uploading, or `--target production` to migrate only production variables.
 
 ## Why
 
@@ -448,9 +466,10 @@ Request → RSC entry (Vite rsc environment) → Route match → Build layout/pa
 packages/vinext/
   src/
     index.ts              # Main plugin — resolve aliases, config, virtual modules
-    cli.ts                # vinext CLI (dev/build/start/deploy/init/check/lint)
+    cli.ts                # vinext CLI (dev/build/start/deploy/init/check/lint/migrate-env)
     check.ts              # Compatibility scanner
     deploy.ts             # Cloudflare Workers deployment
+    migrate-env.ts        # Vercel → Cloudflare env var migration
     init.ts               # vinext init — one-command migration for Next.js apps
     client/
       entry.ts            # Client-side hydration entry

--- a/packages/vinext/src/cli.ts
+++ b/packages/vinext/src/cli.ts
@@ -23,6 +23,7 @@ import { deploy as runDeploy, parseDeployArgs } from "./deploy.js";
 import { runCheck, formatReport } from "./check.js";
 import { init as runInit } from "./init.js";
 import { loadDotenv } from "./config/dotenv.js";
+import { migrateEnv, parseMigrateEnvArgs } from "./migrate-env.js";
 
 // ─── Resolve Vite from the project root ────────────────────────────────────────
 //
@@ -390,6 +391,22 @@ async function initCommand() {
   });
 }
 
+async function migrateEnvCommand() {
+  const parsed = parseMigrateEnvArgs(rawArgs);
+  if (parsed.help) return printHelp("migrate-env");
+
+  await migrateEnv({
+    root: process.cwd(),
+    vercelToken: parsed.vercelToken ?? "",
+    project: parsed.project ?? "",
+    teamId: parsed.teamId,
+    target: parsed.target,
+    dryRun: parsed.dryRun,
+    includeSystem: parsed.includeSystem,
+    envFile: parsed.envFile,
+  });
+}
+
 // ─── Help ─────────────────────────────────────────────────────────────────────
 
 function printHelp(cmd?: string) {
@@ -527,6 +544,47 @@ function printHelp(cmd?: string) {
     return;
   }
 
+   if (cmd === "migrate-env") {
+    console.log(`
+  vinext migrate-env - Migrate env vars from Vercel to Cloudflare
+
+  Usage: vinext migrate-env [options]
+
+  Prerequisite:
+    Run \`vinext deploy --dry-run\` first to generate wrangler.jsonc.
+    This command reads the Worker name from that config.
+
+  Pulls environment variables from a Vercel project and securely uploads
+  them to Cloudflare Workers. Secrets are uploaded via \`wrangler secret bulk\`,
+  plain vars are injected into wrangler.jsonc [vars].
+
+  Authentication:
+    Vercel: auto-detected from Vercel CLI login, VERCEL_TOKEN env var,
+    --vercel-token flag, or prompted interactively.
+    Cloudflare: \`wrangler login\` or CLOUDFLARE_API_TOKEN env var.
+
+  Options:
+    --vercel-token <token>   Vercel access token (or set VERCEL_TOKEN)
+    --project <id|name>      Vercel project ID or name (auto-detected from
+                             .vercel/project.json or package.json)
+    --team <id>              Vercel team ID (or set VERCEL_TEAM_ID)
+    --target <env>           Filter by target: production, preview, development
+    --dry-run                Show what would be migrated without making changes
+    --include-system         Include Vercel system vars (VERCEL_*, etc.)
+    --env-file               Also write a .env.cloudflare backup file
+    -h, --help               Show this help
+
+  Examples:
+    vinext deploy --dry-run                     Generate config files first
+    vinext migrate-env                           Auto-detect project, migrate all vars
+    vinext migrate-env --target production       Only production env vars
+    vinext migrate-env --dry-run                 Preview migration without uploading
+    vinext migrate-env --project my-app --team team_xxx  Specify project and team
+    vinext migrate-env --env-file                Also create .env.cloudflare backup
+`);
+    return;
+  }
+
   if (cmd === "lint") {
     console.log(`
   vinext lint - Run linter
@@ -551,8 +609,9 @@ function printHelp(cmd?: string) {
     dev      Start development server
     build    Build for production
     start    Start production server
-    deploy   Deploy to Cloudflare Workers
-    init     Migrate a Next.js project to vinext
+    deploy      Deploy to Cloudflare Workers
+    init        Migrate a Next.js project to vinext
+    migrate-env  Migrate env vars from Vercel to Cloudflare
     check    Scan Next.js app for compatibility
     lint     Run linter
 
@@ -567,6 +626,7 @@ function printHelp(cmd?: string) {
     vinext start                Start production server
     vinext deploy               Deploy to Cloudflare Workers
     vinext init                 Migrate a Next.js project
+    vinext migrate-env           Migrate Vercel env vars to Cloudflare
     vinext check                Check compatibility
     vinext lint                 Run linter
 
@@ -633,6 +693,13 @@ switch (command) {
 
   case "lint":
     lint().catch((e) => {
+      console.error(e);
+      process.exit(1);
+    });
+    break;
+
+  case "migrate-env":
+    migrateEnvCommand().catch((e) => {
       console.error(e);
       process.exit(1);
     });

--- a/packages/vinext/src/migrate-env.ts
+++ b/packages/vinext/src/migrate-env.ts
@@ -1,0 +1,1241 @@
+/**
+ * vinext migrate-env — securely migrate environment variables from Vercel to Cloudflare.
+ *
+ * Pulls env vars from the Vercel REST API and uploads them to Cloudflare Workers:
+ *   - Secret/encrypted/sensitive vars → `wrangler secret bulk` (temp file, securely deleted)
+ *   - Plain vars → injected into wrangler.jsonc `[vars]` section
+ *   - NEXT_PUBLIC_* vars → always plain (needed at build time)
+ *
+ * Security:
+ *   - Tokens are read from env vars or stdin (never logged or written to disk)
+ *   - Temp secret files use 0600 permissions and are zeroed before unlink
+ *   - All child processes use execFileSync (no shell injection)
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { execFileSync } from "node:child_process";
+import { parseArgs as nodeParseArgs } from "node:util";
+import { randomBytes } from "node:crypto";
+import readline from "node:readline";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface VercelEnvVar {
+  /** Environment variable key */
+  key: string;
+  /** Decrypted value (only available if token has read access) */
+  value: string;
+  /** Deployment targets this var applies to */
+  target: Array<"production" | "preview" | "development">;
+  /** Vercel var type */
+  type: "plain" | "secret" | "encrypted" | "sensitive";
+  /** Whether this is a system env var */
+  system?: boolean;
+}
+
+export interface MigrateEnvOptions {
+  /** Project root directory */
+  root: string;
+  /** Vercel access token */
+  vercelToken: string;
+  /** Vercel project ID or name */
+  project: string;
+  /** Vercel team ID (for team-scoped projects) */
+  teamId?: string;
+  /** Filter by Vercel deployment target */
+  target?: "production" | "preview" | "development";
+  /** Show what would be migrated without uploading */
+  dryRun?: boolean;
+  /** Include Vercel system env vars (VERCEL_*, NEXT_PUBLIC_VERCEL_*) */
+  includeSystem?: boolean;
+  /** Also write a .env.cloudflare backup file */
+  envFile?: boolean;
+  /** Custom fetch function for testing */
+  fetcher?: typeof fetch;
+}
+
+export interface ClassifiedVars {
+  secrets: Array<{ key: string; value: string }>;
+  plainVars: Array<{ key: string; value: string }>;
+  skipped: Array<{ key: string; reason: string }>;
+}
+
+// ─── Vercel System Vars ──────────────────────────────────────────────────────
+
+/** Vercel/Turborepo system env vars that have no Cloudflare equivalent */
+const VERCEL_SYSTEM_PREFIXES = [
+  "VERCEL_",
+  "NEXT_PUBLIC_VERCEL_",
+  "TURBO_",
+];
+
+const VERCEL_SYSTEM_EXACT = [
+  "VERCEL",
+  "CI",
+  "NX_DAEMON",
+];
+
+export function isVercelSystemVar(key: string): boolean {
+  if (VERCEL_SYSTEM_EXACT.includes(key)) return true;
+  return VERCEL_SYSTEM_PREFIXES.some((prefix) => key.startsWith(prefix));
+}
+
+// ─── CLI Arg Parsing ─────────────────────────────────────────────────────────
+
+const migrateEnvArgOptions = {
+  help:             { type: "boolean", short: "h", default: false },
+  "vercel-token":   { type: "string" },
+  project:          { type: "string" },
+  team:             { type: "string" },
+  target:           { type: "string" },
+  "dry-run":        { type: "boolean", default: false },
+  "include-system": { type: "boolean", default: false },
+  "env-file":       { type: "boolean", default: false },
+} as const;
+
+export function parseMigrateEnvArgs(args: string[]) {
+  const { values } = nodeParseArgs({ args, options: migrateEnvArgOptions, strict: true });
+
+  const target = values.target?.trim() || undefined;
+  if (target && !["production", "preview", "development"].includes(target)) {
+    throw new Error(
+      `Invalid --target value: "${target}". Must be one of: production, preview, development`,
+    );
+  }
+
+  return {
+    help: values.help,
+    vercelToken: values["vercel-token"]?.trim() || undefined,
+    project: values.project?.trim() || undefined,
+    teamId: values.team?.trim() || undefined,
+    target: target as MigrateEnvOptions["target"],
+    dryRun: values["dry-run"],
+    includeSystem: values["include-system"],
+    envFile: values["env-file"],
+  };
+}
+
+// ─── Vercel Project Detection ────────────────────────────────────────────────
+
+/**
+ * Detect the Vercel project ID from local config or package.json.
+ * Checks (in order):
+ *   1. `.vercel/project.json` (contains projectId from `vercel link`)
+ *   2. `package.json` name field (used as project name fallback)
+ */
+export function detectVercelProject(root: string): string | null {
+  // 1. Check .vercel/project.json
+  const vercelConfigPath = path.join(root, ".vercel", "project.json");
+  if (fs.existsSync(vercelConfigPath)) {
+    try {
+      const config = JSON.parse(fs.readFileSync(vercelConfigPath, "utf-8"));
+      if (config.projectId && typeof config.projectId === "string") {
+        return config.projectId;
+      }
+    } catch {
+      // ignore parse errors
+    }
+  }
+
+  // 2. Fall back to package.json name
+  const pkgPath = path.join(root, "package.json");
+  if (fs.existsSync(pkgPath)) {
+    try {
+      const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf-8"));
+      if (pkg.name && typeof pkg.name === "string") {
+        // Strip npm scope
+        return pkg.name.replace(/^@[^/]+\//, "");
+      }
+    } catch {
+      // ignore parse errors
+    }
+  }
+
+  return null;
+}
+
+
+
+/**
+ * Detect the Vercel org/team ID from `.vercel/project.json`.
+ * This file is created by `vercel link` and contains both projectId and orgId.
+ */
+export function detectVercelOrgId(root: string): string | null {
+  const vercelConfigPath = path.join(root, ".vercel", "project.json");
+  if (!fs.existsSync(vercelConfigPath)) return null;
+
+  try {
+    const config = JSON.parse(fs.readFileSync(vercelConfigPath, "utf-8"));
+    if (config.orgId && typeof config.orgId === "string") {
+      return config.orgId;
+    }
+  } catch {
+    // ignore parse errors
+  }
+
+  return null;
+}
+
+/**
+ * Detect Vercel auth token from the global Vercel CLI config.
+ *
+ * The Vercel CLI stores the token in one of these locations:
+ *   - `~/.config/com.vercel.cli/auth.json` (XDG-style, macOS/Linux)
+ *   - `~/.vercel/auth.json` (legacy location)
+ *
+ * The auth.json structure: { "token": "<access-token>" }
+ *
+ * Note: This is a convenience fallback. Users should prefer VERCEL_TOKEN env var
+ * or --vercel-token flag for security. The global config token may have broader
+ * permissions than needed.
+ */
+export function detectVercelToken(): string | null {
+  const homedir = os.homedir();
+
+  // Possible auth.json locations (in order of preference)
+  const authPaths = [
+    path.join(homedir, ".config", "com.vercel.cli", "auth.json"),
+    path.join(homedir, ".vercel", "auth.json"),
+    // Windows fallback
+    path.join(homedir, "AppData", "Roaming", "com.vercel.cli", "auth.json"),
+  ];
+
+  for (const authPath of authPaths) {
+    if (!fs.existsSync(authPath)) continue;
+
+    try {
+      const config = JSON.parse(fs.readFileSync(authPath, "utf-8"));
+      // Standard format: { "token": "..." }
+      if (config.token && typeof config.token === "string") {
+        return config.token;
+      }
+      // Some versions use a nested structure: { "credentials": [{ "token": "..." }] }
+      if (Array.isArray(config.credentials) && config.credentials.length > 0) {
+        const cred = config.credentials[0];
+        if (cred.token && typeof cred.token === "string") {
+          return cred.token;
+        }
+      }
+    } catch {
+      // ignore parse errors
+    }
+  }
+
+  return null;
+}
+
+// ─── Vercel CLI Detection & Env Pull ─────────────────────────────────────────
+
+/**
+ * Check if the Vercel CLI is installed and available.
+ * Returns the path to the vercel binary, or null if not found.
+ */
+export function detectVercelCli(): string | null {
+  const cmd = process.platform === "win32" ? "where" : "which";
+  try {
+    const result = execFileSync(cmd, ["vercel"], {
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+    return result || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Check if the user is logged in to Vercel CLI.
+ * Returns true if authenticated.
+ */
+export function isVercelCliAuthenticated(): boolean {
+  try {
+    execFileSync("vercel", ["whoami"], {
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Pull environment variables using `vercel env pull`.
+ *
+ * This uses the Vercel CLI's built-in auth (from `vercel login`),
+ * so no manual token is needed.
+ *
+ * @param root - Project root directory
+ * @param environment - Target environment: production, preview, development
+ * @returns Parsed key-value pairs from the .env file, or null if pull failed
+ */
+export function pullEnvWithVercelCli(
+  root: string,
+  environment: string = "production",
+): Array<{ key: string; value: string }> | null {
+  // Use a temp file to avoid overwriting any existing .env
+  const tmpEnvFile = path.join(root, `.env.vercel-pull-${Date.now()}`);
+
+  try {
+    execFileSync(
+      "vercel",
+      ["env", "pull", tmpEnvFile, "--environment", environment, "--yes"],
+      {
+        cwd: root,
+        encoding: "utf-8",
+        stdio: ["pipe", "pipe", "pipe"],
+      },
+    );
+
+    if (!fs.existsSync(tmpEnvFile)) {
+      return null;
+    }
+
+    const content = fs.readFileSync(tmpEnvFile, "utf-8");
+    return parseEnvFile(content);
+  } catch {
+    return null;
+  } finally {
+    // Clean up temp file
+    try {
+      if (fs.existsSync(tmpEnvFile)) fs.unlinkSync(tmpEnvFile);
+    } catch {
+      // ignore
+    }
+  }
+}
+
+/**
+ * Parse a .env file content into key-value pairs.
+ * Supports:
+ *   - KEY=VALUE
+ *   - KEY="quoted value"
+ *   - KEY='single quoted value'
+ *   - # comments
+ *   - Empty lines
+ *   - Escaped characters in double-quoted values
+ */
+export function parseEnvFile(content: string): Array<{ key: string; value: string }> {
+  const vars: Array<{ key: string; value: string }> = [];
+  const lines = content.split("\n");
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    // Skip empty lines and comments
+    if (!trimmed || trimmed.startsWith("#")) continue;
+
+    // Match KEY=VALUE pattern
+    const eqIndex = trimmed.indexOf("=");
+    if (eqIndex === -1) continue;
+
+    const key = trimmed.slice(0, eqIndex).trim();
+    let value = trimmed.slice(eqIndex + 1);
+
+    // Skip invalid keys
+    if (!key || !/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue;
+
+    // Handle quoted values
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      const quote = value[0];
+      value = value.slice(1, -1);
+      // Unescape double-quoted values
+      if (quote === '"') {
+        value = value
+          .replace(/\\n/g, "\n")
+          .replace(/\\r/g, "\r")
+          .replace(/\\t/g, "\t")
+          .replace(/\\\\/g, "\\")
+          .replace(/\\"/g, '"');
+      }
+    }
+
+    vars.push({ key, value });
+  }
+
+  return vars;
+}
+
+// ─── Vercel API ──────────────────────────────────────────────────────────────
+
+/**
+ * Fetch all environment variables from a Vercel project.
+ * Handles pagination (Vercel returns max 100 per page).
+ */
+export async function fetchVercelEnvVars(
+  token: string,
+  projectId: string,
+  teamId?: string,
+  fetcher: typeof fetch = globalThis.fetch,
+): Promise<VercelEnvVar[]> {
+  const allVars: VercelEnvVar[] = [];
+  let hasMore = true;
+  let offset = 0;
+  const limit = 100;
+
+  while (hasMore) {
+    const url = new URL(`https://api.vercel.com/v9/projects/${encodeURIComponent(projectId)}/env`);
+    url.searchParams.set("limit", String(limit));
+    url.searchParams.set("offset", String(offset));
+    if (teamId) {
+      url.searchParams.set("teamId", teamId);
+    }
+
+    const response = await fetcher(url.toString(), {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+    });
+
+    if (!response.ok) {
+      const status = response.status;
+      if (status === 401) {
+        throw new Error(
+          "Vercel API authentication failed (401). Check your VERCEL_TOKEN or --vercel-token value.",
+        );
+      }
+      if (status === 403) {
+        throw new Error(
+          "Vercel API access denied (403). Your token may not have permission for this project/team.",
+        );
+      }
+      if (status === 404) {
+        throw new Error(
+          `Vercel project "${projectId}" not found (404). Check the --project value or .vercel/project.json.`,
+        );
+      }
+      const body = await response.text().catch(() => "");
+      throw new Error(`Vercel API error (${status}): ${body || response.statusText}`);
+    }
+
+    const data = (await response.json()) as { envs: VercelEnvVar[] };
+
+    if (!data.envs || !Array.isArray(data.envs)) {
+      throw new Error("Unexpected Vercel API response: missing envs array.");
+    }
+
+    for (const env of data.envs) {
+      allVars.push({
+        key: env.key,
+        value: env.value ?? "",
+        target: Array.isArray(env.target) ? env.target : [],
+        type: env.type || "plain",
+        system: env.system,
+      });
+    }
+
+    if (data.envs.length < limit) {
+      hasMore = false;
+    } else {
+      offset += limit;
+    }
+  }
+
+  return allVars;
+}
+
+// ─── Var Classification ──────────────────────────────────────────────────────
+
+/**
+ * Classify Vercel env vars into secrets, plain vars, and skipped vars.
+ *
+ * Rules:
+ *   - NEXT_PUBLIC_* → always plain (needed at build time, must be in [vars])
+ *   - type: "secret" | "encrypted" | "sensitive" → secret
+ *   - type: "plain" → plain var
+ *   - Vercel system vars (VERCEL_*) → skipped (unless --include-system)
+ *   - Filter by --target if specified
+ */
+export function classifyVars(
+  vars: VercelEnvVar[],
+  options: {
+    target?: "production" | "preview" | "development";
+    includeSystem?: boolean;
+  } = {},
+): ClassifiedVars {
+  const secrets: ClassifiedVars["secrets"] = [];
+  const plainVars: ClassifiedVars["plainVars"] = [];
+  const skipped: ClassifiedVars["skipped"] = [];
+
+  // Track seen keys to handle duplicates (last wins with warning)
+  const seenKeys = new Map<string, string>();
+
+  for (const env of vars) {
+    // Filter by target if specified
+    if (options.target && env.target.length > 0 && !env.target.includes(options.target)) {
+      skipped.push({ key: env.key, reason: `target mismatch (wanted: ${options.target})` });
+      continue;
+    }
+
+    // NEXT_PUBLIC_* vars are always plain (build-time inlined).
+    // They should NEVER be skipped unless they are specifically NEXT_PUBLIC_VERCEL_
+    if (env.key.startsWith("NEXT_PUBLIC_")) {
+      // If it's NEXT_PUBLIC_VERCEL_ and we aren't including system vars, it's skipped
+      if (!options.includeSystem && env.key.startsWith("NEXT_PUBLIC_VERCEL_")) {
+        skipped.push({ key: env.key, reason: "Vercel system var (use --include-system to include)" });
+        continue;
+      }
+      
+      // Track duplicates
+      if (seenKeys.has(env.key)) {
+        const prevDest = seenKeys.get(env.key)!;
+        const secretIdx = secrets.findIndex((s) => s.key === env.key);
+        if (secretIdx >= 0) secrets.splice(secretIdx, 1);
+        const plainIdx = plainVars.findIndex((p) => p.key === env.key);
+        if (plainIdx >= 0) plainVars.splice(plainIdx, 1);
+        skipped.push({
+          key: `${env.key} (duplicate)`,
+          reason: `replaced previous (was: ${prevDest})`,
+        });
+      }
+
+      plainVars.push({ key: env.key, value: env.value });
+      seenKeys.set(env.key, "plain");
+      continue;
+    }
+
+    // Skip Vercel system vars unless opted in
+    if (!options.includeSystem && (env.system || isVercelSystemVar(env.key))) {
+        skipped.push({ key: env.key, reason: "Vercel system var (use --include-system to include)" });
+        continue;
+    }
+
+    // Track duplicates
+    if (seenKeys.has(env.key)) {
+      const prevDest = seenKeys.get(env.key)!;
+      // Remove previous entry
+      const secretIdx = secrets.findIndex((s) => s.key === env.key);
+      if (secretIdx >= 0) secrets.splice(secretIdx, 1);
+      const plainIdx = plainVars.findIndex((p) => p.key === env.key);
+      if (plainIdx >= 0) plainVars.splice(plainIdx, 1);
+      skipped.push({
+        key: `${env.key} (duplicate)`,
+        reason: `replaced previous (was: ${prevDest})`,
+      });
+    }
+
+    // Classify by type
+    if (env.type === "secret" || env.type === "encrypted" || env.type === "sensitive") {
+      secrets.push({ key: env.key, value: env.value });
+      seenKeys.set(env.key, "secret");
+    } else {
+      plainVars.push({ key: env.key, value: env.value });
+      seenKeys.set(env.key, "plain");
+    }
+  }
+
+  return { secrets, plainVars, skipped };
+}
+
+// ─── Cloudflare Upload ───────────────────────────────────────────────────────
+
+/**
+ * Upload secrets to Cloudflare Workers via `wrangler secret bulk`.
+ * Writes a temporary JSON file with strict permissions, then executes wrangler.
+ * The temp file is securely wiped (zeroed) and deleted after use.
+ */
+export function uploadSecrets(
+  root: string,
+  secrets: Array<{ key: string; value: string }>,
+  workerName?: string,
+  dryRun = false,
+): { uploaded: number; output: string } {
+  if (secrets.length === 0) {
+    return { uploaded: 0, output: "No secrets to upload." };
+  }
+
+  // Build the secrets JSON object { KEY: "value", ... }
+  const secretsObj: Record<string, string> = {};
+  for (const s of secrets) {
+    secretsObj[s.key] = s.value;
+  }
+
+  if (dryRun) {
+    const keys = secrets.map((s) => s.key).join(", ");
+    return {
+      uploaded: 0,
+      output: `[dry-run] Would upload ${secrets.length} secret(s): ${keys}`,
+    };
+  }
+
+  // Write to a temp file with strict permissions
+  const tmpName = `.vinext-secrets-${randomBytes(8).toString("hex")}.json`;
+  const tmpPath = path.join(root, tmpName);
+
+  try {
+    const jsonContent = JSON.stringify(secretsObj);
+    fs.writeFileSync(tmpPath, jsonContent, { mode: 0o600, encoding: "utf-8" });
+
+    // Use local wrangler binary (same as deploy.ts)
+    const wranglerBin = path.join(root, "node_modules", ".bin", "wrangler");
+
+    if (!fs.existsSync(wranglerBin)) {
+      throw new Error(
+        `Wrangler is not installed. Run \`npm install -D wrangler\` or \`vinext deploy\` (which installs it automatically).`,
+      );
+    }
+
+    const args = ["secret", "bulk", tmpPath];
+    if (workerName) {
+      args.push("--name", workerName);
+    }
+
+    // Use execFileSync to avoid shell injection — args are passed as an array,
+    // never interpolated into a shell command string.
+    try {
+      const output = execFileSync(wranglerBin, args, {
+        cwd: root,
+        stdio: "pipe",
+        encoding: "utf-8",
+      });
+      return { uploaded: secrets.length, output: output.trim() };
+    } catch (err: any) {
+      const combined = `${err.stdout ?? ""}\n${err.stderr ?? ""}`.toLowerCase();
+      const isAuthError =
+        combined.includes("not authenticated") ||
+        combined.includes("wrangler login") ||
+        combined.includes("cloudflare_api_token");
+
+      if (!isAuthError) {
+        throw new Error(`Wrangler secret upload failed: ${err.message}`);
+      }
+
+      // Auth failure — attempt interactive login via local wrangler, then retry
+      console.log("\n  Cloudflare authentication required. Launching wrangler login...\n");
+      try {
+        execFileSync(wranglerBin, ["login"], { cwd: root, stdio: "inherit" });
+      } catch {
+        throw new Error(
+          `Wrangler login failed. Run \`wrangler login\` manually or set CLOUDFLARE_API_TOKEN.`,
+        );
+      }
+
+      console.log("\n  Retrying secret upload...");
+      const retryOutput = execFileSync(wranglerBin, args, {
+        cwd: root,
+        stdio: "pipe",
+        encoding: "utf-8",
+      });
+      return { uploaded: secrets.length, output: retryOutput.trim() };
+    }
+  } finally {
+    // Secure deletion: zero out then unlink
+    secureDelete(tmpPath);
+  }
+}
+/**
+ * Securely delete a file by overwriting its contents with zeros before unlinking.
+ * This provides defense-in-depth against disk forensics recovering secret values.
+ */
+export function secureDelete(filePath: string): void {
+  try {
+    if (!fs.existsSync(filePath)) return;
+    const stat = fs.statSync(filePath);
+    // Overwrite with zeros
+    const zeros = Buffer.alloc(stat.size, 0);
+    fs.writeFileSync(filePath, zeros);
+    // Then unlink
+    fs.unlinkSync(filePath);
+  } catch {
+    // Best effort — try to unlink even if zeroing fails
+    try {
+      fs.unlinkSync(filePath);
+    } catch {
+      // ignore
+    }
+  }
+}
+
+// ─── Wrangler Config Var Injection ───────────────────────────────────────────
+
+/**
+ * Detect the wrangler config file in the project root.
+ * Returns the path and format, or null if not found.
+ */
+export function detectWranglerConfig(root: string): { path: string; format: "json" | "toml" } | null {
+  const jsonc = path.join(root, "wrangler.jsonc");
+  if (fs.existsSync(jsonc)) return { path: jsonc, format: "json" };
+
+  const json = path.join(root, "wrangler.json");
+  if (fs.existsSync(json)) return { path: json, format: "json" };
+
+  const toml = path.join(root, "wrangler.toml");
+  if (fs.existsSync(toml)) return { path: toml, format: "toml" };
+
+  return null;
+}
+
+/**
+ * Detect the Worker name from the wrangler config file.
+ */
+export function detectWorkerName(root: string): string | null {
+  const config = detectWranglerConfig(root);
+  if (!config || config.format !== "json") return null;
+
+  try {
+    // Strip JSONC comments for parsing
+    const raw = fs.readFileSync(config.path, "utf-8");
+    const cleaned = stripJsonComments(raw);
+    const parsed = JSON.parse(cleaned);
+    return parsed.name || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Strip single-line (//) and multi-line comments from JSONC content.
+ * Simple implementation that handles the common cases.
+ */
+export function stripJsonComments(content: string): string {
+  let result = "";
+  let inString = false;
+  let inSingleComment = false;
+  let inMultiComment = false;
+  let i = 0;
+
+  while (i < content.length) {
+    if (inSingleComment) {
+      if (content[i] === "\n") {
+        inSingleComment = false;
+        result += "\n";
+      }
+      i++;
+      continue;
+    }
+
+    if (inMultiComment) {
+      if (content[i] === "*" && content[i + 1] === "/") {
+        inMultiComment = false;
+        i += 2;
+      } else {
+        if (content[i] === "\n") result += "\n";
+        i++;
+      }
+      continue;
+    }
+
+    if (inString) {
+      if (content[i] === "\\" && i + 1 < content.length) {
+        result += content[i] + content[i + 1];
+        i += 2;
+        continue;
+      }
+      if (content[i] === '"') {
+        inString = false;
+      }
+      result += content[i];
+      i++;
+      continue;
+    }
+
+    // Not in string or comment
+    if (content[i] === '"') {
+      inString = true;
+      result += content[i];
+      i++;
+      continue;
+    }
+
+    if (content[i] === "/" && content[i + 1] === "/") {
+      inSingleComment = true;
+      i += 2;
+      continue;
+    }
+
+    if (content[i] === "/" && content[i + 1] === "*") {
+      inMultiComment = true;
+      i += 2;
+      continue;
+    }
+
+    result += content[i];
+    i++;
+  }
+
+  return result;
+}
+
+/**
+ * Inject plain vars into the wrangler config [vars] section.
+ *
+ * For JSON/JSONC configs: reads, merges, writes back.
+ * For TOML configs: warns and suggests manual merge (TOML writing is complex).
+ *
+ * Returns an object with the number of vars added, conflicts found, and any warnings.
+ */
+export function injectPlainVars(
+  root: string,
+  vars: Array<{ key: string; value: string }>,
+  dryRun = false,
+): { added: number; conflicts: string[]; warnings: string[] } {
+  if (vars.length === 0) {
+    return { added: 0, conflicts: [], warnings: [] };
+  }
+
+  const config = detectWranglerConfig(root);
+  const conflicts: string[] = [];
+  const warnings: string[] = [];
+
+  // No wrangler config — error, require deploy --dry-run first
+  if (!config) {
+    throw new Error(
+      `No wrangler config found. Run \`vinext deploy --dry-run\` first to generate wrangler.jsonc.`,
+    );
+  }
+
+  // TOML config — warn and skip
+  if (config.format === "toml") {
+    warnings.push(
+      "wrangler.toml detected. Cannot auto-inject vars into TOML format. " +
+      "Please add vars manually under [vars] section, or convert to wrangler.jsonc.",
+    );
+    return { added: 0, conflicts: [], warnings };
+  }
+
+  // JSON/JSONC config — read, merge, write
+  try {
+    const raw = fs.readFileSync(config.path, "utf-8");
+    const cleaned = stripJsonComments(raw);
+    const parsed = JSON.parse(cleaned);
+
+    if (!parsed.vars) {
+      parsed.vars = {};
+    }
+
+    let added = 0;
+    for (const v of vars) {
+      if (parsed.vars[v.key] !== undefined && parsed.vars[v.key] !== v.value) {
+        conflicts.push(v.key);
+      }
+      if (!dryRun) {
+        parsed.vars[v.key] = v.value;
+      }
+      added++;
+    }
+
+    if (!dryRun) {
+      fs.writeFileSync(config.path, JSON.stringify(parsed, null, 2) + "\n", "utf-8");
+    }
+
+    if (conflicts.length > 0) {
+      warnings.push(
+        `${conflicts.length} var(s) already existed with different values and were overwritten: ${conflicts.join(", ")}`,
+      );
+    }
+
+    return { added, conflicts, warnings };
+  } catch (err) {
+    throw new Error(`Failed to update ${path.basename(config.path)}: ${(err as Error).message}`);
+  }
+}
+
+// ─── .env Backup ─────────────────────────────────────────────────────────────
+
+/**
+ * Write a .env.cloudflare backup file with all migrated vars.
+ * Also adds .env.cloudflare to .gitignore if not already present.
+ */
+export function writeEnvBackup(
+  root: string,
+  vars: Array<{ key: string; value: string }>,
+  dryRun = false,
+): void {
+  if (vars.length === 0) return;
+
+  const envPath = path.join(root, ".env.cloudflare");
+
+  const lines: string[] = [
+    "# Auto-generated by vinext migrateenv",
+    `# Generated at: ${new Date().toISOString()}`,
+    "# This file contains all env vars migrated from Vercel.",
+    "# DO NOT commit this file to version control.",
+    "",
+  ];
+
+  for (const v of vars) {
+    // Quote values that contain special characters or are multiline
+    if (v.value.includes("\n") || v.value.includes("=") || v.value.includes('"') || v.value.includes(" ") || v.value.includes("$")) {
+      // Use double quotes, escape inner quotes and backslashes
+      const escaped = v.value
+        .replace(/\\/g, "\\\\")
+        .replace(/"/g, '\\"')
+        .replace(/\n/g, "\\n");
+      lines.push(`${v.key}="${escaped}"`);
+    } else if (v.value === "") {
+      lines.push(`${v.key}=`);
+    } else {
+      lines.push(`${v.key}=${v.value}`);
+    }
+  }
+
+  lines.push(""); // trailing newline
+
+  if (!dryRun) {
+    fs.writeFileSync(envPath, lines.join("\n"), "utf-8");
+
+    // Add to .gitignore if not already present
+    const gitignorePath = path.join(root, ".gitignore");
+    if (fs.existsSync(gitignorePath)) {
+      const gitignore = fs.readFileSync(gitignorePath, "utf-8");
+      if (!gitignore.includes(".env.cloudflare")) {
+        fs.appendFileSync(gitignorePath, "\n# vinext migrateenv backup\n.env.cloudflare\n");
+      }
+    }
+  }
+}
+
+// ─── Interactive Token Prompt ────────────────────────────────────────────────
+
+/**
+ * Prompt the user for a token via stdin with masking.
+ * Returns the entered token string.
+ */
+export async function promptForToken(message: string): Promise<string> {
+  return new Promise((resolve) => {
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    });
+
+    // Disable echo for password-like input
+    if (process.stdin.isTTY) {
+      process.stdout.write(message);
+      process.stdin.setRawMode(true);
+      let token = "";
+
+      const onData = (data: Buffer) => {
+        const char = data.toString("utf-8");
+        if (char === "\n" || char === "\r") {
+          process.stdin.setRawMode(false);
+          process.stdin.removeListener("data", onData);
+          process.stdout.write("\n");
+          rl.close();
+          resolve(token);
+          return;
+        }
+        if (char === "\u0003") {
+          // Ctrl+C
+          process.stdin.setRawMode(false);
+          rl.close();
+          process.exit(1);
+        }
+        if (char === "\u007F" || char === "\b") {
+          // Backspace
+          if (token.length > 0) {
+            token = token.slice(0, -1);
+            process.stdout.write("\b \b");
+          }
+          return;
+        }
+        token += char;
+        process.stdout.write("*");
+      };
+
+      process.stdin.on("data", onData);
+    } else {
+      // Non-TTY: just read a line
+      rl.question(message, (answer: string) => {
+        rl.close();
+        resolve(answer.trim());
+      });
+    }
+  });
+}
+
+// ─── Main Orchestrator ───────────────────────────────────────────────────────
+
+export async function migrateEnv(options: MigrateEnvOptions): Promise<void> {
+  const root = path.resolve(options.root);
+
+  console.log("\n  vinext migrate-env\n");
+
+  // Step 0: Require wrangler config (created by vinext deploy --dry-run)
+  const workerName = detectWorkerName(root);
+  if (!workerName) {
+    console.error("  Error: No wrangler config with a Worker name found.");
+    console.error("  Run `vinext deploy --dry-run` first to generate wrangler.jsonc.\n");
+    process.exit(1);
+  }
+
+  // Step 0b: Verify this looks like a Vercel project before going further
+  if (!options.project) {
+    const hasVercelDir = fs.existsSync(path.join(root, ".vercel", "project.json"));
+    const hasPackageName = (() => {
+      try {
+        const pkg = JSON.parse(fs.readFileSync(path.join(root, "package.json"), "utf-8"));
+        return !!pkg.name;
+      } catch { return false; }
+    })();
+
+    if (!hasVercelDir && !hasPackageName) {
+      console.error("  Error: This does not appear to be a Vercel project.");
+      console.error("  No .vercel/project.json or package.json name found.");
+      console.error("  If this is a Vercel project, use --project <id-or-name> to specify it.\n");
+      process.exit(1);
+    }
+  }
+
+  // Step 1: Check for Vercel CLI first (preferred approach)
+  const hasVercelCli = detectVercelCli() !== null;
+  let envVars: VercelEnvVar[] = [];
+
+  if (hasVercelCli && isVercelCliAuthenticated()) {
+    console.log("  ✓ Vercel CLI detected and authenticated\n");
+    console.log(`  Worker name:    ${workerName}`);
+    if (options.target) console.log(`  Target filter:  ${options.target}`);
+    if (options.dryRun) console.log("  Mode:           DRY RUN");
+    console.log();
+
+    // Pull env vars using Vercel CLI
+    const targetEnv = options.target || "production";
+    console.log(`  Pulling ${targetEnv} environment variables via Vercel CLI...`);
+    const pulled = pullEnvWithVercelCli(root, targetEnv);
+
+    if (pulled && pulled.length > 0) {
+      console.log(`  Found ${pulled.length} environment variable(s)\n`);
+
+      // When using CLI, all vars come as plain key-value pairs.
+      // We treat everything as secrets for Cloudflare (safer default)
+      // unless the key starts with NEXT_PUBLIC_ (needs to be build-time accessible)
+      const secrets: Array<{ key: string; value: string }> = [];
+      const plainVars: Array<{ key: string; value: string }> = [];
+      const skipped: Array<{ key: string; reason: string }> = [];
+
+      for (const v of pulled) {
+        if (v.key.startsWith("NEXT_PUBLIC_")) {
+          if (!options.includeSystem && v.key.startsWith("NEXT_PUBLIC_VERCEL_")) {
+            skipped.push({ key: v.key, reason: "Vercel system var" });
+            continue;
+          }
+          plainVars.push(v);
+        } else if (!options.includeSystem && isVercelSystemVar(v.key)) {
+          skipped.push({ key: v.key, reason: "Vercel system var" });
+        } else {
+          secrets.push(v);
+        }
+      }
+
+      // Print summary
+      console.log("  ┌─────────────────────────────────────────────────┐");
+      console.log("  │  Migration Summary                              │");
+      console.log("  ├─────────────────────────────────────────────────┤");
+      console.log(`  │  Secrets (wrangler secret bulk):  ${String(secrets.length).padStart(3)}          │`);
+      console.log(`  │  Plain vars (wrangler.jsonc):     ${String(plainVars.length).padStart(3)}          │`);
+      console.log(`  │  Skipped:                         ${String(skipped.length).padStart(3)}          │`);
+      console.log("  └─────────────────────────────────────────────────┘");
+      console.log();
+
+      if (skipped.length > 0) {
+        console.log("  Skipped variables:");
+        for (const s of skipped) {
+          console.log(`    • ${s.key} — ${s.reason}`);
+        }
+        console.log();
+      }
+
+      // Upload secrets
+      if (secrets.length > 0) {
+        console.log("  Uploading secrets to Cloudflare Workers...");
+        const result = uploadSecrets(root, secrets, workerName, options.dryRun);
+        if (options.dryRun) {
+          console.log(`  ${result.output}`);
+        } else {
+          console.log(`  ✓ Uploaded ${result.uploaded} secret(s)`);
+        }
+        console.log();
+      }
+
+      // Inject plain vars
+      if (plainVars.length > 0) {
+        console.log("  Injecting plain vars into wrangler config...");
+        const result = injectPlainVars(root, plainVars, options.dryRun);
+        const plainKeys = plainVars.map((v) => v.key).join(", ");
+        if (options.dryRun) {
+          console.log(`  [dry-run] Would inject ${result.added} var(s) into wrangler config: ${plainKeys}`);
+        } else {
+          console.log(`  ✓ Injected ${result.added} var(s) into wrangler config: ${plainKeys}`);
+        }
+        for (const w of result.warnings) {
+          console.log(`  ⚠ ${w}`);
+        }
+        console.log();
+      }
+
+      // Write backup
+      if (options.envFile) {
+        const allVars = [...secrets, ...plainVars];
+        if (options.dryRun) {
+          console.log(`  [dry-run] Would write .env.cloudflare with ${allVars.length} var(s)\n`);
+        } else {
+          writeEnvBackup(root, allVars);
+          console.log(`  ✓ Wrote .env.cloudflare backup (${allVars.length} var(s))\n`);
+        }
+      }
+
+      // Done
+      console.log("  ─────────────────────────────────────────");
+      if (options.dryRun) {
+        console.log("  Dry run complete. No changes were made.");
+      } else {
+        console.log("  Migration complete!");
+        console.log("  Run `vinext deploy` to deploy with the new environment variables.");
+      }
+      console.log("  ─────────────────────────────────────────\n");
+      return;
+    } else {
+      console.log("  ⚠ Vercel CLI pull returned no variables, falling back to REST API...\n");
+    }
+  } else if (hasVercelCli && !isVercelCliAuthenticated()) {
+    console.log("  ⚠ Vercel CLI found but not authenticated. Run `vercel login` or provide a token.\n");
+  }
+
+  // ─── Fallback: REST API approach ───────────────────────────────────────────
+
+  // Step 1b: Resolve Vercel token for API
+  let vercelToken = options.vercelToken;
+  if (!vercelToken) {
+    vercelToken = process.env.VERCEL_TOKEN ?? "";
+  }
+  if (!vercelToken) {
+    const cliToken = detectVercelToken();
+    if (cliToken) {
+      vercelToken = cliToken;
+      console.log("  Using token from Vercel CLI config\n");
+    }
+  }
+  if (!vercelToken) {
+    console.log("  ┌───────────────────────────────────────────────────────────┐");
+    console.log("  │  Create a Vercel Access Token:                           │");
+    console.log("  │  → https://vercel.com/account/tokens                     │");
+    console.log("  └───────────────────────────────────────────────────────────┘\n");
+    vercelToken = await promptForToken("  Paste your Vercel Access Token: ");
+  }
+  if (!vercelToken) {
+    console.error("  Error: No Vercel token provided.");
+    console.error("  Options:");
+    console.error("    1. Install Vercel CLI and run: vercel login");
+    console.error("    2. Set VERCEL_TOKEN env var");
+    console.error("    3. Use --vercel-token <token>");
+    console.error("    4. Create a token at: https://vercel.com/account/tokens\n");
+    process.exit(1);
+  }
+
+  // Step 2: Resolve project ID
+  let projectId: string | undefined = options.project || undefined;
+  if (!projectId) {
+    projectId = detectVercelProject(root) ?? undefined;
+  }
+  if (!projectId) {
+    console.error("  Error: Could not determine Vercel project.");
+    console.error("  Use --project <id-or-name>, run `vercel link` first, or add a project name to package.json.\n");
+    process.exit(1);
+  }
+
+  // Step 3: Resolve team ID (orgId from .vercel/project.json serves as teamId)
+  let teamId = options.teamId || process.env.VERCEL_TEAM_ID || undefined;
+  if (!teamId) {
+    teamId = detectVercelOrgId(root) ?? undefined;
+  }
+
+  // Worker name already resolved above
+
+  console.log(`  Vercel project: ${projectId}`);
+  if (teamId) console.log(`  Vercel team:    ${teamId}`);
+  console.log(`  Worker name:    ${workerName}`);
+  if (options.target) console.log(`  Target filter:  ${options.target}`);
+  if (options.dryRun) console.log("  Mode:           DRY RUN");
+  console.log();
+
+  // Step 5: Fetch env vars from Vercel
+  console.log("  Fetching environment variables from Vercel...");
+  const fetcher = options.fetcher ?? globalThis.fetch;
+  envVars = await fetchVercelEnvVars(vercelToken, projectId, teamId, fetcher);
+
+  if (envVars.length === 0) {
+    console.log("  No environment variables found in Vercel project.\n");
+    return;
+  }
+
+  console.log(`  Found ${envVars.length} environment variable(s)\n`);
+
+  // Step 6: Classify vars
+  const classified = classifyVars(envVars, {
+    target: options.target,
+    includeSystem: options.includeSystem,
+  });
+
+  // Step 7: Print summary table
+  console.log("  ┌─────────────────────────────────────────────────┐");
+  console.log("  │  Migration Summary                              │");
+  console.log("  ├─────────────────────────────────────────────────┤");
+  console.log(`  │  Secrets (wrangler secret bulk):  ${String(classified.secrets.length).padStart(3)}          │`);
+  console.log(`  │  Plain vars (wrangler.jsonc):     ${String(classified.plainVars.length).padStart(3)}          │`);
+  console.log(`  │  Skipped:                         ${String(classified.skipped.length).padStart(3)}          │`);
+  console.log("  └─────────────────────────────────────────────────┘");
+  console.log();
+
+  // Print skipped vars
+  if (classified.skipped.length > 0) {
+    console.log("  Skipped variables:");
+    for (const s of classified.skipped) {
+      console.log(`    • ${s.key} — ${s.reason}`);
+    }
+    console.log();
+  }
+
+  // Step 8: Upload secrets
+  if (classified.secrets.length > 0) {
+    console.log("  Uploading secrets to Cloudflare Workers...");
+    const result = uploadSecrets(root, classified.secrets, workerName, options.dryRun);
+    if (options.dryRun) {
+      console.log(`  ${result.output}`);
+    } else {
+      console.log(`  ✓ Uploaded ${result.uploaded} secret(s)`);
+    }
+    console.log();
+  }
+
+  // Step 9: Inject plain vars
+  if (classified.plainVars.length > 0) {
+    console.log("  Injecting plain vars into wrangler config...");
+    const result = injectPlainVars(root, classified.plainVars, options.dryRun);
+    const plainKeys = classified.plainVars.map((v) => v.key).join(", ");
+    if (options.dryRun) {
+      console.log(`  [dry-run] Would inject ${result.added} var(s) into wrangler config: ${plainKeys}`);
+    } else {
+      console.log(`  ✓ Injected ${result.added} var(s) into wrangler config: ${plainKeys}`);
+    }
+    for (const w of result.warnings) {
+      console.log(`  ⚠ ${w}`);
+    }
+    console.log();
+  }
+
+  // Step 10: Write .env backup file
+  if (options.envFile) {
+    const allVars = [...classified.secrets, ...classified.plainVars];
+    if (options.dryRun) {
+      console.log(`  [dry-run] Would write .env.cloudflare with ${allVars.length} var(s)\n`);
+    } else {
+      writeEnvBackup(root, allVars);
+      console.log(`  ✓ Wrote .env.cloudflare backup (${allVars.length} var(s))\n`);
+    }
+  }
+
+  // Done
+  console.log("  ─────────────────────────────────────────");
+  if (options.dryRun) {
+    console.log("  Dry run complete. No changes were made.");
+  } else {
+    console.log("  Migration complete!");
+    console.log("  Run `vinext deploy` to deploy with the new environment variables.");
+  }
+  console.log("  ─────────────────────────────────────────\n");
+}

--- a/tests/migrate-env.test.ts
+++ b/tests/migrate-env.test.ts
@@ -1,0 +1,1011 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import {
+  parseMigrateEnvArgs,
+  classifyVars,
+  isVercelSystemVar,
+  detectVercelProject,
+  detectVercelOrgId,
+  detectVercelToken,
+  detectVercelCli,
+  isVercelCliAuthenticated,
+  parseEnvFile,
+  fetchVercelEnvVars,
+  injectPlainVars,
+  writeEnvBackup,
+  detectWranglerConfig,
+  detectWorkerName,
+  stripJsonComments,
+  secureDelete,
+  uploadSecrets,
+  type VercelEnvVar,
+} from "../packages/vinext/src/migrate-env.js";
+
+// ─── Test Helpers ────────────────────────────────────────────────────────────
+
+let tmpDir: string;
+
+function createTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "vinext-migrateenv-test-"));
+}
+
+function writeFile(dir: string, relativePath: string, content: string): void {
+  const fullPath = path.join(dir, relativePath);
+  fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+  fs.writeFileSync(fullPath, content, "utf-8");
+}
+
+function readFile(dir: string, relativePath: string): string {
+  return fs.readFileSync(path.join(dir, relativePath), "utf-8");
+}
+
+function mkdir(dir: string, relativePath: string): void {
+  fs.mkdirSync(path.join(dir, relativePath), { recursive: true });
+}
+
+beforeEach(() => {
+  tmpDir = createTmpDir();
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ─── parseMigrateEnvArgs ────────────────────────────────────────────────────
+
+describe("parseMigrateEnvArgs", () => {
+  it("defaults with no flags", () => {
+    const parsed = parseMigrateEnvArgs([]);
+    expect(parsed.help).toBe(false);
+    expect(parsed.vercelToken).toBeUndefined();
+    expect(parsed.project).toBeUndefined();
+    expect(parsed.teamId).toBeUndefined();
+    expect(parsed.target).toBeUndefined();
+    expect(parsed.dryRun).toBe(false);
+    expect(parsed.includeSystem).toBe(false);
+    expect(parsed.envFile).toBe(false);
+  });
+
+  it("parses --vercel-token", () => {
+    const parsed = parseMigrateEnvArgs(["--vercel-token", "tok_abc123"]);
+    expect(parsed.vercelToken).toBe("tok_abc123");
+  });
+
+  it("parses --project with space-separated value", () => {
+    expect(parseMigrateEnvArgs(["--project", "my-app"]).project).toBe("my-app");
+  });
+
+  it("parses --project=value form", () => {
+    expect(parseMigrateEnvArgs(["--project=my-app"]).project).toBe("my-app");
+  });
+
+  it("parses --team", () => {
+    expect(parseMigrateEnvArgs(["--team", "team_xxx"]).teamId).toBe("team_xxx");
+  });
+
+  it("parses --target production", () => {
+    expect(parseMigrateEnvArgs(["--target", "production"]).target).toBe("production");
+  });
+
+  it("parses --target preview", () => {
+    expect(parseMigrateEnvArgs(["--target", "preview"]).target).toBe("preview");
+  });
+
+  it("parses --target development", () => {
+    expect(parseMigrateEnvArgs(["--target", "development"]).target).toBe("development");
+  });
+
+  it("throws on invalid --target value", () => {
+    expect(() => parseMigrateEnvArgs(["--target", "staging"])).toThrow("Invalid --target");
+  });
+
+  it("parses boolean flags", () => {
+    const parsed = parseMigrateEnvArgs(["--dry-run", "--include-system", "--env-file"]);
+    expect(parsed.dryRun).toBe(true);
+    expect(parsed.includeSystem).toBe(true);
+    expect(parsed.envFile).toBe(true);
+  });
+
+  it("parses -h as help", () => {
+    expect(parseMigrateEnvArgs(["-h"]).help).toBe(true);
+  });
+
+  it("trims whitespace from --vercel-token", () => {
+    expect(parseMigrateEnvArgs(["--vercel-token", "  tok_abc  "]).vercelToken).toBe("tok_abc");
+  });
+
+  it("treats whitespace-only --project as undefined", () => {
+    expect(parseMigrateEnvArgs(["--project", "   "]).project).toBeUndefined();
+  });
+
+  it("throws on unknown flags (strict mode)", () => {
+    expect(() => parseMigrateEnvArgs(["--bogus"])).toThrow();
+  });
+
+
+
+  it("parses all flags combined", () => {
+    const parsed = parseMigrateEnvArgs([
+      "--vercel-token", "tok_abc",
+      "--project", "my-app",
+      "--team", "team_xxx",
+      "--target", "production",
+      "--dry-run",
+      "--include-system",
+      "--env-file",
+    ]);
+    expect(parsed.vercelToken).toBe("tok_abc");
+    expect(parsed.project).toBe("my-app");
+    expect(parsed.teamId).toBe("team_xxx");
+    expect(parsed.target).toBe("production");
+    expect(parsed.dryRun).toBe(true);
+    expect(parsed.includeSystem).toBe(true);
+    expect(parsed.envFile).toBe(true);
+  });
+});
+
+// ─── isVercelSystemVar ──────────────────────────────────────────────────────
+
+describe("isVercelSystemVar", () => {
+  it("identifies VERCEL_URL as system var", () => {
+    expect(isVercelSystemVar("VERCEL_URL")).toBe(true);
+  });
+
+  it("identifies VERCEL_ENV as system var", () => {
+    expect(isVercelSystemVar("VERCEL_ENV")).toBe(true);
+  });
+
+  it("identifies NEXT_PUBLIC_VERCEL_URL as system var", () => {
+    expect(isVercelSystemVar("NEXT_PUBLIC_VERCEL_URL")).toBe(true);
+  });
+
+  it("does not flag DATABASE_URL as system var", () => {
+    expect(isVercelSystemVar("DATABASE_URL")).toBe(false);
+  });
+
+  it("does not flag NEXT_PUBLIC_API_KEY as system var", () => {
+    expect(isVercelSystemVar("NEXT_PUBLIC_API_KEY")).toBe(false);
+  });
+
+  it("does not flag VERCEL_LIKE_VAR without prefix", () => {
+    expect(isVercelSystemVar("MY_VERCEL_TOKEN")).toBe(false);
+  });
+
+  it("identifies VERCEL exact match as system var", () => {
+    expect(isVercelSystemVar("VERCEL")).toBe(true);
+  });
+
+  it("identifies CI as system var", () => {
+    expect(isVercelSystemVar("CI")).toBe(true);
+  });
+
+  it("identifies NX_DAEMON as system var", () => {
+    expect(isVercelSystemVar("NX_DAEMON")).toBe(true);
+  });
+
+  it("identifies TURBO_CACHE as system var", () => {
+    expect(isVercelSystemVar("TURBO_CACHE")).toBe(true);
+  });
+
+  it("identifies TURBO_RUN_SUMMARY as system var", () => {
+    expect(isVercelSystemVar("TURBO_RUN_SUMMARY")).toBe(true);
+  });
+});
+
+// ─── classifyVars ───────────────────────────────────────────────────────────
+
+describe("classifyVars", () => {
+  const makeVar = (
+    key: string,
+    value: string,
+    type: VercelEnvVar["type"] = "plain",
+    target: VercelEnvVar["target"] = ["production"],
+    system = false,
+  ): VercelEnvVar => ({ key, value, target, type, system });
+
+  it("classifies plain vars as plainVars", () => {
+    const vars = [makeVar("API_URL", "https://api.example.com", "plain")];
+    const result = classifyVars(vars);
+    expect(result.plainVars).toHaveLength(1);
+    expect(result.plainVars[0].key).toBe("API_URL");
+    expect(result.secrets).toHaveLength(0);
+  });
+
+  it("classifies secret vars as secrets", () => {
+    const vars = [makeVar("API_KEY", "sk-123", "secret")];
+    const result = classifyVars(vars);
+    expect(result.secrets).toHaveLength(1);
+    expect(result.secrets[0].key).toBe("API_KEY");
+    expect(result.plainVars).toHaveLength(0);
+  });
+
+  it("classifies encrypted vars as secrets", () => {
+    const vars = [makeVar("DB_PASSWORD", "enc_xxx", "encrypted")];
+    const result = classifyVars(vars);
+    expect(result.secrets).toHaveLength(1);
+    expect(result.secrets[0].key).toBe("DB_PASSWORD");
+  });
+
+  it("classifies sensitive vars as secrets", () => {
+    const vars = [makeVar("AUTH_SECRET", "secret_xxx", "sensitive")];
+    const result = classifyVars(vars);
+    expect(result.secrets).toHaveLength(1);
+  });
+
+  it("forces NEXT_PUBLIC_* vars to plain even if marked secret", () => {
+    const vars = [makeVar("NEXT_PUBLIC_APP_URL", "https://app.com", "secret")];
+    const result = classifyVars(vars);
+    expect(result.plainVars).toHaveLength(1);
+    expect(result.plainVars[0].key).toBe("NEXT_PUBLIC_APP_URL");
+    expect(result.secrets).toHaveLength(0);
+  });
+
+  it("skips Vercel system vars by default", () => {
+    const vars = [
+      makeVar("VERCEL_URL", "my-app.vercel.app", "plain", ["production"], true),
+      makeVar("DATABASE_URL", "postgres://...", "secret"),
+    ];
+    const result = classifyVars(vars);
+    expect(result.secrets).toHaveLength(1);
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0].key).toBe("VERCEL_URL");
+    expect(result.skipped[0].reason).toContain("system var");
+  });
+
+  it("includes system vars when includeSystem is true", () => {
+    const vars = [makeVar("VERCEL_URL", "my-app.vercel.app", "plain", ["production"], true)];
+    const result = classifyVars(vars, { includeSystem: true });
+    expect(result.plainVars).toHaveLength(1);
+    expect(result.skipped).toHaveLength(0);
+  });
+
+  it("filters by target when specified", () => {
+    const vars = [
+      makeVar("API_KEY", "key-prod", "secret", ["production"]),
+      makeVar("DEBUG_FLAG", "true", "plain", ["development"]),
+    ];
+    const result = classifyVars(vars, { target: "production" });
+    expect(result.secrets).toHaveLength(1);
+    expect(result.secrets[0].key).toBe("API_KEY");
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0].key).toBe("DEBUG_FLAG");
+  });
+
+  it("includes vars with matching target", () => {
+    const vars = [
+      makeVar("API_KEY", "key-all", "secret", ["production", "preview", "development"]),
+    ];
+    const result = classifyVars(vars, { target: "preview" });
+    expect(result.secrets).toHaveLength(1);
+  });
+
+  it("includes vars with empty target (applies to all)", () => {
+    const vars = [makeVar("GLOBAL_VAR", "value", "plain", [])];
+    const result = classifyVars(vars, { target: "production" });
+    expect(result.plainVars).toHaveLength(1);
+  });
+
+  it("handles duplicate keys (last wins)", () => {
+    const vars = [
+      makeVar("API_KEY", "old-value", "secret", ["production"]),
+      makeVar("API_KEY", "new-value", "secret", ["production"]),
+    ];
+    const result = classifyVars(vars);
+    expect(result.secrets).toHaveLength(1);
+    expect(result.secrets[0].value).toBe("new-value");
+    // Should have a skipped entry noting the duplicate
+    expect(result.skipped.some((s) => s.key.includes("duplicate"))).toBe(true);
+  });
+
+  it("handles empty var list", () => {
+    const result = classifyVars([]);
+    expect(result.secrets).toHaveLength(0);
+    expect(result.plainVars).toHaveLength(0);
+    expect(result.skipped).toHaveLength(0);
+  });
+
+  it("handles vars with empty values", () => {
+    const vars = [makeVar("EMPTY_VAR", "", "plain")];
+    const result = classifyVars(vars);
+    expect(result.plainVars).toHaveLength(1);
+    expect(result.plainVars[0].value).toBe("");
+  });
+
+  it("classifies system vars by prefix even without system flag", () => {
+    const vars = [makeVar("VERCEL_ENV", "production", "plain", ["production"], false)];
+    const result = classifyVars(vars);
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0].reason).toContain("system var");
+  });
+
+  it("classifies mixed batch correctly", () => {
+    const vars = [
+      makeVar("DATABASE_URL", "postgres://...", "secret"),
+      makeVar("API_URL", "https://api.com", "plain"),
+      makeVar("NEXT_PUBLIC_APP_NAME", "My App", "secret"),
+      makeVar("VERCEL_URL", "app.vercel.app", "plain", ["production"], true),
+      makeVar("AUTH_TOKEN", "tok_xxx", "encrypted"),
+    ];
+    const result = classifyVars(vars);
+    expect(result.secrets).toHaveLength(2); // DATABASE_URL, AUTH_TOKEN
+    expect(result.plainVars).toHaveLength(2); // API_URL, NEXT_PUBLIC_APP_NAME
+    expect(result.skipped).toHaveLength(1); // VERCEL_URL
+  });
+});
+
+// ─── detectVercelProject ────────────────────────────────────────────────────
+
+describe("detectVercelProject", () => {
+  it("reads project ID from .vercel/project.json", () => {
+    writeFile(tmpDir, ".vercel/project.json", JSON.stringify({
+      projectId: "prj_abc123",
+      orgId: "org_xxx",
+    }));
+    expect(detectVercelProject(tmpDir)).toBe("prj_abc123");
+  });
+
+  it("falls back to package.json name", () => {
+    writeFile(tmpDir, "package.json", JSON.stringify({ name: "my-app" }));
+    expect(detectVercelProject(tmpDir)).toBe("my-app");
+  });
+
+  it("strips npm scope from package.json name", () => {
+    writeFile(tmpDir, "package.json", JSON.stringify({ name: "@org/my-app" }));
+    expect(detectVercelProject(tmpDir)).toBe("my-app");
+  });
+
+  it("prefers .vercel/project.json over package.json", () => {
+    writeFile(tmpDir, ".vercel/project.json", JSON.stringify({ projectId: "prj_abc" }));
+    writeFile(tmpDir, "package.json", JSON.stringify({ name: "pkg-name" }));
+    expect(detectVercelProject(tmpDir)).toBe("prj_abc");
+  });
+
+  it("returns null when no project info available", () => {
+    expect(detectVercelProject(tmpDir)).toBeNull();
+  });
+
+  it("handles malformed .vercel/project.json gracefully", () => {
+    writeFile(tmpDir, ".vercel/project.json", "not json");
+    writeFile(tmpDir, "package.json", JSON.stringify({ name: "fallback-app" }));
+    expect(detectVercelProject(tmpDir)).toBe("fallback-app");
+  });
+
+  it("handles .vercel/project.json without projectId", () => {
+    writeFile(tmpDir, ".vercel/project.json", JSON.stringify({ orgId: "org_xxx" }));
+    writeFile(tmpDir, "package.json", JSON.stringify({ name: "fallback-app" }));
+    expect(detectVercelProject(tmpDir)).toBe("fallback-app");
+  });
+});
+
+// ─── detectVercelOrgId ──────────────────────────────────────────────────────
+
+describe("detectVercelOrgId", () => {
+  it("reads orgId from .vercel/project.json", () => {
+    writeFile(tmpDir, ".vercel/project.json", JSON.stringify({
+      projectId: "prj_abc123",
+      orgId: "team_xyz789",
+    }));
+    expect(detectVercelOrgId(tmpDir)).toBe("team_xyz789");
+  });
+
+  it("returns null when no .vercel/project.json exists", () => {
+    expect(detectVercelOrgId(tmpDir)).toBeNull();
+  });
+
+  it("returns null when orgId is missing", () => {
+    writeFile(tmpDir, ".vercel/project.json", JSON.stringify({ projectId: "prj_abc" }));
+    expect(detectVercelOrgId(tmpDir)).toBeNull();
+  });
+
+  it("handles malformed JSON gracefully", () => {
+    writeFile(tmpDir, ".vercel/project.json", "not valid json");
+    expect(detectVercelOrgId(tmpDir)).toBeNull();
+  });
+});
+
+// ─── detectVercelToken ──────────────────────────────────────────────────────
+
+describe("detectVercelToken", () => {
+  it("doesn't crash when no auth files exist", () => {
+    const result = detectVercelToken();
+    expect(result === null || typeof result === "string").toBe(true);
+  });
+});
+
+// ─── detectVercelCli ────────────────────────────────────────────────────────
+
+describe("detectVercelCli", () => {
+  it("returns string or null without crashing", () => {
+    const result = detectVercelCli();
+    expect(result === null || typeof result === "string").toBe(true);
+  });
+});
+
+// ─── isVercelCliAuthenticated ───────────────────────────────────────────────
+
+describe("isVercelCliAuthenticated", () => {
+  it("returns boolean without crashing", () => {
+    const result = isVercelCliAuthenticated();
+    expect(typeof result).toBe("boolean");
+  });
+});
+
+// ─── parseEnvFile ───────────────────────────────────────────────────────────
+
+describe("parseEnvFile", () => {
+  it("parses simple KEY=VALUE pairs", () => {
+    const content = "API_KEY=abc123\nDB_URL=postgres://localhost";
+    const result = parseEnvFile(content);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({ key: "API_KEY", value: "abc123" });
+    expect(result[1]).toEqual({ key: "DB_URL", value: "postgres://localhost" });
+  });
+
+  it("skips comments and empty lines", () => {
+    const content = "# This is a comment\n\nAPI_KEY=abc123\n# Another comment";
+    const result = parseEnvFile(content);
+    expect(result).toHaveLength(1);
+    expect(result[0].key).toBe("API_KEY");
+  });
+
+  it("handles double-quoted values", () => {
+    const content = 'GREETING="hello world"';
+    const result = parseEnvFile(content);
+    expect(result[0].value).toBe("hello world");
+  });
+
+  it("handles single-quoted values", () => {
+    const content = "GREETING='hello world'";
+    const result = parseEnvFile(content);
+    expect(result[0].value).toBe("hello world");
+  });
+
+  it("unescapes \\n in double-quoted values", () => {
+    const content = 'MULTILINE="line1\\nline2"';
+    const result = parseEnvFile(content);
+    expect(result[0].value).toBe("line1\nline2");
+  });
+
+  it("does not unescape in single-quoted values", () => {
+    const content = "RAW='hello\\nworld'";
+    const result = parseEnvFile(content);
+    expect(result[0].value).toBe("hello\\nworld");
+  });
+
+  it("handles values with equals signs", () => {
+    const content = "CONNECTION=host=localhost;port=5432";
+    const result = parseEnvFile(content);
+    expect(result[0].value).toBe("host=localhost;port=5432");
+  });
+
+  it("handles empty values", () => {
+    const content = "EMPTY_VAR=";
+    const result = parseEnvFile(content);
+    expect(result[0]).toEqual({ key: "EMPTY_VAR", value: "" });
+  });
+
+  it("skips lines without equals sign", () => {
+    const content = "NO_EQUALS_HERE\nVALID=yes";
+    const result = parseEnvFile(content);
+    expect(result).toHaveLength(1);
+    expect(result[0].key).toBe("VALID");
+  });
+
+  it("handles empty input", () => {
+    expect(parseEnvFile("")).toHaveLength(0);
+  });
+
+  it("handles Vercel env pull header comments", () => {
+    const content = `# Created by Vercel CLI\nNEXT_PUBLIC_APP="my app"\nDB_URL=postgres://...`;
+    const result = parseEnvFile(content);
+    expect(result).toHaveLength(2);
+  });
+
+  it("handles escaped quotes in double-quoted values", () => {
+    const content = 'MSG="say \\"hello\\""';
+    const result = parseEnvFile(content);
+    expect(result[0].value).toBe('say "hello"');
+  });
+});
+
+// ─── fetchVercelEnvVars ─────────────────────────────────────────────────────
+
+describe("fetchVercelEnvVars", () => {
+  function mockFetcher(responses: Array<{ status: number; body: unknown }>): typeof fetch {
+    let callIndex = 0;
+    return async (input: RequestInfo | URL) => {
+      const response = responses[callIndex++] ?? responses[responses.length - 1];
+      return new Response(JSON.stringify(response.body), {
+        status: response.status,
+        headers: { "Content-Type": "application/json" },
+      });
+    };
+  }
+
+  it("fetches env vars from Vercel API", async () => {
+    const fetcher = mockFetcher([{
+      status: 200,
+      body: {
+        envs: [
+          { key: "DB_URL", value: "postgres://...", target: ["production"], type: "secret" },
+          { key: "API_URL", value: "https://api.com", target: ["production"], type: "plain" },
+        ],
+      },
+    }]);
+
+    const vars = await fetchVercelEnvVars("tok_test", "my-project", undefined, fetcher);
+    expect(vars).toHaveLength(2);
+    expect(vars[0].key).toBe("DB_URL");
+    expect(vars[1].key).toBe("API_URL");
+  });
+
+  it("throws on 401 unauthorized", async () => {
+    const fetcher = mockFetcher([{ status: 401, body: { error: "Unauthorized" } }]);
+    await expect(fetchVercelEnvVars("bad_token", "proj", undefined, fetcher))
+      .rejects.toThrow("authentication failed");
+  });
+
+  it("throws on 403 forbidden", async () => {
+    const fetcher = mockFetcher([{ status: 403, body: { error: "Forbidden" } }]);
+    await expect(fetchVercelEnvVars("tok", "proj", undefined, fetcher))
+      .rejects.toThrow("access denied");
+  });
+
+  it("throws on 404 not found", async () => {
+    const fetcher = mockFetcher([{ status: 404, body: { error: "Not found" } }]);
+    await expect(fetchVercelEnvVars("tok", "proj", undefined, fetcher))
+      .rejects.toThrow("not found");
+  });
+
+  it("handles pagination", async () => {
+    // First page: 100 items (triggers next page)
+    const page1Envs = Array.from({ length: 100 }, (_, i) => ({
+      key: `VAR_${i}`,
+      value: `val_${i}`,
+      target: ["production"],
+      type: "plain" as const,
+    }));
+    // Second page: 5 items (less than 100, stops pagination)
+    const page2Envs = Array.from({ length: 5 }, (_, i) => ({
+      key: `VAR_${100 + i}`,
+      value: `val_${100 + i}`,
+      target: ["production"],
+      type: "plain" as const,
+    }));
+
+    const fetcher = mockFetcher([
+      { status: 200, body: { envs: page1Envs } },
+      { status: 200, body: { envs: page2Envs } },
+    ]);
+
+    const vars = await fetchVercelEnvVars("tok", "proj", undefined, fetcher);
+    expect(vars).toHaveLength(105);
+  });
+
+  it("handles empty env list", async () => {
+    const fetcher = mockFetcher([{ status: 200, body: { envs: [] } }]);
+    const vars = await fetchVercelEnvVars("tok", "proj", undefined, fetcher);
+    expect(vars).toHaveLength(0);
+  });
+
+  it("handles vars with missing value (defaults to empty string)", async () => {
+    const fetcher = mockFetcher([{
+      status: 200,
+      body: {
+        envs: [{ key: "EMPTY", target: ["production"], type: "plain" }],
+      },
+    }]);
+    const vars = await fetchVercelEnvVars("tok", "proj", undefined, fetcher);
+    expect(vars[0].value).toBe("");
+  });
+
+  it("passes teamId as query parameter", async () => {
+    let capturedUrl = "";
+    const fetcher: typeof fetch = async (input: RequestInfo | URL) => {
+      capturedUrl = typeof input === "string" ? input : input.toString();
+      return new Response(JSON.stringify({ envs: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    };
+
+    await fetchVercelEnvVars("tok", "proj", "team_xxx", fetcher);
+    expect(capturedUrl).toContain("teamId=team_xxx");
+  });
+});
+
+// ─── stripJsonComments ──────────────────────────────────────────────────────
+
+describe("stripJsonComments", () => {
+  it("strips single-line comments", () => {
+    const input = `{
+  // this is a comment
+  "name": "test"
+}`;
+    const result = stripJsonComments(input);
+    expect(JSON.parse(result)).toEqual({ name: "test" });
+  });
+
+  it("strips multi-line comments", () => {
+    const input = `{
+  /* multi
+   * line
+   * comment */
+  "name": "test"
+}`;
+    const result = stripJsonComments(input);
+    expect(JSON.parse(result)).toEqual({ name: "test" });
+  });
+
+  it("preserves URLs in string values", () => {
+    const input = `{ "url": "https://example.com" }`;
+    const result = stripJsonComments(input);
+    expect(JSON.parse(result)).toEqual({ url: "https://example.com" });
+  });
+
+  it("preserves // inside strings", () => {
+    const input = `{ "path": "foo//bar" }`;
+    const result = stripJsonComments(input);
+    expect(JSON.parse(result)).toEqual({ path: "foo//bar" });
+  });
+
+  it("handles escaped quotes in strings", () => {
+    const input = `{ "value": "he said \\"hello\\"" }`;
+    const result = stripJsonComments(input);
+    expect(JSON.parse(result)).toEqual({ value: 'he said "hello"' });
+  });
+
+  it("handles empty input", () => {
+    expect(stripJsonComments("")).toBe("");
+  });
+});
+
+// ─── detectWranglerConfig ───────────────────────────────────────────────────
+
+describe("detectWranglerConfig", () => {
+  it("detects wrangler.jsonc", () => {
+    writeFile(tmpDir, "wrangler.jsonc", "{}");
+    const config = detectWranglerConfig(tmpDir);
+    expect(config?.format).toBe("json");
+    expect(config?.path).toContain("wrangler.jsonc");
+  });
+
+  it("detects wrangler.json", () => {
+    writeFile(tmpDir, "wrangler.json", "{}");
+    const config = detectWranglerConfig(tmpDir);
+    expect(config?.format).toBe("json");
+  });
+
+  it("detects wrangler.toml", () => {
+    writeFile(tmpDir, "wrangler.toml", "[vars]");
+    const config = detectWranglerConfig(tmpDir);
+    expect(config?.format).toBe("toml");
+  });
+
+  it("returns null when no config exists", () => {
+    expect(detectWranglerConfig(tmpDir)).toBeNull();
+  });
+
+  it("prefers jsonc over json over toml", () => {
+    writeFile(tmpDir, "wrangler.jsonc", "{}");
+    writeFile(tmpDir, "wrangler.json", "{}");
+    writeFile(tmpDir, "wrangler.toml", "[vars]");
+    const config = detectWranglerConfig(tmpDir);
+    expect(config?.path).toContain("wrangler.jsonc");
+  });
+});
+
+// ─── detectWorkerName ───────────────────────────────────────────────────────
+
+describe("detectWorkerName", () => {
+  it("reads name from wrangler.jsonc", () => {
+    writeFile(tmpDir, "wrangler.jsonc", JSON.stringify({ name: "my-worker" }));
+    expect(detectWorkerName(tmpDir)).toBe("my-worker");
+  });
+
+  it("reads name from wrangler.jsonc with comments", () => {
+    writeFile(tmpDir, "wrangler.jsonc", `{
+  // Worker name
+  "name": "commented-worker"
+}`);
+    expect(detectWorkerName(tmpDir)).toBe("commented-worker");
+  });
+
+  it("returns null when no wrangler config", () => {
+    expect(detectWorkerName(tmpDir)).toBeNull();
+  });
+
+  it("returns null for toml config", () => {
+    writeFile(tmpDir, "wrangler.toml", 'name = "my-worker"');
+    expect(detectWorkerName(tmpDir)).toBeNull();
+  });
+
+  it("returns null when name field missing", () => {
+    writeFile(tmpDir, "wrangler.jsonc", JSON.stringify({ compatibility_date: "2026-01-01" }));
+    expect(detectWorkerName(tmpDir)).toBeNull();
+  });
+});
+
+// ─── injectPlainVars ────────────────────────────────────────────────────────
+
+describe("injectPlainVars", () => {
+  it("throws when no wrangler config exists", () => {
+    expect(() =>
+      injectPlainVars(tmpDir, [{ key: "API_URL", value: "https://api.com" }])
+    ).toThrow("No wrangler config found");
+  });
+
+  it("merges into existing wrangler.jsonc vars", () => {
+    writeFile(tmpDir, "wrangler.jsonc", JSON.stringify({
+      name: "my-worker",
+      vars: { EXISTING: "value" },
+    }));
+
+    const result = injectPlainVars(tmpDir, [{ key: "NEW_VAR", value: "new" }]);
+    expect(result.added).toBe(1);
+
+    const config = JSON.parse(readFile(tmpDir, "wrangler.jsonc"));
+    expect(config.vars.EXISTING).toBe("value");
+    expect(config.vars.NEW_VAR).toBe("new");
+    expect(config.name).toBe("my-worker"); // preserves other fields
+  });
+
+  it("creates vars section when missing in existing config", () => {
+    writeFile(tmpDir, "wrangler.jsonc", JSON.stringify({ name: "my-worker" }));
+
+    injectPlainVars(tmpDir, [{ key: "API_KEY", value: "abc" }]);
+
+    const config = JSON.parse(readFile(tmpDir, "wrangler.jsonc"));
+    expect(config.vars.API_KEY).toBe("abc");
+  });
+
+  it("reports conflicts when overwriting existing vars", () => {
+    writeFile(tmpDir, "wrangler.jsonc", JSON.stringify({
+      vars: { API_URL: "old-value" },
+    }));
+
+    const result = injectPlainVars(tmpDir, [{ key: "API_URL", value: "new-value" }]);
+    expect(result.conflicts).toContain("API_URL");
+    expect(result.warnings.some((w) => w.includes("overwritten"))).toBe(true);
+
+    const config = JSON.parse(readFile(tmpDir, "wrangler.jsonc"));
+    expect(config.vars.API_URL).toBe("new-value");
+  });
+
+  it("does not report conflict when value is the same", () => {
+    writeFile(tmpDir, "wrangler.jsonc", JSON.stringify({
+      vars: { API_URL: "same-value" },
+    }));
+
+    const result = injectPlainVars(tmpDir, [{ key: "API_URL", value: "same-value" }]);
+    expect(result.conflicts).toHaveLength(0);
+  });
+
+  it("warns for toml config", () => {
+    writeFile(tmpDir, "wrangler.toml", "[vars]\nAPI_URL = \"old\"");
+
+    const result = injectPlainVars(tmpDir, [{ key: "NEW", value: "val" }]);
+    expect(result.added).toBe(0);
+    expect(result.warnings.some((w) => w.includes("TOML") || w.includes("toml"))).toBe(true);
+  });
+
+  it("returns empty result for empty vars list", () => {
+    const result = injectPlainVars(tmpDir, []);
+    expect(result.added).toBe(0);
+    expect(result.conflicts).toHaveLength(0);
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it("handles dry run without writing", () => {
+    const result = injectPlainVars(tmpDir, [{ key: "API_URL", value: "val" }], true);
+    expect(result.added).toBe(1);
+    // Should not have created the file
+    expect(result.warnings.some((w) => w.includes("dry-run") || w.includes("Would"))).toBe(true);
+  });
+
+  it("handles multiple vars at once", () => {
+    writeFile(tmpDir, "wrangler.jsonc", JSON.stringify({ name: "worker" }));
+
+    const vars = [
+      { key: "VAR_A", value: "a" },
+      { key: "VAR_B", value: "b" },
+      { key: "VAR_C", value: "c" },
+    ];
+    const result = injectPlainVars(tmpDir, vars);
+    expect(result.added).toBe(3);
+
+    const config = JSON.parse(readFile(tmpDir, "wrangler.jsonc"));
+    expect(config.vars.VAR_A).toBe("a");
+    expect(config.vars.VAR_B).toBe("b");
+    expect(config.vars.VAR_C).toBe("c");
+  });
+
+  it("handles JSONC with comments", () => {
+    // Note: after parsing + re-serializing, comments will be lost (expected behavior)
+    writeFile(tmpDir, "wrangler.jsonc", `{
+  // Worker config
+  "name": "my-worker",
+  "vars": {
+    "EXISTING": "value"
+  }
+}`);
+
+    const result = injectPlainVars(tmpDir, [{ key: "NEW", value: "val" }]);
+    expect(result.added).toBe(1);
+
+    const config = JSON.parse(readFile(tmpDir, "wrangler.jsonc"));
+    expect(config.vars.EXISTING).toBe("value");
+    expect(config.vars.NEW).toBe("val");
+  });
+});
+
+// ─── writeEnvBackup ─────────────────────────────────────────────────────────
+
+describe("writeEnvBackup", () => {
+  it("writes .env.cloudflare file", () => {
+    const vars = [
+      { key: "API_KEY", value: "abc123" },
+      { key: "DB_URL", value: "postgres://localhost/db" },
+    ];
+    writeEnvBackup(tmpDir, vars);
+
+    const content = readFile(tmpDir, ".env.cloudflare");
+    expect(content).toContain("API_KEY=abc123");
+    expect(content).toContain("DB_URL=postgres://localhost/db");
+    expect(content).toContain("Auto-generated by vinext migrateenv");
+  });
+
+  it("quotes values with special characters", () => {
+    const vars = [
+      { key: "MULTI", value: "line1\nline2" },
+      { key: "WITH_EQUALS", value: "foo=bar" },
+      { key: "WITH_SPACES", value: "hello world" },
+      { key: "WITH_DOLLAR", value: "price$100" },
+    ];
+    writeEnvBackup(tmpDir, vars);
+
+    const content = readFile(tmpDir, ".env.cloudflare");
+    expect(content).toContain('MULTI="line1\\nline2"');
+    expect(content).toContain('WITH_EQUALS="foo=bar"');
+    expect(content).toContain('WITH_SPACES="hello world"');
+    expect(content).toContain('WITH_DOLLAR="price$100"');
+  });
+
+  it("handles empty values", () => {
+    const vars = [{ key: "EMPTY", value: "" }];
+    writeEnvBackup(tmpDir, vars);
+
+    const content = readFile(tmpDir, ".env.cloudflare");
+    expect(content).toContain("EMPTY=");
+  });
+
+  it("adds .env.cloudflare to .gitignore", () => {
+    writeFile(tmpDir, ".gitignore", "node_modules\n");
+
+    writeEnvBackup(tmpDir, [{ key: "FOO", value: "bar" }]);
+
+    const gitignore = readFile(tmpDir, ".gitignore");
+    expect(gitignore).toContain(".env.cloudflare");
+  });
+
+  it("does not duplicate .env.cloudflare in .gitignore", () => {
+    writeFile(tmpDir, ".gitignore", "node_modules\n.env.cloudflare\n");
+
+    writeEnvBackup(tmpDir, [{ key: "FOO", value: "bar" }]);
+
+    const gitignore = readFile(tmpDir, ".gitignore");
+    const count = gitignore.split(".env.cloudflare").length - 1;
+    expect(count).toBe(1);
+  });
+
+  it("does nothing for empty vars list", () => {
+    writeEnvBackup(tmpDir, []);
+    expect(fs.existsSync(path.join(tmpDir, ".env.cloudflare"))).toBe(false);
+  });
+
+  it("does not write in dry run mode", () => {
+    writeEnvBackup(tmpDir, [{ key: "FOO", value: "bar" }], true);
+    expect(fs.existsSync(path.join(tmpDir, ".env.cloudflare"))).toBe(false);
+  });
+});
+
+// ─── secureDelete ───────────────────────────────────────────────────────────
+
+describe("secureDelete", () => {
+  it("deletes a file", () => {
+    const filePath = path.join(tmpDir, "secret.json");
+    fs.writeFileSync(filePath, "sensitive data");
+    expect(fs.existsSync(filePath)).toBe(true);
+
+    secureDelete(filePath);
+    expect(fs.existsSync(filePath)).toBe(false);
+  });
+
+  it("handles non-existent file gracefully", () => {
+    const filePath = path.join(tmpDir, "nonexistent.json");
+    expect(() => secureDelete(filePath)).not.toThrow();
+  });
+});
+
+// ─── uploadSecrets ──────────────────────────────────────────────────────────
+
+describe("uploadSecrets", () => {
+  it("returns empty result for no secrets", () => {
+    const result = uploadSecrets(tmpDir, []);
+    expect(result.uploaded).toBe(0);
+    expect(result.output).toContain("No secrets");
+  });
+
+  it("returns dry-run output without uploading", () => {
+    const secrets = [
+      { key: "API_KEY", value: "abc" },
+      { key: "DB_PASS", value: "xyz" },
+    ];
+    const result = uploadSecrets(tmpDir, secrets, "my-worker", true);
+    expect(result.uploaded).toBe(0);
+    expect(result.output).toContain("dry-run");
+    expect(result.output).toContain("API_KEY");
+    expect(result.output).toContain("DB_PASS");
+    expect(result.output).toContain("2 secret(s)");
+  });
+});
+
+// ─── Edge Cases ─────────────────────────────────────────────────────────────
+
+describe("edge cases", () => {
+  it("handles multiline env var values in classification", () => {
+    const vars: VercelEnvVar[] = [{
+      key: "PRIVATE_KEY",
+      value: "-----BEGIN RSA PRIVATE KEY-----\nMIIEpA...\n-----END RSA PRIVATE KEY-----",
+      target: ["production"],
+      type: "secret",
+    }];
+    const result = classifyVars(vars);
+    expect(result.secrets).toHaveLength(1);
+    expect(result.secrets[0].value).toContain("\n");
+  });
+
+  it("handles values with special characters", () => {
+    const vars: VercelEnvVar[] = [{
+      key: "SPECIAL",
+      value: 'value with "quotes" and $dollars and `backticks`',
+      target: ["production"],
+      type: "plain",
+    }];
+    const result = classifyVars(vars);
+    expect(result.plainVars).toHaveLength(1);
+    expect(result.plainVars[0].value).toContain('"quotes"');
+  });
+
+  it("handles very long env var values", () => {
+    const longValue = "x".repeat(10000);
+    const vars: VercelEnvVar[] = [{
+      key: "LONG_VAR",
+      value: longValue,
+      target: ["production"],
+      type: "plain",
+    }];
+    const result = classifyVars(vars);
+    expect(result.plainVars).toHaveLength(1);
+    expect(result.plainVars[0].value.length).toBe(10000);
+  });
+
+  it("writeEnvBackup handles values with quotes correctly", () => {
+    const vars = [{ key: "QUOTED", value: 'value "with" quotes' }];
+    writeEnvBackup(tmpDir, vars);
+
+    const content = readFile(tmpDir, ".env.cloudflare");
+    expect(content).toContain('QUOTED="value \\"with\\" quotes"');
+  });
+
+  it("writeEnvBackup handles values with backslashes", () => {
+    const vars = [{ key: "ESCAPED", value: "path\\to\\file" }];
+    writeEnvBackup(tmpDir, vars);
+
+    const content = readFile(tmpDir, ".env.cloudflare");
+    // Should be properly escaped
+    expect(content).toContain("ESCAPED=path\\to\\file");
+  });
+});


### PR DESCRIPTION
Securely migrate environment variables from Vercel to Cloudflare Workers.

- Secrets uploaded via wrangler secret bulk (temp file zeroed before delete)
- NEXT_PUBLIC_* vars injected into wrangler.jsonc as plain vars
- Auto-detects Vercel auth (CLI, VERCEL_TOKEN, interactive prompt)
- Auto-login for Cloudflare (wrangler login with retry)
- Requires existing wrangler.jsonc (from vinext deploy --dry-run)
- Early validation: checks for wrangler config and Vercel project
- All child processes use execFileSync (no shell injection)
- Vitest tests covering arg parsing, classification, API pagination, config injection, secure deletion, and more

Workflow:
  vinext deploy --dry-run   # Generate config files
  vinext migrate-env        # Migrate env vars from Vercel
  vinext deploy             # Build and deploy with env vars