### PR TITLE
test: add Pages Router has/missing header condition coverage

### DIFF
--- a/tests/fixtures/pages-basic/next.config.mjs
+++ b/tests/fixtures/pages-basic/next.config.mjs
@@ -45,6 +45,18 @@ const nextConfig = {
           },
         ],
       },
+      // Used by Vitest: pages-router.test.ts — has/missing conditions on headers
+      // Ported from PR #47 by @ibruno
+      {
+        source: "/about",
+        has: [{ type: "cookie", key: "logged-in" }],
+        headers: [{ key: "X-Auth-Only-Header", value: "1" }],
+      },
+      {
+        source: "/about",
+        missing: [{ type: "cookie", key: "logged-in" }],
+        headers: [{ key: "X-Guest-Only-Header", value: "1" }],
+      },
     ];
   },
 };

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -236,6 +236,21 @@ describe("Pages Router integration", () => {
     expect(res.headers.get("x-custom-header")).toBe("vinext");
   });
 
+  // Ported from PR #47 by @ibruno
+  it("applies has/missing conditions for next.config.js headers", async () => {
+    const guestRes = await fetch(`${baseUrl}/about`);
+    expect(guestRes.status).toBe(200);
+    expect(guestRes.headers.get("x-guest-only-header")).toBe("1");
+    expect(guestRes.headers.get("x-auth-only-header")).toBeNull();
+
+    const authRes = await fetch(`${baseUrl}/about`, {
+      headers: { Cookie: "logged-in=1" },
+    });
+    expect(authRes.status).toBe(200);
+    expect(authRes.headers.get("x-auth-only-header")).toBe("1");
+    expect(authRes.headers.get("x-guest-only-header")).toBeNull();
+  });
+
   it("applies beforeFiles rewrites from next.config.js", async () => {
     const res = await fetch(`${baseUrl}/before-rewrite`);
     expect(res.status).toBe(200);
@@ -1320,6 +1335,21 @@ describe("Production server next.config.js features (Pages Router)", () => {
     const res = await fetch(`${prodUrl}/api/hello`);
     expect(res.status).toBe(200);
     expect(res.headers.get("x-custom-header")).toBe("vinext");
+  });
+
+  // Ported from PR #47 by @ibruno
+  it("applies has/missing conditions for next.config.js headers", async () => {
+    const guestRes = await fetch(`${prodUrl}/about`);
+    expect(guestRes.status).toBe(200);
+    expect(guestRes.headers.get("x-guest-only-header")).toBe("1");
+    expect(guestRes.headers.get("x-auth-only-header")).toBeNull();
+
+    const authRes = await fetch(`${prodUrl}/about`, {
+      headers: { Cookie: "logged-in=1" },
+    });
+    expect(authRes.status).toBe(200);
+    expect(authRes.headers.get("x-auth-only-header")).toBe("1");
+    expect(authRes.headers.get("x-guest-only-header")).toBeNull();
   });
 
   it("serves normal pages unaffected by config rules", async () => {


### PR DESCRIPTION
## Summary

- Adds integration tests for `has`/`missing` conditions on `next.config.js` headers in the Pages Router (dev + production servers)
- Adds corresponding fixture config in `pages-basic/next.config.mjs`

The implementation was merged in #48 but lacked Pages Router-specific test coverage. These tests were ported from #47 by @ibruno.

Closes #47