### PR TITLE
fix: merge top-level optimizeDeps with per-environment config

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -1337,6 +1337,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         // also preserve entries from earlier plugins.
         viteConfig.optimizeDeps = {
           exclude: [...new Set([...incomingExclude, "vinext", "@vercel/og"])],
+          ...(incomingInclude.length > 0 ? { include: incomingInclude } : {}),
         };
 
         // If app/ directory exists, configure RSC environments

--- a/tests/build-optimization.test.ts
+++ b/tests/build-optimization.test.ts
@@ -126,9 +126,7 @@ describe("optimizeDeps.exclude for vinext", () => {
       // Incoming excludes from other plugins must survive the merge
       expect(result.optimizeDeps?.exclude).toContain("@lingui/macro");
       // No duplicates
-      expect(new Set(result.optimizeDeps.exclude).size).toBe(
-        result.optimizeDeps.exclude.length,
-      );
+      expect(new Set(result.optimizeDeps.exclude).size).toBe(result.optimizeDeps.exclude.length);
     } finally {
       await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
     }
@@ -190,10 +188,9 @@ describe("optimizeDeps.exclude for vinext", () => {
         expect(envExclude, `${envName} should contain @vercel/og`).toContain("@vercel/og");
         // Verify no duplicates exist (Set-based dedup works correctly even
         // when incoming config overlaps with vinext's own entries)
-        expect(
-          new Set(envExclude).size,
-          `${envName} should have no duplicate excludes`,
-        ).toBe(envExclude.length);
+        expect(new Set(envExclude).size, `${envName} should have no duplicate excludes`).toBe(
+          envExclude.length,
+        );
       }
 
       // Client environment should merge incoming includes


### PR DESCRIPTION
## Summary

Fixes #538

vinext's `config()` hook was creating per-environment `optimizeDeps` objects from scratch, discarding any `exclude` or `include` entries that other Vite plugins (e.g. `@lingui/vite-plugin`) had added to the top-level `config.optimizeDeps` during their own `config` hooks.

This PR captures the incoming `config.optimizeDeps.exclude` and `config.optimizeDeps.include` arrays before building the per-environment configs, then merges them (with deduplication via `Set`) into each environment:

- **rsc**: `exclude` now includes incoming excludes + `["vinext", "@vercel/og"]`
- **ssr**: `exclude` now includes incoming excludes + `["vinext", "@vercel/og"]`
- **client**: `exclude` now includes incoming excludes + `["vinext", "@vercel/og", ...serverExternalPackages]`; `include` now includes incoming includes + React packages

### Changes

- `packages/vinext/src/index.ts` — Read `config.optimizeDeps?.exclude` and `config.optimizeDeps?.include` at the top of the environments block, then spread them into each environment's `optimizeDeps` using `[...new Set([...incoming, ...vinextOwn])]`
- `tests/build-optimization.test.ts` — New test that passes `optimizeDeps.exclude` and `optimizeDeps.include` via the mock config (simulating an earlier plugin like `@lingui/vite-plugin`) and verifies those entries appear in all three environments alongside vinext's own entries

## Test plan

- [x] New unit test: passes top-level `optimizeDeps.exclude` (`@lingui/macro`, `@lingui/core/macro`) and `optimizeDeps.include` (`some-lib`) via mock config, verifies they appear in rsc/ssr/client environments alongside vinext's own entries
- [x] Existing `optimizeDeps.exclude` tests still pass (66/66 in `build-optimization.test.ts`)
- [x] `pnpm run fmt:check` — passes
- [x] `pnpm run lint` — 0 warnings, 0 errors
- [x] `pnpm run typecheck` — passes