### PR TITLE
fix: support @voidzero-dev/vite-plus-core as vite alias

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -289,7 +289,8 @@ function getViteMajorVersion(): number {
     );
     return 7;
   } catch (error) {
-    console.warn("[vinext] Failed to resolve vite/package.json; assuming Vite 7", error);
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(`[vinext] Failed to resolve vite/package.json (${message}); assuming Vite 7`);
     return 7;
   }
 }

--- a/tests/tsconfig-paths-vite8.test.ts
+++ b/tests/tsconfig-paths-vite8.test.ts
@@ -141,6 +141,7 @@ describe("Vite tsconfig paths support", () => {
     const plugins = vinext({ appDir: root });
 
     expect(findNamedPlugin(plugins, "vite-tsconfig-paths")).toBeDefined();
+    expect(warn).toHaveBeenCalledOnce();
     expect(warn).toHaveBeenCalledWith(
       "[vinext] Could not determine Vite major version from @voidzero-dev/vite-plus-core; assuming Vite 7",
     );


### PR DESCRIPTION
https://github.com/voidzero-dev/vite-plus/blob/8c6c1b23f1fe702f21ae72ff96979bfedb66364b/packages/core/package.json#L219-L223

https://github.com/voidzero-dev/vite-plus#manual-installation--migration

> If you are manually migrating a project to Vite+, install these dev dependencies first:
> You need to add overrides to your package manager for vite and vitest so that other packages depending on Vite and Vitest will use the Vite+ versions:

```json
"overrides": {
  "vite": "npm:@voidzero-dev/vite-plus-core@latest",
  "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
}
```