### PR TITLE
chore(ci): change bonk perms back to normal

### DIFF
--- a/.github/workflows/bigbonk.yml
+++ b/.github/workflows/bigbonk.yml
@@ -18,8 +18,7 @@ jobs:
       (
         github.event.comment.author_association == 'MEMBER' ||
         github.event.comment.author_association == 'COLLABORATOR' ||
-        github.event.comment.author_association == 'OWNER' ||
-        github.event.sender.login == 'NathanDrake2406'
+        github.event.comment.author_association == 'OWNER'
       )
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -46,7 +45,7 @@ jobs:
           model: "cloudflare-ai-gateway/anthropic/claude-opus-4-6"
           mentions: "/bigbonk"
           variant: "max"
-          permissions: any
+          permissions: write
           opencode_dev: false
           opencode_version: 1.14.22
           agent: viguy


### PR DESCRIPTION
Unable to be used for people without write access due to 
https://github.com/anomalyco/opencode/blob/9d1f17d83671fe2674ebbe31005e16bfaec12acc/packages/opencode/src/cli/cmd/github.ts#L1211-L1231