### PR TITLE
refactor: extract app page stream helpers

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -59,6 +59,9 @@ const appPageResponsePath = fileURLToPath(
 const appPageExecutionPath = fileURLToPath(
   new URL("../server/app-page-execution.js", import.meta.url),
 ).replace(/\\/g, "/");
+const appPageStreamPath = fileURLToPath(
+  new URL("../server/app-page-stream.js", import.meta.url),
+).replace(/\\/g, "/");
 const appRouteHandlerResponsePath = fileURLToPath(
   new URL("../server/app-route-handler-response.js", import.meta.url),
 ).replace(/\\/g, "/");
@@ -385,6 +388,13 @@ import {
   resolveAppPageSpecialError as __resolveAppPageSpecialError,
   teeAppPageRscStreamForCapture as __teeAppPageRscStreamForCapture,
 } from ${JSON.stringify(appPageExecutionPath)};
+import {
+  createAppPageFontData as __createAppPageFontData,
+  createAppPageRscErrorTracker as __createAppPageRscErrorTracker,
+  renderAppPageHtmlResponse as __renderAppPageHtmlResponse,
+  renderAppPageHtmlStream as __renderAppPageHtmlStream,
+  shouldRerenderAppPageWithGlobalError as __shouldRerenderAppPageWithGlobalError,
+} from ${JSON.stringify(appPageStreamPath)};
 import {
   applyRouteHandlerMiddlewareContext as __applyRouteHandlerMiddlewareContext,
 } from ${JSON.stringify(appRouteHandlerResponsePath)};
@@ -877,22 +887,23 @@ async function renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, req
     route?.pattern ?? _pathname,
   );
   const rscStream = renderToReadableStream(element, { onError: onRenderError });
-  // Collect font data from RSC environment
-  const fontData = {
-    links: _getSSRFontLinks(),
-    styles: _getSSRFontStyles(),
-    preloads: _getSSRFontPreloads(),
-  };
+  const fontData = __createAppPageFontData({
+    getLinks: _getSSRFontLinks,
+    getPreloads: _getSSRFontPreloads,
+    getStyles: _getSSRFontStyles,
+  });
   const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
-  const htmlStream = await ssrEntry.handleSsr(rscStream, _getNavigationContext(), fontData);
-  setHeadersContext(null);
-  setNavigationContext(null);
-  const _respHeaders = { "Content-Type": "text/html; charset=utf-8", "Vary": "RSC, Accept" };
-  const _fontLinkHeader = __buildAppPageFontLinkHeader(fontData.preloads);
-  if (_fontLinkHeader) _respHeaders["Link"] = _fontLinkHeader;
-  return new Response(htmlStream, {
+  return __renderAppPageHtmlResponse({
+    clearRequestContext() {
+      setHeadersContext(null);
+      setNavigationContext(null);
+    },
+    fontData,
+    fontLinkHeader: __buildAppPageFontLinkHeader(fontData.preloads),
+    navigationContext: _getNavigationContext(),
+    rscStream,
+    ssrHandler: ssrEntry,
     status: statusCode,
-    headers: _respHeaders,
   });
 }
 
@@ -1017,22 +1028,23 @@ async function renderErrorBoundaryPage(route, error, isRscRequest, request, matc
 
   // HTML (full page load) response — render through RSC → SSR pipeline
   const rscStream = renderToReadableStream(element, { onError: onRenderError });
-  // Collect font data from RSC environment so error pages include font styles
-  const fontData = {
-    links: _getSSRFontLinks(),
-    styles: _getSSRFontStyles(),
-    preloads: _getSSRFontPreloads(),
-  };
+  const fontData = __createAppPageFontData({
+    getLinks: _getSSRFontLinks,
+    getPreloads: _getSSRFontPreloads,
+    getStyles: _getSSRFontStyles,
+  });
   const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
-  const htmlStream = await ssrEntry.handleSsr(rscStream, _getNavigationContext(), fontData);
-  setHeadersContext(null);
-  setNavigationContext(null);
-  const _errHeaders = { "Content-Type": "text/html; charset=utf-8", "Vary": "RSC, Accept" };
-  const _errFontLinkHeader = __buildAppPageFontLinkHeader(fontData.preloads);
-  if (_errFontLinkHeader) _errHeaders["Link"] = _errFontLinkHeader;
-  return new Response(htmlStream, {
+  return __renderAppPageHtmlResponse({
+    clearRequestContext() {
+      setHeadersContext(null);
+      setNavigationContext(null);
+    },
+    fontData,
+    fontLinkHeader: __buildAppPageFontLinkHeader(fontData.preloads),
+    navigationContext: _getNavigationContext(),
+    rscStream,
+    ssrHandler: ssrEntry,
     status: 200,
-    headers: _errHeaders,
   });
 }
 
@@ -2711,14 +2723,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // Track non-navigation RSC errors so we can detect when the in-tree global
   // ErrorBoundary catches during SSR (producing double <html>/<body>) and
   // re-render with renderErrorBoundaryPage (which skips layouts for global-error).
-  let _rscErrorForRerender = null;
   const _baseOnError = createRscOnErrorHandler(request, cleanPathname, route.pattern);
-  const onRenderError = function(error, requestInfo, errorContext) {
-    if (!(error && typeof error === "object" && "digest" in error)) {
-      _rscErrorForRerender = error;
-    }
-    return _baseOnError(error, requestInfo, errorContext);
-  };
+  const _rscErrorTracker = __createAppPageRscErrorTracker(_baseOnError);
+  const onRenderError = _rscErrorTracker.onRenderError;
   const rscStream = renderToReadableStream(element, { onError: onRenderError });
 
   // For ISR pages in production: tee the RSC stream immediately after creation so we
@@ -2789,11 +2796,11 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
 
   // Collect font data from RSC environment before passing to SSR
   // (Fonts are loaded during RSC rendering when layout.tsx calls Geist() etc.)
-  const fontData = {
-    links: _getSSRFontLinks(),
-    styles: _getSSRFontStyles(),
-    preloads: _getSSRFontPreloads(),
-  };
+  const fontData = __createAppPageFontData({
+    getLinks: _getSSRFontLinks,
+    getPreloads: _getSSRFontPreloads,
+    getStyles: _getSSRFontStyles,
+  });
 
   // Build HTTP Link header for font preloading.
   // This lets the browser (and CDN) start fetching font files before parsing HTML,
@@ -2809,7 +2816,12 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   let htmlStream;
   try {
     const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
-    htmlStream = await ssrEntry.handleSsr(__rscForResponse, _getNavigationContext(), fontData);
+    htmlStream = await __renderAppPageHtmlStream({
+      fontData,
+      navigationContext: _getNavigationContext(),
+      rscStream: __rscForResponse,
+      ssrHandler: ssrEntry,
+    });
     // Shell render complete; Suspense boundaries stream asynchronously
     if (process.env.NODE_ENV !== "production") __renderEnd = performance.now();
   } catch (ssrErr) {
@@ -2828,12 +2840,13 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   ${
     globalErrorVar
       ? `
-  if (_rscErrorForRerender && !isRscRequest) {
-    const _hasLocalBoundary = !!(route?.error?.default) || !!(route?.errors && route.errors.some(function(e) { return e?.default; }));
-    if (!_hasLocalBoundary) {
-      const cleanResp = await renderErrorBoundaryPage(route, _rscErrorForRerender, false, request, params);
+  const _capturedRscError = _rscErrorTracker.getCapturedError();
+  if (__shouldRerenderAppPageWithGlobalError({
+    capturedError: _capturedRscError,
+    hasLocalBoundary: !!(route?.error?.default) || !!(route?.errors && route.errors.some(function(e) { return e?.default; })),
+  })) {
+      const cleanResp = await renderErrorBoundaryPage(route, _capturedRscError, false, request, params);
       if (cleanResp) return cleanResp;
-    }
   }
   `
       : ""

--- a/packages/vinext/src/server/app-page-stream.ts
+++ b/packages/vinext/src/server/app-page-stream.ts
@@ -1,0 +1,107 @@
+import type { AppPageFontPreload } from "./app-page-execution.js";
+
+export interface AppPageFontData {
+  links: string[];
+  preloads: readonly AppPageFontPreload[];
+  styles: string[];
+}
+
+export interface CreateAppPageFontDataOptions {
+  getLinks: () => string[];
+  getPreloads: () => AppPageFontPreload[];
+  getStyles: () => string[];
+}
+
+export interface AppPageSsrHandler {
+  handleSsr: (
+    rscStream: ReadableStream<Uint8Array>,
+    navigationContext: unknown,
+    fontData: AppPageFontData,
+  ) => Promise<ReadableStream<Uint8Array>>;
+}
+
+export interface RenderAppPageHtmlStreamOptions {
+  fontData: AppPageFontData;
+  navigationContext: unknown;
+  rscStream: ReadableStream<Uint8Array>;
+  ssrHandler: AppPageSsrHandler;
+}
+
+export interface RenderAppPageHtmlResponseOptions extends RenderAppPageHtmlStreamOptions {
+  clearRequestContext: () => void;
+  fontLinkHeader?: string;
+  status: number;
+}
+
+export interface AppPageRscErrorTracker {
+  getCapturedError: () => unknown;
+  onRenderError: (error: unknown, requestInfo: unknown, errorContext: unknown) => unknown;
+}
+
+export interface ShouldRerenderAppPageWithGlobalErrorOptions {
+  capturedError: unknown;
+  hasLocalBoundary: boolean;
+}
+
+export function createAppPageFontData(options: CreateAppPageFontDataOptions): AppPageFontData {
+  return {
+    links: options.getLinks(),
+    preloads: options.getPreloads(),
+    styles: options.getStyles(),
+  };
+}
+
+export async function renderAppPageHtmlStream(
+  options: RenderAppPageHtmlStreamOptions,
+): Promise<ReadableStream<Uint8Array>> {
+  return options.ssrHandler.handleSsr(
+    options.rscStream,
+    options.navigationContext,
+    options.fontData,
+  );
+}
+
+export async function renderAppPageHtmlResponse(
+  options: RenderAppPageHtmlResponseOptions,
+): Promise<Response> {
+  const htmlStream = await renderAppPageHtmlStream(options);
+  options.clearRequestContext();
+
+  const headers: Record<string, string> = {
+    "Content-Type": "text/html; charset=utf-8",
+    Vary: "RSC, Accept",
+  };
+
+  if (options.fontLinkHeader) {
+    headers.Link = options.fontLinkHeader;
+  }
+
+  return new Response(htmlStream, {
+    status: options.status,
+    headers,
+  });
+}
+
+export function createAppPageRscErrorTracker(
+  baseOnError: (error: unknown, requestInfo: unknown, errorContext: unknown) => unknown,
+): AppPageRscErrorTracker {
+  let capturedError: unknown = null;
+
+  return {
+    getCapturedError() {
+      return capturedError;
+    },
+    onRenderError(error, requestInfo, errorContext) {
+      if (!(error && typeof error === "object" && "digest" in error)) {
+        capturedError = error;
+      }
+      return baseOnError(error, requestInfo, errorContext);
+    },
+  };
+}
+
+export function shouldRerenderAppPageWithGlobalError(
+  options: ShouldRerenderAppPageWithGlobalErrorOptions,
+): boolean {
+  return Boolean(options.capturedError) && !options.hasLocalBoundary;
+}

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -87,6 +87,13 @@ import {
   teeAppPageRscStreamForCapture as __teeAppPageRscStreamForCapture,
 } from "<ROOT>/packages/vinext/src/server/app-page-execution.js";
 import {
+  createAppPageFontData as __createAppPageFontData,
+  createAppPageRscErrorTracker as __createAppPageRscErrorTracker,
+  renderAppPageHtmlResponse as __renderAppPageHtmlResponse,
+  renderAppPageHtmlStream as __renderAppPageHtmlStream,
+  shouldRerenderAppPageWithGlobalError as __shouldRerenderAppPageWithGlobalError,
+} from "<ROOT>/packages/vinext/src/server/app-page-stream.js";
+import {
   applyRouteHandlerMiddlewareContext as __applyRouteHandlerMiddlewareContext,
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-response.js";
 import { _consumeRequestScopedCacheLife, getCacheHandler } from "next/cache";
@@ -629,22 +636,23 @@ async function renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, req
     route?.pattern ?? _pathname,
   );
   const rscStream = renderToReadableStream(element, { onError: onRenderError });
-  // Collect font data from RSC environment
-  const fontData = {
-    links: _getSSRFontLinks(),
-    styles: _getSSRFontStyles(),
-    preloads: _getSSRFontPreloads(),
-  };
+  const fontData = __createAppPageFontData({
+    getLinks: _getSSRFontLinks,
+    getPreloads: _getSSRFontPreloads,
+    getStyles: _getSSRFontStyles,
+  });
   const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
-  const htmlStream = await ssrEntry.handleSsr(rscStream, _getNavigationContext(), fontData);
-  setHeadersContext(null);
-  setNavigationContext(null);
-  const _respHeaders = { "Content-Type": "text/html; charset=utf-8", "Vary": "RSC, Accept" };
-  const _fontLinkHeader = __buildAppPageFontLinkHeader(fontData.preloads);
-  if (_fontLinkHeader) _respHeaders["Link"] = _fontLinkHeader;
-  return new Response(htmlStream, {
+  return __renderAppPageHtmlResponse({
+    clearRequestContext() {
+      setHeadersContext(null);
+      setNavigationContext(null);
+    },
+    fontData,
+    fontLinkHeader: __buildAppPageFontLinkHeader(fontData.preloads),
+    navigationContext: _getNavigationContext(),
+    rscStream,
+    ssrHandler: ssrEntry,
     status: statusCode,
-    headers: _respHeaders,
   });
 }
 
@@ -748,22 +756,23 @@ async function renderErrorBoundaryPage(route, error, isRscRequest, request, matc
 
   // HTML (full page load) response — render through RSC → SSR pipeline
   const rscStream = renderToReadableStream(element, { onError: onRenderError });
-  // Collect font data from RSC environment so error pages include font styles
-  const fontData = {
-    links: _getSSRFontLinks(),
-    styles: _getSSRFontStyles(),
-    preloads: _getSSRFontPreloads(),
-  };
+  const fontData = __createAppPageFontData({
+    getLinks: _getSSRFontLinks,
+    getPreloads: _getSSRFontPreloads,
+    getStyles: _getSSRFontStyles,
+  });
   const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
-  const htmlStream = await ssrEntry.handleSsr(rscStream, _getNavigationContext(), fontData);
-  setHeadersContext(null);
-  setNavigationContext(null);
-  const _errHeaders = { "Content-Type": "text/html; charset=utf-8", "Vary": "RSC, Accept" };
-  const _errFontLinkHeader = __buildAppPageFontLinkHeader(fontData.preloads);
-  if (_errFontLinkHeader) _errHeaders["Link"] = _errFontLinkHeader;
-  return new Response(htmlStream, {
+  return __renderAppPageHtmlResponse({
+    clearRequestContext() {
+      setHeadersContext(null);
+      setNavigationContext(null);
+    },
+    fontData,
+    fontLinkHeader: __buildAppPageFontLinkHeader(fontData.preloads),
+    navigationContext: _getNavigationContext(),
+    rscStream,
+    ssrHandler: ssrEntry,
     status: 200,
-    headers: _errHeaders,
   });
 }
 
@@ -2380,14 +2389,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // Track non-navigation RSC errors so we can detect when the in-tree global
   // ErrorBoundary catches during SSR (producing double <html>/<body>) and
   // re-render with renderErrorBoundaryPage (which skips layouts for global-error).
-  let _rscErrorForRerender = null;
   const _baseOnError = createRscOnErrorHandler(request, cleanPathname, route.pattern);
-  const onRenderError = function(error, requestInfo, errorContext) {
-    if (!(error && typeof error === "object" && "digest" in error)) {
-      _rscErrorForRerender = error;
-    }
-    return _baseOnError(error, requestInfo, errorContext);
-  };
+  const _rscErrorTracker = __createAppPageRscErrorTracker(_baseOnError);
+  const onRenderError = _rscErrorTracker.onRenderError;
   const rscStream = renderToReadableStream(element, { onError: onRenderError });
 
   // For ISR pages in production: tee the RSC stream immediately after creation so we
@@ -2458,11 +2462,11 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
 
   // Collect font data from RSC environment before passing to SSR
   // (Fonts are loaded during RSC rendering when layout.tsx calls Geist() etc.)
-  const fontData = {
-    links: _getSSRFontLinks(),
-    styles: _getSSRFontStyles(),
-    preloads: _getSSRFontPreloads(),
-  };
+  const fontData = __createAppPageFontData({
+    getLinks: _getSSRFontLinks,
+    getPreloads: _getSSRFontPreloads,
+    getStyles: _getSSRFontStyles,
+  });
 
   // Build HTTP Link header for font preloading.
   // This lets the browser (and CDN) start fetching font files before parsing HTML,
@@ -2478,7 +2482,12 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   let htmlStream;
   try {
     const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
-    htmlStream = await ssrEntry.handleSsr(__rscForResponse, _getNavigationContext(), fontData);
+    htmlStream = await __renderAppPageHtmlStream({
+      fontData,
+      navigationContext: _getNavigationContext(),
+      rscStream: __rscForResponse,
+      ssrHandler: ssrEntry,
+    });
     // Shell render complete; Suspense boundaries stream asynchronously
     if (process.env.NODE_ENV !== "production") __renderEnd = performance.now();
   } catch (ssrErr) {
@@ -2658,6 +2667,13 @@ import {
   resolveAppPageSpecialError as __resolveAppPageSpecialError,
   teeAppPageRscStreamForCapture as __teeAppPageRscStreamForCapture,
 } from "<ROOT>/packages/vinext/src/server/app-page-execution.js";
+import {
+  createAppPageFontData as __createAppPageFontData,
+  createAppPageRscErrorTracker as __createAppPageRscErrorTracker,
+  renderAppPageHtmlResponse as __renderAppPageHtmlResponse,
+  renderAppPageHtmlStream as __renderAppPageHtmlStream,
+  shouldRerenderAppPageWithGlobalError as __shouldRerenderAppPageWithGlobalError,
+} from "<ROOT>/packages/vinext/src/server/app-page-stream.js";
 import {
   applyRouteHandlerMiddlewareContext as __applyRouteHandlerMiddlewareContext,
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-response.js";
@@ -3201,22 +3217,23 @@ async function renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, req
     route?.pattern ?? _pathname,
   );
   const rscStream = renderToReadableStream(element, { onError: onRenderError });
-  // Collect font data from RSC environment
-  const fontData = {
-    links: _getSSRFontLinks(),
-    styles: _getSSRFontStyles(),
-    preloads: _getSSRFontPreloads(),
-  };
+  const fontData = __createAppPageFontData({
+    getLinks: _getSSRFontLinks,
+    getPreloads: _getSSRFontPreloads,
+    getStyles: _getSSRFontStyles,
+  });
   const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
-  const htmlStream = await ssrEntry.handleSsr(rscStream, _getNavigationContext(), fontData);
-  setHeadersContext(null);
-  setNavigationContext(null);
-  const _respHeaders = { "Content-Type": "text/html; charset=utf-8", "Vary": "RSC, Accept" };
-  const _fontLinkHeader = __buildAppPageFontLinkHeader(fontData.preloads);
-  if (_fontLinkHeader) _respHeaders["Link"] = _fontLinkHeader;
-  return new Response(htmlStream, {
+  return __renderAppPageHtmlResponse({
+    clearRequestContext() {
+      setHeadersContext(null);
+      setNavigationContext(null);
+    },
+    fontData,
+    fontLinkHeader: __buildAppPageFontLinkHeader(fontData.preloads),
+    navigationContext: _getNavigationContext(),
+    rscStream,
+    ssrHandler: ssrEntry,
     status: statusCode,
-    headers: _respHeaders,
   });
 }
 
@@ -3320,22 +3337,23 @@ async function renderErrorBoundaryPage(route, error, isRscRequest, request, matc
 
   // HTML (full page load) response — render through RSC → SSR pipeline
   const rscStream = renderToReadableStream(element, { onError: onRenderError });
-  // Collect font data from RSC environment so error pages include font styles
-  const fontData = {
-    links: _getSSRFontLinks(),
-    styles: _getSSRFontStyles(),
-    preloads: _getSSRFontPreloads(),
-  };
+  const fontData = __createAppPageFontData({
+    getLinks: _getSSRFontLinks,
+    getPreloads: _getSSRFontPreloads,
+    getStyles: _getSSRFontStyles,
+  });
   const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
-  const htmlStream = await ssrEntry.handleSsr(rscStream, _getNavigationContext(), fontData);
-  setHeadersContext(null);
-  setNavigationContext(null);
-  const _errHeaders = { "Content-Type": "text/html; charset=utf-8", "Vary": "RSC, Accept" };
-  const _errFontLinkHeader = __buildAppPageFontLinkHeader(fontData.preloads);
-  if (_errFontLinkHeader) _errHeaders["Link"] = _errFontLinkHeader;
-  return new Response(htmlStream, {
+  return __renderAppPageHtmlResponse({
+    clearRequestContext() {
+      setHeadersContext(null);
+      setNavigationContext(null);
+    },
+    fontData,
+    fontLinkHeader: __buildAppPageFontLinkHeader(fontData.preloads),
+    navigationContext: _getNavigationContext(),
+    rscStream,
+    ssrHandler: ssrEntry,
     status: 200,
-    headers: _errHeaders,
   });
 }
 
@@ -4955,14 +4973,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // Track non-navigation RSC errors so we can detect when the in-tree global
   // ErrorBoundary catches during SSR (producing double <html>/<body>) and
   // re-render with renderErrorBoundaryPage (which skips layouts for global-error).
-  let _rscErrorForRerender = null;
   const _baseOnError = createRscOnErrorHandler(request, cleanPathname, route.pattern);
-  const onRenderError = function(error, requestInfo, errorContext) {
-    if (!(error && typeof error === "object" && "digest" in error)) {
-      _rscErrorForRerender = error;
-    }
-    return _baseOnError(error, requestInfo, errorContext);
-  };
+  const _rscErrorTracker = __createAppPageRscErrorTracker(_baseOnError);
+  const onRenderError = _rscErrorTracker.onRenderError;
   const rscStream = renderToReadableStream(element, { onError: onRenderError });
 
   // For ISR pages in production: tee the RSC stream immediately after creation so we
@@ -5033,11 +5046,11 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
 
   // Collect font data from RSC environment before passing to SSR
   // (Fonts are loaded during RSC rendering when layout.tsx calls Geist() etc.)
-  const fontData = {
-    links: _getSSRFontLinks(),
-    styles: _getSSRFontStyles(),
-    preloads: _getSSRFontPreloads(),
-  };
+  const fontData = __createAppPageFontData({
+    getLinks: _getSSRFontLinks,
+    getPreloads: _getSSRFontPreloads,
+    getStyles: _getSSRFontStyles,
+  });
 
   // Build HTTP Link header for font preloading.
   // This lets the browser (and CDN) start fetching font files before parsing HTML,
@@ -5053,7 +5066,12 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   let htmlStream;
   try {
     const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
-    htmlStream = await ssrEntry.handleSsr(__rscForResponse, _getNavigationContext(), fontData);
+    htmlStream = await __renderAppPageHtmlStream({
+      fontData,
+      navigationContext: _getNavigationContext(),
+      rscStream: __rscForResponse,
+      ssrHandler: ssrEntry,
+    });
     // Shell render complete; Suspense boundaries stream asynchronously
     if (process.env.NODE_ENV !== "production") __renderEnd = performance.now();
   } catch (ssrErr) {
@@ -5233,6 +5251,13 @@ import {
   resolveAppPageSpecialError as __resolveAppPageSpecialError,
   teeAppPageRscStreamForCapture as __teeAppPageRscStreamForCapture,
 } from "<ROOT>/packages/vinext/src/server/app-page-execution.js";
+import {
+  createAppPageFontData as __createAppPageFontData,
+  createAppPageRscErrorTracker as __createAppPageRscErrorTracker,
+  renderAppPageHtmlResponse as __renderAppPageHtmlResponse,
+  renderAppPageHtmlStream as __renderAppPageHtmlStream,
+  shouldRerenderAppPageWithGlobalError as __shouldRerenderAppPageWithGlobalError,
+} from "<ROOT>/packages/vinext/src/server/app-page-stream.js";
 import {
   applyRouteHandlerMiddlewareContext as __applyRouteHandlerMiddlewareContext,
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-response.js";
@@ -5785,22 +5810,23 @@ async function renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, req
     route?.pattern ?? _pathname,
   );
   const rscStream = renderToReadableStream(element, { onError: onRenderError });
-  // Collect font data from RSC environment
-  const fontData = {
-    links: _getSSRFontLinks(),
-    styles: _getSSRFontStyles(),
-    preloads: _getSSRFontPreloads(),
-  };
+  const fontData = __createAppPageFontData({
+    getLinks: _getSSRFontLinks,
+    getPreloads: _getSSRFontPreloads,
+    getStyles: _getSSRFontStyles,
+  });
   const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
-  const htmlStream = await ssrEntry.handleSsr(rscStream, _getNavigationContext(), fontData);
-  setHeadersContext(null);
-  setNavigationContext(null);
-  const _respHeaders = { "Content-Type": "text/html; charset=utf-8", "Vary": "RSC, Accept" };
-  const _fontLinkHeader = __buildAppPageFontLinkHeader(fontData.preloads);
-  if (_fontLinkHeader) _respHeaders["Link"] = _fontLinkHeader;
-  return new Response(htmlStream, {
+  return __renderAppPageHtmlResponse({
+    clearRequestContext() {
+      setHeadersContext(null);
+      setNavigationContext(null);
+    },
+    fontData,
+    fontLinkHeader: __buildAppPageFontLinkHeader(fontData.preloads),
+    navigationContext: _getNavigationContext(),
+    rscStream,
+    ssrHandler: ssrEntry,
     status: statusCode,
-    headers: _respHeaders,
   });
 }
 
@@ -5917,22 +5943,23 @@ async function renderErrorBoundaryPage(route, error, isRscRequest, request, matc
 
   // HTML (full page load) response — render through RSC → SSR pipeline
   const rscStream = renderToReadableStream(element, { onError: onRenderError });
-  // Collect font data from RSC environment so error pages include font styles
-  const fontData = {
-    links: _getSSRFontLinks(),
-    styles: _getSSRFontStyles(),
-    preloads: _getSSRFontPreloads(),
-  };
+  const fontData = __createAppPageFontData({
+    getLinks: _getSSRFontLinks,
+    getPreloads: _getSSRFontPreloads,
+    getStyles: _getSSRFontStyles,
+  });
   const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
-  const htmlStream = await ssrEntry.handleSsr(rscStream, _getNavigationContext(), fontData);
-  setHeadersContext(null);
-  setNavigationContext(null);
-  const _errHeaders = { "Content-Type": "text/html; charset=utf-8", "Vary": "RSC, Accept" };
-  const _errFontLinkHeader = __buildAppPageFontLinkHeader(fontData.preloads);
-  if (_errFontLinkHeader) _errHeaders["Link"] = _errFontLinkHeader;
-  return new Response(htmlStream, {
+  return __renderAppPageHtmlResponse({
+    clearRequestContext() {
+      setHeadersContext(null);
+      setNavigationContext(null);
+    },
+    fontData,
+    fontLinkHeader: __buildAppPageFontLinkHeader(fontData.preloads),
+    navigationContext: _getNavigationContext(),
+    rscStream,
+    ssrHandler: ssrEntry,
     status: 200,
-    headers: _errHeaders,
   });
 }
 
@@ -7557,14 +7584,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // Track non-navigation RSC errors so we can detect when the in-tree global
   // ErrorBoundary catches during SSR (producing double <html>/<body>) and
   // re-render with renderErrorBoundaryPage (which skips layouts for global-error).
-  let _rscErrorForRerender = null;
   const _baseOnError = createRscOnErrorHandler(request, cleanPathname, route.pattern);
-  const onRenderError = function(error, requestInfo, errorContext) {
-    if (!(error && typeof error === "object" && "digest" in error)) {
-      _rscErrorForRerender = error;
-    }
-    return _baseOnError(error, requestInfo, errorContext);
-  };
+  const _rscErrorTracker = __createAppPageRscErrorTracker(_baseOnError);
+  const onRenderError = _rscErrorTracker.onRenderError;
   const rscStream = renderToReadableStream(element, { onError: onRenderError });
 
   // For ISR pages in production: tee the RSC stream immediately after creation so we
@@ -7635,11 +7657,11 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
 
   // Collect font data from RSC environment before passing to SSR
   // (Fonts are loaded during RSC rendering when layout.tsx calls Geist() etc.)
-  const fontData = {
-    links: _getSSRFontLinks(),
-    styles: _getSSRFontStyles(),
-    preloads: _getSSRFontPreloads(),
-  };
+  const fontData = __createAppPageFontData({
+    getLinks: _getSSRFontLinks,
+    getPreloads: _getSSRFontPreloads,
+    getStyles: _getSSRFontStyles,
+  });
 
   // Build HTTP Link header for font preloading.
   // This lets the browser (and CDN) start fetching font files before parsing HTML,
@@ -7655,7 +7677,12 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   let htmlStream;
   try {
     const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
-    htmlStream = await ssrEntry.handleSsr(__rscForResponse, _getNavigationContext(), fontData);
+    htmlStream = await __renderAppPageHtmlStream({
+      fontData,
+      navigationContext: _getNavigationContext(),
+      rscStream: __rscForResponse,
+      ssrHandler: ssrEntry,
+    });
     // Shell render complete; Suspense boundaries stream asynchronously
     if (process.env.NODE_ENV !== "production") __renderEnd = performance.now();
   } catch (ssrErr) {
@@ -7672,12 +7699,13 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // Discard it and re-render using renderErrorBoundaryPage which skips layouts
   // when the error falls through to global-error.tsx.
   
-  if (_rscErrorForRerender && !isRscRequest) {
-    const _hasLocalBoundary = !!(route?.error?.default) || !!(route?.errors && route.errors.some(function(e) { return e?.default; }));
-    if (!_hasLocalBoundary) {
-      const cleanResp = await renderErrorBoundaryPage(route, _rscErrorForRerender, false, request, params);
+  const _capturedRscError = _rscErrorTracker.getCapturedError();
+  if (__shouldRerenderAppPageWithGlobalError({
+    capturedError: _capturedRscError,
+    hasLocalBoundary: !!(route?.error?.default) || !!(route?.errors && route.errors.some(function(e) { return e?.default; })),
+  })) {
+      const cleanResp = await renderErrorBoundaryPage(route, _capturedRscError, false, request, params);
       if (cleanResp) return cleanResp;
-    }
   }
   
 
@@ -7843,6 +7871,13 @@ import {
   resolveAppPageSpecialError as __resolveAppPageSpecialError,
   teeAppPageRscStreamForCapture as __teeAppPageRscStreamForCapture,
 } from "<ROOT>/packages/vinext/src/server/app-page-execution.js";
+import {
+  createAppPageFontData as __createAppPageFontData,
+  createAppPageRscErrorTracker as __createAppPageRscErrorTracker,
+  renderAppPageHtmlResponse as __renderAppPageHtmlResponse,
+  renderAppPageHtmlStream as __renderAppPageHtmlStream,
+  shouldRerenderAppPageWithGlobalError as __shouldRerenderAppPageWithGlobalError,
+} from "<ROOT>/packages/vinext/src/server/app-page-stream.js";
 import {
   applyRouteHandlerMiddlewareContext as __applyRouteHandlerMiddlewareContext,
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-response.js";
@@ -8416,22 +8451,23 @@ async function renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, req
     route?.pattern ?? _pathname,
   );
   const rscStream = renderToReadableStream(element, { onError: onRenderError });
-  // Collect font data from RSC environment
-  const fontData = {
-    links: _getSSRFontLinks(),
-    styles: _getSSRFontStyles(),
-    preloads: _getSSRFontPreloads(),
-  };
+  const fontData = __createAppPageFontData({
+    getLinks: _getSSRFontLinks,
+    getPreloads: _getSSRFontPreloads,
+    getStyles: _getSSRFontStyles,
+  });
   const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
-  const htmlStream = await ssrEntry.handleSsr(rscStream, _getNavigationContext(), fontData);
-  setHeadersContext(null);
-  setNavigationContext(null);
-  const _respHeaders = { "Content-Type": "text/html; charset=utf-8", "Vary": "RSC, Accept" };
-  const _fontLinkHeader = __buildAppPageFontLinkHeader(fontData.preloads);
-  if (_fontLinkHeader) _respHeaders["Link"] = _fontLinkHeader;
-  return new Response(htmlStream, {
+  return __renderAppPageHtmlResponse({
+    clearRequestContext() {
+      setHeadersContext(null);
+      setNavigationContext(null);
+    },
+    fontData,
+    fontLinkHeader: __buildAppPageFontLinkHeader(fontData.preloads),
+    navigationContext: _getNavigationContext(),
+    rscStream,
+    ssrHandler: ssrEntry,
     status: statusCode,
-    headers: _respHeaders,
   });
 }
 
@@ -8535,22 +8571,23 @@ async function renderErrorBoundaryPage(route, error, isRscRequest, request, matc
 
   // HTML (full page load) response — render through RSC → SSR pipeline
   const rscStream = renderToReadableStream(element, { onError: onRenderError });
-  // Collect font data from RSC environment so error pages include font styles
-  const fontData = {
-    links: _getSSRFontLinks(),
-    styles: _getSSRFontStyles(),
-    preloads: _getSSRFontPreloads(),
-  };
+  const fontData = __createAppPageFontData({
+    getLinks: _getSSRFontLinks,
+    getPreloads: _getSSRFontPreloads,
+    getStyles: _getSSRFontStyles,
+  });
   const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
-  const htmlStream = await ssrEntry.handleSsr(rscStream, _getNavigationContext(), fontData);
-  setHeadersContext(null);
-  setNavigationContext(null);
-  const _errHeaders = { "Content-Type": "text/html; charset=utf-8", "Vary": "RSC, Accept" };
-  const _errFontLinkHeader = __buildAppPageFontLinkHeader(fontData.preloads);
-  if (_errFontLinkHeader) _errHeaders["Link"] = _errFontLinkHeader;
-  return new Response(htmlStream, {
+  return __renderAppPageHtmlResponse({
+    clearRequestContext() {
+      setHeadersContext(null);
+      setNavigationContext(null);
+    },
+    fontData,
+    fontLinkHeader: __buildAppPageFontLinkHeader(fontData.preloads),
+    navigationContext: _getNavigationContext(),
+    rscStream,
+    ssrHandler: ssrEntry,
     status: 200,
-    headers: _errHeaders,
   });
 }
 
@@ -10170,14 +10207,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // Track non-navigation RSC errors so we can detect when the in-tree global
   // ErrorBoundary catches during SSR (producing double <html>/<body>) and
   // re-render with renderErrorBoundaryPage (which skips layouts for global-error).
-  let _rscErrorForRerender = null;
   const _baseOnError = createRscOnErrorHandler(request, cleanPathname, route.pattern);
-  const onRenderError = function(error, requestInfo, errorContext) {
-    if (!(error && typeof error === "object" && "digest" in error)) {
-      _rscErrorForRerender = error;
-    }
-    return _baseOnError(error, requestInfo, errorContext);
-  };
+  const _rscErrorTracker = __createAppPageRscErrorTracker(_baseOnError);
+  const onRenderError = _rscErrorTracker.onRenderError;
   const rscStream = renderToReadableStream(element, { onError: onRenderError });
 
   // For ISR pages in production: tee the RSC stream immediately after creation so we
@@ -10248,11 +10280,11 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
 
   // Collect font data from RSC environment before passing to SSR
   // (Fonts are loaded during RSC rendering when layout.tsx calls Geist() etc.)
-  const fontData = {
-    links: _getSSRFontLinks(),
-    styles: _getSSRFontStyles(),
-    preloads: _getSSRFontPreloads(),
-  };
+  const fontData = __createAppPageFontData({
+    getLinks: _getSSRFontLinks,
+    getPreloads: _getSSRFontPreloads,
+    getStyles: _getSSRFontStyles,
+  });
 
   // Build HTTP Link header for font preloading.
   // This lets the browser (and CDN) start fetching font files before parsing HTML,
@@ -10268,7 +10300,12 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   let htmlStream;
   try {
     const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
-    htmlStream = await ssrEntry.handleSsr(__rscForResponse, _getNavigationContext(), fontData);
+    htmlStream = await __renderAppPageHtmlStream({
+      fontData,
+      navigationContext: _getNavigationContext(),
+      rscStream: __rscForResponse,
+      ssrHandler: ssrEntry,
+    });
     // Shell render complete; Suspense boundaries stream asynchronously
     if (process.env.NODE_ENV !== "production") __renderEnd = performance.now();
   } catch (ssrErr) {
@@ -10448,6 +10485,13 @@ import {
   resolveAppPageSpecialError as __resolveAppPageSpecialError,
   teeAppPageRscStreamForCapture as __teeAppPageRscStreamForCapture,
 } from "<ROOT>/packages/vinext/src/server/app-page-execution.js";
+import {
+  createAppPageFontData as __createAppPageFontData,
+  createAppPageRscErrorTracker as __createAppPageRscErrorTracker,
+  renderAppPageHtmlResponse as __renderAppPageHtmlResponse,
+  renderAppPageHtmlStream as __renderAppPageHtmlStream,
+  shouldRerenderAppPageWithGlobalError as __shouldRerenderAppPageWithGlobalError,
+} from "<ROOT>/packages/vinext/src/server/app-page-stream.js";
 import {
   applyRouteHandlerMiddlewareContext as __applyRouteHandlerMiddlewareContext,
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-response.js";
@@ -10998,22 +11042,23 @@ async function renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, req
     route?.pattern ?? _pathname,
   );
   const rscStream = renderToReadableStream(element, { onError: onRenderError });
-  // Collect font data from RSC environment
-  const fontData = {
-    links: _getSSRFontLinks(),
-    styles: _getSSRFontStyles(),
-    preloads: _getSSRFontPreloads(),
-  };
+  const fontData = __createAppPageFontData({
+    getLinks: _getSSRFontLinks,
+    getPreloads: _getSSRFontPreloads,
+    getStyles: _getSSRFontStyles,
+  });
   const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
-  const htmlStream = await ssrEntry.handleSsr(rscStream, _getNavigationContext(), fontData);
-  setHeadersContext(null);
-  setNavigationContext(null);
-  const _respHeaders = { "Content-Type": "text/html; charset=utf-8", "Vary": "RSC, Accept" };
-  const _fontLinkHeader = __buildAppPageFontLinkHeader(fontData.preloads);
-  if (_fontLinkHeader) _respHeaders["Link"] = _fontLinkHeader;
-  return new Response(htmlStream, {
+  return __renderAppPageHtmlResponse({
+    clearRequestContext() {
+      setHeadersContext(null);
+      setNavigationContext(null);
+    },
+    fontData,
+    fontLinkHeader: __buildAppPageFontLinkHeader(fontData.preloads),
+    navigationContext: _getNavigationContext(),
+    rscStream,
+    ssrHandler: ssrEntry,
     status: statusCode,
-    headers: _respHeaders,
   });
 }
 
@@ -11117,22 +11162,23 @@ async function renderErrorBoundaryPage(route, error, isRscRequest, request, matc
 
   // HTML (full page load) response — render through RSC → SSR pipeline
   const rscStream = renderToReadableStream(element, { onError: onRenderError });
-  // Collect font data from RSC environment so error pages include font styles
-  const fontData = {
-    links: _getSSRFontLinks(),
-    styles: _getSSRFontStyles(),
-    preloads: _getSSRFontPreloads(),
-  };
+  const fontData = __createAppPageFontData({
+    getLinks: _getSSRFontLinks,
+    getPreloads: _getSSRFontPreloads,
+    getStyles: _getSSRFontStyles,
+  });
   const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
-  const htmlStream = await ssrEntry.handleSsr(rscStream, _getNavigationContext(), fontData);
-  setHeadersContext(null);
-  setNavigationContext(null);
-  const _errHeaders = { "Content-Type": "text/html; charset=utf-8", "Vary": "RSC, Accept" };
-  const _errFontLinkHeader = __buildAppPageFontLinkHeader(fontData.preloads);
-  if (_errFontLinkHeader) _errHeaders["Link"] = _errFontLinkHeader;
-  return new Response(htmlStream, {
+  return __renderAppPageHtmlResponse({
+    clearRequestContext() {
+      setHeadersContext(null);
+      setNavigationContext(null);
+    },
+    fontData,
+    fontLinkHeader: __buildAppPageFontLinkHeader(fontData.preloads),
+    navigationContext: _getNavigationContext(),
+    rscStream,
+    ssrHandler: ssrEntry,
     status: 200,
-    headers: _errHeaders,
   });
 }
 
@@ -12749,14 +12795,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // Track non-navigation RSC errors so we can detect when the in-tree global
   // ErrorBoundary catches during SSR (producing double <html>/<body>) and
   // re-render with renderErrorBoundaryPage (which skips layouts for global-error).
-  let _rscErrorForRerender = null;
   const _baseOnError = createRscOnErrorHandler(request, cleanPathname, route.pattern);
-  const onRenderError = function(error, requestInfo, errorContext) {
-    if (!(error && typeof error === "object" && "digest" in error)) {
-      _rscErrorForRerender = error;
-    }
-    return _baseOnError(error, requestInfo, errorContext);
-  };
+  const _rscErrorTracker = __createAppPageRscErrorTracker(_baseOnError);
+  const onRenderError = _rscErrorTracker.onRenderError;
   const rscStream = renderToReadableStream(element, { onError: onRenderError });
 
   // For ISR pages in production: tee the RSC stream immediately after creation so we
@@ -12827,11 +12868,11 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
 
   // Collect font data from RSC environment before passing to SSR
   // (Fonts are loaded during RSC rendering when layout.tsx calls Geist() etc.)
-  const fontData = {
-    links: _getSSRFontLinks(),
-    styles: _getSSRFontStyles(),
-    preloads: _getSSRFontPreloads(),
-  };
+  const fontData = __createAppPageFontData({
+    getLinks: _getSSRFontLinks,
+    getPreloads: _getSSRFontPreloads,
+    getStyles: _getSSRFontStyles,
+  });
 
   // Build HTTP Link header for font preloading.
   // This lets the browser (and CDN) start fetching font files before parsing HTML,
@@ -12847,7 +12888,12 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   let htmlStream;
   try {
     const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
-    htmlStream = await ssrEntry.handleSsr(__rscForResponse, _getNavigationContext(), fontData);
+    htmlStream = await __renderAppPageHtmlStream({
+      fontData,
+      navigationContext: _getNavigationContext(),
+      rscStream: __rscForResponse,
+      ssrHandler: ssrEntry,
+    });
     // Shell render complete; Suspense boundaries stream asynchronously
     if (process.env.NODE_ENV !== "production") __renderEnd = performance.now();
   } catch (ssrErr) {
@@ -13027,6 +13073,13 @@ import {
   resolveAppPageSpecialError as __resolveAppPageSpecialError,
   teeAppPageRscStreamForCapture as __teeAppPageRscStreamForCapture,
 } from "<ROOT>/packages/vinext/src/server/app-page-execution.js";
+import {
+  createAppPageFontData as __createAppPageFontData,
+  createAppPageRscErrorTracker as __createAppPageRscErrorTracker,
+  renderAppPageHtmlResponse as __renderAppPageHtmlResponse,
+  renderAppPageHtmlStream as __renderAppPageHtmlStream,
+  shouldRerenderAppPageWithGlobalError as __shouldRerenderAppPageWithGlobalError,
+} from "<ROOT>/packages/vinext/src/server/app-page-stream.js";
 import {
   applyRouteHandlerMiddlewareContext as __applyRouteHandlerMiddlewareContext,
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-response.js";
@@ -13570,22 +13623,23 @@ async function renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, req
     route?.pattern ?? _pathname,
   );
   const rscStream = renderToReadableStream(element, { onError: onRenderError });
-  // Collect font data from RSC environment
-  const fontData = {
-    links: _getSSRFontLinks(),
-    styles: _getSSRFontStyles(),
-    preloads: _getSSRFontPreloads(),
-  };
+  const fontData = __createAppPageFontData({
+    getLinks: _getSSRFontLinks,
+    getPreloads: _getSSRFontPreloads,
+    getStyles: _getSSRFontStyles,
+  });
   const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
-  const htmlStream = await ssrEntry.handleSsr(rscStream, _getNavigationContext(), fontData);
-  setHeadersContext(null);
-  setNavigationContext(null);
-  const _respHeaders = { "Content-Type": "text/html; charset=utf-8", "Vary": "RSC, Accept" };
-  const _fontLinkHeader = __buildAppPageFontLinkHeader(fontData.preloads);
-  if (_fontLinkHeader) _respHeaders["Link"] = _fontLinkHeader;
-  return new Response(htmlStream, {
+  return __renderAppPageHtmlResponse({
+    clearRequestContext() {
+      setHeadersContext(null);
+      setNavigationContext(null);
+    },
+    fontData,
+    fontLinkHeader: __buildAppPageFontLinkHeader(fontData.preloads),
+    navigationContext: _getNavigationContext(),
+    rscStream,
+    ssrHandler: ssrEntry,
     status: statusCode,
-    headers: _respHeaders,
   });
 }
 
@@ -13689,22 +13743,23 @@ async function renderErrorBoundaryPage(route, error, isRscRequest, request, matc
 
   // HTML (full page load) response — render through RSC → SSR pipeline
   const rscStream = renderToReadableStream(element, { onError: onRenderError });
-  // Collect font data from RSC environment so error pages include font styles
-  const fontData = {
-    links: _getSSRFontLinks(),
-    styles: _getSSRFontStyles(),
-    preloads: _getSSRFontPreloads(),
-  };
+  const fontData = __createAppPageFontData({
+    getLinks: _getSSRFontLinks,
+    getPreloads: _getSSRFontPreloads,
+    getStyles: _getSSRFontStyles,
+  });
   const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
-  const htmlStream = await ssrEntry.handleSsr(rscStream, _getNavigationContext(), fontData);
-  setHeadersContext(null);
-  setNavigationContext(null);
-  const _errHeaders = { "Content-Type": "text/html; charset=utf-8", "Vary": "RSC, Accept" };
-  const _errFontLinkHeader = __buildAppPageFontLinkHeader(fontData.preloads);
-  if (_errFontLinkHeader) _errHeaders["Link"] = _errFontLinkHeader;
-  return new Response(htmlStream, {
+  return __renderAppPageHtmlResponse({
+    clearRequestContext() {
+      setHeadersContext(null);
+      setNavigationContext(null);
+    },
+    fontData,
+    fontLinkHeader: __buildAppPageFontLinkHeader(fontData.preloads),
+    navigationContext: _getNavigationContext(),
+    rscStream,
+    ssrHandler: ssrEntry,
     status: 200,
-    headers: _errHeaders,
   });
 }
 
@@ -15681,14 +15736,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // Track non-navigation RSC errors so we can detect when the in-tree global
   // ErrorBoundary catches during SSR (producing double <html>/<body>) and
   // re-render with renderErrorBoundaryPage (which skips layouts for global-error).
-  let _rscErrorForRerender = null;
   const _baseOnError = createRscOnErrorHandler(request, cleanPathname, route.pattern);
-  const onRenderError = function(error, requestInfo, errorContext) {
-    if (!(error && typeof error === "object" && "digest" in error)) {
-      _rscErrorForRerender = error;
-    }
-    return _baseOnError(error, requestInfo, errorContext);
-  };
+  const _rscErrorTracker = __createAppPageRscErrorTracker(_baseOnError);
+  const onRenderError = _rscErrorTracker.onRenderError;
   const rscStream = renderToReadableStream(element, { onError: onRenderError });
 
   // For ISR pages in production: tee the RSC stream immediately after creation so we
@@ -15759,11 +15809,11 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
 
   // Collect font data from RSC environment before passing to SSR
   // (Fonts are loaded during RSC rendering when layout.tsx calls Geist() etc.)
-  const fontData = {
-    links: _getSSRFontLinks(),
-    styles: _getSSRFontStyles(),
-    preloads: _getSSRFontPreloads(),
-  };
+  const fontData = __createAppPageFontData({
+    getLinks: _getSSRFontLinks,
+    getPreloads: _getSSRFontPreloads,
+    getStyles: _getSSRFontStyles,
+  });
 
   // Build HTTP Link header for font preloading.
   // This lets the browser (and CDN) start fetching font files before parsing HTML,
@@ -15779,7 +15829,12 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   let htmlStream;
   try {
     const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
-    htmlStream = await ssrEntry.handleSsr(__rscForResponse, _getNavigationContext(), fontData);
+    htmlStream = await __renderAppPageHtmlStream({
+      fontData,
+      navigationContext: _getNavigationContext(),
+      rscStream: __rscForResponse,
+      ssrHandler: ssrEntry,
+    });
     // Shell render complete; Suspense boundaries stream asynchronously
     if (process.env.NODE_ENV !== "production") __renderEnd = performance.now();
   } catch (ssrErr) {

--- a/tests/app-page-stream.test.ts
+++ b/tests/app-page-stream.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+import {
+  createAppPageFontData,
+  createAppPageRscErrorTracker,
+  renderAppPageHtmlResponse,
+  renderAppPageHtmlStream,
+  shouldRerenderAppPageWithGlobalError,
+} from "../packages/vinext/src/server/app-page-stream.js";
+
+function createStream(chunks: string[]): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(new TextEncoder().encode(chunk));
+      }
+      controller.close();
+    },
+  });
+}
+
+describe("app page stream helpers", () => {
+  it("collects app page font data from RSC environment getters", () => {
+    expect(
+      createAppPageFontData({
+        getLinks() {
+          return ["/font.css"];
+        },
+        getPreloads() {
+          return [{ href: "/font.woff2", type: "font/woff2" }];
+        },
+        getStyles() {
+          return [".font { font-family: Test; }"];
+        },
+      }),
+    ).toEqual({
+      links: ["/font.css"],
+      preloads: [{ href: "/font.woff2", type: "font/woff2" }],
+      styles: [".font { font-family: Test; }"],
+    });
+  });
+
+  it("renders the HTML stream through the SSR handler", async () => {
+    const fontData = createAppPageFontData({
+      getLinks: () => ["/font.css"],
+      getPreloads: () => [{ href: "/font.woff2", type: "font/woff2" }],
+      getStyles: () => [],
+    });
+
+    const htmlStream = await renderAppPageHtmlStream({
+      fontData,
+      navigationContext: { pathname: "/test" },
+      rscStream: createStream(["flight"]),
+      ssrHandler: {
+        async handleSsr(_rscStream, navigationContext, receivedFontData) {
+          expect(navigationContext).toEqual({ pathname: "/test" });
+          expect(receivedFontData).toEqual(fontData);
+          return createStream(["<html>ok</html>"]);
+        },
+      },
+    });
+
+    await expect(new Response(htmlStream).text()).resolves.toBe("<html>ok</html>");
+  });
+
+  it("builds an HTML response, including link headers, after clearing request context", async () => {
+    const clearRequestContext = vi.fn();
+
+    const response = await renderAppPageHtmlResponse({
+      clearRequestContext,
+      fontData: {
+        links: [],
+        preloads: [],
+        styles: [],
+      },
+      fontLinkHeader: "</font.woff2>; rel=preload; as=font; type=font/woff2; crossorigin",
+      navigationContext: null,
+      rscStream: createStream(["flight"]),
+      ssrHandler: {
+        async handleSsr() {
+          return createStream(["<html>page</html>"]);
+        },
+      },
+      status: 203,
+    });
+
+    expect(clearRequestContext).toHaveBeenCalledTimes(1);
+    expect(response.status).toBe(203);
+    expect(response.headers.get("content-type")).toBe("text/html; charset=utf-8");
+    expect(response.headers.get("link")).toBe(
+      "</font.woff2>; rel=preload; as=font; type=font/woff2; crossorigin",
+    );
+    await expect(response.text()).resolves.toBe("<html>page</html>");
+  });
+
+  it("tracks non-navigation RSC errors while preserving the base onError callback", () => {
+    const baseOnError = vi.fn(() => "base-result");
+    const tracker = createAppPageRscErrorTracker(baseOnError);
+
+    expect(tracker.onRenderError(new Error("boom"), { path: "/test" }, { chunk: 1 })).toBe(
+      "base-result",
+    );
+    expect(tracker.getCapturedError()).toBeInstanceOf(Error);
+
+    tracker.onRenderError({ digest: "NEXT_NOT_FOUND" }, { path: "/test" }, { chunk: 2 });
+    expect((tracker.getCapturedError() as Error).message).toBe("boom");
+    expect(baseOnError).toHaveBeenCalledTimes(2);
+  });
+
+  it("only rerenders with global-error when an RSC error was captured and no local boundary exists", () => {
+    expect(
+      shouldRerenderAppPageWithGlobalError({
+        capturedError: new Error("boom"),
+        hasLocalBoundary: false,
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldRerenderAppPageWithGlobalError({
+        capturedError: new Error("boom"),
+        hasLocalBoundary: true,
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldRerenderAppPageWithGlobalError({
+        capturedError: null,
+        hasLocalBoundary: false,
+      }),
+    ).toBe(false);
+  });
+});

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -3684,6 +3684,17 @@ describe("generateRscEntry ISR code generation", () => {
     );
   });
 
+  it("generated code delegates page HTML stream plumbing to typed helpers", () => {
+    const code = generateRscEntry("/tmp/test/app", minimalRoutes);
+    expect(code).toContain("createAppPageFontData as __createAppPageFontData");
+    expect(code).toContain("renderAppPageHtmlResponse as __renderAppPageHtmlResponse");
+    expect(code).toContain("renderAppPageHtmlStream as __renderAppPageHtmlStream");
+    expect(code).toContain(
+      "shouldRerenderAppPageWithGlobalError as __shouldRerenderAppPageWithGlobalError",
+    );
+    expect(code).toContain("createAppPageRscErrorTracker as __createAppPageRscErrorTracker");
+  });
+
   it("generated code delegates page cache HIT handling to a typed helper", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes);
     expect(code).toContain("readAppPageCacheResponse as __readAppPageCacheResponse");


### PR DESCRIPTION
## Summary
- extract the remaining repeated App Router page stream/SSR handoff helpers from `app-rsc-entry.ts` into a typed runtime module
- delegate fallback/error HTML responses, main-page SSR handoff, font data collection, and RSC error tracking through `app-page-stream.ts`
- add focused unit coverage for the new helper and update generated-entry assertions/snapshots

## Testing
- `vp check packages/vinext/src/server/app-page-stream.ts packages/vinext/src/entries/app-rsc-entry.ts tests/app-page-stream.test.ts tests/app-router.test.ts`
- `vp test run tests/app-page-stream.test.ts tests/app-router.test.ts -t "app page stream helpers|generated code delegates page HTML stream plumbing|generated code delegates page probes|RSC stream tee for rscData capture happens before the RSC response is returned"`
- `vp test run tests/app-page-stream.test.ts tests/app-page-execution.test.ts tests/app-page-cache.test.ts tests/app-page-response.test.ts`
- `vp test run tests/entry-templates.test.ts -u`
- `vp test run tests/app-router.test.ts -t "generated code|page ISR \+ searchParams"`
- `vp run vinext#build`

Written by Codex.