### PR TITLE
fix(next/font/google): use real axis range, validate options at build time (#885)

### DIFF
--- a/examples/app-router-nitro/app/layout.tsx
+++ b/examples/app-router-nitro/app/layout.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import type { Metadata, Viewport } from "next";
 
 const inter = Inter({ subsets: ["latin"], weight: ["400", "700"] });
-const mono = Geist_Mono({ variable: "--font-mono" });
+const mono = Geist_Mono({ variable: "--font-mono", subsets: ["latin"] });
 
 // Static metadata on root layout with title template
 export const metadata: Metadata = {

--- a/packages/vinext/src/build/google-fonts/validate.ts
+++ b/packages/vinext/src/build/google-fonts/validate.ts
@@ -62,6 +62,12 @@ export function validateGoogleFontOptions(
     throw new Error(`Unknown font \`${fontFamily}\``);
   }
 
+  if (axes !== undefined && !Array.isArray(axes)) {
+    throw new Error(
+      `Invalid axes value for font \`${fontFamily}\`, expected an array of axis names.`,
+    );
+  }
+
   const availableSubsets = fontFamilyData.subsets;
   if (availableSubsets.length === 0) {
     // No preloadable subsets means preload is meaningless. Silently disable

--- a/packages/vinext/src/plugins/fonts.ts
+++ b/packages/vinext/src/plugins/fonts.ts
@@ -83,6 +83,15 @@ const GOOGLE_FONT_UTILITY_EXPORTS = new Set([
  * user-provided public files.
  */
 const VINEXT_FONT_URL_NAMESPACE = "_vinext_fonts";
+const MAX_GOOGLE_FONTS_ERROR_BODY_LENGTH = 500;
+
+function formatGoogleFontsErrorBody(body: string): string {
+  const trimmed = body.trim();
+  if (!trimmed) return "(empty response body)";
+  if (trimmed.length <= MAX_GOOGLE_FONTS_ERROR_BODY_LENGTH) return trimmed;
+  const omitted = trimmed.length - MAX_GOOGLE_FONTS_ERROR_BODY_LENGTH;
+  return `${trimmed.slice(0, MAX_GOOGLE_FONTS_ERROR_BODY_LENGTH)}\n... (truncated ${omitted} characters)`;
+}
 
 /**
  * Rewrite absolute filesystem paths in cached Google Fonts CSS so the
@@ -817,7 +826,7 @@ export function createGoogleFontsPlugin(fontGoogleShimPath: string, shimsDir: st
                 // through to a CDN URL that ships the same bad request
                 // to the browser.
                 throw new Error(
-                  `[vinext:google-fonts] ${id}: Google Fonts returned HTTP ${err.status} for ${err.url}.\n${err.responseBody.trim() || "(empty response body)"}`,
+                  `[vinext:google-fonts] ${id}: Google Fonts returned HTTP ${err.status} for ${err.url}.\n${formatGoogleFontsErrorBody(err.responseBody)}`,
                 );
               }
               // Network errors (offline, DNS, AbortError) are recoverable;

--- a/packages/vinext/src/plugins/fonts.ts
+++ b/packages/vinext/src/plugins/fonts.ts
@@ -27,6 +27,26 @@ import { parseAst } from "vite";
 import path from "node:path";
 import fs from "node:fs";
 import MagicString from "magic-string";
+import { validateGoogleFontOptions } from "../build/google-fonts/validate.js";
+import { getFontAxes } from "../build/google-fonts/get-axes.js";
+import { buildGoogleFontsUrl } from "../build/google-fonts/build-url.js";
+
+/**
+ * Thrown when Google Fonts returns a non-2xx response. Distinct from a raw
+ * `fetch` rejection (network error, DNS failure, AbortError) so the call
+ * site can decide whether to surface as a build error or fall through to
+ * the runtime CDN path.
+ */
+class GoogleFontsHttpError extends Error {
+  constructor(
+    public readonly url: string,
+    public readonly status: number,
+    public readonly responseBody: string,
+  ) {
+    super(`Google Fonts returned HTTP ${status} for ${url}`);
+    this.name = "GoogleFontsHttpError";
+  }
+}
 
 // ── Virtual module IDs ────────────────────────────────────────────────────────
 
@@ -409,7 +429,11 @@ async function fetchAndCacheFont(
     },
   });
   if (!cssResponse.ok) {
-    throw new Error(`Failed to fetch Google Fonts CSS: ${cssResponse.status}`);
+    // Include the response body when Google rejected the request so the
+    // caller can see why (the body usually contains a one-line CSS comment
+    // identifying the bad axis or family).
+    const body = await cssResponse.text().catch(() => "");
+    throw new GoogleFontsHttpError(cssUrl, cssResponse.status, body);
   }
   let css = await cssResponse.text();
 
@@ -753,41 +777,30 @@ export function createGoogleFontsPlugin(fontGoogleShimPath: string, shimsDir: st
             return; // Can't parse options statically, skip
           }
 
-          // Build the Google Fonts CSS URL
-          const weights = options.weight
-            ? Array.isArray(options.weight)
-              ? options.weight
-              : [options.weight]
-            : [];
-          const styles = options.style
-            ? Array.isArray(options.style)
-              ? options.style
-              : [options.style]
-            : [];
-          const display = options.display ?? "swap";
-
-          let spec = family.replace(/\s+/g, "+");
-          if (weights.length > 0) {
-            const hasItalic = styles.includes("italic");
-            if (hasItalic) {
-              const pairs: string[] = [];
-              for (const w of weights) {
-                pairs.push(`0,${w}`);
-                pairs.push(`1,${w}`);
-              }
-              spec += `:ital,wght@${pairs.join(";")}`;
-            } else {
-              spec += `:wght@${weights.join(";")}`;
-            }
-          } else if (styles.length === 0) {
-            // Request full variable weight range when no weight specified.
-            // Without this, Google Fonts returns only weight 400.
-            spec += `:wght@100..900`;
+          // Validate the call against the bundled Google Fonts metadata
+          // and resolve the actual axis values. This replaces an earlier
+          // inline URL builder that hardcoded `:wght@100..900` regardless
+          // of the font's real `wght` axis range, which produced HTTP 400
+          // for fonts whose axis is narrower (Sen 400..800, Anton 400).
+          // See issue #885.
+          let validated;
+          try {
+            validated = validateGoogleFontOptions(family, options);
+          } catch (err) {
+            // Validation errors are programmer errors (unknown family,
+            // missing required weight on a static font, etc.). Re-throw
+            // with the file path attached so Vite reports the offending
+            // call site instead of a generic plugin error.
+            const message = err instanceof Error ? err.message : String(err);
+            throw new Error(`[vinext:google-fonts] ${id}: ${message}`);
           }
-          const params = new URLSearchParams();
-          params.set("family", spec);
-          params.set("display", display);
-          const cssUrl = `https://fonts.googleapis.com/css2?${params.toString()}`;
+          const axes = getFontAxes(
+            family,
+            validated.weights,
+            validated.styles,
+            validated.selectedVariableAxes,
+          );
+          const cssUrl = buildGoogleFontsUrl(family, axes, validated.display);
 
           // Check cache
           let localCSS = fontCache.get(cssUrl);
@@ -795,8 +808,20 @@ export function createGoogleFontsPlugin(fontGoogleShimPath: string, shimsDir: st
             try {
               localCSS = await fetchAndCacheFont(cssUrl, family, cacheDir);
               fontCache.set(cssUrl, localCSS);
-            } catch {
-              // Fetch failed (offline?) — fall back to CDN mode
+            } catch (err) {
+              if (err instanceof GoogleFontsHttpError) {
+                // HTTP 4xx/5xx from Google means the URL is malformed or
+                // the family/axis combination is invalid. Surface as a
+                // build error so the user sees the failing URL plus
+                // Google's response body, rather than silently falling
+                // through to a CDN URL that ships the same bad request
+                // to the browser.
+                throw new Error(
+                  `[vinext:google-fonts] ${id}: Google Fonts returned HTTP ${err.status} for ${err.url}.\n${err.responseBody.trim() || "(empty response body)"}`,
+                );
+              }
+              // Network errors (offline, DNS, AbortError) are recoverable;
+              // skip self-hosting and let the runtime CDN path handle it.
               return;
             }
           }

--- a/packages/vinext/src/shims/font-google-base.ts
+++ b/packages/vinext/src/shims/font-google-base.ts
@@ -1,3 +1,5 @@
+import { buildGoogleFontsUrl as buildUrlFromAxes } from "../build/google-fonts/build-url.js";
+
 /**
  * next/font/google shim
  *
@@ -109,15 +111,24 @@ function toVarName(family: string): string {
 
 /**
  * Build a Google Fonts CSS URL.
+ *
+ * In production this code path is dead. The build plugin
+ * (`vinext:google-fonts` in `src/plugins/fonts.ts`) statically resolves
+ * each font call's axis values against the bundled metadata, fetches the
+ * Google Fonts CSS, and injects the resulting CSS as `_selfHostedCSS` so
+ * the runtime never queries Google. The shim only reaches this builder
+ * when the plugin's static parser bails (dynamic options, eval-only
+ * shapes), which is dev-only.
+ *
+ * The dev fallback intentionally has no metadata: shipping the 388 KB
+ * `font-data.json` to the Worker bundle would dwarf the rest of the shim,
+ * and the production path already has the metadata-aware variant. The
+ * tradeoff is that the dev fallback cannot resolve a variable font's
+ * actual `wght` axis range. It emits no axis segment when no `weight` is
+ * given, which makes Google return the default static face (200) instead
+ * of the broken `:wght@100..900` URL that issue #885 reports.
  */
 export function buildGoogleFontsUrl(family: string, options: FontOptions): string {
-  const params = new URLSearchParams();
-  // Don't pre-replace spaces with "+". URLSearchParams handles encoding:
-  // spaces become "+" in application/x-www-form-urlencoded format.
-  // Pre-replacing would cause double-encoding: "+" -> "%2B" (400 error).
-  let spec = family;
-
-  // Build weight/style specs
   const weights = options.weight
     ? Array.isArray(options.weight)
       ? options.weight
@@ -129,33 +140,21 @@ export function buildGoogleFontsUrl(family: string, options: FontOptions): strin
       : [options.style]
     : [];
 
-  if (weights.length > 0 || styles.length > 0) {
-    const hasItalic = styles.includes("italic");
-    if (weights.length > 0) {
-      if (hasItalic) {
-        // Use ital axis: ital,wght@0,400;0,700;1,400;1,700
-        const pairs: string[] = [];
-        for (const w of weights) {
-          pairs.push(`0,${w}`);
-          pairs.push(`1,${w}`);
-        }
-        spec += `:ital,wght@${pairs.join(";")}`;
-      } else {
-        spec += `:wght@${weights.join(";")}`;
-      }
-    }
-  } else {
-    // When no weight is specified, request the full variable weight range.
-    // Without this, Google Fonts returns only weight 400 (the default).
-    // Next.js loads the full variable font by default, so we match that
-    // behavior to ensure all font weights render correctly.
-    spec += `:wght@100..900`;
-  }
+  const hasItalic = styles.includes("italic");
+  const hasNormal = styles.includes("normal");
+  // Google treats omitted ital as ital=0, so italic-only requests emit
+  // ['1']; mixed requests emit ['0','1']; normal-only stays undefined so
+  // the URL has no ital axis at all.
+  const ital = hasItalic ? [...(hasNormal ? ["0"] : []), "1"] : undefined;
 
-  params.set("family", spec);
-  params.set("display", options.display ?? "swap");
+  // Italic-only with no explicit weight still needs a wght value or the
+  // ital axis has nowhere to attach in Google's URL grammar. Fall back to
+  // '400' because every Google Font has it and it is the visible default.
+  // The plugin's metadata-aware path covers the variable-font case in
+  // production.
+  const wght = weights.length > 0 ? weights : ital ? ["400"] : undefined;
 
-  return `https://fonts.googleapis.com/css2?${params.toString()}`;
+  return buildUrlFromAxes(family, { wght, ital }, options.display ?? "swap");
 }
 
 /**

--- a/packages/vinext/src/shims/font-google-base.ts
+++ b/packages/vinext/src/shims/font-google-base.ts
@@ -147,12 +147,17 @@ export function buildGoogleFontsUrl(family: string, options: FontOptions): strin
   // the URL has no ital axis at all.
   const ital = hasItalic ? [...(hasNormal ? ["0"] : []), "1"] : undefined;
 
+  // The dev fallback has no metadata, so the variable sentinel cannot be
+  // resolved to the font's real axis range here. Drop it like empty options
+  // instead of emitting the invalid Google Fonts URL `:wght@variable`.
+  const normalizedWeights = weights.length === 1 && weights[0] === "variable" ? [] : weights;
+
   // Italic-only with no explicit weight still needs a wght value or the
   // ital axis has nowhere to attach in Google's URL grammar. Fall back to
   // '400' because every Google Font has it and it is the visible default.
   // The plugin's metadata-aware path covers the variable-font case in
   // production.
-  const wght = weights.length > 0 ? weights : ital ? ["400"] : undefined;
+  const wght = normalizedWeights.length > 0 ? normalizedWeights : ital ? ["400"] : undefined;
 
   return buildUrlFromAxes(family, { wght, ital }, options.display ?? "swap");
 }

--- a/tests/font-google.test.ts
+++ b/tests/font-google.test.ts
@@ -136,6 +136,36 @@ describe("next/font/google shim", () => {
     expect(url).toMatch(/Roboto[+%].*Mono/);
   });
 
+  it("buildGoogleFontsUrl emits no axis segment for empty options (regression for #885)", async () => {
+    // Issue #885: `Sen({ subsets: ['latin'] })` used to emit
+    // `:wght@100..900` and Google returned HTTP 400 because Sen's wght
+    // axis is 400..800. The shim's dev fallback now emits no axis
+    // segment, so Google returns the default static face (200) regardless
+    // of the font's actual axis. The build plugin always pre-resolves the
+    // real axis range from metadata before this path is reached in
+    // production.
+    //
+    // URLSearchParams encodes `:` and `@`, so check the decoded URL.
+    const { buildGoogleFontsUrl } = await import("../packages/vinext/src/shims/font-google.js");
+    const url = buildGoogleFontsUrl("Sen", { subsets: ["latin"] });
+    const decoded = decodeURIComponent(url);
+    expect(decoded).not.toContain("wght@100..900");
+    expect(decoded).not.toContain("wght@");
+    expect(decoded).toContain("family=Sen");
+    expect(decoded).toContain("display=swap");
+  });
+
+  it("buildGoogleFontsUrl preserves italic-only style requests", async () => {
+    // Pre-port shim: outer guard on `weights.length > 0 || styles.length > 0`
+    // entered the block, but the inner branch only handled `weights.length > 0`.
+    // The result was `family=Inter&display=swap` with no ital axis, so Google
+    // served the regular (non-italic) face and the user's italic was silently
+    // dropped. Italic-only must now leave a visible ital axis in the URL.
+    const { buildGoogleFontsUrl } = await import("../packages/vinext/src/shims/font-google.js");
+    const url = buildGoogleFontsUrl("Inter", { style: ["italic"] });
+    expect(url).toContain("ital");
+  });
+
   it("getSSRFontLinks returns collected URLs without clearing", async () => {
     const mod = await import("../packages/vinext/src/shims/font-google.js");
     // Force a CDN-mode font load (SSR context: document is undefined)
@@ -422,7 +452,7 @@ describe("vinext:google-fonts plugin", () => {
       const transform = unwrapHook(plugin.transform);
       const code = [
         `import { Inter } from 'next/font/google';`,
-        `const inter = Inter({ weight: '400' });`,
+        `const inter = Inter({ weight: '400', subsets: ['latin'] });`,
       ].join("\n");
 
       // First call: fetches and caches
@@ -467,8 +497,8 @@ describe("vinext:google-fonts plugin", () => {
       const transform = unwrapHook(plugin.transform);
       const code = [
         `import { Inter, Roboto } from 'next/font/google';`,
-        `const inter = Inter({ weight: '400' });`,
-        `const roboto = Roboto({ weight: '400' });`,
+        `const inter = Inter({ weight: '400', subsets: ['latin'] });`,
+        `const roboto = Roboto({ weight: '400', subsets: ['latin'] });`,
       ].join("\n");
 
       const result = await transform.call(plugin, code, "/app/layout.tsx");
@@ -500,7 +530,7 @@ describe("vinext:google-fonts plugin", () => {
       const transform = unwrapHook(plugin.transform);
       const code = [
         `import { Inter } from 'next/font/google';`,
-        `const inter = Inter({ weight: '400' });`,
+        `const inter = Inter({ weight: '400', subsets: ['latin'] });`,
         `const Roboto = (opts) => opts; // Not from import`,
         `const roboto = Roboto({ weight: '400' });`,
       ].join("\n");
@@ -575,7 +605,7 @@ describe("vinext:google-fonts plugin", () => {
       // Named-import form with a nested axes object
       const code = [
         `import { Inter } from 'next/font/google';`,
-        `const inter = Inter({ subsets: ["latin"], axes: { wght: 400 } });`,
+        `const inter = Inter({ subsets: ["latin"], _placeholder: { wght: 400 } });`,
       ].join("\n");
 
       const result = await transform.call(plugin, code, "/app/layout.tsx");
@@ -610,7 +640,7 @@ describe("vinext:google-fonts plugin", () => {
 
       const code = [
         `import fonts from 'next/font/google';`,
-        `const inter = fonts.Inter({ subsets: ["latin"], axes: { wght: 400 } });`,
+        `const inter = fonts.Inter({ subsets: ["latin"], _placeholder: { wght: 400 } });`,
       ].join("\n");
 
       const result = await transform.call(plugin, code, "/app/layout.tsx");
@@ -642,7 +672,7 @@ describe("vinext:google-fonts plugin", () => {
       // String value contains '}' — old \{[^}]*\} regex would have stopped here.
       const code = [
         `import { Inter } from 'next/font/google';`,
-        `const inter = Inter({ display: "swap", label: "font {bold}" });`,
+        `const inter = Inter({ subsets: ["latin"], display: "swap", _label: "font {bold}" });`,
       ].join("\n");
 
       const result = await transform.call(plugin, code, "/app/layout.tsx");
@@ -671,12 +701,146 @@ describe("vinext:google-fonts plugin", () => {
       const transform = unwrapHook(plugin.transform);
       const code = [
         `import { Inter as inter } from 'next/font/google';`,
-        `const body = inter({ weight: '400' });`,
+        `const body = inter({ weight: '400', subsets: ['latin'] });`,
       ].join("\n");
       const result = await transform.call(plugin, code, "/app/layout.tsx");
       expect(result).not.toBeNull();
       expect(result.code).toContain("virtual:vinext-google-fonts?");
       expect(result.code).toContain("_selfHostedCSS");
+    } finally {
+      globalThis.fetch = originalFetch;
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("resolves narrow-axis variable fonts to their real wght range (regression for #885)", async () => {
+    // Sen's wght axis is 400..800. Pre-port vinext built
+    // `:wght@100..900` and Google returned HTTP 400. The metadata-driven
+    // pipeline must now request the real axis range from Google.
+    const plugin = getGoogleFontsPlugin();
+    const root = path.join(import.meta.dirname, ".test-font-root-sen");
+    initPlugin(plugin, { command: "build", root });
+
+    const originalFetch = globalThis.fetch;
+    const fetchedUrls: string[] = [];
+    globalThis.fetch = async (input: any) => {
+      fetchedUrls.push(String(input));
+      return new Response("@font-face { font-family: 'Sen'; src: url(/sen.woff2); }", {
+        status: 200,
+        headers: { "content-type": "text/css" },
+      });
+    };
+
+    try {
+      const transform = unwrapHook(plugin.transform);
+      const code = [
+        `import { Sen } from 'next/font/google';`,
+        `const sen = Sen({ subsets: ['latin'] });`,
+      ].join("\n");
+
+      const result = await transform.call(plugin, code, "/app/layout.tsx");
+      expect(result).not.toBeNull();
+      expect(result.code).toContain("_selfHostedCSS");
+
+      const cssFetch = fetchedUrls.find((u) => u.includes("fonts.googleapis.com/css2"));
+      expect(cssFetch).toBeDefined();
+      const decoded = decodeURIComponent(cssFetch!);
+      expect(decoded).toContain("Sen:wght@400..800");
+      expect(decoded).not.toContain("wght@100..900");
+    } finally {
+      globalThis.fetch = originalFetch;
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("throws a build error on unknown font families (regression for #885)", async () => {
+    // Pre-port vinext built a URL for any property name on the proxy and
+    // only discovered the family was unknown when Google returned 400.
+    // The validator now surfaces this at transform time with a message
+    // pointing at the file path.
+    const plugin = getGoogleFontsPlugin();
+    initPlugin(plugin, { command: "build", root: import.meta.dirname });
+    const transform = unwrapHook(plugin.transform);
+    const code = [
+      `import { NotARealFont } from 'next/font/google';`,
+      `const f = NotARealFont({ weight: '400', subsets: ['latin'] });`,
+    ].join("\n");
+    await expect(transform.call(plugin, code, "/app/layout.tsx")).rejects.toThrow(
+      /Unknown font `NotARealFont`/,
+    );
+  });
+
+  it("throws a build error when a static font is called without an explicit weight (regression for #885)", async () => {
+    // Anton has only weight '400' and no variable face, so calling it
+    // without weight should error at build time. Pre-port vinext silently
+    // emitted `:wght@100..900` which Google rejected with HTTP 400.
+    const plugin = getGoogleFontsPlugin();
+    initPlugin(plugin, { command: "build", root: import.meta.dirname });
+    const transform = unwrapHook(plugin.transform);
+    const code = [
+      `import { Anton } from 'next/font/google';`,
+      `const f = Anton({ subsets: ['latin'] });`,
+    ].join("\n");
+    await expect(transform.call(plugin, code, "/app/layout.tsx")).rejects.toThrow(
+      /Missing weight for font `Anton`/,
+    );
+  });
+
+  it("surfaces HTTP errors from Google Fonts as build errors with response body", async () => {
+    // If Google returns 4xx/5xx the plugin must not silently fall through
+    // to the runtime CDN path; the same broken URL would just 400 in the
+    // browser. Throw a build error containing the URL and Google's body
+    // so the user can see what went wrong.
+    const plugin = getGoogleFontsPlugin();
+    const root = path.join(import.meta.dirname, ".test-font-root-http-error");
+    initPlugin(plugin, { command: "build", root });
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () =>
+      new Response("/* axis range out of bounds */", {
+        status: 400,
+        headers: { "content-type": "text/html" },
+      });
+
+    try {
+      const transform = unwrapHook(plugin.transform);
+      const code = [
+        `import { Inter } from 'next/font/google';`,
+        `const inter = Inter({ weight: '400', subsets: ['latin'] });`,
+      ].join("\n");
+      await expect(transform.call(plugin, code, "/app/layout.tsx")).rejects.toThrow(
+        /Google Fonts returned HTTP 400/,
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("falls through silently when fetch fails with a network error (offline dev)", async () => {
+    // A raw fetch rejection (DNS, ECONNREFUSED, AbortError) is treated as
+    // recoverable: the plugin skips self-hosting and the runtime CDN path
+    // takes over. Distinct from an HTTP non-2xx response, which is a hard
+    // build error.
+    const plugin = getGoogleFontsPlugin();
+    const root = path.join(import.meta.dirname, ".test-font-root-network-error");
+    initPlugin(plugin, { command: "build", root });
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () => {
+      throw new TypeError("fetch failed");
+    };
+
+    try {
+      const transform = unwrapHook(plugin.transform);
+      const code = [
+        `import { Inter } from 'next/font/google';`,
+        `const inter = Inter({ weight: '400', subsets: ['latin'] });`,
+      ].join("\n");
+      const result = await transform.call(plugin, code, "/app/layout.tsx");
+      // Transform still returns; it just does not inject _selfHostedCSS.
+      expect(result).not.toBeNull();
+      expect(result.code).not.toContain("_selfHostedCSS");
     } finally {
       globalThis.fetch = originalFetch;
       fs.rmSync(root, { recursive: true, force: true });
@@ -699,7 +863,7 @@ describe("vinext:google-fonts plugin", () => {
       const transform = unwrapHook(plugin.transform);
       const code = [
         `import fonts from 'next/font/google';`,
-        `const mono = fonts.Roboto_Mono({ weight: '400' });`,
+        `const mono = fonts.Roboto_Mono({ weight: '400', subsets: ['latin'] });`,
       ].join("\n");
       const result = await transform.call(plugin, code, "/app/layout.tsx");
       expect(result).not.toBeNull();

--- a/tests/font-google.test.ts
+++ b/tests/font-google.test.ts
@@ -163,7 +163,20 @@ describe("next/font/google shim", () => {
     // dropped. Italic-only must now leave a visible ital axis in the URL.
     const { buildGoogleFontsUrl } = await import("../packages/vinext/src/shims/font-google.js");
     const url = buildGoogleFontsUrl("Inter", { style: ["italic"] });
-    expect(url).toContain("ital");
+    const decoded = decodeURIComponent(url);
+    expect(decoded).toContain(":ital,wght@1,400");
+    expect(decoded).not.toContain("ital,wght@0,");
+  });
+
+  it("buildGoogleFontsUrl drops the unresolved variable sentinel in the dev fallback", async () => {
+    // The shim has no metadata, so it cannot resolve "variable" to the
+    // font's real min..max range. Production resolves this in the plugin;
+    // dev fallback should avoid emitting Google's invalid `wght@variable`.
+    const { buildGoogleFontsUrl } = await import("../packages/vinext/src/shims/font-google.js");
+    const url = buildGoogleFontsUrl("Inter", { weight: "variable" });
+    const decoded = decodeURIComponent(url);
+    expect(decoded).not.toContain("wght@variable");
+    expect(decoded).not.toContain("wght@");
   });
 
   it("getSSRFontLinks returns collected URLs without clearing", async () => {
@@ -753,6 +766,44 @@ describe("vinext:google-fonts plugin", () => {
     }
   });
 
+  it("self-hosts variable font axes through the plugin pipeline", async () => {
+    // Covers the documented `axes` option end-to-end: static parsing,
+    // validation, metadata axis resolution, and URL assembly.
+    const plugin = getGoogleFontsPlugin();
+    const root = path.join(import.meta.dirname, ".test-font-root-axes");
+    initPlugin(plugin, { command: "build", root });
+
+    const originalFetch = globalThis.fetch;
+    const fetchedUrls: string[] = [];
+    globalThis.fetch = async (input: any) => {
+      fetchedUrls.push(String(input));
+      return new Response("@font-face { font-family: 'Roboto Flex'; src: url(/flex.woff2); }", {
+        status: 200,
+        headers: { "content-type": "text/css" },
+      });
+    };
+
+    try {
+      const transform = unwrapHook(plugin.transform);
+      const code = [
+        `import { Roboto_Flex } from 'next/font/google';`,
+        `const flex = Roboto_Flex({ weight: 'variable', axes: ['opsz'], subsets: ['latin'] });`,
+      ].join("\n");
+
+      const result = await transform.call(plugin, code, "/app/layout.tsx");
+      expect(result).not.toBeNull();
+      expect(result.code).toContain("_selfHostedCSS");
+
+      const cssFetch = fetchedUrls.find((u) => u.includes("fonts.googleapis.com/css2"));
+      expect(cssFetch).toBeDefined();
+      const decoded = decodeURIComponent(cssFetch!);
+      expect(decoded).toContain("Roboto+Flex:opsz,wght@8..144,100..1000");
+    } finally {
+      globalThis.fetch = originalFetch;
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("throws a build error on unknown font families (regression for #885)", async () => {
     // Pre-port vinext built a URL for any property name on the proxy and
     // only discovered the family was unknown when Google returned 400.
@@ -786,7 +837,7 @@ describe("vinext:google-fonts plugin", () => {
     );
   });
 
-  it("surfaces HTTP errors from Google Fonts as build errors with response body", async () => {
+  it("surfaces HTTP errors from Google Fonts as build errors with a bounded response body", async () => {
     // If Google returns 4xx/5xx the plugin must not silently fall through
     // to the runtime CDN path; the same broken URL would just 400 in the
     // browser. Throw a build error containing the URL and Google's body
@@ -794,10 +845,12 @@ describe("vinext:google-fonts plugin", () => {
     const plugin = getGoogleFontsPlugin();
     const root = path.join(import.meta.dirname, ".test-font-root-http-error");
     initPlugin(plugin, { command: "build", root });
+    const longBody = `/* axis range out of bounds */${"x".repeat(600)}`;
+    const truncatedLength = longBody.length - 500;
 
     const originalFetch = globalThis.fetch;
     globalThis.fetch = async () =>
-      new Response("/* axis range out of bounds */", {
+      new Response(longBody, {
         status: 400,
         headers: { "content-type": "text/html" },
       });
@@ -808,8 +861,10 @@ describe("vinext:google-fonts plugin", () => {
         `import { Inter } from 'next/font/google';`,
         `const inter = Inter({ weight: '400', subsets: ['latin'] });`,
       ].join("\n");
-      await expect(transform.call(plugin, code, "/app/layout.tsx")).rejects.toThrow(
-        /Google Fonts returned HTTP 400/,
+      await expect(transform.call(plugin, code, "/app/layout.tsx")).rejects.toThrowError(
+        new RegExp(
+          `Google Fonts returned HTTP 400[\\s\\S]*truncated ${truncatedLength} characters`,
+        ),
       );
     } finally {
       globalThis.fetch = originalFetch;

--- a/tests/google-fonts/validate.test.ts
+++ b/tests/google-fonts/validate.test.ts
@@ -78,6 +78,16 @@ describe("validateGoogleFontOptions", () => {
     ).toThrow(/Axes can only be defined for variable fonts/);
   });
 
+  it("rejects non-array axes before font capability checks", () => {
+    expect(() =>
+      validateGoogleFontOptions("Anton", {
+        weight: "400",
+        axes: { wght: 400 } as any,
+        subsets: ["latin"],
+      }),
+    ).toThrow(/Invalid axes value for font `Anton`, expected an array of axis names/);
+  });
+
   it("rejects axes when an explicit (non-variable) weight is set on a variable font", () => {
     expect(() =>
       validateGoogleFontOptions("Inter", { weight: "400", axes: ["opsz"], subsets: ["latin"] }),


### PR DESCRIPTION
## What this changes

Wires the metadata-driven Google Fonts pipeline from #892 into the two consumers that previously hardcoded `:wght@100..900`. Fixes issue #885 and related Google Fonts URL bugs.

| File | Change |
|---|---|
| `shims/font-google-base.ts` | Rewrite `buildGoogleFontsUrl` on top of the pure URL builder. No metadata in the shim, so the Worker bundle stays small. Empty options and `weight: 'variable'` no longer emit invalid fallback axes. |
| `plugins/fonts.ts` | Replace inline URL construction with `validateGoogleFontOptions` + `getFontAxes` + `buildGoogleFontsUrl`. Surface validation errors and HTTP 4xx/5xx as build errors, with bounded Google response bodies. |
| `build/google-fonts/validate.ts` | Report non-array `axes` values before font capability checks so object-form migration errors are clearer. |
| `examples/app-router-nitro` | Add the required `subsets` option to its `Geist_Mono` call so the example still builds under the stricter validator. |
| `tests/*` | Add regression coverage for narrow axes, italic-only URLs, `weight: 'variable'` fallback behavior, plugin-level `axes`, validation errors, HTTP error truncation, and network-error fallback. |

## Why

Issue #885: vinext hardcoded `:wght@100..900` in two URL builders, so fonts whose `wght` axis is narrower (Sen 400..800, Anton 400) returned HTTP 400 from Google and rendered as `sans-serif` fallback. Investigation found related cases broken by the same code path: italic-only style requests dropped italic in dev fallback, the documented `axes` option was ignored by the plugin path, `weight: 'variable'` could produce a rejected dev fallback URL, and unknown families silently produced URLs that Google rejected at request time.

## Approach

1. **shim**: wrap the pure URL builder. Empty options now emit no axis segment; italic-only requests now keep the ital axis; unresolved `weight: 'variable'` is dropped in the dev fallback because the shim intentionally has no metadata.
2. **plugin**: validate at transform time, fetch with the metadata-driven URL, distinguish HTTP errors from network errors. HTTP 4xx/5xx surfaces as a build error with the URL and a bounded response body; network errors still fall through silently for offline dev.
3. **tests/examples**: lock in the reported regression and review feedback, including the Nitro example build, exact italic axis values, valid `axes: ['opsz']` through the plugin pipeline, and clearer object-form axes errors.

## Validation

- `vp test run tests/font-google.test.ts tests/google-fonts/build-url.test.ts tests/google-fonts/validate.test.ts`: 120 tests pass
- `vp check examples/app-router-nitro/app/layout.tsx packages/vinext/src/plugins/fonts.ts packages/vinext/src/shims/font-google-base.ts packages/vinext/src/build/google-fonts/validate.ts tests/font-google.test.ts tests/google-fonts/validate.test.ts`: clean
- `vp run --filter vinext-app-router-nitro build`: pass

## Risks / release notes

- `fontCache` is keyed by URL. Existing on-disk caches under `.vinext/fonts/<hash>/` are stale for affected fonts; one refetch per font on next build.
- Validator is now strict about subsets when preload is enabled, matching Next.js. User code that relied on vinext's pre-fix permissiveness needs `subsets: [...]` or `preload: false`; in-tree examples now satisfy this.
- Italic-only dev fallback requests now emit only `ital=1` instead of accidentally also shipping the regular face. This matches Next.js and the intent of `style: ['italic']`, but it is user-visible for code that relied on the old side effect.
- Shim's dev fallback emits no axis segment for empty options or unresolved `weight: 'variable'`, so dev mode under dynamic options returns Google's default static face instead of a full variable range. Production uses the metadata-aware path and is unaffected.
- The "auto-disables preload" test in #892 pins on `Playwrite AR Guides` (empty subsets in current upstream metadata). If a future canary refresh adds a subset to that family the fixture needs to change.

Closes #885.