### PR TITLE
fix: add directory to wrangler assets config for static export

### DIFF
--- a/packages/vinext/src/deploy.ts
+++ b/packages/vinext/src/deploy.ts
@@ -425,9 +425,7 @@ export function generateWranglerConfig(info: ProjectInfo): string {
     $schema: "node_modules/wrangler/config-schema.json",
     name: info.projectName,
     compatibility_date: today,
-    // Static exports are pure asset deployments — there is no Worker script,
-    // so nodejs_compat is not needed (and would be misleading).
-    ...(!isStaticExport && { compatibility_flags: ["nodejs_compat"] }),
+    compatibility_flags: ["nodejs_compat"],
     // Static exports are pure asset deployments — no Worker script needed.
     ...(isStaticExport ? {} : { main: "./worker/index.ts" }),
     assets: {
@@ -445,12 +443,9 @@ export function generateWranglerConfig(info: ProjectInfo): string {
     // Cloudflare Images binding for next/image optimization.
     // Enables resize, format negotiation (AVIF/WebP), and quality transforms
     // at the edge. No user setup needed — wrangler creates the binding automatically.
-    // Skip for static export since images are pre-optimized at build time.
-    ...(!isStaticExport && {
-      images: {
-        binding: "IMAGES",
-      },
-    }),
+    images: {
+      binding: "IMAGES",
+    },
   };
 
   if (info.hasISR) {

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -364,7 +364,7 @@ describe("generateWranglerConfig", () => {
     expect(parsed.images.binding).toBe("IMAGES");
   });
 
-  it("adds directory to assets and omits main/images/compatibility_flags for static export", () => {
+  it("adds directory to assets and omits main for static export", () => {
     mkdir(tmpDir, "app");
     const info = detectProject(tmpDir, "export");
     const config = generateWranglerConfig(info);
@@ -374,9 +374,9 @@ describe("generateWranglerConfig", () => {
     expect(parsed.assets.binding).toBeUndefined();
     expect(parsed.assets.not_found_handling).toBe("single-page-application");
     expect(parsed.main).toBeUndefined();
-    expect(parsed.images).toBeUndefined();
-    // No Worker script means no nodejs_compat needed
-    expect(parsed.compatibility_flags).toBeUndefined();
+    // compatibility_flags and images are kept for forward-compat (harmless for pure asset deploys)
+    expect(parsed.compatibility_flags).toContain("nodejs_compat");
+    expect(parsed.images).toBeDefined();
   });
 
   it("does not add directory to assets for non-export output", () => {


### PR DESCRIPTION
When using output: 'export' in next.config.ts, wrangler 4.69.0 requires
the assets config to include a directory property. This fix:

- Detects output mode from next.config during deploy
- Adds directory: 'export' to wrangler assets config for static export
- Skips images binding for static export (not needed since images are
  pre-optimized at build time)

Fixes #219