### PR TITLE
refactor: extract Pages page data and ISR runtime

### DIFF
--- a/packages/vinext/src/entries/pages-server-entry.ts
+++ b/packages/vinext/src/entries/pages-server-entry.ts
@@ -36,6 +36,9 @@ const _pagesI18nPath = fileURLToPath(new URL("../server/pages-i18n.js", import.m
 const _pagesPageResponsePath = fileURLToPath(
   new URL("../server/pages-page-response.js", import.meta.url),
 ).replace(/\\/g, "/");
+const _pagesPageDataPath = fileURLToPath(
+  new URL("../server/pages-page-data.js", import.meta.url),
+).replace(/\\/g, "/");
 
 /**
  * Generate the virtual SSR server entry module.
@@ -284,6 +287,7 @@ import { runWithExecutionContext as _runWithExecutionContext, getRequestExecutio
 import { buildRouteTrie as _buildRouteTrie, trieMatch as _trieMatch } from ${JSON.stringify(_routeTriePath)};
 import { reportRequestError as _reportRequestError } from "vinext/instrumentation";
 import { resolvePagesI18nRequest } from ${JSON.stringify(_pagesI18nPath)};
+import { resolvePagesPageData as __resolvePagesPageData } from ${JSON.stringify(_pagesPageDataPath)};
 import { renderPagesPageResponse as __renderPagesPageResponse } from ${JSON.stringify(_pagesPageResponsePath)};
 ${instrumentationImportCode}
 ${middlewareImportCode}
@@ -741,19 +745,20 @@ async function _renderPage(request, url, manifest) {
       { status: 404, headers: { "Content-Type": "text/html" } });
   }
 
-  const { route, params } = match;
-  const __uCtx = _createUnifiedCtx({
-    executionContext: _getRequestExecutionContext(),
-  });
-  return _runWithUnifiedCtx(__uCtx, async () => {
-    ensureFetchPatch();
-    try {
-    if (typeof setSSRContext === "function") {
-      setSSRContext({
-        pathname: patternToNextFormat(route.pattern),
-        query: { ...params, ...parseQuery(routeUrl) },
-        asPath: routeUrl,
-        locale: locale,
+	  const { route, params } = match;
+	  const __uCtx = _createUnifiedCtx({
+	    executionContext: _getRequestExecutionContext(),
+	  });
+	  return _runWithUnifiedCtx(__uCtx, async () => {
+	    ensureFetchPatch();
+	    try {
+	    const routePattern = patternToNextFormat(route.pattern);
+	    if (typeof setSSRContext === "function") {
+	      setSSRContext({
+	        pathname: routePattern,
+	        query: { ...params, ...parseQuery(routeUrl) },
+	        asPath: routeUrl,
+	        locale: locale,
         locales: i18nConfig ? i18nConfig.locales : undefined,
         defaultLocale: currentDefaultLocale,
         domainLocales: domainLocales,
@@ -772,210 +777,96 @@ async function _renderPage(request, url, manifest) {
 
     const pageModule = route.module;
     const PageComponent = pageModule.default;
-    if (!PageComponent) {
-      return new Response("Page has no default export", { status: 500 });
-    }
-
-    // Handle getStaticPaths for dynamic routes
-    if (typeof pageModule.getStaticPaths === "function" && route.isDynamic) {
-      const pathsResult = await pageModule.getStaticPaths({
-        locales: i18nConfig ? i18nConfig.locales : [],
-        defaultLocale: currentDefaultLocale || "",
-      });
-      const fallback = pathsResult && pathsResult.fallback !== undefined ? pathsResult.fallback : false;
-
-      if (fallback === false) {
-        const paths = pathsResult && pathsResult.paths ? pathsResult.paths : [];
-        const isValidPath = paths.some(function(p) {
-          return Object.entries(p.params).every(function(entry) {
-            var key = entry[0], val = entry[1];
-            var actual = params[key];
-            if (Array.isArray(val)) {
-              return Array.isArray(actual) && val.join("/") === actual.join("/");
-            }
-            return String(val) === String(actual);
-          });
-        });
-        if (!isValidPath) {
-          return new Response("<!DOCTYPE html><html><body><h1>404 - Page not found</h1></body></html>",
-            { status: 404, headers: { "Content-Type": "text/html" } });
-        }
-      }
-    }
-
-    let pageProps = {};
-    var gsspRes = null;
-    if (typeof pageModule.getServerSideProps === "function") {
-      const { req, res, responsePromise } = createReqRes(request, routeUrl, parseQuery(routeUrl), undefined);
-      const ctx = {
-        params, req, res,
-        query: parseQuery(routeUrl),
-        resolvedUrl: routeUrl,
-        locale: locale,
-        locales: i18nConfig ? i18nConfig.locales : undefined,
-        defaultLocale: currentDefaultLocale,
-      };
-      const result = await pageModule.getServerSideProps(ctx);
-      // If gSSP called res.end() directly (short-circuit), return that response.
-      if (res.headersSent) {
-        return await responsePromise;
-      }
-      if (result && result.props) pageProps = result.props;
-      if (result && result.redirect) {
-        var gsspStatus = result.redirect.statusCode != null ? result.redirect.statusCode : (result.redirect.permanent ? 308 : 307);
-        return new Response(null, { status: gsspStatus, headers: { Location: sanitizeDestinationLocal(result.redirect.destination) } });
-      }
-      if (result && result.notFound) {
-        return new Response("404", { status: 404 });
-      }
-      // Preserve the res object so headers/status/cookies set by gSSP
-      // can be merged into the final HTML response.
-      gsspRes = res;
-    }
-    // Build font Link header early so it's available for ISR cached responses too.
-    // Font preloads are module-level state populated at import time and persist across requests.
-    var _fontLinkHeader = "";
-    var _allFp = [];
+	    if (!PageComponent) {
+	      return new Response("Page has no default export", { status: 500 });
+	    }
+	    // Build font Link header early so it's available for ISR cached responses too.
+	    // Font preloads are module-level state populated at import time and persist across requests.
+	    var _fontLinkHeader = "";
+	    var _allFp = [];
     try {
       var _fpGoogle = typeof _getSSRFontPreloadsGoogle === "function" ? _getSSRFontPreloadsGoogle() : [];
       var _fpLocal = typeof _getSSRFontPreloadsLocal === "function" ? _getSSRFontPreloadsLocal() : [];
       _allFp = _fpGoogle.concat(_fpLocal);
-      if (_allFp.length > 0) {
-        _fontLinkHeader = _allFp.map(function(p) { return "<" + p.href + ">; rel=preload; as=font; type=" + p.type + "; crossorigin"; }).join(", ");
-      }
-    } catch (e) { /* font preloads not available */ }
+	      if (_allFp.length > 0) {
+	        _fontLinkHeader = _allFp.map(function(p) { return "<" + p.href + ">; rel=preload; as=font; type=" + p.type + "; crossorigin"; }).join(", ");
+	      }
+	    } catch (e) { /* font preloads not available */ }
+	    const query = parseQuery(routeUrl);
+	    const pageDataResult = await __resolvePagesPageData({
+	      applyRequestContexts() {
+	        if (typeof setSSRContext === "function") {
+	          setSSRContext({
+	            pathname: routePattern,
+	            query: { ...params, ...query },
+	            asPath: routeUrl,
+	            locale: locale,
+	            locales: i18nConfig ? i18nConfig.locales : undefined,
+	            defaultLocale: currentDefaultLocale,
+	            domainLocales: domainLocales,
+	          });
+	        }
+	        if (i18nConfig) {
+	          setI18nContext({
+	            locale: locale,
+	            locales: i18nConfig.locales,
+	            defaultLocale: currentDefaultLocale,
+	            domainLocales: domainLocales,
+	            hostname: new URL(request.url).hostname,
+	          });
+	        }
+	      },
+	      buildId,
+	      createGsspReqRes() {
+	        return createReqRes(request, routeUrl, query, undefined);
+	      },
+	      createPageElement(currentPageProps) {
+	        var currentElement = AppComponent
+	          ? React.createElement(AppComponent, { Component: PageComponent, pageProps: currentPageProps })
+	          : React.createElement(PageComponent, currentPageProps);
+	        return wrapWithRouterContext(currentElement);
+	      },
+	      fontLinkHeader: _fontLinkHeader,
+	      i18n: {
+	        locale: locale,
+	        locales: i18nConfig ? i18nConfig.locales : undefined,
+	        defaultLocale: currentDefaultLocale,
+	        domainLocales: domainLocales,
+	      },
+	      isrCacheKey,
+	      isrGet,
+	      isrSet,
+	      pageModule,
+	      params,
+	      query,
+	      renderIsrPassToStringAsync,
+	      route: {
+	        isDynamic: route.isDynamic,
+	      },
+	      routePattern,
+	      routeUrl,
+	      runInFreshUnifiedContext(callback) {
+	        var revalCtx = _createUnifiedCtx({
+	          executionContext: _getRequestExecutionContext(),
+	        });
+	        return _runWithUnifiedCtx(revalCtx, async () => {
+	          ensureFetchPatch();
+	          return callback();
+	        });
+	      },
+	      safeJsonStringify,
+	      sanitizeDestination: sanitizeDestinationLocal,
+	      triggerBackgroundRegeneration,
+	    });
+	    if (pageDataResult.kind === "response") {
+	      return pageDataResult.response;
+	    }
+	    let pageProps = pageDataResult.pageProps;
+	    var gsspRes = pageDataResult.gsspRes;
+	    let isrRevalidateSeconds = pageDataResult.isrRevalidateSeconds;
 
-    let isrRevalidateSeconds = null;
-    if (typeof pageModule.getStaticProps === "function") {
-      const pathname = routeUrl.split("?")[0];
-      const cacheKey = isrCacheKey("pages", pathname);
-      const cached = await isrGet(cacheKey);
-
-      if (cached && !cached.isStale && cached.value.value && cached.value.value.kind === "PAGES") {
-        var _hitHeaders = {
-          "Content-Type": "text/html", "X-Vinext-Cache": "HIT",
-          "Cache-Control": "s-maxage=" + (cached.value.value.revalidate || 60) + ", stale-while-revalidate",
-        };
-        if (_fontLinkHeader) _hitHeaders["Link"] = _fontLinkHeader;
-        return new Response(cached.value.value.html, { status: 200, headers: _hitHeaders });
-      }
-
-      if (cached && cached.isStale && cached.value.value && cached.value.value.kind === "PAGES") {
-        triggerBackgroundRegeneration(cacheKey, async function() {
-          var revalCtx = _createUnifiedCtx({
-            executionContext: _getRequestExecutionContext(),
-          });
-          return _runWithUnifiedCtx(revalCtx, async () => {
-            ensureFetchPatch();
-              var freshResult = await pageModule.getStaticProps({
-                params: params,
-                locale: locale,
-                locales: i18nConfig ? i18nConfig.locales : undefined,
-                defaultLocale: currentDefaultLocale,
-              });
-              if (freshResult && freshResult.props && typeof freshResult.revalidate === "number" && freshResult.revalidate > 0) {
-                var _fp = freshResult.props;
-                if (typeof setSSRContext === "function") {
-                  setSSRContext({
-                    pathname: patternToNextFormat(route.pattern),
-                    query: { ...params, ...parseQuery(routeUrl) },
-                    asPath: routeUrl,
-                    locale: locale,
-                    locales: i18nConfig ? i18nConfig.locales : undefined,
-                    defaultLocale: currentDefaultLocale,
-                    domainLocales: domainLocales,
-                  });
-                }
-                if (i18nConfig) {
-                  setI18nContext({
-                    locale: locale,
-                    locales: i18nConfig.locales,
-                    defaultLocale: currentDefaultLocale,
-                    domainLocales: domainLocales,
-                    hostname: new URL(request.url).hostname,
-                  });
-                }
-                // Re-render the page with fresh props inside fresh render sub-scopes
-                // so head/cache state cannot leak across passes.
-                var _el = AppComponent
-                  ? React.createElement(AppComponent, { Component: PageComponent, pageProps: _fp })
-                  : React.createElement(PageComponent, _fp);
-                _el = wrapWithRouterContext(_el);
-                var _freshBody = await renderIsrPassToStringAsync(_el);
-                // Rebuild __NEXT_DATA__ with fresh props
-                var _regenPayload = {
-                  props: { pageProps: _fp }, page: patternToNextFormat(route.pattern),
-                  query: params, buildId: buildId, isFallback: false,
-                };
-                if (i18nConfig) {
-                  _regenPayload.locale = locale;
-                  _regenPayload.locales = i18nConfig.locales;
-                  _regenPayload.defaultLocale = currentDefaultLocale;
-                  _regenPayload.domainLocales = domainLocales;
-                }
-                var _lGlobals = i18nConfig
-                  ? ";window.__VINEXT_LOCALE__=" + safeJsonStringify(locale) +
-                    ";window.__VINEXT_LOCALES__=" + safeJsonStringify(i18nConfig.locales) +
-                    ";window.__VINEXT_DEFAULT_LOCALE__=" + safeJsonStringify(currentDefaultLocale)
-                  : "";
-                var _freshNDS = "<script>window.__NEXT_DATA__ = " + safeJsonStringify(_regenPayload) + _lGlobals + "</script>";
-                // Reconstruct ISR HTML preserving the document shell from the
-                // cached entry (head, fonts, assets, custom _document markup).
-                var _cachedStr = cached.value.value.html;
-                var _btag = '<div id="__next">';
-                var _bstart = _cachedStr.indexOf(_btag);
-                var _bodyStart = _bstart >= 0 ? _bstart + _btag.length : -1;
-                // Locate __NEXT_DATA__ script to split body from suffix
-                var _ndMarker = '<script>window.__NEXT_DATA__';
-                var _ndStart = _cachedStr.indexOf(_ndMarker);
-                var _freshHtml;
-                if (_bodyStart >= 0 && _ndStart >= 0) {
-                  // Region between body start and __NEXT_DATA__ contains:
-                  // BODY_HTML + </div> + optional gap (custom _document content)
-                  var _region = _cachedStr.slice(_bodyStart, _ndStart);
-                  var _lastClose = _region.lastIndexOf('</div>');
-                  var _gap = _lastClose >= 0 ? _region.slice(_lastClose + 6) : '';
-                  // Tail: everything after the old __NEXT_DATA__ </script>
-                  var _ndEnd = _cachedStr.indexOf('</script>', _ndStart) + 9;
-                  var _tail = _cachedStr.slice(_ndEnd);
-                  _freshHtml = _cachedStr.slice(0, _bodyStart) + _freshBody + '</div>' + _gap + _freshNDS + _tail;
-                } else {
-                  _freshHtml = '<!DOCTYPE html>\\n<html>\\n<head>\\n</head>\\n<body>\\n  <div id="__next">' + _freshBody + '</div>\\n  ' + _freshNDS + '\\n</body>\\n</html>';
-                }
-                await isrSet(cacheKey, { kind: "PAGES", html: _freshHtml, pageData: _fp, headers: undefined, status: undefined }, freshResult.revalidate);
-              }
-            });
-        });
-        var _staleHeaders = {
-          "Content-Type": "text/html", "X-Vinext-Cache": "STALE",
-          "Cache-Control": "s-maxage=0, stale-while-revalidate",
-        };
-        if (_fontLinkHeader) _staleHeaders["Link"] = _fontLinkHeader;
-        return new Response(cached.value.value.html, { status: 200, headers: _staleHeaders });
-      }
-
-      const ctx = {
-        params,
-        locale: locale,
-        locales: i18nConfig ? i18nConfig.locales : undefined,
-        defaultLocale: currentDefaultLocale,
-      };
-      const result = await pageModule.getStaticProps(ctx);
-      if (result && result.props) pageProps = result.props;
-      if (result && result.redirect) {
-        var gspStatus = result.redirect.statusCode != null ? result.redirect.statusCode : (result.redirect.permanent ? 308 : 307);
-        return new Response(null, { status: gspStatus, headers: { Location: sanitizeDestinationLocal(result.redirect.destination) } });
-      }
-      if (result && result.notFound) {
-        return new Response("404", { status: 404 });
-      }
-      if (typeof result.revalidate === "number" && result.revalidate > 0) {
-        isrRevalidateSeconds = result.revalidate;
-      }
-    }
-
-    const pageModuleIds = route.filePath ? [route.filePath] : [];
-    const assetTags = collectAssetTags(manifest, pageModuleIds);
+	    const pageModuleIds = route.filePath ? [route.filePath] : [];
+	    const assetTags = collectAssetTags(manifest, pageModuleIds);
 
     return __renderPagesPageResponse({
       assetTags,
@@ -1013,8 +904,8 @@ async function _renderPage(request, url, manifest) {
           return [];
         }
       },
-      getSSRHeadHTML: typeof getSSRHeadHTML === "function" ? getSSRHeadHTML : undefined,
-      gsspRes,
+	      getSSRHeadHTML: typeof getSSRHeadHTML === "function" ? getSSRHeadHTML : undefined,
+	      gsspRes,
       isrCacheKey,
       isrRevalidateSeconds,
       isrSet,
@@ -1034,7 +925,7 @@ async function _renderPage(request, url, manifest) {
         return renderToReadableStream(element);
       },
       resetSSRHead: typeof resetSSRHead === "function" ? resetSSRHead : undefined,
-      routePattern: patternToNextFormat(route.pattern),
+	      routePattern,
       routeUrl,
       safeJsonStringify,
     });

--- a/packages/vinext/src/server/pages-page-data.ts
+++ b/packages/vinext/src/server/pages-page-data.ts
@@ -1,0 +1,396 @@
+import type { ReactNode } from "react";
+import type { Route } from "../routing/pages-router.js";
+import type { CachedPagesValue } from "../shims/cache.js";
+import { buildPagesCacheValue, type ISRCacheEntry } from "./isr-cache.js";
+import {
+  buildPagesNextDataScript,
+  type PagesGsspResponse,
+  type PagesI18nRenderContext,
+} from "./pages-page-response.js";
+
+interface PagesRedirectResult {
+  destination: string;
+  permanent?: boolean;
+  statusCode?: number;
+}
+
+interface PagesStaticPathsEntry {
+  params: Record<string, unknown>;
+}
+
+interface PagesStaticPathsResult {
+  fallback?: boolean | "blocking";
+  paths?: PagesStaticPathsEntry[];
+}
+
+interface PagesPagePropsResult {
+  props?: Record<string, unknown>;
+  redirect?: PagesRedirectResult;
+  notFound?: boolean;
+  revalidate?: number;
+}
+
+export interface PagesMutableGsspResponse extends PagesGsspResponse {
+  headersSent: boolean;
+}
+
+export interface PagesGsspContextResponse {
+  req: unknown;
+  res: PagesMutableGsspResponse;
+  responsePromise: Promise<Response>;
+}
+
+export interface PagesPageModule {
+  default?: unknown;
+  getStaticPaths?: (context: {
+    locales: string[];
+    defaultLocale: string;
+  }) => Promise<PagesStaticPathsResult> | PagesStaticPathsResult;
+  getServerSideProps?: (context: {
+    params: Record<string, unknown>;
+    req: unknown;
+    res: PagesMutableGsspResponse;
+    query: Record<string, unknown>;
+    resolvedUrl: string;
+    locale?: string;
+    locales?: string[];
+    defaultLocale?: string;
+  }) => Promise<PagesPagePropsResult> | PagesPagePropsResult;
+  getStaticProps?: (context: {
+    params: Record<string, unknown>;
+    locale?: string;
+    locales?: string[];
+    defaultLocale?: string;
+  }) => Promise<PagesPagePropsResult> | PagesPagePropsResult;
+}
+
+export interface RenderPagesIsrHtmlOptions {
+  buildId: string | null;
+  cachedHtml: string;
+  createPageElement: (pageProps: Record<string, unknown>) => ReactNode;
+  i18n: PagesI18nRenderContext;
+  pageProps: Record<string, unknown>;
+  params: Record<string, unknown>;
+  renderIsrPassToStringAsync: (element: ReactNode) => Promise<string>;
+  routePattern: string;
+  safeJsonStringify: (value: unknown) => string;
+}
+
+export interface ResolvePagesPageDataOptions {
+  applyRequestContexts: () => void;
+  buildId: string | null;
+  createGsspReqRes: () => PagesGsspContextResponse;
+  createPageElement: (pageProps: Record<string, unknown>) => ReactNode;
+  fontLinkHeader: string;
+  i18n: PagesI18nRenderContext;
+  isrCacheKey: (router: string, pathname: string) => string;
+  isrGet: (key: string) => Promise<ISRCacheEntry | null>;
+  isrSet: (
+    key: string,
+    data: CachedPagesValue,
+    revalidateSeconds: number,
+    tags?: string[],
+  ) => Promise<void>;
+  pageModule: PagesPageModule;
+  params: Record<string, unknown>;
+  query: Record<string, unknown>;
+  route: Pick<Route, "isDynamic">;
+  routePattern: string;
+  routeUrl: string;
+  runInFreshUnifiedContext: <T>(callback: () => Promise<T>) => Promise<T>;
+  safeJsonStringify: (value: unknown) => string;
+  sanitizeDestination: (destination: string) => string;
+  triggerBackgroundRegeneration: (key: string, renderFn: () => Promise<void>) => void;
+  renderIsrPassToStringAsync: (element: ReactNode) => Promise<string>;
+}
+
+export interface ResolvePagesPageDataRenderResult {
+  kind: "render";
+  gsspRes: PagesGsspResponse | null;
+  isrRevalidateSeconds: number | null;
+  pageProps: Record<string, unknown>;
+}
+
+export interface ResolvePagesPageDataResponseResult {
+  kind: "response";
+  response: Response;
+}
+
+export type ResolvePagesPageDataResult =
+  | ResolvePagesPageDataRenderResult
+  | ResolvePagesPageDataResponseResult;
+
+function buildPagesNotFoundResponse(): Response {
+  return new Response("<!DOCTYPE html><html><body><h1>404 - Page not found</h1></body></html>", {
+    status: 404,
+    headers: { "Content-Type": "text/html" },
+  });
+}
+
+function buildPagesDataNotFoundResponse(): Response {
+  return new Response("404", { status: 404 });
+}
+
+function resolvePagesRedirectStatus(redirect: PagesRedirectResult): number {
+  return redirect.statusCode != null ? redirect.statusCode : redirect.permanent ? 308 : 307;
+}
+
+function matchesPagesStaticPath(
+  pathEntry: PagesStaticPathsEntry,
+  params: Record<string, unknown>,
+): boolean {
+  return Object.entries(pathEntry.params).every(([key, value]) => {
+    const actual = params[key];
+    if (Array.isArray(value)) {
+      return Array.isArray(actual) && value.join("/") === actual.join("/");
+    }
+    return String(value) === String(actual);
+  });
+}
+
+function buildPagesCacheResponse(
+  html: string,
+  cacheState: "HIT" | "STALE",
+  fontLinkHeader: string,
+  revalidateSeconds?: number,
+): Response {
+  const headers: Record<string, string> = {
+    "Content-Type": "text/html",
+    "X-Vinext-Cache": cacheState,
+    "Cache-Control":
+      cacheState === "HIT"
+        ? `s-maxage=${revalidateSeconds ?? 60}, stale-while-revalidate`
+        : "s-maxage=0, stale-while-revalidate",
+  };
+
+  if (fontLinkHeader) {
+    headers.Link = fontLinkHeader;
+  }
+
+  return new Response(html, {
+    status: 200,
+    headers,
+  });
+}
+
+function rewritePagesCachedHtml(
+  cachedHtml: string,
+  freshBody: string,
+  nextDataScript: string,
+): string {
+  const bodyMarker = '<div id="__next">';
+  const bodyStart = cachedHtml.indexOf(bodyMarker);
+  const contentStart = bodyStart >= 0 ? bodyStart + bodyMarker.length : -1;
+  const nextDataMarker = "<script>window.__NEXT_DATA__";
+  const nextDataStart = cachedHtml.indexOf(nextDataMarker);
+
+  if (contentStart >= 0 && nextDataStart >= 0) {
+    const region = cachedHtml.slice(contentStart, nextDataStart);
+    const lastCloseDiv = region.lastIndexOf("</div>");
+    const gap = lastCloseDiv >= 0 ? region.slice(lastCloseDiv + 6) : "";
+    const nextDataEnd = cachedHtml.indexOf("</script>", nextDataStart) + 9;
+    const tail = cachedHtml.slice(nextDataEnd);
+
+    return cachedHtml.slice(0, contentStart) + freshBody + "</div>" + gap + nextDataScript + tail;
+  }
+
+  return (
+    '<!DOCTYPE html>\n<html>\n<head>\n</head>\n<body>\n  <div id="__next">' +
+    freshBody +
+    "</div>\n  " +
+    nextDataScript +
+    "\n</body>\n</html>"
+  );
+}
+
+export async function renderPagesIsrHtml(options: RenderPagesIsrHtmlOptions): Promise<string> {
+  const freshBody = await options.renderIsrPassToStringAsync(
+    options.createPageElement(options.pageProps),
+  );
+  const nextDataScript = buildPagesNextDataScript({
+    buildId: options.buildId,
+    i18n: options.i18n,
+    pageProps: options.pageProps,
+    params: options.params,
+    routePattern: options.routePattern,
+    safeJsonStringify: options.safeJsonStringify,
+  });
+
+  return rewritePagesCachedHtml(options.cachedHtml, freshBody, nextDataScript);
+}
+
+export async function resolvePagesPageData(
+  options: ResolvePagesPageDataOptions,
+): Promise<ResolvePagesPageDataResult> {
+  if (typeof options.pageModule.getStaticPaths === "function" && options.route.isDynamic) {
+    const pathsResult = await options.pageModule.getStaticPaths({
+      locales: options.i18n.locales ?? [],
+      defaultLocale: options.i18n.defaultLocale ?? "",
+    });
+    const fallback = pathsResult?.fallback ?? false;
+
+    if (fallback === false) {
+      const paths = pathsResult?.paths ?? [];
+      const isValidPath = paths.some((pathEntry) =>
+        matchesPagesStaticPath(pathEntry, options.params),
+      );
+
+      if (!isValidPath) {
+        return {
+          kind: "response",
+          response: buildPagesNotFoundResponse(),
+        };
+      }
+    }
+  }
+
+  let pageProps: Record<string, unknown> = {};
+  let gsspRes: PagesMutableGsspResponse | null = null;
+
+  if (typeof options.pageModule.getServerSideProps === "function") {
+    const { req, res, responsePromise } = options.createGsspReqRes();
+    const result = await options.pageModule.getServerSideProps({
+      params: options.params,
+      req,
+      res,
+      query: options.query,
+      resolvedUrl: options.routeUrl,
+      locale: options.i18n.locale,
+      locales: options.i18n.locales,
+      defaultLocale: options.i18n.defaultLocale,
+    });
+
+    if (res.headersSent) {
+      return {
+        kind: "response",
+        response: await responsePromise,
+      };
+    }
+
+    if (result?.props) {
+      pageProps = result.props;
+    }
+
+    if (result?.redirect) {
+      return {
+        kind: "response",
+        response: new Response(null, {
+          status: resolvePagesRedirectStatus(result.redirect),
+          headers: { Location: options.sanitizeDestination(result.redirect.destination) },
+        }),
+      };
+    }
+
+    if (result?.notFound) {
+      return {
+        kind: "response",
+        response: buildPagesDataNotFoundResponse(),
+      };
+    }
+
+    gsspRes = res;
+  }
+
+  let isrRevalidateSeconds: number | null = null;
+
+  if (typeof options.pageModule.getStaticProps === "function") {
+    const pathname = options.routeUrl.split("?")[0];
+    const cacheKey = options.isrCacheKey("pages", pathname);
+    const cached = await options.isrGet(cacheKey);
+    const cachedValue = cached?.value.value;
+
+    if (cachedValue?.kind === "PAGES" && cached && !cached.isStale) {
+      return {
+        kind: "response",
+        response: buildPagesCacheResponse(
+          cachedValue.html,
+          "HIT",
+          options.fontLinkHeader,
+          (cachedValue as CachedPagesValue & { revalidate?: number }).revalidate,
+        ),
+      };
+    }
+
+    if (cachedValue?.kind === "PAGES" && cached && cached.isStale) {
+      options.triggerBackgroundRegeneration(cacheKey, async function () {
+        return options.runInFreshUnifiedContext(async () => {
+          const freshResult = await options.pageModule.getStaticProps?.({
+            params: options.params,
+            locale: options.i18n.locale,
+            locales: options.i18n.locales,
+            defaultLocale: options.i18n.defaultLocale,
+          });
+
+          if (
+            freshResult?.props &&
+            typeof freshResult.revalidate === "number" &&
+            freshResult.revalidate > 0
+          ) {
+            options.applyRequestContexts();
+            const freshHtml = await renderPagesIsrHtml({
+              buildId: options.buildId,
+              cachedHtml: cachedValue.html,
+              createPageElement: options.createPageElement,
+              i18n: options.i18n,
+              pageProps: freshResult.props,
+              params: options.params,
+              renderIsrPassToStringAsync: options.renderIsrPassToStringAsync,
+              routePattern: options.routePattern,
+              safeJsonStringify: options.safeJsonStringify,
+            });
+
+            await options.isrSet(
+              cacheKey,
+              buildPagesCacheValue(freshHtml, freshResult.props),
+              freshResult.revalidate,
+            );
+          }
+        });
+      });
+
+      return {
+        kind: "response",
+        response: buildPagesCacheResponse(cachedValue.html, "STALE", options.fontLinkHeader),
+      };
+    }
+
+    const result = await options.pageModule.getStaticProps({
+      params: options.params,
+      locale: options.i18n.locale,
+      locales: options.i18n.locales,
+      defaultLocale: options.i18n.defaultLocale,
+    });
+
+    if (result?.props) {
+      pageProps = result.props;
+    }
+
+    if (result?.redirect) {
+      return {
+        kind: "response",
+        response: new Response(null, {
+          status: resolvePagesRedirectStatus(result.redirect),
+          headers: { Location: options.sanitizeDestination(result.redirect.destination) },
+        }),
+      };
+    }
+
+    if (result?.notFound) {
+      return {
+        kind: "response",
+        response: buildPagesDataNotFoundResponse(),
+      };
+    }
+
+    if (typeof result?.revalidate === "number" && result.revalidate > 0) {
+      isrRevalidateSeconds = result.revalidate;
+    }
+  }
+
+  return {
+    kind: "render",
+    gsspRes,
+    isrRevalidateSeconds,
+    pageProps,
+  };
+}

--- a/packages/vinext/src/server/pages-page-response.ts
+++ b/packages/vinext/src/server/pages-page-response.ts
@@ -85,7 +85,7 @@ function buildPagesFontHeadHtml(
   return html;
 }
 
-function buildPagesNextDataScript(
+export function buildPagesNextDataScript(
   options: Pick<
     RenderPagesPageResponseOptions,
     "buildId" | "i18n" | "pageProps" | "params" | "routePattern" | "safeJsonStringify"

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -13705,6 +13705,7 @@ import { runWithExecutionContext as _runWithExecutionContext, getRequestExecutio
 import { buildRouteTrie as _buildRouteTrie, trieMatch as _trieMatch } from "<ROOT>/packages/vinext/src/routing/route-trie.js";
 import { reportRequestError as _reportRequestError } from "vinext/instrumentation";
 import { resolvePagesI18nRequest } from "<ROOT>/packages/vinext/src/server/pages-i18n.js";
+import { resolvePagesPageData as __resolvePagesPageData } from "<ROOT>/packages/vinext/src/server/pages-page-data.js";
 import { renderPagesPageResponse as __renderPagesPageResponse } from "<ROOT>/packages/vinext/src/server/pages-page-response.js";
 import * as _instrumentation from "<ROOT>/tests/fixtures/pages-basic/instrumentation.ts";
 import * as middlewareModule from "<ROOT>/tests/fixtures/pages-basic/middleware.ts";
@@ -14265,19 +14266,20 @@ async function _renderPage(request, url, manifest) {
       { status: 404, headers: { "Content-Type": "text/html" } });
   }
 
-  const { route, params } = match;
-  const __uCtx = _createUnifiedCtx({
-    executionContext: _getRequestExecutionContext(),
-  });
-  return _runWithUnifiedCtx(__uCtx, async () => {
-    ensureFetchPatch();
-    try {
-    if (typeof setSSRContext === "function") {
-      setSSRContext({
-        pathname: patternToNextFormat(route.pattern),
-        query: { ...params, ...parseQuery(routeUrl) },
-        asPath: routeUrl,
-        locale: locale,
+	  const { route, params } = match;
+	  const __uCtx = _createUnifiedCtx({
+	    executionContext: _getRequestExecutionContext(),
+	  });
+	  return _runWithUnifiedCtx(__uCtx, async () => {
+	    ensureFetchPatch();
+	    try {
+	    const routePattern = patternToNextFormat(route.pattern);
+	    if (typeof setSSRContext === "function") {
+	      setSSRContext({
+	        pathname: routePattern,
+	        query: { ...params, ...parseQuery(routeUrl) },
+	        asPath: routeUrl,
+	        locale: locale,
         locales: i18nConfig ? i18nConfig.locales : undefined,
         defaultLocale: currentDefaultLocale,
         domainLocales: domainLocales,
@@ -14296,210 +14298,96 @@ async function _renderPage(request, url, manifest) {
 
     const pageModule = route.module;
     const PageComponent = pageModule.default;
-    if (!PageComponent) {
-      return new Response("Page has no default export", { status: 500 });
-    }
-
-    // Handle getStaticPaths for dynamic routes
-    if (typeof pageModule.getStaticPaths === "function" && route.isDynamic) {
-      const pathsResult = await pageModule.getStaticPaths({
-        locales: i18nConfig ? i18nConfig.locales : [],
-        defaultLocale: currentDefaultLocale || "",
-      });
-      const fallback = pathsResult && pathsResult.fallback !== undefined ? pathsResult.fallback : false;
-
-      if (fallback === false) {
-        const paths = pathsResult && pathsResult.paths ? pathsResult.paths : [];
-        const isValidPath = paths.some(function(p) {
-          return Object.entries(p.params).every(function(entry) {
-            var key = entry[0], val = entry[1];
-            var actual = params[key];
-            if (Array.isArray(val)) {
-              return Array.isArray(actual) && val.join("/") === actual.join("/");
-            }
-            return String(val) === String(actual);
-          });
-        });
-        if (!isValidPath) {
-          return new Response("<!DOCTYPE html><html><body><h1>404 - Page not found</h1></body></html>",
-            { status: 404, headers: { "Content-Type": "text/html" } });
-        }
-      }
-    }
-
-    let pageProps = {};
-    var gsspRes = null;
-    if (typeof pageModule.getServerSideProps === "function") {
-      const { req, res, responsePromise } = createReqRes(request, routeUrl, parseQuery(routeUrl), undefined);
-      const ctx = {
-        params, req, res,
-        query: parseQuery(routeUrl),
-        resolvedUrl: routeUrl,
-        locale: locale,
-        locales: i18nConfig ? i18nConfig.locales : undefined,
-        defaultLocale: currentDefaultLocale,
-      };
-      const result = await pageModule.getServerSideProps(ctx);
-      // If gSSP called res.end() directly (short-circuit), return that response.
-      if (res.headersSent) {
-        return await responsePromise;
-      }
-      if (result && result.props) pageProps = result.props;
-      if (result && result.redirect) {
-        var gsspStatus = result.redirect.statusCode != null ? result.redirect.statusCode : (result.redirect.permanent ? 308 : 307);
-        return new Response(null, { status: gsspStatus, headers: { Location: sanitizeDestinationLocal(result.redirect.destination) } });
-      }
-      if (result && result.notFound) {
-        return new Response("404", { status: 404 });
-      }
-      // Preserve the res object so headers/status/cookies set by gSSP
-      // can be merged into the final HTML response.
-      gsspRes = res;
-    }
-    // Build font Link header early so it's available for ISR cached responses too.
-    // Font preloads are module-level state populated at import time and persist across requests.
-    var _fontLinkHeader = "";
-    var _allFp = [];
+	    if (!PageComponent) {
+	      return new Response("Page has no default export", { status: 500 });
+	    }
+	    // Build font Link header early so it's available for ISR cached responses too.
+	    // Font preloads are module-level state populated at import time and persist across requests.
+	    var _fontLinkHeader = "";
+	    var _allFp = [];
     try {
       var _fpGoogle = typeof _getSSRFontPreloadsGoogle === "function" ? _getSSRFontPreloadsGoogle() : [];
       var _fpLocal = typeof _getSSRFontPreloadsLocal === "function" ? _getSSRFontPreloadsLocal() : [];
       _allFp = _fpGoogle.concat(_fpLocal);
-      if (_allFp.length > 0) {
-        _fontLinkHeader = _allFp.map(function(p) { return "<" + p.href + ">; rel=preload; as=font; type=" + p.type + "; crossorigin"; }).join(", ");
-      }
-    } catch (e) { /* font preloads not available */ }
+	      if (_allFp.length > 0) {
+	        _fontLinkHeader = _allFp.map(function(p) { return "<" + p.href + ">; rel=preload; as=font; type=" + p.type + "; crossorigin"; }).join(", ");
+	      }
+	    } catch (e) { /* font preloads not available */ }
+	    const query = parseQuery(routeUrl);
+	    const pageDataResult = await __resolvePagesPageData({
+	      applyRequestContexts() {
+	        if (typeof setSSRContext === "function") {
+	          setSSRContext({
+	            pathname: routePattern,
+	            query: { ...params, ...query },
+	            asPath: routeUrl,
+	            locale: locale,
+	            locales: i18nConfig ? i18nConfig.locales : undefined,
+	            defaultLocale: currentDefaultLocale,
+	            domainLocales: domainLocales,
+	          });
+	        }
+	        if (i18nConfig) {
+	          setI18nContext({
+	            locale: locale,
+	            locales: i18nConfig.locales,
+	            defaultLocale: currentDefaultLocale,
+	            domainLocales: domainLocales,
+	            hostname: new URL(request.url).hostname,
+	          });
+	        }
+	      },
+	      buildId,
+	      createGsspReqRes() {
+	        return createReqRes(request, routeUrl, query, undefined);
+	      },
+	      createPageElement(currentPageProps) {
+	        var currentElement = AppComponent
+	          ? React.createElement(AppComponent, { Component: PageComponent, pageProps: currentPageProps })
+	          : React.createElement(PageComponent, currentPageProps);
+	        return wrapWithRouterContext(currentElement);
+	      },
+	      fontLinkHeader: _fontLinkHeader,
+	      i18n: {
+	        locale: locale,
+	        locales: i18nConfig ? i18nConfig.locales : undefined,
+	        defaultLocale: currentDefaultLocale,
+	        domainLocales: domainLocales,
+	      },
+	      isrCacheKey,
+	      isrGet,
+	      isrSet,
+	      pageModule,
+	      params,
+	      query,
+	      renderIsrPassToStringAsync,
+	      route: {
+	        isDynamic: route.isDynamic,
+	      },
+	      routePattern,
+	      routeUrl,
+	      runInFreshUnifiedContext(callback) {
+	        var revalCtx = _createUnifiedCtx({
+	          executionContext: _getRequestExecutionContext(),
+	        });
+	        return _runWithUnifiedCtx(revalCtx, async () => {
+	          ensureFetchPatch();
+	          return callback();
+	        });
+	      },
+	      safeJsonStringify,
+	      sanitizeDestination: sanitizeDestinationLocal,
+	      triggerBackgroundRegeneration,
+	    });
+	    if (pageDataResult.kind === "response") {
+	      return pageDataResult.response;
+	    }
+	    let pageProps = pageDataResult.pageProps;
+	    var gsspRes = pageDataResult.gsspRes;
+	    let isrRevalidateSeconds = pageDataResult.isrRevalidateSeconds;
 
-    let isrRevalidateSeconds = null;
-    if (typeof pageModule.getStaticProps === "function") {
-      const pathname = routeUrl.split("?")[0];
-      const cacheKey = isrCacheKey("pages", pathname);
-      const cached = await isrGet(cacheKey);
-
-      if (cached && !cached.isStale && cached.value.value && cached.value.value.kind === "PAGES") {
-        var _hitHeaders = {
-          "Content-Type": "text/html", "X-Vinext-Cache": "HIT",
-          "Cache-Control": "s-maxage=" + (cached.value.value.revalidate || 60) + ", stale-while-revalidate",
-        };
-        if (_fontLinkHeader) _hitHeaders["Link"] = _fontLinkHeader;
-        return new Response(cached.value.value.html, { status: 200, headers: _hitHeaders });
-      }
-
-      if (cached && cached.isStale && cached.value.value && cached.value.value.kind === "PAGES") {
-        triggerBackgroundRegeneration(cacheKey, async function() {
-          var revalCtx = _createUnifiedCtx({
-            executionContext: _getRequestExecutionContext(),
-          });
-          return _runWithUnifiedCtx(revalCtx, async () => {
-            ensureFetchPatch();
-              var freshResult = await pageModule.getStaticProps({
-                params: params,
-                locale: locale,
-                locales: i18nConfig ? i18nConfig.locales : undefined,
-                defaultLocale: currentDefaultLocale,
-              });
-              if (freshResult && freshResult.props && typeof freshResult.revalidate === "number" && freshResult.revalidate > 0) {
-                var _fp = freshResult.props;
-                if (typeof setSSRContext === "function") {
-                  setSSRContext({
-                    pathname: patternToNextFormat(route.pattern),
-                    query: { ...params, ...parseQuery(routeUrl) },
-                    asPath: routeUrl,
-                    locale: locale,
-                    locales: i18nConfig ? i18nConfig.locales : undefined,
-                    defaultLocale: currentDefaultLocale,
-                    domainLocales: domainLocales,
-                  });
-                }
-                if (i18nConfig) {
-                  setI18nContext({
-                    locale: locale,
-                    locales: i18nConfig.locales,
-                    defaultLocale: currentDefaultLocale,
-                    domainLocales: domainLocales,
-                    hostname: new URL(request.url).hostname,
-                  });
-                }
-                // Re-render the page with fresh props inside fresh render sub-scopes
-                // so head/cache state cannot leak across passes.
-                var _el = AppComponent
-                  ? React.createElement(AppComponent, { Component: PageComponent, pageProps: _fp })
-                  : React.createElement(PageComponent, _fp);
-                _el = wrapWithRouterContext(_el);
-                var _freshBody = await renderIsrPassToStringAsync(_el);
-                // Rebuild __NEXT_DATA__ with fresh props
-                var _regenPayload = {
-                  props: { pageProps: _fp }, page: patternToNextFormat(route.pattern),
-                  query: params, buildId: buildId, isFallback: false,
-                };
-                if (i18nConfig) {
-                  _regenPayload.locale = locale;
-                  _regenPayload.locales = i18nConfig.locales;
-                  _regenPayload.defaultLocale = currentDefaultLocale;
-                  _regenPayload.domainLocales = domainLocales;
-                }
-                var _lGlobals = i18nConfig
-                  ? ";window.__VINEXT_LOCALE__=" + safeJsonStringify(locale) +
-                    ";window.__VINEXT_LOCALES__=" + safeJsonStringify(i18nConfig.locales) +
-                    ";window.__VINEXT_DEFAULT_LOCALE__=" + safeJsonStringify(currentDefaultLocale)
-                  : "";
-                var _freshNDS = "<script>window.__NEXT_DATA__ = " + safeJsonStringify(_regenPayload) + _lGlobals + "</script>";
-                // Reconstruct ISR HTML preserving the document shell from the
-                // cached entry (head, fonts, assets, custom _document markup).
-                var _cachedStr = cached.value.value.html;
-                var _btag = '<div id="__next">';
-                var _bstart = _cachedStr.indexOf(_btag);
-                var _bodyStart = _bstart >= 0 ? _bstart + _btag.length : -1;
-                // Locate __NEXT_DATA__ script to split body from suffix
-                var _ndMarker = '<script>window.__NEXT_DATA__';
-                var _ndStart = _cachedStr.indexOf(_ndMarker);
-                var _freshHtml;
-                if (_bodyStart >= 0 && _ndStart >= 0) {
-                  // Region between body start and __NEXT_DATA__ contains:
-                  // BODY_HTML + </div> + optional gap (custom _document content)
-                  var _region = _cachedStr.slice(_bodyStart, _ndStart);
-                  var _lastClose = _region.lastIndexOf('</div>');
-                  var _gap = _lastClose >= 0 ? _region.slice(_lastClose + 6) : '';
-                  // Tail: everything after the old __NEXT_DATA__ </script>
-                  var _ndEnd = _cachedStr.indexOf('</script>', _ndStart) + 9;
-                  var _tail = _cachedStr.slice(_ndEnd);
-                  _freshHtml = _cachedStr.slice(0, _bodyStart) + _freshBody + '</div>' + _gap + _freshNDS + _tail;
-                } else {
-                  _freshHtml = '<!DOCTYPE html>\\n<html>\\n<head>\\n</head>\\n<body>\\n  <div id="__next">' + _freshBody + '</div>\\n  ' + _freshNDS + '\\n</body>\\n</html>';
-                }
-                await isrSet(cacheKey, { kind: "PAGES", html: _freshHtml, pageData: _fp, headers: undefined, status: undefined }, freshResult.revalidate);
-              }
-            });
-        });
-        var _staleHeaders = {
-          "Content-Type": "text/html", "X-Vinext-Cache": "STALE",
-          "Cache-Control": "s-maxage=0, stale-while-revalidate",
-        };
-        if (_fontLinkHeader) _staleHeaders["Link"] = _fontLinkHeader;
-        return new Response(cached.value.value.html, { status: 200, headers: _staleHeaders });
-      }
-
-      const ctx = {
-        params,
-        locale: locale,
-        locales: i18nConfig ? i18nConfig.locales : undefined,
-        defaultLocale: currentDefaultLocale,
-      };
-      const result = await pageModule.getStaticProps(ctx);
-      if (result && result.props) pageProps = result.props;
-      if (result && result.redirect) {
-        var gspStatus = result.redirect.statusCode != null ? result.redirect.statusCode : (result.redirect.permanent ? 308 : 307);
-        return new Response(null, { status: gspStatus, headers: { Location: sanitizeDestinationLocal(result.redirect.destination) } });
-      }
-      if (result && result.notFound) {
-        return new Response("404", { status: 404 });
-      }
-      if (typeof result.revalidate === "number" && result.revalidate > 0) {
-        isrRevalidateSeconds = result.revalidate;
-      }
-    }
-
-    const pageModuleIds = route.filePath ? [route.filePath] : [];
-    const assetTags = collectAssetTags(manifest, pageModuleIds);
+	    const pageModuleIds = route.filePath ? [route.filePath] : [];
+	    const assetTags = collectAssetTags(manifest, pageModuleIds);
 
     return __renderPagesPageResponse({
       assetTags,
@@ -14537,8 +14425,8 @@ async function _renderPage(request, url, manifest) {
           return [];
         }
       },
-      getSSRHeadHTML: typeof getSSRHeadHTML === "function" ? getSSRHeadHTML : undefined,
-      gsspRes,
+	      getSSRHeadHTML: typeof getSSRHeadHTML === "function" ? getSSRHeadHTML : undefined,
+	      gsspRes,
       isrCacheKey,
       isrRevalidateSeconds,
       isrSet,
@@ -14558,7 +14446,7 @@ async function _renderPage(request, url, manifest) {
         return renderToReadableStream(element);
       },
       resetSSRHead: typeof resetSSRHead === "function" ? resetSSRHead : undefined,
-      routePattern: patternToNextFormat(route.pattern),
+	      routePattern,
       routeUrl,
       safeJsonStringify,
     });

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -304,27 +304,18 @@ describe("Pages Router entry templates", () => {
     expect(renderPageSection).toContain("executionContext: _getRequestExecutionContext(),");
   });
 
-  it("server entry wraps ISR regeneration in unified context for fetch patch", async () => {
+  it("server entry passes a fresh unified-context ISR runner into the typed page-data helper", async () => {
     const code = await getVirtualModuleCode("virtual:vinext-server-entry");
+    const runnerIndex = code.indexOf("runInFreshUnifiedContext(callback) {");
 
-    // Find the triggerBackgroundRegeneration call for stale cache handling
-    const staleRegenIndex = code.indexOf(
-      "triggerBackgroundRegeneration(cacheKey, async function()",
-    );
-    expect(staleRegenIndex).toBeGreaterThan(-1);
+    expect(runnerIndex).toBeGreaterThan(-1);
 
-    // Extract the callback body (roughly next 500 chars after the call)
-    const callbackSection = code.slice(staleRegenIndex, staleRegenIndex + 800);
-
-    // The callback should use _runWithUnifiedCtx to provide context for patched fetch
-    expect(callbackSection).toContain("_runWithUnifiedCtx");
-
-    // Prod regeneration should explicitly read the outer ExecutionContext ALS
-    // instead of relying on createRequestContext() inheritance defaults.
-    expect(callbackSection).toContain("executionContext: _getRequestExecutionContext()");
-
-    // It should also call ensureFetchPatch() to enable cache tagging during regen
-    expect(callbackSection).toContain("ensureFetchPatch");
+    const runnerSection = code.slice(runnerIndex, runnerIndex + 500);
+    expect(runnerSection).toContain("_createUnifiedCtx");
+    expect(runnerSection).toContain("executionContext: _getRequestExecutionContext()");
+    expect(runnerSection).toContain("_runWithUnifiedCtx");
+    expect(runnerSection).toContain("ensureFetchPatch();");
+    expect(runnerSection).toContain("return callback();");
   });
 
   it("server entry delegates Pages HTML stream/response shaping to a typed helper", async () => {
@@ -334,6 +325,16 @@ describe("Pages Router entry templates", () => {
     expect(code).toContain("return __renderPagesPageResponse({");
     expect(code).not.toContain('var BODY_MARKER = "<!--VINEXT_STREAM_BODY-->";');
     expect(code).not.toContain("var compositeStream = new ReadableStream({");
+  });
+
+  it("server entry delegates Pages data/ISR handling to a typed helper", async () => {
+    const code = await getVirtualModuleCode("virtual:vinext-server-entry");
+
+    expect(code).toContain("resolvePagesPageData as __resolvePagesPageData");
+    expect(code).toContain("const pageDataResult = await __resolvePagesPageData({");
+    expect(code).not.toContain("triggerBackgroundRegeneration(cacheKey, async function()");
+    expect(code).not.toContain("const result = await pageModule.getServerSideProps(ctx);");
+    expect(code).not.toContain("const result = await pageModule.getStaticProps(ctx);");
   });
 
   it("server entry isolates the ISR cache-fill rerender in fresh render sub-scopes", async () => {

--- a/tests/pages-page-data.test.ts
+++ b/tests/pages-page-data.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+import {
+  renderPagesIsrHtml,
+  resolvePagesPageData,
+  type ResolvePagesPageDataOptions,
+} from "../packages/vinext/src/server/pages-page-data.js";
+
+function createOptions(
+  overrides: Partial<ResolvePagesPageDataOptions> = {},
+): ResolvePagesPageDataOptions {
+  return {
+    applyRequestContexts: vi.fn(),
+    buildId: "build-123",
+    createGsspReqRes() {
+      return {
+        req: {},
+        res: {
+          headersSent: false,
+          statusCode: 200,
+          getHeaders() {
+            return {};
+          },
+        },
+        responsePromise: Promise.resolve(new Response("short-circuit", { status: 202 })),
+      };
+    },
+    createPageElement(_pageProps: Record<string, unknown>) {
+      return "page";
+    },
+    fontLinkHeader: "</font.woff2>; rel=preload; as=font; type=font/woff2; crossorigin",
+    i18n: {
+      locale: "en",
+      locales: ["en", "fr"],
+      defaultLocale: "en",
+      domainLocales: [{ domain: "example.com", defaultLocale: "en", locales: ["en"] }],
+    },
+    isrCacheKey(_router: string, pathname: string) {
+      return `pages:${pathname}`;
+    },
+    isrGet: vi.fn().mockResolvedValue(null),
+    isrSet: vi.fn(async () => {}),
+    pageModule: {},
+    params: { slug: "post" },
+    query: { slug: "post" },
+    renderIsrPassToStringAsync: vi.fn(async () => "<div>fresh-body</div>"),
+    route: { isDynamic: false },
+    routePattern: "/posts/[slug]",
+    routeUrl: "/posts/post",
+    async runInFreshUnifiedContext<T>(callback: () => Promise<T>): Promise<T> {
+      return callback();
+    },
+    safeJsonStringify(value: unknown) {
+      return JSON.stringify(value);
+    },
+    sanitizeDestination(destination: string) {
+      return destination;
+    },
+    triggerBackgroundRegeneration: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("pages page data", () => {
+  it("renders fresh ISR HTML while preserving custom document gaps and tail scripts", async () => {
+    const html = await renderPagesIsrHtml({
+      buildId: "build-123",
+      cachedHtml:
+        '<!DOCTYPE html><html><head><title>cached</title></head><body><div id="__next"><div>stale-body</div></div><aside data-gap="1"></aside><script>window.__NEXT_DATA__ = {"old":1}</script><script src="/tail.js"></script></body></html>',
+      createPageElement(_pageProps: Record<string, unknown>) {
+        return "page";
+      },
+      i18n: {
+        locale: "en",
+        locales: ["en", "fr"],
+        defaultLocale: "en",
+        domainLocales: [{ domain: "example.com", defaultLocale: "en", locales: ["en"] }],
+      },
+      pageProps: { title: "fresh" },
+      params: { slug: "post" },
+      renderIsrPassToStringAsync: vi.fn(async () => "<div>fresh-body</div>"),
+      routePattern: "/posts/[slug]",
+      safeJsonStringify(value: unknown) {
+        return JSON.stringify(value);
+      },
+    });
+
+    expect(html).toContain("<div>fresh-body</div>");
+    expect(html).toContain('<aside data-gap="1"></aside>');
+    expect(html).toContain('<script src="/tail.js"></script>');
+    expect(html).toContain('"page":"/posts/[slug]"');
+    expect(html).toContain('"slug":"post"');
+  });
+
+  it("returns an HTML 404 when getStaticPaths excludes a dynamic path", async () => {
+    const result = await resolvePagesPageData(
+      createOptions({
+        pageModule: {
+          async getStaticPaths() {
+            return {
+              fallback: false,
+              paths: [{ params: { slug: "hello-world" } }],
+            };
+          },
+        },
+        params: { slug: "missing" },
+        query: { slug: "missing" },
+        route: { isDynamic: true },
+        routeUrl: "/posts/missing",
+      }),
+    );
+
+    expect(result.kind).toBe("response");
+    if (result.kind !== "response") {
+      throw new Error("expected response result");
+    }
+    expect(result.response.status).toBe(404);
+    await expect(result.response.text()).resolves.toContain("404 - Page not found");
+  });
+
+  it("short-circuits getServerSideProps responses after res.end()", async () => {
+    const responsePromise = Promise.resolve(
+      new Response('{"ok":true}', {
+        status: 202,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    const result = await resolvePagesPageData(
+      createOptions({
+        createGsspReqRes() {
+          const res = {
+            headersSent: false,
+            statusCode: 202,
+            getHeaders() {
+              return { "content-type": "application/json" };
+            },
+          };
+          return {
+            req: { method: "GET" },
+            res,
+            responsePromise,
+          };
+        },
+        pageModule: {
+          async getServerSideProps(context) {
+            context.res.headersSent = true;
+            return {};
+          },
+        },
+      }),
+    );
+
+    expect(result.kind).toBe("response");
+    if (result.kind !== "response") {
+      throw new Error("expected response result");
+    }
+    expect(result.response.status).toBe(202);
+    await expect(result.response.text()).resolves.toBe('{"ok":true}');
+  });
+
+  it("serves stale ISR entries immediately and regenerates them through typed helpers", async () => {
+    let regenPromise: Promise<void> | null = null;
+    const applyRequestContexts = vi.fn();
+    const isrSet = vi.fn(async () => {});
+    const runInFreshUnifiedContext = vi.fn(
+      async <T>(callback: () => Promise<T>): Promise<T> => callback(),
+    ) as ResolvePagesPageDataOptions["runInFreshUnifiedContext"];
+    const triggerBackgroundRegeneration = vi.fn((_key: string, renderFn: () => Promise<void>) => {
+      regenPromise = renderFn();
+    });
+
+    const result = await resolvePagesPageData(
+      createOptions({
+        applyRequestContexts,
+        isrGet: vi.fn().mockResolvedValue({
+          isStale: true,
+          value: {
+            lastModified: 1,
+            cacheState: "stale",
+            value: {
+              kind: "PAGES",
+              html: '<!DOCTYPE html><html><head><title>cached</title></head><body><div id="__next"><div>stale-body</div></div><div data-gap="1"></div><script>window.__NEXT_DATA__ = {"old":1}</script><script src="/tail.js"></script></body></html>',
+              pageData: { stale: true },
+              headers: undefined,
+              status: undefined,
+            },
+          },
+        }),
+        isrSet,
+        pageModule: {
+          async getStaticProps() {
+            return {
+              props: { title: "fresh" },
+              revalidate: 15,
+            };
+          },
+        },
+        runInFreshUnifiedContext,
+        triggerBackgroundRegeneration,
+      }),
+    );
+
+    expect(result.kind).toBe("response");
+    if (result.kind !== "response") {
+      throw new Error("expected response result");
+    }
+
+    expect(result.response.status).toBe(200);
+    expect(result.response.headers.get("x-vinext-cache")).toBe("STALE");
+    expect(result.response.headers.get("cache-control")).toBe("s-maxage=0, stale-while-revalidate");
+    expect(result.response.headers.get("link")).toBe(
+      "</font.woff2>; rel=preload; as=font; type=font/woff2; crossorigin",
+    );
+    await expect(result.response.text()).resolves.toContain("stale-body");
+
+    expect(triggerBackgroundRegeneration).toHaveBeenCalledOnce();
+    if (!regenPromise) {
+      throw new Error("expected stale ISR regeneration to start");
+    }
+
+    const pendingRegen: Promise<void> = regenPromise;
+    await pendingRegen;
+
+    expect(runInFreshUnifiedContext).toHaveBeenCalledOnce();
+    expect(applyRequestContexts).toHaveBeenCalledOnce();
+    expect(isrSet).toHaveBeenCalledWith(
+      "pages:/posts/post",
+      expect.objectContaining({
+        kind: "PAGES",
+        html: expect.stringContaining("<div>fresh-body</div>"),
+        pageData: { title: "fresh" },
+      }),
+      15,
+    );
+  });
+
+  it("returns normalized render data for cache misses", async () => {
+    const result = await resolvePagesPageData(
+      createOptions({
+        pageModule: {
+          async getStaticProps() {
+            return {
+              props: { title: "hello" },
+              revalidate: 30,
+            };
+          },
+        },
+      }),
+    );
+
+    expect(result).toEqual({
+      kind: "render",
+      gsspRes: null,
+      isrRevalidateSeconds: 30,
+      pageProps: { title: "hello" },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- extract the Pages Router `getStaticPaths` / `getServerSideProps` / `getStaticProps` + ISR decision path into typed runtime code in `packages/vinext/src/server/pages-page-data.ts`
- keep `packages/vinext/src/entries/pages-server-entry.ts` focused on route-specific wiring while delegating page data/cache behavior to the helper layer
- add direct helper coverage in `tests/pages-page-data.test.ts` and update generator expectations/snapshots for the new delegation boundary

## Why
This keeps another large chunk of real request/cache behavior out of the generated Pages Router entry, following the same pattern we used for App Router and the earlier Pages response extraction. The goal is to make the code easier to typecheck, test, and safely modify.

## Verification
- `vp check packages/vinext/src/server/pages-page-data.ts tests/pages-page-data.test.ts packages/vinext/src/entries/pages-server-entry.ts tests/entry-templates.test.ts packages/vinext/src/server/pages-page-response.ts`
- `vp test run tests/pages-page-data.test.ts tests/entry-templates.test.ts`
- `vp test run tests/pages-router.test.ts -t 'renders pages with getStaticPaths \+ getStaticProps|returns 404 for paths not in getStaticPaths when fallback is false|getServerSideProps calling res.end\(\) short-circuits the response|keeps ISR cache-fill rerenders isolated from the streamed render state|wraps stale regeneration in a fresh unified request context'`
- `vp run vinext#build`

Written by Codex.
