### PR TITLE
fix: strip Set-Cookie headers from fetch cache entries

### DIFF
--- a/packages/vinext/src/shims/fetch-cache.ts
+++ b/packages/vinext/src/shims/fetch-cache.ts
@@ -641,6 +641,7 @@ function createPatchedFetch(): typeof globalThis.fetch {
               const freshBody = await freshResp.text();
               const freshHeaders: Record<string, string> = {};
               freshResp.headers.forEach((v, k) => {
+                if (k.toLowerCase() === "set-cookie") return;
                 freshHeaders[k] = v;
               });
 
@@ -723,6 +724,9 @@ function createPatchedFetch(): typeof globalThis.fetch {
       const body = await cloned.text();
       const headers: Record<string, string> = {};
       cloned.headers.forEach((v, k) => {
+        // Never cache Set-Cookie headers — they are per-user and must not
+        // be replayed to subsequent requests from different users.
+        if (k.toLowerCase() === "set-cookie") return;
         headers[k] = v;
       });
 

--- a/tests/fetch-cache.test.ts
+++ b/tests/fetch-cache.test.ts
@@ -2019,4 +2019,35 @@ describe("fetch cache shim", () => {
       expect(fetchMock).toHaveBeenCalledTimes(2);
     });
   });
+
+  // ── Set-Cookie stripping from cached responses ──────────────────────────
+
+  describe("Set-Cookie header stripping", () => {
+    it("does not include Set-Cookie in cached response headers", async () => {
+      fetchMock.mockImplementationOnce(async () => {
+        return new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+            "set-cookie": "session=abc123; Path=/; HttpOnly",
+            "x-custom": "keep-me",
+          },
+        });
+      });
+
+      // First request — response has Set-Cookie
+      const res1 = await fetch("https://api.example.com/set-cookie-test", {
+        next: { revalidate: 300 },
+      });
+      expect(res1.headers.get("set-cookie")).toBe("session=abc123; Path=/; HttpOnly");
+      expect(res1.headers.get("x-custom")).toBe("keep-me");
+
+      // Second request — served from cache, Set-Cookie must be absent
+      const res2 = await fetch("https://api.example.com/set-cookie-test", {
+        next: { revalidate: 300 },
+      });
+      expect(res2.headers.get("set-cookie")).toBeNull();
+      expect(res2.headers.get("x-custom")).toBe("keep-me");
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Fetch cache entries now exclude `Set-Cookie` response headers before storing.
- Both the primary cache write path and the stale-while-revalidate background refresh path are fixed.
- Adds a test verifying that the original response retains `Set-Cookie` but the cached response does not.

## Details

When storing fetch responses in the cache, all response headers were included without filtering. `Set-Cookie` is a per-response header that should not persist in cache entries, since cached responses are shared across requests. The original (non-cached) response still includes the `Set-Cookie` header as expected.

Other non-cacheable headers like `content-type` and custom headers are preserved in the cache.