### PR TITLE
fix(app-router): reject middleware control responses in route handlers

### DIFF
--- a/packages/vinext/src/server/app-route-handler-cache.ts
+++ b/packages/vinext/src/server/app-route-handler-cache.ts
@@ -3,6 +3,7 @@ import type { ISRCacheEntry } from "./isr-cache.js";
 import type { RouteHandlerMiddlewareContext } from "./app-route-handler-response.js";
 import {
   applyRouteHandlerMiddlewareContext,
+  assertSupportedAppRouteHandlerResponse,
   buildAppRouteCacheValue,
   buildRouteHandlerCachedResponse,
 } from "./app-route-handler-response.js";
@@ -102,6 +103,7 @@ export async function readAppRouteHandlerCacheResponse(
           });
 
           options.setNavigationContext(null);
+          assertSupportedAppRouteHandlerResponse(response);
 
           if (dynamicUsedInHandler) {
             markKnownDynamicAppRoute(options.routePattern);

--- a/packages/vinext/src/server/app-route-handler-execution.ts
+++ b/packages/vinext/src/server/app-route-handler-execution.ts
@@ -12,6 +12,7 @@ import {
 import {
   applyRouteHandlerMiddlewareContext,
   applyRouteHandlerRevalidateHeader,
+  assertSupportedAppRouteHandlerResponse,
   buildAppRouteCacheValue,
   finalizeRouteHandlerResponse,
   markRouteHandlerCacheMiss,
@@ -109,6 +110,7 @@ export async function executeAppRouteHandler(
 
   try {
     const { dynamicUsedInHandler, response } = await runAppRouteHandler(options);
+    assertSupportedAppRouteHandlerResponse(response);
     const handlerSetCacheControl = response.headers.has("cache-control");
 
     if (dynamicUsedInHandler) {

--- a/packages/vinext/src/server/app-route-handler-response.ts
+++ b/packages/vinext/src/server/app-route-handler-response.ts
@@ -23,9 +23,9 @@ type FinalizeRouteHandlerResponseOptions = {
 const NEVER_CACHE_CONTROL = "private, no-cache, no-store, max-age=0, must-revalidate";
 
 const APP_ROUTE_REWRITE_ERROR =
-  "NextResponse.rewrite() was used in a app route handler, this is not currently supported. Please remove the invocation to continue.";
+  "NextResponse.rewrite() was used in an app route handler, this is not currently supported. Please remove the invocation to continue.";
 const APP_ROUTE_NEXT_ERROR =
-  "NextResponse.next() was used in a app route handler, this is not supported. See here for more info: https://nextjs.org/docs/messages/next-response-next-in-app-route-handler";
+  "NextResponse.next() was used in an app route handler, this is not supported. See here for more info: https://nextjs.org/docs/messages/next-response-next-in-app-route-handler";
 
 function buildRouteHandlerCacheControl(
   cacheState: BuildRouteHandlerCachedResponseOptions["cacheState"],

--- a/packages/vinext/src/server/app-route-handler-response.ts
+++ b/packages/vinext/src/server/app-route-handler-response.ts
@@ -23,9 +23,9 @@ type FinalizeRouteHandlerResponseOptions = {
 const NEVER_CACHE_CONTROL = "private, no-cache, no-store, max-age=0, must-revalidate";
 
 const APP_ROUTE_REWRITE_ERROR =
-  "NextResponse.rewrite() was used in an app route handler, this is not currently supported. Please remove the invocation to continue.";
+  "NextResponse.rewrite() was used in a app route handler, this is not currently supported. Please remove the invocation to continue.";
 const APP_ROUTE_NEXT_ERROR =
-  "NextResponse.next() was used in an app route handler, this is not supported. See here for more info: https://nextjs.org/docs/messages/next-response-next-in-app-route-handler";
+  "NextResponse.next() was used in a app route handler, this is not supported. See here for more info: https://nextjs.org/docs/messages/next-response-next-in-app-route-handler";
 
 function buildRouteHandlerCacheControl(
   cacheState: BuildRouteHandlerCachedResponseOptions["cacheState"],

--- a/packages/vinext/src/server/app-route-handler-response.ts
+++ b/packages/vinext/src/server/app-route-handler-response.ts
@@ -22,6 +22,11 @@ type FinalizeRouteHandlerResponseOptions = {
 // See .nextjs-ref/packages/next/src/server/lib/cache-control.ts.
 const NEVER_CACHE_CONTROL = "private, no-cache, no-store, max-age=0, must-revalidate";
 
+const APP_ROUTE_REWRITE_ERROR =
+  "NextResponse.rewrite() was used in a app route handler, this is not currently supported. Please remove the invocation to continue.";
+const APP_ROUTE_NEXT_ERROR =
+  "NextResponse.next() was used in a app route handler, this is not supported. See here for more info: https://nextjs.org/docs/messages/next-response-next-in-app-route-handler";
+
 function buildRouteHandlerCacheControl(
   cacheState: BuildRouteHandlerCachedResponseOptions["cacheState"],
   revalidateSeconds: number,
@@ -57,6 +62,18 @@ export function applyRouteHandlerMiddlewareContext(
     statusText: response.statusText,
     headers: responseHeaders,
   });
+}
+
+export function assertSupportedAppRouteHandlerResponse(response: Response): void {
+  // NextResponse.next() and rewrite() are middleware control-flow signals.
+  // Once an App Route handler has returned, Next.js rejects those responses.
+  if (response.headers.has("x-middleware-rewrite")) {
+    throw new Error(APP_ROUTE_REWRITE_ERROR);
+  }
+
+  if (response.headers.get("x-middleware-next") === "1") {
+    throw new Error(APP_ROUTE_NEXT_ERROR);
+  }
 }
 
 export function buildRouteHandlerCachedResponse(

--- a/tests/app-route-handler-cache.test.ts
+++ b/tests/app-route-handler-cache.test.ts
@@ -231,6 +231,67 @@ describe("app route handler cache helpers", () => {
     expect(isKnownDynamicAppRoute(routePattern)).toBe(true);
   });
 
+  it("rejects invalid route handler responses during background regeneration", async () => {
+    const dynamicUsage = createDynamicUsageState();
+    const scheduledRegens: Array<() => Promise<void>> = [];
+    let wroteCache = false;
+
+    const response = await readAppRouteHandlerCacheResponse({
+      buildPageCacheTags(pathname, extraTags) {
+        return [pathname, ...extraTags];
+      },
+      cleanPathname: "/api/stale-invalid",
+      clearRequestContext() {},
+      consumeDynamicUsage: dynamicUsage.consumeDynamicUsage,
+      getCollectedFetchTags() {
+        return [];
+      },
+      handlerFn() {
+        return new Response("should not be cached", {
+          headers: { "x-middleware-next": "1" },
+        });
+      },
+      isAutoHead: false,
+      async isrGet() {
+        return buildISRCacheEntry(buildCachedRouteValue("from-stale"), true);
+      },
+      isrRouteKey(pathname) {
+        return "route:" + pathname;
+      },
+      async isrSet() {
+        wroteCache = true;
+      },
+      markDynamicUsage: dynamicUsage.markDynamicUsage,
+      middlewareContext: { headers: null, status: null },
+      params: {},
+      requestUrl: "https://example.com/api/stale-invalid",
+      revalidateSearchParams: new URLSearchParams(),
+      revalidateSeconds: 60,
+      routePattern: "/api/stale-invalid",
+      async runInRevalidationContext(renderFn) {
+        await renderFn();
+      },
+      scheduleBackgroundRegeneration(_key, renderFn) {
+        scheduledRegens.push(renderFn);
+      },
+      setNavigationContext() {},
+    });
+
+    expect(response?.headers.get("x-vinext-cache")).toBe("STALE");
+    await expect(response?.text()).resolves.toBe("from-stale");
+    expect(scheduledRegens).toHaveLength(1);
+
+    const scheduledRegenRun = scheduledRegens[0];
+    if (!scheduledRegenRun) {
+      throw new Error("Expected scheduled route regeneration");
+    }
+
+    await expect(scheduledRegenRun()).rejects.toThrow(
+      "NextResponse.next() was used in a app route handler",
+    );
+    expect(wroteCache).toBe(false);
+  });
+
   it("falls through on cache read errors", async () => {
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 

--- a/tests/app-route-handler-execution.test.ts
+++ b/tests/app-route-handler-execution.test.ts
@@ -308,13 +308,13 @@ describe("app route handler execution helpers", () => {
         headerName: "x-middleware-next",
         headerValue: "1",
         message:
-          "NextResponse.next() was used in a app route handler, this is not supported. See here for more info: https://nextjs.org/docs/messages/next-response-next-in-app-route-handler",
+          "NextResponse.next() was used in an app route handler, this is not supported. See here for more info: https://nextjs.org/docs/messages/next-response-next-in-app-route-handler",
       },
       {
         headerName: "x-middleware-rewrite",
         headerValue: "https://example.com/rewritten",
         message:
-          "NextResponse.rewrite() was used in a app route handler, this is not currently supported. Please remove the invocation to continue.",
+          "NextResponse.rewrite() was used in an app route handler, this is not currently supported. Please remove the invocation to continue.",
       },
     ];
 

--- a/tests/app-route-handler-execution.test.ts
+++ b/tests/app-route-handler-execution.test.ts
@@ -297,4 +297,92 @@ describe("app route handler execution helpers", () => {
 
     errorSpy.mockRestore();
   });
+
+  it("rejects middleware control responses returned from route handlers", async () => {
+    // The NextResponse.next() case is ported from Next.js:
+    // test/e2e/app-dir/app-routes/app-custom-routes.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/app-routes/app-custom-routes.test.ts
+    // The NextResponse.rewrite() case mirrors the adjacent App Route module validation.
+    const cases = [
+      {
+        headerName: "x-middleware-next",
+        headerValue: "1",
+        message:
+          "NextResponse.next() was used in a app route handler, this is not supported. See here for more info: https://nextjs.org/docs/messages/next-response-next-in-app-route-handler",
+      },
+      {
+        headerName: "x-middleware-rewrite",
+        headerValue: "https://example.com/rewritten",
+        message:
+          "NextResponse.rewrite() was used in a app route handler, this is not currently supported. Please remove the invocation to continue.",
+      },
+    ];
+
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      for (const testCase of cases) {
+        const dynamicUsage = createDynamicUsageState();
+        const reportedErrors: Error[] = [];
+        let wroteCache = false;
+        let didClearRequestContext = false;
+
+        const response = await executeAppRouteHandler({
+          buildPageCacheTags(pathname, extraTags) {
+            return [pathname, ...extraTags];
+          },
+          cleanPathname: "/api/middleware-control",
+          clearRequestContext() {
+            didClearRequestContext = true;
+          },
+          consumeDynamicUsage: dynamicUsage.consumeDynamicUsage,
+          executionContext: null,
+          getAndClearPendingCookies() {
+            return [];
+          },
+          getCollectedFetchTags() {
+            return [];
+          },
+          getDraftModeCookieHeader() {
+            return null;
+          },
+          handler: { dynamic: "auto" },
+          handlerFn() {
+            return new Response("should not be sent", {
+              headers: { [testCase.headerName]: testCase.headerValue },
+            });
+          },
+          isAutoHead: false,
+          isProduction: true,
+          isrRouteKey(pathname) {
+            return "route:" + pathname;
+          },
+          async isrSet() {
+            wroteCache = true;
+          },
+          markDynamicUsage: dynamicUsage.markDynamicUsage,
+          method: "GET",
+          middlewareContext: { headers: null, status: null },
+          params: {},
+          reportRequestError(error) {
+            reportedErrors.push(error);
+          },
+          request: new Request("https://example.com/api/middleware-control"),
+          revalidateSeconds: 60,
+          routePattern: "/api/middleware-control",
+          setHeadersAccessPhase() {
+            return "render";
+          },
+        });
+
+        expect(response.status).toBe(500);
+        await expect(response.text()).resolves.toBe("");
+        expect(reportedErrors.map((error) => error.message)).toEqual([testCase.message]);
+        expect(wroteCache).toBe(false);
+        expect(didClearRequestContext).toBe(true);
+      }
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
 });

--- a/tests/app-route-handler-execution.test.ts
+++ b/tests/app-route-handler-execution.test.ts
@@ -308,13 +308,13 @@ describe("app route handler execution helpers", () => {
         headerName: "x-middleware-next",
         headerValue: "1",
         message:
-          "NextResponse.next() was used in an app route handler, this is not supported. See here for more info: https://nextjs.org/docs/messages/next-response-next-in-app-route-handler",
+          "NextResponse.next() was used in a app route handler, this is not supported. See here for more info: https://nextjs.org/docs/messages/next-response-next-in-app-route-handler",
       },
       {
         headerName: "x-middleware-rewrite",
         headerValue: "https://example.com/rewritten",
         message:
-          "NextResponse.rewrite() was used in an app route handler, this is not currently supported. Please remove the invocation to continue.",
+          "NextResponse.rewrite() was used in a app route handler, this is not currently supported. Please remove the invocation to continue.",
       },
     ];
 

--- a/tests/app-route-handler-response.test.ts
+++ b/tests/app-route-handler-response.test.ts
@@ -3,6 +3,7 @@ import type { CachedRouteValue } from "../packages/vinext/src/shims/cache.js";
 import {
   applyRouteHandlerMiddlewareContext,
   applyRouteHandlerRevalidateHeader,
+  assertSupportedAppRouteHandlerResponse,
   buildAppRouteCacheValue,
   buildRouteHandlerCachedResponse,
   finalizeRouteHandlerResponse,
@@ -217,6 +218,30 @@ describe("app route handler response helpers", () => {
 
     expect(response.headers.get("cache-control")).toBe("s-maxage=30, stale-while-revalidate");
     expect(response.headers.get("x-vinext-cache")).toBe("MISS");
+  });
+
+  it("only rejects the active x-middleware-next control signal", () => {
+    expect(() =>
+      assertSupportedAppRouteHandlerResponse(
+        new Response(null, {
+          headers: { "x-middleware-next": "0" },
+        }),
+      ),
+    ).not.toThrow();
+    expect(() =>
+      assertSupportedAppRouteHandlerResponse(
+        new Response(null, {
+          headers: { "x-middleware-next": "true" },
+        }),
+      ),
+    ).not.toThrow();
+    expect(() =>
+      assertSupportedAppRouteHandlerResponse(
+        new Response(null, {
+          headers: { "x-middleware-next": "1" },
+        }),
+      ),
+    ).toThrow("NextResponse.next() was used in a app route handler");
   });
 
   it("emits a no-store Cache-Control for revalidate = 0 route handlers", () => {

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -631,6 +631,20 @@ describe("App Router integration", () => {
     expect(body).toBe("");
   });
 
+  it("rejects middleware control responses returned from route handlers", async () => {
+    // The NextResponse.next() case is ported from Next.js:
+    // test/e2e/app-dir/app-routes/app-custom-routes.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/app-routes/app-custom-routes.test.ts
+    // The NextResponse.rewrite() case mirrors the adjacent App Route module validation.
+    const nextRes = await fetch(`${baseUrl}/api/invalid-next-response-next`);
+    expect(nextRes.status).toBe(500);
+    expect(await nextRes.text()).toBe("");
+
+    const rewriteRes = await fetch(`${baseUrl}/api/invalid-next-response-rewrite`);
+    expect(rewriteRes.status).toBe(500);
+    expect(await rewriteRes.text()).toBe("");
+  });
+
   it("catches redirect() thrown in route handlers", async () => {
     const res = await fetch(`${baseUrl}/api/redirect-route`, { redirect: "manual" });
     expect(res.status).toBe(307);

--- a/tests/fixtures/app-basic/app/api/invalid-next-response-next/route.ts
+++ b/tests/fixtures/app-basic/app/api/invalid-next-response-next/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from "next/server";
+
+export function GET() {
+  return NextResponse.next();
+}

--- a/tests/fixtures/app-basic/app/api/invalid-next-response-rewrite/route.ts
+++ b/tests/fixtures/app-basic/app/api/invalid-next-response-rewrite/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from "next/server";
+
+export function GET(request: Request) {
+  return NextResponse.rewrite(new URL("/api/hello", request.url));
+}


### PR DESCRIPTION
## What this changes
App Route handlers now reject `NextResponse.next()` and `NextResponse.rewrite()` responses instead of treating their internal middleware headers as ordinary successful route-handler output.

## Why
These helpers are middleware control-flow responses. Next.js rejects them after an App Route handler returns:

- [`NextResponse.rewrite()` App Route rejection in Next.js](https://github.com/vercel/next.js/blob/ae61573e062e900050b8e6b24626e450accc4570/packages/next/src/server/route-modules/app-route/module.ts#L968-L972)
- [`NextResponse.next()` App Route rejection in Next.js](https://github.com/vercel/next.js/blob/ae61573e062e900050b8e6b24626e450accc4570/packages/next/src/server/route-modules/app-route/module.ts#L974-L978)
- [Next.js e2e coverage for `NextResponse.next()` returning 500](https://github.com/vercel/next.js/blob/ae61573e062e900050b8e6b24626e450accc4570/test/e2e/app-dir/app-routes/app-custom-routes.test.ts#L557-L575)

Vinext previously accepted those responses and returned `200`, which silently diverged from Next.js and could cache or finalize an invalid route-handler response.

## Approach
The validation lives in the typed route-handler response helper and is invoked from `executeAppRouteHandler()` immediately after the user handler returns. That keeps the generated App RSC entry unchanged and prevents invalid middleware-control responses from reaching cache policy, cookie finalization, or response merging.

The check matches Next.js semantics:

- reject any returned response with `x-middleware-rewrite`
- reject returned responses with `x-middleware-next: 1`
- allow the existing generic route-handler error path to produce the empty `500` response

## Validation
- `vp test run tests/app-route-handler-execution.test.ts tests/app-router.test.ts -t "rejects middleware control responses"` failed before the implementation with `200` responses
- `vp fmt`
- `vp test run tests/app-route-handler-execution.test.ts tests/app-router.test.ts`
- `vp check`

## Risks / follow-ups
No generated App RSC entry code was added. This intentionally preserves middleware use of `NextResponse.next()` and `NextResponse.rewrite()` while rejecting only App Route handler returns.