### PR TITLE
fix: prevent user searchParams from leaking into ISR cache

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -2373,8 +2373,8 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           });
           const __revalResult = await _runWithUnifiedCtx(__revalUCtx, async () => {
             _ensureFetchPatch();
-            setNavigationContext({ pathname: cleanPathname, searchParams: url.searchParams, params });
-            const __revalElement = await buildPageElement(route, params, undefined, url.searchParams);
+            setNavigationContext({ pathname: cleanPathname, searchParams: new URLSearchParams(), params });
+            const __revalElement = await buildPageElement(route, params, undefined, new URLSearchParams());
             const __revalOnError = createRscOnErrorHandler(request, cleanPathname, route.pattern);
             const __revalRscStream = renderToReadableStream(__revalElement, { onError: __revalOnError });
             // Tee RSC stream: one for SSR, one to capture rscData

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -2507,8 +2507,8 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           });
           const __revalResult = await _runWithUnifiedCtx(__revalUCtx, async () => {
             _ensureFetchPatch();
-            setNavigationContext({ pathname: cleanPathname, searchParams: url.searchParams, params });
-            const __revalElement = await buildPageElement(route, params, undefined, url.searchParams);
+            setNavigationContext({ pathname: cleanPathname, searchParams: new URLSearchParams(), params });
+            const __revalElement = await buildPageElement(route, params, undefined, new URLSearchParams());
             const __revalOnError = createRscOnErrorHandler(request, cleanPathname, route.pattern);
             const __revalRscStream = renderToReadableStream(__revalElement, { onError: __revalOnError });
             // Tee RSC stream: one for SSR, one to capture rscData
@@ -5399,8 +5399,8 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           });
           const __revalResult = await _runWithUnifiedCtx(__revalUCtx, async () => {
             _ensureFetchPatch();
-            setNavigationContext({ pathname: cleanPathname, searchParams: url.searchParams, params });
-            const __revalElement = await buildPageElement(route, params, undefined, url.searchParams);
+            setNavigationContext({ pathname: cleanPathname, searchParams: new URLSearchParams(), params });
+            const __revalElement = await buildPageElement(route, params, undefined, new URLSearchParams());
             const __revalOnError = createRscOnErrorHandler(request, cleanPathname, route.pattern);
             const __revalRscStream = renderToReadableStream(__revalElement, { onError: __revalOnError });
             // Tee RSC stream: one for SSR, one to capture rscData
@@ -8318,8 +8318,8 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           });
           const __revalResult = await _runWithUnifiedCtx(__revalUCtx, async () => {
             _ensureFetchPatch();
-            setNavigationContext({ pathname: cleanPathname, searchParams: url.searchParams, params });
-            const __revalElement = await buildPageElement(route, params, undefined, url.searchParams);
+            setNavigationContext({ pathname: cleanPathname, searchParams: new URLSearchParams(), params });
+            const __revalElement = await buildPageElement(route, params, undefined, new URLSearchParams());
             const __revalOnError = createRscOnErrorHandler(request, cleanPathname, route.pattern);
             const __revalRscStream = renderToReadableStream(__revalElement, { onError: __revalOnError });
             // Tee RSC stream: one for SSR, one to capture rscData
@@ -11247,8 +11247,8 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           });
           const __revalResult = await _runWithUnifiedCtx(__revalUCtx, async () => {
             _ensureFetchPatch();
-            setNavigationContext({ pathname: cleanPathname, searchParams: url.searchParams, params });
-            const __revalElement = await buildPageElement(route, params, undefined, url.searchParams);
+            setNavigationContext({ pathname: cleanPathname, searchParams: new URLSearchParams(), params });
+            const __revalElement = await buildPageElement(route, params, undefined, new URLSearchParams());
             const __revalOnError = createRscOnErrorHandler(request, cleanPathname, route.pattern);
             const __revalRscStream = renderToReadableStream(__revalElement, { onError: __revalOnError });
             // Tee RSC stream: one for SSR, one to capture rscData
@@ -14143,8 +14143,8 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           });
           const __revalResult = await _runWithUnifiedCtx(__revalUCtx, async () => {
             _ensureFetchPatch();
-            setNavigationContext({ pathname: cleanPathname, searchParams: url.searchParams, params });
-            const __revalElement = await buildPageElement(route, params, undefined, url.searchParams);
+            setNavigationContext({ pathname: cleanPathname, searchParams: new URLSearchParams(), params });
+            const __revalElement = await buildPageElement(route, params, undefined, new URLSearchParams());
             const __revalOnError = createRscOnErrorHandler(request, cleanPathname, route.pattern);
             const __revalRscStream = renderToReadableStream(__revalElement, { onError: __revalOnError });
             // Tee RSC stream: one for SSR, one to capture rscData
@@ -17349,8 +17349,8 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           });
           const __revalResult = await _runWithUnifiedCtx(__revalUCtx, async () => {
             _ensureFetchPatch();
-            setNavigationContext({ pathname: cleanPathname, searchParams: url.searchParams, params });
-            const __revalElement = await buildPageElement(route, params, undefined, url.searchParams);
+            setNavigationContext({ pathname: cleanPathname, searchParams: new URLSearchParams(), params });
+            const __revalElement = await buildPageElement(route, params, undefined, new URLSearchParams());
             const __revalOnError = createRscOnErrorHandler(request, cleanPathname, route.pattern);
             const __revalRscStream = renderToReadableStream(__revalElement, { onError: __revalOnError });
             // Tee RSC stream: one for SSR, one to capture rscData

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -3636,6 +3636,29 @@ describe("generateRscEntry ISR code generation", () => {
     expect(code).toContain("rscData: __freshRscData");
   });
 
+  it("ISR background regeneration uses empty searchParams, not the triggering user's", () => {
+    const code = generateRscEntry("/tmp/test/app", minimalRoutes);
+
+    // Find the __triggerBackgroundRegeneration callback for stale cache hits
+    const regenIdx = code.indexOf("__triggerBackgroundRegeneration(cleanPathname,");
+    expect(regenIdx).toBeGreaterThan(-1);
+
+    // Extract the regeneration callback body — needs enough chars to cover
+    // the setNavigationContext + buildPageElement calls past the unified
+    // context setup boilerplate.
+    const regenBody = code.slice(regenIdx, regenIdx + 1200);
+
+    // The regeneration must NOT use url.searchParams — that leaks the triggering
+    // user's query params into cached content served to all subsequent users.
+    // Headers are already correctly emptied (new Headers()), searchParams must
+    // get the same treatment.
+    expect(regenBody).not.toContain("url.searchParams");
+
+    // Instead it should use empty URLSearchParams for both setNavigationContext
+    // and buildPageElement
+    expect(regenBody).toContain("new URLSearchParams()");
+  });
+
   it("generated code writes RSC-first partial cache entry on RSC MISS", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes);
     // The RSC-path cache write must store rscData with html:"" as a partial entry.


### PR DESCRIPTION
## Summary

- ISR background regeneration was passing the triggering user's `url.searchParams` into `setNavigationContext()` and `buildPageElement()`, causing cached content to reflect one user's query params and be served to all subsequent users
- Headers were already correctly sanitized (`new Headers()`, `new Map()` for cookies), but `searchParams` was missed
- Replaced `url.searchParams` with `new URLSearchParams()` in both the navigation context and page element builder during background regen

## Test plan

- [x] New test verifying regen callback uses empty `URLSearchParams()` instead of user's params
- [x] All 254 app-router tests pass
- [x] All 32 isr-cache tests pass
- [x] Snapshot updates are mechanical (only the `URLSearchParams` substitution)
- [x] Typecheck and lint clean