### PR TITLE
fix: add ResponseCookies.has() shim

### DIFF
--- a/packages/vinext/src/shims/server.ts
+++ b/packages/vinext/src/shims/server.ts
@@ -442,6 +442,10 @@ export class ResponseCookies {
     return undefined;
   }
 
+  has(name: string): boolean {
+    return this.get(name) !== undefined;
+  }
+
   getAll(): CookieEntry[] {
     const entries: CookieEntry[] = [];
     for (const header of this._headers.getSetCookie()) {

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -3459,6 +3459,17 @@ describe("ResponseCookies API", () => {
     expect(all).toContainEqual({ name: "c", value: "3" });
   });
 
+  it("has() checks whether a response cookie exists", async () => {
+    const { ResponseCookies } = await import("../packages/vinext/src/shims/server.js");
+    const headers = new Headers();
+    const cookies = new ResponseCookies(headers);
+
+    cookies.set("session", "abc");
+
+    expect(cookies.has("session")).toBe(true);
+    expect(cookies.has("missing")).toBe(false);
+  });
+
   it("delete() sets Max-Age=0", async () => {
     const { ResponseCookies } = await import("../packages/vinext/src/shims/server.js");
     const headers = new Headers();


### PR DESCRIPTION
## Summary
This adds the missing `ResponseCookies.has(name)` method to the `next/server` shim and covers it with a regression test.

## What Changed
- added `ResponseCookies.has(name)` in `packages/vinext/src/shims/server.ts`
- added a targeted `ResponseCookies` API test in `tests/shims.test.ts`

## Why It Matters
`RequestCookies` already exposed `has()`, and Next.js documents `NextResponse.cookies.has(name)` as part of the public API. Without this method, middleware code like `response.cookies.has("session")` throws at runtime instead of returning a boolean.

## Risks Or Limits
This is a small shim-surface change. `has()` delegates to `get()`, so it inherits the existing response-cookie parsing behavior rather than introducing a second code path.

## Verification
- `./node_modules/.bin/vp test run tests/shims.test.ts -t "response cookie exists"`
- `./node_modules/.bin/vp test run tests/shims.test.ts -t "ResponseCookies API|response cookie exists"`
- `git diff --check`