### PR TITLE
feat: add /dist/ to .gitignore during vinext init

### DIFF
--- a/packages/vinext/src/init.ts
+++ b/packages/vinext/src/init.ts
@@ -226,22 +226,22 @@ function installDeps(
  */
 export function updateGitignore(root: string): boolean {
   const gitignorePath = path.join(root, ".gitignore");
-  const entry = "/dist/";
+  const exactEntry = "/dist/";
 
   let content = "";
   if (fs.existsSync(gitignorePath)) {
     content = fs.readFileSync(gitignorePath, "utf-8");
 
-    // Check if /dist/ is already listed (as its own line, ignoring whitespace)
+    // Check if dist is already covered — match /dist/, dist/, or dist (all common variants)
     const lines = content.split("\n").map((l) => l.trim());
-    if (lines.includes(entry)) {
+    if (lines.includes(exactEntry) || lines.includes("dist/") || lines.includes("dist")) {
       return false;
     }
   }
 
   // Append /dist/ with a trailing newline, ensuring we don't merge with an existing last line
   const separator = content.length > 0 && !content.endsWith("\n") ? "\n" : "";
-  fs.writeFileSync(gitignorePath, content + separator + entry + "\n", "utf-8");
+  fs.writeFileSync(gitignorePath, content + separator + exactEntry + "\n", "utf-8");
   return true;
 }
 

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -716,6 +716,26 @@ describe("updateGitignore", () => {
 
     expect(result).toBe(false);
   });
+
+  it("does not add /dist/ when dist/ (without leading slash) is already present", () => {
+    writeFile(tmpDir, ".gitignore", "node_modules/\ndist/\n");
+
+    const result = updateGitignore(tmpDir);
+
+    expect(result).toBe(false);
+    const content = readFile(tmpDir, ".gitignore");
+    expect(content).toBe("node_modules/\ndist/\n");
+  });
+
+  it("does not add /dist/ when bare dist is already present", () => {
+    writeFile(tmpDir, ".gitignore", "node_modules/\ndist\n");
+
+    const result = updateGitignore(tmpDir);
+
+    expect(result).toBe(false);
+    const content = readFile(tmpDir, ".gitignore");
+    expect(content).toBe("node_modules/\ndist\n");
+  });
 });
 
 // ─── Integration: init updates .gitignore ────────────────────────────────────


### PR DESCRIPTION
## Summary

- `vinext init` now adds `/dist/` to `.gitignore` (Step 6 in the init flow)
- Creates `.gitignore` if it doesn't exist, appends the entry if missing, skips if already present
- Preserves all existing `.gitignore` entries

## Changes

- **`packages/vinext/src/init.ts`**: Added `updateGitignore()` function, wired into `init()` as Step 6, added `updatedGitignore` to `InitResult`, added summary log line
- **`tests/init.test.ts`**: Added 8 new tests — 5 unit tests for `updateGitignore()` and 3 integration tests for the full `init` flow

## Why

`vite build` outputs to `/dist/` by default. Without this entry in `.gitignore`, users who run `vinext init` and then build will end up with build artifacts tracked in git.