### PR TITLE
fix: exclude react-server-dom-webpack from rsc/ssr dep optimizer

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -2306,7 +2306,14 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                     },
                   }),
               optimizeDeps: {
-                exclude: [...new Set([...incomingExclude, "vinext", "@vercel/og"])],
+                exclude: [
+                  ...new Set([
+                    ...incomingExclude,
+                    "vinext",
+                    "@vercel/og",
+                    "react-server-dom-webpack",
+                  ]),
+                ],
                 entries: appEntries,
               },
               build: {
@@ -2331,7 +2338,14 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                     },
                   }),
               optimizeDeps: {
-                exclude: [...new Set([...incomingExclude, "vinext", "@vercel/og"])],
+                exclude: [
+                  ...new Set([
+                    ...incomingExclude,
+                    "vinext",
+                    "@vercel/og",
+                    "react-server-dom-webpack",
+                  ]),
+                ],
                 entries: appEntries,
               },
               build: {

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -1136,6 +1136,23 @@ describe("App Router integration", () => {
     expect(clientInclude).toContain("react-dom/client");
   });
 
+  it("excludes react-server-dom-webpack from rsc/ssr optimizeDeps to prevent dep optimizer re-runs from invalidating the Flight client", () => {
+    // react-server-dom-webpack is the RSC Flight protocol implementation.
+    // If it's pre-bundled by the dep optimizer, any re-optimisation cascade
+    // (triggered by lazily-discovered user-land deps) invalidates the Flight
+    // client module mid-request. In-flight RSC streams then crash with
+    // "chunk.reason.enqueueModel is not a function" because chunk objects
+    // from the old module instance don't match the new module's functions.
+    //
+    // Excluding it from the dep optimizer means it's loaded through Vite's
+    // regular transform pipeline and is immune to re-optimisation invalidation.
+    const rscExclude = server.config.environments.rsc?.optimizeDeps?.exclude;
+    const ssrExclude = server.config.environments.ssr?.optimizeDeps?.exclude;
+
+    expect(rscExclude).toContain("react-server-dom-webpack");
+    expect(ssrExclude).toContain("react-server-dom-webpack");
+  });
+
   // ── CSRF protection for server actions ───────────────────────────────
   it("rejects server action POST with mismatched Origin header (CSRF protection)", async () => {
     const res = await fetch(`${baseUrl}/actions.rsc`, {


### PR DESCRIPTION
## Summary

- Excludes `react-server-dom-webpack` from `optimizeDeps` in both the `rsc` and `ssr` environments, preventing dep optimizer re-runs from invalidating the Flight client module mid-request

## Problem

When an App Router app has multiple routes that import different third-party packages, Vite's dep optimizer can re-run mid-request as it lazily discovers new user-land dependencies. A dep optimizer re-run re-bundles **all** pre-bundled modules, creating fresh module instances. In-flight RSC streams crash with `chunk.reason.enqueueModel is not a function` because Flight chunk objects created by the old `ReactPromise` constructor don't match functions from the new module instance.

## Fix

Excluding `react-server-dom-webpack` from the dep optimizer means it's loaded through Vite's regular transform pipeline (which works correctly with `noExternal: true`) and is completely immune to re-optimisation invalidation. The `exclude` intentionally overrides the RSC plugin's `include` for this package (Vite `exclude` takes priority over `include`), ensuring the Flight protocol modules live outside the dep optimizer's lifecycle.

Both the `rsc` and `ssr` environments are covered — the RSC side produces the Flight stream (`renderToReadableStream`) and the SSR side consumes it (`createFromReadableStream`), so both need protection from module invalidation.

Closes #672

## Test plan

- [x] New test verifies `react-server-dom-webpack` is in `optimizeDeps.exclude` for both `rsc` and `ssr` environments
- [x] Existing `optimizeDeps.entries` and `optimizeDeps.include` tests still pass
- [x] Full app-router test suite passes (272/272)