### PR TITLE
fix(router): reject invalid app route discovery conflicts

### DIFF
--- a/packages/vinext/src/routing/app-router.ts
+++ b/packages/vinext/src/routing/app-router.ts
@@ -218,6 +218,7 @@ export async function appRouter(
   const slotSubRoutes = discoverSlotSubRoutes(routes, appDir, matcher);
   routes.push(...slotSubRoutes);
 
+  validatePageRouteConflicts(routes, appDir);
   validateRoutePatterns(routes.map((route) => route.pattern));
   const interceptTargetPatterns = [
     ...new Set(
@@ -237,6 +238,46 @@ export async function appRouter(
   cachedAppDir = appDir;
   cachedPageExtensionsKey = pageExtensionsKey;
   return routes;
+}
+
+function validatePageRouteConflicts(routes: AppRoute[], appDir: string): void {
+  const byPattern = new Map<string, { pagePath: string | null; routePath: string | null }>();
+
+  for (const route of routes) {
+    const entry = byPattern.get(route.pattern);
+    if (!entry) {
+      byPattern.set(route.pattern, {
+        pagePath: route.pagePath,
+        routePath: route.routePath,
+      });
+      continue;
+    }
+
+    if (!entry.pagePath && route.pagePath) {
+      entry.pagePath = route.pagePath;
+    }
+    if (!entry.routePath && route.routePath) {
+      entry.routePath = route.routePath;
+    }
+  }
+
+  for (const [pattern, entry] of byPattern) {
+    if (!entry.pagePath || !entry.routePath) continue;
+
+    throw new Error(
+      `Conflicting route and page at ${pattern}: route at ${formatAppFilePath(
+        entry.routePath,
+        appDir,
+      )} and page at ${formatAppFilePath(entry.pagePath, appDir)}`,
+    );
+  }
+}
+
+function formatAppFilePath(filePath: string, appDir: string): string {
+  const relativePath = path.relative(appDir, filePath).replace(/\\/g, "/");
+  const parsedPath = path.parse(relativePath);
+  const withoutExtension = path.join(parsedPath.dir, parsedPath.name).replace(/\\/g, "/");
+  return withoutExtension.startsWith("/") ? withoutExtension : `/${withoutExtension}`;
 }
 
 /**
@@ -1012,6 +1053,22 @@ function computeInterceptTarget(
           climbed++;
         }
       }
+      if (climbed < levelsToClimb) {
+        const interceptionRoute = formatInterceptionRoutePath(
+          routeSegments,
+          convention,
+          interceptSegment,
+          path.relative(interceptRoot, currentDir).split(path.sep).filter(Boolean),
+        );
+        if (convention === "..") {
+          throw new Error(
+            `Invalid interception route: ${interceptionRoute}. Cannot use (..) marker at the root level, use (.) instead.`,
+          );
+        }
+        throw new Error(
+          `Invalid interception route: ${interceptionRoute}. Cannot use (..)(..) marker at the root level or one level up.`,
+        );
+      }
       baseParts = routeSegments.slice(0, cutIndex);
       break;
     }
@@ -1033,6 +1090,36 @@ function computeInterceptTarget(
 
   const pattern = "/" + urlSegments.join("/");
   return { pattern: pattern === "/" ? "/" : pattern, params };
+}
+
+function formatInterceptionRoutePath(
+  routeSegments: string[],
+  convention: string,
+  interceptSegment: string,
+  nestedParts: string[],
+): string {
+  const marker = markerForInterceptionConvention(convention);
+  const convertedRoute = convertSegmentsToRouteParts(routeSegments);
+  const prefix = convertedRoute ? convertedRoute.urlSegments : [];
+  const routePath = [...prefix, `${marker}${interceptSegment}`, ...nestedParts]
+    .filter(Boolean)
+    .join("/");
+  return routePath ? `/${routePath}` : "/";
+}
+
+function markerForInterceptionConvention(convention: string): string {
+  switch (convention) {
+    case ".":
+      return "(.)";
+    case "..":
+      return "(..)";
+    case "../..":
+      return "(..)(..)";
+    case "...":
+      return "(...)";
+    default:
+      return "";
+  }
 }
 
 /**

--- a/packages/vinext/src/routing/app-router.ts
+++ b/packages/vinext/src/routing/app-router.ts
@@ -243,6 +243,8 @@ export async function appRouter(
 function validatePageRouteConflicts(routes: AppRoute[], appDir: string): void {
   const byPattern = new Map<string, { pagePath: string | null; routePath: string | null }>();
 
+  // validateRoutePatterns() would also reject page/route pairs because they
+  // share a URL pattern. Keep this pass first so the error names both files.
   for (const route of routes) {
     const entry = byPattern.get(route.pattern);
     if (!entry) {
@@ -1100,7 +1102,9 @@ function formatInterceptionRoutePath(
 ): string {
   const marker = markerForInterceptionConvention(convention);
   const convertedRoute = convertSegmentsToRouteParts(routeSegments);
-  const prefix = convertedRoute ? convertedRoute.urlSegments : [];
+  const prefix = convertedRoute
+    ? convertedRoute.urlSegments
+    : routeSegments.filter((segment) => !isInvisibleSegment(segment));
   const routePath = [...prefix, `${marker}${interceptSegment}`, ...nestedParts]
     .filter(Boolean)
     .join("/");

--- a/tests/routing.test.ts
+++ b/tests/routing.test.ts
@@ -689,6 +689,33 @@ describe("appRouter - route discovery", () => {
     });
   });
 
+  it("allows (..) intercepting routes in route groups with one visible parent segment", async () => {
+    // Next.js validates the normalized intercepting route: /(group) is root,
+    // but /shop/(group) has one visible segment and can climb to /.
+    // https://github.com/vercel/next.js/blob/ae61573e062e900050b8e6b24626e450accc4570/packages/next/src/shared/lib/router/utils/interception-routes.ts#L60-L95
+    await withTempDir("vinext-app-intercept-group-with-visible-parent-", async (tmpDir) => {
+      const appDir = path.join(tmpDir, "app");
+      await mkdir(path.join(appDir, "shop", "(group)", "@modal", "(..)foo"), {
+        recursive: true,
+      });
+      await writeFile(path.join(appDir, "shop", "(group)", "page.tsx"), EMPTY_PAGE);
+      await writeFile(
+        path.join(appDir, "shop", "(group)", "@modal", "(..)foo", "page.tsx"),
+        EMPTY_PAGE,
+      );
+
+      invalidateAppRouteCache();
+      const routes = await appRouter(appDir);
+      const shopRoute = routes.find((route) => route.pattern === "/shop");
+      expect(shopRoute).toBeDefined();
+
+      const modalSlot = shopRoute!.parallelSlots.find((slot) => slot.name === "modal");
+      expect(modalSlot).toBeDefined();
+      expect(modalSlot!.interceptingRoutes).toHaveLength(1);
+      expect(modalSlot!.interceptingRoutes[0].targetPattern).toBe("/foo");
+    });
+  });
+
   it("(..) climbs visible route segments, not filesystem dirs (route group between segments)", async () => {
     // Bug: computeInterceptTarget uses path.dirname() which counts filesystem dirs,
     // but (..) should count visible route segments (skipping route groups).

--- a/tests/routing.test.ts
+++ b/tests/routing.test.ts
@@ -328,6 +328,22 @@ describe("appRouter - route discovery", () => {
     expect(apiPatterns).toContain("/api/hello");
   });
 
+  it("rejects page and route handler files at the same app route", async () => {
+    // Next.js docs forbid page.js and route.js at the same normalized route:
+    // https://github.com/vercel/next.js/blob/ae61573e062e900050b8e6b24626e450accc4570/docs/01-app/01-getting-started/15-route-handlers.mdx#L150-L163
+    await withTempDir("vinext-app-page-route-conflict-", async (tmpDir) => {
+      const appDir = path.join(tmpDir, "app");
+      await mkdir(path.join(appDir, "foo"), { recursive: true });
+      await writeFile(path.join(appDir, "foo", "page.tsx"), EMPTY_PAGE);
+      await writeFile(path.join(appDir, "foo", "route.ts"), EMPTY_ROUTE);
+
+      invalidateAppRouteCache();
+      await expect(appRouter(appDir)).rejects.toThrow(
+        "Conflicting route and page at /foo: route at /foo/route and page at /foo/page",
+      );
+    });
+  });
+
   it("discovers layouts from root to leaf", async () => {
     const routes = await appRouter(APP_FIXTURE_DIR);
     const homeRoute = routes.find((r) => r.pattern === "/");
@@ -607,6 +623,69 @@ describe("appRouter - route discovery", () => {
       expect(modalSlot!.interceptingRoutes).toHaveLength(1);
       expect(modalSlot!.interceptingRoutes[0].targetPattern).toBe("/photos/:slug+");
       expect(modalSlot!.interceptingRoutes[0].params).toEqual(["slug"]);
+    });
+  });
+
+  it("rejects (..) intercepting routes at the normalized root", async () => {
+    // Ported from Next.js:
+    // packages/next/src/shared/lib/router/utils/interception-routes.test.ts
+    // https://github.com/vercel/next.js/blob/ae61573e062e900050b8e6b24626e450accc4570/packages/next/src/shared/lib/router/utils/interception-routes.test.ts#L66-L75
+    await withTempDir("vinext-app-intercept-root-parent-marker-", async (tmpDir) => {
+      const appDir = path.join(tmpDir, "app");
+      await mkdir(path.join(appDir, "@modal", "(..)foo"), { recursive: true });
+      await writeFile(path.join(appDir, "page.tsx"), EMPTY_PAGE);
+      await writeFile(path.join(appDir, "@modal", "(..)foo", "page.tsx"), EMPTY_PAGE);
+
+      invalidateAppRouteCache();
+      await expect(appRouter(appDir)).rejects.toThrow(
+        "Cannot use (..) marker at the root level, use (.) instead.",
+      );
+    });
+  });
+
+  it("rejects (..) intercepting routes at the root after route group normalization", async () => {
+    // Next.js validates the normalized intercepting route, so transparent
+    // route groups do not make an upward marker valid at the URL root.
+    // https://github.com/vercel/next.js/blob/ae61573e062e900050b8e6b24626e450accc4570/packages/next/src/shared/lib/router/utils/interception-routes.ts#L60-L95
+    await withTempDir("vinext-app-intercept-group-root-parent-marker-", async (tmpDir) => {
+      const appDir = path.join(tmpDir, "app");
+      await mkdir(path.join(appDir, "(group)", "@modal", "(..)foo"), { recursive: true });
+      await writeFile(path.join(appDir, "(group)", "page.tsx"), EMPTY_PAGE);
+      await writeFile(path.join(appDir, "(group)", "@modal", "(..)foo", "page.tsx"), EMPTY_PAGE);
+
+      invalidateAppRouteCache();
+      await expect(appRouter(appDir)).rejects.toThrow(
+        "Cannot use (..) marker at the root level, use (.) instead.",
+      );
+    });
+  });
+
+  it("rejects (..)(..) intercepting routes at root or one visible level up", async () => {
+    // Ported from Next.js:
+    // packages/next/src/shared/lib/router/utils/interception-routes.test.ts
+    // https://github.com/vercel/next.js/blob/ae61573e062e900050b8e6b24626e450accc4570/packages/next/src/shared/lib/router/utils/interception-routes.test.ts#L66-L75
+    await withTempDir("vinext-app-intercept-two-up-marker-root-", async (tmpDir) => {
+      const appDir = path.join(tmpDir, "app");
+      await mkdir(path.join(appDir, "@modal", "(..)(..)foo"), { recursive: true });
+      await writeFile(path.join(appDir, "page.tsx"), EMPTY_PAGE);
+      await writeFile(path.join(appDir, "@modal", "(..)(..)foo", "page.tsx"), EMPTY_PAGE);
+
+      invalidateAppRouteCache();
+      await expect(appRouter(appDir)).rejects.toThrow(
+        "Cannot use (..)(..) marker at the root level or one level up.",
+      );
+    });
+
+    await withTempDir("vinext-app-intercept-two-up-marker-one-level-", async (tmpDir) => {
+      const appDir = path.join(tmpDir, "app");
+      await mkdir(path.join(appDir, "feed", "@modal", "(..)(..)foo"), { recursive: true });
+      await writeFile(path.join(appDir, "feed", "page.tsx"), EMPTY_PAGE);
+      await writeFile(path.join(appDir, "feed", "@modal", "(..)(..)foo", "page.tsx"), EMPTY_PAGE);
+
+      invalidateAppRouteCache();
+      await expect(appRouter(appDir)).rejects.toThrow(
+        "Cannot use (..)(..) marker at the root level or one level up.",
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

- Reject App Router interception routes that use `( .. )`-style upward markers after the normalized route has no visible segment left to climb.
- Report an explicit page/route handler conflict when `page` and `route` files resolve to the same App Router path.
- This intentionally groups two scanner-time validation/DX parity issues in one PR, while leaving slot ownership behavior for a separate PR.

## Root cause / Why

vinext already resolved interception targets by visible route segments, but it kept resolving at root when `( .. )` or `( .. )( .. )` tried to climb past the normalized intercepting route. Next.js validates the normalized interception route first and throws explicit marker errors instead of silently resolving from root.

vinext also discovered `page` and `route` files as separate entries and deferred conflict detection to the generic duplicate route pattern validator. That produced a correct rejection but not the explicit App Router conflict that points at the page and route handler files.

Next.js parity references:

- [Interception route validation source](https://github.com/vercel/next.js/blob/ae61573e062e900050b8e6b24626e450accc4570/packages/next/src/shared/lib/router/utils/interception-routes.ts#L60-L95)
- [Interception route validation tests](https://github.com/vercel/next.js/blob/ae61573e062e900050b8e6b24626e450accc4570/packages/next/src/shared/lib/router/utils/interception-routes.test.ts#L66-L75)
- [Route handler docs: page.js and route.js conflict](https://github.com/vercel/next.js/blob/ae61573e062e900050b8e6b24626e450accc4570/docs/01-app/01-getting-started/15-route-handlers.mdx#L150-L163)
- [App path normalization source](https://github.com/vercel/next.js/blob/ae61573e062e900050b8e6b24626e450accc4570/packages/next/src/shared/lib/router/utils/app-paths.ts#L23-L51)

## Verification

- `vp test run tests/routing.test.ts`
- `vp test run tests/route-sorting.test.ts`
- `vp check tests/routing.test.ts packages/vinext/src/routing/app-router.ts`
