### PR TITLE
ci(bonk): pin opencode to 1.4.6 to dodge cf-ai-gateway ProviderInitError

### DIFF
--- a/.github/workflows/bigbonk.yml
+++ b/.github/workflows/bigbonk.yml
@@ -47,5 +47,5 @@ jobs:
           variant: "xhigh"
           permissions: write
           opencode_dev: false
-          opencode_version: 1.14.25
+          opencode_version: 1.4.6
           agent: viguy

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -47,4 +47,5 @@ jobs:
           variant: "xhigh"
           permissions: write
           opencode_dev: false
+          opencode_version: 1.4.6
           agent: viguy


### PR DESCRIPTION
## What
Pin `opencode_version: 1.4.6` in both `bonk.yml` and `bigbonk.yml`.

## Why
@james-elicx — #900 downgraded the model to gpt-5.4 but bots still throw `UnknownError: ProviderInitError` (run https://github.com/cloudflare/vinext/actions/runs/24939417069). Real regression is opencode 1.14.25, not the model. The throw fires during cf-ai-gateway SDK init before any per-model code path runs, so model swaps don't help.

workers-sdk hit the same regression on the same opencode bump and pinned `opencode_version: "1.4.6"` with an inline comment:

```yaml
opencode_version: "1.4.6" # pin to this version as newer versions are causing ProviderInitError issues
```

Other Cloudflare repos (containers, workers-py, kumo, workerd) pin 1.2.27 / 1.4.6 for the same reason. vinext is the only CF repo running OpenAI through cf-ai-gateway, which is why the OAI path stayed unobserved until #898.

**Treat this as the last attempt at OAI on cf-ai-gateway.** If `/bigbonk review` on this PR still throws, fall back to `anthropic/claude-opus-4-7` + `variant: max` and stop chasing GPT until upstream opencode + ai-gateway-provider settle.

## Approach
- `bigbonk.yml`: `opencode_version: 1.14.25` → `1.4.6`.
- `bonk.yml`: add `opencode_version: 1.4.6` (was unset, defaulted to latest).
- gpt-5.4 model from #900 stays; gpt-5.4 predates 1.4.6's bundled snapshot by over a month, so registry resolution is fine.

## Validation
Comment `/bigbonk review` on this PR before merging. If green, merge; if red, drop OAI and revert to opus.