### PR TITLE
Return leaf selected layout segment for named parallel routes

### DIFF
--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -1327,7 +1327,11 @@ export function useRouter() {
  */
 export function useSelectedLayoutSegment(parallelRoutesKey?: string): string | null {
   const segments = useSelectedLayoutSegments(parallelRoutesKey);
-  return segments.length > 0 ? segments[0] : null;
+  if (segments.length === 0) return null;
+
+  return parallelRoutesKey === undefined || parallelRoutesKey === "children"
+    ? segments[0]
+    : segments[segments.length - 1];
 }
 
 /**

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -15,6 +15,33 @@ import {
   startFixtureServer,
 } from "./helpers.js";
 
+function decodeHtmlText(text: string): string {
+  return text
+    .replaceAll("&quot;", '"')
+    .replaceAll("&lt;", "<")
+    .replaceAll("&gt;", ">")
+    .replaceAll("&amp;", "&");
+}
+
+function textContentByTestId(html: string, testId: string): string {
+  const attrIndex = html.indexOf(`data-testid="${testId}"`);
+  if (attrIndex === -1) {
+    throw new Error(`Missing data-testid="${testId}"`);
+  }
+
+  const contentStart = html.indexOf(">", attrIndex);
+  if (contentStart === -1) {
+    throw new Error(`Missing opening tag end for data-testid="${testId}"`);
+  }
+
+  const contentEnd = html.indexOf("</", contentStart);
+  if (contentEnd === -1) {
+    throw new Error(`Missing closing tag for data-testid="${testId}"`);
+  }
+
+  return decodeHtmlText(html.slice(contentStart + 1, contentEnd));
+}
+
 describe("App Router integration", () => {
   let server: ViteDevServer;
   let baseUrl: string;
@@ -363,10 +390,8 @@ describe("App Router integration", () => {
     expect(res.status).toBe(200);
     const html = await res.text();
 
-    // The SegmentDisplay renders: <span data-testid="segments">["settings"]</span>
-    expect(html).toContain('data-testid="segments"');
     // Verify it returns ["settings"], not ["dashboard", "settings"]
-    expect(html).toMatch(/data-testid="segments"[^>]*>\[&quot;settings&quot;\]/);
+    expect(JSON.parse(textContentByTestId(html, "segments"))).toEqual(["settings"]);
   });
 
   it("useSelectedLayoutSegment returns first segment relative to dashboard layout", async () => {
@@ -374,9 +399,7 @@ describe("App Router integration", () => {
     expect(res.status).toBe(200);
     const html = await res.text();
 
-    // The SegmentDisplay renders: <span data-testid="segment">settings</span>
-    expect(html).toContain('data-testid="segment"');
-    expect(html).toMatch(/data-testid="segment"[^>]*>settings</);
+    expect(textContentByTestId(html, "segment")).toBe("settings");
   });
 
   it("useSelectedLayoutSegments returns empty array at leaf route", async () => {
@@ -385,8 +408,7 @@ describe("App Router integration", () => {
     expect(res.status).toBe(200);
     const html = await res.text();
 
-    // Should render: <span data-testid="segments">[]</span>
-    expect(html).toMatch(/data-testid="segments"[^>]*>\[\]/);
+    expect(JSON.parse(textContentByTestId(html, "segments"))).toEqual([]);
   });
 
   it("useSelectedLayoutSegment returns null at leaf route", async () => {
@@ -394,8 +416,7 @@ describe("App Router integration", () => {
     expect(res.status).toBe(200);
     const html = await res.text();
 
-    // Should render: <span data-testid="segment">null</span>
-    expect(html).toMatch(/data-testid="segment"[^>]*>null</);
+    expect(textContentByTestId(html, "segment")).toBe("null");
   });
 
   // --- parallelRoutesKey support ---
@@ -408,8 +429,8 @@ describe("App Router integration", () => {
     expect(res.status).toBe(200);
     const html = await res.text();
 
-    expect(html).toMatch(/data-testid="team-segments"[^>]*>\[\]/);
-    expect(html).toMatch(/data-testid="team-segment"[^>]*>null</);
+    expect(JSON.parse(textContentByTestId(html, "team-segments"))).toEqual([]);
+    expect(textContentByTestId(html, "team-segment")).toBe("null");
   });
 
   it("useSelectedLayoutSegments('analytics') returns [] when slot page is at root", async () => {
@@ -417,7 +438,7 @@ describe("App Router integration", () => {
     expect(res.status).toBe(200);
     const html = await res.text();
 
-    expect(html).toMatch(/data-testid="analytics-segments"[^>]*>\[\]/);
+    expect(JSON.parse(textContentByTestId(html, "analytics-segments"))).toEqual([]);
   });
 
   it("useSelectedLayoutSegments('team') returns slot sub-route segments", async () => {
@@ -427,8 +448,21 @@ describe("App Router integration", () => {
     expect(res.status).toBe(200);
     const html = await res.text();
 
-    expect(html).toMatch(/data-testid="team-segments"[^>]*>\[&quot;members&quot;\]/);
-    expect(html).toMatch(/data-testid="team-segment"[^>]*>members</);
+    expect(JSON.parse(textContentByTestId(html, "team-segments"))).toEqual(["members"]);
+    expect(textContentByTestId(html, "team-segment")).toBe("members");
+  });
+
+  it("useSelectedLayoutSegment('team') returns the leaf segment for nested slot routes", async () => {
+    // Mirrors Next.js @auth/reset/withEmail coverage:
+    // useSelectedLayoutSegments("team") should return ["members", "profile"],
+    // while useSelectedLayoutSegment("team") should return "profile".
+    const res = await fetch(`${baseUrl}/dashboard/members/profile`);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+
+    expect(html).toContain('data-testid="team-member-profile-page"');
+    expect(JSON.parse(textContentByTestId(html, "team-segments"))).toEqual(["members", "profile"]);
+    expect(textContentByTestId(html, "team-segment")).toBe("profile");
   });
 
   it("useSelectedLayoutSegments('analytics') returns [] when slot shows default on sub-route", async () => {
@@ -438,7 +472,7 @@ describe("App Router integration", () => {
     expect(res.status).toBe(200);
     const html = await res.text();
 
-    expect(html).toMatch(/data-testid="analytics-segments"[^>]*>\[\]/);
+    expect(JSON.parse(textContentByTestId(html, "analytics-segments"))).toEqual([]);
   });
 
   it("useSelectedLayoutSegments() (default children) still returns correct segments after migration", async () => {
@@ -447,7 +481,7 @@ describe("App Router integration", () => {
     const html = await res.text();
 
     // children segments below the dashboard layout should include "settings"
-    expect(html).toMatch(/data-testid="segments"[^>]*>\[&quot;settings&quot;\]/);
+    expect(JSON.parse(textContentByTestId(html, "segments"))).toEqual(["settings"]);
   });
 
   // --- Intercepting routes ---

--- a/tests/fixtures/app-basic/app/dashboard/@team/members/profile/page.tsx
+++ b/tests/fixtures/app-basic/app/dashboard/@team/members/profile/page.tsx
@@ -1,0 +1,7 @@
+export default function TeamMemberProfilePage() {
+  return (
+    <div data-testid="team-member-profile-page">
+      <h2>Team Member Profile</h2>
+    </div>
+  );
+}


### PR DESCRIPTION
## What this changes

`useSelectedLayoutSegment(parallelRoutesKey)` now matches Next.js for named parallel routes: the default `children` route still returns the first child segment, while named slots return the active leaf segment from that slot path.

This fixes nested parallel slot routes such as `@team/members/profile`, where `useSelectedLayoutSegments("team")` returns `["members", "profile"]` and `useSelectedLayoutSegment("team")` should return `"profile"`.

## Why

Vinext previously reduced every segment array with `segments[0]`. That is only correct for the default `children` route. Next.js intentionally treats named parallel route keys differently in `computeSelectedLayoutSegment()`:

- `children`: first segment
- non-`children` parallel route keys: last segment

Source references:

- Next.js implementation: https://github.com/vercel/next.js/blob/6d4a405f4ad9a4173f8b06e80e836b8a104f406c/packages/next/src/shared/lib/segment.ts#L32-L49
- Next.js hook delegation: https://github.com/vercel/next.js/blob/6d4a405f4ad9a4173f8b06e80e836b8a104f406c/packages/next/src/client/components/navigation.ts#L310-L338
- Next.js E2E coverage for nested named slots: https://github.com/vercel/next.js/blob/6d4a405f4ad9a4173f8b06e80e836b8a104f406c/test/e2e/app-dir/parallel-routes-use-selected-layout-segment/parallel-routes-use-selected-layout-segment.test.ts#L84-L93
- Hard navigation nested slot expectation: https://github.com/vercel/next.js/blob/6d4a405f4ad9a4173f8b06e80e836b8a104f406c/test/e2e/app-dir/parallel-routes-use-selected-layout-segment/parallel-routes-use-selected-layout-segment.test.ts#L146-L155

## Approach

The shim now returns `null` for an empty segment list, returns the first segment for `undefined` or `"children"`, and returns the final segment for named parallel route keys.

The regression test adds a nested `@team` slot fixture and asserts both behaviours together:

- `useSelectedLayoutSegments("team")` exposes the full slot path `["members", "profile"]`
- `useSelectedLayoutSegment("team")` returns the leaf segment `"profile"`

## Validation

- `vp test run tests/app-router.test.ts -t "useSelectedLayoutSegment"`
- `vp check tests/app-router.test.ts packages/vinext/src/shims/navigation.ts tests/fixtures/app-basic/app/dashboard/@team/members/profile/page.tsx`

## Risks / follow-ups

This is scoped to the client navigation shim reduction rule. It does not change route discovery or segment-map construction, which already preserves the full slot segment path needed for this behaviour.