### PR TITLE
fix: preserve multiple Set-Cookie headers in response merging

### DIFF
--- a/examples/pages-router-cloudflare/worker/index.ts
+++ b/examples/pages-router-cloudflare/worker/index.ts
@@ -18,6 +18,7 @@ import {
   isExternalUrl,
   proxyExternalRequest,
 } from "vinext/config/config-matchers";
+import { mergeHeaders } from "vinext/server/worker-utils";
 
 // @ts-expect-error -- virtual module resolved by vinext at build time
 import { renderPage, handleApiRoute, runMiddleware, vinextConfig } from "virtual:vinext-server-entry";
@@ -226,34 +227,3 @@ export default {
   },
 };
 
-/**
- * Merge middleware/config headers into a response.
- * Response headers take precedence over middleware headers.
- * Uses getSetCookie() to preserve multiple Set-Cookie values.
- */
-function mergeHeaders(
-  response: Response,
-  extraHeaders: Record<string, string | string[]>,
-  statusOverride?: number,
-): Response {
-  if (!Object.keys(extraHeaders).length && !statusOverride) return response;
-  const merged = new Headers();
-  for (const [k, v] of Object.entries(extraHeaders)) {
-    if (Array.isArray(v)) {
-      for (const item of v) merged.append(k, item);
-    } else {
-      merged.set(k, v);
-    }
-  }
-  response.headers.forEach((v, k) => {
-    if (k === "set-cookie") return;
-    merged.set(k, v);
-  });
-  const responseCookies = response.headers.getSetCookie?.() ?? [];
-  for (const cookie of responseCookies) merged.append("set-cookie", cookie);
-  return new Response(response.body, {
-    status: statusOverride ?? response.status,
-    statusText: response.statusText,
-    headers: merged,
-  });
-}

--- a/examples/pages-router-cloudflare/worker/index.ts
+++ b/examples/pages-router-cloudflare/worker/index.ts
@@ -158,6 +158,8 @@ export default {
             } else {
               middlewareHeaders[lk] = [h.value];
             }
+          } else if (lk === "vary" && middlewareHeaders[lk]) {
+            middlewareHeaders[lk] += ", " + h.value;
           } else {
             middlewareHeaders[lk] = h.value;
           }

--- a/examples/pages-router-cloudflare/worker/index.ts
+++ b/examples/pages-router-cloudflare/worker/index.ts
@@ -148,7 +148,19 @@ export default {
       if (configHeaders.length) {
         const matched = matchHeaders(resolvedPathname, configHeaders);
         for (const h of matched) {
-          middlewareHeaders[h.key.toLowerCase()] = h.value;
+          const lk = h.key.toLowerCase();
+          if (lk === "set-cookie") {
+            const existing = middlewareHeaders[lk];
+            if (Array.isArray(existing)) {
+              existing.push(h.value);
+            } else if (existing) {
+              middlewareHeaders[lk] = [existing as string, h.value];
+            } else {
+              middlewareHeaders[lk] = [h.value];
+            }
+          } else {
+            middlewareHeaders[lk] = h.value;
+          }
         }
       }
 

--- a/examples/pages-router-cloudflare/worker/index.ts
+++ b/examples/pages-router-cloudflare/worker/index.ts
@@ -77,7 +77,7 @@ export default {
 
       // Run middleware
       let resolvedUrl = urlWithQuery;
-      const middlewareHeaders: Record<string, string> = {};
+      const middlewareHeaders: Record<string, string | string[]> = {};
       let middlewareRewriteStatus: number | undefined;
       if (typeof runMiddleware === "function") {
         const result = await runMiddleware(request);
@@ -94,9 +94,22 @@ export default {
           }
         }
 
+        // Collect middleware response headers to merge into final response.
+        // Use an array for Set-Cookie to preserve multiple values.
         if (result.responseHeaders) {
           for (const [key, value] of result.responseHeaders) {
-            middlewareHeaders[key] = value;
+            if (key === "set-cookie") {
+              const existing = middlewareHeaders[key];
+              if (Array.isArray(existing)) {
+                existing.push(value);
+              } else if (existing) {
+                middlewareHeaders[key] = [existing as string, value];
+              } else {
+                middlewareHeaders[key] = [value];
+              }
+            } else {
+              middlewareHeaders[key] = value;
+            }
           }
         }
         if (result.rewriteUrl) {
@@ -110,7 +123,7 @@ export default {
       const mwReqHeaders: Record<string, string> = {};
       for (const key of Object.keys(middlewareHeaders)) {
         if (key.startsWith(mwReqPrefix)) {
-          mwReqHeaders[key.slice(mwReqPrefix.length)] = middlewareHeaders[key];
+          mwReqHeaders[key.slice(mwReqPrefix.length)] = middlewareHeaders[key] as string;
           delete middlewareHeaders[key];
         }
       }
@@ -216,15 +229,28 @@ export default {
 /**
  * Merge middleware/config headers into a response.
  * Response headers take precedence over middleware headers.
+ * Uses getSetCookie() to preserve multiple Set-Cookie values.
  */
 function mergeHeaders(
   response: Response,
-  extraHeaders: Record<string, string>,
+  extraHeaders: Record<string, string | string[]>,
   statusOverride?: number,
 ): Response {
   if (!Object.keys(extraHeaders).length && !statusOverride) return response;
-  const merged: Record<string, string> = { ...extraHeaders };
-  response.headers.forEach((v, k) => { merged[k] = v; });
+  const merged = new Headers();
+  for (const [k, v] of Object.entries(extraHeaders)) {
+    if (Array.isArray(v)) {
+      for (const item of v) merged.append(k, item);
+    } else {
+      merged.set(k, v);
+    }
+  }
+  response.headers.forEach((v, k) => {
+    if (k === "set-cookie") return;
+    merged.set(k, v);
+  });
+  const responseCookies = response.headers.getSetCookie?.() ?? [];
+  for (const cookie of responseCookies) merged.append("set-cookie", cookie);
   return new Response(response.body, {
     status: statusOverride ?? response.status,
     statusText: response.statusText,

--- a/examples/realworld-api-rest/worker/index.ts
+++ b/examples/realworld-api-rest/worker/index.ts
@@ -18,6 +18,7 @@ import {
   isExternalUrl,
   proxyExternalRequest,
 } from "vinext/config/config-matchers";
+import { mergeHeaders } from "vinext/server/worker-utils";
 
 // @ts-expect-error -- virtual module resolved by vinext at build time
 import { renderPage, handleApiRoute, runMiddleware, vinextConfig } from "virtual:vinext-server-entry";
@@ -226,34 +227,3 @@ export default {
   },
 };
 
-/**
- * Merge middleware/config headers into a response.
- * Response headers take precedence over middleware headers.
- * Uses getSetCookie() to preserve multiple Set-Cookie values.
- */
-function mergeHeaders(
-  response: Response,
-  extraHeaders: Record<string, string | string[]>,
-  statusOverride?: number,
-): Response {
-  if (!Object.keys(extraHeaders).length && !statusOverride) return response;
-  const merged = new Headers();
-  for (const [k, v] of Object.entries(extraHeaders)) {
-    if (Array.isArray(v)) {
-      for (const item of v) merged.append(k, item);
-    } else {
-      merged.set(k, v);
-    }
-  }
-  response.headers.forEach((v, k) => {
-    if (k === "set-cookie") return;
-    merged.set(k, v);
-  });
-  const responseCookies = response.headers.getSetCookie?.() ?? [];
-  for (const cookie of responseCookies) merged.append("set-cookie", cookie);
-  return new Response(response.body, {
-    status: statusOverride ?? response.status,
-    statusText: response.statusText,
-    headers: merged,
-  });
-}

--- a/examples/realworld-api-rest/worker/index.ts
+++ b/examples/realworld-api-rest/worker/index.ts
@@ -158,6 +158,8 @@ export default {
             } else {
               middlewareHeaders[lk] = [h.value];
             }
+          } else if (lk === "vary" && middlewareHeaders[lk]) {
+            middlewareHeaders[lk] += ", " + h.value;
           } else {
             middlewareHeaders[lk] = h.value;
           }

--- a/examples/realworld-api-rest/worker/index.ts
+++ b/examples/realworld-api-rest/worker/index.ts
@@ -148,7 +148,19 @@ export default {
       if (configHeaders.length) {
         const matched = matchHeaders(resolvedPathname, configHeaders);
         for (const h of matched) {
-          middlewareHeaders[h.key.toLowerCase()] = h.value;
+          const lk = h.key.toLowerCase();
+          if (lk === "set-cookie") {
+            const existing = middlewareHeaders[lk];
+            if (Array.isArray(existing)) {
+              existing.push(h.value);
+            } else if (existing) {
+              middlewareHeaders[lk] = [existing as string, h.value];
+            } else {
+              middlewareHeaders[lk] = [h.value];
+            }
+          } else {
+            middlewareHeaders[lk] = h.value;
+          }
         }
       }
 

--- a/examples/realworld-api-rest/worker/index.ts
+++ b/examples/realworld-api-rest/worker/index.ts
@@ -77,7 +77,7 @@ export default {
 
       // Run middleware
       let resolvedUrl = urlWithQuery;
-      const middlewareHeaders: Record<string, string> = {};
+      const middlewareHeaders: Record<string, string | string[]> = {};
       let middlewareRewriteStatus: number | undefined;
       if (typeof runMiddleware === "function") {
         const result = await runMiddleware(request);
@@ -94,9 +94,22 @@ export default {
           }
         }
 
+        // Collect middleware response headers to merge into final response.
+        // Use an array for Set-Cookie to preserve multiple values.
         if (result.responseHeaders) {
           for (const [key, value] of result.responseHeaders) {
-            middlewareHeaders[key] = value;
+            if (key === "set-cookie") {
+              const existing = middlewareHeaders[key];
+              if (Array.isArray(existing)) {
+                existing.push(value);
+              } else if (existing) {
+                middlewareHeaders[key] = [existing as string, value];
+              } else {
+                middlewareHeaders[key] = [value];
+              }
+            } else {
+              middlewareHeaders[key] = value;
+            }
           }
         }
         if (result.rewriteUrl) {
@@ -110,7 +123,7 @@ export default {
       const mwReqHeaders: Record<string, string> = {};
       for (const key of Object.keys(middlewareHeaders)) {
         if (key.startsWith(mwReqPrefix)) {
-          mwReqHeaders[key.slice(mwReqPrefix.length)] = middlewareHeaders[key];
+          mwReqHeaders[key.slice(mwReqPrefix.length)] = middlewareHeaders[key] as string;
           delete middlewareHeaders[key];
         }
       }
@@ -216,15 +229,28 @@ export default {
 /**
  * Merge middleware/config headers into a response.
  * Response headers take precedence over middleware headers.
+ * Uses getSetCookie() to preserve multiple Set-Cookie values.
  */
 function mergeHeaders(
   response: Response,
-  extraHeaders: Record<string, string>,
+  extraHeaders: Record<string, string | string[]>,
   statusOverride?: number,
 ): Response {
   if (!Object.keys(extraHeaders).length && !statusOverride) return response;
-  const merged: Record<string, string> = { ...extraHeaders };
-  response.headers.forEach((v, k) => { merged[k] = v; });
+  const merged = new Headers();
+  for (const [k, v] of Object.entries(extraHeaders)) {
+    if (Array.isArray(v)) {
+      for (const item of v) merged.append(k, item);
+    } else {
+      merged.set(k, v);
+    }
+  }
+  response.headers.forEach((v, k) => {
+    if (k === "set-cookie") return;
+    merged.set(k, v);
+  });
+  const responseCookies = response.headers.getSetCookie?.() ?? [];
+  for (const cookie of responseCookies) merged.append("set-cookie", cookie);
   return new Response(response.body, {
     status: statusOverride ?? response.status,
     statusText: response.statusText,

--- a/packages/vinext/package.json
+++ b/packages/vinext/package.json
@@ -44,6 +44,10 @@
     "./config/config-matchers": {
       "import": "./dist/config/config-matchers.js",
       "types": "./dist/config/config-matchers.d.ts"
+    },
+    "./server/worker-utils": {
+      "import": "./dist/server/worker-utils.js",
+      "types": "./dist/server/worker-utils.d.ts"
     }
   },
   "files": [

--- a/packages/vinext/src/deploy.ts
+++ b/packages/vinext/src/deploy.ts
@@ -548,7 +548,7 @@ export default {
 
       // ── 3. Run middleware ──────────────────────────────────────────
       let resolvedUrl = urlWithQuery;
-      const middlewareHeaders: Record<string, string> = {};
+      const middlewareHeaders: Record<string, string | string[]> = {};
       let middlewareRewriteStatus: number | undefined;
       if (typeof runMiddleware === "function") {
         const result = await runMiddleware(request);
@@ -565,10 +565,22 @@ export default {
           }
         }
 
-        // Collect middleware response headers to merge into final response
+        // Collect middleware response headers to merge into final response.
+        // Use an array for Set-Cookie to preserve multiple values.
         if (result.responseHeaders) {
           for (const [key, value] of result.responseHeaders) {
-            middlewareHeaders[key] = value;
+            if (key.toLowerCase() === "set-cookie") {
+              const existing = middlewareHeaders[key];
+              if (Array.isArray(existing)) {
+                existing.push(value);
+              } else if (existing) {
+                middlewareHeaders[key] = [existing, value];
+              } else {
+                middlewareHeaders[key] = [value];
+              }
+            } else {
+              middlewareHeaders[key] = value;
+            }
           }
         }
 
@@ -699,18 +711,32 @@ export default {
 /**
  * Merge middleware/config headers into a response.
  * Response headers take precedence over middleware headers, matching
- * the behavior in prod-server.ts.
+ * the behavior in prod-server.ts. Uses getSetCookie() to preserve
+ * multiple Set-Cookie values.
  */
 function mergeHeaders(
   response: Response,
-  extraHeaders: Record<string, string>,
+  extraHeaders: Record<string, string | string[]>,
   statusOverride?: number,
 ): Response {
   if (!Object.keys(extraHeaders).length && !statusOverride) return response;
-  // Middleware/config headers go in first (lower precedence), then
-  // response headers overlay them (higher precedence).
-  const merged: Record<string, string> = { ...extraHeaders };
-  response.headers.forEach((v, k) => { merged[k] = v; });
+  const merged = new Headers();
+  // Middleware/config headers go in first (lower precedence)
+  for (const [k, v] of Object.entries(extraHeaders)) {
+    if (Array.isArray(v)) {
+      for (const item of v) merged.append(k, item);
+    } else {
+      merged.set(k, v);
+    }
+  }
+  // Response headers overlay them (higher precedence), except Set-Cookie
+  // which is additive (both middleware and response cookies should be sent).
+  response.headers.forEach((v, k) => {
+    if (k.toLowerCase() === "set-cookie") return;
+    merged.set(k, v);
+  });
+  const responseCookies = response.headers.getSetCookie?.() ?? [];
+  for (const cookie of responseCookies) merged.append("set-cookie", cookie);
   return new Response(response.body, {
     status: statusOverride ?? response.status,
     statusText: response.statusText,

--- a/packages/vinext/src/deploy.ts
+++ b/packages/vinext/src/deploy.ts
@@ -569,7 +569,7 @@ export default {
         // Use an array for Set-Cookie to preserve multiple values.
         if (result.responseHeaders) {
           for (const [key, value] of result.responseHeaders) {
-            if (key.toLowerCase() === "set-cookie") {
+            if (key === "set-cookie") {
               const existing = middlewareHeaders[key];
               if (Array.isArray(existing)) {
                 existing.push(value);
@@ -732,7 +732,7 @@ function mergeHeaders(
   // Response headers overlay them (higher precedence), except Set-Cookie
   // which is additive (both middleware and response cookies should be sent).
   response.headers.forEach((v, k) => {
-    if (k.toLowerCase() === "set-cookie") return;
+    if (k === "set-cookie") return;
     merged.set(k, v);
   });
   const responseCookies = response.headers.getSetCookie?.() ?? [];

--- a/packages/vinext/src/deploy.ts
+++ b/packages/vinext/src/deploy.ts
@@ -574,7 +574,7 @@ export default {
               if (Array.isArray(existing)) {
                 existing.push(value);
               } else if (existing) {
-                middlewareHeaders[key] = [existing, value];
+                middlewareHeaders[key] = [existing as string, value];
               } else {
                 middlewareHeaders[key] = [value];
               }

--- a/packages/vinext/src/deploy.ts
+++ b/packages/vinext/src/deploy.ts
@@ -633,22 +633,30 @@ export default {
       let resolvedPathname = resolvedUrl.split("?")[0];
 
       // ── 4. Apply custom headers from next.config.js ───────────────
-      // Config headers are additive for multi-value headers (Vary,
-      // Set-Cookie) and override for everything else. Vary values are
-      // comma-joined per HTTP spec. Set-Cookie values are comma-joined
-      // here because middlewareHeaders is a flat Record<string, string>;
-      // mergeHeaders() downstream handles multi-value expansion.
-      if (configHeaders.length) {
-        const matched = matchHeaders(resolvedPathname, configHeaders, reqCtx);
-        for (const h of matched) {
-          const lk = h.key.toLowerCase();
-          if ((lk === "vary" || lk === "set-cookie") && middlewareHeaders[lk]) {
-            middlewareHeaders[lk] += ", " + h.value;
-          } else {
-            middlewareHeaders[lk] = h.value;
-          }
-        }
-      }
+       // Config headers are additive for multi-value headers (Vary,
+       // Set-Cookie) and override for everything else. Vary values are
+       // comma-joined per HTTP spec. Set-Cookie values are accumulated
+       // as arrays (RFC 6265 forbids comma-joining cookies).
+       if (configHeaders.length) {
+         const matched = matchHeaders(resolvedPathname, configHeaders, reqCtx);
+         for (const h of matched) {
+           const lk = h.key.toLowerCase();
+           if (lk === "set-cookie") {
+             const existing = middlewareHeaders[lk];
+             if (Array.isArray(existing)) {
+               existing.push(h.value);
+             } else if (existing) {
+               middlewareHeaders[lk] = [existing as string, h.value];
+             } else {
+               middlewareHeaders[lk] = [h.value];
+             }
+           } else if (lk === "vary" && middlewareHeaders[lk]) {
+             middlewareHeaders[lk] += ", " + h.value;
+           } else {
+             middlewareHeaders[lk] = h.value;
+           }
+         }
+       }
 
       // ── 5. Apply redirects from next.config.js ────────────────────
       if (configRedirects.length) {
@@ -729,9 +737,10 @@ export default {
 
 /**
  * Merge middleware/config headers into a response.
- * Response headers take precedence over middleware headers, matching
- * the behavior in prod-server.ts. Uses getSetCookie() to preserve
- * multiple Set-Cookie values.
+  * Response headers take precedence over middleware headers for all headers
+  * except Set-Cookie, which is additive (both middleware and response cookies
+  * are preserved). Matches the behavior in prod-server.ts. Uses getSetCookie()
+  * to preserve multiple Set-Cookie values.
  */
 function mergeHeaders(
   response: Response,

--- a/packages/vinext/src/deploy.ts
+++ b/packages/vinext/src/deploy.ts
@@ -633,30 +633,30 @@ export default {
       let resolvedPathname = resolvedUrl.split("?")[0];
 
       // ── 4. Apply custom headers from next.config.js ───────────────
-       // Config headers are additive for multi-value headers (Vary,
-       // Set-Cookie) and override for everything else. Vary values are
-       // comma-joined per HTTP spec. Set-Cookie values are accumulated
-       // as arrays (RFC 6265 forbids comma-joining cookies).
-       if (configHeaders.length) {
-         const matched = matchHeaders(resolvedPathname, configHeaders, reqCtx);
-         for (const h of matched) {
-           const lk = h.key.toLowerCase();
-           if (lk === "set-cookie") {
-             const existing = middlewareHeaders[lk];
-             if (Array.isArray(existing)) {
-               existing.push(h.value);
-             } else if (existing) {
-               middlewareHeaders[lk] = [existing as string, h.value];
-             } else {
-               middlewareHeaders[lk] = [h.value];
-             }
-           } else if (lk === "vary" && middlewareHeaders[lk]) {
-             middlewareHeaders[lk] += ", " + h.value;
-           } else {
-             middlewareHeaders[lk] = h.value;
-           }
-         }
-       }
+      // Config headers are additive for multi-value headers (Vary,
+      // Set-Cookie) and override for everything else. Vary values are
+      // comma-joined per HTTP spec. Set-Cookie values are accumulated
+      // as arrays (RFC 6265 forbids comma-joining cookies).
+      if (configHeaders.length) {
+        const matched = matchHeaders(resolvedPathname, configHeaders, reqCtx);
+        for (const h of matched) {
+          const lk = h.key.toLowerCase();
+          if (lk === "set-cookie") {
+            const existing = middlewareHeaders[lk];
+            if (Array.isArray(existing)) {
+              existing.push(h.value);
+            } else if (existing) {
+              middlewareHeaders[lk] = [existing as string, h.value];
+            } else {
+              middlewareHeaders[lk] = [h.value];
+            }
+          } else if (lk === "vary" && middlewareHeaders[lk]) {
+            middlewareHeaders[lk] += ", " + h.value;
+          } else {
+            middlewareHeaders[lk] = h.value;
+          }
+        }
+      }
 
       // ── 5. Apply redirects from next.config.js ────────────────────
       if (configRedirects.length) {
@@ -737,10 +737,10 @@ export default {
 
 /**
  * Merge middleware/config headers into a response.
-  * Response headers take precedence over middleware headers for all headers
-  * except Set-Cookie, which is additive (both middleware and response cookies
-  * are preserved). Matches the behavior in prod-server.ts. Uses getSetCookie()
-  * to preserve multiple Set-Cookie values.
+ * Response headers take precedence over middleware headers for all headers
+ * except Set-Cookie, which is additive (both middleware and response cookies
+ * are preserved). Matches the behavior in prod-server.ts. Uses getSetCookie()
+ * to preserve multiple Set-Cookie values.
  */
 function mergeHeaders(
   response: Response,

--- a/packages/vinext/src/deploy.ts
+++ b/packages/vinext/src/deploy.ts
@@ -601,7 +601,7 @@ export default {
       for (const key of Object.keys(middlewareHeaders)) {
         if (key.startsWith(mwReqPrefix)) {
           const realName = key.slice(mwReqPrefix.length);
-          mwReqHeaders[realName] = middlewareHeaders[key];
+          mwReqHeaders[realName] = middlewareHeaders[key] as string;
           delete middlewareHeaders[key];
         } else if (key.startsWith("x-middleware-")) {
           delete middlewareHeaders[key];

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -116,8 +116,9 @@ function mergeResponseHeaders(
   const merged: Record<string, string | string[]> = { ...middlewareHeaders };
 
   // Copy all non-Set-Cookie headers from the response (response wins on conflict)
+  // Headers.forEach() always yields lowercase keys
   response.headers.forEach((v, k) => {
-    if (k.toLowerCase() === "set-cookie") return;
+    if (k === "set-cookie") return;
     merged[k] = v;
   });
 
@@ -821,7 +822,7 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
             // using getSetCookie() for cookies and forEach for the rest.
             const respHeaders: Record<string, string | string[]> = {};
             result.response.headers.forEach((value: string, key: string) => {
-              if (key.toLowerCase() === "set-cookie") return; // handled below
+              if (key === "set-cookie") return; // handled below
               respHeaders[key] = value;
             });
             const setCookies = result.response.headers.getSetCookie?.() ?? [];
@@ -836,7 +837,7 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
         // Use an array for Set-Cookie to preserve multiple values.
         if (result.responseHeaders) {
           for (const [key, value] of result.responseHeaders) {
-            if (key.toLowerCase() === "set-cookie") {
+            if (key === "set-cookie") {
               const existing = middlewareHeaders[key];
               if (Array.isArray(existing)) {
                 existing.push(value);

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -901,9 +901,9 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
             if (Array.isArray(existing)) {
               existing.push(h.value);
             } else if (existing) {
-              (middlewareHeaders as any)[lk] = [existing, h.value];
+              middlewareHeaders[lk] = [existing as string, h.value];
             } else {
-              (middlewareHeaders as any)[lk] = [h.value];
+              middlewareHeaders[lk] = [h.value];
             }
           } else if (lk === "vary" && middlewareHeaders[lk]) {
             middlewareHeaders[lk] += ", " + h.value;

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -105,6 +105,36 @@ function createCompressor(encoding: "br" | "gzip" | "deflate"): zlib.BrotliCompr
 }
 
 /**
+ * Merge middleware headers and a Web Response's headers into a single
+ * record suitable for Node.js `res.writeHead()`. Uses `getSetCookie()`
+ * to preserve multiple Set-Cookie values instead of flattening them.
+ */
+function mergeResponseHeaders(
+  middlewareHeaders: Record<string, string | string[]>,
+  response: Response,
+): Record<string, string | string[]> {
+  const merged: Record<string, string | string[]> = { ...middlewareHeaders };
+
+  // Copy all non-Set-Cookie headers from the response (response wins on conflict)
+  response.headers.forEach((v, k) => {
+    if (k.toLowerCase() === "set-cookie") return;
+    merged[k] = v;
+  });
+
+  // Preserve multiple Set-Cookie headers using getSetCookie()
+  const responseCookies = response.headers.getSetCookie?.() ?? [];
+  if (responseCookies.length > 0) {
+    const existing = merged["set-cookie"];
+    const mwCookies = existing
+      ? (Array.isArray(existing) ? existing : [existing])
+      : [];
+    merged["set-cookie"] = [...mwCookies, ...responseCookies];
+  }
+
+  return merged;
+}
+
+/**
  * Send a compressed response if the content type is compressible and the
  * client supports compression. Otherwise send uncompressed.
  */
@@ -114,7 +144,7 @@ function sendCompressed(
   body: string | Buffer,
   contentType: string,
   statusCode: number,
-  extraHeaders: Record<string, string> = {},
+  extraHeaders: Record<string, string | string[]> = {},
   compress: boolean = true,
 ): void {
   const buf = typeof body === "string" ? Buffer.from(body) : body;
@@ -770,7 +800,7 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
 
       // ── 4. Run middleware ─────────────────────────────────────────
       let resolvedUrl = url;
-      const middlewareHeaders: Record<string, string> = {};
+      const middlewareHeaders: Record<string, string | string[]> = {};
       let middlewareRewriteStatus: number | undefined;
       if (typeof runMiddleware === "function") {
         const result = await runMiddleware(webRequest);
@@ -810,9 +840,9 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
               if (Array.isArray(existing)) {
                 existing.push(value);
               } else if (existing) {
-                (middlewareHeaders as any)[key] = [existing, value];
+                middlewareHeaders[key] = [existing as string, value];
               } else {
-                (middlewareHeaders as any)[key] = [value];
+                middlewareHeaders[key] = [value];
               }
             } else {
               middlewareHeaders[key] = value;
@@ -839,7 +869,7 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
       for (const key of Object.keys(middlewareHeaders)) {
         if (key.startsWith(mwReqPrefix)) {
           const realName = key.slice(mwReqPrefix.length);
-          webRequest.headers.set(realName, middlewareHeaders[key]);
+          webRequest.headers.set(realName, middlewareHeaders[key] as string);
           delete middlewareHeaders[key];
         } else if (key.startsWith("x-middleware-")) {
           delete middlewareHeaders[key];
@@ -900,8 +930,7 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
         // Merge middleware + config headers into the response
         const responseBody = Buffer.from(await response.arrayBuffer());
         const ct = response.headers.get("content-type") ?? "text/html";
-        const responseHeaders: Record<string, string> = { ...middlewareHeaders };
-        response.headers.forEach((v, k) => { responseHeaders[k] = v; });
+        const responseHeaders = mergeResponseHeaders(middlewareHeaders, response);
 
         sendCompressed(req, res, responseBody, ct, middlewareRewriteStatus ?? response.status, responseHeaders, compress);
         return;
@@ -949,8 +978,7 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
       // Merge middleware + config headers into the response
       const responseBody = Buffer.from(await response.arrayBuffer());
       const ct = response.headers.get("content-type") ?? "text/html";
-      const responseHeaders: Record<string, string> = { ...middlewareHeaders };
-      response.headers.forEach((v, k) => { responseHeaders[k] = v; });
+      const responseHeaders = mergeResponseHeaders(middlewareHeaders, response);
 
       sendCompressed(req, res, responseBody, ct, middlewareRewriteStatus ?? response.status, responseHeaders, compress);
     } catch (e) {
@@ -973,4 +1001,4 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
 }
 
 // Export helpers for testing
-export { sendCompressed, negotiateEncoding, COMPRESSIBLE_TYPES, COMPRESS_THRESHOLD, resolveHost, trustedHosts, trustProxy, nodeToWebRequest };
+export { sendCompressed, negotiateEncoding, COMPRESSIBLE_TYPES, COMPRESS_THRESHOLD, resolveHost, trustedHosts, trustProxy, nodeToWebRequest, mergeResponseHeaders };

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -156,11 +156,12 @@ function sendCompressed(
     // Merge Accept-Encoding into existing Vary header from extraHeaders instead
     // of overwriting. Preserves Vary values set by the App Router for content
     // negotiation (e.g. "RSC, Accept").
-    const existingVary = extraHeaders["Vary"] ?? extraHeaders["vary"];
+    const rawVary = extraHeaders["Vary"] ?? extraHeaders["vary"];
+    const existingVary = Array.isArray(rawVary) ? rawVary.join(", ") : rawVary;
     let varyValue: string;
     if (existingVary) {
-      const existing = String(existingVary).toLowerCase();
-      varyValue = existing.includes("accept-encoding") ? String(existingVary) : existingVary + ", Accept-Encoding";
+      const existing = existingVary.toLowerCase();
+      varyValue = existing.includes("accept-encoding") ? existingVary : existingVary + ", Accept-Encoding";
     } else {
       varyValue = "Accept-Encoding";
     }

--- a/packages/vinext/src/server/worker-utils.ts
+++ b/packages/vinext/src/server/worker-utils.ts
@@ -1,0 +1,39 @@
+/**
+ * Shared utilities for Cloudflare Worker entries.
+ *
+ * Used by hand-written example worker entries and can be imported as
+ * "vinext/server/worker-utils". The generated worker entry (deploy.ts)
+ * inlines these functions in its template string.
+ */
+
+/**
+ * Merge middleware/config headers into a response.
+ * Response headers take precedence over middleware headers.
+ * Uses getSetCookie() to preserve multiple Set-Cookie values.
+ */
+export function mergeHeaders(
+  response: Response,
+  extraHeaders: Record<string, string | string[]>,
+  statusOverride?: number,
+): Response {
+  if (!Object.keys(extraHeaders).length && !statusOverride) return response;
+  const merged = new Headers();
+  for (const [k, v] of Object.entries(extraHeaders)) {
+    if (Array.isArray(v)) {
+      for (const item of v) merged.append(k, item);
+    } else {
+      merged.set(k, v);
+    }
+  }
+  response.headers.forEach((v, k) => {
+    if (k === "set-cookie") return;
+    merged.set(k, v);
+  });
+  const responseCookies = response.headers.getSetCookie?.() ?? [];
+  for (const cookie of responseCookies) merged.append("set-cookie", cookie);
+  return new Response(response.body, {
+    status: statusOverride ?? response.status,
+    statusText: response.statusText,
+    headers: merged,
+  });
+}

--- a/packages/vinext/src/server/worker-utils.ts
+++ b/packages/vinext/src/server/worker-utils.ts
@@ -8,8 +8,9 @@
 
 /**
  * Merge middleware/config headers into a response.
- * Response headers take precedence over middleware headers.
- * Uses getSetCookie() to preserve multiple Set-Cookie values.
+ * Response headers take precedence over middleware headers for all headers
+ * except Set-Cookie, which is additive (both middleware and response cookies
+ * are preserved). Uses getSetCookie() to preserve multiple Set-Cookie values.
  */
 export function mergeHeaders(
   response: Response,

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -18,6 +18,7 @@ import {
   isPackageResolvable,
 } from "../packages/vinext/src/deploy.js";
 import { computeLazyChunks } from "../packages/vinext/src/index.js";
+import { mergeHeaders } from "../packages/vinext/src/server/worker-utils.js";
 
 // ─── Test Helpers ────────────────────────────────────────────────────────────
 
@@ -545,6 +546,32 @@ describe("generatePagesRouterWorkerEntry", () => {
     // mergeHeaders uses Headers API and getSetCookie() to preserve multi-value cookies.
     expect(content).toContain("merged.set(k, v)");
     expect(content).toContain("getSetCookie");
+  });
+
+  it("mergeHeaders preserves multiple Set-Cookie headers from both middleware and response", () => {
+    // Behavioral test for the mergeHeaders function inlined in the generated worker entry.
+    // worker-utils.ts exports the same function — kept in sync with the deploy.ts template.
+    const response = new Response("body", {
+      headers: [
+        ["set-cookie", "resp=1; Path=/"],
+        ["set-cookie", "resp=2; Path=/"],
+        ["content-type", "text/html"],
+      ],
+    });
+    const extraHeaders: Record<string, string | string[]> = {
+      "set-cookie": ["mw=1; Path=/"],
+      "x-custom": "from-middleware",
+    };
+
+    const merged = mergeHeaders(response, extraHeaders);
+    const cookies = merged.headers.getSetCookie();
+    expect(cookies).toContain("mw=1; Path=/");
+    expect(cookies).toContain("resp=1; Path=/");
+    expect(cookies).toContain("resp=2; Path=/");
+    // Response takes precedence for non-Set-Cookie headers
+    expect(merged.headers.get("content-type")).toBe("text/html");
+    // Middleware-only headers are preserved
+    expect(merged.headers.get("x-custom")).toBe("from-middleware");
   });
 
   it("preserves x-middleware-request-* headers for prod request override handling", () => {

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -542,9 +542,9 @@ describe("generatePagesRouterWorkerEntry", () => {
     expect(content).toContain("mergeHeaders");
     expect(content).toContain("middlewareHeaders");
     // Response headers must override middleware headers (matching prod-server).
-    // mergeHeaders should spread extraHeaders first, then overlay response headers.
-    expect(content).toContain("{ ...extraHeaders }");
-    expect(content).toContain("response.headers.forEach");
+    // mergeHeaders uses Headers API and getSetCookie() to preserve multi-value cookies.
+    expect(content).toContain("merged.set(k, v)");
+    expect(content).toContain("getSetCookie");
   });
 
   it("preserves x-middleware-request-* headers for prod request override handling", () => {

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -2726,6 +2726,87 @@ describe("production server compression", () => {
   });
 });
 
+describe("Set-Cookie header preservation in prod-server", () => {
+  it("mergeResponseHeaders preserves multiple Set-Cookie from response", async () => {
+    const { mergeResponseHeaders } = await import(
+      "../packages/vinext/src/server/prod-server.js"
+    );
+
+    const middlewareHeaders: Record<string, string | string[]> = {};
+    const response = new Response("ok", {
+      headers: [
+        ["set-cookie", "a=1; Path=/"],
+        ["set-cookie", "b=2; Path=/"],
+        ["content-type", "text/html"],
+      ],
+    });
+
+    const merged = mergeResponseHeaders(middlewareHeaders, response);
+    expect(merged["set-cookie"]).toEqual(["a=1; Path=/", "b=2; Path=/"]);
+    expect(merged["content-type"]).toBe("text/html");
+  });
+
+  it("mergeResponseHeaders merges middleware and response Set-Cookie", async () => {
+    const { mergeResponseHeaders } = await import(
+      "../packages/vinext/src/server/prod-server.js"
+    );
+
+    const middlewareHeaders: Record<string, string | string[]> = {
+      "set-cookie": ["mw=1; Path=/"],
+    };
+    const response = new Response("ok", {
+      headers: [
+        ["set-cookie", "resp=2; Path=/"],
+      ],
+    });
+
+    const merged = mergeResponseHeaders(middlewareHeaders, response);
+    expect(merged["set-cookie"]).toEqual(["mw=1; Path=/", "resp=2; Path=/"]);
+  });
+
+  it("mergeResponseHeaders does not duplicate non-Set-Cookie headers", async () => {
+    const { mergeResponseHeaders } = await import(
+      "../packages/vinext/src/server/prod-server.js"
+    );
+
+    const middlewareHeaders: Record<string, string | string[]> = {
+      "x-custom": "from-middleware",
+    };
+    const response = new Response("ok", {
+      headers: [
+        ["x-custom", "from-response"],
+        ["content-type", "text/html"],
+      ],
+    });
+
+    const merged = mergeResponseHeaders(middlewareHeaders, response);
+    // Response headers should override middleware headers for non-Set-Cookie
+    expect(merged["x-custom"]).toBe("from-response");
+  });
+
+  it("sendCompressed passes array-valued Set-Cookie to writeHead", async () => {
+    const { sendCompressed } = await import(
+      "../packages/vinext/src/server/prod-server.js"
+    );
+
+    let writtenHeaders: Record<string, string | string[]> = {};
+    const req = { headers: {} };
+    const res = {
+      writeHead: (_status: number, headers: Record<string, string | string[]>) => {
+        writtenHeaders = headers;
+      },
+      end: () => {},
+    };
+
+    const extraHeaders: Record<string, string | string[]> = {
+      "set-cookie": ["a=1; Path=/", "b=2; Path=/"],
+    };
+
+    sendCompressed(req as any, res as any, "small body", "text/html", 200, extraHeaders, false);
+    expect(writtenHeaders["set-cookie"]).toEqual(["a=1; Path=/", "b=2; Path=/"]);
+  });
+});
+
 describe("host header poisoning prevention", () => {
   it("resolveHost ignores X-Forwarded-Host by default", async () => {
     const { resolveHost } = await import(

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -2764,6 +2764,24 @@ describe("Set-Cookie header preservation in prod-server", () => {
     expect(merged["set-cookie"]).toEqual(["mw=1; Path=/", "resp=2; Path=/"]);
   });
 
+  it("mergeResponseHeaders handles middleware cookie as plain string", async () => {
+    const { mergeResponseHeaders } = await import(
+      "../packages/vinext/src/server/prod-server.js"
+    );
+
+    const middlewareHeaders: Record<string, string | string[]> = {
+      "set-cookie": "mw=1; Path=/",
+    };
+    const response = new Response("ok", {
+      headers: [
+        ["set-cookie", "resp=2; Path=/"],
+      ],
+    });
+
+    const merged = mergeResponseHeaders(middlewareHeaders, response);
+    expect(merged["set-cookie"]).toEqual(["mw=1; Path=/", "resp=2; Path=/"]);
+  });
+
   it("mergeResponseHeaders does not duplicate non-Set-Cookie headers", async () => {
     const { mergeResponseHeaders } = await import(
       "../packages/vinext/src/server/prod-server.js"


### PR DESCRIPTION
## Summary

- Fixes Set-Cookie headers being flattened to a single value in `prod-server.ts` and the generated Cloudflare worker entry (`deploy.ts`)
- The `Record<string, string>` pattern caused multiple Set-Cookie values to be overwritten (last wins) or corrupted by comma-joining (breaking cookies with `Expires` dates)
- Extracts `mergeResponseHeaders()` helper using `getSetCookie()` (Node 20+) to preserve array-valued Set-Cookie
- Applies the same fix to the worker entry template in `deploy.ts` using the `Headers` API
- Fixes both the API route path and the SSR page rendering path in prod-server

Fixes #295

## Test plan

- [x] Added 4 unit tests for Set-Cookie preservation (`mergeResponseHeaders` + `sendCompressed` with array headers)
- [x] All 224 features tests pass
- [x] All 155 deploy tests pass
- [x] All 122 pages-router tests pass
- [x] Typecheck clean
- [x] Lint clean