### PR TITLE
fix(shims): import local navigation module in error boundary

### DIFF
--- a/packages/vinext/src/shims/error-boundary.tsx
+++ b/packages/vinext/src/shims/error-boundary.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import React from "react";
-// oxlint-disable-next-line @typescript-eslint/no-require-imports -- next/navigation is shimmed
-import { usePathname } from "next/navigation";
+// Import the local shim, not the public next/navigation alias. The built
+// package may execute this file before the plugin's resolveId hook is active.
+import { usePathname } from "./navigation.js";
 
 export type ErrorBoundaryProps = {
   fallback: React.ComponentType<{ error: Error; reset: () => void }>;


### PR DESCRIPTION
## Summary

The built package can execute `shims/error-boundary.tsx` before the plugin's `resolveId` hook is active, so the public `next/navigation` alias is not yet registered. Import the local `./navigation.js` module directly instead.

Three-line change extracted from the PR #768 restack; landing independently because it's orthogonal to the layout-persistence feature work.

## Stack context

This is the sibling of the PR #768 restack. Not part of the 6-PR stack; open on its own.

## Test plan

- [x] `vp check` on the shim file
- [ ] Manual verification in `examples/` that the error boundary still renders when thrown