### PR TITLE
Use append for multi-value headers in config header application

### DIFF
--- a/packages/vinext/src/deploy.ts
+++ b/packages/vinext/src/deploy.ts
@@ -620,7 +620,10 @@ export default {
 
       // ── 4. Apply custom headers from next.config.js ───────────────
       // Config headers are additive for multi-value headers (Vary,
-      // Set-Cookie) and override for everything else.
+      // Set-Cookie) and override for everything else. Vary values are
+      // comma-joined per HTTP spec. Set-Cookie values are comma-joined
+      // here because middlewareHeaders is a flat Record<string, string>;
+      // mergeHeaders() downstream handles multi-value expansion.
       if (configHeaders.length) {
         const matched = matchHeaders(resolvedPathname, configHeaders, reqCtx);
         for (const h of matched) {

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -4040,7 +4040,18 @@ function applyHeaders(
     // (Vary, Set-Cookie). Using setHeader() on these would destroy
     // existing values like "Vary: RSC, Accept".
     const lk = header.key.toLowerCase();
-    if (lk === "vary" || lk === "set-cookie") {
+    if (lk === "set-cookie") {
+      // Node.js res.getHeader("set-cookie") returns string[] when
+      // multiple Set-Cookie headers have been set. Preserve the array.
+      const existing = res.getHeader(lk);
+      if (Array.isArray(existing)) {
+        res.setHeader(header.key, [...existing, header.value]);
+      } else if (existing) {
+        res.setHeader(header.key, [String(existing), header.value]);
+      } else {
+        res.setHeader(header.key, header.value);
+      }
+    } else if (lk === "vary") {
       const existing = res.getHeader(lk);
       if (existing) {
         res.setHeader(header.key, existing + ", " + header.value);

--- a/packages/vinext/src/server/app-dev-server.ts
+++ b/packages/vinext/src/server/app-dev-server.ts
@@ -1261,7 +1261,16 @@ export default async function handler(request) {
                 ${bp ? `if (pathname.startsWith(${JSON.stringify(bp)})) pathname = pathname.slice(${JSON.stringify(bp)}.length) || "/";` : ""}
                 const extraHeaders = __applyConfigHeaders(pathname, __reqCtx);
                 for (const h of extraHeaders) {
-                  response.headers.set(h.key, h.value);
+                  // Use append() for headers where multiple values must coexist
+                  // (Vary, Set-Cookie). Using set() on these would destroy
+                  // existing values like "Vary: RSC, Accept" which are critical
+                  // for correct CDN caching behavior.
+                  const lk = h.key.toLowerCase();
+                  if (lk === "vary" || lk === "set-cookie") {
+                    response.headers.append(h.key, h.value);
+                  } else {
+                    response.headers.set(h.key, h.value);
+                  }
                 }
               }
               // Merge middleware response headers into the final response.

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -857,10 +857,27 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
       let resolvedPathname = resolvedUrl.split("?")[0];
 
       // ── 5. Apply custom headers from next.config.js ───────────────
+      // Config headers are additive for multi-value headers (Vary,
+      // Set-Cookie) and override for everything else. Set-Cookie values
+      // are stored as arrays (RFC 6265 forbids comma-joining cookies).
       if (configHeaders.length) {
         const matched = matchHeaders(resolvedPathname, configHeaders, reqCtx);
         for (const h of matched) {
-          middlewareHeaders[h.key.toLowerCase()] = h.value;
+          const lk = h.key.toLowerCase();
+          if (lk === "set-cookie") {
+            const existing = middlewareHeaders[lk];
+            if (Array.isArray(existing)) {
+              existing.push(h.value);
+            } else if (existing) {
+              (middlewareHeaders as any)[lk] = [existing, h.value];
+            } else {
+              (middlewareHeaders as any)[lk] = [h.value];
+            }
+          } else if (lk === "vary" && middlewareHeaders[lk]) {
+            middlewareHeaders[lk] += ", " + h.value;
+          } else {
+            middlewareHeaders[lk] = h.value;
+          }
         }
       }
 

--- a/tests/fixtures/pages-basic/next.config.mjs
+++ b/tests/fixtures/pages-basic/next.config.mjs
@@ -57,6 +57,11 @@ const nextConfig = {
         missing: [{ type: "cookie", key: "logged-in" }],
         headers: [{ key: "X-Guest-Only-Header", value: "1" }],
       },
+      // Test that Vary headers from config are additive (append, not replace)
+      {
+        source: "/ssr",
+        headers: [{ key: "Vary", value: "Accept-Language" }],
+      },
     ];
   },
 };

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -1504,6 +1504,16 @@ describe("Production server next.config.js features (Pages Router)", () => {
     expect(res.headers.get("x-guest-only-header")).toBeNull();
   });
 
+  it("config Vary header appends instead of replacing existing values", async () => {
+    // The /ssr page has config headers: [{ key: "Vary", value: "Accept-Language" }].
+    // If the response already has a Vary header (e.g. from compression),
+    // the config value should be appended, not replace it.
+    const res = await fetch(`${prodUrl}/ssr`);
+    expect(res.status).toBe(200);
+    const vary = res.headers.get("vary") ?? "";
+    expect(vary).toContain("Accept-Language");
+  });
+
   it("serves normal pages unaffected by config rules", async () => {
     const res = await fetch(`${prodUrl}/`);
     expect(res.status).toBe(200);


### PR DESCRIPTION
## Summary

- Config headers from `next.config.js` were applied using `set()`, which replaces any existing header with the same key. For multi-value headers like `Vary` and `Set-Cookie`, this destroys previously set values. For example, a config header setting `Vary: Accept-Language` would replace the existing `Vary: RSC, Accept` header, breaking CDN caching behavior.
- Changed to use `append()` for `Vary` and `Set-Cookie` headers so values accumulate correctly. All other headers continue to use `set()` (override is the correct behavior for single-value headers).

## Changes

- `packages/vinext/src/server/app-dev-server.ts`: Config header application in handler() wrapper uses `append()` for Vary and Set-Cookie, `set()` for all others.
- `packages/vinext/src/server/prod-server.ts`: Config header merging into middlewareHeaders object concatenates Vary and Set-Cookie values instead of overwriting.
- `tests/fixtures/pages-basic/next.config.mjs`: Added a Vary config header rule on `/ssr`.
- `tests/pages-router.test.ts`: New test verifying Vary config header appears in the response.