### PR TITLE
fix(app-router): keep ownerless URL commits from releasing navigation snapshots

### DIFF
--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -271,7 +271,7 @@ function drainPrePaintEffects(upToRenderId: number): void {
         // Superseded navigation: balance its activateNavigationSnapshot().
         // Pass undefined navId intentionally so this cleanup cannot clear
         // pendingPathname owned by the current active navigation.
-        commitClientNavigationState(undefined);
+        commitClientNavigationState(undefined, { releaseSnapshot: true });
       }
     }
   }
@@ -290,7 +290,7 @@ function createNavigationCommitEffect(
     if (navId !== activeNavigationId) {
       // This transition was superseded before commit; balance the active
       // snapshot counter without clearing pendingPathname ownership.
-      commitClientNavigationState(undefined);
+      commitClientNavigationState(undefined, { releaseSnapshot: true });
       return;
     }
 

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -567,6 +567,10 @@ type ClientNavigationState = {
   navigationSnapshotActiveCount: number;
 };
 
+type CommitClientNavigationStateOptions = {
+  releaseSnapshot?: boolean;
+};
+
 type ClientNavigationGlobal = typeof globalThis & {
   [_CLIENT_NAV_STATE_KEY]?: ClientNavigationState;
   [_MOUNTED_SLOTS_HEADER_KEY]?: string | null;
@@ -1016,19 +1020,23 @@ function withSuppressedUrlNotifications<T>(fn: () => T): T {
  * Commit pending client navigation state to committed snapshots.
  *
  * navId is optional: callers that don't own pendingPathname (for example,
- * superseded pre-paint cleanup) may pass undefined to flush snapshot/params
- * state without clearing pendingPathname owned by the active navigation.
+ * superseded pre-paint cleanup) may pass undefined to flush URL/params state
+ * without clearing pendingPathname owned by the active navigation. Such callers
+ * must opt in explicitly if they also own an activated render snapshot.
  */
-export function commitClientNavigationState(navId?: number): void {
+export function commitClientNavigationState(
+  navId?: number,
+  options?: CommitClientNavigationStateOptions,
+): void {
   if (isServer) return;
   const state = getClientNavigationState();
   if (!state) return;
 
-  // Only decrement the snapshot counter if a snapshot was previously activated.
-  // Several code paths call commit without a prior activateNavigationSnapshot()
-  // — hash-only changes (navigateClientSide), Pages Router popstate, and
-  // patched history.pushState/replaceState — which legitimately have count == 0.
-  if (state.navigationSnapshotActiveCount > 0) {
+  // Only navigation-owned commits may release a render snapshot. Ownerless URL
+  // syncs still update committed pathname/search state, but must not consume
+  // the active snapshot for an in-flight App Router transition.
+  const shouldReleaseSnapshot = navId !== undefined || options?.releaseSnapshot === true;
+  if (shouldReleaseSnapshot && state.navigationSnapshotActiveCount > 0) {
     state.navigationSnapshotActiveCount -= 1;
   }
 

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -43,6 +43,92 @@ describe("next/navigation shim", () => {
     expect(typeof router.prefetch).toBe("function");
   });
 
+  it("keeps pending render snapshot active when external history.pushState syncs the URL", async () => {
+    const previousWindow = (globalThis as any).window;
+    const win = {
+      location: {
+        pathname: "/current",
+        search: "?from=committed",
+        hash: "",
+        href: "http://localhost/current?from=committed",
+        origin: "http://localhost",
+      },
+      history: {
+        state: null,
+        pushState(_data: unknown, _unused: string, url?: string | URL | null) {
+          if (!url) return;
+          const parsed = new URL(url, win.location.href);
+          win.location.pathname = parsed.pathname;
+          win.location.search = parsed.search;
+          win.location.hash = parsed.hash;
+          win.location.href = parsed.href;
+        },
+        replaceState(_data: unknown, _unused: string, url?: string | URL | null) {
+          if (!url) return;
+          const parsed = new URL(url, win.location.href);
+          win.location.pathname = parsed.pathname;
+          win.location.search = parsed.search;
+          win.location.hash = parsed.hash;
+          win.location.href = parsed.href;
+        },
+      },
+      addEventListener: vi.fn(),
+    };
+    (globalThis as any).window = win;
+
+    try {
+      vi.resetModules();
+      const React = await import("react");
+      const { renderToStaticMarkup } = await import("react-dom/server");
+      const navigation = await import("../packages/vinext/src/shims/navigation.js");
+      const Context = navigation.getClientNavigationRenderContext();
+      if (!Context) {
+        throw new Error("Expected client navigation render context");
+      }
+
+      navigation.activateNavigationSnapshot();
+      const snapshot = navigation.createClientNavigationRenderSnapshot(
+        "http://localhost/pending?from=snapshot",
+        {},
+      );
+
+      const readHookValues = () => {
+        let pathname = "";
+        let search = "";
+        function Probe() {
+          pathname = navigation.usePathname();
+          search = navigation.useSearchParams().toString();
+          return React.createElement("span", null, pathname);
+        }
+
+        renderToStaticMarkup(
+          React.createElement(Context.Provider, { value: snapshot }, React.createElement(Probe)),
+        );
+
+        return { pathname, search };
+      };
+
+      expect(readHookValues()).toEqual({
+        pathname: "/pending",
+        search: "from=snapshot",
+      });
+
+      win.history.pushState(null, "", "/ownerless?from=history");
+
+      expect(readHookValues()).toEqual({
+        pathname: "/pending",
+        search: "from=snapshot",
+      });
+    } finally {
+      vi.resetModules();
+      if (previousWindow === undefined) {
+        delete (globalThis as any).window;
+      } else {
+        (globalThis as any).window = previousWindow;
+      }
+    }
+  });
+
   it("exports redirect, notFound, permanentRedirect", async () => {
     const nav = await import("../packages/vinext/src/shims/navigation.js");
     expect(typeof nav.redirect).toBe("function");


### PR DESCRIPTION
## What changed
Ownerless client URL sync commits no longer release an active App Router navigation render snapshot.

## Why
`commitClientNavigationState(undefined)` covered both ownerless URL syncs and superseded-transition cleanup. Hash-only navigation and patched `history.pushState` / `history.replaceState` could therefore consume a snapshot owned by an in-flight navigation. Once consumed, `usePathname()` and `useSearchParams()` stopped reading the pending render snapshot and could flicker back to stale committed URL state mid-transition.

## Approach
`commitClientNavigationState` now releases a snapshot only when called by a navigation owner (`navId`) or when a superseded App Router cleanup path explicitly opts into snapshot release. Ownerless URL sync paths still update committed pathname/search state and notify subscribers, but they do not balance `activateNavigationSnapshot()`.

The App Router superseded cleanup sites pass `{ releaseSnapshot: true }` while keeping `navId` undefined so they continue to avoid clearing `pendingPathname` owned by a newer navigation.

## Validation
- `vp test run tests/shims.test.ts -t "keeps pending render snapshot active"`
- `vp test run tests/app-browser-entry.test.ts`
- `vp test run tests/shims.test.ts`
- `vp check`

## Risks / follow-ups
The main risk is future superseded-transition cleanup code forgetting to opt into `releaseSnapshot`. The current App Router cleanup paths are explicit, and ownerless URL sync remains intentionally non-releasing.

## Next.js references
- [App Router pushState/replaceState restore path](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/app-router.tsx#L303-L372)
- [App Router shallow routing hash navigation coverage](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/shallow-routing/shallow-routing.test.ts#L450-L462)
