### PR TITLE
fix(app-router): action redirects

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -325,6 +325,7 @@ ${slotEntries.join(",\n")}
   return `
 import {
   renderToReadableStream as _renderToReadableStream,
+  decodeAction,
   decodeReply,
   loadServerAction,
   createTemporaryReferenceSet,
@@ -1758,7 +1759,105 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   });
 
   // Handle server action POST requests
-  const actionId = request.headers.get("x-rsc-action");
+  const actionId = request.headers.get("x-rsc-action") ?? request.headers.get("next-action");
+  const actionContentType = request.headers.get("content-type") || "";
+  const isMultipartAction = request.method === "POST" && actionContentType.startsWith("multipart/form-data");
+
+  if (isMultipartAction && !actionId) {
+    // ── CSRF protection ─────────────────────────────────────────────────
+    // Multipart POSTs without the fetch-action header are progressive
+    // enhancement submissions from browser forms. Next.js still routes them
+    // through the server action decoder and lets decodeAction decide whether
+    // the form contains action metadata.
+    const csrfResponse = validateCsrfOrigin(request, __allowedOrigins);
+    if (csrfResponse) return csrfResponse;
+
+    const contentLength = parseInt(request.headers.get("content-length") || "0", 10);
+    if (contentLength > __MAX_ACTION_BODY_SIZE) {
+      setHeadersContext(null);
+      setNavigationContext(null);
+      return new Response("Payload Too Large", { status: 413 });
+    }
+
+    try {
+      let body;
+      try {
+        body = await __readFormDataWithLimit(request, __MAX_ACTION_BODY_SIZE);
+      } catch (sizeErr) {
+        if (sizeErr && sizeErr.message === "Request body too large") {
+          setHeadersContext(null);
+          setNavigationContext(null);
+          return new Response("Payload Too Large", { status: 413 });
+        }
+        throw sizeErr;
+      }
+
+      const payloadResponse = await validateServerActionPayload(body);
+      if (payloadResponse) {
+        setHeadersContext(null);
+        setNavigationContext(null);
+        return payloadResponse;
+      }
+
+      const action = await decodeAction(body);
+      if (typeof action === "function") {
+        let actionRedirect = null;
+        const previousHeadersPhase = setHeadersAccessPhase("action");
+        try {
+          await action();
+        } catch (e) {
+          if (e && typeof e === "object" && "digest" in e) {
+            const digest = String(e.digest);
+            if (digest.startsWith("NEXT_REDIRECT;")) {
+              const parts = digest.split(";");
+              actionRedirect = {
+                url: decodeURIComponent(parts[2]),
+              };
+            } else {
+              throw e;
+            }
+          } else {
+            throw e;
+          }
+        } finally {
+          setHeadersAccessPhase(previousHeadersPhase);
+        }
+
+        if (actionRedirect) {
+          const actionPendingCookies = getAndClearPendingCookies();
+          const actionDraftCookie = getDraftModeCookieHeader();
+          setHeadersContext(null);
+          setNavigationContext(null);
+          const redirectHeaders = new Headers({
+            Location: new URL(actionRedirect.url, request.url).toString(),
+          });
+          __mergeMiddlewareResponseHeaders(redirectHeaders, _mwCtx.headers);
+          for (const cookie of actionPendingCookies) {
+            redirectHeaders.append("Set-Cookie", cookie);
+          }
+          if (actionDraftCookie) redirectHeaders.append("Set-Cookie", actionDraftCookie);
+          return new Response(null, { status: 303, headers: redirectHeaders });
+        }
+      }
+    } catch (err) {
+      getAndClearPendingCookies();
+      console.error("[vinext] Server action error:", err);
+      _reportRequestError(
+        err instanceof Error ? err : new Error(String(err)),
+        { path: cleanPathname, method: request.method, headers: Object.fromEntries(request.headers.entries()) },
+        { routerKind: "App Router", routePath: cleanPathname, routeType: "action" },
+      );
+      setHeadersContext(null);
+      setNavigationContext(null);
+      return new Response(
+        process.env.NODE_ENV === "production"
+          ? "Internal Server Error"
+          : "Server action failed: " + (err && err.message ? err.message : String(err)),
+        { status: 500 },
+      );
+    }
+  }
+
   if (request.method === "POST" && actionId) {
     // ── CSRF protection ─────────────────────────────────────────────────
     // Verify that the Origin header matches the Host header to prevent
@@ -1778,10 +1877,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     }
 
     try {
-      const contentType = request.headers.get("content-type") || "";
       let body;
       try {
-        body = contentType.startsWith("multipart/form-data")
+        body = actionContentType.startsWith("multipart/form-data")
           ? await __readFormDataWithLimit(request, __MAX_ACTION_BODY_SIZE)
           : await __readBodyWithLimit(request, __MAX_ACTION_BODY_SIZE);
       } catch (sizeErr) {

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -49,6 +49,10 @@ const appRouteHandlerExecutionPath = resolveEntryPath(
   "../server/app-route-handler-execution.js",
   import.meta.url,
 );
+const appServerActionExecutionPath = resolveEntryPath(
+  "../server/app-server-action-execution.js",
+  import.meta.url,
+);
 const appRouteHandlerCachePath = resolveEntryPath(
   "../server/app-route-handler-cache.js",
   import.meta.url,
@@ -385,6 +389,9 @@ import {
 import {
   executeAppRouteHandler as __executeAppRouteHandler,
 } from ${JSON.stringify(appRouteHandlerExecutionPath)};
+import {
+  handleProgressiveServerActionRequest as __handleProgressiveServerActionRequest,
+} from ${JSON.stringify(appServerActionExecutionPath)};
 import { readAppRouteHandlerCacheResponse as __readAppRouteHandlerCacheResponse } from ${JSON.stringify(appRouteHandlerCachePath)};
 import { readAppPageCacheResponse as __readAppPageCacheResponse } from ${JSON.stringify(appPageCachePath)};
 import {
@@ -1761,102 +1768,26 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // Handle server action POST requests
   const actionId = request.headers.get("x-rsc-action") ?? request.headers.get("next-action");
   const actionContentType = request.headers.get("content-type") || "";
-  const isMultipartAction = request.method === "POST" && actionContentType.startsWith("multipart/form-data");
-
-  if (isMultipartAction && !actionId) {
-    // ── CSRF protection ─────────────────────────────────────────────────
-    // Multipart POSTs without the fetch-action header are progressive
-    // enhancement submissions from browser forms. Next.js still routes them
-    // through the server action decoder and lets decodeAction decide whether
-    // the form contains action metadata.
-    const csrfResponse = validateCsrfOrigin(request, __allowedOrigins);
-    if (csrfResponse) return csrfResponse;
-
-    const contentLength = parseInt(request.headers.get("content-length") || "0", 10);
-    if (contentLength > __MAX_ACTION_BODY_SIZE) {
+  const progressiveActionResponse = await __handleProgressiveServerActionRequest({
+    actionId,
+    allowedOrigins: __allowedOrigins,
+    cleanPathname,
+    clearRequestContext() {
       setHeadersContext(null);
       setNavigationContext(null);
-      return new Response("Payload Too Large", { status: 413 });
-    }
-
-    try {
-      let body;
-      try {
-        body = await __readFormDataWithLimit(request, __MAX_ACTION_BODY_SIZE);
-      } catch (sizeErr) {
-        if (sizeErr && sizeErr.message === "Request body too large") {
-          setHeadersContext(null);
-          setNavigationContext(null);
-          return new Response("Payload Too Large", { status: 413 });
-        }
-        throw sizeErr;
-      }
-
-      const payloadResponse = await validateServerActionPayload(body);
-      if (payloadResponse) {
-        setHeadersContext(null);
-        setNavigationContext(null);
-        return payloadResponse;
-      }
-
-      const action = await decodeAction(body);
-      if (typeof action === "function") {
-        let actionRedirect = null;
-        const previousHeadersPhase = setHeadersAccessPhase("action");
-        try {
-          await action();
-        } catch (e) {
-          if (e && typeof e === "object" && "digest" in e) {
-            const digest = String(e.digest);
-            if (digest.startsWith("NEXT_REDIRECT;")) {
-              const parts = digest.split(";");
-              actionRedirect = {
-                url: decodeURIComponent(parts[2]),
-              };
-            } else {
-              throw e;
-            }
-          } else {
-            throw e;
-          }
-        } finally {
-          setHeadersAccessPhase(previousHeadersPhase);
-        }
-
-        if (actionRedirect) {
-          const actionPendingCookies = getAndClearPendingCookies();
-          const actionDraftCookie = getDraftModeCookieHeader();
-          setHeadersContext(null);
-          setNavigationContext(null);
-          const redirectHeaders = new Headers({
-            Location: new URL(actionRedirect.url, request.url).toString(),
-          });
-          __mergeMiddlewareResponseHeaders(redirectHeaders, _mwCtx.headers);
-          for (const cookie of actionPendingCookies) {
-            redirectHeaders.append("Set-Cookie", cookie);
-          }
-          if (actionDraftCookie) redirectHeaders.append("Set-Cookie", actionDraftCookie);
-          return new Response(null, { status: 303, headers: redirectHeaders });
-        }
-      }
-    } catch (err) {
-      getAndClearPendingCookies();
-      console.error("[vinext] Server action error:", err);
-      _reportRequestError(
-        err instanceof Error ? err : new Error(String(err)),
-        { path: cleanPathname, method: request.method, headers: Object.fromEntries(request.headers.entries()) },
-        { routerKind: "App Router", routePath: cleanPathname, routeType: "action" },
-      );
-      setHeadersContext(null);
-      setNavigationContext(null);
-      return new Response(
-        process.env.NODE_ENV === "production"
-          ? "Internal Server Error"
-          : "Server action failed: " + (err && err.message ? err.message : String(err)),
-        { status: 500 },
-      );
-    }
-  }
+    },
+    contentType: actionContentType,
+    decodeAction,
+    getAndClearPendingCookies,
+    getDraftModeCookieHeader,
+    maxActionBodySize: __MAX_ACTION_BODY_SIZE,
+    middlewareHeaders: _mwCtx.headers,
+    readFormDataWithLimit: __readFormDataWithLimit,
+    reportRequestError: _reportRequestError,
+    request,
+    setHeadersAccessPhase,
+  });
+  if (progressiveActionResponse) return progressiveActionResponse;
 
   if (request.method === "POST" && actionId) {
     // ── CSRF protection ─────────────────────────────────────────────────

--- a/packages/vinext/src/server/app-route-handler-execution.ts
+++ b/packages/vinext/src/server/app-route-handler-execution.ts
@@ -3,6 +3,7 @@ import type { HeadersAccessPhase } from "../shims/headers.js";
 import type { ExecutionContextLike } from "../shims/request-context.js";
 import type { CachedRouteValue } from "../shims/cache.js";
 import {
+  isPossibleAppRouteActionRequest,
   resolveAppRouteHandlerSpecialError,
   shouldApplyAppRouteHandlerRevalidateHeader,
   shouldWriteAppRouteHandlerCache,
@@ -177,17 +178,27 @@ export async function executeAppRouteHandler(
       options.middlewareContext,
     );
   } catch (error) {
-    options.getAndClearPendingCookies();
-    const specialError = resolveAppRouteHandlerSpecialError(error, options.request.url);
+    const pendingCookies = options.getAndClearPendingCookies();
+    const draftCookie = options.getDraftModeCookieHeader();
+    const specialError = resolveAppRouteHandlerSpecialError(error, options.request.url, {
+      isAction: isPossibleAppRouteActionRequest(options.request),
+    });
     options.clearRequestContext();
 
     if (specialError) {
       if (specialError.kind === "redirect") {
         return applyRouteHandlerMiddlewareContext(
-          new Response(null, {
-            status: specialError.statusCode,
-            headers: { Location: specialError.location },
-          }),
+          finalizeRouteHandlerResponse(
+            new Response(null, {
+              status: specialError.statusCode,
+              headers: { Location: specialError.location },
+            }),
+            {
+              pendingCookies,
+              draftCookie,
+              isHead: options.isAutoHead,
+            },
+          ),
           options.middlewareContext,
         );
       }

--- a/packages/vinext/src/server/app-route-handler-policy.ts
+++ b/packages/vinext/src/server/app-route-handler-policy.ts
@@ -51,6 +51,24 @@ type AppRouteHandlerSpecialError =
       statusCode: number;
     };
 
+type AppRouteHandlerSpecialErrorOptions = {
+  isAction: boolean;
+};
+
+export function isPossibleAppRouteActionRequest(
+  request: Pick<Request, "headers" | "method">,
+): boolean {
+  if (request.method.toUpperCase() !== "POST") return false;
+
+  const contentType = request.headers.get("content-type");
+  return (
+    request.headers.has("x-rsc-action") ||
+    request.headers.has("next-action") ||
+    contentType === "application/x-www-form-urlencoded" ||
+    contentType?.startsWith("multipart/form-data") === true
+  );
+}
+
 export function getAppRouteHandlerRevalidateSeconds(
   handler: Pick<AppRouteHandlerModule, "revalidate">,
 ): number | null {
@@ -147,6 +165,7 @@ export function shouldWriteAppRouteHandlerCache(
 export function resolveAppRouteHandlerSpecialError(
   error: unknown,
   requestUrl: string,
+  options?: AppRouteHandlerSpecialErrorOptions,
 ): AppRouteHandlerSpecialError | null {
   if (!(error && typeof error === "object" && "digest" in error)) {
     return null;
@@ -159,7 +178,7 @@ export function resolveAppRouteHandlerSpecialError(
     return {
       kind: "redirect",
       location: new URL(redirectUrl, requestUrl).toString(),
-      statusCode: parts[3] ? parseInt(parts[3], 10) : 307,
+      statusCode: options?.isAction ? 303 : parts[3] ? parseInt(parts[3], 10) : 307,
     };
   }
 

--- a/packages/vinext/src/server/app-route-handler-policy.ts
+++ b/packages/vinext/src/server/app-route-handler-policy.ts
@@ -64,6 +64,8 @@ export function isPossibleAppRouteActionRequest(
   return (
     request.headers.has("x-rsc-action") ||
     request.headers.has("next-action") ||
+    // Next.js uses strict equality here, so charset variants intentionally do
+    // not classify as action requests even though they are valid form posts.
     contentType === "application/x-www-form-urlencoded" ||
     contentType?.startsWith("multipart/form-data") === true
   );

--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -29,9 +29,15 @@ export type HandleProgressiveServerActionRequestOptions = {
   setHeadersAccessPhase: (phase: HeadersAccessPhase) => HeadersAccessPhase;
 };
 
-type ActionRedirect = {
-  url: string;
-};
+type ActionControlResponse =
+  | {
+      kind: "redirect";
+      url: string;
+    }
+  | {
+      kind: "status";
+      statusCode: number;
+    };
 
 function isRequestBodyTooLarge(error: unknown): boolean {
   return error instanceof Error && error.message === "Request body too large";
@@ -45,25 +51,38 @@ function getErrorMessage(error: unknown): string {
   return error instanceof Error && error.message ? error.message : String(error);
 }
 
-function getActionRedirect(error: unknown): ActionRedirect | null {
+function getActionControlResponse(error: unknown): ActionControlResponse | null {
   if (!error || typeof error !== "object" || !("digest" in error)) {
     return null;
   }
 
   const digest = String(error.digest);
-  if (!digest.startsWith("NEXT_REDIRECT;")) {
-    return null;
+  if (digest.startsWith("NEXT_REDIRECT;")) {
+    const parts = digest.split(";");
+    const encodedUrl = parts[2];
+    if (!encodedUrl) {
+      return null;
+    }
+
+    return {
+      kind: "redirect",
+      url: decodeURIComponent(encodedUrl),
+    };
   }
 
-  const parts = digest.split(";");
-  const encodedUrl = parts[2];
-  if (!encodedUrl) {
-    return null;
+  if (digest === "NEXT_NOT_FOUND" || digest.startsWith("NEXT_HTTP_ERROR_FALLBACK;")) {
+    const statusCode = digest === "NEXT_NOT_FOUND" ? 404 : parseInt(digest.split(";")[1], 10);
+    if (!Number.isInteger(statusCode)) {
+      return null;
+    }
+
+    return {
+      kind: "status",
+      statusCode,
+    };
   }
 
-  return {
-    url: decodeURIComponent(encodedUrl),
-  };
+  return null;
 }
 
 export function isProgressiveServerActionRequest(
@@ -71,7 +90,11 @@ export function isProgressiveServerActionRequest(
   contentType: string,
   actionId: string | null,
 ): boolean {
-  return request.method === "POST" && contentType.startsWith("multipart/form-data") && !actionId;
+  return (
+    request.method.toUpperCase() === "POST" &&
+    contentType.startsWith("multipart/form-data") &&
+    !actionId
+  );
 }
 
 export async function handleProgressiveServerActionRequest(
@@ -95,7 +118,13 @@ export async function handleProgressiveServerActionRequest(
   try {
     let body: FormData;
     try {
-      body = await options.readFormDataWithLimit(options.request, options.maxActionBodySize);
+      // Progressive submissions can still fall through to a regular page render when
+      // the multipart body is not an action payload. Read a clone so that fallback
+      // code can still consume the original request body.
+      body = await options.readFormDataWithLimit(
+        options.request.clone(),
+        options.maxActionBodySize,
+      );
     } catch (error) {
       if (isRequestBodyTooLarge(error)) {
         options.clearRequestContext();
@@ -115,20 +144,23 @@ export async function handleProgressiveServerActionRequest(
       return null;
     }
 
-    let actionRedirect: ActionRedirect | null = null;
+    let actionControlResponse: ActionControlResponse | null = null;
     const previousHeadersPhase = options.setHeadersAccessPhase("action");
     try {
       await action();
     } catch (error) {
-      actionRedirect = getActionRedirect(error);
-      if (!actionRedirect) {
+      actionControlResponse = getActionControlResponse(error);
+      if (!actionControlResponse) {
         throw error;
       }
     } finally {
       options.setHeadersAccessPhase(previousHeadersPhase);
     }
 
-    if (!actionRedirect) {
+    if (!actionControlResponse) {
+      // Next.js decodes form state and re-renders after a successful MPA action.
+      // vinext currently supports the redirect/error status cases; successful
+      // non-redirect actions intentionally fall through to the page render.
       return null;
     }
 
@@ -136,20 +168,27 @@ export async function handleProgressiveServerActionRequest(
     const actionDraftCookie = options.getDraftModeCookieHeader();
     options.clearRequestContext();
 
-    const redirectHeaders = new Headers({
-      Location: new URL(actionRedirect.url, options.request.url).toString(),
-    });
-    mergeMiddlewareResponseHeaders(redirectHeaders, options.middlewareHeaders);
+    const headers = new Headers();
+    if (actionControlResponse.kind === "redirect") {
+      headers.set("Location", new URL(actionControlResponse.url, options.request.url).toString());
+    }
+    mergeMiddlewareResponseHeaders(headers, options.middlewareHeaders);
     for (const cookie of actionPendingCookies) {
-      redirectHeaders.append("Set-Cookie", cookie);
+      headers.append("Set-Cookie", cookie);
     }
     if (actionDraftCookie) {
-      redirectHeaders.append("Set-Cookie", actionDraftCookie);
+      headers.append("Set-Cookie", actionDraftCookie);
     }
 
-    return new Response(null, { status: 303, headers: redirectHeaders });
+    return new Response(null, {
+      status: actionControlResponse.kind === "redirect" ? 303 : actionControlResponse.statusCode,
+      headers,
+    });
   } catch (error) {
     options.getAndClearPendingCookies();
+    // Next.js rethrows generic MPA action errors into its page render path.
+    // vinext does not yet implement that form-state render path, so unexpected
+    // action failures remain request failures here.
     console.error("[vinext] Server action error:", error);
     options.reportRequestError(
       normalizeError(error),

--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -1,0 +1,171 @@
+import type { HeadersAccessPhase } from "../shims/headers.js";
+import { mergeMiddlewareResponseHeaders } from "./middleware-response-headers.js";
+import { validateCsrfOrigin, validateServerActionPayload } from "./request-pipeline.js";
+
+type AppServerActionErrorReporter = (
+  error: Error,
+  request: { path: string; method: string; headers: Record<string, string> },
+  route: { routerKind: "App Router"; routePath: string; routeType: "action" },
+) => void;
+
+type AppServerActionDecoder = (body: FormData) => Promise<unknown>;
+
+type ReadFormDataWithLimit = (request: Request, maxBytes: number) => Promise<FormData>;
+
+export type HandleProgressiveServerActionRequestOptions = {
+  actionId: string | null;
+  allowedOrigins: string[];
+  cleanPathname: string;
+  clearRequestContext: () => void;
+  contentType: string;
+  decodeAction: AppServerActionDecoder;
+  getAndClearPendingCookies: () => string[];
+  getDraftModeCookieHeader: () => string | null | undefined;
+  maxActionBodySize: number;
+  middlewareHeaders: Headers | null;
+  readFormDataWithLimit: ReadFormDataWithLimit;
+  reportRequestError: AppServerActionErrorReporter;
+  request: Request;
+  setHeadersAccessPhase: (phase: HeadersAccessPhase) => HeadersAccessPhase;
+};
+
+type ActionRedirect = {
+  url: string;
+};
+
+function isRequestBodyTooLarge(error: unknown): boolean {
+  return error instanceof Error && error.message === "Request body too large";
+}
+
+function normalizeError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error && error.message ? error.message : String(error);
+}
+
+function getActionRedirect(error: unknown): ActionRedirect | null {
+  if (!error || typeof error !== "object" || !("digest" in error)) {
+    return null;
+  }
+
+  const digest = String(error.digest);
+  if (!digest.startsWith("NEXT_REDIRECT;")) {
+    return null;
+  }
+
+  const parts = digest.split(";");
+  const encodedUrl = parts[2];
+  if (!encodedUrl) {
+    return null;
+  }
+
+  return {
+    url: decodeURIComponent(encodedUrl),
+  };
+}
+
+export function isProgressiveServerActionRequest(
+  request: Pick<Request, "method">,
+  contentType: string,
+  actionId: string | null,
+): boolean {
+  return request.method === "POST" && contentType.startsWith("multipart/form-data") && !actionId;
+}
+
+export async function handleProgressiveServerActionRequest(
+  options: HandleProgressiveServerActionRequestOptions,
+): Promise<Response | null> {
+  if (!isProgressiveServerActionRequest(options.request, options.contentType, options.actionId)) {
+    return null;
+  }
+
+  const csrfResponse = validateCsrfOrigin(options.request, options.allowedOrigins);
+  if (csrfResponse) {
+    return csrfResponse;
+  }
+
+  const contentLength = parseInt(options.request.headers.get("content-length") || "0", 10);
+  if (contentLength > options.maxActionBodySize) {
+    options.clearRequestContext();
+    return new Response("Payload Too Large", { status: 413 });
+  }
+
+  try {
+    let body: FormData;
+    try {
+      body = await options.readFormDataWithLimit(options.request, options.maxActionBodySize);
+    } catch (error) {
+      if (isRequestBodyTooLarge(error)) {
+        options.clearRequestContext();
+        return new Response("Payload Too Large", { status: 413 });
+      }
+      throw error;
+    }
+
+    const payloadResponse = await validateServerActionPayload(body);
+    if (payloadResponse) {
+      options.clearRequestContext();
+      return payloadResponse;
+    }
+
+    const action = await options.decodeAction(body);
+    if (typeof action !== "function") {
+      return null;
+    }
+
+    let actionRedirect: ActionRedirect | null = null;
+    const previousHeadersPhase = options.setHeadersAccessPhase("action");
+    try {
+      await action();
+    } catch (error) {
+      actionRedirect = getActionRedirect(error);
+      if (!actionRedirect) {
+        throw error;
+      }
+    } finally {
+      options.setHeadersAccessPhase(previousHeadersPhase);
+    }
+
+    if (!actionRedirect) {
+      return null;
+    }
+
+    const actionPendingCookies = options.getAndClearPendingCookies();
+    const actionDraftCookie = options.getDraftModeCookieHeader();
+    options.clearRequestContext();
+
+    const redirectHeaders = new Headers({
+      Location: new URL(actionRedirect.url, options.request.url).toString(),
+    });
+    mergeMiddlewareResponseHeaders(redirectHeaders, options.middlewareHeaders);
+    for (const cookie of actionPendingCookies) {
+      redirectHeaders.append("Set-Cookie", cookie);
+    }
+    if (actionDraftCookie) {
+      redirectHeaders.append("Set-Cookie", actionDraftCookie);
+    }
+
+    return new Response(null, { status: 303, headers: redirectHeaders });
+  } catch (error) {
+    options.getAndClearPendingCookies();
+    console.error("[vinext] Server action error:", error);
+    options.reportRequestError(
+      normalizeError(error),
+      {
+        path: options.cleanPathname,
+        method: options.request.method,
+        headers: Object.fromEntries(options.request.headers.entries()),
+      },
+      { routerKind: "App Router", routePath: options.cleanPathname, routeType: "action" },
+    );
+    options.clearRequestContext();
+    return new Response(
+      process.env.NODE_ENV === "production"
+        ? "Internal Server Error"
+        : "Server action failed: " + getErrorMessage(error),
+      { status: 500 },
+    );
+  }
+}

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -6,6 +6,7 @@ exports[`App Router entry templates > generateRscEntry snapshot (minimal routes)
 "
 import {
   renderToReadableStream as _renderToReadableStream,
+  decodeAction,
   decodeReply,
   loadServerAction,
   createTemporaryReferenceSet,
@@ -1479,7 +1480,105 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   });
 
   // Handle server action POST requests
-  const actionId = request.headers.get("x-rsc-action");
+  const actionId = request.headers.get("x-rsc-action") ?? request.headers.get("next-action");
+  const actionContentType = request.headers.get("content-type") || "";
+  const isMultipartAction = request.method === "POST" && actionContentType.startsWith("multipart/form-data");
+
+  if (isMultipartAction && !actionId) {
+    // ── CSRF protection ─────────────────────────────────────────────────
+    // Multipart POSTs without the fetch-action header are progressive
+    // enhancement submissions from browser forms. Next.js still routes them
+    // through the server action decoder and lets decodeAction decide whether
+    // the form contains action metadata.
+    const csrfResponse = validateCsrfOrigin(request, __allowedOrigins);
+    if (csrfResponse) return csrfResponse;
+
+    const contentLength = parseInt(request.headers.get("content-length") || "0", 10);
+    if (contentLength > __MAX_ACTION_BODY_SIZE) {
+      setHeadersContext(null);
+      setNavigationContext(null);
+      return new Response("Payload Too Large", { status: 413 });
+    }
+
+    try {
+      let body;
+      try {
+        body = await __readFormDataWithLimit(request, __MAX_ACTION_BODY_SIZE);
+      } catch (sizeErr) {
+        if (sizeErr && sizeErr.message === "Request body too large") {
+          setHeadersContext(null);
+          setNavigationContext(null);
+          return new Response("Payload Too Large", { status: 413 });
+        }
+        throw sizeErr;
+      }
+
+      const payloadResponse = await validateServerActionPayload(body);
+      if (payloadResponse) {
+        setHeadersContext(null);
+        setNavigationContext(null);
+        return payloadResponse;
+      }
+
+      const action = await decodeAction(body);
+      if (typeof action === "function") {
+        let actionRedirect = null;
+        const previousHeadersPhase = setHeadersAccessPhase("action");
+        try {
+          await action();
+        } catch (e) {
+          if (e && typeof e === "object" && "digest" in e) {
+            const digest = String(e.digest);
+            if (digest.startsWith("NEXT_REDIRECT;")) {
+              const parts = digest.split(";");
+              actionRedirect = {
+                url: decodeURIComponent(parts[2]),
+              };
+            } else {
+              throw e;
+            }
+          } else {
+            throw e;
+          }
+        } finally {
+          setHeadersAccessPhase(previousHeadersPhase);
+        }
+
+        if (actionRedirect) {
+          const actionPendingCookies = getAndClearPendingCookies();
+          const actionDraftCookie = getDraftModeCookieHeader();
+          setHeadersContext(null);
+          setNavigationContext(null);
+          const redirectHeaders = new Headers({
+            Location: new URL(actionRedirect.url, request.url).toString(),
+          });
+          __mergeMiddlewareResponseHeaders(redirectHeaders, _mwCtx.headers);
+          for (const cookie of actionPendingCookies) {
+            redirectHeaders.append("Set-Cookie", cookie);
+          }
+          if (actionDraftCookie) redirectHeaders.append("Set-Cookie", actionDraftCookie);
+          return new Response(null, { status: 303, headers: redirectHeaders });
+        }
+      }
+    } catch (err) {
+      getAndClearPendingCookies();
+      console.error("[vinext] Server action error:", err);
+      _reportRequestError(
+        err instanceof Error ? err : new Error(String(err)),
+        { path: cleanPathname, method: request.method, headers: Object.fromEntries(request.headers.entries()) },
+        { routerKind: "App Router", routePath: cleanPathname, routeType: "action" },
+      );
+      setHeadersContext(null);
+      setNavigationContext(null);
+      return new Response(
+        process.env.NODE_ENV === "production"
+          ? "Internal Server Error"
+          : "Server action failed: " + (err && err.message ? err.message : String(err)),
+        { status: 500 },
+      );
+    }
+  }
+
   if (request.method === "POST" && actionId) {
     // ── CSRF protection ─────────────────────────────────────────────────
     // Verify that the Origin header matches the Host header to prevent
@@ -1499,10 +1598,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     }
 
     try {
-      const contentType = request.headers.get("content-type") || "";
       let body;
       try {
-        body = contentType.startsWith("multipart/form-data")
+        body = actionContentType.startsWith("multipart/form-data")
           ? await __readFormDataWithLimit(request, __MAX_ACTION_BODY_SIZE)
           : await __readBodyWithLimit(request, __MAX_ACTION_BODY_SIZE);
       } catch (sizeErr) {
@@ -2330,6 +2428,7 @@ exports[`App Router entry templates > generateRscEntry snapshot (with config) 1`
 "
 import {
   renderToReadableStream as _renderToReadableStream,
+  decodeAction,
   decodeReply,
   loadServerAction,
   createTemporaryReferenceSet,
@@ -3809,7 +3908,105 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   });
 
   // Handle server action POST requests
-  const actionId = request.headers.get("x-rsc-action");
+  const actionId = request.headers.get("x-rsc-action") ?? request.headers.get("next-action");
+  const actionContentType = request.headers.get("content-type") || "";
+  const isMultipartAction = request.method === "POST" && actionContentType.startsWith("multipart/form-data");
+
+  if (isMultipartAction && !actionId) {
+    // ── CSRF protection ─────────────────────────────────────────────────
+    // Multipart POSTs without the fetch-action header are progressive
+    // enhancement submissions from browser forms. Next.js still routes them
+    // through the server action decoder and lets decodeAction decide whether
+    // the form contains action metadata.
+    const csrfResponse = validateCsrfOrigin(request, __allowedOrigins);
+    if (csrfResponse) return csrfResponse;
+
+    const contentLength = parseInt(request.headers.get("content-length") || "0", 10);
+    if (contentLength > __MAX_ACTION_BODY_SIZE) {
+      setHeadersContext(null);
+      setNavigationContext(null);
+      return new Response("Payload Too Large", { status: 413 });
+    }
+
+    try {
+      let body;
+      try {
+        body = await __readFormDataWithLimit(request, __MAX_ACTION_BODY_SIZE);
+      } catch (sizeErr) {
+        if (sizeErr && sizeErr.message === "Request body too large") {
+          setHeadersContext(null);
+          setNavigationContext(null);
+          return new Response("Payload Too Large", { status: 413 });
+        }
+        throw sizeErr;
+      }
+
+      const payloadResponse = await validateServerActionPayload(body);
+      if (payloadResponse) {
+        setHeadersContext(null);
+        setNavigationContext(null);
+        return payloadResponse;
+      }
+
+      const action = await decodeAction(body);
+      if (typeof action === "function") {
+        let actionRedirect = null;
+        const previousHeadersPhase = setHeadersAccessPhase("action");
+        try {
+          await action();
+        } catch (e) {
+          if (e && typeof e === "object" && "digest" in e) {
+            const digest = String(e.digest);
+            if (digest.startsWith("NEXT_REDIRECT;")) {
+              const parts = digest.split(";");
+              actionRedirect = {
+                url: decodeURIComponent(parts[2]),
+              };
+            } else {
+              throw e;
+            }
+          } else {
+            throw e;
+          }
+        } finally {
+          setHeadersAccessPhase(previousHeadersPhase);
+        }
+
+        if (actionRedirect) {
+          const actionPendingCookies = getAndClearPendingCookies();
+          const actionDraftCookie = getDraftModeCookieHeader();
+          setHeadersContext(null);
+          setNavigationContext(null);
+          const redirectHeaders = new Headers({
+            Location: new URL(actionRedirect.url, request.url).toString(),
+          });
+          __mergeMiddlewareResponseHeaders(redirectHeaders, _mwCtx.headers);
+          for (const cookie of actionPendingCookies) {
+            redirectHeaders.append("Set-Cookie", cookie);
+          }
+          if (actionDraftCookie) redirectHeaders.append("Set-Cookie", actionDraftCookie);
+          return new Response(null, { status: 303, headers: redirectHeaders });
+        }
+      }
+    } catch (err) {
+      getAndClearPendingCookies();
+      console.error("[vinext] Server action error:", err);
+      _reportRequestError(
+        err instanceof Error ? err : new Error(String(err)),
+        { path: cleanPathname, method: request.method, headers: Object.fromEntries(request.headers.entries()) },
+        { routerKind: "App Router", routePath: cleanPathname, routeType: "action" },
+      );
+      setHeadersContext(null);
+      setNavigationContext(null);
+      return new Response(
+        process.env.NODE_ENV === "production"
+          ? "Internal Server Error"
+          : "Server action failed: " + (err && err.message ? err.message : String(err)),
+        { status: 500 },
+      );
+    }
+  }
+
   if (request.method === "POST" && actionId) {
     // ── CSRF protection ─────────────────────────────────────────────────
     // Verify that the Origin header matches the Host header to prevent
@@ -3829,10 +4026,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     }
 
     try {
-      const contentType = request.headers.get("content-type") || "";
       let body;
       try {
-        body = contentType.startsWith("multipart/form-data")
+        body = actionContentType.startsWith("multipart/form-data")
           ? await __readFormDataWithLimit(request, __MAX_ACTION_BODY_SIZE)
           : await __readBodyWithLimit(request, __MAX_ACTION_BODY_SIZE);
       } catch (sizeErr) {
@@ -4660,6 +4856,7 @@ exports[`App Router entry templates > generateRscEntry snapshot (with global err
 "
 import {
   renderToReadableStream as _renderToReadableStream,
+  decodeAction,
   decodeReply,
   loadServerAction,
   createTemporaryReferenceSet,
@@ -6134,7 +6331,105 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   });
 
   // Handle server action POST requests
-  const actionId = request.headers.get("x-rsc-action");
+  const actionId = request.headers.get("x-rsc-action") ?? request.headers.get("next-action");
+  const actionContentType = request.headers.get("content-type") || "";
+  const isMultipartAction = request.method === "POST" && actionContentType.startsWith("multipart/form-data");
+
+  if (isMultipartAction && !actionId) {
+    // ── CSRF protection ─────────────────────────────────────────────────
+    // Multipart POSTs without the fetch-action header are progressive
+    // enhancement submissions from browser forms. Next.js still routes them
+    // through the server action decoder and lets decodeAction decide whether
+    // the form contains action metadata.
+    const csrfResponse = validateCsrfOrigin(request, __allowedOrigins);
+    if (csrfResponse) return csrfResponse;
+
+    const contentLength = parseInt(request.headers.get("content-length") || "0", 10);
+    if (contentLength > __MAX_ACTION_BODY_SIZE) {
+      setHeadersContext(null);
+      setNavigationContext(null);
+      return new Response("Payload Too Large", { status: 413 });
+    }
+
+    try {
+      let body;
+      try {
+        body = await __readFormDataWithLimit(request, __MAX_ACTION_BODY_SIZE);
+      } catch (sizeErr) {
+        if (sizeErr && sizeErr.message === "Request body too large") {
+          setHeadersContext(null);
+          setNavigationContext(null);
+          return new Response("Payload Too Large", { status: 413 });
+        }
+        throw sizeErr;
+      }
+
+      const payloadResponse = await validateServerActionPayload(body);
+      if (payloadResponse) {
+        setHeadersContext(null);
+        setNavigationContext(null);
+        return payloadResponse;
+      }
+
+      const action = await decodeAction(body);
+      if (typeof action === "function") {
+        let actionRedirect = null;
+        const previousHeadersPhase = setHeadersAccessPhase("action");
+        try {
+          await action();
+        } catch (e) {
+          if (e && typeof e === "object" && "digest" in e) {
+            const digest = String(e.digest);
+            if (digest.startsWith("NEXT_REDIRECT;")) {
+              const parts = digest.split(";");
+              actionRedirect = {
+                url: decodeURIComponent(parts[2]),
+              };
+            } else {
+              throw e;
+            }
+          } else {
+            throw e;
+          }
+        } finally {
+          setHeadersAccessPhase(previousHeadersPhase);
+        }
+
+        if (actionRedirect) {
+          const actionPendingCookies = getAndClearPendingCookies();
+          const actionDraftCookie = getDraftModeCookieHeader();
+          setHeadersContext(null);
+          setNavigationContext(null);
+          const redirectHeaders = new Headers({
+            Location: new URL(actionRedirect.url, request.url).toString(),
+          });
+          __mergeMiddlewareResponseHeaders(redirectHeaders, _mwCtx.headers);
+          for (const cookie of actionPendingCookies) {
+            redirectHeaders.append("Set-Cookie", cookie);
+          }
+          if (actionDraftCookie) redirectHeaders.append("Set-Cookie", actionDraftCookie);
+          return new Response(null, { status: 303, headers: redirectHeaders });
+        }
+      }
+    } catch (err) {
+      getAndClearPendingCookies();
+      console.error("[vinext] Server action error:", err);
+      _reportRequestError(
+        err instanceof Error ? err : new Error(String(err)),
+        { path: cleanPathname, method: request.method, headers: Object.fromEntries(request.headers.entries()) },
+        { routerKind: "App Router", routePath: cleanPathname, routeType: "action" },
+      );
+      setHeadersContext(null);
+      setNavigationContext(null);
+      return new Response(
+        process.env.NODE_ENV === "production"
+          ? "Internal Server Error"
+          : "Server action failed: " + (err && err.message ? err.message : String(err)),
+        { status: 500 },
+      );
+    }
+  }
+
   if (request.method === "POST" && actionId) {
     // ── CSRF protection ─────────────────────────────────────────────────
     // Verify that the Origin header matches the Host header to prevent
@@ -6154,10 +6449,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     }
 
     try {
-      const contentType = request.headers.get("content-type") || "";
       let body;
       try {
-        body = contentType.startsWith("multipart/form-data")
+        body = actionContentType.startsWith("multipart/form-data")
           ? await __readFormDataWithLimit(request, __MAX_ACTION_BODY_SIZE)
           : await __readBodyWithLimit(request, __MAX_ACTION_BODY_SIZE);
       } catch (sizeErr) {
@@ -6985,6 +7279,7 @@ exports[`App Router entry templates > generateRscEntry snapshot (with instrument
 "
 import {
   renderToReadableStream as _renderToReadableStream,
+  decodeAction,
   decodeReply,
   loadServerAction,
   createTemporaryReferenceSet,
@@ -8491,7 +8786,105 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   });
 
   // Handle server action POST requests
-  const actionId = request.headers.get("x-rsc-action");
+  const actionId = request.headers.get("x-rsc-action") ?? request.headers.get("next-action");
+  const actionContentType = request.headers.get("content-type") || "";
+  const isMultipartAction = request.method === "POST" && actionContentType.startsWith("multipart/form-data");
+
+  if (isMultipartAction && !actionId) {
+    // ── CSRF protection ─────────────────────────────────────────────────
+    // Multipart POSTs without the fetch-action header are progressive
+    // enhancement submissions from browser forms. Next.js still routes them
+    // through the server action decoder and lets decodeAction decide whether
+    // the form contains action metadata.
+    const csrfResponse = validateCsrfOrigin(request, __allowedOrigins);
+    if (csrfResponse) return csrfResponse;
+
+    const contentLength = parseInt(request.headers.get("content-length") || "0", 10);
+    if (contentLength > __MAX_ACTION_BODY_SIZE) {
+      setHeadersContext(null);
+      setNavigationContext(null);
+      return new Response("Payload Too Large", { status: 413 });
+    }
+
+    try {
+      let body;
+      try {
+        body = await __readFormDataWithLimit(request, __MAX_ACTION_BODY_SIZE);
+      } catch (sizeErr) {
+        if (sizeErr && sizeErr.message === "Request body too large") {
+          setHeadersContext(null);
+          setNavigationContext(null);
+          return new Response("Payload Too Large", { status: 413 });
+        }
+        throw sizeErr;
+      }
+
+      const payloadResponse = await validateServerActionPayload(body);
+      if (payloadResponse) {
+        setHeadersContext(null);
+        setNavigationContext(null);
+        return payloadResponse;
+      }
+
+      const action = await decodeAction(body);
+      if (typeof action === "function") {
+        let actionRedirect = null;
+        const previousHeadersPhase = setHeadersAccessPhase("action");
+        try {
+          await action();
+        } catch (e) {
+          if (e && typeof e === "object" && "digest" in e) {
+            const digest = String(e.digest);
+            if (digest.startsWith("NEXT_REDIRECT;")) {
+              const parts = digest.split(";");
+              actionRedirect = {
+                url: decodeURIComponent(parts[2]),
+              };
+            } else {
+              throw e;
+            }
+          } else {
+            throw e;
+          }
+        } finally {
+          setHeadersAccessPhase(previousHeadersPhase);
+        }
+
+        if (actionRedirect) {
+          const actionPendingCookies = getAndClearPendingCookies();
+          const actionDraftCookie = getDraftModeCookieHeader();
+          setHeadersContext(null);
+          setNavigationContext(null);
+          const redirectHeaders = new Headers({
+            Location: new URL(actionRedirect.url, request.url).toString(),
+          });
+          __mergeMiddlewareResponseHeaders(redirectHeaders, _mwCtx.headers);
+          for (const cookie of actionPendingCookies) {
+            redirectHeaders.append("Set-Cookie", cookie);
+          }
+          if (actionDraftCookie) redirectHeaders.append("Set-Cookie", actionDraftCookie);
+          return new Response(null, { status: 303, headers: redirectHeaders });
+        }
+      }
+    } catch (err) {
+      getAndClearPendingCookies();
+      console.error("[vinext] Server action error:", err);
+      _reportRequestError(
+        err instanceof Error ? err : new Error(String(err)),
+        { path: cleanPathname, method: request.method, headers: Object.fromEntries(request.headers.entries()) },
+        { routerKind: "App Router", routePath: cleanPathname, routeType: "action" },
+      );
+      setHeadersContext(null);
+      setNavigationContext(null);
+      return new Response(
+        process.env.NODE_ENV === "production"
+          ? "Internal Server Error"
+          : "Server action failed: " + (err && err.message ? err.message : String(err)),
+        { status: 500 },
+      );
+    }
+  }
+
   if (request.method === "POST" && actionId) {
     // ── CSRF protection ─────────────────────────────────────────────────
     // Verify that the Origin header matches the Host header to prevent
@@ -8511,10 +8904,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     }
 
     try {
-      const contentType = request.headers.get("content-type") || "";
       let body;
       try {
-        body = contentType.startsWith("multipart/form-data")
+        body = actionContentType.startsWith("multipart/form-data")
           ? await __readFormDataWithLimit(request, __MAX_ACTION_BODY_SIZE)
           : await __readBodyWithLimit(request, __MAX_ACTION_BODY_SIZE);
       } catch (sizeErr) {
@@ -9342,6 +9734,7 @@ exports[`App Router entry templates > generateRscEntry snapshot (with metadata r
 "
 import {
   renderToReadableStream as _renderToReadableStream,
+  decodeAction,
   decodeReply,
   loadServerAction,
   createTemporaryReferenceSet,
@@ -10822,7 +11215,105 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   });
 
   // Handle server action POST requests
-  const actionId = request.headers.get("x-rsc-action");
+  const actionId = request.headers.get("x-rsc-action") ?? request.headers.get("next-action");
+  const actionContentType = request.headers.get("content-type") || "";
+  const isMultipartAction = request.method === "POST" && actionContentType.startsWith("multipart/form-data");
+
+  if (isMultipartAction && !actionId) {
+    // ── CSRF protection ─────────────────────────────────────────────────
+    // Multipart POSTs without the fetch-action header are progressive
+    // enhancement submissions from browser forms. Next.js still routes them
+    // through the server action decoder and lets decodeAction decide whether
+    // the form contains action metadata.
+    const csrfResponse = validateCsrfOrigin(request, __allowedOrigins);
+    if (csrfResponse) return csrfResponse;
+
+    const contentLength = parseInt(request.headers.get("content-length") || "0", 10);
+    if (contentLength > __MAX_ACTION_BODY_SIZE) {
+      setHeadersContext(null);
+      setNavigationContext(null);
+      return new Response("Payload Too Large", { status: 413 });
+    }
+
+    try {
+      let body;
+      try {
+        body = await __readFormDataWithLimit(request, __MAX_ACTION_BODY_SIZE);
+      } catch (sizeErr) {
+        if (sizeErr && sizeErr.message === "Request body too large") {
+          setHeadersContext(null);
+          setNavigationContext(null);
+          return new Response("Payload Too Large", { status: 413 });
+        }
+        throw sizeErr;
+      }
+
+      const payloadResponse = await validateServerActionPayload(body);
+      if (payloadResponse) {
+        setHeadersContext(null);
+        setNavigationContext(null);
+        return payloadResponse;
+      }
+
+      const action = await decodeAction(body);
+      if (typeof action === "function") {
+        let actionRedirect = null;
+        const previousHeadersPhase = setHeadersAccessPhase("action");
+        try {
+          await action();
+        } catch (e) {
+          if (e && typeof e === "object" && "digest" in e) {
+            const digest = String(e.digest);
+            if (digest.startsWith("NEXT_REDIRECT;")) {
+              const parts = digest.split(";");
+              actionRedirect = {
+                url: decodeURIComponent(parts[2]),
+              };
+            } else {
+              throw e;
+            }
+          } else {
+            throw e;
+          }
+        } finally {
+          setHeadersAccessPhase(previousHeadersPhase);
+        }
+
+        if (actionRedirect) {
+          const actionPendingCookies = getAndClearPendingCookies();
+          const actionDraftCookie = getDraftModeCookieHeader();
+          setHeadersContext(null);
+          setNavigationContext(null);
+          const redirectHeaders = new Headers({
+            Location: new URL(actionRedirect.url, request.url).toString(),
+          });
+          __mergeMiddlewareResponseHeaders(redirectHeaders, _mwCtx.headers);
+          for (const cookie of actionPendingCookies) {
+            redirectHeaders.append("Set-Cookie", cookie);
+          }
+          if (actionDraftCookie) redirectHeaders.append("Set-Cookie", actionDraftCookie);
+          return new Response(null, { status: 303, headers: redirectHeaders });
+        }
+      }
+    } catch (err) {
+      getAndClearPendingCookies();
+      console.error("[vinext] Server action error:", err);
+      _reportRequestError(
+        err instanceof Error ? err : new Error(String(err)),
+        { path: cleanPathname, method: request.method, headers: Object.fromEntries(request.headers.entries()) },
+        { routerKind: "App Router", routePath: cleanPathname, routeType: "action" },
+      );
+      setHeadersContext(null);
+      setNavigationContext(null);
+      return new Response(
+        process.env.NODE_ENV === "production"
+          ? "Internal Server Error"
+          : "Server action failed: " + (err && err.message ? err.message : String(err)),
+        { status: 500 },
+      );
+    }
+  }
+
   if (request.method === "POST" && actionId) {
     // ── CSRF protection ─────────────────────────────────────────────────
     // Verify that the Origin header matches the Host header to prevent
@@ -10842,10 +11333,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     }
 
     try {
-      const contentType = request.headers.get("content-type") || "";
       let body;
       try {
-        body = contentType.startsWith("multipart/form-data")
+        body = actionContentType.startsWith("multipart/form-data")
           ? await __readFormDataWithLimit(request, __MAX_ACTION_BODY_SIZE)
           : await __readBodyWithLimit(request, __MAX_ACTION_BODY_SIZE);
       } catch (sizeErr) {
@@ -11673,6 +12163,7 @@ exports[`App Router entry templates > generateRscEntry snapshot (with middleware
 "
 import {
   renderToReadableStream as _renderToReadableStream,
+  decodeAction,
   decodeReply,
   loadServerAction,
   createTemporaryReferenceSet,
@@ -13513,7 +14004,105 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   });
 
   // Handle server action POST requests
-  const actionId = request.headers.get("x-rsc-action");
+  const actionId = request.headers.get("x-rsc-action") ?? request.headers.get("next-action");
+  const actionContentType = request.headers.get("content-type") || "";
+  const isMultipartAction = request.method === "POST" && actionContentType.startsWith("multipart/form-data");
+
+  if (isMultipartAction && !actionId) {
+    // ── CSRF protection ─────────────────────────────────────────────────
+    // Multipart POSTs without the fetch-action header are progressive
+    // enhancement submissions from browser forms. Next.js still routes them
+    // through the server action decoder and lets decodeAction decide whether
+    // the form contains action metadata.
+    const csrfResponse = validateCsrfOrigin(request, __allowedOrigins);
+    if (csrfResponse) return csrfResponse;
+
+    const contentLength = parseInt(request.headers.get("content-length") || "0", 10);
+    if (contentLength > __MAX_ACTION_BODY_SIZE) {
+      setHeadersContext(null);
+      setNavigationContext(null);
+      return new Response("Payload Too Large", { status: 413 });
+    }
+
+    try {
+      let body;
+      try {
+        body = await __readFormDataWithLimit(request, __MAX_ACTION_BODY_SIZE);
+      } catch (sizeErr) {
+        if (sizeErr && sizeErr.message === "Request body too large") {
+          setHeadersContext(null);
+          setNavigationContext(null);
+          return new Response("Payload Too Large", { status: 413 });
+        }
+        throw sizeErr;
+      }
+
+      const payloadResponse = await validateServerActionPayload(body);
+      if (payloadResponse) {
+        setHeadersContext(null);
+        setNavigationContext(null);
+        return payloadResponse;
+      }
+
+      const action = await decodeAction(body);
+      if (typeof action === "function") {
+        let actionRedirect = null;
+        const previousHeadersPhase = setHeadersAccessPhase("action");
+        try {
+          await action();
+        } catch (e) {
+          if (e && typeof e === "object" && "digest" in e) {
+            const digest = String(e.digest);
+            if (digest.startsWith("NEXT_REDIRECT;")) {
+              const parts = digest.split(";");
+              actionRedirect = {
+                url: decodeURIComponent(parts[2]),
+              };
+            } else {
+              throw e;
+            }
+          } else {
+            throw e;
+          }
+        } finally {
+          setHeadersAccessPhase(previousHeadersPhase);
+        }
+
+        if (actionRedirect) {
+          const actionPendingCookies = getAndClearPendingCookies();
+          const actionDraftCookie = getDraftModeCookieHeader();
+          setHeadersContext(null);
+          setNavigationContext(null);
+          const redirectHeaders = new Headers({
+            Location: new URL(actionRedirect.url, request.url).toString(),
+          });
+          __mergeMiddlewareResponseHeaders(redirectHeaders, _mwCtx.headers);
+          for (const cookie of actionPendingCookies) {
+            redirectHeaders.append("Set-Cookie", cookie);
+          }
+          if (actionDraftCookie) redirectHeaders.append("Set-Cookie", actionDraftCookie);
+          return new Response(null, { status: 303, headers: redirectHeaders });
+        }
+      }
+    } catch (err) {
+      getAndClearPendingCookies();
+      console.error("[vinext] Server action error:", err);
+      _reportRequestError(
+        err instanceof Error ? err : new Error(String(err)),
+        { path: cleanPathname, method: request.method, headers: Object.fromEntries(request.headers.entries()) },
+        { routerKind: "App Router", routePath: cleanPathname, routeType: "action" },
+      );
+      setHeadersContext(null);
+      setNavigationContext(null);
+      return new Response(
+        process.env.NODE_ENV === "production"
+          ? "Internal Server Error"
+          : "Server action failed: " + (err && err.message ? err.message : String(err)),
+        { status: 500 },
+      );
+    }
+  }
+
   if (request.method === "POST" && actionId) {
     // ── CSRF protection ─────────────────────────────────────────────────
     // Verify that the Origin header matches the Host header to prevent
@@ -13533,10 +14122,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     }
 
     try {
-      const contentType = request.headers.get("content-type") || "";
       let body;
       try {
-        body = contentType.startsWith("multipart/form-data")
+        body = actionContentType.startsWith("multipart/form-data")
           ? await __readFormDataWithLimit(request, __MAX_ACTION_BODY_SIZE)
           : await __readBodyWithLimit(request, __MAX_ACTION_BODY_SIZE);
       } catch (sizeErr) {

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -66,6 +66,9 @@ import {
 import {
   executeAppRouteHandler as __executeAppRouteHandler,
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-execution.js";
+import {
+  handleProgressiveServerActionRequest as __handleProgressiveServerActionRequest,
+} from "<ROOT>/packages/vinext/src/server/app-server-action-execution.js";
 import { readAppRouteHandlerCacheResponse as __readAppRouteHandlerCacheResponse } from "<ROOT>/packages/vinext/src/server/app-route-handler-cache.js";
 import { readAppPageCacheResponse as __readAppPageCacheResponse } from "<ROOT>/packages/vinext/src/server/app-page-cache.js";
 import {
@@ -1482,102 +1485,26 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // Handle server action POST requests
   const actionId = request.headers.get("x-rsc-action") ?? request.headers.get("next-action");
   const actionContentType = request.headers.get("content-type") || "";
-  const isMultipartAction = request.method === "POST" && actionContentType.startsWith("multipart/form-data");
-
-  if (isMultipartAction && !actionId) {
-    // ── CSRF protection ─────────────────────────────────────────────────
-    // Multipart POSTs without the fetch-action header are progressive
-    // enhancement submissions from browser forms. Next.js still routes them
-    // through the server action decoder and lets decodeAction decide whether
-    // the form contains action metadata.
-    const csrfResponse = validateCsrfOrigin(request, __allowedOrigins);
-    if (csrfResponse) return csrfResponse;
-
-    const contentLength = parseInt(request.headers.get("content-length") || "0", 10);
-    if (contentLength > __MAX_ACTION_BODY_SIZE) {
+  const progressiveActionResponse = await __handleProgressiveServerActionRequest({
+    actionId,
+    allowedOrigins: __allowedOrigins,
+    cleanPathname,
+    clearRequestContext() {
       setHeadersContext(null);
       setNavigationContext(null);
-      return new Response("Payload Too Large", { status: 413 });
-    }
-
-    try {
-      let body;
-      try {
-        body = await __readFormDataWithLimit(request, __MAX_ACTION_BODY_SIZE);
-      } catch (sizeErr) {
-        if (sizeErr && sizeErr.message === "Request body too large") {
-          setHeadersContext(null);
-          setNavigationContext(null);
-          return new Response("Payload Too Large", { status: 413 });
-        }
-        throw sizeErr;
-      }
-
-      const payloadResponse = await validateServerActionPayload(body);
-      if (payloadResponse) {
-        setHeadersContext(null);
-        setNavigationContext(null);
-        return payloadResponse;
-      }
-
-      const action = await decodeAction(body);
-      if (typeof action === "function") {
-        let actionRedirect = null;
-        const previousHeadersPhase = setHeadersAccessPhase("action");
-        try {
-          await action();
-        } catch (e) {
-          if (e && typeof e === "object" && "digest" in e) {
-            const digest = String(e.digest);
-            if (digest.startsWith("NEXT_REDIRECT;")) {
-              const parts = digest.split(";");
-              actionRedirect = {
-                url: decodeURIComponent(parts[2]),
-              };
-            } else {
-              throw e;
-            }
-          } else {
-            throw e;
-          }
-        } finally {
-          setHeadersAccessPhase(previousHeadersPhase);
-        }
-
-        if (actionRedirect) {
-          const actionPendingCookies = getAndClearPendingCookies();
-          const actionDraftCookie = getDraftModeCookieHeader();
-          setHeadersContext(null);
-          setNavigationContext(null);
-          const redirectHeaders = new Headers({
-            Location: new URL(actionRedirect.url, request.url).toString(),
-          });
-          __mergeMiddlewareResponseHeaders(redirectHeaders, _mwCtx.headers);
-          for (const cookie of actionPendingCookies) {
-            redirectHeaders.append("Set-Cookie", cookie);
-          }
-          if (actionDraftCookie) redirectHeaders.append("Set-Cookie", actionDraftCookie);
-          return new Response(null, { status: 303, headers: redirectHeaders });
-        }
-      }
-    } catch (err) {
-      getAndClearPendingCookies();
-      console.error("[vinext] Server action error:", err);
-      _reportRequestError(
-        err instanceof Error ? err : new Error(String(err)),
-        { path: cleanPathname, method: request.method, headers: Object.fromEntries(request.headers.entries()) },
-        { routerKind: "App Router", routePath: cleanPathname, routeType: "action" },
-      );
-      setHeadersContext(null);
-      setNavigationContext(null);
-      return new Response(
-        process.env.NODE_ENV === "production"
-          ? "Internal Server Error"
-          : "Server action failed: " + (err && err.message ? err.message : String(err)),
-        { status: 500 },
-      );
-    }
-  }
+    },
+    contentType: actionContentType,
+    decodeAction,
+    getAndClearPendingCookies,
+    getDraftModeCookieHeader,
+    maxActionBodySize: __MAX_ACTION_BODY_SIZE,
+    middlewareHeaders: _mwCtx.headers,
+    readFormDataWithLimit: __readFormDataWithLimit,
+    reportRequestError: _reportRequestError,
+    request,
+    setHeadersAccessPhase,
+  });
+  if (progressiveActionResponse) return progressiveActionResponse;
 
   if (request.method === "POST" && actionId) {
     // ── CSRF protection ─────────────────────────────────────────────────
@@ -2488,6 +2415,9 @@ import {
 import {
   executeAppRouteHandler as __executeAppRouteHandler,
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-execution.js";
+import {
+  handleProgressiveServerActionRequest as __handleProgressiveServerActionRequest,
+} from "<ROOT>/packages/vinext/src/server/app-server-action-execution.js";
 import { readAppRouteHandlerCacheResponse as __readAppRouteHandlerCacheResponse } from "<ROOT>/packages/vinext/src/server/app-route-handler-cache.js";
 import { readAppPageCacheResponse as __readAppPageCacheResponse } from "<ROOT>/packages/vinext/src/server/app-page-cache.js";
 import {
@@ -3910,102 +3840,26 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // Handle server action POST requests
   const actionId = request.headers.get("x-rsc-action") ?? request.headers.get("next-action");
   const actionContentType = request.headers.get("content-type") || "";
-  const isMultipartAction = request.method === "POST" && actionContentType.startsWith("multipart/form-data");
-
-  if (isMultipartAction && !actionId) {
-    // ── CSRF protection ─────────────────────────────────────────────────
-    // Multipart POSTs without the fetch-action header are progressive
-    // enhancement submissions from browser forms. Next.js still routes them
-    // through the server action decoder and lets decodeAction decide whether
-    // the form contains action metadata.
-    const csrfResponse = validateCsrfOrigin(request, __allowedOrigins);
-    if (csrfResponse) return csrfResponse;
-
-    const contentLength = parseInt(request.headers.get("content-length") || "0", 10);
-    if (contentLength > __MAX_ACTION_BODY_SIZE) {
+  const progressiveActionResponse = await __handleProgressiveServerActionRequest({
+    actionId,
+    allowedOrigins: __allowedOrigins,
+    cleanPathname,
+    clearRequestContext() {
       setHeadersContext(null);
       setNavigationContext(null);
-      return new Response("Payload Too Large", { status: 413 });
-    }
-
-    try {
-      let body;
-      try {
-        body = await __readFormDataWithLimit(request, __MAX_ACTION_BODY_SIZE);
-      } catch (sizeErr) {
-        if (sizeErr && sizeErr.message === "Request body too large") {
-          setHeadersContext(null);
-          setNavigationContext(null);
-          return new Response("Payload Too Large", { status: 413 });
-        }
-        throw sizeErr;
-      }
-
-      const payloadResponse = await validateServerActionPayload(body);
-      if (payloadResponse) {
-        setHeadersContext(null);
-        setNavigationContext(null);
-        return payloadResponse;
-      }
-
-      const action = await decodeAction(body);
-      if (typeof action === "function") {
-        let actionRedirect = null;
-        const previousHeadersPhase = setHeadersAccessPhase("action");
-        try {
-          await action();
-        } catch (e) {
-          if (e && typeof e === "object" && "digest" in e) {
-            const digest = String(e.digest);
-            if (digest.startsWith("NEXT_REDIRECT;")) {
-              const parts = digest.split(";");
-              actionRedirect = {
-                url: decodeURIComponent(parts[2]),
-              };
-            } else {
-              throw e;
-            }
-          } else {
-            throw e;
-          }
-        } finally {
-          setHeadersAccessPhase(previousHeadersPhase);
-        }
-
-        if (actionRedirect) {
-          const actionPendingCookies = getAndClearPendingCookies();
-          const actionDraftCookie = getDraftModeCookieHeader();
-          setHeadersContext(null);
-          setNavigationContext(null);
-          const redirectHeaders = new Headers({
-            Location: new URL(actionRedirect.url, request.url).toString(),
-          });
-          __mergeMiddlewareResponseHeaders(redirectHeaders, _mwCtx.headers);
-          for (const cookie of actionPendingCookies) {
-            redirectHeaders.append("Set-Cookie", cookie);
-          }
-          if (actionDraftCookie) redirectHeaders.append("Set-Cookie", actionDraftCookie);
-          return new Response(null, { status: 303, headers: redirectHeaders });
-        }
-      }
-    } catch (err) {
-      getAndClearPendingCookies();
-      console.error("[vinext] Server action error:", err);
-      _reportRequestError(
-        err instanceof Error ? err : new Error(String(err)),
-        { path: cleanPathname, method: request.method, headers: Object.fromEntries(request.headers.entries()) },
-        { routerKind: "App Router", routePath: cleanPathname, routeType: "action" },
-      );
-      setHeadersContext(null);
-      setNavigationContext(null);
-      return new Response(
-        process.env.NODE_ENV === "production"
-          ? "Internal Server Error"
-          : "Server action failed: " + (err && err.message ? err.message : String(err)),
-        { status: 500 },
-      );
-    }
-  }
+    },
+    contentType: actionContentType,
+    decodeAction,
+    getAndClearPendingCookies,
+    getDraftModeCookieHeader,
+    maxActionBodySize: __MAX_ACTION_BODY_SIZE,
+    middlewareHeaders: _mwCtx.headers,
+    readFormDataWithLimit: __readFormDataWithLimit,
+    reportRequestError: _reportRequestError,
+    request,
+    setHeadersAccessPhase,
+  });
+  if (progressiveActionResponse) return progressiveActionResponse;
 
   if (request.method === "POST" && actionId) {
     // ── CSRF protection ─────────────────────────────────────────────────
@@ -4916,6 +4770,9 @@ import {
 import {
   executeAppRouteHandler as __executeAppRouteHandler,
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-execution.js";
+import {
+  handleProgressiveServerActionRequest as __handleProgressiveServerActionRequest,
+} from "<ROOT>/packages/vinext/src/server/app-server-action-execution.js";
 import { readAppRouteHandlerCacheResponse as __readAppRouteHandlerCacheResponse } from "<ROOT>/packages/vinext/src/server/app-route-handler-cache.js";
 import { readAppPageCacheResponse as __readAppPageCacheResponse } from "<ROOT>/packages/vinext/src/server/app-page-cache.js";
 import {
@@ -6333,102 +6190,26 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // Handle server action POST requests
   const actionId = request.headers.get("x-rsc-action") ?? request.headers.get("next-action");
   const actionContentType = request.headers.get("content-type") || "";
-  const isMultipartAction = request.method === "POST" && actionContentType.startsWith("multipart/form-data");
-
-  if (isMultipartAction && !actionId) {
-    // ── CSRF protection ─────────────────────────────────────────────────
-    // Multipart POSTs without the fetch-action header are progressive
-    // enhancement submissions from browser forms. Next.js still routes them
-    // through the server action decoder and lets decodeAction decide whether
-    // the form contains action metadata.
-    const csrfResponse = validateCsrfOrigin(request, __allowedOrigins);
-    if (csrfResponse) return csrfResponse;
-
-    const contentLength = parseInt(request.headers.get("content-length") || "0", 10);
-    if (contentLength > __MAX_ACTION_BODY_SIZE) {
+  const progressiveActionResponse = await __handleProgressiveServerActionRequest({
+    actionId,
+    allowedOrigins: __allowedOrigins,
+    cleanPathname,
+    clearRequestContext() {
       setHeadersContext(null);
       setNavigationContext(null);
-      return new Response("Payload Too Large", { status: 413 });
-    }
-
-    try {
-      let body;
-      try {
-        body = await __readFormDataWithLimit(request, __MAX_ACTION_BODY_SIZE);
-      } catch (sizeErr) {
-        if (sizeErr && sizeErr.message === "Request body too large") {
-          setHeadersContext(null);
-          setNavigationContext(null);
-          return new Response("Payload Too Large", { status: 413 });
-        }
-        throw sizeErr;
-      }
-
-      const payloadResponse = await validateServerActionPayload(body);
-      if (payloadResponse) {
-        setHeadersContext(null);
-        setNavigationContext(null);
-        return payloadResponse;
-      }
-
-      const action = await decodeAction(body);
-      if (typeof action === "function") {
-        let actionRedirect = null;
-        const previousHeadersPhase = setHeadersAccessPhase("action");
-        try {
-          await action();
-        } catch (e) {
-          if (e && typeof e === "object" && "digest" in e) {
-            const digest = String(e.digest);
-            if (digest.startsWith("NEXT_REDIRECT;")) {
-              const parts = digest.split(";");
-              actionRedirect = {
-                url: decodeURIComponent(parts[2]),
-              };
-            } else {
-              throw e;
-            }
-          } else {
-            throw e;
-          }
-        } finally {
-          setHeadersAccessPhase(previousHeadersPhase);
-        }
-
-        if (actionRedirect) {
-          const actionPendingCookies = getAndClearPendingCookies();
-          const actionDraftCookie = getDraftModeCookieHeader();
-          setHeadersContext(null);
-          setNavigationContext(null);
-          const redirectHeaders = new Headers({
-            Location: new URL(actionRedirect.url, request.url).toString(),
-          });
-          __mergeMiddlewareResponseHeaders(redirectHeaders, _mwCtx.headers);
-          for (const cookie of actionPendingCookies) {
-            redirectHeaders.append("Set-Cookie", cookie);
-          }
-          if (actionDraftCookie) redirectHeaders.append("Set-Cookie", actionDraftCookie);
-          return new Response(null, { status: 303, headers: redirectHeaders });
-        }
-      }
-    } catch (err) {
-      getAndClearPendingCookies();
-      console.error("[vinext] Server action error:", err);
-      _reportRequestError(
-        err instanceof Error ? err : new Error(String(err)),
-        { path: cleanPathname, method: request.method, headers: Object.fromEntries(request.headers.entries()) },
-        { routerKind: "App Router", routePath: cleanPathname, routeType: "action" },
-      );
-      setHeadersContext(null);
-      setNavigationContext(null);
-      return new Response(
-        process.env.NODE_ENV === "production"
-          ? "Internal Server Error"
-          : "Server action failed: " + (err && err.message ? err.message : String(err)),
-        { status: 500 },
-      );
-    }
-  }
+    },
+    contentType: actionContentType,
+    decodeAction,
+    getAndClearPendingCookies,
+    getDraftModeCookieHeader,
+    maxActionBodySize: __MAX_ACTION_BODY_SIZE,
+    middlewareHeaders: _mwCtx.headers,
+    readFormDataWithLimit: __readFormDataWithLimit,
+    reportRequestError: _reportRequestError,
+    request,
+    setHeadersAccessPhase,
+  });
+  if (progressiveActionResponse) return progressiveActionResponse;
 
   if (request.method === "POST" && actionId) {
     // ── CSRF protection ─────────────────────────────────────────────────
@@ -7339,6 +7120,9 @@ import {
 import {
   executeAppRouteHandler as __executeAppRouteHandler,
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-execution.js";
+import {
+  handleProgressiveServerActionRequest as __handleProgressiveServerActionRequest,
+} from "<ROOT>/packages/vinext/src/server/app-server-action-execution.js";
 import { readAppRouteHandlerCacheResponse as __readAppRouteHandlerCacheResponse } from "<ROOT>/packages/vinext/src/server/app-route-handler-cache.js";
 import { readAppPageCacheResponse as __readAppPageCacheResponse } from "<ROOT>/packages/vinext/src/server/app-page-cache.js";
 import {
@@ -8788,102 +8572,26 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // Handle server action POST requests
   const actionId = request.headers.get("x-rsc-action") ?? request.headers.get("next-action");
   const actionContentType = request.headers.get("content-type") || "";
-  const isMultipartAction = request.method === "POST" && actionContentType.startsWith("multipart/form-data");
-
-  if (isMultipartAction && !actionId) {
-    // ── CSRF protection ─────────────────────────────────────────────────
-    // Multipart POSTs without the fetch-action header are progressive
-    // enhancement submissions from browser forms. Next.js still routes them
-    // through the server action decoder and lets decodeAction decide whether
-    // the form contains action metadata.
-    const csrfResponse = validateCsrfOrigin(request, __allowedOrigins);
-    if (csrfResponse) return csrfResponse;
-
-    const contentLength = parseInt(request.headers.get("content-length") || "0", 10);
-    if (contentLength > __MAX_ACTION_BODY_SIZE) {
+  const progressiveActionResponse = await __handleProgressiveServerActionRequest({
+    actionId,
+    allowedOrigins: __allowedOrigins,
+    cleanPathname,
+    clearRequestContext() {
       setHeadersContext(null);
       setNavigationContext(null);
-      return new Response("Payload Too Large", { status: 413 });
-    }
-
-    try {
-      let body;
-      try {
-        body = await __readFormDataWithLimit(request, __MAX_ACTION_BODY_SIZE);
-      } catch (sizeErr) {
-        if (sizeErr && sizeErr.message === "Request body too large") {
-          setHeadersContext(null);
-          setNavigationContext(null);
-          return new Response("Payload Too Large", { status: 413 });
-        }
-        throw sizeErr;
-      }
-
-      const payloadResponse = await validateServerActionPayload(body);
-      if (payloadResponse) {
-        setHeadersContext(null);
-        setNavigationContext(null);
-        return payloadResponse;
-      }
-
-      const action = await decodeAction(body);
-      if (typeof action === "function") {
-        let actionRedirect = null;
-        const previousHeadersPhase = setHeadersAccessPhase("action");
-        try {
-          await action();
-        } catch (e) {
-          if (e && typeof e === "object" && "digest" in e) {
-            const digest = String(e.digest);
-            if (digest.startsWith("NEXT_REDIRECT;")) {
-              const parts = digest.split(";");
-              actionRedirect = {
-                url: decodeURIComponent(parts[2]),
-              };
-            } else {
-              throw e;
-            }
-          } else {
-            throw e;
-          }
-        } finally {
-          setHeadersAccessPhase(previousHeadersPhase);
-        }
-
-        if (actionRedirect) {
-          const actionPendingCookies = getAndClearPendingCookies();
-          const actionDraftCookie = getDraftModeCookieHeader();
-          setHeadersContext(null);
-          setNavigationContext(null);
-          const redirectHeaders = new Headers({
-            Location: new URL(actionRedirect.url, request.url).toString(),
-          });
-          __mergeMiddlewareResponseHeaders(redirectHeaders, _mwCtx.headers);
-          for (const cookie of actionPendingCookies) {
-            redirectHeaders.append("Set-Cookie", cookie);
-          }
-          if (actionDraftCookie) redirectHeaders.append("Set-Cookie", actionDraftCookie);
-          return new Response(null, { status: 303, headers: redirectHeaders });
-        }
-      }
-    } catch (err) {
-      getAndClearPendingCookies();
-      console.error("[vinext] Server action error:", err);
-      _reportRequestError(
-        err instanceof Error ? err : new Error(String(err)),
-        { path: cleanPathname, method: request.method, headers: Object.fromEntries(request.headers.entries()) },
-        { routerKind: "App Router", routePath: cleanPathname, routeType: "action" },
-      );
-      setHeadersContext(null);
-      setNavigationContext(null);
-      return new Response(
-        process.env.NODE_ENV === "production"
-          ? "Internal Server Error"
-          : "Server action failed: " + (err && err.message ? err.message : String(err)),
-        { status: 500 },
-      );
-    }
-  }
+    },
+    contentType: actionContentType,
+    decodeAction,
+    getAndClearPendingCookies,
+    getDraftModeCookieHeader,
+    maxActionBodySize: __MAX_ACTION_BODY_SIZE,
+    middlewareHeaders: _mwCtx.headers,
+    readFormDataWithLimit: __readFormDataWithLimit,
+    reportRequestError: _reportRequestError,
+    request,
+    setHeadersAccessPhase,
+  });
+  if (progressiveActionResponse) return progressiveActionResponse;
 
   if (request.method === "POST" && actionId) {
     // ── CSRF protection ─────────────────────────────────────────────────
@@ -9794,6 +9502,9 @@ import {
 import {
   executeAppRouteHandler as __executeAppRouteHandler,
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-execution.js";
+import {
+  handleProgressiveServerActionRequest as __handleProgressiveServerActionRequest,
+} from "<ROOT>/packages/vinext/src/server/app-server-action-execution.js";
 import { readAppRouteHandlerCacheResponse as __readAppRouteHandlerCacheResponse } from "<ROOT>/packages/vinext/src/server/app-route-handler-cache.js";
 import { readAppPageCacheResponse as __readAppPageCacheResponse } from "<ROOT>/packages/vinext/src/server/app-page-cache.js";
 import {
@@ -11217,102 +10928,26 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // Handle server action POST requests
   const actionId = request.headers.get("x-rsc-action") ?? request.headers.get("next-action");
   const actionContentType = request.headers.get("content-type") || "";
-  const isMultipartAction = request.method === "POST" && actionContentType.startsWith("multipart/form-data");
-
-  if (isMultipartAction && !actionId) {
-    // ── CSRF protection ─────────────────────────────────────────────────
-    // Multipart POSTs without the fetch-action header are progressive
-    // enhancement submissions from browser forms. Next.js still routes them
-    // through the server action decoder and lets decodeAction decide whether
-    // the form contains action metadata.
-    const csrfResponse = validateCsrfOrigin(request, __allowedOrigins);
-    if (csrfResponse) return csrfResponse;
-
-    const contentLength = parseInt(request.headers.get("content-length") || "0", 10);
-    if (contentLength > __MAX_ACTION_BODY_SIZE) {
+  const progressiveActionResponse = await __handleProgressiveServerActionRequest({
+    actionId,
+    allowedOrigins: __allowedOrigins,
+    cleanPathname,
+    clearRequestContext() {
       setHeadersContext(null);
       setNavigationContext(null);
-      return new Response("Payload Too Large", { status: 413 });
-    }
-
-    try {
-      let body;
-      try {
-        body = await __readFormDataWithLimit(request, __MAX_ACTION_BODY_SIZE);
-      } catch (sizeErr) {
-        if (sizeErr && sizeErr.message === "Request body too large") {
-          setHeadersContext(null);
-          setNavigationContext(null);
-          return new Response("Payload Too Large", { status: 413 });
-        }
-        throw sizeErr;
-      }
-
-      const payloadResponse = await validateServerActionPayload(body);
-      if (payloadResponse) {
-        setHeadersContext(null);
-        setNavigationContext(null);
-        return payloadResponse;
-      }
-
-      const action = await decodeAction(body);
-      if (typeof action === "function") {
-        let actionRedirect = null;
-        const previousHeadersPhase = setHeadersAccessPhase("action");
-        try {
-          await action();
-        } catch (e) {
-          if (e && typeof e === "object" && "digest" in e) {
-            const digest = String(e.digest);
-            if (digest.startsWith("NEXT_REDIRECT;")) {
-              const parts = digest.split(";");
-              actionRedirect = {
-                url: decodeURIComponent(parts[2]),
-              };
-            } else {
-              throw e;
-            }
-          } else {
-            throw e;
-          }
-        } finally {
-          setHeadersAccessPhase(previousHeadersPhase);
-        }
-
-        if (actionRedirect) {
-          const actionPendingCookies = getAndClearPendingCookies();
-          const actionDraftCookie = getDraftModeCookieHeader();
-          setHeadersContext(null);
-          setNavigationContext(null);
-          const redirectHeaders = new Headers({
-            Location: new URL(actionRedirect.url, request.url).toString(),
-          });
-          __mergeMiddlewareResponseHeaders(redirectHeaders, _mwCtx.headers);
-          for (const cookie of actionPendingCookies) {
-            redirectHeaders.append("Set-Cookie", cookie);
-          }
-          if (actionDraftCookie) redirectHeaders.append("Set-Cookie", actionDraftCookie);
-          return new Response(null, { status: 303, headers: redirectHeaders });
-        }
-      }
-    } catch (err) {
-      getAndClearPendingCookies();
-      console.error("[vinext] Server action error:", err);
-      _reportRequestError(
-        err instanceof Error ? err : new Error(String(err)),
-        { path: cleanPathname, method: request.method, headers: Object.fromEntries(request.headers.entries()) },
-        { routerKind: "App Router", routePath: cleanPathname, routeType: "action" },
-      );
-      setHeadersContext(null);
-      setNavigationContext(null);
-      return new Response(
-        process.env.NODE_ENV === "production"
-          ? "Internal Server Error"
-          : "Server action failed: " + (err && err.message ? err.message : String(err)),
-        { status: 500 },
-      );
-    }
-  }
+    },
+    contentType: actionContentType,
+    decodeAction,
+    getAndClearPendingCookies,
+    getDraftModeCookieHeader,
+    maxActionBodySize: __MAX_ACTION_BODY_SIZE,
+    middlewareHeaders: _mwCtx.headers,
+    readFormDataWithLimit: __readFormDataWithLimit,
+    reportRequestError: _reportRequestError,
+    request,
+    setHeadersAccessPhase,
+  });
+  if (progressiveActionResponse) return progressiveActionResponse;
 
   if (request.method === "POST" && actionId) {
     // ── CSRF protection ─────────────────────────────────────────────────
@@ -12223,6 +11858,9 @@ import {
 import {
   executeAppRouteHandler as __executeAppRouteHandler,
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-execution.js";
+import {
+  handleProgressiveServerActionRequest as __handleProgressiveServerActionRequest,
+} from "<ROOT>/packages/vinext/src/server/app-server-action-execution.js";
 import { readAppRouteHandlerCacheResponse as __readAppRouteHandlerCacheResponse } from "<ROOT>/packages/vinext/src/server/app-route-handler-cache.js";
 import { readAppPageCacheResponse as __readAppPageCacheResponse } from "<ROOT>/packages/vinext/src/server/app-page-cache.js";
 import {
@@ -14006,102 +13644,26 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // Handle server action POST requests
   const actionId = request.headers.get("x-rsc-action") ?? request.headers.get("next-action");
   const actionContentType = request.headers.get("content-type") || "";
-  const isMultipartAction = request.method === "POST" && actionContentType.startsWith("multipart/form-data");
-
-  if (isMultipartAction && !actionId) {
-    // ── CSRF protection ─────────────────────────────────────────────────
-    // Multipart POSTs without the fetch-action header are progressive
-    // enhancement submissions from browser forms. Next.js still routes them
-    // through the server action decoder and lets decodeAction decide whether
-    // the form contains action metadata.
-    const csrfResponse = validateCsrfOrigin(request, __allowedOrigins);
-    if (csrfResponse) return csrfResponse;
-
-    const contentLength = parseInt(request.headers.get("content-length") || "0", 10);
-    if (contentLength > __MAX_ACTION_BODY_SIZE) {
+  const progressiveActionResponse = await __handleProgressiveServerActionRequest({
+    actionId,
+    allowedOrigins: __allowedOrigins,
+    cleanPathname,
+    clearRequestContext() {
       setHeadersContext(null);
       setNavigationContext(null);
-      return new Response("Payload Too Large", { status: 413 });
-    }
-
-    try {
-      let body;
-      try {
-        body = await __readFormDataWithLimit(request, __MAX_ACTION_BODY_SIZE);
-      } catch (sizeErr) {
-        if (sizeErr && sizeErr.message === "Request body too large") {
-          setHeadersContext(null);
-          setNavigationContext(null);
-          return new Response("Payload Too Large", { status: 413 });
-        }
-        throw sizeErr;
-      }
-
-      const payloadResponse = await validateServerActionPayload(body);
-      if (payloadResponse) {
-        setHeadersContext(null);
-        setNavigationContext(null);
-        return payloadResponse;
-      }
-
-      const action = await decodeAction(body);
-      if (typeof action === "function") {
-        let actionRedirect = null;
-        const previousHeadersPhase = setHeadersAccessPhase("action");
-        try {
-          await action();
-        } catch (e) {
-          if (e && typeof e === "object" && "digest" in e) {
-            const digest = String(e.digest);
-            if (digest.startsWith("NEXT_REDIRECT;")) {
-              const parts = digest.split(";");
-              actionRedirect = {
-                url: decodeURIComponent(parts[2]),
-              };
-            } else {
-              throw e;
-            }
-          } else {
-            throw e;
-          }
-        } finally {
-          setHeadersAccessPhase(previousHeadersPhase);
-        }
-
-        if (actionRedirect) {
-          const actionPendingCookies = getAndClearPendingCookies();
-          const actionDraftCookie = getDraftModeCookieHeader();
-          setHeadersContext(null);
-          setNavigationContext(null);
-          const redirectHeaders = new Headers({
-            Location: new URL(actionRedirect.url, request.url).toString(),
-          });
-          __mergeMiddlewareResponseHeaders(redirectHeaders, _mwCtx.headers);
-          for (const cookie of actionPendingCookies) {
-            redirectHeaders.append("Set-Cookie", cookie);
-          }
-          if (actionDraftCookie) redirectHeaders.append("Set-Cookie", actionDraftCookie);
-          return new Response(null, { status: 303, headers: redirectHeaders });
-        }
-      }
-    } catch (err) {
-      getAndClearPendingCookies();
-      console.error("[vinext] Server action error:", err);
-      _reportRequestError(
-        err instanceof Error ? err : new Error(String(err)),
-        { path: cleanPathname, method: request.method, headers: Object.fromEntries(request.headers.entries()) },
-        { routerKind: "App Router", routePath: cleanPathname, routeType: "action" },
-      );
-      setHeadersContext(null);
-      setNavigationContext(null);
-      return new Response(
-        process.env.NODE_ENV === "production"
-          ? "Internal Server Error"
-          : "Server action failed: " + (err && err.message ? err.message : String(err)),
-        { status: 500 },
-      );
-    }
-  }
+    },
+    contentType: actionContentType,
+    decodeAction,
+    getAndClearPendingCookies,
+    getDraftModeCookieHeader,
+    maxActionBodySize: __MAX_ACTION_BODY_SIZE,
+    middlewareHeaders: _mwCtx.headers,
+    readFormDataWithLimit: __readFormDataWithLimit,
+    reportRequestError: _reportRequestError,
+    request,
+    setHeadersAccessPhase,
+  });
+  if (progressiveActionResponse) return progressiveActionResponse;
 
   if (request.method === "POST" && actionId) {
     // ── CSRF protection ─────────────────────────────────────────────────

--- a/tests/app-route-handler-policy.test.ts
+++ b/tests/app-route-handler-policy.test.ts
@@ -214,6 +214,22 @@ describe("app route handler policy helpers", () => {
     expect(
       isPossibleAppRouteActionRequest(
         new Request("https://example.com/api", {
+          method: "POST",
+          headers: { "next-action": "abc" },
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      isPossibleAppRouteActionRequest(
+        new Request("https://example.com/api", {
+          method: "POST",
+          headers: { "content-type": "application/x-www-form-urlencoded; charset=UTF-8" },
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      isPossibleAppRouteActionRequest(
+        new Request("https://example.com/api", {
           method: "GET",
           headers: { "content-type": "multipart/form-data; boundary=test" },
         }),

--- a/tests/app-route-handler-policy.test.ts
+++ b/tests/app-route-handler-policy.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vite-plus/test";
 import {
   getAppRouteHandlerRevalidateSeconds,
   hasAppRouteHandlerDefaultExport,
+  isPossibleAppRouteActionRequest,
   resolveAppRouteHandlerMethod,
   resolveAppRouteHandlerSpecialError,
   shouldApplyAppRouteHandlerRevalidateHeader,
@@ -150,6 +151,18 @@ describe("app route handler policy helpers", () => {
 
     expect(
       resolveAppRouteHandlerSpecialError(
+        { digest: "NEXT_REDIRECT;replace;%2Ftarget%3Fok%3D1;308" },
+        "https://example.com/source",
+        { isAction: true },
+      ),
+    ).toEqual({
+      kind: "redirect",
+      location: "https://example.com/target?ok=1",
+      statusCode: 303,
+    });
+
+    expect(
+      resolveAppRouteHandlerSpecialError(
         { digest: "NEXT_NOT_FOUND" },
         "https://example.com/source",
       ),
@@ -171,5 +184,48 @@ describe("app route handler policy helpers", () => {
     expect(resolveAppRouteHandlerSpecialError(new Error("no digest"), "https://example.com")).toBe(
       null,
     );
+  });
+
+  it("classifies possible app-route action requests like Next.js", () => {
+    expect(
+      isPossibleAppRouteActionRequest(
+        new Request("https://example.com/api", {
+          method: "POST",
+          headers: { "content-type": "application/x-www-form-urlencoded" },
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      isPossibleAppRouteActionRequest(
+        new Request("https://example.com/api", {
+          method: "POST",
+          headers: { "content-type": "multipart/form-data; boundary=test" },
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      isPossibleAppRouteActionRequest(
+        new Request("https://example.com/api", {
+          method: "POST",
+          headers: { "x-rsc-action": "abc" },
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      isPossibleAppRouteActionRequest(
+        new Request("https://example.com/api", {
+          method: "GET",
+          headers: { "content-type": "multipart/form-data; boundary=test" },
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      isPossibleAppRouteActionRequest(
+        new Request("https://example.com/api", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+        }),
+      ),
+    ).toBe(false);
   });
 });

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -4614,6 +4614,13 @@ describe("generateRscEntry ISR code generation", () => {
     expect(actionResponseBody).toContain("mergeMiddlewareResponseHeaders");
   });
 
+  it("generated code accepts both vinext and Next.js action header names", () => {
+    const code = generateRscEntry("/tmp/test/app", minimalRoutes);
+    expect(code).toContain(
+      'request.headers.get("x-rsc-action") ?? request.headers.get("next-action")',
+    );
+  });
+
   it("generated code merges middleware headers into server action redirect responses", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes);
     // The server action redirect path must call mergeMiddlewareResponseHeaders

--- a/tests/app-server-action-execution.test.ts
+++ b/tests/app-server-action-execution.test.ts
@@ -23,6 +23,17 @@ function createMultipartRequest(headers?: HeadersInit): Request {
   });
 }
 
+function createMultipartBodyRequest(body: FormData): Request {
+  return new Request("https://example.com/action-source", {
+    method: "POST",
+    body,
+    headers: {
+      host: "example.com",
+      origin: "https://example.com",
+    },
+  });
+}
+
 function createOptions(
   overrides: Partial<HandleProgressiveServerActionRequestOptions> = {},
 ): HandleProgressiveServerActionRequestOptions {
@@ -59,7 +70,7 @@ describe("app server action execution helpers", () => {
   it("identifies progressive multipart server action submissions", () => {
     expect(
       isProgressiveServerActionRequest(
-        { method: "POST" },
+        { method: "post" },
         "multipart/form-data; boundary=vinext",
         null,
       ),
@@ -86,6 +97,28 @@ describe("app server action execution helpers", () => {
     );
 
     expect(response).toBeNull();
+  });
+
+  it("returns null for non-action multipart posts without consuming the original body", async () => {
+    const formData = new FormData();
+    formData.set("field", "value");
+    const request = createMultipartBodyRequest(formData);
+
+    const response = await handleProgressiveServerActionRequest(
+      createOptions({
+        contentType: request.headers.get("content-type") ?? "",
+        async decodeAction() {
+          return null;
+        },
+        readFormDataWithLimit(readRequest) {
+          return readRequest.formData();
+        },
+        request,
+      }),
+    );
+
+    expect(response).toBeNull();
+    expect((await request.formData()).get("field")).toBe("value");
   });
 
   it("enforces content-length and stream body limits", async () => {
@@ -170,9 +203,64 @@ describe("app server action execution helpers", () => {
     expect(response?.status).toBe(303);
     expect(response?.headers.get("location")).toBe("https://example.com/result?ok=1");
     expect(response?.headers.get("x-middleware")).toBe("present");
-    expect(response?.headers.getSetCookie?.()).toEqual(["session=1; Path=/", "draft=1; Path=/"]);
+    expect(response?.headers.getSetCookie()).toEqual(["session=1; Path=/", "draft=1; Path=/"]);
     expect(phaseCalls).toEqual(["action", "render"]);
     expect(clearContext).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls through after successful non-redirect actions without consuming the original body", async () => {
+    const formData = new FormData();
+    formData.set("$ACTION_ID_test", "");
+    formData.set("field", "value");
+    const request = createMultipartBodyRequest(formData);
+    let actionRan = false;
+
+    const response = await handleProgressiveServerActionRequest(
+      createOptions({
+        contentType: request.headers.get("content-type") ?? "",
+        async decodeAction() {
+          return () => {
+            actionRan = true;
+          };
+        },
+        readFormDataWithLimit(readRequest) {
+          return readRequest.formData();
+        },
+        request,
+      }),
+    );
+
+    expect(response).toBeNull();
+    expect(actionRan).toBe(true);
+    expect((await request.formData()).get("field")).toBe("value");
+  });
+
+  it("maps action HTTP fallback errors to status responses", async () => {
+    for (const [digest, statusCode] of [
+      ["NEXT_NOT_FOUND", 404],
+      ["NEXT_HTTP_ERROR_FALLBACK;403", 403],
+    ]) {
+      const clearContext = vi.fn();
+      const reportedErrors: Error[] = [];
+
+      const response = await handleProgressiveServerActionRequest(
+        createOptions({
+          clearRequestContext: clearContext,
+          async decodeAction() {
+            return () => {
+              throw { digest };
+            };
+          },
+          reportRequestError(error) {
+            reportedErrors.push(error);
+          },
+        }),
+      );
+
+      expect(response?.status).toBe(statusCode);
+      expect(reportedErrors).toEqual([]);
+      expect(clearContext).toHaveBeenCalledTimes(1);
+    }
   });
 
   it("reports action execution failures and clears pending cookies", async () => {

--- a/tests/app-server-action-execution.test.ts
+++ b/tests/app-server-action-execution.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+import {
+  handleProgressiveServerActionRequest,
+  isProgressiveServerActionRequest,
+  type HandleProgressiveServerActionRequestOptions,
+} from "../packages/vinext/src/server/app-server-action-execution.js";
+
+function createMultipartRequest(headers?: HeadersInit): Request {
+  const requestHeaders = new Headers({
+    "content-type": "multipart/form-data; boundary=vinext",
+    host: "example.com",
+    origin: "https://example.com",
+  });
+  if (headers) {
+    for (const [key, value] of new Headers(headers)) {
+      requestHeaders.set(key, value);
+    }
+  }
+
+  return new Request("https://example.com/action-source", {
+    method: "POST",
+    headers: requestHeaders,
+  });
+}
+
+function createOptions(
+  overrides: Partial<HandleProgressiveServerActionRequestOptions> = {},
+): HandleProgressiveServerActionRequestOptions {
+  return {
+    actionId: null,
+    allowedOrigins: [],
+    cleanPathname: "/action-source",
+    clearRequestContext() {},
+    contentType: "multipart/form-data; boundary=vinext",
+    async decodeAction() {
+      return null;
+    },
+    getAndClearPendingCookies() {
+      return [];
+    },
+    getDraftModeCookieHeader() {
+      return null;
+    },
+    maxActionBodySize: 1024,
+    middlewareHeaders: null,
+    async readFormDataWithLimit() {
+      return new FormData();
+    },
+    reportRequestError() {},
+    request: createMultipartRequest(),
+    setHeadersAccessPhase() {
+      return "render";
+    },
+    ...overrides,
+  };
+}
+
+describe("app server action execution helpers", () => {
+  it("identifies progressive multipart server action submissions", () => {
+    expect(
+      isProgressiveServerActionRequest(
+        { method: "POST" },
+        "multipart/form-data; boundary=vinext",
+        null,
+      ),
+    ).toBe(true);
+    expect(
+      isProgressiveServerActionRequest(
+        { method: "POST" },
+        "multipart/form-data; boundary=vinext",
+        "action-id",
+      ),
+    ).toBe(false);
+    expect(isProgressiveServerActionRequest({ method: "GET" }, "multipart/form-data", null)).toBe(
+      false,
+    );
+    expect(isProgressiveServerActionRequest({ method: "POST" }, "text/plain", null)).toBe(false);
+  });
+
+  it("returns null for non-progressive action requests", async () => {
+    const response = await handleProgressiveServerActionRequest(
+      createOptions({
+        actionId: "action-id",
+        decodeAction: vi.fn(),
+      }),
+    );
+
+    expect(response).toBeNull();
+  });
+
+  it("enforces content-length and stream body limits", async () => {
+    const clearContext = vi.fn();
+    const lengthResponse = await handleProgressiveServerActionRequest(
+      createOptions({
+        clearRequestContext: clearContext,
+        maxActionBodySize: 10,
+        request: createMultipartRequest({ "content-length": "11" }),
+      }),
+    );
+
+    expect(lengthResponse?.status).toBe(413);
+    expect(await lengthResponse?.text()).toBe("Payload Too Large");
+    expect(clearContext).toHaveBeenCalledTimes(1);
+
+    const streamLimitResponse = await handleProgressiveServerActionRequest(
+      createOptions({
+        clearRequestContext: clearContext,
+        readFormDataWithLimit() {
+          throw new Error("Request body too large");
+        },
+      }),
+    );
+
+    expect(streamLimitResponse?.status).toBe(413);
+    expect(await streamLimitResponse?.text()).toBe("Payload Too Large");
+    expect(clearContext).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects malformed action payloads before decoding the action", async () => {
+    const formData = new FormData();
+    formData.set("0", '"$Q1"');
+    const decodeAction = vi.fn();
+
+    const response = await handleProgressiveServerActionRequest(
+      createOptions({
+        decodeAction,
+        readFormDataWithLimit() {
+          return Promise.resolve(formData);
+        },
+      }),
+    );
+
+    expect(response?.status).toBe(400);
+    expect(await response?.text()).toBe("Invalid server action payload");
+    expect(decodeAction).not.toHaveBeenCalled();
+  });
+
+  it("executes decoded form actions and converts redirects into 303 responses", async () => {
+    const phaseCalls: string[] = [];
+    const clearContext = vi.fn();
+    const formData = new FormData();
+    formData.set("$ACTION_ID_test", "");
+
+    const response = await handleProgressiveServerActionRequest(
+      createOptions({
+        clearRequestContext: clearContext,
+        async decodeAction(body) {
+          expect(body).toBe(formData);
+          return () => {
+            throw { digest: "NEXT_REDIRECT;replace;%2Fresult%3Fok%3D1;307" };
+          };
+        },
+        getAndClearPendingCookies() {
+          return ["session=1; Path=/"];
+        },
+        getDraftModeCookieHeader() {
+          return "draft=1; Path=/";
+        },
+        middlewareHeaders: new Headers([["x-middleware", "present"]]),
+        readFormDataWithLimit() {
+          return Promise.resolve(formData);
+        },
+        setHeadersAccessPhase(phase) {
+          phaseCalls.push(phase);
+          return "render";
+        },
+      }),
+    );
+
+    expect(response?.status).toBe(303);
+    expect(response?.headers.get("location")).toBe("https://example.com/result?ok=1");
+    expect(response?.headers.get("x-middleware")).toBe("present");
+    expect(response?.headers.getSetCookie?.()).toEqual(["session=1; Path=/", "draft=1; Path=/"]);
+    expect(phaseCalls).toEqual(["action", "render"]);
+    expect(clearContext).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports action execution failures and clears pending cookies", async () => {
+    const reportedErrors: Error[] = [];
+    const clearedCookies = vi.fn(() => ["session=1; Path=/"]);
+    const clearContext = vi.fn();
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const response = await handleProgressiveServerActionRequest(
+      createOptions({
+        cleanPathname: "/action-source",
+        clearRequestContext: clearContext,
+        async decodeAction() {
+          return () => {
+            throw new Error("boom");
+          };
+        },
+        getAndClearPendingCookies: clearedCookies,
+        reportRequestError(error) {
+          reportedErrors.push(error);
+        },
+      }),
+    );
+
+    expect(response?.status).toBe(500);
+    expect(await response?.text()).toBe("Server action failed: boom");
+    expect(reportedErrors.map((error) => error.message)).toEqual(["boom"]);
+    expect(clearedCookies).toHaveBeenCalledTimes(1);
+    expect(clearContext).toHaveBeenCalledTimes(1);
+
+    errorSpy.mockRestore();
+  });
+});

--- a/tests/e2e/app-router/server-actions.spec.ts
+++ b/tests/e2e/app-router/server-actions.spec.ts
@@ -57,6 +57,35 @@ test.describe("Server Actions", () => {
     await expect(page.locator('[data-testid="like-btn"]')).toBeVisible();
   });
 
+  // Ported from Next.js:
+  // test/e2e/app-dir/actions/app-action-progressive-enhancement.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/actions/app-action-progressive-enhancement.test.ts
+  test("server action formData redirect works without JavaScript", async ({ browser }) => {
+    let actionResponseStatus: number | undefined;
+    const context = await browser.newContext({ javaScriptEnabled: false });
+    const page = await context.newPage();
+    page.on("response", (response) => {
+      const url = new URL(response.url());
+      if (url.pathname === "/nextjs-compat/action-progressive") {
+        actionResponseStatus = response.status();
+      }
+    });
+
+    try {
+      await page.goto(`${BASE}/nextjs-compat/action-progressive`);
+      await page.fill("#name", "test");
+      await page.click("#submit");
+
+      await expect(page).toHaveURL(
+        `${BASE}/nextjs-compat/action-progressive/result?name=test&hidden-info=hi`,
+      );
+      await expect(page.locator("h1")).toHaveText("Action Progressive Result");
+      expect(actionResponseStatus).toBe(303);
+    } finally {
+      await context.close();
+    }
+  });
+
   test("server action with redirect() navigates to target page", async ({ page }) => {
     await page.goto(`${BASE}/action-redirect-test`);
     await expect(page.locator("h1")).toHaveText("Action Redirect Test");

--- a/tests/fixtures/app-basic/app/nextjs-compat/action-progressive/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/action-progressive/page.tsx
@@ -1,0 +1,33 @@
+import { redirect } from "next/navigation";
+
+async function submitAction(formData: FormData): Promise<void> {
+  "use server";
+
+  const params = new URLSearchParams();
+  const name = formData.get("name");
+  const hiddenInfo = formData.get("hidden-info");
+
+  if (typeof name === "string") {
+    params.set("name", name);
+  }
+  if (typeof hiddenInfo === "string") {
+    params.set("hidden-info", hiddenInfo);
+  }
+
+  redirect(`/nextjs-compat/action-progressive/result?${params.toString()}`);
+}
+
+export default function ActionProgressivePage() {
+  return (
+    <main>
+      <h1>Action Progressive Enhancement</h1>
+      <form action={submitAction}>
+        <input type="hidden" name="hidden-info" value="hi" />
+        <input id="name" name="name" required />
+        <button id="submit" type="submit">
+          Submit
+        </button>
+      </form>
+    </main>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/action-progressive/result/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/action-progressive/result/page.tsx
@@ -1,0 +1,18 @@
+type ResultPageProps = {
+  searchParams: Promise<{
+    name?: string;
+    "hidden-info"?: string;
+  }>;
+};
+
+export default async function ActionProgressiveResultPage({ searchParams }: ResultPageProps) {
+  const params = await searchParams;
+
+  return (
+    <main>
+      <h1>Action Progressive Result</h1>
+      <p id="name">{params.name}</p>
+      <p id="hidden-info">{params["hidden-info"]}</p>
+    </main>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/api/post-form-permanent-redirect/route.ts
+++ b/tests/fixtures/app-basic/app/nextjs-compat/api/post-form-permanent-redirect/route.ts
@@ -1,0 +1,5 @@
+import { permanentRedirect } from "next/navigation";
+
+export function POST(): void {
+  permanentRedirect("/nextjs-compat/route-handler-redirects?success=true");
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/api/post-form-redirect/route.ts
+++ b/tests/fixtures/app-basic/app/nextjs-compat/api/post-form-redirect/route.ts
@@ -1,0 +1,9 @@
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+
+export async function POST(): Promise<void> {
+  const cookieStore = await cookies();
+  cookieStore.set("route-redirect", "preserved", { path: "/" });
+
+  redirect("/nextjs-compat/route-handler-redirects?success=true");
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/route-handler-redirects/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/route-handler-redirects/page.tsx
@@ -1,0 +1,7 @@
+export default function RouteHandlerRedirectsPage() {
+  return (
+    <main>
+      <h1>Route Handler Redirects</h1>
+    </main>
+  );
+}

--- a/tests/nextjs-compat/app-routes.test.ts
+++ b/tests/nextjs-compat/app-routes.test.ts
@@ -232,6 +232,41 @@ describe("Next.js compat: app-routes", () => {
     expect(res.headers.get("location")).toContain("/about");
   });
 
+  // Ported from Next.js:
+  // test/e2e/app-dir/actions/app-action.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/actions/app-action.test.ts
+  it("POST form route handler redirect() produces 303", async () => {
+    const res = await fetch(`${baseUrl}/nextjs-compat/api/post-form-redirect`, {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: "",
+      redirect: "manual",
+    });
+
+    expect(res.status).toBe(303);
+    expect(res.headers.get("location")).toContain(
+      "/nextjs-compat/route-handler-redirects?success=true",
+    );
+    expect(res.headers.get("set-cookie")).toContain("route-redirect=preserved");
+  });
+
+  // Ported from Next.js:
+  // test/e2e/app-dir/actions/app-action.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/actions/app-action.test.ts
+  it("POST form route handler permanentRedirect() produces 303", async () => {
+    const res = await fetch(`${baseUrl}/nextjs-compat/api/post-form-permanent-redirect`, {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: "",
+      redirect: "manual",
+    });
+
+    expect(res.status).toBe(303);
+    expect(res.headers.get("location")).toContain(
+      "/nextjs-compat/route-handler-redirects?success=true",
+    );
+  });
+
   // ── notFound() in route handlers ─────────────────────────────
   // Next.js: 'can respond correctly in nodejs' (notFound)
   // Source: https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/app-routes/app-custom-routes.test.ts#L186-L191


### PR DESCRIPTION
## What changed

- Treat no-JS multipart App Router server action form submissions as possible MPA server actions, decode them with React's `decodeAction`, and return a real HTTP 303 redirect when the action calls `redirect()`.
- Classify app route-handler POST form submissions as action-like for redirect handling, so `redirect()` and `permanentRedirect()` return 303 instead of replay-prone 307/308 semantics.
- Preserve pending `cookies()` / draft-mode cookies when a route handler throws a redirect, matching Next.js app-route behavior.
- Add Next.js-compat fixtures and tests for no-JS server action redirects and POST form route-handler redirects.

## Why

Browser form submissions without JavaScript send `multipart/form-data` and no RSC action header. The previous implementation only handled POSTs with `x-rsc-action`, so progressive-enhancement server action forms fell through to a normal render and the action was silently skipped.

For route handlers, `redirect()` encodes 307/308 in the digest, but Next.js overrides action-like POST redirects to 303 so the browser follows with GET instead of resubmitting the original POST.

## Next.js references

- [`getServerActionRequestMetadata()`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/server-action-request-meta.ts): marks POST `multipart/form-data`, POST `application/x-www-form-urlencoded`, and POST action-header requests as possible server actions.
- [`action-handler.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/action-handler.ts): multipart non-fetch actions call `decodeAction(formData, serverModuleMap)` and return through the full-page render path for progressive enhancement.
- [`app-route/module.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/route-modules/app-route/module.ts): app route redirects return `RedirectStatusCode.SeeOther` when `actionStore.isAction` is true, and append mutable cookies to the redirect response.
- [`app-action-progressive-enhancement.test.ts`](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/actions/app-action-progressive-enhancement.test.ts): verifies formData + redirect without JavaScript returns 303 and navigates.
- [`app-action.test.ts`](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/actions/app-action.test.ts): verifies POST route-handler `redirect()` / `permanentRedirect()` flows use 303.

## Validation

- `vp check`
- `vp test run tests/app-route-handler-policy.test.ts`
- `vp test run tests/nextjs-compat/app-routes.test.ts`
- `vp test run tests/app-router.test.ts -t "server action"`
- `vp test run tests/entry-templates.test.ts`
- `vp run vinext#build`
- `PLAYWRIGHT_PROJECT=app-router vp exec playwright test tests/e2e/app-router/server-actions.spec.ts`

Note: the local pre-commit hook failed in this worktree during Vitest suite initialization before running assertions (`Cannot read properties of undefined (reading 'config')`). The same snapshot update/test command passes when run directly through `vp`, and the updated snapshot is committed.
