### PR TITLE
refactor: extract app page boundary helpers

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -59,6 +59,9 @@ const appPageResponsePath = fileURLToPath(
 const appPageExecutionPath = fileURLToPath(
   new URL("../server/app-page-execution.js", import.meta.url),
 ).replace(/\\/g, "/");
+const appPageBoundaryPath = fileURLToPath(
+  new URL("../server/app-page-boundary.js", import.meta.url),
+).replace(/\\/g, "/");
 const appPageStreamPath = fileURLToPath(
   new URL("../server/app-page-stream.js", import.meta.url),
 ).replace(/\\/g, "/");
@@ -391,6 +394,12 @@ import {
   resolveAppPageSpecialError as __resolveAppPageSpecialError,
   teeAppPageRscStreamForCapture as __teeAppPageRscStreamForCapture,
 } from ${JSON.stringify(appPageExecutionPath)};
+import {
+  renderAppPageBoundaryResponse as __renderAppPageBoundaryResponse,
+  resolveAppPageErrorBoundary as __resolveAppPageErrorBoundary,
+  resolveAppPageHttpAccessBoundaryComponent as __resolveAppPageHttpAccessBoundaryComponent,
+  wrapAppPageBoundaryElement as __wrapAppPageBoundaryElement,
+} from ${JSON.stringify(appPageBoundaryPath)};
 import {
   createAppPageFontData as __createAppPageFontData,
   createAppPageRscErrorTracker as __createAppPageRscErrorTracker,
@@ -774,19 +783,20 @@ const rootLayouts = [${rootLayoutVars.join(", ")}];
  * @param opts.layouts - Override the layouts to wrap with (for layout-level notFound, excludes the throwing layout)
  */
 async function renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, opts) {
-  // Determine which boundary component to use based on status code
-  let BoundaryComponent = opts?.boundaryComponent ?? null;
-  if (!BoundaryComponent) {
-    let boundaryModule;
-    if (statusCode === 403) {
-      boundaryModule = route?.forbidden ?? rootForbiddenModule;
-    } else if (statusCode === 401) {
-      boundaryModule = route?.unauthorized ?? rootUnauthorizedModule;
-    } else {
-      boundaryModule = route?.notFound ?? rootNotFoundModule;
-    }
-    BoundaryComponent = boundaryModule?.default ?? null;
-  }
+  const BoundaryComponent =
+    opts?.boundaryComponent ??
+    __resolveAppPageHttpAccessBoundaryComponent({
+      getDefaultExport(boundaryModule) {
+        return boundaryModule?.default ?? null;
+      },
+      rootForbiddenModule: rootForbiddenModule,
+      rootNotFoundModule: rootNotFoundModule,
+      rootUnauthorizedModule: rootUnauthorizedModule,
+      routeForbiddenModule: route?.forbidden,
+      routeNotFoundModule: route?.notFound,
+      routeUnauthorizedModule: route?.unauthorized,
+      statusCode,
+    });
   const layouts = opts?.layouts ?? route?.layouts ?? rootLayouts;
   if (!BoundaryComponent) return null;
 
@@ -823,94 +833,67 @@ async function renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, req
   if (resolvedMetadata) headElements.push(createElement(MetadataHead, { metadata: resolvedMetadata }));
   headElements.push(createElement(ViewportHead, { viewport: resolvedViewport }));
   let element = createElement(Fragment, null, ...headElements, createElement(BoundaryComponent));
-  if (isRscRequest) {
-    // For RSC requests (client-side navigation), wrap the element with the same
-    // component wrappers that buildPageElement() uses. Without these wrappers,
-    // React's reconciliation would see a mismatched tree structure between the
-    // old fiber tree (ErrorBoundary > LayoutSegmentProvider > html > body > NotFoundBoundary > ...)
-    // and the new tree (html > body > ...), causing it to destroy and recreate
-    // the entire DOM tree, resulting in a blank white page.
-    //
-    // We wrap each layout with LayoutSegmentProvider and add GlobalErrorBoundary
-    // to match the wrapping order in buildPageElement(), ensuring smooth
-    // client-side tree reconciliation.
-    const _treePositions = route?.layoutTreePositions;
-    const _routeSegs = route?.routeSegments || [];
-    const _fallbackParams = opts?.matchedParams ?? route?.params ?? {};
-    const _asyncFallbackParams = makeThenableParams(_fallbackParams);
-    for (let i = layouts.length - 1; i >= 0; i--) {
-      const LayoutComponent = layouts[i]?.default;
-      if (LayoutComponent) {
-        element = createElement(LayoutComponent, { children: element, params: _asyncFallbackParams });
-        const _tp = _treePositions ? _treePositions[i] : 0;
-        const _cs = __resolveChildSegments(_routeSegs, _tp, _fallbackParams);
-        element = createElement(LayoutSegmentProvider, { childSegments: _cs }, element);
-      }
-    }
-    ${
-      globalErrorVar
-        ? `
-    const _GlobalErrorComponent = ${globalErrorVar}.default;
-    if (_GlobalErrorComponent) {
-      element = createElement(ErrorBoundary, {
-        fallback: _GlobalErrorComponent,
-        children: element,
-      });
-    }
-    `
-        : ""
-    }
-    const _pathname = new URL(request.url).pathname;
-    const onRenderError = createRscOnErrorHandler(
-      request,
-      _pathname,
-      route?.pattern ?? _pathname,
-    );
-    const rscStream = renderToReadableStream(element, { onError: onRenderError });
-    // Do NOT clear context here — the RSC stream is consumed lazily by the client.
-    // Clearing context now would cause async server components (e.g. NextIntlClientProviderServer)
-    // that run during stream consumption to see null headers/navigation context and throw,
-    // resulting in missing provider context on the client (e.g. next-intl useTranslations fails
-    // with "context from NextIntlClientProvider was not found").
-    // Context is cleared naturally when the ALS scope from runWithRequestContext unwinds.
-    return new Response(rscStream, {
-      status: statusCode,
-      headers: { "Content-Type": "text/x-component; charset=utf-8", "Vary": "RSC, Accept" },
-    });
-  }
-  // For HTML (full page load) responses, wrap with layouts only (no client-side
-  // wrappers needed since SSR generates the complete HTML document).
-  const _fallbackParamsHtml = opts?.matchedParams ?? route?.params ?? {};
-  const _asyncFallbackParamsHtml = makeThenableParams(_fallbackParamsHtml);
-  for (let i = layouts.length - 1; i >= 0; i--) {
-    const LayoutComponent = layouts[i]?.default;
-    if (LayoutComponent) {
-      element = createElement(LayoutComponent, { children: element, params: _asyncFallbackParamsHtml });
-    }
-  }
-  const _pathname = new URL(request.url).pathname;
-  const onRenderError = createRscOnErrorHandler(
-    request,
-    _pathname,
-    route?.pattern ?? _pathname,
-  );
-  const rscStream = renderToReadableStream(element, { onError: onRenderError });
-  const fontData = __createAppPageFontData({
-    getLinks: _getSSRFontLinks,
-    getPreloads: _getSSRFontPreloads,
-    getStyles: _getSSRFontStyles,
-  });
-  const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
-  return __renderAppPageHtmlResponse({
-    clearRequestContext() {
-      setHeadersContext(null);
-      setNavigationContext(null);
+  element = __wrapAppPageBoundaryElement({
+    element,
+    getDefaultExport(layoutModule) {
+      return layoutModule?.default ?? null;
     },
-    fontData,
-    fontLinkHeader: __buildAppPageFontLinkHeader(fontData.preloads),
-    navigationContext: _getNavigationContext(),
-    rscStream,
-    ssrHandler: ssrEntry,
+    globalErrorComponent: ${globalErrorVar ? `${globalErrorVar}.default` : "null"},
+    includeGlobalErrorBoundary: true,
+    isRscRequest,
+    layoutModules: layouts,
+    layoutTreePositions: route?.layoutTreePositions,
+    makeThenableParams,
+    matchedParams: _fallbackParams,
+    renderErrorBoundary(GlobalErrorComponent, children) {
+      return createElement(ErrorBoundary, {
+        fallback: GlobalErrorComponent,
+        children,
+      });
+    },
+    renderLayout(LayoutComponent, children, asyncParams) {
+      return createElement(LayoutComponent, { children, params: asyncParams });
+    },
+    renderLayoutSegmentProvider(childSegments, children) {
+      return createElement(LayoutSegmentProvider, { childSegments }, children);
+    },
+    resolveChildSegments(routeSegments, treePosition, boundaryParams) {
+      return __resolveChildSegments(routeSegments, treePosition, boundaryParams);
+    },
+    routeSegments: route?.routeSegments || [],
+  });
+  const _pathname = new URL(request.url).pathname;
+  return __renderAppPageBoundaryResponse({
+    async createHtmlResponse(rscStream, responseStatus) {
+      const fontData = __createAppPageFontData({
+        getLinks: _getSSRFontLinks,
+        getPreloads: _getSSRFontPreloads,
+        getStyles: _getSSRFontStyles,
+      });
+      const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
+      return __renderAppPageHtmlResponse({
+        clearRequestContext() {
+          setHeadersContext(null);
+          setNavigationContext(null);
+        },
+        fontData,
+        fontLinkHeader: __buildAppPageFontLinkHeader(fontData.preloads),
+        navigationContext: _getNavigationContext(),
+        rscStream,
+        ssrHandler: ssrEntry,
+        status: responseStatus,
+      });
+    },
+    createRscOnErrorHandler() {
+      return createRscOnErrorHandler(
+        request,
+        _pathname,
+        route?.pattern ?? _pathname,
+      );
+    },
+    element,
+    isRscRequest,
+    renderToReadableStream,
     status: statusCode,
   });
 }
@@ -928,29 +911,15 @@ async function renderNotFoundPage(route, isRscRequest, request, matchedParams) {
  * by the boundary). This matches that behavior intentionally.
  */
 async function renderErrorBoundaryPage(route, error, isRscRequest, request, matchedParams) {
-  // Resolve the error boundary component: leaf error.tsx first, then walk per-layout
-  // errors from innermost to outermost (matching ancestor inheritance), then global-error.tsx.
-  let ErrorComponent = route?.error?.default ?? null;
-  let _isGlobalError = false;
-  if (!ErrorComponent && route?.errors) {
-    for (let i = route.errors.length - 1; i >= 0; i--) {
-      if (route.errors[i]?.default) {
-        ErrorComponent = route.errors[i].default;
-        break;
-      }
-    }
-  }
-  ${
-    globalErrorVar
-      ? `
-  if (!ErrorComponent) {
-    ErrorComponent = ${globalErrorVar}?.default ?? null;
-    _isGlobalError = !!ErrorComponent;
-  }
-  `
-      : ""
-  }
-  if (!ErrorComponent) return null;
+  const __errorBoundary = __resolveAppPageErrorBoundary({
+    getDefaultExport(errorModule) {
+      return errorModule?.default ?? null;
+    },
+    globalErrorModule: ${globalErrorVar ? globalErrorVar : "null"},
+    layoutErrorModules: route?.errors,
+    pageErrorModule: route?.error,
+  });
+  if (!__errorBoundary.component) return null;
 
   const rawError = error instanceof Error ? error : new Error(String(error));
   // Sanitize the error in production to avoid leaking internal details
@@ -961,97 +930,73 @@ async function renderErrorBoundaryPage(route, error, isRscRequest, request, matc
   // can't be serialized through RSC. The error.tsx component will receive reset=undefined
   // during SSR, which is fine — onClick={undefined} is harmless, and the real reset
   // function is only meaningful after hydration.
-  let element = createElement(ErrorComponent, {
+  let element = createElement(__errorBoundary.component, {
     error: errorObj,
   });
-
-  // global-error.tsx provides its own <html> and <body> (it replaces the root
-  // layout). Skip layout wrapping when rendering it to avoid double <html> tags.
-  if (!_isGlobalError) {
-    const layouts = route?.layouts ?? rootLayouts;
-    if (isRscRequest) {
-      // For RSC requests (client-side navigation), wrap with the same component
-      // wrappers that buildPageElement() uses (LayoutSegmentProvider, GlobalErrorBoundary).
-      // This ensures React can reconcile the tree without destroying the DOM.
-      // Same rationale as renderHTTPAccessFallbackPage — see comment there.
-      const _errTreePositions = route?.layoutTreePositions;
-      const _errRouteSegs = route?.routeSegments || [];
-      const _errParams = matchedParams ?? route?.params ?? {};
-      const _asyncErrParams = makeThenableParams(_errParams);
-      for (let i = layouts.length - 1; i >= 0; i--) {
-        const LayoutComponent = layouts[i]?.default;
-        if (LayoutComponent) {
-          element = createElement(LayoutComponent, { children: element, params: _asyncErrParams });
-          const _etp = _errTreePositions ? _errTreePositions[i] : 0;
-          const _ecs = __resolveChildSegments(_errRouteSegs, _etp, _errParams);
-          element = createElement(LayoutSegmentProvider, { childSegments: _ecs }, element);
-        }
-      }
-      ${
-        globalErrorVar
-          ? `
-      const _ErrGlobalComponent = ${globalErrorVar}.default;
-      if (_ErrGlobalComponent) {
-        element = createElement(ErrorBoundary, {
-          fallback: _ErrGlobalComponent,
-          children: element,
-        });
-      }
-      `
-          : ""
-      }
-    } else {
-      // For HTML (full page load) responses, wrap with layouts only.
-      const _errParamsHtml = matchedParams ?? route?.params ?? {};
-      const _asyncErrParamsHtml = makeThenableParams(_errParamsHtml);
-      for (let i = layouts.length - 1; i >= 0; i--) {
-        const LayoutComponent = layouts[i]?.default;
-        if (LayoutComponent) {
-          element = createElement(LayoutComponent, { children: element, params: _asyncErrParamsHtml });
-        }
-      }
-    }
-  }
+  const _errParams = matchedParams ?? route?.params ?? {};
+  element = __wrapAppPageBoundaryElement({
+    element,
+    getDefaultExport(layoutModule) {
+      return layoutModule?.default ?? null;
+    },
+    globalErrorComponent: ${globalErrorVar ? `${globalErrorVar}.default` : "null"},
+    includeGlobalErrorBoundary: !__errorBoundary.isGlobalError,
+    isRscRequest,
+    layoutModules: route?.layouts ?? rootLayouts,
+    layoutTreePositions: route?.layoutTreePositions,
+    makeThenableParams,
+    matchedParams: _errParams,
+    renderErrorBoundary(GlobalErrorComponent, children) {
+      return createElement(ErrorBoundary, {
+        fallback: GlobalErrorComponent,
+        children,
+      });
+    },
+    renderLayout(LayoutComponent, children, asyncParams) {
+      return createElement(LayoutComponent, { children, params: asyncParams });
+    },
+    renderLayoutSegmentProvider(childSegments, children) {
+      return createElement(LayoutSegmentProvider, { childSegments }, children);
+    },
+    resolveChildSegments(routeSegments, treePosition, boundaryParams) {
+      return __resolveChildSegments(routeSegments, treePosition, boundaryParams);
+    },
+    routeSegments: route?.routeSegments || [],
+    skipLayoutWrapping: __errorBoundary.isGlobalError,
+  });
 
   const _pathname = new URL(request.url).pathname;
-  const onRenderError = createRscOnErrorHandler(
-    request,
-    _pathname,
-    route?.pattern ?? _pathname,
-  );
-
-  if (isRscRequest) {
-    const rscStream = renderToReadableStream(element, { onError: onRenderError });
-    // Do NOT clear context here — the RSC stream is consumed lazily by the client.
-    // Clearing context now would cause async server components (e.g. NextIntlClientProviderServer)
-    // that run during stream consumption to see null headers/navigation context and throw,
-    // resulting in missing provider context on the client (e.g. next-intl useTranslations fails
-    // with "context from NextIntlClientProvider was not found").
-    // Context is cleared naturally when the ALS scope from runWithRequestContext unwinds.
-    return new Response(rscStream, {
-      status: 200,
-      headers: { "Content-Type": "text/x-component; charset=utf-8", "Vary": "RSC, Accept" },
-    });
-  }
-
-  // HTML (full page load) response — render through RSC → SSR pipeline
-  const rscStream = renderToReadableStream(element, { onError: onRenderError });
-  const fontData = __createAppPageFontData({
-    getLinks: _getSSRFontLinks,
-    getPreloads: _getSSRFontPreloads,
-    getStyles: _getSSRFontStyles,
-  });
-  const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
-  return __renderAppPageHtmlResponse({
-    clearRequestContext() {
-      setHeadersContext(null);
-      setNavigationContext(null);
+  return __renderAppPageBoundaryResponse({
+    async createHtmlResponse(rscStream, responseStatus) {
+      const fontData = __createAppPageFontData({
+        getLinks: _getSSRFontLinks,
+        getPreloads: _getSSRFontPreloads,
+        getStyles: _getSSRFontStyles,
+      });
+      const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
+      return __renderAppPageHtmlResponse({
+        clearRequestContext() {
+          setHeadersContext(null);
+          setNavigationContext(null);
+        },
+        fontData,
+        fontLinkHeader: __buildAppPageFontLinkHeader(fontData.preloads),
+        navigationContext: _getNavigationContext(),
+        rscStream,
+        ssrHandler: ssrEntry,
+        status: responseStatus,
+      });
     },
-    fontData,
-    fontLinkHeader: __buildAppPageFontLinkHeader(fontData.preloads),
-    navigationContext: _getNavigationContext(),
-    rscStream,
-    ssrHandler: ssrEntry,
+    createRscOnErrorHandler() {
+      return createRscOnErrorHandler(
+        request,
+        _pathname,
+        route?.pattern ?? _pathname,
+      );
+    },
+    element,
+    isRscRequest,
+    renderToReadableStream,
     status: 200,
   });
 }

--- a/packages/vinext/src/server/app-page-boundary.ts
+++ b/packages/vinext/src/server/app-page-boundary.ts
@@ -1,0 +1,189 @@
+export type AppPageParams = Record<string, string | string[]>;
+
+export interface ResolveAppPageHttpAccessBoundaryComponentOptions<TModule, TComponent> {
+  getDefaultExport: (module: TModule | null | undefined) => TComponent | null | undefined;
+  rootForbiddenModule?: TModule | null;
+  rootNotFoundModule?: TModule | null;
+  rootUnauthorizedModule?: TModule | null;
+  routeForbiddenModule?: TModule | null;
+  routeNotFoundModule?: TModule | null;
+  routeUnauthorizedModule?: TModule | null;
+  statusCode: number;
+}
+
+export interface ResolveAppPageErrorBoundaryOptions<TModule, TComponent> {
+  getDefaultExport: (module: TModule | null | undefined) => TComponent | null | undefined;
+  globalErrorModule?: TModule | null;
+  layoutErrorModules?: readonly (TModule | null | undefined)[] | null;
+  pageErrorModule?: TModule | null;
+}
+
+export interface ResolveAppPageErrorBoundaryResult<TComponent> {
+  component: TComponent | null;
+  isGlobalError: boolean;
+}
+
+export interface WrapAppPageBoundaryElementOptions<
+  TElement,
+  TLayoutModule,
+  TLayoutComponent,
+  TChildSegments,
+  TGlobalErrorComponent,
+> {
+  element: TElement;
+  getDefaultExport: (
+    module: TLayoutModule | null | undefined,
+  ) => TLayoutComponent | null | undefined;
+  globalErrorComponent?: TGlobalErrorComponent | null;
+  includeGlobalErrorBoundary: boolean;
+  isRscRequest: boolean;
+  layoutModules: readonly (TLayoutModule | null | undefined)[];
+  layoutTreePositions?: readonly number[] | null;
+  makeThenableParams: (params: AppPageParams) => unknown;
+  matchedParams: AppPageParams;
+  renderErrorBoundary: (component: TGlobalErrorComponent, children: TElement) => TElement;
+  renderLayout: (component: TLayoutComponent, children: TElement, params: unknown) => TElement;
+  renderLayoutSegmentProvider?: (childSegments: TChildSegments, children: TElement) => TElement;
+  resolveChildSegments?: (
+    routeSegments: readonly string[],
+    treePosition: number,
+    params: AppPageParams,
+  ) => TChildSegments;
+  routeSegments?: readonly string[];
+  skipLayoutWrapping?: boolean;
+}
+
+type AppPageBoundaryOnError = (
+  error: unknown,
+  requestInfo: unknown,
+  errorContext: unknown,
+) => unknown;
+
+export interface RenderAppPageBoundaryResponseOptions<TElement> {
+  createHtmlResponse: (rscStream: ReadableStream<Uint8Array>, status: number) => Promise<Response>;
+  createRscOnErrorHandler: () => AppPageBoundaryOnError;
+  element: TElement;
+  isRscRequest: boolean;
+  renderToReadableStream: (
+    element: TElement,
+    options: { onError: AppPageBoundaryOnError },
+  ) => ReadableStream<Uint8Array>;
+  status: number;
+}
+
+export function resolveAppPageHttpAccessBoundaryComponent<TModule, TComponent>(
+  options: ResolveAppPageHttpAccessBoundaryComponentOptions<TModule, TComponent>,
+): TComponent | null {
+  let boundaryModule: TModule | null | undefined;
+
+  if (options.statusCode === 403) {
+    boundaryModule = options.routeForbiddenModule ?? options.rootForbiddenModule;
+  } else if (options.statusCode === 401) {
+    boundaryModule = options.routeUnauthorizedModule ?? options.rootUnauthorizedModule;
+  } else {
+    boundaryModule = options.routeNotFoundModule ?? options.rootNotFoundModule;
+  }
+
+  return options.getDefaultExport(boundaryModule) ?? null;
+}
+
+export function resolveAppPageErrorBoundary<TModule, TComponent>(
+  options: ResolveAppPageErrorBoundaryOptions<TModule, TComponent>,
+): ResolveAppPageErrorBoundaryResult<TComponent> {
+  const pageErrorComponent = options.getDefaultExport(options.pageErrorModule);
+  if (pageErrorComponent) {
+    return {
+      component: pageErrorComponent,
+      isGlobalError: false,
+    };
+  }
+
+  if (options.layoutErrorModules) {
+    for (let index = options.layoutErrorModules.length - 1; index >= 0; index--) {
+      const layoutErrorComponent = options.getDefaultExport(options.layoutErrorModules[index]);
+      if (layoutErrorComponent) {
+        return {
+          component: layoutErrorComponent,
+          isGlobalError: false,
+        };
+      }
+    }
+  }
+
+  const globalErrorComponent = options.getDefaultExport(options.globalErrorModule);
+  return {
+    component: globalErrorComponent ?? null,
+    isGlobalError: Boolean(globalErrorComponent),
+  };
+}
+
+export function wrapAppPageBoundaryElement<
+  TElement,
+  TLayoutModule,
+  TLayoutComponent,
+  TChildSegments,
+  TGlobalErrorComponent,
+>(
+  options: WrapAppPageBoundaryElementOptions<
+    TElement,
+    TLayoutModule,
+    TLayoutComponent,
+    TChildSegments,
+    TGlobalErrorComponent
+  >,
+): TElement {
+  let element = options.element;
+
+  if (!options.skipLayoutWrapping) {
+    const asyncParams = options.makeThenableParams(options.matchedParams);
+
+    for (let index = options.layoutModules.length - 1; index >= 0; index--) {
+      const layoutComponent = options.getDefaultExport(options.layoutModules[index]);
+      if (!layoutComponent) {
+        continue;
+      }
+
+      element = options.renderLayout(layoutComponent, element, asyncParams);
+
+      if (
+        options.isRscRequest &&
+        options.renderLayoutSegmentProvider &&
+        options.resolveChildSegments
+      ) {
+        const treePosition = options.layoutTreePositions ? options.layoutTreePositions[index] : 0;
+        const childSegments = options.resolveChildSegments(
+          options.routeSegments ?? [],
+          treePosition,
+          options.matchedParams,
+        );
+        element = options.renderLayoutSegmentProvider(childSegments, element);
+      }
+    }
+  }
+
+  if (options.isRscRequest && options.includeGlobalErrorBoundary && options.globalErrorComponent) {
+    element = options.renderErrorBoundary(options.globalErrorComponent, element);
+  }
+
+  return element;
+}
+
+export async function renderAppPageBoundaryResponse<TElement>(
+  options: RenderAppPageBoundaryResponseOptions<TElement>,
+): Promise<Response> {
+  const rscStream = options.renderToReadableStream(options.element, {
+    onError: options.createRscOnErrorHandler(),
+  });
+
+  if (options.isRscRequest) {
+    // Do NOT clear request-scoped context here. RSC responses are consumed lazily
+    // by the client, so headers()/cookies() and async server components still need
+    // their ALS-backed state while the stream is being read.
+    return new Response(rscStream, {
+      status: options.status,
+      headers: { "Content-Type": "text/x-component; charset=utf-8", Vary: "RSC, Accept" },
+    });
+  }
+
+  return options.createHtmlResponse(rscStream, options.status);
+}

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -87,6 +87,12 @@ import {
   teeAppPageRscStreamForCapture as __teeAppPageRscStreamForCapture,
 } from "<ROOT>/packages/vinext/src/server/app-page-execution.js";
 import {
+  renderAppPageBoundaryResponse as __renderAppPageBoundaryResponse,
+  resolveAppPageErrorBoundary as __resolveAppPageErrorBoundary,
+  resolveAppPageHttpAccessBoundaryComponent as __resolveAppPageHttpAccessBoundaryComponent,
+  wrapAppPageBoundaryElement as __wrapAppPageBoundaryElement,
+} from "<ROOT>/packages/vinext/src/server/app-page-boundary.js";
+import {
   createAppPageFontData as __createAppPageFontData,
   createAppPageRscErrorTracker as __createAppPageRscErrorTracker,
   renderAppPageHtmlResponse as __renderAppPageHtmlResponse,
@@ -532,19 +538,20 @@ const rootLayouts = [mod_1];
  * @param opts.layouts - Override the layouts to wrap with (for layout-level notFound, excludes the throwing layout)
  */
 async function renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, opts) {
-  // Determine which boundary component to use based on status code
-  let BoundaryComponent = opts?.boundaryComponent ?? null;
-  if (!BoundaryComponent) {
-    let boundaryModule;
-    if (statusCode === 403) {
-      boundaryModule = route?.forbidden ?? rootForbiddenModule;
-    } else if (statusCode === 401) {
-      boundaryModule = route?.unauthorized ?? rootUnauthorizedModule;
-    } else {
-      boundaryModule = route?.notFound ?? rootNotFoundModule;
-    }
-    BoundaryComponent = boundaryModule?.default ?? null;
-  }
+  const BoundaryComponent =
+    opts?.boundaryComponent ??
+    __resolveAppPageHttpAccessBoundaryComponent({
+      getDefaultExport(boundaryModule) {
+        return boundaryModule?.default ?? null;
+      },
+      rootForbiddenModule: rootForbiddenModule,
+      rootNotFoundModule: rootNotFoundModule,
+      rootUnauthorizedModule: rootUnauthorizedModule,
+      routeForbiddenModule: route?.forbidden,
+      routeNotFoundModule: route?.notFound,
+      routeUnauthorizedModule: route?.unauthorized,
+      statusCode,
+    });
   const layouts = opts?.layouts ?? route?.layouts ?? rootLayouts;
   if (!BoundaryComponent) return null;
 
@@ -581,82 +588,67 @@ async function renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, req
   if (resolvedMetadata) headElements.push(createElement(MetadataHead, { metadata: resolvedMetadata }));
   headElements.push(createElement(ViewportHead, { viewport: resolvedViewport }));
   let element = createElement(Fragment, null, ...headElements, createElement(BoundaryComponent));
-  if (isRscRequest) {
-    // For RSC requests (client-side navigation), wrap the element with the same
-    // component wrappers that buildPageElement() uses. Without these wrappers,
-    // React's reconciliation would see a mismatched tree structure between the
-    // old fiber tree (ErrorBoundary > LayoutSegmentProvider > html > body > NotFoundBoundary > ...)
-    // and the new tree (html > body > ...), causing it to destroy and recreate
-    // the entire DOM tree, resulting in a blank white page.
-    //
-    // We wrap each layout with LayoutSegmentProvider and add GlobalErrorBoundary
-    // to match the wrapping order in buildPageElement(), ensuring smooth
-    // client-side tree reconciliation.
-    const _treePositions = route?.layoutTreePositions;
-    const _routeSegs = route?.routeSegments || [];
-    const _fallbackParams = opts?.matchedParams ?? route?.params ?? {};
-    const _asyncFallbackParams = makeThenableParams(_fallbackParams);
-    for (let i = layouts.length - 1; i >= 0; i--) {
-      const LayoutComponent = layouts[i]?.default;
-      if (LayoutComponent) {
-        element = createElement(LayoutComponent, { children: element, params: _asyncFallbackParams });
-        const _tp = _treePositions ? _treePositions[i] : 0;
-        const _cs = __resolveChildSegments(_routeSegs, _tp, _fallbackParams);
-        element = createElement(LayoutSegmentProvider, { childSegments: _cs }, element);
-      }
-    }
-    
-    const _pathname = new URL(request.url).pathname;
-    const onRenderError = createRscOnErrorHandler(
-      request,
-      _pathname,
-      route?.pattern ?? _pathname,
-    );
-    const rscStream = renderToReadableStream(element, { onError: onRenderError });
-    // Do NOT clear context here — the RSC stream is consumed lazily by the client.
-    // Clearing context now would cause async server components (e.g. NextIntlClientProviderServer)
-    // that run during stream consumption to see null headers/navigation context and throw,
-    // resulting in missing provider context on the client (e.g. next-intl useTranslations fails
-    // with "context from NextIntlClientProvider was not found").
-    // Context is cleared naturally when the ALS scope from runWithRequestContext unwinds.
-    return new Response(rscStream, {
-      status: statusCode,
-      headers: { "Content-Type": "text/x-component; charset=utf-8", "Vary": "RSC, Accept" },
-    });
-  }
-  // For HTML (full page load) responses, wrap with layouts only (no client-side
-  // wrappers needed since SSR generates the complete HTML document).
-  const _fallbackParamsHtml = opts?.matchedParams ?? route?.params ?? {};
-  const _asyncFallbackParamsHtml = makeThenableParams(_fallbackParamsHtml);
-  for (let i = layouts.length - 1; i >= 0; i--) {
-    const LayoutComponent = layouts[i]?.default;
-    if (LayoutComponent) {
-      element = createElement(LayoutComponent, { children: element, params: _asyncFallbackParamsHtml });
-    }
-  }
-  const _pathname = new URL(request.url).pathname;
-  const onRenderError = createRscOnErrorHandler(
-    request,
-    _pathname,
-    route?.pattern ?? _pathname,
-  );
-  const rscStream = renderToReadableStream(element, { onError: onRenderError });
-  const fontData = __createAppPageFontData({
-    getLinks: _getSSRFontLinks,
-    getPreloads: _getSSRFontPreloads,
-    getStyles: _getSSRFontStyles,
-  });
-  const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
-  return __renderAppPageHtmlResponse({
-    clearRequestContext() {
-      setHeadersContext(null);
-      setNavigationContext(null);
+  element = __wrapAppPageBoundaryElement({
+    element,
+    getDefaultExport(layoutModule) {
+      return layoutModule?.default ?? null;
     },
-    fontData,
-    fontLinkHeader: __buildAppPageFontLinkHeader(fontData.preloads),
-    navigationContext: _getNavigationContext(),
-    rscStream,
-    ssrHandler: ssrEntry,
+    globalErrorComponent: null,
+    includeGlobalErrorBoundary: true,
+    isRscRequest,
+    layoutModules: layouts,
+    layoutTreePositions: route?.layoutTreePositions,
+    makeThenableParams,
+    matchedParams: _fallbackParams,
+    renderErrorBoundary(GlobalErrorComponent, children) {
+      return createElement(ErrorBoundary, {
+        fallback: GlobalErrorComponent,
+        children,
+      });
+    },
+    renderLayout(LayoutComponent, children, asyncParams) {
+      return createElement(LayoutComponent, { children, params: asyncParams });
+    },
+    renderLayoutSegmentProvider(childSegments, children) {
+      return createElement(LayoutSegmentProvider, { childSegments }, children);
+    },
+    resolveChildSegments(routeSegments, treePosition, boundaryParams) {
+      return __resolveChildSegments(routeSegments, treePosition, boundaryParams);
+    },
+    routeSegments: route?.routeSegments || [],
+  });
+  const _pathname = new URL(request.url).pathname;
+  return __renderAppPageBoundaryResponse({
+    async createHtmlResponse(rscStream, responseStatus) {
+      const fontData = __createAppPageFontData({
+        getLinks: _getSSRFontLinks,
+        getPreloads: _getSSRFontPreloads,
+        getStyles: _getSSRFontStyles,
+      });
+      const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
+      return __renderAppPageHtmlResponse({
+        clearRequestContext() {
+          setHeadersContext(null);
+          setNavigationContext(null);
+        },
+        fontData,
+        fontLinkHeader: __buildAppPageFontLinkHeader(fontData.preloads),
+        navigationContext: _getNavigationContext(),
+        rscStream,
+        ssrHandler: ssrEntry,
+        status: responseStatus,
+      });
+    },
+    createRscOnErrorHandler() {
+      return createRscOnErrorHandler(
+        request,
+        _pathname,
+        route?.pattern ?? _pathname,
+      );
+    },
+    element,
+    isRscRequest,
+    renderToReadableStream,
     status: statusCode,
   });
 }
@@ -674,20 +666,15 @@ async function renderNotFoundPage(route, isRscRequest, request, matchedParams) {
  * by the boundary). This matches that behavior intentionally.
  */
 async function renderErrorBoundaryPage(route, error, isRscRequest, request, matchedParams) {
-  // Resolve the error boundary component: leaf error.tsx first, then walk per-layout
-  // errors from innermost to outermost (matching ancestor inheritance), then global-error.tsx.
-  let ErrorComponent = route?.error?.default ?? null;
-  let _isGlobalError = false;
-  if (!ErrorComponent && route?.errors) {
-    for (let i = route.errors.length - 1; i >= 0; i--) {
-      if (route.errors[i]?.default) {
-        ErrorComponent = route.errors[i].default;
-        break;
-      }
-    }
-  }
-  
-  if (!ErrorComponent) return null;
+  const __errorBoundary = __resolveAppPageErrorBoundary({
+    getDefaultExport(errorModule) {
+      return errorModule?.default ?? null;
+    },
+    globalErrorModule: null,
+    layoutErrorModules: route?.errors,
+    pageErrorModule: route?.error,
+  });
+  if (!__errorBoundary.component) return null;
 
   const rawError = error instanceof Error ? error : new Error(String(error));
   // Sanitize the error in production to avoid leaking internal details
@@ -698,85 +685,73 @@ async function renderErrorBoundaryPage(route, error, isRscRequest, request, matc
   // can't be serialized through RSC. The error.tsx component will receive reset=undefined
   // during SSR, which is fine — onClick={undefined} is harmless, and the real reset
   // function is only meaningful after hydration.
-  let element = createElement(ErrorComponent, {
+  let element = createElement(__errorBoundary.component, {
     error: errorObj,
   });
-
-  // global-error.tsx provides its own <html> and <body> (it replaces the root
-  // layout). Skip layout wrapping when rendering it to avoid double <html> tags.
-  if (!_isGlobalError) {
-    const layouts = route?.layouts ?? rootLayouts;
-    if (isRscRequest) {
-      // For RSC requests (client-side navigation), wrap with the same component
-      // wrappers that buildPageElement() uses (LayoutSegmentProvider, GlobalErrorBoundary).
-      // This ensures React can reconcile the tree without destroying the DOM.
-      // Same rationale as renderHTTPAccessFallbackPage — see comment there.
-      const _errTreePositions = route?.layoutTreePositions;
-      const _errRouteSegs = route?.routeSegments || [];
-      const _errParams = matchedParams ?? route?.params ?? {};
-      const _asyncErrParams = makeThenableParams(_errParams);
-      for (let i = layouts.length - 1; i >= 0; i--) {
-        const LayoutComponent = layouts[i]?.default;
-        if (LayoutComponent) {
-          element = createElement(LayoutComponent, { children: element, params: _asyncErrParams });
-          const _etp = _errTreePositions ? _errTreePositions[i] : 0;
-          const _ecs = __resolveChildSegments(_errRouteSegs, _etp, _errParams);
-          element = createElement(LayoutSegmentProvider, { childSegments: _ecs }, element);
-        }
-      }
-      
-    } else {
-      // For HTML (full page load) responses, wrap with layouts only.
-      const _errParamsHtml = matchedParams ?? route?.params ?? {};
-      const _asyncErrParamsHtml = makeThenableParams(_errParamsHtml);
-      for (let i = layouts.length - 1; i >= 0; i--) {
-        const LayoutComponent = layouts[i]?.default;
-        if (LayoutComponent) {
-          element = createElement(LayoutComponent, { children: element, params: _asyncErrParamsHtml });
-        }
-      }
-    }
-  }
+  const _errParams = matchedParams ?? route?.params ?? {};
+  element = __wrapAppPageBoundaryElement({
+    element,
+    getDefaultExport(layoutModule) {
+      return layoutModule?.default ?? null;
+    },
+    globalErrorComponent: null,
+    includeGlobalErrorBoundary: !__errorBoundary.isGlobalError,
+    isRscRequest,
+    layoutModules: route?.layouts ?? rootLayouts,
+    layoutTreePositions: route?.layoutTreePositions,
+    makeThenableParams,
+    matchedParams: _errParams,
+    renderErrorBoundary(GlobalErrorComponent, children) {
+      return createElement(ErrorBoundary, {
+        fallback: GlobalErrorComponent,
+        children,
+      });
+    },
+    renderLayout(LayoutComponent, children, asyncParams) {
+      return createElement(LayoutComponent, { children, params: asyncParams });
+    },
+    renderLayoutSegmentProvider(childSegments, children) {
+      return createElement(LayoutSegmentProvider, { childSegments }, children);
+    },
+    resolveChildSegments(routeSegments, treePosition, boundaryParams) {
+      return __resolveChildSegments(routeSegments, treePosition, boundaryParams);
+    },
+    routeSegments: route?.routeSegments || [],
+    skipLayoutWrapping: __errorBoundary.isGlobalError,
+  });
 
   const _pathname = new URL(request.url).pathname;
-  const onRenderError = createRscOnErrorHandler(
-    request,
-    _pathname,
-    route?.pattern ?? _pathname,
-  );
-
-  if (isRscRequest) {
-    const rscStream = renderToReadableStream(element, { onError: onRenderError });
-    // Do NOT clear context here — the RSC stream is consumed lazily by the client.
-    // Clearing context now would cause async server components (e.g. NextIntlClientProviderServer)
-    // that run during stream consumption to see null headers/navigation context and throw,
-    // resulting in missing provider context on the client (e.g. next-intl useTranslations fails
-    // with "context from NextIntlClientProvider was not found").
-    // Context is cleared naturally when the ALS scope from runWithRequestContext unwinds.
-    return new Response(rscStream, {
-      status: 200,
-      headers: { "Content-Type": "text/x-component; charset=utf-8", "Vary": "RSC, Accept" },
-    });
-  }
-
-  // HTML (full page load) response — render through RSC → SSR pipeline
-  const rscStream = renderToReadableStream(element, { onError: onRenderError });
-  const fontData = __createAppPageFontData({
-    getLinks: _getSSRFontLinks,
-    getPreloads: _getSSRFontPreloads,
-    getStyles: _getSSRFontStyles,
-  });
-  const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
-  return __renderAppPageHtmlResponse({
-    clearRequestContext() {
-      setHeadersContext(null);
-      setNavigationContext(null);
+  return __renderAppPageBoundaryResponse({
+    async createHtmlResponse(rscStream, responseStatus) {
+      const fontData = __createAppPageFontData({
+        getLinks: _getSSRFontLinks,
+        getPreloads: _getSSRFontPreloads,
+        getStyles: _getSSRFontStyles,
+      });
+      const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
+      return __renderAppPageHtmlResponse({
+        clearRequestContext() {
+          setHeadersContext(null);
+          setNavigationContext(null);
+        },
+        fontData,
+        fontLinkHeader: __buildAppPageFontLinkHeader(fontData.preloads),
+        navigationContext: _getNavigationContext(),
+        rscStream,
+        ssrHandler: ssrEntry,
+        status: responseStatus,
+      });
     },
-    fontData,
-    fontLinkHeader: __buildAppPageFontLinkHeader(fontData.preloads),
-    navigationContext: _getNavigationContext(),
-    rscStream,
-    ssrHandler: ssrEntry,
+    createRscOnErrorHandler() {
+      return createRscOnErrorHandler(
+        request,
+        _pathname,
+        route?.pattern ?? _pathname,
+      );
+    },
+    element,
+    isRscRequest,
+    renderToReadableStream,
     status: 200,
   });
 }
@@ -2669,6 +2644,12 @@ import {
   teeAppPageRscStreamForCapture as __teeAppPageRscStreamForCapture,
 } from "<ROOT>/packages/vinext/src/server/app-page-execution.js";
 import {
+  renderAppPageBoundaryResponse as __renderAppPageBoundaryResponse,
+  resolveAppPageErrorBoundary as __resolveAppPageErrorBoundary,
+  resolveAppPageHttpAccessBoundaryComponent as __resolveAppPageHttpAccessBoundaryComponent,
+  wrapAppPageBoundaryElement as __wrapAppPageBoundaryElement,
+} from "<ROOT>/packages/vinext/src/server/app-page-boundary.js";
+import {
   createAppPageFontData as __createAppPageFontData,
   createAppPageRscErrorTracker as __createAppPageRscErrorTracker,
   renderAppPageHtmlResponse as __renderAppPageHtmlResponse,
@@ -3114,19 +3095,20 @@ const rootLayouts = [mod_1];
  * @param opts.layouts - Override the layouts to wrap with (for layout-level notFound, excludes the throwing layout)
  */
 async function renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, opts) {
-  // Determine which boundary component to use based on status code
-  let BoundaryComponent = opts?.boundaryComponent ?? null;
-  if (!BoundaryComponent) {
-    let boundaryModule;
-    if (statusCode === 403) {
-      boundaryModule = route?.forbidden ?? rootForbiddenModule;
-    } else if (statusCode === 401) {
-      boundaryModule = route?.unauthorized ?? rootUnauthorizedModule;
-    } else {
-      boundaryModule = route?.notFound ?? rootNotFoundModule;
-    }
-    BoundaryComponent = boundaryModule?.default ?? null;
-  }
+  const BoundaryComponent =
+    opts?.boundaryComponent ??
+    __resolveAppPageHttpAccessBoundaryComponent({
+      getDefaultExport(boundaryModule) {
+        return boundaryModule?.default ?? null;
+      },
+      rootForbiddenModule: rootForbiddenModule,
+      rootNotFoundModule: rootNotFoundModule,
+      rootUnauthorizedModule: rootUnauthorizedModule,
+      routeForbiddenModule: route?.forbidden,
+      routeNotFoundModule: route?.notFound,
+      routeUnauthorizedModule: route?.unauthorized,
+      statusCode,
+    });
   const layouts = opts?.layouts ?? route?.layouts ?? rootLayouts;
   if (!BoundaryComponent) return null;
 
@@ -3163,82 +3145,67 @@ async function renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, req
   if (resolvedMetadata) headElements.push(createElement(MetadataHead, { metadata: resolvedMetadata }));
   headElements.push(createElement(ViewportHead, { viewport: resolvedViewport }));
   let element = createElement(Fragment, null, ...headElements, createElement(BoundaryComponent));
-  if (isRscRequest) {
-    // For RSC requests (client-side navigation), wrap the element with the same
-    // component wrappers that buildPageElement() uses. Without these wrappers,
-    // React's reconciliation would see a mismatched tree structure between the
-    // old fiber tree (ErrorBoundary > LayoutSegmentProvider > html > body > NotFoundBoundary > ...)
-    // and the new tree (html > body > ...), causing it to destroy and recreate
-    // the entire DOM tree, resulting in a blank white page.
-    //
-    // We wrap each layout with LayoutSegmentProvider and add GlobalErrorBoundary
-    // to match the wrapping order in buildPageElement(), ensuring smooth
-    // client-side tree reconciliation.
-    const _treePositions = route?.layoutTreePositions;
-    const _routeSegs = route?.routeSegments || [];
-    const _fallbackParams = opts?.matchedParams ?? route?.params ?? {};
-    const _asyncFallbackParams = makeThenableParams(_fallbackParams);
-    for (let i = layouts.length - 1; i >= 0; i--) {
-      const LayoutComponent = layouts[i]?.default;
-      if (LayoutComponent) {
-        element = createElement(LayoutComponent, { children: element, params: _asyncFallbackParams });
-        const _tp = _treePositions ? _treePositions[i] : 0;
-        const _cs = __resolveChildSegments(_routeSegs, _tp, _fallbackParams);
-        element = createElement(LayoutSegmentProvider, { childSegments: _cs }, element);
-      }
-    }
-    
-    const _pathname = new URL(request.url).pathname;
-    const onRenderError = createRscOnErrorHandler(
-      request,
-      _pathname,
-      route?.pattern ?? _pathname,
-    );
-    const rscStream = renderToReadableStream(element, { onError: onRenderError });
-    // Do NOT clear context here — the RSC stream is consumed lazily by the client.
-    // Clearing context now would cause async server components (e.g. NextIntlClientProviderServer)
-    // that run during stream consumption to see null headers/navigation context and throw,
-    // resulting in missing provider context on the client (e.g. next-intl useTranslations fails
-    // with "context from NextIntlClientProvider was not found").
-    // Context is cleared naturally when the ALS scope from runWithRequestContext unwinds.
-    return new Response(rscStream, {
-      status: statusCode,
-      headers: { "Content-Type": "text/x-component; charset=utf-8", "Vary": "RSC, Accept" },
-    });
-  }
-  // For HTML (full page load) responses, wrap with layouts only (no client-side
-  // wrappers needed since SSR generates the complete HTML document).
-  const _fallbackParamsHtml = opts?.matchedParams ?? route?.params ?? {};
-  const _asyncFallbackParamsHtml = makeThenableParams(_fallbackParamsHtml);
-  for (let i = layouts.length - 1; i >= 0; i--) {
-    const LayoutComponent = layouts[i]?.default;
-    if (LayoutComponent) {
-      element = createElement(LayoutComponent, { children: element, params: _asyncFallbackParamsHtml });
-    }
-  }
-  const _pathname = new URL(request.url).pathname;
-  const onRenderError = createRscOnErrorHandler(
-    request,
-    _pathname,
-    route?.pattern ?? _pathname,
-  );
-  const rscStream = renderToReadableStream(element, { onError: onRenderError });
-  const fontData = __createAppPageFontData({
-    getLinks: _getSSRFontLinks,
-    getPreloads: _getSSRFontPreloads,
-    getStyles: _getSSRFontStyles,
-  });
-  const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
-  return __renderAppPageHtmlResponse({
-    clearRequestContext() {
-      setHeadersContext(null);
-      setNavigationContext(null);
+  element = __wrapAppPageBoundaryElement({
+    element,
+    getDefaultExport(layoutModule) {
+      return layoutModule?.default ?? null;
     },
-    fontData,
-    fontLinkHeader: __buildAppPageFontLinkHeader(fontData.preloads),
-    navigationContext: _getNavigationContext(),
-    rscStream,
-    ssrHandler: ssrEntry,
+    globalErrorComponent: null,
+    includeGlobalErrorBoundary: true,
+    isRscRequest,
+    layoutModules: layouts,
+    layoutTreePositions: route?.layoutTreePositions,
+    makeThenableParams,
+    matchedParams: _fallbackParams,
+    renderErrorBoundary(GlobalErrorComponent, children) {
+      return createElement(ErrorBoundary, {
+        fallback: GlobalErrorComponent,
+        children,
+      });
+    },
+    renderLayout(LayoutComponent, children, asyncParams) {
+      return createElement(LayoutComponent, { children, params: asyncParams });
+    },
+    renderLayoutSegmentProvider(childSegments, children) {
+      return createElement(LayoutSegmentProvider, { childSegments }, children);
+    },
+    resolveChildSegments(routeSegments, treePosition, boundaryParams) {
+      return __resolveChildSegments(routeSegments, treePosition, boundaryParams);
+    },
+    routeSegments: route?.routeSegments || [],
+  });
+  const _pathname = new URL(request.url).pathname;
+  return __renderAppPageBoundaryResponse({
+    async createHtmlResponse(rscStream, responseStatus) {
+      const fontData = __createAppPageFontData({
+        getLinks: _getSSRFontLinks,
+        getPreloads: _getSSRFontPreloads,
+        getStyles: _getSSRFontStyles,
+      });
+      const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
+      return __renderAppPageHtmlResponse({
+        clearRequestContext() {
+          setHeadersContext(null);
+          setNavigationContext(null);
+        },
+        fontData,
+        fontLinkHeader: __buildAppPageFontLinkHeader(fontData.preloads),
+        navigationContext: _getNavigationContext(),
+        rscStream,
+        ssrHandler: ssrEntry,
+        status: responseStatus,
+      });
+    },
+    createRscOnErrorHandler() {
+      return createRscOnErrorHandler(
+        request,
+        _pathname,
+        route?.pattern ?? _pathname,
+      );
+    },
+    element,
+    isRscRequest,
+    renderToReadableStream,
     status: statusCode,
   });
 }
@@ -3256,20 +3223,15 @@ async function renderNotFoundPage(route, isRscRequest, request, matchedParams) {
  * by the boundary). This matches that behavior intentionally.
  */
 async function renderErrorBoundaryPage(route, error, isRscRequest, request, matchedParams) {
-  // Resolve the error boundary component: leaf error.tsx first, then walk per-layout
-  // errors from innermost to outermost (matching ancestor inheritance), then global-error.tsx.
-  let ErrorComponent = route?.error?.default ?? null;
-  let _isGlobalError = false;
-  if (!ErrorComponent && route?.errors) {
-    for (let i = route.errors.length - 1; i >= 0; i--) {
-      if (route.errors[i]?.default) {
-        ErrorComponent = route.errors[i].default;
-        break;
-      }
-    }
-  }
-  
-  if (!ErrorComponent) return null;
+  const __errorBoundary = __resolveAppPageErrorBoundary({
+    getDefaultExport(errorModule) {
+      return errorModule?.default ?? null;
+    },
+    globalErrorModule: null,
+    layoutErrorModules: route?.errors,
+    pageErrorModule: route?.error,
+  });
+  if (!__errorBoundary.component) return null;
 
   const rawError = error instanceof Error ? error : new Error(String(error));
   // Sanitize the error in production to avoid leaking internal details
@@ -3280,85 +3242,73 @@ async function renderErrorBoundaryPage(route, error, isRscRequest, request, matc
   // can't be serialized through RSC. The error.tsx component will receive reset=undefined
   // during SSR, which is fine — onClick={undefined} is harmless, and the real reset
   // function is only meaningful after hydration.
-  let element = createElement(ErrorComponent, {
+  let element = createElement(__errorBoundary.component, {
     error: errorObj,
   });
-
-  // global-error.tsx provides its own <html> and <body> (it replaces the root
-  // layout). Skip layout wrapping when rendering it to avoid double <html> tags.
-  if (!_isGlobalError) {
-    const layouts = route?.layouts ?? rootLayouts;
-    if (isRscRequest) {
-      // For RSC requests (client-side navigation), wrap with the same component
-      // wrappers that buildPageElement() uses (LayoutSegmentProvider, GlobalErrorBoundary).
-      // This ensures React can reconcile the tree without destroying the DOM.
-      // Same rationale as renderHTTPAccessFallbackPage — see comment there.
-      const _errTreePositions = route?.layoutTreePositions;
-      const _errRouteSegs = route?.routeSegments || [];
-      const _errParams = matchedParams ?? route?.params ?? {};
-      const _asyncErrParams = makeThenableParams(_errParams);
-      for (let i = layouts.length - 1; i >= 0; i--) {
-        const LayoutComponent = layouts[i]?.default;
-        if (LayoutComponent) {
-          element = createElement(LayoutComponent, { children: element, params: _asyncErrParams });
-          const _etp = _errTreePositions ? _errTreePositions[i] : 0;
-          const _ecs = __resolveChildSegments(_errRouteSegs, _etp, _errParams);
-          element = createElement(LayoutSegmentProvider, { childSegments: _ecs }, element);
-        }
-      }
-      
-    } else {
-      // For HTML (full page load) responses, wrap with layouts only.
-      const _errParamsHtml = matchedParams ?? route?.params ?? {};
-      const _asyncErrParamsHtml = makeThenableParams(_errParamsHtml);
-      for (let i = layouts.length - 1; i >= 0; i--) {
-        const LayoutComponent = layouts[i]?.default;
-        if (LayoutComponent) {
-          element = createElement(LayoutComponent, { children: element, params: _asyncErrParamsHtml });
-        }
-      }
-    }
-  }
+  const _errParams = matchedParams ?? route?.params ?? {};
+  element = __wrapAppPageBoundaryElement({
+    element,
+    getDefaultExport(layoutModule) {
+      return layoutModule?.default ?? null;
+    },
+    globalErrorComponent: null,
+    includeGlobalErrorBoundary: !__errorBoundary.isGlobalError,
+    isRscRequest,
+    layoutModules: route?.layouts ?? rootLayouts,
+    layoutTreePositions: route?.layoutTreePositions,
+    makeThenableParams,
+    matchedParams: _errParams,
+    renderErrorBoundary(GlobalErrorComponent, children) {
+      return createElement(ErrorBoundary, {
+        fallback: GlobalErrorComponent,
+        children,
+      });
+    },
+    renderLayout(LayoutComponent, children, asyncParams) {
+      return createElement(LayoutComponent, { children, params: asyncParams });
+    },
+    renderLayoutSegmentProvider(childSegments, children) {
+      return createElement(LayoutSegmentProvider, { childSegments }, children);
+    },
+    resolveChildSegments(routeSegments, treePosition, boundaryParams) {
+      return __resolveChildSegments(routeSegments, treePosition, boundaryParams);
+    },
+    routeSegments: route?.routeSegments || [],
+    skipLayoutWrapping: __errorBoundary.isGlobalError,
+  });
 
   const _pathname = new URL(request.url).pathname;
-  const onRenderError = createRscOnErrorHandler(
-    request,
-    _pathname,
-    route?.pattern ?? _pathname,
-  );
-
-  if (isRscRequest) {
-    const rscStream = renderToReadableStream(element, { onError: onRenderError });
-    // Do NOT clear context here — the RSC stream is consumed lazily by the client.
-    // Clearing context now would cause async server components (e.g. NextIntlClientProviderServer)
-    // that run during stream consumption to see null headers/navigation context and throw,
-    // resulting in missing provider context on the client (e.g. next-intl useTranslations fails
-    // with "context from NextIntlClientProvider was not found").
-    // Context is cleared naturally when the ALS scope from runWithRequestContext unwinds.
-    return new Response(rscStream, {
-      status: 200,
-      headers: { "Content-Type": "text/x-component; charset=utf-8", "Vary": "RSC, Accept" },
-    });
-  }
-
-  // HTML (full page load) response — render through RSC → SSR pipeline
-  const rscStream = renderToReadableStream(element, { onError: onRenderError });
-  const fontData = __createAppPageFontData({
-    getLinks: _getSSRFontLinks,
-    getPreloads: _getSSRFontPreloads,
-    getStyles: _getSSRFontStyles,
-  });
-  const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
-  return __renderAppPageHtmlResponse({
-    clearRequestContext() {
-      setHeadersContext(null);
-      setNavigationContext(null);
+  return __renderAppPageBoundaryResponse({
+    async createHtmlResponse(rscStream, responseStatus) {
+      const fontData = __createAppPageFontData({
+        getLinks: _getSSRFontLinks,
+        getPreloads: _getSSRFontPreloads,
+        getStyles: _getSSRFontStyles,
+      });
+      const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
+      return __renderAppPageHtmlResponse({
+        clearRequestContext() {
+          setHeadersContext(null);
+          setNavigationContext(null);
+        },
+        fontData,
+        fontLinkHeader: __buildAppPageFontLinkHeader(fontData.preloads),
+        navigationContext: _getNavigationContext(),
+        rscStream,
+        ssrHandler: ssrEntry,
+        status: responseStatus,
+      });
     },
-    fontData,
-    fontLinkHeader: __buildAppPageFontLinkHeader(fontData.preloads),
-    navigationContext: _getNavigationContext(),
-    rscStream,
-    ssrHandler: ssrEntry,
+    createRscOnErrorHandler() {
+      return createRscOnErrorHandler(
+        request,
+        _pathname,
+        route?.pattern ?? _pathname,
+      );
+    },
+    element,
+    isRscRequest,
+    renderToReadableStream,
     status: 200,
   });
 }
@@ -5254,6 +5204,12 @@ import {
   teeAppPageRscStreamForCapture as __teeAppPageRscStreamForCapture,
 } from "<ROOT>/packages/vinext/src/server/app-page-execution.js";
 import {
+  renderAppPageBoundaryResponse as __renderAppPageBoundaryResponse,
+  resolveAppPageErrorBoundary as __resolveAppPageErrorBoundary,
+  resolveAppPageHttpAccessBoundaryComponent as __resolveAppPageHttpAccessBoundaryComponent,
+  wrapAppPageBoundaryElement as __wrapAppPageBoundaryElement,
+} from "<ROOT>/packages/vinext/src/server/app-page-boundary.js";
+import {
   createAppPageFontData as __createAppPageFontData,
   createAppPageRscErrorTracker as __createAppPageRscErrorTracker,
   renderAppPageHtmlResponse as __renderAppPageHtmlResponse,
@@ -5700,19 +5656,20 @@ const rootLayouts = [mod_1];
  * @param opts.layouts - Override the layouts to wrap with (for layout-level notFound, excludes the throwing layout)
  */
 async function renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, opts) {
-  // Determine which boundary component to use based on status code
-  let BoundaryComponent = opts?.boundaryComponent ?? null;
-  if (!BoundaryComponent) {
-    let boundaryModule;
-    if (statusCode === 403) {
-      boundaryModule = route?.forbidden ?? rootForbiddenModule;
-    } else if (statusCode === 401) {
-      boundaryModule = route?.unauthorized ?? rootUnauthorizedModule;
-    } else {
-      boundaryModule = route?.notFound ?? rootNotFoundModule;
-    }
-    BoundaryComponent = boundaryModule?.default ?? null;
-  }
+  const BoundaryComponent =
+    opts?.boundaryComponent ??
+    __resolveAppPageHttpAccessBoundaryComponent({
+      getDefaultExport(boundaryModule) {
+        return boundaryModule?.default ?? null;
+      },
+      rootForbiddenModule: rootForbiddenModule,
+      rootNotFoundModule: rootNotFoundModule,
+      rootUnauthorizedModule: rootUnauthorizedModule,
+      routeForbiddenModule: route?.forbidden,
+      routeNotFoundModule: route?.notFound,
+      routeUnauthorizedModule: route?.unauthorized,
+      statusCode,
+    });
   const layouts = opts?.layouts ?? route?.layouts ?? rootLayouts;
   if (!BoundaryComponent) return null;
 
@@ -5749,90 +5706,67 @@ async function renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, req
   if (resolvedMetadata) headElements.push(createElement(MetadataHead, { metadata: resolvedMetadata }));
   headElements.push(createElement(ViewportHead, { viewport: resolvedViewport }));
   let element = createElement(Fragment, null, ...headElements, createElement(BoundaryComponent));
-  if (isRscRequest) {
-    // For RSC requests (client-side navigation), wrap the element with the same
-    // component wrappers that buildPageElement() uses. Without these wrappers,
-    // React's reconciliation would see a mismatched tree structure between the
-    // old fiber tree (ErrorBoundary > LayoutSegmentProvider > html > body > NotFoundBoundary > ...)
-    // and the new tree (html > body > ...), causing it to destroy and recreate
-    // the entire DOM tree, resulting in a blank white page.
-    //
-    // We wrap each layout with LayoutSegmentProvider and add GlobalErrorBoundary
-    // to match the wrapping order in buildPageElement(), ensuring smooth
-    // client-side tree reconciliation.
-    const _treePositions = route?.layoutTreePositions;
-    const _routeSegs = route?.routeSegments || [];
-    const _fallbackParams = opts?.matchedParams ?? route?.params ?? {};
-    const _asyncFallbackParams = makeThenableParams(_fallbackParams);
-    for (let i = layouts.length - 1; i >= 0; i--) {
-      const LayoutComponent = layouts[i]?.default;
-      if (LayoutComponent) {
-        element = createElement(LayoutComponent, { children: element, params: _asyncFallbackParams });
-        const _tp = _treePositions ? _treePositions[i] : 0;
-        const _cs = __resolveChildSegments(_routeSegs, _tp, _fallbackParams);
-        element = createElement(LayoutSegmentProvider, { childSegments: _cs }, element);
-      }
-    }
-    
-    const _GlobalErrorComponent = mod_11.default;
-    if (_GlobalErrorComponent) {
-      element = createElement(ErrorBoundary, {
-        fallback: _GlobalErrorComponent,
-        children: element,
-      });
-    }
-    
-    const _pathname = new URL(request.url).pathname;
-    const onRenderError = createRscOnErrorHandler(
-      request,
-      _pathname,
-      route?.pattern ?? _pathname,
-    );
-    const rscStream = renderToReadableStream(element, { onError: onRenderError });
-    // Do NOT clear context here — the RSC stream is consumed lazily by the client.
-    // Clearing context now would cause async server components (e.g. NextIntlClientProviderServer)
-    // that run during stream consumption to see null headers/navigation context and throw,
-    // resulting in missing provider context on the client (e.g. next-intl useTranslations fails
-    // with "context from NextIntlClientProvider was not found").
-    // Context is cleared naturally when the ALS scope from runWithRequestContext unwinds.
-    return new Response(rscStream, {
-      status: statusCode,
-      headers: { "Content-Type": "text/x-component; charset=utf-8", "Vary": "RSC, Accept" },
-    });
-  }
-  // For HTML (full page load) responses, wrap with layouts only (no client-side
-  // wrappers needed since SSR generates the complete HTML document).
-  const _fallbackParamsHtml = opts?.matchedParams ?? route?.params ?? {};
-  const _asyncFallbackParamsHtml = makeThenableParams(_fallbackParamsHtml);
-  for (let i = layouts.length - 1; i >= 0; i--) {
-    const LayoutComponent = layouts[i]?.default;
-    if (LayoutComponent) {
-      element = createElement(LayoutComponent, { children: element, params: _asyncFallbackParamsHtml });
-    }
-  }
-  const _pathname = new URL(request.url).pathname;
-  const onRenderError = createRscOnErrorHandler(
-    request,
-    _pathname,
-    route?.pattern ?? _pathname,
-  );
-  const rscStream = renderToReadableStream(element, { onError: onRenderError });
-  const fontData = __createAppPageFontData({
-    getLinks: _getSSRFontLinks,
-    getPreloads: _getSSRFontPreloads,
-    getStyles: _getSSRFontStyles,
-  });
-  const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
-  return __renderAppPageHtmlResponse({
-    clearRequestContext() {
-      setHeadersContext(null);
-      setNavigationContext(null);
+  element = __wrapAppPageBoundaryElement({
+    element,
+    getDefaultExport(layoutModule) {
+      return layoutModule?.default ?? null;
     },
-    fontData,
-    fontLinkHeader: __buildAppPageFontLinkHeader(fontData.preloads),
-    navigationContext: _getNavigationContext(),
-    rscStream,
-    ssrHandler: ssrEntry,
+    globalErrorComponent: mod_11.default,
+    includeGlobalErrorBoundary: true,
+    isRscRequest,
+    layoutModules: layouts,
+    layoutTreePositions: route?.layoutTreePositions,
+    makeThenableParams,
+    matchedParams: _fallbackParams,
+    renderErrorBoundary(GlobalErrorComponent, children) {
+      return createElement(ErrorBoundary, {
+        fallback: GlobalErrorComponent,
+        children,
+      });
+    },
+    renderLayout(LayoutComponent, children, asyncParams) {
+      return createElement(LayoutComponent, { children, params: asyncParams });
+    },
+    renderLayoutSegmentProvider(childSegments, children) {
+      return createElement(LayoutSegmentProvider, { childSegments }, children);
+    },
+    resolveChildSegments(routeSegments, treePosition, boundaryParams) {
+      return __resolveChildSegments(routeSegments, treePosition, boundaryParams);
+    },
+    routeSegments: route?.routeSegments || [],
+  });
+  const _pathname = new URL(request.url).pathname;
+  return __renderAppPageBoundaryResponse({
+    async createHtmlResponse(rscStream, responseStatus) {
+      const fontData = __createAppPageFontData({
+        getLinks: _getSSRFontLinks,
+        getPreloads: _getSSRFontPreloads,
+        getStyles: _getSSRFontStyles,
+      });
+      const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
+      return __renderAppPageHtmlResponse({
+        clearRequestContext() {
+          setHeadersContext(null);
+          setNavigationContext(null);
+        },
+        fontData,
+        fontLinkHeader: __buildAppPageFontLinkHeader(fontData.preloads),
+        navigationContext: _getNavigationContext(),
+        rscStream,
+        ssrHandler: ssrEntry,
+        status: responseStatus,
+      });
+    },
+    createRscOnErrorHandler() {
+      return createRscOnErrorHandler(
+        request,
+        _pathname,
+        route?.pattern ?? _pathname,
+      );
+    },
+    element,
+    isRscRequest,
+    renderToReadableStream,
     status: statusCode,
   });
 }
@@ -5850,25 +5784,15 @@ async function renderNotFoundPage(route, isRscRequest, request, matchedParams) {
  * by the boundary). This matches that behavior intentionally.
  */
 async function renderErrorBoundaryPage(route, error, isRscRequest, request, matchedParams) {
-  // Resolve the error boundary component: leaf error.tsx first, then walk per-layout
-  // errors from innermost to outermost (matching ancestor inheritance), then global-error.tsx.
-  let ErrorComponent = route?.error?.default ?? null;
-  let _isGlobalError = false;
-  if (!ErrorComponent && route?.errors) {
-    for (let i = route.errors.length - 1; i >= 0; i--) {
-      if (route.errors[i]?.default) {
-        ErrorComponent = route.errors[i].default;
-        break;
-      }
-    }
-  }
-  
-  if (!ErrorComponent) {
-    ErrorComponent = mod_11?.default ?? null;
-    _isGlobalError = !!ErrorComponent;
-  }
-  
-  if (!ErrorComponent) return null;
+  const __errorBoundary = __resolveAppPageErrorBoundary({
+    getDefaultExport(errorModule) {
+      return errorModule?.default ?? null;
+    },
+    globalErrorModule: mod_11,
+    layoutErrorModules: route?.errors,
+    pageErrorModule: route?.error,
+  });
+  if (!__errorBoundary.component) return null;
 
   const rawError = error instanceof Error ? error : new Error(String(error));
   // Sanitize the error in production to avoid leaking internal details
@@ -5879,93 +5803,73 @@ async function renderErrorBoundaryPage(route, error, isRscRequest, request, matc
   // can't be serialized through RSC. The error.tsx component will receive reset=undefined
   // during SSR, which is fine — onClick={undefined} is harmless, and the real reset
   // function is only meaningful after hydration.
-  let element = createElement(ErrorComponent, {
+  let element = createElement(__errorBoundary.component, {
     error: errorObj,
   });
-
-  // global-error.tsx provides its own <html> and <body> (it replaces the root
-  // layout). Skip layout wrapping when rendering it to avoid double <html> tags.
-  if (!_isGlobalError) {
-    const layouts = route?.layouts ?? rootLayouts;
-    if (isRscRequest) {
-      // For RSC requests (client-side navigation), wrap with the same component
-      // wrappers that buildPageElement() uses (LayoutSegmentProvider, GlobalErrorBoundary).
-      // This ensures React can reconcile the tree without destroying the DOM.
-      // Same rationale as renderHTTPAccessFallbackPage — see comment there.
-      const _errTreePositions = route?.layoutTreePositions;
-      const _errRouteSegs = route?.routeSegments || [];
-      const _errParams = matchedParams ?? route?.params ?? {};
-      const _asyncErrParams = makeThenableParams(_errParams);
-      for (let i = layouts.length - 1; i >= 0; i--) {
-        const LayoutComponent = layouts[i]?.default;
-        if (LayoutComponent) {
-          element = createElement(LayoutComponent, { children: element, params: _asyncErrParams });
-          const _etp = _errTreePositions ? _errTreePositions[i] : 0;
-          const _ecs = __resolveChildSegments(_errRouteSegs, _etp, _errParams);
-          element = createElement(LayoutSegmentProvider, { childSegments: _ecs }, element);
-        }
-      }
-      
-      const _ErrGlobalComponent = mod_11.default;
-      if (_ErrGlobalComponent) {
-        element = createElement(ErrorBoundary, {
-          fallback: _ErrGlobalComponent,
-          children: element,
-        });
-      }
-      
-    } else {
-      // For HTML (full page load) responses, wrap with layouts only.
-      const _errParamsHtml = matchedParams ?? route?.params ?? {};
-      const _asyncErrParamsHtml = makeThenableParams(_errParamsHtml);
-      for (let i = layouts.length - 1; i >= 0; i--) {
-        const LayoutComponent = layouts[i]?.default;
-        if (LayoutComponent) {
-          element = createElement(LayoutComponent, { children: element, params: _asyncErrParamsHtml });
-        }
-      }
-    }
-  }
+  const _errParams = matchedParams ?? route?.params ?? {};
+  element = __wrapAppPageBoundaryElement({
+    element,
+    getDefaultExport(layoutModule) {
+      return layoutModule?.default ?? null;
+    },
+    globalErrorComponent: mod_11.default,
+    includeGlobalErrorBoundary: !__errorBoundary.isGlobalError,
+    isRscRequest,
+    layoutModules: route?.layouts ?? rootLayouts,
+    layoutTreePositions: route?.layoutTreePositions,
+    makeThenableParams,
+    matchedParams: _errParams,
+    renderErrorBoundary(GlobalErrorComponent, children) {
+      return createElement(ErrorBoundary, {
+        fallback: GlobalErrorComponent,
+        children,
+      });
+    },
+    renderLayout(LayoutComponent, children, asyncParams) {
+      return createElement(LayoutComponent, { children, params: asyncParams });
+    },
+    renderLayoutSegmentProvider(childSegments, children) {
+      return createElement(LayoutSegmentProvider, { childSegments }, children);
+    },
+    resolveChildSegments(routeSegments, treePosition, boundaryParams) {
+      return __resolveChildSegments(routeSegments, treePosition, boundaryParams);
+    },
+    routeSegments: route?.routeSegments || [],
+    skipLayoutWrapping: __errorBoundary.isGlobalError,
+  });
 
   const _pathname = new URL(request.url).pathname;
-  const onRenderError = createRscOnErrorHandler(
-    request,
-    _pathname,
-    route?.pattern ?? _pathname,
-  );
-
-  if (isRscRequest) {
-    const rscStream = renderToReadableStream(element, { onError: onRenderError });
-    // Do NOT clear context here — the RSC stream is consumed lazily by the client.
-    // Clearing context now would cause async server components (e.g. NextIntlClientProviderServer)
-    // that run during stream consumption to see null headers/navigation context and throw,
-    // resulting in missing provider context on the client (e.g. next-intl useTranslations fails
-    // with "context from NextIntlClientProvider was not found").
-    // Context is cleared naturally when the ALS scope from runWithRequestContext unwinds.
-    return new Response(rscStream, {
-      status: 200,
-      headers: { "Content-Type": "text/x-component; charset=utf-8", "Vary": "RSC, Accept" },
-    });
-  }
-
-  // HTML (full page load) response — render through RSC → SSR pipeline
-  const rscStream = renderToReadableStream(element, { onError: onRenderError });
-  const fontData = __createAppPageFontData({
-    getLinks: _getSSRFontLinks,
-    getPreloads: _getSSRFontPreloads,
-    getStyles: _getSSRFontStyles,
-  });
-  const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
-  return __renderAppPageHtmlResponse({
-    clearRequestContext() {
-      setHeadersContext(null);
-      setNavigationContext(null);
+  return __renderAppPageBoundaryResponse({
+    async createHtmlResponse(rscStream, responseStatus) {
+      const fontData = __createAppPageFontData({
+        getLinks: _getSSRFontLinks,
+        getPreloads: _getSSRFontPreloads,
+        getStyles: _getSSRFontStyles,
+      });
+      const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
+      return __renderAppPageHtmlResponse({
+        clearRequestContext() {
+          setHeadersContext(null);
+          setNavigationContext(null);
+        },
+        fontData,
+        fontLinkHeader: __buildAppPageFontLinkHeader(fontData.preloads),
+        navigationContext: _getNavigationContext(),
+        rscStream,
+        ssrHandler: ssrEntry,
+        status: responseStatus,
+      });
     },
-    fontData,
-    fontLinkHeader: __buildAppPageFontLinkHeader(fontData.preloads),
-    navigationContext: _getNavigationContext(),
-    rscStream,
-    ssrHandler: ssrEntry,
+    createRscOnErrorHandler() {
+      return createRscOnErrorHandler(
+        request,
+        _pathname,
+        route?.pattern ?? _pathname,
+      );
+    },
+    element,
+    isRscRequest,
+    renderToReadableStream,
     status: 200,
   });
 }
@@ -7875,6 +7779,12 @@ import {
   teeAppPageRscStreamForCapture as __teeAppPageRscStreamForCapture,
 } from "<ROOT>/packages/vinext/src/server/app-page-execution.js";
 import {
+  renderAppPageBoundaryResponse as __renderAppPageBoundaryResponse,
+  resolveAppPageErrorBoundary as __resolveAppPageErrorBoundary,
+  resolveAppPageHttpAccessBoundaryComponent as __resolveAppPageHttpAccessBoundaryComponent,
+  wrapAppPageBoundaryElement as __wrapAppPageBoundaryElement,
+} from "<ROOT>/packages/vinext/src/server/app-page-boundary.js";
+import {
   createAppPageFontData as __createAppPageFontData,
   createAppPageRscErrorTracker as __createAppPageRscErrorTracker,
   renderAppPageHtmlResponse as __renderAppPageHtmlResponse,
@@ -8350,19 +8260,20 @@ const rootLayouts = [mod_1];
  * @param opts.layouts - Override the layouts to wrap with (for layout-level notFound, excludes the throwing layout)
  */
 async function renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, opts) {
-  // Determine which boundary component to use based on status code
-  let BoundaryComponent = opts?.boundaryComponent ?? null;
-  if (!BoundaryComponent) {
-    let boundaryModule;
-    if (statusCode === 403) {
-      boundaryModule = route?.forbidden ?? rootForbiddenModule;
-    } else if (statusCode === 401) {
-      boundaryModule = route?.unauthorized ?? rootUnauthorizedModule;
-    } else {
-      boundaryModule = route?.notFound ?? rootNotFoundModule;
-    }
-    BoundaryComponent = boundaryModule?.default ?? null;
-  }
+  const BoundaryComponent =
+    opts?.boundaryComponent ??
+    __resolveAppPageHttpAccessBoundaryComponent({
+      getDefaultExport(boundaryModule) {
+        return boundaryModule?.default ?? null;
+      },
+      rootForbiddenModule: rootForbiddenModule,
+      rootNotFoundModule: rootNotFoundModule,
+      rootUnauthorizedModule: rootUnauthorizedModule,
+      routeForbiddenModule: route?.forbidden,
+      routeNotFoundModule: route?.notFound,
+      routeUnauthorizedModule: route?.unauthorized,
+      statusCode,
+    });
   const layouts = opts?.layouts ?? route?.layouts ?? rootLayouts;
   if (!BoundaryComponent) return null;
 
@@ -8399,82 +8310,67 @@ async function renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, req
   if (resolvedMetadata) headElements.push(createElement(MetadataHead, { metadata: resolvedMetadata }));
   headElements.push(createElement(ViewportHead, { viewport: resolvedViewport }));
   let element = createElement(Fragment, null, ...headElements, createElement(BoundaryComponent));
-  if (isRscRequest) {
-    // For RSC requests (client-side navigation), wrap the element with the same
-    // component wrappers that buildPageElement() uses. Without these wrappers,
-    // React's reconciliation would see a mismatched tree structure between the
-    // old fiber tree (ErrorBoundary > LayoutSegmentProvider > html > body > NotFoundBoundary > ...)
-    // and the new tree (html > body > ...), causing it to destroy and recreate
-    // the entire DOM tree, resulting in a blank white page.
-    //
-    // We wrap each layout with LayoutSegmentProvider and add GlobalErrorBoundary
-    // to match the wrapping order in buildPageElement(), ensuring smooth
-    // client-side tree reconciliation.
-    const _treePositions = route?.layoutTreePositions;
-    const _routeSegs = route?.routeSegments || [];
-    const _fallbackParams = opts?.matchedParams ?? route?.params ?? {};
-    const _asyncFallbackParams = makeThenableParams(_fallbackParams);
-    for (let i = layouts.length - 1; i >= 0; i--) {
-      const LayoutComponent = layouts[i]?.default;
-      if (LayoutComponent) {
-        element = createElement(LayoutComponent, { children: element, params: _asyncFallbackParams });
-        const _tp = _treePositions ? _treePositions[i] : 0;
-        const _cs = __resolveChildSegments(_routeSegs, _tp, _fallbackParams);
-        element = createElement(LayoutSegmentProvider, { childSegments: _cs }, element);
-      }
-    }
-    
-    const _pathname = new URL(request.url).pathname;
-    const onRenderError = createRscOnErrorHandler(
-      request,
-      _pathname,
-      route?.pattern ?? _pathname,
-    );
-    const rscStream = renderToReadableStream(element, { onError: onRenderError });
-    // Do NOT clear context here — the RSC stream is consumed lazily by the client.
-    // Clearing context now would cause async server components (e.g. NextIntlClientProviderServer)
-    // that run during stream consumption to see null headers/navigation context and throw,
-    // resulting in missing provider context on the client (e.g. next-intl useTranslations fails
-    // with "context from NextIntlClientProvider was not found").
-    // Context is cleared naturally when the ALS scope from runWithRequestContext unwinds.
-    return new Response(rscStream, {
-      status: statusCode,
-      headers: { "Content-Type": "text/x-component; charset=utf-8", "Vary": "RSC, Accept" },
-    });
-  }
-  // For HTML (full page load) responses, wrap with layouts only (no client-side
-  // wrappers needed since SSR generates the complete HTML document).
-  const _fallbackParamsHtml = opts?.matchedParams ?? route?.params ?? {};
-  const _asyncFallbackParamsHtml = makeThenableParams(_fallbackParamsHtml);
-  for (let i = layouts.length - 1; i >= 0; i--) {
-    const LayoutComponent = layouts[i]?.default;
-    if (LayoutComponent) {
-      element = createElement(LayoutComponent, { children: element, params: _asyncFallbackParamsHtml });
-    }
-  }
-  const _pathname = new URL(request.url).pathname;
-  const onRenderError = createRscOnErrorHandler(
-    request,
-    _pathname,
-    route?.pattern ?? _pathname,
-  );
-  const rscStream = renderToReadableStream(element, { onError: onRenderError });
-  const fontData = __createAppPageFontData({
-    getLinks: _getSSRFontLinks,
-    getPreloads: _getSSRFontPreloads,
-    getStyles: _getSSRFontStyles,
-  });
-  const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
-  return __renderAppPageHtmlResponse({
-    clearRequestContext() {
-      setHeadersContext(null);
-      setNavigationContext(null);
+  element = __wrapAppPageBoundaryElement({
+    element,
+    getDefaultExport(layoutModule) {
+      return layoutModule?.default ?? null;
     },
-    fontData,
-    fontLinkHeader: __buildAppPageFontLinkHeader(fontData.preloads),
-    navigationContext: _getNavigationContext(),
-    rscStream,
-    ssrHandler: ssrEntry,
+    globalErrorComponent: null,
+    includeGlobalErrorBoundary: true,
+    isRscRequest,
+    layoutModules: layouts,
+    layoutTreePositions: route?.layoutTreePositions,
+    makeThenableParams,
+    matchedParams: _fallbackParams,
+    renderErrorBoundary(GlobalErrorComponent, children) {
+      return createElement(ErrorBoundary, {
+        fallback: GlobalErrorComponent,
+        children,
+      });
+    },
+    renderLayout(LayoutComponent, children, asyncParams) {
+      return createElement(LayoutComponent, { children, params: asyncParams });
+    },
+    renderLayoutSegmentProvider(childSegments, children) {
+      return createElement(LayoutSegmentProvider, { childSegments }, children);
+    },
+    resolveChildSegments(routeSegments, treePosition, boundaryParams) {
+      return __resolveChildSegments(routeSegments, treePosition, boundaryParams);
+    },
+    routeSegments: route?.routeSegments || [],
+  });
+  const _pathname = new URL(request.url).pathname;
+  return __renderAppPageBoundaryResponse({
+    async createHtmlResponse(rscStream, responseStatus) {
+      const fontData = __createAppPageFontData({
+        getLinks: _getSSRFontLinks,
+        getPreloads: _getSSRFontPreloads,
+        getStyles: _getSSRFontStyles,
+      });
+      const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
+      return __renderAppPageHtmlResponse({
+        clearRequestContext() {
+          setHeadersContext(null);
+          setNavigationContext(null);
+        },
+        fontData,
+        fontLinkHeader: __buildAppPageFontLinkHeader(fontData.preloads),
+        navigationContext: _getNavigationContext(),
+        rscStream,
+        ssrHandler: ssrEntry,
+        status: responseStatus,
+      });
+    },
+    createRscOnErrorHandler() {
+      return createRscOnErrorHandler(
+        request,
+        _pathname,
+        route?.pattern ?? _pathname,
+      );
+    },
+    element,
+    isRscRequest,
+    renderToReadableStream,
     status: statusCode,
   });
 }
@@ -8492,20 +8388,15 @@ async function renderNotFoundPage(route, isRscRequest, request, matchedParams) {
  * by the boundary). This matches that behavior intentionally.
  */
 async function renderErrorBoundaryPage(route, error, isRscRequest, request, matchedParams) {
-  // Resolve the error boundary component: leaf error.tsx first, then walk per-layout
-  // errors from innermost to outermost (matching ancestor inheritance), then global-error.tsx.
-  let ErrorComponent = route?.error?.default ?? null;
-  let _isGlobalError = false;
-  if (!ErrorComponent && route?.errors) {
-    for (let i = route.errors.length - 1; i >= 0; i--) {
-      if (route.errors[i]?.default) {
-        ErrorComponent = route.errors[i].default;
-        break;
-      }
-    }
-  }
-  
-  if (!ErrorComponent) return null;
+  const __errorBoundary = __resolveAppPageErrorBoundary({
+    getDefaultExport(errorModule) {
+      return errorModule?.default ?? null;
+    },
+    globalErrorModule: null,
+    layoutErrorModules: route?.errors,
+    pageErrorModule: route?.error,
+  });
+  if (!__errorBoundary.component) return null;
 
   const rawError = error instanceof Error ? error : new Error(String(error));
   // Sanitize the error in production to avoid leaking internal details
@@ -8516,85 +8407,73 @@ async function renderErrorBoundaryPage(route, error, isRscRequest, request, matc
   // can't be serialized through RSC. The error.tsx component will receive reset=undefined
   // during SSR, which is fine — onClick={undefined} is harmless, and the real reset
   // function is only meaningful after hydration.
-  let element = createElement(ErrorComponent, {
+  let element = createElement(__errorBoundary.component, {
     error: errorObj,
   });
-
-  // global-error.tsx provides its own <html> and <body> (it replaces the root
-  // layout). Skip layout wrapping when rendering it to avoid double <html> tags.
-  if (!_isGlobalError) {
-    const layouts = route?.layouts ?? rootLayouts;
-    if (isRscRequest) {
-      // For RSC requests (client-side navigation), wrap with the same component
-      // wrappers that buildPageElement() uses (LayoutSegmentProvider, GlobalErrorBoundary).
-      // This ensures React can reconcile the tree without destroying the DOM.
-      // Same rationale as renderHTTPAccessFallbackPage — see comment there.
-      const _errTreePositions = route?.layoutTreePositions;
-      const _errRouteSegs = route?.routeSegments || [];
-      const _errParams = matchedParams ?? route?.params ?? {};
-      const _asyncErrParams = makeThenableParams(_errParams);
-      for (let i = layouts.length - 1; i >= 0; i--) {
-        const LayoutComponent = layouts[i]?.default;
-        if (LayoutComponent) {
-          element = createElement(LayoutComponent, { children: element, params: _asyncErrParams });
-          const _etp = _errTreePositions ? _errTreePositions[i] : 0;
-          const _ecs = __resolveChildSegments(_errRouteSegs, _etp, _errParams);
-          element = createElement(LayoutSegmentProvider, { childSegments: _ecs }, element);
-        }
-      }
-      
-    } else {
-      // For HTML (full page load) responses, wrap with layouts only.
-      const _errParamsHtml = matchedParams ?? route?.params ?? {};
-      const _asyncErrParamsHtml = makeThenableParams(_errParamsHtml);
-      for (let i = layouts.length - 1; i >= 0; i--) {
-        const LayoutComponent = layouts[i]?.default;
-        if (LayoutComponent) {
-          element = createElement(LayoutComponent, { children: element, params: _asyncErrParamsHtml });
-        }
-      }
-    }
-  }
+  const _errParams = matchedParams ?? route?.params ?? {};
+  element = __wrapAppPageBoundaryElement({
+    element,
+    getDefaultExport(layoutModule) {
+      return layoutModule?.default ?? null;
+    },
+    globalErrorComponent: null,
+    includeGlobalErrorBoundary: !__errorBoundary.isGlobalError,
+    isRscRequest,
+    layoutModules: route?.layouts ?? rootLayouts,
+    layoutTreePositions: route?.layoutTreePositions,
+    makeThenableParams,
+    matchedParams: _errParams,
+    renderErrorBoundary(GlobalErrorComponent, children) {
+      return createElement(ErrorBoundary, {
+        fallback: GlobalErrorComponent,
+        children,
+      });
+    },
+    renderLayout(LayoutComponent, children, asyncParams) {
+      return createElement(LayoutComponent, { children, params: asyncParams });
+    },
+    renderLayoutSegmentProvider(childSegments, children) {
+      return createElement(LayoutSegmentProvider, { childSegments }, children);
+    },
+    resolveChildSegments(routeSegments, treePosition, boundaryParams) {
+      return __resolveChildSegments(routeSegments, treePosition, boundaryParams);
+    },
+    routeSegments: route?.routeSegments || [],
+    skipLayoutWrapping: __errorBoundary.isGlobalError,
+  });
 
   const _pathname = new URL(request.url).pathname;
-  const onRenderError = createRscOnErrorHandler(
-    request,
-    _pathname,
-    route?.pattern ?? _pathname,
-  );
-
-  if (isRscRequest) {
-    const rscStream = renderToReadableStream(element, { onError: onRenderError });
-    // Do NOT clear context here — the RSC stream is consumed lazily by the client.
-    // Clearing context now would cause async server components (e.g. NextIntlClientProviderServer)
-    // that run during stream consumption to see null headers/navigation context and throw,
-    // resulting in missing provider context on the client (e.g. next-intl useTranslations fails
-    // with "context from NextIntlClientProvider was not found").
-    // Context is cleared naturally when the ALS scope from runWithRequestContext unwinds.
-    return new Response(rscStream, {
-      status: 200,
-      headers: { "Content-Type": "text/x-component; charset=utf-8", "Vary": "RSC, Accept" },
-    });
-  }
-
-  // HTML (full page load) response — render through RSC → SSR pipeline
-  const rscStream = renderToReadableStream(element, { onError: onRenderError });
-  const fontData = __createAppPageFontData({
-    getLinks: _getSSRFontLinks,
-    getPreloads: _getSSRFontPreloads,
-    getStyles: _getSSRFontStyles,
-  });
-  const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
-  return __renderAppPageHtmlResponse({
-    clearRequestContext() {
-      setHeadersContext(null);
-      setNavigationContext(null);
+  return __renderAppPageBoundaryResponse({
+    async createHtmlResponse(rscStream, responseStatus) {
+      const fontData = __createAppPageFontData({
+        getLinks: _getSSRFontLinks,
+        getPreloads: _getSSRFontPreloads,
+        getStyles: _getSSRFontStyles,
+      });
+      const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
+      return __renderAppPageHtmlResponse({
+        clearRequestContext() {
+          setHeadersContext(null);
+          setNavigationContext(null);
+        },
+        fontData,
+        fontLinkHeader: __buildAppPageFontLinkHeader(fontData.preloads),
+        navigationContext: _getNavigationContext(),
+        rscStream,
+        ssrHandler: ssrEntry,
+        status: responseStatus,
+      });
     },
-    fontData,
-    fontLinkHeader: __buildAppPageFontLinkHeader(fontData.preloads),
-    navigationContext: _getNavigationContext(),
-    rscStream,
-    ssrHandler: ssrEntry,
+    createRscOnErrorHandler() {
+      return createRscOnErrorHandler(
+        request,
+        _pathname,
+        route?.pattern ?? _pathname,
+      );
+    },
+    element,
+    isRscRequest,
+    renderToReadableStream,
     status: 200,
   });
 }
@@ -10490,6 +10369,12 @@ import {
   teeAppPageRscStreamForCapture as __teeAppPageRscStreamForCapture,
 } from "<ROOT>/packages/vinext/src/server/app-page-execution.js";
 import {
+  renderAppPageBoundaryResponse as __renderAppPageBoundaryResponse,
+  resolveAppPageErrorBoundary as __resolveAppPageErrorBoundary,
+  resolveAppPageHttpAccessBoundaryComponent as __resolveAppPageHttpAccessBoundaryComponent,
+  wrapAppPageBoundaryElement as __wrapAppPageBoundaryElement,
+} from "<ROOT>/packages/vinext/src/server/app-page-boundary.js";
+import {
   createAppPageFontData as __createAppPageFontData,
   createAppPageRscErrorTracker as __createAppPageRscErrorTracker,
   renderAppPageHtmlResponse as __renderAppPageHtmlResponse,
@@ -10942,19 +10827,20 @@ const rootLayouts = [mod_1];
  * @param opts.layouts - Override the layouts to wrap with (for layout-level notFound, excludes the throwing layout)
  */
 async function renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, opts) {
-  // Determine which boundary component to use based on status code
-  let BoundaryComponent = opts?.boundaryComponent ?? null;
-  if (!BoundaryComponent) {
-    let boundaryModule;
-    if (statusCode === 403) {
-      boundaryModule = route?.forbidden ?? rootForbiddenModule;
-    } else if (statusCode === 401) {
-      boundaryModule = route?.unauthorized ?? rootUnauthorizedModule;
-    } else {
-      boundaryModule = route?.notFound ?? rootNotFoundModule;
-    }
-    BoundaryComponent = boundaryModule?.default ?? null;
-  }
+  const BoundaryComponent =
+    opts?.boundaryComponent ??
+    __resolveAppPageHttpAccessBoundaryComponent({
+      getDefaultExport(boundaryModule) {
+        return boundaryModule?.default ?? null;
+      },
+      rootForbiddenModule: rootForbiddenModule,
+      rootNotFoundModule: rootNotFoundModule,
+      rootUnauthorizedModule: rootUnauthorizedModule,
+      routeForbiddenModule: route?.forbidden,
+      routeNotFoundModule: route?.notFound,
+      routeUnauthorizedModule: route?.unauthorized,
+      statusCode,
+    });
   const layouts = opts?.layouts ?? route?.layouts ?? rootLayouts;
   if (!BoundaryComponent) return null;
 
@@ -10991,82 +10877,67 @@ async function renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, req
   if (resolvedMetadata) headElements.push(createElement(MetadataHead, { metadata: resolvedMetadata }));
   headElements.push(createElement(ViewportHead, { viewport: resolvedViewport }));
   let element = createElement(Fragment, null, ...headElements, createElement(BoundaryComponent));
-  if (isRscRequest) {
-    // For RSC requests (client-side navigation), wrap the element with the same
-    // component wrappers that buildPageElement() uses. Without these wrappers,
-    // React's reconciliation would see a mismatched tree structure between the
-    // old fiber tree (ErrorBoundary > LayoutSegmentProvider > html > body > NotFoundBoundary > ...)
-    // and the new tree (html > body > ...), causing it to destroy and recreate
-    // the entire DOM tree, resulting in a blank white page.
-    //
-    // We wrap each layout with LayoutSegmentProvider and add GlobalErrorBoundary
-    // to match the wrapping order in buildPageElement(), ensuring smooth
-    // client-side tree reconciliation.
-    const _treePositions = route?.layoutTreePositions;
-    const _routeSegs = route?.routeSegments || [];
-    const _fallbackParams = opts?.matchedParams ?? route?.params ?? {};
-    const _asyncFallbackParams = makeThenableParams(_fallbackParams);
-    for (let i = layouts.length - 1; i >= 0; i--) {
-      const LayoutComponent = layouts[i]?.default;
-      if (LayoutComponent) {
-        element = createElement(LayoutComponent, { children: element, params: _asyncFallbackParams });
-        const _tp = _treePositions ? _treePositions[i] : 0;
-        const _cs = __resolveChildSegments(_routeSegs, _tp, _fallbackParams);
-        element = createElement(LayoutSegmentProvider, { childSegments: _cs }, element);
-      }
-    }
-    
-    const _pathname = new URL(request.url).pathname;
-    const onRenderError = createRscOnErrorHandler(
-      request,
-      _pathname,
-      route?.pattern ?? _pathname,
-    );
-    const rscStream = renderToReadableStream(element, { onError: onRenderError });
-    // Do NOT clear context here — the RSC stream is consumed lazily by the client.
-    // Clearing context now would cause async server components (e.g. NextIntlClientProviderServer)
-    // that run during stream consumption to see null headers/navigation context and throw,
-    // resulting in missing provider context on the client (e.g. next-intl useTranslations fails
-    // with "context from NextIntlClientProvider was not found").
-    // Context is cleared naturally when the ALS scope from runWithRequestContext unwinds.
-    return new Response(rscStream, {
-      status: statusCode,
-      headers: { "Content-Type": "text/x-component; charset=utf-8", "Vary": "RSC, Accept" },
-    });
-  }
-  // For HTML (full page load) responses, wrap with layouts only (no client-side
-  // wrappers needed since SSR generates the complete HTML document).
-  const _fallbackParamsHtml = opts?.matchedParams ?? route?.params ?? {};
-  const _asyncFallbackParamsHtml = makeThenableParams(_fallbackParamsHtml);
-  for (let i = layouts.length - 1; i >= 0; i--) {
-    const LayoutComponent = layouts[i]?.default;
-    if (LayoutComponent) {
-      element = createElement(LayoutComponent, { children: element, params: _asyncFallbackParamsHtml });
-    }
-  }
-  const _pathname = new URL(request.url).pathname;
-  const onRenderError = createRscOnErrorHandler(
-    request,
-    _pathname,
-    route?.pattern ?? _pathname,
-  );
-  const rscStream = renderToReadableStream(element, { onError: onRenderError });
-  const fontData = __createAppPageFontData({
-    getLinks: _getSSRFontLinks,
-    getPreloads: _getSSRFontPreloads,
-    getStyles: _getSSRFontStyles,
-  });
-  const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
-  return __renderAppPageHtmlResponse({
-    clearRequestContext() {
-      setHeadersContext(null);
-      setNavigationContext(null);
+  element = __wrapAppPageBoundaryElement({
+    element,
+    getDefaultExport(layoutModule) {
+      return layoutModule?.default ?? null;
     },
-    fontData,
-    fontLinkHeader: __buildAppPageFontLinkHeader(fontData.preloads),
-    navigationContext: _getNavigationContext(),
-    rscStream,
-    ssrHandler: ssrEntry,
+    globalErrorComponent: null,
+    includeGlobalErrorBoundary: true,
+    isRscRequest,
+    layoutModules: layouts,
+    layoutTreePositions: route?.layoutTreePositions,
+    makeThenableParams,
+    matchedParams: _fallbackParams,
+    renderErrorBoundary(GlobalErrorComponent, children) {
+      return createElement(ErrorBoundary, {
+        fallback: GlobalErrorComponent,
+        children,
+      });
+    },
+    renderLayout(LayoutComponent, children, asyncParams) {
+      return createElement(LayoutComponent, { children, params: asyncParams });
+    },
+    renderLayoutSegmentProvider(childSegments, children) {
+      return createElement(LayoutSegmentProvider, { childSegments }, children);
+    },
+    resolveChildSegments(routeSegments, treePosition, boundaryParams) {
+      return __resolveChildSegments(routeSegments, treePosition, boundaryParams);
+    },
+    routeSegments: route?.routeSegments || [],
+  });
+  const _pathname = new URL(request.url).pathname;
+  return __renderAppPageBoundaryResponse({
+    async createHtmlResponse(rscStream, responseStatus) {
+      const fontData = __createAppPageFontData({
+        getLinks: _getSSRFontLinks,
+        getPreloads: _getSSRFontPreloads,
+        getStyles: _getSSRFontStyles,
+      });
+      const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
+      return __renderAppPageHtmlResponse({
+        clearRequestContext() {
+          setHeadersContext(null);
+          setNavigationContext(null);
+        },
+        fontData,
+        fontLinkHeader: __buildAppPageFontLinkHeader(fontData.preloads),
+        navigationContext: _getNavigationContext(),
+        rscStream,
+        ssrHandler: ssrEntry,
+        status: responseStatus,
+      });
+    },
+    createRscOnErrorHandler() {
+      return createRscOnErrorHandler(
+        request,
+        _pathname,
+        route?.pattern ?? _pathname,
+      );
+    },
+    element,
+    isRscRequest,
+    renderToReadableStream,
     status: statusCode,
   });
 }
@@ -11084,20 +10955,15 @@ async function renderNotFoundPage(route, isRscRequest, request, matchedParams) {
  * by the boundary). This matches that behavior intentionally.
  */
 async function renderErrorBoundaryPage(route, error, isRscRequest, request, matchedParams) {
-  // Resolve the error boundary component: leaf error.tsx first, then walk per-layout
-  // errors from innermost to outermost (matching ancestor inheritance), then global-error.tsx.
-  let ErrorComponent = route?.error?.default ?? null;
-  let _isGlobalError = false;
-  if (!ErrorComponent && route?.errors) {
-    for (let i = route.errors.length - 1; i >= 0; i--) {
-      if (route.errors[i]?.default) {
-        ErrorComponent = route.errors[i].default;
-        break;
-      }
-    }
-  }
-  
-  if (!ErrorComponent) return null;
+  const __errorBoundary = __resolveAppPageErrorBoundary({
+    getDefaultExport(errorModule) {
+      return errorModule?.default ?? null;
+    },
+    globalErrorModule: null,
+    layoutErrorModules: route?.errors,
+    pageErrorModule: route?.error,
+  });
+  if (!__errorBoundary.component) return null;
 
   const rawError = error instanceof Error ? error : new Error(String(error));
   // Sanitize the error in production to avoid leaking internal details
@@ -11108,85 +10974,73 @@ async function renderErrorBoundaryPage(route, error, isRscRequest, request, matc
   // can't be serialized through RSC. The error.tsx component will receive reset=undefined
   // during SSR, which is fine — onClick={undefined} is harmless, and the real reset
   // function is only meaningful after hydration.
-  let element = createElement(ErrorComponent, {
+  let element = createElement(__errorBoundary.component, {
     error: errorObj,
   });
-
-  // global-error.tsx provides its own <html> and <body> (it replaces the root
-  // layout). Skip layout wrapping when rendering it to avoid double <html> tags.
-  if (!_isGlobalError) {
-    const layouts = route?.layouts ?? rootLayouts;
-    if (isRscRequest) {
-      // For RSC requests (client-side navigation), wrap with the same component
-      // wrappers that buildPageElement() uses (LayoutSegmentProvider, GlobalErrorBoundary).
-      // This ensures React can reconcile the tree without destroying the DOM.
-      // Same rationale as renderHTTPAccessFallbackPage — see comment there.
-      const _errTreePositions = route?.layoutTreePositions;
-      const _errRouteSegs = route?.routeSegments || [];
-      const _errParams = matchedParams ?? route?.params ?? {};
-      const _asyncErrParams = makeThenableParams(_errParams);
-      for (let i = layouts.length - 1; i >= 0; i--) {
-        const LayoutComponent = layouts[i]?.default;
-        if (LayoutComponent) {
-          element = createElement(LayoutComponent, { children: element, params: _asyncErrParams });
-          const _etp = _errTreePositions ? _errTreePositions[i] : 0;
-          const _ecs = __resolveChildSegments(_errRouteSegs, _etp, _errParams);
-          element = createElement(LayoutSegmentProvider, { childSegments: _ecs }, element);
-        }
-      }
-      
-    } else {
-      // For HTML (full page load) responses, wrap with layouts only.
-      const _errParamsHtml = matchedParams ?? route?.params ?? {};
-      const _asyncErrParamsHtml = makeThenableParams(_errParamsHtml);
-      for (let i = layouts.length - 1; i >= 0; i--) {
-        const LayoutComponent = layouts[i]?.default;
-        if (LayoutComponent) {
-          element = createElement(LayoutComponent, { children: element, params: _asyncErrParamsHtml });
-        }
-      }
-    }
-  }
+  const _errParams = matchedParams ?? route?.params ?? {};
+  element = __wrapAppPageBoundaryElement({
+    element,
+    getDefaultExport(layoutModule) {
+      return layoutModule?.default ?? null;
+    },
+    globalErrorComponent: null,
+    includeGlobalErrorBoundary: !__errorBoundary.isGlobalError,
+    isRscRequest,
+    layoutModules: route?.layouts ?? rootLayouts,
+    layoutTreePositions: route?.layoutTreePositions,
+    makeThenableParams,
+    matchedParams: _errParams,
+    renderErrorBoundary(GlobalErrorComponent, children) {
+      return createElement(ErrorBoundary, {
+        fallback: GlobalErrorComponent,
+        children,
+      });
+    },
+    renderLayout(LayoutComponent, children, asyncParams) {
+      return createElement(LayoutComponent, { children, params: asyncParams });
+    },
+    renderLayoutSegmentProvider(childSegments, children) {
+      return createElement(LayoutSegmentProvider, { childSegments }, children);
+    },
+    resolveChildSegments(routeSegments, treePosition, boundaryParams) {
+      return __resolveChildSegments(routeSegments, treePosition, boundaryParams);
+    },
+    routeSegments: route?.routeSegments || [],
+    skipLayoutWrapping: __errorBoundary.isGlobalError,
+  });
 
   const _pathname = new URL(request.url).pathname;
-  const onRenderError = createRscOnErrorHandler(
-    request,
-    _pathname,
-    route?.pattern ?? _pathname,
-  );
-
-  if (isRscRequest) {
-    const rscStream = renderToReadableStream(element, { onError: onRenderError });
-    // Do NOT clear context here — the RSC stream is consumed lazily by the client.
-    // Clearing context now would cause async server components (e.g. NextIntlClientProviderServer)
-    // that run during stream consumption to see null headers/navigation context and throw,
-    // resulting in missing provider context on the client (e.g. next-intl useTranslations fails
-    // with "context from NextIntlClientProvider was not found").
-    // Context is cleared naturally when the ALS scope from runWithRequestContext unwinds.
-    return new Response(rscStream, {
-      status: 200,
-      headers: { "Content-Type": "text/x-component; charset=utf-8", "Vary": "RSC, Accept" },
-    });
-  }
-
-  // HTML (full page load) response — render through RSC → SSR pipeline
-  const rscStream = renderToReadableStream(element, { onError: onRenderError });
-  const fontData = __createAppPageFontData({
-    getLinks: _getSSRFontLinks,
-    getPreloads: _getSSRFontPreloads,
-    getStyles: _getSSRFontStyles,
-  });
-  const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
-  return __renderAppPageHtmlResponse({
-    clearRequestContext() {
-      setHeadersContext(null);
-      setNavigationContext(null);
+  return __renderAppPageBoundaryResponse({
+    async createHtmlResponse(rscStream, responseStatus) {
+      const fontData = __createAppPageFontData({
+        getLinks: _getSSRFontLinks,
+        getPreloads: _getSSRFontPreloads,
+        getStyles: _getSSRFontStyles,
+      });
+      const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
+      return __renderAppPageHtmlResponse({
+        clearRequestContext() {
+          setHeadersContext(null);
+          setNavigationContext(null);
+        },
+        fontData,
+        fontLinkHeader: __buildAppPageFontLinkHeader(fontData.preloads),
+        navigationContext: _getNavigationContext(),
+        rscStream,
+        ssrHandler: ssrEntry,
+        status: responseStatus,
+      });
     },
-    fontData,
-    fontLinkHeader: __buildAppPageFontLinkHeader(fontData.preloads),
-    navigationContext: _getNavigationContext(),
-    rscStream,
-    ssrHandler: ssrEntry,
+    createRscOnErrorHandler() {
+      return createRscOnErrorHandler(
+        request,
+        _pathname,
+        route?.pattern ?? _pathname,
+      );
+    },
+    element,
+    isRscRequest,
+    renderToReadableStream,
     status: 200,
   });
 }
@@ -13079,6 +12933,12 @@ import {
   teeAppPageRscStreamForCapture as __teeAppPageRscStreamForCapture,
 } from "<ROOT>/packages/vinext/src/server/app-page-execution.js";
 import {
+  renderAppPageBoundaryResponse as __renderAppPageBoundaryResponse,
+  resolveAppPageErrorBoundary as __resolveAppPageErrorBoundary,
+  resolveAppPageHttpAccessBoundaryComponent as __resolveAppPageHttpAccessBoundaryComponent,
+  wrapAppPageBoundaryElement as __wrapAppPageBoundaryElement,
+} from "<ROOT>/packages/vinext/src/server/app-page-boundary.js";
+import {
   createAppPageFontData as __createAppPageFontData,
   createAppPageRscErrorTracker as __createAppPageRscErrorTracker,
   renderAppPageHtmlResponse as __renderAppPageHtmlResponse,
@@ -13524,19 +13384,20 @@ const rootLayouts = [mod_1];
  * @param opts.layouts - Override the layouts to wrap with (for layout-level notFound, excludes the throwing layout)
  */
 async function renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, opts) {
-  // Determine which boundary component to use based on status code
-  let BoundaryComponent = opts?.boundaryComponent ?? null;
-  if (!BoundaryComponent) {
-    let boundaryModule;
-    if (statusCode === 403) {
-      boundaryModule = route?.forbidden ?? rootForbiddenModule;
-    } else if (statusCode === 401) {
-      boundaryModule = route?.unauthorized ?? rootUnauthorizedModule;
-    } else {
-      boundaryModule = route?.notFound ?? rootNotFoundModule;
-    }
-    BoundaryComponent = boundaryModule?.default ?? null;
-  }
+  const BoundaryComponent =
+    opts?.boundaryComponent ??
+    __resolveAppPageHttpAccessBoundaryComponent({
+      getDefaultExport(boundaryModule) {
+        return boundaryModule?.default ?? null;
+      },
+      rootForbiddenModule: rootForbiddenModule,
+      rootNotFoundModule: rootNotFoundModule,
+      rootUnauthorizedModule: rootUnauthorizedModule,
+      routeForbiddenModule: route?.forbidden,
+      routeNotFoundModule: route?.notFound,
+      routeUnauthorizedModule: route?.unauthorized,
+      statusCode,
+    });
   const layouts = opts?.layouts ?? route?.layouts ?? rootLayouts;
   if (!BoundaryComponent) return null;
 
@@ -13573,82 +13434,67 @@ async function renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, req
   if (resolvedMetadata) headElements.push(createElement(MetadataHead, { metadata: resolvedMetadata }));
   headElements.push(createElement(ViewportHead, { viewport: resolvedViewport }));
   let element = createElement(Fragment, null, ...headElements, createElement(BoundaryComponent));
-  if (isRscRequest) {
-    // For RSC requests (client-side navigation), wrap the element with the same
-    // component wrappers that buildPageElement() uses. Without these wrappers,
-    // React's reconciliation would see a mismatched tree structure between the
-    // old fiber tree (ErrorBoundary > LayoutSegmentProvider > html > body > NotFoundBoundary > ...)
-    // and the new tree (html > body > ...), causing it to destroy and recreate
-    // the entire DOM tree, resulting in a blank white page.
-    //
-    // We wrap each layout with LayoutSegmentProvider and add GlobalErrorBoundary
-    // to match the wrapping order in buildPageElement(), ensuring smooth
-    // client-side tree reconciliation.
-    const _treePositions = route?.layoutTreePositions;
-    const _routeSegs = route?.routeSegments || [];
-    const _fallbackParams = opts?.matchedParams ?? route?.params ?? {};
-    const _asyncFallbackParams = makeThenableParams(_fallbackParams);
-    for (let i = layouts.length - 1; i >= 0; i--) {
-      const LayoutComponent = layouts[i]?.default;
-      if (LayoutComponent) {
-        element = createElement(LayoutComponent, { children: element, params: _asyncFallbackParams });
-        const _tp = _treePositions ? _treePositions[i] : 0;
-        const _cs = __resolveChildSegments(_routeSegs, _tp, _fallbackParams);
-        element = createElement(LayoutSegmentProvider, { childSegments: _cs }, element);
-      }
-    }
-    
-    const _pathname = new URL(request.url).pathname;
-    const onRenderError = createRscOnErrorHandler(
-      request,
-      _pathname,
-      route?.pattern ?? _pathname,
-    );
-    const rscStream = renderToReadableStream(element, { onError: onRenderError });
-    // Do NOT clear context here — the RSC stream is consumed lazily by the client.
-    // Clearing context now would cause async server components (e.g. NextIntlClientProviderServer)
-    // that run during stream consumption to see null headers/navigation context and throw,
-    // resulting in missing provider context on the client (e.g. next-intl useTranslations fails
-    // with "context from NextIntlClientProvider was not found").
-    // Context is cleared naturally when the ALS scope from runWithRequestContext unwinds.
-    return new Response(rscStream, {
-      status: statusCode,
-      headers: { "Content-Type": "text/x-component; charset=utf-8", "Vary": "RSC, Accept" },
-    });
-  }
-  // For HTML (full page load) responses, wrap with layouts only (no client-side
-  // wrappers needed since SSR generates the complete HTML document).
-  const _fallbackParamsHtml = opts?.matchedParams ?? route?.params ?? {};
-  const _asyncFallbackParamsHtml = makeThenableParams(_fallbackParamsHtml);
-  for (let i = layouts.length - 1; i >= 0; i--) {
-    const LayoutComponent = layouts[i]?.default;
-    if (LayoutComponent) {
-      element = createElement(LayoutComponent, { children: element, params: _asyncFallbackParamsHtml });
-    }
-  }
-  const _pathname = new URL(request.url).pathname;
-  const onRenderError = createRscOnErrorHandler(
-    request,
-    _pathname,
-    route?.pattern ?? _pathname,
-  );
-  const rscStream = renderToReadableStream(element, { onError: onRenderError });
-  const fontData = __createAppPageFontData({
-    getLinks: _getSSRFontLinks,
-    getPreloads: _getSSRFontPreloads,
-    getStyles: _getSSRFontStyles,
-  });
-  const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
-  return __renderAppPageHtmlResponse({
-    clearRequestContext() {
-      setHeadersContext(null);
-      setNavigationContext(null);
+  element = __wrapAppPageBoundaryElement({
+    element,
+    getDefaultExport(layoutModule) {
+      return layoutModule?.default ?? null;
     },
-    fontData,
-    fontLinkHeader: __buildAppPageFontLinkHeader(fontData.preloads),
-    navigationContext: _getNavigationContext(),
-    rscStream,
-    ssrHandler: ssrEntry,
+    globalErrorComponent: null,
+    includeGlobalErrorBoundary: true,
+    isRscRequest,
+    layoutModules: layouts,
+    layoutTreePositions: route?.layoutTreePositions,
+    makeThenableParams,
+    matchedParams: _fallbackParams,
+    renderErrorBoundary(GlobalErrorComponent, children) {
+      return createElement(ErrorBoundary, {
+        fallback: GlobalErrorComponent,
+        children,
+      });
+    },
+    renderLayout(LayoutComponent, children, asyncParams) {
+      return createElement(LayoutComponent, { children, params: asyncParams });
+    },
+    renderLayoutSegmentProvider(childSegments, children) {
+      return createElement(LayoutSegmentProvider, { childSegments }, children);
+    },
+    resolveChildSegments(routeSegments, treePosition, boundaryParams) {
+      return __resolveChildSegments(routeSegments, treePosition, boundaryParams);
+    },
+    routeSegments: route?.routeSegments || [],
+  });
+  const _pathname = new URL(request.url).pathname;
+  return __renderAppPageBoundaryResponse({
+    async createHtmlResponse(rscStream, responseStatus) {
+      const fontData = __createAppPageFontData({
+        getLinks: _getSSRFontLinks,
+        getPreloads: _getSSRFontPreloads,
+        getStyles: _getSSRFontStyles,
+      });
+      const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
+      return __renderAppPageHtmlResponse({
+        clearRequestContext() {
+          setHeadersContext(null);
+          setNavigationContext(null);
+        },
+        fontData,
+        fontLinkHeader: __buildAppPageFontLinkHeader(fontData.preloads),
+        navigationContext: _getNavigationContext(),
+        rscStream,
+        ssrHandler: ssrEntry,
+        status: responseStatus,
+      });
+    },
+    createRscOnErrorHandler() {
+      return createRscOnErrorHandler(
+        request,
+        _pathname,
+        route?.pattern ?? _pathname,
+      );
+    },
+    element,
+    isRscRequest,
+    renderToReadableStream,
     status: statusCode,
   });
 }
@@ -13666,20 +13512,15 @@ async function renderNotFoundPage(route, isRscRequest, request, matchedParams) {
  * by the boundary). This matches that behavior intentionally.
  */
 async function renderErrorBoundaryPage(route, error, isRscRequest, request, matchedParams) {
-  // Resolve the error boundary component: leaf error.tsx first, then walk per-layout
-  // errors from innermost to outermost (matching ancestor inheritance), then global-error.tsx.
-  let ErrorComponent = route?.error?.default ?? null;
-  let _isGlobalError = false;
-  if (!ErrorComponent && route?.errors) {
-    for (let i = route.errors.length - 1; i >= 0; i--) {
-      if (route.errors[i]?.default) {
-        ErrorComponent = route.errors[i].default;
-        break;
-      }
-    }
-  }
-  
-  if (!ErrorComponent) return null;
+  const __errorBoundary = __resolveAppPageErrorBoundary({
+    getDefaultExport(errorModule) {
+      return errorModule?.default ?? null;
+    },
+    globalErrorModule: null,
+    layoutErrorModules: route?.errors,
+    pageErrorModule: route?.error,
+  });
+  if (!__errorBoundary.component) return null;
 
   const rawError = error instanceof Error ? error : new Error(String(error));
   // Sanitize the error in production to avoid leaking internal details
@@ -13690,85 +13531,73 @@ async function renderErrorBoundaryPage(route, error, isRscRequest, request, matc
   // can't be serialized through RSC. The error.tsx component will receive reset=undefined
   // during SSR, which is fine — onClick={undefined} is harmless, and the real reset
   // function is only meaningful after hydration.
-  let element = createElement(ErrorComponent, {
+  let element = createElement(__errorBoundary.component, {
     error: errorObj,
   });
-
-  // global-error.tsx provides its own <html> and <body> (it replaces the root
-  // layout). Skip layout wrapping when rendering it to avoid double <html> tags.
-  if (!_isGlobalError) {
-    const layouts = route?.layouts ?? rootLayouts;
-    if (isRscRequest) {
-      // For RSC requests (client-side navigation), wrap with the same component
-      // wrappers that buildPageElement() uses (LayoutSegmentProvider, GlobalErrorBoundary).
-      // This ensures React can reconcile the tree without destroying the DOM.
-      // Same rationale as renderHTTPAccessFallbackPage — see comment there.
-      const _errTreePositions = route?.layoutTreePositions;
-      const _errRouteSegs = route?.routeSegments || [];
-      const _errParams = matchedParams ?? route?.params ?? {};
-      const _asyncErrParams = makeThenableParams(_errParams);
-      for (let i = layouts.length - 1; i >= 0; i--) {
-        const LayoutComponent = layouts[i]?.default;
-        if (LayoutComponent) {
-          element = createElement(LayoutComponent, { children: element, params: _asyncErrParams });
-          const _etp = _errTreePositions ? _errTreePositions[i] : 0;
-          const _ecs = __resolveChildSegments(_errRouteSegs, _etp, _errParams);
-          element = createElement(LayoutSegmentProvider, { childSegments: _ecs }, element);
-        }
-      }
-      
-    } else {
-      // For HTML (full page load) responses, wrap with layouts only.
-      const _errParamsHtml = matchedParams ?? route?.params ?? {};
-      const _asyncErrParamsHtml = makeThenableParams(_errParamsHtml);
-      for (let i = layouts.length - 1; i >= 0; i--) {
-        const LayoutComponent = layouts[i]?.default;
-        if (LayoutComponent) {
-          element = createElement(LayoutComponent, { children: element, params: _asyncErrParamsHtml });
-        }
-      }
-    }
-  }
+  const _errParams = matchedParams ?? route?.params ?? {};
+  element = __wrapAppPageBoundaryElement({
+    element,
+    getDefaultExport(layoutModule) {
+      return layoutModule?.default ?? null;
+    },
+    globalErrorComponent: null,
+    includeGlobalErrorBoundary: !__errorBoundary.isGlobalError,
+    isRscRequest,
+    layoutModules: route?.layouts ?? rootLayouts,
+    layoutTreePositions: route?.layoutTreePositions,
+    makeThenableParams,
+    matchedParams: _errParams,
+    renderErrorBoundary(GlobalErrorComponent, children) {
+      return createElement(ErrorBoundary, {
+        fallback: GlobalErrorComponent,
+        children,
+      });
+    },
+    renderLayout(LayoutComponent, children, asyncParams) {
+      return createElement(LayoutComponent, { children, params: asyncParams });
+    },
+    renderLayoutSegmentProvider(childSegments, children) {
+      return createElement(LayoutSegmentProvider, { childSegments }, children);
+    },
+    resolveChildSegments(routeSegments, treePosition, boundaryParams) {
+      return __resolveChildSegments(routeSegments, treePosition, boundaryParams);
+    },
+    routeSegments: route?.routeSegments || [],
+    skipLayoutWrapping: __errorBoundary.isGlobalError,
+  });
 
   const _pathname = new URL(request.url).pathname;
-  const onRenderError = createRscOnErrorHandler(
-    request,
-    _pathname,
-    route?.pattern ?? _pathname,
-  );
-
-  if (isRscRequest) {
-    const rscStream = renderToReadableStream(element, { onError: onRenderError });
-    // Do NOT clear context here — the RSC stream is consumed lazily by the client.
-    // Clearing context now would cause async server components (e.g. NextIntlClientProviderServer)
-    // that run during stream consumption to see null headers/navigation context and throw,
-    // resulting in missing provider context on the client (e.g. next-intl useTranslations fails
-    // with "context from NextIntlClientProvider was not found").
-    // Context is cleared naturally when the ALS scope from runWithRequestContext unwinds.
-    return new Response(rscStream, {
-      status: 200,
-      headers: { "Content-Type": "text/x-component; charset=utf-8", "Vary": "RSC, Accept" },
-    });
-  }
-
-  // HTML (full page load) response — render through RSC → SSR pipeline
-  const rscStream = renderToReadableStream(element, { onError: onRenderError });
-  const fontData = __createAppPageFontData({
-    getLinks: _getSSRFontLinks,
-    getPreloads: _getSSRFontPreloads,
-    getStyles: _getSSRFontStyles,
-  });
-  const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
-  return __renderAppPageHtmlResponse({
-    clearRequestContext() {
-      setHeadersContext(null);
-      setNavigationContext(null);
+  return __renderAppPageBoundaryResponse({
+    async createHtmlResponse(rscStream, responseStatus) {
+      const fontData = __createAppPageFontData({
+        getLinks: _getSSRFontLinks,
+        getPreloads: _getSSRFontPreloads,
+        getStyles: _getSSRFontStyles,
+      });
+      const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
+      return __renderAppPageHtmlResponse({
+        clearRequestContext() {
+          setHeadersContext(null);
+          setNavigationContext(null);
+        },
+        fontData,
+        fontLinkHeader: __buildAppPageFontLinkHeader(fontData.preloads),
+        navigationContext: _getNavigationContext(),
+        rscStream,
+        ssrHandler: ssrEntry,
+        status: responseStatus,
+      });
     },
-    fontData,
-    fontLinkHeader: __buildAppPageFontLinkHeader(fontData.preloads),
-    navigationContext: _getNavigationContext(),
-    rscStream,
-    ssrHandler: ssrEntry,
+    createRscOnErrorHandler() {
+      return createRscOnErrorHandler(
+        request,
+        _pathname,
+        route?.pattern ?? _pathname,
+      );
+    },
+    element,
+    isRscRequest,
+    renderToReadableStream,
     status: 200,
   });
 }

--- a/tests/app-page-boundary.test.ts
+++ b/tests/app-page-boundary.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+import {
+  renderAppPageBoundaryResponse,
+  resolveAppPageErrorBoundary,
+  resolveAppPageHttpAccessBoundaryComponent,
+  wrapAppPageBoundaryElement,
+} from "../packages/vinext/src/server/app-page-boundary.js";
+
+async function readText(stream: ReadableStream<Uint8Array>): Promise<string> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let text = "";
+
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+    text += decoder.decode(value, { stream: true });
+  }
+
+  return text + decoder.decode();
+}
+
+describe("app page boundary helpers", () => {
+  it("prefers route-specific HTTP access boundaries over root fallbacks", () => {
+    const component = resolveAppPageHttpAccessBoundaryComponent({
+      getDefaultExport(boundaryModule) {
+        return boundaryModule?.default ?? null;
+      },
+      rootForbiddenModule: { default: "RootForbidden" },
+      rootNotFoundModule: { default: "RootNotFound" },
+      rootUnauthorizedModule: { default: "RootUnauthorized" },
+      routeForbiddenModule: { default: "RouteForbidden" },
+      routeNotFoundModule: { default: "RouteNotFound" },
+      routeUnauthorizedModule: { default: "RouteUnauthorized" },
+      statusCode: 403,
+    });
+
+    expect(component).toBe("RouteForbidden");
+  });
+
+  it("falls back to the root not-found boundary when the route has none", () => {
+    const component = resolveAppPageHttpAccessBoundaryComponent({
+      getDefaultExport(boundaryModule) {
+        return boundaryModule?.default ?? null;
+      },
+      rootNotFoundModule: { default: "RootNotFound" },
+      statusCode: 404,
+    });
+
+    expect(component).toBe("RootNotFound");
+  });
+
+  it("resolves page, layout, and global error boundaries in order", () => {
+    expect(
+      resolveAppPageErrorBoundary({
+        getDefaultExport(errorModule) {
+          return errorModule?.default ?? null;
+        },
+        layoutErrorModules: [{ default: "RootLayoutError" }, { default: "LeafLayoutError" }],
+        pageErrorModule: { default: "PageError" },
+      }),
+    ).toEqual({
+      component: "PageError",
+      isGlobalError: false,
+    });
+
+    expect(
+      resolveAppPageErrorBoundary({
+        getDefaultExport(errorModule) {
+          return errorModule?.default ?? null;
+        },
+        globalErrorModule: { default: "GlobalError" },
+        layoutErrorModules: [{ default: "RootLayoutError" }, { default: "LeafLayoutError" }],
+        pageErrorModule: null,
+      }),
+    ).toEqual({
+      component: "LeafLayoutError",
+      isGlobalError: false,
+    });
+
+    expect(
+      resolveAppPageErrorBoundary({
+        getDefaultExport(errorModule) {
+          return errorModule?.default ?? null;
+        },
+        globalErrorModule: { default: "GlobalError" },
+        layoutErrorModules: [null, undefined],
+        pageErrorModule: null,
+      }),
+    ).toEqual({
+      component: "GlobalError",
+      isGlobalError: true,
+    });
+  });
+
+  it("wraps boundary elements with layouts, segment providers, and the global boundary for RSC", () => {
+    const wrapped = wrapAppPageBoundaryElement({
+      element: "Boundary",
+      getDefaultExport(layoutModule) {
+        return layoutModule?.default ?? null;
+      },
+      globalErrorComponent: "GlobalError",
+      includeGlobalErrorBoundary: true,
+      isRscRequest: true,
+      layoutModules: [{ default: "RootLayout" }, { default: "LeafLayout" }],
+      layoutTreePositions: [0, 1],
+      makeThenableParams(params) {
+        return { ...params, thenable: true };
+      },
+      matchedParams: { slug: "post" },
+      renderErrorBoundary(component, children) {
+        return `ErrorBoundary(${component})[${children}]`;
+      },
+      renderLayout(component, children, params) {
+        return `Layout(${component})[${children}|${JSON.stringify(params)}]`;
+      },
+      renderLayoutSegmentProvider(childSegments, children) {
+        return `Segment(${String(childSegments)})[${children}]`;
+      },
+      resolveChildSegments(routeSegments, treePosition, params) {
+        const slug = Array.isArray(params.slug) ? params.slug.join("/") : params.slug;
+        return `${routeSegments[treePosition] ?? "root"}:${slug}`;
+      },
+      routeSegments: ["root", "[slug]"],
+    });
+
+    expect(wrapped).toBe(
+      'ErrorBoundary(GlobalError)[Segment(root:post)[Layout(RootLayout)[Segment([slug]:post)[Layout(LeafLayout)[Boundary|{"slug":"post","thenable":true}]]|{"slug":"post","thenable":true}]]]',
+    );
+  });
+
+  it("skips layout wrapping for global-error renders", () => {
+    const wrapped = wrapAppPageBoundaryElement({
+      element: "Boundary",
+      getDefaultExport(layoutModule) {
+        return layoutModule?.default ?? null;
+      },
+      globalErrorComponent: "GlobalError",
+      includeGlobalErrorBoundary: false,
+      isRscRequest: false,
+      layoutModules: [{ default: "RootLayout" }],
+      makeThenableParams(params) {
+        return params;
+      },
+      matchedParams: {},
+      renderErrorBoundary(component, children) {
+        return `ErrorBoundary(${component})[${children}]`;
+      },
+      renderLayout(component, children) {
+        return `Layout(${component})[${children}]`;
+      },
+      skipLayoutWrapping: true,
+    });
+
+    expect(wrapped).toBe("Boundary");
+  });
+
+  it("returns direct RSC responses without invoking the HTML callback", async () => {
+    const createHtmlResponse = vi.fn(async () => new Response("html"));
+
+    const response = await renderAppPageBoundaryResponse({
+      createHtmlResponse,
+      createRscOnErrorHandler() {
+        return () => null;
+      },
+      element: "RSC boundary",
+      isRscRequest: true,
+      renderToReadableStream(element) {
+        return new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode(String(element)));
+            controller.close();
+          },
+        });
+      },
+      status: 404,
+    });
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get("Content-Type")).toBe("text/x-component; charset=utf-8");
+    expect(createHtmlResponse).not.toHaveBeenCalled();
+    await expect(response.text()).resolves.toBe("RSC boundary");
+  });
+
+  it("routes HTML boundary renders through the provided SSR callback", async () => {
+    const createHtmlResponse = vi.fn(
+      async (rscStream: ReadableStream<Uint8Array>, status: number) => {
+        return new Response(`${status}:${await readText(rscStream)}`);
+      },
+    );
+
+    const response = await renderAppPageBoundaryResponse({
+      createHtmlResponse,
+      createRscOnErrorHandler() {
+        return () => null;
+      },
+      element: "HTML boundary",
+      isRscRequest: false,
+      renderToReadableStream(element) {
+        return new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode(String(element)));
+            controller.close();
+          },
+        });
+      },
+      status: 200,
+    });
+
+    expect(createHtmlResponse).toHaveBeenCalledTimes(1);
+    await expect(response.text()).resolves.toBe("200:HTML boundary");
+  });
+});

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -3732,6 +3732,19 @@ describe("generateRscEntry ISR code generation", () => {
     expect(code).toContain("const __pageBuildResult = await __buildAppPageElement({");
   });
 
+  it("generated code delegates page boundary rendering to typed helpers", () => {
+    const code = generateRscEntry("/tmp/test/app", minimalRoutes);
+    expect(code).toContain("renderAppPageBoundaryResponse as __renderAppPageBoundaryResponse");
+    expect(code).toContain("resolveAppPageErrorBoundary as __resolveAppPageErrorBoundary");
+    expect(code).toContain(
+      "resolveAppPageHttpAccessBoundaryComponent as __resolveAppPageHttpAccessBoundaryComponent",
+    );
+    expect(code).toContain("wrapAppPageBoundaryElement as __wrapAppPageBoundaryElement");
+    expect(code).toContain("__resolveAppPageHttpAccessBoundaryComponent({");
+    expect(code).toContain("element = __wrapAppPageBoundaryElement({");
+    expect(code).toContain("return __renderAppPageBoundaryResponse({");
+  });
+
   it("generated code delegates page cache HIT handling to a typed helper", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes);
     expect(code).toContain("readAppPageCacheResponse as __readAppPageCacheResponse");


### PR DESCRIPTION
## Summary
- extract App Router page boundary selection and shared wrap/render branching into `app-page-boundary.ts`
- keep `app-rsc-entry.ts` focused on route-specific metadata and tree wiring while delegating fallback/error boundary response orchestration to typed helpers
- add focused boundary helper tests and relax the Suspense not-found assertion to check for preserved digests across equivalent React dev payload shapes

## Testing
- `vp check packages/vinext/src/server/app-page-boundary.ts packages/vinext/src/entries/app-rsc-entry.ts tests/app-page-boundary.test.ts tests/app-router.test.ts`
- `vp test run tests/app-page-boundary.test.ts tests/app-router.test.ts -t 'app page boundary helpers|generated code delegates page boundary rendering'`
- `vp test run tests/app-page-boundary.test.ts tests/app-page-request.test.ts tests/app-page-stream.test.ts tests/app-page-execution.test.ts tests/app-page-cache.test.ts tests/app-page-response.test.ts tests/error-boundary.test.ts`
- `vp test run tests/entry-templates.test.ts -u`
- `vp test run tests/app-router.test.ts -t 'notFound\(\) inside Suspense boundary preserves digest for not-found UI|renders intercepted photo modal on RSC navigation from feed|renders custom not-found.tsx for unmatched routes|notFound\(\) escalates to nearest ancestor not-found.tsx|forbidden\(\) from Server Component returns 403 with forbidden.tsx|unauthorized\(\) from Server Component returns 401 with unauthorized.tsx|renders error boundary wrapper for routes with error.tsx|generated code delegates page boundary rendering to typed helpers|generated code|dynamicParams = false|page ISR \+ searchParams'`
- `vp run vinext#build`

Written by Codex.
