### PR TITLE
fix: ResponseCookies deduplicate Set-Cookie headers and add missing API surface

### DIFF
--- a/packages/vinext/src/shims/server.ts
+++ b/packages/vinext/src/shims/server.ts
@@ -639,6 +639,9 @@ export class ResponseCookies {
       expires: new Date(0),
       path: opts?.path,
       domain: opts?.domain,
+      httpOnly: opts?.httpOnly,
+      secure: opts?.secure,
+      sameSite: opts?.sameSite,
     });
   }
 
@@ -683,7 +686,7 @@ function parseCookieSetArgs(
     return [args[0], args[1] as string, args[2] as CookieOptions | undefined];
   }
   const { name, value, ...opts } = args[0];
-  return [name, value, Object.keys(opts).length > 0 ? (opts as CookieOptions) : undefined];
+  return [name, value, opts as CookieOptions];
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -4107,6 +4107,28 @@ describe("ResponseCookies correctness", () => {
     expect(setCookie[0]).toContain("Expires=");
   });
 
+  it("delete() forwards httpOnly, secure, and sameSite attributes", async () => {
+    const { ResponseCookies } = await import("../packages/vinext/src/shims/server.js");
+    const headers = new Headers();
+    const cookies = new ResponseCookies(headers);
+
+    cookies.delete({
+      name: "session",
+      path: "/app",
+      httpOnly: true,
+      secure: true,
+      sameSite: "Lax",
+    });
+
+    const setCookie = headers.getSetCookie();
+    expect(setCookie).toHaveLength(1);
+    expect(setCookie[0]).toContain("HttpOnly");
+    expect(setCookie[0]).toContain("Secure");
+    expect(setCookie[0]).toContain("SameSite=Lax");
+    expect(setCookie[0]).toContain("Path=/app");
+    expect(setCookie[0]).toContain("Expires=");
+  });
+
   it("delete() replaces existing cookie's Set-Cookie header", async () => {
     const { ResponseCookies } = await import("../packages/vinext/src/shims/server.js");
     const headers = new Headers();


### PR DESCRIPTION
## Summary
- **Bug 1 (critical):** `ResponseCookies.set()` unconditionally appended Set-Cookie headers — setting the same cookie name twice produced duplicate headers, and `get()` returned the stale first match. Rewritten to use an internal `Map<name, {serialized, entry}>` as the single source of truth (matching `@edge-runtime/cookies`'s architecture). The `_syncHeaders()` method deletes all Set-Cookie headers and re-appends from the map on every mutation.
- **Bug 2:** Added object form for `set({ name, value, httpOnly, ... })` matching Next.js docs and middleware patterns.
- **Bug 3:** Added name filter parameter to `getAll(name?)` and `getAll({ name })`.
- **Bug 4:** Added object form to `delete({ name, path, domain })` with path/domain propagation.
- Constructor now hydrates the internal map from existing Set-Cookie headers.
- `get()` accepts object form `get({ name })` matching edge-runtime.
- `delete()` now uses `Expires=epoch` (matching edge-runtime) instead of `Max-Age=0`.
- `delete()` now forwards `httpOnly`, `secure`, and `sameSite` attributes (matching edge-runtime — browsers need matching `Secure` to actually delete a cookie).
- **Behavioral change:** `set()` now defaults `Path=/` when no path option is given (previously omitted `Path` entirely). This matches `@edge-runtime/cookies`'s `normalizeCookie` behavior.

## Test plan
- [x] Test: set same cookie name twice → only one Set-Cookie header, get() returns latest
- [x] Test: set replaces only matching cookie, preserves others
- [x] Test: set({ name, value, httpOnly }) object form works
- [x] Test: object form replaces existing cookie of same name
- [x] Test: getAll("name") filters correctly
- [x] Test: getAll({ name }) object form filters correctly
- [x] Test: getAll(name) returns empty array for non-existent cookie
- [x] Test: delete({ name, path, domain }) produces correct Set-Cookie with matching path/domain
- [x] Test: delete() forwards httpOnly/secure/sameSite attributes
- [x] Test: delete() replaces existing cookie's Set-Cookie (no duplicates)
- [x] Test: constructor parses existing Set-Cookie headers
- [x] Test: has() works with internal map after delete()
- [x] Test: get({ name }) object form
- [x] All existing shims tests pass