### PR TITLE
fix: add shell: true on Windows for execFileSync calls

### DIFF
--- a/packages/vinext/src/cli.ts
+++ b/packages/vinext/src/cli.ts
@@ -403,7 +403,7 @@ async function buildApp() {
       const installCmd = detectPackageManager(process.cwd()).replace(/ -D$/, "");
       const [pm, ...pmArgs] = installCmd.split(" ");
       console.log("  Upgrading React for RSC compatibility...");
-      execFileSync(pm, [...pmArgs, ...reactUpgrade], { cwd: process.cwd(), stdio: "inherit" });
+      execFileSync(pm, [...pmArgs, ...reactUpgrade], { cwd: process.cwd(), stdio: "inherit", shell: process.platform === "win32" });
     }
   }
 
@@ -567,13 +567,13 @@ async function lint() {
   try {
     if (hasEslint && hasNextLintConfig) {
       console.log("  Using eslint (with existing config)\n");
-      execFileSync("npx", ["eslint", "."], { cwd, stdio: "inherit" });
+      execFileSync("npx", ["eslint", "."], { cwd, stdio: "inherit", shell: process.platform === "win32" });
     } else if (hasOxlint) {
       console.log("  Using oxlint\n");
-      execFileSync("npx", ["oxlint", "."], { cwd, stdio: "inherit" });
+      execFileSync("npx", ["oxlint", "."], { cwd, stdio: "inherit", shell: process.platform === "win32" });
     } else if (hasEslint) {
       console.log("  Using eslint\n");
-      execFileSync("npx", ["eslint", "."], { cwd, stdio: "inherit" });
+      execFileSync("npx", ["eslint", "."], { cwd, stdio: "inherit", shell: process.platform === "win32" });
     } else {
       console.log(
         "  No linter found. Install eslint or oxlint:\n\n" +

--- a/packages/vinext/src/cli.ts
+++ b/packages/vinext/src/cli.ts
@@ -403,7 +403,11 @@ async function buildApp() {
       const installCmd = detectPackageManager(process.cwd()).replace(/ -D$/, "");
       const [pm, ...pmArgs] = installCmd.split(" ");
       console.log("  Upgrading React for RSC compatibility...");
-      execFileSync(pm, [...pmArgs, ...reactUpgrade], { cwd: process.cwd(), stdio: "inherit", shell: process.platform === "win32" });
+      execFileSync(pm, [...pmArgs, ...reactUpgrade], {
+        cwd: process.cwd(),
+        stdio: "inherit",
+        shell: process.platform === "win32",
+      });
     }
   }
 
@@ -567,13 +571,25 @@ async function lint() {
   try {
     if (hasEslint && hasNextLintConfig) {
       console.log("  Using eslint (with existing config)\n");
-      execFileSync("npx", ["eslint", "."], { cwd, stdio: "inherit", shell: process.platform === "win32" });
+      execFileSync("npx", ["eslint", "."], {
+        cwd,
+        stdio: "inherit",
+        shell: process.platform === "win32",
+      });
     } else if (hasOxlint) {
       console.log("  Using oxlint\n");
-      execFileSync("npx", ["oxlint", "."], { cwd, stdio: "inherit", shell: process.platform === "win32" });
+      execFileSync("npx", ["oxlint", "."], {
+        cwd,
+        stdio: "inherit",
+        shell: process.platform === "win32",
+      });
     } else if (hasEslint) {
       console.log("  Using eslint\n");
-      execFileSync("npx", ["eslint", "."], { cwd, stdio: "inherit", shell: process.platform === "win32" });
+      execFileSync("npx", ["eslint", "."], {
+        cwd,
+        stdio: "inherit",
+        shell: process.platform === "win32",
+      });
     } else {
       console.log(
         "  No linter found. Install eslint or oxlint:\n\n" +

--- a/packages/vinext/src/deploy.ts
+++ b/packages/vinext/src/deploy.ts
@@ -1225,8 +1225,9 @@ function runWranglerDeploy(root: string, options: Pick<DeployOptions, "preview" 
     console.log("\n  Deploying to production...");
   }
 
-  // Use execFileSync to avoid shell injection — args are passed as an array,
-  // never interpolated into a shell command string.
+  // execFileSync passes args as an array, avoiding shell injection on Unix.
+  // On Windows, shell: true is required for .cmd wrappers but the array form
+  // still prevents trivial injection.
   const output = execFileSync(wranglerBin, args, execOpts) as string;
 
   // Parse the deployed URL from wrangler output

--- a/packages/vinext/src/deploy.ts
+++ b/packages/vinext/src/deploy.ts
@@ -1059,6 +1059,7 @@ function installDeps(root: string, deps: MissingDep[]): void {
   execFileSync(pm, [...pmArgs, ...depSpecs], {
     cwd: root,
     stdio: "inherit",
+    shell: process.platform === "win32",
   });
 }
 
@@ -1210,6 +1211,10 @@ function runWranglerDeploy(root: string, options: Pick<DeployOptions, "preview" 
     cwd: root,
     stdio: "pipe",
     encoding: "utf-8",
+    // On Windows, .bin/wrangler is a .cmd wrapper; execFileSync can't run
+    // it without a shell.  Enabling shell only on win32 keeps the
+    // no-shell-injection guarantee on other platforms.
+    shell: process.platform === "win32",
   };
 
   const { args, env } = buildWranglerDeployArgs(options);
@@ -1275,7 +1280,7 @@ export async function deploy(options: DeployOptions): Promise<void> {
       console.log(
         `  Upgrading ${reactUpgrade.map((d) => d.replace(/@latest$/, "")).join(", ")}...`,
       );
-      execFileSync(pm, [...pmArgs, ...reactUpgrade], { cwd: root, stdio: "inherit" });
+      execFileSync(pm, [...pmArgs, ...reactUpgrade], { cwd: root, stdio: "inherit", shell: process.platform === "win32" });
     }
   }
   const missingDeps = getMissingDeps(info);

--- a/packages/vinext/src/deploy.ts
+++ b/packages/vinext/src/deploy.ts
@@ -17,7 +17,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { createRequire } from "node:module";
-import { execFileSync, type ExecSyncOptions } from "node:child_process";
+import { execFileSync, type ExecFileSyncOptions } from "node:child_process";
 import { parseArgs as nodeParseArgs } from "node:util";
 import { pathToFileURL } from "node:url";
 import {
@@ -1207,7 +1207,7 @@ function runWranglerDeploy(root: string, options: Pick<DeployOptions, "preview" 
     _findInNodeModules(root, ".bin/wrangler") ??
     path.join(root, "node_modules", ".bin", "wrangler"); // fallback for error message clarity
 
-  const execOpts: ExecSyncOptions = {
+  const execOpts: ExecFileSyncOptions = {
     cwd: root,
     stdio: "pipe",
     encoding: "utf-8",

--- a/packages/vinext/src/deploy.ts
+++ b/packages/vinext/src/deploy.ts
@@ -1280,7 +1280,11 @@ export async function deploy(options: DeployOptions): Promise<void> {
       console.log(
         `  Upgrading ${reactUpgrade.map((d) => d.replace(/@latest$/, "")).join(", ")}...`,
       );
-      execFileSync(pm, [...pmArgs, ...reactUpgrade], { cwd: root, stdio: "inherit", shell: process.platform === "win32" });
+      execFileSync(pm, [...pmArgs, ...reactUpgrade], {
+        cwd: root,
+        stdio: "inherit",
+        shell: process.platform === "win32",
+      });
     }
   }
   const missingDeps = getMissingDeps(info);


### PR DESCRIPTION
## Summary

`vinext deploy`, `vinext build`, and `vinext lint` fail on Windows with `spawnSync ENOENT` because `execFileSync` cannot execute `.bin/wrangler` (a shell script) or package manager commands like `npm`/`npx` (`.cmd` wrappers) without enabling the shell.

```
Error: spawnSync C:\Users\...\node_modules\.bin\wrangler ENOENT
    at runWranglerDeploy (deploy.js)
```

## Fix

Add `shell: process.platform === "win32"` to all `execFileSync` options in `deploy.ts` and `cli.ts`. This only enables the shell on Windows where it's required, preserving the no-shell-injection guarantee on other platforms.

**Affected call sites:**
- `runWranglerDeploy()` in `deploy.ts` — wrangler binary
- `installDeps()` in `deploy.ts` — package manager
- React upgrade in `deploy()` — package manager  
- React upgrade in `buildApp()` in `cli.ts` — package manager
- `lint()` in `cli.ts` — npx eslint/oxlint

## Test plan

- [x] Verified `npx wrangler deploy` works as workaround on Windows 11
- [x] `vinext deploy` on Windows with this patch
- [x] `vinext build` on Windows (react upgrade path)
- [ ] `vinext lint` on Windows
- [ ] Existing behavior on macOS/Linux unaffected (shell option is `false`)

**Environment:** Windows 11, Node 22, wrangler 4.79.0