### PR TITLE
feat(images): support dangerouslyAllowSVG

### DIFF
--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -102,6 +102,12 @@ export interface NextConfig {
     deviceSizes?: number[];
     /** Allowed image sizes for fixed-width images. Defaults to Next.js defaults: [16, 32, 48, 64, 96, 128, 256, 384] */
     imageSizes?: number[];
+    /** Allow SVG images through the image optimization endpoint. SVG can contain scripts — only enable if you trust all image sources. */
+    dangerouslyAllowSVG?: boolean;
+    /** Content-Disposition header for image responses. Defaults to "inline". */
+    contentDispositionType?: 'inline' | 'attachment';
+    /** Content-Security-Policy header for image responses. Defaults to "script-src 'none'; frame-src 'none'; sandbox;" */
+    contentSecurityPolicy?: string;
   };
   /** Build output mode: 'export' for full static export, 'standalone' for single server */
   output?: "export" | "standalone";

--- a/packages/vinext/src/deploy.ts
+++ b/packages/vinext/src/deploy.ts
@@ -412,6 +412,11 @@ export default {
     // Image optimization via Cloudflare Images binding.
     // The parseImageParams validation inside handleImageOptimization
     // normalizes backslashes and validates the origin hasn't changed.
+    // To enable SVG support, pass a 4th argument with your image config:
+    //   handleImageOptimization(request, handlers, allowedWidths, {
+    //     dangerouslyAllowSVG: true,
+    //     contentSecurityPolicy: "script-src 'none'; frame-src 'none'; sandbox;",
+    //   })
     if (url.pathname === "/_vinext/image") {
       const allowedWidths = [...DEFAULT_DEVICE_SIZES, ...DEFAULT_IMAGE_SIZES];
       return handleImageOptimization(request, {
@@ -437,6 +442,7 @@ export function generatePagesRouterWorkerEntry(): string {
  * Edit freely or delete to regenerate on next deploy.
  */
 import { handleImageOptimization, DEFAULT_DEVICE_SIZES, DEFAULT_IMAGE_SIZES } from "vinext/server/image-optimization";
+import type { ImageConfig } from "vinext/server/image-optimization";
 import {
   matchRedirect,
   matchRewrite,
@@ -466,6 +472,11 @@ const trailingSlash: boolean = vinextConfig?.trailingSlash ?? false;
 const configRedirects = vinextConfig?.redirects ?? [];
 const configRewrites = vinextConfig?.rewrites ?? { beforeFiles: [], afterFiles: [], fallback: [] };
 const configHeaders = vinextConfig?.headers ?? [];
+const imageConfig: ImageConfig | undefined = vinextConfig?.images ? {
+  dangerouslyAllowSVG: vinextConfig.images.dangerouslyAllowSVG,
+  contentDispositionType: vinextConfig.images.contentDispositionType,
+  contentSecurityPolicy: vinextConfig.images.contentSecurityPolicy,
+} : undefined;
 
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
@@ -498,7 +509,7 @@ export default {
             const result = await env.IMAGES.input(body).transform(width > 0 ? { width } : {}).output({ format, quality });
             return result.response();
           },
-        }, allowedWidths);
+        }, allowedWidths, imageConfig);
       }
 
       // ── 2. Trailing slash normalization ────────────────────────────

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -655,6 +655,13 @@ export default function vinext(options: VinextOptions = {}): Plugin[] {
       rewrites: nextConfig?.rewrites ?? { beforeFiles: [], afterFiles: [], fallback: [] },
       headers: nextConfig?.headers ?? [],
       i18n: nextConfig?.i18n ?? null,
+      images: {
+        deviceSizes: nextConfig?.images?.deviceSizes,
+        imageSizes: nextConfig?.images?.imageSizes,
+        dangerouslyAllowSVG: nextConfig?.images?.dangerouslyAllowSVG,
+        contentDispositionType: nextConfig?.images?.contentDispositionType,
+        contentSecurityPolicy: nextConfig?.images?.contentSecurityPolicy,
+      },
     });
 
     // Generate middleware code if middleware.ts exists
@@ -3113,6 +3120,36 @@ hydrate();
           } catch {
             // @vercel/og not installed — nothing to copy
           }
+        },
+      },
+    },
+    // Write image config JSON for the App Router production server.
+    // The App Router RSC entry doesn't export vinextConfig, so we write a
+    // separate JSON file at build time that prod-server.ts reads at startup.
+    {
+      name: "vinext:image-config",
+      apply: "build",
+      enforce: "post",
+      writeBundle: {
+        sequential: true,
+        order: "post",
+        handler(options) {
+          const envName = this.environment?.name;
+          if (envName !== "rsc") return;
+
+          const outDir = options.dir;
+          if (!outDir) return;
+
+          const imageConfig = {
+            dangerouslyAllowSVG: nextConfig?.images?.dangerouslyAllowSVG,
+            contentDispositionType: nextConfig?.images?.contentDispositionType,
+            contentSecurityPolicy: nextConfig?.images?.contentSecurityPolicy,
+          };
+
+          fs.writeFileSync(
+            path.join(outDir, "image-config.json"),
+            JSON.stringify(imageConfig),
+          );
         },
       },
     },

--- a/packages/vinext/src/server/image-optimization.ts
+++ b/packages/vinext/src/server/image-optimization.ts
@@ -19,6 +19,16 @@
 export const IMAGE_OPTIMIZATION_PATH = "/_vinext/image";
 
 /**
+ * Image security configuration from next.config.js.
+ * Controls SVG handling and security headers for the image endpoint.
+ */
+export interface ImageConfig {
+  dangerouslyAllowSVG?: boolean;
+  contentDispositionType?: 'inline' | 'attachment';
+  contentSecurityPolicy?: string;
+}
+
+/**
  * Next.js default device sizes and image sizes.
  * These are the allowed widths for image optimization when no custom
  * config is provided. Matches Next.js defaults exactly.
@@ -131,12 +141,15 @@ const SAFE_IMAGE_CONTENT_TYPES = new Set([
 /**
  * Check if a Content-Type header value is a safe image type.
  * Returns false for SVG, HTML, or any non-image type.
+ * When `dangerouslyAllowSVG` is true, also accepts "image/svg+xml".
  */
-export function isSafeImageContentType(contentType: string | null): boolean {
+export function isSafeImageContentType(contentType: string | null, dangerouslyAllowSVG = false): boolean {
   if (!contentType) return false;
   // Extract the media type, ignoring parameters (e.g., charset)
   const mediaType = contentType.split(";")[0].trim().toLowerCase();
-  return SAFE_IMAGE_CONTENT_TYPES.has(mediaType);
+  if (SAFE_IMAGE_CONTENT_TYPES.has(mediaType)) return true;
+  if (dangerouslyAllowSVG && mediaType === "image/svg+xml") return true;
+  return false;
 }
 
 /**
@@ -144,10 +157,10 @@ export function isSafeImageContentType(contentType: string | null): boolean {
  * These headers are set on every response from the image endpoint,
  * regardless of whether the image was transformed or served as-is.
  */
-function setImageSecurityHeaders(headers: Headers): void {
-  headers.set("Content-Security-Policy", IMAGE_CONTENT_SECURITY_POLICY);
+function setImageSecurityHeaders(headers: Headers, config?: ImageConfig): void {
+  headers.set("Content-Security-Policy", config?.contentSecurityPolicy ?? IMAGE_CONTENT_SECURITY_POLICY);
   headers.set("X-Content-Type-Options", "nosniff");
-  headers.set("Content-Disposition", "inline");
+  headers.set("Content-Disposition", config?.contentDispositionType ?? "inline");
 }
 
 /**
@@ -175,6 +188,7 @@ export async function handleImageOptimization(
   request: Request,
   handlers: ImageHandlers,
   allowedWidths?: number[],
+  imageConfig?: ImageConfig,
 ): Promise<Response> {
   const url = new URL(request.url);
   const params = parseImageParams(url, allowedWidths);
@@ -198,8 +212,19 @@ export async function handleImageOptimization(
   // Check the source Content-Type before any processing — if the source is
   // an SVG or other non-image type, reject it regardless of transformation.
   const sourceContentType = source.headers.get("Content-Type");
-  if (!isSafeImageContentType(sourceContentType)) {
+  if (!isSafeImageContentType(sourceContentType, imageConfig?.dangerouslyAllowSVG)) {
     return new Response("The requested resource is not an allowed image type", { status: 400 });
+  }
+
+  // SVG passthrough: SVG is a vector format, transformation provides no benefit.
+  // Serve as-is with security headers (matches Next.js behavior).
+  const sourceMediaType = sourceContentType?.split(";")[0].trim().toLowerCase();
+  if (sourceMediaType === "image/svg+xml") {
+    const headers = new Headers(source.headers);
+    headers.set("Cache-Control", IMAGE_CACHE_CONTROL);
+    headers.set("Vary", "Accept");
+    setImageSecurityHeaders(headers, imageConfig);
+    return new Response(source.body, { status: 200, headers });
   }
 
   // Transform if handler provided, otherwise serve original
@@ -213,11 +238,11 @@ export async function handleImageOptimization(
       const headers = new Headers(transformed.headers);
       headers.set("Cache-Control", IMAGE_CACHE_CONTROL);
       headers.set("Vary", "Accept");
-      setImageSecurityHeaders(headers);
+      setImageSecurityHeaders(headers, imageConfig);
 
       // Verify the transformed response also has a safe Content-Type.
       // A malicious or buggy transform handler could return HTML.
-      if (!isSafeImageContentType(headers.get("Content-Type"))) {
+      if (!isSafeImageContentType(headers.get("Content-Type"), imageConfig?.dangerouslyAllowSVG)) {
         headers.set("Content-Type", format);
       }
 
@@ -232,6 +257,6 @@ export async function handleImageOptimization(
   const headers = new Headers(source.headers);
   headers.set("Cache-Control", IMAGE_CACHE_CONTROL);
   headers.set("Vary", "Accept");
-  setImageSecurityHeaders(headers);
+  setImageSecurityHeaders(headers, imageConfig);
   return new Response(source.body, { status: 200, headers });
 }

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -25,7 +25,7 @@ import path from "node:path";
 import zlib from "node:zlib";
 import { matchRedirect, matchRewrite, matchHeaders, requestContextFromRequest, isExternalUrl, proxyExternalRequest, sanitizeDestination } from "../config/config-matchers.js";
 import type { RequestContext } from "../config/config-matchers.js";
-import { IMAGE_OPTIMIZATION_PATH, IMAGE_CONTENT_SECURITY_POLICY, parseImageParams, isSafeImageContentType, DEFAULT_DEVICE_SIZES, DEFAULT_IMAGE_SIZES } from "./image-optimization.js";
+import { IMAGE_OPTIMIZATION_PATH, IMAGE_CONTENT_SECURITY_POLICY, parseImageParams, isSafeImageContentType, DEFAULT_DEVICE_SIZES, DEFAULT_IMAGE_SIZES, type ImageConfig } from "./image-optimization.js";
 import { normalizePath } from "./normalize-path.js";
 import { computeLazyChunks } from "../index.js";
 
@@ -466,6 +466,15 @@ interface AppRouterServerOptions {
 async function startAppRouterServer(options: AppRouterServerOptions) {
   const { port, host, clientDir, rscEntryPath, compress } = options;
 
+  // Load image config written at build time by vinext:image-config plugin
+  let imageConfig: ImageConfig | undefined;
+  const imageConfigPath = path.join(path.dirname(rscEntryPath), "image-config.json");
+  if (fs.existsSync(imageConfigPath)) {
+    try {
+      imageConfig = JSON.parse(fs.readFileSync(imageConfigPath, "utf-8"));
+    } catch { /* ignore parse errors */ }
+  }
+
   // Import the RSC handler (use file:// URL for reliable dynamic import)
   const rscModule = await import(pathToFileURL(rscEntryPath).href);
   const rscHandler: (request: Request) => Promise<Response> = rscModule.default;
@@ -517,16 +526,16 @@ async function startAppRouterServer(options: AppRouterServerOptions) {
       // This must happen before serving to prevent XSS via SVG passthrough.
       const ext = path.extname(params.imageUrl).toLowerCase();
       const ct = CONTENT_TYPES[ext] ?? "application/octet-stream";
-      if (!isSafeImageContentType(ct)) {
+      if (!isSafeImageContentType(ct, imageConfig?.dangerouslyAllowSVG)) {
         res.writeHead(400);
         res.end("The requested resource is not an allowed image type");
         return;
       }
       // Serve the original image with CSP and security headers
       const imageSecurityHeaders: Record<string, string> = {
-        "Content-Security-Policy": IMAGE_CONTENT_SECURITY_POLICY,
+        "Content-Security-Policy": imageConfig?.contentSecurityPolicy ?? IMAGE_CONTENT_SECURITY_POLICY,
         "X-Content-Type-Options": "nosniff",
-        "Content-Disposition": "inline",
+        "Content-Disposition": imageConfig?.contentDispositionType ?? "inline",
       };
       if (tryServeStatic(req, res, clientDir, params.imageUrl, false, imageSecurityHeaders)) {
         return;
@@ -622,6 +631,12 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
     ...(vinextConfig?.images?.deviceSizes ?? DEFAULT_DEVICE_SIZES),
     ...(vinextConfig?.images?.imageSizes ?? DEFAULT_IMAGE_SIZES),
   ];
+  // Extract image security config for SVG handling and security headers
+  const pagesImageConfig: ImageConfig | undefined = vinextConfig?.images ? {
+    dangerouslyAllowSVG: vinextConfig.images.dangerouslyAllowSVG,
+    contentDispositionType: vinextConfig.images.contentDispositionType,
+    contentSecurityPolicy: vinextConfig.images.contentSecurityPolicy,
+  } : undefined;
 
   const server = createServer(async (req, res) => {
     const rawUrl = req.url ?? "/";
@@ -677,15 +692,15 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
       // Block SVG and other unsafe content types
       const ext = path.extname(params.imageUrl).toLowerCase();
       const ct = CONTENT_TYPES[ext] ?? "application/octet-stream";
-      if (!isSafeImageContentType(ct)) {
+      if (!isSafeImageContentType(ct, pagesImageConfig?.dangerouslyAllowSVG)) {
         res.writeHead(400);
         res.end("The requested resource is not an allowed image type");
         return;
       }
       const imageSecurityHeaders: Record<string, string> = {
-        "Content-Security-Policy": IMAGE_CONTENT_SECURITY_POLICY,
+        "Content-Security-Policy": pagesImageConfig?.contentSecurityPolicy ?? IMAGE_CONTENT_SECURITY_POLICY,
         "X-Content-Type-Options": "nosniff",
-        "Content-Disposition": "inline",
+        "Content-Disposition": pagesImageConfig?.contentDispositionType ?? "inline",
       };
       if (tryServeStatic(req, res, clientDir, params.imageUrl, false, imageSecurityHeaders)) {
         return;

--- a/packages/vinext/src/shims/image.tsx
+++ b/packages/vinext/src/shims/image.tsx
@@ -281,7 +281,7 @@ const Image = forwardRef<HTMLImageElement, ImageProps>(function Image(
   // the Images binding. In dev, it serves the original file as a passthrough.
   // When `unoptimized` is true, bypass the endpoint entirely (Next.js compat).
   const imgQuality = quality ?? 75;
-  const skipOptimization = _unoptimized === true;
+  const skipOptimization = _unoptimized === true || src.endsWith(".svg");
 
   // Build srcSet for responsive local images (common breakpoints).
   // Each entry points to /_vinext/image with the appropriate width.
@@ -393,7 +393,7 @@ export function getImageProps(props: ImageProps): {
 
   // For local images (no loader, not remote), route through optimization endpoint.
   // When `unoptimized` is true, bypass the endpoint entirely (Next.js compat).
-  const skipOpt = _unoptimized === true || blockedInProd || !!loader || isRemoteUrl(resolvedSrc);
+  const skipOpt = _unoptimized === true || resolvedSrc.endsWith(".svg") || blockedInProd || !!loader || isRemoteUrl(resolvedSrc);
   const optimizedSrc = skipOpt
     ? resolvedSrc
     : imgWidth

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -603,6 +603,22 @@ importers:
         specifier: ^7.0.0
         version: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.31.1)
 
+  tests/fixtures/svg-test:
+    dependencies:
+      react:
+        specifier: ^19.0.0
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.4(react@19.2.4)
+      vinext:
+        specifier: workspace:*
+        version: link:../../../packages/vinext
+    devDependencies:
+      vite:
+        specifier: ^7.0.0
+        version: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.31.1)
+
 packages:
 
   '@alloc/quick-lru@5.2.0':

--- a/tests/fixtures/svg-test/next-shims.d.ts
+++ b/tests/fixtures/svg-test/next-shims.d.ts
@@ -1,0 +1,182 @@
+/**
+ * Type declarations for next/* module shims.
+ *
+ * These are resolved at runtime via Vite's resolve.alias to our
+ * shim implementations. This file tells TypeScript they exist.
+ */
+
+declare module "next/head" {
+  import { ComponentType, ReactNode } from "react";
+  const Head: ComponentType<{ children?: ReactNode }>;
+  export default Head;
+  export function resetSSRHead(): void;
+  export function getSSRHeadHTML(): string;
+}
+
+declare module "next/link" {
+  import { ComponentType, AnchorHTMLAttributes, ReactNode } from "react";
+  interface LinkProps extends Omit<AnchorHTMLAttributes<HTMLAnchorElement>, "href"> {
+    href: string | { pathname?: string; query?: Record<string, string> };
+    as?: string;
+    replace?: boolean;
+    prefetch?: boolean;
+    passHref?: boolean;
+    scroll?: boolean;
+    locale?: string | false;
+    children?: ReactNode;
+  }
+  const Link: ComponentType<LinkProps>;
+  export default Link;
+}
+
+declare module "next/router" {
+  export function useRouter(): {
+    pathname: string;
+    route: string;
+    query: Record<string, string | string[]>;
+    asPath: string;
+    basePath: string;
+    isReady: boolean;
+    isPreview: boolean;
+    isFallback: boolean;
+    push(url: string | object, as?: string, options?: object): Promise<boolean>;
+    replace(url: string | object, as?: string, options?: object): Promise<boolean>;
+    back(): void;
+    reload(): void;
+    prefetch(url: string): Promise<void>;
+    events: {
+      on(event: string, handler: (...args: unknown[]) => void): void;
+      off(event: string, handler: (...args: unknown[]) => void): void;
+      emit(event: string, ...args: unknown[]): void;
+    };
+  };
+  export function setSSRContext(ctx: object | null): void;
+  const Router: {
+    push(url: string | object): Promise<boolean>;
+    replace(url: string | object): Promise<boolean>;
+    back(): void;
+    reload(): void;
+    prefetch(url: string): Promise<void>;
+    events: {
+      on(event: string, handler: (...args: unknown[]) => void): void;
+      off(event: string, handler: (...args: unknown[]) => void): void;
+      emit(event: string, ...args: unknown[]): void;
+    };
+  };
+  export default Router;
+}
+
+declare module "next/image" {
+  import { ComponentType } from "react";
+  interface ImageProps {
+    src: string | { src: string; height: number; width: number; blurDataURL?: string };
+    alt: string;
+    width?: number;
+    height?: number;
+    fill?: boolean;
+    priority?: boolean;
+    quality?: number;
+    placeholder?: "blur" | "empty";
+    blurDataURL?: string;
+    sizes?: string;
+    className?: string;
+    style?: React.CSSProperties;
+    loading?: "lazy" | "eager";
+    [key: string]: unknown;
+  }
+  const Image: ComponentType<ImageProps>;
+  export default Image;
+}
+
+declare module "next/dynamic" {
+  import { ComponentType } from "react";
+  interface DynamicOptions {
+    loading?: ComponentType<{ error?: Error | null; isLoading?: boolean; pastDelay?: boolean }>;
+    ssr?: boolean;
+  }
+  function dynamic<P extends object = object>(
+    loader: () => Promise<{ default: ComponentType<P> } | ComponentType<P>>,
+    options?: DynamicOptions,
+  ): ComponentType<P>;
+  export default dynamic;
+  export function flushPreloads(): Promise<void[]>;
+}
+
+declare module "next/app" {
+  import { ComponentType } from "react";
+  export interface AppProps {
+    Component: ComponentType<any>;
+    pageProps: Record<string, unknown>;
+  }
+}
+
+declare module "next" {
+  import type { IncomingMessage, ServerResponse } from "node:http";
+  export interface NextApiRequest extends IncomingMessage {
+    query: Record<string, string | string[]>;
+    body: unknown;
+    cookies: Record<string, string>;
+  }
+  export interface NextApiResponse<T = unknown> extends ServerResponse {
+    status(code: number): NextApiResponse<T>;
+    json(data: T): void;
+    send(data: T): void;
+    redirect(statusOrUrl: number | string, url?: string): void;
+  }
+}
+
+declare module "next/document" {
+  import { ComponentType, ReactNode } from "react";
+  export const Html: ComponentType<{ lang?: string; children?: ReactNode; [key: string]: unknown }>;
+  export const Head: ComponentType<{ children?: ReactNode }>;
+  export const Main: ComponentType;
+  export const NextScript: ComponentType;
+}
+
+declare module "next/config" {
+  interface RuntimeConfig {
+    serverRuntimeConfig: Record<string, unknown>;
+    publicRuntimeConfig: Record<string, unknown>;
+  }
+  export default function getConfig(): RuntimeConfig;
+  export function setConfig(configValue: RuntimeConfig): void;
+}
+
+declare module "next/script" {
+  import { ReactElement } from "react";
+  interface ScriptProps {
+    src?: string;
+    strategy?: "beforeInteractive" | "afterInteractive" | "lazyOnload" | "worker";
+    id?: string;
+    onLoad?: (e: Event) => void;
+    onReady?: () => void;
+    onError?: (e: Event) => void;
+    children?: React.ReactNode;
+    dangerouslySetInnerHTML?: { __html: string };
+    [key: string]: unknown;
+  }
+  const Script: (props: ScriptProps) => ReactElement | null;
+  export default Script;
+  export { ScriptProps };
+  export function handleClientScriptLoad(props: ScriptProps): void;
+  export function initScriptLoader(scripts: ScriptProps[]): void;
+}
+
+declare module "next/server" {
+  export class NextRequest extends Request {
+    get nextUrl(): any;
+    get cookies(): any;
+  }
+  export class NextResponse<Body = unknown> extends Response {
+    get cookies(): any;
+    static json<T>(body: T, init?: ResponseInit): NextResponse<T>;
+    static redirect(url: string | URL, init?: number | ResponseInit): NextResponse;
+    static rewrite(destination: string | URL, init?: ResponseInit): NextResponse;
+    static next(init?: ResponseInit): NextResponse;
+  }
+  export function userAgent(req: { headers: Headers }): any;
+  export function userAgentFromString(ua: string | undefined): any;
+  export function after<T>(task: Promise<T> | (() => T | Promise<T>)): void;
+  export function connection(): Promise<void>;
+  export type NextMiddleware = (request: NextRequest, event: any) => any;
+}

--- a/tests/fixtures/svg-test/next.config.mjs
+++ b/tests/fixtures/svg-test/next.config.mjs
@@ -1,0 +1,2 @@
+/** @type {import('next').NextConfig} */
+export default {};

--- a/tests/fixtures/svg-test/package.json
+++ b/tests/fixtures/svg-test/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "fixture-svg-test",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "vinext": "workspace:*"
+  },
+  "devDependencies": {
+    "vite": "^7.0.0"
+  }
+}

--- a/tests/fixtures/svg-test/pages/_app.tsx
+++ b/tests/fixtures/svg-test/pages/_app.tsx
@@ -1,0 +1,5 @@
+import type { AppProps } from "next/app";
+
+export default function App({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}

--- a/tests/fixtures/svg-test/pages/index.tsx
+++ b/tests/fixtures/svg-test/pages/index.tsx
@@ -1,0 +1,63 @@
+import Image from "next/image";
+import Head from "next/head";
+
+export default function SvgTestPage() {
+  return (
+    <div style={{ fontFamily: "system-ui, sans-serif", padding: "2rem", maxWidth: 800, margin: "0 auto" }}>
+      <Head>
+        <title>SVG Image Test — vinext</title>
+      </Head>
+
+      <h1>SVG Image Optimization Test</h1>
+      <p style={{ color: "#666" }}>
+        This page tests whether SVG images can be served through the{" "}
+        <code style={{ background: "#f0f0f0", padding: "2px 6px", borderRadius: 4 }}>/_vinext/image</code> endpoint.
+      </p>
+
+      <hr style={{ margin: "2rem 0" }} />
+
+      <h2>1. SVG via next/image (through /_vinext/image)</h2>
+      <p>
+        If <code>dangerouslyAllowSVG</code> is <b>not</b> set → <b style={{ color: "red" }}>broken image</b> (400 error).<br />
+        If <code>dangerouslyAllowSVG: true</code> → <b style={{ color: "green" }}>renders correctly</b>.
+      </p>
+      <div style={{ border: "2px dashed #ccc", padding: "1rem", borderRadius: 8, display: "inline-block", background: "#fafafa" }}>
+        <Image
+          src="/logo.svg"
+          alt="vinext logo (SVG via next/image)"
+          width={256}
+          height={256}
+        />
+      </div>
+
+      <hr style={{ margin: "2rem 0" }} />
+
+      <h2>2. SVG via plain &lt;img&gt; (direct, no optimization)</h2>
+      <p>This always works — it bypasses the image optimization endpoint entirely.</p>
+      <div style={{ border: "2px dashed #ccc", padding: "1rem", borderRadius: 8, display: "inline-block", background: "#fafafa" }}>
+        <img src="/logo.svg" alt="vinext logo (direct img)" width={256} height={256} />
+      </div>
+
+      <hr style={{ margin: "2rem 0" }} />
+
+      <h2>3. JPEG via next/image (always works)</h2>
+      <p>JPEG is always allowed, regardless of SVG config.</p>
+      <div style={{ border: "2px dashed #ccc", padding: "1rem", borderRadius: 8, display: "inline-block", background: "#fafafa" }}>
+        <Image
+          src="/photo.jpg"
+          alt="photo (JPEG via next/image)"
+          width={128}
+          height={128}
+        />
+      </div>
+
+      <hr style={{ margin: "2rem 0" }} />
+      <h2>How to check</h2>
+      <ol>
+        <li>Open <b>DevTools → Network</b> tab</li>
+        <li>Look for the request to <code>/_vinext/image?url=%2Flogo.svg...</code></li>
+        <li>Check its HTTP status code (200 = allowed, 400 = blocked)</li>
+      </ol>
+    </div>
+  );
+}

--- a/tests/fixtures/svg-test/public/logo.svg
+++ b/tests/fixtures/svg-test/public/logo.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200">
+  <rect width="200" height="200" rx="20" fill="#1a1a2e"/>
+  <text x="100" y="115" font-family="system-ui, sans-serif" font-size="72" font-weight="bold" fill="#e94560" text-anchor="middle">V</text>
+  <text x="100" y="170" font-family="system-ui, sans-serif" font-size="20" fill="#0f3460" text-anchor="middle">vinext</text>
+</svg>

--- a/tests/fixtures/svg-test/test-svg.sh
+++ b/tests/fixtures/svg-test/test-svg.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+#
+# End-to-end SVG test for vinext image optimization.
+#
+# Usage:
+#   ./test-svg.sh             — runs both phases automatically with curl checks
+#   ./test-svg.sh --manual    — builds, starts server, and waits for you to
+#                               open http://localhost:3456 in a browser
+#
+# What it does:
+#   Phase 1: Builds WITHOUT dangerouslyAllowSVG → SVG returns 400 (blocked)
+#   Phase 2: Builds WITH    dangerouslyAllowSVG → SVG returns 200 (allowed)
+#
+set -uo pipefail
+cd "$(dirname "$0")"
+
+VINEXT_CLI="../../../packages/vinext/dist/cli.js"
+PORT_PHASE1=3461
+PORT_PHASE2=3462
+MANUAL="${1:-}"
+
+bold="\033[1m"
+dim="\033[2m"
+red="\033[31m"
+green="\033[32m"
+yellow="\033[33m"
+cyan="\033[36m"
+reset="\033[0m"
+
+SERVER_PID=""
+
+cleanup() {
+  if [[ -n "$SERVER_PID" ]]; then
+    kill "$SERVER_PID" 2>/dev/null || true
+    wait "$SERVER_PID" 2>/dev/null || true
+    SERVER_PID=""
+  fi
+}
+trap cleanup EXIT
+
+wait_for_server() {
+  local port="$1"
+  for _ in $(seq 1 40); do
+    if curl -s -o /dev/null "http://localhost:$port/" 2>/dev/null; then
+      return 0
+    fi
+    sleep 0.25
+  done
+  echo -e "  ${red}Server failed to start on port $port!${reset}"
+  return 1
+}
+
+passed=0
+failed=0
+
+check() {
+  local label="$1"
+  local condition="$2"  # "eq" or "contains"
+  local actual="$3"
+  local expected="$4"
+
+  local ok=false
+  if [[ "$condition" == "eq" && "$actual" == "$expected" ]]; then ok=true; fi
+  if [[ "$condition" == "contains" && "$actual" == *"$expected"* ]]; then ok=true; fi
+
+  if $ok; then
+    echo -e "  ${green}✅ PASS${reset}  $label"
+    passed=$((passed + 1))
+  else
+    echo -e "  ${red}❌ FAIL${reset}  $label"
+    echo -e "         got:      \"$(echo "$actual" | head -1)\""
+    echo -e "         expected: \"$expected\""
+    failed=$((failed + 1))
+  fi
+}
+
+run_phase() {
+  local phase_label="$1"
+  local svg_allowed="$2"  # "true" or "false"
+  local port="$3"
+
+  echo ""
+  echo -e "${bold}═══════════════════════════════════════════════════════════════${reset}"
+  echo -e "${bold}  $phase_label${reset}"
+  echo -e "${bold}═══════════════════════════════════════════════════════════════${reset}"
+
+  # ── Write next.config.mjs ──
+  if [[ "$svg_allowed" == "true" ]]; then
+    cat > next.config.mjs << 'CONF'
+/** @type {import('next').NextConfig} */
+export default {
+  images: {
+    dangerouslyAllowSVG: true,
+    contentSecurityPolicy: "script-src 'none'; frame-src 'none'; sandbox;",
+  },
+};
+CONF
+    echo -e "\n  ${cyan}next.config.mjs:${reset}"
+    echo -e "    ${yellow}images.dangerouslyAllowSVG: true${reset}"
+  else
+    cat > next.config.mjs << 'CONF'
+/** @type {import('next').NextConfig} */
+export default {};
+CONF
+    echo -e "\n  ${cyan}next.config.mjs:${reset}"
+    echo -e "    ${dim}(no images config — SVG blocked by default)${reset}"
+  fi
+
+  # ── Build ──
+  echo -e "\n  Building..."
+  node "$VINEXT_CLI" build 2>&1 | grep -E "built in|Build complete" | while read -r line; do
+    echo -e "    ${dim}$line${reset}"
+  done
+
+  # ── Start prod server ──
+  echo -e "  Starting prod server on :$port..."
+  node "$VINEXT_CLI" start --port "$port" &>/dev/null &
+  SERVER_PID=$!
+  wait_for_server "$port"
+  echo ""
+
+  if [[ "$MANUAL" == "--manual" ]]; then
+    # ── Manual browser testing mode ──
+    echo -e "  ${green}${bold}Server is running!${reset}"
+    echo ""
+    echo -e "  Open in your browser:"
+    echo -e "    ${bold}${cyan}http://localhost:$port${reset}"
+    echo ""
+    echo -e "  What to look for:"
+    if [[ "$svg_allowed" == "true" ]]; then
+      echo -e "    Section 1 (SVG via next/image):  ${green}should render the logo${reset}"
+    else
+      echo -e "    Section 1 (SVG via next/image):  ${red}should show broken image${reset}"
+    fi
+    echo -e "    Section 2 (direct <img>):         ${green}always renders${reset}"
+    echo -e "    Section 3 (JPEG via next/image):  ${green}always renders${reset}"
+    echo ""
+    echo -e "  Also open ${bold}DevTools → Network${reset} tab:"
+    echo -e "    Look for ${cyan}/_vinext/image?url=%2Flogo.svg${reset}"
+    if [[ "$svg_allowed" == "true" ]]; then
+      echo -e "    Expected status: ${green}200${reset}"
+    else
+      echo -e "    Expected status: ${red}400${reset}"
+    fi
+    echo ""
+    echo -e "  Press ${bold}Enter${reset} when done observing..."
+    read -r
+  else
+    # ── Automated curl testing mode ──
+    local expect_svg
+    if [[ "$svg_allowed" == "true" ]]; then expect_svg="200"; else expect_svg="400"; fi
+
+    # Test 1: SVG through image optimization
+    local svg_status
+    svg_status=$(curl -s -o /dev/null -w "%{http_code}" \
+      "http://localhost:$port/_vinext/image?url=%2Flogo.svg&w=640&q=75")
+    check "SVG via /_vinext/image → HTTP $expect_svg" eq "$svg_status" "$expect_svg"
+
+    # Test 2: SVG body check
+    if [[ "$svg_allowed" == "true" ]]; then
+      local svg_body
+      svg_body=$(curl -s "http://localhost:$port/_vinext/image?url=%2Flogo.svg&w=640&q=75")
+      check "SVG body contains <svg> (served as-is)" contains "$svg_body" "<svg"
+
+      # Check security headers
+      local headers
+      headers=$(curl -s -D- -o /dev/null "http://localhost:$port/_vinext/image?url=%2Flogo.svg&w=640&q=75" 2>&1)
+      check "Content-Security-Policy header present" contains "$headers" "Content-Security-Policy"
+      check "X-Content-Type-Options: nosniff present" contains "$headers" "nosniff"
+    else
+      local svg_body
+      svg_body=$(curl -s "http://localhost:$port/_vinext/image?url=%2Flogo.svg&w=640&q=75")
+      check "Error: not an allowed image type" eq "$svg_body" "The requested resource is not an allowed image type"
+    fi
+
+    # Test 3: JPEG always works
+    local jpg_status
+    jpg_status=$(curl -s -o /dev/null -w "%{http_code}" \
+      "http://localhost:$port/_vinext/image?url=%2Fphoto.jpg&w=640&q=75")
+    check "JPEG via /_vinext/image → HTTP 200 (always works)" eq "$jpg_status" "200"
+
+    # Test 4: Direct SVG always works (bypasses optimizer)
+    local direct_status
+    direct_status=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:$port/logo.svg")
+    check "Direct /logo.svg → HTTP 200 (bypasses optimizer)" eq "$direct_status" "200"
+
+    # Test 5: Page renders
+    local page_status
+    page_status=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:$port/")
+    check "/ page renders → HTTP 200" eq "$page_status" "200"
+  fi
+
+  # ── Stop server ──
+  cleanup
+  sleep 1  # Give the port time to be released
+}
+
+echo ""
+echo -e "${bold}═══════════════════════════════════════════════════════════════${reset}"
+echo -e "${bold}   vinext — dangerouslyAllowSVG End-to-End Test${reset}"
+echo -e "${bold}═══════════════════════════════════════════════════════════════${reset}"
+
+# Save original config
+[[ -f next.config.mjs ]] && cp next.config.mjs next.config.mjs.bak
+
+# Phase 1: SVG blocked (use first port)
+run_phase "Phase 1: WITHOUT dangerouslyAllowSVG (SVG should be BLOCKED)" "false" "$PORT_PHASE1"
+
+# Phase 2: SVG allowed (use second port to avoid port conflict)
+run_phase "Phase 2: WITH dangerouslyAllowSVG: true (SVG should be ALLOWED)" "true" "$PORT_PHASE2"
+
+# Restore original config
+if [[ -f next.config.mjs.bak ]]; then
+  mv next.config.mjs.bak next.config.mjs
+else
+  rm -f next.config.mjs
+fi
+
+echo ""
+echo -e "${bold}═══════════════════════════════════════════════════════════════${reset}"
+if [[ $failed -eq 0 ]]; then
+  echo -e "${green}${bold}  All $passed checks passed!${reset}"
+else
+  echo -e "${red}${bold}  $passed passed, $failed failed${reset}"
+fi
+echo -e "${bold}═══════════════════════════════════════════════════════════════${reset}"
+echo ""
+
+exit $failed

--- a/tests/fixtures/svg-test/tsconfig.json
+++ b/tests/fixtures/svg-test/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["pages", "*.ts"]
+}

--- a/tests/fixtures/svg-test/vite.config.ts
+++ b/tests/fixtures/svg-test/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from "vite";
+import vinext from "vinext";
+
+export default defineConfig({
+  plugins: [vinext()],
+});

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -5437,6 +5437,29 @@ describe("next/image enhancements", () => {
     expect(result.props.src).toBe("/photo.jpg");
     expect(result.props.src).not.toContain("/_vinext/image");
   });
+
+  it("SVG src auto-skips optimization endpoint", async () => {
+    const { getImageProps } = await import("../packages/vinext/src/shims/image.js");
+    const result = getImageProps({
+      src: "/logo.svg",
+      alt: "SVG logo",
+      width: 200,
+      height: 200,
+    });
+    expect(result.props.src).toBe("/logo.svg");
+    expect(result.props.src).not.toContain("/_vinext/image");
+  });
+
+  it("non-SVG src still uses optimization endpoint", async () => {
+    const { getImageProps } = await import("../packages/vinext/src/shims/image.js");
+    const result = getImageProps({
+      src: "/photo.png",
+      alt: "PNG photo",
+      width: 256,
+      height: 256,
+    });
+    expect(result.props.src).toContain("/_vinext/image");
+  });
 });
 
 describe("next/image component rendering", () => {
@@ -5974,6 +5997,23 @@ describe("isSafeImageContentType", () => {
     expect(isSafeImageContentType("Image/JPEG")).toBe(true);
     expect(isSafeImageContentType("IMAGE/SVG+XML")).toBe(false);
   });
+
+  it("allows SVG when dangerouslyAllowSVG is true", async () => {
+    const { isSafeImageContentType } = await import("../packages/vinext/src/server/image-optimization.js");
+    expect(isSafeImageContentType("image/svg+xml", true)).toBe(true);
+  });
+
+  it("allows SVG with parameters when dangerouslyAllowSVG is true", async () => {
+    const { isSafeImageContentType } = await import("../packages/vinext/src/server/image-optimization.js");
+    expect(isSafeImageContentType("image/svg+xml; charset=utf-8", true)).toBe(true);
+  });
+
+  it("still rejects non-image types when dangerouslyAllowSVG is true", async () => {
+    const { isSafeImageContentType } = await import("../packages/vinext/src/server/image-optimization.js");
+    expect(isSafeImageContentType("text/html", true)).toBe(false);
+    expect(isSafeImageContentType("application/javascript", true)).toBe(false);
+    expect(isSafeImageContentType(null, true)).toBe(false);
+  });
 });
 
 describe("handleImageOptimization", () => {
@@ -6170,6 +6210,114 @@ describe("handleImageOptimization", () => {
     expect(response.status).toBe(200);
     // Should override to the negotiated format, not pass through text/html
     expect(response.headers.get("Content-Type")).toBe("image/webp");
+  });
+
+  it("allows SVG passthrough with dangerouslyAllowSVG: true", async () => {
+    const { handleImageOptimization } = await import("../packages/vinext/src/server/image-optimization.js");
+    const request = new Request("http://localhost/_vinext/image?url=%2Flogo.svg&w=100&q=75");
+    const handlers = {
+      fetchAsset: async () => new Response('<svg xmlns="http://www.w3.org/2000/svg"><rect/></svg>', {
+        status: 200,
+        headers: { "Content-Type": "image/svg+xml" },
+      }),
+    };
+    const response = await handleImageOptimization(request, handlers, undefined, { dangerouslyAllowSVG: true });
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe('<svg xmlns="http://www.w3.org/2000/svg"><rect/></svg>');
+    expect(response.headers.get("Content-Type")).toBe("image/svg+xml");
+  });
+
+  it("still blocks SVG with dangerouslyAllowSVG: false", async () => {
+    const { handleImageOptimization } = await import("../packages/vinext/src/server/image-optimization.js");
+    const request = new Request("http://localhost/_vinext/image?url=%2Flogo.svg&w=100&q=75");
+    const handlers = {
+      fetchAsset: async () => new Response('<svg></svg>', {
+        status: 200,
+        headers: { "Content-Type": "image/svg+xml" },
+      }),
+    };
+    const response = await handleImageOptimization(request, handlers, undefined, { dangerouslyAllowSVG: false });
+    expect(response.status).toBe(400);
+  });
+
+  it("SVG passthrough skips transformImage", async () => {
+    const { handleImageOptimization } = await import("../packages/vinext/src/server/image-optimization.js");
+    const request = new Request("http://localhost/_vinext/image?url=%2Flogo.svg&w=100&q=75");
+    let transformCalled = false;
+    const handlers = {
+      fetchAsset: async () => new Response('<svg></svg>', {
+        status: 200,
+        headers: { "Content-Type": "image/svg+xml" },
+      }),
+      transformImage: async () => {
+        transformCalled = true;
+        return new Response("transformed");
+      },
+    };
+    const response = await handleImageOptimization(request, handlers, undefined, { dangerouslyAllowSVG: true });
+    expect(response.status).toBe(200);
+    expect(transformCalled).toBe(false);
+    expect(await response.text()).toBe('<svg></svg>');
+  });
+
+  it("applies custom contentDispositionType", async () => {
+    const { handleImageOptimization } = await import("../packages/vinext/src/server/image-optimization.js");
+    const request = new Request("http://localhost/_vinext/image?url=%2Fimg.jpg&w=800");
+    const handlers = {
+      fetchAsset: async () => new Response("image-data", {
+        status: 200,
+        headers: { "Content-Type": "image/jpeg" },
+      }),
+    };
+    const response = await handleImageOptimization(request, handlers, undefined, { contentDispositionType: "attachment" });
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Disposition")).toBe("attachment");
+  });
+
+  it("applies custom contentSecurityPolicy", async () => {
+    const { handleImageOptimization } = await import("../packages/vinext/src/server/image-optimization.js");
+    const request = new Request("http://localhost/_vinext/image?url=%2Fimg.jpg&w=800");
+    const handlers = {
+      fetchAsset: async () => new Response("image-data", {
+        status: 200,
+        headers: { "Content-Type": "image/jpeg" },
+      }),
+    };
+    const customCSP = "default-src 'self'; script-src 'none';";
+    const response = await handleImageOptimization(request, handlers, undefined, { contentSecurityPolicy: customCSP });
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Security-Policy")).toBe(customCSP);
+  });
+
+  it("applies security headers on SVG passthrough", async () => {
+    const { handleImageOptimization } = await import("../packages/vinext/src/server/image-optimization.js");
+    const request = new Request("http://localhost/_vinext/image?url=%2Flogo.svg&w=100&q=75");
+    const handlers = {
+      fetchAsset: async () => new Response('<svg></svg>', {
+        status: 200,
+        headers: { "Content-Type": "image/svg+xml" },
+      }),
+    };
+    const response = await handleImageOptimization(request, handlers, undefined, { dangerouslyAllowSVG: true });
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Security-Policy")).toBe("script-src 'none'; frame-src 'none'; sandbox;");
+    expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(response.headers.get("Content-Disposition")).toBe("inline");
+  });
+
+  it("default behavior unchanged when no imageConfig provided", async () => {
+    const { handleImageOptimization } = await import("../packages/vinext/src/server/image-optimization.js");
+    const request = new Request("http://localhost/_vinext/image?url=%2Fimg.jpg&w=800");
+    const handlers = {
+      fetchAsset: async () => new Response("image-data", {
+        status: 200,
+        headers: { "Content-Type": "image/jpeg" },
+      }),
+    };
+    const response = await handleImageOptimization(request, handlers);
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Security-Policy")).toBe("script-src 'none'; frame-src 'none'; sandbox;");
+    expect(response.headers.get("Content-Disposition")).toBe("inline");
   });
 });
 


### PR DESCRIPTION
Add image security config options matching Next.js behavior:
- dangerouslyAllowSVG: opt-in to serve SVG through /_vinext/image
- contentDispositionType: control Content-Disposition header
- contentSecurityPolicy: custom CSP for image responses

SVG is blocked by default (400). When allowed, SVG is served as-is (no transformation) with security headers. Works in Pages Router (prod server + CF Worker) and App Router (prod server).

Includes 10 unit tests and an e2e test fixture (tests/fixtures/svg-test).

Closes #205