### PR TITLE
fix(isr): use getRequestExecutionContext() from ALS in background regeneration

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -258,7 +258,7 @@ ${effectiveMetaRoutes.length > 0 ? `import { sitemapToXml, robotsToText, manifes
 import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, matchHeaders, isExternalUrl, proxyExternalRequest, sanitizeDestination } from ${JSON.stringify(configMatchersPath)};
 import { validateCsrfOrigin, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash, processMiddlewareHeaders } from ${JSON.stringify(requestPipelinePath)};
 import { _consumeRequestScopedCacheLife, _runWithCacheState, getCacheHandler } from "next/cache";
-import { runWithExecutionContext as _runWithExecutionContext } from ${JSON.stringify(requestContextShimPath)};
+import { runWithExecutionContext as _runWithExecutionContext, getRequestExecutionContext as _getRequestExecutionContext } from ${JSON.stringify(requestContextShimPath)};
 import { runWithFetchCache } from "vinext/fetch-cache";
 import { runWithPrivateCache as _runWithPrivateCache } from "vinext/cache-runtime";
 // Import server-only state module to register ALS-backed accessors.
@@ -322,12 +322,13 @@ async function __isrSet(key, data, revalidateSeconds) {
 // headers — but that case is already prevented by the dynamic-usage opt-out.
 // TODO: capture render-time response headers for full Next.js parity.
 const __pendingRegenerations = new Map();
-function __triggerBackgroundRegeneration(key, renderFn, ctx) {
+function __triggerBackgroundRegeneration(key, renderFn) {
   if (__pendingRegenerations.has(key)) return;
   const promise = renderFn()
     .catch((err) => console.error("[vinext] ISR regen failed for " + key + ":", err))
     .finally(() => __pendingRegenerations.delete(key));
   __pendingRegenerations.set(key, promise);
+  const ctx = _getRequestExecutionContext();
   if (ctx && typeof ctx.waitUntil === "function") ctx.waitUntil(promise);
 }
 // HTML and RSC are stored under separate keys — matching Next.js's file-system
@@ -2226,7 +2227,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx, ctx) {
             __isrSet(__isrRscKey(cleanPathname), { kind: "APP_PAGE", html: "", rscData: __revalResult.rscData, headers: undefined, postponed: undefined, status: 200 }, __revalSecs),
           ]);
           __isrDebug?.("regen complete", cleanPathname);
-        }, ctx);
+        });
         if (isRscRequest && __staleValue.rscData) {
           __isrDebug?.("STALE (RSC)", cleanPathname);
           setHeadersContext(null);

--- a/packages/vinext/src/server/isr-cache.ts
+++ b/packages/vinext/src/server/isr-cache.ts
@@ -21,6 +21,7 @@ import {
   type CachedAppPageValue,
 } from "../shims/cache.js";
 import { fnv1a64 } from "../utils/hash.js";
+import { getRequestExecutionContext } from "../shims/request-context.js";
 
 /**
  * Minimal ExecutionContext interface for Cloudflare Workers.
@@ -106,7 +107,8 @@ export function triggerBackgroundRegeneration(
   // Register with the Workers ExecutionContext so the runtime keeps the
   // isolate alive until the regeneration completes, even after the Response
   // has already been sent to the client.
-  ctx?.waitUntil(promise);
+  const execCtx = ctx ?? getRequestExecutionContext();
+  execCtx?.waitUntil(promise);
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -355,7 +355,7 @@ import { MetadataHead, mergeMetadata, resolveModuleMetadata, ViewportHead, merge
 import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, matchHeaders, isExternalUrl, proxyExternalRequest, sanitizeDestination } from "<ROOT>/packages/vinext/src/config/config-matchers.js";
 import { validateCsrfOrigin, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash, processMiddlewareHeaders } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
 import { _consumeRequestScopedCacheLife, _runWithCacheState, getCacheHandler } from "next/cache";
-import { runWithExecutionContext as _runWithExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
+import { runWithExecutionContext as _runWithExecutionContext, getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
 import { runWithFetchCache } from "vinext/fetch-cache";
 import { runWithPrivateCache as _runWithPrivateCache } from "vinext/cache-runtime";
 // Import server-only state module to register ALS-backed accessors.
@@ -419,12 +419,13 @@ async function __isrSet(key, data, revalidateSeconds) {
 // headers — but that case is already prevented by the dynamic-usage opt-out.
 // TODO: capture render-time response headers for full Next.js parity.
 const __pendingRegenerations = new Map();
-function __triggerBackgroundRegeneration(key, renderFn, ctx) {
+function __triggerBackgroundRegeneration(key, renderFn) {
   if (__pendingRegenerations.has(key)) return;
   const promise = renderFn()
     .catch((err) => console.error("[vinext] ISR regen failed for " + key + ":", err))
     .finally(() => __pendingRegenerations.delete(key));
   __pendingRegenerations.set(key, promise);
+  const ctx = _getRequestExecutionContext();
   if (ctx && typeof ctx.waitUntil === "function") ctx.waitUntil(promise);
 }
 // HTML and RSC are stored under separate keys — matching Next.js's file-system
@@ -2379,7 +2380,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx, ctx) {
             __isrSet(__isrRscKey(cleanPathname), { kind: "APP_PAGE", html: "", rscData: __revalResult.rscData, headers: undefined, postponed: undefined, status: 200 }, __revalSecs),
           ]);
           __isrDebug?.("regen complete", cleanPathname);
-        }, ctx);
+        });
         if (isRscRequest && __staleValue.rscData) {
           __isrDebug?.("STALE (RSC)", cleanPathname);
           setHeadersContext(null);
@@ -3066,7 +3067,7 @@ import { MetadataHead, mergeMetadata, resolveModuleMetadata, ViewportHead, merge
 import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, matchHeaders, isExternalUrl, proxyExternalRequest, sanitizeDestination } from "<ROOT>/packages/vinext/src/config/config-matchers.js";
 import { validateCsrfOrigin, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash, processMiddlewareHeaders } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
 import { _consumeRequestScopedCacheLife, _runWithCacheState, getCacheHandler } from "next/cache";
-import { runWithExecutionContext as _runWithExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
+import { runWithExecutionContext as _runWithExecutionContext, getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
 import { runWithFetchCache } from "vinext/fetch-cache";
 import { runWithPrivateCache as _runWithPrivateCache } from "vinext/cache-runtime";
 // Import server-only state module to register ALS-backed accessors.
@@ -3130,12 +3131,13 @@ async function __isrSet(key, data, revalidateSeconds) {
 // headers — but that case is already prevented by the dynamic-usage opt-out.
 // TODO: capture render-time response headers for full Next.js parity.
 const __pendingRegenerations = new Map();
-function __triggerBackgroundRegeneration(key, renderFn, ctx) {
+function __triggerBackgroundRegeneration(key, renderFn) {
   if (__pendingRegenerations.has(key)) return;
   const promise = renderFn()
     .catch((err) => console.error("[vinext] ISR regen failed for " + key + ":", err))
     .finally(() => __pendingRegenerations.delete(key));
   __pendingRegenerations.set(key, promise);
+  const ctx = _getRequestExecutionContext();
   if (ctx && typeof ctx.waitUntil === "function") ctx.waitUntil(promise);
 }
 // HTML and RSC are stored under separate keys — matching Next.js's file-system
@@ -5093,7 +5095,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx, ctx) {
             __isrSet(__isrRscKey(cleanPathname), { kind: "APP_PAGE", html: "", rscData: __revalResult.rscData, headers: undefined, postponed: undefined, status: 200 }, __revalSecs),
           ]);
           __isrDebug?.("regen complete", cleanPathname);
-        }, ctx);
+        });
         if (isRscRequest && __staleValue.rscData) {
           __isrDebug?.("STALE (RSC)", cleanPathname);
           setHeadersContext(null);
@@ -5780,7 +5782,7 @@ import { MetadataHead, mergeMetadata, resolveModuleMetadata, ViewportHead, merge
 import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, matchHeaders, isExternalUrl, proxyExternalRequest, sanitizeDestination } from "<ROOT>/packages/vinext/src/config/config-matchers.js";
 import { validateCsrfOrigin, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash, processMiddlewareHeaders } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
 import { _consumeRequestScopedCacheLife, _runWithCacheState, getCacheHandler } from "next/cache";
-import { runWithExecutionContext as _runWithExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
+import { runWithExecutionContext as _runWithExecutionContext, getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
 import { runWithFetchCache } from "vinext/fetch-cache";
 import { runWithPrivateCache as _runWithPrivateCache } from "vinext/cache-runtime";
 // Import server-only state module to register ALS-backed accessors.
@@ -5844,12 +5846,13 @@ async function __isrSet(key, data, revalidateSeconds) {
 // headers — but that case is already prevented by the dynamic-usage opt-out.
 // TODO: capture render-time response headers for full Next.js parity.
 const __pendingRegenerations = new Map();
-function __triggerBackgroundRegeneration(key, renderFn, ctx) {
+function __triggerBackgroundRegeneration(key, renderFn) {
   if (__pendingRegenerations.has(key)) return;
   const promise = renderFn()
     .catch((err) => console.error("[vinext] ISR regen failed for " + key + ":", err))
     .finally(() => __pendingRegenerations.delete(key));
   __pendingRegenerations.set(key, promise);
+  const ctx = _getRequestExecutionContext();
   if (ctx && typeof ctx.waitUntil === "function") ctx.waitUntil(promise);
 }
 // HTML and RSC are stored under separate keys — matching Next.js's file-system
@@ -7834,7 +7837,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx, ctx) {
             __isrSet(__isrRscKey(cleanPathname), { kind: "APP_PAGE", html: "", rscData: __revalResult.rscData, headers: undefined, postponed: undefined, status: 200 }, __revalSecs),
           ]);
           __isrDebug?.("regen complete", cleanPathname);
-        }, ctx);
+        });
         if (isRscRequest && __staleValue.rscData) {
           __isrDebug?.("STALE (RSC)", cleanPathname);
           setHeadersContext(null);
@@ -8529,7 +8532,7 @@ import * as _instrumentation from "/tmp/test/instrumentation.ts";
 import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, matchHeaders, isExternalUrl, proxyExternalRequest, sanitizeDestination } from "<ROOT>/packages/vinext/src/config/config-matchers.js";
 import { validateCsrfOrigin, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash, processMiddlewareHeaders } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
 import { _consumeRequestScopedCacheLife, _runWithCacheState, getCacheHandler } from "next/cache";
-import { runWithExecutionContext as _runWithExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
+import { runWithExecutionContext as _runWithExecutionContext, getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
 import { runWithFetchCache } from "vinext/fetch-cache";
 import { runWithPrivateCache as _runWithPrivateCache } from "vinext/cache-runtime";
 // Import server-only state module to register ALS-backed accessors.
@@ -8593,12 +8596,13 @@ async function __isrSet(key, data, revalidateSeconds) {
 // headers — but that case is already prevented by the dynamic-usage opt-out.
 // TODO: capture render-time response headers for full Next.js parity.
 const __pendingRegenerations = new Map();
-function __triggerBackgroundRegeneration(key, renderFn, ctx) {
+function __triggerBackgroundRegeneration(key, renderFn) {
   if (__pendingRegenerations.has(key)) return;
   const promise = renderFn()
     .catch((err) => console.error("[vinext] ISR regen failed for " + key + ":", err))
     .finally(() => __pendingRegenerations.delete(key));
   __pendingRegenerations.set(key, promise);
+  const ctx = _getRequestExecutionContext();
   if (ctx && typeof ctx.waitUntil === "function") ctx.waitUntil(promise);
 }
 // HTML and RSC are stored under separate keys — matching Next.js's file-system
@@ -10585,7 +10589,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx, ctx) {
             __isrSet(__isrRscKey(cleanPathname), { kind: "APP_PAGE", html: "", rscData: __revalResult.rscData, headers: undefined, postponed: undefined, status: 200 }, __revalSecs),
           ]);
           __isrDebug?.("regen complete", cleanPathname);
-        }, ctx);
+        });
         if (isRscRequest && __staleValue.rscData) {
           __isrDebug?.("STALE (RSC)", cleanPathname);
           setHeadersContext(null);
@@ -11272,7 +11276,7 @@ import { sitemapToXml, robotsToText, manifestToJson } from "<ROOT>/packages/vine
 import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, matchHeaders, isExternalUrl, proxyExternalRequest, sanitizeDestination } from "<ROOT>/packages/vinext/src/config/config-matchers.js";
 import { validateCsrfOrigin, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash, processMiddlewareHeaders } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
 import { _consumeRequestScopedCacheLife, _runWithCacheState, getCacheHandler } from "next/cache";
-import { runWithExecutionContext as _runWithExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
+import { runWithExecutionContext as _runWithExecutionContext, getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
 import { runWithFetchCache } from "vinext/fetch-cache";
 import { runWithPrivateCache as _runWithPrivateCache } from "vinext/cache-runtime";
 // Import server-only state module to register ALS-backed accessors.
@@ -11336,12 +11340,13 @@ async function __isrSet(key, data, revalidateSeconds) {
 // headers — but that case is already prevented by the dynamic-usage opt-out.
 // TODO: capture render-time response headers for full Next.js parity.
 const __pendingRegenerations = new Map();
-function __triggerBackgroundRegeneration(key, renderFn, ctx) {
+function __triggerBackgroundRegeneration(key, renderFn) {
   if (__pendingRegenerations.has(key)) return;
   const promise = renderFn()
     .catch((err) => console.error("[vinext] ISR regen failed for " + key + ":", err))
     .finally(() => __pendingRegenerations.delete(key));
   __pendingRegenerations.set(key, promise);
+  const ctx = _getRequestExecutionContext();
   if (ctx && typeof ctx.waitUntil === "function") ctx.waitUntil(promise);
 }
 // HTML and RSC are stored under separate keys — matching Next.js's file-system
@@ -13303,7 +13308,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx, ctx) {
             __isrSet(__isrRscKey(cleanPathname), { kind: "APP_PAGE", html: "", rscData: __revalResult.rscData, headers: undefined, postponed: undefined, status: 200 }, __revalSecs),
           ]);
           __isrDebug?.("regen complete", cleanPathname);
-        }, ctx);
+        });
         if (isRscRequest && __staleValue.rscData) {
           __isrDebug?.("STALE (RSC)", cleanPathname);
           setHeadersContext(null);
@@ -13990,7 +13995,7 @@ import * as middlewareModule from "/tmp/test/middleware.ts";
 import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, matchHeaders, isExternalUrl, proxyExternalRequest, sanitizeDestination } from "<ROOT>/packages/vinext/src/config/config-matchers.js";
 import { validateCsrfOrigin, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash, processMiddlewareHeaders } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
 import { _consumeRequestScopedCacheLife, _runWithCacheState, getCacheHandler } from "next/cache";
-import { runWithExecutionContext as _runWithExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
+import { runWithExecutionContext as _runWithExecutionContext, getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
 import { runWithFetchCache } from "vinext/fetch-cache";
 import { runWithPrivateCache as _runWithPrivateCache } from "vinext/cache-runtime";
 // Import server-only state module to register ALS-backed accessors.
@@ -14054,12 +14059,13 @@ async function __isrSet(key, data, revalidateSeconds) {
 // headers — but that case is already prevented by the dynamic-usage opt-out.
 // TODO: capture render-time response headers for full Next.js parity.
 const __pendingRegenerations = new Map();
-function __triggerBackgroundRegeneration(key, renderFn, ctx) {
+function __triggerBackgroundRegeneration(key, renderFn) {
   if (__pendingRegenerations.has(key)) return;
   const promise = renderFn()
     .catch((err) => console.error("[vinext] ISR regen failed for " + key + ":", err))
     .finally(() => __pendingRegenerations.delete(key));
   __pendingRegenerations.set(key, promise);
+  const ctx = _getRequestExecutionContext();
   if (ctx && typeof ctx.waitUntil === "function") ctx.waitUntil(promise);
 }
 // HTML and RSC are stored under separate keys — matching Next.js's file-system
@@ -16292,7 +16298,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx, ctx) {
             __isrSet(__isrRscKey(cleanPathname), { kind: "APP_PAGE", html: "", rscData: __revalResult.rscData, headers: undefined, postponed: undefined, status: 200 }, __revalSecs),
           ]);
           __isrDebug?.("regen complete", cleanPathname);
-        }, ctx);
+        });
         if (isRscRequest && __staleValue.rscData) {
           __isrDebug?.("STALE (RSC)", cleanPathname);
           setHeadersContext(null);


### PR DESCRIPTION
## Summary

- `__triggerBackgroundRegeneration` in `app-rsc-entry.ts` was receiving `ctx` as a parameter from the outer request handler, but by the time the stale-while-revalidate branch executed, that reference could be stale or absent — causing `waitUntil()` to never be called and the Workers isolate to terminate before the revalidation completed
- Fix: call `getRequestExecutionContext()` (AsyncLocalStorage-backed) inside the function to always retrieve the live `ExecutionContext` for the current request
- Same fallback added to `isr-cache.ts`'s `triggerBackgroundRegeneration` so the dev-server path (which passes no `ctx`) also benefits