### PR TITLE
fix: security audit findings from issue #741

### DIFF
--- a/.github/workflows/nextjs-tracker.yml
+++ b/.github/workflows/nextjs-tracker.yml
@@ -39,8 +39,9 @@ jobs:
         id: commits
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SINCE_HOURS: ${{ github.event.inputs.since_hours || '24' }}
         run: |
-          HOURS="${{ github.event.inputs.since_hours || '24' }}"
+          HOURS="$SINCE_HOURS"
           SINCE=$(date -u -d "${HOURS} hours ago" +%Y-%m-%dT%H:%M:%SZ)
 
           echo "Fetching Next.js canary commits since $SINCE"
@@ -70,8 +71,10 @@ jobs:
       - name: Build tracker prompt
         id: build_prompt
         if: steps.commits.outputs.has_commits == 'true'
+        env:
+          DRY_RUN_INPUT: ${{ github.event.inputs.dry_run || 'false' }}
         run: |
-          DRY_RUN="${{ github.event.inputs.dry_run || 'false' }}"
+          DRY_RUN="$DRY_RUN_INPUT"
           COMMITS=$(cat /tmp/nextjs-commits.json)
 
           if [ "$DRY_RUN" = "true" ]; then
@@ -134,4 +137,6 @@ jobs:
 
       - name: Skip (no commits)
         if: steps.commits.outputs.has_commits == 'false'
-        run: echo "No Next.js canary commits in the last ${{ github.event.inputs.since_hours || '24' }} hours. Nothing to do."
+        env:
+          SINCE_HOURS: ${{ github.event.inputs.since_hours || '24' }}
+        run: echo "No Next.js canary commits in the last $SINCE_HOURS hours. Nothing to do."

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,13 +44,15 @@ jobs:
       - name: Bump version
         id: version
         working-directory: packages/vinext
+        env:
+          BUMP: ${{ inputs.bump }}
         run: |
           # vp wraps package-manager subcommands, but versioning still needs the real npm CLI
           # because we are mutating package.json in place before the publish step.
           LATEST=$(npm view vinext version 2>/dev/null || echo "0.0.0")
           IFS='.' read -r MAJOR MINOR PATCH <<< "$LATEST"
 
-          case "${{ inputs.bump }}" in
+          case "$BUMP" in
             major)
               MAJOR=$((MAJOR + 1))
               MINOR=0

--- a/examples/hackernews/components/comment.jsx
+++ b/examples/hackernews/components/comment.jsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import DOMPurify from 'dompurify';
 
 import timeAgo from '../lib/time-ago';
 
@@ -26,7 +27,7 @@ export default function Comment({ user, text, date, comments, commentsCount }) {
             <div
               key="text"
               className={styles.text}
-              dangerouslySetInnerHTML={{ __html: text }}
+              dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(text) }}
             />,
             <div key="children" className={styles.children}>
               {comments.map((comment) => (

--- a/examples/hackernews/package.json
+++ b/examples/hackernews/package.json
@@ -1,26 +1,28 @@
 {
-  "name": "vinext-hackernews",
-  "type": "module",
-  "private": true,
-  "scripts": {
-    "dev": "vp dev",
-    "build": "vp build",
-    "preview": "vp preview"
-  },
-  "dependencies": {
-    "@vitejs/plugin-react": "catalog:",
-    "ms": "catalog:",
-    "react": "catalog:",
-    "react-dom": "catalog:",
-    "server-only": "catalog:",
-    "vite": "catalog:",
-    "vinext": "workspace:*",
-    "@vitejs/plugin-rsc": "catalog:",
-    "react-server-dom-webpack": "catalog:",
-    "@cloudflare/vite-plugin": "catalog:",
-    "wrangler": "catalog:"
-  },
-  "devDependencies": {
-    "vite-plus": "catalog:"
-  }
+    "name": "vinext-hackernews",
+    "type": "module",
+    "private": true,
+    "scripts": {
+        "dev": "vp dev",
+        "build": "vp build",
+        "preview": "vp preview"
+    },
+    "dependencies": {
+        "@vitejs/plugin-react": "catalog:",
+        "dompurify": "catalog:",
+        "ms": "catalog:",
+        "react": "catalog:",
+        "react-dom": "catalog:",
+        "server-only": "catalog:",
+        "vite": "catalog:",
+        "vinext": "workspace:*",
+        "@vitejs/plugin-rsc": "catalog:",
+        "react-server-dom-webpack": "catalog:",
+        "@cloudflare/vite-plugin": "catalog:",
+        "wrangler": "catalog:"
+    },
+    "devDependencies": {
+        "@cloudflare/workers-types": "catalog:",
+        "vite-plus": "catalog:"
+    }
 }

--- a/examples/hackernews/tsconfig.json
+++ b/examples/hackernews/tsconfig.json
@@ -8,8 +8,15 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "allowJs": true,
-    "baseUrl": ".",
-    "types": ["@cloudflare/workers-types"]
+    "noEmit": true,
+    "types": [
+      "@cloudflare/workers-types"
+    ]
   },
-  "include": ["app", "components", "lib", "worker"]
+  "include": [
+    "app",
+    "components",
+    "lib",
+    "worker"
+  ]
 }

--- a/packages/vinext/src/shims/head.ts
+++ b/packages/vinext/src/shims/head.ts
@@ -272,7 +272,9 @@ export function escapeAttr(s: string): string {
  * context but prevents the HTML parser from seeing a closing tag.
  */
 export function escapeInlineContent(content: string, tag: string): string {
-  // Build a pattern like `<\/script` or `<\/style`, case-insensitive
+  // Build a pattern like `<\/script` or `<\/style`, case-insensitive.
+  // `tag` is always a literal developer-controlled value ("script" or "style")
+  // guarded by the RAW_CONTENT_TAGS.has(tag) check at all call sites — never user input.
   const pattern = new RegExp(`<\\/(${tag})`, "gi");
   return content.replace(pattern, "<\\/$1");
 }

--- a/packages/vinext/src/shims/script.tsx
+++ b/packages/vinext/src/shims/script.tsx
@@ -156,6 +156,11 @@ function Script(props: ScriptProps): React.ReactElement | null {
       }
 
       if (dangerouslySetInnerHTML?.__html) {
+        // Intentional: mirrors the Next.js <Script> API where dangerouslySetInnerHTML
+        // is developer-supplied inline script content (not user input). The prop name
+        // itself signals developer awareness of the XSS risk, consistent with React's
+        // design. User-supplied data must never flow into this prop.
+        // eslint-disable-next-line no-unsanitized/property
         el.innerHTML = dangerouslySetInnerHTML.__html as string;
       } else if (children && typeof children === "string") {
         el.textContent = children;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,9 @@ catalogs:
     date-fns:
       specifier: 4.1.0
       version: 4.1.0
+    dompurify:
+      specifier: ^3.2.6
+      version: 3.3.3
     fumadocs-core:
       specifier: 16.6.17
       version: 16.6.17
@@ -574,6 +577,9 @@ importers:
       '@vitejs/plugin-rsc':
         specifier: 'catalog:'
         version: 0.5.21(@voidzero-dev/vite-plus-core@0.1.12(@types/node@25.2.3)(esbuild@0.27.3)(jiti@2.6.1)(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+      dompurify:
+        specifier: 'catalog:'
+        version: 3.3.3
       ms:
         specifier: 'catalog:'
         version: 3.0.0-canary.1
@@ -599,6 +605,9 @@ importers:
         specifier: 'catalog:'
         version: 4.66.0(@cloudflare/workers-types@4.20260313.1)
     devDependencies:
+      '@cloudflare/workers-types':
+        specifier: 'catalog:'
+        version: 4.20260313.1
       vite-plus:
         specifier: 'catalog:'
         version: 0.1.12(@types/node@25.2.3)(@voidzero-dev/vite-plus-core@0.1.12(@types/node@25.2.3)(esbuild@0.27.3)(jiti@2.6.1)(typescript@5.9.3))(esbuild@0.27.3)(jiti@2.6.1)(typescript@5.9.3)
@@ -3122,6 +3131,9 @@ packages:
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
@@ -3642,6 +3654,9 @@ packages:
   diff@5.2.2:
     resolution: {integrity: sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==}
     engines: {node: '>=0.3.1'}
+
+  dompurify@3.3.3:
+    resolution: {integrity: sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==}
 
   emoji-regex-xs@2.0.1:
     resolution: {integrity: sha512-1QFuh8l7LqUcKe24LsPUNzjrzJQ7pgRwp1QMcZ5MX6mFplk2zQ08NVCM84++1cveaUUYtcCYHmeFEuNg16sU4g==}
@@ -6829,6 +6844,9 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
@@ -7205,6 +7223,10 @@ snapshots:
       dequal: 2.0.3
 
   diff@5.2.2: {}
+
+  dompurify@3.3.3:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   emoji-regex-xs@2.0.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -41,6 +41,8 @@ catalog:
   clsx: ^2.1.1
   codehike: 1.0.7
   date-fns: 4.1.0
+  dompurify: ^3.2.6
+  "@types/dompurify": ^3.0.5
   fumadocs-core: 16.6.17
   fumadocs-mdx: 14.2.10
   fumadocs-ui: 16.6.17

--- a/tests/vite-hmr-websocket.test.ts
+++ b/tests/vite-hmr-websocket.test.ts
@@ -29,7 +29,7 @@ function readUpgradeResponse(
         "Connection: Upgrade",
         "Upgrade: websocket",
         "Sec-WebSocket-Version: 13",
-        "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==",
+        "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==", // gitleaks:allow — RFC 6455 example nonce ("the sample nonce"), not a real credential
         "Sec-WebSocket-Protocol: vite-hmr",
       ];
       if (origin) lines.push(`Origin: ${origin}`);


### PR DESCRIPTION
Closes #741

Addresses all findings from the static security scan. Each change is described below with the reasoning and any assumptions made.

---

## 🔴 Critical: gitleaks false positive in test file

**File:** `tests/vite-hmr-websocket.test.ts:32`

**Change:** Added `// gitleaks:allow` inline comment.

**Reasoning:** The value `dGhlIHNhbXBsZSBub25jZQ==` is the RFC 6455 example WebSocket handshake nonce ("the sample nonce"), hardcoded in the WebSocket spec itself. It is not a credential. The `gitleaks:allow` directive suppresses the scanner without altering test behavior.

**Assumption:** This is a well-known public value from the spec, not a real secret. No rotation needed.

---

## 🟠 High: GitHub Actions shell injection (4 locations)

**Files:** `.github/workflows/publish.yml:47`, `.github/workflows/nextjs-tracker.yml:42,73,137`

**Change:** Moved `${{ github.event.inputs.* }}` context expressions out of `run:` shell scripts and into `env:` blocks, then referenced them as shell variables (`$VAR`).

**Reasoning:** GitHub Actions expressions interpolated directly into `run:` steps are evaluated before the shell sees the script, meaning a malicious input value (e.g. a crafted `since_hours` like `24; curl attacker.com`) can inject arbitrary shell commands. Moving values into `env:` passes them as environment variables, which the shell treats as data — not code.

**Assumption:** All four inputs are `workflow_dispatch` inputs, so they require a GitHub account with write access to trigger. The risk is lower than for `pull_request` event data, but the fix is cheap and correct practice regardless. The `inputs.bump` value is also constrained to a `choice` type (`patch`/`minor`/`major`), so it had minimal practical exploitability, but the fix is still the right pattern.

---

## 🟠 High: `innerHTML` in script shim

**File:** `packages/vinext/src/shims/script.tsx:159`

**Change:** Added a security comment; no behavior change.

**Reasoning:** The `el.innerHTML = dangerouslySetInnerHTML.__html` path replicates the Next.js `<Script>` API exactly. The prop name `dangerouslySetInnerHTML` is React's own convention for signalling developer awareness of the XSS risk. This path is only reached when the developer explicitly passes that prop — it is never populated from user input by the framework. Changing the behavior would break compatibility with Next.js.

**Assumption:** User-supplied data never flows into `dangerouslySetInnerHTML.__html` on the `<Script>` component. This is the developer's responsibility, consistent with how React itself handles the same prop on all elements.

---

## 🟡 Medium: `dangerouslySetInnerHTML` in hackernews example

**File:** `examples/hackernews/components/comment.jsx:29`

**Change:** Wrapped the HN API `text` value in `DOMPurify.sanitize()` before passing to `dangerouslySetInnerHTML`. Added `dompurify` to `package.json` and to the workspace catalog.

**Reasoning:** The HN API returns comment text as HTML (links, italics, etc.). The original code rendered it raw. Although HN is generally trusted, rendering unsanitized third-party HTML is a stored XSS vector — a compromised or malicious HN post could inject scripts into pages served by this example. DOMPurify strips dangerous tags and attributes while preserving the safe formatting HTML the API returns.

**Assumption:** DOMPurify's default config (strip `<script>`, `javascript:` hrefs, event handlers, etc.) is appropriate here. The HN API only uses basic formatting tags so no content is lost in practice.

---

## 🟡 Medium: non-literal RegExp (6 locations)

**Files:** `shims/head.ts`, `shims/image-config.ts`, `config/config-matchers.ts` (×2), `routing/file-matcher.ts` (×2)

**Change:** Added a clarifying comment to `escapeInlineContent` in `head.ts`; no behavior changes elsewhere.

**Reasoning:** All six `new RegExp(variable)` usages were reviewed:

- `head.ts:276` — `tag` is always `"script"` or `"style"`, guarded by `RAW_CONTENT_TAGS.has(tag)` at every call site.
- `image-config.ts:58` — builds a pattern from developer-supplied `remotePatterns` config, not request-time user input.
- `config-matchers.ts:341,974` — both are already guarded by `safeRegExp()`, which runs `isSafeRegex()` to reject ReDoS-vulnerable patterns before compiling.
- `file-matcher.ts:51,54` — built from `pageExtensions` config values, escaped with `escapeRegex()` before interpolation.

No user-controlled input reaches any of these paths at request time.

---

## Deprecation cleanup (bonus, unrelated to security)

**File:** `examples/hackernews/tsconfig.json`

- Removed `baseUrl: "."` — deprecated in TypeScript 6, will be removed in TS 7. All imports in this package use relative paths so `baseUrl` was doing nothing.
- Added `noEmit: true` — prevents TypeScript from trying to write compiled output over the existing `.js` files in `lib/`, which caused a compiler error.
- Added `@cloudflare/workers-types` to `devDependencies` — it was referenced in `tsconfig.json` `types` but missing from `package.json`, causing a type resolution error.