### PR TITLE
Render intercept route layouts inside App Router slots

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -175,9 +175,12 @@ export function generateRscEntry(
       if (slot.layoutPath) getImportVar(slot.layoutPath);
       if (slot.loadingPath) getImportVar(slot.loadingPath);
       if (slot.errorPath) getImportVar(slot.errorPath);
-      // Register intercepting route page modules
+      // Register intercepting route modules
       for (const ir of slot.interceptingRoutes) {
         getImportVar(ir.pagePath);
+        for (const layoutPath of ir.layoutPaths) {
+          getImportVar(layoutPath);
+        }
       }
     }
   }
@@ -192,6 +195,7 @@ export function generateRscEntry(
         (ir) => `        {
           convention: ${JSON.stringify(ir.convention)},
           targetPattern: ${JSON.stringify(ir.targetPattern)},
+          layouts: [${ir.layoutPaths.map((layoutPath) => getImportVar(layoutPath)).join(", ")}],
           page: ${getImportVar(ir.pagePath)},
           params: ${JSON.stringify(ir.params)},
         }`,
@@ -935,7 +939,7 @@ function mergeMatchedParams(sourceParams, targetParams) {
 }
 
 // Build a global intercepting route lookup for RSC navigation.
-// Maps target URL patterns to { sourceRouteIndex, slotKey, interceptPage, params }.
+// Maps target URL patterns to { sourceRouteIndex, slotKey, interceptPage, interceptLayouts, params }.
 const interceptLookup = [];
 for (let ri = 0; ri < routes.length; ri++) {
   const r = routes[ri];
@@ -948,6 +952,7 @@ for (let ri = 0; ri < routes.length; ri++) {
         slotKey,
         targetPattern: intercept.targetPattern,
         targetPatternParts: intercept.targetPattern.split("/").filter(Boolean),
+        layouts: intercept.layouts,
         page: intercept.page,
         params: intercept.params,
       });
@@ -1131,6 +1136,7 @@ async function buildPageElements(route, params, routePath, pageRequest) {
       opts && opts.interceptSlotKey && opts.interceptPage
         ? {
             [opts.interceptSlotKey]: {
+              layoutModules: opts.interceptLayouts || null,
               pageModule: opts.interceptPage,
               params: opts.interceptParams || params,
             },
@@ -1892,6 +1898,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           toInterceptOpts(intercept) {
             return {
               interceptionContext: interceptionContextHeader,
+              interceptLayouts: intercept.layouts,
               interceptSlotKey: intercept.slotKey,
               interceptPage: intercept.page,
               interceptParams: intercept.matchedParams,
@@ -2416,6 +2423,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     toInterceptOpts(intercept) {
       return {
         interceptionContext: interceptionContextHeader,
+        interceptLayouts: intercept.layouts,
         interceptSlotKey: intercept.slotKey,
         interceptPage: intercept.page,
         interceptParams: intercept.matchedParams,

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -195,7 +195,7 @@ export function generateRscEntry(
         (ir) => `        {
           convention: ${JSON.stringify(ir.convention)},
           targetPattern: ${JSON.stringify(ir.targetPattern)},
-          layouts: [${ir.layoutPaths.map((layoutPath) => getImportVar(layoutPath)).join(", ")}],
+          interceptLayouts: [${ir.layoutPaths.map((layoutPath) => getImportVar(layoutPath)).join(", ")}],
           page: ${getImportVar(ir.pagePath)},
           params: ${JSON.stringify(ir.params)},
         }`,
@@ -952,7 +952,7 @@ for (let ri = 0; ri < routes.length; ri++) {
         slotKey,
         targetPattern: intercept.targetPattern,
         targetPatternParts: intercept.targetPattern.split("/").filter(Boolean),
-        layouts: intercept.layouts,
+        interceptLayouts: intercept.interceptLayouts,
         page: intercept.page,
         params: intercept.params,
       });
@@ -1898,7 +1898,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           toInterceptOpts(intercept) {
             return {
               interceptionContext: interceptionContextHeader,
-              interceptLayouts: intercept.layouts,
+              interceptLayouts: intercept.interceptLayouts,
               interceptSlotKey: intercept.slotKey,
               interceptPage: intercept.page,
               interceptParams: intercept.matchedParams,
@@ -2423,7 +2423,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     toInterceptOpts(intercept) {
       return {
         interceptionContext: interceptionContextHeader,
-        interceptLayouts: intercept.layouts,
+        interceptLayouts: intercept.interceptLayouts,
         interceptSlotKey: intercept.slotKey,
         interceptPage: intercept.page,
         interceptParams: intercept.matchedParams,

--- a/packages/vinext/src/routing/app-router.ts
+++ b/packages/vinext/src/routing/app-router.ts
@@ -908,7 +908,13 @@ function collectInterceptingPages(
   appDir: string,
   results: InterceptingRoute[],
   matcher: ValidFileMatcher,
+  parentLayoutPaths: readonly string[] = [],
 ): void {
+  const currentLayoutPath = findFile(currentDir, "layout", matcher);
+  const layoutPaths = currentLayoutPath
+    ? [...parentLayoutPaths, currentLayoutPath]
+    : parentLayoutPaths;
+
   // Check for page.tsx in current directory
   const page = findFile(currentDir, "page", matcher);
   if (page) {
@@ -923,7 +929,7 @@ function collectInterceptingPages(
     if (targetPattern) {
       results.push({
         convention,
-        layoutPaths: collectInterceptLayoutPaths(interceptRoot, currentDir, matcher),
+        layoutPaths: [...layoutPaths],
         targetPattern: targetPattern.pattern,
         pagePath: page,
         params: targetPattern.params,
@@ -947,34 +953,9 @@ function collectInterceptingPages(
       appDir,
       results,
       matcher,
+      layoutPaths,
     );
   }
-}
-
-function collectInterceptLayoutPaths(
-  interceptRoot: string,
-  currentDir: string,
-  matcher: ValidFileMatcher,
-): string[] {
-  const relativeDir = path.relative(interceptRoot, currentDir);
-  const relativeSegments = relativeDir === "" ? [] : relativeDir.split(path.sep);
-  const layoutPaths: string[] = [];
-  let scanDir = interceptRoot;
-
-  const rootLayout = findFile(scanDir, "layout", matcher);
-  if (rootLayout) {
-    layoutPaths.push(rootLayout);
-  }
-
-  for (const segment of relativeSegments) {
-    scanDir = path.join(scanDir, segment);
-    const layoutPath = findFile(scanDir, "layout", matcher);
-    if (layoutPath) {
-      layoutPaths.push(layoutPath);
-    }
-  }
-
-  return layoutPaths;
 }
 
 /**

--- a/packages/vinext/src/routing/app-router.ts
+++ b/packages/vinext/src/routing/app-router.ts
@@ -31,6 +31,8 @@ export type InterceptingRoute = {
   targetPattern: string;
   /** Absolute path to the intercepting page component */
   pagePath: string;
+  /** Absolute layout paths inside the intercepting route tree, outermost to innermost */
+  layoutPaths: string[];
   /** Parameter names for dynamic segments */
   params: string[];
 };
@@ -921,6 +923,7 @@ function collectInterceptingPages(
     if (targetPattern) {
       results.push({
         convention,
+        layoutPaths: collectInterceptLayoutPaths(interceptRoot, currentDir, matcher),
         targetPattern: targetPattern.pattern,
         pagePath: page,
         params: targetPattern.params,
@@ -946,6 +949,32 @@ function collectInterceptingPages(
       matcher,
     );
   }
+}
+
+function collectInterceptLayoutPaths(
+  interceptRoot: string,
+  currentDir: string,
+  matcher: ValidFileMatcher,
+): string[] {
+  const relativeDir = path.relative(interceptRoot, currentDir);
+  const relativeSegments = relativeDir === "" ? [] : relativeDir.split(path.sep);
+  const layoutPaths: string[] = [];
+  let scanDir = interceptRoot;
+
+  const rootLayout = findFile(scanDir, "layout", matcher);
+  if (rootLayout) {
+    layoutPaths.push(rootLayout);
+  }
+
+  for (const segment of relativeSegments) {
+    scanDir = path.join(scanDir, segment);
+    const layoutPath = findFile(scanDir, "layout", matcher);
+    if (layoutPath) {
+      layoutPaths.push(layoutPath);
+    }
+  }
+
+  return layoutPaths;
 }
 
 /**

--- a/packages/vinext/src/server/app-page-route-wiring.tsx
+++ b/packages/vinext/src/server/app-page-route-wiring.tsx
@@ -496,8 +496,8 @@ export function buildAppPageElements<
     let slotElement: ReactNode = <SlotComponent {...slotProps} />;
     const interceptLayouts = slotOverride?.layoutModules ?? [];
 
-    for (let index = interceptLayouts.length; index > 0; index--) {
-      const interceptLayoutComponent = getDefaultExport(interceptLayouts[index - 1]);
+    for (let layoutIndex = interceptLayouts.length - 1; layoutIndex >= 0; layoutIndex--) {
+      const interceptLayoutComponent = getDefaultExport(interceptLayouts[layoutIndex]);
       if (!interceptLayoutComponent) {
         continue;
       }

--- a/packages/vinext/src/server/app-page-route-wiring.tsx
+++ b/packages/vinext/src/server/app-page-route-wiring.tsx
@@ -484,8 +484,9 @@ export function buildAppPageElements<
       continue;
     }
 
+    const slotThenableParams = options.makeThenableParams(slotParams);
     const slotProps: Record<string, unknown> = {
-      params: options.makeThenableParams(slotParams),
+      params: slotThenableParams,
     };
     if (slotOverride?.props) {
       Object.assign(slotProps, slotOverride.props);
@@ -493,15 +494,16 @@ export function buildAppPageElements<
 
     const SlotComponent = slotComponent;
     let slotElement: ReactNode = <SlotComponent {...slotProps} />;
+    const interceptLayouts = slotOverride?.layoutModules ?? [];
 
-    for (let index = (slotOverride?.layoutModules?.length ?? 0) - 1; index >= 0; index--) {
-      const interceptLayoutComponent = getDefaultExport(slotOverride?.layoutModules?.[index]);
+    for (let index = interceptLayouts.length; index > 0; index--) {
+      const interceptLayoutComponent = getDefaultExport(interceptLayouts[index - 1]);
       if (!interceptLayoutComponent) {
         continue;
       }
       const InterceptLayoutComponent = interceptLayoutComponent;
       slotElement = (
-        <InterceptLayoutComponent params={options.makeThenableParams(slotParams)}>
+        <InterceptLayoutComponent params={slotThenableParams}>
           {slotElement}
         </InterceptLayoutComponent>
       );
@@ -511,9 +513,7 @@ export function buildAppPageElements<
     if (slotLayoutComponent) {
       const SlotLayoutComponent = slotLayoutComponent;
       slotElement = (
-        <SlotLayoutComponent params={options.makeThenableParams(slotParams)}>
-          {slotElement}
-        </SlotLayoutComponent>
+        <SlotLayoutComponent params={slotThenableParams}>{slotElement}</SlotLayoutComponent>
       );
     }
 

--- a/packages/vinext/src/server/app-page-route-wiring.tsx
+++ b/packages/vinext/src/server/app-page-route-wiring.tsx
@@ -74,6 +74,7 @@ export type AppPageRouteWiringRoute<
 };
 
 export type AppPageSlotOverride<TModule extends AppPageModule = AppPageModule> = {
+  layoutModules?: readonly (TModule | null | undefined)[] | null;
   pageModule: TModule;
   params?: AppPageParams;
   props?: Readonly<Record<string, unknown>>;
@@ -492,6 +493,19 @@ export function buildAppPageElements<
 
     const SlotComponent = slotComponent;
     let slotElement: ReactNode = <SlotComponent {...slotProps} />;
+
+    for (let index = (slotOverride?.layoutModules?.length ?? 0) - 1; index >= 0; index--) {
+      const interceptLayoutComponent = getDefaultExport(slotOverride?.layoutModules?.[index]);
+      if (!interceptLayoutComponent) {
+        continue;
+      }
+      const InterceptLayoutComponent = interceptLayoutComponent;
+      slotElement = (
+        <InterceptLayoutComponent params={options.makeThenableParams(slotParams)}>
+          {slotElement}
+        </InterceptLayoutComponent>
+      );
+    }
 
     const slotLayoutComponent = getDefaultExport(slot.layout);
     if (slotLayoutComponent) {

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -708,7 +708,7 @@ for (let ri = 0; ri < routes.length; ri++) {
         slotKey,
         targetPattern: intercept.targetPattern,
         targetPatternParts: intercept.targetPattern.split("/").filter(Boolean),
-        layouts: intercept.layouts,
+        interceptLayouts: intercept.interceptLayouts,
         page: intercept.page,
         params: intercept.params,
       });
@@ -1619,7 +1619,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           toInterceptOpts(intercept) {
             return {
               interceptionContext: interceptionContextHeader,
-              interceptLayouts: intercept.layouts,
+              interceptLayouts: intercept.interceptLayouts,
               interceptSlotKey: intercept.slotKey,
               interceptPage: intercept.page,
               interceptParams: intercept.matchedParams,
@@ -2102,7 +2102,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     toInterceptOpts(intercept) {
       return {
         interceptionContext: interceptionContextHeader,
-        interceptLayouts: intercept.layouts,
+        interceptLayouts: intercept.interceptLayouts,
         interceptSlotKey: intercept.slotKey,
         interceptPage: intercept.page,
         interceptParams: intercept.matchedParams,
@@ -3032,7 +3032,7 @@ for (let ri = 0; ri < routes.length; ri++) {
         slotKey,
         targetPattern: intercept.targetPattern,
         targetPatternParts: intercept.targetPattern.split("/").filter(Boolean),
-        layouts: intercept.layouts,
+        interceptLayouts: intercept.interceptLayouts,
         page: intercept.page,
         params: intercept.params,
       });
@@ -3949,7 +3949,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           toInterceptOpts(intercept) {
             return {
               interceptionContext: interceptionContextHeader,
-              interceptLayouts: intercept.layouts,
+              interceptLayouts: intercept.interceptLayouts,
               interceptSlotKey: intercept.slotKey,
               interceptPage: intercept.page,
               interceptParams: intercept.matchedParams,
@@ -4432,7 +4432,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     toInterceptOpts(intercept) {
       return {
         interceptionContext: interceptionContextHeader,
-        interceptLayouts: intercept.layouts,
+        interceptLayouts: intercept.interceptLayouts,
         interceptSlotKey: intercept.slotKey,
         interceptPage: intercept.page,
         interceptParams: intercept.matchedParams,
@@ -5363,7 +5363,7 @@ for (let ri = 0; ri < routes.length; ri++) {
         slotKey,
         targetPattern: intercept.targetPattern,
         targetPatternParts: intercept.targetPattern.split("/").filter(Boolean),
-        layouts: intercept.layouts,
+        interceptLayouts: intercept.interceptLayouts,
         page: intercept.page,
         params: intercept.params,
       });
@@ -6274,7 +6274,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           toInterceptOpts(intercept) {
             return {
               interceptionContext: interceptionContextHeader,
-              interceptLayouts: intercept.layouts,
+              interceptLayouts: intercept.interceptLayouts,
               interceptSlotKey: intercept.slotKey,
               interceptPage: intercept.page,
               interceptParams: intercept.matchedParams,
@@ -6757,7 +6757,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     toInterceptOpts(intercept) {
       return {
         interceptionContext: interceptionContextHeader,
-        interceptLayouts: intercept.layouts,
+        interceptLayouts: intercept.interceptLayouts,
         interceptSlotKey: intercept.slotKey,
         interceptPage: intercept.page,
         interceptParams: intercept.matchedParams,
@@ -7717,7 +7717,7 @@ for (let ri = 0; ri < routes.length; ri++) {
         slotKey,
         targetPattern: intercept.targetPattern,
         targetPatternParts: intercept.targetPattern.split("/").filter(Boolean),
-        layouts: intercept.layouts,
+        interceptLayouts: intercept.interceptLayouts,
         page: intercept.page,
         params: intercept.params,
       });
@@ -8631,7 +8631,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           toInterceptOpts(intercept) {
             return {
               interceptionContext: interceptionContextHeader,
-              interceptLayouts: intercept.layouts,
+              interceptLayouts: intercept.interceptLayouts,
               interceptSlotKey: intercept.slotKey,
               interceptPage: intercept.page,
               interceptParams: intercept.matchedParams,
@@ -9114,7 +9114,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     toInterceptOpts(intercept) {
       return {
         interceptionContext: interceptionContextHeader,
-        interceptLayouts: intercept.layouts,
+        interceptLayouts: intercept.interceptLayouts,
         interceptSlotKey: intercept.slotKey,
         interceptPage: intercept.page,
         interceptParams: intercept.matchedParams,
@@ -10051,7 +10051,7 @@ for (let ri = 0; ri < routes.length; ri++) {
         slotKey,
         targetPattern: intercept.targetPattern,
         targetPatternParts: intercept.targetPattern.split("/").filter(Boolean),
-        layouts: intercept.layouts,
+        interceptLayouts: intercept.interceptLayouts,
         page: intercept.page,
         params: intercept.params,
       });
@@ -10962,7 +10962,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           toInterceptOpts(intercept) {
             return {
               interceptionContext: interceptionContextHeader,
-              interceptLayouts: intercept.layouts,
+              interceptLayouts: intercept.interceptLayouts,
               interceptSlotKey: intercept.slotKey,
               interceptPage: intercept.page,
               interceptParams: intercept.matchedParams,
@@ -11445,7 +11445,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     toInterceptOpts(intercept) {
       return {
         interceptionContext: interceptionContextHeader,
-        interceptLayouts: intercept.layouts,
+        interceptLayouts: intercept.interceptLayouts,
         interceptSlotKey: intercept.slotKey,
         interceptPage: intercept.page,
         interceptParams: intercept.matchedParams,
@@ -12375,7 +12375,7 @@ for (let ri = 0; ri < routes.length; ri++) {
         slotKey,
         targetPattern: intercept.targetPattern,
         targetPatternParts: intercept.targetPattern.split("/").filter(Boolean),
-        layouts: intercept.layouts,
+        interceptLayouts: intercept.interceptLayouts,
         page: intercept.page,
         params: intercept.params,
       });
@@ -13653,7 +13653,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           toInterceptOpts(intercept) {
             return {
               interceptionContext: interceptionContextHeader,
-              interceptLayouts: intercept.layouts,
+              interceptLayouts: intercept.interceptLayouts,
               interceptSlotKey: intercept.slotKey,
               interceptPage: intercept.page,
               interceptParams: intercept.matchedParams,
@@ -14136,7 +14136,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     toInterceptOpts(intercept) {
       return {
         interceptionContext: interceptionContextHeader,
-        interceptLayouts: intercept.layouts,
+        interceptLayouts: intercept.interceptLayouts,
         interceptSlotKey: intercept.slotKey,
         interceptPage: intercept.page,
         interceptParams: intercept.matchedParams,

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -695,7 +695,7 @@ function mergeMatchedParams(sourceParams, targetParams) {
 }
 
 // Build a global intercepting route lookup for RSC navigation.
-// Maps target URL patterns to { sourceRouteIndex, slotKey, interceptPage, params }.
+// Maps target URL patterns to { sourceRouteIndex, slotKey, interceptPage, interceptLayouts, params }.
 const interceptLookup = [];
 for (let ri = 0; ri < routes.length; ri++) {
   const r = routes[ri];
@@ -708,6 +708,7 @@ for (let ri = 0; ri < routes.length; ri++) {
         slotKey,
         targetPattern: intercept.targetPattern,
         targetPatternParts: intercept.targetPattern.split("/").filter(Boolean),
+        layouts: intercept.layouts,
         page: intercept.page,
         params: intercept.params,
       });
@@ -891,6 +892,7 @@ async function buildPageElements(route, params, routePath, pageRequest) {
       opts && opts.interceptSlotKey && opts.interceptPage
         ? {
             [opts.interceptSlotKey]: {
+              layoutModules: opts.interceptLayouts || null,
               pageModule: opts.interceptPage,
               params: opts.interceptParams || params,
             },
@@ -1617,6 +1619,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           toInterceptOpts(intercept) {
             return {
               interceptionContext: interceptionContextHeader,
+              interceptLayouts: intercept.layouts,
               interceptSlotKey: intercept.slotKey,
               interceptPage: intercept.page,
               interceptParams: intercept.matchedParams,
@@ -2099,6 +2102,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     toInterceptOpts(intercept) {
       return {
         interceptionContext: interceptionContextHeader,
+        interceptLayouts: intercept.layouts,
         interceptSlotKey: intercept.slotKey,
         interceptPage: intercept.page,
         interceptParams: intercept.matchedParams,
@@ -3015,7 +3019,7 @@ function mergeMatchedParams(sourceParams, targetParams) {
 }
 
 // Build a global intercepting route lookup for RSC navigation.
-// Maps target URL patterns to { sourceRouteIndex, slotKey, interceptPage, params }.
+// Maps target URL patterns to { sourceRouteIndex, slotKey, interceptPage, interceptLayouts, params }.
 const interceptLookup = [];
 for (let ri = 0; ri < routes.length; ri++) {
   const r = routes[ri];
@@ -3028,6 +3032,7 @@ for (let ri = 0; ri < routes.length; ri++) {
         slotKey,
         targetPattern: intercept.targetPattern,
         targetPatternParts: intercept.targetPattern.split("/").filter(Boolean),
+        layouts: intercept.layouts,
         page: intercept.page,
         params: intercept.params,
       });
@@ -3211,6 +3216,7 @@ async function buildPageElements(route, params, routePath, pageRequest) {
       opts && opts.interceptSlotKey && opts.interceptPage
         ? {
             [opts.interceptSlotKey]: {
+              layoutModules: opts.interceptLayouts || null,
               pageModule: opts.interceptPage,
               params: opts.interceptParams || params,
             },
@@ -3943,6 +3949,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           toInterceptOpts(intercept) {
             return {
               interceptionContext: interceptionContextHeader,
+              interceptLayouts: intercept.layouts,
               interceptSlotKey: intercept.slotKey,
               interceptPage: intercept.page,
               interceptParams: intercept.matchedParams,
@@ -4425,6 +4432,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     toInterceptOpts(intercept) {
       return {
         interceptionContext: interceptionContextHeader,
+        interceptLayouts: intercept.layouts,
         interceptSlotKey: intercept.slotKey,
         interceptPage: intercept.page,
         interceptParams: intercept.matchedParams,
@@ -5342,7 +5350,7 @@ function mergeMatchedParams(sourceParams, targetParams) {
 }
 
 // Build a global intercepting route lookup for RSC navigation.
-// Maps target URL patterns to { sourceRouteIndex, slotKey, interceptPage, params }.
+// Maps target URL patterns to { sourceRouteIndex, slotKey, interceptPage, interceptLayouts, params }.
 const interceptLookup = [];
 for (let ri = 0; ri < routes.length; ri++) {
   const r = routes[ri];
@@ -5355,6 +5363,7 @@ for (let ri = 0; ri < routes.length; ri++) {
         slotKey,
         targetPattern: intercept.targetPattern,
         targetPatternParts: intercept.targetPattern.split("/").filter(Boolean),
+        layouts: intercept.layouts,
         page: intercept.page,
         params: intercept.params,
       });
@@ -5538,6 +5547,7 @@ async function buildPageElements(route, params, routePath, pageRequest) {
       opts && opts.interceptSlotKey && opts.interceptPage
         ? {
             [opts.interceptSlotKey]: {
+              layoutModules: opts.interceptLayouts || null,
               pageModule: opts.interceptPage,
               params: opts.interceptParams || params,
             },
@@ -6264,6 +6274,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           toInterceptOpts(intercept) {
             return {
               interceptionContext: interceptionContextHeader,
+              interceptLayouts: intercept.layouts,
               interceptSlotKey: intercept.slotKey,
               interceptPage: intercept.page,
               interceptParams: intercept.matchedParams,
@@ -6746,6 +6757,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     toInterceptOpts(intercept) {
       return {
         interceptionContext: interceptionContextHeader,
+        interceptLayouts: intercept.layouts,
         interceptSlotKey: intercept.slotKey,
         interceptPage: intercept.page,
         interceptParams: intercept.matchedParams,
@@ -7692,7 +7704,7 @@ function mergeMatchedParams(sourceParams, targetParams) {
 }
 
 // Build a global intercepting route lookup for RSC navigation.
-// Maps target URL patterns to { sourceRouteIndex, slotKey, interceptPage, params }.
+// Maps target URL patterns to { sourceRouteIndex, slotKey, interceptPage, interceptLayouts, params }.
 const interceptLookup = [];
 for (let ri = 0; ri < routes.length; ri++) {
   const r = routes[ri];
@@ -7705,6 +7717,7 @@ for (let ri = 0; ri < routes.length; ri++) {
         slotKey,
         targetPattern: intercept.targetPattern,
         targetPatternParts: intercept.targetPattern.split("/").filter(Boolean),
+        layouts: intercept.layouts,
         page: intercept.page,
         params: intercept.params,
       });
@@ -7888,6 +7901,7 @@ async function buildPageElements(route, params, routePath, pageRequest) {
       opts && opts.interceptSlotKey && opts.interceptPage
         ? {
             [opts.interceptSlotKey]: {
+              layoutModules: opts.interceptLayouts || null,
               pageModule: opts.interceptPage,
               params: opts.interceptParams || params,
             },
@@ -8617,6 +8631,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           toInterceptOpts(intercept) {
             return {
               interceptionContext: interceptionContextHeader,
+              interceptLayouts: intercept.layouts,
               interceptSlotKey: intercept.slotKey,
               interceptPage: intercept.page,
               interceptParams: intercept.matchedParams,
@@ -9099,6 +9114,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     toInterceptOpts(intercept) {
       return {
         interceptionContext: interceptionContextHeader,
+        interceptLayouts: intercept.layouts,
         interceptSlotKey: intercept.slotKey,
         interceptPage: intercept.page,
         interceptParams: intercept.matchedParams,
@@ -10022,7 +10038,7 @@ function mergeMatchedParams(sourceParams, targetParams) {
 }
 
 // Build a global intercepting route lookup for RSC navigation.
-// Maps target URL patterns to { sourceRouteIndex, slotKey, interceptPage, params }.
+// Maps target URL patterns to { sourceRouteIndex, slotKey, interceptPage, interceptLayouts, params }.
 const interceptLookup = [];
 for (let ri = 0; ri < routes.length; ri++) {
   const r = routes[ri];
@@ -10035,6 +10051,7 @@ for (let ri = 0; ri < routes.length; ri++) {
         slotKey,
         targetPattern: intercept.targetPattern,
         targetPatternParts: intercept.targetPattern.split("/").filter(Boolean),
+        layouts: intercept.layouts,
         page: intercept.page,
         params: intercept.params,
       });
@@ -10218,6 +10235,7 @@ async function buildPageElements(route, params, routePath, pageRequest) {
       opts && opts.interceptSlotKey && opts.interceptPage
         ? {
             [opts.interceptSlotKey]: {
+              layoutModules: opts.interceptLayouts || null,
               pageModule: opts.interceptPage,
               params: opts.interceptParams || params,
             },
@@ -10944,6 +10962,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           toInterceptOpts(intercept) {
             return {
               interceptionContext: interceptionContextHeader,
+              interceptLayouts: intercept.layouts,
               interceptSlotKey: intercept.slotKey,
               interceptPage: intercept.page,
               interceptParams: intercept.matchedParams,
@@ -11426,6 +11445,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     toInterceptOpts(intercept) {
       return {
         interceptionContext: interceptionContextHeader,
+        interceptLayouts: intercept.layouts,
         interceptSlotKey: intercept.slotKey,
         interceptPage: intercept.page,
         interceptParams: intercept.matchedParams,
@@ -12342,7 +12362,7 @@ function mergeMatchedParams(sourceParams, targetParams) {
 }
 
 // Build a global intercepting route lookup for RSC navigation.
-// Maps target URL patterns to { sourceRouteIndex, slotKey, interceptPage, params }.
+// Maps target URL patterns to { sourceRouteIndex, slotKey, interceptPage, interceptLayouts, params }.
 const interceptLookup = [];
 for (let ri = 0; ri < routes.length; ri++) {
   const r = routes[ri];
@@ -12355,6 +12375,7 @@ for (let ri = 0; ri < routes.length; ri++) {
         slotKey,
         targetPattern: intercept.targetPattern,
         targetPatternParts: intercept.targetPattern.split("/").filter(Boolean),
+        layouts: intercept.layouts,
         page: intercept.page,
         params: intercept.params,
       });
@@ -12538,6 +12559,7 @@ async function buildPageElements(route, params, routePath, pageRequest) {
       opts && opts.interceptSlotKey && opts.interceptPage
         ? {
             [opts.interceptSlotKey]: {
+              layoutModules: opts.interceptLayouts || null,
               pageModule: opts.interceptPage,
               params: opts.interceptParams || params,
             },
@@ -13631,6 +13653,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           toInterceptOpts(intercept) {
             return {
               interceptionContext: interceptionContextHeader,
+              interceptLayouts: intercept.layouts,
               interceptSlotKey: intercept.slotKey,
               interceptPage: intercept.page,
               interceptParams: intercept.matchedParams,
@@ -14113,6 +14136,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     toInterceptOpts(intercept) {
       return {
         interceptionContext: interceptionContextHeader,
+        interceptLayouts: intercept.layouts,
         interceptSlotKey: intercept.slotKey,
         interceptPage: intercept.page,
         interceptParams: intercept.matchedParams,

--- a/tests/app-page-route-wiring.test.ts
+++ b/tests/app-page-route-wiring.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from "vite-plus/test";
 import { useSelectedLayoutSegments } from "../packages/vinext/src/shims/navigation.js";
 import type { AppElements } from "../packages/vinext/src/server/app-elements.js";
 import {
+  type AppPageModule,
+  type AppPageSlotOverride,
   buildAppPageElements,
   createAppPageLayoutEntries,
   resolveAppPageChildSegments,
@@ -120,6 +122,14 @@ function GroupLayout(props: Record<string, unknown>) {
 
 function SlotLayout(props: Record<string, unknown>) {
   return createElement("div", { "data-slot-layout": "sidebar" }, readChildren(props.children));
+}
+
+function InterceptOuterLayout(props: Record<string, unknown>) {
+  return createElement("div", { "data-intercept-layout": "outer" }, readChildren(props.children));
+}
+
+function InterceptInnerLayout(props: Record<string, unknown>) {
+  return createElement("div", { "data-intercept-layout": "inner" }, readChildren(props.children));
 }
 
 function SlotPage(props: Record<string, unknown>) {
@@ -299,6 +309,69 @@ describe("app page route wiring helpers", () => {
 
     expect(html).toContain('data-slot-page="override"');
     expect(html).toContain('data-sidebar-segments="members|42"');
+  });
+
+  it("wraps intercepted slot overrides with intercept layout modules inside the slot layout", async () => {
+    const sidebarOverride: AppPageSlotOverride<AppPageModule> = {
+      layoutModules: [{ default: InterceptOuterLayout }, { default: InterceptInnerLayout }],
+      pageModule: { default: SlotPage },
+      props: { label: "intercepted" },
+    };
+
+    const elements = buildAppPageElements({
+      element: createElement(PageProbe),
+      makeThenableParams(params) {
+        return Promise.resolve(params);
+      },
+      matchedParams: {},
+      resolvedMetadata: null,
+      resolvedViewport: {},
+      route: {
+        error: null,
+        errors: [null],
+        layoutTreePositions: [0],
+        layouts: [{ default: RootLayout }],
+        loading: null,
+        notFound: null,
+        notFounds: [null],
+        routeSegments: ["dashboard"],
+        slots: {
+          sidebar: {
+            default: null,
+            error: null,
+            layout: { default: SlotLayout },
+            layoutIndex: 0,
+            loading: null,
+            name: "sidebar",
+            page: { default: SlotPage },
+            routeSegments: [],
+          },
+        },
+        templateTreePositions: [],
+        templates: [],
+      },
+      routePath: "/dashboard",
+      rootNotFoundModule: null,
+      slotOverrides: {
+        sidebar: sidebarOverride,
+      },
+    });
+
+    const html = await renderRouteEntry(elements, "route:/dashboard");
+
+    expect(html).toContain('data-slot-layout="sidebar"');
+    expect(html).toContain('data-intercept-layout="outer"');
+    expect(html).toContain('data-intercept-layout="inner"');
+    expect(html).toContain('data-slot-page="intercepted"');
+
+    const slotLayoutPos = html.indexOf('data-slot-layout="sidebar"');
+    const outerLayoutPos = html.indexOf('data-intercept-layout="outer"');
+    const innerLayoutPos = html.indexOf('data-intercept-layout="inner"');
+    const pagePos = html.indexOf('data-slot-page="intercepted"');
+
+    expect(slotLayoutPos).toBeLessThan(outerLayoutPos);
+    expect(outerLayoutPos).toBeLessThan(innerLayoutPos);
+    expect(innerLayoutPos).toBeLessThan(pagePos);
   });
 
   it("renders same-named slot props independently at different layout levels", async () => {

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -4456,8 +4456,8 @@ describe("generateRscEntry ISR code generation", () => {
 
     const code = generateRscEntry("/tmp/test/app", [routeWithInterceptLayouts]);
 
-    expect(code).toContain("layouts: [mod_");
-    expect(code).toContain("interceptLayouts: intercept.layouts");
+    expect(code).toContain("interceptLayouts: [mod_");
+    expect(code).toContain("interceptLayouts: intercept.interceptLayouts");
     expect(code).toContain("layoutModules: opts.interceptLayouts || null");
   });
 

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -4409,6 +4409,58 @@ describe("generateRscEntry ISR code generation", () => {
     expect(code).toContain("const __pageBuildResult = await __buildAppPageElement({");
   });
 
+  it("generated code threads intercept layout modules through slot overrides", () => {
+    const routeWithInterceptLayouts: AppRoute = {
+      errorPath: null,
+      forbiddenPath: null,
+      isDynamic: false,
+      layoutErrorPaths: [null],
+      layouts: ["/tmp/test/app/layout.tsx"],
+      layoutTreePositions: [0],
+      loadingPath: null,
+      notFoundPath: null,
+      notFoundPaths: [null],
+      pagePath: "/tmp/test/app/page.tsx",
+      parallelSlots: [
+        {
+          defaultPath: "/tmp/test/app/@modal/default.tsx",
+          errorPath: null,
+          interceptingRoutes: [
+            {
+              convention: ".",
+              layoutPaths: ["/tmp/test/app/@modal/(.)explicit-layout/layout.tsx"],
+              pagePath: "/tmp/test/app/@modal/(.)explicit-layout/deeper/page.tsx",
+              params: [],
+              targetPattern: "/explicit-layout/deeper",
+            },
+          ],
+          key: "modal@@modal",
+          layoutIndex: 0,
+          layoutPath: "/tmp/test/app/@modal/layout.tsx",
+          loadingPath: null,
+          name: "modal",
+          ownerDir: "/tmp/test/app/@modal",
+          pagePath: null,
+          routeSegments: null,
+        },
+      ],
+      params: [],
+      pattern: "/",
+      patternParts: [],
+      routePath: null,
+      routeSegments: [],
+      templates: [],
+      templateTreePositions: [],
+      unauthorizedPath: null,
+    };
+
+    const code = generateRscEntry("/tmp/test/app", [routeWithInterceptLayouts]);
+
+    expect(code).toContain("layouts: [mod_");
+    expect(code).toContain("interceptLayouts: intercept.layouts");
+    expect(code).toContain("layoutModules: opts.interceptLayouts || null");
+  });
+
   it("generated code delegates page boundary rendering to typed helpers", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes);
     expect(code).toContain("renderAppPageErrorBoundary as __renderAppPageErrorBoundary");

--- a/tests/routing.test.ts
+++ b/tests/routing.test.ts
@@ -1076,6 +1076,48 @@ describe("matchAppRoute - URL matching", () => {
     expect(intercept.pagePath).toContain("(...)photos");
   });
 
+  it("discovers intercept layout chains inside parallel slots", async () => {
+    // Ported from Next.js:
+    // test/e2e/app-dir/interception-dynamic-segment/interception-dynamic-segment.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/interception-dynamic-segment/interception-dynamic-segment.test.ts
+    await withTempDir("vinext-app-intercept-layout-chain-", async (tmpDir) => {
+      const appDir = path.join(tmpDir, "app");
+
+      await mkdir(path.join(appDir, "@modal", "(.)explicit-layout", "deeper"), {
+        recursive: true,
+      });
+      await mkdir(path.join(appDir, "explicit-layout", "deeper"), {
+        recursive: true,
+      });
+
+      await writeFile(path.join(appDir, "layout.tsx"), EMPTY_PAGE);
+      await writeFile(path.join(appDir, "page.tsx"), EMPTY_PAGE);
+      await writeFile(path.join(appDir, "@modal", "default.tsx"), EMPTY_PAGE);
+      await writeFile(path.join(appDir, "@modal", "(.)explicit-layout", "layout.tsx"), EMPTY_PAGE);
+      await writeFile(
+        path.join(appDir, "@modal", "(.)explicit-layout", "deeper", "page.tsx"),
+        EMPTY_PAGE,
+      );
+      await writeFile(path.join(appDir, "explicit-layout", "page.tsx"), EMPTY_PAGE);
+      await writeFile(path.join(appDir, "explicit-layout", "deeper", "page.tsx"), EMPTY_PAGE);
+
+      invalidateAppRouteCache();
+      const routes = await appRouter(appDir);
+      const homeRoute = routes.find((route) => route.pattern === "/");
+
+      expect(homeRoute).toBeDefined();
+
+      const modalSlot = homeRoute!.parallelSlots.find((slot) => slot.name === "modal");
+      expect(modalSlot).toBeDefined();
+      expect(modalSlot!.interceptingRoutes).toHaveLength(1);
+      expect(modalSlot!.interceptingRoutes[0]).toMatchObject({
+        convention: ".",
+        targetPattern: "/explicit-layout/deeper",
+        layoutPaths: [path.join(appDir, "@modal", "(.)explicit-layout", "layout.tsx")],
+      });
+    });
+  });
+
   it("allows inherited intercepting slots to reuse the same target pattern", async () => {
     await withTempDir("vinext-app-intercept-inherited-slot-", async (tmpDir) => {
       const appDir = path.join(tmpDir, "app");

--- a/tests/routing.test.ts
+++ b/tests/routing.test.ts
@@ -1118,6 +1118,43 @@ describe("matchAppRoute - URL matching", () => {
     });
   });
 
+  it("discovers nested intercept layout chains in outermost-to-innermost order", async () => {
+    await withTempDir("vinext-app-intercept-layout-depth-", async (tmpDir) => {
+      const appDir = path.join(tmpDir, "app");
+
+      await mkdir(path.join(appDir, "@modal", "(.)foo", "bar", "baz"), {
+        recursive: true,
+      });
+      await mkdir(path.join(appDir, "foo", "bar", "baz"), {
+        recursive: true,
+      });
+
+      await writeFile(path.join(appDir, "layout.tsx"), EMPTY_PAGE);
+      await writeFile(path.join(appDir, "page.tsx"), EMPTY_PAGE);
+      await writeFile(path.join(appDir, "@modal", "default.tsx"), EMPTY_PAGE);
+      await writeFile(path.join(appDir, "@modal", "(.)foo", "layout.tsx"), EMPTY_PAGE);
+      await writeFile(path.join(appDir, "@modal", "(.)foo", "bar", "layout.tsx"), EMPTY_PAGE);
+      await writeFile(path.join(appDir, "@modal", "(.)foo", "bar", "baz", "page.tsx"), EMPTY_PAGE);
+      await writeFile(path.join(appDir, "foo", "page.tsx"), EMPTY_PAGE);
+      await writeFile(path.join(appDir, "foo", "bar", "page.tsx"), EMPTY_PAGE);
+      await writeFile(path.join(appDir, "foo", "bar", "baz", "page.tsx"), EMPTY_PAGE);
+
+      invalidateAppRouteCache();
+      const routes = await appRouter(appDir);
+      const homeRoute = routes.find((route) => route.pattern === "/");
+
+      expect(homeRoute).toBeDefined();
+
+      const modalSlot = homeRoute!.parallelSlots.find((slot) => slot.name === "modal");
+      expect(modalSlot).toBeDefined();
+      expect(modalSlot!.interceptingRoutes).toHaveLength(1);
+      expect(modalSlot!.interceptingRoutes[0]?.layoutPaths).toEqual([
+        path.join(appDir, "@modal", "(.)foo", "layout.tsx"),
+        path.join(appDir, "@modal", "(.)foo", "bar", "layout.tsx"),
+      ]);
+    });
+  });
+
   it("allows inherited intercepting slots to reuse the same target pattern", async () => {
     await withTempDir("vinext-app-intercept-inherited-slot-", async (tmpDir) => {
       const appDir = path.join(tmpDir, "app");


### PR DESCRIPTION
## What this changes
App Router intercepting routes now keep and render `layout.tsx` files that live inside the intercepting route tree instead of rendering the intercepted page bare inside the slot.

## Why
Current vinext behavior drops those intercept-local layouts during discovery, so a modal intercept can match the right page but still miss required wrappers that Next.js applies. That breaks cases like `@modal/(.)explicit-layout/layout.tsx` with a nested intercepted page.

## Approach
Collect intercept layout paths during App Router discovery, carry them through generated RSC entry serialization, and apply the resulting layout modules around the intercepted slot override before the slot layout renders.

This stays within the existing intercept pipeline rather than adding a separate render path.

## Validation
- Added routing coverage for intercept layout chain discovery
- Added route-wiring coverage for slot layout -> intercept layouts -> page render order
- Added RSC entry codegen coverage for forwarding intercept layout modules
- Ran `vp test run /Users/nathan/Projects/vinext/tests/routing.test.ts /Users/nathan/Projects/vinext/tests/app-page-route-wiring.test.ts /Users/nathan/Projects/vinext/tests/app-router.test.ts`

## Risks / follow-ups
The generated entry now carries one more intercept field through the serialization path. The added codegen test covers that contract directly.
