### PR TITLE
fix: guard dev-origin check with NODE_ENV to prevent 403s in production

### DIFF
--- a/packages/vinext/src/server/app-dev-server.ts
+++ b/packages/vinext/src/server/app-dev-server.ts
@@ -1483,10 +1483,13 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // Format: "handlerStart,compileMs,renderMs" - all as integers (ms). Dev-only.
   const url = new URL(request.url);
 
-  // ── Cross-origin request protection ─────────────────────────────────
+  // ── Cross-origin request protection (dev only) ─────────────────────
   // Block requests from non-localhost origins to prevent data exfiltration.
-  const __originBlock = __validateDevRequestOrigin(request);
-  if (__originBlock) return __originBlock;
+  // Skipped in production — Vite replaces NODE_ENV at build time.
+  if (process.env.NODE_ENV !== "production") {
+    const __originBlock = __validateDevRequestOrigin(request);
+    if (__originBlock) return __originBlock;
+  }
 
   // Guard against protocol-relative URL open redirects.
   // Paths like //example.com/ would be redirected to //example.com by the

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -1794,10 +1794,13 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // Format: "handlerStart,compileMs,renderMs" - all as integers (ms). Dev-only.
   const url = new URL(request.url);
 
-  // ── Cross-origin request protection ─────────────────────────────────
+  // ── Cross-origin request protection (dev only) ─────────────────────
   // Block requests from non-localhost origins to prevent data exfiltration.
-  const __originBlock = __validateDevRequestOrigin(request);
-  if (__originBlock) return __originBlock;
+  // Skipped in production — Vite replaces NODE_ENV at build time.
+  if (process.env.NODE_ENV !== "production") {
+    const __originBlock = __validateDevRequestOrigin(request);
+    if (__originBlock) return __originBlock;
+  }
 
   // Guard against protocol-relative URL open redirects.
   // Paths like //example.com/ would be redirected to //example.com by the
@@ -4294,10 +4297,13 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // Format: "handlerStart,compileMs,renderMs" - all as integers (ms). Dev-only.
   const url = new URL(request.url);
 
-  // ── Cross-origin request protection ─────────────────────────────────
+  // ── Cross-origin request protection (dev only) ─────────────────────
   // Block requests from non-localhost origins to prevent data exfiltration.
-  const __originBlock = __validateDevRequestOrigin(request);
-  if (__originBlock) return __originBlock;
+  // Skipped in production — Vite replaces NODE_ENV at build time.
+  if (process.env.NODE_ENV !== "production") {
+    const __originBlock = __validateDevRequestOrigin(request);
+    if (__originBlock) return __originBlock;
+  }
 
   // Guard against protocol-relative URL open redirects.
   // Paths like //example.com/ would be redirected to //example.com by the
@@ -6829,10 +6835,13 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // Format: "handlerStart,compileMs,renderMs" - all as integers (ms). Dev-only.
   const url = new URL(request.url);
 
-  // ── Cross-origin request protection ─────────────────────────────────
+  // ── Cross-origin request protection (dev only) ─────────────────────
   // Block requests from non-localhost origins to prevent data exfiltration.
-  const __originBlock = __validateDevRequestOrigin(request);
-  if (__originBlock) return __originBlock;
+  // Skipped in production — Vite replaces NODE_ENV at build time.
+  if (process.env.NODE_ENV !== "production") {
+    const __originBlock = __validateDevRequestOrigin(request);
+    if (__originBlock) return __originBlock;
+  }
 
   // Guard against protocol-relative URL open redirects.
   // Paths like //example.com/ would be redirected to //example.com by the
@@ -9352,10 +9361,13 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // Format: "handlerStart,compileMs,renderMs" - all as integers (ms). Dev-only.
   const url = new URL(request.url);
 
-  // ── Cross-origin request protection ─────────────────────────────────
+  // ── Cross-origin request protection (dev only) ─────────────────────
   // Block requests from non-localhost origins to prevent data exfiltration.
-  const __originBlock = __validateDevRequestOrigin(request);
-  if (__originBlock) return __originBlock;
+  // Skipped in production — Vite replaces NODE_ENV at build time.
+  if (process.env.NODE_ENV !== "production") {
+    const __originBlock = __validateDevRequestOrigin(request);
+    if (__originBlock) return __originBlock;
+  }
 
   // Guard against protocol-relative URL open redirects.
   // Paths like //example.com/ would be redirected to //example.com by the
@@ -11859,10 +11871,13 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // Format: "handlerStart,compileMs,renderMs" - all as integers (ms). Dev-only.
   const url = new URL(request.url);
 
-  // ── Cross-origin request protection ─────────────────────────────────
+  // ── Cross-origin request protection (dev only) ─────────────────────
   // Block requests from non-localhost origins to prevent data exfiltration.
-  const __originBlock = __validateDevRequestOrigin(request);
-  if (__originBlock) return __originBlock;
+  // Skipped in production — Vite replaces NODE_ENV at build time.
+  if (process.env.NODE_ENV !== "production") {
+    const __originBlock = __validateDevRequestOrigin(request);
+    if (__originBlock) return __originBlock;
+  }
 
   // Guard against protocol-relative URL open redirects.
   // Paths like //example.com/ would be redirected to //example.com by the
@@ -14397,10 +14412,13 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // Format: "handlerStart,compileMs,renderMs" - all as integers (ms). Dev-only.
   const url = new URL(request.url);
 
-  // ── Cross-origin request protection ─────────────────────────────────
+  // ── Cross-origin request protection (dev only) ─────────────────────
   // Block requests from non-localhost origins to prevent data exfiltration.
-  const __originBlock = __validateDevRequestOrigin(request);
-  if (__originBlock) return __originBlock;
+  // Skipped in production — Vite replaces NODE_ENV at build time.
+  if (process.env.NODE_ENV !== "production") {
+    const __originBlock = __validateDevRequestOrigin(request);
+    if (__originBlock) return __originBlock;
+  }
 
   // Guard against protocol-relative URL open redirects.
   // Paths like //example.com/ would be redirected to //example.com by the


### PR DESCRIPTION
## Summary

- Wraps the `__validateDevRequestOrigin()` call in the generated App Router RSC entry with a `process.env.NODE_ENV !== "production"` guard
- Prevents legitimate cross-origin requests from being blocked with 403 Forbidden when deployed to Cloudflare Workers
- Vite statically replaces `NODE_ENV` at build time, so the entire block becomes dead code in production builds

Closes #361

## Test plan

- [x] `pnpm test tests/dev-origin-check.test.ts` — 28 tests pass (function behavior unchanged)
- [x] `pnpm test tests/entry-templates.test.ts` — 10 tests pass (snapshots updated)
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run lint` — clean