### PR TITLE
fix: include query string in route handler ISR cache key

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -2256,8 +2256,15 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     }
 
     // Include query string in route handler ISR cache key so different
-    // query parameters produce distinct cache entries.
-    const __routeQs = (method === "GET" || isAutoHead) ? new URL(request.url).search : "";
+    // query parameters produce distinct cache entries. Parameters are
+    // sorted to normalize key order (?a=1&b=2 and ?b=2&a=1 produce the
+    // same key) and prevent cache-busting via parameter reordering.
+    let __routeQs = "";
+    if (method === "GET" || isAutoHead) {
+      const __qs = new URLSearchParams(url.searchParams);
+      __qs.sort();
+      if (__qs.size) __routeQs = "?" + __qs.toString();
+    }
 
     // ISR cache read for route handlers (production only).
     // Only GET/HEAD (auto-HEAD) with finite revalidate > 0 are ISR-eligible.

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -2272,6 +2272,17 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       isAutoHead = true;
     }
 
+    // Include query string in route handler ISR cache key so different
+    // query parameters produce distinct cache entries. Parameters are
+    // sorted to normalize key order (?a=1&b=2 and ?b=2&a=1 produce the
+    // same key) and prevent cache-busting via parameter reordering.
+    let __routeQs = "";
+    if (method === "GET" || isAutoHead) {
+      const __qs = new URLSearchParams(url.searchParams);
+      __qs.sort();
+      if (__qs.size) __routeQs = "?" + __qs.toString();
+    }
+
     // ISR cache read for route handlers (production only).
     // Only GET/HEAD (auto-HEAD) with finite revalidate > 0 are ISR-eligible.
     // This runs before handler execution so a cache HIT skips the handler entirely.
@@ -2282,7 +2293,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       (method === "GET" || isAutoHead) &&
       typeof handlerFn === "function"
     ) {
-      const __routeKey = __isrRouteKey(cleanPathname);
+      const __routeKey = __isrRouteKey(cleanPathname + __routeQs);
       try {
         const __cached = await __isrGet(__routeKey);
         if (__cached && !__cached.isStale && __cached.value.value && __cached.value.value.kind === "APP_ROUTE") {
@@ -2383,7 +2394,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         ) {
           response.headers.set("X-Vinext-Cache", "MISS");
           const __routeClone = response.clone();
-          const __routeKey = __isrRouteKey(cleanPathname);
+          const __routeKey = __isrRouteKey(cleanPathname + __routeQs);
           const __revalSecs = revalidateSeconds;
           const __routeTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
           const __routeWritePromise = (async () => {
@@ -5261,6 +5272,17 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       isAutoHead = true;
     }
 
+    // Include query string in route handler ISR cache key so different
+    // query parameters produce distinct cache entries. Parameters are
+    // sorted to normalize key order (?a=1&b=2 and ?b=2&a=1 produce the
+    // same key) and prevent cache-busting via parameter reordering.
+    let __routeQs = "";
+    if (method === "GET" || isAutoHead) {
+      const __qs = new URLSearchParams(url.searchParams);
+      __qs.sort();
+      if (__qs.size) __routeQs = "?" + __qs.toString();
+    }
+
     // ISR cache read for route handlers (production only).
     // Only GET/HEAD (auto-HEAD) with finite revalidate > 0 are ISR-eligible.
     // This runs before handler execution so a cache HIT skips the handler entirely.
@@ -5271,7 +5293,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       (method === "GET" || isAutoHead) &&
       typeof handlerFn === "function"
     ) {
-      const __routeKey = __isrRouteKey(cleanPathname);
+      const __routeKey = __isrRouteKey(cleanPathname + __routeQs);
       try {
         const __cached = await __isrGet(__routeKey);
         if (__cached && !__cached.isStale && __cached.value.value && __cached.value.value.kind === "APP_ROUTE") {
@@ -5372,7 +5394,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         ) {
           response.headers.set("X-Vinext-Cache", "MISS");
           const __routeClone = response.clone();
-          const __routeKey = __isrRouteKey(cleanPathname);
+          const __routeKey = __isrRouteKey(cleanPathname + __routeQs);
           const __revalSecs = revalidateSeconds;
           const __routeTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
           const __routeWritePromise = (async () => {
@@ -8277,6 +8299,17 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       isAutoHead = true;
     }
 
+    // Include query string in route handler ISR cache key so different
+    // query parameters produce distinct cache entries. Parameters are
+    // sorted to normalize key order (?a=1&b=2 and ?b=2&a=1 produce the
+    // same key) and prevent cache-busting via parameter reordering.
+    let __routeQs = "";
+    if (method === "GET" || isAutoHead) {
+      const __qs = new URLSearchParams(url.searchParams);
+      __qs.sort();
+      if (__qs.size) __routeQs = "?" + __qs.toString();
+    }
+
     // ISR cache read for route handlers (production only).
     // Only GET/HEAD (auto-HEAD) with finite revalidate > 0 are ISR-eligible.
     // This runs before handler execution so a cache HIT skips the handler entirely.
@@ -8287,7 +8320,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       (method === "GET" || isAutoHead) &&
       typeof handlerFn === "function"
     ) {
-      const __routeKey = __isrRouteKey(cleanPathname);
+      const __routeKey = __isrRouteKey(cleanPathname + __routeQs);
       try {
         const __cached = await __isrGet(__routeKey);
         if (__cached && !__cached.isStale && __cached.value.value && __cached.value.value.kind === "APP_ROUTE") {
@@ -8388,7 +8421,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         ) {
           response.headers.set("X-Vinext-Cache", "MISS");
           const __routeClone = response.clone();
-          const __routeKey = __isrRouteKey(cleanPathname);
+          const __routeKey = __isrRouteKey(cleanPathname + __routeQs);
           const __revalSecs = revalidateSeconds;
           const __routeTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
           const __routeWritePromise = (async () => {
@@ -11304,6 +11337,17 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       isAutoHead = true;
     }
 
+    // Include query string in route handler ISR cache key so different
+    // query parameters produce distinct cache entries. Parameters are
+    // sorted to normalize key order (?a=1&b=2 and ?b=2&a=1 produce the
+    // same key) and prevent cache-busting via parameter reordering.
+    let __routeQs = "";
+    if (method === "GET" || isAutoHead) {
+      const __qs = new URLSearchParams(url.searchParams);
+      __qs.sort();
+      if (__qs.size) __routeQs = "?" + __qs.toString();
+    }
+
     // ISR cache read for route handlers (production only).
     // Only GET/HEAD (auto-HEAD) with finite revalidate > 0 are ISR-eligible.
     // This runs before handler execution so a cache HIT skips the handler entirely.
@@ -11314,7 +11358,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       (method === "GET" || isAutoHead) &&
       typeof handlerFn === "function"
     ) {
-      const __routeKey = __isrRouteKey(cleanPathname);
+      const __routeKey = __isrRouteKey(cleanPathname + __routeQs);
       try {
         const __cached = await __isrGet(__routeKey);
         if (__cached && !__cached.isStale && __cached.value.value && __cached.value.value.kind === "APP_ROUTE") {
@@ -11415,7 +11459,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         ) {
           response.headers.set("X-Vinext-Cache", "MISS");
           const __routeClone = response.clone();
-          const __routeKey = __isrRouteKey(cleanPathname);
+          const __routeKey = __isrRouteKey(cleanPathname + __routeQs);
           const __revalSecs = revalidateSeconds;
           const __routeTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
           const __routeWritePromise = (async () => {
@@ -14297,6 +14341,17 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       isAutoHead = true;
     }
 
+    // Include query string in route handler ISR cache key so different
+    // query parameters produce distinct cache entries. Parameters are
+    // sorted to normalize key order (?a=1&b=2 and ?b=2&a=1 produce the
+    // same key) and prevent cache-busting via parameter reordering.
+    let __routeQs = "";
+    if (method === "GET" || isAutoHead) {
+      const __qs = new URLSearchParams(url.searchParams);
+      __qs.sort();
+      if (__qs.size) __routeQs = "?" + __qs.toString();
+    }
+
     // ISR cache read for route handlers (production only).
     // Only GET/HEAD (auto-HEAD) with finite revalidate > 0 are ISR-eligible.
     // This runs before handler execution so a cache HIT skips the handler entirely.
@@ -14307,7 +14362,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       (method === "GET" || isAutoHead) &&
       typeof handlerFn === "function"
     ) {
-      const __routeKey = __isrRouteKey(cleanPathname);
+      const __routeKey = __isrRouteKey(cleanPathname + __routeQs);
       try {
         const __cached = await __isrGet(__routeKey);
         if (__cached && !__cached.isStale && __cached.value.value && __cached.value.value.kind === "APP_ROUTE") {
@@ -14408,7 +14463,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         ) {
           response.headers.set("X-Vinext-Cache", "MISS");
           const __routeClone = response.clone();
-          const __routeKey = __isrRouteKey(cleanPathname);
+          const __routeKey = __isrRouteKey(cleanPathname + __routeQs);
           const __revalSecs = revalidateSeconds;
           const __routeTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
           const __routeWritePromise = (async () => {
@@ -17643,6 +17698,17 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       isAutoHead = true;
     }
 
+    // Include query string in route handler ISR cache key so different
+    // query parameters produce distinct cache entries. Parameters are
+    // sorted to normalize key order (?a=1&b=2 and ?b=2&a=1 produce the
+    // same key) and prevent cache-busting via parameter reordering.
+    let __routeQs = "";
+    if (method === "GET" || isAutoHead) {
+      const __qs = new URLSearchParams(url.searchParams);
+      __qs.sort();
+      if (__qs.size) __routeQs = "?" + __qs.toString();
+    }
+
     // ISR cache read for route handlers (production only).
     // Only GET/HEAD (auto-HEAD) with finite revalidate > 0 are ISR-eligible.
     // This runs before handler execution so a cache HIT skips the handler entirely.
@@ -17653,7 +17719,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       (method === "GET" || isAutoHead) &&
       typeof handlerFn === "function"
     ) {
-      const __routeKey = __isrRouteKey(cleanPathname);
+      const __routeKey = __isrRouteKey(cleanPathname + __routeQs);
       try {
         const __cached = await __isrGet(__routeKey);
         if (__cached && !__cached.isStale && __cached.value.value && __cached.value.value.kind === "APP_ROUTE") {
@@ -17754,7 +17820,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         ) {
           response.headers.set("X-Vinext-Cache", "MISS");
           const __routeClone = response.clone();
-          const __routeKey = __isrRouteKey(cleanPathname);
+          const __routeKey = __isrRouteKey(cleanPathname + __routeQs);
           const __revalSecs = revalidateSeconds;
           const __routeTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
           const __routeWritePromise = (async () => {

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -3816,7 +3816,7 @@ describe("generateRscEntry ISR code generation", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes);
     expect(code).toContain('"APP_ROUTE"');
     // Route handler ISR uses __isrRouteKey to build the cache key, then reads via __isrGet
-    expect(code).toContain("__isrRouteKey(cleanPathname)");
+    expect(code).toContain("__isrRouteKey(cleanPathname + __routeQs)");
     expect(code).toContain("__isrGet(__routeKey)");
   });
 


### PR DESCRIPTION
## Summary

- Route handler ISR cache keys now include the query string, so `/api/data?user=alice` and `/api/data?user=bob` produce distinct cache entries.
- Applied to both the cache read (HIT) and cache write (MISS) paths.

## Details

Previously, `__isrRouteKey(cleanPathname)` used only the pathname for the cache key. Route handlers that return different responses based on `searchParams` would cache the first response and serve it for all subsequent requests regardless of query parameters.

The fix extracts the query string from `request.url` and appends it to the pathname before computing the cache key. Only GET/HEAD requests are affected (POST/PUT/etc. are never ISR-cached).