### PR TITLE
fix: percent-encode X-Vinext-Params to allow non-ASCII route params

### DIFF
--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -104,7 +104,7 @@ async function readInitialRscStream(): Promise<ReadableStream<Uint8Array>> {
   const paramsHeader = rscResponse.headers.get("X-Vinext-Params");
   if (paramsHeader) {
     try {
-      params = JSON.parse(paramsHeader) as Record<string, string | string[]>;
+      params = JSON.parse(decodeURIComponent(paramsHeader)) as Record<string, string | string[]>;
       setClientParams(params);
     } catch {
       // Ignore malformed param headers and continue with hydration.
@@ -243,7 +243,7 @@ async function main(): Promise<void> {
       const paramsHeader = navResponse.headers.get("X-Vinext-Params");
       if (paramsHeader) {
         try {
-          setClientParams(JSON.parse(paramsHeader));
+          setClientParams(JSON.parse(decodeURIComponent(paramsHeader)));
         } catch {
           setClientParams({});
         }

--- a/packages/vinext/src/server/app-page-response.ts
+++ b/packages/vinext/src/server/app-page-response.ts
@@ -167,7 +167,9 @@ export function buildAppPageRscResponse(
   });
 
   if (options.params && Object.keys(options.params).length > 0) {
-    headers.set("X-Vinext-Params", JSON.stringify(options.params));
+    // encodeURIComponent so non-ASCII params (e.g. Korean slugs) survive the
+    // HTTP ByteString constraint — Headers.set() rejects chars above U+00FF.
+    headers.set("X-Vinext-Params", encodeURIComponent(JSON.stringify(options.params)));
   }
   if (options.policy.cacheControl) {
     headers.set("Cache-Control", options.policy.cacheControl);

--- a/tests/app-page-response.test.ts
+++ b/tests/app-page-response.test.ts
@@ -220,12 +220,32 @@ describe("app page response helpers", () => {
 
     expect(response.status).toBe(202);
     expect(response.headers.get("content-type")).toBe("text/x-component; charset=utf-8");
-    expect(response.headers.get("x-vinext-params")).toBe('{"slug":"test"}');
+    expect(response.headers.get("x-vinext-params")).toBe(encodeURIComponent('{"slug":"test"}'));
     expect(response.headers.get("cache-control")).toBe("private, max-age=5");
     expect(response.headers.get("x-vinext-cache")).toBe("MISS");
     expect(response.headers.get("vary")).toBe("RSC, Accept, Next-Router-State-Tree");
     expect(response.headers.get("x-vinext-timing")).toBe("10,5,-1");
     await expect(response.text()).resolves.toBe("flight");
+  });
+
+  it("percent-encodes X-Vinext-Params so non-ASCII characters survive the ByteString header constraint (issue #676)", () => {
+    // HTTP headers are ByteStrings: each character value must be <= 255.
+    // JSON.stringify preserves non-ASCII characters verbatim (e.g. Korean 완 = U+C644 = 50756),
+    // which causes Headers.set() to throw a TypeError in compliant runtimes.
+    // The fix: encodeURIComponent the JSON before setting the header.
+    const koreanSlug = "useState-완전정복";
+    const response = buildAppPageRscResponse(createBody("flight"), {
+      middlewareContext: { headers: new Headers(), status: 200 },
+      params: { slug: [koreanSlug] },
+      policy: {},
+      timing: { handlerStart: 0, responseKind: "rsc" },
+    });
+
+    const rawHeader = response.headers.get("x-vinext-params")!;
+    // Header value must be ASCII-safe (all byte values <= 127 after encoding)
+    expect(Array.from(rawHeader).every((c) => c.charCodeAt(0) <= 127)).toBe(true);
+    // Decoding must round-trip back to the original params
+    expect(JSON.parse(decodeURIComponent(rawHeader))).toEqual({ slug: [koreanSlug] });
   });
 
   it("builds HTML responses with draft cookies, preload links, middleware, and timing", async () => {


### PR DESCRIPTION
## Summary

- `buildAppPageRscResponse` was calling `Headers.set("X-Vinext-Params", JSON.stringify(params))` with raw Unicode characters in the value
- The Fetch spec requires header values to be ByteStrings (each char ≤ U+00FF), so non-ASCII params (Korean, Japanese, etc.) caused a `TypeError: Cannot convert argument to a ByteString`
- Only RSC/client-side navigation was affected — direct SSR requests (`buildAppPageHtmlResponse`) never set this header

## Fix

- Encode with `encodeURIComponent` when setting `X-Vinext-Params` in `app-page-response.ts`
- Decode with `decodeURIComponent` in both read sites in `app-browser-entry.ts` (initial hydration and client-side navigation)

## Test

Added a unit test to `tests/app-page-response.test.ts` that verifies:
1. The header value is ASCII-safe after encoding
2. The params round-trip correctly through encode/decode

Closes #676