### PR TITLE
refactor: extract app route handler response helpers

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -41,6 +41,9 @@ const requestContextShimPath = fileURLToPath(
 const appRouteHandlerRuntimePath = fileURLToPath(
   new URL("../server/app-route-handler-runtime.js", import.meta.url),
 ).replace(/\\/g, "/");
+const appRouteHandlerResponsePath = fileURLToPath(
+  new URL("../server/app-route-handler-response.js", import.meta.url),
+).replace(/\\/g, "/");
 const routeTriePath = fileURLToPath(new URL("../routing/route-trie.js", import.meta.url)).replace(
   /\\/g,
   "/",
@@ -338,6 +341,14 @@ import {
   isKnownDynamicAppRoute as __isKnownDynamicAppRoute,
   markKnownDynamicAppRoute as __markKnownDynamicAppRoute,
 } from ${JSON.stringify(appRouteHandlerRuntimePath)};
+import {
+  applyRouteHandlerMiddlewareContext as __applyRouteHandlerMiddlewareContext,
+  applyRouteHandlerRevalidateHeader as __applyRouteHandlerRevalidateHeader,
+  buildAppRouteCacheValue as __buildAppRouteCacheValue,
+  buildRouteHandlerCachedResponse as __buildRouteHandlerCachedResponse,
+  finalizeRouteHandlerResponse as __finalizeRouteHandlerResponse,
+  markRouteHandlerCacheMiss as __markRouteHandlerCacheMiss,
+} from ${JSON.stringify(appRouteHandlerResponsePath)};
 import { _consumeRequestScopedCacheLife, getCacheHandler } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from ${JSON.stringify(requestContextShimPath)};
 import { ensureFetchPatch as _ensureFetchPatch, getCollectedFetchTags } from "vinext/fetch-cache";
@@ -2199,37 +2210,17 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     const exportedMethods = collectRouteHandlerMethods(handler);
     const allowHeaderForOptions = buildRouteHandlerAllowHeader(exportedMethods);
 
-    // Route handlers need the same middleware header/status merge behavior as
-    // page responses. This keeps middleware response headers visible on API
-    // routes in Workers/dev, and preserves custom rewrite status overrides.
-    function attachRouteHandlerMiddlewareContext(response) {
-      // _mwCtx.headers is only set (non-null) when middleware actually ran and
-      // produced a continue/rewrite response. An empty Headers object (middleware
-      // ran but produced no response headers) is a harmless edge case: the early
-      // return is skipped, but the copy loop below is a no-op, so no incorrect
-      // headers are added. The allocation cost in that case is acceptable.
-      if (!_mwCtx.headers && _mwCtx.status == null) return response;
-      const responseHeaders = new Headers(response.headers);
-      if (_mwCtx.headers) {
-        for (const [key, value] of _mwCtx.headers) {
-          responseHeaders.append(key, value);
-        }
-      }
-      return new Response(response.body, {
-        status: _mwCtx.status ?? response.status,
-        statusText: response.statusText,
-        headers: responseHeaders,
-      });
-    }
-
     // OPTIONS auto-implementation: respond with Allow header and 204
     if (method === "OPTIONS" && typeof handler["OPTIONS"] !== "function") {
       setHeadersContext(null);
       setNavigationContext(null);
-      return attachRouteHandlerMiddlewareContext(new Response(null, {
-        status: 204,
-        headers: { "Allow": allowHeaderForOptions },
-      }));
+      return __applyRouteHandlerMiddlewareContext(
+        new Response(null, {
+          status: 204,
+          headers: { "Allow": allowHeaderForOptions },
+        }),
+        _mwCtx,
+      );
     }
 
     // HEAD auto-implementation: run GET handler and strip body
@@ -2262,13 +2253,14 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           __isrDebug?.("HIT (route)", cleanPathname);
           setHeadersContext(null);
           setNavigationContext(null);
-          const __hitHeaders = Object.assign({}, __cv.headers || {});
-          __hitHeaders["X-Vinext-Cache"] = "HIT";
-          __hitHeaders["Cache-Control"] = "s-maxage=" + revalidateSeconds + ", stale-while-revalidate";
-          if (isAutoHead) {
-            return attachRouteHandlerMiddlewareContext(new Response(null, { status: __cv.status, headers: __hitHeaders }));
-          }
-          return attachRouteHandlerMiddlewareContext(new Response(__cv.body, { status: __cv.status, headers: __hitHeaders }));
+          return __applyRouteHandlerMiddlewareContext(
+            __buildRouteHandlerCachedResponse(__cv, {
+              cacheState: "HIT",
+              isHead: isAutoHead,
+              revalidateSeconds,
+            }),
+            _mwCtx,
+          );
         }
         if (__cached && __cached.isStale && __cached.value.value && __cached.value.value.kind === "APP_ROUTE") {
           // STALE — serve stale response, trigger background regeneration
@@ -2308,26 +2300,23 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
                 __isrDebug?.("route regen skipped (dynamic usage)", cleanPathname);
                 return;
               }
-              const __freshBody = await __revalResponse.arrayBuffer();
-              const __freshHeaders = {};
-              __revalResponse.headers.forEach(function(v, k) {
-                if (k !== "x-vinext-cache" && k !== "cache-control") __freshHeaders[k] = v;
-              });
               const __routeTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
-              await __isrSet(__routeKey, { kind: "APP_ROUTE", body: __freshBody, status: __revalResponse.status, headers: __freshHeaders }, __revalSecs, __routeTags);
+              const __routeCacheValue = await __buildAppRouteCacheValue(__revalResponse);
+              await __isrSet(__routeKey, __routeCacheValue, __revalSecs, __routeTags);
               __isrDebug?.("route regen complete", __routeKey);
             });
           });
           __isrDebug?.("STALE (route)", cleanPathname);
           setHeadersContext(null);
           setNavigationContext(null);
-          const __staleHeaders = Object.assign({}, __sv.headers || {});
-          __staleHeaders["X-Vinext-Cache"] = "STALE";
-          __staleHeaders["Cache-Control"] = "s-maxage=0, stale-while-revalidate";
-          if (isAutoHead) {
-            return attachRouteHandlerMiddlewareContext(new Response(null, { status: __sv.status, headers: __staleHeaders }));
-          }
-          return attachRouteHandlerMiddlewareContext(new Response(__sv.body, { status: __sv.status, headers: __staleHeaders }));
+          return __applyRouteHandlerMiddlewareContext(
+            __buildRouteHandlerCachedResponse(__sv, {
+              cacheState: "STALE",
+              isHead: isAutoHead,
+              revalidateSeconds,
+            }),
+            _mwCtx,
+          );
         }
       } catch (__routeCacheErr) {
         // Cache read failure — fall through to normal handler execution
@@ -2363,7 +2352,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           (method === "GET" || isAutoHead) &&
           !handlerSetCacheControl
         ) {
-          response.headers.set("cache-control", "s-maxage=" + revalidateSeconds + ", stale-while-revalidate");
+          __applyRouteHandlerRevalidateHeader(response, revalidateSeconds);
         }
 
         // ISR cache write for route handlers (production, MISS).
@@ -2377,19 +2366,15 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           (method === "GET" || isAutoHead) &&
           !handlerSetCacheControl
         ) {
-          response.headers.set("X-Vinext-Cache", "MISS");
+          __markRouteHandlerCacheMiss(response);
           const __routeClone = response.clone();
           const __routeKey = __isrRouteKey(cleanPathname);
           const __revalSecs = revalidateSeconds;
           const __routeTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
           const __routeWritePromise = (async () => {
             try {
-              const __buf = await __routeClone.arrayBuffer();
-              const __hdrs = {};
-              __routeClone.headers.forEach(function(v, k) {
-                if (k !== "x-vinext-cache" && k !== "cache-control") __hdrs[k] = v;
-              });
-              await __isrSet(__routeKey, { kind: "APP_ROUTE", body: __buf, status: __routeClone.status, headers: __hdrs }, __revalSecs, __routeTags);
+              const __routeCacheValue = await __buildAppRouteCacheValue(__routeClone);
+              await __isrSet(__routeKey, __routeCacheValue, __revalSecs, __routeTags);
               __isrDebug?.("route cache written", __routeKey);
             } catch (__cacheErr) {
               console.error("[vinext] ISR route cache write error:", __cacheErr);
@@ -2403,38 +2388,14 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         const draftCookie = getDraftModeCookieHeader();
         setHeadersContext(null);
         setNavigationContext(null);
-
-        // If we have pending cookies, create a new response with them attached
-        if (pendingCookies.length > 0 || draftCookie) {
-          const newHeaders = new Headers(response.headers);
-          for (const cookie of pendingCookies) {
-            newHeaders.append("Set-Cookie", cookie);
-          }
-          if (draftCookie) newHeaders.append("Set-Cookie", draftCookie);
-
-          if (isAutoHead) {
-            return attachRouteHandlerMiddlewareContext(new Response(null, {
-              status: response.status,
-              statusText: response.statusText,
-              headers: newHeaders,
-            }));
-          }
-          return attachRouteHandlerMiddlewareContext(new Response(response.body, {
-            status: response.status,
-            statusText: response.statusText,
-            headers: newHeaders,
-          }));
-        }
-
-        if (isAutoHead) {
-          // Strip body for auto-HEAD, preserve headers and status
-          return attachRouteHandlerMiddlewareContext(new Response(null, {
-            status: response.status,
-            statusText: response.statusText,
-            headers: response.headers,
-          }));
-        }
-        return attachRouteHandlerMiddlewareContext(response);
+        return __applyRouteHandlerMiddlewareContext(
+          __finalizeRouteHandlerResponse(response, {
+            pendingCookies,
+            draftCookie,
+            isHead: isAutoHead,
+          }),
+          _mwCtx,
+        );
       } catch (err) {
         getAndClearPendingCookies(); // Clear any pending cookies on error
         // Catch redirect() / notFound() thrown from route handlers
@@ -2446,16 +2407,19 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
             const statusCode = parts[3] ? parseInt(parts[3], 10) : 307;
             setHeadersContext(null);
             setNavigationContext(null);
-            return attachRouteHandlerMiddlewareContext(new Response(null, {
-              status: statusCode,
-              headers: { Location: new URL(redirectUrl, request.url).toString() },
-            }));
+            return __applyRouteHandlerMiddlewareContext(
+              new Response(null, {
+                status: statusCode,
+                headers: { Location: new URL(redirectUrl, request.url).toString() },
+              }),
+              _mwCtx,
+            );
           }
           if (digest === "NEXT_NOT_FOUND" || digest.startsWith("NEXT_HTTP_ERROR_FALLBACK;")) {
             const statusCode = digest === "NEXT_NOT_FOUND" ? 404 : parseInt(digest.split(";")[1], 10);
             setHeadersContext(null);
             setNavigationContext(null);
-            return attachRouteHandlerMiddlewareContext(new Response(null, { status: statusCode }));
+            return __applyRouteHandlerMiddlewareContext(new Response(null, { status: statusCode }), _mwCtx);
           }
         }
         setHeadersContext(null);
@@ -2466,16 +2430,19 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           { path: cleanPathname, method: request.method, headers: Object.fromEntries(request.headers.entries()) },
           { routerKind: "App Router", routePath: route.pattern, routeType: "route" },
         );
-        return attachRouteHandlerMiddlewareContext(new Response(null, { status: 500 }));
+        return __applyRouteHandlerMiddlewareContext(new Response(null, { status: 500 }), _mwCtx);
       } finally {
         setHeadersAccessPhase(previousHeadersPhase);
       }
     }
     setHeadersContext(null);
     setNavigationContext(null);
-    return attachRouteHandlerMiddlewareContext(new Response(null, {
-      status: 405,
-    }));
+    return __applyRouteHandlerMiddlewareContext(
+      new Response(null, {
+        status: 405,
+      }),
+      _mwCtx,
+    );
   }
 
   // Build the component tree: layouts wrapping the page

--- a/packages/vinext/src/server/app-route-handler-response.ts
+++ b/packages/vinext/src/server/app-route-handler-response.ts
@@ -1,0 +1,130 @@
+import type { CachedRouteValue } from "../shims/cache.js";
+
+export interface RouteHandlerMiddlewareContext {
+  headers: Headers | null;
+  status: number | null;
+}
+
+export interface BuildRouteHandlerCachedResponseOptions {
+  cacheState: "HIT" | "STALE";
+  isHead: boolean;
+  revalidateSeconds: number;
+}
+
+export interface FinalizeRouteHandlerResponseOptions {
+  pendingCookies: string[];
+  draftCookie?: string | null;
+  isHead: boolean;
+}
+
+function buildRouteHandlerCacheControl(
+  cacheState: BuildRouteHandlerCachedResponseOptions["cacheState"],
+  revalidateSeconds: number,
+): string {
+  if (cacheState === "STALE") {
+    return "s-maxage=0, stale-while-revalidate";
+  }
+
+  return `s-maxage=${revalidateSeconds}, stale-while-revalidate`;
+}
+
+export function applyRouteHandlerMiddlewareContext(
+  response: Response,
+  middlewareContext: RouteHandlerMiddlewareContext,
+): Response {
+  if (!middlewareContext.headers && middlewareContext.status == null) {
+    return response;
+  }
+
+  const responseHeaders = new Headers(response.headers);
+  if (middlewareContext.headers) {
+    for (const [key, value] of middlewareContext.headers) {
+      responseHeaders.append(key, value);
+    }
+  }
+
+  return new Response(response.body, {
+    status: middlewareContext.status ?? response.status,
+    statusText: response.statusText,
+    headers: responseHeaders,
+  });
+}
+
+export function buildRouteHandlerCachedResponse(
+  cachedValue: CachedRouteValue,
+  options: BuildRouteHandlerCachedResponseOptions,
+): Response {
+  const headers = new Headers();
+  for (const [key, value] of Object.entries(cachedValue.headers)) {
+    if (Array.isArray(value)) {
+      for (const entry of value) {
+        headers.append(key, entry);
+      }
+    } else {
+      headers.set(key, value);
+    }
+  }
+  headers.set("X-Vinext-Cache", options.cacheState);
+  headers.set(
+    "Cache-Control",
+    buildRouteHandlerCacheControl(options.cacheState, options.revalidateSeconds),
+  );
+
+  return new Response(options.isHead ? null : cachedValue.body, {
+    status: cachedValue.status,
+    headers,
+  });
+}
+
+export function applyRouteHandlerRevalidateHeader(
+  response: Response,
+  revalidateSeconds: number,
+): void {
+  response.headers.set("cache-control", buildRouteHandlerCacheControl("HIT", revalidateSeconds));
+}
+
+export function markRouteHandlerCacheMiss(response: Response): void {
+  response.headers.set("X-Vinext-Cache", "MISS");
+}
+
+export async function buildAppRouteCacheValue(response: Response): Promise<CachedRouteValue> {
+  const body = await response.arrayBuffer();
+  const headers: CachedRouteValue["headers"] = {};
+
+  response.headers.forEach((value, key) => {
+    if (key !== "x-vinext-cache" && key !== "cache-control") {
+      headers[key] = value;
+    }
+  });
+
+  return {
+    kind: "APP_ROUTE",
+    body,
+    status: response.status,
+    headers,
+  };
+}
+
+export function finalizeRouteHandlerResponse(
+  response: Response,
+  options: FinalizeRouteHandlerResponseOptions,
+): Response {
+  const { pendingCookies, draftCookie, isHead } = options;
+  if (pendingCookies.length === 0 && !draftCookie && !isHead) {
+    return response;
+  }
+
+  const headers = new Headers(response.headers);
+  for (const cookie of pendingCookies) {
+    headers.append("Set-Cookie", cookie);
+  }
+  if (draftCookie) {
+    headers.append("Set-Cookie", draftCookie);
+  }
+
+  return new Response(isHead ? null : response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -60,6 +60,14 @@ import {
   isKnownDynamicAppRoute as __isKnownDynamicAppRoute,
   markKnownDynamicAppRoute as __markKnownDynamicAppRoute,
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-runtime.js";
+import {
+  applyRouteHandlerMiddlewareContext as __applyRouteHandlerMiddlewareContext,
+  applyRouteHandlerRevalidateHeader as __applyRouteHandlerRevalidateHeader,
+  buildAppRouteCacheValue as __buildAppRouteCacheValue,
+  buildRouteHandlerCachedResponse as __buildRouteHandlerCachedResponse,
+  finalizeRouteHandlerResponse as __finalizeRouteHandlerResponse,
+  markRouteHandlerCacheMiss as __markRouteHandlerCacheMiss,
+} from "<ROOT>/packages/vinext/src/server/app-route-handler-response.js";
 import { _consumeRequestScopedCacheLife, getCacheHandler } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
 import { ensureFetchPatch as _ensureFetchPatch, getCollectedFetchTags } from "vinext/fetch-cache";
@@ -1889,37 +1897,17 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     const exportedMethods = collectRouteHandlerMethods(handler);
     const allowHeaderForOptions = buildRouteHandlerAllowHeader(exportedMethods);
 
-    // Route handlers need the same middleware header/status merge behavior as
-    // page responses. This keeps middleware response headers visible on API
-    // routes in Workers/dev, and preserves custom rewrite status overrides.
-    function attachRouteHandlerMiddlewareContext(response) {
-      // _mwCtx.headers is only set (non-null) when middleware actually ran and
-      // produced a continue/rewrite response. An empty Headers object (middleware
-      // ran but produced no response headers) is a harmless edge case: the early
-      // return is skipped, but the copy loop below is a no-op, so no incorrect
-      // headers are added. The allocation cost in that case is acceptable.
-      if (!_mwCtx.headers && _mwCtx.status == null) return response;
-      const responseHeaders = new Headers(response.headers);
-      if (_mwCtx.headers) {
-        for (const [key, value] of _mwCtx.headers) {
-          responseHeaders.append(key, value);
-        }
-      }
-      return new Response(response.body, {
-        status: _mwCtx.status ?? response.status,
-        statusText: response.statusText,
-        headers: responseHeaders,
-      });
-    }
-
     // OPTIONS auto-implementation: respond with Allow header and 204
     if (method === "OPTIONS" && typeof handler["OPTIONS"] !== "function") {
       setHeadersContext(null);
       setNavigationContext(null);
-      return attachRouteHandlerMiddlewareContext(new Response(null, {
-        status: 204,
-        headers: { "Allow": allowHeaderForOptions },
-      }));
+      return __applyRouteHandlerMiddlewareContext(
+        new Response(null, {
+          status: 204,
+          headers: { "Allow": allowHeaderForOptions },
+        }),
+        _mwCtx,
+      );
     }
 
     // HEAD auto-implementation: run GET handler and strip body
@@ -1952,13 +1940,14 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           __isrDebug?.("HIT (route)", cleanPathname);
           setHeadersContext(null);
           setNavigationContext(null);
-          const __hitHeaders = Object.assign({}, __cv.headers || {});
-          __hitHeaders["X-Vinext-Cache"] = "HIT";
-          __hitHeaders["Cache-Control"] = "s-maxage=" + revalidateSeconds + ", stale-while-revalidate";
-          if (isAutoHead) {
-            return attachRouteHandlerMiddlewareContext(new Response(null, { status: __cv.status, headers: __hitHeaders }));
-          }
-          return attachRouteHandlerMiddlewareContext(new Response(__cv.body, { status: __cv.status, headers: __hitHeaders }));
+          return __applyRouteHandlerMiddlewareContext(
+            __buildRouteHandlerCachedResponse(__cv, {
+              cacheState: "HIT",
+              isHead: isAutoHead,
+              revalidateSeconds,
+            }),
+            _mwCtx,
+          );
         }
         if (__cached && __cached.isStale && __cached.value.value && __cached.value.value.kind === "APP_ROUTE") {
           // STALE — serve stale response, trigger background regeneration
@@ -1998,26 +1987,23 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
                 __isrDebug?.("route regen skipped (dynamic usage)", cleanPathname);
                 return;
               }
-              const __freshBody = await __revalResponse.arrayBuffer();
-              const __freshHeaders = {};
-              __revalResponse.headers.forEach(function(v, k) {
-                if (k !== "x-vinext-cache" && k !== "cache-control") __freshHeaders[k] = v;
-              });
               const __routeTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
-              await __isrSet(__routeKey, { kind: "APP_ROUTE", body: __freshBody, status: __revalResponse.status, headers: __freshHeaders }, __revalSecs, __routeTags);
+              const __routeCacheValue = await __buildAppRouteCacheValue(__revalResponse);
+              await __isrSet(__routeKey, __routeCacheValue, __revalSecs, __routeTags);
               __isrDebug?.("route regen complete", __routeKey);
             });
           });
           __isrDebug?.("STALE (route)", cleanPathname);
           setHeadersContext(null);
           setNavigationContext(null);
-          const __staleHeaders = Object.assign({}, __sv.headers || {});
-          __staleHeaders["X-Vinext-Cache"] = "STALE";
-          __staleHeaders["Cache-Control"] = "s-maxage=0, stale-while-revalidate";
-          if (isAutoHead) {
-            return attachRouteHandlerMiddlewareContext(new Response(null, { status: __sv.status, headers: __staleHeaders }));
-          }
-          return attachRouteHandlerMiddlewareContext(new Response(__sv.body, { status: __sv.status, headers: __staleHeaders }));
+          return __applyRouteHandlerMiddlewareContext(
+            __buildRouteHandlerCachedResponse(__sv, {
+              cacheState: "STALE",
+              isHead: isAutoHead,
+              revalidateSeconds,
+            }),
+            _mwCtx,
+          );
         }
       } catch (__routeCacheErr) {
         // Cache read failure — fall through to normal handler execution
@@ -2053,7 +2039,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           (method === "GET" || isAutoHead) &&
           !handlerSetCacheControl
         ) {
-          response.headers.set("cache-control", "s-maxage=" + revalidateSeconds + ", stale-while-revalidate");
+          __applyRouteHandlerRevalidateHeader(response, revalidateSeconds);
         }
 
         // ISR cache write for route handlers (production, MISS).
@@ -2067,19 +2053,15 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           (method === "GET" || isAutoHead) &&
           !handlerSetCacheControl
         ) {
-          response.headers.set("X-Vinext-Cache", "MISS");
+          __markRouteHandlerCacheMiss(response);
           const __routeClone = response.clone();
           const __routeKey = __isrRouteKey(cleanPathname);
           const __revalSecs = revalidateSeconds;
           const __routeTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
           const __routeWritePromise = (async () => {
             try {
-              const __buf = await __routeClone.arrayBuffer();
-              const __hdrs = {};
-              __routeClone.headers.forEach(function(v, k) {
-                if (k !== "x-vinext-cache" && k !== "cache-control") __hdrs[k] = v;
-              });
-              await __isrSet(__routeKey, { kind: "APP_ROUTE", body: __buf, status: __routeClone.status, headers: __hdrs }, __revalSecs, __routeTags);
+              const __routeCacheValue = await __buildAppRouteCacheValue(__routeClone);
+              await __isrSet(__routeKey, __routeCacheValue, __revalSecs, __routeTags);
               __isrDebug?.("route cache written", __routeKey);
             } catch (__cacheErr) {
               console.error("[vinext] ISR route cache write error:", __cacheErr);
@@ -2093,38 +2075,14 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         const draftCookie = getDraftModeCookieHeader();
         setHeadersContext(null);
         setNavigationContext(null);
-
-        // If we have pending cookies, create a new response with them attached
-        if (pendingCookies.length > 0 || draftCookie) {
-          const newHeaders = new Headers(response.headers);
-          for (const cookie of pendingCookies) {
-            newHeaders.append("Set-Cookie", cookie);
-          }
-          if (draftCookie) newHeaders.append("Set-Cookie", draftCookie);
-
-          if (isAutoHead) {
-            return attachRouteHandlerMiddlewareContext(new Response(null, {
-              status: response.status,
-              statusText: response.statusText,
-              headers: newHeaders,
-            }));
-          }
-          return attachRouteHandlerMiddlewareContext(new Response(response.body, {
-            status: response.status,
-            statusText: response.statusText,
-            headers: newHeaders,
-          }));
-        }
-
-        if (isAutoHead) {
-          // Strip body for auto-HEAD, preserve headers and status
-          return attachRouteHandlerMiddlewareContext(new Response(null, {
-            status: response.status,
-            statusText: response.statusText,
-            headers: response.headers,
-          }));
-        }
-        return attachRouteHandlerMiddlewareContext(response);
+        return __applyRouteHandlerMiddlewareContext(
+          __finalizeRouteHandlerResponse(response, {
+            pendingCookies,
+            draftCookie,
+            isHead: isAutoHead,
+          }),
+          _mwCtx,
+        );
       } catch (err) {
         getAndClearPendingCookies(); // Clear any pending cookies on error
         // Catch redirect() / notFound() thrown from route handlers
@@ -2136,16 +2094,19 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
             const statusCode = parts[3] ? parseInt(parts[3], 10) : 307;
             setHeadersContext(null);
             setNavigationContext(null);
-            return attachRouteHandlerMiddlewareContext(new Response(null, {
-              status: statusCode,
-              headers: { Location: new URL(redirectUrl, request.url).toString() },
-            }));
+            return __applyRouteHandlerMiddlewareContext(
+              new Response(null, {
+                status: statusCode,
+                headers: { Location: new URL(redirectUrl, request.url).toString() },
+              }),
+              _mwCtx,
+            );
           }
           if (digest === "NEXT_NOT_FOUND" || digest.startsWith("NEXT_HTTP_ERROR_FALLBACK;")) {
             const statusCode = digest === "NEXT_NOT_FOUND" ? 404 : parseInt(digest.split(";")[1], 10);
             setHeadersContext(null);
             setNavigationContext(null);
-            return attachRouteHandlerMiddlewareContext(new Response(null, { status: statusCode }));
+            return __applyRouteHandlerMiddlewareContext(new Response(null, { status: statusCode }), _mwCtx);
           }
         }
         setHeadersContext(null);
@@ -2156,16 +2117,19 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           { path: cleanPathname, method: request.method, headers: Object.fromEntries(request.headers.entries()) },
           { routerKind: "App Router", routePath: route.pattern, routeType: "route" },
         );
-        return attachRouteHandlerMiddlewareContext(new Response(null, { status: 500 }));
+        return __applyRouteHandlerMiddlewareContext(new Response(null, { status: 500 }), _mwCtx);
       } finally {
         setHeadersAccessPhase(previousHeadersPhase);
       }
     }
     setHeadersContext(null);
     setNavigationContext(null);
-    return attachRouteHandlerMiddlewareContext(new Response(null, {
-      status: 405,
-    }));
+    return __applyRouteHandlerMiddlewareContext(
+      new Response(null, {
+        status: 405,
+      }),
+      _mwCtx,
+    );
   }
 
   // Build the component tree: layouts wrapping the page
@@ -3063,6 +3027,14 @@ import {
   isKnownDynamicAppRoute as __isKnownDynamicAppRoute,
   markKnownDynamicAppRoute as __markKnownDynamicAppRoute,
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-runtime.js";
+import {
+  applyRouteHandlerMiddlewareContext as __applyRouteHandlerMiddlewareContext,
+  applyRouteHandlerRevalidateHeader as __applyRouteHandlerRevalidateHeader,
+  buildAppRouteCacheValue as __buildAppRouteCacheValue,
+  buildRouteHandlerCachedResponse as __buildRouteHandlerCachedResponse,
+  finalizeRouteHandlerResponse as __finalizeRouteHandlerResponse,
+  markRouteHandlerCacheMiss as __markRouteHandlerCacheMiss,
+} from "<ROOT>/packages/vinext/src/server/app-route-handler-response.js";
 import { _consumeRequestScopedCacheLife, getCacheHandler } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
 import { ensureFetchPatch as _ensureFetchPatch, getCollectedFetchTags } from "vinext/fetch-cache";
@@ -4895,37 +4867,17 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     const exportedMethods = collectRouteHandlerMethods(handler);
     const allowHeaderForOptions = buildRouteHandlerAllowHeader(exportedMethods);
 
-    // Route handlers need the same middleware header/status merge behavior as
-    // page responses. This keeps middleware response headers visible on API
-    // routes in Workers/dev, and preserves custom rewrite status overrides.
-    function attachRouteHandlerMiddlewareContext(response) {
-      // _mwCtx.headers is only set (non-null) when middleware actually ran and
-      // produced a continue/rewrite response. An empty Headers object (middleware
-      // ran but produced no response headers) is a harmless edge case: the early
-      // return is skipped, but the copy loop below is a no-op, so no incorrect
-      // headers are added. The allocation cost in that case is acceptable.
-      if (!_mwCtx.headers && _mwCtx.status == null) return response;
-      const responseHeaders = new Headers(response.headers);
-      if (_mwCtx.headers) {
-        for (const [key, value] of _mwCtx.headers) {
-          responseHeaders.append(key, value);
-        }
-      }
-      return new Response(response.body, {
-        status: _mwCtx.status ?? response.status,
-        statusText: response.statusText,
-        headers: responseHeaders,
-      });
-    }
-
     // OPTIONS auto-implementation: respond with Allow header and 204
     if (method === "OPTIONS" && typeof handler["OPTIONS"] !== "function") {
       setHeadersContext(null);
       setNavigationContext(null);
-      return attachRouteHandlerMiddlewareContext(new Response(null, {
-        status: 204,
-        headers: { "Allow": allowHeaderForOptions },
-      }));
+      return __applyRouteHandlerMiddlewareContext(
+        new Response(null, {
+          status: 204,
+          headers: { "Allow": allowHeaderForOptions },
+        }),
+        _mwCtx,
+      );
     }
 
     // HEAD auto-implementation: run GET handler and strip body
@@ -4958,13 +4910,14 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           __isrDebug?.("HIT (route)", cleanPathname);
           setHeadersContext(null);
           setNavigationContext(null);
-          const __hitHeaders = Object.assign({}, __cv.headers || {});
-          __hitHeaders["X-Vinext-Cache"] = "HIT";
-          __hitHeaders["Cache-Control"] = "s-maxage=" + revalidateSeconds + ", stale-while-revalidate";
-          if (isAutoHead) {
-            return attachRouteHandlerMiddlewareContext(new Response(null, { status: __cv.status, headers: __hitHeaders }));
-          }
-          return attachRouteHandlerMiddlewareContext(new Response(__cv.body, { status: __cv.status, headers: __hitHeaders }));
+          return __applyRouteHandlerMiddlewareContext(
+            __buildRouteHandlerCachedResponse(__cv, {
+              cacheState: "HIT",
+              isHead: isAutoHead,
+              revalidateSeconds,
+            }),
+            _mwCtx,
+          );
         }
         if (__cached && __cached.isStale && __cached.value.value && __cached.value.value.kind === "APP_ROUTE") {
           // STALE — serve stale response, trigger background regeneration
@@ -5004,26 +4957,23 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
                 __isrDebug?.("route regen skipped (dynamic usage)", cleanPathname);
                 return;
               }
-              const __freshBody = await __revalResponse.arrayBuffer();
-              const __freshHeaders = {};
-              __revalResponse.headers.forEach(function(v, k) {
-                if (k !== "x-vinext-cache" && k !== "cache-control") __freshHeaders[k] = v;
-              });
               const __routeTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
-              await __isrSet(__routeKey, { kind: "APP_ROUTE", body: __freshBody, status: __revalResponse.status, headers: __freshHeaders }, __revalSecs, __routeTags);
+              const __routeCacheValue = await __buildAppRouteCacheValue(__revalResponse);
+              await __isrSet(__routeKey, __routeCacheValue, __revalSecs, __routeTags);
               __isrDebug?.("route regen complete", __routeKey);
             });
           });
           __isrDebug?.("STALE (route)", cleanPathname);
           setHeadersContext(null);
           setNavigationContext(null);
-          const __staleHeaders = Object.assign({}, __sv.headers || {});
-          __staleHeaders["X-Vinext-Cache"] = "STALE";
-          __staleHeaders["Cache-Control"] = "s-maxage=0, stale-while-revalidate";
-          if (isAutoHead) {
-            return attachRouteHandlerMiddlewareContext(new Response(null, { status: __sv.status, headers: __staleHeaders }));
-          }
-          return attachRouteHandlerMiddlewareContext(new Response(__sv.body, { status: __sv.status, headers: __staleHeaders }));
+          return __applyRouteHandlerMiddlewareContext(
+            __buildRouteHandlerCachedResponse(__sv, {
+              cacheState: "STALE",
+              isHead: isAutoHead,
+              revalidateSeconds,
+            }),
+            _mwCtx,
+          );
         }
       } catch (__routeCacheErr) {
         // Cache read failure — fall through to normal handler execution
@@ -5059,7 +5009,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           (method === "GET" || isAutoHead) &&
           !handlerSetCacheControl
         ) {
-          response.headers.set("cache-control", "s-maxage=" + revalidateSeconds + ", stale-while-revalidate");
+          __applyRouteHandlerRevalidateHeader(response, revalidateSeconds);
         }
 
         // ISR cache write for route handlers (production, MISS).
@@ -5073,19 +5023,15 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           (method === "GET" || isAutoHead) &&
           !handlerSetCacheControl
         ) {
-          response.headers.set("X-Vinext-Cache", "MISS");
+          __markRouteHandlerCacheMiss(response);
           const __routeClone = response.clone();
           const __routeKey = __isrRouteKey(cleanPathname);
           const __revalSecs = revalidateSeconds;
           const __routeTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
           const __routeWritePromise = (async () => {
             try {
-              const __buf = await __routeClone.arrayBuffer();
-              const __hdrs = {};
-              __routeClone.headers.forEach(function(v, k) {
-                if (k !== "x-vinext-cache" && k !== "cache-control") __hdrs[k] = v;
-              });
-              await __isrSet(__routeKey, { kind: "APP_ROUTE", body: __buf, status: __routeClone.status, headers: __hdrs }, __revalSecs, __routeTags);
+              const __routeCacheValue = await __buildAppRouteCacheValue(__routeClone);
+              await __isrSet(__routeKey, __routeCacheValue, __revalSecs, __routeTags);
               __isrDebug?.("route cache written", __routeKey);
             } catch (__cacheErr) {
               console.error("[vinext] ISR route cache write error:", __cacheErr);
@@ -5099,38 +5045,14 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         const draftCookie = getDraftModeCookieHeader();
         setHeadersContext(null);
         setNavigationContext(null);
-
-        // If we have pending cookies, create a new response with them attached
-        if (pendingCookies.length > 0 || draftCookie) {
-          const newHeaders = new Headers(response.headers);
-          for (const cookie of pendingCookies) {
-            newHeaders.append("Set-Cookie", cookie);
-          }
-          if (draftCookie) newHeaders.append("Set-Cookie", draftCookie);
-
-          if (isAutoHead) {
-            return attachRouteHandlerMiddlewareContext(new Response(null, {
-              status: response.status,
-              statusText: response.statusText,
-              headers: newHeaders,
-            }));
-          }
-          return attachRouteHandlerMiddlewareContext(new Response(response.body, {
-            status: response.status,
-            statusText: response.statusText,
-            headers: newHeaders,
-          }));
-        }
-
-        if (isAutoHead) {
-          // Strip body for auto-HEAD, preserve headers and status
-          return attachRouteHandlerMiddlewareContext(new Response(null, {
-            status: response.status,
-            statusText: response.statusText,
-            headers: response.headers,
-          }));
-        }
-        return attachRouteHandlerMiddlewareContext(response);
+        return __applyRouteHandlerMiddlewareContext(
+          __finalizeRouteHandlerResponse(response, {
+            pendingCookies,
+            draftCookie,
+            isHead: isAutoHead,
+          }),
+          _mwCtx,
+        );
       } catch (err) {
         getAndClearPendingCookies(); // Clear any pending cookies on error
         // Catch redirect() / notFound() thrown from route handlers
@@ -5142,16 +5064,19 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
             const statusCode = parts[3] ? parseInt(parts[3], 10) : 307;
             setHeadersContext(null);
             setNavigationContext(null);
-            return attachRouteHandlerMiddlewareContext(new Response(null, {
-              status: statusCode,
-              headers: { Location: new URL(redirectUrl, request.url).toString() },
-            }));
+            return __applyRouteHandlerMiddlewareContext(
+              new Response(null, {
+                status: statusCode,
+                headers: { Location: new URL(redirectUrl, request.url).toString() },
+              }),
+              _mwCtx,
+            );
           }
           if (digest === "NEXT_NOT_FOUND" || digest.startsWith("NEXT_HTTP_ERROR_FALLBACK;")) {
             const statusCode = digest === "NEXT_NOT_FOUND" ? 404 : parseInt(digest.split(";")[1], 10);
             setHeadersContext(null);
             setNavigationContext(null);
-            return attachRouteHandlerMiddlewareContext(new Response(null, { status: statusCode }));
+            return __applyRouteHandlerMiddlewareContext(new Response(null, { status: statusCode }), _mwCtx);
           }
         }
         setHeadersContext(null);
@@ -5162,16 +5087,19 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           { path: cleanPathname, method: request.method, headers: Object.fromEntries(request.headers.entries()) },
           { routerKind: "App Router", routePath: route.pattern, routeType: "route" },
         );
-        return attachRouteHandlerMiddlewareContext(new Response(null, { status: 500 }));
+        return __applyRouteHandlerMiddlewareContext(new Response(null, { status: 500 }), _mwCtx);
       } finally {
         setHeadersAccessPhase(previousHeadersPhase);
       }
     }
     setHeadersContext(null);
     setNavigationContext(null);
-    return attachRouteHandlerMiddlewareContext(new Response(null, {
-      status: 405,
-    }));
+    return __applyRouteHandlerMiddlewareContext(
+      new Response(null, {
+        status: 405,
+      }),
+      _mwCtx,
+    );
   }
 
   // Build the component tree: layouts wrapping the page
@@ -6069,6 +5997,14 @@ import {
   isKnownDynamicAppRoute as __isKnownDynamicAppRoute,
   markKnownDynamicAppRoute as __markKnownDynamicAppRoute,
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-runtime.js";
+import {
+  applyRouteHandlerMiddlewareContext as __applyRouteHandlerMiddlewareContext,
+  applyRouteHandlerRevalidateHeader as __applyRouteHandlerRevalidateHeader,
+  buildAppRouteCacheValue as __buildAppRouteCacheValue,
+  buildRouteHandlerCachedResponse as __buildRouteHandlerCachedResponse,
+  finalizeRouteHandlerResponse as __finalizeRouteHandlerResponse,
+  markRouteHandlerCacheMiss as __markRouteHandlerCacheMiss,
+} from "<ROOT>/packages/vinext/src/server/app-route-handler-response.js";
 import { _consumeRequestScopedCacheLife, getCacheHandler } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
 import { ensureFetchPatch as _ensureFetchPatch, getCollectedFetchTags } from "vinext/fetch-cache";
@@ -7928,37 +7864,17 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     const exportedMethods = collectRouteHandlerMethods(handler);
     const allowHeaderForOptions = buildRouteHandlerAllowHeader(exportedMethods);
 
-    // Route handlers need the same middleware header/status merge behavior as
-    // page responses. This keeps middleware response headers visible on API
-    // routes in Workers/dev, and preserves custom rewrite status overrides.
-    function attachRouteHandlerMiddlewareContext(response) {
-      // _mwCtx.headers is only set (non-null) when middleware actually ran and
-      // produced a continue/rewrite response. An empty Headers object (middleware
-      // ran but produced no response headers) is a harmless edge case: the early
-      // return is skipped, but the copy loop below is a no-op, so no incorrect
-      // headers are added. The allocation cost in that case is acceptable.
-      if (!_mwCtx.headers && _mwCtx.status == null) return response;
-      const responseHeaders = new Headers(response.headers);
-      if (_mwCtx.headers) {
-        for (const [key, value] of _mwCtx.headers) {
-          responseHeaders.append(key, value);
-        }
-      }
-      return new Response(response.body, {
-        status: _mwCtx.status ?? response.status,
-        statusText: response.statusText,
-        headers: responseHeaders,
-      });
-    }
-
     // OPTIONS auto-implementation: respond with Allow header and 204
     if (method === "OPTIONS" && typeof handler["OPTIONS"] !== "function") {
       setHeadersContext(null);
       setNavigationContext(null);
-      return attachRouteHandlerMiddlewareContext(new Response(null, {
-        status: 204,
-        headers: { "Allow": allowHeaderForOptions },
-      }));
+      return __applyRouteHandlerMiddlewareContext(
+        new Response(null, {
+          status: 204,
+          headers: { "Allow": allowHeaderForOptions },
+        }),
+        _mwCtx,
+      );
     }
 
     // HEAD auto-implementation: run GET handler and strip body
@@ -7991,13 +7907,14 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           __isrDebug?.("HIT (route)", cleanPathname);
           setHeadersContext(null);
           setNavigationContext(null);
-          const __hitHeaders = Object.assign({}, __cv.headers || {});
-          __hitHeaders["X-Vinext-Cache"] = "HIT";
-          __hitHeaders["Cache-Control"] = "s-maxage=" + revalidateSeconds + ", stale-while-revalidate";
-          if (isAutoHead) {
-            return attachRouteHandlerMiddlewareContext(new Response(null, { status: __cv.status, headers: __hitHeaders }));
-          }
-          return attachRouteHandlerMiddlewareContext(new Response(__cv.body, { status: __cv.status, headers: __hitHeaders }));
+          return __applyRouteHandlerMiddlewareContext(
+            __buildRouteHandlerCachedResponse(__cv, {
+              cacheState: "HIT",
+              isHead: isAutoHead,
+              revalidateSeconds,
+            }),
+            _mwCtx,
+          );
         }
         if (__cached && __cached.isStale && __cached.value.value && __cached.value.value.kind === "APP_ROUTE") {
           // STALE — serve stale response, trigger background regeneration
@@ -8037,26 +7954,23 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
                 __isrDebug?.("route regen skipped (dynamic usage)", cleanPathname);
                 return;
               }
-              const __freshBody = await __revalResponse.arrayBuffer();
-              const __freshHeaders = {};
-              __revalResponse.headers.forEach(function(v, k) {
-                if (k !== "x-vinext-cache" && k !== "cache-control") __freshHeaders[k] = v;
-              });
               const __routeTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
-              await __isrSet(__routeKey, { kind: "APP_ROUTE", body: __freshBody, status: __revalResponse.status, headers: __freshHeaders }, __revalSecs, __routeTags);
+              const __routeCacheValue = await __buildAppRouteCacheValue(__revalResponse);
+              await __isrSet(__routeKey, __routeCacheValue, __revalSecs, __routeTags);
               __isrDebug?.("route regen complete", __routeKey);
             });
           });
           __isrDebug?.("STALE (route)", cleanPathname);
           setHeadersContext(null);
           setNavigationContext(null);
-          const __staleHeaders = Object.assign({}, __sv.headers || {});
-          __staleHeaders["X-Vinext-Cache"] = "STALE";
-          __staleHeaders["Cache-Control"] = "s-maxage=0, stale-while-revalidate";
-          if (isAutoHead) {
-            return attachRouteHandlerMiddlewareContext(new Response(null, { status: __sv.status, headers: __staleHeaders }));
-          }
-          return attachRouteHandlerMiddlewareContext(new Response(__sv.body, { status: __sv.status, headers: __staleHeaders }));
+          return __applyRouteHandlerMiddlewareContext(
+            __buildRouteHandlerCachedResponse(__sv, {
+              cacheState: "STALE",
+              isHead: isAutoHead,
+              revalidateSeconds,
+            }),
+            _mwCtx,
+          );
         }
       } catch (__routeCacheErr) {
         // Cache read failure — fall through to normal handler execution
@@ -8092,7 +8006,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           (method === "GET" || isAutoHead) &&
           !handlerSetCacheControl
         ) {
-          response.headers.set("cache-control", "s-maxage=" + revalidateSeconds + ", stale-while-revalidate");
+          __applyRouteHandlerRevalidateHeader(response, revalidateSeconds);
         }
 
         // ISR cache write for route handlers (production, MISS).
@@ -8106,19 +8020,15 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           (method === "GET" || isAutoHead) &&
           !handlerSetCacheControl
         ) {
-          response.headers.set("X-Vinext-Cache", "MISS");
+          __markRouteHandlerCacheMiss(response);
           const __routeClone = response.clone();
           const __routeKey = __isrRouteKey(cleanPathname);
           const __revalSecs = revalidateSeconds;
           const __routeTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
           const __routeWritePromise = (async () => {
             try {
-              const __buf = await __routeClone.arrayBuffer();
-              const __hdrs = {};
-              __routeClone.headers.forEach(function(v, k) {
-                if (k !== "x-vinext-cache" && k !== "cache-control") __hdrs[k] = v;
-              });
-              await __isrSet(__routeKey, { kind: "APP_ROUTE", body: __buf, status: __routeClone.status, headers: __hdrs }, __revalSecs, __routeTags);
+              const __routeCacheValue = await __buildAppRouteCacheValue(__routeClone);
+              await __isrSet(__routeKey, __routeCacheValue, __revalSecs, __routeTags);
               __isrDebug?.("route cache written", __routeKey);
             } catch (__cacheErr) {
               console.error("[vinext] ISR route cache write error:", __cacheErr);
@@ -8132,38 +8042,14 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         const draftCookie = getDraftModeCookieHeader();
         setHeadersContext(null);
         setNavigationContext(null);
-
-        // If we have pending cookies, create a new response with them attached
-        if (pendingCookies.length > 0 || draftCookie) {
-          const newHeaders = new Headers(response.headers);
-          for (const cookie of pendingCookies) {
-            newHeaders.append("Set-Cookie", cookie);
-          }
-          if (draftCookie) newHeaders.append("Set-Cookie", draftCookie);
-
-          if (isAutoHead) {
-            return attachRouteHandlerMiddlewareContext(new Response(null, {
-              status: response.status,
-              statusText: response.statusText,
-              headers: newHeaders,
-            }));
-          }
-          return attachRouteHandlerMiddlewareContext(new Response(response.body, {
-            status: response.status,
-            statusText: response.statusText,
-            headers: newHeaders,
-          }));
-        }
-
-        if (isAutoHead) {
-          // Strip body for auto-HEAD, preserve headers and status
-          return attachRouteHandlerMiddlewareContext(new Response(null, {
-            status: response.status,
-            statusText: response.statusText,
-            headers: response.headers,
-          }));
-        }
-        return attachRouteHandlerMiddlewareContext(response);
+        return __applyRouteHandlerMiddlewareContext(
+          __finalizeRouteHandlerResponse(response, {
+            pendingCookies,
+            draftCookie,
+            isHead: isAutoHead,
+          }),
+          _mwCtx,
+        );
       } catch (err) {
         getAndClearPendingCookies(); // Clear any pending cookies on error
         // Catch redirect() / notFound() thrown from route handlers
@@ -8175,16 +8061,19 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
             const statusCode = parts[3] ? parseInt(parts[3], 10) : 307;
             setHeadersContext(null);
             setNavigationContext(null);
-            return attachRouteHandlerMiddlewareContext(new Response(null, {
-              status: statusCode,
-              headers: { Location: new URL(redirectUrl, request.url).toString() },
-            }));
+            return __applyRouteHandlerMiddlewareContext(
+              new Response(null, {
+                status: statusCode,
+                headers: { Location: new URL(redirectUrl, request.url).toString() },
+              }),
+              _mwCtx,
+            );
           }
           if (digest === "NEXT_NOT_FOUND" || digest.startsWith("NEXT_HTTP_ERROR_FALLBACK;")) {
             const statusCode = digest === "NEXT_NOT_FOUND" ? 404 : parseInt(digest.split(";")[1], 10);
             setHeadersContext(null);
             setNavigationContext(null);
-            return attachRouteHandlerMiddlewareContext(new Response(null, { status: statusCode }));
+            return __applyRouteHandlerMiddlewareContext(new Response(null, { status: statusCode }), _mwCtx);
           }
         }
         setHeadersContext(null);
@@ -8195,16 +8084,19 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           { path: cleanPathname, method: request.method, headers: Object.fromEntries(request.headers.entries()) },
           { routerKind: "App Router", routePath: route.pattern, routeType: "route" },
         );
-        return attachRouteHandlerMiddlewareContext(new Response(null, { status: 500 }));
+        return __applyRouteHandlerMiddlewareContext(new Response(null, { status: 500 }), _mwCtx);
       } finally {
         setHeadersAccessPhase(previousHeadersPhase);
       }
     }
     setHeadersContext(null);
     setNavigationContext(null);
-    return attachRouteHandlerMiddlewareContext(new Response(null, {
-      status: 405,
-    }));
+    return __applyRouteHandlerMiddlewareContext(
+      new Response(null, {
+        status: 405,
+      }),
+      _mwCtx,
+    );
   }
 
   // Build the component tree: layouts wrapping the page
@@ -9110,6 +9002,14 @@ import {
   isKnownDynamicAppRoute as __isKnownDynamicAppRoute,
   markKnownDynamicAppRoute as __markKnownDynamicAppRoute,
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-runtime.js";
+import {
+  applyRouteHandlerMiddlewareContext as __applyRouteHandlerMiddlewareContext,
+  applyRouteHandlerRevalidateHeader as __applyRouteHandlerRevalidateHeader,
+  buildAppRouteCacheValue as __buildAppRouteCacheValue,
+  buildRouteHandlerCachedResponse as __buildRouteHandlerCachedResponse,
+  finalizeRouteHandlerResponse as __finalizeRouteHandlerResponse,
+  markRouteHandlerCacheMiss as __markRouteHandlerCacheMiss,
+} from "<ROOT>/packages/vinext/src/server/app-route-handler-response.js";
 import { _consumeRequestScopedCacheLife, getCacheHandler } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
 import { ensureFetchPatch as _ensureFetchPatch, getCollectedFetchTags } from "vinext/fetch-cache";
@@ -10972,37 +10872,17 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     const exportedMethods = collectRouteHandlerMethods(handler);
     const allowHeaderForOptions = buildRouteHandlerAllowHeader(exportedMethods);
 
-    // Route handlers need the same middleware header/status merge behavior as
-    // page responses. This keeps middleware response headers visible on API
-    // routes in Workers/dev, and preserves custom rewrite status overrides.
-    function attachRouteHandlerMiddlewareContext(response) {
-      // _mwCtx.headers is only set (non-null) when middleware actually ran and
-      // produced a continue/rewrite response. An empty Headers object (middleware
-      // ran but produced no response headers) is a harmless edge case: the early
-      // return is skipped, but the copy loop below is a no-op, so no incorrect
-      // headers are added. The allocation cost in that case is acceptable.
-      if (!_mwCtx.headers && _mwCtx.status == null) return response;
-      const responseHeaders = new Headers(response.headers);
-      if (_mwCtx.headers) {
-        for (const [key, value] of _mwCtx.headers) {
-          responseHeaders.append(key, value);
-        }
-      }
-      return new Response(response.body, {
-        status: _mwCtx.status ?? response.status,
-        statusText: response.statusText,
-        headers: responseHeaders,
-      });
-    }
-
     // OPTIONS auto-implementation: respond with Allow header and 204
     if (method === "OPTIONS" && typeof handler["OPTIONS"] !== "function") {
       setHeadersContext(null);
       setNavigationContext(null);
-      return attachRouteHandlerMiddlewareContext(new Response(null, {
-        status: 204,
-        headers: { "Allow": allowHeaderForOptions },
-      }));
+      return __applyRouteHandlerMiddlewareContext(
+        new Response(null, {
+          status: 204,
+          headers: { "Allow": allowHeaderForOptions },
+        }),
+        _mwCtx,
+      );
     }
 
     // HEAD auto-implementation: run GET handler and strip body
@@ -11035,13 +10915,14 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           __isrDebug?.("HIT (route)", cleanPathname);
           setHeadersContext(null);
           setNavigationContext(null);
-          const __hitHeaders = Object.assign({}, __cv.headers || {});
-          __hitHeaders["X-Vinext-Cache"] = "HIT";
-          __hitHeaders["Cache-Control"] = "s-maxage=" + revalidateSeconds + ", stale-while-revalidate";
-          if (isAutoHead) {
-            return attachRouteHandlerMiddlewareContext(new Response(null, { status: __cv.status, headers: __hitHeaders }));
-          }
-          return attachRouteHandlerMiddlewareContext(new Response(__cv.body, { status: __cv.status, headers: __hitHeaders }));
+          return __applyRouteHandlerMiddlewareContext(
+            __buildRouteHandlerCachedResponse(__cv, {
+              cacheState: "HIT",
+              isHead: isAutoHead,
+              revalidateSeconds,
+            }),
+            _mwCtx,
+          );
         }
         if (__cached && __cached.isStale && __cached.value.value && __cached.value.value.kind === "APP_ROUTE") {
           // STALE — serve stale response, trigger background regeneration
@@ -11081,26 +10962,23 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
                 __isrDebug?.("route regen skipped (dynamic usage)", cleanPathname);
                 return;
               }
-              const __freshBody = await __revalResponse.arrayBuffer();
-              const __freshHeaders = {};
-              __revalResponse.headers.forEach(function(v, k) {
-                if (k !== "x-vinext-cache" && k !== "cache-control") __freshHeaders[k] = v;
-              });
               const __routeTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
-              await __isrSet(__routeKey, { kind: "APP_ROUTE", body: __freshBody, status: __revalResponse.status, headers: __freshHeaders }, __revalSecs, __routeTags);
+              const __routeCacheValue = await __buildAppRouteCacheValue(__revalResponse);
+              await __isrSet(__routeKey, __routeCacheValue, __revalSecs, __routeTags);
               __isrDebug?.("route regen complete", __routeKey);
             });
           });
           __isrDebug?.("STALE (route)", cleanPathname);
           setHeadersContext(null);
           setNavigationContext(null);
-          const __staleHeaders = Object.assign({}, __sv.headers || {});
-          __staleHeaders["X-Vinext-Cache"] = "STALE";
-          __staleHeaders["Cache-Control"] = "s-maxage=0, stale-while-revalidate";
-          if (isAutoHead) {
-            return attachRouteHandlerMiddlewareContext(new Response(null, { status: __sv.status, headers: __staleHeaders }));
-          }
-          return attachRouteHandlerMiddlewareContext(new Response(__sv.body, { status: __sv.status, headers: __staleHeaders }));
+          return __applyRouteHandlerMiddlewareContext(
+            __buildRouteHandlerCachedResponse(__sv, {
+              cacheState: "STALE",
+              isHead: isAutoHead,
+              revalidateSeconds,
+            }),
+            _mwCtx,
+          );
         }
       } catch (__routeCacheErr) {
         // Cache read failure — fall through to normal handler execution
@@ -11136,7 +11014,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           (method === "GET" || isAutoHead) &&
           !handlerSetCacheControl
         ) {
-          response.headers.set("cache-control", "s-maxage=" + revalidateSeconds + ", stale-while-revalidate");
+          __applyRouteHandlerRevalidateHeader(response, revalidateSeconds);
         }
 
         // ISR cache write for route handlers (production, MISS).
@@ -11150,19 +11028,15 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           (method === "GET" || isAutoHead) &&
           !handlerSetCacheControl
         ) {
-          response.headers.set("X-Vinext-Cache", "MISS");
+          __markRouteHandlerCacheMiss(response);
           const __routeClone = response.clone();
           const __routeKey = __isrRouteKey(cleanPathname);
           const __revalSecs = revalidateSeconds;
           const __routeTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
           const __routeWritePromise = (async () => {
             try {
-              const __buf = await __routeClone.arrayBuffer();
-              const __hdrs = {};
-              __routeClone.headers.forEach(function(v, k) {
-                if (k !== "x-vinext-cache" && k !== "cache-control") __hdrs[k] = v;
-              });
-              await __isrSet(__routeKey, { kind: "APP_ROUTE", body: __buf, status: __routeClone.status, headers: __hdrs }, __revalSecs, __routeTags);
+              const __routeCacheValue = await __buildAppRouteCacheValue(__routeClone);
+              await __isrSet(__routeKey, __routeCacheValue, __revalSecs, __routeTags);
               __isrDebug?.("route cache written", __routeKey);
             } catch (__cacheErr) {
               console.error("[vinext] ISR route cache write error:", __cacheErr);
@@ -11176,38 +11050,14 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         const draftCookie = getDraftModeCookieHeader();
         setHeadersContext(null);
         setNavigationContext(null);
-
-        // If we have pending cookies, create a new response with them attached
-        if (pendingCookies.length > 0 || draftCookie) {
-          const newHeaders = new Headers(response.headers);
-          for (const cookie of pendingCookies) {
-            newHeaders.append("Set-Cookie", cookie);
-          }
-          if (draftCookie) newHeaders.append("Set-Cookie", draftCookie);
-
-          if (isAutoHead) {
-            return attachRouteHandlerMiddlewareContext(new Response(null, {
-              status: response.status,
-              statusText: response.statusText,
-              headers: newHeaders,
-            }));
-          }
-          return attachRouteHandlerMiddlewareContext(new Response(response.body, {
-            status: response.status,
-            statusText: response.statusText,
-            headers: newHeaders,
-          }));
-        }
-
-        if (isAutoHead) {
-          // Strip body for auto-HEAD, preserve headers and status
-          return attachRouteHandlerMiddlewareContext(new Response(null, {
-            status: response.status,
-            statusText: response.statusText,
-            headers: response.headers,
-          }));
-        }
-        return attachRouteHandlerMiddlewareContext(response);
+        return __applyRouteHandlerMiddlewareContext(
+          __finalizeRouteHandlerResponse(response, {
+            pendingCookies,
+            draftCookie,
+            isHead: isAutoHead,
+          }),
+          _mwCtx,
+        );
       } catch (err) {
         getAndClearPendingCookies(); // Clear any pending cookies on error
         // Catch redirect() / notFound() thrown from route handlers
@@ -11219,16 +11069,19 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
             const statusCode = parts[3] ? parseInt(parts[3], 10) : 307;
             setHeadersContext(null);
             setNavigationContext(null);
-            return attachRouteHandlerMiddlewareContext(new Response(null, {
-              status: statusCode,
-              headers: { Location: new URL(redirectUrl, request.url).toString() },
-            }));
+            return __applyRouteHandlerMiddlewareContext(
+              new Response(null, {
+                status: statusCode,
+                headers: { Location: new URL(redirectUrl, request.url).toString() },
+              }),
+              _mwCtx,
+            );
           }
           if (digest === "NEXT_NOT_FOUND" || digest.startsWith("NEXT_HTTP_ERROR_FALLBACK;")) {
             const statusCode = digest === "NEXT_NOT_FOUND" ? 404 : parseInt(digest.split(";")[1], 10);
             setHeadersContext(null);
             setNavigationContext(null);
-            return attachRouteHandlerMiddlewareContext(new Response(null, { status: statusCode }));
+            return __applyRouteHandlerMiddlewareContext(new Response(null, { status: statusCode }), _mwCtx);
           }
         }
         setHeadersContext(null);
@@ -11239,16 +11092,19 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           { path: cleanPathname, method: request.method, headers: Object.fromEntries(request.headers.entries()) },
           { routerKind: "App Router", routePath: route.pattern, routeType: "route" },
         );
-        return attachRouteHandlerMiddlewareContext(new Response(null, { status: 500 }));
+        return __applyRouteHandlerMiddlewareContext(new Response(null, { status: 500 }), _mwCtx);
       } finally {
         setHeadersAccessPhase(previousHeadersPhase);
       }
     }
     setHeadersContext(null);
     setNavigationContext(null);
-    return attachRouteHandlerMiddlewareContext(new Response(null, {
-      status: 405,
-    }));
+    return __applyRouteHandlerMiddlewareContext(
+      new Response(null, {
+        status: 405,
+      }),
+      _mwCtx,
+    );
   }
 
   // Build the component tree: layouts wrapping the page
@@ -12146,6 +12002,14 @@ import {
   isKnownDynamicAppRoute as __isKnownDynamicAppRoute,
   markKnownDynamicAppRoute as __markKnownDynamicAppRoute,
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-runtime.js";
+import {
+  applyRouteHandlerMiddlewareContext as __applyRouteHandlerMiddlewareContext,
+  applyRouteHandlerRevalidateHeader as __applyRouteHandlerRevalidateHeader,
+  buildAppRouteCacheValue as __buildAppRouteCacheValue,
+  buildRouteHandlerCachedResponse as __buildRouteHandlerCachedResponse,
+  finalizeRouteHandlerResponse as __finalizeRouteHandlerResponse,
+  markRouteHandlerCacheMiss as __markRouteHandlerCacheMiss,
+} from "<ROOT>/packages/vinext/src/server/app-route-handler-response.js";
 import { _consumeRequestScopedCacheLife, getCacheHandler } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
 import { ensureFetchPatch as _ensureFetchPatch, getCollectedFetchTags } from "vinext/fetch-cache";
@@ -13982,37 +13846,17 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     const exportedMethods = collectRouteHandlerMethods(handler);
     const allowHeaderForOptions = buildRouteHandlerAllowHeader(exportedMethods);
 
-    // Route handlers need the same middleware header/status merge behavior as
-    // page responses. This keeps middleware response headers visible on API
-    // routes in Workers/dev, and preserves custom rewrite status overrides.
-    function attachRouteHandlerMiddlewareContext(response) {
-      // _mwCtx.headers is only set (non-null) when middleware actually ran and
-      // produced a continue/rewrite response. An empty Headers object (middleware
-      // ran but produced no response headers) is a harmless edge case: the early
-      // return is skipped, but the copy loop below is a no-op, so no incorrect
-      // headers are added. The allocation cost in that case is acceptable.
-      if (!_mwCtx.headers && _mwCtx.status == null) return response;
-      const responseHeaders = new Headers(response.headers);
-      if (_mwCtx.headers) {
-        for (const [key, value] of _mwCtx.headers) {
-          responseHeaders.append(key, value);
-        }
-      }
-      return new Response(response.body, {
-        status: _mwCtx.status ?? response.status,
-        statusText: response.statusText,
-        headers: responseHeaders,
-      });
-    }
-
     // OPTIONS auto-implementation: respond with Allow header and 204
     if (method === "OPTIONS" && typeof handler["OPTIONS"] !== "function") {
       setHeadersContext(null);
       setNavigationContext(null);
-      return attachRouteHandlerMiddlewareContext(new Response(null, {
-        status: 204,
-        headers: { "Allow": allowHeaderForOptions },
-      }));
+      return __applyRouteHandlerMiddlewareContext(
+        new Response(null, {
+          status: 204,
+          headers: { "Allow": allowHeaderForOptions },
+        }),
+        _mwCtx,
+      );
     }
 
     // HEAD auto-implementation: run GET handler and strip body
@@ -14045,13 +13889,14 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           __isrDebug?.("HIT (route)", cleanPathname);
           setHeadersContext(null);
           setNavigationContext(null);
-          const __hitHeaders = Object.assign({}, __cv.headers || {});
-          __hitHeaders["X-Vinext-Cache"] = "HIT";
-          __hitHeaders["Cache-Control"] = "s-maxage=" + revalidateSeconds + ", stale-while-revalidate";
-          if (isAutoHead) {
-            return attachRouteHandlerMiddlewareContext(new Response(null, { status: __cv.status, headers: __hitHeaders }));
-          }
-          return attachRouteHandlerMiddlewareContext(new Response(__cv.body, { status: __cv.status, headers: __hitHeaders }));
+          return __applyRouteHandlerMiddlewareContext(
+            __buildRouteHandlerCachedResponse(__cv, {
+              cacheState: "HIT",
+              isHead: isAutoHead,
+              revalidateSeconds,
+            }),
+            _mwCtx,
+          );
         }
         if (__cached && __cached.isStale && __cached.value.value && __cached.value.value.kind === "APP_ROUTE") {
           // STALE — serve stale response, trigger background regeneration
@@ -14091,26 +13936,23 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
                 __isrDebug?.("route regen skipped (dynamic usage)", cleanPathname);
                 return;
               }
-              const __freshBody = await __revalResponse.arrayBuffer();
-              const __freshHeaders = {};
-              __revalResponse.headers.forEach(function(v, k) {
-                if (k !== "x-vinext-cache" && k !== "cache-control") __freshHeaders[k] = v;
-              });
               const __routeTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
-              await __isrSet(__routeKey, { kind: "APP_ROUTE", body: __freshBody, status: __revalResponse.status, headers: __freshHeaders }, __revalSecs, __routeTags);
+              const __routeCacheValue = await __buildAppRouteCacheValue(__revalResponse);
+              await __isrSet(__routeKey, __routeCacheValue, __revalSecs, __routeTags);
               __isrDebug?.("route regen complete", __routeKey);
             });
           });
           __isrDebug?.("STALE (route)", cleanPathname);
           setHeadersContext(null);
           setNavigationContext(null);
-          const __staleHeaders = Object.assign({}, __sv.headers || {});
-          __staleHeaders["X-Vinext-Cache"] = "STALE";
-          __staleHeaders["Cache-Control"] = "s-maxage=0, stale-while-revalidate";
-          if (isAutoHead) {
-            return attachRouteHandlerMiddlewareContext(new Response(null, { status: __sv.status, headers: __staleHeaders }));
-          }
-          return attachRouteHandlerMiddlewareContext(new Response(__sv.body, { status: __sv.status, headers: __staleHeaders }));
+          return __applyRouteHandlerMiddlewareContext(
+            __buildRouteHandlerCachedResponse(__sv, {
+              cacheState: "STALE",
+              isHead: isAutoHead,
+              revalidateSeconds,
+            }),
+            _mwCtx,
+          );
         }
       } catch (__routeCacheErr) {
         // Cache read failure — fall through to normal handler execution
@@ -14146,7 +13988,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           (method === "GET" || isAutoHead) &&
           !handlerSetCacheControl
         ) {
-          response.headers.set("cache-control", "s-maxage=" + revalidateSeconds + ", stale-while-revalidate");
+          __applyRouteHandlerRevalidateHeader(response, revalidateSeconds);
         }
 
         // ISR cache write for route handlers (production, MISS).
@@ -14160,19 +14002,15 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           (method === "GET" || isAutoHead) &&
           !handlerSetCacheControl
         ) {
-          response.headers.set("X-Vinext-Cache", "MISS");
+          __markRouteHandlerCacheMiss(response);
           const __routeClone = response.clone();
           const __routeKey = __isrRouteKey(cleanPathname);
           const __revalSecs = revalidateSeconds;
           const __routeTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
           const __routeWritePromise = (async () => {
             try {
-              const __buf = await __routeClone.arrayBuffer();
-              const __hdrs = {};
-              __routeClone.headers.forEach(function(v, k) {
-                if (k !== "x-vinext-cache" && k !== "cache-control") __hdrs[k] = v;
-              });
-              await __isrSet(__routeKey, { kind: "APP_ROUTE", body: __buf, status: __routeClone.status, headers: __hdrs }, __revalSecs, __routeTags);
+              const __routeCacheValue = await __buildAppRouteCacheValue(__routeClone);
+              await __isrSet(__routeKey, __routeCacheValue, __revalSecs, __routeTags);
               __isrDebug?.("route cache written", __routeKey);
             } catch (__cacheErr) {
               console.error("[vinext] ISR route cache write error:", __cacheErr);
@@ -14186,38 +14024,14 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         const draftCookie = getDraftModeCookieHeader();
         setHeadersContext(null);
         setNavigationContext(null);
-
-        // If we have pending cookies, create a new response with them attached
-        if (pendingCookies.length > 0 || draftCookie) {
-          const newHeaders = new Headers(response.headers);
-          for (const cookie of pendingCookies) {
-            newHeaders.append("Set-Cookie", cookie);
-          }
-          if (draftCookie) newHeaders.append("Set-Cookie", draftCookie);
-
-          if (isAutoHead) {
-            return attachRouteHandlerMiddlewareContext(new Response(null, {
-              status: response.status,
-              statusText: response.statusText,
-              headers: newHeaders,
-            }));
-          }
-          return attachRouteHandlerMiddlewareContext(new Response(response.body, {
-            status: response.status,
-            statusText: response.statusText,
-            headers: newHeaders,
-          }));
-        }
-
-        if (isAutoHead) {
-          // Strip body for auto-HEAD, preserve headers and status
-          return attachRouteHandlerMiddlewareContext(new Response(null, {
-            status: response.status,
-            statusText: response.statusText,
-            headers: response.headers,
-          }));
-        }
-        return attachRouteHandlerMiddlewareContext(response);
+        return __applyRouteHandlerMiddlewareContext(
+          __finalizeRouteHandlerResponse(response, {
+            pendingCookies,
+            draftCookie,
+            isHead: isAutoHead,
+          }),
+          _mwCtx,
+        );
       } catch (err) {
         getAndClearPendingCookies(); // Clear any pending cookies on error
         // Catch redirect() / notFound() thrown from route handlers
@@ -14229,16 +14043,19 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
             const statusCode = parts[3] ? parseInt(parts[3], 10) : 307;
             setHeadersContext(null);
             setNavigationContext(null);
-            return attachRouteHandlerMiddlewareContext(new Response(null, {
-              status: statusCode,
-              headers: { Location: new URL(redirectUrl, request.url).toString() },
-            }));
+            return __applyRouteHandlerMiddlewareContext(
+              new Response(null, {
+                status: statusCode,
+                headers: { Location: new URL(redirectUrl, request.url).toString() },
+              }),
+              _mwCtx,
+            );
           }
           if (digest === "NEXT_NOT_FOUND" || digest.startsWith("NEXT_HTTP_ERROR_FALLBACK;")) {
             const statusCode = digest === "NEXT_NOT_FOUND" ? 404 : parseInt(digest.split(";")[1], 10);
             setHeadersContext(null);
             setNavigationContext(null);
-            return attachRouteHandlerMiddlewareContext(new Response(null, { status: statusCode }));
+            return __applyRouteHandlerMiddlewareContext(new Response(null, { status: statusCode }), _mwCtx);
           }
         }
         setHeadersContext(null);
@@ -14249,16 +14066,19 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           { path: cleanPathname, method: request.method, headers: Object.fromEntries(request.headers.entries()) },
           { routerKind: "App Router", routePath: route.pattern, routeType: "route" },
         );
-        return attachRouteHandlerMiddlewareContext(new Response(null, { status: 500 }));
+        return __applyRouteHandlerMiddlewareContext(new Response(null, { status: 500 }), _mwCtx);
       } finally {
         setHeadersAccessPhase(previousHeadersPhase);
       }
     }
     setHeadersContext(null);
     setNavigationContext(null);
-    return attachRouteHandlerMiddlewareContext(new Response(null, {
-      status: 405,
-    }));
+    return __applyRouteHandlerMiddlewareContext(
+      new Response(null, {
+        status: 405,
+      }),
+      _mwCtx,
+    );
   }
 
   // Build the component tree: layouts wrapping the page
@@ -15156,6 +14976,14 @@ import {
   isKnownDynamicAppRoute as __isKnownDynamicAppRoute,
   markKnownDynamicAppRoute as __markKnownDynamicAppRoute,
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-runtime.js";
+import {
+  applyRouteHandlerMiddlewareContext as __applyRouteHandlerMiddlewareContext,
+  applyRouteHandlerRevalidateHeader as __applyRouteHandlerRevalidateHeader,
+  buildAppRouteCacheValue as __buildAppRouteCacheValue,
+  buildRouteHandlerCachedResponse as __buildRouteHandlerCachedResponse,
+  finalizeRouteHandlerResponse as __finalizeRouteHandlerResponse,
+  markRouteHandlerCacheMiss as __markRouteHandlerCacheMiss,
+} from "<ROOT>/packages/vinext/src/server/app-route-handler-response.js";
 import { _consumeRequestScopedCacheLife, getCacheHandler } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
 import { ensureFetchPatch as _ensureFetchPatch, getCollectedFetchTags } from "vinext/fetch-cache";
@@ -17345,37 +17173,17 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     const exportedMethods = collectRouteHandlerMethods(handler);
     const allowHeaderForOptions = buildRouteHandlerAllowHeader(exportedMethods);
 
-    // Route handlers need the same middleware header/status merge behavior as
-    // page responses. This keeps middleware response headers visible on API
-    // routes in Workers/dev, and preserves custom rewrite status overrides.
-    function attachRouteHandlerMiddlewareContext(response) {
-      // _mwCtx.headers is only set (non-null) when middleware actually ran and
-      // produced a continue/rewrite response. An empty Headers object (middleware
-      // ran but produced no response headers) is a harmless edge case: the early
-      // return is skipped, but the copy loop below is a no-op, so no incorrect
-      // headers are added. The allocation cost in that case is acceptable.
-      if (!_mwCtx.headers && _mwCtx.status == null) return response;
-      const responseHeaders = new Headers(response.headers);
-      if (_mwCtx.headers) {
-        for (const [key, value] of _mwCtx.headers) {
-          responseHeaders.append(key, value);
-        }
-      }
-      return new Response(response.body, {
-        status: _mwCtx.status ?? response.status,
-        statusText: response.statusText,
-        headers: responseHeaders,
-      });
-    }
-
     // OPTIONS auto-implementation: respond with Allow header and 204
     if (method === "OPTIONS" && typeof handler["OPTIONS"] !== "function") {
       setHeadersContext(null);
       setNavigationContext(null);
-      return attachRouteHandlerMiddlewareContext(new Response(null, {
-        status: 204,
-        headers: { "Allow": allowHeaderForOptions },
-      }));
+      return __applyRouteHandlerMiddlewareContext(
+        new Response(null, {
+          status: 204,
+          headers: { "Allow": allowHeaderForOptions },
+        }),
+        _mwCtx,
+      );
     }
 
     // HEAD auto-implementation: run GET handler and strip body
@@ -17408,13 +17216,14 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           __isrDebug?.("HIT (route)", cleanPathname);
           setHeadersContext(null);
           setNavigationContext(null);
-          const __hitHeaders = Object.assign({}, __cv.headers || {});
-          __hitHeaders["X-Vinext-Cache"] = "HIT";
-          __hitHeaders["Cache-Control"] = "s-maxage=" + revalidateSeconds + ", stale-while-revalidate";
-          if (isAutoHead) {
-            return attachRouteHandlerMiddlewareContext(new Response(null, { status: __cv.status, headers: __hitHeaders }));
-          }
-          return attachRouteHandlerMiddlewareContext(new Response(__cv.body, { status: __cv.status, headers: __hitHeaders }));
+          return __applyRouteHandlerMiddlewareContext(
+            __buildRouteHandlerCachedResponse(__cv, {
+              cacheState: "HIT",
+              isHead: isAutoHead,
+              revalidateSeconds,
+            }),
+            _mwCtx,
+          );
         }
         if (__cached && __cached.isStale && __cached.value.value && __cached.value.value.kind === "APP_ROUTE") {
           // STALE — serve stale response, trigger background regeneration
@@ -17454,26 +17263,23 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
                 __isrDebug?.("route regen skipped (dynamic usage)", cleanPathname);
                 return;
               }
-              const __freshBody = await __revalResponse.arrayBuffer();
-              const __freshHeaders = {};
-              __revalResponse.headers.forEach(function(v, k) {
-                if (k !== "x-vinext-cache" && k !== "cache-control") __freshHeaders[k] = v;
-              });
               const __routeTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
-              await __isrSet(__routeKey, { kind: "APP_ROUTE", body: __freshBody, status: __revalResponse.status, headers: __freshHeaders }, __revalSecs, __routeTags);
+              const __routeCacheValue = await __buildAppRouteCacheValue(__revalResponse);
+              await __isrSet(__routeKey, __routeCacheValue, __revalSecs, __routeTags);
               __isrDebug?.("route regen complete", __routeKey);
             });
           });
           __isrDebug?.("STALE (route)", cleanPathname);
           setHeadersContext(null);
           setNavigationContext(null);
-          const __staleHeaders = Object.assign({}, __sv.headers || {});
-          __staleHeaders["X-Vinext-Cache"] = "STALE";
-          __staleHeaders["Cache-Control"] = "s-maxage=0, stale-while-revalidate";
-          if (isAutoHead) {
-            return attachRouteHandlerMiddlewareContext(new Response(null, { status: __sv.status, headers: __staleHeaders }));
-          }
-          return attachRouteHandlerMiddlewareContext(new Response(__sv.body, { status: __sv.status, headers: __staleHeaders }));
+          return __applyRouteHandlerMiddlewareContext(
+            __buildRouteHandlerCachedResponse(__sv, {
+              cacheState: "STALE",
+              isHead: isAutoHead,
+              revalidateSeconds,
+            }),
+            _mwCtx,
+          );
         }
       } catch (__routeCacheErr) {
         // Cache read failure — fall through to normal handler execution
@@ -17509,7 +17315,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           (method === "GET" || isAutoHead) &&
           !handlerSetCacheControl
         ) {
-          response.headers.set("cache-control", "s-maxage=" + revalidateSeconds + ", stale-while-revalidate");
+          __applyRouteHandlerRevalidateHeader(response, revalidateSeconds);
         }
 
         // ISR cache write for route handlers (production, MISS).
@@ -17523,19 +17329,15 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           (method === "GET" || isAutoHead) &&
           !handlerSetCacheControl
         ) {
-          response.headers.set("X-Vinext-Cache", "MISS");
+          __markRouteHandlerCacheMiss(response);
           const __routeClone = response.clone();
           const __routeKey = __isrRouteKey(cleanPathname);
           const __revalSecs = revalidateSeconds;
           const __routeTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
           const __routeWritePromise = (async () => {
             try {
-              const __buf = await __routeClone.arrayBuffer();
-              const __hdrs = {};
-              __routeClone.headers.forEach(function(v, k) {
-                if (k !== "x-vinext-cache" && k !== "cache-control") __hdrs[k] = v;
-              });
-              await __isrSet(__routeKey, { kind: "APP_ROUTE", body: __buf, status: __routeClone.status, headers: __hdrs }, __revalSecs, __routeTags);
+              const __routeCacheValue = await __buildAppRouteCacheValue(__routeClone);
+              await __isrSet(__routeKey, __routeCacheValue, __revalSecs, __routeTags);
               __isrDebug?.("route cache written", __routeKey);
             } catch (__cacheErr) {
               console.error("[vinext] ISR route cache write error:", __cacheErr);
@@ -17549,38 +17351,14 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         const draftCookie = getDraftModeCookieHeader();
         setHeadersContext(null);
         setNavigationContext(null);
-
-        // If we have pending cookies, create a new response with them attached
-        if (pendingCookies.length > 0 || draftCookie) {
-          const newHeaders = new Headers(response.headers);
-          for (const cookie of pendingCookies) {
-            newHeaders.append("Set-Cookie", cookie);
-          }
-          if (draftCookie) newHeaders.append("Set-Cookie", draftCookie);
-
-          if (isAutoHead) {
-            return attachRouteHandlerMiddlewareContext(new Response(null, {
-              status: response.status,
-              statusText: response.statusText,
-              headers: newHeaders,
-            }));
-          }
-          return attachRouteHandlerMiddlewareContext(new Response(response.body, {
-            status: response.status,
-            statusText: response.statusText,
-            headers: newHeaders,
-          }));
-        }
-
-        if (isAutoHead) {
-          // Strip body for auto-HEAD, preserve headers and status
-          return attachRouteHandlerMiddlewareContext(new Response(null, {
-            status: response.status,
-            statusText: response.statusText,
-            headers: response.headers,
-          }));
-        }
-        return attachRouteHandlerMiddlewareContext(response);
+        return __applyRouteHandlerMiddlewareContext(
+          __finalizeRouteHandlerResponse(response, {
+            pendingCookies,
+            draftCookie,
+            isHead: isAutoHead,
+          }),
+          _mwCtx,
+        );
       } catch (err) {
         getAndClearPendingCookies(); // Clear any pending cookies on error
         // Catch redirect() / notFound() thrown from route handlers
@@ -17592,16 +17370,19 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
             const statusCode = parts[3] ? parseInt(parts[3], 10) : 307;
             setHeadersContext(null);
             setNavigationContext(null);
-            return attachRouteHandlerMiddlewareContext(new Response(null, {
-              status: statusCode,
-              headers: { Location: new URL(redirectUrl, request.url).toString() },
-            }));
+            return __applyRouteHandlerMiddlewareContext(
+              new Response(null, {
+                status: statusCode,
+                headers: { Location: new URL(redirectUrl, request.url).toString() },
+              }),
+              _mwCtx,
+            );
           }
           if (digest === "NEXT_NOT_FOUND" || digest.startsWith("NEXT_HTTP_ERROR_FALLBACK;")) {
             const statusCode = digest === "NEXT_NOT_FOUND" ? 404 : parseInt(digest.split(";")[1], 10);
             setHeadersContext(null);
             setNavigationContext(null);
-            return attachRouteHandlerMiddlewareContext(new Response(null, { status: statusCode }));
+            return __applyRouteHandlerMiddlewareContext(new Response(null, { status: statusCode }), _mwCtx);
           }
         }
         setHeadersContext(null);
@@ -17612,16 +17393,19 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           { path: cleanPathname, method: request.method, headers: Object.fromEntries(request.headers.entries()) },
           { routerKind: "App Router", routePath: route.pattern, routeType: "route" },
         );
-        return attachRouteHandlerMiddlewareContext(new Response(null, { status: 500 }));
+        return __applyRouteHandlerMiddlewareContext(new Response(null, { status: 500 }), _mwCtx);
       } finally {
         setHeadersAccessPhase(previousHeadersPhase);
       }
     }
     setHeadersContext(null);
     setNavigationContext(null);
-    return attachRouteHandlerMiddlewareContext(new Response(null, {
-      status: 405,
-    }));
+    return __applyRouteHandlerMiddlewareContext(
+      new Response(null, {
+        status: 405,
+      }),
+      _mwCtx,
+    );
   }
 
   // Build the component tree: layouts wrapping the page

--- a/tests/app-route-handler-response.test.ts
+++ b/tests/app-route-handler-response.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vite-plus/test";
+import type { CachedRouteValue } from "../packages/vinext/src/shims/cache.js";
+import {
+  applyRouteHandlerMiddlewareContext,
+  applyRouteHandlerRevalidateHeader,
+  buildAppRouteCacheValue,
+  buildRouteHandlerCachedResponse,
+  finalizeRouteHandlerResponse,
+  markRouteHandlerCacheMiss,
+} from "../packages/vinext/src/server/app-route-handler-response.js";
+
+function buildCachedRouteValue(
+  body: string,
+  headers: Record<string, string> = {},
+): CachedRouteValue {
+  return {
+    kind: "APP_ROUTE",
+    body: new TextEncoder().encode(body).buffer,
+    status: 200,
+    headers,
+  };
+}
+
+describe("app route handler response helpers", () => {
+  it("returns the original response when no middleware context exists", () => {
+    const response = new Response("hello");
+
+    expect(
+      applyRouteHandlerMiddlewareContext(response, {
+        headers: null,
+        status: null,
+      }),
+    ).toBe(response);
+  });
+
+  it("applies middleware headers and status overrides to route handler responses", async () => {
+    const response = new Response("hello", {
+      status: 200,
+      headers: {
+        "content-type": "text/plain",
+        "x-response": "app",
+      },
+    });
+
+    const result = applyRouteHandlerMiddlewareContext(response, {
+      headers: new Headers([
+        ["x-middleware", "mw"],
+        ["x-response", "middleware-copy"],
+      ]),
+      status: 202,
+    });
+
+    expect(result.status).toBe(202);
+    expect(result.headers.get("content-type")).toBe("text/plain");
+    expect(result.headers.get("x-response")).toBe("app, middleware-copy");
+    expect(result.headers.get("x-middleware")).toBe("mw");
+    await expect(result.text()).resolves.toBe("hello");
+  });
+
+  it("builds cached HIT and STALE route handler responses", async () => {
+    const cachedValue = buildCachedRouteValue("from-cache", {
+      "content-type": "text/plain",
+    });
+
+    const hit = buildRouteHandlerCachedResponse(cachedValue, {
+      cacheState: "HIT",
+      isHead: false,
+      revalidateSeconds: 60,
+    });
+    expect(hit.headers.get("x-vinext-cache")).toBe("HIT");
+    expect(hit.headers.get("cache-control")).toBe("s-maxage=60, stale-while-revalidate");
+    await expect(hit.text()).resolves.toBe("from-cache");
+
+    const staleHead = buildRouteHandlerCachedResponse(cachedValue, {
+      cacheState: "STALE",
+      isHead: true,
+      revalidateSeconds: 60,
+    });
+    expect(staleHead.headers.get("x-vinext-cache")).toBe("STALE");
+    expect(staleHead.headers.get("cache-control")).toBe("s-maxage=0, stale-while-revalidate");
+    await expect(staleHead.text()).resolves.toBe("");
+  });
+
+  it("serializes APP_ROUTE cache values without cache bookkeeping headers", async () => {
+    const response = new Response("cache me", {
+      status: 201,
+      headers: {
+        "content-type": "text/plain",
+        "cache-control": "s-maxage=60, stale-while-revalidate",
+        "x-vinext-cache": "MISS",
+        "x-extra": "kept",
+      },
+    });
+
+    const value = await buildAppRouteCacheValue(response);
+
+    expect(value.kind).toBe("APP_ROUTE");
+    expect(value.status).toBe(201);
+    expect(value.headers).toEqual({
+      "content-type": "text/plain",
+      "x-extra": "kept",
+    });
+    expect(new TextDecoder().decode(value.body)).toBe("cache me");
+  });
+
+  it("finalizes route handler responses with cookies and auto-head semantics", async () => {
+    const response = new Response("body", {
+      status: 202,
+      statusText: "Accepted",
+      headers: {
+        "content-type": "text/plain",
+      },
+    });
+
+    const result = finalizeRouteHandlerResponse(response, {
+      pendingCookies: ["a=1; Path=/"],
+      draftCookie: "draft=1; Path=/",
+      isHead: true,
+    });
+
+    expect(result.status).toBe(202);
+    expect(result.statusText).toBe("Accepted");
+    expect(result.headers.getSetCookie?.()).toEqual(["a=1; Path=/", "draft=1; Path=/"]);
+    await expect(result.text()).resolves.toBe("");
+  });
+
+  it("applies revalidate and MISS headers separately", () => {
+    const response = new Response("hello");
+
+    applyRouteHandlerRevalidateHeader(response, 30);
+    markRouteHandlerCacheMiss(response);
+
+    expect(response.headers.get("cache-control")).toBe("s-maxage=30, stale-while-revalidate");
+    expect(response.headers.get("x-vinext-cache")).toBe("MISS");
+  });
+});

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -3763,8 +3763,8 @@ describe("generateRscEntry ISR code generation", () => {
 
   it("generated code contains APP_ROUTE ISR cache write for route handlers", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes);
-    // Route handler ISR writes use __isrSet with __routeKey and APP_ROUTE kind
-    expect(code).toContain("__isrSet(__routeKey,");
-    expect(code).toContain('kind: "APP_ROUTE"');
+    // Route handler ISR writes now flow through the typed cache-value helper.
+    expect(code).toContain("__buildAppRouteCacheValue(__routeClone)");
+    expect(code).toContain("__isrSet(__routeKey, __routeCacheValue");
   });
 });


### PR DESCRIPTION
## Summary
- written by Codex
- extract App Router route-handler response and cache-shaping helpers into a real typed server module
- keep `app-rsc-entry.ts` focused on request orchestration while moving low-level `Response` assembly out of the template string
- add direct unit coverage for the new route-handler response helper layer

## What moved
- middleware header/status application for route handlers
- cached HIT/STALE response construction
- APP_ROUTE cache-value serialization for ISR writes/regeneration
- route-handler response finalization for pending cookies, draft mode cookies, and auto-HEAD body stripping

## Files
- new helper module: `packages/vinext/src/server/app-route-handler-response.ts`
- new unit coverage: `tests/app-route-handler-response.test.ts`
- generator wiring updated in `packages/vinext/src/entries/app-rsc-entry.ts`

## Why this is the next step
`#618` pulled direct request-access tracking out of the generated RSC entry.
This PR keeps going in the same hotspot, but takes the response/cache-shaping half next.
That leaves the generated route-handler block noticeably smaller and pushes more behavior into normal importable TypeScript.

## Verification
- `vp check packages/vinext/src/server/app-route-handler-response.ts packages/vinext/src/entries/app-rsc-entry.ts tests/app-route-handler-response.test.ts tests/app-route-handler-runtime.test.ts tests/app-router.test.ts`
- `vp test run tests/app-route-handler-response.test.ts tests/app-route-handler-runtime.test.ts`
- `vp test run tests/entry-templates.test.ts -u`
- `vp test run tests/app-router.test.ts -t "route handler"`
- `vp test run tests/nextjs-compat/app-routes.test.ts`
- `vp run vinext#build`

## Notes
- This PR is stacked on #618 (`codex/app-route-handler-runtime`).
- One generated-code assertion was updated to reflect the new helper-based APP_ROUTE cache write path instead of the old inline object literal.
