### PR TITLE
fix(isr): KVCacheHandler.set() now awaits KV put to prevent perpetual STALE

### DIFF
--- a/packages/vinext/src/cloudflare/kv-cache-handler.ts
+++ b/packages/vinext/src/cloudflare/kv-cache-handler.ts
@@ -280,17 +280,12 @@ export class KVCacheHandler implements CacheHandler {
     // else: fire-and-forget on Node.js
   }
 
-
   /**
    * Execute a KV put and return the promise so callers can await completion.
    * Also registers with ctx.waitUntil() so the Workers runtime keeps the
    * isolate alive even if the caller does not await the returned promise.
    */
-  private _put(
-    kvKey: string,
-    value: string,
-    options?: { expirationTtl?: number },
-  ): Promise<void> {
+  private _put(kvKey: string, value: string, options?: { expirationTtl?: number }): Promise<void> {
     const promise = this.kv.put(kvKey, value, options);
     const ctx = getRequestExecutionContext() ?? this.ctx;
     if (ctx) {

--- a/tests/kv-cache-handler.test.ts
+++ b/tests/kv-cache-handler.test.ts
@@ -477,14 +477,18 @@ describe("KVCacheHandler", () => {
       // the key in the store before the await returns.
       const handler2 = new KVCacheHandler(kv as any);
 
-      await handler2.set("stale-regen", {
-        kind: "APP_PAGE",
-        html: "<html>fresh</html>",
-        rscData: undefined,
-        headers: undefined,
-        postponed: undefined,
-        status: 200,
-      }, { revalidate: 10 });
+      await handler2.set(
+        "stale-regen",
+        {
+          kind: "APP_PAGE",
+          html: "<html>fresh</html>",
+          rscData: undefined,
+          headers: undefined,
+          postponed: undefined,
+          status: 200,
+        },
+        { revalidate: 10 },
+      );
 
       // After await, the KV store must already contain the key.
       // Before the fix this would also pass (synchronous mock), but the
@@ -500,9 +504,9 @@ describe("KVCacheHandler", () => {
       // Swap out kv.put with a delayed version so we can verify that the
       // promise returned by set() is NOT resolved until the put completes.
       let resolveKvPut!: () => void;
-      const kvPutLatch = new Promise<void>((r) => { resolveKvPut = r; });
-      let putResolvedBeforeSetAwaited = false;
-
+      const kvPutLatch = new Promise<void>((r) => {
+        resolveKvPut = r;
+      });
       kv.put = vi.fn(async (key: string, value: string) => {
         await kvPutLatch;
         store.set(key, value);
@@ -518,7 +522,9 @@ describe("KVCacheHandler", () => {
 
       // The set() promise should NOT be resolved yet because the kv.put hasn't resolved.
       let setSettled = false;
-      setPromise.then(() => { setSettled = true; });
+      setPromise.then(() => {
+        setSettled = true;
+      });
 
       // Give microtasks a chance to run
       await Promise.resolve();
@@ -539,7 +545,9 @@ describe("KVCacheHandler", () => {
       // Simulate a delayed KV put (network latency) to prove that
       // ctx.waitUntil keeps the isolate alive until the write completes.
       let resolveKvPut!: () => void;
-      const kvPutLatch = new Promise<void>((r) => { resolveKvPut = r; });
+      const kvPutLatch = new Promise<void>((r) => {
+        resolveKvPut = r;
+      });
 
       kv.put = vi.fn(async (key: string, value: string) => {
         await kvPutLatch;
@@ -551,21 +559,27 @@ describe("KVCacheHandler", () => {
 
       // Simulate the regen renderFn pattern from app-rsc-entry.ts
       const renderFn = async () => {
-        await handlerWithCtx.set("regen-key", {
-          kind: "APP_PAGE",
-          html: "<html>revalidated</html>",
-          rscData: undefined,
-          headers: undefined,
-          postponed: undefined,
-          status: 200,
-        }, { revalidate: 30 });
+        await handlerWithCtx.set(
+          "regen-key",
+          {
+            kind: "APP_PAGE",
+            html: "<html>revalidated</html>",
+            rscData: undefined,
+            headers: undefined,
+            postponed: undefined,
+            status: 200,
+          },
+          { revalidate: 30 },
+        );
       };
 
       // Trigger background regen as the generated entry does
       let regenSettled = false;
       const regenPromise = renderFn()
         .catch(() => {})
-        .finally(() => { regenSettled = true; });
+        .finally(() => {
+          regenSettled = true;
+        });
       ctx.waitUntil(regenPromise);
 
       // Regen should not have settled yet (put is blocked)


### PR DESCRIPTION
## Problem

After a cache entry's TTL expires, every subsequent request returned `X-Vinext-Cache: STALE` and never transitioned to `HIT`. Background regeneration appeared to trigger but the cache was never updated.

**Root cause:** `KVCacheHandler.set()` called `_putInBackground()` and immediately returned `Promise.resolve()`. In the background regen path in `app-rsc-entry.ts`:

\`\`\`js
await Promise.all([
  __isrSet(htmlKey, ...),  // resolves immediately — KV put not done
  __isrSet(rscKey, ...),
]);
// renderFn() resolves here, before KV write completes
\`\`\`

`ctx.waitUntil(renderFn())` expired as soon as `renderFn()` resolved. The Cloudflare Workers runtime tore down the isolate while the `kv.put()` network operation was still in flight, silently killing the write. The entry stayed STALE forever.

The MISS path was not affected — it tees the HTML stream and builds an explicit `__cachePromise` that fully awaits the write before `ctx.waitUntil` can expire.

## Fix

Replace the fire-and-forget `_putInBackground()` with `_put()` which returns the actual `kv.put()` promise. `set()` now returns that promise instead of `Promise.resolve()`.

\`\`\`ts
// Before
this._putInBackground(kvKey, json, opts);
return Promise.resolve();  // resolves before KV write

// After
return this._put(kvKey, json, opts);  // resolves when KV write completes
\`\`\`

`_put()` also registers with `ctx.waitUntil()` as belt-and-suspenders (same as before), so the Workers runtime keeps the isolate alive even if a caller doesn't `await` the returned promise.

The full regen chain is now properly awaited end-to-end:
`ctx.waitUntil(renderFn())` → `await Promise.all([__isrSet(...)])` → `await handler.set(...)` → `return this._put(...)` → `return kv.put(...)`

## Tests

Adds three regression tests in `tests/kv-cache-handler.test.ts` under **"STALE → regen → HIT lifecycle"**:

1. `set()` resolves only after the KV put completes
2. `set()` returned promise is the actual `kv.put` promise, not an immediately-resolved stub (uses a latch-controlled mock to prove this)
3. Background regen `waitUntil` covers the actual KV write with a delayed put — regen promise does not settle until the write completes