### PR TITLE
fix: intercept routes (..) climb visible route segments, not filesystem dirs

### DIFF
--- a/packages/vinext/src/routing/app-router.ts
+++ b/packages/vinext/src/routing/app-router.ts
@@ -870,11 +870,28 @@ function collectInterceptingPages(
 }
 
 /**
+ * Check whether a path segment is invisible in the URL (route groups, parallel slots, ".").
+ *
+ * Used by computeInterceptTarget, convertSegmentsToRouteParts, and
+ * hasRemainingVisibleSegments — keep this the single source of truth.
+ */
+function isInvisibleSegment(segment: string): boolean {
+  if (segment === ".") return true;
+  if (segment.startsWith("(") && segment.endsWith(")")) return true;
+  if (segment.startsWith("@")) return true;
+  return false;
+}
+
+/**
  * Compute the target URL pattern for an intercepting route.
  *
+ * Interception conventions (..), (..)(..)" climb by *visible route segments*
+ * (not filesystem directories). Route groups like (marketing) and parallel
+ * slots like @modal are invisible and must be skipped when counting levels.
+ *
  * - (.) same level: resolve relative to routeDir
- * - (..) one level up: resolve relative to parent of routeDir
- * - (..)(..)" two levels up: resolve relative to grandparent of routeDir
+ * - (..) one level up: climb 1 visible segment
+ * - (..)(..) two levels up: climb 2 visible segments
  * - (...) root: resolve from appDir
  */
 function computeInterceptTarget(
@@ -885,27 +902,36 @@ function computeInterceptTarget(
   routeDir: string,
   appDir: string,
 ): { pattern: string; params: string[] } | null {
-  // Determine the base directory for target resolution
-  let baseDir: string;
+  // Determine the base segments for target resolution.
+  // We work on route segments (not filesystem paths) so that route groups
+  // and parallel slots are properly skipped when climbing.
+  const routeSegments = path.relative(appDir, routeDir).split(path.sep).filter(Boolean);
+
+  let baseParts: string[];
   switch (convention) {
     case ".":
-      baseDir = routeDir;
+      baseParts = routeSegments;
       break;
     case "..":
-      baseDir = path.dirname(routeDir);
+    case "../..": {
+      const levelsToClimb = convention === ".." ? 1 : 2;
+      let climbed = 0;
+      let cutIndex = routeSegments.length;
+      while (cutIndex > 0 && climbed < levelsToClimb) {
+        cutIndex--;
+        if (!isInvisibleSegment(routeSegments[cutIndex])) {
+          climbed++;
+        }
+      }
+      baseParts = routeSegments.slice(0, cutIndex);
       break;
-    case "../..":
-      baseDir = path.dirname(path.dirname(routeDir));
-      break;
+    }
     case "...":
-      baseDir = appDir;
+      baseParts = [];
       break;
     default:
       return null;
   }
-
-  // Build the target URL segments from baseDir relative to appDir
-  const baseParts = path.relative(appDir, baseDir).split(path.sep).filter(Boolean);
 
   // Add the intercept segment and any nested path segments
   const nestedParts = path.relative(interceptRoot, currentDir).split(path.sep).filter(Boolean);
@@ -936,10 +962,6 @@ function findFile(dir: string, name: string, matcher: ValidFileMatcher): string 
  * Convert filesystem path segments to URL route parts, skipping invisible segments
  * (route groups, @slots, ".") and converting dynamic segment syntax to Express-style
  * patterns (e.g. "[id]" → ":id", "[...slug]" → ":slug+").
- *
- * Note: the invisible-segment filtering logic here is also applied manually in
- * discoverSlotSubRoutes when building the dedup key from urlSegments. If a new
- * invisible segment type is added, both locations need updating.
  */
 function convertSegmentsToRouteParts(
   segments: string[],
@@ -951,13 +973,7 @@ function convertSegmentsToRouteParts(
   for (let i = 0; i < segments.length; i++) {
     const segment = segments[i];
 
-    if (segment === ".") continue;
-
-    // Route groups are transparent in the URL.
-    if (segment.startsWith("(") && segment.endsWith(")")) continue;
-
-    // Parallel slots are also transparent.
-    if (segment.startsWith("@")) continue;
+    if (isInvisibleSegment(segment)) continue;
 
     // Catch-all segments are only valid in terminal URL position.
     const catchAllMatch = segment.match(/^\[\.\.\.([\w-]+)\]$/);
@@ -994,12 +1010,8 @@ function convertSegmentsToRouteParts(
 
 function hasRemainingVisibleSegments(segments: string[], startIndex: number): boolean {
   for (let i = startIndex; i < segments.length; i++) {
-    const segment = segments[i];
-    if (segment.startsWith("(") && segment.endsWith(")")) continue;
-    if (segment.startsWith("@")) continue;
-    return true;
+    if (!isInvisibleSegment(segments[i])) return true;
   }
-
   return false;
 }
 

--- a/tests/routing.test.ts
+++ b/tests/routing.test.ts
@@ -610,6 +610,96 @@ describe("appRouter - route discovery", () => {
     });
   });
 
+  it("(..) climbs visible route segments, not filesystem dirs (route group between segments)", async () => {
+    // Bug: computeInterceptTarget uses path.dirname() which counts filesystem dirs,
+    // but (..) should count visible route segments (skipping route groups).
+    // Structure: app/a/(group)/b/@modal/(..)(..)target/page.tsx
+    // Visible path: /a/b → (..)(..) should climb 2 visible segments → root → /target
+    // Bug produces: /a/target (climbs past "b" and "(group)", lands on "a")
+    await withTempDir("vinext-app-intercept-route-group-climb-", async (tmpDir) => {
+      const appDir = path.join(tmpDir, "app");
+      await mkdir(path.join(appDir, "a", "(group)", "b", "@modal", "(..)(..)target"), {
+        recursive: true,
+      });
+      await writeFile(path.join(appDir, "a", "(group)", "b", "page.tsx"), EMPTY_PAGE);
+      await writeFile(
+        path.join(appDir, "a", "(group)", "b", "@modal", "(..)(..)target", "page.tsx"),
+        EMPTY_PAGE,
+      );
+      // The actual target route
+      await mkdir(path.join(appDir, "target"), { recursive: true });
+      await writeFile(path.join(appDir, "target", "page.tsx"), EMPTY_PAGE);
+
+      invalidateAppRouteCache();
+      const routes = await appRouter(appDir);
+      const bRoute = routes.find((r) => r.pattern === "/a/b");
+      expect(bRoute).toBeDefined();
+
+      const modalSlot = bRoute!.parallelSlots.find((s) => s.name === "modal");
+      expect(modalSlot).toBeDefined();
+      expect(modalSlot!.interceptingRoutes).toHaveLength(1);
+      // (..)(..) should climb 2 visible segments (b → a → root), landing at /target
+      expect(modalSlot!.interceptingRoutes[0].targetPattern).toBe("/target");
+    });
+  });
+
+  it("(..) with single route group between segments resolves correctly", async () => {
+    // Structure: app/shop/(featured)/products/@modal/(..)cart/page.tsx
+    // Visible path: /shop/products → (..) climbs 1 visible segment above products → /shop
+    // Target: /shop/cart
+    await withTempDir("vinext-app-intercept-single-group-climb-", async (tmpDir) => {
+      const appDir = path.join(tmpDir, "app");
+      await mkdir(path.join(appDir, "shop", "(featured)", "products", "@modal", "(..)cart"), {
+        recursive: true,
+      });
+      await writeFile(path.join(appDir, "shop", "(featured)", "products", "page.tsx"), EMPTY_PAGE);
+      await writeFile(
+        path.join(appDir, "shop", "(featured)", "products", "@modal", "(..)cart", "page.tsx"),
+        EMPTY_PAGE,
+      );
+      await mkdir(path.join(appDir, "shop", "cart"), { recursive: true });
+      await writeFile(path.join(appDir, "shop", "cart", "page.tsx"), EMPTY_PAGE);
+
+      invalidateAppRouteCache();
+      const routes = await appRouter(appDir);
+      const productsRoute = routes.find((r) => r.pattern === "/shop/products");
+      expect(productsRoute).toBeDefined();
+
+      const modalSlot = productsRoute!.parallelSlots.find((s) => s.name === "modal");
+      expect(modalSlot).toBeDefined();
+      expect(modalSlot!.interceptingRoutes).toHaveLength(1);
+      expect(modalSlot!.interceptingRoutes[0].targetPattern).toBe("/shop/cart");
+    });
+  });
+
+  it("(..) skips multiple consecutive route groups when climbing", async () => {
+    // Structure: app/a/(g1)/(g2)/b/@modal/(..)(..)target/page.tsx
+    // Visible path: /a/b → (..)(..) climbs 2 visible segments → root → /target
+    await withTempDir("vinext-app-intercept-multi-group-climb-", async (tmpDir) => {
+      const appDir = path.join(tmpDir, "app");
+      await mkdir(path.join(appDir, "a", "(g1)", "(g2)", "b", "@modal", "(..)(..)target"), {
+        recursive: true,
+      });
+      await writeFile(path.join(appDir, "a", "(g1)", "(g2)", "b", "page.tsx"), EMPTY_PAGE);
+      await writeFile(
+        path.join(appDir, "a", "(g1)", "(g2)", "b", "@modal", "(..)(..)target", "page.tsx"),
+        EMPTY_PAGE,
+      );
+      await mkdir(path.join(appDir, "target"), { recursive: true });
+      await writeFile(path.join(appDir, "target", "page.tsx"), EMPTY_PAGE);
+
+      invalidateAppRouteCache();
+      const routes = await appRouter(appDir);
+      const bRoute = routes.find((r) => r.pattern === "/a/b");
+      expect(bRoute).toBeDefined();
+
+      const modalSlot = bRoute!.parallelSlots.find((s) => s.name === "modal");
+      expect(modalSlot).toBeDefined();
+      expect(modalSlot!.interceptingRoutes).toHaveLength(1);
+      expect(modalSlot!.interceptingRoutes[0].targetPattern).toBe("/target");
+    });
+  });
+
   it("rejects sibling intercept targets that differ only by param name", async () => {
     await withTempDir("vinext-app-intercept-dynamic-conflict-", async (tmpDir) => {
       const appDir = path.join(tmpDir, "app");


### PR DESCRIPTION
## Summary

- **Fixed `computeInterceptTarget()`** to climb by visible route segments instead of filesystem directories. Previously it used `path.dirname()` which counted route groups like `(marketing)` as levels, causing `(..)` and `(..)(..)` to resolve to the wrong target when route groups sit between visible segments.
- **Consolidated invisible-segment detection** into a single `isInvisibleSegment()` helper, replacing three duplicated inline checks across `computeInterceptTarget`, `convertSegmentsToRouteParts`, and `hasRemainingVisibleSegments`.

### Example of the bug

```
app/a/(group)/b/@modal/(..)(..)target/page.tsx
```

Visible route path: `/a/b`. `(..)(..)` should climb 2 visible segments → root → intercept `/target`.

**Before:** `path.dirname(path.dirname("app/a/(group)/b"))` = `"app/a"` → produced `/a/target` (wrong — climbed `b` then `(group)`, wasting a level on the invisible route group).

**After:** Walks backward through `["a", "(group)", "b"]`, counting only visible segments (`b` → `a`), correctly resolving to `/target`.

## Test plan

- [x] 3 new test cases covering `(..)` and `(..)(..)` with route groups between segments
- [x] All 90 routing tests pass
- [x] All 247 app-router tests pass
- [ ] CI: Format, Lint, Typecheck, Vitest, Playwright E2E