### PR TITLE
fix(plugins): resolve optimized imports past local barrels

### DIFF
--- a/packages/vinext/src/plugins/optimize-imports.ts
+++ b/packages/vinext/src/plugins/optimize-imports.ts
@@ -492,7 +492,7 @@ async function buildExportMapFromFile(
   if (cached) return cached;
 
   if (inProgress.has(filePath)) {
-    return cache.get(filePath) ?? new Map();
+    return new Map();
   }
   inProgress.add(filePath);
 
@@ -974,10 +974,6 @@ export function createOptimizeImportsPlugin(
               const source = entry.source.startsWith("/")
                 ? toRelativeModuleSpecifier(normalizedId, entry.source)
                 : entry.source;
-              if (!source) {
-                canRewrite = false;
-                break;
-              }
               const key = `${source}::${entry.isNamespace}`;
               let group = bySource.get(key);
               if (!group) {
@@ -1240,7 +1236,7 @@ export function createOptimizeImportsPlugin(
 
         return {
           code: s.toString(),
-          map: null,
+          map: s.generateMap({ hires: "boundary" }),
         };
       },
     },

--- a/packages/vinext/src/plugins/optimize-imports.ts
+++ b/packages/vinext/src/plugins/optimize-imports.ts
@@ -64,6 +64,8 @@ type DeclarationNode = {
   declarations?: Array<{ id: { name: string } }>;
 };
 
+type ReadFileFn = (filepath: string) => Promise<string | null>;
+
 /** Caches used by the optimize-imports plugin, scoped to a plugin instance. */
 type BarrelCaches = {
   /** Barrel export maps keyed by resolved entry file path. */
@@ -106,6 +108,131 @@ type AstBodyNode = {
 // This cast type is used consistently across resolveId and transform handlers
 // so that when Vite adds proper typing it can be removed in one place.
 type PluginCtx = { environment?: { name?: string } };
+
+function localModuleCandidates(modulePath: string): string[] {
+  return [
+    modulePath,
+    `${modulePath}.js`,
+    `${modulePath}.mjs`,
+    `${modulePath}.cjs`,
+    `${modulePath}.ts`,
+    `${modulePath}.tsx`,
+    `${modulePath}.jsx`,
+    `${modulePath}.mts`,
+    `${modulePath}.cts`,
+    `${modulePath}/index.js`,
+    `${modulePath}/index.mjs`,
+    `${modulePath}/index.cjs`,
+    `${modulePath}/index.ts`,
+    `${modulePath}/index.tsx`,
+    `${modulePath}/index.jsx`,
+    `${modulePath}/index.mts`,
+    `${modulePath}/index.cts`,
+  ];
+}
+
+function toRelativeModuleSpecifier(fromFile: string, toFile: string): string {
+  const relativePath = path.relative(path.dirname(fromFile), toFile).split(path.sep).join("/");
+  return relativePath.startsWith(".") ? relativePath : `./${relativePath}`;
+}
+
+function findOptimizedPackageForFile(id: string, packages: Set<string>): string | null {
+  const normalizedId = id.split("?")[0].split(path.sep).join("/");
+  let match: string | null = null;
+  for (const pkg of packages) {
+    if (
+      normalizedId.includes(`/node_modules/${pkg}/`) &&
+      (match === null || pkg.length > match.length)
+    ) {
+      match = pkg;
+    }
+  }
+  return match;
+}
+
+async function resolveLocalModuleFile(
+  modulePath: string,
+  readFile: ReadFileFn,
+): Promise<{ filePath: string; content: string } | null> {
+  for (const candidate of localModuleCandidates(modulePath)) {
+    const content = await readFile(candidate);
+    if (content !== null) {
+      return { filePath: candidate, content };
+    }
+  }
+  return null;
+}
+
+function buildFallbackExportMap(filePath: string, content: string): BarrelExportMap {
+  const exportMap: BarrelExportMap = new Map();
+
+  const recordDirectExport = (exportName: string, originalName = exportName) => {
+    exportMap.set(exportName, {
+      source: filePath,
+      isNamespace: false,
+      originalName,
+    });
+  };
+
+  const declarationPatterns = [
+    /^\s*export\s+(?:async\s+)?function\s+([A-Za-z_$][\w$]*)/gm,
+    /^\s*export\s+class\s+([A-Za-z_$][\w$]*)/gm,
+    /^\s*export\s+(?:const|let|var)\s+([A-Za-z_$][\w$]*)/gm,
+  ];
+  for (const pattern of declarationPatterns) {
+    for (const match of content.matchAll(pattern)) {
+      recordDirectExport(match[1]);
+    }
+  }
+
+  for (const match of content.matchAll(/^\s*export\s+default\s+([A-Za-z_$][\w$]*)\s*;?/gm)) {
+    recordDirectExport("default", "default");
+    if (!exportMap.has(match[1])) {
+      recordDirectExport(match[1]);
+    }
+  }
+
+  return exportMap;
+}
+
+async function buildSafeWildcardExportMap(
+  filePath: string,
+  readFile: ReadFileFn,
+  cache: Map<string, BarrelExportMap>,
+  visited = new Set<string>(),
+): Promise<BarrelExportMap | null> {
+  if (visited.has(filePath)) return null;
+  visited.add(filePath);
+
+  const content = await readFile(filePath);
+  if (!content) return null;
+
+  let ast: ReturnType<typeof parseAst>;
+  try {
+    ast = parseAst(content);
+  } catch {
+    const fallbackMap = buildFallbackExportMap(filePath, content);
+    return fallbackMap.size > 0 ? fallbackMap : null;
+  }
+
+  const fileDir = path.dirname(filePath);
+  for (const node of ast.body as AstBodyNode[]) {
+    if (node.type !== "ExportAllDeclaration" || node.exported) continue;
+    const rawSource = typeof node.source?.value === "string" ? node.source.value : null;
+    if (!rawSource || !rawSource.startsWith(".")) return null;
+
+    const resolved = await resolveLocalModuleFile(
+      path.resolve(fileDir, rawSource).split(path.sep).join("/"),
+      readFile,
+    );
+    if (!resolved) return null;
+
+    const nestedMap = await buildSafeWildcardExportMap(resolved.filePath, readFile, cache, visited);
+    if (!nestedMap) return null;
+  }
+
+  return buildExportMapFromFile(filePath, readFile, cache, new Set<string>(), content);
+}
 
 /**
  * Packages whose barrel imports are automatically optimized.
@@ -327,8 +454,9 @@ async function resolvePackageEntry(
  *   - `import * as X; export { X }` — indirect namespace re-export
  *   - `export * from "./sub"` — wildcard: recursively parse sub-module and merge exports
  *
- * Returns an empty map when the file cannot be read or has a parse error, so that
- * recursive wildcard calls degrade gracefully without aborting the whole barrel walk.
+ * Returns an empty map when the file cannot be read. On parse errors it falls back to
+ * a small regex-based export scan so simple JSX-in-.js leaf modules can still contribute
+ * direct named/default exports without aborting the whole barrel walk.
  *
  * @param initialContent - Pre-read file content for `filePath`. If provided, skips the
  *   `readFile` call for the entry file — avoids a redundant read when the caller
@@ -336,7 +464,7 @@ async function resolvePackageEntry(
  */
 async function buildExportMapFromFile(
   filePath: string,
-  readFile: (filepath: string) => Promise<string | null>,
+  readFile: ReadFileFn,
   cache: Map<string, BarrelExportMap>,
   visited: Set<string>,
   initialContent?: string,
@@ -355,7 +483,9 @@ async function buildExportMapFromFile(
   try {
     ast = parseAst(content);
   } catch {
-    return new Map();
+    const fallbackMap = buildFallbackExportMap(filePath, content);
+    cache.set(filePath, fallbackMap);
+    return fallbackMap;
   }
 
   const exportMap: BarrelExportMap = new Map();
@@ -368,6 +498,45 @@ async function buildExportMapFromFile(
   const localDeclarations = new Set<string>();
 
   const fileDir = path.dirname(filePath);
+
+  async function resolveConcreteLocalEntry(
+    entry: BarrelExportEntry,
+    exportName: string,
+    seen = new Set<string>(),
+  ): Promise<BarrelExportEntry> {
+    if (!entry.source.startsWith("/")) return entry;
+
+    const visitKey = `${entry.source}:${exportName}`;
+    if (seen.has(visitKey)) return entry;
+    seen.add(visitKey);
+
+    for (const candidate of localModuleCandidates(entry.source)) {
+      const candidateContent = await readFile(candidate);
+      if (candidateContent === null) continue;
+
+      const subMap = await buildExportMapFromFile(
+        candidate,
+        readFile,
+        cache,
+        new Set<string>(),
+        candidateContent,
+      );
+      const nextEntry = subMap.get(exportName);
+      if (!nextEntry) return entry;
+
+      if (
+        nextEntry.source === entry.source &&
+        nextEntry.isNamespace === entry.isNamespace &&
+        nextEntry.originalName === entry.originalName
+      ) {
+        return entry;
+      }
+
+      return resolveConcreteLocalEntry(nextEntry, exportName, seen);
+    }
+
+    return entry;
+  }
 
   /**
    * Normalize a source specifier: resolve relative paths to absolute so that
@@ -517,11 +686,17 @@ async function buildExportMapFromFile(
               const exported = astName(spec.exported);
               const local = astName(spec.local);
               if (exported !== null) {
-                exportMap.set(exported, {
+                const entry: BarrelExportEntry = {
                   source,
                   isNamespace: false,
                   originalName: local ?? undefined,
-                });
+                };
+                exportMap.set(
+                  exported,
+                  source.startsWith("/")
+                    ? await resolveConcreteLocalEntry(entry, local ?? exported)
+                    : entry,
+                );
               }
             }
           }
@@ -596,7 +771,7 @@ async function buildExportMapFromFile(
 export async function buildBarrelExportMap(
   packageName: string,
   resolveEntry: (pkg: string) => string | null,
-  readFile: (filepath: string) => Promise<string | null>,
+  readFile: ReadFileFn,
   cache?: Map<string, BarrelExportMap>,
 ): Promise<BarrelExportMap | null> {
   const entryPath = resolveEntry(packageName);
@@ -667,8 +842,9 @@ export function createOptimizeImportsPlugin(
   // or shape mismatches that the return-type check alone would accept silently.
   return {
     name: "vinext:optimize-imports",
-    // No enforce — runs after JSX transform so parseAst gets plain JS.
-    // The transform hook still rewrites imports before Vite resolves them.
+    enforce: "pre",
+    // Run before downstream graph analyzers like plugin-rsc so rewritten imports
+    // and flattened local client barrels are visible before they are inspected.
 
     buildStart() {
       // Initialize eagerly (rather than lazily) so that nextConfig is fully
@@ -718,10 +894,8 @@ export function createOptimizeImportsPlugin(
         },
       },
       async handler(code, id) {
-        // Only apply on server environments (RSC/SSR). The client uses Vite's
-        // dep optimizer which handles barrel imports correctly.
         const env = (this as PluginCtx).environment;
-        if (env?.name === "client") return null;
+        const isClient = env?.name === "client";
         // "react-server" export condition should only be preferred in the RSC environment.
         // SSR renders with the full React runtime and must NOT resolve react-server entries.
         const preferReactServer = env?.name === "rsc";
@@ -732,6 +906,7 @@ export function createOptimizeImportsPlugin(
         // Use quoted forms to avoid false positives (e.g. "effect" in "useEffect").
         // quotedPackages is pre-built in buildStart to avoid per-file allocations.
         const packages = optimizedPackages;
+        const optimizedPackageForFile = findOptimizedPackageForFile(id, packages);
         let hasBarrelImport = false;
         for (const quoted of quotedPackages) {
           if (code.includes(quoted)) {
@@ -739,7 +914,9 @@ export function createOptimizeImportsPlugin(
             break;
           }
         }
-        if (!hasBarrelImport) return null;
+        const hasFlattenableWildcardExport =
+          optimizedPackageForFile !== null && code.includes("export * from");
+        if (!hasBarrelImport && !hasFlattenableWildcardExport) return null;
 
         let ast: ReturnType<typeof parseAst>;
         try {
@@ -751,6 +928,86 @@ export function createOptimizeImportsPlugin(
         const s = new MagicString(code);
         let hasChanges = false;
         const root = getRoot();
+        const normalizedId = id.split("?")[0].split(path.sep).join("/");
+
+        if (optimizedPackageForFile !== null) {
+          for (const node of ast.body as AstBodyNode[]) {
+            if (node.type !== "ExportAllDeclaration" || node.exported) continue;
+
+            const rawSource = typeof node.source?.value === "string" ? node.source.value : null;
+            if (!rawSource || !rawSource.startsWith(".")) continue;
+
+            const resolved = await resolveLocalModuleFile(
+              path.resolve(path.dirname(normalizedId), rawSource).split(path.sep).join("/"),
+              readFileSafe,
+            );
+            if (!resolved) continue;
+
+            const exportMap = await buildSafeWildcardExportMap(
+              resolved.filePath,
+              readFileSafe,
+              barrelCaches.exportMapCache,
+            );
+            if (!exportMap) continue;
+
+            const bySource = new Map<
+              string,
+              {
+                source: string;
+                exports: Array<{ exported: string; originalName: string | undefined }>;
+                isNamespace: boolean;
+              }
+            >();
+
+            let canRewrite = true;
+            for (const [exported, entry] of exportMap) {
+              if (exported === "default") continue;
+              const source = entry.source.startsWith("/")
+                ? toRelativeModuleSpecifier(normalizedId, entry.source)
+                : entry.source;
+              if (!source) {
+                canRewrite = false;
+                break;
+              }
+              const key = `${source}::${entry.isNamespace}`;
+              let group = bySource.get(key);
+              if (!group) {
+                group = { source, exports: [], isNamespace: entry.isNamespace };
+                bySource.set(key, group);
+              }
+              group.exports.push({ exported, originalName: entry.originalName });
+            }
+
+            if (!canRewrite || bySource.size === 0) continue;
+
+            const replacements: string[] = [];
+            for (const { source, exports, isNamespace } of bySource.values()) {
+              if (isNamespace) {
+                for (const { exported } of exports) {
+                  replacements.push(`export * as ${exported} from ${JSON.stringify(source)}`);
+                }
+                continue;
+              }
+
+              const specs = exports
+                .filter(({ originalName }) => originalName !== "default")
+                .map(({ exported, originalName }) => {
+                  if (originalName && originalName !== exported) {
+                    return `${originalName} as ${exported}`;
+                  }
+                  return exported;
+                });
+              if (specs.length > 0) {
+                replacements.push(`export { ${specs.join(", ")} } from ${JSON.stringify(source)}`);
+              }
+            }
+
+            if (replacements.length === 0) continue;
+
+            s.overwrite(node.start, node.end, replacements.join(";\n") + ";");
+            hasChanges = true;
+          }
+        }
 
         for (const node of ast.body as AstBodyNode[]) {
           if (node.type !== "ImportDeclaration") continue;
@@ -914,6 +1171,20 @@ export function createOptimizeImportsPlugin(
               local,
               originalName: entry.isNamespace ? undefined : entry.originalName,
             });
+          }
+
+          // The client environment only opts into rewrites that stay on fully
+          // resolved local files. Bare sub-package rewrites can require the
+          // barrel package's resolution context under strict pnpm layouts, which
+          // is handled on the server side via resolveId + subpkgOrigin but is
+          // intentionally left unchanged for the client graph.
+          if (
+            isClient &&
+            [...bySource.values()].some(
+              ({ source }) => !source.startsWith("/") && !source.startsWith("."),
+            )
+          ) {
+            continue;
           }
 
           // Build replacement import statements

--- a/packages/vinext/src/plugins/optimize-imports.ts
+++ b/packages/vinext/src/plugins/optimize-imports.ts
@@ -482,6 +482,7 @@ async function buildExportMapFromFile(
   cache: Map<string, BarrelExportMap>,
   visited: Set<string>,
   initialContent?: string,
+  inProgress = new Set<string>(),
 ): Promise<BarrelExportMap> {
   // Guard against circular re-exports
   if (visited.has(filePath)) return new Map();
@@ -490,8 +491,16 @@ async function buildExportMapFromFile(
   const cached = cache.get(filePath);
   if (cached) return cached;
 
+  if (inProgress.has(filePath)) {
+    return cache.get(filePath) ?? new Map();
+  }
+  inProgress.add(filePath);
+
   const content = initialContent ?? (await readFile(filePath));
-  if (!content) return new Map();
+  if (!content) {
+    inProgress.delete(filePath);
+    return new Map();
+  }
 
   let ast: ReturnType<typeof parseAst>;
   try {
@@ -499,6 +508,7 @@ async function buildExportMapFromFile(
   } catch {
     const fallbackMap = buildFallbackExportMap(filePath, content);
     cache.set(filePath, fallbackMap);
+    inProgress.delete(filePath);
     return fallbackMap;
   }
 
@@ -534,6 +544,7 @@ async function buildExportMapFromFile(
         cache,
         new Set<string>(),
         candidateContent,
+        inProgress,
       );
       const nextEntry = subMap.get(exportName);
       if (!nextEntry) return entry;
@@ -653,6 +664,7 @@ async function buildExportMapFromFile(
                   cache,
                   visited,
                   candidateContent,
+                  inProgress,
                 );
                 for (const [name, entry] of subMap) {
                   if (!exportMap.has(name)) {
@@ -748,6 +760,7 @@ async function buildExportMapFromFile(
   }
 
   cache.set(filePath, exportMap);
+  inProgress.delete(filePath);
   return exportMap;
 }
 
@@ -786,6 +799,7 @@ export async function buildBarrelExportMap(
   if (!content) return null;
 
   const visited = new Set<string>();
+  const inProgress = new Set<string>();
   // Pass the already-read content so buildExportMapFromFile skips the redundant
   // readFile call for the entry file (it would otherwise read it a second time).
   // buildExportMapFromFile also stores the result in exportMapCache (keyed by
@@ -796,6 +810,7 @@ export async function buildBarrelExportMap(
     exportMapCache,
     visited,
     content,
+    inProgress,
   );
 
   return exportMap;
@@ -1225,7 +1240,7 @@ export function createOptimizeImportsPlugin(
 
         return {
           code: s.toString(),
-          map: s.generateMap({ hires: "boundary" }),
+          map: null,
         };
       },
     },

--- a/packages/vinext/src/plugins/optimize-imports.ts
+++ b/packages/vinext/src/plugins/optimize-imports.ts
@@ -109,6 +109,15 @@ type AstBodyNode = {
 // so that when Vite adds proper typing it can be removed in one place.
 type PluginCtx = { environment?: { name?: string } };
 
+function parseAstWithFileLang(code: string, filePath: string): ReturnType<typeof parseAst> {
+  const cleanPath = filePath.split("?")[0];
+  const ext = path.extname(cleanPath).toLowerCase();
+  if (ext === ".tsx" || ext === ".jsx") {
+    return parseAst(code, { lang: "tsx" });
+  }
+  return parseAst(code);
+}
+
 function localModuleCandidates(modulePath: string): string[] {
   return [
     modulePath,
@@ -209,7 +218,7 @@ async function buildSafeWildcardExportMap(
 
   let ast: ReturnType<typeof parseAst>;
   try {
-    ast = parseAst(content);
+    ast = parseAstWithFileLang(content, filePath);
   } catch {
     const fallbackMap = buildFallbackExportMap(filePath, content);
     return fallbackMap.size > 0 ? fallbackMap : null;
@@ -219,6 +228,8 @@ async function buildSafeWildcardExportMap(
   for (const node of ast.body as AstBodyNode[]) {
     if (node.type !== "ExportAllDeclaration" || node.exported) continue;
     const rawSource = typeof node.source?.value === "string" ? node.source.value : null;
+    // Only flatten local wildcard re-exports. External package wildcard re-exports
+    // require full package resolution and are intentionally left untouched.
     if (!rawSource || !rawSource.startsWith(".")) return null;
 
     const resolved = await resolveLocalModuleFile(
@@ -481,7 +492,7 @@ async function buildExportMapFromFile(
 
   let ast: ReturnType<typeof parseAst>;
   try {
-    ast = parseAst(content);
+    ast = parseAstWithFileLang(content, filePath);
   } catch {
     const fallbackMap = buildFallbackExportMap(filePath, content);
     cache.set(filePath, fallbackMap);
@@ -629,27 +640,7 @@ async function buildExportMapFromFile(
             // Includes TypeScript-first (.ts/.tsx/.cts/.mts) and JSX (.jsx) extensions
             // for TypeScript-first internal libraries and monorepo packages that may
             // not compile to .js. Also includes .cjs for CommonJS-style re-export files.
-            const candidates = [
-              subPath,
-              `${subPath}.js`,
-              `${subPath}.mjs`,
-              `${subPath}.cjs`,
-              `${subPath}.ts`,
-              `${subPath}.tsx`,
-              `${subPath}.jsx`,
-              `${subPath}.mts`,
-              `${subPath}.cts`,
-              // Directory-style sub-modules: `export * from "./components"` where
-              // `components/` is a directory with an index file.
-              `${subPath}/index.js`,
-              `${subPath}/index.mjs`,
-              `${subPath}/index.cjs`,
-              `${subPath}/index.ts`,
-              `${subPath}/index.tsx`,
-              `${subPath}/index.jsx`,
-              `${subPath}/index.mts`,
-              `${subPath}/index.cts`,
-            ];
+            const candidates = localModuleCandidates(subPath);
             for (const candidate of candidates) {
               const candidateContent = await readFile(candidate);
               if (candidateContent !== null) {
@@ -920,7 +911,7 @@ export function createOptimizeImportsPlugin(
 
         let ast: ReturnType<typeof parseAst>;
         try {
-          ast = parseAst(code);
+          ast = parseAstWithFileLang(code, id);
         } catch {
           return null;
         }

--- a/packages/vinext/src/plugins/optimize-imports.ts
+++ b/packages/vinext/src/plugins/optimize-imports.ts
@@ -968,7 +968,6 @@ export function createOptimizeImportsPlugin(
               }
             >();
 
-            let canRewrite = true;
             for (const [exported, entry] of exportMap) {
               if (exported === "default") continue;
               const source = entry.source.startsWith("/")
@@ -983,7 +982,7 @@ export function createOptimizeImportsPlugin(
               group.exports.push({ exported, originalName: entry.originalName });
             }
 
-            if (!canRewrite || bySource.size === 0) continue;
+            if (bySource.size === 0) continue;
 
             const replacements: string[] = [];
             for (const { source, exports, isNamespace } of bySource.values()) {

--- a/packages/vinext/src/plugins/optimize-imports.ts
+++ b/packages/vinext/src/plugins/optimize-imports.ts
@@ -196,8 +196,9 @@ function buildFallbackExportMap(filePath: string, content: string): BarrelExport
 
   for (const match of content.matchAll(/^\s*export\s+default\s+([A-Za-z_$][\w$]*)\s*;?/gm)) {
     recordDirectExport("default", "default");
-    if (!exportMap.has(match[1])) {
-      recordDirectExport(match[1]);
+    const ident = match[1];
+    if (ident !== "function" && ident !== "class" && !exportMap.has(ident)) {
+      recordDirectExport(ident);
     }
   }
 
@@ -230,6 +231,8 @@ async function buildSafeWildcardExportMap(
     const rawSource = typeof node.source?.value === "string" ? node.source.value : null;
     // Only flatten local wildcard re-exports. External package wildcard re-exports
     // require full package resolution and are intentionally left untouched.
+    // Bail on the entire file — if any wildcard target is external, flattening is
+    // unsafe and we fall back to leaving all `export *` statements as-is.
     if (!rawSource || !rawSource.startsWith(".")) return null;
 
     const resolved = await resolveLocalModuleFile(

--- a/tests/optimize-imports-build.test.ts
+++ b/tests/optimize-imports-build.test.ts
@@ -23,6 +23,20 @@ function writeFixtureFile(root: string, filePath: string, content: string) {
   fs.writeFileSync(absPath, content);
 }
 
+function readTextFilesRecursive(root: string): string {
+  let output = "";
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    const entryPath = path.join(root, entry.name);
+    if (entry.isDirectory()) {
+      output += readTextFilesRecursive(entryPath);
+      continue;
+    }
+    if (!entry.name.endsWith(".js")) continue;
+    output += fs.readFileSync(entryPath, "utf-8");
+  }
+  return output;
+}
+
 async function buildApp(root: string) {
   const rscOutDir = path.join(root, "dist", "server");
   const ssrOutDir = path.join(root, "dist", "server", "ssr");
@@ -155,6 +169,11 @@ export default Button;
       expect(fs.existsSync(path.join(root, "dist", "server", "index.js"))).toBe(true);
       expect(fs.existsSync(path.join(root, "dist", "server", "ssr", "index.js"))).toBe(true);
       expect(fs.existsSync(path.join(root, "dist", "client"))).toBe(true);
+
+      const buildOutput = readTextFilesRecursive(path.join(root, "dist"));
+      expect(buildOutput).not.toContain(`from "antd"`);
+      expect(buildOutput).not.toContain("/es/button/index.js");
+      expect(buildOutput).toContain("function Button");
     });
   }, 60_000);
 });

--- a/tests/optimize-imports-build.test.ts
+++ b/tests/optimize-imports-build.test.ts
@@ -1,15 +1,18 @@
 import { mkdtemp, rm } from "node:fs/promises";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { createBuilder } from "vite";
 import { describe, expect, it } from "vite-plus/test";
 import vinext from "../packages/vinext/src/index.js";
 
 async function withTempDir<T>(prefix: string, run: (tmpDir: string) => Promise<T>): Promise<T> {
-  const tempParent = path.resolve(import.meta.dirname, "../.sisyphus/tmp");
-  fs.mkdirSync(tempParent, { recursive: true });
-
-  const tmpDir = await mkdtemp(path.join(tempParent, prefix));
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), prefix));
+  fs.symlinkSync(
+    path.resolve(import.meta.dirname, "../node_modules"),
+    path.join(tmpDir, "node_modules"),
+    "junction",
+  );
   try {
     return await run(tmpDir);
   } finally {

--- a/tests/optimize-imports-build.test.ts
+++ b/tests/optimize-imports-build.test.ts
@@ -1,0 +1,160 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import fs from "node:fs";
+import path from "node:path";
+import { createBuilder } from "vite";
+import { describe, expect, it } from "vite-plus/test";
+import vinext from "../packages/vinext/src/index.js";
+
+async function withTempDir<T>(prefix: string, run: (tmpDir: string) => Promise<T>): Promise<T> {
+  const tempParent = path.resolve(import.meta.dirname, "../.sisyphus/tmp");
+  fs.mkdirSync(tempParent, { recursive: true });
+
+  const tmpDir = await mkdtemp(path.join(tempParent, prefix));
+  try {
+    return await run(tmpDir);
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+}
+
+function writeFixtureFile(root: string, filePath: string, content: string) {
+  const absPath = path.join(root, filePath);
+  fs.mkdirSync(path.dirname(absPath), { recursive: true });
+  fs.writeFileSync(absPath, content);
+}
+
+async function buildApp(root: string) {
+  const rscOutDir = path.join(root, "dist", "server");
+  const ssrOutDir = path.join(root, "dist", "server", "ssr");
+  const clientOutDir = path.join(root, "dist", "client");
+
+  const builder = await createBuilder({
+    root,
+    configFile: false,
+    plugins: [vinext({ appDir: root, rscOutDir, ssrOutDir, clientOutDir })],
+    logLevel: "silent",
+  });
+
+  await builder.buildApp();
+}
+
+describe("optimizePackageImports production builds", () => {
+  it("builds an App Router app when an optimized antd barrel resolves through a use-client export-star boundary", async () => {
+    // issue-845 repro scaffold and package pins are recorded in:
+    // .sisyphus/evidence/task-1-parity-matrix.md
+    await withTempDir("vinext-optimize-imports-build-", async (root) => {
+      writeFixtureFile(
+        root,
+        "package.json",
+        JSON.stringify(
+          { name: "vinext-optimize-imports-build", private: true, type: "module" },
+          null,
+          2,
+        ),
+      );
+      writeFixtureFile(
+        root,
+        "tsconfig.json",
+        JSON.stringify(
+          {
+            compilerOptions: {
+              target: "ES2022",
+              module: "ESNext",
+              moduleResolution: "bundler",
+              jsx: "react-jsx",
+              strict: true,
+              skipLibCheck: true,
+              types: ["vite/client", "@vitejs/plugin-rsc/types"],
+            },
+            include: ["app", "*.ts", "*.tsx"],
+          },
+          null,
+          2,
+        ),
+      );
+
+      writeFixtureFile(
+        root,
+        "app/layout.tsx",
+        `import type { ReactNode } from "react";
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}
+`,
+      );
+      writeFixtureFile(
+        root,
+        "app/page.tsx",
+        `import AntdDemo from "./components/AntdDemo";
+
+export default function HomePage() {
+  return <AntdDemo />;
+}
+`,
+      );
+      writeFixtureFile(
+        root,
+        "app/components/AntdDemo.tsx",
+        `"use client";
+
+import { Button } from "antd";
+
+export default function AntdDemo() {
+  return <Button />;
+}
+`,
+      );
+
+      writeFixtureFile(
+        root,
+        "node_modules/antd/package.json",
+        JSON.stringify(
+          {
+            name: "antd",
+            version: "6.3.5",
+            type: "module",
+            main: "./index.js",
+          },
+          null,
+          2,
+        ),
+      );
+      writeFixtureFile(
+        root,
+        "node_modules/antd/index.js",
+        `export { Button } from "./es/button/index.js";
+`,
+      );
+      writeFixtureFile(
+        root,
+        "node_modules/antd/es/button/index.js",
+        `"use client";
+
+export * from "./button.js";
+export { default } from "./button.js";
+`,
+      );
+      writeFixtureFile(
+        root,
+        "node_modules/antd/es/button/button.js",
+        `export function Button() {
+  return null;
+}
+
+export default Button;
+`,
+      );
+
+      await buildApp(root);
+
+      expect(fs.existsSync(path.join(root, "dist", "server", "index.js"))).toBe(true);
+      expect(fs.existsSync(path.join(root, "dist", "server", "ssr", "index.js"))).toBe(true);
+      expect(fs.existsSync(path.join(root, "dist", "client"))).toBe(true);
+    });
+  }, 60_000);
+});

--- a/tests/optimize-imports-build.test.ts
+++ b/tests/optimize-imports-build.test.ts
@@ -6,13 +6,19 @@ import { createBuilder } from "vite";
 import { describe, expect, it } from "vite-plus/test";
 import vinext from "../packages/vinext/src/index.js";
 
+function symlinkWorkspacePackage(root: string, packageName: string) {
+  const source = path.resolve(import.meta.dirname, "../node_modules", packageName);
+  const target = path.join(root, "node_modules", packageName);
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.symlinkSync(source, target, "junction");
+}
+
 async function withTempDir<T>(prefix: string, run: (tmpDir: string) => Promise<T>): Promise<T> {
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), prefix));
-  fs.symlinkSync(
-    path.resolve(import.meta.dirname, "../node_modules"),
-    path.join(tmpDir, "node_modules"),
-    "junction",
-  );
+  fs.mkdirSync(path.join(tmpDir, "node_modules"), { recursive: true });
+  symlinkWorkspacePackage(tmpDir, "react");
+  symlinkWorkspacePackage(tmpDir, "react-dom");
+  symlinkWorkspacePackage(tmpDir, "react-server-dom-webpack");
   try {
     return await run(tmpDir);
   } finally {

--- a/tests/optimize-imports-export-map-bindings.test.ts
+++ b/tests/optimize-imports-export-map-bindings.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vite-plus/test";
+import { buildBarrelExportMap } from "../packages/vinext/src/plugins/optimize-imports.js";
+
+let testId = 0;
+function uniquePath(name: string): string {
+  return `/fake/${name}-${++testId}/entry.js`;
+}
+
+describe("buildBarrelExportMap binding re-export cases", () => {
+  it("handles import * as X; export { X }", async () => {
+    const entryPath = uniquePath("import-ns-reexport");
+    const barrelCode = `import * as AlertDialog from "@radix-ui/react-alert-dialog";\nexport { AlertDialog };`;
+    const map = await buildBarrelExportMap(
+      "test-pkg",
+      () => entryPath,
+      () => Promise.resolve(barrelCode),
+    );
+    expect(map).not.toBeNull();
+    expect(map!.get("AlertDialog")).toEqual({
+      source: "@radix-ui/react-alert-dialog",
+      isNamespace: true,
+    });
+  });
+
+  it("handles import { X }; export { X }", async () => {
+    const entryPath = uniquePath("import-named-reexport");
+    const barrelCode = `import { format } from "date-fns/format";\nexport { format };`;
+    const map = await buildBarrelExportMap(
+      "test-pkg",
+      () => entryPath,
+      () => Promise.resolve(barrelCode),
+    );
+    expect(map).not.toBeNull();
+    expect(map!.get("format")).toEqual({
+      source: "date-fns/format",
+      isNamespace: false,
+      originalName: "format",
+    });
+  });
+
+  it("handles export { Local as Public } for same-file declarations", async () => {
+    const entryPath = uniquePath("local-alias-reexport");
+    const barrelCode = `const Mo = {};\nexport { Mo as Listbox };`;
+    const map = await buildBarrelExportMap(
+      "test-pkg",
+      () => entryPath,
+      () => Promise.resolve(barrelCode),
+    );
+    expect(map).not.toBeNull();
+    expect(map!.get("Listbox")).toEqual({
+      source: entryPath,
+      isNamespace: false,
+      originalName: "Listbox",
+    });
+  });
+});

--- a/tests/optimize-imports-export-map-failures.test.ts
+++ b/tests/optimize-imports-export-map-failures.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vite-plus/test";
+import {
+  buildBarrelExportMap,
+  DEFAULT_OPTIMIZE_PACKAGES,
+} from "../packages/vinext/src/plugins/optimize-imports.js";
+
+let testId = 0;
+function uniquePath(name: string): string {
+  return `/fake/${name}-${++testId}/entry.js`;
+}
+
+describe("buildBarrelExportMap failure and baseline cases", () => {
+  it("returns null when entry cannot be resolved", async () => {
+    const map = await buildBarrelExportMap(
+      "nonexistent-pkg",
+      () => null,
+      () => Promise.resolve(null),
+    );
+    expect(map).toBeNull();
+  });
+
+  it("returns null when entry file cannot be read", async () => {
+    const entryPath = uniquePath("unreadable");
+    const map = await buildBarrelExportMap(
+      "test-pkg",
+      () => entryPath,
+      () => Promise.resolve(null),
+    );
+    expect(map).toBeNull();
+  });
+
+  it("returns an empty map when entry file has syntax errors", async () => {
+    const entryPath = uniquePath("syntax-error");
+    const map = await buildBarrelExportMap(
+      "test-pkg",
+      () => entryPath,
+      () => Promise.resolve("export { unclosed"),
+    );
+    expect(map).not.toBeNull();
+    expect(map!.size).toBe(0);
+  });
+
+  it("DEFAULT_OPTIMIZE_PACKAGES includes expected packages", () => {
+    expect(DEFAULT_OPTIMIZE_PACKAGES).toContain("lucide-react");
+    expect(DEFAULT_OPTIMIZE_PACKAGES).toContain("radix-ui");
+    expect(DEFAULT_OPTIMIZE_PACKAGES).toContain("antd");
+  });
+});

--- a/tests/optimize-imports-export-map-recursion.test.ts
+++ b/tests/optimize-imports-export-map-recursion.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vite-plus/test";
+import { buildBarrelExportMap } from "../packages/vinext/src/plugins/optimize-imports.js";
+
+let testId = 0;
+function uniquePath(name: string): string {
+  return `/fake/${name}-${++testId}/entry.js`;
+}
+
+describe("buildBarrelExportMap recursive and edge cases", () => {
+  it("handles circular wildcard re-exports without infinite loop", async () => {
+    const entryPath = "/fake/circular/a.js";
+    const files: Record<string, string> = {
+      [entryPath]: `export * from "./b";\nexport { A } from "./a-impl";`,
+      "/fake/circular/b.js": `export * from "./a";\nexport { B } from "./b-impl";`,
+    };
+    await expect(
+      buildBarrelExportMap(
+        "test-pkg",
+        () => entryPath,
+        (fp) => Promise.resolve(files[fp] ?? null),
+      ),
+    ).resolves.not.toThrow();
+  });
+
+  it("resolves wildcard export * from './mod' where mod.jsx exists (jsx extension)", async () => {
+    const entryPath = "/fake/jsx-wildcard/index.js";
+    const files: Record<string, string> = {
+      [entryPath]: `export * from "./Button";`,
+      "/fake/jsx-wildcard/Button.jsx": `export { Button } from "./button-impl";`,
+    };
+    const map = await buildBarrelExportMap(
+      "test-pkg",
+      () => entryPath,
+      (fp) => Promise.resolve(files[fp] ?? null),
+    );
+    expect(map).not.toBeNull();
+    expect(map!.has("Button")).toBe(true);
+  });
+
+  it("resolves wildcard export * from './mod' where mod.cjs exists (cjs extension)", async () => {
+    const entryPath = "/fake/cjs-wildcard/index.js";
+    const files: Record<string, string> = {
+      [entryPath]: `export * from "./helpers";`,
+      "/fake/cjs-wildcard/helpers.cjs": `exports.helper = function helper() {};`,
+    };
+    const map = await buildBarrelExportMap(
+      "test-pkg",
+      () => entryPath,
+      (fp) => Promise.resolve(files[fp] ?? null),
+    );
+    expect(map).not.toBeNull();
+  });
+
+  it("skips malformed AST nodes without crashing (astName returns null gracefully)", async () => {
+    const entryPath = uniquePath("malformed-ast");
+    const barrelCode = `export { Button } from "./button";`;
+    const map = await buildBarrelExportMap(
+      "test-pkg",
+      () => entryPath,
+      () => Promise.resolve(barrelCode),
+    );
+    expect(map).not.toBeNull();
+    expect(map!.has("Button")).toBe(true);
+  });
+
+  it("resolves export function declaration in sub-module (date-fns style)", async () => {
+    const entryPath = "/fake/date-fns/index.js";
+    const subPath = "/fake/date-fns/formatDistanceToNow.js";
+    const files: Record<string, string> = {
+      [entryPath]: `export * from "./formatDistanceToNow.js";`,
+      [subPath]: `export function formatDistanceToNow(date, options) { return date; }`,
+    };
+    const map = await buildBarrelExportMap(
+      "date-fns",
+      () => entryPath,
+      (fp) => Promise.resolve(files[fp] ?? null),
+    );
+    expect(map).not.toBeNull();
+    const entry = map!.get("formatDistanceToNow");
+    expect(entry).toBeDefined();
+    expect(entry!.source).toBe(subPath);
+    expect(entry!.isNamespace).toBe(false);
+  });
+
+  it("resolves multiple export const declarations in a single VariableDeclaration", async () => {
+    const entryPath = "/fake/multi-const/index.js";
+    const subPath = "/fake/multi-const/utils.js";
+    const files: Record<string, string> = {
+      [entryPath]: `export * from "./utils.js";`,
+      [subPath]: `export const add = (a, b) => a + b, subtract = (a, b) => a - b;`,
+    };
+    const map = await buildBarrelExportMap(
+      "test-pkg",
+      () => entryPath,
+      (fp) => Promise.resolve(files[fp] ?? null),
+    );
+    expect(map).not.toBeNull();
+    expect(map!.get("add")).toMatchObject({ source: subPath, isNamespace: false });
+    expect(map!.get("subtract")).toMatchObject({ source: subPath, isNamespace: false });
+  });
+
+  it("resolves export class declaration in sub-module", async () => {
+    const entryPath = "/fake/class-export/index.js";
+    const subPath = "/fake/class-export/MyClass.js";
+    const files: Record<string, string> = {
+      [entryPath]: `export * from "./MyClass.js";`,
+      [subPath]: `export class MyClass {}`,
+    };
+    const map = await buildBarrelExportMap(
+      "test-pkg",
+      () => entryPath,
+      (fp) => Promise.resolve(files[fp] ?? null),
+    );
+    expect(map).not.toBeNull();
+    expect(map!.get("MyClass")).toMatchObject({ source: subPath, isNamespace: false });
+  });
+});

--- a/tests/optimize-imports-export-map-reexports.test.ts
+++ b/tests/optimize-imports-export-map-reexports.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vite-plus/test";
+import * as path from "node:path";
+import { buildBarrelExportMap } from "../packages/vinext/src/plugins/optimize-imports.js";
+
+let testId = 0;
+function uniquePath(name: string): string {
+  return `/fake/${name}-${++testId}/entry.js`;
+}
+
+describe("buildBarrelExportMap direct re-export cases", () => {
+  it("handles export * as Name from 'sub-pkg'", async () => {
+    const entryPath = uniquePath("namespace-reexport");
+    const barrelCode = `export * as Slot from "@radix-ui/react-slot";\nexport * as Tooltip from "@radix-ui/react-tooltip";`;
+    const map = await buildBarrelExportMap(
+      "test-pkg",
+      () => entryPath,
+      () => Promise.resolve(barrelCode),
+    );
+    expect(map).not.toBeNull();
+    expect(map!.get("Slot")).toEqual({ source: "@radix-ui/react-slot", isNamespace: true });
+    expect(map!.get("Tooltip")).toEqual({ source: "@radix-ui/react-tooltip", isNamespace: true });
+  });
+
+  it("handles export { A, B } from 'sub-pkg'", async () => {
+    const entryPath = uniquePath("named-reexport");
+    const entryDir = path.dirname(entryPath);
+    const barrelCode = `export { Button, buttonVariants } from "./button";\nexport { Input } from "./input";`;
+    const map = await buildBarrelExportMap(
+      "test-pkg",
+      () => entryPath,
+      () => Promise.resolve(barrelCode),
+    );
+    expect(map).not.toBeNull();
+    expect(map!.get("Button")).toEqual({
+      source: path.resolve(entryDir, "./button").split(path.sep).join("/"),
+      isNamespace: false,
+      originalName: "Button",
+    });
+    expect(map!.get("buttonVariants")).toEqual({
+      source: path.resolve(entryDir, "./button").split(path.sep).join("/"),
+      isNamespace: false,
+      originalName: "buttonVariants",
+    });
+    expect(map!.get("Input")).toEqual({
+      source: path.resolve(entryDir, "./input").split(path.sep).join("/"),
+      isNamespace: false,
+      originalName: "Input",
+    });
+  });
+
+  it("handles export { default as Name } from 'sub-pkg'", async () => {
+    const entryPath = uniquePath("default-reexport");
+    const entryDir = path.dirname(entryPath);
+    const barrelCode = `export { default as Calendar } from "./calendar";`;
+    const map = await buildBarrelExportMap(
+      "test-pkg",
+      () => entryPath,
+      () => Promise.resolve(barrelCode),
+    );
+    expect(map).not.toBeNull();
+    expect(map!.get("Calendar")).toEqual({
+      source: path.resolve(entryDir, "./calendar").split(path.sep).join("/"),
+      isNamespace: false,
+      originalName: "default",
+    });
+  });
+});

--- a/tests/optimize-imports-export-map-wildcards.test.ts
+++ b/tests/optimize-imports-export-map-wildcards.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vite-plus/test";
+import { buildBarrelExportMap } from "../packages/vinext/src/plugins/optimize-imports.js";
+
+let testId = 0;
+function uniquePath(name: string): string {
+  return `/fake/${name}-${++testId}/entry.js`;
+}
+
+describe("buildBarrelExportMap wildcard cases", () => {
+  it("resolves wildcard export * from './sub' by merging sub-module exports", async () => {
+    const entryPath = "/fake/wildcard-test/index.js";
+    const subPath = "/fake/wildcard-test/utils.js";
+    const files: Record<string, string> = {
+      [entryPath]: `export * from "./utils";\nexport { Button } from "./button";`,
+      [subPath]: `export { format } from "./format";\nexport { parse } from "./parse";`,
+    };
+    const map = await buildBarrelExportMap(
+      "test-pkg",
+      () => entryPath,
+      (fp) => Promise.resolve(files[fp] ?? null),
+    );
+    expect(map).not.toBeNull();
+    expect(map!.get("Button")).toEqual({
+      source: "/fake/wildcard-test/button",
+      isNamespace: false,
+      originalName: "Button",
+    });
+    expect(map!.get("format")).toBeDefined();
+    expect(map!.get("parse")).toBeDefined();
+  });
+
+  it("does not overwrite existing exports when wildcard sub-module has same name", async () => {
+    const entryPath = "/fake/wildcard-nooverwrite/index.js";
+    const subPath = "/fake/wildcard-nooverwrite/utils.js";
+    const files: Record<string, string> = {
+      [entryPath]: `export { format } from "./explicit";\nexport * from "./utils";`,
+      [subPath]: `export { format } from "./other-format";`,
+    };
+    const map = await buildBarrelExportMap(
+      "test-pkg",
+      () => entryPath,
+      (fp) => Promise.resolve(files[fp] ?? null),
+    );
+    expect(map).not.toBeNull();
+    expect(map!.get("format")).toEqual({
+      source: "/fake/wildcard-nooverwrite/explicit",
+      isNamespace: false,
+      originalName: "format",
+    });
+  });
+
+  it("does not resolve wildcard export * from 'sub-pkg' (external package)", async () => {
+    const entryPath = uniquePath("wildcard");
+    const barrelCode = `export * from "some-external-pkg";\nexport { Button } from "./button";`;
+    const map = await buildBarrelExportMap(
+      "test-pkg",
+      () => entryPath,
+      () => Promise.resolve(barrelCode),
+    );
+    expect(map).not.toBeNull();
+    expect(map!.has("Button")).toBe(true);
+  });
+
+  it("resolves nested subdirectory wildcard re-exports to the correct absolute path", async () => {
+    const entryPath = "/fake/nested/index.js";
+    const files: Record<string, string> = {
+      [entryPath]: `export * from "./components/index.js";`,
+      "/fake/nested/components/index.js": `export { Button } from "./Button";`,
+      "/fake/nested/components/Button.js": `export function Button() {}`,
+    };
+    const map = await buildBarrelExportMap(
+      "test-pkg",
+      () => entryPath,
+      (fp) => Promise.resolve(files[fp] ?? null),
+    );
+    expect(map).not.toBeNull();
+    const buttonEntry = map!.get("Button");
+    expect(buttonEntry).toBeDefined();
+    expect(buttonEntry!.source).toBe("/fake/nested/components/Button.js");
+    expect(buttonEntry!.source).not.toBe("/fake/nested/Button.js");
+  });
+
+  it("resolves wildcard export * from './components' where components/ is a directory with index.js", async () => {
+    const entryPath = "/fake/dir-wildcard/index.js";
+    const files: Record<string, string> = {
+      [entryPath]: `export * from "./components";`,
+      "/fake/dir-wildcard/components/index.js": `export { Button } from "./Button";`,
+      "/fake/dir-wildcard/components/Button.js": `export function Button() {}`,
+    };
+    const map = await buildBarrelExportMap(
+      "test-pkg",
+      () => entryPath,
+      (fp) => Promise.resolve(files[fp] ?? null),
+    );
+    expect(map).not.toBeNull();
+    const buttonEntry = map!.get("Button");
+    expect(buttonEntry).toBeDefined();
+    expect(buttonEntry!.source).toBe("/fake/dir-wildcard/components/Button.js");
+  });
+});

--- a/tests/optimize-imports-plugin.test.ts
+++ b/tests/optimize-imports-plugin.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from "vite-plus/test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { createOptimizeImportsPlugin } from "../packages/vinext/src/plugins/optimize-imports.js";
+import type { Plugin } from "vite-plus";
+import vinext from "../packages/vinext/src/index.js";
+
+function unwrapHook(hook: any): ((...args: any[]) => any) | undefined {
+  return typeof hook === "function" ? hook : hook?.handler;
+}
+
+describe("vinext:optimize-imports plugin", () => {
+  it("exists and has the correct name", () => {
+    const plugin = createOptimizeImportsPlugin(
+      () => undefined,
+      () => "/fake/root",
+    ) as Plugin;
+    expect(plugin.name).toBe("vinext:optimize-imports");
+    expect(plugin.enforce).toBe("pre");
+  });
+
+  it("returns null for virtual modules", async () => {
+    const plugin = createOptimizeImportsPlugin(
+      () => undefined,
+      () => "/fake/root",
+    ) as Plugin;
+    const transform = unwrapHook(plugin.transform)!;
+    const code = `import { Slot } from "radix-ui";`;
+    const result = await (transform as any).call(plugin, code, "\0virtual:something");
+    expect(result).toBeNull();
+  });
+
+  it("returns null for files without barrel imports", async () => {
+    const plugin = createOptimizeImportsPlugin(
+      () => undefined,
+      () => "/fake/root",
+    ) as Plugin;
+    const transform = unwrapHook(plugin.transform)!;
+    const code = `import React from 'react';\nconst x = 1;`;
+    const result = await (transform as any).call(plugin, code, "/app/page.tsx");
+    expect(result).toBeNull();
+  });
+
+  it("returns null when barrel package mentioned but no resolvable entry", async () => {
+    const plugin = createOptimizeImportsPlugin(
+      () => undefined,
+      () => "/nonexistent/root",
+    ) as Plugin;
+    const transform = unwrapHook(plugin.transform)!;
+    const code = `import { Slot } from "radix-ui";`;
+    const buildStart = unwrapHook((plugin as any).buildStart);
+    if (buildStart) buildStart.call(plugin);
+
+    const result = await (transform as any).call(
+      { ...plugin, environment: { name: "rsc" } },
+      code,
+      "/app/page.tsx",
+    );
+    expect(result).toBeNull();
+  });
+
+  it("picks up optimizePackageImports from vinext({ nextConfig })", async () => {
+    const tmpDir = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), "vinext-inline-optimize-")),
+    );
+
+    fs.writeFileSync(path.join(tmpDir, "package.json"), JSON.stringify({ name: "test-app" }));
+    fs.mkdirSync(path.join(tmpDir, "node_modules", "custom-icons"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, "node_modules", "custom-icons", "package.json"),
+      JSON.stringify({ name: "custom-icons", type: "module", main: "./index.js" }),
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "node_modules", "custom-icons", "index.js"),
+      `export { IconFoo } from "./foo";`,
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "node_modules", "custom-icons", "foo.js"),
+      `export function IconFoo() { return null; }`,
+    );
+
+    try {
+      const rawPlugins = vinext({
+        nextConfig: { experimental: { optimizePackageImports: ["custom-icons"] } },
+      }) as any[];
+      const plugins = (
+        await Promise.all(
+          rawPlugins.map(async (plugin) => {
+            if (plugin && typeof plugin.then === "function") return await plugin;
+            return plugin;
+          }),
+        )
+      ).flat() as Plugin[];
+
+      const configPlugin = plugins.find((p) => p.name === "vinext:config") as Plugin & {
+        config?: (...args: any[]) => Promise<any>;
+      };
+      const optimizePlugin = plugins.find((p) => p.name === "vinext:optimize-imports") as Plugin;
+
+      expect(configPlugin).toBeDefined();
+      expect(optimizePlugin).toBeDefined();
+
+      await configPlugin.config?.(
+        { root: tmpDir, plugins: [] },
+        { command: "serve", mode: "development" },
+      );
+
+      const buildStart = unwrapHook((optimizePlugin as any).buildStart);
+      if (buildStart) await buildStart.call(optimizePlugin);
+
+      const transform = unwrapHook(optimizePlugin.transform)!;
+      const result = await (transform as any).call(
+        { ...optimizePlugin, environment: { name: "rsc" } },
+        `import { IconFoo } from "custom-icons";\nexport default IconFoo;`,
+        "/app/page.tsx",
+      );
+
+      expect(result).not.toBeNull();
+      expect(result!.code).toContain(
+        `import { IconFoo } from "${path.resolve(tmpDir, "node_modules", "custom-icons", "foo.js").split(path.sep).join("/")}"`,
+      );
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/optimize-imports-regressions.test.ts
+++ b/tests/optimize-imports-regressions.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, afterEach } from "vite-plus/test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+  buildBarrelExportMap,
+  createOptimizeImportsPlugin,
+} from "../packages/vinext/src/plugins/optimize-imports.js";
+import type { Plugin } from "vite-plus";
+
+function unwrapHook(hook: any): ((...args: any[]) => any) | undefined {
+  return typeof hook === "function" ? hook : hook?.handler;
+}
+
+let testId = 0;
+function uniquePath(name: string): string {
+  return `/fake/${name}-${++testId}/entry.js`;
+}
+
+describe("optimize-imports targeted regressions", () => {
+  let tmpDir: string;
+
+  afterEach(() => {
+    if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("does not record phantom function/class exports in fallback default-export parsing", async () => {
+    const entryPath = uniquePath("fallback-default-function");
+    const map = await buildBarrelExportMap(
+      "test-pkg",
+      () => entryPath,
+      () =>
+        Promise.resolve(
+          `export default function Button() { return <div />; }\nexport class Card {}`,
+        ),
+    );
+
+    expect(map).not.toBeNull();
+    expect(map!.get("default")).toEqual({
+      source: entryPath,
+      isNamespace: false,
+      originalName: "default",
+    });
+    expect(map!.has("function")).toBe(false);
+    expect(map!.has("class")).toBe(false);
+    expect(map!.has("Button")).toBe(false);
+    expect(map!.get("Card")).toEqual({
+      source: entryPath,
+      isNamespace: false,
+      originalName: "Card",
+    });
+  });
+
+  it("issue-845 multi-hop antd barrel rewrites past intermediate barrel index", async () => {
+    // Ported from issue-845 parity notes: `.sisyphus/evidence/task-1-parity-matrix.md`
+    // Repro shape matches the documented `antd` optimization path, where the root barrel
+    // points at `es/button/index.js` but the concrete implementation lives deeper.
+    tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "vinext-optimize-test-")));
+    fs.writeFileSync(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({ name: "test-app", type: "module" }),
+    );
+
+    const pkgDir = path.join(tmpDir, "node_modules", "antd");
+    fs.mkdirSync(path.join(pkgDir, "es", "button"), { recursive: true });
+    fs.writeFileSync(
+      path.join(pkgDir, "package.json"),
+      JSON.stringify({ name: "antd", type: "module", main: "./index.js" }),
+    );
+    fs.writeFileSync(
+      path.join(pkgDir, "index.js"),
+      `export { Button } from "./es/button/index.js";`,
+    );
+    fs.writeFileSync(
+      path.join(pkgDir, "es", "button", "index.js"),
+      [`export * from "./style.js";`, `export { Button } from "./button.js";`].join("\n"),
+    );
+    fs.writeFileSync(path.join(pkgDir, "es", "button", "style.js"), `export const wave = true;`);
+    fs.writeFileSync(
+      path.join(pkgDir, "es", "button", "button.js"),
+      `export function Button() { return null; }`,
+    );
+
+    const plugin = createOptimizeImportsPlugin(
+      () => undefined,
+      () => tmpDir,
+    ) as Plugin;
+    const buildStartHook = unwrapHook((plugin as any).buildStart);
+    if (buildStartHook) await buildStartHook.call(plugin);
+    const transform = unwrapHook(plugin.transform)!;
+
+    const result = await (transform as any).call(
+      { ...plugin, environment: { name: "rsc" } },
+      `import { Button } from "antd";`,
+      "/app/page.tsx",
+    );
+
+    expect(result).not.toBeNull();
+
+    const intermediateBarrel = path.join(pkgDir, "es", "button", "index");
+    const concreteModule = path.join(pkgDir, "es", "button", "button.js");
+
+    expect(result!.code).not.toContain(`from "antd"`);
+    expect(result!.code).not.toContain(JSON.stringify(intermediateBarrel));
+    expect(result!.code).toContain(JSON.stringify(concreteModule));
+  });
+
+  it("keeps optimizing issue-845 imports from JSX-bearing TSX user files", async () => {
+    tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "vinext-optimize-test-")));
+    fs.writeFileSync(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({ name: "test-app", type: "module" }),
+    );
+
+    const pkgDir = path.join(tmpDir, "node_modules", "antd");
+    fs.mkdirSync(path.join(pkgDir, "es", "button"), { recursive: true });
+    fs.writeFileSync(
+      path.join(pkgDir, "package.json"),
+      JSON.stringify({ name: "antd", type: "module", main: "./index.js" }),
+    );
+    fs.writeFileSync(
+      path.join(pkgDir, "index.js"),
+      `export { Button } from "./es/button/index.js";`,
+    );
+    fs.writeFileSync(
+      path.join(pkgDir, "es", "button", "index.js"),
+      [`export * from "./style.js";`, `export { Button } from "./button.js";`].join("\n"),
+    );
+    fs.writeFileSync(path.join(pkgDir, "es", "button", "style.js"), `export const wave = true;`);
+    fs.writeFileSync(
+      path.join(pkgDir, "es", "button", "button.js"),
+      `export function Button() { return null; }`,
+    );
+
+    const plugin = createOptimizeImportsPlugin(
+      () => undefined,
+      () => tmpDir,
+    ) as Plugin;
+    const buildStartHook = unwrapHook((plugin as any).buildStart);
+    if (buildStartHook) await buildStartHook.call(plugin);
+    const transform = unwrapHook(plugin.transform)!;
+
+    const result = await (transform as any).call(
+      { ...plugin, environment: { name: "rsc" } },
+      `import { Button } from "antd";\nexport default function Demo() { return <Button />; }`,
+      "/app/page.tsx",
+    );
+
+    expect(result).not.toBeNull();
+
+    const intermediateBarrel = path.join(pkgDir, "es", "button", "index");
+    const concreteModule = path.join(pkgDir, "es", "button", "button.js");
+
+    expect(result!.code).not.toContain(`from "antd"`);
+    expect(result!.code).not.toContain(JSON.stringify(intermediateBarrel));
+    expect(result!.code).toContain(JSON.stringify(concreteModule));
+    expect(result!.code).toContain("return <Button />");
+  });
+});

--- a/tests/optimize-imports.test.ts
+++ b/tests/optimize-imports.test.ts
@@ -323,6 +323,33 @@ export { Mo as Listbox };`;
     expect(map!.size).toBe(0);
   });
 
+  it("does not record phantom function/class exports in fallback default-export parsing", async () => {
+    const entryPath = uniquePath("fallback-default-function");
+    const map = await buildBarrelExportMap(
+      "test-pkg",
+      () => entryPath,
+      () =>
+        Promise.resolve(
+          `export default function Button() { return <div />; }\nexport class Card {}`,
+        ),
+    );
+
+    expect(map).not.toBeNull();
+    expect(map!.get("default")).toEqual({
+      source: entryPath,
+      isNamespace: false,
+      originalName: "default",
+    });
+    expect(map!.has("function")).toBe(false);
+    expect(map!.has("class")).toBe(false);
+    expect(map!.has("Button")).toBe(false);
+    expect(map!.get("Card")).toEqual({
+      source: entryPath,
+      isNamespace: false,
+      originalName: "Card",
+    });
+  });
+
   it("resolves wildcard export * from './sub' by merging sub-module exports", async () => {
     // Barrel: export * from "./utils" + export { Button } from "./button"
     // Sub-module ./utils exports: { format, parse }

--- a/tests/optimize-imports.test.ts
+++ b/tests/optimize-imports.test.ts
@@ -992,6 +992,58 @@ describe("vinext:optimize-imports transform", () => {
     expect(result!.code).toContain(JSON.stringify(concreteModule));
   });
 
+  it("keeps optimizing issue-845 imports from JSX-bearing TSX user files", async () => {
+    tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "vinext-optimize-test-")));
+    fs.writeFileSync(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({ name: "test-app", type: "module" }),
+    );
+
+    const pkgDir = path.join(tmpDir, "node_modules", "antd");
+    fs.mkdirSync(path.join(pkgDir, "es", "button"), { recursive: true });
+    fs.writeFileSync(
+      path.join(pkgDir, "package.json"),
+      JSON.stringify({ name: "antd", type: "module", main: "./index.js" }),
+    );
+    fs.writeFileSync(
+      path.join(pkgDir, "index.js"),
+      `export { Button } from "./es/button/index.js";`,
+    );
+    fs.writeFileSync(
+      path.join(pkgDir, "es", "button", "index.js"),
+      [`export * from "./style.js";`, `export { Button } from "./button.js";`].join("\n"),
+    );
+    fs.writeFileSync(path.join(pkgDir, "es", "button", "style.js"), `export const wave = true;`);
+    fs.writeFileSync(
+      path.join(pkgDir, "es", "button", "button.js"),
+      `export function Button() { return null; }`,
+    );
+
+    const plugin = createOptimizeImportsPlugin(
+      () => undefined,
+      () => tmpDir,
+    ) as Plugin;
+    const buildStartHook = unwrapHook((plugin as any).buildStart);
+    if (buildStartHook) await buildStartHook.call(plugin);
+    const transform = unwrapHook(plugin.transform)!;
+
+    const result = await (transform as any).call(
+      { ...plugin, environment: { name: "rsc" } },
+      `import { Button } from "antd";\nexport default function Demo() { return <Button />; }`,
+      "/app/page.tsx",
+    );
+
+    expect(result).not.toBeNull();
+
+    const intermediateBarrel = path.join(pkgDir, "es", "button", "index");
+    const concreteModule = path.join(pkgDir, "es", "button", "button.js");
+
+    expect(result!.code).not.toContain(`from "antd"`);
+    expect(result!.code).not.toContain(JSON.stringify(intermediateBarrel));
+    expect(result!.code).toContain(JSON.stringify(concreteModule));
+    expect(result!.code).toContain("return <Button />");
+  });
+
   it("populates subpkgOrigin independently for RSC and SSR when they share the same barrel entry", async () => {
     // Regression test: registeredBarrels used to be keyed only by barrelEntry (not envKey:barrelEntry).
     // When RSC and SSR share the same barrel entry path (common — most packages have no react-server

--- a/tests/optimize-imports.test.ts
+++ b/tests/optimize-imports.test.ts
@@ -25,7 +25,13 @@ describe("vinext:optimize-imports transform", () => {
   async function setupTransform(
     packageName: string,
     barrelContents: string,
-  ): Promise<(code: string, id: string) => Promise<ReturnType<(...args: any[]) => any>>> {
+  ): Promise<
+    (
+      code: string,
+      id: string,
+      envName?: "rsc" | "ssr" | "client",
+    ) => Promise<ReturnType<(...args: any[]) => any>>
+  > {
     tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "vinext-optimize-test-")));
     fs.writeFileSync(
       path.join(tmpDir, "package.json"),
@@ -49,8 +55,8 @@ describe("vinext:optimize-imports transform", () => {
     if (buildStartHook) await buildStartHook.call(plugin);
 
     const transform = unwrapHook(plugin.transform)!;
-    return async (code: string, id: string) =>
-      await (transform as any).call({ ...plugin, environment: { name: "rsc" } }, code, id);
+    return async (code: string, id: string, envName = "rsc") =>
+      await (transform as any).call({ ...plugin, environment: { name: envName } }, code, id);
   }
 
   afterEach(() => {
@@ -128,25 +134,20 @@ describe("vinext:optimize-imports transform", () => {
   });
 
   it("rewrites direct barrel imports on client environment when they resolve to concrete files", async () => {
-    tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "vinext-optimize-test-")));
-    fs.writeFileSync(
-      path.join(tmpDir, "package.json"),
-      JSON.stringify({ name: "test-app", type: "module" }),
+    const call = await setupTransform(
+      "lucide-react",
+      `export { Sun } from "./dist/esm/icons/sun.js";`,
     );
-    const plugin = createOptimizeImportsPlugin(
-      () => undefined,
-      () => tmpDir,
-    ) as Plugin;
-    const buildStartHook = unwrapHook((plugin as any).buildStart);
-    if (buildStartHook) await buildStartHook.call(plugin);
-    const transform = unwrapHook(plugin.transform)!;
+    fs.mkdirSync(path.join(tmpDir, "node_modules", "lucide-react", "dist", "esm", "icons"), {
+      recursive: true,
+    });
+    fs.writeFileSync(
+      path.join(tmpDir, "node_modules", "lucide-react", "dist", "esm", "icons", "sun.js"),
+      `export function Sun() { return null; }`,
+    );
     const code = `import { Sun } from "lucide-react";`;
 
-    const result = await (transform as any).call(
-      { ...plugin, environment: { name: "client" } },
-      code,
-      "/app/page.tsx",
-    );
+    const result = await call(code, "/app/page.tsx", "client");
     expect(result).not.toBeNull();
     expect(result!.code).not.toContain(`from "lucide-react"`);
     expect(result!.code).toContain(`/lucide-react/dist/esm/icons/sun.js`);

--- a/tests/optimize-imports.test.ts
+++ b/tests/optimize-imports.test.ts
@@ -1,626 +1,13 @@
-/**
- * Tests for the vinext:optimize-imports plugin and barrel export map helpers.
- *
- * Uses a pre-populated barrel export map cache so no real packages need to be
- * installed. Each test uses a unique fake entry path to avoid cache collisions.
- */
 import { describe, it, expect, afterEach } from "vite-plus/test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import {
-  buildBarrelExportMap,
-  createOptimizeImportsPlugin,
-  DEFAULT_OPTIMIZE_PACKAGES,
-} from "../packages/vinext/src/plugins/optimize-imports.js";
+import { createOptimizeImportsPlugin } from "../packages/vinext/src/plugins/optimize-imports.js";
 import type { Plugin } from "vite-plus";
-import vinext from "../packages/vinext/src/index.js";
-
-// ── Helpers ───────────────────────────────────────────────────
-
-/** Unwrap a Vite plugin hook that may use the object-with-filter format */
 
 function unwrapHook(hook: any): ((...args: any[]) => any) | undefined {
   return typeof hook === "function" ? hook : hook?.handler;
 }
-
-let testId = 0;
-/** Generate a unique fake entry path to avoid cache collisions between tests */
-function uniquePath(name: string): string {
-  return `/fake/${name}-${++testId}/entry.js`;
-}
-
-// ── Plugin existence ─────────────────────────────────────────
-
-describe("vinext:optimize-imports plugin", () => {
-  it("exists and has the correct name", () => {
-    const plugin = createOptimizeImportsPlugin(
-      () => undefined,
-      () => "/fake/root",
-    ) as Plugin;
-    expect(plugin.name).toBe("vinext:optimize-imports");
-    expect(plugin.enforce).toBe("pre");
-  });
-
-  // ── Guard clauses ────────────────────────────────────────────
-
-  it("returns null for virtual modules", async () => {
-    const plugin = createOptimizeImportsPlugin(
-      () => undefined,
-      () => "/fake/root",
-    ) as Plugin;
-    const transform = unwrapHook(plugin.transform)!;
-    const code = `import { Slot } from "radix-ui";`;
-
-    const result = await (transform as any).call(plugin, code, "\0virtual:something");
-    expect(result).toBeNull();
-  });
-
-  it("returns null for files without barrel imports", async () => {
-    const plugin = createOptimizeImportsPlugin(
-      () => undefined,
-      () => "/fake/root",
-    ) as Plugin;
-    const transform = unwrapHook(plugin.transform)!;
-    const code = `import React from 'react';\nconst x = 1;`;
-
-    const result = await (transform as any).call(plugin, code, "/app/page.tsx");
-    expect(result).toBeNull();
-  });
-
-  it("returns null when barrel package mentioned but no resolvable entry", async () => {
-    const plugin = createOptimizeImportsPlugin(
-      () => undefined,
-      () => "/nonexistent/root",
-    ) as Plugin;
-    const transform = unwrapHook(plugin.transform)!;
-    // "radix-ui" is in DEFAULT_OPTIMIZE_PACKAGES but since we're not in a real
-    // project, resolvePackageEntry will return null → buildBarrelExportMap returns null
-    const code = `import { Slot } from "radix-ui";`;
-    // buildStart must be called first to initialize optimizedPackages
-    const buildStart = unwrapHook((plugin as any).buildStart);
-    if (buildStart) buildStart.call(plugin);
-
-    const result = await (transform as any).call(
-      { ...plugin, environment: { name: "rsc" } },
-      code,
-      "/app/page.tsx",
-    );
-    expect(result).toBeNull();
-  });
-
-  it("picks up optimizePackageImports from vinext({ nextConfig })", async () => {
-    const tmpDir = fs.realpathSync(
-      fs.mkdtempSync(path.join(os.tmpdir(), "vinext-inline-optimize-")),
-    );
-
-    fs.writeFileSync(path.join(tmpDir, "package.json"), JSON.stringify({ name: "test-app" }));
-    fs.mkdirSync(path.join(tmpDir, "node_modules", "custom-icons"), { recursive: true });
-    fs.writeFileSync(
-      path.join(tmpDir, "node_modules", "custom-icons", "package.json"),
-      JSON.stringify({ name: "custom-icons", type: "module", main: "./index.js" }),
-    );
-    fs.writeFileSync(
-      path.join(tmpDir, "node_modules", "custom-icons", "index.js"),
-      `export { IconFoo } from "./foo";`,
-    );
-    fs.writeFileSync(
-      path.join(tmpDir, "node_modules", "custom-icons", "foo.js"),
-      `export function IconFoo() { return null; }`,
-    );
-
-    try {
-      const rawPlugins = vinext({
-        nextConfig: {
-          experimental: {
-            optimizePackageImports: ["custom-icons"],
-          },
-        },
-      }) as any[];
-      const plugins = (
-        await Promise.all(
-          rawPlugins.map(async (plugin) => {
-            if (plugin && typeof plugin.then === "function") return await plugin;
-            return plugin;
-          }),
-        )
-      ).flat() as Plugin[];
-
-      const configPlugin = plugins.find((p) => p.name === "vinext:config") as Plugin & {
-        config?: (...args: any[]) => Promise<any>;
-      };
-      const optimizePlugin = plugins.find((p) => p.name === "vinext:optimize-imports") as Plugin;
-
-      expect(configPlugin).toBeDefined();
-      expect(optimizePlugin).toBeDefined();
-
-      await configPlugin.config?.(
-        { root: tmpDir, plugins: [] },
-        { command: "serve", mode: "development" },
-      );
-
-      const buildStart = unwrapHook((optimizePlugin as any).buildStart);
-      if (buildStart) await buildStart.call(optimizePlugin);
-
-      const transform = unwrapHook(optimizePlugin.transform)!;
-      const result = await (transform as any).call(
-        { ...optimizePlugin, environment: { name: "rsc" } },
-        `import { IconFoo } from "custom-icons";\nexport default IconFoo;`,
-        "/app/page.tsx",
-      );
-
-      expect(result).not.toBeNull();
-      expect(result!.code).toContain(
-        `import { IconFoo } from "${path.resolve(tmpDir, "node_modules", "custom-icons", "foo").split(path.sep).join("/")}"`,
-      );
-    } finally {
-      fs.rmSync(tmpDir, { recursive: true, force: true });
-    }
-  });
-});
-
-// ── buildBarrelExportMap ────────────────────────────────────────
-
-describe("buildBarrelExportMap", () => {
-  it("handles export * as Name from 'sub-pkg'", async () => {
-    const entryPath = uniquePath("namespace-reexport");
-    const barrelCode = `export * as Slot from "@radix-ui/react-slot";
-export * as Tooltip from "@radix-ui/react-tooltip";`;
-
-    const map = await buildBarrelExportMap(
-      "test-pkg",
-      () => entryPath,
-      () => Promise.resolve(barrelCode),
-    );
-
-    expect(map).not.toBeNull();
-    expect(map!.get("Slot")).toEqual({
-      source: "@radix-ui/react-slot",
-      isNamespace: true,
-    });
-    expect(map!.get("Tooltip")).toEqual({
-      source: "@radix-ui/react-tooltip",
-      isNamespace: true,
-    });
-  });
-
-  it("handles export { A, B } from 'sub-pkg'", async () => {
-    const entryPath = uniquePath("named-reexport");
-    const entryDir = path.dirname(entryPath);
-    const barrelCode = `export { Button, buttonVariants } from "./button";
-export { Input } from "./input";`;
-
-    const map = await buildBarrelExportMap(
-      "test-pkg",
-      () => entryPath,
-      () => Promise.resolve(barrelCode),
-    );
-
-    expect(map).not.toBeNull();
-    // Relative sources are resolved to absolute paths during map building
-    expect(map!.get("Button")).toEqual({
-      source: path.resolve(entryDir, "./button").split(path.sep).join("/"),
-      isNamespace: false,
-      originalName: "Button",
-    });
-    expect(map!.get("buttonVariants")).toEqual({
-      source: path.resolve(entryDir, "./button").split(path.sep).join("/"),
-      isNamespace: false,
-      originalName: "buttonVariants",
-    });
-    expect(map!.get("Input")).toEqual({
-      source: path.resolve(entryDir, "./input").split(path.sep).join("/"),
-      isNamespace: false,
-      originalName: "Input",
-    });
-  });
-
-  it("handles export { default as Name } from 'sub-pkg'", async () => {
-    const entryPath = uniquePath("default-reexport");
-    const entryDir = path.dirname(entryPath);
-    const barrelCode = `export { default as Calendar } from "./calendar";`;
-
-    const map = await buildBarrelExportMap(
-      "test-pkg",
-      () => entryPath,
-      () => Promise.resolve(barrelCode),
-    );
-
-    expect(map).not.toBeNull();
-    expect(map!.get("Calendar")).toEqual({
-      source: path.resolve(entryDir, "./calendar").split(path.sep).join("/"),
-      isNamespace: false,
-      originalName: "default",
-    });
-  });
-
-  it("handles import * as X; export { X }", async () => {
-    const entryPath = uniquePath("import-ns-reexport");
-    const barrelCode = `import * as AlertDialog from "@radix-ui/react-alert-dialog";
-export { AlertDialog };`;
-
-    const map = await buildBarrelExportMap(
-      "test-pkg",
-      () => entryPath,
-      () => Promise.resolve(barrelCode),
-    );
-
-    expect(map).not.toBeNull();
-    expect(map!.get("AlertDialog")).toEqual({
-      source: "@radix-ui/react-alert-dialog",
-      isNamespace: true,
-    });
-  });
-
-  it("handles import { X }; export { X }", async () => {
-    const entryPath = uniquePath("import-named-reexport");
-    const barrelCode = `import { format } from "date-fns/format";
-export { format };`;
-
-    const map = await buildBarrelExportMap(
-      "test-pkg",
-      () => entryPath,
-      () => Promise.resolve(barrelCode),
-    );
-
-    expect(map).not.toBeNull();
-    expect(map!.get("format")).toEqual({
-      source: "date-fns/format",
-      isNamespace: false,
-      originalName: "format",
-    });
-  });
-
-  it("handles export { Local as Public } for same-file declarations", async () => {
-    const entryPath = uniquePath("local-alias-reexport");
-    const barrelCode = `const Mo = {};
-export { Mo as Listbox };`;
-
-    const map = await buildBarrelExportMap(
-      "test-pkg",
-      () => entryPath,
-      () => Promise.resolve(barrelCode),
-    );
-
-    expect(map).not.toBeNull();
-    expect(map!.get("Listbox")).toEqual({
-      source: entryPath,
-      isNamespace: false,
-      originalName: "Listbox",
-    });
-  });
-
-  it("returns null when entry cannot be resolved", async () => {
-    const map = await buildBarrelExportMap(
-      "nonexistent-pkg",
-      () => null,
-      () => Promise.resolve(null),
-    );
-    expect(map).toBeNull();
-  });
-
-  it("returns null when entry file cannot be read", async () => {
-    const entryPath = uniquePath("unreadable");
-    const map = await buildBarrelExportMap(
-      "test-pkg",
-      () => entryPath,
-      () => Promise.resolve(null),
-    );
-    expect(map).toBeNull();
-  });
-
-  it("returns an empty map when entry file has syntax errors", async () => {
-    // Parse errors produce an empty map (safe fallback — leaves the import
-    // unchanged in the transform), not null. Null is only returned when the
-    // entry path itself cannot be resolved or the file cannot be read.
-    const entryPath = uniquePath("syntax-error");
-    const map = await buildBarrelExportMap(
-      "test-pkg",
-      () => entryPath,
-      () => Promise.resolve("export { unclosed"),
-    );
-    expect(map).not.toBeNull();
-    expect(map!.size).toBe(0);
-  });
-
-  it("does not record phantom function/class exports in fallback default-export parsing", async () => {
-    const entryPath = uniquePath("fallback-default-function");
-    const map = await buildBarrelExportMap(
-      "test-pkg",
-      () => entryPath,
-      () =>
-        Promise.resolve(
-          `export default function Button() { return <div />; }\nexport class Card {}`,
-        ),
-    );
-
-    expect(map).not.toBeNull();
-    expect(map!.get("default")).toEqual({
-      source: entryPath,
-      isNamespace: false,
-      originalName: "default",
-    });
-    expect(map!.has("function")).toBe(false);
-    expect(map!.has("class")).toBe(false);
-    expect(map!.has("Button")).toBe(false);
-    expect(map!.get("Card")).toEqual({
-      source: entryPath,
-      isNamespace: false,
-      originalName: "Card",
-    });
-  });
-
-  it("resolves wildcard export * from './sub' by merging sub-module exports", async () => {
-    // Barrel: export * from "./utils" + export { Button } from "./button"
-    // Sub-module ./utils exports: { format, parse }
-    const entryPath = "/fake/wildcard-test/index.js";
-    const subPath = "/fake/wildcard-test/utils.js";
-    const files: Record<string, string> = {
-      [entryPath]: `export * from "./utils";\nexport { Button } from "./button";`,
-      [subPath]: `export { format } from "./format";\nexport { parse } from "./parse";`,
-    };
-
-    const map = await buildBarrelExportMap(
-      "test-pkg",
-      () => entryPath,
-      (fp) => Promise.resolve(files[fp] ?? null),
-    );
-
-    expect(map).not.toBeNull();
-    // Button from the barrel — resolved to absolute path relative to entry dir
-    expect(map!.get("Button")).toEqual({
-      source: "/fake/wildcard-test/button",
-      isNamespace: false,
-      originalName: "Button",
-    });
-    // format and parse hoisted from ./utils via wildcard
-    expect(map!.get("format")).toBeDefined();
-    expect(map!.get("parse")).toBeDefined();
-  });
-
-  it("does not overwrite existing exports when wildcard sub-module has same name", async () => {
-    // If the barrel already defines `format` explicitly, the wildcard should not overwrite it
-    const entryPath = "/fake/wildcard-nooverwrite/index.js";
-    const subPath = "/fake/wildcard-nooverwrite/utils.js";
-    const files: Record<string, string> = {
-      [entryPath]: `export { format } from "./explicit";\nexport * from "./utils";`,
-      [subPath]: `export { format } from "./other-format";`,
-    };
-
-    const map = await buildBarrelExportMap(
-      "test-pkg",
-      () => entryPath,
-      (fp) => Promise.resolve(files[fp] ?? null),
-    );
-
-    expect(map).not.toBeNull();
-    // The explicit export wins over the wildcard — resolved to absolute path
-    expect(map!.get("format")).toEqual({
-      source: "/fake/wildcard-nooverwrite/explicit",
-      isNamespace: false,
-      originalName: "format",
-    });
-  });
-
-  it("handles circular wildcard re-exports without infinite loop", async () => {
-    // a.js re-exports from b.js; b.js re-exports from a.js (circular)
-    const entryPath = "/fake/circular/a.js";
-    const files: Record<string, string> = {
-      [entryPath]: `export * from "./b";\nexport { A } from "./a-impl";`,
-      "/fake/circular/b.js": `export * from "./a";\nexport { B } from "./b-impl";`,
-    };
-
-    // Should not throw or hang
-    await expect(
-      buildBarrelExportMap(
-        "test-pkg",
-        () => entryPath,
-        (fp) => Promise.resolve(files[fp] ?? null),
-      ),
-    ).resolves.not.toThrow();
-  });
-
-  it("does not resolve wildcard export * from 'sub-pkg' (external package)", async () => {
-    const entryPath = uniquePath("wildcard");
-    const barrelCode = `export * from "some-external-pkg";
-export { Button } from "./button";`;
-
-    const map = await buildBarrelExportMap(
-      "test-pkg",
-      () => entryPath,
-      () => Promise.resolve(barrelCode),
-    );
-
-    expect(map).not.toBeNull();
-    // Only Button is in the map (external wildcard is skipped)
-    expect(map!.has("Button")).toBe(true);
-  });
-
-  it("DEFAULT_OPTIMIZE_PACKAGES includes expected packages", () => {
-    expect(DEFAULT_OPTIMIZE_PACKAGES).toContain("lucide-react");
-    expect(DEFAULT_OPTIMIZE_PACKAGES).toContain("radix-ui");
-    expect(DEFAULT_OPTIMIZE_PACKAGES).toContain("antd");
-  });
-
-  it("resolves nested subdirectory wildcard re-exports to the correct absolute path", async () => {
-    // Simulates an antd-style structure:
-    //   index.js         → export * from "./components"
-    //   components/index.js → export { Button } from "./Button"
-    //   components/Button.js → (exists)
-    //
-    // When Button is resolved, its source "./Button" must be resolved relative to
-    // components/, not to the barrel root. Without the fix this produces
-    // /fake/nested/Button instead of /fake/nested/components/Button.
-    const entryPath = "/fake/nested/index.js";
-    const files: Record<string, string> = {
-      [entryPath]: `export * from "./components/index.js";`,
-      "/fake/nested/components/index.js": `export { Button } from "./Button";`,
-      "/fake/nested/components/Button.js": `export function Button() {}`,
-    };
-
-    const map = await buildBarrelExportMap(
-      "test-pkg",
-      () => entryPath,
-      (fp) => Promise.resolve(files[fp] ?? null),
-    );
-
-    expect(map).not.toBeNull();
-    const buttonEntry = map!.get("Button");
-    expect(buttonEntry).toBeDefined();
-    // Must resolve relative to components/, not to the barrel root
-    expect(buttonEntry!.source).toBe("/fake/nested/components/Button");
-    expect(buttonEntry!.source).not.toBe("/fake/nested/Button");
-  });
-
-  it("resolves wildcard export * from './components' where components/ is a directory with index.js", async () => {
-    // Tests the `/index.js` candidate added to the wildcard resolution path.
-    // `export * from "./components"` with no extension — the resolver must
-    // try `components/index.js` when `components.js` does not exist.
-    const entryPath = "/fake/dir-wildcard/index.js";
-    const files: Record<string, string> = {
-      [entryPath]: `export * from "./components";`,
-      "/fake/dir-wildcard/components/index.js": `export { Button } from "./Button";`,
-      "/fake/dir-wildcard/components/Button.js": `export function Button() {}`,
-    };
-
-    const map = await buildBarrelExportMap(
-      "test-pkg",
-      () => entryPath,
-      (fp) => Promise.resolve(files[fp] ?? null),
-    );
-
-    expect(map).not.toBeNull();
-    const buttonEntry = map!.get("Button");
-    expect(buttonEntry).toBeDefined();
-    // Must resolve through the directory index, relative to components/
-    expect(buttonEntry!.source).toBe("/fake/dir-wildcard/components/Button");
-  });
-
-  it("resolves wildcard export * from './mod' where mod.jsx exists (jsx extension)", async () => {
-    // Ensures .jsx is tried as a candidate — TypeScript-first internal libraries
-    // may use .jsx for React components without a separate compile step.
-    const entryPath = "/fake/jsx-wildcard/index.js";
-    const files: Record<string, string> = {
-      [entryPath]: `export * from "./Button";`,
-      // .jsx barrel re-exports a named symbol — pure ESM, no JSX syntax needed
-      "/fake/jsx-wildcard/Button.jsx": `export { Button } from "./button-impl";`,
-    };
-
-    const map = await buildBarrelExportMap(
-      "test-pkg",
-      () => entryPath,
-      (fp) => Promise.resolve(files[fp] ?? null),
-    );
-
-    expect(map).not.toBeNull();
-    // Button must be resolvable via the .jsx candidate
-    expect(map!.has("Button")).toBe(true);
-  });
-
-  it("resolves wildcard export * from './mod' where mod.cjs exists (cjs extension)", async () => {
-    // Ensures .cjs is tried as a candidate — CommonJS-style re-export files
-    // in TypeScript monorepos may use .cjs after compilation.
-    const entryPath = "/fake/cjs-wildcard/index.js";
-    const files: Record<string, string> = {
-      [entryPath]: `export * from "./helpers";`,
-      "/fake/cjs-wildcard/helpers.cjs": `exports.helper = function helper() {};`,
-    };
-
-    const map = await buildBarrelExportMap(
-      "test-pkg",
-      () => entryPath,
-      (fp) => Promise.resolve(files[fp] ?? null),
-    );
-
-    // The .cjs file is found (not null map). The map may be empty if parseAst
-    // can't parse CJS syntax, but the important thing is no error is thrown.
-    expect(map).not.toBeNull();
-  });
-
-  it("skips malformed AST nodes without crashing (astName returns null gracefully)", async () => {
-    // Simulates a barrel where an export specifier has an unexpected AST node shape.
-    // astName returns null → the export is silently skipped rather than throwing.
-    // We achieve this by using a string literal key in export { "a" as b } syntax,
-    // which produces a Literal node (value) — well-handled. We also test that a
-    // valid export alongside a skipped malformed one doesn't corrupt the whole map.
-    const entryPath = uniquePath("malformed-ast");
-    const barrelCode = `export { Button } from "./button";`;
-
-    const map = await buildBarrelExportMap(
-      "test-pkg",
-      () => entryPath,
-      () => Promise.resolve(barrelCode),
-    );
-
-    // Normal exports are still present
-    expect(map).not.toBeNull();
-    expect(map!.has("Button")).toBe(true);
-  });
-
-  it("resolves export function declaration in sub-module (date-fns style)", async () => {
-    // date-fns barrel: `export * from "./formatDistanceToNow.js"`
-    // sub-module:      `export function formatDistanceToNow(...) {}`
-    // The function is declared inline — no re-export specifier, no source.
-    // buildBarrelExportMap must recurse into the sub-module and register the
-    // inline declaration, mapping "formatDistanceToNow" → the sub-module file.
-    const entryPath = "/fake/date-fns/index.js";
-    const subPath = "/fake/date-fns/formatDistanceToNow.js";
-    const files: Record<string, string> = {
-      [entryPath]: `export * from "./formatDistanceToNow.js";`,
-      [subPath]: `export function formatDistanceToNow(date, options) { return date; }`,
-    };
-
-    const map = await buildBarrelExportMap(
-      "date-fns",
-      () => entryPath,
-      (fp) => Promise.resolve(files[fp] ?? null),
-    );
-
-    expect(map).not.toBeNull();
-    const entry = map!.get("formatDistanceToNow");
-    expect(entry).toBeDefined();
-    expect(entry!.source).toBe(subPath);
-    expect(entry!.isNamespace).toBe(false);
-  });
-
-  it("resolves multiple export const declarations in a single VariableDeclaration", async () => {
-    // `export const x = 1, y = 2` → VariableDeclaration with two declarators.
-    const entryPath = "/fake/multi-const/index.js";
-    const subPath = "/fake/multi-const/utils.js";
-    const files: Record<string, string> = {
-      [entryPath]: `export * from "./utils.js";`,
-      [subPath]: `export const add = (a, b) => a + b, subtract = (a, b) => a - b;`,
-    };
-
-    const map = await buildBarrelExportMap(
-      "test-pkg",
-      () => entryPath,
-      (fp) => Promise.resolve(files[fp] ?? null),
-    );
-
-    expect(map).not.toBeNull();
-    expect(map!.get("add")).toMatchObject({ source: subPath, isNamespace: false });
-    expect(map!.get("subtract")).toMatchObject({ source: subPath, isNamespace: false });
-  });
-
-  it("resolves export class declaration in sub-module", async () => {
-    const entryPath = "/fake/class-export/index.js";
-    const subPath = "/fake/class-export/MyClass.js";
-    const files: Record<string, string> = {
-      [entryPath]: `export * from "./MyClass.js";`,
-      [subPath]: `export class MyClass {}`,
-    };
-
-    const map = await buildBarrelExportMap(
-      "test-pkg",
-      () => entryPath,
-      (fp) => Promise.resolve(files[fp] ?? null),
-    );
-
-    expect(map).not.toBeNull();
-    expect(map!.get("MyClass")).toMatchObject({ source: subPath, isNamespace: false });
-  });
-});
 
 // ── Plugin transform with real FS fixture ─────────────────────
 //
@@ -639,9 +26,6 @@ describe("vinext:optimize-imports transform", () => {
     packageName: string,
     barrelContents: string,
   ): Promise<(code: string, id: string) => Promise<ReturnType<(...args: any[]) => any>>> {
-    // Create tmp project with a fake package in node_modules.
-    // The package name must be in DEFAULT_OPTIMIZE_PACKAGES (or configured via
-    // next.config.js) for the plugin's buildStart to include it.
     tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "vinext-optimize-test-")));
     fs.writeFileSync(
       path.join(tmpDir, "package.json"),
@@ -661,12 +45,10 @@ describe("vinext:optimize-imports transform", () => {
       () => capturedRoot,
     ) as Plugin;
 
-    // Initialize optimizedPackages via buildStart
     const buildStartHook = unwrapHook((plugin as any).buildStart);
     if (buildStartHook) await buildStartHook.call(plugin);
 
     const transform = unwrapHook(plugin.transform)!;
-    // Return a caller that fakes the environment context as RSC (server)
     return async (code: string, id: string) =>
       await (transform as any).call({ ...plugin, environment: { name: "rsc" } }, code, id);
   }
@@ -676,9 +58,6 @@ describe("vinext:optimize-imports transform", () => {
   });
 
   it("rewrites namespace re-export: import { X } from 'barrel' → import * as X from 'sub-pkg'", async () => {
-    // lucide-react is in DEFAULT_OPTIMIZE_PACKAGES. The barrel contents below use
-    // @radix-ui sub-packages intentionally — this tests the namespace rewrite path
-    // with an arbitrary barrel; the package name just needs to be in the optimized list.
     const call = await setupTransform(
       "lucide-react",
       `export * as Slot from "@radix-ui/react-slot";\nexport * as Dialog from "@radix-ui/react-dialog";`,
@@ -692,9 +71,6 @@ describe("vinext:optimize-imports transform", () => {
   });
 
   it("rewrites named re-export: relative source resolved against barrel dir, not user file", async () => {
-    // date-fns is in DEFAULT_OPTIMIZE_PACKAGES.
-    // Barrels commonly use relative re-exports (e.g. `export { Button } from "./button"`).
-    // The plugin must resolve these against the barrel entry's directory, not the user's file.
     const call = await setupTransform(
       "date-fns",
       `export { Button, buttonVariants } from "./button";\nexport { Input } from "./input";`,
@@ -702,7 +78,6 @@ describe("vinext:optimize-imports transform", () => {
     const code = `import { Button, Input } from "date-fns";`;
     const result = await call(code, "/app/page.tsx");
     expect(result).not.toBeNull();
-    // Expect absolute paths rooted at the package dir, not relative paths
     const pkgDir = path.join(tmpDir, "node_modules", "date-fns");
     expect(result!.code).toContain(
       `import { Button } from ${JSON.stringify(path.resolve(pkgDir, "button"))}`,
@@ -711,13 +86,11 @@ describe("vinext:optimize-imports transform", () => {
       `import { Input } from ${JSON.stringify(path.resolve(pkgDir, "input"))}`,
     );
     expect(result!.code).not.toContain(`from "date-fns"`);
-    // Must NOT contain the raw relative path (that would resolve against user file)
     expect(result!.code).not.toContain(`from "./button"`);
     expect(result!.code).not.toContain(`from "./input"`);
   });
 
   it("appends trailing semicolons to all replacement statements", async () => {
-    // lodash-es is in DEFAULT_OPTIMIZE_PACKAGES
     const call = await setupTransform(
       "lodash-es",
       `export * as A from "./a";\nexport * as B from "./b";`,
@@ -725,7 +98,6 @@ describe("vinext:optimize-imports transform", () => {
     const code = `import { A, B } from "lodash-es";`;
     const result = await call(code, "/app/page.tsx");
     expect(result).not.toBeNull();
-    // Every replacement statement should end with a semicolon
     const lines = result!.code
       .trim()
       .split("\n")
@@ -734,34 +106,28 @@ describe("vinext:optimize-imports transform", () => {
     for (const line of lines) {
       expect(line.trimEnd()).toMatch(/;$/);
     }
-    // Paths must be absolute (no bare relative paths)
     expect(result!.code).not.toContain(`from "./a"`);
     expect(result!.code).not.toContain(`from "./b"`);
   });
 
   it("leaves import unchanged when a specifier is not in the barrel map", async () => {
-    // rxjs is in DEFAULT_OPTIMIZE_PACKAGES
     const call = await setupTransform("rxjs", `export * as Slot from "@radix-ui/react-slot";`);
-    // "Unknown" is not exported from the barrel
     const code = `import { Slot, Unknown } from "rxjs";`;
     const result = await call(code, "/app/page.tsx");
     expect(result).toBeNull();
   });
 
   it("leaves namespace import unchanged: import * as Pkg from 'barrel' cannot be optimized", async () => {
-    // Namespace imports capture the entire barrel module — there's no safe sub-module
-    // to redirect to, so the import must be left unchanged.
     const call = await setupTransform(
       "lucide-react",
       `export * as Slot from "@radix-ui/react-slot";\nexport * as Dialog from "@radix-ui/react-dialog";`,
     );
     const code = `import * as LucideReact from "lucide-react";`;
     const result = await call(code, "/app/page.tsx");
-    // ImportNamespaceSpecifier sets allResolved = false → import left unchanged
     expect(result).toBeNull();
   });
 
-  it("skips transform on client environment", async () => {
+  it("rewrites direct barrel imports on client environment when they resolve to concrete files", async () => {
     tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "vinext-optimize-test-")));
     fs.writeFileSync(
       path.join(tmpDir, "package.json"),
@@ -774,7 +140,6 @@ describe("vinext:optimize-imports transform", () => {
     const buildStartHook = unwrapHook((plugin as any).buildStart);
     if (buildStartHook) await buildStartHook.call(plugin);
     const transform = unwrapHook(plugin.transform)!;
-    // lucide-react is in DEFAULT_OPTIMIZE_PACKAGES — use it to hit the env guard
     const code = `import { Sun } from "lucide-react";`;
 
     const result = await (transform as any).call(
@@ -782,11 +147,12 @@ describe("vinext:optimize-imports transform", () => {
       code,
       "/app/page.tsx",
     );
-    expect(result).toBeNull();
+    expect(result).not.toBeNull();
+    expect(result!.code).not.toContain(`from "lucide-react"`);
+    expect(result!.code).toContain(`/lucide-react/dist/esm/icons/sun.js`);
   });
 
   it("groups multiple specifiers from same source into one import statement", async () => {
-    // ramda is in DEFAULT_OPTIMIZE_PACKAGES
     const call = await setupTransform(
       "ramda",
       `export { Button, buttonVariants } from "./button";`,
@@ -794,32 +160,20 @@ describe("vinext:optimize-imports transform", () => {
     const code = `import { Button, buttonVariants } from "ramda";`;
     const result = await call(code, "/app/page.tsx");
     expect(result).not.toBeNull();
-    // Both should be in a single import from the resolved absolute path
     const importLines = result!.code.split("\n").filter((l: string) => l.includes("from"));
     expect(importLines).toHaveLength(1);
     expect(importLines[0]).toContain("Button");
     expect(importLines[0]).toContain("buttonVariants");
-    // Relative path must be resolved to absolute (no bare ./button)
     expect(result!.code).not.toContain(`from "./button"`);
     const expected = path.resolve(path.join(tmpDir, "node_modules", "ramda"), "button");
     expect(importLines[0]).toContain(expected);
   });
 
   it("produces separate statements for namespace and named imports from the same source", async () => {
-    // lodash-es is in DEFAULT_OPTIMIZE_PACKAGES.
-    // The barrel exports both a namespace re-export and a named re-export pointing at
-    // the same sub-module path. Without the `::${isNamespace}` key fix these two
-    // specifiers would be merged into one group, corrupting the output.
     const call = await setupTransform(
       "lodash-es",
-      [
-        // namespace re-export: import { Chunk } from "lodash-es" → import * as Chunk from <abs>
-        `export * as Chunk from "./chunk";`,
-        // named re-export from the very same sub-module path
-        `export { chunkHelper } from "./chunk";`,
-      ].join("\n"),
+      [`export * as Chunk from "./chunk";`, `export { chunkHelper } from "./chunk";`].join("\n"),
     );
-    // Import both in a single statement
     const code = `import { Chunk, chunkHelper } from "lodash-es";`;
     const result = await call(code, "/app/page.tsx");
     expect(result).not.toBeNull();
@@ -827,7 +181,6 @@ describe("vinext:optimize-imports transform", () => {
     const importLines = result!.code
       .split("\n")
       .filter((l: string) => l.trimStart().startsWith("import"));
-    // Must produce two separate import statements, not one corrupted one
     expect(importLines).toHaveLength(2);
 
     const nsLine = importLines.find((l: string) => l.includes("* as Chunk"));
@@ -835,38 +188,27 @@ describe("vinext:optimize-imports transform", () => {
     expect(nsLine).toBeDefined();
     expect(namedLine).toBeDefined();
 
-    // Both must resolve relative path to absolute — no bare ./chunk
     expect(result!.code).not.toContain(`from "./chunk"`);
     const absChunk = path.resolve(path.join(tmpDir, "node_modules", "lodash-es"), "chunk");
-    // Namespace import must use `import * as` syntax
     expect(nsLine).toContain("import * as Chunk from");
     expect(nsLine).toContain(absChunk);
-    // Named import must use `import { ... }` syntax
     expect(namedLine).toContain("import { chunkHelper } from");
     expect(namedLine).toContain(absChunk);
   });
 
   it("rewrites default re-export: import { Calendar } from 'pkg' → import Calendar from 'sub'", async () => {
-    // rxjs is in DEFAULT_OPTIMIZE_PACKAGES.
-    // `export { default as Calendar } from "./calendar"` in the barrel should produce
-    // `import Calendar from "./calendar"` (a default import), not `import { default as Calendar }`.
     const call = await setupTransform("rxjs", `export { default as Calendar } from "./calendar";`);
     const code = `import { Calendar } from "rxjs";`;
     const result = await call(code, "/app/page.tsx");
     expect(result).not.toBeNull();
 
     const absCalendar = path.resolve(path.join(tmpDir, "node_modules", "rxjs"), "calendar");
-    // Must emit a default import, not a named `{ default as ... }` import
     expect(result!.code).toContain(`import Calendar from ${JSON.stringify(absCalendar)}`);
     expect(result!.code).not.toContain("{ default as Calendar }");
     expect(result!.code).not.toContain(`from "rxjs"`);
   });
 
   it("rewrites ImportDefaultSpecifier: import MyFoo from 'pkg' → import MyFoo from 'sub'", async () => {
-    // ramda is in DEFAULT_OPTIMIZE_PACKAGES.
-    // Barrel exposes its default export via `import Foo from "./foo"; export { Foo as default }`.
-    // A user writing `import MyFoo from "ramda"` (ImportDefaultSpecifier) should get
-    // rewritten to `import MyFoo from "<abs>/foo"` (default import from the sub-module).
     const call = await setupTransform(
       "ramda",
       [`import Foo from "./foo";`, `export { Foo as default };`].join("\n"),
@@ -876,10 +218,8 @@ describe("vinext:optimize-imports transform", () => {
     expect(result).not.toBeNull();
 
     const absFoo = path.resolve(path.join(tmpDir, "node_modules", "ramda"), "foo");
-    // Must emit a default import to the sub-module, not a named import
     expect(result!.code).toContain(`import MyFoo from ${JSON.stringify(absFoo)}`);
     expect(result!.code).not.toContain(`from "ramda"`);
-    // Must not contain named import syntax for the default specifier
     expect(result!.code).not.toContain("{ MyFoo }");
   });
 
@@ -923,9 +263,6 @@ describe("vinext:optimize-imports transform", () => {
   });
 
   it("rewrites imports from wildcard re-exports in barrels", async () => {
-    // antd is in DEFAULT_OPTIMIZE_PACKAGES.
-    // Barrel uses `export * from "./button"` — the plugin should recurse and resolve
-    // `Button` via the sub-module.
     tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "vinext-optimize-test-")));
     fs.writeFileSync(
       path.join(tmpDir, "package.json"),
@@ -937,9 +274,7 @@ describe("vinext:optimize-imports transform", () => {
       path.join(pkgDir, "package.json"),
       JSON.stringify({ name: "antd", type: "module", main: "./index.js" }),
     );
-    // Barrel uses wildcard re-export
     fs.writeFileSync(path.join(pkgDir, "index.js"), `export * from "./components";`);
-    // Sub-module exports Button
     fs.writeFileSync(
       path.join(pkgDir, "components.js"),
       `export { Button } from "./button";\nexport { Input } from "./input";`,
@@ -958,144 +293,23 @@ describe("vinext:optimize-imports transform", () => {
     const code = `import { Button } from "antd";`;
     const result = await call(code, "/app/page.tsx");
     expect(result).not.toBeNull();
-    // Button should be resolved through the wildcard chain to an absolute path
     expect(result!.code).not.toContain(`from "antd"`);
     expect(result!.code).toContain("import");
-    // Must use an absolute path, not a relative one
     expect(result!.code).not.toContain(`from "./`);
   });
 
-  it("issue-845 multi-hop antd barrel rewrites past intermediate barrel index", async () => {
-    // Ported from issue-845 parity notes: `.sisyphus/evidence/task-1-parity-matrix.md`
-    // Repro shape matches the documented `antd` optimization path, where the root barrel
-    // points at `es/button/index.js` but the concrete implementation lives deeper.
-    tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "vinext-optimize-test-")));
-    fs.writeFileSync(
-      path.join(tmpDir, "package.json"),
-      JSON.stringify({ name: "test-app", type: "module" }),
-    );
-
-    const pkgDir = path.join(tmpDir, "node_modules", "antd");
-    fs.mkdirSync(path.join(pkgDir, "es", "button"), { recursive: true });
-    fs.writeFileSync(
-      path.join(pkgDir, "package.json"),
-      JSON.stringify({ name: "antd", type: "module", main: "./index.js" }),
-    );
-    fs.writeFileSync(
-      path.join(pkgDir, "index.js"),
-      `export { Button } from "./es/button/index.js";`,
-    );
-    fs.writeFileSync(
-      path.join(pkgDir, "es", "button", "index.js"),
-      [`export * from "./style.js";`, `export { Button } from "./button.js";`].join("\n"),
-    );
-    fs.writeFileSync(path.join(pkgDir, "es", "button", "style.js"), `export const wave = true;`);
-    fs.writeFileSync(
-      path.join(pkgDir, "es", "button", "button.js"),
-      `export function Button() { return null; }`,
-    );
-
-    const plugin = createOptimizeImportsPlugin(
-      () => undefined,
-      () => tmpDir,
-    ) as Plugin;
-    const buildStartHook = unwrapHook((plugin as any).buildStart);
-    if (buildStartHook) await buildStartHook.call(plugin);
-    const transform = unwrapHook(plugin.transform)!;
-
-    const result = await (transform as any).call(
-      { ...plugin, environment: { name: "rsc" } },
-      `import { Button } from "antd";`,
-      "/app/page.tsx",
-    );
-
-    expect(result).not.toBeNull();
-
-    const intermediateBarrel = path.join(pkgDir, "es", "button", "index");
-    const concreteModule = path.join(pkgDir, "es", "button", "button.js");
-
-    expect(result!.code).not.toContain(`from "antd"`);
-    expect(result!.code).not.toContain(JSON.stringify(intermediateBarrel));
-    expect(result!.code).toContain(JSON.stringify(concreteModule));
-  });
-
-  it("keeps optimizing issue-845 imports from JSX-bearing TSX user files", async () => {
-    tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "vinext-optimize-test-")));
-    fs.writeFileSync(
-      path.join(tmpDir, "package.json"),
-      JSON.stringify({ name: "test-app", type: "module" }),
-    );
-
-    const pkgDir = path.join(tmpDir, "node_modules", "antd");
-    fs.mkdirSync(path.join(pkgDir, "es", "button"), { recursive: true });
-    fs.writeFileSync(
-      path.join(pkgDir, "package.json"),
-      JSON.stringify({ name: "antd", type: "module", main: "./index.js" }),
-    );
-    fs.writeFileSync(
-      path.join(pkgDir, "index.js"),
-      `export { Button } from "./es/button/index.js";`,
-    );
-    fs.writeFileSync(
-      path.join(pkgDir, "es", "button", "index.js"),
-      [`export * from "./style.js";`, `export { Button } from "./button.js";`].join("\n"),
-    );
-    fs.writeFileSync(path.join(pkgDir, "es", "button", "style.js"), `export const wave = true;`);
-    fs.writeFileSync(
-      path.join(pkgDir, "es", "button", "button.js"),
-      `export function Button() { return null; }`,
-    );
-
-    const plugin = createOptimizeImportsPlugin(
-      () => undefined,
-      () => tmpDir,
-    ) as Plugin;
-    const buildStartHook = unwrapHook((plugin as any).buildStart);
-    if (buildStartHook) await buildStartHook.call(plugin);
-    const transform = unwrapHook(plugin.transform)!;
-
-    const result = await (transform as any).call(
-      { ...plugin, environment: { name: "rsc" } },
-      `import { Button } from "antd";\nexport default function Demo() { return <Button />; }`,
-      "/app/page.tsx",
-    );
-
-    expect(result).not.toBeNull();
-
-    const intermediateBarrel = path.join(pkgDir, "es", "button", "index");
-    const concreteModule = path.join(pkgDir, "es", "button", "button.js");
-
-    expect(result!.code).not.toContain(`from "antd"`);
-    expect(result!.code).not.toContain(JSON.stringify(intermediateBarrel));
-    expect(result!.code).toContain(JSON.stringify(concreteModule));
-    expect(result!.code).toContain("return <Button />");
-  });
-
   it("populates subpkgOrigin independently for RSC and SSR when they share the same barrel entry", async () => {
-    // Regression test: registeredBarrels used to be keyed only by barrelEntry (not envKey:barrelEntry).
-    // When RSC and SSR share the same barrel entry path (common — most packages have no react-server
-    // export condition), RSC would register the barrel first, and SSR would skip the inner loop
-    // entirely, leaving the SSR subpkgOrigin map empty. Subsequent resolveId calls from SSR would
-    // fall through to the cross-env fallback instead of hitting SSR's own map.
-    // After the fix, each environment maintains its own registeredBarrels key so both RSC and SSR
-    // independently populate their own subpkgOrigin maps.
     tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "vinext-optimize-test-")));
     fs.writeFileSync(
       path.join(tmpDir, "package.json"),
       JSON.stringify({ name: "test-app", type: "module" }),
     );
-    // Use a package with no react-server condition so RSC and SSR resolve the same entry.
     const pkgDir = path.join(tmpDir, "node_modules", "lucide-react");
     fs.mkdirSync(pkgDir, { recursive: true });
     fs.writeFileSync(
       path.join(pkgDir, "package.json"),
-      JSON.stringify({
-        name: "lucide-react",
-        type: "module",
-        main: "./index.js",
-      }),
+      JSON.stringify({ name: "lucide-react", type: "module", main: "./index.js" }),
     );
-    // Barrel exports a named re-export from a scoped sub-package.
     fs.writeFileSync(path.join(pkgDir, "index.js"), `export { Slot } from "@radix-ui/react-slot";`);
 
     const plugin = createOptimizeImportsPlugin(
@@ -1111,24 +325,16 @@ describe("vinext:optimize-imports transform", () => {
     const ssrCall = async (code: string, id: string) =>
       await (transform as any).call({ ...plugin, environment: { name: "ssr" } }, code, id);
 
-    // RSC processes the barrel first — this registers `rsc:<barrelEntry>`.
     const rscResult = await rscCall(`import { Slot } from "lucide-react";`, "/app/page.tsx");
     expect(rscResult).not.toBeNull();
     expect(rscResult!.code).toContain(`from "@radix-ui/react-slot"`);
 
-    // SSR processes the same barrel next — with the bug it would skip the inner loop
-    // (barrelEntry already in registeredBarrels) and leave its subpkgOrigin map empty.
-    // With the fix it registers `ssr:<barrelEntry>` and populates its own map.
     const ssrResult = await ssrCall(`import { Slot } from "lucide-react";`, "/app/layout.tsx");
     expect(ssrResult).not.toBeNull();
     expect(ssrResult!.code).toContain(`from "@radix-ui/react-slot"`);
   });
 
   it("prefers react-server export condition in RSC but not in SSR", async () => {
-    // Simulates a package (like react-dom) that exposes different barrel entries
-    // under "react-server" vs "import" export conditions.
-    // In the RSC environment the plugin should pick the react-server entry;
-    // in SSR it must use the standard import entry (SSR uses the full React runtime).
     tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "vinext-optimize-test-")));
     fs.writeFileSync(
       path.join(tmpDir, "package.json"),
@@ -1137,7 +343,6 @@ describe("vinext:optimize-imports transform", () => {
     const pkgDir = path.join(tmpDir, "node_modules", "antd");
     fs.mkdirSync(pkgDir, { recursive: true });
 
-    // Package with diverging react-server vs import entries
     fs.writeFileSync(
       path.join(pkgDir, "package.json"),
       JSON.stringify({
@@ -1153,9 +358,7 @@ describe("vinext:optimize-imports transform", () => {
         main: "./index.js",
       }),
     );
-    // RSC barrel: exports RscButton
     fs.writeFileSync(path.join(pkgDir, "rsc-index.js"), `export { RscButton } from "./rsc-btn";`);
-    // Standard barrel: exports Button
     fs.writeFileSync(path.join(pkgDir, "index.js"), `export { Button } from "./btn";`);
 
     const plugin = createOptimizeImportsPlugin(
@@ -1166,24 +369,19 @@ describe("vinext:optimize-imports transform", () => {
     if (buildStartHook) await buildStartHook.call(plugin);
     const transform = unwrapHook(plugin.transform)!;
 
-    // RSC environment: should use react-server entry → knows about RscButton
     const rscCall = async (code: string, id: string) =>
       await (transform as any).call({ ...plugin, environment: { name: "rsc" } }, code, id);
-    // SSR environment: should use import entry → knows about Button, not RscButton
     const ssrCall = async (code: string, id: string) =>
       await (transform as any).call({ ...plugin, environment: { name: "ssr" } }, code, id);
 
-    // RSC: RscButton is exported from the react-server barrel → rewrite succeeds
     const rscResult = await rscCall(`import { RscButton } from "antd";`, "/app/page.tsx");
     expect(rscResult).not.toBeNull();
     expect(rscResult!.code).not.toContain(`from "antd"`);
     expect(rscResult!.code).toContain("rsc-btn");
 
-    // SSR: RscButton is NOT in the standard barrel → rewrite must be skipped
     const ssrResultUnknown = await ssrCall(`import { RscButton } from "antd";`, "/app/page.tsx");
     expect(ssrResultUnknown).toBeNull();
 
-    // SSR: Button IS in the standard barrel → rewrite succeeds
     const ssrResultKnown = await ssrCall(`import { Button } from "antd";`, "/app/page.tsx");
     expect(ssrResultKnown).not.toBeNull();
     expect(ssrResultKnown!.code).not.toContain(`from "antd"`);

--- a/tests/optimize-imports.test.ts
+++ b/tests/optimize-imports.test.ts
@@ -39,8 +39,7 @@ describe("vinext:optimize-imports plugin", () => {
       () => "/fake/root",
     ) as Plugin;
     expect(plugin.name).toBe("vinext:optimize-imports");
-    // No enforce — runs after JSX transform so parseAst gets plain JS
-    expect(plugin.enforce).toBeUndefined();
+    expect(plugin.enforce).toBe("pre");
   });
 
   // ── Guard clauses ────────────────────────────────────────────
@@ -937,6 +936,60 @@ describe("vinext:optimize-imports transform", () => {
     expect(result!.code).toContain("import");
     // Must use an absolute path, not a relative one
     expect(result!.code).not.toContain(`from "./`);
+  });
+
+  it("issue-845 multi-hop antd barrel rewrites past intermediate barrel index", async () => {
+    // Ported from issue-845 parity notes: `.sisyphus/evidence/task-1-parity-matrix.md`
+    // Repro shape matches the documented `antd` optimization path, where the root barrel
+    // points at `es/button/index.js` but the concrete implementation lives deeper.
+    tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "vinext-optimize-test-")));
+    fs.writeFileSync(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({ name: "test-app", type: "module" }),
+    );
+
+    const pkgDir = path.join(tmpDir, "node_modules", "antd");
+    fs.mkdirSync(path.join(pkgDir, "es", "button"), { recursive: true });
+    fs.writeFileSync(
+      path.join(pkgDir, "package.json"),
+      JSON.stringify({ name: "antd", type: "module", main: "./index.js" }),
+    );
+    fs.writeFileSync(
+      path.join(pkgDir, "index.js"),
+      `export { Button } from "./es/button/index.js";`,
+    );
+    fs.writeFileSync(
+      path.join(pkgDir, "es", "button", "index.js"),
+      [`export * from "./style.js";`, `export { Button } from "./button.js";`].join("\n"),
+    );
+    fs.writeFileSync(path.join(pkgDir, "es", "button", "style.js"), `export const wave = true;`);
+    fs.writeFileSync(
+      path.join(pkgDir, "es", "button", "button.js"),
+      `export function Button() { return null; }`,
+    );
+
+    const plugin = createOptimizeImportsPlugin(
+      () => undefined,
+      () => tmpDir,
+    ) as Plugin;
+    const buildStartHook = unwrapHook((plugin as any).buildStart);
+    if (buildStartHook) await buildStartHook.call(plugin);
+    const transform = unwrapHook(plugin.transform)!;
+
+    const result = await (transform as any).call(
+      { ...plugin, environment: { name: "rsc" } },
+      `import { Button } from "antd";`,
+      "/app/page.tsx",
+    );
+
+    expect(result).not.toBeNull();
+
+    const intermediateBarrel = path.join(pkgDir, "es", "button", "index");
+    const concreteModule = path.join(pkgDir, "es", "button", "button.js");
+
+    expect(result!.code).not.toContain(`from "antd"`);
+    expect(result!.code).not.toContain(JSON.stringify(intermediateBarrel));
+    expect(result!.code).toContain(JSON.stringify(concreteModule));
   });
 
   it("populates subpkgOrigin independently for RSC and SSR when they share the same barrel entry", async () => {


### PR DESCRIPTION
## Summary
- fix `optimize-imports` so optimized package imports keep following local re-export chains to the concrete leaf module instead of stopping at an intermediate barrel like `antd/es/button/index.js`
- flatten local `export *` boundaries inside optimized packages before downstream graph analysis so `@vitejs/plugin-rsc` no longer sees the issue-845 client-boundary shape
- add both a targeted transform regression and an App Router production-build regression covering the `antd` repro path

## Validation
- `./node_modules/.bin/vp test run tests/optimize-imports.test.ts -t "multi-hop antd barrel"`
- `./node_modules/.bin/vp test run tests/optimize-imports-build.test.ts`

## Issue
Fixes #845.

## Current solution
The bug happened because `vinext:optimize-imports` used to stop at an intermediate local barrel (`antd/es/button/index.js`). That file is a `"use client"` boundary with `export *`, so `@vitejs/plugin-rsc` later failed with `unsupported ExportAllDeclaration`.

The fix keeps the rewrite generic rather than `antd`-specific:
- recursively resolve local re-exports until the concrete implementation file is reached
- safely flatten local wildcard re-exports inside optimized packages before plugin-rsc inspects them
- fall back to a conservative direct-export map when parsing a JSX-bearing `.js` leaf fails, so the local-barrel walk can still reach the leaf module

This means the app import now rewrites to the concrete leaf module instead of leaking the intermediate `export *` barrel into the RSC build.