### PR TITLE
fix: normalize null-prototype params from matchPattern() for RSC serialization

### DIFF
--- a/packages/vinext/src/server/app-dev-server.ts
+++ b/packages/vinext/src/server/app-dev-server.ts
@@ -245,6 +245,20 @@ function setNavigationContext(ctx) {
 // based on export const revalidate for testing purposes.
 // Production ISR is handled by prod-server.ts and the Cloudflare worker entry.
 
+// Normalize null-prototype objects from matchPattern() into thenable objects
+// that work both as Promises (for Next.js 15+ async params) and as plain
+// objects with synchronous property access (for pre-15 code like params.id).
+//
+// matchPattern() uses Object.create(null), producing objects without
+// Object.prototype. The RSC serializer rejects these. Spreading ({...obj})
+// restores a normal prototype. Object.assign onto the Promise preserves
+// synchronous property access (params.id, params.slug) that existing
+// components and test fixtures rely on.
+function makeThenableParams(obj) {
+  const plain = { ...obj };
+  return Object.assign(Promise.resolve(plain), plain);
+}
+
 // djb2 hash — matches Next.js's stringHash for digest generation.
 // Produces a stable numeric string from error message + stack.
 function __errorDigest(str) {
@@ -637,8 +651,8 @@ async function buildPageElement(route, params, opts, searchParams) {
   // Build nested layout tree from outermost to innermost.
   // Next.js 16 passes params/searchParams as Promises (async pattern)
   // but pre-16 code accesses them as plain objects (params.id).
-  // We create a "thenable object" that works both ways.
-  const asyncParams = Object.assign(Promise.resolve(params), params);
+  // makeThenableParams() normalises null-prototype + preserves both patterns.
+  const asyncParams = makeThenableParams(params);
   const pageProps = { params: asyncParams };
   if (searchParams) {
     const spObj = {};
@@ -661,7 +675,7 @@ async function buildPageElement(route, params, opts, searchParams) {
     // approximation: pages with query params in the URL are almost always
     // dynamic, and this avoids false positives from React internals.
     if (hasSearchParams) markDynamicUsage();
-    pageProps.searchParams = Object.assign(Promise.resolve(spObj), spObj);
+    pageProps.searchParams = makeThenableParams(spObj);
   }
   let element = createElement(PageComponent, pageProps);
 
@@ -762,7 +776,7 @@ async function buildPageElement(route, params, opts, searchParams) {
         }
       }
 
-      const layoutProps = { children: element, params: Object.assign(Promise.resolve(params), params) };
+      const layoutProps = { children: element, params: makeThenableParams(params) };
 
       // Add parallel slot elements to the layout that defines them.
       // Each slot has a layoutIndex indicating which layout it belongs to.
@@ -784,7 +798,7 @@ async function buildPageElement(route, params, opts, searchParams) {
           }
 
           if (SlotPage) {
-            let slotElement = createElement(SlotPage, { params: Object.assign(Promise.resolve(slotParams), slotParams) });
+            let slotElement = createElement(SlotPage, { params: makeThenableParams(slotParams) });
             // Wrap with slot-specific layout if present.
             // In Next.js, @slot/layout.tsx wraps the slot's page content
             // before it is passed as a prop to the parent layout.
@@ -792,7 +806,7 @@ async function buildPageElement(route, params, opts, searchParams) {
             if (SlotLayout) {
               slotElement = createElement(SlotLayout, {
                 children: slotElement,
-                params: Object.assign(Promise.resolve(slotParams), slotParams),
+                params: makeThenableParams(slotParams),
               });
             }
             // Wrap with slot-specific loading if present
@@ -1966,7 +1980,7 @@ async function _handleRequest(request, __reqCtx) {
   // triggers renderHTTPAccessFallbackPage with ALL route layouts, but one of those
   // layouts itself throws notFound() during the fallback rendering (causing a 500).
   if (route.layouts && route.layouts.length > 0) {
-    const asyncParams = Object.assign(Promise.resolve(params), params);
+    const asyncParams = makeThenableParams(params);
     for (let li = route.layouts.length - 1; li >= 0; li--) {
       const LayoutComp = route.layouts[li]?.default;
       if (!LayoutComp) continue;

--- a/packages/vinext/src/shims/metadata.tsx
+++ b/packages/vinext/src/shims/metadata.tsx
@@ -10,6 +10,15 @@ import React from "react";
 // Viewport types and resolution
 // ---------------------------------------------------------------------------
 
+/**
+ * Normalize null-prototype objects from matchPattern() into thenable objects.
+ * See app-dev-server.ts makeThenableParams() for full explanation.
+ */
+function makeThenableParams<T extends Record<string, unknown>>(obj: T): Promise<T> & T {
+  const plain = { ...obj } as T;
+  return Object.assign(Promise.resolve(plain), plain);
+}
+
 export interface Viewport {
   /** Viewport width (default: "device-width") */
   width?: string | number;
@@ -40,7 +49,7 @@ export async function resolveModuleViewport(
   params: Record<string, string | string[]>,
 ): Promise<Viewport | null> {
   if (typeof mod.generateViewport === "function") {
-    const asyncParams = Object.assign(Promise.resolve(params), params);
+    const asyncParams = makeThenableParams(params);
     return await mod.generateViewport({ params: asyncParams });
   }
   if (mod.viewport && typeof mod.viewport === "object") {
@@ -266,10 +275,10 @@ export async function resolveModuleMetadata(
 ): Promise<Metadata | null> {
   if (typeof mod.generateMetadata === "function") {
     // Next.js 16 passes params/searchParams as Promises (async pattern).
-    // Create thenable objects that work both as Promises and plain objects.
-    const asyncParams = Object.assign(Promise.resolve(params), params);
+    // makeThenableParams() normalises null-prototype + preserves sync access.
+    const asyncParams = makeThenableParams(params);
     const sp = searchParams ?? {};
-    const asyncSp = Object.assign(Promise.resolve(sp), sp);
+    const asyncSp = makeThenableParams(sp);
     return await mod.generateMetadata({ params: asyncParams, searchParams: asyncSp });
   }
   if (mod.metadata && typeof mod.metadata === "object") {


### PR DESCRIPTION
## Summary

`matchPattern()` uses `Object.create(null)`, producing objects without `Object.prototype`. The RSC serializer rejects these during dynamic route rendering, causing 500 errors on all dynamic routes (e.g. `/dashboards/[id]`).

Fixes #241

## Fix

A `makeThenableParams()` helper that satisfies both constraints:

```js
function makeThenableParams(obj) {
  const plain = { ...obj };
  return Object.assign(Promise.resolve(plain), plain);
}
```

1. **Spread** (`{...obj}`) normalizes the null prototype → RSC serializer accepts it
2. **`Object.assign`** onto the Promise preserves synchronous property access (`params.id`, `params.slug`) for pre-Next.js 15 code

This replaces the previous `Object.assign(Promise.resolve(params), params)` pattern at all 6 call sites in `app-dev-server.ts` and 3 in `metadata.tsx`. The old pattern passed the original null-prototype object to both `Promise.resolve()` and `Object.assign()` — while the thenable worked, the resolved value still had a null prototype causing RSC serialization failure.

## Files Changed (2 files, 1 commit)

| File | Changes |
|------|---------|
| `packages/vinext/src/server/app-dev-server.ts` | Added `makeThenableParams()`, replaced 6 `Object.assign(Promise.resolve(x), x)` sites, updated stale comment |
| `packages/vinext/src/shims/metadata.tsx` | Added typed `makeThenableParams<T>()`, replaced 3 call sites, updated comment |

## Testing

- **2110 Vitest tests pass** (51/51 files, 0 failures)
- **387 Playwright E2E tests pass** (0 failures, 12 skipped)
- Specifically verified: dynamic routes with `params.id`, `params.slug`, catch-all routes (`params.slug.join()`), `generateMetadata()` with async params — all pass
- Tested with a production Next.js 16 / React 19 app on Vinext (dynamic routes, metadata, server actions)

## vs. PR #242

This is a replacement for #242, which was correctly identified by review as breaking synchronous params access. Changes from #242:
- **Fixed**: `Promise.resolve({...obj})` → `Object.assign(Promise.resolve({...obj}), {...obj})` — preserves backward compat
- **Removed**: Unrelated `credentials: "same-origin"` changes (4 fetch calls)
- **Removed**: Unrelated `findReactServerPackages()` feature
- **Removed**: README.md overwrite
- **Removed**: `.gitignore` change
- **Removed**: `link.tsx` / `navigation.ts` changes
- **Removed**: Accidentally tracked build artifact update