### PR TITLE
fix: always mark pages that receive searchParams as dynamic

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -1035,15 +1035,15 @@ async function buildPageElements(route, params, routePath, opts, searchParams, i
     // when the query string is empty -- pages that do "await searchParams" need
     // it to be a thenable rather than undefined.
     pageProps.searchParams = makeThenableParams(spObj);
-    // If the URL has query parameters, mark the page as dynamic.
-    // In Next.js, only accessing the searchParams prop signals dynamic usage,
-    // but a Proxy-based approach doesn't work here because React's RSC debug
-    // serializer accesses properties on all props (e.g. $$typeof check in
-    // isClientReference), triggering the Proxy even when user code doesn't
-    // read searchParams. Checking for non-empty query params is a safe
-    // approximation: pages with query params in the URL are almost always
-    // dynamic, and this avoids false positives from React internals.
-    if (hasSearchParams) markDynamicUsage();
+    // Mark the render as dynamic whenever searchParams is provided. In Next.js,
+    // accessing the searchParams prop via a Proxy triggers dynamic rendering.
+    // We cannot use a Proxy here because React's RSC debug serializer accesses
+    // properties on all props ($$typeof, etc.), causing false positives.
+    // Instead, we unconditionally mark dynamic: any page that receives
+    // searchParams is request-dependent, even when the first request has an
+    // empty query string. Without this, the empty-query render would be cached
+    // and replayed to later requests with different query parameters.
+    markDynamicUsage();
   }
   const __mountedSlotsHeader = __normalizeMountedSlotsHeader(
     request?.headers?.get("x-vinext-mounted-slots"),

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -790,15 +790,15 @@ async function buildPageElements(route, params, routePath, opts, searchParams, i
     // when the query string is empty -- pages that do "await searchParams" need
     // it to be a thenable rather than undefined.
     pageProps.searchParams = makeThenableParams(spObj);
-    // If the URL has query parameters, mark the page as dynamic.
-    // In Next.js, only accessing the searchParams prop signals dynamic usage,
-    // but a Proxy-based approach doesn't work here because React's RSC debug
-    // serializer accesses properties on all props (e.g. $$typeof check in
-    // isClientReference), triggering the Proxy even when user code doesn't
-    // read searchParams. Checking for non-empty query params is a safe
-    // approximation: pages with query params in the URL are almost always
-    // dynamic, and this avoids false positives from React internals.
-    if (hasSearchParams) markDynamicUsage();
+    // Mark the render as dynamic whenever searchParams is provided. In Next.js,
+    // accessing the searchParams prop via a Proxy triggers dynamic rendering.
+    // We cannot use a Proxy here because React's RSC debug serializer accesses
+    // properties on all props ($$typeof, etc.), causing false positives.
+    // Instead, we unconditionally mark dynamic: any page that receives
+    // searchParams is request-dependent, even when the first request has an
+    // empty query string. Without this, the empty-query render would be cached
+    // and replayed to later requests with different query parameters.
+    markDynamicUsage();
   }
   const __mountedSlotsHeader = __normalizeMountedSlotsHeader(
     request?.headers?.get("x-vinext-mounted-slots"),
@@ -2964,15 +2964,15 @@ async function buildPageElements(route, params, routePath, opts, searchParams, i
     // when the query string is empty -- pages that do "await searchParams" need
     // it to be a thenable rather than undefined.
     pageProps.searchParams = makeThenableParams(spObj);
-    // If the URL has query parameters, mark the page as dynamic.
-    // In Next.js, only accessing the searchParams prop signals dynamic usage,
-    // but a Proxy-based approach doesn't work here because React's RSC debug
-    // serializer accesses properties on all props (e.g. $$typeof check in
-    // isClientReference), triggering the Proxy even when user code doesn't
-    // read searchParams. Checking for non-empty query params is a safe
-    // approximation: pages with query params in the URL are almost always
-    // dynamic, and this avoids false positives from React internals.
-    if (hasSearchParams) markDynamicUsage();
+    // Mark the render as dynamic whenever searchParams is provided. In Next.js,
+    // accessing the searchParams prop via a Proxy triggers dynamic rendering.
+    // We cannot use a Proxy here because React's RSC debug serializer accesses
+    // properties on all props ($$typeof, etc.), causing false positives.
+    // Instead, we unconditionally mark dynamic: any page that receives
+    // searchParams is request-dependent, even when the first request has an
+    // empty query string. Without this, the empty-query render would be cached
+    // and replayed to later requests with different query parameters.
+    markDynamicUsage();
   }
   const __mountedSlotsHeader = __normalizeMountedSlotsHeader(
     request?.headers?.get("x-vinext-mounted-slots"),
@@ -5145,15 +5145,15 @@ async function buildPageElements(route, params, routePath, opts, searchParams, i
     // when the query string is empty -- pages that do "await searchParams" need
     // it to be a thenable rather than undefined.
     pageProps.searchParams = makeThenableParams(spObj);
-    // If the URL has query parameters, mark the page as dynamic.
-    // In Next.js, only accessing the searchParams prop signals dynamic usage,
-    // but a Proxy-based approach doesn't work here because React's RSC debug
-    // serializer accesses properties on all props (e.g. $$typeof check in
-    // isClientReference), triggering the Proxy even when user code doesn't
-    // read searchParams. Checking for non-empty query params is a safe
-    // approximation: pages with query params in the URL are almost always
-    // dynamic, and this avoids false positives from React internals.
-    if (hasSearchParams) markDynamicUsage();
+    // Mark the render as dynamic whenever searchParams is provided. In Next.js,
+    // accessing the searchParams prop via a Proxy triggers dynamic rendering.
+    // We cannot use a Proxy here because React's RSC debug serializer accesses
+    // properties on all props ($$typeof, etc.), causing false positives.
+    // Instead, we unconditionally mark dynamic: any page that receives
+    // searchParams is request-dependent, even when the first request has an
+    // empty query string. Without this, the empty-query render would be cached
+    // and replayed to later requests with different query parameters.
+    markDynamicUsage();
   }
   const __mountedSlotsHeader = __normalizeMountedSlotsHeader(
     request?.headers?.get("x-vinext-mounted-slots"),
@@ -7349,15 +7349,15 @@ async function buildPageElements(route, params, routePath, opts, searchParams, i
     // when the query string is empty -- pages that do "await searchParams" need
     // it to be a thenable rather than undefined.
     pageProps.searchParams = makeThenableParams(spObj);
-    // If the URL has query parameters, mark the page as dynamic.
-    // In Next.js, only accessing the searchParams prop signals dynamic usage,
-    // but a Proxy-based approach doesn't work here because React's RSC debug
-    // serializer accesses properties on all props (e.g. $$typeof check in
-    // isClientReference), triggering the Proxy even when user code doesn't
-    // read searchParams. Checking for non-empty query params is a safe
-    // approximation: pages with query params in the URL are almost always
-    // dynamic, and this avoids false positives from React internals.
-    if (hasSearchParams) markDynamicUsage();
+    // Mark the render as dynamic whenever searchParams is provided. In Next.js,
+    // accessing the searchParams prop via a Proxy triggers dynamic rendering.
+    // We cannot use a Proxy here because React's RSC debug serializer accesses
+    // properties on all props ($$typeof, etc.), causing false positives.
+    // Instead, we unconditionally mark dynamic: any page that receives
+    // searchParams is request-dependent, even when the first request has an
+    // empty query string. Without this, the empty-query render would be cached
+    // and replayed to later requests with different query parameters.
+    markDynamicUsage();
   }
   const __mountedSlotsHeader = __normalizeMountedSlotsHeader(
     request?.headers?.get("x-vinext-mounted-slots"),
@@ -9533,15 +9533,15 @@ async function buildPageElements(route, params, routePath, opts, searchParams, i
     // when the query string is empty -- pages that do "await searchParams" need
     // it to be a thenable rather than undefined.
     pageProps.searchParams = makeThenableParams(spObj);
-    // If the URL has query parameters, mark the page as dynamic.
-    // In Next.js, only accessing the searchParams prop signals dynamic usage,
-    // but a Proxy-based approach doesn't work here because React's RSC debug
-    // serializer accesses properties on all props (e.g. $$typeof check in
-    // isClientReference), triggering the Proxy even when user code doesn't
-    // read searchParams. Checking for non-empty query params is a safe
-    // approximation: pages with query params in the URL are almost always
-    // dynamic, and this avoids false positives from React internals.
-    if (hasSearchParams) markDynamicUsage();
+    // Mark the render as dynamic whenever searchParams is provided. In Next.js,
+    // accessing the searchParams prop via a Proxy triggers dynamic rendering.
+    // We cannot use a Proxy here because React's RSC debug serializer accesses
+    // properties on all props ($$typeof, etc.), causing false positives.
+    // Instead, we unconditionally mark dynamic: any page that receives
+    // searchParams is request-dependent, even when the first request has an
+    // empty query string. Without this, the empty-query render would be cached
+    // and replayed to later requests with different query parameters.
+    markDynamicUsage();
   }
   const __mountedSlotsHeader = __normalizeMountedSlotsHeader(
     request?.headers?.get("x-vinext-mounted-slots"),
@@ -11707,15 +11707,15 @@ async function buildPageElements(route, params, routePath, opts, searchParams, i
     // when the query string is empty -- pages that do "await searchParams" need
     // it to be a thenable rather than undefined.
     pageProps.searchParams = makeThenableParams(spObj);
-    // If the URL has query parameters, mark the page as dynamic.
-    // In Next.js, only accessing the searchParams prop signals dynamic usage,
-    // but a Proxy-based approach doesn't work here because React's RSC debug
-    // serializer accesses properties on all props (e.g. $$typeof check in
-    // isClientReference), triggering the Proxy even when user code doesn't
-    // read searchParams. Checking for non-empty query params is a safe
-    // approximation: pages with query params in the URL are almost always
-    // dynamic, and this avoids false positives from React internals.
-    if (hasSearchParams) markDynamicUsage();
+    // Mark the render as dynamic whenever searchParams is provided. In Next.js,
+    // accessing the searchParams prop via a Proxy triggers dynamic rendering.
+    // We cannot use a Proxy here because React's RSC debug serializer accesses
+    // properties on all props ($$typeof, etc.), causing false positives.
+    // Instead, we unconditionally mark dynamic: any page that receives
+    // searchParams is request-dependent, even when the first request has an
+    // empty query string. Without this, the empty-query render would be cached
+    // and replayed to later requests with different query parameters.
+    markDynamicUsage();
   }
   const __mountedSlotsHeader = __normalizeMountedSlotsHeader(
     request?.headers?.get("x-vinext-mounted-slots"),

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -2046,6 +2046,26 @@ describe("App Router Production server (startProdServer)", () => {
     expect(html2).not.toContain('"filter">alpha<');
   });
 
+  it("page ISR + searchParams: empty-query first request does not cache and poison later query requests", async () => {
+    // First request with NO query params. The page reads searchParams, so it
+    // must NOT be cached even though the query string is empty.
+    const res1 = await fetch(`${baseUrl}/search-params-page`);
+    expect(res1.status).toBe(200);
+    expect(res1.headers.get("x-vinext-cache")).toBeNull();
+    const html1 = await res1.text();
+    // React inserts <!-- --> between text nodes, so match the id + content pattern
+    expect(html1).toContain('id="filter"');
+    expect(html1).toContain("none");
+
+    // Second request WITH query params must see its own searchParams, not
+    // a cached empty-query response.
+    const res2 = await fetch(`${baseUrl}/search-params-page?filter=violet`);
+    expect(res2.status).toBe(200);
+    expect(res2.headers.get("x-vinext-cache")).toBeNull();
+    const html2 = await res2.text();
+    expect(html2).toContain("violet");
+  });
+
   // Route handler ISR caching tests
   // These tests are ORDER-DEPENDENT: they share a single production server and
   // /api/static-data cache state persists across tests. HIT depends on MISS

--- a/tests/fixtures/app-basic/app/search-params-page/page.tsx
+++ b/tests/fixtures/app-basic/app/search-params-page/page.tsx
@@ -1,0 +1,16 @@
+export const revalidate = 60;
+
+export default async function SearchParamsPage(props: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const sp = await props.searchParams;
+  const filter = sp.filter ?? "none";
+
+  return (
+    <div>
+      <h1>Search Params Page</h1>
+      <p id="filter">filter={String(filter)}</p>
+      <p id="keys">keys={Object.keys(sp).sort().join(",")}</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Pages that read `searchParams` are now always marked dynamic, even when the first request has an empty query string.

## Details

Previously, `markDynamicUsage()` was only called when the URL contained query parameters (`hasSearchParams`). A request to `/page` (no query) would render with `searchParams = {}`, not be marked dynamic, and get ISR-cached. A later request to `/page?filter=violet` would then receive the cached empty-query response.

The fix removes the `hasSearchParams` guard so `markDynamicUsage()` is called unconditionally whenever `searchParams` is provided to the page component. This matches Next.js behavior where accessing the `searchParams` prop signals dynamic rendering regardless of whether the URL has query parameters.

## Tests

Adds a production integration test with a dedicated fixture page (`/search-params-page`) that reads `searchParams`:
- first request with no query: not cached, renders `filter=none`
- second request with `?filter=violet`: not cached, renders `filter=violet`