### PR TITLE
refactor: extract app route handler policy helpers

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -41,6 +41,9 @@ const requestContextShimPath = fileURLToPath(
 const appRouteHandlerRuntimePath = fileURLToPath(
   new URL("../server/app-route-handler-runtime.js", import.meta.url),
 ).replace(/\\/g, "/");
+const appRouteHandlerPolicyPath = fileURLToPath(
+  new URL("../server/app-route-handler-policy.js", import.meta.url),
+).replace(/\\/g, "/");
 const appRouteHandlerResponsePath = fileURLToPath(
   new URL("../server/app-route-handler-response.js", import.meta.url),
 ).replace(/\\/g, "/");
@@ -335,12 +338,19 @@ ${effectiveMetaRoutes.length > 0 ? `import { sitemapToXml, robotsToText, manifes
 import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, matchHeaders, isExternalUrl, proxyExternalRequest, sanitizeDestination } from ${JSON.stringify(configMatchersPath)};
 import { validateCsrfOrigin, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash, processMiddlewareHeaders } from ${JSON.stringify(requestPipelinePath)};
 import {
-  buildRouteHandlerAllowHeader,
-  collectRouteHandlerMethods,
   createTrackedAppRouteRequest as __createTrackedAppRouteRequest,
   isKnownDynamicAppRoute as __isKnownDynamicAppRoute,
   markKnownDynamicAppRoute as __markKnownDynamicAppRoute,
 } from ${JSON.stringify(appRouteHandlerRuntimePath)};
+import {
+  getAppRouteHandlerRevalidateSeconds as __getAppRouteHandlerRevalidateSeconds,
+  hasAppRouteHandlerDefaultExport as __hasAppRouteHandlerDefaultExport,
+  resolveAppRouteHandlerMethod as __resolveAppRouteHandlerMethod,
+  resolveAppRouteHandlerSpecialError as __resolveAppRouteHandlerSpecialError,
+  shouldApplyAppRouteHandlerRevalidateHeader as __shouldApplyAppRouteHandlerRevalidateHeader,
+  shouldReadAppRouteHandlerCache as __shouldReadAppRouteHandlerCache,
+  shouldWriteAppRouteHandlerCache as __shouldWriteAppRouteHandlerCache,
+} from ${JSON.stringify(appRouteHandlerPolicyPath)};
 import {
   applyRouteHandlerMiddlewareContext as __applyRouteHandlerMiddlewareContext,
   applyRouteHandlerRevalidateHeader as __applyRouteHandlerRevalidateHeader,
@@ -2199,19 +2209,21 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   if (route.routeHandler) {
     const handler = route.routeHandler;
     const method = request.method.toUpperCase();
-    const revalidateSeconds = typeof handler.revalidate === "number" && handler.revalidate > 0 && handler.revalidate !== Infinity ? handler.revalidate : null;
-    if (typeof handler["default"] === "function" && process.env.NODE_ENV === "development") {
+    const revalidateSeconds = __getAppRouteHandlerRevalidateSeconds(handler);
+    if (__hasAppRouteHandlerDefaultExport(handler) && process.env.NODE_ENV === "development") {
       console.error(
         "[vinext] Detected default export in route handler " + route.pattern + ". Export a named export for each HTTP method instead.",
       );
     }
 
-    // Collect exported HTTP methods for OPTIONS auto-response and Allow header
-    const exportedMethods = collectRouteHandlerMethods(handler);
-    const allowHeaderForOptions = buildRouteHandlerAllowHeader(exportedMethods);
+    const {
+      allowHeaderForOptions,
+      handlerFn,
+      isAutoHead,
+      shouldAutoRespondToOptions,
+    } = __resolveAppRouteHandlerMethod(handler, method);
 
-    // OPTIONS auto-implementation: respond with Allow header and 204
-    if (method === "OPTIONS" && typeof handler["OPTIONS"] !== "function") {
+    if (shouldAutoRespondToOptions) {
       setHeadersContext(null);
       setNavigationContext(null);
       return __applyRouteHandlerMiddlewareContext(
@@ -2223,26 +2235,21 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       );
     }
 
-    // HEAD auto-implementation: run GET handler and strip body
-    let handlerFn = handler[method];
-    let isAutoHead = false;
-    if (method === "HEAD" && typeof handler["HEAD"] !== "function" && typeof handler["GET"] === "function") {
-      handlerFn = handler["GET"];
-      isAutoHead = true;
-    }
-
     // ISR cache read for route handlers (production only).
     // Only GET/HEAD (auto-HEAD) with finite revalidate > 0 are ISR-eligible.
     // Known-dynamic handlers skip the read entirely so stale cache entries
     // from earlier requests do not replay once the process has learned they
     // access request-specific data.
     if (
-      process.env.NODE_ENV === "production" &&
-      revalidateSeconds !== null &&
-      handler.dynamic !== "force-dynamic" &&
-      !__isKnownDynamicAppRoute(route.pattern) &&
-      (method === "GET" || isAutoHead) &&
-      typeof handlerFn === "function"
+      __shouldReadAppRouteHandlerCache({
+        dynamicConfig: handler.dynamic,
+        handlerFn,
+        isAutoHead,
+        isKnownDynamic: __isKnownDynamicAppRoute(route.pattern),
+        isProduction: process.env.NODE_ENV === "production",
+        method,
+        revalidateSeconds,
+      })
     ) {
       const __routeKey = __isrRouteKey(cleanPathname);
       try {
@@ -2347,10 +2354,13 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         // Runtime request APIs like headers() / cookies() make GET handlers dynamic,
         // so only attach ISR headers when the handler stayed static.
         if (
-          revalidateSeconds !== null &&
-          !dynamicUsedInHandler &&
-          (method === "GET" || isAutoHead) &&
-          !handlerSetCacheControl
+          __shouldApplyAppRouteHandlerRevalidateHeader({
+            dynamicUsedInHandler,
+            handlerSetCacheControl,
+            isAutoHead,
+            method,
+            revalidateSeconds,
+          })
         ) {
           __applyRouteHandlerRevalidateHeader(response, revalidateSeconds);
         }
@@ -2359,12 +2369,15 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         // Store the raw handler response before cookie/middleware transforms
         // (those are request-specific and shouldn't be cached).
         if (
-          process.env.NODE_ENV === "production" &&
-          revalidateSeconds !== null &&
-          handler.dynamic !== "force-dynamic" &&
-          !dynamicUsedInHandler &&
-          (method === "GET" || isAutoHead) &&
-          !handlerSetCacheControl
+          __shouldWriteAppRouteHandlerCache({
+            dynamicConfig: handler.dynamic,
+            dynamicUsedInHandler,
+            handlerSetCacheControl,
+            isAutoHead,
+            isProduction: process.env.NODE_ENV === "production",
+            method,
+            revalidateSeconds,
+          })
         ) {
           __markRouteHandlerCacheMiss(response);
           const __routeClone = response.clone();
@@ -2398,29 +2411,23 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         );
       } catch (err) {
         getAndClearPendingCookies(); // Clear any pending cookies on error
-        // Catch redirect() / notFound() thrown from route handlers
-        if (err && typeof err === "object" && "digest" in err) {
-          const digest = String(err.digest);
-          if (digest.startsWith("NEXT_REDIRECT;")) {
-            const parts = digest.split(";");
-            const redirectUrl = decodeURIComponent(parts[2]);
-            const statusCode = parts[3] ? parseInt(parts[3], 10) : 307;
-            setHeadersContext(null);
-            setNavigationContext(null);
+        const specialError = __resolveAppRouteHandlerSpecialError(err, request.url);
+        if (specialError) {
+          setHeadersContext(null);
+          setNavigationContext(null);
+          if (specialError.kind === "redirect") {
             return __applyRouteHandlerMiddlewareContext(
               new Response(null, {
-                status: statusCode,
-                headers: { Location: new URL(redirectUrl, request.url).toString() },
+                status: specialError.statusCode,
+                headers: { Location: specialError.location },
               }),
               _mwCtx,
             );
           }
-          if (digest === "NEXT_NOT_FOUND" || digest.startsWith("NEXT_HTTP_ERROR_FALLBACK;")) {
-            const statusCode = digest === "NEXT_NOT_FOUND" ? 404 : parseInt(digest.split(";")[1], 10);
-            setHeadersContext(null);
-            setNavigationContext(null);
-            return __applyRouteHandlerMiddlewareContext(new Response(null, { status: statusCode }), _mwCtx);
-          }
+          return __applyRouteHandlerMiddlewareContext(
+            new Response(null, { status: specialError.statusCode }),
+            _mwCtx,
+          );
         }
         setHeadersContext(null);
         setNavigationContext(null);

--- a/packages/vinext/src/server/app-route-handler-policy.ts
+++ b/packages/vinext/src/server/app-route-handler-policy.ts
@@ -1,0 +1,160 @@
+import {
+  buildRouteHandlerAllowHeader,
+  collectRouteHandlerMethods,
+  type RouteHandlerHttpMethod,
+  type RouteHandlerModule,
+} from "./app-route-handler-runtime.js";
+
+export interface AppRouteHandlerModule extends RouteHandlerModule {
+  dynamic?: string;
+  revalidate?: unknown;
+}
+
+type AppRouteHandlerFunction = (...args: unknown[]) => unknown;
+
+export interface ResolvedAppRouteHandlerMethod {
+  allowHeaderForOptions: string;
+  exportedMethods: RouteHandlerHttpMethod[];
+  handlerFn: AppRouteHandlerFunction | undefined;
+  isAutoHead: boolean;
+  shouldAutoRespondToOptions: boolean;
+}
+
+export interface AppRouteHandlerCacheReadOptions {
+  dynamicConfig?: string;
+  handlerFn: unknown;
+  isAutoHead: boolean;
+  isKnownDynamic: boolean;
+  isProduction: boolean;
+  method: string;
+  revalidateSeconds: number | null;
+}
+
+export interface AppRouteHandlerResponseCacheOptions {
+  dynamicConfig?: string;
+  dynamicUsedInHandler: boolean;
+  handlerSetCacheControl: boolean;
+  isAutoHead: boolean;
+  isProduction: boolean;
+  method: string;
+  revalidateSeconds: number | null;
+}
+
+export type AppRouteHandlerSpecialError =
+  | {
+      kind: "redirect";
+      location: string;
+      statusCode: number;
+    }
+  | {
+      kind: "status";
+      statusCode: number;
+    };
+
+export function getAppRouteHandlerRevalidateSeconds(
+  handler: Pick<AppRouteHandlerModule, "revalidate">,
+): number | null {
+  return typeof handler.revalidate === "number" &&
+    handler.revalidate > 0 &&
+    handler.revalidate !== Infinity
+    ? handler.revalidate
+    : null;
+}
+
+export function hasAppRouteHandlerDefaultExport(handler: RouteHandlerModule): boolean {
+  return typeof handler.default === "function";
+}
+
+export function resolveAppRouteHandlerMethod(
+  handler: AppRouteHandlerModule,
+  method: string,
+): ResolvedAppRouteHandlerMethod {
+  const exportedMethods = collectRouteHandlerMethods(handler);
+  const allowHeaderForOptions = buildRouteHandlerAllowHeader(exportedMethods);
+  const shouldAutoRespondToOptions = method === "OPTIONS" && typeof handler.OPTIONS !== "function";
+
+  let handlerFn =
+    typeof handler[method as RouteHandlerHttpMethod] === "function"
+      ? (handler[method as RouteHandlerHttpMethod] as AppRouteHandlerFunction)
+      : undefined;
+  let isAutoHead = false;
+
+  if (
+    method === "HEAD" &&
+    typeof handler.HEAD !== "function" &&
+    typeof handler.GET === "function"
+  ) {
+    handlerFn = handler.GET as AppRouteHandlerFunction;
+    isAutoHead = true;
+  }
+
+  return {
+    allowHeaderForOptions,
+    exportedMethods,
+    handlerFn,
+    isAutoHead,
+    shouldAutoRespondToOptions,
+  };
+}
+
+export function shouldReadAppRouteHandlerCache(options: AppRouteHandlerCacheReadOptions): boolean {
+  return (
+    options.isProduction &&
+    options.revalidateSeconds !== null &&
+    options.dynamicConfig !== "force-dynamic" &&
+    !options.isKnownDynamic &&
+    (options.method === "GET" || options.isAutoHead) &&
+    typeof options.handlerFn === "function"
+  );
+}
+
+export function shouldApplyAppRouteHandlerRevalidateHeader(
+  options: Omit<AppRouteHandlerResponseCacheOptions, "dynamicConfig" | "isProduction">,
+): boolean {
+  return (
+    options.revalidateSeconds !== null &&
+    !options.dynamicUsedInHandler &&
+    (options.method === "GET" || options.isAutoHead) &&
+    !options.handlerSetCacheControl
+  );
+}
+
+export function shouldWriteAppRouteHandlerCache(
+  options: AppRouteHandlerResponseCacheOptions,
+): boolean {
+  return (
+    options.isProduction &&
+    options.revalidateSeconds !== null &&
+    options.dynamicConfig !== "force-dynamic" &&
+    shouldApplyAppRouteHandlerRevalidateHeader(options)
+  );
+}
+
+export function resolveAppRouteHandlerSpecialError(
+  error: unknown,
+  requestUrl: string,
+): AppRouteHandlerSpecialError | null {
+  if (!(error && typeof error === "object" && "digest" in error)) {
+    return null;
+  }
+
+  const digest = String(error.digest);
+  if (digest.startsWith("NEXT_REDIRECT;")) {
+    const parts = digest.split(";");
+    const redirectUrl = decodeURIComponent(parts[2]);
+    return {
+      kind: "redirect",
+      location: new URL(redirectUrl, requestUrl).toString(),
+      statusCode: parts[3] ? parseInt(parts[3], 10) : 307,
+    };
+  }
+
+  if (digest === "NEXT_NOT_FOUND" || digest.startsWith("NEXT_HTTP_ERROR_FALLBACK;")) {
+    return {
+      kind: "status",
+      statusCode: digest === "NEXT_NOT_FOUND" ? 404 : parseInt(digest.split(";")[1], 10),
+    };
+  }
+
+  return null;
+}

--- a/packages/vinext/src/server/app-route-handler-runtime.ts
+++ b/packages/vinext/src/server/app-route-handler-runtime.ts
@@ -11,9 +11,9 @@ export const ROUTE_HANDLER_HTTP_METHODS = [
   "OPTIONS",
 ] as const;
 
-type RouteHandlerHttpMethod = (typeof ROUTE_HANDLER_HTTP_METHODS)[number];
+export type RouteHandlerHttpMethod = (typeof ROUTE_HANDLER_HTTP_METHODS)[number];
 
-type RouteHandlerModule = Partial<Record<RouteHandlerHttpMethod | "default", unknown>>;
+export type RouteHandlerModule = Partial<Record<RouteHandlerHttpMethod | "default", unknown>>;
 
 export function collectRouteHandlerMethods(handler: RouteHandlerModule): RouteHandlerHttpMethod[] {
   const methods = ROUTE_HANDLER_HTTP_METHODS.filter(

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -54,12 +54,19 @@ import { MetadataHead, mergeMetadata, resolveModuleMetadata, ViewportHead, merge
 import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, matchHeaders, isExternalUrl, proxyExternalRequest, sanitizeDestination } from "<ROOT>/packages/vinext/src/config/config-matchers.js";
 import { validateCsrfOrigin, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash, processMiddlewareHeaders } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
 import {
-  buildRouteHandlerAllowHeader,
-  collectRouteHandlerMethods,
   createTrackedAppRouteRequest as __createTrackedAppRouteRequest,
   isKnownDynamicAppRoute as __isKnownDynamicAppRoute,
   markKnownDynamicAppRoute as __markKnownDynamicAppRoute,
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-runtime.js";
+import {
+  getAppRouteHandlerRevalidateSeconds as __getAppRouteHandlerRevalidateSeconds,
+  hasAppRouteHandlerDefaultExport as __hasAppRouteHandlerDefaultExport,
+  resolveAppRouteHandlerMethod as __resolveAppRouteHandlerMethod,
+  resolveAppRouteHandlerSpecialError as __resolveAppRouteHandlerSpecialError,
+  shouldApplyAppRouteHandlerRevalidateHeader as __shouldApplyAppRouteHandlerRevalidateHeader,
+  shouldReadAppRouteHandlerCache as __shouldReadAppRouteHandlerCache,
+  shouldWriteAppRouteHandlerCache as __shouldWriteAppRouteHandlerCache,
+} from "<ROOT>/packages/vinext/src/server/app-route-handler-policy.js";
 import {
   applyRouteHandlerMiddlewareContext as __applyRouteHandlerMiddlewareContext,
   applyRouteHandlerRevalidateHeader as __applyRouteHandlerRevalidateHeader,
@@ -1886,19 +1893,21 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   if (route.routeHandler) {
     const handler = route.routeHandler;
     const method = request.method.toUpperCase();
-    const revalidateSeconds = typeof handler.revalidate === "number" && handler.revalidate > 0 && handler.revalidate !== Infinity ? handler.revalidate : null;
-    if (typeof handler["default"] === "function" && process.env.NODE_ENV === "development") {
+    const revalidateSeconds = __getAppRouteHandlerRevalidateSeconds(handler);
+    if (__hasAppRouteHandlerDefaultExport(handler) && process.env.NODE_ENV === "development") {
       console.error(
         "[vinext] Detected default export in route handler " + route.pattern + ". Export a named export for each HTTP method instead.",
       );
     }
 
-    // Collect exported HTTP methods for OPTIONS auto-response and Allow header
-    const exportedMethods = collectRouteHandlerMethods(handler);
-    const allowHeaderForOptions = buildRouteHandlerAllowHeader(exportedMethods);
+    const {
+      allowHeaderForOptions,
+      handlerFn,
+      isAutoHead,
+      shouldAutoRespondToOptions,
+    } = __resolveAppRouteHandlerMethod(handler, method);
 
-    // OPTIONS auto-implementation: respond with Allow header and 204
-    if (method === "OPTIONS" && typeof handler["OPTIONS"] !== "function") {
+    if (shouldAutoRespondToOptions) {
       setHeadersContext(null);
       setNavigationContext(null);
       return __applyRouteHandlerMiddlewareContext(
@@ -1910,26 +1919,21 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       );
     }
 
-    // HEAD auto-implementation: run GET handler and strip body
-    let handlerFn = handler[method];
-    let isAutoHead = false;
-    if (method === "HEAD" && typeof handler["HEAD"] !== "function" && typeof handler["GET"] === "function") {
-      handlerFn = handler["GET"];
-      isAutoHead = true;
-    }
-
     // ISR cache read for route handlers (production only).
     // Only GET/HEAD (auto-HEAD) with finite revalidate > 0 are ISR-eligible.
     // Known-dynamic handlers skip the read entirely so stale cache entries
     // from earlier requests do not replay once the process has learned they
     // access request-specific data.
     if (
-      process.env.NODE_ENV === "production" &&
-      revalidateSeconds !== null &&
-      handler.dynamic !== "force-dynamic" &&
-      !__isKnownDynamicAppRoute(route.pattern) &&
-      (method === "GET" || isAutoHead) &&
-      typeof handlerFn === "function"
+      __shouldReadAppRouteHandlerCache({
+        dynamicConfig: handler.dynamic,
+        handlerFn,
+        isAutoHead,
+        isKnownDynamic: __isKnownDynamicAppRoute(route.pattern),
+        isProduction: process.env.NODE_ENV === "production",
+        method,
+        revalidateSeconds,
+      })
     ) {
       const __routeKey = __isrRouteKey(cleanPathname);
       try {
@@ -2034,10 +2038,13 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         // Runtime request APIs like headers() / cookies() make GET handlers dynamic,
         // so only attach ISR headers when the handler stayed static.
         if (
-          revalidateSeconds !== null &&
-          !dynamicUsedInHandler &&
-          (method === "GET" || isAutoHead) &&
-          !handlerSetCacheControl
+          __shouldApplyAppRouteHandlerRevalidateHeader({
+            dynamicUsedInHandler,
+            handlerSetCacheControl,
+            isAutoHead,
+            method,
+            revalidateSeconds,
+          })
         ) {
           __applyRouteHandlerRevalidateHeader(response, revalidateSeconds);
         }
@@ -2046,12 +2053,15 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         // Store the raw handler response before cookie/middleware transforms
         // (those are request-specific and shouldn't be cached).
         if (
-          process.env.NODE_ENV === "production" &&
-          revalidateSeconds !== null &&
-          handler.dynamic !== "force-dynamic" &&
-          !dynamicUsedInHandler &&
-          (method === "GET" || isAutoHead) &&
-          !handlerSetCacheControl
+          __shouldWriteAppRouteHandlerCache({
+            dynamicConfig: handler.dynamic,
+            dynamicUsedInHandler,
+            handlerSetCacheControl,
+            isAutoHead,
+            isProduction: process.env.NODE_ENV === "production",
+            method,
+            revalidateSeconds,
+          })
         ) {
           __markRouteHandlerCacheMiss(response);
           const __routeClone = response.clone();
@@ -2085,29 +2095,23 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         );
       } catch (err) {
         getAndClearPendingCookies(); // Clear any pending cookies on error
-        // Catch redirect() / notFound() thrown from route handlers
-        if (err && typeof err === "object" && "digest" in err) {
-          const digest = String(err.digest);
-          if (digest.startsWith("NEXT_REDIRECT;")) {
-            const parts = digest.split(";");
-            const redirectUrl = decodeURIComponent(parts[2]);
-            const statusCode = parts[3] ? parseInt(parts[3], 10) : 307;
-            setHeadersContext(null);
-            setNavigationContext(null);
+        const specialError = __resolveAppRouteHandlerSpecialError(err, request.url);
+        if (specialError) {
+          setHeadersContext(null);
+          setNavigationContext(null);
+          if (specialError.kind === "redirect") {
             return __applyRouteHandlerMiddlewareContext(
               new Response(null, {
-                status: statusCode,
-                headers: { Location: new URL(redirectUrl, request.url).toString() },
+                status: specialError.statusCode,
+                headers: { Location: specialError.location },
               }),
               _mwCtx,
             );
           }
-          if (digest === "NEXT_NOT_FOUND" || digest.startsWith("NEXT_HTTP_ERROR_FALLBACK;")) {
-            const statusCode = digest === "NEXT_NOT_FOUND" ? 404 : parseInt(digest.split(";")[1], 10);
-            setHeadersContext(null);
-            setNavigationContext(null);
-            return __applyRouteHandlerMiddlewareContext(new Response(null, { status: statusCode }), _mwCtx);
-          }
+          return __applyRouteHandlerMiddlewareContext(
+            new Response(null, { status: specialError.statusCode }),
+            _mwCtx,
+          );
         }
         setHeadersContext(null);
         setNavigationContext(null);
@@ -3021,12 +3025,19 @@ import { MetadataHead, mergeMetadata, resolveModuleMetadata, ViewportHead, merge
 import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, matchHeaders, isExternalUrl, proxyExternalRequest, sanitizeDestination } from "<ROOT>/packages/vinext/src/config/config-matchers.js";
 import { validateCsrfOrigin, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash, processMiddlewareHeaders } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
 import {
-  buildRouteHandlerAllowHeader,
-  collectRouteHandlerMethods,
   createTrackedAppRouteRequest as __createTrackedAppRouteRequest,
   isKnownDynamicAppRoute as __isKnownDynamicAppRoute,
   markKnownDynamicAppRoute as __markKnownDynamicAppRoute,
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-runtime.js";
+import {
+  getAppRouteHandlerRevalidateSeconds as __getAppRouteHandlerRevalidateSeconds,
+  hasAppRouteHandlerDefaultExport as __hasAppRouteHandlerDefaultExport,
+  resolveAppRouteHandlerMethod as __resolveAppRouteHandlerMethod,
+  resolveAppRouteHandlerSpecialError as __resolveAppRouteHandlerSpecialError,
+  shouldApplyAppRouteHandlerRevalidateHeader as __shouldApplyAppRouteHandlerRevalidateHeader,
+  shouldReadAppRouteHandlerCache as __shouldReadAppRouteHandlerCache,
+  shouldWriteAppRouteHandlerCache as __shouldWriteAppRouteHandlerCache,
+} from "<ROOT>/packages/vinext/src/server/app-route-handler-policy.js";
 import {
   applyRouteHandlerMiddlewareContext as __applyRouteHandlerMiddlewareContext,
   applyRouteHandlerRevalidateHeader as __applyRouteHandlerRevalidateHeader,
@@ -4856,19 +4867,21 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   if (route.routeHandler) {
     const handler = route.routeHandler;
     const method = request.method.toUpperCase();
-    const revalidateSeconds = typeof handler.revalidate === "number" && handler.revalidate > 0 && handler.revalidate !== Infinity ? handler.revalidate : null;
-    if (typeof handler["default"] === "function" && process.env.NODE_ENV === "development") {
+    const revalidateSeconds = __getAppRouteHandlerRevalidateSeconds(handler);
+    if (__hasAppRouteHandlerDefaultExport(handler) && process.env.NODE_ENV === "development") {
       console.error(
         "[vinext] Detected default export in route handler " + route.pattern + ". Export a named export for each HTTP method instead.",
       );
     }
 
-    // Collect exported HTTP methods for OPTIONS auto-response and Allow header
-    const exportedMethods = collectRouteHandlerMethods(handler);
-    const allowHeaderForOptions = buildRouteHandlerAllowHeader(exportedMethods);
+    const {
+      allowHeaderForOptions,
+      handlerFn,
+      isAutoHead,
+      shouldAutoRespondToOptions,
+    } = __resolveAppRouteHandlerMethod(handler, method);
 
-    // OPTIONS auto-implementation: respond with Allow header and 204
-    if (method === "OPTIONS" && typeof handler["OPTIONS"] !== "function") {
+    if (shouldAutoRespondToOptions) {
       setHeadersContext(null);
       setNavigationContext(null);
       return __applyRouteHandlerMiddlewareContext(
@@ -4880,26 +4893,21 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       );
     }
 
-    // HEAD auto-implementation: run GET handler and strip body
-    let handlerFn = handler[method];
-    let isAutoHead = false;
-    if (method === "HEAD" && typeof handler["HEAD"] !== "function" && typeof handler["GET"] === "function") {
-      handlerFn = handler["GET"];
-      isAutoHead = true;
-    }
-
     // ISR cache read for route handlers (production only).
     // Only GET/HEAD (auto-HEAD) with finite revalidate > 0 are ISR-eligible.
     // Known-dynamic handlers skip the read entirely so stale cache entries
     // from earlier requests do not replay once the process has learned they
     // access request-specific data.
     if (
-      process.env.NODE_ENV === "production" &&
-      revalidateSeconds !== null &&
-      handler.dynamic !== "force-dynamic" &&
-      !__isKnownDynamicAppRoute(route.pattern) &&
-      (method === "GET" || isAutoHead) &&
-      typeof handlerFn === "function"
+      __shouldReadAppRouteHandlerCache({
+        dynamicConfig: handler.dynamic,
+        handlerFn,
+        isAutoHead,
+        isKnownDynamic: __isKnownDynamicAppRoute(route.pattern),
+        isProduction: process.env.NODE_ENV === "production",
+        method,
+        revalidateSeconds,
+      })
     ) {
       const __routeKey = __isrRouteKey(cleanPathname);
       try {
@@ -5004,10 +5012,13 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         // Runtime request APIs like headers() / cookies() make GET handlers dynamic,
         // so only attach ISR headers when the handler stayed static.
         if (
-          revalidateSeconds !== null &&
-          !dynamicUsedInHandler &&
-          (method === "GET" || isAutoHead) &&
-          !handlerSetCacheControl
+          __shouldApplyAppRouteHandlerRevalidateHeader({
+            dynamicUsedInHandler,
+            handlerSetCacheControl,
+            isAutoHead,
+            method,
+            revalidateSeconds,
+          })
         ) {
           __applyRouteHandlerRevalidateHeader(response, revalidateSeconds);
         }
@@ -5016,12 +5027,15 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         // Store the raw handler response before cookie/middleware transforms
         // (those are request-specific and shouldn't be cached).
         if (
-          process.env.NODE_ENV === "production" &&
-          revalidateSeconds !== null &&
-          handler.dynamic !== "force-dynamic" &&
-          !dynamicUsedInHandler &&
-          (method === "GET" || isAutoHead) &&
-          !handlerSetCacheControl
+          __shouldWriteAppRouteHandlerCache({
+            dynamicConfig: handler.dynamic,
+            dynamicUsedInHandler,
+            handlerSetCacheControl,
+            isAutoHead,
+            isProduction: process.env.NODE_ENV === "production",
+            method,
+            revalidateSeconds,
+          })
         ) {
           __markRouteHandlerCacheMiss(response);
           const __routeClone = response.clone();
@@ -5055,29 +5069,23 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         );
       } catch (err) {
         getAndClearPendingCookies(); // Clear any pending cookies on error
-        // Catch redirect() / notFound() thrown from route handlers
-        if (err && typeof err === "object" && "digest" in err) {
-          const digest = String(err.digest);
-          if (digest.startsWith("NEXT_REDIRECT;")) {
-            const parts = digest.split(";");
-            const redirectUrl = decodeURIComponent(parts[2]);
-            const statusCode = parts[3] ? parseInt(parts[3], 10) : 307;
-            setHeadersContext(null);
-            setNavigationContext(null);
+        const specialError = __resolveAppRouteHandlerSpecialError(err, request.url);
+        if (specialError) {
+          setHeadersContext(null);
+          setNavigationContext(null);
+          if (specialError.kind === "redirect") {
             return __applyRouteHandlerMiddlewareContext(
               new Response(null, {
-                status: statusCode,
-                headers: { Location: new URL(redirectUrl, request.url).toString() },
+                status: specialError.statusCode,
+                headers: { Location: specialError.location },
               }),
               _mwCtx,
             );
           }
-          if (digest === "NEXT_NOT_FOUND" || digest.startsWith("NEXT_HTTP_ERROR_FALLBACK;")) {
-            const statusCode = digest === "NEXT_NOT_FOUND" ? 404 : parseInt(digest.split(";")[1], 10);
-            setHeadersContext(null);
-            setNavigationContext(null);
-            return __applyRouteHandlerMiddlewareContext(new Response(null, { status: statusCode }), _mwCtx);
-          }
+          return __applyRouteHandlerMiddlewareContext(
+            new Response(null, { status: specialError.statusCode }),
+            _mwCtx,
+          );
         }
         setHeadersContext(null);
         setNavigationContext(null);
@@ -5991,12 +5999,19 @@ import { MetadataHead, mergeMetadata, resolveModuleMetadata, ViewportHead, merge
 import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, matchHeaders, isExternalUrl, proxyExternalRequest, sanitizeDestination } from "<ROOT>/packages/vinext/src/config/config-matchers.js";
 import { validateCsrfOrigin, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash, processMiddlewareHeaders } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
 import {
-  buildRouteHandlerAllowHeader,
-  collectRouteHandlerMethods,
   createTrackedAppRouteRequest as __createTrackedAppRouteRequest,
   isKnownDynamicAppRoute as __isKnownDynamicAppRoute,
   markKnownDynamicAppRoute as __markKnownDynamicAppRoute,
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-runtime.js";
+import {
+  getAppRouteHandlerRevalidateSeconds as __getAppRouteHandlerRevalidateSeconds,
+  hasAppRouteHandlerDefaultExport as __hasAppRouteHandlerDefaultExport,
+  resolveAppRouteHandlerMethod as __resolveAppRouteHandlerMethod,
+  resolveAppRouteHandlerSpecialError as __resolveAppRouteHandlerSpecialError,
+  shouldApplyAppRouteHandlerRevalidateHeader as __shouldApplyAppRouteHandlerRevalidateHeader,
+  shouldReadAppRouteHandlerCache as __shouldReadAppRouteHandlerCache,
+  shouldWriteAppRouteHandlerCache as __shouldWriteAppRouteHandlerCache,
+} from "<ROOT>/packages/vinext/src/server/app-route-handler-policy.js";
 import {
   applyRouteHandlerMiddlewareContext as __applyRouteHandlerMiddlewareContext,
   applyRouteHandlerRevalidateHeader as __applyRouteHandlerRevalidateHeader,
@@ -7853,19 +7868,21 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   if (route.routeHandler) {
     const handler = route.routeHandler;
     const method = request.method.toUpperCase();
-    const revalidateSeconds = typeof handler.revalidate === "number" && handler.revalidate > 0 && handler.revalidate !== Infinity ? handler.revalidate : null;
-    if (typeof handler["default"] === "function" && process.env.NODE_ENV === "development") {
+    const revalidateSeconds = __getAppRouteHandlerRevalidateSeconds(handler);
+    if (__hasAppRouteHandlerDefaultExport(handler) && process.env.NODE_ENV === "development") {
       console.error(
         "[vinext] Detected default export in route handler " + route.pattern + ". Export a named export for each HTTP method instead.",
       );
     }
 
-    // Collect exported HTTP methods for OPTIONS auto-response and Allow header
-    const exportedMethods = collectRouteHandlerMethods(handler);
-    const allowHeaderForOptions = buildRouteHandlerAllowHeader(exportedMethods);
+    const {
+      allowHeaderForOptions,
+      handlerFn,
+      isAutoHead,
+      shouldAutoRespondToOptions,
+    } = __resolveAppRouteHandlerMethod(handler, method);
 
-    // OPTIONS auto-implementation: respond with Allow header and 204
-    if (method === "OPTIONS" && typeof handler["OPTIONS"] !== "function") {
+    if (shouldAutoRespondToOptions) {
       setHeadersContext(null);
       setNavigationContext(null);
       return __applyRouteHandlerMiddlewareContext(
@@ -7877,26 +7894,21 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       );
     }
 
-    // HEAD auto-implementation: run GET handler and strip body
-    let handlerFn = handler[method];
-    let isAutoHead = false;
-    if (method === "HEAD" && typeof handler["HEAD"] !== "function" && typeof handler["GET"] === "function") {
-      handlerFn = handler["GET"];
-      isAutoHead = true;
-    }
-
     // ISR cache read for route handlers (production only).
     // Only GET/HEAD (auto-HEAD) with finite revalidate > 0 are ISR-eligible.
     // Known-dynamic handlers skip the read entirely so stale cache entries
     // from earlier requests do not replay once the process has learned they
     // access request-specific data.
     if (
-      process.env.NODE_ENV === "production" &&
-      revalidateSeconds !== null &&
-      handler.dynamic !== "force-dynamic" &&
-      !__isKnownDynamicAppRoute(route.pattern) &&
-      (method === "GET" || isAutoHead) &&
-      typeof handlerFn === "function"
+      __shouldReadAppRouteHandlerCache({
+        dynamicConfig: handler.dynamic,
+        handlerFn,
+        isAutoHead,
+        isKnownDynamic: __isKnownDynamicAppRoute(route.pattern),
+        isProduction: process.env.NODE_ENV === "production",
+        method,
+        revalidateSeconds,
+      })
     ) {
       const __routeKey = __isrRouteKey(cleanPathname);
       try {
@@ -8001,10 +8013,13 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         // Runtime request APIs like headers() / cookies() make GET handlers dynamic,
         // so only attach ISR headers when the handler stayed static.
         if (
-          revalidateSeconds !== null &&
-          !dynamicUsedInHandler &&
-          (method === "GET" || isAutoHead) &&
-          !handlerSetCacheControl
+          __shouldApplyAppRouteHandlerRevalidateHeader({
+            dynamicUsedInHandler,
+            handlerSetCacheControl,
+            isAutoHead,
+            method,
+            revalidateSeconds,
+          })
         ) {
           __applyRouteHandlerRevalidateHeader(response, revalidateSeconds);
         }
@@ -8013,12 +8028,15 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         // Store the raw handler response before cookie/middleware transforms
         // (those are request-specific and shouldn't be cached).
         if (
-          process.env.NODE_ENV === "production" &&
-          revalidateSeconds !== null &&
-          handler.dynamic !== "force-dynamic" &&
-          !dynamicUsedInHandler &&
-          (method === "GET" || isAutoHead) &&
-          !handlerSetCacheControl
+          __shouldWriteAppRouteHandlerCache({
+            dynamicConfig: handler.dynamic,
+            dynamicUsedInHandler,
+            handlerSetCacheControl,
+            isAutoHead,
+            isProduction: process.env.NODE_ENV === "production",
+            method,
+            revalidateSeconds,
+          })
         ) {
           __markRouteHandlerCacheMiss(response);
           const __routeClone = response.clone();
@@ -8052,29 +8070,23 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         );
       } catch (err) {
         getAndClearPendingCookies(); // Clear any pending cookies on error
-        // Catch redirect() / notFound() thrown from route handlers
-        if (err && typeof err === "object" && "digest" in err) {
-          const digest = String(err.digest);
-          if (digest.startsWith("NEXT_REDIRECT;")) {
-            const parts = digest.split(";");
-            const redirectUrl = decodeURIComponent(parts[2]);
-            const statusCode = parts[3] ? parseInt(parts[3], 10) : 307;
-            setHeadersContext(null);
-            setNavigationContext(null);
+        const specialError = __resolveAppRouteHandlerSpecialError(err, request.url);
+        if (specialError) {
+          setHeadersContext(null);
+          setNavigationContext(null);
+          if (specialError.kind === "redirect") {
             return __applyRouteHandlerMiddlewareContext(
               new Response(null, {
-                status: statusCode,
-                headers: { Location: new URL(redirectUrl, request.url).toString() },
+                status: specialError.statusCode,
+                headers: { Location: specialError.location },
               }),
               _mwCtx,
             );
           }
-          if (digest === "NEXT_NOT_FOUND" || digest.startsWith("NEXT_HTTP_ERROR_FALLBACK;")) {
-            const statusCode = digest === "NEXT_NOT_FOUND" ? 404 : parseInt(digest.split(";")[1], 10);
-            setHeadersContext(null);
-            setNavigationContext(null);
-            return __applyRouteHandlerMiddlewareContext(new Response(null, { status: statusCode }), _mwCtx);
-          }
+          return __applyRouteHandlerMiddlewareContext(
+            new Response(null, { status: specialError.statusCode }),
+            _mwCtx,
+          );
         }
         setHeadersContext(null);
         setNavigationContext(null);
@@ -8996,12 +9008,19 @@ import * as _instrumentation from "/tmp/test/instrumentation.ts";
 import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, matchHeaders, isExternalUrl, proxyExternalRequest, sanitizeDestination } from "<ROOT>/packages/vinext/src/config/config-matchers.js";
 import { validateCsrfOrigin, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash, processMiddlewareHeaders } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
 import {
-  buildRouteHandlerAllowHeader,
-  collectRouteHandlerMethods,
   createTrackedAppRouteRequest as __createTrackedAppRouteRequest,
   isKnownDynamicAppRoute as __isKnownDynamicAppRoute,
   markKnownDynamicAppRoute as __markKnownDynamicAppRoute,
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-runtime.js";
+import {
+  getAppRouteHandlerRevalidateSeconds as __getAppRouteHandlerRevalidateSeconds,
+  hasAppRouteHandlerDefaultExport as __hasAppRouteHandlerDefaultExport,
+  resolveAppRouteHandlerMethod as __resolveAppRouteHandlerMethod,
+  resolveAppRouteHandlerSpecialError as __resolveAppRouteHandlerSpecialError,
+  shouldApplyAppRouteHandlerRevalidateHeader as __shouldApplyAppRouteHandlerRevalidateHeader,
+  shouldReadAppRouteHandlerCache as __shouldReadAppRouteHandlerCache,
+  shouldWriteAppRouteHandlerCache as __shouldWriteAppRouteHandlerCache,
+} from "<ROOT>/packages/vinext/src/server/app-route-handler-policy.js";
 import {
   applyRouteHandlerMiddlewareContext as __applyRouteHandlerMiddlewareContext,
   applyRouteHandlerRevalidateHeader as __applyRouteHandlerRevalidateHeader,
@@ -10861,19 +10880,21 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   if (route.routeHandler) {
     const handler = route.routeHandler;
     const method = request.method.toUpperCase();
-    const revalidateSeconds = typeof handler.revalidate === "number" && handler.revalidate > 0 && handler.revalidate !== Infinity ? handler.revalidate : null;
-    if (typeof handler["default"] === "function" && process.env.NODE_ENV === "development") {
+    const revalidateSeconds = __getAppRouteHandlerRevalidateSeconds(handler);
+    if (__hasAppRouteHandlerDefaultExport(handler) && process.env.NODE_ENV === "development") {
       console.error(
         "[vinext] Detected default export in route handler " + route.pattern + ". Export a named export for each HTTP method instead.",
       );
     }
 
-    // Collect exported HTTP methods for OPTIONS auto-response and Allow header
-    const exportedMethods = collectRouteHandlerMethods(handler);
-    const allowHeaderForOptions = buildRouteHandlerAllowHeader(exportedMethods);
+    const {
+      allowHeaderForOptions,
+      handlerFn,
+      isAutoHead,
+      shouldAutoRespondToOptions,
+    } = __resolveAppRouteHandlerMethod(handler, method);
 
-    // OPTIONS auto-implementation: respond with Allow header and 204
-    if (method === "OPTIONS" && typeof handler["OPTIONS"] !== "function") {
+    if (shouldAutoRespondToOptions) {
       setHeadersContext(null);
       setNavigationContext(null);
       return __applyRouteHandlerMiddlewareContext(
@@ -10885,26 +10906,21 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       );
     }
 
-    // HEAD auto-implementation: run GET handler and strip body
-    let handlerFn = handler[method];
-    let isAutoHead = false;
-    if (method === "HEAD" && typeof handler["HEAD"] !== "function" && typeof handler["GET"] === "function") {
-      handlerFn = handler["GET"];
-      isAutoHead = true;
-    }
-
     // ISR cache read for route handlers (production only).
     // Only GET/HEAD (auto-HEAD) with finite revalidate > 0 are ISR-eligible.
     // Known-dynamic handlers skip the read entirely so stale cache entries
     // from earlier requests do not replay once the process has learned they
     // access request-specific data.
     if (
-      process.env.NODE_ENV === "production" &&
-      revalidateSeconds !== null &&
-      handler.dynamic !== "force-dynamic" &&
-      !__isKnownDynamicAppRoute(route.pattern) &&
-      (method === "GET" || isAutoHead) &&
-      typeof handlerFn === "function"
+      __shouldReadAppRouteHandlerCache({
+        dynamicConfig: handler.dynamic,
+        handlerFn,
+        isAutoHead,
+        isKnownDynamic: __isKnownDynamicAppRoute(route.pattern),
+        isProduction: process.env.NODE_ENV === "production",
+        method,
+        revalidateSeconds,
+      })
     ) {
       const __routeKey = __isrRouteKey(cleanPathname);
       try {
@@ -11009,10 +11025,13 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         // Runtime request APIs like headers() / cookies() make GET handlers dynamic,
         // so only attach ISR headers when the handler stayed static.
         if (
-          revalidateSeconds !== null &&
-          !dynamicUsedInHandler &&
-          (method === "GET" || isAutoHead) &&
-          !handlerSetCacheControl
+          __shouldApplyAppRouteHandlerRevalidateHeader({
+            dynamicUsedInHandler,
+            handlerSetCacheControl,
+            isAutoHead,
+            method,
+            revalidateSeconds,
+          })
         ) {
           __applyRouteHandlerRevalidateHeader(response, revalidateSeconds);
         }
@@ -11021,12 +11040,15 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         // Store the raw handler response before cookie/middleware transforms
         // (those are request-specific and shouldn't be cached).
         if (
-          process.env.NODE_ENV === "production" &&
-          revalidateSeconds !== null &&
-          handler.dynamic !== "force-dynamic" &&
-          !dynamicUsedInHandler &&
-          (method === "GET" || isAutoHead) &&
-          !handlerSetCacheControl
+          __shouldWriteAppRouteHandlerCache({
+            dynamicConfig: handler.dynamic,
+            dynamicUsedInHandler,
+            handlerSetCacheControl,
+            isAutoHead,
+            isProduction: process.env.NODE_ENV === "production",
+            method,
+            revalidateSeconds,
+          })
         ) {
           __markRouteHandlerCacheMiss(response);
           const __routeClone = response.clone();
@@ -11060,29 +11082,23 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         );
       } catch (err) {
         getAndClearPendingCookies(); // Clear any pending cookies on error
-        // Catch redirect() / notFound() thrown from route handlers
-        if (err && typeof err === "object" && "digest" in err) {
-          const digest = String(err.digest);
-          if (digest.startsWith("NEXT_REDIRECT;")) {
-            const parts = digest.split(";");
-            const redirectUrl = decodeURIComponent(parts[2]);
-            const statusCode = parts[3] ? parseInt(parts[3], 10) : 307;
-            setHeadersContext(null);
-            setNavigationContext(null);
+        const specialError = __resolveAppRouteHandlerSpecialError(err, request.url);
+        if (specialError) {
+          setHeadersContext(null);
+          setNavigationContext(null);
+          if (specialError.kind === "redirect") {
             return __applyRouteHandlerMiddlewareContext(
               new Response(null, {
-                status: statusCode,
-                headers: { Location: new URL(redirectUrl, request.url).toString() },
+                status: specialError.statusCode,
+                headers: { Location: specialError.location },
               }),
               _mwCtx,
             );
           }
-          if (digest === "NEXT_NOT_FOUND" || digest.startsWith("NEXT_HTTP_ERROR_FALLBACK;")) {
-            const statusCode = digest === "NEXT_NOT_FOUND" ? 404 : parseInt(digest.split(";")[1], 10);
-            setHeadersContext(null);
-            setNavigationContext(null);
-            return __applyRouteHandlerMiddlewareContext(new Response(null, { status: statusCode }), _mwCtx);
-          }
+          return __applyRouteHandlerMiddlewareContext(
+            new Response(null, { status: specialError.statusCode }),
+            _mwCtx,
+          );
         }
         setHeadersContext(null);
         setNavigationContext(null);
@@ -11996,12 +12012,19 @@ import { sitemapToXml, robotsToText, manifestToJson } from "<ROOT>/packages/vine
 import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, matchHeaders, isExternalUrl, proxyExternalRequest, sanitizeDestination } from "<ROOT>/packages/vinext/src/config/config-matchers.js";
 import { validateCsrfOrigin, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash, processMiddlewareHeaders } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
 import {
-  buildRouteHandlerAllowHeader,
-  collectRouteHandlerMethods,
   createTrackedAppRouteRequest as __createTrackedAppRouteRequest,
   isKnownDynamicAppRoute as __isKnownDynamicAppRoute,
   markKnownDynamicAppRoute as __markKnownDynamicAppRoute,
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-runtime.js";
+import {
+  getAppRouteHandlerRevalidateSeconds as __getAppRouteHandlerRevalidateSeconds,
+  hasAppRouteHandlerDefaultExport as __hasAppRouteHandlerDefaultExport,
+  resolveAppRouteHandlerMethod as __resolveAppRouteHandlerMethod,
+  resolveAppRouteHandlerSpecialError as __resolveAppRouteHandlerSpecialError,
+  shouldApplyAppRouteHandlerRevalidateHeader as __shouldApplyAppRouteHandlerRevalidateHeader,
+  shouldReadAppRouteHandlerCache as __shouldReadAppRouteHandlerCache,
+  shouldWriteAppRouteHandlerCache as __shouldWriteAppRouteHandlerCache,
+} from "<ROOT>/packages/vinext/src/server/app-route-handler-policy.js";
 import {
   applyRouteHandlerMiddlewareContext as __applyRouteHandlerMiddlewareContext,
   applyRouteHandlerRevalidateHeader as __applyRouteHandlerRevalidateHeader,
@@ -13835,19 +13858,21 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   if (route.routeHandler) {
     const handler = route.routeHandler;
     const method = request.method.toUpperCase();
-    const revalidateSeconds = typeof handler.revalidate === "number" && handler.revalidate > 0 && handler.revalidate !== Infinity ? handler.revalidate : null;
-    if (typeof handler["default"] === "function" && process.env.NODE_ENV === "development") {
+    const revalidateSeconds = __getAppRouteHandlerRevalidateSeconds(handler);
+    if (__hasAppRouteHandlerDefaultExport(handler) && process.env.NODE_ENV === "development") {
       console.error(
         "[vinext] Detected default export in route handler " + route.pattern + ". Export a named export for each HTTP method instead.",
       );
     }
 
-    // Collect exported HTTP methods for OPTIONS auto-response and Allow header
-    const exportedMethods = collectRouteHandlerMethods(handler);
-    const allowHeaderForOptions = buildRouteHandlerAllowHeader(exportedMethods);
+    const {
+      allowHeaderForOptions,
+      handlerFn,
+      isAutoHead,
+      shouldAutoRespondToOptions,
+    } = __resolveAppRouteHandlerMethod(handler, method);
 
-    // OPTIONS auto-implementation: respond with Allow header and 204
-    if (method === "OPTIONS" && typeof handler["OPTIONS"] !== "function") {
+    if (shouldAutoRespondToOptions) {
       setHeadersContext(null);
       setNavigationContext(null);
       return __applyRouteHandlerMiddlewareContext(
@@ -13859,26 +13884,21 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       );
     }
 
-    // HEAD auto-implementation: run GET handler and strip body
-    let handlerFn = handler[method];
-    let isAutoHead = false;
-    if (method === "HEAD" && typeof handler["HEAD"] !== "function" && typeof handler["GET"] === "function") {
-      handlerFn = handler["GET"];
-      isAutoHead = true;
-    }
-
     // ISR cache read for route handlers (production only).
     // Only GET/HEAD (auto-HEAD) with finite revalidate > 0 are ISR-eligible.
     // Known-dynamic handlers skip the read entirely so stale cache entries
     // from earlier requests do not replay once the process has learned they
     // access request-specific data.
     if (
-      process.env.NODE_ENV === "production" &&
-      revalidateSeconds !== null &&
-      handler.dynamic !== "force-dynamic" &&
-      !__isKnownDynamicAppRoute(route.pattern) &&
-      (method === "GET" || isAutoHead) &&
-      typeof handlerFn === "function"
+      __shouldReadAppRouteHandlerCache({
+        dynamicConfig: handler.dynamic,
+        handlerFn,
+        isAutoHead,
+        isKnownDynamic: __isKnownDynamicAppRoute(route.pattern),
+        isProduction: process.env.NODE_ENV === "production",
+        method,
+        revalidateSeconds,
+      })
     ) {
       const __routeKey = __isrRouteKey(cleanPathname);
       try {
@@ -13983,10 +14003,13 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         // Runtime request APIs like headers() / cookies() make GET handlers dynamic,
         // so only attach ISR headers when the handler stayed static.
         if (
-          revalidateSeconds !== null &&
-          !dynamicUsedInHandler &&
-          (method === "GET" || isAutoHead) &&
-          !handlerSetCacheControl
+          __shouldApplyAppRouteHandlerRevalidateHeader({
+            dynamicUsedInHandler,
+            handlerSetCacheControl,
+            isAutoHead,
+            method,
+            revalidateSeconds,
+          })
         ) {
           __applyRouteHandlerRevalidateHeader(response, revalidateSeconds);
         }
@@ -13995,12 +14018,15 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         // Store the raw handler response before cookie/middleware transforms
         // (those are request-specific and shouldn't be cached).
         if (
-          process.env.NODE_ENV === "production" &&
-          revalidateSeconds !== null &&
-          handler.dynamic !== "force-dynamic" &&
-          !dynamicUsedInHandler &&
-          (method === "GET" || isAutoHead) &&
-          !handlerSetCacheControl
+          __shouldWriteAppRouteHandlerCache({
+            dynamicConfig: handler.dynamic,
+            dynamicUsedInHandler,
+            handlerSetCacheControl,
+            isAutoHead,
+            isProduction: process.env.NODE_ENV === "production",
+            method,
+            revalidateSeconds,
+          })
         ) {
           __markRouteHandlerCacheMiss(response);
           const __routeClone = response.clone();
@@ -14034,29 +14060,23 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         );
       } catch (err) {
         getAndClearPendingCookies(); // Clear any pending cookies on error
-        // Catch redirect() / notFound() thrown from route handlers
-        if (err && typeof err === "object" && "digest" in err) {
-          const digest = String(err.digest);
-          if (digest.startsWith("NEXT_REDIRECT;")) {
-            const parts = digest.split(";");
-            const redirectUrl = decodeURIComponent(parts[2]);
-            const statusCode = parts[3] ? parseInt(parts[3], 10) : 307;
-            setHeadersContext(null);
-            setNavigationContext(null);
+        const specialError = __resolveAppRouteHandlerSpecialError(err, request.url);
+        if (specialError) {
+          setHeadersContext(null);
+          setNavigationContext(null);
+          if (specialError.kind === "redirect") {
             return __applyRouteHandlerMiddlewareContext(
               new Response(null, {
-                status: statusCode,
-                headers: { Location: new URL(redirectUrl, request.url).toString() },
+                status: specialError.statusCode,
+                headers: { Location: specialError.location },
               }),
               _mwCtx,
             );
           }
-          if (digest === "NEXT_NOT_FOUND" || digest.startsWith("NEXT_HTTP_ERROR_FALLBACK;")) {
-            const statusCode = digest === "NEXT_NOT_FOUND" ? 404 : parseInt(digest.split(";")[1], 10);
-            setHeadersContext(null);
-            setNavigationContext(null);
-            return __applyRouteHandlerMiddlewareContext(new Response(null, { status: statusCode }), _mwCtx);
-          }
+          return __applyRouteHandlerMiddlewareContext(
+            new Response(null, { status: specialError.statusCode }),
+            _mwCtx,
+          );
         }
         setHeadersContext(null);
         setNavigationContext(null);
@@ -14970,12 +14990,19 @@ import * as middlewareModule from "/tmp/test/middleware.ts";
 import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, matchHeaders, isExternalUrl, proxyExternalRequest, sanitizeDestination } from "<ROOT>/packages/vinext/src/config/config-matchers.js";
 import { validateCsrfOrigin, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash, processMiddlewareHeaders } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
 import {
-  buildRouteHandlerAllowHeader,
-  collectRouteHandlerMethods,
   createTrackedAppRouteRequest as __createTrackedAppRouteRequest,
   isKnownDynamicAppRoute as __isKnownDynamicAppRoute,
   markKnownDynamicAppRoute as __markKnownDynamicAppRoute,
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-runtime.js";
+import {
+  getAppRouteHandlerRevalidateSeconds as __getAppRouteHandlerRevalidateSeconds,
+  hasAppRouteHandlerDefaultExport as __hasAppRouteHandlerDefaultExport,
+  resolveAppRouteHandlerMethod as __resolveAppRouteHandlerMethod,
+  resolveAppRouteHandlerSpecialError as __resolveAppRouteHandlerSpecialError,
+  shouldApplyAppRouteHandlerRevalidateHeader as __shouldApplyAppRouteHandlerRevalidateHeader,
+  shouldReadAppRouteHandlerCache as __shouldReadAppRouteHandlerCache,
+  shouldWriteAppRouteHandlerCache as __shouldWriteAppRouteHandlerCache,
+} from "<ROOT>/packages/vinext/src/server/app-route-handler-policy.js";
 import {
   applyRouteHandlerMiddlewareContext as __applyRouteHandlerMiddlewareContext,
   applyRouteHandlerRevalidateHeader as __applyRouteHandlerRevalidateHeader,
@@ -17162,19 +17189,21 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   if (route.routeHandler) {
     const handler = route.routeHandler;
     const method = request.method.toUpperCase();
-    const revalidateSeconds = typeof handler.revalidate === "number" && handler.revalidate > 0 && handler.revalidate !== Infinity ? handler.revalidate : null;
-    if (typeof handler["default"] === "function" && process.env.NODE_ENV === "development") {
+    const revalidateSeconds = __getAppRouteHandlerRevalidateSeconds(handler);
+    if (__hasAppRouteHandlerDefaultExport(handler) && process.env.NODE_ENV === "development") {
       console.error(
         "[vinext] Detected default export in route handler " + route.pattern + ". Export a named export for each HTTP method instead.",
       );
     }
 
-    // Collect exported HTTP methods for OPTIONS auto-response and Allow header
-    const exportedMethods = collectRouteHandlerMethods(handler);
-    const allowHeaderForOptions = buildRouteHandlerAllowHeader(exportedMethods);
+    const {
+      allowHeaderForOptions,
+      handlerFn,
+      isAutoHead,
+      shouldAutoRespondToOptions,
+    } = __resolveAppRouteHandlerMethod(handler, method);
 
-    // OPTIONS auto-implementation: respond with Allow header and 204
-    if (method === "OPTIONS" && typeof handler["OPTIONS"] !== "function") {
+    if (shouldAutoRespondToOptions) {
       setHeadersContext(null);
       setNavigationContext(null);
       return __applyRouteHandlerMiddlewareContext(
@@ -17186,26 +17215,21 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       );
     }
 
-    // HEAD auto-implementation: run GET handler and strip body
-    let handlerFn = handler[method];
-    let isAutoHead = false;
-    if (method === "HEAD" && typeof handler["HEAD"] !== "function" && typeof handler["GET"] === "function") {
-      handlerFn = handler["GET"];
-      isAutoHead = true;
-    }
-
     // ISR cache read for route handlers (production only).
     // Only GET/HEAD (auto-HEAD) with finite revalidate > 0 are ISR-eligible.
     // Known-dynamic handlers skip the read entirely so stale cache entries
     // from earlier requests do not replay once the process has learned they
     // access request-specific data.
     if (
-      process.env.NODE_ENV === "production" &&
-      revalidateSeconds !== null &&
-      handler.dynamic !== "force-dynamic" &&
-      !__isKnownDynamicAppRoute(route.pattern) &&
-      (method === "GET" || isAutoHead) &&
-      typeof handlerFn === "function"
+      __shouldReadAppRouteHandlerCache({
+        dynamicConfig: handler.dynamic,
+        handlerFn,
+        isAutoHead,
+        isKnownDynamic: __isKnownDynamicAppRoute(route.pattern),
+        isProduction: process.env.NODE_ENV === "production",
+        method,
+        revalidateSeconds,
+      })
     ) {
       const __routeKey = __isrRouteKey(cleanPathname);
       try {
@@ -17310,10 +17334,13 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         // Runtime request APIs like headers() / cookies() make GET handlers dynamic,
         // so only attach ISR headers when the handler stayed static.
         if (
-          revalidateSeconds !== null &&
-          !dynamicUsedInHandler &&
-          (method === "GET" || isAutoHead) &&
-          !handlerSetCacheControl
+          __shouldApplyAppRouteHandlerRevalidateHeader({
+            dynamicUsedInHandler,
+            handlerSetCacheControl,
+            isAutoHead,
+            method,
+            revalidateSeconds,
+          })
         ) {
           __applyRouteHandlerRevalidateHeader(response, revalidateSeconds);
         }
@@ -17322,12 +17349,15 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         // Store the raw handler response before cookie/middleware transforms
         // (those are request-specific and shouldn't be cached).
         if (
-          process.env.NODE_ENV === "production" &&
-          revalidateSeconds !== null &&
-          handler.dynamic !== "force-dynamic" &&
-          !dynamicUsedInHandler &&
-          (method === "GET" || isAutoHead) &&
-          !handlerSetCacheControl
+          __shouldWriteAppRouteHandlerCache({
+            dynamicConfig: handler.dynamic,
+            dynamicUsedInHandler,
+            handlerSetCacheControl,
+            isAutoHead,
+            isProduction: process.env.NODE_ENV === "production",
+            method,
+            revalidateSeconds,
+          })
         ) {
           __markRouteHandlerCacheMiss(response);
           const __routeClone = response.clone();
@@ -17361,29 +17391,23 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         );
       } catch (err) {
         getAndClearPendingCookies(); // Clear any pending cookies on error
-        // Catch redirect() / notFound() thrown from route handlers
-        if (err && typeof err === "object" && "digest" in err) {
-          const digest = String(err.digest);
-          if (digest.startsWith("NEXT_REDIRECT;")) {
-            const parts = digest.split(";");
-            const redirectUrl = decodeURIComponent(parts[2]);
-            const statusCode = parts[3] ? parseInt(parts[3], 10) : 307;
-            setHeadersContext(null);
-            setNavigationContext(null);
+        const specialError = __resolveAppRouteHandlerSpecialError(err, request.url);
+        if (specialError) {
+          setHeadersContext(null);
+          setNavigationContext(null);
+          if (specialError.kind === "redirect") {
             return __applyRouteHandlerMiddlewareContext(
               new Response(null, {
-                status: statusCode,
-                headers: { Location: new URL(redirectUrl, request.url).toString() },
+                status: specialError.statusCode,
+                headers: { Location: specialError.location },
               }),
               _mwCtx,
             );
           }
-          if (digest === "NEXT_NOT_FOUND" || digest.startsWith("NEXT_HTTP_ERROR_FALLBACK;")) {
-            const statusCode = digest === "NEXT_NOT_FOUND" ? 404 : parseInt(digest.split(";")[1], 10);
-            setHeadersContext(null);
-            setNavigationContext(null);
-            return __applyRouteHandlerMiddlewareContext(new Response(null, { status: statusCode }), _mwCtx);
-          }
+          return __applyRouteHandlerMiddlewareContext(
+            new Response(null, { status: specialError.statusCode }),
+            _mwCtx,
+          );
         }
         setHeadersContext(null);
         setNavigationContext(null);

--- a/tests/app-route-handler-policy.test.ts
+++ b/tests/app-route-handler-policy.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  getAppRouteHandlerRevalidateSeconds,
+  hasAppRouteHandlerDefaultExport,
+  resolveAppRouteHandlerMethod,
+  resolveAppRouteHandlerSpecialError,
+  shouldApplyAppRouteHandlerRevalidateHeader,
+  shouldReadAppRouteHandlerCache,
+  shouldWriteAppRouteHandlerCache,
+} from "../packages/vinext/src/server/app-route-handler-policy.js";
+
+describe("app route handler policy helpers", () => {
+  it("extracts finite positive route handler revalidate values", () => {
+    expect(getAppRouteHandlerRevalidateSeconds({ revalidate: 60 })).toBe(60);
+    expect(getAppRouteHandlerRevalidateSeconds({ revalidate: 0 })).toBeNull();
+    expect(getAppRouteHandlerRevalidateSeconds({ revalidate: Infinity })).toBeNull();
+    expect(getAppRouteHandlerRevalidateSeconds({ revalidate: false })).toBeNull();
+  });
+
+  it("detects invalid default-export route handlers", () => {
+    expect(hasAppRouteHandlerDefaultExport({ default() {} })).toBe(true);
+    expect(hasAppRouteHandlerDefaultExport({ default: "nope" })).toBe(false);
+    expect(hasAppRouteHandlerDefaultExport({ GET() {} })).toBe(false);
+  });
+
+  it("resolves auto-options and auto-head route handler behavior", () => {
+    const resolvedOptions = resolveAppRouteHandlerMethod(
+      {
+        GET() {},
+        POST() {},
+      },
+      "OPTIONS",
+    );
+
+    expect(resolvedOptions.shouldAutoRespondToOptions).toBe(true);
+    expect(resolvedOptions.allowHeaderForOptions).toBe("GET, HEAD, OPTIONS, POST");
+
+    const resolvedHead = resolveAppRouteHandlerMethod(
+      {
+        GET() {
+          return Response.json({ ok: true });
+        },
+      },
+      "HEAD",
+    );
+
+    expect(resolvedHead.isAutoHead).toBe(true);
+    expect(typeof resolvedHead.handlerFn).toBe("function");
+  });
+
+  it("determines when route handler ISR cache reads are allowed", () => {
+    const base = {
+      dynamicConfig: "auto",
+      handlerFn() {},
+      isAutoHead: false,
+      isKnownDynamic: false,
+      isProduction: true,
+      method: "GET",
+      revalidateSeconds: 60,
+    };
+
+    expect(shouldReadAppRouteHandlerCache(base)).toBe(true);
+    expect(shouldReadAppRouteHandlerCache({ ...base, dynamicConfig: "force-dynamic" })).toBe(false);
+    expect(shouldReadAppRouteHandlerCache({ ...base, isKnownDynamic: true })).toBe(false);
+    expect(shouldReadAppRouteHandlerCache({ ...base, method: "POST" })).toBe(false);
+    expect(shouldReadAppRouteHandlerCache({ ...base, method: "HEAD", isAutoHead: true })).toBe(
+      true,
+    );
+    expect(shouldReadAppRouteHandlerCache({ ...base, method: "HEAD", isAutoHead: false })).toBe(
+      false,
+    );
+  });
+
+  it("determines when route handler cache headers and writes are allowed", () => {
+    const base = {
+      dynamicConfig: "auto",
+      dynamicUsedInHandler: false,
+      handlerSetCacheControl: false,
+      isAutoHead: false,
+      isProduction: true,
+      method: "GET",
+      revalidateSeconds: 60,
+    };
+
+    expect(shouldApplyAppRouteHandlerRevalidateHeader(base)).toBe(true);
+    expect(
+      shouldApplyAppRouteHandlerRevalidateHeader({ ...base, dynamicUsedInHandler: true }),
+    ).toBe(false);
+    expect(
+      shouldApplyAppRouteHandlerRevalidateHeader({ ...base, handlerSetCacheControl: true }),
+    ).toBe(false);
+    expect(shouldWriteAppRouteHandlerCache(base)).toBe(true);
+    expect(shouldWriteAppRouteHandlerCache({ ...base, isProduction: false })).toBe(false);
+    expect(shouldWriteAppRouteHandlerCache({ ...base, dynamicConfig: "force-dynamic" })).toBe(
+      false,
+    );
+  });
+
+  it("maps special route handler digests to typed redirect and status results", () => {
+    expect(
+      resolveAppRouteHandlerSpecialError(
+        { digest: "NEXT_REDIRECT;replace;%2Ftarget%3Fok%3D1;308" },
+        "https://example.com/source",
+      ),
+    ).toEqual({
+      kind: "redirect",
+      location: "https://example.com/target?ok=1",
+      statusCode: 308,
+    });
+
+    expect(
+      resolveAppRouteHandlerSpecialError(
+        { digest: "NEXT_NOT_FOUND" },
+        "https://example.com/source",
+      ),
+    ).toEqual({
+      kind: "status",
+      statusCode: 404,
+    });
+
+    expect(
+      resolveAppRouteHandlerSpecialError(
+        { digest: "NEXT_HTTP_ERROR_FALLBACK;401" },
+        "https://example.com/source",
+      ),
+    ).toEqual({
+      kind: "status",
+      statusCode: 401,
+    });
+
+    expect(resolveAppRouteHandlerSpecialError(new Error("no digest"), "https://example.com")).toBe(
+      null,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- extract route-handler method/revalidate/cache-policy decisions out of `app-rsc-entry.ts` into a typed `app-route-handler-policy.ts` runtime module
- keep the generated App Router RSC entry focused on wiring by delegating route-handler ISR/read/write eligibility and special digest handling to the new helper layer
- add focused unit coverage for the extracted policy helpers and update the App Router entry snapshots

## Verification
- `vp check packages/vinext/src/server/app-route-handler-runtime.ts packages/vinext/src/server/app-route-handler-policy.ts packages/vinext/src/entries/app-rsc-entry.ts tests/app-route-handler-policy.test.ts tests/app-route-handler-runtime.test.ts tests/app-route-handler-response.test.ts tests/app-router.test.ts tests/entry-templates.test.ts`
- `vp test run tests/app-route-handler-policy.test.ts tests/app-route-handler-runtime.test.ts tests/app-route-handler-response.test.ts tests/entry-templates.test.ts tests/app-router.test.ts -t 'route handler'`
- `vp test run tests/nextjs-compat/app-routes.test.ts`
- `vp run vinext#build`

Written by Codex.
