### PR TITLE
fix: use closest ancestor parallel slot instead of farthest

### DIFF
--- a/packages/vinext/src/routing/app-router.ts
+++ b/packages/vinext/src/routing/app-router.ts
@@ -658,10 +658,9 @@ function discoverInheritedParallelSlots(
           layoutIndex: lvlLayoutIdx,
           // defaultPath, loadingPath, errorPath, interceptingRoutes remain
         };
-        // Only inherit if we haven't seen this slot at a closer level
-        if (!slotMap.has(slot.name)) {
-          slotMap.set(slot.name, inheritedSlot);
-        }
+        // Iteration goes root-to-leaf, so later (closer) ancestors overwrite
+        // earlier (farther) ones — the closest ancestor's slot wins.
+        slotMap.set(slot.name, inheritedSlot);
       }
     }
   }

--- a/tests/routing.test.ts
+++ b/tests/routing.test.ts
@@ -1230,6 +1230,42 @@ describe("matchAppRoute - URL matching", () => {
     expect(result!.route.pattern).toBe("/auth/:auth-method");
     expect(result!.params["auth-method"]).toBe("google");
   });
+
+  // --- Inherited parallel slot priority ---
+
+  it("closest ancestor parallel slot wins over farthest when same name exists at multiple levels", async () => {
+    await withTempDir("vinext-app-parallel-slot-priority-", async (tmpDir) => {
+      const appDir = path.join(tmpDir, "app");
+
+      // Root-level @sidebar
+      await mkdir(path.join(appDir, "@sidebar"), { recursive: true });
+      await writeFile(path.join(appDir, "@sidebar", "default.tsx"), EMPTY_PAGE);
+      await writeFile(path.join(appDir, "layout.tsx"), EMPTY_PAGE);
+      await writeFile(path.join(appDir, "page.tsx"), EMPTY_PAGE);
+
+      // Dashboard-level @sidebar (closer ancestor to /dashboard/settings)
+      await mkdir(path.join(appDir, "dashboard", "@sidebar"), { recursive: true });
+      await writeFile(path.join(appDir, "dashboard", "@sidebar", "default.tsx"), EMPTY_PAGE);
+      await writeFile(path.join(appDir, "dashboard", "layout.tsx"), EMPTY_PAGE);
+      await writeFile(path.join(appDir, "dashboard", "page.tsx"), EMPTY_PAGE);
+
+      // The leaf route
+      await mkdir(path.join(appDir, "dashboard", "settings"), { recursive: true });
+      await writeFile(path.join(appDir, "dashboard", "settings", "page.tsx"), EMPTY_PAGE);
+
+      invalidateAppRouteCache();
+      const routes = await appRouter(appDir);
+      const settingsRoute = routes.find((r) => r.pattern === "/dashboard/settings");
+      expect(settingsRoute).toBeDefined();
+
+      const sidebarSlot = settingsRoute!.parallelSlots.find((s) => s.name === "sidebar");
+      expect(sidebarSlot).toBeDefined();
+
+      // The dashboard-level @sidebar (closest ancestor) should win
+      expect(sidebarSlot!.defaultPath).not.toBeNull();
+      expect(sidebarSlot!.defaultPath).toContain(path.join("dashboard", "@sidebar"));
+    });
+  });
 });
 
 // --- Pages Router: hyphenated param names ---


### PR DESCRIPTION
## Summary

- `discoverInheritedParallelSlots` iterated root-to-leaf but used `if (!slotMap.has(slot.name))` which made the farthest ancestor's slot win instead of the closest
- For example, with `@sidebar` at both `app/` and `app/dashboard/`, the route `/dashboard/settings` would incorrectly get the root-level sidebar
- Removed the `has()` guard so `slotMap.set()` is called unconditionally for inherited slots — since iteration goes root-to-leaf, later (closer) ancestors naturally overwrite earlier (farther) ones
- One-line fix, consistent with the `isOwnDir` branch which already used unconditional `set()`

## Test plan

- [x] New test with fixture: same `@sidebar` at root and dashboard levels, verifies `/dashboard/settings` gets the dashboard-level slot
- [x] All 128 routing tests pass (91 routing + 37 route-sorting)
- [x] Typecheck and lint clean