### PR TITLE
fix: exclude @tailwindcss/oxide from dep optimization

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -1207,7 +1207,8 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           },
         };
         viteConfig.optimizeDeps = {
-          exclude: [...new Set([...incomingExclude, "vinext", "@vercel/og"])],
+          // @tailwindcss/oxide contains native .node bindings that Rolldown cannot process
+          exclude: [...new Set([...incomingExclude, "vinext", "@vercel/og", "@tailwindcss/oxide"])],
           ...(incomingInclude.length > 0 ? { include: incomingInclude } : {}),
           rolldownOptions: { plugins: [depOptimizeAliasPlugin] },
         };


### PR DESCRIPTION
## Summary

Exclude `@tailwindcss/oxide` from Vite's dependency optimization — Rolldown cannot process native `.node` binaries.

## Problem

Rolldown cannot process native `.node` binary files. When a project uses Tailwind CSS v4, `@tailwindcss/oxide` contains platform-specific native bindings (`tailwindcss-oxide.darwin-arm64.node`) that cause Rolldown to fail with `UNLOADABLE_DEPENDENCY` during dependency optimization.

**Error:**
```
[UNLOADABLE_DEPENDENCY] Error: Could not load @tailwindcss/oxide-darwin-arm64/tailwindcss-oxide.darwin-arm64.node
  stream did not contain valid UTF-8
```

## Fix

Added `@tailwindcss/oxide` to the default `optimizeDeps.exclude` list alongside `vinext` and `@vercel/og`.

## Changes

Dropped the `next/navigation` default export per review feedback — Next.js itself does not provide a default export from `next/navigation`, and the stated `@clerk/nextjs` use case was incorrect (Clerk uses named imports).

## Test plan

- [x] Reproduced with Vite 8.0.8 + Rolldown 1.0.0-rc.15 + @tailwindcss/vite 4.2.2
- [x] Tested against [next-shadcn-dashboard-starter](https://github.com/Kiranism/next-shadcn-dashboard-starter) (Next.js 16, Tailwind v4)
- [ ] Run existing test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)