### PR TITLE
fix: bound fetch cache key body serialization

### DIFF
--- a/packages/vinext/src/shims/fetch-cache.ts
+++ b/packages/vinext/src/shims/fetch-cache.ts
@@ -37,7 +37,7 @@ import { AsyncLocalStorage } from "node:async_hooks";
 const HEADER_BLOCKLIST = ["traceparent", "tracestate"];
 
 // Cache key version — bump when changing the key format to bust stale entries
-const CACHE_KEY_PREFIX = "v1";
+const CACHE_KEY_PREFIX = "v2";
 const MAX_CACHE_KEY_BODY_BYTES = 1024 * 1024; // 1 MiB
 
 class BodyTooLargeForCacheKeyError extends Error {
@@ -129,7 +129,13 @@ async function serializeBody(init?: RequestInit): Promise<string[]> {
         if (typeof value === "string") {
           pushBodyChunk(value);
         } else {
-          pushBodyChunk(decoder.decode(value, { stream: true }));
+          // Check raw byte size before the expensive decode to prevent
+          // OOM from a single oversized chunk.
+          totalBodyBytes += value.byteLength;
+          if (totalBodyBytes > MAX_CACHE_KEY_BODY_BYTES) {
+            throw new BodyTooLargeForCacheKeyError();
+          }
+          bodyChunks.push(decoder.decode(value, { stream: true }));
         }
       }
       const finalChunk = decoder.decode();
@@ -137,8 +143,8 @@ async function serializeBody(init?: RequestInit): Promise<string[]> {
         pushBodyChunk(finalChunk);
       }
     } catch (err) {
+      await reader.cancel();
       if (err instanceof BodyTooLargeForCacheKeyError) {
-        await reader.cancel();
         throw err;
       }
       console.error("[vinext] Problem reading body for cache key", err);
@@ -176,6 +182,11 @@ async function serializeBody(init?: RequestInit): Promise<string[]> {
     const arrayBuffer = await blob.arrayBuffer();
     (init as any)._ogBody = new Blob([arrayBuffer], { type: blob.type });
   } else if (typeof init.body === "string") {
+    // String length is always <= UTF-8 byte length, so this is a
+    // cheap lower-bound check that avoids encoder.encode() for huge strings.
+    if (init.body.length > MAX_CACHE_KEY_BODY_BYTES) {
+      throw new BodyTooLargeForCacheKeyError();
+    }
     pushBodyChunk(init.body);
     (init as any)._ogBody = init.body;
   }

--- a/tests/fetch-cache.test.ts
+++ b/tests/fetch-cache.test.ts
@@ -1096,6 +1096,103 @@ describe("fetch cache shim", () => {
       const init = fetchMock.mock.calls[0][1] as RequestInit;
       expect(init.body).toBeInstanceOf(ReadableStream);
     });
+
+    it("oversized Uint8Array body bypasses cache and still fetches", async () => {
+      const largeBuffer = new Uint8Array(1024 * 1024 + 1);
+
+      const res1 = await fetch("https://api.example.com/large-uint8", {
+        method: "POST",
+        body: largeBuffer,
+        next: { revalidate: 60 },
+      });
+      const data1 = await res1.json();
+      expect(data1.count).toBe(1);
+
+      const res2 = await fetch("https://api.example.com/large-uint8", {
+        method: "POST",
+        body: largeBuffer,
+        next: { revalidate: 60 },
+      });
+      const data2 = await res2.json();
+      expect(data2.count).toBe(2); // bypassed cache because body is oversized
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("oversized string body bypasses cache and still fetches", async () => {
+      const largeString = "x".repeat(1024 * 1024 + 1);
+
+      const res1 = await fetch("https://api.example.com/large-string", {
+        method: "POST",
+        body: largeString,
+        next: { revalidate: 60 },
+      });
+      const data1 = await res1.json();
+      expect(data1.count).toBe(1);
+
+      const res2 = await fetch("https://api.example.com/large-string", {
+        method: "POST",
+        body: largeString,
+        next: { revalidate: 60 },
+      });
+      const data2 = await res2.json();
+      expect(data2.count).toBe(2); // bypassed cache because body is oversized
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("ReadableStream with many small chunks accumulating past limit bypasses cache", async () => {
+      const chunkSize = 64 * 1024; // 64 KiB per chunk
+      const numChunks = 17; // 17 * 64 KiB = 1088 KiB > 1 MiB
+
+      const makeLargeMultiChunkStream = () => new ReadableStream({
+        start(controller) {
+          for (let i = 0; i < numChunks; i++) {
+            controller.enqueue(new Uint8Array(chunkSize));
+          }
+          controller.close();
+        },
+      });
+
+      const res1 = await fetch("https://api.example.com/large-multi-chunk", {
+        method: "POST",
+        body: makeLargeMultiChunkStream(),
+        next: { revalidate: 60 },
+      });
+      const data1 = await res1.json();
+      expect(data1.count).toBe(1);
+
+      const res2 = await fetch("https://api.example.com/large-multi-chunk", {
+        method: "POST",
+        body: makeLargeMultiChunkStream(),
+        next: { revalidate: 60 },
+      });
+      const data2 = await res2.json();
+      expect(data2.count).toBe(2); // bypassed cache because cumulative size exceeds limit
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("FormData with large File entry bypasses cache and still fetches", async () => {
+      const largeContent = "x".repeat(1024 * 1024 + 1);
+      const largeFile = new File([largeContent], "big.txt", { type: "text/plain" });
+      const form = new FormData();
+      form.append("file", largeFile);
+
+      const res1 = await fetch("https://api.example.com/large-formdata", {
+        method: "POST",
+        body: form,
+        next: { revalidate: 60 },
+      });
+      const data1 = await res1.json();
+      expect(data1.count).toBe(1);
+
+      const res2 = await fetch("https://api.example.com/large-formdata", {
+        method: "POST",
+        body: form,
+        next: { revalidate: 60 },
+      });
+      const data2 = await res2.json();
+      expect(data2.count).toBe(2); // bypassed cache because file is oversized
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
   });
 
 


### PR DESCRIPTION
### Motivation

- The fetch cache key generator previously serialized and fully buffered many `BodyInit` types (streams, blobs, form data) with no size limit, allowing an attacker to cause unbounded memory growth during cached `fetch()` calls.
- The goal is to prevent OOM scenarios while preserving caching behavior for normal-sized bodies and ensuring the original request body remains usable for the real network fetch.

### Description

- Add a configurable hard limit `MAX_CACHE_KEY_BODY_BYTES` (1 MiB) and a `BodyTooLargeForCacheKeyError` to guard cache-key body serialization and abort unsafe buffering.
- Rework stream handling to use `ReadableStream.prototype.tee()` so one branch is consumed for cache-key hashing while the other branch is forwarded to the real fetch without reconstructing a full in-memory buffer.
- For bodies that exceed the size limit (Blob, `Uint8Array`, streamed chunks, `FormData` files), short-circuit cache-key generation and fall back to passing the request through to `originalFetch` (i.e., bypass caching) to avoid buffering; `_ogBody` restoration remains supported for safe cases.
- Update tests to reflect preserved stream forwarding behavior and add checks that oversized `Blob` and `ReadableStream` bodies bypass the cache and still perform the network fetch.

### Testing

- Ran unit tests with `pnpm test tests/fetch-cache.test.ts`, which passed (`54 tests` all green). 
- Ran type checking with `pnpm run typecheck`, which completed successfully with no type errors.
- New/updated tests exercise stream preservation and oversized-body fallback behavior and passed as part of the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1f69e2e14832396f748a282248f53)