### PR TITLE
feat: seed memory cache from pre-rendered routes

### DIFF
--- a/packages/vinext/src/build/prerender.ts
+++ b/packages/vinext/src/build/prerender.ts
@@ -51,6 +51,8 @@ export type PrerenderRouteResult =
        * Omitted for non-dynamic routes where pattern === path.
        */
       path?: string;
+      /** Which router produced this route. Used by cache seeding. */
+      router: "app" | "pages";
     }
   | {
       route: string;
@@ -586,6 +588,7 @@ export async function prerenderPages({
             status: "rendered",
             outputFiles,
             revalidate,
+            router: "pages",
             ...(urlPath !== route.pattern ? { path: urlPath } : {}),
           };
         } catch (e) {
@@ -619,6 +622,7 @@ export async function prerenderPages({
             status: "rendered",
             outputFiles: ["404.html"],
             revalidate: false,
+            router: "pages",
           });
         }
       } catch {
@@ -627,7 +631,11 @@ export async function prerenderPages({
     }
 
     // ── Write vinext-prerender.json ───────────────────────────────────────────
-    if (!skipManifest) writePrerenderIndex(results, manifestDir);
+    if (!skipManifest)
+      writePrerenderIndex(results, manifestDir, {
+        buildId: config.buildId,
+        trailingSlash: config.trailingSlash,
+      });
 
     return { routes: results };
   } finally {
@@ -1045,6 +1053,7 @@ export async function prerenderApp({
           status: "rendered",
           outputFiles,
           revalidate,
+          router: "app",
           ...(urlPath !== routePattern ? { path: urlPath } : {}),
         };
       } catch (e) {
@@ -1090,6 +1099,7 @@ export async function prerenderApp({
           status: "rendered",
           outputFiles: ["404.html"],
           revalidate: false,
+          router: "app",
         });
       }
     } catch {
@@ -1097,7 +1107,11 @@ export async function prerenderApp({
     }
 
     // ── Write vinext-prerender.json ───────────────────────────────────────────
-    if (!skipManifest) writePrerenderIndex(results, manifestDir);
+    if (!skipManifest)
+      writePrerenderIndex(results, manifestDir, {
+        buildId: config.buildId,
+        trailingSlash: config.trailingSlash,
+      });
 
     return { routes: results };
   } finally {
@@ -1124,10 +1138,16 @@ export function getRscOutputPath(urlPath: string): string {
 /**
  * Write `vinext-prerender.json` to `outDir`.
  *
- * This is a minimal flat list of route results used during testing and as a
- * seed for future ISR cache population. Not consumed by the production server.
+ * Contains a flat list of route results used during testing and as a seed for
+ * ISR cache population at production startup. The `buildId` is included so
+ * the seeding function can construct matching cache keys.
  */
-export function writePrerenderIndex(routes: PrerenderRouteResult[], outDir: string): void {
+export function writePrerenderIndex(
+  routes: PrerenderRouteResult[],
+  outDir: string,
+  options?: { buildId?: string; trailingSlash?: boolean },
+): void {
+  const { buildId, trailingSlash } = options ?? {};
   // Produce a stripped-down version for the index (omit outputFiles detail)
   const indexRoutes = routes.map((r) => {
     if (r.status === "rendered") {
@@ -1135,6 +1155,7 @@ export function writePrerenderIndex(routes: PrerenderRouteResult[], outDir: stri
         route: r.route,
         status: r.status,
         revalidate: r.revalidate,
+        router: r.router,
         ...(r.path ? { path: r.path } : {}),
       };
     }
@@ -1144,7 +1165,11 @@ export function writePrerenderIndex(routes: PrerenderRouteResult[], outDir: stri
     return { route: r.route, status: r.status, error: r.error };
   });
 
-  const index = { routes: indexRoutes };
+  const index = {
+    ...(buildId ? { buildId } : {}),
+    ...(trailingSlash ? { trailingSlash } : {}),
+    routes: indexRoutes,
+  };
   fs.writeFileSync(
     path.join(outDir, "vinext-prerender.json"),
     JSON.stringify(index, null, 2),

--- a/packages/vinext/src/build/prerender.ts
+++ b/packages/vinext/src/build/prerender.ts
@@ -1167,7 +1167,7 @@ export function writePrerenderIndex(
 
   const index = {
     ...(buildId ? { buildId } : {}),
-    ...(trailingSlash ? { trailingSlash } : {}),
+    ...(typeof trailingSlash === "boolean" ? { trailingSlash } : {}),
     routes: indexRoutes,
   };
   fs.writeFileSync(

--- a/packages/vinext/src/build/run-prerender.ts
+++ b/packages/vinext/src/build/run-prerender.ts
@@ -281,7 +281,10 @@ export async function runPrerender(options: RunPrerenderOptions): Promise<Preren
 
   try {
     fs.mkdirSync(manifestDir, { recursive: true });
-    writePrerenderIndex(allRoutes, manifestDir);
+    writePrerenderIndex(allRoutes, manifestDir, {
+      buildId: config.buildId,
+      trailingSlash: config.trailingSlash,
+    });
   } finally {
     progress.finish(rendered, skipped, errors);
   }

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -50,6 +50,7 @@ import { manifestFileWithBase } from "../utils/manifest-paths.js";
 import { normalizePathnameForRouteMatchStrict } from "../routing/utils.js";
 import type { ExecutionContextLike } from "../shims/request-context.js";
 import { readPrerenderSecret } from "../build/server-manifest.js";
+import { seedMemoryCacheFromPrerender } from "./seed-cache.js";
 
 /** Convert a Node.js IncomingMessage into a ReadableStream for Web Request body. */
 function readNodeStream(req: IncomingMessage): ReadableStream<Uint8Array> {
@@ -768,6 +769,10 @@ async function startAppRouterServer(options: AppRouterServerOptions) {
   const rscMtime = fs.statSync(rscEntryPath).mtimeMs;
   const rscModule = await import(`${pathToFileURL(rscEntryPath).href}?t=${rscMtime}`);
   const rscHandler = resolveAppRouterHandler(rscModule.default);
+
+  // Seed the memory cache with pre-rendered routes so the first request to
+  // any pre-rendered page is a cache HIT instead of a full re-render.
+  await seedMemoryCacheFromPrerender(path.dirname(rscEntryPath));
 
   const server = createServer(async (req, res) => {
     const rawUrl = req.url ?? "/";

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -772,7 +772,12 @@ async function startAppRouterServer(options: AppRouterServerOptions) {
 
   // Seed the memory cache with pre-rendered routes so the first request to
   // any pre-rendered page is a cache HIT instead of a full re-render.
-  await seedMemoryCacheFromPrerender(path.dirname(rscEntryPath));
+  const seededRoutes = await seedMemoryCacheFromPrerender(path.dirname(rscEntryPath));
+  if (seededRoutes > 0) {
+    console.log(
+      `[vinext] Seeded ${seededRoutes} pre-rendered route${seededRoutes !== 1 ? "s" : ""} into memory cache`,
+    );
+  }
 
   const server = createServer(async (req, res) => {
     const rawUrl = req.url ?? "/";

--- a/packages/vinext/src/server/seed-cache.ts
+++ b/packages/vinext/src/server/seed-cache.ts
@@ -9,12 +9,30 @@
  * This is only useful for the MemoryCacheHandler (the default for Node.js
  * production). Persistent backends like KV already retain entries across
  * deploys and can be pre-populated via TPR or similar mechanisms.
+ *
+ * Consistency model:
+ * - The manifest is authoritative for which routes were pre-rendered and their
+ *   revalidation config. The HTML/RSC files on disk are the source of truth
+ *   for content. Both are produced by the same build and are immutable after
+ *   the build completes.
+ * - Cache keys include the buildId, so entries from a previous build are never
+ *   matched by a new server process (new build = new buildId = new keys).
+ * - Seeded entries are indistinguishable from entries created by the ISR
+ *   render path: same cache value shape, same revalidate duration tracking,
+ *   same cache key construction. The serving path does not know or care
+ *   whether an entry was seeded or rendered.
+ *
+ * Concurrency model:
+ * - This function runs at startup before the HTTP server begins accepting
+ *   requests, so there are no concurrent readers during seeding. All I/O is
+ *   synchronous (readFileSync) which is appropriate for a startup-only path
+ *   that runs once before the event loop serves traffic.
  */
 
 import fs from "node:fs";
 import path from "node:path";
-import { getCacheHandler, type CacheHandler, type CachedAppPageValue } from "../shims/cache.js";
-import { isrCacheKey } from "./isr-cache.js";
+import { getCacheHandler, type CachedAppPageValue } from "../shims/cache.js";
+import { isrCacheKey, setRevalidateDuration } from "./isr-cache.js";
 import { getOutputPath, getRscOutputPath } from "../build/prerender.js";
 
 // ─── Manifest types ───────────────────────────────────────────────────────────
@@ -42,72 +60,108 @@ interface PrerenderManifestRoute {
  * If the manifest doesn't exist (no prerender phase was run), this is a no-op.
  *
  * @param serverDir - Path to `dist/server/` (where vinext-prerender.json lives)
+ * @returns The number of routes seeded (0 if no manifest or no renderable routes).
  */
-export async function seedMemoryCacheFromPrerender(serverDir: string): Promise<void> {
+export async function seedMemoryCacheFromPrerender(serverDir: string): Promise<number> {
   const manifestPath = path.join(serverDir, "vinext-prerender.json");
-  if (!fs.existsSync(manifestPath)) return;
+  if (!fs.existsSync(manifestPath)) return 0;
 
   let manifest: PrerenderManifest;
   try {
     manifest = JSON.parse(fs.readFileSync(manifestPath, "utf-8"));
-  } catch {
-    return;
+  } catch (err) {
+    console.warn("[vinext] Failed to parse vinext-prerender.json, skipping cache seeding:", err);
+    return 0;
   }
 
   const { buildId, routes } = manifest;
-  if (!buildId || !Array.isArray(routes)) return;
+  if (!buildId || !Array.isArray(routes)) return 0;
 
   const trailingSlash = manifest.trailingSlash ?? false;
   const prerenderDir = path.join(serverDir, "prerendered-routes");
   const handler = getCacheHandler();
+  let seeded = 0;
 
   for (const route of routes) {
     if (route.status !== "rendered") continue;
     if (route.router !== "app") continue;
 
-    // Use concrete path for dynamic routes, route pattern for static
     const pathname = route.path ?? route.route;
-    const revalidateCtx =
-      typeof route.revalidate === "number" ? { revalidate: route.revalidate } : {};
+    const baseKey = isrCacheKey("app", pathname, buildId);
+    const revalidateSeconds = typeof route.revalidate === "number" ? route.revalidate : undefined;
 
-    await seedAppRoute(handler, prerenderDir, pathname, buildId, trailingSlash, revalidateCtx);
+    if (
+      await seedHtml(handler, prerenderDir, baseKey, pathname, trailingSlash, revalidateSeconds)
+    ) {
+      await seedRsc(handler, prerenderDir, baseKey, pathname, revalidateSeconds);
+      seeded++;
+    }
   }
+
+  return seeded;
 }
 
 // ─── Internals ────────────────────────────────────────────────────────────────
 
-async function seedAppRoute(
-  handler: CacheHandler,
+/**
+ * Build the CacheHandler context object from a revalidate value.
+ * `revalidate: undefined` (static routes) → empty context → no expiry.
+ */
+function revalidateCtx(seconds: number | undefined): Record<string, unknown> {
+  return seconds !== undefined ? { revalidate: seconds } : {};
+}
+
+/**
+ * Seed the HTML cache entry for a single route.
+ * Returns true if the file existed and was seeded.
+ */
+async function seedHtml(
+  handler: ReturnType<typeof getCacheHandler>,
   prerenderDir: string,
+  baseKey: string,
   pathname: string,
-  buildId: string,
   trailingSlash: boolean,
-  ctx: Record<string, unknown>,
-): Promise<void> {
-  const htmlRelPath = getOutputPath(pathname, trailingSlash);
-  const htmlFullPath = path.join(prerenderDir, htmlRelPath);
-  if (!fs.existsSync(htmlFullPath)) return;
+  revalidateSeconds: number | undefined,
+): Promise<boolean> {
+  const relPath = getOutputPath(pathname, trailingSlash);
+  const fullPath = path.join(prerenderDir, relPath);
+  if (!fs.existsSync(fullPath)) return false;
 
-  const html = fs.readFileSync(htmlFullPath, "utf-8");
-  const baseKey = isrCacheKey("app", pathname, buildId);
-
-  // Seed HTML entry
   const htmlValue: CachedAppPageValue = {
     kind: "APP_PAGE",
-    html,
+    html: fs.readFileSync(fullPath, "utf-8"),
     rscData: undefined,
     headers: undefined,
     postponed: undefined,
     status: undefined,
   };
-  await handler.set(baseKey + ":html", htmlValue, ctx);
 
-  // Seed RSC entry (if file exists)
-  const rscRelPath = getRscOutputPath(pathname);
-  const rscFullPath = path.join(prerenderDir, rscRelPath);
-  if (!fs.existsSync(rscFullPath)) return;
+  const key = baseKey + ":html";
+  await handler.set(key, htmlValue, revalidateCtx(revalidateSeconds));
 
-  const rscBuffer = fs.readFileSync(rscFullPath);
+  if (revalidateSeconds !== undefined) {
+    setRevalidateDuration(key, revalidateSeconds);
+  }
+
+  return true;
+}
+
+/**
+ * Seed the RSC cache entry for a single route.
+ * No-op if the .rsc file doesn't exist on disk.
+ */
+async function seedRsc(
+  handler: ReturnType<typeof getCacheHandler>,
+  prerenderDir: string,
+  baseKey: string,
+  pathname: string,
+  revalidateSeconds: number | undefined,
+): Promise<void> {
+  const relPath = getRscOutputPath(pathname);
+  const fullPath = path.join(prerenderDir, relPath);
+  if (!fs.existsSync(fullPath)) return;
+
+  const rscBuffer = fs.readFileSync(fullPath);
   const rscValue: CachedAppPageValue = {
     kind: "APP_PAGE",
     html: "",
@@ -119,5 +173,11 @@ async function seedAppRoute(
     postponed: undefined,
     status: undefined,
   };
-  await handler.set(baseKey + ":rsc", rscValue, ctx);
+
+  const key = baseKey + ":rsc";
+  await handler.set(key, rscValue, revalidateCtx(revalidateSeconds));
+
+  if (revalidateSeconds !== undefined) {
+    setRevalidateDuration(key, revalidateSeconds);
+  }
 }

--- a/packages/vinext/src/server/seed-cache.ts
+++ b/packages/vinext/src/server/seed-cache.ts
@@ -1,0 +1,123 @@
+/**
+ * Seed the memory cache from pre-rendered build output.
+ *
+ * Reads `vinext-prerender.json` and the corresponding HTML/RSC files from
+ * `dist/server/prerendered-routes/`, then populates the active CacheHandler
+ * so pre-rendered pages are served as cache HITs on the very first request
+ * instead of triggering a full re-render.
+ *
+ * This is only useful for the MemoryCacheHandler (the default for Node.js
+ * production). Persistent backends like KV already retain entries across
+ * deploys and can be pre-populated via TPR or similar mechanisms.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { getCacheHandler, type CacheHandler, type CachedAppPageValue } from "../shims/cache.js";
+import { isrCacheKey } from "./isr-cache.js";
+import { getOutputPath, getRscOutputPath } from "../build/prerender.js";
+
+// ─── Manifest types ───────────────────────────────────────────────────────────
+
+interface PrerenderManifest {
+  buildId: string;
+  trailingSlash?: boolean;
+  routes: PrerenderManifestRoute[];
+}
+
+interface PrerenderManifestRoute {
+  route: string;
+  status: string;
+  revalidate?: number | false;
+  path?: string;
+  router?: "app" | "pages";
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Read pre-rendered routes from disk and seed the active CacheHandler.
+ *
+ * Call this during production server startup, before any requests are served.
+ * If the manifest doesn't exist (no prerender phase was run), this is a no-op.
+ *
+ * @param serverDir - Path to `dist/server/` (where vinext-prerender.json lives)
+ */
+export async function seedMemoryCacheFromPrerender(serverDir: string): Promise<void> {
+  const manifestPath = path.join(serverDir, "vinext-prerender.json");
+  if (!fs.existsSync(manifestPath)) return;
+
+  let manifest: PrerenderManifest;
+  try {
+    manifest = JSON.parse(fs.readFileSync(manifestPath, "utf-8"));
+  } catch {
+    return;
+  }
+
+  const { buildId, routes } = manifest;
+  if (!buildId || !Array.isArray(routes)) return;
+
+  const trailingSlash = manifest.trailingSlash ?? false;
+  const prerenderDir = path.join(serverDir, "prerendered-routes");
+  const handler = getCacheHandler();
+
+  for (const route of routes) {
+    if (route.status !== "rendered") continue;
+    if (route.router !== "app") continue;
+
+    // Use concrete path for dynamic routes, route pattern for static
+    const pathname = route.path ?? route.route;
+    const revalidateCtx =
+      typeof route.revalidate === "number" ? { revalidate: route.revalidate } : {};
+
+    await seedAppRoute(handler, prerenderDir, pathname, buildId, trailingSlash, revalidateCtx);
+  }
+}
+
+// ─── Internals ────────────────────────────────────────────────────────────────
+
+async function seedAppRoute(
+  handler: CacheHandler,
+  prerenderDir: string,
+  pathname: string,
+  buildId: string,
+  trailingSlash: boolean,
+  ctx: Record<string, unknown>,
+): Promise<void> {
+  const htmlRelPath = getOutputPath(pathname, trailingSlash);
+  const htmlFullPath = path.join(prerenderDir, htmlRelPath);
+  if (!fs.existsSync(htmlFullPath)) return;
+
+  const html = fs.readFileSync(htmlFullPath, "utf-8");
+  const baseKey = isrCacheKey("app", pathname, buildId);
+
+  // Seed HTML entry
+  const htmlValue: CachedAppPageValue = {
+    kind: "APP_PAGE",
+    html,
+    rscData: undefined,
+    headers: undefined,
+    postponed: undefined,
+    status: undefined,
+  };
+  await handler.set(baseKey + ":html", htmlValue, ctx);
+
+  // Seed RSC entry (if file exists)
+  const rscRelPath = getRscOutputPath(pathname);
+  const rscFullPath = path.join(prerenderDir, rscRelPath);
+  if (!fs.existsSync(rscFullPath)) return;
+
+  const rscBuffer = fs.readFileSync(rscFullPath);
+  const rscValue: CachedAppPageValue = {
+    kind: "APP_PAGE",
+    html: "",
+    rscData: rscBuffer.buffer.slice(
+      rscBuffer.byteOffset,
+      rscBuffer.byteOffset + rscBuffer.byteLength,
+    ),
+    headers: undefined,
+    postponed: undefined,
+    status: undefined,
+  };
+  await handler.set(baseKey + ":rsc", rscValue, ctx);
+}

--- a/tests/seed-cache.test.ts
+++ b/tests/seed-cache.test.ts
@@ -1,0 +1,361 @@
+/**
+ * Tests for seeding the memory cache from pre-rendered routes.
+ *
+ * Verifies that seedMemoryCacheFromPrerender() reads vinext-prerender.json
+ * and the corresponding HTML/RSC files from disk, then populates the
+ * CacheHandler so pre-rendered pages are served as cache HITs on first request.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vite-plus/test";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import {
+  MemoryCacheHandler,
+  setCacheHandler,
+  getCacheHandler,
+} from "../packages/vinext/src/shims/cache.js";
+import { isrCacheKey } from "../packages/vinext/src/server/isr-cache.js";
+import { seedMemoryCacheFromPrerender } from "../packages/vinext/src/server/seed-cache.js";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function createTempServerDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "vinext-seed-cache-"));
+}
+
+/**
+ * Write a vinext-prerender.json manifest and corresponding pre-rendered files
+ * to a temporary directory structure matching the production build layout.
+ */
+function setupPrerenderFixture(
+  serverDir: string,
+  manifest: { buildId: string; trailingSlash?: boolean; routes: unknown[] },
+  files: Record<string, string>,
+): void {
+  // Write manifest to serverDir (dist/server/)
+  fs.writeFileSync(
+    path.join(serverDir, "vinext-prerender.json"),
+    JSON.stringify(manifest, null, 2),
+    "utf-8",
+  );
+
+  // Write pre-rendered files to prerendered-routes/
+  const prerenderDir = path.join(serverDir, "prerendered-routes");
+  for (const [filePath, content] of Object.entries(files)) {
+    const fullPath = path.join(prerenderDir, filePath);
+    fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+    fs.writeFileSync(fullPath, content, "utf-8");
+  }
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("seedMemoryCacheFromPrerender", () => {
+  let serverDir: string;
+  let handler: MemoryCacheHandler;
+
+  beforeEach(() => {
+    serverDir = createTempServerDir();
+    handler = new MemoryCacheHandler();
+    setCacheHandler(handler);
+  });
+
+  afterEach(() => {
+    fs.rmSync(serverDir, { recursive: true, force: true });
+  });
+
+  // ── App Router ISR routes ─────────────────────────────────────────────────
+
+  it("seeds App Router ISR routes with HTML and RSC entries", async () => {
+    const buildId = "test-build-001";
+    setupPrerenderFixture(
+      serverDir,
+      {
+        buildId,
+        routes: [{ route: "/about", status: "rendered", revalidate: 60, router: "app" }],
+      },
+      {
+        "about.html": "<html><body>About page</body></html>",
+        "about.rsc": "RSC payload for about",
+      },
+    );
+
+    await seedMemoryCacheFromPrerender(serverDir);
+
+    // HTML entry should be cached
+    const htmlKey = isrCacheKey("app", "/about", buildId) + ":html";
+    const htmlEntry = await getCacheHandler().get(htmlKey);
+    expect(htmlEntry).not.toBeNull();
+    const htmlValue = htmlEntry?.value;
+    expect(htmlValue).not.toBeNull();
+    expect(htmlValue?.kind).toBe("APP_PAGE");
+    if (htmlValue?.kind === "APP_PAGE") {
+      expect(htmlValue.html).toBe("<html><body>About page</body></html>");
+    }
+
+    // RSC entry should be cached
+    const rscKey = isrCacheKey("app", "/about", buildId) + ":rsc";
+    const rscEntry = await getCacheHandler().get(rscKey);
+    expect(rscEntry).not.toBeNull();
+    const rscValue = rscEntry?.value;
+    expect(rscValue).not.toBeNull();
+    expect(rscValue?.kind).toBe("APP_PAGE");
+    if (rscValue?.kind === "APP_PAGE") {
+      expect(rscValue.rscData).toBeDefined();
+      const rscText = new TextDecoder().decode(rscValue.rscData!);
+      expect(rscText).toBe("RSC payload for about");
+    }
+  });
+
+  it("seeds the index route correctly", async () => {
+    const buildId = "test-build-002";
+    setupPrerenderFixture(
+      serverDir,
+      {
+        buildId,
+        routes: [{ route: "/", status: "rendered", revalidate: 30, router: "app" }],
+      },
+      {
+        "index.html": "<html><body>Home</body></html>",
+        "index.rsc": "RSC payload for index",
+      },
+    );
+
+    await seedMemoryCacheFromPrerender(serverDir);
+
+    const htmlKey = isrCacheKey("app", "/", buildId) + ":html";
+    const htmlEntry = await getCacheHandler().get(htmlKey);
+    expect(htmlEntry).not.toBeNull();
+    expect(htmlEntry!.value!.kind).toBe("APP_PAGE");
+  });
+
+  it("seeds dynamic routes using their concrete path", async () => {
+    const buildId = "test-build-003";
+    setupPrerenderFixture(
+      serverDir,
+      {
+        buildId,
+        routes: [
+          {
+            route: "/blog/:slug",
+            status: "rendered",
+            revalidate: 120,
+            path: "/blog/hello-world",
+            router: "app",
+          },
+        ],
+      },
+      {
+        "blog/hello-world.html": "<html><body>Blog post</body></html>",
+        "blog/hello-world.rsc": "RSC blog payload",
+      },
+    );
+
+    await seedMemoryCacheFromPrerender(serverDir);
+
+    // Should use the concrete path, not the pattern
+    const htmlKey = isrCacheKey("app", "/blog/hello-world", buildId) + ":html";
+    const htmlEntry = await getCacheHandler().get(htmlKey);
+    expect(htmlEntry).not.toBeNull();
+    expect(htmlEntry!.value!.kind).toBe("APP_PAGE");
+  });
+
+  // ── Static routes (revalidate: false) ─────────────────────────────────────
+
+  it("seeds static routes (revalidate: false) with no expiry", async () => {
+    const buildId = "test-build-004";
+    setupPrerenderFixture(
+      serverDir,
+      {
+        buildId,
+        routes: [{ route: "/static", status: "rendered", revalidate: false, router: "app" }],
+      },
+      {
+        "static.html": "<html><body>Static page</body></html>",
+        "static.rsc": "RSC static payload",
+      },
+    );
+
+    await seedMemoryCacheFromPrerender(serverDir);
+
+    const htmlKey = isrCacheKey("app", "/static", buildId) + ":html";
+    const htmlEntry = await getCacheHandler().get(htmlKey);
+    expect(htmlEntry).not.toBeNull();
+    // No cacheState means fresh — should never expire
+    expect(htmlEntry!.cacheState).toBeUndefined();
+  });
+
+  // ── Skipped and errored routes ────────────────────────────────────────────
+
+  it("does not seed skipped routes", async () => {
+    const buildId = "test-build-005";
+    setupPrerenderFixture(
+      serverDir,
+      {
+        buildId,
+        routes: [
+          { route: "/ssr-page", status: "skipped", reason: "ssr" },
+          { route: "/about", status: "rendered", revalidate: 60, router: "app" },
+        ],
+      },
+      {
+        "about.html": "<html><body>About</body></html>",
+        "about.rsc": "RSC about",
+      },
+    );
+
+    await seedMemoryCacheFromPrerender(serverDir);
+
+    // Skipped route should not be in cache
+    const skippedKey = isrCacheKey("app", "/ssr-page", buildId) + ":html";
+    const skippedEntry = await getCacheHandler().get(skippedKey);
+    expect(skippedEntry).toBeNull();
+
+    // Rendered route should be cached
+    const aboutKey = isrCacheKey("app", "/about", buildId) + ":html";
+    const aboutEntry = await getCacheHandler().get(aboutKey);
+    expect(aboutEntry).not.toBeNull();
+  });
+
+  it("does not seed errored routes", async () => {
+    const buildId = "test-build-006";
+    setupPrerenderFixture(
+      serverDir,
+      {
+        buildId,
+        routes: [{ route: "/broken", status: "error", error: "render failed" }],
+      },
+      {},
+    );
+
+    await seedMemoryCacheFromPrerender(serverDir);
+
+    const brokenKey = isrCacheKey("app", "/broken", buildId) + ":html";
+    const entry = await getCacheHandler().get(brokenKey);
+    expect(entry).toBeNull();
+  });
+
+  // ── Multiple routes ───────────────────────────────────────────────────────
+
+  it("seeds multiple routes in one pass", async () => {
+    const buildId = "test-build-007";
+    setupPrerenderFixture(
+      serverDir,
+      {
+        buildId,
+        routes: [
+          { route: "/", status: "rendered", revalidate: 30, router: "app" },
+          { route: "/about", status: "rendered", revalidate: 60, router: "app" },
+          {
+            route: "/blog/:slug",
+            status: "rendered",
+            revalidate: 120,
+            path: "/blog/post-1",
+            router: "app",
+          },
+        ],
+      },
+      {
+        "index.html": "<html>Home</html>",
+        "index.rsc": "RSC home",
+        "about.html": "<html>About</html>",
+        "about.rsc": "RSC about",
+        "blog/post-1.html": "<html>Blog Post 1</html>",
+        "blog/post-1.rsc": "RSC blog 1",
+      },
+    );
+
+    await seedMemoryCacheFromPrerender(serverDir);
+
+    for (const pathname of ["/", "/about", "/blog/post-1"]) {
+      const htmlKey = isrCacheKey("app", pathname, buildId) + ":html";
+      const entry = await getCacheHandler().get(htmlKey);
+      expect(entry, `expected cache entry for ${pathname}`).not.toBeNull();
+    }
+  });
+
+  // ── Graceful degradation ──────────────────────────────────────────────────
+
+  it("is a no-op when vinext-prerender.json does not exist", async () => {
+    // serverDir has no manifest file
+    await seedMemoryCacheFromPrerender(serverDir);
+    // Should not throw — just silently skip
+  });
+
+  it("skips routes whose HTML files are missing from disk", async () => {
+    const buildId = "test-build-008";
+    setupPrerenderFixture(
+      serverDir,
+      {
+        buildId,
+        routes: [{ route: "/missing", status: "rendered", revalidate: 60, router: "app" }],
+      },
+      {
+        // Deliberately not writing any files for /missing
+      },
+    );
+
+    await seedMemoryCacheFromPrerender(serverDir);
+
+    const htmlKey = isrCacheKey("app", "/missing", buildId) + ":html";
+    const entry = await getCacheHandler().get(htmlKey);
+    expect(entry).toBeNull();
+  });
+
+  // ── trailingSlash ──────────────────────────────────────────────────────────
+
+  it("reads files from trailingSlash directory layout", async () => {
+    const buildId = "test-build-010";
+    setupPrerenderFixture(
+      serverDir,
+      {
+        buildId,
+        trailingSlash: true,
+        routes: [{ route: "/about", status: "rendered", revalidate: 60, router: "app" }],
+      },
+      {
+        // trailingSlash: true writes to about/index.html, not about.html
+        "about/index.html": "<html><body>About (trailing slash)</body></html>",
+        "about.rsc": "RSC about",
+      },
+    );
+
+    await seedMemoryCacheFromPrerender(serverDir);
+
+    const htmlKey = isrCacheKey("app", "/about", buildId) + ":html";
+    const htmlEntry = await getCacheHandler().get(htmlKey);
+    expect(htmlEntry).not.toBeNull();
+    if (htmlEntry?.value?.kind === "APP_PAGE") {
+      expect(htmlEntry.value.html).toBe("<html><body>About (trailing slash)</body></html>");
+    }
+  });
+
+  // ── RSC file optional ─────────────────────────────────────────────────────
+
+  it("seeds HTML even when RSC file is missing", async () => {
+    const buildId = "test-build-009";
+    setupPrerenderFixture(
+      serverDir,
+      {
+        buildId,
+        routes: [{ route: "/html-only", status: "rendered", revalidate: 60, router: "app" }],
+      },
+      {
+        "html-only.html": "<html><body>HTML only</body></html>",
+        // No .rsc file
+      },
+    );
+
+    await seedMemoryCacheFromPrerender(serverDir);
+
+    // HTML should be cached
+    const htmlKey = isrCacheKey("app", "/html-only", buildId) + ":html";
+    const htmlEntry = await getCacheHandler().get(htmlKey);
+    expect(htmlEntry).not.toBeNull();
+
+    // RSC should not be cached (no file to read)
+    const rscKey = isrCacheKey("app", "/html-only", buildId) + ":rsc";
+    const rscEntry = await getCacheHandler().get(rscKey);
+    expect(rscEntry).toBeNull();
+  });
+});

--- a/tests/seed-cache.test.ts
+++ b/tests/seed-cache.test.ts
@@ -14,7 +14,7 @@ import {
   setCacheHandler,
   getCacheHandler,
 } from "../packages/vinext/src/shims/cache.js";
-import { isrCacheKey } from "../packages/vinext/src/server/isr-cache.js";
+import { isrCacheKey, getRevalidateDuration } from "../packages/vinext/src/server/isr-cache.js";
 import { seedMemoryCacheFromPrerender } from "../packages/vinext/src/server/seed-cache.js";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -32,14 +32,12 @@ function setupPrerenderFixture(
   manifest: { buildId: string; trailingSlash?: boolean; routes: unknown[] },
   files: Record<string, string>,
 ): void {
-  // Write manifest to serverDir (dist/server/)
   fs.writeFileSync(
     path.join(serverDir, "vinext-prerender.json"),
     JSON.stringify(manifest, null, 2),
     "utf-8",
   );
 
-  // Write pre-rendered files to prerendered-routes/
   const prerenderDir = path.join(serverDir, "prerendered-routes");
   for (const [filePath, content] of Object.entries(files)) {
     const fullPath = path.join(prerenderDir, filePath);
@@ -48,16 +46,21 @@ function setupPrerenderFixture(
   }
 }
 
+/**
+ * Write raw content to vinext-prerender.json (for corrupt manifest tests).
+ */
+function writeRawManifest(serverDir: string, content: string): void {
+  fs.writeFileSync(path.join(serverDir, "vinext-prerender.json"), content, "utf-8");
+}
+
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
 describe("seedMemoryCacheFromPrerender", () => {
   let serverDir: string;
-  let handler: MemoryCacheHandler;
 
   beforeEach(() => {
     serverDir = createTempServerDir();
-    handler = new MemoryCacheHandler();
-    setCacheHandler(handler);
+    setCacheHandler(new MemoryCacheHandler());
   });
 
   afterEach(() => {
@@ -82,7 +85,6 @@ describe("seedMemoryCacheFromPrerender", () => {
 
     await seedMemoryCacheFromPrerender(serverDir);
 
-    // HTML entry should be cached
     const htmlKey = isrCacheKey("app", "/about", buildId) + ":html";
     const htmlEntry = await getCacheHandler().get(htmlKey);
     expect(htmlEntry).not.toBeNull();
@@ -93,7 +95,6 @@ describe("seedMemoryCacheFromPrerender", () => {
       expect(htmlValue.html).toBe("<html><body>About page</body></html>");
     }
 
-    // RSC entry should be cached
     const rscKey = isrCacheKey("app", "/about", buildId) + ":rsc";
     const rscEntry = await getCacheHandler().get(rscKey);
     expect(rscEntry).not.toBeNull();
@@ -126,7 +127,7 @@ describe("seedMemoryCacheFromPrerender", () => {
     const htmlKey = isrCacheKey("app", "/", buildId) + ":html";
     const htmlEntry = await getCacheHandler().get(htmlKey);
     expect(htmlEntry).not.toBeNull();
-    expect(htmlEntry!.value!.kind).toBe("APP_PAGE");
+    expect(htmlEntry?.value?.kind).toBe("APP_PAGE");
   });
 
   it("seeds dynamic routes using their concrete path", async () => {
@@ -153,11 +154,84 @@ describe("seedMemoryCacheFromPrerender", () => {
 
     await seedMemoryCacheFromPrerender(serverDir);
 
-    // Should use the concrete path, not the pattern
     const htmlKey = isrCacheKey("app", "/blog/hello-world", buildId) + ":html";
     const htmlEntry = await getCacheHandler().get(htmlKey);
     expect(htmlEntry).not.toBeNull();
-    expect(htmlEntry!.value!.kind).toBe("APP_PAGE");
+    expect(htmlEntry?.value?.kind).toBe("APP_PAGE");
+  });
+
+  // ── Return value ──────────────────────────────────────────────────────────
+
+  it("returns the number of seeded routes", async () => {
+    setupPrerenderFixture(
+      serverDir,
+      {
+        buildId: "count-test",
+        routes: [
+          { route: "/a", status: "rendered", revalidate: 60, router: "app" },
+          { route: "/b", status: "rendered", revalidate: 60, router: "app" },
+          { route: "/c", status: "skipped", reason: "ssr" },
+        ],
+      },
+      {
+        "a.html": "<html>A</html>",
+        "a.rsc": "RSC a",
+        "b.html": "<html>B</html>",
+        "b.rsc": "RSC b",
+      },
+    );
+
+    const count = await seedMemoryCacheFromPrerender(serverDir);
+    expect(count).toBe(2);
+  });
+
+  it("returns 0 when no manifest exists", async () => {
+    const count = await seedMemoryCacheFromPrerender(serverDir);
+    expect(count).toBe(0);
+  });
+
+  // ── Revalidate duration tracking ──────────────────────────────────────────
+
+  it("populates revalidate duration map for ISR routes", async () => {
+    const buildId = "reval-duration-test";
+    setupPrerenderFixture(
+      serverDir,
+      {
+        buildId,
+        routes: [{ route: "/isr", status: "rendered", revalidate: 45, router: "app" }],
+      },
+      {
+        "isr.html": "<html>ISR</html>",
+        "isr.rsc": "RSC isr",
+      },
+    );
+
+    await seedMemoryCacheFromPrerender(serverDir);
+
+    const baseKey = isrCacheKey("app", "/isr", buildId);
+    expect(getRevalidateDuration(baseKey + ":html")).toBe(45);
+    expect(getRevalidateDuration(baseKey + ":rsc")).toBe(45);
+  });
+
+  it("does not set revalidate duration for static routes", async () => {
+    const buildId = "static-duration-test";
+    setupPrerenderFixture(
+      serverDir,
+      {
+        buildId,
+        routes: [{ route: "/static", status: "rendered", revalidate: false, router: "app" }],
+      },
+      {
+        "static.html": "<html>Static</html>",
+        "static.rsc": "RSC static",
+      },
+    );
+
+    await seedMemoryCacheFromPrerender(serverDir);
+
+    const baseKey = isrCacheKey("app", "/static", buildId);
+    expect(getRevalidateDuration(baseKey + ":html")).toBeUndefined();
+    expect(getRevalidateDuration(baseKey + ":rsc")).toBeUndefined();
   });
 
   // ── Static routes (revalidate: false) ─────────────────────────────────────
@@ -181,8 +255,7 @@ describe("seedMemoryCacheFromPrerender", () => {
     const htmlKey = isrCacheKey("app", "/static", buildId) + ":html";
     const htmlEntry = await getCacheHandler().get(htmlKey);
     expect(htmlEntry).not.toBeNull();
-    // No cacheState means fresh — should never expire
-    expect(htmlEntry!.cacheState).toBeUndefined();
+    expect(htmlEntry?.cacheState).toBeUndefined();
   });
 
   // ── Skipped and errored routes ────────────────────────────────────────────
@@ -206,15 +279,11 @@ describe("seedMemoryCacheFromPrerender", () => {
 
     await seedMemoryCacheFromPrerender(serverDir);
 
-    // Skipped route should not be in cache
     const skippedKey = isrCacheKey("app", "/ssr-page", buildId) + ":html";
-    const skippedEntry = await getCacheHandler().get(skippedKey);
-    expect(skippedEntry).toBeNull();
+    expect(await getCacheHandler().get(skippedKey)).toBeNull();
 
-    // Rendered route should be cached
     const aboutKey = isrCacheKey("app", "/about", buildId) + ":html";
-    const aboutEntry = await getCacheHandler().get(aboutKey);
-    expect(aboutEntry).not.toBeNull();
+    expect(await getCacheHandler().get(aboutKey)).not.toBeNull();
   });
 
   it("does not seed errored routes", async () => {
@@ -228,11 +297,8 @@ describe("seedMemoryCacheFromPrerender", () => {
       {},
     );
 
-    await seedMemoryCacheFromPrerender(serverDir);
-
-    const brokenKey = isrCacheKey("app", "/broken", buildId) + ":html";
-    const entry = await getCacheHandler().get(brokenKey);
-    expect(entry).toBeNull();
+    const count = await seedMemoryCacheFromPrerender(serverDir);
+    expect(count).toBe(0);
   });
 
   // ── Multiple routes ───────────────────────────────────────────────────────
@@ -265,21 +331,23 @@ describe("seedMemoryCacheFromPrerender", () => {
       },
     );
 
-    await seedMemoryCacheFromPrerender(serverDir);
+    const count = await seedMemoryCacheFromPrerender(serverDir);
+    expect(count).toBe(3);
 
     for (const pathname of ["/", "/about", "/blog/post-1"]) {
       const htmlKey = isrCacheKey("app", pathname, buildId) + ":html";
-      const entry = await getCacheHandler().get(htmlKey);
-      expect(entry, `expected cache entry for ${pathname}`).not.toBeNull();
+      expect(
+        await getCacheHandler().get(htmlKey),
+        `expected cache entry for ${pathname}`,
+      ).not.toBeNull();
     }
   });
 
   // ── Graceful degradation ──────────────────────────────────────────────────
 
   it("is a no-op when vinext-prerender.json does not exist", async () => {
-    // serverDir has no manifest file
-    await seedMemoryCacheFromPrerender(serverDir);
-    // Should not throw — just silently skip
+    const count = await seedMemoryCacheFromPrerender(serverDir);
+    expect(count).toBe(0);
   });
 
   it("skips routes whose HTML files are missing from disk", async () => {
@@ -290,16 +358,25 @@ describe("seedMemoryCacheFromPrerender", () => {
         buildId,
         routes: [{ route: "/missing", status: "rendered", revalidate: 60, router: "app" }],
       },
-      {
-        // Deliberately not writing any files for /missing
-      },
+      {},
     );
 
-    await seedMemoryCacheFromPrerender(serverDir);
+    const count = await seedMemoryCacheFromPrerender(serverDir);
+    expect(count).toBe(0);
+  });
 
-    const htmlKey = isrCacheKey("app", "/missing", buildId) + ":html";
-    const entry = await getCacheHandler().get(htmlKey);
-    expect(entry).toBeNull();
+  it("returns 0 and warns on corrupt manifest JSON", async () => {
+    writeRawManifest(serverDir, "{ this is not valid json !!!");
+
+    const count = await seedMemoryCacheFromPrerender(serverDir);
+    expect(count).toBe(0);
+  });
+
+  it("returns 0 when manifest has no buildId", async () => {
+    writeRawManifest(serverDir, JSON.stringify({ routes: [] }));
+
+    const count = await seedMemoryCacheFromPrerender(serverDir);
+    expect(count).toBe(0);
   });
 
   // ── trailingSlash ──────────────────────────────────────────────────────────
@@ -314,7 +391,6 @@ describe("seedMemoryCacheFromPrerender", () => {
         routes: [{ route: "/about", status: "rendered", revalidate: 60, router: "app" }],
       },
       {
-        // trailingSlash: true writes to about/index.html, not about.html
         "about/index.html": "<html><body>About (trailing slash)</body></html>",
         "about.rsc": "RSC about",
       },
@@ -342,20 +418,51 @@ describe("seedMemoryCacheFromPrerender", () => {
       },
       {
         "html-only.html": "<html><body>HTML only</body></html>",
-        // No .rsc file
       },
     );
 
-    await seedMemoryCacheFromPrerender(serverDir);
+    const count = await seedMemoryCacheFromPrerender(serverDir);
+    expect(count).toBe(1);
 
-    // HTML should be cached
     const htmlKey = isrCacheKey("app", "/html-only", buildId) + ":html";
-    const htmlEntry = await getCacheHandler().get(htmlKey);
-    expect(htmlEntry).not.toBeNull();
+    expect(await getCacheHandler().get(htmlKey)).not.toBeNull();
 
-    // RSC should not be cached (no file to read)
     const rscKey = isrCacheKey("app", "/html-only", buildId) + ":rsc";
-    const rscEntry = await getCacheHandler().get(rscKey);
-    expect(rscEntry).toBeNull();
+    expect(await getCacheHandler().get(rscKey)).toBeNull();
+  });
+
+  // ── Long pathnames (FNV hash path) ────────────────────────────────────────
+
+  it("seeds routes with very long pathnames that hit the hash path", async () => {
+    const buildId = "hash-test";
+    const longSlug = "a".repeat(200);
+    const longPath = `/blog/${longSlug}`;
+    setupPrerenderFixture(
+      serverDir,
+      {
+        buildId,
+        routes: [
+          {
+            route: "/blog/:slug",
+            status: "rendered",
+            revalidate: 60,
+            path: longPath,
+            router: "app",
+          },
+        ],
+      },
+      {
+        [`blog/${longSlug}.html`]: "<html>Long path</html>",
+        [`blog/${longSlug}.rsc`]: "RSC long",
+      },
+    );
+
+    const count = await seedMemoryCacheFromPrerender(serverDir);
+    expect(count).toBe(1);
+
+    // Verify the hashed key matches what isrCacheKey produces
+    const htmlKey = isrCacheKey("app", longPath, buildId) + ":html";
+    expect(htmlKey).toContain("__hash:");
+    expect(await getCacheHandler().get(htmlKey)).not.toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

- Reads `vinext-prerender.json` at production server startup and populates the `MemoryCacheHandler` with pre-rendered HTML/RSC files from `dist/server/prerendered-routes/`
- First request to any pre-rendered page is now a cache HIT instead of a full re-render
- Adds `buildId`, `router`, and `trailingSlash` to the prerender manifest so the seeding function can construct matching cache keys and locate files correctly

## Changes

| File | Change |
|------|--------|
| `src/server/seed-cache.ts` | New `seedMemoryCacheFromPrerender()` function |
| `src/build/prerender.ts` | Add `router` to `PrerenderRouteResult`, add `buildId`/`trailingSlash` to manifest |
| `src/build/run-prerender.ts` | Pass `buildId`/`trailingSlash` to `writePrerenderIndex` |
| `src/server/prod-server.ts` | Call seeding at App Router production server startup |
| `tests/seed-cache.test.ts` | 11 unit tests |

## Scope

App Router only for now. Pages Router seeding requires the prerender phase to also write `pageData` JSON files (not currently done), so it's left for a follow-up.

Closes #561

## Test plan

- [x] 11 unit tests covering: ISR routes, static routes, dynamic routes, index route, trailingSlash layout, skipped/errored routes, missing manifest, missing HTML files, missing RSC files, multiple routes
- [x] Existing prerender tests (46) and ISR cache tests (42) pass unchanged
- [x] Type-aware lint clean