### PR TITLE
fix: serialize SSR render and head collection in Pages Router (#792)

### DIFF
--- a/packages/vinext/src/server/pages-page-response.ts
+++ b/packages/vinext/src/server/pages-page-response.ts
@@ -247,6 +247,13 @@ export async function renderPagesPageResponse(
     scriptNonce: options.scriptNonce,
   });
   const bodyMarker = "<!--VINEXT_STREAM_BODY-->";
+  // Render the page FIRST so that <Head> and other SSR state collectors
+  // (e.g. styled-jsx, useServerInsertedHTML) are populated before we read
+  // them. This fixes a race condition where head styles were silently dropped
+  // because they were collected before the page had finished rendering.
+  // Mirrors Next.js fix: vercel/next.js@9853944
+  const bodyStream = await options.renderToReadableStream(pageElement);
+
   const shellHtml = await buildPagesShellHtml(bodyMarker, fontHeadHTML, nextDataScript, {
     assetTags: options.assetTags,
     DocumentComponent: options.DocumentComponent,
@@ -259,7 +266,6 @@ export async function renderPagesPageResponse(
   const markerIndex = shellHtml.indexOf(bodyMarker);
   const shellPrefix = shellHtml.slice(0, markerIndex);
   const shellSuffix = shellHtml.slice(markerIndex + bodyMarker.length);
-  const bodyStream = await options.renderToReadableStream(pageElement);
   const compositeStream = await buildPagesCompositeStream(bodyStream, shellPrefix, shellSuffix);
 
   if (

--- a/tests/pages-page-response.test.ts
+++ b/tests/pages-page-response.test.ts
@@ -191,6 +191,52 @@ describe("pages page response", () => {
     );
   });
 
+  it("renders page before collecting SSR head HTML to prevent style race conditions", async () => {
+    // Ported from Next.js: vercel/next.js@9853944
+    // styled-jsx (and <Head>) styles must be collected AFTER rendering completes,
+    // not concurrently. Otherwise dynamic styles that are registered during
+    // rendering are silently dropped from the HTML output.
+    const common = createCommonOptions();
+    const callOrder: string[] = [];
+
+    common.renderToReadableStream.mockImplementation(async () => {
+      // Verify getSSRHeadHTML has NOT been called yet
+      expect(common.options.getSSRHeadHTML).not.toHaveBeenCalled();
+      callOrder.push("render");
+      // Return the original stream by calling the original factory
+      return createStream(["<div>live-body</div>"]);
+    });
+
+    (common.options.getSSRHeadHTML as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      callOrder.push("head");
+      return '<meta name="test-head" content="1" />';
+    });
+
+    await renderPagesPageResponse(common.options);
+
+    expect(callOrder).toEqual(["render", "head"]);
+  });
+
+  it("clears SSR context only after rendering, not before", async () => {
+    const common = createCommonOptions();
+    const callOrder: string[] = [];
+
+    common.renderToReadableStream.mockImplementation(async () => {
+      // Verify clearSsrContext has NOT been called yet
+      expect(common.clearSsrContext).not.toHaveBeenCalled();
+      callOrder.push("render");
+      return createStream(["<div>live-body</div>"]);
+    });
+
+    common.clearSsrContext.mockImplementation(() => {
+      callOrder.push("clear");
+    });
+
+    await renderPagesPageResponse(common.options);
+
+    expect(callOrder).toEqual(["render", "clear"]);
+  });
+
   it("disables pages ISR caching when a script nonce is present", async () => {
     const common = createCommonOptions();
 


### PR DESCRIPTION
Fixes #792

## Summary
- Audited styled-jsx race condition: vinext does not call `styledJsxInsertedHTML()` (no styled-jsx style registry exists), so the specific Next.js bug does not apply
- Fixed a related ordering bug in Pages Router prod path: `getSSRHeadHTML()` was called before `renderToReadableStream()`, causing `<Head>` content to be silently dropped from SSR HTML
- Fixed `clearSsrContext()` ordering: SSR context was cleared before rendering, so `useRouter()` would return defaults during SSR
- Verified dev-server.ts and app-ssr-entry.ts are already correct (render first, then collect styles)
- Added ordering tests to verify render completes before style/context collection

## Test plan
- Added 2 unit tests in `pages-page-response.test.ts` that verify `renderToReadableStream` is called before `getSSRHeadHTML` and `clearSsrContext`
- All existing `pages-page-response` tests (7 total) pass
- All `head` tests (30) pass
- `pages-router.test.ts` (196 tests) pass
- Build, lint, format, typecheck all pass