### PR TITLE
fix(app-router): use override semantics when merging middleware headers into HTML responses

### DIFF
--- a/packages/vinext/src/server/app-page-response.ts
+++ b/packages/vinext/src/server/app-page-response.ts
@@ -254,11 +254,7 @@ export function buildAppPageHtmlResponse(
     headers.set("Link", options.fontLinkHeader);
   }
 
-  if (options.middlewareContext.headers) {
-    for (const [key, value] of options.middlewareContext.headers) {
-      headers.append(key, value);
-    }
-  }
+  mergeMiddlewareResponseHeaders(headers, options.middlewareContext.headers);
 
   applyTimingHeader(headers, options.timing);
 

--- a/tests/app-page-response.test.ts
+++ b/tests/app-page-response.test.ts
@@ -309,9 +309,11 @@ describe("app page response helpers", () => {
     expect(JSON.parse(decodeURIComponent(rawHeader))).toEqual({ slug: [koreanSlug] });
   });
 
-  it("builds HTML responses with draft cookies, preload links, middleware, and timing", async () => {
+  it("builds HTML responses with middleware override/append header semantics", async () => {
     const middlewareHeaders = new Headers();
+    middlewareHeaders.set("cache-control", "private, max-age=5");
     middlewareHeaders.append("set-cookie", "mw=1; Path=/");
+    middlewareHeaders.set("vary", "Next-Router-State-Tree");
     middlewareHeaders.append("x-extra", "present");
 
     const response = buildAppPageHtmlResponse(createBody("<h1>page</h1>"), {
@@ -335,8 +337,9 @@ describe("app page response helpers", () => {
 
     expect(response.status).toBe(203);
     expect(response.headers.get("content-type")).toBe("text/html; charset=utf-8");
-    expect(response.headers.get("cache-control")).toBe("s-maxage=31536000, stale-while-revalidate");
+    expect(response.headers.get("cache-control")).toBe("private, max-age=5");
     expect(response.headers.get("x-vinext-cache")).toBe("STATIC");
+    expect(response.headers.get("vary")).toBe("RSC, Accept, Next-Router-State-Tree");
     expect(response.headers.get("link")).toBe(
       "</font.woff2>; rel=preload; as=font; type=font/woff2; crossorigin",
     );


### PR DESCRIPTION
## Summary
- reuse `mergeMiddlewareResponseHeaders` in `buildAppPageHtmlResponse` so HTML responses follow the same middleware merge semantics as RSC responses
- append only additive headers (`Set-Cookie`, `Vary`) and override singular headers (for example `Cache-Control`)
- extend HTML response helper test coverage to assert middleware `Cache-Control` override with `Set-Cookie`/`Vary` accumulation

## Verification
- `vp test run tests/app-page-response.test.ts`
- `vp test run tests/app-route-handler-response.test.ts`
