### PR TITLE
docs: add targeted test running guidance for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,9 @@ vinext reimplements the Next.js API surface using Vite, with Cloudflare Workers 
 ### Commands
 
 ```bash
-pnpm test             # Vitest unit + integration tests
+pnpm test             # Vitest — full suite (~2 min, serial)
+pnpm test -- tests/routing.test.ts          # Run a single test file (~seconds)
+pnpm test -- tests/shims.test.ts tests/link.test.ts  # Run specific files
 pnpm run test:e2e     # Playwright E2E tests (5 projects)
 pnpm run typecheck    # TypeScript via tsgo (fast)
 pnpm run lint         # oxlint
@@ -65,7 +67,7 @@ examples/               # User-facing demo apps
 3. **Add tests first** — put test cases in the appropriate `tests/*.test.ts` file
 4. **Implement in shims or server** — most features are either a shim (`next/*` module) or server-side logic
 5. **Add fixture pages if needed** — `tests/fixtures/` has test apps for integration testing
-6. **Run the full test suite** before committing
+6. **Run the relevant test file(s)** to verify your changes (see [Running Tests](#running-tests) below)
 
 ### Searching the Next.js Test Suite
 
@@ -89,6 +91,42 @@ When you find relevant Next.js tests, port the test cases to our test suite and 
 gh search code "middleware" --repo vercel/next.js --filename "*.test.*" --limit 20
 gh search code "must export" --repo vercel/next.js --filename "*.test.*" --limit 10
 ```
+
+### Running Tests
+
+**Always run targeted tests, not the full suite.** The full Vitest suite takes ~2 minutes because test files run serially (to avoid Vite deps optimizer cache races). Running the full suite during development wastes time, especially when multiple agents are working on the repo simultaneously.
+
+**During development**, run only the test file(s) relevant to your change:
+
+```bash
+# Run a single test file (fast — seconds, not minutes)
+pnpm test -- tests/routing.test.ts
+
+# Run a few related files
+pnpm test -- tests/shims.test.ts tests/link.test.ts
+
+# Run all nextjs-compat tests
+pnpm test -- tests/nextjs-compat/
+
+# Run tests matching a name pattern
+pnpm test -- -t "middleware"
+```
+
+**Which test files to run** depends on what you changed:
+
+| If you changed... | Run these tests |
+|-------------------|----------------|
+| A shim (`shims/*.ts`) | `tests/shims.test.ts` + the specific shim test (e.g., `tests/link.test.ts`) |
+| Routing (`routing/*.ts`) | `tests/routing.test.ts`, `tests/route-sorting.test.ts` |
+| App Router server (`server/app-dev-server.ts`) | `tests/app-router.test.ts`, `tests/features.test.ts` |
+| Pages Router server (`server/dev-server.ts`) | `tests/pages-router.test.ts` |
+| Caching/ISR | `tests/isr-cache.test.ts`, `tests/fetch-cache.test.ts`, `tests/kv-cache-handler.test.ts` |
+| Build/deploy | `tests/deploy.test.ts`, `tests/build-optimization.test.ts` |
+| Next.js compat features | `tests/nextjs-compat/` (the relevant file) |
+
+**Let CI run the full suite.** The full `pnpm test` and all 5 Playwright E2E projects run in CI on every PR. You do not need to run the full suite locally before pushing. CI will catch any cross-cutting regressions.
+
+**When to run the full suite locally:** Only if you're making a broad change that touches shared infrastructure (e.g., the Vite plugin's `resolveId` hook, virtual module generation, or the test helpers themselves). Even then, consider pushing and letting CI do it.
 
 ### Fixing Bugs
 


### PR DESCRIPTION
## Summary

- Adds a **Running Tests** section to AGENTS.md with a mapping from source files to relevant test files
- Updates the "Adding a New Feature" workflow to reference targeted tests instead of "run the full test suite"
- Adds targeted test command examples to the Quick Reference commands section

## Motivation

The full Vitest suite runs serially (~2 min) because test files race on Vite's deps optimizer cache when run in parallel. During development, agents almost never need the full suite. They typically touch one area (a shim, a routing file, a server handler) and only need to verify 1-3 test files.

With 3-4 agents working on the repo simultaneously, each running `pnpm test` (2 min serial) creates unnecessary CPU contention. Running targeted tests instead takes seconds.

## Changes

The new section includes:
- Explicit examples of how to run single files, multiple files, and name-pattern matching
- A lookup table mapping source directories to their relevant test files
- Guidance on when to let CI run the full suite vs running it locally

/bigbonk review this