### PR TITLE
fix: add assets.directory to generated wrangler.jsonc

### DIFF
--- a/packages/vinext/src/deploy.ts
+++ b/packages/vinext/src/deploy.ts
@@ -398,6 +398,9 @@ export function generateWranglerConfig(info: ProjectInfo): string {
     compatibility_flags: ["nodejs_compat"],
     main: "./worker/index.ts",
     assets: {
+      // Wrangler 4.69+ requires `directory` when `assets` is an object.
+      // The @cloudflare/vite-plugin always writes static assets to dist/client/.
+      directory: "dist/client",
       not_found_handling: "none",
       // Expose static assets to the Worker via env.ASSETS so the image
       // optimization handler can fetch source images programmatically.

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -302,7 +302,11 @@ describe("generateWranglerConfig", () => {
     expect(parsed.name).toBe(info.projectName);
     expect(parsed.compatibility_flags).toContain("nodejs_compat");
     expect(parsed.main).toBe("./worker/index.ts");
-    expect(parsed.assets).toEqual({ not_found_handling: "none", binding: "ASSETS" });
+    expect(parsed.assets).toEqual({
+      directory: "dist/client",
+      not_found_handling: "none",
+      binding: "ASSETS",
+    });
     expect(parsed.$schema).toBe("node_modules/wrangler/config-schema.json");
   });
 
@@ -339,6 +343,17 @@ describe("generateWranglerConfig", () => {
     const parsed = JSON.parse(config);
 
     expect(parsed.kv_namespaces).toBeUndefined();
+  });
+
+  it("includes assets.directory pointing to dist/client (required by wrangler 4.69+)", () => {
+    mkdir(tmpDir, "app");
+    const info = detectProject(tmpDir);
+    const config = generateWranglerConfig(info);
+    const parsed = JSON.parse(config);
+
+    // Wrangler 4.69+ rejects assets blocks that lack `directory`.
+    // The @cloudflare/vite-plugin always writes static assets to dist/client/.
+    expect(parsed.assets.directory).toBe("dist/client");
   });
 
   it("includes Cloudflare Images binding for image optimization", () => {


### PR DESCRIPTION
## Summary

- Wrangler 4.69+ rejects an `assets` object that lacks a `directory` field, causing `vinext deploy` to fail with: `The 'assets' property in your configuration is missing the required 'directory' property`
- Added `directory: "dist/client"` to the generated `assets` block in `generateWranglerConfig()` — this is always the correct value since `@cloudflare/vite-plugin` unconditionally writes static assets to `dist/client/`
- Updated the existing test asserting the `assets` object shape, and added a dedicated test for the `directory` field

## Notes

- `not_found_handling: "none"` is intentional and unchanged — it ensures unmatched requests fall through to the user Worker (enabling SSR) rather than being handled by the asset worker directly

Fixes #219