### PR TITLE
fix: block dangerous URI schemes in Link and Form components

### DIFF
--- a/packages/vinext/src/shims/url-safety.ts
+++ b/packages/vinext/src/shims/url-safety.ts
@@ -1,0 +1,17 @@
+/**
+ * Shared URL safety utilities for Link, Form, and navigation shims.
+ *
+ * Centralizes dangerous URI scheme detection so all components and
+ * navigation functions use the same validation logic.
+ */
+
+/**
+ * Detect dangerous URI schemes that should never be navigated to.
+ * Strips leading whitespace and zero-width characters before testing,
+ * since browsers ignore these when interpreting the scheme.
+ */
+const DANGEROUS_SCHEME_RE = /^[\s\u200B\uFEFF]*(javascript|data|vbscript)\s*:/i;
+
+export function isDangerousScheme(url: string): boolean {
+  return DANGEROUS_SCHEME_RE.test(url);
+}


### PR DESCRIPTION
## Summary

Validates URL schemes in the `Link` and `Form` component shims to match how Next.js handles these cases. Blocks `javascript:`, `data:`, and `vbscript:` URI schemes that should never appear in navigation targets.

## Changes

**New: `url-safety.ts`** -- shared `isDangerousScheme()` utility with a single regex that handles evasion vectors (mixed case, leading whitespace, zero-width characters, whitespace before colon).

**Link component** (`link.tsx`)
- Checks resolved href against `isDangerousScheme()` before rendering
- Dangerous hrefs render an inert `<a>` without `href` (preserves className, id, aria-* for styling)
- Warns in dev mode via `console.warn`

**Form component** (`form.tsx`)
- New `isSafeAction()` validates string action URLs
- Blocks dangerous URI schemes, protocol-relative URLs (`//evil.com`), and cross-origin absolute URLs
- Unsafe forms render without `action` attribute (submits to current page)
- Warns in dev mode

Based on the work by @kochrac in #142. This PR takes a different approach (validating at the component level rather than escaping in code generation) since the generated entries are Vite virtual modules, not inline HTML.

Supersedes #142