### PR TITLE
fix(app-router): return 405 for non-action mutations to static pages

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -72,6 +72,7 @@ const appPageRenderPath = resolveEntryPath("../server/app-page-render.js", impor
 const appPageResponsePath = resolveEntryPath("../server/app-page-response.js", import.meta.url);
 const cspPath = resolveEntryPath("../server/csp.js", import.meta.url);
 const appPageRequestPath = resolveEntryPath("../server/app-page-request.js", import.meta.url);
+const appPageMethodPath = resolveEntryPath("../server/app-page-method.js", import.meta.url);
 const appRouteHandlerResponsePath = resolveEntryPath(
   "../server/app-route-handler-response.js",
   import.meta.url,
@@ -428,6 +429,9 @@ import {
   resolveAppPageIntercept as __resolveAppPageIntercept,
   validateAppPageDynamicParams as __validateAppPageDynamicParams,
 } from ${JSON.stringify(appPageRequestPath)};
+import {
+  resolveAppPageMethodResponse as __resolveAppPageMethodResponse,
+} from ${JSON.stringify(appPageMethodPath)};
 import {
   applyRouteHandlerMiddlewareContext as __applyRouteHandlerMiddlewareContext,
 } from ${JSON.stringify(appRouteHandlerResponsePath)};
@@ -2281,6 +2285,19 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   const dynamicParamsConfig = route.page?.dynamicParams; // true (default) | false
   const isForceStatic = dynamicConfig === "force-static";
   const isDynamicError = dynamicConfig === "error";
+  const __methodResponse = __resolveAppPageMethodResponse({
+    dynamicConfig,
+    hasGenerateStaticParams: typeof route.page?.generateStaticParams === "function",
+    isDynamicRoute: route.isDynamic,
+    middlewareHeaders: _mwCtx.headers,
+    request,
+    revalidateSeconds,
+  });
+  if (__methodResponse) {
+    setHeadersContext(null);
+    setNavigationContext(null);
+    return __methodResponse;
+  }
 
   // force-static: replace headers/cookies context with empty values and
   // clear searchParams so dynamic APIs return defaults instead of real data

--- a/packages/vinext/src/server/app-page-method.ts
+++ b/packages/vinext/src/server/app-page-method.ts
@@ -53,10 +53,9 @@ export function resolveAppPageMethodResponse(
     return null;
   }
 
-  const headers = new Headers({
-    Allow: "GET, HEAD",
-  });
+  const headers = new Headers();
   mergeMiddlewareResponseHeaders(headers, options.middlewareHeaders ?? null);
+  headers.set("Allow", "GET, HEAD");
 
   return new Response("Method Not Allowed", {
     headers,

--- a/packages/vinext/src/server/app-page-method.ts
+++ b/packages/vinext/src/server/app-page-method.ts
@@ -1,0 +1,65 @@
+import { isPossibleAppRouteActionRequest } from "./app-route-handler-policy.js";
+import { mergeMiddlewareResponseHeaders } from "./middleware-response-headers.js";
+
+type AppPageMethodPolicyOptions = {
+  dynamicConfig?: string;
+  hasGenerateStaticParams: boolean;
+  isDynamicRoute: boolean;
+  revalidateSeconds: number | null;
+};
+
+type ResolveAppPageMethodResponseOptions = {
+  middlewareHeaders?: Headers | null;
+  request: Pick<Request, "headers" | "method">;
+} & AppPageMethodPolicyOptions;
+
+function isNonGetOrHead(method: string): boolean {
+  const normalizedMethod = method.toUpperCase();
+  return normalizedMethod !== "GET" && normalizedMethod !== "HEAD";
+}
+
+export function isStaticOrSsgAppPageCandidate(options: AppPageMethodPolicyOptions): boolean {
+  if (options.dynamicConfig === "force-dynamic" || options.revalidateSeconds === 0) {
+    return false;
+  }
+
+  if (options.dynamicConfig === "force-static" || options.dynamicConfig === "error") {
+    return true;
+  }
+
+  if (options.revalidateSeconds !== null && options.revalidateSeconds > 0) {
+    return true;
+  }
+
+  if (options.hasGenerateStaticParams) {
+    return true;
+  }
+
+  return !options.isDynamicRoute;
+}
+
+export function resolveAppPageMethodResponse(
+  options: ResolveAppPageMethodResponseOptions,
+): Response | null {
+  if (!isNonGetOrHead(options.request.method)) {
+    return null;
+  }
+
+  if (isPossibleAppRouteActionRequest(options.request)) {
+    return null;
+  }
+
+  if (!isStaticOrSsgAppPageCandidate(options)) {
+    return null;
+  }
+
+  const headers = new Headers({
+    Allow: "GET, HEAD",
+  });
+  mergeMiddlewareResponseHeaders(headers, options.middlewareHeaders ?? null);
+
+  return new Response("Method Not Allowed", {
+    headers,
+    status: 405,
+  });
+}

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -105,6 +105,9 @@ import {
   validateAppPageDynamicParams as __validateAppPageDynamicParams,
 } from "<ROOT>/packages/vinext/src/server/app-page-request.js";
 import {
+  resolveAppPageMethodResponse as __resolveAppPageMethodResponse,
+} from "<ROOT>/packages/vinext/src/server/app-page-method.js";
+import {
   applyRouteHandlerMiddlewareContext as __applyRouteHandlerMiddlewareContext,
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-response.js";
 import { _consumeRequestScopedCacheLife, getCacheHandler } from "next/cache";
@@ -1955,6 +1958,19 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   const dynamicParamsConfig = route.page?.dynamicParams; // true (default) | false
   const isForceStatic = dynamicConfig === "force-static";
   const isDynamicError = dynamicConfig === "error";
+  const __methodResponse = __resolveAppPageMethodResponse({
+    dynamicConfig,
+    hasGenerateStaticParams: typeof route.page?.generateStaticParams === "function",
+    isDynamicRoute: route.isDynamic,
+    middlewareHeaders: _mwCtx.headers,
+    request,
+    revalidateSeconds,
+  });
+  if (__methodResponse) {
+    setHeadersContext(null);
+    setNavigationContext(null);
+    return __methodResponse;
+  }
 
   // force-static: replace headers/cookies context with empty values and
   // clear searchParams so dynamic APIs return defaults instead of real data
@@ -2496,6 +2512,9 @@ import {
   resolveAppPageIntercept as __resolveAppPageIntercept,
   validateAppPageDynamicParams as __validateAppPageDynamicParams,
 } from "<ROOT>/packages/vinext/src/server/app-page-request.js";
+import {
+  resolveAppPageMethodResponse as __resolveAppPageMethodResponse,
+} from "<ROOT>/packages/vinext/src/server/app-page-method.js";
 import {
   applyRouteHandlerMiddlewareContext as __applyRouteHandlerMiddlewareContext,
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-response.js";
@@ -4353,6 +4372,19 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   const dynamicParamsConfig = route.page?.dynamicParams; // true (default) | false
   const isForceStatic = dynamicConfig === "force-static";
   const isDynamicError = dynamicConfig === "error";
+  const __methodResponse = __resolveAppPageMethodResponse({
+    dynamicConfig,
+    hasGenerateStaticParams: typeof route.page?.generateStaticParams === "function",
+    isDynamicRoute: route.isDynamic,
+    middlewareHeaders: _mwCtx.headers,
+    request,
+    revalidateSeconds,
+  });
+  if (__methodResponse) {
+    setHeadersContext(null);
+    setNavigationContext(null);
+    return __methodResponse;
+  }
 
   // force-static: replace headers/cookies context with empty values and
   // clear searchParams so dynamic APIs return defaults instead of real data
@@ -4894,6 +4926,9 @@ import {
   resolveAppPageIntercept as __resolveAppPageIntercept,
   validateAppPageDynamicParams as __validateAppPageDynamicParams,
 } from "<ROOT>/packages/vinext/src/server/app-page-request.js";
+import {
+  resolveAppPageMethodResponse as __resolveAppPageMethodResponse,
+} from "<ROOT>/packages/vinext/src/server/app-page-method.js";
 import {
   applyRouteHandlerMiddlewareContext as __applyRouteHandlerMiddlewareContext,
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-response.js";
@@ -6746,6 +6781,19 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   const dynamicParamsConfig = route.page?.dynamicParams; // true (default) | false
   const isForceStatic = dynamicConfig === "force-static";
   const isDynamicError = dynamicConfig === "error";
+  const __methodResponse = __resolveAppPageMethodResponse({
+    dynamicConfig,
+    hasGenerateStaticParams: typeof route.page?.generateStaticParams === "function",
+    isDynamicRoute: route.isDynamic,
+    middlewareHeaders: _mwCtx.headers,
+    request,
+    revalidateSeconds,
+  });
+  if (__methodResponse) {
+    setHeadersContext(null);
+    setNavigationContext(null);
+    return __methodResponse;
+  }
 
   // force-static: replace headers/cookies context with empty values and
   // clear searchParams so dynamic APIs return defaults instead of real data
@@ -7287,6 +7335,9 @@ import {
   resolveAppPageIntercept as __resolveAppPageIntercept,
   validateAppPageDynamicParams as __validateAppPageDynamicParams,
 } from "<ROOT>/packages/vinext/src/server/app-page-request.js";
+import {
+  resolveAppPageMethodResponse as __resolveAppPageMethodResponse,
+} from "<ROOT>/packages/vinext/src/server/app-page-method.js";
 import {
   applyRouteHandlerMiddlewareContext as __applyRouteHandlerMiddlewareContext,
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-response.js";
@@ -9171,6 +9222,19 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   const dynamicParamsConfig = route.page?.dynamicParams; // true (default) | false
   const isForceStatic = dynamicConfig === "force-static";
   const isDynamicError = dynamicConfig === "error";
+  const __methodResponse = __resolveAppPageMethodResponse({
+    dynamicConfig,
+    hasGenerateStaticParams: typeof route.page?.generateStaticParams === "function",
+    isDynamicRoute: route.isDynamic,
+    middlewareHeaders: _mwCtx.headers,
+    request,
+    revalidateSeconds,
+  });
+  if (__methodResponse) {
+    setHeadersContext(null);
+    setNavigationContext(null);
+    return __methodResponse;
+  }
 
   // force-static: replace headers/cookies context with empty values and
   // clear searchParams so dynamic APIs return defaults instead of real data
@@ -9712,6 +9776,9 @@ import {
   resolveAppPageIntercept as __resolveAppPageIntercept,
   validateAppPageDynamicParams as __validateAppPageDynamicParams,
 } from "<ROOT>/packages/vinext/src/server/app-page-request.js";
+import {
+  resolveAppPageMethodResponse as __resolveAppPageMethodResponse,
+} from "<ROOT>/packages/vinext/src/server/app-page-method.js";
 import {
   applyRouteHandlerMiddlewareContext as __applyRouteHandlerMiddlewareContext,
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-response.js";
@@ -11570,6 +11637,19 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   const dynamicParamsConfig = route.page?.dynamicParams; // true (default) | false
   const isForceStatic = dynamicConfig === "force-static";
   const isDynamicError = dynamicConfig === "error";
+  const __methodResponse = __resolveAppPageMethodResponse({
+    dynamicConfig,
+    hasGenerateStaticParams: typeof route.page?.generateStaticParams === "function",
+    isDynamicRoute: route.isDynamic,
+    middlewareHeaders: _mwCtx.headers,
+    request,
+    revalidateSeconds,
+  });
+  if (__methodResponse) {
+    setHeadersContext(null);
+    setNavigationContext(null);
+    return __methodResponse;
+  }
 
   // force-static: replace headers/cookies context with empty values and
   // clear searchParams so dynamic APIs return defaults instead of real data
@@ -12111,6 +12191,9 @@ import {
   resolveAppPageIntercept as __resolveAppPageIntercept,
   validateAppPageDynamicParams as __validateAppPageDynamicParams,
 } from "<ROOT>/packages/vinext/src/server/app-page-request.js";
+import {
+  resolveAppPageMethodResponse as __resolveAppPageMethodResponse,
+} from "<ROOT>/packages/vinext/src/server/app-page-method.js";
 import {
   applyRouteHandlerMiddlewareContext as __applyRouteHandlerMiddlewareContext,
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-response.js";
@@ -14329,6 +14412,19 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   const dynamicParamsConfig = route.page?.dynamicParams; // true (default) | false
   const isForceStatic = dynamicConfig === "force-static";
   const isDynamicError = dynamicConfig === "error";
+  const __methodResponse = __resolveAppPageMethodResponse({
+    dynamicConfig,
+    hasGenerateStaticParams: typeof route.page?.generateStaticParams === "function",
+    isDynamicRoute: route.isDynamic,
+    middlewareHeaders: _mwCtx.headers,
+    request,
+    revalidateSeconds,
+  });
+  if (__methodResponse) {
+    setHeadersContext(null);
+    setNavigationContext(null);
+    return __methodResponse;
+  }
 
   // force-static: replace headers/cookies context with empty values and
   // clear searchParams so dynamic APIs return defaults instead of real data

--- a/tests/app-page-method.test.ts
+++ b/tests/app-page-method.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  isStaticOrSsgAppPageCandidate,
+  resolveAppPageMethodResponse,
+} from "../packages/vinext/src/server/app-page-method.js";
+
+describe("app page method policy", () => {
+  it("returns 405 with Allow for non-action mutation requests to static candidates", async () => {
+    const response = resolveAppPageMethodResponse({
+      hasGenerateStaticParams: false,
+      isDynamicRoute: false,
+      request: new Request("https://example.com/about", { method: "POST" }),
+      revalidateSeconds: null,
+    });
+
+    if (!response) {
+      throw new Error("Expected a Method Not Allowed response");
+    }
+    expect(response.status).toBe(405);
+    expect(response.headers.get("allow")).toBe("GET, HEAD");
+    await expect(response.text()).resolves.toBe("Method Not Allowed");
+  });
+
+  it("preserves possible server action POSTs", () => {
+    const response = resolveAppPageMethodResponse({
+      hasGenerateStaticParams: false,
+      isDynamicRoute: false,
+      request: new Request("https://example.com/about", {
+        headers: { "next-action": "abc123" },
+        method: "POST",
+      }),
+      revalidateSeconds: null,
+    });
+
+    expect(response).toBeNull();
+  });
+
+  it("treats ISR and generateStaticParams routes as SSG candidates", () => {
+    expect(
+      isStaticOrSsgAppPageCandidate({
+        hasGenerateStaticParams: false,
+        isDynamicRoute: false,
+        revalidateSeconds: 60,
+      }),
+    ).toBe(true);
+
+    expect(
+      isStaticOrSsgAppPageCandidate({
+        hasGenerateStaticParams: true,
+        isDynamicRoute: true,
+        revalidateSeconds: null,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not guard force-dynamic or revalidate zero pages", () => {
+    expect(
+      resolveAppPageMethodResponse({
+        dynamicConfig: "force-dynamic",
+        hasGenerateStaticParams: false,
+        isDynamicRoute: false,
+        request: new Request("https://example.com/dynamic", { method: "PUT" }),
+        revalidateSeconds: null,
+      }),
+    ).toBeNull();
+
+    expect(
+      resolveAppPageMethodResponse({
+        hasGenerateStaticParams: false,
+        isDynamicRoute: false,
+        request: new Request("https://example.com/no-store", { method: "PUT" }),
+        revalidateSeconds: 0,
+      }),
+    ).toBeNull();
+  });
+});

--- a/tests/app-page-method.test.ts
+++ b/tests/app-page-method.test.ts
@@ -35,6 +35,27 @@ describe("app page method policy", () => {
     expect(response).toBeNull();
   });
 
+  it("does not let middleware headers override the 405 Allow header", () => {
+    const middlewareHeaders = new Headers({
+      Allow: "POST",
+      "x-from-middleware": "1",
+    });
+
+    const response = resolveAppPageMethodResponse({
+      hasGenerateStaticParams: false,
+      isDynamicRoute: false,
+      middlewareHeaders,
+      request: new Request("https://example.com/about", { method: "PUT" }),
+      revalidateSeconds: null,
+    });
+
+    if (!response) {
+      throw new Error("Expected a Method Not Allowed response");
+    }
+    expect(response.headers.get("allow")).toBe("GET, HEAD");
+    expect(response.headers.get("x-from-middleware")).toBe("1");
+  });
+
   it("treats ISR and generateStaticParams routes as SSG candidates", () => {
     expect(
       isStaticOrSsgAppPageCandidate({

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -72,6 +72,20 @@ describe("App Router integration", () => {
     expect(html).toContain("This is the about page.");
   });
 
+  // Ported from Next.js: test/e2e/prerender.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/prerender.test.ts
+  it("returns Method Not Allowed for non-action mutation requests to App Router pages", async () => {
+    const staticPageResponse = await fetch(`${baseUrl}/about`, { method: "POST" });
+    expect(staticPageResponse.status).toBe(405);
+    expect(staticPageResponse.headers.get("allow")).toBe("GET, HEAD");
+    expect(await staticPageResponse.text()).toContain("Method Not Allowed");
+
+    const ssgPageResponse = await fetch(`${baseUrl}/isr-test`, { method: "PUT" });
+    expect(ssgPageResponse.status).toBe(405);
+    expect(ssgPageResponse.headers.get("allow")).toBe("GET, HEAD");
+    expect(await ssgPageResponse.text()).toContain("Method Not Allowed");
+  });
+
   it("resolves tsconfig path aliases (@/ imports)", async () => {
     const { res, html } = await fetchHtml(baseUrl, "/alias-test");
     expect(res.status).toBe(200);


### PR DESCRIPTION
## What this changes

Static and SSG App Router page routes now return `405 Method Not Allowed` with `Allow: GET, HEAD` for non-action mutation requests instead of rendering the page.

## Why

Next.js has an explicit static/SSG page guard that returns 405 for non-action, non-GET/HEAD page requests: [base-server.ts#L2274-L2289](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/base-server.ts#L2274-L2289).

That guard intentionally excludes possible server action requests, using the same request-shape semantics defined in [server-action-request-meta.ts#L26-L43](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/server-action-request-meta.ts#L26-L43). Next.js also covers the behavior in the prerender suite: [prerender.test.ts#L564-L572](https://github.com/vercel/next.js/blob/canary/test/e2e/prerender.test.ts#L564-L572).

Vinext already handled route handlers and server actions, but a plain `POST` or `PUT` to a static App Router page fell through to page rendering.

## Approach

- Add `server/app-page-method.ts` for the page method policy so the generated RSC entry stays thin.
- Call that helper before page rendering once route static/SSG metadata is available.
- Preserve possible server action POSTs and explicit dynamic opt-outs (`force-dynamic` and `revalidate = 0`).
- Merge middleware response headers into the generated 405 response.
- Add focused helper tests plus a live App Router fixture regression for static and ISR pages.

## Validation

- `vp test run tests/app-page-method.test.ts tests/app-router.test.ts tests/entry-templates.test.ts`
- `vp check packages/vinext/src/server/app-page-method.ts packages/vinext/src/entries/app-rsc-entry.ts tests/app-page-method.test.ts tests/app-router.test.ts tests/entry-templates.test.ts`
- `vp run vinext#build`

## Risk

The static/SSG classification uses the route metadata currently available in the App Router entry. It preserves explicit dynamic opt-outs and server action requests, and it can become more exact as vinext records richer build-time static classification metadata.