### PR TITLE
fix: clear stale parallel slots on traversal in mergeElements

### DIFF
--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -453,7 +453,7 @@ function dispatchBrowserTree(
   elements: AppElements,
   navigationSnapshot: ClientNavigationRenderSnapshot,
   renderId: number,
-  actionType: "navigate" | "replace",
+  actionType: "navigate" | "replace" | "traverse",
   routeId: string,
   rootLayoutTreePath: string | null,
   useTransitionMode: boolean,
@@ -484,7 +484,7 @@ async function renderNavigationPayload(
   navId: number,
   prePaintEffect: (() => void) | null = null,
   useTransition = true,
-  actionType: "navigate" | "replace" = "navigate",
+  actionType: "navigate" | "replace" | "traverse" = "navigate",
 ): Promise<void> {
   const renderId = ++nextNavigationRenderId;
   const committed = new Promise<void>((resolve) => {
@@ -783,6 +783,7 @@ async function main(): Promise<void> {
             navId,
             createNavigationCommitEffect(href, historyUpdateMode, cachedParams),
             isSameRoute,
+            navigationKind === "traverse" ? "traverse" : "navigate",
           );
         } finally {
           // Always clear _snapshotPending so the outer catch does not
@@ -871,6 +872,7 @@ async function main(): Promise<void> {
           navId,
           createNavigationCommitEffect(href, historyUpdateMode, navParams),
           isSameRoute,
+          navigationKind === "traverse" ? "traverse" : "navigate",
         );
       } finally {
         // Always clear _snapshotPending after renderNavigationPayload returns or

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -75,6 +75,14 @@ type ServerActionResult = {
 };
 
 type NavigationKind = "navigate" | "traverse" | "refresh";
+
+// Maps NavigationKind to the AppRouterAction type used by the reducer.
+// "refresh" is intentionally treated as "navigate" (merge, preserve absent slots).
+// Both call sites must stay in sync — update here if NavigationKind gains new values.
+function toActionType(kind: NavigationKind): "navigate" | "traverse" {
+  return kind === "traverse" ? "traverse" : "navigate";
+}
+
 type HistoryUpdateMode = "push" | "replace";
 type VisitedResponseCacheEntry = {
   params: Record<string, string | string[]>;
@@ -783,7 +791,7 @@ async function main(): Promise<void> {
             navId,
             createNavigationCommitEffect(href, historyUpdateMode, cachedParams),
             isSameRoute,
-            navigationKind === "traverse" ? "traverse" : "navigate",
+            toActionType(navigationKind),
           );
         } finally {
           // Always clear _snapshotPending so the outer catch does not
@@ -872,7 +880,7 @@ async function main(): Promise<void> {
           navId,
           createNavigationCommitEffect(href, historyUpdateMode, navParams),
           isSameRoute,
-          navigationKind === "traverse" ? "traverse" : "navigate",
+          toActionType(navigationKind),
         );
       } finally {
         // Always clear _snapshotPending after renderNavigationPayload returns or

--- a/packages/vinext/src/server/app-browser-state.ts
+++ b/packages/vinext/src/server/app-browser-state.ts
@@ -16,7 +16,7 @@ export type AppRouterAction = {
   renderId: number;
   rootLayoutTreePath: string | null;
   routeId: string;
-  type: "navigate" | "replace";
+  type: "navigate" | "replace" | "traverse";
 };
 
 export type PendingNavigationCommit = {
@@ -36,6 +36,14 @@ export function routerReducer(state: AppRouterState, action: AppRouterAction): A
     case "navigate":
       return {
         elements: mergeElements(state.elements, action.elements),
+        navigationSnapshot: action.navigationSnapshot,
+        renderId: action.renderId,
+        rootLayoutTreePath: action.rootLayoutTreePath,
+        routeId: action.routeId,
+      };
+    case "traverse":
+      return {
+        elements: mergeElements(state.elements, action.elements, true),
         navigationSnapshot: action.navigationSnapshot,
         renderId: action.renderId,
         rootLayoutTreePath: action.rootLayoutTreePath,
@@ -92,7 +100,7 @@ export async function createPendingNavigationCommit(options: {
   nextElements: Promise<AppElements>;
   navigationSnapshot: ClientNavigationRenderSnapshot;
   renderId: number;
-  type: "navigate" | "replace";
+  type: "navigate" | "replace" | "traverse";
 }): Promise<PendingNavigationCommit> {
   const elements = await options.nextElements;
   const metadata = readAppElementsMetadata(elements);
@@ -118,7 +126,7 @@ export async function resolveAndClassifyNavigationCommit(options: {
   nextElements: Promise<AppElements>;
   renderId: number;
   startedNavigationId: number;
-  type: "navigate" | "replace";
+  type: "navigate" | "replace" | "traverse";
 }): Promise<ClassifiedPendingNavigationCommit> {
   const pending = await createPendingNavigationCommit({
     currentState: options.currentState,

--- a/packages/vinext/src/server/app-browser-state.ts
+++ b/packages/vinext/src/server/app-browser-state.ts
@@ -33,17 +33,10 @@ export type ClassifiedPendingNavigationCommit = {
 
 export function routerReducer(state: AppRouterState, action: AppRouterAction): AppRouterState {
   switch (action.type) {
+    case "traverse":
     case "navigate":
       return {
-        elements: mergeElements(state.elements, action.elements),
-        navigationSnapshot: action.navigationSnapshot,
-        renderId: action.renderId,
-        rootLayoutTreePath: action.rootLayoutTreePath,
-        routeId: action.routeId,
-      };
-    case "traverse":
-      return {
-        elements: mergeElements(state.elements, action.elements, true),
+        elements: mergeElements(state.elements, action.elements, action.type === "traverse"),
         navigationSnapshot: action.navigationSnapshot,
         renderId: action.renderId,
         rootLayoutTreePath: action.rootLayoutTreePath,

--- a/packages/vinext/src/server/app-elements.ts
+++ b/packages/vinext/src/server/app-elements.ts
@@ -6,7 +6,7 @@ export const APP_UNMATCHED_SLOT_WIRE_VALUE = "__VINEXT_UNMATCHED_SLOT__";
 
 export const UNMATCHED_SLOT = Symbol.for("vinext.unmatchedSlot");
 
-export type AppElementValue = ReactNode | typeof UNMATCHED_SLOT | string | null;
+export type AppElementValue = ReactNode | symbol | string | null;
 export type AppWireElementValue = ReactNode | string | null;
 
 export type AppElements = Readonly<Record<string, AppElementValue>>;

--- a/packages/vinext/src/server/app-elements.ts
+++ b/packages/vinext/src/server/app-elements.ts
@@ -6,7 +6,7 @@ export const APP_UNMATCHED_SLOT_WIRE_VALUE = "__VINEXT_UNMATCHED_SLOT__";
 
 export const UNMATCHED_SLOT = Symbol.for("vinext.unmatchedSlot");
 
-export type AppElementValue = ReactNode | symbol | string | null;
+export type AppElementValue = ReactNode | typeof UNMATCHED_SLOT | string | null;
 export type AppWireElementValue = ReactNode | string | null;
 
 export type AppElements = Readonly<Record<string, AppElementValue>>;

--- a/packages/vinext/src/shims/slot.tsx
+++ b/packages/vinext/src/shims/slot.tsx
@@ -22,7 +22,11 @@ export const ParallelSlotsContext = React.createContext<Readonly<
   Record<string, React.ReactNode>
 > | null>(null);
 
-export function mergeElements(prev: AppElements, next: AppElements): AppElements {
+export function mergeElements(
+  prev: AppElements,
+  next: AppElements,
+  clearAbsentSlots = false,
+): AppElements {
   const merged: Record<string, AppElementValue> = { ...prev, ...next };
   // On soft navigation, unmatched parallel slots preserve their previous subtree
   // instead of firing notFound(). Only hard navigation (full page load) should 404.
@@ -30,6 +34,18 @@ export function mergeElements(prev: AppElements, next: AppElements): AppElements
   for (const key of Object.keys(merged)) {
     if (key.startsWith("slot:") && merged[key] === UNMATCHED_SLOT && Object.hasOwn(prev, key)) {
       merged[key] = prev[key];
+    }
+  }
+  // On traversal (browser back/forward), the server renders the full destination
+  // route tree. A slot absent from next means the destination route tree does not
+  // include it, so clear it rather than keeping the stale prev value. This only
+  // runs for traversals because soft forward navigations may omit parent layout
+  // slots that should be preserved.
+  if (clearAbsentSlots) {
+    for (const key of Object.keys(merged)) {
+      if (key.startsWith("slot:") && !Object.hasOwn(next, key)) {
+        delete merged[key];
+      }
     }
   }
   return merged;

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -221,6 +221,46 @@ describe("app browser entry state helpers", () => {
     expect(shouldHardNavigate(null, "/")).toBe(false);
     expect(shouldHardNavigate("/", null)).toBe(false);
   });
+
+  it("clears stale parallel slots on traverse", () => {
+    const state = createState({
+      elements: createResolvedElements("route:/feed", "/", {
+        "slot:modal:/feed": React.createElement("div", null, "modal"),
+      }),
+    });
+    const nextElements = createResolvedElements("route:/feed", "/");
+
+    const nextState = routerReducer(state, {
+      elements: nextElements,
+      navigationSnapshot: createState().navigationSnapshot,
+      renderId: 1,
+      rootLayoutTreePath: "/",
+      routeId: "route:/feed",
+      type: "traverse",
+    });
+
+    expect(Object.hasOwn(nextState.elements, "slot:modal:/feed")).toBe(false);
+  });
+
+  it("preserves absent parallel slots on navigate", () => {
+    const state = createState({
+      elements: createResolvedElements("route:/feed", "/", {
+        "slot:modal:/feed": React.createElement("div", null, "modal"),
+      }),
+    });
+    const nextElements = createResolvedElements("route:/feed/comments", "/");
+
+    const nextState = routerReducer(state, {
+      elements: nextElements,
+      navigationSnapshot: createState().navigationSnapshot,
+      renderId: 1,
+      rootLayoutTreePath: "/",
+      routeId: "route:/feed/comments",
+      type: "navigate",
+    });
+
+    expect(Object.hasOwn(nextState.elements, "slot:modal:/feed")).toBe(true);
+  });
 });
 
 describe("mounted slot helpers", () => {

--- a/tests/slot.test.ts
+++ b/tests/slot.test.ts
@@ -309,6 +309,7 @@ describe("slot primitives", () => {
       {
         "layout:/": React.createElement("div", null, "layout"),
         "page:/feed": React.createElement("div", null, "feed"),
+        // @ts-expect-error - typescript is not correctly inferring the type of the symbol
         "slot:modal:/feed": UNMATCHED_SLOT,
       },
       true,

--- a/tests/slot.test.ts
+++ b/tests/slot.test.ts
@@ -296,6 +296,31 @@ describe("slot primitives", () => {
     expect(Object.hasOwn(merged, "slot:modal:/feed")).toBe(false);
   });
 
+  it("mergeElements on traversal: UNMATCHED_SLOT in next is restored from prev and not cleared", async () => {
+    const { mergeElements, UNMATCHED_SLOT } = await import("../packages/vinext/src/shims/slot.js");
+
+    const realContent = React.createElement("div", null, "modal content");
+    const merged = mergeElements(
+      {
+        "layout:/": React.createElement("div", null, "layout"),
+        "page:/feed": React.createElement("div", null, "feed"),
+        "slot:modal:/feed": realContent,
+      },
+      {
+        "layout:/": React.createElement("div", null, "layout"),
+        "page:/feed": React.createElement("div", null, "feed"),
+        "slot:modal:/feed": UNMATCHED_SLOT,
+      },
+      true,
+    );
+
+    // The slot IS present in next (as UNMATCHED_SLOT), so clearAbsentSlots does not
+    // delete it. The UNMATCHED_SLOT preservation loop then restores the real prev
+    // content because prev had a non-sentinel value.
+    expect(Object.hasOwn(merged, "slot:modal:/feed")).toBe(true);
+    expect(merged["slot:modal:/feed"]).toBe(realContent);
+  });
+
   it("mergeElements preserves absent slots when clearAbsentSlots is not set", async () => {
     const { mergeElements } = await import("../packages/vinext/src/shims/slot.js");
 

--- a/tests/slot.test.ts
+++ b/tests/slot.test.ts
@@ -277,6 +277,43 @@ describe("slot primitives", () => {
     expect(merged["slot:modal:/"]).toBe(UNMATCHED_SLOT);
   });
 
+  it("mergeElements clears stale slots absent from next when clearAbsentSlots is set", async () => {
+    const { mergeElements } = await import("../packages/vinext/src/shims/slot.js");
+
+    const merged = mergeElements(
+      {
+        "layout:/": React.createElement("div", null, "layout"),
+        "page:/feed": React.createElement("div", null, "feed"),
+        "slot:modal:/feed": React.createElement("div", null, "intercepted modal"),
+      },
+      {
+        "layout:/": React.createElement("div", null, "layout"),
+        "page:/feed": React.createElement("div", null, "feed"),
+      },
+      true,
+    );
+
+    expect(Object.hasOwn(merged, "slot:modal:/feed")).toBe(false);
+  });
+
+  it("mergeElements preserves absent slots when clearAbsentSlots is not set", async () => {
+    const { mergeElements } = await import("../packages/vinext/src/shims/slot.js");
+
+    const merged = mergeElements(
+      {
+        "layout:/": React.createElement("div", null, "layout"),
+        "page:/dashboard": React.createElement("div", null, "dashboard"),
+        "slot:team:/dashboard": React.createElement("div", null, "team panel"),
+      },
+      {
+        "page:/dashboard/settings": React.createElement("div", null, "settings"),
+      },
+    );
+
+    // Without clearAbsentSlots, absent slots survive (soft nav to child route)
+    expect(Object.hasOwn(merged, "slot:team:/dashboard")).toBe(true);
+  });
+
   it("Slot renders element from resolved context", async () => {
     const mod = await import("../packages/vinext/src/shims/slot.js");
 


### PR DESCRIPTION
## Summary

- Adds `"traverse"` as a first-class action type in the router reducer, distinct from `"navigate"` and `"replace"`
- `mergeElements` gains a `clearAbsentSlots` flag (default false) that removes slot keys present in `prev` but absent from `next`
- The traverse action type sets this flag, clearing stale parallel slots on browser back/forward
- Soft forward navigations continue to preserve absent slots (unchanged behavior)

## Context

When navigating back from an intercepted route (e.g., `/feed` with photo modal -> browser back), the RSC response for the destination omits the `@modal` slot. Previously, `mergeElements` carried the stale modal forward from `prev` via `{ ...prev, ...next }`.

The fix cannot simply clear all absent slots because soft forward navigation (e.g., `/dashboard` -> `/dashboard/settings`) intentionally omits parent layout slots that haven't changed. Those must be preserved.

The solution: thread the navigation kind through the action type. Browser back/forward dispatches `"traverse"` instead of `"navigate"`, which tells `mergeElements` to clear absent slots.

Closes #814

## Test plan

- [x] Unit test: `mergeElements clears stale slots absent from next when clearAbsentSlots is set`
- [x] Unit test: `mergeElements preserves absent slots when clearAbsentSlots is not set`
- [x] Existing `mergeElements` tests pass (UNMATCHED_SLOT preservation, shallow merge)
- [ ] E2E: `parallel slot content persists on soft navigation to child route` (existing, should still pass in CI)
- [ ] E2E: back/forward on intercepted routes (depends on #753 fixtures, tracked separately)