### PR TITLE
fix(app-router): surface Error.cause in dev-server error output

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -1311,12 +1311,17 @@ export default async function handler(request, ctx) {
     try {
       response = await _handleRequest(request, __reqCtx, _mwCtx);
     } catch (err) {
-      // Embed err.cause chain into err.message/err.stack so single-pass
-      // formatters upstream (Vite's dev-server "Internal server error:" logger
-      // builds output from message + stack only) reveal the underlying root
-      // cause (ECONNREFUSED, role missing, workerd socket error, etc.) instead
-      // of dropping it. Idempotent and a no-op when cause is absent.
-      __flattenErrorCauses(err);
+      // Dev only: embed err.cause chain into err.message/err.stack so Vite's
+      // dev-server "Internal server error:" logger (which builds output from
+      // message + stack only) reveals the underlying root cause (ECONNREFUSED,
+      // role missing, workerd socket error, etc.) instead of dropping it.
+      // Skipped in production because Node's util.inspect / workerd's logger
+      // already render .cause natively, so flattening would double-print it.
+      // NODE_ENV is build-time-replaced by Vite, so the prod bundle compiles
+      // this branch out entirely.
+      if (process.env.NODE_ENV !== "production") {
+        __flattenErrorCauses(err);
+      }
       throw err;
     }
     // Apply custom headers from next.config.js to non-redirect responses.

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -74,6 +74,7 @@ const appRouteHandlerResponsePath = resolveEntryPath(
 );
 const routeTriePath = resolveEntryPath("../routing/route-trie.js", import.meta.url);
 const metadataRoutesPath = resolveEntryPath("../server/metadata-routes.js", import.meta.url);
+const errorCausePath = resolveEntryPath("../utils/error-cause.js", import.meta.url);
 
 /**
  * Resolved config options relevant to App Router request handling.
@@ -430,6 +431,7 @@ import { buildRouteTrie as _buildRouteTrie, trieMatch as _trieMatch } from ${JSO
 import "vinext/navigation-state";
 import { runWithRequestContext as _runWithUnifiedCtx, createRequestContext as _createUnifiedCtx } from "vinext/unified-request-context";
 import { reportRequestError as _reportRequestError } from "vinext/instrumentation";
+import { flattenErrorCauses as __flattenErrorCauses } from ${JSON.stringify(errorCausePath)};
 import { getSSRFontLinks as _getSSRFontLinks, getSSRFontStyles as _getSSRFontStylesGoogle, getSSRFontPreloads as _getSSRFontPreloadsGoogle } from "next/font/google";
 import { getSSRFontStyles as _getSSRFontStylesLocal, getSSRFontPreloads as _getSSRFontPreloadsLocal } from "next/font/local";
 function _getSSRFontStyles() { return [..._getSSRFontStylesGoogle(), ..._getSSRFontStylesLocal()]; }
@@ -1305,7 +1307,18 @@ export default async function handler(request, ctx) {
     // _handleRequest which fills in .headers and .status;
     // avoids module-level variables that race on Workers.
     const _mwCtx = { headers: null, requestHeaders: null, status: null };
-    const response = await _handleRequest(request, __reqCtx, _mwCtx);
+    let response;
+    try {
+      response = await _handleRequest(request, __reqCtx, _mwCtx);
+    } catch (err) {
+      // Embed err.cause chain into err.message/err.stack so single-pass
+      // formatters upstream (Vite's dev-server "Internal server error:" logger
+      // builds output from message + stack only) reveal the underlying root
+      // cause (ECONNREFUSED, role missing, workerd socket error, etc.) instead
+      // of dropping it. Idempotent and a no-op when cause is absent.
+      __flattenErrorCauses(err);
+      throw err;
+    }
     // Apply custom headers from next.config.js to non-redirect responses.
     // Skip redirects (3xx) because Response.redirect() creates immutable headers,
     // and Next.js doesn't apply custom headers to redirects anyway.

--- a/packages/vinext/src/utils/error-cause.ts
+++ b/packages/vinext/src/utils/error-cause.ts
@@ -8,14 +8,20 @@
  * shows up in the Vite dev console as just "Failed query" — the actual
  * ECONNREFUSED / role-missing / socket-error in `.cause` is lost.
  *
- * - Idempotent (marked via a non-enumerable symbol so repeat calls are no-ops,
- *   and so `util.inspect` output is unaffected — no doubled cause rendering
- *   in Node's default error logging).
+ * Intended for **dev-server use only**. Production loggers (Node's
+ * `console.error` → `util.inspect`, workerd's runtime logger) already render
+ * `.cause` natively, so calling this in prod would double-print the cause —
+ * once in the synthesized message, once in util.inspect's `[cause]:` block.
+ * Callers should gate on `process.env.NODE_ENV !== "production"` (Vite
+ * build-time-replaces this, so the prod bundle gets a no-op).
+ *
+ * - Best-effort: never throws. Frozen / non-extensible errors are left untouched.
+ * - Idempotent (repeat calls are no-ops via a non-enumerable module-private symbol).
  * - Cycle-safe and depth-capped (10) for pathological cause graphs.
  * - Cause stack frames are appended as `at` lines so stack-cleaning regexes
  *   like Vite's `/^\s*at/` filter preserve them.
  */
-const FLATTENED_MARKER = Symbol.for("vinext.errorCausesFlattened");
+const FLATTENED_MARKER = Symbol("vinext.errorCausesFlattened");
 const MAX_CAUSE_DEPTH = 10;
 
 function stringifyNonError(value: unknown): string {
@@ -35,12 +41,20 @@ export function flattenErrorCauses(err: unknown): void {
   if (!(err instanceof Error)) return;
   const marked = err as Error & { [FLATTENED_MARKER]?: true };
   if (marked[FLATTENED_MARKER]) return;
-  Object.defineProperty(marked, FLATTENED_MARKER, {
-    value: true,
-    enumerable: false,
-    configurable: false,
-    writable: false,
-  });
+  // defineProperty throws on frozen errors; mutations below also throw.
+  // Wrap each step so this function honours its "never throw" contract —
+  // a thrown TypeError here would propagate from the caller's catch block
+  // and replace the user's real error with our enrichment failure.
+  try {
+    Object.defineProperty(marked, FLATTENED_MARKER, {
+      value: true,
+      enumerable: false,
+      configurable: false,
+      writable: false,
+    });
+  } catch {
+    return;
+  }
 
   const seen = new WeakSet<object>([err]);
   const causes: Array<{ message: string; stack?: string }> = [];
@@ -63,7 +77,13 @@ export function flattenErrorCauses(err: unknown): void {
   if (causes.length === 0) return;
 
   const messageSuffix = causes.map((c) => `  [cause]: ${c.message}`).join("\n");
-  err.message = `${err.message}\n${messageSuffix}`;
+  try {
+    err.message = `${err.message}\n${messageSuffix}`;
+  } catch {
+    // Frozen / non-writable .message — leave the rest untouched too,
+    // since a partial write would be misleading.
+    return;
+  }
 
   if (typeof err.stack === "string") {
     let stackSuffix = "";
@@ -78,6 +98,10 @@ export function flattenErrorCauses(err: unknown): void {
         if (frames) stackSuffix += `\n${frames}`;
       }
     }
-    err.stack = `${err.stack}${stackSuffix}`;
+    try {
+      err.stack = `${err.stack}${stackSuffix}`;
+    } catch {
+      // Stack is read-only on some hosts; message enrichment still holds.
+    }
   }
 }

--- a/packages/vinext/src/utils/error-cause.ts
+++ b/packages/vinext/src/utils/error-cause.ts
@@ -1,0 +1,83 @@
+/**
+ * Embed an Error's `.cause` chain into its own `.message` and `.stack` so
+ * single-pass formatters (Vite's "Internal server error: ${err.message}\n${err.stack}"
+ * dev-server logger, anything that just prints message + stack) reveal the
+ * underlying root cause instead of silently dropping it.
+ *
+ * Without this, a wrapper like `new Error("Failed query", { cause: pgError })`
+ * shows up in the Vite dev console as just "Failed query" — the actual
+ * ECONNREFUSED / role-missing / socket-error in `.cause` is lost.
+ *
+ * - Idempotent (marked via a non-enumerable symbol so repeat calls are no-ops,
+ *   and so `util.inspect` output is unaffected — no doubled cause rendering
+ *   in Node's default error logging).
+ * - Cycle-safe and depth-capped (10) for pathological cause graphs.
+ * - Cause stack frames are appended as `at` lines so stack-cleaning regexes
+ *   like Vite's `/^\s*at/` filter preserve them.
+ */
+const FLATTENED_MARKER = Symbol.for("vinext.errorCausesFlattened");
+const MAX_CAUSE_DEPTH = 10;
+
+function stringifyNonError(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
+    return String(value);
+  }
+  if (value === null || value === undefined) return String(value);
+  try {
+    return JSON.stringify(value) ?? Object.prototype.toString.call(value);
+  } catch {
+    return Object.prototype.toString.call(value);
+  }
+}
+
+export function flattenErrorCauses(err: unknown): void {
+  if (!(err instanceof Error)) return;
+  const marked = err as Error & { [FLATTENED_MARKER]?: true };
+  if (marked[FLATTENED_MARKER]) return;
+  Object.defineProperty(marked, FLATTENED_MARKER, {
+    value: true,
+    enumerable: false,
+    configurable: false,
+    writable: false,
+  });
+
+  const seen = new WeakSet<object>([err]);
+  const causes: Array<{ message: string; stack?: string }> = [];
+  let cur: unknown = (err as { cause?: unknown }).cause;
+  let depth = 0;
+  while (cur != null && depth < MAX_CAUSE_DEPTH) {
+    if (typeof cur === "object") {
+      if (seen.has(cur as object)) break;
+      seen.add(cur as object);
+    }
+    if (cur instanceof Error) {
+      causes.push({ message: cur.message, stack: cur.stack });
+      cur = (cur as { cause?: unknown }).cause;
+    } else {
+      causes.push({ message: stringifyNonError(cur) });
+      cur = null;
+    }
+    depth++;
+  }
+  if (causes.length === 0) return;
+
+  const messageSuffix = causes.map((c) => `  [cause]: ${c.message}`).join("\n");
+  err.message = `${err.message}\n${messageSuffix}`;
+
+  if (typeof err.stack === "string") {
+    let stackSuffix = "";
+    for (const c of causes) {
+      const headline = c.message.split("\n", 1)[0];
+      stackSuffix += `\n    at [cause: ${headline}]`;
+      if (c.stack) {
+        const frames = c.stack
+          .split("\n")
+          .filter((l) => /^\s*at\s/.test(l))
+          .join("\n");
+        if (frames) stackSuffix += `\n${frames}`;
+      }
+    }
+    err.stack = `${err.stack}${stackSuffix}`;
+  }
+}

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -1224,12 +1224,17 @@ export default async function handler(request, ctx) {
     try {
       response = await _handleRequest(request, __reqCtx, _mwCtx);
     } catch (err) {
-      // Embed err.cause chain into err.message/err.stack so single-pass
-      // formatters upstream (Vite's dev-server "Internal server error:" logger
-      // builds output from message + stack only) reveal the underlying root
-      // cause (ECONNREFUSED, role missing, workerd socket error, etc.) instead
-      // of dropping it. Idempotent and a no-op when cause is absent.
-      __flattenErrorCauses(err);
+      // Dev only: embed err.cause chain into err.message/err.stack so Vite's
+      // dev-server "Internal server error:" logger (which builds output from
+      // message + stack only) reveals the underlying root cause (ECONNREFUSED,
+      // role missing, workerd socket error, etc.) instead of dropping it.
+      // Skipped in production because Node's util.inspect / workerd's logger
+      // already render .cause natively, so flattening would double-print it.
+      // NODE_ENV is build-time-replaced by Vite, so the prod bundle compiles
+      // this branch out entirely.
+      if (process.env.NODE_ENV !== "production") {
+        __flattenErrorCauses(err);
+      }
       throw err;
     }
     // Apply custom headers from next.config.js to non-redirect responses.
@@ -3580,12 +3585,17 @@ export default async function handler(request, ctx) {
     try {
       response = await _handleRequest(request, __reqCtx, _mwCtx);
     } catch (err) {
-      // Embed err.cause chain into err.message/err.stack so single-pass
-      // formatters upstream (Vite's dev-server "Internal server error:" logger
-      // builds output from message + stack only) reveal the underlying root
-      // cause (ECONNREFUSED, role missing, workerd socket error, etc.) instead
-      // of dropping it. Idempotent and a no-op when cause is absent.
-      __flattenErrorCauses(err);
+      // Dev only: embed err.cause chain into err.message/err.stack so Vite's
+      // dev-server "Internal server error:" logger (which builds output from
+      // message + stack only) reveals the underlying root cause (ECONNREFUSED,
+      // role missing, workerd socket error, etc.) instead of dropping it.
+      // Skipped in production because Node's util.inspect / workerd's logger
+      // already render .cause natively, so flattening would double-print it.
+      // NODE_ENV is build-time-replaced by Vite, so the prod bundle compiles
+      // this branch out entirely.
+      if (process.env.NODE_ENV !== "production") {
+        __flattenErrorCauses(err);
+      }
       throw err;
     }
     // Apply custom headers from next.config.js to non-redirect responses.
@@ -5943,12 +5953,17 @@ export default async function handler(request, ctx) {
     try {
       response = await _handleRequest(request, __reqCtx, _mwCtx);
     } catch (err) {
-      // Embed err.cause chain into err.message/err.stack so single-pass
-      // formatters upstream (Vite's dev-server "Internal server error:" logger
-      // builds output from message + stack only) reveal the underlying root
-      // cause (ECONNREFUSED, role missing, workerd socket error, etc.) instead
-      // of dropping it. Idempotent and a no-op when cause is absent.
-      __flattenErrorCauses(err);
+      // Dev only: embed err.cause chain into err.message/err.stack so Vite's
+      // dev-server "Internal server error:" logger (which builds output from
+      // message + stack only) reveals the underlying root cause (ECONNREFUSED,
+      // role missing, workerd socket error, etc.) instead of dropping it.
+      // Skipped in production because Node's util.inspect / workerd's logger
+      // already render .cause natively, so flattening would double-print it.
+      // NODE_ENV is build-time-replaced by Vite, so the prod bundle compiles
+      // this branch out entirely.
+      if (process.env.NODE_ENV !== "production") {
+        __flattenErrorCauses(err);
+      }
       throw err;
     }
     // Apply custom headers from next.config.js to non-redirect responses.
@@ -8332,12 +8347,17 @@ export default async function handler(request, ctx) {
     try {
       response = await _handleRequest(request, __reqCtx, _mwCtx);
     } catch (err) {
-      // Embed err.cause chain into err.message/err.stack so single-pass
-      // formatters upstream (Vite's dev-server "Internal server error:" logger
-      // builds output from message + stack only) reveal the underlying root
-      // cause (ECONNREFUSED, role missing, workerd socket error, etc.) instead
-      // of dropping it. Idempotent and a no-op when cause is absent.
-      __flattenErrorCauses(err);
+      // Dev only: embed err.cause chain into err.message/err.stack so Vite's
+      // dev-server "Internal server error:" logger (which builds output from
+      // message + stack only) reveals the underlying root cause (ECONNREFUSED,
+      // role missing, workerd socket error, etc.) instead of dropping it.
+      // Skipped in production because Node's util.inspect / workerd's logger
+      // already render .cause natively, so flattening would double-print it.
+      // NODE_ENV is build-time-replaced by Vite, so the prod bundle compiles
+      // this branch out entirely.
+      if (process.env.NODE_ENV !== "production") {
+        __flattenErrorCauses(err);
+      }
       throw err;
     }
     // Apply custom headers from next.config.js to non-redirect responses.
@@ -10695,12 +10715,17 @@ export default async function handler(request, ctx) {
     try {
       response = await _handleRequest(request, __reqCtx, _mwCtx);
     } catch (err) {
-      // Embed err.cause chain into err.message/err.stack so single-pass
-      // formatters upstream (Vite's dev-server "Internal server error:" logger
-      // builds output from message + stack only) reveal the underlying root
-      // cause (ECONNREFUSED, role missing, workerd socket error, etc.) instead
-      // of dropping it. Idempotent and a no-op when cause is absent.
-      __flattenErrorCauses(err);
+      // Dev only: embed err.cause chain into err.message/err.stack so Vite's
+      // dev-server "Internal server error:" logger (which builds output from
+      // message + stack only) reveals the underlying root cause (ECONNREFUSED,
+      // role missing, workerd socket error, etc.) instead of dropping it.
+      // Skipped in production because Node's util.inspect / workerd's logger
+      // already render .cause natively, so flattening would double-print it.
+      // NODE_ENV is build-time-replaced by Vite, so the prod bundle compiles
+      // this branch out entirely.
+      if (process.env.NODE_ENV !== "production") {
+        __flattenErrorCauses(err);
+      }
       throw err;
     }
     // Apply custom headers from next.config.js to non-redirect responses.
@@ -13280,12 +13305,17 @@ export default async function handler(request, ctx) {
     try {
       response = await _handleRequest(request, __reqCtx, _mwCtx);
     } catch (err) {
-      // Embed err.cause chain into err.message/err.stack so single-pass
-      // formatters upstream (Vite's dev-server "Internal server error:" logger
-      // builds output from message + stack only) reveal the underlying root
-      // cause (ECONNREFUSED, role missing, workerd socket error, etc.) instead
-      // of dropping it. Idempotent and a no-op when cause is absent.
-      __flattenErrorCauses(err);
+      // Dev only: embed err.cause chain into err.message/err.stack so Vite's
+      // dev-server "Internal server error:" logger (which builds output from
+      // message + stack only) reveals the underlying root cause (ECONNREFUSED,
+      // role missing, workerd socket error, etc.) instead of dropping it.
+      // Skipped in production because Node's util.inspect / workerd's logger
+      // already render .cause natively, so flattening would double-print it.
+      // NODE_ENV is build-time-replaced by Vite, so the prod bundle compiles
+      // this branch out entirely.
+      if (process.env.NODE_ENV !== "production") {
+        __flattenErrorCauses(err);
+      }
       throw err;
     }
     // Apply custom headers from next.config.js to non-redirect responses.

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -111,6 +111,7 @@ import { buildRouteTrie as _buildRouteTrie, trieMatch as _trieMatch } from "<ROO
 import "vinext/navigation-state";
 import { runWithRequestContext as _runWithUnifiedCtx, createRequestContext as _createUnifiedCtx } from "vinext/unified-request-context";
 import { reportRequestError as _reportRequestError } from "vinext/instrumentation";
+import { flattenErrorCauses as __flattenErrorCauses } from "<ROOT>/packages/vinext/src/utils/error-cause.js";
 import { getSSRFontLinks as _getSSRFontLinks, getSSRFontStyles as _getSSRFontStylesGoogle, getSSRFontPreloads as _getSSRFontPreloadsGoogle } from "next/font/google";
 import { getSSRFontStyles as _getSSRFontStylesLocal, getSSRFontPreloads as _getSSRFontPreloadsLocal } from "next/font/local";
 function _getSSRFontStyles() { return [..._getSSRFontStylesGoogle(), ..._getSSRFontStylesLocal()]; }
@@ -1219,7 +1220,18 @@ export default async function handler(request, ctx) {
     // _handleRequest which fills in .headers and .status;
     // avoids module-level variables that race on Workers.
     const _mwCtx = { headers: null, requestHeaders: null, status: null };
-    const response = await _handleRequest(request, __reqCtx, _mwCtx);
+    let response;
+    try {
+      response = await _handleRequest(request, __reqCtx, _mwCtx);
+    } catch (err) {
+      // Embed err.cause chain into err.message/err.stack so single-pass
+      // formatters upstream (Vite's dev-server "Internal server error:" logger
+      // builds output from message + stack only) reveal the underlying root
+      // cause (ECONNREFUSED, role missing, workerd socket error, etc.) instead
+      // of dropping it. Idempotent and a no-op when cause is absent.
+      __flattenErrorCauses(err);
+      throw err;
+    }
     // Apply custom headers from next.config.js to non-redirect responses.
     // Skip redirects (3xx) because Response.redirect() creates immutable headers,
     // and Next.js doesn't apply custom headers to redirects anyway.
@@ -2455,6 +2467,7 @@ import { buildRouteTrie as _buildRouteTrie, trieMatch as _trieMatch } from "<ROO
 import "vinext/navigation-state";
 import { runWithRequestContext as _runWithUnifiedCtx, createRequestContext as _createUnifiedCtx } from "vinext/unified-request-context";
 import { reportRequestError as _reportRequestError } from "vinext/instrumentation";
+import { flattenErrorCauses as __flattenErrorCauses } from "<ROOT>/packages/vinext/src/utils/error-cause.js";
 import { getSSRFontLinks as _getSSRFontLinks, getSSRFontStyles as _getSSRFontStylesGoogle, getSSRFontPreloads as _getSSRFontPreloadsGoogle } from "next/font/google";
 import { getSSRFontStyles as _getSSRFontStylesLocal, getSSRFontPreloads as _getSSRFontPreloadsLocal } from "next/font/local";
 function _getSSRFontStyles() { return [..._getSSRFontStylesGoogle(), ..._getSSRFontStylesLocal()]; }
@@ -3563,7 +3576,18 @@ export default async function handler(request, ctx) {
     // _handleRequest which fills in .headers and .status;
     // avoids module-level variables that race on Workers.
     const _mwCtx = { headers: null, requestHeaders: null, status: null };
-    const response = await _handleRequest(request, __reqCtx, _mwCtx);
+    let response;
+    try {
+      response = await _handleRequest(request, __reqCtx, _mwCtx);
+    } catch (err) {
+      // Embed err.cause chain into err.message/err.stack so single-pass
+      // formatters upstream (Vite's dev-server "Internal server error:" logger
+      // builds output from message + stack only) reveal the underlying root
+      // cause (ECONNREFUSED, role missing, workerd socket error, etc.) instead
+      // of dropping it. Idempotent and a no-op when cause is absent.
+      __flattenErrorCauses(err);
+      throw err;
+    }
     // Apply custom headers from next.config.js to non-redirect responses.
     // Skip redirects (3xx) because Response.redirect() creates immutable headers,
     // and Next.js doesn't apply custom headers to redirects anyway.
@@ -4805,6 +4829,7 @@ import { buildRouteTrie as _buildRouteTrie, trieMatch as _trieMatch } from "<ROO
 import "vinext/navigation-state";
 import { runWithRequestContext as _runWithUnifiedCtx, createRequestContext as _createUnifiedCtx } from "vinext/unified-request-context";
 import { reportRequestError as _reportRequestError } from "vinext/instrumentation";
+import { flattenErrorCauses as __flattenErrorCauses } from "<ROOT>/packages/vinext/src/utils/error-cause.js";
 import { getSSRFontLinks as _getSSRFontLinks, getSSRFontStyles as _getSSRFontStylesGoogle, getSSRFontPreloads as _getSSRFontPreloadsGoogle } from "next/font/google";
 import { getSSRFontStyles as _getSSRFontStylesLocal, getSSRFontPreloads as _getSSRFontPreloadsLocal } from "next/font/local";
 function _getSSRFontStyles() { return [..._getSSRFontStylesGoogle(), ..._getSSRFontStylesLocal()]; }
@@ -5914,7 +5939,18 @@ export default async function handler(request, ctx) {
     // _handleRequest which fills in .headers and .status;
     // avoids module-level variables that race on Workers.
     const _mwCtx = { headers: null, requestHeaders: null, status: null };
-    const response = await _handleRequest(request, __reqCtx, _mwCtx);
+    let response;
+    try {
+      response = await _handleRequest(request, __reqCtx, _mwCtx);
+    } catch (err) {
+      // Embed err.cause chain into err.message/err.stack so single-pass
+      // formatters upstream (Vite's dev-server "Internal server error:" logger
+      // builds output from message + stack only) reveal the underlying root
+      // cause (ECONNREFUSED, role missing, workerd socket error, etc.) instead
+      // of dropping it. Idempotent and a no-op when cause is absent.
+      __flattenErrorCauses(err);
+      throw err;
+    }
     // Apply custom headers from next.config.js to non-redirect responses.
     // Skip redirects (3xx) because Response.redirect() creates immutable headers,
     // and Next.js doesn't apply custom headers to redirects anyway.
@@ -7150,6 +7186,7 @@ import { buildRouteTrie as _buildRouteTrie, trieMatch as _trieMatch } from "<ROO
 import "vinext/navigation-state";
 import { runWithRequestContext as _runWithUnifiedCtx, createRequestContext as _createUnifiedCtx } from "vinext/unified-request-context";
 import { reportRequestError as _reportRequestError } from "vinext/instrumentation";
+import { flattenErrorCauses as __flattenErrorCauses } from "<ROOT>/packages/vinext/src/utils/error-cause.js";
 import { getSSRFontLinks as _getSSRFontLinks, getSSRFontStyles as _getSSRFontStylesGoogle, getSSRFontPreloads as _getSSRFontPreloadsGoogle } from "next/font/google";
 import { getSSRFontStyles as _getSSRFontStylesLocal, getSSRFontPreloads as _getSSRFontPreloadsLocal } from "next/font/local";
 function _getSSRFontStyles() { return [..._getSSRFontStylesGoogle(), ..._getSSRFontStylesLocal()]; }
@@ -8291,7 +8328,18 @@ export default async function handler(request, ctx) {
     // _handleRequest which fills in .headers and .status;
     // avoids module-level variables that race on Workers.
     const _mwCtx = { headers: null, requestHeaders: null, status: null };
-    const response = await _handleRequest(request, __reqCtx, _mwCtx);
+    let response;
+    try {
+      response = await _handleRequest(request, __reqCtx, _mwCtx);
+    } catch (err) {
+      // Embed err.cause chain into err.message/err.stack so single-pass
+      // formatters upstream (Vite's dev-server "Internal server error:" logger
+      // builds output from message + stack only) reveal the underlying root
+      // cause (ECONNREFUSED, role missing, workerd socket error, etc.) instead
+      // of dropping it. Idempotent and a no-op when cause is absent.
+      __flattenErrorCauses(err);
+      throw err;
+    }
     // Apply custom headers from next.config.js to non-redirect responses.
     // Skip redirects (3xx) because Response.redirect() creates immutable headers,
     // and Next.js doesn't apply custom headers to redirects anyway.
@@ -9527,6 +9575,7 @@ import { buildRouteTrie as _buildRouteTrie, trieMatch as _trieMatch } from "<ROO
 import "vinext/navigation-state";
 import { runWithRequestContext as _runWithUnifiedCtx, createRequestContext as _createUnifiedCtx } from "vinext/unified-request-context";
 import { reportRequestError as _reportRequestError } from "vinext/instrumentation";
+import { flattenErrorCauses as __flattenErrorCauses } from "<ROOT>/packages/vinext/src/utils/error-cause.js";
 import { getSSRFontLinks as _getSSRFontLinks, getSSRFontStyles as _getSSRFontStylesGoogle, getSSRFontPreloads as _getSSRFontPreloadsGoogle } from "next/font/google";
 import { getSSRFontStyles as _getSSRFontStylesLocal, getSSRFontPreloads as _getSSRFontPreloadsLocal } from "next/font/local";
 function _getSSRFontStyles() { return [..._getSSRFontStylesGoogle(), ..._getSSRFontStylesLocal()]; }
@@ -10642,7 +10691,18 @@ export default async function handler(request, ctx) {
     // _handleRequest which fills in .headers and .status;
     // avoids module-level variables that race on Workers.
     const _mwCtx = { headers: null, requestHeaders: null, status: null };
-    const response = await _handleRequest(request, __reqCtx, _mwCtx);
+    let response;
+    try {
+      response = await _handleRequest(request, __reqCtx, _mwCtx);
+    } catch (err) {
+      // Embed err.cause chain into err.message/err.stack so single-pass
+      // formatters upstream (Vite's dev-server "Internal server error:" logger
+      // builds output from message + stack only) reveal the underlying root
+      // cause (ECONNREFUSED, role missing, workerd socket error, etc.) instead
+      // of dropping it. Idempotent and a no-op when cause is absent.
+      __flattenErrorCauses(err);
+      throw err;
+    }
     // Apply custom headers from next.config.js to non-redirect responses.
     // Skip redirects (3xx) because Response.redirect() creates immutable headers,
     // and Next.js doesn't apply custom headers to redirects anyway.
@@ -11878,6 +11938,7 @@ import { buildRouteTrie as _buildRouteTrie, trieMatch as _trieMatch } from "<ROO
 import "vinext/navigation-state";
 import { runWithRequestContext as _runWithUnifiedCtx, createRequestContext as _createUnifiedCtx } from "vinext/unified-request-context";
 import { reportRequestError as _reportRequestError } from "vinext/instrumentation";
+import { flattenErrorCauses as __flattenErrorCauses } from "<ROOT>/packages/vinext/src/utils/error-cause.js";
 import { getSSRFontLinks as _getSSRFontLinks, getSSRFontStyles as _getSSRFontStylesGoogle, getSSRFontPreloads as _getSSRFontPreloadsGoogle } from "next/font/google";
 import { getSSRFontStyles as _getSSRFontStylesLocal, getSSRFontPreloads as _getSSRFontPreloadsLocal } from "next/font/local";
 function _getSSRFontStyles() { return [..._getSSRFontStylesGoogle(), ..._getSSRFontStylesLocal()]; }
@@ -13215,7 +13276,18 @@ export default async function handler(request, ctx) {
     // _handleRequest which fills in .headers and .status;
     // avoids module-level variables that race on Workers.
     const _mwCtx = { headers: null, requestHeaders: null, status: null };
-    const response = await _handleRequest(request, __reqCtx, _mwCtx);
+    let response;
+    try {
+      response = await _handleRequest(request, __reqCtx, _mwCtx);
+    } catch (err) {
+      // Embed err.cause chain into err.message/err.stack so single-pass
+      // formatters upstream (Vite's dev-server "Internal server error:" logger
+      // builds output from message + stack only) reveal the underlying root
+      // cause (ECONNREFUSED, role missing, workerd socket error, etc.) instead
+      // of dropping it. Idempotent and a no-op when cause is absent.
+      __flattenErrorCauses(err);
+      throw err;
+    }
     // Apply custom headers from next.config.js to non-redirect responses.
     // Skip redirects (3xx) because Response.redirect() creates immutable headers,
     // and Next.js doesn't apply custom headers to redirects anyway.

--- a/tests/error-cause.test.ts
+++ b/tests/error-cause.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Repro + regression tests for the silently-dropped `.cause` chain in
+ * single-pass error formatters (Vite's dev-server "Internal server error:"
+ * logger and similar).
+ *
+ * The bug: a wrapper like
+ *   new Error("Failed query: ...", { cause: pgError })
+ * would surface in the dev console as just "Failed query: ..." — the actual
+ * postgres ECONNREFUSED / role-missing / socket error in `.cause` was lost
+ * because Vite's `buildErrorMessage` only reads `.message` and `.stack`.
+ *
+ * The fix: vinext flattens the cause chain into `err.message` and `err.stack`
+ * before the error escapes its handler boundary, so single-pass formatters
+ * surface the root cause.
+ */
+import { describe, it, expect } from "vite-plus/test";
+import { flattenErrorCauses } from "../packages/vinext/src/utils/error-cause.js";
+
+// Mirror Vite's `cleanStack` from
+// vite-plus-core/dist/vite/node/chunks/node.js (~line 7730) — keeps only
+// `at`-prefixed frames. Used here to verify cause stack frames survive that
+// filter when emitted into err.stack.
+function cleanStack(stack: string): string {
+  return stack
+    .split("\n")
+    .filter((l) => /^\s*at/.test(l))
+    .join("\n");
+}
+
+// Mirror Vite's `buildErrorMessage` shape — what the dev-server actually
+// prints. If a cause is present and we don't flatten, the cause is invisible
+// in the rendered output.
+function buildViteLikeMessage(err: Error): string {
+  return `Internal server error: ${err.message}\n${cleanStack(err.stack ?? "")}`;
+}
+
+describe("flattenErrorCauses", () => {
+  it("repro: without flattening, Vite-style formatter drops the cause", () => {
+    const cause = new Error("ECONNREFUSED 127.0.0.1:5432");
+    const wrapped = new Error("Failed query: select ...", { cause });
+
+    const rendered = buildViteLikeMessage(wrapped);
+
+    expect(rendered).toContain("Failed query: select ...");
+    // This is the bug the user reported:
+    expect(rendered).not.toContain("ECONNREFUSED");
+  });
+
+  it("after flattening, the cause message appears in the rendered output", () => {
+    const cause = new Error("ECONNREFUSED 127.0.0.1:5432");
+    const wrapped = new Error("Failed query: select ...", { cause });
+
+    flattenErrorCauses(wrapped);
+    const rendered = buildViteLikeMessage(wrapped);
+
+    expect(rendered).toContain("Failed query: select ...");
+    expect(rendered).toContain("ECONNREFUSED 127.0.0.1:5432");
+    expect(rendered).toContain("[cause]");
+  });
+
+  it("walks a multi-level cause chain", () => {
+    const root = new Error('role "vinext" does not exist');
+    const mid = new Error("connection failed", { cause: root });
+    const top = new Error("Failed query", { cause: mid });
+
+    flattenErrorCauses(top);
+
+    expect(top.message).toContain("Failed query");
+    expect(top.message).toContain("connection failed");
+    expect(top.message).toContain('role "vinext" does not exist');
+  });
+
+  it("preserves cause stack frames as `at` lines so cleanStack keeps them", () => {
+    const cause = new Error("inner");
+    const wrapped = new Error("outer", { cause });
+
+    flattenErrorCauses(wrapped);
+
+    // The marker line itself must start with "    at " so Vite's cleanStack
+    // (which filters to /^\s*at/) doesn't strip it.
+    const cleaned = cleanStack(wrapped.stack ?? "");
+    expect(cleaned).toMatch(/^\s*at \[cause: inner\]/m);
+  });
+
+  it("is idempotent — calling twice does not double-append", () => {
+    const cause = new Error("inner");
+    const wrapped = new Error("outer", { cause });
+
+    flattenErrorCauses(wrapped);
+    const messageAfterFirst = wrapped.message;
+    const stackAfterFirst = wrapped.stack;
+
+    flattenErrorCauses(wrapped);
+    expect(wrapped.message).toBe(messageAfterFirst);
+    expect(wrapped.stack).toBe(stackAfterFirst);
+  });
+
+  it("is a no-op when there is no cause", () => {
+    const err = new Error("plain");
+    const originalMessage = err.message;
+    const originalStack = err.stack;
+
+    flattenErrorCauses(err);
+
+    expect(err.message).toBe(originalMessage);
+    expect(err.stack).toBe(originalStack);
+  });
+
+  it("handles non-Error causes (string, plain object)", () => {
+    const stringCause = new Error("wrap1", { cause: "raw string reason" });
+    flattenErrorCauses(stringCause);
+    expect(stringCause.message).toContain("raw string reason");
+
+    const objectCause = new Error("wrap2", { cause: { code: "ECONNRESET" } });
+    flattenErrorCauses(objectCause);
+    expect(objectCause.message).toContain("ECONNRESET");
+  });
+
+  it("handles cyclic cause graphs without looping forever", () => {
+    const a = new Error("a");
+    const b = new Error("b");
+    (a as { cause?: unknown }).cause = b;
+    (b as { cause?: unknown }).cause = a;
+
+    flattenErrorCauses(a);
+
+    expect(a.message).toContain("a");
+    expect(a.message).toContain("b");
+  });
+
+  it("ignores non-Error inputs gracefully", () => {
+    expect(() => flattenErrorCauses(undefined)).not.toThrow();
+    expect(() => flattenErrorCauses(null)).not.toThrow();
+    expect(() => flattenErrorCauses("oops")).not.toThrow();
+    expect(() => flattenErrorCauses({ message: "fake" })).not.toThrow();
+  });
+
+  it("the flatten marker is non-enumerable so util.inspect output is unaffected", () => {
+    const err = new Error("outer", { cause: new Error("inner") });
+    flattenErrorCauses(err);
+
+    // The marker symbol must not appear in standard property enumeration —
+    // otherwise Node's util.inspect would render it alongside the error,
+    // polluting prod logs that already format causes correctly.
+    const ownKeys = Reflect.ownKeys(err);
+    const markerKeys = ownKeys.filter(
+      (k) => typeof k === "symbol" && k.description === "vinext.errorCausesFlattened",
+    );
+    expect(markerKeys).toHaveLength(1);
+    const desc = Object.getOwnPropertyDescriptor(err, markerKeys[0]);
+    expect(desc?.enumerable).toBe(false);
+  });
+});

--- a/tests/error-cause.test.ts
+++ b/tests/error-cause.test.ts
@@ -14,6 +14,7 @@
  * surface the root cause.
  */
 import { describe, it, expect } from "vite-plus/test";
+import { inspect } from "node:util";
 import { flattenErrorCauses } from "../packages/vinext/src/utils/error-cause.js";
 
 // Mirror Vite's `cleanStack` from
@@ -135,19 +136,31 @@ describe("flattenErrorCauses", () => {
     expect(() => flattenErrorCauses({ message: "fake" })).not.toThrow();
   });
 
-  it("the flatten marker is non-enumerable so util.inspect output is unaffected", () => {
+  it("the flatten marker is invisible to util.inspect (no symbol leak in error output)", () => {
     const err = new Error("outer", { cause: new Error("inner") });
     flattenErrorCauses(err);
 
-    // The marker symbol must not appear in standard property enumeration —
-    // otherwise Node's util.inspect would render it alongside the error,
-    // polluting prod logs that already format causes correctly.
-    const ownKeys = Reflect.ownKeys(err);
-    const markerKeys = ownKeys.filter(
-      (k) => typeof k === "symbol" && k.description === "vinext.errorCausesFlattened",
-    );
-    expect(markerKeys).toHaveLength(1);
-    const desc = Object.getOwnPropertyDescriptor(err, markerKeys[0]);
-    expect(desc?.enumerable).toBe(false);
+    // util.inspect is what console.error uses to render Errors. The marker
+    // must not appear in its output — otherwise prod logs (which call this
+    // function via the gated dev-only branch is fine, but local repros and
+    // tests still inspect flattened errors) would gain a stray
+    // "[Symbol(vinext.errorCausesFlattened)]: true" line.
+    const rendered = inspect(err, { showHidden: false });
+    expect(rendered).not.toContain("vinext.errorCausesFlattened");
+    expect(rendered).not.toContain("Symbol(");
+  });
+
+  it("never throws on a frozen Error — leaves it unmodified rather than masking the original failure", () => {
+    // If user code throws Object.freeze(new Error(...)), defineProperty and
+    // err.message = ... would each throw TypeError. The catch block in the
+    // generated handler would then propagate that TypeError instead of the
+    // user's real error, masking the actual failure during debugging. The
+    // helper's contract is best-effort: never throw.
+    const cause = new Error("inner");
+    const wrapped = new Error("outer", { cause });
+    Object.freeze(wrapped);
+
+    expect(() => flattenErrorCauses(wrapped)).not.toThrow();
+    expect(wrapped.message).toBe("outer");
   });
 });


### PR DESCRIPTION
## Summary

Vite's dev-server "Internal server error:" formatter (`buildErrorMessage` in `vite-plus-core`) builds output from `err.message` and `err.stack` only, silently dropping `err.cause`. A wrapper like `new Error("Failed query", { cause: pgError })` would surface in the dev console as just `Failed query` — the actual `ECONNREFUSED`, role-missing, or workerd socket error in `.cause` was invisible.

This PR adds `flattenErrorCauses(err)`, called at the App Router RSC handler boundary before any error escapes to Vite. It walks the `.cause` chain (depth-capped, cycle-safe) and embeds each cause's message into `err.message` and stack frames into `err.stack` as `at` lines (so they survive Vite's `cleanStack` `/^\s*at/` filter).

### Before
```
[vite+] Internal server error: Failed query: select ...
      at PostgresJsPreparedQuery.queryWithCache ...
```

### After
```
[vite+] Internal server error: Failed query: select ...
  [cause]: ECONNREFUSED 127.0.0.1:5432
      at PostgresJsPreparedQuery.queryWithCache ...
      at [cause: ECONNREFUSED 127.0.0.1:5432]
      at <postgres driver frames>
```

### Notes
- Marked idempotent via a non-enumerable `Symbol.for("vinext.errorCausesFlattened")` so Node's `util.inspect` output (which already shows `.cause` since Node 16.9) is unaffected — no doubled cause rendering in prod logs.
- Pages Router catches errors locally and uses `console.error(err)` → `util.inspect`, which already shows `.cause`, so no change needed there.
- Out of scope: production digest sites (`__sanitizeErrorForClient`, `rscOnError`, `app-ssr-entry`) also exclude cause from their hash input — different errors with different causes can collide on the same digest. Happy to do that as a follow-up if wanted.

## Test plan

- [x] Unit tests for `flattenErrorCauses` in `tests/error-cause.test.ts` — 10 tests including a direct repro that mirrors Vite's formatter and asserts `ECONNREFUSED` is dropped before flattening and surfaced after; plus multi-level chains, idempotency, cyclic graphs, non-Error causes, `null`/`undefined`/string inputs, and marker non-enumerability
- [x] Snapshot updates in `tests/__snapshots__/entry-templates.test.ts.snap` (6 snapshots) reflect the try/catch around `_handleRequest`
- [x] `vp check` passes on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)