### PR TITLE
fix: encode non-ASCII route params in X-Vinext-Params header

### DIFF
--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -104,7 +104,7 @@ async function readInitialRscStream(): Promise<ReadableStream<Uint8Array>> {
   const paramsHeader = rscResponse.headers.get("X-Vinext-Params");
   if (paramsHeader) {
     try {
-      params = JSON.parse(paramsHeader) as Record<string, string | string[]>;
+      params = JSON.parse(decodeURIComponent(paramsHeader)) as Record<string, string | string[]>;
       setClientParams(params);
     } catch {
       // Ignore malformed param headers and continue with hydration.
@@ -243,7 +243,7 @@ async function main(): Promise<void> {
       const paramsHeader = navResponse.headers.get("X-Vinext-Params");
       if (paramsHeader) {
         try {
-          setClientParams(JSON.parse(paramsHeader));
+          setClientParams(JSON.parse(decodeURIComponent(paramsHeader)));
         } catch {
           setClientParams({});
         }

--- a/packages/vinext/src/server/app-page-response.ts
+++ b/packages/vinext/src/server/app-page-response.ts
@@ -1,236 +1,249 @@
 export interface AppPageMiddlewareContext {
-  headers: Headers | null;
-  status: number | null;
+    headers: Headers | null;
+    status: number | null;
 }
 
 export interface AppPageResponseTiming {
-  compileEnd?: number;
-  handlerStart: number;
-  renderEnd?: number;
-  responseKind: "html" | "rsc";
+    compileEnd?: number;
+    handlerStart: number;
+    renderEnd?: number;
+    responseKind: 'html' | 'rsc';
 }
 
 export interface AppPageResponsePolicy {
-  cacheControl?: string;
-  cacheState?: "MISS" | "STATIC";
+    cacheControl?: string;
+    cacheState?: 'MISS' | 'STATIC';
 }
 
 interface ResolveAppPageResponsePolicyBaseOptions {
-  isDynamicError: boolean;
-  isForceDynamic: boolean;
-  isForceStatic: boolean;
-  isProduction: boolean;
-  revalidateSeconds: number | null;
+    isDynamicError: boolean;
+    isForceDynamic: boolean;
+    isForceStatic: boolean;
+    isProduction: boolean;
+    revalidateSeconds: number | null;
 }
 
 export interface ResolveAppPageRscResponsePolicyOptions extends ResolveAppPageResponsePolicyBaseOptions {
-  dynamicUsedDuringBuild: boolean;
+    dynamicUsedDuringBuild: boolean;
 }
 
 export interface ResolveAppPageHtmlResponsePolicyOptions extends ResolveAppPageResponsePolicyBaseOptions {
-  dynamicUsedDuringRender: boolean;
+    dynamicUsedDuringRender: boolean;
 }
 
 export interface AppPageHtmlResponsePolicy extends AppPageResponsePolicy {
-  shouldWriteToCache: boolean;
+    shouldWriteToCache: boolean;
 }
 
 export interface BuildAppPageRscResponseOptions {
-  middlewareContext: AppPageMiddlewareContext;
-  params?: Record<string, unknown>;
-  policy: AppPageResponsePolicy;
-  timing?: AppPageResponseTiming;
+    middlewareContext: AppPageMiddlewareContext;
+    params?: Record<string, unknown>;
+    policy: AppPageResponsePolicy;
+    timing?: AppPageResponseTiming;
 }
 
 export interface BuildAppPageHtmlResponseOptions {
-  draftCookie?: string | null;
-  fontLinkHeader?: string;
-  middlewareContext: AppPageMiddlewareContext;
-  policy: AppPageResponsePolicy;
-  timing?: AppPageResponseTiming;
+    draftCookie?: string | null;
+    fontLinkHeader?: string;
+    middlewareContext: AppPageMiddlewareContext;
+    policy: AppPageResponsePolicy;
+    timing?: AppPageResponseTiming;
 }
 
-const STATIC_CACHE_CONTROL = "s-maxage=31536000, stale-while-revalidate";
-const NO_STORE_CACHE_CONTROL = "no-store, must-revalidate";
+const STATIC_CACHE_CONTROL = 's-maxage=31536000, stale-while-revalidate';
+const NO_STORE_CACHE_CONTROL = 'no-store, must-revalidate';
 
 function buildRevalidateCacheControl(revalidateSeconds: number): string {
-  return `s-maxage=${revalidateSeconds}, stale-while-revalidate`;
+    return `s-maxage=${revalidateSeconds}, stale-while-revalidate`;
 }
 
-function applyTimingHeader(headers: Headers, timing?: AppPageResponseTiming): void {
-  if (!timing) {
-    return;
-  }
+function applyTimingHeader(
+    headers: Headers,
+    timing?: AppPageResponseTiming,
+): void {
+    if (!timing) {
+        return;
+    }
 
-  const handlerStart = Math.round(timing.handlerStart);
-  const compileMs =
-    timing.compileEnd !== undefined ? Math.round(timing.compileEnd - timing.handlerStart) : -1;
-  const renderMs =
-    timing.responseKind === "html" &&
-    timing.renderEnd !== undefined &&
-    timing.compileEnd !== undefined
-      ? Math.round(timing.renderEnd - timing.compileEnd)
-      : -1;
+    const handlerStart = Math.round(timing.handlerStart);
+    const compileMs =
+        timing.compileEnd !== undefined
+            ? Math.round(timing.compileEnd - timing.handlerStart)
+            : -1;
+    const renderMs =
+        timing.responseKind === 'html' &&
+        timing.renderEnd !== undefined &&
+        timing.compileEnd !== undefined
+            ? Math.round(timing.renderEnd - timing.compileEnd)
+            : -1;
 
-  headers.set("x-vinext-timing", `${handlerStart},${compileMs},${renderMs}`);
+    headers.set('x-vinext-timing', `${handlerStart},${compileMs},${renderMs}`);
 }
 
 export function resolveAppPageRscResponsePolicy(
-  options: ResolveAppPageRscResponsePolicyOptions,
+    options: ResolveAppPageRscResponsePolicyOptions,
 ): AppPageResponsePolicy {
-  if (options.isForceDynamic || options.dynamicUsedDuringBuild) {
-    return { cacheControl: NO_STORE_CACHE_CONTROL };
-  }
+    if (options.isForceDynamic || options.dynamicUsedDuringBuild) {
+        return { cacheControl: NO_STORE_CACHE_CONTROL };
+    }
 
-  if (
-    ((options.isForceStatic || options.isDynamicError) && !options.revalidateSeconds) ||
-    options.revalidateSeconds === Infinity
-  ) {
-    return {
-      cacheControl: STATIC_CACHE_CONTROL,
-      cacheState: "STATIC",
-    };
-  }
+    if (
+        ((options.isForceStatic || options.isDynamicError) &&
+            !options.revalidateSeconds) ||
+        options.revalidateSeconds === Infinity
+    ) {
+        return {
+            cacheControl: STATIC_CACHE_CONTROL,
+            cacheState: 'STATIC',
+        };
+    }
 
-  if (options.revalidateSeconds) {
-    return {
-      cacheControl: buildRevalidateCacheControl(options.revalidateSeconds),
-      // Emit MISS as part of the initial RSC response shape rather than bolting
-      // it on later in the cache-write block so response construction stays
-      // centralized in this helper. This matches the eventual write path: the
-      // first ISR-eligible production response is a cache miss.
-      cacheState: options.isProduction ? "MISS" : undefined,
-    };
-  }
+    if (options.revalidateSeconds) {
+        return {
+            cacheControl: buildRevalidateCacheControl(
+                options.revalidateSeconds,
+            ),
+            // Emit MISS as part of the initial RSC response shape rather than bolting
+            // it on later in the cache-write block so response construction stays
+            // centralized in this helper. This matches the eventual write path: the
+            // first ISR-eligible production response is a cache miss.
+            cacheState: options.isProduction ? 'MISS' : undefined,
+        };
+    }
 
-  return {};
+    return {};
 }
 
 export function resolveAppPageHtmlResponsePolicy(
-  options: ResolveAppPageHtmlResponsePolicyOptions,
+    options: ResolveAppPageHtmlResponsePolicyOptions,
 ): AppPageHtmlResponsePolicy {
-  if (options.isForceDynamic) {
-    return {
-      cacheControl: NO_STORE_CACHE_CONTROL,
-      shouldWriteToCache: false,
-    };
-  }
+    if (options.isForceDynamic) {
+        return {
+            cacheControl: NO_STORE_CACHE_CONTROL,
+            shouldWriteToCache: false,
+        };
+    }
 
-  if (
-    (options.isForceStatic || options.isDynamicError) &&
-    (options.revalidateSeconds === null || options.revalidateSeconds === 0)
-  ) {
-    return {
-      cacheControl: STATIC_CACHE_CONTROL,
-      cacheState: "STATIC",
-      shouldWriteToCache: false,
-    };
-  }
+    if (
+        (options.isForceStatic || options.isDynamicError) &&
+        (options.revalidateSeconds === null || options.revalidateSeconds === 0)
+    ) {
+        return {
+            cacheControl: STATIC_CACHE_CONTROL,
+            cacheState: 'STATIC',
+            shouldWriteToCache: false,
+        };
+    }
 
-  if (options.dynamicUsedDuringRender) {
-    return {
-      cacheControl: NO_STORE_CACHE_CONTROL,
-      shouldWriteToCache: false,
-    };
-  }
+    if (options.dynamicUsedDuringRender) {
+        return {
+            cacheControl: NO_STORE_CACHE_CONTROL,
+            shouldWriteToCache: false,
+        };
+    }
 
-  if (
-    options.revalidateSeconds !== null &&
-    options.revalidateSeconds > 0 &&
-    options.revalidateSeconds !== Infinity
-  ) {
-    return {
-      cacheControl: buildRevalidateCacheControl(options.revalidateSeconds),
-      cacheState: options.isProduction ? "MISS" : undefined,
-      shouldWriteToCache: options.isProduction,
-    };
-  }
+    if (
+        options.revalidateSeconds !== null &&
+        options.revalidateSeconds > 0 &&
+        options.revalidateSeconds !== Infinity
+    ) {
+        return {
+            cacheControl: buildRevalidateCacheControl(
+                options.revalidateSeconds,
+            ),
+            cacheState: options.isProduction ? 'MISS' : undefined,
+            shouldWriteToCache: options.isProduction,
+        };
+    }
 
-  if (options.revalidateSeconds === Infinity) {
-    return {
-      cacheControl: STATIC_CACHE_CONTROL,
-      cacheState: "STATIC",
-      shouldWriteToCache: false,
-    };
-  }
+    if (options.revalidateSeconds === Infinity) {
+        return {
+            cacheControl: STATIC_CACHE_CONTROL,
+            cacheState: 'STATIC',
+            shouldWriteToCache: false,
+        };
+    }
 
-  return { shouldWriteToCache: false };
+    return { shouldWriteToCache: false };
 }
 
 export function buildAppPageRscResponse(
-  body: ReadableStream,
-  options: BuildAppPageRscResponseOptions,
+    body: ReadableStream,
+    options: BuildAppPageRscResponseOptions,
 ): Response {
-  const headers = new Headers({
-    "Content-Type": "text/x-component; charset=utf-8",
-    Vary: "RSC, Accept",
-  });
+    const headers = new Headers({
+        'Content-Type': 'text/x-component; charset=utf-8',
+        Vary: 'RSC, Accept',
+    });
 
-  if (options.params && Object.keys(options.params).length > 0) {
-    headers.set("X-Vinext-Params", JSON.stringify(options.params));
-  }
-  if (options.policy.cacheControl) {
-    headers.set("Cache-Control", options.policy.cacheControl);
-  }
-  if (options.policy.cacheState) {
-    headers.set("X-Vinext-Cache", options.policy.cacheState);
-  }
-
-  if (options.middlewareContext.headers) {
-    for (const [key, value] of options.middlewareContext.headers) {
-      const lowerKey = key.toLowerCase();
-      if (lowerKey === "set-cookie" || lowerKey === "vary") {
-        headers.append(key, value);
-      } else {
-        // Keep parity with the old inline RSC path: middleware owns singular
-        // response headers like Cache-Control here, while Set-Cookie and Vary
-        // are accumulated. The HTML helper intentionally keeps its legacy
-        // append-for-everything behavior below.
-        headers.set(key, value);
-      }
+    if (options.params && Object.keys(options.params).length > 0) {
+        headers.set(
+            'X-Vinext-Params',
+            encodeURIComponent(JSON.stringify(options.params)),
+        );
     }
-  }
+    if (options.policy.cacheControl) {
+        headers.set('Cache-Control', options.policy.cacheControl);
+    }
+    if (options.policy.cacheState) {
+        headers.set('X-Vinext-Cache', options.policy.cacheState);
+    }
 
-  applyTimingHeader(headers, options.timing);
+    if (options.middlewareContext.headers) {
+        for (const [key, value] of options.middlewareContext.headers) {
+            const lowerKey = key.toLowerCase();
+            if (lowerKey === 'set-cookie' || lowerKey === 'vary') {
+                headers.append(key, value);
+            } else {
+                // Keep parity with the old inline RSC path: middleware owns singular
+                // response headers like Cache-Control here, while Set-Cookie and Vary
+                // are accumulated. The HTML helper intentionally keeps its legacy
+                // append-for-everything behavior below.
+                headers.set(key, value);
+            }
+        }
+    }
 
-  return new Response(body, {
-    status: options.middlewareContext.status ?? 200,
-    headers,
-  });
+    applyTimingHeader(headers, options.timing);
+
+    return new Response(body, {
+        status: options.middlewareContext.status ?? 200,
+        headers,
+    });
 }
 
 export function buildAppPageHtmlResponse(
-  body: ReadableStream,
-  options: BuildAppPageHtmlResponseOptions,
+    body: ReadableStream,
+    options: BuildAppPageHtmlResponseOptions,
 ): Response {
-  const headers = new Headers({
-    "Content-Type": "text/html; charset=utf-8",
-    Vary: "RSC, Accept",
-  });
+    const headers = new Headers({
+        'Content-Type': 'text/html; charset=utf-8',
+        Vary: 'RSC, Accept',
+    });
 
-  if (options.policy.cacheControl) {
-    headers.set("Cache-Control", options.policy.cacheControl);
-  }
-  if (options.policy.cacheState) {
-    headers.set("X-Vinext-Cache", options.policy.cacheState);
-  }
-  if (options.draftCookie) {
-    headers.append("Set-Cookie", options.draftCookie);
-  }
-  if (options.fontLinkHeader) {
-    headers.set("Link", options.fontLinkHeader);
-  }
-
-  if (options.middlewareContext.headers) {
-    for (const [key, value] of options.middlewareContext.headers) {
-      headers.append(key, value);
+    if (options.policy.cacheControl) {
+        headers.set('Cache-Control', options.policy.cacheControl);
     }
-  }
+    if (options.policy.cacheState) {
+        headers.set('X-Vinext-Cache', options.policy.cacheState);
+    }
+    if (options.draftCookie) {
+        headers.append('Set-Cookie', options.draftCookie);
+    }
+    if (options.fontLinkHeader) {
+        headers.set('Link', options.fontLinkHeader);
+    }
 
-  applyTimingHeader(headers, options.timing);
+    if (options.middlewareContext.headers) {
+        for (const [key, value] of options.middlewareContext.headers) {
+            headers.append(key, value);
+        }
+    }
 
-  return new Response(body, {
-    status: options.middlewareContext.status ?? 200,
-    headers,
-  });
+    applyTimingHeader(headers, options.timing);
+
+    return new Response(body, {
+        status: options.middlewareContext.status ?? 200,
+        headers,
+    });
 }

--- a/tests/app-page-response.test.ts
+++ b/tests/app-page-response.test.ts
@@ -1,270 +1,304 @@
-import { describe, expect, it } from "vite-plus/test";
+import { describe, expect, it } from 'vite-plus/test';
 import {
-  buildAppPageHtmlResponse,
-  buildAppPageRscResponse,
-  resolveAppPageHtmlResponsePolicy,
-  resolveAppPageRscResponsePolicy,
-} from "../packages/vinext/src/server/app-page-response.js";
+    buildAppPageHtmlResponse,
+    buildAppPageRscResponse,
+    resolveAppPageHtmlResponsePolicy,
+    resolveAppPageRscResponsePolicy,
+} from '../packages/vinext/src/server/app-page-response.js';
 
 function createBody(text: string): ReadableStream {
-  return new ReadableStream({
-    start(controller) {
-      controller.enqueue(new TextEncoder().encode(text));
-      controller.close();
-    },
-  });
+    return new ReadableStream({
+        start(controller) {
+            controller.enqueue(new TextEncoder().encode(text));
+            controller.close();
+        },
+    });
 }
 
-describe("app page response helpers", () => {
-  it("resolves RSC response policy for static and ISR responses", () => {
-    expect(
-      resolveAppPageRscResponsePolicy({
-        dynamicUsedDuringBuild: false,
-        isDynamicError: false,
-        isForceDynamic: false,
-        isForceStatic: true,
-        isProduction: true,
-        revalidateSeconds: null,
-      }),
-    ).toEqual({
-      cacheControl: "s-maxage=31536000, stale-while-revalidate",
-      cacheState: "STATIC",
+describe('app page response helpers', () => {
+    it('resolves RSC response policy for static and ISR responses', () => {
+        expect(
+            resolveAppPageRscResponsePolicy({
+                dynamicUsedDuringBuild: false,
+                isDynamicError: false,
+                isForceDynamic: false,
+                isForceStatic: true,
+                isProduction: true,
+                revalidateSeconds: null,
+            }),
+        ).toEqual({
+            cacheControl: 's-maxage=31536000, stale-while-revalidate',
+            cacheState: 'STATIC',
+        });
+
+        expect(
+            resolveAppPageRscResponsePolicy({
+                dynamicUsedDuringBuild: false,
+                isDynamicError: false,
+                isForceDynamic: false,
+                isForceStatic: false,
+                isProduction: true,
+                revalidateSeconds: 60,
+            }),
+        ).toEqual({
+            cacheControl: 's-maxage=60, stale-while-revalidate',
+            cacheState: 'MISS',
+        });
     });
 
-    expect(
-      resolveAppPageRscResponsePolicy({
-        dynamicUsedDuringBuild: false,
-        isDynamicError: false,
-        isForceDynamic: false,
-        isForceStatic: false,
-        isProduction: true,
-        revalidateSeconds: 60,
-      }),
-    ).toEqual({
-      cacheControl: "s-maxage=60, stale-while-revalidate",
-      cacheState: "MISS",
-    });
-  });
+    it('resolves RSC response policy for force-dynamic, infinity, and default cases', () => {
+        expect(
+            resolveAppPageRscResponsePolicy({
+                dynamicUsedDuringBuild: false,
+                isDynamicError: false,
+                isForceDynamic: true,
+                isForceStatic: false,
+                isProduction: true,
+                revalidateSeconds: 60,
+            }),
+        ).toEqual({
+            cacheControl: 'no-store, must-revalidate',
+        });
 
-  it("resolves RSC response policy for force-dynamic, infinity, and default cases", () => {
-    expect(
-      resolveAppPageRscResponsePolicy({
-        dynamicUsedDuringBuild: false,
-        isDynamicError: false,
-        isForceDynamic: true,
-        isForceStatic: false,
-        isProduction: true,
-        revalidateSeconds: 60,
-      }),
-    ).toEqual({
-      cacheControl: "no-store, must-revalidate",
-    });
+        expect(
+            resolveAppPageRscResponsePolicy({
+                dynamicUsedDuringBuild: false,
+                isDynamicError: false,
+                isForceDynamic: false,
+                isForceStatic: false,
+                isProduction: true,
+                revalidateSeconds: Infinity,
+            }),
+        ).toEqual({
+            cacheControl: 's-maxage=31536000, stale-while-revalidate',
+            cacheState: 'STATIC',
+        });
 
-    expect(
-      resolveAppPageRscResponsePolicy({
-        dynamicUsedDuringBuild: false,
-        isDynamicError: false,
-        isForceDynamic: false,
-        isForceStatic: false,
-        isProduction: true,
-        revalidateSeconds: Infinity,
-      }),
-    ).toEqual({
-      cacheControl: "s-maxage=31536000, stale-while-revalidate",
-      cacheState: "STATIC",
+        expect(
+            resolveAppPageRscResponsePolicy({
+                dynamicUsedDuringBuild: false,
+                isDynamicError: false,
+                isForceDynamic: false,
+                isForceStatic: false,
+                isProduction: true,
+                revalidateSeconds: null,
+            }),
+        ).toEqual({});
     });
 
-    expect(
-      resolveAppPageRscResponsePolicy({
-        dynamicUsedDuringBuild: false,
-        isDynamicError: false,
-        isForceDynamic: false,
-        isForceStatic: false,
-        isProduction: true,
-        revalidateSeconds: null,
-      }),
-    ).toEqual({});
-  });
-
-  it("resolves RSC response policy as no-store when dynamic usage is detected during build", () => {
-    expect(
-      resolveAppPageRscResponsePolicy({
-        dynamicUsedDuringBuild: true,
-        isDynamicError: false,
-        isForceDynamic: false,
-        isForceStatic: false,
-        isProduction: true,
-        revalidateSeconds: 60,
-      }),
-    ).toEqual({
-      cacheControl: "no-store, must-revalidate",
-    });
-  });
-
-  it("resolves HTML response policy precedence", () => {
-    expect(
-      resolveAppPageHtmlResponsePolicy({
-        dynamicUsedDuringRender: true,
-        isDynamicError: false,
-        isForceDynamic: false,
-        isForceStatic: false,
-        isProduction: true,
-        revalidateSeconds: 60,
-      }),
-    ).toEqual({
-      cacheControl: "no-store, must-revalidate",
-      shouldWriteToCache: false,
+    it('resolves RSC response policy as no-store when dynamic usage is detected during build', () => {
+        expect(
+            resolveAppPageRscResponsePolicy({
+                dynamicUsedDuringBuild: true,
+                isDynamicError: false,
+                isForceDynamic: false,
+                isForceStatic: false,
+                isProduction: true,
+                revalidateSeconds: 60,
+            }),
+        ).toEqual({
+            cacheControl: 'no-store, must-revalidate',
+        });
     });
 
-    expect(
-      resolveAppPageHtmlResponsePolicy({
-        dynamicUsedDuringRender: false,
-        isDynamicError: false,
-        isForceDynamic: false,
-        isForceStatic: false,
-        isProduction: false,
-        revalidateSeconds: 60,
-      }),
-    ).toEqual({
-      cacheControl: "s-maxage=60, stale-while-revalidate",
-      cacheState: undefined,
-      shouldWriteToCache: false,
+    it('resolves HTML response policy precedence', () => {
+        expect(
+            resolveAppPageHtmlResponsePolicy({
+                dynamicUsedDuringRender: true,
+                isDynamicError: false,
+                isForceDynamic: false,
+                isForceStatic: false,
+                isProduction: true,
+                revalidateSeconds: 60,
+            }),
+        ).toEqual({
+            cacheControl: 'no-store, must-revalidate',
+            shouldWriteToCache: false,
+        });
+
+        expect(
+            resolveAppPageHtmlResponsePolicy({
+                dynamicUsedDuringRender: false,
+                isDynamicError: false,
+                isForceDynamic: false,
+                isForceStatic: false,
+                isProduction: false,
+                revalidateSeconds: 60,
+            }),
+        ).toEqual({
+            cacheControl: 's-maxage=60, stale-while-revalidate',
+            cacheState: undefined,
+            shouldWriteToCache: false,
+        });
+
+        expect(
+            resolveAppPageHtmlResponsePolicy({
+                dynamicUsedDuringRender: false,
+                isDynamicError: false,
+                isForceDynamic: false,
+                isForceStatic: false,
+                isProduction: true,
+                revalidateSeconds: Infinity,
+            }),
+        ).toEqual({
+            cacheControl: 's-maxage=31536000, stale-while-revalidate',
+            cacheState: 'STATIC',
+            shouldWriteToCache: false,
+        });
     });
 
-    expect(
-      resolveAppPageHtmlResponsePolicy({
-        dynamicUsedDuringRender: false,
-        isDynamicError: false,
-        isForceDynamic: false,
-        isForceStatic: false,
-        isProduction: true,
-        revalidateSeconds: Infinity,
-      }),
-    ).toEqual({
-      cacheControl: "s-maxage=31536000, stale-while-revalidate",
-      cacheState: "STATIC",
-      shouldWriteToCache: false,
-    });
-  });
-
-  it("resolves HTML response policy when cache writes stay enabled", () => {
-    expect(
-      resolveAppPageHtmlResponsePolicy({
-        dynamicUsedDuringRender: false,
-        isDynamicError: false,
-        isForceDynamic: false,
-        isForceStatic: false,
-        isProduction: true,
-        revalidateSeconds: 60,
-      }),
-    ).toEqual({
-      cacheControl: "s-maxage=60, stale-while-revalidate",
-      cacheState: "MISS",
-      shouldWriteToCache: true,
-    });
-  });
-
-  it("treats force-static with explicit revalidate as ISR in both policy helpers", () => {
-    expect(
-      resolveAppPageRscResponsePolicy({
-        dynamicUsedDuringBuild: false,
-        isDynamicError: false,
-        isForceDynamic: false,
-        isForceStatic: true,
-        isProduction: true,
-        revalidateSeconds: 60,
-      }),
-    ).toEqual({
-      cacheControl: "s-maxage=60, stale-while-revalidate",
-      cacheState: "MISS",
+    it('resolves HTML response policy when cache writes stay enabled', () => {
+        expect(
+            resolveAppPageHtmlResponsePolicy({
+                dynamicUsedDuringRender: false,
+                isDynamicError: false,
+                isForceDynamic: false,
+                isForceStatic: false,
+                isProduction: true,
+                revalidateSeconds: 60,
+            }),
+        ).toEqual({
+            cacheControl: 's-maxage=60, stale-while-revalidate',
+            cacheState: 'MISS',
+            shouldWriteToCache: true,
+        });
     });
 
-    expect(
-      resolveAppPageHtmlResponsePolicy({
-        dynamicUsedDuringRender: false,
-        isDynamicError: false,
-        isForceDynamic: false,
-        isForceStatic: true,
-        isProduction: true,
-        revalidateSeconds: 60,
-      }),
-    ).toEqual({
-      cacheControl: "s-maxage=60, stale-while-revalidate",
-      cacheState: "MISS",
-      shouldWriteToCache: true,
-    });
-  });
+    it('treats force-static with explicit revalidate as ISR in both policy helpers', () => {
+        expect(
+            resolveAppPageRscResponsePolicy({
+                dynamicUsedDuringBuild: false,
+                isDynamicError: false,
+                isForceDynamic: false,
+                isForceStatic: true,
+                isProduction: true,
+                revalidateSeconds: 60,
+            }),
+        ).toEqual({
+            cacheControl: 's-maxage=60, stale-while-revalidate',
+            cacheState: 'MISS',
+        });
 
-  it("builds RSC responses with params, middleware headers, and timing", async () => {
-    const middlewareHeaders = new Headers();
-    middlewareHeaders.set("cache-control", "private, max-age=5");
-    middlewareHeaders.append("set-cookie", "session=abc; Path=/");
-    middlewareHeaders.append("vary", "Next-Router-State-Tree");
-
-    const response = buildAppPageRscResponse(createBody("flight"), {
-      middlewareContext: {
-        headers: middlewareHeaders,
-        status: 202,
-      },
-      params: { slug: "test" },
-      policy: {
-        cacheControl: "s-maxage=60, stale-while-revalidate",
-        cacheState: "MISS",
-      },
-      timing: {
-        compileEnd: 15,
-        handlerStart: 10,
-        responseKind: "rsc",
-      },
+        expect(
+            resolveAppPageHtmlResponsePolicy({
+                dynamicUsedDuringRender: false,
+                isDynamicError: false,
+                isForceDynamic: false,
+                isForceStatic: true,
+                isProduction: true,
+                revalidateSeconds: 60,
+            }),
+        ).toEqual({
+            cacheControl: 's-maxage=60, stale-while-revalidate',
+            cacheState: 'MISS',
+            shouldWriteToCache: true,
+        });
     });
 
-    expect(response.status).toBe(202);
-    expect(response.headers.get("content-type")).toBe("text/x-component; charset=utf-8");
-    expect(response.headers.get("x-vinext-params")).toBe('{"slug":"test"}');
-    expect(response.headers.get("cache-control")).toBe("private, max-age=5");
-    expect(response.headers.get("x-vinext-cache")).toBe("MISS");
-    expect(response.headers.get("vary")).toBe("RSC, Accept, Next-Router-State-Tree");
-    expect(response.headers.get("x-vinext-timing")).toBe("10,5,-1");
-    await expect(response.text()).resolves.toBe("flight");
-  });
+    it('builds RSC responses with params, middleware headers, and timing', async () => {
+        const middlewareHeaders = new Headers();
+        middlewareHeaders.set('cache-control', 'private, max-age=5');
+        middlewareHeaders.append('set-cookie', 'session=abc; Path=/');
+        middlewareHeaders.append('vary', 'Next-Router-State-Tree');
 
-  it("builds HTML responses with draft cookies, preload links, middleware, and timing", async () => {
-    const middlewareHeaders = new Headers();
-    middlewareHeaders.append("set-cookie", "mw=1; Path=/");
-    middlewareHeaders.append("x-extra", "present");
+        const response = buildAppPageRscResponse(createBody('flight'), {
+            middlewareContext: {
+                headers: middlewareHeaders,
+                status: 202,
+            },
+            params: { slug: 'test' },
+            policy: {
+                cacheControl: 's-maxage=60, stale-while-revalidate',
+                cacheState: 'MISS',
+            },
+            timing: {
+                compileEnd: 15,
+                handlerStart: 10,
+                responseKind: 'rsc',
+            },
+        });
 
-    const response = buildAppPageHtmlResponse(createBody("<h1>page</h1>"), {
-      draftCookie: "__prerender_bypass=token; Path=/",
-      fontLinkHeader: "</font.woff2>; rel=preload; as=font; type=font/woff2; crossorigin",
-      middlewareContext: {
-        headers: middlewareHeaders,
-        status: 203,
-      },
-      policy: {
-        cacheControl: "s-maxage=31536000, stale-while-revalidate",
-        cacheState: "STATIC",
-      },
-      timing: {
-        compileEnd: 12,
-        handlerStart: 10,
-        renderEnd: 20,
-        responseKind: "html",
-      },
+        expect(response.status).toBe(202);
+        expect(response.headers.get('content-type')).toBe(
+            'text/x-component; charset=utf-8',
+        );
+        expect(response.headers.get('x-vinext-params')).toBe(
+            encodeURIComponent('{"slug":"test"}'),
+        );
+        expect(response.headers.get('cache-control')).toBe(
+            'private, max-age=5',
+        );
+        expect(response.headers.get('x-vinext-cache')).toBe('MISS');
+        expect(response.headers.get('vary')).toBe(
+            'RSC, Accept, Next-Router-State-Tree',
+        );
+        expect(response.headers.get('x-vinext-timing')).toBe('10,5,-1');
+        await expect(response.text()).resolves.toBe('flight');
     });
 
-    expect(response.status).toBe(203);
-    expect(response.headers.get("content-type")).toBe("text/html; charset=utf-8");
-    expect(response.headers.get("cache-control")).toBe("s-maxage=31536000, stale-while-revalidate");
-    expect(response.headers.get("x-vinext-cache")).toBe("STATIC");
-    expect(response.headers.get("link")).toBe(
-      "</font.woff2>; rel=preload; as=font; type=font/woff2; crossorigin",
-    );
-    expect(response.headers.get("x-extra")).toBe("present");
-    expect(response.headers.get("x-vinext-timing")).toBe("10,2,8");
+    it('builds RSC responses with non-ASCII params without ByteString error', async () => {
+        const response = buildAppPageRscResponse(createBody('flight'), {
+            middlewareContext: {
+                headers: null,
+                status: null,
+            },
+            params: { slug: ['frontend', 'hooks', 'useState-완전정복'] },
+            policy: {},
+            timing: undefined,
+        });
 
-    const setCookies = response.headers.getSetCookie();
-    expect(setCookies).toContain("__prerender_bypass=token; Path=/");
-    expect(setCookies).toContain("mw=1; Path=/");
-    await expect(response.text()).resolves.toBe("<h1>page</h1>");
-  });
+        expect(response.status).toBe(200);
+        expect(response.headers.get('content-type')).toBe(
+            'text/x-component; charset=utf-8',
+        );
+        expect(response.headers.get('x-vinext-params')).toBe(
+            encodeURIComponent('{"slug":["frontend","hooks","한국어"]}'),
+        );
+        await expect(response.text()).resolves.toBe('flight');
+    });
+
+    it('builds HTML responses with draft cookies, preload links, middleware, and timing', async () => {
+        const middlewareHeaders = new Headers();
+        middlewareHeaders.append('set-cookie', 'mw=1; Path=/');
+        middlewareHeaders.append('x-extra', 'present');
+
+        const response = buildAppPageHtmlResponse(createBody('<h1>page</h1>'), {
+            draftCookie: '__prerender_bypass=token; Path=/',
+            fontLinkHeader:
+                '</font.woff2>; rel=preload; as=font; type=font/woff2; crossorigin',
+            middlewareContext: {
+                headers: middlewareHeaders,
+                status: 203,
+            },
+            policy: {
+                cacheControl: 's-maxage=31536000, stale-while-revalidate',
+                cacheState: 'STATIC',
+            },
+            timing: {
+                compileEnd: 12,
+                handlerStart: 10,
+                renderEnd: 20,
+                responseKind: 'html',
+            },
+        });
+
+        expect(response.status).toBe(203);
+        expect(response.headers.get('content-type')).toBe(
+            'text/html; charset=utf-8',
+        );
+        expect(response.headers.get('cache-control')).toBe(
+            's-maxage=31536000, stale-while-revalidate',
+        );
+        expect(response.headers.get('x-vinext-cache')).toBe('STATIC');
+        expect(response.headers.get('link')).toBe(
+            '</font.woff2>; rel=preload; as=font; type=font/woff2; crossorigin',
+        );
+        expect(response.headers.get('x-extra')).toBe('present');
+        expect(response.headers.get('x-vinext-timing')).toBe('10,2,8');
+
+        const setCookies = response.headers.getSetCookie();
+        expect(setCookies).toContain('__prerender_bypass=token; Path=/');
+        expect(setCookies).toContain('mw=1; Path=/');
+        await expect(response.text()).resolves.toBe('<h1>page</h1>');
+    });
 });


### PR DESCRIPTION
Non-ASCII characters in dynamic route parameters (e.g., Korean slugs) cause a ByteString TypeError when set as HTTP header values during RSC streaming. Percent-encode the JSON before setting the header.

Fixes #676 