### PR TITLE
chore(debug): classification reasons sidecar behind VINEXT_DEBUG_CLASSIFICATION [6/6]

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -215,6 +215,7 @@ ${interceptEntries.join(",\n")}
     );
     return `  {
     __buildTimeClassifications: __VINEXT_CLASS(${routeIdx}), // evaluated once at module load
+    __buildTimeReasons: __classDebug ? __VINEXT_CLASS_REASONS(${routeIdx}) : null,
     pattern: ${JSON.stringify(route.pattern)},
     patternParts: ${JSON.stringify(route.patternParts)},
     isDynamic: ${route.isDynamic},
@@ -573,6 +574,16 @@ const __isrDebug = process.env.NEXT_PRIVATE_DEBUG_CACHE
   ? console.debug.bind(console, "[vinext] ISR:")
   : undefined;
 
+// Classification debug — opt in with VINEXT_DEBUG_CLASSIFICATION=1. Gated on
+// the env var so the hot path pays no overhead unless an operator is actively
+// tracing why a layout was flagged static or dynamic. The reason payload is
+// carried by __VINEXT_CLASS_REASONS and consumed inside probeAppPageLayouts.
+const __classDebug = process.env.VINEXT_DEBUG_CLASSIFICATION
+  ? function(layoutId, reason) {
+      console.debug("[vinext] CLS:", layoutId, reason);
+    }
+  : undefined;
+
 // Normalize null-prototype objects from matchPattern() into thenable objects
 // that work both as Promises (for Next.js 15+ async params) and as plain
 // objects with synchronous property access (for pre-15 code like params.id).
@@ -751,6 +762,15 @@ async function __ensureInstrumentation() {
 // plugin patches this stub, every route falls back to the Layer 3
 // runtime probe, which is the current (slow) behaviour.
 function __VINEXT_CLASS(routeIdx) {
+  return null;
+}
+
+// Build-time layout classification reasons dispatch. Sibling of
+// __VINEXT_CLASS, returning a per-route Map<layoutIndex, ClassificationReason>
+// that feeds the debug channel when VINEXT_DEBUG_CLASSIFICATION is active.
+// Replaced in generateBundle with a real dispatch table; the stub returns
+// null so the hot path never allocates reason maps when debug is off.
+function __VINEXT_CLASS_REASONS(routeIdx) {
   return null;
 }
 
@@ -2496,6 +2516,8 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         return "layout:" + __createAppPageTreePath(route.routeSegments, tp);
       },
       buildTimeClassifications: route.__buildTimeClassifications,
+      buildTimeReasons: route.__buildTimeReasons,
+      debugClassification: __classDebug,
       async runWithIsolatedDynamicScope(fn) {
         const priorDynamic = consumeDynamicUsage();
         try {

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -19,6 +19,7 @@ import { generateSsrEntry } from "./entries/app-ssr-entry.js";
 import { generateBrowserEntry } from "./entries/app-browser-entry.js";
 import {
   buildGenerateBundleReplacement,
+  buildReasonsReplacement,
   collectRouteClassificationManifest,
   type RouteClassificationManifest,
 } from "./build/route-classification-manifest.js";
@@ -1684,11 +1685,15 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         if (this.environment?.name !== "rsc") return;
         if (!rscClassificationManifest) return;
 
+        const enableClassificationDebug = Boolean(process.env.VINEXT_DEBUG_CLASSIFICATION);
+
         // The `?` after the semicolon is intentional: Rolldown may or may not
         // emit the trailing semicolon depending on minification settings.
         // This regex relies on `__VINEXT_CLASS` retaining its name, which holds
         // because RSC entry chunk bindings are not subject to scope-hoisting renames.
         const stubRe = /function __VINEXT_CLASS\(routeIdx\)\s*\{\s*return null;?\s*\}/;
+        const reasonsStubRe =
+          /function __VINEXT_CLASS_REASONS\(routeIdx\)\s*\{\s*return null;?\s*\}/;
 
         // Skip the scan-phase build where the RSC entry code has been
         // tree-shaken out entirely. In the real RSC build the chunk that
@@ -1731,6 +1736,11 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         if (chunksWithStubBody.length > 1) {
           throw new Error(
             `vinext: build-time classification — expected __VINEXT_CLASS stub in exactly one RSC chunk, found ${chunksWithStubBody.length}`,
+          );
+        }
+        if (enableClassificationDebug && !reasonsStubRe.test(chunksWithStubBody[0]!.chunk.code)) {
+          throw new Error(
+            "vinext: build-time classification — __VINEXT_CLASS_REASONS stub is missing alongside __VINEXT_CLASS. The generator and generateBundle have drifted.",
           );
         }
 
@@ -1797,6 +1807,16 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         const patchedBody = `function __VINEXT_CLASS(routeIdx) { return (${replacement})(routeIdx); }`;
         const target = chunksWithStubBody[0]!.chunk;
         target.code = target.code.replace(stubRe, patchedBody);
+
+        if (enableClassificationDebug) {
+          const reasonsReplacement = buildReasonsReplacement(
+            rscClassificationManifest,
+            layer2PerRoute,
+          );
+          const patchedReasonsBody = `function __VINEXT_CLASS_REASONS(routeIdx) { return (${reasonsReplacement})(routeIdx); }`;
+          target.code = target.code.replace(reasonsStubRe, patchedReasonsBody);
+        }
+
         // The patched body is longer than the stub, so any existing source map
         // would be stale. RSC entry source maps are not served or consumed, so
         // nulling the map is safe and prevents stale-map confusion in tooling.

--- a/packages/vinext/src/server/app-page-execution.ts
+++ b/packages/vinext/src/server/app-page-execution.ts
@@ -1,6 +1,8 @@
 import type { LayoutFlags } from "./app-elements.js";
+import type { ClassificationReason } from "../build/layout-classification-types.js";
 
 export type { LayoutFlags };
+export type { ClassificationReason };
 
 export type AppPageSpecialError =
   | { kind: "redirect"; location: string; statusCode: number }
@@ -31,6 +33,22 @@ export type ProbeAppPageLayoutsResult = {
 export type LayoutClassificationOptions = {
   /** Build-time classifications from segment config or module graph, keyed by layout index. */
   buildTimeClassifications?: ReadonlyMap<number, "static" | "dynamic"> | null;
+  /**
+   * Per-layout classification reasons keyed by layout index. Requires
+   * `VINEXT_DEBUG_CLASSIFICATION` at BOTH lifecycle points: at build time so
+   * the plugin patches the `__VINEXT_CLASS_REASONS` dispatch stub, and at
+   * runtime so the route object actually calls it. Setting the flag only at
+   * runtime leaves the stub returning `null`, and every build-time classified
+   * layout will fall through to `{ layer: "no-classifier" }` in the debug
+   * channel. The hot path never reads this and the wire payload is unchanged.
+   */
+  buildTimeReasons?: ReadonlyMap<number, ClassificationReason> | null;
+  /**
+   * Emits one log line per layout with the classification reason, keyed by
+   * layout ID. Set by the generator when `VINEXT_DEBUG_CLASSIFICATION` is
+   * active. When undefined, the probe loop skips debug emission entirely.
+   */
+  debugClassification?: (layoutId: string, reason: ClassificationReason) => void;
   /** Maps layout index to its layout ID (e.g. "layout:/blog"). */
   getLayoutId: (layoutIndex: number) => string;
   /** Runs a function with isolated dynamic usage tracking per layout. */
@@ -116,6 +134,7 @@ export async function buildAppPageSpecialErrorResponse(
   });
 }
 
+/** See `LayoutFlags` type docblock in app-elements.ts for lifecycle. */
 export async function probeAppPageLayouts(
   options: ProbeAppPageLayoutsOptions,
 ): Promise<ProbeAppPageLayoutsResult> {
@@ -130,6 +149,17 @@ export async function probeAppPageLayouts(
         // Build-time classified (Layer 1 or Layer 2): skip dynamic isolation,
         // but still probe for special errors (redirects, not-found).
         layoutFlags[cls.getLayoutId(layoutIndex)] = buildTimeResult === "static" ? "s" : "d";
+        if (cls.debugClassification) {
+          // `no-classifier` is the documented fallback for a layout that was
+          // build-time classified but whose reason payload is absent — either
+          // because the build was run without `VINEXT_DEBUG_CLASSIFICATION` or
+          // because no Layer 1/2 classifier attached a reason. This is the sole
+          // producer of the variant; see `layout-classification-types.ts`.
+          cls.debugClassification(
+            cls.getLayoutId(layoutIndex),
+            cls.buildTimeReasons?.get(layoutIndex) ?? { layer: "no-classifier" },
+          );
+        }
         const errorResponse = await probeLayoutForErrors(options, layoutIndex);
         if (errorResponse) return errorResponse;
         continue;
@@ -143,9 +173,22 @@ export async function probeAppPageLayouts(
             options.probeLayoutAt(layoutIndex),
           );
           layoutFlags[cls.getLayoutId(layoutIndex)] = dynamicDetected ? "d" : "s";
+          if (cls.debugClassification) {
+            cls.debugClassification(cls.getLayoutId(layoutIndex), {
+              layer: "runtime-probe",
+              outcome: dynamicDetected ? "dynamic" : "static",
+            });
+          }
         } catch (error) {
           // Probe failed — conservatively treat as dynamic.
           layoutFlags[cls.getLayoutId(layoutIndex)] = "d";
+          if (cls.debugClassification) {
+            cls.debugClassification(cls.getLayoutId(layoutIndex), {
+              layer: "runtime-probe",
+              outcome: "dynamic",
+              error: error instanceof Error ? error.message : String(error),
+            });
+          }
           const errorResponse = await options.onLayoutError(error, layoutIndex);
           if (errorResponse) return errorResponse;
         }

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -259,6 +259,16 @@ const __isrDebug = process.env.NEXT_PRIVATE_DEBUG_CACHE
   ? console.debug.bind(console, "[vinext] ISR:")
   : undefined;
 
+// Classification debug — opt in with VINEXT_DEBUG_CLASSIFICATION=1. Gated on
+// the env var so the hot path pays no overhead unless an operator is actively
+// tracing why a layout was flagged static or dynamic. The reason payload is
+// carried by __VINEXT_CLASS_REASONS and consumed inside probeAppPageLayouts.
+const __classDebug = process.env.VINEXT_DEBUG_CLASSIFICATION
+  ? function(layoutId, reason) {
+      console.debug("[vinext] CLS:", layoutId, reason);
+    }
+  : undefined;
+
 // Normalize null-prototype objects from matchPattern() into thenable objects
 // that work both as Promises (for Next.js 15+ async params) and as plain
 // objects with synchronous property access (for pre-15 code like params.id).
@@ -416,9 +426,19 @@ function __VINEXT_CLASS(routeIdx) {
   return null;
 }
 
+// Build-time layout classification reasons dispatch. Sibling of
+// __VINEXT_CLASS, returning a per-route Map<layoutIndex, ClassificationReason>
+// that feeds the debug channel when VINEXT_DEBUG_CLASSIFICATION is active.
+// Replaced in generateBundle with a real dispatch table; the stub returns
+// null so the hot path never allocates reason maps when debug is off.
+function __VINEXT_CLASS_REASONS(routeIdx) {
+  return null;
+}
+
 const routes = [
   {
     __buildTimeClassifications: __VINEXT_CLASS(0), // evaluated once at module load
+    __buildTimeReasons: __classDebug ? __VINEXT_CLASS_REASONS(0) : null,
     pattern: "/",
     patternParts: [],
     isDynamic: false,
@@ -443,6 +463,7 @@ const routes = [
   },
   {
     __buildTimeClassifications: __VINEXT_CLASS(1), // evaluated once at module load
+    __buildTimeReasons: __classDebug ? __VINEXT_CLASS_REASONS(1) : null,
     pattern: "/about",
     patternParts: ["about"],
     isDynamic: false,
@@ -467,6 +488,7 @@ const routes = [
   },
   {
     __buildTimeClassifications: __VINEXT_CLASS(2), // evaluated once at module load
+    __buildTimeReasons: __classDebug ? __VINEXT_CLASS_REASONS(2) : null,
     pattern: "/blog/:slug",
     patternParts: ["blog",":slug"],
     isDynamic: true,
@@ -491,6 +513,7 @@ const routes = [
   },
   {
     __buildTimeClassifications: __VINEXT_CLASS(3), // evaluated once at module load
+    __buildTimeReasons: __classDebug ? __VINEXT_CLASS_REASONS(3) : null,
     pattern: "/dashboard",
     patternParts: ["dashboard"],
     isDynamic: false,
@@ -2176,6 +2199,8 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         return "layout:" + __createAppPageTreePath(route.routeSegments, tp);
       },
       buildTimeClassifications: route.__buildTimeClassifications,
+      buildTimeReasons: route.__buildTimeReasons,
+      debugClassification: __classDebug,
       async runWithIsolatedDynamicScope(fn) {
         const priorDynamic = consumeDynamicUsage();
         try {
@@ -2532,6 +2557,16 @@ const __isrDebug = process.env.NEXT_PRIVATE_DEBUG_CACHE
   ? console.debug.bind(console, "[vinext] ISR:")
   : undefined;
 
+// Classification debug — opt in with VINEXT_DEBUG_CLASSIFICATION=1. Gated on
+// the env var so the hot path pays no overhead unless an operator is actively
+// tracing why a layout was flagged static or dynamic. The reason payload is
+// carried by __VINEXT_CLASS_REASONS and consumed inside probeAppPageLayouts.
+const __classDebug = process.env.VINEXT_DEBUG_CLASSIFICATION
+  ? function(layoutId, reason) {
+      console.debug("[vinext] CLS:", layoutId, reason);
+    }
+  : undefined;
+
 // Normalize null-prototype objects from matchPattern() into thenable objects
 // that work both as Promises (for Next.js 15+ async params) and as plain
 // objects with synchronous property access (for pre-15 code like params.id).
@@ -2689,9 +2724,19 @@ function __VINEXT_CLASS(routeIdx) {
   return null;
 }
 
+// Build-time layout classification reasons dispatch. Sibling of
+// __VINEXT_CLASS, returning a per-route Map<layoutIndex, ClassificationReason>
+// that feeds the debug channel when VINEXT_DEBUG_CLASSIFICATION is active.
+// Replaced in generateBundle with a real dispatch table; the stub returns
+// null so the hot path never allocates reason maps when debug is off.
+function __VINEXT_CLASS_REASONS(routeIdx) {
+  return null;
+}
+
 const routes = [
   {
     __buildTimeClassifications: __VINEXT_CLASS(0), // evaluated once at module load
+    __buildTimeReasons: __classDebug ? __VINEXT_CLASS_REASONS(0) : null,
     pattern: "/",
     patternParts: [],
     isDynamic: false,
@@ -2716,6 +2761,7 @@ const routes = [
   },
   {
     __buildTimeClassifications: __VINEXT_CLASS(1), // evaluated once at module load
+    __buildTimeReasons: __classDebug ? __VINEXT_CLASS_REASONS(1) : null,
     pattern: "/about",
     patternParts: ["about"],
     isDynamic: false,
@@ -2740,6 +2786,7 @@ const routes = [
   },
   {
     __buildTimeClassifications: __VINEXT_CLASS(2), // evaluated once at module load
+    __buildTimeReasons: __classDebug ? __VINEXT_CLASS_REASONS(2) : null,
     pattern: "/blog/:slug",
     patternParts: ["blog",":slug"],
     isDynamic: true,
@@ -2764,6 +2811,7 @@ const routes = [
   },
   {
     __buildTimeClassifications: __VINEXT_CLASS(3), // evaluated once at module load
+    __buildTimeReasons: __classDebug ? __VINEXT_CLASS_REASONS(3) : null,
     pattern: "/dashboard",
     patternParts: ["dashboard"],
     isDynamic: false,
@@ -4455,6 +4503,8 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         return "layout:" + __createAppPageTreePath(route.routeSegments, tp);
       },
       buildTimeClassifications: route.__buildTimeClassifications,
+      buildTimeReasons: route.__buildTimeReasons,
+      debugClassification: __classDebug,
       async runWithIsolatedDynamicScope(fn) {
         const priorDynamic = consumeDynamicUsage();
         try {
@@ -4811,6 +4861,16 @@ const __isrDebug = process.env.NEXT_PRIVATE_DEBUG_CACHE
   ? console.debug.bind(console, "[vinext] ISR:")
   : undefined;
 
+// Classification debug — opt in with VINEXT_DEBUG_CLASSIFICATION=1. Gated on
+// the env var so the hot path pays no overhead unless an operator is actively
+// tracing why a layout was flagged static or dynamic. The reason payload is
+// carried by __VINEXT_CLASS_REASONS and consumed inside probeAppPageLayouts.
+const __classDebug = process.env.VINEXT_DEBUG_CLASSIFICATION
+  ? function(layoutId, reason) {
+      console.debug("[vinext] CLS:", layoutId, reason);
+    }
+  : undefined;
+
 // Normalize null-prototype objects from matchPattern() into thenable objects
 // that work both as Promises (for Next.js 15+ async params) and as plain
 // objects with synchronous property access (for pre-15 code like params.id).
@@ -4969,9 +5029,19 @@ function __VINEXT_CLASS(routeIdx) {
   return null;
 }
 
+// Build-time layout classification reasons dispatch. Sibling of
+// __VINEXT_CLASS, returning a per-route Map<layoutIndex, ClassificationReason>
+// that feeds the debug channel when VINEXT_DEBUG_CLASSIFICATION is active.
+// Replaced in generateBundle with a real dispatch table; the stub returns
+// null so the hot path never allocates reason maps when debug is off.
+function __VINEXT_CLASS_REASONS(routeIdx) {
+  return null;
+}
+
 const routes = [
   {
     __buildTimeClassifications: __VINEXT_CLASS(0), // evaluated once at module load
+    __buildTimeReasons: __classDebug ? __VINEXT_CLASS_REASONS(0) : null,
     pattern: "/",
     patternParts: [],
     isDynamic: false,
@@ -4996,6 +5066,7 @@ const routes = [
   },
   {
     __buildTimeClassifications: __VINEXT_CLASS(1), // evaluated once at module load
+    __buildTimeReasons: __classDebug ? __VINEXT_CLASS_REASONS(1) : null,
     pattern: "/about",
     patternParts: ["about"],
     isDynamic: false,
@@ -5020,6 +5091,7 @@ const routes = [
   },
   {
     __buildTimeClassifications: __VINEXT_CLASS(2), // evaluated once at module load
+    __buildTimeReasons: __classDebug ? __VINEXT_CLASS_REASONS(2) : null,
     pattern: "/blog/:slug",
     patternParts: ["blog",":slug"],
     isDynamic: true,
@@ -5044,6 +5116,7 @@ const routes = [
   },
   {
     __buildTimeClassifications: __VINEXT_CLASS(3), // evaluated once at module load
+    __buildTimeReasons: __classDebug ? __VINEXT_CLASS_REASONS(3) : null,
     pattern: "/dashboard",
     patternParts: ["dashboard"],
     isDynamic: false,
@@ -6729,6 +6802,8 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         return "layout:" + __createAppPageTreePath(route.routeSegments, tp);
       },
       buildTimeClassifications: route.__buildTimeClassifications,
+      buildTimeReasons: route.__buildTimeReasons,
+      debugClassification: __classDebug,
       async runWithIsolatedDynamicScope(fn) {
         const priorDynamic = consumeDynamicUsage();
         try {
@@ -7085,6 +7160,16 @@ const __isrDebug = process.env.NEXT_PRIVATE_DEBUG_CACHE
   ? console.debug.bind(console, "[vinext] ISR:")
   : undefined;
 
+// Classification debug — opt in with VINEXT_DEBUG_CLASSIFICATION=1. Gated on
+// the env var so the hot path pays no overhead unless an operator is actively
+// tracing why a layout was flagged static or dynamic. The reason payload is
+// carried by __VINEXT_CLASS_REASONS and consumed inside probeAppPageLayouts.
+const __classDebug = process.env.VINEXT_DEBUG_CLASSIFICATION
+  ? function(layoutId, reason) {
+      console.debug("[vinext] CLS:", layoutId, reason);
+    }
+  : undefined;
+
 // Normalize null-prototype objects from matchPattern() into thenable objects
 // that work both as Promises (for Next.js 15+ async params) and as plain
 // objects with synchronous property access (for pre-15 code like params.id).
@@ -7272,9 +7357,19 @@ function __VINEXT_CLASS(routeIdx) {
   return null;
 }
 
+// Build-time layout classification reasons dispatch. Sibling of
+// __VINEXT_CLASS, returning a per-route Map<layoutIndex, ClassificationReason>
+// that feeds the debug channel when VINEXT_DEBUG_CLASSIFICATION is active.
+// Replaced in generateBundle with a real dispatch table; the stub returns
+// null so the hot path never allocates reason maps when debug is off.
+function __VINEXT_CLASS_REASONS(routeIdx) {
+  return null;
+}
+
 const routes = [
   {
     __buildTimeClassifications: __VINEXT_CLASS(0), // evaluated once at module load
+    __buildTimeReasons: __classDebug ? __VINEXT_CLASS_REASONS(0) : null,
     pattern: "/",
     patternParts: [],
     isDynamic: false,
@@ -7299,6 +7394,7 @@ const routes = [
   },
   {
     __buildTimeClassifications: __VINEXT_CLASS(1), // evaluated once at module load
+    __buildTimeReasons: __classDebug ? __VINEXT_CLASS_REASONS(1) : null,
     pattern: "/about",
     patternParts: ["about"],
     isDynamic: false,
@@ -7323,6 +7419,7 @@ const routes = [
   },
   {
     __buildTimeClassifications: __VINEXT_CLASS(2), // evaluated once at module load
+    __buildTimeReasons: __classDebug ? __VINEXT_CLASS_REASONS(2) : null,
     pattern: "/blog/:slug",
     patternParts: ["blog",":slug"],
     isDynamic: true,
@@ -7347,6 +7444,7 @@ const routes = [
   },
   {
     __buildTimeClassifications: __VINEXT_CLASS(3), // evaluated once at module load
+    __buildTimeReasons: __classDebug ? __VINEXT_CLASS_REASONS(3) : null,
     pattern: "/dashboard",
     patternParts: ["dashboard"],
     isDynamic: false,
@@ -9035,6 +9133,8 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         return "layout:" + __createAppPageTreePath(route.routeSegments, tp);
       },
       buildTimeClassifications: route.__buildTimeClassifications,
+      buildTimeReasons: route.__buildTimeReasons,
+      debugClassification: __classDebug,
       async runWithIsolatedDynamicScope(fn) {
         const priorDynamic = consumeDynamicUsage();
         try {
@@ -9391,6 +9491,16 @@ const __isrDebug = process.env.NEXT_PRIVATE_DEBUG_CACHE
   ? console.debug.bind(console, "[vinext] ISR:")
   : undefined;
 
+// Classification debug — opt in with VINEXT_DEBUG_CLASSIFICATION=1. Gated on
+// the env var so the hot path pays no overhead unless an operator is actively
+// tracing why a layout was flagged static or dynamic. The reason payload is
+// carried by __VINEXT_CLASS_REASONS and consumed inside probeAppPageLayouts.
+const __classDebug = process.env.VINEXT_DEBUG_CLASSIFICATION
+  ? function(layoutId, reason) {
+      console.debug("[vinext] CLS:", layoutId, reason);
+    }
+  : undefined;
+
 // Normalize null-prototype objects from matchPattern() into thenable objects
 // that work both as Promises (for Next.js 15+ async params) and as plain
 // objects with synchronous property access (for pre-15 code like params.id).
@@ -9549,9 +9659,19 @@ function __VINEXT_CLASS(routeIdx) {
   return null;
 }
 
+// Build-time layout classification reasons dispatch. Sibling of
+// __VINEXT_CLASS, returning a per-route Map<layoutIndex, ClassificationReason>
+// that feeds the debug channel when VINEXT_DEBUG_CLASSIFICATION is active.
+// Replaced in generateBundle with a real dispatch table; the stub returns
+// null so the hot path never allocates reason maps when debug is off.
+function __VINEXT_CLASS_REASONS(routeIdx) {
+  return null;
+}
+
 const routes = [
   {
     __buildTimeClassifications: __VINEXT_CLASS(0), // evaluated once at module load
+    __buildTimeReasons: __classDebug ? __VINEXT_CLASS_REASONS(0) : null,
     pattern: "/",
     patternParts: [],
     isDynamic: false,
@@ -9576,6 +9696,7 @@ const routes = [
   },
   {
     __buildTimeClassifications: __VINEXT_CLASS(1), // evaluated once at module load
+    __buildTimeReasons: __classDebug ? __VINEXT_CLASS_REASONS(1) : null,
     pattern: "/about",
     patternParts: ["about"],
     isDynamic: false,
@@ -9600,6 +9721,7 @@ const routes = [
   },
   {
     __buildTimeClassifications: __VINEXT_CLASS(2), // evaluated once at module load
+    __buildTimeReasons: __classDebug ? __VINEXT_CLASS_REASONS(2) : null,
     pattern: "/blog/:slug",
     patternParts: ["blog",":slug"],
     isDynamic: true,
@@ -9624,6 +9746,7 @@ const routes = [
   },
   {
     __buildTimeClassifications: __VINEXT_CLASS(3), // evaluated once at module load
+    __buildTimeReasons: __classDebug ? __VINEXT_CLASS_REASONS(3) : null,
     pattern: "/dashboard",
     patternParts: ["dashboard"],
     isDynamic: false,
@@ -11315,6 +11438,8 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         return "layout:" + __createAppPageTreePath(route.routeSegments, tp);
       },
       buildTimeClassifications: route.__buildTimeClassifications,
+      buildTimeReasons: route.__buildTimeReasons,
+      debugClassification: __classDebug,
       async runWithIsolatedDynamicScope(fn) {
         const priorDynamic = consumeDynamicUsage();
         try {
@@ -11671,6 +11796,16 @@ const __isrDebug = process.env.NEXT_PRIVATE_DEBUG_CACHE
   ? console.debug.bind(console, "[vinext] ISR:")
   : undefined;
 
+// Classification debug — opt in with VINEXT_DEBUG_CLASSIFICATION=1. Gated on
+// the env var so the hot path pays no overhead unless an operator is actively
+// tracing why a layout was flagged static or dynamic. The reason payload is
+// carried by __VINEXT_CLASS_REASONS and consumed inside probeAppPageLayouts.
+const __classDebug = process.env.VINEXT_DEBUG_CLASSIFICATION
+  ? function(layoutId, reason) {
+      console.debug("[vinext] CLS:", layoutId, reason);
+    }
+  : undefined;
+
 // Normalize null-prototype objects from matchPattern() into thenable objects
 // that work both as Promises (for Next.js 15+ async params) and as plain
 // objects with synchronous property access (for pre-15 code like params.id).
@@ -11828,9 +11963,19 @@ function __VINEXT_CLASS(routeIdx) {
   return null;
 }
 
+// Build-time layout classification reasons dispatch. Sibling of
+// __VINEXT_CLASS, returning a per-route Map<layoutIndex, ClassificationReason>
+// that feeds the debug channel when VINEXT_DEBUG_CLASSIFICATION is active.
+// Replaced in generateBundle with a real dispatch table; the stub returns
+// null so the hot path never allocates reason maps when debug is off.
+function __VINEXT_CLASS_REASONS(routeIdx) {
+  return null;
+}
+
 const routes = [
   {
     __buildTimeClassifications: __VINEXT_CLASS(0), // evaluated once at module load
+    __buildTimeReasons: __classDebug ? __VINEXT_CLASS_REASONS(0) : null,
     pattern: "/",
     patternParts: [],
     isDynamic: false,
@@ -11855,6 +12000,7 @@ const routes = [
   },
   {
     __buildTimeClassifications: __VINEXT_CLASS(1), // evaluated once at module load
+    __buildTimeReasons: __classDebug ? __VINEXT_CLASS_REASONS(1) : null,
     pattern: "/about",
     patternParts: ["about"],
     isDynamic: false,
@@ -11879,6 +12025,7 @@ const routes = [
   },
   {
     __buildTimeClassifications: __VINEXT_CLASS(2), // evaluated once at module load
+    __buildTimeReasons: __classDebug ? __VINEXT_CLASS_REASONS(2) : null,
     pattern: "/blog/:slug",
     patternParts: ["blog",":slug"],
     isDynamic: true,
@@ -11903,6 +12050,7 @@ const routes = [
   },
   {
     __buildTimeClassifications: __VINEXT_CLASS(3), // evaluated once at module load
+    __buildTimeReasons: __classDebug ? __VINEXT_CLASS_REASONS(3) : null,
     pattern: "/dashboard",
     patternParts: ["dashboard"],
     isDynamic: false,
@@ -13955,6 +14103,8 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         return "layout:" + __createAppPageTreePath(route.routeSegments, tp);
       },
       buildTimeClassifications: route.__buildTimeClassifications,
+      buildTimeReasons: route.__buildTimeReasons,
+      debugClassification: __classDebug,
       async runWithIsolatedDynamicScope(fn) {
         const priorDynamic = consumeDynamicUsage();
         try {

--- a/tests/app-page-execution.test.ts
+++ b/tests/app-page-execution.test.ts
@@ -528,6 +528,46 @@ describe("app page execution helpers", () => {
     });
   });
 
+  it("emits runtime-probe reason with the error message when the probe throws", async () => {
+    const calls: Array<{ layoutId: string; reason: unknown }> = [];
+
+    await probeAppPageLayouts({
+      layoutCount: 2,
+      onLayoutError() {
+        return Promise.resolve(null);
+      },
+      probeLayoutAt(layoutIndex) {
+        if (layoutIndex === 1) throw new Error("headers() outside render");
+        return null;
+      },
+      runWithSuppressedHookWarning(probe) {
+        return probe();
+      },
+      classification: {
+        debugClassification(layoutId, reason) {
+          calls.push({ layoutId, reason });
+        },
+        getLayoutId(layoutIndex) {
+          return ["layout:/", "layout:/dashboard"][layoutIndex];
+        },
+        runWithIsolatedDynamicScope(fn) {
+          return Promise.resolve(fn()).then((result) => ({ result, dynamicDetected: false }));
+        },
+      },
+    });
+
+    const byId = Object.fromEntries(calls.map((c) => [c.layoutId, c.reason]));
+    expect(byId["layout:/dashboard"]).toEqual({
+      layer: "runtime-probe",
+      outcome: "dynamic",
+      error: "headers() outside render",
+    });
+    expect(byId["layout:/"]).toEqual({
+      layer: "runtime-probe",
+      outcome: "static",
+    });
+  });
+
   it("builds Link headers for preloaded app-page fonts", () => {
     expect(
       buildAppPageFontLinkHeader([

--- a/tests/app-page-execution.test.ts
+++ b/tests/app-page-execution.test.ts
@@ -394,6 +394,140 @@ describe("app page execution helpers", () => {
     expect(result.layoutFlags).toEqual({ "layout:/admin": "s" });
   });
 
+  it("does not read build-time reasons when debugClassification is absent", async () => {
+    const throwingReasons = {
+      get() {
+        throw new Error("build-time reasons should stay dormant when debug is disabled");
+      },
+    } as unknown as ReadonlyMap<number, { layer: "segment-config"; key: "dynamic"; value: string }>;
+
+    await probeAppPageLayouts({
+      layoutCount: 2,
+      onLayoutError() {
+        return Promise.resolve(null);
+      },
+      probeLayoutAt() {
+        return null;
+      },
+      runWithSuppressedHookWarning(probe) {
+        return probe();
+      },
+      classification: {
+        buildTimeClassifications: new Map([
+          [0, "static"],
+          [1, "dynamic"],
+        ]),
+        buildTimeReasons: throwingReasons,
+        getLayoutId(layoutIndex) {
+          return ["layout:/", "layout:/admin"][layoutIndex];
+        },
+        runWithIsolatedDynamicScope(fn) {
+          return Promise.resolve({ result: fn(), dynamicDetected: false });
+        },
+      },
+    });
+  });
+
+  it("emits a debug reason per layout when debugClassification is provided with build-time reasons", async () => {
+    const calls: Array<{ layoutId: string; reason: unknown }> = [];
+
+    await probeAppPageLayouts({
+      layoutCount: 3,
+      onLayoutError() {
+        return Promise.resolve(null);
+      },
+      probeLayoutAt() {
+        return null;
+      },
+      runWithSuppressedHookWarning(probe) {
+        return probe();
+      },
+      classification: {
+        buildTimeClassifications: new Map([
+          [0, "static"],
+          [1, "dynamic"],
+          [2, "static"],
+        ]),
+        buildTimeReasons: new Map([
+          [0, { layer: "segment-config", key: "dynamic", value: "force-static" }],
+          [1, { layer: "segment-config", key: "dynamic", value: "force-dynamic" }],
+          [2, { layer: "module-graph", result: "static" }],
+        ]),
+        debugClassification(layoutId, reason) {
+          calls.push({ layoutId, reason });
+        },
+        getLayoutId(layoutIndex) {
+          return ["layout:/", "layout:/admin", "layout:/admin/posts"][layoutIndex];
+        },
+        runWithIsolatedDynamicScope(fn) {
+          return Promise.resolve({ result: fn(), dynamicDetected: false });
+        },
+      },
+    });
+
+    expect(calls).toHaveLength(3);
+    const byId = Object.fromEntries(calls.map((c) => [c.layoutId, c.reason]));
+    expect(byId["layout:/"]).toEqual({
+      layer: "segment-config",
+      key: "dynamic",
+      value: "force-static",
+    });
+    expect(byId["layout:/admin"]).toEqual({
+      layer: "segment-config",
+      key: "dynamic",
+      value: "force-dynamic",
+    });
+    expect(byId["layout:/admin/posts"]).toEqual({
+      layer: "module-graph",
+      result: "static",
+    });
+  });
+
+  it("emits runtime-probe reason for layouts resolved by the Layer 3 probe", async () => {
+    const calls: Array<{ layoutId: string; reason: unknown }> = [];
+    let probeCalls = 0;
+
+    await probeAppPageLayouts({
+      layoutCount: 2,
+      onLayoutError() {
+        return Promise.resolve(null);
+      },
+      probeLayoutAt() {
+        return null;
+      },
+      runWithSuppressedHookWarning(probe) {
+        return probe();
+      },
+      classification: {
+        // No buildTimeClassifications → every layout takes the runtime path.
+        debugClassification(layoutId, reason) {
+          calls.push({ layoutId, reason });
+        },
+        getLayoutId(layoutIndex) {
+          return ["layout:/", "layout:/dashboard"][layoutIndex];
+        },
+        runWithIsolatedDynamicScope(fn) {
+          probeCalls++;
+          // probeAppPageLayouts iterates inner-to-outer:
+          // first call → layout 1 (dashboard) → dynamic
+          // second call → layout 0 (root) → static
+          return Promise.resolve({ result: fn(), dynamicDetected: probeCalls === 1 });
+        },
+      },
+    });
+
+    expect(calls).toHaveLength(2);
+    const byId = Object.fromEntries(calls.map((c) => [c.layoutId, c.reason]));
+    expect(byId["layout:/dashboard"]).toEqual({
+      layer: "runtime-probe",
+      outcome: "dynamic",
+    });
+    expect(byId["layout:/"]).toEqual({
+      layer: "runtime-probe",
+      outcome: "static",
+    });
+  });
+
   it("builds Link headers for preloaded app-page fonts", () => {
     expect(
       buildAppPageFontLinkHeader([

--- a/tests/build-time-classification-integration.test.ts
+++ b/tests/build-time-classification-integration.test.ts
@@ -292,9 +292,17 @@ describe("build-time classification integration", () => {
  * targets the sibling reasons stub. Kept intentionally permissive about the
  * emitted codegen shape so this test survives the #863 refactor.
  */
+type ReasonShape = { layer: string; result?: string };
+
+function isReasonShape(value: unknown): value is ReasonShape {
+  if (!value || typeof value !== "object") return false;
+  if (!("layer" in value)) return false;
+  return typeof value.layer === "string";
+}
+
 function extractReasonsDispatch(
   chunkSource: string,
-): (routeIdx: number) => Map<number, { layer: string }> | null {
+): (routeIdx: number) => Map<number, ReasonShape> | null {
   const stubRe = /function\s+__VINEXT_CLASS_REASONS\s*\(routeIdx\)\s*\{\s*return null;?\s*\}/;
   if (stubRe.test(chunkSource)) {
     throw new Error("__VINEXT_CLASS_REASONS was not patched despite VINEXT_DEBUG_CLASSIFICATION=1");
@@ -312,7 +320,19 @@ function extractReasonsDispatch(
   return (routeIdx: number) => {
     const result: unknown = Reflect.apply(raw, null, [routeIdx]);
     if (result === null) return null;
-    if (result instanceof Map) return result as Map<number, { layer: string }>;
+    if (result instanceof Map) {
+      const narrowed = new Map<number, ReasonShape>();
+      for (const [key, value] of result) {
+        if (typeof key !== "number") {
+          throw new Error(`Reasons dispatch returned non-numeric key: ${String(key)}`);
+        }
+        if (!isReasonShape(value)) {
+          throw new Error(`Reasons dispatch returned malformed reason: ${JSON.stringify(value)}`);
+        }
+        narrowed.set(key, value);
+      }
+      return narrowed;
+    }
     throw new Error(
       `Reasons dispatch returned unexpected value for routeIdx ${routeIdx}: ${JSON.stringify(result)}`,
     );
@@ -335,20 +355,22 @@ describe("build-time classification integration (debug on)", () => {
     );
   });
 
-  it("emits a segment-config reason for the force-dyn layout", () => {
-    // Coarse behavioural assertion: the Layer 1 pipeline produces a
-    // `segment-config` reason for a layout that declares `dynamic = "force-dynamic"`.
-    // We do not pin the exact reason object shape beyond the discriminator
-    // tag — the #863 refactor may reshape codegen, and this test should keep
-    // catching "build-time debug branch stopped producing reasons" regressions
-    // without having to track every field.
+  it("emits both Layer 1 and Layer 2 reasons on the force-dyn route dispatch entry", () => {
+    // Only the discriminator + Layer 2 `result` are pinned so the test
+    // survives the #863 codegen reshape.
     const reasonsFor = extractReasonsDispatch(built.chunkSource);
     const routeIdx = built.routeIndexByPattern.get("/force-dyn");
     expect(routeIdx).toBeDefined();
     const reasons = reasonsFor(routeIdx!);
     expect(reasons).toBeInstanceOf(Map);
-    const layoutReason = reasons!.get(1);
-    expect(layoutReason).toBeDefined();
-    expect(layoutReason!.layer).toBe("segment-config");
+
+    const nestedReason = reasons!.get(1);
+    expect(nestedReason).toBeDefined();
+    expect(nestedReason!.layer).toBe("segment-config");
+
+    const rootReason = reasons!.get(0);
+    expect(rootReason).toBeDefined();
+    expect(rootReason!.layer).toBe("module-graph");
+    expect(rootReason!.result).toBe("static");
   });
 });

--- a/tests/build-time-classification-integration.test.ts
+++ b/tests/build-time-classification-integration.test.ts
@@ -77,7 +77,7 @@ function extractDispatch(chunkSource: string): Dispatch {
  */
 function extractRouteIndexByPattern(chunkSource: string): Map<string, number> {
   const result = new Map<string, number>();
-  const re = /__buildTimeClassifications:\s*__VINEXT_CLASS\((\d+)\)[^,]*,\s*pattern:\s*"([^"]+)"/g;
+  const re = /__buildTimeClassifications:\s*__VINEXT_CLASS\((\d+)\)[\s\S]*?pattern:\s*"([^"]+)"/g;
   let match: RegExpExecArray | null;
   while ((match = re.exec(chunkSource)) !== null) {
     result.set(match[2]!, Number(match[1]!));
@@ -88,7 +88,9 @@ function extractRouteIndexByPattern(chunkSource: string): Map<string, number> {
   return result;
 }
 
-async function buildMinimalFixture(): Promise<BuiltFixture> {
+async function buildMinimalFixture({
+  debug = false,
+}: { debug?: boolean } = {}): Promise<BuiltFixture> {
   const workspaceRoot = path.resolve(import.meta.dirname, "..");
   const workspaceNodeModules = path.join(workspaceRoot, "node_modules");
 
@@ -169,7 +171,28 @@ export default function ForceStaticLayout({ children }) {
     plugins: [vinext({ appDir: tmpDir, rscOutDir, ssrOutDir, clientOutDir })],
     logLevel: "silent",
   });
-  await builder.buildApp();
+
+  // The plugin reads `VINEXT_DEBUG_CLASSIFICATION` directly from `process.env`
+  // in its `generateBundle` hook. Save, override, and restore around the build
+  // so these tests are hermetic: asserting "stub stays null" works even when
+  // a developer has the flag set in their local shell, and the debug-on suite
+  // below can force the patched path without polluting the sibling suite.
+  const envKey = "VINEXT_DEBUG_CLASSIFICATION";
+  const prior = process.env[envKey];
+  if (debug) {
+    process.env[envKey] = "1";
+  } else {
+    delete process.env[envKey];
+  }
+  try {
+    await builder.buildApp();
+  } finally {
+    if (prior === undefined) {
+      delete process.env[envKey];
+    } else {
+      process.env[envKey] = prior;
+    }
+  }
 
   // The RSC entry is emitted as either server/index.js or server/index.mjs
   // depending on whether the fixture has a package.json with "type": "module".
@@ -205,6 +228,21 @@ describe("build-time classification integration", () => {
     // The untouched stub body is `{ return null; }`; the patched body must
     // contain a switch dispatcher.
     expect(built.chunkSource).toMatch(/function\s+__VINEXT_CLASS\s*\(routeIdx\)\s*\{[^}]*switch/);
+  });
+
+  it("gates the reasons sidecar behind __classDebug in the route table", () => {
+    expect(built.chunkSource).toMatch(
+      /__buildTimeReasons:\s*__classDebug\s*\?\s*__VINEXT_CLASS_REASONS\(\d+\)\s*:\s*null/,
+    );
+  });
+
+  it("leaves __VINEXT_CLASS_REASONS as a null stub when build-time debug is off", () => {
+    expect(built.chunkSource).toMatch(
+      /function\s+__VINEXT_CLASS_REASONS\s*\(routeIdx\)\s*\{\s*return null;?\s*\}/,
+    );
+    expect(built.chunkSource).not.toMatch(
+      /function\s+__VINEXT_CLASS_REASONS\s*\(routeIdx\)\s*\{[^}]*switch/,
+    );
   });
 
   it("classifies the force-dynamic layout at build time", () => {
@@ -245,5 +283,72 @@ describe("build-time classification integration", () => {
     const map = built.dispatch(routeIdx!);
     expect(map).toBeInstanceOf(Map);
     expect(map!.get(0)).toBe("static");
+  });
+});
+
+/**
+ * Extracts and evaluates `__VINEXT_CLASS_REASONS` from a build output that was
+ * produced with `VINEXT_DEBUG_CLASSIFICATION=1`. Mirrors `extractDispatch` but
+ * targets the sibling reasons stub. Kept intentionally permissive about the
+ * emitted codegen shape so this test survives the #863 refactor.
+ */
+function extractReasonsDispatch(
+  chunkSource: string,
+): (routeIdx: number) => Map<number, { layer: string }> | null {
+  const stubRe = /function\s+__VINEXT_CLASS_REASONS\s*\(routeIdx\)\s*\{\s*return null;?\s*\}/;
+  if (stubRe.test(chunkSource)) {
+    throw new Error("__VINEXT_CLASS_REASONS was not patched despite VINEXT_DEBUG_CLASSIFICATION=1");
+  }
+  const re =
+    /function\s+__VINEXT_CLASS_REASONS\s*\(routeIdx\)\s*\{\s*return\s+(\([\s\S]*?\))\(routeIdx\);\s*\}/;
+  const match = re.exec(chunkSource);
+  if (!match) {
+    throw new Error("Could not locate patched __VINEXT_CLASS_REASONS in chunk source");
+  }
+  const raw: unknown = vm.runInThisContext(match[1]!);
+  if (typeof raw !== "function") {
+    throw new Error("Patched __VINEXT_CLASS_REASONS body did not evaluate to a function");
+  }
+  return (routeIdx: number) => {
+    const result: unknown = Reflect.apply(raw, null, [routeIdx]);
+    if (result === null) return null;
+    if (result instanceof Map) return result as Map<number, { layer: string }>;
+    throw new Error(
+      `Reasons dispatch returned unexpected value for routeIdx ${routeIdx}: ${JSON.stringify(result)}`,
+    );
+  };
+}
+
+describe("build-time classification integration (debug on)", () => {
+  let built: BuiltFixture;
+
+  beforeAll(async () => {
+    built = await buildMinimalFixture({ debug: true });
+  }, 120_000);
+
+  it("patches __VINEXT_CLASS_REASONS with a populated dispatcher", () => {
+    expect(built.chunkSource).toMatch(
+      /function\s+__VINEXT_CLASS_REASONS\s*\(routeIdx\)\s*\{[^}]*switch/,
+    );
+    expect(built.chunkSource).not.toMatch(
+      /function\s+__VINEXT_CLASS_REASONS\s*\(routeIdx\)\s*\{\s*return null;?\s*\}/,
+    );
+  });
+
+  it("emits a segment-config reason for the force-dyn layout", () => {
+    // Coarse behavioural assertion: the Layer 1 pipeline produces a
+    // `segment-config` reason for a layout that declares `dynamic = "force-dynamic"`.
+    // We do not pin the exact reason object shape beyond the discriminator
+    // tag — the #863 refactor may reshape codegen, and this test should keep
+    // catching "build-time debug branch stopped producing reasons" regressions
+    // without having to track every field.
+    const reasonsFor = extractReasonsDispatch(built.chunkSource);
+    const routeIdx = built.routeIndexByPattern.get("/force-dyn");
+    expect(routeIdx).toBeDefined();
+    const reasons = reasonsFor(routeIdx!);
+    expect(reasons).toBeInstanceOf(Map);
+    const layoutReason = reasons!.get(1);
+    expect(layoutReason).toBeDefined();
+    expect(layoutReason!.layer).toBe("segment-config");
   });
 });


### PR DESCRIPTION
## Summary

**PR 6 of 6, restack of #768.** Previously stacked on #842; now rebased directly onto `main` after #842 merged.

Operators tracing why a layout was flagged static or dynamic can opt in with `VINEXT_DEBUG_CLASSIFICATION=1` at build time. When active, the plugin patches a second stub (`__VINEXT_CLASS_REASONS`) with a dispatch table that returns per-layout `ClassificationReason` structures. The runtime probe loop emits a debug line per layout when `debugClassification` is wired, and the hot path remains allocation-free when debug is off because the stub returns `null`.

The reasons machinery (types, `report.ts` tagged results, and `buildReasonsReplacement`) already shipped in #842 as tested-but-uncalled infrastructure. This PR wires it up end-to-end.

## What changes

- `index.ts` `generateBundle` hook reads `VINEXT_DEBUG_CLASSIFICATION` at build time; when set, it calls `buildReasonsReplacement` and patches the `__VINEXT_CLASS_REASONS` stub alongside `__VINEXT_CLASS`. Runs before the existing `target.map = null` / manifest-clear so both inputs are still available.
- Stub-drift detection extended: when build-time debug is on, a missing `__VINEXT_CLASS_REASONS` stub throws loudly, matching the existing policy for `__VINEXT_CLASS`.
- Generated RSC entry emits the `__VINEXT_CLASS_REASONS` null stub and an env-gated `__classDebug` logger. Each route's `__buildTimeReasons` field is gated `__classDebug ? __VINEXT_CLASS_REASONS(routeIdx) : null`, so at module load the reasons Map is only constructed when runtime debug is also on.
- `app-page-execution.ts` accepts optional `buildTimeReasons` and `debugClassification` in `LayoutClassificationOptions`. The probe loop emits one debug line per layout across all three outcome paths: build-time classified, runtime probe success, runtime probe error. The `no-classifier` variant has a single documented producer here, the `??` fallback when a build-time classified layout has no attached reason payload.
- Tests: new gated-on and gated-off cases in `app-page-execution.test.ts`; integration test asserts the `__classDebug` gating expression and the null stub when build-time debug is off.

## Combinations

Both env checks are independent and all four combinations are safe:

| build-time | runtime | behaviour |
|---|---|---|
| off | off | stub stays `return null`, `__classDebug` undefined, zero cost |
| on  | off | stub patched but never called (`__classDebug` undefined) |
| off | on  | stub stays `return null`, reasons map is null, fallback emits `{ layer: "no-classifier" }` |
| on  | on  | full reason payload per layout |

## Stack

1. [1/6] #838, merged, centralize request-derived page inputs
2. [2/6] #839, merged, emit per-layout flags
3. [3/6] #840, closed, filter skipped layouts. The server-side skip mechanism relied on rewriting the React Flight wire-format payload on egress, which proved too coupled to React-internal tag conventions for a framework that does not vendor React. The skip-mechanism design is being reworked around render-time omission rather than byte-level filtering.
4. [4/6] #841, closed, send X-Vinext-Router-Skip. Closed for the same reason as #840.
5. [5/6] #842, merged, wire build-time layout classification into the RSC entry
6. **[6/6] this PR**, classification reasons sidecar

## Validation

Run locally via `vp test run <file>`:

- [x] `tests/app-page-execution.test.ts` (17 cases, including 3 new debug-gated cases)
- [x] `tests/build-time-classification-integration.test.ts` (7 cases, including 2 new reasons-sidecar cases)
- [x] `tests/entry-templates.test.ts` (snapshot regenerated)
- [x] `tests/app-router.test.ts`
- [x] `vp check` clean

## Risks / follow-ups

- **Regex-based stub patching is the wrong abstraction boundary.** This PR extends the same `generateBundle` + string-replace pattern that @james-elicx flagged on #842 (https://github.com/cloudflare/vinext/pull/842#discussion_r3109733377). Each new dispatch table (here, `__VINEXT_CLASS_REASONS`) multiplies the regex surface and the drift detection surface. The feature itself is fine; the way it crosses the build boundary needs an upgrade. Tracked in #863, which scopes out a virtual-module-with-`renderChunk` replacement that would fold both `__VINEXT_CLASS` and `__VINEXT_CLASS_REASONS` into a single typed module contract. Landing that refactor before the next dispatch surface (render-time layout skip) avoids shipping a third parallel regex.
- The env-var name `VINEXT_DEBUG_CLASSIFICATION` is a literal in three sites (plugin, emitted codegen template, runtime type docblock). A rename requires grepping all three. Acceptable for a debug flag.
- The `classifyAllRouteLayouts` test-only divergence risk called out in #842 is unchanged by this PR.