### PR TITLE
fix(app-router): keep isPending true across programmatic router.push

### DIFF
--- a/packages/vinext/src/global.d.ts
+++ b/packages/vinext/src/global.d.ts
@@ -94,6 +94,7 @@ declare global {
           navigationKind?: "navigate" | "traverse" | "refresh",
           historyUpdateMode?: "push" | "replace",
           previousNextUrlOverride?: string | null,
+          programmaticTransition?: boolean,
         ) => Promise<void>)
       | undefined;
 

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -5,8 +5,8 @@ import {
   startTransition,
   use,
   useLayoutEffect,
-  useReducer,
   useRef,
+  useState,
   type Dispatch,
   type ReactNode,
 } from "react";
@@ -122,8 +122,21 @@ let nextNavigationRenderId = 0;
 let activeNavigationId = 0;
 const pendingNavigationCommits = new Map<number, () => void>();
 const pendingNavigationPrePaintEffects = new Map<number, () => void>();
-let dispatchBrowserRouterAction: Dispatch<AppRouterAction> | null = null;
+type PendingBrowserRouterState = {
+  promise: Promise<AppRouterState>;
+  resolve: (state: AppRouterState) => void;
+  settled: boolean;
+};
+
+function isRouterStatePromise(
+  value: AppRouterState | Promise<AppRouterState>,
+): value is Promise<AppRouterState> {
+  return "then" in value;
+}
+
+let setBrowserRouterState: Dispatch<AppRouterState | Promise<AppRouterState>> | null = null;
 let browserRouterStateRef: { current: AppRouterState } | null = null;
+let activePendingBrowserRouterState: PendingBrowserRouterState | null = null;
 let latestClientParams: Record<string, string | string[]> = {};
 const visitedResponseCache = new Map<string, VisitedResponseCacheEntry>();
 
@@ -131,11 +144,11 @@ function isServerActionResult(value: unknown): value is ServerActionResult {
   return !!value && typeof value === "object" && "root" in value;
 }
 
-function getBrowserRouterDispatch(): Dispatch<AppRouterAction> {
-  if (!dispatchBrowserRouterAction) {
-    throw new Error("[vinext] Browser router dispatch is not initialized");
+function getBrowserRouterStateSetter(): Dispatch<AppRouterState | Promise<AppRouterState>> {
+  if (!setBrowserRouterState) {
+    throw new Error("[vinext] Browser router state setter is not initialized");
   }
-  return dispatchBrowserRouterAction;
+  return setBrowserRouterState;
 }
 
 function getBrowserRouterState(): AppRouterState {
@@ -143,6 +156,58 @@ function getBrowserRouterState(): AppRouterState {
     throw new Error("[vinext] Browser router state is not initialized");
   }
   return browserRouterStateRef.current;
+}
+
+function beginPendingBrowserRouterState(): PendingBrowserRouterState {
+  const setter = getBrowserRouterStateSetter();
+
+  if (activePendingBrowserRouterState && !activePendingBrowserRouterState.settled) {
+    activePendingBrowserRouterState.settled = true;
+    activePendingBrowserRouterState.resolve(getBrowserRouterState());
+  }
+
+  let resolve!: (state: AppRouterState) => void;
+  const promise = new Promise<AppRouterState>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+
+  const pending: PendingBrowserRouterState = {
+    promise,
+    resolve,
+    settled: false,
+  };
+
+  activePendingBrowserRouterState = pending;
+  setter(promise);
+
+  return pending;
+}
+
+function settlePendingBrowserRouterState(
+  pending: PendingBrowserRouterState | null | undefined,
+): void {
+  if (!pending || pending.settled) return;
+
+  pending.settled = true;
+  pending.resolve(getBrowserRouterState());
+
+  if (activePendingBrowserRouterState === pending) {
+    activePendingBrowserRouterState = null;
+  }
+}
+
+function resolvePendingBrowserRouterState(
+  pending: PendingBrowserRouterState | null | undefined,
+  action: AppRouterAction,
+): void {
+  if (!pending || pending.settled) return;
+
+  pending.settled = true;
+  pending.resolve(routerReducer(getBrowserRouterState(), action));
+
+  if (activePendingBrowserRouterState === pending) {
+    activePendingBrowserRouterState = null;
+  }
 }
 
 function applyClientParams(params: Record<string, string | string[]>): void {
@@ -465,6 +530,7 @@ async function commitSameUrlNavigatePayload(
       pending.previousNextUrl,
       pending.routeId,
       pending.rootLayoutTreePath,
+      null,
       false,
     );
   }
@@ -492,7 +558,7 @@ function BrowserRoot({
 }) {
   const resolvedElements = use(initialElements);
   const initialMetadata = readAppElementsMetadata(resolvedElements);
-  const [treeState, dispatchTreeState] = useReducer(routerReducer, {
+  const [treeStateValue, setTreeStateValue] = useState<AppRouterState | Promise<AppRouterState>>({
     elements: resolvedElements,
     interceptionContext: initialMetadata.interceptionContext,
     layoutFlags: initialMetadata.layoutFlags,
@@ -502,6 +568,7 @@ function BrowserRoot({
     rootLayoutTreePath: initialMetadata.rootLayoutTreePath,
     routeId: initialMetadata.routeId,
   });
+  const treeState = isRouterStatePromise(treeStateValue) ? use(treeStateValue) : treeStateValue;
 
   // Keep the latest router state in a ref so external callers (navigate(),
   // server actions, HMR) always read the current state. Safe: those readers
@@ -518,18 +585,18 @@ function BrowserRoot({
   // after hydrateRoot() returns; by then this layout effect has already run for
   // the hydration commit, so getBrowserRouterState() never observes a null ref.
   useLayoutEffect(() => {
-    dispatchBrowserRouterAction = dispatchTreeState;
+    setBrowserRouterState = setTreeStateValue;
     browserRouterStateRef = stateRef;
     return () => {
-      if (dispatchBrowserRouterAction === dispatchTreeState) {
-        dispatchBrowserRouterAction = null;
+      if (setBrowserRouterState === setTreeStateValue) {
+        setBrowserRouterState = null;
       }
       if (browserRouterStateRef === stateRef) {
         browserRouterStateRef = null;
       }
       setMountedSlotsHeader(null);
     };
-  }, [dispatchTreeState]);
+  }, [setTreeStateValue]);
 
   useLayoutEffect(() => {
     setMountedSlotsHeader(getMountedSlotIdsHeader(stateRef.current.elements));
@@ -579,22 +646,30 @@ function dispatchBrowserTree(
   previousNextUrl: string | null,
   routeId: string,
   rootLayoutTreePath: string | null,
+  pendingRouterState: PendingBrowserRouterState | null,
   useTransitionMode: boolean,
 ): void {
-  const dispatch = getBrowserRouterDispatch();
+  const setter = getBrowserRouterStateSetter();
+  const action: AppRouterAction = {
+    elements,
+    interceptionContext,
+    layoutFlags,
+    navigationSnapshot,
+    previousNextUrl,
+    renderId,
+    rootLayoutTreePath,
+    routeId,
+    type: actionType,
+  };
 
-  const applyAction = () =>
-    dispatch({
-      elements,
-      interceptionContext,
-      layoutFlags,
-      navigationSnapshot,
-      previousNextUrl,
-      renderId,
-      rootLayoutTreePath,
-      routeId,
-      type: actionType,
-    });
+  const applyAction = () => {
+    if (pendingRouterState) {
+      resolvePendingBrowserRouterState(pendingRouterState, action);
+      return;
+    }
+
+    setter(routerReducer(getBrowserRouterState(), action));
+  };
 
   if (useTransitionMode) {
     startTransition(applyAction);
@@ -611,6 +686,7 @@ async function renderNavigationPayload(
   historyUpdateMode: HistoryUpdateMode | undefined,
   params: Record<string, string | string[]>,
   previousNextUrl: string | null,
+  pendingRouterState: PendingBrowserRouterState | null,
   useTransition = true,
   actionType: "navigate" | "replace" | "traverse" = "navigate",
 ): Promise<void> {
@@ -639,6 +715,7 @@ async function renderNavigationPayload(
     });
 
     if (disposition === "skip") {
+      settlePendingBrowserRouterState(pendingRouterState);
       const resolve = pendingNavigationCommits.get(renderId);
       pendingNavigationCommits.delete(renderId);
       resolve?.();
@@ -646,6 +723,7 @@ async function renderNavigationPayload(
     }
 
     if (disposition === "hard-navigate") {
+      settlePendingBrowserRouterState(pendingRouterState);
       pendingNavigationCommits.delete(renderId);
       window.location.assign(targetHref);
       return;
@@ -673,6 +751,7 @@ async function renderNavigationPayload(
       pending.previousNextUrl,
       pending.routeId,
       pending.rootLayoutTreePath,
+      pendingRouterState,
       useTransition,
     );
   } catch (error) {
@@ -686,6 +765,7 @@ async function renderNavigationPayload(
     if (snapshotActivated) {
       commitClientNavigationState(navId);
     }
+    settlePendingBrowserRouterState(pendingRouterState);
     resolve?.();
     throw error;
   }
@@ -883,6 +963,7 @@ async function main(): Promise<void> {
     navigationKind: NavigationKind = "navigate",
     historyUpdateMode?: HistoryUpdateMode,
     previousNextUrlOverride?: string | null,
+    programmaticTransition = false,
   ): Promise<void> {
     if (redirectDepth > 10) {
       console.error(
@@ -893,10 +974,15 @@ async function main(): Promise<void> {
     }
 
     let _snapshotPending = false;
+    let pendingRouterState: PendingBrowserRouterState | null = null;
     // Hoist navId above try so the catch block can guard against hard-navigating
     // to a stale URL when this navigation has already been superseded.
     const navId = ++activeNavigationId;
     try {
+      if (programmaticTransition) {
+        pendingRouterState = beginPendingBrowserRouterState();
+      }
+
       const url = new URL(href, window.location.origin);
       const rscUrl = toRscUrl(url.pathname + url.search);
       const requestState = getRequestState(navigationKind, previousNextUrlOverride);
@@ -935,7 +1021,10 @@ async function main(): Promise<void> {
         // between navId checks consistently; the cached path omits the check between
         // createClientNavigationRenderSnapshot (synchronous) and createFromFetch
         // because there is no await in that gap.
-        if (navId !== activeNavigationId) return;
+        if (navId !== activeNavigationId) {
+          settlePendingBrowserRouterState(pendingRouterState);
+          return;
+        }
         const cachedParams = cachedRoute.params;
         // createClientNavigationRenderSnapshot is synchronous (URL parsing + param
         // wrapping only) — no stale-navigation recheck needed between here and the
@@ -946,7 +1035,10 @@ async function main(): Promise<void> {
             Promise.resolve(restoreRscResponse(cachedRoute.response)),
           ),
         );
-        if (navId !== activeNavigationId) return;
+        if (navId !== activeNavigationId) {
+          settlePendingBrowserRouterState(pendingRouterState);
+          return;
+        }
         _snapshotPending = true; // Set before renderNavigationPayload
         try {
           await renderNavigationPayload(
@@ -957,6 +1049,7 @@ async function main(): Promise<void> {
             historyUpdateMode,
             cachedParams,
             requestPreviousNextUrl,
+            pendingRouterState,
             isSameRoute,
             toActionType(navigationKind),
           );
@@ -996,7 +1089,10 @@ async function main(): Promise<void> {
         });
       }
 
-      if (navId !== activeNavigationId) return;
+      if (navId !== activeNavigationId) {
+        settlePendingBrowserRouterState(pendingRouterState);
+        return;
+      }
 
       const finalUrl = new URL(navResponseUrl ?? navResponse.url, window.location.origin);
       const requestedUrl = new URL(rscUrl, window.location.origin);
@@ -1011,9 +1107,19 @@ async function main(): Promise<void> {
 
         const navigate = window.__VINEXT_RSC_NAVIGATE__;
         if (!navigate) {
+          settlePendingBrowserRouterState(pendingRouterState);
           window.location.href = destinationPath;
           return;
         }
+
+        // Hand ownership of the pending transition off before recursing. The
+        // recursive call will not receive pendingRouterState (programmaticTransition=false),
+        // so if we left it unsettled its promise would orphan in the useState slot
+        // until the next programmatic push caught it via the !settled branch in
+        // beginPendingBrowserRouterState. Settling here with the current committed
+        // state makes isPending flip false mid-redirect — a deliberate tradeoff
+        // over leaning on React's internal transition-completion heuristic.
+        settlePendingBrowserRouterState(pendingRouterState);
 
         // The URL has already been updated via replaceHistoryStateWithoutNotify above,
         // so the recursive navigation should NOT push/replace again. Pass undefined
@@ -1024,6 +1130,7 @@ async function main(): Promise<void> {
           navigationKind,
           undefined,
           requestPreviousNextUrl,
+          false,
         );
       }
 
@@ -1044,13 +1151,19 @@ async function main(): Promise<void> {
 
       const responseSnapshot = await snapshotRscResponse(navResponse);
 
-      if (navId !== activeNavigationId) return;
+      if (navId !== activeNavigationId) {
+        settlePendingBrowserRouterState(pendingRouterState);
+        return;
+      }
 
       const rscPayload = normalizeAppElementsPromise(
         createFromFetch<AppWireElements>(Promise.resolve(restoreRscResponse(responseSnapshot))),
       );
 
-      if (navId !== activeNavigationId) return;
+      if (navId !== activeNavigationId) {
+        settlePendingBrowserRouterState(pendingRouterState);
+        return;
+      }
 
       _snapshotPending = true; // Set before renderNavigationPayload
       try {
@@ -1062,6 +1175,7 @@ async function main(): Promise<void> {
           historyUpdateMode,
           navParams,
           requestPreviousNextUrl,
+          pendingRouterState,
           isSameRoute,
           toActionType(navigationKind),
         );
@@ -1075,7 +1189,10 @@ async function main(): Promise<void> {
       }
       // Don't cache the response if this navigation was superseded during
       // renderNavigationPayload's await — the elements were never dispatched.
-      if (navId !== activeNavigationId) return;
+      if (navId !== activeNavigationId) {
+        settlePendingBrowserRouterState(pendingRouterState);
+        return;
+      }
       // Store the visited response only after renderNavigationPayload succeeds.
       // If we stored it before and renderNavigationPayload threw, a future
       // back/forward navigation could replay a snapshot from a navigation that
@@ -1100,6 +1217,7 @@ async function main(): Promise<void> {
         _snapshotPending = false;
         commitClientNavigationState(navId);
       }
+      settlePendingBrowserRouterState(pendingRouterState);
       // Clear pending pathname on error so subsequent navigations compare correctly.
       // Only clear if this is still the active navigation — a newer navigation
       // has already overwritten pendingPathname with its own target.
@@ -1108,7 +1226,9 @@ async function main(): Promise<void> {
       }
       // Don't hard-navigate to a stale URL if this navigation was superseded by
       // a newer one — the newer navigation is already in flight and would be clobbered.
-      if (navId !== activeNavigationId) return;
+      if (navId !== activeNavigationId) {
+        return;
+      }
       console.error("[vinext] RSC navigation error:", error);
       window.location.href = href;
     }
@@ -1168,6 +1288,7 @@ async function main(): Promise<void> {
           pending.previousNextUrl,
           pending.routeId,
           pending.rootLayoutTreePath,
+          null,
           false,
         );
       } catch (error) {

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -131,7 +131,7 @@ type PendingBrowserRouterState = {
 function isRouterStatePromise(
   value: AppRouterState | Promise<AppRouterState>,
 ): value is Promise<AppRouterState> {
-  return "then" in value;
+  return value instanceof Promise;
 }
 
 let setBrowserRouterState: Dispatch<AppRouterState | Promise<AppRouterState>> | null = null;
@@ -664,6 +664,9 @@ function dispatchBrowserTree(
 
   const applyAction = () => {
     if (pendingRouterState) {
+      // The programmatic navigation is already running inside React.startTransition
+      // (from router.push/replace/refresh), so resolving the deferred promise is
+      // sufficient — no additional startTransition wrapper is needed below.
       resolvePendingBrowserRouterState(pendingRouterState, action);
       return;
     }

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -1117,6 +1117,7 @@ export async function navigateClientSide(
   href: string,
   mode: "push" | "replace",
   scroll: boolean,
+  programmaticTransition = false,
 ): Promise<void> {
   // Normalize same-origin absolute URLs to local paths for SPA navigation
   let normalizedHref = href;
@@ -1172,7 +1173,14 @@ export async function navigateClientSide(
   // double-push and ensures window.location still reflects the *current* URL
   // when navigateRsc computes isSameRoute (cross-route vs same-route).
   if (typeof window.__VINEXT_RSC_NAVIGATE__ === "function") {
-    await window.__VINEXT_RSC_NAVIGATE__(fullHref, 0, "navigate", mode);
+    await window.__VINEXT_RSC_NAVIGATE__(
+      fullHref,
+      0,
+      "navigate",
+      mode,
+      undefined,
+      programmaticTransition,
+    );
   } else {
     if (mode === "replace") {
       replaceHistoryStateWithoutNotify(null, "", fullHref);
@@ -1204,11 +1212,25 @@ export async function navigateClientSide(
 const _appRouter = {
   push(href: string, options?: { scroll?: boolean }): void {
     if (isServer) return;
-    void navigateClientSide(href, "push", options?.scroll !== false);
+    const navigate = () => {
+      void navigateClientSide(href, "push", options?.scroll !== false, true);
+    };
+    if (typeof React.startTransition === "function") {
+      React.startTransition(navigate);
+    } else {
+      navigate();
+    }
   },
   replace(href: string, options?: { scroll?: boolean }): void {
     if (isServer) return;
-    void navigateClientSide(href, "replace", options?.scroll !== false);
+    const navigate = () => {
+      void navigateClientSide(href, "replace", options?.scroll !== false, true);
+    };
+    if (typeof React.startTransition === "function") {
+      React.startTransition(navigate);
+    } else {
+      navigate();
+    }
   },
   back(): void {
     if (isServer) return;
@@ -1221,8 +1243,16 @@ const _appRouter = {
   refresh(): void {
     if (isServer) return;
     // Re-fetch the current page's RSC stream
-    if (typeof window.__VINEXT_RSC_NAVIGATE__ === "function") {
-      void window.__VINEXT_RSC_NAVIGATE__(window.location.href, 0, "refresh");
+    const rscNavigate = window.__VINEXT_RSC_NAVIGATE__;
+    if (typeof rscNavigate === "function") {
+      const navigate = () => {
+        void rscNavigate(window.location.href, 0, "refresh", undefined, undefined, true);
+      };
+      if (typeof React.startTransition === "function") {
+        React.startTransition(navigate);
+      } else {
+        navigate();
+      }
     }
   },
   prefetch(href: string): void {

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -1212,25 +1212,15 @@ export async function navigateClientSide(
 const _appRouter = {
   push(href: string, options?: { scroll?: boolean }): void {
     if (isServer) return;
-    const navigate = () => {
+    React.startTransition(() => {
       void navigateClientSide(href, "push", options?.scroll !== false, true);
-    };
-    if (typeof React.startTransition === "function") {
-      React.startTransition(navigate);
-    } else {
-      navigate();
-    }
+    });
   },
   replace(href: string, options?: { scroll?: boolean }): void {
     if (isServer) return;
-    const navigate = () => {
+    React.startTransition(() => {
       void navigateClientSide(href, "replace", options?.scroll !== false, true);
-    };
-    if (typeof React.startTransition === "function") {
-      React.startTransition(navigate);
-    } else {
-      navigate();
-    }
+    });
   },
   back(): void {
     if (isServer) return;
@@ -1248,11 +1238,7 @@ const _appRouter = {
       const navigate = () => {
         void rscNavigate(window.location.href, 0, "refresh", undefined, undefined, true);
       };
-      if (typeof React.startTransition === "function") {
-        React.startTransition(navigate);
-      } else {
-        navigate();
-      }
+      React.startTransition(navigate);
     }
   },
   prefetch(href: string): void {

--- a/tests/e2e/app-router/nextjs-compat/router-push-pending.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/router-push-pending.spec.ts
@@ -1,0 +1,45 @@
+/**
+ * Next.js Compat E2E: router push pending state
+ *
+ * Next.js references:
+ * - https://github.com/vercel/next.js/blob/canary/test/e2e/use-link-status/index.test.ts
+ * - https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/navigation/navigation.test.ts
+ *
+ * The contract we care about here is that a programmatic App Router navigation
+ * started inside useTransition should flip isPending immediately and keep it
+ * true until the navigation commits.
+ */
+
+import { expect, test } from "@playwright/test";
+import { waitForAppRouterHydration } from "../../helpers";
+
+const BASE = "http://localhost:4174";
+
+test.describe("Next.js compat: router.push pending state (browser)", () => {
+  test("same-route search param push keeps useTransition pending until commit", async ({
+    page,
+  }) => {
+    await page.goto(`${BASE}/nextjs-compat/router-push-pending`);
+    await waitForAppRouterHydration(page);
+
+    await expect(page.locator("#pending-state")).toHaveText("idle");
+    await expect(page.locator("#client-filter")).toHaveText("client filter: none");
+    await expect(page.locator("#server-filter")).toHaveText("server filter: none");
+
+    const clickPromise = page.click("#push-alpha", { noWaitAfter: true });
+
+    await expect(page.locator("#pending-state")).toHaveText("pending", {
+      timeout: 1_000,
+    });
+    await clickPromise;
+    await expect(page.locator("#client-filter")).toHaveText("client filter: alpha", {
+      timeout: 10_000,
+    });
+    await expect(page.locator("#server-filter")).toHaveText("server filter: alpha", {
+      timeout: 10_000,
+    });
+    await expect(page.locator("#pending-state")).toHaveText("idle", {
+      timeout: 10_000,
+    });
+  });
+});

--- a/tests/fixtures/app-basic/app/nextjs-compat/router-push-pending/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/router-push-pending/page.tsx
@@ -2,7 +2,7 @@ import { Suspense } from "react";
 import { PendingClient } from "./pending-client";
 
 async function SlowFilterResult({ filter }: { filter: string }) {
-  await new Promise((resolve) => setTimeout(resolve, 200));
+  await new Promise((resolve) => setTimeout(resolve, 1_000));
 
   return <p id="server-filter">server filter: {filter}</p>;
 }

--- a/tests/fixtures/app-basic/app/nextjs-compat/router-push-pending/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/router-push-pending/page.tsx
@@ -1,0 +1,26 @@
+import { Suspense } from "react";
+import { PendingClient } from "./pending-client";
+
+async function SlowFilterResult({ filter }: { filter: string }) {
+  await new Promise((resolve) => setTimeout(resolve, 200));
+
+  return <p id="server-filter">server filter: {filter}</p>;
+}
+
+export default async function RouterPushPendingPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ filter?: string }>;
+}) {
+  const { filter = "none" } = await searchParams;
+
+  return (
+    <div>
+      <h1 id="router-push-pending-title">Router push pending</h1>
+      <PendingClient />
+      <Suspense fallback={<p id="server-filter-loading">loading</p>}>
+        <SlowFilterResult filter={filter} />
+      </Suspense>
+    </div>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/router-push-pending/pending-client.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/router-push-pending/pending-client.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useTransition } from "react";
+
+export function PendingClient() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const filter = searchParams.get("filter") ?? "none";
+  const [isPending, startTransition] = useTransition();
+
+  return (
+    <div>
+      <p id="pending-state">{isPending ? "pending" : "idle"}</p>
+      <p id="client-filter">client filter: {filter}</p>
+      <button
+        id="push-alpha"
+        onClick={() => {
+          startTransition(() => {
+            router.push("?filter=alpha");
+          });
+        }}
+      >
+        Push alpha
+      </button>
+    </div>
+  );
+}

--- a/tests/form.test.ts
+++ b/tests/form.test.ts
@@ -263,7 +263,14 @@ describe("Form client GET interception", () => {
     );
     expect(event.preventDefault).toHaveBeenCalledOnce();
     // navigateClientSide delegates URL push to __VINEXT_RSC_NAVIGATE__ (two-phase commit)
-    expect(navigate).toHaveBeenCalledWith("/search?q=react", 0, "navigate", "push");
+    expect(navigate).toHaveBeenCalledWith(
+      "/search?q=react",
+      0,
+      "navigate",
+      "push",
+      undefined,
+      false,
+    );
     expect(scrollTo).toHaveBeenCalledWith(0, 0);
   });
 
@@ -294,6 +301,8 @@ describe("Form client GET interception", () => {
       0,
       "navigate",
       "push",
+      undefined,
+      false,
     );
   });
 
@@ -322,6 +331,8 @@ describe("Form client GET interception", () => {
       0,
       "navigate",
       "push",
+      undefined,
+      false,
     );
   });
 
@@ -364,6 +375,8 @@ describe("Form client GET interception", () => {
       0,
       "navigate",
       "push",
+      undefined,
+      false,
     );
   });
 


### PR DESCRIPTION
Closes #639.

## What this changes

`router.push()` / `router.replace()` / `router.refresh()` now publish a deferred router-state promise into the browser's `useState` slot the moment the programmatic call is made, instead of dispatching the new tree only at commit. `BrowserRoot` unwraps the slot with `use()`, so any render during the RSC fetch suspends with transition priority and the previous UI stays visible. `useTransition().isPending` latches true for the entire navigation window and drops exactly once, at commit.

`router.push` / `replace` / `refresh` also wrap their synchronous entry in `React.startTransition`, mirroring Next.js's `packages/next/src/client/components/app-router-instance.ts`.

## Why

Before this change, the browser router state was a `useReducer` that only dispatched at commit time. React had nothing in-flight to wait on, so wrapping a programmatic navigation in `useTransition` did not latch `isPending`, and Suspense boundaries inside the destination tree visibly committed their fallbacks during the RSC fetch. Issue #639 describes the user-visible symptom: double-flashing Suspense fallbacks during client navigation triggered by `router.push`. A keyed list remount in a reporter's `movies-ranking` app is one concrete reproduction — the provider chip flashed empty because `isPending` was false while the new server component was still fetching.

Link clicks already worked because they go through a different code path that keeps old UI visible; the gap was specifically programmatic navigations.

## Approach

- Browser router state: `useReducer` → `useState<AppRouterState | Promise<AppRouterState>>` in `server/app-browser-entry.ts`. `BrowserRoot` unwraps the slot via `use()`.
- Introduce a per-navigation `PendingBrowserRouterState` (deferred promise + resolver + settled flag). Programmatic navigations call `beginPendingBrowserRouterState()` synchronously inside `React.startTransition`, which publishes the promise into the state slot. On successful dispatch, `dispatchBrowserTree` resolves it to the reducer output. On supersession, error, or an internal RSC redirect, it's settled with the current committed state so the slot recovers.
- `navigateClientSide` gains a `programmaticTransition` arg, threaded through `__VINEXT_RSC_NAVIGATE__`'s public signature so only `router.push` / `replace` / `refresh` opt into the pending-promise machinery. Link clicks still go through the direct-setter path.
- `_appRouter.push` / `replace` / `refresh` wrap their synchronous entry in `React.startTransition`, matching Next.js.

Scope boundaries (non-goals):

- No change to `<Link>` navigation. Link clicks already preserved the previous UI via the existing transition path.
- No change to server actions. `commitSameUrlNavigatePayload` passes `null` for pending state — server actions don't open a user-visible transition.
- The internal RSC-redirect path (`app-browser-entry.ts` around the pathname-mismatch branch) still recurses through `__VINEXT_RSC_NAVIGATE__`. The outer pending is settled before the recursion, so `isPending` briefly flashes false across the redirect hop. A full Next.js-style inline redirect loop is filed as a follow-up.

## Validation

- Added `tests/e2e/app-router/nextjs-compat/router-push-pending.spec.ts` + fixture under `tests/fixtures/app-basic/app/nextjs-compat/router-push-pending/`: same-route search-param `router.push` inside `useTransition` must keep `isPending` true through the SSR delay and drop to false once the server filter commits.
- `vp exec playwright test tests/e2e/app-router/nextjs-compat/router-push-pending.spec.ts -c tests/e2e/app-router/nextjs-compat/playwright.nextjs-compat.config.ts` — passes.
- `vp exec playwright test tests/e2e/app-router/nextjs-compat/search-params-key.spec.ts -c tests/e2e/app-router/nextjs-compat/playwright.nextjs-compat.config.ts` — passes (no regression in the existing search-param navigation spec).
- `vp check` — clean (format, lint, type).
- Manually verified against a user-reported reproduction (keyed provider-chip list in `movies-ranking`) that the mid-navigation flash no longer occurs.

## Risks / follow-ups

- The internal RSC-redirect recursion at `navigateRsc` remains. A follow-up issue converts it into an inline loop inside `navigateRsc` so a single deferred promise can span all redirect hops, the way Next.js's action queue does. Until then, `isPending` across a same-call internal redirect is not perfectly continuous.
- `PendingBrowserRouterState` settlement is diffused across multiple bailout sites in `navigateRsc`. Each is idempotent via the `settled` flag, but a future early return will need to remember to settle. A `try / finally` wrapper around the body is a reasonable follow-up cleanup.