### PR TITLE
test: E2E verification for layout persistence flat payload pipeline

### DIFF
--- a/tests/e2e/app-router/layout-persistence.spec.ts
+++ b/tests/e2e/app-router/layout-persistence.spec.ts
@@ -1,0 +1,228 @@
+import { test, expect } from "@playwright/test";
+
+const BASE = "http://localhost:4174";
+
+/**
+ * Wait for the RSC browser entry to hydrate.
+ */
+async function waitForHydration(page: import("@playwright/test").Page) {
+  await expect(async () => {
+    const ready = await page.evaluate(() => "__VINEXT_RSC_ROOT__" in window);
+    expect(ready).toBe(true);
+  }).toPass({ timeout: 10_000 });
+}
+
+// ---------------------------------------------------------------------------
+// 1. Layout persistence — navigate between sibling routes, prove the layout
+//    DOM survives and client state in it persists.
+// ---------------------------------------------------------------------------
+
+test.describe("Layout persistence", () => {
+  test("dashboard layout counter survives sibling navigation", async ({ page }) => {
+    await page.goto(`${BASE}/dashboard`);
+    await expect(page.locator("h1")).toHaveText("Dashboard");
+    await waitForHydration(page);
+
+    // Increment the counter in the dashboard layout
+    await page.click('[data-testid="layout-increment"]');
+    await page.click('[data-testid="layout-increment"]');
+    await page.click('[data-testid="layout-increment"]');
+    await expect(page.locator('[data-testid="layout-count"]')).toHaveText("Layout count: 3");
+
+    // Navigate to settings (sibling route under same layout)
+    await page.click('[data-testid="dash-settings-link"]');
+    await expect(page.locator("h1")).toHaveText("Settings");
+
+    // Layout counter should still be 3 — the layout was NOT remounted
+    await expect(page.locator('[data-testid="layout-count"]')).toHaveText("Layout count: 3");
+
+    // Navigate back to dashboard home
+    await page.click('[data-testid="dash-home-link"]');
+    await expect(page.locator("h1")).toHaveText("Dashboard");
+
+    // Counter should still be 3
+    await expect(page.locator('[data-testid="layout-count"]')).toHaveText("Layout count: 3");
+  });
+
+  test("layout counter resets on hard navigation", async ({ page }) => {
+    await page.goto(`${BASE}/dashboard`);
+    await waitForHydration(page);
+
+    // Increment counter
+    await page.click('[data-testid="layout-increment"]');
+    await expect(page.locator('[data-testid="layout-count"]')).toHaveText("Layout count: 1");
+
+    // Hard navigation (full page load) should reset everything
+    await page.goto(`${BASE}/dashboard`);
+    await waitForHydration(page);
+
+    await expect(page.locator('[data-testid="layout-count"]')).toHaveText("Layout count: 0");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Template remount — prove template state resets on segment boundary
+//    change but persists on search param change.
+// ---------------------------------------------------------------------------
+
+test.describe("Template remount", () => {
+  test("root template counter resets when navigating between top-level segments", async ({
+    page,
+  }) => {
+    await page.goto(`${BASE}/`);
+    await expect(page.locator("h1")).toHaveText("Welcome to App Router");
+    await waitForHydration(page);
+
+    // Increment the template counter
+    await page.click('[data-testid="template-increment"]');
+    await page.click('[data-testid="template-increment"]');
+    await expect(page.locator('[data-testid="template-count"]')).toHaveText("Template count: 2");
+
+    // Navigate to /about — this changes the root segment from "" to "about",
+    // so the root template should remount and the counter should reset.
+    await page.click('a[href="/about"]');
+    await expect(page.locator("h1")).toHaveText("About");
+
+    await expect(page.locator('[data-testid="template-count"]')).toHaveText("Template count: 0");
+  });
+
+  test("root template counter persists within same top-level segment", async ({ page }) => {
+    await page.goto(`${BASE}/dashboard`);
+    await expect(page.locator("h1")).toHaveText("Dashboard");
+    await waitForHydration(page);
+
+    // Increment the template counter
+    await page.click('[data-testid="template-increment"]');
+    await page.click('[data-testid="template-increment"]');
+    await expect(page.locator('[data-testid="template-count"]')).toHaveText("Template count: 2");
+
+    // Navigate to /dashboard/settings — this is still under the "dashboard"
+    // top-level segment, so the root template should NOT remount.
+    await page.click('[data-testid="dash-settings-link"]');
+    await expect(page.locator("h1")).toHaveText("Settings");
+
+    await expect(page.locator('[data-testid="template-count"]')).toHaveText("Template count: 2");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Error recovery — trigger an error, navigate away via client nav,
+//    navigate back, prove the error is gone and normal content renders.
+// ---------------------------------------------------------------------------
+
+test.describe("Error recovery across navigation", () => {
+  test("navigating away from error and back clears the error", async ({ page }) => {
+    await page.goto(`${BASE}/error-test`);
+    await expect(page.locator('[data-testid="error-content"]')).toBeVisible();
+    await waitForHydration(page);
+
+    // Trigger error
+    await expect(async () => {
+      await page.click('[data-testid="trigger-error"]');
+      await expect(page.locator("#error-boundary")).toBeVisible({ timeout: 2_000 });
+    }).toPass({ timeout: 15_000 });
+
+    // Error boundary should be visible
+    await expect(page.locator("#error-boundary")).toBeVisible();
+
+    // Client-navigate away to home via the link in the error boundary
+    await page.click('[data-testid="error-go-home"]');
+    await expect(page.locator("h1")).toHaveText("Welcome to App Router");
+
+    // Client-navigate back to error-test via link on home page
+    await page.click('[data-testid="error-test-link"]');
+
+    // Error should be gone — fresh page renders normally
+    await expect(page.locator('[data-testid="error-content"]')).toBeVisible({ timeout: 5_000 });
+    await expect(page.locator("#error-boundary")).not.toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Back/forward — navigate through a sequence, go back, prove layout
+//    state survived the round trip.
+// ---------------------------------------------------------------------------
+
+test.describe("Back/forward with layout state", () => {
+  test("browser back preserves layout counter across navigation history", async ({ page }) => {
+    await page.goto(`${BASE}/dashboard`);
+    await expect(page.locator("h1")).toHaveText("Dashboard");
+    await waitForHydration(page);
+
+    // Increment layout counter to 2
+    await page.click('[data-testid="layout-increment"]');
+    await page.click('[data-testid="layout-increment"]');
+    await expect(page.locator('[data-testid="layout-count"]')).toHaveText("Layout count: 2");
+
+    // Navigate: dashboard → settings
+    await page.click('[data-testid="dash-settings-link"]');
+    await expect(page.locator("h1")).toHaveText("Settings");
+
+    // Counter should still be 2 (layout persisted)
+    await expect(page.locator('[data-testid="layout-count"]')).toHaveText("Layout count: 2");
+
+    // Increment once more while on settings
+    await page.click('[data-testid="layout-increment"]');
+    await expect(page.locator('[data-testid="layout-count"]')).toHaveText("Layout count: 3");
+
+    // Go back to dashboard
+    await page.goBack();
+    await expect(page.locator("h1")).toHaveText("Dashboard");
+
+    // Counter should still be 3 — back/forward doesn't remount the layout
+    await expect(page.locator('[data-testid="layout-count"]')).toHaveText("Layout count: 3");
+
+    // Go forward to settings
+    await page.goForward();
+    await expect(page.locator("h1")).toHaveText("Settings");
+
+    // Counter should still be 3
+    await expect(page.locator('[data-testid="layout-count"]')).toHaveText("Layout count: 3");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Parallel slots — soft nav keeps slot content; hard load shows default.
+// ---------------------------------------------------------------------------
+
+test.describe("Parallel slot persistence", () => {
+  test("parallel slot content persists on soft navigation to child route", async ({ page }) => {
+    // Load /dashboard — parallel slots @team and @analytics have page.tsx
+    await page.goto(`${BASE}/dashboard`);
+    await expect(page.locator("h1")).toHaveText("Dashboard");
+    await waitForHydration(page);
+
+    // Verify slot content is visible
+    await expect(page.locator('[data-testid="team-panel"]')).toBeVisible();
+    await expect(page.locator('[data-testid="analytics-panel"]')).toBeVisible();
+    await expect(page.locator('[data-testid="team-slot"]')).toBeVisible();
+    await expect(page.locator('[data-testid="analytics-slot"]')).toBeVisible();
+
+    // Soft navigate to /dashboard/settings
+    await page.click('[data-testid="dash-settings-link"]');
+    await expect(page.locator("h1")).toHaveText("Settings");
+
+    // Parallel slot content should persist from the soft nav —
+    // the slots don't have a page.tsx for /settings, so the previous
+    // slot content is retained (absent key = persisted from prior soft nav).
+    await expect(page.locator('[data-testid="team-panel"]')).toBeVisible();
+    await expect(page.locator('[data-testid="analytics-panel"]')).toBeVisible();
+  });
+
+  test("parallel slots show default.tsx on hard navigation to child route", async ({ page }) => {
+    // Hard-load /dashboard/settings directly — slots should show default.tsx
+    await page.goto(`${BASE}/dashboard/settings`);
+    await expect(page.locator("h1")).toHaveText("Settings");
+    await waitForHydration(page);
+
+    // On hard load, slots should render their default.tsx content
+    await expect(page.locator('[data-testid="team-panel"]')).toBeVisible();
+    await expect(page.locator('[data-testid="analytics-panel"]')).toBeVisible();
+    await expect(page.locator('[data-testid="team-default"]')).toBeVisible();
+    await expect(page.locator('[data-testid="analytics-default"]')).toBeVisible();
+
+    // The page-specific slot content should NOT be visible
+    await expect(page.locator('[data-testid="team-slot"]')).not.toBeVisible();
+    await expect(page.locator('[data-testid="analytics-slot"]')).not.toBeVisible();
+  });
+});

--- a/tests/e2e/app-router/layout-persistence.spec.ts
+++ b/tests/e2e/app-router/layout-persistence.spec.ts
@@ -100,9 +100,9 @@ test.describe("Layout persistence", () => {
     await page.goto(`${BASE}/dashboard`);
     await waitForAppRouterHydration(page);
 
-    await waitForInteractiveCounter(page, layoutCounter);
-    await incrementCounter(page, layoutCounter, 2);
-    await incrementCounter(page, layoutCounter, 3);
+    const countAfterHydration = await waitForInteractiveCounter(page, layoutCounter);
+    await incrementCounter(page, layoutCounter, countAfterHydration + 1);
+    await incrementCounter(page, layoutCounter, countAfterHydration + 2);
 
     // Hard navigation (full page load) should reset everything
     await page.goto(`${BASE}/dashboard`);
@@ -202,7 +202,7 @@ test.describe("Error recovery across navigation", () => {
 
     // Error should be gone — fresh page renders normally
     await expect(page.locator('[data-testid="error-content"]')).toBeVisible({ timeout: 5_000 });
-    await expect(page.locator("#error-boundary")).not.toBeVisible();
+    await expect(page.locator("#error-boundary")).not.toBeAttached();
   });
 });
 
@@ -271,8 +271,8 @@ test.describe("Parallel slot persistence", () => {
     await expect(page.locator('[data-testid="analytics-panel"]')).toBeVisible();
     await expect(page.locator('[data-testid="team-slot"]')).toBeVisible();
     await expect(page.locator('[data-testid="analytics-slot"]')).toBeVisible();
-    await expect(page.locator('[data-testid="team-default"]')).not.toBeVisible();
-    await expect(page.locator('[data-testid="analytics-default"]')).not.toBeVisible();
+    await expect(page.locator('[data-testid="team-default"]')).not.toBeAttached();
+    await expect(page.locator('[data-testid="analytics-default"]')).not.toBeAttached();
   });
 
   test("parallel slots show default.tsx on hard navigation to child route", async ({ page }) => {

--- a/tests/e2e/app-router/layout-persistence.spec.ts
+++ b/tests/e2e/app-router/layout-persistence.spec.ts
@@ -1,16 +1,70 @@
 import { test, expect } from "@playwright/test";
+import { waitForAppRouterHydration } from "../helpers";
 
 const BASE = "http://localhost:4174";
 
-/**
- * Wait for the RSC browser entry to hydrate.
- */
-async function waitForHydration(page: import("@playwright/test").Page) {
-  await expect(async () => {
-    const ready = await page.evaluate(() => "__VINEXT_RSC_ROOT__" in window);
-    expect(ready).toBe(true);
-  }).toPass({ timeout: 10_000 });
+type CounterControls = {
+  countTestId: string;
+  incrementTestId: string;
+  label: string;
+};
+
+async function readCounterValue(
+  page: import("@playwright/test").Page,
+  { countTestId, label }: CounterControls,
+): Promise<number> {
+  const text = await page.getByTestId(countTestId).textContent();
+  if (text == null) {
+    throw new Error(`Missing counter text for ${countTestId}`);
+  }
+
+  const expectedPrefix = `${label}: `;
+  if (!text.startsWith(expectedPrefix)) {
+    throw new Error(`Unexpected counter text for ${countTestId}: ${text}`);
+  }
+
+  return Number.parseInt(text.slice(expectedPrefix.length), 10);
 }
+
+async function waitForInteractiveCounter(
+  page: import("@playwright/test").Page,
+  controls: CounterControls,
+): Promise<number> {
+  const incrementButton = page.getByTestId(controls.incrementTestId);
+  await incrementButton.waitFor({ state: "visible" });
+
+  await expect(async () => {
+    const before = await readCounterValue(page, controls);
+    await incrementButton.click();
+    const after = await readCounterValue(page, controls);
+    expect(after).toBeGreaterThan(before);
+  }).toPass({ timeout: 10_000 });
+
+  return readCounterValue(page, controls);
+}
+
+async function incrementCounter(
+  page: import("@playwright/test").Page,
+  controls: CounterControls,
+  expectedValue: number,
+) {
+  await page.getByTestId(controls.incrementTestId).click();
+  await expect(page.getByTestId(controls.countTestId)).toHaveText(
+    `${controls.label}: ${expectedValue}`,
+  );
+}
+
+const layoutCounter = {
+  countTestId: "layout-count",
+  incrementTestId: "layout-increment",
+  label: "Layout count",
+} as const;
+
+const templateCounter = {
+  countTestId: "template-count",
+  incrementTestId: "template-increment",
+  label: "Template count",
+} as const;
 
 // ---------------------------------------------------------------------------
 // 1. Layout persistence — navigate between sibling routes, prove the layout
@@ -21,42 +75,38 @@ test.describe("Layout persistence", () => {
   test("dashboard layout counter survives sibling navigation", async ({ page }) => {
     await page.goto(`${BASE}/dashboard`);
     await expect(page.locator("h1")).toHaveText("Dashboard");
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
-    // Increment the counter in the dashboard layout
-    await page.click('[data-testid="layout-increment"]');
-    await page.click('[data-testid="layout-increment"]');
-    await page.click('[data-testid="layout-increment"]');
-    await expect(page.locator('[data-testid="layout-count"]')).toHaveText("Layout count: 3");
+    // Prove the counter is interactive before asserting exact values.
+    const initialCount = await waitForInteractiveCounter(page, layoutCounter);
+    await incrementCounter(page, layoutCounter, initialCount + 1);
+    await incrementCounter(page, layoutCounter, initialCount + 2);
 
     // Navigate to settings (sibling route under same layout)
-    await page.click('[data-testid="dash-settings-link"]');
+    await page.getByTestId("dash-settings-link").click();
     await expect(page.locator("h1")).toHaveText("Settings");
 
-    // Layout counter should still be 3 — the layout was NOT remounted
-    await expect(page.locator('[data-testid="layout-count"]')).toHaveText("Layout count: 3");
+    // Layout counter should preserve its value — the layout was NOT remounted.
+    await expect(page.getByTestId("layout-count")).toHaveText(`Layout count: ${initialCount + 2}`);
 
     // Navigate back to dashboard home
-    await page.click('[data-testid="dash-home-link"]');
+    await page.getByTestId("dash-home-link").click();
     await expect(page.locator("h1")).toHaveText("Dashboard");
 
-    // Counter should still be 3
-    await expect(page.locator('[data-testid="layout-count"]')).toHaveText("Layout count: 3");
+    await expect(page.getByTestId("layout-count")).toHaveText(`Layout count: ${initialCount + 2}`);
   });
 
   test("layout counter resets on hard navigation", async ({ page }) => {
     await page.goto(`${BASE}/dashboard`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
-    // Increment counter
-    await page.click('[data-testid="layout-increment"]');
-    await expect(page.locator('[data-testid="layout-count"]')).toHaveText("Layout count: 1");
+    expect(await waitForInteractiveCounter(page, layoutCounter)).toBeGreaterThan(0);
 
     // Hard navigation (full page load) should reset everything
     await page.goto(`${BASE}/dashboard`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
-    await expect(page.locator('[data-testid="layout-count"]')).toHaveText("Layout count: 0");
+    await expect(page.getByTestId("layout-count")).toHaveText("Layout count: 0");
   });
 });
 
@@ -71,37 +121,35 @@ test.describe("Template remount", () => {
   }) => {
     await page.goto(`${BASE}/`);
     await expect(page.locator("h1")).toHaveText("Welcome to App Router");
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
-    // Increment the template counter
-    await page.click('[data-testid="template-increment"]');
-    await page.click('[data-testid="template-increment"]');
-    await expect(page.locator('[data-testid="template-count"]')).toHaveText("Template count: 2");
+    const initialCount = await waitForInteractiveCounter(page, templateCounter);
+    await incrementCounter(page, templateCounter, initialCount + 1);
 
     // Navigate to /about — this changes the root segment from "" to "about",
     // so the root template should remount and the counter should reset.
     await page.click('a[href="/about"]');
     await expect(page.locator("h1")).toHaveText("About");
 
-    await expect(page.locator('[data-testid="template-count"]')).toHaveText("Template count: 0");
+    await expect(page.getByTestId("template-count")).toHaveText("Template count: 0");
   });
 
   test("root template counter persists within same top-level segment", async ({ page }) => {
     await page.goto(`${BASE}/dashboard`);
     await expect(page.locator("h1")).toHaveText("Dashboard");
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
-    // Increment the template counter
-    await page.click('[data-testid="template-increment"]');
-    await page.click('[data-testid="template-increment"]');
-    await expect(page.locator('[data-testid="template-count"]')).toHaveText("Template count: 2");
+    const initialCount = await waitForInteractiveCounter(page, templateCounter);
+    await incrementCounter(page, templateCounter, initialCount + 1);
 
     // Navigate to /dashboard/settings — this is still under the "dashboard"
     // top-level segment, so the root template should NOT remount.
-    await page.click('[data-testid="dash-settings-link"]');
+    await page.getByTestId("dash-settings-link").click();
     await expect(page.locator("h1")).toHaveText("Settings");
 
-    await expect(page.locator('[data-testid="template-count"]')).toHaveText("Template count: 2");
+    await expect(page.getByTestId("template-count")).toHaveText(
+      `Template count: ${initialCount + 1}`,
+    );
   });
 });
 
@@ -114,7 +162,7 @@ test.describe("Error recovery across navigation", () => {
   test("navigating away from error and back clears the error", async ({ page }) => {
     await page.goto(`${BASE}/error-test`);
     await expect(page.locator('[data-testid="error-content"]')).toBeVisible();
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     // Trigger error
     await expect(async () => {
@@ -147,37 +195,31 @@ test.describe("Back/forward with layout state", () => {
   test("browser back preserves layout counter across navigation history", async ({ page }) => {
     await page.goto(`${BASE}/dashboard`);
     await expect(page.locator("h1")).toHaveText("Dashboard");
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
-    // Increment layout counter to 2
-    await page.click('[data-testid="layout-increment"]');
-    await page.click('[data-testid="layout-increment"]');
-    await expect(page.locator('[data-testid="layout-count"]')).toHaveText("Layout count: 2");
+    const initialCount = await waitForInteractiveCounter(page, layoutCounter);
+    await incrementCounter(page, layoutCounter, initialCount + 1);
 
     // Navigate: dashboard → settings
-    await page.click('[data-testid="dash-settings-link"]');
+    await page.getByTestId("dash-settings-link").click();
     await expect(page.locator("h1")).toHaveText("Settings");
 
-    // Counter should still be 2 (layout persisted)
-    await expect(page.locator('[data-testid="layout-count"]')).toHaveText("Layout count: 2");
+    await expect(page.getByTestId("layout-count")).toHaveText(`Layout count: ${initialCount + 1}`);
 
     // Increment once more while on settings
-    await page.click('[data-testid="layout-increment"]');
-    await expect(page.locator('[data-testid="layout-count"]')).toHaveText("Layout count: 3");
+    await incrementCounter(page, layoutCounter, initialCount + 2);
 
     // Go back to dashboard
     await page.goBack();
     await expect(page.locator("h1")).toHaveText("Dashboard");
 
-    // Counter should still be 3 — back/forward doesn't remount the layout
-    await expect(page.locator('[data-testid="layout-count"]')).toHaveText("Layout count: 3");
+    await expect(page.getByTestId("layout-count")).toHaveText(`Layout count: ${initialCount + 2}`);
 
     // Go forward to settings
     await page.goForward();
     await expect(page.locator("h1")).toHaveText("Settings");
 
-    // Counter should still be 3
-    await expect(page.locator('[data-testid="layout-count"]')).toHaveText("Layout count: 3");
+    await expect(page.getByTestId("layout-count")).toHaveText(`Layout count: ${initialCount + 2}`);
   });
 });
 
@@ -190,7 +232,7 @@ test.describe("Parallel slot persistence", () => {
     // Load /dashboard — parallel slots @team and @analytics have page.tsx
     await page.goto(`${BASE}/dashboard`);
     await expect(page.locator("h1")).toHaveText("Dashboard");
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     // Verify slot content is visible
     await expect(page.locator('[data-testid="team-panel"]')).toBeVisible();
@@ -213,7 +255,7 @@ test.describe("Parallel slot persistence", () => {
     // Hard-load /dashboard/settings directly — slots should show default.tsx
     await page.goto(`${BASE}/dashboard/settings`);
     await expect(page.locator("h1")).toHaveText("Settings");
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     // On hard load, slots should render their default.tsx content
     await expect(page.locator('[data-testid="team-panel"]')).toBeVisible();

--- a/tests/e2e/app-router/layout-persistence.spec.ts
+++ b/tests/e2e/app-router/layout-persistence.spec.ts
@@ -1,6 +1,18 @@
 import { test, expect } from "@playwright/test";
 import { waitForAppRouterHydration } from "../helpers";
 
+async function disableViteErrorOverlay(page: import("@playwright/test").Page) {
+  // Vite's dev error overlay can appear during tests (even for expected errors)
+  // and intercept pointer events, causing flaky click failures.
+  await page
+    .addStyleTag({
+      content: "vite-error-overlay{display:none !important; pointer-events:none !important;}",
+    })
+    .catch(() => {
+      // best effort
+    });
+}
+
 const BASE = "http://localhost:4174";
 
 type CounterControls = {
@@ -186,6 +198,10 @@ test.describe("Error recovery across navigation", () => {
     await expect(page.locator('[data-testid="error-content"]')).toBeVisible();
     await waitForAppRouterHydration(page);
 
+    // Hide Vite's dev error overlay before triggering an error — it can appear
+    // over interactive elements and intercept pointer events, causing flaky failures.
+    await disableViteErrorOverlay(page);
+
     // Trigger error
     await page.getByTestId("trigger-error").waitFor({ state: "visible" });
     await page.getByTestId("trigger-error").click();
@@ -287,8 +303,9 @@ test.describe("Parallel slot persistence", () => {
     await expect(page.locator('[data-testid="team-default"]')).toBeVisible();
     await expect(page.locator('[data-testid="analytics-default"]')).toBeVisible();
 
-    // The page-specific slot content should NOT be visible
-    await expect(page.locator('[data-testid="team-slot"]')).not.toBeVisible();
-    await expect(page.locator('[data-testid="analytics-slot"]')).not.toBeVisible();
+    // The page-specific slot content should not be in the DOM at all —
+    // the server rendered default.tsx for these slots, not page.tsx.
+    await expect(page.locator('[data-testid="team-slot"]')).not.toBeAttached();
+    await expect(page.locator('[data-testid="analytics-slot"]')).not.toBeAttached();
   });
 });

--- a/tests/e2e/app-router/layout-persistence.spec.ts
+++ b/tests/e2e/app-router/layout-persistence.spec.ts
@@ -100,7 +100,9 @@ test.describe("Layout persistence", () => {
     await page.goto(`${BASE}/dashboard`);
     await waitForAppRouterHydration(page);
 
-    expect(await waitForInteractiveCounter(page, layoutCounter)).toBeGreaterThan(0);
+    await waitForInteractiveCounter(page, layoutCounter);
+    await incrementCounter(page, layoutCounter, 2);
+    await incrementCounter(page, layoutCounter, 3);
 
     // Hard navigation (full page load) should reset everything
     await page.goto(`${BASE}/dashboard`);
@@ -151,6 +153,26 @@ test.describe("Template remount", () => {
       `Template count: ${initialCount + 1}`,
     );
   });
+
+  test("template counter does not reset on search param change within same segment", async ({
+    page,
+  }) => {
+    await page.goto(`${BASE}/dashboard`);
+    await expect(page.locator("h1")).toHaveText("Dashboard");
+    await waitForAppRouterHydration(page);
+
+    const initialCount = await waitForInteractiveCounter(page, templateCounter);
+    await incrementCounter(page, templateCounter, initialCount + 1);
+
+    // Navigate to /dashboard?tab=settings — same pathname, only search params change.
+    // The root segment stays "dashboard", so the root template must NOT remount.
+    await page.getByTestId("dash-tab-link").click();
+    await expect(page.locator("h1")).toHaveText("Dashboard");
+
+    await expect(page.getByTestId("template-count")).toHaveText(
+      `Template count: ${initialCount + 1}`,
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -165,13 +187,11 @@ test.describe("Error recovery across navigation", () => {
     await waitForAppRouterHydration(page);
 
     // Trigger error
-    await expect(async () => {
-      await page.click('[data-testid="trigger-error"]');
-      await expect(page.locator("#error-boundary")).toBeVisible({ timeout: 2_000 });
-    }).toPass({ timeout: 15_000 });
+    await page.getByTestId("trigger-error").waitFor({ state: "visible" });
+    await page.getByTestId("trigger-error").click();
 
     // Error boundary should be visible
-    await expect(page.locator("#error-boundary")).toBeVisible();
+    await expect(page.locator("#error-boundary")).toBeVisible({ timeout: 10_000 });
 
     // Client-navigate away to home via the link in the error boundary
     await page.click('[data-testid="error-go-home"]');
@@ -249,6 +269,10 @@ test.describe("Parallel slot persistence", () => {
     // slot content is retained (absent key = persisted from prior soft nav).
     await expect(page.locator('[data-testid="team-panel"]')).toBeVisible();
     await expect(page.locator('[data-testid="analytics-panel"]')).toBeVisible();
+    await expect(page.locator('[data-testid="team-slot"]')).toBeVisible();
+    await expect(page.locator('[data-testid="analytics-slot"]')).toBeVisible();
+    await expect(page.locator('[data-testid="team-default"]')).not.toBeVisible();
+    await expect(page.locator('[data-testid="analytics-default"]')).not.toBeVisible();
   });
 
   test("parallel slots show default.tsx on hard navigation to child route", async ({ page }) => {

--- a/tests/fixtures/app-basic/app/components/layout-counter.tsx
+++ b/tests/fixtures/app-basic/app/components/layout-counter.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { useState } from "react";
+
+/**
+ * Client counter used to verify layout persistence.
+ * If the layout remounts, this counter resets to 0.
+ * If the layout persists across navigation, the counter retains its value.
+ */
+export function LayoutCounter() {
+  const [count, setCount] = useState(0);
+
+  return (
+    <div data-testid="layout-counter">
+      <span data-testid="layout-count">Layout count: {count}</span>
+      <button data-testid="layout-increment" onClick={() => setCount((c) => c + 1)}>
+        +1
+      </button>
+    </div>
+  );
+}

--- a/tests/fixtures/app-basic/app/components/template-counter.tsx
+++ b/tests/fixtures/app-basic/app/components/template-counter.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { useState } from "react";
+
+/**
+ * Client counter used to verify template remount behavior.
+ * Templates remount when navigation crosses their segment boundary,
+ * so this counter should reset. But search param changes within the
+ * same segment should NOT cause a remount, so the counter persists.
+ */
+export function TemplateCounter() {
+  const [count, setCount] = useState(0);
+
+  return (
+    <div data-testid="template-counter">
+      <span data-testid="template-count">Template count: {count}</span>
+      <button data-testid="template-increment" onClick={() => setCount((c) => c + 1)}>
+        +1
+      </button>
+    </div>
+  );
+}

--- a/tests/fixtures/app-basic/app/dashboard/layout.tsx
+++ b/tests/fixtures/app-basic/app/dashboard/layout.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+import { LayoutCounter } from "../components/layout-counter";
 import { SegmentDisplay } from "./segment-display";
 
 export default function DashboardLayout({
@@ -13,7 +15,14 @@ export default function DashboardLayout({
     <div id="dashboard-layout">
       <nav>
         <span>Dashboard Nav</span>
+        <Link href="/dashboard" data-testid="dash-home-link">
+          Dashboard Home
+        </Link>
+        <Link href="/dashboard/settings" data-testid="dash-settings-link">
+          Settings
+        </Link>
       </nav>
+      <LayoutCounter />
       <SegmentDisplay />
       <section>{children}</section>
       {team && <aside data-testid="team-panel">{team}</aside>}

--- a/tests/fixtures/app-basic/app/dashboard/page.tsx
+++ b/tests/fixtures/app-basic/app/dashboard/page.tsx
@@ -1,8 +1,13 @@
+import Link from "next/link";
+
 export default function DashboardPage() {
   return (
     <div>
       <h1>Dashboard</h1>
       <p>Welcome to your dashboard.</p>
+      <Link href="/dashboard?tab=settings" data-testid="dash-tab-link">
+        Settings Tab
+      </Link>
     </div>
   );
 }

--- a/tests/fixtures/app-basic/app/error-test/error.tsx
+++ b/tests/fixtures/app-basic/app/error-test/error.tsx
@@ -1,11 +1,16 @@
 "use client";
 
+import Link from "next/link";
+
 export default function ErrorPage({ error, reset }: { error: Error; reset: () => void }) {
   return (
     <div id="error-boundary">
       <h2>Something went wrong!</h2>
       <p>{error.message}</p>
       <button onClick={reset}>Try again</button>
+      <Link href="/" data-testid="error-go-home">
+        Go home
+      </Link>
     </div>
   );
 }

--- a/tests/fixtures/app-basic/app/page.tsx
+++ b/tests/fixtures/app-basic/app/page.tsx
@@ -21,6 +21,9 @@ export default function HomePage() {
         <Link href="/nav-flash/list" data-testid="nav-flash-list-link">
           Nav Flash List
         </Link>
+        <Link href="/error-test" data-testid="error-test-link">
+          Error Test
+        </Link>
       </nav>
     </main>
   );

--- a/tests/fixtures/app-basic/app/template.tsx
+++ b/tests/fixtures/app-basic/app/template.tsx
@@ -1,3 +1,5 @@
+import { TemplateCounter } from "./components/template-counter";
+
 /**
  * Root template — wraps all pages but re-mounts on navigation.
  * Unlike layout.tsx, template.tsx creates a new instance for each route.
@@ -6,6 +8,7 @@ export default function RootTemplate({ children }: { children: React.ReactNode }
   return (
     <div data-testid="root-template">
       <div className="template-header">Template Active</div>
+      <TemplateCounter />
       {children}
     </div>
   );


### PR DESCRIPTION
## Summary

Part of #726 (PR 3). Pure test code — zero production changes. Proves the flat keyed map payload pipeline from PR 2c actually works end-to-end in a real browser.

Every test answers: "would a real user notice if this broke?" Layout state surviving navigation, template state resetting on segment change, errors clearing on re-navigation — these are observable user behaviors, not implementation details.

### What's tested

| Behavior | Method |
|----------|--------|
| Layout state persists across sibling navigation | Client counter in dashboard layout survives dashboard → settings → dashboard |
| Layout state resets on hard navigation | `page.goto()` resets counter vs Link click preserving it |
| Template remounts on segment boundary change | Root template counter resets on `/` → `/about` (segment changes) |
| Template persists within same segment | Root template counter survives `/dashboard` → `/dashboard/settings` (same top-level segment) |
| Error clears on navigate-away-and-back | Trigger error → client-nav to home → client-nav back → fresh page |
| Back/forward preserves layout state | Counter survives `goBack()` / `goForward()` through dashboard history |
| Parallel slots persist on soft nav | `@team` and `@analytics` slot content survives `/dashboard` → `/dashboard/settings` |
| Parallel slots show default on hard nav | Direct load of `/dashboard/settings` renders `default.tsx` instead of page slot content |

### What's NOT tested here (and why)

- **Root layout switch** — requires restructuring fixtures into route groups with separate root layouts. Already unit-tested via `shouldHardNavigate` in `tests/app-browser-entry.test.ts`
- **RSC payload structure** — implementation detail, covered by unit tests in PR 2c
- **Reducer dispatch types** — wiring, not user-observable behavior

### Fixture changes

Minimal additions to `tests/fixtures/app-basic/` to make behaviors observable:

- `app/components/layout-counter.tsx` — `"use client"` counter proving layout persistence
- `app/components/template-counter.tsx` — `"use client"` counter proving template remount
- `app/dashboard/layout.tsx` — added LayoutCounter + nav links between dashboard pages
- `app/template.tsx` — added TemplateCounter
- `app/error-test/error.tsx` — added "Go home" Link for error recovery navigation
- `app/page.tsx` — added "Error Test" Link

All existing E2E tests (navigation, error-handling, navigation-flows — 25 tests) still pass with these fixture changes.

## Test plan

- [x] `tests/e2e/app-router/layout-persistence.spec.ts` — 8 E2E tests, all passing
- [x] Existing navigation/error-handling/navigation-flows E2E — 25 tests, no regressions
- [x] `tests/app-router.test.ts -t "not-found|forbidden|unauthorized"` — 5 SSR integration tests, all passing
- [x] `vp check` — 0 lint/type errors