### PR TITLE
fix(app-router): keep isPending true across RSC-level redirects

### DIFF
--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -968,250 +968,227 @@ async function main(): Promise<void> {
     previousNextUrlOverride?: string | null,
     programmaticTransition = false,
   ): Promise<void> {
-    if (redirectDepth > 10) {
-      console.error(
-        "[vinext] Too many RSC redirects — aborting navigation to prevent infinite loop.",
-      );
-      window.location.href = href;
-      return;
-    }
-
     let _snapshotPending = false;
     let pendingRouterState: PendingBrowserRouterState | null = null;
-    // Hoist navId above try so the catch block can guard against hard-navigating
-    // to a stale URL when this navigation has already been superseded.
+    // Hoist navId above try so the catch and finally blocks can reference it.
     const navId = ++activeNavigationId;
+
+    // Loop variables for inline redirect following. On a redirect, these are
+    // updated and the loop continues without returning or re-entering navigateRsc,
+    // so a single pendingRouterState spans all hops and isPending never flashes.
+    let currentHref = href;
+    let currentHistoryMode = historyUpdateMode;
+    let currentPrevNextUrl = previousNextUrlOverride;
+    let redirectCount = redirectDepth;
+
     try {
       if (programmaticTransition) {
         pendingRouterState = beginPendingBrowserRouterState();
       }
 
-      const url = new URL(href, window.location.origin);
-      const rscUrl = toRscUrl(url.pathname + url.search);
-      const requestState = getRequestState(navigationKind, previousNextUrlOverride);
-      const requestInterceptionContext = requestState.interceptionContext;
-      const requestPreviousNextUrl = requestState.previousNextUrl;
-
-      // Compare against previous pending navigation first, then committed state.
-      // This avoids isSameRoute misclassification during rapid back-to-back clicks.
-      const navState = getClientNavigationState();
-      const currentPath =
-        navState?.pendingPathname ??
-        navState?.cachedPathname ??
-        stripBasePath(window.location.pathname, __basePath);
-
-      const targetPath = stripBasePath(url.pathname, __basePath);
-      const isSameRoute = targetPath === currentPath;
-
-      // Set this navigation as the pending pathname, overwriting any previous.
-      // Pass navId so only this navigation (or a newer one) can clear it later.
-      setPendingPathname(url.pathname, navId);
-
-      const elementsAtNavStart = getBrowserRouterState().elements;
-      const mountedSlotsHeader = getMountedSlotIdsHeader(elementsAtNavStart);
-      const cachedRoute = getVisitedResponse(
-        rscUrl,
-        requestInterceptionContext,
-        mountedSlotsHeader,
-        navigationKind,
-      );
-      if (cachedRoute) {
-        // Check stale-navigation before and after createFromFetch. The pre-check
-        // avoids wasted parse work; the post-check catches supersessions that
-        // occur during the await. createFromFetch on a buffered response is fast
-        // but still async, so the window exists. The non-cached path (below) places
-        // its heavyweight async steps (fetch, snapshotRscResponse, createFromFetch)
-        // between navId checks consistently; the cached path omits the check between
-        // createClientNavigationRenderSnapshot (synchronous) and createFromFetch
-        // because there is no await in that gap.
-        if (navId !== activeNavigationId) {
-          settlePendingBrowserRouterState(pendingRouterState);
+      while (true) {
+        if (redirectCount > 10) {
+          console.error(
+            "[vinext] Too many RSC redirects — aborting navigation to prevent infinite loop.",
+          );
+          window.location.href = currentHref;
           return;
         }
-        const cachedParams = cachedRoute.params;
-        // createClientNavigationRenderSnapshot is synchronous (URL parsing + param
-        // wrapping only) — no stale-navigation recheck needed between here and the
-        // next await.
-        const cachedNavigationSnapshot = createClientNavigationRenderSnapshot(href, cachedParams);
-        const cachedPayload = normalizeAppElementsPromise(
-          createFromFetch<AppWireElements>(
-            Promise.resolve(restoreRscResponse(cachedRoute.response)),
-          ),
+
+        const url = new URL(currentHref, window.location.origin);
+        const rscUrl = toRscUrl(url.pathname + url.search);
+        const requestState = getRequestState(navigationKind, currentPrevNextUrl);
+        const requestInterceptionContext = requestState.interceptionContext;
+        const requestPreviousNextUrl = requestState.previousNextUrl;
+
+        // Compare against previous pending navigation first, then committed state.
+        // This avoids isSameRoute misclassification during rapid back-to-back clicks.
+        const navState = getClientNavigationState();
+        const currentPath =
+          navState?.pendingPathname ??
+          navState?.cachedPathname ??
+          stripBasePath(window.location.pathname, __basePath);
+
+        const targetPath = stripBasePath(url.pathname, __basePath);
+        const isSameRoute = targetPath === currentPath;
+
+        // Set this navigation as the pending pathname, overwriting any previous.
+        // Pass navId so only this navigation (or a newer one) can clear it later.
+        setPendingPathname(url.pathname, navId);
+
+        const elementsAtNavStart = getBrowserRouterState().elements;
+        const mountedSlotsHeader = getMountedSlotIdsHeader(elementsAtNavStart);
+        const cachedRoute = getVisitedResponse(
+          rscUrl,
+          requestInterceptionContext,
+          mountedSlotsHeader,
+          navigationKind,
         );
-        if (navId !== activeNavigationId) {
-          settlePendingBrowserRouterState(pendingRouterState);
+        if (cachedRoute) {
+          // Check stale-navigation before and after createFromFetch. The pre-check
+          // avoids wasted parse work; the post-check catches supersessions that
+          // occur during the await. createFromFetch on a buffered response is fast
+          // but still async, so the window exists. The non-cached path (below) places
+          // its heavyweight async steps (fetch, snapshotRscResponse, createFromFetch)
+          // between navId checks consistently; the cached path omits the check between
+          // createClientNavigationRenderSnapshot (synchronous) and createFromFetch
+          // because there is no await in that gap.
+          if (navId !== activeNavigationId) return;
+          const cachedParams = cachedRoute.params;
+          // createClientNavigationRenderSnapshot is synchronous (URL parsing + param
+          // wrapping only) — no stale-navigation recheck needed between here and the
+          // next await.
+          const cachedNavigationSnapshot = createClientNavigationRenderSnapshot(
+            currentHref,
+            cachedParams,
+          );
+          const cachedPayload = normalizeAppElementsPromise(
+            createFromFetch<AppWireElements>(
+              Promise.resolve(restoreRscResponse(cachedRoute.response)),
+            ),
+          );
+          if (navId !== activeNavigationId) return;
+          _snapshotPending = true; // Set before renderNavigationPayload
+          try {
+            await renderNavigationPayload(
+              cachedPayload,
+              cachedNavigationSnapshot,
+              currentHref,
+              navId,
+              currentHistoryMode,
+              cachedParams,
+              requestPreviousNextUrl,
+              pendingRouterState,
+              isSameRoute,
+              toActionType(navigationKind),
+            );
+          } finally {
+            // Always clear _snapshotPending so the outer catch does not
+            // double-decrement if renderNavigationPayload throws.
+            _snapshotPending = false;
+          }
           return;
         }
+
+        // Continue using the slot state captured at navigation start for fetches
+        // and prefetch compatibility decisions.
+
+        let navResponse: Response | undefined;
+        let navResponseUrl: string | null = null;
+        if (navigationKind !== "refresh") {
+          const prefetchedResponse = consumePrefetchResponse(
+            rscUrl,
+            requestInterceptionContext,
+            mountedSlotsHeader,
+          );
+          if (prefetchedResponse) {
+            navResponse = restoreRscResponse(prefetchedResponse, false);
+            navResponseUrl = prefetchedResponse.url;
+          }
+        }
+
+        if (!navResponse) {
+          const requestHeaders = createRscRequestHeaders(requestInterceptionContext);
+          if (mountedSlotsHeader) {
+            requestHeaders.set("X-Vinext-Mounted-Slots", mountedSlotsHeader);
+          }
+          navResponse = await fetch(rscUrl, {
+            headers: requestHeaders,
+            credentials: "include",
+          });
+        }
+
+        if (navId !== activeNavigationId) return;
+
+        const finalUrl = new URL(navResponseUrl ?? navResponse.url, window.location.origin);
+        const requestedUrl = new URL(rscUrl, window.location.origin);
+
+        if (finalUrl.pathname !== requestedUrl.pathname) {
+          // Server-side redirect: update the URL in history and loop to fetch
+          // the destination without settling pendingRouterState. This keeps
+          // isPending true across all redirect hops instead of flashing false.
+          const destinationPath = finalUrl.pathname.replace(/\.rsc$/, "") + finalUrl.search;
+          replaceHistoryStateWithoutNotify(
+            createHistoryStateWithPreviousNextUrl(null, requestPreviousNextUrl),
+            "",
+            destinationPath,
+          );
+
+          currentHref = destinationPath;
+          // URL already written above; the commit effect must not push/replace again.
+          currentHistoryMode = undefined;
+          currentPrevNextUrl = requestPreviousNextUrl;
+          redirectCount += 1;
+          continue;
+        }
+
+        let navParams: Record<string, string | string[]> = {};
+        const paramsHeader = navResponse.headers.get("X-Vinext-Params");
+        if (paramsHeader) {
+          try {
+            navParams = JSON.parse(decodeURIComponent(paramsHeader)) as Record<
+              string,
+              string | string[]
+            >;
+          } catch {
+            // navParams stays as {}
+          }
+        }
+        // Build snapshot from local params, not latestClientParams
+        const navigationSnapshot = createClientNavigationRenderSnapshot(currentHref, navParams);
+
+        const responseSnapshot = await snapshotRscResponse(navResponse);
+
+        if (navId !== activeNavigationId) return;
+
+        const rscPayload = normalizeAppElementsPromise(
+          createFromFetch<AppWireElements>(Promise.resolve(restoreRscResponse(responseSnapshot))),
+        );
+
+        if (navId !== activeNavigationId) return;
+
         _snapshotPending = true; // Set before renderNavigationPayload
         try {
           await renderNavigationPayload(
-            cachedPayload,
-            cachedNavigationSnapshot,
-            href,
+            rscPayload,
+            navigationSnapshot,
+            currentHref,
             navId,
-            historyUpdateMode,
-            cachedParams,
+            currentHistoryMode,
+            navParams,
             requestPreviousNextUrl,
             pendingRouterState,
             isSameRoute,
             toActionType(navigationKind),
           );
         } finally {
-          // Always clear _snapshotPending so the outer catch does not
-          // double-decrement if renderNavigationPayload throws.
+          // Always clear _snapshotPending after renderNavigationPayload returns or
+          // throws. renderNavigationPayload's inner catch already calls
+          // commitClientNavigationState() on synchronous errors and re-throws, so
+          // the outer catch must not call it again. Clearing here prevents the outer
+          // catch from double-decrementing navigationSnapshotActiveCount.
           _snapshotPending = false;
         }
-        return;
-      }
-
-      // Continue using the slot state captured at navigation start for fetches
-      // and prefetch compatibility decisions.
-
-      let navResponse: Response | undefined;
-      let navResponseUrl: string | null = null;
-      if (navigationKind !== "refresh") {
-        const prefetchedResponse = consumePrefetchResponse(
+        // Don't cache the response if this navigation was superseded during
+        // renderNavigationPayload's await — the elements were never dispatched.
+        if (navId !== activeNavigationId) return;
+        // Store the visited response only after renderNavigationPayload succeeds.
+        // If we stored it before and renderNavigationPayload threw, a future
+        // back/forward navigation could replay a snapshot from a navigation that
+        // never actually rendered successfully.
+        const resolvedElements = await rscPayload;
+        const metadata = readAppElementsMetadata(resolvedElements);
+        storeVisitedResponseSnapshot(
           rscUrl,
-          requestInterceptionContext,
-          mountedSlotsHeader,
-        );
-        if (prefetchedResponse) {
-          navResponse = restoreRscResponse(prefetchedResponse, false);
-          navResponseUrl = prefetchedResponse.url;
-        }
-      }
-
-      if (!navResponse) {
-        const requestHeaders = createRscRequestHeaders(requestInterceptionContext);
-        if (mountedSlotsHeader) {
-          requestHeaders.set("X-Vinext-Mounted-Slots", mountedSlotsHeader);
-        }
-        navResponse = await fetch(rscUrl, {
-          headers: requestHeaders,
-          credentials: "include",
-        });
-      }
-
-      if (navId !== activeNavigationId) {
-        settlePendingBrowserRouterState(pendingRouterState);
-        return;
-      }
-
-      const finalUrl = new URL(navResponseUrl ?? navResponse.url, window.location.origin);
-      const requestedUrl = new URL(rscUrl, window.location.origin);
-
-      if (finalUrl.pathname !== requestedUrl.pathname) {
-        const destinationPath = finalUrl.pathname.replace(/\.rsc$/, "") + finalUrl.search;
-        replaceHistoryStateWithoutNotify(
-          createHistoryStateWithPreviousNextUrl(null, requestPreviousNextUrl),
-          "",
-          destinationPath,
-        );
-
-        const navigate = window.__VINEXT_RSC_NAVIGATE__;
-        if (!navigate) {
-          settlePendingBrowserRouterState(pendingRouterState);
-          window.location.href = destinationPath;
-          return;
-        }
-
-        // Hand ownership of the pending transition off before recursing. The
-        // recursive call will not receive pendingRouterState (programmaticTransition=false),
-        // so if we left it unsettled its promise would orphan in the useState slot
-        // until the next programmatic push caught it via the !settled branch in
-        // beginPendingBrowserRouterState. Settling here with the current committed
-        // state makes isPending flip false mid-redirect — a deliberate tradeoff
-        // over leaning on React's internal transition-completion heuristic.
-        settlePendingBrowserRouterState(pendingRouterState);
-
-        // The URL has already been updated via replaceHistoryStateWithoutNotify above,
-        // so the recursive navigation should NOT push/replace again. Pass undefined
-        // for historyUpdateMode to make the commit effect a no-op for history updates.
-        return navigate(
-          destinationPath,
-          redirectDepth + 1,
-          navigationKind,
-          undefined,
-          requestPreviousNextUrl,
-          false,
-        );
-      }
-
-      let navParams: Record<string, string | string[]> = {};
-      const paramsHeader = navResponse.headers.get("X-Vinext-Params");
-      if (paramsHeader) {
-        try {
-          navParams = JSON.parse(decodeURIComponent(paramsHeader)) as Record<
-            string,
-            string | string[]
-          >;
-        } catch {
-          // navParams stays as {}
-        }
-      }
-      // Build snapshot from local params, not latestClientParams
-      const navigationSnapshot = createClientNavigationRenderSnapshot(href, navParams);
-
-      const responseSnapshot = await snapshotRscResponse(navResponse);
-
-      if (navId !== activeNavigationId) {
-        settlePendingBrowserRouterState(pendingRouterState);
-        return;
-      }
-
-      const rscPayload = normalizeAppElementsPromise(
-        createFromFetch<AppWireElements>(Promise.resolve(restoreRscResponse(responseSnapshot))),
-      );
-
-      if (navId !== activeNavigationId) {
-        settlePendingBrowserRouterState(pendingRouterState);
-        return;
-      }
-
-      _snapshotPending = true; // Set before renderNavigationPayload
-      try {
-        await renderNavigationPayload(
-          rscPayload,
-          navigationSnapshot,
-          href,
-          navId,
-          historyUpdateMode,
+          resolveVisitedResponseInterceptionContext(
+            requestInterceptionContext,
+            metadata.interceptionContext,
+          ),
+          responseSnapshot,
           navParams,
-          requestPreviousNextUrl,
-          pendingRouterState,
-          isSameRoute,
-          toActionType(navigationKind),
         );
-      } finally {
-        // Always clear _snapshotPending after renderNavigationPayload returns or
-        // throws. renderNavigationPayload's inner catch already calls
-        // commitClientNavigationState() on synchronous errors and re-throws, so
-        // the outer catch must not call it again. Clearing here prevents the outer
-        // catch from double-decrementing navigationSnapshotActiveCount.
-        _snapshotPending = false;
-      }
-      // Don't cache the response if this navigation was superseded during
-      // renderNavigationPayload's await — the elements were never dispatched.
-      if (navId !== activeNavigationId) {
-        settlePendingBrowserRouterState(pendingRouterState);
         return;
       }
-      // Store the visited response only after renderNavigationPayload succeeds.
-      // If we stored it before and renderNavigationPayload threw, a future
-      // back/forward navigation could replay a snapshot from a navigation that
-      // never actually rendered successfully.
-      const resolvedElements = await rscPayload;
-      const metadata = readAppElementsMetadata(resolvedElements);
-      storeVisitedResponseSnapshot(
-        rscUrl,
-        resolveVisitedResponseInterceptionContext(
-          requestInterceptionContext,
-          metadata.interceptionContext,
-        ),
-        responseSnapshot,
-        navParams,
-      );
-      return;
     } catch (error) {
       // Only decrement counter if snapshot was activated but not yet committed.
       // renderNavigationPayload clears _snapshotPending (via its inner try-finally)
@@ -1220,20 +1197,23 @@ async function main(): Promise<void> {
         _snapshotPending = false;
         commitClientNavigationState(navId);
       }
+      // Don't hard-navigate to a stale URL if this navigation was superseded by
+      // a newer one — the newer navigation is already in flight and would be clobbered.
+      if (navId !== activeNavigationId) return;
+      console.error("[vinext] RSC navigation error:", error);
+      window.location.href = currentHref;
+    } finally {
+      // Single settlement site: covers normal return, early returns on stale-id
+      // checks, and error paths. The finally runs even when the catch returns.
+      // settlePendingBrowserRouterState is idempotent via the settled flag.
       settlePendingBrowserRouterState(pendingRouterState);
-      // Clear pending pathname on error so subsequent navigations compare correctly.
-      // Only clear if this is still the active navigation — a newer navigation
-      // has already overwritten pendingPathname with its own target.
+      // Clear pendingPathname on all exit paths. On the success path this fires
+      // before the RAF commit effect, but commitClientNavigationState() in the
+      // commit effect clears it again — that double-clear is idempotent. Skipped
+      // when superseded so a newer navigation's pendingPathname is not disturbed.
       if (navId === activeNavigationId) {
         clearPendingPathname(navId);
       }
-      // Don't hard-navigate to a stale URL if this navigation was superseded by
-      // a newer one — the newer navigation is already in flight and would be clobbered.
-      if (navId !== activeNavigationId) {
-        return;
-      }
-      console.error("[vinext] RSC navigation error:", error);
-      window.location.href = href;
     }
   };
 

--- a/tests/e2e/app-router/nextjs-compat/router-push-pending.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/router-push-pending.spec.ts
@@ -4,6 +4,8 @@
  * Next.js references:
  * - https://github.com/vercel/next.js/blob/canary/test/e2e/use-link-status/index.test.ts
  * - https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/navigation/navigation.test.ts
+ * - https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/navigation/navigation.test.ts#L482
+ *   (redirect-with-loading: verifies redirect only triggers once and does not flicker)
  *
  * The contract we care about here is that a programmatic App Router navigation
  * started inside useTransition should flip isPending immediately and keep it
@@ -41,5 +43,97 @@ test.describe("Next.js compat: router.push pending state (browser)", () => {
     await expect(page.locator("#pending-state")).toHaveText("idle", {
       timeout: 10_000,
     });
+  });
+
+  /**
+   * Ported from Next.js: test/e2e/app-dir/navigation/navigation.test.ts
+   * https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/navigation/navigation.test.ts#L482
+   *
+   * When router.push() targets a page whose server component calls redirect(),
+   * isPending must stay true continuously from the push until the final
+   * destination commits. Previously, a bandage settle fired before the
+   * recursive navigate() call, causing isPending to flash false mid-redirect.
+   *
+   * Detection strategy: install a MutationObserver before click, record every
+   * text value #pending-state takes. After the destination commits, assert
+   * that no "idle" value appeared before the final "idle" (i.e. no mid-redirect
+   * flash). Because the destination page does not render #pending-state, we
+   * track when the element is removed as the end-of-navigation signal.
+   */
+  test("push to server-redirecting page keeps useTransition pending through redirect", async ({
+    page,
+  }) => {
+    await page.goto(`${BASE}/nextjs-compat/router-push-pending`);
+    await waitForAppRouterHydration(page);
+
+    await expect(page.locator("#pending-state")).toHaveText("idle");
+
+    // Install a MutationObserver to record every text value of #pending-state
+    // before clicking. This captures the state transitions during the redirect.
+    await page.evaluate(() => {
+      const log: string[] = [];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (window as any).__pendingLog = log;
+
+      const el = document.querySelector("#pending-state");
+      if (!el) return;
+
+      // Record initial value
+      log.push(el.textContent ?? "");
+
+      const obs = new MutationObserver(() => {
+        // el may have been detached; try to re-query
+        const current = document.querySelector("#pending-state");
+        if (current) {
+          log.push(current.textContent ?? "");
+        } else {
+          // Element removed from DOM — navigation committed to destination page
+          log.push("__removed__");
+          obs.disconnect();
+        }
+      });
+      obs.observe(document.body, { childList: true, subtree: true, characterData: true });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (window as any).__pendingObs = obs;
+    });
+
+    await page.click("#push-redirect");
+
+    // Wait for destination page to appear — the redirect committed
+    await expect(page.locator("#redirect-destination")).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Collect the log. The observer may still be running; disconnect it.
+    const log = await page.evaluate(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const w = window as any;
+      (w.__pendingObs as MutationObserver | undefined)?.disconnect();
+      return w.__pendingLog as string[];
+    });
+
+    // The sequence must be: "idle" (before click) then one or more "pending"
+    // entries, then possibly "__removed__" once the destination renders.
+    // Any "idle" between the first "pending" and the final removal is the bug.
+    const firstPendingIdx = log.indexOf("pending");
+    expect(
+      firstPendingIdx,
+      `isPending never became "pending". Log: ${JSON.stringify(log)}`,
+    ).toBeGreaterThan(-1);
+
+    // Slice from first "pending" to the last observed value before removal.
+    const afterFirstPending = log.slice(firstPendingIdx);
+    const removedIdx = afterFirstPending.indexOf("__removed__");
+    const beforeRemoval =
+      removedIdx >= 0 ? afterFirstPending.slice(0, removedIdx) : afterFirstPending;
+
+    const idleFlash = beforeRemoval.indexOf("idle");
+    expect(
+      idleFlash,
+      `isPending flashed "idle" mid-redirect at index ${idleFlash}. Full log: ${JSON.stringify(log)}`,
+    ).toBe(-1);
+
+    // Final state: URL is at destination
+    expect(page.url()).toContain("/nextjs-compat/router-push-pending-destination");
   });
 });

--- a/tests/fixtures/app-basic/app/nextjs-compat/router-push-pending-destination/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/router-push-pending-destination/page.tsx
@@ -1,0 +1,9 @@
+// Final destination for the router-push-pending redirect test.
+// The #redirect-destination element signals that the navigation fully committed.
+export default function RouterPushPendingDestinationPage() {
+  return (
+    <div>
+      <p id="redirect-destination">Redirect destination</p>
+    </div>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/router-push-pending-redirect/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/router-push-pending-redirect/page.tsx
@@ -1,0 +1,8 @@
+import { redirect } from "next/navigation";
+
+// Server component that immediately redirects to the destination.
+// Used to test that isPending stays true through an RSC-level redirect
+// when triggered by router.push() inside startTransition.
+export default function RouterPushPendingRedirectPage() {
+  redirect("/nextjs-compat/router-push-pending-destination");
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/router-push-pending/pending-client.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/router-push-pending/pending-client.tsx
@@ -23,6 +23,16 @@ export function PendingClient() {
       >
         Push alpha
       </button>
+      <button
+        id="push-redirect"
+        onClick={() => {
+          startTransition(() => {
+            router.push("/nextjs-compat/router-push-pending-redirect");
+          });
+        }}
+      >
+        Push redirect
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
## What this changes

`router.push('/a')` where `/a`'s server component calls `redirect('/b')` no longer causes `useTransition().isPending` to flash `false` mid-redirect. The pending indicator stays `true` continuously from the push through the final destination commit.

## Why

PR #868 latched `isPending` during programmatic navigations via a deferred promise in browser router state. But when the RSC response redirected (307), `navigateRsc` detected the response URL differing from the requested URL, settled the deferred promise to avoid orphaning it, then recursed with `programmaticTransition=false`. The settle fired before the recursive call, so React resolved the transition and `isPending` dropped to `false` during the hop.

The bug was explicitly documented in the bandage comment before the recursive call:

> Settling here with the current committed state makes isPending flip false mid-redirect -- a deliberate tradeoff over leaning on React's internal transition-completion heuristic.

Issue #869 asked to remove that tradeoff.

## Approach

Convert the recursive redirect follow into an inline `while(true)` loop inside `navigateRsc`. Loop variables (`currentHref`, `currentHistoryMode`, `currentPrevNextUrl`, `redirectCount`) are updated on each redirect hop; the loop `continue`s without re-entering `navigateRsc`. A single `pendingRouterState` is created before the loop and lives until the `finally` block, so `isPending` stays `true` across all hops.

The scattered `settlePendingBrowserRouterState(pendingRouterState)` calls inside the try body (early-return stale-id guards) are removed. The `finally` owns the single settlement site and is idempotent via the `settled` flag on `PendingBrowserRouterState`.

Scope: this is the minimal fix described in issue #869. The `NavigationTask`-based refactor in `nathan/navigation-architecture.md` is explicitly out of scope.

## Validation

New E2E test (`router-push-pending.spec.ts`) installs a `MutationObserver` before click, records every text value of `#pending-state`, and asserts no `"idle"` entry appears between the first `"pending"` and the destination commit.

Test log on unmodified code: `["idle","pending","idle","__removed__"]` -- the mid-redirect flash at index 2 fails the assertion.

Test log after fix: `["idle","pending","__removed__"]` -- no idle flash.

- New redirect E2E test: passes
- Existing same-route pending E2E test: passes
- Existing search-params-key E2E tests: pass
- All 62 nextjs-compat E2E tests: pass
- `vp check`: clean

Ported test from Next.js:
https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/navigation/navigation.test.ts#L482

Closes #869.

## Risks / follow-ups

- The `redirectDepth` parameter on `navigateRsc` is now vestigial (no caller passes non-zero since recursion is gone). Left as-is to avoid an unnecessary signature churn; can be cleaned up in a separate pass.
- Next.js history semantics for "push that redirects" (should it land as push or replace in history?) are unchanged; this PR is about `isPending` correctness only.