### PR TITLE
fix: validate attribute names in next/head SSR serializer

### DIFF
--- a/packages/vinext/src/shims/head.ts
+++ b/packages/vinext/src/shims/head.ts
@@ -181,6 +181,22 @@ export function reduceHeadChildren(headChildren: React.ReactNode[]): React.React
 }
 
 /**
+ * Validate an HTML attribute name. Rejects names that could break out of
+ * the attribute context during SSR serialization, or that represent inline
+ * event handlers (on*). Only allows alphanumeric characters, hyphens, and
+ * common data-attribute patterns.
+ */
+const SAFE_ATTR_NAME_RE = /^[a-zA-Z][a-zA-Z0-9\-:.]*$/;
+
+export function isSafeAttrName(name: string): boolean {
+  if (!SAFE_ATTR_NAME_RE.test(name)) return false;
+  // Block inline event handlers (onclick, onerror, etc.)
+  if (name.length > 2 && name[0] === "o" && name[1] === "n" && name[2] >= "A" && name[2] <= "z")
+    return false;
+  return true;
+}
+
+/**
  * Convert a React element to an HTML string for SSR head injection.
  * Returns an empty string for disallowed tag types.
  */
@@ -211,8 +227,10 @@ function reactElementToHTML(child: React.ReactElement): string {
     } else if (key === "className") {
       attrs.push(`class="${escapeAttr(String(value))}"`);
     } else if (typeof value === "string") {
+      if (!isSafeAttrName(key)) continue;
       attrs.push(`${key}="${escapeAttr(value)}"`);
     } else if (typeof value === "boolean" && value) {
+      if (!isSafeAttrName(key)) continue;
       attrs.push(key);
     }
   }
@@ -280,8 +298,10 @@ function syncClientHead(): void {
       } else if (key === "className") {
         domEl.setAttribute("class", String(value));
       } else if (typeof value === "boolean" && value) {
+        if (!isSafeAttrName(key)) continue;
         domEl.setAttribute(key, "");
       } else if (key !== "children" && typeof value === "string") {
+        if (!isSafeAttrName(key)) continue;
         domEl.setAttribute(key, value);
       }
     }

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -10758,3 +10758,73 @@ describe("shim alias map .js variants", () => {
     expect(missing, `Missing .js aliases for: ${missing.join(", ")}`).toEqual([]);
   });
 });
+
+// ── next/head attribute name validation ─────────────────────────────────────
+
+describe("isSafeAttrName", () => {
+  let isSafeAttrName: (name: string) => boolean;
+
+  beforeEach(async () => {
+    const mod = await import("../packages/vinext/src/shims/head.js");
+    isSafeAttrName = mod.isSafeAttrName;
+  });
+
+  it("allows standard HTML attribute names", () => {
+    expect(isSafeAttrName("name")).toBe(true);
+    expect(isSafeAttrName("content")).toBe(true);
+    expect(isSafeAttrName("charset")).toBe(true);
+    expect(isSafeAttrName("http-equiv")).toBe(true);
+    expect(isSafeAttrName("data-testid")).toBe(true);
+    expect(isSafeAttrName("property")).toBe(true);
+    expect(isSafeAttrName("rel")).toBe(true);
+    expect(isSafeAttrName("href")).toBe(true);
+    expect(isSafeAttrName("crossOrigin")).toBe(true);
+  });
+
+  it("allows xml-namespaced attributes", () => {
+    expect(isSafeAttrName("xml:lang")).toBe(true);
+    expect(isSafeAttrName("xlink:href")).toBe(true);
+  });
+
+  it("rejects attribute names containing quotes", () => {
+    expect(isSafeAttrName('x"')).toBe(false);
+    expect(isSafeAttrName("x'")).toBe(false);
+  });
+
+  it("rejects attribute names containing angle brackets", () => {
+    expect(isSafeAttrName("x>")).toBe(false);
+    expect(isSafeAttrName("x<script")).toBe(false);
+  });
+
+  it("rejects attribute names containing slashes", () => {
+    expect(isSafeAttrName("x/")).toBe(false);
+    expect(isSafeAttrName('x"/><script>alert(1)</script><meta a="')).toBe(false);
+  });
+
+  it("rejects attribute names containing spaces", () => {
+    expect(isSafeAttrName("x y")).toBe(false);
+    expect(isSafeAttrName("x\ty")).toBe(false);
+  });
+
+  it("rejects attribute names containing equals", () => {
+    expect(isSafeAttrName("x=y")).toBe(false);
+  });
+
+  it("rejects inline event handler attributes", () => {
+    expect(isSafeAttrName("onclick")).toBe(false);
+    expect(isSafeAttrName("onerror")).toBe(false);
+    expect(isSafeAttrName("onload")).toBe(false);
+    expect(isSafeAttrName("onmouseover")).toBe(false);
+  });
+
+  it("allows attributes starting with 'o' that are not event handlers", () => {
+    expect(isSafeAttrName("open")).toBe(true);
+    expect(isSafeAttrName("og:title")).toBe(true);
+  });
+
+  it("rejects empty or non-alpha-starting names", () => {
+    expect(isSafeAttrName("")).toBe(false);
+    expect(isSafeAttrName("123")).toBe(false);
+    expect(isSafeAttrName("-foo")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- The head.ts SSR serializer was interpolating attribute names directly into HTML without validation. Only attribute values were escaped via `escapeAttr()`.
- Adds `isSafeAttrName()` that validates attribute names against a strict regex (alphanumeric, hyphens, colons, dots) and blocks inline event handler attributes (`on*`).
- Applied in both the SSR `reactElementToHTML()` path and the client-side `syncClientHead()` path.

## Details

Previously, attribute names from React element props were used verbatim in the SSR HTML output. If application code spread an object with arbitrary keys onto a JSX element inside `<Head>`, those keys would appear unescaped in the rendered HTML. The new validation rejects names containing characters that could break the attribute context (`<`, `>`, `"`, `/`, `=`, spaces) and blocks `on*` event handler attributes.

Standard HTML attributes like `name`, `content`, `http-equiv`, `data-*`, and XML-namespaced attributes like `xml:lang` continue to work normally.

Also adds unit tests covering allowed names, rejected names, event handlers, and edge cases.