### PR TITLE
fix: clear stale parallel slots on traversal in mergeElements

### DIFF
--- a/packages/vinext/src/shims/slot.tsx
+++ b/packages/vinext/src/shims/slot.tsx
@@ -32,6 +32,17 @@ export function mergeElements(prev: AppElements, next: AppElements): AppElements
       merged[key] = prev[key];
     }
   }
+  // On traversal (browser back/forward), the RSC response omits slots that are
+  // not part of the target route tree. A slot absent from next means the server
+  // considers it inactive, so clear it rather than keeping the stale prev value.
+  // This is distinct from the UNMATCHED_SLOT case above: the server emits
+  // UNMATCHED_SLOT for slots defined in the layout but not matched by the route;
+  // it omits a slot entirely when the route tree does not include it at all.
+  for (const key of Object.keys(merged)) {
+    if (key.startsWith("slot:") && !Object.hasOwn(next, key)) {
+      delete merged[key];
+    }
+  }
   return merged;
 }
 

--- a/tests/slot.test.ts
+++ b/tests/slot.test.ts
@@ -277,6 +277,28 @@ describe("slot primitives", () => {
     expect(merged["slot:modal:/"]).toBe(UNMATCHED_SLOT);
   });
 
+  it("mergeElements clears stale slots absent from next response", async () => {
+    const { mergeElements } = await import("../packages/vinext/src/shims/slot.js");
+
+    const merged = mergeElements(
+      {
+        "layout:/": React.createElement("div", null, "layout"),
+        "page:/feed": React.createElement("div", null, "feed"),
+        "slot:modal:/feed": React.createElement("div", null, "intercepted modal"),
+      },
+      {
+        "layout:/": React.createElement("div", null, "layout"),
+        "page:/feed": React.createElement("div", null, "feed"),
+        // slot:modal:/feed is absent: server's route tree does not include it
+      },
+    );
+
+    // A slot key absent from next means the route tree no longer includes it.
+    // This happens on browser back from an intercepted route. The stale modal
+    // must not survive the merge.
+    expect(Object.hasOwn(merged, "slot:modal:/feed")).toBe(false);
+  });
+
   it("Slot renders element from resolved context", async () => {
     const mod = await import("../packages/vinext/src/shims/slot.js");
 


### PR DESCRIPTION
## Summary

- `mergeElements` now deletes slot keys from `prev` that are absent from `next`, fixing stale parallel slots persisting through browser back/forward
- Adds unit test verifying the new behavior alongside existing UNMATCHED_SLOT preservation tests

## Context

When navigating back from an intercepted route (e.g., `/feed` -> photo modal -> back), the RSC response for `/feed` omits the `@modal` slot entirely. The spread `{ ...prev, ...next }` silently carried the stale modal forward. Now, a slot absent from `next` is treated as "not in the route tree" and cleared.

This is distinct from the existing `UNMATCHED_SLOT` case, where the server acknowledges the slot but no route matched it (preserved for soft navigation continuity).

Closes #814

## Test plan

- [x] Unit test: `mergeElements clears stale slots absent from next response`
- [x] Existing `mergeElements` tests still pass (UNMATCHED_SLOT preservation, shallow merge)
- [ ] E2E test for back/forward on intercepted routes (depends on #753 for test infrastructure, tracked separately)