### PR TITLE
perf: cache compiled regexes in middleware matcher

### DIFF
--- a/packages/vinext/src/server/middleware-codegen.ts
+++ b/packages/vinext/src/server/middleware-codegen.ts
@@ -150,16 +150,11 @@ export function generateMiddlewareMatcherCode(style: "modern" | "es5" = "modern"
   // packages/vinext/src/server/middleware.ts. Any changes here must be
   // mirrored there and vice versa.
   return `
-function matchMiddlewarePattern(pathname, pattern) {
-  // Regex patterns: if the pattern contains "(" or "\\" it's a regex —
-  // pass it through to RegExp directly WITHOUT dot-escaping.
-  // This guard prevents regex pattern corruption from dot-escaping.
+${v} __mwPatternCache = new Map();
+function __compileMwPattern(pattern) {
   if (pattern.includes("(") || pattern.includes("\\\\")) {
-    ${v} re = __safeRegExp("^" + pattern + "$");
-    if (re) return re.test(pathname);
+    return __safeRegExp("^" + pattern + "$");
   }
-  // Single-pass tokenizer (avoids chained .replace() flagged by CodeQL as
-  // incomplete sanitization — later passes could re-process earlier outputs).
   ${l} regexStr = "";
   ${v} tokenRe = /\\/:([\\w-]+)\\*|\\/:([\\w-]+)\\+|:([\\w-]+)|[.]|[^/:.]+|./g;
   ${l} tok;
@@ -170,8 +165,15 @@ function matchMiddlewarePattern(pathname, pattern) {
     else if (tok[0] === ".") { regexStr += "\\\\."; }
     else { regexStr += tok[0]; }
   }
-  ${v} re2 = __safeRegExp("^" + regexStr + "$");
-  return re2 ? re2.test(pathname) : pathname === pattern;
+  return __safeRegExp("^" + regexStr + "$");
+}
+function matchMiddlewarePattern(pathname, pattern) {
+  ${l} cached = __mwPatternCache.get(pattern);
+  if (cached === undefined) {
+    cached = __compileMwPattern(pattern);
+    __mwPatternCache.set(pattern, cached);
+  }
+  return cached ? cached.test(pathname) : pathname === pattern;
 }
 
 function matchesMiddleware(pathname, matcher) {

--- a/packages/vinext/src/server/middleware.ts
+++ b/packages/vinext/src/server/middleware.ts
@@ -152,6 +152,21 @@ export function matchesMiddleware(pathname: string, matcher: MatcherConfig | und
 }
 
 /**
+ * Cache for compiled middleware matcher regexes.
+ *
+ * Middleware matcher patterns are static — they come from `config.matcher`
+ * in the user's middleware/proxy file and never change at runtime. Without
+ * caching, every request re-runs the full tokeniser + isSafeRegex scan +
+ * new RegExp() for every matcher pattern. This is the same problem that
+ * config-matchers.ts solved with `_compiledPatternCache` (which eliminated
+ * ~2.4s of CPU self-time in profiling).
+ *
+ * Value is `null` when safeRegExp rejected the pattern (ReDoS risk), so we
+ * skip it on subsequent requests without re-running the scanner.
+ */
+const _mwPatternCache = new Map<string, RegExp | null>();
+
+/**
  * Match a single pattern against a pathname.
  * Supports Next.js matcher patterns:
  *   /about          -> exact match
@@ -160,11 +175,22 @@ export function matchesMiddleware(pathname: string, matcher: MatcherConfig | und
  *   /((?!api|_next).*)  -> regex patterns
  */
 export function matchPattern(pathname: string, pattern: string): boolean {
-  // Handle regex patterns (starts with /)
+  let cached = _mwPatternCache.get(pattern);
+  if (cached === undefined) {
+    cached = compileMatcherPattern(pattern);
+    _mwPatternCache.set(pattern, cached);
+  }
+  if (cached === null) return pathname === pattern;
+  return cached.test(pathname);
+}
+
+/**
+ * Compile a matcher pattern into a RegExp (or null if rejected by safeRegExp).
+ */
+function compileMatcherPattern(pattern: string): RegExp | null {
+  // Handle regex patterns (contains groups or escapes)
   if (pattern.includes("(") || pattern.includes("\\")) {
-    const re = safeRegExp("^" + pattern + "$");
-    if (re) return re.test(pathname);
-    // Fall through to simple matching
+    return safeRegExp("^" + pattern + "$");
   }
 
   // Convert Next.js path patterns to regex in a single pass.
@@ -190,9 +216,7 @@ export function matchPattern(pathname: string, pattern: string): boolean {
     }
   }
 
-  const re = safeRegExp("^" + regexStr + "$");
-  if (re) return re.test(pathname);
-  return pathname === pattern;
+  return safeRegExp("^" + regexStr + "$");
 }
 
 /** Result of running middleware. */

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -12843,16 +12843,11 @@ async function buildPageElement(route, params, opts, searchParams) {
 }
 
 
-function matchMiddlewarePattern(pathname, pattern) {
-  // Regex patterns: if the pattern contains "(" or "\\" it's a regex —
-  // pass it through to RegExp directly WITHOUT dot-escaping.
-  // This guard prevents regex pattern corruption from dot-escaping.
+const __mwPatternCache = new Map();
+function __compileMwPattern(pattern) {
   if (pattern.includes("(") || pattern.includes("\\\\")) {
-    const re = __safeRegExp("^" + pattern + "$");
-    if (re) return re.test(pathname);
+    return __safeRegExp("^" + pattern + "$");
   }
-  // Single-pass tokenizer (avoids chained .replace() flagged by CodeQL as
-  // incomplete sanitization — later passes could re-process earlier outputs).
   let regexStr = "";
   const tokenRe = /\\/:([\\w-]+)\\*|\\/:([\\w-]+)\\+|:([\\w-]+)|[.]|[^/:.]+|./g;
   let tok;
@@ -12863,8 +12858,15 @@ function matchMiddlewarePattern(pathname, pattern) {
     else if (tok[0] === ".") { regexStr += "\\\\."; }
     else { regexStr += tok[0]; }
   }
-  const re2 = __safeRegExp("^" + regexStr + "$");
-  return re2 ? re2.test(pathname) : pathname === pattern;
+  return __safeRegExp("^" + regexStr + "$");
+}
+function matchMiddlewarePattern(pathname, pattern) {
+  let cached = __mwPatternCache.get(pattern);
+  if (cached === undefined) {
+    cached = __compileMwPattern(pattern);
+    __mwPatternCache.set(pattern, cached);
+  }
+  return cached ? cached.test(pathname) : pathname === pattern;
 }
 
 function matchesMiddleware(pathname, matcher) {
@@ -15792,16 +15794,11 @@ function __safeRegExp(pattern, flags) {
   try { return new RegExp(pattern, flags); } catch { return null; }
 }
 
-function matchMiddlewarePattern(pathname, pattern) {
-  // Regex patterns: if the pattern contains "(" or "\\" it's a regex —
-  // pass it through to RegExp directly WITHOUT dot-escaping.
-  // This guard prevents regex pattern corruption from dot-escaping.
+var __mwPatternCache = new Map();
+function __compileMwPattern(pattern) {
   if (pattern.includes("(") || pattern.includes("\\\\")) {
-    var re = __safeRegExp("^" + pattern + "$");
-    if (re) return re.test(pathname);
+    return __safeRegExp("^" + pattern + "$");
   }
-  // Single-pass tokenizer (avoids chained .replace() flagged by CodeQL as
-  // incomplete sanitization — later passes could re-process earlier outputs).
   var regexStr = "";
   var tokenRe = /\\/:([\\w-]+)\\*|\\/:([\\w-]+)\\+|:([\\w-]+)|[.]|[^/:.]+|./g;
   var tok;
@@ -15812,8 +15809,15 @@ function matchMiddlewarePattern(pathname, pattern) {
     else if (tok[0] === ".") { regexStr += "\\\\."; }
     else { regexStr += tok[0]; }
   }
-  var re2 = __safeRegExp("^" + regexStr + "$");
-  return re2 ? re2.test(pathname) : pathname === pattern;
+  return __safeRegExp("^" + regexStr + "$");
+}
+function matchMiddlewarePattern(pathname, pattern) {
+  var cached = __mwPatternCache.get(pattern);
+  if (cached === undefined) {
+    cached = __compileMwPattern(pattern);
+    __mwPatternCache.set(pattern, cached);
+  }
+  return cached ? cached.test(pathname) : pathname === pattern;
 }
 
 function matchesMiddleware(pathname, matcher) {


### PR DESCRIPTION
## Summary

- Middleware matcher patterns (from `config.matcher`) are static but `matchPattern()` was re-running the full tokeniser + `isSafeRegex` scan + `new RegExp()` on **every request** for every matcher entry
- This is the same problem that `config-matchers.ts` solved with `_compiledPatternCache` (which eliminated ~2.4s of CPU self-time in profiling) — the middleware path was never given the same fix
- Add a `Map<string, RegExp | null>` cache to both the runtime `matchPattern()` and the codegen `matchMiddlewarePattern()` so each pattern is compiled exactly once per process lifetime

## Test plan

- [x] All 57 existing middleware matcher tests pass (exact match, params, wildcards, regex, ReDoS rejection, bypass prevention, double-encoding)
- [x] All 3 codegen parity tests pass (eval'd generated code produces identical results)
- [x] Entry template snapshots updated
- [x] Typecheck clean
- [x] Lint clean