### PR TITLE
fix: restrict bonk commands to repo members, collaborators, and owners

### DIFF
--- a/.github/workflows/bigbonk.yml
+++ b/.github/workflows/bigbonk.yml
@@ -12,7 +12,14 @@ concurrency:
 
 jobs:
   bonk:
-    if: github.event.sender.type != 'Bot' && contains(github.event.comment.body, '/bigbonk')
+    if: >-
+      github.event.sender.type != 'Bot' &&
+      contains(github.event.comment.body, '/bigbonk') &&
+      (
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR' ||
+        github.event.comment.author_association == 'OWNER'
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -12,7 +12,14 @@ concurrency:
 
 jobs:
   bonk:
-    if: github.event.sender.type != 'Bot' && (contains(github.event.comment.body, '/bonk') || contains(github.event.comment.body, '@ask-bonk'))
+    if: >-
+      github.event.sender.type != 'Bot' &&
+      (contains(github.event.comment.body, '/bonk') || contains(github.event.comment.body, '@ask-bonk')) &&
+      (
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR' ||
+        github.event.comment.author_association == 'OWNER'
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:


### PR DESCRIPTION
## Summary

- Adds `author_association` check to both `bonk.yml` and `bigbonk.yml`, matching the existing pattern in `deploy-preview-command.yml`
- `/bonk`, `@ask-bonk`, and `/bigbonk` can now only be triggered by `MEMBER`, `COLLABORATOR`, or `OWNER` — preventing arbitrary users from invoking the AI agent