### PR TITLE
fix: return empty headers/cookies when called outside request context

### DIFF
--- a/packages/vinext/src/shims/headers.ts
+++ b/packages/vinext/src/shims/headers.ts
@@ -513,12 +513,14 @@ export function headers(): Promise<Headers> & Headers {
 
   const state = _getState();
   if (!state.headersContext) {
-    return _decorateRejectedRequestApiPromise<Headers>(
-      new Error(
-        "headers() can only be called from a Server Component, Route Handler, " +
-          "or Server Action. Make sure you're not calling it from a Client Component.",
-      ),
-    );
+    // Return empty readonly headers instead of rejecting.
+    // Libraries like TRPC call headers() inside React cache() during RSC
+    // module initialization, before runWithHeadersContext sets up the ALS
+    // scope. Rejecting here crashes the process; returning empty headers
+    // lets initialization proceed. The real request headers are available
+    // when the TRPC procedure is actually invoked during rendering.
+    const emptyHeaders = _sealHeaders(new Headers());
+    return _decorateRequestApiPromise(Promise.resolve(emptyHeaders), emptyHeaders);
   }
 
   if (state.headersContext.accessError) {
@@ -543,11 +545,9 @@ export function cookies(): Promise<RequestCookies> & RequestCookies {
 
   const state = _getState();
   if (!state.headersContext) {
-    return _decorateRejectedRequestApiPromise<RequestCookies>(
-      new Error(
-        "cookies() can only be called from a Server Component, Route Handler, or Server Action.",
-      ),
-    );
+    // Return empty readonly cookies instead of rejecting (same rationale as headers()).
+    const emptyCookies = _sealCookies(new RequestCookies(new Map()));
+    return _decorateRequestApiPromise(Promise.resolve(emptyCookies), emptyCookies);
   }
 
   if (state.headersContext.accessError) {


### PR DESCRIPTION
## Problem

When `headers()` or `cookies()` is called outside of a request's AsyncLocalStorage scope, the current code returns a rejected Promise. This crashes the process because:

1. Libraries like [TRPC](https://trpc.io/) call `headers()` inside `React.cache()` wrappers at **module initialization time** — before `runWithHeadersContext()` sets up the ALS scope
2. The rejected Promise propagates as an unhandled rejection
3. The process crashes before any request is served

### Stack trace

```
Error: headers() can only be called from a Server Component, Route Handler,
or Server Action. Make sure you're not calling it from a Client Component.
```

This happens during RSC module evaluation, not from a Client Component.

## Solution

Return empty readonly `Headers` / `RequestCookies` objects instead of rejecting when `state.headersContext` is null.

This matches Next.js behavior — their `headers()` and `cookies()` gracefully degrade when called outside request context. The real request headers become available when the component or procedure is actually invoked during rendering within the proper ALS scope.

## Changes

**`packages/vinext/src/shims/headers.ts`**

- `headers()`: Return `_sealHeaders(new Headers())` wrapped in `_decorateRequestApiPromise` instead of `_decorateRejectedRequestApiPromise`
- `cookies()`: Return `_sealCookies(new RequestCookies(new Map()))` wrapped in `_decorateRequestApiPromise` instead of `_decorateRejectedRequestApiPromise`

Both return readonly wrappers (sealed via Proxy) so mutation attempts still throw.

## Reproduction

```typescript
// In a TRPC router (RSC module scope):
import { headers } from "next/headers";

const getHeaders = React.cache(() => headers());

// This runs at module evaluation time, before any request context exists.
// Current: unhandled rejection → crash
// Fixed: returns empty Headers, real headers available at call time
```

## Risk

Low. The empty objects are readonly (mutations throw), and the fix only affects the edge case where there is no ALS store. Normal request-scoped calls are unaffected — the code path for `state.headersContext !== null` is unchanged.