### PR TITLE
test: use metadata API in app-basic root layout

### DIFF
--- a/tests/fixtures/app-basic/app/layout.tsx
+++ b/tests/fixtures/app-basic/app/layout.tsx
@@ -1,3 +1,9 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "App Basic",
+};
+
 export default function RootLayout({
   children,
 }: {
@@ -5,11 +11,6 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <head>
-        <meta charSet="utf-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <title>App Basic</title>
-      </head>
       <body>{children}</body>
     </html>
   );

--- a/tests/nextjs-compat/metadata-suspense.test.ts
+++ b/tests/nextjs-compat/metadata-suspense.test.ts
@@ -45,20 +45,11 @@ describe("Next.js compat: metadata-suspense", () => {
     );
   });
 
-  // SKIP: Vinext emits duplicate <title> tags when a layout wraps children
-  // in <Suspense>. The metadata is injected once in the shell and again when
-  // the Suspense boundary resolves, producing two <title> elements.
-  //
-  // ROOT CAUSE: Metadata is rendered as part of the page element tree, which
-  // gets wrapped by Suspense. When SSR streams the shell (with fallback) and
-  // then the resolved content, both include the metadata head tags.
-  //
-  // TO FIX: `packages/vinext/src/server/app-dev-server.ts` — metadata should
-  // be hoisted above Suspense boundaries (rendered outside the Suspense wrapper
-  // in buildPageElement) or deduplicated during SSR HTML assembly.
-  //
-  // VERIFY: Remove skip, run this test. Should see exactly 1 <title> tag.
-  it.skip("should not produce duplicate title tags with Suspense layout", async () => {
+  // Regression test: the shared app-basic root layout used to hardcode
+  // <title>App Basic</title>, which made metadata routes appear to emit
+  // duplicate titles. Keep this assertion live so metadata fixtures rely on
+  // the Metadata API rather than manual <head> tags.
+  it("should not produce duplicate title tags with Suspense layout", async () => {
     const { html } = await fetchHtml(
       ctx.baseUrl,
       "/nextjs-compat/metadata-suspense-test",


### PR DESCRIPTION
## Summary
- move the shared app-basic root title from manual `<head>` markup to the Metadata API
- enable the metadata-suspense duplicate-title regression test
- update the test comment to describe the real failure mode

## Why
The duplicate `<title>` was coming from the shared test fixture root layout hardcoding `<title>App Basic</title>`, not from Suspense-specific metadata streaming.

## Testing
- `pnpm test tests/nextjs-compat/metadata-suspense.test.ts tests/nextjs-compat/metadata.test.ts`