### PR TITLE
fix: matchConfigPattern incorrectly matches :param with literal suffix

### DIFF
--- a/packages/vinext/src/config/config-matchers.ts
+++ b/packages/vinext/src/config/config-matchers.ts
@@ -372,10 +372,14 @@ export function matchConfigPattern(
   // followed by a literal suffix (e.g. "/:path*.md"). Without this, the suffix
   // pattern falls through to the simple segment matcher which incorrectly treats
   // the whole segment (":path*.md") as a named parameter and matches everything.
+  // The last condition catches simple params with literal suffixes (e.g. "/:slug.md")
+  // where the param name is followed by a dot — the simple matcher would treat
+  // "slug.md" as the param name and match any single segment regardless of suffix.
   if (
     pattern.includes("(") ||
     pattern.includes("\\") ||
-    /:[\w-]+[*+][^/]/.test(pattern)
+    /:[\w-]+[*+][^/]/.test(pattern) ||
+    /:[\w-]+\./.test(pattern)
   ) {
     try {
       // Param names may contain hyphens (e.g. :auth-method, :sign-in).

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -3284,7 +3284,8 @@ export function matchConfigPattern(
   if (
     pattern.includes("(") ||
     pattern.includes("\\") ||
-    /:[\w-]+[*+][^/]/.test(pattern)
+    /:[\w-]+[*+][^/]/.test(pattern) ||
+    /:[\w-]+\./.test(pattern)
   ) {
     try {
       // Extract named params and their constraints from the pattern.

--- a/packages/vinext/src/server/app-dev-server.ts
+++ b/packages/vinext/src/server/app-dev-server.ts
@@ -915,7 +915,7 @@ ${generateNormalizePathCode("modern")}
 
 // ── Config pattern matching (redirects, rewrites, headers) ──────────────
 function __matchConfigPattern(pathname, pattern) {
-  if (pattern.includes("(") || pattern.includes("\\\\") || /:[\\w-]+[*+][^/]/.test(pattern)) {
+  if (pattern.includes("(") || pattern.includes("\\\\") || /:[\\w-]+[*+][^/]/.test(pattern) || /:[\\w-]+\\./.test(pattern)) {
     try {
       const paramNames = [];
       const regexStr = pattern

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -2646,6 +2646,30 @@ describe("matchConfigPattern", () => {
     expect(matchConfigPattern("/blog/intro.md", "/docs/:path*.md")).toBeNull();
   });
 
+  it("matches :param with literal suffix (e.g. /:slug.md)", async () => {
+    const { matchConfigPattern } = await import(
+      "../packages/vinext/src/index.js"
+    );
+    // Should match URLs with the .md suffix and extract the param
+    expect(matchConfigPattern("/hello-world.md", "/:slug.md")).toEqual({ slug: "hello-world" });
+    expect(matchConfigPattern("/my-post.md", "/:slug.md")).toEqual({ slug: "my-post" });
+    // Should NOT match URLs without .md suffix
+    expect(matchConfigPattern("/", "/:slug.md")).toBeNull();
+    expect(matchConfigPattern("/hello-world", "/:slug.md")).toBeNull();
+    expect(matchConfigPattern("/hello-world.txt", "/:slug.md")).toBeNull();
+    // Should NOT match paths with extra segments
+    expect(matchConfigPattern("/blog/hello-world.md", "/:slug.md")).toBeNull();
+  });
+
+  it("matches :param with literal suffix via config-matchers module", async () => {
+    const { matchConfigPattern } = await import(
+      "../packages/vinext/src/config/config-matchers.js"
+    );
+    expect(matchConfigPattern("/hello-world.md", "/:slug.md")).toEqual({ slug: "hello-world" });
+    expect(matchConfigPattern("/", "/:slug.md")).toBeNull();
+    expect(matchConfigPattern("/hello-world", "/:slug.md")).toBeNull();
+  });
+
   it("still matches plain :path* catch-all (no suffix) correctly", async () => {
     const { matchConfigPattern } = await import(
       "../packages/vinext/src/index.js"


### PR DESCRIPTION
## Summary

- Patterns like `/:slug.md` fell through to the simple segment matcher, which treated `slug.md` as the entire parameter name and matched any single-segment path (including `/`)
- This caused rewrites like `{ source: "/:slug.md", destination: "/api/markdown/:slug" }` to rewrite **every page request**, resulting in 404s on all routes
- Added `/:[\w-]+\./.test(pattern)` to the condition that triggers the regex-based matcher, which already tokenizes `:slug` + `.` + `md` correctly

## Test plan

- [x] Added unit tests for `/:slug.md` pattern via both `index.ts` and `config/config-matchers.ts`
- [x] All 18 existing `matchConfigPattern` tests pass (no regressions)
- [x] Verified with a real app: `GET /` returns 200 with HTML (was 404 before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)