### PR TITLE
feat(app-router): emit per-layout flags in the RSC payload [2/6]

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -2461,6 +2461,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           const dynamicDetected = consumeDynamicUsage();
           return { result, dynamicDetected };
         } finally {
+          consumeDynamicUsage();
           if (priorDynamic) markDynamicUsage();
         }
       },

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -2449,6 +2449,22 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       const _asyncSearchParams = makeThenableParams(_probeSearchObj);
       return PageComponent({ params: _asyncLayoutParams, searchParams: _asyncSearchParams });
     },
+    classification: {
+      getLayoutId(index) {
+        const tp = route.layoutTreePositions?.[index] ?? 0;
+        return "layout:" + __createAppPageTreePath(route.routeSegments, tp);
+      },
+      async runWithIsolatedDynamicScope(fn) {
+        const priorDynamic = consumeDynamicUsage();
+        try {
+          const result = await fn();
+          const dynamicDetected = consumeDynamicUsage();
+          return { result, dynamicDetected };
+        } finally {
+          if (priorDynamic) markDynamicUsage();
+        }
+      },
+    },
     revalidateSeconds,
     mountedSlotsHeader: __mountedSlotsHeader,
     renderErrorBoundaryResponse(renderErr) {

--- a/packages/vinext/src/server/app-elements.ts
+++ b/packages/vinext/src/server/app-elements.ts
@@ -137,12 +137,15 @@ function parseLayoutFlags(value: unknown): LayoutFlags {
 }
 
 /**
- * Type predicate for a plain (non-null, non-array) record of app elements.
- * Used to distinguish the App Router elements object from bare React elements
- * at the render boundary. Delegates to React's canonical `isValidElement` so
- * we don't depend on React's internal `$$typeof` marker scheme.
+ * Type predicate for a plain (non-null, non-array) record of app payload values.
+ * Used to distinguish the App Router payload object from bare React elements at
+ * the render boundary. Narrows to `Readonly<Record<string, unknown>>` because
+ * the outgoing payload carries heterogeneous values (ReactNodes for the rendered
+ * tree, plus metadata like `__layoutFlags` which is a plain object). Delegates
+ * to React's canonical `isValidElement` so we don't depend on React's internal
+ * `$$typeof` marker scheme.
  */
-export function isAppElementsRecord(value: unknown): value is Record<string, ReactNode> {
+export function isAppElementsRecord(value: unknown): value is Readonly<Record<string, unknown>> {
   if (typeof value !== "object" || value === null) return false;
   if (Array.isArray(value)) return false;
   if (isValidElement(value)) return false;
@@ -183,7 +186,7 @@ export function buildOutgoingAppPayload(input: {
   if (!isAppElementsRecord(input.element)) {
     return input.element;
   }
-  return withLayoutFlags({ ...input.element }, input.layoutFlags);
+  return withLayoutFlags(input.element, input.layoutFlags);
 }
 
 /**

--- a/packages/vinext/src/server/app-elements.ts
+++ b/packages/vinext/src/server/app-elements.ts
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import { isValidElement, type ReactNode } from "react";
 
 const APP_INTERCEPTION_SEPARATOR = "\0";
 
@@ -16,7 +16,23 @@ export type AppWireElementValue = ReactNode | string | null;
 export type AppElements = Readonly<Record<string, AppElementValue>>;
 export type AppWireElements = Readonly<Record<string, AppWireElementValue>>;
 
-/** Per-layout static/dynamic flags propagated in the RSC payload. `"s"` = static, `"d"` = dynamic. */
+/**
+ * Per-layout static/dynamic flags. `"s"` = static (skippable on next nav);
+ * `"d"` = dynamic (must always render).
+ *
+ * Lifecycle (partial — later PRs extend this):
+ *
+ *   1. PROBE   — probeAppPageLayouts (server/app-page-execution.ts) returns
+ *                LayoutFlags for every layout in the route at render time.
+ *
+ *   2. ATTACH  — withLayoutFlags (this file) writes `__layoutFlags` into the
+ *                outgoing App Router payload record.
+ *
+ *   3. WIRE    — renderToReadableStream serializes the record as RSC row 0.
+ *
+ *   4. PARSE   — readAppElementsMetadata (this file) extracts layoutFlags from
+ *                the wire payload on the client side.
+ */
 export type LayoutFlags = Readonly<Record<string, "s" | "d">>;
 
 export type AppElementsMetadata = {
@@ -121,9 +137,61 @@ function parseLayoutFlags(value: unknown): LayoutFlags {
 }
 
 /**
+ * Type predicate for a plain (non-null, non-array) record of app elements.
+ * Used to distinguish the App Router elements object from bare React elements
+ * at the render boundary. Delegates to React's canonical `isValidElement` so
+ * we don't depend on React's internal `$$typeof` marker scheme.
+ */
+export function isAppElementsRecord(value: unknown): value is Record<string, ReactNode> {
+  if (typeof value !== "object" || value === null) return false;
+  if (Array.isArray(value)) return false;
+  if (isValidElement(value)) return false;
+  return true;
+}
+
+/**
+ * Pure: returns a new record with `__layoutFlags` attached. Owns the write
+ * boundary for the layout flags key so the write side sits next to
+ * `readAppElementsMetadata`.
+ *
+ * See `LayoutFlags` type docblock in this file for lifecycle.
+ */
+export function withLayoutFlags<T extends Record<string, unknown>>(
+  elements: T,
+  layoutFlags: LayoutFlags,
+): T & { [APP_LAYOUT_FLAGS_KEY]: LayoutFlags } {
+  return { ...elements, [APP_LAYOUT_FLAGS_KEY]: layoutFlags };
+}
+
+/**
+ * The outgoing wire payload shape. Includes ReactNode values for the
+ * rendered tree plus metadata values like LayoutFlags attached under
+ * known keys (e.g. __layoutFlags). Distinct from AppElements / AppWireElements
+ * which only carry render-time values.
+ */
+export type AppOutgoingElements = Readonly<Record<string, ReactNode | LayoutFlags>>;
+
+/**
+ * Pure: builds the outgoing payload for the wire. Non-record inputs (e.g. a
+ * bare React element) are returned unchanged. Record inputs get a fresh copy
+ * with `__layoutFlags` attached. Never mutates `input.element`.
+ */
+export function buildOutgoingAppPayload(input: {
+  element: ReactNode | Readonly<Record<string, ReactNode>>;
+  layoutFlags: LayoutFlags;
+}): ReactNode | AppOutgoingElements {
+  if (!isAppElementsRecord(input.element)) {
+    return input.element;
+  }
+  return withLayoutFlags({ ...input.element }, input.layoutFlags);
+}
+
+/**
  * Parses metadata from the wire payload. Accepts `Record<string, unknown>`
  * because the RSC payload carries heterogeneous values (React elements,
  * strings, and plain objects like layout flags) under the same record type.
+ *
+ * See `LayoutFlags` type docblock in this file for lifecycle.
  */
 export function readAppElementsMetadata(
   elements: Readonly<Record<string, unknown>>,

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import type { CachedAppPageValue } from "../shims/cache.js";
+import { buildOutgoingAppPayload, type AppOutgoingElements } from "./app-elements.js";
 import {
   finalizeAppPageHtmlCacheResponse,
   scheduleAppPageRscCacheWrite,
@@ -10,6 +11,7 @@ import {
   teeAppPageRscStreamForCapture,
   type AppPageFontPreload,
   type AppPageSpecialError,
+  type LayoutClassificationOptions,
 } from "./app-page-execution.js";
 import { probeAppPageBeforeRender } from "./app-page-probe.js";
 import {
@@ -84,7 +86,7 @@ export type RenderAppPageLifecycleOptions = {
   ) => Promise<Response>;
   renderPageSpecialError: (specialError: AppPageSpecialError) => Promise<Response>;
   renderToReadableStream: (
-    element: ReactNode | Record<string, ReactNode>,
+    element: ReactNode | AppOutgoingElements,
     options: { onError: AppPageBoundaryOnError },
   ) => ReadableStream<Uint8Array>;
   routeHasLocalBoundary: boolean;
@@ -93,7 +95,8 @@ export type RenderAppPageLifecycleOptions = {
   scriptNonce?: string;
   mountedSlotsHeader?: string | null;
   waitUntil?: (promise: Promise<void>) => void;
-  element: ReactNode | Record<string, ReactNode>;
+  element: ReactNode | Readonly<Record<string, ReactNode>>;
+  classification?: LayoutClassificationOptions | null;
 };
 
 function buildResponseTiming(
@@ -137,15 +140,26 @@ export async function renderAppPageLifecycle(
     runWithSuppressedHookWarning(probe) {
       return options.runWithSuppressedHookWarning(probe);
     },
+    classification: options.classification,
   });
   if (preRenderResult.response) {
     return preRenderResult.response;
   }
 
+  const layoutFlags = preRenderResult.layoutFlags;
+
+  // Render the CANONICAL element. The outgoing payload carries per-layout
+  // static/dynamic flags under `__layoutFlags` so the client can later tell
+  // which layouts are safe to skip on subsequent navigations.
+  const outgoingElement = buildOutgoingAppPayload({
+    element: options.element,
+    layoutFlags,
+  });
+
   const compileEnd = options.isProduction ? undefined : performance.now();
   const baseOnError = options.createRscOnErrorHandler(options.cleanPathname, options.routePattern);
   const rscErrorTracker = createAppPageRscErrorTracker(baseOnError);
-  const rscStream = options.renderToReadableStream(options.element, {
+  const rscStream = options.renderToReadableStream(outgoingElement, {
     onError: rscErrorTracker.onRenderError,
   });
 

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -2138,6 +2138,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           const dynamicDetected = consumeDynamicUsage();
           return { result, dynamicDetected };
         } finally {
+          consumeDynamicUsage();
           if (priorDynamic) markDynamicUsage();
         }
       },
@@ -4371,6 +4372,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           const dynamicDetected = consumeDynamicUsage();
           return { result, dynamicDetected };
         } finally {
+          consumeDynamicUsage();
           if (priorDynamic) markDynamicUsage();
         }
       },
@@ -6599,6 +6601,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           const dynamicDetected = consumeDynamicUsage();
           return { result, dynamicDetected };
         } finally {
+          consumeDynamicUsage();
           if (priorDynamic) markDynamicUsage();
         }
       },
@@ -8859,6 +8862,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           const dynamicDetected = consumeDynamicUsage();
           return { result, dynamicDetected };
         } finally {
+          consumeDynamicUsage();
           if (priorDynamic) markDynamicUsage();
         }
       },
@@ -11093,6 +11097,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           const dynamicDetected = consumeDynamicUsage();
           return { result, dynamicDetected };
         } finally {
+          consumeDynamicUsage();
           if (priorDynamic) markDynamicUsage();
         }
       },
@@ -13687,6 +13692,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           const dynamicDetected = consumeDynamicUsage();
           return { result, dynamicDetected };
         } finally {
+          consumeDynamicUsage();
           if (priorDynamic) markDynamicUsage();
         }
       },

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -2126,6 +2126,22 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       const _asyncSearchParams = makeThenableParams(_probeSearchObj);
       return PageComponent({ params: _asyncLayoutParams, searchParams: _asyncSearchParams });
     },
+    classification: {
+      getLayoutId(index) {
+        const tp = route.layoutTreePositions?.[index] ?? 0;
+        return "layout:" + __createAppPageTreePath(route.routeSegments, tp);
+      },
+      async runWithIsolatedDynamicScope(fn) {
+        const priorDynamic = consumeDynamicUsage();
+        try {
+          const result = await fn();
+          const dynamicDetected = consumeDynamicUsage();
+          return { result, dynamicDetected };
+        } finally {
+          if (priorDynamic) markDynamicUsage();
+        }
+      },
+    },
     revalidateSeconds,
     mountedSlotsHeader: __mountedSlotsHeader,
     renderErrorBoundaryResponse(renderErr) {
@@ -4343,6 +4359,22 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       const _asyncSearchParams = makeThenableParams(_probeSearchObj);
       return PageComponent({ params: _asyncLayoutParams, searchParams: _asyncSearchParams });
     },
+    classification: {
+      getLayoutId(index) {
+        const tp = route.layoutTreePositions?.[index] ?? 0;
+        return "layout:" + __createAppPageTreePath(route.routeSegments, tp);
+      },
+      async runWithIsolatedDynamicScope(fn) {
+        const priorDynamic = consumeDynamicUsage();
+        try {
+          const result = await fn();
+          const dynamicDetected = consumeDynamicUsage();
+          return { result, dynamicDetected };
+        } finally {
+          if (priorDynamic) markDynamicUsage();
+        }
+      },
+    },
     revalidateSeconds,
     mountedSlotsHeader: __mountedSlotsHeader,
     renderErrorBoundaryResponse(renderErr) {
@@ -6554,6 +6586,22 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       });
       const _asyncSearchParams = makeThenableParams(_probeSearchObj);
       return PageComponent({ params: _asyncLayoutParams, searchParams: _asyncSearchParams });
+    },
+    classification: {
+      getLayoutId(index) {
+        const tp = route.layoutTreePositions?.[index] ?? 0;
+        return "layout:" + __createAppPageTreePath(route.routeSegments, tp);
+      },
+      async runWithIsolatedDynamicScope(fn) {
+        const priorDynamic = consumeDynamicUsage();
+        try {
+          const result = await fn();
+          const dynamicDetected = consumeDynamicUsage();
+          return { result, dynamicDetected };
+        } finally {
+          if (priorDynamic) markDynamicUsage();
+        }
+      },
     },
     revalidateSeconds,
     mountedSlotsHeader: __mountedSlotsHeader,
@@ -8799,6 +8847,22 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       const _asyncSearchParams = makeThenableParams(_probeSearchObj);
       return PageComponent({ params: _asyncLayoutParams, searchParams: _asyncSearchParams });
     },
+    classification: {
+      getLayoutId(index) {
+        const tp = route.layoutTreePositions?.[index] ?? 0;
+        return "layout:" + __createAppPageTreePath(route.routeSegments, tp);
+      },
+      async runWithIsolatedDynamicScope(fn) {
+        const priorDynamic = consumeDynamicUsage();
+        try {
+          const result = await fn();
+          const dynamicDetected = consumeDynamicUsage();
+          return { result, dynamicDetected };
+        } finally {
+          if (priorDynamic) markDynamicUsage();
+        }
+      },
+    },
     revalidateSeconds,
     mountedSlotsHeader: __mountedSlotsHeader,
     renderErrorBoundaryResponse(renderErr) {
@@ -11016,6 +11080,22 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       });
       const _asyncSearchParams = makeThenableParams(_probeSearchObj);
       return PageComponent({ params: _asyncLayoutParams, searchParams: _asyncSearchParams });
+    },
+    classification: {
+      getLayoutId(index) {
+        const tp = route.layoutTreePositions?.[index] ?? 0;
+        return "layout:" + __createAppPageTreePath(route.routeSegments, tp);
+      },
+      async runWithIsolatedDynamicScope(fn) {
+        const priorDynamic = consumeDynamicUsage();
+        try {
+          const result = await fn();
+          const dynamicDetected = consumeDynamicUsage();
+          return { result, dynamicDetected };
+        } finally {
+          if (priorDynamic) markDynamicUsage();
+        }
+      },
     },
     revalidateSeconds,
     mountedSlotsHeader: __mountedSlotsHeader,
@@ -13594,6 +13674,22 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       });
       const _asyncSearchParams = makeThenableParams(_probeSearchObj);
       return PageComponent({ params: _asyncLayoutParams, searchParams: _asyncSearchParams });
+    },
+    classification: {
+      getLayoutId(index) {
+        const tp = route.layoutTreePositions?.[index] ?? 0;
+        return "layout:" + __createAppPageTreePath(route.routeSegments, tp);
+      },
+      async runWithIsolatedDynamicScope(fn) {
+        const priorDynamic = consumeDynamicUsage();
+        try {
+          const result = await fn();
+          const dynamicDetected = consumeDynamicUsage();
+          return { result, dynamicDetected };
+        } finally {
+          if (priorDynamic) markDynamicUsage();
+        }
+      },
     },
     revalidateSeconds,
     mountedSlotsHeader: __mountedSlotsHeader,

--- a/tests/app-elements.test.ts
+++ b/tests/app-elements.test.ts
@@ -7,11 +7,14 @@ import {
   APP_ROOT_LAYOUT_KEY,
   APP_ROUTE_KEY,
   APP_UNMATCHED_SLOT_WIRE_VALUE,
+  buildOutgoingAppPayload,
   createAppPayloadCacheKey,
   createAppPayloadRouteId,
+  isAppElementsRecord,
   normalizeAppElements,
   readAppElementsMetadata,
   resolveVisitedResponseInterceptionContext,
+  withLayoutFlags,
 } from "../packages/vinext/src/server/app-elements.js";
 
 describe("app elements payload helpers", () => {
@@ -147,5 +150,143 @@ describe("app elements payload helpers", () => {
     );
 
     expect(metadata.layoutFlags).toEqual({});
+  });
+});
+
+describe("isAppElementsRecord", () => {
+  it("returns true for a plain record", () => {
+    expect(isAppElementsRecord({ "page:/": "x" })).toBe(true);
+  });
+
+  it("returns false for a React element", () => {
+    expect(isAppElementsRecord(React.createElement("div", null, "x"))).toBe(false);
+  });
+
+  it("returns false for null", () => {
+    expect(isAppElementsRecord(null)).toBe(false);
+  });
+
+  it("returns false for an array", () => {
+    expect(isAppElementsRecord([])).toBe(false);
+  });
+
+  it("returns false for a string", () => {
+    expect(isAppElementsRecord("string")).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isAppElementsRecord(undefined)).toBe(false);
+  });
+});
+
+describe("withLayoutFlags", () => {
+  it("attaches the __layoutFlags key with the supplied value", () => {
+    const input = { "page:/": "page" };
+    const result = withLayoutFlags(input, { "layout:/": "s" });
+    expect(result[APP_LAYOUT_FLAGS_KEY]).toEqual({ "layout:/": "s" });
+  });
+
+  it("does not mutate the input", () => {
+    const input: Record<string, unknown> = { "page:/": "page", "layout:/": "layout" };
+    const snapshot = structuredClone(input);
+    const result = withLayoutFlags(input, { "layout:/": "d" });
+    expect(result).not.toBe(input);
+    expect(input).toEqual(snapshot);
+    expect(Object.keys(input)).toEqual(Object.keys(snapshot));
+    expect(APP_LAYOUT_FLAGS_KEY in input).toBe(false);
+  });
+
+  it("preserves other keys on the returned object", () => {
+    const input = { "page:/blog": "page", "layout:/": "layout" };
+    const result = withLayoutFlags(input, { "layout:/": "s" });
+    expect(result["page:/blog"]).toBe("page");
+    expect(result["layout:/"]).toBe("layout");
+  });
+
+  it("returns a new object with a different identity", () => {
+    const input = { "page:/": "page" };
+    const result = withLayoutFlags(input, {});
+    expect(result).not.toBe(input);
+  });
+});
+
+describe("buildOutgoingAppPayload", () => {
+  it("returns a non-record element unchanged (same identity)", () => {
+    const element = React.createElement("div", null, "page");
+    const result = buildOutgoingAppPayload({
+      element,
+      layoutFlags: { "layout:/": "s" },
+    });
+    expect(result).toBe(element);
+  });
+
+  it("returns a new object for a record element (different identity)", () => {
+    const element = { "page:/": "page" };
+    const result = buildOutgoingAppPayload({
+      element,
+      layoutFlags: {},
+    });
+    expect(result).not.toBe(element);
+  });
+
+  it("does not mutate the input record", () => {
+    const element: Record<string, React.ReactNode> = {
+      "layout:/": "root-layout",
+      "layout:/blog": "blog-layout",
+      "page:/blog": "blog-page",
+    };
+    const snapshot = structuredClone(element);
+    const result = buildOutgoingAppPayload({
+      element,
+      layoutFlags: { "layout:/": "s", "layout:/blog": "d" },
+    });
+    expect(result).not.toBe(element);
+    expect(element).toEqual(snapshot);
+    expect(Object.keys(element)).toEqual(Object.keys(snapshot));
+    expect(APP_LAYOUT_FLAGS_KEY in element).toBe(false);
+  });
+
+  it("attaches __layoutFlags on the returned record", () => {
+    const result = buildOutgoingAppPayload({
+      element: { "page:/": "page" },
+      layoutFlags: { "layout:/": "s" },
+    });
+    expect(isAppElementsRecord(result)).toBe(true);
+    if (isAppElementsRecord(result)) {
+      expect(result[APP_LAYOUT_FLAGS_KEY]).toEqual({ "layout:/": "s" });
+    }
+  });
+
+  it("returns canonical record keys regardless of any upstream skip intent", () => {
+    const result = buildOutgoingAppPayload({
+      element: { "layout:/": "root-layout", "page:/": "page" },
+      layoutFlags: { "layout:/": "s" },
+    });
+    expect(isAppElementsRecord(result)).toBe(true);
+    if (isAppElementsRecord(result)) {
+      expect(result["layout:/"]).toBe("root-layout");
+      expect(result["page:/"]).toBe("page");
+    }
+  });
+
+  it("preserves non-layout metadata keys", () => {
+    const result = buildOutgoingAppPayload({
+      element: {
+        [APP_ROUTE_KEY]: "route:/blog",
+        [APP_ROOT_LAYOUT_KEY]: "/",
+        [APP_INTERCEPTION_CONTEXT_KEY]: null,
+        "layout:/": "root-layout",
+        "page:/blog": "blog-page",
+      },
+      layoutFlags: { "layout:/": "s" },
+    });
+    expect(isAppElementsRecord(result)).toBe(true);
+    if (isAppElementsRecord(result)) {
+      expect(result[APP_ROUTE_KEY]).toBe("route:/blog");
+      expect(result[APP_ROOT_LAYOUT_KEY]).toBe("/");
+      expect(result[APP_INTERCEPTION_CONTEXT_KEY]).toBeNull();
+      expect(result["page:/blog"]).toBe("blog-page");
+      expect(result["layout:/"]).toBe("root-layout");
+    }
   });
 });

--- a/tests/app-page-execution.test.ts
+++ b/tests/app-page-execution.test.ts
@@ -277,6 +277,51 @@ describe("app page execution helpers", () => {
     expect(result.layoutFlags["layout:/"]).toBe("s");
   });
 
+  it("isolates dynamic usage across throwing layout probes", async () => {
+    let dynamicUsageDetected = false;
+
+    const result = await probeAppPageLayouts({
+      layoutCount: 2,
+      onLayoutError() {
+        return Promise.resolve(null);
+      },
+      probeLayoutAt(layoutIndex) {
+        if (layoutIndex === 1) {
+          dynamicUsageDetected = true;
+          throw new Error("layout failed after headers()");
+        }
+        return null;
+      },
+      runWithSuppressedHookWarning(probe) {
+        return probe();
+      },
+      classification: {
+        getLayoutId(layoutIndex) {
+          return ["layout:/", "layout:/dashboard"][layoutIndex];
+        },
+        async runWithIsolatedDynamicScope(fn) {
+          const priorDynamic = dynamicUsageDetected;
+          dynamicUsageDetected = false;
+          try {
+            const result = await fn();
+            const detectedInScope = dynamicUsageDetected;
+            dynamicUsageDetected = false;
+            return { result, dynamicDetected: detectedInScope };
+          } finally {
+            dynamicUsageDetected = false;
+            if (priorDynamic) dynamicUsageDetected = true;
+          }
+        },
+      },
+    });
+
+    expect(result.response).toBeNull();
+    expect(result.layoutFlags).toEqual({
+      "layout:/": "s",
+      "layout:/dashboard": "d",
+    });
+  });
+
   it("skips probe for build-time classified layouts", async () => {
     let probeCalls = 0;
     const result = await probeAppPageLayouts({

--- a/tests/app-page-render.test.ts
+++ b/tests/app-page-render.test.ts
@@ -337,7 +337,6 @@ describe("layoutFlags injection into RSC payload", () => {
     layoutCount?: number;
     probeLayoutAt?: (index: number) => unknown;
     classification?: LayoutClassificationOptions | null;
-    requestedSkipLayoutIds?: ReadonlySet<string>;
   }) {
     let capturedElement: Record<string, unknown> | null = null;
 
@@ -382,7 +381,6 @@ describe("layoutFlags injection into RSC payload", () => {
       runWithSuppressedHookWarning: <T>(probe: () => Promise<T>) => probe(),
       element: overrides.element ?? { "page:/test": "test-page" },
       classification: overrides.classification,
-      requestedSkipLayoutIds: overrides.requestedSkipLayoutIds,
     };
 
     return {
@@ -493,7 +491,6 @@ describe("layoutFlags injection into RSC payload", () => {
           return { result, dynamicDetected: false };
         },
       },
-      requestedSkipLayoutIds: new Set(["layout:/"]),
     });
 
     await renderAppPageLifecycle(options);

--- a/tests/app-page-render.test.ts
+++ b/tests/app-page-render.test.ts
@@ -1,6 +1,20 @@
+import type { ReactNode } from "react";
 import { describe, expect, it, vi } from "vite-plus/test";
 import React from "react";
+import {
+  APP_LAYOUT_FLAGS_KEY,
+  isAppElementsRecord,
+  type AppOutgoingElements,
+} from "../packages/vinext/src/server/app-elements.js";
+import type { LayoutClassificationOptions } from "../packages/vinext/src/server/app-page-execution.js";
 import { renderAppPageLifecycle } from "../packages/vinext/src/server/app-page-render.js";
+
+function captureRecord(value: ReactNode | AppOutgoingElements): Record<string, unknown> {
+  if (!isAppElementsRecord(value)) {
+    throw new Error("Expected captured element to be a plain record");
+  }
+  return value;
+}
 
 function createStream(chunks: string[]): ReadableStream<Uint8Array> {
   return new ReadableStream({
@@ -314,5 +328,211 @@ describe("app page render lifecycle", () => {
     await expect(response.text()).resolves.toBe("<html>page</html>");
     expect(common.waitUntilPromises).toHaveLength(0);
     expect(common.isrSet).not.toHaveBeenCalled();
+  });
+});
+
+describe("layoutFlags injection into RSC payload", () => {
+  function createRscOptions(overrides: {
+    element?: Record<string, ReactNode>;
+    layoutCount?: number;
+    probeLayoutAt?: (index: number) => unknown;
+    classification?: LayoutClassificationOptions | null;
+    requestedSkipLayoutIds?: ReadonlySet<string>;
+  }) {
+    let capturedElement: Record<string, unknown> | null = null;
+
+    const options = {
+      cleanPathname: "/test",
+      clearRequestContext: vi.fn(),
+      consumeDynamicUsage: vi.fn(() => false),
+      createRscOnErrorHandler: () => () => {},
+      getDraftModeCookieHeader: () => null,
+      getFontLinks: () => [],
+      getFontPreloads: () => [],
+      getFontStyles: () => [],
+      getNavigationContext: () => null,
+      getPageTags: () => [],
+      getRequestCacheLife: () => null,
+      handlerStart: 0,
+      hasLoadingBoundary: false,
+      isDynamicError: false,
+      isForceDynamic: false,
+      isForceStatic: false,
+      isProduction: true,
+      isRscRequest: true,
+      isrHtmlKey: (p: string) => `html:${p}`,
+      isrRscKey: (p: string) => `rsc:${p}`,
+      isrSet: vi.fn().mockResolvedValue(undefined),
+      layoutCount: overrides.layoutCount ?? 0,
+      loadSsrHandler: vi.fn(),
+      middlewareContext: { headers: null, status: null },
+      params: {},
+      probeLayoutAt: overrides.probeLayoutAt ?? (() => null),
+      probePage: () => null,
+      revalidateSeconds: null,
+      renderErrorBoundaryResponse: async () => null,
+      renderLayoutSpecialError: async () => new Response("error", { status: 500 }),
+      renderPageSpecialError: async () => new Response("error", { status: 500 }),
+      renderToReadableStream(el: ReactNode | AppOutgoingElements) {
+        capturedElement = captureRecord(el);
+        return createStream(["flight-data"]);
+      },
+      routeHasLocalBoundary: false,
+      routePattern: "/test",
+      runWithSuppressedHookWarning: <T>(probe: () => Promise<T>) => probe(),
+      element: overrides.element ?? { "page:/test": "test-page" },
+      classification: overrides.classification,
+      requestedSkipLayoutIds: overrides.requestedSkipLayoutIds,
+    };
+
+    return {
+      options,
+      getCapturedElement: (): Record<string, unknown> => {
+        if (capturedElement === null) {
+          throw new Error("renderToReadableStream was not called");
+        }
+        return capturedElement;
+      },
+    };
+  }
+
+  it("injects __layoutFlags with 's' when classification detects a static layout", async () => {
+    const { options, getCapturedElement } = createRscOptions({
+      element: { "layout:/": "root-layout", "page:/test": "test-page" },
+      layoutCount: 1,
+      probeLayoutAt: () => null,
+      classification: {
+        getLayoutId: () => "layout:/",
+        buildTimeClassifications: null,
+        async runWithIsolatedDynamicScope(fn) {
+          const result = await fn();
+          return { result, dynamicDetected: false };
+        },
+      },
+    });
+
+    await renderAppPageLifecycle(options);
+    expect(getCapturedElement()[APP_LAYOUT_FLAGS_KEY]).toEqual({ "layout:/": "s" });
+  });
+
+  it("injects __layoutFlags with 'd' for dynamic layouts", async () => {
+    const { options, getCapturedElement } = createRscOptions({
+      element: { "layout:/": "root-layout", "page:/test": "test-page" },
+      layoutCount: 1,
+      probeLayoutAt: () => null,
+      classification: {
+        getLayoutId: () => "layout:/",
+        buildTimeClassifications: null,
+        async runWithIsolatedDynamicScope(fn) {
+          const result = await fn();
+          return { result, dynamicDetected: true };
+        },
+      },
+    });
+
+    await renderAppPageLifecycle(options);
+    expect(getCapturedElement()[APP_LAYOUT_FLAGS_KEY]).toEqual({ "layout:/": "d" });
+  });
+
+  it("injects empty __layoutFlags when classification is not provided (backward compat)", async () => {
+    const { options, getCapturedElement } = createRscOptions({
+      element: { "layout:/": "root-layout", "page:/test": "test-page" },
+      layoutCount: 1,
+      probeLayoutAt: () => null,
+    });
+
+    await renderAppPageLifecycle(options);
+    expect(getCapturedElement()[APP_LAYOUT_FLAGS_KEY]).toEqual({});
+  });
+
+  it("injects __layoutFlags for multiple independently classified layouts", async () => {
+    let callCount = 0;
+    const { options, getCapturedElement } = createRscOptions({
+      element: {
+        "layout:/": "root-layout",
+        "layout:/blog": "blog-layout",
+        "page:/blog/post": "post-page",
+      },
+      layoutCount: 2,
+      probeLayoutAt: () => null,
+      classification: {
+        getLayoutId: (index: number) => (index === 0 ? "layout:/" : "layout:/blog"),
+        buildTimeClassifications: null,
+        async runWithIsolatedDynamicScope(fn) {
+          callCount++;
+          const result = await fn();
+          // probeAppPageLayouts iterates from layoutCount-1 down to 0:
+          // call 1 → layout index 1 (blog) → dynamic
+          // call 2 → layout index 0 (root) → static
+          return { result, dynamicDetected: callCount === 1 };
+        },
+      },
+    });
+
+    await renderAppPageLifecycle(options);
+    expect(getCapturedElement()[APP_LAYOUT_FLAGS_KEY]).toEqual({
+      "layout:/": "s",
+      "layout:/blog": "d",
+    });
+  });
+
+  it("__layoutFlags includes flags for ALL layouts even when some are skipped", async () => {
+    const { options, getCapturedElement } = createRscOptions({
+      element: {
+        "layout:/": "root-layout",
+        "layout:/blog": "blog-layout",
+        "page:/blog/post": "post-page",
+      },
+      layoutCount: 2,
+      probeLayoutAt: () => null,
+      classification: {
+        getLayoutId: (index: number) => (index === 0 ? "layout:/" : "layout:/blog"),
+        buildTimeClassifications: null,
+        async runWithIsolatedDynamicScope(fn) {
+          const result = await fn();
+          return { result, dynamicDetected: false };
+        },
+      },
+      requestedSkipLayoutIds: new Set(["layout:/"]),
+    });
+
+    await renderAppPageLifecycle(options);
+    // layoutFlags must include ALL layout flags, even for skipped layouts
+    expect(getCapturedElement()[APP_LAYOUT_FLAGS_KEY]).toEqual({
+      "layout:/": "s",
+      "layout:/blog": "s",
+    });
+  });
+
+  it("wire payload layoutFlags uses only the shorthand 's'/'d' values, never tagged reasons", async () => {
+    const { options, getCapturedElement } = createRscOptions({
+      element: {
+        "layout:/": "root-layout",
+        "layout:/admin": "admin-layout",
+        "page:/admin/users": "users-page",
+      },
+      layoutCount: 2,
+      probeLayoutAt: () => null,
+      classification: {
+        buildTimeClassifications: new Map([
+          [0, "static"],
+          [1, "dynamic"],
+        ]),
+        getLayoutId: (index: number) => (index === 0 ? "layout:/" : "layout:/admin"),
+        async runWithIsolatedDynamicScope(fn) {
+          const result = await fn();
+          return { result, dynamicDetected: false };
+        },
+      },
+    });
+
+    await renderAppPageLifecycle(options);
+
+    const wireFlags = getCapturedElement()[APP_LAYOUT_FLAGS_KEY];
+    expect(wireFlags).toEqual({ "layout:/": "s", "layout:/admin": "d" });
+
+    for (const [_id, flag] of Object.entries(wireFlags as Record<string, unknown>)) {
+      expect(flag === "s" || flag === "d").toBe(true);
+    }
   });
 });


### PR DESCRIPTION
## Summary

**PR 2 of 6 — restack of #768.** Now rebased onto `main` after #838 merged.

Wires runtime layout classification through `renderAppPageLifecycle` and attaches the resulting flags as `__layoutFlags` in the outgoing RSC payload via `buildOutgoingAppPayload`. Payload-shape helpers (`withLayoutFlags`, `isAppElementsRecord`, `buildOutgoingAppPayload`, `AppOutgoingElements`) live alongside `readAppElementsMetadata` so the write and read boundaries sit next to each other.

No filtering yet; the outgoing element is always canonical. Filtering lands in PR 3.

## Stack

1. ~~[1/6] #838 — centralize request-derived page inputs~~ ✅ merged
2. **[2/6] this PR** — emit per-layout flags in the RSC payload
3. [3/6] filter skipped layouts from RSC responses and cached reads
4. [4/6] send X-Vinext-Router-Skip on navigation requests
5. [5/6] wire build-time layout classification
6. [6/6] classification reasons sidecar

## Test plan

- [x] `tests/app-elements.test.ts` (28 tests)
- [x] `tests/app-page-render.test.ts` (13 tests)
- [x] `tests/app-page-execution.test.ts` (13 tests)
- [x] `tests/entry-templates.test.ts` (22 tests, snapshot regenerated)
