### PR TITLE
fix: useRouter() returns stable singleton to prevent unnecessary re-renders

### DIFF
--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -509,61 +509,76 @@ async function navigateImpl(
   }
 }
 
+// ---------------------------------------------------------------------------
+// App Router router singleton
+//
+// All methods close over module-level state (navigateImpl, withBasePath, etc.)
+// and carry no per-render data, so the object can be created once and reused.
+// Next.js returns the same router reference on every call to useRouter(), which
+// matters for components that rely on referential equality (e.g. useMemo /
+// useEffect dependency arrays, React.memo bailouts).
+// ---------------------------------------------------------------------------
+
+const _appRouter = {
+  push(href: string, options?: { scroll?: boolean }): void {
+    if (isServer) return;
+    void navigateImpl(href, "push", options?.scroll !== false);
+  },
+  replace(href: string, options?: { scroll?: boolean }): void {
+    if (isServer) return;
+    void navigateImpl(href, "replace", options?.scroll !== false);
+  },
+  back(): void {
+    if (isServer) return;
+    window.history.back();
+  },
+  forward(): void {
+    if (isServer) return;
+    window.history.forward();
+  },
+  refresh(): void {
+    if (isServer) return;
+    // Re-fetch the current page's RSC stream
+    if (typeof (window as any).__VINEXT_RSC_NAVIGATE__ === "function") {
+      (window as any).__VINEXT_RSC_NAVIGATE__(window.location.href);
+    }
+  },
+  prefetch(href: string): void {
+    if (isServer) return;
+    // Prefetch the RSC payload for the target route and store in cache
+    const fullHref = withBasePath(href);
+    const rscUrl = toRscUrl(fullHref);
+    const prefetched = getPrefetchedUrls();
+    if (prefetched.has(rscUrl)) return;
+    prefetched.add(rscUrl);
+    fetch(rscUrl, {
+      headers: { Accept: "text/x-component" },
+      credentials: "include",
+      priority: "low" as RequestInit["priority"],
+    }).then((response) => {
+      if (response.ok) {
+        storePrefetchResponse(rscUrl, response);
+      } else {
+        // Non-ok response: allow retry on next prefetch() call
+        prefetched.delete(rscUrl);
+      }
+    }).catch(() => {
+      // Network error: allow retry on next prefetch() call
+      prefetched.delete(rscUrl);
+    });
+  },
+};
+
 /**
  * App Router's useRouter — returns push/replace/back/forward/refresh.
  * Different from Pages Router's useRouter (next/router).
+ *
+ * Returns a stable singleton: the same object reference on every call,
+ * matching Next.js behavior so components using referential equality
+ * (e.g. useMemo / useEffect deps, React.memo) don't re-render unnecessarily.
  */
 export function useRouter() {
-  const router = {
-    push(href: string, options?: { scroll?: boolean }): void {
-      if (isServer) return;
-      void navigateImpl(href, "push", options?.scroll !== false);
-    },
-    replace(href: string, options?: { scroll?: boolean }): void {
-      if (isServer) return;
-      void navigateImpl(href, "replace", options?.scroll !== false);
-    },
-    back(): void {
-      if (isServer) return;
-      window.history.back();
-    },
-    forward(): void {
-      if (isServer) return;
-      window.history.forward();
-    },
-    refresh(): void {
-      if (isServer) return;
-      // Re-fetch the current page's RSC stream
-      if (typeof (window as any).__VINEXT_RSC_NAVIGATE__ === "function") {
-        (window as any).__VINEXT_RSC_NAVIGATE__(window.location.href);
-      }
-    },
-    prefetch(href: string): void {
-      if (isServer) return;
-      // Prefetch the RSC payload for the target route and store in cache
-      const fullHref = withBasePath(href);
-      const rscUrl = toRscUrl(fullHref);
-      const prefetched = getPrefetchedUrls();
-      if (prefetched.has(rscUrl)) return;
-      prefetched.add(rscUrl);
-      fetch(rscUrl, {
-        headers: { Accept: "text/x-component" },
-        credentials: "include",
-        priority: "low" as RequestInit["priority"],
-      }).then((response) => {
-        if (response.ok) {
-          storePrefetchResponse(rscUrl, response);
-        } else {
-          // Non-ok response: allow retry on next prefetch() call
-          prefetched.delete(rscUrl);
-        }
-      }).catch(() => {
-        // Network error: allow retry on next prefetch() call
-        prefetched.delete(rscUrl);
-      });
-    },
-  };
-  return router;
+  return _appRouter;
 }
 
 /**

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -17,6 +17,36 @@ describe("next/navigation shim", () => {
     expect(typeof nav.useRouter).toBe("function");
   });
 
+  // Regression test: useRouter() must return a stable singleton.
+  // Next.js returns the same router object reference on every call.
+  // Components using the router in useMemo/useEffect dependency arrays or
+  // wrapped in React.memo would re-render unnecessarily if each call
+  // returned a new object.
+  // Ported from: https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/hooks/hooks.test.ts
+  it("useRouter() returns the same object reference on every call (stable singleton)", async () => {
+    const { useRouter } = await import(
+      "../packages/vinext/src/shims/navigation.js"
+    );
+    const first = useRouter();
+    const second = useRouter();
+    const third = useRouter();
+    expect(first).toBe(second);
+    expect(second).toBe(third);
+  });
+
+  it("useRouter() singleton exposes the expected navigation methods", async () => {
+    const { useRouter } = await import(
+      "../packages/vinext/src/shims/navigation.js"
+    );
+    const router = useRouter();
+    expect(typeof router.push).toBe("function");
+    expect(typeof router.replace).toBe("function");
+    expect(typeof router.back).toBe("function");
+    expect(typeof router.forward).toBe("function");
+    expect(typeof router.refresh).toBe("function");
+    expect(typeof router.prefetch).toBe("function");
+  });
+
   it("exports redirect, notFound, permanentRedirect", async () => {
     const nav = await import(
       "../packages/vinext/src/shims/navigation.js"


### PR DESCRIPTION
## Summary

- \`useRouter()\` in \`next/navigation\` was creating a new object literal on every call
- Next.js returns the same router reference on every call — components relying on referential equality (e.g. \`useMemo\`/\`useEffect\` dependency arrays, \`React.memo\` bailouts) would re-render unnecessarily on every render cycle
- Fix: hoist the router object to module level; all methods close over module-level state and carry no per-render data, so this is safe and exactly matches Next.js behavior

## Changes

- \`packages/vinext/src/shims/navigation.ts\`: Replace the inline object literal in \`useRouter()\` with a module-level \`_appRouter\` singleton
- \`tests/shims.test.ts\`: Add two regression tests
  - Asserts \`useRouter()\` returns the same reference across multiple calls (\`first === second === third\`)
  - Asserts the singleton exposes all expected navigation methods (\`push\`, \`replace\`, \`back\`, \`forward\`, \`refresh\`, \`prefetch\`)

## Testing

```
pnpm test tests/shims.test.ts   # 568 tests, all passing
```