### PR TITLE
refactor: extract app page cache writes

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -362,7 +362,10 @@ import {
   executeAppRouteHandler as __executeAppRouteHandler,
 } from ${JSON.stringify(appRouteHandlerExecutionPath)};
 import { readAppRouteHandlerCacheResponse as __readAppRouteHandlerCacheResponse } from ${JSON.stringify(appRouteHandlerCachePath)};
-import { readAppPageCacheResponse as __readAppPageCacheResponse } from ${JSON.stringify(appPageCachePath)};
+import {
+  finalizeAppPageHtmlCacheResponse as __finalizeAppPageHtmlCacheResponse,
+  readAppPageCacheResponse as __readAppPageCacheResponse,
+} from ${JSON.stringify(appPageCachePath)};
 import {
   buildAppPageHtmlResponse as __buildAppPageHtmlResponse,
   buildAppPageRscResponse as __buildAppPageRscResponse,
@@ -2923,11 +2926,6 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // revalidate=Infinity means "cache forever" (no periodic revalidation) — treated as
   // static here so we emit s-maxage=31536000 but skip ISR cache management.
   if (__htmlResponsePolicy.shouldWriteToCache) {
-    // In production, tee the HTML response body to simultaneously stream to the
-    // client and collect the full HTML string for the ISR cache. rscData was
-    // already captured above by teeing the RSC stream before SSR.
-    // In dev, skip the tee and the X-Vinext-Cache header — every request renders
-    // fresh (no cache reads or writes in dev mode).
     const __isrResponseProd = __buildAppPageHtmlResponse(htmlStream, {
       draftCookie,
       fontLinkHeader,
@@ -2935,55 +2933,23 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       policy: __htmlResponsePolicy,
       timing: __htmlResponseTiming,
     });
-    if (__isrResponseProd.body) {
-      const [__streamForClient, __streamForCache] = __isrResponseProd.body.tee();
-      const __isrKey = __isrHtmlKey(cleanPathname);
-      const __isrKeyRscFromHtml = __isrRscKey(cleanPathname);
-      const __revalSecs = revalidateSeconds;
-      const __capturedRscDataPromise = __isrRscDataPromise;
-      const __cachePromise = (async () => {
-        try {
-          const __reader = __streamForCache.getReader();
-          const __decoder = new TextDecoder();
-          const __chunks = [];
-          for (;;) {
-            const { done, value } = await __reader.read();
-            if (done) break;
-            __chunks.push(__decoder.decode(value, { stream: true }));
-          }
-          __chunks.push(__decoder.decode());
-          const __fullHtml = __chunks.join("");
-          const __pageTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
-          // Write HTML and RSC to their own keys independently.
-          // RSC data was captured by the tee above (before isRscRequest branch)
-          // so an initial browser visit (HTML request) also populates the RSC key,
-          // ensuring the first client-side navigation after a direct visit is a
-          // cache hit rather than a miss.
-          const __writes = [
-            __isrSet(__isrKey, { kind: "APP_PAGE", html: __fullHtml, rscData: undefined, headers: undefined, postponed: undefined, status: 200 }, __revalSecs, __pageTags),
-          ];
-          if (__capturedRscDataPromise) {
-            __writes.push(
-              __capturedRscDataPromise.then((__rscBuf) =>
-                __isrSet(__isrKeyRscFromHtml, { kind: "APP_PAGE", html: "", rscData: __rscBuf, headers: undefined, postponed: undefined, status: 200 }, __revalSecs, __pageTags)
-              )
-            );
-          }
-          await Promise.all(__writes);
-          __isrDebug?.("HTML cache written", __isrKey);
-        } catch (__cacheErr) {
-          console.error("[vinext] ISR cache write error:", __cacheErr);
-        }
-      })();
-      // Register with ExecutionContext (from ALS) so the Workers runtime keeps
-      // the isolate alive until the cache write finishes, even after the response is sent.
-      _getRequestExecutionContext()?.waitUntil(__cachePromise);
-      return new Response(__streamForClient, {
-        status: __isrResponseProd.status,
-        headers: __isrResponseProd.headers,
-      });
-    }
-    return __isrResponseProd;
+    return __finalizeAppPageHtmlCacheResponse(__isrResponseProd, {
+      capturedRscDataPromise: __isrRscDataPromise,
+      cleanPathname,
+      getPageTags: function() {
+        return __pageCacheTags(cleanPathname, getCollectedFetchTags());
+      },
+      isrDebug: __isrDebug,
+      isrHtmlKey: __isrHtmlKey,
+      isrRscKey: __isrRscKey,
+      isrSet: __isrSet,
+      revalidateSeconds,
+      waitUntil: function(__cachePromise) {
+        // Register with ExecutionContext (from ALS) so the Workers runtime keeps
+        // the isolate alive until the cache write finishes, even after the response is sent.
+        _getRequestExecutionContext()?.waitUntil(__cachePromise);
+      },
+    });
   }
 
   return __buildAppPageHtmlResponse(htmlStream, {

--- a/packages/vinext/src/server/app-page-cache.ts
+++ b/packages/vinext/src/server/app-page-cache.ts
@@ -37,6 +37,18 @@ export interface ReadAppPageCacheResponseOptions {
   scheduleBackgroundRegeneration: AppPageBackgroundRegenerator;
 }
 
+export interface FinalizeAppPageHtmlCacheResponseOptions {
+  capturedRscDataPromise: Promise<ArrayBuffer> | null;
+  cleanPathname: string;
+  getPageTags: () => string[];
+  isrDebug?: AppPageDebugLogger;
+  isrHtmlKey: (pathname: string) => string;
+  isrRscKey: (pathname: string) => string;
+  isrSet: AppPageCacheSetter;
+  revalidateSeconds: number;
+  waitUntil?: (promise: Promise<void>) => void;
+}
+
 function buildAppPageCacheControl(
   cacheState: BuildAppPageCachedResponseOptions["cacheState"],
   revalidateSeconds: number,
@@ -172,4 +184,69 @@ export async function readAppPageCacheResponse(
   }
 
   return null;
+}
+
+export function finalizeAppPageHtmlCacheResponse(
+  response: Response,
+  options: FinalizeAppPageHtmlCacheResponseOptions,
+): Response {
+  if (!response.body) {
+    return response;
+  }
+
+  const [streamForClient, streamForCache] = response.body.tee();
+  const htmlKey = options.isrHtmlKey(options.cleanPathname);
+  const rscKey = options.isrRscKey(options.cleanPathname);
+
+  const cachePromise = (async () => {
+    try {
+      const reader = streamForCache.getReader();
+      const decoder = new TextDecoder();
+      const chunks: string[] = [];
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) {
+          break;
+        }
+        chunks.push(decoder.decode(value, { stream: true }));
+      }
+      chunks.push(decoder.decode());
+
+      const pageTags = options.getPageTags();
+      const writes = [
+        options.isrSet(
+          htmlKey,
+          buildAppPageCacheValue(chunks.join(""), undefined, 200),
+          options.revalidateSeconds,
+          pageTags,
+        ),
+      ];
+
+      if (options.capturedRscDataPromise) {
+        writes.push(
+          options.capturedRscDataPromise.then((rscData) =>
+            options.isrSet(
+              rscKey,
+              buildAppPageCacheValue("", rscData, 200),
+              options.revalidateSeconds,
+              pageTags,
+            ),
+          ),
+        );
+      }
+
+      await Promise.all(writes);
+      options.isrDebug?.("HTML cache written", htmlKey);
+    } catch (cacheError) {
+      console.error("[vinext] ISR cache write error:", cacheError);
+    }
+  })();
+
+  options.waitUntil?.(cachePromise);
+
+  return new Response(streamForClient, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
 }

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -66,7 +66,10 @@ import {
   executeAppRouteHandler as __executeAppRouteHandler,
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-execution.js";
 import { readAppRouteHandlerCacheResponse as __readAppRouteHandlerCacheResponse } from "<ROOT>/packages/vinext/src/server/app-route-handler-cache.js";
-import { readAppPageCacheResponse as __readAppPageCacheResponse } from "<ROOT>/packages/vinext/src/server/app-page-cache.js";
+import {
+  finalizeAppPageHtmlCacheResponse as __finalizeAppPageHtmlCacheResponse,
+  readAppPageCacheResponse as __readAppPageCacheResponse,
+} from "<ROOT>/packages/vinext/src/server/app-page-cache.js";
 import {
   buildAppPageHtmlResponse as __buildAppPageHtmlResponse,
   buildAppPageRscResponse as __buildAppPageRscResponse,
@@ -2583,11 +2586,6 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // revalidate=Infinity means "cache forever" (no periodic revalidation) — treated as
   // static here so we emit s-maxage=31536000 but skip ISR cache management.
   if (__htmlResponsePolicy.shouldWriteToCache) {
-    // In production, tee the HTML response body to simultaneously stream to the
-    // client and collect the full HTML string for the ISR cache. rscData was
-    // already captured above by teeing the RSC stream before SSR.
-    // In dev, skip the tee and the X-Vinext-Cache header — every request renders
-    // fresh (no cache reads or writes in dev mode).
     const __isrResponseProd = __buildAppPageHtmlResponse(htmlStream, {
       draftCookie,
       fontLinkHeader,
@@ -2595,55 +2593,23 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       policy: __htmlResponsePolicy,
       timing: __htmlResponseTiming,
     });
-    if (__isrResponseProd.body) {
-      const [__streamForClient, __streamForCache] = __isrResponseProd.body.tee();
-      const __isrKey = __isrHtmlKey(cleanPathname);
-      const __isrKeyRscFromHtml = __isrRscKey(cleanPathname);
-      const __revalSecs = revalidateSeconds;
-      const __capturedRscDataPromise = __isrRscDataPromise;
-      const __cachePromise = (async () => {
-        try {
-          const __reader = __streamForCache.getReader();
-          const __decoder = new TextDecoder();
-          const __chunks = [];
-          for (;;) {
-            const { done, value } = await __reader.read();
-            if (done) break;
-            __chunks.push(__decoder.decode(value, { stream: true }));
-          }
-          __chunks.push(__decoder.decode());
-          const __fullHtml = __chunks.join("");
-          const __pageTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
-          // Write HTML and RSC to their own keys independently.
-          // RSC data was captured by the tee above (before isRscRequest branch)
-          // so an initial browser visit (HTML request) also populates the RSC key,
-          // ensuring the first client-side navigation after a direct visit is a
-          // cache hit rather than a miss.
-          const __writes = [
-            __isrSet(__isrKey, { kind: "APP_PAGE", html: __fullHtml, rscData: undefined, headers: undefined, postponed: undefined, status: 200 }, __revalSecs, __pageTags),
-          ];
-          if (__capturedRscDataPromise) {
-            __writes.push(
-              __capturedRscDataPromise.then((__rscBuf) =>
-                __isrSet(__isrKeyRscFromHtml, { kind: "APP_PAGE", html: "", rscData: __rscBuf, headers: undefined, postponed: undefined, status: 200 }, __revalSecs, __pageTags)
-              )
-            );
-          }
-          await Promise.all(__writes);
-          __isrDebug?.("HTML cache written", __isrKey);
-        } catch (__cacheErr) {
-          console.error("[vinext] ISR cache write error:", __cacheErr);
-        }
-      })();
-      // Register with ExecutionContext (from ALS) so the Workers runtime keeps
-      // the isolate alive until the cache write finishes, even after the response is sent.
-      _getRequestExecutionContext()?.waitUntil(__cachePromise);
-      return new Response(__streamForClient, {
-        status: __isrResponseProd.status,
-        headers: __isrResponseProd.headers,
-      });
-    }
-    return __isrResponseProd;
+    return __finalizeAppPageHtmlCacheResponse(__isrResponseProd, {
+      capturedRscDataPromise: __isrRscDataPromise,
+      cleanPathname,
+      getPageTags: function() {
+        return __pageCacheTags(cleanPathname, getCollectedFetchTags());
+      },
+      isrDebug: __isrDebug,
+      isrHtmlKey: __isrHtmlKey,
+      isrRscKey: __isrRscKey,
+      isrSet: __isrSet,
+      revalidateSeconds,
+      waitUntil: function(__cachePromise) {
+        // Register with ExecutionContext (from ALS) so the Workers runtime keeps
+        // the isolate alive until the cache write finishes, even after the response is sent.
+        _getRequestExecutionContext()?.waitUntil(__cachePromise);
+      },
+    });
   }
 
   return __buildAppPageHtmlResponse(htmlStream, {
@@ -2725,7 +2691,10 @@ import {
   executeAppRouteHandler as __executeAppRouteHandler,
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-execution.js";
 import { readAppRouteHandlerCacheResponse as __readAppRouteHandlerCacheResponse } from "<ROOT>/packages/vinext/src/server/app-route-handler-cache.js";
-import { readAppPageCacheResponse as __readAppPageCacheResponse } from "<ROOT>/packages/vinext/src/server/app-page-cache.js";
+import {
+  finalizeAppPageHtmlCacheResponse as __finalizeAppPageHtmlCacheResponse,
+  readAppPageCacheResponse as __readAppPageCacheResponse,
+} from "<ROOT>/packages/vinext/src/server/app-page-cache.js";
 import {
   buildAppPageHtmlResponse as __buildAppPageHtmlResponse,
   buildAppPageRscResponse as __buildAppPageRscResponse,
@@ -5245,11 +5214,6 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // revalidate=Infinity means "cache forever" (no periodic revalidation) — treated as
   // static here so we emit s-maxage=31536000 but skip ISR cache management.
   if (__htmlResponsePolicy.shouldWriteToCache) {
-    // In production, tee the HTML response body to simultaneously stream to the
-    // client and collect the full HTML string for the ISR cache. rscData was
-    // already captured above by teeing the RSC stream before SSR.
-    // In dev, skip the tee and the X-Vinext-Cache header — every request renders
-    // fresh (no cache reads or writes in dev mode).
     const __isrResponseProd = __buildAppPageHtmlResponse(htmlStream, {
       draftCookie,
       fontLinkHeader,
@@ -5257,55 +5221,23 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       policy: __htmlResponsePolicy,
       timing: __htmlResponseTiming,
     });
-    if (__isrResponseProd.body) {
-      const [__streamForClient, __streamForCache] = __isrResponseProd.body.tee();
-      const __isrKey = __isrHtmlKey(cleanPathname);
-      const __isrKeyRscFromHtml = __isrRscKey(cleanPathname);
-      const __revalSecs = revalidateSeconds;
-      const __capturedRscDataPromise = __isrRscDataPromise;
-      const __cachePromise = (async () => {
-        try {
-          const __reader = __streamForCache.getReader();
-          const __decoder = new TextDecoder();
-          const __chunks = [];
-          for (;;) {
-            const { done, value } = await __reader.read();
-            if (done) break;
-            __chunks.push(__decoder.decode(value, { stream: true }));
-          }
-          __chunks.push(__decoder.decode());
-          const __fullHtml = __chunks.join("");
-          const __pageTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
-          // Write HTML and RSC to their own keys independently.
-          // RSC data was captured by the tee above (before isRscRequest branch)
-          // so an initial browser visit (HTML request) also populates the RSC key,
-          // ensuring the first client-side navigation after a direct visit is a
-          // cache hit rather than a miss.
-          const __writes = [
-            __isrSet(__isrKey, { kind: "APP_PAGE", html: __fullHtml, rscData: undefined, headers: undefined, postponed: undefined, status: 200 }, __revalSecs, __pageTags),
-          ];
-          if (__capturedRscDataPromise) {
-            __writes.push(
-              __capturedRscDataPromise.then((__rscBuf) =>
-                __isrSet(__isrKeyRscFromHtml, { kind: "APP_PAGE", html: "", rscData: __rscBuf, headers: undefined, postponed: undefined, status: 200 }, __revalSecs, __pageTags)
-              )
-            );
-          }
-          await Promise.all(__writes);
-          __isrDebug?.("HTML cache written", __isrKey);
-        } catch (__cacheErr) {
-          console.error("[vinext] ISR cache write error:", __cacheErr);
-        }
-      })();
-      // Register with ExecutionContext (from ALS) so the Workers runtime keeps
-      // the isolate alive until the cache write finishes, even after the response is sent.
-      _getRequestExecutionContext()?.waitUntil(__cachePromise);
-      return new Response(__streamForClient, {
-        status: __isrResponseProd.status,
-        headers: __isrResponseProd.headers,
-      });
-    }
-    return __isrResponseProd;
+    return __finalizeAppPageHtmlCacheResponse(__isrResponseProd, {
+      capturedRscDataPromise: __isrRscDataPromise,
+      cleanPathname,
+      getPageTags: function() {
+        return __pageCacheTags(cleanPathname, getCollectedFetchTags());
+      },
+      isrDebug: __isrDebug,
+      isrHtmlKey: __isrHtmlKey,
+      isrRscKey: __isrRscKey,
+      isrSet: __isrSet,
+      revalidateSeconds,
+      waitUntil: function(__cachePromise) {
+        // Register with ExecutionContext (from ALS) so the Workers runtime keeps
+        // the isolate alive until the cache write finishes, even after the response is sent.
+        _getRequestExecutionContext()?.waitUntil(__cachePromise);
+      },
+    });
   }
 
   return __buildAppPageHtmlResponse(htmlStream, {
@@ -5387,7 +5319,10 @@ import {
   executeAppRouteHandler as __executeAppRouteHandler,
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-execution.js";
 import { readAppRouteHandlerCacheResponse as __readAppRouteHandlerCacheResponse } from "<ROOT>/packages/vinext/src/server/app-route-handler-cache.js";
-import { readAppPageCacheResponse as __readAppPageCacheResponse } from "<ROOT>/packages/vinext/src/server/app-page-cache.js";
+import {
+  finalizeAppPageHtmlCacheResponse as __finalizeAppPageHtmlCacheResponse,
+  readAppPageCacheResponse as __readAppPageCacheResponse,
+} from "<ROOT>/packages/vinext/src/server/app-page-cache.js";
 import {
   buildAppPageHtmlResponse as __buildAppPageHtmlResponse,
   buildAppPageRscResponse as __buildAppPageRscResponse,
@@ -7942,11 +7877,6 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // revalidate=Infinity means "cache forever" (no periodic revalidation) — treated as
   // static here so we emit s-maxage=31536000 but skip ISR cache management.
   if (__htmlResponsePolicy.shouldWriteToCache) {
-    // In production, tee the HTML response body to simultaneously stream to the
-    // client and collect the full HTML string for the ISR cache. rscData was
-    // already captured above by teeing the RSC stream before SSR.
-    // In dev, skip the tee and the X-Vinext-Cache header — every request renders
-    // fresh (no cache reads or writes in dev mode).
     const __isrResponseProd = __buildAppPageHtmlResponse(htmlStream, {
       draftCookie,
       fontLinkHeader,
@@ -7954,55 +7884,23 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       policy: __htmlResponsePolicy,
       timing: __htmlResponseTiming,
     });
-    if (__isrResponseProd.body) {
-      const [__streamForClient, __streamForCache] = __isrResponseProd.body.tee();
-      const __isrKey = __isrHtmlKey(cleanPathname);
-      const __isrKeyRscFromHtml = __isrRscKey(cleanPathname);
-      const __revalSecs = revalidateSeconds;
-      const __capturedRscDataPromise = __isrRscDataPromise;
-      const __cachePromise = (async () => {
-        try {
-          const __reader = __streamForCache.getReader();
-          const __decoder = new TextDecoder();
-          const __chunks = [];
-          for (;;) {
-            const { done, value } = await __reader.read();
-            if (done) break;
-            __chunks.push(__decoder.decode(value, { stream: true }));
-          }
-          __chunks.push(__decoder.decode());
-          const __fullHtml = __chunks.join("");
-          const __pageTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
-          // Write HTML and RSC to their own keys independently.
-          // RSC data was captured by the tee above (before isRscRequest branch)
-          // so an initial browser visit (HTML request) also populates the RSC key,
-          // ensuring the first client-side navigation after a direct visit is a
-          // cache hit rather than a miss.
-          const __writes = [
-            __isrSet(__isrKey, { kind: "APP_PAGE", html: __fullHtml, rscData: undefined, headers: undefined, postponed: undefined, status: 200 }, __revalSecs, __pageTags),
-          ];
-          if (__capturedRscDataPromise) {
-            __writes.push(
-              __capturedRscDataPromise.then((__rscBuf) =>
-                __isrSet(__isrKeyRscFromHtml, { kind: "APP_PAGE", html: "", rscData: __rscBuf, headers: undefined, postponed: undefined, status: 200 }, __revalSecs, __pageTags)
-              )
-            );
-          }
-          await Promise.all(__writes);
-          __isrDebug?.("HTML cache written", __isrKey);
-        } catch (__cacheErr) {
-          console.error("[vinext] ISR cache write error:", __cacheErr);
-        }
-      })();
-      // Register with ExecutionContext (from ALS) so the Workers runtime keeps
-      // the isolate alive until the cache write finishes, even after the response is sent.
-      _getRequestExecutionContext()?.waitUntil(__cachePromise);
-      return new Response(__streamForClient, {
-        status: __isrResponseProd.status,
-        headers: __isrResponseProd.headers,
-      });
-    }
-    return __isrResponseProd;
+    return __finalizeAppPageHtmlCacheResponse(__isrResponseProd, {
+      capturedRscDataPromise: __isrRscDataPromise,
+      cleanPathname,
+      getPageTags: function() {
+        return __pageCacheTags(cleanPathname, getCollectedFetchTags());
+      },
+      isrDebug: __isrDebug,
+      isrHtmlKey: __isrHtmlKey,
+      isrRscKey: __isrRscKey,
+      isrSet: __isrSet,
+      revalidateSeconds,
+      waitUntil: function(__cachePromise) {
+        // Register with ExecutionContext (from ALS) so the Workers runtime keeps
+        // the isolate alive until the cache write finishes, even after the response is sent.
+        _getRequestExecutionContext()?.waitUntil(__cachePromise);
+      },
+    });
   }
 
   return __buildAppPageHtmlResponse(htmlStream, {
@@ -8084,7 +7982,10 @@ import {
   executeAppRouteHandler as __executeAppRouteHandler,
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-execution.js";
 import { readAppRouteHandlerCacheResponse as __readAppRouteHandlerCacheResponse } from "<ROOT>/packages/vinext/src/server/app-route-handler-cache.js";
-import { readAppPageCacheResponse as __readAppPageCacheResponse } from "<ROOT>/packages/vinext/src/server/app-page-cache.js";
+import {
+  finalizeAppPageHtmlCacheResponse as __finalizeAppPageHtmlCacheResponse,
+  readAppPageCacheResponse as __readAppPageCacheResponse,
+} from "<ROOT>/packages/vinext/src/server/app-page-cache.js";
 import {
   buildAppPageHtmlResponse as __buildAppPageHtmlResponse,
   buildAppPageRscResponse as __buildAppPageRscResponse,
@@ -10634,11 +10535,6 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // revalidate=Infinity means "cache forever" (no periodic revalidation) — treated as
   // static here so we emit s-maxage=31536000 but skip ISR cache management.
   if (__htmlResponsePolicy.shouldWriteToCache) {
-    // In production, tee the HTML response body to simultaneously stream to the
-    // client and collect the full HTML string for the ISR cache. rscData was
-    // already captured above by teeing the RSC stream before SSR.
-    // In dev, skip the tee and the X-Vinext-Cache header — every request renders
-    // fresh (no cache reads or writes in dev mode).
     const __isrResponseProd = __buildAppPageHtmlResponse(htmlStream, {
       draftCookie,
       fontLinkHeader,
@@ -10646,55 +10542,23 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       policy: __htmlResponsePolicy,
       timing: __htmlResponseTiming,
     });
-    if (__isrResponseProd.body) {
-      const [__streamForClient, __streamForCache] = __isrResponseProd.body.tee();
-      const __isrKey = __isrHtmlKey(cleanPathname);
-      const __isrKeyRscFromHtml = __isrRscKey(cleanPathname);
-      const __revalSecs = revalidateSeconds;
-      const __capturedRscDataPromise = __isrRscDataPromise;
-      const __cachePromise = (async () => {
-        try {
-          const __reader = __streamForCache.getReader();
-          const __decoder = new TextDecoder();
-          const __chunks = [];
-          for (;;) {
-            const { done, value } = await __reader.read();
-            if (done) break;
-            __chunks.push(__decoder.decode(value, { stream: true }));
-          }
-          __chunks.push(__decoder.decode());
-          const __fullHtml = __chunks.join("");
-          const __pageTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
-          // Write HTML and RSC to their own keys independently.
-          // RSC data was captured by the tee above (before isRscRequest branch)
-          // so an initial browser visit (HTML request) also populates the RSC key,
-          // ensuring the first client-side navigation after a direct visit is a
-          // cache hit rather than a miss.
-          const __writes = [
-            __isrSet(__isrKey, { kind: "APP_PAGE", html: __fullHtml, rscData: undefined, headers: undefined, postponed: undefined, status: 200 }, __revalSecs, __pageTags),
-          ];
-          if (__capturedRscDataPromise) {
-            __writes.push(
-              __capturedRscDataPromise.then((__rscBuf) =>
-                __isrSet(__isrKeyRscFromHtml, { kind: "APP_PAGE", html: "", rscData: __rscBuf, headers: undefined, postponed: undefined, status: 200 }, __revalSecs, __pageTags)
-              )
-            );
-          }
-          await Promise.all(__writes);
-          __isrDebug?.("HTML cache written", __isrKey);
-        } catch (__cacheErr) {
-          console.error("[vinext] ISR cache write error:", __cacheErr);
-        }
-      })();
-      // Register with ExecutionContext (from ALS) so the Workers runtime keeps
-      // the isolate alive until the cache write finishes, even after the response is sent.
-      _getRequestExecutionContext()?.waitUntil(__cachePromise);
-      return new Response(__streamForClient, {
-        status: __isrResponseProd.status,
-        headers: __isrResponseProd.headers,
-      });
-    }
-    return __isrResponseProd;
+    return __finalizeAppPageHtmlCacheResponse(__isrResponseProd, {
+      capturedRscDataPromise: __isrRscDataPromise,
+      cleanPathname,
+      getPageTags: function() {
+        return __pageCacheTags(cleanPathname, getCollectedFetchTags());
+      },
+      isrDebug: __isrDebug,
+      isrHtmlKey: __isrHtmlKey,
+      isrRscKey: __isrRscKey,
+      isrSet: __isrSet,
+      revalidateSeconds,
+      waitUntil: function(__cachePromise) {
+        // Register with ExecutionContext (from ALS) so the Workers runtime keeps
+        // the isolate alive until the cache write finishes, even after the response is sent.
+        _getRequestExecutionContext()?.waitUntil(__cachePromise);
+      },
+    });
   }
 
   return __buildAppPageHtmlResponse(htmlStream, {
@@ -10776,7 +10640,10 @@ import {
   executeAppRouteHandler as __executeAppRouteHandler,
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-execution.js";
 import { readAppRouteHandlerCacheResponse as __readAppRouteHandlerCacheResponse } from "<ROOT>/packages/vinext/src/server/app-route-handler-cache.js";
-import { readAppPageCacheResponse as __readAppPageCacheResponse } from "<ROOT>/packages/vinext/src/server/app-page-cache.js";
+import {
+  finalizeAppPageHtmlCacheResponse as __finalizeAppPageHtmlCacheResponse,
+  readAppPageCacheResponse as __readAppPageCacheResponse,
+} from "<ROOT>/packages/vinext/src/server/app-page-cache.js";
 import {
   buildAppPageHtmlResponse as __buildAppPageHtmlResponse,
   buildAppPageRscResponse as __buildAppPageRscResponse,
@@ -13300,11 +13167,6 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // revalidate=Infinity means "cache forever" (no periodic revalidation) — treated as
   // static here so we emit s-maxage=31536000 but skip ISR cache management.
   if (__htmlResponsePolicy.shouldWriteToCache) {
-    // In production, tee the HTML response body to simultaneously stream to the
-    // client and collect the full HTML string for the ISR cache. rscData was
-    // already captured above by teeing the RSC stream before SSR.
-    // In dev, skip the tee and the X-Vinext-Cache header — every request renders
-    // fresh (no cache reads or writes in dev mode).
     const __isrResponseProd = __buildAppPageHtmlResponse(htmlStream, {
       draftCookie,
       fontLinkHeader,
@@ -13312,55 +13174,23 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       policy: __htmlResponsePolicy,
       timing: __htmlResponseTiming,
     });
-    if (__isrResponseProd.body) {
-      const [__streamForClient, __streamForCache] = __isrResponseProd.body.tee();
-      const __isrKey = __isrHtmlKey(cleanPathname);
-      const __isrKeyRscFromHtml = __isrRscKey(cleanPathname);
-      const __revalSecs = revalidateSeconds;
-      const __capturedRscDataPromise = __isrRscDataPromise;
-      const __cachePromise = (async () => {
-        try {
-          const __reader = __streamForCache.getReader();
-          const __decoder = new TextDecoder();
-          const __chunks = [];
-          for (;;) {
-            const { done, value } = await __reader.read();
-            if (done) break;
-            __chunks.push(__decoder.decode(value, { stream: true }));
-          }
-          __chunks.push(__decoder.decode());
-          const __fullHtml = __chunks.join("");
-          const __pageTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
-          // Write HTML and RSC to their own keys independently.
-          // RSC data was captured by the tee above (before isRscRequest branch)
-          // so an initial browser visit (HTML request) also populates the RSC key,
-          // ensuring the first client-side navigation after a direct visit is a
-          // cache hit rather than a miss.
-          const __writes = [
-            __isrSet(__isrKey, { kind: "APP_PAGE", html: __fullHtml, rscData: undefined, headers: undefined, postponed: undefined, status: 200 }, __revalSecs, __pageTags),
-          ];
-          if (__capturedRscDataPromise) {
-            __writes.push(
-              __capturedRscDataPromise.then((__rscBuf) =>
-                __isrSet(__isrKeyRscFromHtml, { kind: "APP_PAGE", html: "", rscData: __rscBuf, headers: undefined, postponed: undefined, status: 200 }, __revalSecs, __pageTags)
-              )
-            );
-          }
-          await Promise.all(__writes);
-          __isrDebug?.("HTML cache written", __isrKey);
-        } catch (__cacheErr) {
-          console.error("[vinext] ISR cache write error:", __cacheErr);
-        }
-      })();
-      // Register with ExecutionContext (from ALS) so the Workers runtime keeps
-      // the isolate alive until the cache write finishes, even after the response is sent.
-      _getRequestExecutionContext()?.waitUntil(__cachePromise);
-      return new Response(__streamForClient, {
-        status: __isrResponseProd.status,
-        headers: __isrResponseProd.headers,
-      });
-    }
-    return __isrResponseProd;
+    return __finalizeAppPageHtmlCacheResponse(__isrResponseProd, {
+      capturedRscDataPromise: __isrRscDataPromise,
+      cleanPathname,
+      getPageTags: function() {
+        return __pageCacheTags(cleanPathname, getCollectedFetchTags());
+      },
+      isrDebug: __isrDebug,
+      isrHtmlKey: __isrHtmlKey,
+      isrRscKey: __isrRscKey,
+      isrSet: __isrSet,
+      revalidateSeconds,
+      waitUntil: function(__cachePromise) {
+        // Register with ExecutionContext (from ALS) so the Workers runtime keeps
+        // the isolate alive until the cache write finishes, even after the response is sent.
+        _getRequestExecutionContext()?.waitUntil(__cachePromise);
+      },
+    });
   }
 
   return __buildAppPageHtmlResponse(htmlStream, {
@@ -13442,7 +13272,10 @@ import {
   executeAppRouteHandler as __executeAppRouteHandler,
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-execution.js";
 import { readAppRouteHandlerCacheResponse as __readAppRouteHandlerCacheResponse } from "<ROOT>/packages/vinext/src/server/app-route-handler-cache.js";
-import { readAppPageCacheResponse as __readAppPageCacheResponse } from "<ROOT>/packages/vinext/src/server/app-page-cache.js";
+import {
+  finalizeAppPageHtmlCacheResponse as __finalizeAppPageHtmlCacheResponse,
+  readAppPageCacheResponse as __readAppPageCacheResponse,
+} from "<ROOT>/packages/vinext/src/server/app-page-cache.js";
 import {
   buildAppPageHtmlResponse as __buildAppPageHtmlResponse,
   buildAppPageRscResponse as __buildAppPageRscResponse,
@@ -16319,11 +16152,6 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // revalidate=Infinity means "cache forever" (no periodic revalidation) — treated as
   // static here so we emit s-maxage=31536000 but skip ISR cache management.
   if (__htmlResponsePolicy.shouldWriteToCache) {
-    // In production, tee the HTML response body to simultaneously stream to the
-    // client and collect the full HTML string for the ISR cache. rscData was
-    // already captured above by teeing the RSC stream before SSR.
-    // In dev, skip the tee and the X-Vinext-Cache header — every request renders
-    // fresh (no cache reads or writes in dev mode).
     const __isrResponseProd = __buildAppPageHtmlResponse(htmlStream, {
       draftCookie,
       fontLinkHeader,
@@ -16331,55 +16159,23 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       policy: __htmlResponsePolicy,
       timing: __htmlResponseTiming,
     });
-    if (__isrResponseProd.body) {
-      const [__streamForClient, __streamForCache] = __isrResponseProd.body.tee();
-      const __isrKey = __isrHtmlKey(cleanPathname);
-      const __isrKeyRscFromHtml = __isrRscKey(cleanPathname);
-      const __revalSecs = revalidateSeconds;
-      const __capturedRscDataPromise = __isrRscDataPromise;
-      const __cachePromise = (async () => {
-        try {
-          const __reader = __streamForCache.getReader();
-          const __decoder = new TextDecoder();
-          const __chunks = [];
-          for (;;) {
-            const { done, value } = await __reader.read();
-            if (done) break;
-            __chunks.push(__decoder.decode(value, { stream: true }));
-          }
-          __chunks.push(__decoder.decode());
-          const __fullHtml = __chunks.join("");
-          const __pageTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
-          // Write HTML and RSC to their own keys independently.
-          // RSC data was captured by the tee above (before isRscRequest branch)
-          // so an initial browser visit (HTML request) also populates the RSC key,
-          // ensuring the first client-side navigation after a direct visit is a
-          // cache hit rather than a miss.
-          const __writes = [
-            __isrSet(__isrKey, { kind: "APP_PAGE", html: __fullHtml, rscData: undefined, headers: undefined, postponed: undefined, status: 200 }, __revalSecs, __pageTags),
-          ];
-          if (__capturedRscDataPromise) {
-            __writes.push(
-              __capturedRscDataPromise.then((__rscBuf) =>
-                __isrSet(__isrKeyRscFromHtml, { kind: "APP_PAGE", html: "", rscData: __rscBuf, headers: undefined, postponed: undefined, status: 200 }, __revalSecs, __pageTags)
-              )
-            );
-          }
-          await Promise.all(__writes);
-          __isrDebug?.("HTML cache written", __isrKey);
-        } catch (__cacheErr) {
-          console.error("[vinext] ISR cache write error:", __cacheErr);
-        }
-      })();
-      // Register with ExecutionContext (from ALS) so the Workers runtime keeps
-      // the isolate alive until the cache write finishes, even after the response is sent.
-      _getRequestExecutionContext()?.waitUntil(__cachePromise);
-      return new Response(__streamForClient, {
-        status: __isrResponseProd.status,
-        headers: __isrResponseProd.headers,
-      });
-    }
-    return __isrResponseProd;
+    return __finalizeAppPageHtmlCacheResponse(__isrResponseProd, {
+      capturedRscDataPromise: __isrRscDataPromise,
+      cleanPathname,
+      getPageTags: function() {
+        return __pageCacheTags(cleanPathname, getCollectedFetchTags());
+      },
+      isrDebug: __isrDebug,
+      isrHtmlKey: __isrHtmlKey,
+      isrRscKey: __isrRscKey,
+      isrSet: __isrSet,
+      revalidateSeconds,
+      waitUntil: function(__cachePromise) {
+        // Register with ExecutionContext (from ALS) so the Workers runtime keeps
+        // the isolate alive until the cache write finishes, even after the response is sent.
+        _getRequestExecutionContext()?.waitUntil(__cachePromise);
+      },
+    });
   }
 
   return __buildAppPageHtmlResponse(htmlStream, {

--- a/tests/app-page-cache.test.ts
+++ b/tests/app-page-cache.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vite-plus/test";
 import {
   buildAppPageCachedResponse,
+  finalizeAppPageHtmlCacheResponse,
   readAppPageCacheResponse,
 } from "../packages/vinext/src/server/app-page-cache.js";
 import type { ISRCacheEntry } from "../packages/vinext/src/server/isr-cache.js";
@@ -264,5 +265,82 @@ describe("app page cache helpers", () => {
     expect(response).toBeNull();
     expect(errorSpy).toHaveBeenCalledOnce();
     errorSpy.mockRestore();
+  });
+
+  it("finalizes HTML responses by teeing the stream and writing HTML and RSC cache keys", async () => {
+    const pendingCacheWrites: Promise<void>[] = [];
+    const isrSetCalls: Array<{
+      key: string;
+      html: string;
+      hasRscData: boolean;
+      revalidateSeconds: number;
+      tags: string[];
+    }> = [];
+    const debugCalls: Array<[string, string]> = [];
+    const rscData = new TextEncoder().encode("flight").buffer;
+
+    const response = finalizeAppPageHtmlCacheResponse(
+      new Response("<h1>fresh</h1>", {
+        status: 201,
+        headers: {
+          "Content-Type": "text/html; charset=utf-8",
+          Vary: "RSC, Accept",
+          "X-Vinext-Cache": "MISS",
+        },
+      }),
+      {
+        capturedRscDataPromise: Promise.resolve(rscData),
+        cleanPathname: "/fresh",
+        getPageTags() {
+          return ["/fresh", "_N_T_/fresh"];
+        },
+        isrDebug(event, detail) {
+          debugCalls.push([event, detail]);
+        },
+        isrHtmlKey(pathname) {
+          return "html:" + pathname;
+        },
+        isrRscKey(pathname) {
+          return "rsc:" + pathname;
+        },
+        async isrSet(key, data, revalidateSeconds, tags) {
+          isrSetCalls.push({
+            key,
+            html: data.html,
+            hasRscData: Boolean(data.rscData),
+            revalidateSeconds,
+            tags,
+          });
+        },
+        revalidateSeconds: 60,
+        waitUntil(promise) {
+          pendingCacheWrites.push(promise);
+        },
+      },
+    );
+
+    expect(response.status).toBe(201);
+    await expect(response.text()).resolves.toBe("<h1>fresh</h1>");
+    expect(pendingCacheWrites).toHaveLength(1);
+
+    await pendingCacheWrites[0];
+
+    expect(isrSetCalls).toEqual([
+      {
+        key: "html:/fresh",
+        html: "<h1>fresh</h1>",
+        hasRscData: false,
+        revalidateSeconds: 60,
+        tags: ["/fresh", "_N_T_/fresh"],
+      },
+      {
+        key: "rsc:/fresh",
+        html: "",
+        hasRscData: true,
+        revalidateSeconds: 60,
+        tags: ["/fresh", "_N_T_/fresh"],
+      },
+    ]);
+    expect(debugCalls).toEqual([["HTML cache written", "html:/fresh"]]);
   });
 });


### PR DESCRIPTION
## Summary
- move App Router APP_PAGE HTML cache tee/write orchestration into the typed page-cache helper
- keep the generated entry focused on rendering and delegate the HTML/RSC cache population flow after a MISS
- add focused unit coverage for the finalized HTML cache response path and update entry snapshots

## Testing
- vp check packages/vinext/src/server/app-page-cache.ts packages/vinext/src/entries/app-rsc-entry.ts tests/app-page-cache.test.ts tests/app-router.test.ts
- vp test run tests/app-page-cache.test.ts tests/app-router.test.ts -t "app page cache helpers|generated code|RSC stream tee"
- vp test run tests/entry-templates.test.ts -u
- vp test run tests/app-page-cache.test.ts tests/app-page-response.test.ts tests/nextjs-compat/app-routes.test.ts
- vp run vinext#build

Stacked on #627.

Written by Codex.