### PR TITLE
fix: include package modules in commonjs transform

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -1668,7 +1668,16 @@ hydrate();
     tsconfigPaths(),
     // Transform CJS require()/module.exports to ESM before other plugins
     // analyze imports (RSC directive scanning, shim resolution, etc.)
-    commonjs(),
+    commonjs({
+      // vite-plugin-commonjs excludes node_modules by default, but there's
+      // nothing preventing a dependency from using CJS, so we need to include
+      // node_modules here.
+      filter(id) {
+        if (getPackageName(id) !== null) {
+          return true
+        }
+      },
+    }),
     {
       name: "vinext:config",
       enforce: "pre",


### PR DESCRIPTION
Previously we only transformed CJS modules if they were part of the part of the project and not if they were in the project's dependencies. Now we will apply CJS to ESM transformations if the vite module id can be resolved to a node module.