### PR TITLE
Block access to .vite/ build metadata in production server

### DIFF
--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -194,6 +194,14 @@ function tryServeStatic(
   } catch {
     return false;
   }
+
+  // Block access to internal build metadata directories. The .vite/
+  // directory contains manifests and other build artifacts that should
+  // not be publicly served. Check after decoding to catch encoded
+  // variants like /%2Evite/manifest.json.
+  if (decodedPathname.startsWith("/.vite/") || decodedPathname === "/.vite") {
+    return false;
+  }
   const staticFile = path.resolve(clientDir, "." + decodedPathname);
   if (!staticFile.startsWith(resolvedClient + path.sep) && staticFile !== resolvedClient) {
     return false;

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -1338,6 +1338,19 @@ describe("Production server middleware (Pages Router)", () => {
     const body = await res.text();
     expect(body).toContain("Bad Request");
   });
+
+  it("blocks access to .vite/ build metadata directory", async () => {
+    // The .vite/ directory contains build manifests (ssr-manifest.json,
+    // manifest.json) that should not be publicly accessible.
+    const res = await fetch(`${prodUrl}/.vite/ssr-manifest.json`);
+    expect(res.status).toBe(404);
+  });
+
+  it("blocks access to .vite/ with percent-encoded dot", async () => {
+    // Ensure encoded variants like /%2Evite/ are also blocked
+    const res = await fetch(`${prodUrl}/%2Evite/ssr-manifest.json`);
+    expect(res.status).toBe(404);
+  });
 });
 
 describe("Production server next.config.js features (Pages Router)", () => {


### PR DESCRIPTION
## Summary

- The `.vite/` directory in the client build output contains build manifests (`ssr-manifest.json`, `manifest.json`) and other artifacts that should not be publicly accessible. The `tryServeStatic()` function had no filtering for these paths.
- Added a check in `tryServeStatic()` that rejects requests to `.vite/` paths after URL decoding, which also handles encoded variants like `/%2Evite/`.

## Changes

- `packages/vinext/src/server/prod-server.ts`: Added `.vite/` path check in `tryServeStatic()` after `decodeURIComponent` to block direct and encoded access to build metadata.
- `tests/pages-router.test.ts`: Two new tests verifying `.vite/ssr-manifest.json` returns 404 for both direct and percent-encoded paths.