### PR TITLE
fix(fonts): double-comma syntax error when font options have a trailing comma

### DIFF
--- a/packages/vinext/src/plugins/fonts.ts
+++ b/packages/vinext/src/plugins/fonts.ts
@@ -584,9 +584,15 @@ export function createGoogleFontsPlugin(fontGoogleShimPath: string, shimsDir: st
           // Inject _selfHostedCSS into the options object
           const escapedCSS = JSON.stringify(localCSS);
           const closingBrace = optionsStr.lastIndexOf("}");
+          const beforeBrace = optionsStr.slice(0, closingBrace).trim();
+          // Determine the separator to insert before the new property:
+          //   - Empty string if the object is empty ({ is the last non-whitespace char)
+          //   - Empty string if there's already a trailing comma (avoid double comma)
+          //   - ", " otherwise (before the new property)
+          const separator = beforeBrace.endsWith("{") || beforeBrace.endsWith(",") ? "" : ", ";
           const optionsWithCSS =
             optionsStr.slice(0, closingBrace) +
-            (optionsStr.slice(0, closingBrace).trim().endsWith("{") ? "" : ", ") +
+            separator +
             `_selfHostedCSS: ${escapedCSS}` +
             optionsStr.slice(closingBrace);
 

--- a/tests/font-google.test.ts
+++ b/tests/font-google.test.ts
@@ -513,6 +513,44 @@ describe("vinext:google-fonts plugin", () => {
     }
   });
 
+  it("does not produce double-comma when font options have a trailing comma", async () => {
+    // Regression test: Inter({ subsets: ["latin"], }) already has a trailing comma.
+    // injectSelfHostedCss must not prepend another ", " making the object literal
+    // {subsets: ["latin"],, _selfHostedCSS: "..."} which is a syntax error.
+    const plugin = getGoogleFontsPlugin();
+    const root = path.join(import.meta.dirname, ".test-font-root-trailing-comma");
+    initPlugin(plugin, { command: "build", root });
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () =>
+      new Response("@font-face { font-family: 'Inter'; src: url(/inter.woff2); }", {
+        status: 200,
+        headers: { "content-type": "text/css" },
+      });
+
+    try {
+      const transform = unwrapHook(plugin.transform);
+      // Note the trailing comma after "latin": Inter({ subsets: ["latin"], })
+      const code = [
+        `import { Inter } from 'next/font/google';`,
+        `const inter = Inter({`,
+        `  subsets: ["latin"],`,
+        `});`,
+      ].join("\n");
+
+      const result = await transform.call(plugin, code, "/app/layout.tsx");
+      expect(result).not.toBeNull();
+      expect(result.code).toContain("_selfHostedCSS");
+      // Must not have a double-comma — that would be a JS syntax error
+      expect(result.code).not.toMatch(/,\s*,/);
+      // Verify the generated code is syntactically valid by checking structure
+      expect(result.code).toContain('_selfHostedCSS: "');
+    } finally {
+      globalThis.fetch = originalFetch;
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("self-hosts aliased lowercase font imports during build", async () => {
     const plugin = getGoogleFontsPlugin();
     const root = path.join(import.meta.dirname, ".test-font-root-alias");


### PR DESCRIPTION
Problem

`vinext build` failed with a cryptic `[builtin:vite-transform] Error: Unexpected token in app/layout.tsx at 191..192` for any project that used `next/font/google` with trailing-comma style (common with Prettier defaults):

```ts
const inter = Inter({
  subsets: ["latin"],  // ← trailing comma
});
```

The error position and file name were both misleading — the reported byte offset pointed into `function Layout` in the original source, but the actual failure was in the **transformed** code produced by the `vinext:google-fonts` Vite plugin.

## Root cause

`injectSelfHostedCss` (in `packages/vinext/src/plugins/fonts.ts`) injects a `_selfHostedCSS` property into the font constructor's options object at build time. It computed the separator before the new property as:

```ts
// separator = "" if object is empty, ", " otherwise
optionsStr.slice(0, closingBrace).trim().endsWith("{") ? "" : ", "
```

This only handled the empty-object case. When the options already had a trailing comma, the trimmed content ended with `,`, not `{`, so it unconditionally prepended `, ` and produced a double comma:

```js
Inter({
  subsets: ["latin"],
, _selfHostedCSS: "..."  // syntax error
})
```

Rolldown's `builtin:vite-transform` native plugin then failed to parse this invalid JS, attributing the error to a byte offset in the MagicString sourcemap that mapped back to an unrelated position in the original source file.

## Fix

Extend the separator check to also skip `, ` when the content already ends with a trailing comma:

```ts
const beforeBrace = optionsStr.slice(0, closingBrace).trim();
const separator = beforeBrace.endsWith("{") || beforeBrace.endsWith(",") ? "" : ", ";
```

Also adds a regression test (`does not produce double-comma when font options have a trailing comma`) to `tests/font-google.test.ts`.
