### PR TITLE
fix: skip ISR cache write for RSC requests when dynamic APIs are used

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -2973,12 +2973,18 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     // The RSC stream is consumed lazily - components render when chunks are read.
     // If we clear context now, headers()/cookies() will fail during rendering.
     // Context will be cleared when the next request starts (via runWithRequestContext).
+
+    // Check if any dynamic API was used during element construction (e.g.
+    // searchParams access in buildPageElement). Dynamic pages must not be
+    // ISR-cached — this mirrors the HTML path's consumeDynamicUsage() check.
+    const __dynamicUsedInRsc = consumeDynamicUsage();
+
     const responseHeaders = { "Content-Type": "text/x-component; charset=utf-8", "Vary": "RSC, Accept" };
     // Include matched route params so the client can hydrate useParams()
     if (params && Object.keys(params).length > 0) {
       responseHeaders["X-Vinext-Params"] = JSON.stringify(params);
     }
-    if (isForceDynamic) {
+    if (isForceDynamic || __dynamicUsedInRsc) {
       responseHeaders["Cache-Control"] = "no-store, must-revalidate";
     } else if ((isForceStatic || isDynamicError) && !revalidateSeconds) {
       responseHeaders["Cache-Control"] = "s-maxage=31536000, stale-while-revalidate";
@@ -3038,7 +3044,8 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     // For ISR-eligible RSC requests in production: write rscData to its own key.
     // HTML is stored under a separate key (written by the HTML path below) so
     // these writes never race or clobber each other.
-    if (process.env.NODE_ENV === "production" && __isrRscDataPromise) {
+    // Skip when dynamic APIs were used — the page opted into dynamic rendering.
+    if (process.env.NODE_ENV === "production" && __isrRscDataPromise && !__dynamicUsedInRsc) {
       responseHeaders["X-Vinext-Cache"] = "MISS";
       const __isrKeyRsc = __isrRscKey(cleanPathname);
       const __revalSecsRsc = revalidateSeconds;

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -3045,6 +3045,10 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     // HTML is stored under a separate key (written by the HTML path below) so
     // these writes never race or clobber each other.
     // Skip when dynamic APIs were used — the page opted into dynamic rendering.
+    // Two-phase check: __dynamicUsedInRsc catches APIs called during element
+    // construction (e.g. searchParams access). The deferred consumeDynamicUsage()
+    // inside the write promise catches APIs called during stream rendering
+    // (e.g. headers(), cookies(), noStore()) which fire after the response is sent.
     if (process.env.NODE_ENV === "production" && __isrRscDataPromise && !__dynamicUsedInRsc) {
       responseHeaders["X-Vinext-Cache"] = "MISS";
       const __isrKeyRsc = __isrRscKey(cleanPathname);
@@ -3052,6 +3056,10 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       const __rscWritePromise = (async () => {
         try {
           const __rscDataForCache = await __isrRscDataPromise;
+          if (consumeDynamicUsage()) {
+            __isrDebug?.("RSC cache write skipped (dynamic usage during render)", __isrKeyRsc);
+            return;
+          }
           const __pageTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
           await __isrSet(__isrKeyRsc, { kind: "APP_PAGE", html: "", rscData: __rscDataForCache, headers: undefined, postponed: undefined, status: 200 }, __revalSecsRsc, __pageTags);
           __isrDebug?.("RSC cache written", __isrKeyRsc);

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -2659,12 +2659,18 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     // The RSC stream is consumed lazily - components render when chunks are read.
     // If we clear context now, headers()/cookies() will fail during rendering.
     // Context will be cleared when the next request starts (via runWithRequestContext).
+
+    // Check if any dynamic API was used during element construction (e.g.
+    // searchParams access in buildPageElement). Dynamic pages must not be
+    // ISR-cached — this mirrors the HTML path's consumeDynamicUsage() check.
+    const __dynamicUsedInRsc = consumeDynamicUsage();
+
     const responseHeaders = { "Content-Type": "text/x-component; charset=utf-8", "Vary": "RSC, Accept" };
     // Include matched route params so the client can hydrate useParams()
     if (params && Object.keys(params).length > 0) {
       responseHeaders["X-Vinext-Params"] = JSON.stringify(params);
     }
-    if (isForceDynamic) {
+    if (isForceDynamic || __dynamicUsedInRsc) {
       responseHeaders["Cache-Control"] = "no-store, must-revalidate";
     } else if ((isForceStatic || isDynamicError) && !revalidateSeconds) {
       responseHeaders["Cache-Control"] = "s-maxage=31536000, stale-while-revalidate";
@@ -2724,13 +2730,22 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     // For ISR-eligible RSC requests in production: write rscData to its own key.
     // HTML is stored under a separate key (written by the HTML path below) so
     // these writes never race or clobber each other.
-    if (process.env.NODE_ENV === "production" && __isrRscDataPromise) {
+    // Skip when dynamic APIs were used — the page opted into dynamic rendering.
+    // Two-phase check: __dynamicUsedInRsc catches APIs called during element
+    // construction (e.g. searchParams access). The deferred consumeDynamicUsage()
+    // inside the write promise catches APIs called during stream rendering
+    // (e.g. headers(), cookies(), noStore()) which fire after the response is sent.
+    if (process.env.NODE_ENV === "production" && __isrRscDataPromise && !__dynamicUsedInRsc) {
       responseHeaders["X-Vinext-Cache"] = "MISS";
       const __isrKeyRsc = __isrRscKey(cleanPathname);
       const __revalSecsRsc = revalidateSeconds;
       const __rscWritePromise = (async () => {
         try {
           const __rscDataForCache = await __isrRscDataPromise;
+          if (consumeDynamicUsage()) {
+            __isrDebug?.("RSC cache write skipped (dynamic usage during render)", __isrKeyRsc);
+            return;
+          }
           const __pageTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
           await __isrSet(__isrKeyRsc, { kind: "APP_PAGE", html: "", rscData: __rscDataForCache, headers: undefined, postponed: undefined, status: 200 }, __revalSecsRsc, __pageTags);
           __isrDebug?.("RSC cache written", __isrKeyRsc);
@@ -5648,12 +5663,18 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     // The RSC stream is consumed lazily - components render when chunks are read.
     // If we clear context now, headers()/cookies() will fail during rendering.
     // Context will be cleared when the next request starts (via runWithRequestContext).
+
+    // Check if any dynamic API was used during element construction (e.g.
+    // searchParams access in buildPageElement). Dynamic pages must not be
+    // ISR-cached — this mirrors the HTML path's consumeDynamicUsage() check.
+    const __dynamicUsedInRsc = consumeDynamicUsage();
+
     const responseHeaders = { "Content-Type": "text/x-component; charset=utf-8", "Vary": "RSC, Accept" };
     // Include matched route params so the client can hydrate useParams()
     if (params && Object.keys(params).length > 0) {
       responseHeaders["X-Vinext-Params"] = JSON.stringify(params);
     }
-    if (isForceDynamic) {
+    if (isForceDynamic || __dynamicUsedInRsc) {
       responseHeaders["Cache-Control"] = "no-store, must-revalidate";
     } else if ((isForceStatic || isDynamicError) && !revalidateSeconds) {
       responseHeaders["Cache-Control"] = "s-maxage=31536000, stale-while-revalidate";
@@ -5713,13 +5734,22 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     // For ISR-eligible RSC requests in production: write rscData to its own key.
     // HTML is stored under a separate key (written by the HTML path below) so
     // these writes never race or clobber each other.
-    if (process.env.NODE_ENV === "production" && __isrRscDataPromise) {
+    // Skip when dynamic APIs were used — the page opted into dynamic rendering.
+    // Two-phase check: __dynamicUsedInRsc catches APIs called during element
+    // construction (e.g. searchParams access). The deferred consumeDynamicUsage()
+    // inside the write promise catches APIs called during stream rendering
+    // (e.g. headers(), cookies(), noStore()) which fire after the response is sent.
+    if (process.env.NODE_ENV === "production" && __isrRscDataPromise && !__dynamicUsedInRsc) {
       responseHeaders["X-Vinext-Cache"] = "MISS";
       const __isrKeyRsc = __isrRscKey(cleanPathname);
       const __revalSecsRsc = revalidateSeconds;
       const __rscWritePromise = (async () => {
         try {
           const __rscDataForCache = await __isrRscDataPromise;
+          if (consumeDynamicUsage()) {
+            __isrDebug?.("RSC cache write skipped (dynamic usage during render)", __isrKeyRsc);
+            return;
+          }
           const __pageTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
           await __isrSet(__isrKeyRsc, { kind: "APP_PAGE", html: "", rscData: __rscDataForCache, headers: undefined, postponed: undefined, status: 200 }, __revalSecsRsc, __pageTags);
           __isrDebug?.("RSC cache written", __isrKeyRsc);
@@ -8664,12 +8694,18 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     // The RSC stream is consumed lazily - components render when chunks are read.
     // If we clear context now, headers()/cookies() will fail during rendering.
     // Context will be cleared when the next request starts (via runWithRequestContext).
+
+    // Check if any dynamic API was used during element construction (e.g.
+    // searchParams access in buildPageElement). Dynamic pages must not be
+    // ISR-cached — this mirrors the HTML path's consumeDynamicUsage() check.
+    const __dynamicUsedInRsc = consumeDynamicUsage();
+
     const responseHeaders = { "Content-Type": "text/x-component; charset=utf-8", "Vary": "RSC, Accept" };
     // Include matched route params so the client can hydrate useParams()
     if (params && Object.keys(params).length > 0) {
       responseHeaders["X-Vinext-Params"] = JSON.stringify(params);
     }
-    if (isForceDynamic) {
+    if (isForceDynamic || __dynamicUsedInRsc) {
       responseHeaders["Cache-Control"] = "no-store, must-revalidate";
     } else if ((isForceStatic || isDynamicError) && !revalidateSeconds) {
       responseHeaders["Cache-Control"] = "s-maxage=31536000, stale-while-revalidate";
@@ -8729,13 +8765,22 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     // For ISR-eligible RSC requests in production: write rscData to its own key.
     // HTML is stored under a separate key (written by the HTML path below) so
     // these writes never race or clobber each other.
-    if (process.env.NODE_ENV === "production" && __isrRscDataPromise) {
+    // Skip when dynamic APIs were used — the page opted into dynamic rendering.
+    // Two-phase check: __dynamicUsedInRsc catches APIs called during element
+    // construction (e.g. searchParams access). The deferred consumeDynamicUsage()
+    // inside the write promise catches APIs called during stream rendering
+    // (e.g. headers(), cookies(), noStore()) which fire after the response is sent.
+    if (process.env.NODE_ENV === "production" && __isrRscDataPromise && !__dynamicUsedInRsc) {
       responseHeaders["X-Vinext-Cache"] = "MISS";
       const __isrKeyRsc = __isrRscKey(cleanPathname);
       const __revalSecsRsc = revalidateSeconds;
       const __rscWritePromise = (async () => {
         try {
           const __rscDataForCache = await __isrRscDataPromise;
+          if (consumeDynamicUsage()) {
+            __isrDebug?.("RSC cache write skipped (dynamic usage during render)", __isrKeyRsc);
+            return;
+          }
           const __pageTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
           await __isrSet(__isrKeyRsc, { kind: "APP_PAGE", html: "", rscData: __rscDataForCache, headers: undefined, postponed: undefined, status: 200 }, __revalSecsRsc, __pageTags);
           __isrDebug?.("RSC cache written", __isrKeyRsc);
@@ -11691,12 +11736,18 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     // The RSC stream is consumed lazily - components render when chunks are read.
     // If we clear context now, headers()/cookies() will fail during rendering.
     // Context will be cleared when the next request starts (via runWithRequestContext).
+
+    // Check if any dynamic API was used during element construction (e.g.
+    // searchParams access in buildPageElement). Dynamic pages must not be
+    // ISR-cached — this mirrors the HTML path's consumeDynamicUsage() check.
+    const __dynamicUsedInRsc = consumeDynamicUsage();
+
     const responseHeaders = { "Content-Type": "text/x-component; charset=utf-8", "Vary": "RSC, Accept" };
     // Include matched route params so the client can hydrate useParams()
     if (params && Object.keys(params).length > 0) {
       responseHeaders["X-Vinext-Params"] = JSON.stringify(params);
     }
-    if (isForceDynamic) {
+    if (isForceDynamic || __dynamicUsedInRsc) {
       responseHeaders["Cache-Control"] = "no-store, must-revalidate";
     } else if ((isForceStatic || isDynamicError) && !revalidateSeconds) {
       responseHeaders["Cache-Control"] = "s-maxage=31536000, stale-while-revalidate";
@@ -11756,13 +11807,22 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     // For ISR-eligible RSC requests in production: write rscData to its own key.
     // HTML is stored under a separate key (written by the HTML path below) so
     // these writes never race or clobber each other.
-    if (process.env.NODE_ENV === "production" && __isrRscDataPromise) {
+    // Skip when dynamic APIs were used — the page opted into dynamic rendering.
+    // Two-phase check: __dynamicUsedInRsc catches APIs called during element
+    // construction (e.g. searchParams access). The deferred consumeDynamicUsage()
+    // inside the write promise catches APIs called during stream rendering
+    // (e.g. headers(), cookies(), noStore()) which fire after the response is sent.
+    if (process.env.NODE_ENV === "production" && __isrRscDataPromise && !__dynamicUsedInRsc) {
       responseHeaders["X-Vinext-Cache"] = "MISS";
       const __isrKeyRsc = __isrRscKey(cleanPathname);
       const __revalSecsRsc = revalidateSeconds;
       const __rscWritePromise = (async () => {
         try {
           const __rscDataForCache = await __isrRscDataPromise;
+          if (consumeDynamicUsage()) {
+            __isrDebug?.("RSC cache write skipped (dynamic usage during render)", __isrKeyRsc);
+            return;
+          }
           const __pageTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
           await __isrSet(__isrKeyRsc, { kind: "APP_PAGE", html: "", rscData: __rscDataForCache, headers: undefined, postponed: undefined, status: 200 }, __revalSecsRsc, __pageTags);
           __isrDebug?.("RSC cache written", __isrKeyRsc);
@@ -14684,12 +14744,18 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     // The RSC stream is consumed lazily - components render when chunks are read.
     // If we clear context now, headers()/cookies() will fail during rendering.
     // Context will be cleared when the next request starts (via runWithRequestContext).
+
+    // Check if any dynamic API was used during element construction (e.g.
+    // searchParams access in buildPageElement). Dynamic pages must not be
+    // ISR-cached — this mirrors the HTML path's consumeDynamicUsage() check.
+    const __dynamicUsedInRsc = consumeDynamicUsage();
+
     const responseHeaders = { "Content-Type": "text/x-component; charset=utf-8", "Vary": "RSC, Accept" };
     // Include matched route params so the client can hydrate useParams()
     if (params && Object.keys(params).length > 0) {
       responseHeaders["X-Vinext-Params"] = JSON.stringify(params);
     }
-    if (isForceDynamic) {
+    if (isForceDynamic || __dynamicUsedInRsc) {
       responseHeaders["Cache-Control"] = "no-store, must-revalidate";
     } else if ((isForceStatic || isDynamicError) && !revalidateSeconds) {
       responseHeaders["Cache-Control"] = "s-maxage=31536000, stale-while-revalidate";
@@ -14749,13 +14815,22 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     // For ISR-eligible RSC requests in production: write rscData to its own key.
     // HTML is stored under a separate key (written by the HTML path below) so
     // these writes never race or clobber each other.
-    if (process.env.NODE_ENV === "production" && __isrRscDataPromise) {
+    // Skip when dynamic APIs were used — the page opted into dynamic rendering.
+    // Two-phase check: __dynamicUsedInRsc catches APIs called during element
+    // construction (e.g. searchParams access). The deferred consumeDynamicUsage()
+    // inside the write promise catches APIs called during stream rendering
+    // (e.g. headers(), cookies(), noStore()) which fire after the response is sent.
+    if (process.env.NODE_ENV === "production" && __isrRscDataPromise && !__dynamicUsedInRsc) {
       responseHeaders["X-Vinext-Cache"] = "MISS";
       const __isrKeyRsc = __isrRscKey(cleanPathname);
       const __revalSecsRsc = revalidateSeconds;
       const __rscWritePromise = (async () => {
         try {
           const __rscDataForCache = await __isrRscDataPromise;
+          if (consumeDynamicUsage()) {
+            __isrDebug?.("RSC cache write skipped (dynamic usage during render)", __isrKeyRsc);
+            return;
+          }
           const __pageTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
           await __isrSet(__isrKeyRsc, { kind: "APP_PAGE", html: "", rscData: __rscDataForCache, headers: undefined, postponed: undefined, status: 200 }, __revalSecsRsc, __pageTags);
           __isrDebug?.("RSC cache written", __isrKeyRsc);
@@ -18030,12 +18105,18 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     // The RSC stream is consumed lazily - components render when chunks are read.
     // If we clear context now, headers()/cookies() will fail during rendering.
     // Context will be cleared when the next request starts (via runWithRequestContext).
+
+    // Check if any dynamic API was used during element construction (e.g.
+    // searchParams access in buildPageElement). Dynamic pages must not be
+    // ISR-cached — this mirrors the HTML path's consumeDynamicUsage() check.
+    const __dynamicUsedInRsc = consumeDynamicUsage();
+
     const responseHeaders = { "Content-Type": "text/x-component; charset=utf-8", "Vary": "RSC, Accept" };
     // Include matched route params so the client can hydrate useParams()
     if (params && Object.keys(params).length > 0) {
       responseHeaders["X-Vinext-Params"] = JSON.stringify(params);
     }
-    if (isForceDynamic) {
+    if (isForceDynamic || __dynamicUsedInRsc) {
       responseHeaders["Cache-Control"] = "no-store, must-revalidate";
     } else if ((isForceStatic || isDynamicError) && !revalidateSeconds) {
       responseHeaders["Cache-Control"] = "s-maxage=31536000, stale-while-revalidate";
@@ -18095,13 +18176,22 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     // For ISR-eligible RSC requests in production: write rscData to its own key.
     // HTML is stored under a separate key (written by the HTML path below) so
     // these writes never race or clobber each other.
-    if (process.env.NODE_ENV === "production" && __isrRscDataPromise) {
+    // Skip when dynamic APIs were used — the page opted into dynamic rendering.
+    // Two-phase check: __dynamicUsedInRsc catches APIs called during element
+    // construction (e.g. searchParams access). The deferred consumeDynamicUsage()
+    // inside the write promise catches APIs called during stream rendering
+    // (e.g. headers(), cookies(), noStore()) which fire after the response is sent.
+    if (process.env.NODE_ENV === "production" && __isrRscDataPromise && !__dynamicUsedInRsc) {
       responseHeaders["X-Vinext-Cache"] = "MISS";
       const __isrKeyRsc = __isrRscKey(cleanPathname);
       const __revalSecsRsc = revalidateSeconds;
       const __rscWritePromise = (async () => {
         try {
           const __rscDataForCache = await __isrRscDataPromise;
+          if (consumeDynamicUsage()) {
+            __isrDebug?.("RSC cache write skipped (dynamic usage during render)", __isrKeyRsc);
+            return;
+          }
           const __pageTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
           await __isrSet(__isrKeyRsc, { kind: "APP_PAGE", html: "", rscData: __rscDataForCache, headers: undefined, postponed: undefined, status: 200 }, __revalSecsRsc, __pageTags);
           __isrDebug?.("RSC cache written", __isrKeyRsc);

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -1798,6 +1798,55 @@ describe("App Router Production server (startProdServer)", () => {
     const body = await headRes.text();
     expect(body).toBe("");
   });
+
+  // Page-level ISR + searchParams dynamic usage tests
+  // Fixture: /isr-dynamic-search exports revalidate=60 AND reads searchParams.
+  // searchParams access is a Request-time API that opts the page into dynamic
+  // rendering — the ISR cache must NOT store the response.
+  // Ported from Next.js: using searchParams opts the page into dynamic rendering
+  // at request time (docs/01-app/03-api-reference/03-file-conventions/page.mdx)
+
+  it("page ISR + searchParams: RSC request is not ISR-cached when searchParams are present", async () => {
+    // Use distinctive filter values that won't appear elsewhere in the RSC payload
+    const res1 = await fetch(`${baseUrl}/isr-dynamic-search?filter=crimson`, {
+      headers: { Accept: "text/x-component" },
+    });
+    expect(res1.status).toBe(200);
+    expect(res1.headers.get("content-type")).toContain("text/x-component");
+    const rsc1 = await res1.text();
+    expect(rsc1).toContain("crimson");
+
+    // Second RSC request with different filter — must render fresh, not return cached data
+    const res2 = await fetch(`${baseUrl}/isr-dynamic-search?filter=indigo`, {
+      headers: { Accept: "text/x-component" },
+    });
+    expect(res2.status).toBe(200);
+    const rsc2 = await res2.text();
+    expect(rsc2).toContain("indigo");
+    expect(rsc2).not.toContain("crimson");
+  });
+
+  it("page ISR + searchParams: RSC response has no X-Vinext-Cache header (dynamic, not ISR-cached)", async () => {
+    const res = await fetch(`${baseUrl}/isr-dynamic-search?filter=x`, {
+      headers: { Accept: "text/x-component" },
+    });
+    expect(res.status).toBe(200);
+    // Dynamic pages should not have ISR cache headers
+    expect(res.headers.get("x-vinext-cache")).toBeNull();
+  });
+
+  it("page ISR + searchParams: HTML response also skips ISR cache", async () => {
+    const res1 = await fetch(`${baseUrl}/isr-dynamic-search?filter=alpha`);
+    expect(res1.status).toBe(200);
+    const html1 = await res1.text();
+    expect(html1).toContain("alpha");
+
+    const res2 = await fetch(`${baseUrl}/isr-dynamic-search?filter=beta`);
+    expect(res2.status).toBe(200);
+    const html2 = await res2.text();
+    expect(html2).toContain("beta");
+    expect(html2).not.toContain('"filter">alpha<');
+  });
 });
 
 describe("App Router Production server worker entry compatibility", () => {
@@ -3721,6 +3770,16 @@ describe("generateRscEntry ISR code generation", () => {
     expect(teeAssignIdx).toBeGreaterThan(-1);
     expect(rscResponseIdx).toBeGreaterThan(-1);
     expect(teeAssignIdx).toBeLessThan(rscResponseIdx);
+  });
+
+  it("RSC path guards ISR cache write with consumeDynamicUsage check", () => {
+    const code = generateRscEntry("/tmp/test/app", minimalRoutes);
+    // The RSC path must call consumeDynamicUsage() and use the result to skip
+    // ISR cache writes for pages that opted into dynamic rendering (e.g. via
+    // searchParams access). Without this guard, dynamic pages get ISR-cached
+    // and subsequent RSC requests return stale data.
+    expect(code).toContain("const __dynamicUsedInRsc = consumeDynamicUsage()");
+    expect(code).toContain("&& !__dynamicUsedInRsc");
   });
 
   // Route handler ISR code generation tests

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -3772,14 +3772,15 @@ describe("generateRscEntry ISR code generation", () => {
     expect(teeAssignIdx).toBeLessThan(rscResponseIdx);
   });
 
-  it("RSC path guards ISR cache write with consumeDynamicUsage check", () => {
+  it("RSC path guards ISR cache write with two-phase consumeDynamicUsage check", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes);
-    // The RSC path must call consumeDynamicUsage() and use the result to skip
-    // ISR cache writes for pages that opted into dynamic rendering (e.g. via
-    // searchParams access). Without this guard, dynamic pages get ISR-cached
-    // and subsequent RSC requests return stale data.
+    // Phase 1: early check catches dynamic APIs called during element construction
+    // (e.g. searchParams access in buildPageElement)
     expect(code).toContain("const __dynamicUsedInRsc = consumeDynamicUsage()");
     expect(code).toContain("&& !__dynamicUsedInRsc");
+    // Phase 2: deferred check inside the cache write promise catches dynamic APIs
+    // called during stream rendering (e.g. headers(), cookies(), noStore())
+    expect(code).toContain("RSC cache write skipped (dynamic usage during render)");
   });
 
   // Route handler ISR code generation tests

--- a/tests/fixtures/app-basic/app/isr-dynamic-search/page.tsx
+++ b/tests/fixtures/app-basic/app/isr-dynamic-search/page.tsx
@@ -1,0 +1,21 @@
+// ISR page that also reads searchParams — searchParams access should opt
+// out of ISR caching (dynamic rendering wins over revalidate config).
+// Ported from Next.js: searchParams is a Request-time API that opts the
+// page into dynamic rendering at request time.
+export const revalidate = 60;
+
+export default async function ISRDynamicSearchPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ filter?: string }>;
+}) {
+  const { filter } = await searchParams;
+  const timestamp = Date.now();
+  return (
+    <div data-testid="isr-dynamic-search-page">
+      <h1>ISR + Dynamic Search</h1>
+      <p data-testid="filter">{filter ?? "none"}</p>
+      <p data-testid="timestamp">{timestamp}</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- RSC response path (client-side navigation) was writing to ISR cache unconditionally, ignoring dynamic API usage (`searchParams`, `headers()`, `cookies()`, `noStore()`). The HTML path correctly checked `consumeDynamicUsage()` before caching, but the RSC path returned before that check ever ran.
- Pages with both `revalidate` and dynamic APIs (like `searchParams` or `headers()`) served stale cached data on client-side navigations — the first request's content was cached under the pathname key and returned for all subsequent RSC requests regardless of different search params.
- Two-phase fix: early `consumeDynamicUsage()` catches APIs called during element construction (searchParams), deferred check inside the cache write promise catches APIs called during stream rendering (headers, cookies, noStore).

Closes #588

## Test plan

- [x] New fixture page (`isr-dynamic-search`) with `revalidate=60` + `searchParams` access
- [x] Integration tests: RSC requests with different searchParams get fresh renders, no `X-Vinext-Cache` header
- [x] Integration tests: HTML responses also skip ISR cache for dynamic pages
- [x] Code generation test: asserts both early and deferred `consumeDynamicUsage()` guards exist
- [x] All 270 existing `app-router.test.ts` tests pass
- [x] All `generateRscEntry` ISR code generation tests pass
- [x] All `features.test.ts` ISR tests pass
- [x] `pnpm run check` clean
- [x] Manually verified on a real app (`headers()` + `noStore()` + `revalidate=604800`) via `wrangler dev`