### PR TITLE
fix: support file:// URLs in cacheHandler config path

### DIFF
--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -268,6 +268,11 @@ export type ResolvedNextConfig = {
    * filesystem paths via fileURLToPath() during config resolution.
    */
   cacheHandler: string | undefined;
+  /**
+   * Maximum memory size (bytes) for the default in-memory cache handler.
+   * Set to 0 to disable in-memory caching entirely.
+   */
+  cacheMaxMemorySize: number | undefined;
 };
 
 const CONFIG_FILES = ["next.config.ts", "next.config.mjs", "next.config.js", "next.config.cjs"];
@@ -496,6 +501,7 @@ export async function resolveNextConfig(
       serverActionsBodySizeLimit: 1 * 1024 * 1024,
       serverExternalPackages: [],
       cacheHandler: undefined,
+      cacheMaxMemorySize: undefined,
       buildId,
     };
     detectNextIntlConfig(root, resolved);
@@ -634,6 +640,10 @@ export async function resolveNextConfig(
       ? resolveCacheHandlerPathToFilesystem(config.cacheHandler)
       : undefined;
 
+  // Resolve cacheMaxMemorySize
+  const cacheMaxMemorySize: number | undefined =
+    typeof config.cacheMaxMemorySize === "number" ? config.cacheMaxMemorySize : undefined;
+
   const resolved: ResolvedNextConfig = {
     env: config.env ?? {},
     basePath: config.basePath ?? "",
@@ -654,6 +664,7 @@ export async function resolveNextConfig(
     serverActionsBodySizeLimit,
     serverExternalPackages,
     cacheHandler,
+    cacheMaxMemorySize,
     buildId,
   };
 

--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -7,6 +7,7 @@
 import path from "node:path";
 import { createRequire } from "node:module";
 import fs from "node:fs";
+import { fileURLToPath } from "node:url";
 import { randomUUID } from "node:crypto";
 import { PHASE_DEVELOPMENT_SERVER, PHASE_PRODUCTION_BUILD } from "../shims/constants.js";
 import { normalizePageExtensions } from "../routing/file-matcher.js";
@@ -196,6 +197,18 @@ export type NextConfig = {
   /** Webpack config (ignored — we use Vite) */
   webpack?: unknown;
   /**
+   * Path to a custom cache handler module (e.g., KV, Redis, DynamoDB).
+   * Accepts relative paths, absolute paths, or file:// URLs from import.meta.resolve().
+   * When "type": "module" is set in package.json, use import.meta.resolve() instead of
+   * require.resolve() to get a valid path.
+   */
+  cacheHandler?: string;
+  /**
+   * Maximum memory size (bytes) for the default in-memory cache handler.
+   * Set to 0 to disable in-memory caching entirely.
+   */
+  cacheMaxMemorySize?: number;
+  /**
    * Custom build ID generator. If provided, called once at build/dev start.
    * Must return a non-empty string, or null to use the default random ID.
    */
@@ -250,6 +263,11 @@ export type ResolvedNextConfig = {
   serverExternalPackages: string[];
   /** Resolved build ID (from generateBuildId, or a random UUID if not provided). */
   buildId: string;
+  /**
+   * Path to a custom cache handler module. file:// URLs are resolved to
+   * filesystem paths via fileURLToPath() during config resolution.
+   */
+  cacheHandler: string | undefined;
 };
 
 const CONFIG_FILES = ["next.config.ts", "next.config.mjs", "next.config.js", "next.config.cjs"];
@@ -435,6 +453,20 @@ async function resolveBuildId(
 }
 
 /**
+ * Converts a cache handler path to a filesystem path.
+ * ESM's import.meta.resolve() returns file:// URLs which break when concatenated
+ * with path operations like path.join or path.relative.
+ * @param filePath - Absolute path, relative path, or file:// URL (e.g. from import.meta.resolve)
+ * @returns A filesystem path suitable for path operations
+ */
+export function resolveCacheHandlerPathToFilesystem(filePath: string): string {
+  if (filePath.startsWith("file://")) {
+    return fileURLToPath(filePath);
+  }
+  return filePath;
+}
+
+/**
  * Resolve a NextConfig into a fully-resolved ResolvedNextConfig.
  * Awaits async functions for redirects/rewrites/headers.
  */
@@ -463,6 +495,7 @@ export async function resolveNextConfig(
       optimizePackageImports: [],
       serverActionsBodySizeLimit: 1 * 1024 * 1024,
       serverExternalPackages: [],
+      cacheHandler: undefined,
       buildId,
     };
     detectNextIntlConfig(root, resolved);
@@ -595,6 +628,12 @@ export async function resolveNextConfig(
     config.generateBuildId as (() => string | null | Promise<string | null>) | undefined,
   );
 
+  // Resolve cacheHandler path — handle file:// URLs from import.meta.resolve()
+  const cacheHandler: string | undefined =
+    typeof config.cacheHandler === "string"
+      ? resolveCacheHandlerPathToFilesystem(config.cacheHandler)
+      : undefined;
+
   const resolved: ResolvedNextConfig = {
     env: config.env ?? {},
     basePath: config.basePath ?? "",
@@ -614,6 +653,7 @@ export async function resolveNextConfig(
     optimizePackageImports,
     serverActionsBodySizeLimit,
     serverExternalPackages,
+    cacheHandler,
     buildId,
   };
 

--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -459,7 +459,7 @@ async function resolveBuildId(
  * @param filePath - Absolute path, relative path, or file:// URL (e.g. from import.meta.resolve)
  * @returns A filesystem path suitable for path operations
  */
-export function resolveCacheHandlerPathToFilesystem(filePath: string): string {
+function resolveCacheHandlerPathToFilesystem(filePath: string): string {
   if (filePath.startsWith("file://")) {
     return fileURLToPath(filePath);
   }

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -427,6 +427,7 @@ describe("detectNextIntlConfig", () => {
       optimizePackageImports: [],
       serverActionsBodySizeLimit: 1 * 1024 * 1024,
       serverExternalPackages: [],
+      cacheHandler: undefined,
       buildId: "test-build-id",
       ...overrides,
     };

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -428,6 +428,7 @@ describe("detectNextIntlConfig", () => {
       serverActionsBodySizeLimit: 1 * 1024 * 1024,
       serverExternalPackages: [],
       cacheHandler: undefined,
+      cacheMaxMemorySize: undefined,
       buildId: "test-build-id",
       ...overrides,
     };
@@ -749,5 +750,50 @@ describe("resolveNextConfig external rewrite warning", () => {
       (call) => typeof call[0] === "string" && call[0].includes("external rewrite"),
     );
     expect(externalWarning).toBeUndefined();
+  });
+});
+
+describe("resolveNextConfig cacheHandler", () => {
+  it("resolves file:// URLs to filesystem paths", async () => {
+    const resolved = await resolveNextConfig({
+      cacheHandler: "file:///absolute/path/to/handler.js",
+    });
+    expect(resolved.cacheHandler).toBe("/absolute/path/to/handler.js");
+  });
+
+  it("passes through absolute paths unchanged", async () => {
+    const resolved = await resolveNextConfig({
+      cacheHandler: "/absolute/path/to/handler.js",
+    });
+    expect(resolved.cacheHandler).toBe("/absolute/path/to/handler.js");
+  });
+
+  it("passes through relative paths unchanged", async () => {
+    const resolved = await resolveNextConfig({
+      cacheHandler: "./my-cache-handler.js",
+    });
+    expect(resolved.cacheHandler).toBe("./my-cache-handler.js");
+  });
+
+  it("defaults to undefined when not configured", async () => {
+    const resolved = await resolveNextConfig({});
+    expect(resolved.cacheHandler).toBeUndefined();
+  });
+
+  it("defaults to undefined when config is null", async () => {
+    const resolved = await resolveNextConfig(null);
+    expect(resolved.cacheHandler).toBeUndefined();
+  });
+
+  it("resolves cacheMaxMemorySize when configured", async () => {
+    const resolved = await resolveNextConfig({
+      cacheMaxMemorySize: 52428800,
+    });
+    expect(resolved.cacheMaxMemorySize).toBe(52428800);
+  });
+
+  it("defaults cacheMaxMemorySize to undefined when not configured", async () => {
+    const resolved = await resolveNextConfig({});
+    expect(resolved.cacheMaxMemorySize).toBeUndefined();
   });
 });


### PR DESCRIPTION
Fixes #728

## Summary
- Added `cacheHandler` and `cacheMaxMemorySize` to `NextConfig` type with JSDoc explaining `import.meta.resolve()` usage
- Added `cacheHandler` to `ResolvedNextConfig` with `file://` URL resolution
- Created `resolveCacheHandlerPathToFilesystem()` utility that converts `file://` URLs to filesystem paths via `fileURLToPath()`

## What this does
When `"type": "module"` is set in `package.json`, users must use `import.meta.resolve()` instead of `require.resolve()` to resolve the cache handler path. `import.meta.resolve()` returns a `file://` URL, which previously would break if used with path operations like `path.join` or `path.relative`. The new helper converts `file://` URLs to proper filesystem paths before any path operations.

Matches Next.js commit [9a0214a1](https://github.com/vercel/next.js/commit/9a0214a12f1ed1901c4b01e84073ab854848eea0).

## Test plan
- All 58 existing `next-config.test.ts` tests pass (test helper updated to include new field)
- Build, format, lint, and type checks all pass