### PR TITLE
fix: parse :param(constraint) in middleware matchers

### DIFF
--- a/packages/vinext/src/server/middleware-codegen.ts
+++ b/packages/vinext/src/server/middleware-codegen.ts
@@ -202,7 +202,7 @@ function __extractConstraint(str, re) {
   return str.slice(start, i - 1);
 }
 function __compileMwPattern(pattern) {
-  ${v} hasConstraints = /:[\\w-]+\\(/.test(pattern);
+  ${v} hasConstraints = /:[\\w-]+[*+]?\\(/.test(pattern);
   if (!hasConstraints && (pattern.includes("(") || pattern.includes("\\\\"))) {
     return __safeRegExp("^" + pattern + "$");
   }
@@ -210,8 +210,14 @@ function __compileMwPattern(pattern) {
   ${v} tokenRe = /\\/:([\\w-]+)\\*|\\/:([\\w-]+)\\+|:([\\w-]+)|[.]|[^/:.]+|./g;
   ${l} tok;
   while ((tok = tokenRe.exec(pattern)) !== null) {
-    if (tok[1] !== undefined) { regexStr += "(?:/.*)?"; }
-    else if (tok[2] !== undefined) { regexStr += "(?:/.+)"; }
+    if (tok[1] !== undefined) {
+      ${v} c1 = hasConstraints ? __extractConstraint(pattern, tokenRe) : null;
+      regexStr += c1 !== null ? "(?:/(" + c1 + "))?" : "(?:/.*)?";
+    }
+    else if (tok[2] !== undefined) {
+      ${v} c2 = hasConstraints ? __extractConstraint(pattern, tokenRe) : null;
+      regexStr += c2 !== null ? "(?:/(" + c2 + "))" : "(?:/.+)";
+    }
     else if (tok[3] !== undefined) {
       ${v} constraint = hasConstraints ? __extractConstraint(pattern, tokenRe) : null;
       ${v} isOptional = pattern[tokenRe.lastIndex] === "?";

--- a/packages/vinext/src/server/middleware.ts
+++ b/packages/vinext/src/server/middleware.ts
@@ -308,7 +308,8 @@ function extractConstraint(str: string, re: RegExp): string | null {
  */
 function compileMatcherPattern(pattern: string): RegExp | null {
   // Check if pattern uses :param(constraint) syntax (e.g. :id(\d+), :locale(en|es|fr))
-  const hasConstraints = /:[\w-]+\(/.test(pattern);
+  // Also matches :param*(constraint) and :param+(constraint) for catch-all variants.
+  const hasConstraints = /:[\w-]+[*+]?\(/.test(pattern);
 
   // Pure regex patterns: contain parens or escapes that aren't param constraints.
   // E.g. /((?!api|_next|favicon\.ico).*)
@@ -325,10 +326,12 @@ function compileMatcherPattern(pattern: string): RegExp | null {
   while ((tok = tokenRe.exec(pattern)) !== null) {
     if (tok[1] !== undefined) {
       // /:param* → optionally match slash + zero or more segments
-      regexStr += "(?:/.*)?";
+      const constraint = hasConstraints ? extractConstraint(pattern, tokenRe) : null;
+      regexStr += constraint !== null ? `(?:/(${constraint}))?` : "(?:/.*)?";
     } else if (tok[2] !== undefined) {
       // /:param+ → match slash + one or more segments
-      regexStr += "(?:/.+)";
+      const constraint = hasConstraints ? extractConstraint(pattern, tokenRe) : null;
+      regexStr += constraint !== null ? `(?:/(${constraint}))` : "(?:/.+)";
     } else if (tok[3] !== undefined) {
       // :param — check for inline constraint (e.g. :id(\d+)) and optional ? marker
       const constraint = hasConstraints ? extractConstraint(pattern, tokenRe) : null;

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -15311,7 +15311,7 @@ function __extractConstraint(str, re) {
   return str.slice(start, i - 1);
 }
 function __compileMwPattern(pattern) {
-  const hasConstraints = /:[\\w-]+\\(/.test(pattern);
+  const hasConstraints = /:[\\w-]+[*+]?\\(/.test(pattern);
   if (!hasConstraints && (pattern.includes("(") || pattern.includes("\\\\"))) {
     return __safeRegExp("^" + pattern + "$");
   }
@@ -15319,8 +15319,14 @@ function __compileMwPattern(pattern) {
   const tokenRe = /\\/:([\\w-]+)\\*|\\/:([\\w-]+)\\+|:([\\w-]+)|[.]|[^/:.]+|./g;
   let tok;
   while ((tok = tokenRe.exec(pattern)) !== null) {
-    if (tok[1] !== undefined) { regexStr += "(?:/.*)?"; }
-    else if (tok[2] !== undefined) { regexStr += "(?:/.+)"; }
+    if (tok[1] !== undefined) {
+      const c1 = hasConstraints ? __extractConstraint(pattern, tokenRe) : null;
+      regexStr += c1 !== null ? "(?:/(" + c1 + "))?" : "(?:/.*)?";
+    }
+    else if (tok[2] !== undefined) {
+      const c2 = hasConstraints ? __extractConstraint(pattern, tokenRe) : null;
+      regexStr += c2 !== null ? "(?:/(" + c2 + "))" : "(?:/.+)";
+    }
     else if (tok[3] !== undefined) {
       const constraint = hasConstraints ? __extractConstraint(pattern, tokenRe) : null;
       const isOptional = pattern[tokenRe.lastIndex] === "?";
@@ -18969,7 +18975,7 @@ function __extractConstraint(str, re) {
   return str.slice(start, i - 1);
 }
 function __compileMwPattern(pattern) {
-  var hasConstraints = /:[\\w-]+\\(/.test(pattern);
+  var hasConstraints = /:[\\w-]+[*+]?\\(/.test(pattern);
   if (!hasConstraints && (pattern.includes("(") || pattern.includes("\\\\"))) {
     return __safeRegExp("^" + pattern + "$");
   }
@@ -18977,8 +18983,14 @@ function __compileMwPattern(pattern) {
   var tokenRe = /\\/:([\\w-]+)\\*|\\/:([\\w-]+)\\+|:([\\w-]+)|[.]|[^/:.]+|./g;
   var tok;
   while ((tok = tokenRe.exec(pattern)) !== null) {
-    if (tok[1] !== undefined) { regexStr += "(?:/.*)?"; }
-    else if (tok[2] !== undefined) { regexStr += "(?:/.+)"; }
+    if (tok[1] !== undefined) {
+      var c1 = hasConstraints ? __extractConstraint(pattern, tokenRe) : null;
+      regexStr += c1 !== null ? "(?:/(" + c1 + "))?" : "(?:/.*)?";
+    }
+    else if (tok[2] !== undefined) {
+      var c2 = hasConstraints ? __extractConstraint(pattern, tokenRe) : null;
+      regexStr += c2 !== null ? "(?:/(" + c2 + "))" : "(?:/.+)";
+    }
     else if (tok[3] !== undefined) {
       var constraint = hasConstraints ? __extractConstraint(pattern, tokenRe) : null;
       var isOptional = pattern[tokenRe.lastIndex] === "?";

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -2156,6 +2156,7 @@ describe("middleware matcher patterns", () => {
     // Optional locale with ? after constraint
     expect(matchPattern("/about", "/:locale(en|es|fr)?/about")).toBe(true);
     expect(matchPattern("/en/about", "/:locale(en|es|fr)?/about")).toBe(true);
+    expect(matchPattern("/de/about", "/:locale(en|es|fr)?/about")).toBe(false);
   });
 
   it("matchPattern: wildcard (:path*) matches zero or more segments", async () => {
@@ -2164,6 +2165,21 @@ describe("middleware matcher patterns", () => {
     expect(matchPattern("/dashboard/settings", "/dashboard/:path*")).toBe(true);
     expect(matchPattern("/dashboard/settings/profile", "/dashboard/:path*")).toBe(true);
     expect(matchPattern("/other", "/dashboard/:path*")).toBe(false);
+  });
+
+  it("matchPattern: :param*(constraint) and :param+(constraint)", async () => {
+    const { matchPattern } = await import("../packages/vinext/src/server/middleware.js");
+    // /:path*(api|static) — optional segment constrained to api or static
+    expect(matchPattern("/cdn", "/cdn/:path*(api|static)")).toBe(true);
+    expect(matchPattern("/cdn/api", "/cdn/:path*(api|static)")).toBe(true);
+    expect(matchPattern("/cdn/static", "/cdn/:path*(api|static)")).toBe(true);
+    expect(matchPattern("/cdn/other", "/cdn/:path*(api|static)")).toBe(false);
+
+    // /:path+(api|static) — required segment constrained
+    expect(matchPattern("/cdn", "/cdn/:path+(api|static)")).toBe(false);
+    expect(matchPattern("/cdn/api", "/cdn/:path+(api|static)")).toBe(true);
+    expect(matchPattern("/cdn/static", "/cdn/:path+(api|static)")).toBe(true);
+    expect(matchPattern("/cdn/other", "/cdn/:path+(api|static)")).toBe(false);
   });
 
   it("matchPattern: one-or-more (:path+) requires at least one segment", async () => {


### PR DESCRIPTION
## Summary

- Middleware matcher compiler (`compileMatcherPattern`) treated any pattern containing `(` as a raw regex, so `/blog/:id(\d+)` was compiled as the literal regex `^/blog/:id(\d+)$` — matching `/blog/:id123` instead of `/blog/123`
- Ported the constraint-aware `extractConstraint()` approach from `config-matchers.ts`: when `(` follows a `:param` name, extract it as an inline regex constraint and emit a proper capture group
- Patterns without `:param(` syntax (e.g. `/((?!api|_next).*)`) still take the raw regex path
- Also supports `:param(constraint)?` for optional constrained segments (e.g. `/:locale(en|es|fr)?/about` matches both `/about` and `/en/about`)
- Mirrored in `middleware-codegen.ts` to keep runtime and generated code in sync

## Test plan

- [x] Added `matchPattern` tests for `:id(\d+)` constraint (positive and negative)
- [x] Added `matchPattern` tests for `:locale(en|es|fr)` alternation constraint
- [x] Added `matchPattern` tests for `:locale(en|es|fr)?` optional constraint
- [x] Added constraint tests to both `modern` and `es5` codegen paths
- [x] All existing middleware matcher tests pass (68 tests)
- [x] Entry template snapshots updated
- [x] Pages Router and routing tests pass (255 tests)
- [x] Typecheck, lint, format all clean
- [ ] CI: full Vitest suite
- [ ] CI: Playwright E2E