### PR TITLE
fix: add React version check to vinext build (#185)

### DIFF
--- a/packages/vinext/src/cli.ts
+++ b/packages/vinext/src/cli.ts
@@ -21,8 +21,9 @@ import { createRequire } from "node:module";
 import { execFileSync } from "node:child_process";
 import { deploy as runDeploy, parseDeployArgs } from "./deploy.js";
 import { runCheck, formatReport } from "./check.js";
-import { init as runInit } from "./init.js";
+import { init as runInit, getReactUpgradeDeps } from "./init.js";
 import { loadDotenv } from "./config/dotenv.js";
+import { detectPackageManager as _detectPackageManager } from "./utils/project.js";
 
 // ─── Resolve Vite from the project root ────────────────────────────────────────
 //
@@ -218,6 +219,19 @@ async function buildApp() {
   console.log(`\n  vinext build  (Vite ${getViteVersion()})\n`);
 
   const isApp = hasAppDir();
+
+  // For App Router: upgrade React if needed for react-server-dom-webpack compatibility.
+  // Without this, builds with react<19.2.4 produce a Worker that crashes at
+  // runtime with "Cannot read properties of undefined (reading 'moduleMap')".
+  if (isApp) {
+    const reactUpgrade = getReactUpgradeDeps(process.cwd());
+    if (reactUpgrade.length > 0) {
+      const installCmd = _detectPackageManager(process.cwd()).replace(/ -D$/, "");
+      const [pm, ...pmArgs] = installCmd.split(" ");
+      console.log("  Upgrading React for RSC compatibility...");
+      execFileSync(pm, [...pmArgs, ...reactUpgrade], { cwd: process.cwd(), stdio: "inherit" });
+    }
+  }
 
   if (isApp) {
     // App Router: use createBuilder for multi-environment RSC builds


### PR DESCRIPTION
**#185 — Add React version check to `vinext build` for App Router compatibility**

**Summary**
- Mirror the `getReactUpgradeDeps()` check from `vinext deploy` into `buildApp()`, ensuring React is upgraded to `≥19.2.4` before any App Router build
- Closes the silent failure path where users running `vinext build` + `wrangler deploy` manually would hit a cryptic `moduleMap` crash at runtime with `react@19.2.0`

**Details**

**Root cause**
`vinext deploy` already guarded against `react-server-dom-webpack` compatibility issues via `getReactUpgradeDeps()`, but `vinext build` had no equivalent check. Users who bypassed `vinext deploy` and ran the build + deploy steps manually fell through this gap with no warning.

**Failing behavior (before)**
```
TypeError: Cannot read properties of undefined (reading 'moduleMap')
```
Triggered at runtime on deployed Workers when `react@19.2.0` was present — no build-time warning, no actionable error.

**Changes**
- `buildApp()` — added `getReactUpgradeDeps()` call before the App Router build step; React `<19.2.4` is now automatically upgraded at build time, matching the behaviour already present in `vinext deploy`

**What's not changed**
- No changes to `vinext deploy` logic — the existing check there is unchanged
- No new dependencies introduced

**Closes**
`moduleMap` runtime error on deployed Workers (`react@19.2.0`)