### PR TITLE
test(app-router): restore rapid-navigation no-reload assertions

### DIFF
--- a/tests/e2e/app-router/rapid-navigation.spec.ts
+++ b/tests/e2e/app-router/rapid-navigation.spec.ts
@@ -1,7 +1,23 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 import { waitForAppRouterHydration } from "../helpers";
 
 const BASE = "http://localhost:4174";
+
+async function clickRapidlyByTestIds(page: Page, testIds: readonly string[]): Promise<void> {
+  const targets = await Promise.all(
+    testIds.map(async (testId) => {
+      const box = await page.locator(`[data-testid="${testId}"]`).boundingBox();
+      if (!box) {
+        throw new Error(`Missing clickable target: ${testId}`);
+      }
+      return { x: box.x + box.width / 2, y: box.y + box.height / 2 };
+    }),
+  );
+
+  for (const target of targets) {
+    await page.mouse.click(target.x, target.y);
+  }
+}
 
 test.describe("rapid navigation", () => {
   test("A→B→C rapid navigation completes smoothly", async ({ page }) => {
@@ -20,15 +36,8 @@ test.describe("rapid navigation", () => {
       (window as any).__NAV_MARKER__ = "started-at-a";
     });
 
-    // Click B then immediately click C (before B fully commits)
-    // Use a single page.evaluate() to click both links atomically.
-    // This avoids React re-render issues and prevents "execution context destroyed" errors in CI.
-    await page.evaluate(() => {
-      const linkB = document.querySelector('[data-testid="page-a-link-to-b"]') as HTMLElement;
-      const linkC = document.querySelector('[data-testid="page-a-link-to-c"]') as HTMLElement;
-      if (linkB) linkB.click();
-      if (linkC) linkC.click();
-    });
+    // Trigger B then C with trusted clicks dispatched back-to-back.
+    await clickRapidlyByTestIds(page, ["page-a-link-to-b", "page-a-link-to-c"]);
 
     // Use toHaveURL (polling) instead of waitForURL (navigation event) because
     // rapid back-to-back client-side navigations abort the first navigation,
@@ -60,24 +69,8 @@ test.describe("rapid navigation", () => {
       (window as any).__NAV_MARKER__ = "started-at-a";
     });
 
-    // Navigate to B then immediately change query param (same-route nav)
-    // Use a single page.evaluate() to click both links atomically.
-    //
-    // Why isSameRoute === true for the second navigation:
-    // Both clicks run synchronously in the same microtask. The first click calls
-    // setPendingPathname('/nav-rapid/page-b', navId=1), storing the pending target.
-    // The second click then reads pendingPathname (which is '/nav-rapid/page-b'),
-    // compares it to its own target pathname (also '/nav-rapid/page-b'), and sees
-    // they match — so isSameRoute is true. This is correct behavior: the second
-    // navigation is a same-route query-param change, not a cross-route navigation.
-    await page.evaluate(() => {
-      const linkB = document.querySelector('[data-testid="page-a-link-to-b"]') as HTMLElement;
-      const linkFilter = document.querySelector(
-        '[data-testid="page-a-link-to-b-filter"]',
-      ) as HTMLElement;
-      if (linkB) linkB.click();
-      if (linkFilter) linkFilter.click();
-    });
+    // Trigger B then B?filter=test with trusted back-to-back clicks.
+    await clickRapidlyByTestIds(page, ["page-a-link-to-b", "page-a-link-to-b-filter"]);
 
     // Should settle on B with query param
     await expect(page.locator("h1")).toHaveText("Page B");

--- a/tests/e2e/app-router/rapid-navigation.spec.ts
+++ b/tests/e2e/app-router/rapid-navigation.spec.ts
@@ -16,6 +16,9 @@ test.describe("rapid navigation", () => {
     await page.goto(`${BASE}/nav-rapid/page-a`);
     await expect(page.locator("h1")).toHaveText("Page A");
     await waitForAppRouterHydration(page);
+    await page.evaluate(() => {
+      (window as any).__NAV_MARKER__ = "started-at-a";
+    });
 
     // Click B then immediately click C (before B fully commits)
     // Use a single page.evaluate() to click both links atomically.
@@ -32,6 +35,8 @@ test.describe("rapid navigation", () => {
     // causing waitForURL to fail with ERR_ABORTED.
     await expect(page).toHaveURL(`${BASE}/nav-rapid/page-c`, { timeout: 10_000 });
     await expect(page.locator("h1")).toHaveText("Page C");
+    const marker = await page.evaluate(() => (window as any).__NAV_MARKER__);
+    expect(marker).toBe("started-at-a");
 
     const navigationErrors = errors.filter(
       (e) => e.includes("navigation") || e.includes("vinext") || e.includes("router"),
@@ -51,6 +56,9 @@ test.describe("rapid navigation", () => {
     await page.goto(`${BASE}/nav-rapid/page-a`);
     await expect(page.locator("h1")).toHaveText("Page A");
     await waitForAppRouterHydration(page);
+    await page.evaluate(() => {
+      (window as any).__NAV_MARKER__ = "started-at-a";
+    });
 
     // Navigate to B then immediately change query param (same-route nav)
     // Use a single page.evaluate() to click both links atomically.
@@ -74,6 +82,8 @@ test.describe("rapid navigation", () => {
     // Should settle on B with query param
     await expect(page.locator("h1")).toHaveText("Page B");
     await expect(page).toHaveURL(`${BASE}/nav-rapid/page-b?filter=test`);
+    const marker = await page.evaluate(() => (window as any).__NAV_MARKER__);
+    expect(marker).toBe("started-at-a");
 
     // Verify no navigation-related errors
     const navigationErrors = errors.filter(


### PR DESCRIPTION
Summary:
Re-enable NAV_MARKER assertions in tests/e2e/app-router/rapid-navigation.spec.ts
 - Cover both rapid cross-route A→B→C and same-route query-change cases
 - Keep existing console-error assertions
 
Why:
Issue #796 reported full-page reloads during rapid navigation, but current main no longer reproduces this when using the suite hydration gate (waitForAppRouterHydration).
 
 This PR restores the regression assertions that were previously removed as a workaround, so this behavior stays locked in.
 
 Validation:
  - pnpm exec playwright test --project app-router -- tests/e2e/app-router/rapid-navigation.spec.ts
  
  Refs #796