### PR TITLE
fix: use segment-wise pathname decoding in App->Pages Router fallback

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -38,6 +38,9 @@ const requestPipelinePath = fileURLToPath(
 const requestContextShimPath = fileURLToPath(
   new URL("../shims/request-context.js", import.meta.url),
 ).replace(/\\/g, "/");
+const normalizePathModulePath = fileURLToPath(
+  new URL("../server/normalize-path.js", import.meta.url),
+).replace(/\\/g, "/");
 const appRouteHandlerRuntimePath = fileURLToPath(
   new URL("../server/app-route-handler-runtime.js", import.meta.url),
 ).replace(/\\/g, "/");
@@ -357,6 +360,7 @@ ${middlewarePath ? `import * as middlewareModule from ${JSON.stringify(middlewar
 ${instrumentationPath ? `import * as _instrumentation from ${JSON.stringify(instrumentationPath.replace(/\\/g, "/"))};` : ""}
 ${effectiveMetaRoutes.length > 0 ? `import { sitemapToXml, robotsToText, manifestToJson } from ${JSON.stringify(fileURLToPath(new URL("../server/metadata-routes.js", import.meta.url)).replace(/\\/g, "/"))};` : ""}
 import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, matchHeaders, isExternalUrl, proxyExternalRequest, sanitizeDestination } from ${JSON.stringify(configMatchersPath)};
+import { decodePathParams as __decodePathParams } from ${JSON.stringify(normalizePathModulePath)};
 import { validateCsrfOrigin, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash, processMiddlewareHeaders } from ${JSON.stringify(requestPipelinePath)};
 import {
   isKnownDynamicAppRoute as __isKnownDynamicAppRoute,
@@ -1997,7 +2001,12 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     if (!isRscRequest) {
       const __pagesEntry = await import.meta.viteRsc.loadModule("ssr", "index");
       if (typeof __pagesEntry.renderPage === "function") {
-        const __pagesRes = await __pagesEntry.renderPage(request, decodeURIComponent(url.pathname) + (url.search || ""), {});
+        // Use segment-wise decoding to preserve encoded path delimiters (%2F).
+        // decodeURIComponent would turn /admin%2Fpanel into /admin/panel,
+        // changing the path structure and bypassing middleware matchers.
+        // Ported from Next.js: packages/next/src/server/lib/router-utils/decode-path-params.ts
+        // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/router-utils/decode-path-params.ts
+        const __pagesRes = await __pagesEntry.renderPage(request, __decodePathParams(url.pathname) + (url.search || ""), {});
         // Only return the Pages Router response if it matched a route
         // (non-404). A 404 means the path isn't a Pages route either,
         // so fall through to the App Router not-found page below.

--- a/packages/vinext/src/server/normalize-path.ts
+++ b/packages/vinext/src/server/normalize-path.ts
@@ -1,4 +1,43 @@
 /**
+ * Re-encode path delimiter characters that were decoded by decodeURIComponent.
+ * After decoding a URL segment, characters like / # ? \ need to be re-encoded
+ * so they don't change the path structure.
+ *
+ * Ported from Next.js: packages/next/src/shared/lib/router/utils/escape-path-delimiters.ts
+ * https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/router/utils/escape-path-delimiters.ts
+ */
+export function escapePathDelimiters(segment: string, escapeEncoded?: boolean): string {
+  return segment.replace(
+    new RegExp(`([/#?]${escapeEncoded ? "|%(2f|23|3f|5c)" : ""})`, "gi"),
+    (char: string) => encodeURIComponent(char),
+  );
+}
+
+/**
+ * Decode a URL pathname segment-by-segment, preserving encoded path delimiters.
+ * Non-ASCII characters (e.g. %C3%A9 -> e) are decoded, but structural characters
+ * like %2F (/) %23 (#) %3F (?) %5C (\) are re-encoded after decoding.
+ *
+ * This prevents encoded slashes from changing the path structure (e.g.
+ * /admin%2Fpanel stays as a single segment, not /admin/panel).
+ *
+ * Ported from Next.js: packages/next/src/server/lib/router-utils/decode-path-params.ts
+ * https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/router-utils/decode-path-params.ts
+ */
+export function decodePathParams(pathname: string): string {
+  return pathname
+    .split("/")
+    .map((seg) => {
+      try {
+        return escapePathDelimiters(decodeURIComponent(seg), true);
+      } catch {
+        return seg;
+      }
+    })
+    .join("/");
+}
+
+/**
  * Path normalization utility for request handling.
  *
  * Normalizes URL pathnames to a canonical form BEFORE any matching occurs

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -52,6 +52,7 @@ import { MetadataHead, mergeMetadata, resolveModuleMetadata, ViewportHead, merge
 
 
 import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, matchHeaders, isExternalUrl, proxyExternalRequest, sanitizeDestination } from "<ROOT>/packages/vinext/src/config/config-matchers.js";
+import { decodePathParams as __decodePathParams } from "<ROOT>/packages/vinext/src/server/normalize-path.js";
 import { validateCsrfOrigin, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash, processMiddlewareHeaders } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
 import {
   isKnownDynamicAppRoute as __isKnownDynamicAppRoute,
@@ -2245,6 +2246,7 @@ import { MetadataHead, mergeMetadata, resolveModuleMetadata, ViewportHead, merge
 
 
 import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, matchHeaders, isExternalUrl, proxyExternalRequest, sanitizeDestination } from "<ROOT>/packages/vinext/src/config/config-matchers.js";
+import { decodePathParams as __decodePathParams } from "<ROOT>/packages/vinext/src/server/normalize-path.js";
 import { validateCsrfOrigin, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash, processMiddlewareHeaders } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
 import {
   isKnownDynamicAppRoute as __isKnownDynamicAppRoute,
@@ -4441,6 +4443,7 @@ import { MetadataHead, mergeMetadata, resolveModuleMetadata, ViewportHead, merge
 
 
 import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, matchHeaders, isExternalUrl, proxyExternalRequest, sanitizeDestination } from "<ROOT>/packages/vinext/src/config/config-matchers.js";
+import { decodePathParams as __decodePathParams } from "<ROOT>/packages/vinext/src/server/normalize-path.js";
 import { validateCsrfOrigin, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash, processMiddlewareHeaders } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
 import {
   isKnownDynamicAppRoute as __isKnownDynamicAppRoute,
@@ -6643,6 +6646,7 @@ import { MetadataHead, mergeMetadata, resolveModuleMetadata, ViewportHead, merge
 import * as _instrumentation from "/tmp/test/instrumentation.ts";
 
 import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, matchHeaders, isExternalUrl, proxyExternalRequest, sanitizeDestination } from "<ROOT>/packages/vinext/src/config/config-matchers.js";
+import { decodePathParams as __decodePathParams } from "<ROOT>/packages/vinext/src/server/normalize-path.js";
 import { validateCsrfOrigin, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash, processMiddlewareHeaders } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
 import {
   isKnownDynamicAppRoute as __isKnownDynamicAppRoute,
@@ -8869,6 +8873,7 @@ import { MetadataHead, mergeMetadata, resolveModuleMetadata, ViewportHead, merge
 
 import { sitemapToXml, robotsToText, manifestToJson } from "<ROOT>/packages/vinext/src/server/metadata-routes.js";
 import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, matchHeaders, isExternalUrl, proxyExternalRequest, sanitizeDestination } from "<ROOT>/packages/vinext/src/config/config-matchers.js";
+import { decodePathParams as __decodePathParams } from "<ROOT>/packages/vinext/src/server/normalize-path.js";
 import { validateCsrfOrigin, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash, processMiddlewareHeaders } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
 import {
   isKnownDynamicAppRoute as __isKnownDynamicAppRoute,
@@ -11069,6 +11074,7 @@ import * as middlewareModule from "/tmp/test/middleware.ts";
 
 
 import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, matchHeaders, isExternalUrl, proxyExternalRequest, sanitizeDestination } from "<ROOT>/packages/vinext/src/config/config-matchers.js";
+import { decodePathParams as __decodePathParams } from "<ROOT>/packages/vinext/src/server/normalize-path.js";
 import { validateCsrfOrigin, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash, processMiddlewareHeaders } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
 import {
   isKnownDynamicAppRoute as __isKnownDynamicAppRoute,

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -2705,6 +2705,89 @@ describe("normalizePath", () => {
   });
 });
 
+// ── escapePathDelimiters / decodePathParams ────────────────────────────────
+// Ported from Next.js: packages/next/src/shared/lib/router/utils/escape-path-delimiters.ts
+// and packages/next/src/server/lib/router-utils/decode-path-params.ts
+
+describe("escapePathDelimiters", () => {
+  let escapePathDelimiters: (segment: string, escapeEncoded?: boolean) => string;
+
+  beforeEach(async () => {
+    const mod = await import("../packages/vinext/src/server/normalize-path.js");
+    escapePathDelimiters = mod.escapePathDelimiters;
+  });
+
+  it("re-encodes forward slash", () => {
+    expect(escapePathDelimiters("admin/panel")).toBe("admin%2Fpanel");
+  });
+
+  it("re-encodes hash and question mark", () => {
+    expect(escapePathDelimiters("foo#bar")).toBe("foo%23bar");
+    expect(escapePathDelimiters("foo?bar")).toBe("foo%3Fbar");
+  });
+
+  it("re-encodes already-encoded delimiters when escapeEncoded is true", () => {
+    expect(escapePathDelimiters("admin%2Fpanel", true)).toBe("admin%252Fpanel");
+    expect(escapePathDelimiters("foo%23bar", true)).toBe("foo%2523bar");
+    expect(escapePathDelimiters("foo%3Fbar", true)).toBe("foo%253Fbar");
+    expect(escapePathDelimiters("foo%5Cbar", true)).toBe("foo%255Cbar");
+  });
+
+  it("leaves non-delimiter characters unchanged", () => {
+    expect(escapePathDelimiters("café")).toBe("café");
+    expect(escapePathDelimiters("hello world")).toBe("hello world");
+  });
+});
+
+describe("decodePathParams", () => {
+  let decodePathParams: (pathname: string) => string;
+
+  beforeEach(async () => {
+    const mod = await import("../packages/vinext/src/server/normalize-path.js");
+    decodePathParams = mod.decodePathParams;
+  });
+
+  it("decodes non-ASCII characters within segments", () => {
+    expect(decodePathParams("/caf%C3%A9")).toBe("/café");
+    expect(decodePathParams("/%E6%97%A5%E6%9C%AC%E8%AA%9E")).toBe("/日本語");
+  });
+
+  it("preserves encoded slashes (%2F) - does not change path structure", () => {
+    expect(decodePathParams("/admin%2Fpanel")).toBe("/admin%2Fpanel");
+  });
+
+  it("preserves encoded hash (%23) and question mark (%3F)", () => {
+    expect(decodePathParams("/foo%23bar")).toBe("/foo%23bar");
+    expect(decodePathParams("/foo%3Fbar")).toBe("/foo%3Fbar");
+  });
+
+  it("decodes encoded backslash (%5C) since it is not a path delimiter", () => {
+    // Backslash is not a URL path delimiter (browsers normalize \ to / before
+    // sending). The escapePathDelimiters function only re-encodes /, #, and ?.
+    // %5C is decoded to \ and left as-is, matching Next.js behavior.
+    expect(decodePathParams("/foo%5Cbar")).toBe("/foo\\bar");
+  });
+
+  it("decodes mixed paths correctly", () => {
+    // Non-ASCII decoded, structural delimiters preserved
+    expect(decodePathParams("/caf%C3%A9/admin%2Fpanel")).toBe("/café/admin%2Fpanel");
+  });
+
+  it("handles already-decoded paths", () => {
+    expect(decodePathParams("/about")).toBe("/about");
+    expect(decodePathParams("/foo/bar/baz")).toBe("/foo/bar/baz");
+  });
+
+  it("handles malformed percent-encoding gracefully", () => {
+    // Should not throw, just return the segment as-is
+    expect(decodePathParams("/%E0%A4%A")).toBe("/%E0%A4%A");
+  });
+
+  it("handles root path", () => {
+    expect(decodePathParams("/")).toBe("/");
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Codegen parity tests (verify generated code matches runtime behavior)
 


### PR DESCRIPTION
## Summary

The App Router to Pages Router fallback now uses segment-wise pathname decoding instead of `decodeURIComponent`, preserving encoded path delimiters like `%2F`.

## Problem

The fallback path used `decodeURIComponent(url.pathname)`, which decoded `%2F` to `/`, changing the path structure. A request to `/security/admin%2Fpanel` would skip a middleware matcher for `/security/admin/:path*` (since `%2F` is not a segment delimiter in the encoded form), but the Pages fallback would decode it to `/security/admin/panel` and serve the protected page.

## Fix

Replace `decodeURIComponent` with `decodePathParams()`, which:
1. Splits the pathname by `/`
2. Decodes each segment individually with `decodeURIComponent`
3. Re-encodes path delimiters (`/`, `#`, `?`) via `escapePathDelimiters`
4. Rejoins with `/`

This decodes non-ASCII characters within segments (e.g., `%C3%A9` -> `e`) but preserves the path structure (`%2F` stays as `%2F`).

Both utilities are ported from Next.js:
- [`escapePathDelimiters`](https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/router/utils/escape-path-delimiters.ts)
- [`decodePathParams`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/router-utils/decode-path-params.ts)

## Tests

- `escapePathDelimiters`: 4 tests (slash, hash, question mark, encoded forms, non-delimiters)
- `decodePathParams`: 8 tests (non-ASCII decode, %2F preservation, %23/%3F preservation, mixed paths, malformed encoding, root path)