### PR TITLE
feat: add ISR caching for App Router route handlers

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -434,6 +434,7 @@ function __isrCacheKey(pathname, suffix) {
 }
 function __isrHtmlKey(pathname) { return __isrCacheKey(pathname, "html"); }
 function __isrRscKey(pathname) { return __isrCacheKey(pathname, "rsc"); }
+function __isrRouteKey(pathname) { return __isrCacheKey(pathname, "route"); }
 // Verbose cache logging — opt in with NEXT_PRIVATE_DEBUG_CACHE=1.
 // Matches the env var Next.js uses for its own cache debug output so operators
 // have a single knob for all cache tracing.
@@ -1988,7 +1989,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   if (route.routeHandler) {
     const handler = route.routeHandler;
     const method = request.method.toUpperCase();
-    const revalidateSeconds = typeof handler.revalidate === "number" && handler.revalidate > 0 ? handler.revalidate : null;
+    const revalidateSeconds = typeof handler.revalidate === "number" && handler.revalidate > 0 && handler.revalidate !== Infinity ? handler.revalidate : null;
     if (typeof handler["default"] === "function" && process.env.NODE_ENV === "development") {
       console.error(
         "[vinext] Detected default export in route handler " + route.pattern + ". Export a named export for each HTTP method instead.",
@@ -2040,11 +2041,88 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       isAutoHead = true;
     }
 
+    // ISR cache read for route handlers (production only).
+    // Only GET/HEAD (auto-HEAD) with finite revalidate > 0 are ISR-eligible.
+    // This runs before handler execution so a cache HIT skips the handler entirely.
+    if (
+      process.env.NODE_ENV === "production" &&
+      revalidateSeconds !== null &&
+      (method === "GET" || isAutoHead) &&
+      typeof handlerFn === "function"
+    ) {
+      const __routeKey = __isrRouteKey(cleanPathname);
+      try {
+        const __cached = await __isrGet(__routeKey);
+        if (__cached && !__cached.isStale && __cached.value.value && __cached.value.value.kind === "APP_ROUTE") {
+          // HIT — return cached response immediately
+          const __cv = __cached.value.value;
+          __isrDebug?.("HIT (route)", cleanPathname);
+          setHeadersContext(null);
+          setNavigationContext(null);
+          const __hitHeaders = Object.assign({}, __cv.headers || {});
+          __hitHeaders["X-Vinext-Cache"] = "HIT";
+          __hitHeaders["Cache-Control"] = "s-maxage=" + revalidateSeconds + ", stale-while-revalidate";
+          if (isAutoHead) {
+            return attachRouteHandlerMiddlewareContext(new Response(null, { status: __cv.status, headers: __hitHeaders }));
+          }
+          return attachRouteHandlerMiddlewareContext(new Response(__cv.body, { status: __cv.status, headers: __hitHeaders }));
+        }
+        if (__cached && __cached.isStale && __cached.value.value && __cached.value.value.kind === "APP_ROUTE") {
+          // STALE — serve stale response, trigger background regeneration
+          const __sv = __cached.value.value;
+          const __revalSecs = revalidateSeconds;
+          const __revalHandlerFn = handlerFn;
+          const __revalParams = params;
+          __triggerBackgroundRegeneration(__routeKey, async function() {
+            const __revalHeadCtx = { headers: new Headers(), cookies: new Map() };
+            const __revalUCtx = _createUnifiedCtx({
+              headersContext: __revalHeadCtx,
+              executionContext: _getRequestExecutionContext(),
+            });
+            await _runWithUnifiedCtx(__revalUCtx, async () => {
+              _ensureFetchPatch();
+              setNavigationContext({ pathname: cleanPathname, searchParams: url.searchParams, params: __revalParams });
+              const __syntheticReq = new Request(request.url, { method: "GET" });
+              const __revalResponse = await __revalHandlerFn(__syntheticReq, { params: __revalParams });
+              const __regenDynamic = consumeDynamicUsage();
+              setNavigationContext(null);
+              if (__regenDynamic) {
+                __isrDebug?.("route regen skipped (dynamic usage)", cleanPathname);
+                return;
+              }
+              const __freshBody = await __revalResponse.arrayBuffer();
+              const __freshHeaders = {};
+              __revalResponse.headers.forEach(function(v, k) {
+                if (k !== "x-vinext-cache") __freshHeaders[k] = v;
+              });
+              const __routeTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
+              await __isrSet(__routeKey, { kind: "APP_ROUTE", body: __freshBody, status: __revalResponse.status, headers: __freshHeaders }, __revalSecs, __routeTags);
+              __isrDebug?.("route regen complete", __routeKey);
+            });
+          });
+          __isrDebug?.("STALE (route)", cleanPathname);
+          setHeadersContext(null);
+          setNavigationContext(null);
+          const __staleHeaders = Object.assign({}, __sv.headers || {});
+          __staleHeaders["X-Vinext-Cache"] = "STALE";
+          __staleHeaders["Cache-Control"] = "s-maxage=0, stale-while-revalidate";
+          if (isAutoHead) {
+            return attachRouteHandlerMiddlewareContext(new Response(null, { status: __sv.status, headers: __staleHeaders }));
+          }
+          return attachRouteHandlerMiddlewareContext(new Response(__sv.body, { status: __sv.status, headers: __staleHeaders }));
+        }
+      } catch (__routeCacheErr) {
+        // Cache read failure — fall through to normal handler execution
+        console.error("[vinext] ISR route cache read error:", __routeCacheErr);
+      }
+    }
+
     if (typeof handlerFn === "function") {
       const previousHeadersPhase = setHeadersAccessPhase("route-handler");
       try {
         const response = await handlerFn(request, { params });
         const dynamicUsedInHandler = consumeDynamicUsage();
+        const handlerSetCacheControl = response.headers.has("cache-control");
 
         // Apply Cache-Control from route segment config (export const revalidate = N).
         // Runtime request APIs like headers() / cookies() make GET handlers dynamic,
@@ -2053,9 +2131,40 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           revalidateSeconds !== null &&
           !dynamicUsedInHandler &&
           (method === "GET" || isAutoHead) &&
-          !response.headers.has("cache-control")
+          !handlerSetCacheControl
         ) {
           response.headers.set("cache-control", "s-maxage=" + revalidateSeconds + ", stale-while-revalidate");
+        }
+
+        // ISR cache write for route handlers (production, MISS).
+        // Store the raw handler response before cookie/middleware transforms
+        // (those are request-specific and shouldn't be cached).
+        if (
+          process.env.NODE_ENV === "production" &&
+          revalidateSeconds !== null &&
+          !dynamicUsedInHandler &&
+          (method === "GET" || isAutoHead) &&
+          !handlerSetCacheControl
+        ) {
+          response.headers.set("X-Vinext-Cache", "MISS");
+          const __routeClone = response.clone();
+          const __routeKey = __isrRouteKey(cleanPathname);
+          const __revalSecs = revalidateSeconds;
+          const __routeTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
+          const __routeWritePromise = (async () => {
+            try {
+              const __buf = await __routeClone.arrayBuffer();
+              const __hdrs = {};
+              __routeClone.headers.forEach(function(v, k) {
+                if (k !== "x-vinext-cache" && k !== "cache-control") __hdrs[k] = v;
+              });
+              await __isrSet(__routeKey, { kind: "APP_ROUTE", body: __buf, status: __routeClone.status, headers: __hdrs }, __revalSecs, __routeTags);
+              __isrDebug?.("route cache written", __routeKey);
+            } catch (__cacheErr) {
+              console.error("[vinext] ISR route cache write error:", __cacheErr);
+            }
+          })();
+          _getRequestExecutionContext()?.waitUntil(__routeWritePromise);
         }
 
         // Collect any Set-Cookie headers from cookies().set()/delete() calls

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -2047,6 +2047,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     if (
       process.env.NODE_ENV === "production" &&
       revalidateSeconds !== null &&
+      handler.dynamic !== "force-dynamic" &&
       (method === "GET" || isAutoHead) &&
       typeof handlerFn === "function"
     ) {
@@ -2093,7 +2094,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
               const __freshBody = await __revalResponse.arrayBuffer();
               const __freshHeaders = {};
               __revalResponse.headers.forEach(function(v, k) {
-                if (k !== "x-vinext-cache") __freshHeaders[k] = v;
+                if (k !== "x-vinext-cache" && k !== "cache-control") __freshHeaders[k] = v;
               });
               const __routeTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
               await __isrSet(__routeKey, { kind: "APP_ROUTE", body: __freshBody, status: __revalResponse.status, headers: __freshHeaders }, __revalSecs, __routeTags);
@@ -2142,6 +2143,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         if (
           process.env.NODE_ENV === "production" &&
           revalidateSeconds !== null &&
+          handler.dynamic !== "force-dynamic" &&
           !dynamicUsedInHandler &&
           (method === "GET" || isAutoHead) &&
           !handlerSetCacheControl

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -2075,6 +2075,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           const __revalHandlerFn = handlerFn;
           const __revalParams = params;
           const __revalUrl = request.url;
+          const __revalSearchParams = new URLSearchParams(url.searchParams);
           __triggerBackgroundRegeneration(__routeKey, async function() {
             const __revalHeadCtx = { headers: new Headers(), cookies: new Map() };
             const __revalUCtx = _createUnifiedCtx({
@@ -2083,7 +2084,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
             });
             await _runWithUnifiedCtx(__revalUCtx, async () => {
               _ensureFetchPatch();
-              setNavigationContext({ pathname: cleanPathname, searchParams: url.searchParams, params: __revalParams });
+              setNavigationContext({ pathname: cleanPathname, searchParams: __revalSearchParams, params: __revalParams });
               const __syntheticReq = new Request(__revalUrl, { method: "GET" });
               const __revalResponse = await __revalHandlerFn(__syntheticReq, { params: __revalParams });
               const __regenDynamic = consumeDynamicUsage();

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -2074,6 +2074,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           const __revalSecs = revalidateSeconds;
           const __revalHandlerFn = handlerFn;
           const __revalParams = params;
+          const __revalUrl = request.url;
           __triggerBackgroundRegeneration(__routeKey, async function() {
             const __revalHeadCtx = { headers: new Headers(), cookies: new Map() };
             const __revalUCtx = _createUnifiedCtx({
@@ -2083,7 +2084,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
             await _runWithUnifiedCtx(__revalUCtx, async () => {
               _ensureFetchPatch();
               setNavigationContext({ pathname: cleanPathname, searchParams: url.searchParams, params: __revalParams });
-              const __syntheticReq = new Request(request.url, { method: "GET" });
+              const __syntheticReq = new Request(__revalUrl, { method: "GET" });
               const __revalResponse = await __revalHandlerFn(__syntheticReq, { params: __revalParams });
               const __regenDynamic = consumeDynamicUsage();
               setNavigationContext(null);

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -2208,6 +2208,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           const __revalSecs = revalidateSeconds;
           const __revalHandlerFn = handlerFn;
           const __revalParams = params;
+          const __revalUrl = request.url;
           __triggerBackgroundRegeneration(__routeKey, async function() {
             const __revalHeadCtx = { headers: new Headers(), cookies: new Map() };
             const __revalUCtx = _createUnifiedCtx({
@@ -2217,7 +2218,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
             await _runWithUnifiedCtx(__revalUCtx, async () => {
               _ensureFetchPatch();
               setNavigationContext({ pathname: cleanPathname, searchParams: url.searchParams, params: __revalParams });
-              const __syntheticReq = new Request(request.url, { method: "GET" });
+              const __syntheticReq = new Request(__revalUrl, { method: "GET" });
               const __revalResponse = await __revalHandlerFn(__syntheticReq, { params: __revalParams });
               const __regenDynamic = consumeDynamicUsage();
               setNavigationContext(null);
@@ -5098,6 +5099,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           const __revalSecs = revalidateSeconds;
           const __revalHandlerFn = handlerFn;
           const __revalParams = params;
+          const __revalUrl = request.url;
           __triggerBackgroundRegeneration(__routeKey, async function() {
             const __revalHeadCtx = { headers: new Headers(), cookies: new Map() };
             const __revalUCtx = _createUnifiedCtx({
@@ -5107,7 +5109,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
             await _runWithUnifiedCtx(__revalUCtx, async () => {
               _ensureFetchPatch();
               setNavigationContext({ pathname: cleanPathname, searchParams: url.searchParams, params: __revalParams });
-              const __syntheticReq = new Request(request.url, { method: "GET" });
+              const __syntheticReq = new Request(__revalUrl, { method: "GET" });
               const __revalResponse = await __revalHandlerFn(__syntheticReq, { params: __revalParams });
               const __regenDynamic = consumeDynamicUsage();
               setNavigationContext(null);
@@ -8015,6 +8017,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           const __revalSecs = revalidateSeconds;
           const __revalHandlerFn = handlerFn;
           const __revalParams = params;
+          const __revalUrl = request.url;
           __triggerBackgroundRegeneration(__routeKey, async function() {
             const __revalHeadCtx = { headers: new Headers(), cookies: new Map() };
             const __revalUCtx = _createUnifiedCtx({
@@ -8024,7 +8027,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
             await _runWithUnifiedCtx(__revalUCtx, async () => {
               _ensureFetchPatch();
               setNavigationContext({ pathname: cleanPathname, searchParams: url.searchParams, params: __revalParams });
-              const __syntheticReq = new Request(request.url, { method: "GET" });
+              const __syntheticReq = new Request(__revalUrl, { method: "GET" });
               const __revalResponse = await __revalHandlerFn(__syntheticReq, { params: __revalParams });
               const __regenDynamic = consumeDynamicUsage();
               setNavigationContext(null);
@@ -10942,6 +10945,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           const __revalSecs = revalidateSeconds;
           const __revalHandlerFn = handlerFn;
           const __revalParams = params;
+          const __revalUrl = request.url;
           __triggerBackgroundRegeneration(__routeKey, async function() {
             const __revalHeadCtx = { headers: new Headers(), cookies: new Map() };
             const __revalUCtx = _createUnifiedCtx({
@@ -10951,7 +10955,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
             await _runWithUnifiedCtx(__revalUCtx, async () => {
               _ensureFetchPatch();
               setNavigationContext({ pathname: cleanPathname, searchParams: url.searchParams, params: __revalParams });
-              const __syntheticReq = new Request(request.url, { method: "GET" });
+              const __syntheticReq = new Request(__revalUrl, { method: "GET" });
               const __revalResponse = await __revalHandlerFn(__syntheticReq, { params: __revalParams });
               const __regenDynamic = consumeDynamicUsage();
               setNavigationContext(null);
@@ -13836,6 +13840,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           const __revalSecs = revalidateSeconds;
           const __revalHandlerFn = handlerFn;
           const __revalParams = params;
+          const __revalUrl = request.url;
           __triggerBackgroundRegeneration(__routeKey, async function() {
             const __revalHeadCtx = { headers: new Headers(), cookies: new Map() };
             const __revalUCtx = _createUnifiedCtx({
@@ -13845,7 +13850,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
             await _runWithUnifiedCtx(__revalUCtx, async () => {
               _ensureFetchPatch();
               setNavigationContext({ pathname: cleanPathname, searchParams: url.searchParams, params: __revalParams });
-              const __syntheticReq = new Request(request.url, { method: "GET" });
+              const __syntheticReq = new Request(__revalUrl, { method: "GET" });
               const __revalResponse = await __revalHandlerFn(__syntheticReq, { params: __revalParams });
               const __regenDynamic = consumeDynamicUsage();
               setNavigationContext(null);
@@ -17040,6 +17045,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           const __revalSecs = revalidateSeconds;
           const __revalHandlerFn = handlerFn;
           const __revalParams = params;
+          const __revalUrl = request.url;
           __triggerBackgroundRegeneration(__routeKey, async function() {
             const __revalHeadCtx = { headers: new Headers(), cookies: new Map() };
             const __revalUCtx = _createUnifiedCtx({
@@ -17049,7 +17055,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
             await _runWithUnifiedCtx(__revalUCtx, async () => {
               _ensureFetchPatch();
               setNavigationContext({ pathname: cleanPathname, searchParams: url.searchParams, params: __revalParams });
-              const __syntheticReq = new Request(request.url, { method: "GET" });
+              const __syntheticReq = new Request(__revalUrl, { method: "GET" });
               const __revalResponse = await __revalHandlerFn(__syntheticReq, { params: __revalParams });
               const __regenDynamic = consumeDynamicUsage();
               setNavigationContext(null);

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -2209,6 +2209,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           const __revalHandlerFn = handlerFn;
           const __revalParams = params;
           const __revalUrl = request.url;
+          const __revalSearchParams = new URLSearchParams(url.searchParams);
           __triggerBackgroundRegeneration(__routeKey, async function() {
             const __revalHeadCtx = { headers: new Headers(), cookies: new Map() };
             const __revalUCtx = _createUnifiedCtx({
@@ -2217,7 +2218,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
             });
             await _runWithUnifiedCtx(__revalUCtx, async () => {
               _ensureFetchPatch();
-              setNavigationContext({ pathname: cleanPathname, searchParams: url.searchParams, params: __revalParams });
+              setNavigationContext({ pathname: cleanPathname, searchParams: __revalSearchParams, params: __revalParams });
               const __syntheticReq = new Request(__revalUrl, { method: "GET" });
               const __revalResponse = await __revalHandlerFn(__syntheticReq, { params: __revalParams });
               const __regenDynamic = consumeDynamicUsage();
@@ -5100,6 +5101,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           const __revalHandlerFn = handlerFn;
           const __revalParams = params;
           const __revalUrl = request.url;
+          const __revalSearchParams = new URLSearchParams(url.searchParams);
           __triggerBackgroundRegeneration(__routeKey, async function() {
             const __revalHeadCtx = { headers: new Headers(), cookies: new Map() };
             const __revalUCtx = _createUnifiedCtx({
@@ -5108,7 +5110,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
             });
             await _runWithUnifiedCtx(__revalUCtx, async () => {
               _ensureFetchPatch();
-              setNavigationContext({ pathname: cleanPathname, searchParams: url.searchParams, params: __revalParams });
+              setNavigationContext({ pathname: cleanPathname, searchParams: __revalSearchParams, params: __revalParams });
               const __syntheticReq = new Request(__revalUrl, { method: "GET" });
               const __revalResponse = await __revalHandlerFn(__syntheticReq, { params: __revalParams });
               const __regenDynamic = consumeDynamicUsage();
@@ -8018,6 +8020,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           const __revalHandlerFn = handlerFn;
           const __revalParams = params;
           const __revalUrl = request.url;
+          const __revalSearchParams = new URLSearchParams(url.searchParams);
           __triggerBackgroundRegeneration(__routeKey, async function() {
             const __revalHeadCtx = { headers: new Headers(), cookies: new Map() };
             const __revalUCtx = _createUnifiedCtx({
@@ -8026,7 +8029,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
             });
             await _runWithUnifiedCtx(__revalUCtx, async () => {
               _ensureFetchPatch();
-              setNavigationContext({ pathname: cleanPathname, searchParams: url.searchParams, params: __revalParams });
+              setNavigationContext({ pathname: cleanPathname, searchParams: __revalSearchParams, params: __revalParams });
               const __syntheticReq = new Request(__revalUrl, { method: "GET" });
               const __revalResponse = await __revalHandlerFn(__syntheticReq, { params: __revalParams });
               const __regenDynamic = consumeDynamicUsage();
@@ -10946,6 +10949,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           const __revalHandlerFn = handlerFn;
           const __revalParams = params;
           const __revalUrl = request.url;
+          const __revalSearchParams = new URLSearchParams(url.searchParams);
           __triggerBackgroundRegeneration(__routeKey, async function() {
             const __revalHeadCtx = { headers: new Headers(), cookies: new Map() };
             const __revalUCtx = _createUnifiedCtx({
@@ -10954,7 +10958,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
             });
             await _runWithUnifiedCtx(__revalUCtx, async () => {
               _ensureFetchPatch();
-              setNavigationContext({ pathname: cleanPathname, searchParams: url.searchParams, params: __revalParams });
+              setNavigationContext({ pathname: cleanPathname, searchParams: __revalSearchParams, params: __revalParams });
               const __syntheticReq = new Request(__revalUrl, { method: "GET" });
               const __revalResponse = await __revalHandlerFn(__syntheticReq, { params: __revalParams });
               const __regenDynamic = consumeDynamicUsage();
@@ -13841,6 +13845,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           const __revalHandlerFn = handlerFn;
           const __revalParams = params;
           const __revalUrl = request.url;
+          const __revalSearchParams = new URLSearchParams(url.searchParams);
           __triggerBackgroundRegeneration(__routeKey, async function() {
             const __revalHeadCtx = { headers: new Headers(), cookies: new Map() };
             const __revalUCtx = _createUnifiedCtx({
@@ -13849,7 +13854,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
             });
             await _runWithUnifiedCtx(__revalUCtx, async () => {
               _ensureFetchPatch();
-              setNavigationContext({ pathname: cleanPathname, searchParams: url.searchParams, params: __revalParams });
+              setNavigationContext({ pathname: cleanPathname, searchParams: __revalSearchParams, params: __revalParams });
               const __syntheticReq = new Request(__revalUrl, { method: "GET" });
               const __revalResponse = await __revalHandlerFn(__syntheticReq, { params: __revalParams });
               const __regenDynamic = consumeDynamicUsage();
@@ -17046,6 +17051,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           const __revalHandlerFn = handlerFn;
           const __revalParams = params;
           const __revalUrl = request.url;
+          const __revalSearchParams = new URLSearchParams(url.searchParams);
           __triggerBackgroundRegeneration(__routeKey, async function() {
             const __revalHeadCtx = { headers: new Headers(), cookies: new Map() };
             const __revalUCtx = _createUnifiedCtx({
@@ -17054,7 +17060,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
             });
             await _runWithUnifiedCtx(__revalUCtx, async () => {
               _ensureFetchPatch();
-              setNavigationContext({ pathname: cleanPathname, searchParams: url.searchParams, params: __revalParams });
+              setNavigationContext({ pathname: cleanPathname, searchParams: __revalSearchParams, params: __revalParams });
               const __syntheticReq = new Request(__revalUrl, { method: "GET" });
               const __revalResponse = await __revalHandlerFn(__syntheticReq, { params: __revalParams });
               const __regenDynamic = consumeDynamicUsage();

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -493,6 +493,7 @@ function __isrCacheKey(pathname, suffix) {
 }
 function __isrHtmlKey(pathname) { return __isrCacheKey(pathname, "html"); }
 function __isrRscKey(pathname) { return __isrCacheKey(pathname, "rsc"); }
+function __isrRouteKey(pathname) { return __isrCacheKey(pathname, "route"); }
 // Verbose cache logging — opt in with NEXT_PRIVATE_DEBUG_CACHE=1.
 // Matches the env var Next.js uses for its own cache debug output so operators
 // have a single knob for all cache tracing.
@@ -2122,7 +2123,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   if (route.routeHandler) {
     const handler = route.routeHandler;
     const method = request.method.toUpperCase();
-    const revalidateSeconds = typeof handler.revalidate === "number" && handler.revalidate > 0 ? handler.revalidate : null;
+    const revalidateSeconds = typeof handler.revalidate === "number" && handler.revalidate > 0 && handler.revalidate !== Infinity ? handler.revalidate : null;
     if (typeof handler["default"] === "function" && process.env.NODE_ENV === "development") {
       console.error(
         "[vinext] Detected default export in route handler " + route.pattern + ". Export a named export for each HTTP method instead.",
@@ -2174,11 +2175,88 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       isAutoHead = true;
     }
 
+    // ISR cache read for route handlers (production only).
+    // Only GET/HEAD (auto-HEAD) with finite revalidate > 0 are ISR-eligible.
+    // This runs before handler execution so a cache HIT skips the handler entirely.
+    if (
+      process.env.NODE_ENV === "production" &&
+      revalidateSeconds !== null &&
+      (method === "GET" || isAutoHead) &&
+      typeof handlerFn === "function"
+    ) {
+      const __routeKey = __isrRouteKey(cleanPathname);
+      try {
+        const __cached = await __isrGet(__routeKey);
+        if (__cached && !__cached.isStale && __cached.value.value && __cached.value.value.kind === "APP_ROUTE") {
+          // HIT — return cached response immediately
+          const __cv = __cached.value.value;
+          __isrDebug?.("HIT (route)", cleanPathname);
+          setHeadersContext(null);
+          setNavigationContext(null);
+          const __hitHeaders = Object.assign({}, __cv.headers || {});
+          __hitHeaders["X-Vinext-Cache"] = "HIT";
+          __hitHeaders["Cache-Control"] = "s-maxage=" + revalidateSeconds + ", stale-while-revalidate";
+          if (isAutoHead) {
+            return attachRouteHandlerMiddlewareContext(new Response(null, { status: __cv.status, headers: __hitHeaders }));
+          }
+          return attachRouteHandlerMiddlewareContext(new Response(__cv.body, { status: __cv.status, headers: __hitHeaders }));
+        }
+        if (__cached && __cached.isStale && __cached.value.value && __cached.value.value.kind === "APP_ROUTE") {
+          // STALE — serve stale response, trigger background regeneration
+          const __sv = __cached.value.value;
+          const __revalSecs = revalidateSeconds;
+          const __revalHandlerFn = handlerFn;
+          const __revalParams = params;
+          __triggerBackgroundRegeneration(__routeKey, async function() {
+            const __revalHeadCtx = { headers: new Headers(), cookies: new Map() };
+            const __revalUCtx = _createUnifiedCtx({
+              headersContext: __revalHeadCtx,
+              executionContext: _getRequestExecutionContext(),
+            });
+            await _runWithUnifiedCtx(__revalUCtx, async () => {
+              _ensureFetchPatch();
+              setNavigationContext({ pathname: cleanPathname, searchParams: url.searchParams, params: __revalParams });
+              const __syntheticReq = new Request(request.url, { method: "GET" });
+              const __revalResponse = await __revalHandlerFn(__syntheticReq, { params: __revalParams });
+              const __regenDynamic = consumeDynamicUsage();
+              setNavigationContext(null);
+              if (__regenDynamic) {
+                __isrDebug?.("route regen skipped (dynamic usage)", cleanPathname);
+                return;
+              }
+              const __freshBody = await __revalResponse.arrayBuffer();
+              const __freshHeaders = {};
+              __revalResponse.headers.forEach(function(v, k) {
+                if (k !== "x-vinext-cache") __freshHeaders[k] = v;
+              });
+              const __routeTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
+              await __isrSet(__routeKey, { kind: "APP_ROUTE", body: __freshBody, status: __revalResponse.status, headers: __freshHeaders }, __revalSecs, __routeTags);
+              __isrDebug?.("route regen complete", __routeKey);
+            });
+          });
+          __isrDebug?.("STALE (route)", cleanPathname);
+          setHeadersContext(null);
+          setNavigationContext(null);
+          const __staleHeaders = Object.assign({}, __sv.headers || {});
+          __staleHeaders["X-Vinext-Cache"] = "STALE";
+          __staleHeaders["Cache-Control"] = "s-maxage=0, stale-while-revalidate";
+          if (isAutoHead) {
+            return attachRouteHandlerMiddlewareContext(new Response(null, { status: __sv.status, headers: __staleHeaders }));
+          }
+          return attachRouteHandlerMiddlewareContext(new Response(__sv.body, { status: __sv.status, headers: __staleHeaders }));
+        }
+      } catch (__routeCacheErr) {
+        // Cache read failure — fall through to normal handler execution
+        console.error("[vinext] ISR route cache read error:", __routeCacheErr);
+      }
+    }
+
     if (typeof handlerFn === "function") {
       const previousHeadersPhase = setHeadersAccessPhase("route-handler");
       try {
         const response = await handlerFn(request, { params });
         const dynamicUsedInHandler = consumeDynamicUsage();
+        const handlerSetCacheControl = response.headers.has("cache-control");
 
         // Apply Cache-Control from route segment config (export const revalidate = N).
         // Runtime request APIs like headers() / cookies() make GET handlers dynamic,
@@ -2187,9 +2265,40 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           revalidateSeconds !== null &&
           !dynamicUsedInHandler &&
           (method === "GET" || isAutoHead) &&
-          !response.headers.has("cache-control")
+          !handlerSetCacheControl
         ) {
           response.headers.set("cache-control", "s-maxage=" + revalidateSeconds + ", stale-while-revalidate");
+        }
+
+        // ISR cache write for route handlers (production, MISS).
+        // Store the raw handler response before cookie/middleware transforms
+        // (those are request-specific and shouldn't be cached).
+        if (
+          process.env.NODE_ENV === "production" &&
+          revalidateSeconds !== null &&
+          !dynamicUsedInHandler &&
+          (method === "GET" || isAutoHead) &&
+          !handlerSetCacheControl
+        ) {
+          response.headers.set("X-Vinext-Cache", "MISS");
+          const __routeClone = response.clone();
+          const __routeKey = __isrRouteKey(cleanPathname);
+          const __revalSecs = revalidateSeconds;
+          const __routeTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
+          const __routeWritePromise = (async () => {
+            try {
+              const __buf = await __routeClone.arrayBuffer();
+              const __hdrs = {};
+              __routeClone.headers.forEach(function(v, k) {
+                if (k !== "x-vinext-cache" && k !== "cache-control") __hdrs[k] = v;
+              });
+              await __isrSet(__routeKey, { kind: "APP_ROUTE", body: __buf, status: __routeClone.status, headers: __hdrs }, __revalSecs, __routeTags);
+              __isrDebug?.("route cache written", __routeKey);
+            } catch (__cacheErr) {
+              console.error("[vinext] ISR route cache write error:", __cacheErr);
+            }
+          })();
+          _getRequestExecutionContext()?.waitUntil(__routeWritePromise);
         }
 
         // Collect any Set-Cookie headers from cookies().set()/delete() calls
@@ -3269,6 +3378,7 @@ function __isrCacheKey(pathname, suffix) {
 }
 function __isrHtmlKey(pathname) { return __isrCacheKey(pathname, "html"); }
 function __isrRscKey(pathname) { return __isrCacheKey(pathname, "rsc"); }
+function __isrRouteKey(pathname) { return __isrCacheKey(pathname, "route"); }
 // Verbose cache logging — opt in with NEXT_PRIVATE_DEBUG_CACHE=1.
 // Matches the env var Next.js uses for its own cache debug output so operators
 // have a single knob for all cache tracing.
@@ -4901,7 +5011,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   if (route.routeHandler) {
     const handler = route.routeHandler;
     const method = request.method.toUpperCase();
-    const revalidateSeconds = typeof handler.revalidate === "number" && handler.revalidate > 0 ? handler.revalidate : null;
+    const revalidateSeconds = typeof handler.revalidate === "number" && handler.revalidate > 0 && handler.revalidate !== Infinity ? handler.revalidate : null;
     if (typeof handler["default"] === "function" && process.env.NODE_ENV === "development") {
       console.error(
         "[vinext] Detected default export in route handler " + route.pattern + ". Export a named export for each HTTP method instead.",
@@ -4953,11 +5063,88 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       isAutoHead = true;
     }
 
+    // ISR cache read for route handlers (production only).
+    // Only GET/HEAD (auto-HEAD) with finite revalidate > 0 are ISR-eligible.
+    // This runs before handler execution so a cache HIT skips the handler entirely.
+    if (
+      process.env.NODE_ENV === "production" &&
+      revalidateSeconds !== null &&
+      (method === "GET" || isAutoHead) &&
+      typeof handlerFn === "function"
+    ) {
+      const __routeKey = __isrRouteKey(cleanPathname);
+      try {
+        const __cached = await __isrGet(__routeKey);
+        if (__cached && !__cached.isStale && __cached.value.value && __cached.value.value.kind === "APP_ROUTE") {
+          // HIT — return cached response immediately
+          const __cv = __cached.value.value;
+          __isrDebug?.("HIT (route)", cleanPathname);
+          setHeadersContext(null);
+          setNavigationContext(null);
+          const __hitHeaders = Object.assign({}, __cv.headers || {});
+          __hitHeaders["X-Vinext-Cache"] = "HIT";
+          __hitHeaders["Cache-Control"] = "s-maxage=" + revalidateSeconds + ", stale-while-revalidate";
+          if (isAutoHead) {
+            return attachRouteHandlerMiddlewareContext(new Response(null, { status: __cv.status, headers: __hitHeaders }));
+          }
+          return attachRouteHandlerMiddlewareContext(new Response(__cv.body, { status: __cv.status, headers: __hitHeaders }));
+        }
+        if (__cached && __cached.isStale && __cached.value.value && __cached.value.value.kind === "APP_ROUTE") {
+          // STALE — serve stale response, trigger background regeneration
+          const __sv = __cached.value.value;
+          const __revalSecs = revalidateSeconds;
+          const __revalHandlerFn = handlerFn;
+          const __revalParams = params;
+          __triggerBackgroundRegeneration(__routeKey, async function() {
+            const __revalHeadCtx = { headers: new Headers(), cookies: new Map() };
+            const __revalUCtx = _createUnifiedCtx({
+              headersContext: __revalHeadCtx,
+              executionContext: _getRequestExecutionContext(),
+            });
+            await _runWithUnifiedCtx(__revalUCtx, async () => {
+              _ensureFetchPatch();
+              setNavigationContext({ pathname: cleanPathname, searchParams: url.searchParams, params: __revalParams });
+              const __syntheticReq = new Request(request.url, { method: "GET" });
+              const __revalResponse = await __revalHandlerFn(__syntheticReq, { params: __revalParams });
+              const __regenDynamic = consumeDynamicUsage();
+              setNavigationContext(null);
+              if (__regenDynamic) {
+                __isrDebug?.("route regen skipped (dynamic usage)", cleanPathname);
+                return;
+              }
+              const __freshBody = await __revalResponse.arrayBuffer();
+              const __freshHeaders = {};
+              __revalResponse.headers.forEach(function(v, k) {
+                if (k !== "x-vinext-cache") __freshHeaders[k] = v;
+              });
+              const __routeTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
+              await __isrSet(__routeKey, { kind: "APP_ROUTE", body: __freshBody, status: __revalResponse.status, headers: __freshHeaders }, __revalSecs, __routeTags);
+              __isrDebug?.("route regen complete", __routeKey);
+            });
+          });
+          __isrDebug?.("STALE (route)", cleanPathname);
+          setHeadersContext(null);
+          setNavigationContext(null);
+          const __staleHeaders = Object.assign({}, __sv.headers || {});
+          __staleHeaders["X-Vinext-Cache"] = "STALE";
+          __staleHeaders["Cache-Control"] = "s-maxage=0, stale-while-revalidate";
+          if (isAutoHead) {
+            return attachRouteHandlerMiddlewareContext(new Response(null, { status: __sv.status, headers: __staleHeaders }));
+          }
+          return attachRouteHandlerMiddlewareContext(new Response(__sv.body, { status: __sv.status, headers: __staleHeaders }));
+        }
+      } catch (__routeCacheErr) {
+        // Cache read failure — fall through to normal handler execution
+        console.error("[vinext] ISR route cache read error:", __routeCacheErr);
+      }
+    }
+
     if (typeof handlerFn === "function") {
       const previousHeadersPhase = setHeadersAccessPhase("route-handler");
       try {
         const response = await handlerFn(request, { params });
         const dynamicUsedInHandler = consumeDynamicUsage();
+        const handlerSetCacheControl = response.headers.has("cache-control");
 
         // Apply Cache-Control from route segment config (export const revalidate = N).
         // Runtime request APIs like headers() / cookies() make GET handlers dynamic,
@@ -4966,9 +5153,40 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           revalidateSeconds !== null &&
           !dynamicUsedInHandler &&
           (method === "GET" || isAutoHead) &&
-          !response.headers.has("cache-control")
+          !handlerSetCacheControl
         ) {
           response.headers.set("cache-control", "s-maxage=" + revalidateSeconds + ", stale-while-revalidate");
+        }
+
+        // ISR cache write for route handlers (production, MISS).
+        // Store the raw handler response before cookie/middleware transforms
+        // (those are request-specific and shouldn't be cached).
+        if (
+          process.env.NODE_ENV === "production" &&
+          revalidateSeconds !== null &&
+          !dynamicUsedInHandler &&
+          (method === "GET" || isAutoHead) &&
+          !handlerSetCacheControl
+        ) {
+          response.headers.set("X-Vinext-Cache", "MISS");
+          const __routeClone = response.clone();
+          const __routeKey = __isrRouteKey(cleanPathname);
+          const __revalSecs = revalidateSeconds;
+          const __routeTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
+          const __routeWritePromise = (async () => {
+            try {
+              const __buf = await __routeClone.arrayBuffer();
+              const __hdrs = {};
+              __routeClone.headers.forEach(function(v, k) {
+                if (k !== "x-vinext-cache" && k !== "cache-control") __hdrs[k] = v;
+              });
+              await __isrSet(__routeKey, { kind: "APP_ROUTE", body: __buf, status: __routeClone.status, headers: __hdrs }, __revalSecs, __routeTags);
+              __isrDebug?.("route cache written", __routeKey);
+            } catch (__cacheErr) {
+              console.error("[vinext] ISR route cache write error:", __cacheErr);
+            }
+          })();
+          _getRequestExecutionContext()?.waitUntil(__routeWritePromise);
         }
 
         // Collect any Set-Cookie headers from cookies().set()/delete() calls
@@ -6048,6 +6266,7 @@ function __isrCacheKey(pathname, suffix) {
 }
 function __isrHtmlKey(pathname) { return __isrCacheKey(pathname, "html"); }
 function __isrRscKey(pathname) { return __isrCacheKey(pathname, "rsc"); }
+function __isrRouteKey(pathname) { return __isrCacheKey(pathname, "route"); }
 // Verbose cache logging — opt in with NEXT_PRIVATE_DEBUG_CACHE=1.
 // Matches the env var Next.js uses for its own cache debug output so operators
 // have a single knob for all cache tracing.
@@ -7707,7 +7926,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   if (route.routeHandler) {
     const handler = route.routeHandler;
     const method = request.method.toUpperCase();
-    const revalidateSeconds = typeof handler.revalidate === "number" && handler.revalidate > 0 ? handler.revalidate : null;
+    const revalidateSeconds = typeof handler.revalidate === "number" && handler.revalidate > 0 && handler.revalidate !== Infinity ? handler.revalidate : null;
     if (typeof handler["default"] === "function" && process.env.NODE_ENV === "development") {
       console.error(
         "[vinext] Detected default export in route handler " + route.pattern + ". Export a named export for each HTTP method instead.",
@@ -7759,11 +7978,88 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       isAutoHead = true;
     }
 
+    // ISR cache read for route handlers (production only).
+    // Only GET/HEAD (auto-HEAD) with finite revalidate > 0 are ISR-eligible.
+    // This runs before handler execution so a cache HIT skips the handler entirely.
+    if (
+      process.env.NODE_ENV === "production" &&
+      revalidateSeconds !== null &&
+      (method === "GET" || isAutoHead) &&
+      typeof handlerFn === "function"
+    ) {
+      const __routeKey = __isrRouteKey(cleanPathname);
+      try {
+        const __cached = await __isrGet(__routeKey);
+        if (__cached && !__cached.isStale && __cached.value.value && __cached.value.value.kind === "APP_ROUTE") {
+          // HIT — return cached response immediately
+          const __cv = __cached.value.value;
+          __isrDebug?.("HIT (route)", cleanPathname);
+          setHeadersContext(null);
+          setNavigationContext(null);
+          const __hitHeaders = Object.assign({}, __cv.headers || {});
+          __hitHeaders["X-Vinext-Cache"] = "HIT";
+          __hitHeaders["Cache-Control"] = "s-maxage=" + revalidateSeconds + ", stale-while-revalidate";
+          if (isAutoHead) {
+            return attachRouteHandlerMiddlewareContext(new Response(null, { status: __cv.status, headers: __hitHeaders }));
+          }
+          return attachRouteHandlerMiddlewareContext(new Response(__cv.body, { status: __cv.status, headers: __hitHeaders }));
+        }
+        if (__cached && __cached.isStale && __cached.value.value && __cached.value.value.kind === "APP_ROUTE") {
+          // STALE — serve stale response, trigger background regeneration
+          const __sv = __cached.value.value;
+          const __revalSecs = revalidateSeconds;
+          const __revalHandlerFn = handlerFn;
+          const __revalParams = params;
+          __triggerBackgroundRegeneration(__routeKey, async function() {
+            const __revalHeadCtx = { headers: new Headers(), cookies: new Map() };
+            const __revalUCtx = _createUnifiedCtx({
+              headersContext: __revalHeadCtx,
+              executionContext: _getRequestExecutionContext(),
+            });
+            await _runWithUnifiedCtx(__revalUCtx, async () => {
+              _ensureFetchPatch();
+              setNavigationContext({ pathname: cleanPathname, searchParams: url.searchParams, params: __revalParams });
+              const __syntheticReq = new Request(request.url, { method: "GET" });
+              const __revalResponse = await __revalHandlerFn(__syntheticReq, { params: __revalParams });
+              const __regenDynamic = consumeDynamicUsage();
+              setNavigationContext(null);
+              if (__regenDynamic) {
+                __isrDebug?.("route regen skipped (dynamic usage)", cleanPathname);
+                return;
+              }
+              const __freshBody = await __revalResponse.arrayBuffer();
+              const __freshHeaders = {};
+              __revalResponse.headers.forEach(function(v, k) {
+                if (k !== "x-vinext-cache") __freshHeaders[k] = v;
+              });
+              const __routeTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
+              await __isrSet(__routeKey, { kind: "APP_ROUTE", body: __freshBody, status: __revalResponse.status, headers: __freshHeaders }, __revalSecs, __routeTags);
+              __isrDebug?.("route regen complete", __routeKey);
+            });
+          });
+          __isrDebug?.("STALE (route)", cleanPathname);
+          setHeadersContext(null);
+          setNavigationContext(null);
+          const __staleHeaders = Object.assign({}, __sv.headers || {});
+          __staleHeaders["X-Vinext-Cache"] = "STALE";
+          __staleHeaders["Cache-Control"] = "s-maxage=0, stale-while-revalidate";
+          if (isAutoHead) {
+            return attachRouteHandlerMiddlewareContext(new Response(null, { status: __sv.status, headers: __staleHeaders }));
+          }
+          return attachRouteHandlerMiddlewareContext(new Response(__sv.body, { status: __sv.status, headers: __staleHeaders }));
+        }
+      } catch (__routeCacheErr) {
+        // Cache read failure — fall through to normal handler execution
+        console.error("[vinext] ISR route cache read error:", __routeCacheErr);
+      }
+    }
+
     if (typeof handlerFn === "function") {
       const previousHeadersPhase = setHeadersAccessPhase("route-handler");
       try {
         const response = await handlerFn(request, { params });
         const dynamicUsedInHandler = consumeDynamicUsage();
+        const handlerSetCacheControl = response.headers.has("cache-control");
 
         // Apply Cache-Control from route segment config (export const revalidate = N).
         // Runtime request APIs like headers() / cookies() make GET handlers dynamic,
@@ -7772,9 +8068,40 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           revalidateSeconds !== null &&
           !dynamicUsedInHandler &&
           (method === "GET" || isAutoHead) &&
-          !response.headers.has("cache-control")
+          !handlerSetCacheControl
         ) {
           response.headers.set("cache-control", "s-maxage=" + revalidateSeconds + ", stale-while-revalidate");
+        }
+
+        // ISR cache write for route handlers (production, MISS).
+        // Store the raw handler response before cookie/middleware transforms
+        // (those are request-specific and shouldn't be cached).
+        if (
+          process.env.NODE_ENV === "production" &&
+          revalidateSeconds !== null &&
+          !dynamicUsedInHandler &&
+          (method === "GET" || isAutoHead) &&
+          !handlerSetCacheControl
+        ) {
+          response.headers.set("X-Vinext-Cache", "MISS");
+          const __routeClone = response.clone();
+          const __routeKey = __isrRouteKey(cleanPathname);
+          const __revalSecs = revalidateSeconds;
+          const __routeTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
+          const __routeWritePromise = (async () => {
+            try {
+              const __buf = await __routeClone.arrayBuffer();
+              const __hdrs = {};
+              __routeClone.headers.forEach(function(v, k) {
+                if (k !== "x-vinext-cache" && k !== "cache-control") __hdrs[k] = v;
+              });
+              await __isrSet(__routeKey, { kind: "APP_ROUTE", body: __buf, status: __routeClone.status, headers: __hdrs }, __revalSecs, __routeTags);
+              __isrDebug?.("route cache written", __routeKey);
+            } catch (__cacheErr) {
+              console.error("[vinext] ISR route cache write error:", __cacheErr);
+            }
+          })();
+          _getRequestExecutionContext()?.waitUntil(__routeWritePromise);
         }
 
         // Collect any Set-Cookie headers from cookies().set()/delete() calls
@@ -8862,6 +9189,7 @@ function __isrCacheKey(pathname, suffix) {
 }
 function __isrHtmlKey(pathname) { return __isrCacheKey(pathname, "html"); }
 function __isrRscKey(pathname) { return __isrCacheKey(pathname, "rsc"); }
+function __isrRouteKey(pathname) { return __isrCacheKey(pathname, "route"); }
 // Verbose cache logging — opt in with NEXT_PRIVATE_DEBUG_CACHE=1.
 // Matches the env var Next.js uses for its own cache debug output so operators
 // have a single knob for all cache tracing.
@@ -10523,7 +10851,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   if (route.routeHandler) {
     const handler = route.routeHandler;
     const method = request.method.toUpperCase();
-    const revalidateSeconds = typeof handler.revalidate === "number" && handler.revalidate > 0 ? handler.revalidate : null;
+    const revalidateSeconds = typeof handler.revalidate === "number" && handler.revalidate > 0 && handler.revalidate !== Infinity ? handler.revalidate : null;
     if (typeof handler["default"] === "function" && process.env.NODE_ENV === "development") {
       console.error(
         "[vinext] Detected default export in route handler " + route.pattern + ". Export a named export for each HTTP method instead.",
@@ -10575,11 +10903,88 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       isAutoHead = true;
     }
 
+    // ISR cache read for route handlers (production only).
+    // Only GET/HEAD (auto-HEAD) with finite revalidate > 0 are ISR-eligible.
+    // This runs before handler execution so a cache HIT skips the handler entirely.
+    if (
+      process.env.NODE_ENV === "production" &&
+      revalidateSeconds !== null &&
+      (method === "GET" || isAutoHead) &&
+      typeof handlerFn === "function"
+    ) {
+      const __routeKey = __isrRouteKey(cleanPathname);
+      try {
+        const __cached = await __isrGet(__routeKey);
+        if (__cached && !__cached.isStale && __cached.value.value && __cached.value.value.kind === "APP_ROUTE") {
+          // HIT — return cached response immediately
+          const __cv = __cached.value.value;
+          __isrDebug?.("HIT (route)", cleanPathname);
+          setHeadersContext(null);
+          setNavigationContext(null);
+          const __hitHeaders = Object.assign({}, __cv.headers || {});
+          __hitHeaders["X-Vinext-Cache"] = "HIT";
+          __hitHeaders["Cache-Control"] = "s-maxage=" + revalidateSeconds + ", stale-while-revalidate";
+          if (isAutoHead) {
+            return attachRouteHandlerMiddlewareContext(new Response(null, { status: __cv.status, headers: __hitHeaders }));
+          }
+          return attachRouteHandlerMiddlewareContext(new Response(__cv.body, { status: __cv.status, headers: __hitHeaders }));
+        }
+        if (__cached && __cached.isStale && __cached.value.value && __cached.value.value.kind === "APP_ROUTE") {
+          // STALE — serve stale response, trigger background regeneration
+          const __sv = __cached.value.value;
+          const __revalSecs = revalidateSeconds;
+          const __revalHandlerFn = handlerFn;
+          const __revalParams = params;
+          __triggerBackgroundRegeneration(__routeKey, async function() {
+            const __revalHeadCtx = { headers: new Headers(), cookies: new Map() };
+            const __revalUCtx = _createUnifiedCtx({
+              headersContext: __revalHeadCtx,
+              executionContext: _getRequestExecutionContext(),
+            });
+            await _runWithUnifiedCtx(__revalUCtx, async () => {
+              _ensureFetchPatch();
+              setNavigationContext({ pathname: cleanPathname, searchParams: url.searchParams, params: __revalParams });
+              const __syntheticReq = new Request(request.url, { method: "GET" });
+              const __revalResponse = await __revalHandlerFn(__syntheticReq, { params: __revalParams });
+              const __regenDynamic = consumeDynamicUsage();
+              setNavigationContext(null);
+              if (__regenDynamic) {
+                __isrDebug?.("route regen skipped (dynamic usage)", cleanPathname);
+                return;
+              }
+              const __freshBody = await __revalResponse.arrayBuffer();
+              const __freshHeaders = {};
+              __revalResponse.headers.forEach(function(v, k) {
+                if (k !== "x-vinext-cache") __freshHeaders[k] = v;
+              });
+              const __routeTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
+              await __isrSet(__routeKey, { kind: "APP_ROUTE", body: __freshBody, status: __revalResponse.status, headers: __freshHeaders }, __revalSecs, __routeTags);
+              __isrDebug?.("route regen complete", __routeKey);
+            });
+          });
+          __isrDebug?.("STALE (route)", cleanPathname);
+          setHeadersContext(null);
+          setNavigationContext(null);
+          const __staleHeaders = Object.assign({}, __sv.headers || {});
+          __staleHeaders["X-Vinext-Cache"] = "STALE";
+          __staleHeaders["Cache-Control"] = "s-maxage=0, stale-while-revalidate";
+          if (isAutoHead) {
+            return attachRouteHandlerMiddlewareContext(new Response(null, { status: __sv.status, headers: __staleHeaders }));
+          }
+          return attachRouteHandlerMiddlewareContext(new Response(__sv.body, { status: __sv.status, headers: __staleHeaders }));
+        }
+      } catch (__routeCacheErr) {
+        // Cache read failure — fall through to normal handler execution
+        console.error("[vinext] ISR route cache read error:", __routeCacheErr);
+      }
+    }
+
     if (typeof handlerFn === "function") {
       const previousHeadersPhase = setHeadersAccessPhase("route-handler");
       try {
         const response = await handlerFn(request, { params });
         const dynamicUsedInHandler = consumeDynamicUsage();
+        const handlerSetCacheControl = response.headers.has("cache-control");
 
         // Apply Cache-Control from route segment config (export const revalidate = N).
         // Runtime request APIs like headers() / cookies() make GET handlers dynamic,
@@ -10588,9 +10993,40 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           revalidateSeconds !== null &&
           !dynamicUsedInHandler &&
           (method === "GET" || isAutoHead) &&
-          !response.headers.has("cache-control")
+          !handlerSetCacheControl
         ) {
           response.headers.set("cache-control", "s-maxage=" + revalidateSeconds + ", stale-while-revalidate");
+        }
+
+        // ISR cache write for route handlers (production, MISS).
+        // Store the raw handler response before cookie/middleware transforms
+        // (those are request-specific and shouldn't be cached).
+        if (
+          process.env.NODE_ENV === "production" &&
+          revalidateSeconds !== null &&
+          !dynamicUsedInHandler &&
+          (method === "GET" || isAutoHead) &&
+          !handlerSetCacheControl
+        ) {
+          response.headers.set("X-Vinext-Cache", "MISS");
+          const __routeClone = response.clone();
+          const __routeKey = __isrRouteKey(cleanPathname);
+          const __revalSecs = revalidateSeconds;
+          const __routeTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
+          const __routeWritePromise = (async () => {
+            try {
+              const __buf = await __routeClone.arrayBuffer();
+              const __hdrs = {};
+              __routeClone.headers.forEach(function(v, k) {
+                if (k !== "x-vinext-cache" && k !== "cache-control") __hdrs[k] = v;
+              });
+              await __isrSet(__routeKey, { kind: "APP_ROUTE", body: __buf, status: __routeClone.status, headers: __hdrs }, __revalSecs, __routeTags);
+              __isrDebug?.("route cache written", __routeKey);
+            } catch (__cacheErr) {
+              console.error("[vinext] ISR route cache write error:", __cacheErr);
+            }
+          })();
+          _getRequestExecutionContext()?.waitUntil(__routeWritePromise);
         }
 
         // Collect any Set-Cookie headers from cookies().set()/delete() calls
@@ -11670,6 +12106,7 @@ function __isrCacheKey(pathname, suffix) {
 }
 function __isrHtmlKey(pathname) { return __isrCacheKey(pathname, "html"); }
 function __isrRscKey(pathname) { return __isrCacheKey(pathname, "rsc"); }
+function __isrRouteKey(pathname) { return __isrCacheKey(pathname, "route"); }
 // Verbose cache logging — opt in with NEXT_PRIVATE_DEBUG_CACHE=1.
 // Matches the env var Next.js uses for its own cache debug output so operators
 // have a single knob for all cache tracing.
@@ -13306,7 +13743,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   if (route.routeHandler) {
     const handler = route.routeHandler;
     const method = request.method.toUpperCase();
-    const revalidateSeconds = typeof handler.revalidate === "number" && handler.revalidate > 0 ? handler.revalidate : null;
+    const revalidateSeconds = typeof handler.revalidate === "number" && handler.revalidate > 0 && handler.revalidate !== Infinity ? handler.revalidate : null;
     if (typeof handler["default"] === "function" && process.env.NODE_ENV === "development") {
       console.error(
         "[vinext] Detected default export in route handler " + route.pattern + ". Export a named export for each HTTP method instead.",
@@ -13358,11 +13795,88 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       isAutoHead = true;
     }
 
+    // ISR cache read for route handlers (production only).
+    // Only GET/HEAD (auto-HEAD) with finite revalidate > 0 are ISR-eligible.
+    // This runs before handler execution so a cache HIT skips the handler entirely.
+    if (
+      process.env.NODE_ENV === "production" &&
+      revalidateSeconds !== null &&
+      (method === "GET" || isAutoHead) &&
+      typeof handlerFn === "function"
+    ) {
+      const __routeKey = __isrRouteKey(cleanPathname);
+      try {
+        const __cached = await __isrGet(__routeKey);
+        if (__cached && !__cached.isStale && __cached.value.value && __cached.value.value.kind === "APP_ROUTE") {
+          // HIT — return cached response immediately
+          const __cv = __cached.value.value;
+          __isrDebug?.("HIT (route)", cleanPathname);
+          setHeadersContext(null);
+          setNavigationContext(null);
+          const __hitHeaders = Object.assign({}, __cv.headers || {});
+          __hitHeaders["X-Vinext-Cache"] = "HIT";
+          __hitHeaders["Cache-Control"] = "s-maxage=" + revalidateSeconds + ", stale-while-revalidate";
+          if (isAutoHead) {
+            return attachRouteHandlerMiddlewareContext(new Response(null, { status: __cv.status, headers: __hitHeaders }));
+          }
+          return attachRouteHandlerMiddlewareContext(new Response(__cv.body, { status: __cv.status, headers: __hitHeaders }));
+        }
+        if (__cached && __cached.isStale && __cached.value.value && __cached.value.value.kind === "APP_ROUTE") {
+          // STALE — serve stale response, trigger background regeneration
+          const __sv = __cached.value.value;
+          const __revalSecs = revalidateSeconds;
+          const __revalHandlerFn = handlerFn;
+          const __revalParams = params;
+          __triggerBackgroundRegeneration(__routeKey, async function() {
+            const __revalHeadCtx = { headers: new Headers(), cookies: new Map() };
+            const __revalUCtx = _createUnifiedCtx({
+              headersContext: __revalHeadCtx,
+              executionContext: _getRequestExecutionContext(),
+            });
+            await _runWithUnifiedCtx(__revalUCtx, async () => {
+              _ensureFetchPatch();
+              setNavigationContext({ pathname: cleanPathname, searchParams: url.searchParams, params: __revalParams });
+              const __syntheticReq = new Request(request.url, { method: "GET" });
+              const __revalResponse = await __revalHandlerFn(__syntheticReq, { params: __revalParams });
+              const __regenDynamic = consumeDynamicUsage();
+              setNavigationContext(null);
+              if (__regenDynamic) {
+                __isrDebug?.("route regen skipped (dynamic usage)", cleanPathname);
+                return;
+              }
+              const __freshBody = await __revalResponse.arrayBuffer();
+              const __freshHeaders = {};
+              __revalResponse.headers.forEach(function(v, k) {
+                if (k !== "x-vinext-cache") __freshHeaders[k] = v;
+              });
+              const __routeTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
+              await __isrSet(__routeKey, { kind: "APP_ROUTE", body: __freshBody, status: __revalResponse.status, headers: __freshHeaders }, __revalSecs, __routeTags);
+              __isrDebug?.("route regen complete", __routeKey);
+            });
+          });
+          __isrDebug?.("STALE (route)", cleanPathname);
+          setHeadersContext(null);
+          setNavigationContext(null);
+          const __staleHeaders = Object.assign({}, __sv.headers || {});
+          __staleHeaders["X-Vinext-Cache"] = "STALE";
+          __staleHeaders["Cache-Control"] = "s-maxage=0, stale-while-revalidate";
+          if (isAutoHead) {
+            return attachRouteHandlerMiddlewareContext(new Response(null, { status: __sv.status, headers: __staleHeaders }));
+          }
+          return attachRouteHandlerMiddlewareContext(new Response(__sv.body, { status: __sv.status, headers: __staleHeaders }));
+        }
+      } catch (__routeCacheErr) {
+        // Cache read failure — fall through to normal handler execution
+        console.error("[vinext] ISR route cache read error:", __routeCacheErr);
+      }
+    }
+
     if (typeof handlerFn === "function") {
       const previousHeadersPhase = setHeadersAccessPhase("route-handler");
       try {
         const response = await handlerFn(request, { params });
         const dynamicUsedInHandler = consumeDynamicUsage();
+        const handlerSetCacheControl = response.headers.has("cache-control");
 
         // Apply Cache-Control from route segment config (export const revalidate = N).
         // Runtime request APIs like headers() / cookies() make GET handlers dynamic,
@@ -13371,9 +13885,40 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           revalidateSeconds !== null &&
           !dynamicUsedInHandler &&
           (method === "GET" || isAutoHead) &&
-          !response.headers.has("cache-control")
+          !handlerSetCacheControl
         ) {
           response.headers.set("cache-control", "s-maxage=" + revalidateSeconds + ", stale-while-revalidate");
+        }
+
+        // ISR cache write for route handlers (production, MISS).
+        // Store the raw handler response before cookie/middleware transforms
+        // (those are request-specific and shouldn't be cached).
+        if (
+          process.env.NODE_ENV === "production" &&
+          revalidateSeconds !== null &&
+          !dynamicUsedInHandler &&
+          (method === "GET" || isAutoHead) &&
+          !handlerSetCacheControl
+        ) {
+          response.headers.set("X-Vinext-Cache", "MISS");
+          const __routeClone = response.clone();
+          const __routeKey = __isrRouteKey(cleanPathname);
+          const __revalSecs = revalidateSeconds;
+          const __routeTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
+          const __routeWritePromise = (async () => {
+            try {
+              const __buf = await __routeClone.arrayBuffer();
+              const __hdrs = {};
+              __routeClone.headers.forEach(function(v, k) {
+                if (k !== "x-vinext-cache" && k !== "cache-control") __hdrs[k] = v;
+              });
+              await __isrSet(__routeKey, { kind: "APP_ROUTE", body: __buf, status: __routeClone.status, headers: __hdrs }, __revalSecs, __routeTags);
+              __isrDebug?.("route cache written", __routeKey);
+            } catch (__cacheErr) {
+              console.error("[vinext] ISR route cache write error:", __cacheErr);
+            }
+          })();
+          _getRequestExecutionContext()?.waitUntil(__routeWritePromise);
         }
 
         // Collect any Set-Cookie headers from cookies().set()/delete() calls
@@ -14453,6 +14998,7 @@ function __isrCacheKey(pathname, suffix) {
 }
 function __isrHtmlKey(pathname) { return __isrCacheKey(pathname, "html"); }
 function __isrRscKey(pathname) { return __isrCacheKey(pathname, "rsc"); }
+function __isrRouteKey(pathname) { return __isrCacheKey(pathname, "route"); }
 // Verbose cache logging — opt in with NEXT_PRIVATE_DEBUG_CACHE=1.
 // Matches the env var Next.js uses for its own cache debug output so operators
 // have a single knob for all cache tracing.
@@ -16399,7 +16945,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   if (route.routeHandler) {
     const handler = route.routeHandler;
     const method = request.method.toUpperCase();
-    const revalidateSeconds = typeof handler.revalidate === "number" && handler.revalidate > 0 ? handler.revalidate : null;
+    const revalidateSeconds = typeof handler.revalidate === "number" && handler.revalidate > 0 && handler.revalidate !== Infinity ? handler.revalidate : null;
     if (typeof handler["default"] === "function" && process.env.NODE_ENV === "development") {
       console.error(
         "[vinext] Detected default export in route handler " + route.pattern + ". Export a named export for each HTTP method instead.",
@@ -16451,11 +16997,88 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       isAutoHead = true;
     }
 
+    // ISR cache read for route handlers (production only).
+    // Only GET/HEAD (auto-HEAD) with finite revalidate > 0 are ISR-eligible.
+    // This runs before handler execution so a cache HIT skips the handler entirely.
+    if (
+      process.env.NODE_ENV === "production" &&
+      revalidateSeconds !== null &&
+      (method === "GET" || isAutoHead) &&
+      typeof handlerFn === "function"
+    ) {
+      const __routeKey = __isrRouteKey(cleanPathname);
+      try {
+        const __cached = await __isrGet(__routeKey);
+        if (__cached && !__cached.isStale && __cached.value.value && __cached.value.value.kind === "APP_ROUTE") {
+          // HIT — return cached response immediately
+          const __cv = __cached.value.value;
+          __isrDebug?.("HIT (route)", cleanPathname);
+          setHeadersContext(null);
+          setNavigationContext(null);
+          const __hitHeaders = Object.assign({}, __cv.headers || {});
+          __hitHeaders["X-Vinext-Cache"] = "HIT";
+          __hitHeaders["Cache-Control"] = "s-maxage=" + revalidateSeconds + ", stale-while-revalidate";
+          if (isAutoHead) {
+            return attachRouteHandlerMiddlewareContext(new Response(null, { status: __cv.status, headers: __hitHeaders }));
+          }
+          return attachRouteHandlerMiddlewareContext(new Response(__cv.body, { status: __cv.status, headers: __hitHeaders }));
+        }
+        if (__cached && __cached.isStale && __cached.value.value && __cached.value.value.kind === "APP_ROUTE") {
+          // STALE — serve stale response, trigger background regeneration
+          const __sv = __cached.value.value;
+          const __revalSecs = revalidateSeconds;
+          const __revalHandlerFn = handlerFn;
+          const __revalParams = params;
+          __triggerBackgroundRegeneration(__routeKey, async function() {
+            const __revalHeadCtx = { headers: new Headers(), cookies: new Map() };
+            const __revalUCtx = _createUnifiedCtx({
+              headersContext: __revalHeadCtx,
+              executionContext: _getRequestExecutionContext(),
+            });
+            await _runWithUnifiedCtx(__revalUCtx, async () => {
+              _ensureFetchPatch();
+              setNavigationContext({ pathname: cleanPathname, searchParams: url.searchParams, params: __revalParams });
+              const __syntheticReq = new Request(request.url, { method: "GET" });
+              const __revalResponse = await __revalHandlerFn(__syntheticReq, { params: __revalParams });
+              const __regenDynamic = consumeDynamicUsage();
+              setNavigationContext(null);
+              if (__regenDynamic) {
+                __isrDebug?.("route regen skipped (dynamic usage)", cleanPathname);
+                return;
+              }
+              const __freshBody = await __revalResponse.arrayBuffer();
+              const __freshHeaders = {};
+              __revalResponse.headers.forEach(function(v, k) {
+                if (k !== "x-vinext-cache") __freshHeaders[k] = v;
+              });
+              const __routeTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
+              await __isrSet(__routeKey, { kind: "APP_ROUTE", body: __freshBody, status: __revalResponse.status, headers: __freshHeaders }, __revalSecs, __routeTags);
+              __isrDebug?.("route regen complete", __routeKey);
+            });
+          });
+          __isrDebug?.("STALE (route)", cleanPathname);
+          setHeadersContext(null);
+          setNavigationContext(null);
+          const __staleHeaders = Object.assign({}, __sv.headers || {});
+          __staleHeaders["X-Vinext-Cache"] = "STALE";
+          __staleHeaders["Cache-Control"] = "s-maxage=0, stale-while-revalidate";
+          if (isAutoHead) {
+            return attachRouteHandlerMiddlewareContext(new Response(null, { status: __sv.status, headers: __staleHeaders }));
+          }
+          return attachRouteHandlerMiddlewareContext(new Response(__sv.body, { status: __sv.status, headers: __staleHeaders }));
+        }
+      } catch (__routeCacheErr) {
+        // Cache read failure — fall through to normal handler execution
+        console.error("[vinext] ISR route cache read error:", __routeCacheErr);
+      }
+    }
+
     if (typeof handlerFn === "function") {
       const previousHeadersPhase = setHeadersAccessPhase("route-handler");
       try {
         const response = await handlerFn(request, { params });
         const dynamicUsedInHandler = consumeDynamicUsage();
+        const handlerSetCacheControl = response.headers.has("cache-control");
 
         // Apply Cache-Control from route segment config (export const revalidate = N).
         // Runtime request APIs like headers() / cookies() make GET handlers dynamic,
@@ -16464,9 +17087,40 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           revalidateSeconds !== null &&
           !dynamicUsedInHandler &&
           (method === "GET" || isAutoHead) &&
-          !response.headers.has("cache-control")
+          !handlerSetCacheControl
         ) {
           response.headers.set("cache-control", "s-maxage=" + revalidateSeconds + ", stale-while-revalidate");
+        }
+
+        // ISR cache write for route handlers (production, MISS).
+        // Store the raw handler response before cookie/middleware transforms
+        // (those are request-specific and shouldn't be cached).
+        if (
+          process.env.NODE_ENV === "production" &&
+          revalidateSeconds !== null &&
+          !dynamicUsedInHandler &&
+          (method === "GET" || isAutoHead) &&
+          !handlerSetCacheControl
+        ) {
+          response.headers.set("X-Vinext-Cache", "MISS");
+          const __routeClone = response.clone();
+          const __routeKey = __isrRouteKey(cleanPathname);
+          const __revalSecs = revalidateSeconds;
+          const __routeTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
+          const __routeWritePromise = (async () => {
+            try {
+              const __buf = await __routeClone.arrayBuffer();
+              const __hdrs = {};
+              __routeClone.headers.forEach(function(v, k) {
+                if (k !== "x-vinext-cache" && k !== "cache-control") __hdrs[k] = v;
+              });
+              await __isrSet(__routeKey, { kind: "APP_ROUTE", body: __buf, status: __routeClone.status, headers: __hdrs }, __revalSecs, __routeTags);
+              __isrDebug?.("route cache written", __routeKey);
+            } catch (__cacheErr) {
+              console.error("[vinext] ISR route cache write error:", __cacheErr);
+            }
+          })();
+          _getRequestExecutionContext()?.waitUntil(__routeWritePromise);
         }
 
         // Collect any Set-Cookie headers from cookies().set()/delete() calls

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -2181,6 +2181,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     if (
       process.env.NODE_ENV === "production" &&
       revalidateSeconds !== null &&
+      handler.dynamic !== "force-dynamic" &&
       (method === "GET" || isAutoHead) &&
       typeof handlerFn === "function"
     ) {
@@ -2227,7 +2228,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
               const __freshBody = await __revalResponse.arrayBuffer();
               const __freshHeaders = {};
               __revalResponse.headers.forEach(function(v, k) {
-                if (k !== "x-vinext-cache") __freshHeaders[k] = v;
+                if (k !== "x-vinext-cache" && k !== "cache-control") __freshHeaders[k] = v;
               });
               const __routeTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
               await __isrSet(__routeKey, { kind: "APP_ROUTE", body: __freshBody, status: __revalResponse.status, headers: __freshHeaders }, __revalSecs, __routeTags);
@@ -2276,6 +2277,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         if (
           process.env.NODE_ENV === "production" &&
           revalidateSeconds !== null &&
+          handler.dynamic !== "force-dynamic" &&
           !dynamicUsedInHandler &&
           (method === "GET" || isAutoHead) &&
           !handlerSetCacheControl
@@ -5069,6 +5071,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     if (
       process.env.NODE_ENV === "production" &&
       revalidateSeconds !== null &&
+      handler.dynamic !== "force-dynamic" &&
       (method === "GET" || isAutoHead) &&
       typeof handlerFn === "function"
     ) {
@@ -5115,7 +5118,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
               const __freshBody = await __revalResponse.arrayBuffer();
               const __freshHeaders = {};
               __revalResponse.headers.forEach(function(v, k) {
-                if (k !== "x-vinext-cache") __freshHeaders[k] = v;
+                if (k !== "x-vinext-cache" && k !== "cache-control") __freshHeaders[k] = v;
               });
               const __routeTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
               await __isrSet(__routeKey, { kind: "APP_ROUTE", body: __freshBody, status: __revalResponse.status, headers: __freshHeaders }, __revalSecs, __routeTags);
@@ -5164,6 +5167,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         if (
           process.env.NODE_ENV === "production" &&
           revalidateSeconds !== null &&
+          handler.dynamic !== "force-dynamic" &&
           !dynamicUsedInHandler &&
           (method === "GET" || isAutoHead) &&
           !handlerSetCacheControl
@@ -7984,6 +7988,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     if (
       process.env.NODE_ENV === "production" &&
       revalidateSeconds !== null &&
+      handler.dynamic !== "force-dynamic" &&
       (method === "GET" || isAutoHead) &&
       typeof handlerFn === "function"
     ) {
@@ -8030,7 +8035,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
               const __freshBody = await __revalResponse.arrayBuffer();
               const __freshHeaders = {};
               __revalResponse.headers.forEach(function(v, k) {
-                if (k !== "x-vinext-cache") __freshHeaders[k] = v;
+                if (k !== "x-vinext-cache" && k !== "cache-control") __freshHeaders[k] = v;
               });
               const __routeTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
               await __isrSet(__routeKey, { kind: "APP_ROUTE", body: __freshBody, status: __revalResponse.status, headers: __freshHeaders }, __revalSecs, __routeTags);
@@ -8079,6 +8084,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         if (
           process.env.NODE_ENV === "production" &&
           revalidateSeconds !== null &&
+          handler.dynamic !== "force-dynamic" &&
           !dynamicUsedInHandler &&
           (method === "GET" || isAutoHead) &&
           !handlerSetCacheControl
@@ -10909,6 +10915,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     if (
       process.env.NODE_ENV === "production" &&
       revalidateSeconds !== null &&
+      handler.dynamic !== "force-dynamic" &&
       (method === "GET" || isAutoHead) &&
       typeof handlerFn === "function"
     ) {
@@ -10955,7 +10962,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
               const __freshBody = await __revalResponse.arrayBuffer();
               const __freshHeaders = {};
               __revalResponse.headers.forEach(function(v, k) {
-                if (k !== "x-vinext-cache") __freshHeaders[k] = v;
+                if (k !== "x-vinext-cache" && k !== "cache-control") __freshHeaders[k] = v;
               });
               const __routeTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
               await __isrSet(__routeKey, { kind: "APP_ROUTE", body: __freshBody, status: __revalResponse.status, headers: __freshHeaders }, __revalSecs, __routeTags);
@@ -11004,6 +11011,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         if (
           process.env.NODE_ENV === "production" &&
           revalidateSeconds !== null &&
+          handler.dynamic !== "force-dynamic" &&
           !dynamicUsedInHandler &&
           (method === "GET" || isAutoHead) &&
           !handlerSetCacheControl
@@ -13801,6 +13809,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     if (
       process.env.NODE_ENV === "production" &&
       revalidateSeconds !== null &&
+      handler.dynamic !== "force-dynamic" &&
       (method === "GET" || isAutoHead) &&
       typeof handlerFn === "function"
     ) {
@@ -13847,7 +13856,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
               const __freshBody = await __revalResponse.arrayBuffer();
               const __freshHeaders = {};
               __revalResponse.headers.forEach(function(v, k) {
-                if (k !== "x-vinext-cache") __freshHeaders[k] = v;
+                if (k !== "x-vinext-cache" && k !== "cache-control") __freshHeaders[k] = v;
               });
               const __routeTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
               await __isrSet(__routeKey, { kind: "APP_ROUTE", body: __freshBody, status: __revalResponse.status, headers: __freshHeaders }, __revalSecs, __routeTags);
@@ -13896,6 +13905,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         if (
           process.env.NODE_ENV === "production" &&
           revalidateSeconds !== null &&
+          handler.dynamic !== "force-dynamic" &&
           !dynamicUsedInHandler &&
           (method === "GET" || isAutoHead) &&
           !handlerSetCacheControl
@@ -17003,6 +17013,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     if (
       process.env.NODE_ENV === "production" &&
       revalidateSeconds !== null &&
+      handler.dynamic !== "force-dynamic" &&
       (method === "GET" || isAutoHead) &&
       typeof handlerFn === "function"
     ) {
@@ -17049,7 +17060,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
               const __freshBody = await __revalResponse.arrayBuffer();
               const __freshHeaders = {};
               __revalResponse.headers.forEach(function(v, k) {
-                if (k !== "x-vinext-cache") __freshHeaders[k] = v;
+                if (k !== "x-vinext-cache" && k !== "cache-control") __freshHeaders[k] = v;
               });
               const __routeTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
               await __isrSet(__routeKey, { kind: "APP_ROUTE", body: __freshBody, status: __revalResponse.status, headers: __freshHeaders }, __revalSecs, __routeTags);
@@ -17098,6 +17109,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         if (
           process.env.NODE_ENV === "production" &&
           revalidateSeconds !== null &&
+          handler.dynamic !== "force-dynamic" &&
           !dynamicUsedInHandler &&
           (method === "GET" || isAutoHead) &&
           !handlerSetCacheControl

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -1682,6 +1682,84 @@ describe("App Router Production server (startProdServer)", () => {
     expect(reqId3).not.toBe(reqId1);
     expect(res3.headers.get("x-vinext-cache")).toBe("MISS");
   });
+
+  // Route handler ISR caching tests
+  // Fixture: /api/static-data exports revalidate = 1 and returns { timestamp: Date.now() }
+  it("route handler ISR: first GET returns MISS", async () => {
+    const res = await fetch(`${baseUrl}/api/static-data`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("x-vinext-cache")).toBe("MISS");
+  });
+
+  it("route handler ISR: second GET returns cached response (HIT)", async () => {
+    // First request populates cache
+    const res1 = await fetch(`${baseUrl}/api/static-data`);
+    const body1 = await res1.json();
+    expect(res1.status).toBe(200);
+
+    // Second request should be a cache hit with identical response
+    const res2 = await fetch(`${baseUrl}/api/static-data`);
+    const body2 = await res2.json();
+    expect(res2.status).toBe(200);
+    expect(body2.timestamp).toBe(body1.timestamp);
+    expect(res2.headers.get("x-vinext-cache")).toBe("HIT");
+  });
+
+  it("route handler ISR: POST bypasses cache", async () => {
+    // POST should never be cached even with revalidate set on GET
+    const res = await fetch(`${baseUrl}/api/static-data`, { method: "POST" });
+    // /api/static-data only exports GET, POST should be 405
+    expect(res.status).toBe(405);
+    expect(res.headers.get("x-vinext-cache")).toBeNull();
+  });
+
+  it("route handler ISR: dynamic handler (reads headers()) is not cached", async () => {
+    // /api/dynamic-request-data exports revalidate=60 but reads headers() and cookies()
+    const res1 = await fetch(`${baseUrl}/api/dynamic-request-data`, {
+      headers: { "x-test-ping": "a" },
+    });
+    const res2 = await fetch(`${baseUrl}/api/dynamic-request-data`, {
+      headers: { "x-test-ping": "b" },
+    });
+    // Dynamic usage should prevent ISR caching
+    expect(res1.headers.get("x-vinext-cache")).toBeNull();
+    expect(res2.headers.get("x-vinext-cache")).toBeNull();
+  });
+
+  it("route handler ISR: handler-set Cache-Control skips ISR caching", async () => {
+    // /api/custom-cache exports revalidate=60 but sets its own Cache-Control
+    const res1 = await fetch(`${baseUrl}/api/custom-cache`);
+    const res2 = await fetch(`${baseUrl}/api/custom-cache`);
+    // Handler controls caching — ISR should not interfere
+    expect(res1.headers.get("x-vinext-cache")).toBeNull();
+    expect(res2.headers.get("x-vinext-cache")).toBeNull();
+  });
+
+  it("route handler ISR: STALE serves stale data and triggers background regen", async () => {
+    // /api/static-data has revalidate=1
+    // Cache may already be warm from earlier tests — ensure we have a known timestamp
+    const warm = await fetch(`${baseUrl}/api/static-data`);
+    const warmBody = await warm.json();
+    const cachedTimestamp = warmBody.timestamp;
+
+    // Wait for cache entry to become stale (revalidate=1)
+    await new Promise((resolve) => setTimeout(resolve, 1500));
+
+    // STALE — serves stale data, triggers background regen
+    const staleRes = await fetch(`${baseUrl}/api/static-data`);
+    expect(staleRes.headers.get("x-vinext-cache")).toBe("STALE");
+    const staleBody = await staleRes.json();
+    expect(staleBody.timestamp).toBe(cachedTimestamp); // Still the old data
+
+    // Wait for background regen to complete
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    // HIT — fresh data from background regen
+    const freshRes = await fetch(`${baseUrl}/api/static-data`);
+    expect(freshRes.headers.get("x-vinext-cache")).toBe("HIT");
+    const freshBody = await freshRes.json();
+    expect(freshBody.timestamp).not.toBe(cachedTimestamp); // New data
+  });
 });
 
 describe("App Router Production server worker entry compatibility", () => {
@@ -3586,5 +3664,26 @@ describe("generateRscEntry ISR code generation", () => {
     expect(teeAssignIdx).toBeGreaterThan(-1);
     expect(rscResponseIdx).toBeGreaterThan(-1);
     expect(teeAssignIdx).toBeLessThan(rscResponseIdx);
+  });
+
+  // Route handler ISR code generation tests
+  it("generated code contains __isrRouteKey helper", () => {
+    const code = generateRscEntry("/tmp/test/app", minimalRoutes);
+    expect(code).toContain("__isrRouteKey");
+  });
+
+  it("generated code contains APP_ROUTE ISR cache read for route handlers", () => {
+    const code = generateRscEntry("/tmp/test/app", minimalRoutes);
+    expect(code).toContain('"APP_ROUTE"');
+    // Route handler ISR uses __isrRouteKey to build the cache key, then reads via __isrGet
+    expect(code).toContain("__isrRouteKey(cleanPathname)");
+    expect(code).toContain("__isrGet(__routeKey)");
+  });
+
+  it("generated code contains APP_ROUTE ISR cache write for route handlers", () => {
+    const code = generateRscEntry("/tmp/test/app", minimalRoutes);
+    // Route handler ISR writes use __isrSet with __routeKey and APP_ROUTE kind
+    expect(code).toContain("__isrSet(__routeKey,");
+    expect(code).toContain('kind: "APP_ROUTE"');
   });
 });

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -1742,8 +1742,8 @@ describe("App Router Production server (startProdServer)", () => {
     const warmBody = await warm.json();
     const cachedTimestamp = warmBody.timestamp;
 
-    // Wait for cache entry to become stale (revalidate=1)
-    await new Promise((resolve) => setTimeout(resolve, 1500));
+    // Wait for cache entry to become stale (revalidate=1, generous margin for slow CI)
+    await new Promise((resolve) => setTimeout(resolve, 2000));
 
     // STALE — serves stale data, triggers background regen
     const staleRes = await fetch(`${baseUrl}/api/static-data`);
@@ -1751,13 +1751,18 @@ describe("App Router Production server (startProdServer)", () => {
     const staleBody = await staleRes.json();
     expect(staleBody.timestamp).toBe(cachedTimestamp); // Still the old data
 
-    // Wait for background regen to complete
-    await new Promise((resolve) => setTimeout(resolve, 500));
+    // Poll until background regen completes (up to 5s)
+    const deadline = Date.now() + 5000;
+    let freshRes: Response;
+    let freshBody: { timestamp: number };
+    do {
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      freshRes = await fetch(`${baseUrl}/api/static-data`);
+      freshBody = await freshRes.json();
+    } while (freshRes.headers.get("x-vinext-cache") !== "HIT" && Date.now() < deadline);
 
     // HIT — fresh data from background regen
-    const freshRes = await fetch(`${baseUrl}/api/static-data`);
     expect(freshRes.headers.get("x-vinext-cache")).toBe("HIT");
-    const freshBody = await freshRes.json();
     expect(freshBody.timestamp).not.toBe(cachedTimestamp); // New data
   });
 

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -1760,6 +1760,21 @@ describe("App Router Production server (startProdServer)", () => {
     const freshBody = await freshRes.json();
     expect(freshBody.timestamp).not.toBe(cachedTimestamp); // New data
   });
+
+  it("route handler ISR: auto-HEAD returns cached headers with empty body", async () => {
+    // Ensure cache is warm
+    const getRes = await fetch(`${baseUrl}/api/static-data`);
+    await getRes.text();
+    const cacheHeader = getRes.headers.get("x-vinext-cache");
+    expect(cacheHeader === "MISS" || cacheHeader === "HIT" || cacheHeader === "STALE").toBe(true);
+
+    // HEAD against a GET-only route should return cached headers, no body
+    const headRes = await fetch(`${baseUrl}/api/static-data`, { method: "HEAD" });
+    expect(headRes.status).toBe(200);
+    expect(headRes.headers.get("x-vinext-cache")).toBe("HIT");
+    const body = await headRes.text();
+    expect(body).toBe("");
+  });
 });
 
 describe("App Router Production server worker entry compatibility", () => {

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -1684,6 +1684,9 @@ describe("App Router Production server (startProdServer)", () => {
   });
 
   // Route handler ISR caching tests
+  // These tests are ORDER-DEPENDENT: they share a single production server and
+  // /api/static-data cache state persists across tests. HIT depends on MISS
+  // having run first, STALE re-warms explicitly. Take care when adding new tests.
   // Fixture: /api/static-data exports revalidate = 1 and returns { timestamp: Date.now() }
   it("route handler ISR: first GET returns MISS", async () => {
     const res = await fetch(`${baseUrl}/api/static-data`);
@@ -1731,6 +1734,14 @@ describe("App Router Production server (startProdServer)", () => {
     const res1 = await fetch(`${baseUrl}/api/custom-cache`);
     const res2 = await fetch(`${baseUrl}/api/custom-cache`);
     // Handler controls caching — ISR should not interfere
+    expect(res1.headers.get("x-vinext-cache")).toBeNull();
+    expect(res2.headers.get("x-vinext-cache")).toBeNull();
+  });
+
+  it("route handler ISR: force-dynamic handler is not cached", async () => {
+    // /api/force-dynamic-revalidate exports revalidate=60 AND dynamic="force-dynamic"
+    const res1 = await fetch(`${baseUrl}/api/force-dynamic-revalidate`);
+    const res2 = await fetch(`${baseUrl}/api/force-dynamic-revalidate`);
     expect(res1.headers.get("x-vinext-cache")).toBeNull();
     expect(res2.headers.get("x-vinext-cache")).toBeNull();
   });

--- a/tests/fixtures/app-basic/app/api/force-dynamic-revalidate/route.ts
+++ b/tests/fixtures/app-basic/app/api/force-dynamic-revalidate/route.ts
@@ -1,0 +1,6 @@
+export const revalidate = 60;
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  return Response.json({ timestamp: Date.now() });
+}

--- a/tests/nextjs-compat/app-routes.test.ts
+++ b/tests/nextjs-compat/app-routes.test.ts
@@ -381,4 +381,16 @@ describe("Next.js compat: app-routes", () => {
   // N/A: 'permanentRedirect' — Would need fixture, minor variant of redirect
   //
   // N/A: 'catch-all routes' — Would need fixture with [...slug] route handler
+
+  // ── ISR caching (dev mode) ─────────────────────────────────
+  // In dev mode, ISR caching is disabled. Route handlers should NOT emit
+  // X-Vinext-Cache headers — every request re-executes the handler fresh.
+  // Production ISR behavioral tests are in app-router.test.ts's production server section.
+
+  it("dev mode: route handler with revalidate does not emit X-Vinext-Cache header", async () => {
+    const res = await fetch(`${baseUrl}/api/static-data`);
+    expect(res.status).toBe(200);
+    // Dev mode should not set X-Vinext-Cache (ISR is production-only)
+    expect(res.headers.get("x-vinext-cache")).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary

- Route handlers with `export const revalidate = N` now get server-side ISR caching (MISS → HIT → STALE with background regeneration), matching the existing page ISR behavior
- Previously only `Cache-Control` headers were emitted — the handler re-executed on every request with no server-side cache lookup or store
- Reuses existing `CachedRouteValue` type (`kind: "APP_ROUTE"`) and KV serialization that were already defined but unused

### Implementation

- **`__isrRouteKey`** helper with `"route"` suffix for cache key construction (no HTML/RSC split needed)
- **Cache READ** before handler execution — HIT returns cached response immediately (skips handler), STALE serves stale data and triggers background regeneration
- **Cache WRITE** on MISS via `response.clone()` + `waitUntil` — stores raw handler response before cookie/middleware transforms
- **Background regen** uses synthetic request + clean ALS context (empty headers/cookies) to prevent user-specific data from leaking into cached responses
- **Guards**: production-only, GET/HEAD only, skips dynamic handlers (`headers()`/`cookies()`), skips handlers that set own `Cache-Control`, filters `Infinity` from `revalidateSeconds`

## Test Plan

- [x] 3 code generation tests (`__isrRouteKey`, `APP_ROUTE` cache read/write in generated code)
- [x] 6 production behavioral tests (MISS, HIT, POST bypass, dynamic bypass, handler Cache-Control bypass, STALE lifecycle)
- [x] 1 dev-mode guard test (no `X-Vinext-Cache` header in dev)
- [x] 262/262 `app-router.test.ts` pass (no regressions to page ISR)
- [x] 28/28 `app-routes.test.ts` pass
- [x] 78/78 `isr-cache.test.ts` + `kv-cache-handler.test.ts` pass
- [x] Typecheck clean, lint clean, format clean