### PR TITLE
fix(shims): narrow `runWith*` return type when callback is async

### DIFF
--- a/packages/vinext/src/shims/cache-runtime.ts
+++ b/packages/vinext/src/shims/cache-runtime.ts
@@ -259,6 +259,8 @@ function _getPrivateState(): PrivateCacheState {
  * Ensures per-request isolation for "use cache: private" entries
  * on concurrent runtimes.
  */
+export function runWithPrivateCache<T>(fn: () => Promise<T>): Promise<T>;
+export function runWithPrivateCache<T>(fn: () => T | Promise<T>): T | Promise<T>;
 export function runWithPrivateCache<T>(fn: () => T | Promise<T>): T | Promise<T> {
   if (isInsideUnifiedScope()) {
     return runWithUnifiedStateMutation((uCtx) => {

--- a/packages/vinext/src/shims/cache.ts
+++ b/packages/vinext/src/shims/cache.ts
@@ -457,6 +457,8 @@ function _getCacheState(): CacheState {
  * on concurrent runtimes.
  * @internal
  */
+export function _runWithCacheState<T>(fn: () => Promise<T>): Promise<T>;
+export function _runWithCacheState<T>(fn: () => T | Promise<T>): T | Promise<T>;
 export function _runWithCacheState<T>(fn: () => T | Promise<T>): T | Promise<T> {
   if (isInsideUnifiedScope()) {
     return runWithUnifiedStateMutation((uCtx) => {

--- a/packages/vinext/src/shims/head-state.ts
+++ b/packages/vinext/src/shims/head-state.ts
@@ -46,6 +46,8 @@ function _getState(): HeadState {
  * Ensures per-request isolation for Pages Router <Head> elements
  * on concurrent runtimes.
  */
+export function runWithHeadState<T>(fn: () => Promise<T>): Promise<T>;
+export function runWithHeadState<T>(fn: () => T | Promise<T>): T | Promise<T>;
 export function runWithHeadState<T>(fn: () => T | Promise<T>): T | Promise<T> {
   if (isInsideUnifiedScope()) {
     return runWithUnifiedStateMutation((uCtx) => {

--- a/packages/vinext/src/shims/headers.ts
+++ b/packages/vinext/src/shims/headers.ts
@@ -202,6 +202,11 @@ export function setHeadersContext(ctx: HeadersContext | null): void {
  * so RSC streaming works correctly — components that render when the
  * stream is consumed still see the correct request's context.
  */
+export function runWithHeadersContext<T>(ctx: HeadersContext, fn: () => Promise<T>): Promise<T>;
+export function runWithHeadersContext<T>(
+  ctx: HeadersContext,
+  fn: () => T | Promise<T>,
+): T | Promise<T>;
 export function runWithHeadersContext<T>(
   ctx: HeadersContext,
   fn: () => T | Promise<T>,

--- a/packages/vinext/src/shims/i18n-state.ts
+++ b/packages/vinext/src/shims/i18n-state.ts
@@ -45,6 +45,8 @@ function _getState(): I18nState {
  * Run a function within an i18n state ALS scope.
  * Ensures per-request isolation for i18n context on concurrent runtimes.
  */
+export function runWithI18nState<T>(fn: () => Promise<T>): Promise<T>;
+export function runWithI18nState<T>(fn: () => T | Promise<T>): T | Promise<T>;
 export function runWithI18nState<T>(fn: () => T | Promise<T>): T | Promise<T> {
   if (isInsideUnifiedScope()) {
     return runWithUnifiedStateMutation((uCtx) => {

--- a/packages/vinext/src/shims/navigation-state.ts
+++ b/packages/vinext/src/shims/navigation-state.ts
@@ -55,6 +55,8 @@ function _getState(): NavigationState {
  * Ensures per-request isolation for navigation context and
  * useServerInsertedHTML callbacks on concurrent runtimes.
  */
+export function runWithNavigationContext<T>(fn: () => Promise<T>): Promise<T>;
+export function runWithNavigationContext<T>(fn: () => T | Promise<T>): T | Promise<T>;
 export function runWithNavigationContext<T>(fn: () => T | Promise<T>): T | Promise<T> {
   if (isInsideUnifiedScope()) {
     return runWithUnifiedStateMutation((uCtx) => {

--- a/packages/vinext/src/shims/navigation-state.ts
+++ b/packages/vinext/src/shims/navigation-state.ts
@@ -79,6 +79,8 @@ export function runWithNavigationContext<T>(fn: () => T | Promise<T>): T | Promi
  * but it needs a fresh callback collection so CSS-in-JS insertions from the
  * streamed render cannot accumulate into the cache-fill render.
  */
+export function runWithServerInsertedHTMLState<T>(fn: () => Promise<T>): Promise<T>;
+export function runWithServerInsertedHTMLState<T>(fn: () => T | Promise<T>): T | Promise<T>;
 export function runWithServerInsertedHTMLState<T>(fn: () => T | Promise<T>): T | Promise<T> {
   if (isInsideUnifiedScope()) {
     return runWithUnifiedStateMutation((uCtx) => {

--- a/packages/vinext/src/shims/request-context.ts
+++ b/packages/vinext/src/shims/request-context.ts
@@ -67,6 +67,14 @@ const _als = (_g[_ALS_KEY] ??=
  */
 export function runWithExecutionContext<T>(
   ctx: ExecutionContextLike,
+  fn: () => Promise<T>,
+): Promise<T>;
+export function runWithExecutionContext<T>(
+  ctx: ExecutionContextLike,
+  fn: () => T | Promise<T>,
+): T | Promise<T>;
+export function runWithExecutionContext<T>(
+  ctx: ExecutionContextLike,
   fn: () => T | Promise<T>,
 ): T | Promise<T> {
   if (isInsideUnifiedScope()) {

--- a/packages/vinext/src/shims/router-state.ts
+++ b/packages/vinext/src/shims/router-state.ts
@@ -55,6 +55,8 @@ function _getState(): RouterState {
  * Ensures per-request isolation for Pages Router SSR context
  * on concurrent runtimes.
  */
+export function runWithRouterState<T>(fn: () => Promise<T>): Promise<T>;
+export function runWithRouterState<T>(fn: () => T | Promise<T>): T | Promise<T>;
 export function runWithRouterState<T>(fn: () => T | Promise<T>): T | Promise<T> {
   if (isInsideUnifiedScope()) {
     return runWithUnifiedStateMutation((uCtx) => {

--- a/packages/vinext/src/shims/unified-request-context.ts
+++ b/packages/vinext/src/shims/unified-request-context.ts
@@ -133,6 +133,14 @@ export function runWithRequestContext<T>(
  */
 export function runWithUnifiedStateMutation<T>(
   mutate: (ctx: UnifiedRequestContext) => void,
+  fn: () => Promise<T>,
+): Promise<T>;
+export function runWithUnifiedStateMutation<T>(
+  mutate: (ctx: UnifiedRequestContext) => void,
+  fn: () => T | Promise<T>,
+): T | Promise<T>;
+export function runWithUnifiedStateMutation<T>(
+  mutate: (ctx: UnifiedRequestContext) => void,
   fn: () => T | Promise<T>,
 ): T | Promise<T> {
   const parentCtx = _als.getStore();

--- a/packages/vinext/src/shims/unified-request-context.ts
+++ b/packages/vinext/src/shims/unified-request-context.ts
@@ -109,6 +109,14 @@ export function createRequestContext(opts?: Partial<UnifiedRequestContext>): Uni
  */
 export function runWithRequestContext<T>(
   ctx: UnifiedRequestContext,
+  fn: () => Promise<T>,
+): Promise<T>;
+export function runWithRequestContext<T>(
+  ctx: UnifiedRequestContext,
+  fn: () => T | Promise<T>,
+): T | Promise<T>;
+export function runWithRequestContext<T>(
+  ctx: UnifiedRequestContext,
   fn: () => T | Promise<T>,
 ): T | Promise<T> {
   return _als.run(ctx, fn);


### PR DESCRIPTION
Add `Promise<T>` overloads to runWithRequestContext, runWithHeadersContext, and runWithNavigationContext so async callbacks don't widen the return type to `T | Promise<T>`. This clears 4 typescript-eslint(await-thenable) warnings where `Promise.all` received the wider union.