### PR TITLE
fix: propagate middleware waitUntil to Workers execution context

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -1577,7 +1577,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       const nextRequest = mwRequest instanceof NextRequest ? mwRequest : new NextRequest(mwRequest);
       const mwFetchEvent = new NextFetchEvent({ page: cleanPathname });
       const mwResponse = await middlewareFn(nextRequest, mwFetchEvent);
-      mwFetchEvent.drainWaitUntil();
+      const _mwWaitUntil = mwFetchEvent.drainWaitUntil();
+      const _mwExecCtx = _getRequestExecutionContext();
+      if (_mwExecCtx && typeof _mwExecCtx.waitUntil === "function") { _mwExecCtx.waitUntil(_mwWaitUntil); }
       if (mwResponse) {
         // Check for x-middleware-next (continue)
         if (mwResponse.headers.get("x-middleware-next") === "1") {

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -15987,7 +15987,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       const nextRequest = mwRequest instanceof NextRequest ? mwRequest : new NextRequest(mwRequest);
       const mwFetchEvent = new NextFetchEvent({ page: cleanPathname });
       const mwResponse = await middlewareFn(nextRequest, mwFetchEvent);
-      mwFetchEvent.drainWaitUntil();
+      const _mwWaitUntil = mwFetchEvent.drainWaitUntil();
+      const _mwExecCtx = _getRequestExecutionContext();
+      if (_mwExecCtx && typeof _mwExecCtx.waitUntil === "function") { _mwExecCtx.waitUntil(_mwWaitUntil); }
       if (mwResponse) {
         // Check for x-middleware-next (continue)
         if (mwResponse.headers.get("x-middleware-next") === "1") {

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -2474,6 +2474,24 @@ describe("App Router next.config.js features (generateRscEntry)", () => {
     expect(code).toContain("must export a function named");
   });
 
+  it("propagates middleware waitUntil promises to the Workers execution context", () => {
+    const code = generateRscEntry(
+      "/tmp/test/app",
+      minimalRoutes,
+      "/tmp/middleware.ts",
+      [],
+      null,
+      "",
+      false,
+    );
+    // drainWaitUntil() must be registered with the execution context so
+    // Workers keeps the isolate alive for background promises.
+    expect(code).toContain("_getRequestExecutionContext()");
+    expect(code).toContain("waitUntil");
+    // Must NOT discard the drainWaitUntil() return value
+    expect(code).not.toMatch(/^\s*mwFetchEvent\.drainWaitUntil\(\);$/m);
+  });
+
   it("applies redirects before middleware in the handler", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes, null, [], null, "", false, {
       redirects: [{ source: "/old", destination: "/new", permanent: true }],


### PR DESCRIPTION
## Summary

- The App Router generated entry called `mwFetchEvent.drainWaitUntil()` but discarded the return value, so middleware background promises registered via `event.waitUntil()` were abandoned when the response was sent on Cloudflare Workers
- Register the drained promise with the Workers execution context via `_getRequestExecutionContext()?.waitUntil()`, matching the pattern the Pages Router entry already uses (`pages-server-entry.ts:208`)

## Test plan

- [x] Added test in `app-router.test.ts` verifying the generated code registers `drainWaitUntil()` with the execution context
- [x] Updated `entry-templates.test.ts` snapshot
- [ ] CI: Vitest, Playwright E2E, typecheck, lint, format