### PR TITLE
fix: centralize protocol-relative URL guard to handle percent-encoded delimiters

### DIFF
--- a/packages/vinext/src/deploy.ts
+++ b/packages/vinext/src/deploy.ts
@@ -564,6 +564,20 @@ function stripBasePath(pathname: string, basePath: string): string {
   return pathname.slice(basePath.length) || "/";
 }
 
+// Mirror of isOpenRedirectShaped in server/request-pipeline.ts. Inlined here
+// because this worker runs in the Cloudflare Workers environment and can't
+// import from our local source at build time. Keep in sync.
+function isOpenRedirectShaped(rawPathname: string): boolean {
+  if (!rawPathname.startsWith("/")) return false;
+  const afterSlash = rawPathname.slice(1);
+  if (afterSlash.startsWith("/") || afterSlash.startsWith("\\")) return true;
+  if (afterSlash.length >= 3 && afterSlash[0] === "%") {
+    const encoded = afterSlash.slice(0, 3).toLowerCase();
+    if (encoded === "%5c" || encoded === "%2f") return true;
+  }
+  return false;
+}
+
 export default {
   async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
     try {
@@ -571,10 +585,13 @@ export default {
       let pathname = url.pathname;
       let urlWithQuery = pathname + url.search;
 
-      // Block protocol-relative URL open redirects (//evil.com/ or /\\evil.com/).
-      // Normalize backslashes: browsers treat /\\ as // in URL context.
-      const safePath = pathname.replaceAll("\\\\", "/");
-      if (safePath.startsWith("//")) {
+      // Block protocol-relative URL open redirects in all shapes:
+      //   literal  //evil.com, /\\\\evil.com
+      //   encoded  /%5Cevil.com, /%2F/evil.com
+      // Browsers normalize backslash to forward slash, and they percent-decode
+      // Location headers, so an encoded backslash in a downstream 308 redirect
+      // would also navigate to the attacker's origin.
+      if (isOpenRedirectShaped(pathname)) {
         return new Response("404 Not Found", { status: 404 });
       }
 

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -46,6 +46,7 @@ import {
 import { findMiddlewareFile, runMiddleware } from "./server/middleware.js";
 import { logRequest, now } from "./server/request-log.js";
 import { normalizePath } from "./server/normalize-path.js";
+import { isOpenRedirectShaped } from "./server/request-pipeline.js";
 import {
   findInstrumentationClientFile,
   findInstrumentationFile,
@@ -2293,15 +2294,16 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
               }
 
               // Guard against protocol-relative URL open redirects.
-              // Normalize backslashes first: browsers treat /\ as // in URL
-              // context. Check the RAW pathname before normalizePath so the
-              // guard fires before normalizePath collapses //.
-              pathname = pathname.replaceAll("\\", "/");
-              if (pathname.startsWith("//")) {
+              // Check the RAW pathname before decode/normalize so both literal
+              // (//, /\) and percent-encoded (%5C, %2F) leading delimiters are
+              // rejected. Encoded forms survive the segment-wise decode below
+              // and would otherwise reach trailing-slash redirect emitters.
+              if (isOpenRedirectShaped(pathname)) {
                 res.writeHead(404);
                 res.end("404 Not Found");
                 return;
               }
+              pathname = pathname.replaceAll("\\", "/");
 
               // Normalize the pathname to prevent path-confusion attacks.
               // decodeURIComponent prevents /%61dmin bypassing /admin matchers.

--- a/packages/vinext/src/server/app-router-entry.ts
+++ b/packages/vinext/src/server/app-router-entry.ts
@@ -16,6 +16,7 @@
 import rscHandler from "virtual:vinext-rsc-entry";
 import { runWithExecutionContext, type ExecutionContextLike } from "../shims/request-context.js";
 import { resolveStaticAssetSignal } from "./worker-utils.js";
+import { isOpenRedirectShaped } from "./request-pipeline.js";
 
 type WorkerAssetEnv = {
   ASSETS?: {
@@ -31,12 +32,11 @@ export default {
   ): Promise<Response> {
     const url = new URL(request.url);
 
-    // Normalize backslashes (browsers treat /\ as //) before any other checks.
-    const rawPathname = url.pathname.replaceAll("\\", "/");
-
-    // Block protocol-relative URL open redirects (//evil.com/ or /\evil.com/).
-    // Check rawPathname BEFORE decode so the guard fires before normalization.
-    if (rawPathname.startsWith("//")) {
+    // Block protocol-relative URL open redirects (//evil.com/, /\evil.com/,
+    // /%5Cevil.com/, /%2F/evil.com/). Check BEFORE decode so both literal and
+    // percent-encoded variants are caught — encoded forms survive segment-wise
+    // decoding and would otherwise reach trailing-slash redirect emitters.
+    if (isOpenRedirectShaped(url.pathname)) {
       return new Response("404 Not Found", { status: 404 });
     }
 
@@ -44,7 +44,7 @@ export default {
     // the actual decode + normalize; we only check here to return a clean 400
     // instead of letting a malformed sequence crash downstream.
     try {
-      decodeURIComponent(rawPathname);
+      decodeURIComponent(url.pathname);
     } catch {
       // Malformed percent-encoding (e.g. /%E0%A4%A) — return 400 instead of throwing.
       return new Response("Bad Request", { status: 400 });

--- a/packages/vinext/src/server/app-ssr-entry.ts
+++ b/packages/vinext/src/server/app-ssr-entry.ts
@@ -14,6 +14,7 @@ import {
   useServerInsertedHTML,
 } from "../shims/navigation.js";
 import { runWithNavigationContext } from "../shims/navigation-state.js";
+import { isOpenRedirectShaped } from "./request-pipeline.js";
 import { withScriptNonce } from "../shims/script-nonce-context.js";
 import {
   createInlineScriptTag,
@@ -247,7 +248,9 @@ export async function handleSsr(
 export default {
   async fetch(request: Request): Promise<Response> {
     const url = new URL(request.url);
-    if (url.pathname.startsWith("//")) {
+    // Block protocol-relative URL open redirects (including percent-encoded
+    // variants like /%5Cevil.com/). See request-pipeline.ts for details.
+    if (isOpenRedirectShaped(url.pathname)) {
       return new Response("404 Not Found", { status: 404 });
     }
 

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -46,6 +46,7 @@ import {
   type ImageConfig,
 } from "./image-optimization.js";
 import { normalizePath } from "./normalize-path.js";
+import { isOpenRedirectShaped } from "./request-pipeline.js";
 import { hasBasePath, stripBasePath } from "../utils/base-path.js";
 import { computeLazyChunks } from "../utils/lazy-chunks.js";
 import { manifestFileWithBase } from "../utils/manifest-paths.js";
@@ -946,23 +947,27 @@ async function startAppRouterServer(options: AppRouterServerOptions) {
 
   const server = createServer(async (req, res) => {
     const rawUrl = req.url ?? "/";
+    const rawPathname = rawUrl.split("?")[0];
+
+    // Guard against protocol-relative URL open redirect attacks.
+    // Run BEFORE decoding so both literal (`//`, `/\`) and encoded (`%5C`, `%2F`)
+    // variants are rejected — the encoded forms survive segment-wise decoding
+    // below and would otherwise reach the trailing-slash redirect emitter.
+    if (isOpenRedirectShaped(rawPathname)) {
+      res.writeHead(404);
+      res.end("404 Not Found");
+      return;
+    }
+
     // Normalize backslashes (browsers treat /\ as //), then decode and normalize path.
-    const rawPathname = rawUrl.split("?")[0].replaceAll("\\", "/");
+    const normalizedRawPathname = rawPathname.replaceAll("\\", "/");
     let pathname: string;
     try {
-      pathname = normalizePath(normalizePathnameForRouteMatchStrict(rawPathname));
+      pathname = normalizePath(normalizePathnameForRouteMatchStrict(normalizedRawPathname));
     } catch {
       // Malformed percent-encoding (e.g. /%E0%A4%A) — return 400 instead of crashing.
       res.writeHead(400);
       res.end("Bad Request");
-      return;
-    }
-
-    // Guard against protocol-relative URL open redirect attacks.
-    // Check rawPathname before normalizePath collapses //.
-    if (rawPathname.startsWith("//")) {
-      res.writeHead(404);
-      res.end("404 Not Found");
       return;
     }
 
@@ -1208,11 +1213,23 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
 
   const server = createServer(async (req, res) => {
     const rawUrl = req.url ?? "/";
+    const rawPagesPathnameBeforeNormalize = rawUrl.split("?")[0];
+
+    // Guard against protocol-relative URL open redirect attacks.
+    // Run BEFORE decoding so both literal (`//`, `/\`) and encoded (`%5C`, `%2F`)
+    // variants are rejected — the encoded forms survive segment-wise decoding
+    // below and would otherwise reach the trailing-slash redirect emitter.
+    if (isOpenRedirectShaped(rawPagesPathnameBeforeNormalize)) {
+      res.writeHead(404);
+      res.end("404 Not Found");
+      return;
+    }
+
     // Normalize backslashes (browsers treat /\ as //), then decode and normalize path.
     // Rebuild `url` from the decoded pathname + original query string so all
     // downstream consumers (resolvedUrl, resolvedPathname, config matchers)
     // always work with the decoded, canonical path.
-    const rawPagesPathname = rawUrl.split("?")[0].replaceAll("\\", "/");
+    const rawPagesPathname = rawPagesPathnameBeforeNormalize.replaceAll("\\", "/");
     const rawQs = rawUrl.includes("?") ? rawUrl.slice(rawUrl.indexOf("?")) : "";
     let pathname: string;
     try {
@@ -1224,14 +1241,6 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
       return;
     }
     let url = pathname + rawQs;
-
-    // Guard against protocol-relative URL open redirect attacks.
-    // Check rawPagesPathname before normalizePath collapses //.
-    if (rawPagesPathname.startsWith("//")) {
-      res.writeHead(404);
-      res.end("404 Not Found");
-      return;
-    }
 
     // Internal prerender endpoint — only reachable with the correct build-time secret.
     // Used by the prerender phase to fetch getStaticPaths results via HTTP.

--- a/packages/vinext/src/server/request-pipeline.ts
+++ b/packages/vinext/src/server/request-pipeline.ts
@@ -24,16 +24,64 @@ import { hasBasePath, stripBasePath } from "../utils/base-path.js";
  * Next.js returns 404 for these paths. We check the RAW pathname before
  * normalization so the guard fires before normalizePath collapses `//`.
  *
+ * Percent-encoded variants are also blocked because:
+ *   - `%5C` decodes to `\` (browsers treat `/\evil.com` as `//evil.com`).
+ *   - `%2F` decodes to `/` (so `/%2F/evil.com` effectively becomes `//evil.com`).
+ * These forms survive segment-wise decoding that re-encodes path delimiters
+ * (e.g. `normalizePathnameForRouteMatchStrict`), so a later trailing-slash
+ * redirect would still echo the encoded form in its `Location` header. See
+ * `isOpenRedirectShaped` for the full list of rejected leading-segment forms.
+ *
  * @param rawPathname - The raw pathname from the URL, before any normalization
  * @returns A 404 Response if the path is protocol-relative, or null to continue
  */
 export function guardProtocolRelativeUrl(rawPathname: string): Response | null {
-  // Normalize backslashes: browsers and the URL constructor treat
-  // /\evil.com as protocol-relative (//evil.com), bypassing the // check.
-  if (rawPathname.replaceAll("\\", "/").startsWith("//")) {
+  if (isOpenRedirectShaped(rawPathname)) {
     return new Response("404 Not Found", { status: 404 });
   }
   return null;
+}
+
+/**
+ * Returns true if a request pathname looks like a protocol-relative open
+ * redirect, in either literal or percent-encoded form.
+ *
+ * Exported for call sites that need to replicate the guard inline (Pages
+ * Router worker codegen, Node production server) and for defense-in-depth
+ * checks inside redirect emitters.
+ *
+ * A pathname is considered "open redirect shaped" when its first segment,
+ * after decoding backslashes and encoded delimiters, would cause a browser
+ * to resolve a `Location` containing the pathname as protocol-relative:
+ *
+ *   - literal   `//evil.com`
+ *   - literal   `/\evil.com`             (browsers normalize `\` to `/`)
+ *   - encoded   `/%5Cevil.com`           (`%5C` decodes to `\` in Location)
+ *   - encoded   `/%2F/evil.com`          (`%2F` decodes to `/` → `//`)
+ *   - mixed     `/%5C%2F`, `/%5C%5C`     (and other combinations)
+ *
+ * We explicitly do not require a valid percent sequence elsewhere in the
+ * pathname — we only examine the leading bytes (up to the second real or
+ * encoded delimiter) so malformed suffixes can still reach the normal
+ * "400 Bad Request" decode path instead of being masked as "404".
+ */
+export function isOpenRedirectShaped(rawPathname: string): boolean {
+  if (!rawPathname.startsWith("/")) return false;
+
+  // Fast path: literal `//...` or `/\...`. Browsers treat `\` as `/` in
+  // URL paths, so `/\evil.com` is equivalent to `//evil.com`.
+  const afterSlash = rawPathname.slice(1);
+  if (afterSlash.startsWith("/") || afterSlash.startsWith("\\")) return true;
+
+  // Slow path: percent-encoded leading delimiter. We only need to consider
+  // `%5C` (backslash) and `%2F` (forward slash) at position 1. Case-insensitive
+  // per RFC 3986 §2.1.
+  if (afterSlash.length >= 3 && afterSlash[0] === "%") {
+    const encoded = afterSlash.slice(0, 3).toLowerCase();
+    if (encoded === "%5c" || encoded === "%2f") return true;
+  }
+
+  return false;
 }
 
 /**
@@ -73,6 +121,13 @@ export function normalizeTrailingSlash(
 ): Response | null {
   if (pathname === "/" || pathname === "/api" || pathname.startsWith("/api/")) {
     return null;
+  }
+  // Defense-in-depth: `guardProtocolRelativeUrl` runs earlier and should
+  // have rejected these shapes. Refuse to emit a Location header that the
+  // browser would resolve as protocol-relative, even if a caller somehow
+  // bypassed the upstream guard.
+  if (isOpenRedirectShaped(pathname)) {
+    return new Response("404 Not Found", { status: 404 });
   }
   const hasTrailing = pathname.endsWith("/");
   // RSC (client-side navigation) requests arrive as /path.rsc — don't

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -631,10 +631,15 @@ describe("generatePagesRouterWorkerEntry", () => {
     expect(content).toContain("ASSETS");
   });
 
-  it("includes backslash normalization in protocol-relative guard", () => {
+  it("includes an open-redirect guard that rejects encoded backslash and slash", () => {
     const content = generatePagesRouterWorkerEntry();
-    // The generated code should normalize backslashes before the // check
-    expect(content).toContain('replaceAll("\\\\", "/")');
+    // The generated worker inlines isOpenRedirectShaped. Regression for
+    // VULN-126915 — the guard must handle both literal (\\, //) and
+    // percent-encoded (%5C, %2F) variants in the leading segment.
+    expect(content).toContain("function isOpenRedirectShaped");
+    expect(content).toContain('"%5c"');
+    expect(content).toContain('"%2f"');
+    expect(content).toContain("isOpenRedirectShaped(pathname)");
   });
 
   it("passes image handlers inline to handleImageOptimization", () => {

--- a/tests/request-pipeline.test.ts
+++ b/tests/request-pipeline.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vite-plus/test";
 import {
   guardProtocolRelativeUrl,
+  isOpenRedirectShaped,
   hasBasePath,
   stripBasePath,
   normalizeTrailingSlash,
@@ -25,10 +26,88 @@ describe("guardProtocolRelativeUrl", () => {
     expect(res!.status).toBe(404);
   });
 
+  // Regression for VULN-126915 / H1 #3576997: encoded backslash in the
+  // leading segment survives segment-wise decoding (the decoder re-encodes
+  // `\` back to `%5C`) and is then echoed into a trailing-slash 308 Location
+  // header. Browsers percent-decode the Location, and WHATWG URL treats `\`
+  // as `/`, so `/\evil.com` resolves as protocol-relative → `http://evil.com/`.
+  it("returns 404 for encoded backslash (%5C) protocol-relative paths", () => {
+    const res = guardProtocolRelativeUrl("/%5Cevil.com/");
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(404);
+  });
+
+  it("returns 404 for lowercase encoded backslash (%5c) protocol-relative paths", () => {
+    const res = guardProtocolRelativeUrl("/%5cevil.com/");
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(404);
+  });
+
+  it("returns 404 for encoded forward slash (%2F) in leading segment", () => {
+    // /%2F/evil.com decodes to //evil.com which is protocol-relative.
+    const res = guardProtocolRelativeUrl("/%2Fevil.com/");
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(404);
+  });
+
+  it("returns 404 for double-encoded backslash (%5C%5C)", () => {
+    const res = guardProtocolRelativeUrl("/%5C%5Cevil.com/");
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(404);
+  });
+
   it("returns null for normal paths", () => {
     expect(guardProtocolRelativeUrl("/about")).toBeNull();
     expect(guardProtocolRelativeUrl("/")).toBeNull();
     expect(guardProtocolRelativeUrl("/api/data")).toBeNull();
+  });
+
+  it("returns null when % appears after the leading slash but not as a delimiter", () => {
+    // /%E4%B8%AD is the UTF-8 encoding of a Chinese character — should pass.
+    expect(guardProtocolRelativeUrl("/%E4%B8%AD")).toBeNull();
+    // /%61dmin decodes to /admin — a single encoded ASCII char is fine.
+    expect(guardProtocolRelativeUrl("/%61dmin")).toBeNull();
+  });
+
+  it("returns null for encoded delimiters that appear after the first segment", () => {
+    // Only the leading-segment shape matters for open redirects. An encoded
+    // backslash elsewhere in the path is a legitimate (if unusual) route.
+    expect(guardProtocolRelativeUrl("/foo/%5Cbar")).toBeNull();
+    expect(guardProtocolRelativeUrl("/foo%5Cbar")).toBeNull();
+  });
+
+  it("returns null for malformed percent-encoding (defers to decode error path)", () => {
+    // `/%E0%A4%A` is malformed but the guard should not 404 it — the
+    // downstream decode will return 400 Bad Request, which is more accurate.
+    expect(guardProtocolRelativeUrl("/%E0%A4%A")).toBeNull();
+  });
+});
+
+// ── isOpenRedirectShaped ────────────────────────────────────────────────
+
+describe("isOpenRedirectShaped", () => {
+  it("detects literal protocol-relative forms", () => {
+    expect(isOpenRedirectShaped("//evil.com")).toBe(true);
+    expect(isOpenRedirectShaped("/\\evil.com")).toBe(true);
+  });
+
+  it("detects percent-encoded delimiter forms", () => {
+    expect(isOpenRedirectShaped("/%5Cevil.com")).toBe(true);
+    expect(isOpenRedirectShaped("/%5cevil.com")).toBe(true);
+    expect(isOpenRedirectShaped("/%2Fevil.com")).toBe(true);
+    expect(isOpenRedirectShaped("/%2fevil.com")).toBe(true);
+  });
+
+  it("returns false for paths that don't start with /", () => {
+    expect(isOpenRedirectShaped("evil.com")).toBe(false);
+    expect(isOpenRedirectShaped("")).toBe(false);
+  });
+
+  it("returns false for safe paths", () => {
+    expect(isOpenRedirectShaped("/")).toBe(false);
+    expect(isOpenRedirectShaped("/about")).toBe(false);
+    expect(isOpenRedirectShaped("/api/users")).toBe(false);
+    expect(isOpenRedirectShaped("/%61dmin")).toBe(false);
   });
 });
 
@@ -147,6 +226,35 @@ describe("normalizeTrailingSlash", () => {
     expect(res).not.toBeNull();
     expect(res!.status).toBe(308);
     expect(res!.headers.get("Location")).toBe("/api-docs");
+  });
+
+  // Defense-in-depth for VULN-126915: even if an upstream guard is bypassed,
+  // the trailing-slash emitter must refuse to echo a protocol-relative path
+  // back into a Location header. Returns 404 instead of 308.
+  it("returns 404 (not 308) for encoded-backslash paths when trailingSlash is false", () => {
+    const res = normalizeTrailingSlash("/%5Cevil.com/", "", false, "");
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(404);
+    expect(res!.headers.get("Location")).toBeNull();
+  });
+
+  it("returns 404 (not 308) for encoded-backslash paths when trailingSlash is true", () => {
+    const res = normalizeTrailingSlash("/%5Cevil.com", "", true, "");
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(404);
+    expect(res!.headers.get("Location")).toBeNull();
+  });
+
+  it("returns 404 for literal double-slash paths", () => {
+    const res = normalizeTrailingSlash("//evil.com/", "", false, "");
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(404);
+  });
+
+  it("returns 404 for encoded-forward-slash paths", () => {
+    const res = normalizeTrailingSlash("/%2Fevil.com/", "", false, "");
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(404);
   });
 });
 

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -3580,7 +3580,9 @@ describe("double-encoded path handling in middleware", () => {
     // (the RSC handler is the single decode point)
     expect(entryCode).not.toMatch(/normalizedRequest\s*=\s*new Request\(normalizedUrl/);
     // It should still validate malformed encoding (return 400)
-    expect(entryCode).toContain("decodeURIComponent(rawPathname)");
+    expect(entryCode).toMatch(
+      /decodeURIComponent\(\s*(?:raw)?[pP]athname|decodeURIComponent\(url\.pathname\)/,
+    );
     // The delegate call should pass the original request object through,
     // without reconstructing a normalized Request before delegation.
     expect(entryCode).toMatch(/rscHandler\(request(?:,\s*ctx)?\)/);


### PR DESCRIPTION
## Summary

Six places in the request pipeline inlined a variation of:

```ts
pathname.replaceAll("\\", "/").startsWith("//")
```

to reject protocol-relative paths before they reach the trailing-slash redirect emitter (which would otherwise echo them back into a `Location` header). The check handles literal delimiters but not their percent-encoded forms — `/%5Cevil.com/` survives the guard, then `normalizePathnameForRouteMatchStrict` re-encodes the decoded backslash back to `%5C` (preserving it as part of a single path segment), so the 308 trailing-slash redirect ends up with `Location: /%5Cevil.com`. Browsers percent-decode `Location` headers and WHATWG URL treats `\` as `/`, so the browser resolves that to a protocol-relative host.

## Changes

Factor the leading-segment shape check into a new `isOpenRedirectShaped` helper in `server/request-pipeline.ts` that recognises literal (`//`, `/\`) and percent-encoded (`%5C`, `%2F`) variants, and swap each call site over to it. Also add a defense-in-depth check in `normalizeTrailingSlash` so a future caller that skips the upstream guard still can't emit a bad `Location`.

Updated call sites:
- `server/request-pipeline.ts` — `guardProtocolRelativeUrl` + `normalizeTrailingSlash`
- `server/prod-server.ts` — App Router and Pages Router Node handlers
- `server/app-router-entry.ts` — default Cloudflare Worker entry
- `server/app-ssr-entry.ts` — SSR environment entry
- `index.ts` — Pages Router Vite dev middleware
- `deploy.ts` — generated Pages Router Cloudflare Worker (inlined copy kept in sync)

## Tests

Regression tests in `tests/request-pipeline.test.ts` cover the encoded variants plus the defense-in-depth path. Updates the pinned string assertion in `tests/deploy.test.ts` that was checking for the old inlined pattern.