### PR TITLE
fix(app-router): fixing cache request leaks

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -73,6 +73,10 @@ const appPageResponsePath = resolveEntryPath("../server/app-page-response.js", i
 const cspPath = resolveEntryPath("../server/csp.js", import.meta.url);
 const appPageRequestPath = resolveEntryPath("../server/app-page-request.js", import.meta.url);
 const appPageMethodPath = resolveEntryPath("../server/app-page-method.js", import.meta.url);
+const appStaticGenerationPath = resolveEntryPath(
+  "../server/app-static-generation.js",
+  import.meta.url,
+);
 const appRouteHandlerResponsePath = resolveEntryPath(
   "../server/app-route-handler-response.js",
   import.meta.url,
@@ -434,6 +438,9 @@ import {
 import {
   resolveAppPageMethodResponse as __resolveAppPageMethodResponse,
 } from ${JSON.stringify(appPageMethodPath)};
+import {
+  createStaticGenerationHeadersContext as __createStaticGenerationHeadersContext,
+} from ${JSON.stringify(appStaticGenerationPath)};
 import {
   applyRouteHandlerMiddlewareContext as __applyRouteHandlerMiddlewareContext,
 } from ${JSON.stringify(appRouteHandlerResponsePath)};
@@ -2185,6 +2192,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           __clearRequestContext();
         },
         consumeDynamicUsage,
+        dynamicConfig: handler.dynamic,
         getCollectedFetchTags,
         handlerFn,
         i18n: __i18nConfig,
@@ -2201,7 +2209,11 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         revalidateSeconds,
         routePattern: route.pattern,
         runInRevalidationContext: async function(renderFn) {
-          const __revalHeadCtx = { headers: new Headers(), cookies: new Map() };
+          const __revalHeadCtx = __createStaticGenerationHeadersContext({
+            dynamicConfig: handler.dynamic,
+            routeKind: "route",
+            routePattern: route.pattern,
+          });
           const __revalUCtx = _createUnifiedCtx({
             headersContext: __revalHeadCtx,
             executionContext: _getRequestExecutionContext(),
@@ -2214,6 +2226,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           });
         },
         scheduleBackgroundRegeneration: __triggerBackgroundRegeneration,
+        setHeadersAccessPhase,
         setNavigationContext,
       });
       if (__cachedRouteResponse) {
@@ -2286,15 +2299,18 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     revalidateSeconds,
   });
   if (__methodResponse) {
-    setHeadersContext(null);
-    setNavigationContext(null);
+    __clearRequestContext();
     return __methodResponse;
   }
 
   // force-static: replace headers/cookies context with empty values and
   // clear searchParams so dynamic APIs return defaults instead of real data
   if (isForceStatic) {
-    setHeadersContext({ headers: new Headers(), cookies: new Map() });
+    setHeadersContext(__createStaticGenerationHeadersContext({
+      dynamicConfig,
+      routeKind: "page",
+      routePattern: route.pattern,
+    }));
     setNavigationContext({
       pathname: cleanPathname,
       searchParams: new URLSearchParams(),
@@ -2305,15 +2321,11 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // dynamic = 'error': install an access error so request APIs fail with the
   // static-generation message even for legacy sync property access.
   if (isDynamicError) {
-    const errorMsg = 'Page with \`dynamic = "error"\` used a dynamic API. ' +
-      'This page was expected to be fully static, but headers(), cookies(), ' +
-      'or searchParams was accessed. Remove the dynamic API usage or change ' +
-      'the dynamic config to "auto" or "force-dynamic".';
-    setHeadersContext({
-      headers: new Headers(),
-      cookies: new Map(),
-      accessError: new Error(errorMsg),
-    });
+    setHeadersContext(__createStaticGenerationHeadersContext({
+      dynamicConfig,
+      routeKind: "page",
+      routePattern: route.pattern,
+    }));
     setNavigationContext({
       pathname: cleanPathname,
       searchParams: new URLSearchParams(),
@@ -2362,7 +2374,11 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         // Use an empty headers context for background regeneration — not the original
         // user request — to prevent user-specific cookies/auth headers from leaking
         // into content that is cached and served to all subsequent users.
-        const __revalHeadCtx = { headers: new Headers(), cookies: new Map() };
+        const __revalHeadCtx = __createStaticGenerationHeadersContext({
+          dynamicConfig,
+          routeKind: "page",
+          routePattern: route.pattern,
+        });
         const __revalUCtx = _createUnifiedCtx({
           headersContext: __revalHeadCtx,
           executionContext: _getRequestExecutionContext(),

--- a/packages/vinext/src/server/app-page-cache.ts
+++ b/packages/vinext/src/server/app-page-cache.ts
@@ -42,6 +42,7 @@ type ReadAppPageCacheResponseOptions = {
 type FinalizeAppPageHtmlCacheResponseOptions = {
   capturedRscDataPromise: Promise<ArrayBuffer> | null;
   cleanPathname: string;
+  consumeDynamicUsage: () => boolean;
   getPageTags: () => string[];
   isrDebug?: AppPageDebugLogger;
   isrHtmlKey: (pathname: string) => string;
@@ -64,6 +65,8 @@ type ScheduleAppPageRscCacheWriteOptions = {
   revalidateSeconds: number;
   waitUntil?: (promise: Promise<void>) => void;
 };
+
+const NO_STORE_CACHE_CONTROL = "no-store, must-revalidate";
 
 function buildAppPageCacheControl(
   cacheState: BuildAppPageCachedResponseOptions["cacheState"],
@@ -233,6 +236,11 @@ export function finalizeAppPageHtmlCacheResponse(
   const [streamForClient, streamForCache] = response.body.tee();
   const htmlKey = options.isrHtmlKey(options.cleanPathname);
   const rscKey = options.isrRscKey(options.cleanPathname, null);
+  const clientHeaders = new Headers(response.headers);
+  // HTML Server Components can access request APIs while the stream is being
+  // consumed. Until that late dynamic check finishes, downstream shared caches
+  // must not cache the speculative MISS response.
+  clientHeaders.set("Cache-Control", NO_STORE_CACHE_CONTROL);
 
   const cachePromise = (async () => {
     try {
@@ -247,6 +255,11 @@ export function finalizeAppPageHtmlCacheResponse(
         chunks.push(decoder.decode(value, { stream: true }));
       }
       chunks.push(decoder.decode());
+
+      if (options.consumeDynamicUsage()) {
+        options.isrDebug?.("HTML cache write skipped (dynamic usage during render)", htmlKey);
+        return;
+      }
 
       const pageTags = options.getPageTags();
       const writes = [
@@ -283,7 +296,29 @@ export function finalizeAppPageHtmlCacheResponse(
   return new Response(streamForClient, {
     status: response.status,
     statusText: response.statusText,
-    headers: response.headers,
+    headers: clientHeaders,
+  });
+}
+
+export function finalizeAppPageRscCacheResponse(
+  response: Response,
+  options: ScheduleAppPageRscCacheWriteOptions,
+): Response {
+  const didSchedule = scheduleAppPageRscCacheWrite(options);
+  if (!didSchedule) {
+    return response;
+  }
+
+  const clientHeaders = new Headers(response.headers);
+  // RSC payloads are also streamed lazily. Until the captured stream proves no
+  // late request API was used, the client-facing MISS response must not enter a
+  // shared cache.
+  clientHeaders.set("Cache-Control", NO_STORE_CACHE_CONTROL);
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: clientHeaders,
   });
 }
 

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -3,7 +3,7 @@ import type { CachedAppPageValue } from "../shims/cache.js";
 import { buildOutgoingAppPayload, type AppOutgoingElements } from "./app-elements.js";
 import {
   finalizeAppPageHtmlCacheResponse,
-  scheduleAppPageRscCacheWrite,
+  finalizeAppPageRscCacheResponse,
 } from "./app-page-cache.js";
 import {
   buildAppPageFontLinkHeader,
@@ -198,7 +198,7 @@ export async function renderAppPageLifecycle(
       }),
     });
 
-    scheduleAppPageRscCacheWrite({
+    return finalizeAppPageRscCacheResponse(rscResponse, {
       capturedRscDataPromise: options.isProduction ? isrRscDataPromise : null,
       cleanPathname: options.cleanPathname,
       consumeDynamicUsage: options.consumeDynamicUsage,
@@ -215,8 +215,6 @@ export async function renderAppPageLifecycle(
         options.waitUntil?.(promise);
       },
     });
-
-    return rscResponse;
   }
 
   const fontData = createAppPageFontData({
@@ -319,6 +317,7 @@ export async function renderAppPageLifecycle(
     return finalizeAppPageHtmlCacheResponse(isrResponse, {
       capturedRscDataPromise: isrRscDataPromise,
       cleanPathname: options.cleanPathname,
+      consumeDynamicUsage: options.consumeDynamicUsage,
       getPageTags() {
         return options.getPageTags();
       },

--- a/packages/vinext/src/server/app-route-handler-cache.ts
+++ b/packages/vinext/src/server/app-route-handler-cache.ts
@@ -1,4 +1,5 @@
 import type { NextI18nConfig } from "../config/next-config.js";
+import type { HeadersAccessPhase } from "../shims/headers.js";
 import type { ISRCacheEntry } from "./isr-cache.js";
 import type { RouteHandlerMiddlewareContext } from "./app-route-handler-response.js";
 import {
@@ -28,6 +29,7 @@ type ReadAppRouteHandlerCacheOptions = {
   cleanPathname: string;
   clearRequestContext: () => void;
   consumeDynamicUsage: AppRouteDynamicUsageFn;
+  dynamicConfig?: string;
   getCollectedFetchTags: () => string[];
   handlerFn: AppRouteHandlerFunction;
   i18n?: NextI18nConfig | null;
@@ -45,6 +47,7 @@ type ReadAppRouteHandlerCacheOptions = {
   routePattern: string;
   runInRevalidationContext: RouteHandlerRevalidationContextRunner;
   scheduleBackgroundRegeneration: RouteHandlerBackgroundRegenerator;
+  setHeadersAccessPhase: (phase: HeadersAccessPhase) => HeadersAccessPhase;
   setNavigationContext: (
     context: {
       pathname: string;
@@ -95,11 +98,14 @@ export async function readAppRouteHandlerCacheResponse(
           const { dynamicUsedInHandler, response } = await runAppRouteHandler({
             basePath: options.basePath,
             consumeDynamicUsage: options.consumeDynamicUsage,
+            dynamicConfig: options.dynamicConfig,
             handlerFn: options.handlerFn,
             i18n: options.i18n,
             markDynamicUsage: options.markDynamicUsage,
             params: options.params,
             request: new Request(options.requestUrl, { method: "GET" }),
+            routePattern: options.routePattern,
+            setHeadersAccessPhase: options.setHeadersAccessPhase,
           });
 
           options.setNavigationContext(null);

--- a/packages/vinext/src/server/app-route-handler-execution.ts
+++ b/packages/vinext/src/server/app-route-handler-execution.ts
@@ -1,7 +1,12 @@
 import type { NextI18nConfig } from "../config/next-config.js";
-import type { HeadersAccessPhase } from "../shims/headers.js";
+import { setHeadersContext, type HeadersAccessPhase } from "../shims/headers.js";
 import type { ExecutionContextLike } from "../shims/request-context.js";
 import type { CachedRouteValue } from "../shims/cache.js";
+import type { NextRequest } from "../shims/server.js";
+import {
+  createStaticGenerationHeadersContext,
+  getAppRouteStaticGenerationErrorMessage,
+} from "./app-static-generation.js";
 import {
   isPossibleAppRouteActionRequest,
   resolveAppRouteHandlerSpecialError,
@@ -27,7 +32,7 @@ export type AppRouteParams = Record<string, string | string[]>;
 export type AppRouteDynamicUsageFn = () => boolean;
 export type MarkAppRouteDynamicUsageFn = () => void;
 export type AppRouteHandlerFunction = (
-  request: Request,
+  request: NextRequest,
   context: { params: AppRouteParams },
 ) => Response | Promise<Response>;
 export type RouteHandlerCacheSetter = (
@@ -46,12 +51,15 @@ export type AppRouteDebugLogger = (event: string, detail: string) => void;
 type RunAppRouteHandlerOptions = {
   basePath?: string;
   consumeDynamicUsage: AppRouteDynamicUsageFn;
+  dynamicConfig?: string;
   handlerFn: AppRouteHandlerFunction;
   i18n?: NextI18nConfig | null;
   markDynamicUsage: MarkAppRouteDynamicUsageFn;
   middlewareRequestHeaders?: Headers | null;
   params: AppRouteParams;
   request: Request;
+  routePattern?: string;
+  setHeadersAccessPhase?: (phase: HeadersAccessPhase) => HeadersAccessPhase;
 };
 
 type RunAppRouteHandlerResult = {
@@ -81,16 +89,37 @@ type ExecuteAppRouteHandlerOptions = {
   setHeadersAccessPhase: (phase: HeadersAccessPhase) => HeadersAccessPhase;
 } & RunAppRouteHandlerOptions;
 
+function configureAppRouteStaticGenerationContext(options: RunAppRouteHandlerOptions): void {
+  if (options.dynamicConfig === "force-static" || options.dynamicConfig === "error") {
+    setHeadersContext(
+      createStaticGenerationHeadersContext({
+        dynamicConfig: options.dynamicConfig,
+        routeKind: "route",
+        routePattern: options.routePattern,
+      }),
+    );
+    options.setHeadersAccessPhase?.("route-handler");
+  }
+}
+
 export async function runAppRouteHandler(
   options: RunAppRouteHandlerOptions,
 ): Promise<RunAppRouteHandlerResult> {
   options.consumeDynamicUsage();
+  configureAppRouteStaticGenerationContext(options);
   const trackedRequest = createTrackedAppRouteRequest(options.request, {
     basePath: options.basePath,
     i18n: options.i18n,
     middlewareHeaders: options.middlewareRequestHeaders,
     onDynamicAccess() {
       options.markDynamicUsage();
+    },
+    requestMode:
+      options.dynamicConfig === "force-static" || options.dynamicConfig === "error"
+        ? options.dynamicConfig
+        : "auto",
+    staticGenerationErrorMessage(expression) {
+      return getAppRouteStaticGenerationErrorMessage(options.routePattern, expression);
     },
   });
   const response = await options.handlerFn(trackedRequest.request, {
@@ -109,7 +138,10 @@ export async function executeAppRouteHandler(
   const previousHeadersPhase = options.setHeadersAccessPhase("route-handler");
 
   try {
-    const { dynamicUsedInHandler, response } = await runAppRouteHandler(options);
+    const { dynamicUsedInHandler, response } = await runAppRouteHandler({
+      ...options,
+      dynamicConfig: options.handler.dynamic,
+    });
     assertSupportedAppRouteHandlerResponse(response);
     const handlerSetCacheControl = response.headers.has("cache-control");
 

--- a/packages/vinext/src/server/app-route-handler-runtime.ts
+++ b/packages/vinext/src/server/app-route-handler-runtime.ts
@@ -1,5 +1,11 @@
 import type { NextI18nConfig } from "../config/next-config.js";
-import { NextRequest, type NextURL } from "../shims/server.js";
+import {
+  NextRequest,
+  RequestCookies,
+  sealRequestCookies,
+  sealRequestHeaders,
+  type NextURL,
+} from "../shims/server.js";
 import { buildRequestHeadersFromMiddlewareResponse } from "./middleware-request-headers.js";
 
 const ROUTE_HANDLER_HTTP_METHODS = [
@@ -57,6 +63,8 @@ export function markKnownDynamicAppRoute(pattern: string): void {
 type RequestDynamicAccess =
   | "request.headers"
   | "request.cookies"
+  | "request.ip"
+  | "request.geo"
   | "request.url"
   | "request.body"
   | "request.blob"
@@ -75,12 +83,15 @@ type NextUrlDynamicAccess =
   | "nextUrl.origin";
 
 type AppRouteDynamicRequestAccess = RequestDynamicAccess | NextUrlDynamicAccess;
+type AppRouteRequestMode = "auto" | "force-static" | "error";
 
 type TrackedAppRouteRequestOptions = {
   basePath?: string;
   i18n?: NextI18nConfig | null;
   middlewareHeaders?: Headers | null;
   onDynamicAccess?: (access: AppRouteDynamicRequestAccess) => void;
+  requestMode?: AppRouteRequestMode;
+  staticGenerationErrorMessage?: (expression?: string) => string;
 };
 
 type TrackedAppRouteRequest = {
@@ -131,11 +142,45 @@ function rebuildRequestWithHeaders(input: Request, headers: Headers): Request {
   return new Request(input.url, init);
 }
 
+function cleanStaticUrl(url: string): string {
+  const cleanUrl = new URL(url);
+  cleanUrl.protocol = "http:";
+  cleanUrl.host = "localhost:3000";
+  cleanUrl.username = "";
+  cleanUrl.password = "";
+  cleanUrl.search = "";
+  cleanUrl.hash = "";
+  return cleanUrl.href;
+}
+
+function readEmptyBodyAsArrayBuffer(): Promise<ArrayBuffer> {
+  return new Response(null).arrayBuffer();
+}
+
+function readEmptyBodyAsBlob(): Promise<Blob> {
+  return new Response(null).blob();
+}
+
+// Empty JSON/form-data parses reject naturally; that keeps force-static body
+// stubs aligned with a bodyless request instead of inventing synthetic data.
+function readEmptyBodyAsFormData(): Promise<FormData> {
+  return new Response(null).formData();
+}
+
+function readEmptyBodyAsJson(): Promise<unknown> {
+  return new Response(null).json();
+}
+
+function readEmptyBodyAsText(): Promise<string> {
+  return new Response(null).text();
+}
+
 export function createTrackedAppRouteRequest(
   request: Request,
   options: TrackedAppRouteRequestOptions = {},
 ): TrackedAppRouteRequest {
   let didAccessDynamicRequest = false;
+  const requestMode = options.requestMode ?? "auto";
   const nextConfig = buildNextConfig(options);
 
   const markDynamicAccess = (access: AppRouteDynamicRequestAccess): void => {
@@ -170,6 +215,64 @@ export function createTrackedAppRouteRequest(
     return new Proxy(nextUrl, nextUrlHandler);
   };
 
+  const wrapForceStaticNextUrl = (nextUrl: NextURL): NextURL => {
+    const emptySearchParams = new URLSearchParams();
+    const staticHref = cleanStaticUrl(nextUrl.href);
+    const nextUrlHandler: ProxyHandler<NextURL> = {
+      get(target, prop): unknown {
+        switch (prop) {
+          case "search":
+            return "";
+          case "searchParams":
+            return emptySearchParams;
+          case "href":
+            return staticHref;
+          case "url":
+            return undefined;
+          case "toJSON":
+          case "toString":
+            return () => staticHref;
+          case "clone":
+            return () => wrapForceStaticNextUrl(target.clone());
+          default:
+            return bindMethodIfNeeded(Reflect.get(target, prop, target), target);
+        }
+      },
+    };
+
+    return new Proxy(nextUrl, nextUrlHandler);
+  };
+
+  const throwStaticGenerationError = (expression: string): never => {
+    throw new Error(
+      options.staticGenerationErrorMessage?.(expression) ??
+        `Route handler with \`dynamic = "error"\` used ${expression}.`,
+    );
+  };
+
+  const wrapRequireStaticNextUrl = (nextUrl: NextURL): NextURL => {
+    const nextUrlHandler: ProxyHandler<NextURL> = {
+      get(target, prop): unknown {
+        switch (prop) {
+          case "search":
+          case "searchParams":
+          case "url":
+          case "href":
+          case "toJSON":
+          case "toString":
+          case "origin":
+            return throwStaticGenerationError(`nextUrl.${String(prop)}`);
+          case "clone":
+            return () => wrapRequireStaticNextUrl(target.clone());
+          default:
+            return bindMethodIfNeeded(Reflect.get(target, prop, target), target);
+        }
+      },
+    };
+
+    return new Proxy(nextUrl, nextUrlHandler);
+  };
+
   const wrapRequest = (input: Request): NextRequest => {
     const requestHeaders = options.middlewareHeaders
       ? buildRequestHeadersFromMiddlewareResponse(input.headers, options.middlewareHeaders)
@@ -182,15 +285,83 @@ export function createTrackedAppRouteRequest(
         ? requestWithOverrides
         : new NextRequest(requestWithOverrides, { nextConfig: nextConfig ?? undefined });
     let proxiedNextUrl: NextURL | null = null;
+    let forceStaticNextUrl: NextURL | null = null;
+    let requireStaticNextUrl: NextURL | null = null;
+    let forceStaticHeaders: Headers | null = null;
+    let forceStaticCookies: RequestCookies | null = null;
 
     const requestHandler: ProxyHandler<NextRequest> = {
       get(target, prop): unknown {
+        if (requestMode === "force-static") {
+          switch (prop) {
+            case "nextUrl":
+              forceStaticNextUrl ??= wrapForceStaticNextUrl(target.nextUrl);
+              return forceStaticNextUrl;
+            case "headers":
+              forceStaticHeaders ??= sealRequestHeaders(new Headers());
+              return forceStaticHeaders;
+            case "cookies":
+              forceStaticCookies ??= sealRequestCookies(new RequestCookies(new Headers()));
+              return forceStaticCookies;
+            case "url":
+              return cleanStaticUrl(target.nextUrl.href);
+            case "ip":
+            case "geo":
+              return undefined;
+            case "body":
+              return null;
+            case "arrayBuffer":
+              return readEmptyBodyAsArrayBuffer;
+            case "blob":
+              return readEmptyBodyAsBlob;
+            case "formData":
+              return readEmptyBodyAsFormData;
+            case "json":
+              return readEmptyBodyAsJson;
+            case "text":
+              return readEmptyBodyAsText;
+            case "clone":
+              return () => wrapRequest(target.clone());
+            default:
+              return bindMethodIfNeeded(Reflect.get(target, prop, target), target);
+          }
+        }
+
+        if (requestMode === "error") {
+          switch (prop) {
+            case "nextUrl":
+              requireStaticNextUrl ??= wrapRequireStaticNextUrl(target.nextUrl);
+              return requireStaticNextUrl;
+            case "headers":
+            case "cookies":
+            case "url":
+            // Deliberate vinext divergence from Next.js: ip/geo are exposed
+            // on NextRequest for Cloudflare compatibility, so require-static
+            // treats them as dynamic request APIs instead of falling through.
+            case "ip":
+            case "geo":
+            case "body":
+            case "blob":
+            case "json":
+            case "text":
+            case "arrayBuffer":
+            case "formData":
+              return throwStaticGenerationError(`request.${String(prop)}`);
+            case "clone":
+              return () => wrapRequest(target.clone());
+            default:
+              return bindMethodIfNeeded(Reflect.get(target, prop, target), target);
+          }
+        }
+
         switch (prop) {
           case "nextUrl":
             proxiedNextUrl ??= wrapNextUrl(target.nextUrl);
             return proxiedNextUrl;
           case "headers":
           case "cookies":
+          case "ip":
+          case "geo":
           case "url":
           case "body":
           case "blob":

--- a/packages/vinext/src/server/app-static-generation.ts
+++ b/packages/vinext/src/server/app-static-generation.ts
@@ -1,0 +1,54 @@
+import type { HeadersContext } from "../shims/headers.js";
+
+type AppStaticGenerationRouteKind = "page" | "route";
+
+type CreateStaticGenerationHeadersContextOptions = {
+  dynamicConfig?: string;
+  routeKind: AppStaticGenerationRouteKind;
+  routePattern?: string;
+};
+
+export function getAppPageStaticGenerationErrorMessage(): string {
+  return (
+    'Page with `dynamic = "error"` used a dynamic API. ' +
+    "This page was expected to be fully static, but headers(), cookies(), " +
+    "or searchParams was accessed. Remove the dynamic API usage or change " +
+    'the dynamic config to "auto" or "force-dynamic".'
+  );
+}
+
+export function getAppRouteStaticGenerationErrorMessage(
+  routePattern?: string,
+  expression?: string,
+): string {
+  const route = routePattern ?? "unknown route";
+  const dynamicExpression = expression ?? "a dynamic request API";
+  return (
+    `Route ${route} with \`dynamic = "error"\` couldn't be rendered statically ` +
+    `because it used ${dynamicExpression}. ` +
+    "See more info here: https://nextjs.org/docs/app/building-your-application/rendering/static-and-dynamic#dynamic-rendering"
+  );
+}
+
+export function createStaticGenerationHeadersContext(
+  options: CreateStaticGenerationHeadersContextOptions,
+): HeadersContext {
+  const context: HeadersContext = {
+    headers: new Headers(),
+    cookies: new Map(),
+  };
+
+  if (options.dynamicConfig === "force-static") {
+    context.forceStatic = true;
+  }
+
+  if (options.dynamicConfig === "error") {
+    context.accessError = new Error(
+      options.routeKind === "route"
+        ? getAppRouteStaticGenerationErrorMessage(options.routePattern)
+        : getAppPageStaticGenerationErrorMessage(),
+    );
+  }
+
+  return context;
+}

--- a/packages/vinext/src/shims/headers.ts
+++ b/packages/vinext/src/shims/headers.ts
@@ -25,6 +25,7 @@ export type HeadersContext = {
   headers: Headers;
   cookies: Map<string, string>;
   accessError?: Error;
+  forceStatic?: boolean;
   mutableCookies?: RequestCookies;
   readonlyCookies?: RequestCookies;
   readonlyHeaders?: Headers;
@@ -81,7 +82,11 @@ function _getState(): VinextHeadersShimState {
  * Called by connection(), cookies(), headers(), and noStore().
  */
 export function markDynamicUsage(): void {
-  _getState().dynamicUsageDetected = true;
+  const state = _getState();
+  if (state.headersContext?.forceStatic) {
+    return;
+  }
+  state.dynamicUsageDetected = true;
 }
 
 // ---------------------------------------------------------------------------
@@ -300,6 +305,9 @@ class ReadonlyHeadersError extends Error {
   }
 }
 
+// Keep this error message in sync with server.ts. The two RequestCookies
+// adapters are separate until the next/headers and NextRequest cookie paths
+// share one implementation.
 class ReadonlyRequestCookiesError extends Error {
   constructor() {
     super(

--- a/packages/vinext/src/shims/server.ts
+++ b/packages/vinext/src/shims/server.ts
@@ -568,6 +568,63 @@ export class RequestCookies {
   }
 }
 
+// Keep this error message in sync with headers.ts. This adapter backs
+// NextRequest cookies, while headers.ts owns the next/headers cookies object.
+class ReadonlyRequestCookiesError extends Error {
+  constructor() {
+    super(
+      "Cookies can only be modified in a Server Action or Route Handler. Read more: https://nextjs.org/docs/app/api-reference/functions/cookies#options",
+    );
+  }
+
+  static callable(this: void): never {
+    throw new ReadonlyRequestCookiesError();
+  }
+}
+
+const REQUEST_HEADERS_MUTATING_METHODS = new Set(["set", "delete", "append"]);
+
+// Keep this error message in sync with headers.ts. This adapter backs
+// NextRequest headers in force-static route handlers, while headers.ts owns the
+// next/headers object.
+class ReadonlyRequestHeadersError extends Error {
+  constructor() {
+    super(
+      "Headers cannot be modified. Read more: https://nextjs.org/docs/app/api-reference/functions/headers",
+    );
+  }
+
+  static callable(this: void): never {
+    throw new ReadonlyRequestHeadersError();
+  }
+}
+
+export function sealRequestHeaders(headers: Headers): Headers {
+  return new Proxy<Headers>(headers, {
+    get(target, prop) {
+      if (typeof prop === "string" && REQUEST_HEADERS_MUTATING_METHODS.has(prop)) {
+        return ReadonlyRequestHeadersError.callable;
+      }
+
+      const value = Reflect.get(target, prop, target);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  });
+}
+
+export function sealRequestCookies(cookies: RequestCookies): RequestCookies {
+  return new Proxy<RequestCookies>(cookies, {
+    get(target, prop) {
+      if (prop === "set" || prop === "delete" || prop === "clear") {
+        return ReadonlyRequestCookiesError.callable;
+      }
+
+      const value = Reflect.get(target, prop, target);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  });
+}
+
 /**
  * RFC 6265 §4.1.1: cookie-name is a token (RFC 2616 §2.2).
  * Allowed: any visible ASCII (0x21-0x7E) except separators: ()<>@,;:\"/[]?={}

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -108,6 +108,9 @@ import {
   resolveAppPageMethodResponse as __resolveAppPageMethodResponse,
 } from "<ROOT>/packages/vinext/src/server/app-page-method.js";
 import {
+  createStaticGenerationHeadersContext as __createStaticGenerationHeadersContext,
+} from "<ROOT>/packages/vinext/src/server/app-static-generation.js";
+import {
   applyRouteHandlerMiddlewareContext as __applyRouteHandlerMiddlewareContext,
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-response.js";
 import { _consumeRequestScopedCacheLife, getCacheHandler } from "next/cache";
@@ -1861,6 +1864,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           __clearRequestContext();
         },
         consumeDynamicUsage,
+        dynamicConfig: handler.dynamic,
         getCollectedFetchTags,
         handlerFn,
         i18n: __i18nConfig,
@@ -1877,7 +1881,11 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         revalidateSeconds,
         routePattern: route.pattern,
         runInRevalidationContext: async function(renderFn) {
-          const __revalHeadCtx = { headers: new Headers(), cookies: new Map() };
+          const __revalHeadCtx = __createStaticGenerationHeadersContext({
+            dynamicConfig: handler.dynamic,
+            routeKind: "route",
+            routePattern: route.pattern,
+          });
           const __revalUCtx = _createUnifiedCtx({
             headersContext: __revalHeadCtx,
             executionContext: _getRequestExecutionContext(),
@@ -1890,6 +1898,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           });
         },
         scheduleBackgroundRegeneration: __triggerBackgroundRegeneration,
+        setHeadersAccessPhase,
         setNavigationContext,
       });
       if (__cachedRouteResponse) {
@@ -1962,15 +1971,18 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     revalidateSeconds,
   });
   if (__methodResponse) {
-    setHeadersContext(null);
-    setNavigationContext(null);
+    __clearRequestContext();
     return __methodResponse;
   }
 
   // force-static: replace headers/cookies context with empty values and
   // clear searchParams so dynamic APIs return defaults instead of real data
   if (isForceStatic) {
-    setHeadersContext({ headers: new Headers(), cookies: new Map() });
+    setHeadersContext(__createStaticGenerationHeadersContext({
+      dynamicConfig,
+      routeKind: "page",
+      routePattern: route.pattern,
+    }));
     setNavigationContext({
       pathname: cleanPathname,
       searchParams: new URLSearchParams(),
@@ -1981,15 +1993,11 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // dynamic = 'error': install an access error so request APIs fail with the
   // static-generation message even for legacy sync property access.
   if (isDynamicError) {
-    const errorMsg = 'Page with \`dynamic = "error"\` used a dynamic API. ' +
-      'This page was expected to be fully static, but headers(), cookies(), ' +
-      'or searchParams was accessed. Remove the dynamic API usage or change ' +
-      'the dynamic config to "auto" or "force-dynamic".';
-    setHeadersContext({
-      headers: new Headers(),
-      cookies: new Map(),
-      accessError: new Error(errorMsg),
-    });
+    setHeadersContext(__createStaticGenerationHeadersContext({
+      dynamicConfig,
+      routeKind: "page",
+      routePattern: route.pattern,
+    }));
     setNavigationContext({
       pathname: cleanPathname,
       searchParams: new URLSearchParams(),
@@ -2038,7 +2046,11 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         // Use an empty headers context for background regeneration — not the original
         // user request — to prevent user-specific cookies/auth headers from leaking
         // into content that is cached and served to all subsequent users.
-        const __revalHeadCtx = { headers: new Headers(), cookies: new Map() };
+        const __revalHeadCtx = __createStaticGenerationHeadersContext({
+          dynamicConfig,
+          routeKind: "page",
+          routePattern: route.pattern,
+        });
         const __revalUCtx = _createUnifiedCtx({
           headersContext: __revalHeadCtx,
           executionContext: _getRequestExecutionContext(),
@@ -2503,6 +2515,9 @@ import {
 import {
   resolveAppPageMethodResponse as __resolveAppPageMethodResponse,
 } from "<ROOT>/packages/vinext/src/server/app-page-method.js";
+import {
+  createStaticGenerationHeadersContext as __createStaticGenerationHeadersContext,
+} from "<ROOT>/packages/vinext/src/server/app-static-generation.js";
 import {
   applyRouteHandlerMiddlewareContext as __applyRouteHandlerMiddlewareContext,
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-response.js";
@@ -4263,6 +4278,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           __clearRequestContext();
         },
         consumeDynamicUsage,
+        dynamicConfig: handler.dynamic,
         getCollectedFetchTags,
         handlerFn,
         i18n: __i18nConfig,
@@ -4279,7 +4295,11 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         revalidateSeconds,
         routePattern: route.pattern,
         runInRevalidationContext: async function(renderFn) {
-          const __revalHeadCtx = { headers: new Headers(), cookies: new Map() };
+          const __revalHeadCtx = __createStaticGenerationHeadersContext({
+            dynamicConfig: handler.dynamic,
+            routeKind: "route",
+            routePattern: route.pattern,
+          });
           const __revalUCtx = _createUnifiedCtx({
             headersContext: __revalHeadCtx,
             executionContext: _getRequestExecutionContext(),
@@ -4292,6 +4312,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           });
         },
         scheduleBackgroundRegeneration: __triggerBackgroundRegeneration,
+        setHeadersAccessPhase,
         setNavigationContext,
       });
       if (__cachedRouteResponse) {
@@ -4364,15 +4385,18 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     revalidateSeconds,
   });
   if (__methodResponse) {
-    setHeadersContext(null);
-    setNavigationContext(null);
+    __clearRequestContext();
     return __methodResponse;
   }
 
   // force-static: replace headers/cookies context with empty values and
   // clear searchParams so dynamic APIs return defaults instead of real data
   if (isForceStatic) {
-    setHeadersContext({ headers: new Headers(), cookies: new Map() });
+    setHeadersContext(__createStaticGenerationHeadersContext({
+      dynamicConfig,
+      routeKind: "page",
+      routePattern: route.pattern,
+    }));
     setNavigationContext({
       pathname: cleanPathname,
       searchParams: new URLSearchParams(),
@@ -4383,15 +4407,11 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // dynamic = 'error': install an access error so request APIs fail with the
   // static-generation message even for legacy sync property access.
   if (isDynamicError) {
-    const errorMsg = 'Page with \`dynamic = "error"\` used a dynamic API. ' +
-      'This page was expected to be fully static, but headers(), cookies(), ' +
-      'or searchParams was accessed. Remove the dynamic API usage or change ' +
-      'the dynamic config to "auto" or "force-dynamic".';
-    setHeadersContext({
-      headers: new Headers(),
-      cookies: new Map(),
-      accessError: new Error(errorMsg),
-    });
+    setHeadersContext(__createStaticGenerationHeadersContext({
+      dynamicConfig,
+      routeKind: "page",
+      routePattern: route.pattern,
+    }));
     setNavigationContext({
       pathname: cleanPathname,
       searchParams: new URLSearchParams(),
@@ -4440,7 +4460,11 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         // Use an empty headers context for background regeneration — not the original
         // user request — to prevent user-specific cookies/auth headers from leaking
         // into content that is cached and served to all subsequent users.
-        const __revalHeadCtx = { headers: new Headers(), cookies: new Map() };
+        const __revalHeadCtx = __createStaticGenerationHeadersContext({
+          dynamicConfig,
+          routeKind: "page",
+          routePattern: route.pattern,
+        });
         const __revalUCtx = _createUnifiedCtx({
           headersContext: __revalHeadCtx,
           executionContext: _getRequestExecutionContext(),
@@ -4905,6 +4929,9 @@ import {
 import {
   resolveAppPageMethodResponse as __resolveAppPageMethodResponse,
 } from "<ROOT>/packages/vinext/src/server/app-page-method.js";
+import {
+  createStaticGenerationHeadersContext as __createStaticGenerationHeadersContext,
+} from "<ROOT>/packages/vinext/src/server/app-static-generation.js";
 import {
   applyRouteHandlerMiddlewareContext as __applyRouteHandlerMiddlewareContext,
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-response.js";
@@ -6660,6 +6687,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           __clearRequestContext();
         },
         consumeDynamicUsage,
+        dynamicConfig: handler.dynamic,
         getCollectedFetchTags,
         handlerFn,
         i18n: __i18nConfig,
@@ -6676,7 +6704,11 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         revalidateSeconds,
         routePattern: route.pattern,
         runInRevalidationContext: async function(renderFn) {
-          const __revalHeadCtx = { headers: new Headers(), cookies: new Map() };
+          const __revalHeadCtx = __createStaticGenerationHeadersContext({
+            dynamicConfig: handler.dynamic,
+            routeKind: "route",
+            routePattern: route.pattern,
+          });
           const __revalUCtx = _createUnifiedCtx({
             headersContext: __revalHeadCtx,
             executionContext: _getRequestExecutionContext(),
@@ -6689,6 +6721,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           });
         },
         scheduleBackgroundRegeneration: __triggerBackgroundRegeneration,
+        setHeadersAccessPhase,
         setNavigationContext,
       });
       if (__cachedRouteResponse) {
@@ -6761,15 +6794,18 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     revalidateSeconds,
   });
   if (__methodResponse) {
-    setHeadersContext(null);
-    setNavigationContext(null);
+    __clearRequestContext();
     return __methodResponse;
   }
 
   // force-static: replace headers/cookies context with empty values and
   // clear searchParams so dynamic APIs return defaults instead of real data
   if (isForceStatic) {
-    setHeadersContext({ headers: new Headers(), cookies: new Map() });
+    setHeadersContext(__createStaticGenerationHeadersContext({
+      dynamicConfig,
+      routeKind: "page",
+      routePattern: route.pattern,
+    }));
     setNavigationContext({
       pathname: cleanPathname,
       searchParams: new URLSearchParams(),
@@ -6780,15 +6816,11 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // dynamic = 'error': install an access error so request APIs fail with the
   // static-generation message even for legacy sync property access.
   if (isDynamicError) {
-    const errorMsg = 'Page with \`dynamic = "error"\` used a dynamic API. ' +
-      'This page was expected to be fully static, but headers(), cookies(), ' +
-      'or searchParams was accessed. Remove the dynamic API usage or change ' +
-      'the dynamic config to "auto" or "force-dynamic".';
-    setHeadersContext({
-      headers: new Headers(),
-      cookies: new Map(),
-      accessError: new Error(errorMsg),
-    });
+    setHeadersContext(__createStaticGenerationHeadersContext({
+      dynamicConfig,
+      routeKind: "page",
+      routePattern: route.pattern,
+    }));
     setNavigationContext({
       pathname: cleanPathname,
       searchParams: new URLSearchParams(),
@@ -6837,7 +6869,11 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         // Use an empty headers context for background regeneration — not the original
         // user request — to prevent user-specific cookies/auth headers from leaking
         // into content that is cached and served to all subsequent users.
-        const __revalHeadCtx = { headers: new Headers(), cookies: new Map() };
+        const __revalHeadCtx = __createStaticGenerationHeadersContext({
+          dynamicConfig,
+          routeKind: "page",
+          routePattern: route.pattern,
+        });
         const __revalUCtx = _createUnifiedCtx({
           headersContext: __revalHeadCtx,
           executionContext: _getRequestExecutionContext(),
@@ -7302,6 +7338,9 @@ import {
 import {
   resolveAppPageMethodResponse as __resolveAppPageMethodResponse,
 } from "<ROOT>/packages/vinext/src/server/app-page-method.js";
+import {
+  createStaticGenerationHeadersContext as __createStaticGenerationHeadersContext,
+} from "<ROOT>/packages/vinext/src/server/app-static-generation.js";
 import {
   applyRouteHandlerMiddlewareContext as __applyRouteHandlerMiddlewareContext,
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-response.js";
@@ -9089,6 +9128,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           __clearRequestContext();
         },
         consumeDynamicUsage,
+        dynamicConfig: handler.dynamic,
         getCollectedFetchTags,
         handlerFn,
         i18n: __i18nConfig,
@@ -9105,7 +9145,11 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         revalidateSeconds,
         routePattern: route.pattern,
         runInRevalidationContext: async function(renderFn) {
-          const __revalHeadCtx = { headers: new Headers(), cookies: new Map() };
+          const __revalHeadCtx = __createStaticGenerationHeadersContext({
+            dynamicConfig: handler.dynamic,
+            routeKind: "route",
+            routePattern: route.pattern,
+          });
           const __revalUCtx = _createUnifiedCtx({
             headersContext: __revalHeadCtx,
             executionContext: _getRequestExecutionContext(),
@@ -9118,6 +9162,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           });
         },
         scheduleBackgroundRegeneration: __triggerBackgroundRegeneration,
+        setHeadersAccessPhase,
         setNavigationContext,
       });
       if (__cachedRouteResponse) {
@@ -9190,15 +9235,18 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     revalidateSeconds,
   });
   if (__methodResponse) {
-    setHeadersContext(null);
-    setNavigationContext(null);
+    __clearRequestContext();
     return __methodResponse;
   }
 
   // force-static: replace headers/cookies context with empty values and
   // clear searchParams so dynamic APIs return defaults instead of real data
   if (isForceStatic) {
-    setHeadersContext({ headers: new Headers(), cookies: new Map() });
+    setHeadersContext(__createStaticGenerationHeadersContext({
+      dynamicConfig,
+      routeKind: "page",
+      routePattern: route.pattern,
+    }));
     setNavigationContext({
       pathname: cleanPathname,
       searchParams: new URLSearchParams(),
@@ -9209,15 +9257,11 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // dynamic = 'error': install an access error so request APIs fail with the
   // static-generation message even for legacy sync property access.
   if (isDynamicError) {
-    const errorMsg = 'Page with \`dynamic = "error"\` used a dynamic API. ' +
-      'This page was expected to be fully static, but headers(), cookies(), ' +
-      'or searchParams was accessed. Remove the dynamic API usage or change ' +
-      'the dynamic config to "auto" or "force-dynamic".';
-    setHeadersContext({
-      headers: new Headers(),
-      cookies: new Map(),
-      accessError: new Error(errorMsg),
-    });
+    setHeadersContext(__createStaticGenerationHeadersContext({
+      dynamicConfig,
+      routeKind: "page",
+      routePattern: route.pattern,
+    }));
     setNavigationContext({
       pathname: cleanPathname,
       searchParams: new URLSearchParams(),
@@ -9266,7 +9310,11 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         // Use an empty headers context for background regeneration — not the original
         // user request — to prevent user-specific cookies/auth headers from leaking
         // into content that is cached and served to all subsequent users.
-        const __revalHeadCtx = { headers: new Headers(), cookies: new Map() };
+        const __revalHeadCtx = __createStaticGenerationHeadersContext({
+          dynamicConfig,
+          routeKind: "page",
+          routePattern: route.pattern,
+        });
         const __revalUCtx = _createUnifiedCtx({
           headersContext: __revalHeadCtx,
           executionContext: _getRequestExecutionContext(),
@@ -9731,6 +9779,9 @@ import {
 import {
   resolveAppPageMethodResponse as __resolveAppPageMethodResponse,
 } from "<ROOT>/packages/vinext/src/server/app-page-method.js";
+import {
+  createStaticGenerationHeadersContext as __createStaticGenerationHeadersContext,
+} from "<ROOT>/packages/vinext/src/server/app-static-generation.js";
 import {
   applyRouteHandlerMiddlewareContext as __applyRouteHandlerMiddlewareContext,
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-response.js";
@@ -11492,6 +11543,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           __clearRequestContext();
         },
         consumeDynamicUsage,
+        dynamicConfig: handler.dynamic,
         getCollectedFetchTags,
         handlerFn,
         i18n: __i18nConfig,
@@ -11508,7 +11560,11 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         revalidateSeconds,
         routePattern: route.pattern,
         runInRevalidationContext: async function(renderFn) {
-          const __revalHeadCtx = { headers: new Headers(), cookies: new Map() };
+          const __revalHeadCtx = __createStaticGenerationHeadersContext({
+            dynamicConfig: handler.dynamic,
+            routeKind: "route",
+            routePattern: route.pattern,
+          });
           const __revalUCtx = _createUnifiedCtx({
             headersContext: __revalHeadCtx,
             executionContext: _getRequestExecutionContext(),
@@ -11521,6 +11577,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           });
         },
         scheduleBackgroundRegeneration: __triggerBackgroundRegeneration,
+        setHeadersAccessPhase,
         setNavigationContext,
       });
       if (__cachedRouteResponse) {
@@ -11593,15 +11650,18 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     revalidateSeconds,
   });
   if (__methodResponse) {
-    setHeadersContext(null);
-    setNavigationContext(null);
+    __clearRequestContext();
     return __methodResponse;
   }
 
   // force-static: replace headers/cookies context with empty values and
   // clear searchParams so dynamic APIs return defaults instead of real data
   if (isForceStatic) {
-    setHeadersContext({ headers: new Headers(), cookies: new Map() });
+    setHeadersContext(__createStaticGenerationHeadersContext({
+      dynamicConfig,
+      routeKind: "page",
+      routePattern: route.pattern,
+    }));
     setNavigationContext({
       pathname: cleanPathname,
       searchParams: new URLSearchParams(),
@@ -11612,15 +11672,11 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // dynamic = 'error': install an access error so request APIs fail with the
   // static-generation message even for legacy sync property access.
   if (isDynamicError) {
-    const errorMsg = 'Page with \`dynamic = "error"\` used a dynamic API. ' +
-      'This page was expected to be fully static, but headers(), cookies(), ' +
-      'or searchParams was accessed. Remove the dynamic API usage or change ' +
-      'the dynamic config to "auto" or "force-dynamic".';
-    setHeadersContext({
-      headers: new Headers(),
-      cookies: new Map(),
-      accessError: new Error(errorMsg),
-    });
+    setHeadersContext(__createStaticGenerationHeadersContext({
+      dynamicConfig,
+      routeKind: "page",
+      routePattern: route.pattern,
+    }));
     setNavigationContext({
       pathname: cleanPathname,
       searchParams: new URLSearchParams(),
@@ -11669,7 +11725,11 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         // Use an empty headers context for background regeneration — not the original
         // user request — to prevent user-specific cookies/auth headers from leaking
         // into content that is cached and served to all subsequent users.
-        const __revalHeadCtx = { headers: new Headers(), cookies: new Map() };
+        const __revalHeadCtx = __createStaticGenerationHeadersContext({
+          dynamicConfig,
+          routeKind: "page",
+          routePattern: route.pattern,
+        });
         const __revalUCtx = _createUnifiedCtx({
           headersContext: __revalHeadCtx,
           executionContext: _getRequestExecutionContext(),
@@ -12134,6 +12194,9 @@ import {
 import {
   resolveAppPageMethodResponse as __resolveAppPageMethodResponse,
 } from "<ROOT>/packages/vinext/src/server/app-page-method.js";
+import {
+  createStaticGenerationHeadersContext as __createStaticGenerationHeadersContext,
+} from "<ROOT>/packages/vinext/src/server/app-static-generation.js";
 import {
   applyRouteHandlerMiddlewareContext as __applyRouteHandlerMiddlewareContext,
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-response.js";
@@ -14255,6 +14318,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           __clearRequestContext();
         },
         consumeDynamicUsage,
+        dynamicConfig: handler.dynamic,
         getCollectedFetchTags,
         handlerFn,
         i18n: __i18nConfig,
@@ -14271,7 +14335,11 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         revalidateSeconds,
         routePattern: route.pattern,
         runInRevalidationContext: async function(renderFn) {
-          const __revalHeadCtx = { headers: new Headers(), cookies: new Map() };
+          const __revalHeadCtx = __createStaticGenerationHeadersContext({
+            dynamicConfig: handler.dynamic,
+            routeKind: "route",
+            routePattern: route.pattern,
+          });
           const __revalUCtx = _createUnifiedCtx({
             headersContext: __revalHeadCtx,
             executionContext: _getRequestExecutionContext(),
@@ -14284,6 +14352,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           });
         },
         scheduleBackgroundRegeneration: __triggerBackgroundRegeneration,
+        setHeadersAccessPhase,
         setNavigationContext,
       });
       if (__cachedRouteResponse) {
@@ -14356,15 +14425,18 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     revalidateSeconds,
   });
   if (__methodResponse) {
-    setHeadersContext(null);
-    setNavigationContext(null);
+    __clearRequestContext();
     return __methodResponse;
   }
 
   // force-static: replace headers/cookies context with empty values and
   // clear searchParams so dynamic APIs return defaults instead of real data
   if (isForceStatic) {
-    setHeadersContext({ headers: new Headers(), cookies: new Map() });
+    setHeadersContext(__createStaticGenerationHeadersContext({
+      dynamicConfig,
+      routeKind: "page",
+      routePattern: route.pattern,
+    }));
     setNavigationContext({
       pathname: cleanPathname,
       searchParams: new URLSearchParams(),
@@ -14375,15 +14447,11 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // dynamic = 'error': install an access error so request APIs fail with the
   // static-generation message even for legacy sync property access.
   if (isDynamicError) {
-    const errorMsg = 'Page with \`dynamic = "error"\` used a dynamic API. ' +
-      'This page was expected to be fully static, but headers(), cookies(), ' +
-      'or searchParams was accessed. Remove the dynamic API usage or change ' +
-      'the dynamic config to "auto" or "force-dynamic".';
-    setHeadersContext({
-      headers: new Headers(),
-      cookies: new Map(),
-      accessError: new Error(errorMsg),
-    });
+    setHeadersContext(__createStaticGenerationHeadersContext({
+      dynamicConfig,
+      routeKind: "page",
+      routePattern: route.pattern,
+    }));
     setNavigationContext({
       pathname: cleanPathname,
       searchParams: new URLSearchParams(),
@@ -14432,7 +14500,11 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         // Use an empty headers context for background regeneration — not the original
         // user request — to prevent user-specific cookies/auth headers from leaking
         // into content that is cached and served to all subsequent users.
-        const __revalHeadCtx = { headers: new Headers(), cookies: new Map() };
+        const __revalHeadCtx = __createStaticGenerationHeadersContext({
+          dynamicConfig,
+          routeKind: "page",
+          routePattern: route.pattern,
+        });
         const __revalUCtx = _createUnifiedCtx({
           headersContext: __revalHeadCtx,
           executionContext: _getRequestExecutionContext(),

--- a/tests/app-page-cache.test.ts
+++ b/tests/app-page-cache.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vite-plus/test";
 import {
   buildAppPageCachedResponse,
   finalizeAppPageHtmlCacheResponse,
+  finalizeAppPageRscCacheResponse,
   readAppPageCacheResponse,
   scheduleAppPageRscCacheWrite,
 } from "../packages/vinext/src/server/app-page-cache.js";
@@ -349,6 +350,7 @@ describe("app page cache helpers", () => {
         status: 201,
         headers: {
           "Content-Type": "text/html; charset=utf-8",
+          "Cache-Control": "s-maxage=60, stale-while-revalidate",
           Vary: "RSC, Accept",
           "X-Vinext-Cache": "MISS",
         },
@@ -356,6 +358,9 @@ describe("app page cache helpers", () => {
       {
         capturedRscDataPromise: Promise.resolve(rscData),
         cleanPathname: "/fresh",
+        consumeDynamicUsage() {
+          return false;
+        },
         getPageTags() {
           return ["/fresh", "_N_T_/fresh"];
         },
@@ -385,6 +390,8 @@ describe("app page cache helpers", () => {
     );
 
     expect(response.status).toBe(201);
+    expect(response.headers.get("Cache-Control")).toBe("no-store, must-revalidate");
+    expect(response.headers.get("X-Vinext-Cache")).toBe("MISS");
     await expect(response.text()).resolves.toBe("<h1>fresh</h1>");
     expect(pendingCacheWrites).toHaveLength(1);
 
@@ -407,6 +414,60 @@ describe("app page cache helpers", () => {
       },
     ]);
     expect(debugCalls).toEqual([["HTML cache written", "html:/fresh"]]);
+  });
+
+  it("skips HTML and RSC cache writes when dynamic usage appears during stream rendering", async () => {
+    const pendingCacheWrites: Promise<void>[] = [];
+    const debugCalls: Array<[string, string]> = [];
+    const isrSet = vi.fn();
+    const options = {
+      capturedRscDataPromise: Promise.resolve(new TextEncoder().encode("flight").buffer),
+      cleanPathname: "/dynamic-html",
+      consumeDynamicUsage() {
+        return true;
+      },
+      getPageTags() {
+        return ["/dynamic-html", "_N_T_/dynamic-html"];
+      },
+      isrDebug(event: string, detail: string) {
+        debugCalls.push([event, detail]);
+      },
+      isrHtmlKey(pathname: string) {
+        return "html:" + pathname;
+      },
+      isrRscKey(pathname: string) {
+        return "rsc:" + pathname;
+      },
+      isrSet,
+      revalidateSeconds: 60,
+      waitUntil(promise: Promise<void>) {
+        pendingCacheWrites.push(promise);
+      },
+    };
+
+    const response = finalizeAppPageHtmlCacheResponse(
+      new Response("<h1>personalized</h1>", {
+        headers: {
+          "Content-Type": "text/html; charset=utf-8",
+          "Cache-Control": "s-maxage=60, stale-while-revalidate",
+          Vary: "RSC, Accept",
+          "X-Vinext-Cache": "MISS",
+        },
+      }),
+      options,
+    );
+
+    expect(response.headers.get("Cache-Control")).toBe("no-store, must-revalidate");
+    expect(response.headers.get("X-Vinext-Cache")).toBe("MISS");
+    await expect(response.text()).resolves.toBe("<h1>personalized</h1>");
+    expect(pendingCacheWrites).toHaveLength(1);
+
+    await pendingCacheWrites[0];
+
+    expect(isrSet).not.toHaveBeenCalled();
+    expect(debugCalls).toEqual([
+      ["HTML cache write skipped (dynamic usage during render)", "html:/dynamic-html"],
+    ]);
   });
 
   it("schedules RSC cache writes when the page stayed static through stream consumption", async () => {
@@ -466,6 +527,51 @@ describe("app page cache helpers", () => {
       },
     ]);
     expect(debugCalls).toEqual([["RSC cache written", "rsc:/fresh-rsc"]]);
+  });
+
+  it("marks client-facing RSC cache MISS responses no-store until the stream dynamic check finishes", async () => {
+    const pendingCacheWrites: Promise<void>[] = [];
+    const isrSetCalls: string[] = [];
+
+    const response = finalizeAppPageRscCacheResponse(
+      new Response("flight", {
+        headers: {
+          "Content-Type": "text/x-component; charset=utf-8",
+          "Cache-Control": "s-maxage=60, stale-while-revalidate",
+          "X-Vinext-Cache": "MISS",
+        },
+      }),
+      {
+        capturedRscDataPromise: Promise.resolve(new TextEncoder().encode("flight").buffer),
+        cleanPathname: "/fresh-rsc",
+        consumeDynamicUsage() {
+          return false;
+        },
+        dynamicUsedDuringBuild: false,
+        getPageTags() {
+          return ["/fresh-rsc"];
+        },
+        isrRscKey(pathname) {
+          return "rsc:" + pathname;
+        },
+        async isrSet(key) {
+          isrSetCalls.push(key);
+        },
+        revalidateSeconds: 60,
+        waitUntil(promise) {
+          pendingCacheWrites.push(promise);
+        },
+      },
+    );
+
+    expect(response.headers.get("Cache-Control")).toBe("no-store, must-revalidate");
+    expect(response.headers.get("X-Vinext-Cache")).toBe("MISS");
+    await expect(response.text()).resolves.toBe("flight");
+    expect(pendingCacheWrites).toHaveLength(1);
+
+    await pendingCacheWrites[0];
+
+    expect(isrSetCalls).toEqual(["rsc:/fresh-rsc"]);
   });
 
   it("skips RSC cache writes when dynamic usage appears during stream rendering", async () => {

--- a/tests/app-page-render.test.ts
+++ b/tests/app-page-render.test.ts
@@ -245,7 +245,7 @@ describe("app page render lifecycle", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("content-type")).toBe("text/x-component; charset=utf-8");
-    expect(response.headers.get("cache-control")).toBe("s-maxage=60, stale-while-revalidate");
+    expect(response.headers.get("cache-control")).toBe("no-store, must-revalidate");
     expect(response.headers.get("x-vinext-cache")).toBe("MISS");
     await expect(response.text()).resolves.toBe("flight-data");
 
@@ -289,7 +289,7 @@ describe("app page render lifecycle", () => {
     });
 
     expect(response.status).toBe(200);
-    expect(response.headers.get("cache-control")).toBe("s-maxage=30, stale-while-revalidate");
+    expect(response.headers.get("cache-control")).toBe("no-store, must-revalidate");
     expect(response.headers.get("x-vinext-cache")).toBe("MISS");
     expect(response.headers.get("set-cookie")).toBe("draft=1; Path=/");
     await expect(response.text()).resolves.toBe("<html>page</html>");

--- a/tests/app-route-handler-cache.test.ts
+++ b/tests/app-route-handler-cache.test.ts
@@ -3,6 +3,7 @@ import { readAppRouteHandlerCacheResponse } from "../packages/vinext/src/server/
 import { isKnownDynamicAppRoute } from "../packages/vinext/src/server/app-route-handler-runtime.js";
 import type { ISRCacheEntry } from "../packages/vinext/src/server/isr-cache.js";
 import type { CachedRouteValue } from "../packages/vinext/src/shims/cache.js";
+import type { HeadersAccessPhase } from "../packages/vinext/src/shims/headers.js";
 
 function createDynamicUsageState(): {
   consumeDynamicUsage: () => boolean;
@@ -91,6 +92,9 @@ describe("app route handler cache helpers", () => {
       scheduleBackgroundRegeneration() {
         throw new Error("should not schedule regeneration");
       },
+      setHeadersAccessPhase() {
+        return "render";
+      },
       setNavigationContext() {},
     });
 
@@ -152,6 +156,9 @@ describe("app route handler cache helpers", () => {
       scheduleBackgroundRegeneration(_key, renderFn) {
         scheduledRegenerations.push(renderFn);
       },
+      setHeadersAccessPhase() {
+        return "render";
+      },
       setNavigationContext(context) {
         navigationCalls.push(context?.pathname ?? null);
       },
@@ -171,6 +178,64 @@ describe("app route handler cache helpers", () => {
       },
     ]);
     expect(navigationCalls).toEqual(["/api/stale", null]);
+  });
+
+  it("sets the route-handler header access phase while stale route handlers regenerate", async () => {
+    const dynamicUsage = createDynamicUsageState();
+    const scheduledRegens: Array<() => Promise<void>> = [];
+    const phases: string[] = [];
+    const options = {
+      buildPageCacheTags(pathname: string, extraTags: string[]) {
+        return [pathname, ...extraTags];
+      },
+      cleanPathname: "/api/stale-force-static",
+      clearRequestContext() {},
+      consumeDynamicUsage: dynamicUsage.consumeDynamicUsage,
+      dynamicConfig: "force-static",
+      getCollectedFetchTags() {
+        return [];
+      },
+      handlerFn() {
+        return new Response("regenerated");
+      },
+      isAutoHead: false,
+      async isrGet() {
+        return buildISRCacheEntry(buildCachedRouteValue("from-stale"), true);
+      },
+      isrRouteKey(pathname: string) {
+        return "route:" + pathname;
+      },
+      async isrSet() {},
+      markDynamicUsage: dynamicUsage.markDynamicUsage,
+      middlewareContext: { headers: null, status: null },
+      params: {},
+      requestUrl: "https://example.com/api/stale-force-static",
+      revalidateSearchParams: new URLSearchParams(),
+      revalidateSeconds: 60,
+      routePattern: "/api/stale-force-static",
+      async runInRevalidationContext(renderFn: () => Promise<void>) {
+        await renderFn();
+      },
+      scheduleBackgroundRegeneration(_key: string, renderFn: () => Promise<void>) {
+        scheduledRegens.push(renderFn);
+      },
+      setHeadersAccessPhase(phase: HeadersAccessPhase): HeadersAccessPhase {
+        phases.push(phase);
+        return "render";
+      },
+      setNavigationContext() {},
+    };
+
+    await readAppRouteHandlerCacheResponse(options);
+
+    const scheduledRegenRun = scheduledRegens[0];
+    expect(scheduledRegens).toHaveLength(1);
+    if (!scheduledRegenRun) {
+      throw new Error("Expected scheduled route regeneration");
+    }
+    await scheduledRegenRun();
+
+    expect(phases).toEqual(["route-handler"]);
   });
 
   it("skips regeneration writes when the stale handler reads dynamic request data", async () => {
@@ -216,6 +281,9 @@ describe("app route handler cache helpers", () => {
       },
       scheduleBackgroundRegeneration(_key, renderFn) {
         scheduledRegens.push(renderFn);
+      },
+      setHeadersAccessPhase() {
+        return "render";
       },
       setNavigationContext() {},
     });
@@ -274,6 +342,9 @@ describe("app route handler cache helpers", () => {
       scheduleBackgroundRegeneration(_key, renderFn) {
         scheduledRegens.push(renderFn);
       },
+      setHeadersAccessPhase() {
+        return "render";
+      },
       setNavigationContext() {},
     });
 
@@ -329,6 +400,9 @@ describe("app route handler cache helpers", () => {
         await renderFn();
       },
       scheduleBackgroundRegeneration() {},
+      setHeadersAccessPhase() {
+        return "render";
+      },
       setNavigationContext() {},
     });
 

--- a/tests/app-route-handler-execution.test.ts
+++ b/tests/app-route-handler-execution.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vite-plus/test";
+import { cookies, headers, setHeadersContext } from "../packages/vinext/src/shims/headers.js";
 import { isKnownDynamicAppRoute } from "../packages/vinext/src/server/app-route-handler-runtime.js";
 import {
   executeAppRouteHandler,
@@ -46,6 +47,61 @@ describe("app route handler execution helpers", () => {
     expect(receivedParams).toEqual({ slug: "demo" });
     expect(dynamicUsedInHandler).toBe(true);
     await expect(response.json()).resolves.toEqual({ header: "pong" });
+  });
+
+  it("runs force-static route handlers with empty request APIs without marking dynamic usage", async () => {
+    const dynamicUsage = createDynamicUsageState();
+
+    try {
+      const { dynamicUsedInHandler, response } = await runAppRouteHandler({
+        consumeDynamicUsage: dynamicUsage.consumeDynamicUsage,
+        dynamicConfig: "force-static",
+        async handlerFn(request) {
+          const headerStore = await headers();
+          const cookieStore = await cookies();
+          return Response.json({
+            cookie: cookieStore.get("session")?.value ?? null,
+            geo: request.geo ?? null,
+            header: headerStore.get("x-test"),
+            ip: request.ip ?? null,
+            requestCookie: request.cookies.get("session")?.value ?? null,
+            requestHeader: request.headers.get("x-test"),
+            requestUrl: request.url,
+            search: request.nextUrl.search,
+            searchParam: request.nextUrl.searchParams.get("token"),
+          });
+        },
+        markDynamicUsage: dynamicUsage.markDynamicUsage,
+        params: {},
+        request: new Request("https://tenant.example.com/api/static?token=secret", {
+          headers: {
+            "cf-connecting-ip": "203.0.113.10",
+            "cf-ipcountry": "AU",
+            cookie: "session=abc",
+            "x-test": "pong",
+          },
+        }),
+        routePattern: "/api/static",
+        setHeadersAccessPhase() {
+          return "render";
+        },
+      });
+
+      expect(dynamicUsedInHandler).toBe(false);
+      await expect(response.json()).resolves.toEqual({
+        cookie: null,
+        geo: null,
+        header: null,
+        ip: null,
+        requestCookie: null,
+        requestHeader: null,
+        requestUrl: "http://localhost:3000/api/static",
+        search: "",
+        searchParam: null,
+      });
+    } finally {
+      setHeadersContext(null);
+    }
   });
 
   it("finalizes static route handler responses and schedules cache writes", async () => {

--- a/tests/app-route-handler-runtime.test.ts
+++ b/tests/app-route-handler-runtime.test.ts
@@ -6,6 +6,7 @@ import {
   isKnownDynamicAppRoute,
   markKnownDynamicAppRoute,
 } from "../packages/vinext/src/server/app-route-handler-runtime.js";
+import { NextRequest, NextURL } from "../packages/vinext/src/shims/server.js";
 
 describe("app route handler runtime helpers", () => {
   it("collects exported route handler methods and auto-adds HEAD for GET", () => {
@@ -37,6 +38,149 @@ describe("app route handler runtime helpers", () => {
     expect(accesses).toEqual(["request.headers"]);
   });
 
+  it("stubs request-specific fields for force-static route handlers", () => {
+    const accesses: string[] = [];
+    const options = {
+      basePath: "",
+      requestMode: "force-static" as const,
+      onDynamicAccess(access: string) {
+        accesses.push(access);
+      },
+    };
+    const tracked = createTrackedAppRouteRequest(
+      new Request("https://tenant.example.com/demo?secret=from-user", {
+        headers: {
+          "cf-connecting-ip": "203.0.113.10",
+          "cf-ipcountry": "AU",
+          cookie: "session=abc",
+          "x-test-ping": "pong",
+        },
+      }),
+      options,
+    );
+
+    expect(tracked.request.headers.get("x-test-ping")).toBeNull();
+    expect(typeof tracked.request.headers.set).toBe("function");
+    expect(() => tracked.request.headers.set("x-test-ping", "mutated")).toThrow(
+      "Headers cannot be modified",
+    );
+    expect(tracked.request.headers.get("x-test-ping")).toBeNull();
+    expect(tracked.request.cookies.get("session")).toBeUndefined();
+    expect(tracked.request.ip).toBeUndefined();
+    expect(tracked.request.geo).toBeUndefined();
+    expect(tracked.request.url).toBe("http://localhost:3000/demo");
+    expect(tracked.request.nextUrl.href).toBe("http://localhost:3000/demo");
+    expect(tracked.request.nextUrl.search).toBe("");
+    expect(tracked.request.nextUrl.searchParams.get("secret")).toBeNull();
+    expect(tracked.didAccessDynamicRequest()).toBe(false);
+    expect(accesses).toEqual([]);
+  });
+
+  it("removes credentials from force-static route handler URLs", () => {
+    const request = new NextRequest("https://tenant.example.com/demo");
+    Object.defineProperty(request, "nextUrl", {
+      configurable: true,
+      value: new NextURL("https://user:pass@tenant.example.com/demo?secret=from-user#fragment"),
+    });
+    const tracked = createTrackedAppRouteRequest(request, {
+      requestMode: "force-static",
+    });
+
+    expect(tracked.request.url).toBe("http://localhost:3000/demo");
+    expect(tracked.request.nextUrl.href).toBe("http://localhost:3000/demo");
+  });
+
+  it("stubs body-reading APIs for force-static route handlers", async () => {
+    const accesses: string[] = [];
+    const createTrackedPost = () =>
+      createTrackedAppRouteRequest(
+        new Request("https://example.com/demo", {
+          method: "POST",
+          body: JSON.stringify({ secret: "from-user" }),
+          headers: { "content-type": "application/json" },
+        }),
+        {
+          requestMode: "force-static",
+          onDynamicAccess(access) {
+            accesses.push(access);
+          },
+        },
+      );
+
+    expect(createTrackedPost().request.body).toBeNull();
+    await expect(createTrackedPost().request.text()).resolves.toBe("");
+    await expect(createTrackedPost().request.arrayBuffer()).resolves.toHaveProperty(
+      "byteLength",
+      0,
+    );
+    await expect(createTrackedPost().request.blob()).resolves.toHaveProperty("size", 0);
+    await expect(createTrackedPost().request.json()).rejects.toThrow();
+    await expect(createTrackedPost().request.formData()).rejects.toThrow();
+    expect(accesses).toEqual([]);
+  });
+
+  it("seals force-static route handler request cookies", () => {
+    const tracked = createTrackedAppRouteRequest(new Request("https://example.com/demo"), {
+      requestMode: "force-static",
+    });
+
+    expect(typeof tracked.request.cookies.set).toBe("function");
+    expect(typeof tracked.request.cookies.delete).toBe("function");
+    expect(typeof tracked.request.cookies.clear).toBe("function");
+    expect(() => tracked.request.cookies.set("session", "abc")).toThrow(
+      "Cookies can only be modified",
+    );
+    expect(() => tracked.request.cookies.delete("session")).toThrow("Cookies can only be modified");
+    expect(() => tracked.request.cookies.clear()).toThrow("Cookies can only be modified");
+  });
+
+  it("throws on dynamic request access for dynamic error route handlers", () => {
+    const expectedMessage = (expression?: string): string =>
+      `Route /private with \`dynamic = "error"\` couldn't be rendered statically because it used ${expression ?? "a dynamic request API"}. See more info here: https://nextjs.org/docs/app/building-your-application/rendering/static-and-dynamic#dynamic-rendering`;
+    const tracked = createTrackedAppRouteRequest(
+      new Request("https://example.com/private?token=secret", {
+        method: "POST",
+        body: "payload",
+      }),
+      {
+        requestMode: "error",
+        staticGenerationErrorMessage: expectedMessage,
+      },
+    );
+
+    expect(() => tracked.request.headers).toThrow(expectedMessage("request.headers"));
+    expect(() => tracked.request.cookies).toThrow(expectedMessage("request.cookies"));
+    expect(() => tracked.request.url).toThrow(expectedMessage("request.url"));
+    expect(() => tracked.request.ip).toThrow(expectedMessage("request.ip"));
+    expect(() => tracked.request.geo).toThrow(expectedMessage("request.geo"));
+    expect(() => Reflect.get(tracked.request, "body")).toThrow(expectedMessage("request.body"));
+    expect(() => Reflect.get(tracked.request, "blob")).toThrow(expectedMessage("request.blob"));
+    expect(() => Reflect.get(tracked.request, "json")).toThrow(expectedMessage("request.json"));
+    expect(() => Reflect.get(tracked.request, "text")).toThrow(expectedMessage("request.text"));
+    expect(() => Reflect.get(tracked.request, "arrayBuffer")).toThrow(
+      expectedMessage("request.arrayBuffer"),
+    );
+    expect(() => Reflect.get(tracked.request, "formData")).toThrow(
+      expectedMessage("request.formData"),
+    );
+
+    expect(() => tracked.request.nextUrl.search).toThrow(expectedMessage("nextUrl.search"));
+    expect(() => tracked.request.nextUrl.searchParams).toThrow(
+      expectedMessage("nextUrl.searchParams"),
+    );
+    expect(() => tracked.request.nextUrl.href).toThrow(expectedMessage("nextUrl.href"));
+    expect(() => tracked.request.nextUrl.origin).toThrow(expectedMessage("nextUrl.origin"));
+    expect(() => Reflect.get(tracked.request.nextUrl, "toString")).toThrow(
+      expectedMessage("nextUrl.toString"),
+    );
+
+    const clonedRequest = tracked.request.clone();
+    expect(() => clonedRequest.headers).toThrow(expectedMessage("request.headers"));
+
+    const clonedNextUrl = tracked.request.nextUrl.clone();
+    expect(() => clonedNextUrl.search).toThrow(expectedMessage("nextUrl.search"));
+  });
+
   it("tracks request.url access for query parsing", () => {
     const accesses: string[] = [];
     const tracked = createTrackedAppRouteRequest(
@@ -66,6 +210,28 @@ describe("app route handler runtime helpers", () => {
 
     expect(tracked.request.nextUrl.href).toBe("https://example.com/base/fr/demo?ping=from-url");
     expect(tracked.request.url).toBe("https://example.com/base/fr/demo?ping=from-url");
+  });
+
+  it("tracks request.ip and request.geo access", () => {
+    const accesses: string[] = [];
+    const tracked = createTrackedAppRouteRequest(
+      new Request("https://example.com/demo", {
+        headers: {
+          "cf-connecting-ip": "203.0.113.10",
+          "cf-ipcountry": "AU",
+        },
+      }),
+      {
+        onDynamicAccess(access) {
+          accesses.push(access);
+        },
+      },
+    );
+
+    expect(tracked.request.ip).toBe("203.0.113.10");
+    expect(tracked.request.geo).toEqual({ country: "AU" });
+    expect(tracked.didAccessDynamicRequest()).toBe(true);
+    expect(accesses).toEqual(["request.ip", "request.geo"]);
   });
 
   it("tracks dynamic nextUrl fields but not pathname", () => {

--- a/tests/app-static-generation.test.ts
+++ b/tests/app-static-generation.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import {
+  createStaticGenerationHeadersContext,
+  getAppPageStaticGenerationErrorMessage,
+  getAppRouteStaticGenerationErrorMessage,
+} from "../packages/vinext/src/server/app-static-generation.js";
+
+describe("app static generation helpers", () => {
+  it("builds a force-static headers context without request data", () => {
+    const context = createStaticGenerationHeadersContext({
+      dynamicConfig: "force-static",
+      routeKind: "page",
+      routePattern: "/profile",
+    });
+
+    expect(Array.from(context.headers)).toEqual([]);
+    expect(Array.from(context.cookies)).toEqual([]);
+    expect(context.forceStatic).toBe(true);
+    expect(context.accessError).toBeUndefined();
+  });
+
+  it("builds a page dynamic-error context with the page message", () => {
+    const context = createStaticGenerationHeadersContext({
+      dynamicConfig: "error",
+      routeKind: "page",
+      routePattern: "/profile",
+    });
+
+    expect(context.forceStatic).toBeUndefined();
+    expect(context.accessError?.message).toBe(getAppPageStaticGenerationErrorMessage());
+  });
+
+  it("builds a route dynamic-error context with the route expression message", () => {
+    const message = getAppRouteStaticGenerationErrorMessage("/api/profile", "request.headers");
+    const context = createStaticGenerationHeadersContext({
+      dynamicConfig: "error",
+      routeKind: "route",
+      routePattern: "/api/profile",
+    });
+
+    expect(message).toContain("Route /api/profile");
+    expect(message).toContain("request.headers");
+    expect(context.accessError?.message).toBe(
+      getAppRouteStaticGenerationErrorMessage("/api/profile"),
+    );
+  });
+});

--- a/tests/e2e/app-router/rsc-fetch-errors.spec.ts
+++ b/tests/e2e/app-router/rsc-fetch-errors.spec.ts
@@ -80,13 +80,17 @@ test.describe("RSC fetch non-ok response handling", () => {
   test("client navigation to a 500-route hard-navs to the destination URL without looping", async ({
     page,
   }) => {
-    // Intercept the .rsc request for /about and return a 500 error. This
+    const targetPath = "/rsc-fetch-error-target";
+
+    // Intercept the .rsc request for a dedicated unlinked fixture page and
+    // return a 500 error. Using an unlinked target keeps the hit count tied to
+    // the explicit navigation below instead of racing home-page Link prefetch.
     // intercept persists across navigations and reloads on this page, so if
     // the fix is incomplete and a reload loop develops, the intercept hit
     // count will grow without bound.
-    let aboutRscHits = 0;
-    await page.route(/\/about\.rsc(\?|$)/, (route) => {
-      aboutRscHits += 1;
+    let targetRscHits = 0;
+    await page.route(/\/rsc-fetch-error-target\.rsc(\?|$)/, (route) => {
+      targetRscHits += 1;
       return route.fulfill({
         status: 500,
         // status 500 + text/html exercises both the !ok guard and the
@@ -107,41 +111,36 @@ test.describe("RSC fetch non-ok response handling", () => {
     await page.goto(`${BASE}/`);
     await waitForAppRouterHydration(page);
 
-    const navigationPromise = page.waitForURL(`${BASE}/about`, { timeout: 10_000 });
-    await Promise.all([navigationPromise, page.locator('a[href="/about"]').click()]);
+    const navigationPromise = page.waitForURL(`${BASE}${targetPath}`, { timeout: 10_000 });
+    await page.evaluate(() => {
+      void (window as any).__VINEXT_RSC_NAVIGATE__("/rsc-fetch-error-target");
+    });
+    await navigationPromise;
 
-    expect(page.url()).toBe(`${BASE}/about`);
+    expect(page.url()).toBe(`${BASE}${targetPath}`);
 
     // Stability check: the hard-nav must settle. Without the
     // readInitialRscStream reload-loop guard, the initial RSC fetch on the
-    // freshly-loaded /about page hits the intercepted 500 and reloads
+    // freshly-loaded target page hits the intercepted 500 and reloads
     // indefinitely — networkidle would never fire and the default timeout
     // catches that. Tracking actual request activity avoids flaky wall-clock
     // waits in CI.
-    const hitsBeforeNetworkIdle = aboutRscHits;
+    const hitsBeforeNetworkIdle = targetRscHits;
     await page.waitForLoadState("networkidle");
-    expect(page.url()).toBe(`${BASE}/about`);
-    // Pin the embedded-RSC assumption: after the hard-nav lands on /about,
+    expect(page.url()).toBe(`${BASE}${targetPath}`);
+    // Pin the embedded-RSC assumption: after the hard-nav lands on the target,
     // hydration must come from the HTML-embedded RSC branch and issue no
     // further .rsc fetches. If a future change makes the embed path
     // conditional and falls back to a fetch, this count would grow and the
     // test would flag it rather than silently relying on networkidle timing.
-    expect(aboutRscHits).toBe(hitsBeforeNetworkIdle);
+    expect(targetRscHits).toBe(hitsBeforeNetworkIdle);
 
-    // Expected trajectory: up to two hits — one from the home-page Link
-    // prefetch of /about.rsc (which the prefetch-cache discards because the
-    // response is !ok), and one from the client RSC nav fetch that triggers
-    // the hard-nav. Hydration timing can race the prefetch, in which case
-    // the count is 1. After the hard navigation to /about, the embedded-RSC
-    // branch in readInitialRscStream handles hydration without a fallback
-    // .rsc fetch, so no post-reload hits occur. A runaway reload loop would
-    // produce many more.
-    // Lower bound: at minimum, the client nav fetch that triggers the
-    // hard-nav must have fired. A value of 0 would mean the navigation
-    // skipped the RSC fetch entirely and the test is no longer exercising
-    // the !ok-guard path.
-    expect(aboutRscHits).toBeGreaterThanOrEqual(1);
-    expect(aboutRscHits).toBeLessThanOrEqual(2);
+    // Expected trajectory: exactly one hit from the client RSC nav fetch that
+    // triggers the hard-nav. The target route is intentionally absent from the
+    // home page's visible Links, so a count of 0 means the test skipped the
+    // !ok guard path, while a count above 1 means hydration fell back to a
+    // post-reload .rsc fetch or entered a reload loop.
+    expect(targetRscHits).toBe(1);
 
     const rscParseError = consoleErrors.find((msg) => isRscStreamParseError(msg));
     expect(rscParseError).toBeUndefined();
@@ -150,13 +149,16 @@ test.describe("RSC fetch non-ok response handling", () => {
   test("redirect chain to a non-ok endpoint hard-navs to the post-redirect URL", async ({
     page,
   }) => {
-    // Chain: client nav to /rsc-fetch-redirect-src →
-    // fetch /rsc-fetch-redirect-src.rsc → 307 Location
+    const sourcePath = "/rsc-fetch-redirect-src";
+    const targetPath = "/rsc-fetch-error-target";
+
+    // Chain: client nav to /rsc-fetch-redirect-src → fetch
+    // /rsc-fetch-redirect-src.rsc → real server redirect to
     // /rsc-fetch-error-target.rsc → 500. The hard-nav target must be
     // /rsc-fetch-error-target (the post-redirect URL), not
     // /rsc-fetch-redirect-src (the original request).
     // Without the navResponseUrl ?? navResponse.url branch in the nav-site
-    // guard, the browser would bounce off /rsc-fetch-redirect-src and the server
+    // guard, the browser would bounce off the source path and the server
     // would re-issue the 307, flashing the wrong URL in the address bar
     // and mis-keying analytics.
     const consoleErrors: string[] = [];
@@ -167,8 +169,9 @@ test.describe("RSC fetch non-ok response handling", () => {
     });
 
     // Capture the document URL at every main-frame navigation so we can
-    // assert the address bar never flashes the redirect source en route to
-    // the post-redirect target.
+    // assert the address bar never flashes the source URL en route to the target.
+    // Without this, a regression that dropped `navResponseUrl ?? navResponse.url`
+    // would still pass because the server's 307 converges to the target eventually.
     const frameUrls: string[] = [];
     page.on("framenavigated", (frame) => {
       if (frame === page.mainFrame()) frameUrls.push(frame.url());
@@ -179,19 +182,15 @@ test.describe("RSC fetch non-ok response handling", () => {
 
     const sourceRedirectPromise = page.waitForResponse(
       (response) =>
-        new URL(response.url()).pathname === "/rsc-fetch-redirect-src.rsc" &&
-        response.status() === 307,
+        new URL(response.url()).pathname === `${sourcePath}.rsc` && response.status() === 307,
       { timeout: 10_000 },
     );
     const targetErrorPromise = page.waitForResponse(
       (response) =>
-        new URL(response.url()).pathname === "/rsc-fetch-error-target.rsc" &&
-        response.status() === 500,
+        new URL(response.url()).pathname === `${targetPath}.rsc` && response.status() === 500,
       { timeout: 10_000 },
     );
-    const navigationPromise = page.waitForURL(`${BASE}/rsc-fetch-error-target`, {
-      timeout: 10_000,
-    });
+    const navigationPromise = page.waitForURL(`${BASE}${targetPath}`, { timeout: 10_000 });
     await Promise.all([
       sourceRedirectPromise,
       targetErrorPromise,
@@ -199,9 +198,9 @@ test.describe("RSC fetch non-ok response handling", () => {
       page.getByTestId("rsc-fetch-redirect-src-link").click(),
     ]);
 
-    expect(page.url()).toBe(`${BASE}/rsc-fetch-error-target`);
+    expect(page.url()).toBe(`${BASE}${targetPath}`);
     await expect(page.getByRole("heading", { name: "RSC fetch error target" })).toBeVisible();
-    expect(frameUrls.some((url) => url.includes("/rsc-fetch-redirect-src"))).toBe(false);
+    expect(frameUrls.some((url) => url.includes(sourcePath))).toBe(false);
 
     const rscParseError = consoleErrors.find((msg) => isRscStreamParseError(msg));
     expect(rscParseError).toBeUndefined();

--- a/tests/fixtures/app-basic/app/rsc-fetch-redirect-src/page.tsx
+++ b/tests/fixtures/app-basic/app/rsc-fetch-redirect-src/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function RscFetchRedirectSourcePage() {
+  redirect("/rsc-fetch-error-target");
+}


### PR DESCRIPTION
## What this changes

Fixes two App Router cache-safety issues around request-specific data:

- Enforces `dynamic = "force-static"` and `dynamic = "error"` for route-handler request APIs by stubbing or throwing for direct `NextRequest` fields and `next/headers`.
- Tracks direct `request.ip` and `request.geo` access as dynamic in auto mode.
- Re-checks dynamic usage after HTML stream consumption before writing ISR HTML/RSC cache entries.

## Why

Route handlers could previously expose request-specific IP/geo/header/cookie data through untracked request fields, and HTML ISR could cache page output before lazy streamed Server Components had finished touching `cookies()` or `headers()`. Both cases could put per-request output into shared cache.

## Approach

This mirrors Next.js' static-generation request policy instead of treating dynamic API access as observation-only state:

- `force-static` route handlers receive empty readonly stubs for request-specific APIs.
- `dynamic = "error"` throws when request-specific APIs are touched during static rendering.
- auto-mode direct request fields are tracked as dynamic instead of silently flowing into cached output.
- cache writes happen only after the relevant stream has been consumed and dynamic usage has been checked again.

## Next.js references

Checked against Next.js canary commit `ae61573e062e900050b8e6b24626e450accc4570`:

- App route modules set `workStore.forceStatic` for `dynamic = "force-static"` and proxy the request through `forceStaticRequestHandlers`: https://github.com/vercel/next.js/blob/ae61573e062e900050b8e6b24626e450accc4570/packages/next/src/server/route-modules/app-route/module.ts#L907-L913
- That proxy returns sealed empty headers and sealed empty cookies for `request.headers` and `request.cookies`: https://github.com/vercel/next.js/blob/ae61573e062e900050b8e6b24626e450accc4570/packages/next/src/server/route-modules/app-route/module.ts#L1038-L1056
- `headers()` under `forceStatic` returns `HeadersAdapter.seal(new Headers({}))` without tracking, while `dynamic = "error"` throws `StaticGenBailoutError`: https://github.com/vercel/next.js/blob/ae61573e062e900050b8e6b24626e450accc4570/packages/next/src/server/request/headers.ts#L58-L101
- `cookies()` under `forceStatic` returns sealed empty request cookies, while `dynamic = "error"` throws `StaticGenBailoutError`: https://github.com/vercel/next.js/blob/ae61573e062e900050b8e6b24626e450accc4570/packages/next/src/server/request/cookies.ts#L52-L62
- Next's readonly cookie adapter returns throwing callables for mutators, so method lookup is safe but invocation fails: https://github.com/vercel/next.js/blob/ae61573e062e900050b8e6b24626e450accc4570/packages/next/src/server/web/spec-extension/adapters/request-cookies.ts#L36-L49
- Next's readonly headers adapter uses the same throwing-callable shape for `append`, `delete`, and `set`: https://github.com/vercel/next.js/blob/ae61573e062e900050b8e6b24626e450accc4570/packages/next/src/server/web/spec-extension/adapters/headers.ts#L117-L132
- Next consumes dynamic access after prerender/static stream work before returning the result metadata: https://github.com/vercel/next.js/blob/ae61573e062e900050b8e6b24626e450accc4570/packages/next/src/server/app-render/app-render.tsx#L7967-L7974

## Validation

- `vp check`
- `vp test run tests/app-route-handler-runtime.test.ts tests/app-route-handler-execution.test.ts tests/app-route-handler-cache.test.ts tests/app-route-handler-policy.test.ts tests/app-page-cache.test.ts tests/app-page-render.test.ts tests/app-page-response.test.ts tests/app-page-probe.test.ts tests/shims.test.ts`
- `vp test run tests/app-router.test.ts`
- `vp run vinext#build`
- GitHub CI passed on the latest pushed branch

## Risks / follow-ups

The behavior is deliberately stricter around cacheable App Router work. The main compatibility risk is code that relied on reading real request fields under `dynamic = "force-static"`, which conflicts with Next.js' empty-stub behavior and can leak per-request data into shared cache.
