### PR TITLE
fix(app-router): flush server-inserted HTML during SSR streaming

### DIFF
--- a/packages/vinext/src/server/app-ssr-entry.ts
+++ b/packages/vinext/src/server/app-ssr-entry.ts
@@ -9,7 +9,7 @@ import type { NavigationContext } from "../shims/navigation.js";
 import {
   ServerInsertedHTMLContext,
   clearServerInsertedHTML,
-  flushServerInsertedHTML,
+  renderServerInsertedHTML,
   setNavigationContext,
   useServerInsertedHTML,
 } from "../shims/navigation.js";
@@ -23,6 +23,7 @@ import {
   safeJsonStringify,
 } from "./html.js";
 import { createRscEmbedTransform, createTickBufferedTransform } from "./app-ssr-stream.js";
+import { deferUntilStreamConsumed } from "./app-page-stream.js";
 import {
   normalizeAppElements,
   readAppElementsMetadata,
@@ -177,6 +178,11 @@ export async function handleSsr(
 
     clearServerInsertedHTML();
 
+    const cleanup = (): void => {
+      setNavigationContext(null);
+      clearServerInsertedHTML();
+    };
+
     try {
       const [ssrStream, embedStream] = rscStream.tee();
       const rscEmbed = createRscEmbedTransform(embedStream, options?.scriptNonce);
@@ -227,20 +233,29 @@ export async function handleSsr(
         },
       });
 
-      const insertedHTML = renderInsertedHtml(flushServerInsertedHTML());
       const fontHTML = renderFontHtml(fontData, options?.scriptNonce);
-      const injectHTML = buildHeadInjectionHtml(
-        navContext,
-        bootstrapScriptContent,
-        insertedHTML,
-        fontHTML,
-        options?.scriptNonce,
-      );
+      let didInjectHeadHTML = false;
+      const getInsertedHTML = (): string => {
+        const insertedHTML = renderInsertedHtml(renderServerInsertedHTML());
+        if (didInjectHeadHTML) return insertedHTML;
 
-      return htmlStream.pipeThrough(createTickBufferedTransform(rscEmbed, injectHTML));
-    } finally {
-      setNavigationContext(null);
-      clearServerInsertedHTML();
+        didInjectHeadHTML = true;
+        return buildHeadInjectionHtml(
+          navContext,
+          bootstrapScriptContent,
+          insertedHTML,
+          fontHTML,
+          options?.scriptNonce,
+        );
+      };
+
+      return deferUntilStreamConsumed(
+        htmlStream.pipeThrough(createTickBufferedTransform(rscEmbed, getInsertedHTML)),
+        cleanup,
+      );
+    } catch (error) {
+      cleanup();
+      throw error;
     }
   }) as Promise<ReadableStream<Uint8Array>>;
 }

--- a/packages/vinext/src/server/app-ssr-stream.ts
+++ b/packages/vinext/src/server/app-ssr-stream.ts
@@ -5,6 +5,8 @@ type RscEmbedTransform = {
   finalize(): Promise<string>;
 };
 
+type HtmlInsertion = string | (() => string);
+
 /**
  * Fix invalid preload "as" values in RSC Flight hint lines before they reach
  * the client. React Flight emits HL hints with as="stylesheet" for CSS, but
@@ -96,22 +98,39 @@ export function fixPreloadAs(html: string): string {
  */
 export function createTickBufferedTransform(
   rscEmbed: RscEmbedTransform,
-  injectHTML = "",
+  injectHTML: HtmlInsertion = "",
 ): TransformStream<Uint8Array, Uint8Array> {
   const decoder = new TextDecoder();
   const encoder = new TextEncoder();
+  const insertsPerFlush = typeof injectHTML === "function";
   let injected = false;
   let buffered: string[] = [];
   let timeoutId: ReturnType<typeof setTimeout> | null = null;
+  const readInsertion = (): string =>
+    typeof injectHTML === "function" ? injectHTML() : injectHTML;
+  const emitInsertion = (controller: TransformStreamDefaultController<Uint8Array>): void => {
+    const insertion = readInsertion();
+    if (insertion) {
+      controller.enqueue(encoder.encode(insertion));
+    }
+  };
 
   const flushBuffered = (controller: TransformStreamDefaultController<Uint8Array>): void => {
+    if (buffered.length === 0) return;
+
+    if (injected && insertsPerFlush) {
+      // Emit newly collected server-inserted HTML before the next Fizz HTML
+      // batch so CSS-in-JS styles precede the elements they style.
+      emitInsertion(controller);
+    }
+
     for (const chunk of buffered) {
       if (!injected) {
         const headEnd = chunk.indexOf("</head>");
         if (headEnd !== -1) {
           const before = chunk.slice(0, headEnd);
           const after = chunk.slice(headEnd);
-          controller.enqueue(encoder.encode(before + injectHTML + after));
+          controller.enqueue(encoder.encode(before + readInsertion() + after));
           injected = true;
           continue;
         }
@@ -153,8 +172,11 @@ export function createTickBufferedTransform(
 
       flushBuffered(controller);
 
-      if (!injected && injectHTML) {
-        controller.enqueue(encoder.encode(injectHTML));
+      if (!injected) {
+        emitInsertion(controller);
+        injected = true;
+      } else if (insertsPerFlush) {
+        emitInsertion(controller);
       }
 
       const finalScripts = await rscEmbed.finalize();

--- a/packages/vinext/src/shims/navigation.react-server.ts
+++ b/packages/vinext/src/shims/navigation.react-server.ts
@@ -21,6 +21,7 @@ export {
 
   // Server-inserted HTML
   flushServerInsertedHTML,
+  renderServerInsertedHTML,
   clearServerInsertedHTML,
 
   // Control-flow errors

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -1401,6 +1401,28 @@ export function flushServerInsertedHTML(): unknown[] {
 }
 
 /**
+ * Render collected useServerInsertedHTML callbacks without unregistering them.
+ *
+ * Streaming SSR needs to invoke the same style-registry callbacks after each
+ * Fizz flush. Libraries such as styled-components and Emotion clear their own
+ * per-flush buffers inside the callback; the registration itself must survive
+ * until the request stream is closed.
+ */
+export function renderServerInsertedHTML(): unknown[] {
+  const callbacks = _getInsertedHTMLCallbacks();
+  const results: unknown[] = [];
+  for (const cb of callbacks) {
+    try {
+      const result = cb();
+      if (result != null) results.push(result);
+    } catch {
+      // Ignore errors from individual callbacks
+    }
+  }
+  return results;
+}
+
+/**
  * Clear all collected useServerInsertedHTML callbacks without flushing.
  * Used for cleanup between requests.
  */

--- a/tests/rsc-streaming.test.ts
+++ b/tests/rsc-streaming.test.ts
@@ -333,6 +333,90 @@ describe("Tick-buffered RSC streaming (behavioral)", () => {
     expect(injectPos).toBeLessThan(headEndPos);
   });
 
+  it("emits new server-inserted HTML before streamed Suspense chunks after head injection", async () => {
+    // Ported from Next.js: test/e2e/app-dir/use-server-inserted-html/use-server-inserted-html.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/use-server-inserted-html/use-server-inserted-html.test.ts
+    const rsc = createMockRscStream();
+    rsc.close();
+
+    const rscEmbed = createRscEmbedTransform(rsc.stream);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    const insertions = [
+      '<style data-styled="shell">.shell { color: blue; }</style>',
+      '<style data-styled="suspense">.suspense { color: orange; }</style>',
+      "",
+    ];
+    let insertCalls = 0;
+    const getServerInsertedHTML = () => {
+      insertCalls++;
+      return insertions.shift() ?? "";
+    };
+
+    const encoder = new TextEncoder();
+    const htmlStream = new ReadableStream<Uint8Array>({
+      async start(controller) {
+        controller.enqueue(
+          encoder.encode("<html><head><title>Test</title></head><body><main>shell"),
+        );
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        controller.enqueue(
+          encoder.encode(
+            '<span id="footer-inner">resolved</span><script>$RC=function(){}</script></main></body></html>',
+          ),
+        );
+        controller.close();
+      },
+    });
+
+    const transform = createTickBufferedTransform(rscEmbed, getServerInsertedHTML);
+    const output = await collectStream(htmlStream.pipeThrough(transform));
+
+    const shellStylePos = output.indexOf('data-styled="shell"');
+    const headEndPos = output.indexOf("</head>");
+    expect(shellStylePos).toBeGreaterThan(-1);
+    expect(shellStylePos).toBeLessThan(headEndPos);
+
+    const suspenseStylePos = output.indexOf('data-styled="suspense"');
+    const refreshScriptPos = output.indexOf("$RC=function");
+    expect(suspenseStylePos).toBeGreaterThan(headEndPos);
+    expect(suspenseStylePos).toBeLessThan(refreshScriptPos);
+    expect(insertCalls).toBeGreaterThanOrEqual(2);
+  });
+
+  it("emits final server-inserted HTML even after buffered chunks were already drained", async () => {
+    const rsc = createMockRscStream();
+    rsc.close();
+
+    const rscEmbed = createRscEmbedTransform(rsc.stream);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    const insertions = [
+      '<style data-styled="shell">.shell { color: blue; }</style>',
+      '<style data-styled="trailing">.trailing { color: green; }</style>',
+    ];
+    const getServerInsertedHTML = () => insertions.shift() ?? "";
+
+    const encoder = new TextEncoder();
+    const htmlStream = new ReadableStream<Uint8Array>({
+      async start(controller) {
+        controller.enqueue(encoder.encode("<html><head></head><body>shell</body></html>"));
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        controller.close();
+      },
+    });
+
+    const transform = createTickBufferedTransform(rscEmbed, getServerInsertedHTML);
+    const output = await collectStream(htmlStream.pipeThrough(transform));
+
+    const shellStylePos = output.indexOf('data-styled="shell"');
+    const trailingStylePos = output.indexOf('data-styled="trailing"');
+    const donePos = output.indexOf("__VINEXT_RSC_DONE__=true");
+    expect(shellStylePos).toBeGreaterThan(-1);
+    expect(trailingStylePos).toBeGreaterThan(shellStylePos);
+    expect(trailingStylePos).toBeLessThan(donePos);
+  });
+
   it("still injects head content even without </head> in stream", async () => {
     const rsc = createMockRscStream();
     rsc.close();

--- a/tests/server-inserted-html.test.ts
+++ b/tests/server-inserted-html.test.ts
@@ -68,6 +68,18 @@ describe("useServerInsertedHTML", () => {
     expect(second).toHaveLength(0);
   });
 
+  it("renderServerInsertedHTML keeps callbacks registered for later streaming flushes", async () => {
+    const { useServerInsertedHTML, renderServerInsertedHTML, flushServerInsertedHTML } =
+      await import("../packages/vinext/src/shims/navigation.js");
+
+    let flushCount = 0;
+    useServerInsertedHTML(() => `style-${++flushCount}`);
+
+    expect(renderServerInsertedHTML()).toEqual(["style-1"]);
+    expect(renderServerInsertedHTML()).toEqual(["style-2"]);
+    expect(flushServerInsertedHTML()).toEqual(["style-3"]);
+  });
+
   it("clearServerInsertedHTML discards callbacks without calling them", async () => {
     const { useServerInsertedHTML, clearServerInsertedHTML, flushServerInsertedHTML } =
       await import("../packages/vinext/src/shims/navigation.js");


### PR DESCRIPTION
## What this changes
App Router SSR now asks for `useServerInsertedHTML` output on each HTML streaming flush instead of only once before returning the stream. The first insertion still places the navigation/bootstrap/font/server HTML before `</head>`, while later insertions emit newly collected server-inserted HTML before the next streamed chunk.

## Why
CSS-in-JS registries such as styled-components and Emotion register a callback during shell render, then collect additional styles as Suspense boundaries continue rendering. Vinext previously flushed and cleared those callbacks before the stream was consumed, so styles collected after the shell never reached streamed HTML.

Next.js keeps server-inserted HTML callbacks registered and asks for insertion HTML from its stream transform repeatedly:

- [`createServerInsertedHTML` stores callbacks without clearing them](https://github.com/vercel/next.js/blob/ae61573e062e900050b8e6b24626e450accc4570/packages/next/src/server/app-render/server-inserted-html.tsx#L9-L30)
- [`makeGetServerInsertedHTML` renders the registered callbacks each time it is called](https://github.com/vercel/next.js/blob/ae61573e062e900050b8e6b24626e450accc4570/packages/next/src/server/app-render/make-get-server-inserted-html.tsx#L38-L109)
- [`createHeadInsertionTransformStream` invokes insertion during stream transforms and final flush](https://github.com/vercel/next.js/blob/ae61573e062e900050b8e6b24626e450accc4570/packages/next/src/server/stream-utils/node-web-streams-helper.ts#L447-L520)
- [Next.js e2e coverage asserts Suspense CSS-in-JS styles stream before the refresh script](https://github.com/vercel/next.js/blob/ae61573e062e900050b8e6b24626e450accc4570/test/e2e/app-dir/use-server-inserted-html/use-server-inserted-html.test.ts#L50-L68)
- [The referenced fixture renders a styled-components node inside Suspense](https://github.com/vercel/next.js/blob/ae61573e062e900050b8e6b24626e450accc4570/test/e2e/app-dir/use-server-inserted-html/app/css-in-js/suspense/page.js#L31-L58)

## Approach
- Add `renderServerInsertedHTML()` for streaming SSR so callbacks can be invoked without unregistering them.
- Keep callback cleanup deferred until the returned SSR stream is consumed or cancelled.
- Let `createTickBufferedTransform()` accept an insertion function and call it after the initial head injection on each buffered flush.
- Preserve the existing one-shot string insertion path for current non-streaming callers.

## Validation
- `vp check`
- `vp test run tests/server-inserted-html.test.ts tests/server-inserted-html-context.test.ts tests/rsc-streaming.test.ts tests/app-router.test.ts tests/features.test.ts tests/app-page-stream.test.ts`

## Risks / follow-ups
The change is scoped to App Router SSR streaming and the existing tick-buffered transform. The test coverage is unit and integration-level; it ports the Next.js streaming order assertion without adding a full styled-components dependency fixture to vinext.
