### PR TITLE
fix: support static metadata URL resolver (fillStaticMetadataSegment)

### DIFF
--- a/packages/vinext/src/server/metadata-routes.ts
+++ b/packages/vinext/src/server/metadata-routes.ts
@@ -340,6 +340,100 @@ function serializeDate(value: string | Date): string {
 }
 
 // -------------------------------------------------------------------
+// Static metadata URL resolution
+//
+// Ported from Next.js: packages/next/src/lib/metadata/get-metadata-route.ts
+// https://github.com/vercel/next.js/blob/7873aea/packages/next/src/lib/metadata/get-metadata-route.ts
+//
+// Static metadata files (like favicon.ico, icon.png) under dynamic parents
+// get a fixed URL with "-" placeholders instead of literal "[param]" segments.
+// Route groups and parallel route parents trigger a unique hash suffix to
+// avoid collisions.
+// -------------------------------------------------------------------
+
+/**
+ * Regular expression pattern used to match route parameters.
+ * Matches both single parameters and parameter groups.
+ * Examples:
+ *   - `[[...slug]]` matches parameter group with key 'slug', repeat: true, optional: true
+ *   - `[...slug]` matches parameter group with key 'slug', repeat: true, optional: false
+ *   - `[[foo]]` matches parameter with key 'foo', repeat: false, optional: true
+ *   - `[bar]` matches parameter with key 'bar', repeat: false, optional: false
+ */
+const PARAMETER_PATTERN = /^([^[]*)\[((?:\[[^\]]*\])|[^\]]+)\](.*)$/;
+
+function isGroupSegment(segment: string): boolean {
+  return segment.startsWith("(") && segment.endsWith(")");
+}
+
+function isParallelRouteSegment(segment: string): boolean {
+  return segment.startsWith("@") && segment !== "@children";
+}
+
+function normalizeStaticMetadataRouteSegment(segment: string): string {
+  let normalizedSegment = segment;
+  let match = normalizedSegment.match(PARAMETER_PATTERN);
+  while (match) {
+    normalizedSegment = `${match[1]}-${match[3]}`;
+    match = normalizedSegment.match(PARAMETER_PATTERN);
+  }
+  return normalizedSegment;
+}
+
+function getStaticMetadataRoute(appDirPath: string): string {
+  const segments = appDirPath.split("/").filter(Boolean);
+  const normalizedSegments: string[] = [];
+  for (const seg of segments) {
+    // Strip route groups and all parallel route slots (including @children)
+    // from the URL path. The @children slot is the default parallel route
+    // and must also be invisible in the URL, matching Next.js behavior.
+    if (isGroupSegment(seg) || seg.startsWith("@")) continue;
+    normalizedSegments.push(normalizeStaticMetadataRouteSegment(seg));
+  }
+  return normalizedSegments.length > 0 ? `/${normalizedSegments.join("/")}` : "";
+}
+
+function getMetadataRouteSuffix(page: string): string {
+  const lastSlash = page.lastIndexOf("/");
+  const parentPathname = lastSlash > 0 ? page.slice(0, lastSlash) : lastSlash === -1 ? "" : "";
+  if (page.endsWith("/sitemap") || page.endsWith("/sitemap.xml")) return "";
+  const segments = parentPathname.split("/");
+  const hasInvisibleParent = segments.some(
+    (seg) => isGroupSegment(seg) || isParallelRouteSegment(seg),
+  );
+  if (!hasInvisibleParent) return "";
+  let hash = 5381;
+  for (let i = 0; i < parentPathname.length; i++) {
+    hash = ((hash << 5) + hash + parentPathname.charCodeAt(i)) & 0xffffffff;
+  }
+  return (hash >>> 0).toString(36).slice(0, 6);
+}
+
+function getMetadataRouteFilename(appDirPath: string, lastSegment: string): string {
+  const ext = path.posix.extname(lastSegment);
+  const name = lastSegment.slice(0, -ext.length || undefined);
+  const pagePath = appDirPath === "" || appDirPath === "/" ? `/${name}` : `${appDirPath}/${name}`;
+  const suffix = getMetadataRouteSuffix(pagePath);
+  const routeSuffix = suffix ? `-${suffix}` : "";
+  return `${name}${routeSuffix}${ext}`;
+}
+
+/**
+ * Compute the static URL for a metadata file given its app directory
+ * parent path and filename.
+ *
+ * Example:
+ *   fillStaticMetadataSegment("/", "favicon.ico") -> "/favicon.ico"
+ *   fillStaticMetadataSegment("/blog/[slug]", "favicon.ico") -> "/blog/-/favicon.ico"
+ *   fillStaticMetadataSegment("/(group)/group", "icon.png") -> "/group/icon-131tc6.png"
+ */
+export function fillStaticMetadataSegment(appDirPath: string, lastSegment: string): string {
+  const route = getStaticMetadataRoute(appDirPath);
+  const filename = getMetadataRouteFilename(appDirPath, lastSegment);
+  return route === "" ? `/${filename}` : `${route}/${filename}`;
+}
+
+// -------------------------------------------------------------------
 // Metadata route discovery
 // -------------------------------------------------------------------
 
@@ -425,14 +519,35 @@ export function scanMetadataFiles(appDir: string): MetadataFileRoute[] {
         const isDynamic = config.dynamicExtensions.includes(ext);
 
         if (!isStatic && !isDynamic) continue;
-        const suffix = metadataRouteSuffix(parentSegments, metaType);
-        const urlPath = withMetadataSuffix(config.urlPath, suffix);
+
+        // For static metadata files, normalize dynamic parent segments to "-"
+        // and strip route groups / parallel routes from the URL. The leaf
+        // URL path comes from METADATA_FILE_MAP (without file extension for
+        // icon, apple-icon, etc.). Dynamic files keep the existing urlPrefix
+        // behavior because the runtime uses patternParts for matching.
+        const appDirPath = parentSegments.length > 0 ? `/${parentSegments.join("/")}` : "";
+        const servedUrl = isStatic
+          ? (() => {
+              const route = getStaticMetadataRoute(appDirPath);
+              const pagePath =
+                appDirPath === "" || appDirPath === "/"
+                  ? `/${metaType}`
+                  : `${appDirPath}/${metaType}`;
+              const suffix = getMetadataRouteSuffix(pagePath);
+              const urlPath = withMetadataSuffix(config.urlPath, suffix);
+              return route === "" ? urlPath : `${route}${urlPath}`;
+            })()
+          : (() => {
+              const suffix = metadataRouteSuffix(parentSegments, metaType);
+              const urlPath = withMetadataSuffix(config.urlPath, suffix);
+              return urlPrefix === "" ? urlPath : `${urlPrefix}${urlPath}`;
+            })();
 
         routes.push({
           type: metaType,
           isDynamic,
           filePath: path.join(dir, fileName),
-          servedUrl: urlPrefix === "" ? urlPath : `${urlPrefix}${urlPath}`,
+          servedUrl,
           contentType: isStatic
             ? getStaticContentType(ext, config.contentType)
             : config.contentType,

--- a/packages/vinext/src/server/metadata-routes.ts
+++ b/packages/vinext/src/server/metadata-routes.ts
@@ -395,7 +395,7 @@ function getStaticMetadataRoute(appDirPath: string): string {
 
 function getMetadataRouteSuffix(page: string): string {
   const lastSlash = page.lastIndexOf("/");
-  const parentPathname = lastSlash > 0 ? page.slice(0, lastSlash) : lastSlash === -1 ? "" : "";
+  const parentPathname = lastSlash > 0 ? page.slice(0, lastSlash) : "";
   if (page.endsWith("/sitemap") || page.endsWith("/sitemap.xml")) return "";
   const segments = parentPathname.split("/");
   const hasInvisibleParent = segments.some(
@@ -409,11 +409,21 @@ function getMetadataRouteSuffix(page: string): string {
   return (hash >>> 0).toString(36).slice(0, 6);
 }
 
+function computeMetadataRouteSuffix(
+  appDirPath: string,
+  leafName: string,
+): { route: string; suffix: string } {
+  const route = getStaticMetadataRoute(appDirPath);
+  const pagePath =
+    appDirPath === "" || appDirPath === "/" ? `/${leafName}` : `${appDirPath}/${leafName}`;
+  const suffix = getMetadataRouteSuffix(pagePath);
+  return { route, suffix };
+}
+
 function getMetadataRouteFilename(appDirPath: string, lastSegment: string): string {
   const ext = path.posix.extname(lastSegment);
   const name = lastSegment.slice(0, -ext.length || undefined);
-  const pagePath = appDirPath === "" || appDirPath === "/" ? `/${name}` : `${appDirPath}/${name}`;
-  const suffix = getMetadataRouteSuffix(pagePath);
+  const { suffix } = computeMetadataRouteSuffix(appDirPath, name);
   const routeSuffix = suffix ? `-${suffix}` : "";
   return `${name}${routeSuffix}${ext}`;
 }
@@ -528,12 +538,7 @@ export function scanMetadataFiles(appDir: string): MetadataFileRoute[] {
         const appDirPath = parentSegments.length > 0 ? `/${parentSegments.join("/")}` : "";
         const servedUrl = isStatic
           ? (() => {
-              const route = getStaticMetadataRoute(appDirPath);
-              const pagePath =
-                appDirPath === "" || appDirPath === "/"
-                  ? `/${metaType}`
-                  : `${appDirPath}/${metaType}`;
-              const suffix = getMetadataRouteSuffix(pagePath);
+              const { route, suffix } = computeMetadataRouteSuffix(appDirPath, metaType);
               const urlPath = withMetadataSuffix(config.urlPath, suffix);
               return route === "" ? urlPath : `${route}${urlPath}`;
             })()

--- a/tests/metadata-routes.test.ts
+++ b/tests/metadata-routes.test.ts
@@ -16,6 +16,7 @@ import {
   robotsToText,
   manifestToJson,
   scanMetadataFiles,
+  fillStaticMetadataSegment,
   METADATA_FILE_MAP,
   type SitemapEntry,
   type RobotsConfig,
@@ -584,6 +585,57 @@ describe("manifestToJson", () => {
   });
 });
 
+// ─── fillStaticMetadataSegment ────────────────────────────────────────────
+// Ported from Next.js: packages/next/src/lib/metadata/get-metadata-route.test.ts
+// https://github.com/vercel/next.js/blob/7873aea/packages/next/src/lib/metadata/get-metadata-route.test.ts
+
+describe("fillStaticMetadataSegment", () => {
+  it("preserves a statically known root favicon path", () => {
+    expect(fillStaticMetadataSegment("/", "favicon.ico")).toBe("/favicon.ico");
+  });
+
+  it("replaces dynamic segments with placeholder segments", () => {
+    expect(fillStaticMetadataSegment("/blog/[slug]", "favicon.ico")).toBe("/blog/-/favicon.ico");
+    expect(fillStaticMetadataSegment("/blog/[...slug]", "icon.png")).toBe("/blog/-/icon.png");
+  });
+
+  it("replaces catch-all segments with placeholder", () => {
+    expect(fillStaticMetadataSegment("/[...slug]", "favicon.ico")).toBe("/-/favicon.ico");
+    expect(fillStaticMetadataSegment("/[[...slug]]", "icon.png")).toBe("/-/icon.png");
+  });
+
+  it("strips route groups and applies hash suffix", () => {
+    const result = fillStaticMetadataSegment("/(group)/group", "icon.png");
+    // Route group (group) is stripped from the URL path.
+    // A unique hash suffix is appended because the parent path had a route group.
+    expect(result).toMatch(/^\/group\/icon-[0-9a-z]{6}\.png$/);
+  });
+
+  it("strips parallel route slots and applies hash suffix", () => {
+    const result = fillStaticMetadataSegment("/parallel/@parallel", "icon.png");
+    // Parallel route slot @parallel is stripped from the URL path.
+    expect(result).toMatch(/^\/parallel\/icon-[0-9a-z]{6}\.png$/);
+  });
+
+  it("keeps regular segments intact", () => {
+    expect(fillStaticMetadataSegment("/about/contact", "opengraph-image.png")).toBe(
+      "/about/contact/opengraph-image.png",
+    );
+  });
+
+  it("handles root path with dynamic file extensions", () => {
+    expect(fillStaticMetadataSegment("/", "icon.svg")).toBe("/icon.svg");
+    expect(fillStaticMetadataSegment("/", "apple-icon.jpg")).toBe("/apple-icon.jpg");
+  });
+
+  it("handles mixed route group and dynamic segments", () => {
+    const result = fillStaticMetadataSegment("/client/(meme)/more-route", "twitter-image.png");
+    // Route group (meme) is stripped, no dynamic segments to replace.
+    // Hash suffix applied due to route group parent.
+    expect(result).toMatch(/^\/client\/more-route\/twitter-image-[0-9a-z]{6}\.png$/);
+  });
+});
+
 // ─── scanMetadataFiles ──────────────────────────────────────────────────
 
 describe("scanMetadataFiles", () => {
@@ -784,6 +836,30 @@ describe("scanMetadataFiles", () => {
     expect(routes.find((r) => r.type === "favicon")).toBeDefined();
     expect(routes.find((r) => r.type === "icon")).toBeDefined();
     expect(routes.find((r) => r.type === "opengraph-image")).toBeDefined();
+  });
+
+  it("static metadata under dynamic parent uses '-' placeholder in servedUrl", () => {
+    createFile("blog/[slug]/opengraph-image.png");
+    const routes = scanMetadataFiles(tmpDir);
+    const og = routes.find((r) => r.type === "opengraph-image" && r.isDynamic === false);
+    expect(og).toBeDefined();
+    expect(og!.servedUrl).toBe("/blog/-/opengraph-image");
+  });
+
+  it("static metadata under catch-all parent uses '-' placeholder", () => {
+    createFile("docs/[...slug]/icon.png");
+    const routes = scanMetadataFiles(tmpDir);
+    const icon = routes.find((r) => r.type === "icon" && r.isDynamic === false);
+    expect(icon).toBeDefined();
+    expect(icon!.servedUrl).toBe("/docs/-/icon");
+  });
+
+  it("static metadata under route group with dynamic parent", () => {
+    createFile("(marketing)/blog/[slug]/icon.png");
+    const routes = scanMetadataFiles(tmpDir);
+    const icon = routes.find((r) => r.type === "icon" && r.isDynamic === false);
+    expect(icon).toBeDefined();
+    expect(icon!.servedUrl).toMatch(/^\/blog\/-\/icon-[0-9a-z]{6}$/);
   });
 });
 


### PR DESCRIPTION
Fixes #861

## Summary
- Port `fillStaticMetadataSegment` from Next.js (commit 7873aea) to correctly resolve URLs for static metadata files under dynamic parent segments
- Update `scanMetadataFiles` to normalize dynamic segments to "-" placeholders in servedUrl for static metadata files
- Strip route groups and parallel route slots from static metadata URL paths, applying djb2 hash suffixes for collision avoidance
- Keep dynamic metadata files on the existing `urlPrefix` path for patternParts-based runtime matching
- Add unit tests for `fillStaticMetadataSegment` and integration tests for static metadata scanning under dynamic parents

## Test plan
- Unit tests: `tests/metadata-routes.test.ts` — 69 tests (8 new for `fillStaticMetadataSegment`, 3 new for scan with dynamic parents)
- Integration tests: `tests/app-router.test.ts` — metadata routes section (20 tests, all passing)
- Full suite: 4398 tests passing (1 pre-existing flaky timeout in pages-router)