### PR TITLE
Escape closing tags in inline script/style SSR output

### DIFF
--- a/packages/vinext/src/shims/head.ts
+++ b/packages/vinext/src/shims/head.ts
@@ -101,6 +101,13 @@ function reactElementToHTML(child: React.ReactElement): string {
     return `<${tag}${attrStr} data-vinext-head="true" />`;
   }
 
+  // For raw-content tags (script, style), escape closing-tag sequences so the
+  // HTML parser doesn't prematurely terminate the element.
+  const rawContentTags = ["script", "style"];
+  if (rawContentTags.includes(tag) && innerHTML) {
+    innerHTML = escapeInlineContent(innerHTML, tag);
+  }
+
   return `<${tag}${attrStr} data-vinext-head="true">${innerHTML}</${tag}>`;
 }
 
@@ -110,6 +117,22 @@ function escapeHTML(s: string): string {
 
 export function escapeAttr(s: string): string {
   return s.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+/**
+ * Escape content that will be placed inside a raw <script> or <style> tag
+ * during SSR. The HTML parser treats `</script>` (or `</style>`) as the end
+ * of the block regardless of JavaScript string context, so any occurrence
+ * of `</` followed by the tag name must be escaped.
+ *
+ * We replace `</script` and `</style` (case-insensitive) with `<\/script`
+ * and `<\/style` respectively. The `<\/` form is harmless in JS/CSS string
+ * context but prevents the HTML parser from seeing a closing tag.
+ */
+export function escapeInlineContent(content: string, tag: string): string {
+  // Build a pattern like `<\/script` or `<\/style`, case-insensitive
+  const pattern = new RegExp(`<\\/(${tag})`, "gi");
+  return content.replace(pattern, "<\\/$1");
 }
 
 // --- Component ---

--- a/packages/vinext/src/shims/script.tsx
+++ b/packages/vinext/src/shims/script.tsx
@@ -13,6 +13,7 @@
  *   - "worker": sets type="text/partytown" (requires Partytown setup)
  */
 import React, { useEffect, useRef } from "react";
+import { escapeInlineContent } from "./head.js";
 
 export interface ScriptProps {
   /** Script source URL */
@@ -194,7 +195,12 @@ function Script(props: ScriptProps): React.ReactElement | null {
       if (src) scriptProps.src = src;
       if (id) scriptProps.id = id;
       if (dangerouslySetInnerHTML) {
-        scriptProps.dangerouslySetInnerHTML = dangerouslySetInnerHTML;
+        // Escape closing </script> sequences in inline content so the HTML
+        // parser doesn't prematurely terminate the element during SSR.
+        const raw = dangerouslySetInnerHTML.__html;
+        scriptProps.dangerouslySetInnerHTML = {
+          __html: escapeInlineContent(raw, "script"),
+        };
       }
       return React.createElement("script", scriptProps, children);
     }

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -6725,6 +6725,45 @@ describe("next/script SSR rendering", () => {
     expect(html).toContain("console.log('hello')");
   });
 
+  it("beforeInteractive escapes </script> in dangerouslySetInnerHTML", async () => {
+    const React = await import("react");
+    const { renderToStaticMarkup } = await import("react-dom/server");
+    const Script = (await import("../packages/vinext/src/shims/script.js")).default;
+
+    const html = renderToStaticMarkup(
+      React.createElement(Script, {
+        strategy: "beforeInteractive",
+        id: "escape-test",
+        dangerouslySetInnerHTML: {
+          __html: 'var x = "</script><img src=x onerror=alert(1)>";',
+        },
+      }),
+    );
+    // The raw </script> must NOT appear — it would break the tag boundary
+    expect(html).not.toContain("</script><img");
+    // The escaped form should be present instead
+    expect(html).toContain("<\\/script>");
+  });
+
+  it("beforeInteractive escapes </script> case-insensitively", async () => {
+    const React = await import("react");
+    const { renderToStaticMarkup } = await import("react-dom/server");
+    const Script = (await import("../packages/vinext/src/shims/script.js")).default;
+
+    const html = renderToStaticMarkup(
+      React.createElement(Script, {
+        strategy: "beforeInteractive",
+        id: "case-test",
+        dangerouslySetInnerHTML: {
+          __html: 'var x = "</SCRIPT><img src=x onerror=alert(1)>";',
+        },
+      }),
+    );
+    // Mixed-case </SCRIPT> must also be escaped
+    expect(html).not.toContain("</SCRIPT>");
+    expect(html).toContain("<\\/SCRIPT>");
+  });
+
   it("exports handleClientScriptLoad and initScriptLoader", async () => {
     const scriptModule = await import("../packages/vinext/src/shims/script.js");
     expect(typeof scriptModule.handleClientScriptLoad).toBe("function");
@@ -7342,6 +7381,51 @@ describe("next/head SSR security", () => {
     expect(html).toContain("body { color: red; }");
   });
 
+  it("escapes </script> in dangerouslySetInnerHTML for script tags", async () => {
+    const React = await import("react");
+    const html = await collectHeadHTML([
+      React.createElement("script", {
+        dangerouslySetInnerHTML: {
+          __html: 'var x = "</script><img src=x onerror=alert(1)>";',
+        },
+      }),
+    ]);
+
+    // The raw </script> must NOT appear in the output
+    expect(html).not.toContain("</script><img");
+    // The escaped form preserves the JS string content
+    expect(html).toContain("<\\/script>");
+  });
+
+  it("escapes </style> in dangerouslySetInnerHTML for style tags", async () => {
+    const React = await import("react");
+    const html = await collectHeadHTML([
+      React.createElement("style", {
+        dangerouslySetInnerHTML: {
+          __html: "body::after { content: '</style><img src=x onerror=alert(1)>'; }",
+        },
+      }),
+    ]);
+
+    // The raw </style> must NOT appear
+    expect(html).not.toContain("</style><img");
+    expect(html).toContain("<\\/style>");
+  });
+
+  it("escapes case-insensitive closing tags in dangerouslySetInnerHTML", async () => {
+    const React = await import("react");
+    const html = await collectHeadHTML([
+      React.createElement("script", {
+        dangerouslySetInnerHTML: {
+          __html: 'var x = "</SCRIPT><img src=x onerror=alert(1)>";',
+        },
+      }),
+    ]);
+
+    expect(html).not.toContain("</SCRIPT>");
+    expect(html).toContain("<\\/SCRIPT>");
+  });
+
   it("attributes are still properly escaped", async () => {
     const React = await import("react");
     const html = await collectHeadHTML([
@@ -7405,6 +7489,54 @@ describe("next/head SSR security", () => {
       expect(html).toContain(`<${tag}`);
       expect(html).toContain('data-vinext-head="true"');
     }
+  });
+});
+
+describe("escapeInlineContent", () => {
+  it("escapes </script> within script content", async () => {
+    const { escapeInlineContent } = await import("../packages/vinext/src/shims/head.js");
+    const input = 'var x = "</script><img src=x onerror=alert(1)>";';
+    const result = escapeInlineContent(input, "script");
+    expect(result).toBe('var x = "<\\/script><img src=x onerror=alert(1)>";');
+    expect(result).not.toContain("</script>");
+  });
+
+  it("escapes </style> within style content", async () => {
+    const { escapeInlineContent } = await import("../packages/vinext/src/shims/head.js");
+    const input = "body::after { content: '</style><div>'; }";
+    const result = escapeInlineContent(input, "style");
+    expect(result).toBe("body::after { content: '<\\/style><div>'; }");
+    expect(result).not.toContain("</style>");
+  });
+
+  it("handles case-insensitive closing tags", async () => {
+    const { escapeInlineContent } = await import("../packages/vinext/src/shims/head.js");
+    expect(escapeInlineContent("</Script>", "script")).toBe("<\\/Script>");
+    expect(escapeInlineContent("</SCRIPT>", "script")).toBe("<\\/SCRIPT>");
+    expect(escapeInlineContent("</sCrIpT>", "script")).toBe("<\\/sCrIpT>");
+  });
+
+  it("handles multiple occurrences", async () => {
+    const { escapeInlineContent } = await import("../packages/vinext/src/shims/head.js");
+    const input = '</script></script></SCRIPT>';
+    const result = escapeInlineContent(input, "script");
+    expect(result).toBe('<\\/script><\\/script><\\/SCRIPT>');
+    expect(result).not.toContain("</script>");
+    expect(result).not.toContain("</SCRIPT>");
+  });
+
+  it("does not escape unrelated closing tags", async () => {
+    const { escapeInlineContent } = await import("../packages/vinext/src/shims/head.js");
+    // Escaping for "script" should not touch </style>
+    const input = '</style></div>';
+    const result = escapeInlineContent(input, "script");
+    expect(result).toBe('</style></div>');
+  });
+
+  it("passes through content with no closing tags", async () => {
+    const { escapeInlineContent } = await import("../packages/vinext/src/shims/head.js");
+    const input = "console.log('hello world');";
+    expect(escapeInlineContent(input, "script")).toBe(input);
   });
 });
 


### PR DESCRIPTION
## Summary

- Inline `<script>` and `<style>` content rendered during SSR could produce malformed HTML when `dangerouslySetInnerHTML.__html` contained `</script>` or `</style>` sequences. The HTML parser treats these as the end of the containing element regardless of JavaScript/CSS string context, breaking the tag boundary.
- Added `escapeInlineContent()` helper that replaces `</script` and `</style` with `<\/script` and `<\/style` (case-insensitive). Applied in the `next/script` `beforeInteractive` SSR path and `next/head` `reactElementToHTML` for script/style tags.

## Changes

- `packages/vinext/src/shims/head.ts`: Added `escapeInlineContent()` export. Applied it to `dangerouslySetInnerHTML` content for `<script>` and `<style>` tags in `reactElementToHTML()`.
- `packages/vinext/src/shims/script.tsx`: Imported `escapeInlineContent` and applied it to `dangerouslySetInnerHTML.__html` in the `beforeInteractive` SSR path before passing to `React.createElement`.
- `tests/shims.test.ts`: 14 new tests covering the escaping helper (6 unit tests), Script component SSR (2 integration tests), and Head component SSR (3 integration tests), plus 3 existing tests continue to pass.