### PR TITLE
[codex] Fix usePathname hydration snapshot

### DIFF
--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -163,8 +163,29 @@ export const GLOBAL_ACCESSORS_KEY = Symbol.for("vinext.navigation.globalAccessor
 const _GLOBAL_ACCESSORS_KEY = GLOBAL_ACCESSORS_KEY;
 type _GlobalWithAccessors = typeof globalThis & { [_GLOBAL_ACCESSORS_KEY]?: _StateAccessors };
 
+// Browser hydration has the same module-split shape as SSR in Vite dev:
+// the browser entry seeds the snapshot before hydrateRoot(), but client
+// components can import a different module instance of this shim.
+const GLOBAL_HYDRATION_CONTEXT_KEY = Symbol.for("vinext.navigation.clientHydrationContext");
+const _GLOBAL_HYDRATION_CONTEXT_KEY = GLOBAL_HYDRATION_CONTEXT_KEY;
+type _GlobalWithHydrationContext = typeof globalThis & {
+  [_GLOBAL_HYDRATION_CONTEXT_KEY]?: NavigationContext | null;
+};
+
 function _getGlobalAccessors(): _StateAccessors | undefined {
   return (globalThis as _GlobalWithAccessors)[_GLOBAL_ACCESSORS_KEY];
+}
+
+function _getClientHydrationContext(): NavigationContext | null | undefined {
+  const globalState = globalThis as _GlobalWithHydrationContext;
+  if (Object.prototype.hasOwnProperty.call(globalState, _GLOBAL_HYDRATION_CONTEXT_KEY)) {
+    return globalState[_GLOBAL_HYDRATION_CONTEXT_KEY] ?? null;
+  }
+  return undefined;
+}
+
+function _setClientHydrationContext(ctx: NavigationContext | null): void {
+  (globalThis as _GlobalWithHydrationContext)[_GLOBAL_HYDRATION_CONTEXT_KEY] = ctx;
 }
 
 let _serverContext: NavigationContext | null = null;
@@ -173,10 +194,19 @@ let _serverInsertedHTMLCallbacks: Array<() => unknown> = [];
 // These are overridden by navigation-state.ts on the server to use ALS.
 // The defaults check globalThis for cross-module-instance access (issue #688).
 let _getServerContext = (): NavigationContext | null => {
+  if (typeof window !== "undefined") {
+    const hydrationContext = _getClientHydrationContext();
+    return hydrationContext !== undefined ? hydrationContext : _serverContext;
+  }
   const g = _getGlobalAccessors();
   return g ? g.getServerContext() : _serverContext;
 };
 let _setServerContext = (ctx: NavigationContext | null): void => {
+  if (typeof window !== "undefined") {
+    _serverContext = ctx;
+    _setClientHydrationContext(ctx);
+    return;
+  }
   const g = _getGlobalAccessors();
   if (g) {
     g.setServerContext(ctx);

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -229,6 +229,90 @@ describe("next/navigation shim", () => {
     setNavigationContext(null);
   });
 
+  it("shares the hydrated navigation snapshot across browser module instances", async () => {
+    // Next.js derives usePathname/useSearchParams from PathnameContext in
+    // packages/next/src/client/components/app-router.tsx, so hydration does
+    // not have a per-module fallback to "/" for the first client snapshot.
+    const React = await import("react");
+    const { renderToStaticMarkup } = await import("react-dom/server");
+    const previousWindow = globalThis.window;
+    const accessorsKey = Symbol.for("vinext.navigation.globalAccessors");
+    const hydrationKey = Symbol.for("vinext.navigation.clientHydrationContext");
+    const globalRecord = globalThis as Record<PropertyKey, unknown>;
+    const previousAccessors = globalRecord[accessorsKey];
+    const previousHydration = globalRecord[hydrationKey];
+
+    try {
+      delete globalRecord[accessorsKey];
+      delete globalRecord[hydrationKey];
+      (globalThis as any).window = {
+        addEventListener() {},
+        dispatchEvent() {
+          return true;
+        },
+        history: {
+          pushState() {},
+          replaceState() {},
+        },
+        location: {
+          href: "http://localhost/split-hydration?q=hello",
+          origin: "http://localhost",
+          pathname: "/split-hydration",
+          search: "?q=hello",
+        },
+        removeEventListener() {},
+      };
+
+      const setterPath = "../packages/vinext/src/shims/navigation.js?hydration-setter=issue-871";
+      const hookPath = "../packages/vinext/src/shims/navigation.js?hydration-hook=issue-871";
+      const setterMod = (await import(
+        setterPath
+      )) as typeof import("../packages/vinext/src/shims/navigation.js");
+      const hookMod = (await import(
+        hookPath
+      )) as typeof import("../packages/vinext/src/shims/navigation.js");
+
+      setterMod.setNavigationContext({
+        pathname: "/split-hydration",
+        searchParams: new URLSearchParams("q=hello"),
+        params: { slug: "hello" },
+      });
+
+      function Probe() {
+        const pathname = hookMod.usePathname();
+        const searchParams = hookMod.useSearchParams();
+        const params = hookMod.useParams<{ slug: string }>();
+        return React.createElement(
+          "span",
+          null,
+          `${pathname}|${searchParams.get("q") ?? ""}|${params.slug ?? ""}`,
+        );
+      }
+
+      expect(renderToStaticMarkup(React.createElement(Probe))).toBe(
+        "<span>/split-hydration|hello|hello</span>",
+      );
+
+      setterMod.setNavigationContext(null);
+    } finally {
+      if (previousWindow === undefined) {
+        delete (globalThis as any).window;
+      } else {
+        (globalThis as any).window = previousWindow;
+      }
+      if (previousAccessors === undefined) {
+        delete globalRecord[accessorsKey];
+      } else {
+        globalRecord[accessorsKey] = previousAccessors;
+      }
+      if (previousHydration === undefined) {
+        delete globalRecord[hydrationKey];
+      } else {
+        globalRecord[hydrationKey] = previousHydration;
+      }
+    }
+  });
+
   it("setClientParams provides referential stability for identical params", async () => {
     const { setClientParams, getClientParams } =
       await import("../packages/vinext/src/shims/navigation.js");


### PR DESCRIPTION
Fixes #871.

## Summary
- Share the browser hydration navigation context through a `Symbol.for` global so split `next/navigation` module instances read the same initial snapshot.
- Keep server-side ALS access unchanged while preventing client `usePathname()`, `useSearchParams()`, and `useParams()` from falling back to `/` during hydration.
- Add a regression test that loads separate setter/hook module instances and verifies the hydrated pathname, query, and params stay in sync.

## Validation
- `pnpm test tests/shims.test.ts -t "shares the hydrated navigation snapshot"`
- `pnpm test tests/nextjs-compat/use-client-page-pathname.test.ts tests/nextjs-compat/rsc-context-lazy-stream.test.ts`
