### PR TITLE
fix: RequestCookie behavior and getAll(name)

### DIFF
--- a/packages/vinext/src/shims/headers.ts
+++ b/packages/vinext/src/shims/headers.ts
@@ -10,6 +10,7 @@
 
 import { AsyncLocalStorage } from "node:async_hooks";
 import { buildRequestHeadersFromMiddlewareResponse } from "../server/middleware-request-headers.js";
+import { parseCookieHeader } from "./internal/parse-cookie-header.js";
 
 // ---------------------------------------------------------------------------
 // Request context
@@ -18,29 +19,6 @@ import { buildRequestHeadersFromMiddlewareResponse } from "../server/middleware-
 interface HeadersContext {
   headers: Headers;
   cookies: Map<string, string>;
-}
-
-function parseCookieHeader(cookieHeader: string): Map<string, string> {
-  const cookies = new Map<string, string>();
-  for (const pair of cookieHeader.split(/; */)) {
-    if (!pair) continue;
-
-    const splitAt = pair.indexOf("=");
-    if (splitAt === -1) {
-      cookies.set(pair, "true");
-      continue;
-    }
-
-    const key = pair.slice(0, splitAt).trim();
-    if (!key) continue;
-
-    try {
-      cookies.set(key, decodeURIComponent(pair.slice(splitAt + 1).trim()));
-    } catch {
-      // Match Next.js/@edge-runtime behavior: ignore malformed cookie values.
-    }
-  }
-  return cookies;
 }
 
 type VinextHeadersShimState = {

--- a/packages/vinext/src/shims/internal/parse-cookie-header.ts
+++ b/packages/vinext/src/shims/internal/parse-cookie-header.ts
@@ -1,0 +1,32 @@
+/**
+ * Port of the current Next.js/@edge-runtime request cookie parser semantics.
+ *
+ * Important details:
+ * - split on a semicolon-plus-optional-spaces pattern
+ * - preserve whitespace around names/values otherwise
+ * - bare tokens become "true"
+ * - malformed percent-encoded values are skipped
+ * - duplicate names collapse to the last value via Map.set()
+ */
+export function parseCookieHeader(cookieHeader: string): Map<string, string> {
+  const cookies = new Map<string, string>();
+  for (const pair of cookieHeader.split(/; */)) {
+    if (!pair) continue;
+
+    const splitAt = pair.indexOf("=");
+    if (splitAt === -1) {
+      cookies.set(pair, "true");
+      continue;
+    }
+
+    const key = pair.slice(0, splitAt);
+    const value = pair.slice(splitAt + 1);
+
+    try {
+      cookies.set(key, decodeURIComponent(value));
+    } catch {
+      // Match Next.js/@edge-runtime behavior: ignore malformed cookie values.
+    }
+  }
+  return cookies;
+}

--- a/packages/vinext/src/shims/server.ts
+++ b/packages/vinext/src/shims/server.ts
@@ -10,6 +10,7 @@
  */
 
 import { encodeMiddlewareRequestHeaders } from "../server/middleware-request-headers.js";
+import { parseCookieHeader } from "./internal/parse-cookie-header.js";
 
 // ---------------------------------------------------------------------------
 // NextRequest
@@ -287,29 +288,6 @@ export class NextURL {
 interface CookieEntry {
   name: string;
   value: string;
-}
-
-function parseCookieHeader(cookieHeader: string): Map<string, string> {
-  const cookies = new Map<string, string>();
-  for (const pair of cookieHeader.split(/; */)) {
-    if (!pair) continue;
-
-    const splitAt = pair.indexOf("=");
-    if (splitAt === -1) {
-      cookies.set(pair, "true");
-      continue;
-    }
-
-    const name = pair.slice(0, splitAt).trim();
-    if (!name) continue;
-
-    try {
-      cookies.set(name, decodeURIComponent(pair.slice(splitAt + 1).trim()));
-    } catch {
-      // Match Next.js/@edge-runtime behavior: ignore malformed cookie values.
-    }
-  }
-  return cookies;
 }
 
 export class RequestCookies {

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -343,6 +343,27 @@ describe("next/headers shim", () => {
     });
   });
 
+  it("cookies() preserves whitespace exactly like the Next.js parser", async () => {
+    const { headersContextFromRequest, runWithHeadersContext, cookies } =
+      await import("../packages/vinext/src/shims/headers.js");
+
+    const ctx = headersContextFromRequest(
+      new Request("https://example.com", {
+        headers: { cookie: "a= 1 ; a =2" },
+      }),
+    );
+
+    await runWithHeadersContext(ctx, async () => {
+      const jar = await cookies();
+      expect(jar.get("a")).toEqual({ name: "a", value: " 1 " });
+      expect(jar.get("a ")).toEqual({ name: "a ", value: "2" });
+      expect(jar.getAll()).toEqual([
+        { name: "a", value: " 1 " },
+        { name: "a ", value: "2" },
+      ]);
+    });
+  });
+
   it("headersContextFromRequest returns mutable headers (not the immutable Request.headers)", async () => {
     // In Cloudflare Workers, Request.headers is immutable. applyMiddlewareRequestHeaders
     // needs ctx.headers.set() after middleware runs, so the context must hold a mutable
@@ -2536,6 +2557,19 @@ describe("RequestCookies API", () => {
     expect(cookies.getAll()).toEqual([
       { name: "empty", value: "" },
       { name: "flag", value: "true" },
+    ]);
+  });
+
+  it("preserves whitespace exactly like the Next.js parser", async () => {
+    const { RequestCookies } = await import("../packages/vinext/src/shims/server.js");
+    const headers = new Headers({ cookie: "a= 1 ; a =2" });
+    const cookies = new RequestCookies(headers);
+
+    expect(cookies.get("a")).toEqual({ name: "a", value: " 1 " });
+    expect(cookies.get("a ")).toEqual({ name: "a ", value: "2" });
+    expect(cookies.getAll()).toEqual([
+      { name: "a", value: " 1 " },
+      { name: "a ", value: "2" },
     ]);
   });
 


### PR DESCRIPTION
Align vinext request-cookie behavior with the current Next.js runtime in both request-cookie implementations:

- `packages/vinext/src/shims/headers.ts`
- `packages/vinext/src/shims/server.ts`

## What changed

### Fix `RequestCookies.getAll(name)`

`getAll(name)` was ignoring its argument and returning the full cookie list.

Before, with:

```http
cookie: a=1; a=2; b=3
```

vinext returned:

- `get('a') => { name: 'a', value: '2' }`
- `getAll('a') => [{ name: 'a', value: '2' }, { name: 'b', value: '3' }]`

Now it returns:

- `get('a') => { name: 'a', value: '2' }`
- `getAll('a') => [{ name: 'a', value: '2' }]`

This now works for both overloads:

- `getAll("a")`
- `getAll({ name: "a" })`

Missing names now correctly return `[]`.

### Align request cookie parsing with current Next.js runtime

While expanding coverage, I found both request-cookie parsers also diverged from current Next.js runtime behavior.

Both shims now match `next@16.1.6` for:

- duplicate names collapsing to the last value
- percent-decoding cookie values
- ignoring malformed percent-encoded values
- treating bare cookie tokens as `"true"`

Examples:

- `token=abc%3D123` => `abc=123`
- `bad=%E0%A4%A` => skipped
- `flag` => `{ name: "flag", value: "true" }`

### Keep middleware cookie rewrites consistent

`applyMiddlewareRequestHeaders()` now rebuilds the cookie map using the same parser, so middleware-rewritten `cookie` headers behave the same as initially parsed request headers.

## Tests

Added targeted regressions in `tests/shims.test.ts` covering:

- `getAll("name")`
- `getAll({ name })`
- missing-name lookups
- duplicate-name behavior
- percent-decoding
- malformed encoded values
- bare token cookies
- middleware cookie rewrites with duplicate names