### PR TITLE
fix: tag GitHub @usernames in release notes, publish release directly

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -99,9 +99,9 @@ jobs:
             SUBJECT=$(echo "$line" | cut -d' ' -f2-)
             LOGIN=$(gh api "repos/${{ github.repository }}/commits/${SHA}" --jq '.author.login // .commit.author.name' 2>/dev/null || echo "")
             if [ -n "$LOGIN" ]; then
-              echo "${SHA} ${SUBJECT} (@${LOGIN})"
+              echo "${SHA:0:7} ${SUBJECT} (@${LOGIN})"
             else
-              echo "${SHA} ${SUBJECT}"
+              echo "${SHA:0:7} ${SUBJECT}"
             fi
           done < /tmp/raw-commits.txt > /tmp/commits.txt
 


### PR DESCRIPTION
## Summary

- Resolves GitHub usernames via the API for each commit so contributors are tagged as `@username` (rendered as clickable mentions) instead of their full git author name
- Removes `--draft` from `gh release create` so releases are published immediately on version bump