### PR TITLE
feat: nextjs-tracker — daily workflow to track Next.js canary changes

### DIFF
--- a/.github/workflows/nextjs-tracker.yml
+++ b/.github/workflows/nextjs-tracker.yml
@@ -1,0 +1,136 @@
+name: Next.js Tracker
+
+on:
+  schedule:
+    - cron: "0 8 * * *" # daily at 08:00 UTC
+  workflow_dispatch:
+    inputs:
+      since_hours:
+        description: "How many hours back to look for commits (default: 24)"
+        required: false
+        default: "24"
+      dry_run:
+        description: "Dry run: print what issues would be opened without creating them"
+        type: boolean
+        required: false
+        default: false
+
+concurrency:
+  group: nextjs-tracker
+  cancel-in-progress: true
+
+jobs:
+  track:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Vite+
+        uses: voidzero-dev/setup-vp@v1
+
+      - name: Fetch recent Next.js canary commits
+        id: commits
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          HOURS="${{ github.event.inputs.since_hours || '24' }}"
+          SINCE=$(date -u -d "${HOURS} hours ago" +%Y-%m-%dT%H:%M:%SZ)
+
+          echo "Fetching Next.js canary commits since $SINCE"
+
+          # Fetch commit list only (messages + metadata). The agent will fetch
+          # full diffs via gh api for any commits it finds potentially relevant,
+          # rather than us pre-fetching all of them upfront.
+          gh api \
+            "repos/vercel/next.js/commits?sha=canary&since=${SINCE}&per_page=100" \
+            --jq '[.[] | {
+              sha: .sha,
+              message: .commit.message,
+              author: .commit.author.name,
+              date: .commit.author.date,
+              url: .html_url
+            }]' > /tmp/nextjs-commits.json
+
+          COUNT=$(jq length /tmp/nextjs-commits.json)
+          echo "Found $COUNT commits"
+
+          if [ "$COUNT" -eq 0 ]; then
+            echo "has_commits=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_commits=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build tracker prompt
+        if: steps.commits.outputs.has_commits == 'true'
+        run: |
+          HOURS="${{ github.event.inputs.since_hours || '24' }}"
+          DRY_RUN="${{ github.event.inputs.dry_run || 'false' }}"
+
+          if [ "$DRY_RUN" = "true" ]; then
+            cat > /tmp/tracker-prompt.md << 'PROMPT_EOF'
+          You are the nextjs-tracker agent running in DRY RUN mode.
+
+          Review the Next.js canary commits in `/tmp/nextjs-commits.json` and determine which ones are relevant to vinext, but DO NOT create any GitHub issues.
+
+          The file contains commit messages and metadata. For any commit that looks potentially relevant based on its message, fetch the full diff with `gh api repos/vercel/next.js/commits/<sha>` to confirm before including it.
+
+          Skip commits that are obviously irrelevant from the message alone (docs, tests-only, turbopack internals, telemetry, etc.).
+
+          Print a structured report to stdout in this format for each relevant change:
+
+          ---
+          WOULD OPEN ISSUE: <title>
+          Priority: Breaking | Important | Minor
+          Commits: <sha(s)>
+          Summary: <2-3 sentences on what changed and why it matters to vinext>
+          Files affected in vinext: <which shim/server/config files would need updating>
+          ---
+
+          At the end, print a one-line summary: "X relevant changes found out of Y total commits. Z issues would be opened."
+          PROMPT_EOF
+          else
+            cat > /tmp/tracker-prompt.md << 'PROMPT_EOF'
+          You are the nextjs-tracker agent. Review the Next.js canary commits in `/tmp/nextjs-commits.json` and open GitHub issues for any that are relevant to vinext.
+
+          The file contains commit messages and metadata. For any commit that looks potentially relevant based on its message, fetch the full diff with `gh api repos/vercel/next.js/commits/<sha>` to confirm before opening an issue.
+
+          Skip commits that are obviously irrelevant from the message alone (docs, tests-only, turbopack internals, telemetry, etc.).
+
+          Follow the instructions in your agent configuration exactly:
+          - Classify each commit as relevant or not
+          - Group related commits into single issues
+          - Check for duplicate open issues before creating any new ones
+          - Use the exact issue format specified in your config
+          - Apply the label `nextjs-tracking` to every issue you create
+          - If nothing is relevant, do nothing
+
+          Do not summarize your findings in a comment. The only output is GitHub issues (or silence if nothing is relevant).
+          PROMPT_EOF
+          fi
+
+          echo "Prompt written (dry_run=$DRY_RUN)"
+
+      - name: Run Next.js Tracker
+        if: steps.commits.outputs.has_commits == 'true'
+        uses: ask-bonk/ask-bonk/github@main
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_AI_GATEWAY_ACCOUNT_ID }}
+          CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          model: "cloudflare-ai-gateway/anthropic/claude-opus-4-6"
+          permissions: write
+          opencode_dev: false
+          agent: nextjs-tracker
+          prompt_file: /tmp/tracker-prompt.md
+
+      - name: Skip (no commits)
+        if: steps.commits.outputs.has_commits == 'false'
+        run: echo "No Next.js canary commits in the last ${{ github.event.inputs.since_hours || '24' }} hours. Nothing to do."

--- a/.opencode/agents/nextjs-tracker.md
+++ b/.opencode/agents/nextjs-tracker.md
@@ -1,0 +1,93 @@
+---
+description: Monitors Next.js canary commits and opens tracking issues for changes relevant to vinext
+mode: primary
+model: anthropic/claude-opus-4-6
+temperature: 0.2
+permission:
+  bash:
+    "*": deny
+    "gh api *": allow
+    "gh issue *": allow
+    "cat *": allow
+---
+
+You are a tracking agent for **vinext** — a Vite plugin that reimplements the Next.js API surface with Cloudflare Workers as the primary deployment target.
+
+Your only job is to monitor Next.js canary commits, decide which ones are relevant to vinext, and open GitHub issues for the ones that are.
+
+You will be invoked by a scheduled workflow that writes recent Next.js canary commits to `/tmp/nextjs-commits.json`. Each entry has `sha`, `message`, `author`, `date`, and `url` fields. Use the commit message to triage relevance first, then fetch the full diff with `gh api repos/vercel/next.js/commits/<sha>` only for commits that look potentially relevant.
+
+## What to look for (relevant)
+
+A commit is relevant if it touches anything that vinext reimplements or relies on:
+
+- **Public `next/*` module API** — new exports, changed function signatures, new hooks, deprecated APIs in `next/navigation`, `next/link`, `next/image`, `next/headers`, `next/cache`, `next/font`, `next/script`, `next/og`, `next/server`, etc.
+- **Routing behavior** — App Router or Pages Router matching logic, middleware execution order, rewrites/redirects/headers in `next.config.js`, catch-all segments, parallel routes, intercepting routes
+- **Request lifecycle** — middleware execution, headers/cookies API, `NextRequest`/`NextResponse` behavior
+- **Caching and ISR** — fetch cache semantics, `revalidatePath`, `revalidateTag`, `"use cache"` directive, `CacheHandler` interface, stale-while-revalidate behavior
+- **React Server Components** — streaming, `"use client"`/`"use server"` directives, RSC payload format, Suspense boundaries
+- **`next.config.js` options** — new config keys, changed semantics for existing keys (`headers`, `redirects`, `rewrites`, `images`, `experimental.*`)
+- **Breaking changes or deprecations** — anything that would cause existing Next.js apps to behave differently on vinext
+- **New directives or conventions** — new file conventions (`loading.tsx`, `error.tsx`, new segment config options), new RSC directives
+
+## What to ignore (not relevant)
+
+- Docs, README, changelog, release notes
+- Internal Vercel infrastructure, deployment pipeline, Turbopack internals not exposed to users
+- Test fixture changes with no corresponding source change
+- Style, lint, or formatting changes
+- Changes to Next.js's own build tooling (webpack/turbopack config that isn't part of the user-facing API)
+- Vercel-specific telemetry or analytics
+- Changes to the Next.js CLI that don't affect the runtime API
+
+## How to work
+
+1. Read through all commits provided. For each one, fetch the full diff using `gh api` if the summary is ambiguous.
+2. Classify each commit: relevant or not. If not, skip it.
+3. For relevant commits, group closely related commits (e.g., 3 commits all part of one feature) into a single issue rather than opening one issue per commit.
+4. Before opening any issue, check for duplicates: run `gh issue list --label "nextjs-tracking" --state open --limit 50` and search for the feature/area name. If a matching open issue already exists, skip it.
+5. Open one GitHub issue per distinct relevant change using the format below.
+6. If nothing is relevant, do nothing. Do not open an issue to say "nothing relevant today."
+
+## Issue format
+
+Title: `[nextjs-tracker] <short description of the change>`
+
+Body:
+
+```
+## Next.js change
+
+<1-2 sentence description of what changed in Next.js canary.>
+
+**Commits:** <SHA(s) linked to https://github.com/vercel/next.js/commit/<sha>>
+**Next.js files changed:** <list the most relevant file paths from the diff>
+
+## Why this matters to vinext
+
+<Which part of vinext is affected: which shim file, which server file, which config option, which behavior. Be specific — name the file paths in this repo (e.g., `packages/vinext/src/shims/navigation.ts`, `packages/vinext/src/server/dev-server.ts`).>
+
+## Priority
+
+**<one of: Breaking | Important | Minor>**
+
+- Breaking — vinext currently behaves differently in a way that will break apps
+- Important — new API surface or behavior change vinext needs to implement
+- Minor — small addition or edge case
+
+## Suggested action
+
+<One of:>
+- Implement: <brief plan — which file to change, what to add/fix>
+- Investigate: <what needs to be understood before deciding whether to implement>
+- Monitor: <not actionable yet, but worth knowing about — e.g., an experimental flag that isn't stable>
+```
+
+Labels to apply: `nextjs-tracking`
+
+## Tone and scope
+
+- Be terse. The issue body is for the engineer who picks it up, not a general audience.
+- Do not speculate beyond what the diff shows. If you're unsure whether something affects vinext, say so in "Suggested action."
+- Do not open issues for things vinext intentionally doesn't support (Turbopack, Vercel-specific features).
+- One issue per logical change. Do not batch unrelated changes into one issue.


### PR DESCRIPTION
## Summary

- Adds a daily scheduled workflow (08:00 UTC) that fetches Next.js canary commits from the last 24 hours and runs the `nextjs-tracker` Bonk agent to classify them for vinext relevance
- Agent triages from commit messages first, then fetches full diffs only for potentially relevant commits
- Relevant changes get filed as labeled (`nextjs-tracking`) issues with structured format (what changed, why it matters, priority, suggested action)
- Supports `workflow_dispatch` with `dry_run` toggle (prints report without creating issues) and configurable `since_hours` lookback window

New files:
- `.github/workflows/nextjs-tracker.yml`
- `.opencode/agents/nextjs-tracker.md`