### PR TITLE
Fix sibling intercepted App Router routes

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -930,6 +930,10 @@ function matchPattern(urlParts, patternParts) {
   return params;
 }
 
+function mergeMatchedParams(sourceParams, targetParams) {
+  return Object.assign(Object.create(null), sourceParams, targetParams);
+}
+
 // Build a global intercepting route lookup for RSC navigation.
 // Maps target URL patterns to { sourceRouteIndex, slotKey, interceptPage, params }.
 const interceptLookup = [];
@@ -960,7 +964,7 @@ function findIntercept(pathname, sourcePathname = null) {
   for (const entry of interceptLookup) {
     const params = matchPattern(urlParts, entry.targetPatternParts);
     if (params !== null) {
-      let sourceParams = {};
+      let sourceParams = Object.create(null);
       if (sourcePathname !== null) {
         const sourceRoute = routes[entry.sourceRouteIndex];
         const sourceParts = sourcePathname.split("/").filter(Boolean);
@@ -971,7 +975,7 @@ function findIntercept(pathname, sourcePathname = null) {
           sourceParams = matchedSourceParams;
         }
       }
-      return { ...entry, matchedParams: { ...sourceParams, ...params } };
+      return { ...entry, matchedParams: mergeMatchedParams(sourceParams, params) };
     }
   }
   return null;

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -967,10 +967,9 @@ function findIntercept(pathname, sourcePathname = null) {
         const matchedSourceParams = sourceRoute
           ? matchPattern(sourceParts, sourceRoute.patternParts)
           : null;
-        if (matchedSourceParams === null) {
-          continue;
+        if (matchedSourceParams !== null) {
+          sourceParams = matchedSourceParams;
         }
-        sourceParams = matchedSourceParams;
       }
       return { ...entry, matchedParams: { ...sourceParams, ...params } };
     }

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -955,12 +955,24 @@ for (let ri = 0; ri < routes.length; ri++) {
  * Check if a pathname matches any intercepting route.
  * Returns the match info or null.
  */
-function findIntercept(pathname) {
+function findIntercept(pathname, sourcePathname = null) {
   const urlParts = pathname.split("/").filter(Boolean);
   for (const entry of interceptLookup) {
     const params = matchPattern(urlParts, entry.targetPatternParts);
     if (params !== null) {
-      return { ...entry, matchedParams: params };
+      let sourceParams = {};
+      if (sourcePathname !== null) {
+        const sourceRoute = routes[entry.sourceRouteIndex];
+        const sourceParts = sourcePathname.split("/").filter(Boolean);
+        const matchedSourceParams = sourceRoute
+          ? matchPattern(sourceParts, sourceRoute.patternParts)
+          : null;
+        if (matchedSourceParams === null) {
+          continue;
+        }
+        sourceParams = matchedSourceParams;
+      }
+      return { ...entry, matchedParams: { ...sourceParams, ...params } };
     }
   }
   return null;
@@ -974,8 +986,9 @@ async function buildPageElements(route, params, routePath, pageRequest) {
     request,
     mountedSlotsHeader,
   } = pageRequest;
+  const hasPageModule = !!route.page;
   const PageComponent = route.page?.default;
-  if (!PageComponent) {
+  if (hasPageModule && !PageComponent) {
     const _interceptionContext = opts?.interceptionContext ?? null;
     const _noExportRouteId = __createAppPayloadRouteId(routePath, _interceptionContext);
     let _noExportRootLayout = null;
@@ -1099,7 +1112,7 @@ async function buildPageElements(route, params, routePath, pageRequest) {
     : null;
 
   return __buildAppPageElements({
-    element: createElement(PageComponent, pageProps),
+    element: PageComponent ? createElement(PageComponent, pageProps) : null,
     globalErrorModule: ${globalErrorVar ? globalErrorVar : "null"},
     isRscRequest,
     mountedSlotIds,
@@ -1863,7 +1876,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           cleanPathname,
           currentParams: actionParams,
           currentRoute: actionRoute,
-          findIntercept,
+          findIntercept(pathname) {
+            return findIntercept(pathname, interceptionContextHeader);
+          },
           getRouteParamNames(sourceRoute) {
             return sourceRoute.params;
           },
@@ -2186,8 +2201,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   }
 
   // Build the component tree: layouts wrapping the page
+  const hasPageModule = !!route.page;
   const PageComponent = route.page?.default;
-  if (!PageComponent) {
+  if (hasPageModule && !PageComponent) {
     setHeadersContext(null);
     setNavigationContext(null);
     return new Response("Page has no default export", { status: 500 });
@@ -2359,7 +2375,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     },
     cleanPathname,
     currentRoute: route,
-    findIntercept,
+    findIntercept(pathname) {
+      return findIntercept(pathname, interceptionContextHeader);
+    },
     getRouteParamNames(sourceRoute) {
       return sourceRoute.params;
     },

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -2518,6 +2518,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       return LayoutComp({ params: _asyncLayoutParams, children: null });
     },
     probePage() {
+      if (!PageComponent) return null;
       const _probeSearchObj = {};
       url.searchParams.forEach(function(v, k) {
         if (k in _probeSearchObj) {

--- a/packages/vinext/src/routing/app-router.ts
+++ b/packages/vinext/src/routing/app-router.ts
@@ -143,6 +143,16 @@ export function invalidateAppRouteCache(): void {
   cachedPageExtensionsKey = null;
 }
 
+function hasParallelSlotDirectory(dir: string): boolean {
+  try {
+    return fs
+      .readdirSync(dir, { withFileTypes: true })
+      .some((entry) => entry.isDirectory() && entry.name.startsWith("@"));
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Scan the app/ directory and return a list of routes.
  */
@@ -189,6 +199,7 @@ export async function appRouter(
   )) {
     const dir = path.dirname(file);
     const routeDir = dir === "." ? appDir : path.join(appDir, dir);
+    if (!hasParallelSlotDirectory(routeDir)) continue;
     if (discoverParallelSlots(routeDir, appDir, matcher).length === 0) continue;
 
     const route = directoryToAppRoute(dir, appDir, matcher, null, null);

--- a/packages/vinext/src/routing/app-router.ts
+++ b/packages/vinext/src/routing/app-router.ts
@@ -177,6 +177,27 @@ export async function appRouter(
     if (route) routes.push(route);
   }
 
+  // Layouts with parallel slot pages are valid route entries even when the
+  // segment has no children page. Next.js uses this for modal/feed patterns
+  // like app/user/[id]/layout + @feed/page + @modal/default.
+  const routePatterns = new Set(routes.map((route) => route.pattern));
+  for await (const file of scanWithExtensions(
+    "**/layout",
+    appDir,
+    matcher.extensions,
+    excludeDir,
+  )) {
+    const dir = path.dirname(file);
+    const routeDir = dir === "." ? appDir : path.join(appDir, dir);
+    if (discoverParallelSlots(routeDir, appDir, matcher).length === 0) continue;
+
+    const route = directoryToAppRoute(dir, appDir, matcher, null, null);
+    if (!route || routePatterns.has(route.pattern)) continue;
+
+    routes.push(route);
+    routePatterns.add(route.pattern);
+  }
+
   // Discover sub-routes created by nested pages within parallel slots.
   // In Next.js, pages nested inside @slot directories create additional URL routes.
   // For example, @audience/demographics/page.tsx at app/parallel-routes/ creates
@@ -417,6 +438,22 @@ function fileToAppRoute(
 ): AppRoute | null {
   // Remove the filename (page.tsx or route.ts)
   const dir = path.dirname(file);
+  return directoryToAppRoute(
+    dir,
+    appDir,
+    matcher,
+    type === "page" ? path.join(appDir, file) : null,
+    type === "route" ? path.join(appDir, file) : null,
+  );
+}
+
+function directoryToAppRoute(
+  dir: string,
+  appDir: string,
+  matcher: ValidFileMatcher,
+  pagePath: string | null,
+  routePath: string | null,
+): AppRoute | null {
   const segments = dir === "." ? [] : dir.split(path.sep);
 
   const params: string[] = [];
@@ -466,8 +503,8 @@ function fileToAppRoute(
 
   return {
     pattern: pattern === "/" ? "/" : pattern,
-    pagePath: type === "page" ? path.join(appDir, file) : null,
-    routePath: type === "route" ? path.join(appDir, file) : null,
+    pagePath,
+    routePath,
     layouts,
     templates,
     parallelSlots,

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -727,10 +727,9 @@ function findIntercept(pathname, sourcePathname = null) {
         const matchedSourceParams = sourceRoute
           ? matchPattern(sourceParts, sourceRoute.patternParts)
           : null;
-        if (matchedSourceParams === null) {
-          continue;
+        if (matchedSourceParams !== null) {
+          sourceParams = matchedSourceParams;
         }
-        sourceParams = matchedSourceParams;
       }
       return { ...entry, matchedParams: { ...sourceParams, ...params } };
     }
@@ -3043,10 +3042,9 @@ function findIntercept(pathname, sourcePathname = null) {
         const matchedSourceParams = sourceRoute
           ? matchPattern(sourceParts, sourceRoute.patternParts)
           : null;
-        if (matchedSourceParams === null) {
-          continue;
+        if (matchedSourceParams !== null) {
+          sourceParams = matchedSourceParams;
         }
-        sourceParams = matchedSourceParams;
       }
       return { ...entry, matchedParams: { ...sourceParams, ...params } };
     }
@@ -5366,10 +5364,9 @@ function findIntercept(pathname, sourcePathname = null) {
         const matchedSourceParams = sourceRoute
           ? matchPattern(sourceParts, sourceRoute.patternParts)
           : null;
-        if (matchedSourceParams === null) {
-          continue;
+        if (matchedSourceParams !== null) {
+          sourceParams = matchedSourceParams;
         }
-        sourceParams = matchedSourceParams;
       }
       return { ...entry, matchedParams: { ...sourceParams, ...params } };
     }
@@ -7712,10 +7709,9 @@ function findIntercept(pathname, sourcePathname = null) {
         const matchedSourceParams = sourceRoute
           ? matchPattern(sourceParts, sourceRoute.patternParts)
           : null;
-        if (matchedSourceParams === null) {
-          continue;
+        if (matchedSourceParams !== null) {
+          sourceParams = matchedSourceParams;
         }
-        sourceParams = matchedSourceParams;
       }
       return { ...entry, matchedParams: { ...sourceParams, ...params } };
     }
@@ -10038,10 +10034,9 @@ function findIntercept(pathname, sourcePathname = null) {
         const matchedSourceParams = sourceRoute
           ? matchPattern(sourceParts, sourceRoute.patternParts)
           : null;
-        if (matchedSourceParams === null) {
-          continue;
+        if (matchedSourceParams !== null) {
+          sourceParams = matchedSourceParams;
         }
-        sourceParams = matchedSourceParams;
       }
       return { ...entry, matchedParams: { ...sourceParams, ...params } };
     }
@@ -12354,10 +12349,9 @@ function findIntercept(pathname, sourcePathname = null) {
         const matchedSourceParams = sourceRoute
           ? matchPattern(sourceParts, sourceRoute.patternParts)
           : null;
-        if (matchedSourceParams === null) {
-          continue;
+        if (matchedSourceParams !== null) {
+          sourceParams = matchedSourceParams;
         }
-        sourceParams = matchedSourceParams;
       }
       return { ...entry, matchedParams: { ...sourceParams, ...params } };
     }

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -690,6 +690,10 @@ function matchPattern(urlParts, patternParts) {
   return params;
 }
 
+function mergeMatchedParams(sourceParams, targetParams) {
+  return Object.assign(Object.create(null), sourceParams, targetParams);
+}
+
 // Build a global intercepting route lookup for RSC navigation.
 // Maps target URL patterns to { sourceRouteIndex, slotKey, interceptPage, params }.
 const interceptLookup = [];
@@ -720,7 +724,7 @@ function findIntercept(pathname, sourcePathname = null) {
   for (const entry of interceptLookup) {
     const params = matchPattern(urlParts, entry.targetPatternParts);
     if (params !== null) {
-      let sourceParams = {};
+      let sourceParams = Object.create(null);
       if (sourcePathname !== null) {
         const sourceRoute = routes[entry.sourceRouteIndex];
         const sourceParts = sourcePathname.split("/").filter(Boolean);
@@ -731,7 +735,7 @@ function findIntercept(pathname, sourcePathname = null) {
           sourceParams = matchedSourceParams;
         }
       }
-      return { ...entry, matchedParams: { ...sourceParams, ...params } };
+      return { ...entry, matchedParams: mergeMatchedParams(sourceParams, params) };
     }
   }
   return null;
@@ -3005,6 +3009,10 @@ function matchPattern(urlParts, patternParts) {
   return params;
 }
 
+function mergeMatchedParams(sourceParams, targetParams) {
+  return Object.assign(Object.create(null), sourceParams, targetParams);
+}
+
 // Build a global intercepting route lookup for RSC navigation.
 // Maps target URL patterns to { sourceRouteIndex, slotKey, interceptPage, params }.
 const interceptLookup = [];
@@ -3035,7 +3043,7 @@ function findIntercept(pathname, sourcePathname = null) {
   for (const entry of interceptLookup) {
     const params = matchPattern(urlParts, entry.targetPatternParts);
     if (params !== null) {
-      let sourceParams = {};
+      let sourceParams = Object.create(null);
       if (sourcePathname !== null) {
         const sourceRoute = routes[entry.sourceRouteIndex];
         const sourceParts = sourcePathname.split("/").filter(Boolean);
@@ -3046,7 +3054,7 @@ function findIntercept(pathname, sourcePathname = null) {
           sourceParams = matchedSourceParams;
         }
       }
-      return { ...entry, matchedParams: { ...sourceParams, ...params } };
+      return { ...entry, matchedParams: mergeMatchedParams(sourceParams, params) };
     }
   }
   return null;
@@ -5327,6 +5335,10 @@ function matchPattern(urlParts, patternParts) {
   return params;
 }
 
+function mergeMatchedParams(sourceParams, targetParams) {
+  return Object.assign(Object.create(null), sourceParams, targetParams);
+}
+
 // Build a global intercepting route lookup for RSC navigation.
 // Maps target URL patterns to { sourceRouteIndex, slotKey, interceptPage, params }.
 const interceptLookup = [];
@@ -5357,7 +5369,7 @@ function findIntercept(pathname, sourcePathname = null) {
   for (const entry of interceptLookup) {
     const params = matchPattern(urlParts, entry.targetPatternParts);
     if (params !== null) {
-      let sourceParams = {};
+      let sourceParams = Object.create(null);
       if (sourcePathname !== null) {
         const sourceRoute = routes[entry.sourceRouteIndex];
         const sourceParts = sourcePathname.split("/").filter(Boolean);
@@ -5368,7 +5380,7 @@ function findIntercept(pathname, sourcePathname = null) {
           sourceParams = matchedSourceParams;
         }
       }
-      return { ...entry, matchedParams: { ...sourceParams, ...params } };
+      return { ...entry, matchedParams: mergeMatchedParams(sourceParams, params) };
     }
   }
   return null;
@@ -7672,6 +7684,10 @@ function matchPattern(urlParts, patternParts) {
   return params;
 }
 
+function mergeMatchedParams(sourceParams, targetParams) {
+  return Object.assign(Object.create(null), sourceParams, targetParams);
+}
+
 // Build a global intercepting route lookup for RSC navigation.
 // Maps target URL patterns to { sourceRouteIndex, slotKey, interceptPage, params }.
 const interceptLookup = [];
@@ -7702,7 +7718,7 @@ function findIntercept(pathname, sourcePathname = null) {
   for (const entry of interceptLookup) {
     const params = matchPattern(urlParts, entry.targetPatternParts);
     if (params !== null) {
-      let sourceParams = {};
+      let sourceParams = Object.create(null);
       if (sourcePathname !== null) {
         const sourceRoute = routes[entry.sourceRouteIndex];
         const sourceParts = sourcePathname.split("/").filter(Boolean);
@@ -7713,7 +7729,7 @@ function findIntercept(pathname, sourcePathname = null) {
           sourceParams = matchedSourceParams;
         }
       }
-      return { ...entry, matchedParams: { ...sourceParams, ...params } };
+      return { ...entry, matchedParams: mergeMatchedParams(sourceParams, params) };
     }
   }
   return null;
@@ -9997,6 +10013,10 @@ function matchPattern(urlParts, patternParts) {
   return params;
 }
 
+function mergeMatchedParams(sourceParams, targetParams) {
+  return Object.assign(Object.create(null), sourceParams, targetParams);
+}
+
 // Build a global intercepting route lookup for RSC navigation.
 // Maps target URL patterns to { sourceRouteIndex, slotKey, interceptPage, params }.
 const interceptLookup = [];
@@ -10027,7 +10047,7 @@ function findIntercept(pathname, sourcePathname = null) {
   for (const entry of interceptLookup) {
     const params = matchPattern(urlParts, entry.targetPatternParts);
     if (params !== null) {
-      let sourceParams = {};
+      let sourceParams = Object.create(null);
       if (sourcePathname !== null) {
         const sourceRoute = routes[entry.sourceRouteIndex];
         const sourceParts = sourcePathname.split("/").filter(Boolean);
@@ -10038,7 +10058,7 @@ function findIntercept(pathname, sourcePathname = null) {
           sourceParams = matchedSourceParams;
         }
       }
-      return { ...entry, matchedParams: { ...sourceParams, ...params } };
+      return { ...entry, matchedParams: mergeMatchedParams(sourceParams, params) };
     }
   }
   return null;
@@ -12312,6 +12332,10 @@ function matchPattern(urlParts, patternParts) {
   return params;
 }
 
+function mergeMatchedParams(sourceParams, targetParams) {
+  return Object.assign(Object.create(null), sourceParams, targetParams);
+}
+
 // Build a global intercepting route lookup for RSC navigation.
 // Maps target URL patterns to { sourceRouteIndex, slotKey, interceptPage, params }.
 const interceptLookup = [];
@@ -12342,7 +12366,7 @@ function findIntercept(pathname, sourcePathname = null) {
   for (const entry of interceptLookup) {
     const params = matchPattern(urlParts, entry.targetPatternParts);
     if (params !== null) {
-      let sourceParams = {};
+      let sourceParams = Object.create(null);
       if (sourcePathname !== null) {
         const sourceRoute = routes[entry.sourceRouteIndex];
         const sourceParts = sourcePathname.split("/").filter(Boolean);
@@ -12353,7 +12377,7 @@ function findIntercept(pathname, sourcePathname = null) {
           sourceParams = matchedSourceParams;
         }
       }
-      return { ...entry, matchedParams: { ...sourceParams, ...params } };
+      return { ...entry, matchedParams: mergeMatchedParams(sourceParams, params) };
     }
   }
   return null;

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -715,12 +715,24 @@ for (let ri = 0; ri < routes.length; ri++) {
  * Check if a pathname matches any intercepting route.
  * Returns the match info or null.
  */
-function findIntercept(pathname) {
+function findIntercept(pathname, sourcePathname = null) {
   const urlParts = pathname.split("/").filter(Boolean);
   for (const entry of interceptLookup) {
     const params = matchPattern(urlParts, entry.targetPatternParts);
     if (params !== null) {
-      return { ...entry, matchedParams: params };
+      let sourceParams = {};
+      if (sourcePathname !== null) {
+        const sourceRoute = routes[entry.sourceRouteIndex];
+        const sourceParts = sourcePathname.split("/").filter(Boolean);
+        const matchedSourceParams = sourceRoute
+          ? matchPattern(sourceParts, sourceRoute.patternParts)
+          : null;
+        if (matchedSourceParams === null) {
+          continue;
+        }
+        sourceParams = matchedSourceParams;
+      }
+      return { ...entry, matchedParams: { ...sourceParams, ...params } };
     }
   }
   return null;
@@ -734,8 +746,9 @@ async function buildPageElements(route, params, routePath, pageRequest) {
     request,
     mountedSlotsHeader,
   } = pageRequest;
+  const hasPageModule = !!route.page;
   const PageComponent = route.page?.default;
-  if (!PageComponent) {
+  if (hasPageModule && !PageComponent) {
     const _interceptionContext = opts?.interceptionContext ?? null;
     const _noExportRouteId = __createAppPayloadRouteId(routePath, _interceptionContext);
     let _noExportRootLayout = null;
@@ -859,7 +872,7 @@ async function buildPageElements(route, params, routePath, pageRequest) {
     : null;
 
   return __buildAppPageElements({
-    element: createElement(PageComponent, pageProps),
+    element: PageComponent ? createElement(PageComponent, pageProps) : null,
     globalErrorModule: null,
     isRscRequest,
     mountedSlotIds,
@@ -1588,7 +1601,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           cleanPathname,
           currentParams: actionParams,
           currentRoute: actionRoute,
-          findIntercept,
+          findIntercept(pathname) {
+            return findIntercept(pathname, interceptionContextHeader);
+          },
           getRouteParamNames(sourceRoute) {
             return sourceRoute.params;
           },
@@ -1869,8 +1884,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   }
 
   // Build the component tree: layouts wrapping the page
+  const hasPageModule = !!route.page;
   const PageComponent = route.page?.default;
-  if (!PageComponent) {
+  if (hasPageModule && !PageComponent) {
     setHeadersContext(null);
     setNavigationContext(null);
     return new Response("Page has no default export", { status: 500 });
@@ -2042,7 +2058,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     },
     cleanPathname,
     currentRoute: route,
-    findIntercept,
+    findIntercept(pathname) {
+      return findIntercept(pathname, interceptionContextHeader);
+    },
     getRouteParamNames(sourceRoute) {
       return sourceRoute.params;
     },
@@ -3013,12 +3031,24 @@ for (let ri = 0; ri < routes.length; ri++) {
  * Check if a pathname matches any intercepting route.
  * Returns the match info or null.
  */
-function findIntercept(pathname) {
+function findIntercept(pathname, sourcePathname = null) {
   const urlParts = pathname.split("/").filter(Boolean);
   for (const entry of interceptLookup) {
     const params = matchPattern(urlParts, entry.targetPatternParts);
     if (params !== null) {
-      return { ...entry, matchedParams: params };
+      let sourceParams = {};
+      if (sourcePathname !== null) {
+        const sourceRoute = routes[entry.sourceRouteIndex];
+        const sourceParts = sourcePathname.split("/").filter(Boolean);
+        const matchedSourceParams = sourceRoute
+          ? matchPattern(sourceParts, sourceRoute.patternParts)
+          : null;
+        if (matchedSourceParams === null) {
+          continue;
+        }
+        sourceParams = matchedSourceParams;
+      }
+      return { ...entry, matchedParams: { ...sourceParams, ...params } };
     }
   }
   return null;
@@ -3032,8 +3062,9 @@ async function buildPageElements(route, params, routePath, pageRequest) {
     request,
     mountedSlotsHeader,
   } = pageRequest;
+  const hasPageModule = !!route.page;
   const PageComponent = route.page?.default;
-  if (!PageComponent) {
+  if (hasPageModule && !PageComponent) {
     const _interceptionContext = opts?.interceptionContext ?? null;
     const _noExportRouteId = __createAppPayloadRouteId(routePath, _interceptionContext);
     let _noExportRootLayout = null;
@@ -3157,7 +3188,7 @@ async function buildPageElements(route, params, routePath, pageRequest) {
     : null;
 
   return __buildAppPageElements({
-    element: createElement(PageComponent, pageProps),
+    element: PageComponent ? createElement(PageComponent, pageProps) : null,
     globalErrorModule: null,
     isRscRequest,
     mountedSlotIds,
@@ -3892,7 +3923,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           cleanPathname,
           currentParams: actionParams,
           currentRoute: actionRoute,
-          findIntercept,
+          findIntercept(pathname) {
+            return findIntercept(pathname, interceptionContextHeader);
+          },
           getRouteParamNames(sourceRoute) {
             return sourceRoute.params;
           },
@@ -4173,8 +4206,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   }
 
   // Build the component tree: layouts wrapping the page
+  const hasPageModule = !!route.page;
   const PageComponent = route.page?.default;
-  if (!PageComponent) {
+  if (hasPageModule && !PageComponent) {
     setHeadersContext(null);
     setNavigationContext(null);
     return new Response("Page has no default export", { status: 500 });
@@ -4346,7 +4380,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     },
     cleanPathname,
     currentRoute: route,
-    findIntercept,
+    findIntercept(pathname) {
+      return findIntercept(pathname, interceptionContextHeader);
+    },
     getRouteParamNames(sourceRoute) {
       return sourceRoute.params;
     },
@@ -5318,12 +5354,24 @@ for (let ri = 0; ri < routes.length; ri++) {
  * Check if a pathname matches any intercepting route.
  * Returns the match info or null.
  */
-function findIntercept(pathname) {
+function findIntercept(pathname, sourcePathname = null) {
   const urlParts = pathname.split("/").filter(Boolean);
   for (const entry of interceptLookup) {
     const params = matchPattern(urlParts, entry.targetPatternParts);
     if (params !== null) {
-      return { ...entry, matchedParams: params };
+      let sourceParams = {};
+      if (sourcePathname !== null) {
+        const sourceRoute = routes[entry.sourceRouteIndex];
+        const sourceParts = sourcePathname.split("/").filter(Boolean);
+        const matchedSourceParams = sourceRoute
+          ? matchPattern(sourceParts, sourceRoute.patternParts)
+          : null;
+        if (matchedSourceParams === null) {
+          continue;
+        }
+        sourceParams = matchedSourceParams;
+      }
+      return { ...entry, matchedParams: { ...sourceParams, ...params } };
     }
   }
   return null;
@@ -5337,8 +5385,9 @@ async function buildPageElements(route, params, routePath, pageRequest) {
     request,
     mountedSlotsHeader,
   } = pageRequest;
+  const hasPageModule = !!route.page;
   const PageComponent = route.page?.default;
-  if (!PageComponent) {
+  if (hasPageModule && !PageComponent) {
     const _interceptionContext = opts?.interceptionContext ?? null;
     const _noExportRouteId = __createAppPayloadRouteId(routePath, _interceptionContext);
     let _noExportRootLayout = null;
@@ -5462,7 +5511,7 @@ async function buildPageElements(route, params, routePath, pageRequest) {
     : null;
 
   return __buildAppPageElements({
-    element: createElement(PageComponent, pageProps),
+    element: PageComponent ? createElement(PageComponent, pageProps) : null,
     globalErrorModule: mod_11,
     isRscRequest,
     mountedSlotIds,
@@ -6191,7 +6240,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           cleanPathname,
           currentParams: actionParams,
           currentRoute: actionRoute,
-          findIntercept,
+          findIntercept(pathname) {
+            return findIntercept(pathname, interceptionContextHeader);
+          },
           getRouteParamNames(sourceRoute) {
             return sourceRoute.params;
           },
@@ -6472,8 +6523,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   }
 
   // Build the component tree: layouts wrapping the page
+  const hasPageModule = !!route.page;
   const PageComponent = route.page?.default;
-  if (!PageComponent) {
+  if (hasPageModule && !PageComponent) {
     setHeadersContext(null);
     setNavigationContext(null);
     return new Response("Page has no default export", { status: 500 });
@@ -6645,7 +6697,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     },
     cleanPathname,
     currentRoute: route,
-    findIntercept,
+    findIntercept(pathname) {
+      return findIntercept(pathname, interceptionContextHeader);
+    },
     getRouteParamNames(sourceRoute) {
       return sourceRoute.params;
     },
@@ -7646,12 +7700,24 @@ for (let ri = 0; ri < routes.length; ri++) {
  * Check if a pathname matches any intercepting route.
  * Returns the match info or null.
  */
-function findIntercept(pathname) {
+function findIntercept(pathname, sourcePathname = null) {
   const urlParts = pathname.split("/").filter(Boolean);
   for (const entry of interceptLookup) {
     const params = matchPattern(urlParts, entry.targetPatternParts);
     if (params !== null) {
-      return { ...entry, matchedParams: params };
+      let sourceParams = {};
+      if (sourcePathname !== null) {
+        const sourceRoute = routes[entry.sourceRouteIndex];
+        const sourceParts = sourcePathname.split("/").filter(Boolean);
+        const matchedSourceParams = sourceRoute
+          ? matchPattern(sourceParts, sourceRoute.patternParts)
+          : null;
+        if (matchedSourceParams === null) {
+          continue;
+        }
+        sourceParams = matchedSourceParams;
+      }
+      return { ...entry, matchedParams: { ...sourceParams, ...params } };
     }
   }
   return null;
@@ -7665,8 +7731,9 @@ async function buildPageElements(route, params, routePath, pageRequest) {
     request,
     mountedSlotsHeader,
   } = pageRequest;
+  const hasPageModule = !!route.page;
   const PageComponent = route.page?.default;
-  if (!PageComponent) {
+  if (hasPageModule && !PageComponent) {
     const _interceptionContext = opts?.interceptionContext ?? null;
     const _noExportRouteId = __createAppPayloadRouteId(routePath, _interceptionContext);
     let _noExportRootLayout = null;
@@ -7790,7 +7857,7 @@ async function buildPageElements(route, params, routePath, pageRequest) {
     : null;
 
   return __buildAppPageElements({
-    element: createElement(PageComponent, pageProps),
+    element: PageComponent ? createElement(PageComponent, pageProps) : null,
     globalErrorModule: null,
     isRscRequest,
     mountedSlotIds,
@@ -8522,7 +8589,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           cleanPathname,
           currentParams: actionParams,
           currentRoute: actionRoute,
-          findIntercept,
+          findIntercept(pathname) {
+            return findIntercept(pathname, interceptionContextHeader);
+          },
           getRouteParamNames(sourceRoute) {
             return sourceRoute.params;
           },
@@ -8803,8 +8872,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   }
 
   // Build the component tree: layouts wrapping the page
+  const hasPageModule = !!route.page;
   const PageComponent = route.page?.default;
-  if (!PageComponent) {
+  if (hasPageModule && !PageComponent) {
     setHeadersContext(null);
     setNavigationContext(null);
     return new Response("Page has no default export", { status: 500 });
@@ -8976,7 +9046,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     },
     cleanPathname,
     currentRoute: route,
-    findIntercept,
+    findIntercept(pathname) {
+      return findIntercept(pathname, interceptionContextHeader);
+    },
     getRouteParamNames(sourceRoute) {
       return sourceRoute.params;
     },
@@ -9954,12 +10026,24 @@ for (let ri = 0; ri < routes.length; ri++) {
  * Check if a pathname matches any intercepting route.
  * Returns the match info or null.
  */
-function findIntercept(pathname) {
+function findIntercept(pathname, sourcePathname = null) {
   const urlParts = pathname.split("/").filter(Boolean);
   for (const entry of interceptLookup) {
     const params = matchPattern(urlParts, entry.targetPatternParts);
     if (params !== null) {
-      return { ...entry, matchedParams: params };
+      let sourceParams = {};
+      if (sourcePathname !== null) {
+        const sourceRoute = routes[entry.sourceRouteIndex];
+        const sourceParts = sourcePathname.split("/").filter(Boolean);
+        const matchedSourceParams = sourceRoute
+          ? matchPattern(sourceParts, sourceRoute.patternParts)
+          : null;
+        if (matchedSourceParams === null) {
+          continue;
+        }
+        sourceParams = matchedSourceParams;
+      }
+      return { ...entry, matchedParams: { ...sourceParams, ...params } };
     }
   }
   return null;
@@ -9973,8 +10057,9 @@ async function buildPageElements(route, params, routePath, pageRequest) {
     request,
     mountedSlotsHeader,
   } = pageRequest;
+  const hasPageModule = !!route.page;
   const PageComponent = route.page?.default;
-  if (!PageComponent) {
+  if (hasPageModule && !PageComponent) {
     const _interceptionContext = opts?.interceptionContext ?? null;
     const _noExportRouteId = __createAppPayloadRouteId(routePath, _interceptionContext);
     let _noExportRootLayout = null;
@@ -10098,7 +10183,7 @@ async function buildPageElements(route, params, routePath, pageRequest) {
     : null;
 
   return __buildAppPageElements({
-    element: createElement(PageComponent, pageProps),
+    element: PageComponent ? createElement(PageComponent, pageProps) : null,
     globalErrorModule: null,
     isRscRequest,
     mountedSlotIds,
@@ -10827,7 +10912,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           cleanPathname,
           currentParams: actionParams,
           currentRoute: actionRoute,
-          findIntercept,
+          findIntercept(pathname) {
+            return findIntercept(pathname, interceptionContextHeader);
+          },
           getRouteParamNames(sourceRoute) {
             return sourceRoute.params;
           },
@@ -11108,8 +11195,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   }
 
   // Build the component tree: layouts wrapping the page
+  const hasPageModule = !!route.page;
   const PageComponent = route.page?.default;
-  if (!PageComponent) {
+  if (hasPageModule && !PageComponent) {
     setHeadersContext(null);
     setNavigationContext(null);
     return new Response("Page has no default export", { status: 500 });
@@ -11281,7 +11369,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     },
     cleanPathname,
     currentRoute: route,
-    findIntercept,
+    findIntercept(pathname) {
+      return findIntercept(pathname, interceptionContextHeader);
+    },
     getRouteParamNames(sourceRoute) {
       return sourceRoute.params;
     },
@@ -12252,12 +12342,24 @@ for (let ri = 0; ri < routes.length; ri++) {
  * Check if a pathname matches any intercepting route.
  * Returns the match info or null.
  */
-function findIntercept(pathname) {
+function findIntercept(pathname, sourcePathname = null) {
   const urlParts = pathname.split("/").filter(Boolean);
   for (const entry of interceptLookup) {
     const params = matchPattern(urlParts, entry.targetPatternParts);
     if (params !== null) {
-      return { ...entry, matchedParams: params };
+      let sourceParams = {};
+      if (sourcePathname !== null) {
+        const sourceRoute = routes[entry.sourceRouteIndex];
+        const sourceParts = sourcePathname.split("/").filter(Boolean);
+        const matchedSourceParams = sourceRoute
+          ? matchPattern(sourceParts, sourceRoute.patternParts)
+          : null;
+        if (matchedSourceParams === null) {
+          continue;
+        }
+        sourceParams = matchedSourceParams;
+      }
+      return { ...entry, matchedParams: { ...sourceParams, ...params } };
     }
   }
   return null;
@@ -12271,8 +12373,9 @@ async function buildPageElements(route, params, routePath, pageRequest) {
     request,
     mountedSlotsHeader,
   } = pageRequest;
+  const hasPageModule = !!route.page;
   const PageComponent = route.page?.default;
-  if (!PageComponent) {
+  if (hasPageModule && !PageComponent) {
     const _interceptionContext = opts?.interceptionContext ?? null;
     const _noExportRouteId = __createAppPayloadRouteId(routePath, _interceptionContext);
     let _noExportRootLayout = null;
@@ -12396,7 +12499,7 @@ async function buildPageElements(route, params, routePath, pageRequest) {
     : null;
 
   return __buildAppPageElements({
-    element: createElement(PageComponent, pageProps),
+    element: PageComponent ? createElement(PageComponent, pageProps) : null,
     globalErrorModule: null,
     isRscRequest,
     mountedSlotIds,
@@ -13492,7 +13595,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           cleanPathname,
           currentParams: actionParams,
           currentRoute: actionRoute,
-          findIntercept,
+          findIntercept(pathname) {
+            return findIntercept(pathname, interceptionContextHeader);
+          },
           getRouteParamNames(sourceRoute) {
             return sourceRoute.params;
           },
@@ -13773,8 +13878,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   }
 
   // Build the component tree: layouts wrapping the page
+  const hasPageModule = !!route.page;
   const PageComponent = route.page?.default;
-  if (!PageComponent) {
+  if (hasPageModule && !PageComponent) {
     setHeadersContext(null);
     setNavigationContext(null);
     return new Response("Page has no default export", { status: 500 });
@@ -13946,7 +14052,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     },
     cleanPathname,
     currentRoute: route,
-    findIntercept,
+    findIntercept(pathname) {
+      return findIntercept(pathname, interceptionContextHeader);
+    },
     getRouteParamNames(sourceRoute) {
       return sourceRoute.params;
     },

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -2201,6 +2201,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       return LayoutComp({ params: _asyncLayoutParams, children: null });
     },
     probePage() {
+      if (!PageComponent) return null;
       const _probeSearchObj = {};
       url.searchParams.forEach(function(v, k) {
         if (k in _probeSearchObj) {
@@ -4526,6 +4527,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       return LayoutComp({ params: _asyncLayoutParams, children: null });
     },
     probePage() {
+      if (!PageComponent) return null;
       const _probeSearchObj = {};
       url.searchParams.forEach(function(v, k) {
         if (k in _probeSearchObj) {
@@ -6846,6 +6848,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       return LayoutComp({ params: _asyncLayoutParams, children: null });
     },
     probePage() {
+      if (!PageComponent) return null;
       const _probeSearchObj = {};
       url.searchParams.forEach(function(v, k) {
         if (k in _probeSearchObj) {
@@ -9198,6 +9201,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       return LayoutComp({ params: _asyncLayoutParams, children: null });
     },
     probePage() {
+      if (!PageComponent) return null;
       const _probeSearchObj = {};
       url.searchParams.forEach(function(v, k) {
         if (k in _probeSearchObj) {
@@ -11524,6 +11528,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       return LayoutComp({ params: _asyncLayoutParams, children: null });
     },
     probePage() {
+      if (!PageComponent) return null;
       const _probeSearchObj = {};
       url.searchParams.forEach(function(v, k) {
         if (k in _probeSearchObj) {
@@ -14210,6 +14215,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       return LayoutComp({ params: _asyncLayoutParams, children: null });
     },
     probePage() {
+      if (!PageComponent) return null;
       const _probeSearchObj = {};
       url.searchParams.forEach(function(v, k) {
         if (k in _probeSearchObj) {

--- a/tests/e2e/app-router/advanced.spec.ts
+++ b/tests/e2e/app-router/advanced.spec.ts
@@ -239,6 +239,20 @@ test.describe("Intercepting Routes", () => {
     await expect(page.locator('[data-testid="parallel-photo-page"]')).not.toBeVisible();
   });
 
+  test("direct navigation to slot-only parallel source route renders feed slot", async ({
+    page,
+  }) => {
+    await page.goto(`${BASE}/parallel-sibling-modal/vercel`);
+
+    await expect(page.locator('[data-testid="parallel-sibling-layout"]')).toBeVisible();
+    await expect(page.locator('[data-testid="parallel-feed-page"]')).toContainText(
+      "Feed for vercel",
+    );
+    await expect(page.locator('[data-testid="parallel-modal-default"]')).toBeVisible();
+    await expect(page.locator('[data-testid="parallel-photo-modal"]')).not.toBeVisible();
+    await expect(page.locator('[data-testid="parallel-photo-page"]')).not.toBeVisible();
+  });
+
   test("back then forward restores intercepted modal view", async ({ page }) => {
     await page.goto(`${BASE}/feed`);
     await waitForAppRouterHydration(page);

--- a/tests/e2e/app-router/advanced.spec.ts
+++ b/tests/e2e/app-router/advanced.spec.ts
@@ -189,6 +189,56 @@ test.describe("Intercepting Routes", () => {
     await expect(page.locator('[data-testid="photo-modal"]')).not.toBeVisible();
   });
 
+  test("sibling (..) intercepted navigation mounts the modal slot", async ({ page }) => {
+    // Ported from the sibling-interception behavior covered by Next.js:
+    // test/e2e/app-dir/parallel-routes-and-interception/parallel-routes-and-interception.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/parallel-routes-and-interception/parallel-routes-and-interception.test.ts
+    await page.goto(`${BASE}/sibling-source`);
+    await waitForAppRouterHydration(page);
+
+    await page.click("#sibling-target-42-link");
+
+    await page.waitForURL(`${BASE}/sibling-target/42`);
+    await expect(page.locator('[data-testid="sibling-source-page"]')).toBeVisible();
+    await expect(page.locator('[data-testid="sibling-target-modal"]')).toBeVisible();
+    await expect(page.locator('[data-testid="sibling-target-modal-id"]')).toContainText(
+      "target-id:42",
+    );
+    await expect(page.locator('[data-testid="sibling-target-page"]')).not.toBeVisible();
+  });
+
+  test("top-level sibling (..) film navigation mounts the modal slot", async ({ page }) => {
+    await page.goto(`${BASE}/top`);
+    await waitForAppRouterHydration(page);
+
+    await page.click("#godfather-film-link");
+
+    await page.waitForURL(`${BASE}/film/tt0068646-the-godfather-1972`);
+    await expect(page.locator('[data-testid="top-page"]')).toBeVisible();
+    await expect(page.locator("h1")).toContainText("Top 1000");
+    await expect(page.locator('[data-testid="film-panel"]')).toBeVisible();
+    await expect(page.locator('[data-testid="film-panel-id"]')).toContainText(
+      "tt0068646-the-godfather-1972",
+    );
+    await expect(page.locator('[data-testid="detail-page"]')).not.toBeVisible();
+  });
+
+  test("sibling (..) modal preserves source content in a parallel feed slot", async ({ page }) => {
+    // Ported from Next.js: test/e2e/app-dir/parallel-routes-and-interception/app/(group)/intercepting-parallel-modal
+    // https://github.com/vercel/next.js/tree/canary/test/e2e/app-dir/parallel-routes-and-interception/app/(group)/intercepting-parallel-modal
+    await page.goto(`${BASE}/parallel-sibling-modal/vercel`);
+    await waitForAppRouterHydration(page);
+
+    await page.click("#parallel-photo-42-link");
+
+    await page.waitForURL(`${BASE}/parallel-sibling-modal/photo/42`);
+    await expect(page.locator('[data-testid="parallel-feed-page"]')).toContainText(
+      "Feed for vercel",
+    );
+    await expect(page.locator('[data-testid="parallel-photo-modal"]')).toHaveText("Photo MODAL 42");
+    await expect(page.locator('[data-testid="parallel-photo-page"]')).not.toBeVisible();
+  });
+
   test("back then forward restores intercepted modal view", async ({ page }) => {
     await page.goto(`${BASE}/feed`);
     await waitForAppRouterHydration(page);

--- a/tests/fixtures/app-basic/app/film/[imdbId]/page.tsx
+++ b/tests/fixtures/app-basic/app/film/[imdbId]/page.tsx
@@ -1,0 +1,8 @@
+export default function FilmPage({ params }: { params: { imdbId: string } }) {
+  return (
+    <main data-testid="detail-page">
+      <h1>Film Detail</h1>
+      <p data-testid="detail-page-id">{params.imdbId}</p>
+    </main>
+  );
+}

--- a/tests/fixtures/app-basic/app/parallel-sibling-modal/[username]/@feed/default.tsx
+++ b/tests/fixtures/app-basic/app/parallel-sibling-modal/[username]/@feed/default.tsx
@@ -1,0 +1,5 @@
+import { notFound } from "next/navigation";
+
+export default function ParallelFeedDefault() {
+  notFound();
+}

--- a/tests/fixtures/app-basic/app/parallel-sibling-modal/[username]/@feed/page.tsx
+++ b/tests/fixtures/app-basic/app/parallel-sibling-modal/[username]/@feed/page.tsx
@@ -1,0 +1,12 @@
+import Link from "next/link";
+
+export default function ParallelFeedPage({ params }: { params: { username: string } }) {
+  return (
+    <section data-testid="parallel-feed-page">
+      <h2>Feed for {params.username}</h2>
+      <Link href="/parallel-sibling-modal/photo/42" id="parallel-photo-42-link">
+        Photo 42
+      </Link>
+    </section>
+  );
+}

--- a/tests/fixtures/app-basic/app/parallel-sibling-modal/[username]/@modal/(..)photo/[id]/page.tsx
+++ b/tests/fixtures/app-basic/app/parallel-sibling-modal/[username]/@modal/(..)photo/[id]/page.tsx
@@ -1,0 +1,3 @@
+export default function ParallelPhotoModal({ params }: { params: { id: string } }) {
+  return <p data-testid="parallel-photo-modal">Photo MODAL {params.id}</p>;
+}

--- a/tests/fixtures/app-basic/app/parallel-sibling-modal/[username]/@modal/default.tsx
+++ b/tests/fixtures/app-basic/app/parallel-sibling-modal/[username]/@modal/default.tsx
@@ -1,0 +1,3 @@
+export default function ParallelModalDefault() {
+  return <div data-testid="parallel-modal-default">default modal slot</div>;
+}

--- a/tests/fixtures/app-basic/app/parallel-sibling-modal/[username]/layout.tsx
+++ b/tests/fixtures/app-basic/app/parallel-sibling-modal/[username]/layout.tsx
@@ -1,0 +1,15 @@
+export default function ParallelSiblingModalLayout({
+  feed,
+  modal,
+}: {
+  feed: React.ReactNode;
+  modal: React.ReactNode;
+}) {
+  return (
+    <main data-testid="parallel-sibling-layout">
+      <h1>Parallel User</h1>
+      {feed}
+      {modal}
+    </main>
+  );
+}

--- a/tests/fixtures/app-basic/app/parallel-sibling-modal/photo/[id]/page.tsx
+++ b/tests/fixtures/app-basic/app/parallel-sibling-modal/photo/[id]/page.tsx
@@ -1,0 +1,3 @@
+export default function ParallelPhotoPage({ params }: { params: { id: string } }) {
+  return <p data-testid="parallel-photo-page">Photo PAGE {params.id}</p>;
+}

--- a/tests/fixtures/app-basic/app/sibling-source/@modal/(..)sibling-target/[id]/page.tsx
+++ b/tests/fixtures/app-basic/app/sibling-source/@modal/(..)sibling-target/[id]/page.tsx
@@ -1,0 +1,8 @@
+export default function SiblingTargetModal({ params }: { params: { id: string } }) {
+  return (
+    <aside data-testid="sibling-target-modal">
+      <h2>Sibling Target Modal</h2>
+      <p data-testid="sibling-target-modal-id">target-id:{params.id}</p>
+    </aside>
+  );
+}

--- a/tests/fixtures/app-basic/app/sibling-source/@modal/default.tsx
+++ b/tests/fixtures/app-basic/app/sibling-source/@modal/default.tsx
@@ -1,0 +1,3 @@
+export default function SiblingModalDefault() {
+  return null;
+}

--- a/tests/fixtures/app-basic/app/sibling-source/layout.tsx
+++ b/tests/fixtures/app-basic/app/sibling-source/layout.tsx
@@ -1,0 +1,14 @@
+export default function SiblingSourceLayout({
+  children,
+  modal,
+}: {
+  children: React.ReactNode;
+  modal?: React.ReactNode;
+}) {
+  return (
+    <div data-testid="sibling-source-layout">
+      {children}
+      {modal && <div data-testid="sibling-modal-slot">{modal}</div>}
+    </div>
+  );
+}

--- a/tests/fixtures/app-basic/app/sibling-source/page.tsx
+++ b/tests/fixtures/app-basic/app/sibling-source/page.tsx
@@ -1,0 +1,12 @@
+import Link from "next/link";
+
+export default function SiblingSourcePage() {
+  return (
+    <main data-testid="sibling-source-page">
+      <h1>Sibling Source</h1>
+      <Link href="/sibling-target/42" id="sibling-target-42-link">
+        Open Target 42
+      </Link>
+    </main>
+  );
+}

--- a/tests/fixtures/app-basic/app/sibling-target/[id]/page.tsx
+++ b/tests/fixtures/app-basic/app/sibling-target/[id]/page.tsx
@@ -1,0 +1,7 @@
+export default function SiblingTargetPage({ params }: { params: { id: string } }) {
+  return (
+    <main data-testid="sibling-target-page">
+      <h1>Sibling Target {params.id}</h1>
+    </main>
+  );
+}

--- a/tests/fixtures/app-basic/app/top/@modal/(..)film/[imdbId]/page.tsx
+++ b/tests/fixtures/app-basic/app/top/@modal/(..)film/[imdbId]/page.tsx
@@ -1,0 +1,8 @@
+export default function FilmModal({ params }: { params: { imdbId: string } }) {
+  return (
+    <aside data-testid="film-panel">
+      <h2>Film Modal</h2>
+      <p data-testid="film-panel-id">{params.imdbId}</p>
+    </aside>
+  );
+}

--- a/tests/fixtures/app-basic/app/top/@modal/default.tsx
+++ b/tests/fixtures/app-basic/app/top/@modal/default.tsx
@@ -1,0 +1,3 @@
+export default function TopModalDefault() {
+  return null;
+}

--- a/tests/fixtures/app-basic/app/top/layout.tsx
+++ b/tests/fixtures/app-basic/app/top/layout.tsx
@@ -1,0 +1,14 @@
+export default function TopLayout({
+  children,
+  modal,
+}: {
+  children: React.ReactNode;
+  modal?: React.ReactNode;
+}) {
+  return (
+    <div data-testid="top-layout">
+      {children}
+      {modal && <div data-testid="top-modal-slot">{modal}</div>}
+    </div>
+  );
+}

--- a/tests/fixtures/app-basic/app/top/page.tsx
+++ b/tests/fixtures/app-basic/app/top/page.tsx
@@ -1,0 +1,12 @@
+import Link from "next/link";
+
+export default function TopPage() {
+  return (
+    <main data-testid="top-page">
+      <h1>Top 1000</h1>
+      <Link href="/film/tt0068646-the-godfather-1972" id="godfather-film-link">
+        The Godfather
+      </Link>
+    </main>
+  );
+}

--- a/tests/routing.test.ts
+++ b/tests/routing.test.ts
@@ -1225,6 +1225,34 @@ describe("matchAppRoute - URL matching", () => {
     expect(membersRoute!.layouts).toEqual(dashboardRoute!.layouts);
   });
 
+  it("discovers layout routes whose own content is parallel slot pages", async () => {
+    await withTempDir("vinext-app-layout-parallel-slot-route-", async (tmpDir) => {
+      const appDir = path.join(tmpDir, "app");
+
+      await mkdir(path.join(appDir, "users", "[username]", "@feed"), { recursive: true });
+      await mkdir(path.join(appDir, "users", "[username]", "@modal"), { recursive: true });
+      await writeFile(path.join(appDir, "layout.tsx"), EMPTY_PAGE);
+      await writeFile(path.join(appDir, "users", "[username]", "layout.tsx"), EMPTY_PAGE);
+      await writeFile(path.join(appDir, "users", "[username]", "@feed", "page.tsx"), EMPTY_PAGE);
+      await writeFile(path.join(appDir, "users", "[username]", "@feed", "default.tsx"), EMPTY_PAGE);
+      await writeFile(
+        path.join(appDir, "users", "[username]", "@modal", "default.tsx"),
+        EMPTY_PAGE,
+      );
+
+      invalidateAppRouteCache();
+      const routes = await appRouter(appDir);
+      const route = routes.find((r) => r.pattern === "/users/:username");
+
+      expect(route).toBeDefined();
+      expect(route!.pagePath).toBeNull();
+      expect(route!.parallelSlots.map((slot) => slot.name).sort()).toEqual(["feed", "modal"]);
+      expect(route!.parallelSlots.find((slot) => slot.name === "feed")!.pagePath).toContain(
+        path.join("@feed", "page.tsx"),
+      );
+    });
+  });
+
   // --- Hyphenated param names (issue #71) ---
 
   it("discovers optional catch-all with hyphenated param name [[...sign-in]]", async () => {


### PR DESCRIPTION
## Summary

Fixes sibling intercepted App Router navigation when the source route is a layout-owned parallel-slot route.

This now matches the Next.js `intercepting-parallel-modal` reference shape where `/[username]` renders `@feed` and `@modal`, and navigating to a sibling target mounts the modal while preserving source content.

Fixes #866

## What Changed

- Discover layout routes whose own renderable content comes from parallel slot pages, even when the segment has no child `page.tsx`.
- Allow the App Router RSC entry to render slot-only routes without treating them as “Page has no default export”.
- Merge params from the source interception context with params from the target URL so preserved source slots keep source-only params.
- Added regression fixtures for simple sibling `(..)`, the reported `/top` to `/film/[imdbId]` shape, and the Next.js `@feed` + `@modal/(..)photo/[id]` shape.

## Why It Matters

Apps using modal/detail routes from a listing page can now keep the listing tree mounted while rendering the intercepted sibling route. Source params such as `username` no longer disappear when they are not present in the target URL.

## Risks Or Limits

This changes route discovery for layout segments with parallel slots but no child page. The added route is only created when that layout owns parallel slots and no existing route pattern already exists.

## Verification

- `npx vp test run tests/routing.test.ts -t "layout routes whose own content is parallel slot pages"`
- `npx vp test run tests/app-router.test.ts -t "intercept"`
- `PLAYWRIGHT_PROJECT=app-router npx playwright test tests/e2e/app-router/advanced.spec.ts -g "sibling|top-level"`
- `npx vp check packages/vinext/src/routing/app-router.ts packages/vinext/src/entries/app-rsc-entry.ts tests/routing.test.ts tests/e2e/app-router/advanced.spec.ts tests/fixtures/app-basic/app/sibling-source tests/fixtures/app-basic/app/sibling-target tests/fixtures/app-basic/app/top tests/fixtures/app-basic/app/film tests/fixtures/app-basic/app/parallel-sibling-modal`
