### PR TITLE
fix: avoid shared cache headers for dynamic GET handlers

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -1822,10 +1822,17 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     if (typeof handlerFn === "function") {
       try {
         const response = await handlerFn(request, { params });
+        const dynamicUsedInHandler = consumeDynamicUsage();
 
         // Apply Cache-Control from route segment config (export const revalidate = N).
-        // Next.js sets s-maxage on GET route handlers with a numeric revalidate value.
-        if (revalidateSeconds !== null && (method === "GET" || isAutoHead) && !response.headers.has("cache-control")) {
+        // Runtime request APIs like headers() / cookies() make GET handlers dynamic,
+        // so only attach ISR headers when the handler stayed static.
+        if (
+          revalidateSeconds !== null &&
+          !dynamicUsedInHandler &&
+          (method === "GET" || isAutoHead) &&
+          !response.headers.has("cache-control")
+        ) {
           response.headers.set("cache-control", "s-maxage=" + revalidateSeconds + ", stale-while-revalidate");
         }
 

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -1983,10 +1983,17 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     if (typeof handlerFn === "function") {
       try {
         const response = await handlerFn(request, { params });
+        const dynamicUsedInHandler = consumeDynamicUsage();
 
         // Apply Cache-Control from route segment config (export const revalidate = N).
-        // Next.js sets s-maxage on GET route handlers with a numeric revalidate value.
-        if (revalidateSeconds !== null && (method === "GET" || isAutoHead) && !response.headers.has("cache-control")) {
+        // Runtime request APIs like headers() / cookies() make GET handlers dynamic,
+        // so only attach ISR headers when the handler stayed static.
+        if (
+          revalidateSeconds !== null &&
+          !dynamicUsedInHandler &&
+          (method === "GET" || isAutoHead) &&
+          !response.headers.has("cache-control")
+        ) {
           response.headers.set("cache-control", "s-maxage=" + revalidateSeconds + ", stale-while-revalidate");
         }
 
@@ -4273,10 +4280,17 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     if (typeof handlerFn === "function") {
       try {
         const response = await handlerFn(request, { params });
+        const dynamicUsedInHandler = consumeDynamicUsage();
 
         // Apply Cache-Control from route segment config (export const revalidate = N).
-        // Next.js sets s-maxage on GET route handlers with a numeric revalidate value.
-        if (revalidateSeconds !== null && (method === "GET" || isAutoHead) && !response.headers.has("cache-control")) {
+        // Runtime request APIs like headers() / cookies() make GET handlers dynamic,
+        // so only attach ISR headers when the handler stayed static.
+        if (
+          revalidateSeconds !== null &&
+          !dynamicUsedInHandler &&
+          (method === "GET" || isAutoHead) &&
+          !response.headers.has("cache-control")
+        ) {
           response.headers.set("cache-control", "s-maxage=" + revalidateSeconds + ", stale-while-revalidate");
         }
 
@@ -6590,10 +6604,17 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     if (typeof handlerFn === "function") {
       try {
         const response = await handlerFn(request, { params });
+        const dynamicUsedInHandler = consumeDynamicUsage();
 
         // Apply Cache-Control from route segment config (export const revalidate = N).
-        // Next.js sets s-maxage on GET route handlers with a numeric revalidate value.
-        if (revalidateSeconds !== null && (method === "GET" || isAutoHead) && !response.headers.has("cache-control")) {
+        // Runtime request APIs like headers() / cookies() make GET handlers dynamic,
+        // so only attach ISR headers when the handler stayed static.
+        if (
+          revalidateSeconds !== null &&
+          !dynamicUsedInHandler &&
+          (method === "GET" || isAutoHead) &&
+          !response.headers.has("cache-control")
+        ) {
           response.headers.set("cache-control", "s-maxage=" + revalidateSeconds + ", stale-while-revalidate");
         }
 
@@ -8917,10 +8938,17 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     if (typeof handlerFn === "function") {
       try {
         const response = await handlerFn(request, { params });
+        const dynamicUsedInHandler = consumeDynamicUsage();
 
         // Apply Cache-Control from route segment config (export const revalidate = N).
-        // Next.js sets s-maxage on GET route handlers with a numeric revalidate value.
-        if (revalidateSeconds !== null && (method === "GET" || isAutoHead) && !response.headers.has("cache-control")) {
+        // Runtime request APIs like headers() / cookies() make GET handlers dynamic,
+        // so only attach ISR headers when the handler stayed static.
+        if (
+          revalidateSeconds !== null &&
+          !dynamicUsedInHandler &&
+          (method === "GET" || isAutoHead) &&
+          !response.headers.has("cache-control")
+        ) {
           response.headers.set("cache-control", "s-maxage=" + revalidateSeconds + ", stale-while-revalidate");
         }
 
@@ -11211,10 +11239,17 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     if (typeof handlerFn === "function") {
       try {
         const response = await handlerFn(request, { params });
+        const dynamicUsedInHandler = consumeDynamicUsage();
 
         // Apply Cache-Control from route segment config (export const revalidate = N).
-        // Next.js sets s-maxage on GET route handlers with a numeric revalidate value.
-        if (revalidateSeconds !== null && (method === "GET" || isAutoHead) && !response.headers.has("cache-control")) {
+        // Runtime request APIs like headers() / cookies() make GET handlers dynamic,
+        // so only attach ISR headers when the handler stayed static.
+        if (
+          revalidateSeconds !== null &&
+          !dynamicUsedInHandler &&
+          (method === "GET" || isAutoHead) &&
+          !response.headers.has("cache-control")
+        ) {
           response.headers.set("cache-control", "s-maxage=" + revalidateSeconds + ", stale-while-revalidate");
         }
 
@@ -13618,10 +13653,17 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     if (typeof handlerFn === "function") {
       try {
         const response = await handlerFn(request, { params });
+        const dynamicUsedInHandler = consumeDynamicUsage();
 
         // Apply Cache-Control from route segment config (export const revalidate = N).
-        // Next.js sets s-maxage on GET route handlers with a numeric revalidate value.
-        if (revalidateSeconds !== null && (method === "GET" || isAutoHead) && !response.headers.has("cache-control")) {
+        // Runtime request APIs like headers() / cookies() make GET handlers dynamic,
+        // so only attach ISR headers when the handler stayed static.
+        if (
+          revalidateSeconds !== null &&
+          !dynamicUsedInHandler &&
+          (method === "GET" || isAutoHead) &&
+          !response.headers.has("cache-control")
+        ) {
           response.headers.set("cache-control", "s-maxage=" + revalidateSeconds + ", stale-while-revalidate");
         }
 

--- a/tests/fixtures/app-basic/app/api/dynamic-request-data/route.ts
+++ b/tests/fixtures/app-basic/app/api/dynamic-request-data/route.ts
@@ -1,0 +1,13 @@
+import { cookies, headers } from "next/headers";
+
+export const revalidate = 60;
+
+export async function GET() {
+  const headerStore = await headers();
+  const cookieStore = await cookies();
+
+  return Response.json({
+    ping: headerStore.get("x-test-ping"),
+    cookie: cookieStore.get("ping")?.value ?? null,
+  });
+}

--- a/tests/nextjs-compat/app-routes.test.ts
+++ b/tests/nextjs-compat/app-routes.test.ts
@@ -325,6 +325,27 @@ describe("Next.js compat: app-routes", () => {
     expect(cacheControl).toBe("public, max-age=300");
   });
 
+  it("does not set s-maxage when a revalidated GET handler reads request-specific data", async () => {
+    const res = await fetch(`${baseUrl}/api/dynamic-request-data`, {
+      headers: {
+        "x-test-ping": "pong",
+        cookie: "ping=cookie-pong",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      ping: "pong",
+      cookie: "cookie-pong",
+    });
+
+    const cacheControl = res.headers.get("cache-control");
+    if (cacheControl) {
+      expect(cacheControl).not.toContain("s-maxage");
+      expect(cacheControl).not.toContain("stale-while-revalidate");
+    }
+  });
+
   // ── Documented skips ─────────────────────────────────────────
   //
   // N/A: 'statically generates correctly with no dynamic usage'


### PR DESCRIPTION
## Summary
- consume the dynamic-usage signal before auto-applying `revalidate` cache headers in App Router GET route handlers
- add a regression fixture and compat test for `GET + revalidate + headers()/cookies()`
- refresh entry template snapshots for the generated App Router entry

## Testing
- [x] `pnpm test tests/nextjs-compat/app-routes.test.ts`
- [x] `pnpm test tests/entry-templates.test.ts -u`
- [x] `pnpm test tests/app-router.test.ts -t "route handler"`
