### PR TITLE
fix: use function form of glob exclude for Node < 22.14 compat

### DIFF
--- a/packages/vinext/src/routing/app-router.ts
+++ b/packages/vinext/src/routing/app-router.ts
@@ -123,13 +123,14 @@ export async function appRouter(appDir: string): Promise<AppRoute[]> {
   const routes: AppRoute[] = [];
 
   // Process page files in a single pass
-  for await (const file of glob("**/page.{tsx,ts,jsx,js}", { cwd: appDir, exclude: ["**/@*"] })) {
+  // Use function form of exclude for Node < 22.14 compatibility (string arrays require >= 22.14)
+  for await (const file of glob("**/page.{tsx,ts,jsx,js}", { cwd: appDir, exclude: (name: string) => name.startsWith("@") })) {
     const route = fileToAppRoute(file, appDir, "page");
     if (route) routes.push(route);
   }
 
   // Process route handler files (API routes) in a single pass
-  for await (const file of glob("**/route.{tsx,ts,jsx,js}", { cwd: appDir, exclude: ["**/@*"] })) {
+  for await (const file of glob("**/route.{tsx,ts,jsx,js}", { cwd: appDir, exclude: (name: string) => name.startsWith("@") })) {
     const route = fileToAppRoute(file, appDir, "route");
     if (route) routes.push(route);
   }

--- a/packages/vinext/src/routing/pages-router.ts
+++ b/packages/vinext/src/routing/pages-router.ts
@@ -51,7 +51,8 @@ export async function pagesRouter(pagesDir: string): Promise<Route[]> {
 async function scanPageRoutes(pagesDir: string): Promise<Route[]> {
   const routes: Route[] = [];
 
-  for await (const file of glob("**/*.{tsx,ts,jsx,js}", { cwd: pagesDir, exclude: ["api", "**/_*"] })) {
+  // Use function form of exclude for Node < 22.14 compatibility (string arrays require >= 22.14)
+  for await (const file of glob("**/*.{tsx,ts,jsx,js}", { cwd: pagesDir, exclude: (name: string) => name === "api" || name.startsWith("_") })) {
     const route = fileToRoute(file, pagesDir);
     if (route) routes.push(route);
   }


### PR DESCRIPTION
## Summary

- Switches `exclude` option on `node:fs/promises` glob from string arrays to function form in both `app-router.ts` and `pages-router.ts`
- String arrays for `exclude` require Node >= 22.14.0, but `engines` allows `>= 22`. Users on 22.0.0-22.13.x get `ERR_INVALID_ARG_TYPE` at runtime.
- The function form works on all Node >= 22.0.0

Extracted from #134 by @erayack.