### PR TITLE
fix: make RequestContext required on matchHeaders/matchRedirect/matchRewrite

### DIFF
--- a/packages/vinext/src/config/config-matchers.ts
+++ b/packages/vinext/src/config/config-matchers.ts
@@ -467,19 +467,19 @@ export function matchConfigPattern(
  * Apply redirect rules from next.config.js.
  * Returns the redirect info if a redirect was matched, or null.
  *
- * When `ctx` is provided, has/missing conditions on the redirect rules
- * are evaluated against the request context (cookies, headers, query, host).
+ * `ctx` provides the request context (cookies, headers, query, host) used
+ * to evaluate has/missing conditions. Next.js always has request context
+ * when evaluating redirects, so this parameter is required.
  */
 export function matchRedirect(
   pathname: string,
   redirects: NextRedirect[],
-  ctx?: RequestContext,
+  ctx: RequestContext,
 ): { destination: string; permanent: boolean } | null {
   for (const redirect of redirects) {
     const params = matchConfigPattern(pathname, redirect.source);
     if (params) {
-      // Check has/missing conditions if present and context is available
-      if (ctx && (redirect.has || redirect.missing)) {
+      if (redirect.has || redirect.missing) {
         if (!checkHasConditions(redirect.has, redirect.missing, ctx)) {
           continue;
         }
@@ -504,19 +504,19 @@ export function matchRedirect(
  * Apply rewrite rules from next.config.js.
  * Returns the rewritten URL or null if no rewrite matched.
  *
- * When `ctx` is provided, has/missing conditions on the rewrite rules
- * are evaluated against the request context (cookies, headers, query, host).
+ * `ctx` provides the request context (cookies, headers, query, host) used
+ * to evaluate has/missing conditions. Next.js always has request context
+ * when evaluating rewrites, so this parameter is required.
  */
 export function matchRewrite(
   pathname: string,
   rewrites: NextRewrite[],
-  ctx?: RequestContext,
+  ctx: RequestContext,
 ): string | null {
   for (const rewrite of rewrites) {
     const params = matchConfigPattern(pathname, rewrite.source);
     if (params) {
-      // Check has/missing conditions if present and context is available
-      if (ctx && (rewrite.has || rewrite.missing)) {
+      if (rewrite.has || rewrite.missing) {
         if (!checkHasConditions(rewrite.has, rewrite.missing, ctx)) {
           continue;
         }
@@ -670,22 +670,21 @@ export async function proxyExternalRequest(
  * Apply custom header rules from next.config.js.
  * Returns an array of { key, value } pairs to set on the response.
  *
- * `ctx` is optional for backward compatibility with existing callers.
- * When omitted, `has`/`missing` conditions are not evaluated.
+ * `ctx` provides the request context (cookies, headers, query, host) used
+ * to evaluate has/missing conditions. Next.js always has request context
+ * when evaluating headers, so this parameter is required.
  */
 export function matchHeaders(
   pathname: string,
   headers: NextHeader[],
-  ctx?: RequestContext,
+  ctx: RequestContext,
 ): Array<{ key: string; value: string }> {
   const result: Array<{ key: string; value: string }> = [];
   for (const rule of headers) {
     const escaped = escapeHeaderSource(rule.source);
     const sourceRegex = safeRegExp("^" + escaped + "$");
     if (sourceRegex && sourceRegex.test(pathname)) {
-      // When no request context is available, skip has/missing checks
-      // and apply all path-matched rules unconditionally (backward compat).
-      if (ctx && (rule.has || rule.missing)) {
+      if (rule.has || rule.missing) {
         if (!checkHasConditions(rule.has, rule.missing, ctx)) {
           continue;
         }

--- a/packages/vinext/src/deploy.ts
+++ b/packages/vinext/src/deploy.ts
@@ -598,7 +598,7 @@ export default {
 
       // ── 4. Apply custom headers from next.config.js ───────────────
       if (configHeaders.length) {
-        const matched = matchHeaders(resolvedPathname, configHeaders);
+        const matched = matchHeaders(resolvedPathname, configHeaders, reqCtx);
         for (const h of matched) {
           middlewareHeaders[h.key.toLowerCase()] = h.value;
         }

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -3443,7 +3443,7 @@ function applyRedirects(
   pathname: string,
   res: any,
   redirects: NextRedirect[],
-  ctx?: RequestContext,
+  ctx: RequestContext,
 ): boolean {
   const result = matchRedirect(pathname, redirects, ctx);
   if (result) {
@@ -3528,7 +3528,7 @@ async function proxyExternalRewriteNode(
 function applyRewrites(
   pathname: string,
   rewrites: NextRewrite[],
-  ctx?: RequestContext,
+  ctx: RequestContext,
 ): string | null {
   const dest = matchRewrite(pathname, rewrites, ctx);
   if (dest) {
@@ -3545,7 +3545,7 @@ function applyHeaders(
   pathname: string,
   res: any,
   headers: NextHeader[],
-  ctx?: RequestContext,
+  ctx: RequestContext,
 ): void {
   const matched = matchHeaders(pathname, headers, ctx);
   for (const header of matched) {

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -1961,15 +1961,16 @@ describe("middleware bypass prevention", () => {
     const headers = [
       { source: "/api/(.*)", headers: [{ key: "X-Custom", value: "true" }] },
     ];
+    const reqCtx = { headers: new Headers(), cookies: {}, query: new URLSearchParams(), host: "localhost" };
     // Decoded path should match
     const decoded = normalizePath(decodeURIComponent("/%61pi/hello"));
     expect(decoded).toBe("/api/hello");
-    const result = matchHeaders(decoded, headers);
+    const result = matchHeaders(decoded, headers, reqCtx);
     expect(result).toHaveLength(1);
     expect(result[0].key).toBe("X-Custom");
 
     // Raw encoded path must NOT match
-    const rawResult = matchHeaders("/%61pi/hello", headers);
+    const rawResult = matchHeaders("/%61pi/hello", headers, reqCtx);
     expect(rawResult).toHaveLength(0);
   });
 
@@ -3411,7 +3412,7 @@ describe("matchHeaders", () => {
     expect(matched).toEqual([{ key: "x-preview-header", value: "true" }]);
   });
 
-  it("keeps backward-compatible behavior when ctx is omitted", async () => {
+  it("skips conditional header rule when has condition is not met", async () => {
     const { matchHeaders } = await import(
       "../packages/vinext/src/config/config-matchers.js"
     );
@@ -3423,8 +3424,9 @@ describe("matchHeaders", () => {
       },
     ];
 
-    const matched = matchHeaders("/about", rules);
-    expect(matched).toEqual([{ key: "x-conditional-header", value: "enabled" }]);
+    // Request without the required header should not match
+    const matched = matchHeaders("/about", rules, makeCtx());
+    expect(matched).toEqual([]);
   });
 });
 
@@ -3678,6 +3680,8 @@ describe("proxyExternalRequest", () => {
 // matchRewrite + isExternalUrl integration (config-matchers)
 
 describe("matchRewrite with external URLs", () => {
+  const emptyCtx = { headers: new Headers(), cookies: {}, query: new URLSearchParams(), host: "localhost" };
+
   it("returns full external URL when destination is external", async () => {
     const { matchRewrite, isExternalUrl } = await import(
       "../packages/vinext/src/config/config-matchers.js"
@@ -3685,7 +3689,7 @@ describe("matchRewrite with external URLs", () => {
     const rewrites = [
       { source: "/ph/:path*", destination: "https://us.i.posthog.com/:path*" },
     ];
-    const result = matchRewrite("/ph/decide", rewrites);
+    const result = matchRewrite("/ph/decide", rewrites, emptyCtx);
     expect(result).toBe("https://us.i.posthog.com/decide");
     expect(isExternalUrl(result!)).toBe(true);
   });
@@ -3697,7 +3701,7 @@ describe("matchRewrite with external URLs", () => {
     const rewrites = [
       { source: "/ph/static/:path*", destination: "https://us-assets.i.posthog.com/static/:path*" },
     ];
-    const result = matchRewrite("/ph/static/array.js", rewrites);
+    const result = matchRewrite("/ph/static/array.js", rewrites, emptyCtx);
     expect(result).toBe("https://us-assets.i.posthog.com/static/array.js");
     expect(isExternalUrl(result!)).toBe(true);
   });
@@ -3709,7 +3713,7 @@ describe("matchRewrite with external URLs", () => {
     const rewrites = [
       { source: "/posts/:id", destination: "/blog/:id" },
     ];
-    const result = matchRewrite("/posts/hello", rewrites);
+    const result = matchRewrite("/posts/hello", rewrites, emptyCtx);
     expect(result).toBe("/blog/hello");
     expect(isExternalUrl(result!)).toBe(false);
   });
@@ -3760,6 +3764,8 @@ describe("sanitizeDestination", () => {
 // Catch-all redirect destination sanitization
 
 describe("open redirect prevention in catch-all redirects", () => {
+  const emptyCtx = { headers: new Headers(), cookies: {}, query: new URLSearchParams(), host: "localhost" };
+
   it("matchRedirect sanitizes decoded %2F that would produce //evil.com", async () => {
     const { matchRedirect } = await import(
       "../packages/vinext/src/config/config-matchers.js"
@@ -3771,7 +3777,7 @@ describe("open redirect prevention in catch-all redirects", () => {
     const redirects = [
       { source: "/old/:path*", destination: "/:path*", permanent: false },
     ];
-    const result = matchRedirect("/old/evil.com", redirects);
+    const result = matchRedirect("/old/evil.com", redirects, emptyCtx);
     expect(result).not.toBeNull();
     expect(result!.destination).toBe("/evil.com");
     // Verify it does NOT start with // (protocol-relative)
@@ -3786,7 +3792,7 @@ describe("open redirect prevention in catch-all redirects", () => {
       { source: "/old/:path*", destination: "/:path*", permanent: false },
     ];
     // Even if an already-decoded path somehow contains //, the sanitizer should handle it
-    const result = matchRedirect("/old//evil.com", redirects);
+    const result = matchRedirect("/old//evil.com", redirects, emptyCtx);
     expect(result).not.toBeNull();
     expect(result!.destination.startsWith("//")).toBe(false);
   });
@@ -3798,7 +3804,7 @@ describe("open redirect prevention in catch-all redirects", () => {
     const redirects = [
       { source: "/go/:path*", destination: "https://example.com/:path*", permanent: false },
     ];
-    const result = matchRedirect("/go/page", redirects);
+    const result = matchRedirect("/go/page", redirects, emptyCtx);
     expect(result).not.toBeNull();
     expect(result!.destination).toBe("https://example.com/page");
   });
@@ -3812,7 +3818,7 @@ describe("open redirect prevention in catch-all redirects", () => {
     ];
     // In the real request flow, the entry point decodes and normalizePath
     // collapses //. Test with already-decoded path.
-    const result = matchRewrite("/old/evil.com", rewrites);
+    const result = matchRewrite("/old/evil.com", rewrites, emptyCtx);
     expect(result).not.toBeNull();
     expect(result!).toBe("/evil.com");
     expect(result!.startsWith("//")).toBe(false);


### PR DESCRIPTION
## Summary

- Makes `ctx: RequestContext` a required parameter on `matchHeaders`, `matchRedirect`, and `matchRewrite` in `config-matchers.ts` (and their wrapper functions in `index.ts`)
- Fixes `deploy.ts` where `matchHeaders` was called without `reqCtx` (the only call site missing it)
- Updates tests to pass a minimal `RequestContext` instead of relying on the previously optional parameter

## Why

Next.js always has request context when evaluating `has`/`missing` conditions. There is no code path where these matchers run without a request. Making `ctx` required:

1. Eliminates the ambiguous "what if ctx is missing?" question (previously, conditional rules were silently applied without checking conditions)
2. Catches missing context at compile time instead of causing silent behavioral bugs at runtime
3. Matches Next.js semantics, where `matchHas()` takes `req` as a required parameter

Extracted from #134 by @erayack.