### PR TITLE
fix: emit no-store Cache-Control for revalidate = 0 route handlers

### DIFF
--- a/packages/vinext/src/server/app-route-handler-policy.ts
+++ b/packages/vinext/src/server/app-route-handler-policy.ts
@@ -54,11 +54,15 @@ export type AppRouteHandlerSpecialError =
 export function getAppRouteHandlerRevalidateSeconds(
   handler: Pick<AppRouteHandlerModule, "revalidate">,
 ): number | null {
-  return typeof handler.revalidate === "number" &&
-    handler.revalidate > 0 &&
-    handler.revalidate !== Infinity
-    ? handler.revalidate
-    : null;
+  // 0 is a meaningful value ("never cache") and must be preserved so the
+  // header path can emit a no-store Cache-Control. Non-finite values
+  // (Infinity, NaN) are not valid revalidate durations and fall back to
+  // the null ("no revalidate configured") branch along with negatives.
+  const { revalidate } = handler;
+  if (typeof revalidate !== "number" || !Number.isFinite(revalidate) || revalidate < 0) {
+    return null;
+  }
+  return revalidate;
 }
 
 export function hasAppRouteHandlerDefaultExport(handler: RouteHandlerModule): boolean {
@@ -98,9 +102,13 @@ export function resolveAppRouteHandlerMethod(
 }
 
 export function shouldReadAppRouteHandlerCache(options: AppRouteHandlerCacheReadOptions): boolean {
+  // revalidateSeconds === 0 means "never cache" and must skip the ISR read.
+  // A previously written entry (e.g. from before the handler opted out)
+  // must never be replayed once the author set revalidate = 0.
   return (
     options.isProduction &&
     options.revalidateSeconds !== null &&
+    options.revalidateSeconds > 0 &&
     options.dynamicConfig !== "force-dynamic" &&
     !options.isKnownDynamic &&
     (options.method === "GET" || options.isAutoHead) &&
@@ -111,6 +119,9 @@ export function shouldReadAppRouteHandlerCache(options: AppRouteHandlerCacheRead
 export function shouldApplyAppRouteHandlerRevalidateHeader(
   options: Omit<AppRouteHandlerResponseCacheOptions, "dynamicConfig" | "isProduction">,
 ): boolean {
+  // Includes revalidateSeconds === 0. That case emits the no-store
+  // Cache-Control, which is exactly the header a never-cache handler
+  // needs to suppress heuristic caching.
   return (
     options.revalidateSeconds !== null &&
     !options.dynamicUsedInHandler &&
@@ -122,9 +133,12 @@ export function shouldApplyAppRouteHandlerRevalidateHeader(
 export function shouldWriteAppRouteHandlerCache(
   options: AppRouteHandlerResponseCacheOptions,
 ): boolean {
+  // Excludes revalidateSeconds === 0. A never-cache response must not be
+  // persisted to ISR, even though it still needs a Cache-Control header.
   return (
     options.isProduction &&
     options.revalidateSeconds !== null &&
+    options.revalidateSeconds > 0 &&
     options.dynamicConfig !== "force-dynamic" &&
     shouldApplyAppRouteHandlerRevalidateHeader(options)
   );

--- a/packages/vinext/src/server/app-route-handler-response.ts
+++ b/packages/vinext/src/server/app-route-handler-response.ts
@@ -18,10 +18,22 @@ export type FinalizeRouteHandlerResponseOptions = {
   isHead: boolean;
 };
 
+// Matches Next.js's getCacheControlHeader for revalidate === 0.
+// See .nextjs-ref/packages/next/src/server/lib/cache-control.ts.
+const NEVER_CACHE_CONTROL = "private, no-cache, no-store, max-age=0, must-revalidate";
+
 function buildRouteHandlerCacheControl(
   cacheState: BuildRouteHandlerCachedResponseOptions["cacheState"],
   revalidateSeconds: number,
 ): string {
+  if (revalidateSeconds === 0) {
+    // A cached response is never produced for revalidate = 0 (the ISR write
+    // path skips it), so only the HIT/STALE->fresh rewrite can arrive here
+    // with a 0 value, via applyRouteHandlerRevalidateHeader. In all such
+    // cases the author opted out of caching entirely.
+    return NEVER_CACHE_CONTROL;
+  }
+
   if (cacheState === "STALE") {
     return "s-maxage=0, stale-while-revalidate";
   }

--- a/tests/app-route-handler-policy.test.ts
+++ b/tests/app-route-handler-policy.test.ts
@@ -19,6 +19,7 @@ describe("app route handler policy helpers", () => {
     expect(getAppRouteHandlerRevalidateSeconds({ revalidate: 60 })).toBe(60);
     expect(getAppRouteHandlerRevalidateSeconds({ revalidate: 0 })).toBe(0);
     expect(getAppRouteHandlerRevalidateSeconds({ revalidate: Infinity })).toBeNull();
+    expect(getAppRouteHandlerRevalidateSeconds({ revalidate: Number.NaN })).toBeNull();
     expect(getAppRouteHandlerRevalidateSeconds({ revalidate: false })).toBeNull();
   });
 

--- a/tests/app-route-handler-policy.test.ts
+++ b/tests/app-route-handler-policy.test.ts
@@ -10,11 +10,50 @@ import {
 } from "../packages/vinext/src/server/app-route-handler-policy.js";
 
 describe("app route handler policy helpers", () => {
-  it("extracts finite positive route handler revalidate values", () => {
+  it("preserves revalidate = 0 as a distinct never-cache signal", () => {
+    // revalidate = 0 must not collapse to null. Downstream header and cache
+    // gates rely on 0 being observable to emit a no-store Cache-Control and
+    // to skip ISR writes. Collapsing it to null would emit no Cache-Control
+    // at all and let CDNs/browsers apply heuristic caching to a response
+    // the author explicitly opted out of.
     expect(getAppRouteHandlerRevalidateSeconds({ revalidate: 60 })).toBe(60);
-    expect(getAppRouteHandlerRevalidateSeconds({ revalidate: 0 })).toBeNull();
+    expect(getAppRouteHandlerRevalidateSeconds({ revalidate: 0 })).toBe(0);
     expect(getAppRouteHandlerRevalidateSeconds({ revalidate: Infinity })).toBeNull();
     expect(getAppRouteHandlerRevalidateSeconds({ revalidate: false })).toBeNull();
+  });
+
+  it("treats revalidate = 0 as never-cache for route handler ISR read/write gates", () => {
+    const readBase = {
+      dynamicConfig: "auto",
+      handlerFn() {},
+      isAutoHead: false,
+      isKnownDynamic: false,
+      isProduction: true,
+      method: "GET",
+      revalidateSeconds: 0,
+    };
+    // A never-cache handler must not be served from ISR. Otherwise stale
+    // entries written before the handler was marked never-cache would keep
+    // replaying.
+    expect(shouldReadAppRouteHandlerCache(readBase)).toBe(false);
+
+    const writeBase = {
+      dynamicConfig: "auto",
+      dynamicUsedInHandler: false,
+      handlerSetCacheControl: false,
+      isAutoHead: false,
+      isProduction: true,
+      method: "GET",
+      revalidateSeconds: 0,
+    };
+    // Writing a never-cache response to ISR would persist uncacheable
+    // content under a key that later requests would try to serve.
+    expect(shouldWriteAppRouteHandlerCache(writeBase)).toBe(false);
+
+    // The framework still owns the Cache-Control header for revalidate = 0
+    // unless the handler set its own. Gating this off would leave the
+    // response with no Cache-Control and expose it to heuristic caching.
+    expect(shouldApplyAppRouteHandlerRevalidateHeader(writeBase)).toBe(true);
   });
 
   it("detects invalid default-export route handlers", () => {

--- a/tests/app-route-handler-response.test.ts
+++ b/tests/app-route-handler-response.test.ts
@@ -218,4 +218,21 @@ describe("app route handler response helpers", () => {
     expect(response.headers.get("cache-control")).toBe("s-maxage=30, stale-while-revalidate");
     expect(response.headers.get("x-vinext-cache")).toBe("MISS");
   });
+
+  it("emits a no-store Cache-Control for revalidate = 0 route handlers", () => {
+    // A handler exporting `revalidate = 0` opts out of caching entirely.
+    // The Cache-Control must tell browsers and CDNs never to store the
+    // response. Emitting `s-maxage=0, stale-while-revalidate` (the SWR
+    // template) would still permit intermediate caches to serve stale
+    // copies, which is the exact opposite of the author's intent.
+    // The exact string matches Next.js's own cache-control helper:
+    // .nextjs-ref/packages/next/src/server/lib/cache-control.ts:29.
+    const response = new Response("no cache me");
+
+    applyRouteHandlerRevalidateHeader(response, 0);
+
+    expect(response.headers.get("cache-control")).toBe(
+      "private, no-cache, no-store, max-age=0, must-revalidate",
+    );
+  });
 });


### PR DESCRIPTION
## What this changes

Route handlers exporting `export const revalidate = 0` now emit the canonical no-store `Cache-Control` header (`private, no-cache, no-store, max-age=0, must-revalidate`) that Next.js emits in the same situation. Previously they emitted no `Cache-Control` at all.

## Why

`getAppRouteHandlerRevalidateSeconds` collapsed `revalidate = 0` into `null` by filtering on `> 0`. Every downstream gate (`shouldReadAppRouteHandlerCache`, `shouldApplyAppRouteHandlerRevalidateHeader`, `shouldWriteAppRouteHandlerCache`) short-circuits when `revalidateSeconds === null`, so the framework skipped the header write. CDNs and browsers then applied heuristic caching to a response the author had explicitly opted out of.

The page path already handles this correctly: `resolveAppPageRscResponsePolicy` and `resolveAppPageHtmlResponsePolicy` each branch on `revalidateSeconds === 0` and return a no-store policy. The route handler path was the asymmetric one.

## Approach

Preserve `0` as a distinct value in the policy helper. Use `Number.isFinite` so `NaN` and `Infinity` still fall to `null` alongside negatives.

Split the three downstream gates along semantic lines:

- `shouldReadAppRouteHandlerCache` and `shouldWriteAppRouteHandlerCache` keep `> 0`. A never-cache handler must not serve from ISR and must not persist to ISR.
- `shouldApplyAppRouteHandlerRevalidateHeader` keeps `!== null`. It must fire for `0` so the header is written.
- `buildRouteHandlerCacheControl` branches on `0` first and returns the canonical Next.js no-store string (matches `.nextjs-ref/packages/next/src/server/lib/cache-control.ts:28-29`).

Non-goals: did not touch the App Router page paths (they were already correct), the Pages Router `buildPagesCacheResponse` helper (separate codepath, separate review), or the generated RSC entry (no change needed, the helper changes flow through).

## Validation

- `vp test run tests/app-route-handler-policy.test.ts tests/app-route-handler-response.test.ts tests/app-route-handler-cache.test.ts tests/app-route-handler-execution.test.ts` - 26 passing.
- `vp check` on the four touched files - clean.
- The tests were committed ahead of the fix so they exercised the bug. Against the previous implementation, `tests/app-route-handler-policy.test.ts` fails with `expected 0, got null` on the helper, `expected true to be false` on the read/write gates with `revalidateSeconds: 0`, and `tests/app-route-handler-response.test.ts` fails with `expected "private, no-cache, no-store, max-age=0, must-revalidate" to be "s-maxage=0, stale-while-revalidate"`.

## Risks / follow-ups

- The Pages Router `buildPagesCacheResponse` (`packages/vinext/src/server/pages-page-data.ts:163`) uses an SWR template without a `0` branch. It is called with a `revalidateSeconds` derived from `getStaticProps`, which has different semantics, so it is out of scope here. Worth a follow-up audit.
- `resolveAppRouteHandlerSpecialError` (`packages/vinext/src/server/app-route-handler-policy.ts:147`) and the equivalent helper in `app-page-execution.ts` currently parse `NEXT_REDIRECT` digests without validating the number of `;`-delimited parts. A malformed digest will silently decode `undefined` or parse `NaN` as a status code. Not touched in this PR. Open issue / follow-up work.