### PR TITLE
refactor(routing): extract shared compareRoutes comparator to utils

### DIFF
--- a/packages/vinext/src/routing/app-router.ts
+++ b/packages/vinext/src/routing/app-router.ts
@@ -15,7 +15,7 @@
  */
 import path from "node:path";
 import fs from "node:fs";
-import { routePrecedence } from "./utils.js";
+import { compareRoutes } from "./utils.js";
 import {
   createValidFileMatcher,
   scanWithExtensions,
@@ -172,10 +172,7 @@ export async function appRouter(
   routes.push(...slotSubRoutes);
 
   // Sort: static routes first, then dynamic, then catch-all
-  routes.sort((a, b) => {
-    const diff = routePrecedence(a.pattern) - routePrecedence(b.pattern);
-    return diff !== 0 ? diff : a.pattern.localeCompare(b.pattern);
-  });
+  routes.sort(compareRoutes);
 
   cachedRoutes = routes;
   cachedAppDir = appDir;

--- a/packages/vinext/src/routing/pages-router.ts
+++ b/packages/vinext/src/routing/pages-router.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { routePrecedence } from "./utils.js";
+import { compareRoutes } from "./utils.js";
 import {
   createValidFileMatcher,
   scanWithExtensions,
@@ -79,10 +79,7 @@ async function scanPageRoutes(
   }
 
   // Sort: static routes first, then dynamic, then catch-all
-  routes.sort((a, b) => {
-    const diff = routePrecedence(a.pattern) - routePrecedence(b.pattern);
-    return diff !== 0 ? diff : a.pattern.localeCompare(b.pattern);
-  });
+  routes.sort(compareRoutes);
 
   return routes;
 }
@@ -229,10 +226,7 @@ async function scanApiRoutes(
   }
 
   // Sort same as page routes
-  routes.sort((a, b) => {
-    const diff = routePrecedence(a.pattern) - routePrecedence(b.pattern);
-    return diff !== 0 ? diff : a.pattern.localeCompare(b.pattern);
-  });
+  routes.sort(compareRoutes);
 
   return routes;
 }

--- a/packages/vinext/src/routing/utils.ts
+++ b/packages/vinext/src/routing/utils.ts
@@ -69,3 +69,14 @@ export function routePrecedence(pattern: string): number {
 
   return score;
 }
+
+/**
+ * Sort comparator for routes — lower precedence score sorts first (higher priority).
+ * Lexicographic tiebreaker on pattern for determinism.
+ *
+ * Usage: routes.sort(compareRoutes)
+ */
+export function compareRoutes<T extends { pattern: string }>(a: T, b: T): number {
+  const diff = routePrecedence(a.pattern) - routePrecedence(b.pattern);
+  return diff !== 0 ? diff : a.pattern.localeCompare(b.pattern);
+}


### PR DESCRIPTION
## Summary

- Extracts the duplicated sort comparator into a new `compareRoutes<T extends { pattern: string }>()` function in `routing/utils.ts`, which already exports `routePrecedence`
- Replaces three identical inline comparators: `scanPageRoutes` and `scanApiRoutes` in `pages-router.ts`, and `appRouter` in `app-router.ts`
- No behaviour change — only deduplication

## Testing

`pnpm test tests/routing.test.ts tests/route-sorting.test.ts` — 75 tests pass.