### PR TITLE
fix(app-route): merge middleware headers with override semantics

### DIFF
--- a/packages/vinext/src/server/app-page-response.ts
+++ b/packages/vinext/src/server/app-page-response.ts
@@ -1,3 +1,5 @@
+import { mergeMiddlewareResponseHeaders } from "./middleware-response-headers.js";
+
 export type AppPageMiddlewareContext = {
   headers: Headers | null;
   status: number | null;
@@ -173,33 +175,7 @@ export function resolveAppPageHtmlResponsePolicy(
   return { shouldWriteToCache: false };
 }
 
-/**
- * Merge middleware response headers into a target Headers object.
- *
- * Set-Cookie and Vary are accumulated (append) since multiple sources can
- * contribute values. All other headers use set() so middleware owns singular
- * response headers like Cache-Control.
- *
- * Used by buildAppPageRscResponse and the generated entry for intercepting
- * route and server action responses that bypass the normal page render path.
- */
-export function mergeMiddlewareResponseHeaders(
-  target: Headers,
-  middlewareHeaders: Headers | null,
-): void {
-  if (!middlewareHeaders) {
-    return;
-  }
-
-  for (const [key, value] of middlewareHeaders) {
-    const lowerKey = key.toLowerCase();
-    if (lowerKey === "set-cookie" || lowerKey === "vary") {
-      target.append(key, value);
-    } else {
-      target.set(key, value);
-    }
-  }
-}
+export { mergeMiddlewareResponseHeaders };
 
 export function buildAppPageRscResponse(
   body: ReadableStream,

--- a/packages/vinext/src/server/app-page-response.ts
+++ b/packages/vinext/src/server/app-page-response.ts
@@ -230,11 +230,7 @@ export function buildAppPageHtmlResponse(
     headers.set("Link", options.fontLinkHeader);
   }
 
-  if (options.middlewareContext.headers) {
-    for (const [key, value] of options.middlewareContext.headers) {
-      headers.append(key, value);
-    }
-  }
+  mergeMiddlewareResponseHeaders(headers, options.middlewareContext.headers);
 
   applyTimingHeader(headers, options.timing);
 

--- a/packages/vinext/src/server/app-route-handler-response.ts
+++ b/packages/vinext/src/server/app-route-handler-response.ts
@@ -1,4 +1,5 @@
 import type { CachedRouteValue } from "../shims/cache.js";
+import { mergeMiddlewareResponseHeaders } from "./middleware-response-headers.js";
 
 export type RouteHandlerMiddlewareContext = {
   headers: Headers | null;
@@ -37,16 +38,7 @@ export function applyRouteHandlerMiddlewareContext(
   }
 
   const responseHeaders = new Headers(response.headers);
-  if (middlewareContext.headers) {
-    for (const [key, value] of middlewareContext.headers) {
-      const lowerKey = key.toLowerCase();
-      if (lowerKey === "set-cookie" || lowerKey === "vary") {
-        responseHeaders.append(key, value);
-      } else {
-        responseHeaders.set(key, value);
-      }
-    }
-  }
+  mergeMiddlewareResponseHeaders(responseHeaders, middlewareContext.headers);
 
   return new Response(response.body, {
     status: middlewareContext.status ?? response.status,

--- a/packages/vinext/src/server/app-route-handler-response.ts
+++ b/packages/vinext/src/server/app-route-handler-response.ts
@@ -39,7 +39,12 @@ export function applyRouteHandlerMiddlewareContext(
   const responseHeaders = new Headers(response.headers);
   if (middlewareContext.headers) {
     for (const [key, value] of middlewareContext.headers) {
-      responseHeaders.append(key, value);
+      const lowerKey = key.toLowerCase();
+      if (lowerKey === "set-cookie" || lowerKey === "vary") {
+        responseHeaders.append(key, value);
+      } else {
+        responseHeaders.set(key, value);
+      }
     }
   }
 

--- a/packages/vinext/src/server/middleware-response-headers.ts
+++ b/packages/vinext/src/server/middleware-response-headers.ts
@@ -1,5 +1,12 @@
 const ADDITIVE_RESPONSE_HEADER_NAMES = new Set(["set-cookie", "vary"]);
 
+/**
+ * Merge middleware response headers into a target Headers object.
+ *
+ * Set-Cookie and Vary are accumulated (append) since multiple sources can
+ * contribute values. All other headers use set() so middleware owns singular
+ * response headers like Cache-Control.
+ */
 export function mergeMiddlewareResponseHeaders(
   target: Headers,
   middlewareHeaders: Headers | null,

--- a/packages/vinext/src/server/middleware-response-headers.ts
+++ b/packages/vinext/src/server/middleware-response-headers.ts
@@ -1,0 +1,19 @@
+const ADDITIVE_RESPONSE_HEADER_NAMES = new Set(["set-cookie", "vary"]);
+
+export function mergeMiddlewareResponseHeaders(
+  target: Headers,
+  middlewareHeaders: Headers | null,
+): void {
+  if (!middlewareHeaders) {
+    return;
+  }
+
+  for (const [key, value] of middlewareHeaders) {
+    if (ADDITIVE_RESPONSE_HEADER_NAMES.has(key.toLowerCase())) {
+      target.append(key, value);
+      continue;
+    }
+
+    target.set(key, value);
+  }
+}

--- a/tests/app-page-response.test.ts
+++ b/tests/app-page-response.test.ts
@@ -313,6 +313,7 @@ describe("app page response helpers", () => {
     const middlewareHeaders = new Headers();
     middlewareHeaders.append("set-cookie", "mw=1; Path=/");
     middlewareHeaders.append("x-extra", "present");
+    middlewareHeaders.set("cache-control", "private, max-age=5");
 
     const response = buildAppPageHtmlResponse(createBody("<h1>page</h1>"), {
       draftCookie: "__prerender_bypass=token; Path=/",
@@ -335,7 +336,7 @@ describe("app page response helpers", () => {
 
     expect(response.status).toBe(203);
     expect(response.headers.get("content-type")).toBe("text/html; charset=utf-8");
-    expect(response.headers.get("cache-control")).toBe("s-maxage=31536000, stale-while-revalidate");
+    expect(response.headers.get("cache-control")).toBe("private, max-age=5");
     expect(response.headers.get("x-vinext-cache")).toBe("STATIC");
     expect(response.headers.get("link")).toBe(
       "</font.woff2>; rel=preload; as=font; type=font/woff2; crossorigin",

--- a/tests/app-route-handler-response.test.ts
+++ b/tests/app-route-handler-response.test.ts
@@ -33,17 +33,19 @@ describe("app route handler response helpers", () => {
     ).toBe(response);
   });
 
-  it("applies middleware headers and status overrides to route handler responses", async () => {
+  it("overrides singular headers and status with middleware values", async () => {
     const response = new Response("hello", {
       status: 200,
       headers: {
         "content-type": "text/plain",
+        "cache-control": "s-maxage=60, stale-while-revalidate",
         "x-response": "app",
       },
     });
 
     const result = applyRouteHandlerMiddlewareContext(response, {
       headers: new Headers([
+        ["cache-control", "private, max-age=5"],
         ["x-middleware", "mw"],
         ["x-response", "middleware-copy"],
       ]),
@@ -52,8 +54,32 @@ describe("app route handler response helpers", () => {
 
     expect(result.status).toBe(202);
     expect(result.headers.get("content-type")).toBe("text/plain");
-    expect(result.headers.get("x-response")).toBe("app, middleware-copy");
+    expect(result.headers.get("cache-control")).toBe("private, max-age=5");
+    expect(result.headers.get("x-response")).toBe("middleware-copy");
     expect(result.headers.get("x-middleware")).toBe("mw");
+    await expect(result.text()).resolves.toBe("hello");
+  });
+
+  it("appends additive middleware headers for Set-Cookie and Vary", async () => {
+    const response = new Response("hello", {
+      status: 200,
+      headers: [
+        ["vary", "RSC, Accept"],
+        ["set-cookie", "existing=1; Path=/"],
+      ],
+    });
+
+    const middlewareHeaders = new Headers();
+    middlewareHeaders.append("vary", "Next-Router-State-Tree");
+    middlewareHeaders.append("set-cookie", "mw=1; Path=/");
+
+    const result = applyRouteHandlerMiddlewareContext(response, {
+      headers: middlewareHeaders,
+      status: null,
+    });
+
+    expect(result.headers.get("vary")).toBe("RSC, Accept, Next-Router-State-Tree");
+    expect(result.headers.getSetCookie()).toEqual(["existing=1; Path=/", "mw=1; Path=/"]);
     await expect(result.text()).resolves.toBe("hello");
   });
 

--- a/tests/app-route-handler-response.test.ts
+++ b/tests/app-route-handler-response.test.ts
@@ -72,6 +72,7 @@ describe("app route handler response helpers", () => {
     const middlewareHeaders = new Headers();
     middlewareHeaders.append("vary", "Next-Router-State-Tree");
     middlewareHeaders.append("set-cookie", "mw=1; Path=/");
+    middlewareHeaders.append("set-cookie", "mw=2; Path=/; HttpOnly");
 
     const result = applyRouteHandlerMiddlewareContext(response, {
       headers: middlewareHeaders,
@@ -79,7 +80,11 @@ describe("app route handler response helpers", () => {
     });
 
     expect(result.headers.get("vary")).toBe("RSC, Accept, Next-Router-State-Tree");
-    expect(result.headers.getSetCookie()).toEqual(["existing=1; Path=/", "mw=1; Path=/"]);
+    expect(result.headers.getSetCookie()).toEqual([
+      "existing=1; Path=/",
+      "mw=1; Path=/",
+      "mw=2; Path=/; HttpOnly",
+    ]);
     await expect(result.text()).resolves.toBe("hello");
   });
 


### PR DESCRIPTION
## Summary
- update `applyRouteHandlerMiddlewareContext` to merge middleware response headers with Next-like semantics
- treat `set-cookie` and `vary` as additive headers (append)
- treat all other headers as singular override headers (`set`), so middleware can override route handler values like `cache-control`
- add regression coverage for singular override and additive merge behavior

## Verification
- `vp test run tests/app-route-handler-response.test.ts tests/app-route-handler-cache.test.ts tests/app-route-handler-execution.test.ts tests/app-route-handler-policy.test.ts tests/app-route-handler-runtime.test.ts`
