### PR TITLE
fix: propagate page generateMetadata errors to error boundary

### DIFF
--- a/packages/vinext/src/server/app-dev-server.ts
+++ b/packages/vinext/src/server/app-dev-server.ts
@@ -832,13 +832,21 @@ async function buildPageElement(route, params, opts, searchParams) {
   // Running them serially made each layout's metadata block the next one.
   // Promise.all fires all resolutions concurrently so the total wait is
   // max(individual times) instead of sum(individual times).
-  const allMods = [...route.layouts.filter(Boolean), ...(route.page ? [route.page] : [])];
-  const [metaResults, vpResults] = await Promise.all([
-    Promise.all(allMods.map((mod) => resolveModuleMetadata(mod, params).catch(() => null))),
-    Promise.all(allMods.map((mod) => resolveModuleViewport(mod, params).catch(() => null))),
+  //
+  // IMPORTANT: Layout metadata errors are swallowed (.catch(() => null)) because
+  // a layout's generateMetadata() failing should not crash the page.
+  // Page metadata errors are NOT swallowed — if the page's generateMetadata()
+  // throws, the error propagates out of buildPageElement() so the caller can
+  // route it to the nearest error.tsx boundary (or global-error.tsx).
+  const layoutMods = route.layouts.filter(Boolean);
+  const [layoutMetaResults, layoutVpResults, pageMeta, pageVp] = await Promise.all([
+    Promise.all(layoutMods.map((mod) => resolveModuleMetadata(mod, params).catch(() => null))),
+    Promise.all(layoutMods.map((mod) => resolveModuleViewport(mod, params).catch(() => null))),
+    route.page ? resolveModuleMetadata(route.page, params) : Promise.resolve(null),
+    route.page ? resolveModuleViewport(route.page, params) : Promise.resolve(null),
   ]);
-  const metadataList = metaResults.filter(Boolean);
-  const viewportList = vpResults.filter(Boolean);
+  const metadataList = [...layoutMetaResults.filter(Boolean), ...(pageMeta ? [pageMeta] : [])];
+  const viewportList = [...layoutVpResults.filter(Boolean), ...(pageVp ? [pageVp] : [])];
   const resolvedMetadata = metadataList.length > 0 ? mergeMetadata(metadataList) : null;
   const resolvedViewport = mergeViewport(viewportList);
 


### PR DESCRIPTION
## Summary

- Fixes a regression introduced by the metadata/viewport parallelisation PR (#372)
- Layout `generateMetadata()` errors are still swallowed (`.catch(() => null)`) — a layout failing shouldn't crash the page
- Page `generateMetadata()` errors now propagate out of `buildPageElement()` so the caller routes them to the nearest `error.tsx` or `global-error.tsx` boundary

## Root Cause

The parallelisation PR applied `.catch(() => null)` to **all** modules including the page module. This silently swallowed errors thrown by `page.generateMetadata()`, preventing the error boundary from being triggered.

## Fix

Separate layout modules from the page module when resolving metadata/viewport in `buildPageElement()`:
- **Layouts**: `.catch(() => null)` — failures are non-fatal
- **Page**: no `.catch()` — errors propagate to the caller, which routes to `error.tsx` / `global-error.tsx`

## Test

The previously failing test now passes:
```
tests/nextjs-compat/global-error.test.ts
  > generateMetadata() error caught by local error.tsx boundary  ✓
```