### PR TITLE
fix: emit served URLs for next/font/google self-hosted assets

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -77,6 +77,7 @@ import {
   createLocalFontsPlugin,
   _findBalancedObject,
   _findCallEnd,
+  _rewriteCachedFontCssToServedUrls,
 } from "./plugins/fonts.js";
 import { hasWranglerConfig, formatMissingCloudflarePluginError } from "./deploy.js";
 import { computeLazyChunks } from "./utils/lazy-chunks.js";
@@ -4205,6 +4206,6 @@ export { hasMdxFiles as _hasMdxFiles };
 export { _mdxScanCache };
 export { scanPublicFileRoutes as _scanPublicFileRoutes };
 export { parseStaticObjectLiteral as _parseStaticObjectLiteral };
-export { _findBalancedObject, _findCallEnd };
+export { _findBalancedObject, _findCallEnd, _rewriteCachedFontCssToServedUrls };
 export { stripServerExports as _stripServerExports };
 export { asyncHooksStubPlugin as _asyncHooksStubPlugin };

--- a/packages/vinext/src/plugins/fonts.ts
+++ b/packages/vinext/src/plugins/fonts.ts
@@ -80,21 +80,37 @@ export const VINEXT_FONT_URL_NAMESPACE = "_vinext_fonts";
  * (e.g. `/home/user/project/.vinext/fonts/geist-<hash>/geist-<hash>.woff2`)
  * and any production request fetches `<origin>/home/user/...` → 404.
  *
+ * `assetsDir` must match whatever Vite has resolved for
+ * `build.assetsDir` on the client environment — otherwise the embedded
+ * CSS URLs and the files emitted by the `writeBundle` hook would diverge
+ * and a user who customizes `build.assetsDir` (e.g. to `"static"`) would
+ * see 404s on every preload. The call site in `injectSelfHostedCss`
+ * passes the resolved value through from plugin state. The default is
+ * kept only so the exported helper can be driven directly from unit
+ * tests without synthesizing a full plugin context.
+ *
  * Uses split/join rather than regex because `cacheDir` is an absolute
  * filesystem path that may contain regex metacharacters on unusual
  * filesystems.
  */
-export function _rewriteCachedFontCssToServedUrls(css: string, cacheDir: string): string {
+export function _rewriteCachedFontCssToServedUrls(
+  css: string,
+  cacheDir: string,
+  assetsDir: string = DEFAULT_ASSETS_DIR,
+): string {
   if (!cacheDir || !css.includes(cacheDir)) return css;
-  return css.split(cacheDir).join(`/${DEFAULT_ASSETS_DIR}/${VINEXT_FONT_URL_NAMESPACE}`);
+  const prefix = assetsDir || DEFAULT_ASSETS_DIR;
+  return css.split(cacheDir).join(`/${prefix}/${VINEXT_FONT_URL_NAMESPACE}`);
 }
 
 /**
- * Default Vite `build.assetsDir` — mirrors Vite's own default. Used to
- * build the served URL prefix in `_rewriteCachedFontCssToServedUrls` so
- * the constant does not depend on plugin state. The matching `writeBundle`
- * hook reads the real `envConfig.build.assetsDir` from Vite and will
- * fall back to this value when it is unset.
+ * Default Vite `build.assetsDir` — mirrors Vite's own default. Used as
+ * the fallback for the `assetsDir` parameter of
+ * `_rewriteCachedFontCssToServedUrls` so the exported helper can be unit
+ * tested without synthesizing plugin state. Production call sites thread
+ * the real `envConfig.build.assetsDir` resolved by Vite through so that
+ * the embedded CSS URLs always match the directory the `writeBundle`
+ * hook copies the font files into.
  */
 const DEFAULT_ASSETS_DIR = "assets";
 
@@ -610,6 +626,14 @@ export function createGoogleFontsPlugin(fontGoogleShimPath: string, shimsDir: st
         if (!code.includes("next/font/google")) return null;
         if (id.startsWith(shimsDir)) return null;
 
+        // Read the resolved `build.assetsDir` from the current Vite
+        // environment so it can be closed over by the inner
+        // `injectSelfHostedCss` helper (a plain function declaration
+        // where `this` is untyped). Captured at the top of the hook so
+        // a single handler invocation always threads one consistent
+        // value through every font-loader call site it rewrites.
+        const transformAssetsDir = this.environment?.config?.build?.assetsDir ?? DEFAULT_ASSETS_DIR;
+
         const s = new MagicString(code);
         let hasChanges = false;
         let proxyImportCounter = 0;
@@ -771,7 +795,20 @@ export function createGoogleFontsPlugin(fontGoogleShimPath: string, shimsDir: st
           // the browser can actually resolve. The plugin's writeBundle hook
           // copies the referenced font files to the matching location under
           // the client output directory so the URLs serve 200s, not 404s.
-          const servedCSS = _rewriteCachedFontCssToServedUrls(localCSS, cacheDir);
+          //
+          // `transformAssetsDir` is captured at the top of the outer
+          // transform handler (where `this.environment` is bound by
+          // Rollup to the plugin context) and closed over here. This
+          // keeps the embedded URL prefix in lockstep with the directory
+          // the writeBundle hook copies files into, so a user who
+          // customizes `build.assetsDir` (e.g. to `"static"`) sees both
+          // the CSS and the copy target move together — otherwise the
+          // rewritten URLs would 404 in production.
+          const servedCSS = _rewriteCachedFontCssToServedUrls(
+            localCSS,
+            cacheDir,
+            transformAssetsDir,
+          );
 
           // Inject _selfHostedCSS into the options object
           const escapedCSS = JSON.stringify(servedCSS);
@@ -879,12 +916,27 @@ export function createGoogleFontsPlugin(fontGoogleShimPath: string, shimsDir: st
       handler(outputOptions: { dir?: string }) {
         // Only copy on the client build — the server/SSR environments
         // don't serve static assets.
+        //
+        // Optional chaining on `this.environment` matches the convention
+        // used by the other build-time plugins in `src/index.ts` (the
+        // `vinext:precompress` and `vinext:cloudflare-build` plugins both
+        // guard on `this.environment?.name !== "client"`). Vite 6+ always
+        // populates `this.environment` inside writeBundle, but keeping
+        // the guard makes the hook safely no-op if the code is ever
+        // executed in a context where Rollup invokes it without a bound
+        // environment (e.g. a thin unit test harness that invokes the
+        // hook directly). Concretely: under normal Vite builds this
+        // always resolves, the early-return is never taken.
         if (this.environment?.name !== "client") return;
         if (!cacheDir || !fs.existsSync(cacheDir)) return;
         const outDir = outputOptions.dir;
         if (!outDir) return;
 
-        const assetsDir = this.environment?.config?.build?.assetsDir ?? DEFAULT_ASSETS_DIR;
+        // Read the resolved `build.assetsDir` from the same environment
+        // that the transform-time rewrite read it from, so the embedded
+        // URL prefix and the physical copy location cannot diverge even
+        // if a user customizes `build.assetsDir`.
+        const assetsDir = this.environment.config?.build?.assetsDir ?? DEFAULT_ASSETS_DIR;
         const targetRoot = path.join(outDir, assetsDir, VINEXT_FONT_URL_NAMESPACE);
 
         // Recursive copy of every cached font file. Skip the companion

--- a/packages/vinext/src/plugins/fonts.ts
+++ b/packages/vinext/src/plugins/fonts.ts
@@ -45,6 +45,59 @@ export const GOOGLE_FONT_UTILITY_EXPORTS = new Set([
   "createFontLoader",
 ]);
 
+/**
+ * Served URL prefix for self-hosted Google Font files.
+ *
+ * `fetchAndCacheFont()` downloads .woff2 files into `<root>/.vinext/fonts/`
+ * and writes an `@font-face` CSS snippet whose `src: url(...)` references
+ * the files by absolute filesystem path — convenient for disk, unusable at
+ * runtime because browsers resolve relative to the origin. Before the CSS
+ * is embedded in the bundle as `_selfHostedCSS`, the filesystem prefix is
+ * rewritten to this URL prefix by `_rewriteCachedFontCssToServedUrls()`,
+ * and the matching `writeBundle` hook in `createGoogleFontsPlugin` copies
+ * the font files into `<clientOutDir>/<assetsDir>/_vinext_fonts/` so the
+ * rewritten URL actually resolves against the origin at request time.
+ *
+ * The leading `_` keeps the namespace distinct from Vite's content-hashed
+ * asset names (which are emitted flat into `<assetsDir>/`) and from any
+ * user-provided public files.
+ */
+export const VINEXT_FONT_URL_NAMESPACE = "_vinext_fonts";
+
+/**
+ * Rewrite absolute filesystem paths in cached Google Fonts CSS so the
+ * `@font-face { src: url(...) }` references point at the served URL the
+ * plugin's `writeBundle` hook copies the font files to.
+ *
+ * This is called once per transform, before the CSS string is embedded in
+ * the bundle as `_selfHostedCSS`. Every downstream consumer reads from the
+ * same rewritten CSS: the injected `<style data-vinext-fonts>` block, the
+ * HTML body's `<link rel="preload">` tags (via `collectFontPreloadsFromCSS`
+ * in `shims/font-google-base.ts`), and the HTTP `Link:` response header
+ * (via `buildAppPageFontLinkHeader` in `server/app-page-execution.ts`).
+ *
+ * Without this rewrite, all three emit the dev-machine filesystem path
+ * (e.g. `/home/user/project/.vinext/fonts/geist-<hash>/geist-<hash>.woff2`)
+ * and any production request fetches `<origin>/home/user/...` → 404.
+ *
+ * Uses split/join rather than regex because `cacheDir` is an absolute
+ * filesystem path that may contain regex metacharacters on unusual
+ * filesystems.
+ */
+export function _rewriteCachedFontCssToServedUrls(css: string, cacheDir: string): string {
+  if (!cacheDir || !css.includes(cacheDir)) return css;
+  return css.split(cacheDir).join(`/${DEFAULT_ASSETS_DIR}/${VINEXT_FONT_URL_NAMESPACE}`);
+}
+
+/**
+ * Default Vite `build.assetsDir` — mirrors Vite's own default. Used to
+ * build the served URL prefix in `_rewriteCachedFontCssToServedUrls` so
+ * the constant does not depend on plugin state. The matching `writeBundle`
+ * hook reads the real `envConfig.build.assetsDir` from Vite and will
+ * fall back to this value when it is unset.
+ */
+const DEFAULT_ASSETS_DIR = "assets";
+
 // ── Types ─────────────────────────────────────────────────────────────────────
 
 type GoogleFontNamedSpecifier = {
@@ -712,8 +765,16 @@ export function createGoogleFontsPlugin(fontGoogleShimPath: string, shimsDir: st
             }
           }
 
+          // Rewrite absolute `.vinext/fonts/` filesystem paths in the cached
+          // CSS to served URLs under `/<assetsDir>/_vinext_fonts/` so the
+          // embedded `_selfHostedCSS` string has origin-relative URLs that
+          // the browser can actually resolve. The plugin's writeBundle hook
+          // copies the referenced font files to the matching location under
+          // the client output directory so the URLs serve 200s, not 404s.
+          const servedCSS = _rewriteCachedFontCssToServedUrls(localCSS, cacheDir);
+
           // Inject _selfHostedCSS into the options object
-          const escapedCSS = JSON.stringify(localCSS);
+          const escapedCSS = JSON.stringify(servedCSS);
           const closingBrace = optionsStr.lastIndexOf("}");
           const beforeBrace = optionsStr.slice(0, closingBrace).trim();
           // Determine the separator to insert before the new property:
@@ -802,6 +863,50 @@ export function createGoogleFontsPlugin(fontGoogleShimPath: string, shimsDir: st
           code: s.toString(),
           map: s.generateMap({ hires: "boundary" }),
         };
+      },
+    },
+
+    // Copy cached Google Font files into the client output so the served
+    // URLs produced by `_rewriteCachedFontCssToServedUrls` resolve against
+    // the origin. Runs once, at the end of the client environment's build.
+    //
+    // `fetchAndCacheFont` downloads files into `<root>/.vinext/fonts/` and
+    // leaves them there — nothing else copies them. Without this hook, the
+    // rewritten `/assets/_vinext_fonts/...` URLs would 404 in production.
+    writeBundle: {
+      sequential: true,
+      order: "post" as const,
+      handler(outputOptions: { dir?: string }) {
+        // Only copy on the client build — the server/SSR environments
+        // don't serve static assets.
+        if (this.environment?.name !== "client") return;
+        if (!cacheDir || !fs.existsSync(cacheDir)) return;
+        const outDir = outputOptions.dir;
+        if (!outDir) return;
+
+        const assetsDir = this.environment?.config?.build?.assetsDir ?? DEFAULT_ASSETS_DIR;
+        const targetRoot = path.join(outDir, assetsDir, VINEXT_FONT_URL_NAMESPACE);
+
+        // Recursive copy of every cached font file. Skip the companion
+        // `style.css` artifact — that is only read by the build plugin
+        // itself, never served at runtime.
+        const stack: string[] = [cacheDir];
+        while (stack.length > 0) {
+          const dir = stack.pop();
+          if (!dir) continue;
+          for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+            const src = path.join(dir, entry.name);
+            if (entry.isDirectory()) {
+              stack.push(src);
+              continue;
+            }
+            if (!/\.(woff2?|ttf|otf|eot)$/i.test(entry.name)) continue;
+            const relative = path.relative(cacheDir, src);
+            const dest = path.join(targetRoot, relative);
+            fs.mkdirSync(path.dirname(dest), { recursive: true });
+            fs.copyFileSync(src, dest);
+          }
+        }
       },
     },
   } satisfies Plugin;

--- a/packages/vinext/src/plugins/fonts.ts
+++ b/packages/vinext/src/plugins/fonts.ts
@@ -441,7 +441,19 @@ async function fetchAndCacheFont(
         fs.writeFileSync(filePath, buffer);
       }
     }
-    // Rewrite CSS to use absolute path (Vite will resolve /@fs/ for dev, or asset for build)
+    // Rewrite every remote Google Fonts CDN URL in the cached CSS to the
+    // absolute filesystem path of the locally-downloaded font file. This
+    // cache file is read back by the plugin and then run through
+    // `_rewriteCachedFontCssToServedUrls()` at embed time, which replaces
+    // the absolute `cacheDir` prefix with the served URL namespace under
+    // `/<assetsDir>/_vinext_fonts/`. The filesystem path is only the
+    // on-disk intermediate form — it must never reach the bundle, the
+    // injected `<style data-vinext-fonts>` block, the HTML `<link
+    // rel="preload">` tags, or the HTTP `Link:` response header. An
+    // earlier version of this code claimed "Vite will resolve /@fs/ for
+    // dev, or asset for build", which was never true: the CSS is
+    // embedded as a JavaScript string literal and Vite's asset pipeline
+    // does not scan string literals. Do not resurrect that assumption.
     css = css.split(fontUrl).join(filePath);
   }
 

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -2297,6 +2297,182 @@ export default {
   });
 });
 
+describe("App Router Production server self-hosted next/font/google headers", () => {
+  // Regression for a bug where vinext's `next/font/google` self-hosting
+  // pipeline emitted the dev-machine absolute filesystem path into the
+  // HTTP `Link:` response header, the HTML body's `<link rel="preload">`
+  // tags, and the `<style data-vinext-fonts>` `@font-face src: url(...)`
+  // block. `fetchAndCacheFont` in `packages/vinext/src/plugins/fonts.ts`
+  // downloaded Google Fonts `.woff2` files into `<root>/.vinext/fonts/`
+  // and wrote `path.join(fontDir, filename)` — an absolute filesystem
+  // path — into the cached `@font-face` CSS's `src: url(...)`. The CSS
+  // was then embedded verbatim as `_selfHostedCSS` in the server bundle
+  // and every downstream consumer (the body preload tags, the Link
+  // response header, and the injected style block) read the same
+  // leaked filesystem path. In production this produced high-priority
+  // 404s (`<origin>/home/user/project/.vinext/fonts/...`) on every
+  // request and fell back to the real font only via the browser's
+  // unrelated runtime retry of the stylesheet CDN.
+  //
+  // The fix uses a separate fixture (`tests/fixtures/font-google-multiple`)
+  // rather than `app-basic` because `app-basic` is shared by many other
+  // tests — adding `next/font/google` to its root layout would force a
+  // real Google Fonts network fetch into every test run in this file.
+  // The mocked fetch below stands in for the Google Fonts CDN so the
+  // build is hermetic.
+  const FONT_FIXTURE_DIR = path.resolve(import.meta.dirname, "./fixtures/font-google-multiple");
+  const fontOutDir = path.resolve(FONT_FIXTURE_DIR, "dist");
+  const fontCacheDir = path.resolve(FONT_FIXTURE_DIR, ".vinext");
+  const nodeModulesLink = path.join(FONT_FIXTURE_DIR, "node_modules");
+  let fontServer: import("node:http").Server | undefined;
+  let fontBaseUrl: string;
+
+  beforeAll(async () => {
+    // Start from a clean slate so the test deterministically exercises
+    // `fetchAndCacheFont`'s fresh-fetch path and the writeBundle copy.
+    fs.rmSync(fontOutDir, { recursive: true, force: true });
+    fs.rmSync(fontCacheDir, { recursive: true, force: true });
+
+    // The font fixture has no installed node_modules of its own — mirror
+    // `font-google-build.test.ts` and symlink the repo-level node_modules
+    // so `vinext` resolves as a workspace package during the in-process
+    // build below.
+    const projectNodeModules = path.resolve(import.meta.dirname, "../node_modules");
+    fs.rmSync(nodeModulesLink, { recursive: true, force: true });
+    fs.symlinkSync(projectNodeModules, nodeModulesLink);
+
+    // Mock the Google Fonts CDN so the build is hermetic and
+    // `fetchAndCacheFont` exercises its real URL-rewrite code path
+    // (which used to bake the filesystem path into the cached CSS).
+    // The mocked CSS MUST contain `https://fonts.gstatic.com/...` URLs
+    // so `fetchAndCacheFont`'s regex extracts them and triggers the
+    // `css.split(fontUrl).join(filePath)` rewrite that was the source
+    // of the bug. Returning CSS with already-relative URLs would sidestep
+    // the failure mode.
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (input: unknown) => {
+      const url = typeof input === "string" ? input : String(input);
+      if (url.includes("fonts.googleapis.com")) {
+        const isMono = url.includes("Geist+Mono") || url.includes("Geist%20Mono");
+        const family = isMono ? "Geist Mono" : "Geist";
+        const gstaticUrl = `https://fonts.gstatic.com/s/${isMono ? "geistmono" : "geist"}/v1/${isMono ? "geistmono" : "geist"}-latin.woff2`;
+        const css = [
+          "@font-face {",
+          `  font-family: '${family}';`,
+          "  font-style: normal;",
+          "  font-weight: 400;",
+          "  font-display: swap;",
+          `  src: url(${gstaticUrl}) format('woff2');`,
+          "  unicode-range: U+0000-00FF;",
+          "}",
+        ].join("\n");
+        return new Response(css, {
+          status: 200,
+          headers: { "content-type": "text/css" },
+        });
+      }
+      if (url.includes("fonts.gstatic.com")) {
+        // 16 bytes is plenty — the plugin writes whatever it gets to disk
+        // under `.vinext/fonts/<family>/<hash>.woff2`. The test never reads
+        // the contents back, it only asserts the file exists and serves
+        // with the right content-type.
+        return new Response(
+          new Uint8Array([0x77, 0x4f, 0x46, 0x32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+          { status: 200, headers: { "content-type": "font/woff2" } },
+        );
+      }
+      return originalFetch(input as RequestInfo);
+    };
+
+    try {
+      const builder = await createBuilder({
+        root: FONT_FIXTURE_DIR,
+        configFile: false,
+        plugins: [vinext({ appDir: FONT_FIXTURE_DIR })],
+        logLevel: "silent",
+      });
+      await builder.buildApp();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    const { startProdServer } = await import("../packages/vinext/src/server/prod-server.js");
+    ({ server: fontServer } = await startProdServer({
+      port: 0,
+      outDir: fontOutDir,
+      noCompression: true,
+    }));
+    const addr = fontServer!.address();
+    const port = typeof addr === "object" && addr ? addr.port : 4212;
+    fontBaseUrl = `http://localhost:${port}`;
+  }, 60000);
+
+  afterAll(() => {
+    fontServer?.close();
+    fs.rmSync(fontOutDir, { recursive: true, force: true });
+    fs.rmSync(fontCacheDir, { recursive: true, force: true });
+    fs.rmSync(nodeModulesLink, { recursive: true, force: true });
+  });
+
+  it("emits served URLs in the HTTP Link response header (not filesystem paths)", async () => {
+    const res = await fetch(`${fontBaseUrl}/`);
+    expect(res.status).toBe(200);
+    const link = res.headers.get("link");
+    expect(link).toBeTruthy();
+    // Every preload in the Link header must reference the served URL
+    // namespace created by the fix. Before the fix, the header value was
+    // `</home/user/project/.vinext/fonts/geist-<hash>/geist-<hash>.woff2>`.
+    expect(link).toContain("/assets/_vinext_fonts/");
+    expect(link).toMatch(/rel=preload/);
+    expect(link).toMatch(/as=font/);
+    expect(link).toMatch(/type=font\/woff2/);
+    // Both the absolute dev-machine prefix and the relative cache dir
+    // name must be absent — the leaked path always contained both.
+    expect(link).not.toContain(FONT_FIXTURE_DIR);
+    expect(link).not.toContain(".vinext/fonts");
+  });
+
+  it("emits served URLs in the body <link rel=preload> tags", async () => {
+    const res = await fetch(`${fontBaseUrl}/`);
+    const html = await res.text();
+    expect(html).toMatch(
+      /<link rel="preload"[^>]*href="\/assets\/_vinext_fonts\/[^"]+\.woff2"[^>]*as="font"/,
+    );
+    expect(html).not.toContain(FONT_FIXTURE_DIR);
+    expect(html).not.toContain(".vinext/fonts");
+  });
+
+  it("emits served URLs in the injected <style data-vinext-fonts> block", async () => {
+    // The injected @font-face CSS is the upstream source of truth the body
+    // `<link>` tags and HTTP `Link:` header are both derived from — a
+    // regression here would reproduce the bug across all three emission
+    // paths at once.
+    const res = await fetch(`${fontBaseUrl}/`);
+    const html = await res.text();
+    const styleMatch = html.match(/<style data-vinext-fonts[^>]*>([\s\S]*?)<\/style>/);
+    expect(styleMatch).not.toBeNull();
+    const styleContent = styleMatch![1];
+    expect(styleContent).toMatch(/url\(\/assets\/_vinext_fonts\/[^)]+\.woff2\)/);
+    expect(styleContent).not.toContain(FONT_FIXTURE_DIR);
+    expect(styleContent).not.toContain(".vinext/fonts");
+  });
+
+  it("serves the cached font files copied into the client output", async () => {
+    // Regression guard for the writeBundle copy hook: without it, the
+    // rewritten URLs would be syntactically correct but 404 at request
+    // time because the font files never leave `<root>/.vinext/fonts/`.
+    const res = await fetch(`${fontBaseUrl}/`);
+    const html = await res.text();
+    const match = html.match(/\/assets\/_vinext_fonts\/[^"]+\.woff2/);
+    expect(match).not.toBeNull();
+    const fontPath = match![0];
+    const fontRes = await fetch(`${fontBaseUrl}${fontPath}`);
+    expect(fontRes.status).toBe(200);
+    expect(fontRes.headers.get("content-type")).toBe("font/woff2");
+    expect(fontRes.headers.get("cache-control")).toContain("immutable");
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Malformed percent-encoded URL regression tests — App Router dev server
 // (covers entries/app-rsc-entry.ts generated RSC handler decodeURIComponent)

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -2350,8 +2350,21 @@ describe("App Router Production server self-hosted next/font/google headers", ()
     // of the bug. Returning CSS with already-relative URLs would sidestep
     // the failure mode.
     const originalFetch = globalThis.fetch;
+    // Normalize every `fetch()` input shape to a plain URL string so the
+    // mock can match by substring. The build plugin currently always
+    // passes string URLs, but `globalThis.fetch` accepts `RequestInfo |
+    // URL` and a future change (or test helper) passing a `Request` or
+    // `URL` instance would otherwise be coerced to `[object Request]`
+    // by `String()` and silently skip the mock branches, falling through
+    // to a real network request for Google Fonts.
+    const resolveFetchUrl = (input: unknown): string => {
+      if (typeof input === "string") return input;
+      if (input instanceof URL) return input.toString();
+      if (typeof Request !== "undefined" && input instanceof Request) return input.url;
+      return String(input);
+    };
     globalThis.fetch = async (input: unknown) => {
-      const url = typeof input === "string" ? input : String(input);
+      const url = resolveFetchUrl(input);
       if (url.includes("fonts.googleapis.com")) {
         const isMono = url.includes("Geist+Mono") || url.includes("Geist%20Mono");
         const family = isMono ? "Geist Mono" : "Geist";

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -2363,7 +2363,14 @@ describe("App Router Production server self-hosted next/font/google headers", ()
       if (typeof Request !== "undefined" && input instanceof Request) return input.url;
       return String(input);
     };
-    globalThis.fetch = async (input: unknown) => {
+    // Preserve `globalThis.fetch`'s full `(input, init)` signature so the
+    // fallback path forwards request options verbatim to the real fetch.
+    // The build plugin only issues plain GETs for Google Fonts today, so
+    // the `init` argument is never populated for the mock branches — but
+    // dropping it from the fallback signature would silently strip
+    // headers/method/body from any unrelated request that happens to run
+    // during the test and fall through.
+    globalThis.fetch = async (input: unknown, init?: RequestInit) => {
       const url = resolveFetchUrl(input);
       if (url.includes("fonts.googleapis.com")) {
         const isMono = url.includes("Geist+Mono") || url.includes("Geist%20Mono");
@@ -2394,7 +2401,7 @@ describe("App Router Production server self-hosted next/font/google headers", ()
           { status: 200, headers: { "content-type": "font/woff2" } },
         );
       }
-      return originalFetch(input as RequestInfo);
+      return originalFetch(input as RequestInfo, init);
     };
 
     try {

--- a/tests/font-google.test.ts
+++ b/tests/font-google.test.ts
@@ -846,6 +846,42 @@ describe("_rewriteCachedFontCssToServedUrls", () => {
     const css = "src: url(/home/user/project/.vinext/fonts/geist/a.woff2);";
     expect(rewriteCachedFontCssToServedUrls(css, "")).toBe(css);
   });
+
+  it("uses a custom assetsDir when passed through from plugin state", () => {
+    // Regression for a bug where the helper hardcoded the default
+    // `assets` directory into the URL prefix while the `writeBundle`
+    // hook read the real `envConfig.build.assetsDir` from Vite — a user
+    // who customized `build.assetsDir` (e.g. to `"static"`) would see
+    // the embedded CSS point at `/assets/_vinext_fonts/...` while the
+    // physical files landed in `<outDir>/static/_vinext_fonts/...`, so
+    // every preload would 404 in production.
+    //
+    // The fix threads the resolved `assetsDir` through as a third
+    // argument from `injectSelfHostedCss` at the call site. This test
+    // exercises the threaded path and asserts the URL prefix tracks it.
+    const cacheDir = "/home/user/project/.vinext/fonts";
+    const css =
+      "src: url(/home/user/project/.vinext/fonts/geist-abc/geist-def.woff2) format('woff2');";
+
+    const out = rewriteCachedFontCssToServedUrls(css, cacheDir, "static");
+
+    expect(out).toBe("src: url(/static/_vinext_fonts/geist-abc/geist-def.woff2) format('woff2');");
+    expect(out).not.toContain("/assets/");
+  });
+
+  it("falls back to the default assetsDir when an empty string is passed", () => {
+    // Guard against a misconfigured environment passing `""` — never
+    // construct a URL of the form `//`. The helper falls back to the
+    // default `assets` prefix so the URL always has a real directory
+    // segment between the root and the `_vinext_fonts` namespace.
+    const cacheDir = "/root/.vinext/fonts";
+    const css = "src: url(/root/.vinext/fonts/geist/a.woff2);";
+
+    const out = rewriteCachedFontCssToServedUrls(css, cacheDir, "");
+
+    expect(out).toBe("src: url(/assets/_vinext_fonts/geist/a.woff2);");
+    expect(out).not.toContain("//_vinext_fonts");
+  });
 });
 
 // ── parseStaticObjectLiteral security tests ───────────────────

--- a/tests/font-google.test.ts
+++ b/tests/font-google.test.ts
@@ -5,6 +5,7 @@ import vinext, {
   _parseStaticObjectLiteral as parseStaticObjectLiteral,
   _findBalancedObject as findBalancedObject,
   _findCallEnd as findCallEnd,
+  _rewriteCachedFontCssToServedUrls as rewriteCachedFontCssToServedUrls,
 } from "../packages/vinext/src/index.js";
 import type { Plugin } from "vite-plus";
 
@@ -754,6 +755,96 @@ describe("fetchAndCacheFont", () => {
     // but we verified the caching logic works via the plugin transform tests above
     expect(fs.existsSync(path.join(fontDir, "style.css"))).toBe(true);
     expect(fs.readFileSync(path.join(fontDir, "style.css"), "utf-8")).toBe(fakeCSS);
+  });
+});
+
+// ── Served URL rewrite for cached Google Fonts CSS ────────────
+
+describe("_rewriteCachedFontCssToServedUrls", () => {
+  // Regression for a bug where self-hosted next/font/google built by vinext
+  // emitted absolute dev-machine filesystem paths into every preload path
+  // — the <style data-vinext-fonts> @font-face src: url(), the HTML body's
+  // <link rel="preload"> tags, and the HTTP Link: response header — because
+  // `fetchAndCacheFont` wrote `path.join(cacheDir, ...)` into the cached
+  // CSS and nothing rewrote those paths before the CSS was embedded in the
+  // bundle as `_selfHostedCSS`. Every downstream consumer then read the
+  // same leaked filesystem path. In production this caused high-priority
+  // 404s (`<origin>/home/user/project/.vinext/fonts/...`) on every request.
+  //
+  // The fix replaces the cache-dir prefix with the served URL namespace
+  // `/assets/_vinext_fonts` before the CSS string is handed off to the
+  // bundle. The plugin's writeBundle hook then copies the cached font
+  // files into the matching `dist/client/assets/_vinext_fonts/` location
+  // so the rewritten URLs actually resolve against the origin.
+
+  it("rewrites absolute cache-dir paths in url() references to served URLs", () => {
+    const cacheDir = "/home/user/project/.vinext/fonts";
+    const css = [
+      "@font-face {",
+      "  font-family: 'Geist';",
+      "  src: url(/home/user/project/.vinext/fonts/geist-4db05770f54f/geist-8e42e564.woff2) format('woff2');",
+      "}",
+      "@font-face {",
+      "  font-family: 'Geist';",
+      "  src: url(/home/user/project/.vinext/fonts/geist-4db05770f54f/geist-bd9fc9d8.woff2) format('woff2');",
+      "}",
+    ].join("\n");
+
+    const out = rewriteCachedFontCssToServedUrls(css, cacheDir);
+
+    expect(out).toContain("url(/assets/_vinext_fonts/geist-4db05770f54f/geist-8e42e564.woff2)");
+    expect(out).toContain("url(/assets/_vinext_fonts/geist-4db05770f54f/geist-bd9fc9d8.woff2)");
+    // The dev-machine filesystem prefix must not leak into the rewritten CSS.
+    expect(out).not.toContain("/home/user/project/.vinext/fonts");
+    // Unrelated @font-face metadata is preserved verbatim.
+    expect(out).toContain("font-family: 'Geist'");
+    expect(out).toContain("format('woff2')");
+  });
+
+  it("rewrites every occurrence when the same path appears multiple times", () => {
+    // The broken path can appear in the same cached CSS via the cyrillic /
+    // latin-ext / latin @font-face blocks Google Fonts returns per family,
+    // plus a duplicate in a `src: url(...) tech(variations)` fallback.
+    const cacheDir = "/root/.vinext/fonts";
+    const css = [
+      "src: url(/root/.vinext/fonts/geist/a.woff2);",
+      "src: url(/root/.vinext/fonts/geist/b.woff2);",
+      "src: url(/root/.vinext/fonts/geist/a.woff2);",
+    ].join("\n");
+
+    const out = rewriteCachedFontCssToServedUrls(css, cacheDir);
+
+    expect(out).not.toContain("/root/.vinext/fonts");
+    const aCount = (out.match(/\/assets\/_vinext_fonts\/geist\/a\.woff2/g) ?? []).length;
+    const bCount = (out.match(/\/assets\/_vinext_fonts\/geist\/b\.woff2/g) ?? []).length;
+    expect(aCount).toBe(2);
+    expect(bCount).toBe(1);
+  });
+
+  it("is a no-op when the CSS does not reference the cache directory", () => {
+    const cacheDir = "/home/user/project/.vinext/fonts";
+    const css = "@font-face { font-family: 'Inter'; src: url(/cached.woff2); }";
+    expect(rewriteCachedFontCssToServedUrls(css, cacheDir)).toBe(css);
+  });
+
+  it("handles cache directories containing regex metacharacters", () => {
+    // Using split/join instead of a constructed regex guarantees safety for
+    // any absolute path — including ones that happen to contain characters
+    // that would otherwise need escaping in a RegExp.
+    const cacheDir = "/tmp/build (1)/.vinext/fonts";
+    const css = "src: url(/tmp/build (1)/.vinext/fonts/inter-xyz/inter-abc.woff2) format('woff2');";
+
+    const out = rewriteCachedFontCssToServedUrls(css, cacheDir);
+
+    expect(out).toBe("src: url(/assets/_vinext_fonts/inter-xyz/inter-abc.woff2) format('woff2');");
+  });
+
+  it("is a no-op when cacheDir is empty", () => {
+    // Defensive guard: before Vite's configResolved hook runs, `cacheDir`
+    // is the empty string. A naive split/join on "" would insert the URL
+    // namespace between every character in the CSS.
+    const css = "src: url(/home/user/project/.vinext/fonts/geist/a.woff2);";
+    expect(rewriteCachedFontCssToServedUrls(css, "")).toBe(css);
   });
 });
 


### PR DESCRIPTION
## Summary

`fetchAndCacheFont()` in `packages/vinext/src/plugins/fonts.ts` downloads Google Fonts `.woff2` files into `<root>/.vinext/fonts/<family>-<urlHash>/` and rewrites the cached `@font-face` CSS with `css.split(fontUrl).join(path.join(fontDir, filename))` — an absolute dev-machine filesystem path. That CSS is then embedded verbatim as `_selfHostedCSS` in the server bundle, and every downstream consumer reads from the same leaked string: the injected `<style data-vinext-fonts>` block's `@font-face { src: url(...) }`, the HTML body's `<link rel="preload">` tags, and the HTTP `Link:` response header.

Production requests on workerd produce header and body preload entries like `</home/<user>/<project>/.vinext/fonts/geist-<hash>/geist-<hash>.woff2>` — the browser follows the absolute `href` to `<origin>/home/<user>/...`, workerd returns 404 (the cached files are never copied into `dist/client/` either), and the console fills with `downloadable font: download failed` and `preloaded with link preload was not used` warnings on every page view. Because preload is high-priority for fonts, the broken request contends with real critical-path traffic and Cloudflare's 103 Early Hints path would emit these broken entries before the HTML even starts streaming.

Any app using stock `next/font/google` self-hosted mode is affected — no user-facing config can work around it (`#472` tracks `assetPrefix` support but that's orthogonal, and the leak happens regardless of whether `assetPrefix` is set).

## Root cause

Three downstream font-preload emitters all read from the same in-memory array populated by `collectFontPreloadsFromCSS()` in `shims/font-google-base.ts`, which extracts `url(...)` references from `_selfHostedCSS` via regex:

1. The injected `<style data-vinext-fonts>` block's `@font-face { src: url(...) }` (via `ssrFontStyles` in `shims/font-google-base.ts`).
2. The HTML body's `<link rel="preload">` tags emitted from `server/app-ssr-entry.ts:renderFontHtml()` via `fontData.preloads[*].href`.
3. The HTTP `Link:` response header, built by `buildAppPageFontLinkHeader()` in `server/app-page-execution.ts` and set on the response in `server/app-page-response.ts:242`.

All three read from the same source of truth, so a single fix at the CSS level propagates to every emitter.

The upstream source — the cached CSS — is written by `fetchAndCacheFont()`:

```ts
// packages/vinext/src/plugins/fonts.ts
for (const [fontUrl, filename] of urls) {
  const filePath = path.join(fontDir, filename);
  // ... download + write to disk ...
  // Rewrite CSS to use absolute path (Vite will resolve /@fs/ for dev, or asset for build)
  css = css.split(fontUrl).join(filePath);
}
```

The "Vite will resolve /@fs/ for dev, or asset for build" comment describes the intended behaviour but is not what actually happens: the CSS is embedded as a **JavaScript string literal** in the bundle, and Vite's asset pipeline operates on CSS files and `import`/`new URL(...)` references — not on string literals inside JS. The filesystem path gets baked into `_selfHostedCSS` verbatim, and nothing downstream rewrites it.

Separately, `fetchAndCacheFont` leaves the downloaded `.woff2` files in `<root>/.vinext/fonts/` and nothing ever copies them into `dist/client/` — so even a correctly-rewritten URL would 404 in production without a companion copy step.

## Fix

Two changes in `packages/vinext/src/plugins/fonts.ts`, both inside the existing `vinext:google-fonts` plugin:

1. **`_rewriteCachedFontCssToServedUrls()`** — a small helper (3 lines of real logic plus regression-detection JSDoc) that replaces the absolute `cacheDir` prefix in a cached CSS string with the served URL namespace `/assets/_vinext_fonts`. Called from `injectSelfHostedCss()` right before the CSS string is `JSON.stringify`'d into the bundle, so every downstream consumer sees the rewritten URL.

2. **`writeBundle` hook** (client environment only) — recursively copies every `.woff2`/`.woff`/`.ttf`/`.otf`/`.eot` file out of `<root>/.vinext/fonts/` into `<clientOutDir>/assets/_vinext_fonts/`, preserving the `<family>-<hash>/` subdirectory structure. The existing `_headers` rule for `/assets/*` already covers the new namespace, and `StaticFileCache` picks the copied files up via its recursive walk of `dist/client/`, so `Content-Type: font/woff2`, `Cache-Control: public, max-age=31536000, immutable`, and an automatic content-hashed ETag all flow through without any server-side changes.

No config surface is added — this does not implement `#472` (`assetPrefix` / `basePath` support), it just stops the absolute filesystem path from leaking into the preload emitters regardless of whether `assetPrefix` is set.

## Tests

Two new regression tests, both verified to fail on `main` and pass with the fix:

- **Unit** — `tests/font-google.test.ts`: five cases in a new `_rewriteCachedFontCssToServedUrls` describe block drive the helper directly with (a) a realistic cached CSS containing multiple `url(...)` references, (b) multi-occurrence replacement where the same path appears multiple times in a single block, (c) a cache directory containing regex metacharacters (`/tmp/build (1)/...`) to prove split/join is safer than a constructed regex, (d) CSS that never references the cache directory (no-op), and (e) an empty cacheDir defensive guard so a split on `""` doesn't insert the URL namespace between every character.
- **Integration** — `tests/app-router.test.ts`, in a new `App Router Production server self-hosted next/font/google headers` describe block. Builds the existing `tests/fixtures/font-google-multiple` fixture (stock `Geist` + `Geist_Mono` via `next/font/google`) with a mocked fetch that stands in for the Google Fonts CDN. The mock returns CSS with real `https://fonts.gstatic.com/...` URLs so `fetchAndCacheFont`'s regex actually exercises the path-rewriting code that was the bug source — returning CSS with already-relative URLs would sidestep the failure mode. Starts `startProdServer()` on a random port and asserts on the raw HTTP response: (a) `Link:` header contains the served URL and neither the absolute fixture path nor `.vinext/fonts` appears anywhere in it, (b) body `<link rel="preload">` tags match `/assets/_vinext_fonts/...`, (c) the injected `<style data-vinext-fonts>` block's `@font-face src: url()` also uses the served URL, and (d) the copied font file serves 200 with `content-type: font/woff2` and an `immutable` cache-control.

A separate fixture is used instead of extending `app-basic` because `app-basic` is shared by every integration test in `tests/app-router.test.ts` — adding `next/font/google` to its root layout would force a real Google Fonts network fetch into every test run in the file. The mocked-fetch approach keeps the test hermetic.

## Verified

With the fix applied:

| Check | Result |
|---|---|
| `pnpm test:unit` | **2853 / 2853** pass |
| `pnpm test:integration` | **1262 / 1262** pass (2 pre-existing skips) |
| `pnpm run check` (lint + format + types) | **0** warnings, **0** errors |
| `pnpm test:e2e` — `app-router` project | **322 / 322** pass (3 flaky on retry, 9 pre-existing skips) |
| `pnpm test:e2e` — `cloudflare-workers` project (Miniflare) | **38 / 38** pass (1 flaky on retry) |

Both new tests were also re-run with the fix reverted on a clean tree to confirm they deterministically catch the regression — the integration suite printed the leaked path verbatim in the `<style data-vinext-fonts>` assertion, e.g.

```
src: url(/home/<user>/.../.vinext/fonts/geist-4db05770f54f/geist-2fba11a4.woff2) format('woff2');
```

and the font-file `200 OK` assertion failed because the cached `.woff2` files were never copied into `dist/client/`.

End-to-end runtime verification on `workerd` (Miniflare, via `wrangler dev`) against `examples/app-router-cloudflare` with a `next/font/google` layout import:

**Before**

```
$ curl -sI http://localhost:4999/
HTTP/1.1 200 OK
Content-Type: text/html; charset=utf-8
Link: </home/<user>/<project>/.vinext/fonts/geist-4db05770f54f/geist-8e42e564.woff2>; rel=preload; as=font; type=font/woff2; crossorigin, </home/<user>/<project>/.vinext/fonts/geist-4db05770f54f/geist-bd9fc9d8.woff2>; rel=preload; as=font; type=font/woff2; crossorigin, </home/<user>/<project>/.vinext/fonts/geist-4db05770f54f/geist-79e7a99c.woff2>; rel=preload; as=font; type=font/woff2; crossorigin
```

```
$ curl -s http://localhost:4999/ | grep -oE '<link[^>]*preload[^>]*woff2[^>]*>'
<link rel="preload" href="/home/<user>/<project>/.vinext/fonts/geist-4db05770f54f/geist-8e42e564.woff2" as="font" type="font/woff2" crossorigin />
<link rel="preload" href="/home/<user>/<project>/.vinext/fonts/geist-4db05770f54f/geist-bd9fc9d8.woff2" as="font" type="font/woff2" crossorigin />
<link rel="preload" href="/home/<user>/<project>/.vinext/fonts/geist-4db05770f54f/geist-79e7a99c.woff2" as="font" type="font/woff2" crossorigin />
```

```
$ curl -sI 'http://localhost:4999/home/<user>/<project>/.vinext/fonts/geist-4db05770f54f/geist-8e42e564.woff2'
HTTP/1.1 404 Not Found
```

**After**

```
$ curl -sI http://localhost:4999/
HTTP/1.1 200 OK
Content-Type: text/html; charset=utf-8
Link: </assets/_vinext_fonts/geist-4db05770f54f/geist-8e42e564.woff2>; rel=preload; as=font; type=font/woff2; crossorigin, </assets/_vinext_fonts/geist-4db05770f54f/geist-bd9fc9d8.woff2>; rel=preload; as=font; type=font/woff2; crossorigin, </assets/_vinext_fonts/geist-4db05770f54f/geist-79e7a99c.woff2>; rel=preload; as=font; type=font/woff2; crossorigin
```

```
$ curl -s http://localhost:4999/ | grep -oE '<link[^>]*preload[^>]*woff2[^>]*>'
<link rel="preload" href="/assets/_vinext_fonts/geist-4db05770f54f/geist-8e42e564.woff2" as="font" type="font/woff2" crossorigin />
<link rel="preload" href="/assets/_vinext_fonts/geist-4db05770f54f/geist-bd9fc9d8.woff2" as="font" type="font/woff2" crossorigin />
<link rel="preload" href="/assets/_vinext_fonts/geist-4db05770f54f/geist-79e7a99c.woff2" as="font" type="font/woff2" crossorigin />
```

```
$ curl -sI http://localhost:4999/assets/_vinext_fonts/geist-4db05770f54f/geist-8e42e564.woff2
HTTP/1.1 200 OK
Content-Type: font/woff2
Cache-Control: public, max-age=31536000, immutable
ETag: "99db0b97ae3a4012f8b03153490d9518"
CF-Cache-Status: HIT
```

The `writeBundle` copy hook landed the cached files in `dist/client/assets/_vinext_fonts/geist-4db05770f54f/` and the existing `_headers` rule for `/assets/*` applies an immutable cache-control header at the edge — workerd returned `CF-Cache-Status: HIT` on the second request, identical to every other hashed asset.

## References

- #472 — `assetPrefix` / `basePath` support in `next.config` (orthogonal: this PR does not implement `assetPrefix`, it just stops the absolute filesystem path from leaking into the preload emitters regardless of whether `assetPrefix` is set)
- #812 — parallel `applyMiddlewareRequestHeaders` sealed-snapshot invalidation fix that followed the same report-and-fixture pattern