### PR TITLE
fix: escape XML special characters in sitemap generation

### DIFF
--- a/packages/vinext/src/server/metadata-routes.ts
+++ b/packages/vinext/src/server/metadata-routes.ts
@@ -177,6 +177,16 @@ export const METADATA_FILE_MAP: Record<
 // Serializers
 // -------------------------------------------------------------------
 
+/** Escape the five XML special characters in text content and attribute values. */
+function escapeXml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
 /**
  * Convert a sitemap array to XML string.
  */
@@ -202,18 +212,18 @@ export function sitemapToXml(entries: SitemapEntry[]): string {
 
   for (const entry of entries) {
     content += "<url>\n";
-    content += `<loc>${entry.url}</loc>\n`;
+    content += `<loc>${escapeXml(entry.url)}</loc>\n`;
 
     const languages = entry.alternates?.languages;
     if (languages && Object.keys(languages).length) {
       for (const language in languages) {
-        content += `<xhtml:link rel="alternate" hreflang="${language}" href="${languages[language]}" />\n`;
+        content += `<xhtml:link rel="alternate" hreflang="${escapeXml(language)}" href="${escapeXml(languages[language])}" />\n`;
       }
     }
 
     if (entry.images?.length) {
       for (const image of entry.images) {
-        content += `<image:image>\n<image:loc>${image}</image:loc>\n</image:image>\n`;
+        content += `<image:image>\n<image:loc>${escapeXml(image)}</image:loc>\n</image:image>\n`;
       }
     }
 
@@ -221,14 +231,16 @@ export function sitemapToXml(entries: SitemapEntry[]): string {
       for (const video of entry.videos) {
         const videoFields = [
           "<video:video>",
-          `<video:title>${video.title}</video:title>`,
-          `<video:thumbnail_loc>${video.thumbnail_loc}</video:thumbnail_loc>`,
-          `<video:description>${video.description}</video:description>`,
-          video.content_loc && `<video:content_loc>${video.content_loc}</video:content_loc>`,
-          video.player_loc && `<video:player_loc>${video.player_loc}</video:player_loc>`,
+          `<video:title>${escapeXml(String(video.title))}</video:title>`,
+          `<video:thumbnail_loc>${escapeXml(String(video.thumbnail_loc))}</video:thumbnail_loc>`,
+          `<video:description>${escapeXml(String(video.description))}</video:description>`,
+          video.content_loc &&
+            `<video:content_loc>${escapeXml(String(video.content_loc))}</video:content_loc>`,
+          video.player_loc &&
+            `<video:player_loc>${escapeXml(String(video.player_loc))}</video:player_loc>`,
           video.duration && `<video:duration>${video.duration}</video:duration>`,
           video.view_count && `<video:view_count>${video.view_count}</video:view_count>`,
-          video.tag && `<video:tag>${video.tag}</video:tag>`,
+          video.tag && `<video:tag>${escapeXml(String(video.tag))}</video:tag>`,
           video.rating && `<video:rating>${video.rating}</video:rating>`,
           video.expiration_date &&
             `<video:expiration_date>${video.expiration_date}</video:expiration_date>`,
@@ -240,11 +252,11 @@ export function sitemapToXml(entries: SitemapEntry[]): string {
             `<video:requires_subscription>${video.requires_subscription}</video:requires_subscription>`,
           video.live && `<video:live>${video.live}</video:live>`,
           video.restriction &&
-            `<video:restriction relationship="${video.restriction.relationship}">${video.restriction.content}</video:restriction>`,
+            `<video:restriction relationship="${escapeXml(String(video.restriction.relationship))}">${escapeXml(String(video.restriction.content))}</video:restriction>`,
           video.platform &&
-            `<video:platform relationship="${video.platform.relationship}">${video.platform.content}</video:platform>`,
+            `<video:platform relationship="${escapeXml(String(video.platform.relationship))}">${escapeXml(String(video.platform.content))}</video:platform>`,
           video.uploader &&
-            `<video:uploader${video.uploader.info ? ` info="${video.uploader.info}"` : ""}>${video.uploader.content}</video:uploader>`,
+            `<video:uploader${video.uploader.info ? ` info="${escapeXml(String(video.uploader.info))}"` : ""}>${escapeXml(String(video.uploader.content))}</video:uploader>`,
           "</video:video>\n",
         ].filter(Boolean);
         content += videoFields.join("\n");

--- a/tests/metadata-routes.test.ts
+++ b/tests/metadata-routes.test.ts
@@ -230,7 +230,10 @@ describe("sitemapToXml", () => {
     expect(xml).toContain("<video:tag>launch</video:tag>");
   });
 
-  it("matches Next's raw interpolation for XML-sensitive values", () => {
+  it("escapes XML-sensitive values instead of raw-interpolating them", () => {
+    // Next.js raw-interpolates these values, producing invalid XML.
+    // vinext intentionally diverges to produce well-formed XML that
+    // search engines can actually parse.
     const entries: SitemapEntry[] = [
       {
         url: "https://example.com?a=1&b=2",
@@ -253,13 +256,12 @@ describe("sitemapToXml", () => {
       },
     ];
     const xml = sitemapToXml(entries);
-    expectSitemapToMatchNext(entries);
-    expect(xml).toContain("<loc>https://example.com?a=1&b=2</loc>");
-    expect(xml).toContain('href="https://example.com/fr?a=1&b=2"');
-    expect(xml).toContain('<video:title>Fish & "Chips"</video:title>');
-    expect(xml).toContain("<video:description>Tasty <b>meal</b></video:description>");
+    expect(xml).toContain("<loc>https://example.com?a=1&amp;b=2</loc>");
+    expect(xml).toContain('href="https://example.com/fr?a=1&amp;b=2"');
+    expect(xml).toContain("<video:title>Fish &amp; &quot;Chips&quot;</video:title>");
+    expect(xml).toContain("<video:description>Tasty &lt;b&gt;meal&lt;/b&gt;</video:description>");
     expect(xml).toContain(
-      '<video:uploader info="https://example.com/authors/jane?bio="yes"&x=1">Jane & Co</video:uploader>',
+      '<video:uploader info="https://example.com/authors/jane?bio=&quot;yes&quot;&amp;x=1">Jane &amp; Co</video:uploader>',
     );
   });
 
@@ -392,9 +394,53 @@ describe("sitemapToXml", () => {
     ];
     expectSitemapToMatchNext(entries);
   });
+
+  it("escapes XML special characters in URLs and text content", () => {
+    const entries: SitemapEntry[] = [
+      {
+        url: "https://example.com/search?q=a&b=2",
+        images: ["https://example.com/img?w=100&h=200"],
+        alternates: {
+          languages: {
+            de: "https://example.com/de/search?q=a&b=2",
+          },
+        },
+      },
+    ];
+    const xml = sitemapToXml(entries);
+    // Bare & must be escaped as &amp; in XML
+    expect(xml).toContain("<loc>https://example.com/search?q=a&amp;b=2</loc>");
+    expect(xml).toContain("<image:loc>https://example.com/img?w=100&amp;h=200</image:loc>");
+    expect(xml).toContain('href="https://example.com/de/search?q=a&amp;b=2"');
+    // Must NOT contain bare & followed by a non-amp; entity
+    expect(xml).not.toMatch(/&(?!amp;|lt;|gt;|quot;|apos;)/);
+  });
+
+  it("escapes XML special characters in video fields", () => {
+    const entries: SitemapEntry[] = [
+      {
+        url: "https://example.com",
+        videos: [
+          {
+            title: "Tom & Jerry <2>",
+            thumbnail_loc: "https://example.com/thumb?a=1&b=2",
+            description: 'He said "hello" & <goodbye>',
+          },
+        ],
+      },
+    ];
+    const xml = sitemapToXml(entries);
+    expect(xml).toContain("<video:title>Tom &amp; Jerry &lt;2&gt;</video:title>");
+    expect(xml).toContain(
+      "<video:thumbnail_loc>https://example.com/thumb?a=1&amp;b=2</video:thumbnail_loc>",
+    );
+    expect(xml).toContain(
+      "<video:description>He said &quot;hello&quot; &amp; &lt;goodbye&gt;</video:description>",
+    );
+  });
 });
 
-// ─── robotsToText ───────────────────────────────────────────────────────
+// ─── robotsToText ────────────────────────────────────────────────────────
 
 describe("robotsToText", () => {
   it("generates basic robots.txt", () => {


### PR DESCRIPTION
## Summary

- `sitemapToXml()` interpolated user-supplied values directly into XML without escaping
- URLs with `&` (extremely common with query params like `?q=a&b=2`) produced invalid XML
- Video titles/descriptions with `<`, `>`, `"`, or `&` also broke the XML structure
- Search engines silently reject malformed sitemaps, causing invisible SEO loss

## Fix

Add `escapeXml()` helper that handles all five XML special characters (`&` `<` `>` `"` `'`) and apply it to every user-supplied string value in the sitemap serializer: URLs, alternate hrefs, hreflang values, image locs, video titles/descriptions/tags/URLs, uploader names/info, restriction/platform attributes.

Numeric fields (duration, view_count, rating) and controlled enums (family_friendly, live) are left unescaped since they can't contain XML-special characters.

This intentionally diverges from Next.js's `resolveSitemap()` which also raw-interpolates. The existing parity test "matches Next's raw interpolation for XML-sensitive values" has been updated to assert correct XML escaping instead.

## Test plan

- [x] New test: URLs with `&` produce `&amp;` in `<loc>`, `<image:loc>`, and `href` attributes
- [x] New test: video fields with `&`, `<`, `>`, `"` are properly escaped
- [x] Updated existing XML-sensitive values test to expect correct escaping
- [x] All 54 metadata-routes tests pass
- [x] Sitemap-related shim tests pass
- [ ] CI: full Vitest + Playwright suite