### PR TITLE
fix: add client optimizeDeps entries

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -1305,6 +1305,10 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
               consumer: "client",
               optimizeDeps: {
                 exclude: ["vinext"],
+                // Crawl app/ source files up front so client-only deps imported
+                // by user components are discovered during startup instead of
+                // triggering a late re-optimisation + full page reload.
+                entries: appEntries,
                 // React packages aren't crawled from app/ source files,
                 // so must be pre-included to avoid late discovery (#25).
                 include: [

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -1068,24 +1068,29 @@ describe("App Router integration", () => {
     expect(html).not.toContain("Enter a search term");
   });
 
-  it("sets optimizeDeps.entries for rsc and ssr environments so deps are discovered at startup", () => {
+  it("sets optimizeDeps.entries for rsc, ssr, and client environments so deps are discovered at startup", () => {
     // Without optimizeDeps.entries, Vite only crawls build.rollupOptions.input
     // for dependency discovery — but those are virtual modules that don't
     // import user dependencies. This causes lazy discovery, re-optimisation
     // cascades, and "Invalid hook call" errors on first load.
     const rscEntries = server.config.environments.rsc?.optimizeDeps?.entries;
     const ssrEntries = server.config.environments.ssr?.optimizeDeps?.entries;
+    const clientEntries = server.config.environments.client?.optimizeDeps?.entries;
 
     expect(rscEntries).toBeDefined();
     expect(ssrEntries).toBeDefined();
+    expect(clientEntries).toBeDefined();
     expect(Array.isArray(rscEntries)).toBe(true);
     expect(Array.isArray(ssrEntries)).toBe(true);
+    expect(Array.isArray(clientEntries)).toBe(true);
 
     // Entries should include a glob pattern that covers app/ source files
     const rscGlob = (rscEntries as string[]).join(",");
     const ssrGlob = (ssrEntries as string[]).join(",");
+    const clientGlob = (clientEntries as string[]).join(",");
     expect(rscGlob).toMatch(/app\/\*\*\/\*\.\{tsx,ts,jsx,js\}/);
     expect(ssrGlob).toMatch(/app\/\*\*\/\*\.\{tsx,ts,jsx,js\}/);
+    expect(clientGlob).toMatch(/app\/\*\*\/\*\.\{tsx,ts,jsx,js\}/);
   });
 
   it("pre-includes framework dependencies in optimizeDeps.include to avoid late discovery", () => {


### PR DESCRIPTION
To avoid something like this

```
10:57:41 PM [vite] (client) ✨ new dependencies optimized: next/navigation
10:57:41 PM [vite] (client) ✨ optimized dependencies changed. reloading
10:57:42 PM [vite] (client) ✨ new dependencies optimized: @amplitude/analytics-browser, @amplitude/plugin-session-replay-browser, @base-ui/react/button, @base-ui/react/tooltip, @floating-ui/react, @headlessui/react, @heroicons/react/20/solid, @heroicons/react/24/outline, @orpc/client, @orpc/contract, @orpc/openapi-client/fetch, @orpc/tanstack-query, @remixicon/react, @sentry/react, @t3-oss/env-nextjs, @tanstack/react-devtools, @tanstack/react-form-devtools, @tanstack/react-query-devtools, @tanstack/react-query, agentation, ahooks, class-variance-authority, clsx, es-toolkit/function, es-toolkit/string, foxact/use-clipboard, i18next-resources-to-backend, i18next, jotai/react, js-cookie, ky, next-themes, next/dynamic, next/link, next/script, react-i18next, string-ts, tailwind-merge, use-context-selector, zod, zustand
10:57:42 PM [vite] (client) ✨ optimized dependencies changed. reloading
```