### PR TITLE
Preserve intercepted app-router state across server actions

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -408,6 +408,7 @@ import {
 } from ${JSON.stringify(appPageResponsePath)};
 import { getScriptNonceFromHeaderSources as __getScriptNonceFromHeaderSources } from ${JSON.stringify(cspPath)};
 import {
+  resolveAppPageActionRerenderTarget as __resolveAppPageActionRerenderTarget,
   buildAppPageElement as __buildAppPageElement,
   resolveAppPageIntercept as __resolveAppPageIntercept,
   validateAppPageDynamicParams as __validateAppPageDynamicParams,
@@ -1817,27 +1818,57 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
 
       // After the action, re-render the current page so the client
       // gets an updated React tree reflecting any mutations.
+      //
+      // When the original request came from inside an intercepted modal
+      // (X-Vinext-Interception-Context present + source route still
+      // matches), rebuild the intercepted tree — otherwise the modal would
+      // unmount and the direct route would render in its place. Mirrors
+      // the interception resolution used by the GET path.
       const match = matchRoute(cleanPathname);
       let element;
+      let errorPattern = match ? match.route.pattern : cleanPathname;
       if (match) {
         const { route: actionRoute, params: actionParams } = match;
+        const __actionRerenderTarget = __resolveAppPageActionRerenderTarget({
+          cleanPathname,
+          currentParams: actionParams,
+          currentRoute: actionRoute,
+          findIntercept,
+          getRouteParamNames(sourceRoute) {
+            return sourceRoute.params;
+          },
+          getSourceRoute(sourceRouteIndex) {
+            return routes[sourceRouteIndex];
+          },
+          isRscRequest,
+          toInterceptOpts(intercept) {
+            return {
+              interceptionContext: interceptionContextHeader,
+              interceptSlotKey: intercept.slotKey,
+              interceptPage: intercept.page,
+              interceptParams: intercept.matchedParams,
+            };
+          },
+        });
+
         setNavigationContext({
           pathname: cleanPathname,
           searchParams: url.searchParams,
-          params: actionParams,
+          params: __actionRerenderTarget.navigationParams,
         });
         element = buildPageElements(
-          actionRoute,
-          actionParams,
+          __actionRerenderTarget.route,
+          __actionRerenderTarget.params,
           cleanPathname,
           {
-            opts: undefined,
+            opts: __actionRerenderTarget.interceptOpts,
             searchParams: url.searchParams,
             isRscRequest,
             request,
             mountedSlotsHeader: __mountedSlotsHeader,
           },
         );
+        errorPattern = __actionRerenderTarget.route.pattern;
       } else {
         const _actionRouteId = __createAppPayloadRouteId(cleanPathname, null);
         element = {
@@ -1851,7 +1882,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       const onRenderError = createRscOnErrorHandler(
         request,
         cleanPathname,
-        match ? match.route.pattern : cleanPathname,
+        errorPattern,
       );
       const rscStream = renderToReadableStream(
         { root: element, returnValue },

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -69,6 +69,7 @@ import {
   resolveAndClassifyNavigationCommit,
   resolveInterceptionContextFromPreviousNextUrl,
   resolvePendingNavigationCommitDisposition,
+  resolveServerActionRequestState,
   routerReducer,
   type AppRouterAction,
   type AppRouterState,
@@ -781,12 +782,22 @@ function registerServerActionCallback(): void {
     const temporaryReferences = createTemporaryReferenceSet();
     const body = await encodeReply(args, { temporaryReferences });
 
-    // Interception context on server-action re-renders is intentionally
-    // deferred: action POSTs always target the current URL's full page without
-    // propagating the source-route provenance.
+    // Carry the interception context + mounted slots from the current router
+    // state so the server-action re-render rebuilds the intercepted tree
+    // instead of replacing it with the direct page. Parity with Next.js,
+    // which sends `Next-URL` on action POSTs when the current tree contains
+    // an interception route.
+    const currentState = getBrowserRouterState();
+    const { headers } = resolveServerActionRequestState({
+      actionId: id,
+      basePath: __basePath,
+      elements: currentState.elements,
+      previousNextUrl: currentState.previousNextUrl,
+    });
+
     const fetchResponse = await fetch(toRscUrl(window.location.pathname + window.location.search), {
       method: "POST",
-      headers: { "x-rsc-action": id },
+      headers,
       body,
     });
 

--- a/packages/vinext/src/server/app-browser-state.ts
+++ b/packages/vinext/src/server/app-browser-state.ts
@@ -1,6 +1,11 @@
 import { mergeElements } from "../shims/slot.js";
 import { stripBasePath } from "../utils/base-path.js";
-import { readAppElementsMetadata, type AppElements, type LayoutFlags } from "./app-elements.js";
+import {
+  getMountedSlotIdsHeader,
+  readAppElementsMetadata,
+  type AppElements,
+  type LayoutFlags,
+} from "./app-elements.js";
 import type { ClientNavigationRenderSnapshot } from "../shims/navigation.js";
 
 const VINEXT_PREVIOUS_NEXT_URL_HISTORY_STATE_KEY = "__vinext_previousNextUrl";
@@ -88,6 +93,52 @@ export function resolveInterceptionContextFromPreviousNextUrl(
 
   const parsedUrl = new URL(previousNextUrl, "http://localhost");
   return stripBasePath(parsedUrl.pathname, basePath);
+}
+
+export type ResolveServerActionRequestStateOptions = {
+  actionId: string;
+  basePath: string;
+  elements: AppElements;
+  previousNextUrl: string | null;
+};
+
+export type ResolveServerActionRequestStateResult = {
+  headers: Headers;
+};
+
+/**
+ * Pure: builds the fetch Headers for a server-action POST. Carries the same
+ * interception-context and mounted-slots headers the refresh path already
+ * sends, so the server-action re-render can rebuild the intercepted tree
+ * instead of replacing it with the direct route.
+ *
+ * Next.js sends `Next-URL: state.previousNextUrl || state.nextUrl` on action
+ * POSTs when `hasInterceptionRouteInCurrentTree(state.tree)`. Vinext's
+ * X-Vinext-Interception-Context is the equivalent signal for the server-side
+ * `findIntercept` lookup.
+ */
+export function resolveServerActionRequestState(
+  options: ResolveServerActionRequestStateOptions,
+): ResolveServerActionRequestStateResult {
+  const headers = new Headers({
+    Accept: "text/x-component",
+    "x-rsc-action": options.actionId,
+  });
+
+  const interceptionContext = resolveInterceptionContextFromPreviousNextUrl(
+    options.previousNextUrl,
+    options.basePath,
+  );
+  if (interceptionContext !== null) {
+    headers.set("X-Vinext-Interception-Context", interceptionContext);
+  }
+
+  const mountedSlotsHeader = getMountedSlotIdsHeader(options.elements);
+  if (mountedSlotsHeader !== null) {
+    headers.set("X-Vinext-Mounted-Slots", mountedSlotsHeader);
+  }
+
+  return { headers };
 }
 
 export function routerReducer(state: AppRouterState, action: AppRouterAction): AppRouterState {

--- a/packages/vinext/src/server/app-page-request.ts
+++ b/packages/vinext/src/server/app-page-request.ts
@@ -30,6 +30,41 @@ export type AppPageInterceptMatch<TPage = unknown> = {
   sourceRouteIndex: number;
 };
 
+export type ResolveAppPageInterceptMatchOptions<TRoute, TPage, TInterceptOpts> = {
+  cleanPathname: string;
+  currentRoute: TRoute;
+  findIntercept: (pathname: string) => AppPageInterceptMatch<TPage> | null;
+  getRouteParamNames: (route: TRoute) => readonly string[];
+  getSourceRoute: (sourceRouteIndex: number) => TRoute | undefined;
+  isRscRequest: boolean;
+  toInterceptOpts: (intercept: AppPageInterceptMatch<TPage>) => TInterceptOpts;
+};
+
+export type ResolveAppPageInterceptMatchResult<TRoute, TInterceptOpts> = {
+  interceptOpts: TInterceptOpts;
+  matchedParams: AppPageParams;
+  sourceParams: AppPageParams;
+  sourceRoute: TRoute;
+};
+
+export type ResolveAppPageActionRerenderTargetOptions<TRoute, TPage, TInterceptOpts> = {
+  cleanPathname: string;
+  currentParams: AppPageParams;
+  currentRoute: TRoute;
+  findIntercept: (pathname: string) => AppPageInterceptMatch<TPage> | null;
+  getRouteParamNames: (route: TRoute) => readonly string[];
+  getSourceRoute: (sourceRouteIndex: number) => TRoute | undefined;
+  isRscRequest: boolean;
+  toInterceptOpts: (intercept: AppPageInterceptMatch<TPage>) => TInterceptOpts;
+};
+
+export type ResolveAppPageActionRerenderTargetResult<TRoute, TInterceptOpts> = {
+  interceptOpts: TInterceptOpts | undefined;
+  navigationParams: AppPageParams;
+  params: AppPageParams;
+  route: TRoute;
+};
+
 export type ResolveAppPageInterceptOptions<TRoute, TPage, TInterceptOpts> = {
   buildPageElement: (
     route: TRoute,
@@ -132,46 +167,149 @@ export async function validateAppPageDynamicParams(
   return null;
 }
 
-export async function resolveAppPageIntercept<TRoute, TPage, TInterceptOpts>(
-  options: ResolveAppPageInterceptOptions<TRoute, TPage, TInterceptOpts>,
-): Promise<ResolveAppPageInterceptResult<TInterceptOpts>> {
+/**
+ * Pure: decides whether the incoming request should re-render an intercepted
+ * source-route tree, and if so returns the source route, the source-route's
+ * param slice, the full matched param set (the URL params the client sees),
+ * and an opaque `interceptOpts` bag for the caller's render pipeline.
+ *
+ * Returns `null` in three decision-fallthrough cases:
+ *   - non-RSC requests (server rendering the direct page for a full HTML load)
+ *   - no intercepting route matches the path
+ *   - the match's source route IS the current route (the same branch today
+ *     returns `interceptOpts` for the direct render)
+ *
+ * Shared by both the GET path (resolveAppPageIntercept, which layers on
+ * `setNavigationContext` + element build + Response wrap) and the server-action
+ * POST path (entries/app-rsc-entry.ts), which runs its own response pipeline.
+ */
+export function resolveAppPageInterceptMatch<TRoute, TPage, TInterceptOpts>(
+  options: ResolveAppPageInterceptMatchOptions<TRoute, TPage, TInterceptOpts>,
+): ResolveAppPageInterceptMatchResult<TRoute, TInterceptOpts> | null {
   if (!options.isRscRequest) {
-    return { interceptOpts: undefined, response: null };
+    return null;
   }
 
   const intercept = options.findIntercept(options.cleanPathname);
   if (!intercept) {
-    return { interceptOpts: undefined, response: null };
+    return null;
   }
 
   const sourceRoute = options.getSourceRoute(intercept.sourceRouteIndex);
-  const interceptOpts = options.toInterceptOpts(intercept);
+  if (!sourceRoute || sourceRoute === options.currentRoute) {
+    return null;
+  }
 
-  if (sourceRoute && sourceRoute !== options.currentRoute) {
-    const sourceParams = pickRouteParams(
-      intercept.matchedParams,
-      options.getRouteParamNames(sourceRoute),
-    );
+  return {
+    interceptOpts: options.toInterceptOpts(intercept),
+    matchedParams: intercept.matchedParams,
+    sourceParams: pickRouteParams(intercept.matchedParams, options.getRouteParamNames(sourceRoute)),
+    sourceRoute,
+  };
+}
+
+function resolveCurrentRouteInterceptOpts<TRoute, TPage, TInterceptOpts>(
+  options: ResolveAppPageInterceptMatchOptions<TRoute, TPage, TInterceptOpts>,
+): TInterceptOpts | undefined {
+  if (!options.isRscRequest) {
+    return undefined;
+  }
+
+  const intercept = options.findIntercept(options.cleanPathname);
+  if (!intercept) {
+    return undefined;
+  }
+
+  const sourceRoute = options.getSourceRoute(intercept.sourceRouteIndex);
+  if (!sourceRoute || sourceRoute !== options.currentRoute) {
+    return undefined;
+  }
+
+  return options.toInterceptOpts(intercept);
+}
+
+export function resolveAppPageActionRerenderTarget<TRoute, TPage, TInterceptOpts>(
+  options: ResolveAppPageActionRerenderTargetOptions<TRoute, TPage, TInterceptOpts>,
+): ResolveAppPageActionRerenderTargetResult<TRoute, TInterceptOpts> {
+  const match = resolveAppPageInterceptMatch({
+    cleanPathname: options.cleanPathname,
+    currentRoute: options.currentRoute,
+    findIntercept: options.findIntercept,
+    getRouteParamNames: options.getRouteParamNames,
+    getSourceRoute: options.getSourceRoute,
+    isRscRequest: options.isRscRequest,
+    toInterceptOpts: options.toInterceptOpts,
+  });
+
+  if (match) {
+    return {
+      interceptOpts: match.interceptOpts,
+      navigationParams: match.matchedParams,
+      params: match.sourceParams,
+      route: match.sourceRoute,
+    };
+  }
+
+  return {
+    interceptOpts: resolveCurrentRouteInterceptOpts({
+      cleanPathname: options.cleanPathname,
+      currentRoute: options.currentRoute,
+      findIntercept: options.findIntercept,
+      getRouteParamNames: options.getRouteParamNames,
+      getSourceRoute: options.getSourceRoute,
+      isRscRequest: options.isRscRequest,
+      toInterceptOpts: options.toInterceptOpts,
+    }),
+    navigationParams: options.currentParams,
+    params: options.currentParams,
+    route: options.currentRoute,
+  };
+}
+
+export async function resolveAppPageIntercept<TRoute, TPage, TInterceptOpts>(
+  options: ResolveAppPageInterceptOptions<TRoute, TPage, TInterceptOpts>,
+): Promise<ResolveAppPageInterceptResult<TInterceptOpts>> {
+  const match = resolveAppPageInterceptMatch({
+    cleanPathname: options.cleanPathname,
+    currentRoute: options.currentRoute,
+    findIntercept: options.findIntercept,
+    getRouteParamNames: options.getRouteParamNames,
+    getSourceRoute: options.getSourceRoute,
+    isRscRequest: options.isRscRequest,
+    toInterceptOpts: options.toInterceptOpts,
+  });
+
+  if (match) {
     options.setNavigationContext({
-      params: intercept.matchedParams,
+      params: match.matchedParams,
       pathname: options.cleanPathname,
       searchParams: options.searchParams,
     });
     const interceptElement = await options.buildPageElement(
-      sourceRoute,
-      sourceParams,
-      interceptOpts,
+      match.sourceRoute,
+      match.sourceParams,
+      match.interceptOpts,
       options.searchParams,
     );
 
     return {
       interceptOpts: undefined,
-      response: await options.renderInterceptResponse(sourceRoute, interceptElement),
+      response: await options.renderInterceptResponse(match.sourceRoute, interceptElement),
     };
   }
 
+  // Reproduce the current-route-is-source branch where we still need the opts
+  // bag even though we did not render a separate intercepted response.
   return {
-    interceptOpts,
+    interceptOpts: resolveCurrentRouteInterceptOpts({
+      cleanPathname: options.cleanPathname,
+      currentRoute: options.currentRoute,
+      findIntercept: options.findIntercept,
+      getRouteParamNames: options.getRouteParamNames,
+      getSourceRoute: options.getSourceRoute,
+      isRscRequest: options.isRscRequest,
+      toInterceptOpts: options.toInterceptOpts,
+    }),
     response: null,
   };
 }

--- a/packages/vinext/src/server/app-page-request.ts
+++ b/packages/vinext/src/server/app-page-request.ts
@@ -47,6 +47,11 @@ export type ResolveAppPageInterceptMatchResult<TRoute, TInterceptOpts> = {
   sourceRoute: TRoute;
 };
 
+type AppPageInterceptState<TRoute, TPage> =
+  | { kind: "none" }
+  | { kind: "current-route"; intercept: AppPageInterceptMatch<TPage> }
+  | { kind: "source-route"; intercept: AppPageInterceptMatch<TPage>; sourceRoute: TRoute };
+
 export type ResolveAppPageActionRerenderTargetOptions<TRoute, TPage, TInterceptOpts> = {
   cleanPathname: string;
   currentParams: AppPageParams;
@@ -186,52 +191,50 @@ export async function validateAppPageDynamicParams(
 export function resolveAppPageInterceptMatch<TRoute, TPage, TInterceptOpts>(
   options: ResolveAppPageInterceptMatchOptions<TRoute, TPage, TInterceptOpts>,
 ): ResolveAppPageInterceptMatchResult<TRoute, TInterceptOpts> | null {
-  if (!options.isRscRequest) {
-    return null;
-  }
-
-  const intercept = options.findIntercept(options.cleanPathname);
-  if (!intercept) {
-    return null;
-  }
-
-  const sourceRoute = options.getSourceRoute(intercept.sourceRouteIndex);
-  if (!sourceRoute || sourceRoute === options.currentRoute) {
+  const interceptState = resolveAppPageInterceptState(options);
+  if (interceptState.kind !== "source-route") {
     return null;
   }
 
   return {
-    interceptOpts: options.toInterceptOpts(intercept),
-    matchedParams: intercept.matchedParams,
-    sourceParams: pickRouteParams(intercept.matchedParams, options.getRouteParamNames(sourceRoute)),
-    sourceRoute,
+    interceptOpts: options.toInterceptOpts(interceptState.intercept),
+    matchedParams: interceptState.intercept.matchedParams,
+    sourceParams: pickRouteParams(
+      interceptState.intercept.matchedParams,
+      options.getRouteParamNames(interceptState.sourceRoute),
+    ),
+    sourceRoute: interceptState.sourceRoute,
   };
 }
 
-function resolveCurrentRouteInterceptOpts<TRoute, TPage, TInterceptOpts>(
+function resolveAppPageInterceptState<TRoute, TPage, TInterceptOpts>(
   options: ResolveAppPageInterceptMatchOptions<TRoute, TPage, TInterceptOpts>,
-): TInterceptOpts | undefined {
+): AppPageInterceptState<TRoute, TPage> {
   if (!options.isRscRequest) {
-    return undefined;
+    return { kind: "none" };
   }
 
   const intercept = options.findIntercept(options.cleanPathname);
   if (!intercept) {
-    return undefined;
+    return { kind: "none" };
   }
 
   const sourceRoute = options.getSourceRoute(intercept.sourceRouteIndex);
-  if (!sourceRoute || sourceRoute !== options.currentRoute) {
-    return undefined;
+  if (!sourceRoute) {
+    return { kind: "none" };
   }
 
-  return options.toInterceptOpts(intercept);
+  if (sourceRoute === options.currentRoute) {
+    return { kind: "current-route", intercept };
+  }
+
+  return { kind: "source-route", intercept, sourceRoute };
 }
 
 export function resolveAppPageActionRerenderTarget<TRoute, TPage, TInterceptOpts>(
   options: ResolveAppPageActionRerenderTargetOptions<TRoute, TPage, TInterceptOpts>,
 ): ResolveAppPageActionRerenderTargetResult<TRoute, TInterceptOpts> {
-  const match = resolveAppPageInterceptMatch({
+  const interceptState = resolveAppPageInterceptState({
     cleanPathname: options.cleanPathname,
     currentRoute: options.currentRoute,
     findIntercept: options.findIntercept,
@@ -241,25 +244,23 @@ export function resolveAppPageActionRerenderTarget<TRoute, TPage, TInterceptOpts
     toInterceptOpts: options.toInterceptOpts,
   });
 
-  if (match) {
+  if (interceptState.kind === "source-route") {
     return {
-      interceptOpts: match.interceptOpts,
-      navigationParams: match.matchedParams,
-      params: match.sourceParams,
-      route: match.sourceRoute,
+      interceptOpts: options.toInterceptOpts(interceptState.intercept),
+      navigationParams: interceptState.intercept.matchedParams,
+      params: pickRouteParams(
+        interceptState.intercept.matchedParams,
+        options.getRouteParamNames(interceptState.sourceRoute),
+      ),
+      route: interceptState.sourceRoute,
     };
   }
 
   return {
-    interceptOpts: resolveCurrentRouteInterceptOpts({
-      cleanPathname: options.cleanPathname,
-      currentRoute: options.currentRoute,
-      findIntercept: options.findIntercept,
-      getRouteParamNames: options.getRouteParamNames,
-      getSourceRoute: options.getSourceRoute,
-      isRscRequest: options.isRscRequest,
-      toInterceptOpts: options.toInterceptOpts,
-    }),
+    interceptOpts:
+      interceptState.kind === "current-route"
+        ? options.toInterceptOpts(interceptState.intercept)
+        : undefined,
     navigationParams: options.currentParams,
     params: options.currentParams,
     route: options.currentRoute,
@@ -269,7 +270,7 @@ export function resolveAppPageActionRerenderTarget<TRoute, TPage, TInterceptOpts
 export async function resolveAppPageIntercept<TRoute, TPage, TInterceptOpts>(
   options: ResolveAppPageInterceptOptions<TRoute, TPage, TInterceptOpts>,
 ): Promise<ResolveAppPageInterceptResult<TInterceptOpts>> {
-  const match = resolveAppPageInterceptMatch({
+  const interceptState = resolveAppPageInterceptState({
     cleanPathname: options.cleanPathname,
     currentRoute: options.currentRoute,
     findIntercept: options.findIntercept,
@@ -279,37 +280,35 @@ export async function resolveAppPageIntercept<TRoute, TPage, TInterceptOpts>(
     toInterceptOpts: options.toInterceptOpts,
   });
 
-  if (match) {
+  if (interceptState.kind === "source-route") {
     options.setNavigationContext({
-      params: match.matchedParams,
+      params: interceptState.intercept.matchedParams,
       pathname: options.cleanPathname,
       searchParams: options.searchParams,
     });
     const interceptElement = await options.buildPageElement(
-      match.sourceRoute,
-      match.sourceParams,
-      match.interceptOpts,
+      interceptState.sourceRoute,
+      pickRouteParams(
+        interceptState.intercept.matchedParams,
+        options.getRouteParamNames(interceptState.sourceRoute),
+      ),
+      options.toInterceptOpts(interceptState.intercept),
       options.searchParams,
     );
 
     return {
       interceptOpts: undefined,
-      response: await options.renderInterceptResponse(match.sourceRoute, interceptElement),
+      response: await options.renderInterceptResponse(interceptState.sourceRoute, interceptElement),
     };
   }
 
   // Reproduce the current-route-is-source branch where we still need the opts
   // bag even though we did not render a separate intercepted response.
   return {
-    interceptOpts: resolveCurrentRouteInterceptOpts({
-      cleanPathname: options.cleanPathname,
-      currentRoute: options.currentRoute,
-      findIntercept: options.findIntercept,
-      getRouteParamNames: options.getRouteParamNames,
-      getSourceRoute: options.getSourceRoute,
-      isRscRequest: options.isRscRequest,
-      toInterceptOpts: options.toInterceptOpts,
-    }),
+    interceptOpts:
+      interceptState.kind === "current-route"
+        ? options.toInterceptOpts(interceptState.intercept)
+        : undefined,
     response: null,
   };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1193,10 +1193,10 @@ importers:
         specifier: 'catalog:'
         version: 0.5.23(@voidzero-dev/vite-plus-core@0.1.12(@types/node@25.2.3)(esbuild@0.27.3)(jiti@2.6.1)(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react-server-dom-webpack@19.2.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
       react:
-        specifier: 'catalog:'
+        specifier: ^19.2.5
         version: 19.2.5
       react-dom:
-        specifier: 'catalog:'
+        specifier: ^19.2.5
         version: 19.2.5(react@19.2.5)
       react-server-dom-webpack:
         specifier: 'catalog:'

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -95,6 +95,7 @@ import {
 } from "<ROOT>/packages/vinext/src/server/app-page-response.js";
 import { getScriptNonceFromHeaderSources as __getScriptNonceFromHeaderSources } from "<ROOT>/packages/vinext/src/server/csp.js";
 import {
+  resolveAppPageActionRerenderTarget as __resolveAppPageActionRerenderTarget,
   buildAppPageElement as __buildAppPageElement,
   resolveAppPageIntercept as __resolveAppPageIntercept,
   validateAppPageDynamicParams as __validateAppPageDynamicParams,
@@ -1536,27 +1537,57 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
 
       // After the action, re-render the current page so the client
       // gets an updated React tree reflecting any mutations.
+      //
+      // When the original request came from inside an intercepted modal
+      // (X-Vinext-Interception-Context present + source route still
+      // matches), rebuild the intercepted tree — otherwise the modal would
+      // unmount and the direct route would render in its place. Mirrors
+      // the interception resolution used by the GET path.
       const match = matchRoute(cleanPathname);
       let element;
+      let errorPattern = match ? match.route.pattern : cleanPathname;
       if (match) {
         const { route: actionRoute, params: actionParams } = match;
+        const __actionRerenderTarget = __resolveAppPageActionRerenderTarget({
+          cleanPathname,
+          currentParams: actionParams,
+          currentRoute: actionRoute,
+          findIntercept,
+          getRouteParamNames(sourceRoute) {
+            return sourceRoute.params;
+          },
+          getSourceRoute(sourceRouteIndex) {
+            return routes[sourceRouteIndex];
+          },
+          isRscRequest,
+          toInterceptOpts(intercept) {
+            return {
+              interceptionContext: interceptionContextHeader,
+              interceptSlotKey: intercept.slotKey,
+              interceptPage: intercept.page,
+              interceptParams: intercept.matchedParams,
+            };
+          },
+        });
+
         setNavigationContext({
           pathname: cleanPathname,
           searchParams: url.searchParams,
-          params: actionParams,
+          params: __actionRerenderTarget.navigationParams,
         });
         element = buildPageElements(
-          actionRoute,
-          actionParams,
+          __actionRerenderTarget.route,
+          __actionRerenderTarget.params,
           cleanPathname,
           {
-            opts: undefined,
+            opts: __actionRerenderTarget.interceptOpts,
             searchParams: url.searchParams,
             isRscRequest,
             request,
             mountedSlotsHeader: __mountedSlotsHeader,
           },
         );
+        errorPattern = __actionRerenderTarget.route.pattern;
       } else {
         const _actionRouteId = __createAppPayloadRouteId(cleanPathname, null);
         element = {
@@ -1570,7 +1601,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       const onRenderError = createRscOnErrorHandler(
         request,
         cleanPathname,
-        match ? match.route.pattern : cleanPathname,
+        errorPattern,
       );
       const rscStream = renderToReadableStream(
         { root: element, returnValue },
@@ -2323,6 +2354,7 @@ import {
 } from "<ROOT>/packages/vinext/src/server/app-page-response.js";
 import { getScriptNonceFromHeaderSources as __getScriptNonceFromHeaderSources } from "<ROOT>/packages/vinext/src/server/csp.js";
 import {
+  resolveAppPageActionRerenderTarget as __resolveAppPageActionRerenderTarget,
   buildAppPageElement as __buildAppPageElement,
   resolveAppPageIntercept as __resolveAppPageIntercept,
   validateAppPageDynamicParams as __validateAppPageDynamicParams,
@@ -3770,27 +3802,57 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
 
       // After the action, re-render the current page so the client
       // gets an updated React tree reflecting any mutations.
+      //
+      // When the original request came from inside an intercepted modal
+      // (X-Vinext-Interception-Context present + source route still
+      // matches), rebuild the intercepted tree — otherwise the modal would
+      // unmount and the direct route would render in its place. Mirrors
+      // the interception resolution used by the GET path.
       const match = matchRoute(cleanPathname);
       let element;
+      let errorPattern = match ? match.route.pattern : cleanPathname;
       if (match) {
         const { route: actionRoute, params: actionParams } = match;
+        const __actionRerenderTarget = __resolveAppPageActionRerenderTarget({
+          cleanPathname,
+          currentParams: actionParams,
+          currentRoute: actionRoute,
+          findIntercept,
+          getRouteParamNames(sourceRoute) {
+            return sourceRoute.params;
+          },
+          getSourceRoute(sourceRouteIndex) {
+            return routes[sourceRouteIndex];
+          },
+          isRscRequest,
+          toInterceptOpts(intercept) {
+            return {
+              interceptionContext: interceptionContextHeader,
+              interceptSlotKey: intercept.slotKey,
+              interceptPage: intercept.page,
+              interceptParams: intercept.matchedParams,
+            };
+          },
+        });
+
         setNavigationContext({
           pathname: cleanPathname,
           searchParams: url.searchParams,
-          params: actionParams,
+          params: __actionRerenderTarget.navigationParams,
         });
         element = buildPageElements(
-          actionRoute,
-          actionParams,
+          __actionRerenderTarget.route,
+          __actionRerenderTarget.params,
           cleanPathname,
           {
-            opts: undefined,
+            opts: __actionRerenderTarget.interceptOpts,
             searchParams: url.searchParams,
             isRscRequest,
             request,
             mountedSlotsHeader: __mountedSlotsHeader,
           },
         );
+        errorPattern = __actionRerenderTarget.route.pattern;
       } else {
         const _actionRouteId = __createAppPayloadRouteId(cleanPathname, null);
         element = {
@@ -3804,7 +3866,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       const onRenderError = createRscOnErrorHandler(
         request,
         cleanPathname,
-        match ? match.route.pattern : cleanPathname,
+        errorPattern,
       );
       const rscStream = renderToReadableStream(
         { root: element, returnValue },
@@ -4557,6 +4619,7 @@ import {
 } from "<ROOT>/packages/vinext/src/server/app-page-response.js";
 import { getScriptNonceFromHeaderSources as __getScriptNonceFromHeaderSources } from "<ROOT>/packages/vinext/src/server/csp.js";
 import {
+  resolveAppPageActionRerenderTarget as __resolveAppPageActionRerenderTarget,
   buildAppPageElement as __buildAppPageElement,
   resolveAppPageIntercept as __resolveAppPageIntercept,
   validateAppPageDynamicParams as __validateAppPageDynamicParams,
@@ -5999,27 +6062,57 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
 
       // After the action, re-render the current page so the client
       // gets an updated React tree reflecting any mutations.
+      //
+      // When the original request came from inside an intercepted modal
+      // (X-Vinext-Interception-Context present + source route still
+      // matches), rebuild the intercepted tree — otherwise the modal would
+      // unmount and the direct route would render in its place. Mirrors
+      // the interception resolution used by the GET path.
       const match = matchRoute(cleanPathname);
       let element;
+      let errorPattern = match ? match.route.pattern : cleanPathname;
       if (match) {
         const { route: actionRoute, params: actionParams } = match;
+        const __actionRerenderTarget = __resolveAppPageActionRerenderTarget({
+          cleanPathname,
+          currentParams: actionParams,
+          currentRoute: actionRoute,
+          findIntercept,
+          getRouteParamNames(sourceRoute) {
+            return sourceRoute.params;
+          },
+          getSourceRoute(sourceRouteIndex) {
+            return routes[sourceRouteIndex];
+          },
+          isRscRequest,
+          toInterceptOpts(intercept) {
+            return {
+              interceptionContext: interceptionContextHeader,
+              interceptSlotKey: intercept.slotKey,
+              interceptPage: intercept.page,
+              interceptParams: intercept.matchedParams,
+            };
+          },
+        });
+
         setNavigationContext({
           pathname: cleanPathname,
           searchParams: url.searchParams,
-          params: actionParams,
+          params: __actionRerenderTarget.navigationParams,
         });
         element = buildPageElements(
-          actionRoute,
-          actionParams,
+          __actionRerenderTarget.route,
+          __actionRerenderTarget.params,
           cleanPathname,
           {
-            opts: undefined,
+            opts: __actionRerenderTarget.interceptOpts,
             searchParams: url.searchParams,
             isRscRequest,
             request,
             mountedSlotsHeader: __mountedSlotsHeader,
           },
         );
+        errorPattern = __actionRerenderTarget.route.pattern;
       } else {
         const _actionRouteId = __createAppPayloadRouteId(cleanPathname, null);
         element = {
@@ -6033,7 +6126,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       const onRenderError = createRscOnErrorHandler(
         request,
         cleanPathname,
-        match ? match.route.pattern : cleanPathname,
+        errorPattern,
       );
       const rscStream = renderToReadableStream(
         { root: element, returnValue },
@@ -6786,6 +6879,7 @@ import {
 } from "<ROOT>/packages/vinext/src/server/app-page-response.js";
 import { getScriptNonceFromHeaderSources as __getScriptNonceFromHeaderSources } from "<ROOT>/packages/vinext/src/server/csp.js";
 import {
+  resolveAppPageActionRerenderTarget as __resolveAppPageActionRerenderTarget,
   buildAppPageElement as __buildAppPageElement,
   resolveAppPageIntercept as __resolveAppPageIntercept,
   validateAppPageDynamicParams as __validateAppPageDynamicParams,
@@ -8260,27 +8354,57 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
 
       // After the action, re-render the current page so the client
       // gets an updated React tree reflecting any mutations.
+      //
+      // When the original request came from inside an intercepted modal
+      // (X-Vinext-Interception-Context present + source route still
+      // matches), rebuild the intercepted tree — otherwise the modal would
+      // unmount and the direct route would render in its place. Mirrors
+      // the interception resolution used by the GET path.
       const match = matchRoute(cleanPathname);
       let element;
+      let errorPattern = match ? match.route.pattern : cleanPathname;
       if (match) {
         const { route: actionRoute, params: actionParams } = match;
+        const __actionRerenderTarget = __resolveAppPageActionRerenderTarget({
+          cleanPathname,
+          currentParams: actionParams,
+          currentRoute: actionRoute,
+          findIntercept,
+          getRouteParamNames(sourceRoute) {
+            return sourceRoute.params;
+          },
+          getSourceRoute(sourceRouteIndex) {
+            return routes[sourceRouteIndex];
+          },
+          isRscRequest,
+          toInterceptOpts(intercept) {
+            return {
+              interceptionContext: interceptionContextHeader,
+              interceptSlotKey: intercept.slotKey,
+              interceptPage: intercept.page,
+              interceptParams: intercept.matchedParams,
+            };
+          },
+        });
+
         setNavigationContext({
           pathname: cleanPathname,
           searchParams: url.searchParams,
-          params: actionParams,
+          params: __actionRerenderTarget.navigationParams,
         });
         element = buildPageElements(
-          actionRoute,
-          actionParams,
+          __actionRerenderTarget.route,
+          __actionRerenderTarget.params,
           cleanPathname,
           {
-            opts: undefined,
+            opts: __actionRerenderTarget.interceptOpts,
             searchParams: url.searchParams,
             isRscRequest,
             request,
             mountedSlotsHeader: __mountedSlotsHeader,
           },
         );
+        errorPattern = __actionRerenderTarget.route.pattern;
       } else {
         const _actionRouteId = __createAppPayloadRouteId(cleanPathname, null);
         element = {
@@ -8294,7 +8418,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       const onRenderError = createRscOnErrorHandler(
         request,
         cleanPathname,
-        match ? match.route.pattern : cleanPathname,
+        errorPattern,
       );
       const rscStream = renderToReadableStream(
         { root: element, returnValue },
@@ -9047,6 +9171,7 @@ import {
 } from "<ROOT>/packages/vinext/src/server/app-page-response.js";
 import { getScriptNonceFromHeaderSources as __getScriptNonceFromHeaderSources } from "<ROOT>/packages/vinext/src/server/csp.js";
 import {
+  resolveAppPageActionRerenderTarget as __resolveAppPageActionRerenderTarget,
   buildAppPageElement as __buildAppPageElement,
   resolveAppPageIntercept as __resolveAppPageIntercept,
   validateAppPageDynamicParams as __validateAppPageDynamicParams,
@@ -10495,27 +10620,57 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
 
       // After the action, re-render the current page so the client
       // gets an updated React tree reflecting any mutations.
+      //
+      // When the original request came from inside an intercepted modal
+      // (X-Vinext-Interception-Context present + source route still
+      // matches), rebuild the intercepted tree — otherwise the modal would
+      // unmount and the direct route would render in its place. Mirrors
+      // the interception resolution used by the GET path.
       const match = matchRoute(cleanPathname);
       let element;
+      let errorPattern = match ? match.route.pattern : cleanPathname;
       if (match) {
         const { route: actionRoute, params: actionParams } = match;
+        const __actionRerenderTarget = __resolveAppPageActionRerenderTarget({
+          cleanPathname,
+          currentParams: actionParams,
+          currentRoute: actionRoute,
+          findIntercept,
+          getRouteParamNames(sourceRoute) {
+            return sourceRoute.params;
+          },
+          getSourceRoute(sourceRouteIndex) {
+            return routes[sourceRouteIndex];
+          },
+          isRscRequest,
+          toInterceptOpts(intercept) {
+            return {
+              interceptionContext: interceptionContextHeader,
+              interceptSlotKey: intercept.slotKey,
+              interceptPage: intercept.page,
+              interceptParams: intercept.matchedParams,
+            };
+          },
+        });
+
         setNavigationContext({
           pathname: cleanPathname,
           searchParams: url.searchParams,
-          params: actionParams,
+          params: __actionRerenderTarget.navigationParams,
         });
         element = buildPageElements(
-          actionRoute,
-          actionParams,
+          __actionRerenderTarget.route,
+          __actionRerenderTarget.params,
           cleanPathname,
           {
-            opts: undefined,
+            opts: __actionRerenderTarget.interceptOpts,
             searchParams: url.searchParams,
             isRscRequest,
             request,
             mountedSlotsHeader: __mountedSlotsHeader,
           },
         );
+        errorPattern = __actionRerenderTarget.route.pattern;
       } else {
         const _actionRouteId = __createAppPayloadRouteId(cleanPathname, null);
         element = {
@@ -10529,7 +10684,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       const onRenderError = createRscOnErrorHandler(
         request,
         cleanPathname,
-        match ? match.route.pattern : cleanPathname,
+        errorPattern,
       );
       const rscStream = renderToReadableStream(
         { root: element, returnValue },
@@ -11282,6 +11437,7 @@ import {
 } from "<ROOT>/packages/vinext/src/server/app-page-response.js";
 import { getScriptNonceFromHeaderSources as __getScriptNonceFromHeaderSources } from "<ROOT>/packages/vinext/src/server/csp.js";
 import {
+  resolveAppPageActionRerenderTarget as __resolveAppPageActionRerenderTarget,
   buildAppPageElement as __buildAppPageElement,
   resolveAppPageIntercept as __resolveAppPageIntercept,
   validateAppPageDynamicParams as __validateAppPageDynamicParams,
@@ -13090,27 +13246,57 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
 
       // After the action, re-render the current page so the client
       // gets an updated React tree reflecting any mutations.
+      //
+      // When the original request came from inside an intercepted modal
+      // (X-Vinext-Interception-Context present + source route still
+      // matches), rebuild the intercepted tree — otherwise the modal would
+      // unmount and the direct route would render in its place. Mirrors
+      // the interception resolution used by the GET path.
       const match = matchRoute(cleanPathname);
       let element;
+      let errorPattern = match ? match.route.pattern : cleanPathname;
       if (match) {
         const { route: actionRoute, params: actionParams } = match;
+        const __actionRerenderTarget = __resolveAppPageActionRerenderTarget({
+          cleanPathname,
+          currentParams: actionParams,
+          currentRoute: actionRoute,
+          findIntercept,
+          getRouteParamNames(sourceRoute) {
+            return sourceRoute.params;
+          },
+          getSourceRoute(sourceRouteIndex) {
+            return routes[sourceRouteIndex];
+          },
+          isRscRequest,
+          toInterceptOpts(intercept) {
+            return {
+              interceptionContext: interceptionContextHeader,
+              interceptSlotKey: intercept.slotKey,
+              interceptPage: intercept.page,
+              interceptParams: intercept.matchedParams,
+            };
+          },
+        });
+
         setNavigationContext({
           pathname: cleanPathname,
           searchParams: url.searchParams,
-          params: actionParams,
+          params: __actionRerenderTarget.navigationParams,
         });
         element = buildPageElements(
-          actionRoute,
-          actionParams,
+          __actionRerenderTarget.route,
+          __actionRerenderTarget.params,
           cleanPathname,
           {
-            opts: undefined,
+            opts: __actionRerenderTarget.interceptOpts,
             searchParams: url.searchParams,
             isRscRequest,
             request,
             mountedSlotsHeader: __mountedSlotsHeader,
           },
         );
+        errorPattern = __actionRerenderTarget.route.pattern;
       } else {
         const _actionRouteId = __createAppPayloadRouteId(cleanPathname, null);
         element = {
@@ -13124,7 +13310,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       const onRenderError = createRscOnErrorHandler(
         request,
         cleanPathname,
-        match ? match.route.pattern : cleanPathname,
+        errorPattern,
       );
       const rscStream = renderToReadableStream(
         { root: element, returnValue },

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -17,6 +17,7 @@ import {
   readHistoryStatePreviousNextUrl,
   resolveAndClassifyNavigationCommit,
   resolveInterceptionContextFromPreviousNextUrl,
+  resolveServerActionRequestState,
   routerReducer,
   resolvePendingNavigationCommitDisposition,
   shouldHardNavigate,
@@ -472,5 +473,87 @@ describe("mounted slot helpers", () => {
     });
 
     expect(getMountedSlotIdsHeader(elements)).toBeNull();
+  });
+});
+
+describe("resolveServerActionRequestState", () => {
+  it("includes only Accept and x-rsc-action when previousNextUrl is null and no slots are mounted", () => {
+    const elements = createResolvedElements("route:/settings", "/");
+
+    const { headers } = resolveServerActionRequestState({
+      actionId: "action-abc",
+      basePath: "",
+      elements,
+      previousNextUrl: null,
+    });
+
+    expect(Array.from(headers.keys()).sort()).toEqual(["accept", "x-rsc-action"]);
+    expect(headers.get("accept")).toBe("text/x-component");
+    expect(headers.get("x-rsc-action")).toBe("action-abc");
+  });
+
+  it("derives X-Vinext-Interception-Context from previousNextUrl", () => {
+    const elements = createResolvedElements("route:/photos/42", "/");
+    const previousNextUrl = "/feed?tab=latest";
+
+    const { headers } = resolveServerActionRequestState({
+      actionId: "bump-likes",
+      basePath: "",
+      elements,
+      previousNextUrl,
+    });
+
+    expect(headers.get("X-Vinext-Interception-Context")).toBe(
+      resolveInterceptionContextFromPreviousNextUrl(previousNextUrl, ""),
+    );
+  });
+
+  it("strips the base path when deriving the interception context", () => {
+    const elements = createResolvedElements("route:/photos/42", "/");
+    const previousNextUrl = "/app/feed";
+
+    const { headers } = resolveServerActionRequestState({
+      actionId: "bump-likes",
+      basePath: "/app",
+      elements,
+      previousNextUrl,
+    });
+
+    expect(headers.get("X-Vinext-Interception-Context")).toBe(
+      resolveInterceptionContextFromPreviousNextUrl(previousNextUrl, "/app"),
+    );
+  });
+
+  it("derives X-Vinext-Mounted-Slots from mounted slot keys", () => {
+    const elements: AppElements = createResolvedElements("route:/feed", "/", null, {
+      "slot:@modal:/feed": React.createElement("div", null, "modal"),
+      "slot:@sidebar:/feed": React.createElement("div", null, "sidebar"),
+    });
+
+    const { headers } = resolveServerActionRequestState({
+      actionId: "action-x",
+      basePath: "",
+      elements,
+      previousNextUrl: null,
+    });
+
+    expect(headers.get("X-Vinext-Mounted-Slots")).toBe(getMountedSlotIdsHeader(elements));
+  });
+
+  it("omits headers whose derived values are null", () => {
+    const elements: AppElements = createResolvedElements("route:/settings", "/", null, {
+      "slot:ghost:/": null,
+      "slot:missing:/": UNMATCHED_SLOT,
+    });
+
+    const { headers } = resolveServerActionRequestState({
+      actionId: "action-y",
+      basePath: "",
+      elements,
+      previousNextUrl: null,
+    });
+
+    expect(headers.has("X-Vinext-Interception-Context")).toBe(false);
+    expect(headers.has("X-Vinext-Mounted-Slots")).toBe(false);
   });
 });

--- a/tests/app-page-request.test.ts
+++ b/tests/app-page-request.test.ts
@@ -335,6 +335,80 @@ describe("resolveAppPageActionRerenderTarget", () => {
     interceptSlotKey: intercept.slotKey,
   });
 
+  it("falls through to the current route on non-RSC requests", () => {
+    const result = resolveAppPageActionRerenderTarget({
+      cleanPathname: "/photos/123",
+      currentParams: { id: "123" },
+      currentRoute,
+      findIntercept() {
+        throw new Error("should not look up intercepts on non-RSC requests");
+      },
+      getRouteParamNames: (route) => route.params,
+      getSourceRoute: () => sourceRoute,
+      isRscRequest: false,
+      toInterceptOpts,
+    });
+
+    expect(result).toEqual({
+      interceptOpts: undefined,
+      navigationParams: { id: "123" },
+      params: { id: "123" },
+      route: currentRoute,
+    });
+  });
+
+  it("falls through to the current route when no intercept matches", () => {
+    const result = resolveAppPageActionRerenderTarget({
+      cleanPathname: "/photos/123",
+      currentParams: { id: "123" },
+      currentRoute,
+      findIntercept: () => null,
+      getRouteParamNames: (route) => route.params,
+      getSourceRoute: () => sourceRoute,
+      isRscRequest: true,
+      toInterceptOpts,
+    });
+
+    expect(result).toEqual({
+      interceptOpts: undefined,
+      navigationParams: { id: "123" },
+      params: { id: "123" },
+      route: currentRoute,
+    });
+  });
+
+  it("looks up the intercept once when the source route is the current route", () => {
+    const findIntercept = vi.fn(() => ({
+      matchedParams: { id: "123" },
+      page: { default: "modal-page" },
+      slotKey: "modal@app/feed/@modal",
+      sourceRouteIndex: 0,
+    }));
+
+    const result = resolveAppPageActionRerenderTarget({
+      cleanPathname: "/photos/123",
+      currentParams: { id: "123" },
+      currentRoute,
+      findIntercept,
+      getRouteParamNames: (route) => route.params,
+      getSourceRoute: () => currentRoute,
+      isRscRequest: true,
+      toInterceptOpts,
+    });
+
+    expect(result).toEqual({
+      interceptOpts: {
+        interceptPage: { default: "modal-page" },
+        interceptParams: { id: "123" },
+        interceptSlotKey: "modal@app/feed/@modal",
+      },
+      navigationParams: { id: "123" },
+      params: { id: "123" },
+      route: currentRoute,
+    });
+    expect(findIntercept).toHaveBeenCalledTimes(1);
+  });
+
   it("preserves current-route intercept opts when action rerender stays on the direct route", () => {
     const result = resolveAppPageActionRerenderTarget({
       cleanPathname: "/photos/123",

--- a/tests/app-page-request.test.ts
+++ b/tests/app-page-request.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it, vi } from "vite-plus/test";
 import { resolveAppPageSpecialError } from "../packages/vinext/src/server/app-page-execution.js";
 import {
   buildAppPageElement,
+  resolveAppPageActionRerenderTarget,
   resolveAppPageIntercept,
+  resolveAppPageInterceptMatch,
   validateAppPageDynamicParams,
 } from "../packages/vinext/src/server/app-page-request.js";
 
@@ -201,5 +203,193 @@ describe("app page request helpers", () => {
 
     expect(result.element).toBeNull();
     expect(result.response).toBe(boundaryResponse);
+  });
+});
+
+describe("resolveAppPageInterceptMatch", () => {
+  const sourceRoute = { params: [], pattern: "/feed" };
+  const currentRoute = { params: ["id"], pattern: "/photos/[id]" };
+
+  const toInterceptOpts = (intercept: {
+    matchedParams: Record<string, string | string[]>;
+    page: unknown;
+    slotKey: string;
+  }) => ({
+    interceptPage: intercept.page,
+    interceptParams: intercept.matchedParams,
+    interceptSlotKey: intercept.slotKey,
+  });
+
+  it("returns null on non-RSC requests", () => {
+    const result = resolveAppPageInterceptMatch({
+      cleanPathname: "/photos/123",
+      currentRoute,
+      findIntercept() {
+        throw new Error("should not look up intercepts on non-RSC requests");
+      },
+      getRouteParamNames: (route) => route.params,
+      getSourceRoute: () => sourceRoute,
+      isRscRequest: false,
+      toInterceptOpts,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when findIntercept returns nothing", () => {
+    const result = resolveAppPageInterceptMatch({
+      cleanPathname: "/photos/123",
+      currentRoute,
+      findIntercept: () => null,
+      getRouteParamNames: (route) => route.params,
+      getSourceRoute: () => sourceRoute,
+      isRscRequest: true,
+      toInterceptOpts,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when the source route is the current route", () => {
+    const result = resolveAppPageInterceptMatch({
+      cleanPathname: "/photos/123",
+      currentRoute,
+      findIntercept: () => ({
+        matchedParams: { id: "123" },
+        page: { default: "modal-page" },
+        slotKey: "modal@app/photos/@modal",
+        sourceRouteIndex: 0,
+      }),
+      getRouteParamNames: (route) => route.params,
+      getSourceRoute: () => currentRoute,
+      isRscRequest: true,
+      toInterceptOpts,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("returns sourceRoute, sourceParams, matchedParams, and interceptOpts when an intercept applies", () => {
+    const matchedParams = { id: "123" };
+    const intercept = {
+      matchedParams,
+      page: { default: "modal-page" },
+      slotKey: "modal@app/feed/@modal",
+      sourceRouteIndex: 0,
+    };
+
+    const result = resolveAppPageInterceptMatch({
+      cleanPathname: "/photos/123",
+      currentRoute,
+      findIntercept: () => intercept,
+      getRouteParamNames: (route) => route.params,
+      getSourceRoute: () => sourceRoute,
+      isRscRequest: true,
+      toInterceptOpts,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.sourceRoute).toBe(sourceRoute);
+    expect(result?.matchedParams).toBe(matchedParams);
+    // sourceParams keeps only the params declared by the source route.
+    // /feed has no dynamic params, so the slice is empty.
+    expect(result?.sourceParams).toEqual({});
+    expect(result?.interceptOpts).toEqual(toInterceptOpts(intercept));
+  });
+
+  it("slices source params down to the source route's declared params", () => {
+    const categorySourceRoute = { params: ["category"], pattern: "/feed/[category]" };
+    const matchedParams = { category: "nature", id: "123" };
+
+    const result = resolveAppPageInterceptMatch({
+      cleanPathname: "/photos/123",
+      currentRoute,
+      findIntercept: () => ({
+        matchedParams,
+        page: { default: "modal-page" },
+        slotKey: "modal@app/feed/[category]/@modal",
+        sourceRouteIndex: 0,
+      }),
+      getRouteParamNames: (route) => route.params,
+      getSourceRoute: () => categorySourceRoute,
+      isRscRequest: true,
+      toInterceptOpts,
+    });
+
+    expect(result?.sourceParams).toEqual({ category: "nature" });
+    expect(result?.matchedParams).toEqual({ category: "nature", id: "123" });
+  });
+});
+
+describe("resolveAppPageActionRerenderTarget", () => {
+  const sourceRoute = { params: [], pattern: "/feed" };
+  const currentRoute = { params: ["id"], pattern: "/photos/[id]" };
+
+  const toInterceptOpts = (intercept: {
+    matchedParams: Record<string, string | string[]>;
+    page: unknown;
+    slotKey: string;
+  }) => ({
+    interceptPage: intercept.page,
+    interceptParams: intercept.matchedParams,
+    interceptSlotKey: intercept.slotKey,
+  });
+
+  it("preserves current-route intercept opts when action rerender stays on the direct route", () => {
+    const result = resolveAppPageActionRerenderTarget({
+      cleanPathname: "/photos/123",
+      currentParams: { id: "123" },
+      currentRoute,
+      findIntercept: () => ({
+        matchedParams: { id: "123" },
+        page: { default: "modal-page" },
+        slotKey: "modal@app/feed/@modal",
+        sourceRouteIndex: 0,
+      }),
+      getRouteParamNames: (route) => route.params,
+      getSourceRoute: () => currentRoute,
+      isRscRequest: true,
+      toInterceptOpts,
+    });
+
+    expect(result).toEqual({
+      interceptOpts: {
+        interceptPage: { default: "modal-page" },
+        interceptParams: { id: "123" },
+        interceptSlotKey: "modal@app/feed/@modal",
+      },
+      navigationParams: { id: "123" },
+      params: { id: "123" },
+      route: currentRoute,
+    });
+  });
+
+  it("rerenders the intercepted source route when an intercept match applies", () => {
+    const result = resolveAppPageActionRerenderTarget({
+      cleanPathname: "/photos/123",
+      currentParams: { id: "123" },
+      currentRoute,
+      findIntercept: () => ({
+        matchedParams: { id: "123" },
+        page: { default: "modal-page" },
+        slotKey: "modal@app/feed/@modal",
+        sourceRouteIndex: 0,
+      }),
+      getRouteParamNames: (route) => route.params,
+      getSourceRoute: () => sourceRoute,
+      isRscRequest: true,
+      toInterceptOpts,
+    });
+
+    expect(result).toEqual({
+      interceptOpts: {
+        interceptPage: { default: "modal-page" },
+        interceptParams: { id: "123" },
+        interceptSlotKey: "modal@app/feed/@modal",
+      },
+      navigationParams: { id: "123" },
+      params: {},
+      route: sourceRoute,
+    });
   });
 });

--- a/tests/e2e/app-router/advanced.spec.ts
+++ b/tests/e2e/app-router/advanced.spec.ts
@@ -150,6 +150,45 @@ test.describe("Intercepting Routes", () => {
     await expect(page.locator('[data-testid="photo-page"]')).not.toBeVisible();
   });
 
+  test("server action from intercepted modal preserves modal tree", async ({ page }) => {
+    await page.goto(`${BASE}/feed`);
+    await waitForAppRouterHydration(page);
+
+    await page.click("#feed-photo-42-link");
+    await expect(page.locator('[data-testid="photo-modal"]')).toBeVisible();
+    await expect(page.locator('[data-testid="feed-page"]')).toBeVisible();
+
+    const likesLocator = page.locator('[data-testid="photo-likes"]');
+    const baselineText = (await likesLocator.textContent()) ?? "";
+    const baseline = Number.parseInt(baselineText, 10);
+    expect(Number.isFinite(baseline)).toBe(true);
+
+    await page.click('[data-testid="photo-like-btn"]');
+
+    // Wait for the count to change before asserting — avoids a timing race
+    // between action fetch and client state update.
+    await expect.poll(async () => (await likesLocator.textContent()) ?? "").not.toBe(baselineText);
+
+    const afterText = (await likesLocator.textContent()) ?? "";
+    const after = Number.parseInt(afterText, 10);
+    expect(after).toBe(baseline + 1);
+
+    // Critical parity assertion: the server-action rerender must keep the
+    // intercepted tree mounted — modal visible, source feed layout intact,
+    // direct /photos/[id] page NOT rendered, URL unchanged.
+    await expect(page.locator('[data-testid="photo-modal"]')).toBeVisible();
+    await expect(page.locator('[data-testid="feed-page"]')).toBeVisible();
+    await expect(page.locator('[data-testid="photo-page"]')).not.toBeVisible();
+    expect(new URL(page.url()).pathname).toBe("/photos/42");
+
+    // Sanity: a hard refresh still routes to the direct page, mirroring the
+    // final assertion in the Next.js reference test.
+    await page.reload();
+    await waitForAppRouterHydration(page);
+    await expect(page.locator('[data-testid="photo-page"]')).toBeVisible();
+    await expect(page.locator('[data-testid="photo-modal"]')).not.toBeVisible();
+  });
+
   test("back then forward restores intercepted modal view", async ({ page }) => {
     await page.goto(`${BASE}/feed`);
     await waitForAppRouterHydration(page);

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -241,8 +241,17 @@ describe("App Router entry templates", () => {
       "// After the action, re-render the current page so the client",
     );
     expect(actionRerenderIdx).toBeGreaterThan(-1);
-    const rerenderSlice = code.slice(actionRerenderIdx, actionRerenderIdx + 700);
+    const rerenderSlice = code.slice(actionRerenderIdx, actionRerenderIdx + 2500);
     expect(rerenderSlice).toContain("element = buildPageElements(");
+  });
+
+  it("generateRscEntry delegates action rerender target selection to the shared helper", () => {
+    const code = generateRscEntry("/tmp/test/app", minimalAppRoutes, null, [], null, "", false);
+
+    expect(code).toContain(
+      "resolveAppPageActionRerenderTarget as __resolveAppPageActionRerenderTarget",
+    );
+    expect(code).toContain("const __actionRerenderTarget = __resolveAppPageActionRerenderTarget({");
   });
 
   it("generateRscEntry reuses the canonical tree-path helper for no-export page payloads", () => {

--- a/tests/fixtures/app-basic/app/feed/@modal/(...)photos/[id]/actions.ts
+++ b/tests/fixtures/app-basic/app/feed/@modal/(...)photos/[id]/actions.ts
@@ -1,0 +1,13 @@
+"use server";
+
+const likesByPhoto = new Map<string, number>();
+
+export async function bumpPhotoLikes(id: string): Promise<number> {
+  const next = (likesByPhoto.get(id) ?? 0) + 1;
+  likesByPhoto.set(id, next);
+  return next;
+}
+
+export async function getPhotoLikes(id: string): Promise<number> {
+  return likesByPhoto.get(id) ?? 0;
+}

--- a/tests/fixtures/app-basic/app/feed/@modal/(...)photos/[id]/like-button.tsx
+++ b/tests/fixtures/app-basic/app/feed/@modal/(...)photos/[id]/like-button.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useState } from "react";
+import { bumpPhotoLikes } from "./actions";
+
+export function LikeButton({ id, initialLikes }: { id: string; initialLikes: number }) {
+  const [likes, setLikes] = useState(initialLikes);
+
+  return (
+    <div>
+      <span data-testid="photo-likes">{likes}</span>
+      <button
+        data-testid="photo-like-btn"
+        type="button"
+        onClick={async () => {
+          const next = await bumpPhotoLikes(id);
+          setLikes(next);
+        }}
+      >
+        Like
+      </button>
+    </div>
+  );
+}

--- a/tests/fixtures/app-basic/app/feed/@modal/(...)photos/[id]/page.tsx
+++ b/tests/fixtures/app-basic/app/feed/@modal/(...)photos/[id]/page.tsx
@@ -1,9 +1,13 @@
 import Link from "next/link";
+import { getPhotoLikes } from "./actions";
+import { LikeButton } from "./like-button";
 import { PhotoModalRefreshButton } from "./refresh-button";
 
 // Intercepting route: renders when navigating from /feed to /photos/[id].
 // Shows a modal version of the photo instead of the full page.
-export default function PhotoModal({ params }: { params: { id: string } }) {
+export default async function PhotoModal({ params }: { params: { id: string } }) {
+  const initialLikes = await getPhotoLikes(params.id);
+
   return (
     <div data-testid="photo-modal">
       <h2>Photo Modal</h2>
@@ -12,6 +16,7 @@ export default function PhotoModal({ params }: { params: { id: string } }) {
         Next Photo
       </Link>
       <PhotoModalRefreshButton />
+      <LikeButton id={params.id} initialLikes={initialLikes} />
     </div>
   );
 }

--- a/tests/fixtures/static-export/package.json
+++ b/tests/fixtures/static-export/package.json
@@ -4,8 +4,8 @@
   "type": "module",
   "dependencies": {
     "@vitejs/plugin-rsc": "catalog:",
-    "react": "catalog:",
-    "react-dom": "catalog:",
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5",
     "react-server-dom-webpack": "catalog:",
     "vinext": "workspace:*",
     "vite": "catalog:"


### PR DESCRIPTION
## Summary
- send interception context and mounted slot headers on app-router server action POSTs using the current browser router state
- reuse a shared action rerender target helper so POST rerenders preserve both intercepted source-route trees and current-route slot overrides
- add regression coverage for the browser-state helper, generated RSC entry code, and the intercepted modal server-action flow
- pin `react` and `react-dom` versions in the `static-export` fixture to match the resolved lockfile state

## Examples
- Before: open `/feed`, soft-navigate to `/photos/42`, then trigger a server action from the modal. The POST omitted interception provenance, so the rerender could replace the modal tree with the direct `/photos/[id]` page.
  After: the same action keeps the modal mounted, keeps the feed layout visible, and leaves the URL at `/photos/42`.
- Before: when an intercept resolved back to the current route, the GET path still preserved `interceptOpts` for slot overrides, but the POST rerender path dropped them.
  After: both GET and POST use the same rerender-target selection logic, so current-route interception shapes keep their slot overrides.
- `static-export` fixture dependencies now declare `react` and `react-dom` as `^19.2.5` instead of `catalog:` so the fixture package manifest matches the checked-in lockfile state.

## Testing
- `vp test run tests/app-browser-entry.test.ts tests/app-page-request.test.ts tests/entry-templates.test.ts`
- `PLAYWRIGHT_PROJECT=app-router vp run test:e2e tests/e2e/app-router/advanced.spec.ts -g 'server action from intercepted modal preserves modal tree'`