### PR TITLE
fix(cache): serve stale unstable_cache entries in App Router

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -1307,6 +1307,7 @@ export default async function handler(request, ctx) {
   const __uCtx = _createUnifiedCtx({
     headersContext: headersCtx,
     executionContext: ctx ?? _getRequestExecutionContext() ?? null,
+    unstableCacheRevalidation: "background",
   });
   return _runWithUnifiedCtx(__uCtx, async () => {
     _ensureFetchPatch();
@@ -2205,6 +2206,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           const __revalUCtx = _createUnifiedCtx({
             headersContext: __revalHeadCtx,
             executionContext: _getRequestExecutionContext(),
+            unstableCacheRevalidation: "foreground",
           });
           await _runWithUnifiedCtx(__revalUCtx, async () => {
             _ensureFetchPatch();
@@ -2356,6 +2358,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         const __revalUCtx = _createUnifiedCtx({
           headersContext: __revalHeadCtx,
           executionContext: _getRequestExecutionContext(),
+          unstableCacheRevalidation: "foreground",
         });
         return _runWithUnifiedCtx(__revalUCtx, async () => {
           _ensureFetchPatch();

--- a/packages/vinext/src/shims/cache.ts
+++ b/packages/vinext/src/shims/cache.ts
@@ -443,8 +443,11 @@ export { unstable_noStore as noStore };
 //
 // Uses AsyncLocalStorage for request isolation on concurrent workers.
 // ---------------------------------------------------------------------------
+export type UnstableCacheRevalidationMode = "foreground" | "background";
+
 export type CacheState = {
   requestScopedCacheLife: CacheLifeConfig | null;
+  unstableCacheRevalidation: UnstableCacheRevalidationMode;
 };
 
 const _ALS_KEY = Symbol.for("vinext.cache.als");
@@ -455,6 +458,7 @@ const _cacheAls = (_g[_ALS_KEY] ??=
 
 const _cacheFallbackState = (_g[_FALLBACK_KEY] ??= {
   requestScopedCacheLife: null,
+  unstableCacheRevalidation: "foreground",
 } satisfies CacheState) as CacheState;
 
 function _getCacheState(): CacheState {
@@ -476,10 +480,12 @@ export function _runWithCacheState<T>(fn: () => T | Promise<T>): T | Promise<T> 
   if (isInsideUnifiedScope()) {
     return runWithUnifiedStateMutation((uCtx) => {
       uCtx.requestScopedCacheLife = null;
+      uCtx.unstableCacheRevalidation = "foreground";
     }, fn);
   }
   const state: CacheState = {
     requestScopedCacheLife: null,
+    unstableCacheRevalidation: "foreground",
   };
   return _cacheAls.run(state, fn);
 }
@@ -672,6 +678,16 @@ function deserializeUnstableCacheResult(body: string): unknown {
   return "undef" in wrapper ? undefined : wrapper.v;
 }
 
+type UnstableCacheReadResult = { ok: true; value: unknown } | { ok: false };
+
+function tryDeserializeUnstableCacheResult(body: string): UnstableCacheReadResult {
+  try {
+    return { ok: true, value: deserializeUnstableCacheResult(body) };
+  } catch {
+    return { ok: false };
+  }
+}
+
 /**
  * Check if the current execution context is inside an unstable_cache() callback.
  * Used by headers(), cookies(), and connection() to throw errors when
@@ -685,6 +701,83 @@ type UnstableCacheOptions = {
   revalidate?: number | false;
   tags?: string[];
 };
+
+const _UNSTABLE_CACHE_PENDING_REVALIDATIONS_KEY = Symbol.for(
+  "vinext.unstableCache.pendingRevalidations",
+);
+
+function getPendingUnstableCacheRevalidations(): Map<string, Promise<void>> {
+  const existing = _g[_UNSTABLE_CACHE_PENDING_REVALIDATIONS_KEY];
+  if (existing instanceof Map) return existing;
+
+  const pending = new Map<string, Promise<void>>();
+  _g[_UNSTABLE_CACHE_PENDING_REVALIDATIONS_KEY] = pending;
+  return pending;
+}
+
+function shouldServeStaleUnstableCacheEntry(): boolean {
+  return _getCacheState().unstableCacheRevalidation === "background";
+}
+
+function waitUntilUnstableCacheRevalidation(promise: Promise<void>): void {
+  if (!isInsideUnifiedScope()) return;
+  getRequestContext().executionContext?.waitUntil(promise);
+}
+
+function scheduleUnstableCacheBackgroundRevalidation(
+  cacheKey: string,
+  refresh: () => Promise<unknown>,
+): void {
+  const pending = getPendingUnstableCacheRevalidations();
+  if (pending.has(cacheKey)) return;
+
+  const revalidation = refresh()
+    .then(() => undefined)
+    .catch((err) => {
+      console.error(`[vinext] unstable_cache background revalidation failed for ${cacheKey}:`, err);
+    });
+  const trackedRevalidation = revalidation.finally(() => {
+    if (pending.get(cacheKey) === trackedRevalidation) {
+      pending.delete(cacheKey);
+    }
+  });
+
+  pending.set(cacheKey, trackedRevalidation);
+  waitUntilUnstableCacheRevalidation(trackedRevalidation);
+}
+
+async function refreshUnstableCacheResult<Args extends unknown[], Result>(
+  fn: (...args: Args) => Promise<Result>,
+  args: Args,
+  cacheKey: string,
+  tags: string[],
+  revalidateSeconds: number | false | undefined,
+): Promise<Result> {
+  const result = await _unstableCacheAls.run(true, () => fn(...args));
+
+  const cacheValue: CachedFetchValue = {
+    kind: "FETCH",
+    data: {
+      headers: {},
+      body: serializeUnstableCacheResult(result),
+      url: cacheKey,
+    },
+    tags,
+    // revalidate: false means "cache indefinitely" (no time-based expiry).
+    // A positive number means time-based revalidation in seconds.
+    // When unset (undefined), default to false (indefinite) matching
+    // Next.js behavior for unstable_cache without explicit revalidate.
+    revalidate: typeof revalidateSeconds === "number" ? revalidateSeconds : false,
+  };
+
+  await _getActiveHandler().set(cacheKey, cacheValue, {
+    fetchCache: true,
+    tags,
+    revalidate: revalidateSeconds,
+  });
+
+  return result;
+}
 
 /**
  * Wrap an async function with caching.
@@ -707,52 +800,38 @@ export function unstable_cache<T extends (...args: any[]) => Promise<any>>(
   const tags = options?.tags ?? [];
   const revalidateSeconds = options?.revalidate;
 
-  const cachedFn = async (...args: Parameters<T>): Promise<Awaited<ReturnType<T>>> => {
+  const cachedFn = async (...args: Parameters<T>) => {
     const argsKey = JSON.stringify(args);
     const cacheKey = `unstable_cache:${baseKey}:${argsKey}`;
 
-    // Try to get from cache. Check cacheState so time-expired entries
-    // trigger a re-fetch instead of being served indefinitely.
+    // Try to get from cache. Stale entries are usable in normal App Router
+    // requests, but foreground-refresh inside revalidation scopes so the
+    // regenerated page/route stores fresh data.
     const existing = await _getActiveHandler().get(cacheKey, {
       kind: "FETCH",
       tags,
     });
-    if (existing?.value && existing.value.kind === "FETCH" && existing.cacheState !== "stale") {
-      try {
-        return deserializeUnstableCacheResult(existing.value.data.body) as Awaited<ReturnType<T>>;
-      } catch {
-        // Corrupted entry, fall through to re-fetch
+    if (existing?.value && existing.value.kind === "FETCH") {
+      const cached = tryDeserializeUnstableCacheResult(existing.value.data.body);
+      if (cached.ok) {
+        if (existing.cacheState === "stale") {
+          if (shouldServeStaleUnstableCacheEntry()) {
+            scheduleUnstableCacheBackgroundRevalidation(cacheKey, () =>
+              refreshUnstableCacheResult(fn, args, cacheKey, tags, revalidateSeconds),
+            );
+            return cached.value;
+          }
+        } else {
+          return cached.value;
+        }
       }
+      // Corrupted entries fall through to a foreground refresh.
     }
 
     // Cache miss — call the function inside the unstable_cache ALS scope
     // so that headers()/cookies()/connection() can detect they're in a
     // cache scope and throw an appropriate error.
-    const result = await _unstableCacheAls.run(true, () => fn(...args));
-
-    // Store in cache using the FETCH kind
-    const cacheValue: CachedFetchValue = {
-      kind: "FETCH",
-      data: {
-        headers: {},
-        body: serializeUnstableCacheResult(result),
-        url: cacheKey,
-      },
-      tags,
-      // revalidate: false means "cache indefinitely" (no time-based expiry).
-      // A positive number means time-based revalidation in seconds.
-      // When unset (undefined), default to false (indefinite) matching
-      // Next.js behavior for unstable_cache without explicit revalidate.
-      revalidate: typeof revalidateSeconds === "number" ? revalidateSeconds : false,
-    };
-
-    await _getActiveHandler().set(cacheKey, cacheValue, {
-      fetchCache: true,
-      tags,
-      revalidate: revalidateSeconds,
-    });
-
-    return result;
+    return await refreshUnstableCacheResult(fn, args, cacheKey, tags, revalidateSeconds);
   };
 
   return cachedFn as T;

--- a/packages/vinext/src/shims/unified-request-context.ts
+++ b/packages/vinext/src/shims/unified-request-context.ts
@@ -92,6 +92,7 @@ export function createRequestContext(opts?: Partial<UnifiedRequestContext>): Uni
     serverContext: null,
     serverInsertedHTMLCallbacks: [],
     requestScopedCacheLife: null,
+    unstableCacheRevalidation: "foreground",
     _privateCache: null,
     currentRequestTags: [],
     currentFetchSoftTags: [],

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -1216,6 +1216,7 @@ export default async function handler(request, ctx) {
   const __uCtx = _createUnifiedCtx({
     headersContext: headersCtx,
     executionContext: ctx ?? _getRequestExecutionContext() ?? null,
+    unstableCacheRevalidation: "background",
   });
   return _runWithUnifiedCtx(__uCtx, async () => {
     _ensureFetchPatch();
@@ -1879,6 +1880,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           const __revalUCtx = _createUnifiedCtx({
             headersContext: __revalHeadCtx,
             executionContext: _getRequestExecutionContext(),
+            unstableCacheRevalidation: "foreground",
           });
           await _runWithUnifiedCtx(__revalUCtx, async () => {
             _ensureFetchPatch();
@@ -2030,6 +2032,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         const __revalUCtx = _createUnifiedCtx({
           headersContext: __revalHeadCtx,
           executionContext: _getRequestExecutionContext(),
+          unstableCacheRevalidation: "foreground",
         });
         return _runWithUnifiedCtx(__revalUCtx, async () => {
           _ensureFetchPatch();
@@ -3605,6 +3608,7 @@ export default async function handler(request, ctx) {
   const __uCtx = _createUnifiedCtx({
     headersContext: headersCtx,
     executionContext: ctx ?? _getRequestExecutionContext() ?? null,
+    unstableCacheRevalidation: "background",
   });
   return _runWithUnifiedCtx(__uCtx, async () => {
     _ensureFetchPatch();
@@ -4274,6 +4278,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           const __revalUCtx = _createUnifiedCtx({
             headersContext: __revalHeadCtx,
             executionContext: _getRequestExecutionContext(),
+            unstableCacheRevalidation: "foreground",
           });
           await _runWithUnifiedCtx(__revalUCtx, async () => {
             _ensureFetchPatch();
@@ -4425,6 +4430,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         const __revalUCtx = _createUnifiedCtx({
           headersContext: __revalHeadCtx,
           executionContext: _getRequestExecutionContext(),
+          unstableCacheRevalidation: "foreground",
         });
         return _runWithUnifiedCtx(__revalUCtx, async () => {
           _ensureFetchPatch();
@@ -6001,6 +6007,7 @@ export default async function handler(request, ctx) {
   const __uCtx = _createUnifiedCtx({
     headersContext: headersCtx,
     executionContext: ctx ?? _getRequestExecutionContext() ?? null,
+    unstableCacheRevalidation: "background",
   });
   return _runWithUnifiedCtx(__uCtx, async () => {
     _ensureFetchPatch();
@@ -6664,6 +6671,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           const __revalUCtx = _createUnifiedCtx({
             headersContext: __revalHeadCtx,
             executionContext: _getRequestExecutionContext(),
+            unstableCacheRevalidation: "foreground",
           });
           await _runWithUnifiedCtx(__revalUCtx, async () => {
             _ensureFetchPatch();
@@ -6815,6 +6823,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         const __revalUCtx = _createUnifiedCtx({
           headersContext: __revalHeadCtx,
           executionContext: _getRequestExecutionContext(),
+          unstableCacheRevalidation: "foreground",
         });
         return _runWithUnifiedCtx(__revalUCtx, async () => {
           _ensureFetchPatch();
@@ -8423,6 +8432,7 @@ export default async function handler(request, ctx) {
   const __uCtx = _createUnifiedCtx({
     headersContext: headersCtx,
     executionContext: ctx ?? _getRequestExecutionContext() ?? null,
+    unstableCacheRevalidation: "background",
   });
   return _runWithUnifiedCtx(__uCtx, async () => {
     _ensureFetchPatch();
@@ -9086,6 +9096,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           const __revalUCtx = _createUnifiedCtx({
             headersContext: __revalHeadCtx,
             executionContext: _getRequestExecutionContext(),
+            unstableCacheRevalidation: "foreground",
           });
           await _runWithUnifiedCtx(__revalUCtx, async () => {
             _ensureFetchPatch();
@@ -9237,6 +9248,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         const __revalUCtx = _createUnifiedCtx({
           headersContext: __revalHeadCtx,
           executionContext: _getRequestExecutionContext(),
+          unstableCacheRevalidation: "foreground",
         });
         return _runWithUnifiedCtx(__revalUCtx, async () => {
           _ensureFetchPatch();
@@ -10819,6 +10831,7 @@ export default async function handler(request, ctx) {
   const __uCtx = _createUnifiedCtx({
     headersContext: headersCtx,
     executionContext: ctx ?? _getRequestExecutionContext() ?? null,
+    unstableCacheRevalidation: "background",
   });
   return _runWithUnifiedCtx(__uCtx, async () => {
     _ensureFetchPatch();
@@ -11482,6 +11495,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           const __revalUCtx = _createUnifiedCtx({
             headersContext: __revalHeadCtx,
             executionContext: _getRequestExecutionContext(),
+            unstableCacheRevalidation: "foreground",
           });
           await _runWithUnifiedCtx(__revalUCtx, async () => {
             _ensureFetchPatch();
@@ -11633,6 +11647,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         const __revalUCtx = _createUnifiedCtx({
           headersContext: __revalHeadCtx,
           executionContext: _getRequestExecutionContext(),
+          unstableCacheRevalidation: "foreground",
         });
         return _runWithUnifiedCtx(__revalUCtx, async () => {
           _ensureFetchPatch();
@@ -13437,6 +13452,7 @@ export default async function handler(request, ctx) {
   const __uCtx = _createUnifiedCtx({
     headersContext: headersCtx,
     executionContext: ctx ?? _getRequestExecutionContext() ?? null,
+    unstableCacheRevalidation: "background",
   });
   return _runWithUnifiedCtx(__uCtx, async () => {
     _ensureFetchPatch();
@@ -14238,6 +14254,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           const __revalUCtx = _createUnifiedCtx({
             headersContext: __revalHeadCtx,
             executionContext: _getRequestExecutionContext(),
+            unstableCacheRevalidation: "foreground",
           });
           await _runWithUnifiedCtx(__revalUCtx, async () => {
             _ensureFetchPatch();
@@ -14389,6 +14406,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         const __revalUCtx = _createUnifiedCtx({
           headersContext: __revalHeadCtx,
           executionContext: _getRequestExecutionContext(),
+          unstableCacheRevalidation: "foreground",
         });
         return _runWithUnifiedCtx(__revalUCtx, async () => {
           _ensureFetchPatch();

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -5,6 +5,11 @@ import { isExternalUrl, isHashOnlyChange } from "../packages/vinext/src/shims/ro
 import { isValidModulePath } from "../packages/vinext/src/client/validate-module-path.js";
 import vinext from "../packages/vinext/src/index.js";
 import type { Plugin } from "vite-plus";
+import type {
+  CacheHandler,
+  CacheHandlerValue,
+  IncrementalCacheValue,
+} from "../packages/vinext/src/shims/cache.js";
 
 const FIXTURE_DIR = PAGES_FIXTURE_DIR;
 
@@ -1918,6 +1923,140 @@ describe("next/cache shim", () => {
     expect(callCount).toBe(2);
 
     setCacheHandler(new MemoryCacheHandler());
+  });
+
+  it("unstable_cache serves stale entries and refreshes them in the background during App Router requests", async () => {
+    const { unstable_cache, setCacheHandler, MemoryCacheHandler } =
+      await import("../packages/vinext/src/shims/cache.js");
+    const { createRequestContext, runWithRequestContext } =
+      await import("../packages/vinext/src/shims/unified-request-context.js");
+
+    const waitUntilPromises: Promise<unknown>[] = [];
+    const setBodies: string[] = [];
+    let callCount = 0;
+
+    const handler: CacheHandler = {
+      async get(): Promise<CacheHandlerValue> {
+        return {
+          lastModified: Date.now() - 2_000,
+          cacheState: "stale",
+          value: {
+            kind: "FETCH",
+            data: {
+              headers: {},
+              body: JSON.stringify({ v: "stale-value" }),
+              url: "unstable_cache:stale-swr-test:[]",
+            },
+            tags: ["stale-swr"],
+            revalidate: 1,
+          },
+        };
+      },
+      async set(_key: string, data: IncrementalCacheValue | null) {
+        if (data?.kind === "FETCH") {
+          setBodies.push(data.data.body);
+        }
+      },
+      async revalidateTag(_tags: string | string[]) {},
+    };
+
+    setCacheHandler(handler);
+
+    const cached = unstable_cache(
+      async () => {
+        callCount++;
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        return "fresh-value";
+      },
+      ["stale-swr-test"],
+      { tags: ["stale-swr"], revalidate: 1 },
+    );
+
+    // Matches Next.js App Router semantics: stale entries schedule a
+    // pending revalidate and return the stale response immediately.
+    // Source: https://github.com/vercel/next.js/blob/canary/packages/next/src/server/web/spec-extension/unstable-cache.ts
+    const requestContext = createRequestContext({
+      unstableCacheRevalidation: "background",
+      executionContext: {
+        waitUntil(promise) {
+          waitUntilPromises.push(promise);
+        },
+      },
+    });
+
+    try {
+      const result = await Promise.race([
+        runWithRequestContext(requestContext, () => cached()),
+        new Promise((resolve) => setTimeout(() => resolve("blocked"), 10)),
+      ]);
+
+      expect(result).toBe("stale-value");
+      expect(callCount).toBe(1);
+      expect(waitUntilPromises).toHaveLength(1);
+      expect(setBodies).toEqual([]);
+
+      await Promise.all(waitUntilPromises);
+
+      expect(setBodies).toEqual([JSON.stringify({ v: "fresh-value" })]);
+    } finally {
+      setCacheHandler(new MemoryCacheHandler());
+    }
+  });
+
+  it("unstable_cache blocks on stale entries inside revalidation scopes", async () => {
+    const { unstable_cache, setCacheHandler, MemoryCacheHandler } =
+      await import("../packages/vinext/src/shims/cache.js");
+    const { createRequestContext, runWithRequestContext } =
+      await import("../packages/vinext/src/shims/unified-request-context.js");
+
+    let callCount = 0;
+    const handler: CacheHandler = {
+      async get(): Promise<CacheHandlerValue> {
+        return {
+          lastModified: Date.now() - 2_000,
+          cacheState: "stale",
+          value: {
+            kind: "FETCH",
+            data: {
+              headers: {},
+              body: JSON.stringify({ v: "stale-value" }),
+              url: "unstable_cache:foreground-test:[]",
+            },
+            tags: ["foreground"],
+            revalidate: 1,
+          },
+        };
+      },
+      async set() {},
+      async revalidateTag(_tags: string | string[]) {},
+    };
+
+    setCacheHandler(handler);
+
+    const cached = unstable_cache(
+      async () => {
+        callCount++;
+        return "fresh-value";
+      },
+      ["foreground-test"],
+      { tags: ["foreground"], revalidate: 1 },
+    );
+
+    // Next.js foreground-revalidates stale unstable_cache entries while
+    // regenerating a static/ISR page so the regenerated page stores fresh data.
+    // Source test: https://github.com/vercel/next.js/blob/canary/test/production/app-dir/unstable-cache-foreground-revalidate/unstable-cache-foreground-revalidate.test.ts
+    const requestContext = createRequestContext({
+      unstableCacheRevalidation: "foreground",
+    });
+
+    try {
+      await expect(runWithRequestContext(requestContext, () => cached())).resolves.toBe(
+        "fresh-value",
+      );
+      expect(callCount).toBe(1);
+    } finally {
+      setCacheHandler(new MemoryCacheHandler());
+    }
   });
 
   it("unstable_cache with no revalidate option caches indefinitely", async () => {


### PR DESCRIPTION
## Summary

- Make `unstable_cache` distinguish normal App Router requests from cache-regeneration scopes.
- Return stale `FETCH` entries immediately for normal App Router requests, while scheduling a deduped background refresh through `waitUntil` when available.
- Keep stale `unstable_cache` entries blocking in route/page revalidation scopes so regenerated ISR artifacts are written with fresh data.

## Why

`CacheHandler.get()` already preserves time-expired `FETCH` entries as `cacheState: "stale"`, but `unstable_cache` treated stale entries as a miss and awaited the callback before responding. That put callback latency on every TTL boundary for App Router requests instead of serving stale data while refreshing in the background.

This is a meaningful parity/performance fix rather than speculative cleanup: any `unstable_cache(..., { revalidate })` entry with a slow callback added foreground latency each time its TTL elapsed.

## Next.js parity references

- Next.js App Router `unstable_cache` schedules `pendingRevalidates` for stale entries, awaits it only during static generation, and otherwise returns the cached response immediately: https://github.com/vercel/next.js/blob/ae61573e062e900050b8e6b24626e450accc4570/packages/next/src/server/web/spec-extension/unstable-cache.ts#L246-L298
- Next.js no-work-store path, used for Pages/outside-render calls, only returns fresh entries and awaits a new result for stale/miss cases: https://github.com/vercel/next.js/blob/ae61573e062e900050b8e6b24626e450accc4570/packages/next/src/server/web/spec-extension/unstable-cache.ts#L330-L387
- Next.js has a production regression test requiring foreground `unstable_cache` revalidation while an ISR page is regenerating: https://github.com/vercel/next.js/blob/ae61573e062e900050b8e6b24626e450accc4570/test/production/app-dir/unstable-cache-foreground-revalidate/unstable-cache-foreground-revalidate.test.ts#L13-L72
- The incremental cache marks `FETCH` entries stale by age/tags rather than deleting them, which is what makes stale-while-revalidate possible: https://github.com/vercel/next.js/blob/ae61573e062e900050b8e6b24626e450accc4570/packages/next/src/server/lib/incremental-cache/index.ts#L546-L565

## Implementation notes

- `UnifiedRequestContext` now carries an `unstableCacheRevalidation` mode.
- Normal App Router request entry sets that mode to `background`.
- Generated App Router revalidation contexts set it to `foreground`.
- The default remains `foreground`, preserving Pages Router and outside-render behavior.
- Background refreshes are deduped by cache key and always settle/clean up their pending map entry.

## Validation

- `vp test run tests/shims.test.ts -t "unstable_cache serves stale entries"` failed before the fix with stale requests blocking on regeneration.
- `vp test run tests/shims.test.ts -t "unstable_cache (serves stale entries|blocks on stale entries|re-fetches when entry is stale)"`
- `vp check tests/shims.test.ts`
- `vp test run tests/entry-templates.test.ts`
- `vp test run tests/unified-request-context.test.ts`
- `vp test run tests/shims.test.ts`
- `vp test run tests/app-router.test.ts -t "route handler ISR: STALE serves stale data"`
- `vp check`
- `vp run vinext#build`