### PR TITLE
fix: invalidate cached headers/cookies snapshot in applyMiddlewareRequestHeaders

### DIFF
--- a/packages/vinext/src/shims/headers.ts
+++ b/packages/vinext/src/shims/headers.ts
@@ -235,6 +235,16 @@ export function runWithHeadersContext<T>(
  * middleware response. This function decodes that protocol and applies the
  * resulting request header set to the live `HeadersContext`. When an override
  * list is present, omitted headers are deleted as part of the rebuild.
+ *
+ * Cached `readonlyHeaders` and `readonlyCookies` snapshots on the
+ * HeadersContext must be invalidated whenever this function rebuilds the
+ * underlying `headers`/`cookies`. Otherwise a middleware that reads
+ * `headers()` (or `cookies()`) before returning a request-header override —
+ * for example `@clerk/nextjs`, whose `clerkClient()` reads `headers()` via
+ * `buildRequestLike()` during middleware execution — primes a sealed snapshot
+ * built from the *pre*-override request, and any subsequent `headers()` call
+ * from a Server Component would return that stale snapshot instead of the
+ * middleware-modified view.
  */
 export function applyMiddlewareRequestHeaders(middlewareResponseHeaders: Headers): void {
   const state = _getState();
@@ -250,11 +260,18 @@ export function applyMiddlewareRequestHeaders(middlewareResponseHeaders: Headers
   if (!nextHeaders) return;
 
   ctx.headers = nextHeaders;
+  // Invalidate any sealed snapshot of the pre-override headers. A middleware
+  // that read `headers()` before returning the override (e.g. clerkMiddleware)
+  // would otherwise leak the pre-override view into the Server Component.
+  ctx.readonlyHeaders = undefined;
   const nextCookieHeader = nextHeaders.get("cookie");
   if (previousCookieHeader === nextCookieHeader) return;
 
-  // If middleware modified the cookie header, rebuild the cookies map.
+  // If middleware modified the cookie header, rebuild the cookies map and
+  // drop any sealed snapshots that were captured from the pre-override map.
   ctx.cookies.clear();
+  ctx.readonlyCookies = undefined;
+  ctx.mutableCookies = undefined;
   if (nextCookieHeader !== null) {
     const nextCookies = parseCookieHeader(nextCookieHeader);
     for (const [name, value] of nextCookies) {

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -2160,6 +2160,50 @@ describe("App Router Production server (startProdServer)", () => {
     const body = await headRes.text();
     expect(body).toBe("");
   });
+
+  it("middleware request header overrides still apply after middleware calls headers() first", async () => {
+    // Regression for a bug where a middleware that reads `next/headers` →
+    // `headers()` *before* returning `NextResponse.next({ request: { headers } })`
+    // leaked the pre-override snapshot into the Server Component.
+    //
+    // The `headers()` call cached the sealed read-only Headers view on the
+    // shared HeadersContext (`ctx.readonlyHeaders = _sealHeaders(ctx.headers)`).
+    // `applyMiddlewareRequestHeaders()` then replaced `ctx.headers` with the
+    // override view but did not invalidate the cached sealed snapshot, so the
+    // Server Component's subsequent `headers()` call returned the original
+    // pre-override request headers.
+    //
+    // Discovered with @clerk/nextjs, whose `clerkClient()` calls
+    // `await headers()` via its internal `buildRequestLike()` helper during
+    // middleware execution. Clerk's `auth()` in a Server Component then threw
+    //
+    //   "auth() was called but Clerk can't detect usage of clerkMiddleware()"
+    //
+    // because Clerk's own x-clerk-auth-* request header overrides never
+    // reached the render. The fixture middleware reproduces the same prime-
+    // then-override sequence without a Clerk dependency by calling
+    // `await headers()` first and then returning the override response.
+    //
+    // The test runs against the production server (startProdServer) because
+    // the bug only manifests on the inline RSC entry path that wraps the
+    // entire request — including middleware execution — in the headers
+    // context. The dev-mode middleware path runs middleware before the
+    // headers context exists, so calling `headers()` from middleware is
+    // instead an immediate error there.
+    const res = await fetch(`${baseUrl}/header-override-after-prior-access`, {
+      headers: {
+        authorization: "Bearer secret",
+        cookie: "a=1; b=2",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain('id="authorization">null<');
+    expect(html).toContain('id="cookie">null<');
+    expect(html).toContain('id="middleware-header">hello-from-middleware<');
+    expect(html).toContain('id="cookie-count">0<');
+  });
 });
 
 describe("App Router Production server worker entry compatibility", () => {

--- a/tests/fixtures/app-basic/app/header-override-after-prior-access/page.tsx
+++ b/tests/fixtures/app-basic/app/header-override-after-prior-access/page.tsx
@@ -1,0 +1,33 @@
+import { cookies, headers } from "next/headers";
+
+/**
+ * Regression test page for a bug where a middleware that reads `headers()`
+ * before applying a request-header override leaks its pre-override view into
+ * the Server Component.
+ *
+ * The matching middleware branch does two things, in order:
+ *   1. `await headers()` — this caches the current sealed read-only Headers
+ *      snapshot on the shared HeadersContext.
+ *   2. Returns `NextResponse.next({ request: { headers: modified } })` where
+ *      `modified` drops `authorization`/`cookie` and adds `x-from-middleware`.
+ *
+ * A correct implementation must invalidate the cached sealed Headers when the
+ * underlying `HeadersContext.headers` is replaced by
+ * `applyMiddlewareRequestHeaders()`, so the Server Component sees the
+ * middleware-modified view. Before the fix, `_getReadonlyHeaders()` returned
+ * the stale snapshot and the Server Component still saw the original request
+ * headers (`authorization` present, `x-from-middleware` missing).
+ */
+export default async function HeaderOverrideAfterPriorAccessPage() {
+  const requestHeaders = await headers();
+  const requestCookies = await cookies();
+
+  return (
+    <div>
+      <p id="authorization">{requestHeaders.get("authorization") ?? "null"}</p>
+      <p id="cookie">{requestHeaders.get("cookie") ?? "null"}</p>
+      <p id="middleware-header">{requestHeaders.get("x-from-middleware") ?? "null"}</p>
+      <p id="cookie-count">{String(requestCookies.getAll().length)}</p>
+    </div>
+  );
+}

--- a/tests/fixtures/app-basic/middleware.ts
+++ b/tests/fixtures/app-basic/middleware.ts
@@ -1,3 +1,4 @@
+import { headers as nextHeaders } from "next/headers";
 import { NextRequest, NextResponse, NextFetchEvent } from "next/server";
 import { recordMiddlewareInvocation } from "./instrumentation-state";
 
@@ -12,7 +13,7 @@ import { recordMiddlewareInvocation } from "./instrumentation-state";
  * - Block with 403
  * - Search params forwarding
  */
-export function middleware(request: NextRequest, event: NextFetchEvent) {
+export async function middleware(request: NextRequest, event: NextFetchEvent) {
   // Test NextRequest.nextUrl - this would fail with TypeError if request is plain Request
   const { pathname } = request.nextUrl;
 
@@ -135,6 +136,33 @@ export function middleware(request: NextRequest, event: NextFetchEvent) {
     return NextResponse.next({ request: { headers } });
   }
 
+  // Regression for a bug where a middleware that reads `next/headers` →
+  // `headers()` before returning a `NextResponse.next({ request: { headers } })`
+  // override leaked the pre-override snapshot into the Server Component.
+  //
+  // Discovered with @clerk/nextjs, whose internal `clerkClient()` calls
+  // `await headers()` via `buildRequestLike()` during middleware execution.
+  // That call cached the sealed read-only Headers view on the shared
+  // HeadersContext. Afterwards, `applyMiddlewareRequestHeaders()` replaced
+  // `ctx.headers` with the override view but never invalidated the cached
+  // sealed snapshot, so the Server Component's later `headers()` call
+  // returned the original request headers — `x-from-middleware` was missing
+  // and deleted credential headers were still visible.
+  if (pathname === "/header-override-after-prior-access") {
+    // 1. Prime the sealed Headers cache via an early `headers()` read — this
+    //    is the step that a real-world middleware like Clerk performs under
+    //    the covers.
+    await nextHeaders();
+
+    // 2. Apply the header override. A correct implementation must invalidate
+    //    the cached sealed snapshot so this override reaches the render.
+    const headers = new Headers(request.headers);
+    headers.delete("authorization");
+    headers.delete("cookie");
+    headers.set("x-from-middleware", "hello-from-middleware");
+    return NextResponse.next({ request: { headers } });
+  }
+
   if (pathname === "/pages-header-override-delete") {
     const headers = new Headers(request.headers);
     headers.delete("authorization");
@@ -218,6 +246,7 @@ export const config = {
     "/headers/override-from-middleware",
     "/header-override-delete",
     "/api/header-override-delete",
+    "/header-override-after-prior-access",
     "/pages-header-override-delete",
     "/revalidate-test",
     "/script-nonce/:path*",

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -5031,6 +5031,66 @@ describe("middleware request header overrides", () => {
       expect(liveCookies.getAll()).toEqual([]);
     });
   });
+
+  it("next/headers applyMiddlewareRequestHeaders invalidates headers() snapshot taken before the override", async () => {
+    // Regression: a middleware that reads `headers()` (or `cookies()`) before
+    // applying a request-header override would prime a sealed read-only
+    // snapshot built from the *pre*-override request. Discovered with
+    // @clerk/nextjs whose `clerkClient()` reads `headers()` via
+    // `buildRequestLike()` during middleware execution; before the fix, the
+    // Server Component subsequently received the stale snapshot and saw the
+    // pre-override credentials and missing middleware-injected headers.
+    const {
+      applyMiddlewareRequestHeaders,
+      cookies,
+      headers,
+      headersContextFromRequest,
+      runWithHeadersContext,
+    } = await import("../packages/vinext/src/shims/headers.js");
+
+    const request = new Request("http://localhost/test", {
+      headers: {
+        authorization: "Bearer secret",
+        cookie: "a=1; b=2",
+        "x-keep": "original",
+      },
+    });
+
+    await runWithHeadersContext(headersContextFromRequest(request), async () => {
+      // 1. Prime the sealed snapshot — this is exactly what
+      //    `clerkMiddleware()` does internally via `buildRequestLike()`.
+      const preHeaders = await headers();
+      const preCookies = await cookies();
+      expect(preHeaders.get("authorization")).toBe("Bearer secret");
+      expect(preHeaders.get("x-keep")).toBe("original");
+      expect(preCookies.getAll()).toEqual([
+        { name: "a", value: "1" },
+        { name: "b", value: "2" },
+      ]);
+
+      // 2. Apply the override — drops `authorization`/`cookie`, adds `x-added`,
+      //    and updates `x-keep`.
+      applyMiddlewareRequestHeaders(
+        new Headers({
+          "x-middleware-override-headers": "x-keep,x-added",
+          "x-middleware-request-x-keep": "updated",
+          "x-middleware-request-x-added": "1",
+        }),
+      );
+
+      // 3. A subsequent `headers()` call — for example from the Server
+      //    Component's render — must observe the override, not the snapshot
+      //    captured in step 1.
+      const postHeaders = await headers();
+      const postCookies = await cookies();
+
+      expect(postHeaders.get("authorization")).toBeNull();
+      expect(postHeaders.get("cookie")).toBeNull();
+      expect(postHeaders.get("x-keep")).toBe("updated");
+      expect(postHeaders.get("x-added")).toBe("1");
+      expect(postCookies.getAll()).toEqual([]);
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`applyMiddlewareRequestHeaders()` rebuilds `ctx.headers` in place (and, when the cookie header changes, `ctx.cookies`), but does not invalidate the sealed read-only snapshots cached on the same `HeadersContext`. When a middleware reads `next/headers` → `headers()` (or `cookies()`) *before* returning a request-header override via `NextResponse.next({ request: { headers } })` or `NextResponse.rewrite(..., { request: { headers } })`, the sealed snapshot is built from the pre-override request, and every subsequent `headers()` / `cookies()` call from the Server Component render returns that stale view. Middleware-injected request headers are missing from the render, and middleware-deleted credential headers are still visible.

Any middleware using the common "read the request, then rewrite via \`NextResponse.next({ request: { headers } })\`" pattern is affected — authentication, logging/tracing, feature flagging, or any \`next/headers\`-aware pre-processing. The bug was discovered via \`@clerk/nextjs\`, whose \`clerkClient()\` reads \`headers()\` through its internal \`buildRequestLike()\` helper during middleware execution. Clerk's \`auth()\` in a Server Component then throws

> Clerk: auth() was called but Clerk can't detect usage of clerkMiddleware()

because Clerk's own \`x-clerk-auth-*\` request header overrides never reach the render pipeline. That same mechanism is what unblocks \`@clerk/nextjs\` from \`partial\` (#803) to \`supported\` in \`check.ts\` as a downstream consequence of this fix — a follow-up PR will update the compat status once this one releases.

## Root cause

\`_getReadonlyHeaders(ctx)\` caches \`ctx.readonlyHeaders = _sealHeaders(ctx.headers)\` on first access. When middleware reads \`headers()\` before returning, that cache is built from the original request headers. \`applyMiddlewareRequestHeaders()\` then replaces \`ctx.headers\` with the middleware-modified view, but the cached sealed snapshot is never invalidated. The Server Component's later \`headers()\` call returns the stale snapshot. The same race exists for \`ctx.readonlyCookies\` and \`ctx.mutableCookies\` when middleware mutates the cookie header.

Captured via \`dist/\` instrumentation against a production build of a minimal reproduction app (vinext@0.0.41 + @clerk/nextjs@7.0.12):

\`\`\`
Error: trace
    at _getReadonlyHeaders (dist/server/assets/headers-*.js:424)
    at headers              (dist/server/assets/headers-*.js:490)
    at buildRequestLike     (dist/server/index.js:1799)    // @clerk/nextjs
    at async clerkClient    (dist/server/index.js:2591)    // @clerk/nextjs
    at async _handleRequest (dist/server/index.js:8635)    // vinext RSC entry
\`\`\`

The stack trace confirms Clerk's middleware-phase \`headers()\` call primes the sealed snapshot before vinext's own \`applyMiddlewareRequestHeaders()\` replaces the underlying \`ctx.headers\`.

## Fix

\`applyMiddlewareRequestHeaders()\` now sets \`ctx.readonlyHeaders = undefined\` immediately after replacing \`ctx.headers\`, and clears \`ctx.readonlyCookies\` / \`ctx.mutableCookies\` in the cookie-rebuild branch. The next \`headers()\` / \`cookies()\` call rebuilds the sealed view from the post-override state.

## Tests

Two new regression tests, both verified to fail on \`main\` and pass with the fix:

- **Unit** — \`tests/shims.test.ts\`: drives \`headers()\` → \`applyMiddlewareRequestHeaders()\` → \`headers()\` directly and asserts the override view replaces the snapshot. Failure on \`main\`: \`expected 'Bearer secret' to be null\`.
- **Integration** — \`tests/app-router.test.ts\`, inside the existing \`App Router Production server (startProdServer)\` describe block. Uses the \`app-basic\` fixture to reproduce the bug end-to-end against the inline RSC entry that wraps middleware execution in the headers context. The fixture middleware calls \`await headers()\` first (mirroring Clerk's \`buildRequestLike()\` pattern) and then returns a \`NextResponse.next({ request: { headers } })\` override. The Server Component asserts the middleware-deleted credentials are null and the middleware-injected \`x-from-middleware\` is visible. Failure on \`main\`: rendered HTML contains \`id=\"authorization\">Bearer secret<\` and \`id=\"middleware-header\">null<\`.

The integration test lives in the production-server describe block rather than the dev-server describe block because the dev-mode middleware path runs middleware before the headers context exists, so calling \`headers()\` from middleware is instead an immediate error there. The bug only manifests on the inline RSC entry path that matches production Cloudflare Workers.

## Verified

With the fix applied:

| Check | Result |
|---|---|
| \`pnpm test:unit\` | **2813 / 2813** pass |
| \`pnpm test:integration\` | **1252 / 1252** pass (2 pre-existing skips) |
| \`pnpm run check\` (lint + format + types) | **0** warnings, **0** errors |
| \`pnpm test:e2e\` — \`app-router\` project | **302 / 302** pass |
| \`pnpm test:e2e\` — \`cloudflare-workers\` project (Miniflare) | **37 / 37** pass |

Both new tests were also run with the fix reverted on a clean tree to confirm they deterministically catch the regression.

End-to-end runtime verification against a real \`@clerk/nextjs@7.0.12\` instance on a production \`vinext build\` + \`vinext start\`:

- **Unauthenticated** \`/dashboard\` request returns 200; \`auth()\` returns \`{ userId: null, orgId: null, sessionId: null }\` without throwing, and all 9 \`x-clerk-auth-*\` request headers are visible via \`headers()\` in the Server Component.
- **Signed in** via Clerk's sign-in-token flow (admin API → Playwright handshake → session cookie): the Server Component's \`auth()\` returned the real \`userId\`, \`orgId\`, and \`sessionId\` from Clerk; \`currentUser()\` returned the real user object; \`headers()\` exposed all 21 request headers including a valid JWT in \`x-clerk-auth-token\`.

## References

- #803 — \`@clerk/nextjs\` compatibility marked \`partial\`
- #809 — parallel App Route request-object fix that uses the same \`applyMiddlewareRequestHeaders\` machinery (this PR covers the remaining RSC render-side gap: sealed-snapshot invalidation)
- #800 — original \`@clerk/nextjs\` compatibility tracking issue