### PR TITLE
fix(app-router): block javascript: URLs in router.push/replace/prefetch

### DIFF
--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -76,6 +76,7 @@ import {
 } from "./app-browser-state.js";
 import { ElementsContext, Slot } from "../shims/slot.js";
 import { devOnCaughtError } from "./app-browser-error.js";
+import { DANGEROUS_URL_BLOCK_MESSAGE, isDangerousScheme } from "../shims/url-safety.js";
 
 type SearchParamInput = ConstructorParameters<typeof URLSearchParams>[0];
 
@@ -980,6 +981,11 @@ function registerServerActionCallback(): void {
 
     const actionRedirect = fetchResponse.headers.get("x-action-redirect");
     if (actionRedirect) {
+      if (isDangerousScheme(actionRedirect)) {
+        console.error(DANGEROUS_URL_BLOCK_MESSAGE);
+        return undefined;
+      }
+
       // Check for external URLs that need a hard redirect.
       try {
         const redirectUrl = new URL(actionRedirect, window.location.origin);

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -16,18 +16,7 @@ import { createAppPayloadCacheKey } from "../server/app-elements.js";
 import { toBrowserNavigationHref, toSameOriginAppPath } from "./url-utils.js";
 import { stripBasePath } from "../utils/base-path.js";
 import { ReadonlyURLSearchParams } from "./readonly-url-search-params.js";
-import { isDangerousScheme } from "./url-safety.js";
-
-// Mirrors Next.js wording exactly so tooling and tests can match across both
-// frameworks. Source: packages/next/src/client/components/app-router-instance.ts
-const DANGEROUS_URL_BLOCK_MESSAGE =
-  "Next.js has blocked a javascript: URL as a security precaution.";
-
-function assertSafeNavigationHref(href: string): void {
-  if (isDangerousScheme(href)) {
-    throw new Error(DANGEROUS_URL_BLOCK_MESSAGE);
-  }
-}
+import { assertSafeNavigationUrl } from "./url-safety.js";
 
 // ─── Layout segment context ───────────────────────────────────────────────────
 // Stores the child segments below the current layout. Each layout wraps its
@@ -1253,14 +1242,14 @@ export async function navigateClientSide(
 
 const _appRouter = {
   push(href: string, options?: { scroll?: boolean }): void {
-    assertSafeNavigationHref(href);
+    assertSafeNavigationUrl(href);
     if (isServer) return;
     React.startTransition(() => {
       void navigateClientSide(href, "push", options?.scroll !== false, true);
     });
   },
   replace(href: string, options?: { scroll?: boolean }): void {
-    assertSafeNavigationHref(href);
+    assertSafeNavigationUrl(href);
     if (isServer) return;
     React.startTransition(() => {
       void navigateClientSide(href, "replace", options?.scroll !== false, true);
@@ -1286,7 +1275,7 @@ const _appRouter = {
     }
   },
   prefetch(href: string): void {
-    assertSafeNavigationHref(href);
+    assertSafeNavigationUrl(href);
     if (isServer) return;
     // Prefetch the RSC payload for the target route and store in cache.
     // We must add to prefetchedUrls manually for deduplication.

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -16,6 +16,18 @@ import { createAppPayloadCacheKey } from "../server/app-elements.js";
 import { toBrowserNavigationHref, toSameOriginAppPath } from "./url-utils.js";
 import { stripBasePath } from "../utils/base-path.js";
 import { ReadonlyURLSearchParams } from "./readonly-url-search-params.js";
+import { isDangerousScheme } from "./url-safety.js";
+
+// Mirrors Next.js wording exactly so tooling and tests can match across both
+// frameworks. Source: packages/next/src/client/components/app-router-instance.ts
+const DANGEROUS_URL_BLOCK_MESSAGE =
+  "Next.js has blocked a javascript: URL as a security precaution.";
+
+function assertSafeNavigationHref(href: string): void {
+  if (isDangerousScheme(href)) {
+    throw new Error(DANGEROUS_URL_BLOCK_MESSAGE);
+  }
+}
 
 // ─── Layout segment context ───────────────────────────────────────────────────
 // Stores the child segments below the current layout. Each layout wraps its
@@ -1241,12 +1253,14 @@ export async function navigateClientSide(
 
 const _appRouter = {
   push(href: string, options?: { scroll?: boolean }): void {
+    assertSafeNavigationHref(href);
     if (isServer) return;
     React.startTransition(() => {
       void navigateClientSide(href, "push", options?.scroll !== false, true);
     });
   },
   replace(href: string, options?: { scroll?: boolean }): void {
+    assertSafeNavigationHref(href);
     if (isServer) return;
     React.startTransition(() => {
       void navigateClientSide(href, "replace", options?.scroll !== false, true);
@@ -1272,6 +1286,7 @@ const _appRouter = {
     }
   },
   prefetch(href: string): void {
+    assertSafeNavigationHref(href);
     if (isServer) return;
     // Prefetch the RSC payload for the target route and store in cache.
     // We must add to prefetchedUrls manually for deduplication.

--- a/packages/vinext/src/shims/server.ts
+++ b/packages/vinext/src/shims/server.ts
@@ -12,6 +12,7 @@
 import { encodeMiddlewareRequestHeaders } from "../server/middleware-request-headers.js";
 import { parseCookieHeader } from "./internal/parse-cookie-header.js";
 import { getRequestExecutionContext } from "./request-context.js";
+import { assertSafeNavigationUrl } from "./url-safety.js";
 
 // ---------------------------------------------------------------------------
 // Inlined cache-scope guard for after()
@@ -164,6 +165,20 @@ export class NextRequest extends Request {
 /** Valid HTTP redirect status codes, matching Next.js's REDIRECTS set. */
 const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
 
+function validateURL(url: string | URL): string {
+  assertSafeNavigationUrl(String(url));
+  try {
+    return String(new URL(String(url)));
+  } catch (error) {
+    throw new Error(
+      `URL is malformed "${String(
+        url,
+      )}". Please use only absolute URLs - https://nextjs.org/docs/messages/middleware-relative-urls`,
+      { cause: error },
+    );
+  }
+}
+
 export class NextResponse<_Body = unknown> extends Response {
   private _cookies: ResponseCookies;
 
@@ -198,9 +213,8 @@ export class NextResponse<_Body = unknown> extends Response {
     if (!REDIRECT_STATUSES.has(status)) {
       throw new RangeError(`Failed to execute "redirect" on "response": Invalid status code`);
     }
-    const destination = typeof url === "string" ? url : url.toString();
     const headers = new Headers(typeof init === "object" ? init?.headers : undefined);
-    headers.set("Location", destination);
+    headers.set("Location", validateURL(url));
     return new NextResponse(null, { status, headers });
   }
 
@@ -209,9 +223,8 @@ export class NextResponse<_Body = unknown> extends Response {
    * Sets the x-middleware-rewrite header.
    */
   static rewrite(destination: string | URL, init?: MiddlewareResponseInit): NextResponse {
-    const url = typeof destination === "string" ? destination : destination.toString();
     const headers = new Headers(init?.headers);
-    headers.set("x-middleware-rewrite", url);
+    headers.set("x-middleware-rewrite", validateURL(destination));
     if (init?.request?.headers) {
       encodeMiddlewareRequestHeaders(headers, init.request.headers);
     }

--- a/packages/vinext/src/shims/url-safety.ts
+++ b/packages/vinext/src/shims/url-safety.ts
@@ -34,7 +34,16 @@ const DANGEROUS_SCHEME_RES = [
   buildDangerousSchemeRegex("vbscript"),
 ];
 
+export const DANGEROUS_URL_BLOCK_MESSAGE =
+  "Next.js has blocked a javascript: URL as a security precaution.";
+
 export function isDangerousScheme(url: string): boolean {
   const str = "" + (url as unknown as string);
   return DANGEROUS_SCHEME_RES.some((re) => re.test(str));
+}
+
+export function assertSafeNavigationUrl(url: string): void {
+  if (isDangerousScheme(url)) {
+    throw new Error(DANGEROUS_URL_BLOCK_MESSAGE);
+  }
 }

--- a/tests/e2e/app-router/nextjs-compat/javascript-urls.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/javascript-urls.spec.ts
@@ -1,0 +1,98 @@
+import { test, expect, type Page, type Request } from "@playwright/test";
+import { waitForAppRouterHydration } from "../../helpers";
+
+const BASE = "http://localhost:4174";
+
+function createNavigationInterceptor() {
+  const navigationRequests: Request[] = [];
+
+  const beforePageLoad = (page: Page) => {
+    page.on("request", (request) => {
+      if (request.resourceType() === "document") {
+        navigationRequests.push(request);
+      }
+    });
+  };
+
+  const getNavigationRequests = () => navigationRequests;
+
+  return { beforePageLoad, getNavigationRequests };
+}
+
+async function expectJavascriptUrlBlocked(
+  page: Page,
+  initialUrl: string,
+  getNavigationRequests: () => Request[],
+) {
+  await expect
+    .poll(async () => {
+      const logs = await page.evaluate(() => {
+        const value = Reflect.get(window, "__VINEXT_TEST_CONSOLE_ERRORS__");
+        return Array.isArray(value) ? value.map(String) : [];
+      });
+      return logs.some((message) =>
+        message.includes("has blocked a javascript: URL as a security precaution."),
+      );
+    })
+    .toBe(true);
+
+  const postLoadNavigations = getNavigationRequests().filter(
+    (request) => !request.url().includes(new URL(initialUrl).pathname),
+  );
+  expect(postLoadNavigations).toHaveLength(0);
+  expect(page.url()).toBe(initialUrl);
+}
+
+test.describe("javascript-urls", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      Reflect.set(window, "__VINEXT_TEST_CONSOLE_ERRORS__", []);
+      const originalError = console.error;
+      console.error = (...args: unknown[]) => {
+        const value = Reflect.get(window, "__VINEXT_TEST_CONSOLE_ERRORS__");
+        if (Array.isArray(value)) {
+          value.push(args.map(String).join(" "));
+        }
+        originalError(...args);
+      };
+    });
+  });
+
+  // Ported from Next.js: test/e2e/app-dir/javascript-urls/javascript-urls.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/javascript-urls/javascript-urls.test.ts
+  test("should prevent javascript URLs in server action redirect through onClick", async ({
+    page,
+  }) => {
+    const { beforePageLoad, getNavigationRequests } = createNavigationInterceptor();
+    beforePageLoad(page);
+
+    await page.goto(`${BASE}/nextjs-compat/javascript-urls/action-redirect-onclick`);
+    await waitForAppRouterHydration(page);
+    const initialUrl = page.url();
+
+    await page.getByRole("button", { name: "redirect via onclick action" }).click();
+    await expectJavascriptUrlBlocked(page, initialUrl, getNavigationRequests);
+
+    await page.locator('a[href="/nextjs-compat/javascript-urls/safe"]').click();
+    await expect(page).toHaveURL(`${BASE}/nextjs-compat/javascript-urls/safe`);
+  });
+
+  // Ported from Next.js: test/e2e/app-dir/javascript-urls/javascript-urls.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/javascript-urls/javascript-urls.test.ts
+  test("should prevent javascript URLs in server action redirect through form action", async ({
+    page,
+  }) => {
+    const { beforePageLoad, getNavigationRequests } = createNavigationInterceptor();
+    beforePageLoad(page);
+
+    await page.goto(`${BASE}/nextjs-compat/javascript-urls/action-redirect-form`);
+    await waitForAppRouterHydration(page);
+    const initialUrl = page.url();
+
+    await page.getByRole("button", { name: "redirect via form action" }).click();
+    await expectJavascriptUrlBlocked(page, initialUrl, getNavigationRequests);
+
+    await page.locator('a[href="/nextjs-compat/javascript-urls/safe"]').click();
+    await expect(page).toHaveURL(`${BASE}/nextjs-compat/javascript-urls/safe`);
+  });
+});

--- a/tests/fixtures/app-basic/app/nextjs-compat/javascript-urls/action-redirect-form/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/javascript-urls/action-redirect-form/page.tsx
@@ -1,0 +1,22 @@
+import { redirect } from "next/navigation";
+import { DANGEROUS_JAVASCRIPT_URL } from "../bad-url";
+
+async function handleRedirect() {
+  "use server";
+  redirect(DANGEROUS_JAVASCRIPT_URL);
+}
+
+export default function Page() {
+  return (
+    <>
+      <p>
+        Clicking this button should result in an error where Next.js blocks a javascript URL through
+        a server action redirect initiated by a form action.
+      </p>
+      <form action={handleRedirect}>
+        <button type="submit">redirect via form action</button>
+      </form>
+      <a href="/nextjs-compat/javascript-urls/safe">safe page</a>
+    </>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/javascript-urls/action-redirect-onclick/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/javascript-urls/action-redirect-onclick/page.tsx
@@ -1,0 +1,20 @@
+import { redirect } from "next/navigation";
+import { DANGEROUS_JAVASCRIPT_URL } from "../bad-url";
+
+async function handleRedirect() {
+  "use server";
+  redirect(DANGEROUS_JAVASCRIPT_URL);
+}
+
+export default function Page() {
+  return (
+    <>
+      <p>
+        Clicking this button should result in an error where Next.js blocks a javascript URL through
+        a server action redirect initiated by an onClick handler.
+      </p>
+      <button onClick={handleRedirect}>redirect via onclick action</button>
+      <a href="/nextjs-compat/javascript-urls/safe">safe page</a>
+    </>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/javascript-urls/bad-url.ts
+++ b/tests/fixtures/app-basic/app/nextjs-compat/javascript-urls/bad-url.ts
@@ -1,0 +1,2 @@
+export const DANGEROUS_JAVASCRIPT_URL =
+  "javascript:window.location.assign('/nextjs-compat/javascript-urls/boom');";

--- a/tests/fixtures/app-basic/app/nextjs-compat/javascript-urls/boom/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/javascript-urls/boom/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>If you were redirected here then the dangerous javascript URL was executed.</p>;
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/javascript-urls/safe/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/javascript-urls/safe/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>Safe page</p>;
+}

--- a/tests/router-javascript-urls.test.ts
+++ b/tests/router-javascript-urls.test.ts
@@ -11,6 +11,15 @@ import { describe, it, expect } from "vite-plus/test";
 // navigation kicks off, at the top of push/replace/prefetch. Even server-side
 // calls throw, matching Next.js intent and giving SSR-safe regression coverage
 // in node-based unit tests.
+//
+// Coverage split:
+//   Ported from the Next.js E2E suite above: javascript: cases for
+//     push/replace/prefetch plus the obfuscation variants that Next.js's
+//     javascript-url.ts regex covers (uppercase, embedded tabs, leading
+//     whitespace).
+//   Vinext-only extensions: data: and vbscript: cases. Vinext intentionally
+//     extends the dangerous-scheme block to those schemes via the shared
+//     isDangerousScheme helper. Rationale and scope: shims/url-safety.ts:20-21.
 
 const BLOCK_MESSAGE = "Next.js has blocked a javascript: URL as a security precaution.";
 

--- a/tests/router-javascript-urls.test.ts
+++ b/tests/router-javascript-urls.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vite-plus/test";
+
+// Ported from Next.js: test/e2e/app-dir/javascript-urls/javascript-urls.test.ts
+// https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/javascript-urls/javascript-urls.test.ts
+//
+// Next.js blocks dangerous URI schemes in router.push/replace/prefetch with a
+// thrown Error: "Next.js has blocked a javascript: URL as a security precaution."
+// See: packages/next/src/client/components/app-router-instance.ts:343,400,440,458
+//
+// Vinext mirrors that behavior. The guard runs before any programmatic
+// navigation kicks off, at the top of push/replace/prefetch. Even server-side
+// calls throw, matching Next.js intent and giving SSR-safe regression coverage
+// in node-based unit tests.
+
+const BLOCK_MESSAGE = "Next.js has blocked a javascript: URL as a security precaution.";
+
+describe("App Router useRouter() blocks dangerous URI schemes", () => {
+  it("router.push throws on javascript: URL", async () => {
+    const { useRouter } = await import("../packages/vinext/src/shims/navigation.js");
+    const router = useRouter();
+    expect(() => router.push("javascript:alert(1)")).toThrow(BLOCK_MESSAGE);
+  });
+
+  it("router.replace throws on javascript: URL", async () => {
+    const { useRouter } = await import("../packages/vinext/src/shims/navigation.js");
+    const router = useRouter();
+    expect(() => router.replace("javascript:alert(1)")).toThrow(BLOCK_MESSAGE);
+  });
+
+  it("router.prefetch throws on javascript: URL", async () => {
+    const { useRouter } = await import("../packages/vinext/src/shims/navigation.js");
+    const router = useRouter();
+    expect(() => router.prefetch("javascript:alert(1)")).toThrow(BLOCK_MESSAGE);
+  });
+
+  it("router.push throws on data: URL", async () => {
+    const { useRouter } = await import("../packages/vinext/src/shims/navigation.js");
+    const router = useRouter();
+    expect(() => router.push("data:text/html,<script>alert(1)</script>")).toThrow();
+  });
+
+  it("router.push throws on vbscript: URL", async () => {
+    const { useRouter } = await import("../packages/vinext/src/shims/navigation.js");
+    const router = useRouter();
+    expect(() => router.push("vbscript:MsgBox(1)")).toThrow();
+  });
+
+  it("router.push throws on obfuscated javascript: URL with embedded tabs", async () => {
+    const { useRouter } = await import("../packages/vinext/src/shims/navigation.js");
+    const router = useRouter();
+    expect(() => router.push("java\tscript:alert(1)")).toThrow(BLOCK_MESSAGE);
+  });
+
+  it("router.push throws on uppercase JAVASCRIPT: URL", async () => {
+    const { useRouter } = await import("../packages/vinext/src/shims/navigation.js");
+    const router = useRouter();
+    expect(() => router.push("JAVASCRIPT:alert(1)")).toThrow(BLOCK_MESSAGE);
+  });
+
+  it("router.push throws on leading-whitespace javascript: URL", async () => {
+    const { useRouter } = await import("../packages/vinext/src/shims/navigation.js");
+    const router = useRouter();
+    expect(() => router.push("   javascript:alert(1)")).toThrow(BLOCK_MESSAGE);
+  });
+
+  // Safe URLs must not throw — guard must not over-block.
+  it("router.push does not throw on a normal pathname", async () => {
+    const { useRouter } = await import("../packages/vinext/src/shims/navigation.js");
+    const router = useRouter();
+    expect(() => router.push("/safe")).not.toThrow();
+  });
+
+  it("router.replace does not throw on absolute https URL", async () => {
+    const { useRouter } = await import("../packages/vinext/src/shims/navigation.js");
+    const router = useRouter();
+    expect(() => router.replace("https://example.com/path")).not.toThrow();
+  });
+
+  it("router.prefetch does not throw on a normal pathname", async () => {
+    const { useRouter } = await import("../packages/vinext/src/shims/navigation.js");
+    const router = useRouter();
+    expect(() => router.prefetch("/safe")).not.toThrow();
+  });
+});

--- a/tests/router-javascript-urls.test.ts
+++ b/tests/router-javascript-urls.test.ts
@@ -45,13 +45,13 @@ describe("App Router useRouter() blocks dangerous URI schemes", () => {
   it("router.push throws on data: URL", async () => {
     const { useRouter } = await import("../packages/vinext/src/shims/navigation.js");
     const router = useRouter();
-    expect(() => router.push("data:text/html,<script>alert(1)</script>")).toThrow();
+    expect(() => router.push("data:text/html,<script>alert(1)</script>")).toThrow(BLOCK_MESSAGE);
   });
 
   it("router.push throws on vbscript: URL", async () => {
     const { useRouter } = await import("../packages/vinext/src/shims/navigation.js");
     const router = useRouter();
-    expect(() => router.push("vbscript:MsgBox(1)")).toThrow();
+    expect(() => router.push("vbscript:MsgBox(1)")).toThrow(BLOCK_MESSAGE);
   });
 
   it("router.push throws on obfuscated javascript: URL with embedded tabs", async () => {

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -5209,6 +5209,7 @@ describe("NextResponse.redirect() status codes", () => {
     const { NextResponse } = await import("../packages/vinext/src/shims/server.js");
     const res = NextResponse.redirect("https://example.com", 301);
     expect(res.status).toBe(301);
+    // validateURL() normalizes via `new URL()`, adding a trailing slash for origin-only URLs.
     expect(res.headers.get("Location")).toBe("https://example.com/");
   });
 

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -1339,11 +1339,27 @@ describe("next/server shim", () => {
     expect(res.headers.get("Location")).toBe("https://example.com/new");
   });
 
+  // Ported from Next.js: test/e2e/middleware-general/test/index.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-general/test/index.test.ts
+  it("NextResponse.redirect() throws when using a relative URL", async () => {
+    const { NextResponse } = await import("../packages/vinext/src/shims/server.js");
+
+    expect(() => NextResponse.redirect("/urls-b")).toThrow("URL is malformed");
+  });
+
   it("NextResponse.rewrite() sets x-middleware-rewrite header", async () => {
     const { NextResponse } = await import("../packages/vinext/src/shims/server.js");
     const res = NextResponse.rewrite("https://example.com/internal");
 
     expect(res.headers.get("x-middleware-rewrite")).toBe("https://example.com/internal");
+  });
+
+  // Ported from Next.js: test/e2e/middleware-general/test/index.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-general/test/index.test.ts
+  it("NextResponse.rewrite() throws when using a relative URL", async () => {
+    const { NextResponse } = await import("../packages/vinext/src/shims/server.js");
+
+    expect(() => NextResponse.rewrite("/urls-b")).toThrow("URL is malformed");
   });
 
   it("NextResponse.rewrite() forwards request header overrides", async () => {
@@ -5193,7 +5209,7 @@ describe("NextResponse.redirect() status codes", () => {
     const { NextResponse } = await import("../packages/vinext/src/shims/server.js");
     const res = NextResponse.redirect("https://example.com", 301);
     expect(res.status).toBe(301);
-    expect(res.headers.get("Location")).toBe("https://example.com");
+    expect(res.headers.get("Location")).toBe("https://example.com/");
   });
 
   it("supports 302 Found", async () => {


### PR DESCRIPTION
## What this changes

This PR blocks dangerous navigation URLs across the App Router surfaces that can reach browser navigation sinks:

- `useRouter().push`, `.replace`, and `.prefetch` reject dangerous URI schemes.
- Server Action `redirect("javascript:...")` responses are blocked before the browser entry assigns to `window.location.*`.
- `NextResponse.redirect()` and `NextResponse.rewrite()` now validate URLs before writing `Location` / `x-middleware-rewrite` headers.

The block message intentionally matches Next.js exactly:

`Next.js has blocked a javascript: URL as a security precaution.`

## Why

`router.push("javascript:alert(1)")` previously flowed into `navigateClientSide`, was classified as external, and reached `window.location.assign`, which browsers treat as script execution.

After the initial router fix, two related paths were still open:

- Server Action redirects are returned through `x-action-redirect`; the browser entry consumed that header and sent it directly to `window.location.href`, `.assign()`, or `.replace()`.
- `NextResponse.redirect()` / `rewrite()` wrote raw userland input into framework routing headers. This differed from Next.js, which validates these helper URLs and rejects relative or malformed values.

## Next.js references

Router dangerous URL blocking:

- `push`: [packages/next/src/client/components/app-router-instance.ts#L343](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/app-router-instance.ts#L343)
- inner push helper: [packages/next/src/client/components/app-router-instance.ts#L400](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/app-router-instance.ts#L400)
- `replace`: [packages/next/src/client/components/app-router-instance.ts#L440](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/app-router-instance.ts#L440)
- `prefetch`: [packages/next/src/client/components/app-router-instance.ts#L458](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/app-router-instance.ts#L458)
- hard navigation / Server Action redirect block: [packages/next/src/client/components/segment-cache/navigation.ts#L536](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/segment-cache/navigation.ts#L536)
- shared matcher: [packages/next/src/client/lib/javascript-url.ts](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/lib/javascript-url.ts)

`NextResponse` URL validation:

- helper implementation: [packages/next/src/server/web/spec-extension/response.ts#L117-L140](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/web/spec-extension/response.ts#L117-L140)
- `validateURL`: [packages/next/src/server/web/utils.ts#L141-L152](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/web/utils.ts#L141-L152)
- relative URL tests: [test/e2e/middleware-general/test/index.test.ts#L721-L735](https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-general/test/index.test.ts#L721-L735)
- server-action javascript URL tests: [test/e2e/app-dir/javascript-urls/javascript-urls.test.ts#L200-L250](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/javascript-urls/javascript-urls.test.ts#L200-L250)

## Approach

The dangerous-scheme error message and assertion now live in `shims/url-safety.ts`, so `next/navigation`, `next/server`, and the browser Server Action redirect sink share one policy.

`NextResponse.redirect()` / `rewrite()` now mirror Next.js by passing URLs through `new URL(String(url))`. That rejects relative and malformed URLs and normalizes valid absolute URLs before header write.

The Server Action redirect consumer checks `x-action-redirect` before any `window.location.*` call. If blocked, it logs the Next.js message and returns without navigating, matching the upstream hard-navigation behavior.

## Deliberate divergence from Next.js

Vinext already treats `data:` and `vbscript:` as dangerous in `shims/url-safety.ts`, and `<Link>` / `<Form>` use that same helper. This PR keeps that existing defense-in-depth policy for the added surfaces too.

Next.js's `validateURL()` rejects relative/malformed URLs but does not reject `javascript:` by itself, because `new URL("javascript:...")` is syntactically valid. Vinext applies the shared dangerous-scheme guard before URL validation so all navigation sinks stay aligned.

## Validation

- `vp test run tests/shims.test.ts -t "relative URL"`
- `vp test run tests/router-javascript-urls.test.ts tests/url-safety.test.ts`
- `PLAYWRIGHT_PROJECT=app-router vp run test:e2e tests/e2e/app-router/nextjs-compat/javascript-urls.spec.ts`
- `vp check <changed files>`
- `vp run vinext#build`

Full `vp check` currently fails on an unrelated local-only ignored note file under `nathan/`, not on this PR's changed files.
