### PR TITLE
chore: exclude benchmarks/nextjs from pnpm workspace to prevent next dep hoisting

### DIFF
--- a/benchmarks/nextjs/next.config.ts
+++ b/benchmarks/nextjs/next.config.ts
@@ -4,14 +4,11 @@ const nextConfig: NextConfig = {
   turbopack: {
     root: process.cwd(),
   },
-  // Disable type checking and linting during builds so benchmark timings
-  // only measure bundler/compilation speed. Vite does not type-check or
-  // lint during build, so this keeps the comparison apples-to-apples.
+  // Disable type checking during builds so benchmark timings only measure
+  // bundler/compilation speed. Vite does not type-check during build, so
+  // this keeps the comparison apples-to-apples.
   typescript: {
     ignoreBuildErrors: true,
-  },
-  eslint: {
-    ignoreDuringBuilds: true,
   },
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,18 +70,6 @@ importers:
         specifier: ^3.2.1
         version: 3.2.4(@types/debug@4.1.12)(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.32.0)
 
-  benchmarks/nextjs:
-    dependencies:
-      next:
-        specifier: 16.1.6
-        version: 16.1.6(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      react:
-        specifier: 19.2.4
-        version: 19.2.4
-      react-dom:
-        specifier: 19.2.4
-        version: 19.2.4(react@19.2.4)
-
   benchmarks/vinext:
     dependencies:
       react:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,4 +3,5 @@ packages:
   - "examples/*"
   - "tests/fixtures/*"
   - "tests/fixtures/ecosystem/*"
-  - "benchmarks/*"
+  - "benchmarks/vinext"
+  - "benchmarks/vinext-rolldown"


### PR DESCRIPTION
## Summary

- Replaces `benchmarks/*` glob in `pnpm-workspace.yaml` with explicit entries for `benchmarks/vinext` and `benchmarks/vinext-rolldown`, leaving `benchmarks/nextjs` outside the workspace
- Removes the `eslint` key from `benchmarks/nextjs/next.config.ts`, which was removed from `NextConfig` in Next.js 16

## Root Cause

The vite v8 bump (#506) added `benchmarks/*` to the pnpm workspace. This caused pnpm to hoist `next` out of `benchmarks/nextjs/node_modules/` into the monorepo root. Turbopack then couldn't resolve `next/package.json` starting from the benchmark project directory, failing with:

```
Error: Next.js inferred your workspace root, but it may not be correct.
    We couldn't find the Next.js package (next/package.json) from the project directory: .../benchmarks/nextjs/app
```

`benchmarks/nextjs` has no dependencies on workspace packages so it doesn't need to be in the workspace. `benchmarks/vinext` and `benchmarks/vinext-rolldown` link to `packages/vinext` via `file:` references and are listed explicitly.