### PR TITLE
feat: track previousNextUrl for intercepted App Router entries

### DIFF
--- a/packages/vinext/src/global.d.ts
+++ b/packages/vinext/src/global.d.ts
@@ -93,6 +93,7 @@ declare global {
           redirectDepth?: number,
           navigationKind?: "navigate" | "traverse" | "refresh",
           historyUpdateMode?: "push" | "replace",
+          previousNextUrlOverride?: string | null,
         ) => Promise<void>)
       | undefined;
 

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -754,8 +754,9 @@ function registerServerActionCallback(): void {
     const temporaryReferences = createTemporaryReferenceSet();
     const body = await encodeReply(args, { temporaryReferences });
 
-    // Intentionally omit interception context for server action re-renders in
-    // this PR. Durable intercepted refresh/action parity belongs to PR 5.
+    // Interception context on server-action re-renders is intentionally
+    // deferred: action POSTs always target the current URL's full page without
+    // propagating the source-route provenance.
     const fetchResponse = await fetch(toRscUrl(window.location.pathname + window.location.search), {
       method: "POST",
       headers: { "x-rsc-action": id },
@@ -1093,8 +1094,9 @@ async function main(): Promise<void> {
           window.location.href,
           latestClientParams,
         );
-        // Intentionally omit interception context for HMR re-renders.
-        // Preserving intercepted modal state across HMR belongs to PR 5.
+        // Interception context on HMR re-renders is intentionally deferred:
+        // preserving intercepted modal state across HMR reloads is out of scope
+        // for the previousNextUrl mechanism.
         const pending = await createPendingNavigationCommit({
           currentState: getBrowserRouterState(),
           nextElements: normalizeAppElementsPromise(

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -334,14 +334,16 @@ function getRequestState(
         previousNextUrl,
       };
     }
-    case "refresh":
+    case "refresh": {
+      const currentPreviousNextUrl = getBrowserRouterState().previousNextUrl;
       return {
         interceptionContext: resolveInterceptionContextFromPreviousNextUrl(
-          getBrowserRouterState().previousNextUrl,
+          currentPreviousNextUrl,
           __basePath,
         ),
-        previousNextUrl: getBrowserRouterState().previousNextUrl,
+        previousNextUrl: currentPreviousNextUrl,
       };
+    }
     default: {
       const _exhaustive: never = navigationKind;
       throw new Error("[vinext] Unknown navigation kind: " + String(_exhaustive));

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -152,8 +152,7 @@ function stageClientParams(params: Record<string, string | string[]>): void {
   // read latestClientParams, so a
   // server action fired during this window would get the pending (not yet
   // committed) params. This is acceptable because the commit effect fires
-  // synchronously in the same React commit phase, keeping the window
-  // vanishingly small.
+  // before hooks observe the new URL state, keeping the window vanishingly small.
   latestClientParams = params;
   replaceClientParamsWithoutNotify(params);
 }

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -26,12 +26,12 @@ import {
   commitClientNavigationState,
   consumePrefetchResponse,
   createClientNavigationRenderSnapshot,
+  getCurrentNextUrl,
   getCurrentInterceptionContext,
   getClientNavigationRenderContext,
   getPrefetchCache,
   getPrefetchedUrls,
   pushHistoryStateWithoutNotify,
-  readHistoryStateInterceptionContext,
   replaceClientParamsWithoutNotify,
   replaceHistoryStateWithoutNotify,
   restoreRscResponse,
@@ -40,7 +40,6 @@ import {
   setMountedSlotsHeader,
   setNavigationContext,
   toRscUrl,
-  VINEXT_INTERCEPTION_CONTEXT_HISTORY_STATE_KEY,
   type CachedRscResponse,
   type ClientNavigationRenderSnapshot,
 } from "../shims/navigation.js";
@@ -60,8 +59,11 @@ import {
   type AppWireElements,
 } from "./app-elements.js";
 import {
+  createHistoryStateWithPreviousNextUrl,
   createPendingNavigationCommit,
+  readHistoryStatePreviousNextUrl,
   resolveAndClassifyNavigationCommit,
+  resolveInterceptionContextFromPreviousNextUrl,
   resolvePendingNavigationCommitDisposition,
   routerReducer,
   type AppRouterAction,
@@ -98,9 +100,6 @@ type VisitedResponseCacheEntry = {
 const MAX_VISITED_RESPONSE_CACHE_SIZE = 50;
 const VISITED_RESPONSE_CACHE_TTL = 5 * 60_000;
 const MAX_TRAVERSAL_CACHE_TTL = 30 * 60_000;
-type HistoryStateRecord = {
-  [key: string]: unknown;
-};
 
 // These are plain module-level variables, unlike ClientNavigationState in
 // navigation.ts which uses Symbol.for to survive multiple Vite module instances.
@@ -208,15 +207,15 @@ function createNavigationCommitEffect(
   href: string,
   historyUpdateMode: HistoryUpdateMode | undefined,
   params: Record<string, string | string[]>,
-  interceptionContext: string | null,
+  previousNextUrl: string | null,
 ): () => void {
   return () => {
     const targetHref = new URL(href, window.location.origin).href;
     stageClientParams(params);
     const preserveExistingState = historyUpdateMode === "replace";
-    const historyState = createHistoryStateWithInterceptionContext(
+    const historyState = createHistoryStateWithPreviousNextUrl(
       preserveExistingState ? window.history.state : null,
-      interceptionContext,
+      previousNextUrl,
     );
 
     if (historyUpdateMode === "replace" && window.location.href !== targetHref) {
@@ -300,41 +299,49 @@ function storeVisitedResponseSnapshot(
   });
 }
 
-function cloneHistoryState(state: unknown): HistoryStateRecord {
-  if (!state || typeof state !== "object") {
-    return {};
+type NavigationRequestState = {
+  interceptionContext: string | null;
+  previousNextUrl: string | null;
+};
+
+function getRequestState(
+  navigationKind: NavigationKind,
+  previousNextUrlOverride?: string | null,
+): NavigationRequestState {
+  if (previousNextUrlOverride !== undefined) {
+    return {
+      interceptionContext: resolveInterceptionContextFromPreviousNextUrl(
+        previousNextUrlOverride,
+        __basePath,
+      ),
+      previousNextUrl: previousNextUrlOverride,
+    };
   }
 
-  const nextState: HistoryStateRecord = {};
-  for (const [key, value] of Object.entries(state)) {
-    nextState[key] = value;
-  }
-  return nextState;
-}
-
-function createHistoryStateWithInterceptionContext(
-  state: unknown,
-  interceptionContext: string | null,
-): HistoryStateRecord | null {
-  const nextState = cloneHistoryState(state);
-
-  if (interceptionContext === null) {
-    delete nextState[VINEXT_INTERCEPTION_CONTEXT_HISTORY_STATE_KEY];
-  } else {
-    nextState[VINEXT_INTERCEPTION_CONTEXT_HISTORY_STATE_KEY] = interceptionContext;
-  }
-
-  return Object.keys(nextState).length > 0 ? nextState : null;
-}
-
-function getRequestInterceptionContext(navigationKind: NavigationKind): string | null {
   switch (navigationKind) {
     case "navigate":
-      return getCurrentInterceptionContext();
-    case "traverse":
-      return readHistoryStateInterceptionContext(window.history.state);
+      return {
+        interceptionContext: getCurrentInterceptionContext(),
+        previousNextUrl: getCurrentNextUrl(),
+      };
+    case "traverse": {
+      const previousNextUrl = readHistoryStatePreviousNextUrl(window.history.state);
+      return {
+        interceptionContext: resolveInterceptionContextFromPreviousNextUrl(
+          previousNextUrl,
+          __basePath,
+        ),
+        previousNextUrl,
+      };
+    }
     case "refresh":
-      return null;
+      return {
+        interceptionContext: resolveInterceptionContextFromPreviousNextUrl(
+          getBrowserRouterState().previousNextUrl,
+          __basePath,
+        ),
+        previousNextUrl: getBrowserRouterState().previousNextUrl,
+      };
     default: {
       const _exhaustive: never = navigationKind;
       throw new Error("[vinext] Unknown navigation kind: " + String(_exhaustive));
@@ -434,6 +441,7 @@ async function commitSameUrlNavigatePayload(
       pending.action.renderId,
       "navigate",
       pending.interceptionContext,
+      pending.previousNextUrl,
       pending.routeId,
       pending.rootLayoutTreePath,
       false,
@@ -467,6 +475,7 @@ function BrowserRoot({
     elements: resolvedElements,
     interceptionContext: initialMetadata.interceptionContext,
     navigationSnapshot: initialNavigationSnapshot,
+    previousNextUrl: null,
     renderId: 0,
     rootLayoutTreePath: initialMetadata.rootLayoutTreePath,
     routeId: initialMetadata.routeId,
@@ -510,14 +519,11 @@ function BrowserRoot({
     }
 
     replaceHistoryStateWithoutNotify(
-      createHistoryStateWithInterceptionContext(
-        window.history.state,
-        treeState.interceptionContext,
-      ),
+      createHistoryStateWithPreviousNextUrl(window.history.state, treeState.previousNextUrl),
       "",
       window.location.href,
     );
-  }, [treeState.interceptionContext, treeState.renderId]);
+  }, [treeState.previousNextUrl, treeState.renderId]);
 
   const committedTree = createElement(
     NavigationCommitSignal,
@@ -547,6 +553,7 @@ function dispatchBrowserTree(
   renderId: number,
   actionType: "navigate" | "replace" | "traverse",
   interceptionContext: string | null,
+  previousNextUrl: string | null,
   routeId: string,
   rootLayoutTreePath: string | null,
   useTransitionMode: boolean,
@@ -558,6 +565,7 @@ function dispatchBrowserTree(
       elements,
       interceptionContext,
       navigationSnapshot,
+      previousNextUrl,
       renderId,
       rootLayoutTreePath,
       routeId,
@@ -578,6 +586,7 @@ async function renderNavigationPayload(
   navId: number,
   historyUpdateMode: HistoryUpdateMode | undefined,
   params: Record<string, string | string[]>,
+  previousNextUrl: string | null,
   useTransition = true,
   actionType: "navigate" | "replace" | "traverse" = "navigate",
 ): Promise<void> {
@@ -593,6 +602,7 @@ async function renderNavigationPayload(
       currentState,
       nextElements: payload,
       navigationSnapshot,
+      previousNextUrl,
       renderId,
       type: actionType,
     });
@@ -619,12 +629,7 @@ async function renderNavigationPayload(
 
     queuePrePaintNavigationEffect(
       renderId,
-      createNavigationCommitEffect(
-        targetHref,
-        historyUpdateMode,
-        params,
-        pending.interceptionContext,
-      ),
+      createNavigationCommitEffect(targetHref, historyUpdateMode, params, pending.previousNextUrl),
     );
     activateNavigationSnapshot();
     snapshotActivated = true;
@@ -634,6 +639,7 @@ async function renderNavigationPayload(
       renderId,
       actionType,
       pending.interceptionContext,
+      pending.previousNextUrl,
       pending.routeId,
       pending.rootLayoutTreePath,
       useTransition,
@@ -813,6 +819,11 @@ async function main(): Promise<void> {
     window.location.href,
     latestClientParams,
   );
+  replaceHistoryStateWithoutNotify(
+    createHistoryStateWithPreviousNextUrl(window.history.state, null),
+    "",
+    window.location.href,
+  );
 
   window.__VINEXT_RSC_ROOT__ = hydrateRoot(
     document,
@@ -829,6 +840,7 @@ async function main(): Promise<void> {
     redirectDepth = 0,
     navigationKind: NavigationKind = "navigate",
     historyUpdateMode?: HistoryUpdateMode,
+    previousNextUrlOverride?: string | null,
   ): Promise<void> {
     if (redirectDepth > 10) {
       console.error(
@@ -845,7 +857,9 @@ async function main(): Promise<void> {
     try {
       const url = new URL(href, window.location.origin);
       const rscUrl = toRscUrl(url.pathname + url.search);
-      const requestInterceptionContext = getRequestInterceptionContext(navigationKind);
+      const requestState = getRequestState(navigationKind, previousNextUrlOverride);
+      const requestInterceptionContext = requestState.interceptionContext;
+      const requestPreviousNextUrl = requestState.previousNextUrl;
       // Use startTransition for same-route navigations (searchParam changes)
       // so React keeps the old UI visible during the transition. For cross-route
       // navigations (different pathname), use synchronous updates — React's
@@ -895,6 +909,7 @@ async function main(): Promise<void> {
             navId,
             historyUpdateMode,
             cachedParams,
+            requestPreviousNextUrl,
             isSameRoute,
             toActionType(navigationKind),
           );
@@ -942,7 +957,7 @@ async function main(): Promise<void> {
       if (finalUrl.pathname !== requestedUrl.pathname) {
         const destinationPath = finalUrl.pathname.replace(/\.rsc$/, "") + finalUrl.search;
         replaceHistoryStateWithoutNotify(
-          createHistoryStateWithInterceptionContext(null, requestInterceptionContext),
+          createHistoryStateWithPreviousNextUrl(null, requestPreviousNextUrl),
           "",
           destinationPath,
         );
@@ -956,7 +971,13 @@ async function main(): Promise<void> {
         // The URL has already been updated via replaceHistoryStateWithoutNotify above,
         // so the recursive navigation should NOT push/replace again. Pass undefined
         // for historyUpdateMode to make the commit effect a no-op for history updates.
-        return navigate(destinationPath, redirectDepth + 1, navigationKind, undefined);
+        return navigate(
+          destinationPath,
+          redirectDepth + 1,
+          navigationKind,
+          undefined,
+          requestPreviousNextUrl,
+        );
       }
 
       let navParams: Record<string, string | string[]> = {};
@@ -993,6 +1014,7 @@ async function main(): Promise<void> {
           navId,
           historyUpdateMode,
           navParams,
+          requestPreviousNextUrl,
           isSameRoute,
           toActionType(navigationKind),
         );
@@ -1088,6 +1110,7 @@ async function main(): Promise<void> {
           pending.action.renderId,
           "replace",
           pending.interceptionContext,
+          pending.previousNextUrl,
           pending.routeId,
           pending.rootLayoutTreePath,
           false,

--- a/packages/vinext/src/server/app-browser-state.ts
+++ b/packages/vinext/src/server/app-browser-state.ts
@@ -159,7 +159,10 @@ export async function createPendingNavigationCommit(options: {
 }): Promise<PendingNavigationCommit> {
   const elements = await options.nextElements;
   const metadata = readAppElementsMetadata(elements);
-  const previousNextUrl = options.previousNextUrl ?? options.currentState.previousNextUrl;
+  const previousNextUrl =
+    options.previousNextUrl !== undefined
+      ? options.previousNextUrl
+      : options.currentState.previousNextUrl;
 
   return {
     action: {

--- a/packages/vinext/src/server/app-browser-state.ts
+++ b/packages/vinext/src/server/app-browser-state.ts
@@ -1,10 +1,18 @@
 import { mergeElements } from "../shims/slot.js";
+import { stripBasePath } from "../utils/base-path.js";
 import { readAppElementsMetadata, type AppElements } from "./app-elements.js";
 import type { ClientNavigationRenderSnapshot } from "../shims/navigation.js";
+
+const VINEXT_PREVIOUS_NEXT_URL_HISTORY_STATE_KEY = "__vinext_previousNextUrl";
+
+type HistoryStateRecord = {
+  [key: string]: unknown;
+};
 
 export type AppRouterState = {
   elements: AppElements;
   interceptionContext: string | null;
+  previousNextUrl: string | null;
   renderId: number;
   navigationSnapshot: ClientNavigationRenderSnapshot;
   rootLayoutTreePath: string | null;
@@ -15,6 +23,7 @@ export type AppRouterAction = {
   elements: AppElements;
   interceptionContext: string | null;
   navigationSnapshot: ClientNavigationRenderSnapshot;
+  previousNextUrl: string | null;
   renderId: number;
   rootLayoutTreePath: string | null;
   routeId: string;
@@ -24,6 +33,7 @@ export type AppRouterAction = {
 export type PendingNavigationCommit = {
   action: AppRouterAction;
   interceptionContext: string | null;
+  previousNextUrl: string | null;
   rootLayoutTreePath: string | null;
   routeId: string;
 };
@@ -34,6 +44,50 @@ export type ClassifiedPendingNavigationCommit = {
   pending: PendingNavigationCommit;
 };
 
+function cloneHistoryState(state: unknown): HistoryStateRecord {
+  if (!state || typeof state !== "object") {
+    return {};
+  }
+
+  const nextState: HistoryStateRecord = {};
+  for (const [key, value] of Object.entries(state)) {
+    nextState[key] = value;
+  }
+  return nextState;
+}
+
+export function createHistoryStateWithPreviousNextUrl(
+  state: unknown,
+  previousNextUrl: string | null,
+): HistoryStateRecord | null {
+  const nextState = cloneHistoryState(state);
+
+  if (previousNextUrl === null) {
+    delete nextState[VINEXT_PREVIOUS_NEXT_URL_HISTORY_STATE_KEY];
+  } else {
+    nextState[VINEXT_PREVIOUS_NEXT_URL_HISTORY_STATE_KEY] = previousNextUrl;
+  }
+
+  return Object.keys(nextState).length > 0 ? nextState : null;
+}
+
+export function readHistoryStatePreviousNextUrl(state: unknown): string | null {
+  const value = cloneHistoryState(state)[VINEXT_PREVIOUS_NEXT_URL_HISTORY_STATE_KEY];
+  return typeof value === "string" ? value : null;
+}
+
+export function resolveInterceptionContextFromPreviousNextUrl(
+  previousNextUrl: string | null,
+  basePath: string = "",
+): string | null {
+  if (previousNextUrl === null) {
+    return null;
+  }
+
+  const parsedUrl = new URL(previousNextUrl, "http://localhost");
+  return stripBasePath(parsedUrl.pathname, basePath);
+}
+
 export function routerReducer(state: AppRouterState, action: AppRouterAction): AppRouterState {
   switch (action.type) {
     case "traverse":
@@ -42,6 +96,7 @@ export function routerReducer(state: AppRouterState, action: AppRouterAction): A
         elements: mergeElements(state.elements, action.elements, action.type === "traverse"),
         interceptionContext: action.interceptionContext,
         navigationSnapshot: action.navigationSnapshot,
+        previousNextUrl: action.previousNextUrl,
         renderId: action.renderId,
         rootLayoutTreePath: action.rootLayoutTreePath,
         routeId: action.routeId,
@@ -51,6 +106,7 @@ export function routerReducer(state: AppRouterState, action: AppRouterAction): A
         elements: action.elements,
         interceptionContext: action.interceptionContext,
         navigationSnapshot: action.navigationSnapshot,
+        previousNextUrl: action.previousNextUrl,
         renderId: action.renderId,
         rootLayoutTreePath: action.rootLayoutTreePath,
         routeId: action.routeId,
@@ -97,17 +153,20 @@ export async function createPendingNavigationCommit(options: {
   currentState: AppRouterState;
   nextElements: Promise<AppElements>;
   navigationSnapshot: ClientNavigationRenderSnapshot;
+  previousNextUrl?: string | null;
   renderId: number;
   type: "navigate" | "replace" | "traverse";
 }): Promise<PendingNavigationCommit> {
   const elements = await options.nextElements;
   const metadata = readAppElementsMetadata(elements);
+  const previousNextUrl = options.previousNextUrl ?? options.currentState.previousNextUrl;
 
   return {
     action: {
       elements,
       interceptionContext: metadata.interceptionContext,
       navigationSnapshot: options.navigationSnapshot,
+      previousNextUrl,
       renderId: options.renderId,
       rootLayoutTreePath: metadata.rootLayoutTreePath,
       routeId: metadata.routeId,
@@ -115,6 +174,7 @@ export async function createPendingNavigationCommit(options: {
     },
     // Convenience aliases — always equal action.interceptionContext / action.rootLayoutTreePath / action.routeId.
     interceptionContext: metadata.interceptionContext,
+    previousNextUrl,
     rootLayoutTreePath: metadata.rootLayoutTreePath,
     routeId: metadata.routeId,
   };
@@ -125,6 +185,7 @@ export async function resolveAndClassifyNavigationCommit(options: {
   currentState: AppRouterState;
   navigationSnapshot: ClientNavigationRenderSnapshot;
   nextElements: Promise<AppElements>;
+  previousNextUrl?: string | null;
   renderId: number;
   startedNavigationId: number;
   type: "navigate" | "replace" | "traverse";
@@ -133,6 +194,7 @@ export async function resolveAndClassifyNavigationCommit(options: {
     currentState: options.currentState,
     nextElements: options.nextElements,
     navigationSnapshot: options.navigationSnapshot,
+    previousNextUrl: options.previousNextUrl,
     renderId: options.renderId,
     type: options.type,
   });

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -297,6 +297,14 @@ export function getCurrentInterceptionContext(): string | null {
   );
 }
 
+export function getCurrentNextUrl(): string {
+  if (isServer) {
+    return "/";
+  }
+
+  return window.location.pathname + window.location.search;
+}
+
 /** Get or create the shared in-memory RSC prefetch cache on window. */
 export function getPrefetchCache(): Map<string, PrefetchCacheEntry> {
   if (isServer) return new Map();

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -244,8 +244,6 @@ export const MAX_PREFETCH_CACHE_SIZE = 50;
 /** TTL for prefetch cache entries in ms (matches Next.js static prefetch TTL). */
 export const PREFETCH_CACHE_TTL = 30_000;
 
-export const VINEXT_INTERCEPTION_CONTEXT_HISTORY_STATE_KEY = "__vinext_interceptionContext";
-
 /** A buffered RSC response stored as an ArrayBuffer for replay. */
 export type CachedRscResponse = {
   buffer: ArrayBuffer;
@@ -277,24 +275,12 @@ export function toRscUrl(href: string): string {
   return normalizedPath + ".rsc" + query;
 }
 
-export function readHistoryStateInterceptionContext(state: unknown): string | null {
-  if (!state || typeof state !== "object") {
-    return null;
-  }
-
-  const value = Reflect.get(state, VINEXT_INTERCEPTION_CONTEXT_HISTORY_STATE_KEY);
-  return typeof value === "string" ? value : null;
-}
-
 export function getCurrentInterceptionContext(): string | null {
   if (isServer) {
     return null;
   }
 
-  return (
-    readHistoryStateInterceptionContext(window.history.state) ??
-    stripBasePath(window.location.pathname, __basePath)
-  );
+  return stripBasePath(window.location.pathname, __basePath);
 }
 
 export function getCurrentNextUrl(): string {

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -140,6 +140,30 @@ describe("app browser entry state helpers", () => {
     expect(pending.action.previousNextUrl).toBe("/feed");
   });
 
+  it("clears previousNextUrl when traversing to a non-intercepted entry", async () => {
+    // Traversing back from an intercepted modal (/photos/42 from /feed) to
+    // /feed itself. The traverse branch reads null from /feed's history state
+    // and passes previousNextUrl: null explicitly — meaning "not intercepted".
+    // This must not inherit the current state's stale "/feed" value.
+    const interceptedState = createState({
+      interceptionContext: "/feed",
+      previousNextUrl: "/feed",
+      routeId: "route:/photos/42\0/feed",
+    });
+
+    const pending = await createPendingNavigationCommit({
+      currentState: interceptedState,
+      nextElements: Promise.resolve(createResolvedElements("route:/feed", "/")),
+      navigationSnapshot: createState().navigationSnapshot,
+      previousNextUrl: null,
+      renderId: 2,
+      type: "traverse",
+    });
+
+    expect(pending.previousNextUrl).toBeNull();
+    expect(pending.action.previousNextUrl).toBeNull();
+  });
+
   it("hard navigates instead of merging when the root layout changes", async () => {
     const currentState = createState({
       rootLayoutTreePath: "/(marketing)",

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -12,8 +12,11 @@ import {
 } from "../packages/vinext/src/server/app-elements.js";
 import { createClientNavigationRenderSnapshot } from "../packages/vinext/src/shims/navigation.js";
 import {
+  createHistoryStateWithPreviousNextUrl,
   createPendingNavigationCommit,
+  readHistoryStatePreviousNextUrl,
   resolveAndClassifyNavigationCommit,
+  resolveInterceptionContextFromPreviousNextUrl,
   routerReducer,
   resolvePendingNavigationCommitDisposition,
   shouldHardNavigate,
@@ -40,6 +43,7 @@ function createState(overrides: Partial<AppRouterState> = {}): AppRouterState {
     navigationSnapshot: createClientNavigationRenderSnapshot("https://example.com/initial", {}),
     renderId: 0,
     interceptionContext: null,
+    previousNextUrl: null,
     rootLayoutTreePath: "/",
     routeId: "route:/initial",
     ...overrides,
@@ -73,6 +77,7 @@ describe("app browser entry state helpers", () => {
         elements: nextElements,
         interceptionContext: null,
         navigationSnapshot: createState().navigationSnapshot,
+        previousNextUrl: null,
         renderId: 1,
         rootLayoutTreePath: "/",
         routeId: "route:/next",
@@ -82,6 +87,7 @@ describe("app browser entry state helpers", () => {
 
     expect(nextState.routeId).toBe("route:/next");
     expect(nextState.interceptionContext).toBeNull();
+    expect(nextState.previousNextUrl).toBeNull();
     expect(nextState.rootLayoutTreePath).toBe("/");
     expect(nextState.elements).toMatchObject({
       "layout:/": expect.anything(),
@@ -98,6 +104,7 @@ describe("app browser entry state helpers", () => {
       elements: nextElements,
       interceptionContext: null,
       navigationSnapshot: createState().navigationSnapshot,
+      previousNextUrl: null,
       renderId: 1,
       rootLayoutTreePath: "/",
       routeId: "route:/next",
@@ -106,6 +113,7 @@ describe("app browser entry state helpers", () => {
 
     expect(nextState.elements).toBe(nextElements);
     expect(nextState.interceptionContext).toBeNull();
+    expect(nextState.previousNextUrl).toBeNull();
     expect(nextState.elements).toMatchObject({
       "page:/next": expect.anything(),
     });
@@ -120,13 +128,16 @@ describe("app browser entry state helpers", () => {
         }),
       ),
       navigationSnapshot: createState().navigationSnapshot,
+      previousNextUrl: "/feed",
       renderId: 1,
       type: "navigate",
     });
 
     expect(pending.routeId).toBe("route:/photos/42\0/feed");
     expect(pending.interceptionContext).toBe("/feed");
+    expect(pending.previousNextUrl).toBe("/feed");
     expect(pending.action.interceptionContext).toBe("/feed");
+    expect(pending.action.previousNextUrl).toBe("/feed");
   });
 
   it("hard navigates instead of merging when the root layout changes", async () => {
@@ -213,6 +224,7 @@ describe("app browser entry state helpers", () => {
       currentState: createState(),
       nextElements: Promise.resolve(createResolvedElements("route:/dashboard", "/")),
       navigationSnapshot: createState().navigationSnapshot,
+      previousNextUrl: "/feed",
       renderId: 1,
       type: "navigate",
     });
@@ -220,6 +232,70 @@ describe("app browser entry state helpers", () => {
     expect(refreshCommit.action.type).toBe("navigate");
     expect(refreshCommit.routeId).toBe("route:/dashboard");
     expect(refreshCommit.rootLayoutTreePath).toBe("/");
+    expect(refreshCommit.previousNextUrl).toBe("/feed");
+  });
+
+  it("stores previousNextUrl on navigate actions", () => {
+    const nextState = routerReducer(createState(), {
+      elements: createResolvedElements("route:/photos/42\0/feed", "/", "/feed"),
+      interceptionContext: "/feed",
+      navigationSnapshot: createState().navigationSnapshot,
+      previousNextUrl: "/feed",
+      renderId: 1,
+      rootLayoutTreePath: "/",
+      routeId: "route:/photos/42\0/feed",
+      type: "navigate",
+    });
+
+    expect(nextState.interceptionContext).toBe("/feed");
+    expect(nextState.previousNextUrl).toBe("/feed");
+  });
+});
+
+describe("app browser entry previousNextUrl helpers", () => {
+  it("stores previousNextUrl alongside existing history state", () => {
+    expect(
+      createHistoryStateWithPreviousNextUrl(
+        {
+          __vinext_scrollY: 120,
+        },
+        "/feed?tab=latest",
+      ),
+    ).toEqual({
+      __vinext_previousNextUrl: "/feed?tab=latest",
+      __vinext_scrollY: 120,
+    });
+  });
+
+  it("drops previousNextUrl when cleared", () => {
+    expect(
+      createHistoryStateWithPreviousNextUrl(
+        {
+          __vinext_previousNextUrl: "/feed",
+          __vinext_scrollY: 120,
+        },
+        null,
+      ),
+    ).toEqual({
+      __vinext_scrollY: 120,
+    });
+  });
+
+  it("reads previousNextUrl from history state", () => {
+    expect(
+      readHistoryStatePreviousNextUrl({
+        __vinext_previousNextUrl: "/feed?tab=latest",
+      }),
+    ).toBe("/feed?tab=latest");
+  });
+
+  it("derives interception context from previousNextUrl pathname", () => {
+    expect(resolveInterceptionContextFromPreviousNextUrl("/feed?tab=latest")).toBe("/feed");
+  });
+
+  it("returns null when previousNextUrl is missing", () => {
+    expect(readHistoryStatePreviousNextUrl({})).toBeNull();
+    expect(resolveInterceptionContextFromPreviousNextUrl(null)).toBeNull();
   });
 
   it("classifies pending commits in one step for same-url payloads", async () => {
@@ -260,6 +336,7 @@ describe("app browser entry state helpers", () => {
       elements: nextElements,
       interceptionContext: null,
       navigationSnapshot: createState().navigationSnapshot,
+      previousNextUrl: null,
       renderId: 1,
       rootLayoutTreePath: "/",
       routeId: "route:/feed",
@@ -281,6 +358,7 @@ describe("app browser entry state helpers", () => {
       elements: nextElements,
       interceptionContext: null,
       navigationSnapshot: createState().navigationSnapshot,
+      previousNextUrl: null,
       renderId: 1,
       rootLayoutTreePath: "/",
       routeId: "route:/feed/comments",

--- a/tests/e2e/app-router/advanced.spec.ts
+++ b/tests/e2e/app-router/advanced.spec.ts
@@ -120,6 +120,36 @@ test.describe("Intercepting Routes", () => {
     await expect(page.locator('[data-testid="photo-modal"]')).not.toBeVisible();
   });
 
+  test("hard reload after intercepted navigation renders the full page", async ({ page }) => {
+    await page.goto(`${BASE}/feed`);
+    await waitForAppRouterHydration(page);
+
+    await page.click("#feed-photo-42-link");
+    await expect(page.locator('[data-testid="photo-modal"]')).toBeVisible();
+    await expect(page.locator('[data-testid="feed-page"]')).toBeVisible();
+
+    await page.reload();
+    await waitForAppRouterHydration(page);
+
+    await expect(page.locator('[data-testid="photo-page"]')).toBeVisible();
+    await expect(page.locator('[data-testid="photo-modal"]')).not.toBeVisible();
+    await expect(page.locator('[data-testid="feed-page"]')).not.toBeVisible();
+  });
+
+  test("router.refresh preserves intercepted modal view", async ({ page }) => {
+    await page.goto(`${BASE}/feed`);
+    await waitForAppRouterHydration(page);
+
+    await page.click("#feed-photo-42-link");
+    await expect(page.locator('[data-testid="photo-modal"]')).toBeVisible();
+
+    await page.click('[data-testid="photo-modal-refresh"]');
+
+    await expect(page.locator('[data-testid="photo-modal"]')).toBeVisible();
+    await expect(page.locator('[data-testid="feed-page"]')).toBeVisible();
+    await expect(page.locator('[data-testid="photo-page"]')).not.toBeVisible();
+  });
+
   test("prefetches keep separate cache entries for feed and gallery interception contexts", async ({
     page,
   }) => {

--- a/tests/e2e/app-router/advanced.spec.ts
+++ b/tests/e2e/app-router/advanced.spec.ts
@@ -150,6 +150,24 @@ test.describe("Intercepting Routes", () => {
     await expect(page.locator('[data-testid="photo-page"]')).not.toBeVisible();
   });
 
+  test("back then forward restores intercepted modal view", async ({ page }) => {
+    await page.goto(`${BASE}/feed`);
+    await waitForAppRouterHydration(page);
+
+    await page.click("#feed-photo-42-link");
+    await expect(page.locator('[data-testid="photo-modal"]')).toBeVisible();
+    await expect(page.locator('[data-testid="feed-page"]')).toBeVisible();
+
+    await page.goBack();
+    await expect(page.locator('[data-testid="photo-modal"]')).not.toBeVisible();
+    await expect(page.locator('[data-testid="feed-page"]')).toBeVisible();
+
+    await page.goForward();
+    await expect(page.locator('[data-testid="photo-modal"]')).toBeVisible();
+    await expect(page.locator('[data-testid="feed-page"]')).toBeVisible();
+    await expect(page.locator('[data-testid="photo-page"]')).not.toBeVisible();
+  });
+
   test("prefetches keep separate cache entries for feed and gallery interception contexts", async ({
     page,
   }) => {

--- a/tests/fixtures/app-basic/app/feed/@modal/(...)photos/[id]/page.tsx
+++ b/tests/fixtures/app-basic/app/feed/@modal/(...)photos/[id]/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { PhotoModalRefreshButton } from "./refresh-button";
 
 // Intercepting route: renders when navigating from /feed to /photos/[id].
 // Shows a modal version of the photo instead of the full page.
@@ -10,6 +11,7 @@ export default function PhotoModal({ params }: { params: { id: string } }) {
       <Link href="/photos/43" id="modal-photo-43-link">
         Next Photo
       </Link>
+      <PhotoModalRefreshButton />
     </div>
   );
 }

--- a/tests/fixtures/app-basic/app/feed/@modal/(...)photos/[id]/refresh-button.tsx
+++ b/tests/fixtures/app-basic/app/feed/@modal/(...)photos/[id]/refresh-button.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+export function PhotoModalRefreshButton() {
+  const router = useRouter();
+
+  return (
+    <button data-testid="photo-modal-refresh" onClick={() => router.refresh()}>
+      Refresh modal
+    </button>
+  );
+}

--- a/tests/prefetch-cache.test.ts
+++ b/tests/prefetch-cache.test.ts
@@ -115,11 +115,8 @@ describe("prefetch cache eviction", () => {
     expect(prefetched.has(rscUrl)).toBe(false);
   });
 
-  it("reuses the committed interception context for soft navigations", () => {
-    (globalThis as any).window.location.pathname = "/photos/42";
-    (globalThis as any).window.history.state = {
-      __vinext_interceptionContext: "/feed",
-    };
+  it("derives the interception context from the current pathname", () => {
+    (globalThis as any).window.location.pathname = "/feed";
 
     expect(getCurrentInterceptionContext()).toBe("/feed");
   });


### PR DESCRIPTION
## Summary

Part of #726 (PR 5). This builds on PR 4's interception-aware payload IDs and cache keys by tracking `previousNextUrl` in the App Router browser state. Intercepted navigations now remember the URL they came from, so refresh/back-forward behavior can distinguish soft interception from direct loads.

The practical effect is that `/feed -> /photos/42` modal navigations now behave correctly across the three important cases: browser reload breaks out to the full page, back/forward restores the intercepted modal view from history state, and `router.refresh()` keeps the intercepted modal instead of silently switching to the direct page tree.

### What changed

- **Browser router state** — `app-browser-state` now carries `previousNextUrl` alongside `elements`, `interceptionContext`, `routeId`, and `rootLayoutTreePath`, with helpers for persisting and reading it from history state
- **History state persistence** — App Router entries now store `__vinext_previousNextUrl` instead of the old interception-context field, preserving the URL active before a soft navigation while keeping the existing scroll restoration state intact
- **Navigation request context** — soft `navigate` records the current URL as `previousNextUrl`, `traverse` reconstructs interception context from `event.state`, and `refresh` reconstructs it from committed router state so refresh preserves interception without changing hard-load behavior
- **Hard-load normalization** — boot clears any carried-over `previousNextUrl` from the active history entry so full document reloads still break out of interception even though browsers preserve `history.state` across reloads
- **Redirect recursion** — redirected RSC navigations carry the original `previousNextUrl` forward so replacement navigations do not lose the source-route provenance
- **Fixtures and tests** — adds unit coverage for `previousNextUrl` state/history helpers plus E2E coverage for reload, back/forward restoration, and `router.refresh()` on intercepted routes. The modal fixture now exposes a small `router.refresh()` button to exercise the public API
- **Comment cleanup** — refreshes a few stale `app-browser-entry` comments so they match the current dispatch/control-flow names after the refactor

### What this does NOT do

Server action interception-request parity is still intentionally deferred. This PR preserves the browser-side `previousNextUrl` state during server-action merges, but it does not add interception headers to the action POST itself.

## Test plan

- [x] `vp test run tests/app-browser-entry.test.ts`
- [x] `vp test run tests/app-router.test.ts`
- [x] `vp run test:e2e tests/e2e/app-router/advanced.spec.ts --grep 'hard reload after intercepted navigation renders the full page|back then forward restores intercepted modal view|router.refresh preserves intercepted modal view'`
- [x] `git commit` pre-commit hook (`vp check --fix`)
