### PR TITLE
Shim next/root-params

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -476,7 +476,7 @@ function setNavigationContext(ctx) {
 function __clearRequestContext() {
   setHeadersContext(null);
   setNavigationContext(null);
-  __setRootParams(null);
+  // setNavigationContext(null) already clears root params internally
 }
 
 // ISR cache is disabled in dev mode — every request re-renders fresh,

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -78,6 +78,7 @@ const appRouteHandlerResponsePath = resolveEntryPath(
 );
 const routeTriePath = resolveEntryPath("../routing/route-trie.js", import.meta.url);
 const metadataRoutesPath = resolveEntryPath("../server/metadata-routes.js", import.meta.url);
+const rootParamsShimPath = resolveEntryPath("../shims/root-params.js", import.meta.url);
 const errorCausePath = resolveEntryPath("../utils/error-cause.js", import.meta.url);
 
 /**
@@ -229,6 +230,7 @@ ${interceptEntries.join(",\n")}
     patternParts: ${JSON.stringify(route.patternParts)},
     isDynamic: ${route.isDynamic},
     params: ${JSON.stringify(route.params)},
+    rootParamNames: ${JSON.stringify(route.rootParamNames ?? [])},
     page: ${route.pagePath ? getImportVar(route.pagePath) : "null"},
     routeHandler: ${route.routePath ? getImportVar(route.routePath) : "null"},
     layouts: [${layoutVars.join(", ")}],
@@ -433,6 +435,7 @@ import {
 } from ${JSON.stringify(appRouteHandlerResponsePath)};
 import { _consumeRequestScopedCacheLife, getCacheHandler } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from ${JSON.stringify(requestContextShimPath)};
+import { setRootParams as __setRootParams } from ${JSON.stringify(rootParamsShimPath)};
 import { ensureFetchPatch as _ensureFetchPatch, getCollectedFetchTags, setCurrentFetchSoftTags } from "vinext/fetch-cache";
 import { buildRouteTrie as _buildRouteTrie, trieMatch as _trieMatch } from ${JSON.stringify(routeTriePath)};
 // Import server-only state module to register ALS-backed accessors.
@@ -610,6 +613,14 @@ const __classDebug = process.env.VINEXT_DEBUG_CLASSIFICATION
 function makeThenableParams(obj) {
   const plain = { ...obj };
   return Object.assign(Promise.resolve(plain), plain);
+}
+
+function __pickRootParams(params, rootParamNames) {
+  const picked = {};
+  for (const name of rootParamNames || []) {
+    picked[name] = params[name];
+  }
+  return picked;
 }
 
 // djb2 hash — matches Next.js's stringHash for digest generation.
@@ -2130,6 +2141,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     searchParams: url.searchParams,
     params,
   });
+  __setRootParams(__pickRootParams(params, route.rootParamNames));
 
   // Handle route.ts API handlers
   if (route.routeHandler) {

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -435,7 +435,7 @@ import {
 } from ${JSON.stringify(appRouteHandlerResponsePath)};
 import { _consumeRequestScopedCacheLife, getCacheHandler } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from ${JSON.stringify(requestContextShimPath)};
-import { setRootParams as __setRootParams } from ${JSON.stringify(rootParamsShimPath)};
+import { setRootParams as __setRootParams, pickRootParams as __pickRootParams } from ${JSON.stringify(rootParamsShimPath)};
 import { ensureFetchPatch as _ensureFetchPatch, getCollectedFetchTags, setCurrentFetchSoftTags } from "vinext/fetch-cache";
 import { buildRouteTrie as _buildRouteTrie, trieMatch as _trieMatch } from ${JSON.stringify(routeTriePath)};
 // Import server-only state module to register ALS-backed accessors.
@@ -470,6 +470,13 @@ console.error = (...args) => {
 // it in a module-level variable (that would leak between concurrent requests).
 function setNavigationContext(ctx) {
   _setNavigationContextOrig(ctx);
+  if (ctx === null) __setRootParams(null);
+}
+
+function __clearRequestContext() {
+  setHeadersContext(null);
+  setNavigationContext(null);
+  __setRootParams(null);
 }
 
 // ISR cache is disabled in dev mode — every request re-renders fresh,
@@ -613,14 +620,6 @@ const __classDebug = process.env.VINEXT_DEBUG_CLASSIFICATION
 function makeThenableParams(obj) {
   const plain = { ...obj };
   return Object.assign(Promise.resolve(plain), plain);
-}
-
-function __pickRootParams(params, rootParamNames) {
-  const picked = {};
-  for (const name of rootParamNames || []) {
-    picked[name] = params[name];
-  }
-  return picked;
 }
 
 // djb2 hash — matches Next.js's stringHash for digest generation.
@@ -826,8 +825,7 @@ async function renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, req
     boundaryComponent: opts?.boundaryComponent ?? null,
     buildFontLinkHeader: __buildAppPageFontLinkHeader,
     clearRequestContext() {
-      setHeadersContext(null);
-      setNavigationContext(null);
+      __clearRequestContext();
     },
     createRscOnErrorHandler(pathname, routePath) {
       return createRscOnErrorHandler(request, pathname, routePath);
@@ -874,8 +872,7 @@ async function renderErrorBoundaryPage(route, error, isRscRequest, request, matc
   return __renderAppPageErrorBoundary({
     buildFontLinkHeader: __buildAppPageFontLinkHeader,
     clearRequestContext() {
-      setHeadersContext(null);
-      setNavigationContext(null);
+      __clearRequestContext();
     },
     createRscOnErrorHandler(pathname, routePath) {
       return createRscOnErrorHandler(request, pathname, routePath);
@@ -1687,8 +1684,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     const __rewritten = matchRewrite(cleanPathname, __configRewrites.beforeFiles, __postMwReqCtx);
     if (__rewritten) {
       if (isExternalUrl(__rewritten)) {
-        setHeadersContext(null);
-        setNavigationContext(null);
+        __clearRequestContext();
         return proxyExternalRequest(request, __rewritten);
       }
       cleanPathname = __rewritten;
@@ -1785,8 +1781,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     !pathname.endsWith(".rsc") &&
     __publicFiles.has(cleanPathname)
   ) {
-    setHeadersContext(null);
-    setNavigationContext(null);
+    __clearRequestContext();
     return __createStaticFileSignal(cleanPathname, _mwCtx);
   }
 
@@ -1806,8 +1801,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     allowedOrigins: __allowedOrigins,
     cleanPathname,
     clearRequestContext() {
-      setHeadersContext(null);
-      setNavigationContext(null);
+      __clearRequestContext();
     },
     contentType: actionContentType,
     decodeAction,
@@ -1835,8 +1829,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     // stream to prevent bypasses via chunked transfer-encoding.
     const contentLength = parseInt(request.headers.get("content-length") || "0", 10);
     if (contentLength > __MAX_ACTION_BODY_SIZE) {
-      setHeadersContext(null);
-      setNavigationContext(null);
+      __clearRequestContext();
       return new Response("Payload Too Large", { status: 413 });
     }
 
@@ -1848,16 +1841,14 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           : await __readBodyWithLimit(request, __MAX_ACTION_BODY_SIZE);
       } catch (sizeErr) {
         if (sizeErr && sizeErr.message === "Request body too large") {
-          setHeadersContext(null);
-          setNavigationContext(null);
+          __clearRequestContext();
           return new Response("Payload Too Large", { status: 413 });
         }
         throw sizeErr;
       }
       const payloadResponse = await validateServerActionPayload(body);
       if (payloadResponse) {
-        setHeadersContext(null);
-        setNavigationContext(null);
+        __clearRequestContext();
         return payloadResponse;
       }
       const temporaryReferences = createTemporaryReferenceSet();
@@ -1912,8 +1903,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       if (actionRedirect) {
         const actionPendingCookies = getAndClearPendingCookies();
         const actionDraftCookie = getDraftModeCookieHeader();
-        setHeadersContext(null);
-        setNavigationContext(null);
+        __clearRequestContext();
         const redirectHeaders = new Headers({
           "Content-Type": "text/x-component; charset=utf-8",
           "Vary": "RSC, Accept",
@@ -2038,8 +2028,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         { path: cleanPathname, method: request.method, headers: Object.fromEntries(request.headers.entries()) },
         { routerKind: "App Router", routePath: cleanPathname, routeType: "action" },
       );
-      setHeadersContext(null);
-      setNavigationContext(null);
+      __clearRequestContext();
       return new Response(
         process.env.NODE_ENV === "production"
           ? "Internal Server Error"
@@ -2054,8 +2043,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     const __afterRewritten = matchRewrite(cleanPathname, __configRewrites.afterFiles, __postMwReqCtx);
     if (__afterRewritten) {
       if (isExternalUrl(__afterRewritten)) {
-        setHeadersContext(null);
-        setNavigationContext(null);
+        __clearRequestContext();
         return proxyExternalRequest(request, __afterRewritten);
       }
       cleanPathname = __afterRewritten;
@@ -2069,8 +2057,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     const __fallbackRewritten = matchRewrite(cleanPathname, __configRewrites.fallback, __postMwReqCtx);
     if (__fallbackRewritten) {
       if (isExternalUrl(__fallbackRewritten)) {
-        setHeadersContext(null);
-        setNavigationContext(null);
+        __clearRequestContext();
         return proxyExternalRequest(request, __fallbackRewritten);
       }
       cleanPathname = __fallbackRewritten;
@@ -2113,8 +2100,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         // (non-404). A 404 means the path isn't a Pages route either,
         // so fall through to the App Router not-found page below.
         if (__pagesRes.status !== 404) {
-          setHeadersContext(null);
-          setNavigationContext(null);
+          __clearRequestContext();
           return __pagesRes;
         }
       }
@@ -2125,8 +2111,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     // Render custom not-found page if available, otherwise plain 404
     const notFoundResponse = await renderNotFoundPage(null, isRscRequest, request, undefined, _scriptNonce, _mwCtx);
     if (notFoundResponse) return notFoundResponse;
-    setHeadersContext(null);
-    setNavigationContext(null);
+    __clearRequestContext();
     const notFoundHeaders = new Headers();
     __mergeMiddlewareResponseHeaders(notFoundHeaders, _mwCtx.headers);
     return new Response("Not Found", { status: 404, headers: notFoundHeaders });
@@ -2162,8 +2147,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     } = __resolveAppRouteHandlerMethod(handler, method);
 
     if (shouldAutoRespondToOptions) {
-      setHeadersContext(null);
-      setNavigationContext(null);
+      __clearRequestContext();
       return __applyRouteHandlerMiddlewareContext(
         new Response(null, {
           status: 204,
@@ -2194,8 +2178,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         buildPageCacheTags: __pageCacheTags,
         cleanPathname,
         clearRequestContext: function() {
-          setHeadersContext(null);
-          setNavigationContext(null);
+          __clearRequestContext();
         },
         consumeDynamicUsage,
         getCollectedFetchTags,
@@ -2240,8 +2223,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         buildPageCacheTags: __pageCacheTags,
         cleanPathname,
         clearRequestContext: function() {
-          setHeadersContext(null);
-          setNavigationContext(null);
+          __clearRequestContext();
         },
         consumeDynamicUsage,
         executionContext: _getRequestExecutionContext(),
@@ -2268,8 +2250,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         setHeadersAccessPhase,
       });
     }
-    setHeadersContext(null);
-    setNavigationContext(null);
+    __clearRequestContext();
     return __applyRouteHandlerMiddlewareContext(
       new Response(null, {
         status: 405,
@@ -2282,8 +2263,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   const hasPageModule = !!route.page;
   const PageComponent = route.page?.default;
   if (hasPageModule && !PageComponent) {
-    setHeadersContext(null);
-    setNavigationContext(null);
+    __clearRequestContext();
     return new Response("Page has no default export", { status: 500 });
   }
 
@@ -2350,8 +2330,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     const __cachedPageResponse = await __readAppPageCacheResponse({
       cleanPathname,
       clearRequestContext: function() {
-        setHeadersContext(null);
-        setNavigationContext(null);
+        __clearRequestContext();
       },
       isRscRequest,
       isrDebug: __isrDebug,
@@ -2401,8 +2380,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
             _getNavigationContext(),
             __revalFontData,
           );
-          setHeadersContext(null);
-          setNavigationContext(null);
+          __clearRequestContext();
           const __freshHtml = await __readAppPageTextStream(__revalHtmlStream);
           const __freshRscData = await __revalRscCapture.capturedRscDataPromise;
           const __pageTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
@@ -2420,8 +2398,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // This runs AFTER the ISR cache read so that a cache hit skips this work entirely.
   const __dynamicParamsResponse = await __validateAppPageDynamicParams({
     clearRequestContext() {
-      setHeadersContext(null);
-      setNavigationContext(null);
+      __clearRequestContext();
     },
     enforceStaticParamsOnly: dynamicParamsConfig === false,
     generateStaticParams: route.page?.generateStaticParams,
@@ -2521,8 +2498,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     renderSpecialError(__buildSpecialError) {
       return __buildAppPageSpecialErrorResponse({
         clearRequestContext() {
-          setHeadersContext(null);
-          setNavigationContext(null);
+          __clearRequestContext();
         },
         middlewareContext: _mwCtx,
         renderFallbackPage(statusCode) {
@@ -2559,8 +2535,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   return __renderAppPageLifecycle({
     cleanPathname,
     clearRequestContext() {
-      setHeadersContext(null);
-      setNavigationContext(null);
+      __clearRequestContext();
     },
     consumeDynamicUsage,
     createRscOnErrorHandler(pathname, routePath) {
@@ -2643,8 +2618,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     async renderLayoutSpecialError(__layoutSpecialError, li) {
       return __buildAppPageSpecialErrorResponse({
         clearRequestContext() {
-          setHeadersContext(null);
-          setNavigationContext(null);
+          __clearRequestContext();
         },
         middlewareContext: _mwCtx,
         renderFallbackPage(statusCode) {
@@ -2686,8 +2660,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     async renderPageSpecialError(specialError) {
       return __buildAppPageSpecialErrorResponse({
         clearRequestContext() {
-          setHeadersContext(null);
-          setNavigationContext(null);
+          __clearRequestContext();
         },
         middlewareContext: _mwCtx,
         renderFallbackPage(statusCode) {

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -367,6 +367,8 @@ const VIRTUAL_APP_SSR_ENTRY = "virtual:vinext-app-ssr-entry";
 const RESOLVED_APP_SSR_ENTRY = "\0" + VIRTUAL_APP_SSR_ENTRY;
 const VIRTUAL_APP_BROWSER_ENTRY = "virtual:vinext-app-browser-entry";
 const RESOLVED_APP_BROWSER_ENTRY = "\0" + VIRTUAL_APP_BROWSER_ENTRY;
+const VIRTUAL_ROOT_PARAMS = "virtual:vinext-root-params";
+const RESOLVED_ROOT_PARAMS = "\0" + VIRTUAL_ROOT_PARAMS;
 /** Image file extensions handled by the vinext:image-imports plugin.
  *  Shared between the Rolldown hook filter and the transform handler regex. */
 const IMAGE_EXTS = "png|jpe?g|gif|webp|avif|svg|ico|bmp|tiff?";
@@ -374,6 +376,21 @@ const IMAGE_EXTS = "png|jpe?g|gif|webp|avif|svg|ico|bmp|tiff?";
 /** Absolute path to vinext's shims directory, used by clientManualChunks. */
 const _shimsDir = path.resolve(__dirname, "shims") + "/";
 const _fontGoogleShimPath = resolveShimModulePath(_shimsDir, "font-google");
+
+function isValidExportIdentifier(name: string): boolean {
+  return /^[$A-Z_a-z][$\w]*$/.test(name);
+}
+
+function generateRootParamsModule(rootParamNames: Iterable<string>): string {
+  const names = Array.from(new Set(rootParamNames)).filter(isValidExportIdentifier).sort();
+  if (names.length === 0) return "export {};\n";
+
+  const rootParamsShimPath = resolveShimModulePath(_shimsDir, "root-params");
+  const exports = names
+    .map((name) => `export function ${name}() { return getRootParam(${JSON.stringify(name)}); }`)
+    .join("\n");
+  return `import { getRootParam } from ${JSON.stringify(rootParamsShimPath)};\n${exports}\n`;
+}
 
 /**
  * Shims with a `.react-server.ts` variant for the RSC environment.
@@ -957,6 +974,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
               "internal",
               "work-unit-async-storage",
             ),
+            "next/dist/server/request/root-params": path.join(shimsDir, "root-params"),
             // Re-export public modules for internal path imports
             // "next/dist/client/components/navigation" in _reactServerShims (#834).
             "next/dist/server/config-shared": path.join(shimsDir, "internal", "utils"),
@@ -1574,6 +1592,9 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           if (cleanId === VIRTUAL_RSC_ENTRY) return RESOLVED_RSC_ENTRY;
           if (cleanId === VIRTUAL_APP_SSR_ENTRY) return RESOLVED_APP_SSR_ENTRY;
           if (cleanId === VIRTUAL_APP_BROWSER_ENTRY) return RESOLVED_APP_BROWSER_ENTRY;
+          if (cleanId === "next/root-params" || cleanId === "next/root-params.js") {
+            return RESOLVED_ROOT_PARAMS;
+          }
           if (cleanId.startsWith(VIRTUAL_GOOGLE_FONTS + "?")) {
             return RESOLVED_VIRTUAL_GOOGLE_FONTS + cleanId.slice(VIRTUAL_GOOGLE_FONTS.length);
           }
@@ -1664,6 +1685,12 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             },
             instrumentationPath,
           );
+        }
+        if (id === RESOLVED_ROOT_PARAMS) {
+          const routes = hasAppDir
+            ? await appRouter(appDir, nextConfig?.pageExtensions, fileMatcher)
+            : [];
+          return generateRootParamsModule(routes.flatMap((route) => route.rootParamNames ?? []));
         }
         if (id === RESOLVED_APP_SSR_ENTRY && hasAppDir) {
           return generateSsrEntry(hasPagesDir);

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -2029,6 +2029,13 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           }
         }
 
+        function invalidateRootParamsModule() {
+          for (const env of Object.values(server.environments)) {
+            const mod = env.moduleGraph.getModuleById(RESOLVED_ROOT_PARAMS);
+            if (mod) env.moduleGraph.invalidateModule(mod);
+          }
+        }
+
         // Node throws on unhandled 'error' events on sockets. When a browser
         // drops the connection mid-response (common in dev: HMR triggers a
         // reload while an RSC stream is still flushing), the next res.write
@@ -2048,6 +2055,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           if (hasAppDir && filePath.startsWith(appDir) && pageExtensions.test(filePath)) {
             invalidateAppRouteCache();
             invalidateRscEntryModule();
+            invalidateRootParamsModule();
           }
         });
         server.watcher.on("unlink", (filePath: string) => {
@@ -2057,6 +2065,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           if (hasAppDir && filePath.startsWith(appDir) && pageExtensions.test(filePath)) {
             invalidateAppRouteCache();
             invalidateRscEntryModule();
+            invalidateRootParamsModule();
           }
         });
 

--- a/packages/vinext/src/routing/app-router.ts
+++ b/packages/vinext/src/routing/app-router.ts
@@ -438,6 +438,7 @@ function discoverSlotSubRoutes(
         layoutTreePositions: parentRoute.layoutTreePositions,
         isDynamic: parentRoute.isDynamic || subIsDynamic,
         params: [...parentRoute.params, ...subParams],
+        rootParamNames: parentRoute.rootParamNames,
         patternParts: [...parentRoute.patternParts, ...urlParts],
       };
       syntheticRoutes.push(newRoute);

--- a/packages/vinext/src/routing/app-router.ts
+++ b/packages/vinext/src/routing/app-router.ts
@@ -130,6 +130,8 @@ export type AppRoute = {
   isDynamic: boolean;
   /** Parameter names for dynamic segments */
   params: string[];
+  /** Dynamic parameter names captured by the route's root layout. */
+  rootParamNames?: string[];
   /** Pre-split pattern segments (computed once at scan time, reused per request) */
   patternParts: string[];
 };
@@ -576,8 +578,31 @@ function directoryToAppRoute(
     layoutTreePositions,
     isDynamic,
     params,
+    rootParamNames: computeRootParamNames(segments, layoutTreePositions),
     patternParts: urlSegments,
   };
+}
+
+function dynamicParamNameFromSegment(segment: string): string | null {
+  if (segment.startsWith("[[...") && segment.endsWith("]]")) return segment.slice(5, -2);
+  if (segment.startsWith("[...") && segment.endsWith("]")) return segment.slice(4, -1);
+  if (segment.startsWith("[") && segment.endsWith("]")) return segment.slice(1, -1);
+  return null;
+}
+
+export function computeRootParamNames(
+  routeSegments: readonly string[],
+  layoutTreePositions: readonly number[],
+): string[] {
+  const rootLayoutPosition = layoutTreePositions[0];
+  if (rootLayoutPosition == null || rootLayoutPosition <= 0) return [];
+
+  const names: string[] = [];
+  for (const segment of routeSegments.slice(0, rootLayoutPosition)) {
+    const name = dynamicParamNameFromSegment(segment);
+    if (name && !names.includes(name)) names.push(name);
+  }
+  return names;
 }
 
 /**

--- a/packages/vinext/src/shims/request-state-types.ts
+++ b/packages/vinext/src/shims/request-state-types.ts
@@ -8,3 +8,4 @@ export type { FetchCacheState } from "./fetch-cache.js";
 export type { ExecutionContextLike } from "./request-context.js";
 export type { SSRContext, RouterState } from "./router-state.js";
 export type { HeadState } from "./head-state.js";
+export type { RootParamsState } from "./root-params.js";

--- a/packages/vinext/src/shims/root-params.ts
+++ b/packages/vinext/src/shims/root-params.ts
@@ -1,4 +1,3 @@
-import { AsyncLocalStorage } from "node:async_hooks";
 import { getRequestContext, isInsideUnifiedScope } from "./unified-request-context.js";
 
 export type RootParams = Record<string, string | string[] | undefined>;
@@ -7,11 +6,8 @@ export type RootParamsState = {
   rootParams: RootParams | null;
 };
 
-const _ALS_KEY = Symbol.for("vinext.rootParams.als");
 const _FALLBACK_KEY = Symbol.for("vinext.rootParams.fallback");
 const _g = globalThis as unknown as Record<PropertyKey, unknown>;
-const _als = (_g[_ALS_KEY] ??=
-  new AsyncLocalStorage<RootParamsState>()) as AsyncLocalStorage<RootParamsState>;
 
 const _fallbackState = (_g[_FALLBACK_KEY] ??= {
   rootParams: null,
@@ -21,13 +17,18 @@ function getState(): RootParamsState {
   if (isInsideUnifiedScope()) {
     return getRequestContext();
   }
-  return _als.getStore() ?? _fallbackState;
+  return _fallbackState;
 }
 
-export function runWithRootParamsContext<T>(fn: () => Promise<T>): Promise<T>;
-export function runWithRootParamsContext<T>(fn: () => T | Promise<T>): T | Promise<T>;
-export function runWithRootParamsContext<T>(fn: () => T | Promise<T>): T | Promise<T> {
-  return _als.run({ rootParams: null }, fn);
+export function pickRootParams(
+  params: RootParams,
+  rootParamNames: readonly string[] | null | undefined,
+): RootParams {
+  const picked: RootParams = {};
+  for (const name of rootParamNames ?? []) {
+    picked[name] = params[name];
+  }
+  return picked;
 }
 
 export function setRootParams(params: RootParams | null): void {

--- a/packages/vinext/src/shims/root-params.ts
+++ b/packages/vinext/src/shims/root-params.ts
@@ -1,0 +1,39 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import { getRequestContext, isInsideUnifiedScope } from "./unified-request-context.js";
+
+export type RootParams = Record<string, string | string[] | undefined>;
+
+export type RootParamsState = {
+  rootParams: RootParams | null;
+};
+
+const _ALS_KEY = Symbol.for("vinext.rootParams.als");
+const _FALLBACK_KEY = Symbol.for("vinext.rootParams.fallback");
+const _g = globalThis as unknown as Record<PropertyKey, unknown>;
+const _als = (_g[_ALS_KEY] ??=
+  new AsyncLocalStorage<RootParamsState>()) as AsyncLocalStorage<RootParamsState>;
+
+const _fallbackState = (_g[_FALLBACK_KEY] ??= {
+  rootParams: null,
+} satisfies RootParamsState) as RootParamsState;
+
+function getState(): RootParamsState {
+  if (isInsideUnifiedScope()) {
+    return getRequestContext();
+  }
+  return _als.getStore() ?? _fallbackState;
+}
+
+export function runWithRootParamsContext<T>(fn: () => Promise<T>): Promise<T>;
+export function runWithRootParamsContext<T>(fn: () => T | Promise<T>): T | Promise<T>;
+export function runWithRootParamsContext<T>(fn: () => T | Promise<T>): T | Promise<T> {
+  return _als.run({ rootParams: null }, fn);
+}
+
+export function setRootParams(params: RootParams | null): void {
+  getState().rootParams = params;
+}
+
+export function getRootParam(name: string): Promise<string | string[] | undefined> {
+  return Promise.resolve(getState().rootParams?.[name]);
+}

--- a/packages/vinext/src/shims/unified-request-context.ts
+++ b/packages/vinext/src/shims/unified-request-context.ts
@@ -20,6 +20,7 @@ import type {
   NavigationState,
   PrivateCacheState,
   RouterState,
+  RootParamsState,
   VinextHeadersShimState,
 } from "./request-state-types.js";
 
@@ -50,7 +51,8 @@ export type UnifiedRequestContext = {
   PrivateCacheState &
   FetchCacheState &
   RouterState &
-  HeadState;
+  HeadState &
+  RootParamsState;
 
 // ---------------------------------------------------------------------------
 // ALS setup — stored on globalThis via Symbol.for so all Vite environments
@@ -100,6 +102,7 @@ export function createRequestContext(opts?: Partial<UnifiedRequestContext>): Uni
     requestCache: new WeakMap(),
     ssrContext: null,
     ssrHeadChildren: [],
+    rootParams: null,
     ...opts,
   };
 }

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -109,6 +109,7 @@ import {
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-response.js";
 import { _consumeRequestScopedCacheLife, getCacheHandler } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
+import { setRootParams as __setRootParams } from "<ROOT>/packages/vinext/src/shims/root-params.js";
 import { ensureFetchPatch as _ensureFetchPatch, getCollectedFetchTags, setCurrentFetchSoftTags } from "vinext/fetch-cache";
 import { buildRouteTrie as _buildRouteTrie, trieMatch as _trieMatch } from "<ROOT>/packages/vinext/src/routing/route-trie.js";
 // Import server-only state module to register ALS-backed accessors.
@@ -288,6 +289,14 @@ function makeThenableParams(obj) {
   return Object.assign(Promise.resolve(plain), plain);
 }
 
+function __pickRootParams(params, rootParamNames) {
+  const picked = {};
+  for (const name of rootParamNames || []) {
+    picked[name] = params[name];
+  }
+  return picked;
+}
+
 // djb2 hash — matches Next.js's stringHash for digest generation.
 // Produces a stable numeric string from error message + stack.
 function __errorDigest(str) {
@@ -448,6 +457,7 @@ const routes = [
     patternParts: [],
     isDynamic: false,
     params: [],
+    rootParamNames: [],
     page: mod_0,
     routeHandler: null,
     layouts: [mod_1],
@@ -473,6 +483,7 @@ const routes = [
     patternParts: ["about"],
     isDynamic: false,
     params: [],
+    rootParamNames: [],
     page: mod_2,
     routeHandler: null,
     layouts: [mod_1],
@@ -498,6 +509,7 @@ const routes = [
     patternParts: ["blog",":slug"],
     isDynamic: true,
     params: ["slug"],
+    rootParamNames: [],
     page: mod_3,
     routeHandler: null,
     layouts: [mod_1, mod_4],
@@ -523,6 +535,7 @@ const routes = [
     patternParts: ["dashboard"],
     isDynamic: false,
     params: [],
+    rootParamNames: [],
     page: mod_5,
     routeHandler: null,
     layouts: [mod_1, mod_6],
@@ -1804,6 +1817,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     searchParams: url.searchParams,
     params,
   });
+  __setRootParams(__pickRootParams(params, route.rootParamNames));
 
   // Handle route.ts API handlers
   if (route.routeHandler) {
@@ -2501,6 +2515,7 @@ import {
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-response.js";
 import { _consumeRequestScopedCacheLife, getCacheHandler } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
+import { setRootParams as __setRootParams } from "<ROOT>/packages/vinext/src/shims/root-params.js";
 import { ensureFetchPatch as _ensureFetchPatch, getCollectedFetchTags, setCurrentFetchSoftTags } from "vinext/fetch-cache";
 import { buildRouteTrie as _buildRouteTrie, trieMatch as _trieMatch } from "<ROOT>/packages/vinext/src/routing/route-trie.js";
 // Import server-only state module to register ALS-backed accessors.
@@ -2680,6 +2695,14 @@ function makeThenableParams(obj) {
   return Object.assign(Promise.resolve(plain), plain);
 }
 
+function __pickRootParams(params, rootParamNames) {
+  const picked = {};
+  for (const name of rootParamNames || []) {
+    picked[name] = params[name];
+  }
+  return picked;
+}
+
 // djb2 hash — matches Next.js's stringHash for digest generation.
 // Produces a stable numeric string from error message + stack.
 function __errorDigest(str) {
@@ -2840,6 +2863,7 @@ const routes = [
     patternParts: [],
     isDynamic: false,
     params: [],
+    rootParamNames: [],
     page: mod_0,
     routeHandler: null,
     layouts: [mod_1],
@@ -2865,6 +2889,7 @@ const routes = [
     patternParts: ["about"],
     isDynamic: false,
     params: [],
+    rootParamNames: [],
     page: mod_2,
     routeHandler: null,
     layouts: [mod_1],
@@ -2890,6 +2915,7 @@ const routes = [
     patternParts: ["blog",":slug"],
     isDynamic: true,
     params: ["slug"],
+    rootParamNames: [],
     page: mod_3,
     routeHandler: null,
     layouts: [mod_1, mod_4],
@@ -2915,6 +2941,7 @@ const routes = [
     patternParts: ["dashboard"],
     isDynamic: false,
     params: [],
+    rootParamNames: [],
     page: mod_5,
     routeHandler: null,
     layouts: [mod_1, mod_6],
@@ -4202,6 +4229,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     searchParams: url.searchParams,
     params,
   });
+  __setRootParams(__pickRootParams(params, route.rootParamNames));
 
   // Handle route.ts API handlers
   if (route.routeHandler) {
@@ -4899,6 +4927,7 @@ import {
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-response.js";
 import { _consumeRequestScopedCacheLife, getCacheHandler } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
+import { setRootParams as __setRootParams } from "<ROOT>/packages/vinext/src/shims/root-params.js";
 import { ensureFetchPatch as _ensureFetchPatch, getCollectedFetchTags, setCurrentFetchSoftTags } from "vinext/fetch-cache";
 import { buildRouteTrie as _buildRouteTrie, trieMatch as _trieMatch } from "<ROOT>/packages/vinext/src/routing/route-trie.js";
 // Import server-only state module to register ALS-backed accessors.
@@ -5078,6 +5107,14 @@ function makeThenableParams(obj) {
   return Object.assign(Promise.resolve(plain), plain);
 }
 
+function __pickRootParams(params, rootParamNames) {
+  const picked = {};
+  for (const name of rootParamNames || []) {
+    picked[name] = params[name];
+  }
+  return picked;
+}
+
 // djb2 hash — matches Next.js's stringHash for digest generation.
 // Produces a stable numeric string from error message + stack.
 function __errorDigest(str) {
@@ -5239,6 +5276,7 @@ const routes = [
     patternParts: [],
     isDynamic: false,
     params: [],
+    rootParamNames: [],
     page: mod_0,
     routeHandler: null,
     layouts: [mod_1],
@@ -5264,6 +5302,7 @@ const routes = [
     patternParts: ["about"],
     isDynamic: false,
     params: [],
+    rootParamNames: [],
     page: mod_2,
     routeHandler: null,
     layouts: [mod_1],
@@ -5289,6 +5328,7 @@ const routes = [
     patternParts: ["blog",":slug"],
     isDynamic: true,
     params: ["slug"],
+    rootParamNames: [],
     page: mod_3,
     routeHandler: null,
     layouts: [mod_1, mod_4],
@@ -5314,6 +5354,7 @@ const routes = [
     patternParts: ["dashboard"],
     isDynamic: false,
     params: [],
+    rootParamNames: [],
     page: mod_5,
     routeHandler: null,
     layouts: [mod_1, mod_6],
@@ -6595,6 +6636,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     searchParams: url.searchParams,
     params,
   });
+  __setRootParams(__pickRootParams(params, route.rootParamNames));
 
   // Handle route.ts API handlers
   if (route.routeHandler) {
@@ -7292,6 +7334,7 @@ import {
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-response.js";
 import { _consumeRequestScopedCacheLife, getCacheHandler } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
+import { setRootParams as __setRootParams } from "<ROOT>/packages/vinext/src/shims/root-params.js";
 import { ensureFetchPatch as _ensureFetchPatch, getCollectedFetchTags, setCurrentFetchSoftTags } from "vinext/fetch-cache";
 import { buildRouteTrie as _buildRouteTrie, trieMatch as _trieMatch } from "<ROOT>/packages/vinext/src/routing/route-trie.js";
 // Import server-only state module to register ALS-backed accessors.
@@ -7469,6 +7512,14 @@ const __classDebug = process.env.VINEXT_DEBUG_CLASSIFICATION
 function makeThenableParams(obj) {
   const plain = { ...obj };
   return Object.assign(Promise.resolve(plain), plain);
+}
+
+function __pickRootParams(params, rootParamNames) {
+  const picked = {};
+  for (const name of rootParamNames || []) {
+    picked[name] = params[name];
+  }
+  return picked;
 }
 
 // djb2 hash — matches Next.js's stringHash for digest generation.
@@ -7661,6 +7712,7 @@ const routes = [
     patternParts: [],
     isDynamic: false,
     params: [],
+    rootParamNames: [],
     page: mod_0,
     routeHandler: null,
     layouts: [mod_1],
@@ -7686,6 +7738,7 @@ const routes = [
     patternParts: ["about"],
     isDynamic: false,
     params: [],
+    rootParamNames: [],
     page: mod_2,
     routeHandler: null,
     layouts: [mod_1],
@@ -7711,6 +7764,7 @@ const routes = [
     patternParts: ["blog",":slug"],
     isDynamic: true,
     params: ["slug"],
+    rootParamNames: [],
     page: mod_3,
     routeHandler: null,
     layouts: [mod_1, mod_4],
@@ -7736,6 +7790,7 @@ const routes = [
     patternParts: ["dashboard"],
     isDynamic: false,
     params: [],
+    rootParamNames: [],
     page: mod_5,
     routeHandler: null,
     layouts: [mod_1, mod_6],
@@ -9020,6 +9075,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     searchParams: url.searchParams,
     params,
   });
+  __setRootParams(__pickRootParams(params, route.rootParamNames));
 
   // Handle route.ts API handlers
   if (route.routeHandler) {
@@ -9717,6 +9773,7 @@ import {
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-response.js";
 import { _consumeRequestScopedCacheLife, getCacheHandler } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
+import { setRootParams as __setRootParams } from "<ROOT>/packages/vinext/src/shims/root-params.js";
 import { ensureFetchPatch as _ensureFetchPatch, getCollectedFetchTags, setCurrentFetchSoftTags } from "vinext/fetch-cache";
 import { buildRouteTrie as _buildRouteTrie, trieMatch as _trieMatch } from "<ROOT>/packages/vinext/src/routing/route-trie.js";
 // Import server-only state module to register ALS-backed accessors.
@@ -9896,6 +9953,14 @@ function makeThenableParams(obj) {
   return Object.assign(Promise.resolve(plain), plain);
 }
 
+function __pickRootParams(params, rootParamNames) {
+  const picked = {};
+  for (const name of rootParamNames || []) {
+    picked[name] = params[name];
+  }
+  return picked;
+}
+
 // djb2 hash — matches Next.js's stringHash for digest generation.
 // Produces a stable numeric string from error message + stack.
 function __errorDigest(str) {
@@ -10057,6 +10122,7 @@ const routes = [
     patternParts: [],
     isDynamic: false,
     params: [],
+    rootParamNames: [],
     page: mod_0,
     routeHandler: null,
     layouts: [mod_1],
@@ -10082,6 +10148,7 @@ const routes = [
     patternParts: ["about"],
     isDynamic: false,
     params: [],
+    rootParamNames: [],
     page: mod_2,
     routeHandler: null,
     layouts: [mod_1],
@@ -10107,6 +10174,7 @@ const routes = [
     patternParts: ["blog",":slug"],
     isDynamic: true,
     params: ["slug"],
+    rootParamNames: [],
     page: mod_3,
     routeHandler: null,
     layouts: [mod_1, mod_4],
@@ -10132,6 +10200,7 @@ const routes = [
     patternParts: ["dashboard"],
     isDynamic: false,
     params: [],
+    rootParamNames: [],
     page: mod_5,
     routeHandler: null,
     layouts: [mod_1, mod_6],
@@ -11419,6 +11488,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     searchParams: url.searchParams,
     params,
   });
+  __setRootParams(__pickRootParams(params, route.rootParamNames));
 
   // Handle route.ts API handlers
   if (route.routeHandler) {
@@ -12116,6 +12186,7 @@ import {
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-response.js";
 import { _consumeRequestScopedCacheLife, getCacheHandler } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
+import { setRootParams as __setRootParams } from "<ROOT>/packages/vinext/src/shims/root-params.js";
 import { ensureFetchPatch as _ensureFetchPatch, getCollectedFetchTags, setCurrentFetchSoftTags } from "vinext/fetch-cache";
 import { buildRouteTrie as _buildRouteTrie, trieMatch as _trieMatch } from "<ROOT>/packages/vinext/src/routing/route-trie.js";
 // Import server-only state module to register ALS-backed accessors.
@@ -12295,6 +12366,14 @@ function makeThenableParams(obj) {
   return Object.assign(Promise.resolve(plain), plain);
 }
 
+function __pickRootParams(params, rootParamNames) {
+  const picked = {};
+  for (const name of rootParamNames || []) {
+    picked[name] = params[name];
+  }
+  return picked;
+}
+
 // djb2 hash — matches Next.js's stringHash for digest generation.
 // Produces a stable numeric string from error message + stack.
 function __errorDigest(str) {
@@ -12455,6 +12534,7 @@ const routes = [
     patternParts: [],
     isDynamic: false,
     params: [],
+    rootParamNames: [],
     page: mod_0,
     routeHandler: null,
     layouts: [mod_1],
@@ -12480,6 +12560,7 @@ const routes = [
     patternParts: ["about"],
     isDynamic: false,
     params: [],
+    rootParamNames: [],
     page: mod_2,
     routeHandler: null,
     layouts: [mod_1],
@@ -12505,6 +12586,7 @@ const routes = [
     patternParts: ["blog",":slug"],
     isDynamic: true,
     params: ["slug"],
+    rootParamNames: [],
     page: mod_3,
     routeHandler: null,
     layouts: [mod_1, mod_4],
@@ -12530,6 +12612,7 @@ const routes = [
     patternParts: ["dashboard"],
     isDynamic: false,
     params: [],
+    rootParamNames: [],
     page: mod_5,
     routeHandler: null,
     layouts: [mod_1, mod_6],
@@ -14178,6 +14261,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     searchParams: url.searchParams,
     params,
   });
+  __setRootParams(__pickRootParams(params, route.rootParamNames));
 
   // Handle route.ts API handlers
   if (route.routeHandler) {

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -109,7 +109,7 @@ import {
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-response.js";
 import { _consumeRequestScopedCacheLife, getCacheHandler } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
-import { setRootParams as __setRootParams } from "<ROOT>/packages/vinext/src/shims/root-params.js";
+import { setRootParams as __setRootParams, pickRootParams as __pickRootParams } from "<ROOT>/packages/vinext/src/shims/root-params.js";
 import { ensureFetchPatch as _ensureFetchPatch, getCollectedFetchTags, setCurrentFetchSoftTags } from "vinext/fetch-cache";
 import { buildRouteTrie as _buildRouteTrie, trieMatch as _trieMatch } from "<ROOT>/packages/vinext/src/routing/route-trie.js";
 // Import server-only state module to register ALS-backed accessors.
@@ -144,6 +144,13 @@ console.error = (...args) => {
 // it in a module-level variable (that would leak between concurrent requests).
 function setNavigationContext(ctx) {
   _setNavigationContextOrig(ctx);
+  if (ctx === null) __setRootParams(null);
+}
+
+function __clearRequestContext() {
+  setHeadersContext(null);
+  setNavigationContext(null);
+  __setRootParams(null);
 }
 
 // ISR cache is disabled in dev mode — every request re-renders fresh,
@@ -287,14 +294,6 @@ const __classDebug = process.env.VINEXT_DEBUG_CLASSIFICATION
 function makeThenableParams(obj) {
   const plain = { ...obj };
   return Object.assign(Promise.resolve(plain), plain);
-}
-
-function __pickRootParams(params, rootParamNames) {
-  const picked = {};
-  for (const name of rootParamNames || []) {
-    picked[name] = params[name];
-  }
-  return picked;
 }
 
 // djb2 hash — matches Next.js's stringHash for digest generation.
@@ -579,8 +578,7 @@ async function renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, req
     boundaryComponent: opts?.boundaryComponent ?? null,
     buildFontLinkHeader: __buildAppPageFontLinkHeader,
     clearRequestContext() {
-      setHeadersContext(null);
-      setNavigationContext(null);
+      __clearRequestContext();
     },
     createRscOnErrorHandler(pathname, routePath) {
       return createRscOnErrorHandler(request, pathname, routePath);
@@ -627,8 +625,7 @@ async function renderErrorBoundaryPage(route, error, isRscRequest, request, matc
   return __renderAppPageErrorBoundary({
     buildFontLinkHeader: __buildAppPageFontLinkHeader,
     clearRequestContext() {
-      setHeadersContext(null);
-      setNavigationContext(null);
+      __clearRequestContext();
     },
     createRscOnErrorHandler(pathname, routePath) {
       return createRscOnErrorHandler(request, pathname, routePath);
@@ -1405,8 +1402,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     const __rewritten = matchRewrite(cleanPathname, __configRewrites.beforeFiles, __postMwReqCtx);
     if (__rewritten) {
       if (isExternalUrl(__rewritten)) {
-        setHeadersContext(null);
-        setNavigationContext(null);
+        __clearRequestContext();
         return proxyExternalRequest(request, __rewritten);
       }
       cleanPathname = __rewritten;
@@ -1503,8 +1499,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     !pathname.endsWith(".rsc") &&
     __publicFiles.has(cleanPathname)
   ) {
-    setHeadersContext(null);
-    setNavigationContext(null);
+    __clearRequestContext();
     return __createStaticFileSignal(cleanPathname, _mwCtx);
   }
 
@@ -1524,8 +1519,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     allowedOrigins: __allowedOrigins,
     cleanPathname,
     clearRequestContext() {
-      setHeadersContext(null);
-      setNavigationContext(null);
+      __clearRequestContext();
     },
     contentType: actionContentType,
     decodeAction,
@@ -1553,8 +1547,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     // stream to prevent bypasses via chunked transfer-encoding.
     const contentLength = parseInt(request.headers.get("content-length") || "0", 10);
     if (contentLength > __MAX_ACTION_BODY_SIZE) {
-      setHeadersContext(null);
-      setNavigationContext(null);
+      __clearRequestContext();
       return new Response("Payload Too Large", { status: 413 });
     }
 
@@ -1566,16 +1559,14 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           : await __readBodyWithLimit(request, __MAX_ACTION_BODY_SIZE);
       } catch (sizeErr) {
         if (sizeErr && sizeErr.message === "Request body too large") {
-          setHeadersContext(null);
-          setNavigationContext(null);
+          __clearRequestContext();
           return new Response("Payload Too Large", { status: 413 });
         }
         throw sizeErr;
       }
       const payloadResponse = await validateServerActionPayload(body);
       if (payloadResponse) {
-        setHeadersContext(null);
-        setNavigationContext(null);
+        __clearRequestContext();
         return payloadResponse;
       }
       const temporaryReferences = createTemporaryReferenceSet();
@@ -1630,8 +1621,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       if (actionRedirect) {
         const actionPendingCookies = getAndClearPendingCookies();
         const actionDraftCookie = getDraftModeCookieHeader();
-        setHeadersContext(null);
-        setNavigationContext(null);
+        __clearRequestContext();
         const redirectHeaders = new Headers({
           "Content-Type": "text/x-component; charset=utf-8",
           "Vary": "RSC, Accept",
@@ -1756,8 +1746,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         { path: cleanPathname, method: request.method, headers: Object.fromEntries(request.headers.entries()) },
         { routerKind: "App Router", routePath: cleanPathname, routeType: "action" },
       );
-      setHeadersContext(null);
-      setNavigationContext(null);
+      __clearRequestContext();
       return new Response(
         process.env.NODE_ENV === "production"
           ? "Internal Server Error"
@@ -1772,8 +1761,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     const __afterRewritten = matchRewrite(cleanPathname, __configRewrites.afterFiles, __postMwReqCtx);
     if (__afterRewritten) {
       if (isExternalUrl(__afterRewritten)) {
-        setHeadersContext(null);
-        setNavigationContext(null);
+        __clearRequestContext();
         return proxyExternalRequest(request, __afterRewritten);
       }
       cleanPathname = __afterRewritten;
@@ -1787,8 +1775,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     const __fallbackRewritten = matchRewrite(cleanPathname, __configRewrites.fallback, __postMwReqCtx);
     if (__fallbackRewritten) {
       if (isExternalUrl(__fallbackRewritten)) {
-        setHeadersContext(null);
-        setNavigationContext(null);
+        __clearRequestContext();
         return proxyExternalRequest(request, __fallbackRewritten);
       }
       cleanPathname = __fallbackRewritten;
@@ -1801,8 +1788,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     // Render custom not-found page if available, otherwise plain 404
     const notFoundResponse = await renderNotFoundPage(null, isRscRequest, request, undefined, _scriptNonce, _mwCtx);
     if (notFoundResponse) return notFoundResponse;
-    setHeadersContext(null);
-    setNavigationContext(null);
+    __clearRequestContext();
     const notFoundHeaders = new Headers();
     __mergeMiddlewareResponseHeaders(notFoundHeaders, _mwCtx.headers);
     return new Response("Not Found", { status: 404, headers: notFoundHeaders });
@@ -1838,8 +1824,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     } = __resolveAppRouteHandlerMethod(handler, method);
 
     if (shouldAutoRespondToOptions) {
-      setHeadersContext(null);
-      setNavigationContext(null);
+      __clearRequestContext();
       return __applyRouteHandlerMiddlewareContext(
         new Response(null, {
           status: 204,
@@ -1870,8 +1855,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         buildPageCacheTags: __pageCacheTags,
         cleanPathname,
         clearRequestContext: function() {
-          setHeadersContext(null);
-          setNavigationContext(null);
+          __clearRequestContext();
         },
         consumeDynamicUsage,
         getCollectedFetchTags,
@@ -1916,8 +1900,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         buildPageCacheTags: __pageCacheTags,
         cleanPathname,
         clearRequestContext: function() {
-          setHeadersContext(null);
-          setNavigationContext(null);
+          __clearRequestContext();
         },
         consumeDynamicUsage,
         executionContext: _getRequestExecutionContext(),
@@ -1944,8 +1927,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         setHeadersAccessPhase,
       });
     }
-    setHeadersContext(null);
-    setNavigationContext(null);
+    __clearRequestContext();
     return __applyRouteHandlerMiddlewareContext(
       new Response(null, {
         status: 405,
@@ -1958,8 +1940,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   const hasPageModule = !!route.page;
   const PageComponent = route.page?.default;
   if (hasPageModule && !PageComponent) {
-    setHeadersContext(null);
-    setNavigationContext(null);
+    __clearRequestContext();
     return new Response("Page has no default export", { status: 500 });
   }
 
@@ -2026,8 +2007,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     const __cachedPageResponse = await __readAppPageCacheResponse({
       cleanPathname,
       clearRequestContext: function() {
-        setHeadersContext(null);
-        setNavigationContext(null);
+        __clearRequestContext();
       },
       isRscRequest,
       isrDebug: __isrDebug,
@@ -2077,8 +2057,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
             _getNavigationContext(),
             __revalFontData,
           );
-          setHeadersContext(null);
-          setNavigationContext(null);
+          __clearRequestContext();
           const __freshHtml = await __readAppPageTextStream(__revalHtmlStream);
           const __freshRscData = await __revalRscCapture.capturedRscDataPromise;
           const __pageTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
@@ -2096,8 +2075,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // This runs AFTER the ISR cache read so that a cache hit skips this work entirely.
   const __dynamicParamsResponse = await __validateAppPageDynamicParams({
     clearRequestContext() {
-      setHeadersContext(null);
-      setNavigationContext(null);
+      __clearRequestContext();
     },
     enforceStaticParamsOnly: dynamicParamsConfig === false,
     generateStaticParams: route.page?.generateStaticParams,
@@ -2197,8 +2175,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     renderSpecialError(__buildSpecialError) {
       return __buildAppPageSpecialErrorResponse({
         clearRequestContext() {
-          setHeadersContext(null);
-          setNavigationContext(null);
+          __clearRequestContext();
         },
         middlewareContext: _mwCtx,
         renderFallbackPage(statusCode) {
@@ -2235,8 +2212,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   return __renderAppPageLifecycle({
     cleanPathname,
     clearRequestContext() {
-      setHeadersContext(null);
-      setNavigationContext(null);
+      __clearRequestContext();
     },
     consumeDynamicUsage,
     createRscOnErrorHandler(pathname, routePath) {
@@ -2319,8 +2295,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     async renderLayoutSpecialError(__layoutSpecialError, li) {
       return __buildAppPageSpecialErrorResponse({
         clearRequestContext() {
-          setHeadersContext(null);
-          setNavigationContext(null);
+          __clearRequestContext();
         },
         middlewareContext: _mwCtx,
         renderFallbackPage(statusCode) {
@@ -2362,8 +2337,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     async renderPageSpecialError(specialError) {
       return __buildAppPageSpecialErrorResponse({
         clearRequestContext() {
-          setHeadersContext(null);
-          setNavigationContext(null);
+          __clearRequestContext();
         },
         middlewareContext: _mwCtx,
         renderFallbackPage(statusCode) {
@@ -2515,7 +2489,7 @@ import {
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-response.js";
 import { _consumeRequestScopedCacheLife, getCacheHandler } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
-import { setRootParams as __setRootParams } from "<ROOT>/packages/vinext/src/shims/root-params.js";
+import { setRootParams as __setRootParams, pickRootParams as __pickRootParams } from "<ROOT>/packages/vinext/src/shims/root-params.js";
 import { ensureFetchPatch as _ensureFetchPatch, getCollectedFetchTags, setCurrentFetchSoftTags } from "vinext/fetch-cache";
 import { buildRouteTrie as _buildRouteTrie, trieMatch as _trieMatch } from "<ROOT>/packages/vinext/src/routing/route-trie.js";
 // Import server-only state module to register ALS-backed accessors.
@@ -2550,6 +2524,13 @@ console.error = (...args) => {
 // it in a module-level variable (that would leak between concurrent requests).
 function setNavigationContext(ctx) {
   _setNavigationContextOrig(ctx);
+  if (ctx === null) __setRootParams(null);
+}
+
+function __clearRequestContext() {
+  setHeadersContext(null);
+  setNavigationContext(null);
+  __setRootParams(null);
 }
 
 // ISR cache is disabled in dev mode — every request re-renders fresh,
@@ -2693,14 +2674,6 @@ const __classDebug = process.env.VINEXT_DEBUG_CLASSIFICATION
 function makeThenableParams(obj) {
   const plain = { ...obj };
   return Object.assign(Promise.resolve(plain), plain);
-}
-
-function __pickRootParams(params, rootParamNames) {
-  const picked = {};
-  for (const name of rootParamNames || []) {
-    picked[name] = params[name];
-  }
-  return picked;
 }
 
 // djb2 hash — matches Next.js's stringHash for digest generation.
@@ -2985,8 +2958,7 @@ async function renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, req
     boundaryComponent: opts?.boundaryComponent ?? null,
     buildFontLinkHeader: __buildAppPageFontLinkHeader,
     clearRequestContext() {
-      setHeadersContext(null);
-      setNavigationContext(null);
+      __clearRequestContext();
     },
     createRscOnErrorHandler(pathname, routePath) {
       return createRscOnErrorHandler(request, pathname, routePath);
@@ -3033,8 +3005,7 @@ async function renderErrorBoundaryPage(route, error, isRscRequest, request, matc
   return __renderAppPageErrorBoundary({
     buildFontLinkHeader: __buildAppPageFontLinkHeader,
     clearRequestContext() {
-      setHeadersContext(null);
-      setNavigationContext(null);
+      __clearRequestContext();
     },
     createRscOnErrorHandler(pathname, routePath) {
       return createRscOnErrorHandler(request, pathname, routePath);
@@ -3817,8 +3788,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     const __rewritten = matchRewrite(cleanPathname, __configRewrites.beforeFiles, __postMwReqCtx);
     if (__rewritten) {
       if (isExternalUrl(__rewritten)) {
-        setHeadersContext(null);
-        setNavigationContext(null);
+        __clearRequestContext();
         return proxyExternalRequest(request, __rewritten);
       }
       cleanPathname = __rewritten;
@@ -3915,8 +3885,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     !pathname.endsWith(".rsc") &&
     __publicFiles.has(cleanPathname)
   ) {
-    setHeadersContext(null);
-    setNavigationContext(null);
+    __clearRequestContext();
     return __createStaticFileSignal(cleanPathname, _mwCtx);
   }
 
@@ -3936,8 +3905,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     allowedOrigins: __allowedOrigins,
     cleanPathname,
     clearRequestContext() {
-      setHeadersContext(null);
-      setNavigationContext(null);
+      __clearRequestContext();
     },
     contentType: actionContentType,
     decodeAction,
@@ -3965,8 +3933,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     // stream to prevent bypasses via chunked transfer-encoding.
     const contentLength = parseInt(request.headers.get("content-length") || "0", 10);
     if (contentLength > __MAX_ACTION_BODY_SIZE) {
-      setHeadersContext(null);
-      setNavigationContext(null);
+      __clearRequestContext();
       return new Response("Payload Too Large", { status: 413 });
     }
 
@@ -3978,16 +3945,14 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           : await __readBodyWithLimit(request, __MAX_ACTION_BODY_SIZE);
       } catch (sizeErr) {
         if (sizeErr && sizeErr.message === "Request body too large") {
-          setHeadersContext(null);
-          setNavigationContext(null);
+          __clearRequestContext();
           return new Response("Payload Too Large", { status: 413 });
         }
         throw sizeErr;
       }
       const payloadResponse = await validateServerActionPayload(body);
       if (payloadResponse) {
-        setHeadersContext(null);
-        setNavigationContext(null);
+        __clearRequestContext();
         return payloadResponse;
       }
       const temporaryReferences = createTemporaryReferenceSet();
@@ -4042,8 +4007,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       if (actionRedirect) {
         const actionPendingCookies = getAndClearPendingCookies();
         const actionDraftCookie = getDraftModeCookieHeader();
-        setHeadersContext(null);
-        setNavigationContext(null);
+        __clearRequestContext();
         const redirectHeaders = new Headers({
           "Content-Type": "text/x-component; charset=utf-8",
           "Vary": "RSC, Accept",
@@ -4168,8 +4132,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         { path: cleanPathname, method: request.method, headers: Object.fromEntries(request.headers.entries()) },
         { routerKind: "App Router", routePath: cleanPathname, routeType: "action" },
       );
-      setHeadersContext(null);
-      setNavigationContext(null);
+      __clearRequestContext();
       return new Response(
         process.env.NODE_ENV === "production"
           ? "Internal Server Error"
@@ -4184,8 +4147,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     const __afterRewritten = matchRewrite(cleanPathname, __configRewrites.afterFiles, __postMwReqCtx);
     if (__afterRewritten) {
       if (isExternalUrl(__afterRewritten)) {
-        setHeadersContext(null);
-        setNavigationContext(null);
+        __clearRequestContext();
         return proxyExternalRequest(request, __afterRewritten);
       }
       cleanPathname = __afterRewritten;
@@ -4199,8 +4161,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     const __fallbackRewritten = matchRewrite(cleanPathname, __configRewrites.fallback, __postMwReqCtx);
     if (__fallbackRewritten) {
       if (isExternalUrl(__fallbackRewritten)) {
-        setHeadersContext(null);
-        setNavigationContext(null);
+        __clearRequestContext();
         return proxyExternalRequest(request, __fallbackRewritten);
       }
       cleanPathname = __fallbackRewritten;
@@ -4213,8 +4174,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     // Render custom not-found page if available, otherwise plain 404
     const notFoundResponse = await renderNotFoundPage(null, isRscRequest, request, undefined, _scriptNonce, _mwCtx);
     if (notFoundResponse) return notFoundResponse;
-    setHeadersContext(null);
-    setNavigationContext(null);
+    __clearRequestContext();
     const notFoundHeaders = new Headers();
     __mergeMiddlewareResponseHeaders(notFoundHeaders, _mwCtx.headers);
     return new Response("Not Found", { status: 404, headers: notFoundHeaders });
@@ -4250,8 +4210,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     } = __resolveAppRouteHandlerMethod(handler, method);
 
     if (shouldAutoRespondToOptions) {
-      setHeadersContext(null);
-      setNavigationContext(null);
+      __clearRequestContext();
       return __applyRouteHandlerMiddlewareContext(
         new Response(null, {
           status: 204,
@@ -4282,8 +4241,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         buildPageCacheTags: __pageCacheTags,
         cleanPathname,
         clearRequestContext: function() {
-          setHeadersContext(null);
-          setNavigationContext(null);
+          __clearRequestContext();
         },
         consumeDynamicUsage,
         getCollectedFetchTags,
@@ -4328,8 +4286,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         buildPageCacheTags: __pageCacheTags,
         cleanPathname,
         clearRequestContext: function() {
-          setHeadersContext(null);
-          setNavigationContext(null);
+          __clearRequestContext();
         },
         consumeDynamicUsage,
         executionContext: _getRequestExecutionContext(),
@@ -4356,8 +4313,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         setHeadersAccessPhase,
       });
     }
-    setHeadersContext(null);
-    setNavigationContext(null);
+    __clearRequestContext();
     return __applyRouteHandlerMiddlewareContext(
       new Response(null, {
         status: 405,
@@ -4370,8 +4326,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   const hasPageModule = !!route.page;
   const PageComponent = route.page?.default;
   if (hasPageModule && !PageComponent) {
-    setHeadersContext(null);
-    setNavigationContext(null);
+    __clearRequestContext();
     return new Response("Page has no default export", { status: 500 });
   }
 
@@ -4438,8 +4393,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     const __cachedPageResponse = await __readAppPageCacheResponse({
       cleanPathname,
       clearRequestContext: function() {
-        setHeadersContext(null);
-        setNavigationContext(null);
+        __clearRequestContext();
       },
       isRscRequest,
       isrDebug: __isrDebug,
@@ -4489,8 +4443,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
             _getNavigationContext(),
             __revalFontData,
           );
-          setHeadersContext(null);
-          setNavigationContext(null);
+          __clearRequestContext();
           const __freshHtml = await __readAppPageTextStream(__revalHtmlStream);
           const __freshRscData = await __revalRscCapture.capturedRscDataPromise;
           const __pageTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
@@ -4508,8 +4461,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // This runs AFTER the ISR cache read so that a cache hit skips this work entirely.
   const __dynamicParamsResponse = await __validateAppPageDynamicParams({
     clearRequestContext() {
-      setHeadersContext(null);
-      setNavigationContext(null);
+      __clearRequestContext();
     },
     enforceStaticParamsOnly: dynamicParamsConfig === false,
     generateStaticParams: route.page?.generateStaticParams,
@@ -4609,8 +4561,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     renderSpecialError(__buildSpecialError) {
       return __buildAppPageSpecialErrorResponse({
         clearRequestContext() {
-          setHeadersContext(null);
-          setNavigationContext(null);
+          __clearRequestContext();
         },
         middlewareContext: _mwCtx,
         renderFallbackPage(statusCode) {
@@ -4647,8 +4598,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   return __renderAppPageLifecycle({
     cleanPathname,
     clearRequestContext() {
-      setHeadersContext(null);
-      setNavigationContext(null);
+      __clearRequestContext();
     },
     consumeDynamicUsage,
     createRscOnErrorHandler(pathname, routePath) {
@@ -4731,8 +4681,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     async renderLayoutSpecialError(__layoutSpecialError, li) {
       return __buildAppPageSpecialErrorResponse({
         clearRequestContext() {
-          setHeadersContext(null);
-          setNavigationContext(null);
+          __clearRequestContext();
         },
         middlewareContext: _mwCtx,
         renderFallbackPage(statusCode) {
@@ -4774,8 +4723,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     async renderPageSpecialError(specialError) {
       return __buildAppPageSpecialErrorResponse({
         clearRequestContext() {
-          setHeadersContext(null);
-          setNavigationContext(null);
+          __clearRequestContext();
         },
         middlewareContext: _mwCtx,
         renderFallbackPage(statusCode) {
@@ -4927,7 +4875,7 @@ import {
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-response.js";
 import { _consumeRequestScopedCacheLife, getCacheHandler } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
-import { setRootParams as __setRootParams } from "<ROOT>/packages/vinext/src/shims/root-params.js";
+import { setRootParams as __setRootParams, pickRootParams as __pickRootParams } from "<ROOT>/packages/vinext/src/shims/root-params.js";
 import { ensureFetchPatch as _ensureFetchPatch, getCollectedFetchTags, setCurrentFetchSoftTags } from "vinext/fetch-cache";
 import { buildRouteTrie as _buildRouteTrie, trieMatch as _trieMatch } from "<ROOT>/packages/vinext/src/routing/route-trie.js";
 // Import server-only state module to register ALS-backed accessors.
@@ -4962,6 +4910,13 @@ console.error = (...args) => {
 // it in a module-level variable (that would leak between concurrent requests).
 function setNavigationContext(ctx) {
   _setNavigationContextOrig(ctx);
+  if (ctx === null) __setRootParams(null);
+}
+
+function __clearRequestContext() {
+  setHeadersContext(null);
+  setNavigationContext(null);
+  __setRootParams(null);
 }
 
 // ISR cache is disabled in dev mode — every request re-renders fresh,
@@ -5105,14 +5060,6 @@ const __classDebug = process.env.VINEXT_DEBUG_CLASSIFICATION
 function makeThenableParams(obj) {
   const plain = { ...obj };
   return Object.assign(Promise.resolve(plain), plain);
-}
-
-function __pickRootParams(params, rootParamNames) {
-  const picked = {};
-  for (const name of rootParamNames || []) {
-    picked[name] = params[name];
-  }
-  return picked;
 }
 
 // djb2 hash — matches Next.js's stringHash for digest generation.
@@ -5398,8 +5345,7 @@ async function renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, req
     boundaryComponent: opts?.boundaryComponent ?? null,
     buildFontLinkHeader: __buildAppPageFontLinkHeader,
     clearRequestContext() {
-      setHeadersContext(null);
-      setNavigationContext(null);
+      __clearRequestContext();
     },
     createRscOnErrorHandler(pathname, routePath) {
       return createRscOnErrorHandler(request, pathname, routePath);
@@ -5446,8 +5392,7 @@ async function renderErrorBoundaryPage(route, error, isRscRequest, request, matc
   return __renderAppPageErrorBoundary({
     buildFontLinkHeader: __buildAppPageFontLinkHeader,
     clearRequestContext() {
-      setHeadersContext(null);
-      setNavigationContext(null);
+      __clearRequestContext();
     },
     createRscOnErrorHandler(pathname, routePath) {
       return createRscOnErrorHandler(request, pathname, routePath);
@@ -6224,8 +6169,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     const __rewritten = matchRewrite(cleanPathname, __configRewrites.beforeFiles, __postMwReqCtx);
     if (__rewritten) {
       if (isExternalUrl(__rewritten)) {
-        setHeadersContext(null);
-        setNavigationContext(null);
+        __clearRequestContext();
         return proxyExternalRequest(request, __rewritten);
       }
       cleanPathname = __rewritten;
@@ -6322,8 +6266,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     !pathname.endsWith(".rsc") &&
     __publicFiles.has(cleanPathname)
   ) {
-    setHeadersContext(null);
-    setNavigationContext(null);
+    __clearRequestContext();
     return __createStaticFileSignal(cleanPathname, _mwCtx);
   }
 
@@ -6343,8 +6286,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     allowedOrigins: __allowedOrigins,
     cleanPathname,
     clearRequestContext() {
-      setHeadersContext(null);
-      setNavigationContext(null);
+      __clearRequestContext();
     },
     contentType: actionContentType,
     decodeAction,
@@ -6372,8 +6314,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     // stream to prevent bypasses via chunked transfer-encoding.
     const contentLength = parseInt(request.headers.get("content-length") || "0", 10);
     if (contentLength > __MAX_ACTION_BODY_SIZE) {
-      setHeadersContext(null);
-      setNavigationContext(null);
+      __clearRequestContext();
       return new Response("Payload Too Large", { status: 413 });
     }
 
@@ -6385,16 +6326,14 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           : await __readBodyWithLimit(request, __MAX_ACTION_BODY_SIZE);
       } catch (sizeErr) {
         if (sizeErr && sizeErr.message === "Request body too large") {
-          setHeadersContext(null);
-          setNavigationContext(null);
+          __clearRequestContext();
           return new Response("Payload Too Large", { status: 413 });
         }
         throw sizeErr;
       }
       const payloadResponse = await validateServerActionPayload(body);
       if (payloadResponse) {
-        setHeadersContext(null);
-        setNavigationContext(null);
+        __clearRequestContext();
         return payloadResponse;
       }
       const temporaryReferences = createTemporaryReferenceSet();
@@ -6449,8 +6388,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       if (actionRedirect) {
         const actionPendingCookies = getAndClearPendingCookies();
         const actionDraftCookie = getDraftModeCookieHeader();
-        setHeadersContext(null);
-        setNavigationContext(null);
+        __clearRequestContext();
         const redirectHeaders = new Headers({
           "Content-Type": "text/x-component; charset=utf-8",
           "Vary": "RSC, Accept",
@@ -6575,8 +6513,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         { path: cleanPathname, method: request.method, headers: Object.fromEntries(request.headers.entries()) },
         { routerKind: "App Router", routePath: cleanPathname, routeType: "action" },
       );
-      setHeadersContext(null);
-      setNavigationContext(null);
+      __clearRequestContext();
       return new Response(
         process.env.NODE_ENV === "production"
           ? "Internal Server Error"
@@ -6591,8 +6528,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     const __afterRewritten = matchRewrite(cleanPathname, __configRewrites.afterFiles, __postMwReqCtx);
     if (__afterRewritten) {
       if (isExternalUrl(__afterRewritten)) {
-        setHeadersContext(null);
-        setNavigationContext(null);
+        __clearRequestContext();
         return proxyExternalRequest(request, __afterRewritten);
       }
       cleanPathname = __afterRewritten;
@@ -6606,8 +6542,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     const __fallbackRewritten = matchRewrite(cleanPathname, __configRewrites.fallback, __postMwReqCtx);
     if (__fallbackRewritten) {
       if (isExternalUrl(__fallbackRewritten)) {
-        setHeadersContext(null);
-        setNavigationContext(null);
+        __clearRequestContext();
         return proxyExternalRequest(request, __fallbackRewritten);
       }
       cleanPathname = __fallbackRewritten;
@@ -6620,8 +6555,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     // Render custom not-found page if available, otherwise plain 404
     const notFoundResponse = await renderNotFoundPage(null, isRscRequest, request, undefined, _scriptNonce, _mwCtx);
     if (notFoundResponse) return notFoundResponse;
-    setHeadersContext(null);
-    setNavigationContext(null);
+    __clearRequestContext();
     const notFoundHeaders = new Headers();
     __mergeMiddlewareResponseHeaders(notFoundHeaders, _mwCtx.headers);
     return new Response("Not Found", { status: 404, headers: notFoundHeaders });
@@ -6657,8 +6591,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     } = __resolveAppRouteHandlerMethod(handler, method);
 
     if (shouldAutoRespondToOptions) {
-      setHeadersContext(null);
-      setNavigationContext(null);
+      __clearRequestContext();
       return __applyRouteHandlerMiddlewareContext(
         new Response(null, {
           status: 204,
@@ -6689,8 +6622,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         buildPageCacheTags: __pageCacheTags,
         cleanPathname,
         clearRequestContext: function() {
-          setHeadersContext(null);
-          setNavigationContext(null);
+          __clearRequestContext();
         },
         consumeDynamicUsage,
         getCollectedFetchTags,
@@ -6735,8 +6667,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         buildPageCacheTags: __pageCacheTags,
         cleanPathname,
         clearRequestContext: function() {
-          setHeadersContext(null);
-          setNavigationContext(null);
+          __clearRequestContext();
         },
         consumeDynamicUsage,
         executionContext: _getRequestExecutionContext(),
@@ -6763,8 +6694,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         setHeadersAccessPhase,
       });
     }
-    setHeadersContext(null);
-    setNavigationContext(null);
+    __clearRequestContext();
     return __applyRouteHandlerMiddlewareContext(
       new Response(null, {
         status: 405,
@@ -6777,8 +6707,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   const hasPageModule = !!route.page;
   const PageComponent = route.page?.default;
   if (hasPageModule && !PageComponent) {
-    setHeadersContext(null);
-    setNavigationContext(null);
+    __clearRequestContext();
     return new Response("Page has no default export", { status: 500 });
   }
 
@@ -6845,8 +6774,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     const __cachedPageResponse = await __readAppPageCacheResponse({
       cleanPathname,
       clearRequestContext: function() {
-        setHeadersContext(null);
-        setNavigationContext(null);
+        __clearRequestContext();
       },
       isRscRequest,
       isrDebug: __isrDebug,
@@ -6896,8 +6824,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
             _getNavigationContext(),
             __revalFontData,
           );
-          setHeadersContext(null);
-          setNavigationContext(null);
+          __clearRequestContext();
           const __freshHtml = await __readAppPageTextStream(__revalHtmlStream);
           const __freshRscData = await __revalRscCapture.capturedRscDataPromise;
           const __pageTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
@@ -6915,8 +6842,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // This runs AFTER the ISR cache read so that a cache hit skips this work entirely.
   const __dynamicParamsResponse = await __validateAppPageDynamicParams({
     clearRequestContext() {
-      setHeadersContext(null);
-      setNavigationContext(null);
+      __clearRequestContext();
     },
     enforceStaticParamsOnly: dynamicParamsConfig === false,
     generateStaticParams: route.page?.generateStaticParams,
@@ -7016,8 +6942,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     renderSpecialError(__buildSpecialError) {
       return __buildAppPageSpecialErrorResponse({
         clearRequestContext() {
-          setHeadersContext(null);
-          setNavigationContext(null);
+          __clearRequestContext();
         },
         middlewareContext: _mwCtx,
         renderFallbackPage(statusCode) {
@@ -7054,8 +6979,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   return __renderAppPageLifecycle({
     cleanPathname,
     clearRequestContext() {
-      setHeadersContext(null);
-      setNavigationContext(null);
+      __clearRequestContext();
     },
     consumeDynamicUsage,
     createRscOnErrorHandler(pathname, routePath) {
@@ -7138,8 +7062,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     async renderLayoutSpecialError(__layoutSpecialError, li) {
       return __buildAppPageSpecialErrorResponse({
         clearRequestContext() {
-          setHeadersContext(null);
-          setNavigationContext(null);
+          __clearRequestContext();
         },
         middlewareContext: _mwCtx,
         renderFallbackPage(statusCode) {
@@ -7181,8 +7104,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     async renderPageSpecialError(specialError) {
       return __buildAppPageSpecialErrorResponse({
         clearRequestContext() {
-          setHeadersContext(null);
-          setNavigationContext(null);
+          __clearRequestContext();
         },
         middlewareContext: _mwCtx,
         renderFallbackPage(statusCode) {
@@ -7334,7 +7256,7 @@ import {
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-response.js";
 import { _consumeRequestScopedCacheLife, getCacheHandler } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
-import { setRootParams as __setRootParams } from "<ROOT>/packages/vinext/src/shims/root-params.js";
+import { setRootParams as __setRootParams, pickRootParams as __pickRootParams } from "<ROOT>/packages/vinext/src/shims/root-params.js";
 import { ensureFetchPatch as _ensureFetchPatch, getCollectedFetchTags, setCurrentFetchSoftTags } from "vinext/fetch-cache";
 import { buildRouteTrie as _buildRouteTrie, trieMatch as _trieMatch } from "<ROOT>/packages/vinext/src/routing/route-trie.js";
 // Import server-only state module to register ALS-backed accessors.
@@ -7369,6 +7291,13 @@ console.error = (...args) => {
 // it in a module-level variable (that would leak between concurrent requests).
 function setNavigationContext(ctx) {
   _setNavigationContextOrig(ctx);
+  if (ctx === null) __setRootParams(null);
+}
+
+function __clearRequestContext() {
+  setHeadersContext(null);
+  setNavigationContext(null);
+  __setRootParams(null);
 }
 
 // ISR cache is disabled in dev mode — every request re-renders fresh,
@@ -7512,14 +7441,6 @@ const __classDebug = process.env.VINEXT_DEBUG_CLASSIFICATION
 function makeThenableParams(obj) {
   const plain = { ...obj };
   return Object.assign(Promise.resolve(plain), plain);
-}
-
-function __pickRootParams(params, rootParamNames) {
-  const picked = {};
-  for (const name of rootParamNames || []) {
-    picked[name] = params[name];
-  }
-  return picked;
 }
 
 // djb2 hash — matches Next.js's stringHash for digest generation.
@@ -7834,8 +7755,7 @@ async function renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, req
     boundaryComponent: opts?.boundaryComponent ?? null,
     buildFontLinkHeader: __buildAppPageFontLinkHeader,
     clearRequestContext() {
-      setHeadersContext(null);
-      setNavigationContext(null);
+      __clearRequestContext();
     },
     createRscOnErrorHandler(pathname, routePath) {
       return createRscOnErrorHandler(request, pathname, routePath);
@@ -7882,8 +7802,7 @@ async function renderErrorBoundaryPage(route, error, isRscRequest, request, matc
   return __renderAppPageErrorBoundary({
     buildFontLinkHeader: __buildAppPageFontLinkHeader,
     clearRequestContext() {
-      setHeadersContext(null);
-      setNavigationContext(null);
+      __clearRequestContext();
     },
     createRscOnErrorHandler(pathname, routePath) {
       return createRscOnErrorHandler(request, pathname, routePath);
@@ -8663,8 +8582,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     const __rewritten = matchRewrite(cleanPathname, __configRewrites.beforeFiles, __postMwReqCtx);
     if (__rewritten) {
       if (isExternalUrl(__rewritten)) {
-        setHeadersContext(null);
-        setNavigationContext(null);
+        __clearRequestContext();
         return proxyExternalRequest(request, __rewritten);
       }
       cleanPathname = __rewritten;
@@ -8761,8 +8679,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     !pathname.endsWith(".rsc") &&
     __publicFiles.has(cleanPathname)
   ) {
-    setHeadersContext(null);
-    setNavigationContext(null);
+    __clearRequestContext();
     return __createStaticFileSignal(cleanPathname, _mwCtx);
   }
 
@@ -8782,8 +8699,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     allowedOrigins: __allowedOrigins,
     cleanPathname,
     clearRequestContext() {
-      setHeadersContext(null);
-      setNavigationContext(null);
+      __clearRequestContext();
     },
     contentType: actionContentType,
     decodeAction,
@@ -8811,8 +8727,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     // stream to prevent bypasses via chunked transfer-encoding.
     const contentLength = parseInt(request.headers.get("content-length") || "0", 10);
     if (contentLength > __MAX_ACTION_BODY_SIZE) {
-      setHeadersContext(null);
-      setNavigationContext(null);
+      __clearRequestContext();
       return new Response("Payload Too Large", { status: 413 });
     }
 
@@ -8824,16 +8739,14 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           : await __readBodyWithLimit(request, __MAX_ACTION_BODY_SIZE);
       } catch (sizeErr) {
         if (sizeErr && sizeErr.message === "Request body too large") {
-          setHeadersContext(null);
-          setNavigationContext(null);
+          __clearRequestContext();
           return new Response("Payload Too Large", { status: 413 });
         }
         throw sizeErr;
       }
       const payloadResponse = await validateServerActionPayload(body);
       if (payloadResponse) {
-        setHeadersContext(null);
-        setNavigationContext(null);
+        __clearRequestContext();
         return payloadResponse;
       }
       const temporaryReferences = createTemporaryReferenceSet();
@@ -8888,8 +8801,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       if (actionRedirect) {
         const actionPendingCookies = getAndClearPendingCookies();
         const actionDraftCookie = getDraftModeCookieHeader();
-        setHeadersContext(null);
-        setNavigationContext(null);
+        __clearRequestContext();
         const redirectHeaders = new Headers({
           "Content-Type": "text/x-component; charset=utf-8",
           "Vary": "RSC, Accept",
@@ -9014,8 +8926,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         { path: cleanPathname, method: request.method, headers: Object.fromEntries(request.headers.entries()) },
         { routerKind: "App Router", routePath: cleanPathname, routeType: "action" },
       );
-      setHeadersContext(null);
-      setNavigationContext(null);
+      __clearRequestContext();
       return new Response(
         process.env.NODE_ENV === "production"
           ? "Internal Server Error"
@@ -9030,8 +8941,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     const __afterRewritten = matchRewrite(cleanPathname, __configRewrites.afterFiles, __postMwReqCtx);
     if (__afterRewritten) {
       if (isExternalUrl(__afterRewritten)) {
-        setHeadersContext(null);
-        setNavigationContext(null);
+        __clearRequestContext();
         return proxyExternalRequest(request, __afterRewritten);
       }
       cleanPathname = __afterRewritten;
@@ -9045,8 +8955,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     const __fallbackRewritten = matchRewrite(cleanPathname, __configRewrites.fallback, __postMwReqCtx);
     if (__fallbackRewritten) {
       if (isExternalUrl(__fallbackRewritten)) {
-        setHeadersContext(null);
-        setNavigationContext(null);
+        __clearRequestContext();
         return proxyExternalRequest(request, __fallbackRewritten);
       }
       cleanPathname = __fallbackRewritten;
@@ -9059,8 +8968,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     // Render custom not-found page if available, otherwise plain 404
     const notFoundResponse = await renderNotFoundPage(null, isRscRequest, request, undefined, _scriptNonce, _mwCtx);
     if (notFoundResponse) return notFoundResponse;
-    setHeadersContext(null);
-    setNavigationContext(null);
+    __clearRequestContext();
     const notFoundHeaders = new Headers();
     __mergeMiddlewareResponseHeaders(notFoundHeaders, _mwCtx.headers);
     return new Response("Not Found", { status: 404, headers: notFoundHeaders });
@@ -9096,8 +9004,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     } = __resolveAppRouteHandlerMethod(handler, method);
 
     if (shouldAutoRespondToOptions) {
-      setHeadersContext(null);
-      setNavigationContext(null);
+      __clearRequestContext();
       return __applyRouteHandlerMiddlewareContext(
         new Response(null, {
           status: 204,
@@ -9128,8 +9035,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         buildPageCacheTags: __pageCacheTags,
         cleanPathname,
         clearRequestContext: function() {
-          setHeadersContext(null);
-          setNavigationContext(null);
+          __clearRequestContext();
         },
         consumeDynamicUsage,
         getCollectedFetchTags,
@@ -9174,8 +9080,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         buildPageCacheTags: __pageCacheTags,
         cleanPathname,
         clearRequestContext: function() {
-          setHeadersContext(null);
-          setNavigationContext(null);
+          __clearRequestContext();
         },
         consumeDynamicUsage,
         executionContext: _getRequestExecutionContext(),
@@ -9202,8 +9107,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         setHeadersAccessPhase,
       });
     }
-    setHeadersContext(null);
-    setNavigationContext(null);
+    __clearRequestContext();
     return __applyRouteHandlerMiddlewareContext(
       new Response(null, {
         status: 405,
@@ -9216,8 +9120,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   const hasPageModule = !!route.page;
   const PageComponent = route.page?.default;
   if (hasPageModule && !PageComponent) {
-    setHeadersContext(null);
-    setNavigationContext(null);
+    __clearRequestContext();
     return new Response("Page has no default export", { status: 500 });
   }
 
@@ -9284,8 +9187,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     const __cachedPageResponse = await __readAppPageCacheResponse({
       cleanPathname,
       clearRequestContext: function() {
-        setHeadersContext(null);
-        setNavigationContext(null);
+        __clearRequestContext();
       },
       isRscRequest,
       isrDebug: __isrDebug,
@@ -9335,8 +9237,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
             _getNavigationContext(),
             __revalFontData,
           );
-          setHeadersContext(null);
-          setNavigationContext(null);
+          __clearRequestContext();
           const __freshHtml = await __readAppPageTextStream(__revalHtmlStream);
           const __freshRscData = await __revalRscCapture.capturedRscDataPromise;
           const __pageTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
@@ -9354,8 +9255,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // This runs AFTER the ISR cache read so that a cache hit skips this work entirely.
   const __dynamicParamsResponse = await __validateAppPageDynamicParams({
     clearRequestContext() {
-      setHeadersContext(null);
-      setNavigationContext(null);
+      __clearRequestContext();
     },
     enforceStaticParamsOnly: dynamicParamsConfig === false,
     generateStaticParams: route.page?.generateStaticParams,
@@ -9455,8 +9355,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     renderSpecialError(__buildSpecialError) {
       return __buildAppPageSpecialErrorResponse({
         clearRequestContext() {
-          setHeadersContext(null);
-          setNavigationContext(null);
+          __clearRequestContext();
         },
         middlewareContext: _mwCtx,
         renderFallbackPage(statusCode) {
@@ -9493,8 +9392,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   return __renderAppPageLifecycle({
     cleanPathname,
     clearRequestContext() {
-      setHeadersContext(null);
-      setNavigationContext(null);
+      __clearRequestContext();
     },
     consumeDynamicUsage,
     createRscOnErrorHandler(pathname, routePath) {
@@ -9577,8 +9475,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     async renderLayoutSpecialError(__layoutSpecialError, li) {
       return __buildAppPageSpecialErrorResponse({
         clearRequestContext() {
-          setHeadersContext(null);
-          setNavigationContext(null);
+          __clearRequestContext();
         },
         middlewareContext: _mwCtx,
         renderFallbackPage(statusCode) {
@@ -9620,8 +9517,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     async renderPageSpecialError(specialError) {
       return __buildAppPageSpecialErrorResponse({
         clearRequestContext() {
-          setHeadersContext(null);
-          setNavigationContext(null);
+          __clearRequestContext();
         },
         middlewareContext: _mwCtx,
         renderFallbackPage(statusCode) {
@@ -9773,7 +9669,7 @@ import {
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-response.js";
 import { _consumeRequestScopedCacheLife, getCacheHandler } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
-import { setRootParams as __setRootParams } from "<ROOT>/packages/vinext/src/shims/root-params.js";
+import { setRootParams as __setRootParams, pickRootParams as __pickRootParams } from "<ROOT>/packages/vinext/src/shims/root-params.js";
 import { ensureFetchPatch as _ensureFetchPatch, getCollectedFetchTags, setCurrentFetchSoftTags } from "vinext/fetch-cache";
 import { buildRouteTrie as _buildRouteTrie, trieMatch as _trieMatch } from "<ROOT>/packages/vinext/src/routing/route-trie.js";
 // Import server-only state module to register ALS-backed accessors.
@@ -9808,6 +9704,13 @@ console.error = (...args) => {
 // it in a module-level variable (that would leak between concurrent requests).
 function setNavigationContext(ctx) {
   _setNavigationContextOrig(ctx);
+  if (ctx === null) __setRootParams(null);
+}
+
+function __clearRequestContext() {
+  setHeadersContext(null);
+  setNavigationContext(null);
+  __setRootParams(null);
 }
 
 // ISR cache is disabled in dev mode — every request re-renders fresh,
@@ -9951,14 +9854,6 @@ const __classDebug = process.env.VINEXT_DEBUG_CLASSIFICATION
 function makeThenableParams(obj) {
   const plain = { ...obj };
   return Object.assign(Promise.resolve(plain), plain);
-}
-
-function __pickRootParams(params, rootParamNames) {
-  const picked = {};
-  for (const name of rootParamNames || []) {
-    picked[name] = params[name];
-  }
-  return picked;
 }
 
 // djb2 hash — matches Next.js's stringHash for digest generation.
@@ -10250,8 +10145,7 @@ async function renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, req
     boundaryComponent: opts?.boundaryComponent ?? null,
     buildFontLinkHeader: __buildAppPageFontLinkHeader,
     clearRequestContext() {
-      setHeadersContext(null);
-      setNavigationContext(null);
+      __clearRequestContext();
     },
     createRscOnErrorHandler(pathname, routePath) {
       return createRscOnErrorHandler(request, pathname, routePath);
@@ -10298,8 +10192,7 @@ async function renderErrorBoundaryPage(route, error, isRscRequest, request, matc
   return __renderAppPageErrorBoundary({
     buildFontLinkHeader: __buildAppPageFontLinkHeader,
     clearRequestContext() {
-      setHeadersContext(null);
-      setNavigationContext(null);
+      __clearRequestContext();
     },
     createRscOnErrorHandler(pathname, routePath) {
       return createRscOnErrorHandler(request, pathname, routePath);
@@ -11076,8 +10969,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     const __rewritten = matchRewrite(cleanPathname, __configRewrites.beforeFiles, __postMwReqCtx);
     if (__rewritten) {
       if (isExternalUrl(__rewritten)) {
-        setHeadersContext(null);
-        setNavigationContext(null);
+        __clearRequestContext();
         return proxyExternalRequest(request, __rewritten);
       }
       cleanPathname = __rewritten;
@@ -11174,8 +11066,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     !pathname.endsWith(".rsc") &&
     __publicFiles.has(cleanPathname)
   ) {
-    setHeadersContext(null);
-    setNavigationContext(null);
+    __clearRequestContext();
     return __createStaticFileSignal(cleanPathname, _mwCtx);
   }
 
@@ -11195,8 +11086,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     allowedOrigins: __allowedOrigins,
     cleanPathname,
     clearRequestContext() {
-      setHeadersContext(null);
-      setNavigationContext(null);
+      __clearRequestContext();
     },
     contentType: actionContentType,
     decodeAction,
@@ -11224,8 +11114,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     // stream to prevent bypasses via chunked transfer-encoding.
     const contentLength = parseInt(request.headers.get("content-length") || "0", 10);
     if (contentLength > __MAX_ACTION_BODY_SIZE) {
-      setHeadersContext(null);
-      setNavigationContext(null);
+      __clearRequestContext();
       return new Response("Payload Too Large", { status: 413 });
     }
 
@@ -11237,16 +11126,14 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           : await __readBodyWithLimit(request, __MAX_ACTION_BODY_SIZE);
       } catch (sizeErr) {
         if (sizeErr && sizeErr.message === "Request body too large") {
-          setHeadersContext(null);
-          setNavigationContext(null);
+          __clearRequestContext();
           return new Response("Payload Too Large", { status: 413 });
         }
         throw sizeErr;
       }
       const payloadResponse = await validateServerActionPayload(body);
       if (payloadResponse) {
-        setHeadersContext(null);
-        setNavigationContext(null);
+        __clearRequestContext();
         return payloadResponse;
       }
       const temporaryReferences = createTemporaryReferenceSet();
@@ -11301,8 +11188,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       if (actionRedirect) {
         const actionPendingCookies = getAndClearPendingCookies();
         const actionDraftCookie = getDraftModeCookieHeader();
-        setHeadersContext(null);
-        setNavigationContext(null);
+        __clearRequestContext();
         const redirectHeaders = new Headers({
           "Content-Type": "text/x-component; charset=utf-8",
           "Vary": "RSC, Accept",
@@ -11427,8 +11313,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         { path: cleanPathname, method: request.method, headers: Object.fromEntries(request.headers.entries()) },
         { routerKind: "App Router", routePath: cleanPathname, routeType: "action" },
       );
-      setHeadersContext(null);
-      setNavigationContext(null);
+      __clearRequestContext();
       return new Response(
         process.env.NODE_ENV === "production"
           ? "Internal Server Error"
@@ -11443,8 +11328,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     const __afterRewritten = matchRewrite(cleanPathname, __configRewrites.afterFiles, __postMwReqCtx);
     if (__afterRewritten) {
       if (isExternalUrl(__afterRewritten)) {
-        setHeadersContext(null);
-        setNavigationContext(null);
+        __clearRequestContext();
         return proxyExternalRequest(request, __afterRewritten);
       }
       cleanPathname = __afterRewritten;
@@ -11458,8 +11342,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     const __fallbackRewritten = matchRewrite(cleanPathname, __configRewrites.fallback, __postMwReqCtx);
     if (__fallbackRewritten) {
       if (isExternalUrl(__fallbackRewritten)) {
-        setHeadersContext(null);
-        setNavigationContext(null);
+        __clearRequestContext();
         return proxyExternalRequest(request, __fallbackRewritten);
       }
       cleanPathname = __fallbackRewritten;
@@ -11472,8 +11355,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     // Render custom not-found page if available, otherwise plain 404
     const notFoundResponse = await renderNotFoundPage(null, isRscRequest, request, undefined, _scriptNonce, _mwCtx);
     if (notFoundResponse) return notFoundResponse;
-    setHeadersContext(null);
-    setNavigationContext(null);
+    __clearRequestContext();
     const notFoundHeaders = new Headers();
     __mergeMiddlewareResponseHeaders(notFoundHeaders, _mwCtx.headers);
     return new Response("Not Found", { status: 404, headers: notFoundHeaders });
@@ -11509,8 +11391,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     } = __resolveAppRouteHandlerMethod(handler, method);
 
     if (shouldAutoRespondToOptions) {
-      setHeadersContext(null);
-      setNavigationContext(null);
+      __clearRequestContext();
       return __applyRouteHandlerMiddlewareContext(
         new Response(null, {
           status: 204,
@@ -11541,8 +11422,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         buildPageCacheTags: __pageCacheTags,
         cleanPathname,
         clearRequestContext: function() {
-          setHeadersContext(null);
-          setNavigationContext(null);
+          __clearRequestContext();
         },
         consumeDynamicUsage,
         getCollectedFetchTags,
@@ -11587,8 +11467,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         buildPageCacheTags: __pageCacheTags,
         cleanPathname,
         clearRequestContext: function() {
-          setHeadersContext(null);
-          setNavigationContext(null);
+          __clearRequestContext();
         },
         consumeDynamicUsage,
         executionContext: _getRequestExecutionContext(),
@@ -11615,8 +11494,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         setHeadersAccessPhase,
       });
     }
-    setHeadersContext(null);
-    setNavigationContext(null);
+    __clearRequestContext();
     return __applyRouteHandlerMiddlewareContext(
       new Response(null, {
         status: 405,
@@ -11629,8 +11507,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   const hasPageModule = !!route.page;
   const PageComponent = route.page?.default;
   if (hasPageModule && !PageComponent) {
-    setHeadersContext(null);
-    setNavigationContext(null);
+    __clearRequestContext();
     return new Response("Page has no default export", { status: 500 });
   }
 
@@ -11697,8 +11574,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     const __cachedPageResponse = await __readAppPageCacheResponse({
       cleanPathname,
       clearRequestContext: function() {
-        setHeadersContext(null);
-        setNavigationContext(null);
+        __clearRequestContext();
       },
       isRscRequest,
       isrDebug: __isrDebug,
@@ -11748,8 +11624,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
             _getNavigationContext(),
             __revalFontData,
           );
-          setHeadersContext(null);
-          setNavigationContext(null);
+          __clearRequestContext();
           const __freshHtml = await __readAppPageTextStream(__revalHtmlStream);
           const __freshRscData = await __revalRscCapture.capturedRscDataPromise;
           const __pageTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
@@ -11767,8 +11642,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // This runs AFTER the ISR cache read so that a cache hit skips this work entirely.
   const __dynamicParamsResponse = await __validateAppPageDynamicParams({
     clearRequestContext() {
-      setHeadersContext(null);
-      setNavigationContext(null);
+      __clearRequestContext();
     },
     enforceStaticParamsOnly: dynamicParamsConfig === false,
     generateStaticParams: route.page?.generateStaticParams,
@@ -11868,8 +11742,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     renderSpecialError(__buildSpecialError) {
       return __buildAppPageSpecialErrorResponse({
         clearRequestContext() {
-          setHeadersContext(null);
-          setNavigationContext(null);
+          __clearRequestContext();
         },
         middlewareContext: _mwCtx,
         renderFallbackPage(statusCode) {
@@ -11906,8 +11779,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   return __renderAppPageLifecycle({
     cleanPathname,
     clearRequestContext() {
-      setHeadersContext(null);
-      setNavigationContext(null);
+      __clearRequestContext();
     },
     consumeDynamicUsage,
     createRscOnErrorHandler(pathname, routePath) {
@@ -11990,8 +11862,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     async renderLayoutSpecialError(__layoutSpecialError, li) {
       return __buildAppPageSpecialErrorResponse({
         clearRequestContext() {
-          setHeadersContext(null);
-          setNavigationContext(null);
+          __clearRequestContext();
         },
         middlewareContext: _mwCtx,
         renderFallbackPage(statusCode) {
@@ -12033,8 +11904,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     async renderPageSpecialError(specialError) {
       return __buildAppPageSpecialErrorResponse({
         clearRequestContext() {
-          setHeadersContext(null);
-          setNavigationContext(null);
+          __clearRequestContext();
         },
         middlewareContext: _mwCtx,
         renderFallbackPage(statusCode) {
@@ -12186,7 +12056,7 @@ import {
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-response.js";
 import { _consumeRequestScopedCacheLife, getCacheHandler } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
-import { setRootParams as __setRootParams } from "<ROOT>/packages/vinext/src/shims/root-params.js";
+import { setRootParams as __setRootParams, pickRootParams as __pickRootParams } from "<ROOT>/packages/vinext/src/shims/root-params.js";
 import { ensureFetchPatch as _ensureFetchPatch, getCollectedFetchTags, setCurrentFetchSoftTags } from "vinext/fetch-cache";
 import { buildRouteTrie as _buildRouteTrie, trieMatch as _trieMatch } from "<ROOT>/packages/vinext/src/routing/route-trie.js";
 // Import server-only state module to register ALS-backed accessors.
@@ -12221,6 +12091,13 @@ console.error = (...args) => {
 // it in a module-level variable (that would leak between concurrent requests).
 function setNavigationContext(ctx) {
   _setNavigationContextOrig(ctx);
+  if (ctx === null) __setRootParams(null);
+}
+
+function __clearRequestContext() {
+  setHeadersContext(null);
+  setNavigationContext(null);
+  __setRootParams(null);
 }
 
 // ISR cache is disabled in dev mode — every request re-renders fresh,
@@ -12364,14 +12241,6 @@ const __classDebug = process.env.VINEXT_DEBUG_CLASSIFICATION
 function makeThenableParams(obj) {
   const plain = { ...obj };
   return Object.assign(Promise.resolve(plain), plain);
-}
-
-function __pickRootParams(params, rootParamNames) {
-  const picked = {};
-  for (const name of rootParamNames || []) {
-    picked[name] = params[name];
-  }
-  return picked;
 }
 
 // djb2 hash — matches Next.js's stringHash for digest generation.
@@ -12656,8 +12525,7 @@ async function renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, req
     boundaryComponent: opts?.boundaryComponent ?? null,
     buildFontLinkHeader: __buildAppPageFontLinkHeader,
     clearRequestContext() {
-      setHeadersContext(null);
-      setNavigationContext(null);
+      __clearRequestContext();
     },
     createRscOnErrorHandler(pathname, routePath) {
       return createRscOnErrorHandler(request, pathname, routePath);
@@ -12704,8 +12572,7 @@ async function renderErrorBoundaryPage(route, error, isRscRequest, request, matc
   return __renderAppPageErrorBoundary({
     buildFontLinkHeader: __buildAppPageFontLinkHeader,
     clearRequestContext() {
-      setHeadersContext(null);
-      setNavigationContext(null);
+      __clearRequestContext();
     },
     createRscOnErrorHandler(pathname, routePath) {
       return createRscOnErrorHandler(request, pathname, routePath);
@@ -13849,8 +13716,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     const __rewritten = matchRewrite(cleanPathname, __configRewrites.beforeFiles, __postMwReqCtx);
     if (__rewritten) {
       if (isExternalUrl(__rewritten)) {
-        setHeadersContext(null);
-        setNavigationContext(null);
+        __clearRequestContext();
         return proxyExternalRequest(request, __rewritten);
       }
       cleanPathname = __rewritten;
@@ -13947,8 +13813,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     !pathname.endsWith(".rsc") &&
     __publicFiles.has(cleanPathname)
   ) {
-    setHeadersContext(null);
-    setNavigationContext(null);
+    __clearRequestContext();
     return __createStaticFileSignal(cleanPathname, _mwCtx);
   }
 
@@ -13968,8 +13833,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     allowedOrigins: __allowedOrigins,
     cleanPathname,
     clearRequestContext() {
-      setHeadersContext(null);
-      setNavigationContext(null);
+      __clearRequestContext();
     },
     contentType: actionContentType,
     decodeAction,
@@ -13997,8 +13861,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     // stream to prevent bypasses via chunked transfer-encoding.
     const contentLength = parseInt(request.headers.get("content-length") || "0", 10);
     if (contentLength > __MAX_ACTION_BODY_SIZE) {
-      setHeadersContext(null);
-      setNavigationContext(null);
+      __clearRequestContext();
       return new Response("Payload Too Large", { status: 413 });
     }
 
@@ -14010,16 +13873,14 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
           : await __readBodyWithLimit(request, __MAX_ACTION_BODY_SIZE);
       } catch (sizeErr) {
         if (sizeErr && sizeErr.message === "Request body too large") {
-          setHeadersContext(null);
-          setNavigationContext(null);
+          __clearRequestContext();
           return new Response("Payload Too Large", { status: 413 });
         }
         throw sizeErr;
       }
       const payloadResponse = await validateServerActionPayload(body);
       if (payloadResponse) {
-        setHeadersContext(null);
-        setNavigationContext(null);
+        __clearRequestContext();
         return payloadResponse;
       }
       const temporaryReferences = createTemporaryReferenceSet();
@@ -14074,8 +13935,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       if (actionRedirect) {
         const actionPendingCookies = getAndClearPendingCookies();
         const actionDraftCookie = getDraftModeCookieHeader();
-        setHeadersContext(null);
-        setNavigationContext(null);
+        __clearRequestContext();
         const redirectHeaders = new Headers({
           "Content-Type": "text/x-component; charset=utf-8",
           "Vary": "RSC, Accept",
@@ -14200,8 +14060,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         { path: cleanPathname, method: request.method, headers: Object.fromEntries(request.headers.entries()) },
         { routerKind: "App Router", routePath: cleanPathname, routeType: "action" },
       );
-      setHeadersContext(null);
-      setNavigationContext(null);
+      __clearRequestContext();
       return new Response(
         process.env.NODE_ENV === "production"
           ? "Internal Server Error"
@@ -14216,8 +14075,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     const __afterRewritten = matchRewrite(cleanPathname, __configRewrites.afterFiles, __postMwReqCtx);
     if (__afterRewritten) {
       if (isExternalUrl(__afterRewritten)) {
-        setHeadersContext(null);
-        setNavigationContext(null);
+        __clearRequestContext();
         return proxyExternalRequest(request, __afterRewritten);
       }
       cleanPathname = __afterRewritten;
@@ -14231,8 +14089,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     const __fallbackRewritten = matchRewrite(cleanPathname, __configRewrites.fallback, __postMwReqCtx);
     if (__fallbackRewritten) {
       if (isExternalUrl(__fallbackRewritten)) {
-        setHeadersContext(null);
-        setNavigationContext(null);
+        __clearRequestContext();
         return proxyExternalRequest(request, __fallbackRewritten);
       }
       cleanPathname = __fallbackRewritten;
@@ -14245,8 +14102,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     // Render custom not-found page if available, otherwise plain 404
     const notFoundResponse = await renderNotFoundPage(null, isRscRequest, request, undefined, _scriptNonce, _mwCtx);
     if (notFoundResponse) return notFoundResponse;
-    setHeadersContext(null);
-    setNavigationContext(null);
+    __clearRequestContext();
     const notFoundHeaders = new Headers();
     __mergeMiddlewareResponseHeaders(notFoundHeaders, _mwCtx.headers);
     return new Response("Not Found", { status: 404, headers: notFoundHeaders });
@@ -14282,8 +14138,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     } = __resolveAppRouteHandlerMethod(handler, method);
 
     if (shouldAutoRespondToOptions) {
-      setHeadersContext(null);
-      setNavigationContext(null);
+      __clearRequestContext();
       return __applyRouteHandlerMiddlewareContext(
         new Response(null, {
           status: 204,
@@ -14314,8 +14169,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         buildPageCacheTags: __pageCacheTags,
         cleanPathname,
         clearRequestContext: function() {
-          setHeadersContext(null);
-          setNavigationContext(null);
+          __clearRequestContext();
         },
         consumeDynamicUsage,
         getCollectedFetchTags,
@@ -14360,8 +14214,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         buildPageCacheTags: __pageCacheTags,
         cleanPathname,
         clearRequestContext: function() {
-          setHeadersContext(null);
-          setNavigationContext(null);
+          __clearRequestContext();
         },
         consumeDynamicUsage,
         executionContext: _getRequestExecutionContext(),
@@ -14388,8 +14241,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         setHeadersAccessPhase,
       });
     }
-    setHeadersContext(null);
-    setNavigationContext(null);
+    __clearRequestContext();
     return __applyRouteHandlerMiddlewareContext(
       new Response(null, {
         status: 405,
@@ -14402,8 +14254,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   const hasPageModule = !!route.page;
   const PageComponent = route.page?.default;
   if (hasPageModule && !PageComponent) {
-    setHeadersContext(null);
-    setNavigationContext(null);
+    __clearRequestContext();
     return new Response("Page has no default export", { status: 500 });
   }
 
@@ -14470,8 +14321,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     const __cachedPageResponse = await __readAppPageCacheResponse({
       cleanPathname,
       clearRequestContext: function() {
-        setHeadersContext(null);
-        setNavigationContext(null);
+        __clearRequestContext();
       },
       isRscRequest,
       isrDebug: __isrDebug,
@@ -14521,8 +14371,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
             _getNavigationContext(),
             __revalFontData,
           );
-          setHeadersContext(null);
-          setNavigationContext(null);
+          __clearRequestContext();
           const __freshHtml = await __readAppPageTextStream(__revalHtmlStream);
           const __freshRscData = await __revalRscCapture.capturedRscDataPromise;
           const __pageTags = __pageCacheTags(cleanPathname, getCollectedFetchTags());
@@ -14540,8 +14389,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // This runs AFTER the ISR cache read so that a cache hit skips this work entirely.
   const __dynamicParamsResponse = await __validateAppPageDynamicParams({
     clearRequestContext() {
-      setHeadersContext(null);
-      setNavigationContext(null);
+      __clearRequestContext();
     },
     enforceStaticParamsOnly: dynamicParamsConfig === false,
     generateStaticParams: route.page?.generateStaticParams,
@@ -14641,8 +14489,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     renderSpecialError(__buildSpecialError) {
       return __buildAppPageSpecialErrorResponse({
         clearRequestContext() {
-          setHeadersContext(null);
-          setNavigationContext(null);
+          __clearRequestContext();
         },
         middlewareContext: _mwCtx,
         renderFallbackPage(statusCode) {
@@ -14679,8 +14526,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   return __renderAppPageLifecycle({
     cleanPathname,
     clearRequestContext() {
-      setHeadersContext(null);
-      setNavigationContext(null);
+      __clearRequestContext();
     },
     consumeDynamicUsage,
     createRscOnErrorHandler(pathname, routePath) {
@@ -14763,8 +14609,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     async renderLayoutSpecialError(__layoutSpecialError, li) {
       return __buildAppPageSpecialErrorResponse({
         clearRequestContext() {
-          setHeadersContext(null);
-          setNavigationContext(null);
+          __clearRequestContext();
         },
         middlewareContext: _mwCtx,
         renderFallbackPage(statusCode) {
@@ -14806,8 +14651,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     async renderPageSpecialError(specialError) {
       return __buildAppPageSpecialErrorResponse({
         clearRequestContext() {
-          setHeadersContext(null);
-          setNavigationContext(null);
+          __clearRequestContext();
         },
         middlewareContext: _mwCtx,
         renderFallbackPage(statusCode) {

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -150,7 +150,7 @@ function setNavigationContext(ctx) {
 function __clearRequestContext() {
   setHeadersContext(null);
   setNavigationContext(null);
-  __setRootParams(null);
+  // setNavigationContext(null) already clears root params internally
 }
 
 // ISR cache is disabled in dev mode — every request re-renders fresh,
@@ -2530,7 +2530,7 @@ function setNavigationContext(ctx) {
 function __clearRequestContext() {
   setHeadersContext(null);
   setNavigationContext(null);
-  __setRootParams(null);
+  // setNavigationContext(null) already clears root params internally
 }
 
 // ISR cache is disabled in dev mode — every request re-renders fresh,
@@ -4916,7 +4916,7 @@ function setNavigationContext(ctx) {
 function __clearRequestContext() {
   setHeadersContext(null);
   setNavigationContext(null);
-  __setRootParams(null);
+  // setNavigationContext(null) already clears root params internally
 }
 
 // ISR cache is disabled in dev mode — every request re-renders fresh,
@@ -7297,7 +7297,7 @@ function setNavigationContext(ctx) {
 function __clearRequestContext() {
   setHeadersContext(null);
   setNavigationContext(null);
-  __setRootParams(null);
+  // setNavigationContext(null) already clears root params internally
 }
 
 // ISR cache is disabled in dev mode — every request re-renders fresh,
@@ -9710,7 +9710,7 @@ function setNavigationContext(ctx) {
 function __clearRequestContext() {
   setHeadersContext(null);
   setNavigationContext(null);
-  __setRootParams(null);
+  // setNavigationContext(null) already clears root params internally
 }
 
 // ISR cache is disabled in dev mode — every request re-renders fresh,
@@ -12097,7 +12097,7 @@ function setNavigationContext(ctx) {
 function __clearRequestContext() {
   setHeadersContext(null);
   setNavigationContext(null);
-  __setRootParams(null);
+  // setNavigationContext(null) already clears root params internally
 }
 
 // ISR cache is disabled in dev mode — every request re-renders fresh,

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -4394,6 +4394,39 @@ describe("generateRscEntry ISR code generation", () => {
     expect(code).toContain('"next/cache"');
   });
 
+  it("generated code stores root layout params separately from leaf params", () => {
+    const routes = [
+      {
+        ...minimalRoutes[0],
+        pattern: "/[lang]/[locale]/other/[slug]",
+        patternParts: [":lang", ":locale", "other", ":slug"],
+        params: ["lang", "locale", "slug"],
+        rootParamNames: ["lang", "locale"],
+        routeSegments: ["[lang]", "[locale]", "other", "[slug]"],
+        layoutTreePositions: [2],
+      },
+    ] as any[];
+
+    const code = generateRscEntry("/tmp/test/app", routes);
+
+    expect(code).toContain("setRootParams as __setRootParams");
+    expect(code).toContain('rootParamNames: ["lang","locale"]');
+    expect(code).toContain("__setRootParams(__pickRootParams(params, route.rootParamNames));");
+  });
+
+  it("root params runtime getter returns current request values", async () => {
+    const { getRootParam, setRootParams } =
+      await import("../packages/vinext/src/shims/root-params.js");
+
+    setRootParams({ lang: "en", locale: "us" });
+
+    await expect(getRootParam("lang")).resolves.toBe("en");
+    await expect(getRootParam("locale")).resolves.toBe("us");
+    await expect(getRootParam("slug")).resolves.toBeUndefined();
+
+    setRootParams(null);
+  });
+
   it("generated code delegates page response policy to typed helpers", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes);
     expect(code).toContain("renderAppPageLifecycle as __renderAppPageLifecycle");

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -4410,13 +4410,28 @@ describe("generateRscEntry ISR code generation", () => {
     const code = generateRscEntry("/tmp/test/app", routes);
 
     expect(code).toContain("setRootParams as __setRootParams");
+    expect(code).toContain("pickRootParams as __pickRootParams");
     expect(code).toContain('rootParamNames: ["lang","locale"]');
     expect(code).toContain("__setRootParams(__pickRootParams(params, route.rootParamNames));");
+    expect(code).toContain("function __clearRequestContext() {");
+    expect(code).toContain("__setRootParams(null);");
+  });
+
+  it("generated root params selection is delegated to the runtime shim", () => {
+    const code = generateRscEntry("/tmp/test/app", minimalRoutes);
+
+    expect(code).toContain("pickRootParams as __pickRootParams");
+    expect(code).not.toContain("function __pickRootParams(params, rootParamNames)");
   });
 
   it("root params runtime getter returns current request values", async () => {
-    const { getRootParam, setRootParams } =
+    const { getRootParam, pickRootParams, setRootParams } =
       await import("../packages/vinext/src/shims/root-params.js");
+
+    expect(pickRootParams({ lang: "en", locale: "us", slug: "post" }, ["lang", "locale"])).toEqual({
+      lang: "en",
+      locale: "us",
+    });
 
     setRootParams({ lang: "en", locale: "us" });
 

--- a/tests/routing.test.ts
+++ b/tests/routing.test.ts
@@ -387,6 +387,27 @@ describe("appRouter - route discovery", () => {
     });
   });
 
+  it("preserves root layout params on synthetic parallel slot routes", async () => {
+    await withTempDir("vinext-app-root-params-parallel-slot-", async (tmpDir) => {
+      const appDir = path.join(tmpDir, "app");
+      await mkdir(path.join(appDir, "[lang]", "@modal", "details"), {
+        recursive: true,
+      });
+      await writeFile(path.join(appDir, "[lang]", "layout.tsx"), EMPTY_PAGE);
+      await writeFile(path.join(appDir, "[lang]", "page.tsx"), EMPTY_PAGE);
+      await writeFile(path.join(appDir, "[lang]", "default.tsx"), EMPTY_PAGE);
+      await writeFile(path.join(appDir, "[lang]", "@modal", "default.tsx"), EMPTY_PAGE);
+      await writeFile(path.join(appDir, "[lang]", "@modal", "details", "page.tsx"), EMPTY_PAGE);
+
+      invalidateAppRouteCache();
+      const routes = await appRouter(appDir);
+      const route = routes.find((r) => r.pattern === "/:lang/details");
+
+      expect(route).toBeDefined();
+      expect(route!.rootParamNames).toEqual(["lang"]);
+    });
+  });
+
   it("computes root layout params for dynamic and catch-all segments", () => {
     expect(computeRootParamNames(["[lang]", "[...slug]", "page"], [2])).toEqual(["lang", "slug"]);
     expect(computeRootParamNames(["[[...rest]]"], [1])).toEqual(["rest"]);

--- a/tests/routing.test.ts
+++ b/tests/routing.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../packages/vinext/src/routing/pages-router.js";
 import {
   appRouter,
+  computeRootParamNames,
   matchAppRoute,
   invalidateAppRouteCache,
   type AppRoute,
@@ -51,6 +52,7 @@ function makeTestAppRoute(
     layoutTreePositions: [],
     isDynamic: pattern.includes(":"),
     params: [],
+    rootParamNames: [],
   };
 }
 
@@ -361,6 +363,33 @@ describe("appRouter - route discovery", () => {
     expect(blogRoute).toBeDefined();
     expect(blogRoute!.isDynamic).toBe(true);
     expect(blogRoute!.params).toEqual(["slug"]);
+  });
+
+  it("discovers dynamic params captured by a nested root layout", async () => {
+    await withTempDir("vinext-app-root-params-", async (tmpDir) => {
+      const appDir = path.join(tmpDir, "app");
+      await mkdir(path.join(appDir, "[lang]", "[locale]", "other", "[slug]"), {
+        recursive: true,
+      });
+      await writeFile(path.join(appDir, "[lang]", "[locale]", "layout.tsx"), EMPTY_PAGE);
+      await writeFile(
+        path.join(appDir, "[lang]", "[locale]", "other", "[slug]", "page.tsx"),
+        EMPTY_PAGE,
+      );
+
+      invalidateAppRouteCache();
+      const routes = await appRouter(appDir);
+      const route = routes.find((r) => r.pattern === "/:lang/:locale/other/:slug");
+
+      expect(route).toBeDefined();
+      expect(route!.params).toEqual(["lang", "locale", "slug"]);
+      expect(route!.rootParamNames).toEqual(["lang", "locale"]);
+    });
+  });
+
+  it("computes root layout params for dynamic and catch-all segments", () => {
+    expect(computeRootParamNames(["[lang]", "[...slug]", "page"], [2])).toEqual(["lang", "slug"]);
+    expect(computeRootParamNames(["[[...rest]]"], [1])).toEqual(["rest"]);
   });
 
   it("sorts static routes before dynamic routes at the same depth", async () => {


### PR DESCRIPTION
## Summary
- Add generated `next/root-params` runtime exports based on App Router root layout params.
- Track root layout params in the RSC request context separately from leaf route params.
- Add scanner, runtime, and generated-entry regression coverage.

Fixes #806