### PR TITLE
fix: anchor has/missing condition value regex for full-string matching

### DIFF
--- a/packages/vinext/src/config/config-matchers.ts
+++ b/packages/vinext/src/config/config-matchers.ts
@@ -573,7 +573,10 @@ function matchSingleCondition(
 function _cachedConditionRegex(value: string): RegExp | null {
   let re = _compiledConditionCache.get(value);
   if (re === undefined) {
-    re = safeRegExp(value);
+    // Anchor the regex to match the full value, not a substring.
+    // Matches Next.js: new RegExp(`^${hasItem.value}$`)
+    // Without anchoring, has:[cookie:role=admin] would match "not-admin".
+    re = safeRegExp(`^${value}$`);
     _compiledConditionCache.set(value, re);
   }
   return re;

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -10871,3 +10871,64 @@ describe("isSafeAttrName", () => {
     expect(isSafeAttrName("-foo")).toBe(false);
   });
 });
+
+// ── has/missing condition value matching (anchored regex) ──────────────────
+
+describe("checkHasConditions value anchoring", () => {
+  let checkHasConditions: Function;
+  let requestContextFromRequest: Function;
+
+  beforeEach(async () => {
+    const mod = await import("../packages/vinext/src/config/config-matchers.js");
+    checkHasConditions = mod.checkHasConditions;
+    requestContextFromRequest = mod.requestContextFromRequest;
+  });
+
+  it("exact value matches fully", () => {
+    const ctx = requestContextFromRequest(
+      new Request("http://localhost/", { headers: { cookie: "role=admin" } }),
+    );
+    const result = checkHasConditions(
+      [{ type: "cookie", key: "role", value: "admin" }],
+      undefined,
+      ctx,
+    );
+    expect(result).toBe(true);
+  });
+
+  it("does not match substring (anchored regex prevents partial match)", () => {
+    const ctx = requestContextFromRequest(
+      new Request("http://localhost/", { headers: { cookie: "role=not-admin" } }),
+    );
+    const result = checkHasConditions(
+      [{ type: "cookie", key: "role", value: "admin" }],
+      undefined,
+      ctx,
+    );
+    expect(result).toBe(false);
+  });
+
+  it("does not match superstring", () => {
+    const ctx = requestContextFromRequest(
+      new Request("http://localhost/", { headers: { cookie: "role=admin-temp" } }),
+    );
+    const result = checkHasConditions(
+      [{ type: "cookie", key: "role", value: "admin" }],
+      undefined,
+      ctx,
+    );
+    expect(result).toBe(false);
+  });
+
+  it("regex patterns still work with anchoring", () => {
+    const ctx = requestContextFromRequest(
+      new Request("http://localhost/", { headers: { "x-lang": "en-US" } }),
+    );
+    const result = checkHasConditions(
+      [{ type: "header", key: "x-lang", value: "en.*" }],
+      undefined,
+      ctx,
+    );
+    expect(result).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Config rule `has`/`missing` conditions now use anchored regex (`^value$`) for value matching, preventing partial substring matches.

## Details

Previously, `_cachedConditionRegex()` compiled the condition value as an unanchored regex via `safeRegExp(value)`. This meant a condition like `has: [{ type: "cookie", key: "role", value: "admin" }]` would match any cookie value *containing* "admin" as a substring (e.g., "not-admin", "admin-temp").

The fix anchors the regex with `^` and `$`, matching Next.js behavior (`prepare-destination.ts` uses `new RegExp(\`^\${hasItem.value}$\`)`).

Regex patterns in condition values continue to work correctly since anchoring just constrains them to match the full value.

## Tests

Adds 4 tests:
- Exact value matches fully
- Does not match substring
- Does not match superstring
- Regex patterns still work with anchoring