### PR TITLE
refactor(ci): extract composite actions and improve workflow hygiene

### DIFF
--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -6,6 +6,10 @@ inputs:
     description: Node.js version to use
     required: false
     default: "24"
+  registry-url:
+    description: npm registry URL (e.g. https://registry.npmjs.org). Leave empty to skip.
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -16,6 +20,7 @@ runs:
       with:
         node-version: ${{ inputs.node-version }}
         cache: pnpm
+        registry-url: ${{ inputs.registry-url }}
 
     - name: Install dependencies
       shell: bash

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -20,14 +20,8 @@ jobs:
         with:
           fetch-depth: 0 # Need full history for commit info
 
-      - uses: pnpm/action-setup@v4
+      - uses: ./.github/actions/setup-node-pnpm
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 24
-          cache: pnpm
-
-      - run: pnpm install --frozen-lockfile
       - name: Build vinext plugin
         run: pnpm run build
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,12 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 24
-          cache: pnpm
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup-node-pnpm
       - name: Build plugin (needed by ecosystem fixtures)
         run: pnpm run build
       - run: pnpm test
@@ -55,12 +50,7 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 24
-          cache: pnpm
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup-node-pnpm
       - name: Build plugin
         run: pnpm run build
 
@@ -115,12 +105,7 @@ jobs:
           - cloudflare-workers
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 24
-          cache: pnpm
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup-node-pnpm
       - name: Build plugin
         run: pnpm run build
 

--- a/.github/workflows/deploy-examples.yml
+++ b/.github/workflows/deploy-examples.yml
@@ -47,15 +47,7 @@ jobs:
             wrangler_config: dist/server/wrangler.json
     steps:
       - uses: actions/checkout@v4
-
-      - uses: pnpm/action-setup@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 24
-          cache: pnpm
-
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup-node-pnpm
 
       - name: Build vinext plugin
         run: pnpm run build

--- a/.github/workflows/deploy-preview-command.yml
+++ b/.github/workflows/deploy-preview-command.yml
@@ -87,14 +87,7 @@ jobs:
         with:
           ref: ${{ needs.check.outputs.sha }}
 
-      - uses: pnpm/action-setup@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 24
-          cache: pnpm
-
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup-node-pnpm
 
       - name: Build vinext plugin
         run: pnpm run build

--- a/.github/workflows/ecosystem-run.yml
+++ b/.github/workflows/ecosystem-run.yml
@@ -25,14 +25,9 @@ jobs:
       - name: Checkout vinext
         uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v4
-
-      - uses: actions/setup-node@v4
+      - uses: ./.github/actions/setup-node-pnpm
         with:
           node-version: ${{ inputs.node_version }}
-          cache: pnpm
-
-      - run: pnpm install --frozen-lockfile
 
       - name: Build vinext plugin
         run: pnpm run build

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -15,11 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 24
-          cache: pnpm
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup-node-pnpm
       - run: pnpm run build
       - run: pnpm dlx pkg-pr-new publish --pnpm './packages/vinext'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,16 +36,9 @@ jobs:
         with:
           fetch-depth: 0 # full history for changelog generation
 
-      - uses: pnpm/action-setup@v4
-
-      - uses: actions/setup-node@v4
+      - uses: ./.github/actions/setup-node-pnpm
         with:
-          node-version: 24
-          cache: pnpm
           registry-url: https://registry.npmjs.org
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
 
       - name: Build
         run: pnpm run build


### PR DESCRIPTION
## Summary

- **`setup-node-pnpm` composite action** replaces the repeated 3-step pnpm/node/install triplet across all eligible workflows — every workflow that does setup and install now uses it consistently
- **Playwright browser cache** added to E2E jobs — avoids re-downloading ~150MB of Chromium on every CI run
- **Concurrency group** added to `deploy-examples.yml` — prevents deploy jobs piling up on busy branches
- **CJS → bash** in `create-next-app` job — replaced the inline `node {0}` + `require()` script with a portable bash loop
- **CJS → ESM** in `ecosystem-run.yml` — all inline Node heredocs converted from `require()` to `node --input-type=module` with `import` statements

## Exceptions (intentionally kept inline)

- `bonk.yml` / `bigbonk.yml` — `issue_comment`-triggered workflows; GHAS flags local composite actions reachable from these as untrusted-checkout TOCTOU
- `tip.yml` `notify-on-failure` job — only needs plain `setup-node`, no pnpm or install