### PR TITLE
fix: wire up RouterContext.Provider in Pages Router

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -769,7 +769,7 @@ import React from "react";
 import { renderToReadableStream } from "react-dom/server.edge";
 import { resetSSRHead, getSSRHeadHTML } from "next/head";
 import { flushPreloads } from "next/dynamic";
-import { setSSRContext } from "next/router";
+import { setSSRContext, wrapWithRouterContext } from "next/router";
 import { getCacheHandler } from "next/cache";
 import { runWithFetchCache } from "vinext/fetch-cache";
 import { _runWithCacheState } from "next/cache";
@@ -1334,6 +1334,7 @@ export async function renderPage(request, url, manifest) {
     } else {
       element = React.createElement(PageComponent, pageProps);
     }
+    element = wrapWithRouterContext(element);
 
     if (typeof resetSSRHead === "function") resetSSRHead();
     if (typeof flushPreloads === "function") await flushPreloads();
@@ -1431,6 +1432,7 @@ export async function renderPage(request, url, manifest) {
       } else {
         isrElement = React.createElement(PageComponent, pageProps);
       }
+      isrElement = wrapWithRouterContext(isrElement);
       var isrHtml = await renderToStringAsync(isrElement);
       var fullHtml = shellPrefix + isrHtml + shellSuffix;
       var isrPathname = url.split("?")[0];
@@ -1596,6 +1598,10 @@ async function hydrate() {
   ` : `
   element = React.createElement(PageComponent, pageProps);
   `}
+
+  // Wrap with RouterContext.Provider so next/compat/router works during hydration
+  const { wrapWithRouterContext } = await import("next/router");
+  element = wrapWithRouterContext(element);
 
   const container = document.getElementById("__next");
   if (!container) {

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -385,7 +385,7 @@ export function createSSRHandler(
           });
 
           if (!isValidPath) {
-            await renderErrorPage(server, req, res, url, pagesDir, 404);
+            await renderErrorPage(server, req, res, url, pagesDir, 404, routerShim.wrapWithRouterContext);
             return;
           }
         }
@@ -427,7 +427,7 @@ export function createSSRHandler(
           return;
         }
         if (result && "notFound" in result && result.notFound) {
-          await renderErrorPage(server, req, res, url, pagesDir, 404);
+          await renderErrorPage(server, req, res, url, pagesDir, 404, routerShim.wrapWithRouterContext);
           return;
         }
       }
@@ -533,7 +533,7 @@ export function createSSRHandler(
           return;
         }
         if (result && "notFound" in result && result.notFound) {
-          await renderErrorPage(server, req, res, url, pagesDir, 404);
+          await renderErrorPage(server, req, res, url, pagesDir, 404, routerShim.wrapWithRouterContext);
           return;
         }
 
@@ -562,6 +562,10 @@ export function createSSRHandler(
       const createElement = React.createElement;
       let element: React.ReactElement;
 
+      // wrapWithRouterContext wraps the element in RouterContext.Provider so that
+      // next/compat/router's useRouter() returns the real router.
+      const wrapWithRouterContext = routerShim.wrapWithRouterContext;
+
       if (AppComponent) {
         element = createElement(AppComponent, {
           Component: PageComponent,
@@ -569,6 +573,10 @@ export function createSSRHandler(
         });
       } else {
         element = createElement(PageComponent, pageProps);
+      }
+
+      if (wrapWithRouterContext) {
+        element = wrapWithRouterContext(element);
       }
 
       // Reset SSR head collector before rendering so <Head> tags are captured
@@ -647,6 +655,7 @@ export function createSSRHandler(
 <script type="module">
 import React from "react";
 import { hydrateRoot } from "react-dom/client";
+import { wrapWithRouterContext } from "next/router";
 
 const nextData = window.__NEXT_DATA__;
 const { pageProps } = nextData.props;
@@ -667,6 +676,7 @@ async function hydrate() {
   element = React.createElement(PageComponent, pageProps);
   `
   }
+  element = wrapWithRouterContext(element);
   const root = hydrateRoot(document.getElementById("__next"), element);
   window.__VINEXT_ROOT__ = root;
 }
@@ -745,9 +755,12 @@ hydrate();
       // For ISR, re-render synchronously to get the complete HTML string.
       // This runs after the stream is already sent, so it doesn't affect TTFB.
       if (isrRevalidateSeconds !== null && isrRevalidateSeconds > 0) {
-        const isrElement = AppComponent
+        let isrElement = AppComponent
           ? createElement(AppComponent, { Component: pageModule.default, pageProps })
           : createElement(pageModule.default, pageProps);
+        if (wrapWithRouterContext) {
+          isrElement = wrapWithRouterContext(isrElement);
+        }
         const isrBodyHtml = await renderToStringAsync(isrElement);
         const isrHtml = `<!DOCTYPE html><html><head></head><body><div id="__next">${isrBodyHtml}</div>${allScripts}</body></html>`;
         const cacheKey = isrCacheKey("pages", url.split("?")[0]);
@@ -811,6 +824,7 @@ async function renderErrorPage(
   url: string,
   pagesDir: string,
   statusCode: number,
+  wrapWithRouterContext?: ((el: React.ReactElement) => React.ReactElement) | null,
 ): Promise<void> {
   // Try specific status page first, then _error, then fallback
   const candidates =
@@ -844,6 +858,18 @@ async function renderErrorPage(
       const createElement = React.createElement;
       const errorProps = { statusCode };
 
+      // If the caller didn't supply wrapWithRouterContext, load it now.
+      // ssrLoadModule caches internally so the cost is negligible.
+      let wrapFn = wrapWithRouterContext;
+      if (!wrapFn) {
+        try {
+          const errRouterShim = await server.ssrLoadModule("next/router");
+          wrapFn = errRouterShim.wrapWithRouterContext;
+        } catch {
+          // router shim not available — continue without it
+        }
+      }
+
       let element: React.ReactElement;
       if (AppComponent) {
         element = createElement(AppComponent, {
@@ -852,6 +878,10 @@ async function renderErrorPage(
         });
       } else {
         element = createElement(ErrorComponent, errorProps);
+      }
+
+      if (wrapFn) {
+        element = wrapFn(element);
       }
 
       const bodyHtml = await renderToStringAsync(element);

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -5,7 +5,8 @@
  * Backed by the browser History API. Supports client-side navigation
  * by fetching new page data and re-rendering the React root.
  */
-import { useState, useEffect, useCallback, useMemo } from "react";
+import { useState, useEffect, useCallback, useMemo, createElement, type ReactElement } from "react";
+import { RouterContext } from "./internal/router-context.js";
 import { isValidModulePath } from "../client/validate-module-path.js";
 
 /** basePath from next.config.js, injected by the plugin at build time */
@@ -388,6 +389,9 @@ async function navigateClient(url: string): Promise<void> {
       element = React.createElement(PageComponent, pageProps);
     }
 
+    // Wrap with RouterContext.Provider so next/compat/router works
+    element = wrapWithRouterContext(element);
+
     root.render(element);
   } catch (err) {
     console.error("[vinext] Client navigation failed:", err);
@@ -396,6 +400,57 @@ async function navigateClient(url: string): Promise<void> {
   } finally {
     _navInProgress = false;
   }
+}
+
+/**
+ * Build the full router value object from the current pathname, query, asPath,
+ * and a set of navigation methods.  Shared by useRouter() (which passes
+ * hook-derived callbacks) and wrapWithRouterContext() (which passes the Router
+ * singleton methods) so the shape stays in sync.
+ */
+function buildRouterValue(
+  pathname: string,
+  query: Record<string, string | string[]>,
+  asPath: string,
+  methods: {
+    push: NextRouter["push"];
+    replace: NextRouter["replace"];
+    back: NextRouter["back"];
+    reload: NextRouter["reload"];
+    prefetch: NextRouter["prefetch"];
+    beforePopState: NextRouter["beforePopState"];
+  },
+): NextRouter {
+  const _ssrState = _getSSRContext();
+  const locale = typeof window === "undefined"
+    ? _ssrState?.locale
+    : (window as any).__VINEXT_LOCALE__;
+  const locales = typeof window === "undefined"
+    ? _ssrState?.locales
+    : (window as any).__VINEXT_LOCALES__;
+  const defaultLocale = typeof window === "undefined"
+    ? _ssrState?.defaultLocale
+    : (window as any).__VINEXT_DEFAULT_LOCALE__;
+
+  const route = typeof window !== "undefined"
+    ? ((window as any).__NEXT_DATA__?.page ?? pathname)
+    : pathname;
+
+  return {
+    pathname,
+    route,
+    query,
+    asPath,
+    basePath: __basePath,
+    locale,
+    locales,
+    defaultLocale,
+    isReady: true,
+    isPreview: false,
+    isFallback: typeof window !== "undefined" && (window as any).__NEXT_DATA__?.isFallback === true,
+    ...methods,
+    events: routerEvents,
+  };
 }
 
 /**
@@ -529,45 +584,16 @@ export function useRouter(): NextRouter {
     }
   }, []);
 
-  // Get i18n info from SSR context or window
-  const _ssrState = _getSSRContext();
-  const locale = typeof window === "undefined"
-    ? _ssrState?.locale
-    : (window as any).__VINEXT_LOCALE__;
-  const locales = typeof window === "undefined"
-    ? _ssrState?.locales
-    : (window as any).__VINEXT_LOCALES__;
-  const defaultLocale = typeof window === "undefined"
-    ? _ssrState?.defaultLocale
-    : (window as any).__VINEXT_DEFAULT_LOCALE__;
-
-  // route is the route pattern (e.g., "/posts/[id]"), not the actual path
-  const route = typeof window !== "undefined"
-    ? ((window as any).__NEXT_DATA__?.page ?? pathname)
-    : pathname;
-
   const router = useMemo(
-    (): NextRouter => ({
-      pathname,
-      route,
-      query,
-      asPath,
-      basePath: __basePath,
-      locale,
-      locales,
-      defaultLocale,
-      isReady: true,
-      isPreview: false,
-      isFallback: typeof window !== "undefined" && (window as any).__NEXT_DATA__?.isFallback === true,
+    (): NextRouter => buildRouterValue(pathname, query, asPath, {
       push,
       replace,
       back,
       reload,
       prefetch,
       beforePopState: (cb: BeforePopStateCallback) => { _beforePopStateCb = cb; },
-      events: routerEvents,
     }),
-    [pathname, query, asPath, locale, locales, defaultLocale, push, replace, back, reload, prefetch, route],
+    [pathname, query, asPath, push, replace, back, reload, prefetch],
   );
 
   return router;
@@ -598,6 +624,30 @@ if (typeof window !== "undefined") {
       window.dispatchEvent(new CustomEvent("vinext:navigate"));
     });
   });
+}
+
+/**
+ * Wrap a React element in a RouterContext.Provider so that
+ * next/compat/router's useRouter() returns the real Pages Router value.
+ *
+ * This is a plain function, NOT a React component — it builds the router
+ * value object directly from the current SSR context (server) or
+ * window.location + Router singleton (client), avoiding duplicate state
+ * that a hook-based component would create.
+ */
+export function wrapWithRouterContext(element: ReactElement): ReactElement {
+  const { pathname, query, asPath } = getPathnameAndQuery();
+
+  const routerValue = buildRouterValue(pathname, query, asPath, {
+    push: Router.push,
+    replace: Router.replace,
+    back: Router.back,
+    reload: Router.reload,
+    prefetch: Router.prefetch,
+    beforePopState: Router.beforePopState,
+  });
+
+  return createElement(RouterContext.Provider, { value: routerValue }, element) as ReactElement;
 }
 
 // Also export a default Router singleton for `import Router from 'next/router'`

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -5220,9 +5220,90 @@ describe("next/compat/router shim", () => {
     expect(typeof mod.useRouter).toBe("function");
     expect((mod as Record<string, unknown>).default).toBeUndefined();
   });
+
+  it("useRouter returns null when no RouterContext.Provider wraps the tree", async () => {
+    const React = await import("react");
+    const { renderToStaticMarkup } = await import("react-dom/server");
+    const { useRouter } = await import(
+      "../packages/vinext/src/shims/compat-router.js"
+    );
+
+    let captured: unknown = "NOT_SET";
+    function Probe() {
+      captured = useRouter();
+      return React.createElement("div", null, "probe");
+    }
+
+    renderToStaticMarkup(React.createElement(Probe));
+    expect(captured).toBeNull();
+  });
+
+  it("useRouter returns the router when wrapWithRouterContext wraps the tree", async () => {
+    const React = await import("react");
+    const { renderToStaticMarkup } = await import("react-dom/server");
+    const { useRouter: useCompatRouter } = await import(
+      "../packages/vinext/src/shims/compat-router.js"
+    );
+    const { wrapWithRouterContext } = await import(
+      "../packages/vinext/src/shims/router.js"
+    );
+
+    let captured: unknown = "NOT_SET";
+    function Probe() {
+      captured = useCompatRouter();
+      return React.createElement("div", null, "probe");
+    }
+
+    const element = wrapWithRouterContext(React.createElement(Probe));
+    renderToStaticMarkup(element);
+    expect(captured).not.toBeNull();
+    expect(typeof (captured as any).pathname).toBe("string");
+    expect(typeof (captured as any).push).toBe("function");
+    expect(typeof (captured as any).replace).toBe("function");
+    expect(typeof (captured as any).back).toBe("function");
+    expect(typeof (captured as any).reload).toBe("function");
+  });
+
+  it("useRouter returns router reflecting SSR context when set", async () => {
+    const React = await import("react");
+    const { renderToStaticMarkup } = await import("react-dom/server");
+    const { useRouter: useCompatRouter } = await import(
+      "../packages/vinext/src/shims/compat-router.js"
+    );
+    const { wrapWithRouterContext, setSSRContext } = await import(
+      "../packages/vinext/src/shims/router.js"
+    );
+
+    setSSRContext({
+      pathname: "/posts/42",
+      query: { id: "42" },
+      asPath: "/posts/42?tab=comments",
+    });
+
+    let captured: unknown = "NOT_SET";
+    function Probe() {
+      captured = useCompatRouter();
+      return React.createElement("div", null, "probe");
+    }
+
+    const element = wrapWithRouterContext(React.createElement(Probe));
+    renderToStaticMarkup(element);
+
+    setSSRContext(null);
+
+    expect(captured).not.toBeNull();
+    expect((captured as any).pathname).toBe("/posts/42");
+    expect((captured as any).asPath).toBe("/posts/42?tab=comments");
+    expect((captured as any).query.id).toBe("42");
+  });
 });
 
 describe("Pages Router router helpers", () => {
+  it("exports wrapWithRouterContext function", async () => {
+    const mod = await import("../packages/vinext/src/shims/router.js");
+    expect(typeof mod.wrapWithRouterContext).toBe("function");
+  });
+
   describe("isExternalUrl", () => {
     it("detects https:// as external", () => {
       expect(isExternalUrl("https://example.com")).toBe(true);


### PR DESCRIPTION
Fixes #239

## Problem

`next/compat/router`'s `useRouter()` always returns `null` in Pages Router because no `<RouterContext.Provider>` wraps the page tree. In Next.js, the framework renders a `RouterContext.Provider` at the top level so both `next/router` and `next/compat/router` read from the same context.

## Root-Cause Fix

Added `wrapWithRouterContext(element)` to the `next/router` shim — a plain function (not a React component) that:

1. Builds a router value object directly from the SSR context (server) or `window.location` + `Router` singleton (client)
2. Wraps the element in `<RouterContext.Provider value={routerValue}>`

This avoids the duplicate-state problem that a hook-based component would create. There's a single source of truth for the router context value, matching Next.js's architecture.

### Why not a React component with hooks?

A `PagesRouterProvider` component calling `useRouter()` would create its own `useState`/`useEffect`/`useMemo` instance — a second, independent router state alongside every other component that also calls `useRouter()`. The plain-function approach builds the value once per render pass with zero hook overhead.

## Changes

| File | Change |
|------|--------|
| `shims/router.ts` | New `wrapWithRouterContext()` export + wrap in `navigateClient()` |
| `server/dev-server.ts` | Wrap at main render, ISR re-render, error page, hydration script |
| `index.ts` | Wrap in production virtual module `renderPage()` + ISR re-render |
| `tests/shims.test.ts` | 4 new tests for RouterContext behavior |

## Tests

- `useRouter` returns `null` without provider (App Router behavior)
- `useRouter` returns full router when `wrapWithRouterContext` wraps tree
- `useRouter` reflects SSR context (`pathname`, `query`, `asPath`)
- `wrapWithRouterContext` is exported from `next/router`

All 535 shims tests pass.