### PR TITLE
fix(router): ignore pre-root parallel slots for routed layouts

### DIFF
--- a/packages/vinext/src/routing/app-router.ts
+++ b/packages/vinext/src/routing/app-router.ts
@@ -711,24 +711,32 @@ function discoverInheritedParallelSlots(
   let currentDir = appDir;
   const dirsToCheck: { dir: string; layoutIdx: number }[] = [];
   let layoutIdx = findFile(appDir, "layout", matcher) ? 0 : -1;
-  dirsToCheck.push({ dir: appDir, layoutIdx: Math.max(layoutIdx, 0) });
+  dirsToCheck.push({ dir: appDir, layoutIdx });
 
   for (const segment of segments) {
     currentDir = path.join(currentDir, segment);
     if (findFile(currentDir, "layout", matcher)) {
       layoutIdx++;
     }
-    dirsToCheck.push({ dir: currentDir, layoutIdx: Math.max(layoutIdx, 0) });
+    dirsToCheck.push({ dir: currentDir, layoutIdx });
   }
 
+  const routeHasLayout = layoutIdx >= 0;
+
   for (const { dir, layoutIdx: lvlLayoutIdx } of dirsToCheck) {
+    // Once a route has a root layout below app/, slots discovered before that
+    // layout are above the root and cannot be owned by any layout in this route.
+    // Layout-less routes keep their legacy slot metadata here; validation is separate.
+    if (lvlLayoutIdx < 0 && routeHasLayout) continue;
+
     const isOwnDir = dir === routeDir;
+    const slotLayoutIdx = Math.max(lvlLayoutIdx, 0);
     const slotsAtLevel = discoverParallelSlots(dir, appDir, matcher);
 
     for (const slot of slotsAtLevel) {
       if (isOwnDir) {
         // At the route's own directory: use page.tsx (normal behavior)
-        slot.layoutIndex = lvlLayoutIdx;
+        slot.layoutIndex = slotLayoutIdx;
         slotMap.set(slot.key, slot);
       } else {
         // At an ancestor directory: use default.tsx as the page, not page.tsx
@@ -736,7 +744,7 @@ function discoverInheritedParallelSlots(
         const inheritedSlot: ParallelSlot = {
           ...slot,
           pagePath: null, // Don't use ancestor's page.tsx
-          layoutIndex: lvlLayoutIdx,
+          layoutIndex: slotLayoutIdx,
           routeSegments: null,
           // defaultPath, loadingPath, errorPath, interceptingRoutes remain
         };

--- a/tests/routing.test.ts
+++ b/tests/routing.test.ts
@@ -1394,6 +1394,52 @@ describe("matchAppRoute - URL matching", () => {
 
   // --- Inherited parallel slots ---
 
+  it("does not attach pre-root parallel slots when the root layout is below app", async () => {
+    // Next.js allows multiple root layouts when app/layout is omitted:
+    // https://github.com/vercel/next.js/blob/ae61573e062e900050b8e6b24626e450accc4570/docs/01-app/03-api-reference/03-file-conventions/layout.mdx#L140-L145
+    // Parallel route children above the selected root layout are not available to that root:
+    // https://github.com/vercel/next.js/blob/ae61573e062e900050b8e6b24626e450accc4570/packages/next/src/server/app-render/create-component-tree.tsx#L1273-L1290
+    await withTempDir("vinext-app-pre-root-parallel-slot-", async (tmpDir) => {
+      const appDir = path.join(tmpDir, "app");
+
+      await mkdir(path.join(appDir, "@modal"), { recursive: true });
+      await mkdir(path.join(appDir, "(group)"), { recursive: true });
+      await writeFile(path.join(appDir, "@modal", "default.tsx"), EMPTY_PAGE);
+      await writeFile(path.join(appDir, "(group)", "layout.tsx"), EMPTY_PAGE);
+      await writeFile(path.join(appDir, "(group)", "page.tsx"), EMPTY_PAGE);
+
+      invalidateAppRouteCache();
+      const routes = await appRouter(appDir);
+      const homeRoute = routes.find((route) => route.pattern === "/");
+
+      expect(homeRoute).toBeDefined();
+      expect(homeRoute!.layouts).toEqual([path.join(appDir, "(group)", "layout.tsx")]);
+      expect(homeRoute!.parallelSlots.find((slot) => slot.name === "modal")).toBeUndefined();
+    });
+  });
+
+  it("attaches parallel slots inside the selected root layout subtree", async () => {
+    await withTempDir("vinext-app-root-subtree-parallel-slot-", async (tmpDir) => {
+      const appDir = path.join(tmpDir, "app");
+
+      await mkdir(path.join(appDir, "(group)", "@modal"), { recursive: true });
+      await writeFile(path.join(appDir, "(group)", "layout.tsx"), EMPTY_PAGE);
+      await writeFile(path.join(appDir, "(group)", "page.tsx"), EMPTY_PAGE);
+      await writeFile(path.join(appDir, "(group)", "@modal", "default.tsx"), EMPTY_PAGE);
+
+      invalidateAppRouteCache();
+      const routes = await appRouter(appDir);
+      const homeRoute = routes.find((route) => route.pattern === "/");
+
+      expect(homeRoute).toBeDefined();
+      const modalSlot = homeRoute!.parallelSlots.find((slot) => slot.name === "modal");
+      expect(modalSlot).toBeDefined();
+      expect(modalSlot!.ownerDir).toBe(path.join(appDir, "(group)", "@modal"));
+      expect(modalSlot!.layoutIndex).toBe(0);
+      expect(modalSlot!.defaultPath).toBe(path.join(appDir, "(group)", "@modal", "default.tsx"));
+    });
+  });
+
   it("preserves same-named parallel slots from multiple layout levels", async () => {
     await withTempDir("vinext-app-parallel-slot-priority-", async (tmpDir) => {
       const appDir = path.join(tmpDir, "app");


### PR DESCRIPTION
## Summary

- Stop attaching parallel slots discovered above a route's first/root layout to that route's `parallelSlots`.
- Add scanner coverage for `app/@modal/default.tsx` with the selected root layout at `app/(group)/layout.tsx`.
- Preserve the valid case where the slot is inside the selected root layout subtree, such as `app/(group)/@modal/default.tsx`.

## Root cause / Why

`discoverInheritedParallelSlots` initialized `layoutIdx` to `-1` when `app/layout.*` was absent, but immediately clamped that value to `0` for `appDir` and every segment before the first actual layout. A slot above the selected root layout, such as `app/@modal/default.tsx`, was therefore recorded as owned by `layoutIndex: 0` and injected into `app/(group)/layout.tsx`.

That diverges from Next.js multiple-root-layout semantics. Next.js documents that omitting `app/layout.js` lets subdirectory layouts become root layouts: [multiple root layout docs](https://github.com/vercel/next.js/blob/ae61573e062e900050b8e6b24626e450accc4570/docs/01-app/03-api-reference/03-file-conventions/layout.mdx#L140-L145). The server tree construction also notes that parallel route children cannot exist above the root layout: [create-component-tree note](https://github.com/vercel/next.js/blob/ae61573e062e900050b8e6b24626e450accc4570/packages/next/src/server/app-render/create-component-tree.tsx#L1273-L1290).

The fix keeps the pre-layout sentinel while scanning and skips those slots once the route has a real layout. Layout-less scanner metadata is intentionally preserved here; scanner validation fixes are intentionally separate in another PR.

## Verification

- `vp test run tests/routing.test.ts`
- `vp check packages/vinext/src/routing/app-router.ts tests/routing.test.ts`
