### PR TITLE
fix(app-router): tag cached pages by route pattern

### DIFF
--- a/knip.ts
+++ b/knip.ts
@@ -70,8 +70,8 @@ export default {
     // probed via require.resolve
     "next-intl",
 
-    // vitest reporter
-    "agent",
+    // vitest reporter used outside CI
+    ...(process.env.CI ? [] : ["agent"]),
 
     // internal module name, not an actual dependency
     "private-next-instrumentation-client",

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -57,6 +57,7 @@ const appRouteHandlerCachePath = resolveEntryPath(
   "../server/app-route-handler-cache.js",
   import.meta.url,
 );
+const implicitTagsPath = resolveEntryPath("../server/implicit-tags.js", import.meta.url);
 const appPageCachePath = resolveEntryPath("../server/app-page-cache.js", import.meta.url);
 const appPageExecutionPath = resolveEntryPath("../server/app-page-execution.js", import.meta.url);
 const appPageBoundaryRenderPath = resolveEntryPath(
@@ -431,6 +432,7 @@ import {
 import {
   applyRouteHandlerMiddlewareContext as __applyRouteHandlerMiddlewareContext,
 } from ${JSON.stringify(appRouteHandlerResponsePath)};
+import { buildPageCacheTags } from ${JSON.stringify(implicitTagsPath)};
 import { _consumeRequestScopedCacheLife, getCacheHandler } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from ${JSON.stringify(requestContextShimPath)};
 import { ensureFetchPatch as _ensureFetchPatch, getCollectedFetchTags, setCurrentFetchSoftTags } from "vinext/fetch-cache";
@@ -487,27 +489,6 @@ async function __isrGet(key) {
 async function __isrSet(key, data, revalidateSeconds, tags) {
   const handler = getCacheHandler();
   await handler.set(key, data, { revalidate: revalidateSeconds, tags: Array.isArray(tags) ? tags : [] });
-}
-function __pageCacheTags(pathname, extraTags) {
-  const tags = [pathname, "_N_T_" + pathname];
-  // Layout hierarchy tags — matches Next.js getDerivedTags.
-  tags.push("_N_T_/layout");
-  const segments = pathname.split("/");
-  let built = "";
-  for (let i = 1; i < segments.length; i++) {
-    if (segments[i]) {
-      built += "/" + segments[i];
-      tags.push("_N_T_" + built + "/layout");
-    }
-  }
-  // Leaf page tag — revalidatePath(path, "page") targets this.
-  tags.push("_N_T_" + built + "/page");
-  if (Array.isArray(extraTags)) {
-    for (const tag of extraTags) {
-      if (!tags.includes(tag)) tags.push(tag);
-    }
-  }
-  return tags;
 }
 // Note: cache entries are written with \`headers: undefined\`. Next.js stores
 // response headers (e.g. set-cookie from cookies().set() during render) in the
@@ -2121,7 +2102,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   }
 
   const { route, params } = match;
-  setCurrentFetchSoftTags(__pageCacheTags(cleanPathname, []));
+  setCurrentFetchSoftTags(
+    buildPageCacheTags(cleanPathname, [], route.routeSegments, route.routeHandler ? "route" : "page"),
+  );
 
   // Update navigation context with matched params
   setNavigationContext({
@@ -2135,6 +2118,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     const handler = route.routeHandler;
     const method = request.method.toUpperCase();
     const revalidateSeconds = __getAppRouteHandlerRevalidateSeconds(handler);
+    const __buildRouteHandlerPageCacheTags = function(pathname, extraTags) {
+      return buildPageCacheTags(pathname, extraTags, route.routeSegments, "route");
+    };
     if (__hasAppRouteHandlerDefaultExport(handler) && process.env.NODE_ENV === "development") {
       console.error(
         "[vinext] Detected default export in route handler " + route.pattern + ". Export a named export for each HTTP method instead.",
@@ -2178,7 +2164,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     ) {
       const __cachedRouteResponse = await __readAppRouteHandlerCacheResponse({
         basePath: __basePath,
-        buildPageCacheTags: __pageCacheTags,
+        buildPageCacheTags: __buildRouteHandlerPageCacheTags,
         cleanPathname,
         clearRequestContext: function() {
           setHeadersContext(null);
@@ -2208,7 +2194,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           });
           await _runWithUnifiedCtx(__revalUCtx, async () => {
             _ensureFetchPatch();
-            setCurrentFetchSoftTags(__pageCacheTags(cleanPathname, []));
+            setCurrentFetchSoftTags(buildPageCacheTags(cleanPathname, [], route.routeSegments, "route"));
             await renderFn();
           });
         },
@@ -2223,7 +2209,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     if (typeof handlerFn === "function") {
       return __executeAppRouteHandler({
         basePath: __basePath,
-        buildPageCacheTags: __pageCacheTags,
+        buildPageCacheTags: __buildRouteHandlerPageCacheTags,
         cleanPathname,
         clearRequestContext: function() {
           setHeadersContext(null);
@@ -2359,7 +2345,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         });
         return _runWithUnifiedCtx(__revalUCtx, async () => {
           _ensureFetchPatch();
-          setCurrentFetchSoftTags(__pageCacheTags(cleanPathname, []));
+          setCurrentFetchSoftTags(buildPageCacheTags(cleanPathname, [], route.routeSegments, "page"));
           setNavigationContext({ pathname: cleanPathname, searchParams: new URLSearchParams(), params });
           // Slot context (X-Vinext-Mounted-Slots) is inherited from the
           // triggering request so the regen result is cached under the
@@ -2390,7 +2376,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           setNavigationContext(null);
           const __freshHtml = await __readAppPageTextStream(__revalHtmlStream);
           const __freshRscData = await __revalRscCapture.capturedRscDataPromise;
-          const __pageTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
+          const __pageTags = buildPageCacheTags(cleanPathname, getCollectedFetchTags(), route.routeSegments, "page");
           return { html: __freshHtml, rscData: __freshRscData, tags: __pageTags };
         });
       },
@@ -2558,7 +2544,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     getFontStyles: _getSSRFontStyles,
     getNavigationContext: _getNavigationContext,
     getPageTags() {
-      return __pageCacheTags(cleanPathname, getCollectedFetchTags());
+      return buildPageCacheTags(cleanPathname, getCollectedFetchTags(), route.routeSegments, "page");
     },
     getRequestCacheLife() {
       return _consumeRequestScopedCacheLife();

--- a/packages/vinext/src/server/implicit-tags.ts
+++ b/packages/vinext/src/server/implicit-tags.ts
@@ -1,0 +1,62 @@
+const NEXT_CACHE_IMPLICIT_TAG_ID = "_N_T_";
+
+type AppCacheLeafKind = "page" | "route";
+
+function appendUnique(tags: string[], tag: string): void {
+  if (!tags.includes(tag)) tags.push(tag);
+}
+
+// App route segments come from raw filesystem directories, so dynamic
+// segments are already in bracket notation such as [slug] or [...all].
+function normalizeRouteSegment(segment: string): string | null {
+  if (!segment || segment === "." || segment.startsWith("@")) return null;
+  return segment;
+}
+
+function buildRouteCachePath(routeSegments: string[], leafKind: AppCacheLeafKind): string {
+  const parts: string[] = [];
+  for (const segment of routeSegments) {
+    const normalized = normalizeRouteSegment(segment);
+    if (normalized) parts.push(normalized);
+  }
+  parts.push(leafKind);
+  return `/${parts.join("/")}`;
+}
+
+function appendDerivedTags(tags: string[], routePath: string): void {
+  appendUnique(tags, `${NEXT_CACHE_IMPLICIT_TAG_ID}/layout`);
+
+  if (!routePath.startsWith("/")) return;
+
+  const routeParts = routePath.split("/");
+  const leafIndex = routeParts.length - 1;
+  for (let i = 1; i <= routeParts.length; i++) {
+    let currentPathname = routeParts.slice(0, i).join("/");
+    if (!currentPathname) continue;
+
+    const isLeaf = i - 1 === leafIndex;
+    if (!isLeaf) {
+      currentPathname = `${currentPathname}/layout`;
+    }
+
+    appendUnique(tags, `${NEXT_CACHE_IMPLICIT_TAG_ID}${currentPathname}`);
+  }
+}
+
+export function buildPageCacheTags(
+  pathname: string,
+  extraTags: string[],
+  routeSegments: string[],
+  leafKind: AppCacheLeafKind,
+): string[] {
+  const tags = [pathname, `${NEXT_CACHE_IMPLICIT_TAG_ID}${pathname}`];
+  if (pathname === "/") appendUnique(tags, `${NEXT_CACHE_IMPLICIT_TAG_ID}/index`);
+  if (pathname === "/index") appendUnique(tags, `${NEXT_CACHE_IMPLICIT_TAG_ID}/`);
+  appendDerivedTags(tags, buildRouteCachePath(routeSegments, leafKind));
+
+  for (const tag of extraTags) {
+    appendUnique(tags, tag);
+  }
+
+  return tags;
+}

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -107,6 +107,7 @@ import {
 import {
   applyRouteHandlerMiddlewareContext as __applyRouteHandlerMiddlewareContext,
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-response.js";
+import { buildPageCacheTags } from "<ROOT>/packages/vinext/src/server/implicit-tags.js";
 import { _consumeRequestScopedCacheLife, getCacheHandler } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
 import { ensureFetchPatch as _ensureFetchPatch, getCollectedFetchTags, setCurrentFetchSoftTags } from "vinext/fetch-cache";
@@ -163,27 +164,6 @@ async function __isrGet(key) {
 async function __isrSet(key, data, revalidateSeconds, tags) {
   const handler = getCacheHandler();
   await handler.set(key, data, { revalidate: revalidateSeconds, tags: Array.isArray(tags) ? tags : [] });
-}
-function __pageCacheTags(pathname, extraTags) {
-  const tags = [pathname, "_N_T_" + pathname];
-  // Layout hierarchy tags — matches Next.js getDerivedTags.
-  tags.push("_N_T_/layout");
-  const segments = pathname.split("/");
-  let built = "";
-  for (let i = 1; i < segments.length; i++) {
-    if (segments[i]) {
-      built += "/" + segments[i];
-      tags.push("_N_T_" + built + "/layout");
-    }
-  }
-  // Leaf page tag — revalidatePath(path, "page") targets this.
-  tags.push("_N_T_" + built + "/page");
-  if (Array.isArray(extraTags)) {
-    for (const tag of extraTags) {
-      if (!tags.includes(tag)) tags.push(tag);
-    }
-  }
-  return tags;
 }
 // Note: cache entries are written with \`headers: undefined\`. Next.js stores
 // response headers (e.g. set-cookie from cookies().set() during render) in the
@@ -1795,7 +1775,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   }
 
   const { route, params } = match;
-  setCurrentFetchSoftTags(__pageCacheTags(cleanPathname, []));
+  setCurrentFetchSoftTags(
+    buildPageCacheTags(cleanPathname, [], route.routeSegments, route.routeHandler ? "route" : "page"),
+  );
 
   // Update navigation context with matched params
   setNavigationContext({
@@ -1809,6 +1791,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     const handler = route.routeHandler;
     const method = request.method.toUpperCase();
     const revalidateSeconds = __getAppRouteHandlerRevalidateSeconds(handler);
+    const __buildRouteHandlerPageCacheTags = function(pathname, extraTags) {
+      return buildPageCacheTags(pathname, extraTags, route.routeSegments, "route");
+    };
     if (__hasAppRouteHandlerDefaultExport(handler) && process.env.NODE_ENV === "development") {
       console.error(
         "[vinext] Detected default export in route handler " + route.pattern + ". Export a named export for each HTTP method instead.",
@@ -1852,7 +1837,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     ) {
       const __cachedRouteResponse = await __readAppRouteHandlerCacheResponse({
         basePath: __basePath,
-        buildPageCacheTags: __pageCacheTags,
+        buildPageCacheTags: __buildRouteHandlerPageCacheTags,
         cleanPathname,
         clearRequestContext: function() {
           setHeadersContext(null);
@@ -1882,7 +1867,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           });
           await _runWithUnifiedCtx(__revalUCtx, async () => {
             _ensureFetchPatch();
-            setCurrentFetchSoftTags(__pageCacheTags(cleanPathname, []));
+            setCurrentFetchSoftTags(buildPageCacheTags(cleanPathname, [], route.routeSegments, "route"));
             await renderFn();
           });
         },
@@ -1897,7 +1882,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     if (typeof handlerFn === "function") {
       return __executeAppRouteHandler({
         basePath: __basePath,
-        buildPageCacheTags: __pageCacheTags,
+        buildPageCacheTags: __buildRouteHandlerPageCacheTags,
         cleanPathname,
         clearRequestContext: function() {
           setHeadersContext(null);
@@ -2033,7 +2018,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         });
         return _runWithUnifiedCtx(__revalUCtx, async () => {
           _ensureFetchPatch();
-          setCurrentFetchSoftTags(__pageCacheTags(cleanPathname, []));
+          setCurrentFetchSoftTags(buildPageCacheTags(cleanPathname, [], route.routeSegments, "page"));
           setNavigationContext({ pathname: cleanPathname, searchParams: new URLSearchParams(), params });
           // Slot context (X-Vinext-Mounted-Slots) is inherited from the
           // triggering request so the regen result is cached under the
@@ -2064,7 +2049,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           setNavigationContext(null);
           const __freshHtml = await __readAppPageTextStream(__revalHtmlStream);
           const __freshRscData = await __revalRscCapture.capturedRscDataPromise;
-          const __pageTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
+          const __pageTags = buildPageCacheTags(cleanPathname, getCollectedFetchTags(), route.routeSegments, "page");
           return { html: __freshHtml, rscData: __freshRscData, tags: __pageTags };
         });
       },
@@ -2232,7 +2217,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     getFontStyles: _getSSRFontStyles,
     getNavigationContext: _getNavigationContext,
     getPageTags() {
-      return __pageCacheTags(cleanPathname, getCollectedFetchTags());
+      return buildPageCacheTags(cleanPathname, getCollectedFetchTags(), route.routeSegments, "page");
     },
     getRequestCacheLife() {
       return _consumeRequestScopedCacheLife();
@@ -2496,6 +2481,7 @@ import {
 import {
   applyRouteHandlerMiddlewareContext as __applyRouteHandlerMiddlewareContext,
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-response.js";
+import { buildPageCacheTags } from "<ROOT>/packages/vinext/src/server/implicit-tags.js";
 import { _consumeRequestScopedCacheLife, getCacheHandler } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
 import { ensureFetchPatch as _ensureFetchPatch, getCollectedFetchTags, setCurrentFetchSoftTags } from "vinext/fetch-cache";
@@ -2552,27 +2538,6 @@ async function __isrGet(key) {
 async function __isrSet(key, data, revalidateSeconds, tags) {
   const handler = getCacheHandler();
   await handler.set(key, data, { revalidate: revalidateSeconds, tags: Array.isArray(tags) ? tags : [] });
-}
-function __pageCacheTags(pathname, extraTags) {
-  const tags = [pathname, "_N_T_" + pathname];
-  // Layout hierarchy tags — matches Next.js getDerivedTags.
-  tags.push("_N_T_/layout");
-  const segments = pathname.split("/");
-  let built = "";
-  for (let i = 1; i < segments.length; i++) {
-    if (segments[i]) {
-      built += "/" + segments[i];
-      tags.push("_N_T_" + built + "/layout");
-    }
-  }
-  // Leaf page tag — revalidatePath(path, "page") targets this.
-  tags.push("_N_T_" + built + "/page");
-  if (Array.isArray(extraTags)) {
-    for (const tag of extraTags) {
-      if (!tags.includes(tag)) tags.push(tag);
-    }
-  }
-  return tags;
 }
 // Note: cache entries are written with \`headers: undefined\`. Next.js stores
 // response headers (e.g. set-cookie from cookies().set() during render) in the
@@ -4190,7 +4155,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   }
 
   const { route, params } = match;
-  setCurrentFetchSoftTags(__pageCacheTags(cleanPathname, []));
+  setCurrentFetchSoftTags(
+    buildPageCacheTags(cleanPathname, [], route.routeSegments, route.routeHandler ? "route" : "page"),
+  );
 
   // Update navigation context with matched params
   setNavigationContext({
@@ -4204,6 +4171,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     const handler = route.routeHandler;
     const method = request.method.toUpperCase();
     const revalidateSeconds = __getAppRouteHandlerRevalidateSeconds(handler);
+    const __buildRouteHandlerPageCacheTags = function(pathname, extraTags) {
+      return buildPageCacheTags(pathname, extraTags, route.routeSegments, "route");
+    };
     if (__hasAppRouteHandlerDefaultExport(handler) && process.env.NODE_ENV === "development") {
       console.error(
         "[vinext] Detected default export in route handler " + route.pattern + ". Export a named export for each HTTP method instead.",
@@ -4247,7 +4217,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     ) {
       const __cachedRouteResponse = await __readAppRouteHandlerCacheResponse({
         basePath: __basePath,
-        buildPageCacheTags: __pageCacheTags,
+        buildPageCacheTags: __buildRouteHandlerPageCacheTags,
         cleanPathname,
         clearRequestContext: function() {
           setHeadersContext(null);
@@ -4277,7 +4247,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           });
           await _runWithUnifiedCtx(__revalUCtx, async () => {
             _ensureFetchPatch();
-            setCurrentFetchSoftTags(__pageCacheTags(cleanPathname, []));
+            setCurrentFetchSoftTags(buildPageCacheTags(cleanPathname, [], route.routeSegments, "route"));
             await renderFn();
           });
         },
@@ -4292,7 +4262,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     if (typeof handlerFn === "function") {
       return __executeAppRouteHandler({
         basePath: __basePath,
-        buildPageCacheTags: __pageCacheTags,
+        buildPageCacheTags: __buildRouteHandlerPageCacheTags,
         cleanPathname,
         clearRequestContext: function() {
           setHeadersContext(null);
@@ -4428,7 +4398,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         });
         return _runWithUnifiedCtx(__revalUCtx, async () => {
           _ensureFetchPatch();
-          setCurrentFetchSoftTags(__pageCacheTags(cleanPathname, []));
+          setCurrentFetchSoftTags(buildPageCacheTags(cleanPathname, [], route.routeSegments, "page"));
           setNavigationContext({ pathname: cleanPathname, searchParams: new URLSearchParams(), params });
           // Slot context (X-Vinext-Mounted-Slots) is inherited from the
           // triggering request so the regen result is cached under the
@@ -4459,7 +4429,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           setNavigationContext(null);
           const __freshHtml = await __readAppPageTextStream(__revalHtmlStream);
           const __freshRscData = await __revalRscCapture.capturedRscDataPromise;
-          const __pageTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
+          const __pageTags = buildPageCacheTags(cleanPathname, getCollectedFetchTags(), route.routeSegments, "page");
           return { html: __freshHtml, rscData: __freshRscData, tags: __pageTags };
         });
       },
@@ -4627,7 +4597,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     getFontStyles: _getSSRFontStyles,
     getNavigationContext: _getNavigationContext,
     getPageTags() {
-      return __pageCacheTags(cleanPathname, getCollectedFetchTags());
+      return buildPageCacheTags(cleanPathname, getCollectedFetchTags(), route.routeSegments, "page");
     },
     getRequestCacheLife() {
       return _consumeRequestScopedCacheLife();
@@ -4891,6 +4861,7 @@ import {
 import {
   applyRouteHandlerMiddlewareContext as __applyRouteHandlerMiddlewareContext,
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-response.js";
+import { buildPageCacheTags } from "<ROOT>/packages/vinext/src/server/implicit-tags.js";
 import { _consumeRequestScopedCacheLife, getCacheHandler } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
 import { ensureFetchPatch as _ensureFetchPatch, getCollectedFetchTags, setCurrentFetchSoftTags } from "vinext/fetch-cache";
@@ -4947,27 +4918,6 @@ async function __isrGet(key) {
 async function __isrSet(key, data, revalidateSeconds, tags) {
   const handler = getCacheHandler();
   await handler.set(key, data, { revalidate: revalidateSeconds, tags: Array.isArray(tags) ? tags : [] });
-}
-function __pageCacheTags(pathname, extraTags) {
-  const tags = [pathname, "_N_T_" + pathname];
-  // Layout hierarchy tags — matches Next.js getDerivedTags.
-  tags.push("_N_T_/layout");
-  const segments = pathname.split("/");
-  let built = "";
-  for (let i = 1; i < segments.length; i++) {
-    if (segments[i]) {
-      built += "/" + segments[i];
-      tags.push("_N_T_" + built + "/layout");
-    }
-  }
-  // Leaf page tag — revalidatePath(path, "page") targets this.
-  tags.push("_N_T_" + built + "/page");
-  if (Array.isArray(extraTags)) {
-    for (const tag of extraTags) {
-      if (!tags.includes(tag)) tags.push(tag);
-    }
-  }
-  return tags;
 }
 // Note: cache entries are written with \`headers: undefined\`. Next.js stores
 // response headers (e.g. set-cookie from cookies().set() during render) in the
@@ -6580,7 +6530,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   }
 
   const { route, params } = match;
-  setCurrentFetchSoftTags(__pageCacheTags(cleanPathname, []));
+  setCurrentFetchSoftTags(
+    buildPageCacheTags(cleanPathname, [], route.routeSegments, route.routeHandler ? "route" : "page"),
+  );
 
   // Update navigation context with matched params
   setNavigationContext({
@@ -6594,6 +6546,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     const handler = route.routeHandler;
     const method = request.method.toUpperCase();
     const revalidateSeconds = __getAppRouteHandlerRevalidateSeconds(handler);
+    const __buildRouteHandlerPageCacheTags = function(pathname, extraTags) {
+      return buildPageCacheTags(pathname, extraTags, route.routeSegments, "route");
+    };
     if (__hasAppRouteHandlerDefaultExport(handler) && process.env.NODE_ENV === "development") {
       console.error(
         "[vinext] Detected default export in route handler " + route.pattern + ". Export a named export for each HTTP method instead.",
@@ -6637,7 +6592,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     ) {
       const __cachedRouteResponse = await __readAppRouteHandlerCacheResponse({
         basePath: __basePath,
-        buildPageCacheTags: __pageCacheTags,
+        buildPageCacheTags: __buildRouteHandlerPageCacheTags,
         cleanPathname,
         clearRequestContext: function() {
           setHeadersContext(null);
@@ -6667,7 +6622,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           });
           await _runWithUnifiedCtx(__revalUCtx, async () => {
             _ensureFetchPatch();
-            setCurrentFetchSoftTags(__pageCacheTags(cleanPathname, []));
+            setCurrentFetchSoftTags(buildPageCacheTags(cleanPathname, [], route.routeSegments, "route"));
             await renderFn();
           });
         },
@@ -6682,7 +6637,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     if (typeof handlerFn === "function") {
       return __executeAppRouteHandler({
         basePath: __basePath,
-        buildPageCacheTags: __pageCacheTags,
+        buildPageCacheTags: __buildRouteHandlerPageCacheTags,
         cleanPathname,
         clearRequestContext: function() {
           setHeadersContext(null);
@@ -6818,7 +6773,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         });
         return _runWithUnifiedCtx(__revalUCtx, async () => {
           _ensureFetchPatch();
-          setCurrentFetchSoftTags(__pageCacheTags(cleanPathname, []));
+          setCurrentFetchSoftTags(buildPageCacheTags(cleanPathname, [], route.routeSegments, "page"));
           setNavigationContext({ pathname: cleanPathname, searchParams: new URLSearchParams(), params });
           // Slot context (X-Vinext-Mounted-Slots) is inherited from the
           // triggering request so the regen result is cached under the
@@ -6849,7 +6804,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           setNavigationContext(null);
           const __freshHtml = await __readAppPageTextStream(__revalHtmlStream);
           const __freshRscData = await __revalRscCapture.capturedRscDataPromise;
-          const __pageTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
+          const __pageTags = buildPageCacheTags(cleanPathname, getCollectedFetchTags(), route.routeSegments, "page");
           return { html: __freshHtml, rscData: __freshRscData, tags: __pageTags };
         });
       },
@@ -7017,7 +6972,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     getFontStyles: _getSSRFontStyles,
     getNavigationContext: _getNavigationContext,
     getPageTags() {
-      return __pageCacheTags(cleanPathname, getCollectedFetchTags());
+      return buildPageCacheTags(cleanPathname, getCollectedFetchTags(), route.routeSegments, "page");
     },
     getRequestCacheLife() {
       return _consumeRequestScopedCacheLife();
@@ -7281,6 +7236,7 @@ import {
 import {
   applyRouteHandlerMiddlewareContext as __applyRouteHandlerMiddlewareContext,
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-response.js";
+import { buildPageCacheTags } from "<ROOT>/packages/vinext/src/server/implicit-tags.js";
 import { _consumeRequestScopedCacheLife, getCacheHandler } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
 import { ensureFetchPatch as _ensureFetchPatch, getCollectedFetchTags, setCurrentFetchSoftTags } from "vinext/fetch-cache";
@@ -7337,27 +7293,6 @@ async function __isrGet(key) {
 async function __isrSet(key, data, revalidateSeconds, tags) {
   const handler = getCacheHandler();
   await handler.set(key, data, { revalidate: revalidateSeconds, tags: Array.isArray(tags) ? tags : [] });
-}
-function __pageCacheTags(pathname, extraTags) {
-  const tags = [pathname, "_N_T_" + pathname];
-  // Layout hierarchy tags — matches Next.js getDerivedTags.
-  tags.push("_N_T_/layout");
-  const segments = pathname.split("/");
-  let built = "";
-  for (let i = 1; i < segments.length; i++) {
-    if (segments[i]) {
-      built += "/" + segments[i];
-      tags.push("_N_T_" + built + "/layout");
-    }
-  }
-  // Leaf page tag — revalidatePath(path, "page") targets this.
-  tags.push("_N_T_" + built + "/page");
-  if (Array.isArray(extraTags)) {
-    for (const tag of extraTags) {
-      if (!tags.includes(tag)) tags.push(tag);
-    }
-  }
-  return tags;
 }
 // Note: cache entries are written with \`headers: undefined\`. Next.js stores
 // response headers (e.g. set-cookie from cookies().set() during render) in the
@@ -9002,7 +8937,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   }
 
   const { route, params } = match;
-  setCurrentFetchSoftTags(__pageCacheTags(cleanPathname, []));
+  setCurrentFetchSoftTags(
+    buildPageCacheTags(cleanPathname, [], route.routeSegments, route.routeHandler ? "route" : "page"),
+  );
 
   // Update navigation context with matched params
   setNavigationContext({
@@ -9016,6 +8953,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     const handler = route.routeHandler;
     const method = request.method.toUpperCase();
     const revalidateSeconds = __getAppRouteHandlerRevalidateSeconds(handler);
+    const __buildRouteHandlerPageCacheTags = function(pathname, extraTags) {
+      return buildPageCacheTags(pathname, extraTags, route.routeSegments, "route");
+    };
     if (__hasAppRouteHandlerDefaultExport(handler) && process.env.NODE_ENV === "development") {
       console.error(
         "[vinext] Detected default export in route handler " + route.pattern + ". Export a named export for each HTTP method instead.",
@@ -9059,7 +8999,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     ) {
       const __cachedRouteResponse = await __readAppRouteHandlerCacheResponse({
         basePath: __basePath,
-        buildPageCacheTags: __pageCacheTags,
+        buildPageCacheTags: __buildRouteHandlerPageCacheTags,
         cleanPathname,
         clearRequestContext: function() {
           setHeadersContext(null);
@@ -9089,7 +9029,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           });
           await _runWithUnifiedCtx(__revalUCtx, async () => {
             _ensureFetchPatch();
-            setCurrentFetchSoftTags(__pageCacheTags(cleanPathname, []));
+            setCurrentFetchSoftTags(buildPageCacheTags(cleanPathname, [], route.routeSegments, "route"));
             await renderFn();
           });
         },
@@ -9104,7 +9044,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     if (typeof handlerFn === "function") {
       return __executeAppRouteHandler({
         basePath: __basePath,
-        buildPageCacheTags: __pageCacheTags,
+        buildPageCacheTags: __buildRouteHandlerPageCacheTags,
         cleanPathname,
         clearRequestContext: function() {
           setHeadersContext(null);
@@ -9240,7 +9180,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         });
         return _runWithUnifiedCtx(__revalUCtx, async () => {
           _ensureFetchPatch();
-          setCurrentFetchSoftTags(__pageCacheTags(cleanPathname, []));
+          setCurrentFetchSoftTags(buildPageCacheTags(cleanPathname, [], route.routeSegments, "page"));
           setNavigationContext({ pathname: cleanPathname, searchParams: new URLSearchParams(), params });
           // Slot context (X-Vinext-Mounted-Slots) is inherited from the
           // triggering request so the regen result is cached under the
@@ -9271,7 +9211,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           setNavigationContext(null);
           const __freshHtml = await __readAppPageTextStream(__revalHtmlStream);
           const __freshRscData = await __revalRscCapture.capturedRscDataPromise;
-          const __pageTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
+          const __pageTags = buildPageCacheTags(cleanPathname, getCollectedFetchTags(), route.routeSegments, "page");
           return { html: __freshHtml, rscData: __freshRscData, tags: __pageTags };
         });
       },
@@ -9439,7 +9379,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     getFontStyles: _getSSRFontStyles,
     getNavigationContext: _getNavigationContext,
     getPageTags() {
-      return __pageCacheTags(cleanPathname, getCollectedFetchTags());
+      return buildPageCacheTags(cleanPathname, getCollectedFetchTags(), route.routeSegments, "page");
     },
     getRequestCacheLife() {
       return _consumeRequestScopedCacheLife();
@@ -9703,6 +9643,7 @@ import {
 import {
   applyRouteHandlerMiddlewareContext as __applyRouteHandlerMiddlewareContext,
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-response.js";
+import { buildPageCacheTags } from "<ROOT>/packages/vinext/src/server/implicit-tags.js";
 import { _consumeRequestScopedCacheLife, getCacheHandler } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
 import { ensureFetchPatch as _ensureFetchPatch, getCollectedFetchTags, setCurrentFetchSoftTags } from "vinext/fetch-cache";
@@ -9759,27 +9700,6 @@ async function __isrGet(key) {
 async function __isrSet(key, data, revalidateSeconds, tags) {
   const handler = getCacheHandler();
   await handler.set(key, data, { revalidate: revalidateSeconds, tags: Array.isArray(tags) ? tags : [] });
-}
-function __pageCacheTags(pathname, extraTags) {
-  const tags = [pathname, "_N_T_" + pathname];
-  // Layout hierarchy tags — matches Next.js getDerivedTags.
-  tags.push("_N_T_/layout");
-  const segments = pathname.split("/");
-  let built = "";
-  for (let i = 1; i < segments.length; i++) {
-    if (segments[i]) {
-      built += "/" + segments[i];
-      tags.push("_N_T_" + built + "/layout");
-    }
-  }
-  // Leaf page tag — revalidatePath(path, "page") targets this.
-  tags.push("_N_T_" + built + "/page");
-  if (Array.isArray(extraTags)) {
-    for (const tag of extraTags) {
-      if (!tags.includes(tag)) tags.push(tag);
-    }
-  }
-  return tags;
 }
 // Note: cache entries are written with \`headers: undefined\`. Next.js stores
 // response headers (e.g. set-cookie from cookies().set() during render) in the
@@ -11398,7 +11318,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   }
 
   const { route, params } = match;
-  setCurrentFetchSoftTags(__pageCacheTags(cleanPathname, []));
+  setCurrentFetchSoftTags(
+    buildPageCacheTags(cleanPathname, [], route.routeSegments, route.routeHandler ? "route" : "page"),
+  );
 
   // Update navigation context with matched params
   setNavigationContext({
@@ -11412,6 +11334,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     const handler = route.routeHandler;
     const method = request.method.toUpperCase();
     const revalidateSeconds = __getAppRouteHandlerRevalidateSeconds(handler);
+    const __buildRouteHandlerPageCacheTags = function(pathname, extraTags) {
+      return buildPageCacheTags(pathname, extraTags, route.routeSegments, "route");
+    };
     if (__hasAppRouteHandlerDefaultExport(handler) && process.env.NODE_ENV === "development") {
       console.error(
         "[vinext] Detected default export in route handler " + route.pattern + ". Export a named export for each HTTP method instead.",
@@ -11455,7 +11380,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     ) {
       const __cachedRouteResponse = await __readAppRouteHandlerCacheResponse({
         basePath: __basePath,
-        buildPageCacheTags: __pageCacheTags,
+        buildPageCacheTags: __buildRouteHandlerPageCacheTags,
         cleanPathname,
         clearRequestContext: function() {
           setHeadersContext(null);
@@ -11485,7 +11410,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           });
           await _runWithUnifiedCtx(__revalUCtx, async () => {
             _ensureFetchPatch();
-            setCurrentFetchSoftTags(__pageCacheTags(cleanPathname, []));
+            setCurrentFetchSoftTags(buildPageCacheTags(cleanPathname, [], route.routeSegments, "route"));
             await renderFn();
           });
         },
@@ -11500,7 +11425,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     if (typeof handlerFn === "function") {
       return __executeAppRouteHandler({
         basePath: __basePath,
-        buildPageCacheTags: __pageCacheTags,
+        buildPageCacheTags: __buildRouteHandlerPageCacheTags,
         cleanPathname,
         clearRequestContext: function() {
           setHeadersContext(null);
@@ -11636,7 +11561,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         });
         return _runWithUnifiedCtx(__revalUCtx, async () => {
           _ensureFetchPatch();
-          setCurrentFetchSoftTags(__pageCacheTags(cleanPathname, []));
+          setCurrentFetchSoftTags(buildPageCacheTags(cleanPathname, [], route.routeSegments, "page"));
           setNavigationContext({ pathname: cleanPathname, searchParams: new URLSearchParams(), params });
           // Slot context (X-Vinext-Mounted-Slots) is inherited from the
           // triggering request so the regen result is cached under the
@@ -11667,7 +11592,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           setNavigationContext(null);
           const __freshHtml = await __readAppPageTextStream(__revalHtmlStream);
           const __freshRscData = await __revalRscCapture.capturedRscDataPromise;
-          const __pageTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
+          const __pageTags = buildPageCacheTags(cleanPathname, getCollectedFetchTags(), route.routeSegments, "page");
           return { html: __freshHtml, rscData: __freshRscData, tags: __pageTags };
         });
       },
@@ -11835,7 +11760,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     getFontStyles: _getSSRFontStyles,
     getNavigationContext: _getNavigationContext,
     getPageTags() {
-      return __pageCacheTags(cleanPathname, getCollectedFetchTags());
+      return buildPageCacheTags(cleanPathname, getCollectedFetchTags(), route.routeSegments, "page");
     },
     getRequestCacheLife() {
       return _consumeRequestScopedCacheLife();
@@ -12099,6 +12024,7 @@ import {
 import {
   applyRouteHandlerMiddlewareContext as __applyRouteHandlerMiddlewareContext,
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-response.js";
+import { buildPageCacheTags } from "<ROOT>/packages/vinext/src/server/implicit-tags.js";
 import { _consumeRequestScopedCacheLife, getCacheHandler } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
 import { ensureFetchPatch as _ensureFetchPatch, getCollectedFetchTags, setCurrentFetchSoftTags } from "vinext/fetch-cache";
@@ -12155,27 +12081,6 @@ async function __isrGet(key) {
 async function __isrSet(key, data, revalidateSeconds, tags) {
   const handler = getCacheHandler();
   await handler.set(key, data, { revalidate: revalidateSeconds, tags: Array.isArray(tags) ? tags : [] });
-}
-function __pageCacheTags(pathname, extraTags) {
-  const tags = [pathname, "_N_T_" + pathname];
-  // Layout hierarchy tags — matches Next.js getDerivedTags.
-  tags.push("_N_T_/layout");
-  const segments = pathname.split("/");
-  let built = "";
-  for (let i = 1; i < segments.length; i++) {
-    if (segments[i]) {
-      built += "/" + segments[i];
-      tags.push("_N_T_" + built + "/layout");
-    }
-  }
-  // Leaf page tag — revalidatePath(path, "page") targets this.
-  tags.push("_N_T_" + built + "/page");
-  if (Array.isArray(extraTags)) {
-    for (const tag of extraTags) {
-      if (!tags.includes(tag)) tags.push(tag);
-    }
-  }
-  return tags;
 }
 // Note: cache entries are written with \`headers: undefined\`. Next.js stores
 // response headers (e.g. set-cookie from cookies().set() during render) in the
@@ -14154,7 +14059,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   }
 
   const { route, params } = match;
-  setCurrentFetchSoftTags(__pageCacheTags(cleanPathname, []));
+  setCurrentFetchSoftTags(
+    buildPageCacheTags(cleanPathname, [], route.routeSegments, route.routeHandler ? "route" : "page"),
+  );
 
   // Update navigation context with matched params
   setNavigationContext({
@@ -14168,6 +14075,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     const handler = route.routeHandler;
     const method = request.method.toUpperCase();
     const revalidateSeconds = __getAppRouteHandlerRevalidateSeconds(handler);
+    const __buildRouteHandlerPageCacheTags = function(pathname, extraTags) {
+      return buildPageCacheTags(pathname, extraTags, route.routeSegments, "route");
+    };
     if (__hasAppRouteHandlerDefaultExport(handler) && process.env.NODE_ENV === "development") {
       console.error(
         "[vinext] Detected default export in route handler " + route.pattern + ". Export a named export for each HTTP method instead.",
@@ -14211,7 +14121,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     ) {
       const __cachedRouteResponse = await __readAppRouteHandlerCacheResponse({
         basePath: __basePath,
-        buildPageCacheTags: __pageCacheTags,
+        buildPageCacheTags: __buildRouteHandlerPageCacheTags,
         cleanPathname,
         clearRequestContext: function() {
           setHeadersContext(null);
@@ -14241,7 +14151,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           });
           await _runWithUnifiedCtx(__revalUCtx, async () => {
             _ensureFetchPatch();
-            setCurrentFetchSoftTags(__pageCacheTags(cleanPathname, []));
+            setCurrentFetchSoftTags(buildPageCacheTags(cleanPathname, [], route.routeSegments, "route"));
             await renderFn();
           });
         },
@@ -14256,7 +14166,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     if (typeof handlerFn === "function") {
       return __executeAppRouteHandler({
         basePath: __basePath,
-        buildPageCacheTags: __pageCacheTags,
+        buildPageCacheTags: __buildRouteHandlerPageCacheTags,
         cleanPathname,
         clearRequestContext: function() {
           setHeadersContext(null);
@@ -14392,7 +14302,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         });
         return _runWithUnifiedCtx(__revalUCtx, async () => {
           _ensureFetchPatch();
-          setCurrentFetchSoftTags(__pageCacheTags(cleanPathname, []));
+          setCurrentFetchSoftTags(buildPageCacheTags(cleanPathname, [], route.routeSegments, "page"));
           setNavigationContext({ pathname: cleanPathname, searchParams: new URLSearchParams(), params });
           // Slot context (X-Vinext-Mounted-Slots) is inherited from the
           // triggering request so the regen result is cached under the
@@ -14423,7 +14333,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           setNavigationContext(null);
           const __freshHtml = await __readAppPageTextStream(__revalHtmlStream);
           const __freshRscData = await __revalRscCapture.capturedRscDataPromise;
-          const __pageTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
+          const __pageTags = buildPageCacheTags(cleanPathname, getCollectedFetchTags(), route.routeSegments, "page");
           return { html: __freshHtml, rscData: __freshRscData, tags: __pageTags };
         });
       },
@@ -14591,7 +14501,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     getFontStyles: _getSSRFontStyles,
     getNavigationContext: _getNavigationContext,
     getPageTags() {
-      return __pageCacheTags(cleanPathname, getCollectedFetchTags());
+      return buildPageCacheTags(cleanPathname, getCollectedFetchTags(), route.routeSegments, "page");
     },
     getRequestCacheLife() {
       return _consumeRequestScopedCacheLife();

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -4374,10 +4374,16 @@ describe("generateRscEntry ISR code generation", () => {
   it("generated code threads collected fetch tags into page ISR writes", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes);
     expect(code).toContain("getCollectedFetchTags");
-    expect(code).toContain("function __pageCacheTags(pathname, extraTags)");
-    expect(code).toContain('const tags = [pathname, "_N_T_" + pathname]');
+    expect(code).toContain("buildPageCacheTags");
     expect(code).toContain(
-      "const __pageTags = __pageCacheTags(cleanPathname, getCollectedFetchTags())",
+      'buildPageCacheTags(cleanPathname, [], route.routeSegments, route.routeHandler ? "route" : "page")',
+    );
+    expect(code).toContain(
+      "const __buildRouteHandlerPageCacheTags = function(pathname, extraTags) {",
+    );
+    expect(code).toContain("buildPageCacheTags: __buildRouteHandlerPageCacheTags");
+    expect(code).toContain(
+      'const __pageTags = buildPageCacheTags(cleanPathname, getCollectedFetchTags(), route.routeSegments, "page")',
     );
     expect(code).toContain("Array.isArray(tags) ? tags : []");
   });
@@ -4554,7 +4560,9 @@ describe("generateRscEntry ISR code generation", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes);
     expect(code).toContain("renderAppPageLifecycle as __renderAppPageLifecycle");
     expect(code).toContain("getPageTags() {");
-    expect(code).toContain("return __pageCacheTags(cleanPathname, getCollectedFetchTags())");
+    expect(code).toContain(
+      'return buildPageCacheTags(cleanPathname, getCollectedFetchTags(), route.routeSegments, "page")',
+    );
     // Background regen still writes fresh RSC bytes directly.
     expect(code).toContain("rscData: __freshRscData");
   });

--- a/tests/isr-cache.test.ts
+++ b/tests/isr-cache.test.ts
@@ -17,6 +17,7 @@ import {
   getRevalidateDuration,
   triggerBackgroundRegeneration,
 } from "../packages/vinext/src/server/isr-cache.js";
+import { buildPageCacheTags } from "../packages/vinext/src/server/implicit-tags.js";
 import { runWithExecutionContext } from "../packages/vinext/src/shims/request-context.js";
 import {
   createRequestContext,
@@ -327,26 +328,17 @@ describe("triggerBackgroundRegeneration", () => {
 describe("revalidatePath type parameter", () => {
   let handler: MemoryCacheHandler;
 
-  /**
-   * Mirrors `__pageCacheTags` in app-rsc-entry.ts — keep in sync.
-   */
-  function deriveImplicitTags(pathname: string): string[] {
-    const tags = ["_N_T_/layout"];
-    const segments = pathname.split("/");
-    let built = "";
-    for (let i = 1; i < segments.length; i++) {
-      if (segments[i]) {
-        built += "/" + segments[i];
-        tags.push(`_N_T_${built}/layout`);
-      }
-    }
-    tags.push(`_N_T_${built}/page`);
-    return tags;
+  function staticRouteSegments(pathname: string): string[] {
+    return pathname.split("/").filter(Boolean);
   }
 
   /** Helper: store a FETCH cache entry with path + implicit hierarchy tags. */
-  async function seedEntry(path: string, body: string): Promise<void> {
-    const tags = [path, `_N_T_${path}`, ...deriveImplicitTags(path)];
+  async function seedEntry(
+    path: string,
+    body: string,
+    routeSegments = staticRouteSegments(path),
+  ): Promise<void> {
+    const tags = buildPageCacheTags(path, [], routeSegments, "page");
     const value: CachedFetchValue = {
       kind: "FETCH",
       data: { headers: {}, body, url: path },
@@ -406,6 +398,21 @@ describe("revalidatePath type parameter", () => {
     expect(await handler.get("entry:/about")).toBeNull();
     // /about/team should remain
     expect(await handler.get("entry:/about/team")).not.toBeNull();
+  });
+
+  it("uses route pattern tags for typed dynamic route invalidation", async () => {
+    await seedEntry("/blog/hello", "hello", ["blog", "[slug]"]);
+
+    await revalidatePath("/blog/hello", "layout");
+    expect(await handler.get("entry:/blog/hello")).not.toBeNull();
+
+    await revalidatePath("/blog/[slug]", "layout");
+    expect(await handler.get("entry:/blog/hello")).toBeNull();
+
+    await seedEntry("/blog/hello", "hello", ["blog", "[slug]"]);
+
+    await revalidatePath("/blog/hello");
+    expect(await handler.get("entry:/blog/hello")).toBeNull();
   });
 
   it("handles deeply nested children under a layout prefix", async () => {

--- a/tests/page-cache-tags.test.ts
+++ b/tests/page-cache-tags.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vite-plus/test";
+import { buildPageCacheTags } from "../packages/vinext/src/server/implicit-tags.js";
+
+describe("App Router page cache tags", () => {
+  // Covers cloudflare/vinext#921: route-scoped soft tags include pattern-derived layout tags.
+  it("uses route pattern segments for dynamic layout and page tags", () => {
+    expect(buildPageCacheTags("/blog/hello", [], ["blog", "[slug]"], "page")).toEqual([
+      "/blog/hello",
+      "_N_T_/blog/hello",
+      "_N_T_/layout",
+      "_N_T_/blog/layout",
+      "_N_T_/blog/[slug]/layout",
+      "_N_T_/blog/[slug]/page",
+    ]);
+  });
+
+  it("adds root and index exact-path aliases", () => {
+    expect(buildPageCacheTags("/", [], [], "page")).toEqual([
+      "/",
+      "_N_T_/",
+      "_N_T_/index",
+      "_N_T_/layout",
+      "_N_T_/page",
+    ]);
+    expect(buildPageCacheTags("/index", [], ["index"], "page")).toContain("_N_T_/");
+  });
+
+  it("keeps route groups in derived pattern tags while preserving the resolved path tag", () => {
+    expect(buildPageCacheTags("/blog/hello", [], ["(main)", "blog", "[slug]"], "page")).toEqual([
+      "/blog/hello",
+      "_N_T_/blog/hello",
+      "_N_T_/layout",
+      "_N_T_/(main)/layout",
+      "_N_T_/(main)/blog/layout",
+      "_N_T_/(main)/blog/[slug]/layout",
+      "_N_T_/(main)/blog/[slug]/page",
+    ]);
+  });
+
+  it("uses route handler leaf tags for route handlers", () => {
+    expect(buildPageCacheTags("/api/posts", ["posts"], ["api", "posts"], "route")).toEqual([
+      "/api/posts",
+      "_N_T_/api/posts",
+      "_N_T_/layout",
+      "_N_T_/api/layout",
+      "_N_T_/api/posts/layout",
+      "_N_T_/api/posts/route",
+      "posts",
+    ]);
+  });
+
+  it("treats literal page and route path segments as intermediate layouts", () => {
+    expect(buildPageCacheTags("/docs/page/intro", [], ["docs", "page", "[slug]"], "page")).toEqual([
+      "/docs/page/intro",
+      "_N_T_/docs/page/intro",
+      "_N_T_/layout",
+      "_N_T_/docs/layout",
+      "_N_T_/docs/page/layout",
+      "_N_T_/docs/page/[slug]/layout",
+      "_N_T_/docs/page/[slug]/page",
+    ]);
+
+    expect(buildPageCacheTags("/api/route/posts", [], ["api", "route", "posts"], "route")).toEqual([
+      "/api/route/posts",
+      "_N_T_/api/route/posts",
+      "_N_T_/layout",
+      "_N_T_/api/layout",
+      "_N_T_/api/route/layout",
+      "_N_T_/api/route/posts/layout",
+      "_N_T_/api/route/posts/route",
+    ]);
+  });
+
+  it("keeps catch-all route segments in derived pattern tags", () => {
+    expect(buildPageCacheTags("/docs/a/b", [], ["docs", "[...slug]"], "page")).toEqual([
+      "/docs/a/b",
+      "_N_T_/docs/a/b",
+      "_N_T_/layout",
+      "_N_T_/docs/layout",
+      "_N_T_/docs/[...slug]/layout",
+      "_N_T_/docs/[...slug]/page",
+    ]);
+
+    expect(buildPageCacheTags("/optional/a", [], ["optional", "[[...id]]"], "page")).toEqual([
+      "/optional/a",
+      "_N_T_/optional/a",
+      "_N_T_/layout",
+      "_N_T_/optional/layout",
+      "_N_T_/optional/[[...id]]/layout",
+      "_N_T_/optional/[[...id]]/page",
+    ]);
+  });
+});


### PR DESCRIPTION
## What this changes
App Router page and route handler cache entries now carry implicit tags derived from the matched route pattern in addition to exact resolved pathname tags.

## Why
`revalidatePath(path, type)` targets `_N_T_` tags based on route files. Entries rendered at dynamic URLs need tags such as `_N_T_/blog/[slug]/layout` so layout-scoped invalidation reaches cached fetches beneath dynamic routes.

Refs #921

## Approach
Move implicit tag construction into `server/implicit-tags.ts` and wire generated RSC entries to pass `route.routeSegments` plus the leaf kind. The helper preserves exact pathname tags, root/index aliases, route groups, dynamic segments, page leaves, and route handler leaves.

This is scoped to App Router cache tag generation and does not change ISR storage semantics.

## Validation
- `vp test run tests/page-cache-tags.test.ts tests/isr-cache.test.ts tests/fetch-cache.test.ts -t "App Router page cache tags|revalidatePath|soft tags"`
- `vp test run tests/app-router.test.ts -t "generated code threads collected fetch tags into page ISR writes|generated code stores rscData in the ISR cache entry"`
- `vp test run tests/entry-templates.test.ts`
- `vp check`
- `vp run vinext#build`