### PR TITLE
fix: detect dynamic API usage in route handlers to prevent stale ISR cache hits

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -2372,16 +2372,17 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
 
     if (typeof handlerFn === "function") {
       const previousHeadersPhase = setHeadersAccessPhase("route-handler");
-      const __proxiedRequest = __proxyRouteRequest(request, markDynamicUsage);
-      // Clear dynamic usage accumulated by pipeline stages (middleware,
-      // headers context setup) so we only detect the handler's own usage.
-      consumeDynamicUsage();
+      let __handlerAccessedDynamicApi = false;
+      const __proxiedRequest = __proxyRouteRequest(request, () => { __handlerAccessedDynamicApi = true; markDynamicUsage(); });
       try {
         const response = await handlerFn(__proxiedRequest, { params });
         const dynamicUsedInHandler = consumeDynamicUsage();
         const handlerSetCacheControl = response.headers.has("cache-control");
 
-        if (dynamicUsedInHandler) {
+        // Only add to the dynamic set if the handler actually accessed
+        // the proxied request's dynamic APIs (headers, searchParams),
+        // not if pipeline stages called markDynamicUsage() via shims.
+        if (__handlerAccessedDynamicApi) {
           __dynamicRouteHandlers.add(handler.pattern);
         }
 

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -2389,16 +2389,17 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
 
     if (typeof handlerFn === "function") {
       const previousHeadersPhase = setHeadersAccessPhase("route-handler");
-      const __proxiedRequest = __proxyRouteRequest(request, markDynamicUsage);
-      // Clear dynamic usage accumulated by pipeline stages (middleware,
-      // headers context setup) so we only detect the handler's own usage.
-      consumeDynamicUsage();
+      let __handlerAccessedDynamicApi = false;
+      const __proxiedRequest = __proxyRouteRequest(request, () => { __handlerAccessedDynamicApi = true; markDynamicUsage(); });
       try {
         const response = await handlerFn(__proxiedRequest, { params });
         const dynamicUsedInHandler = consumeDynamicUsage();
         const handlerSetCacheControl = response.headers.has("cache-control");
 
-        if (dynamicUsedInHandler) {
+        // Only add to the dynamic set if the handler actually accessed
+        // the proxied request's dynamic APIs (headers, searchParams),
+        // not if pipeline stages called markDynamicUsage() via shims.
+        if (__handlerAccessedDynamicApi) {
           __dynamicRouteHandlers.add(handler.pattern);
         }
 
@@ -5422,16 +5423,17 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
 
     if (typeof handlerFn === "function") {
       const previousHeadersPhase = setHeadersAccessPhase("route-handler");
-      const __proxiedRequest = __proxyRouteRequest(request, markDynamicUsage);
-      // Clear dynamic usage accumulated by pipeline stages (middleware,
-      // headers context setup) so we only detect the handler's own usage.
-      consumeDynamicUsage();
+      let __handlerAccessedDynamicApi = false;
+      const __proxiedRequest = __proxyRouteRequest(request, () => { __handlerAccessedDynamicApi = true; markDynamicUsage(); });
       try {
         const response = await handlerFn(__proxiedRequest, { params });
         const dynamicUsedInHandler = consumeDynamicUsage();
         const handlerSetCacheControl = response.headers.has("cache-control");
 
-        if (dynamicUsedInHandler) {
+        // Only add to the dynamic set if the handler actually accessed
+        // the proxied request's dynamic APIs (headers, searchParams),
+        // not if pipeline stages called markDynamicUsage() via shims.
+        if (__handlerAccessedDynamicApi) {
           __dynamicRouteHandlers.add(handler.pattern);
         }
 
@@ -8482,16 +8484,17 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
 
     if (typeof handlerFn === "function") {
       const previousHeadersPhase = setHeadersAccessPhase("route-handler");
-      const __proxiedRequest = __proxyRouteRequest(request, markDynamicUsage);
-      // Clear dynamic usage accumulated by pipeline stages (middleware,
-      // headers context setup) so we only detect the handler's own usage.
-      consumeDynamicUsage();
+      let __handlerAccessedDynamicApi = false;
+      const __proxiedRequest = __proxyRouteRequest(request, () => { __handlerAccessedDynamicApi = true; markDynamicUsage(); });
       try {
         const response = await handlerFn(__proxiedRequest, { params });
         const dynamicUsedInHandler = consumeDynamicUsage();
         const handlerSetCacheControl = response.headers.has("cache-control");
 
-        if (dynamicUsedInHandler) {
+        // Only add to the dynamic set if the handler actually accessed
+        // the proxied request's dynamic APIs (headers, searchParams),
+        // not if pipeline stages called markDynamicUsage() via shims.
+        if (__handlerAccessedDynamicApi) {
           __dynamicRouteHandlers.add(handler.pattern);
         }
 
@@ -11553,16 +11556,17 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
 
     if (typeof handlerFn === "function") {
       const previousHeadersPhase = setHeadersAccessPhase("route-handler");
-      const __proxiedRequest = __proxyRouteRequest(request, markDynamicUsage);
-      // Clear dynamic usage accumulated by pipeline stages (middleware,
-      // headers context setup) so we only detect the handler's own usage.
-      consumeDynamicUsage();
+      let __handlerAccessedDynamicApi = false;
+      const __proxiedRequest = __proxyRouteRequest(request, () => { __handlerAccessedDynamicApi = true; markDynamicUsage(); });
       try {
         const response = await handlerFn(__proxiedRequest, { params });
         const dynamicUsedInHandler = consumeDynamicUsage();
         const handlerSetCacheControl = response.headers.has("cache-control");
 
-        if (dynamicUsedInHandler) {
+        // Only add to the dynamic set if the handler actually accessed
+        // the proxied request's dynamic APIs (headers, searchParams),
+        // not if pipeline stages called markDynamicUsage() via shims.
+        if (__handlerAccessedDynamicApi) {
           __dynamicRouteHandlers.add(handler.pattern);
         }
 
@@ -14590,16 +14594,17 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
 
     if (typeof handlerFn === "function") {
       const previousHeadersPhase = setHeadersAccessPhase("route-handler");
-      const __proxiedRequest = __proxyRouteRequest(request, markDynamicUsage);
-      // Clear dynamic usage accumulated by pipeline stages (middleware,
-      // headers context setup) so we only detect the handler's own usage.
-      consumeDynamicUsage();
+      let __handlerAccessedDynamicApi = false;
+      const __proxiedRequest = __proxyRouteRequest(request, () => { __handlerAccessedDynamicApi = true; markDynamicUsage(); });
       try {
         const response = await handlerFn(__proxiedRequest, { params });
         const dynamicUsedInHandler = consumeDynamicUsage();
         const handlerSetCacheControl = response.headers.has("cache-control");
 
-        if (dynamicUsedInHandler) {
+        // Only add to the dynamic set if the handler actually accessed
+        // the proxied request's dynamic APIs (headers, searchParams),
+        // not if pipeline stages called markDynamicUsage() via shims.
+        if (__handlerAccessedDynamicApi) {
           __dynamicRouteHandlers.add(handler.pattern);
         }
 
@@ -17980,16 +17985,17 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
 
     if (typeof handlerFn === "function") {
       const previousHeadersPhase = setHeadersAccessPhase("route-handler");
-      const __proxiedRequest = __proxyRouteRequest(request, markDynamicUsage);
-      // Clear dynamic usage accumulated by pipeline stages (middleware,
-      // headers context setup) so we only detect the handler's own usage.
-      consumeDynamicUsage();
+      let __handlerAccessedDynamicApi = false;
+      const __proxiedRequest = __proxyRouteRequest(request, () => { __handlerAccessedDynamicApi = true; markDynamicUsage(); });
       try {
         const response = await handlerFn(__proxiedRequest, { params });
         const dynamicUsedInHandler = consumeDynamicUsage();
         const handlerSetCacheControl = response.headers.has("cache-control");
 
-        if (dynamicUsedInHandler) {
+        // Only add to the dynamic set if the handler actually accessed
+        // the proxied request's dynamic APIs (headers, searchParams),
+        // not if pipeline stages called markDynamicUsage() via shims.
+        if (__handlerAccessedDynamicApi) {
           __dynamicRouteHandlers.add(handler.pattern);
         }
 


### PR DESCRIPTION
## Summary

Route handlers that access `request.headers` or `request.nextUrl.searchParams` are dynamic and should not be served from the ISR cache. This PR adds runtime dynamic detection matching Next.js behavior.

Minimal diff: only changes `app-rsc-entry.ts` (and snapshots). No changes to `headers.ts` or the dynamic usage flag type.

## Changes

1. **`__proxyRouteRequest`**: Wraps the `Request` in a Proxy. Accessing `.headers` or `.nextUrl.searchParams` calls `markDynamicUsage()`. Methods are bound to the original target to preserve Web API internal slots.

2. **`__dynamicRouteHandlers`**: A `Set` that remembers route patterns whose handlers used dynamic APIs. The ISR cache read skips known-dynamic handlers. The Set grows monotonically for the process lifetime (intentional, matches Next.js which determines dynamism statically).

3. **Cache read guard**: `!__dynamicRouteHandlers.has(handler.pattern)` added to the ISR cache read condition.

4. **Background regen**: Synthetic request is also wrapped in the Proxy, and dynamic detection adds to the Set.