### PR TITLE
fix: unstable_cache undefined cache

### DIFF
--- a/packages/vinext/src/shims/cache.ts
+++ b/packages/vinext/src/shims/cache.ts
@@ -581,6 +581,21 @@ const _UNSTABLE_CACHE_ALS_KEY = Symbol.for("vinext.unstableCache.als");
 const _unstableCacheAls = (
   (_g[_UNSTABLE_CACHE_ALS_KEY] ??= new AsyncLocalStorage<boolean>()) as AsyncLocalStorage<boolean>
 );
+const UNSTABLE_CACHE_UNDEFINED_SENTINEL = "__vinext_unstable_cache_undefined__";
+
+function serializeUnstableCacheResult(value: unknown): string {
+  return value === undefined
+    ? UNSTABLE_CACHE_UNDEFINED_SENTINEL
+    : JSON.stringify(value);
+}
+
+function deserializeUnstableCacheResult(body: string): unknown {
+  if (body === UNSTABLE_CACHE_UNDEFINED_SENTINEL) {
+    return undefined;
+  }
+
+  return JSON.parse(body);
+}
 
 /**
  * Check if the current execution context is inside an unstable_cache() callback.
@@ -625,7 +640,7 @@ export function unstable_cache<T extends (...args: any[]) => Promise<any>>(
     });
     if (existing?.value && existing.value.kind === "FETCH" && existing.cacheState !== "stale") {
       try {
-        return JSON.parse(existing.value.data.body);
+        return deserializeUnstableCacheResult(existing.value.data.body);
       } catch {
         // Corrupted entry, fall through to re-fetch
       }
@@ -641,7 +656,7 @@ export function unstable_cache<T extends (...args: any[]) => Promise<any>>(
       kind: "FETCH",
       data: {
         headers: {},
-        body: JSON.stringify(result),
+        body: serializeUnstableCacheResult(result),
         url: cacheKey,
       },
       tags,

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -733,6 +733,27 @@ describe("next/cache shim", () => {
     setCacheHandler(new MemoryCacheHandler());
   });
 
+  it("unstable_cache caches undefined results", async () => {
+    const { unstable_cache, setCacheHandler, MemoryCacheHandler } =
+      await import("../packages/vinext/src/shims/cache.js");
+
+    setCacheHandler(new MemoryCacheHandler());
+
+    let callCount = 0;
+    const cached = unstable_cache(async () => {
+      callCount++;
+      return undefined;
+    }, ["undefined-result-test"]);
+
+    await expect(cached()).resolves.toBeUndefined();
+    expect(callCount).toBe(1);
+
+    await expect(cached()).resolves.toBeUndefined();
+    expect(callCount).toBe(1);
+
+    setCacheHandler(new MemoryCacheHandler());
+  });
+
   it("revalidateTag invalidates cached entries", async () => {
     const {
       unstable_cache,


### PR DESCRIPTION
**Summary**

Fix `unstable_cache()` so cached functions that return top-level `undefined` actually hit the cache on subsequent calls.

**Problem**

`unstable_cache()` was serializing results with `JSON.stringify(result)` and reading them back with `JSON.parse(body)`.

For a top-level `undefined` return value, `JSON.stringify(undefined)` returns `undefined` rather than a JSON string. On the next read, `JSON.parse(undefined)` throws, so the shim treated the entry as invalid and recomputed the function every time.

**Changes**

- Add a dedicated sentinel payload for top-level `undefined` results in the `unstable_cache()` serialization path
- Teach the read path to recognize that sentinel before falling back to `JSON.parse`
- Add a regression test covering an `unstable_cache()`-wrapped function that returns `undefined` and should only execute once across repeated calls

**Why**

This is a real correctness/performance bug in the cache shim: callers still receive `undefined`, but the cache never produces a true hit for that value.

**Testing**

- `pnpm test tests/shims.test.ts -t "unstable_cache"`