### PR TITLE
fix: strip internal prerender auth header from external rewrites

### DIFF
--- a/packages/vinext/src/config/config-matchers.ts
+++ b/packages/vinext/src/config/config-matchers.ts
@@ -1055,6 +1055,10 @@ export async function proxyExternalRequest(
   for (const key of keysToDelete) {
     headers.delete(key);
   }
+  // Internal prerender authentication header must never be forwarded to
+  // external rewrite destinations. It authorizes hidden production endpoints
+  // used only by vinext's own prerender pipeline.
+  headers.delete("x-vinext-prerender-secret");
 
   const method = request.method;
   const hasBody = method !== "GET" && method !== "HEAD";

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -3587,6 +3587,7 @@ describe("App Router external rewrite proxy credential forwarding", () => {
         "x-api-key": "sk_live_secret",
         "proxy-authorization": "Basic cHJveHk=",
         "x-middleware-next": "1",
+        "x-vinext-prerender-secret": "build-secret-123",
         "x-custom-safe": "keep-me",
       },
     });
@@ -3599,6 +3600,7 @@ describe("App Router external rewrite proxy credential forwarding", () => {
     expect(capturedHeaders!["proxy-authorization"]).toBe("Basic cHJveHk=");
     // Internal middleware headers must be stripped
     expect(capturedHeaders!["x-middleware-next"]).toBeUndefined();
+    expect(capturedHeaders!["x-vinext-prerender-secret"]).toBeUndefined();
     // Non-sensitive headers must be preserved
     expect(capturedHeaders!["x-custom-safe"]).toBe("keep-me");
   });

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -5832,6 +5832,7 @@ describe("proxyExternalRequest", () => {
         "proxy-authorization": "Basic cHJveHk=",
         "x-middleware-rewrite": "/internal",
         "x-middleware-next": "1",
+        "x-vinext-prerender-secret": "build-secret-123",
         "x-custom-header": "keep-me",
         "user-agent": "vinext-test",
       },
@@ -5855,6 +5856,7 @@ describe("proxyExternalRequest", () => {
       // Internal middleware headers must be stripped
       expect(capturedHeaders!.get("x-middleware-rewrite")).toBeNull();
       expect(capturedHeaders!.get("x-middleware-next")).toBeNull();
+      expect(capturedHeaders!.get("x-vinext-prerender-secret")).toBeNull();
       // Non-sensitive headers must be preserved
       expect(capturedHeaders!.get("x-custom-header")).toBe("keep-me");
       expect(capturedHeaders!.get("user-agent")).toBe("vinext-test");


### PR DESCRIPTION
## Summary

The shared external rewrite proxy now strips `x-vinext-prerender-secret` before forwarding requests upstream.

## Details

`proxyExternalRequest()` intentionally forwards most request headers to match external rewrite proxying behavior, while stripping hop-by-hop and `x-middleware-*` headers. During vinext's prerender pipeline, internal HTTP requests carry `x-vinext-prerender-secret` so hidden prerender endpoints can authenticate.

That internal auth header should never be forwarded to external rewrite destinations.

This change adds a targeted strip in `proxyExternalRequest()` and extends the existing external rewrite forwarding tests to verify:
- credential headers still forward
- `x-middleware-*` headers are still stripped
- `x-vinext-prerender-secret` is also stripped

## Tests

- `tests/shims.test.ts` external rewrite proxy unit test
- `tests/app-router.test.ts` external rewrite integration test