### PR TITLE
chore: Harden CI supply chain

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,25 @@
+name: Setup
+description: Setup
+
+inputs:
+  node-version:
+    description: Node.js version to use
+    required: false
+  cache:
+    description: Whether to enable caching for Vite+ dependencies
+    required: false
+    default: true
+  run-install:
+    description: Whether to run `vp install` after setup
+    required: false
+    default: true
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Vite+
+      uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: ${{ inputs.cache }}
+        run-install: ${{ inputs.run-install }}

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           fetch-depth: 0 # Need full history for commit info
 
-      - uses: voidzero-dev/setup-vp@v1
+      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1
 
       - name: Build vinext plugin
         run: vp run build

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           fetch-depth: 0 # Need full history for commit info
 
-      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1
+      - uses: ./.github/actions/setup
 
       - name: Build vinext plugin
         run: vp run build

--- a/.github/workflows/bigbonk.yml
+++ b/.github/workflows/bigbonk.yml
@@ -34,7 +34,7 @@ jobs:
           fetch-depth: 30 # 30 is a balance in providing enough context for the agent vs. pulling down the entire repo history. It is not a scientific number. 27 or 31 or 36 would likely work as well.
 
       - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@v1
+        uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1
 
       - name: Run Bonk
         uses: ask-bonk/ask-bonk/github@main

--- a/.github/workflows/bigbonk.yml
+++ b/.github/workflows/bigbonk.yml
@@ -33,8 +33,7 @@ jobs:
         with:
           fetch-depth: 30 # 30 is a balance in providing enough context for the agent vs. pulling down the entire repo history. It is not a scientific number. 27 or 31 or 36 would likely work as well.
 
-      - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1
+      - uses: ./.github/actions/setup
 
       - name: Run Bonk
         uses: ask-bonk/ask-bonk/github@main

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -34,7 +34,7 @@ jobs:
           fetch-depth: 30 # 30 is a balance in providing enough context for the agent vs. pulling down the entire repo history. It is not a scientific number. 27 or 31 or 36 would likely work as well.
 
       - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@v1
+        uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1
 
       - name: Run Bonk
         uses: ask-bonk/ask-bonk/github@main

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -33,8 +33,7 @@ jobs:
         with:
           fetch-depth: 30 # 30 is a balance in providing enough context for the agent vs. pulling down the entire repo history. It is not a scientific number. 27 or 31 or 36 would likely work as well.
 
-      - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1
+      - uses: ./.github/actions/setup
 
       - name: Run Bonk
         uses: ask-bonk/ask-bonk/github@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: voidzero-dev/setup-vp@v1
+      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1
       - name: Build plugin (needed for benchmark workspace type resolution)
         run: vp run build
       - run: vp run check
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: voidzero-dev/setup-vp@v1
+      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1
       - run: vp test run --project unit
 
   test-integration:
@@ -43,7 +43,7 @@ jobs:
         shardTotal: [3]
     steps:
       - uses: actions/checkout@v6
-      - uses: voidzero-dev/setup-vp@v1
+      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1
       - name: Build plugin (needed by ecosystem and nextjs-compat fixtures)
         run: vp run build
       - run: vp test run --project integration --reporter=blob --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: voidzero-dev/setup-vp@v1
+      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1
       - uses: actions/download-artifact@v7
         with:
           path: .vitest-reports
@@ -83,7 +83,7 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v6
-      - uses: voidzero-dev/setup-vp@v1
+      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1
       - name: Build plugin
         run: vp run build
 
@@ -92,7 +92,7 @@ jobs:
         working-directory: packages/vinext
 
       - name: Scaffold a fresh create-next-app project
-        run: vp dlx create-next-app@latest "${{ runner.temp }}/cna-test" --yes
+        run: vp dlx create-next-app@16.2.3 "${{ runner.temp }}/cna-test" --yes
 
       - name: Install vinext from local tarball
         working-directory: ${{ runner.temp }}/cna-test
@@ -142,7 +142,7 @@ jobs:
           - app-with-src
     steps:
       - uses: actions/checkout@v6
-      - uses: voidzero-dev/setup-vp@v1
+      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1
       - name: Build plugin
         run: vp run build
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1
+      - uses: ./.github/actions/setup
       - name: Build plugin (needed for benchmark workspace type resolution)
         run: vp run build
       - run: vp run check
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1
+      - uses: ./.github/actions/setup
       - run: vp test run --project unit
 
   test-integration:
@@ -43,7 +43,7 @@ jobs:
         shardTotal: [3]
     steps:
       - uses: actions/checkout@v6
-      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1
+      - uses: ./.github/actions/setup
       - name: Build plugin (needed by ecosystem and nextjs-compat fixtures)
         run: vp run build
       - run: vp test run --project integration --reporter=blob --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1
+      - uses: ./.github/actions/setup
       - uses: actions/download-artifact@v7
         with:
           path: .vitest-reports
@@ -83,7 +83,7 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v6
-      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1
+      - uses: ./.github/actions/setup
       - name: Build plugin
         run: vp run build
 
@@ -142,7 +142,7 @@ jobs:
           - app-with-src
     steps:
       - uses: actions/checkout@v6
-      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1
+      - uses: ./.github/actions/setup
       - name: Build plugin
         run: vp run build
 

--- a/.github/workflows/deploy-examples.yml
+++ b/.github/workflows/deploy-examples.yml
@@ -46,7 +46,7 @@ jobs:
             wrangler_config: dist/server/wrangler.json
     steps:
       - uses: actions/checkout@v6
-      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1
+      - uses: ./.github/actions/setup
 
       - name: Build vinext plugin
         run: vp run build

--- a/.github/workflows/deploy-examples.yml
+++ b/.github/workflows/deploy-examples.yml
@@ -46,7 +46,7 @@ jobs:
             wrangler_config: dist/server/wrangler.json
     steps:
       - uses: actions/checkout@v6
-      - uses: voidzero-dev/setup-vp@v1
+      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1
 
       - name: Build vinext plugin
         run: vp run build

--- a/.github/workflows/ecosystem-run.yml
+++ b/.github/workflows/ecosystem-run.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout vinext
         uses: actions/checkout@v6
 
-      - uses: voidzero-dev/setup-vp@v1
+      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1
         with:
           node-version: ${{ inputs.node_version }}
 

--- a/.github/workflows/ecosystem-run.yml
+++ b/.github/workflows/ecosystem-run.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout vinext
         uses: actions/checkout@v6
 
-      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1
+      - uses: ./.github/actions/setup
         with:
           node-version: ${{ inputs.node_version }}
 

--- a/.github/workflows/nextjs-tracker.yml
+++ b/.github/workflows/nextjs-tracker.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@v1
+        uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1
 
       - name: Fetch recent Next.js canary commits
         id: commits

--- a/.github/workflows/nextjs-tracker.yml
+++ b/.github/workflows/nextjs-tracker.yml
@@ -32,8 +32,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1
+      - uses: ./.github/actions/setup
 
       - name: Fetch recent Next.js canary commits
         id: commits

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -15,6 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1
+      - uses: ./.github/actions/setup
       - run: vp run build
       - run: vp dlx pkg-pr-new@0.0.66 publish --pnpm './packages/vinext'

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -15,6 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: voidzero-dev/setup-vp@v1
+      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1
       - run: vp run build
-      - run: vp dlx pkg-pr-new publish --pnpm './packages/vinext'
+      - run: vp dlx pkg-pr-new@0.0.66 publish --pnpm './packages/vinext'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           fetch-depth: 0 # full history for changelog generation
 
-      - uses: voidzero-dev/setup-vp@v1
+      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1
 
       - name: Build
         run: vp run build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           fetch-depth: 0 # full history for changelog generation
 
-      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1
+      - uses: ./.github/actions/setup
 
       - name: Build
         run: vp run build

--- a/.github/workflows/tip.yml
+++ b/.github/workflows/tip.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@v1
+        uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1
         with:
           cache: "false"
           run-install: false

--- a/.github/workflows/tip.yml
+++ b/.github/workflows/tip.yml
@@ -44,9 +44,9 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1
+        uses: ./.github/actions/setup
         with:
-          cache: "false"
+          cache: false
           run-install: false
 
       - name: Send failure notification


### PR DESCRIPTION
## Summary

Pin `voidzero-dev/setup-vp` to commit SHA, and pin `create-next-app` and `pkg-pr-new` to exact versions in CI workflows.

## Changes Made

- Pin `voidzero-dev/setup-vp@v1` → `voidzero-dev/setup-vp@237a7eda...` across all 10 workflow files
- `ci.yml`: `create-next-app@latest` → `create-next-app@16.2.3`
- `preview-release.yml`: `pkg-pr-new` → `pkg-pr-new@0.0.66`

## Recommendations

- [ ] Create `.github/dependabot.yml` with [`cooldown`](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-) setting and `github-actions` ecosystem to track action version updates automatically
- [ ] Commit a `package-lock.json` for `benchmarks/nextjs/` and switch [`npm install` → `npm ci`](https://github.com/cloudflare/vinext/blob/5f6bccbd039bbbbbf7e0d516f0737080cef5ce15/.github/workflows/benchmarks.yml#L40) in `benchmarks.yml` to enforce reproducible CI installs (currently [gitignored](https://github.com/cloudflare/vinext/blob/5f6bccbd039bbbbbf7e0d516f0737080cef5ce15/benchmarks/.gitignore#L17) — check if intentional)
- [ ] Pin `npm install` commands in `ecosystem-run.yml` where feasible ([line 80](https://github.com/cloudflare/vinext/blob/5f6bccbd039bbbbbf7e0d516f0737080cef5ce15/.github/workflows/ecosystem-run.yml#L80), [line 88](https://github.com/cloudflare/vinext/blob/5f6bccbd039bbbbbf7e0d516f0737080cef5ce15/.github/workflows/ecosystem-run.yml#L88), [line 101](https://github.com/cloudflare/vinext/blob/5f6bccbd039bbbbbf7e0d516f0737080cef5ce15/.github/workflows/ecosystem-run.yml#L101) install into cloned third-party repos)

<details>
<summary>Why this matters — real-world supply chain attacks</summary>

### GitHub Actions

Mutable tags and branches in GitHub Actions have been exploited in multiple incidents:

- **Trivy, KICS, LiteLLM** ([CVE-2026-33634](https://nvd.nist.gov/vuln/detail/CVE-2026-33634)) — Compromised GitHub Actions used by thousands of repositories, injecting malicious code via tag mutation
- **reviewdog** ([CVE-2025-30154](https://nvd.nist.gov/vuln/detail/CVE-2025-30154)) — Popular review action compromised, leaking CI secrets from repositories that referenced it by tag
- **tj-actions/changed-files** ([CVE-2025-30066](https://nvd.nist.gov/vuln/detail/CVE-2025-30066)) — Action tag was overwritten to exfiltrate secrets from CI runners

Pinning to SHA digests makes these attacks impossible — a commit hash is immutable.

### Package registries

Unpinned package installs in CI are vulnerable to registry compromises:

- **[Axios npm compromise impacting OpenAI](https://openai.com/index/axios-developer-tool-compromise/)** (2026) — Compromised Axios package affected OpenAI and other consumers
- **[PyTorch torchtriton](https://pytorch.org/blog/compromised-nightly-dependency/)** (2022) — Malicious package published to PyPI, executed on install
- **colors.js** ([CVE-2021-23567](https://nvd.nist.gov/vuln/detail/CVE-2021-23567), 2022) — Maintainer intentionally sabotaged the package
- **[ua-parser-js](https://github.com/advisories/GHSA-pjwm-rvh2-c87w)** (2021) — Hijacked npm account used to publish cryptominer
- **[event-stream](https://github.com/advisories/GHSA-mh6f-8j2x-4483)** (2018) — Social engineering attack to inject credential-stealing code

Using lockfiles with `npm ci` and pinning `dlx` versions prevents CI from silently pulling compromised releases.

</details>