### PR TITLE
fix: ensure clientDir exists before writing _headers file

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -3570,6 +3570,7 @@ hydrate();
               "  Cache-Control: public, max-age=31536000, immutable",
               "",
             ].join("\n");
+            fs.mkdirSync(clientDir, { recursive: true });
             fs.writeFileSync(headersPath, headersContent);
           }
         },


### PR DESCRIPTION
## Summary

- The `closeBundle` hook writes `_headers` to `clientDir` (`dist/client/`) without creating the directory first. Only `distDir` (`dist/`) is checked earlier in the hook.
- When build cache is invalidated (e.g., chunk graph changes), `dist/client/` may not exist yet, causing an **ENOENT** error on `writeFileSync`.
- Adds `fs.mkdirSync(clientDir, { recursive: true })` before the write. `recursive: true` is a no-op if the directory already exists, so this is safe on warm builds.

## Reproduction

1. Delete `dist/` entirely (simulating cache invalidation)
2. Run `bun run build`
3. Build fails with `ENOENT: no such file or directory, open 'dist/client/_headers'`

## Fix

Single line addition at `packages/vinext/src/index.ts` — ensures the directory exists before writing.

## Test plan

- [ ] Clean build (`rm -rf dist && bun run build`) succeeds without ENOENT
- [ ] Warm build (re-run `bun run build` with existing `dist/`) still succeeds (no-op `mkdirSync`)
- [ ] `dist/client/_headers` file is generated with correct cache headers