### PR TITLE
fix(link): use localized href for SPA navigation

### DIFF
--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -367,7 +367,7 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
     // External links: let the browser handle it.
     // Same-origin absolute URLs (e.g. http://localhost:3000/about) are
     // normalized to local paths so they get client-side navigation.
-    let navigateHref = resolvedHref;
+    let navigateHref = localizedHref;
     if (
       resolvedHref.startsWith("http://") ||
       resolvedHref.startsWith("https://") ||
@@ -383,7 +383,7 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
     // Call onNavigate callback if provided (Next.js 16 View Transitions support)
     if (onNavigate) {
       try {
-        const navUrl = new URL(resolvedHref, window.location.origin);
+        const navUrl = new URL(localizedHref, window.location.origin);
         let prevented = false;
         const navEvent: NavigateEvent = {
           url: navUrl,


### PR DESCRIPTION
## Summary

- `next/link`'s `locale` prop correctly affected the rendered `<a>` href and prefetch path, but SPA click navigation and the `onNavigate` callback used the non-localized `resolvedHref`
- Clicking `<Link href="/about" locale="fr">` would render `<a href="/fr/about">` and prefetch `/fr/about`, but SPA-navigate to `/about`
- Fixed by using `localizedHref` instead of `resolvedHref` in the click handler (line 370) and `onNavigate` callback (line 386)

## Test plan

- [x] Existing `link.test.ts` locale tests pass (36/36)
- [x] Typecheck clean
- [x] Lint clean
- [x] CI