### PR TITLE
fix(cache): scope use cache entries by build id

### DIFF
--- a/packages/vinext/src/shims/cache-runtime.ts
+++ b/packages/vinext/src/shims/cache-runtime.ts
@@ -6,7 +6,7 @@
  * Vite plugin to wrap them with `registerCachedFunction()`.
  *
  * The runtime:
- * 1. Generates a cache key from function identity + serialized arguments
+ * 1. Generates a cache key from build ID + function identity + serialized arguments
  * 2. Checks the CacheHandler for a cached value
  * 3. On HIT: returns the cached value (deserialized via RSC stream)
  * 4. On MISS: creates an AsyncLocalStorage context for cacheLife/cacheTag,
@@ -90,6 +90,22 @@ type RscModule = {
   createClientTemporaryReferenceSet: () => unknown;
   decodeReply: (body: string | FormData, options?: unknown) => Promise<unknown[]>;
 };
+
+function getUseCacheBuildId(): string | undefined {
+  try {
+    // Keep this direct reference so Vite's define transform can inline it for
+    // Worker bundles where the process global might not exist at runtime.
+    return process.env.__VINEXT_BUILD_ID;
+  } catch (error) {
+    if (error instanceof ReferenceError) return undefined;
+    throw error;
+  }
+}
+
+function buildUseCacheKey(id: string, buildId: string | undefined, argsKey?: string): string {
+  const scopedId = buildId ? `build:${encodeURIComponent(buildId)}:${id}` : id;
+  return argsKey === undefined ? `use-cache:${scopedId}` : `use-cache:${scopedId}:${argsKey}`;
+}
 
 const NOT_LOADED = Symbol("not-loaded");
 let _rscModule: RscModule | null | typeof NOT_LOADED = NOT_LOADED;
@@ -322,6 +338,7 @@ export function registerCachedFunction<T extends (...args: any[]) => Promise<any
   // oxlint-disable-next-line @typescript-eslint/no-explicit-any
   const cachedFn = async (...args: any[]): Promise<any> => {
     const rsc = await getRscModule();
+    const buildId = getUseCacheBuildId();
 
     // Build the cache key. Use encodeReply (RSC protocol) when available —
     // it correctly handles React elements as temporary references (excluded
@@ -344,11 +361,10 @@ export function registerCachedFunction<T extends (...args: any[]) => Promise<any
         const encoded = await rsc.encodeReply(processedArgs, {
           temporaryReferences: tempRefs,
         });
-        const argsKey = await replyToCacheKey(encoded);
-        cacheKey = `use-cache:${id}:${argsKey}`;
+        cacheKey = buildUseCacheKey(id, buildId, await replyToCacheKey(encoded));
       } else {
-        const argsKey = args.length > 0 ? ":" + stableStringify(args) : "";
-        cacheKey = `use-cache:${id}${argsKey}`;
+        const argsKey = args.length > 0 ? stableStringify(args) : undefined;
+        cacheKey = buildUseCacheKey(id, buildId, argsKey);
       }
     } catch {
       // Non-serializable arguments — run without caching

--- a/packages/vinext/src/shims/cache-runtime.ts
+++ b/packages/vinext/src/shims/cache-runtime.ts
@@ -94,7 +94,8 @@ type RscModule = {
 function getUseCacheBuildId(): string | undefined {
   try {
     // Keep this direct reference so Vite's define transform can inline it for
-    // Worker bundles where the process global might not exist at runtime.
+    // Worker bundles where the process global might not exist at runtime. A
+    // typeof process guard would return before the inlined build ID is reached.
     return process.env.__VINEXT_BUILD_ID;
   } catch (error) {
     if (error instanceof ReferenceError) return undefined;
@@ -334,11 +335,11 @@ export function registerCachedFunction<T extends (...args: any[]) => Promise<any
   // Per-request ("use cache: private") caching still works in dev since
   // it's scoped to a single request and doesn't persist across HMR.
   const isDev = typeof process !== "undefined" && process.env.NODE_ENV === "development";
+  const buildId = getUseCacheBuildId();
 
   // oxlint-disable-next-line @typescript-eslint/no-explicit-any
   const cachedFn = async (...args: any[]): Promise<any> => {
     const rsc = await getRscModule();
-    const buildId = getUseCacheBuildId();
 
     // Build the cache key. Use encodeReply (RSC protocol) when available —
     // it correctly handles React elements as temporary references (excluded

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -1992,6 +1992,43 @@ describe('"use cache" runtime', () => {
     expect(callCount).toBe(2);
   });
 
+  it("scopes shared cache entries by build ID", async () => {
+    const { registerCachedFunction } =
+      await import("../packages/vinext/src/shims/cache-runtime.js");
+    const { setCacheHandler, MemoryCacheHandler } =
+      await import("../packages/vinext/src/shims/cache.js");
+    setCacheHandler(new MemoryCacheHandler());
+
+    const previousBuildId = process.env.__VINEXT_BUILD_ID;
+    try {
+      let callCount = 0;
+
+      process.env.__VINEXT_BUILD_ID = "build-one";
+      const firstBuild = registerCachedFunction(async () => {
+        callCount++;
+        return { version: "old" };
+      }, "test:same-id");
+
+      expect(await firstBuild()).toEqual({ version: "old" });
+      expect(callCount).toBe(1);
+
+      process.env.__VINEXT_BUILD_ID = "build-two";
+      const secondBuild = registerCachedFunction(async () => {
+        callCount++;
+        return { version: "new" };
+      }, "test:same-id");
+
+      expect(await secondBuild()).toEqual({ version: "new" });
+      expect(callCount).toBe(2);
+    } finally {
+      if (previousBuildId === undefined) {
+        delete process.env.__VINEXT_BUILD_ID;
+      } else {
+        process.env.__VINEXT_BUILD_ID = previousBuildId;
+      }
+    }
+  });
+
   it("registerCachedFunction respects cacheLife inside cached function", async () => {
     const { registerCachedFunction } =
       await import("../packages/vinext/src/shims/cache-runtime.js");


### PR DESCRIPTION
## What this changes

Shared `"use cache"` entries now include the vinext build ID in their persistent cache key before the cached function ID and serialized arguments. Environments without a build ID keep the previous key shape.

## Why

Persistent handlers such as Workers KV can outlive a deploy. Before this change, vinext keyed shared `"use cache"` entries as function ID plus arguments, so a new deployment could read a serialized RSC result produced by an older function body when the generated ID and arguments stayed stable.

Next.js includes `buildId` as the first part of the `"use cache"` key material:

- [Next.js `CacheKeyParts` tuple includes `buildId`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/use-cache/use-cache-wrapper.ts#L105-L107)
- [Next.js comment explaining build ID is needed because action IDs are not unique per implementation](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/use-cache/use-cache-wrapper.ts#L1509-L1513)
- [Next.js runtime constructs cache keys with `buildId`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/use-cache/use-cache-wrapper.ts#L1682-L1684)
- [Next.js custom cache handler test expects `buildId` as the first serialized key element](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/use-cache-custom-handler/use-cache-custom-handler.test.ts#L30-L35)

## Approach

`registerCachedFunction()` now reads `process.env.__VINEXT_BUILD_ID` and uses it to scope shared cache entries as build-specific keys. The read keeps a direct `process.env.__VINEXT_BUILD_ID` reference so Vite can inline the value for Worker bundles, and it only recovers the missing `process` global case.

The key builder encodes custom build IDs before placing them in the colon-delimited key, which avoids delimiter collisions without changing key shape when no build ID exists.

## Validation

- `git diff --check`
- `vp test run tests/shims.test.ts -t 'scopes shared cache entries by build ID'`
- `vp test run tests/shims.test.ts -t '"use cache" runtime'`
- `vp check packages/vinext/src/shims/cache-runtime.ts tests/shims.test.ts`
- `vp test run tests/shims.test.ts`
- `vp run vinext#build`

## Risks / follow-ups

This intentionally invalidates existing shared `"use cache"` entries on the next deploy when a build ID is available. That is the desired Next.js-compatible behavior for code-derived cached RSC streams.
