### PR TITLE
fix: add headersSent guard to Pages Router prod error handler

### DIFF
--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -1160,8 +1160,10 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
       );
     } catch (e) {
       console.error("[vinext] Server error:", e);
-      res.writeHead(500);
-      res.end("Internal Server Error");
+      if (!res.headersSent) {
+        res.writeHead(500);
+        res.end("Internal Server Error");
+      }
     }
   });
 


### PR DESCRIPTION
## Summary

- Adds `res.headersSent` guard to the Pages Router production server error handler in `prod-server.ts`
- If SSR begins streaming then throws, `res.writeHead(500)` was called on an already-sent response, causing a silent socket error
- The App Router error handler (line 688) already has this guard — this brings the Pages Router path into parity

## Test plan

- [x] CI passes (format, lint, typecheck, vitest, playwright)
- [x] Verify Pages Router prod server handles mid-stream SSR errors gracefully without socket crash