### PR TITLE
fix: return error for client hook used without directive

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -354,16 +354,18 @@ const _shimsDir = path.resolve(__dirname, "shims") + "/";
 const _fontGoogleShimPath = resolveShimModulePath(_shimsDir, "font-google");
 
 /**
- * Shims that have a `.react-server.ts` variant for the RSC environment.
- * Maps every import specifier that should be intercepted → the base shim name
- * (without extension). In the RSC env the resolveId hook appends
- * `.react-server`; in other envs it resolves to the base name.
+ * Shims with a `.react-server.ts` variant for the RSC environment.
+ * Maps import specifier → base shim name. In the RSC env, resolveId
+ * appends `.react-server`; in other envs it resolves to the base.
+ *
+ * These MUST NOT appear in `nextShimMap` (resolve.alias) because Vite's
+ * alias plugin runs before user `enforce:"pre"` plugins — aliases are
+ * unoverridable. Keeping them out of the alias lets the resolveId hook
+ * control resolution per-environment.
  *
  * To add a new react-server shim:
  *   1. Create `<name>.react-server.ts` in src/shims/
- *   2. Add an entry here for each import specifier.
- *   3. Remove the corresponding entry from `nextShimMap` (so the alias
- *      doesn't shadow the resolveId hook).
+ *   2. Add entries here for each import specifier.
  */
 const _reactServerShims = new Map<string, string>([
   ["next/navigation", "navigation"],
@@ -857,10 +859,8 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             "next/config": path.join(shimsDir, "config"),
             "next/script": path.join(shimsDir, "script"),
             "next/server": path.join(shimsDir, "server"),
-            // "next/navigation" is intentionally NOT in this alias map.
-            // It is resolved in the resolveId hook so the RSC environment
-            // gets the react-server variant (navigation.react-server.ts)
-            // which omits client-only hooks. See #834.
+            // "next/navigation" is NOT here — it's in _reactServerShims and
+            // handled by the resolveId hook for per-environment control (#834).
             "next/headers": path.join(shimsDir, "headers"),
             "next/font/google": path.join(shimsDir, "font-google"),
             "next/font/local": path.join(shimsDir, "font-local"),
@@ -917,7 +917,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
               "work-unit-async-storage",
             ),
             // Re-export public modules for internal path imports
-            // "next/dist/client/components/navigation" handled in resolveId (see #834).
+            // "next/dist/client/components/navigation" in _reactServerShims (#834).
             "next/dist/server/config-shared": path.join(shimsDir, "internal", "utils"),
             // server-only / client-only marker packages
             "server-only": path.join(shimsDir, "server-only"),
@@ -1193,9 +1193,23 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         // Merge incoming excludes into the top-level optimizeDeps so
         // Pages Router builds (which don't set per-environment configs)
         // also preserve entries from earlier plugins.
+        // Build a rolldown plugin for shims resolved via resolveId instead
+        // of resolve.alias. The dep optimizer's bundler uses its own
+        // rolldown pipeline (not the Vite plugin pipeline), so it needs
+        // these aliases injected separately. See #834.
+        const depOptimizeAliasPlugin = {
+          name: "vinext:dep-optimize-alias",
+          resolveId(id: string) {
+            const shimBase = _reactServerShims.get(id);
+            if (shimBase !== undefined) {
+              return resolveShimModulePath(shimsDir, shimBase);
+            }
+          },
+        };
         viteConfig.optimizeDeps = {
           exclude: [...new Set([...incomingExclude, "vinext", "@vercel/og"])],
           ...(incomingInclude.length > 0 ? { include: incomingInclude } : {}),
+          rolldownOptions: { plugins: [depOptimizeAliasPlugin] },
         };
         const pagesOptimizeEntries = !hasAppDir
           ? [
@@ -1550,12 +1564,9 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             );
           }
 
-          // In the RSC environment, resolve shims that contain client-only
-          // hooks to their `.react-server.ts` variant. Those variants
-          // re-export the server-safe subset and provide error-throwing
-          // stubs for hooks, matching Next.js / React's react-server
-          // export condition behavior. Adding a new react-server shim is
-          // just adding an entry to the map below.
+          // Shims with react-server variants — resolve per-environment.
+          // These are NOT in resolve.alias (Vite's alias plugin runs
+          // before enforce:"pre" plugins and can't be overridden).
           // See https://github.com/cloudflare/vinext/issues/834
           const reactServerShim = _reactServerShims.get(cleanId);
           if (reactServerShim !== undefined) {

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -353,6 +353,24 @@ const IMAGE_EXTS = "png|jpe?g|gif|webp|avif|svg|ico|bmp|tiff?";
 const _shimsDir = path.resolve(__dirname, "shims") + "/";
 const _fontGoogleShimPath = resolveShimModulePath(_shimsDir, "font-google");
 
+/**
+ * Shims that have a `.react-server.ts` variant for the RSC environment.
+ * Maps every import specifier that should be intercepted → the base shim name
+ * (without extension). In the RSC env the resolveId hook appends
+ * `.react-server`; in other envs it resolves to the base name.
+ *
+ * To add a new react-server shim:
+ *   1. Create `<name>.react-server.ts` in src/shims/
+ *   2. Add an entry here for each import specifier.
+ *   3. Remove the corresponding entry from `nextShimMap` (so the alias
+ *      doesn't shadow the resolveId hook).
+ */
+const _reactServerShims = new Map<string, string>([
+  ["next/navigation", "navigation"],
+  ["next/navigation.js", "navigation"],
+  ["next/dist/client/components/navigation", "navigation"],
+]);
+
 const clientManualChunks = createClientManualChunks(_shimsDir);
 const clientOutputConfig = createClientOutputConfig(clientManualChunks);
 const clientCodeSplittingConfig = createClientCodeSplittingConfig(clientManualChunks);
@@ -839,7 +857,10 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             "next/config": path.join(shimsDir, "config"),
             "next/script": path.join(shimsDir, "script"),
             "next/server": path.join(shimsDir, "server"),
-            "next/navigation": path.join(shimsDir, "navigation"),
+            // "next/navigation" is intentionally NOT in this alias map.
+            // It is resolved in the resolveId hook so the RSC environment
+            // gets the react-server variant (navigation.react-server.ts)
+            // which omits client-only hooks. See #834.
             "next/headers": path.join(shimsDir, "headers"),
             "next/font/google": path.join(shimsDir, "font-google"),
             "next/font/local": path.join(shimsDir, "font-local"),
@@ -896,7 +917,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
               "work-unit-async-storage",
             ),
             // Re-export public modules for internal path imports
-            "next/dist/client/components/navigation": path.join(shimsDir, "navigation"),
+            // "next/dist/client/components/navigation" handled in resolveId (see #834).
             "next/dist/server/config-shared": path.join(shimsDir, "internal", "utils"),
             // server-only / client-only marker packages
             "server-only": path.join(shimsDir, "server-only"),
@@ -1527,6 +1548,22 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
               RESOLVED_VIRTUAL_GOOGLE_FONTS +
               cleanId.slice(queryIndex + VIRTUAL_GOOGLE_FONTS.length)
             );
+          }
+
+          // In the RSC environment, resolve shims that contain client-only
+          // hooks to their `.react-server.ts` variant. Those variants
+          // re-export the server-safe subset and provide error-throwing
+          // stubs for hooks, matching Next.js / React's react-server
+          // export condition behavior. Adding a new react-server shim is
+          // just adding an entry to the map below.
+          // See https://github.com/cloudflare/vinext/issues/834
+          const reactServerShim = _reactServerShims.get(cleanId);
+          if (reactServerShim !== undefined) {
+            const shimName =
+              this.environment?.name === "rsc"
+                ? `${reactServerShim}.react-server`
+                : reactServerShim;
+            return resolveShimModulePath(_shimsDir, shimName);
           }
         },
       },

--- a/packages/vinext/src/shims/client-hook-error.ts
+++ b/packages/vinext/src/shims/client-hook-error.ts
@@ -1,0 +1,15 @@
+/**
+ * Shared error helper for client-only hooks called in Server Components.
+ *
+ * Used by `.react-server.ts` shim variants to provide a clear, actionable
+ * error message when a developer forgets the "use client" directive.
+ *
+ * @see https://github.com/cloudflare/vinext/issues/834
+ */
+export function throwClientHookError(hookName: string): never {
+  throw new Error(
+    `${hookName} only works in Client Components. Add the "use client" directive ` +
+      `at the top of the file to use it. Read more: ` +
+      `https://nextjs.org/docs/messages/react-client-hook-in-server-component`,
+  );
+}

--- a/packages/vinext/src/shims/navigation.react-server.ts
+++ b/packages/vinext/src/shims/navigation.react-server.ts
@@ -1,0 +1,72 @@
+import { throwClientHookError } from "./client-hook-error.js";
+
+// Re-export server-safe APIs from the canonical navigation module.
+// This import uses a relative path to the source file, which does NOT
+// go through the `next/navigation` resolveId hook — so it always
+// resolves to the full module, avoiding a circular redirect.
+export {
+  // Types
+  type NavigationContext,
+  type SegmentMap,
+
+  // Server-side navigation state
+  GLOBAL_ACCESSORS_KEY,
+  _registerStateAccessors,
+  getNavigationContext,
+  setNavigationContext,
+
+  // Layout segment context (returns null in RSC — createContext unavailable)
+  getLayoutSegmentContext,
+  ServerInsertedHTMLContext,
+
+  // Server-inserted HTML
+  flushServerInsertedHTML,
+  clearServerInsertedHTML,
+
+  // Control-flow errors
+  HTTP_ERROR_FALLBACK_ERROR_CODE,
+  isHTTPAccessFallbackError,
+  getAccessFallbackHTTPStatus,
+  RedirectType,
+  redirect,
+  permanentRedirect,
+  notFound,
+  forbidden,
+  unauthorized,
+
+  // Utilities
+  ReadonlyURLSearchParams,
+} from "./navigation.js";
+
+// These hooks are client-only. Exporting error-throwing stubs (rather than
+// omitting them entirely) gives developers a clear, actionable error message
+// instead of the cryptic "is not a function" that Vite's runtime module
+// system produces for missing exports.
+
+export function usePathname(): never {
+  throwClientHookError("usePathname()");
+}
+
+export function useSearchParams(): never {
+  throwClientHookError("useSearchParams()");
+}
+
+export function useParams(): never {
+  throwClientHookError("useParams()");
+}
+
+export function useRouter(): never {
+  throwClientHookError("useRouter()");
+}
+
+export function useSelectedLayoutSegment(): never {
+  throwClientHookError("useSelectedLayoutSegment()");
+}
+
+export function useSelectedLayoutSegments(): never {
+  throwClientHookError("useSelectedLayoutSegments()");
+}
+
+export function useServerInsertedHTML(): never {
+  throwClientHookError("useServerInsertedHTML()");
+}

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -844,10 +844,6 @@ function subscribeToNavigation(cb: () => void): () => void {
   };
 }
 
-// ---------------------------------------------------------------------------
-// Hooks
-// ---------------------------------------------------------------------------
-
 /* oxlint-disable eslint-plugin-react-hooks/rules-of-hooks */
 /**
  * Returns the current pathname.

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -727,6 +727,21 @@ describe("App Router integration", () => {
     expect(html).toContain('content="noindex"');
   });
 
+  // ── Client hook usage without "use client" (#834) ──
+  // When a Server Component imports a client-only hook from next/navigation
+  // without the "use client" directive, vinext should surface a clear error
+  // instead of silently returning a fallback value.
+  it("errors when client hook is used in a Server Component without 'use client' (#834)", async () => {
+    const { res, html } = await fetchHtml(baseUrl, "/missing-use-client-test");
+    expect(res.status).toBe(200); // error boundary renders, not a 500
+    // The error message should be clear and actionable
+    expect(html).toContain("usePathname()");
+    expect(html).toContain("Client Components");
+    expect(html).toContain("use client");
+    // Should NOT contain the actual page content (it errored before rendering)
+    expect(html).not.toContain("Missing use client test");
+  });
+
   it("redirect() from Server Component returns redirect response", async () => {
     const res = await fetch(`${baseUrl}/redirect-test`, { redirect: "manual" });
     expect(res.status).toBeGreaterThanOrEqual(300);

--- a/tests/fixtures/app-basic/app/missing-use-client-test/page.tsx
+++ b/tests/fixtures/app-basic/app/missing-use-client-test/page.tsx
@@ -1,0 +1,21 @@
+/**
+ * Reproduces https://github.com/cloudflare/vinext/issues/834
+ *
+ * This is a SERVER component (no "use client" directive) that calls
+ * usePathname() from next/navigation. It should throw a clear error
+ * telling the developer to add "use client", but previously it
+ * silently returned a fallback value.
+ */
+import { usePathname } from "next/navigation";
+
+export default function MissingUseClientPage() {
+  // This should throw an error because we're in a server component
+  const pathname = usePathname();
+
+  return (
+    <div>
+      <h1>Missing use client test</h1>
+      <p>Pathname: {pathname}</p>
+    </div>
+  );
+}


### PR DESCRIPTION
fixes #834

**Summary**
- Hooks like usePathname() from next/navigation now throw a clear error when called from a Server Component without the "use client" directive, matching Next.js behavior
- Previously these hooks silently returned fallback values, making the root cause extremely difficult to diagnose
- Uses the same react-server export condition pattern as Next.js: the RSC Vite environment resolves next/navigation to a server-safe variant that provides error-throwing stubs for client-only hooks

**Approach**
A new navigation.react-server.ts shim re-exports server-safe APIs (redirect, notFound, setNavigationContext, etc.) from the canonical navigation.ts and adds error-throwing stubs for client-only hooks. The resolveId hook routes next/navigation to this variant in the RSC environment and to the full shim elsewhere.