### PR TITLE
refactor: post-PR #690 cleanup - shared test helper and ??= syntax

### DIFF
--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -490,28 +490,26 @@ function getClientNavigationState(): ClientNavigationState | null {
   if (isServer) return null;
 
   const globalState = window as ClientNavigationGlobal;
-  if (!globalState[_CLIENT_NAV_STATE_KEY]) {
-    globalState[_CLIENT_NAV_STATE_KEY] = {
-      listeners: new Set<NavigationListener>(),
-      cachedSearch: window.location.search,
-      cachedReadonlySearchParams: new ReadonlyURLSearchParams(window.location.search),
-      cachedPathname: stripBasePath(window.location.pathname, __basePath),
-      clientParams: {},
-      clientParamsJson: "{}",
-      pendingClientParams: null,
-      pendingClientParamsJson: null,
-      // NB: These capture the currently installed history methods, not guaranteed
-      // native ones. If a third-party library (analytics, router) has already patched
-      // history methods before this module loads, we intentionally preserve that
-      // wrapper. With Symbol.for global state, the first module instance to load wins.
-      originalPushState: window.history.pushState.bind(window.history),
-      originalReplaceState: window.history.replaceState.bind(window.history),
-      patchInstalled: false,
-      hasPendingNavigationUpdate: false,
-      suppressUrlNotifyCount: 0,
-      navigationSnapshotActiveCount: 0,
-    };
-  }
+  globalState[_CLIENT_NAV_STATE_KEY] ??= {
+    listeners: new Set<NavigationListener>(),
+    cachedSearch: window.location.search,
+    cachedReadonlySearchParams: new ReadonlyURLSearchParams(window.location.search),
+    cachedPathname: stripBasePath(window.location.pathname, __basePath),
+    clientParams: {},
+    clientParamsJson: "{}",
+    pendingClientParams: null,
+    pendingClientParamsJson: null,
+    // NB: These capture the currently installed history methods, not guaranteed
+    // native ones. If a third-party library (analytics, router) has already patched
+    // history methods before this module loads, we intentionally preserve that
+    // wrapper. With Symbol.for global state, the first module instance to load wins.
+    originalPushState: window.history.pushState.bind(window.history),
+    originalReplaceState: window.history.replaceState.bind(window.history),
+    patchInstalled: false,
+    hasPendingNavigationUpdate: false,
+    suppressUrlNotifyCount: 0,
+    navigationSnapshotActiveCount: 0,
+  };
 
   return globalState[_CLIENT_NAV_STATE_KEY]!;
 }

--- a/tests/e2e/app-router/form.spec.ts
+++ b/tests/e2e/app-router/form.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+import { waitForAppRouterHydration } from "../helpers";
 
 const BASE = "http://localhost:4174";
 
@@ -17,11 +18,7 @@ async function disableViteErrorOverlay(page: import("@playwright/test").Page) {
  * Wait for RSC hydration.
  */
 async function waitForHydration(page: import("@playwright/test").Page) {
-  await expect(async () => {
-    const ready = await page.evaluate(() => !!(window as any).__VINEXT_RSC_ROOT__);
-    expect(ready).toBe(true);
-  }).toPass({ timeout: 10_000 });
-
+  await waitForAppRouterHydration(page);
   await disableViteErrorOverlay(page);
 }
 

--- a/tests/e2e/app-router/instrumentation-client.spec.ts
+++ b/tests/e2e/app-router/instrumentation-client.spec.ts
@@ -4,15 +4,12 @@
 
 import { test, expect } from "@playwright/test";
 import { promises as fs } from "node:fs";
+import { waitForAppRouterHydration } from "../helpers";
 
 const instrumentationClientPath = `${process.cwd()}/tests/fixtures/app-basic/instrumentation-client.ts`;
 
 function filterNavigationStartLogs(logs: string[]): string[] {
   return logs.filter((message) => message.startsWith("[Router Transition Start]"));
-}
-
-async function waitForHydration(page: import("@playwright/test").Page): Promise<void> {
-  await page.waitForFunction(() => !!window.__VINEXT_RSC_ROOT__);
 }
 
 test.describe.serial("instrumentation-client (App Router)", () => {
@@ -21,7 +18,7 @@ test.describe.serial("instrumentation-client (App Router)", () => {
     page.on("console", (message) => logs.push(message.text()));
 
     await page.goto("/instrumentation-client");
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
     await page.waitForFunction(() => {
       const win = window as Window & {
         __INSTRUMENTATION_CLIENT_EXECUTED_AT?: number;
@@ -62,14 +59,14 @@ test.describe.serial("instrumentation-client (App Router)", () => {
     page.on("console", (message) => logs.push(message.text()));
 
     await page.goto("/instrumentation-client");
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
     await page.getByRole("link", { name: "Go to Some Page" }).click();
     await expect(page.locator("#instrumentation-client-some-page")).toBeVisible();
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     await page.getByRole("link", { name: "Go Home" }).click();
     await expect(page.locator("#instrumentation-client-home")).toBeVisible();
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     expect(filterNavigationStartLogs(logs)).toEqual([
       "[Router Transition Start] [push] /instrumentation-client/some-page",
@@ -84,18 +81,18 @@ test.describe.serial("instrumentation-client (App Router)", () => {
     page.on("console", (message) => logs.push(message.text()));
 
     await page.goto("/instrumentation-client");
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
     await page.getByRole("link", { name: "Go to Some Page" }).click();
     await expect(page.locator("#instrumentation-client-some-page")).toBeVisible();
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     await page.goBack();
     await expect(page.locator("#instrumentation-client-home")).toBeVisible();
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     await page.goForward();
     await expect(page.locator("#instrumentation-client-some-page")).toBeVisible();
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     expect(filterNavigationStartLogs(logs)).toEqual([
       "[Router Transition Start] [push] /instrumentation-client/some-page",
@@ -109,7 +106,7 @@ test.describe.serial("instrumentation-client (App Router)", () => {
 
     try {
       await page.goto("/instrumentation-client");
-      await waitForHydration(page);
+      await waitForAppRouterHydration(page);
       await page.waitForFunction(() => {
         const win = window as Window & { __INSTRUMENTATION_CLIENT_EXECUTED_AT?: number };
         return win.__INSTRUMENTATION_CLIENT_EXECUTED_AT !== undefined;

--- a/tests/e2e/app-router/layout-params.spec.ts
+++ b/tests/e2e/app-router/layout-params.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+import { waitForAppRouterHydration } from "../helpers";
 
 /**
  * Regression: layout components receive correct `params` in renderHTTPAccessFallbackPage.
@@ -27,20 +28,13 @@ import { test, expect } from "@playwright/test";
 
 const BASE = "http://localhost:4174";
 
-async function waitForHydration(page: import("@playwright/test").Page) {
-  await expect(async () => {
-    const ready = await page.evaluate(() => !!(window as any).__VINEXT_RSC_ROOT__);
-    expect(ready).toBe(true);
-  }).toPass({ timeout: 10_000 });
-}
-
 test.describe("layout params in fallback render (renderHTTPAccessFallbackPage)", () => {
   /**
    * Baseline: valid slug — layout renders, page renders, params are correct.
    */
   test("valid slug: layout renders with correct data-slug", async ({ page }) => {
     await page.goto(`${BASE}/nextjs-compat/layout-params-notfound/hello`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     await expect(page.locator("#layout-params-notfound-wrapper")).toHaveAttribute(
       "data-slug",
@@ -95,7 +89,7 @@ test.describe("layout params in fallback render (renderHTTPAccessFallbackPage)",
     page,
   }) => {
     await page.goto(`${BASE}/nextjs-compat/layout-params-notfound/hello`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     await expect(page.locator("#layout-params-notfound-wrapper")).toHaveAttribute(
       "data-slug",

--- a/tests/e2e/app-router/navigation-flows.spec.ts
+++ b/tests/e2e/app-router/navigation-flows.spec.ts
@@ -1,22 +1,13 @@
 import { test, expect } from "@playwright/test";
+import { waitForAppRouterHydration } from "../helpers";
 
 const BASE = "http://localhost:4174";
-
-/**
- * Wait for the RSC browser entry to hydrate.
- */
-async function waitForHydration(page: import("@playwright/test").Page) {
-  await expect(async () => {
-    const ready = await page.evaluate(() => !!(window as any).__VINEXT_RSC_ROOT__);
-    expect(ready).toBe(true);
-  }).toPass({ timeout: 10_000 });
-}
 
 test.describe("App Router navigation flows", () => {
   test("multi-page navigation chain without reload", async ({ page }) => {
     await page.goto(`${BASE}/`);
     await expect(page.locator("h1")).toHaveText("Welcome to App Router");
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     await page.evaluate(() => {
       (window as any).__NAV_MARKER__ = true;
@@ -49,7 +40,7 @@ test.describe("App Router navigation flows", () => {
 
   test("back/forward through multiple pages preserves content", async ({ page }) => {
     await page.goto(`${BASE}/`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     // Navigate through 3 pages via links
     await page.click('a[href="/about"]');
@@ -81,7 +72,7 @@ test.describe("App Router navigation flows", () => {
   test("search form flow: type, submit, modify, resubmit", async ({ page }) => {
     await page.goto(`${BASE}/search`);
     await expect(page.locator("h1")).toHaveText("Search");
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     // Empty state
     await expect(page.locator("#search-empty")).toHaveText("Enter a search term");
@@ -107,7 +98,7 @@ test.describe("App Router navigation flows", () => {
   test("server action: like button click flow", async ({ page }) => {
     await page.goto(`${BASE}/actions`);
     await expect(page.locator("h1")).toHaveText("Server Actions");
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     // Initial state
     await expect(page.locator('[data-testid="likes"]')).toHaveText("Likes: 0");
@@ -133,7 +124,7 @@ test.describe("App Router navigation flows", () => {
 
   test("server action: message form submit flow", async ({ page }) => {
     await page.goto(`${BASE}/actions`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     // Type and submit a message
     await page.fill('[data-testid="message-input"]', "Hello!");
@@ -154,7 +145,7 @@ test.describe("App Router navigation flows", () => {
   test("useActionState: increment and decrement counter", async ({ page }) => {
     await page.goto(`${BASE}/action-state-test`);
     await expect(page.locator("#count")).toHaveText("Count: 0");
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     // Increment 3 times
     for (let i = 1; i <= 3; i++) {

--- a/tests/e2e/app-router/navigation-regressions.spec.ts
+++ b/tests/e2e/app-router/navigation-regressions.spec.ts
@@ -1,21 +1,15 @@
 import { test, expect } from "@playwright/test";
+import { waitForAppRouterHydration } from "../helpers";
 
 // Hardcoded BASE URL matches the convention used in all other E2E test files in
 // this directory (navigation.spec.ts, server-client-only.spec.ts, after.spec.ts,
 // etc.). Port 4174 is the vite preview default for the app-basic fixture.
 const BASE = "http://localhost:4174";
 
-async function waitForHydration(page: import("@playwright/test").Page) {
-  await expect(async () => {
-    const ready = await page.evaluate(() => !!(window as any).__VINEXT_RSC_ROOT__);
-    expect(ready).toBe(true);
-  }).toPass({ timeout: 10_000 });
-}
-
 test.describe("Navigation regression tests (#652 Firefox hang fix)", () => {
   test("cross-route navigation completes without hanging", async ({ page }) => {
     await page.goto(`${BASE}/nav-flash/link-sync`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
     await expect(page.locator("#page-title")).toHaveText("All Items");
 
     // Set a marker to verify no full page reload
@@ -37,7 +31,7 @@ test.describe("Navigation regression tests (#652 Firefox hang fix)", () => {
 
   test("same-route navigation (search param change) works", async ({ page }) => {
     await page.goto(`${BASE}/nav-flash/link-sync`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
     await expect(page.locator("#page-title")).toHaveText("All Items");
 
     await page.evaluate(() => {
@@ -59,7 +53,7 @@ test.describe("Navigation regression tests (#652 Firefox hang fix)", () => {
 
   test("back/forward navigation works after cross-route nav", async ({ page }) => {
     await page.goto(`${BASE}/nav-flash/link-sync`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
     await expect(page.locator("#page-title")).toHaveText("All Items");
 
     // Navigate to list page
@@ -79,7 +73,7 @@ test.describe("Navigation regression tests (#652 Firefox hang fix)", () => {
 
   test("rapid same-route navigation settles correctly", async ({ page }) => {
     await page.goto(`${BASE}/nav-flash/link-sync`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
     await expect(page.locator("#page-title")).toHaveText("All Items");
 
     // Rapidly click between filters
@@ -96,7 +90,7 @@ test.describe("Navigation regression tests (#652 Firefox hang fix)", () => {
 
   test("cross-route then same-route navigation works", async ({ page }) => {
     await page.goto(`${BASE}/nav-flash/list`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
     await expect(page.locator("#list-title")).toHaveText("Nav Flash List");
 
     // Cross-route: list -> query-sync
@@ -112,7 +106,7 @@ test.describe("Navigation regression tests (#652 Firefox hang fix)", () => {
 
   test("usePathname reflects correct value during cross-route navigation", async ({ page }) => {
     await page.goto(`${BASE}/nav-flash/link-sync`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     await expect(page.locator("#hook-pathname")).toHaveText("pathname: /nav-flash/link-sync");
 
@@ -129,7 +123,7 @@ test.describe("Navigation regression tests (#652 Firefox hang fix)", () => {
 
   test("useParams reflects correct value after param change", async ({ page }) => {
     await page.goto(`${BASE}/nav-flash/param-sync/active`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     await expect(page.locator("#param-title")).toHaveText("Filter: active");
     await expect(page.locator("#hook-params")).toHaveText("params.filter: active");
@@ -142,7 +136,7 @@ test.describe("Navigation regression tests (#652 Firefox hang fix)", () => {
 
   test("navigation from home page to nav-flash routes", async ({ page }) => {
     await page.goto(`${BASE}/`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
     await expect(page.locator("h1")).toHaveText("Welcome to App Router");
 
     // Navigate to nav-flash test
@@ -155,7 +149,7 @@ test.describe("Navigation regression tests (#652 Firefox hang fix)", () => {
 
   test("cross-route round trip preserves SPA state", async ({ page }) => {
     await page.goto(`${BASE}/nav-flash/link-sync`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     await page.evaluate(() => {
       (window as any).__ROUND_TRIP_MARKER__ = "alive";
@@ -176,7 +170,7 @@ test.describe("Navigation regression tests (#652 Firefox hang fix)", () => {
 
   test("provider page cross-route navigation between dynamic params", async ({ page }) => {
     await page.goto(`${BASE}/nav-flash/provider/1`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
     await expect(page.locator("#provider-title")).toHaveText("Provider 1");
 
     // Navigate to provider 2 (cross-route: different dynamic param)
@@ -193,7 +187,7 @@ test.describe("Navigation regression tests (#652 Firefox hang fix)", () => {
     // This test verifies the fix for: stale navigation bailout leaving staged params
     // that could be committed by the next navigation.
     await page.goto(`${BASE}/nav-flash/slow-route/slow-value`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
     await expect(page.locator("#slow-param")).toHaveText("Param: slow-value");
 
     // Set marker to detect full page reload

--- a/tests/e2e/app-router/navigation.spec.ts
+++ b/tests/e2e/app-router/navigation.spec.ts
@@ -1,23 +1,13 @@
 import { test, expect } from "@playwright/test";
+import { waitForAppRouterHydration } from "../helpers";
 
 const BASE = "http://localhost:4174";
-
-/**
- * Wait for the RSC browser entry to hydrate. The browser entry sets
- * window.__VINEXT_RSC_ROOT__ after hydration completes.
- */
-async function waitForHydration(page: import("@playwright/test").Page) {
-  await expect(async () => {
-    const ready = await page.evaluate(() => !!(window as any).__VINEXT_RSC_ROOT__);
-    expect(ready).toBe(true);
-  }).toPass({ timeout: 10_000 });
-}
 
 test.describe("App Router Client-side Navigation", () => {
   test("Link click navigates without full page reload", async ({ page }) => {
     await page.goto(`${BASE}/`);
     await expect(page.locator("h1")).toHaveText("Welcome to App Router");
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     // Set marker to detect full page reload
     await page.evaluate(() => {
@@ -42,7 +32,7 @@ test.describe("App Router Client-side Navigation", () => {
   test("Link navigates back from about to home", async ({ page }) => {
     await page.goto(`${BASE}/about`);
     await expect(page.locator("h1")).toHaveText("About");
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     await page.evaluate(() => {
       (window as any).__NAV_MARKER__ = true;
@@ -59,7 +49,7 @@ test.describe("App Router Client-side Navigation", () => {
   test("browser back/forward buttons work after client navigation", async ({ page }) => {
     await page.goto(`${BASE}/`);
     await expect(page.locator("h1")).toHaveText("Welcome to App Router");
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     // Navigate: Home -> About via link
     await page.click('a[href="/about"]');
@@ -79,7 +69,7 @@ test.describe("App Router Client-side Navigation", () => {
   test("multiple sequential navigations work without reload", async ({ page }) => {
     await page.goto(`${BASE}/`);
     await expect(page.locator("h1")).toHaveText("Welcome to App Router");
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     await page.evaluate(() => {
       (window as any).__NAV_MARKER__ = true;
@@ -106,7 +96,7 @@ test.describe("App Router Client-side Navigation", () => {
   test("navigation to dynamic route renders correct params", async ({ page }) => {
     await page.goto(`${BASE}/`);
     await expect(page.locator("h1")).toHaveText("Welcome to App Router");
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     await page.click('a[href="/blog/hello-world"]');
     await expect(page.locator("h1")).toHaveText("Blog Post");
@@ -117,7 +107,7 @@ test.describe("App Router Client-side Navigation", () => {
   test("navigation to dashboard preserves nested layout", async ({ page }) => {
     await page.goto(`${BASE}/`);
     await expect(page.locator("h1")).toHaveText("Welcome to App Router");
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     await page.click('a[href="/dashboard"]');
     await expect(page.locator("h1")).toHaveText("Dashboard");
@@ -128,7 +118,7 @@ test.describe("App Router Client-side Navigation", () => {
   test("scroll-to-top happens after new content renders", async ({ page }) => {
     await page.goto(`${BASE}/`);
     await expect(page.locator("h1")).toHaveText("Welcome to App Router");
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     // Make the page scrollable and scroll down
     await page.evaluate(() => {

--- a/tests/e2e/app-router/nextjs-compat/actions-nav.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/actions-nav.spec.ts
@@ -7,22 +7,16 @@
  */
 
 import { test, expect } from "@playwright/test";
+import { waitForAppRouterHydration } from "../../helpers";
 
 const BASE = "http://localhost:4174";
-
-async function waitForHydration(page: import("@playwright/test").Page) {
-  await expect(async () => {
-    const ready = await page.evaluate(() => !!(window as any).__VINEXT_RSC_ROOT__);
-    expect(ready).toBe(true);
-  }).toPass({ timeout: 10_000 });
-}
 
 test.describe("Next.js compat: actions-navigation (browser)", () => {
   // Next.js: 'should handle actions correctly after navigation / redirection events'
   // Simplified: Navigate to action page, submit form, verify result
   test("server action works after client-side navigation", async ({ page }) => {
     await page.goto(`${BASE}/nextjs-compat/action-redirect-nav`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     // Navigate to the action page via Link click
     await page.click("#go-to-action");

--- a/tests/e2e/app-router/nextjs-compat/actions-revalidate.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/actions-revalidate.spec.ts
@@ -10,22 +10,16 @@
  */
 
 import { test, expect } from "@playwright/test";
+import { waitForAppRouterHydration } from "../../helpers";
 
 const BASE = "http://localhost:4174";
-
-async function waitForHydration(page: import("@playwright/test").Page) {
-  await expect(async () => {
-    const ready = await page.evaluate(() => !!(window as any).__VINEXT_RSC_ROOT__);
-    expect(ready).toBe(true);
-  }).toPass({ timeout: 10_000 });
-}
 
 test.describe("Next.js compat: actions-revalidate (browser)", () => {
   // Next.js: 'should not remount the page + loading component when revalidating'
   // Adapted: Verify that clicking revalidate button updates the timestamp
   test("revalidatePath via server action updates page data", async ({ page }) => {
     await page.goto(`${BASE}/nextjs-compat/action-revalidate`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     // Read initial timestamp
     const time1 = await page.locator("#time").textContent();
@@ -45,7 +39,7 @@ test.describe("Next.js compat: actions-revalidate (browser)", () => {
   // Test router.refresh() re-renders with fresh data
   test("router.refresh() updates page data", async ({ page }) => {
     await page.goto(`${BASE}/nextjs-compat/refresh-test`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     // Read initial timestamp
     const time1 = await page.locator("#time").textContent();

--- a/tests/e2e/app-router/nextjs-compat/dynamic.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/dynamic.spec.ts
@@ -10,15 +10,9 @@
  */
 
 import { test, expect } from "@playwright/test";
+import { waitForAppRouterHydration } from "../../helpers";
 
 const BASE = "http://localhost:4174";
-
-async function waitForHydration(page: import("@playwright/test").Page) {
-  await expect(async () => {
-    const ready = await page.evaluate(() => !!(window as any).__VINEXT_RSC_ROOT__);
-    expect(ready).toBe(true);
-  }).toPass({ timeout: 10_000 });
-}
 
 test.describe("Next.js compat: next/dynamic (browser)", () => {
   // Next.js: 'should handle next/dynamic in hydration correctly'
@@ -27,7 +21,7 @@ test.describe("Next.js compat: next/dynamic (browser)", () => {
   // After hydration, the ssr:false component should appear in the DOM.
   test("ssr:false component appears after hydration", async ({ page }) => {
     await page.goto(`${BASE}/nextjs-compat/dynamic`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     // The ssr:false component should now be visible after client-side rendering
     await expect(async () => {
@@ -39,7 +33,7 @@ test.describe("Next.js compat: next/dynamic (browser)", () => {
   // Verify SSR-rendered dynamic components are still present after hydration
   test("dynamic() components remain visible after hydration", async ({ page }) => {
     await page.goto(`${BASE}/nextjs-compat/dynamic`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     await expect(page.locator("#css-text-lazy")).toContainText("next-dynamic lazy");
     await expect(page.locator("#css-text-dynamic-server")).toContainText(
@@ -57,7 +51,7 @@ test.describe("Next.js compat: next/dynamic (browser)", () => {
   // Source: https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/dynamic/dynamic.test.ts#L97-L100
   test("named export via dynamic() renders button after hydration", async ({ page }) => {
     await page.goto(`${BASE}/nextjs-compat/dynamic/named-export`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     await expect(page.locator("#client-button")).toHaveText("this is a client button");
   });
@@ -69,7 +63,7 @@ test.describe("Next.js compat: next/dynamic (browser)", () => {
     // Static content should be present immediately
     await expect(page.locator("#static-text")).toHaveText("This is static content");
 
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     // After hydration, the ssr:false component should appear
     await expect(async () => {
@@ -87,7 +81,7 @@ test.describe("Next.js compat: next/dynamic (browser)", () => {
     // Server-rendered static content should be present immediately
     await expect(page.locator("#server-text")).toHaveText("Server rendered");
 
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     // After hydration, the ssr:false component should appear
     await expect(async () => {

--- a/tests/e2e/app-router/nextjs-compat/error-nav.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/error-nav.spec.ts
@@ -4,20 +4,14 @@
  */
 
 import { test, expect } from "@playwright/test";
+import { waitForAppRouterHydration } from "../../helpers";
 
 const BASE = "http://localhost:4174";
-
-async function waitForHydration(page: import("@playwright/test").Page) {
-  await expect(async () => {
-    const ready = await page.evaluate(() => !!(window as any).__VINEXT_RSC_ROOT__);
-    expect(ready).toBe(true);
-  }).toPass({ timeout: 10_000 });
-}
 
 test.describe("Next.js compat: error-boundary-navigation (browser)", () => {
   test("can navigate away from error page", async ({ page }) => {
     await page.goto(`${BASE}/nextjs-compat/error-nav`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     await page.click("#link-to-error");
     await expect(page.locator("#error-boundary")).toBeVisible({
@@ -59,7 +53,7 @@ test.describe("Next.js compat: error-boundary-navigation (browser)", () => {
 
   test("navigation to error page then back works", async ({ page }) => {
     await page.goto(`${BASE}/nextjs-compat/error-nav`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     await page.click("#link-to-error");
     await expect(page.locator("#error-boundary")).toBeVisible({

--- a/tests/e2e/app-router/nextjs-compat/external-redirect.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/external-redirect.spec.ts
@@ -7,15 +7,9 @@
  */
 
 import { test, expect } from "@playwright/test";
+import { waitForAppRouterHydration } from "../../helpers";
 
 const BASE = "http://localhost:4174";
-
-async function waitForHydration(page: import("@playwright/test").Page) {
-  await expect(async () => {
-    const ready = await page.evaluate(() => !!(window as any).__VINEXT_RSC_ROOT__);
-    expect(ready).toBe(true);
-  }).toPass({ timeout: 10_000 });
-}
 
 test.describe("Next.js compat: external-redirect (browser)", () => {
   test("server action redirect to external URL", async ({ page }) => {
@@ -31,7 +25,7 @@ test.describe("Next.js compat: external-redirect (browser)", () => {
     });
 
     await page.goto(`${BASE}/nextjs-compat/external-redirect-test`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     // Click the redirect button (triggers server action with redirect to external URL)
     await page.click("#redirect-external");

--- a/tests/e2e/app-router/nextjs-compat/hooks.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/hooks.spec.ts
@@ -4,21 +4,15 @@
  */
 
 import { test, expect } from "@playwright/test";
+import { waitForAppRouterHydration } from "../../helpers";
 
 const BASE = "http://localhost:4174";
-
-async function waitForHydration(page: import("@playwright/test").Page) {
-  await expect(async () => {
-    const ready = await page.evaluate(() => !!(window as any).__VINEXT_RSC_ROOT__);
-    expect(ready).toBe(true);
-  }).toPass({ timeout: 10_000 });
-}
 
 test.describe("Next.js compat: hooks (browser)", () => {
   // useParams – single dynamic param
   test("useParams returns correct value for single dynamic param", async ({ page }) => {
     await page.goto(`${BASE}/nextjs-compat/hooks-params/test-value`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     await expect(page.locator("#param-id")).toHaveText("test-value");
   });
@@ -26,7 +20,7 @@ test.describe("Next.js compat: hooks (browser)", () => {
   // useParams – nested dynamic params
   test("useParams returns correct values for nested dynamic params", async ({ page }) => {
     await page.goto(`${BASE}/nextjs-compat/hooks-params/parent/child`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     await expect(page.locator("#param-id")).toHaveText("parent");
     await expect(page.locator("#param-subid")).toHaveText("child");
@@ -35,7 +29,7 @@ test.describe("Next.js compat: hooks (browser)", () => {
   // useParams – catch-all params
   test("useParams returns correct catch-all params", async ({ page }) => {
     await page.goto(`${BASE}/nextjs-compat/hooks-params/catchall/x/y/z`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     await expect(page.locator("#params-slug")).toContainText('["x","y","z"]');
   });
@@ -43,7 +37,7 @@ test.describe("Next.js compat: hooks (browser)", () => {
   // useSearchParams – reads query params
   test("useSearchParams reads query params in browser", async ({ page }) => {
     await page.goto(`${BASE}/nextjs-compat/hooks-search?q=browser-test&page=5`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     await expect(page.locator("#param-q")).toHaveText("browser-test");
     await expect(page.locator("#param-page")).toHaveText("5");
@@ -52,7 +46,7 @@ test.describe("Next.js compat: hooks (browser)", () => {
   // useSearchParams – reactive update on pushState
   test("useSearchParams updates reactively on pushState", async ({ page }) => {
     await page.goto(`${BASE}/nextjs-compat/hooks-search`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     await page.click("#push-search");
 
@@ -67,7 +61,7 @@ test.describe("Next.js compat: hooks (browser)", () => {
   // Source fixture: https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/hooks/app/hooks/use-search-params/instanceof/page.js
   test("useSearchParams returns ReadonlyURLSearchParams on the client", async ({ page }) => {
     await page.goto(`${BASE}/nextjs-compat/hooks-search-readonly?foo=bar&foo=baz`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     await expect(page.locator('[data-testid="server-instance"]')).toHaveText(
       "PASS instanceof check",
@@ -79,7 +73,7 @@ test.describe("Next.js compat: hooks (browser)", () => {
 
   test("useSearchParams mutation methods throw on the client", async ({ page }) => {
     await page.goto(`${BASE}/nextjs-compat/hooks-search-readonly?foo=bar&zap=zazzle`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     await expect(page.locator('[data-testid="server-mutation-status"]')).toHaveText(
       "PASS mutation blocked",
@@ -97,7 +91,7 @@ test.describe("Next.js compat: hooks (browser)", () => {
   // useRouter.push() – navigates to new page
   test("useRouter.push() navigates to new page", async ({ page }) => {
     await page.goto(`${BASE}/nextjs-compat/hooks-router`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     await page.click("#push-btn");
     await expect(page.locator("#result-page")).toHaveText("Result Page", {
@@ -111,7 +105,7 @@ test.describe("Next.js compat: hooks (browser)", () => {
     // Start on a known page so we have a history entry before hooks-router
     await page.goto(`${BASE}/nextjs-compat/nav-redirect-result`);
     await page.goto(`${BASE}/nextjs-compat/hooks-router`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     await page.click("#replace-btn");
     await expect(page.locator("#result-page")).toHaveText("Result Page", {
@@ -130,7 +124,7 @@ test.describe("Next.js compat: hooks (browser)", () => {
     await page.goto(`${BASE}/nextjs-compat/hooks-router`);
     await page.goto(`${BASE}/nextjs-compat/nav-redirect-result`);
     await page.goto(`${BASE}/nextjs-compat/hooks-router`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     await page.click("#back-btn");
 
@@ -145,7 +139,7 @@ test.describe("Next.js compat: hooks (browser)", () => {
 
   test("useParams updates reactively on client-side navigation", async ({ page }) => {
     await page.goto(`${BASE}/nextjs-compat/hooks-params-nav/1`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     // Verify initial param
     await expect(page.locator("#current-id")).toHaveText("1");
@@ -160,7 +154,7 @@ test.describe("Next.js compat: hooks (browser)", () => {
 
   test("useParams updates across multiple consecutive navigations", async ({ page }) => {
     await page.goto(`${BASE}/nextjs-compat/hooks-params-nav/1`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     await expect(page.locator("#current-id")).toHaveText("1");
 
@@ -179,7 +173,7 @@ test.describe("Next.js compat: hooks (browser)", () => {
 
   test("useParams updates on browser back/forward", async ({ page }) => {
     await page.goto(`${BASE}/nextjs-compat/hooks-params-nav/1`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     await expect(page.locator("#current-id")).toHaveText("1");
 

--- a/tests/e2e/app-router/nextjs-compat/metadata.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/metadata.spec.ts
@@ -10,15 +10,9 @@
  */
 
 import { test, expect } from "@playwright/test";
+import { waitForAppRouterHydration } from "../../helpers";
 
 const BASE = "http://localhost:4174";
-
-async function waitForHydration(page: import("@playwright/test").Page) {
-  await expect(async () => {
-    const ready = await page.evaluate(() => !!(window as any).__VINEXT_RSC_ROOT__);
-    expect(ready).toBe(true);
-  }).toPass({ timeout: 10_000 });
-}
 
 test.describe("Next.js compat: metadata (browser)", () => {
   // Next.js: 'should support title and description'
@@ -82,7 +76,7 @@ test.describe("Next.js compat: metadata (browser)", () => {
   // Source: metadata.test.ts#L130-L149
   test("title updates on client-side navigation", async ({ page }) => {
     await page.goto(`${BASE}/nextjs-compat/nav-link-test`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     // Navigate to the title page via Link
     await page.click("#link-to-title");

--- a/tests/e2e/app-router/nextjs-compat/navigation.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/navigation.spec.ts
@@ -12,15 +12,9 @@
  */
 
 import { test, expect } from "@playwright/test";
+import { waitForAppRouterHydration } from "../../helpers";
 
 const BASE = "http://localhost:4174";
-
-async function waitForHydration(page: import("@playwright/test").Page) {
-  await expect(async () => {
-    const ready = await page.evaluate(() => !!(window as any).__VINEXT_RSC_ROOT__);
-    expect(ready).toBe(true);
-  }).toPass({ timeout: 10_000 });
-}
 
 test.describe("Next.js compat: navigation (browser)", () => {
   // Next.js: 'should redirect in a server component'
@@ -36,7 +30,7 @@ test.describe("Next.js compat: navigation (browser)", () => {
   // Source: navigation.test.ts#L184-L191
   test("client-side redirect via router.push()", async ({ page }) => {
     await page.goto(`${BASE}/nextjs-compat/nav-client-redirect`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     await page.click("#redirect-btn");
     await expect(page.locator("#result-page")).toHaveText("Result Page", {
@@ -58,7 +52,7 @@ test.describe("Next.js compat: navigation (browser)", () => {
   // Source: navigation.test.ts#L155-L165
   test("client-side notFound() trigger renders not-found component", async ({ page }) => {
     await page.goto(`${BASE}/nextjs-compat/nav-client-notfound`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     // Verify the page loaded correctly first
     await expect(page.locator("#notfound-trigger-page")).toHaveText("Not Found Trigger Page");
@@ -76,7 +70,7 @@ test.describe("Next.js compat: navigation (browser)", () => {
   // Next.js: Link-based client-side navigation
   test("Link navigates client-side without full reload", async ({ page }) => {
     await page.goto(`${BASE}/nextjs-compat/nav-link-test`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     // Set marker for reload detection
     await page.evaluate(() => {
@@ -100,7 +94,7 @@ test.describe("Next.js compat: navigation (browser)", () => {
   // exist should render the not-found.tsx boundary, not a blank white page.
   test("Link to non-existent route renders not-found via client navigation", async ({ page }) => {
     await page.goto(`${BASE}/nextjs-compat/nav-link-test`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     // Set marker to verify it's a client-side navigation (no full reload)
     await page.evaluate(() => {
@@ -122,7 +116,7 @@ test.describe("Next.js compat: navigation (browser)", () => {
     page,
   }) => {
     await page.goto(`${BASE}/nextjs-compat/nav-link-test`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     // Click Link to a page that calls notFound()
     await page.click("#link-to-notfound-page");
@@ -137,7 +131,7 @@ test.describe("Next.js compat: navigation (browser)", () => {
   // Back/forward navigation
   test("browser back button works after client navigation", async ({ page }) => {
     await page.goto(`${BASE}/nextjs-compat/nav-link-test`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     // Navigate to result page
     await page.click("#link-to-result");
@@ -152,7 +146,7 @@ test.describe("Next.js compat: navigation (browser)", () => {
 
   test("Link onNavigate reports the resolved URL for relative query hrefs", async ({ page }) => {
     await page.goto(`${BASE}/nextjs-compat/nav-link-test`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
     await expect(async () => {
       const ready = await page.evaluate(() => !!(window as any).__APP_RELATIVE_QUERY_LINK_READY__);
       expect(ready).toBe(true);

--- a/tests/e2e/app-router/nextjs-compat/prefetch.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/prefetch.spec.ts
@@ -7,21 +7,15 @@
  */
 
 import { test, expect } from "@playwright/test";
+import { waitForAppRouterHydration } from "../../helpers";
 
 const BASE = "http://localhost:4174";
-
-async function waitForHydration(page: import("@playwright/test").Page) {
-  await expect(async () => {
-    const ready = await page.evaluate(() => !!(window as any).__VINEXT_RSC_ROOT__);
-    expect(ready).toBe(true);
-  }).toPass({ timeout: 10_000 });
-}
 
 test.describe("Next.js compat: prefetch (browser)", () => {
   // Next.js: 'should navigate when prefetch is false'
   test("should navigate when prefetch is false", async ({ page }) => {
     await page.goto(`${BASE}/nextjs-compat/prefetch-test`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     // Click the no-prefetch link
     await page.click("#no-prefetch-link");
@@ -33,7 +27,7 @@ test.describe("Next.js compat: prefetch (browser)", () => {
   // Test that prefetched link navigates correctly
   test("should navigate via prefetched link", async ({ page }) => {
     await page.goto(`${BASE}/nextjs-compat/prefetch-test`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     // Click the prefetch link
     await page.click("#prefetch-link");
@@ -45,7 +39,7 @@ test.describe("Next.js compat: prefetch (browser)", () => {
   // Test that prefetched navigation preserves client state (no full reload)
   test("prefetched navigation does not cause full page reload", async ({ page }) => {
     await page.goto(`${BASE}/nextjs-compat/prefetch-test`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     // Set marker to detect full reload
     await page.evaluate(() => {
@@ -66,7 +60,7 @@ test.describe("Next.js compat: prefetch (browser)", () => {
   // Test that prefetch populates the in-memory RSC cache
   test("visible Link prefetches RSC payload into in-memory cache", async ({ page }) => {
     await page.goto(`${BASE}/nextjs-compat/prefetch-test`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     // Wait for prefetch to complete (requestIdleCallback + fetch)
     await expect(async () => {
@@ -92,7 +86,7 @@ test.describe("Next.js compat: prefetch (browser)", () => {
   // Test that prefetch={false} does NOT populate the cache
   test("Link with prefetch={false} does not prefetch RSC payload", async ({ page }) => {
     await page.goto(`${BASE}/nextjs-compat/prefetch-test`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     // Wait for the prefetch-enabled link to populate the cache, then check
     // that the no-prefetch target is NOT in the cache.
@@ -120,7 +114,7 @@ test.describe("Next.js compat: prefetch (browser)", () => {
   // Test that navigating to a prefetched link uses the cache (no extra fetch)
   test("navigation to prefetched link uses cached RSC payload", async ({ page }) => {
     await page.goto(`${BASE}/nextjs-compat/prefetch-test`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     // Wait for prefetch to populate the cache
     await expect(async () => {

--- a/tests/e2e/app-router/nextjs-compat/rsc-basic.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/rsc-basic.spec.ts
@@ -4,21 +4,15 @@
  */
 
 import { test, expect } from "@playwright/test";
+import { waitForAppRouterHydration } from "../../helpers";
 
 const BASE = "http://localhost:4174";
-
-async function waitForHydration(page: import("@playwright/test").Page) {
-  await expect(async () => {
-    const ready = await page.evaluate(() => !!(window as any).__VINEXT_RSC_ROOT__);
-    expect(ready).toBe(true);
-  }).toPass({ timeout: 10_000 });
-}
 
 test.describe("Next.js compat: rsc-basic (browser)", () => {
   // Server component renders and hydrates
   test("server component renders and hydrates correctly", async ({ page }) => {
     await page.goto(`${BASE}/nextjs-compat/rsc-server`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     await expect(page.locator("#server-rendered")).toHaveText("Server Component");
     await expect(page.locator("#server-message")).toHaveText("from server");
@@ -27,7 +21,7 @@ test.describe("Next.js compat: rsc-basic (browser)", () => {
   // Client component receives props from server and is interactive
   test("client component receives props from server and is interactive", async ({ page }) => {
     await page.goto(`${BASE}/nextjs-compat/rsc-server`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     await expect(page.locator("#server-greeting")).toHaveText("hello from server");
     await expect(page.locator("#click-count")).toHaveText("0");
@@ -39,7 +33,7 @@ test.describe("Next.js compat: rsc-basic (browser)", () => {
   // Client component state persists across clicks
   test("client component state persists across clicks", async ({ page }) => {
     await page.goto(`${BASE}/nextjs-compat/rsc-server`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     await expect(page.locator("#click-count")).toHaveText("0");
 

--- a/tests/e2e/app-router/nextjs-compat/search-params-key.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/search-params-key.spec.ts
@@ -8,21 +8,15 @@
  */
 
 import { test, expect } from "@playwright/test";
+import { waitForAppRouterHydration } from "../../helpers";
 
 const BASE = "http://localhost:4174";
-
-async function waitForHydration(page: import("@playwright/test").Page) {
-  await expect(async () => {
-    const ready = await page.evaluate(() => !!(window as any).__VINEXT_RSC_ROOT__);
-    expect(ready).toBe(true);
-  }).toPass({ timeout: 10_000 });
-}
 
 test.describe("Next.js compat: search-params-react-key (browser)", () => {
   // Next.js: 'should keep the React router instance the same when changing the search params'
   test("component state persists across search param changes via router.push", async ({ page }) => {
     await page.goto(`${BASE}/nextjs-compat/search-params-key`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     // Initial state: count=0
     await expect(page.locator("#count")).toHaveText("0");
@@ -48,7 +42,7 @@ test.describe("Next.js compat: search-params-react-key (browser)", () => {
     page,
   }) => {
     await page.goto(`${BASE}/nextjs-compat/search-params-key`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     // Increment twice: count=2
     await page.click("#increment");

--- a/tests/e2e/app-router/routes.spec.ts
+++ b/tests/e2e/app-router/routes.spec.ts
@@ -1,16 +1,7 @@
 import { test, expect } from "@playwright/test";
+import { waitForAppRouterHydration } from "../helpers";
 
 const BASE = "http://localhost:4174";
-
-/**
- * Wait for the RSC browser entry to hydrate.
- */
-async function waitForHydration(page: import("@playwright/test").Page) {
-  await expect(async () => {
-    const ready = await page.evaluate(() => !!(window as any).__VINEXT_RSC_ROOT__);
-    expect(ready).toBe(true);
-  }).toPass({ timeout: 10_000 });
-}
 
 test.describe("Catch-all routes", () => {
   test("renders with single segment", async ({ page }) => {
@@ -67,7 +58,7 @@ test.describe("Route groups", () => {
 
   test("route group page is accessible via client navigation", async ({ page }) => {
     await page.goto(`${BASE}/`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     // Navigate to features page — it's under (marketing) group
     await page.evaluate(() => {
@@ -102,7 +93,7 @@ test.describe("Nested dynamic routes", () => {
   test("navigating between categories via client navigation", async ({ page }) => {
     await page.goto(`${BASE}/shop/electronics`);
     await expect(page.locator("h1")).toHaveText("Category: electronics");
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     await page.evaluate(() => {
       (window as any).__NAV_MARKER__ = true;
@@ -175,7 +166,7 @@ test.describe('"use client" page component with usePathname (issue #688)', () =>
     page.on("pageerror", (err) => errors.push(err.message));
 
     await page.goto(`${BASE}/use-client-page-pathname`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     await expect(page.locator("#client-page-pathname")).toHaveText("/use-client-page-pathname");
     expect(errors.filter((e) => e.includes("Hydration"))).toHaveLength(0);
@@ -183,7 +174,7 @@ test.describe('"use client" page component with usePathname (issue #688)', () =>
 
   test("useSearchParams works on use client page with query string", async ({ page }) => {
     await page.goto(`${BASE}/use-client-page-pathname?q=test`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     await expect(page.locator("#client-page-search-q")).toHaveText("test");
   });
@@ -193,7 +184,7 @@ test.describe('"use client" page component with usePathname (issue #688)', () =>
     page.on("pageerror", (err) => errors.push(err.message));
 
     await page.goto(`${BASE}/use-client-page-pathname/my-slug`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     await expect(page.locator("#client-page-dynamic-pathname")).toHaveText(
       "/use-client-page-pathname/my-slug",

--- a/tests/e2e/app-router/server-actions.spec.ts
+++ b/tests/e2e/app-router/server-actions.spec.ts
@@ -1,22 +1,13 @@
 import { test, expect } from "@playwright/test";
+import { waitForAppRouterHydration } from "../helpers";
 
 const BASE = "http://localhost:4174";
-
-/**
- * Wait for the RSC browser entry to hydrate.
- */
-async function waitForHydration(page: import("@playwright/test").Page) {
-  await expect(async () => {
-    const ready = await page.evaluate(() => !!(window as any).__VINEXT_RSC_ROOT__);
-    expect(ready).toBe(true);
-  }).toPass({ timeout: 10_000 });
-}
 
 test.describe("Server Actions", () => {
   test("like button calls server action and updates count", async ({ page }) => {
     await page.goto(`${BASE}/actions`);
     await expect(page.locator("h1")).toHaveText("Server Actions");
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     // Initial state
     await expect(page.locator('[data-testid="likes"]')).toContainText("Likes:");
@@ -41,7 +32,7 @@ test.describe("Server Actions", () => {
   test("message form calls server action with FormData", async ({ page }) => {
     await page.goto(`${BASE}/actions`);
     await expect(page.locator("h1")).toHaveText("Server Actions");
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     // Type a message and submit
     await page.fill('[data-testid="message-input"]', "Hello vinext!");
@@ -69,7 +60,7 @@ test.describe("Server Actions", () => {
   test("server action with redirect() navigates to target page", async ({ page }) => {
     await page.goto(`${BASE}/action-redirect-test`);
     await expect(page.locator("h1")).toHaveText("Action Redirect Test");
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     // Click the redirect button — should invoke redirectAction() which calls redirect("/about")
     await page.click('[data-testid="redirect-btn"]');
@@ -83,7 +74,7 @@ test.describe("Server Actions", () => {
     test.slow();
     await page.goto(`${BASE}/nextjs-compat/action-cookie-phase`);
     await expect(page.locator("h1")).toHaveText("Action Cookie Phase");
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
     await expect(page.locator("#cookie-value")).toHaveText("missing");
     await expect(page.locator("#cookie-error")).toContainText(
       "Cookies can only be modified in a Server Action or Route Handler",
@@ -174,7 +165,7 @@ test.describe("useActionState", () => {
   test("useActionState: redirect does not cause undefined state (issue #589)", async ({ page }) => {
     await page.goto(`${BASE}/action-state-redirect`);
     await expect(page.locator("h1")).toHaveText("useActionState Redirect Test");
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     // Initial state should be { success: false }
     await expect(async () => {

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -1,5 +1,24 @@
 import type { Page } from "@playwright/test";
+import { expect } from "@playwright/test";
 
-export async function waitForHydration(page: Page) {
+/**
+ * Wait for Pages Router hydration to complete.
+ * Checks for window.__VINEXT_ROOT__.
+ */
+export async function waitForHydration(page: Page): Promise<void> {
   await page.waitForFunction(() => Boolean(window.__VINEXT_ROOT__));
+}
+
+/**
+ * Wait for App Router (RSC) hydration to complete.
+ * Checks for window.__VINEXT_RSC_ROOT__.
+ *
+ * Uses expect().toPass() for better error messages on timeout.
+ * 10 second timeout matches Next.js hydration expectations.
+ */
+export async function waitForAppRouterHydration(page: Page): Promise<void> {
+  await expect(async () => {
+    const ready = await page.evaluate(() => Boolean(window.__VINEXT_RSC_ROOT__));
+    expect(ready).toBe(true);
+  }).toPass({ timeout: 10_000 });
 }


### PR DESCRIPTION
Addresses review comments from PR #690:

1. **Extract waitForHydration helper** (@james-elicx)
   - Added \`waitForAppRouterHydration()\` to \`tests/e2e/helpers.ts\`
   - Updated 19 App Router test files to use shared helper
   - Removes ~100 lines of duplicated code across test suite
   - Standardizes on \`expect().toPass()\` pattern for better error messages
   
Original comment here: https://github.com/cloudflare/vinext/pull/690#pullrequestreview-4047070113

2. **Apply ??= syntax nit** (@james-elicx)
   - Replaced \`if (!x) { x = {...} }\` with \`x ??= {...}\` in navigation.ts
   - Cleaner, idiomatic TypeScript for lazy initialization

Original comment here: https://github.com/cloudflare/vinext/pull/690#pullrequestreview-4047067498

**Verification:**
- vp check: ✅ all pass (0 lint/type errors)
- E2E subset (navigation-regressions.spec.ts): ✅ 11 passed