### PR TITLE
fix: draftMode() must mark dynamic usage to prevent caching

### DIFF
--- a/packages/vinext/src/shims/headers.ts
+++ b/packages/vinext/src/shims/headers.ts
@@ -359,6 +359,7 @@ interface DraftModeResult {
  */
 export async function draftMode(): Promise<DraftModeResult> {
   throwIfInsideCacheScope("draftMode()");
+  markDynamicUsage();
 
   const state = _getState();
   const secret = getDraftSecret();

--- a/tests/nextjs-compat/draft-mode.test.ts
+++ b/tests/nextjs-compat/draft-mode.test.ts
@@ -124,6 +124,30 @@ describe("Next.js compat: draft-mode", () => {
     expect(bypassCookie).not.toMatch(/;\s*Secure/i);
   });
 
+  // ── draftMode() marks dynamic usage ──────────────────────────
+  // draftMode() reads from a request cookie, so it must opt out of
+  // static/ISR caching — same as headers() and cookies().
+
+  it("draftMode() marks dynamic usage so the render is uncacheable", async () => {
+    const {
+      draftMode: draftModeFn,
+      consumeDynamicUsage,
+      runWithHeadersContext,
+      headersContextFromRequest,
+    } = await import("../../packages/vinext/src/shims/headers.js");
+
+    const ctx = headersContextFromRequest(
+      new Request("http://localhost/test"),
+    );
+    await runWithHeadersContext(ctx, async () => {
+      // Reset any prior dynamic usage
+      consumeDynamicUsage();
+
+      await draftModeFn();
+      expect(consumeDynamicUsage()).toBe(true);
+    });
+  });
+
   it("draftMode().isEnabled returns true after enable() round-trip", async () => {
     // Enable draft mode and extract the Set-Cookie value
     const enableRes = await fetch(`${baseUrl}/nextjs-compat/api/draft-enable`);


### PR DESCRIPTION
## Summary

- `draftMode()` reads the `__prerender_bypass` cookie (request-specific data) but did not call `markDynamicUsage()`, unlike `headers()` and `cookies()`
- This means a Server Component branching on `draftMode().isEnabled` could have its output cached by ISR, serving draft content to regular users or stale content to draft users
- Added the missing `markDynamicUsage()` call and a test verifying the behavior

## Test plan

- [x] New test: `draftMode() marks dynamic usage so the render is uncacheable` — calls `draftMode()` within a headers context and asserts `consumeDynamicUsage()` returns `true`
- [x] All existing draft-mode tests pass (8/8)