### PR TITLE
docs: update Vite 8 guidance

### DIFF
--- a/.agents/skills/migrate-to-vinext/SKILL.md
+++ b/.agents/skills/migrate-to-vinext/SKILL.md
@@ -94,6 +94,8 @@ Add `"type": "module"` to package.json. Rename any CJS config files:
 
 See [references/config-examples.md](references/config-examples.md) for config variants per router and deployment target.
 
+If the project already has custom Vite config, prefer Vite 8-native keys when editing it: `oxc`, `optimizeDeps.rolldownOptions`, and `build.rolldownOptions`. Older `esbuild` and `build.rollupOptions` settings still work for now but are migration targets.
+
 **Pages Router (minimal):**
 
 ```ts

--- a/.agents/skills/migrate-to-vinext/references/config-examples.md
+++ b/.agents/skills/migrate-to-vinext/references/config-examples.md
@@ -1,5 +1,7 @@
 # Vite Config Examples
 
+These examples stay minimal on purpose. If you add custom build tuning on Vite 8, prefer `oxc`, `optimizeDeps.rolldownOptions`, and `build.rolldownOptions` / `worker.rolldownOptions` over older `esbuild` and `build.rollupOptions` settings.
+
 ## Pages Router — Local Development
 
 No Cloudflare, no deployment. Simplest possible config.

--- a/.agents/skills/migrate-to-vinext/references/troubleshooting.md
+++ b/.agents/skills/migrate-to-vinext/references/troubleshooting.md
@@ -12,6 +12,20 @@
 | RSC environment crash on dev start            | Native Node module (sharp, satori) loaded in RSC env | vinext auto-stubs these in production; in dev, ensure these are only imported in server code behind dynamic `import()` |
 | `ASSETS binding not found`                    | wrangler.jsonc missing assets config                 | Add `"assets": { "not_found_handling": "none" }` to wrangler.jsonc                                                     |
 
+## Vite 8 Migration Notes
+
+- **Symptom:** deprecation warnings for `esbuild`, `optimizeDeps.esbuildOptions`, or `build.rollupOptions`.
+  **Cause:** Vite 8 now defaults to Oxc and Rolldown.
+  **Fix:** Prefer `oxc`, `optimizeDeps.rolldownOptions`, and `build.rolldownOptions` / `worker.rolldownOptions` in custom Vite config.
+
+- **Symptom:** a package only breaks on Vite 8 with a bad `default` import from CommonJS.
+  **Cause:** Vite 8 made CommonJS default import handling more consistent.
+  **Fix:** Fix the import or package if possible. As a temporary workaround, set `legacy.inconsistentCjsInterop: true`.
+
+- **Symptom:** older browsers stop working after migration.
+  **Cause:** Vite 8 raised the default `build.target` browser baseline.
+  **Fix:** Set `build.target` explicitly in `vite.config.*` if you need older browser support.
+
 ## ESM Conversion Issues
 
 When adding `"type": "module"`, any `.js` file using `module.exports` or `require()` will break. Common files that need renaming to `.cjs`:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -355,6 +355,16 @@ The RSC entry's `default` export is the request handler. The plugin calls it for
 
 You **must** use `createBuilder()` + `builder.buildApp()` for production builds, not `build()` directly. Calling `build()` from the Vite JS API doesn't trigger the RSC plugin's multi-environment build pipeline. `buildApp()` runs the 5-step RSC/SSR/client build sequence in the correct order.
 
+### Vite 8 Defaults
+
+This repo currently resolves `vite` to `@voidzero-dev/vite-plus-core`, which bundles Vite 8. Keep that in mind when touching Vite config or plugin integration code:
+
+- Prefer `oxc` over `esbuild` for new JavaScript transform config
+- Prefer `optimizeDeps.rolldownOptions` over `optimizeDeps.esbuildOptions`
+- Prefer `build.rolldownOptions` / `worker.rolldownOptions` over adding new `*.rollupOptions` config
+- When touching existing `build.rollupOptions` or `manualChunks`, preserve Vite 7 compatibility but treat them as migration targets, not patterns to copy forward
+- If something breaks only on Vite 8, check the newer `build.target` baseline and stricter CommonJS default import behavior first
+
 ### Virtual Module Resolution Quirks
 
 - **Build-time root prefix:** Vite prefixes virtual module IDs with the project root path when resolving SSR build entries. The `resolveId` hook must handle both `virtual:vinext-server-entry` and `<root>/virtual:vinext-server-entry`.

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ This will:
 
 The migration is non-destructive -- your existing Next.js setup continues to work alongside vinext. It does not modify `next.config`, `tsconfig.json`, or any source files, and it does not remove Next.js dependencies.
 
+vinext supports both Vite 7 and Vite 8. If you bring custom Vite config or plugins from an older setup, note that Vite 8 now defaults to Rolldown, Oxc, Lightning CSS, and a newer browser baseline. Prefer `oxc`, `optimizeDeps.rolldownOptions`, and `build.rolldownOptions` over older `esbuild` and `build.rollupOptions` knobs, and override `build.target` if you still need older browsers. If a dependency only breaks on Vite 8 because of stricter CommonJS default import handling, fix the import or use `legacy.inconsistentCjsInterop: true` as a temporary escape hatch. See the [Vite 8 migration guide](https://vite.dev/guide/migration).
+
 ```bash
 npm run dev:vinext    # Start the vinext dev server (port 3001)
 npm run dev           # Still runs Next.js as before
@@ -696,7 +698,7 @@ Or add it to your `package.json` as a file dependency:
 }
 ```
 
-vinext has peer dependencies on `react ^19.2.4`, `react-dom ^19.2.4`, and `vite ^7.0.0`. Then replace `next` with `vinext` in your scripts and run as normal.
+vinext has peer dependencies on `react ^19.2.4`, `react-dom ^19.2.4`, and `vite ^7.0.0 || ^8.0.0`. Then replace `next` with `vinext` in your scripts and run as normal.
 
 ## Contributing
 

--- a/tests/tsconfig-paths-vite8.test.ts
+++ b/tests/tsconfig-paths-vite8.test.ts
@@ -52,7 +52,7 @@ describe("Vite tsconfig paths support", () => {
   });
 
   it("uses resolve.tsconfigPaths on Vite 8 instead of vite-tsconfig-paths", async () => {
-    const root = setupProject({ name: "vite", version: "8.0.0-beta.18" });
+    const root = setupProject({ name: "vite", version: "8.0.0" });
     process.chdir(root);
 
     const plugins = vinext({ appDir: root });
@@ -78,7 +78,7 @@ describe("Vite tsconfig paths support", () => {
   });
 
   it("does not override user-defined resolve.tsconfigPaths on Vite 8", async () => {
-    const root = setupProject({ name: "vite", version: "8.0.0-beta.18" });
+    const root = setupProject({ name: "vite", version: "8.0.0" });
     process.chdir(root);
 
     const plugins = vinext({ appDir: root });


### PR DESCRIPTION
## Summary
- add Vite 8 guidance to the README, agent instructions, and migration skill docs
- call out Rolldown/Oxc-era config recommendations and common migration gotchas
- update the Vite 8 tsconfig-paths test to use the stable release version

## Testing
- pnpm test tests/tsconfig-paths-vite8.test.ts