### PR TITLE
feat: add unstable_io shim for next/cache

### DIFF
--- a/packages/vinext/src/check.ts
+++ b/packages/vinext/src/check.ts
@@ -54,7 +54,7 @@ const IMPORT_SUPPORT: Record<string, { status: Status; detail?: string }> = {
   "next/server": { status: "supported", detail: "NextRequest/NextResponse shimmed" },
   "next/cache": {
     status: "supported",
-    detail: "revalidateTag, revalidatePath, unstable_cache, cacheLife, cacheTag",
+    detail: "revalidateTag, revalidatePath, unstable_cache, unstable_io, cacheLife, cacheTag",
   },
   "next/dynamic": { status: "supported" },
   "next/head": { status: "supported" },

--- a/packages/vinext/src/shims/cache.ts
+++ b/packages/vinext/src/shims/cache.ts
@@ -453,8 +453,9 @@ const _resolvedIOPromise: Promise<void> = Promise.resolve(undefined);
  * Guard removed: https://github.com/vercel/next.js/pull/92923
  *
  * In Next.js, `unstable_io()` during prerendering contexts returns a hanging
- * promise to prevent execution past the IO boundary. vinext targets
- * Cloudflare Workers (no prerendering), so this always resolves immediately.
+ * promise to prevent execution past the IO boundary. vinext does support
+ * prerendering (static export, --prerender-all, TPR), but the hanging IO
+ * boundary behavior is not yet implemented, so this always resolves immediately.
  */
 export function unstable_io(): Promise<void> {
   return _resolvedIOPromise;

--- a/packages/vinext/src/shims/cache.ts
+++ b/packages/vinext/src/shims/cache.ts
@@ -450,6 +450,7 @@ const _resolvedIOPromise: Promise<void> = Promise.resolve(undefined);
  * Marks an IO boundary in server components by returning a resolved promise.
  *
  * See: https://github.com/vercel/next.js/pull/92521
+ * Guard removed: https://github.com/vercel/next.js/pull/92923
  *
  * In Next.js, `unstable_io()` during prerendering contexts returns a hanging
  * promise to prevent execution past the IO boundary. vinext targets

--- a/packages/vinext/src/shims/cache.ts
+++ b/packages/vinext/src/shims/cache.ts
@@ -435,6 +435,30 @@ export function unstable_noStore(): void {
 // Also export as `noStore` (Next.js 15+ naming)
 export { unstable_noStore as noStore };
 
+/**
+ * A fulfilled thenable that React can unwrap synchronously via `use()`
+ * without ever suspending. Reusing a single instance avoids allocating
+ * on every call — matching Next.js's browser/client implementation.
+ *
+ * @see https://github.com/vercel/next.js/blob/canary/packages/next/src/client/request/io.browser.ts
+ */
+const _resolvedIOPromise: Promise<void> = Promise.resolve(undefined);
+(_resolvedIOPromise as unknown as Record<string, unknown>).status = "fulfilled";
+(_resolvedIOPromise as unknown as Record<string, unknown>).value = undefined;
+
+/**
+ * Marks an IO boundary in server components by returning a resolved promise.
+ *
+ * See: https://github.com/vercel/next.js/pull/92521
+ *
+ * In Next.js, `unstable_io()` during prerendering contexts returns a hanging
+ * promise to prevent execution past the IO boundary. vinext targets
+ * Cloudflare Workers (no prerendering), so this always resolves immediately.
+ */
+export function unstable_io(): Promise<void> {
+  return _resolvedIOPromise;
+}
+
 // ---------------------------------------------------------------------------
 // Request-scoped cacheLife for page-level "use cache" directives.
 // When cacheLife() is called outside a "use cache" function context (e.g.,

--- a/packages/vinext/src/shims/next-shims.d.ts
+++ b/packages/vinext/src/shims/next-shims.d.ts
@@ -500,6 +500,7 @@ declare module "next/cache" {
   ): T;
   export function unstable_noStore(): void;
   export function noStore(): void;
+  export function unstable_io(): Promise<void>;
 
   // "use cache" APIs (Next.js 15+)
   export type CacheLifeConfig = {

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -1903,6 +1903,8 @@ describe("next/cache shim", () => {
     const { unstable_io } = await import("../packages/vinext/src/shims/cache.js");
     const result = unstable_io();
     expect(result).toBeInstanceOf(Promise);
+    expect((result as any).status).toBe("fulfilled");
+    expect((result as any).value).toBeUndefined();
     await expect(result).resolves.toBeUndefined();
   });
 

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -1892,6 +1892,27 @@ describe("next/cache shim", () => {
     mod.refresh();
   });
 
+  // Ported from Next.js: packages/next/src/client/request/io.browser.ts
+  // https://github.com/vercel/next.js/blob/canary/packages/next/src/client/request/io.browser.ts
+  it("exports unstable_io function", async () => {
+    const mod = await import("../packages/vinext/src/shims/cache.js");
+    expect(typeof mod.unstable_io).toBe("function");
+  });
+
+  it("unstable_io returns a resolved promise", async () => {
+    const { unstable_io } = await import("../packages/vinext/src/shims/cache.js");
+    const result = unstable_io();
+    expect(result).toBeInstanceOf(Promise);
+    await expect(result).resolves.toBeUndefined();
+  });
+
+  it("unstable_io returns same instance (singleton)", async () => {
+    const { unstable_io } = await import("../packages/vinext/src/shims/cache.js");
+    const r1 = unstable_io();
+    const r2 = unstable_io();
+    expect(r1).toBe(r2);
+  });
+
   it("setCacheHandler swaps the active handler", async () => {
     const { setCacheHandler, getCacheHandler, unstable_cache } =
       await import("../packages/vinext/src/shims/cache.js");


### PR DESCRIPTION
Fixes #805

## Summary
- Adds `unstable_io()` export to the `next/cache` shim
- Returns a pre-resolved fulfilled thenable matching Next.js's browser/client implementation
- React's `use()` hook can unwrap it synchronously without suspending
- No config gate needed — the guard was removed upstream in next.js#92923

## Test plan
- Added 3 unit tests in `tests/shims.test.ts`:
  - Verifies `unstable_io` is exported as a function
  - Verifies it returns a resolved `Promise<void>`
  - Verifies singleton behavior (same instance on multiple calls)