### PR TITLE
ci: add dependency audit and Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      minor-and-patch:
+        update-types: ["minor", "patch"]
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,16 @@ jobs:
       - uses: ./.github/actions/setup-node-pnpm
       - run: pnpm run fmt:check
 
+  dependencies:
+    name: Dependency Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-node-pnpm
+      - name: Audit dependencies
+        run: pnpm audit --audit-level high
+        continue-on-error: true
+
   typecheck:
     name: Typecheck
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add `pnpm audit --audit-level high` job to CI (advisory, non-blocking via `continue-on-error`)
- Add Dependabot config for npm (weekly, minor+patch grouped) and GitHub Actions (weekly)

Closes #416

## Test plan
- [ ] CI workflow YAML is valid
- [ ] Dependabot config YAML is valid
- [ ] New `Dependency Audit` job appears in CI run
- [ ] Dependabot starts opening PRs after merge