### PR TITLE
fix: apply middleware request-header overrides to App Route request objects

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -1188,7 +1188,7 @@ export default async function handler(request, ctx) {
     // Per-request container for middleware state. Passed into
     // _handleRequest which fills in .headers and .status;
     // avoids module-level variables that race on Workers.
-    const _mwCtx = { headers: null, status: null };
+    const _mwCtx = { headers: null, requestHeaders: null, status: null };
     const response = await _handleRequest(request, __reqCtx, _mwCtx);
     // Apply custom headers from next.config.js to non-redirect responses.
     // Skip redirects (3xx) because Response.redirect() creates immutable headers,
@@ -1500,6 +1500,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // be merged into the outgoing HTTP response — this prefix is reserved for
   // internal routing signals and must never reach clients.
   if (_mwCtx.headers) {
+    // Preserve the pre-strip header set so route handlers can reconstruct
+    // a request object with middleware header overrides applied.
+    _mwCtx.requestHeaders = new Headers(_mwCtx.headers);
     applyMiddlewareRequestHeaders(_mwCtx.headers);
     processMiddlewareHeaders(_mwCtx.headers);
   }
@@ -2004,6 +2007,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         markDynamicUsage,
         method,
         middlewareContext: _mwCtx,
+        middlewareRequestHeaders: _mwCtx.requestHeaders,
         params: makeThenableParams(params),
         reportRequestError: _reportRequestError,
         request,

--- a/packages/vinext/src/server/app-route-handler-execution.ts
+++ b/packages/vinext/src/server/app-route-handler-execution.ts
@@ -47,6 +47,7 @@ export type RunAppRouteHandlerOptions = {
   handlerFn: AppRouteHandlerFunction;
   i18n?: NextI18nConfig | null;
   markDynamicUsage: MarkAppRouteDynamicUsageFn;
+  middlewareRequestHeaders?: Headers | null;
   params: AppRouteParams;
   request: Request;
 };
@@ -85,6 +86,7 @@ export async function runAppRouteHandler(
   const trackedRequest = createTrackedAppRouteRequest(options.request, {
     basePath: options.basePath,
     i18n: options.i18n,
+    middlewareHeaders: options.middlewareRequestHeaders,
     onDynamicAccess() {
       options.markDynamicUsage();
     },

--- a/packages/vinext/src/server/app-route-handler-runtime.ts
+++ b/packages/vinext/src/server/app-route-handler-runtime.ts
@@ -1,5 +1,6 @@
 import type { NextI18nConfig } from "../config/next-config.js";
 import { NextRequest, type NextURL } from "../shims/server.js";
+import { buildRequestHeadersFromMiddlewareResponse } from "./middleware-request-headers.js";
 
 export const ROUTE_HANDLER_HTTP_METHODS = [
   "GET",
@@ -78,6 +79,7 @@ export type AppRouteDynamicRequestAccess = RequestDynamicAccess | NextUrlDynamic
 export type TrackedAppRouteRequestOptions = {
   basePath?: string;
   i18n?: NextI18nConfig | null;
+  middlewareHeaders?: Headers | null;
   onDynamicAccess?: (access: AppRouteDynamicRequestAccess) => void;
 };
 
@@ -102,6 +104,31 @@ function buildNextConfig(options: TrackedAppRouteRequestOptions): {
     basePath: options.basePath,
     i18n: options.i18n ?? undefined,
   };
+}
+
+function rebuildRequestWithHeaders(input: Request, headers: Headers): Request {
+  const method = input.method;
+  const hasBody = method !== "GET" && method !== "HEAD";
+  const init: RequestInit & { duplex?: "half" } = {
+    method,
+    headers,
+    cache: input.cache,
+    credentials: input.credentials,
+    integrity: input.integrity,
+    keepalive: input.keepalive,
+    mode: input.mode,
+    redirect: input.redirect,
+    referrer: input.referrer,
+    referrerPolicy: input.referrerPolicy,
+    signal: input.signal,
+  };
+
+  if (hasBody && input.body) {
+    init.body = input.body;
+    init.duplex = "half";
+  }
+
+  return new Request(input.url, init);
 }
 
 export function createTrackedAppRouteRequest(
@@ -144,10 +171,16 @@ export function createTrackedAppRouteRequest(
   };
 
   const wrapRequest = (input: Request): NextRequest => {
+    const requestHeaders = options.middlewareHeaders
+      ? buildRequestHeadersFromMiddlewareResponse(input.headers, options.middlewareHeaders)
+      : null;
+    const requestWithOverrides = requestHeaders
+      ? rebuildRequestWithHeaders(input, requestHeaders)
+      : input;
     const nextRequest =
-      input instanceof NextRequest
-        ? input
-        : new NextRequest(input, { nextConfig: nextConfig ?? undefined });
+      requestWithOverrides instanceof NextRequest
+        ? requestWithOverrides
+        : new NextRequest(requestWithOverrides, { nextConfig: nextConfig ?? undefined });
     let proxiedNextUrl: NextURL | null = null;
 
     const requestHandler: ProxyHandler<NextRequest> = {

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -1101,7 +1101,7 @@ export default async function handler(request, ctx) {
     // Per-request container for middleware state. Passed into
     // _handleRequest which fills in .headers and .status;
     // avoids module-level variables that race on Workers.
-    const _mwCtx = { headers: null, status: null };
+    const _mwCtx = { headers: null, requestHeaders: null, status: null };
     const response = await _handleRequest(request, __reqCtx, _mwCtx);
     // Apply custom headers from next.config.js to non-redirect responses.
     // Skip redirects (3xx) because Response.redirect() creates immutable headers,
@@ -1697,6 +1697,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         markDynamicUsage,
         method,
         middlewareContext: _mwCtx,
+        middlewareRequestHeaders: _mwCtx.requestHeaders,
         params: makeThenableParams(params),
         reportRequestError: _reportRequestError,
         request,
@@ -3216,7 +3217,7 @@ export default async function handler(request, ctx) {
     // Per-request container for middleware state. Passed into
     // _handleRequest which fills in .headers and .status;
     // avoids module-level variables that race on Workers.
-    const _mwCtx = { headers: null, status: null };
+    const _mwCtx = { headers: null, requestHeaders: null, status: null };
     const response = await _handleRequest(request, __reqCtx, _mwCtx);
     // Apply custom headers from next.config.js to non-redirect responses.
     // Skip redirects (3xx) because Response.redirect() creates immutable headers,
@@ -3818,6 +3819,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         markDynamicUsage,
         method,
         middlewareContext: _mwCtx,
+        middlewareRequestHeaders: _mwCtx.requestHeaders,
         params: makeThenableParams(params),
         reportRequestError: _reportRequestError,
         request,
@@ -5338,7 +5340,7 @@ export default async function handler(request, ctx) {
     // Per-request container for middleware state. Passed into
     // _handleRequest which fills in .headers and .status;
     // avoids module-level variables that race on Workers.
-    const _mwCtx = { headers: null, status: null };
+    const _mwCtx = { headers: null, requestHeaders: null, status: null };
     const response = await _handleRequest(request, __reqCtx, _mwCtx);
     // Apply custom headers from next.config.js to non-redirect responses.
     // Skip redirects (3xx) because Response.redirect() creates immutable headers,
@@ -5934,6 +5936,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         markDynamicUsage,
         method,
         middlewareContext: _mwCtx,
+        middlewareRequestHeaders: _mwCtx.requestHeaders,
         params: makeThenableParams(params),
         reportRequestError: _reportRequestError,
         request,
@@ -7486,7 +7489,7 @@ export default async function handler(request, ctx) {
     // Per-request container for middleware state. Passed into
     // _handleRequest which fills in .headers and .status;
     // avoids module-level variables that race on Workers.
-    const _mwCtx = { headers: null, status: null };
+    const _mwCtx = { headers: null, requestHeaders: null, status: null };
     const response = await _handleRequest(request, __reqCtx, _mwCtx);
     // Apply custom headers from next.config.js to non-redirect responses.
     // Skip redirects (3xx) because Response.redirect() creates immutable headers,
@@ -8082,6 +8085,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         markDynamicUsage,
         method,
         middlewareContext: _mwCtx,
+        middlewareRequestHeaders: _mwCtx.requestHeaders,
         params: makeThenableParams(params),
         reportRequestError: _reportRequestError,
         request,
@@ -9608,7 +9612,7 @@ export default async function handler(request, ctx) {
     // Per-request container for middleware state. Passed into
     // _handleRequest which fills in .headers and .status;
     // avoids module-level variables that race on Workers.
-    const _mwCtx = { headers: null, status: null };
+    const _mwCtx = { headers: null, requestHeaders: null, status: null };
     const response = await _handleRequest(request, __reqCtx, _mwCtx);
     // Apply custom headers from next.config.js to non-redirect responses.
     // Skip redirects (3xx) because Response.redirect() creates immutable headers,
@@ -10204,6 +10208,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         markDynamicUsage,
         method,
         middlewareContext: _mwCtx,
+        middlewareRequestHeaders: _mwCtx.requestHeaders,
         params: makeThenableParams(params),
         reportRequestError: _reportRequestError,
         request,
@@ -11952,7 +11957,7 @@ export default async function handler(request, ctx) {
     // Per-request container for middleware state. Passed into
     // _handleRequest which fills in .headers and .status;
     // avoids module-level variables that race on Workers.
-    const _mwCtx = { headers: null, status: null };
+    const _mwCtx = { headers: null, requestHeaders: null, status: null };
     const response = await _handleRequest(request, __reqCtx, _mwCtx);
     // Apply custom headers from next.config.js to non-redirect responses.
     // Skip redirects (3xx) because Response.redirect() creates immutable headers,
@@ -12211,6 +12216,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // be merged into the outgoing HTTP response — this prefix is reserved for
   // internal routing signals and must never reach clients.
   if (_mwCtx.headers) {
+    // Preserve the pre-strip header set so route handlers can reconstruct
+    // a request object with middleware header overrides applied.
+    _mwCtx.requestHeaders = new Headers(_mwCtx.headers);
     applyMiddlewareRequestHeaders(_mwCtx.headers);
     processMiddlewareHeaders(_mwCtx.headers);
   }
@@ -12683,6 +12691,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         markDynamicUsage,
         method,
         middlewareContext: _mwCtx,
+        middlewareRequestHeaders: _mwCtx.requestHeaders,
         params: makeThenableParams(params),
         reportRequestError: _reportRequestError,
         request,

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -3413,6 +3413,25 @@ describe("App Router middleware with NextRequest", () => {
     expect(html).toContain('id="cookie-count">0<');
   });
 
+  it("middleware request header overrides also apply to App Route request.headers", async () => {
+    const res = await fetch(`${baseUrl}/api/header-override-delete`, {
+      headers: {
+        authorization: "Bearer secret",
+        cookie: "a=1; b=2",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      requestAuthorization: null,
+      requestCookie: null,
+      requestMiddlewareHeader: "hello-from-middleware",
+      headersApiAuthorization: null,
+      headersApiCookie: null,
+      headersApiMiddlewareHeader: "hello-from-middleware",
+    });
+  });
+
   it("middleware request header overrides can delete credential headers before pages getServerSideProps in mixed projects", async () => {
     const { res, html } = await fetchHtml(baseUrl, "/pages-header-override-delete", {
       headers: {

--- a/tests/fixtures/app-basic/app/api/header-override-delete/route.ts
+++ b/tests/fixtures/app-basic/app/api/header-override-delete/route.ts
@@ -1,0 +1,15 @@
+import { headers } from "next/headers";
+import { NextResponse, type NextRequest } from "next/server";
+
+export async function GET(request: NextRequest) {
+  const requestHeaders = await headers();
+
+  return NextResponse.json({
+    requestAuthorization: request.headers.get("authorization"),
+    requestCookie: request.headers.get("cookie"),
+    requestMiddlewareHeader: request.headers.get("x-from-middleware"),
+    headersApiAuthorization: requestHeaders.get("authorization"),
+    headersApiCookie: requestHeaders.get("cookie"),
+    headersApiMiddlewareHeader: requestHeaders.get("x-from-middleware"),
+  });
+}

--- a/tests/fixtures/app-basic/middleware.ts
+++ b/tests/fixtures/app-basic/middleware.ts
@@ -127,7 +127,7 @@ export function middleware(request: NextRequest, event: NextFetchEvent) {
     return res;
   }
 
-  if (pathname === "/header-override-delete") {
+  if (pathname === "/header-override-delete" || pathname === "/api/header-override-delete") {
     const headers = new Headers(request.headers);
     headers.delete("authorization");
     headers.delete("cookie");
@@ -217,6 +217,7 @@ export const config = {
     "/search-query",
     "/headers/override-from-middleware",
     "/header-override-delete",
+    "/api/header-override-delete",
     "/pages-header-override-delete",
     "/revalidate-test",
     "/script-nonce/:path*",


### PR DESCRIPTION
## Summary

App Route handlers now receive a request object rebuilt from middleware request-header overrides, so `request.headers` and `headers()` agree after middleware mutations.

## Details

Middleware request-header overrides were already applied to the `next/headers` ALS context, so `headers()` reflected the middleware-modified request state. But App Route handlers still received a tracked `NextRequest` built from the original request object, so `request.headers` exposed the pre-middleware Authorization/Cookie headers.

This change:
- preserves a clone of the middleware response headers before internal `x-middleware-*` headers are stripped for response safety
- threads that preserved header set into the typed App Route execution module
- rebuilds the underlying `Request` with `buildRequestHeadersFromMiddlewareResponse()` before constructing the tracked `NextRequest`

## Tests

Adds an App Route fixture and integration test proving that after middleware deletes credential headers and injects `x-from-middleware`, both:
- `request.headers`
- `headers()`

see the same middleware-modified values.