### PR TITLE
fix(dev): hoist socket-error backstop to module top-level so lifecycle events can't remove it

### DIFF
--- a/packages/vinext/src/build/prerender.ts
+++ b/packages/vinext/src/build/prerender.ts
@@ -370,6 +370,7 @@ export async function prerenderPages({
 
   const previousHandler = getCacheHandler();
   setCacheHandler(new NoOpCacheHandler());
+  const previousPrerenderFlag = process.env.VINEXT_PRERENDER;
   process.env.VINEXT_PRERENDER = "1";
   // ownedProdServerHandle: a prod server we started ourselves and must close in finally.
   // When the caller passes options._prodServer we use that and do NOT close it.
@@ -642,7 +643,8 @@ export async function prerenderPages({
     return { routes: results };
   } finally {
     setCacheHandler(previousHandler);
-    delete process.env.VINEXT_PRERENDER;
+    if (previousPrerenderFlag === undefined) delete process.env.VINEXT_PRERENDER;
+    else process.env.VINEXT_PRERENDER = previousPrerenderFlag;
     if (ownedProdServerHandle) {
       await new Promise<void>((resolve) => ownedProdServerHandle!.server.close(() => resolve()));
     }
@@ -685,8 +687,12 @@ export async function prerenderApp({
   const previousHandler = getCacheHandler();
   setCacheHandler(new NoOpCacheHandler());
   // VINEXT_PRERENDER=1 tells the prod server to skip instrumentation.register()
-  // and enable prerender-only endpoints (/__vinext/prerender/*).
-  // The set/delete is wrapped in try/finally so it is always restored.
+  // and enable prerender-only endpoints (/__vinext/prerender/*). It also makes
+  // the socket-error backstop (server/socket-error-backstop.ts) re-throw
+  // peer-disconnect errors during prerender. Save the prior value so callers
+  // that already set the flag (run-prerender.ts) aren't clobbered when this
+  // function's finally block restores.
+  const previousPrerenderFlag = process.env.VINEXT_PRERENDER;
   process.env.VINEXT_PRERENDER = "1";
 
   const serverDir = path.dirname(rscBundlePath);
@@ -1113,7 +1119,8 @@ export async function prerenderApp({
     return { routes: results };
   } finally {
     setCacheHandler(previousHandler);
-    delete process.env.VINEXT_PRERENDER;
+    if (previousPrerenderFlag === undefined) delete process.env.VINEXT_PRERENDER;
+    else process.env.VINEXT_PRERENDER = previousPrerenderFlag;
     if (ownedProdServerHandle) {
       await new Promise<void>((resolve) => ownedProdServerHandle!.server.close(() => resolve()));
     }

--- a/packages/vinext/src/build/run-prerender.ts
+++ b/packages/vinext/src/build/run-prerender.ts
@@ -130,6 +130,7 @@ export async function runPrerender(options: RunPrerenderOptions): Promise<Preren
   // sets and clears this var around its own render passes, but we widen
   // the scope here to cover startProdServer / shared-server setup that
   // happens before those phases run. See server/socket-error-backstop.ts.
+  const previousPrerenderFlag = process.env.VINEXT_PRERENDER;
   process.env.VINEXT_PRERENDER = "1";
 
   // The manifest lands in dist/server/ alongside the server bundle so it's
@@ -270,6 +271,8 @@ export async function runPrerender(options: RunPrerenderOptions): Promise<Preren
     if (sharedProdServer) {
       await new Promise<void>((resolve) => sharedProdServer!.server.close(() => resolve()));
     }
+    if (previousPrerenderFlag === undefined) delete process.env.VINEXT_PRERENDER;
+    else process.env.VINEXT_PRERENDER = previousPrerenderFlag;
   }
 
   if (allRoutes.length === 0) {

--- a/packages/vinext/src/build/run-prerender.ts
+++ b/packages/vinext/src/build/run-prerender.ts
@@ -124,6 +124,14 @@ export async function runPrerender(options: RunPrerenderOptions): Promise<Preren
 
   if (!appDir && !pagesDir) return null;
 
+  // Mark the entire prerender orchestration so the socket-error backstop
+  // re-throws peer-disconnect errors during user fetch() calls instead of
+  // silently absorbing them and producing corrupt output. prerender.ts
+  // sets and clears this var around its own render passes, but we widen
+  // the scope here to cover startProdServer / shared-server setup that
+  // happens before those phases run. See server/socket-error-backstop.ts.
+  process.env.VINEXT_PRERENDER = "1";
+
   // The manifest lands in dist/server/ alongside the server bundle so it's
   // cleaned by Vite's emptyOutDir on rebuild and co-located with server artifacts.
   const manifestDir = path.join(root, "dist", "server");

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -118,9 +118,10 @@ import commonjs from "vite-plugin-commonjs";
 // Install the process-level peer-disconnect backstop as soon as this
 // module loads. Vite plugin lifecycle hooks (config / configureServer)
 // proved timing-fragile in vite-plus — install was silently skipped,
-// confirmed via the VINEXT_DEBUG_SOCKET_ERRORS=1 marker. Module-load
-// is the only spot reliably observed to fire. Idempotent and skips in
-// Vitest workers (see socket-error-backstop.ts for full rationale).
+// confirmed via VINEXT_DEBUG_SOCKET_ERRORS=1. Module-load is the only
+// spot reliably observed to fire. Self-gates on NODE_ENV / VITEST so
+// build (incl. prerender) and tests skip cleanly. See
+// socket-error-backstop.ts for full rationale.
 installSocketErrorBackstop();
 
 type ASTNode = ReturnType<typeof parseAst>["body"][number]["parent"];

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -492,6 +492,65 @@ type NitroSetupContext = {
   };
 };
 
+/**
+ * Dev-only diagnostic backstop for peer-disconnect errors.
+ *
+ * Installed at module top-level (not inside configureServer) so it
+ * predates any subsequent lifecycle teardown — dep re-optimization,
+ * full reloads, server restarts can't remove it.
+ *
+ * Filters strictly on peer-disconnect codes (ECONNRESET / EPIPE /
+ * ECONNABORTED) and synchronously re-throws everything else, preserving
+ * Node's default crash semantics for genuine bugs.
+ *
+ * Set `VINEXT_DEBUG_SOCKET_ERRORS=1` in the environment to log a
+ * one-line marker each time the listener absorbs an error. Useful when
+ * users still see `node:events:487 throw er; // Unhandled 'error'
+ * event` in their dev output — the marker confirms whether the listener
+ * never ran at all (handler not installed / removed) or was bypassed
+ * by some other path.
+ *
+ * Symbol.for guard prevents double-install when vinext is loaded twice
+ * (e.g. by both a project and a sibling workspace package).
+ *
+ * Dev-only by virtue of being unused by the production prod-server
+ * entry, which runs as a Cloudflare Worker where socket lifecycle is
+ * owned by the runtime.
+ */
+const DEV_SOCKET_BACKSTOP_FLAG = Symbol.for("vinext.devSocketErrorBackstop");
+{
+  const proc = process as typeof process & { [DEV_SOCKET_BACKSTOP_FLAG]?: true };
+  if (!proc[DEV_SOCKET_BACKSTOP_FLAG]) {
+    proc[DEV_SOCKET_BACKSTOP_FLAG] = true;
+    const debug = process.env.VINEXT_DEBUG_SOCKET_ERRORS === "1";
+    const isPeerDisconnect = (err: unknown): boolean => {
+      const code = (err as { code?: string } | null)?.code;
+      return code === "ECONNRESET" || code === "EPIPE" || code === "ECONNABORTED";
+    };
+    if (debug) console.warn("[vinext] dev socket-error backstop installed");
+    process.on("uncaughtException", (err: Error) => {
+      if (isPeerDisconnect(err)) {
+        if (debug) {
+          const code = (err as Error & { code?: string }).code;
+          console.warn(`[vinext] absorbed uncaughtException ${code}`);
+        }
+        return;
+      }
+      throw err;
+    });
+    process.on("unhandledRejection", (reason: unknown) => {
+      if (isPeerDisconnect(reason)) {
+        if (debug) {
+          const code = (reason as Error & { code?: string }).code;
+          console.warn(`[vinext] absorbed unhandledRejection ${code}`);
+        }
+        return;
+      }
+      throw reason;
+    });
+  }
+}
+
 export default function vinext(options: VinextOptions = {}): PluginOption[] {
   const viteMajorVersion = getViteMajorVersion();
   let root: string;
@@ -2004,44 +2063,6 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         server.httpServer?.on("connection", (socket) => {
           socket.on("error", () => {});
         });
-
-        // Backstop for stream-pipe paths the connection-level guard misses.
-        // When a Readable is piped to a Writable that has no 'error' listener,
-        // Node's pipe() machinery re-emits the source's error onto the
-        // destination, which then throws (e.g. fromWeb(fetch().body).pipe(res)
-        // in proxyExternalRewriteNode, or any streaming surface inside
-        // @vitejs/plugin-rsc). Outbound sockets created by fetch() also never
-        // fire 'connection' on server.httpServer. Filtering by error code
-        // keeps real bugs surfacing — only peer-disconnect codes are dropped.
-        //
-        // Skipped in middleware mode (httpServer is null): the embedding host
-        // owns process-level handlers, and we have no reliable teardown hook
-        // to remove ours, so installation would leak.
-        if (server.httpServer) {
-          const isPeerDisconnect = (err: unknown): boolean => {
-            const code = (err as { code?: string } | null)?.code;
-            return code === "ECONNRESET" || code === "EPIPE" || code === "ECONNABORTED";
-          };
-          // Synchronous throw inside an uncaughtException listener aborts
-          // the process the same way no listener would (stack to stderr,
-          // non-zero exit). Re-throwing on nextTick instead would re-enter
-          // this same listener and loop indefinitely, silently swallowing
-          // genuine errors.
-          const onUncaught = (err: Error) => {
-            if (isPeerDisconnect(err)) return;
-            throw err;
-          };
-          const onUnhandledRejection = (reason: unknown) => {
-            if (isPeerDisconnect(reason)) return;
-            throw reason;
-          };
-          process.on("uncaughtException", onUncaught);
-          process.on("unhandledRejection", onUnhandledRejection);
-          server.httpServer.once("close", () => {
-            process.removeListener("uncaughtException", onUncaught);
-            process.removeListener("unhandledRejection", onUnhandledRejection);
-          });
-        }
 
         server.watcher.on("add", (filePath: string) => {
           if (hasPagesDir && filePath.startsWith(pagesDir) && pageExtensions.test(filePath)) {

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -493,62 +493,69 @@ type NitroSetupContext = {
 };
 
 /**
- * Dev-only diagnostic backstop for peer-disconnect errors.
+ * Dev-only backstop for peer-disconnect errors.
  *
- * Installed at module top-level (not inside configureServer) so it
- * predates any subsequent lifecycle teardown — dep re-optimization,
- * full reloads, server restarts can't remove it.
+ * Installed lazily from `configureServer` (dev only — never fires
+ * during `vinext build` or Vitest test workers that import this
+ * module), but **without** binding teardown to any server lifecycle
+ * event. The earlier version in PR #913 removed the listener on
+ * `httpServer` `'close'`, which Vite emits on dep re-optimization,
+ * full reloads, and other lifecycle events — leaving a window where
+ * the listener was absent when a stale stream errored. Symbol.for
+ * guard makes re-invocation (e.g. server restart) a no-op so the
+ * listener lives for the process.
  *
  * Filters strictly on peer-disconnect codes (ECONNRESET / EPIPE /
- * ECONNABORTED) and synchronously re-throws everything else, preserving
- * Node's default crash semantics for genuine bugs.
+ * ECONNABORTED) and synchronously re-throws everything else,
+ * preserving Node's default crash semantics for genuine bugs.
  *
- * Set `VINEXT_DEBUG_SOCKET_ERRORS=1` in the environment to log a
- * one-line marker each time the listener absorbs an error. Useful when
- * users still see `node:events:487 throw er; // Unhandled 'error'
- * event` in their dev output — the marker confirms whether the listener
- * never ran at all (handler not installed / removed) or was bypassed
- * by some other path.
+ * Skipped in middleware mode (httpServer is null): the embedding
+ * host (Express/Connect/etc.) owns process-level handlers.
  *
- * Symbol.for guard prevents double-install when vinext is loaded twice
- * (e.g. by both a project and a sibling workspace package).
+ * Listener ordering: because install happens during `configureServer`
+ * — after most user / tooling setup — vinext's listener registers
+ * late in the queue, so earlier observers (Sentry, structured logging,
+ * test runner hooks) still see non-peer-disconnect errors before the
+ * sync re-throw aborts further iteration.
  *
- * Dev-only by virtue of being unused by the production prod-server
- * entry, which runs as a Cloudflare Worker where socket lifecycle is
- * owned by the runtime.
+ * Set `VINEXT_DEBUG_SOCKET_ERRORS=1` to log a one-line marker each
+ * time the listener absorbs an error — useful for confirming the
+ * listener is in place when users still report `node:events:487
+ * throw er` crashes in the field.
+ *
+ * Symbol.for caveat: `Symbol.for("vinext.devSocketErrorBackstop")`
+ * is process-global, so if two different vinext versions are loaded
+ * in the same process the first to evaluate wins and the second's
+ * filter rules silently don't apply.
  */
 const DEV_SOCKET_BACKSTOP_FLAG = Symbol.for("vinext.devSocketErrorBackstop");
-{
+function installDevSocketErrorBackstop(): void {
   const proc = process as typeof process & { [DEV_SOCKET_BACKSTOP_FLAG]?: true };
-  if (!proc[DEV_SOCKET_BACKSTOP_FLAG]) {
-    proc[DEV_SOCKET_BACKSTOP_FLAG] = true;
-    const debug = process.env.VINEXT_DEBUG_SOCKET_ERRORS === "1";
-    const isPeerDisconnect = (err: unknown): boolean => {
-      const code = (err as { code?: string } | null)?.code;
-      return code === "ECONNRESET" || code === "EPIPE" || code === "ECONNABORTED";
-    };
-    if (debug) console.warn("[vinext] dev socket-error backstop installed");
-    process.on("uncaughtException", (err: Error) => {
-      if (isPeerDisconnect(err)) {
-        if (debug) {
-          const code = (err as Error & { code?: string }).code;
-          console.warn(`[vinext] absorbed uncaughtException ${code}`);
-        }
-        return;
-      }
-      throw err;
-    });
-    process.on("unhandledRejection", (reason: unknown) => {
-      if (isPeerDisconnect(reason)) {
-        if (debug) {
-          const code = (reason as Error & { code?: string }).code;
-          console.warn(`[vinext] absorbed unhandledRejection ${code}`);
-        }
-        return;
-      }
-      throw reason;
-    });
-  }
+  if (proc[DEV_SOCKET_BACKSTOP_FLAG]) return;
+  proc[DEV_SOCKET_BACKSTOP_FLAG] = true;
+
+  const debug = process.env.VINEXT_DEBUG_SOCKET_ERRORS === "1";
+  const peerDisconnectCode = (err: unknown): string | undefined => {
+    const code = (err as { code?: string } | null)?.code;
+    return code === "ECONNRESET" || code === "EPIPE" || code === "ECONNABORTED" ? code : undefined;
+  };
+  if (debug) console.warn("[vinext] dev socket-error backstop installed");
+  process.on("uncaughtException", (err: Error) => {
+    const code = peerDisconnectCode(err);
+    if (code) {
+      if (debug) console.warn(`[vinext] absorbed uncaughtException ${code}`);
+      return;
+    }
+    throw err;
+  });
+  process.on("unhandledRejection", (reason: unknown) => {
+    const code = peerDisconnectCode(reason);
+    if (code) {
+      if (debug) console.warn(`[vinext] absorbed unhandledRejection ${code}`);
+      return;
+    }
+    throw reason;
+  });
 }
 
 export default function vinext(options: VinextOptions = {}): PluginOption[] {
@@ -2063,6 +2070,12 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         server.httpServer?.on("connection", (socket) => {
           socket.on("error", () => {});
         });
+
+        // Process-level peer-disconnect backstop. Skipped in middleware
+        // mode (httpServer null) — the embedding host owns its handlers.
+        if (server.httpServer) {
+          installDevSocketErrorBackstop();
+        }
 
         server.watcher.on("add", (filePath: string) => {
           if (hasPagesDir && filePath.startsWith(pagesDir) && pageExtensions.test(filePath)) {

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -494,103 +494,76 @@ type NitroSetupContext = {
 
 /**
  * Backstop for peer-disconnect errors that escape the per-connection
- * `socket.on("error")` guard above (pipe re-emission to non-socket
- * destinations, outbound `fetch()` sockets, etc.).
+ * `socket.on("error")` guard installed in `configureServer` (pipe
+ * re-emission to non-socket destinations, outbound `fetch()` sockets,
+ * streaming surfaces inside `@vitejs/plugin-rsc`, etc.).
  *
- * **Installed at module load — not in `configureServer`.** An earlier
- * iteration of this fix moved install into `configureServer` to make
- * it strictly dev-only, but in vite-plus's plugin lifecycle
- * `server.httpServer` is null at the time the hook runs, so the
- * `if (server.httpServer)` middleware-mode guard caused install to
- * be skipped entirely. Field reproducer confirmed: with install
- * gated inside `configureServer`, the listener never fires (no
- * startup marker, immediate ECONNRESET crash on first request);
- * hoisting back to module load fires it as expected.
+ * **Where this is invoked from matters.** Earlier iterations got this
+ * wrong twice:
+ *   - `configureServer` hook: in vite-plus's lifecycle `httpServer` is
+ *     null when the hook fires, so the middleware-mode guard caused
+ *     install to be skipped entirely.
+ *   - Module top-level: install ran in every context that imported
+ *     this module, including Vitest workers and `vinext build`,
+ *     swallowing genuine peer-disconnect errors during builds and
+ *     test runs. argv-sniffing was a flimsy mitigation.
  *
- * The earlier reason for hoisting still applies: the previous-prior
- * iteration tied teardown to `httpServer` `'close'`, which Vite emits
- * on dep re-optimization and full reloads, leaving a window where
- * the listener was absent when a stale stream errored. No teardown
- * here — listener lives for the process.
+ * Now invoked from Vite's `config()` hook, gated on `command ===
+ * "serve"`. Vite passes `command` directly, so the gate is the
+ * canonical "are we in dev?" signal — works identically for `vinext
+ * dev`, `vp dev`, `vite dev`, and library embedders that call
+ * `createServer` themselves. `config()` runs before `configureServer`
+ * (so before httpServer matters) and is called once per dev session,
+ * so the listener is in place before any I/O.
  *
  * Filters strictly on peer-disconnect codes (ECONNRESET / EPIPE /
  * ECONNABORTED) and synchronously re-throws everything else,
  * preserving Node's default crash semantics for genuine bugs.
  *
- * **Positive context gate.** Install only when `process.argv[2] ===
- * "dev"` — matches `vinext dev`, `vp dev`, `vite dev`, and any other
- * CLI that follows the standard `<bin> dev` convention. `vinext
- * build`, Vitest workers that import `index.ts` directly, and library
- * embedders with a custom runner all skip install, so genuine
- * peer-disconnect errors in those contexts surface normally. argv is
- * read directly because the CLI entry imports this module before it
- * has a chance to set an env var, and Vite plugin hooks like
- * `configResolved` run too late for module-load gating.
- *
- * **Listener ordering.** Because install runs at module load, vinext's
- * listener registers earlier than most user / tooling listeners
- * (Sentry, structured logging, test-runner hooks). For peer-disconnect
- * codes the early-return is fine. For non-peer-disconnect errors the
- * sync re-throw still crashes with the correct stack — Node's default
- * handler runs because no listener fully handled it — but later-
- * registered observers don't see the event. Acceptable trade-off in
- * dev: the alternative (deferred re-throw with re-entry guard) adds
- * complexity for an edge case that's rare in dev workflows.
- *
- * **Middleware-mode embedders** (Express/Connect hosting vinext) get
- * these process-level listeners installed too — there is no module-
- * load-time signal to detect middleware mode. Embedders that want to
- * own their own handlers can set the `VINEXT_DEBUG_SOCKET_ERRORS`
- * marker to verify whether vinext's listener is intercepting their
- * errors and import vinext lazily from inside their own configured
- * handler if so.
+ * **Listener ordering.** Vite calls plugin `config()` hooks during
+ * `createServer`, after most user setup. vinext's listener therefore
+ * registers late in the queue, so earlier observers (Sentry,
+ * structured logging) still see non-peer-disconnect errors before
+ * the sync re-throw aborts further iteration.
  *
  * **Symbol.for caveat.** `Symbol.for("vinext.devSocketErrorBackstop")`
  * is process-global, so if two different vinext versions are loaded
  * in the same process the first to evaluate wins and the second's
- * filter rules silently don't apply.
+ * filter rules silently don't apply. Idempotent across multiple
+ * `config()` invocations within a single process (e.g. server
+ * restarts within a dev session).
  *
  * Set `VINEXT_DEBUG_SOCKET_ERRORS=1` to log a one-line marker each
  * time the listener absorbs an error.
  */
 const DEV_SOCKET_BACKSTOP_FLAG = Symbol.for("vinext.devSocketErrorBackstop");
-{
+function installDevSocketErrorBackstop(): void {
   const proc = process as typeof process & { [DEV_SOCKET_BACKSTOP_FLAG]?: true };
-  // Positive gate: install only when this looks like a dev-server
-  // invocation. `argv[2] === "dev"` matches `vinext dev`, `vp dev`,
-  // `vite dev`, and any other CLI that follows the "<bin> dev"
-  // convention. Anything else — `build`, Vitest workers that import
-  // index.ts directly, library embedders with a custom runner — gets
-  // no listener installed, so genuine peer-disconnect errors in those
-  // contexts surface normally.
-  const isDevCommand = process.argv[2] === "dev";
-  if (!proc[DEV_SOCKET_BACKSTOP_FLAG] && isDevCommand) {
-    proc[DEV_SOCKET_BACKSTOP_FLAG] = true;
-    const debug = process.env.VINEXT_DEBUG_SOCKET_ERRORS === "1";
-    const peerDisconnectCode = (err: unknown): string | undefined => {
-      const code = (err as { code?: string } | null)?.code;
-      return code === "ECONNRESET" || code === "EPIPE" || code === "ECONNABORTED"
-        ? code
-        : undefined;
-    };
-    if (debug) console.warn("[vinext] dev socket-error backstop installed");
-    process.on("uncaughtException", (err: Error) => {
-      const code = peerDisconnectCode(err);
-      if (code) {
-        if (debug) console.warn(`[vinext] absorbed uncaughtException ${code}`);
-        return;
-      }
-      throw err;
-    });
-    process.on("unhandledRejection", (reason: unknown) => {
-      const code = peerDisconnectCode(reason);
-      if (code) {
-        if (debug) console.warn(`[vinext] absorbed unhandledRejection ${code}`);
-        return;
-      }
-      throw reason;
-    });
-  }
+  if (proc[DEV_SOCKET_BACKSTOP_FLAG]) return;
+  proc[DEV_SOCKET_BACKSTOP_FLAG] = true;
+
+  const debug = process.env.VINEXT_DEBUG_SOCKET_ERRORS === "1";
+  const peerDisconnectCode = (err: unknown): string | undefined => {
+    const code = (err as { code?: string } | null)?.code;
+    return code === "ECONNRESET" || code === "EPIPE" || code === "ECONNABORTED" ? code : undefined;
+  };
+  if (debug) console.warn("[vinext] dev socket-error backstop installed");
+  process.on("uncaughtException", (err: Error) => {
+    const code = peerDisconnectCode(err);
+    if (code) {
+      if (debug) console.warn(`[vinext] absorbed uncaughtException ${code}`);
+      return;
+    }
+    throw err;
+  });
+  process.on("unhandledRejection", (reason: unknown) => {
+    const code = peerDisconnectCode(reason);
+    if (code) {
+      if (debug) console.warn(`[vinext] absorbed unhandledRejection ${code}`);
+      return;
+    }
+    throw reason;
+  });
 }
 
 export default function vinext(options: VinextOptions = {}): PluginOption[] {
@@ -826,6 +799,14 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
       enforce: "pre",
 
       async config(config, env) {
+        // Process-level peer-disconnect backstop. `command === "serve"`
+        // is Vite's canonical "we're in dev" signal — works identically
+        // across `vinext dev`, `vp dev`, `vite dev`, and library
+        // embedders that call createServer themselves.
+        if (env?.command === "serve") {
+          installDevSocketErrorBackstop();
+        }
+
         root = config.root ?? process.cwd();
         const userResolve = config.resolve as UserResolveConfigWithTsconfigPaths | undefined;
         const shouldEnableNativeTsconfigPaths =

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -493,69 +493,104 @@ type NitroSetupContext = {
 };
 
 /**
- * Dev-only backstop for peer-disconnect errors.
+ * Backstop for peer-disconnect errors that escape the per-connection
+ * `socket.on("error")` guard above (pipe re-emission to non-socket
+ * destinations, outbound `fetch()` sockets, etc.).
  *
- * Installed lazily from `configureServer` (dev only — never fires
- * during `vinext build` or Vitest test workers that import this
- * module), but **without** binding teardown to any server lifecycle
- * event. The earlier version in PR #913 removed the listener on
- * `httpServer` `'close'`, which Vite emits on dep re-optimization,
- * full reloads, and other lifecycle events — leaving a window where
- * the listener was absent when a stale stream errored. Symbol.for
- * guard makes re-invocation (e.g. server restart) a no-op so the
- * listener lives for the process.
+ * **Installed at module load — not in `configureServer`.** An earlier
+ * iteration of this fix moved install into `configureServer` to make
+ * it strictly dev-only, but in vite-plus's plugin lifecycle
+ * `server.httpServer` is null at the time the hook runs, so the
+ * `if (server.httpServer)` middleware-mode guard caused install to
+ * be skipped entirely. Field reproducer confirmed: with install
+ * gated inside `configureServer`, the listener never fires (no
+ * startup marker, immediate ECONNRESET crash on first request);
+ * hoisting back to module load fires it as expected.
+ *
+ * The earlier reason for hoisting still applies: the previous-prior
+ * iteration tied teardown to `httpServer` `'close'`, which Vite emits
+ * on dep re-optimization and full reloads, leaving a window where
+ * the listener was absent when a stale stream errored. No teardown
+ * here — listener lives for the process.
  *
  * Filters strictly on peer-disconnect codes (ECONNRESET / EPIPE /
  * ECONNABORTED) and synchronously re-throws everything else,
  * preserving Node's default crash semantics for genuine bugs.
  *
- * Skipped in middleware mode (httpServer is null): the embedding
- * host (Express/Connect/etc.) owns process-level handlers.
+ * **Context skips.** This module is also imported by Vitest workers
+ * (`tests/shims.test.ts` etc.) and during `vinext build` — installing
+ * in those contexts would silently swallow peer-disconnect errors
+ * during builds and test runs. Skip both:
+ *   - `process.env.VITEST === "true"` covers Vitest workers.
+ *   - `process.argv` containing `build` covers `vinext build` and
+ *     `vp build`; we read argv directly because the CLI entry imports
+ *     this module before it has a chance to set an env var, and Vite
+ *     plugin hooks like `configResolved` run too late for module-load
+ *     gating.
  *
- * Listener ordering: because install happens during `configureServer`
- * — after most user / tooling setup — vinext's listener registers
- * late in the queue, so earlier observers (Sentry, structured logging,
- * test runner hooks) still see non-peer-disconnect errors before the
- * sync re-throw aborts further iteration.
+ * **Listener ordering.** Because install runs at module load, vinext's
+ * listener registers earlier than most user / tooling listeners
+ * (Sentry, structured logging, test-runner hooks). For peer-disconnect
+ * codes the early-return is fine. For non-peer-disconnect errors the
+ * sync re-throw still crashes with the correct stack — Node's default
+ * handler runs because no listener fully handled it — but later-
+ * registered observers don't see the event. Acceptable trade-off in
+ * dev: the alternative (deferred re-throw with re-entry guard) adds
+ * complexity for an edge case that's rare in dev workflows.
  *
- * Set `VINEXT_DEBUG_SOCKET_ERRORS=1` to log a one-line marker each
- * time the listener absorbs an error — useful for confirming the
- * listener is in place when users still report `node:events:487
- * throw er` crashes in the field.
+ * **Middleware-mode embedders** (Express/Connect hosting vinext) get
+ * these process-level listeners installed too — there is no module-
+ * load-time signal to detect middleware mode. Embedders that want to
+ * own their own handlers can set the `VINEXT_DEBUG_SOCKET_ERRORS`
+ * marker to verify whether vinext's listener is intercepting their
+ * errors and import vinext lazily from inside their own configured
+ * handler if so.
  *
- * Symbol.for caveat: `Symbol.for("vinext.devSocketErrorBackstop")`
+ * **Symbol.for caveat.** `Symbol.for("vinext.devSocketErrorBackstop")`
  * is process-global, so if two different vinext versions are loaded
  * in the same process the first to evaluate wins and the second's
  * filter rules silently don't apply.
+ *
+ * Set `VINEXT_DEBUG_SOCKET_ERRORS=1` to log a one-line marker each
+ * time the listener absorbs an error.
  */
 const DEV_SOCKET_BACKSTOP_FLAG = Symbol.for("vinext.devSocketErrorBackstop");
-function installDevSocketErrorBackstop(): void {
+{
   const proc = process as typeof process & { [DEV_SOCKET_BACKSTOP_FLAG]?: true };
-  if (proc[DEV_SOCKET_BACKSTOP_FLAG]) return;
-  proc[DEV_SOCKET_BACKSTOP_FLAG] = true;
-
-  const debug = process.env.VINEXT_DEBUG_SOCKET_ERRORS === "1";
-  const peerDisconnectCode = (err: unknown): string | undefined => {
-    const code = (err as { code?: string } | null)?.code;
-    return code === "ECONNRESET" || code === "EPIPE" || code === "ECONNABORTED" ? code : undefined;
-  };
-  if (debug) console.warn("[vinext] dev socket-error backstop installed");
-  process.on("uncaughtException", (err: Error) => {
-    const code = peerDisconnectCode(err);
-    if (code) {
-      if (debug) console.warn(`[vinext] absorbed uncaughtException ${code}`);
-      return;
-    }
-    throw err;
-  });
-  process.on("unhandledRejection", (reason: unknown) => {
-    const code = peerDisconnectCode(reason);
-    if (code) {
-      if (debug) console.warn(`[vinext] absorbed unhandledRejection ${code}`);
-      return;
-    }
-    throw reason;
-  });
+  // Skip contexts where this module is loaded but isn't the dev server:
+  //   - VITEST=true → Vitest workers that import index.ts directly
+  //   - argv build  → `vinext build` / `vp build` CLI invocations
+  // Genuine peer-disconnect errors during builds / test runs should not
+  // be silently swallowed.
+  const isVitest = process.env.VITEST === "true";
+  const isBuild = process.argv.slice(2).some((a) => a === "build");
+  if (!proc[DEV_SOCKET_BACKSTOP_FLAG] && !isVitest && !isBuild) {
+    proc[DEV_SOCKET_BACKSTOP_FLAG] = true;
+    const debug = process.env.VINEXT_DEBUG_SOCKET_ERRORS === "1";
+    const peerDisconnectCode = (err: unknown): string | undefined => {
+      const code = (err as { code?: string } | null)?.code;
+      return code === "ECONNRESET" || code === "EPIPE" || code === "ECONNABORTED"
+        ? code
+        : undefined;
+    };
+    if (debug) console.warn("[vinext] dev socket-error backstop installed");
+    process.on("uncaughtException", (err: Error) => {
+      const code = peerDisconnectCode(err);
+      if (code) {
+        if (debug) console.warn(`[vinext] absorbed uncaughtException ${code}`);
+        return;
+      }
+      throw err;
+    });
+    process.on("unhandledRejection", (reason: unknown) => {
+      const code = peerDisconnectCode(reason);
+      if (code) {
+        if (debug) console.warn(`[vinext] absorbed unhandledRejection ${code}`);
+        return;
+      }
+      throw reason;
+    });
+  }
 }
 
 export default function vinext(options: VinextOptions = {}): PluginOption[] {
@@ -2070,12 +2105,6 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         server.httpServer?.on("connection", (socket) => {
           socket.on("error", () => {});
         });
-
-        // Process-level peer-disconnect backstop. Skipped in middleware
-        // mode (httpServer null) — the embedding host owns its handlers.
-        if (server.httpServer) {
-          installDevSocketErrorBackstop();
-        }
 
         server.watcher.on("add", (filePath: string) => {
           if (hasPagesDir && filePath.startsWith(pagesDir) && pageExtensions.test(filePath)) {

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -800,10 +800,12 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
 
       async config(config, env) {
         // Process-level peer-disconnect backstop. `command === "serve"`
-        // is Vite's canonical "we're in dev" signal — works identically
-        // across `vinext dev`, `vp dev`, `vite dev`, and library
-        // embedders that call createServer themselves.
-        if (env?.command === "serve") {
+        // covers both `vite dev` and `vite preview`; `!isPreview`
+        // narrows to dev only — preview is a static prod-build server
+        // that doesn't stream RSC and doesn't need this guard.
+        // `vinext start` runs prod-server.ts directly without Vite, so
+        // this hook never fires there.
+        if (env?.command === "serve" && !env.isPreview) {
           installDevSocketErrorBackstop();
         }
 

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -13,6 +13,7 @@ import type { NitroRouteRuleConfig } from "./build/nitro-route-rules.js";
 import { createValidFileMatcher } from "./routing/file-matcher.js";
 import { createSSRHandler } from "./server/dev-server.js";
 import { handleApiRoute } from "./server/api-handler.js";
+import { installSocketErrorBackstop } from "./server/socket-error-backstop.js";
 import { createDirectRunner } from "./server/dev-module-runner.js";
 import { generateRscEntry } from "./entries/app-rsc-entry.js";
 import { generateSsrEntry } from "./entries/app-ssr-entry.js";
@@ -492,80 +493,6 @@ type NitroSetupContext = {
   };
 };
 
-/**
- * Backstop for peer-disconnect errors that escape the per-connection
- * `socket.on("error")` guard installed in `configureServer` (pipe
- * re-emission to non-socket destinations, outbound `fetch()` sockets,
- * streaming surfaces inside `@vitejs/plugin-rsc`, etc.).
- *
- * **Where this is invoked from matters.** Earlier iterations got this
- * wrong twice:
- *   - `configureServer` hook: in vite-plus's lifecycle `httpServer` is
- *     null when the hook fires, so the middleware-mode guard caused
- *     install to be skipped entirely.
- *   - Module top-level: install ran in every context that imported
- *     this module, including Vitest workers and `vinext build`,
- *     swallowing genuine peer-disconnect errors during builds and
- *     test runs. argv-sniffing was a flimsy mitigation.
- *
- * Now invoked from Vite's `config()` hook, gated on `command ===
- * "serve"`. Vite passes `command` directly, so the gate is the
- * canonical "are we in dev?" signal — works identically for `vinext
- * dev`, `vp dev`, `vite dev`, and library embedders that call
- * `createServer` themselves. `config()` runs before `configureServer`
- * (so before httpServer matters) and is called once per dev session,
- * so the listener is in place before any I/O.
- *
- * Filters strictly on peer-disconnect codes (ECONNRESET / EPIPE /
- * ECONNABORTED) and synchronously re-throws everything else,
- * preserving Node's default crash semantics for genuine bugs.
- *
- * **Listener ordering.** Vite calls plugin `config()` hooks during
- * `createServer`, after most user setup. vinext's listener therefore
- * registers late in the queue, so earlier observers (Sentry,
- * structured logging) still see non-peer-disconnect errors before
- * the sync re-throw aborts further iteration.
- *
- * **Symbol.for caveat.** `Symbol.for("vinext.devSocketErrorBackstop")`
- * is process-global, so if two different vinext versions are loaded
- * in the same process the first to evaluate wins and the second's
- * filter rules silently don't apply. Idempotent across multiple
- * `config()` invocations within a single process (e.g. server
- * restarts within a dev session).
- *
- * Set `VINEXT_DEBUG_SOCKET_ERRORS=1` to log a one-line marker each
- * time the listener absorbs an error.
- */
-const DEV_SOCKET_BACKSTOP_FLAG = Symbol.for("vinext.devSocketErrorBackstop");
-function installDevSocketErrorBackstop(): void {
-  const proc = process as typeof process & { [DEV_SOCKET_BACKSTOP_FLAG]?: true };
-  if (proc[DEV_SOCKET_BACKSTOP_FLAG]) return;
-  proc[DEV_SOCKET_BACKSTOP_FLAG] = true;
-
-  const debug = process.env.VINEXT_DEBUG_SOCKET_ERRORS === "1";
-  const peerDisconnectCode = (err: unknown): string | undefined => {
-    const code = (err as { code?: string } | null)?.code;
-    return code === "ECONNRESET" || code === "EPIPE" || code === "ECONNABORTED" ? code : undefined;
-  };
-  if (debug) console.warn("[vinext] dev socket-error backstop installed");
-  process.on("uncaughtException", (err: Error) => {
-    const code = peerDisconnectCode(err);
-    if (code) {
-      if (debug) console.warn(`[vinext] absorbed uncaughtException ${code}`);
-      return;
-    }
-    throw err;
-  });
-  process.on("unhandledRejection", (reason: unknown) => {
-    const code = peerDisconnectCode(reason);
-    if (code) {
-      if (debug) console.warn(`[vinext] absorbed unhandledRejection ${code}`);
-      return;
-    }
-    throw reason;
-  });
-}
-
 export default function vinext(options: VinextOptions = {}): PluginOption[] {
   const viteMajorVersion = getViteMajorVersion();
   let root: string;
@@ -801,12 +728,11 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
       async config(config, env) {
         // Process-level peer-disconnect backstop. `command === "serve"`
         // covers both `vite dev` and `vite preview`; `!isPreview`
-        // narrows to dev only — preview is a static prod-build server
-        // that doesn't stream RSC and doesn't need this guard.
-        // `vinext start` runs prod-server.ts directly without Vite, so
-        // this hook never fires there.
+        // narrows to dev only. `vinext start` installs the same
+        // backstop from prod-server.ts directly, matching Next.js's
+        // pattern of guarding any Node HTTP-serving entry point.
         if (env?.command === "serve" && !env.isPreview) {
-          installDevSocketErrorBackstop();
+          installSocketErrorBackstop();
         }
 
         root = config.root ?? process.cwd();

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -13,9 +13,7 @@ import type { NitroRouteRuleConfig } from "./build/nitro-route-rules.js";
 import { createValidFileMatcher } from "./routing/file-matcher.js";
 import { createSSRHandler } from "./server/dev-server.js";
 import { handleApiRoute } from "./server/api-handler.js";
-// Side-effect import: auto-installs a process-level peer-disconnect
-// backstop at module load. See socket-error-backstop.ts for rationale.
-import "./server/socket-error-backstop.js";
+import { installSocketErrorBackstop } from "./server/socket-error-backstop.js";
 import { createDirectRunner } from "./server/dev-module-runner.js";
 import { generateRscEntry } from "./entries/app-rsc-entry.js";
 import { generateSsrEntry } from "./entries/app-ssr-entry.js";
@@ -116,6 +114,14 @@ import { createRequire } from "node:module";
 import fs from "node:fs";
 import { randomBytes } from "node:crypto";
 import commonjs from "vite-plugin-commonjs";
+
+// Install the process-level peer-disconnect backstop as soon as this
+// module loads. Vite plugin lifecycle hooks (config / configureServer)
+// proved timing-fragile in vite-plus — install was silently skipped,
+// confirmed via the VINEXT_DEBUG_SOCKET_ERRORS=1 marker. Module-load
+// is the only spot reliably observed to fire. Idempotent and skips in
+// Vitest workers (see socket-error-backstop.ts for full rationale).
+installSocketErrorBackstop();
 
 type ASTNode = ReturnType<typeof parseAst>["body"][number]["parent"];
 

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -517,16 +517,15 @@ type NitroSetupContext = {
  * ECONNABORTED) and synchronously re-throws everything else,
  * preserving Node's default crash semantics for genuine bugs.
  *
- * **Context skips.** This module is also imported by Vitest workers
- * (`tests/shims.test.ts` etc.) and during `vinext build` — installing
- * in those contexts would silently swallow peer-disconnect errors
- * during builds and test runs. Skip both:
- *   - `process.env.VITEST === "true"` covers Vitest workers.
- *   - `process.argv` containing `build` covers `vinext build` and
- *     `vp build`; we read argv directly because the CLI entry imports
- *     this module before it has a chance to set an env var, and Vite
- *     plugin hooks like `configResolved` run too late for module-load
- *     gating.
+ * **Positive context gate.** Install only when `process.argv[2] ===
+ * "dev"` — matches `vinext dev`, `vp dev`, `vite dev`, and any other
+ * CLI that follows the standard `<bin> dev` convention. `vinext
+ * build`, Vitest workers that import `index.ts` directly, and library
+ * embedders with a custom runner all skip install, so genuine
+ * peer-disconnect errors in those contexts surface normally. argv is
+ * read directly because the CLI entry imports this module before it
+ * has a chance to set an env var, and Vite plugin hooks like
+ * `configResolved` run too late for module-load gating.
  *
  * **Listener ordering.** Because install runs at module load, vinext's
  * listener registers earlier than most user / tooling listeners
@@ -557,14 +556,15 @@ type NitroSetupContext = {
 const DEV_SOCKET_BACKSTOP_FLAG = Symbol.for("vinext.devSocketErrorBackstop");
 {
   const proc = process as typeof process & { [DEV_SOCKET_BACKSTOP_FLAG]?: true };
-  // Skip contexts where this module is loaded but isn't the dev server:
-  //   - VITEST=true → Vitest workers that import index.ts directly
-  //   - argv build  → `vinext build` / `vp build` CLI invocations
-  // Genuine peer-disconnect errors during builds / test runs should not
-  // be silently swallowed.
-  const isVitest = process.env.VITEST === "true";
-  const isBuild = process.argv.slice(2).some((a) => a === "build");
-  if (!proc[DEV_SOCKET_BACKSTOP_FLAG] && !isVitest && !isBuild) {
+  // Positive gate: install only when this looks like a dev-server
+  // invocation. `argv[2] === "dev"` matches `vinext dev`, `vp dev`,
+  // `vite dev`, and any other CLI that follows the "<bin> dev"
+  // convention. Anything else — `build`, Vitest workers that import
+  // index.ts directly, library embedders with a custom runner — gets
+  // no listener installed, so genuine peer-disconnect errors in those
+  // contexts surface normally.
+  const isDevCommand = process.argv[2] === "dev";
+  if (!proc[DEV_SOCKET_BACKSTOP_FLAG] && isDevCommand) {
     proc[DEV_SOCKET_BACKSTOP_FLAG] = true;
     const debug = process.env.VINEXT_DEBUG_SOCKET_ERRORS === "1";
     const peerDisconnectCode = (err: unknown): string | undefined => {

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -115,13 +115,12 @@ import fs from "node:fs";
 import { randomBytes } from "node:crypto";
 import commonjs from "vite-plugin-commonjs";
 
-// Install the process-level peer-disconnect backstop as soon as this
-// module loads. Vite plugin lifecycle hooks (config / configureServer)
-// proved timing-fragile in vite-plus — install was silently skipped,
-// confirmed via VINEXT_DEBUG_SOCKET_ERRORS=1. Module-load is the only
-// spot reliably observed to fire. Self-gates on NODE_ENV / VITEST so
-// build (incl. prerender) and tests skip cleanly. See
-// socket-error-backstop.ts for full rationale.
+// Install the process-level peer-disconnect backstop at module load.
+// Vite plugin lifecycle hooks (config / configureServer) proved
+// timing-fragile in vite-plus — install was silently skipped,
+// confirmed via VINEXT_DEBUG_SOCKET_ERRORS=1. Skips Vitest workers
+// via env-var gate; bypasses during prerender via fire-time
+// VINEXT_PRERENDER check. See socket-error-backstop.ts.
 installSocketErrorBackstop();
 
 type ASTNode = ReturnType<typeof parseAst>["body"][number]["parent"];

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -13,7 +13,9 @@ import type { NitroRouteRuleConfig } from "./build/nitro-route-rules.js";
 import { createValidFileMatcher } from "./routing/file-matcher.js";
 import { createSSRHandler } from "./server/dev-server.js";
 import { handleApiRoute } from "./server/api-handler.js";
-import { installSocketErrorBackstop } from "./server/socket-error-backstop.js";
+// Side-effect import: auto-installs a process-level peer-disconnect
+// backstop at module load. See socket-error-backstop.ts for rationale.
+import "./server/socket-error-backstop.js";
 import { createDirectRunner } from "./server/dev-module-runner.js";
 import { generateRscEntry } from "./entries/app-rsc-entry.js";
 import { generateSsrEntry } from "./entries/app-ssr-entry.js";
@@ -726,15 +728,6 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
       enforce: "pre",
 
       async config(config, env) {
-        // Process-level peer-disconnect backstop. `command === "serve"`
-        // covers both `vite dev` and `vite preview`; `!isPreview`
-        // narrows to dev only. `vinext start` installs the same
-        // backstop from prod-server.ts directly, matching Next.js's
-        // pattern of guarding any Node HTTP-serving entry point.
-        if (env?.command === "serve" && !env.isPreview) {
-          installSocketErrorBackstop();
-        }
-
         root = config.root ?? process.cwd();
         const userResolve = config.resolve as UserResolveConfigWithTsconfigPaths | undefined;
         const shouldEnableNativeTsconfigPaths =

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -813,9 +813,11 @@ async function sendWebResponse(
  * Pages Router (dist/server/entry.js) and configures the appropriate handler.
  */
 export async function startProdServer(options: ProdServerOptions = {}) {
-  // Process-level peer-disconnect backstop. Matches the install from
-  // vinext's Vite plugin config() hook for dev — covers any Node
-  // HTTP-serving entry, mirroring Next.js's router-server pattern.
+  // Process-level peer-disconnect backstop. installSocketErrorBackstop
+  // self-gates on NODE_ENV: this call is a no-op during prerender
+  // (NODE_ENV=production) so user fetch() calls hit by ECONNRESET
+  // still crash the build instead of producing corrupt output. Fires
+  // for vinext start only when NODE_ENV is unset.
   installSocketErrorBackstop();
 
   const {

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -54,6 +54,7 @@ import { normalizePathnameForRouteMatchStrict } from "../routing/utils.js";
 import type { ExecutionContextLike } from "../shims/request-context.js";
 import { readPrerenderSecret } from "../build/server-manifest.js";
 import { seedMemoryCacheFromPrerender } from "./seed-cache.js";
+import { installSocketErrorBackstop } from "./socket-error-backstop.js";
 
 /** Convert a Node.js IncomingMessage into a ReadableStream for Web Request body. */
 function readNodeStream(req: IncomingMessage): ReadableStream<Uint8Array> {
@@ -812,6 +813,11 @@ async function sendWebResponse(
  * Pages Router (dist/server/entry.js) and configures the appropriate handler.
  */
 export async function startProdServer(options: ProdServerOptions = {}) {
+  // Process-level peer-disconnect backstop. Matches the install from
+  // vinext's Vite plugin config() hook for dev — covers any Node
+  // HTTP-serving entry, mirroring Next.js's router-server pattern.
+  installSocketErrorBackstop();
+
   const {
     port = process.env.PORT ? parseInt(process.env.PORT) : 3000,
     host = "0.0.0.0",

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -813,11 +813,13 @@ async function sendWebResponse(
  * Pages Router (dist/server/entry.js) and configures the appropriate handler.
  */
 export async function startProdServer(options: ProdServerOptions = {}) {
-  // Process-level peer-disconnect backstop. installSocketErrorBackstop
-  // self-gates on NODE_ENV: this call is a no-op during prerender
-  // (NODE_ENV=production) so user fetch() calls hit by ECONNRESET
-  // still crash the build instead of producing corrupt output. Fires
-  // for vinext start only when NODE_ENV is unset.
+  // Process-level peer-disconnect backstop. Idempotent via the
+  // Symbol.for guard inside installSocketErrorBackstop, so this call
+  // is a no-op when index.ts has already installed it. Kept here so
+  // entry points that load prod-server without going through index.ts
+  // (none today, but preserves Next.js's "install everywhere a Node
+  // HTTP server runs" parity) still get the backstop. Prerender
+  // bypass is fire-time via VINEXT_PRERENDER, not install-time.
   installSocketErrorBackstop();
 
   const {

--- a/packages/vinext/src/server/socket-error-backstop.ts
+++ b/packages/vinext/src/server/socket-error-backstop.ts
@@ -83,10 +83,3 @@ export function installSocketErrorBackstop(): void {
     throw reason;
   });
 }
-
-// Auto-install at module load. The Vite plugin lifecycle hooks proved
-// timing-fragile in vite-plus, so we install eagerly. The Vitest skip
-// inside installSocketErrorBackstop() is the only context-specific
-// guard. Idempotent — prod-server.ts's explicit call is a no-op when
-// loaded in the same process.
-installSocketErrorBackstop();

--- a/packages/vinext/src/server/socket-error-backstop.ts
+++ b/packages/vinext/src/server/socket-error-backstop.ts
@@ -26,23 +26,41 @@
  * vite-plus's lifecycle — install was silently skipped. The
  * connection-level guard from #911 confirms `configureServer`-tied
  * lifecycle hooks are timing-fragile too. Module-load install is
- * the only place that's been reliably observed to fire (verified
- * via the `VINEXT_DEBUG_SOCKET_ERRORS` marker).
+ * the only place reliably observed to fire (verified via the
+ * `VINEXT_DEBUG_SOCKET_ERRORS` marker).
  *
- * The earlier reason for hoisting still applies: prior versions tied
- * teardown to `httpServer` `'close'`, which Vite emits on dep
- * re-optimization and full reloads, leaving a window where the
- * listener was absent when a stale stream errored. No teardown here.
+ * **Production / build / test skip.** Three exclusions are critical:
  *
- * **Vitest skip.** Vitest workers import this module via test files
- * that depend on `index.ts`. Skip install in those contexts so
- * genuine peer-disconnect errors during test runs surface normally.
- * `process.env.VITEST === "true"` is set by Vitest in every worker.
+ *   - `NODE_ENV === "production"` — covers `vinext build`, including
+ *     the prerender pass that calls `startProdServer()` from
+ *     `build/run-prerender.ts` and `build/prerender.ts`. User
+ *     `fetch()` calls during prerender hit external APIs that can
+ *     drop connections; absorbing those silently produces corrupt
+ *     prerendered output instead of a build crash. Also covers
+ *     `vinext start` for self-hosted Node deploys (loses Next.js's
+ *     "install everywhere" parity but acceptable — `pipeline()`
+ *     callbacks in prod-server already handle the streaming case).
  *
- * Build runs (`vinext build`) also import index.ts but the listener
- * is harmless there — the build process is short-lived and doesn't
- * stream peer-disconnect-prone responses. Matches Next.js's pattern
- * of installing in any HTTP-serving entry without further gating.
+ *   - `VITEST === "true"` — Vitest workers that import `index.ts`
+ *     directly. Genuine peer-disconnect errors during test runs
+ *     should surface normally.
+ *
+ *   - `NODE_ENV === "test"` — other test runners that follow the
+ *     standard NODE_ENV convention.
+ *
+ * Vite sets `NODE_ENV=production` for the build command before
+ * plugins load, so the gate fires correctly even when `vinext build`
+ * is invoked through `vp build` / `vite build`.
+ *
+ * **Listener ordering.** `index.ts` is imported synchronously at the
+ * top of every user's `vite.config.ts`, so vinext's listener registers
+ * before most user / tooling listeners (Sentry, OpenTelemetry,
+ * structured logging). For peer-disconnect codes the early-return is
+ * fine. For non-peer-disconnect errors the synchronous re-throw still
+ * crashes the process with the original stack, but listeners
+ * registered after vinext don't observe the event. Users who need
+ * crash-reporter visibility for non-peer-disconnect errors must
+ * register their handler before importing vinext.
  *
  * **Symbol.for caveat.** `Symbol.for("vinext.socketErrorBackstop")`
  * is process-global, so if two different vinext versions are loaded
@@ -57,6 +75,8 @@ const SOCKET_BACKSTOP_FLAG = Symbol.for("vinext.socketErrorBackstop");
 export function installSocketErrorBackstop(): void {
   const proc = process as typeof process & { [SOCKET_BACKSTOP_FLAG]?: true };
   if (proc[SOCKET_BACKSTOP_FLAG]) return;
+  const nodeEnv = process.env.NODE_ENV;
+  if (nodeEnv === "production" || nodeEnv === "test") return;
   if (process.env.VITEST === "true") return;
   proc[SOCKET_BACKSTOP_FLAG] = true;
 

--- a/packages/vinext/src/server/socket-error-backstop.ts
+++ b/packages/vinext/src/server/socket-error-backstop.ts
@@ -29,28 +29,26 @@
  * the only place reliably observed to fire (verified via the
  * `VINEXT_DEBUG_SOCKET_ERRORS` marker).
  *
- * **Production / build / test skip.** Three exclusions are critical:
+ * **Prerender check is dynamic, not install-time.** Prerender (in
+ * `build/prerender.ts` and `build/run-prerender.ts`) calls
+ * `startProdServer()` from inside `vinext build` to render pages
+ * against a real HTTP server. User `fetch()` calls during prerender
+ * hit external APIs that can drop connections; absorbing those would
+ * silently produce corrupt prerendered output instead of crashing
+ * the build. Prerender already sets `VINEXT_PRERENDER=1` for its
+ * own purposes — the listener checks it at fire time and re-throws
+ * unconditionally when set, acting as if no listener were installed.
+ * Doing the check at install time wouldn't work: `index.ts` loads at
+ * Vite plugin import (well before prerender starts), so by the time
+ * `VINEXT_PRERENDER` is set the listener would already be installed
+ * via the Symbol.for guard.
  *
- *   - `NODE_ENV === "production"` — covers `vinext build`, including
- *     the prerender pass that calls `startProdServer()` from
- *     `build/run-prerender.ts` and `build/prerender.ts`. User
- *     `fetch()` calls during prerender hit external APIs that can
- *     drop connections; absorbing those silently produces corrupt
- *     prerendered output instead of a build crash. Also covers
- *     `vinext start` for self-hosted Node deploys (loses Next.js's
- *     "install everywhere" parity but acceptable — `pipeline()`
- *     callbacks in prod-server already handle the streaming case).
- *
- *   - `VITEST === "true"` — Vitest workers that import `index.ts`
- *     directly. Genuine peer-disconnect errors during test runs
- *     should surface normally.
- *
- *   - `NODE_ENV === "test"` — other test runners that follow the
- *     standard NODE_ENV convention.
- *
- * Vite sets `NODE_ENV=production` for the build command before
- * plugins load, so the gate fires correctly even when `vinext build`
- * is invoked through `vp build` / `vite build`.
+ * **Test skip is install-time.** Vitest workers that import
+ * `index.ts` directly should never have the listener installed —
+ * peer-disconnect errors during test runs should surface normally.
+ * `process.env.VITEST === "true"` is set by Vitest in every worker;
+ * `NODE_ENV === "test"` covers other test runners that follow the
+ * standard convention.
  *
  * **Listener ordering.** `index.ts` is imported synchronously at the
  * top of every user's `vite.config.ts`, so vinext's listener registers
@@ -75,9 +73,7 @@ const SOCKET_BACKSTOP_FLAG = Symbol.for("vinext.socketErrorBackstop");
 export function installSocketErrorBackstop(): void {
   const proc = process as typeof process & { [SOCKET_BACKSTOP_FLAG]?: true };
   if (proc[SOCKET_BACKSTOP_FLAG]) return;
-  const nodeEnv = process.env.NODE_ENV;
-  if (nodeEnv === "production" || nodeEnv === "test") return;
-  if (process.env.VITEST === "true") return;
+  if (process.env.VITEST === "true" || process.env.NODE_ENV === "test") return;
   proc[SOCKET_BACKSTOP_FLAG] = true;
 
   const debug = process.env.VINEXT_DEBUG_SOCKET_ERRORS === "1";
@@ -87,6 +83,7 @@ export function installSocketErrorBackstop(): void {
   };
   if (debug) console.warn("[vinext] socket-error backstop installed");
   process.on("uncaughtException", (err: Error) => {
+    if (process.env.VINEXT_PRERENDER === "1") throw err;
     const code = peerDisconnectCode(err);
     if (code) {
       if (debug) console.warn(`[vinext] absorbed uncaughtException ${code}`);
@@ -95,6 +92,7 @@ export function installSocketErrorBackstop(): void {
     throw err;
   });
   process.on("unhandledRejection", (reason: unknown) => {
+    if (process.env.VINEXT_PRERENDER === "1") throw reason;
     const code = peerDisconnectCode(reason);
     if (code) {
       if (debug) console.warn(`[vinext] absorbed unhandledRejection ${code}`);

--- a/packages/vinext/src/server/socket-error-backstop.ts
+++ b/packages/vinext/src/server/socket-error-backstop.ts
@@ -1,0 +1,82 @@
+/**
+ * Process-level backstop for peer-disconnect errors that escape
+ * per-connection / per-request error guards.
+ *
+ * Three real call sites in vinext that hit this:
+ *   - `fromWeb(fetch().body).pipe(res)` in proxyExternalRewriteNode.
+ *   - Streaming surfaces inside `@vitejs/plugin-rsc` with their own
+ *     pipe topology (destinations aren't inbound connection sockets).
+ *   - Outbound sockets created by middleware `fetch()`.
+ *
+ * Node's `pipe()` re-emits source errors onto the destination when
+ * the destination has no `'error'` listener, throwing synchronously
+ * inside a `nextTick` callback. The throw escapes to
+ * `uncaughtException`, where this listener filters it.
+ *
+ * Filters strictly on peer-disconnect codes (ECONNRESET / EPIPE /
+ * ECONNABORTED) and synchronously re-throws everything else,
+ * preserving Node's default crash semantics for genuine bugs. This
+ * is more conservative than Next.js's equivalent
+ * (`router-server.ts`'s log-only handler), which silently swallows
+ * every uncaught — vinext keeps real bugs surfacing.
+ *
+ * **Where to call from.** This module exports a function so callers
+ * can gate it correctly. Vinext invokes it from:
+ *   - The `vinext:config` plugin's `config()` hook when
+ *     `command === "serve" && !isPreview` — covers `vinext dev`,
+ *     `vp dev`, `vite dev`, and library embedders that call
+ *     `createServer` themselves.
+ *   - `startProdServer()` in `prod-server.ts` — covers `vinext start`
+ *     for self-hosted Node deployments. Cloudflare Workers prod
+ *     doesn't load this module; the runtime owns socket lifecycle.
+ *
+ * Vitest workers and `vinext build` never reach either entry point,
+ * so genuine peer-disconnect errors in those contexts surface
+ * normally.
+ *
+ * **Listener ordering.** Vinext's listener registers when the
+ * relevant entry point initializes, after most user setup, so
+ * earlier observers (Sentry, structured logging) still see
+ * non-peer-disconnect errors before the sync re-throw aborts further
+ * iteration.
+ *
+ * **Symbol.for caveat.** `Symbol.for("vinext.socketErrorBackstop")`
+ * is process-global, so if two different vinext versions are loaded
+ * in the same process the first to evaluate wins and the second's
+ * filter rules silently don't apply. Idempotent across multiple
+ * invocations within a single process (e.g. server restarts within
+ * a dev session, or a process that runs both dev and prod entries).
+ *
+ * Set `VINEXT_DEBUG_SOCKET_ERRORS=1` to log a one-line marker each
+ * time the listener absorbs an error.
+ */
+const SOCKET_BACKSTOP_FLAG = Symbol.for("vinext.socketErrorBackstop");
+
+export function installSocketErrorBackstop(): void {
+  const proc = process as typeof process & { [SOCKET_BACKSTOP_FLAG]?: true };
+  if (proc[SOCKET_BACKSTOP_FLAG]) return;
+  proc[SOCKET_BACKSTOP_FLAG] = true;
+
+  const debug = process.env.VINEXT_DEBUG_SOCKET_ERRORS === "1";
+  const peerDisconnectCode = (err: unknown): string | undefined => {
+    const code = (err as { code?: string } | null)?.code;
+    return code === "ECONNRESET" || code === "EPIPE" || code === "ECONNABORTED" ? code : undefined;
+  };
+  if (debug) console.warn("[vinext] socket-error backstop installed");
+  process.on("uncaughtException", (err: Error) => {
+    const code = peerDisconnectCode(err);
+    if (code) {
+      if (debug) console.warn(`[vinext] absorbed uncaughtException ${code}`);
+      return;
+    }
+    throw err;
+  });
+  process.on("unhandledRejection", (reason: unknown) => {
+    const code = peerDisconnectCode(reason);
+    if (code) {
+      if (debug) console.warn(`[vinext] absorbed unhandledRejection ${code}`);
+      return;
+    }
+    throw reason;
+  });
+}

--- a/packages/vinext/src/server/socket-error-backstop.ts
+++ b/packages/vinext/src/server/socket-error-backstop.ts
@@ -39,9 +39,19 @@
  * own purposes — the listener checks it at fire time and re-throws
  * unconditionally when set, acting as if no listener were installed.
  * Doing the check at install time wouldn't work: `index.ts` loads at
- * Vite plugin import (well before prerender starts), so by the time
- * `VINEXT_PRERENDER` is set the listener would already be installed
- * via the Symbol.for guard.
+ * Vite plugin import, well before prerender starts, so by the time
+ * `VINEXT_PRERENDER` is set the listener has already been installed
+ * (we cannot uninstall and re-install per phase).
+ *
+ * Side-effect of the unconditional re-throw during prerender: an
+ * orchestrator-induced ECONNRESET (e.g. the prerender's own HTTP
+ * client aborting a stuck route fetch) will surface the build crash
+ * as `Error: read ECONNRESET` rather than the underlying route
+ * failure. Acceptable trade-off — a hung prerender route is itself
+ * a build problem worth surfacing — but the resulting stack will
+ * point at the disconnect, not the cause. Set
+ * `VINEXT_DEBUG_SOCKET_ERRORS=1` to log peer-disconnect codes if
+ * you need to disambiguate.
  *
  * **Test skip is install-time.** Vitest workers that import
  * `index.ts` directly should never have the listener installed —

--- a/packages/vinext/src/server/socket-error-backstop.ts
+++ b/packages/vinext/src/server/socket-error-backstop.ts
@@ -80,6 +80,27 @@
  */
 const SOCKET_BACKSTOP_FLAG = Symbol.for("vinext.socketErrorBackstop");
 
+/**
+ * Pure predicate: returns the peer-disconnect code when `err` carries
+ * one of `ECONNRESET` / `EPIPE` / `ECONNABORTED`, otherwise `undefined`.
+ * Exported for unit testing in isolation (no process-state mutation).
+ */
+export function peerDisconnectCode(err: unknown): string | undefined {
+  const code = (err as { code?: string } | null)?.code;
+  return code === "ECONNRESET" || code === "EPIPE" || code === "ECONNABORTED" ? code : undefined;
+}
+
+/**
+ * Test-only: returns whether the backstop has been installed in this
+ * process. Used by the unit test to assert idempotent install via the
+ * Symbol.for guard. Not part of the public API.
+ */
+export function isSocketErrorBackstopInstalled(): boolean {
+  return Boolean(
+    (process as typeof process & { [SOCKET_BACKSTOP_FLAG]?: true })[SOCKET_BACKSTOP_FLAG],
+  );
+}
+
 export function installSocketErrorBackstop(): void {
   const proc = process as typeof process & { [SOCKET_BACKSTOP_FLAG]?: true };
   if (proc[SOCKET_BACKSTOP_FLAG]) return;
@@ -87,10 +108,6 @@ export function installSocketErrorBackstop(): void {
   proc[SOCKET_BACKSTOP_FLAG] = true;
 
   const debug = process.env.VINEXT_DEBUG_SOCKET_ERRORS === "1";
-  const peerDisconnectCode = (err: unknown): string | undefined => {
-    const code = (err as { code?: string } | null)?.code;
-    return code === "ECONNRESET" || code === "EPIPE" || code === "ECONNABORTED" ? code : undefined;
-  };
   if (debug) console.warn("[vinext] socket-error backstop installed");
   process.on("uncaughtException", (err: Error) => {
     if (process.env.VINEXT_PRERENDER === "1") throw err;

--- a/packages/vinext/src/server/socket-error-backstop.ts
+++ b/packages/vinext/src/server/socket-error-backstop.ts
@@ -20,32 +20,34 @@
  * (`router-server.ts`'s log-only handler), which silently swallows
  * every uncaught — vinext keeps real bugs surfacing.
  *
- * **Where to call from.** This module exports a function so callers
- * can gate it correctly. Vinext invokes it from:
- *   - The `vinext:config` plugin's `config()` hook when
- *     `command === "serve" && !isPreview` — covers `vinext dev`,
- *     `vp dev`, `vite dev`, and library embedders that call
- *     `createServer` themselves.
- *   - `startProdServer()` in `prod-server.ts` — covers `vinext start`
- *     for self-hosted Node deployments. Cloudflare Workers prod
- *     doesn't load this module; the runtime owns socket lifecycle.
+ * **Installed at module load.** Earlier iterations tried to gate
+ * install via Vite's `config()` hook (`command === "serve"`) so it
+ * was strictly dev-only, but the hook didn't fire reliably in
+ * vite-plus's lifecycle — install was silently skipped. The
+ * connection-level guard from #911 confirms `configureServer`-tied
+ * lifecycle hooks are timing-fragile too. Module-load install is
+ * the only place that's been reliably observed to fire (verified
+ * via the `VINEXT_DEBUG_SOCKET_ERRORS` marker).
  *
- * Vitest workers and `vinext build` never reach either entry point,
- * so genuine peer-disconnect errors in those contexts surface
- * normally.
+ * The earlier reason for hoisting still applies: prior versions tied
+ * teardown to `httpServer` `'close'`, which Vite emits on dep
+ * re-optimization and full reloads, leaving a window where the
+ * listener was absent when a stale stream errored. No teardown here.
  *
- * **Listener ordering.** Vinext's listener registers when the
- * relevant entry point initializes, after most user setup, so
- * earlier observers (Sentry, structured logging) still see
- * non-peer-disconnect errors before the sync re-throw aborts further
- * iteration.
+ * **Vitest skip.** Vitest workers import this module via test files
+ * that depend on `index.ts`. Skip install in those contexts so
+ * genuine peer-disconnect errors during test runs surface normally.
+ * `process.env.VITEST === "true"` is set by Vitest in every worker.
+ *
+ * Build runs (`vinext build`) also import index.ts but the listener
+ * is harmless there — the build process is short-lived and doesn't
+ * stream peer-disconnect-prone responses. Matches Next.js's pattern
+ * of installing in any HTTP-serving entry without further gating.
  *
  * **Symbol.for caveat.** `Symbol.for("vinext.socketErrorBackstop")`
  * is process-global, so if two different vinext versions are loaded
  * in the same process the first to evaluate wins and the second's
- * filter rules silently don't apply. Idempotent across multiple
- * invocations within a single process (e.g. server restarts within
- * a dev session, or a process that runs both dev and prod entries).
+ * filter rules silently don't apply.
  *
  * Set `VINEXT_DEBUG_SOCKET_ERRORS=1` to log a one-line marker each
  * time the listener absorbs an error.
@@ -55,6 +57,7 @@ const SOCKET_BACKSTOP_FLAG = Symbol.for("vinext.socketErrorBackstop");
 export function installSocketErrorBackstop(): void {
   const proc = process as typeof process & { [SOCKET_BACKSTOP_FLAG]?: true };
   if (proc[SOCKET_BACKSTOP_FLAG]) return;
+  if (process.env.VITEST === "true") return;
   proc[SOCKET_BACKSTOP_FLAG] = true;
 
   const debug = process.env.VINEXT_DEBUG_SOCKET_ERRORS === "1";
@@ -80,3 +83,10 @@ export function installSocketErrorBackstop(): void {
     throw reason;
   });
 }
+
+// Auto-install at module load. The Vite plugin lifecycle hooks proved
+// timing-fragile in vite-plus, so we install eagerly. The Vitest skip
+// inside installSocketErrorBackstop() is the only context-specific
+// guard. Idempotent — prod-server.ts's explicit call is a no-op when
+// loaded in the same process.
+installSocketErrorBackstop();

--- a/tests/socket-error-backstop.test.ts
+++ b/tests/socket-error-backstop.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  isSocketErrorBackstopInstalled,
+  peerDisconnectCode,
+} from "../packages/vinext/src/server/socket-error-backstop.js";
+
+describe("peerDisconnectCode", () => {
+  it("returns the matched code for peer-disconnect errors", () => {
+    expect(peerDisconnectCode(Object.assign(new Error("reset"), { code: "ECONNRESET" }))).toBe(
+      "ECONNRESET",
+    );
+    expect(peerDisconnectCode(Object.assign(new Error("pipe"), { code: "EPIPE" }))).toBe("EPIPE");
+    expect(peerDisconnectCode(Object.assign(new Error("aborted"), { code: "ECONNABORTED" }))).toBe(
+      "ECONNABORTED",
+    );
+  });
+
+  it("returns undefined for non-peer-disconnect errors", () => {
+    expect(peerDisconnectCode(new Error("boom"))).toBeUndefined();
+    expect(
+      peerDisconnectCode(Object.assign(new Error("nope"), { code: "ENOENT" })),
+    ).toBeUndefined();
+    expect(
+      peerDisconnectCode(Object.assign(new Error("ehost"), { code: "EHOSTUNREACH" })),
+    ).toBeUndefined();
+  });
+
+  it("handles non-Error / null / primitive reasons without throwing", () => {
+    // unhandledRejection can fire with arbitrary reason values.
+    expect(peerDisconnectCode(null)).toBeUndefined();
+    expect(peerDisconnectCode(undefined)).toBeUndefined();
+    expect(peerDisconnectCode("ECONNRESET")).toBeUndefined();
+    expect(peerDisconnectCode(42)).toBeUndefined();
+    // Plain object with the right shape is accepted (Node sometimes
+    // emits these from native stream errors).
+    expect(peerDisconnectCode({ code: "ECONNRESET" })).toBe("ECONNRESET");
+    expect(peerDisconnectCode({ code: "OTHER" })).toBeUndefined();
+  });
+});
+
+describe("installSocketErrorBackstop", () => {
+  it("skips installation in test runners", () => {
+    // process.env.VITEST is "true" inside Vitest workers, so import-time
+    // installation is short-circuited and the predicate stays false.
+    expect(process.env.VITEST).toBe("true");
+    expect(isSocketErrorBackstopInstalled()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Real fix for the residual #905 crashes that #913 didn't catch. Confirmed via the opt-in trace below.

#913 installed the `uncaughtException` handler inside `configureServer` and tore it down on `httpServer` `'close'`. Vite emits `close` on dep re-optimization, full reloads, and other lifecycle events — leaving a window where the listener is absent when a stale stream errors. The exact pattern users were hitting:

```
GET /page 200 in 109ms
node:events:487
      throw er; // Unhandled 'error' event
Error: read ECONNRESET
```

Reproducer confirmed with the diagnostic flag from this PR:

```
$ VINEXT_DEBUG_SOCKET_ERRORS=1 vp dlx https://pkg.pr.new/vinext@916 dev
...
[vinext] absorbed uncaughtException ECONNRESET
```

The marker firing where the crash used to happen confirms the listener is now in place when the error fires.

## Changes

1. **Hoist install from `configureServer` to module top-level**, guarded by `Symbol.for("vinext.devSocketErrorBackstop")` to prevent double-install (e.g. when vinext is loaded by both a project and a sibling workspace package). No teardown — the listener lives for the process.

2. **Add opt-in `VINEXT_DEBUG_SOCKET_ERRORS=1` trace** that logs when the listener absorbs a peer-disconnect. Default off; useful for confirming the listener fires when users still see crashes in the field.

Filter codes (`ECONNRESET` / `EPIPE` / `ECONNABORTED`) and synchronous re-throw of non-peer-disconnect errors are unchanged from #913.

## Refs

- Refs #905 (residual crashes after #911 and #913)
- Closes #915 (the `EventEmitter.prototype.emit` patch was the wrong direction — domain can replace prototype emit on its load, so that approach was fragile)

## Test plan

- [x] `vp check` passes (1 pre-existing benchmarks `Cannot find module 'vinext'` error is unrelated)
- [x] Reproducer from #905: `VINEXT_DEBUG_SOCKET_ERRORS=1 vp dev` no longer crashes; `[vinext] absorbed uncaughtException ECONNRESET` printed where the crash used to be
- [x] Genuine programming errors still crash dev server with full stack (sync re-throw preserves Node default crash semantics)

🤖 Generated with [Claude Code](https://claude.com/claude-code)