### PR TITLE
perf: split vitest into unit and integration projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "scripts": {
     "build": "pnpm --filter vinext run build",
     "test": "vitest run",
+    "test:unit": "vitest run --project unit",
+    "test:integration": "vitest run --project integration",
     "test:watch": "vitest",
     "generate:google-fonts": "node scripts/generate-google-fonts.js",
     "typecheck": "tsgo --noEmit",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,24 +1,62 @@
 import { randomUUID } from "node:crypto";
 import { defineConfig } from "vitest/config";
 
+/**
+ * Integration test files that spin up Vite dev servers against shared fixture
+ * directories. These must run serially to avoid Vite deps optimizer cache
+ * races (node_modules/.vite/*) that produce "outdated pre-bundle" 500s.
+ *
+ * When adding a new test file that calls startFixtureServer(), createServer()
+ * from Vite, or spawns a dev server subprocess, add it here.
+ */
+const integrationTests = [
+  "tests/app-router.test.ts",
+  "tests/pages-router.test.ts",
+  "tests/features.test.ts",
+  "tests/cjs.test.ts",
+  "tests/ecosystem.test.ts",
+  "tests/static-export.test.ts",
+  "tests/postcss-resolve.test.ts",
+  "tests/nextjs-compat/**/*.test.ts",
+];
+
+// GitHub Actions reporter adds inline failure annotations in PR diffs.
+const reporters: string[] = process.env.CI
+  ? ["default", "github-actions"]
+  : ["default"];
+
+const env = {
+  // Mirrors the Vite `define` in index.ts that inlines a build-time UUID.
+  // Setting it here means tests exercise the same code path as production.
+  __VINEXT_DRAFT_SECRET: randomUUID(),
+};
+
 export default defineConfig({
   test: {
-    include: ["tests/**/*.test.ts"],
-    testTimeout: 30000,
-    env: {
-      // Mirrors the Vite `define` in index.ts that inlines a build-time UUID.
-      // Setting it here means tests exercise the same code path as production.
-      __VINEXT_DRAFT_SECRET: randomUUID(),
-    },
-    // Multiple suites spin up Vite dev servers against the same fixture dirs.
-    // Running test files in parallel can race on Vite's deps optimizer cache
-    // (node_modules/.vite/*) and produce "outdated pre-bundle" 500s.
+    reporters,
+    // fileParallelism is a global setting in vitest 3.x (cannot be set
+    // per-project). Integration tests need serial execution, so we keep
+    // it disabled globally. The win from the project split is that
+    // `vitest run --project unit` lets you skip integration tests entirely
+    // for a fast feedback loop (~seconds vs ~2 minutes).
     fileParallelism: false,
-    // GitHub Actions reporter adds inline failure annotations in PR diffs.
-    // It's auto-enabled with the default reporter, but being explicit ensures
-    // it survives any future reporter config changes.
-    reporters: process.env.CI
-      ? ["default", "github-actions"]
-      : ["default"],
+    projects: [
+      {
+        test: {
+          name: "unit",
+          include: ["tests/**/*.test.ts"],
+          exclude: integrationTests,
+          env,
+        },
+      },
+      {
+        test: {
+          name: "integration",
+          include: integrationTests,
+          testTimeout: 30000,
+          env,
+        },
+      },
+    ],
   },
 });


### PR DESCRIPTION
## Summary

- Splits the vitest config into two projects: **unit** (28 files) and **integration** (24 files)
- Adds `test:unit` and `test:integration` npm scripts for targeted runs
- No changes to CI (full suite still runs via `pnpm test`)

## Motivation

The full vitest suite takes ~2 minutes because `fileParallelism: false` forces all 52 test files to run serially. This is necessary for integration tests (they race on Vite's deps optimizer cache), but the 28 unit test files don't start dev servers and don't need serial execution.

With vitest 3.x, `fileParallelism` is a global-only setting (it cannot be set per-project), so both projects still run serially when you invoke `pnpm test`. The practical win is that developers and agents can now run subsets:

| Command | What runs | Time |
|---------|-----------|------|
| `pnpm test` | All 52 files (serial) | ~100s |
| `pnpm test:unit` | 28 unit files only (serial) | ~14s |
| `pnpm test:integration` | 24 integration files only (serial) | ~97s |
| `pnpm test -- tests/routing.test.ts` | Single file | ~3s |

When multiple agents are working on the repo simultaneously, `pnpm test:unit` provides a fast feedback loop without the overhead of spinning up Vite dev servers.

## Integration test classification

Tests are classified as integration if they call `startFixtureServer()`, import `createServer` from Vite, or spawn dev server subprocesses. The `integrationTests` array in `vitest.config.ts` documents this and includes guidance for future test authors.

## Future improvement

When vitest adds per-project `fileParallelism` support (tracked in vitest 4.x), unit tests can run in parallel while integration tests remain serial. This would further reduce the full suite runtime.

/bigbonk review this