### PR TITLE
fix: middleware custom response corrupts binary bodies in dev

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -2150,7 +2150,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                     for (const [key, value] of result.response.headers) {
                       res.appendHeader(key, value);
                     }
-                    const body = await result.response.text();
+                    const body = Buffer.from(await result.response.arrayBuffer());
                     res.end(body);
                     return;
                   }

--- a/tests/fixtures/pages-basic/middleware.ts
+++ b/tests/fixtures/pages-basic/middleware.ts
@@ -43,6 +43,30 @@ export function middleware(request: NextRequest) {
     return new Response("Access Denied", { status: 403, statusText: "Blocked by Middleware" });
   }
 
+  // Return a binary response (PNG 1x1 pixel) to test binary body preservation
+  if (url.pathname === "/binary-response") {
+    const pixel = new Uint8Array([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44,
+      0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x02, 0x00, 0x00, 0x00, 0x90,
+      0x77, 0x53, 0xde, 0x00, 0x00, 0x00, 0x0c, 0x49, 0x44, 0x41, 0x54, 0x08, 0xd7, 0x63, 0xf8,
+      0xcf, 0xc0, 0x00, 0x00, 0x00, 0x02, 0x00, 0x01, 0xe2, 0x21, 0xbc, 0x33, 0x00, 0x00, 0x00,
+      0x00, 0x49, 0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
+    ]);
+    return new Response(pixel, {
+      status: 200,
+      headers: { "content-type": "image/png" },
+    });
+  }
+
+  // Return a response with multiple Set-Cookie headers
+  if (url.pathname === "/multi-cookie-response") {
+    const res = new Response("cookies set", { status: 200 });
+    res.headers.append("set-cookie", "a=1; Path=/");
+    res.headers.append("set-cookie", "b=2; Path=/");
+    res.headers.append("set-cookie", "c=3; Path=/");
+    return res;
+  }
+
   // Throw an error to test that middleware errors return 500, not bypass auth
   if (url.pathname === "/middleware-throw") {
     throw new Error("middleware crash");

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -596,6 +596,27 @@ describe("Pages Router integration", () => {
     expect(text).toContain("Access Denied");
   });
 
+  it("middleware custom response preserves binary body", async () => {
+    const res = await fetch(`${baseUrl}/binary-response`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("image/png");
+    const buf = new Uint8Array(await res.arrayBuffer());
+    // PNG magic bytes
+    expect(buf[0]).toBe(0x89);
+    expect(buf[1]).toBe(0x50); // P
+    expect(buf[2]).toBe(0x4e); // N
+    expect(buf[3]).toBe(0x47); // G
+  });
+
+  it("middleware custom response preserves multiple Set-Cookie headers", async () => {
+    const res = await fetch(`${baseUrl}/multi-cookie-response`);
+    expect(res.status).toBe(200);
+    const setCookies = res.headers.getSetCookie();
+    expect(setCookies).toContain("a=1; Path=/");
+    expect(setCookies).toContain("b=2; Path=/");
+    expect(setCookies).toContain("c=3; Path=/");
+  });
+
   it("object-form matcher requires has and missing conditions", async () => {
     const noHeaderRes = await fetch(`${baseUrl}/mw-object-gated`);
     expect(noHeaderRes.status).toBe(200);


### PR DESCRIPTION
## Summary

- The dev server read middleware custom response bodies with `response.text()`, which decodes bytes as UTF-8 — this corrupts any binary response (images, protobuf, etc.)
- The prod server already uses `response.arrayBuffer()` + `Buffer.from()` correctly (`prod-server.ts:961`)
- One-line fix: swap `text()` → `arrayBuffer()` in the dev middleware response path (`index.ts:2153`)

**Note:** The original audit also flagged multi-value `Set-Cookie` loss via `Headers.forEach()` coalescing, but testing confirmed the dev path uses `for...of` + `appendHeader()` which correctly preserves separate `Set-Cookie` entries per the modern Fetch spec. Added a regression test for that too.

## Test plan

- [x] Added middleware fixture route `/binary-response` returning a 1x1 PNG
- [x] Added middleware fixture route `/multi-cookie-response` returning 3 Set-Cookie headers
- [x] Test: `middleware custom response preserves binary body` — verifies PNG magic bytes survive round-trip
- [x] Test: `middleware custom response preserves multiple Set-Cookie headers` — regression test
- [x] Lint, format, typecheck pass locally
- [x] CI passes (format, lint, typecheck, vitest, playwright)