### PR TITLE
fix: use exact heading locator in next/dynamic E2E to fix flaky test

### DIFF
--- a/tests/e2e/pages-router/head-and-dynamic.spec.ts
+++ b/tests/e2e/pages-router/head-and-dynamic.spec.ts
@@ -38,14 +38,18 @@ test.describe("next/dynamic", () => {
 
     await expect(page.locator("h1")).toHaveText("Dynamic Import Page");
     // The heavy component should be SSR-rendered (ssr: true by default)
-    await expect(page.locator("text=Heavy Component")).toBeVisible();
+    await expect(
+      page.getByRole("heading", { level: 2, name: "Heavy Component" }),
+    ).toBeVisible();
   });
 
   test("dynamically imported component is interactive after hydration", async ({ page }) => {
     await page.goto(`${BASE}/dynamic-page`);
 
     await expect(page.locator("h1")).toHaveText("Dynamic Import Page");
-    await expect(page.locator("text=Heavy Component")).toBeVisible();
+    await expect(
+      page.getByRole("heading", { level: 2, name: "Heavy Component" }),
+    ).toBeVisible();
     await expect(page.locator("text=Loaded dynamically")).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary

- Replaces ambiguous `text=Heavy Component` locator with `getByRole("heading", { level: 2, name: "Heavy Component" })` in the pages-router `next/dynamic` E2E tests
- Prevents false matches when the text appears in multiple elements on the page

Extracted from #134 by @erayack.