### PR TITLE
fix: add next/offline shim with useOffline() hook

### DIFF
--- a/packages/vinext/src/check.ts
+++ b/packages/vinext/src/check.ts
@@ -70,6 +70,10 @@ const IMPORT_SUPPORT: Record<string, { status: Status; detail?: string }> = {
   "next/og": { status: "supported", detail: "ImageResponse via @vercel/og" },
   "next/config": { status: "supported" },
   "next/amp": { status: "unsupported", detail: "AMP is not supported" },
+  "next/offline": {
+    status: "supported",
+    detail: "useOffline() hook available; offline retry behavior deferred",
+  },
   "next/document": { status: "supported", detail: "custom _document.tsx" },
   "next/app": { status: "supported", detail: "custom _app.tsx" },
   "next/error": { status: "supported" },

--- a/packages/vinext/src/check.ts
+++ b/packages/vinext/src/check.ts
@@ -71,7 +71,7 @@ const IMPORT_SUPPORT: Record<string, { status: Status; detail?: string }> = {
   "next/config": { status: "supported" },
   "next/amp": { status: "unsupported", detail: "AMP is not supported" },
   "next/offline": {
-    status: "supported",
+    status: "partial",
     detail: "useOffline() hook available; offline retry behavior deferred",
   },
   "next/document": { status: "supported", detail: "custom _document.tsx" },

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -927,6 +927,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             "next/og": path.join(shimsDir, "og"),
             "next/web-vitals": path.join(shimsDir, "web-vitals"),
             "next/amp": path.join(shimsDir, "amp"),
+            "next/offline": path.join(shimsDir, "offline"),
             "next/error": path.join(shimsDir, "error"),
             "next/constants": path.join(shimsDir, "constants"),
             // Internal next/dist/* paths used by popular libraries

--- a/packages/vinext/src/shims/next-shims.d.ts
+++ b/packages/vinext/src/shims/next-shims.d.ts
@@ -543,6 +543,10 @@ declare module "next/amp" {
   export function isInAmpMode(): boolean;
 }
 
+declare module "next/offline" {
+  export function useOffline(): boolean;
+}
+
 declare module "next/og" {
   import { ReactElement } from "react";
 

--- a/packages/vinext/src/shims/offline.ts
+++ b/packages/vinext/src/shims/offline.ts
@@ -1,3 +1,13 @@
+/**
+ * next/offline shim
+ *
+ * Stub for the experimental `useOffline()` hook added in Next.js
+ * (vercel/next.js#92012). Returns `false` (online) unconditionally.
+ * Full offline retry behavior (navigation retry, prefetch pause/resume,
+ * OfflineProvider) will be implemented once the feature stabilizes upstream.
+ */
+"use client";
+
 export function useOffline(): boolean {
   return false;
 }

--- a/packages/vinext/src/shims/offline.ts
+++ b/packages/vinext/src/shims/offline.ts
@@ -1,0 +1,3 @@
+export function useOffline(): boolean {
+  return false;
+}

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -12704,8 +12704,7 @@ describe("isOriginAllowed", () => {
   });
 });
 
-// Ported from Next.js: packages/next/src/client/components/offline.ts
-// https://github.com/vercel/next.js/pull/92012 — useOffline() hook
+// Reference: vercel/next.js#92012 — useOffline() hook
 describe("next/offline shim", () => {
   it("exports useOffline", async () => {
     const offline = await import("../packages/vinext/src/shims/offline.js");

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -12703,3 +12703,18 @@ describe("isOriginAllowed", () => {
     expect(isOriginAllowed("evil.example.com.attacker.com", ["**.example.com"])).toBe(false);
   });
 });
+
+// Ported from Next.js: packages/next/src/client/components/offline.ts
+// https://github.com/vercel/next.js/pull/92012 — useOffline() hook
+describe("next/offline shim", () => {
+  it("exports useOffline", async () => {
+    const offline = await import("../packages/vinext/src/shims/offline.js");
+    expect(offline.useOffline).toBeDefined();
+    expect(typeof offline.useOffline).toBe("function");
+  });
+
+  it("useOffline returns false (no-op stub)", async () => {
+    const offline = await import("../packages/vinext/src/shims/offline.js");
+    expect(offline.useOffline()).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes #701

## Summary
- Added `next/offline` shim exporting `useOffline()` hook (returns `false` as no-op)
- Registered in shim resolution map, type declarations, and import support check
- Full offline retry behavior (navigation retry, prefetch pause/resume, `OfflineProvider`) deferred until the feature stabilizes upstream
- Added unit tests for the shim export

## Test plan
- `tests/shims.test.ts` — 2 new tests verifying `useOffline` export exists and returns `false`
- Full suite: 135 passed, 1 pre-existing flaky timeout in pages-router cleanup