### PR TITLE
refactor: extract app page execution helpers

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -56,6 +56,9 @@ const appPageCachePath = fileURLToPath(
 const appPageResponsePath = fileURLToPath(
   new URL("../server/app-page-response.js", import.meta.url),
 ).replace(/\\/g, "/");
+const appPageExecutionPath = fileURLToPath(
+  new URL("../server/app-page-execution.js", import.meta.url),
+).replace(/\\/g, "/");
 const appRouteHandlerResponsePath = fileURLToPath(
   new URL("../server/app-route-handler-response.js", import.meta.url),
 ).replace(/\\/g, "/");
@@ -374,6 +377,15 @@ import {
   resolveAppPageRscResponsePolicy as __resolveAppPageRscResponsePolicy,
 } from ${JSON.stringify(appPageResponsePath)};
 import {
+  buildAppPageFontLinkHeader as __buildAppPageFontLinkHeader,
+  buildAppPageSpecialErrorResponse as __buildAppPageSpecialErrorResponse,
+  probeAppPageComponent as __probeAppPageComponent,
+  probeAppPageLayouts as __probeAppPageLayouts,
+  readAppPageTextStream as __readAppPageTextStream,
+  resolveAppPageSpecialError as __resolveAppPageSpecialError,
+  teeAppPageRscStreamForCapture as __teeAppPageRscStreamForCapture,
+} from ${JSON.stringify(appPageExecutionPath)};
+import {
   applyRouteHandlerMiddlewareContext as __applyRouteHandlerMiddlewareContext,
 } from ${JSON.stringify(appRouteHandlerResponsePath)};
 import { _consumeRequestScopedCacheLife, getCacheHandler } from "next/cache";
@@ -581,15 +593,8 @@ function __errorDigest(str) {
 // unchanged since their digests are used for client-side routing.
 function __sanitizeErrorForClient(error) {
   // Navigation errors must pass through with their digest intact
-  if (error && typeof error === "object" && "digest" in error) {
-    const digest = String(error.digest);
-    if (
-      digest.startsWith("NEXT_REDIRECT;") ||
-      digest === "NEXT_NOT_FOUND" ||
-      digest.startsWith("NEXT_HTTP_ERROR_FALLBACK;")
-    ) {
-      return error;
-    }
+  if (__resolveAppPageSpecialError(error)) {
+    return error;
   }
   // In development, pass through the original error for debugging
   if (process.env.NODE_ENV !== "production") {
@@ -883,8 +888,8 @@ async function renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, req
   setHeadersContext(null);
   setNavigationContext(null);
   const _respHeaders = { "Content-Type": "text/html; charset=utf-8", "Vary": "RSC, Accept" };
-  const _linkParts = (fontData.preloads || []).map(function(p) { return "<" + p.href + ">; rel=preload; as=font; type=" + p.type + "; crossorigin"; });
-  if (_linkParts.length > 0) _respHeaders["Link"] = _linkParts.join(", ");
+  const _fontLinkHeader = __buildAppPageFontLinkHeader(fontData.preloads);
+  if (_fontLinkHeader) _respHeaders["Link"] = _fontLinkHeader;
   return new Response(htmlStream, {
     status: statusCode,
     headers: _respHeaders,
@@ -1023,8 +1028,8 @@ async function renderErrorBoundaryPage(route, error, isRscRequest, request, matc
   setHeadersContext(null);
   setNavigationContext(null);
   const _errHeaders = { "Content-Type": "text/html; charset=utf-8", "Vary": "RSC, Accept" };
-  const _errLinkParts = (fontData.preloads || []).map(function(p) { return "<" + p.href + ">; rel=preload; as=font; type=" + p.type + "; crossorigin"; });
-  if (_errLinkParts.length > 0) _errHeaders["Link"] = _errLinkParts.join(", ");
+  const _errFontLinkHeader = __buildAppPageFontLinkHeader(fontData.preloads);
+  if (_errFontLinkHeader) _errHeaders["Link"] = _errFontLinkHeader;
   return new Response(htmlStream, {
     status: 200,
     headers: _errHeaders,
@@ -2450,41 +2455,18 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           const __revalElement = await buildPageElement(route, params, undefined, new URLSearchParams());
           const __revalOnError = createRscOnErrorHandler(request, cleanPathname, route.pattern);
           const __revalRscStream = renderToReadableStream(__revalElement, { onError: __revalOnError });
-          // Tee RSC stream: one for SSR, one to capture rscData
-          const [__revalRscForSsr, __revalRscForCapture] = __revalRscStream.tee();
-          // Capture rscData bytes in parallel with SSR
-          const __rscDataPromise = (async () => {
-            const __rscReader = __revalRscForCapture.getReader();
-            const __rscChunks = [];
-            let __rscTotal = 0;
-            for (;;) {
-              const { done, value } = await __rscReader.read();
-              if (done) break;
-              __rscChunks.push(value);
-              __rscTotal += value.byteLength;
-            }
-            const __rscBuf = new Uint8Array(__rscTotal);
-            let __rscOff = 0;
-            for (const c of __rscChunks) { __rscBuf.set(c, __rscOff); __rscOff += c.byteLength; }
-            return __rscBuf.buffer;
-          })();
+          const __revalRscCapture = __teeAppPageRscStreamForCapture(__revalRscStream, true);
           const __revalFontData = { links: _getSSRFontLinks(), styles: _getSSRFontStyles(), preloads: _getSSRFontPreloads() };
           const __revalSsrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
-          const __revalHtmlStream = await __revalSsrEntry.handleSsr(__revalRscForSsr, _getNavigationContext(), __revalFontData);
+          const __revalHtmlStream = await __revalSsrEntry.handleSsr(
+            __revalRscCapture.responseStream,
+            _getNavigationContext(),
+            __revalFontData,
+          );
           setHeadersContext(null);
           setNavigationContext(null);
-          // Collect the full HTML string from the stream
-          const __revalReader = __revalHtmlStream.getReader();
-          const __revalDecoder = new TextDecoder();
-          const __revalChunks = [];
-          for (;;) {
-            const { done, value } = await __revalReader.read();
-            if (done) break;
-            __revalChunks.push(__revalDecoder.decode(value, { stream: true }));
-          }
-          __revalChunks.push(__revalDecoder.decode());
-          const __freshHtml = __revalChunks.join("");
-          const __freshRscData = await __rscDataPromise;
+          const __freshHtml = await __readAppPageTextStream(__revalHtmlStream);
+          const __freshRscData = await __revalRscCapture.capturedRscDataPromise;
           const __pageTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
           return { html: __freshHtml, rscData: __freshRscData, tags: __pageTags };
         });
@@ -2576,26 +2558,21 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   try {
     element = await buildPageElement(route, params, interceptOpts, url.searchParams);
   } catch (buildErr) {
-    // Check for redirect/notFound/forbidden/unauthorized thrown during metadata resolution or async components
-    if (buildErr && typeof buildErr === "object" && "digest" in buildErr) {
-      const digest = String(buildErr.digest);
-      if (digest.startsWith("NEXT_REDIRECT;")) {
-        const parts = digest.split(";");
-        const redirectUrl = decodeURIComponent(parts[2]);
-        const statusCode = parts[3] ? parseInt(parts[3], 10) : 307;
-        setHeadersContext(null);
-        setNavigationContext(null);
-        return Response.redirect(new URL(redirectUrl, request.url), statusCode);
-      }
-      if (digest === "NEXT_NOT_FOUND" || digest.startsWith("NEXT_HTTP_ERROR_FALLBACK;")) {
-        const statusCode = digest === "NEXT_NOT_FOUND" ? 404 : parseInt(digest.split(";")[1], 10);
-        const fallbackResp = await renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, { matchedParams: params });
-        if (fallbackResp) return fallbackResp;
-        setHeadersContext(null);
-        setNavigationContext(null);
-        const statusText = statusCode === 403 ? "Forbidden" : statusCode === 401 ? "Unauthorized" : "Not Found";
-        return new Response(statusText, { status: statusCode });
-      }
+    const __buildSpecialError = __resolveAppPageSpecialError(buildErr);
+    if (__buildSpecialError) {
+      return __buildAppPageSpecialErrorResponse({
+        clearRequestContext() {
+          setHeadersContext(null);
+          setNavigationContext(null);
+        },
+        renderFallbackPage(statusCode) {
+          return renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, {
+            matchedParams: params,
+          });
+        },
+        requestUrl: request.url,
+        specialError: __buildSpecialError,
+      });
     }
     // Non-special error (e.g. generateMetadata() threw) — render error.tsx if available
     const errorBoundaryResp = await renderErrorBoundaryPage(route, buildErr, isRscRequest, request, params);
@@ -2608,25 +2585,21 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
 
   // Helper: check if an error is a redirect/notFound/forbidden/unauthorized thrown by the navigation shim
   async function handleRenderError(err) {
-    if (err && typeof err === "object" && "digest" in err) {
-      const digest = String(err.digest);
-      if (digest.startsWith("NEXT_REDIRECT;")) {
-        const parts = digest.split(";");
-        const redirectUrl = decodeURIComponent(parts[2]);
-        const statusCode = parts[3] ? parseInt(parts[3], 10) : 307;
-        setHeadersContext(null);
-        setNavigationContext(null);
-        return Response.redirect(new URL(redirectUrl, request.url), statusCode);
-      }
-      if (digest === "NEXT_NOT_FOUND" || digest.startsWith("NEXT_HTTP_ERROR_FALLBACK;")) {
-        const statusCode = digest === "NEXT_NOT_FOUND" ? 404 : parseInt(digest.split(";")[1], 10);
-        const fallbackResp = await renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, { matchedParams: params });
-        if (fallbackResp) return fallbackResp;
-        setHeadersContext(null);
-        setNavigationContext(null);
-        const statusText = statusCode === 403 ? "Forbidden" : statusCode === 401 ? "Unauthorized" : "Not Found";
-        return new Response(statusText, { status: statusCode });
-      }
+    const specialError = __resolveAppPageSpecialError(err);
+    if (specialError) {
+      return __buildAppPageSpecialErrorResponse({
+        clearRequestContext() {
+          setHeadersContext(null);
+          setNavigationContext(null);
+        },
+        renderFallbackPage(statusCode) {
+          return renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, {
+            matchedParams: params,
+          });
+        },
+        requestUrl: request.url,
+        specialError,
+      });
     }
     return null;
   }
@@ -2645,59 +2618,55 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // layouts itself throws notFound() during the fallback rendering (causing a 500).
   if (route.layouts && route.layouts.length > 0) {
     const asyncParams = makeThenableParams(params);
-    // Run inside ALS context so the module-level console.error patch suppresses
-    // "Invalid hook call" only for this request's probe — concurrent requests
-    // each have their own ALS store and are unaffected.
-    const _layoutProbeResult = await _suppressHookWarningAls.run(true, async () => {
-      for (let li = route.layouts.length - 1; li >= 0; li--) {
-        const LayoutComp = route.layouts[li]?.default;
-        if (!LayoutComp) continue;
-        try {
-          const lr = LayoutComp({ params: asyncParams, children: null });
-          if (lr && typeof lr === "object" && typeof lr.then === "function") await lr;
-        } catch (layoutErr) {
-          if (layoutErr && typeof layoutErr === "object" && "digest" in layoutErr) {
-            const digest = String(layoutErr.digest);
-             if (digest.startsWith("NEXT_REDIRECT;")) {
-               const parts = digest.split(";");
-               const redirectUrl = decodeURIComponent(parts[2]);
-               const statusCode = parts[3] ? parseInt(parts[3], 10) : 307;
-               setHeadersContext(null);
-               setNavigationContext(null);
-               return Response.redirect(new URL(redirectUrl, request.url), statusCode);
-            }
-            if (digest === "NEXT_NOT_FOUND" || digest.startsWith("NEXT_HTTP_ERROR_FALLBACK;")) {
-              const statusCode = digest === "NEXT_NOT_FOUND" ? 404 : parseInt(digest.split(";")[1], 10);
-              // Find the not-found component from the parent level (the boundary that
-              // would catch this in Next.js). Walk up from the throwing layout to find
-              // the nearest not-found at a parent layout's directory.
-              let parentNotFound = null;
-              if (route.notFounds) {
-                for (let pi = li - 1; pi >= 0; pi--) {
-                  if (route.notFounds[pi]?.default) {
-                    parentNotFound = route.notFounds[pi].default;
-                    break;
-                  }
+    const _layoutProbeResult = await __probeAppPageLayouts({
+      layoutCount: route.layouts.length,
+      async onLayoutError(layoutErr, li) {
+        const __layoutSpecialError = __resolveAppPageSpecialError(layoutErr);
+        if (!__layoutSpecialError) {
+          return null;
+        }
+
+        return __buildAppPageSpecialErrorResponse({
+          clearRequestContext() {
+            setHeadersContext(null);
+            setNavigationContext(null);
+          },
+          renderFallbackPage(statusCode) {
+            // Find the not-found component from the parent level (the boundary that
+            // would catch this in Next.js). Walk up from the throwing layout to find
+            // the nearest not-found at a parent layout's directory.
+            let parentNotFound = null;
+            if (route.notFounds) {
+              for (let pi = li - 1; pi >= 0; pi--) {
+                if (route.notFounds[pi]?.default) {
+                  parentNotFound = route.notFounds[pi].default;
+                  break;
                 }
               }
-              if (!parentNotFound) parentNotFound = ${rootNotFoundVar ? `${rootNotFoundVar}?.default` : "null"};
-              // Wrap in only the layouts above the throwing one
-              const parentLayouts = route.layouts.slice(0, li);
-              const fallbackResp = await renderHTTPAccessFallbackPage(
-                route, statusCode, isRscRequest, request,
-                { boundaryComponent: parentNotFound, layouts: parentLayouts, matchedParams: params }
-              );
-              if (fallbackResp) return fallbackResp;
-              setHeadersContext(null);
-              setNavigationContext(null);
-              const statusText = statusCode === 403 ? "Forbidden" : statusCode === 401 ? "Unauthorized" : "Not Found";
-              return new Response(statusText, { status: statusCode });
             }
-          }
-          // Not a special error — let it propagate through normal RSC rendering
-        }
-      }
-      return null;
+            if (!parentNotFound) parentNotFound = ${rootNotFoundVar ? `${rootNotFoundVar}?.default` : "null"};
+            const parentLayouts = route.layouts.slice(0, li);
+            return renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, {
+              boundaryComponent: parentNotFound,
+              layouts: parentLayouts,
+              matchedParams: params,
+            });
+          },
+          requestUrl: request.url,
+          specialError: __layoutSpecialError,
+        });
+      },
+      probeLayoutAt(li) {
+        const LayoutComp = route.layouts[li]?.default;
+        if (!LayoutComp) return null;
+        return LayoutComp({ params: asyncParams, children: null });
+      },
+      runWithSuppressedHookWarning(probe) {
+        // Run inside ALS context so the module-level console.error patch suppresses
+        // "Invalid hook call" only for this request's probe — concurrent requests
+        // each have their own ALS store and are unaffected.
+        return _suppressHookWarningAls.run(true, probe);
+      },
     });
     if (_layoutProbeResult instanceof Response) return _layoutProbeResult;
   }
@@ -2715,30 +2684,23 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // trigger "Invalid hook call" console.error in dev. The module-level ALS patch
   // suppresses the warning only within this request's execution context.
   const _hasLoadingBoundary = !!(route.loading && route.loading.default);
-  const _pageProbeResult = await _suppressHookWarningAls.run(true, async () => {
-    try {
-      const testResult = PageComponent({ params });
-      // If it's a promise (async component), only await if there's no loading boundary.
-      // With a loading boundary, the Suspense streaming pipeline handles async resolution
-      // and any redirect/notFound errors via rscOnError.
-      if (testResult && typeof testResult === "object" && typeof testResult.then === "function") {
-        if (!_hasLoadingBoundary) {
-          await testResult;
-        } else {
-          // Suppress unhandled promise rejection — with a loading boundary,
-          // redirect/notFound errors are handled by rscOnError during streaming.
-          testResult.catch(() => {});
-        }
-      }
-    } catch (preRenderErr) {
+  const _pageProbeResult = await __probeAppPageComponent({
+    awaitAsyncResult: !_hasLoadingBoundary,
+    async onError(preRenderErr) {
       const specialResponse = await handleRenderError(preRenderErr);
       if (specialResponse) return specialResponse;
       // Non-special errors from the pre-render test are expected (e.g. use() hook
       // fails outside React's render cycle, client references can't execute on server).
       // Only redirect/notFound/forbidden/unauthorized are actionable here — other
       // errors will be properly caught during actual RSC/SSR rendering below.
-    }
-    return null;
+      return null;
+    },
+    probePage() {
+      return PageComponent({ params });
+    },
+    runWithSuppressedHookWarning(probe) {
+      return _suppressHookWarningAls.run(true, probe);
+    },
   });
   if (_pageProbeResult instanceof Response) return _pageProbeResult;
 
@@ -2765,27 +2727,16 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // paths can use the captured bytes when writing to the ISR cache.
   //   __rscForResponse  → sent to the client (RSC response) or to SSR (HTML response)
   //   __isrRscDataPromise → resolves to ArrayBuffer of captured RSC wire bytes
-  let __rscForResponse = rscStream;
-  let __isrRscDataPromise = null;
-  if (process.env.NODE_ENV === "production" && revalidateSeconds !== null && revalidateSeconds > 0 && revalidateSeconds !== Infinity && !isForceDynamic) {
-    const [__rscA, __rscB] = rscStream.tee();
-    __rscForResponse = __rscA;
-    __isrRscDataPromise = (async () => {
-      const __rscReader = __rscB.getReader();
-      const __rscChunks = [];
-      let __rscTotal = 0;
-      for (;;) {
-        const { done, value } = await __rscReader.read();
-        if (done) break;
-        __rscChunks.push(value);
-        __rscTotal += value.byteLength;
-      }
-      const __rscBuf = new Uint8Array(__rscTotal);
-      let __rscOff = 0;
-      for (const c of __rscChunks) { __rscBuf.set(c, __rscOff); __rscOff += c.byteLength; }
-      return __rscBuf.buffer;
-    })();
-  }
+  const __rscCapture = __teeAppPageRscStreamForCapture(
+    rscStream,
+    process.env.NODE_ENV === "production" &&
+      revalidateSeconds !== null &&
+      revalidateSeconds > 0 &&
+      revalidateSeconds !== Infinity &&
+      !isForceDynamic,
+  );
+  const __rscForResponse = __rscCapture.responseStream;
+  const __isrRscDataPromise = __rscCapture.capturedRscDataPromise;
 
   if (isRscRequest) {
     // Direct RSC stream response (for client-side navigation)
@@ -2847,12 +2798,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // Build HTTP Link header for font preloading.
   // This lets the browser (and CDN) start fetching font files before parsing HTML,
   // eliminating the CSS → woff2 download waterfall.
-  const fontPreloads = fontData.preloads || [];
-  const fontLinkHeaderParts = [];
-  for (const preload of fontPreloads) {
-    fontLinkHeaderParts.push("<" + preload.href + ">; rel=preload; as=font; type=" + preload.type + "; crossorigin");
-  }
-  const fontLinkHeader = fontLinkHeaderParts.length > 0 ? fontLinkHeaderParts.join(", ") : "";
+  const fontLinkHeader = __buildAppPageFontLinkHeader(fontData.preloads);
 
   // __rscForResponse was already teed above (before isRscRequest) for ISR pages in
   // production. For non-ISR or dev, __rscForResponse === rscStream (no tee).

--- a/packages/vinext/src/server/app-page-execution.ts
+++ b/packages/vinext/src/server/app-page-execution.ts
@@ -1,0 +1,213 @@
+export type AppPageSpecialError =
+  | { kind: "redirect"; location: string; statusCode: number }
+  | { kind: "http-access-fallback"; statusCode: number };
+
+export interface AppPageFontPreload {
+  href: string;
+  type: string;
+}
+
+export interface AppPageRscStreamCapture {
+  capturedRscDataPromise: Promise<ArrayBuffer> | null;
+  responseStream: ReadableStream<Uint8Array>;
+}
+
+export interface BuildAppPageSpecialErrorResponseOptions {
+  clearRequestContext: () => void;
+  renderFallbackPage?: (statusCode: number) => Promise<Response | null>;
+  requestUrl: string;
+  specialError: AppPageSpecialError;
+}
+
+export interface ProbeAppPageLayoutsOptions {
+  layoutCount: number;
+  onLayoutError: (error: unknown, layoutIndex: number) => Promise<Response | null>;
+  probeLayoutAt: (layoutIndex: number) => unknown;
+  runWithSuppressedHookWarning<T>(probe: () => Promise<T>): Promise<T>;
+}
+
+export interface ProbeAppPageComponentOptions {
+  awaitAsyncResult: boolean;
+  onError: (error: unknown) => Promise<Response | null>;
+  probePage: () => unknown;
+  runWithSuppressedHookWarning<T>(probe: () => Promise<T>): Promise<T>;
+}
+
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+  return Boolean(
+    value &&
+    (typeof value === "object" || typeof value === "function") &&
+    "then" in value &&
+    typeof value.then === "function",
+  );
+}
+
+function getAppPageStatusText(statusCode: number): string {
+  return statusCode === 403 ? "Forbidden" : statusCode === 401 ? "Unauthorized" : "Not Found";
+}
+
+export function resolveAppPageSpecialError(error: unknown): AppPageSpecialError | null {
+  if (!(error && typeof error === "object" && "digest" in error)) {
+    return null;
+  }
+
+  const digest = String(error.digest);
+
+  if (digest.startsWith("NEXT_REDIRECT;")) {
+    const parts = digest.split(";");
+    return {
+      kind: "redirect",
+      location: decodeURIComponent(parts[2]),
+      statusCode: parts[3] ? parseInt(parts[3], 10) : 307,
+    };
+  }
+
+  if (digest === "NEXT_NOT_FOUND" || digest.startsWith("NEXT_HTTP_ERROR_FALLBACK;")) {
+    return {
+      kind: "http-access-fallback",
+      statusCode: digest === "NEXT_NOT_FOUND" ? 404 : parseInt(digest.split(";")[1], 10),
+    };
+  }
+
+  return null;
+}
+
+export async function buildAppPageSpecialErrorResponse(
+  options: BuildAppPageSpecialErrorResponseOptions,
+): Promise<Response> {
+  if (options.specialError.kind === "redirect") {
+    options.clearRequestContext();
+    return Response.redirect(
+      new URL(options.specialError.location, options.requestUrl),
+      options.specialError.statusCode,
+    );
+  }
+
+  if (options.renderFallbackPage) {
+    const fallbackResponse = await options.renderFallbackPage(options.specialError.statusCode);
+    if (fallbackResponse) {
+      return fallbackResponse;
+    }
+  }
+
+  options.clearRequestContext();
+  return new Response(getAppPageStatusText(options.specialError.statusCode), {
+    status: options.specialError.statusCode,
+  });
+}
+
+export async function probeAppPageLayouts(
+  options: ProbeAppPageLayoutsOptions,
+): Promise<Response | null> {
+  return options.runWithSuppressedHookWarning(async () => {
+    for (let layoutIndex = options.layoutCount - 1; layoutIndex >= 0; layoutIndex--) {
+      try {
+        const layoutResult = options.probeLayoutAt(layoutIndex);
+        if (isPromiseLike(layoutResult)) {
+          await layoutResult;
+        }
+      } catch (error) {
+        const response = await options.onLayoutError(error, layoutIndex);
+        if (response) {
+          return response;
+        }
+      }
+    }
+
+    return null;
+  });
+}
+
+export async function probeAppPageComponent(
+  options: ProbeAppPageComponentOptions,
+): Promise<Response | null> {
+  return options.runWithSuppressedHookWarning(async () => {
+    try {
+      const pageResult = options.probePage();
+      if (isPromiseLike(pageResult)) {
+        if (options.awaitAsyncResult) {
+          await pageResult;
+        } else {
+          void Promise.resolve(pageResult).catch(() => {});
+        }
+      }
+    } catch (error) {
+      return options.onError(error);
+    }
+
+    return null;
+  });
+}
+
+export async function readAppPageTextStream(stream: ReadableStream<Uint8Array>): Promise<string> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  const chunks: string[] = [];
+
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+    chunks.push(decoder.decode(value, { stream: true }));
+  }
+
+  chunks.push(decoder.decode());
+  return chunks.join("");
+}
+
+export async function readAppPageBinaryStream(
+  stream: ReadableStream<Uint8Array>,
+): Promise<ArrayBuffer> {
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalLength = 0;
+
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+    chunks.push(value);
+    totalLength += value.byteLength;
+  }
+
+  const buffer = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const chunk of chunks) {
+    buffer.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+
+  return buffer.buffer;
+}
+
+export function teeAppPageRscStreamForCapture(
+  stream: ReadableStream<Uint8Array>,
+  shouldCapture: boolean,
+): AppPageRscStreamCapture {
+  if (!shouldCapture) {
+    return {
+      capturedRscDataPromise: null,
+      responseStream: stream,
+    };
+  }
+
+  const [responseStream, captureStream] = stream.tee();
+  return {
+    capturedRscDataPromise: readAppPageBinaryStream(captureStream),
+    responseStream,
+  };
+}
+
+export function buildAppPageFontLinkHeader(
+  preloads: readonly AppPageFontPreload[] | null | undefined,
+): string {
+  if (!preloads || preloads.length === 0) {
+    return "";
+  }
+
+  return preloads
+    .map((preload) => `<${preload.href}>; rel=preload; as=font; type=${preload.type}; crossorigin`)
+    .join(", ");
+}

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -78,6 +78,15 @@ import {
   resolveAppPageRscResponsePolicy as __resolveAppPageRscResponsePolicy,
 } from "<ROOT>/packages/vinext/src/server/app-page-response.js";
 import {
+  buildAppPageFontLinkHeader as __buildAppPageFontLinkHeader,
+  buildAppPageSpecialErrorResponse as __buildAppPageSpecialErrorResponse,
+  probeAppPageComponent as __probeAppPageComponent,
+  probeAppPageLayouts as __probeAppPageLayouts,
+  readAppPageTextStream as __readAppPageTextStream,
+  resolveAppPageSpecialError as __resolveAppPageSpecialError,
+  teeAppPageRscStreamForCapture as __teeAppPageRscStreamForCapture,
+} from "<ROOT>/packages/vinext/src/server/app-page-execution.js";
+import {
   applyRouteHandlerMiddlewareContext as __applyRouteHandlerMiddlewareContext,
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-response.js";
 import { _consumeRequestScopedCacheLife, getCacheHandler } from "next/cache";
@@ -285,15 +294,8 @@ function __errorDigest(str) {
 // unchanged since their digests are used for client-side routing.
 function __sanitizeErrorForClient(error) {
   // Navigation errors must pass through with their digest intact
-  if (error && typeof error === "object" && "digest" in error) {
-    const digest = String(error.digest);
-    if (
-      digest.startsWith("NEXT_REDIRECT;") ||
-      digest === "NEXT_NOT_FOUND" ||
-      digest.startsWith("NEXT_HTTP_ERROR_FALLBACK;")
-    ) {
-      return error;
-    }
+  if (__resolveAppPageSpecialError(error)) {
+    return error;
   }
   // In development, pass through the original error for debugging
   if (process.env.NODE_ENV !== "production") {
@@ -638,8 +640,8 @@ async function renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, req
   setHeadersContext(null);
   setNavigationContext(null);
   const _respHeaders = { "Content-Type": "text/html; charset=utf-8", "Vary": "RSC, Accept" };
-  const _linkParts = (fontData.preloads || []).map(function(p) { return "<" + p.href + ">; rel=preload; as=font; type=" + p.type + "; crossorigin"; });
-  if (_linkParts.length > 0) _respHeaders["Link"] = _linkParts.join(", ");
+  const _fontLinkHeader = __buildAppPageFontLinkHeader(fontData.preloads);
+  if (_fontLinkHeader) _respHeaders["Link"] = _fontLinkHeader;
   return new Response(htmlStream, {
     status: statusCode,
     headers: _respHeaders,
@@ -757,8 +759,8 @@ async function renderErrorBoundaryPage(route, error, isRscRequest, request, matc
   setHeadersContext(null);
   setNavigationContext(null);
   const _errHeaders = { "Content-Type": "text/html; charset=utf-8", "Vary": "RSC, Accept" };
-  const _errLinkParts = (fontData.preloads || []).map(function(p) { return "<" + p.href + ">; rel=preload; as=font; type=" + p.type + "; crossorigin"; });
-  if (_errLinkParts.length > 0) _errHeaders["Link"] = _errLinkParts.join(", ");
+  const _errFontLinkHeader = __buildAppPageFontLinkHeader(fontData.preloads);
+  if (_errFontLinkHeader) _errHeaders["Link"] = _errFontLinkHeader;
   return new Response(htmlStream, {
     status: 200,
     headers: _errHeaders,
@@ -2122,41 +2124,18 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           const __revalElement = await buildPageElement(route, params, undefined, new URLSearchParams());
           const __revalOnError = createRscOnErrorHandler(request, cleanPathname, route.pattern);
           const __revalRscStream = renderToReadableStream(__revalElement, { onError: __revalOnError });
-          // Tee RSC stream: one for SSR, one to capture rscData
-          const [__revalRscForSsr, __revalRscForCapture] = __revalRscStream.tee();
-          // Capture rscData bytes in parallel with SSR
-          const __rscDataPromise = (async () => {
-            const __rscReader = __revalRscForCapture.getReader();
-            const __rscChunks = [];
-            let __rscTotal = 0;
-            for (;;) {
-              const { done, value } = await __rscReader.read();
-              if (done) break;
-              __rscChunks.push(value);
-              __rscTotal += value.byteLength;
-            }
-            const __rscBuf = new Uint8Array(__rscTotal);
-            let __rscOff = 0;
-            for (const c of __rscChunks) { __rscBuf.set(c, __rscOff); __rscOff += c.byteLength; }
-            return __rscBuf.buffer;
-          })();
+          const __revalRscCapture = __teeAppPageRscStreamForCapture(__revalRscStream, true);
           const __revalFontData = { links: _getSSRFontLinks(), styles: _getSSRFontStyles(), preloads: _getSSRFontPreloads() };
           const __revalSsrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
-          const __revalHtmlStream = await __revalSsrEntry.handleSsr(__revalRscForSsr, _getNavigationContext(), __revalFontData);
+          const __revalHtmlStream = await __revalSsrEntry.handleSsr(
+            __revalRscCapture.responseStream,
+            _getNavigationContext(),
+            __revalFontData,
+          );
           setHeadersContext(null);
           setNavigationContext(null);
-          // Collect the full HTML string from the stream
-          const __revalReader = __revalHtmlStream.getReader();
-          const __revalDecoder = new TextDecoder();
-          const __revalChunks = [];
-          for (;;) {
-            const { done, value } = await __revalReader.read();
-            if (done) break;
-            __revalChunks.push(__revalDecoder.decode(value, { stream: true }));
-          }
-          __revalChunks.push(__revalDecoder.decode());
-          const __freshHtml = __revalChunks.join("");
-          const __freshRscData = await __rscDataPromise;
+          const __freshHtml = await __readAppPageTextStream(__revalHtmlStream);
+          const __freshRscData = await __revalRscCapture.capturedRscDataPromise;
           const __pageTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
           return { html: __freshHtml, rscData: __freshRscData, tags: __pageTags };
         });
@@ -2248,26 +2227,21 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   try {
     element = await buildPageElement(route, params, interceptOpts, url.searchParams);
   } catch (buildErr) {
-    // Check for redirect/notFound/forbidden/unauthorized thrown during metadata resolution or async components
-    if (buildErr && typeof buildErr === "object" && "digest" in buildErr) {
-      const digest = String(buildErr.digest);
-      if (digest.startsWith("NEXT_REDIRECT;")) {
-        const parts = digest.split(";");
-        const redirectUrl = decodeURIComponent(parts[2]);
-        const statusCode = parts[3] ? parseInt(parts[3], 10) : 307;
-        setHeadersContext(null);
-        setNavigationContext(null);
-        return Response.redirect(new URL(redirectUrl, request.url), statusCode);
-      }
-      if (digest === "NEXT_NOT_FOUND" || digest.startsWith("NEXT_HTTP_ERROR_FALLBACK;")) {
-        const statusCode = digest === "NEXT_NOT_FOUND" ? 404 : parseInt(digest.split(";")[1], 10);
-        const fallbackResp = await renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, { matchedParams: params });
-        if (fallbackResp) return fallbackResp;
-        setHeadersContext(null);
-        setNavigationContext(null);
-        const statusText = statusCode === 403 ? "Forbidden" : statusCode === 401 ? "Unauthorized" : "Not Found";
-        return new Response(statusText, { status: statusCode });
-      }
+    const __buildSpecialError = __resolveAppPageSpecialError(buildErr);
+    if (__buildSpecialError) {
+      return __buildAppPageSpecialErrorResponse({
+        clearRequestContext() {
+          setHeadersContext(null);
+          setNavigationContext(null);
+        },
+        renderFallbackPage(statusCode) {
+          return renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, {
+            matchedParams: params,
+          });
+        },
+        requestUrl: request.url,
+        specialError: __buildSpecialError,
+      });
     }
     // Non-special error (e.g. generateMetadata() threw) — render error.tsx if available
     const errorBoundaryResp = await renderErrorBoundaryPage(route, buildErr, isRscRequest, request, params);
@@ -2280,25 +2254,21 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
 
   // Helper: check if an error is a redirect/notFound/forbidden/unauthorized thrown by the navigation shim
   async function handleRenderError(err) {
-    if (err && typeof err === "object" && "digest" in err) {
-      const digest = String(err.digest);
-      if (digest.startsWith("NEXT_REDIRECT;")) {
-        const parts = digest.split(";");
-        const redirectUrl = decodeURIComponent(parts[2]);
-        const statusCode = parts[3] ? parseInt(parts[3], 10) : 307;
-        setHeadersContext(null);
-        setNavigationContext(null);
-        return Response.redirect(new URL(redirectUrl, request.url), statusCode);
-      }
-      if (digest === "NEXT_NOT_FOUND" || digest.startsWith("NEXT_HTTP_ERROR_FALLBACK;")) {
-        const statusCode = digest === "NEXT_NOT_FOUND" ? 404 : parseInt(digest.split(";")[1], 10);
-        const fallbackResp = await renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, { matchedParams: params });
-        if (fallbackResp) return fallbackResp;
-        setHeadersContext(null);
-        setNavigationContext(null);
-        const statusText = statusCode === 403 ? "Forbidden" : statusCode === 401 ? "Unauthorized" : "Not Found";
-        return new Response(statusText, { status: statusCode });
-      }
+    const specialError = __resolveAppPageSpecialError(err);
+    if (specialError) {
+      return __buildAppPageSpecialErrorResponse({
+        clearRequestContext() {
+          setHeadersContext(null);
+          setNavigationContext(null);
+        },
+        renderFallbackPage(statusCode) {
+          return renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, {
+            matchedParams: params,
+          });
+        },
+        requestUrl: request.url,
+        specialError,
+      });
     }
     return null;
   }
@@ -2317,59 +2287,55 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // layouts itself throws notFound() during the fallback rendering (causing a 500).
   if (route.layouts && route.layouts.length > 0) {
     const asyncParams = makeThenableParams(params);
-    // Run inside ALS context so the module-level console.error patch suppresses
-    // "Invalid hook call" only for this request's probe — concurrent requests
-    // each have their own ALS store and are unaffected.
-    const _layoutProbeResult = await _suppressHookWarningAls.run(true, async () => {
-      for (let li = route.layouts.length - 1; li >= 0; li--) {
-        const LayoutComp = route.layouts[li]?.default;
-        if (!LayoutComp) continue;
-        try {
-          const lr = LayoutComp({ params: asyncParams, children: null });
-          if (lr && typeof lr === "object" && typeof lr.then === "function") await lr;
-        } catch (layoutErr) {
-          if (layoutErr && typeof layoutErr === "object" && "digest" in layoutErr) {
-            const digest = String(layoutErr.digest);
-             if (digest.startsWith("NEXT_REDIRECT;")) {
-               const parts = digest.split(";");
-               const redirectUrl = decodeURIComponent(parts[2]);
-               const statusCode = parts[3] ? parseInt(parts[3], 10) : 307;
-               setHeadersContext(null);
-               setNavigationContext(null);
-               return Response.redirect(new URL(redirectUrl, request.url), statusCode);
-            }
-            if (digest === "NEXT_NOT_FOUND" || digest.startsWith("NEXT_HTTP_ERROR_FALLBACK;")) {
-              const statusCode = digest === "NEXT_NOT_FOUND" ? 404 : parseInt(digest.split(";")[1], 10);
-              // Find the not-found component from the parent level (the boundary that
-              // would catch this in Next.js). Walk up from the throwing layout to find
-              // the nearest not-found at a parent layout's directory.
-              let parentNotFound = null;
-              if (route.notFounds) {
-                for (let pi = li - 1; pi >= 0; pi--) {
-                  if (route.notFounds[pi]?.default) {
-                    parentNotFound = route.notFounds[pi].default;
-                    break;
-                  }
+    const _layoutProbeResult = await __probeAppPageLayouts({
+      layoutCount: route.layouts.length,
+      async onLayoutError(layoutErr, li) {
+        const __layoutSpecialError = __resolveAppPageSpecialError(layoutErr);
+        if (!__layoutSpecialError) {
+          return null;
+        }
+
+        return __buildAppPageSpecialErrorResponse({
+          clearRequestContext() {
+            setHeadersContext(null);
+            setNavigationContext(null);
+          },
+          renderFallbackPage(statusCode) {
+            // Find the not-found component from the parent level (the boundary that
+            // would catch this in Next.js). Walk up from the throwing layout to find
+            // the nearest not-found at a parent layout's directory.
+            let parentNotFound = null;
+            if (route.notFounds) {
+              for (let pi = li - 1; pi >= 0; pi--) {
+                if (route.notFounds[pi]?.default) {
+                  parentNotFound = route.notFounds[pi].default;
+                  break;
                 }
               }
-              if (!parentNotFound) parentNotFound = null;
-              // Wrap in only the layouts above the throwing one
-              const parentLayouts = route.layouts.slice(0, li);
-              const fallbackResp = await renderHTTPAccessFallbackPage(
-                route, statusCode, isRscRequest, request,
-                { boundaryComponent: parentNotFound, layouts: parentLayouts, matchedParams: params }
-              );
-              if (fallbackResp) return fallbackResp;
-              setHeadersContext(null);
-              setNavigationContext(null);
-              const statusText = statusCode === 403 ? "Forbidden" : statusCode === 401 ? "Unauthorized" : "Not Found";
-              return new Response(statusText, { status: statusCode });
             }
-          }
-          // Not a special error — let it propagate through normal RSC rendering
-        }
-      }
-      return null;
+            if (!parentNotFound) parentNotFound = null;
+            const parentLayouts = route.layouts.slice(0, li);
+            return renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, {
+              boundaryComponent: parentNotFound,
+              layouts: parentLayouts,
+              matchedParams: params,
+            });
+          },
+          requestUrl: request.url,
+          specialError: __layoutSpecialError,
+        });
+      },
+      probeLayoutAt(li) {
+        const LayoutComp = route.layouts[li]?.default;
+        if (!LayoutComp) return null;
+        return LayoutComp({ params: asyncParams, children: null });
+      },
+      runWithSuppressedHookWarning(probe) {
+        // Run inside ALS context so the module-level console.error patch suppresses
+        // "Invalid hook call" only for this request's probe — concurrent requests
+        // each have their own ALS store and are unaffected.
+        return _suppressHookWarningAls.run(true, probe);
+      },
     });
     if (_layoutProbeResult instanceof Response) return _layoutProbeResult;
   }
@@ -2387,30 +2353,23 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // trigger "Invalid hook call" console.error in dev. The module-level ALS patch
   // suppresses the warning only within this request's execution context.
   const _hasLoadingBoundary = !!(route.loading && route.loading.default);
-  const _pageProbeResult = await _suppressHookWarningAls.run(true, async () => {
-    try {
-      const testResult = PageComponent({ params });
-      // If it's a promise (async component), only await if there's no loading boundary.
-      // With a loading boundary, the Suspense streaming pipeline handles async resolution
-      // and any redirect/notFound errors via rscOnError.
-      if (testResult && typeof testResult === "object" && typeof testResult.then === "function") {
-        if (!_hasLoadingBoundary) {
-          await testResult;
-        } else {
-          // Suppress unhandled promise rejection — with a loading boundary,
-          // redirect/notFound errors are handled by rscOnError during streaming.
-          testResult.catch(() => {});
-        }
-      }
-    } catch (preRenderErr) {
+  const _pageProbeResult = await __probeAppPageComponent({
+    awaitAsyncResult: !_hasLoadingBoundary,
+    async onError(preRenderErr) {
       const specialResponse = await handleRenderError(preRenderErr);
       if (specialResponse) return specialResponse;
       // Non-special errors from the pre-render test are expected (e.g. use() hook
       // fails outside React's render cycle, client references can't execute on server).
       // Only redirect/notFound/forbidden/unauthorized are actionable here — other
       // errors will be properly caught during actual RSC/SSR rendering below.
-    }
-    return null;
+      return null;
+    },
+    probePage() {
+      return PageComponent({ params });
+    },
+    runWithSuppressedHookWarning(probe) {
+      return _suppressHookWarningAls.run(true, probe);
+    },
   });
   if (_pageProbeResult instanceof Response) return _pageProbeResult;
 
@@ -2437,27 +2396,16 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // paths can use the captured bytes when writing to the ISR cache.
   //   __rscForResponse  → sent to the client (RSC response) or to SSR (HTML response)
   //   __isrRscDataPromise → resolves to ArrayBuffer of captured RSC wire bytes
-  let __rscForResponse = rscStream;
-  let __isrRscDataPromise = null;
-  if (process.env.NODE_ENV === "production" && revalidateSeconds !== null && revalidateSeconds > 0 && revalidateSeconds !== Infinity && !isForceDynamic) {
-    const [__rscA, __rscB] = rscStream.tee();
-    __rscForResponse = __rscA;
-    __isrRscDataPromise = (async () => {
-      const __rscReader = __rscB.getReader();
-      const __rscChunks = [];
-      let __rscTotal = 0;
-      for (;;) {
-        const { done, value } = await __rscReader.read();
-        if (done) break;
-        __rscChunks.push(value);
-        __rscTotal += value.byteLength;
-      }
-      const __rscBuf = new Uint8Array(__rscTotal);
-      let __rscOff = 0;
-      for (const c of __rscChunks) { __rscBuf.set(c, __rscOff); __rscOff += c.byteLength; }
-      return __rscBuf.buffer;
-    })();
-  }
+  const __rscCapture = __teeAppPageRscStreamForCapture(
+    rscStream,
+    process.env.NODE_ENV === "production" &&
+      revalidateSeconds !== null &&
+      revalidateSeconds > 0 &&
+      revalidateSeconds !== Infinity &&
+      !isForceDynamic,
+  );
+  const __rscForResponse = __rscCapture.responseStream;
+  const __isrRscDataPromise = __rscCapture.capturedRscDataPromise;
 
   if (isRscRequest) {
     // Direct RSC stream response (for client-side navigation)
@@ -2519,12 +2467,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // Build HTTP Link header for font preloading.
   // This lets the browser (and CDN) start fetching font files before parsing HTML,
   // eliminating the CSS → woff2 download waterfall.
-  const fontPreloads = fontData.preloads || [];
-  const fontLinkHeaderParts = [];
-  for (const preload of fontPreloads) {
-    fontLinkHeaderParts.push("<" + preload.href + ">; rel=preload; as=font; type=" + preload.type + "; crossorigin");
-  }
-  const fontLinkHeader = fontLinkHeaderParts.length > 0 ? fontLinkHeaderParts.join(", ") : "";
+  const fontLinkHeader = __buildAppPageFontLinkHeader(fontData.preloads);
 
   // __rscForResponse was already teed above (before isRscRequest) for ISR pages in
   // production. For non-ISR or dev, __rscForResponse === rscStream (no tee).
@@ -2706,6 +2649,15 @@ import {
   resolveAppPageHtmlResponsePolicy as __resolveAppPageHtmlResponsePolicy,
   resolveAppPageRscResponsePolicy as __resolveAppPageRscResponsePolicy,
 } from "<ROOT>/packages/vinext/src/server/app-page-response.js";
+import {
+  buildAppPageFontLinkHeader as __buildAppPageFontLinkHeader,
+  buildAppPageSpecialErrorResponse as __buildAppPageSpecialErrorResponse,
+  probeAppPageComponent as __probeAppPageComponent,
+  probeAppPageLayouts as __probeAppPageLayouts,
+  readAppPageTextStream as __readAppPageTextStream,
+  resolveAppPageSpecialError as __resolveAppPageSpecialError,
+  teeAppPageRscStreamForCapture as __teeAppPageRscStreamForCapture,
+} from "<ROOT>/packages/vinext/src/server/app-page-execution.js";
 import {
   applyRouteHandlerMiddlewareContext as __applyRouteHandlerMiddlewareContext,
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-response.js";
@@ -2914,15 +2866,8 @@ function __errorDigest(str) {
 // unchanged since their digests are used for client-side routing.
 function __sanitizeErrorForClient(error) {
   // Navigation errors must pass through with their digest intact
-  if (error && typeof error === "object" && "digest" in error) {
-    const digest = String(error.digest);
-    if (
-      digest.startsWith("NEXT_REDIRECT;") ||
-      digest === "NEXT_NOT_FOUND" ||
-      digest.startsWith("NEXT_HTTP_ERROR_FALLBACK;")
-    ) {
-      return error;
-    }
+  if (__resolveAppPageSpecialError(error)) {
+    return error;
   }
   // In development, pass through the original error for debugging
   if (process.env.NODE_ENV !== "production") {
@@ -3267,8 +3212,8 @@ async function renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, req
   setHeadersContext(null);
   setNavigationContext(null);
   const _respHeaders = { "Content-Type": "text/html; charset=utf-8", "Vary": "RSC, Accept" };
-  const _linkParts = (fontData.preloads || []).map(function(p) { return "<" + p.href + ">; rel=preload; as=font; type=" + p.type + "; crossorigin"; });
-  if (_linkParts.length > 0) _respHeaders["Link"] = _linkParts.join(", ");
+  const _fontLinkHeader = __buildAppPageFontLinkHeader(fontData.preloads);
+  if (_fontLinkHeader) _respHeaders["Link"] = _fontLinkHeader;
   return new Response(htmlStream, {
     status: statusCode,
     headers: _respHeaders,
@@ -3386,8 +3331,8 @@ async function renderErrorBoundaryPage(route, error, isRscRequest, request, matc
   setHeadersContext(null);
   setNavigationContext(null);
   const _errHeaders = { "Content-Type": "text/html; charset=utf-8", "Vary": "RSC, Accept" };
-  const _errLinkParts = (fontData.preloads || []).map(function(p) { return "<" + p.href + ">; rel=preload; as=font; type=" + p.type + "; crossorigin"; });
-  if (_errLinkParts.length > 0) _errHeaders["Link"] = _errLinkParts.join(", ");
+  const _errFontLinkHeader = __buildAppPageFontLinkHeader(fontData.preloads);
+  if (_errFontLinkHeader) _errHeaders["Link"] = _errFontLinkHeader;
   return new Response(htmlStream, {
     status: 200,
     headers: _errHeaders,
@@ -4754,41 +4699,18 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           const __revalElement = await buildPageElement(route, params, undefined, new URLSearchParams());
           const __revalOnError = createRscOnErrorHandler(request, cleanPathname, route.pattern);
           const __revalRscStream = renderToReadableStream(__revalElement, { onError: __revalOnError });
-          // Tee RSC stream: one for SSR, one to capture rscData
-          const [__revalRscForSsr, __revalRscForCapture] = __revalRscStream.tee();
-          // Capture rscData bytes in parallel with SSR
-          const __rscDataPromise = (async () => {
-            const __rscReader = __revalRscForCapture.getReader();
-            const __rscChunks = [];
-            let __rscTotal = 0;
-            for (;;) {
-              const { done, value } = await __rscReader.read();
-              if (done) break;
-              __rscChunks.push(value);
-              __rscTotal += value.byteLength;
-            }
-            const __rscBuf = new Uint8Array(__rscTotal);
-            let __rscOff = 0;
-            for (const c of __rscChunks) { __rscBuf.set(c, __rscOff); __rscOff += c.byteLength; }
-            return __rscBuf.buffer;
-          })();
+          const __revalRscCapture = __teeAppPageRscStreamForCapture(__revalRscStream, true);
           const __revalFontData = { links: _getSSRFontLinks(), styles: _getSSRFontStyles(), preloads: _getSSRFontPreloads() };
           const __revalSsrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
-          const __revalHtmlStream = await __revalSsrEntry.handleSsr(__revalRscForSsr, _getNavigationContext(), __revalFontData);
+          const __revalHtmlStream = await __revalSsrEntry.handleSsr(
+            __revalRscCapture.responseStream,
+            _getNavigationContext(),
+            __revalFontData,
+          );
           setHeadersContext(null);
           setNavigationContext(null);
-          // Collect the full HTML string from the stream
-          const __revalReader = __revalHtmlStream.getReader();
-          const __revalDecoder = new TextDecoder();
-          const __revalChunks = [];
-          for (;;) {
-            const { done, value } = await __revalReader.read();
-            if (done) break;
-            __revalChunks.push(__revalDecoder.decode(value, { stream: true }));
-          }
-          __revalChunks.push(__revalDecoder.decode());
-          const __freshHtml = __revalChunks.join("");
-          const __freshRscData = await __rscDataPromise;
+          const __freshHtml = await __readAppPageTextStream(__revalHtmlStream);
+          const __freshRscData = await __revalRscCapture.capturedRscDataPromise;
           const __pageTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
           return { html: __freshHtml, rscData: __freshRscData, tags: __pageTags };
         });
@@ -4880,26 +4802,21 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   try {
     element = await buildPageElement(route, params, interceptOpts, url.searchParams);
   } catch (buildErr) {
-    // Check for redirect/notFound/forbidden/unauthorized thrown during metadata resolution or async components
-    if (buildErr && typeof buildErr === "object" && "digest" in buildErr) {
-      const digest = String(buildErr.digest);
-      if (digest.startsWith("NEXT_REDIRECT;")) {
-        const parts = digest.split(";");
-        const redirectUrl = decodeURIComponent(parts[2]);
-        const statusCode = parts[3] ? parseInt(parts[3], 10) : 307;
-        setHeadersContext(null);
-        setNavigationContext(null);
-        return Response.redirect(new URL(redirectUrl, request.url), statusCode);
-      }
-      if (digest === "NEXT_NOT_FOUND" || digest.startsWith("NEXT_HTTP_ERROR_FALLBACK;")) {
-        const statusCode = digest === "NEXT_NOT_FOUND" ? 404 : parseInt(digest.split(";")[1], 10);
-        const fallbackResp = await renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, { matchedParams: params });
-        if (fallbackResp) return fallbackResp;
-        setHeadersContext(null);
-        setNavigationContext(null);
-        const statusText = statusCode === 403 ? "Forbidden" : statusCode === 401 ? "Unauthorized" : "Not Found";
-        return new Response(statusText, { status: statusCode });
-      }
+    const __buildSpecialError = __resolveAppPageSpecialError(buildErr);
+    if (__buildSpecialError) {
+      return __buildAppPageSpecialErrorResponse({
+        clearRequestContext() {
+          setHeadersContext(null);
+          setNavigationContext(null);
+        },
+        renderFallbackPage(statusCode) {
+          return renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, {
+            matchedParams: params,
+          });
+        },
+        requestUrl: request.url,
+        specialError: __buildSpecialError,
+      });
     }
     // Non-special error (e.g. generateMetadata() threw) — render error.tsx if available
     const errorBoundaryResp = await renderErrorBoundaryPage(route, buildErr, isRscRequest, request, params);
@@ -4912,25 +4829,21 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
 
   // Helper: check if an error is a redirect/notFound/forbidden/unauthorized thrown by the navigation shim
   async function handleRenderError(err) {
-    if (err && typeof err === "object" && "digest" in err) {
-      const digest = String(err.digest);
-      if (digest.startsWith("NEXT_REDIRECT;")) {
-        const parts = digest.split(";");
-        const redirectUrl = decodeURIComponent(parts[2]);
-        const statusCode = parts[3] ? parseInt(parts[3], 10) : 307;
-        setHeadersContext(null);
-        setNavigationContext(null);
-        return Response.redirect(new URL(redirectUrl, request.url), statusCode);
-      }
-      if (digest === "NEXT_NOT_FOUND" || digest.startsWith("NEXT_HTTP_ERROR_FALLBACK;")) {
-        const statusCode = digest === "NEXT_NOT_FOUND" ? 404 : parseInt(digest.split(";")[1], 10);
-        const fallbackResp = await renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, { matchedParams: params });
-        if (fallbackResp) return fallbackResp;
-        setHeadersContext(null);
-        setNavigationContext(null);
-        const statusText = statusCode === 403 ? "Forbidden" : statusCode === 401 ? "Unauthorized" : "Not Found";
-        return new Response(statusText, { status: statusCode });
-      }
+    const specialError = __resolveAppPageSpecialError(err);
+    if (specialError) {
+      return __buildAppPageSpecialErrorResponse({
+        clearRequestContext() {
+          setHeadersContext(null);
+          setNavigationContext(null);
+        },
+        renderFallbackPage(statusCode) {
+          return renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, {
+            matchedParams: params,
+          });
+        },
+        requestUrl: request.url,
+        specialError,
+      });
     }
     return null;
   }
@@ -4949,59 +4862,55 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // layouts itself throws notFound() during the fallback rendering (causing a 500).
   if (route.layouts && route.layouts.length > 0) {
     const asyncParams = makeThenableParams(params);
-    // Run inside ALS context so the module-level console.error patch suppresses
-    // "Invalid hook call" only for this request's probe — concurrent requests
-    // each have their own ALS store and are unaffected.
-    const _layoutProbeResult = await _suppressHookWarningAls.run(true, async () => {
-      for (let li = route.layouts.length - 1; li >= 0; li--) {
-        const LayoutComp = route.layouts[li]?.default;
-        if (!LayoutComp) continue;
-        try {
-          const lr = LayoutComp({ params: asyncParams, children: null });
-          if (lr && typeof lr === "object" && typeof lr.then === "function") await lr;
-        } catch (layoutErr) {
-          if (layoutErr && typeof layoutErr === "object" && "digest" in layoutErr) {
-            const digest = String(layoutErr.digest);
-             if (digest.startsWith("NEXT_REDIRECT;")) {
-               const parts = digest.split(";");
-               const redirectUrl = decodeURIComponent(parts[2]);
-               const statusCode = parts[3] ? parseInt(parts[3], 10) : 307;
-               setHeadersContext(null);
-               setNavigationContext(null);
-               return Response.redirect(new URL(redirectUrl, request.url), statusCode);
-            }
-            if (digest === "NEXT_NOT_FOUND" || digest.startsWith("NEXT_HTTP_ERROR_FALLBACK;")) {
-              const statusCode = digest === "NEXT_NOT_FOUND" ? 404 : parseInt(digest.split(";")[1], 10);
-              // Find the not-found component from the parent level (the boundary that
-              // would catch this in Next.js). Walk up from the throwing layout to find
-              // the nearest not-found at a parent layout's directory.
-              let parentNotFound = null;
-              if (route.notFounds) {
-                for (let pi = li - 1; pi >= 0; pi--) {
-                  if (route.notFounds[pi]?.default) {
-                    parentNotFound = route.notFounds[pi].default;
-                    break;
-                  }
+    const _layoutProbeResult = await __probeAppPageLayouts({
+      layoutCount: route.layouts.length,
+      async onLayoutError(layoutErr, li) {
+        const __layoutSpecialError = __resolveAppPageSpecialError(layoutErr);
+        if (!__layoutSpecialError) {
+          return null;
+        }
+
+        return __buildAppPageSpecialErrorResponse({
+          clearRequestContext() {
+            setHeadersContext(null);
+            setNavigationContext(null);
+          },
+          renderFallbackPage(statusCode) {
+            // Find the not-found component from the parent level (the boundary that
+            // would catch this in Next.js). Walk up from the throwing layout to find
+            // the nearest not-found at a parent layout's directory.
+            let parentNotFound = null;
+            if (route.notFounds) {
+              for (let pi = li - 1; pi >= 0; pi--) {
+                if (route.notFounds[pi]?.default) {
+                  parentNotFound = route.notFounds[pi].default;
+                  break;
                 }
               }
-              if (!parentNotFound) parentNotFound = null;
-              // Wrap in only the layouts above the throwing one
-              const parentLayouts = route.layouts.slice(0, li);
-              const fallbackResp = await renderHTTPAccessFallbackPage(
-                route, statusCode, isRscRequest, request,
-                { boundaryComponent: parentNotFound, layouts: parentLayouts, matchedParams: params }
-              );
-              if (fallbackResp) return fallbackResp;
-              setHeadersContext(null);
-              setNavigationContext(null);
-              const statusText = statusCode === 403 ? "Forbidden" : statusCode === 401 ? "Unauthorized" : "Not Found";
-              return new Response(statusText, { status: statusCode });
             }
-          }
-          // Not a special error — let it propagate through normal RSC rendering
-        }
-      }
-      return null;
+            if (!parentNotFound) parentNotFound = null;
+            const parentLayouts = route.layouts.slice(0, li);
+            return renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, {
+              boundaryComponent: parentNotFound,
+              layouts: parentLayouts,
+              matchedParams: params,
+            });
+          },
+          requestUrl: request.url,
+          specialError: __layoutSpecialError,
+        });
+      },
+      probeLayoutAt(li) {
+        const LayoutComp = route.layouts[li]?.default;
+        if (!LayoutComp) return null;
+        return LayoutComp({ params: asyncParams, children: null });
+      },
+      runWithSuppressedHookWarning(probe) {
+        // Run inside ALS context so the module-level console.error patch suppresses
+        // "Invalid hook call" only for this request's probe — concurrent requests
+        // each have their own ALS store and are unaffected.
+        return _suppressHookWarningAls.run(true, probe);
+      },
     });
     if (_layoutProbeResult instanceof Response) return _layoutProbeResult;
   }
@@ -5019,30 +4928,23 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // trigger "Invalid hook call" console.error in dev. The module-level ALS patch
   // suppresses the warning only within this request's execution context.
   const _hasLoadingBoundary = !!(route.loading && route.loading.default);
-  const _pageProbeResult = await _suppressHookWarningAls.run(true, async () => {
-    try {
-      const testResult = PageComponent({ params });
-      // If it's a promise (async component), only await if there's no loading boundary.
-      // With a loading boundary, the Suspense streaming pipeline handles async resolution
-      // and any redirect/notFound errors via rscOnError.
-      if (testResult && typeof testResult === "object" && typeof testResult.then === "function") {
-        if (!_hasLoadingBoundary) {
-          await testResult;
-        } else {
-          // Suppress unhandled promise rejection — with a loading boundary,
-          // redirect/notFound errors are handled by rscOnError during streaming.
-          testResult.catch(() => {});
-        }
-      }
-    } catch (preRenderErr) {
+  const _pageProbeResult = await __probeAppPageComponent({
+    awaitAsyncResult: !_hasLoadingBoundary,
+    async onError(preRenderErr) {
       const specialResponse = await handleRenderError(preRenderErr);
       if (specialResponse) return specialResponse;
       // Non-special errors from the pre-render test are expected (e.g. use() hook
       // fails outside React's render cycle, client references can't execute on server).
       // Only redirect/notFound/forbidden/unauthorized are actionable here — other
       // errors will be properly caught during actual RSC/SSR rendering below.
-    }
-    return null;
+      return null;
+    },
+    probePage() {
+      return PageComponent({ params });
+    },
+    runWithSuppressedHookWarning(probe) {
+      return _suppressHookWarningAls.run(true, probe);
+    },
   });
   if (_pageProbeResult instanceof Response) return _pageProbeResult;
 
@@ -5069,27 +4971,16 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // paths can use the captured bytes when writing to the ISR cache.
   //   __rscForResponse  → sent to the client (RSC response) or to SSR (HTML response)
   //   __isrRscDataPromise → resolves to ArrayBuffer of captured RSC wire bytes
-  let __rscForResponse = rscStream;
-  let __isrRscDataPromise = null;
-  if (process.env.NODE_ENV === "production" && revalidateSeconds !== null && revalidateSeconds > 0 && revalidateSeconds !== Infinity && !isForceDynamic) {
-    const [__rscA, __rscB] = rscStream.tee();
-    __rscForResponse = __rscA;
-    __isrRscDataPromise = (async () => {
-      const __rscReader = __rscB.getReader();
-      const __rscChunks = [];
-      let __rscTotal = 0;
-      for (;;) {
-        const { done, value } = await __rscReader.read();
-        if (done) break;
-        __rscChunks.push(value);
-        __rscTotal += value.byteLength;
-      }
-      const __rscBuf = new Uint8Array(__rscTotal);
-      let __rscOff = 0;
-      for (const c of __rscChunks) { __rscBuf.set(c, __rscOff); __rscOff += c.byteLength; }
-      return __rscBuf.buffer;
-    })();
-  }
+  const __rscCapture = __teeAppPageRscStreamForCapture(
+    rscStream,
+    process.env.NODE_ENV === "production" &&
+      revalidateSeconds !== null &&
+      revalidateSeconds > 0 &&
+      revalidateSeconds !== Infinity &&
+      !isForceDynamic,
+  );
+  const __rscForResponse = __rscCapture.responseStream;
+  const __isrRscDataPromise = __rscCapture.capturedRscDataPromise;
 
   if (isRscRequest) {
     // Direct RSC stream response (for client-side navigation)
@@ -5151,12 +5042,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // Build HTTP Link header for font preloading.
   // This lets the browser (and CDN) start fetching font files before parsing HTML,
   // eliminating the CSS → woff2 download waterfall.
-  const fontPreloads = fontData.preloads || [];
-  const fontLinkHeaderParts = [];
-  for (const preload of fontPreloads) {
-    fontLinkHeaderParts.push("<" + preload.href + ">; rel=preload; as=font; type=" + preload.type + "; crossorigin");
-  }
-  const fontLinkHeader = fontLinkHeaderParts.length > 0 ? fontLinkHeaderParts.join(", ") : "";
+  const fontLinkHeader = __buildAppPageFontLinkHeader(fontData.preloads);
 
   // __rscForResponse was already teed above (before isRscRequest) for ISR pages in
   // production. For non-ISR or dev, __rscForResponse === rscStream (no tee).
@@ -5338,6 +5224,15 @@ import {
   resolveAppPageHtmlResponsePolicy as __resolveAppPageHtmlResponsePolicy,
   resolveAppPageRscResponsePolicy as __resolveAppPageRscResponsePolicy,
 } from "<ROOT>/packages/vinext/src/server/app-page-response.js";
+import {
+  buildAppPageFontLinkHeader as __buildAppPageFontLinkHeader,
+  buildAppPageSpecialErrorResponse as __buildAppPageSpecialErrorResponse,
+  probeAppPageComponent as __probeAppPageComponent,
+  probeAppPageLayouts as __probeAppPageLayouts,
+  readAppPageTextStream as __readAppPageTextStream,
+  resolveAppPageSpecialError as __resolveAppPageSpecialError,
+  teeAppPageRscStreamForCapture as __teeAppPageRscStreamForCapture,
+} from "<ROOT>/packages/vinext/src/server/app-page-execution.js";
 import {
   applyRouteHandlerMiddlewareContext as __applyRouteHandlerMiddlewareContext,
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-response.js";
@@ -5546,15 +5441,8 @@ function __errorDigest(str) {
 // unchanged since their digests are used for client-side routing.
 function __sanitizeErrorForClient(error) {
   // Navigation errors must pass through with their digest intact
-  if (error && typeof error === "object" && "digest" in error) {
-    const digest = String(error.digest);
-    if (
-      digest.startsWith("NEXT_REDIRECT;") ||
-      digest === "NEXT_NOT_FOUND" ||
-      digest.startsWith("NEXT_HTTP_ERROR_FALLBACK;")
-    ) {
-      return error;
-    }
+  if (__resolveAppPageSpecialError(error)) {
+    return error;
   }
   // In development, pass through the original error for debugging
   if (process.env.NODE_ENV !== "production") {
@@ -5908,8 +5796,8 @@ async function renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, req
   setHeadersContext(null);
   setNavigationContext(null);
   const _respHeaders = { "Content-Type": "text/html; charset=utf-8", "Vary": "RSC, Accept" };
-  const _linkParts = (fontData.preloads || []).map(function(p) { return "<" + p.href + ">; rel=preload; as=font; type=" + p.type + "; crossorigin"; });
-  if (_linkParts.length > 0) _respHeaders["Link"] = _linkParts.join(", ");
+  const _fontLinkHeader = __buildAppPageFontLinkHeader(fontData.preloads);
+  if (_fontLinkHeader) _respHeaders["Link"] = _fontLinkHeader;
   return new Response(htmlStream, {
     status: statusCode,
     headers: _respHeaders,
@@ -6040,8 +5928,8 @@ async function renderErrorBoundaryPage(route, error, isRscRequest, request, matc
   setHeadersContext(null);
   setNavigationContext(null);
   const _errHeaders = { "Content-Type": "text/html; charset=utf-8", "Vary": "RSC, Accept" };
-  const _errLinkParts = (fontData.preloads || []).map(function(p) { return "<" + p.href + ">; rel=preload; as=font; type=" + p.type + "; crossorigin"; });
-  if (_errLinkParts.length > 0) _errHeaders["Link"] = _errLinkParts.join(", ");
+  const _errFontLinkHeader = __buildAppPageFontLinkHeader(fontData.preloads);
+  if (_errFontLinkHeader) _errHeaders["Link"] = _errFontLinkHeader;
   return new Response(htmlStream, {
     status: 200,
     headers: _errHeaders,
@@ -7413,41 +7301,18 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           const __revalElement = await buildPageElement(route, params, undefined, new URLSearchParams());
           const __revalOnError = createRscOnErrorHandler(request, cleanPathname, route.pattern);
           const __revalRscStream = renderToReadableStream(__revalElement, { onError: __revalOnError });
-          // Tee RSC stream: one for SSR, one to capture rscData
-          const [__revalRscForSsr, __revalRscForCapture] = __revalRscStream.tee();
-          // Capture rscData bytes in parallel with SSR
-          const __rscDataPromise = (async () => {
-            const __rscReader = __revalRscForCapture.getReader();
-            const __rscChunks = [];
-            let __rscTotal = 0;
-            for (;;) {
-              const { done, value } = await __rscReader.read();
-              if (done) break;
-              __rscChunks.push(value);
-              __rscTotal += value.byteLength;
-            }
-            const __rscBuf = new Uint8Array(__rscTotal);
-            let __rscOff = 0;
-            for (const c of __rscChunks) { __rscBuf.set(c, __rscOff); __rscOff += c.byteLength; }
-            return __rscBuf.buffer;
-          })();
+          const __revalRscCapture = __teeAppPageRscStreamForCapture(__revalRscStream, true);
           const __revalFontData = { links: _getSSRFontLinks(), styles: _getSSRFontStyles(), preloads: _getSSRFontPreloads() };
           const __revalSsrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
-          const __revalHtmlStream = await __revalSsrEntry.handleSsr(__revalRscForSsr, _getNavigationContext(), __revalFontData);
+          const __revalHtmlStream = await __revalSsrEntry.handleSsr(
+            __revalRscCapture.responseStream,
+            _getNavigationContext(),
+            __revalFontData,
+          );
           setHeadersContext(null);
           setNavigationContext(null);
-          // Collect the full HTML string from the stream
-          const __revalReader = __revalHtmlStream.getReader();
-          const __revalDecoder = new TextDecoder();
-          const __revalChunks = [];
-          for (;;) {
-            const { done, value } = await __revalReader.read();
-            if (done) break;
-            __revalChunks.push(__revalDecoder.decode(value, { stream: true }));
-          }
-          __revalChunks.push(__revalDecoder.decode());
-          const __freshHtml = __revalChunks.join("");
-          const __freshRscData = await __rscDataPromise;
+          const __freshHtml = await __readAppPageTextStream(__revalHtmlStream);
+          const __freshRscData = await __revalRscCapture.capturedRscDataPromise;
           const __pageTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
           return { html: __freshHtml, rscData: __freshRscData, tags: __pageTags };
         });
@@ -7539,26 +7404,21 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   try {
     element = await buildPageElement(route, params, interceptOpts, url.searchParams);
   } catch (buildErr) {
-    // Check for redirect/notFound/forbidden/unauthorized thrown during metadata resolution or async components
-    if (buildErr && typeof buildErr === "object" && "digest" in buildErr) {
-      const digest = String(buildErr.digest);
-      if (digest.startsWith("NEXT_REDIRECT;")) {
-        const parts = digest.split(";");
-        const redirectUrl = decodeURIComponent(parts[2]);
-        const statusCode = parts[3] ? parseInt(parts[3], 10) : 307;
-        setHeadersContext(null);
-        setNavigationContext(null);
-        return Response.redirect(new URL(redirectUrl, request.url), statusCode);
-      }
-      if (digest === "NEXT_NOT_FOUND" || digest.startsWith("NEXT_HTTP_ERROR_FALLBACK;")) {
-        const statusCode = digest === "NEXT_NOT_FOUND" ? 404 : parseInt(digest.split(";")[1], 10);
-        const fallbackResp = await renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, { matchedParams: params });
-        if (fallbackResp) return fallbackResp;
-        setHeadersContext(null);
-        setNavigationContext(null);
-        const statusText = statusCode === 403 ? "Forbidden" : statusCode === 401 ? "Unauthorized" : "Not Found";
-        return new Response(statusText, { status: statusCode });
-      }
+    const __buildSpecialError = __resolveAppPageSpecialError(buildErr);
+    if (__buildSpecialError) {
+      return __buildAppPageSpecialErrorResponse({
+        clearRequestContext() {
+          setHeadersContext(null);
+          setNavigationContext(null);
+        },
+        renderFallbackPage(statusCode) {
+          return renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, {
+            matchedParams: params,
+          });
+        },
+        requestUrl: request.url,
+        specialError: __buildSpecialError,
+      });
     }
     // Non-special error (e.g. generateMetadata() threw) — render error.tsx if available
     const errorBoundaryResp = await renderErrorBoundaryPage(route, buildErr, isRscRequest, request, params);
@@ -7571,25 +7431,21 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
 
   // Helper: check if an error is a redirect/notFound/forbidden/unauthorized thrown by the navigation shim
   async function handleRenderError(err) {
-    if (err && typeof err === "object" && "digest" in err) {
-      const digest = String(err.digest);
-      if (digest.startsWith("NEXT_REDIRECT;")) {
-        const parts = digest.split(";");
-        const redirectUrl = decodeURIComponent(parts[2]);
-        const statusCode = parts[3] ? parseInt(parts[3], 10) : 307;
-        setHeadersContext(null);
-        setNavigationContext(null);
-        return Response.redirect(new URL(redirectUrl, request.url), statusCode);
-      }
-      if (digest === "NEXT_NOT_FOUND" || digest.startsWith("NEXT_HTTP_ERROR_FALLBACK;")) {
-        const statusCode = digest === "NEXT_NOT_FOUND" ? 404 : parseInt(digest.split(";")[1], 10);
-        const fallbackResp = await renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, { matchedParams: params });
-        if (fallbackResp) return fallbackResp;
-        setHeadersContext(null);
-        setNavigationContext(null);
-        const statusText = statusCode === 403 ? "Forbidden" : statusCode === 401 ? "Unauthorized" : "Not Found";
-        return new Response(statusText, { status: statusCode });
-      }
+    const specialError = __resolveAppPageSpecialError(err);
+    if (specialError) {
+      return __buildAppPageSpecialErrorResponse({
+        clearRequestContext() {
+          setHeadersContext(null);
+          setNavigationContext(null);
+        },
+        renderFallbackPage(statusCode) {
+          return renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, {
+            matchedParams: params,
+          });
+        },
+        requestUrl: request.url,
+        specialError,
+      });
     }
     return null;
   }
@@ -7608,59 +7464,55 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // layouts itself throws notFound() during the fallback rendering (causing a 500).
   if (route.layouts && route.layouts.length > 0) {
     const asyncParams = makeThenableParams(params);
-    // Run inside ALS context so the module-level console.error patch suppresses
-    // "Invalid hook call" only for this request's probe — concurrent requests
-    // each have their own ALS store and are unaffected.
-    const _layoutProbeResult = await _suppressHookWarningAls.run(true, async () => {
-      for (let li = route.layouts.length - 1; li >= 0; li--) {
-        const LayoutComp = route.layouts[li]?.default;
-        if (!LayoutComp) continue;
-        try {
-          const lr = LayoutComp({ params: asyncParams, children: null });
-          if (lr && typeof lr === "object" && typeof lr.then === "function") await lr;
-        } catch (layoutErr) {
-          if (layoutErr && typeof layoutErr === "object" && "digest" in layoutErr) {
-            const digest = String(layoutErr.digest);
-             if (digest.startsWith("NEXT_REDIRECT;")) {
-               const parts = digest.split(";");
-               const redirectUrl = decodeURIComponent(parts[2]);
-               const statusCode = parts[3] ? parseInt(parts[3], 10) : 307;
-               setHeadersContext(null);
-               setNavigationContext(null);
-               return Response.redirect(new URL(redirectUrl, request.url), statusCode);
-            }
-            if (digest === "NEXT_NOT_FOUND" || digest.startsWith("NEXT_HTTP_ERROR_FALLBACK;")) {
-              const statusCode = digest === "NEXT_NOT_FOUND" ? 404 : parseInt(digest.split(";")[1], 10);
-              // Find the not-found component from the parent level (the boundary that
-              // would catch this in Next.js). Walk up from the throwing layout to find
-              // the nearest not-found at a parent layout's directory.
-              let parentNotFound = null;
-              if (route.notFounds) {
-                for (let pi = li - 1; pi >= 0; pi--) {
-                  if (route.notFounds[pi]?.default) {
-                    parentNotFound = route.notFounds[pi].default;
-                    break;
-                  }
+    const _layoutProbeResult = await __probeAppPageLayouts({
+      layoutCount: route.layouts.length,
+      async onLayoutError(layoutErr, li) {
+        const __layoutSpecialError = __resolveAppPageSpecialError(layoutErr);
+        if (!__layoutSpecialError) {
+          return null;
+        }
+
+        return __buildAppPageSpecialErrorResponse({
+          clearRequestContext() {
+            setHeadersContext(null);
+            setNavigationContext(null);
+          },
+          renderFallbackPage(statusCode) {
+            // Find the not-found component from the parent level (the boundary that
+            // would catch this in Next.js). Walk up from the throwing layout to find
+            // the nearest not-found at a parent layout's directory.
+            let parentNotFound = null;
+            if (route.notFounds) {
+              for (let pi = li - 1; pi >= 0; pi--) {
+                if (route.notFounds[pi]?.default) {
+                  parentNotFound = route.notFounds[pi].default;
+                  break;
                 }
               }
-              if (!parentNotFound) parentNotFound = null;
-              // Wrap in only the layouts above the throwing one
-              const parentLayouts = route.layouts.slice(0, li);
-              const fallbackResp = await renderHTTPAccessFallbackPage(
-                route, statusCode, isRscRequest, request,
-                { boundaryComponent: parentNotFound, layouts: parentLayouts, matchedParams: params }
-              );
-              if (fallbackResp) return fallbackResp;
-              setHeadersContext(null);
-              setNavigationContext(null);
-              const statusText = statusCode === 403 ? "Forbidden" : statusCode === 401 ? "Unauthorized" : "Not Found";
-              return new Response(statusText, { status: statusCode });
             }
-          }
-          // Not a special error — let it propagate through normal RSC rendering
-        }
-      }
-      return null;
+            if (!parentNotFound) parentNotFound = null;
+            const parentLayouts = route.layouts.slice(0, li);
+            return renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, {
+              boundaryComponent: parentNotFound,
+              layouts: parentLayouts,
+              matchedParams: params,
+            });
+          },
+          requestUrl: request.url,
+          specialError: __layoutSpecialError,
+        });
+      },
+      probeLayoutAt(li) {
+        const LayoutComp = route.layouts[li]?.default;
+        if (!LayoutComp) return null;
+        return LayoutComp({ params: asyncParams, children: null });
+      },
+      runWithSuppressedHookWarning(probe) {
+        // Run inside ALS context so the module-level console.error patch suppresses
+        // "Invalid hook call" only for this request's probe — concurrent requests
+        // each have their own ALS store and are unaffected.
+        return _suppressHookWarningAls.run(true, probe);
+      },
     });
     if (_layoutProbeResult instanceof Response) return _layoutProbeResult;
   }
@@ -7678,30 +7530,23 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // trigger "Invalid hook call" console.error in dev. The module-level ALS patch
   // suppresses the warning only within this request's execution context.
   const _hasLoadingBoundary = !!(route.loading && route.loading.default);
-  const _pageProbeResult = await _suppressHookWarningAls.run(true, async () => {
-    try {
-      const testResult = PageComponent({ params });
-      // If it's a promise (async component), only await if there's no loading boundary.
-      // With a loading boundary, the Suspense streaming pipeline handles async resolution
-      // and any redirect/notFound errors via rscOnError.
-      if (testResult && typeof testResult === "object" && typeof testResult.then === "function") {
-        if (!_hasLoadingBoundary) {
-          await testResult;
-        } else {
-          // Suppress unhandled promise rejection — with a loading boundary,
-          // redirect/notFound errors are handled by rscOnError during streaming.
-          testResult.catch(() => {});
-        }
-      }
-    } catch (preRenderErr) {
+  const _pageProbeResult = await __probeAppPageComponent({
+    awaitAsyncResult: !_hasLoadingBoundary,
+    async onError(preRenderErr) {
       const specialResponse = await handleRenderError(preRenderErr);
       if (specialResponse) return specialResponse;
       // Non-special errors from the pre-render test are expected (e.g. use() hook
       // fails outside React's render cycle, client references can't execute on server).
       // Only redirect/notFound/forbidden/unauthorized are actionable here — other
       // errors will be properly caught during actual RSC/SSR rendering below.
-    }
-    return null;
+      return null;
+    },
+    probePage() {
+      return PageComponent({ params });
+    },
+    runWithSuppressedHookWarning(probe) {
+      return _suppressHookWarningAls.run(true, probe);
+    },
   });
   if (_pageProbeResult instanceof Response) return _pageProbeResult;
 
@@ -7728,27 +7573,16 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // paths can use the captured bytes when writing to the ISR cache.
   //   __rscForResponse  → sent to the client (RSC response) or to SSR (HTML response)
   //   __isrRscDataPromise → resolves to ArrayBuffer of captured RSC wire bytes
-  let __rscForResponse = rscStream;
-  let __isrRscDataPromise = null;
-  if (process.env.NODE_ENV === "production" && revalidateSeconds !== null && revalidateSeconds > 0 && revalidateSeconds !== Infinity && !isForceDynamic) {
-    const [__rscA, __rscB] = rscStream.tee();
-    __rscForResponse = __rscA;
-    __isrRscDataPromise = (async () => {
-      const __rscReader = __rscB.getReader();
-      const __rscChunks = [];
-      let __rscTotal = 0;
-      for (;;) {
-        const { done, value } = await __rscReader.read();
-        if (done) break;
-        __rscChunks.push(value);
-        __rscTotal += value.byteLength;
-      }
-      const __rscBuf = new Uint8Array(__rscTotal);
-      let __rscOff = 0;
-      for (const c of __rscChunks) { __rscBuf.set(c, __rscOff); __rscOff += c.byteLength; }
-      return __rscBuf.buffer;
-    })();
-  }
+  const __rscCapture = __teeAppPageRscStreamForCapture(
+    rscStream,
+    process.env.NODE_ENV === "production" &&
+      revalidateSeconds !== null &&
+      revalidateSeconds > 0 &&
+      revalidateSeconds !== Infinity &&
+      !isForceDynamic,
+  );
+  const __rscForResponse = __rscCapture.responseStream;
+  const __isrRscDataPromise = __rscCapture.capturedRscDataPromise;
 
   if (isRscRequest) {
     // Direct RSC stream response (for client-side navigation)
@@ -7810,12 +7644,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // Build HTTP Link header for font preloading.
   // This lets the browser (and CDN) start fetching font files before parsing HTML,
   // eliminating the CSS → woff2 download waterfall.
-  const fontPreloads = fontData.preloads || [];
-  const fontLinkHeaderParts = [];
-  for (const preload of fontPreloads) {
-    fontLinkHeaderParts.push("<" + preload.href + ">; rel=preload; as=font; type=" + preload.type + "; crossorigin");
-  }
-  const fontLinkHeader = fontLinkHeaderParts.length > 0 ? fontLinkHeaderParts.join(", ") : "";
+  const fontLinkHeader = __buildAppPageFontLinkHeader(fontData.preloads);
 
   // __rscForResponse was already teed above (before isRscRequest) for ISR pages in
   // production. For non-ISR or dev, __rscForResponse === rscStream (no tee).
@@ -8005,6 +7834,15 @@ import {
   resolveAppPageHtmlResponsePolicy as __resolveAppPageHtmlResponsePolicy,
   resolveAppPageRscResponsePolicy as __resolveAppPageRscResponsePolicy,
 } from "<ROOT>/packages/vinext/src/server/app-page-response.js";
+import {
+  buildAppPageFontLinkHeader as __buildAppPageFontLinkHeader,
+  buildAppPageSpecialErrorResponse as __buildAppPageSpecialErrorResponse,
+  probeAppPageComponent as __probeAppPageComponent,
+  probeAppPageLayouts as __probeAppPageLayouts,
+  readAppPageTextStream as __readAppPageTextStream,
+  resolveAppPageSpecialError as __resolveAppPageSpecialError,
+  teeAppPageRscStreamForCapture as __teeAppPageRscStreamForCapture,
+} from "<ROOT>/packages/vinext/src/server/app-page-execution.js";
 import {
   applyRouteHandlerMiddlewareContext as __applyRouteHandlerMiddlewareContext,
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-response.js";
@@ -8213,15 +8051,8 @@ function __errorDigest(str) {
 // unchanged since their digests are used for client-side routing.
 function __sanitizeErrorForClient(error) {
   // Navigation errors must pass through with their digest intact
-  if (error && typeof error === "object" && "digest" in error) {
-    const digest = String(error.digest);
-    if (
-      digest.startsWith("NEXT_REDIRECT;") ||
-      digest === "NEXT_NOT_FOUND" ||
-      digest.startsWith("NEXT_HTTP_ERROR_FALLBACK;")
-    ) {
-      return error;
-    }
+  if (__resolveAppPageSpecialError(error)) {
+    return error;
   }
   // In development, pass through the original error for debugging
   if (process.env.NODE_ENV !== "production") {
@@ -8596,8 +8427,8 @@ async function renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, req
   setHeadersContext(null);
   setNavigationContext(null);
   const _respHeaders = { "Content-Type": "text/html; charset=utf-8", "Vary": "RSC, Accept" };
-  const _linkParts = (fontData.preloads || []).map(function(p) { return "<" + p.href + ">; rel=preload; as=font; type=" + p.type + "; crossorigin"; });
-  if (_linkParts.length > 0) _respHeaders["Link"] = _linkParts.join(", ");
+  const _fontLinkHeader = __buildAppPageFontLinkHeader(fontData.preloads);
+  if (_fontLinkHeader) _respHeaders["Link"] = _fontLinkHeader;
   return new Response(htmlStream, {
     status: statusCode,
     headers: _respHeaders,
@@ -8715,8 +8546,8 @@ async function renderErrorBoundaryPage(route, error, isRscRequest, request, matc
   setHeadersContext(null);
   setNavigationContext(null);
   const _errHeaders = { "Content-Type": "text/html; charset=utf-8", "Vary": "RSC, Accept" };
-  const _errLinkParts = (fontData.preloads || []).map(function(p) { return "<" + p.href + ">; rel=preload; as=font; type=" + p.type + "; crossorigin"; });
-  if (_errLinkParts.length > 0) _errHeaders["Link"] = _errLinkParts.join(", ");
+  const _errFontLinkHeader = __buildAppPageFontLinkHeader(fontData.preloads);
+  if (_errFontLinkHeader) _errHeaders["Link"] = _errFontLinkHeader;
   return new Response(htmlStream, {
     status: 200,
     headers: _errHeaders,
@@ -10083,41 +9914,18 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           const __revalElement = await buildPageElement(route, params, undefined, new URLSearchParams());
           const __revalOnError = createRscOnErrorHandler(request, cleanPathname, route.pattern);
           const __revalRscStream = renderToReadableStream(__revalElement, { onError: __revalOnError });
-          // Tee RSC stream: one for SSR, one to capture rscData
-          const [__revalRscForSsr, __revalRscForCapture] = __revalRscStream.tee();
-          // Capture rscData bytes in parallel with SSR
-          const __rscDataPromise = (async () => {
-            const __rscReader = __revalRscForCapture.getReader();
-            const __rscChunks = [];
-            let __rscTotal = 0;
-            for (;;) {
-              const { done, value } = await __rscReader.read();
-              if (done) break;
-              __rscChunks.push(value);
-              __rscTotal += value.byteLength;
-            }
-            const __rscBuf = new Uint8Array(__rscTotal);
-            let __rscOff = 0;
-            for (const c of __rscChunks) { __rscBuf.set(c, __rscOff); __rscOff += c.byteLength; }
-            return __rscBuf.buffer;
-          })();
+          const __revalRscCapture = __teeAppPageRscStreamForCapture(__revalRscStream, true);
           const __revalFontData = { links: _getSSRFontLinks(), styles: _getSSRFontStyles(), preloads: _getSSRFontPreloads() };
           const __revalSsrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
-          const __revalHtmlStream = await __revalSsrEntry.handleSsr(__revalRscForSsr, _getNavigationContext(), __revalFontData);
+          const __revalHtmlStream = await __revalSsrEntry.handleSsr(
+            __revalRscCapture.responseStream,
+            _getNavigationContext(),
+            __revalFontData,
+          );
           setHeadersContext(null);
           setNavigationContext(null);
-          // Collect the full HTML string from the stream
-          const __revalReader = __revalHtmlStream.getReader();
-          const __revalDecoder = new TextDecoder();
-          const __revalChunks = [];
-          for (;;) {
-            const { done, value } = await __revalReader.read();
-            if (done) break;
-            __revalChunks.push(__revalDecoder.decode(value, { stream: true }));
-          }
-          __revalChunks.push(__revalDecoder.decode());
-          const __freshHtml = __revalChunks.join("");
-          const __freshRscData = await __rscDataPromise;
+          const __freshHtml = await __readAppPageTextStream(__revalHtmlStream);
+          const __freshRscData = await __revalRscCapture.capturedRscDataPromise;
           const __pageTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
           return { html: __freshHtml, rscData: __freshRscData, tags: __pageTags };
         });
@@ -10209,26 +10017,21 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   try {
     element = await buildPageElement(route, params, interceptOpts, url.searchParams);
   } catch (buildErr) {
-    // Check for redirect/notFound/forbidden/unauthorized thrown during metadata resolution or async components
-    if (buildErr && typeof buildErr === "object" && "digest" in buildErr) {
-      const digest = String(buildErr.digest);
-      if (digest.startsWith("NEXT_REDIRECT;")) {
-        const parts = digest.split(";");
-        const redirectUrl = decodeURIComponent(parts[2]);
-        const statusCode = parts[3] ? parseInt(parts[3], 10) : 307;
-        setHeadersContext(null);
-        setNavigationContext(null);
-        return Response.redirect(new URL(redirectUrl, request.url), statusCode);
-      }
-      if (digest === "NEXT_NOT_FOUND" || digest.startsWith("NEXT_HTTP_ERROR_FALLBACK;")) {
-        const statusCode = digest === "NEXT_NOT_FOUND" ? 404 : parseInt(digest.split(";")[1], 10);
-        const fallbackResp = await renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, { matchedParams: params });
-        if (fallbackResp) return fallbackResp;
-        setHeadersContext(null);
-        setNavigationContext(null);
-        const statusText = statusCode === 403 ? "Forbidden" : statusCode === 401 ? "Unauthorized" : "Not Found";
-        return new Response(statusText, { status: statusCode });
-      }
+    const __buildSpecialError = __resolveAppPageSpecialError(buildErr);
+    if (__buildSpecialError) {
+      return __buildAppPageSpecialErrorResponse({
+        clearRequestContext() {
+          setHeadersContext(null);
+          setNavigationContext(null);
+        },
+        renderFallbackPage(statusCode) {
+          return renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, {
+            matchedParams: params,
+          });
+        },
+        requestUrl: request.url,
+        specialError: __buildSpecialError,
+      });
     }
     // Non-special error (e.g. generateMetadata() threw) — render error.tsx if available
     const errorBoundaryResp = await renderErrorBoundaryPage(route, buildErr, isRscRequest, request, params);
@@ -10241,25 +10044,21 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
 
   // Helper: check if an error is a redirect/notFound/forbidden/unauthorized thrown by the navigation shim
   async function handleRenderError(err) {
-    if (err && typeof err === "object" && "digest" in err) {
-      const digest = String(err.digest);
-      if (digest.startsWith("NEXT_REDIRECT;")) {
-        const parts = digest.split(";");
-        const redirectUrl = decodeURIComponent(parts[2]);
-        const statusCode = parts[3] ? parseInt(parts[3], 10) : 307;
-        setHeadersContext(null);
-        setNavigationContext(null);
-        return Response.redirect(new URL(redirectUrl, request.url), statusCode);
-      }
-      if (digest === "NEXT_NOT_FOUND" || digest.startsWith("NEXT_HTTP_ERROR_FALLBACK;")) {
-        const statusCode = digest === "NEXT_NOT_FOUND" ? 404 : parseInt(digest.split(";")[1], 10);
-        const fallbackResp = await renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, { matchedParams: params });
-        if (fallbackResp) return fallbackResp;
-        setHeadersContext(null);
-        setNavigationContext(null);
-        const statusText = statusCode === 403 ? "Forbidden" : statusCode === 401 ? "Unauthorized" : "Not Found";
-        return new Response(statusText, { status: statusCode });
-      }
+    const specialError = __resolveAppPageSpecialError(err);
+    if (specialError) {
+      return __buildAppPageSpecialErrorResponse({
+        clearRequestContext() {
+          setHeadersContext(null);
+          setNavigationContext(null);
+        },
+        renderFallbackPage(statusCode) {
+          return renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, {
+            matchedParams: params,
+          });
+        },
+        requestUrl: request.url,
+        specialError,
+      });
     }
     return null;
   }
@@ -10278,59 +10077,55 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // layouts itself throws notFound() during the fallback rendering (causing a 500).
   if (route.layouts && route.layouts.length > 0) {
     const asyncParams = makeThenableParams(params);
-    // Run inside ALS context so the module-level console.error patch suppresses
-    // "Invalid hook call" only for this request's probe — concurrent requests
-    // each have their own ALS store and are unaffected.
-    const _layoutProbeResult = await _suppressHookWarningAls.run(true, async () => {
-      for (let li = route.layouts.length - 1; li >= 0; li--) {
-        const LayoutComp = route.layouts[li]?.default;
-        if (!LayoutComp) continue;
-        try {
-          const lr = LayoutComp({ params: asyncParams, children: null });
-          if (lr && typeof lr === "object" && typeof lr.then === "function") await lr;
-        } catch (layoutErr) {
-          if (layoutErr && typeof layoutErr === "object" && "digest" in layoutErr) {
-            const digest = String(layoutErr.digest);
-             if (digest.startsWith("NEXT_REDIRECT;")) {
-               const parts = digest.split(";");
-               const redirectUrl = decodeURIComponent(parts[2]);
-               const statusCode = parts[3] ? parseInt(parts[3], 10) : 307;
-               setHeadersContext(null);
-               setNavigationContext(null);
-               return Response.redirect(new URL(redirectUrl, request.url), statusCode);
-            }
-            if (digest === "NEXT_NOT_FOUND" || digest.startsWith("NEXT_HTTP_ERROR_FALLBACK;")) {
-              const statusCode = digest === "NEXT_NOT_FOUND" ? 404 : parseInt(digest.split(";")[1], 10);
-              // Find the not-found component from the parent level (the boundary that
-              // would catch this in Next.js). Walk up from the throwing layout to find
-              // the nearest not-found at a parent layout's directory.
-              let parentNotFound = null;
-              if (route.notFounds) {
-                for (let pi = li - 1; pi >= 0; pi--) {
-                  if (route.notFounds[pi]?.default) {
-                    parentNotFound = route.notFounds[pi].default;
-                    break;
-                  }
+    const _layoutProbeResult = await __probeAppPageLayouts({
+      layoutCount: route.layouts.length,
+      async onLayoutError(layoutErr, li) {
+        const __layoutSpecialError = __resolveAppPageSpecialError(layoutErr);
+        if (!__layoutSpecialError) {
+          return null;
+        }
+
+        return __buildAppPageSpecialErrorResponse({
+          clearRequestContext() {
+            setHeadersContext(null);
+            setNavigationContext(null);
+          },
+          renderFallbackPage(statusCode) {
+            // Find the not-found component from the parent level (the boundary that
+            // would catch this in Next.js). Walk up from the throwing layout to find
+            // the nearest not-found at a parent layout's directory.
+            let parentNotFound = null;
+            if (route.notFounds) {
+              for (let pi = li - 1; pi >= 0; pi--) {
+                if (route.notFounds[pi]?.default) {
+                  parentNotFound = route.notFounds[pi].default;
+                  break;
                 }
               }
-              if (!parentNotFound) parentNotFound = null;
-              // Wrap in only the layouts above the throwing one
-              const parentLayouts = route.layouts.slice(0, li);
-              const fallbackResp = await renderHTTPAccessFallbackPage(
-                route, statusCode, isRscRequest, request,
-                { boundaryComponent: parentNotFound, layouts: parentLayouts, matchedParams: params }
-              );
-              if (fallbackResp) return fallbackResp;
-              setHeadersContext(null);
-              setNavigationContext(null);
-              const statusText = statusCode === 403 ? "Forbidden" : statusCode === 401 ? "Unauthorized" : "Not Found";
-              return new Response(statusText, { status: statusCode });
             }
-          }
-          // Not a special error — let it propagate through normal RSC rendering
-        }
-      }
-      return null;
+            if (!parentNotFound) parentNotFound = null;
+            const parentLayouts = route.layouts.slice(0, li);
+            return renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, {
+              boundaryComponent: parentNotFound,
+              layouts: parentLayouts,
+              matchedParams: params,
+            });
+          },
+          requestUrl: request.url,
+          specialError: __layoutSpecialError,
+        });
+      },
+      probeLayoutAt(li) {
+        const LayoutComp = route.layouts[li]?.default;
+        if (!LayoutComp) return null;
+        return LayoutComp({ params: asyncParams, children: null });
+      },
+      runWithSuppressedHookWarning(probe) {
+        // Run inside ALS context so the module-level console.error patch suppresses
+        // "Invalid hook call" only for this request's probe — concurrent requests
+        // each have their own ALS store and are unaffected.
+        return _suppressHookWarningAls.run(true, probe);
+      },
     });
     if (_layoutProbeResult instanceof Response) return _layoutProbeResult;
   }
@@ -10348,30 +10143,23 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // trigger "Invalid hook call" console.error in dev. The module-level ALS patch
   // suppresses the warning only within this request's execution context.
   const _hasLoadingBoundary = !!(route.loading && route.loading.default);
-  const _pageProbeResult = await _suppressHookWarningAls.run(true, async () => {
-    try {
-      const testResult = PageComponent({ params });
-      // If it's a promise (async component), only await if there's no loading boundary.
-      // With a loading boundary, the Suspense streaming pipeline handles async resolution
-      // and any redirect/notFound errors via rscOnError.
-      if (testResult && typeof testResult === "object" && typeof testResult.then === "function") {
-        if (!_hasLoadingBoundary) {
-          await testResult;
-        } else {
-          // Suppress unhandled promise rejection — with a loading boundary,
-          // redirect/notFound errors are handled by rscOnError during streaming.
-          testResult.catch(() => {});
-        }
-      }
-    } catch (preRenderErr) {
+  const _pageProbeResult = await __probeAppPageComponent({
+    awaitAsyncResult: !_hasLoadingBoundary,
+    async onError(preRenderErr) {
       const specialResponse = await handleRenderError(preRenderErr);
       if (specialResponse) return specialResponse;
       // Non-special errors from the pre-render test are expected (e.g. use() hook
       // fails outside React's render cycle, client references can't execute on server).
       // Only redirect/notFound/forbidden/unauthorized are actionable here — other
       // errors will be properly caught during actual RSC/SSR rendering below.
-    }
-    return null;
+      return null;
+    },
+    probePage() {
+      return PageComponent({ params });
+    },
+    runWithSuppressedHookWarning(probe) {
+      return _suppressHookWarningAls.run(true, probe);
+    },
   });
   if (_pageProbeResult instanceof Response) return _pageProbeResult;
 
@@ -10398,27 +10186,16 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // paths can use the captured bytes when writing to the ISR cache.
   //   __rscForResponse  → sent to the client (RSC response) or to SSR (HTML response)
   //   __isrRscDataPromise → resolves to ArrayBuffer of captured RSC wire bytes
-  let __rscForResponse = rscStream;
-  let __isrRscDataPromise = null;
-  if (process.env.NODE_ENV === "production" && revalidateSeconds !== null && revalidateSeconds > 0 && revalidateSeconds !== Infinity && !isForceDynamic) {
-    const [__rscA, __rscB] = rscStream.tee();
-    __rscForResponse = __rscA;
-    __isrRscDataPromise = (async () => {
-      const __rscReader = __rscB.getReader();
-      const __rscChunks = [];
-      let __rscTotal = 0;
-      for (;;) {
-        const { done, value } = await __rscReader.read();
-        if (done) break;
-        __rscChunks.push(value);
-        __rscTotal += value.byteLength;
-      }
-      const __rscBuf = new Uint8Array(__rscTotal);
-      let __rscOff = 0;
-      for (const c of __rscChunks) { __rscBuf.set(c, __rscOff); __rscOff += c.byteLength; }
-      return __rscBuf.buffer;
-    })();
-  }
+  const __rscCapture = __teeAppPageRscStreamForCapture(
+    rscStream,
+    process.env.NODE_ENV === "production" &&
+      revalidateSeconds !== null &&
+      revalidateSeconds > 0 &&
+      revalidateSeconds !== Infinity &&
+      !isForceDynamic,
+  );
+  const __rscForResponse = __rscCapture.responseStream;
+  const __isrRscDataPromise = __rscCapture.capturedRscDataPromise;
 
   if (isRscRequest) {
     // Direct RSC stream response (for client-side navigation)
@@ -10480,12 +10257,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // Build HTTP Link header for font preloading.
   // This lets the browser (and CDN) start fetching font files before parsing HTML,
   // eliminating the CSS → woff2 download waterfall.
-  const fontPreloads = fontData.preloads || [];
-  const fontLinkHeaderParts = [];
-  for (const preload of fontPreloads) {
-    fontLinkHeaderParts.push("<" + preload.href + ">; rel=preload; as=font; type=" + preload.type + "; crossorigin");
-  }
-  const fontLinkHeader = fontLinkHeaderParts.length > 0 ? fontLinkHeaderParts.join(", ") : "";
+  const fontLinkHeader = __buildAppPageFontLinkHeader(fontData.preloads);
 
   // __rscForResponse was already teed above (before isRscRequest) for ISR pages in
   // production. For non-ISR or dev, __rscForResponse === rscStream (no tee).
@@ -10667,6 +10439,15 @@ import {
   resolveAppPageHtmlResponsePolicy as __resolveAppPageHtmlResponsePolicy,
   resolveAppPageRscResponsePolicy as __resolveAppPageRscResponsePolicy,
 } from "<ROOT>/packages/vinext/src/server/app-page-response.js";
+import {
+  buildAppPageFontLinkHeader as __buildAppPageFontLinkHeader,
+  buildAppPageSpecialErrorResponse as __buildAppPageSpecialErrorResponse,
+  probeAppPageComponent as __probeAppPageComponent,
+  probeAppPageLayouts as __probeAppPageLayouts,
+  readAppPageTextStream as __readAppPageTextStream,
+  resolveAppPageSpecialError as __resolveAppPageSpecialError,
+  teeAppPageRscStreamForCapture as __teeAppPageRscStreamForCapture,
+} from "<ROOT>/packages/vinext/src/server/app-page-execution.js";
 import {
   applyRouteHandlerMiddlewareContext as __applyRouteHandlerMiddlewareContext,
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-response.js";
@@ -10875,15 +10656,8 @@ function __errorDigest(str) {
 // unchanged since their digests are used for client-side routing.
 function __sanitizeErrorForClient(error) {
   // Navigation errors must pass through with their digest intact
-  if (error && typeof error === "object" && "digest" in error) {
-    const digest = String(error.digest);
-    if (
-      digest.startsWith("NEXT_REDIRECT;") ||
-      digest === "NEXT_NOT_FOUND" ||
-      digest.startsWith("NEXT_HTTP_ERROR_FALLBACK;")
-    ) {
-      return error;
-    }
+  if (__resolveAppPageSpecialError(error)) {
+    return error;
   }
   // In development, pass through the original error for debugging
   if (process.env.NODE_ENV !== "production") {
@@ -11235,8 +11009,8 @@ async function renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, req
   setHeadersContext(null);
   setNavigationContext(null);
   const _respHeaders = { "Content-Type": "text/html; charset=utf-8", "Vary": "RSC, Accept" };
-  const _linkParts = (fontData.preloads || []).map(function(p) { return "<" + p.href + ">; rel=preload; as=font; type=" + p.type + "; crossorigin"; });
-  if (_linkParts.length > 0) _respHeaders["Link"] = _linkParts.join(", ");
+  const _fontLinkHeader = __buildAppPageFontLinkHeader(fontData.preloads);
+  if (_fontLinkHeader) _respHeaders["Link"] = _fontLinkHeader;
   return new Response(htmlStream, {
     status: statusCode,
     headers: _respHeaders,
@@ -11354,8 +11128,8 @@ async function renderErrorBoundaryPage(route, error, isRscRequest, request, matc
   setHeadersContext(null);
   setNavigationContext(null);
   const _errHeaders = { "Content-Type": "text/html; charset=utf-8", "Vary": "RSC, Accept" };
-  const _errLinkParts = (fontData.preloads || []).map(function(p) { return "<" + p.href + ">; rel=preload; as=font; type=" + p.type + "; crossorigin"; });
-  if (_errLinkParts.length > 0) _errHeaders["Link"] = _errLinkParts.join(", ");
+  const _errFontLinkHeader = __buildAppPageFontLinkHeader(fontData.preloads);
+  if (_errFontLinkHeader) _errHeaders["Link"] = _errFontLinkHeader;
   return new Response(htmlStream, {
     status: 200,
     headers: _errHeaders,
@@ -12719,41 +12493,18 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           const __revalElement = await buildPageElement(route, params, undefined, new URLSearchParams());
           const __revalOnError = createRscOnErrorHandler(request, cleanPathname, route.pattern);
           const __revalRscStream = renderToReadableStream(__revalElement, { onError: __revalOnError });
-          // Tee RSC stream: one for SSR, one to capture rscData
-          const [__revalRscForSsr, __revalRscForCapture] = __revalRscStream.tee();
-          // Capture rscData bytes in parallel with SSR
-          const __rscDataPromise = (async () => {
-            const __rscReader = __revalRscForCapture.getReader();
-            const __rscChunks = [];
-            let __rscTotal = 0;
-            for (;;) {
-              const { done, value } = await __rscReader.read();
-              if (done) break;
-              __rscChunks.push(value);
-              __rscTotal += value.byteLength;
-            }
-            const __rscBuf = new Uint8Array(__rscTotal);
-            let __rscOff = 0;
-            for (const c of __rscChunks) { __rscBuf.set(c, __rscOff); __rscOff += c.byteLength; }
-            return __rscBuf.buffer;
-          })();
+          const __revalRscCapture = __teeAppPageRscStreamForCapture(__revalRscStream, true);
           const __revalFontData = { links: _getSSRFontLinks(), styles: _getSSRFontStyles(), preloads: _getSSRFontPreloads() };
           const __revalSsrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
-          const __revalHtmlStream = await __revalSsrEntry.handleSsr(__revalRscForSsr, _getNavigationContext(), __revalFontData);
+          const __revalHtmlStream = await __revalSsrEntry.handleSsr(
+            __revalRscCapture.responseStream,
+            _getNavigationContext(),
+            __revalFontData,
+          );
           setHeadersContext(null);
           setNavigationContext(null);
-          // Collect the full HTML string from the stream
-          const __revalReader = __revalHtmlStream.getReader();
-          const __revalDecoder = new TextDecoder();
-          const __revalChunks = [];
-          for (;;) {
-            const { done, value } = await __revalReader.read();
-            if (done) break;
-            __revalChunks.push(__revalDecoder.decode(value, { stream: true }));
-          }
-          __revalChunks.push(__revalDecoder.decode());
-          const __freshHtml = __revalChunks.join("");
-          const __freshRscData = await __rscDataPromise;
+          const __freshHtml = await __readAppPageTextStream(__revalHtmlStream);
+          const __freshRscData = await __revalRscCapture.capturedRscDataPromise;
           const __pageTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
           return { html: __freshHtml, rscData: __freshRscData, tags: __pageTags };
         });
@@ -12845,26 +12596,21 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   try {
     element = await buildPageElement(route, params, interceptOpts, url.searchParams);
   } catch (buildErr) {
-    // Check for redirect/notFound/forbidden/unauthorized thrown during metadata resolution or async components
-    if (buildErr && typeof buildErr === "object" && "digest" in buildErr) {
-      const digest = String(buildErr.digest);
-      if (digest.startsWith("NEXT_REDIRECT;")) {
-        const parts = digest.split(";");
-        const redirectUrl = decodeURIComponent(parts[2]);
-        const statusCode = parts[3] ? parseInt(parts[3], 10) : 307;
-        setHeadersContext(null);
-        setNavigationContext(null);
-        return Response.redirect(new URL(redirectUrl, request.url), statusCode);
-      }
-      if (digest === "NEXT_NOT_FOUND" || digest.startsWith("NEXT_HTTP_ERROR_FALLBACK;")) {
-        const statusCode = digest === "NEXT_NOT_FOUND" ? 404 : parseInt(digest.split(";")[1], 10);
-        const fallbackResp = await renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, { matchedParams: params });
-        if (fallbackResp) return fallbackResp;
-        setHeadersContext(null);
-        setNavigationContext(null);
-        const statusText = statusCode === 403 ? "Forbidden" : statusCode === 401 ? "Unauthorized" : "Not Found";
-        return new Response(statusText, { status: statusCode });
-      }
+    const __buildSpecialError = __resolveAppPageSpecialError(buildErr);
+    if (__buildSpecialError) {
+      return __buildAppPageSpecialErrorResponse({
+        clearRequestContext() {
+          setHeadersContext(null);
+          setNavigationContext(null);
+        },
+        renderFallbackPage(statusCode) {
+          return renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, {
+            matchedParams: params,
+          });
+        },
+        requestUrl: request.url,
+        specialError: __buildSpecialError,
+      });
     }
     // Non-special error (e.g. generateMetadata() threw) — render error.tsx if available
     const errorBoundaryResp = await renderErrorBoundaryPage(route, buildErr, isRscRequest, request, params);
@@ -12877,25 +12623,21 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
 
   // Helper: check if an error is a redirect/notFound/forbidden/unauthorized thrown by the navigation shim
   async function handleRenderError(err) {
-    if (err && typeof err === "object" && "digest" in err) {
-      const digest = String(err.digest);
-      if (digest.startsWith("NEXT_REDIRECT;")) {
-        const parts = digest.split(";");
-        const redirectUrl = decodeURIComponent(parts[2]);
-        const statusCode = parts[3] ? parseInt(parts[3], 10) : 307;
-        setHeadersContext(null);
-        setNavigationContext(null);
-        return Response.redirect(new URL(redirectUrl, request.url), statusCode);
-      }
-      if (digest === "NEXT_NOT_FOUND" || digest.startsWith("NEXT_HTTP_ERROR_FALLBACK;")) {
-        const statusCode = digest === "NEXT_NOT_FOUND" ? 404 : parseInt(digest.split(";")[1], 10);
-        const fallbackResp = await renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, { matchedParams: params });
-        if (fallbackResp) return fallbackResp;
-        setHeadersContext(null);
-        setNavigationContext(null);
-        const statusText = statusCode === 403 ? "Forbidden" : statusCode === 401 ? "Unauthorized" : "Not Found";
-        return new Response(statusText, { status: statusCode });
-      }
+    const specialError = __resolveAppPageSpecialError(err);
+    if (specialError) {
+      return __buildAppPageSpecialErrorResponse({
+        clearRequestContext() {
+          setHeadersContext(null);
+          setNavigationContext(null);
+        },
+        renderFallbackPage(statusCode) {
+          return renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, {
+            matchedParams: params,
+          });
+        },
+        requestUrl: request.url,
+        specialError,
+      });
     }
     return null;
   }
@@ -12914,59 +12656,55 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // layouts itself throws notFound() during the fallback rendering (causing a 500).
   if (route.layouts && route.layouts.length > 0) {
     const asyncParams = makeThenableParams(params);
-    // Run inside ALS context so the module-level console.error patch suppresses
-    // "Invalid hook call" only for this request's probe — concurrent requests
-    // each have their own ALS store and are unaffected.
-    const _layoutProbeResult = await _suppressHookWarningAls.run(true, async () => {
-      for (let li = route.layouts.length - 1; li >= 0; li--) {
-        const LayoutComp = route.layouts[li]?.default;
-        if (!LayoutComp) continue;
-        try {
-          const lr = LayoutComp({ params: asyncParams, children: null });
-          if (lr && typeof lr === "object" && typeof lr.then === "function") await lr;
-        } catch (layoutErr) {
-          if (layoutErr && typeof layoutErr === "object" && "digest" in layoutErr) {
-            const digest = String(layoutErr.digest);
-             if (digest.startsWith("NEXT_REDIRECT;")) {
-               const parts = digest.split(";");
-               const redirectUrl = decodeURIComponent(parts[2]);
-               const statusCode = parts[3] ? parseInt(parts[3], 10) : 307;
-               setHeadersContext(null);
-               setNavigationContext(null);
-               return Response.redirect(new URL(redirectUrl, request.url), statusCode);
-            }
-            if (digest === "NEXT_NOT_FOUND" || digest.startsWith("NEXT_HTTP_ERROR_FALLBACK;")) {
-              const statusCode = digest === "NEXT_NOT_FOUND" ? 404 : parseInt(digest.split(";")[1], 10);
-              // Find the not-found component from the parent level (the boundary that
-              // would catch this in Next.js). Walk up from the throwing layout to find
-              // the nearest not-found at a parent layout's directory.
-              let parentNotFound = null;
-              if (route.notFounds) {
-                for (let pi = li - 1; pi >= 0; pi--) {
-                  if (route.notFounds[pi]?.default) {
-                    parentNotFound = route.notFounds[pi].default;
-                    break;
-                  }
+    const _layoutProbeResult = await __probeAppPageLayouts({
+      layoutCount: route.layouts.length,
+      async onLayoutError(layoutErr, li) {
+        const __layoutSpecialError = __resolveAppPageSpecialError(layoutErr);
+        if (!__layoutSpecialError) {
+          return null;
+        }
+
+        return __buildAppPageSpecialErrorResponse({
+          clearRequestContext() {
+            setHeadersContext(null);
+            setNavigationContext(null);
+          },
+          renderFallbackPage(statusCode) {
+            // Find the not-found component from the parent level (the boundary that
+            // would catch this in Next.js). Walk up from the throwing layout to find
+            // the nearest not-found at a parent layout's directory.
+            let parentNotFound = null;
+            if (route.notFounds) {
+              for (let pi = li - 1; pi >= 0; pi--) {
+                if (route.notFounds[pi]?.default) {
+                  parentNotFound = route.notFounds[pi].default;
+                  break;
                 }
               }
-              if (!parentNotFound) parentNotFound = null;
-              // Wrap in only the layouts above the throwing one
-              const parentLayouts = route.layouts.slice(0, li);
-              const fallbackResp = await renderHTTPAccessFallbackPage(
-                route, statusCode, isRscRequest, request,
-                { boundaryComponent: parentNotFound, layouts: parentLayouts, matchedParams: params }
-              );
-              if (fallbackResp) return fallbackResp;
-              setHeadersContext(null);
-              setNavigationContext(null);
-              const statusText = statusCode === 403 ? "Forbidden" : statusCode === 401 ? "Unauthorized" : "Not Found";
-              return new Response(statusText, { status: statusCode });
             }
-          }
-          // Not a special error — let it propagate through normal RSC rendering
-        }
-      }
-      return null;
+            if (!parentNotFound) parentNotFound = null;
+            const parentLayouts = route.layouts.slice(0, li);
+            return renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, {
+              boundaryComponent: parentNotFound,
+              layouts: parentLayouts,
+              matchedParams: params,
+            });
+          },
+          requestUrl: request.url,
+          specialError: __layoutSpecialError,
+        });
+      },
+      probeLayoutAt(li) {
+        const LayoutComp = route.layouts[li]?.default;
+        if (!LayoutComp) return null;
+        return LayoutComp({ params: asyncParams, children: null });
+      },
+      runWithSuppressedHookWarning(probe) {
+        // Run inside ALS context so the module-level console.error patch suppresses
+        // "Invalid hook call" only for this request's probe — concurrent requests
+        // each have their own ALS store and are unaffected.
+        return _suppressHookWarningAls.run(true, probe);
+      },
     });
     if (_layoutProbeResult instanceof Response) return _layoutProbeResult;
   }
@@ -12984,30 +12722,23 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // trigger "Invalid hook call" console.error in dev. The module-level ALS patch
   // suppresses the warning only within this request's execution context.
   const _hasLoadingBoundary = !!(route.loading && route.loading.default);
-  const _pageProbeResult = await _suppressHookWarningAls.run(true, async () => {
-    try {
-      const testResult = PageComponent({ params });
-      // If it's a promise (async component), only await if there's no loading boundary.
-      // With a loading boundary, the Suspense streaming pipeline handles async resolution
-      // and any redirect/notFound errors via rscOnError.
-      if (testResult && typeof testResult === "object" && typeof testResult.then === "function") {
-        if (!_hasLoadingBoundary) {
-          await testResult;
-        } else {
-          // Suppress unhandled promise rejection — with a loading boundary,
-          // redirect/notFound errors are handled by rscOnError during streaming.
-          testResult.catch(() => {});
-        }
-      }
-    } catch (preRenderErr) {
+  const _pageProbeResult = await __probeAppPageComponent({
+    awaitAsyncResult: !_hasLoadingBoundary,
+    async onError(preRenderErr) {
       const specialResponse = await handleRenderError(preRenderErr);
       if (specialResponse) return specialResponse;
       // Non-special errors from the pre-render test are expected (e.g. use() hook
       // fails outside React's render cycle, client references can't execute on server).
       // Only redirect/notFound/forbidden/unauthorized are actionable here — other
       // errors will be properly caught during actual RSC/SSR rendering below.
-    }
-    return null;
+      return null;
+    },
+    probePage() {
+      return PageComponent({ params });
+    },
+    runWithSuppressedHookWarning(probe) {
+      return _suppressHookWarningAls.run(true, probe);
+    },
   });
   if (_pageProbeResult instanceof Response) return _pageProbeResult;
 
@@ -13034,27 +12765,16 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // paths can use the captured bytes when writing to the ISR cache.
   //   __rscForResponse  → sent to the client (RSC response) or to SSR (HTML response)
   //   __isrRscDataPromise → resolves to ArrayBuffer of captured RSC wire bytes
-  let __rscForResponse = rscStream;
-  let __isrRscDataPromise = null;
-  if (process.env.NODE_ENV === "production" && revalidateSeconds !== null && revalidateSeconds > 0 && revalidateSeconds !== Infinity && !isForceDynamic) {
-    const [__rscA, __rscB] = rscStream.tee();
-    __rscForResponse = __rscA;
-    __isrRscDataPromise = (async () => {
-      const __rscReader = __rscB.getReader();
-      const __rscChunks = [];
-      let __rscTotal = 0;
-      for (;;) {
-        const { done, value } = await __rscReader.read();
-        if (done) break;
-        __rscChunks.push(value);
-        __rscTotal += value.byteLength;
-      }
-      const __rscBuf = new Uint8Array(__rscTotal);
-      let __rscOff = 0;
-      for (const c of __rscChunks) { __rscBuf.set(c, __rscOff); __rscOff += c.byteLength; }
-      return __rscBuf.buffer;
-    })();
-  }
+  const __rscCapture = __teeAppPageRscStreamForCapture(
+    rscStream,
+    process.env.NODE_ENV === "production" &&
+      revalidateSeconds !== null &&
+      revalidateSeconds > 0 &&
+      revalidateSeconds !== Infinity &&
+      !isForceDynamic,
+  );
+  const __rscForResponse = __rscCapture.responseStream;
+  const __isrRscDataPromise = __rscCapture.capturedRscDataPromise;
 
   if (isRscRequest) {
     // Direct RSC stream response (for client-side navigation)
@@ -13116,12 +12836,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // Build HTTP Link header for font preloading.
   // This lets the browser (and CDN) start fetching font files before parsing HTML,
   // eliminating the CSS → woff2 download waterfall.
-  const fontPreloads = fontData.preloads || [];
-  const fontLinkHeaderParts = [];
-  for (const preload of fontPreloads) {
-    fontLinkHeaderParts.push("<" + preload.href + ">; rel=preload; as=font; type=" + preload.type + "; crossorigin");
-  }
-  const fontLinkHeader = fontLinkHeaderParts.length > 0 ? fontLinkHeaderParts.join(", ") : "";
+  const fontLinkHeader = __buildAppPageFontLinkHeader(fontData.preloads);
 
   // __rscForResponse was already teed above (before isRscRequest) for ISR pages in
   // production. For non-ISR or dev, __rscForResponse === rscStream (no tee).
@@ -13303,6 +13018,15 @@ import {
   resolveAppPageHtmlResponsePolicy as __resolveAppPageHtmlResponsePolicy,
   resolveAppPageRscResponsePolicy as __resolveAppPageRscResponsePolicy,
 } from "<ROOT>/packages/vinext/src/server/app-page-response.js";
+import {
+  buildAppPageFontLinkHeader as __buildAppPageFontLinkHeader,
+  buildAppPageSpecialErrorResponse as __buildAppPageSpecialErrorResponse,
+  probeAppPageComponent as __probeAppPageComponent,
+  probeAppPageLayouts as __probeAppPageLayouts,
+  readAppPageTextStream as __readAppPageTextStream,
+  resolveAppPageSpecialError as __resolveAppPageSpecialError,
+  teeAppPageRscStreamForCapture as __teeAppPageRscStreamForCapture,
+} from "<ROOT>/packages/vinext/src/server/app-page-execution.js";
 import {
   applyRouteHandlerMiddlewareContext as __applyRouteHandlerMiddlewareContext,
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-response.js";
@@ -13511,15 +13235,8 @@ function __errorDigest(str) {
 // unchanged since their digests are used for client-side routing.
 function __sanitizeErrorForClient(error) {
   // Navigation errors must pass through with their digest intact
-  if (error && typeof error === "object" && "digest" in error) {
-    const digest = String(error.digest);
-    if (
-      digest.startsWith("NEXT_REDIRECT;") ||
-      digest === "NEXT_NOT_FOUND" ||
-      digest.startsWith("NEXT_HTTP_ERROR_FALLBACK;")
-    ) {
-      return error;
-    }
+  if (__resolveAppPageSpecialError(error)) {
+    return error;
   }
   // In development, pass through the original error for debugging
   if (process.env.NODE_ENV !== "production") {
@@ -13864,8 +13581,8 @@ async function renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, req
   setHeadersContext(null);
   setNavigationContext(null);
   const _respHeaders = { "Content-Type": "text/html; charset=utf-8", "Vary": "RSC, Accept" };
-  const _linkParts = (fontData.preloads || []).map(function(p) { return "<" + p.href + ">; rel=preload; as=font; type=" + p.type + "; crossorigin"; });
-  if (_linkParts.length > 0) _respHeaders["Link"] = _linkParts.join(", ");
+  const _fontLinkHeader = __buildAppPageFontLinkHeader(fontData.preloads);
+  if (_fontLinkHeader) _respHeaders["Link"] = _fontLinkHeader;
   return new Response(htmlStream, {
     status: statusCode,
     headers: _respHeaders,
@@ -13983,8 +13700,8 @@ async function renderErrorBoundaryPage(route, error, isRscRequest, request, matc
   setHeadersContext(null);
   setNavigationContext(null);
   const _errHeaders = { "Content-Type": "text/html; charset=utf-8", "Vary": "RSC, Accept" };
-  const _errLinkParts = (fontData.preloads || []).map(function(p) { return "<" + p.href + ">; rel=preload; as=font; type=" + p.type + "; crossorigin"; });
-  if (_errLinkParts.length > 0) _errHeaders["Link"] = _errLinkParts.join(", ");
+  const _errFontLinkHeader = __buildAppPageFontLinkHeader(fontData.preloads);
+  if (_errFontLinkHeader) _errHeaders["Link"] = _errFontLinkHeader;
   return new Response(htmlStream, {
     status: 200,
     headers: _errHeaders,
@@ -15708,41 +15425,18 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           const __revalElement = await buildPageElement(route, params, undefined, new URLSearchParams());
           const __revalOnError = createRscOnErrorHandler(request, cleanPathname, route.pattern);
           const __revalRscStream = renderToReadableStream(__revalElement, { onError: __revalOnError });
-          // Tee RSC stream: one for SSR, one to capture rscData
-          const [__revalRscForSsr, __revalRscForCapture] = __revalRscStream.tee();
-          // Capture rscData bytes in parallel with SSR
-          const __rscDataPromise = (async () => {
-            const __rscReader = __revalRscForCapture.getReader();
-            const __rscChunks = [];
-            let __rscTotal = 0;
-            for (;;) {
-              const { done, value } = await __rscReader.read();
-              if (done) break;
-              __rscChunks.push(value);
-              __rscTotal += value.byteLength;
-            }
-            const __rscBuf = new Uint8Array(__rscTotal);
-            let __rscOff = 0;
-            for (const c of __rscChunks) { __rscBuf.set(c, __rscOff); __rscOff += c.byteLength; }
-            return __rscBuf.buffer;
-          })();
+          const __revalRscCapture = __teeAppPageRscStreamForCapture(__revalRscStream, true);
           const __revalFontData = { links: _getSSRFontLinks(), styles: _getSSRFontStyles(), preloads: _getSSRFontPreloads() };
           const __revalSsrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
-          const __revalHtmlStream = await __revalSsrEntry.handleSsr(__revalRscForSsr, _getNavigationContext(), __revalFontData);
+          const __revalHtmlStream = await __revalSsrEntry.handleSsr(
+            __revalRscCapture.responseStream,
+            _getNavigationContext(),
+            __revalFontData,
+          );
           setHeadersContext(null);
           setNavigationContext(null);
-          // Collect the full HTML string from the stream
-          const __revalReader = __revalHtmlStream.getReader();
-          const __revalDecoder = new TextDecoder();
-          const __revalChunks = [];
-          for (;;) {
-            const { done, value } = await __revalReader.read();
-            if (done) break;
-            __revalChunks.push(__revalDecoder.decode(value, { stream: true }));
-          }
-          __revalChunks.push(__revalDecoder.decode());
-          const __freshHtml = __revalChunks.join("");
-          const __freshRscData = await __rscDataPromise;
+          const __freshHtml = await __readAppPageTextStream(__revalHtmlStream);
+          const __freshRscData = await __revalRscCapture.capturedRscDataPromise;
           const __pageTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
           return { html: __freshHtml, rscData: __freshRscData, tags: __pageTags };
         });
@@ -15834,26 +15528,21 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   try {
     element = await buildPageElement(route, params, interceptOpts, url.searchParams);
   } catch (buildErr) {
-    // Check for redirect/notFound/forbidden/unauthorized thrown during metadata resolution or async components
-    if (buildErr && typeof buildErr === "object" && "digest" in buildErr) {
-      const digest = String(buildErr.digest);
-      if (digest.startsWith("NEXT_REDIRECT;")) {
-        const parts = digest.split(";");
-        const redirectUrl = decodeURIComponent(parts[2]);
-        const statusCode = parts[3] ? parseInt(parts[3], 10) : 307;
-        setHeadersContext(null);
-        setNavigationContext(null);
-        return Response.redirect(new URL(redirectUrl, request.url), statusCode);
-      }
-      if (digest === "NEXT_NOT_FOUND" || digest.startsWith("NEXT_HTTP_ERROR_FALLBACK;")) {
-        const statusCode = digest === "NEXT_NOT_FOUND" ? 404 : parseInt(digest.split(";")[1], 10);
-        const fallbackResp = await renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, { matchedParams: params });
-        if (fallbackResp) return fallbackResp;
-        setHeadersContext(null);
-        setNavigationContext(null);
-        const statusText = statusCode === 403 ? "Forbidden" : statusCode === 401 ? "Unauthorized" : "Not Found";
-        return new Response(statusText, { status: statusCode });
-      }
+    const __buildSpecialError = __resolveAppPageSpecialError(buildErr);
+    if (__buildSpecialError) {
+      return __buildAppPageSpecialErrorResponse({
+        clearRequestContext() {
+          setHeadersContext(null);
+          setNavigationContext(null);
+        },
+        renderFallbackPage(statusCode) {
+          return renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, {
+            matchedParams: params,
+          });
+        },
+        requestUrl: request.url,
+        specialError: __buildSpecialError,
+      });
     }
     // Non-special error (e.g. generateMetadata() threw) — render error.tsx if available
     const errorBoundaryResp = await renderErrorBoundaryPage(route, buildErr, isRscRequest, request, params);
@@ -15866,25 +15555,21 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
 
   // Helper: check if an error is a redirect/notFound/forbidden/unauthorized thrown by the navigation shim
   async function handleRenderError(err) {
-    if (err && typeof err === "object" && "digest" in err) {
-      const digest = String(err.digest);
-      if (digest.startsWith("NEXT_REDIRECT;")) {
-        const parts = digest.split(";");
-        const redirectUrl = decodeURIComponent(parts[2]);
-        const statusCode = parts[3] ? parseInt(parts[3], 10) : 307;
-        setHeadersContext(null);
-        setNavigationContext(null);
-        return Response.redirect(new URL(redirectUrl, request.url), statusCode);
-      }
-      if (digest === "NEXT_NOT_FOUND" || digest.startsWith("NEXT_HTTP_ERROR_FALLBACK;")) {
-        const statusCode = digest === "NEXT_NOT_FOUND" ? 404 : parseInt(digest.split(";")[1], 10);
-        const fallbackResp = await renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, { matchedParams: params });
-        if (fallbackResp) return fallbackResp;
-        setHeadersContext(null);
-        setNavigationContext(null);
-        const statusText = statusCode === 403 ? "Forbidden" : statusCode === 401 ? "Unauthorized" : "Not Found";
-        return new Response(statusText, { status: statusCode });
-      }
+    const specialError = __resolveAppPageSpecialError(err);
+    if (specialError) {
+      return __buildAppPageSpecialErrorResponse({
+        clearRequestContext() {
+          setHeadersContext(null);
+          setNavigationContext(null);
+        },
+        renderFallbackPage(statusCode) {
+          return renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, {
+            matchedParams: params,
+          });
+        },
+        requestUrl: request.url,
+        specialError,
+      });
     }
     return null;
   }
@@ -15903,59 +15588,55 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // layouts itself throws notFound() during the fallback rendering (causing a 500).
   if (route.layouts && route.layouts.length > 0) {
     const asyncParams = makeThenableParams(params);
-    // Run inside ALS context so the module-level console.error patch suppresses
-    // "Invalid hook call" only for this request's probe — concurrent requests
-    // each have their own ALS store and are unaffected.
-    const _layoutProbeResult = await _suppressHookWarningAls.run(true, async () => {
-      for (let li = route.layouts.length - 1; li >= 0; li--) {
-        const LayoutComp = route.layouts[li]?.default;
-        if (!LayoutComp) continue;
-        try {
-          const lr = LayoutComp({ params: asyncParams, children: null });
-          if (lr && typeof lr === "object" && typeof lr.then === "function") await lr;
-        } catch (layoutErr) {
-          if (layoutErr && typeof layoutErr === "object" && "digest" in layoutErr) {
-            const digest = String(layoutErr.digest);
-             if (digest.startsWith("NEXT_REDIRECT;")) {
-               const parts = digest.split(";");
-               const redirectUrl = decodeURIComponent(parts[2]);
-               const statusCode = parts[3] ? parseInt(parts[3], 10) : 307;
-               setHeadersContext(null);
-               setNavigationContext(null);
-               return Response.redirect(new URL(redirectUrl, request.url), statusCode);
-            }
-            if (digest === "NEXT_NOT_FOUND" || digest.startsWith("NEXT_HTTP_ERROR_FALLBACK;")) {
-              const statusCode = digest === "NEXT_NOT_FOUND" ? 404 : parseInt(digest.split(";")[1], 10);
-              // Find the not-found component from the parent level (the boundary that
-              // would catch this in Next.js). Walk up from the throwing layout to find
-              // the nearest not-found at a parent layout's directory.
-              let parentNotFound = null;
-              if (route.notFounds) {
-                for (let pi = li - 1; pi >= 0; pi--) {
-                  if (route.notFounds[pi]?.default) {
-                    parentNotFound = route.notFounds[pi].default;
-                    break;
-                  }
+    const _layoutProbeResult = await __probeAppPageLayouts({
+      layoutCount: route.layouts.length,
+      async onLayoutError(layoutErr, li) {
+        const __layoutSpecialError = __resolveAppPageSpecialError(layoutErr);
+        if (!__layoutSpecialError) {
+          return null;
+        }
+
+        return __buildAppPageSpecialErrorResponse({
+          clearRequestContext() {
+            setHeadersContext(null);
+            setNavigationContext(null);
+          },
+          renderFallbackPage(statusCode) {
+            // Find the not-found component from the parent level (the boundary that
+            // would catch this in Next.js). Walk up from the throwing layout to find
+            // the nearest not-found at a parent layout's directory.
+            let parentNotFound = null;
+            if (route.notFounds) {
+              for (let pi = li - 1; pi >= 0; pi--) {
+                if (route.notFounds[pi]?.default) {
+                  parentNotFound = route.notFounds[pi].default;
+                  break;
                 }
               }
-              if (!parentNotFound) parentNotFound = null;
-              // Wrap in only the layouts above the throwing one
-              const parentLayouts = route.layouts.slice(0, li);
-              const fallbackResp = await renderHTTPAccessFallbackPage(
-                route, statusCode, isRscRequest, request,
-                { boundaryComponent: parentNotFound, layouts: parentLayouts, matchedParams: params }
-              );
-              if (fallbackResp) return fallbackResp;
-              setHeadersContext(null);
-              setNavigationContext(null);
-              const statusText = statusCode === 403 ? "Forbidden" : statusCode === 401 ? "Unauthorized" : "Not Found";
-              return new Response(statusText, { status: statusCode });
             }
-          }
-          // Not a special error — let it propagate through normal RSC rendering
-        }
-      }
-      return null;
+            if (!parentNotFound) parentNotFound = null;
+            const parentLayouts = route.layouts.slice(0, li);
+            return renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, {
+              boundaryComponent: parentNotFound,
+              layouts: parentLayouts,
+              matchedParams: params,
+            });
+          },
+          requestUrl: request.url,
+          specialError: __layoutSpecialError,
+        });
+      },
+      probeLayoutAt(li) {
+        const LayoutComp = route.layouts[li]?.default;
+        if (!LayoutComp) return null;
+        return LayoutComp({ params: asyncParams, children: null });
+      },
+      runWithSuppressedHookWarning(probe) {
+        // Run inside ALS context so the module-level console.error patch suppresses
+        // "Invalid hook call" only for this request's probe — concurrent requests
+        // each have their own ALS store and are unaffected.
+        return _suppressHookWarningAls.run(true, probe);
+      },
     });
     if (_layoutProbeResult instanceof Response) return _layoutProbeResult;
   }
@@ -15973,30 +15654,23 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // trigger "Invalid hook call" console.error in dev. The module-level ALS patch
   // suppresses the warning only within this request's execution context.
   const _hasLoadingBoundary = !!(route.loading && route.loading.default);
-  const _pageProbeResult = await _suppressHookWarningAls.run(true, async () => {
-    try {
-      const testResult = PageComponent({ params });
-      // If it's a promise (async component), only await if there's no loading boundary.
-      // With a loading boundary, the Suspense streaming pipeline handles async resolution
-      // and any redirect/notFound errors via rscOnError.
-      if (testResult && typeof testResult === "object" && typeof testResult.then === "function") {
-        if (!_hasLoadingBoundary) {
-          await testResult;
-        } else {
-          // Suppress unhandled promise rejection — with a loading boundary,
-          // redirect/notFound errors are handled by rscOnError during streaming.
-          testResult.catch(() => {});
-        }
-      }
-    } catch (preRenderErr) {
+  const _pageProbeResult = await __probeAppPageComponent({
+    awaitAsyncResult: !_hasLoadingBoundary,
+    async onError(preRenderErr) {
       const specialResponse = await handleRenderError(preRenderErr);
       if (specialResponse) return specialResponse;
       // Non-special errors from the pre-render test are expected (e.g. use() hook
       // fails outside React's render cycle, client references can't execute on server).
       // Only redirect/notFound/forbidden/unauthorized are actionable here — other
       // errors will be properly caught during actual RSC/SSR rendering below.
-    }
-    return null;
+      return null;
+    },
+    probePage() {
+      return PageComponent({ params });
+    },
+    runWithSuppressedHookWarning(probe) {
+      return _suppressHookWarningAls.run(true, probe);
+    },
   });
   if (_pageProbeResult instanceof Response) return _pageProbeResult;
 
@@ -16023,27 +15697,16 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // paths can use the captured bytes when writing to the ISR cache.
   //   __rscForResponse  → sent to the client (RSC response) or to SSR (HTML response)
   //   __isrRscDataPromise → resolves to ArrayBuffer of captured RSC wire bytes
-  let __rscForResponse = rscStream;
-  let __isrRscDataPromise = null;
-  if (process.env.NODE_ENV === "production" && revalidateSeconds !== null && revalidateSeconds > 0 && revalidateSeconds !== Infinity && !isForceDynamic) {
-    const [__rscA, __rscB] = rscStream.tee();
-    __rscForResponse = __rscA;
-    __isrRscDataPromise = (async () => {
-      const __rscReader = __rscB.getReader();
-      const __rscChunks = [];
-      let __rscTotal = 0;
-      for (;;) {
-        const { done, value } = await __rscReader.read();
-        if (done) break;
-        __rscChunks.push(value);
-        __rscTotal += value.byteLength;
-      }
-      const __rscBuf = new Uint8Array(__rscTotal);
-      let __rscOff = 0;
-      for (const c of __rscChunks) { __rscBuf.set(c, __rscOff); __rscOff += c.byteLength; }
-      return __rscBuf.buffer;
-    })();
-  }
+  const __rscCapture = __teeAppPageRscStreamForCapture(
+    rscStream,
+    process.env.NODE_ENV === "production" &&
+      revalidateSeconds !== null &&
+      revalidateSeconds > 0 &&
+      revalidateSeconds !== Infinity &&
+      !isForceDynamic,
+  );
+  const __rscForResponse = __rscCapture.responseStream;
+  const __isrRscDataPromise = __rscCapture.capturedRscDataPromise;
 
   if (isRscRequest) {
     // Direct RSC stream response (for client-side navigation)
@@ -16105,12 +15768,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // Build HTTP Link header for font preloading.
   // This lets the browser (and CDN) start fetching font files before parsing HTML,
   // eliminating the CSS → woff2 download waterfall.
-  const fontPreloads = fontData.preloads || [];
-  const fontLinkHeaderParts = [];
-  for (const preload of fontPreloads) {
-    fontLinkHeaderParts.push("<" + preload.href + ">; rel=preload; as=font; type=" + preload.type + "; crossorigin");
-  }
-  const fontLinkHeader = fontLinkHeaderParts.length > 0 ? fontLinkHeaderParts.join(", ") : "";
+  const fontLinkHeader = __buildAppPageFontLinkHeader(fontData.preloads);
 
   // __rscForResponse was already teed above (before isRscRequest) for ISR pages in
   // production. For non-ISR or dev, __rscForResponse === rscStream (no tee).

--- a/tests/app-page-execution.test.ts
+++ b/tests/app-page-execution.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+import {
+  buildAppPageFontLinkHeader,
+  buildAppPageSpecialErrorResponse,
+  probeAppPageComponent,
+  probeAppPageLayouts,
+  readAppPageTextStream,
+  resolveAppPageSpecialError,
+  teeAppPageRscStreamForCapture,
+} from "../packages/vinext/src/server/app-page-execution.js";
+
+function createStream(chunks: string[]): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(new TextEncoder().encode(chunk));
+      }
+      controller.close();
+    },
+  });
+}
+
+describe("app page execution helpers", () => {
+  it("parses redirect and access-fallback digests", () => {
+    expect(
+      resolveAppPageSpecialError({
+        digest: "NEXT_REDIRECT;replace;%2Fredirected;308",
+      }),
+    ).toEqual({
+      kind: "redirect",
+      location: "/redirected",
+      statusCode: 308,
+    });
+
+    expect(
+      resolveAppPageSpecialError({
+        digest: "NEXT_HTTP_ERROR_FALLBACK;403",
+      }),
+    ).toEqual({
+      kind: "http-access-fallback",
+      statusCode: 403,
+    });
+
+    expect(resolveAppPageSpecialError({ digest: "not-special" })).toBeNull();
+  });
+
+  it("builds redirect and fallback responses while preserving fallback context behavior", async () => {
+    const clearRequestContext = vi.fn();
+
+    const redirectResponse = await buildAppPageSpecialErrorResponse({
+      clearRequestContext,
+      requestUrl: "https://example.com/start",
+      specialError: {
+        kind: "redirect",
+        location: "/redirected",
+        statusCode: 307,
+      },
+    });
+
+    expect(redirectResponse.status).toBe(307);
+    expect(redirectResponse.headers.get("location")).toBe("https://example.com/redirected");
+    expect(clearRequestContext).toHaveBeenCalledTimes(1);
+
+    clearRequestContext.mockClear();
+
+    const fallbackResponse = await buildAppPageSpecialErrorResponse({
+      clearRequestContext,
+      renderFallbackPage(statusCode) {
+        return Promise.resolve(new Response(`fallback:${statusCode}`, { status: statusCode }));
+      },
+      requestUrl: "https://example.com/start",
+      specialError: {
+        kind: "http-access-fallback",
+        statusCode: 404,
+      },
+    });
+
+    expect(fallbackResponse.status).toBe(404);
+    await expect(fallbackResponse.text()).resolves.toBe("fallback:404");
+    expect(clearRequestContext).not.toHaveBeenCalled();
+  });
+
+  it("falls back to a plain status response when no fallback page is available", async () => {
+    const clearRequestContext = vi.fn();
+
+    const response = await buildAppPageSpecialErrorResponse({
+      clearRequestContext,
+      renderFallbackPage() {
+        return Promise.resolve(null);
+      },
+      requestUrl: "https://example.com/start",
+      specialError: {
+        kind: "http-access-fallback",
+        statusCode: 401,
+      },
+    });
+
+    expect(response.status).toBe(401);
+    await expect(response.text()).resolves.toBe("Unauthorized");
+    expect(clearRequestContext).toHaveBeenCalledTimes(1);
+  });
+
+  it("probes layouts from inner to outer and stops on a handled special response", async () => {
+    const probedLayouts: number[] = [];
+
+    const response = await probeAppPageLayouts({
+      layoutCount: 3,
+      async onLayoutError(error, layoutIndex) {
+        expect(error).toBeInstanceOf(Error);
+        return layoutIndex === 1 ? new Response("layout-fallback", { status: 404 }) : null;
+      },
+      probeLayoutAt(layoutIndex) {
+        probedLayouts.push(layoutIndex);
+        if (layoutIndex === 1) {
+          throw new Error("layout failed");
+        }
+        return null;
+      },
+      runWithSuppressedHookWarning(probe) {
+        return probe();
+      },
+    });
+
+    expect(probedLayouts).toEqual([2, 1]);
+    expect(response?.status).toBe(404);
+    await expect(response?.text()).resolves.toBe("layout-fallback");
+  });
+
+  it("does not await async page probes when a loading boundary is present", async () => {
+    const onError = vi.fn();
+
+    const response = await probeAppPageComponent({
+      awaitAsyncResult: false,
+      onError,
+      probePage() {
+        return new Promise<void>(() => {});
+      },
+      runWithSuppressedHookWarning(probe) {
+        return probe();
+      },
+    });
+
+    expect(response).toBeNull();
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("reads streamed text and captures RSC bytes when teeing the response stream", async () => {
+    const capture = teeAppPageRscStreamForCapture(createStream(["flight-", "chunk"]), true);
+
+    await expect(readAppPageTextStream(capture.responseStream)).resolves.toBe("flight-chunk");
+    const captured = await capture.capturedRscDataPromise;
+    expect(new TextDecoder().decode(captured ? new Uint8Array(captured) : undefined)).toBe(
+      "flight-chunk",
+    );
+  });
+
+  it("builds Link headers for preloaded app-page fonts", () => {
+    expect(
+      buildAppPageFontLinkHeader([
+        { href: "/font-a.woff2", type: "font/woff2" },
+        { href: "/font-b.woff2", type: "font/woff2" },
+      ]),
+    ).toBe(
+      "</font-a.woff2>; rel=preload; as=font; type=font/woff2; crossorigin, </font-b.woff2>; rel=preload; as=font; type=font/woff2; crossorigin",
+    );
+  });
+});

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -3674,6 +3674,16 @@ describe("generateRscEntry ISR code generation", () => {
     expect(code).toContain("resolveAppPageRscResponsePolicy as __resolveAppPageRscResponsePolicy");
   });
 
+  it("generated code delegates page probes and special-error handling to typed helpers", () => {
+    const code = generateRscEntry("/tmp/test/app", minimalRoutes);
+    expect(code).toContain("probeAppPageLayouts as __probeAppPageLayouts");
+    expect(code).toContain("probeAppPageComponent as __probeAppPageComponent");
+    expect(code).toContain("resolveAppPageSpecialError as __resolveAppPageSpecialError");
+    expect(code).toContain(
+      "buildAppPageSpecialErrorResponse as __buildAppPageSpecialErrorResponse",
+    );
+  });
+
   it("generated code delegates page cache HIT handling to a typed helper", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes);
     expect(code).toContain("readAppPageCacheResponse as __readAppPageCacheResponse");
@@ -3692,13 +3702,12 @@ describe("generateRscEntry ISR code generation", () => {
     expect(code).toContain("_getRequestExecutionContext()?.waitUntil");
   });
 
-  it("generated code tees the RSC stream to capture rscData for cache", () => {
+  it("generated code delegates page RSC capture and streamed text collection to typed helpers", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes);
-    // There must be at least two .tee() calls:
-    //  1) RSC stream tee (before SSR) to capture rscData
-    //  2) HTML response stream tee (to collect html while streaming to client)
-    const teeCount = (code.match(/\.tee\(\)/g) || []).length;
-    expect(teeCount).toBeGreaterThanOrEqual(2);
+    expect(code).toContain("teeAppPageRscStreamForCapture as __teeAppPageRscStreamForCapture");
+    expect(code).toContain("readAppPageTextStream as __readAppPageTextStream");
+    expect(code).toContain("const __revalRscCapture = __teeAppPageRscStreamForCapture(");
+    expect(code).toContain("const __rscCapture = __teeAppPageRscStreamForCapture(");
   });
 
   it("generated code stores rscData in the ISR cache entry", () => {
@@ -3763,10 +3772,9 @@ describe("generateRscEntry ISR code generation", () => {
 
   it("RSC stream tee for rscData capture happens before the RSC response is returned", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes);
-    // __rscForResponse must be assigned before the RSC response is returned so
-    // the tee branch (__rscB) is also consumed (populating the ISR cache).
-    // The RSC response is now built via the typed page-response helper.
-    const teeAssignIdx = code.indexOf("let __rscForResponse");
+    // The RSC capture helper must run before the RSC response is returned so the
+    // captured branch can populate the ISR cache while the response streams.
+    const teeAssignIdx = code.indexOf("const __rscCapture = __teeAppPageRscStreamForCapture(");
     const rscResponseIdx = code.indexOf("const __rscResponse = __buildAppPageRscResponse(");
     expect(teeAssignIdx).toBeGreaterThan(-1);
     expect(rscResponseIdx).toBeGreaterThan(-1);


### PR DESCRIPTION
## Summary
- continue hollowing out `app-rsc-entry.ts` by moving page probe, special-error, font-link, and RSC capture utilities into a real typed runtime module
- wire the App Router RSC entry through `app-page-execution.ts` for build errors, layout/page probes, background regeneration capture, and shared font-link generation
- add focused unit coverage for the new helper layer and update generated-entry assertions/snapshots

## Testing
- `vp check packages/vinext/src/server/app-page-execution.ts packages/vinext/src/entries/app-rsc-entry.ts tests/app-page-execution.test.ts tests/app-router.test.ts`
- `vp test run tests/app-page-execution.test.ts tests/app-router.test.ts -t "generated code|page ISR \+ searchParams|app page execution helpers"`
- `vp test run tests/entry-templates.test.ts -u`
- `vp test run tests/app-page-execution.test.ts tests/app-page-cache.test.ts tests/app-page-response.test.ts`
- `vp run vinext#build`

Written by Codex.