### PR TITLE
fix: load .env files into process.env (closes #228)

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -1,5 +1,5 @@
 import type { Plugin, UserConfig, ViteDevServer } from "vite";
-import { parseAst } from "vite";
+import { loadEnv, parseAst } from "vite";
 import { pagesRouter, apiRouter, invalidateRouteCache, matchRoute, patternToNextFormat as pagesPatternToNextFormat, type Route } from "./routing/pages-router.js";
 import { appRouter, invalidateAppRouteCache } from "./routing/app-router.js";
 import { createSSRHandler } from "./server/dev-server.js";
@@ -1673,8 +1673,22 @@ hydrate();
       name: "vinext:config",
       enforce: "pre",
 
-      async config(config) {
+      async config(config, env) {
         root = config.root ?? process.cwd();
+
+        // Load .env files into process.env before anything else.
+        // Next.js loads .env files before evaluating next.config.js, so
+        // env vars are available in config, server-side code, and as
+        // NEXT_PUBLIC_* defines for the client bundle.
+        // Pass '' as prefix to load ALL vars, not just VITE_-prefixed ones.
+        const mode = env?.mode ?? "development";
+        const envDir = config.envDir ?? root;
+        const dotenvVars = loadEnv(mode, envDir, "");
+        for (const [key, value] of Object.entries(dotenvVars)) {
+          if (process.env[key] === undefined) {
+            process.env[key] = value;
+          }
+        }
 
         // Resolve the base directory for app/pages detection.
         // If appDir is provided, resolve it (supports both relative and absolute paths).

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -3968,3 +3968,130 @@ export default function NestedProps({ user }) {
     expect(html).toContain("Custom 404 - Not Found");
   });
 });
+
+// ---------------------------------------------------------------------------
+// .env file loading (Issue #228)
+// ---------------------------------------------------------------------------
+
+describe(".env file loading (Issue #228)", () => {
+  let envServer: ViteDevServer;
+  let envBaseUrl: string;
+  let tmpDir: string;
+
+  beforeAll(async () => {
+    const os = await import("node:os");
+    const fsp = await import("node:fs/promises");
+
+    tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "vinext-env-"));
+
+    // Symlink node_modules
+    const rootNodeModules = path.resolve(import.meta.dirname, "../node_modules");
+    await fsp.symlink(rootNodeModules, path.join(tmpDir, "node_modules"), "junction");
+
+    // .env file with NEXT_PUBLIC_ and server-only vars
+    await fsp.writeFile(
+      path.join(tmpDir, ".env"),
+      `NEXT_PUBLIC_APP_NAME=vinext-test-app
+SERVER_ONLY_SECRET=super-secret-123
+BETTER_AUTH_URL=http://localhost:9999
+`,
+    );
+
+    // pages directory with a page that renders env vars
+    await fsp.mkdir(path.join(tmpDir, "pages"), { recursive: true });
+
+    await fsp.writeFile(
+      path.join(tmpDir, "pages", "index.tsx"),
+      `export function getServerSideProps() {
+  return {
+    props: {
+      publicVar: process.env.NEXT_PUBLIC_APP_NAME ?? "NOT_LOADED",
+      serverVar: process.env.SERVER_ONLY_SECRET ?? "NOT_LOADED",
+      authUrl: process.env.BETTER_AUTH_URL ?? "NOT_LOADED",
+    },
+  };
+}
+
+export default function Home({ publicVar, serverVar, authUrl }) {
+  return (
+    <div>
+      <p id="public">PUBLIC:{publicVar}</p>
+      <p id="server">SERVER:{serverVar}</p>
+      <p id="auth">AUTH:{authUrl}</p>
+    </div>
+  );
+}
+`,
+    );
+
+    // Start server
+    const plugins: any[] = [vinext()];
+    envServer = await createServer({
+      root: tmpDir,
+      configFile: false,
+      plugins,
+      server: { port: 0 },
+      logLevel: "silent",
+    });
+
+    await envServer.listen();
+    const addr = envServer.httpServer?.address();
+    if (addr && typeof addr === "object") {
+      envBaseUrl = `http://localhost:${addr.port}`;
+    }
+  }, 30000);
+
+  afterAll(async () => {
+    // Clean up env vars loaded from .env to avoid polluting other tests
+    delete process.env.NEXT_PUBLIC_APP_NAME;
+    delete process.env.SERVER_ONLY_SECRET;
+    delete process.env.BETTER_AUTH_URL;
+
+    try {
+      (envServer?.httpServer as any)?.closeAllConnections?.();
+      await Promise.race([
+        envServer?.close(),
+        new Promise((r) => setTimeout(r, 3000)),
+      ]);
+    } catch {}
+
+    if (tmpDir) {
+      const fsp = await import("node:fs/promises");
+      await fsp.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("NEXT_PUBLIC_ vars from .env are available via process.env", () => {
+    // Check the Vite define config — NEXT_PUBLIC_ vars from .env should
+    // be registered as define entries for client-side inlining.
+    const defineKey = "process.env.NEXT_PUBLIC_APP_NAME";
+    const defineValue = envServer.config.define?.[defineKey];
+    expect(defineValue).toBe(JSON.stringify("vinext-test-app"));
+  });
+
+  it("server-only vars from .env are NOT exposed in client defines", () => {
+    // Only NEXT_PUBLIC_* vars should be inlined into the client bundle.
+    // Server-only secrets must never appear in config.define, or they
+    // would be embedded in client JavaScript and sent to the browser.
+    const defines = envServer.config.define ?? {};
+    expect(defines["process.env.SERVER_ONLY_SECRET"]).toBeUndefined();
+    expect(defines["process.env.BETTER_AUTH_URL"]).toBeUndefined();
+
+    // Also verify no define key contains the secret value itself
+    const allDefineValues = Object.values(defines).join(" ");
+    expect(allDefineValues).not.toContain("super-secret-123");
+    expect(allDefineValues).not.toContain("localhost:9999");
+  });
+
+  it("server-side code can read .env vars via process.env", async () => {
+    // getServerSideProps reads process.env at runtime.
+    // If .env is loaded, these should have the values from .env.
+    const res = await fetch(`${envBaseUrl}/`);
+    const html = await res.text();
+    // React SSR inserts <!-- --> comments between adjacent text nodes,
+    // so check __NEXT_DATA__ which has the raw props.
+    expect(html).toContain('"publicVar":"vinext-test-app"');
+    expect(html).toContain('"serverVar":"super-secret-123"');
+    expect(html).toContain('"authUrl":"http://localhost:9999"');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #228. vinext was not loading `.env` files, so environment variables defined in `.env` were unavailable everywhere: server-side code (`getServerSideProps`, API routes, server components), `NEXT_PUBLIC_*` client bundle defines, and `next.config.js` evaluation.

- Calls Vite's `loadEnv()` early in the `config` hook (before `loadNextConfig()`) with an empty prefix to load all `.env` vars into `process.env`, matching Next.js behavior
- Respects existing `process.env` values (system env takes precedence over `.env` files)
- Respects Vite's `envDir` config option
- Adds two integration tests covering both `NEXT_PUBLIC_*` define injection and server-side `process.env` access

## Changes

**`packages/vinext/src/index.ts`** (the fix, 12 lines):
- Import `loadEnv` from Vite
- In the `config` hook, call `loadEnv(mode, envDir, "")` and merge results into `process.env` before config loading

**`tests/features.test.ts`** (reproduction tests):
- Creates a temp project with a `.env` file containing `NEXT_PUBLIC_APP_NAME`, `SERVER_ONLY_SECRET`, and `BETTER_AUTH_URL`
- Verifies `NEXT_PUBLIC_*` vars appear in Vite's `config.define` map
- Verifies `getServerSideProps` can read all `.env` vars via `process.env`