### PR TITLE
fix(rsc): emit actionable hint when non-plain object crosses server-client boundary

### DIFF
--- a/packages/vinext/src/server/app-dev-server.ts
+++ b/packages/vinext/src/server/app-dev-server.ts
@@ -321,21 +321,22 @@ function rscOnError(error) {
     error.message.includes("Only plain objects, and a few built-ins, can be passed to Client Components")
   ) {
     console.error(
-      "[vinext] RSC serialization error: a non-plain object was passed from a Server Component to a Client Component.\n" +
-      "\n" +
-      "Common causes:\n" +
-      "  * Passing a module namespace (import * as X) directly as a prop.\n" +
-      "    Unlike Next.js (webpack), Vite produces real ESM module namespace objects\n" +
-      "    which are not serializable. Fix: pass individual values instead,\n" +
-      "    e.g. <Comp value={module.value} />\n" +
-      "  * Passing a class instance (new Foo()) as a prop.\n" +
-      "    Fix: convert to a plain object, e.g. { id: foo.id, name: foo.name }\n" +
-      "  * Passing a Date, Map, or Set. Use .toISOString(), [...map.entries()], etc.\n" +
-      "  * Passing Object.create(null). Use { ...obj } to restore a prototype.\n" +
-      "\n" +
+      "[vinext] RSC serialization error: a non-plain object was passed from a Server Component to a Client Component.\\n" +
+      "\\n" +
+      "Common causes:\\n" +
+      "  * Passing a module namespace (import * as X) directly as a prop.\\n" +
+      "    Unlike Next.js (webpack), Vite produces real ESM module namespace objects\\n" +
+      "    which are not serializable. Fix: pass individual values instead,\\n" +
+      "    e.g. <Comp value={module.value} />\\n" +
+      "  * Passing a class instance (new Foo()) as a prop.\\n" +
+      "    Fix: convert to a plain object, e.g. { id: foo.id, name: foo.name }\\n" +
+      "  * Passing a Date, Map, or Set. Use .toISOString(), [...map.entries()], etc.\\n" +
+      "  * Passing Object.create(null). Use { ...obj } to restore a prototype.\\n" +
+      "\\n" +
       "Original error:",
       error.message,
     );
+    return undefined;
   }
 
   // In production, generate a digest hash for non-navigation errors

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
 import { createBuilder, type ViteDevServer } from "vite";
 import path from "node:path";
 import fs from "node:fs";
@@ -2217,6 +2217,86 @@ describe("App Router next.config.js features (generateRscEntry)", () => {
       // The existing digest path (redirect/notFound) must still be present
       expect(code).toContain('"digest" in error');
       expect(code).toContain("String(error.digest)");
+    });
+
+    // Runtime tests: extract the rscOnError function from the generated code
+    // and evaluate it. This catches syntax errors and logic bugs that the
+    // string-presence tests above would miss (e.g. unterminated strings,
+    // wrong return values, broken control flow).
+    describe("runtime behavior", () => {
+      let rscOnError: (error: unknown) => string | undefined;
+
+      beforeAll(() => {
+        const code = generateRscEntry(
+          "/tmp/test/app",
+          minimalRoutes,
+          null,
+          [],
+          null,
+          "",
+          false,
+        );
+
+        // Extract a top-level function from the generated code by matching
+        // balanced braces (simple regex can't handle nested braces).
+        function extractFunction(src: string, name: string): string {
+          const marker = `function ${name}(`;
+          const start = src.indexOf(marker);
+          if (start === -1) throw new Error(`Could not find ${name} in generated code`);
+          const braceStart = src.indexOf("{", start);
+          let depth = 0;
+          for (let i = braceStart; i < src.length; i++) {
+            if (src[i] === "{") depth++;
+            else if (src[i] === "}") depth--;
+            if (depth === 0) return src.slice(start, i + 1);
+          }
+          throw new Error(`Unbalanced braces in ${name}`);
+        }
+
+        const digestFn = extractFunction(code, "__errorDigest");
+        const onErrorFn = extractFunction(code, "rscOnError");
+
+        const body = `${digestFn}\n${onErrorFn}\nreturn rscOnError;`;
+        const factory = new Function("process", body);
+        rscOnError = factory({ env: { NODE_ENV: "development" } });
+      });
+
+      it("returns the digest string for navigation errors (redirect/notFound)", () => {
+        const error = Object.assign(new Error("NEXT_REDIRECT"), {
+          digest: "NEXT_REDIRECT;push;/dashboard;307",
+        });
+        expect(rscOnError(error)).toBe("NEXT_REDIRECT;push;/dashboard;307");
+      });
+
+      it("logs an actionable hint and returns undefined for RSC serialization errors", () => {
+        const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+        try {
+          const error = new Error(
+            "Only plain objects, and a few built-ins, can be passed to Client Components from Server Components. " +
+              "Objects with toJSON methods are not supported. Module namespace objects are not supported.",
+          );
+          const result = rscOnError(error);
+          expect(result).toBeUndefined();
+          expect(spy).toHaveBeenCalledOnce();
+          expect(spy.mock.calls[0]![0]).toContain(
+            "[vinext] RSC serialization error",
+          );
+        } finally {
+          spy.mockRestore();
+        }
+      });
+
+      it("returns undefined for generic errors in dev (no digest, no serialization match)", () => {
+        const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+        try {
+          const result = rscOnError(new Error("something went wrong"));
+          expect(result).toBeUndefined();
+          // Should NOT log the hint for unrelated errors
+          expect(spy).not.toHaveBeenCalled();
+        } finally {
+          spy.mockRestore();
+        }
+      });
     });
   });
 });


### PR DESCRIPTION
Fixes #237 

### Problem

  When a Server Component passes a non-serializable value (class instance, ESM module namespace object, `Date`, `Map`, or `Object.create(null)`) as a prop to a Client Component, React's RSC serializer throws:

  > Only plain objects, and a few built-ins, can be passed to Client Components
  from Server Components. Classes or null prototypes are not supported.
    [..., Module, Null, ..., ..., [], 1]
          ^^^^^^

  The error surfaces in the browser with no indication of **which component or prop** triggered it, making it nearly impossible to debug in large applications. Users migrating from plain Next.js are especially affected because the same code silently works there (see root cause below).

  ---

  ### Root Cause

  This is a fundamental difference between how Vite and webpack handle ES modules:

  | | Next.js (webpack) | vinext (Vite/ESM) |
  |---|---|---|
  | `import * as X from './mod'` | `{ __esModule: true, ...exports }` — **plain object** | True ESM Module Namespace Object — **non-plain** |
  | RSC serializable? | ✅ Yes (passes `isPlainObject` check) | ❌ No (internal `[[Module]]` slot) |

  When users pass `import * as utils` as a prop to a Client Component, webpack wraps it as a plain `__esModule` object that React's RSC serializer accepts. Vite produces a real ESM Module Namespace Object with a null-like prototype that React correctly rejects. **vinext's behavior is actually more spec-correct** — Next.js/webpack was accidentally permitting invalid semantics.

  ---

  ### Solutions Considered

  #### ✅ Solution 1 — User-land fix (always applicable)

  Convert non-serializable values to plain objects before passing them across
  the RSC boundary:

  ```ts
  // ❌ Fails: class instance
  const service = new UserService();
  return <UserCard service={service} />;

  // ✅ Works: extract plain data
  const user = await service.getUser(1);
  return <UserCard user={{ id: user.id, name: user.name }} />;

  // ❌ Fails: module namespace object
  import * as config from './config';
  return <AppInfo config={config} />;

  // ✅ Works: spread into a plain object
  return <AppInfo config={{ ...config }} />;

  // ❌ Fails: Date instance
  return <Card createdAt={new Date()} />;

  // ✅ Works: serialize to string
  return <Card createdAt={new Date().toISOString()} />;
```

  #### ✅ Solution 2 — Actionable dev-mode hint in rscOnError (this PR)

  Enhanced rscOnError in app-dev-server.ts to detect this specific error
  in dev mode and print a structured, actionable message to the server console:

```
[vinext] RSC serialization error: a non-plain object was passed from a Server Component to a Client Component.

Common causes:
  * Passing a module namespace (import * as X) directly as a prop.
    Unlike Next.js (webpack), Vite produces real ESM module namespace objects
    which are not serializable. Fix: pass individual values instead,
    e.g. <Comp value={module.value} />
  * Passing a class instance (new Foo()) as a prop.
    Fix: convert to a plain object, e.g. { id: foo.id, name: foo.name }
  * Passing a Date, Map, or Set. Use .toISOString(), [...map.entries()], etc.
  * Passing Object.create(null). Use { ...obj } to restore a prototype.
```

  No behavior change in production — the existing digest hash logic is unchanged.

  #### ❌ Solution 3 — Auto-convert Module Namespace Objects in vinext (not applied)

  An alternative approach was considered: intercept props before
  renderToReadableStream and automatically convert ESM Module Namespace
  Objects to plain objects via { ...moduleNS } or
  Object.fromEntries(Object.entries(moduleNS)).

  This was rejected for three reasons:

  1. Semantic corruption. Silently flattening a module namespace drops
  important distinctions — live bindings become static snapshots, and any
  non-enumerable exports or symbols are lost without warning. It would make
  vinext behave like webpack rather than being correct.
  2. Tree-shaking breakage. Auto-converting import * as X to a plain
  object and passing it to a Client Component means all exports of that
  module would be bundled into the client, defeating the RSC boundary's
  purpose of keeping server-only code out of the client bundle.
  3. Hides the real bug. The user's code has a genuine error — passing
  non-serializable data across an RSC boundary. Silently fixing it
  server-side masks the problem instead of helping the user understand and
  fix their code. A clear error message is the correct resolution.

  ---
### Changes

  - packages/vinext/src/server/app-dev-server.ts: added non-plain object detection block in rscOnError (dev-only, no production impact)

  ---
###  Testing

Minimal reproduction:

```ts
  // app/components/UserCard.tsx
  'use client';
  export function UserCard({ service }: { service: any }) {
    return <div />;
  }

  // app/page.tsx  (Server Component)
  import { UserCard } from './components/UserCard';
  class UserService { constructor(public baseUrl: string) {} }

  export default function Page() {
    // Triggers the error — class instance across RSC boundary
    return <UserCard service={new UserService('https://api.example.com')} />;
  }
  ```