### PR TITLE
fix: register reportRequestError with ctx.waitUntil on Workers

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -535,9 +535,7 @@ function rscOnError(error, requestInfo, errorContext) {
       error instanceof Error ? error : new Error(String(error)),
       requestInfo,
       errorContext,
-    ).catch((reportErr) => {
-      console.error("[vinext] Failed to report render error:", reportErr);
-    });
+    );
   }
 
   // In production, generate a digest hash for non-navigation errors
@@ -1872,9 +1870,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         err instanceof Error ? err : new Error(String(err)),
         { path: cleanPathname, method: request.method, headers: Object.fromEntries(request.headers.entries()) },
         { routerKind: "App Router", routePath: cleanPathname, routeType: "action" },
-      ).catch((reportErr) => {
-        console.error("[vinext] Failed to report server action error:", reportErr);
-      });
+      );
       setHeadersContext(null);
       setNavigationContext(null);
       return new Response(
@@ -2076,9 +2072,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           err instanceof Error ? err : new Error(String(err)),
           { path: cleanPathname, method: request.method, headers: Object.fromEntries(request.headers.entries()) },
           { routerKind: "App Router", routePath: route.pattern, routeType: "route" },
-        ).catch((reportErr) => {
-          console.error("[vinext] Failed to report route handler error:", reportErr);
-        });
+        );
         return attachRouteHandlerMiddlewareContext(new Response(null, { status: 500 }));
       } finally {
         setHeadersAccessPhase(previousHeadersPhase);

--- a/packages/vinext/src/entries/pages-server-entry.ts
+++ b/packages/vinext/src/entries/pages-server-entry.ts
@@ -1056,7 +1056,7 @@ async function _renderPage(request, url, manifest) {
       e instanceof Error ? e : new Error(String(e)),
       { path: url, method: request.method, headers: Object.fromEntries(request.headers.entries()) },
       { routerKind: "Pages Router", routePath: route.pattern, routeType: "render" },
-    ).catch(() => { /* ignore reporting errors */ });
+    );
     return new Response("Internal Server Error", { status: 500 });
   }
           }) // end runWithFetchCache
@@ -1135,7 +1135,7 @@ export async function handleApiRoute(request, url) {
       e instanceof Error ? e : new Error(String(e)),
       { path: url, method: request.method, headers: Object.fromEntries(request.headers.entries()) },
       { routerKind: "Pages Router", routePath: route.pattern, routeType: "route" },
-    ).catch(() => { /* ignore reporting errors */ });
+    );
     return new Response("Internal Server Error", { status: 500 });
   }
 }

--- a/packages/vinext/src/server/api-handler.ts
+++ b/packages/vinext/src/server/api-handler.ts
@@ -257,9 +257,7 @@ export async function handleApiRoute(
         ),
       },
       { routerKind: "Pages Router", routePath: match.route.pattern, routeType: "route" },
-    ).catch(() => {
-      /* ignore reporting errors */
-    });
+    );
     if (!res.headersSent) {
       if ((e as Error).message === "Request body too large") {
         res.statusCode = 413;

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -1005,9 +1005,7 @@ hydrate();
                             routePath: route.pattern,
                             routeType: "render",
                           },
-                        ).catch(() => {
-                          /* ignore reporting errors */
-                        });
+                        );
                         // Try to render custom 500 error page
                         try {
                           await renderErrorPage(

--- a/packages/vinext/src/server/instrumentation.ts
+++ b/packages/vinext/src/server/instrumentation.ts
@@ -38,6 +38,7 @@
 
 import fs from "node:fs";
 import path from "node:path";
+import { getRequestExecutionContext } from "../shims/request-context.js";
 /**
  * Minimal duck-typed interface for the module runner passed to
  * `runInstrumentation`. Only `.import()` is used — this avoids requiring
@@ -157,20 +158,30 @@ export async function runInstrumentation(
  * Reads the handler from globalThis so this function works correctly regardless
  * of which environment it is called from.
  */
-export async function reportRequestError(
+export function reportRequestError(
   error: Error,
   request: { path: string; method: string; headers: Record<string, string> },
   context: OnRequestErrorContext,
 ): Promise<void> {
   const handler = getOnRequestErrorHandler();
-  if (!handler) return;
+  if (!handler) return Promise.resolve();
 
-  try {
-    await handler(error, request, context);
-  } catch (reportErr) {
-    console.error(
-      "[vinext] onRequestError handler threw:",
-      reportErr instanceof Error ? reportErr.message : String(reportErr),
-    );
-  }
+  const promise = (async () => {
+    try {
+      await handler(error, request, context);
+    } catch (reportErr) {
+      console.error(
+        "[vinext] onRequestError handler threw:",
+        reportErr instanceof Error ? reportErr.message : String(reportErr),
+      );
+    }
+  })();
+
+  // On Cloudflare Workers, register with ctx.waitUntil() so the isolate
+  // stays alive until the report completes (e.g. Sentry HTTP request).
+  // On Node.js (dev or vinext start), getRequestExecutionContext() returns
+  // null — fire-and-forget is fine because the process doesn't die.
+  getRequestExecutionContext()?.waitUntil(promise);
+
+  return promise;
 }

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -627,9 +627,7 @@ function rscOnError(error, requestInfo, errorContext) {
       error instanceof Error ? error : new Error(String(error)),
       requestInfo,
       errorContext,
-    ).catch((reportErr) => {
-      console.error("[vinext] Failed to report render error:", reportErr);
-    });
+    );
   }
 
   // In production, generate a digest hash for non-navigation errors
@@ -2045,9 +2043,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         err instanceof Error ? err : new Error(String(err)),
         { path: cleanPathname, method: request.method, headers: Object.fromEntries(request.headers.entries()) },
         { routerKind: "App Router", routePath: cleanPathname, routeType: "action" },
-      ).catch((reportErr) => {
-        console.error("[vinext] Failed to report server action error:", reportErr);
-      });
+      );
       setHeadersContext(null);
       setNavigationContext(null);
       return new Response(
@@ -2249,9 +2245,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           err instanceof Error ? err : new Error(String(err)),
           { path: cleanPathname, method: request.method, headers: Object.fromEntries(request.headers.entries()) },
           { routerKind: "App Router", routePath: route.pattern, routeType: "route" },
-        ).catch((reportErr) => {
-          console.error("[vinext] Failed to report route handler error:", reportErr);
-        });
+        );
         return attachRouteHandlerMiddlewareContext(new Response(null, { status: 500 }));
       } finally {
         setHeadersAccessPhase(previousHeadersPhase);
@@ -3399,9 +3393,7 @@ function rscOnError(error, requestInfo, errorContext) {
       error instanceof Error ? error : new Error(String(error)),
       requestInfo,
       errorContext,
-    ).catch((reportErr) => {
-      console.error("[vinext] Failed to report render error:", reportErr);
-    });
+    );
   }
 
   // In production, generate a digest hash for non-navigation errors
@@ -4820,9 +4812,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         err instanceof Error ? err : new Error(String(err)),
         { path: cleanPathname, method: request.method, headers: Object.fromEntries(request.headers.entries()) },
         { routerKind: "App Router", routePath: cleanPathname, routeType: "action" },
-      ).catch((reportErr) => {
-        console.error("[vinext] Failed to report server action error:", reportErr);
-      });
+      );
       setHeadersContext(null);
       setNavigationContext(null);
       return new Response(
@@ -5024,9 +5014,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           err instanceof Error ? err : new Error(String(err)),
           { path: cleanPathname, method: request.method, headers: Object.fromEntries(request.headers.entries()) },
           { routerKind: "App Router", routePath: route.pattern, routeType: "route" },
-        ).catch((reportErr) => {
-          console.error("[vinext] Failed to report route handler error:", reportErr);
-        });
+        );
         return attachRouteHandlerMiddlewareContext(new Response(null, { status: 500 }));
       } finally {
         setHeadersAccessPhase(previousHeadersPhase);
@@ -6174,9 +6162,7 @@ function rscOnError(error, requestInfo, errorContext) {
       error instanceof Error ? error : new Error(String(error)),
       requestInfo,
       errorContext,
-    ).catch((reportErr) => {
-      console.error("[vinext] Failed to report render error:", reportErr);
-    });
+    );
   }
 
   // In production, generate a digest hash for non-navigation errors
@@ -7622,9 +7608,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         err instanceof Error ? err : new Error(String(err)),
         { path: cleanPathname, method: request.method, headers: Object.fromEntries(request.headers.entries()) },
         { routerKind: "App Router", routePath: cleanPathname, routeType: "action" },
-      ).catch((reportErr) => {
-        console.error("[vinext] Failed to report server action error:", reportErr);
-      });
+      );
       setHeadersContext(null);
       setNavigationContext(null);
       return new Response(
@@ -7826,9 +7810,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           err instanceof Error ? err : new Error(String(err)),
           { path: cleanPathname, method: request.method, headers: Object.fromEntries(request.headers.entries()) },
           { routerKind: "App Router", routePath: route.pattern, routeType: "route" },
-        ).catch((reportErr) => {
-          console.error("[vinext] Failed to report route handler error:", reportErr);
-        });
+        );
         return attachRouteHandlerMiddlewareContext(new Response(null, { status: 500 }));
       } finally {
         setHeadersAccessPhase(previousHeadersPhase);
@@ -8984,9 +8966,7 @@ function rscOnError(error, requestInfo, errorContext) {
       error instanceof Error ? error : new Error(String(error)),
       requestInfo,
       errorContext,
-    ).catch((reportErr) => {
-      console.error("[vinext] Failed to report render error:", reportErr);
-    });
+    );
   }
 
   // In production, generate a digest hash for non-navigation errors
@@ -10434,9 +10414,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         err instanceof Error ? err : new Error(String(err)),
         { path: cleanPathname, method: request.method, headers: Object.fromEntries(request.headers.entries()) },
         { routerKind: "App Router", routePath: cleanPathname, routeType: "action" },
-      ).catch((reportErr) => {
-        console.error("[vinext] Failed to report server action error:", reportErr);
-      });
+      );
       setHeadersContext(null);
       setNavigationContext(null);
       return new Response(
@@ -10638,9 +10616,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           err instanceof Error ? err : new Error(String(err)),
           { path: cleanPathname, method: request.method, headers: Object.fromEntries(request.headers.entries()) },
           { routerKind: "App Router", routePath: route.pattern, routeType: "route" },
-        ).catch((reportErr) => {
-          console.error("[vinext] Failed to report route handler error:", reportErr);
-        });
+        );
         return attachRouteHandlerMiddlewareContext(new Response(null, { status: 500 }));
       } finally {
         setHeadersAccessPhase(previousHeadersPhase);
@@ -11788,9 +11764,7 @@ function rscOnError(error, requestInfo, errorContext) {
       error instanceof Error ? error : new Error(String(error)),
       requestInfo,
       errorContext,
-    ).catch((reportErr) => {
-      console.error("[vinext] Failed to report render error:", reportErr);
-    });
+    );
   }
 
   // In production, generate a digest hash for non-navigation errors
@@ -13213,9 +13187,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         err instanceof Error ? err : new Error(String(err)),
         { path: cleanPathname, method: request.method, headers: Object.fromEntries(request.headers.entries()) },
         { routerKind: "App Router", routePath: cleanPathname, routeType: "action" },
-      ).catch((reportErr) => {
-        console.error("[vinext] Failed to report server action error:", reportErr);
-      });
+      );
       setHeadersContext(null);
       setNavigationContext(null);
       return new Response(
@@ -13417,9 +13389,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           err instanceof Error ? err : new Error(String(err)),
           { path: cleanPathname, method: request.method, headers: Object.fromEntries(request.headers.entries()) },
           { routerKind: "App Router", routePath: route.pattern, routeType: "route" },
-        ).catch((reportErr) => {
-          console.error("[vinext] Failed to report route handler error:", reportErr);
-        });
+        );
         return attachRouteHandlerMiddlewareContext(new Response(null, { status: 500 }));
       } finally {
         setHeadersAccessPhase(previousHeadersPhase);
@@ -14567,9 +14537,7 @@ function rscOnError(error, requestInfo, errorContext) {
       error instanceof Error ? error : new Error(String(error)),
       requestInfo,
       errorContext,
-    ).catch((reportErr) => {
-      console.error("[vinext] Failed to report render error:", reportErr);
-    });
+    );
   }
 
   // In production, generate a digest hash for non-navigation errors
@@ -16263,9 +16231,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         err instanceof Error ? err : new Error(String(err)),
         { path: cleanPathname, method: request.method, headers: Object.fromEntries(request.headers.entries()) },
         { routerKind: "App Router", routePath: cleanPathname, routeType: "action" },
-      ).catch((reportErr) => {
-        console.error("[vinext] Failed to report server action error:", reportErr);
-      });
+      );
       setHeadersContext(null);
       setNavigationContext(null);
       return new Response(
@@ -16467,9 +16433,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           err instanceof Error ? err : new Error(String(err)),
           { path: cleanPathname, method: request.method, headers: Object.fromEntries(request.headers.entries()) },
           { routerKind: "App Router", routePath: route.pattern, routeType: "route" },
-        ).catch((reportErr) => {
-          console.error("[vinext] Failed to report route handler error:", reportErr);
-        });
+        );
         return attachRouteHandlerMiddlewareContext(new Response(null, { status: 500 }));
       } finally {
         setHeadersAccessPhase(previousHeadersPhase);
@@ -18757,7 +18721,7 @@ async function _renderPage(request, url, manifest) {
       e instanceof Error ? e : new Error(String(e)),
       { path: url, method: request.method, headers: Object.fromEntries(request.headers.entries()) },
       { routerKind: "Pages Router", routePath: route.pattern, routeType: "render" },
-    ).catch(() => { /* ignore reporting errors */ });
+    );
     return new Response("Internal Server Error", { status: 500 });
   }
           }) // end runWithFetchCache
@@ -18836,7 +18800,7 @@ export async function handleApiRoute(request, url) {
       e instanceof Error ? e : new Error(String(e)),
       { path: url, method: request.method, headers: Object.fromEntries(request.headers.entries()) },
       { routerKind: "Pages Router", routePath: route.pattern, routeType: "route" },
-    ).catch(() => { /* ignore reporting errors */ });
+    );
     return new Response("Internal Server Error", { status: 500 });
   }
 }

--- a/tests/instrumentation.test.ts
+++ b/tests/instrumentation.test.ts
@@ -123,6 +123,7 @@ describe("runInstrumentation", () => {
 describe("reportRequestError", () => {
   let runInstrumentation: typeof import("../packages/vinext/src/server/instrumentation.js").runInstrumentation;
   let reportRequestError: typeof import("../packages/vinext/src/server/instrumentation.js").reportRequestError;
+  let runWithExecutionContext: typeof import("../packages/vinext/src/shims/request-context.js").runWithExecutionContext;
 
   const sampleRequest = { path: "/test", method: "GET", headers: {} };
   const sampleContext = {
@@ -136,6 +137,8 @@ describe("reportRequestError", () => {
     const mod = await import("../packages/vinext/src/server/instrumentation.js");
     runInstrumentation = mod.runInstrumentation;
     reportRequestError = mod.reportRequestError;
+    const ctxMod = await import("../packages/vinext/src/shims/request-context.js");
+    runWithExecutionContext = ctxMod.runWithExecutionContext;
   });
 
   it("calls the registered handler with correct args", async () => {
@@ -172,5 +175,37 @@ describe("reportRequestError", () => {
       "handler broke",
     );
     consoleSpy.mockRestore();
+  });
+
+  it("registers the report promise with ctx.waitUntil on Workers", async () => {
+    const onRequestError = vi.fn().mockResolvedValue(undefined);
+    const runner = {
+      import: vi.fn().mockResolvedValue({ onRequestError }),
+    };
+    await runInstrumentation(runner, "/fake/instrumentation.ts");
+
+    const waitUntil = vi.fn();
+    const ctx = { waitUntil };
+
+    await runWithExecutionContext(ctx, () =>
+      reportRequestError(new Error("boom"), sampleRequest, sampleContext),
+    );
+
+    expect(waitUntil).toHaveBeenCalledOnce();
+    // The promise passed to waitUntil should resolve (reportRequestError never rejects)
+    await expect(waitUntil.mock.calls[0][0]).resolves.toBeUndefined();
+  });
+
+  it("does not call waitUntil when no execution context is available", async () => {
+    const onRequestError = vi.fn().mockResolvedValue(undefined);
+    const runner = {
+      import: vi.fn().mockResolvedValue({ onRequestError }),
+    };
+    await runInstrumentation(runner, "/fake/instrumentation.ts");
+
+    // Call outside runWithExecutionContext — should not throw
+    await reportRequestError(new Error("boom"), sampleRequest, sampleContext);
+
+    expect(onRequestError).toHaveBeenCalledOnce();
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #492. On Cloudflare Workers, the isolate can terminate after the Response is sent, killing in-flight error reports (e.g. Sentry HTTP requests) that were fire-and-forget.

- `reportRequestError()` now self-registers with `ctx.waitUntil()` via the ALS-backed `getRequestExecutionContext()`, matching the existing pattern used by `KVCacheHandler`, ISR regeneration, and fetch cache revalidation
- On Node.js (dev or `vinext start`), `getRequestExecutionContext()` returns `null` — fire-and-forget remains correct since the process doesn't die
- Since `reportRequestError` never rejects (internal try/catch), the redundant `.catch()` at all 5 call sites across both routers is removed

## Test plan

- [x] New test: `registers the report promise with ctx.waitUntil on Workers` — verifies `waitUntil` is called with the report promise inside `runWithExecutionContext`
- [x] New test: `does not call waitUntil when no execution context is available` — verifies no-op on Node.js
- [x] All 13 instrumentation tests pass
- [x] `pages-router.test.ts` passes (166 tests)
- [x] `entry-templates.test.ts` passes (12 tests)
- [x] `api-handler.test.ts` passes (40 tests)
- [ ] CI: full Vitest + Playwright E2E suite