### PR TITLE
Run safe CI for external contributors, add /deploy-preview slash command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,16 +3,14 @@ name: CI
 on:
   push:
     branches: [main]
-  # pull_request_target runs automatically for fork PRs (no approval needed)
-  # while still using the base branch's workflow definition for security.
-  pull_request_target:
+  pull_request:
     branches: [main]
 
 permissions:
   contents: read
 
 concurrency:
-  group: ci-${{ github.event.pull_request.number || github.ref }}
+  group: ci-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -21,8 +19,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
@@ -36,8 +32,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
@@ -51,8 +45,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
@@ -77,8 +69,6 @@ jobs:
           - cloudflare-workers
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/deploy-examples.yml
+++ b/.github/workflows/deploy-examples.yml
@@ -8,6 +8,9 @@ on:
 
 jobs:
   deploy:
+    # Skip entirely for fork PRs — they don't have access to deploy secrets.
+    # Use /deploy-preview slash command for fork PRs instead.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     name: Deploy ${{ matrix.example.name }}
     runs-on: ubuntu-latest
     permissions:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,14 +202,13 @@ If you're trying to understand how something works under the hood — route matc
 
 CI is split into safe checks (no secrets) and deploy previews (requires secrets). This lets external contributors get feedback on their PRs without exposing credentials.
 
-**Safe CI (`ci.yml`)** runs automatically for all PRs, including forks:
+**Safe CI (`ci.yml`)** runs for all PRs after first-time contributor approval:
 - Lint, Typecheck, Vitest, Playwright E2E
-- Uses `pull_request_target` so it runs without requiring approval for fork PRs
-- Checks out the PR's code via explicit `ref: github.event.pull_request.head.sha`
 - Uses zero secrets and read-only permissions
+- First-time contributors need one manual approval, then subsequent PRs run automatically
 
 **Deploy previews (`deploy-examples.yml`)** run automatically only for same-repo branches:
-- The deploy steps check `github.event.pull_request.head.repo.full_name == github.repository`
+- The entire workflow is skipped for fork PRs via a job-level `if` condition
 - Cloudflare employees should push branches to the main repo (not fork), so previews deploy automatically
 - For fork PRs, a maintainer can comment `/deploy-preview` to trigger the deploy (see `deploy-preview-command.yml`)
 
@@ -220,8 +219,8 @@ CI is split into safe checks (no secrets) and deploy previews (requires secrets)
 
 When modifying CI workflows, keep these rules in mind:
 - `ci.yml` must never use secrets. It runs untrusted code from forks.
-- Deploy workflows gate secret usage behind the fork check or the `author_association` check.
-- The `pull_request_target` trigger uses the workflow definition from the base branch, not the PR. Changes to the workflow file itself require merging to main before they take effect on future PRs.
+- `deploy-examples.yml` must skip entirely for fork PRs. Don't remove the job-level `if` guard.
+- The `/deploy-preview` slash command gates secret usage behind the `author_association` check.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -499,9 +499,9 @@ This project is experimental and under active development. Issues and PRs are we
 
 ### CI
 
-When you open a PR, CI runs automatically, even from forks. The safe checks (lint, typecheck, Vitest, Playwright E2E) use no secrets and require no approval. You'll get feedback on your PR without any manual intervention.
+When you open a PR, CI (lint, typecheck, Vitest, Playwright E2E) runs automatically. First-time contributors need one manual approval from a maintainer, then subsequent PRs run without intervention.
 
-Deploy previews (building and deploying examples to Cloudflare Workers) only run automatically for branches pushed to the main repo. If you're a Cloudflare employee, push your branch to the main repo instead of forking, and previews will deploy automatically. For fork PRs, a maintainer can comment `/deploy-preview` to trigger the deploy and post preview URLs.
+Deploy previews (building and deploying examples to Cloudflare Workers) only run for branches pushed to the main repo. If you're a Cloudflare employee, push your branch to the main repo instead of forking, and previews deploy automatically. For fork PRs, a maintainer can comment `/deploy-preview` to trigger the deploy and post preview URLs.
 
 ### Reporting bugs
 


### PR DESCRIPTION
## Summary

- Skip `deploy-examples.yml` entirely for fork PRs via a job-level `if` condition. This is the main fix: no more noisy failed/skipped deploy checks on external contributor PRs.
- Add a `/deploy-preview` slash command workflow (`deploy-preview-command.yml`) that lets maintainers trigger deploy previews on fork PRs. Gated by `author_association` (org members, collaborators, repo owners).
- `ci.yml` is unchanged. It uses no secrets and runs for all PRs. First-time contributors need one manual approval, then subsequent PRs run automatically.
- Cloudflare employees who push branches to the main repo continue to get automatic deploy previews via the existing `deploy-examples.yml`.
- Document the CI setup in both AGENTS.md and README.md.

## How it works

| Contributor type | Safe CI (lint, typecheck, tests) | Deploy previews |
|---|---|---|
| Cloudflare employee (branch on main repo) | Automatic | Automatic |
| External contributor (fork, first PR) | One-time approval | Maintainer comments `/deploy-preview` |
| External contributor (fork, subsequent PRs) | Automatic | Maintainer comments `/deploy-preview` |