### PR TITLE
fix: bind iterator methods on request headers proxy

### DIFF
--- a/packages/vinext/src/shims/headers.ts
+++ b/packages/vinext/src/shims/headers.ts
@@ -443,16 +443,12 @@ export function headersContextFromRequest(request: Request): HeadersContext {
   let _mutable: Headers | null = null;
 
   const headersProxy = new Proxy(request.headers, {
-    get(target, prop: string | symbol, receiver) {
+    get(target, prop: string | symbol) {
       // Route to the materialised copy if it exists.
       const src = _mutable ?? target;
 
-      if (typeof prop !== "string") {
-        return Reflect.get(src, prop, receiver);
-      }
-
       // Intercept mutating methods: materialise on first write.
-      if (_HEADERS_MUTATING_METHODS.has(prop)) {
+      if (typeof prop === "string" && _HEADERS_MUTATING_METHODS.has(prop)) {
         return (...args: unknown[]) => {
           if (!_mutable) {
             _mutable = new Headers(target);

--- a/tests/fixtures/app-basic/app/nextjs-compat/api/headers-iterate/route.ts
+++ b/tests/fixtures/app-basic/app/nextjs-compat/api/headers-iterate/route.ts
@@ -1,0 +1,25 @@
+import { headers } from "next/headers";
+import { NextResponse } from "next/server";
+
+const PREFIX = "x-iterate-";
+
+export async function GET() {
+  const syncHeaders = headers() as Promise<Headers> & Headers;
+  const awaitedHeaders = await headers();
+
+  const syncEntries = Array.from(syncHeaders).filter(([key]) => key.startsWith(PREFIX));
+  const awaitedEntries = Array.from(awaitedHeaders.entries()).filter(([key]) =>
+    key.startsWith(PREFIX),
+  );
+  const keys = Array.from(awaitedHeaders.keys()).filter((key) => key.startsWith(PREFIX));
+  const values = Array.from(awaitedHeaders.values());
+  const object = Object.fromEntries(awaitedEntries);
+
+  return NextResponse.json({
+    syncEntries,
+    awaitedEntries,
+    keys,
+    values,
+    object,
+  });
+}

--- a/tests/nextjs-compat/request-apis.test.ts
+++ b/tests/nextjs-compat/request-apis.test.ts
@@ -8,6 +8,7 @@
  * Covers real App Router request behavior for:
  * - legacy sync access to headers() / cookies()
  * - readonly headers() in both pages and route handlers
+ * - iterator-based headers() access in route handlers
  * - readonly cookies() in Server Component render paths
  * - mutable cookies() in route handlers, including sync access
  */
@@ -95,6 +96,33 @@ describe("Next.js compat: request-apis", () => {
     expect(data).toEqual({
       error: expect.stringContaining("Headers cannot be modified"),
       value: "original-route-header",
+    });
+  });
+
+  it("supports iterator-based headers() access in route handlers", async () => {
+    const res = await fetch(`${baseUrl}/nextjs-compat/api/headers-iterate`, {
+      headers: {
+        "x-iterate-a": "alpha",
+        "x-iterate-b": "beta",
+      },
+    });
+    const data = await res.json();
+
+    expect(data).toEqual({
+      syncEntries: [
+        ["x-iterate-a", "alpha"],
+        ["x-iterate-b", "beta"],
+      ],
+      awaitedEntries: [
+        ["x-iterate-a", "alpha"],
+        ["x-iterate-b", "beta"],
+      ],
+      keys: ["x-iterate-a", "x-iterate-b"],
+      values: expect.arrayContaining(["alpha", "beta"]),
+      object: {
+        "x-iterate-a": "alpha",
+        "x-iterate-b": "beta",
+      },
     });
   });
 

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -510,6 +510,69 @@ describe("next/headers shim", () => {
     expect(req.headers.get("x-foo")).toBe("bar");
   });
 
+  it("headersContextFromRequest preserves iterator-based reads before copy-on-write", async () => {
+    // Ported from Next.js:
+    // packages/next/src/server/web/spec-extension/adapters/headers.test.ts
+    // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/web/spec-extension/adapters/headers.test.ts
+    const { headersContextFromRequest } = await import("../packages/vinext/src/shims/headers.js");
+    const ctx = headersContextFromRequest(
+      new Request("https://example.com", {
+        headers: {
+          "x-iter-a": "alpha",
+          "x-iter-b": "beta",
+        },
+      }),
+    );
+
+    expect(Array.from(ctx.headers)).toEqual([
+      ["x-iter-a", "alpha"],
+      ["x-iter-b", "beta"],
+    ]);
+    expect(Array.from(ctx.headers.entries())).toEqual([
+      ["x-iter-a", "alpha"],
+      ["x-iter-b", "beta"],
+    ]);
+    expect(Array.from(ctx.headers.keys())).toEqual(["x-iter-a", "x-iter-b"]);
+    expect(Array.from(ctx.headers.values())).toEqual(["alpha", "beta"]);
+    expect(Object.fromEntries(ctx.headers)).toEqual({
+      "x-iter-a": "alpha",
+      "x-iter-b": "beta",
+    });
+  });
+
+  it("headers() preserves iterator-based reads for sync and awaited access", async () => {
+    const { headersContextFromRequest, runWithHeadersContext, headers } =
+      await import("../packages/vinext/src/shims/headers.js");
+    const ctx = headersContextFromRequest(
+      new Request("https://example.com", {
+        headers: {
+          "x-iter-a": "alpha",
+          "x-iter-b": "beta",
+        },
+      }),
+    );
+
+    await runWithHeadersContext(ctx, async () => {
+      const syncHeaders = headers();
+      expect(Array.from(syncHeaders)).toEqual([
+        ["x-iter-a", "alpha"],
+        ["x-iter-b", "beta"],
+      ]);
+      expect(Array.from(syncHeaders.keys())).toEqual(["x-iter-a", "x-iter-b"]);
+
+      const awaitedHeaders = await headers();
+      expect(Array.from(awaitedHeaders.entries())).toEqual([
+        ["x-iter-a", "alpha"],
+        ["x-iter-b", "beta"],
+      ]);
+      expect(Array.from(awaitedHeaders.values())).toEqual(["alpha", "beta"]);
+      expect(Object.fromEntries(awaitedHeaders)).toEqual({
+        "x-iter-a": "alpha",
+        "x-iter-b": "beta",
+      });
+    });
+  });
+
   it("headersContextFromRequest defers cookie parsing until first access", async () => {
     // Cookie parsing should be deferred: accessing ctx.cookies triggers parsing,
     // but merely calling headersContextFromRequest must not.


### PR DESCRIPTION
## Summary
- bind non-mutating request header proxy members, including `Symbol.iterator`, to the live `Headers` instance
- add shim regression coverage for iterator-based `headers()` access, ported from the Next.js headers adapter tests
- add a live App Router route handler regression that exercises `Array.from(headers())`, `entries()`, `keys()`, `values()`, and `Object.fromEntries()`

## Testing
- pnpm test tests/shims.test.ts
- pnpm test tests/nextjs-compat/request-apis.test.ts
- pnpm run lint
- pnpm run fmt -- packages/vinext/src/shims/headers.ts tests/shims.test.ts tests/nextjs-compat/request-apis.test.ts tests/fixtures/app-basic/app/nextjs-compat/api/headers-iterate/route.ts

Refs #443