### PR TITLE
fix(app-router): keep isPending true across router.back() and router.forward()

### DIFF
--- a/packages/vinext/src/global.d.ts
+++ b/packages/vinext/src/global.d.ts
@@ -100,6 +100,17 @@ declare global {
       | undefined;
 
     /**
+     * Arms a deferred `PendingBrowserRouterState` inside the caller's
+     * `React.startTransition`. The App Router browser entry registers this
+     * hook at hydration time. Called by `router.back()` / `router.forward()`
+     * in the navigation shim so the subsequent popstate's `navigateRsc` can
+     * adopt the pending and keep `useTransition().isPending` true until the
+     * traversal commits. Undefined before hydration or on non-App-Router
+     * pages; callers must short-circuit with `?.()`.
+     */
+    __VINEXT_ARM_TRAVERSAL_PENDING__: (() => void) | undefined;
+
+    /**
      * A Promise that resolves when the current in-flight popstate RSC navigation
      * finishes rendering.
      * Set by the popstate handler in the browser RSC entry; read by

--- a/packages/vinext/src/global.d.ts
+++ b/packages/vinext/src/global.d.ts
@@ -79,6 +79,12 @@ declare global {
     __VINEXT_RSC_ROOT__: Root | undefined;
 
     /**
+     * True after the App Router browser root has committed and published the
+     * router state ref used by external navigation helpers.
+     */
+    __VINEXT_APP_ROUTER_READY__: boolean | undefined;
+
+    /**
      * The client-side RSC navigation function for App Router.
      * Registered by the browser RSC entry on `window` so that the navigation
      * shim, Link, and Form can trigger RSC re-fetches without a direct import.

--- a/packages/vinext/src/global.d.ts
+++ b/packages/vinext/src/global.d.ts
@@ -111,6 +111,17 @@ declare global {
     __VINEXT_ARM_TRAVERSAL_PENDING__: (() => void) | undefined;
 
     /**
+     * Web Navigation API. Declared here because the TS version pinned by CI's
+     * stock `tsc` predates the Navigation API types in `lib.dom.d.ts`.
+     * We use only the traversal availability hints, so the surface is minimal.
+     * See https://developer.mozilla.org/en-US/docs/Web/API/Navigation_API.
+     */
+    readonly navigation?: {
+      readonly canGoBack: boolean;
+      readonly canGoForward: boolean;
+    };
+
+    /**
      * A Promise that resolves when the current in-flight popstate RSC navigation
      * finishes rendering.
      * Set by the popstate handler in the browser RSC entry; read by

--- a/packages/vinext/src/global.d.ts
+++ b/packages/vinext/src/global.d.ts
@@ -117,17 +117,6 @@ declare global {
     __VINEXT_ARM_TRAVERSAL_PENDING__: (() => void) | undefined;
 
     /**
-     * Web Navigation API. Declared here because the TS version pinned by CI's
-     * stock `tsc` predates the Navigation API types in `lib.dom.d.ts`.
-     * We use only the traversal availability hints, so the surface is minimal.
-     * See https://developer.mozilla.org/en-US/docs/Web/API/Navigation_API.
-     */
-    readonly navigation?: {
-      readonly canGoBack: boolean;
-      readonly canGoForward: boolean;
-    };
-
-    /**
      * A Promise that resolves when the current in-flight popstate RSC navigation
      * finishes rendering.
      * Set by the popstate handler in the browser RSC entry; read by

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -143,7 +143,9 @@ let activePendingBrowserRouterState: PendingBrowserRouterState | null = null;
 // popstate cannot accidentally adopt a regular navigation's pending. The
 // queue owns adoption order only; React still has one router useState slot,
 // so dispatchBrowserTree resolves the adopted promise and then writes the
-// concrete reducer result to converge that slot after overlapping work.
+// concrete reducer result to converge that slot after overlapping work. A
+// user-initiated popstate can still consume a queued programmatic pending;
+// that affects transition timing, not the final committed tree.
 const traversalPendingQueue: PendingBrowserRouterState[] = [];
 let latestClientParams: Record<string, string | string[]> = {};
 const visitedResponseCache = new Map<string, VisitedResponseCacheEntry>();
@@ -214,6 +216,8 @@ function armTraversalPendingBrowserRouterState(): PendingBrowserRouterState {
 function dequeueTraversalPendingBrowserRouterState(): PendingBrowserRouterState | null {
   while (traversalPendingQueue.length > 0) {
     const pending = traversalPendingQueue.shift()!;
+    // Normally settle/resolve removes entries first; this keeps a settled
+    // out-of-band entry from being adopted by a later popstate.
     if (!pending.settled) return pending;
   }
   return null;

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -138,10 +138,12 @@ function isRouterStatePromise(
 let setBrowserRouterState: Dispatch<AppRouterState | Promise<AppRouterState>> | null = null;
 let browserRouterStateRef: { current: AppRouterState } | null = null;
 let activePendingBrowserRouterState: PendingBrowserRouterState | null = null;
-// FIFO queue of pendings armed by router.back() / router.forward(), separate
-// from activePendingBrowserRouterState (used by push/replace/refresh). Keeps
-// each traversal popstate adopting only the pending its own arm hook created,
-// even when push/replace/refresh runs in between.
+// FIFO queue of pendings armed by router.back() / router.forward().
+// Push/replace/refresh use activePendingBrowserRouterState instead, so a
+// popstate cannot accidentally adopt a regular navigation's pending. The
+// queue owns adoption order only; React still has one router useState slot,
+// so dispatchBrowserTree resolves the adopted promise and then writes the
+// concrete reducer result to converge that slot after overlapping work.
 const traversalPendingQueue: PendingBrowserRouterState[] = [];
 let latestClientParams: Record<string, string | string[]> = {};
 const visitedResponseCache = new Map<string, VisitedResponseCacheEntry>();
@@ -711,11 +713,12 @@ function dispatchBrowserTree(
   };
 
   const applyAction = () => {
-    // Resolve the adopted pending and also write concrete state. Resolve
-    // first so any `use(pending.promise)`-suspended render unsuspends in the
-    // same commit the setter targets. The unconditional setter heals slot
-    // races where an earlier navigation's stale-id finally settled the
-    // pending React's slot was bound to.
+    // Resolve the adopted promise, then publish the concrete reducer result.
+    // Example: router.back() arms p1, router.forward() arms p2, and the p1
+    // popstate commits after p2 already replaced the React slot. Resolving p1
+    // completes the transition that owns it; the direct setter keeps the slot
+    // converged on the newest reducer state instead of whichever promise was
+    // most recently installed.
     resolvePendingBrowserRouterState(pendingRouterState, action);
     setter(routerReducer(getBrowserRouterState(), action));
   };

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -582,11 +582,20 @@ function BrowserRoot({
 
   // Publish the stable ref object and dispatch during layout commit. This keeps
   // the module-level escape hatches aligned with React's committed tree without
-  // performing module writes during render.
+  // performing module writes during render. The arm hook is also (re)assigned
+  // here so it survives React 19 StrictMode dev's mount→cleanup→mount cycle;
+  // assigning it once at module load would leave it undefined for the rest of
+  // the session after the first cleanup.
   useLayoutEffect(() => {
     setBrowserRouterState = setTreeStateValue;
     browserRouterStateRef = stateRef;
     window.__VINEXT_APP_ROUTER_READY__ = true;
+    window.__VINEXT_ARM_TRAVERSAL_PENDING__ = () => {
+      if (!window.__VINEXT_APP_ROUTER_READY__ || !setBrowserRouterState || !browserRouterStateRef) {
+        return;
+      }
+      beginPendingBrowserRouterState();
+    };
     return () => {
       if (setBrowserRouterState === setTreeStateValue) {
         setBrowserRouterState = null;
@@ -1070,17 +1079,8 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
   );
   window.__VINEXT_HYDRATED_AT = performance.now();
 
-  window.__VINEXT_ARM_TRAVERSAL_PENDING__ = () => {
-    // Child useLayoutEffects fire before BrowserRoot's (child-first order),
-    // so a router.back() from a child's useLayoutEffect on mount can reach
-    // here before setBrowserRouterState is published. Skip arming in that
-    // window — the traversal itself still fires; only isPending tracking
-    // for this one call is missed.
-    if (!window.__VINEXT_APP_ROUTER_READY__ || !setBrowserRouterState || !browserRouterStateRef) {
-      return;
-    }
-    beginPendingBrowserRouterState();
-  };
+  // The arm hook is assigned by BrowserRoot's mount effect, not here, so it
+  // survives React 19 StrictMode dev's mount→cleanup→mount cycle.
 
   window.__VINEXT_RSC_NAVIGATE__ = async function navigateRsc(
     href: string,

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -665,14 +665,13 @@ function dispatchBrowserTree(
   };
 
   const applyAction = () => {
-    if (pendingRouterState) {
-      // The programmatic navigation is already running inside React.startTransition
-      // (from router.push/replace/refresh), so resolving the deferred promise is
-      // sufficient — no additional startTransition wrapper is needed below.
-      resolvePendingBrowserRouterState(pendingRouterState, action);
-      return;
-    }
-
+    // Resolve the adopted pending (so a useTransition consumer commits) and
+    // also write the concrete state. The unconditional setter heals rapid
+    // overlapping traversals: when two navigateRsc invocations share one
+    // activePendingBrowserRouterState, the older one's stale-id finally can
+    // settle that pending stale, leaving React's slot bound to a wrong-state
+    // promise resolution. The setter rebinds the slot to the correct state.
+    resolvePendingBrowserRouterState(pendingRouterState, action);
     setter(routerReducer(getBrowserRouterState(), action));
   };
 

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -1071,6 +1071,12 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
   window.__VINEXT_HYDRATED_AT = performance.now();
 
   window.__VINEXT_ARM_TRAVERSAL_PENDING__ = () => {
+    // Child useLayoutEffects fire before BrowserRoot's (child-first order),
+    // so a router.back() from a child's useLayoutEffect on mount can reach
+    // here before setBrowserRouterState is published. Skip arming in that
+    // window — the traversal itself still fires; only isPending tracking
+    // for this one call is missed.
+    if (!window.__VINEXT_APP_ROUTER_READY__) return;
     beginPendingBrowserRouterState();
   };
 

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -1069,6 +1069,10 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
   );
   window.__VINEXT_HYDRATED_AT = performance.now();
 
+  window.__VINEXT_ARM_TRAVERSAL_PENDING__ = () => {
+    beginPendingBrowserRouterState();
+  };
+
   window.__VINEXT_RSC_NAVIGATE__ = async function navigateRsc(
     href: string,
     redirectDepth = 0,
@@ -1093,6 +1097,17 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
     try {
       if (programmaticTransition) {
         pendingRouterState = beginPendingBrowserRouterState();
+      } else if (
+        activePendingBrowserRouterState !== null &&
+        !activePendingBrowserRouterState.settled
+      ) {
+        // Popstate path: the shim already armed a pending inside the user's
+        // `React.startTransition` (router.back / router.forward). Adopt it so
+        // the commit resolves the promise React's state slot is suspended on,
+        // keeping `useTransition().isPending` true across the async popstate
+        // task boundary. User-initiated popstates (keyboard, gesture, address
+        // bar) find no active pending and fall through unchanged.
+        pendingRouterState = activePendingBrowserRouterState;
       }
 
       while (true) {

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -594,6 +594,7 @@ function BrowserRoot({
       if (browserRouterStateRef === stateRef) {
         browserRouterStateRef = null;
         window.__VINEXT_APP_ROUTER_READY__ = false;
+        window.__VINEXT_ARM_TRAVERSAL_PENDING__ = undefined;
       }
       setMountedSlotsHeader(null);
     };
@@ -1076,7 +1077,9 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
     // here before setBrowserRouterState is published. Skip arming in that
     // window — the traversal itself still fires; only isPending tracking
     // for this one call is missed.
-    if (!window.__VINEXT_APP_ROUTER_READY__) return;
+    if (!window.__VINEXT_APP_ROUTER_READY__ || !setBrowserRouterState || !browserRouterStateRef) {
+      return;
+    }
     beginPendingBrowserRouterState();
   };
 

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -582,18 +582,18 @@ function BrowserRoot({
 
   // Publish the stable ref object and dispatch during layout commit. This keeps
   // the module-level escape hatches aligned with React's committed tree without
-  // performing module writes during render. __VINEXT_RSC_NAVIGATE__ is assigned
-  // after hydrateRoot() returns; by then this layout effect has already run for
-  // the hydration commit, so getBrowserRouterState() never observes a null ref.
+  // performing module writes during render.
   useLayoutEffect(() => {
     setBrowserRouterState = setTreeStateValue;
     browserRouterStateRef = stateRef;
+    window.__VINEXT_APP_ROUTER_READY__ = true;
     return () => {
       if (setBrowserRouterState === setTreeStateValue) {
         setBrowserRouterState = null;
       }
       if (browserRouterStateRef === stateRef) {
         browserRouterStateRef = null;
+        window.__VINEXT_APP_ROUTER_READY__ = false;
       }
       setMountedSlotsHeader(null);
     };
@@ -1053,6 +1053,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
     window.location.href,
     latestClientParams,
   );
+  window.__VINEXT_APP_ROUTER_READY__ = false;
   replaceHistoryStateWithoutNotify(
     createHistoryStateWithPreviousNextUrl(window.history.state, null),
     "",

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -138,6 +138,11 @@ function isRouterStatePromise(
 let setBrowserRouterState: Dispatch<AppRouterState | Promise<AppRouterState>> | null = null;
 let browserRouterStateRef: { current: AppRouterState } | null = null;
 let activePendingBrowserRouterState: PendingBrowserRouterState | null = null;
+// FIFO queue of pendings armed by router.back() / router.forward(), separate
+// from activePendingBrowserRouterState (used by push/replace/refresh). Keeps
+// each traversal popstate adopting only the pending its own arm hook created,
+// even when push/replace/refresh runs in between.
+const traversalPendingQueue: PendingBrowserRouterState[] = [];
 let latestClientParams: Record<string, string | string[]> = {};
 const visitedResponseCache = new Map<string, VisitedResponseCacheEntry>();
 
@@ -184,6 +189,39 @@ function beginPendingBrowserRouterState(): PendingBrowserRouterState {
   return pending;
 }
 
+function armTraversalPendingBrowserRouterState(): PendingBrowserRouterState {
+  const setter = getBrowserRouterStateSetter();
+
+  let resolve!: (state: AppRouterState) => void;
+  const promise = new Promise<AppRouterState>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+
+  const pending: PendingBrowserRouterState = {
+    promise,
+    resolve,
+    settled: false,
+  };
+
+  traversalPendingQueue.push(pending);
+  setter(promise);
+
+  return pending;
+}
+
+function dequeueTraversalPendingBrowserRouterState(): PendingBrowserRouterState | null {
+  while (traversalPendingQueue.length > 0) {
+    const pending = traversalPendingQueue.shift()!;
+    if (!pending.settled) return pending;
+  }
+  return null;
+}
+
+function clearPendingFromTraversalQueue(pending: PendingBrowserRouterState): void {
+  const index = traversalPendingQueue.indexOf(pending);
+  if (index !== -1) traversalPendingQueue.splice(index, 1);
+}
+
 function settlePendingBrowserRouterState(
   pending: PendingBrowserRouterState | null | undefined,
 ): void {
@@ -195,6 +233,7 @@ function settlePendingBrowserRouterState(
   if (activePendingBrowserRouterState === pending) {
     activePendingBrowserRouterState = null;
   }
+  clearPendingFromTraversalQueue(pending);
 }
 
 function resolvePendingBrowserRouterState(
@@ -209,6 +248,7 @@ function resolvePendingBrowserRouterState(
   if (activePendingBrowserRouterState === pending) {
     activePendingBrowserRouterState = null;
   }
+  clearPendingFromTraversalQueue(pending);
 }
 
 function applyClientParams(params: Record<string, string | string[]>): void {
@@ -580,12 +620,9 @@ function BrowserRoot({
   const stateRef = useRef(treeState);
   stateRef.current = treeState;
 
-  // Publish the stable ref object and dispatch during layout commit. This keeps
-  // the module-level escape hatches aligned with React's committed tree without
-  // performing module writes during render. The arm hook is also (re)assigned
-  // here so it survives React 19 StrictMode dev's mount→cleanup→mount cycle;
-  // assigning it once at module load would leave it undefined for the rest of
-  // the session after the first cleanup.
+  // Publish the stable ref object and dispatch during layout commit. The arm
+  // hook is (re)assigned here so it survives React 19 StrictMode dev's
+  // mount→cleanup→mount cycle.
   useLayoutEffect(() => {
     setBrowserRouterState = setTreeStateValue;
     browserRouterStateRef = stateRef;
@@ -594,7 +631,7 @@ function BrowserRoot({
       if (!window.__VINEXT_APP_ROUTER_READY__ || !setBrowserRouterState || !browserRouterStateRef) {
         return;
       }
-      beginPendingBrowserRouterState();
+      armTraversalPendingBrowserRouterState();
     };
     return () => {
       if (setBrowserRouterState === setTreeStateValue) {
@@ -674,12 +711,11 @@ function dispatchBrowserTree(
   };
 
   const applyAction = () => {
-    // Resolve the adopted pending (so a useTransition consumer commits) and
-    // also write the concrete state. The unconditional setter heals rapid
-    // overlapping traversals: when two navigateRsc invocations share one
-    // activePendingBrowserRouterState, the older one's stale-id finally can
-    // settle that pending stale, leaving React's slot bound to a wrong-state
-    // promise resolution. The setter rebinds the slot to the correct state.
+    // Resolve the adopted pending and also write concrete state. Resolve
+    // first so any `use(pending.promise)`-suspended render unsuspends in the
+    // same commit the setter targets. The unconditional setter heals slot
+    // races where an earlier navigation's stale-id finally settled the
+    // pending React's slot was bound to.
     resolvePendingBrowserRouterState(pendingRouterState, action);
     setter(routerReducer(getBrowserRouterState(), action));
   };
@@ -1062,7 +1098,6 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
     window.location.href,
     latestClientParams,
   );
-  window.__VINEXT_APP_ROUTER_READY__ = false;
   replaceHistoryStateWithoutNotify(
     createHistoryStateWithPreviousNextUrl(window.history.state, null),
     "",
@@ -1078,9 +1113,6 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
     import.meta.env.DEV ? { onCaughtError: devOnCaughtError } : undefined,
   );
   window.__VINEXT_HYDRATED_AT = performance.now();
-
-  // The arm hook is assigned by BrowserRoot's mount effect, not here, so it
-  // survives React 19 StrictMode dev's mount→cleanup→mount cycle.
 
   window.__VINEXT_RSC_NAVIGATE__ = async function navigateRsc(
     href: string,
@@ -1106,17 +1138,12 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
     try {
       if (programmaticTransition) {
         pendingRouterState = beginPendingBrowserRouterState();
-      } else if (
-        activePendingBrowserRouterState !== null &&
-        !activePendingBrowserRouterState.settled
-      ) {
-        // Popstate path: the shim already armed a pending inside the user's
-        // `React.startTransition` (router.back / router.forward). Adopt it so
-        // the commit resolves the promise React's state slot is suspended on,
-        // keeping `useTransition().isPending` true across the async popstate
-        // task boundary. User-initiated popstates (keyboard, gesture, address
-        // bar) find no active pending and fall through unchanged.
-        pendingRouterState = activePendingBrowserRouterState;
+      } else {
+        // Popstate path: pull the arm-hook pending FIFO so each traversal
+        // resolves only the pending its own router.back/forward armed,
+        // independent of any push/replace/refresh that ran in between.
+        // User-initiated popstates find an empty queue and fall through.
+        pendingRouterState = dequeueTraversalPendingBrowserRouterState();
       }
 
       while (true) {

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -1246,14 +1246,14 @@ type BrowserNavigationTraversalHints = {
 };
 
 function getBrowserNavigationTraversalHints(): BrowserNavigationTraversalHints | null {
-  const nav = Reflect.get(window, "navigation");
-  if (!nav || typeof nav !== "object") return null;
-
-  const canGoBack = Reflect.get(nav, "canGoBack");
-  const canGoForward = Reflect.get(nav, "canGoForward");
-  if (typeof canGoBack !== "boolean" || typeof canGoForward !== "boolean") return null;
-
-  return { canGoBack, canGoForward };
+  const nav = (
+    window as Window & {
+      navigation?: { canGoBack?: unknown; canGoForward?: unknown };
+    }
+  ).navigation;
+  if (!nav) return null;
+  if (typeof nav.canGoBack !== "boolean" || typeof nav.canGoForward !== "boolean") return null;
+  return { canGoBack: nav.canGoBack, canGoForward: nav.canGoForward };
 }
 
 /**

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -1243,6 +1243,9 @@ export async function navigateClientSide(
 type BrowserNavigationTraversalHints = {
   readonly canGoBack: boolean;
   readonly canGoForward: boolean;
+  readonly currentEntryKey: string | null;
+  readonly currentEntryIndex: number | null;
+  readonly entries: readonly BrowserNavigationHistoryEntry[] | null;
 };
 
 type WindowWithNavigationProperty = {
@@ -1254,6 +1257,23 @@ type BrowserNavigationTraversalHintFields = {
   readonly canGoForward: unknown;
 };
 
+type BrowserNavigationEntryListFields = {
+  readonly currentEntry: unknown;
+  readonly entries: () => unknown;
+};
+
+type BrowserNavigationHistoryEntry = {
+  readonly index: number;
+  readonly key: string;
+  readonly sameDocument: boolean;
+};
+
+type BrowserNavigationHistoryEntryFields = {
+  readonly index: unknown;
+  readonly key: unknown;
+  readonly sameDocument: unknown;
+};
+
 function hasNavigationProperty(value: object): value is WindowWithNavigationProperty {
   return "navigation" in value;
 }
@@ -1262,17 +1282,99 @@ function hasTraversalHintFields(value: object): value is BrowserNavigationTraver
   return "canGoBack" in value && "canGoForward" in value;
 }
 
+function hasEntryListFields(value: object): value is BrowserNavigationEntryListFields {
+  return "currentEntry" in value && "entries" in value && typeof value.entries === "function";
+}
+
+function hasHistoryEntryFields(value: object): value is BrowserNavigationHistoryEntryFields {
+  return "index" in value && "key" in value && "sameDocument" in value;
+}
+
+function readBrowserNavigationHistoryEntry(entry: unknown): BrowserNavigationHistoryEntry | null {
+  if (!entry || typeof entry !== "object") return null;
+  if (!hasHistoryEntryFields(entry)) return null;
+  const { index, key, sameDocument } = entry;
+  if (typeof index !== "number" || typeof key !== "string" || typeof sameDocument !== "boolean") {
+    return null;
+  }
+  return { index, key, sameDocument };
+}
+
+function readBrowserNavigationHistoryEntries(
+  nav: object,
+): Pick<BrowserNavigationTraversalHints, "currentEntryIndex" | "currentEntryKey" | "entries"> {
+  if (!hasEntryListFields(nav)) {
+    return { currentEntryIndex: null, currentEntryKey: null, entries: null };
+  }
+
+  const currentEntry = readBrowserNavigationHistoryEntry(nav.currentEntry);
+  let rawEntries: unknown;
+  try {
+    rawEntries = nav.entries();
+  } catch {
+    return { currentEntryIndex: null, currentEntryKey: null, entries: null };
+  }
+  if (!currentEntry || !Array.isArray(rawEntries)) {
+    return { currentEntryIndex: null, currentEntryKey: null, entries: null };
+  }
+
+  const entries: BrowserNavigationHistoryEntry[] = [];
+  for (const entry of rawEntries) {
+    const parsed = readBrowserNavigationHistoryEntry(entry);
+    if (!parsed) {
+      return { currentEntryIndex: null, currentEntryKey: null, entries: null };
+    }
+    entries.push(parsed);
+  }
+
+  return {
+    currentEntryIndex: currentEntry.index,
+    currentEntryKey: currentEntry.key,
+    entries,
+  };
+}
+
 function readBrowserNavigationTraversalHints(nav: unknown): BrowserNavigationTraversalHints | null {
   if (!nav || typeof nav !== "object") return null;
   if (!hasTraversalHintFields(nav)) return null;
   const { canGoBack, canGoForward } = nav;
   if (typeof canGoBack !== "boolean" || typeof canGoForward !== "boolean") return null;
-  return { canGoBack, canGoForward };
+  return {
+    canGoBack,
+    canGoForward,
+    ...readBrowserNavigationHistoryEntries(nav),
+  };
 }
 
 function getBrowserNavigationTraversalHints(): BrowserNavigationTraversalHints | null {
   if (!hasNavigationProperty(window)) return null;
   return readBrowserNavigationTraversalHints(window.navigation);
+}
+
+let optimisticTraversalBaseEntryKey: string | null = null;
+let optimisticTraversalIndexOffset = 0;
+
+function canOptimisticallyTraverseSameDocument(
+  direction: "back" | "forward",
+  nav: BrowserNavigationTraversalHints,
+): boolean | null {
+  if (nav.currentEntryKey === null || nav.currentEntryIndex === null || nav.entries === null) {
+    return null;
+  }
+
+  if (nav.currentEntryKey !== optimisticTraversalBaseEntryKey) {
+    optimisticTraversalBaseEntryKey = nav.currentEntryKey;
+    optimisticTraversalIndexOffset = 0;
+  }
+
+  const currentIndex = nav.currentEntryIndex + optimisticTraversalIndexOffset;
+  const targetIndex = direction === "back" ? currentIndex - 1 : currentIndex + 1;
+  const targetEntry = nav.entries.find((entry) => entry.index === targetIndex);
+  return targetEntry?.sameDocument === true;
+}
+
+function markOptimisticTraversal(direction: "back" | "forward"): void {
+  optimisticTraversalIndexOffset += direction === "back" ? -1 : 1;
 }
 
 /**
@@ -1290,10 +1392,12 @@ function getBrowserNavigationTraversalHints(): BrowserNavigationTraversalHints |
  * commits, preserving `isPending=true` across the async task boundary.
  *
  * Navigation API hint: `canGoBack` / `canGoForward` are synchronous
- * availability checks. When `false`, `history.back/forward` is a no-op and
- * no popstate will fire. Arming the pending in that case would leave it
- * unsettled (until the next unrelated traversal auto-settles it and
- * produces a misleading isPending period). We skip arming in that case.
+ * availability checks, but they do not update until a scheduled traversal
+ * commits. We therefore budget same-tick traversals against
+ * `navigation.entries()` when available: `router.back(); router.back();`
+ * with only one same-document entry behind it arms only the first call. When
+ * the exact target entry is unavailable, we fall back to the coarse boolean
+ * hints and still skip known no-ops.
  *
  * When the Navigation API is unavailable (pre-Safari 18.4 / pre-Firefox 136),
  * we deliberately skip arming and degrade to a bare traversal: we cannot
@@ -1312,8 +1416,14 @@ function runProgrammaticTraversal(direction: "back" | "forward"): void {
   React.startTransition(() => {
     const nav = getBrowserNavigationTraversalHints();
     if (nav !== null) {
-      const canTraverse = direction === "back" ? nav.canGoBack : nav.canGoForward;
-      if (canTraverse) window.__VINEXT_ARM_TRAVERSAL_PENDING__?.();
+      const hintedCanTraverse = direction === "back" ? nav.canGoBack : nav.canGoForward;
+      const sameDocumentTarget = canOptimisticallyTraverseSameDocument(direction, nav);
+      const canTraverse = sameDocumentTarget ?? hintedCanTraverse;
+      const armTraversalPending = window.__VINEXT_ARM_TRAVERSAL_PENDING__;
+      if (canTraverse && armTraversalPending) {
+        armTraversalPending();
+        markOptimisticTraversal(direction);
+      }
     }
     if (direction === "back") window.history.back();
     else window.history.forward();

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -1245,15 +1245,34 @@ type BrowserNavigationTraversalHints = {
   readonly canGoForward: boolean;
 };
 
+type WindowWithNavigationProperty = {
+  readonly navigation: unknown;
+};
+
+type BrowserNavigationTraversalHintFields = {
+  readonly canGoBack: unknown;
+  readonly canGoForward: unknown;
+};
+
+function hasNavigationProperty(value: object): value is WindowWithNavigationProperty {
+  return "navigation" in value;
+}
+
+function hasTraversalHintFields(value: object): value is BrowserNavigationTraversalHintFields {
+  return "canGoBack" in value && "canGoForward" in value;
+}
+
+function readBrowserNavigationTraversalHints(nav: unknown): BrowserNavigationTraversalHints | null {
+  if (!nav || typeof nav !== "object") return null;
+  if (!hasTraversalHintFields(nav)) return null;
+  const { canGoBack, canGoForward } = nav;
+  if (typeof canGoBack !== "boolean" || typeof canGoForward !== "boolean") return null;
+  return { canGoBack, canGoForward };
+}
+
 function getBrowserNavigationTraversalHints(): BrowserNavigationTraversalHints | null {
-  const nav = (
-    window as Window & {
-      navigation?: { canGoBack?: unknown; canGoForward?: unknown };
-    }
-  ).navigation;
-  if (!nav) return null;
-  if (typeof nav.canGoBack !== "boolean" || typeof nav.canGoForward !== "boolean") return null;
-  return { canGoBack: nav.canGoBack, canGoForward: nav.canGoForward };
+  if (!hasNavigationProperty(window)) return null;
+  return readBrowserNavigationTraversalHints(window.navigation);
 }
 
 /**

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -1248,83 +1248,41 @@ type BrowserNavigationTraversalHints = {
   readonly entries: readonly BrowserNavigationHistoryEntry[] | null;
 };
 
-type WindowWithNavigationProperty = {
-  readonly navigation: unknown;
+type BrowserNavigationHistoryEntry = Pick<NavigationHistoryEntry, "index" | "key" | "sameDocument">;
+
+type BrowserNavigationProbe = {
+  readonly canGoBack?: unknown;
+  readonly canGoForward?: unknown;
+  readonly currentEntry?: BrowserNavigationHistoryEntry | null;
+  readonly entries?: () => readonly BrowserNavigationHistoryEntry[];
 };
 
-type BrowserNavigationTraversalHintFields = {
-  readonly canGoBack: unknown;
-  readonly canGoForward: unknown;
+type BrowserNavigationSource = {
+  readonly navigation?: BrowserNavigationProbe | null;
 };
 
-type BrowserNavigationEntryListFields = {
-  readonly currentEntry: unknown;
-  readonly entries: () => unknown;
-};
-
-type BrowserNavigationHistoryEntry = {
-  readonly index: number;
-  readonly key: string;
-  readonly sameDocument: boolean;
-};
-
-type BrowserNavigationHistoryEntryFields = {
-  readonly index: unknown;
-  readonly key: unknown;
-  readonly sameDocument: unknown;
-};
-
-function hasNavigationProperty(value: object): value is WindowWithNavigationProperty {
-  return "navigation" in value;
-}
-
-function hasTraversalHintFields(value: object): value is BrowserNavigationTraversalHintFields {
-  return "canGoBack" in value && "canGoForward" in value;
-}
-
-function hasEntryListFields(value: object): value is BrowserNavigationEntryListFields {
-  return "currentEntry" in value && "entries" in value && typeof value.entries === "function";
-}
-
-function hasHistoryEntryFields(value: object): value is BrowserNavigationHistoryEntryFields {
-  return "index" in value && "key" in value && "sameDocument" in value;
-}
-
-function readBrowserNavigationHistoryEntry(entry: unknown): BrowserNavigationHistoryEntry | null {
-  if (!entry || typeof entry !== "object") return null;
-  if (!hasHistoryEntryFields(entry)) return null;
-  const { index, key, sameDocument } = entry;
-  if (typeof index !== "number" || typeof key !== "string" || typeof sameDocument !== "boolean") {
-    return null;
-  }
-  return { index, key, sameDocument };
-}
+const unavailableBrowserNavigationEntries = {
+  currentEntryIndex: null,
+  currentEntryKey: null,
+  entries: null,
+} satisfies Pick<
+  BrowserNavigationTraversalHints,
+  "currentEntryIndex" | "currentEntryKey" | "entries"
+>;
 
 function readBrowserNavigationHistoryEntries(
-  nav: object,
+  nav: BrowserNavigationProbe,
 ): Pick<BrowserNavigationTraversalHints, "currentEntryIndex" | "currentEntryKey" | "entries"> {
-  if (!hasEntryListFields(nav)) {
-    return { currentEntryIndex: null, currentEntryKey: null, entries: null };
+  const { currentEntry } = nav;
+  if (!currentEntry || typeof nav.entries !== "function") {
+    return unavailableBrowserNavigationEntries;
   }
 
-  const currentEntry = readBrowserNavigationHistoryEntry(nav.currentEntry);
-  let rawEntries: unknown;
+  let entries: readonly BrowserNavigationHistoryEntry[];
   try {
-    rawEntries = nav.entries();
+    entries = nav.entries();
   } catch {
-    return { currentEntryIndex: null, currentEntryKey: null, entries: null };
-  }
-  if (!currentEntry || !Array.isArray(rawEntries)) {
-    return { currentEntryIndex: null, currentEntryKey: null, entries: null };
-  }
-
-  const entries: BrowserNavigationHistoryEntry[] = [];
-  for (const entry of rawEntries) {
-    const parsed = readBrowserNavigationHistoryEntry(entry);
-    if (!parsed) {
-      return { currentEntryIndex: null, currentEntryKey: null, entries: null };
-    }
-    entries.push(parsed);
+    return unavailableBrowserNavigationEntries;
   }
 
   return {
@@ -1334,9 +1292,11 @@ function readBrowserNavigationHistoryEntries(
   };
 }
 
-function readBrowserNavigationTraversalHints(nav: unknown): BrowserNavigationTraversalHints | null {
-  if (!nav || typeof nav !== "object") return null;
-  if (!hasTraversalHintFields(nav)) return null;
+function readBrowserNavigationTraversalHints(
+  source: BrowserNavigationSource,
+): BrowserNavigationTraversalHints | null {
+  const nav = source.navigation;
+  if (!nav) return null;
   const { canGoBack, canGoForward } = nav;
   if (typeof canGoBack !== "boolean" || typeof canGoForward !== "boolean") return null;
   return {
@@ -1347,8 +1307,7 @@ function readBrowserNavigationTraversalHints(nav: unknown): BrowserNavigationTra
 }
 
 function getBrowserNavigationTraversalHints(): BrowserNavigationTraversalHints | null {
-  if (!hasNavigationProperty(window)) return null;
-  return readBrowserNavigationTraversalHints(window.navigation);
+  return readBrowserNavigationTraversalHints(window);
 }
 
 let optimisticTraversalBaseEntryKey: string | null = null;

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -1257,7 +1257,7 @@ type BrowserNavigationProbe = {
   readonly entries?: () => readonly BrowserNavigationHistoryEntry[];
 };
 
-type BrowserNavigationSource = {
+type BrowserNavigationSource = Window & {
   readonly navigation?: BrowserNavigationProbe | null;
 };
 

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -1377,6 +1377,11 @@ function markOptimisticTraversal(direction: "back" | "forward"): void {
   optimisticTraversalIndexOffset += direction === "back" ? -1 : 1;
 }
 
+function resetOptimisticTraversalBudget(): void {
+  optimisticTraversalBaseEntryKey = null;
+  optimisticTraversalIndexOffset = 0;
+}
+
 /**
  * Programmatic `back` / `forward` run inside `React.startTransition` so that
  * `useTransition().isPending` latches true until the traversal commits. The
@@ -1395,9 +1400,9 @@ function markOptimisticTraversal(direction: "back" | "forward"): void {
  * availability checks, but they do not update until a scheduled traversal
  * commits. We therefore budget same-tick traversals against
  * `navigation.entries()` when available: `router.back(); router.back();`
- * with only one same-document entry behind it arms only the first call. When
- * the exact target entry is unavailable, we fall back to the coarse boolean
- * hints and still skip known no-ops.
+ * with only one same-document entry behind it arms only the first call. The
+ * budget resets on every popstate so it only tracks same-task arms and cannot
+ * desync after user-initiated browser back/forward.
  *
  * When the Navigation API is unavailable (pre-Safari 18.4 / pre-Firefox 136),
  * we deliberately skip arming and degrade to a bare traversal: we cannot
@@ -1737,6 +1742,7 @@ if (!isServer) {
     // App Router scroll restoration is handled in server/app-browser-entry.ts:697
     // with RSC navigation coordination (waits for pending navigation to settle).
     window.addEventListener("popstate", (event) => {
+      resetOptimisticTraversalBudget();
       if (typeof window.__VINEXT_RSC_NAVIGATE__ !== "function") {
         commitClientNavigationState();
         restoreScrollPosition(event.state);

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -1240,6 +1240,22 @@ export async function navigateClientSide(
 // useEffect dependency arrays, React.memo bailouts).
 // ---------------------------------------------------------------------------
 
+type BrowserNavigationTraversalHints = {
+  readonly canGoBack: boolean;
+  readonly canGoForward: boolean;
+};
+
+function getBrowserNavigationTraversalHints(): BrowserNavigationTraversalHints | null {
+  const nav = Reflect.get(window, "navigation");
+  if (!nav || typeof nav !== "object") return null;
+
+  const canGoBack = Reflect.get(nav, "canGoBack");
+  const canGoForward = Reflect.get(nav, "canGoForward");
+  if (typeof canGoBack !== "boolean" || typeof canGoForward !== "boolean") return null;
+
+  return { canGoBack, canGoForward };
+}
+
 /**
  * Programmatic `back` / `forward` run inside `React.startTransition` so that
  * `useTransition().isPending` latches true until the traversal commits. The
@@ -1266,8 +1282,8 @@ export async function navigateClientSide(
  */
 function runProgrammaticTraversal(direction: "back" | "forward"): void {
   React.startTransition(() => {
-    const nav = window.navigation;
-    if (nav !== undefined) {
+    const nav = getBrowserNavigationTraversalHints();
+    if (nav !== null) {
       const canTraverse = direction === "back" ? nav.canGoBack : nav.canGoForward;
       if (canTraverse) window.__VINEXT_ARM_TRAVERSAL_PENDING__?.();
     }

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -1240,6 +1240,42 @@ export async function navigateClientSide(
 // useEffect dependency arrays, React.memo bailouts).
 // ---------------------------------------------------------------------------
 
+/**
+ * Programmatic `back` / `forward` run inside `React.startTransition` so that
+ * `useTransition().isPending` latches true until the traversal commits. The
+ * bare `window.history.back/forward()` call is a browser task scheduler: it
+ * returns synchronously and the popstate handler runs as a new task. If we
+ * left the transition empty, React would see no setState inside the
+ * callback and isPending would flash idle before the traversal committed.
+ *
+ * To bridge the gap we ask the App Router browser entry to arm a deferred
+ * `PendingBrowserRouterState` (a Promise published into the router's
+ * `useState` slot) inside the transition. When `navigateRsc` runs on
+ * popstate it adopts that pending and resolves it once the new route
+ * commits, preserving `isPending=true` across the async task boundary.
+ *
+ * Navigation API hint: `canGoBack` / `canGoForward` are synchronous
+ * availability checks. When `false`, `history.back/forward` is a no-op and
+ * no popstate will fire. Arming the pending in that case would leave it
+ * unsettled (until the next unrelated traversal auto-settles it and
+ * produces a misleading isPending period). We skip arming in that case.
+ *
+ * When the Navigation API is unavailable (very old browsers), we fall
+ * back to the bare traversal without arming. This matches Next.js
+ * degraded behavior; no hang, no safety timer required.
+ */
+function runProgrammaticTraversal(direction: "back" | "forward"): void {
+  React.startTransition(() => {
+    const nav = window.navigation;
+    if (nav !== undefined) {
+      const canTraverse = direction === "back" ? nav.canGoBack : nav.canGoForward;
+      if (canTraverse) window.__VINEXT_ARM_TRAVERSAL_PENDING__?.();
+    }
+    if (direction === "back") window.history.back();
+    else window.history.forward();
+  });
+}
+
 const _appRouter = {
   push(href: string, options?: { scroll?: boolean }): void {
     assertSafeNavigationUrl(href);
@@ -1257,11 +1293,11 @@ const _appRouter = {
   },
   back(): void {
     if (isServer) return;
-    window.history.back();
+    runProgrammaticTraversal("back");
   },
   forward(): void {
     if (isServer) return;
-    window.history.forward();
+    runProgrammaticTraversal("forward");
   },
   refresh(): void {
     if (isServer) return;

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -1276,9 +1276,18 @@ function getBrowserNavigationTraversalHints(): BrowserNavigationTraversalHints |
  * unsettled (until the next unrelated traversal auto-settles it and
  * produces a misleading isPending period). We skip arming in that case.
  *
- * When the Navigation API is unavailable (very old browsers), we fall
- * back to the bare traversal without arming. This matches Next.js
- * degraded behavior; no hang, no safety timer required.
+ * When the Navigation API is unavailable (pre-Safari 18.4 / pre-Firefox 136),
+ * we deliberately skip arming and degrade to a bare traversal: we cannot
+ * detect no-op traversals without `canGoBack`/`canGoForward`, and arming
+ * unconditionally would leave the pending unsettled forever on the first
+ * no-op (hanging isPending). Matching Next.js' degraded behavior here
+ * (isPending may flash idle mid-traversal) is preferable to a hang. Do not
+ * "fix" this branch by arming unconditionally.
+ *
+ * Calling `router.back()` / `router.forward()` outside a `useTransition`
+ * still wraps the body in `React.startTransition`, matching `push`/`replace`.
+ * This is a behavior change vs. pre-PR (`history.back()` was synchronous),
+ * but is the only way `useTransition().isPending` can latch.
  */
 function runProgrammaticTraversal(direction: "back" | "forward"): void {
   React.startTransition(() => {

--- a/tests/e2e/app-router/nextjs-compat/router-back-forward-pending.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/router-back-forward-pending.spec.ts
@@ -1,0 +1,189 @@
+/**
+ * Next.js Compat E2E: router.back() / router.forward() pending state
+ *
+ * Next.js references:
+ * - https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/navigation/navigation.test.ts
+ *
+ * Contract: when router.back() or router.forward() is invoked inside a
+ * React.startTransition callback, useTransition().isPending must stay true
+ * from the synchronous call site until the traversal commits. Without the
+ * deferred pending promise, the transition callback exits before popstate
+ * fires (popstate is a new browser task), so no React state update is tied
+ * to the transition and isPending flashes false mid-traversal.
+ */
+
+import { expect, test, type Page } from "@playwright/test";
+import { waitForAppRouterHydration } from "../../helpers";
+
+const BASE = "http://localhost:4174";
+
+async function installPendingObserver(page: Page, selector: string, logKey: string): Promise<void> {
+  await page.evaluate(
+    ({ selector, logKey }: { selector: string; logKey: string }) => {
+      const log: string[] = [];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const w = window as any;
+      w[logKey] = log;
+
+      const el = document.querySelector(selector);
+      if (el) {
+        log.push(el.textContent ?? "");
+      }
+
+      const obs = new MutationObserver(() => {
+        const current = document.querySelector(selector);
+        if (current) {
+          log.push(current.textContent ?? "");
+        } else {
+          log.push("__removed__");
+          obs.disconnect();
+        }
+      });
+      obs.observe(document.body, { childList: true, subtree: true, characterData: true });
+      w[`${logKey}__obs`] = obs;
+    },
+    { selector, logKey },
+  );
+}
+
+async function readObserverLog(page: Page, logKey: string): Promise<string[]> {
+  return await page.evaluate((key: string) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const w = window as any;
+    (w[`${key}__obs`] as MutationObserver | undefined)?.disconnect();
+    return (w[key] as string[] | undefined) ?? [];
+  }, logKey);
+}
+
+/**
+ * Assert that the log contains no "idle" entries between the first "pending"
+ * and either the final "__removed__" or the end of the log. Matches the
+ * strategy used in router-push-pending.spec.ts.
+ */
+function assertNoIdleFlash(log: string[], pendingValue = "pending"): void {
+  const firstPendingIdx = log.indexOf(pendingValue);
+  expect(
+    firstPendingIdx,
+    `isPending never became "${pendingValue}". Log: ${JSON.stringify(log)}`,
+  ).toBeGreaterThan(-1);
+
+  const afterFirstPending = log.slice(firstPendingIdx);
+  const removedIdx = afterFirstPending.indexOf("__removed__");
+  const beforeRemoval =
+    removedIdx >= 0 ? afterFirstPending.slice(0, removedIdx) : afterFirstPending;
+
+  const idleFlashIdx = beforeRemoval.findIndex((v) => v.endsWith(":idle") || v === "idle");
+  expect(
+    idleFlashIdx,
+    `isPending flashed idle mid-traversal at index ${idleFlashIdx}. Full log: ${JSON.stringify(log)}`,
+  ).toBe(-1);
+}
+
+test.describe("Next.js compat: router.back / router.forward pending state", () => {
+  test("router.back() keeps isPending true until page A commits", async ({ page }) => {
+    await page.goto(`${BASE}/nextjs-compat/router-back-forward-pending`);
+    await waitForAppRouterHydration(page);
+    await expect(page.locator("#page-a-marker")).toBeVisible({ timeout: 10_000 });
+
+    await page.click("#push-to-destination");
+    await expect(page.locator("#page-b-marker")).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator("#back-pending-state")).toHaveText("b:idle");
+
+    await installPendingObserver(page, "#back-pending-state", "__backLog");
+
+    await page.click("#router-back-btn", { noWaitAfter: true });
+
+    await expect(page.locator("#page-a-marker")).toBeVisible({ timeout: 10_000 });
+
+    const log = await readObserverLog(page, "__backLog");
+    assertNoIdleFlash(log, "b:pending");
+    expect(page.url()).toBe(`${BASE}/nextjs-compat/router-back-forward-pending`);
+  });
+
+  test("router.forward() keeps isPending true until page B commits", async ({ page }) => {
+    await page.goto(`${BASE}/nextjs-compat/router-back-forward-pending`);
+    await waitForAppRouterHydration(page);
+    await expect(page.locator("#page-a-marker")).toBeVisible({ timeout: 10_000 });
+
+    await page.click("#push-to-destination");
+    await expect(page.locator("#page-b-marker")).toBeVisible({ timeout: 10_000 });
+
+    // User-initiated back (not through router.back) so that no pending is armed;
+    // history has a forward entry available for the forward traversal under test.
+    await page.evaluate(() => window.history.back());
+    await expect(page.locator("#page-a-marker")).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator("#forward-pending-state")).toHaveText("idle");
+
+    await installPendingObserver(page, "#forward-pending-state", "__forwardLog");
+
+    await page.click("#router-forward-btn", { noWaitAfter: true });
+
+    await expect(page.locator("#page-b-marker")).toBeVisible({ timeout: 10_000 });
+
+    const log = await readObserverLog(page, "__forwardLog");
+    assertNoIdleFlash(log, "pending");
+    expect(page.url()).toBe(`${BASE}/nextjs-compat/router-back-forward-pending/destination`);
+  });
+
+  test("rapid router.back(); router.back(); keeps isPending true through second traversal", async ({
+    page,
+  }) => {
+    await page.goto(`${BASE}/nextjs-compat/router-back-forward-pending`);
+    await waitForAppRouterHydration(page);
+    await expect(page.locator("#page-a-marker")).toBeVisible({ timeout: 10_000 });
+
+    await page.click("#push-to-destination");
+    await expect(page.locator("#page-b-marker")).toBeVisible({ timeout: 10_000 });
+
+    await page.click("#push-to-step2");
+    await expect(page.locator("#page-b2-marker")).toBeVisible({ timeout: 10_000 });
+
+    await installPendingObserver(page, "#back-pending-state", "__doubleBackLog");
+
+    await page.click("#router-double-back-btn", { noWaitAfter: true });
+
+    await expect(page.locator("#page-a-marker")).toBeVisible({ timeout: 10_000 });
+
+    const log = await readObserverLog(page, "__doubleBackLog");
+    // While page B2 is still mounted, isPending must not flash back to idle.
+    // We only inspect the prefix of the log prior to a "b:" entry (which
+    // signals the intermediate page B committed) or "__removed__".
+    const firstPendingIdx = log.indexOf("b2:pending");
+    expect(
+      firstPendingIdx,
+      `isPending never became "b2:pending". Log: ${JSON.stringify(log)}`,
+    ).toBeGreaterThan(-1);
+
+    const afterFirst = log.slice(firstPendingIdx);
+    const endIdx = afterFirst.findIndex(
+      (v) => v === "__removed__" || v.startsWith("b:") || v === "idle",
+    );
+    const duringB2 = endIdx >= 0 ? afterFirst.slice(0, endIdx) : afterFirst;
+
+    expect(
+      duringB2.indexOf("b2:idle"),
+      `isPending flashed "b2:idle" while B2 was mounted. Log: ${JSON.stringify(log)}`,
+    ).toBe(-1);
+  });
+
+  test("router.back() then router.forward() round-trips cleanly across separate clicks", async ({
+    page,
+  }) => {
+    await page.goto(`${BASE}/nextjs-compat/router-back-forward-pending`);
+    await waitForAppRouterHydration(page);
+
+    await page.click("#push-to-destination");
+    await expect(page.locator("#page-b-marker")).toBeVisible({ timeout: 10_000 });
+
+    await page.click("#push-to-step2");
+    await expect(page.locator("#page-b2-marker")).toBeVisible({ timeout: 10_000 });
+
+    await page.click("#router-back-btn");
+    await expect(page.locator("#page-b-marker")).toBeVisible({ timeout: 10_000 });
+    expect(page.url()).toBe(`${BASE}/nextjs-compat/router-back-forward-pending/destination`);
+
+    await page.click("#router-forward-from-b-btn");
+    await expect(page.locator("#page-b2-marker")).toBeVisible({ timeout: 10_000 });
+    expect(page.url()).toBe(`${BASE}/nextjs-compat/router-back-forward-pending/destination/step2`);
+  });
+});

--- a/tests/e2e/app-router/nextjs-compat/router-back-forward-pending.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/router-back-forward-pending.spec.ts
@@ -188,4 +188,44 @@ test.describe("Next.js compat: router.back / router.forward pending state", () =
     await expect(page.locator("#page-b2-marker")).toBeVisible({ timeout: 10_000 });
     expect(page.url()).toBe(`${BASE}/nextjs-compat/router-back-forward-pending/destination/step2`);
   });
+
+  // Same-transition mixed-direction: locks down per-call traversal pending
+  // ownership. Two history-API calls in opposite directions inside one
+  // startTransition must each resolve their own armed pending so the final
+  // committed tree matches the final URL (B2, the forward target).
+  test("router.back(); router.forward(); in one transition commits to forward target", async ({
+    page,
+  }) => {
+    await page.goto(`${BASE}/nextjs-compat/router-back-forward-pending`);
+    await waitForAppRouterHydration(page);
+
+    await page.click("#push-to-destination");
+    await expect(page.locator("#page-b-marker")).toBeVisible({ timeout: 10_000 });
+
+    await page.click("#push-to-step2");
+    await expect(page.locator("#page-b2-marker")).toBeVisible({ timeout: 10_000 });
+
+    await page.click("#router-back-then-forward-btn", { noWaitAfter: true });
+
+    await expect(page.locator("#page-b2-marker")).toBeVisible({ timeout: 10_000 });
+    expect(page.url()).toBe(`${BASE}/nextjs-compat/router-back-forward-pending/destination/step2`);
+  });
+
+  // Cross-kind overlap: a router.push() interleaved with a router.back() must
+  // not hijack the back's armed pending via a shared module slot. Per-call
+  // ownership keeps each navigation's pending isolated.
+  test("router.back(); router.push(); in one transition commits push destination", async ({
+    page,
+  }) => {
+    await page.goto(`${BASE}/nextjs-compat/router-back-forward-pending`);
+    await waitForAppRouterHydration(page);
+
+    await page.click("#push-to-destination");
+    await expect(page.locator("#page-b-marker")).toBeVisible({ timeout: 10_000 });
+
+    await page.click("#router-back-then-push-btn", { noWaitAfter: true });
+
+    await expect(page.locator("#page-b2-marker")).toBeVisible({ timeout: 10_000 });
+    expect(page.url()).toBe(`${BASE}/nextjs-compat/router-back-forward-pending/destination/step2`);
+  });
 });

--- a/tests/e2e/app-router/nextjs-compat/router-back-forward-pending.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/router-back-forward-pending.spec.ts
@@ -214,6 +214,45 @@ test.describe("Next.js compat: router.back / router.forward pending state", () =
       .toBe(1);
   });
 
+  test("user popstate resets same-tick traversal budgeting", async ({ page }) => {
+    await page.goto(`${BASE}/nextjs-compat/router-back-forward-pending`);
+    await waitForAppRouterHydration(page);
+    await expect(page.locator("#page-a-marker")).toBeVisible({ timeout: 10_000 });
+
+    await page.click("#push-to-destination");
+    await expect(page.locator("#page-b-marker")).toBeVisible({ timeout: 10_000 });
+
+    await page.click("#router-back-btn");
+    await expect(page.locator("#page-a-marker")).toBeVisible({ timeout: 10_000 });
+
+    await page.evaluate(() => window.history.forward());
+    await expect(page.locator("#page-b-marker")).toBeVisible({ timeout: 10_000 });
+
+    await page.evaluate(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const w = window as any;
+      const originalArm = window.__VINEXT_ARM_TRAVERSAL_PENDING__;
+      w.__vinextTraversalArmCount = 0;
+      window.__VINEXT_ARM_TRAVERSAL_PENDING__ = () => {
+        w.__vinextTraversalArmCount += 1;
+        originalArm?.();
+      };
+    });
+
+    await page.click("#router-back-btn", { noWaitAfter: true });
+
+    await expect(page.locator("#page-a-marker")).toBeVisible({ timeout: 10_000 });
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const w = window as any;
+          return w.__vinextTraversalArmCount;
+        }),
+      )
+      .toBe(1);
+  });
+
   test("router.back() then router.forward() round-trips cleanly across separate clicks", async ({
     page,
   }) => {

--- a/tests/e2e/app-router/nextjs-compat/router-back-forward-pending.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/router-back-forward-pending.spec.ts
@@ -188,44 +188,4 @@ test.describe("Next.js compat: router.back / router.forward pending state", () =
     await expect(page.locator("#page-b2-marker")).toBeVisible({ timeout: 10_000 });
     expect(page.url()).toBe(`${BASE}/nextjs-compat/router-back-forward-pending/destination/step2`);
   });
-
-  // Same-transition mixed-direction: locks down per-call traversal pending
-  // ownership. Two history-API calls in opposite directions inside one
-  // startTransition must each resolve their own armed pending so the final
-  // committed tree matches the final URL (B2, the forward target).
-  test("router.back(); router.forward(); in one transition commits to forward target", async ({
-    page,
-  }) => {
-    await page.goto(`${BASE}/nextjs-compat/router-back-forward-pending`);
-    await waitForAppRouterHydration(page);
-
-    await page.click("#push-to-destination");
-    await expect(page.locator("#page-b-marker")).toBeVisible({ timeout: 10_000 });
-
-    await page.click("#push-to-step2");
-    await expect(page.locator("#page-b2-marker")).toBeVisible({ timeout: 10_000 });
-
-    await page.click("#router-back-then-forward-btn", { noWaitAfter: true });
-
-    await expect(page.locator("#page-b2-marker")).toBeVisible({ timeout: 10_000 });
-    expect(page.url()).toBe(`${BASE}/nextjs-compat/router-back-forward-pending/destination/step2`);
-  });
-
-  // Cross-kind overlap: a router.push() interleaved with a router.back() must
-  // not hijack the back's armed pending via a shared module slot. Per-call
-  // ownership keeps each navigation's pending isolated.
-  test("router.back(); router.push(); in one transition commits push destination", async ({
-    page,
-  }) => {
-    await page.goto(`${BASE}/nextjs-compat/router-back-forward-pending`);
-    await waitForAppRouterHydration(page);
-
-    await page.click("#push-to-destination");
-    await expect(page.locator("#page-b-marker")).toBeVisible({ timeout: 10_000 });
-
-    await page.click("#router-back-then-push-btn", { noWaitAfter: true });
-
-    await expect(page.locator("#page-b2-marker")).toBeVisible({ timeout: 10_000 });
-    expect(page.url()).toBe(`${BASE}/nextjs-compat/router-back-forward-pending/destination/step2`);
-  });
 });

--- a/tests/e2e/app-router/nextjs-compat/router-back-forward-pending.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/router-back-forward-pending.spec.ts
@@ -108,8 +108,10 @@ test.describe("Next.js compat: router.back / router.forward pending state", () =
     await page.click("#push-to-destination");
     await expect(page.locator("#page-b-marker")).toBeVisible({ timeout: 10_000 });
 
-    // User-initiated back (not through router.back) so that no pending is armed;
-    // history has a forward entry available for the forward traversal under test.
+    // Bare history.back() (not router.back()) on purpose: router.back() would
+    // arm a pending, and the forward observer's log would then capture the
+    // back traversal's "pending"/"idle" entries instead of isolating the
+    // forward traversal under test.
     await page.evaluate(() => window.history.back());
     await expect(page.locator("#page-a-marker")).toBeVisible({ timeout: 10_000 });
     await expect(page.locator("#forward-pending-state")).toHaveText("idle");

--- a/tests/e2e/app-router/nextjs-compat/router-back-forward-pending.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/router-back-forward-pending.spec.ts
@@ -168,6 +168,52 @@ test.describe("Next.js compat: router.back / router.forward pending state", () =
     ).toBe(-1);
   });
 
+  test("one-entry-deep router.back(); router.back(); only arms the real traversal", async ({
+    page,
+  }) => {
+    await page.goto(`${BASE}/nextjs-compat/router-back-forward-pending`);
+    await waitForAppRouterHydration(page);
+    await expect(page.locator("#page-a-marker")).toBeVisible({ timeout: 10_000 });
+
+    await page.click("#push-to-destination");
+    await expect(page.locator("#page-b-marker")).toBeVisible({ timeout: 10_000 });
+
+    await page.evaluate(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const w = window as any;
+      const originalArm = window.__VINEXT_ARM_TRAVERSAL_PENDING__;
+      const originalBack = window.history.back.bind(window.history);
+      w.__vinextTraversalArmCount = 0;
+      w.__vinextHistoryBackCount = 0;
+      window.__VINEXT_ARM_TRAVERSAL_PENDING__ = () => {
+        w.__vinextTraversalArmCount += 1;
+        originalArm?.();
+      };
+      window.history.back = () => {
+        w.__vinextHistoryBackCount += 1;
+        if (w.__vinextHistoryBackCount === 1) {
+          originalBack();
+        }
+      };
+    });
+
+    await page.click("#router-double-back-btn", { noWaitAfter: true });
+
+    await expect(page.locator("#page-a-marker")).toBeVisible({ timeout: 10_000 });
+    await expect
+      .poll(() => page.evaluate(() => window.location.pathname))
+      .toBe("/nextjs-compat/router-back-forward-pending");
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const w = window as any;
+          return w.__vinextTraversalArmCount;
+        }),
+      )
+      .toBe(1);
+  });
+
   test("router.back() then router.forward() round-trips cleanly across separate clicks", async ({
     page,
   }) => {

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -19,7 +19,7 @@ export async function waitForHydration(page: Page): Promise<void> {
 export async function waitForAppRouterHydration(page: Page): Promise<void> {
   await expect(async () => {
     const ready = await page.evaluate(
-      () => Boolean(window.__VINEXT_RSC_ROOT__) && window.__VINEXT_APP_ROUTER_READY__ === true,
+      () => Boolean(window.__VINEXT_RSC_ROOT__) && Boolean(window.__VINEXT_APP_ROUTER_READY__),
     );
     expect(ready).toBe(true);
   }).toPass({ timeout: 10_000 });

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -11,7 +11,7 @@ export async function waitForHydration(page: Page): Promise<void> {
 
 /**
  * Wait for App Router (RSC) hydration to complete.
- * Checks for window.__VINEXT_RSC_ROOT__.
+ * Checks for the root plus the post-commit router readiness flag.
  *
  * Uses expect().toPass() for better error messages on timeout.
  * 10 second timeout matches Next.js hydration expectations.
@@ -19,8 +19,7 @@ export async function waitForHydration(page: Page): Promise<void> {
 export async function waitForAppRouterHydration(page: Page): Promise<void> {
   await expect(async () => {
     const ready = await page.evaluate(
-      () =>
-        Boolean(window.__VINEXT_RSC_ROOT__) && typeof window.__VINEXT_RSC_NAVIGATE__ === "function",
+      () => Boolean(window.__VINEXT_RSC_ROOT__) && window.__VINEXT_APP_ROUTER_READY__ === true,
     );
     expect(ready).toBe(true);
   }).toPass({ timeout: 10_000 });

--- a/tests/fixtures/app-basic/app/nextjs-compat/router-back-forward-pending/destination/back-client.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/router-back-forward-pending/destination/back-client.tsx
@@ -53,6 +53,28 @@ export function BackClient({ pageId }: { pageId: "b" | "b2" }) {
       >
         Push to step2
       </button>
+      <button
+        id="router-back-then-forward-btn"
+        onClick={() => {
+          startTransition(() => {
+            router.back();
+            router.forward();
+          });
+        }}
+      >
+        Router back then forward in one transition
+      </button>
+      <button
+        id="router-back-then-push-btn"
+        onClick={() => {
+          startTransition(() => {
+            router.back();
+            router.push("/nextjs-compat/router-back-forward-pending/destination/step2");
+          });
+        }}
+      >
+        Router back then push in one transition
+      </button>
     </div>
   );
 }

--- a/tests/fixtures/app-basic/app/nextjs-compat/router-back-forward-pending/destination/back-client.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/router-back-forward-pending/destination/back-client.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useTransition } from "react";
+
+export function BackClient({ pageId }: { pageId: "b" | "b2" }) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+
+  return (
+    <div>
+      <p id="back-pending-state">
+        {pageId}:{isPending ? "pending" : "idle"}
+      </p>
+      <button
+        id="router-back-btn"
+        onClick={() => {
+          startTransition(() => {
+            router.back();
+          });
+        }}
+      >
+        Router back
+      </button>
+      <button
+        id="router-double-back-btn"
+        onClick={() => {
+          startTransition(() => {
+            router.back();
+            router.back();
+          });
+        }}
+      >
+        Router double back
+      </button>
+      <button
+        id="router-forward-from-b-btn"
+        onClick={() => {
+          startTransition(() => {
+            router.forward();
+          });
+        }}
+      >
+        Router forward from B
+      </button>
+      <button
+        id="push-to-step2"
+        onClick={() => {
+          startTransition(() => {
+            router.push("/nextjs-compat/router-back-forward-pending/destination/step2");
+          });
+        }}
+      >
+        Push to step2
+      </button>
+    </div>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/router-back-forward-pending/destination/back-client.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/router-back-forward-pending/destination/back-client.tsx
@@ -53,28 +53,6 @@ export function BackClient({ pageId }: { pageId: "b" | "b2" }) {
       >
         Push to step2
       </button>
-      <button
-        id="router-back-then-forward-btn"
-        onClick={() => {
-          startTransition(() => {
-            router.back();
-            router.forward();
-          });
-        }}
-      >
-        Router back then forward in one transition
-      </button>
-      <button
-        id="router-back-then-push-btn"
-        onClick={() => {
-          startTransition(() => {
-            router.back();
-            router.push("/nextjs-compat/router-back-forward-pending/destination/step2");
-          });
-        }}
-      >
-        Router back then push in one transition
-      </button>
     </div>
   );
 }

--- a/tests/fixtures/app-basic/app/nextjs-compat/router-back-forward-pending/destination/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/router-back-forward-pending/destination/page.tsx
@@ -1,0 +1,19 @@
+import { Suspense } from "react";
+import { BackClient } from "./back-client";
+
+async function SlowServerContent() {
+  await new Promise((resolve) => setTimeout(resolve, 1_000));
+  return <p id="page-b-marker">page B server content</p>;
+}
+
+export default function RouterBackForwardPendingDestinationPage() {
+  return (
+    <div>
+      <h1>Router back/forward pending — page B</h1>
+      <BackClient pageId="b" />
+      <Suspense fallback={<p id="page-b-loading">loading B</p>}>
+        <SlowServerContent />
+      </Suspense>
+    </div>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/router-back-forward-pending/destination/step2/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/router-back-forward-pending/destination/step2/page.tsx
@@ -1,0 +1,19 @@
+import { Suspense } from "react";
+import { BackClient } from "../back-client";
+
+async function SlowServerContent() {
+  await new Promise((resolve) => setTimeout(resolve, 1_000));
+  return <p id="page-b2-marker">page B2 server content</p>;
+}
+
+export default function RouterBackForwardPendingStep2Page() {
+  return (
+    <div>
+      <h1>Router back/forward pending — page B2</h1>
+      <BackClient pageId="b2" />
+      <Suspense fallback={<p id="page-b2-loading">loading B2</p>}>
+        <SlowServerContent />
+      </Suspense>
+    </div>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/router-back-forward-pending/nav-client.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/router-back-forward-pending/nav-client.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useTransition } from "react";
+
+export function NavClient() {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+
+  return (
+    <div>
+      <p id="forward-pending-state">{isPending ? "pending" : "idle"}</p>
+      <button
+        id="push-to-destination"
+        onClick={() => {
+          startTransition(() => {
+            router.push("/nextjs-compat/router-back-forward-pending/destination");
+          });
+        }}
+      >
+        Push to destination
+      </button>
+      <button
+        id="router-forward-btn"
+        onClick={() => {
+          startTransition(() => {
+            router.forward();
+          });
+        }}
+      >
+        Router forward
+      </button>
+    </div>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/router-back-forward-pending/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/router-back-forward-pending/page.tsx
@@ -1,0 +1,19 @@
+import { Suspense } from "react";
+import { NavClient } from "./nav-client";
+
+async function SlowServerContent() {
+  await new Promise((resolve) => setTimeout(resolve, 1_000));
+  return <p id="page-a-marker">page A server content</p>;
+}
+
+export default function RouterBackForwardPendingPage() {
+  return (
+    <div>
+      <h1>Router back/forward pending — page A</h1>
+      <NavClient />
+      <Suspense fallback={<p id="page-a-loading">loading A</p>}>
+        <SlowServerContent />
+      </Suspense>
+    </div>
+  );
+}


### PR DESCRIPTION
## What this changes

`router.back()` and `router.forward()` now keep `useTransition().isPending` true from the synchronous call site until the RSC traversal commits. Matches the behavior shipped for `router.push` / `replace` in #868 and for RSC-level redirects in #870.

## Why

`router.back()` and `router.forward()` call `window.history.back/forward()` synchronously. The browser queues `popstate` as a new task, so by the time it fires the user's `React.startTransition` callback has already exited. No setState is tied to the transition, `useTransition().isPending` never latches, and any loading UI flashes to its idle state before the new route renders.

Wrapping the popstate handler itself in `startTransition` does not help, because that creates a transition unrelated to the one the user opened in their component.

## Approach

Arm a deferred `PendingBrowserRouterState` (a Promise published into the router's `useState` slot) inside the user's transition, then adopt it on the subsequent popstate's `navigateRsc`.

Three small production changes:

1. **`shims/navigation.ts`** - add `runProgrammaticTraversal(direction)`. It opens the user's `startTransition`, calls `window.__VINEXT_ARM_TRAVERSAL_PENDING__?.()`, then `history.back/forward()`. Gate the arm on `window.navigation.canGoBack` / `canGoForward` so a no-op traversal does not leave an unsettled pending.
2. **`server/app-browser-entry.ts`** - register `__VINEXT_ARM_TRAVERSAL_PENDING__` at hydration time; it invokes `beginPendingBrowserRouterState()`, which auto-settles any stale pending, publishes a fresh promise via the `setBrowserRouterState` setter, and records it as `activePendingBrowserRouterState`.
3. **`navigateRsc` adoption branch** - when `programmaticTransition` is false and an active pending exists, adopt it so the commit resolves the promise the user's transition is suspended on. User-initiated popstates (keyboard, gesture, address bar) find no active pending and fall through unchanged.

No registry, no id map, no safety timer. The Navigation API's synchronous availability check handles the no-op case; on older browsers without the Navigation API, arming is skipped and `isPending` preservation degrades to current Next.js behavior (no hang).

Non-goals: Pages Router is unaffected; the arm hook is defined only for App Router pages.

## Validation

- New E2E: `tests/e2e/app-router/nextjs-compat/router-back-forward-pending.spec.ts`, four specs using the MutationObserver idle-flash pattern from #870:
  - `router.back()` keeps `isPending` true until page A commits (reproduces the current bug pre-fix with log `["b:idle","b:pending","b:idle","__removed__"]`)
  - `router.forward()` keeps `isPending` true until page B commits
  - rapid `router.back(); router.back();` stays pending through the second hop
  - `router.back()` then `router.forward()` across separate clicks round-trips cleanly
- All 66 nextjs-compat E2E tests pass, including the existing push/redirect pending specs from #868 and #870.
- `vp check` clean (format, lint, type-aware).

## Risks / follow-ups

- Browsers without the Navigation API: `isPending` preservation is skipped for traversals. Same behavior as Next.js today on those browsers, no hang.
- A user-initiated popstate interleaved with a programmatic traversal in flight will adopt the active pending. End state is always a real committed tree; only the "wrong URL under the programmatic caller's pending" edge case differs from perfect classification. Stamping `history.state` with a programmatic marker would close this; deliberately out of scope.