### PR TITLE
ci(opencode): register openai/gpt-5.5 under cloudflare-ai-gateway

### DIFF
--- a/.github/workflows/bigbonk.yml
+++ b/.github/workflows/bigbonk.yml
@@ -42,9 +42,9 @@ jobs:
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
         with:
-          model: "cloudflare-ai-gateway/anthropic/claude-opus-4-7"
+          model: "cloudflare-ai-gateway/openai/gpt-5.5"
           mentions: "/bigbonk"
-          variant: "max"
+          variant: "xhigh"
           permissions: write
           opencode_dev: false
           opencode_version: 1.14.22

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -42,8 +42,9 @@ jobs:
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
         with:
-          model: "cloudflare-ai-gateway/anthropic/claude-opus-4-7"
+          model: "cloudflare-ai-gateway/openai/gpt-5.5"
           mentions: "/bonk,@ask-bonk"
+          variant: "xhigh"
           permissions: write
           opencode_dev: false
           agent: viguy

--- a/.opencode/agents/reviewer.md
+++ b/.opencode/agents/reviewer.md
@@ -1,7 +1,7 @@
 ---
 description: Thorough code reviewer focused on correctness, edge cases, and dev/prod parity. Posts reviews directly on GitHub PRs.
 mode: subagent
-model: anthropic/claude-opus-4-7
+model: openai/gpt-5.5
 temperature: 0.1
 tools:
   write: false

--- a/.opencode/agents/viguy.md
+++ b/.opencode/agents/viguy.md
@@ -1,7 +1,7 @@
 ---
 description: Vite, Next.js, TypeScript and JS build systems expert for vinext
 mode: primary
-model: anthropic/claude-opus-4-7
+model: openai/gpt-5.5
 temperature: 0.2
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ vinext was born from an experiment in pushing AI to its limits. Almost every lin
 
 ## Recommended setup
 
-We use [OpenCode](https://opencode.ai) with Claude Opus 4.6, set to max thinking. This is the same setup that built the project.
+We use [OpenCode](https://opencode.ai) with GPT-5.5, set to xhigh reasoning effort. This is the same setup that built the project.
 
 ## Before you open a PR
 
@@ -15,7 +15,7 @@ We use [OpenCode](https://opencode.ai) with Claude Opus 4.6, set to max thinking
 
 ## AI code review
 
-Every PR goes through AI code review. When you open a PR, a contributor with write access will request a review from **BigBonk** (Claude Opus 4.6, max thinking mode). External contributors can't trigger this directly.
+Every PR goes through AI code review. When you open a PR, a contributor with write access will request a review from **BigBonk** (GPT-5.5, xhigh reasoning effort). External contributors can't trigger this directly.
 
 Our process is to iterate on BigBonk's feedback until there are no unresolved comments. That doesn't mean you have to accept every suggestion verbatim, but we've found it to be very good at finding real problems and very useful for debugging this codebase. Expect multiple review rounds on larger PRs.
 

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "cloudflare-ai-gateway": {
+      "models": {
+        "openai/gpt-5.5": {
+          "id": "openai/gpt-5.5",
+          "name": "GPT-5.5",
+          "release_date": "2026-04-23",
+          "attachment": true,
+          "reasoning": true,
+          "temperature": false,
+          "tool_call": true,
+          "modalities": {
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
+          },
+          "cost": {
+            "input": 5.0,
+            "output": 30.0,
+            "cache_read": 0.5,
+            "context_over_200k": {
+              "input": 10.0,
+              "output": 45.0,
+              "cache_read": 1.0
+            }
+          },
+          "limit": {
+            "context": 1050000,
+            "input": 920000,
+            "output": 130000
+          },
+          "provider": {
+            "npm": "ai-gateway-provider"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What
Add `opencode.json` registering `openai/gpt-5.5` under the built-in `cloudflare-ai-gateway` provider, mirroring the upstream models.dev spec.

## Why
After #898, bonk/bigbonk throw `ProviderModelNotFoundError`. opencode's bundled models snapshot predates GPT-5.5 (2026-04-23) and the `cloudflare-ai-gateway` entry on models.dev does not list it yet, so `provider.models["openai/gpt-5.5"]` lookup fails before any network call. Failing run: https://github.com/cloudflare/vinext/actions/runs/24938461196.

opencode merges user-supplied provider models into the resolved dict, so this entry unblocks invocations without an opencode release.

## Tradeoffs
- Custom-provider configs in opencode-action context have regressed before (anomalyco/opencode#7958). If `/bigbonk` still fails after merge, revert + downgrade to `gpt-5.4`.
- `variant: xhigh` reasoning effort mapping for a custom-registered model is untested; may fall back to default effort.
- Duplicates upstream config until the snapshot catches up.

## Removal plan
@james-elicx fyi. I'm tracking anomalyco/models.dev#1596 (cloudflare-ai-gateway/openai/gpt-5.5 entry). Once that lands AND opencode publishes a release with a refreshed snapshot, I'll delete `opencode.json` in a follow-up.

## Validation
- Lookup throw site verified against opencode source (`packages/opencode/src/provider/provider.ts`).
- Test on this PR by commenting `/bigbonk review` before merging to main.