### PR TITLE
fix(app-router): restore hash anchors on history traversal

### DIFF
--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -789,8 +789,38 @@ function restoreHydrationNavigationContext(
   });
 }
 
+function decodeHashFragment(fragment: string): string {
+  try {
+    return decodeURIComponent(fragment);
+  } catch {
+    return fragment;
+  }
+}
+
+function scrollToHashTarget(hash: string): void {
+  const fragment = decodeHashFragment(hash.startsWith("#") ? hash.slice(1) : hash);
+
+  requestAnimationFrame(() => {
+    if (fragment === "" || fragment === "top") {
+      window.scrollTo(0, 0);
+      return;
+    }
+
+    const idElement = document.getElementById(fragment);
+    if (idElement) {
+      idElement.scrollIntoView();
+      return;
+    }
+
+    document.getElementsByName(fragment)[0]?.scrollIntoView();
+  });
+}
+
 function restorePopstateScrollPosition(state: unknown): void {
   if (!(state && typeof state === "object" && "__vinext_scrollY" in state)) {
+    if (window.location.hash) {
+      scrollToHashTarget(window.location.hash);
+    }
     return;
   }
 

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -808,11 +808,11 @@ function scrollToHashTarget(hash: string): void {
 
     const idElement = document.getElementById(fragment);
     if (idElement) {
-      idElement.scrollIntoView();
+      idElement.scrollIntoView({ behavior: "auto" });
       return;
     }
 
-    document.getElementsByName(fragment)[0]?.scrollIntoView();
+    document.getElementsByName(fragment)[0]?.scrollIntoView({ behavior: "auto" });
   });
 }
 

--- a/tests/e2e/app-router/nextjs-compat/hash-popstate-scroll.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/hash-popstate-scroll.spec.ts
@@ -1,9 +1,39 @@
+import type { Page } from "@playwright/test";
 import { test, expect } from "@playwright/test";
 import { waitForAppRouterHydration } from "../../helpers";
 
 const BASE = "http://localhost:4174";
 
 test.describe("Next.js compat: hash popstate scroll", () => {
+  async function expectScrollY(page: Page, expected: number) {
+    await expect(async () => {
+      const scrollY = await page.evaluate(() => window.scrollY);
+      expect(scrollY).toBe(expected);
+    }).toPass();
+  }
+
+  async function expectHashForwardTraversal(
+    page: Page,
+    linkSelector: string,
+    hash: string,
+    targetSelector: string,
+  ) {
+    await page.goto(`${BASE}/nextjs-compat/hash-popstate-scroll`);
+    await waitForAppRouterHydration(page);
+    await expect(page.locator("h1")).toHaveText("Hash Popstate Scroll");
+
+    await page.click(linkSelector);
+    await expect(page).toHaveURL(`${BASE}/nextjs-compat/hash-popstate-scroll${hash}`);
+
+    await page.goBack();
+    await expect(page).toHaveURL(`${BASE}/nextjs-compat/hash-popstate-scroll`);
+    await expectScrollY(page, 0);
+
+    await page.goForward();
+    await expect(page).toHaveURL(`${BASE}/nextjs-compat/hash-popstate-scroll${hash}`);
+    await expect(page.locator(targetSelector)).toBeInViewport();
+  }
+
   // Ported from the App Router hash-scroll behavior covered by:
   // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/navigation/navigation.test.ts
   // Next.js stores hash scroll intent in focusAndScrollRef and layout-router
@@ -21,13 +51,43 @@ test.describe("Next.js compat: hash popstate scroll", () => {
 
     await page.goBack();
     await expect(page).toHaveURL(`${BASE}/nextjs-compat/hash-popstate-scroll`);
-    await expect(async () => {
-      const scrollY = await page.evaluate(() => window.scrollY);
-      expect(scrollY).toBe(0);
-    }).toPass();
+    await expectScrollY(page, 0);
 
     await page.goForward();
     await expect(page).toHaveURL(`${BASE}/nextjs-compat/hash-popstate-scroll#content`);
     await expect(page.locator("#content")).toBeInViewport();
+  });
+
+  test("forward traversal decodes non-latin hash fragments", async ({ page }) => {
+    await expectHashForwardTraversal(page, "#encoded-link", "#caf%C3%A9", '[id="café"]');
+  });
+
+  test("forward traversal falls back to named anchors", async ({ page }) => {
+    await expectHashForwardTraversal(
+      page,
+      "#name-link",
+      "#legacy-anchor",
+      '[name="legacy-anchor"]',
+    );
+  });
+
+  test("forward traversal to #top scrolls to the top", async ({ page }) => {
+    await page.goto(`${BASE}/nextjs-compat/hash-popstate-scroll`);
+    await waitForAppRouterHydration(page);
+
+    await page.click("#hash-link");
+    await expect(page).toHaveURL(`${BASE}/nextjs-compat/hash-popstate-scroll#content`);
+    await expect(page.locator("#content")).toBeInViewport();
+
+    await page.evaluate(() => document.getElementById("top-link")?.click());
+    await expect(page).toHaveURL(`${BASE}/nextjs-compat/hash-popstate-scroll#top`);
+
+    await page.goBack();
+    await expect(page).toHaveURL(`${BASE}/nextjs-compat/hash-popstate-scroll#content`);
+    await expect(page.locator("#content")).toBeInViewport();
+
+    await page.goForward();
+    await expect(page).toHaveURL(`${BASE}/nextjs-compat/hash-popstate-scroll#top`);
+    await expectScrollY(page, 0);
   });
 });

--- a/tests/e2e/app-router/nextjs-compat/hash-popstate-scroll.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/hash-popstate-scroll.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from "@playwright/test";
+import { waitForAppRouterHydration } from "../../helpers";
+
+const BASE = "http://localhost:4174";
+
+test.describe("Next.js compat: hash popstate scroll", () => {
+  // Ported from the App Router hash-scroll behavior covered by:
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/navigation/navigation.test.ts
+  // Next.js stores hash scroll intent in focusAndScrollRef and layout-router
+  // consumes it after navigation commits.
+  test("forward traversal to a hash-only Link entry scrolls the anchor into view", async ({
+    page,
+  }) => {
+    await page.goto(`${BASE}/nextjs-compat/hash-popstate-scroll`);
+    await waitForAppRouterHydration(page);
+    await expect(page.locator("h1")).toHaveText("Hash Popstate Scroll");
+
+    await page.click("#hash-link");
+    await expect(page).toHaveURL(`${BASE}/nextjs-compat/hash-popstate-scroll#content`);
+    await expect(page.locator("#content")).toBeInViewport();
+
+    await page.goBack();
+    await expect(page).toHaveURL(`${BASE}/nextjs-compat/hash-popstate-scroll`);
+    await expect(async () => {
+      const scrollY = await page.evaluate(() => window.scrollY);
+      expect(scrollY).toBe(0);
+    }).toPass();
+
+    await page.goForward();
+    await expect(page).toHaveURL(`${BASE}/nextjs-compat/hash-popstate-scroll#content`);
+    await expect(page.locator("#content")).toBeInViewport();
+  });
+});

--- a/tests/fixtures/app-basic/app/nextjs-compat/hash-popstate-scroll/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/hash-popstate-scroll/page.tsx
@@ -4,14 +4,35 @@ export default function HashPopstateScrollPage() {
   return (
     <main style={{ minHeight: "3200px", padding: 24 }}>
       <h1>Hash Popstate Scroll</h1>
-      <Link href="#content" id="hash-link">
-        Go to content
-      </Link>
-      <div style={{ height: 1800 }} />
+      <nav style={{ display: "flex", gap: 16 }}>
+        <Link href="#content" id="hash-link">
+          Go to content
+        </Link>
+        <Link href="#caf%C3%A9" id="encoded-link">
+          Go to cafe
+        </Link>
+        <Link href="#legacy-anchor" id="name-link">
+          Go to named anchor
+        </Link>
+        <Link href="#top" id="top-link">
+          Go to top
+        </Link>
+      </nav>
+      <div style={{ height: 1200 }} />
       <section id="content" style={{ minHeight: 400 }}>
         <h2>Anchored Content</h2>
         <p>This content should be restored into view on forward traversal.</p>
       </section>
+      <div style={{ height: 700 }} />
+      <section id="café" style={{ minHeight: 400 }}>
+        <h2>Encoded Cafe</h2>
+        <p>This target requires decoding the URL hash fragment.</p>
+      </section>
+      <div style={{ height: 700 }} />
+      <a name="legacy-anchor" style={{ display: "block", minHeight: 400 }}>
+        <h2>Named Anchor</h2>
+        <p>This target uses the browser-compatible name fallback.</p>
+      </a>
     </main>
   );
 }

--- a/tests/fixtures/app-basic/app/nextjs-compat/hash-popstate-scroll/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/hash-popstate-scroll/page.tsx
@@ -1,0 +1,17 @@
+import Link from "next/link";
+
+export default function HashPopstateScrollPage() {
+  return (
+    <main style={{ minHeight: "3200px", padding: 24 }}>
+      <h1>Hash Popstate Scroll</h1>
+      <Link href="#content" id="hash-link">
+        Go to content
+      </Link>
+      <div style={{ height: 1800 }} />
+      <section id="content" style={{ minHeight: 400 }}>
+        <h2>Anchored Content</h2>
+        <p>This content should be restored into view on forward traversal.</p>
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
## What changed
App Router popstate scroll restoration now falls back to hash-anchor scrolling when the traversed history entry has no vinext numeric scroll state.

A focused App Router e2e fixture and regression tests cover vinext-managed hash-only Link entries through back and forward traversal, including decoded non-latin IDs, named-anchor fallback, and #top.

## Why
vinext sets history.scrollRestoration to manual. Hash-only App Router navigations can push entries without __vinext_scrollY, so forward traversal to /path#anchor updated the URL but skipped the browser native anchor scroll and could leave the page at the top.

## Approach
The popstate restoration path keeps saved numeric scroll state as the first-priority behavior. Only entries without vinext scroll state fall back to window.location.hash.

Hash fallback mirrors practical Next.js semantics: decode the fragment when possible, treat #top and empty fragments as top, prefer id lookup, then fall back to name lookup. Malformed encodings are left as-is instead of throwing. The fallback uses explicit auto scroll behavior to match the existing vinext hash-scroll helpers.

## Validation
- Added a failing Playwright regression first, then verified it passed after the fix: PLAYWRIGHT_PROJECT=app-router vp run test:e2e -- tests/e2e/app-router/nextjs-compat/hash-popstate-scroll.spec.ts
- Expanded the same E2E coverage after review for decoded fragments, named anchors, and #top: PLAYWRIGHT_PROJECT=app-router vp run test:e2e -- tests/e2e/app-router/nextjs-compat/hash-popstate-scroll.spec.ts
- Ran adjacent unit coverage: vp test run tests/app-browser-entry.test.ts
- Ran repo checks: vp check
- Rebuilt the vinext package for local e2e validation: vp run vinext#build

## Risks / follow-ups
Numeric back and forward restoration intentionally remains higher priority than hash scrolling, so entries with saved __vinext_scrollY keep existing behavior.

This does not attempt to refactor the existing duplicate hash-scroll helpers between App Router browser entry and next/navigation; the change stays scoped to the App Router popstate gap.

## Next.js references
- App Router records hash scroll intent in focusAndScrollRef: https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/segment-cache/navigation.ts#L596-L693
- App Router resolves id and name hash targets in layout-router: https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/layout-router.tsx#L122-L140
- App Router consumes hash scroll after navigation commits: https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/layout-router.tsx#L306-L313
- App Router hash-scroll e2e coverage: https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/navigation/navigation.test.ts#L149-L211
- Pages Router hash target semantics for #top, id, name, and decodeURIComponent: https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/router/router.ts#L2323-L2348