### PR TITLE
fix: add tests verifying strings thrown in Server Components are not swallowed

### DIFF
--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -818,8 +818,9 @@ describe("App Router integration", () => {
   it("error boundary catches string thrown in Server Component", async () => {
     const { res, html } = await fetchHtml(baseUrl, "/throw-string-test");
     expect(res.status).toBe(200);
-    expect(html).toContain("this is a test string thrown in a server component");
-    expect(html).toContain('data-testid="string-error-boundary"');
+    expect(textContentByTestId(html, "string-error-message")).toBe(
+      "this is a test string thrown in a server component",
+    );
   });
 
   it("redirect() from Server Component returns redirect response", async () => {
@@ -3649,6 +3650,7 @@ describe("App Router next.config.js features (generateRscEntry)", () => {
     // wrong return values, broken control flow).
     describe("runtime behavior", () => {
       let rscOnError: (error: unknown) => string | undefined;
+      let prodRscOnError: (error: unknown) => string | undefined;
       let digestFn: string;
       let onErrorFn: string;
 
@@ -3678,6 +3680,7 @@ describe("App Router next.config.js features (generateRscEntry)", () => {
         // oxlint-disable-next-line no-new-func, @typescript-eslint/no-implied-eval -- reconstructing emitted runtime code is the behavior under test
         const factory = new Function("process", body);
         rscOnError = factory({ env: { NODE_ENV: "development" } });
+        prodRscOnError = factory({ env: { NODE_ENV: "production" } });
       });
 
       it("returns the digest string for navigation errors (redirect/notFound)", () => {
@@ -3716,12 +3719,6 @@ describe("App Router next.config.js features (generateRscEntry)", () => {
       });
 
       it("does not swallow strings thrown in Server Components", () => {
-        // oxlint-disable-next-line no-new-func, @typescript-eslint/no-implied-eval -- reconstructing emitted runtime code is the behavior under test
-        const digestFactory = new Function(
-          "process",
-          `${digestFn}\n${onErrorFn}\nreturn rscOnError;`,
-        );
-        const prodRscOnError = digestFactory({ env: { NODE_ENV: "production" } });
         const result = prodRscOnError("this is a test string");
         // Should return a digest hash (not undefined), indicating the string
         // was processed through the normal error path
@@ -3738,9 +3735,6 @@ describe("App Router next.config.js features (generateRscEntry)", () => {
         // early, swallowing the error before logging. Verify the generated
         // rscOnError has no such early-return path.
         expect(onErrorFn).not.toContain("typeof thrownValue === 'string'");
-        // Should still handle strings for digest generation
-        expect(onErrorFn).toContain("error instanceof Error");
-        expect(onErrorFn).toContain("String(error)");
       });
     });
   });

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -815,6 +815,13 @@ describe("App Router integration", () => {
     expect(html).not.toContain("Missing use client react hook test");
   });
 
+  it("error boundary catches string thrown in Server Component", async () => {
+    const { res, html } = await fetchHtml(baseUrl, "/throw-string-test");
+    expect(res.status).toBe(200);
+    expect(html).toContain("this is a test string thrown in a server component");
+    expect(html).toContain('data-testid="string-error-boundary"');
+  });
+
   it("redirect() from Server Component returns redirect response", async () => {
     const res = await fetch(`${baseUrl}/redirect-test`, { redirect: "manual" });
     expect(res.status).toBeGreaterThanOrEqual(300);
@@ -3642,6 +3649,8 @@ describe("App Router next.config.js features (generateRscEntry)", () => {
     // wrong return values, broken control flow).
     describe("runtime behavior", () => {
       let rscOnError: (error: unknown) => string | undefined;
+      let digestFn: string;
+      let onErrorFn: string;
 
       beforeAll(() => {
         const code = generateRscEntry("/tmp/test/app", minimalRoutes, null, [], null, "", false);
@@ -3662,8 +3671,8 @@ describe("App Router next.config.js features (generateRscEntry)", () => {
           throw new Error(`Unbalanced braces in ${name}`);
         }
 
-        const digestFn = extractFunction(code, "__errorDigest");
-        const onErrorFn = extractFunction(code, "rscOnError");
+        digestFn = extractFunction(code, "__errorDigest");
+        onErrorFn = extractFunction(code, "rscOnError");
 
         const body = `${digestFn}\n${onErrorFn}\nreturn rscOnError;`;
         // oxlint-disable-next-line no-new-func, @typescript-eslint/no-implied-eval -- reconstructing emitted runtime code is the behavior under test
@@ -3704,6 +3713,34 @@ describe("App Router next.config.js features (generateRscEntry)", () => {
         } finally {
           spy.mockRestore();
         }
+      });
+
+      it("does not swallow strings thrown in Server Components", () => {
+        // oxlint-disable-next-line no-new-func, @typescript-eslint/no-implied-eval -- reconstructing emitted runtime code is the behavior under test
+        const digestFactory = new Function(
+          "process",
+          `${digestFn}\n${onErrorFn}\nreturn rscOnError;`,
+        );
+        const prodRscOnError = digestFactory({ env: { NODE_ENV: "production" } });
+        const result = prodRscOnError("this is a test string");
+        // Should return a digest hash (not undefined), indicating the string
+        // was processed through the normal error path
+        expect(result).toBeDefined();
+        expect(typeof result).toBe("string");
+        expect((result as string).length).toBeGreaterThan(0);
+        // The digest should be based on the string content
+        const result2 = prodRscOnError("different string");
+        expect(result2).not.toBe(result);
+      });
+
+      it("does not have an early return for string thrown values in generated code", () => {
+        // Next.js had a bug where typeof thrownValue === 'string' returned
+        // early, swallowing the error before logging. Verify the generated
+        // rscOnError has no such early-return path.
+        expect(onErrorFn).not.toContain("typeof thrownValue === 'string'");
+        // Should still handle strings for digest generation
+        expect(onErrorFn).toContain("error instanceof Error");
+        expect(onErrorFn).toContain("String(error)");
       });
     });
   });

--- a/tests/fixtures/app-basic/app/throw-string-test/error.tsx
+++ b/tests/fixtures/app-basic/app/throw-string-test/error.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+export default function ThrowStringErrorBoundary({
+  error,
+  reset,
+}: {
+  error: Error;
+  reset: () => void;
+}) {
+  return (
+    <div data-testid="string-error-boundary">
+      <h2>String Error Caught</h2>
+      <p data-testid="string-error-message">{error.message}</p>
+      <button data-testid="string-error-reset" onClick={reset}>
+        Retry
+      </button>
+    </div>
+  );
+}

--- a/tests/fixtures/app-basic/app/throw-string-test/page.tsx
+++ b/tests/fixtures/app-basic/app/throw-string-test/page.tsx
@@ -1,0 +1,4 @@
+export default function ThrowStringTestPage() {
+  throw "this is a test string thrown in a server component";
+  return <div>This should never render</div>;
+}


### PR DESCRIPTION
Fixes #810

## Summary
- vinext's `rscOnError` already correctly handles strings thrown in Server Components — no early-return swallow bug exists (unlike the Next.js bug fixed in vercel/next.js@b9ca95c62)
- Added fixture page (`throw-string-test`) that throws a string in a Server Component with an error boundary
- Added integration test verifying the error boundary renders with the string message
- Added runtime test confirming `rscOnError` returns a valid digest hash for string throws in production
- Added static test confirming generated code has no `typeof thrownValue === 'string'` early-return path

## Test plan
- Integration test: error boundary catches string thrown in Server Component and displays the message
- Runtime test: `rscOnError` processes string throws through normal error path (produces digest in production)
- Static test: generated code free of the string early-return anti-pattern

Upstream: https://github.com/vercel/next.js/commit/b9ca95c62dd882eb3c0e5fc0be9b20bf0b198fb1