### PR TITLE
fix: normalize NextRequest.url through nextUrl

### DIFF
--- a/packages/vinext/src/shims/server.ts
+++ b/packages/vinext/src/shims/server.ts
@@ -58,6 +58,7 @@ function _throwIfInsideCacheScope(apiName: string): void {
 
 export class NextRequest extends Request {
   private _nextUrl: NextURL;
+  private _url: string;
   private _cookies: RequestCookies;
 
   constructor(
@@ -97,11 +98,18 @@ export class NextRequest extends Request {
       ? { basePath: _nextConfig.basePath, nextConfig: { i18n: _nextConfig.i18n } }
       : undefined;
     this._nextUrl = new NextURL(url, undefined, urlConfig);
+    this._url = process.env.__NEXT_NO_MIDDLEWARE_URL_NORMALIZE
+      ? url.toString()
+      : this._nextUrl.toString();
     this._cookies = new RequestCookies(this.headers);
   }
 
   get nextUrl(): NextURL {
     return this._nextUrl;
+  }
+
+  get url(): string {
+    return this._url;
   }
 
   get cookies(): RequestCookies {

--- a/tests/app-route-handler-runtime.test.ts
+++ b/tests/app-route-handler-runtime.test.ts
@@ -55,6 +55,19 @@ describe("app route handler runtime helpers", () => {
     expect(accesses).toEqual(["request.url"]);
   });
 
+  it("normalizes request.url through nextUrl for stripped internal app route requests", () => {
+    const tracked = createTrackedAppRouteRequest(
+      new Request("https://example.com/fr/demo?ping=from-url"),
+      {
+        basePath: "/base",
+        i18n: { locales: ["en", "fr"], defaultLocale: "en" },
+      },
+    );
+
+    expect(tracked.request.nextUrl.href).toBe("https://example.com/base/fr/demo?ping=from-url");
+    expect(tracked.request.url).toBe("https://example.com/base/fr/demo?ping=from-url");
+  });
+
   it("tracks dynamic nextUrl fields but not pathname", () => {
     const accesses: string[] = [];
     const tracked = createTrackedAppRouteRequest(

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -4967,6 +4967,42 @@ describe("NextURL basePath and locale properties", () => {
     expect(req.nextUrl.href).toBe("http://localhost/app/fr/dashboard");
   });
 
+  it("NextRequest.url reflects the normalized nextUrl href", async () => {
+    const { NextRequest } = await import("../packages/vinext/src/shims/server.js");
+    const req = new NextRequest("http://localhost/fr/dashboard?tab=settings", {
+      nextConfig: {
+        basePath: "/app",
+        i18n: { locales: ["en", "fr"], defaultLocale: "en" },
+      },
+    });
+
+    expect(req.nextUrl.href).toBe("http://localhost/app/fr/dashboard?tab=settings");
+    expect(req.url).toBe(req.nextUrl.href);
+  });
+
+  it("NextRequest.url preserves raw input when middleware URL normalization is disabled", async () => {
+    const previous = process.env.__NEXT_NO_MIDDLEWARE_URL_NORMALIZE;
+    process.env.__NEXT_NO_MIDDLEWARE_URL_NORMALIZE = "1";
+    try {
+      const { NextRequest } = await import("../packages/vinext/src/shims/server.js");
+      const req = new NextRequest("http://localhost/fr/dashboard?tab=settings", {
+        nextConfig: {
+          basePath: "/app",
+          i18n: { locales: ["en", "fr"], defaultLocale: "en" },
+        },
+      });
+
+      expect(req.nextUrl.href).toBe("http://localhost/app/fr/dashboard?tab=settings");
+      expect(req.url).toBe("http://localhost/fr/dashboard?tab=settings");
+    } finally {
+      if (previous === undefined) {
+        delete process.env.__NEXT_NO_MIDDLEWARE_URL_NORMALIZE;
+      } else {
+        process.env.__NEXT_NO_MIDDLEWARE_URL_NORMALIZE = previous;
+      }
+    }
+  });
+
   it("NextRequest passes config when input is a Request object", async () => {
     const { NextRequest } = await import("../packages/vinext/src/shims/server.js");
     const raw = new Request("http://localhost/app/fr/dashboard");
@@ -4980,6 +5016,20 @@ describe("NextURL basePath and locale properties", () => {
     expect(req.nextUrl.locale).toBe("fr");
     expect(req.nextUrl.pathname).toBe("/dashboard");
     expect(req.nextUrl.href).toBe("http://localhost/app/fr/dashboard");
+  });
+
+  it("NextRequest.url normalizes Request input through nextUrl", async () => {
+    const { NextRequest } = await import("../packages/vinext/src/shims/server.js");
+    const raw = new Request("http://localhost/fr/dashboard?tab=settings");
+    const req = new NextRequest(raw, {
+      nextConfig: {
+        basePath: "/app",
+        i18n: { locales: ["en", "fr"], defaultLocale: "en" },
+      },
+    });
+
+    expect(req.nextUrl.href).toBe("http://localhost/app/fr/dashboard?tab=settings");
+    expect(req.url).toBe(req.nextUrl.href);
   });
 });
 


### PR DESCRIPTION
## Summary

- Store `NextRequest.url` separately from the underlying Web `Request` URL and expose the normalized `nextUrl.toString()` value by default.
- Preserve the `__NEXT_NO_MIDDLEWARE_URL_NORMALIZE` opt-out so callers can still observe the raw request URL when that compatibility flag is set.
- Add regression coverage for string input, `Request` input, and the app route handler wrapper path where vinext receives a basePath-stripped internal URL.

## Why

Next.js does not expose the superclass `Request.url` directly from `NextRequest`. It constructs a `NextURL`, stores `url` as `nextUrl.toString()` unless `__NEXT_NO_MIDDLEWARE_URL_NORMALIZE` is set, and returns that stored value from the `url` getter:

- [`NextRequest` stores normalized `url`](https://github.com/vercel/next.js/blob/ae61573e062e900050b8e6b24626e450accc4570/packages/next/src/server/web/spec-extension/request.ts#L41-L50)
- [`NextRequest.url` getter returns the stored value](https://github.com/vercel/next.js/blob/ae61573e062e900050b8e6b24626e450accc4570/packages/next/src/server/web/spec-extension/request.ts#L102-L104)
- [`NextURL.href` formats the pathname with basePath/locale data](https://github.com/vercel/next.js/blob/ae61573e062e900050b8e6b24626e450accc4570/packages/next/src/server/web/next-url.ts#L193-L197)
- [`NextURL.toString()` returns `href`](https://github.com/vercel/next.js/blob/ae61573e062e900050b8e6b24626e450accc4570/packages/next/src/server/web/next-url.ts#L256-L258)
- The middleware adapter also branches on `__NEXT_NO_MIDDLEWARE_URL_NORMALIZE` when choosing the request input URL: [`adapter.ts`](https://github.com/vercel/next.js/blob/ae61573e062e900050b8e6b24626e450accc4570/packages/next/src/server/web/adapter.ts#L172-L184)

Vinext already normalizes `nextUrl.href` with configured basePath/i18n, but `request.url` was inherited from `super(...)`. In runtime paths that strip basePath for internal routing before wrapping in `NextRequest`, userland code using `new URL(request.url)` could see `/callback` while `request.nextUrl.href` correctly represented `/base/callback`. That breaks code that signs, verifies, or compares the externally visible callback/webhook URL.

## Validation

- `vp test run tests/shims.test.ts tests/app-route-handler-runtime.test.ts`
- `vp check packages/vinext/src/shims/server.ts tests/shims.test.ts tests/app-route-handler-runtime.test.ts`