### PR TITLE
fix: apply middleware request-header overrides before App->Pages fallback

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -31,6 +31,10 @@ import { isProxyFile } from "../server/middleware.js";
 // resolve these at code-generation time and embed them as absolute paths.
 const configMatchersPath = resolveEntryPath("../config/config-matchers.js", import.meta.url);
 const requestPipelinePath = resolveEntryPath("../server/request-pipeline.js", import.meta.url);
+const middlewareRequestHeadersPath = resolveEntryPath(
+  "../server/middleware-request-headers.js",
+  import.meta.url,
+);
 const requestContextShimPath = resolveEntryPath("../shims/request-context.js", import.meta.url);
 const normalizePathModulePath = resolveEntryPath("../server/normalize-path.js", import.meta.url);
 const appRouteHandlerRuntimePath = resolveEntryPath(
@@ -359,6 +363,7 @@ ${instrumentationPath ? `import * as _instrumentation from ${JSON.stringify(inst
 ${effectiveMetaRoutes.length > 0 ? `import { sitemapToXml, robotsToText, manifestToJson } from ${JSON.stringify(metadataRoutesPath)};` : ""}
 import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, matchHeaders, isExternalUrl, proxyExternalRequest, sanitizeDestination } from ${JSON.stringify(configMatchersPath)};
 import { decodePathParams as __decodePathParams } from ${JSON.stringify(normalizePathModulePath)};
+import { buildRequestHeadersFromMiddlewareResponse as __buildRequestHeadersFromMiddlewareResponse } from ${JSON.stringify(middlewareRequestHeadersPath)};
 import { validateCsrfOrigin, validateServerActionPayload, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash, processMiddlewareHeaders } from ${JSON.stringify(requestPipelinePath)};
 import {
   isKnownDynamicAppRoute as __isKnownDynamicAppRoute,
@@ -1910,12 +1915,24 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     if (!isRscRequest) {
       const __pagesEntry = await import.meta.viteRsc.loadModule("ssr", "index");
       if (typeof __pagesEntry.renderPage === "function") {
+        const __pagesRequestHeaders = _mwCtx.requestHeaders
+          ? __buildRequestHeadersFromMiddlewareResponse(request.headers, _mwCtx.requestHeaders)
+          : null;
+        const __pagesRequest = __pagesRequestHeaders
+          ? new Request(request.url, { method: request.method, headers: __pagesRequestHeaders })
+          : request;
         // Use segment-wise decoding to preserve encoded path delimiters (%2F).
         // decodeURIComponent would turn /admin%2Fpanel into /admin/panel,
         // changing the path structure and bypassing middleware matchers.
         // Ported from Next.js: packages/next/src/server/lib/router-utils/decode-path-params.ts
         // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/router-utils/decode-path-params.ts
-        const __pagesRes = await __pagesEntry.renderPage(request, __decodePathParams(url.pathname) + (url.search || ""), {});
+        const __pagesRes = await __pagesEntry.renderPage(
+          __pagesRequest,
+          __decodePathParams(url.pathname) + (url.search || ""),
+          {},
+          undefined,
+          _mwCtx.requestHeaders,
+        );
         // Only return the Pages Router response if it matched a route
         // (non-404). A 404 means the path isn't a Pages route either,
         // so fall through to the App Router not-found page below.

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -51,6 +51,7 @@ import { mergeMetadata, resolveModuleMetadata, mergeViewport, resolveModuleViewp
 
 import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, matchHeaders, isExternalUrl, proxyExternalRequest, sanitizeDestination } from "<ROOT>/packages/vinext/src/config/config-matchers.js";
 import { decodePathParams as __decodePathParams } from "<ROOT>/packages/vinext/src/server/normalize-path.js";
+import { buildRequestHeadersFromMiddlewareResponse as __buildRequestHeadersFromMiddlewareResponse } from "<ROOT>/packages/vinext/src/server/middleware-request-headers.js";
 import { validateCsrfOrigin, validateServerActionPayload, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash, processMiddlewareHeaders } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
 import {
   isKnownDynamicAppRoute as __isKnownDynamicAppRoute,
@@ -2224,6 +2225,7 @@ import { mergeMetadata, resolveModuleMetadata, mergeViewport, resolveModuleViewp
 
 import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, matchHeaders, isExternalUrl, proxyExternalRequest, sanitizeDestination } from "<ROOT>/packages/vinext/src/config/config-matchers.js";
 import { decodePathParams as __decodePathParams } from "<ROOT>/packages/vinext/src/server/normalize-path.js";
+import { buildRequestHeadersFromMiddlewareResponse as __buildRequestHeadersFromMiddlewareResponse } from "<ROOT>/packages/vinext/src/server/middleware-request-headers.js";
 import { validateCsrfOrigin, validateServerActionPayload, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash, processMiddlewareHeaders } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
 import {
   isKnownDynamicAppRoute as __isKnownDynamicAppRoute,
@@ -4403,6 +4405,7 @@ import { mergeMetadata, resolveModuleMetadata, mergeViewport, resolveModuleViewp
 
 import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, matchHeaders, isExternalUrl, proxyExternalRequest, sanitizeDestination } from "<ROOT>/packages/vinext/src/config/config-matchers.js";
 import { decodePathParams as __decodePathParams } from "<ROOT>/packages/vinext/src/server/normalize-path.js";
+import { buildRequestHeadersFromMiddlewareResponse as __buildRequestHeadersFromMiddlewareResponse } from "<ROOT>/packages/vinext/src/server/middleware-request-headers.js";
 import { validateCsrfOrigin, validateServerActionPayload, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash, processMiddlewareHeaders } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
 import {
   isKnownDynamicAppRoute as __isKnownDynamicAppRoute,
@@ -6577,6 +6580,7 @@ import * as _instrumentation from "/tmp/test/instrumentation.ts";
 
 import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, matchHeaders, isExternalUrl, proxyExternalRequest, sanitizeDestination } from "<ROOT>/packages/vinext/src/config/config-matchers.js";
 import { decodePathParams as __decodePathParams } from "<ROOT>/packages/vinext/src/server/normalize-path.js";
+import { buildRequestHeadersFromMiddlewareResponse as __buildRequestHeadersFromMiddlewareResponse } from "<ROOT>/packages/vinext/src/server/middleware-request-headers.js";
 import { validateCsrfOrigin, validateServerActionPayload, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash, processMiddlewareHeaders } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
 import {
   isKnownDynamicAppRoute as __isKnownDynamicAppRoute,
@@ -8783,6 +8787,7 @@ import { mergeMetadata, resolveModuleMetadata, mergeViewport, resolveModuleViewp
 import { sitemapToXml, robotsToText, manifestToJson } from "<ROOT>/packages/vinext/src/server/metadata-routes.js";
 import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, matchHeaders, isExternalUrl, proxyExternalRequest, sanitizeDestination } from "<ROOT>/packages/vinext/src/config/config-matchers.js";
 import { decodePathParams as __decodePathParams } from "<ROOT>/packages/vinext/src/server/normalize-path.js";
+import { buildRequestHeadersFromMiddlewareResponse as __buildRequestHeadersFromMiddlewareResponse } from "<ROOT>/packages/vinext/src/server/middleware-request-headers.js";
 import { validateCsrfOrigin, validateServerActionPayload, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash, processMiddlewareHeaders } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
 import {
   isKnownDynamicAppRoute as __isKnownDynamicAppRoute,
@@ -10963,6 +10968,7 @@ import * as middlewareModule from "/tmp/test/middleware.ts";
 
 import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, matchHeaders, isExternalUrl, proxyExternalRequest, sanitizeDestination } from "<ROOT>/packages/vinext/src/config/config-matchers.js";
 import { decodePathParams as __decodePathParams } from "<ROOT>/packages/vinext/src/server/normalize-path.js";
+import { buildRequestHeadersFromMiddlewareResponse as __buildRequestHeadersFromMiddlewareResponse } from "<ROOT>/packages/vinext/src/server/middleware-request-headers.js";
 import { validateCsrfOrigin, validateServerActionPayload, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash, processMiddlewareHeaders } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
 import {
   isKnownDynamicAppRoute as __isKnownDynamicAppRoute,

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -2115,6 +2115,25 @@ describe("App Router Production server (startProdServer)", () => {
     expect(res2.headers.get("x-vinext-cache")).toBeNull();
   });
 
+  it("route handler ISR: cached HIT responses do not replay Set-Cookie headers", async () => {
+    const res1 = await fetch(`${baseUrl}/api/static-set-cookie`);
+    expect(res1.status).toBe(200);
+    expect(res1.headers.get("x-vinext-cache")).toBe("MISS");
+    const missSetCookies = res1.headers.getSetCookie();
+    expect(missSetCookies.length).toBeGreaterThan(0);
+    expect(missSetCookies[0]).toContain("session=");
+
+    const body1 = await res1.json();
+
+    const res2 = await fetch(`${baseUrl}/api/static-set-cookie`);
+    expect(res2.status).toBe(200);
+    expect(res2.headers.get("x-vinext-cache")).toBe("HIT");
+    expect(res2.headers.getSetCookie()).toEqual([]);
+
+    const body2 = await res2.json();
+    expect(body2.timestamp).toBe(body1.timestamp);
+  });
+
   it("route handler ISR: STALE serves stale data and triggers background regen", async () => {
     // /api/static-data has revalidate=1
     // Cache may already be warm from earlier tests — ensure we have a known timestamp


### PR DESCRIPTION
## Summary

In mixed App+Pages projects, the App Router production fallback now rebuilds the request from middleware request-header overrides before delegating to Pages SSR.

## Details

Middleware request-header overrides were already applied to:
- App page rendering
- App Route handlers

But the App Router production fallback still delegated to `renderPage()` with the original `Request` object. That meant a Pages route reached via App->Pages fallback could still see the original `Authorization` / `Cookie` headers in `getServerSideProps`, even when middleware had deleted them and injected trusted replacement headers.

This change:
- rebuilds the fallback request with `buildRequestHeadersFromMiddlewareResponse()` using the preserved middleware request-header payload
- passes that rebuilt request into `renderPage()`
- keeps passing the preserved middleware header payload into the existing `middlewareHeaders` parameter

## Tests

Adds a production-only regression test verifying that `/pages-header-override-delete` in a mixed App+Pages project sees:
- `authorization: null`
- `cookie: null`
- `x-from-middleware: hello-from-middleware`

before `getServerSideProps` runs.