### PR TITLE
fix: honor beforePopState when useRouter is mounted

### DIFF
--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -453,19 +453,8 @@ function buildRouterValue(
 export function useRouter(): NextRouter {
   const [{ pathname, query, asPath }, setState] = useState(getPathnameAndQuery);
 
-  useEffect(() => {
-    const onPopState = (e: PopStateEvent) => {
-      setState(getPathnameAndQuery());
-      // Re-render with the new page on back/forward navigation
-      void navigateClient(window.location.pathname + window.location.search).then(() => {
-        restoreScrollPosition(e.state);
-      });
-    };
-    window.addEventListener("popstate", onPopState);
-    return () => window.removeEventListener("popstate", onPopState);
-  }, []);
-
-  // Listen for custom navigation events from Link component
+  // Popstate is handled by the module-level listener below so beforePopState()
+  // is consistently enforced even when multiple components mount useRouter().
   useEffect(() => {
     const onNavigate = ((_e: CustomEvent) => {
       setState(getPathnameAndQuery());

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -17414,6 +17414,7 @@ const pageLoaders = {
   "/404": () => import("<ROOT>/tests/fixtures/pages-basic/pages/404.tsx"),
   "/about": () => import("<ROOT>/tests/fixtures/pages-basic/pages/about.tsx"),
   "/alias-test": () => import("<ROOT>/tests/fixtures/pages-basic/pages/alias-test.tsx"),
+  "/before-pop-state-destination": () => import("<ROOT>/tests/fixtures/pages-basic/pages/before-pop-state-destination.tsx"),
   "/before-pop-state-test": () => import("<ROOT>/tests/fixtures/pages-basic/pages/before-pop-state-test.tsx"),
   "/cjs/basic": () => import("<ROOT>/tests/fixtures/pages-basic/pages/cjs/basic.tsx"),
   "/cjs/random": () => import("<ROOT>/tests/fixtures/pages-basic/pages/cjs/random.ts"),
@@ -17594,33 +17595,34 @@ import * as page_0 from "<ROOT>/tests/fixtures/pages-basic/pages/index.tsx";
 import * as page_1 from "<ROOT>/tests/fixtures/pages-basic/pages/404.tsx";
 import * as page_2 from "<ROOT>/tests/fixtures/pages-basic/pages/about.tsx";
 import * as page_3 from "<ROOT>/tests/fixtures/pages-basic/pages/alias-test.tsx";
-import * as page_4 from "<ROOT>/tests/fixtures/pages-basic/pages/before-pop-state-test.tsx";
-import * as page_5 from "<ROOT>/tests/fixtures/pages-basic/pages/cjs/basic.tsx";
-import * as page_6 from "<ROOT>/tests/fixtures/pages-basic/pages/cjs/random.ts";
-import * as page_7 from "<ROOT>/tests/fixtures/pages-basic/pages/config-test.tsx";
-import * as page_8 from "<ROOT>/tests/fixtures/pages-basic/pages/counter.tsx";
-import * as page_9 from "<ROOT>/tests/fixtures/pages-basic/pages/dynamic-page.tsx";
-import * as page_10 from "<ROOT>/tests/fixtures/pages-basic/pages/dynamic-ssr-false.tsx";
-import * as page_11 from "<ROOT>/tests/fixtures/pages-basic/pages/header-override-delete.tsx";
-import * as page_12 from "<ROOT>/tests/fixtures/pages-basic/pages/isr-test.tsx";
-import * as page_13 from "<ROOT>/tests/fixtures/pages-basic/pages/link-test.tsx";
-import * as page_14 from "<ROOT>/tests/fixtures/pages-basic/pages/mw-object-gated.tsx";
-import * as page_15 from "<ROOT>/tests/fixtures/pages-basic/pages/nav-test.tsx";
-import * as page_16 from "<ROOT>/tests/fixtures/pages-basic/pages/posts/missing.tsx";
-import * as page_17 from "<ROOT>/tests/fixtures/pages-basic/pages/redirect-xss.tsx";
-import * as page_18 from "<ROOT>/tests/fixtures/pages-basic/pages/router-events-test.tsx";
-import * as page_19 from "<ROOT>/tests/fixtures/pages-basic/pages/script-test.tsx";
-import * as page_20 from "<ROOT>/tests/fixtures/pages-basic/pages/shallow-test.tsx";
-import * as page_21 from "<ROOT>/tests/fixtures/pages-basic/pages/ssr.tsx";
-import * as page_22 from "<ROOT>/tests/fixtures/pages-basic/pages/ssr-headers.tsx";
-import * as page_23 from "<ROOT>/tests/fixtures/pages-basic/pages/ssr-res-end.tsx";
-import * as page_24 from "<ROOT>/tests/fixtures/pages-basic/pages/suspense-test.tsx";
-import * as page_25 from "<ROOT>/tests/fixtures/pages-basic/pages/articles/[id].tsx";
-import * as page_26 from "<ROOT>/tests/fixtures/pages-basic/pages/blog/[slug].tsx";
-import * as page_27 from "<ROOT>/tests/fixtures/pages-basic/pages/posts/[id].tsx";
-import * as page_28 from "<ROOT>/tests/fixtures/pages-basic/pages/products/[pid].tsx";
-import * as page_29 from "<ROOT>/tests/fixtures/pages-basic/pages/docs/[...slug].tsx";
-import * as page_30 from "<ROOT>/tests/fixtures/pages-basic/pages/sign-up/[[...sign-up]]/index.tsx";
+import * as page_4 from "<ROOT>/tests/fixtures/pages-basic/pages/before-pop-state-destination.tsx";
+import * as page_5 from "<ROOT>/tests/fixtures/pages-basic/pages/before-pop-state-test.tsx";
+import * as page_6 from "<ROOT>/tests/fixtures/pages-basic/pages/cjs/basic.tsx";
+import * as page_7 from "<ROOT>/tests/fixtures/pages-basic/pages/cjs/random.ts";
+import * as page_8 from "<ROOT>/tests/fixtures/pages-basic/pages/config-test.tsx";
+import * as page_9 from "<ROOT>/tests/fixtures/pages-basic/pages/counter.tsx";
+import * as page_10 from "<ROOT>/tests/fixtures/pages-basic/pages/dynamic-page.tsx";
+import * as page_11 from "<ROOT>/tests/fixtures/pages-basic/pages/dynamic-ssr-false.tsx";
+import * as page_12 from "<ROOT>/tests/fixtures/pages-basic/pages/header-override-delete.tsx";
+import * as page_13 from "<ROOT>/tests/fixtures/pages-basic/pages/isr-test.tsx";
+import * as page_14 from "<ROOT>/tests/fixtures/pages-basic/pages/link-test.tsx";
+import * as page_15 from "<ROOT>/tests/fixtures/pages-basic/pages/mw-object-gated.tsx";
+import * as page_16 from "<ROOT>/tests/fixtures/pages-basic/pages/nav-test.tsx";
+import * as page_17 from "<ROOT>/tests/fixtures/pages-basic/pages/posts/missing.tsx";
+import * as page_18 from "<ROOT>/tests/fixtures/pages-basic/pages/redirect-xss.tsx";
+import * as page_19 from "<ROOT>/tests/fixtures/pages-basic/pages/router-events-test.tsx";
+import * as page_20 from "<ROOT>/tests/fixtures/pages-basic/pages/script-test.tsx";
+import * as page_21 from "<ROOT>/tests/fixtures/pages-basic/pages/shallow-test.tsx";
+import * as page_22 from "<ROOT>/tests/fixtures/pages-basic/pages/ssr.tsx";
+import * as page_23 from "<ROOT>/tests/fixtures/pages-basic/pages/ssr-headers.tsx";
+import * as page_24 from "<ROOT>/tests/fixtures/pages-basic/pages/ssr-res-end.tsx";
+import * as page_25 from "<ROOT>/tests/fixtures/pages-basic/pages/suspense-test.tsx";
+import * as page_26 from "<ROOT>/tests/fixtures/pages-basic/pages/articles/[id].tsx";
+import * as page_27 from "<ROOT>/tests/fixtures/pages-basic/pages/blog/[slug].tsx";
+import * as page_28 from "<ROOT>/tests/fixtures/pages-basic/pages/posts/[id].tsx";
+import * as page_29 from "<ROOT>/tests/fixtures/pages-basic/pages/products/[pid].tsx";
+import * as page_30 from "<ROOT>/tests/fixtures/pages-basic/pages/docs/[...slug].tsx";
+import * as page_31 from "<ROOT>/tests/fixtures/pages-basic/pages/sign-up/[[...sign-up]]/index.tsx";
 import * as api_0 from "<ROOT>/tests/fixtures/pages-basic/pages/api/binary.ts";
 import * as api_1 from "<ROOT>/tests/fixtures/pages-basic/pages/api/error-route.ts";
 import * as api_2 from "<ROOT>/tests/fixtures/pages-basic/pages/api/hello.ts";
@@ -17637,33 +17639,34 @@ const pageRoutes = [
   { pattern: "/404", patternParts: ["404"], isDynamic: false, params: [], module: page_1, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/404.tsx" },
   { pattern: "/about", patternParts: ["about"], isDynamic: false, params: [], module: page_2, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/about.tsx" },
   { pattern: "/alias-test", patternParts: ["alias-test"], isDynamic: false, params: [], module: page_3, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/alias-test.tsx" },
-  { pattern: "/before-pop-state-test", patternParts: ["before-pop-state-test"], isDynamic: false, params: [], module: page_4, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/before-pop-state-test.tsx" },
-  { pattern: "/cjs/basic", patternParts: ["cjs","basic"], isDynamic: false, params: [], module: page_5, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/cjs/basic.tsx" },
-  { pattern: "/cjs/random", patternParts: ["cjs","random"], isDynamic: false, params: [], module: page_6, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/cjs/random.ts" },
-  { pattern: "/config-test", patternParts: ["config-test"], isDynamic: false, params: [], module: page_7, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/config-test.tsx" },
-  { pattern: "/counter", patternParts: ["counter"], isDynamic: false, params: [], module: page_8, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/counter.tsx" },
-  { pattern: "/dynamic-page", patternParts: ["dynamic-page"], isDynamic: false, params: [], module: page_9, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/dynamic-page.tsx" },
-  { pattern: "/dynamic-ssr-false", patternParts: ["dynamic-ssr-false"], isDynamic: false, params: [], module: page_10, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/dynamic-ssr-false.tsx" },
-  { pattern: "/header-override-delete", patternParts: ["header-override-delete"], isDynamic: false, params: [], module: page_11, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/header-override-delete.tsx" },
-  { pattern: "/isr-test", patternParts: ["isr-test"], isDynamic: false, params: [], module: page_12, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/isr-test.tsx" },
-  { pattern: "/link-test", patternParts: ["link-test"], isDynamic: false, params: [], module: page_13, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/link-test.tsx" },
-  { pattern: "/mw-object-gated", patternParts: ["mw-object-gated"], isDynamic: false, params: [], module: page_14, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/mw-object-gated.tsx" },
-  { pattern: "/nav-test", patternParts: ["nav-test"], isDynamic: false, params: [], module: page_15, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/nav-test.tsx" },
-  { pattern: "/posts/missing", patternParts: ["posts","missing"], isDynamic: false, params: [], module: page_16, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/posts/missing.tsx" },
-  { pattern: "/redirect-xss", patternParts: ["redirect-xss"], isDynamic: false, params: [], module: page_17, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/redirect-xss.tsx" },
-  { pattern: "/router-events-test", patternParts: ["router-events-test"], isDynamic: false, params: [], module: page_18, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/router-events-test.tsx" },
-  { pattern: "/script-test", patternParts: ["script-test"], isDynamic: false, params: [], module: page_19, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/script-test.tsx" },
-  { pattern: "/shallow-test", patternParts: ["shallow-test"], isDynamic: false, params: [], module: page_20, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/shallow-test.tsx" },
-  { pattern: "/ssr", patternParts: ["ssr"], isDynamic: false, params: [], module: page_21, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/ssr.tsx" },
-  { pattern: "/ssr-headers", patternParts: ["ssr-headers"], isDynamic: false, params: [], module: page_22, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/ssr-headers.tsx" },
-  { pattern: "/ssr-res-end", patternParts: ["ssr-res-end"], isDynamic: false, params: [], module: page_23, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/ssr-res-end.tsx" },
-  { pattern: "/suspense-test", patternParts: ["suspense-test"], isDynamic: false, params: [], module: page_24, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/suspense-test.tsx" },
-  { pattern: "/articles/:id", patternParts: ["articles",":id"], isDynamic: true, params: ["id"], module: page_25, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/articles/[id].tsx" },
-  { pattern: "/blog/:slug", patternParts: ["blog",":slug"], isDynamic: true, params: ["slug"], module: page_26, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/blog/[slug].tsx" },
-  { pattern: "/posts/:id", patternParts: ["posts",":id"], isDynamic: true, params: ["id"], module: page_27, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/posts/[id].tsx" },
-  { pattern: "/products/:pid", patternParts: ["products",":pid"], isDynamic: true, params: ["pid"], module: page_28, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/products/[pid].tsx" },
-  { pattern: "/docs/:slug+", patternParts: ["docs",":slug+"], isDynamic: true, params: ["slug"], module: page_29, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/docs/[...slug].tsx" },
-  { pattern: "/sign-up/:sign-up*", patternParts: ["sign-up",":sign-up*"], isDynamic: true, params: ["sign-up"], module: page_30, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/sign-up/[[...sign-up]]/index.tsx" }
+  { pattern: "/before-pop-state-destination", patternParts: ["before-pop-state-destination"], isDynamic: false, params: [], module: page_4, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/before-pop-state-destination.tsx" },
+  { pattern: "/before-pop-state-test", patternParts: ["before-pop-state-test"], isDynamic: false, params: [], module: page_5, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/before-pop-state-test.tsx" },
+  { pattern: "/cjs/basic", patternParts: ["cjs","basic"], isDynamic: false, params: [], module: page_6, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/cjs/basic.tsx" },
+  { pattern: "/cjs/random", patternParts: ["cjs","random"], isDynamic: false, params: [], module: page_7, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/cjs/random.ts" },
+  { pattern: "/config-test", patternParts: ["config-test"], isDynamic: false, params: [], module: page_8, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/config-test.tsx" },
+  { pattern: "/counter", patternParts: ["counter"], isDynamic: false, params: [], module: page_9, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/counter.tsx" },
+  { pattern: "/dynamic-page", patternParts: ["dynamic-page"], isDynamic: false, params: [], module: page_10, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/dynamic-page.tsx" },
+  { pattern: "/dynamic-ssr-false", patternParts: ["dynamic-ssr-false"], isDynamic: false, params: [], module: page_11, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/dynamic-ssr-false.tsx" },
+  { pattern: "/header-override-delete", patternParts: ["header-override-delete"], isDynamic: false, params: [], module: page_12, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/header-override-delete.tsx" },
+  { pattern: "/isr-test", patternParts: ["isr-test"], isDynamic: false, params: [], module: page_13, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/isr-test.tsx" },
+  { pattern: "/link-test", patternParts: ["link-test"], isDynamic: false, params: [], module: page_14, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/link-test.tsx" },
+  { pattern: "/mw-object-gated", patternParts: ["mw-object-gated"], isDynamic: false, params: [], module: page_15, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/mw-object-gated.tsx" },
+  { pattern: "/nav-test", patternParts: ["nav-test"], isDynamic: false, params: [], module: page_16, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/nav-test.tsx" },
+  { pattern: "/posts/missing", patternParts: ["posts","missing"], isDynamic: false, params: [], module: page_17, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/posts/missing.tsx" },
+  { pattern: "/redirect-xss", patternParts: ["redirect-xss"], isDynamic: false, params: [], module: page_18, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/redirect-xss.tsx" },
+  { pattern: "/router-events-test", patternParts: ["router-events-test"], isDynamic: false, params: [], module: page_19, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/router-events-test.tsx" },
+  { pattern: "/script-test", patternParts: ["script-test"], isDynamic: false, params: [], module: page_20, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/script-test.tsx" },
+  { pattern: "/shallow-test", patternParts: ["shallow-test"], isDynamic: false, params: [], module: page_21, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/shallow-test.tsx" },
+  { pattern: "/ssr", patternParts: ["ssr"], isDynamic: false, params: [], module: page_22, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/ssr.tsx" },
+  { pattern: "/ssr-headers", patternParts: ["ssr-headers"], isDynamic: false, params: [], module: page_23, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/ssr-headers.tsx" },
+  { pattern: "/ssr-res-end", patternParts: ["ssr-res-end"], isDynamic: false, params: [], module: page_24, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/ssr-res-end.tsx" },
+  { pattern: "/suspense-test", patternParts: ["suspense-test"], isDynamic: false, params: [], module: page_25, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/suspense-test.tsx" },
+  { pattern: "/articles/:id", patternParts: ["articles",":id"], isDynamic: true, params: ["id"], module: page_26, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/articles/[id].tsx" },
+  { pattern: "/blog/:slug", patternParts: ["blog",":slug"], isDynamic: true, params: ["slug"], module: page_27, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/blog/[slug].tsx" },
+  { pattern: "/posts/:id", patternParts: ["posts",":id"], isDynamic: true, params: ["id"], module: page_28, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/posts/[id].tsx" },
+  { pattern: "/products/:pid", patternParts: ["products",":pid"], isDynamic: true, params: ["pid"], module: page_29, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/products/[pid].tsx" },
+  { pattern: "/docs/:slug+", patternParts: ["docs",":slug+"], isDynamic: true, params: ["slug"], module: page_30, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/docs/[...slug].tsx" },
+  { pattern: "/sign-up/:sign-up*", patternParts: ["sign-up",":sign-up*"], isDynamic: true, params: ["sign-up"], module: page_31, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/sign-up/[[...sign-up]]/index.tsx" }
 ];
 
 const apiRoutes = [

--- a/tests/e2e/pages-router/before-pop-state.spec.ts
+++ b/tests/e2e/pages-router/before-pop-state.spec.ts
@@ -32,6 +32,33 @@ test.describe("router.beforePopState (Pages Router)", () => {
     expect(blocked).toBeGreaterThanOrEqual(1);
   });
 
+  test("blocking callback still prevents route change when destination mounts useRouter", async ({
+    page,
+  }) => {
+    await page.goto(`${BASE}/before-pop-state-test`);
+    await page.waitForFunction(() => (window as any).__VINEXT_ROOT__);
+
+    await page.click('[data-testid="enable-blocking"]');
+    await expect(page.locator('[data-testid="toggle-blocking"]')).toHaveText("Blocking: ON");
+
+    await page.click('[data-testid="link-destination"]');
+    await expect(page.locator("h1")).toHaveText("Before Pop State Destination");
+    await expect(page.locator('[data-testid="destination-path"]')).toHaveText(
+      "/before-pop-state-destination",
+    );
+
+    await page.goBack();
+    await page.waitForTimeout(500);
+
+    await expect(page.locator("h1")).toHaveText("Before Pop State Destination");
+    await expect(page.locator('[data-testid="destination-path"]')).toHaveText(
+      "/before-pop-state-destination",
+    );
+
+    const blocked = await page.evaluate(() => (window as any).__popBlocked);
+    expect(blocked).toBeGreaterThanOrEqual(1);
+  });
+
   test("allowing callback permits back navigation", async ({ page }) => {
     await page.goto(`${BASE}/before-pop-state-test`);
     await page.waitForFunction(() => (window as any).__VINEXT_ROOT__);
@@ -44,6 +71,25 @@ test.describe("router.beforePopState (Pages Router)", () => {
     await expect(page.locator("h1")).toHaveText("About");
 
     // Go back — should be allowed (beforePopState returns true)
+    await page.goBack();
+    await expect(page.locator("h1")).toHaveText("Before Pop State Test");
+    await expect(page.locator('[data-testid="current-path"]')).toHaveText("/before-pop-state-test");
+  });
+
+  test("allowing callback permits back navigation when destination mounts useRouter", async ({
+    page,
+  }) => {
+    await page.goto(`${BASE}/before-pop-state-test`);
+    await page.waitForFunction(() => (window as any).__VINEXT_ROOT__);
+
+    await expect(page.locator('[data-testid="toggle-blocking"]')).toHaveText("Blocking: OFF");
+
+    await page.click('[data-testid="link-destination"]');
+    await expect(page.locator("h1")).toHaveText("Before Pop State Destination");
+    await expect(page.locator('[data-testid="destination-path"]')).toHaveText(
+      "/before-pop-state-destination",
+    );
+
     await page.goBack();
     await expect(page.locator("h1")).toHaveText("Before Pop State Test");
     await expect(page.locator('[data-testid="current-path"]')).toHaveText("/before-pop-state-test");

--- a/tests/fixtures/pages-basic/pages/before-pop-state-destination.tsx
+++ b/tests/fixtures/pages-basic/pages/before-pop-state-destination.tsx
@@ -1,0 +1,16 @@
+import Link from "next/link";
+import { useRouter } from "next/router";
+
+export default function BeforePopStateDestination() {
+  const router = useRouter();
+
+  return (
+    <div>
+      <h1>Before Pop State Destination</h1>
+      <p data-testid="destination-path">{router.asPath}</p>
+      <Link href="/before-pop-state-test" data-testid="link-back-to-test">
+        Back to Before Pop State Test
+      </Link>
+    </div>
+  );
+}

--- a/tests/fixtures/pages-basic/pages/before-pop-state-test.tsx
+++ b/tests/fixtures/pages-basic/pages/before-pop-state-test.tsx
@@ -32,6 +32,9 @@ export default function BeforePopStateTest() {
       <Link href="/about" data-testid="link-about">
         Go to About
       </Link>
+      <Link href="/before-pop-state-destination" data-testid="link-destination">
+        Go to Destination With Router
+      </Link>
       <button data-testid="toggle-blocking" onClick={() => setBlocking(!blocking)}>
         {blocking ? "Blocking: ON" : "Blocking: OFF"}
       </button>

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -6607,6 +6607,26 @@ describe("Pages Router router helpers", () => {
     expect(typeof mod.wrapWithRouterContext).toBe("function");
   });
 
+  it("exposes beforePopState on both the Router singleton and wrapped router context", async () => {
+    const React = await import("react");
+    const { renderToStaticMarkup } = await import("react-dom/server");
+    const mod = await import("../packages/vinext/src/shims/router.js");
+    const { useRouter: useCompatRouter } =
+      await import("../packages/vinext/src/shims/compat-router.js");
+    const routerSingleton = mod.default;
+
+    let captured: unknown = "NOT_SET";
+    function Probe() {
+      captured = useCompatRouter();
+      return React.createElement("div", null, "probe");
+    }
+
+    renderToStaticMarkup(mod.wrapWithRouterContext(React.createElement(Probe)));
+
+    expect(typeof (routerSingleton as any).beforePopState).toBe("function");
+    expect(typeof (captured as any).beforePopState).toBe("function");
+  });
+
   describe("isExternalUrl", () => {
     it("detects https:// as external", () => {
       expect(isExternalUrl("https://example.com")).toBe(true);


### PR DESCRIPTION
Fix a Pages Router bug where `router.beforePopState()` could be bypassed whenever the currently mounted page called `useRouter()`.

Previously, the `next/router` shim had two separate `popstate` listeners:

- A module-level listener that checked `_beforePopStateCb`
- A `useRouter()`-scoped listener that always called `navigateClient()`

That meant a blocked back/forward navigation could still proceed through the hook-local listener even if the module-level listener returned early.

This change removes the duplicate `useRouter()` `popstate` listener and keeps browser back/forward handling owned by the module-level listener only. `useRouter()` still updates via the existing `vinext:navigate` event after successful navigations.

## Problem

The bug was in `packages/vinext/src/shims/router.ts`.

Before this change:

- `beforePopState(cb)` stored the callback in `_beforePopStateCb`
- The module-level `popstate` handler checked `_beforePopStateCb` and returned if it got `false`
- But `useRouter()` also registered its own `popstate` listener
- That hook-local listener always called `navigateClient(window.location.pathname + window.location.search)`

So when a page mounted `useRouter()`, a blocked `popstate` could still navigate anyway.

In practice, the existing e2e test did not catch this because it navigated from `/before-pop-state-test` to `/about`, and `/about` does not mount `useRouter()`. By the time `page.goBack()` fired, the extra hook-level listener was no longer present.

## Fix

Make `popstate` handling single-owner.

Changes:

- Remove the `useRouter()`-local `popstate` `useEffect`
- Keep all browser back/forward navigation in the module-level `popstate` listener
- Continue syncing `useRouter()` state from the existing `vinext:navigate` event

This matches Next.js more closely. In Next.js, the router owns a single `onPopState` handler and checks `beforePopState()` there; it does not install an additional hook-level `popstate` listener.

## Tests

Added regression coverage for the real failing case.

### Fixture changes

- Added `tests/fixtures/pages-basic/pages/before-pop-state-destination.tsx`
  - This page mounts `useRouter()` and exposes its current `asPath`
- Updated `tests/fixtures/pages-basic/pages/before-pop-state-test.tsx`
  - Added a link to the new destination page

### E2E coverage

Expanded `tests/e2e/pages-router/before-pop-state.spec.ts` to cover:

- blocking callback prevents route change on back navigation
- blocking callback still prevents route change when destination mounts `useRouter`
- allowing callback permits back navigation
- allowing callback permits back navigation when destination mounts `useRouter`

This closes the coverage gap that allowed the bug to slip through.

### Unit/snapshot coverage

- Added a small shim-surface assertion in `tests/shims.test.ts`
- Updated `tests/__snapshots__/entry-templates.test.ts.snap` for the new Pages Router fixture route

## Verification

- `pnpm test tests/shims.test.ts -t "beforePopState on both"`
- `pnpm test tests/entry-templates.test.ts -u`
- `PLAYWRIGHT_PROJECT=pages-router pnpm run test:e2e tests/e2e/pages-router/before-pop-state.spec.ts`
- `PLAYWRIGHT_PROJECT=cloudflare-pages-router pnpm run test:e2e tests/e2e/cloudflare-pages-router/interactive.spec.ts`