### PR TITLE
feat: encode interception context in App Router payload IDs and caches

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -59,6 +59,7 @@ const appPageBoundaryRenderPath = resolveEntryPath(
   "../server/app-page-boundary-render.js",
   import.meta.url,
 );
+const appElementsPath = resolveEntryPath("../server/app-elements.js", import.meta.url);
 const appPageRouteWiringPath = resolveEntryPath(
   "../server/app-page-route-wiring.js",
   import.meta.url,
@@ -390,6 +391,10 @@ import {
   renderAppPageErrorBoundary as __renderAppPageErrorBoundary,
   renderAppPageHttpAccessFallback as __renderAppPageHttpAccessFallback,
 } from ${JSON.stringify(appPageBoundaryRenderPath)};
+import {
+  APP_INTERCEPTION_CONTEXT_KEY as __APP_INTERCEPTION_CONTEXT_KEY,
+  createAppPayloadRouteId as __createAppPayloadRouteId,
+} from ${JSON.stringify(appElementsPath)};
 import {
   buildAppPageElements as __buildAppPageElements,
   createAppPageTreePath as __createAppPageTreePath,
@@ -933,7 +938,8 @@ function findIntercept(pathname) {
 async function buildPageElements(route, params, routePath, opts, searchParams, isRscRequest, request) {
   const PageComponent = route.page?.default;
   if (!PageComponent) {
-    const _noExportRouteId = "route:" + routePath;
+    const _interceptionContext = opts?.interceptionContext ?? null;
+    const _noExportRouteId = __createAppPayloadRouteId(routePath, _interceptionContext);
     let _noExportRootLayout = null;
     if (route.layouts?.length > 0) {
       // Compute the root layout tree path for this error payload using the
@@ -942,6 +948,7 @@ async function buildPageElements(route, params, routePath, opts, searchParams, i
       _noExportRootLayout = __createAppPageTreePath(route.routeSegments, _tp);
     }
     return {
+      [__APP_INTERCEPTION_CONTEXT_KEY]: _interceptionContext,
       __route: _noExportRouteId,
       __rootLayout: _noExportRootLayout,
       [_noExportRouteId]: createElement("div", null, "Page has no default export"),
@@ -1061,6 +1068,7 @@ async function buildPageElements(route, params, routePath, opts, searchParams, i
     matchedParams: params,
     resolvedMetadata,
     resolvedViewport,
+    interceptionContext: opts?.interceptionContext ?? null,
     routePath,
     rootNotFoundModule: ${rootNotFoundVar ? rootNotFoundVar : "null"},
     route,
@@ -1404,6 +1412,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   }
 
   const isRscRequest = pathname.endsWith(".rsc") || request.headers.get("accept")?.includes("text/x-component");
+  const interceptionContextHeader = request.headers.get("X-Vinext-Interception-Context");
   let cleanPathname = pathname.replace(/\\.rsc$/, "");
 
   // Middleware response headers and custom rewrite status are stored in
@@ -1812,8 +1821,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           request,
         );
       } else {
-        const _actionRouteId = "route:" + cleanPathname;
+        const _actionRouteId = __createAppPayloadRouteId(cleanPathname, null);
         element = {
+          [__APP_INTERCEPTION_CONTEXT_KEY]: null,
           __route: _actionRouteId,
           __rootLayout: null,
           [_actionRouteId]: createElement("div", null, "Page not found"),
@@ -2302,6 +2312,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     setNavigationContext,
     toInterceptOpts(intercept) {
       return {
+        interceptionContext: interceptionContextHeader,
         interceptSlotKey: intercept.slotKey,
         interceptPage: intercept.page,
         interceptParams: intercept.matchedParams,

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -1412,7 +1412,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   }
 
   const isRscRequest = pathname.endsWith(".rsc") || request.headers.get("accept")?.includes("text/x-component");
-  const interceptionContextHeader = request.headers.get("X-Vinext-Interception-Context");
+  const interceptionContextHeader = request.headers.get("X-Vinext-Interception-Context")?.replaceAll("\0", "") || null;
   let cleanPathname = pathname.replace(/\\.rsc$/, "");
 
   // Middleware response headers and custom rewrite status are stored in

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -860,7 +860,12 @@ async function main(): Promise<void> {
         stripBasePath(window.location.pathname, __basePath);
       const elementsAtNavStart = getBrowserRouterState().elements;
       const mountedSlotsHeader = getMountedSlotIdsHeader(elementsAtNavStart);
-      const cachedRoute = getVisitedResponse(rscUrl, requestInterceptionContext, mountedSlotsHeader, navigationKind);
+      const cachedRoute = getVisitedResponse(
+        rscUrl,
+        requestInterceptionContext,
+        mountedSlotsHeader,
+        navigationKind,
+      );
       if (cachedRoute) {
         // Check stale-navigation before and after createFromFetch. The pre-check
         // avoids wasted parse work; the post-check catches supersessions that
@@ -908,7 +913,11 @@ async function main(): Promise<void> {
       let navResponse: Response | undefined;
       let navResponseUrl: string | null = null;
       if (navigationKind !== "refresh") {
-        const prefetchedResponse = consumePrefetchResponse(rscUrl, requestInterceptionContext, mountedSlotsHeader);
+        const prefetchedResponse = consumePrefetchResponse(
+          rscUrl,
+          requestInterceptionContext,
+          mountedSlotsHeader,
+        );
         if (prefetchedResponse) {
           navResponse = restoreRscResponse(prefetchedResponse, false);
           navResponseUrl = prefetchedResponse.url;

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -31,6 +31,7 @@ import {
   getPrefetchCache,
   getPrefetchedUrls,
   pushHistoryStateWithoutNotify,
+  readHistoryStateInterceptionContext,
   replaceClientParamsWithoutNotify,
   replaceHistoryStateWithoutNotify,
   restoreRscResponse,
@@ -39,6 +40,7 @@ import {
   setMountedSlotsHeader,
   setNavigationContext,
   toRscUrl,
+  VINEXT_INTERCEPTION_CONTEXT_HISTORY_STATE_KEY,
   type CachedRscResponse,
   type ClientNavigationRenderSnapshot,
 } from "../shims/navigation.js";
@@ -96,8 +98,6 @@ type VisitedResponseCacheEntry = {
 const MAX_VISITED_RESPONSE_CACHE_SIZE = 50;
 const VISITED_RESPONSE_CACHE_TTL = 5 * 60_000;
 const MAX_TRAVERSAL_CACHE_TTL = 30 * 60_000;
-const VINEXT_INTERCEPTION_CONTEXT_HISTORY_STATE_KEY = "__vinext_interceptionContext";
-
 type HistoryStateRecord = {
   [key: string]: unknown;
 };
@@ -328,11 +328,6 @@ function createHistoryStateWithInterceptionContext(
   return Object.keys(nextState).length > 0 ? nextState : null;
 }
 
-function readHistoryStateInterceptionContext(state: unknown): string | null {
-  const value = cloneHistoryState(state)[VINEXT_INTERCEPTION_CONTEXT_HISTORY_STATE_KEY];
-  return typeof value === "string" ? value : null;
-}
-
 function getRequestInterceptionContext(navigationKind: NavigationKind): string | null {
   switch (navigationKind) {
     case "navigate":
@@ -509,6 +504,21 @@ function BrowserRoot({
   useLayoutEffect(() => {
     setMountedSlotsHeader(getMountedSlotIdsHeader(stateRef.current.elements));
   }, [treeState.elements]);
+
+  useLayoutEffect(() => {
+    if (treeState.renderId !== 0) {
+      return;
+    }
+
+    replaceHistoryStateWithoutNotify(
+      createHistoryStateWithInterceptionContext(
+        window.history.state,
+        treeState.interceptionContext,
+      ),
+      "",
+      window.location.href,
+    );
+  }, [treeState.interceptionContext, treeState.renderId]);
 
   const committedTree = createElement(
     NavigationCommitSignal,

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -26,6 +26,7 @@ import {
   commitClientNavigationState,
   consumePrefetchResponse,
   createClientNavigationRenderSnapshot,
+  getCurrentInterceptionContext,
   getClientNavigationRenderContext,
   getPrefetchCache,
   getPrefetchedUrls,
@@ -48,9 +49,11 @@ import {
   getVinextBrowserGlobal,
 } from "./app-browser-stream.js";
 import {
+  createAppPayloadCacheKey,
   getMountedSlotIdsHeader,
   normalizeAppElements,
   readAppElementsMetadata,
+  resolveVisitedResponseInterceptionContext,
   type AppElements,
   type AppWireElements,
 } from "./app-elements.js";
@@ -93,6 +96,11 @@ type VisitedResponseCacheEntry = {
 const MAX_VISITED_RESPONSE_CACHE_SIZE = 50;
 const VISITED_RESPONSE_CACHE_TTL = 5 * 60_000;
 const MAX_TRAVERSAL_CACHE_TTL = 30 * 60_000;
+const VINEXT_INTERCEPTION_CONTEXT_HISTORY_STATE_KEY = "__vinext_interceptionContext";
+
+type HistoryStateRecord = {
+  [key: string]: unknown;
+};
 
 // These are plain module-level variables, unlike ClientNavigationState in
 // navigation.ts which uses Symbol.for to survive multiple Vite module instances.
@@ -201,15 +209,21 @@ function createNavigationCommitEffect(
   href: string,
   historyUpdateMode: HistoryUpdateMode | undefined,
   params: Record<string, string | string[]>,
+  interceptionContext: string | null,
 ): () => void {
   return () => {
     const targetHref = new URL(href, window.location.origin).href;
     stageClientParams(params);
+    const preserveExistingState = historyUpdateMode === "replace";
+    const historyState = createHistoryStateWithInterceptionContext(
+      preserveExistingState ? window.history.state : null,
+      interceptionContext,
+    );
 
     if (historyUpdateMode === "replace" && window.location.href !== targetHref) {
-      replaceHistoryStateWithoutNotify(null, "", href);
+      replaceHistoryStateWithoutNotify(historyState, "", href);
     } else if (historyUpdateMode === "push" && window.location.href !== targetHref) {
-      pushHistoryStateWithoutNotify(null, "", href);
+      pushHistoryStateWithoutNotify(historyState, "", href);
     }
 
     commitClientNavigationState();
@@ -228,16 +242,18 @@ function evictVisitedResponseCacheIfNeeded(): void {
 
 function getVisitedResponse(
   rscUrl: string,
+  interceptionContext: string | null,
   mountedSlotsHeader: string | null,
   navigationKind: NavigationKind,
 ): VisitedResponseCacheEntry | null {
-  const cached = visitedResponseCache.get(rscUrl);
+  const cacheKey = createAppPayloadCacheKey(rscUrl, interceptionContext);
+  const cached = visitedResponseCache.get(cacheKey);
   if (!cached) {
     return null;
   }
 
   if ((cached.response.mountedSlotsHeader ?? null) !== mountedSlotsHeader) {
-    visitedResponseCache.delete(rscUrl);
+    visitedResponseCache.delete(cacheKey);
     return null;
   }
 
@@ -248,39 +264,96 @@ function getVisitedResponse(
   if (navigationKind === "traverse") {
     const createdAt = cached.expiresAt - VISITED_RESPONSE_CACHE_TTL;
     if (Date.now() - createdAt >= MAX_TRAVERSAL_CACHE_TTL) {
-      visitedResponseCache.delete(rscUrl);
+      visitedResponseCache.delete(cacheKey);
       return null;
     }
     // LRU: promote to most-recently-used (delete + re-insert moves to end of Map)
-    visitedResponseCache.delete(rscUrl);
-    visitedResponseCache.set(rscUrl, cached);
+    visitedResponseCache.delete(cacheKey);
+    visitedResponseCache.set(cacheKey, cached);
     return cached;
   }
 
   if (cached.expiresAt > Date.now()) {
     // LRU: promote to most-recently-used
-    visitedResponseCache.delete(rscUrl);
-    visitedResponseCache.set(rscUrl, cached);
+    visitedResponseCache.delete(cacheKey);
+    visitedResponseCache.set(cacheKey, cached);
     return cached;
   }
 
-  visitedResponseCache.delete(rscUrl);
+  visitedResponseCache.delete(cacheKey);
   return null;
 }
 
 function storeVisitedResponseSnapshot(
   rscUrl: string,
+  interceptionContext: string | null,
   snapshot: CachedRscResponse,
   params: Record<string, string | string[]>,
 ): void {
-  visitedResponseCache.delete(rscUrl);
+  const cacheKey = createAppPayloadCacheKey(rscUrl, interceptionContext);
+  visitedResponseCache.delete(cacheKey);
   evictVisitedResponseCacheIfNeeded();
   const now = Date.now();
-  visitedResponseCache.set(rscUrl, {
+  visitedResponseCache.set(cacheKey, {
     params,
     expiresAt: now + VISITED_RESPONSE_CACHE_TTL,
     response: snapshot,
   });
+}
+
+function cloneHistoryState(state: unknown): HistoryStateRecord {
+  if (!state || typeof state !== "object") {
+    return {};
+  }
+
+  const nextState: HistoryStateRecord = {};
+  for (const [key, value] of Object.entries(state)) {
+    nextState[key] = value;
+  }
+  return nextState;
+}
+
+function createHistoryStateWithInterceptionContext(
+  state: unknown,
+  interceptionContext: string | null,
+): HistoryStateRecord | null {
+  const nextState = cloneHistoryState(state);
+
+  if (interceptionContext === null) {
+    delete nextState[VINEXT_INTERCEPTION_CONTEXT_HISTORY_STATE_KEY];
+  } else {
+    nextState[VINEXT_INTERCEPTION_CONTEXT_HISTORY_STATE_KEY] = interceptionContext;
+  }
+
+  return Object.keys(nextState).length > 0 ? nextState : null;
+}
+
+function readHistoryStateInterceptionContext(state: unknown): string | null {
+  const value = cloneHistoryState(state)[VINEXT_INTERCEPTION_CONTEXT_HISTORY_STATE_KEY];
+  return typeof value === "string" ? value : null;
+}
+
+function getRequestInterceptionContext(navigationKind: NavigationKind): string | null {
+  switch (navigationKind) {
+    case "navigate":
+      return getCurrentInterceptionContext();
+    case "traverse":
+      return readHistoryStateInterceptionContext(window.history.state);
+    case "refresh":
+      return null;
+    default: {
+      const _exhaustive: never = navigationKind;
+      throw new Error("[vinext] Unknown navigation kind: " + String(_exhaustive));
+    }
+  }
+}
+
+function createRscRequestHeaders(interceptionContext: string | null): Headers {
+  const headers = new Headers({ Accept: "text/x-component" });
+  if (interceptionContext !== null) {
+    headers.set("X-Vinext-Interception-Context", interceptionContext);
+  }
+  return headers;
 }
 
 /**
@@ -366,6 +439,7 @@ async function commitSameUrlNavigatePayload(
       navigationSnapshot,
       pending.action.renderId,
       "navigate",
+      pending.interceptionContext,
       pending.routeId,
       pending.rootLayoutTreePath,
       false,
@@ -397,6 +471,7 @@ function BrowserRoot({
   const initialMetadata = readAppElementsMetadata(resolvedElements);
   const [treeState, dispatchTreeState] = useReducer(routerReducer, {
     elements: resolvedElements,
+    interceptionContext: initialMetadata.interceptionContext,
     navigationSnapshot: initialNavigationSnapshot,
     renderId: 0,
     rootLayoutTreePath: initialMetadata.rootLayoutTreePath,
@@ -462,6 +537,7 @@ function dispatchBrowserTree(
   navigationSnapshot: ClientNavigationRenderSnapshot,
   renderId: number,
   actionType: "navigate" | "replace" | "traverse",
+  interceptionContext: string | null,
   routeId: string,
   rootLayoutTreePath: string | null,
   useTransitionMode: boolean,
@@ -471,6 +547,7 @@ function dispatchBrowserTree(
   const applyAction = () =>
     dispatch({
       elements,
+      interceptionContext,
       navigationSnapshot,
       renderId,
       rootLayoutTreePath,
@@ -490,7 +567,8 @@ async function renderNavigationPayload(
   navigationSnapshot: ClientNavigationRenderSnapshot,
   targetHref: string,
   navId: number,
-  prePaintEffect: (() => void) | null = null,
+  historyUpdateMode: HistoryUpdateMode | undefined,
+  params: Record<string, string | string[]>,
   useTransition = true,
   actionType: "navigate" | "replace" | "traverse" = "navigate",
 ): Promise<void> {
@@ -530,7 +608,15 @@ async function renderNavigationPayload(
       return;
     }
 
-    queuePrePaintNavigationEffect(renderId, prePaintEffect);
+    queuePrePaintNavigationEffect(
+      renderId,
+      createNavigationCommitEffect(
+        targetHref,
+        historyUpdateMode,
+        params,
+        pending.interceptionContext,
+      ),
+    );
     activateNavigationSnapshot();
     snapshotActivated = true;
     dispatchBrowserTree(
@@ -538,6 +624,7 @@ async function renderNavigationPayload(
       navigationSnapshot,
       renderId,
       actionType,
+      pending.interceptionContext,
       pending.routeId,
       pending.rootLayoutTreePath,
       useTransition,
@@ -650,6 +737,8 @@ function registerServerActionCallback(): void {
     const temporaryReferences = createTemporaryReferenceSet();
     const body = await encodeReply(args, { temporaryReferences });
 
+    // Intentionally omit interception context for server action re-renders in
+    // this PR. Durable intercepted refresh/action parity belongs to PR 5.
     const fetchResponse = await fetch(toRscUrl(window.location.pathname + window.location.search), {
       method: "POST",
       headers: { "x-rsc-action": id },
@@ -747,6 +836,7 @@ async function main(): Promise<void> {
     try {
       const url = new URL(href, window.location.origin);
       const rscUrl = toRscUrl(url.pathname + url.search);
+      const requestInterceptionContext = getRequestInterceptionContext(navigationKind);
       // Use startTransition for same-route navigations (searchParam changes)
       // so React keeps the old UI visible during the transition. For cross-route
       // navigations (different pathname), use synchronous updates — React's
@@ -760,7 +850,7 @@ async function main(): Promise<void> {
         stripBasePath(window.location.pathname, __basePath);
       const elementsAtNavStart = getBrowserRouterState().elements;
       const mountedSlotsHeader = getMountedSlotIdsHeader(elementsAtNavStart);
-      const cachedRoute = getVisitedResponse(rscUrl, mountedSlotsHeader, navigationKind);
+      const cachedRoute = getVisitedResponse(rscUrl, requestInterceptionContext, mountedSlotsHeader, navigationKind);
       if (cachedRoute) {
         // Check stale-navigation before and after createFromFetch. The pre-check
         // avoids wasted parse work; the post-check catches supersessions that
@@ -789,7 +879,8 @@ async function main(): Promise<void> {
             cachedNavigationSnapshot,
             href,
             navId,
-            createNavigationCommitEffect(href, historyUpdateMode, cachedParams),
+            historyUpdateMode,
+            cachedParams,
             isSameRoute,
             toActionType(navigationKind),
           );
@@ -807,7 +898,7 @@ async function main(): Promise<void> {
       let navResponse: Response | undefined;
       let navResponseUrl: string | null = null;
       if (navigationKind !== "refresh") {
-        const prefetchedResponse = consumePrefetchResponse(rscUrl, mountedSlotsHeader);
+        const prefetchedResponse = consumePrefetchResponse(rscUrl, requestInterceptionContext, mountedSlotsHeader);
         if (prefetchedResponse) {
           navResponse = restoreRscResponse(prefetchedResponse, false);
           navResponseUrl = prefetchedResponse.url;
@@ -815,12 +906,12 @@ async function main(): Promise<void> {
       }
 
       if (!navResponse) {
-        const rscFetchHeaders: Record<string, string> = { Accept: "text/x-component" };
+        const requestHeaders = createRscRequestHeaders(requestInterceptionContext);
         if (mountedSlotsHeader) {
-          rscFetchHeaders["X-Vinext-Mounted-Slots"] = mountedSlotsHeader;
+          requestHeaders.set("X-Vinext-Mounted-Slots", mountedSlotsHeader);
         }
         navResponse = await fetch(rscUrl, {
-          headers: rscFetchHeaders,
+          headers: requestHeaders,
           credentials: "include",
         });
       }
@@ -832,7 +923,11 @@ async function main(): Promise<void> {
 
       if (finalUrl.pathname !== requestedUrl.pathname) {
         const destinationPath = finalUrl.pathname.replace(/\.rsc$/, "") + finalUrl.search;
-        replaceHistoryStateWithoutNotify(null, "", destinationPath);
+        replaceHistoryStateWithoutNotify(
+          createHistoryStateWithInterceptionContext(null, requestInterceptionContext),
+          "",
+          destinationPath,
+        );
 
         const navigate = window.__VINEXT_RSC_NAVIGATE__;
         if (!navigate) {
@@ -878,7 +973,8 @@ async function main(): Promise<void> {
           navigationSnapshot,
           href,
           navId,
-          createNavigationCommitEffect(href, historyUpdateMode, navParams),
+          historyUpdateMode,
+          navParams,
           isSameRoute,
           toActionType(navigationKind),
         );
@@ -897,7 +993,17 @@ async function main(): Promise<void> {
       // If we stored it before and renderNavigationPayload threw, a future
       // back/forward navigation could replay a snapshot from a navigation that
       // never actually rendered successfully.
-      storeVisitedResponseSnapshot(rscUrl, responseSnapshot, navParams);
+      const resolvedElements = await rscPayload;
+      const metadata = readAppElementsMetadata(resolvedElements);
+      storeVisitedResponseSnapshot(
+        rscUrl,
+        resolveVisitedResponseInterceptionContext(
+          requestInterceptionContext,
+          metadata.interceptionContext,
+        ),
+        responseSnapshot,
+        navParams,
+      );
       return;
     } catch (error) {
       // Only decrement counter if snapshot was activated but not yet committed.
@@ -961,6 +1067,7 @@ async function main(): Promise<void> {
           navigationSnapshot,
           pending.action.renderId,
           "replace",
+          pending.interceptionContext,
           pending.routeId,
           pending.rootLayoutTreePath,
           false,

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -1070,6 +1070,8 @@ async function main(): Promise<void> {
           window.location.href,
           latestClientParams,
         );
+        // Intentionally omit interception context for HMR re-renders.
+        // Preserving intercepted modal state across HMR belongs to PR 5.
         const pending = await createPendingNavigationCommit({
           currentState: getBrowserRouterState(),
           nextElements: normalizeAppElementsPromise(

--- a/packages/vinext/src/server/app-browser-state.ts
+++ b/packages/vinext/src/server/app-browser-state.ts
@@ -4,6 +4,7 @@ import type { ClientNavigationRenderSnapshot } from "../shims/navigation.js";
 
 export type AppRouterState = {
   elements: AppElements;
+  interceptionContext: string | null;
   renderId: number;
   navigationSnapshot: ClientNavigationRenderSnapshot;
   rootLayoutTreePath: string | null;
@@ -12,6 +13,7 @@ export type AppRouterState = {
 
 export type AppRouterAction = {
   elements: AppElements;
+  interceptionContext: string | null;
   navigationSnapshot: ClientNavigationRenderSnapshot;
   renderId: number;
   rootLayoutTreePath: string | null;
@@ -21,6 +23,7 @@ export type AppRouterAction = {
 
 export type PendingNavigationCommit = {
   action: AppRouterAction;
+  interceptionContext: string | null;
   rootLayoutTreePath: string | null;
   routeId: string;
 };
@@ -37,6 +40,7 @@ export function routerReducer(state: AppRouterState, action: AppRouterAction): A
     case "navigate":
       return {
         elements: mergeElements(state.elements, action.elements, action.type === "traverse"),
+        interceptionContext: action.interceptionContext,
         navigationSnapshot: action.navigationSnapshot,
         renderId: action.renderId,
         rootLayoutTreePath: action.rootLayoutTreePath,
@@ -45,6 +49,7 @@ export function routerReducer(state: AppRouterState, action: AppRouterAction): A
     case "replace":
       return {
         elements: action.elements,
+        interceptionContext: action.interceptionContext,
         navigationSnapshot: action.navigationSnapshot,
         renderId: action.renderId,
         rootLayoutTreePath: action.rootLayoutTreePath,
@@ -101,12 +106,14 @@ export async function createPendingNavigationCommit(options: {
   return {
     action: {
       elements,
+      interceptionContext: metadata.interceptionContext,
       navigationSnapshot: options.navigationSnapshot,
       renderId: options.renderId,
       rootLayoutTreePath: metadata.rootLayoutTreePath,
       routeId: metadata.routeId,
       type: options.type,
     },
+    interceptionContext: metadata.interceptionContext,
     rootLayoutTreePath: metadata.rootLayoutTreePath,
     routeId: metadata.routeId,
   };

--- a/packages/vinext/src/server/app-browser-state.ts
+++ b/packages/vinext/src/server/app-browser-state.ts
@@ -113,6 +113,7 @@ export async function createPendingNavigationCommit(options: {
       routeId: metadata.routeId,
       type: options.type,
     },
+    // Convenience aliases — always equal action.interceptionContext / action.rootLayoutTreePath / action.routeId.
     interceptionContext: metadata.interceptionContext,
     rootLayoutTreePath: metadata.rootLayoutTreePath,
     routeId: metadata.routeId,

--- a/packages/vinext/src/server/app-elements.ts
+++ b/packages/vinext/src/server/app-elements.ts
@@ -1,5 +1,8 @@
 import type { ReactNode } from "react";
 
+const APP_INTERCEPTION_SEPARATOR = "\0";
+
+export const APP_INTERCEPTION_CONTEXT_KEY = "__interceptionContext";
 export const APP_ROUTE_KEY = "__route";
 export const APP_ROOT_LAYOUT_KEY = "__rootLayout";
 export const APP_UNMATCHED_SLOT_WIRE_VALUE = "__VINEXT_UNMATCHED_SLOT__";
@@ -13,6 +16,7 @@ export type AppElements = Readonly<Record<string, AppElementValue>>;
 export type AppWireElements = Readonly<Record<string, AppWireElementValue>>;
 
 export type AppElementsMetadata = {
+  interceptionContext: string | null;
   routeId: string;
   rootLayoutTreePath: string | null;
 };
@@ -40,6 +44,40 @@ export function getMountedSlotIds(elements: AppElements): string[] {
 
 export function getMountedSlotIdsHeader(elements: AppElements): string | null {
   return normalizeMountedSlotsHeader(getMountedSlotIds(elements).join(" "));
+}
+
+function appendInterceptionContext(identity: string, interceptionContext: string | null): string {
+  return interceptionContext === null
+    ? identity
+    : `${identity}${APP_INTERCEPTION_SEPARATOR}${interceptionContext}`;
+}
+
+export function createAppPayloadRouteId(
+  routePath: string,
+  interceptionContext: string | null,
+): string {
+  return appendInterceptionContext(`route:${routePath}`, interceptionContext);
+}
+
+export function createAppPayloadPageId(
+  routePath: string,
+  interceptionContext: string | null,
+): string {
+  return appendInterceptionContext(`page:${routePath}`, interceptionContext);
+}
+
+export function createAppPayloadCacheKey(
+  rscUrl: string,
+  interceptionContext: string | null,
+): string {
+  return appendInterceptionContext(rscUrl, interceptionContext);
+}
+
+export function resolveVisitedResponseInterceptionContext(
+  requestInterceptionContext: string | null,
+  payloadInterceptionContext: string | null,
+): string | null {
+  return payloadInterceptionContext ?? requestInterceptionContext;
 }
 
 export function normalizeAppElements(elements: AppWireElements): AppElements {
@@ -70,6 +108,15 @@ export function readAppElementsMetadata(elements: AppElements): AppElementsMetad
     throw new Error("[vinext] Missing __route string in App Router payload");
   }
 
+  const interceptionContext = elements[APP_INTERCEPTION_CONTEXT_KEY];
+  if (
+    interceptionContext !== undefined &&
+    interceptionContext !== null &&
+    typeof interceptionContext !== "string"
+  ) {
+    throw new Error("[vinext] Invalid __interceptionContext in App Router payload");
+  }
+
   const rootLayoutTreePath = elements[APP_ROOT_LAYOUT_KEY];
   if (rootLayoutTreePath === undefined) {
     throw new Error("[vinext] Missing __rootLayout key in App Router payload");
@@ -79,6 +126,7 @@ export function readAppElementsMetadata(elements: AppElements): AppElementsMetad
   }
 
   return {
+    interceptionContext: interceptionContext ?? null,
     routeId,
     rootLayoutTreePath,
   };

--- a/packages/vinext/src/server/app-page-boundary-render.ts
+++ b/packages/vinext/src/server/app-page-boundary-render.ts
@@ -24,7 +24,13 @@ import {
   renderAppPageHtmlResponse,
   type AppPageSsrHandler,
 } from "./app-page-stream.js";
-import { APP_ROOT_LAYOUT_KEY, APP_ROUTE_KEY, type AppElements } from "./app-elements.js";
+import {
+  APP_INTERCEPTION_CONTEXT_KEY,
+  APP_ROOT_LAYOUT_KEY,
+  APP_ROUTE_KEY,
+  createAppPayloadRouteId,
+  type AppElements,
+} from "./app-elements.js";
 import { createAppPageLayoutEntries } from "./app-page-route-wiring.js";
 
 // oxlint-disable-next-line @typescript-eslint/no-explicit-any
@@ -234,9 +240,10 @@ function resolveAppPageBoundaryRootLayoutTreePath<TModule extends AppPageModule>
 function createAppPageBoundaryRscPayload<TModule extends AppPageModule>(
   options: AppPageBoundaryRscPayloadOptions<TModule>,
 ): AppElements {
-  const routeId = `route:${options.pathname}`;
+  const routeId = createAppPayloadRouteId(options.pathname, null);
 
   return {
+    [APP_INTERCEPTION_CONTEXT_KEY]: null,
     [APP_ROUTE_KEY]: routeId,
     [APP_ROOT_LAYOUT_KEY]: resolveAppPageBoundaryRootLayoutTreePath(options.route),
     [routeId]: options.element,

--- a/packages/vinext/src/server/app-page-route-wiring.tsx
+++ b/packages/vinext/src/server/app-page-route-wiring.tsx
@@ -1,8 +1,11 @@
 import { Suspense, type ComponentType, type ReactNode } from "react";
 import {
+  APP_INTERCEPTION_CONTEXT_KEY,
   APP_ROOT_LAYOUT_KEY,
   APP_ROUTE_KEY,
   APP_UNMATCHED_SLOT_WIRE_VALUE,
+  createAppPayloadPageId,
+  createAppPayloadRouteId,
   type AppElements,
 } from "./app-elements.js";
 import { ErrorBoundary, NotFoundBoundary } from "../shims/error-boundary.js";
@@ -107,6 +110,7 @@ export type BuildAppPageElementsOptions<
   TModule extends AppPageModule = AppPageModule,
   TErrorModule extends AppPageErrorModule = AppPageErrorModule,
 > = BuildAppPageRouteElementOptions<TModule, TErrorModule> & {
+  interceptionContext?: string | null;
   isRscRequest?: boolean;
   mountedSlotIds?: ReadonlySet<string> | null;
   routePath: string;
@@ -301,8 +305,9 @@ export function buildAppPageElements<
   TErrorModule extends AppPageErrorModule,
 >(options: BuildAppPageElementsOptions<TModule, TErrorModule>): AppElements {
   const elements: Record<string, ReactNode | string | null> = {};
-  const routeId = `route:${options.routePath}`;
-  const pageId = `page:${options.routePath}`;
+  const interceptionContext = options.interceptionContext ?? null;
+  const routeId = createAppPayloadRouteId(options.routePath, interceptionContext);
+  const pageId = createAppPayloadPageId(options.routePath, interceptionContext);
   const layoutEntries = createAppPageLayoutEntries(options.route);
   const templateEntries = createAppPageTemplateEntries(options.route);
   const layoutEntriesByTreePosition = new Map<number, AppPageLayoutEntry<TModule, TErrorModule>>();
@@ -378,6 +383,7 @@ export function buildAppPageElements<
   }
 
   elements[APP_ROUTE_KEY] = routeId;
+  elements[APP_INTERCEPTION_CONTEXT_KEY] = interceptionContext;
   elements[APP_ROOT_LAYOUT_KEY] = rootLayoutTreePath;
   elements[pageId] = renderAfterAppDependencies(options.element, pageDependencies);
 

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -21,12 +21,14 @@ import React, {
 // Import shared RSC prefetch utilities from navigation shim (relative path
 // so this resolves both via the Vite plugin and in direct vitest imports)
 import {
+  getCurrentInterceptionContext,
   toRscUrl,
   getPrefetchedUrls,
   getMountedSlotsHeader,
   navigateClientSide,
   prefetchRscResponse,
 } from "./navigation.js";
+import { createAppPayloadCacheKey } from "../server/app-elements.js";
 import { isDangerousScheme } from "./url-safety.js";
 import {
   resolveRelativeHref,
@@ -125,21 +127,26 @@ function prefetchUrl(href: string): void {
 
   const fullHref = toBrowserNavigationHref(prefetchHref, window.location.href, __basePath);
 
-  // Don't prefetch the same URL twice (keyed by rscUrl so the browser
-  // entry can clear the key when a cache entry is consumed)
+  // Distinguish the same visible URL when it is prefetched from different
+  // interception sources such as /feed vs /gallery.
   const rscUrl = toRscUrl(fullHref);
+  const interceptionContext = getCurrentInterceptionContext();
+  const cacheKey = createAppPayloadCacheKey(rscUrl, interceptionContext);
   const prefetched = getPrefetchedUrls();
-  if (prefetched.has(rscUrl)) return;
-  prefetched.add(rscUrl);
+  if (prefetched.has(cacheKey)) return;
+  prefetched.add(cacheKey);
 
   const schedule = window.requestIdleCallback ?? ((fn: () => void) => setTimeout(fn, 100));
 
   schedule(() => {
     if (typeof window.__VINEXT_RSC_NAVIGATE__ === "function") {
       const mountedSlotsHeader = getMountedSlotsHeader();
-      const headers: Record<string, string> = { Accept: "text/x-component" };
+      const headers = new Headers({ Accept: "text/x-component" });
       if (mountedSlotsHeader) {
-        headers["X-Vinext-Mounted-Slots"] = mountedSlotsHeader;
+        headers.set("X-Vinext-Mounted-Slots", mountedSlotsHeader);
+      }
+      if (interceptionContext !== null) {
+        headers.set("X-Vinext-Interception-Context", interceptionContext);
       }
       prefetchRscResponse(
         rscUrl,
@@ -150,6 +157,7 @@ function prefetchUrl(href: string): void {
           // @ts-expect-error — purpose is a valid fetch option in some browsers
           purpose: "prefetch",
         }),
+        interceptionContext,
         mountedSlotsHeader,
       );
     } else if ((window.__NEXT_DATA__ as VinextNextData | undefined)?.__vinext?.pageModuleUrl) {

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -244,6 +244,8 @@ export const MAX_PREFETCH_CACHE_SIZE = 50;
 /** TTL for prefetch cache entries in ms (matches Next.js static prefetch TTL). */
 export const PREFETCH_CACHE_TTL = 30_000;
 
+export const VINEXT_INTERCEPTION_CONTEXT_HISTORY_STATE_KEY = "__vinext_interceptionContext";
+
 /** A buffered RSC response stored as an ArrayBuffer for replay. */
 export type CachedRscResponse = {
   buffer: ArrayBuffer;
@@ -275,12 +277,24 @@ export function toRscUrl(href: string): string {
   return normalizedPath + ".rsc" + query;
 }
 
+export function readHistoryStateInterceptionContext(state: unknown): string | null {
+  if (!state || typeof state !== "object") {
+    return null;
+  }
+
+  const value = Reflect.get(state, VINEXT_INTERCEPTION_CONTEXT_HISTORY_STATE_KEY);
+  return typeof value === "string" ? value : null;
+}
+
 export function getCurrentInterceptionContext(): string | null {
   if (isServer) {
     return null;
   }
 
-  return stripBasePath(window.location.pathname, __basePath);
+  return (
+    readHistoryStateInterceptionContext(window.history.state) ??
+    stripBasePath(window.location.pathname, __basePath)
+  );
 }
 
 /** Get or create the shared in-memory RSC prefetch cache on window. */

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -12,6 +12,7 @@
 // bindings are just `undefined` on the namespace object and we can guard at runtime.
 import * as React from "react";
 import { notifyAppRouterTransitionStart } from "../client/instrumentation-client-state.js";
+import { createAppPayloadCacheKey } from "../server/app-elements.js";
 import { toBrowserNavigationHref, toSameOriginAppPath } from "./url-utils.js";
 import { stripBasePath } from "../utils/base-path.js";
 import { ReadonlyURLSearchParams } from "./readonly-url-search-params.js";
@@ -274,6 +275,14 @@ export function toRscUrl(href: string): string {
   return normalizedPath + ".rsc" + query;
 }
 
+export function getCurrentInterceptionContext(): string | null {
+  if (isServer) {
+    return null;
+  }
+
+  return stripBasePath(window.location.pathname, __basePath);
+}
+
 /** Get or create the shared in-memory RSC prefetch cache on window. */
 export function getPrefetchCache(): Map<string, PrefetchCacheEntry> {
   if (isServer) return new Map();
@@ -285,7 +294,7 @@ export function getPrefetchCache(): Map<string, PrefetchCacheEntry> {
 
 /**
  * Get or create the shared set of already-prefetched RSC URLs on window.
- * Keyed by rscUrl so that the browser entry can clear entries when consumed.
+ * Keyed by interception-aware cache key so distinct source routes do not alias.
  */
 export function getPrefetchedUrls(): Set<string> {
   if (isServer) return new Set();
@@ -340,7 +349,12 @@ function evictPrefetchCacheIfNeeded(): void {
  * NB: Caller is responsible for managing getPrefetchedUrls() — this
  * function only stores the response in the prefetch cache.
  */
-export function storePrefetchResponse(rscUrl: string, response: Response): void {
+export function storePrefetchResponse(
+  rscUrl: string,
+  response: Response,
+  interceptionContext: string | null = null,
+): void {
+  const cacheKey = createAppPayloadCacheKey(rscUrl, interceptionContext);
   evictPrefetchCacheIfNeeded();
   const entry: PrefetchCacheEntry = { timestamp: Date.now() };
   entry.pending = snapshotRscResponse(response)
@@ -348,12 +362,12 @@ export function storePrefetchResponse(rscUrl: string, response: Response): void 
       entry.snapshot = snapshot;
     })
     .catch(() => {
-      getPrefetchCache().delete(rscUrl);
+      getPrefetchCache().delete(cacheKey);
     })
     .finally(() => {
       entry.pending = undefined;
     });
-  getPrefetchCache().set(rscUrl, entry);
+  getPrefetchCache().set(cacheKey, entry);
 }
 
 /**
@@ -411,8 +425,10 @@ export function restoreRscResponse(cached: CachedRscResponse, copy = true): Resp
 export function prefetchRscResponse(
   rscUrl: string,
   fetchPromise: Promise<Response>,
+  interceptionContext: string | null = null,
   mountedSlotsHeader: string | null = null,
 ): void {
+  const cacheKey = createAppPayloadCacheKey(rscUrl, interceptionContext);
   const cache = getPrefetchCache();
   const prefetched = getPrefetchedUrls();
   const now = Date.now();
@@ -429,13 +445,13 @@ export function prefetchRscResponse(
           mountedSlotsHeader,
         };
       } else {
-        prefetched.delete(rscUrl);
-        cache.delete(rscUrl);
+        prefetched.delete(cacheKey);
+        cache.delete(cacheKey);
       }
     })
     .catch(() => {
-      prefetched.delete(rscUrl);
-      cache.delete(rscUrl);
+      prefetched.delete(cacheKey);
+      cache.delete(cacheKey);
     })
     .finally(() => {
       entry.pending = undefined;
@@ -444,7 +460,7 @@ export function prefetchRscResponse(
   // Insert the new entry before evicting. FIFO evicts from the front of the
   // Map (oldest insertion order), so the just-appended entry is safe — only
   // entries inserted before it are candidates for removal.
-  cache.set(rscUrl, entry);
+  cache.set(cacheKey, entry);
   evictPrefetchCacheIfNeeded();
 }
 
@@ -455,17 +471,19 @@ export function prefetchRscResponse(
  */
 export function consumePrefetchResponse(
   rscUrl: string,
+  interceptionContext: string | null = null,
   mountedSlotsHeader: string | null = null,
 ): CachedRscResponse | null {
+  const cacheKey = createAppPayloadCacheKey(rscUrl, interceptionContext);
   const cache = getPrefetchCache();
-  const entry = cache.get(rscUrl);
+  const entry = cache.get(cacheKey);
   if (!entry) return null;
 
   // Don't consume pending entries — let the navigation fetch independently.
   if (entry.pending) return null;
 
-  cache.delete(rscUrl);
-  getPrefetchedUrls().delete(rscUrl);
+  cache.delete(cacheKey);
+  getPrefetchedUrls().delete(cacheKey);
 
   if (entry.snapshot) {
     if ((entry.snapshot.mountedSlotsHeader ?? null) !== mountedSlotsHeader) {
@@ -1159,13 +1177,18 @@ const _appRouter = {
     // prefetchRscResponse only manages the cache Map, not the URL set.
     const fullHref = toBrowserNavigationHref(href, window.location.href, __basePath);
     const rscUrl = toRscUrl(fullHref);
+    const interceptionContext = getCurrentInterceptionContext();
+    const cacheKey = createAppPayloadCacheKey(rscUrl, interceptionContext);
     const prefetched = getPrefetchedUrls();
-    if (prefetched.has(rscUrl)) return;
-    prefetched.add(rscUrl);
+    if (prefetched.has(cacheKey)) return;
+    prefetched.add(cacheKey);
     const mountedSlotsHeader = getMountedSlotsHeader();
-    const headers: Record<string, string> = { Accept: "text/x-component" };
+    const headers = new Headers({ Accept: "text/x-component" });
     if (mountedSlotsHeader) {
-      headers["X-Vinext-Mounted-Slots"] = mountedSlotsHeader;
+      headers.set("X-Vinext-Mounted-Slots", mountedSlotsHeader);
+    }
+    if (interceptionContext !== null) {
+      headers.set("X-Vinext-Interception-Context", interceptionContext);
     }
     prefetchRscResponse(
       rscUrl,
@@ -1174,6 +1197,7 @@ const _appRouter = {
         credentials: "include",
         priority: "low" as RequestInit["priority"],
       }),
+      interceptionContext,
       mountedSlotsHeader,
     );
   },

--- a/packages/vinext/src/shims/next-shims.d.ts
+++ b/packages/vinext/src/shims/next-shims.d.ts
@@ -121,7 +121,11 @@ declare module "next/navigation" {
   export function toRscUrl(href: string): string;
   export function getPrefetchCache(): Map<string, PrefetchCacheEntry>;
   export function getPrefetchedUrls(): Set<string>;
-  export function storePrefetchResponse(rscUrl: string, response: Response): void;
+  export function storePrefetchResponse(
+    rscUrl: string,
+    response: Response,
+    interceptionContext?: string | null,
+  ): void;
 }
 
 declare module "next/image" {

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -1273,7 +1273,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   }
 
   const isRscRequest = pathname.endsWith(".rsc") || request.headers.get("accept")?.includes("text/x-component");
-  const interceptionContextHeader = request.headers.get("X-Vinext-Interception-Context");
+  const interceptionContextHeader = request.headers.get("X-Vinext-Interception-Context")?.replaceAll(" ", "") || null;
   let cleanPathname = pathname.replace(/\\.rsc$/, "");
 
   // Middleware response headers and custom rewrite status are stored in
@@ -3463,7 +3463,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   }
 
   const isRscRequest = pathname.endsWith(".rsc") || request.headers.get("accept")?.includes("text/x-component");
-  const interceptionContextHeader = request.headers.get("X-Vinext-Interception-Context");
+  const interceptionContextHeader = request.headers.get("X-Vinext-Interception-Context")?.replaceAll(" ", "") || null;
   let cleanPathname = pathname.replace(/\\.rsc$/, "");
 
   // Middleware response headers and custom rewrite status are stored in
@@ -5648,7 +5648,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   }
 
   const isRscRequest = pathname.endsWith(".rsc") || request.headers.get("accept")?.includes("text/x-component");
-  const interceptionContextHeader = request.headers.get("X-Vinext-Interception-Context");
+  const interceptionContextHeader = request.headers.get("X-Vinext-Interception-Context")?.replaceAll(" ", "") || null;
   let cleanPathname = pathname.replace(/\\.rsc$/, "");
 
   // Middleware response headers and custom rewrite status are stored in
@@ -7865,7 +7865,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   }
 
   const isRscRequest = pathname.endsWith(".rsc") || request.headers.get("accept")?.includes("text/x-component");
-  const interceptionContextHeader = request.headers.get("X-Vinext-Interception-Context");
+  const interceptionContextHeader = request.headers.get("X-Vinext-Interception-Context")?.replaceAll(" ", "") || null;
   let cleanPathname = pathname.replace(/\\.rsc$/, "");
 
   // Middleware response headers and custom rewrite status are stored in
@@ -10056,7 +10056,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   }
 
   const isRscRequest = pathname.endsWith(".rsc") || request.headers.get("accept")?.includes("text/x-component");
-  const interceptionContextHeader = request.headers.get("X-Vinext-Interception-Context");
+  const interceptionContextHeader = request.headers.get("X-Vinext-Interception-Context")?.replaceAll(" ", "") || null;
   let cleanPathname = pathname.replace(/\\.rsc$/, "");
 
   // Middleware response headers and custom rewrite status are stored in
@@ -12469,7 +12469,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   }
 
   const isRscRequest = pathname.endsWith(".rsc") || request.headers.get("accept")?.includes("text/x-component");
-  const interceptionContextHeader = request.headers.get("X-Vinext-Interception-Context");
+  const interceptionContextHeader = request.headers.get("X-Vinext-Interception-Context")?.replaceAll(" ", "") || null;
   let cleanPathname = pathname.replace(/\\.rsc$/, "");
 
   // Middleware response headers and custom rewrite status are stored in

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -79,6 +79,10 @@ import {
   renderAppPageHttpAccessFallback as __renderAppPageHttpAccessFallback,
 } from "<ROOT>/packages/vinext/src/server/app-page-boundary-render.js";
 import {
+  APP_INTERCEPTION_CONTEXT_KEY as __APP_INTERCEPTION_CONTEXT_KEY,
+  createAppPayloadRouteId as __createAppPayloadRouteId,
+} from "<ROOT>/packages/vinext/src/server/app-elements.js";
+import {
   buildAppPageElements as __buildAppPageElements,
   createAppPageTreePath as __createAppPageTreePath,
   resolveAppPageChildSegments as __resolveAppPageChildSegments,
@@ -688,7 +692,8 @@ function findIntercept(pathname) {
 async function buildPageElements(route, params, routePath, opts, searchParams, isRscRequest, request) {
   const PageComponent = route.page?.default;
   if (!PageComponent) {
-    const _noExportRouteId = "route:" + routePath;
+    const _interceptionContext = opts?.interceptionContext ?? null;
+    const _noExportRouteId = __createAppPayloadRouteId(routePath, _interceptionContext);
     let _noExportRootLayout = null;
     if (route.layouts?.length > 0) {
       // Compute the root layout tree path for this error payload using the
@@ -697,6 +702,7 @@ async function buildPageElements(route, params, routePath, opts, searchParams, i
       _noExportRootLayout = __createAppPageTreePath(route.routeSegments, _tp);
     }
     return {
+      [__APP_INTERCEPTION_CONTEXT_KEY]: _interceptionContext,
       __route: _noExportRouteId,
       __rootLayout: _noExportRootLayout,
       [_noExportRouteId]: createElement("div", null, "Page has no default export"),
@@ -816,6 +822,7 @@ async function buildPageElements(route, params, routePath, opts, searchParams, i
     matchedParams: params,
     resolvedMetadata,
     resolvedViewport,
+    interceptionContext: opts?.interceptionContext ?? null,
     routePath,
     rootNotFoundModule: null,
     route,
@@ -1266,6 +1273,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   }
 
   const isRscRequest = pathname.endsWith(".rsc") || request.headers.get("accept")?.includes("text/x-component");
+  const interceptionContextHeader = request.headers.get("X-Vinext-Interception-Context");
   let cleanPathname = pathname.replace(/\\.rsc$/, "");
 
   // Middleware response headers and custom rewrite status are stored in
@@ -1532,8 +1540,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           request,
         );
       } else {
-        const _actionRouteId = "route:" + cleanPathname;
+        const _actionRouteId = __createAppPayloadRouteId(cleanPathname, null);
         element = {
+          [__APP_INTERCEPTION_CONTEXT_KEY]: null,
           __route: _actionRouteId,
           __rootLayout: null,
           [_actionRouteId]: createElement("div", null, "Page not found"),
@@ -1980,6 +1989,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     setNavigationContext,
     toInterceptOpts(intercept) {
       return {
+        interceptionContext: interceptionContextHeader,
         interceptSlotKey: intercept.slotKey,
         interceptPage: intercept.page,
         interceptParams: intercept.matchedParams,
@@ -2252,6 +2262,10 @@ import {
   renderAppPageErrorBoundary as __renderAppPageErrorBoundary,
   renderAppPageHttpAccessFallback as __renderAppPageHttpAccessFallback,
 } from "<ROOT>/packages/vinext/src/server/app-page-boundary-render.js";
+import {
+  APP_INTERCEPTION_CONTEXT_KEY as __APP_INTERCEPTION_CONTEXT_KEY,
+  createAppPayloadRouteId as __createAppPayloadRouteId,
+} from "<ROOT>/packages/vinext/src/server/app-elements.js";
 import {
   buildAppPageElements as __buildAppPageElements,
   createAppPageTreePath as __createAppPageTreePath,
@@ -2862,7 +2876,8 @@ function findIntercept(pathname) {
 async function buildPageElements(route, params, routePath, opts, searchParams, isRscRequest, request) {
   const PageComponent = route.page?.default;
   if (!PageComponent) {
-    const _noExportRouteId = "route:" + routePath;
+    const _interceptionContext = opts?.interceptionContext ?? null;
+    const _noExportRouteId = __createAppPayloadRouteId(routePath, _interceptionContext);
     let _noExportRootLayout = null;
     if (route.layouts?.length > 0) {
       // Compute the root layout tree path for this error payload using the
@@ -2871,6 +2886,7 @@ async function buildPageElements(route, params, routePath, opts, searchParams, i
       _noExportRootLayout = __createAppPageTreePath(route.routeSegments, _tp);
     }
     return {
+      [__APP_INTERCEPTION_CONTEXT_KEY]: _interceptionContext,
       __route: _noExportRouteId,
       __rootLayout: _noExportRootLayout,
       [_noExportRouteId]: createElement("div", null, "Page has no default export"),
@@ -2990,6 +3006,7 @@ async function buildPageElements(route, params, routePath, opts, searchParams, i
     matchedParams: params,
     resolvedMetadata,
     resolvedViewport,
+    interceptionContext: opts?.interceptionContext ?? null,
     routePath,
     rootNotFoundModule: null,
     route,
@@ -3446,6 +3463,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   }
 
   const isRscRequest = pathname.endsWith(".rsc") || request.headers.get("accept")?.includes("text/x-component");
+  const interceptionContextHeader = request.headers.get("X-Vinext-Interception-Context");
   let cleanPathname = pathname.replace(/\\.rsc$/, "");
 
   // Middleware response headers and custom rewrite status are stored in
@@ -3712,8 +3730,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           request,
         );
       } else {
-        const _actionRouteId = "route:" + cleanPathname;
+        const _actionRouteId = __createAppPayloadRouteId(cleanPathname, null);
         element = {
+          [__APP_INTERCEPTION_CONTEXT_KEY]: null,
           __route: _actionRouteId,
           __rootLayout: null,
           [_actionRouteId]: createElement("div", null, "Page not found"),
@@ -4160,6 +4179,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     setNavigationContext,
     toInterceptOpts(intercept) {
       return {
+        interceptionContext: interceptionContextHeader,
         interceptSlotKey: intercept.slotKey,
         interceptPage: intercept.page,
         interceptParams: intercept.matchedParams,
@@ -4432,6 +4452,10 @@ import {
   renderAppPageErrorBoundary as __renderAppPageErrorBoundary,
   renderAppPageHttpAccessFallback as __renderAppPageHttpAccessFallback,
 } from "<ROOT>/packages/vinext/src/server/app-page-boundary-render.js";
+import {
+  APP_INTERCEPTION_CONTEXT_KEY as __APP_INTERCEPTION_CONTEXT_KEY,
+  createAppPayloadRouteId as __createAppPayloadRouteId,
+} from "<ROOT>/packages/vinext/src/server/app-elements.js";
 import {
   buildAppPageElements as __buildAppPageElements,
   createAppPageTreePath as __createAppPageTreePath,
@@ -5043,7 +5067,8 @@ function findIntercept(pathname) {
 async function buildPageElements(route, params, routePath, opts, searchParams, isRscRequest, request) {
   const PageComponent = route.page?.default;
   if (!PageComponent) {
-    const _noExportRouteId = "route:" + routePath;
+    const _interceptionContext = opts?.interceptionContext ?? null;
+    const _noExportRouteId = __createAppPayloadRouteId(routePath, _interceptionContext);
     let _noExportRootLayout = null;
     if (route.layouts?.length > 0) {
       // Compute the root layout tree path for this error payload using the
@@ -5052,6 +5077,7 @@ async function buildPageElements(route, params, routePath, opts, searchParams, i
       _noExportRootLayout = __createAppPageTreePath(route.routeSegments, _tp);
     }
     return {
+      [__APP_INTERCEPTION_CONTEXT_KEY]: _interceptionContext,
       __route: _noExportRouteId,
       __rootLayout: _noExportRootLayout,
       [_noExportRouteId]: createElement("div", null, "Page has no default export"),
@@ -5171,6 +5197,7 @@ async function buildPageElements(route, params, routePath, opts, searchParams, i
     matchedParams: params,
     resolvedMetadata,
     resolvedViewport,
+    interceptionContext: opts?.interceptionContext ?? null,
     routePath,
     rootNotFoundModule: null,
     route,
@@ -5621,6 +5648,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   }
 
   const isRscRequest = pathname.endsWith(".rsc") || request.headers.get("accept")?.includes("text/x-component");
+  const interceptionContextHeader = request.headers.get("X-Vinext-Interception-Context");
   let cleanPathname = pathname.replace(/\\.rsc$/, "");
 
   // Middleware response headers and custom rewrite status are stored in
@@ -5887,8 +5915,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           request,
         );
       } else {
-        const _actionRouteId = "route:" + cleanPathname;
+        const _actionRouteId = __createAppPayloadRouteId(cleanPathname, null);
         element = {
+          [__APP_INTERCEPTION_CONTEXT_KEY]: null,
           __route: _actionRouteId,
           __rootLayout: null,
           [_actionRouteId]: createElement("div", null, "Page not found"),
@@ -6335,6 +6364,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     setNavigationContext,
     toInterceptOpts(intercept) {
       return {
+        interceptionContext: interceptionContextHeader,
         interceptSlotKey: intercept.slotKey,
         interceptPage: intercept.page,
         interceptParams: intercept.matchedParams,
@@ -6607,6 +6637,10 @@ import {
   renderAppPageErrorBoundary as __renderAppPageErrorBoundary,
   renderAppPageHttpAccessFallback as __renderAppPageHttpAccessFallback,
 } from "<ROOT>/packages/vinext/src/server/app-page-boundary-render.js";
+import {
+  APP_INTERCEPTION_CONTEXT_KEY as __APP_INTERCEPTION_CONTEXT_KEY,
+  createAppPayloadRouteId as __createAppPayloadRouteId,
+} from "<ROOT>/packages/vinext/src/server/app-elements.js";
 import {
   buildAppPageElements as __buildAppPageElements,
   createAppPageTreePath as __createAppPageTreePath,
@@ -7247,7 +7281,8 @@ function findIntercept(pathname) {
 async function buildPageElements(route, params, routePath, opts, searchParams, isRscRequest, request) {
   const PageComponent = route.page?.default;
   if (!PageComponent) {
-    const _noExportRouteId = "route:" + routePath;
+    const _interceptionContext = opts?.interceptionContext ?? null;
+    const _noExportRouteId = __createAppPayloadRouteId(routePath, _interceptionContext);
     let _noExportRootLayout = null;
     if (route.layouts?.length > 0) {
       // Compute the root layout tree path for this error payload using the
@@ -7256,6 +7291,7 @@ async function buildPageElements(route, params, routePath, opts, searchParams, i
       _noExportRootLayout = __createAppPageTreePath(route.routeSegments, _tp);
     }
     return {
+      [__APP_INTERCEPTION_CONTEXT_KEY]: _interceptionContext,
       __route: _noExportRouteId,
       __rootLayout: _noExportRootLayout,
       [_noExportRouteId]: createElement("div", null, "Page has no default export"),
@@ -7375,6 +7411,7 @@ async function buildPageElements(route, params, routePath, opts, searchParams, i
     matchedParams: params,
     resolvedMetadata,
     resolvedViewport,
+    interceptionContext: opts?.interceptionContext ?? null,
     routePath,
     rootNotFoundModule: null,
     route,
@@ -7828,6 +7865,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   }
 
   const isRscRequest = pathname.endsWith(".rsc") || request.headers.get("accept")?.includes("text/x-component");
+  const interceptionContextHeader = request.headers.get("X-Vinext-Interception-Context");
   let cleanPathname = pathname.replace(/\\.rsc$/, "");
 
   // Middleware response headers and custom rewrite status are stored in
@@ -8094,8 +8132,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           request,
         );
       } else {
-        const _actionRouteId = "route:" + cleanPathname;
+        const _actionRouteId = __createAppPayloadRouteId(cleanPathname, null);
         element = {
+          [__APP_INTERCEPTION_CONTEXT_KEY]: null,
           __route: _actionRouteId,
           __rootLayout: null,
           [_actionRouteId]: createElement("div", null, "Page not found"),
@@ -8542,6 +8581,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     setNavigationContext,
     toInterceptOpts(intercept) {
       return {
+        interceptionContext: interceptionContextHeader,
         interceptSlotKey: intercept.slotKey,
         interceptPage: intercept.page,
         interceptParams: intercept.matchedParams,
@@ -8814,6 +8854,10 @@ import {
   renderAppPageErrorBoundary as __renderAppPageErrorBoundary,
   renderAppPageHttpAccessFallback as __renderAppPageHttpAccessFallback,
 } from "<ROOT>/packages/vinext/src/server/app-page-boundary-render.js";
+import {
+  APP_INTERCEPTION_CONTEXT_KEY as __APP_INTERCEPTION_CONTEXT_KEY,
+  createAppPayloadRouteId as __createAppPayloadRouteId,
+} from "<ROOT>/packages/vinext/src/server/app-elements.js";
 import {
   buildAppPageElements as __buildAppPageElements,
   createAppPageTreePath as __createAppPageTreePath,
@@ -9431,7 +9475,8 @@ function findIntercept(pathname) {
 async function buildPageElements(route, params, routePath, opts, searchParams, isRscRequest, request) {
   const PageComponent = route.page?.default;
   if (!PageComponent) {
-    const _noExportRouteId = "route:" + routePath;
+    const _interceptionContext = opts?.interceptionContext ?? null;
+    const _noExportRouteId = __createAppPayloadRouteId(routePath, _interceptionContext);
     let _noExportRootLayout = null;
     if (route.layouts?.length > 0) {
       // Compute the root layout tree path for this error payload using the
@@ -9440,6 +9485,7 @@ async function buildPageElements(route, params, routePath, opts, searchParams, i
       _noExportRootLayout = __createAppPageTreePath(route.routeSegments, _tp);
     }
     return {
+      [__APP_INTERCEPTION_CONTEXT_KEY]: _interceptionContext,
       __route: _noExportRouteId,
       __rootLayout: _noExportRootLayout,
       [_noExportRouteId]: createElement("div", null, "Page has no default export"),
@@ -9559,6 +9605,7 @@ async function buildPageElements(route, params, routePath, opts, searchParams, i
     matchedParams: params,
     resolvedMetadata,
     resolvedViewport,
+    interceptionContext: opts?.interceptionContext ?? null,
     routePath,
     rootNotFoundModule: null,
     route,
@@ -10009,6 +10056,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   }
 
   const isRscRequest = pathname.endsWith(".rsc") || request.headers.get("accept")?.includes("text/x-component");
+  const interceptionContextHeader = request.headers.get("X-Vinext-Interception-Context");
   let cleanPathname = pathname.replace(/\\.rsc$/, "");
 
   // Middleware response headers and custom rewrite status are stored in
@@ -10275,8 +10323,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           request,
         );
       } else {
-        const _actionRouteId = "route:" + cleanPathname;
+        const _actionRouteId = __createAppPayloadRouteId(cleanPathname, null);
         element = {
+          [__APP_INTERCEPTION_CONTEXT_KEY]: null,
           __route: _actionRouteId,
           __rootLayout: null,
           [_actionRouteId]: createElement("div", null, "Page not found"),
@@ -10723,6 +10772,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     setNavigationContext,
     toInterceptOpts(intercept) {
       return {
+        interceptionContext: interceptionContextHeader,
         interceptSlotKey: intercept.slotKey,
         interceptPage: intercept.page,
         interceptParams: intercept.matchedParams,
@@ -10995,6 +11045,10 @@ import {
   renderAppPageErrorBoundary as __renderAppPageErrorBoundary,
   renderAppPageHttpAccessFallback as __renderAppPageHttpAccessFallback,
 } from "<ROOT>/packages/vinext/src/server/app-page-boundary-render.js";
+import {
+  APP_INTERCEPTION_CONTEXT_KEY as __APP_INTERCEPTION_CONTEXT_KEY,
+  createAppPayloadRouteId as __createAppPayloadRouteId,
+} from "<ROOT>/packages/vinext/src/server/app-elements.js";
 import {
   buildAppPageElements as __buildAppPageElements,
   createAppPageTreePath as __createAppPageTreePath,
@@ -11605,7 +11659,8 @@ function findIntercept(pathname) {
 async function buildPageElements(route, params, routePath, opts, searchParams, isRscRequest, request) {
   const PageComponent = route.page?.default;
   if (!PageComponent) {
-    const _noExportRouteId = "route:" + routePath;
+    const _interceptionContext = opts?.interceptionContext ?? null;
+    const _noExportRouteId = __createAppPayloadRouteId(routePath, _interceptionContext);
     let _noExportRootLayout = null;
     if (route.layouts?.length > 0) {
       // Compute the root layout tree path for this error payload using the
@@ -11614,6 +11669,7 @@ async function buildPageElements(route, params, routePath, opts, searchParams, i
       _noExportRootLayout = __createAppPageTreePath(route.routeSegments, _tp);
     }
     return {
+      [__APP_INTERCEPTION_CONTEXT_KEY]: _interceptionContext,
       __route: _noExportRouteId,
       __rootLayout: _noExportRootLayout,
       [_noExportRouteId]: createElement("div", null, "Page has no default export"),
@@ -11733,6 +11789,7 @@ async function buildPageElements(route, params, routePath, opts, searchParams, i
     matchedParams: params,
     resolvedMetadata,
     resolvedViewport,
+    interceptionContext: opts?.interceptionContext ?? null,
     routePath,
     rootNotFoundModule: null,
     route,
@@ -12412,6 +12469,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   }
 
   const isRscRequest = pathname.endsWith(".rsc") || request.headers.get("accept")?.includes("text/x-component");
+  const interceptionContextHeader = request.headers.get("X-Vinext-Interception-Context");
   let cleanPathname = pathname.replace(/\\.rsc$/, "");
 
   // Middleware response headers and custom rewrite status are stored in
@@ -12816,8 +12874,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           request,
         );
       } else {
-        const _actionRouteId = "route:" + cleanPathname;
+        const _actionRouteId = __createAppPayloadRouteId(cleanPathname, null);
         element = {
+          [__APP_INTERCEPTION_CONTEXT_KEY]: null,
           __route: _actionRouteId,
           __rootLayout: null,
           [_actionRouteId]: createElement("div", null, "Page not found"),
@@ -13264,6 +13323,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     setNavigationContext,
     toInterceptOpts(intercept) {
       return {
+        interceptionContext: interceptionContextHeader,
         interceptSlotKey: intercept.slotKey,
         interceptPage: intercept.page,
         interceptParams: intercept.matchedParams,

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -250,7 +250,7 @@ describe("app browser entry state helpers", () => {
 
   it("clears stale parallel slots on traverse", () => {
     const state = createState({
-      elements: createResolvedElements("route:/feed", "/", {
+      elements: createResolvedElements("route:/feed", "/", null, {
         "slot:modal:/feed": React.createElement("div", null, "modal"),
       }),
     });
@@ -258,6 +258,7 @@ describe("app browser entry state helpers", () => {
 
     const nextState = routerReducer(state, {
       elements: nextElements,
+      interceptionContext: null,
       navigationSnapshot: createState().navigationSnapshot,
       renderId: 1,
       rootLayoutTreePath: "/",
@@ -270,7 +271,7 @@ describe("app browser entry state helpers", () => {
 
   it("preserves absent parallel slots on navigate", () => {
     const state = createState({
-      elements: createResolvedElements("route:/feed", "/", {
+      elements: createResolvedElements("route:/feed", "/", null, {
         "slot:modal:/feed": React.createElement("div", null, "modal"),
       }),
     });
@@ -278,6 +279,7 @@ describe("app browser entry state helpers", () => {
 
     const nextState = routerReducer(state, {
       elements: nextElements,
+      interceptionContext: null,
       navigationSnapshot: createState().navigationSnapshot,
       renderId: 1,
       rootLayoutTreePath: "/",

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -1,6 +1,7 @@
 import React from "react";
 import { describe, expect, it } from "vite-plus/test";
 import {
+  APP_INTERCEPTION_CONTEXT_KEY,
   APP_ROOT_LAYOUT_KEY,
   APP_ROUTE_KEY,
   UNMATCHED_SLOT,
@@ -22,9 +23,11 @@ import {
 function createResolvedElements(
   routeId: string,
   rootLayoutTreePath: string | null,
+  interceptionContext: string | null = null,
   extraEntries: Record<string, unknown> = {},
 ) {
   return normalizeAppElements({
+    [APP_INTERCEPTION_CONTEXT_KEY]: interceptionContext,
     [APP_ROUTE_KEY]: routeId,
     [APP_ROOT_LAYOUT_KEY]: rootLayoutTreePath,
     ...extraEntries,
@@ -36,6 +39,7 @@ function createState(overrides: Partial<AppRouterState> = {}): AppRouterState {
     elements: createResolvedElements("route:/initial", "/"),
     navigationSnapshot: createClientNavigationRenderSnapshot("https://example.com/initial", {}),
     renderId: 0,
+    interceptionContext: null,
     rootLayoutTreePath: "/",
     routeId: "route:/initial",
     ...overrides,
@@ -54,10 +58,10 @@ describe("app browser entry state helpers", () => {
   });
 
   it("merges elements on navigate", async () => {
-    const previousElements = createResolvedElements("route:/initial", "/", {
+    const previousElements = createResolvedElements("route:/initial", "/", null, {
       "layout:/": React.createElement("div", null, "layout"),
     });
-    const nextElements = createResolvedElements("route:/next", "/", {
+    const nextElements = createResolvedElements("route:/next", "/", null, {
       "page:/next": React.createElement("main", null, "next"),
     });
 
@@ -67,6 +71,7 @@ describe("app browser entry state helpers", () => {
       }),
       {
         elements: nextElements,
+        interceptionContext: null,
         navigationSnapshot: createState().navigationSnapshot,
         renderId: 1,
         rootLayoutTreePath: "/",
@@ -76,6 +81,7 @@ describe("app browser entry state helpers", () => {
     );
 
     expect(nextState.routeId).toBe("route:/next");
+    expect(nextState.interceptionContext).toBeNull();
     expect(nextState.rootLayoutTreePath).toBe("/");
     expect(nextState.elements).toMatchObject({
       "layout:/": expect.anything(),
@@ -84,12 +90,13 @@ describe("app browser entry state helpers", () => {
   });
 
   it("replaces elements on replace", () => {
-    const nextElements = createResolvedElements("route:/next", "/", {
+    const nextElements = createResolvedElements("route:/next", "/", null, {
       "page:/next": React.createElement("main", null, "next"),
     });
 
     const nextState = routerReducer(createState(), {
       elements: nextElements,
+      interceptionContext: null,
       navigationSnapshot: createState().navigationSnapshot,
       renderId: 1,
       rootLayoutTreePath: "/",
@@ -98,9 +105,27 @@ describe("app browser entry state helpers", () => {
     });
 
     expect(nextState.elements).toBe(nextElements);
+    expect(nextState.interceptionContext).toBeNull();
     expect(nextState.elements).toMatchObject({
       "page:/next": expect.anything(),
     });
+  });
+
+  it("carries interception context through pending navigation commits", async () => {
+    const pending = await createPendingNavigationCommit({
+      currentState: createState(),
+      nextElements: Promise.resolve(
+        createResolvedElements("route:/photos/42\0/feed", "/", "/feed", {
+          "page:/photos/42": React.createElement("main", null, "photo"),
+        }),
+      ),
+      navigationSnapshot: createState().navigationSnapshot,
+      type: "navigate",
+    });
+
+    expect(pending.routeId).toBe("route:/photos/42\0/feed");
+    expect(pending.interceptionContext).toBe("/feed");
+    expect(pending.action.interceptionContext).toBe("/feed");
   });
 
   it("hard navigates instead of merging when the root layout changes", async () => {

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -120,6 +120,7 @@ describe("app browser entry state helpers", () => {
         }),
       ),
       navigationSnapshot: createState().navigationSnapshot,
+      renderId: 1,
       type: "navigate",
     });
 
@@ -290,7 +291,7 @@ describe("app browser entry state helpers", () => {
 
 describe("mounted slot helpers", () => {
   it("collects only mounted slot ids", () => {
-    const elements: AppElements = createResolvedElements("route:/dashboard", "/", {
+    const elements: AppElements = createResolvedElements("route:/dashboard", "/", null, {
       "layout:/": React.createElement("div", null, "layout"),
       "slot:modal:/": React.createElement("div", null, "modal"),
       "slot:sidebar:/": React.createElement("div", null, "sidebar"),
@@ -302,7 +303,7 @@ describe("mounted slot helpers", () => {
   });
 
   it("serializes mounted slot ids into a stable header value", () => {
-    const elements: AppElements = createResolvedElements("route:/dashboard", "/", {
+    const elements: AppElements = createResolvedElements("route:/dashboard", "/", null, {
       "slot:z:/": React.createElement("div", null, "z"),
       "slot:a:/": React.createElement("div", null, "a"),
     });
@@ -311,7 +312,7 @@ describe("mounted slot helpers", () => {
   });
 
   it("returns null when there are no mounted slots", () => {
-    const elements: AppElements = createResolvedElements("route:/dashboard", "/", {
+    const elements: AppElements = createResolvedElements("route:/dashboard", "/", null, {
       "slot:ghost:/": null,
       "slot:missing:/": UNMATCHED_SLOT,
     });

--- a/tests/app-elements.test.ts
+++ b/tests/app-elements.test.ts
@@ -2,11 +2,15 @@ import React from "react";
 import { describe, expect, it } from "vite-plus/test";
 import { UNMATCHED_SLOT } from "../packages/vinext/src/shims/slot.js";
 import {
+  APP_INTERCEPTION_CONTEXT_KEY,
   APP_ROOT_LAYOUT_KEY,
   APP_ROUTE_KEY,
   APP_UNMATCHED_SLOT_WIRE_VALUE,
+  createAppPayloadCacheKey,
+  createAppPayloadRouteId,
   normalizeAppElements,
   readAppElementsMetadata,
+  resolveVisitedResponseInterceptionContext,
 } from "../packages/vinext/src/server/app-elements.js";
 
 describe("app elements payload helpers", () => {
@@ -35,6 +39,7 @@ describe("app elements payload helpers", () => {
   it("reads route metadata from the normalized payload", () => {
     const metadata = readAppElementsMetadata(
       normalizeAppElements({
+        [APP_INTERCEPTION_CONTEXT_KEY]: "/feed",
         [APP_ROOT_LAYOUT_KEY]: "/(dashboard)",
         [APP_ROUTE_KEY]: "route:/dashboard",
         "route:/dashboard": React.createElement("div", null, "route"),
@@ -42,7 +47,34 @@ describe("app elements payload helpers", () => {
     );
 
     expect(metadata.routeId).toBe("route:/dashboard");
+    expect(metadata.interceptionContext).toBe("/feed");
     expect(metadata.rootLayoutTreePath).toBe("/(dashboard)");
+  });
+
+  it("defaults missing interception context metadata to null", () => {
+    const metadata = readAppElementsMetadata(
+      normalizeAppElements({
+        [APP_ROOT_LAYOUT_KEY]: "/",
+        [APP_ROUTE_KEY]: "route:/dashboard",
+        "route:/dashboard": React.createElement("div", null, "route"),
+      }),
+    );
+
+    expect(metadata.interceptionContext).toBeNull();
+  });
+
+  it("encodes intercepted route ids and cache keys with a NUL separator", () => {
+    expect(createAppPayloadRouteId("/photos/42", null)).toBe("route:/photos/42");
+    expect(createAppPayloadRouteId("/photos/42", "/feed")).toBe("route:/photos/42\0/feed");
+    expect(createAppPayloadCacheKey("/photos/42.rsc", null)).toBe("/photos/42.rsc");
+    expect(createAppPayloadCacheKey("/photos/42.rsc", "/feed")).toBe("/photos/42.rsc\0/feed");
+  });
+
+  it("preserves the request cache context when a direct-route payload omits it", () => {
+    expect(resolveVisitedResponseInterceptionContext("/feed", null)).toBe("/feed");
+    expect(resolveVisitedResponseInterceptionContext("/feed", "/feed")).toBe("/feed");
+    expect(resolveVisitedResponseInterceptionContext("/feed", "/gallery")).toBe("/gallery");
+    expect(resolveVisitedResponseInterceptionContext(null, null)).toBeNull();
   });
 
   it("rejects payloads with a missing __route key", () => {
@@ -74,5 +106,17 @@ describe("app elements payload helpers", () => {
         }),
       ),
     ).toThrow("[vinext] Missing __rootLayout key in App Router payload");
+  });
+
+  it("rejects payloads with an invalid __interceptionContext value", () => {
+    expect(() =>
+      readAppElementsMetadata(
+        normalizeAppElements({
+          [APP_INTERCEPTION_CONTEXT_KEY]: 123,
+          [APP_ROOT_LAYOUT_KEY]: "/",
+          [APP_ROUTE_KEY]: "route:/dashboard",
+        }),
+      ),
+    ).toThrow("[vinext] Invalid __interceptionContext in App Router payload");
   });
 });

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -480,7 +480,10 @@ describe("App Router integration", () => {
   it("renders intercepted photo modal on RSC navigation from feed", async () => {
     // RSC request simulates client-side navigation
     const res = await fetch(`${baseUrl}/photos/42.rsc`, {
-      headers: { Accept: "text/x-component" },
+      headers: {
+        Accept: "text/x-component",
+        "X-Vinext-Interception-Context": "/feed",
+      },
     });
     expect(res.status).toBe(200);
     expect(res.headers.get("content-type")).toContain("text/x-component");
@@ -492,6 +495,13 @@ describe("App Router integration", () => {
     // It should also contain the feed page content (the source route)
     expect(rscPayload).toContain("Photo Feed");
     expect(rscPayload).toContain("feed-page");
+    expect(rscPayload).toContain("__interceptionContext");
+    expect(rscPayload).toContain("/feed");
+    const nul = String.fromCharCode(0);
+    expect(
+      rscPayload.includes("route:/photos/42\\u0000/feed") ||
+        rscPayload.includes(`route:/photos/42${nul}/feed`),
+    ).toBe(true);
   });
 
   // --- Intercepting routes with dynamic source route ---

--- a/tests/e2e/app-router/advanced.spec.ts
+++ b/tests/e2e/app-router/advanced.spec.ts
@@ -2,6 +2,12 @@ import { test, expect } from "@playwright/test";
 
 const BASE = "http://localhost:4174";
 
+async function waitForAppRouterHydration(page: import("@playwright/test").Page) {
+  await page.waitForFunction(() => typeof window.__VINEXT_RSC_NAVIGATE__ === "function", null, {
+    timeout: 10_000,
+  });
+}
+
 test.describe("Parallel Routes", () => {
   test("dashboard renders all parallel slot content", async ({ page }) => {
     await page.goto(`${BASE}/dashboard`);
@@ -55,30 +61,76 @@ test.describe("Intercepting Routes", () => {
     await expect(page.locator('[data-testid="photo-modal"]')).not.toBeVisible();
   });
 
-  // TODO: This test is temporarily skipped due to a timing issue with embedded
-  // RSC hydration. The intercepting route feature still works - this is a test
-  // infrastructure issue that needs investigation. See issue #61 comments.
-  test.skip("RSC client navigation intercepts to show modal", async ({ page }) => {
-    // Start on the feed page
+  test("direct payload cache does not override intercepted navigation", async ({ page }) => {
+    await page.goto(`${BASE}/photos/42`);
+    await expect(page.locator('[data-testid="photo-page"]')).toBeVisible();
+
     await page.goto(`${BASE}/feed`);
+    await waitForAppRouterHydration(page);
 
-    // Wait for hydration
-    await page.waitForFunction(
-      () => typeof (window as any).__VINEXT_RSC_NAVIGATE__ === "function",
-      null,
-      { timeout: 10000 },
-    );
+    await page.click("#feed-photo-42-link");
 
-    // Click a photo link — this should be intercepted and show a modal
-    await page.click('a[href="/photos/1"]');
+    await expect(page.locator('[data-testid="photo-modal"]')).toBeVisible();
+    await expect(page.locator('[data-testid="feed-page"]')).toBeVisible();
+    await expect(page.locator('[data-testid="photo-page"]')).not.toBeVisible();
+  });
 
-    // Wait for RSC navigation to complete
-    await page.waitForTimeout(1000);
+  test("intercepted payload cache is reused for repeated source-page navigations", async ({
+    page,
+  }) => {
+    await page.goto(`${BASE}/feed`);
+    await waitForAppRouterHydration(page);
 
-    // The modal version of the photo should appear
-    await expect(page.locator('[data-testid="photo-modal"]')).toBeVisible({
-      timeout: 5000,
-    });
+    await page.click("#feed-photo-42-link");
+    await expect(page.locator('[data-testid="photo-modal"]')).toBeVisible();
+
+    await page.goto(`${BASE}/about`);
+    await page.goto(`${BASE}/feed`);
+    await waitForAppRouterHydration(page);
+
+    await page.click("#feed-photo-42-link");
+    await expect(page.locator('[data-testid="photo-modal"]')).toBeVisible();
+    await expect(page.locator('[data-testid="photo-page"]')).not.toBeVisible();
+  });
+
+  test("refresh on direct photo load preserves the full-page render", async ({ page }) => {
+    await page.goto(`${BASE}/photos/42`);
+    await expect(page.locator('[data-testid="photo-page"]')).toBeVisible();
+
+    await page.reload();
+    await waitForAppRouterHydration(page);
+
+    await expect(page.locator('[data-testid="photo-page"]')).toBeVisible();
+    await expect(page.locator('[data-testid="photo-modal"]')).not.toBeVisible();
+  });
+
+  test("prefetches keep separate cache entries for feed and gallery interception contexts", async ({
+    page,
+  }) => {
+    await page.goto(`${BASE}/feed`);
+    await waitForAppRouterHydration(page);
+    await expect
+      .poll(async () =>
+        page.evaluate(() =>
+          Array.from(window.__VINEXT_RSC_PREFETCH_CACHE__?.keys() ?? []).filter((key) =>
+            key.includes("/photos/42.rsc"),
+          ),
+        ),
+      )
+      .toEqual(["/photos/42.rsc\u0000/feed"]);
+
+    await page.click("#gallery-link");
+    await page.waitForURL(`${BASE}/gallery`);
+    await waitForAppRouterHydration(page);
+    await expect
+      .poll(async () =>
+        page.evaluate(() =>
+          Array.from(window.__VINEXT_RSC_PREFETCH_CACHE__?.keys() ?? [])
+            .filter((key) => key.includes("/photos/42.rsc"))
+            .sort(),
+        ),
+      )
+      .toEqual(["/photos/42.rsc\u0000/feed", "/photos/42.rsc\u0000/gallery"]);
   });
 });
 

--- a/tests/e2e/app-router/advanced.spec.ts
+++ b/tests/e2e/app-router/advanced.spec.ts
@@ -93,6 +93,22 @@ test.describe("Intercepting Routes", () => {
     await expect(page.locator('[data-testid="photo-page"]')).not.toBeVisible();
   });
 
+  test("chained intercepted navigations keep the original source context", async ({ page }) => {
+    await page.goto(`${BASE}/feed`);
+    await waitForAppRouterHydration(page);
+
+    await page.click("#feed-photo-42-link");
+    await expect(page.locator('[data-testid="photo-modal"]')).toBeVisible();
+    await expect(page.locator('[data-testid="photo-modal"]')).toContainText("Viewing photo 42");
+
+    await page.click("#modal-photo-43-link");
+
+    await expect(page.locator('[data-testid="photo-modal"]')).toBeVisible();
+    await expect(page.locator('[data-testid="photo-modal"]')).toContainText("Viewing photo 43");
+    await expect(page.locator('[data-testid="feed-page"]')).toBeVisible();
+    await expect(page.locator('[data-testid="photo-page"]')).not.toBeVisible();
+  });
+
   test("refresh on direct photo load preserves the full-page render", async ({ page }) => {
     await page.goto(`${BASE}/photos/42`);
     await expect(page.locator('[data-testid="photo-page"]')).toBeVisible();

--- a/tests/e2e/app-router/layout-persistence.spec.ts
+++ b/tests/e2e/app-router/layout-persistence.spec.ts
@@ -1,82 +1,16 @@
 import { test, expect } from "@playwright/test";
-import { waitForAppRouterHydration } from "../helpers";
-
-async function disableViteErrorOverlay(page: import("@playwright/test").Page) {
-  // Vite's dev error overlay can appear during tests (even for expected errors)
-  // and intercept pointer events, causing flaky click failures.
-  await page
-    .addStyleTag({
-      content: "vite-error-overlay{display:none !important; pointer-events:none !important;}",
-    })
-    .catch(() => {
-      // best effort
-    });
-}
 
 const BASE = "http://localhost:4174";
 
-type CounterControls = {
-  countTestId: string;
-  incrementTestId: string;
-  label: string;
-};
-
-async function readCounterValue(
-  page: import("@playwright/test").Page,
-  { countTestId, label }: CounterControls,
-): Promise<number> {
-  const text = await page.getByTestId(countTestId).textContent();
-  if (text == null) {
-    throw new Error(`Missing counter text for ${countTestId}`);
-  }
-
-  const expectedPrefix = `${label}: `;
-  if (!text.startsWith(expectedPrefix)) {
-    throw new Error(`Unexpected counter text for ${countTestId}: ${text}`);
-  }
-
-  return Number.parseInt(text.slice(expectedPrefix.length), 10);
-}
-
-async function waitForInteractiveCounter(
-  page: import("@playwright/test").Page,
-  controls: CounterControls,
-): Promise<number> {
-  const incrementButton = page.getByTestId(controls.incrementTestId);
-  await incrementButton.waitFor({ state: "visible" });
-
+/**
+ * Wait for the RSC browser entry to hydrate.
+ */
+async function waitForHydration(page: import("@playwright/test").Page) {
   await expect(async () => {
-    const before = await readCounterValue(page, controls);
-    await incrementButton.click();
-    const after = await readCounterValue(page, controls);
-    expect(after).toBeGreaterThan(before);
+    const ready = await page.evaluate(() => "__VINEXT_RSC_ROOT__" in window);
+    expect(ready).toBe(true);
   }).toPass({ timeout: 10_000 });
-
-  return readCounterValue(page, controls);
 }
-
-async function incrementCounter(
-  page: import("@playwright/test").Page,
-  controls: CounterControls,
-  expectedValue: number,
-) {
-  await page.getByTestId(controls.incrementTestId).click();
-  await expect(page.getByTestId(controls.countTestId)).toHaveText(
-    `${controls.label}: ${expectedValue}`,
-  );
-}
-
-const layoutCounter = {
-  countTestId: "layout-count",
-  incrementTestId: "layout-increment",
-  label: "Layout count",
-} as const;
-
-const templateCounter = {
-  countTestId: "template-count",
-  incrementTestId: "template-increment",
-  label: "Template count",
-} as const;
 
 // ---------------------------------------------------------------------------
 // 1. Layout persistence — navigate between sibling routes, prove the layout
@@ -87,40 +21,42 @@ test.describe("Layout persistence", () => {
   test("dashboard layout counter survives sibling navigation", async ({ page }) => {
     await page.goto(`${BASE}/dashboard`);
     await expect(page.locator("h1")).toHaveText("Dashboard");
-    await waitForAppRouterHydration(page);
+    await waitForHydration(page);
 
-    // Prove the counter is interactive before asserting exact values.
-    const initialCount = await waitForInteractiveCounter(page, layoutCounter);
-    await incrementCounter(page, layoutCounter, initialCount + 1);
-    await incrementCounter(page, layoutCounter, initialCount + 2);
+    // Increment the counter in the dashboard layout
+    await page.click('[data-testid="layout-increment"]');
+    await page.click('[data-testid="layout-increment"]');
+    await page.click('[data-testid="layout-increment"]');
+    await expect(page.locator('[data-testid="layout-count"]')).toHaveText("Layout count: 3");
 
     // Navigate to settings (sibling route under same layout)
-    await page.getByTestId("dash-settings-link").click();
+    await page.click('[data-testid="dash-settings-link"]');
     await expect(page.locator("h1")).toHaveText("Settings");
 
-    // Layout counter should preserve its value — the layout was NOT remounted.
-    await expect(page.getByTestId("layout-count")).toHaveText(`Layout count: ${initialCount + 2}`);
+    // Layout counter should still be 3 — the layout was NOT remounted
+    await expect(page.locator('[data-testid="layout-count"]')).toHaveText("Layout count: 3");
 
     // Navigate back to dashboard home
-    await page.getByTestId("dash-home-link").click();
+    await page.click('[data-testid="dash-home-link"]');
     await expect(page.locator("h1")).toHaveText("Dashboard");
 
-    await expect(page.getByTestId("layout-count")).toHaveText(`Layout count: ${initialCount + 2}`);
+    // Counter should still be 3
+    await expect(page.locator('[data-testid="layout-count"]')).toHaveText("Layout count: 3");
   });
 
   test("layout counter resets on hard navigation", async ({ page }) => {
     await page.goto(`${BASE}/dashboard`);
-    await waitForAppRouterHydration(page);
+    await waitForHydration(page);
 
-    const countAfterHydration = await waitForInteractiveCounter(page, layoutCounter);
-    await incrementCounter(page, layoutCounter, countAfterHydration + 1);
-    await incrementCounter(page, layoutCounter, countAfterHydration + 2);
+    // Increment counter
+    await page.click('[data-testid="layout-increment"]');
+    await expect(page.locator('[data-testid="layout-count"]')).toHaveText("Layout count: 1");
 
     // Hard navigation (full page load) should reset everything
     await page.goto(`${BASE}/dashboard`);
-    await waitForAppRouterHydration(page);
+    await waitForHydration(page);
 
-    await expect(page.getByTestId("layout-count")).toHaveText("Layout count: 0");
+    await expect(page.locator('[data-testid="layout-count"]')).toHaveText("Layout count: 0");
   });
 });
 
@@ -135,55 +71,37 @@ test.describe("Template remount", () => {
   }) => {
     await page.goto(`${BASE}/`);
     await expect(page.locator("h1")).toHaveText("Welcome to App Router");
-    await waitForAppRouterHydration(page);
+    await waitForHydration(page);
 
-    const initialCount = await waitForInteractiveCounter(page, templateCounter);
-    await incrementCounter(page, templateCounter, initialCount + 1);
+    // Increment the template counter
+    await page.click('[data-testid="template-increment"]');
+    await page.click('[data-testid="template-increment"]');
+    await expect(page.locator('[data-testid="template-count"]')).toHaveText("Template count: 2");
 
     // Navigate to /about — this changes the root segment from "" to "about",
     // so the root template should remount and the counter should reset.
     await page.click('a[href="/about"]');
     await expect(page.locator("h1")).toHaveText("About");
 
-    await expect(page.getByTestId("template-count")).toHaveText("Template count: 0");
+    await expect(page.locator('[data-testid="template-count"]')).toHaveText("Template count: 0");
   });
 
   test("root template counter persists within same top-level segment", async ({ page }) => {
     await page.goto(`${BASE}/dashboard`);
     await expect(page.locator("h1")).toHaveText("Dashboard");
-    await waitForAppRouterHydration(page);
+    await waitForHydration(page);
 
-    const initialCount = await waitForInteractiveCounter(page, templateCounter);
-    await incrementCounter(page, templateCounter, initialCount + 1);
+    // Increment the template counter
+    await page.click('[data-testid="template-increment"]');
+    await page.click('[data-testid="template-increment"]');
+    await expect(page.locator('[data-testid="template-count"]')).toHaveText("Template count: 2");
 
     // Navigate to /dashboard/settings — this is still under the "dashboard"
     // top-level segment, so the root template should NOT remount.
-    await page.getByTestId("dash-settings-link").click();
+    await page.click('[data-testid="dash-settings-link"]');
     await expect(page.locator("h1")).toHaveText("Settings");
 
-    await expect(page.getByTestId("template-count")).toHaveText(
-      `Template count: ${initialCount + 1}`,
-    );
-  });
-
-  test("template counter does not reset on search param change within same segment", async ({
-    page,
-  }) => {
-    await page.goto(`${BASE}/dashboard`);
-    await expect(page.locator("h1")).toHaveText("Dashboard");
-    await waitForAppRouterHydration(page);
-
-    const initialCount = await waitForInteractiveCounter(page, templateCounter);
-    await incrementCounter(page, templateCounter, initialCount + 1);
-
-    // Navigate to /dashboard?tab=settings — same pathname, only search params change.
-    // The root segment stays "dashboard", so the root template must NOT remount.
-    await page.getByTestId("dash-tab-link").click();
-    await expect(page.locator("h1")).toHaveText("Dashboard");
-
-    await expect(page.getByTestId("template-count")).toHaveText(
-      `Template count: ${initialCount + 1}`,
-    );
+    await expect(page.locator('[data-testid="template-count"]')).toHaveText("Template count: 2");
   });
 });
 
@@ -196,18 +114,16 @@ test.describe("Error recovery across navigation", () => {
   test("navigating away from error and back clears the error", async ({ page }) => {
     await page.goto(`${BASE}/error-test`);
     await expect(page.locator('[data-testid="error-content"]')).toBeVisible();
-    await waitForAppRouterHydration(page);
-
-    // Hide Vite's dev error overlay before triggering an error — it can appear
-    // over interactive elements and intercept pointer events, causing flaky failures.
-    await disableViteErrorOverlay(page);
+    await waitForHydration(page);
 
     // Trigger error
-    await page.getByTestId("trigger-error").waitFor({ state: "visible" });
-    await page.getByTestId("trigger-error").click();
+    await expect(async () => {
+      await page.click('[data-testid="trigger-error"]');
+      await expect(page.locator("#error-boundary")).toBeVisible({ timeout: 2_000 });
+    }).toPass({ timeout: 15_000 });
 
     // Error boundary should be visible
-    await expect(page.locator("#error-boundary")).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator("#error-boundary")).toBeVisible();
 
     // Client-navigate away to home via the link in the error boundary
     await page.click('[data-testid="error-go-home"]');
@@ -218,7 +134,7 @@ test.describe("Error recovery across navigation", () => {
 
     // Error should be gone — fresh page renders normally
     await expect(page.locator('[data-testid="error-content"]')).toBeVisible({ timeout: 5_000 });
-    await expect(page.locator("#error-boundary")).not.toBeAttached();
+    await expect(page.locator("#error-boundary")).not.toBeVisible();
   });
 });
 
@@ -231,31 +147,37 @@ test.describe("Back/forward with layout state", () => {
   test("browser back preserves layout counter across navigation history", async ({ page }) => {
     await page.goto(`${BASE}/dashboard`);
     await expect(page.locator("h1")).toHaveText("Dashboard");
-    await waitForAppRouterHydration(page);
+    await waitForHydration(page);
 
-    const initialCount = await waitForInteractiveCounter(page, layoutCounter);
-    await incrementCounter(page, layoutCounter, initialCount + 1);
+    // Increment layout counter to 2
+    await page.click('[data-testid="layout-increment"]');
+    await page.click('[data-testid="layout-increment"]');
+    await expect(page.locator('[data-testid="layout-count"]')).toHaveText("Layout count: 2");
 
     // Navigate: dashboard → settings
-    await page.getByTestId("dash-settings-link").click();
+    await page.click('[data-testid="dash-settings-link"]');
     await expect(page.locator("h1")).toHaveText("Settings");
 
-    await expect(page.getByTestId("layout-count")).toHaveText(`Layout count: ${initialCount + 1}`);
+    // Counter should still be 2 (layout persisted)
+    await expect(page.locator('[data-testid="layout-count"]')).toHaveText("Layout count: 2");
 
     // Increment once more while on settings
-    await incrementCounter(page, layoutCounter, initialCount + 2);
+    await page.click('[data-testid="layout-increment"]');
+    await expect(page.locator('[data-testid="layout-count"]')).toHaveText("Layout count: 3");
 
     // Go back to dashboard
     await page.goBack();
     await expect(page.locator("h1")).toHaveText("Dashboard");
 
-    await expect(page.getByTestId("layout-count")).toHaveText(`Layout count: ${initialCount + 2}`);
+    // Counter should still be 3 — back/forward doesn't remount the layout
+    await expect(page.locator('[data-testid="layout-count"]')).toHaveText("Layout count: 3");
 
     // Go forward to settings
     await page.goForward();
     await expect(page.locator("h1")).toHaveText("Settings");
 
-    await expect(page.getByTestId("layout-count")).toHaveText(`Layout count: ${initialCount + 2}`);
+    // Counter should still be 3
+    await expect(page.locator('[data-testid="layout-count"]')).toHaveText("Layout count: 3");
   });
 });
 
@@ -268,7 +190,7 @@ test.describe("Parallel slot persistence", () => {
     // Load /dashboard — parallel slots @team and @analytics have page.tsx
     await page.goto(`${BASE}/dashboard`);
     await expect(page.locator("h1")).toHaveText("Dashboard");
-    await waitForAppRouterHydration(page);
+    await waitForHydration(page);
 
     // Verify slot content is visible
     await expect(page.locator('[data-testid="team-panel"]')).toBeVisible();
@@ -285,17 +207,13 @@ test.describe("Parallel slot persistence", () => {
     // slot content is retained (absent key = persisted from prior soft nav).
     await expect(page.locator('[data-testid="team-panel"]')).toBeVisible();
     await expect(page.locator('[data-testid="analytics-panel"]')).toBeVisible();
-    await expect(page.locator('[data-testid="team-slot"]')).toBeVisible();
-    await expect(page.locator('[data-testid="analytics-slot"]')).toBeVisible();
-    await expect(page.locator('[data-testid="team-default"]')).not.toBeAttached();
-    await expect(page.locator('[data-testid="analytics-default"]')).not.toBeAttached();
   });
 
   test("parallel slots show default.tsx on hard navigation to child route", async ({ page }) => {
     // Hard-load /dashboard/settings directly — slots should show default.tsx
     await page.goto(`${BASE}/dashboard/settings`);
     await expect(page.locator("h1")).toHaveText("Settings");
-    await waitForAppRouterHydration(page);
+    await waitForHydration(page);
 
     // On hard load, slots should render their default.tsx content
     await expect(page.locator('[data-testid="team-panel"]')).toBeVisible();
@@ -303,9 +221,8 @@ test.describe("Parallel slot persistence", () => {
     await expect(page.locator('[data-testid="team-default"]')).toBeVisible();
     await expect(page.locator('[data-testid="analytics-default"]')).toBeVisible();
 
-    // The page-specific slot content should not be in the DOM at all —
-    // the server rendered default.tsx for these slots, not page.tsx.
-    await expect(page.locator('[data-testid="team-slot"]')).not.toBeAttached();
-    await expect(page.locator('[data-testid="analytics-slot"]')).not.toBeAttached();
+    // The page-specific slot content should NOT be visible
+    await expect(page.locator('[data-testid="team-slot"]')).not.toBeVisible();
+    await expect(page.locator('[data-testid="analytics-slot"]')).not.toBeVisible();
   });
 });

--- a/tests/e2e/app-router/layout-persistence.spec.ts
+++ b/tests/e2e/app-router/layout-persistence.spec.ts
@@ -100,9 +100,9 @@ test.describe("Layout persistence", () => {
     await page.goto(`${BASE}/dashboard`);
     await waitForAppRouterHydration(page);
 
-    await waitForInteractiveCounter(page, layoutCounter);
-    await incrementCounter(page, layoutCounter, 2);
-    await incrementCounter(page, layoutCounter, 3);
+    const countAfterHydration = await waitForInteractiveCounter(page, layoutCounter);
+    await incrementCounter(page, layoutCounter, countAfterHydration + 1);
+    await incrementCounter(page, layoutCounter, countAfterHydration + 2);
 
     // Hard navigation (full page load) should reset everything
     await page.goto(`${BASE}/dashboard`);
@@ -202,7 +202,7 @@ test.describe("Error recovery across navigation", () => {
 
     // Error should be gone — fresh page renders normally
     await expect(page.locator('[data-testid="error-content"]')).toBeVisible({ timeout: 5_000 });
-    await expect(page.locator("#error-boundary")).not.toBeVisible();
+    await expect(page.locator("#error-boundary")).not.toBeAttached();
   });
 });
 
@@ -271,8 +271,8 @@ test.describe("Parallel slot persistence", () => {
     await expect(page.locator('[data-testid="analytics-panel"]')).toBeVisible();
     await expect(page.locator('[data-testid="team-slot"]')).toBeVisible();
     await expect(page.locator('[data-testid="analytics-slot"]')).toBeVisible();
-    await expect(page.locator('[data-testid="team-default"]')).not.toBeVisible();
-    await expect(page.locator('[data-testid="analytics-default"]')).not.toBeVisible();
+    await expect(page.locator('[data-testid="team-default"]')).not.toBeAttached();
+    await expect(page.locator('[data-testid="analytics-default"]')).not.toBeAttached();
   });
 
   test("parallel slots show default.tsx on hard navigation to child route", async ({ page }) => {

--- a/tests/e2e/app-router/layout-persistence.spec.ts
+++ b/tests/e2e/app-router/layout-persistence.spec.ts
@@ -1,16 +1,70 @@
 import { test, expect } from "@playwright/test";
+import { waitForAppRouterHydration } from "../helpers";
 
 const BASE = "http://localhost:4174";
 
-/**
- * Wait for the RSC browser entry to hydrate.
- */
-async function waitForHydration(page: import("@playwright/test").Page) {
-  await expect(async () => {
-    const ready = await page.evaluate(() => "__VINEXT_RSC_ROOT__" in window);
-    expect(ready).toBe(true);
-  }).toPass({ timeout: 10_000 });
+type CounterControls = {
+  countTestId: string;
+  incrementTestId: string;
+  label: string;
+};
+
+async function readCounterValue(
+  page: import("@playwright/test").Page,
+  { countTestId, label }: CounterControls,
+): Promise<number> {
+  const text = await page.getByTestId(countTestId).textContent();
+  if (text == null) {
+    throw new Error(`Missing counter text for ${countTestId}`);
+  }
+
+  const expectedPrefix = `${label}: `;
+  if (!text.startsWith(expectedPrefix)) {
+    throw new Error(`Unexpected counter text for ${countTestId}: ${text}`);
+  }
+
+  return Number.parseInt(text.slice(expectedPrefix.length), 10);
 }
+
+async function waitForInteractiveCounter(
+  page: import("@playwright/test").Page,
+  controls: CounterControls,
+): Promise<number> {
+  const incrementButton = page.getByTestId(controls.incrementTestId);
+  await incrementButton.waitFor({ state: "visible" });
+
+  await expect(async () => {
+    const before = await readCounterValue(page, controls);
+    await incrementButton.click();
+    const after = await readCounterValue(page, controls);
+    expect(after).toBeGreaterThan(before);
+  }).toPass({ timeout: 10_000 });
+
+  return readCounterValue(page, controls);
+}
+
+async function incrementCounter(
+  page: import("@playwright/test").Page,
+  controls: CounterControls,
+  expectedValue: number,
+) {
+  await page.getByTestId(controls.incrementTestId).click();
+  await expect(page.getByTestId(controls.countTestId)).toHaveText(
+    `${controls.label}: ${expectedValue}`,
+  );
+}
+
+const layoutCounter = {
+  countTestId: "layout-count",
+  incrementTestId: "layout-increment",
+  label: "Layout count",
+} as const;
+
+const templateCounter = {
+  countTestId: "template-count",
+  incrementTestId: "template-increment",
+  label: "Template count",
+} as const;
 
 // ---------------------------------------------------------------------------
 // 1. Layout persistence — navigate between sibling routes, prove the layout
@@ -21,42 +75,38 @@ test.describe("Layout persistence", () => {
   test("dashboard layout counter survives sibling navigation", async ({ page }) => {
     await page.goto(`${BASE}/dashboard`);
     await expect(page.locator("h1")).toHaveText("Dashboard");
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
-    // Increment the counter in the dashboard layout
-    await page.click('[data-testid="layout-increment"]');
-    await page.click('[data-testid="layout-increment"]');
-    await page.click('[data-testid="layout-increment"]');
-    await expect(page.locator('[data-testid="layout-count"]')).toHaveText("Layout count: 3");
+    // Prove the counter is interactive before asserting exact values.
+    const initialCount = await waitForInteractiveCounter(page, layoutCounter);
+    await incrementCounter(page, layoutCounter, initialCount + 1);
+    await incrementCounter(page, layoutCounter, initialCount + 2);
 
     // Navigate to settings (sibling route under same layout)
-    await page.click('[data-testid="dash-settings-link"]');
+    await page.getByTestId("dash-settings-link").click();
     await expect(page.locator("h1")).toHaveText("Settings");
 
-    // Layout counter should still be 3 — the layout was NOT remounted
-    await expect(page.locator('[data-testid="layout-count"]')).toHaveText("Layout count: 3");
+    // Layout counter should preserve its value — the layout was NOT remounted.
+    await expect(page.getByTestId("layout-count")).toHaveText(`Layout count: ${initialCount + 2}`);
 
     // Navigate back to dashboard home
-    await page.click('[data-testid="dash-home-link"]');
+    await page.getByTestId("dash-home-link").click();
     await expect(page.locator("h1")).toHaveText("Dashboard");
 
-    // Counter should still be 3
-    await expect(page.locator('[data-testid="layout-count"]')).toHaveText("Layout count: 3");
+    await expect(page.getByTestId("layout-count")).toHaveText(`Layout count: ${initialCount + 2}`);
   });
 
   test("layout counter resets on hard navigation", async ({ page }) => {
     await page.goto(`${BASE}/dashboard`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
-    // Increment counter
-    await page.click('[data-testid="layout-increment"]');
-    await expect(page.locator('[data-testid="layout-count"]')).toHaveText("Layout count: 1");
+    expect(await waitForInteractiveCounter(page, layoutCounter)).toBeGreaterThan(0);
 
     // Hard navigation (full page load) should reset everything
     await page.goto(`${BASE}/dashboard`);
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
-    await expect(page.locator('[data-testid="layout-count"]')).toHaveText("Layout count: 0");
+    await expect(page.getByTestId("layout-count")).toHaveText("Layout count: 0");
   });
 });
 
@@ -71,37 +121,35 @@ test.describe("Template remount", () => {
   }) => {
     await page.goto(`${BASE}/`);
     await expect(page.locator("h1")).toHaveText("Welcome to App Router");
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
-    // Increment the template counter
-    await page.click('[data-testid="template-increment"]');
-    await page.click('[data-testid="template-increment"]');
-    await expect(page.locator('[data-testid="template-count"]')).toHaveText("Template count: 2");
+    const initialCount = await waitForInteractiveCounter(page, templateCounter);
+    await incrementCounter(page, templateCounter, initialCount + 1);
 
     // Navigate to /about — this changes the root segment from "" to "about",
     // so the root template should remount and the counter should reset.
     await page.click('a[href="/about"]');
     await expect(page.locator("h1")).toHaveText("About");
 
-    await expect(page.locator('[data-testid="template-count"]')).toHaveText("Template count: 0");
+    await expect(page.getByTestId("template-count")).toHaveText("Template count: 0");
   });
 
   test("root template counter persists within same top-level segment", async ({ page }) => {
     await page.goto(`${BASE}/dashboard`);
     await expect(page.locator("h1")).toHaveText("Dashboard");
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
-    // Increment the template counter
-    await page.click('[data-testid="template-increment"]');
-    await page.click('[data-testid="template-increment"]');
-    await expect(page.locator('[data-testid="template-count"]')).toHaveText("Template count: 2");
+    const initialCount = await waitForInteractiveCounter(page, templateCounter);
+    await incrementCounter(page, templateCounter, initialCount + 1);
 
     // Navigate to /dashboard/settings — this is still under the "dashboard"
     // top-level segment, so the root template should NOT remount.
-    await page.click('[data-testid="dash-settings-link"]');
+    await page.getByTestId("dash-settings-link").click();
     await expect(page.locator("h1")).toHaveText("Settings");
 
-    await expect(page.locator('[data-testid="template-count"]')).toHaveText("Template count: 2");
+    await expect(page.getByTestId("template-count")).toHaveText(
+      `Template count: ${initialCount + 1}`,
+    );
   });
 });
 
@@ -114,7 +162,7 @@ test.describe("Error recovery across navigation", () => {
   test("navigating away from error and back clears the error", async ({ page }) => {
     await page.goto(`${BASE}/error-test`);
     await expect(page.locator('[data-testid="error-content"]')).toBeVisible();
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     // Trigger error
     await expect(async () => {
@@ -147,37 +195,31 @@ test.describe("Back/forward with layout state", () => {
   test("browser back preserves layout counter across navigation history", async ({ page }) => {
     await page.goto(`${BASE}/dashboard`);
     await expect(page.locator("h1")).toHaveText("Dashboard");
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
-    // Increment layout counter to 2
-    await page.click('[data-testid="layout-increment"]');
-    await page.click('[data-testid="layout-increment"]');
-    await expect(page.locator('[data-testid="layout-count"]')).toHaveText("Layout count: 2");
+    const initialCount = await waitForInteractiveCounter(page, layoutCounter);
+    await incrementCounter(page, layoutCounter, initialCount + 1);
 
     // Navigate: dashboard → settings
-    await page.click('[data-testid="dash-settings-link"]');
+    await page.getByTestId("dash-settings-link").click();
     await expect(page.locator("h1")).toHaveText("Settings");
 
-    // Counter should still be 2 (layout persisted)
-    await expect(page.locator('[data-testid="layout-count"]')).toHaveText("Layout count: 2");
+    await expect(page.getByTestId("layout-count")).toHaveText(`Layout count: ${initialCount + 1}`);
 
     // Increment once more while on settings
-    await page.click('[data-testid="layout-increment"]');
-    await expect(page.locator('[data-testid="layout-count"]')).toHaveText("Layout count: 3");
+    await incrementCounter(page, layoutCounter, initialCount + 2);
 
     // Go back to dashboard
     await page.goBack();
     await expect(page.locator("h1")).toHaveText("Dashboard");
 
-    // Counter should still be 3 — back/forward doesn't remount the layout
-    await expect(page.locator('[data-testid="layout-count"]')).toHaveText("Layout count: 3");
+    await expect(page.getByTestId("layout-count")).toHaveText(`Layout count: ${initialCount + 2}`);
 
     // Go forward to settings
     await page.goForward();
     await expect(page.locator("h1")).toHaveText("Settings");
 
-    // Counter should still be 3
-    await expect(page.locator('[data-testid="layout-count"]')).toHaveText("Layout count: 3");
+    await expect(page.getByTestId("layout-count")).toHaveText(`Layout count: ${initialCount + 2}`);
   });
 });
 
@@ -190,7 +232,7 @@ test.describe("Parallel slot persistence", () => {
     // Load /dashboard — parallel slots @team and @analytics have page.tsx
     await page.goto(`${BASE}/dashboard`);
     await expect(page.locator("h1")).toHaveText("Dashboard");
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     // Verify slot content is visible
     await expect(page.locator('[data-testid="team-panel"]')).toBeVisible();
@@ -213,7 +255,7 @@ test.describe("Parallel slot persistence", () => {
     // Hard-load /dashboard/settings directly — slots should show default.tsx
     await page.goto(`${BASE}/dashboard/settings`);
     await expect(page.locator("h1")).toHaveText("Settings");
-    await waitForHydration(page);
+    await waitForAppRouterHydration(page);
 
     // On hard load, slots should render their default.tsx content
     await expect(page.locator('[data-testid="team-panel"]')).toBeVisible();

--- a/tests/e2e/app-router/layout-persistence.spec.ts
+++ b/tests/e2e/app-router/layout-persistence.spec.ts
@@ -100,7 +100,9 @@ test.describe("Layout persistence", () => {
     await page.goto(`${BASE}/dashboard`);
     await waitForAppRouterHydration(page);
 
-    expect(await waitForInteractiveCounter(page, layoutCounter)).toBeGreaterThan(0);
+    await waitForInteractiveCounter(page, layoutCounter);
+    await incrementCounter(page, layoutCounter, 2);
+    await incrementCounter(page, layoutCounter, 3);
 
     // Hard navigation (full page load) should reset everything
     await page.goto(`${BASE}/dashboard`);
@@ -151,6 +153,26 @@ test.describe("Template remount", () => {
       `Template count: ${initialCount + 1}`,
     );
   });
+
+  test("template counter does not reset on search param change within same segment", async ({
+    page,
+  }) => {
+    await page.goto(`${BASE}/dashboard`);
+    await expect(page.locator("h1")).toHaveText("Dashboard");
+    await waitForAppRouterHydration(page);
+
+    const initialCount = await waitForInteractiveCounter(page, templateCounter);
+    await incrementCounter(page, templateCounter, initialCount + 1);
+
+    // Navigate to /dashboard?tab=settings — same pathname, only search params change.
+    // The root segment stays "dashboard", so the root template must NOT remount.
+    await page.getByTestId("dash-tab-link").click();
+    await expect(page.locator("h1")).toHaveText("Dashboard");
+
+    await expect(page.getByTestId("template-count")).toHaveText(
+      `Template count: ${initialCount + 1}`,
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -165,13 +187,11 @@ test.describe("Error recovery across navigation", () => {
     await waitForAppRouterHydration(page);
 
     // Trigger error
-    await expect(async () => {
-      await page.click('[data-testid="trigger-error"]');
-      await expect(page.locator("#error-boundary")).toBeVisible({ timeout: 2_000 });
-    }).toPass({ timeout: 15_000 });
+    await page.getByTestId("trigger-error").waitFor({ state: "visible" });
+    await page.getByTestId("trigger-error").click();
 
     // Error boundary should be visible
-    await expect(page.locator("#error-boundary")).toBeVisible();
+    await expect(page.locator("#error-boundary")).toBeVisible({ timeout: 10_000 });
 
     // Client-navigate away to home via the link in the error boundary
     await page.click('[data-testid="error-go-home"]');
@@ -249,6 +269,10 @@ test.describe("Parallel slot persistence", () => {
     // slot content is retained (absent key = persisted from prior soft nav).
     await expect(page.locator('[data-testid="team-panel"]')).toBeVisible();
     await expect(page.locator('[data-testid="analytics-panel"]')).toBeVisible();
+    await expect(page.locator('[data-testid="team-slot"]')).toBeVisible();
+    await expect(page.locator('[data-testid="analytics-slot"]')).toBeVisible();
+    await expect(page.locator('[data-testid="team-default"]')).not.toBeVisible();
+    await expect(page.locator('[data-testid="analytics-default"]')).not.toBeVisible();
   });
 
   test("parallel slots show default.tsx on hard navigation to child route", async ({ page }) => {

--- a/tests/fixtures/app-basic/app/feed/@modal/(...)photos/[id]/page.tsx
+++ b/tests/fixtures/app-basic/app/feed/@modal/(...)photos/[id]/page.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+
 // Intercepting route: renders when navigating from /feed to /photos/[id].
 // Shows a modal version of the photo instead of the full page.
 export default function PhotoModal({ params }: { params: { id: string } }) {
@@ -5,6 +7,9 @@ export default function PhotoModal({ params }: { params: { id: string } }) {
     <div data-testid="photo-modal">
       <h2>Photo Modal</h2>
       <p>Viewing photo {params.id} in modal</p>
+      <Link href="/photos/43" id="modal-photo-43-link">
+        Next Photo
+      </Link>
     </div>
   );
 }

--- a/tests/fixtures/app-basic/app/feed/page.tsx
+++ b/tests/fixtures/app-basic/app/feed/page.tsx
@@ -1,16 +1,28 @@
+import Link from "next/link";
+
 export default function FeedPage() {
   return (
     <div data-testid="feed-page">
       <h1>Photo Feed</h1>
       <ul>
         <li>
-          <a href="/photos/1">Photo 1</a>
+          <Link href="/photos/1">Photo 1</Link>
         </li>
         <li>
-          <a href="/photos/2">Photo 2</a>
+          <Link href="/photos/2">Photo 2</Link>
         </li>
         <li>
-          <a href="/photos/3">Photo 3</a>
+          <Link href="/photos/3">Photo 3</Link>
+        </li>
+        <li>
+          <Link href="/photos/42" id="feed-photo-42-link">
+            Photo 42
+          </Link>
+        </li>
+        <li>
+          <Link href="/gallery" id="gallery-link">
+            Gallery
+          </Link>
         </li>
       </ul>
     </div>

--- a/tests/fixtures/app-basic/app/gallery/page.tsx
+++ b/tests/fixtures/app-basic/app/gallery/page.tsx
@@ -1,0 +1,16 @@
+import Link from "next/link";
+
+export default function GalleryPage() {
+  return (
+    <div data-testid="gallery-page">
+      <h1>Photo Gallery</h1>
+      <ul>
+        <li>
+          <Link href="/photos/42" id="gallery-photo-42-link">
+            Photo 42
+          </Link>
+        </li>
+      </ul>
+    </div>
+  );
+}

--- a/tests/prefetch-cache.test.ts
+++ b/tests/prefetch-cache.test.ts
@@ -10,6 +10,7 @@
  * vi.resetModules() + dynamic import().
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vite-plus/test";
+import { createAppPayloadCacheKey } from "../packages/vinext/src/server/app-elements.js";
 
 type Navigation = typeof import("../packages/vinext/src/shims/navigation.js");
 let storePrefetchResponse: Navigation["storePrefetchResponse"];
@@ -85,7 +86,7 @@ describe("prefetch cache eviction", () => {
     cache.set(rscUrl, { snapshot, timestamp: Date.now() });
     prefetched.add(rscUrl);
 
-    expect(consumePrefetchResponse(rscUrl, "slot:auth:/")).toEqual(snapshot);
+    expect(consumePrefetchResponse(rscUrl, null, "slot:auth:/")).toEqual(snapshot);
     expect(cache.has(rscUrl)).toBe(false);
     expect(prefetched.has(rscUrl)).toBe(false);
   });
@@ -107,9 +108,21 @@ describe("prefetch cache eviction", () => {
     });
     prefetched.add(rscUrl);
 
-    expect(consumePrefetchResponse(rscUrl, "slot:nav:/")).toBeNull();
+    expect(consumePrefetchResponse(rscUrl, null, "slot:nav:/")).toBeNull();
     expect(cache.has(rscUrl)).toBe(false);
     expect(prefetched.has(rscUrl)).toBe(false);
+  });
+
+  it("allows separate interception-context entries for the same RSC URL", () => {
+    const feedKey = createAppPayloadCacheKey("/photos/42.rsc", "/feed");
+    const galleryKey = createAppPayloadCacheKey("/photos/42.rsc", "/gallery");
+
+    storePrefetchResponse(feedKey, new Response("feed"));
+    storePrefetchResponse(galleryKey, new Response("gallery"));
+
+    expect(feedKey).not.toBe(galleryKey);
+    expect(getPrefetchCache().has(feedKey)).toBe(true);
+    expect(getPrefetchCache().has(galleryKey)).toBe(true);
   });
 
   it("preserves X-Vinext-Params when replaying cached RSC responses", async () => {

--- a/tests/prefetch-cache.test.ts
+++ b/tests/prefetch-cache.test.ts
@@ -17,6 +17,7 @@ let storePrefetchResponse: Navigation["storePrefetchResponse"];
 let consumePrefetchResponse: Navigation["consumePrefetchResponse"];
 let getPrefetchCache: Navigation["getPrefetchCache"];
 let getPrefetchedUrls: Navigation["getPrefetchedUrls"];
+let getCurrentInterceptionContext: Navigation["getCurrentInterceptionContext"];
 let MAX_PREFETCH_CACHE_SIZE: Navigation["MAX_PREFETCH_CACHE_SIZE"];
 let PREFETCH_CACHE_TTL: Navigation["PREFETCH_CACHE_TTL"];
 let snapshotRscResponse: Navigation["snapshotRscResponse"];
@@ -38,6 +39,7 @@ beforeEach(async () => {
   consumePrefetchResponse = nav.consumePrefetchResponse;
   getPrefetchCache = nav.getPrefetchCache;
   getPrefetchedUrls = nav.getPrefetchedUrls;
+  getCurrentInterceptionContext = nav.getCurrentInterceptionContext;
   MAX_PREFETCH_CACHE_SIZE = nav.MAX_PREFETCH_CACHE_SIZE;
   PREFETCH_CACHE_TTL = nav.PREFETCH_CACHE_TTL;
   snapshotRscResponse = nav.snapshotRscResponse;
@@ -111,6 +113,15 @@ describe("prefetch cache eviction", () => {
     expect(consumePrefetchResponse(rscUrl, null, "slot:nav:/")).toBeNull();
     expect(cache.has(rscUrl)).toBe(false);
     expect(prefetched.has(rscUrl)).toBe(false);
+  });
+
+  it("reuses the committed interception context for soft navigations", () => {
+    (globalThis as any).window.location.pathname = "/photos/42";
+    (globalThis as any).window.history.state = {
+      __vinext_interceptionContext: "/feed",
+    };
+
+    expect(getCurrentInterceptionContext()).toBe("/feed");
   });
 
   it("allows separate interception-context entries for the same RSC URL", () => {

--- a/tests/prefetch-cache.test.ts
+++ b/tests/prefetch-cache.test.ts
@@ -125,12 +125,11 @@ describe("prefetch cache eviction", () => {
   });
 
   it("allows separate interception-context entries for the same RSC URL", () => {
+    storePrefetchResponse("/photos/42.rsc", new Response("feed"), "/feed");
+    storePrefetchResponse("/photos/42.rsc", new Response("gallery"), "/gallery");
+
     const feedKey = createAppPayloadCacheKey("/photos/42.rsc", "/feed");
     const galleryKey = createAppPayloadCacheKey("/photos/42.rsc", "/gallery");
-
-    storePrefetchResponse(feedKey, new Response("feed"));
-    storePrefetchResponse(galleryKey, new Response("gallery"));
-
     expect(feedKey).not.toBe(galleryKey);
     expect(getPrefetchCache().has(feedKey)).toBe(true);
     expect(getPrefetchCache().has(galleryKey)).toBe(true);


### PR DESCRIPTION
## Summary

Part of #726 (PR 4). This adds the interception-context identity that PR 2c intentionally deferred. Intercepted App Router navigations now carry their source route through the payload IDs, prefetch cache, visited-response cache, and history state, so `/feed -> /photos/42` modal navigations stop aliasing direct `/photos/42` page loads.

The practical effect is that intercepted and direct renders of the same visible pathname no longer stomp each other. Repeated feed/gallery modal navigations reuse the right cached payload, back/forward restores the right source context, and the ordinary visited-response cache still works for non-intercepted navigations.

### What changed

- **Payload metadata and IDs** — App Router payloads now include `__interceptionContext` when an intercepted render is active, and route/page IDs are encoded with that context instead of keying only by pathname
- **Browser router state** — `app-browser-entry` and `app-browser-state` now carry committed interception context alongside `elements`, `routeId`, and `rootLayoutTreePath`, and write it into history state so traversal can recover the original source route
- **Prefetch and visited-response caches** — prefetch keys and visited-response keys are now interception-aware, so `/photos/42.rsc` from `/feed` and `/gallery` do not alias each other. Direct-route payloads still omit interception metadata, so visited-response storage preserves the request-side cache partition when the payload does not provide one
- **Client requests** — `next/link` prefetch and App Router navigations send `X-Vinext-Interception-Context` when the current render is inside an intercepted flow, and the server reads that header when building intercepted payloads
- **Fixtures and tests** — adds a `gallery` source route plus targeted integration/E2E coverage for direct-vs-intercepted cache separation, repeated intercepted navigations, refresh behavior, and interception-aware prefetch entries

### What this does NOT do

Server action / refresh parity for intercepted routes is still deferred. This PR intentionally leaves action re-renders on the direct-route path and keeps the scope to payload encoding + browser-side cache/history identity.

## Test plan

- [x] `vp test run tests/app-elements.test.ts tests/app-browser-entry.test.ts tests/prefetch-cache.test.ts`
- [x] `vp test run tests/app-router.test.ts -t "renders intercepted photo modal on RSC navigation from feed"`
- [x] `vp run test:e2e -- tests/e2e/app-router/advanced.spec.ts --project app-router`
- [x] `git commit` pre-commit hook (`vp check --fix`)