### PR TITLE
feat: add client primitives for layout persistence (Slot, Children, mergeElementsPromise)

### DIFF
--- a/packages/vinext/src/shims/slot.tsx
+++ b/packages/vinext/src/shims/slot.tsx
@@ -5,9 +5,12 @@ import { notFound } from "./navigation.js";
 
 export type Elements = Record<string, React.ReactNode | typeof UNMATCHED_SLOT>;
 
-// Shared across requests — safe because the resolved value is an immutable empty object.
+// Shared across requests — safe because the resolved value is frozen.
 // A Slot rendered outside an ElementsContext.Provider sees {} and returns null for all IDs.
-const EMPTY_ELEMENTS_PROMISE = Promise.resolve<Elements>({});
+const EMPTY_ELEMENTS_PROMISE = Promise.resolve<Elements>(Object.freeze({}));
+// Client-only optimisation: memoises merged promises by identity so React.use() sees a stable
+// reference across re-renders. During SSR each request creates fresh promises so the cache is
+// never hit, but the WeakMap entries are GC-eligible once the request's promises are collected.
 const mergeCache = new WeakMap<Promise<Elements>, WeakMap<Promise<Elements>, Promise<Elements>>>();
 
 export const UNMATCHED_SLOT = Symbol.for("vinext.unmatchedSlot");
@@ -56,13 +59,13 @@ export function Slot({
 }) {
   const elements = React.use(React.useContext(ElementsContext));
 
-  if (!(id in elements)) {
+  if (!Object.hasOwn(elements, id)) {
     return null;
   }
 
   const element = elements[id];
   if (element === UNMATCHED_SLOT) {
-    notFound();
+    notFound(); // throws — never reaches the JSX below
   }
 
   return (

--- a/tests/slot.test.ts
+++ b/tests/slot.test.ts
@@ -2,10 +2,6 @@ import React, { Suspense } from "react";
 import { renderToReadableStream } from "react-dom/server.edge";
 import { describe, expect, it, vi } from "vite-plus/test";
 
-vi.mock("next/navigation", () => ({
-  usePathname: () => "/",
-}));
-
 type Deferred<T> = {
   promise: Promise<T>;
   resolve: (value: T) => void;
@@ -236,25 +232,24 @@ describe("slot primitives", () => {
     const reader = stream.getReader();
     const decoder = new TextDecoder();
     const firstChunkPromise = reader.read();
+
+    // Verify the stream is suspended — reader.read() should not resolve synchronously
+    // because React.use() on the unresolved deferred throws to trigger Suspense.
+    // NOTE: Promise.race between two microtasks is engine-dependent, but reliable here
+    // because renderToReadableStream won't enqueue any chunk while the component is suspended.
     const firstReadState = await Promise.race([
       firstChunkPromise.then(() => "resolved"),
       Promise.resolve("pending"),
     ]);
-
     expect(firstReadState).toBe("pending");
 
-    const resolvedPromise = new Promise<void>((resolve) => {
-      setTimeout(() => {
-        deferred.resolve({
-          "layout:/": React.createElement("div", null, "resolved slot"),
-        });
-        resolve();
-      }, 20);
+    // Resolve the deferred so the stream can flush
+    deferred.resolve({
+      "layout:/": React.createElement("div", null, "resolved slot"),
     });
 
     const firstChunk = await firstChunkPromise;
     const firstHtml = decoder.decode(firstChunk.value, { stream: true });
-    await resolvedPromise;
 
     let rest = "";
     for (;;) {


### PR DESCRIPTION
## Summary

Part of #726 (PR 2a). Adds the client-side composition primitives that the flat keyed map architecture needs. These are purely additive — no existing code consumes them yet. PR 2c ("The Switch") wires them into the browser/SSR entries.

### New file: `packages/vinext/src/shims/slot.tsx`

Four `"use client"` exports that implement the Waku-inspired slot/children pattern:

- **`Slot`** — The core composition primitive. Reads an entry from the shared `Promise<Elements>` map by ID, provides children and parallel slots via context. Handles three states:
  - Key absent → return null (entry persists from prior soft nav)
  - `UNMATCHED_SLOT` sentinel → call `notFound()` (no `default.js` exists)
  - Any other value (including `null`) → render normally
- **`Children`** — How layouts render their child content. Reads from `ChildrenContext`, which `Slot` sets when rendering a layout entry. This maintains Next.js's `{children}` prop API.
- **`ParallelSlot`** — How layouts render named parallel slots (`@modal`, `@sidebar`). Reads from `ParallelSlotsContext`.
- **`mergeElementsPromise`** — The layout persistence mechanism. Shallow-merges new entries into existing ones with a double-nested WeakMap cache for referential stability (same `(prev, next)` promise pair always returns the same output Promise — critical for avoiding unnecessary React re-renders via `use()`).

### Design decisions

**`UNMATCHED_SLOT` uses `Symbol.for("vinext.unmatchedSlot")` instead of `null`** — because `default.tsx` can legitimately return `null` (e.g., `feed/@modal/default.tsx`). Using `null` as the sentinel would make it impossible to distinguish "render default.js which returned null" from "no default.js exists." See [design discussion in #726](https://github.com/cloudflare/vinext/issues/726#issuecomment-4167423501).

**RSC wire format note:** Symbols can't survive React's flight serialization. PR 2c handles the translation — the server uses a serializable marker, and the client translates to the Symbol after `createFromFetch()`. The `Slot` component always checks against the Symbol, never the wire format.

### Contexts

| Context | Default | Set by | Read by |
|---------|---------|--------|---------|
| `ElementsContext` | Empty resolved promise | `BrowserRoot` (PR 2c) | `Slot` |
| `ChildrenContext` | `null` | `Slot` | `Children` |
| `ParallelSlotsContext` | `null` | `Slot` (when `parallelSlots` prop provided) | `ParallelSlot` |

## Test plan

New test file: `tests/slot.test.ts` (10 tests)

- [x] All exports exist with correct types
- [x] `Children` renders null outside a `Slot` provider
- [x] `ParallelSlot` renders null outside a `Slot` provider
- [x] `Slot` renders matched element and provides children + parallel slots via context
- [x] `Slot` returns null for absent entries (soft nav persistence)
- [x] `Slot` throws `notFound()` for `UNMATCHED_SLOT` sentinel (with correct digest)
- [x] `Slot` renders `null` entries without triggering `notFound` (default.tsx returning null)
- [x] `mergeElementsPromise` shallow-merges with correct key semantics
- [x] `mergeElementsPromise` caches by input promise identity (WeakMap memoization)
- [x] `Slot` suspends on pending elements promise and streams with Suspense fallback

```
vp test run tests/slot.test.ts
```

Refs #726