### PR TITLE
fix: sanitize redirect destination in generated worker entry

### DIFF
--- a/packages/vinext/src/deploy.ts
+++ b/packages/vinext/src/deploy.ts
@@ -453,6 +453,7 @@ import {
   requestContextFromRequest,
   isExternalUrl,
   proxyExternalRequest,
+  sanitizeDestination,
 } from "vinext/config/config-matchers";
 
 // @ts-expect-error -- virtual module resolved by vinext at build time
@@ -622,9 +623,11 @@ export default {
       if (configRedirects.length) {
         const redirect = matchRedirect(resolvedPathname, configRedirects, reqCtx);
         if (redirect) {
-          const dest = basePath && !redirect.destination.startsWith(basePath)
-            ? basePath + redirect.destination
-            : redirect.destination;
+          const dest = sanitizeDestination(
+            basePath && !redirect.destination.startsWith(basePath)
+              ? basePath + redirect.destination
+              : redirect.destination,
+          );
           return new Response(null, {
             status: redirect.permanent ? 308 : 307,
             headers: { Location: dest },


### PR DESCRIPTION
## Summary

- The generated Pages Router worker entry (`generatePagesRouterWorkerEntry`) was not wrapping the final redirect destination in `sanitizeDestination()`, unlike the equivalent code in `prod-server.ts`
- Added `sanitizeDestination` to the imports from `vinext/config/config-matchers` in the generated worker template
- Wrapped the redirect destination computation in `sanitizeDestination()` to normalize protocol-relative URLs (e.g. `//evil.com` becomes `/evil.com`) before setting the `Location` header

This brings the generated worker entry in line with `prod-server.ts` which already applies this normalization.