### PR TITLE
Fix fetch cache key collisions for Request and FormData bodies

### DIFF
--- a/packages/vinext/src/shims/fetch-cache.ts
+++ b/packages/vinext/src/shims/fetch-cache.ts
@@ -295,7 +295,7 @@ async function serializeBody(input: string | URL | Request, init?: RequestInit):
         const boundedRequest = new Request(input.url, {
           method: input.method,
           headers: contentType ? { "content-type": contentType } : undefined,
-          body: new Blob(chunks.map((chunk) => chunk.slice())),
+          body: new Blob(chunks as unknown as BlobPart[]),
         });
         const formData = await boundedRequest.formData();
         await serializeFormData(formData, pushBodyChunk, getTotalBodyBytes);
@@ -312,7 +312,7 @@ async function serializeBody(input: string | URL | Request, init?: RequestInit):
     }
 
     for (const chunk of chunks) {
-      bodyChunks.push(decoder.decode(chunk, { stream: true }));
+      pushBodyChunk(decoder.decode(chunk, { stream: true }));
     }
     const finalChunk = decoder.decode();
     if (finalChunk) {

--- a/tests/fetch-cache.test.ts
+++ b/tests/fetch-cache.test.ts
@@ -15,14 +15,15 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 // We need to mock fetch at the module level BEFORE fetch-cache.ts captures
 // `originalFetch`. Use vi.stubGlobal to intercept at import time.
 let requestCount = 0;
-const fetchMock = vi.fn(async (input: string | URL | Request, _init?: RequestInit) => {
+const defaultFetchMockImplementation = async (input: string | URL | Request, _init?: RequestInit) => {
   requestCount++;
   const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
   return new Response(JSON.stringify({ url, count: requestCount }), {
     status: 200,
     headers: { "content-type": "application/json" },
   });
-});
+};
+const fetchMock = vi.fn(defaultFetchMockImplementation);
 
 // Stub globalThis.fetch BEFORE importing modules that capture it
 vi.stubGlobal("fetch", fetchMock);
@@ -37,7 +38,8 @@ describe("fetch cache shim", () => {
   beforeEach(() => {
     // Reset state
     requestCount = 0;
-    fetchMock.mockClear();
+    fetchMock.mockReset();
+    fetchMock.mockImplementation(defaultFetchMockImplementation);
     // Reset the cache handler to a fresh instance for each test
     setCacheHandler(new MemoryCacheHandler());
     // Install the patched fetch
@@ -224,6 +226,46 @@ describe("fetch cache shim", () => {
     // Wait for background refetch
     await new Promise((resolve) => setTimeout(resolve, 50));
     expect(fetchMock).toHaveBeenCalledTimes(2); // Original + background refetch
+  });
+
+  it("preserves Request bodies for stale background revalidation", async () => {
+    const seenBodies: string[] = [];
+    fetchMock.mockImplementation(async (input: string | URL | Request, _init?: RequestInit) => {
+      requestCount++;
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      const body = input instanceof Request ? await input.clone().text() : "";
+      seenBodies.push(body);
+      return new Response(JSON.stringify({ url, count: requestCount, body }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+
+    const makeRequest = () => new Request("https://api.example.com/stale-request-body", {
+      method: "POST",
+      body: "request-body-content",
+      headers: { "content-type": "text/plain" },
+    });
+
+    const res1 = await fetch(makeRequest(), { next: { revalidate: 1 } });
+    const data1 = await res1.json();
+    expect(data1.count).toBe(1);
+    expect(data1.body).toBe("request-body-content");
+
+    const handler = getCacheHandler() as InstanceType<typeof MemoryCacheHandler>;
+    const store = (handler as any).store as Map<string, any>;
+    for (const [, entry] of store) {
+      entry.revalidateAt = Date.now() - 1000;
+    }
+
+    const res2 = await fetch(makeRequest(), { next: { revalidate: 1 } });
+    const data2 = await res2.json();
+    expect(data2.count).toBe(1);
+    expect(data2.body).toBe("request-body-content");
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(seenBodies).toEqual(["request-body-content", "request-body-content"]);
   });
 
   // ── Independent cache entries per URL ───────────────────────────────
@@ -1303,6 +1345,25 @@ describe("fetch cache shim", () => {
       const forwardedRequest = call[0] as Request;
       expect(forwardedRequest).toBeInstanceOf(Request);
       expect(await forwardedRequest.text()).toBe("request-body-content");
+    });
+
+    it("already-consumed Request bodies bypass cache key generation and defer to the underlying fetch", async () => {
+      fetchMock.mockImplementation(async (input: string | URL | Request, _init?: RequestInit) => {
+        if (input instanceof Request && input.bodyUsed) {
+          throw new TypeError("body already used");
+        }
+        return defaultFetchMockImplementation(input, _init);
+      });
+
+      const request = new Request("https://api.example.com/request-used", {
+        method: "POST",
+        body: "request-body-content",
+        headers: { "content-type": "text/plain" },
+      });
+      await request.text();
+
+      await expect(fetch(request, { next: { revalidate: 60 } })).rejects.toThrow("body already used");
+      expect(fetchMock).toHaveBeenCalledTimes(1);
     });
   });
 


### PR DESCRIPTION
## Summary

Fix fetch cache key generation so cached requests are keyed by the actual effective request body, including when the body is provided on a `Request` object.

This also fixes ambiguous `FormData` serialization that could cause distinct payloads to collapse into the same cache entry.

## Problem

Vinext’s fetch cache key generation did not fully account for the request body in all supported call shapes.

### `Request` bodies were ignored

The cache key logic correctly merged headers from both `input` and `init`, but it only serialized `init.body`. If the body lived on a `Request` object, vinext effectively treated the request as body-less for cache-key purposes.

Example:

```ts
await fetch(
  new Request("https://api.example.com/search", {
    method: "POST",
    body: JSON.stringify({ query: "alpha" }),
    headers: { "content-type": "application/json" },
  }),
  { next: { revalidate: 60 } },
)

await fetch(
  new Request("https://api.example.com/search", {
    method: "POST",
    body: JSON.stringify({ query: "bravo" }),
    headers: { "content-type": "application/json" },
  }),
  { next: { revalidate: 60 } },
)
```

Before this change, both requests could produce the same cache key even though the payloads were different.

That makes cached POST-style fetches unsafe: a response generated for one payload can be reused for another payload.

Concrete failure modes include:
- a search endpoint returning results for the wrong query
- a filtered API response being reused for the wrong filter set
- application data keyed by request body being served from the wrong cached entry

### Multi-value `FormData` could collide

`FormData` values were serialized by joining them with commas, which is ambiguous.

Example:

```ts
const formA = new FormData()
formA.append("name", "a,b")
formA.append("name", "c")
// serialized as: "name=a,b,c"

const formB = new FormData()
formB.append("name", "a")
formB.append("name", "b,c")
// also serialized as: "name=a,b,c"
```

These are different payloads, but they produced the same cache-key fragment.

## Root Cause

The issue was in the fetch cache key builder, not in cache storage itself.

- `collectHeaders()` already handled `Request` inputs correctly
- `buildFetchCacheKey()` used `serializeBody(init)`
- `serializeBody()` only looked at `init.body`
- `Request` bodies were therefore omitted unless duplicated in `init`
- `FormData` entries were flattened with comma-joining, which is not injective

In other words, the cache key did not always represent the true effective request.

## What Changed

### Fetch cache keying

- Include `Request` object bodies in cache key generation
- Support body extraction from `Request` inputs without mutating the original fetch behavior
- Preserve the original request body for the underlying network fetch

### `FormData` serialization

- Replace ambiguous comma-joined serialization with structured serialization
- Serialize per-key value lists in a format that preserves boundaries and ordering semantics
- Keep existing oversized-body protections in place

### Tests

Add regression coverage for:
- different `Request` bodies producing distinct cache entries
- identical `Request` bodies reusing the same cache entry
- ambiguous comma-containing multi-value `FormData` payloads not colliding
- `Request` bodies still being forwarded intact after cache-key generation

## Examples

### Example 1: POST search requests

Before:

```ts
await fetch(
  new Request("https://api.example.com/search", {
    method: "POST",
    body: JSON.stringify({ query: "alpha" }),
    headers: { "content-type": "application/json" },
  }),
  { next: { revalidate: 60 } },
)

await fetch(
  new Request("https://api.example.com/search", {
    method: "POST",
    body: JSON.stringify({ query: "bravo" }),
    headers: { "content-type": "application/json" },
  }),
  { next: { revalidate: 60 } },
)
```

These could collide and reuse the wrong cached response.

After:
- the request body is included in the cache key
- each distinct payload gets its own cache entry

### Example 2: Multi-value form submissions

Before:

```ts
const formA = new FormData()
formA.append("name", "a,b")
formA.append("name", "c")

const formB = new FormData()
formB.append("name", "a")
formB.append("name", "b,c")
```

These serialized to the same cache-key fragment.

After:
- `FormData` values are serialized in a structured format
- these payloads no longer collide

## Why This Approach

This change fixes the root cause while keeping the existing caching model intact.

The principle is simple:
- semantically different requests must not share a cache entry
- semantically identical requests should still reuse the same cache entry

The patch stays within the current fetch cache architecture and only changes key generation and regression coverage.

## Files Changed

- `packages/vinext/src/shims/fetch-cache.ts`
- `tests/fetch-cache.test.ts`

## Test Plan

Ran targeted regression coverage for the affected surface:

```bash
pnpm dlx vitest run tests/fetch-cache.test.ts
```