### PR TITLE
fix: nextjs-tracker workflow fails because prompt_file is not a valid action input

### DIFF
--- a/.github/workflows/nextjs-tracker.yml
+++ b/.github/workflows/nextjs-tracker.yml
@@ -67,9 +67,9 @@ jobs:
           fi
 
       - name: Build tracker prompt
+        id: build_prompt
         if: steps.commits.outputs.has_commits == 'true'
         run: |
-          HOURS="${{ github.event.inputs.since_hours || '24' }}"
           DRY_RUN="${{ github.event.inputs.dry_run || 'false' }}"
 
           if [ "$DRY_RUN" = "true" ]; then
@@ -114,7 +114,11 @@ jobs:
           PROMPT_EOF
           fi
 
-          echo "Prompt written (dry_run=$DRY_RUN)"
+          {
+            echo 'prompt<<PROMPT_DELIM'
+            cat /tmp/tracker-prompt.md
+            echo 'PROMPT_DELIM'
+          } >> "$GITHUB_OUTPUT"
 
       - name: Run Next.js Tracker
         if: steps.commits.outputs.has_commits == 'true'
@@ -129,7 +133,7 @@ jobs:
           permissions: write
           opencode_dev: false
           agent: nextjs-tracker
-          prompt_file: /tmp/tracker-prompt.md
+          prompt: ${{ steps.build_prompt.outputs.prompt }}
 
       - name: Skip (no commits)
         if: steps.commits.outputs.has_commits == 'false'


### PR DESCRIPTION
## Summary

- The `ask-bonk` action doesn't support a `prompt_file` input (valid inputs: `model`, `agent`, `prompt`, `mentions`, `permissions`, `oidc_base_url`, `forks`, `variant`, `token_permissions`, `opencode_version`, `opencode_dev`)
- The first scheduled run at 08:11 UTC today failed immediately with: `PROMPT input is required for scheduled and workflow_dispatch events`
- Fix: write the prompt to a multiline `$GITHUB_OUTPUT` in the "Build tracker prompt" step and reference it via `prompt: ${{ steps.build_prompt.outputs.prompt }}`

Failed run: https://github.com/cloudflare/vinext/actions/runs/23531220466