### PR TITLE
refactor: extract app page html recovery runtime

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -409,6 +409,7 @@ import {
   createAppPageRscErrorTracker as __createAppPageRscErrorTracker,
   renderAppPageHtmlResponse as __renderAppPageHtmlResponse,
   renderAppPageHtmlStream as __renderAppPageHtmlStream,
+  renderAppPageHtmlStreamWithRecovery as __renderAppPageHtmlStreamWithRecovery,
   shouldRerenderAppPageWithGlobalError as __shouldRerenderAppPageWithGlobalError,
 } from ${JSON.stringify(appPageStreamPath)};
 import {
@@ -2713,41 +2714,42 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // __isrRscDataPromise resolves to rscData bytes used by the RSC write path above;
   // the HTML write path below uses its own separate key and does not need rscData.
 
-  // Delegate to SSR environment for HTML rendering
-  let htmlStream;
-  try {
-    const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
-    htmlStream = await __renderAppPageHtmlStream({
-      fontData,
-      navigationContext: _getNavigationContext(),
-      rscStream: __rscForResponse,
-      ssrHandler: ssrEntry,
-    });
-    // Shell render complete; Suspense boundaries stream asynchronously
-    if (process.env.NODE_ENV !== "production") __renderEnd = performance.now();
-  } catch (ssrErr) {
-    const __ssrSpecialError = __resolveAppPageSpecialError(ssrErr);
-    const specialResponse = __ssrSpecialError
-      ? await __buildAppPageSpecialErrorResponse({
-          clearRequestContext() {
-            setHeadersContext(null);
-            setNavigationContext(null);
-          },
-          renderFallbackPage(statusCode) {
-            return renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, {
-              matchedParams: params,
-            });
-          },
-          requestUrl: request.url,
-          specialError: __ssrSpecialError,
-        })
-      : null;
-    if (specialResponse) return specialResponse;
-    // Non-special error during SSR — render error.tsx if available
-    const errorBoundaryResp = await renderErrorBoundaryPage(route, ssrErr, isRscRequest, request, params);
-    if (errorBoundaryResp) return errorBoundaryResp;
-    throw ssrErr;
-  }
+  const __htmlRender = await __renderAppPageHtmlStreamWithRecovery({
+    onShellRendered() {
+      // Shell render complete; Suspense boundaries stream asynchronously.
+      if (process.env.NODE_ENV !== "production") __renderEnd = performance.now();
+    },
+    renderErrorBoundaryResponse(ssrErr) {
+      return renderErrorBoundaryPage(route, ssrErr, isRscRequest, request, params);
+    },
+    async renderHtmlStream() {
+      const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
+      return __renderAppPageHtmlStream({
+        fontData,
+        navigationContext: _getNavigationContext(),
+        rscStream: __rscForResponse,
+        ssrHandler: ssrEntry,
+      });
+    },
+    renderSpecialErrorResponse(__ssrSpecialError) {
+      return __buildAppPageSpecialErrorResponse({
+        clearRequestContext() {
+          setHeadersContext(null);
+          setNavigationContext(null);
+        },
+        renderFallbackPage(statusCode) {
+          return renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, {
+            matchedParams: params,
+          });
+        },
+        requestUrl: request.url,
+        specialError: __ssrSpecialError,
+      });
+    },
+    resolveSpecialError: __resolveAppPageSpecialError,
+  });
+  if (__htmlRender.response) return __htmlRender.response;
+  const htmlStream = __htmlRender.htmlStream;
 
   // If an RSC error was caught by the in-tree global ErrorBoundary during SSR,
   // the HTML output has double <html>/<body> (root layout + global-error.tsx).

--- a/packages/vinext/src/server/app-page-stream.ts
+++ b/packages/vinext/src/server/app-page-stream.ts
@@ -33,6 +33,19 @@ export interface RenderAppPageHtmlResponseOptions extends RenderAppPageHtmlStrea
   status: number;
 }
 
+export interface AppPageHtmlStreamRecoveryResult {
+  htmlStream: ReadableStream<Uint8Array> | null;
+  response: Response | null;
+}
+
+export interface RenderAppPageHtmlStreamWithRecoveryOptions<TSpecialError> {
+  onShellRendered?: () => void;
+  renderErrorBoundaryResponse: (error: unknown) => Promise<Response | null>;
+  renderHtmlStream: () => Promise<ReadableStream<Uint8Array>>;
+  renderSpecialErrorResponse: (specialError: TSpecialError) => Promise<Response>;
+  resolveSpecialError: (error: unknown) => TSpecialError | null;
+}
+
 export interface AppPageRscErrorTracker {
   getCapturedError: () => unknown;
   onRenderError: (error: unknown, requestInfo: unknown, errorContext: unknown) => unknown;
@@ -80,6 +93,37 @@ export async function renderAppPageHtmlResponse(
     status: options.status,
     headers,
   });
+}
+
+export async function renderAppPageHtmlStreamWithRecovery<TSpecialError>(
+  options: RenderAppPageHtmlStreamWithRecoveryOptions<TSpecialError>,
+): Promise<AppPageHtmlStreamRecoveryResult> {
+  try {
+    const htmlStream = await options.renderHtmlStream();
+    options.onShellRendered?.();
+    return {
+      htmlStream,
+      response: null,
+    };
+  } catch (error) {
+    const specialError = options.resolveSpecialError(error);
+    if (specialError) {
+      return {
+        htmlStream: null,
+        response: await options.renderSpecialErrorResponse(specialError),
+      };
+    }
+
+    const boundaryResponse = await options.renderErrorBoundaryResponse(error);
+    if (boundaryResponse) {
+      return {
+        htmlStream: null,
+        response: boundaryResponse,
+      };
+    }
+
+    throw error;
+  }
 }
 
 export function createAppPageRscErrorTracker(

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -98,6 +98,7 @@ import {
   createAppPageRscErrorTracker as __createAppPageRscErrorTracker,
   renderAppPageHtmlResponse as __renderAppPageHtmlResponse,
   renderAppPageHtmlStream as __renderAppPageHtmlStream,
+  renderAppPageHtmlStreamWithRecovery as __renderAppPageHtmlStreamWithRecovery,
   shouldRerenderAppPageWithGlobalError as __shouldRerenderAppPageWithGlobalError,
 } from "<ROOT>/packages/vinext/src/server/app-page-stream.js";
 import {
@@ -2403,41 +2404,42 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // __isrRscDataPromise resolves to rscData bytes used by the RSC write path above;
   // the HTML write path below uses its own separate key and does not need rscData.
 
-  // Delegate to SSR environment for HTML rendering
-  let htmlStream;
-  try {
-    const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
-    htmlStream = await __renderAppPageHtmlStream({
-      fontData,
-      navigationContext: _getNavigationContext(),
-      rscStream: __rscForResponse,
-      ssrHandler: ssrEntry,
-    });
-    // Shell render complete; Suspense boundaries stream asynchronously
-    if (process.env.NODE_ENV !== "production") __renderEnd = performance.now();
-  } catch (ssrErr) {
-    const __ssrSpecialError = __resolveAppPageSpecialError(ssrErr);
-    const specialResponse = __ssrSpecialError
-      ? await __buildAppPageSpecialErrorResponse({
-          clearRequestContext() {
-            setHeadersContext(null);
-            setNavigationContext(null);
-          },
-          renderFallbackPage(statusCode) {
-            return renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, {
-              matchedParams: params,
-            });
-          },
-          requestUrl: request.url,
-          specialError: __ssrSpecialError,
-        })
-      : null;
-    if (specialResponse) return specialResponse;
-    // Non-special error during SSR — render error.tsx if available
-    const errorBoundaryResp = await renderErrorBoundaryPage(route, ssrErr, isRscRequest, request, params);
-    if (errorBoundaryResp) return errorBoundaryResp;
-    throw ssrErr;
-  }
+  const __htmlRender = await __renderAppPageHtmlStreamWithRecovery({
+    onShellRendered() {
+      // Shell render complete; Suspense boundaries stream asynchronously.
+      if (process.env.NODE_ENV !== "production") __renderEnd = performance.now();
+    },
+    renderErrorBoundaryResponse(ssrErr) {
+      return renderErrorBoundaryPage(route, ssrErr, isRscRequest, request, params);
+    },
+    async renderHtmlStream() {
+      const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
+      return __renderAppPageHtmlStream({
+        fontData,
+        navigationContext: _getNavigationContext(),
+        rscStream: __rscForResponse,
+        ssrHandler: ssrEntry,
+      });
+    },
+    renderSpecialErrorResponse(__ssrSpecialError) {
+      return __buildAppPageSpecialErrorResponse({
+        clearRequestContext() {
+          setHeadersContext(null);
+          setNavigationContext(null);
+        },
+        renderFallbackPage(statusCode) {
+          return renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, {
+            matchedParams: params,
+          });
+        },
+        requestUrl: request.url,
+        specialError: __ssrSpecialError,
+      });
+    },
+    resolveSpecialError: __resolveAppPageSpecialError,
+  });
+  if (__htmlRender.response) return __htmlRender.response;
+  const htmlStream = __htmlRender.htmlStream;
 
   // If an RSC error was caught by the in-tree global ErrorBoundary during SSR,
   // the HTML output has double <html>/<body> (root layout + global-error.tsx).
@@ -2619,6 +2621,7 @@ import {
   createAppPageRscErrorTracker as __createAppPageRscErrorTracker,
   renderAppPageHtmlResponse as __renderAppPageHtmlResponse,
   renderAppPageHtmlStream as __renderAppPageHtmlStream,
+  renderAppPageHtmlStreamWithRecovery as __renderAppPageHtmlStreamWithRecovery,
   shouldRerenderAppPageWithGlobalError as __shouldRerenderAppPageWithGlobalError,
 } from "<ROOT>/packages/vinext/src/server/app-page-stream.js";
 import {
@@ -4927,41 +4930,42 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // __isrRscDataPromise resolves to rscData bytes used by the RSC write path above;
   // the HTML write path below uses its own separate key and does not need rscData.
 
-  // Delegate to SSR environment for HTML rendering
-  let htmlStream;
-  try {
-    const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
-    htmlStream = await __renderAppPageHtmlStream({
-      fontData,
-      navigationContext: _getNavigationContext(),
-      rscStream: __rscForResponse,
-      ssrHandler: ssrEntry,
-    });
-    // Shell render complete; Suspense boundaries stream asynchronously
-    if (process.env.NODE_ENV !== "production") __renderEnd = performance.now();
-  } catch (ssrErr) {
-    const __ssrSpecialError = __resolveAppPageSpecialError(ssrErr);
-    const specialResponse = __ssrSpecialError
-      ? await __buildAppPageSpecialErrorResponse({
-          clearRequestContext() {
-            setHeadersContext(null);
-            setNavigationContext(null);
-          },
-          renderFallbackPage(statusCode) {
-            return renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, {
-              matchedParams: params,
-            });
-          },
-          requestUrl: request.url,
-          specialError: __ssrSpecialError,
-        })
-      : null;
-    if (specialResponse) return specialResponse;
-    // Non-special error during SSR — render error.tsx if available
-    const errorBoundaryResp = await renderErrorBoundaryPage(route, ssrErr, isRscRequest, request, params);
-    if (errorBoundaryResp) return errorBoundaryResp;
-    throw ssrErr;
-  }
+  const __htmlRender = await __renderAppPageHtmlStreamWithRecovery({
+    onShellRendered() {
+      // Shell render complete; Suspense boundaries stream asynchronously.
+      if (process.env.NODE_ENV !== "production") __renderEnd = performance.now();
+    },
+    renderErrorBoundaryResponse(ssrErr) {
+      return renderErrorBoundaryPage(route, ssrErr, isRscRequest, request, params);
+    },
+    async renderHtmlStream() {
+      const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
+      return __renderAppPageHtmlStream({
+        fontData,
+        navigationContext: _getNavigationContext(),
+        rscStream: __rscForResponse,
+        ssrHandler: ssrEntry,
+      });
+    },
+    renderSpecialErrorResponse(__ssrSpecialError) {
+      return __buildAppPageSpecialErrorResponse({
+        clearRequestContext() {
+          setHeadersContext(null);
+          setNavigationContext(null);
+        },
+        renderFallbackPage(statusCode) {
+          return renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, {
+            matchedParams: params,
+          });
+        },
+        requestUrl: request.url,
+        specialError: __ssrSpecialError,
+      });
+    },
+    resolveSpecialError: __resolveAppPageSpecialError,
+  });
+  if (__htmlRender.response) return __htmlRender.response;
+  const htmlStream = __htmlRender.htmlStream;
 
   // If an RSC error was caught by the in-tree global ErrorBoundary during SSR,
   // the HTML output has double <html>/<body> (root layout + global-error.tsx).
@@ -5143,6 +5147,7 @@ import {
   createAppPageRscErrorTracker as __createAppPageRscErrorTracker,
   renderAppPageHtmlResponse as __renderAppPageHtmlResponse,
   renderAppPageHtmlStream as __renderAppPageHtmlStream,
+  renderAppPageHtmlStreamWithRecovery as __renderAppPageHtmlStreamWithRecovery,
   shouldRerenderAppPageWithGlobalError as __shouldRerenderAppPageWithGlobalError,
 } from "<ROOT>/packages/vinext/src/server/app-page-stream.js";
 import {
@@ -7457,41 +7462,42 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // __isrRscDataPromise resolves to rscData bytes used by the RSC write path above;
   // the HTML write path below uses its own separate key and does not need rscData.
 
-  // Delegate to SSR environment for HTML rendering
-  let htmlStream;
-  try {
-    const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
-    htmlStream = await __renderAppPageHtmlStream({
-      fontData,
-      navigationContext: _getNavigationContext(),
-      rscStream: __rscForResponse,
-      ssrHandler: ssrEntry,
-    });
-    // Shell render complete; Suspense boundaries stream asynchronously
-    if (process.env.NODE_ENV !== "production") __renderEnd = performance.now();
-  } catch (ssrErr) {
-    const __ssrSpecialError = __resolveAppPageSpecialError(ssrErr);
-    const specialResponse = __ssrSpecialError
-      ? await __buildAppPageSpecialErrorResponse({
-          clearRequestContext() {
-            setHeadersContext(null);
-            setNavigationContext(null);
-          },
-          renderFallbackPage(statusCode) {
-            return renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, {
-              matchedParams: params,
-            });
-          },
-          requestUrl: request.url,
-          specialError: __ssrSpecialError,
-        })
-      : null;
-    if (specialResponse) return specialResponse;
-    // Non-special error during SSR — render error.tsx if available
-    const errorBoundaryResp = await renderErrorBoundaryPage(route, ssrErr, isRscRequest, request, params);
-    if (errorBoundaryResp) return errorBoundaryResp;
-    throw ssrErr;
-  }
+  const __htmlRender = await __renderAppPageHtmlStreamWithRecovery({
+    onShellRendered() {
+      // Shell render complete; Suspense boundaries stream asynchronously.
+      if (process.env.NODE_ENV !== "production") __renderEnd = performance.now();
+    },
+    renderErrorBoundaryResponse(ssrErr) {
+      return renderErrorBoundaryPage(route, ssrErr, isRscRequest, request, params);
+    },
+    async renderHtmlStream() {
+      const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
+      return __renderAppPageHtmlStream({
+        fontData,
+        navigationContext: _getNavigationContext(),
+        rscStream: __rscForResponse,
+        ssrHandler: ssrEntry,
+      });
+    },
+    renderSpecialErrorResponse(__ssrSpecialError) {
+      return __buildAppPageSpecialErrorResponse({
+        clearRequestContext() {
+          setHeadersContext(null);
+          setNavigationContext(null);
+        },
+        renderFallbackPage(statusCode) {
+          return renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, {
+            matchedParams: params,
+          });
+        },
+        requestUrl: request.url,
+        specialError: __ssrSpecialError,
+      });
+    },
+    resolveSpecialError: __resolveAppPageSpecialError,
+  });
+  if (__htmlRender.response) return __htmlRender.response;
+  const htmlStream = __htmlRender.htmlStream;
 
   // If an RSC error was caught by the in-tree global ErrorBoundary during SSR,
   // the HTML output has double <html>/<body> (root layout + global-error.tsx).
@@ -7682,6 +7688,7 @@ import {
   createAppPageRscErrorTracker as __createAppPageRscErrorTracker,
   renderAppPageHtmlResponse as __renderAppPageHtmlResponse,
   renderAppPageHtmlStream as __renderAppPageHtmlStream,
+  renderAppPageHtmlStreamWithRecovery as __renderAppPageHtmlStreamWithRecovery,
   shouldRerenderAppPageWithGlobalError as __shouldRerenderAppPageWithGlobalError,
 } from "<ROOT>/packages/vinext/src/server/app-page-stream.js";
 import {
@@ -10020,41 +10027,42 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // __isrRscDataPromise resolves to rscData bytes used by the RSC write path above;
   // the HTML write path below uses its own separate key and does not need rscData.
 
-  // Delegate to SSR environment for HTML rendering
-  let htmlStream;
-  try {
-    const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
-    htmlStream = await __renderAppPageHtmlStream({
-      fontData,
-      navigationContext: _getNavigationContext(),
-      rscStream: __rscForResponse,
-      ssrHandler: ssrEntry,
-    });
-    // Shell render complete; Suspense boundaries stream asynchronously
-    if (process.env.NODE_ENV !== "production") __renderEnd = performance.now();
-  } catch (ssrErr) {
-    const __ssrSpecialError = __resolveAppPageSpecialError(ssrErr);
-    const specialResponse = __ssrSpecialError
-      ? await __buildAppPageSpecialErrorResponse({
-          clearRequestContext() {
-            setHeadersContext(null);
-            setNavigationContext(null);
-          },
-          renderFallbackPage(statusCode) {
-            return renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, {
-              matchedParams: params,
-            });
-          },
-          requestUrl: request.url,
-          specialError: __ssrSpecialError,
-        })
-      : null;
-    if (specialResponse) return specialResponse;
-    // Non-special error during SSR — render error.tsx if available
-    const errorBoundaryResp = await renderErrorBoundaryPage(route, ssrErr, isRscRequest, request, params);
-    if (errorBoundaryResp) return errorBoundaryResp;
-    throw ssrErr;
-  }
+  const __htmlRender = await __renderAppPageHtmlStreamWithRecovery({
+    onShellRendered() {
+      // Shell render complete; Suspense boundaries stream asynchronously.
+      if (process.env.NODE_ENV !== "production") __renderEnd = performance.now();
+    },
+    renderErrorBoundaryResponse(ssrErr) {
+      return renderErrorBoundaryPage(route, ssrErr, isRscRequest, request, params);
+    },
+    async renderHtmlStream() {
+      const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
+      return __renderAppPageHtmlStream({
+        fontData,
+        navigationContext: _getNavigationContext(),
+        rscStream: __rscForResponse,
+        ssrHandler: ssrEntry,
+      });
+    },
+    renderSpecialErrorResponse(__ssrSpecialError) {
+      return __buildAppPageSpecialErrorResponse({
+        clearRequestContext() {
+          setHeadersContext(null);
+          setNavigationContext(null);
+        },
+        renderFallbackPage(statusCode) {
+          return renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, {
+            matchedParams: params,
+          });
+        },
+        requestUrl: request.url,
+        specialError: __ssrSpecialError,
+      });
+    },
+    resolveSpecialError: __resolveAppPageSpecialError,
+  });
+  if (__htmlRender.response) return __htmlRender.response;
+  const htmlStream = __htmlRender.htmlStream;
 
   // If an RSC error was caught by the in-tree global ErrorBoundary during SSR,
   // the HTML output has double <html>/<body> (root layout + global-error.tsx).
@@ -10236,6 +10244,7 @@ import {
   createAppPageRscErrorTracker as __createAppPageRscErrorTracker,
   renderAppPageHtmlResponse as __renderAppPageHtmlResponse,
   renderAppPageHtmlStream as __renderAppPageHtmlStream,
+  renderAppPageHtmlStreamWithRecovery as __renderAppPageHtmlStreamWithRecovery,
   shouldRerenderAppPageWithGlobalError as __shouldRerenderAppPageWithGlobalError,
 } from "<ROOT>/packages/vinext/src/server/app-page-stream.js";
 import {
@@ -12548,41 +12557,42 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // __isrRscDataPromise resolves to rscData bytes used by the RSC write path above;
   // the HTML write path below uses its own separate key and does not need rscData.
 
-  // Delegate to SSR environment for HTML rendering
-  let htmlStream;
-  try {
-    const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
-    htmlStream = await __renderAppPageHtmlStream({
-      fontData,
-      navigationContext: _getNavigationContext(),
-      rscStream: __rscForResponse,
-      ssrHandler: ssrEntry,
-    });
-    // Shell render complete; Suspense boundaries stream asynchronously
-    if (process.env.NODE_ENV !== "production") __renderEnd = performance.now();
-  } catch (ssrErr) {
-    const __ssrSpecialError = __resolveAppPageSpecialError(ssrErr);
-    const specialResponse = __ssrSpecialError
-      ? await __buildAppPageSpecialErrorResponse({
-          clearRequestContext() {
-            setHeadersContext(null);
-            setNavigationContext(null);
-          },
-          renderFallbackPage(statusCode) {
-            return renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, {
-              matchedParams: params,
-            });
-          },
-          requestUrl: request.url,
-          specialError: __ssrSpecialError,
-        })
-      : null;
-    if (specialResponse) return specialResponse;
-    // Non-special error during SSR — render error.tsx if available
-    const errorBoundaryResp = await renderErrorBoundaryPage(route, ssrErr, isRscRequest, request, params);
-    if (errorBoundaryResp) return errorBoundaryResp;
-    throw ssrErr;
-  }
+  const __htmlRender = await __renderAppPageHtmlStreamWithRecovery({
+    onShellRendered() {
+      // Shell render complete; Suspense boundaries stream asynchronously.
+      if (process.env.NODE_ENV !== "production") __renderEnd = performance.now();
+    },
+    renderErrorBoundaryResponse(ssrErr) {
+      return renderErrorBoundaryPage(route, ssrErr, isRscRequest, request, params);
+    },
+    async renderHtmlStream() {
+      const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
+      return __renderAppPageHtmlStream({
+        fontData,
+        navigationContext: _getNavigationContext(),
+        rscStream: __rscForResponse,
+        ssrHandler: ssrEntry,
+      });
+    },
+    renderSpecialErrorResponse(__ssrSpecialError) {
+      return __buildAppPageSpecialErrorResponse({
+        clearRequestContext() {
+          setHeadersContext(null);
+          setNavigationContext(null);
+        },
+        renderFallbackPage(statusCode) {
+          return renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, {
+            matchedParams: params,
+          });
+        },
+        requestUrl: request.url,
+        specialError: __ssrSpecialError,
+      });
+    },
+    resolveSpecialError: __resolveAppPageSpecialError,
+  });
+  if (__htmlRender.response) return __htmlRender.response;
+  const htmlStream = __htmlRender.htmlStream;
 
   // If an RSC error was caught by the in-tree global ErrorBoundary during SSR,
   // the HTML output has double <html>/<body> (root layout + global-error.tsx).
@@ -12764,6 +12774,7 @@ import {
   createAppPageRscErrorTracker as __createAppPageRscErrorTracker,
   renderAppPageHtmlResponse as __renderAppPageHtmlResponse,
   renderAppPageHtmlStream as __renderAppPageHtmlStream,
+  renderAppPageHtmlStreamWithRecovery as __renderAppPageHtmlStreamWithRecovery,
   shouldRerenderAppPageWithGlobalError as __shouldRerenderAppPageWithGlobalError,
 } from "<ROOT>/packages/vinext/src/server/app-page-stream.js";
 import {
@@ -15429,41 +15440,42 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // __isrRscDataPromise resolves to rscData bytes used by the RSC write path above;
   // the HTML write path below uses its own separate key and does not need rscData.
 
-  // Delegate to SSR environment for HTML rendering
-  let htmlStream;
-  try {
-    const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
-    htmlStream = await __renderAppPageHtmlStream({
-      fontData,
-      navigationContext: _getNavigationContext(),
-      rscStream: __rscForResponse,
-      ssrHandler: ssrEntry,
-    });
-    // Shell render complete; Suspense boundaries stream asynchronously
-    if (process.env.NODE_ENV !== "production") __renderEnd = performance.now();
-  } catch (ssrErr) {
-    const __ssrSpecialError = __resolveAppPageSpecialError(ssrErr);
-    const specialResponse = __ssrSpecialError
-      ? await __buildAppPageSpecialErrorResponse({
-          clearRequestContext() {
-            setHeadersContext(null);
-            setNavigationContext(null);
-          },
-          renderFallbackPage(statusCode) {
-            return renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, {
-              matchedParams: params,
-            });
-          },
-          requestUrl: request.url,
-          specialError: __ssrSpecialError,
-        })
-      : null;
-    if (specialResponse) return specialResponse;
-    // Non-special error during SSR — render error.tsx if available
-    const errorBoundaryResp = await renderErrorBoundaryPage(route, ssrErr, isRscRequest, request, params);
-    if (errorBoundaryResp) return errorBoundaryResp;
-    throw ssrErr;
-  }
+  const __htmlRender = await __renderAppPageHtmlStreamWithRecovery({
+    onShellRendered() {
+      // Shell render complete; Suspense boundaries stream asynchronously.
+      if (process.env.NODE_ENV !== "production") __renderEnd = performance.now();
+    },
+    renderErrorBoundaryResponse(ssrErr) {
+      return renderErrorBoundaryPage(route, ssrErr, isRscRequest, request, params);
+    },
+    async renderHtmlStream() {
+      const ssrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
+      return __renderAppPageHtmlStream({
+        fontData,
+        navigationContext: _getNavigationContext(),
+        rscStream: __rscForResponse,
+        ssrHandler: ssrEntry,
+      });
+    },
+    renderSpecialErrorResponse(__ssrSpecialError) {
+      return __buildAppPageSpecialErrorResponse({
+        clearRequestContext() {
+          setHeadersContext(null);
+          setNavigationContext(null);
+        },
+        renderFallbackPage(statusCode) {
+          return renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, {
+            matchedParams: params,
+          });
+        },
+        requestUrl: request.url,
+        specialError: __ssrSpecialError,
+      });
+    },
+    resolveSpecialError: __resolveAppPageSpecialError,
+  });
+  if (__htmlRender.response) return __htmlRender.response;
+  const htmlStream = __htmlRender.htmlStream;
 
   // If an RSC error was caught by the in-tree global ErrorBoundary during SSR,
   // the HTML output has double <html>/<body> (root layout + global-error.tsx).

--- a/tests/app-page-stream.test.ts
+++ b/tests/app-page-stream.test.ts
@@ -4,6 +4,7 @@ import {
   createAppPageRscErrorTracker,
   renderAppPageHtmlResponse,
   renderAppPageHtmlStream,
+  renderAppPageHtmlStreamWithRecovery,
   shouldRerenderAppPageWithGlobalError,
 } from "../packages/vinext/src/server/app-page-stream.js";
 
@@ -90,6 +91,88 @@ describe("app page stream helpers", () => {
       "</font.woff2>; rel=preload; as=font; type=font/woff2; crossorigin",
     );
     await expect(response.text()).resolves.toBe("<html>page</html>");
+  });
+
+  it("returns the HTML stream and marks shell render completion when SSR succeeds", async () => {
+    const onShellRendered = vi.fn();
+
+    const result = await renderAppPageHtmlStreamWithRecovery({
+      onShellRendered,
+      async renderErrorBoundaryResponse() {
+        throw new Error("should not render an error boundary");
+      },
+      async renderHtmlStream() {
+        return createStream(["<html>ok</html>"]);
+      },
+      async renderSpecialErrorResponse() {
+        throw new Error("should not render a special response");
+      },
+      resolveSpecialError() {
+        return null;
+      },
+    });
+
+    expect(onShellRendered).toHaveBeenCalledTimes(1);
+    expect(result.response).toBeNull();
+    await expect(new Response(result.htmlStream).text()).resolves.toBe("<html>ok</html>");
+  });
+
+  it("turns special SSR failures into the provided response", async () => {
+    const ssrError = new Error("redirect");
+    const renderSpecialErrorResponse = vi.fn(async () => new Response("special", { status: 307 }));
+
+    const result = await renderAppPageHtmlStreamWithRecovery({
+      async renderErrorBoundaryResponse() {
+        throw new Error("should not render an error boundary");
+      },
+      async renderHtmlStream() {
+        throw ssrError;
+      },
+      renderSpecialErrorResponse,
+      resolveSpecialError(error) {
+        return error === ssrError
+          ? {
+              kind: "redirect",
+              location: "/target",
+              statusCode: 307,
+            }
+          : null;
+      },
+    });
+
+    expect(renderSpecialErrorResponse).toHaveBeenCalledWith({
+      kind: "redirect",
+      location: "/target",
+      statusCode: 307,
+    });
+    expect(result.htmlStream).toBeNull();
+    expect(result.response?.status).toBe(307);
+    await expect(result.response?.text()).resolves.toBe("special");
+  });
+
+  it("falls back to the error boundary response for non-special SSR failures", async () => {
+    const ssrError = new Error("boom");
+    const renderErrorBoundaryResponse = vi.fn(
+      async () => new Response("boundary", { status: 200 }),
+    );
+
+    const result = await renderAppPageHtmlStreamWithRecovery({
+      renderErrorBoundaryResponse,
+      async renderHtmlStream() {
+        throw ssrError;
+      },
+      async renderSpecialErrorResponse() {
+        throw new Error("should not render a special response");
+      },
+      resolveSpecialError() {
+        return null;
+      },
+    });
+
+    expect(renderErrorBoundaryResponse).toHaveBeenCalledWith(ssrError);
+    expect(result.htmlStream).toBeNull();
+    expect(result.response?.status).toBe(200);
+    await expect(result.response?.text()).resolves.toBe("boundary");
   });
 
   it("tracks non-navigation RSC errors while preserving the base onError callback", () => {

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -3713,8 +3713,11 @@ describe("generateRscEntry ISR code generation", () => {
 
   it("generated code handles SSR special errors without a legacy handleRenderError helper", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes);
-    expect(code).toContain("const __ssrSpecialError = __resolveAppPageSpecialError(ssrErr);");
-    expect(code).toContain("specialError: __ssrSpecialError");
+    expect(code).toContain(
+      "renderAppPageHtmlStreamWithRecovery as __renderAppPageHtmlStreamWithRecovery",
+    );
+    expect(code).toContain("const __htmlRender = await __renderAppPageHtmlStreamWithRecovery({");
+    expect(code).toContain("resolveSpecialError: __resolveAppPageSpecialError");
     expect(code).not.toContain("handleRenderError(ssrErr)");
   });
 
@@ -3723,6 +3726,9 @@ describe("generateRscEntry ISR code generation", () => {
     expect(code).toContain("createAppPageFontData as __createAppPageFontData");
     expect(code).toContain("renderAppPageHtmlResponse as __renderAppPageHtmlResponse");
     expect(code).toContain("renderAppPageHtmlStream as __renderAppPageHtmlStream");
+    expect(code).toContain(
+      "renderAppPageHtmlStreamWithRecovery as __renderAppPageHtmlStreamWithRecovery",
+    );
     expect(code).toContain(
       "shouldRerenderAppPageWithGlobalError as __shouldRerenderAppPageWithGlobalError",
     );


### PR DESCRIPTION
## Summary
- extract the App Router HTML SSR recovery flow into the typed `app-page-stream` runtime helper
- keep `app-rsc-entry.ts` focused on wiring while delegating HTML stream recovery, special-error handling, and boundary fallback selection to typed code
- add focused runtime coverage and refresh generated-entry assertions/snapshots for the new helper boundary

## Testing
- `vp check packages/vinext/src/server/app-page-stream.ts packages/vinext/src/entries/app-rsc-entry.ts tests/app-page-stream.test.ts tests/app-router.test.ts`
- `vp test run tests/app-page-stream.test.ts tests/app-page-boundary.test.ts tests/app-page-cache.test.ts tests/app-page-execution.test.ts tests/app-page-probe.test.ts tests/app-page-request.test.ts tests/app-page-response.test.ts tests/error-boundary.test.ts`
- `vp test run tests/app-page-stream.test.ts tests/nextjs-compat/global-error.test.ts`
- `vp test run tests/entry-templates.test.ts -u`
- `vp test run tests/app-router.test.ts -t "generated code handles SSR special errors without a legacy handleRenderError helper|generated code delegates page HTML stream plumbing to typed helpers|redirect\(\) inside Suspense boundary preserves digest in RSC payload|notFound\(\) inside Suspense boundary preserves digest for not-found UI|renders error boundary wrapper for routes with error.tsx"`
- `vp run vinext#build`

Written by Codex.