### PR TITLE
chore: add missing __vinext globals to global.d.ts

### DIFF
--- a/packages/vinext/src/global.d.ts
+++ b/packages/vinext/src/global.d.ts
@@ -276,6 +276,13 @@ declare global {
       __VINEXT_DRAFT_SECRET?: string;
 
       /**
+       * Build ID string injected via Vite `define` at production build time.
+       * Matches `next.config.js` → `buildId` (or a generated UUID when unset).
+       * `undefined` in dev mode.
+       */
+      __VINEXT_BUILD_ID?: string;
+
+      /**
        * JSON-encoded array of `RemotePattern` objects from
        * `next.config.js` → `images.remotePatterns`.
        */
@@ -305,6 +312,22 @@ declare global {
        */
       __VINEXT_IMAGE_DANGEROUSLY_ALLOW_SVG?: string;
     }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// node:http augmentations — vinext properties added to IncomingMessage
+// ---------------------------------------------------------------------------
+
+declare module "node:http" {
+  interface IncomingMessage {
+    /**
+     * The HTTP status code set by vinext middleware for Pages Router rewrite
+     * responses (e.g. 307 for a rewrite that should surface as a redirect).
+     * Written in `index.ts` when middleware emits a `rewriteStatus`, read by
+     * the downstream Pages Router handler to decide the final response status.
+     */
+    __vinextRewriteStatus?: number;
   }
 }
 

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -2221,7 +2221,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                   req.url = url;
                 }
                 if (result.rewriteStatus) {
-                  (req as any).__vinextRewriteStatus = result.rewriteStatus;
+                  req.__vinextRewriteStatus = result.rewriteStatus;
                 }
               }
 
@@ -2310,7 +2310,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                 nextConfig?.basePath ?? "",
                 nextConfig?.trailingSlash ?? false,
               );
-              const mwStatus = (req as any).__vinextRewriteStatus as number | undefined;
+              const mwStatus = req.__vinextRewriteStatus;
 
               // Try rendering the resolved URL
               const match = matchRoute(resolvedUrl.split("?")[0], routes);


### PR DESCRIPTION
## Summary

- Adds `process.env.__VINEXT_BUILD_ID` to the `ProcessEnv` interface — it was already injected via Vite `define` at build time and read in 6+ source files, but was missing from the declaration.
- Adds a `declare module "node:http"` augmentation for `IncomingMessage.__vinextRewriteStatus` — previously accessed via `(req as any)` in two places in `index.ts`; both casts are now removed.

## What was already covered

All `__VINEXT_RSC_*`, `__VINEXT_ROOT__`, `__VINEXT_APP__`, locale, manifest, and error-handler globals were already declared in `global.d.ts`. The `__vinext_scrollX` / `__vinext_scrollY` history-state properties don't need a global declaration since `history.state` is typed `any` in the DOM — the existing inline casts at those sites are appropriate.