### PR TITLE
fix: preserve named has captures in config destinations

### DIFF
--- a/packages/vinext/src/config/config-matchers.ts
+++ b/packages/vinext/src/config/config-matchers.ts
@@ -810,8 +810,8 @@ export function matchRedirect(
         if (!conditionParams) continue;
         // Locale was omitted (the `?` made it optional) — param value is "".
         let dest = substituteDestinationParams(redirect.destination, {
-          ...conditionParams,
           [entry.paramName]: "",
+          ...conditionParams,
         });
         dest = sanitizeDestination(dest);
         localeMatch = { destination: dest, permanent: redirect.permanent };
@@ -840,8 +840,8 @@ export function matchRedirect(
               : _emptyParams();
           if (!conditionParams) continue;
           let dest = substituteDestinationParams(redirect.destination, {
-            ...conditionParams,
             [entry.paramName]: localePart,
+            ...conditionParams,
           });
           dest = sanitizeDestination(dest);
           localeMatch = { destination: dest, permanent: redirect.permanent };

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -4544,6 +4544,34 @@ describe("matchRedirect locale-static index", () => {
     expect(withHeader!.destination).toBe("/en/gated-dest");
   });
 
+  it("lets has captures override locale params in locale-static redirects", async () => {
+    const { matchRedirect } = await import("../packages/vinext/src/config/config-matchers.js");
+    const redirects = [
+      {
+        source: `/:locale(en|fr)?/docs`,
+        destination: `/target/:locale`,
+        permanent: false as const,
+        has: [{ type: "header" as const, key: "x-locale", value: "(?<locale>forced)" }],
+      },
+    ];
+
+    const withLocalePrefix = matchRedirect("/en/docs", redirects, {
+      headers: new Headers({ "x-locale": "forced" }),
+      cookies: {},
+      query: new URLSearchParams(),
+      host: "localhost",
+    });
+    expect(withLocalePrefix).toEqual({ destination: "/target/forced", permanent: false });
+
+    const withoutLocalePrefix = matchRedirect("/docs", redirects, {
+      headers: new Headers({ "x-locale": "forced" }),
+      cookies: {},
+      query: new URLSearchParams(),
+      host: "localhost",
+    });
+    expect(withoutLocalePrefix).toEqual({ destination: "/target/forced", permanent: false });
+  });
+
   it("falls back to linear matching for rules that are not locale-static", async () => {
     const { matchRedirect } = await import("../packages/vinext/src/config/config-matchers.js");
     // A mix: some locale-static rules and one catch-all that matches /other.


### PR DESCRIPTION
## Summary
This preserves named capture groups from `has` conditions when vinext builds redirect and rewrite destinations.

Before this change, a rule could match successfully but still leave placeholders like `:authorized` unresolved in the destination. That diverged from documented Next.js behavior for config redirects and rewrites.

## What Changed
- changed `config-matchers.ts` so satisfied `has` conditions can return captured params instead of only a boolean
- kept `checkHasConditions()` as the boolean wrapper for existing callers
- merged `has` captures into the destination param bag for redirects and rewrites, matching Next.js's route-param-then-has-param merge order
- added regression tests for the documented Next.js cases where `(?<authorized>yes|true)` is reused in redirect and rewrite destinations

## Why It Matters
Redirects and rewrites that depend on captured header, cookie, query, or host values now produce the right destination instead of silently shipping unresolved placeholders.

## Risks Or Limits
- this change is intentionally narrow: `missing` conditions still act only as gates and do not contribute params
- if a `has` capture name collides with a path param, the `has` capture wins, which matches Next.js's current merge order

## Verification
- `vp test run tests/shims.test.ts`
- `vp run typecheck`