### PR TITLE
fix: pass --no-git-checks to pnpm publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -75,7 +75,7 @@ jobs:
         working-directory: packages/vinext
         env:
           NPM_CONFIG_REGISTRY: https://registry.npmjs.org
-        run: vp pm publish --access public -- --provenance
+        run: vp pm publish --no-git-checks --access public -- --provenance
 
       - name: Tag release
         run: |


### PR DESCRIPTION
## Summary

- The publish workflow bumps the version in `package.json` without committing (`--no-git-tag-version`), leaving the working tree dirty. pnpm's `publish` command enforces git-checks by default and refuses to publish in this state (`ERR_PNPM_GIT_UNCLEAN`). This adds `--no-git-checks` before the `--` separator so pnpm skips the check while `--provenance` still passes through to npm.

Fixes: https://github.com/cloudflare/vinext/actions/runs/23191634900/job/67389628516