### PR TITLE
fix: strip content-encoding/content-length from proxied rewrite responses

### DIFF
--- a/packages/vinext/src/config/config-matchers.ts
+++ b/packages/vinext/src/config/config-matchers.ts
@@ -656,9 +656,14 @@ export async function proxyExternalRequest(
 
   // Build the response to return to the client.
   // Copy all upstream headers except hop-by-hop headers.
+  // Also strip content-encoding and content-length because Node's fetch()
+  // automatically decompresses the body, making these headers inaccurate.
+  // Forwarding them causes browsers to attempt double decompression,
+  // resulting in ERR_CONTENT_DECODING_FAILED.
   const responseHeaders = new Headers();
   upstreamResponse.headers.forEach((value, key) => {
-    if (!HOP_BY_HOP_HEADERS.has(key.toLowerCase())) {
+    const lk = key.toLowerCase();
+    if (!HOP_BY_HOP_HEADERS.has(lk) && lk !== "content-encoding" && lk !== "content-length") {
       responseHeaders.append(key, value);
     }
   });

--- a/packages/vinext/src/server/app-dev-server.ts
+++ b/packages/vinext/src/server/app-dev-server.ts
@@ -1205,7 +1205,7 @@ async function __proxyExternalRequest(request, externalUrl) {
     console.error("[vinext] External rewrite proxy error:", e); return new Response("Bad Gateway", { status: 502 });
   }
   const respHeaders = new Headers();
-  upstream.headers.forEach(function(value, key) { if (!__hopByHopHeaders.has(key.toLowerCase())) respHeaders.append(key, value); });
+  upstream.headers.forEach(function(value, key) { var lk = key.toLowerCase(); if (!__hopByHopHeaders.has(lk) && lk !== "content-encoding" && lk !== "content-length") respHeaders.append(key, value); });
   return new Response(upstream.body, { status: upstream.status, statusText: upstream.statusText, headers: respHeaders });
 }
 


### PR DESCRIPTION
Fixes #263

## Problem

`proxyExternalRequest` and `__proxyExternalRequest` forward upstream `content-encoding` and `content-length` headers to the browser as-is. However, Node.js `fetch()` automatically decompresses response bodies (gzip, br, deflate), so these headers no longer match the actual body. The browser sees `content-encoding: gzip`, attempts to decompress the already-decompressed body, and fails with `ERR_CONTENT_DECODING_FAILED`.

## Fix

Strip `content-encoding` and `content-length` from upstream response headers before forwarding to the client. Applied in both:

- `config-matchers.ts` — `proxyExternalRequest` (used by prod server)
- `app-dev-server.ts` — `__proxyExternalRequest` (inlined in dev server virtual module)