### PR TITLE
refactor(app-router): delegate RSC preload hint normalization

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -85,6 +85,7 @@ const appRscRouteMatchingPath = resolveEntryPath(
   "../server/app-rsc-route-matching.js",
   import.meta.url,
 );
+const rscStreamHintsPath = resolveEntryPath("../server/rsc-stream-hints.js", import.meta.url);
 const metadataRoutesPath = resolveEntryPath("../server/metadata-routes.js", import.meta.url);
 const rootParamsShimPath = resolveEntryPath("../shims/root-params.js", import.meta.url);
 const errorCausePath = resolveEntryPath("../utils/error-cause.js", import.meta.url);
@@ -362,34 +363,12 @@ import {
 } from "@vitejs/plugin-rsc/rsc";
 import { AsyncLocalStorage } from "node:async_hooks";
 
-// React Flight emits HL hints with "stylesheet" for CSS, but the HTML spec
-// requires "style" for <link rel="preload">. Fix at the source so every
-// consumer (SSR embed, client-side navigation, server actions) gets clean data.
-//
-// Flight lines are newline-delimited, so we buffer partial lines across chunks
-// to guarantee the regex never sees a split hint.
+import {
+  normalizeReactFlightPreloadHints as __normalizeReactFlightPreloadHints,
+} from ${JSON.stringify(rscStreamHintsPath)};
+
 function renderToReadableStream(model, options) {
-  const _hlFixRe = /(\\d*:HL\\[.*?),"stylesheet"(\\]|,)/g;
-  const stream = _renderToReadableStream(model, options);
-  const decoder = new TextDecoder();
-  const encoder = new TextEncoder();
-  let carry = "";
-  return stream.pipeThrough(new TransformStream({
-    transform(chunk, controller) {
-      const text = carry + decoder.decode(chunk, { stream: true });
-      const lastNl = text.lastIndexOf("\\n");
-      if (lastNl === -1) {
-        carry = text;
-        return;
-      }
-      carry = text.slice(lastNl + 1);
-      controller.enqueue(encoder.encode(text.slice(0, lastNl + 1).replace(_hlFixRe, '$1,"style"$2')));
-    },
-    flush(controller) {
-      const text = carry + decoder.decode();
-      if (text) controller.enqueue(encoder.encode(text.replace(_hlFixRe, '$1,"style"$2')));
-    }
-  }));
+  return __normalizeReactFlightPreloadHints(_renderToReadableStream(model, options));
 }
 import { createElement } from "react";
 import { setNavigationContext as _setNavigationContextOrig, getNavigationContext as _getNavigationContext } from "next/navigation";

--- a/packages/vinext/src/server/rsc-stream-hints.ts
+++ b/packages/vinext/src/server/rsc-stream-hints.ts
@@ -1,5 +1,10 @@
 const REACT_FLIGHT_STYLESHEET_PRELOAD_HINT = /(\d*:HL\[.*?),"stylesheet"(\]|,)/g;
 
+/**
+ * React Flight emits HL hints with "stylesheet" for CSS preloads, but the
+ * HTML spec requires "style" for <link rel="preload">. Rewrite each complete
+ * Flight line so SSR embeds, navigation, and server actions see valid hints.
+ */
 function normalizeReactFlightHintLine(line: string): string {
   return line.replace(REACT_FLIGHT_STYLESHEET_PRELOAD_HINT, '$1,"style"$2');
 }

--- a/packages/vinext/src/server/rsc-stream-hints.ts
+++ b/packages/vinext/src/server/rsc-stream-hints.ts
@@ -1,0 +1,38 @@
+const REACT_FLIGHT_STYLESHEET_PRELOAD_HINT = /(\d*:HL\[.*?),"stylesheet"(\]|,)/g;
+
+function normalizeReactFlightHintLine(line: string): string {
+  return line.replace(REACT_FLIGHT_STYLESHEET_PRELOAD_HINT, '$1,"style"$2');
+}
+
+export function normalizeReactFlightPreloadHints(
+  stream: ReadableStream<Uint8Array>,
+): ReadableStream<Uint8Array> {
+  const decoder = new TextDecoder();
+  const encoder = new TextEncoder();
+  let carry = "";
+
+  return stream.pipeThrough(
+    new TransformStream<Uint8Array, Uint8Array>({
+      transform(chunk, controller) {
+        const text = carry + decoder.decode(chunk, { stream: true });
+        const lastNewline = text.lastIndexOf("\n");
+
+        if (lastNewline === -1) {
+          carry = text;
+          return;
+        }
+
+        carry = text.slice(lastNewline + 1);
+        controller.enqueue(
+          encoder.encode(normalizeReactFlightHintLine(text.slice(0, lastNewline + 1))),
+        );
+      },
+      flush(controller) {
+        const text = carry + decoder.decode();
+        if (text) {
+          controller.enqueue(encoder.encode(normalizeReactFlightHintLine(text)));
+        }
+      },
+    }),
+  );
+}

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -13,34 +13,12 @@ import {
 } from "@vitejs/plugin-rsc/rsc";
 import { AsyncLocalStorage } from "node:async_hooks";
 
-// React Flight emits HL hints with "stylesheet" for CSS, but the HTML spec
-// requires "style" for <link rel="preload">. Fix at the source so every
-// consumer (SSR embed, client-side navigation, server actions) gets clean data.
-//
-// Flight lines are newline-delimited, so we buffer partial lines across chunks
-// to guarantee the regex never sees a split hint.
+import {
+  normalizeReactFlightPreloadHints as __normalizeReactFlightPreloadHints,
+} from "<ROOT>/packages/vinext/src/server/rsc-stream-hints.js";
+
 function renderToReadableStream(model, options) {
-  const _hlFixRe = /(\\d*:HL\\[.*?),"stylesheet"(\\]|,)/g;
-  const stream = _renderToReadableStream(model, options);
-  const decoder = new TextDecoder();
-  const encoder = new TextEncoder();
-  let carry = "";
-  return stream.pipeThrough(new TransformStream({
-    transform(chunk, controller) {
-      const text = carry + decoder.decode(chunk, { stream: true });
-      const lastNl = text.lastIndexOf("\\n");
-      if (lastNl === -1) {
-        carry = text;
-        return;
-      }
-      carry = text.slice(lastNl + 1);
-      controller.enqueue(encoder.encode(text.slice(0, lastNl + 1).replace(_hlFixRe, '$1,"style"$2')));
-    },
-    flush(controller) {
-      const text = carry + decoder.decode();
-      if (text) controller.enqueue(encoder.encode(text.replace(_hlFixRe, '$1,"style"$2')));
-    }
-  }));
+  return __normalizeReactFlightPreloadHints(_renderToReadableStream(model, options));
 }
 import { createElement } from "react";
 import { setNavigationContext as _setNavigationContextOrig, getNavigationContext as _getNavigationContext } from "next/navigation";
@@ -2155,34 +2133,12 @@ import {
 } from "@vitejs/plugin-rsc/rsc";
 import { AsyncLocalStorage } from "node:async_hooks";
 
-// React Flight emits HL hints with "stylesheet" for CSS, but the HTML spec
-// requires "style" for <link rel="preload">. Fix at the source so every
-// consumer (SSR embed, client-side navigation, server actions) gets clean data.
-//
-// Flight lines are newline-delimited, so we buffer partial lines across chunks
-// to guarantee the regex never sees a split hint.
+import {
+  normalizeReactFlightPreloadHints as __normalizeReactFlightPreloadHints,
+} from "<ROOT>/packages/vinext/src/server/rsc-stream-hints.js";
+
 function renderToReadableStream(model, options) {
-  const _hlFixRe = /(\\d*:HL\\[.*?),"stylesheet"(\\]|,)/g;
-  const stream = _renderToReadableStream(model, options);
-  const decoder = new TextDecoder();
-  const encoder = new TextEncoder();
-  let carry = "";
-  return stream.pipeThrough(new TransformStream({
-    transform(chunk, controller) {
-      const text = carry + decoder.decode(chunk, { stream: true });
-      const lastNl = text.lastIndexOf("\\n");
-      if (lastNl === -1) {
-        carry = text;
-        return;
-      }
-      carry = text.slice(lastNl + 1);
-      controller.enqueue(encoder.encode(text.slice(0, lastNl + 1).replace(_hlFixRe, '$1,"style"$2')));
-    },
-    flush(controller) {
-      const text = carry + decoder.decode();
-      if (text) controller.enqueue(encoder.encode(text.replace(_hlFixRe, '$1,"style"$2')));
-    }
-  }));
+  return __normalizeReactFlightPreloadHints(_renderToReadableStream(model, options));
 }
 import { createElement } from "react";
 import { setNavigationContext as _setNavigationContextOrig, getNavigationContext as _getNavigationContext } from "next/navigation";
@@ -4303,34 +4259,12 @@ import {
 } from "@vitejs/plugin-rsc/rsc";
 import { AsyncLocalStorage } from "node:async_hooks";
 
-// React Flight emits HL hints with "stylesheet" for CSS, but the HTML spec
-// requires "style" for <link rel="preload">. Fix at the source so every
-// consumer (SSR embed, client-side navigation, server actions) gets clean data.
-//
-// Flight lines are newline-delimited, so we buffer partial lines across chunks
-// to guarantee the regex never sees a split hint.
+import {
+  normalizeReactFlightPreloadHints as __normalizeReactFlightPreloadHints,
+} from "<ROOT>/packages/vinext/src/server/rsc-stream-hints.js";
+
 function renderToReadableStream(model, options) {
-  const _hlFixRe = /(\\d*:HL\\[.*?),"stylesheet"(\\]|,)/g;
-  const stream = _renderToReadableStream(model, options);
-  const decoder = new TextDecoder();
-  const encoder = new TextEncoder();
-  let carry = "";
-  return stream.pipeThrough(new TransformStream({
-    transform(chunk, controller) {
-      const text = carry + decoder.decode(chunk, { stream: true });
-      const lastNl = text.lastIndexOf("\\n");
-      if (lastNl === -1) {
-        carry = text;
-        return;
-      }
-      carry = text.slice(lastNl + 1);
-      controller.enqueue(encoder.encode(text.slice(0, lastNl + 1).replace(_hlFixRe, '$1,"style"$2')));
-    },
-    flush(controller) {
-      const text = carry + decoder.decode();
-      if (text) controller.enqueue(encoder.encode(text.replace(_hlFixRe, '$1,"style"$2')));
-    }
-  }));
+  return __normalizeReactFlightPreloadHints(_renderToReadableStream(model, options));
 }
 import { createElement } from "react";
 import { setNavigationContext as _setNavigationContextOrig, getNavigationContext as _getNavigationContext } from "next/navigation";
@@ -6446,34 +6380,12 @@ import {
 } from "@vitejs/plugin-rsc/rsc";
 import { AsyncLocalStorage } from "node:async_hooks";
 
-// React Flight emits HL hints with "stylesheet" for CSS, but the HTML spec
-// requires "style" for <link rel="preload">. Fix at the source so every
-// consumer (SSR embed, client-side navigation, server actions) gets clean data.
-//
-// Flight lines are newline-delimited, so we buffer partial lines across chunks
-// to guarantee the regex never sees a split hint.
+import {
+  normalizeReactFlightPreloadHints as __normalizeReactFlightPreloadHints,
+} from "<ROOT>/packages/vinext/src/server/rsc-stream-hints.js";
+
 function renderToReadableStream(model, options) {
-  const _hlFixRe = /(\\d*:HL\\[.*?),"stylesheet"(\\]|,)/g;
-  const stream = _renderToReadableStream(model, options);
-  const decoder = new TextDecoder();
-  const encoder = new TextEncoder();
-  let carry = "";
-  return stream.pipeThrough(new TransformStream({
-    transform(chunk, controller) {
-      const text = carry + decoder.decode(chunk, { stream: true });
-      const lastNl = text.lastIndexOf("\\n");
-      if (lastNl === -1) {
-        carry = text;
-        return;
-      }
-      carry = text.slice(lastNl + 1);
-      controller.enqueue(encoder.encode(text.slice(0, lastNl + 1).replace(_hlFixRe, '$1,"style"$2')));
-    },
-    flush(controller) {
-      const text = carry + decoder.decode();
-      if (text) controller.enqueue(encoder.encode(text.replace(_hlFixRe, '$1,"style"$2')));
-    }
-  }));
+  return __normalizeReactFlightPreloadHints(_renderToReadableStream(model, options));
 }
 import { createElement } from "react";
 import { setNavigationContext as _setNavigationContextOrig, getNavigationContext as _getNavigationContext } from "next/navigation";
@@ -8621,34 +8533,12 @@ import {
 } from "@vitejs/plugin-rsc/rsc";
 import { AsyncLocalStorage } from "node:async_hooks";
 
-// React Flight emits HL hints with "stylesheet" for CSS, but the HTML spec
-// requires "style" for <link rel="preload">. Fix at the source so every
-// consumer (SSR embed, client-side navigation, server actions) gets clean data.
-//
-// Flight lines are newline-delimited, so we buffer partial lines across chunks
-// to guarantee the regex never sees a split hint.
+import {
+  normalizeReactFlightPreloadHints as __normalizeReactFlightPreloadHints,
+} from "<ROOT>/packages/vinext/src/server/rsc-stream-hints.js";
+
 function renderToReadableStream(model, options) {
-  const _hlFixRe = /(\\d*:HL\\[.*?),"stylesheet"(\\]|,)/g;
-  const stream = _renderToReadableStream(model, options);
-  const decoder = new TextDecoder();
-  const encoder = new TextEncoder();
-  let carry = "";
-  return stream.pipeThrough(new TransformStream({
-    transform(chunk, controller) {
-      const text = carry + decoder.decode(chunk, { stream: true });
-      const lastNl = text.lastIndexOf("\\n");
-      if (lastNl === -1) {
-        carry = text;
-        return;
-      }
-      carry = text.slice(lastNl + 1);
-      controller.enqueue(encoder.encode(text.slice(0, lastNl + 1).replace(_hlFixRe, '$1,"style"$2')));
-    },
-    flush(controller) {
-      const text = carry + decoder.decode();
-      if (text) controller.enqueue(encoder.encode(text.replace(_hlFixRe, '$1,"style"$2')));
-    }
-  }));
+  return __normalizeReactFlightPreloadHints(_renderToReadableStream(model, options));
 }
 import { createElement } from "react";
 import { setNavigationContext as _setNavigationContextOrig, getNavigationContext as _getNavigationContext } from "next/navigation";
@@ -10770,34 +10660,12 @@ import {
 } from "@vitejs/plugin-rsc/rsc";
 import { AsyncLocalStorage } from "node:async_hooks";
 
-// React Flight emits HL hints with "stylesheet" for CSS, but the HTML spec
-// requires "style" for <link rel="preload">. Fix at the source so every
-// consumer (SSR embed, client-side navigation, server actions) gets clean data.
-//
-// Flight lines are newline-delimited, so we buffer partial lines across chunks
-// to guarantee the regex never sees a split hint.
+import {
+  normalizeReactFlightPreloadHints as __normalizeReactFlightPreloadHints,
+} from "<ROOT>/packages/vinext/src/server/rsc-stream-hints.js";
+
 function renderToReadableStream(model, options) {
-  const _hlFixRe = /(\\d*:HL\\[.*?),"stylesheet"(\\]|,)/g;
-  const stream = _renderToReadableStream(model, options);
-  const decoder = new TextDecoder();
-  const encoder = new TextEncoder();
-  let carry = "";
-  return stream.pipeThrough(new TransformStream({
-    transform(chunk, controller) {
-      const text = carry + decoder.decode(chunk, { stream: true });
-      const lastNl = text.lastIndexOf("\\n");
-      if (lastNl === -1) {
-        carry = text;
-        return;
-      }
-      carry = text.slice(lastNl + 1);
-      controller.enqueue(encoder.encode(text.slice(0, lastNl + 1).replace(_hlFixRe, '$1,"style"$2')));
-    },
-    flush(controller) {
-      const text = carry + decoder.decode();
-      if (text) controller.enqueue(encoder.encode(text.replace(_hlFixRe, '$1,"style"$2')));
-    }
-  }));
+  return __normalizeReactFlightPreloadHints(_renderToReadableStream(model, options));
 }
 import { createElement } from "react";
 import { setNavigationContext as _setNavigationContextOrig, getNavigationContext as _getNavigationContext } from "next/navigation";

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -3970,7 +3970,7 @@ describe("App Router middleware with NextRequest", () => {
 });
 
 describe("RSC Flight hint fix", () => {
-  it("generateRscEntry wraps renderToReadableStream with HL hint fix", () => {
+  it("generateRscEntry delegates renderToReadableStream hint normalization", () => {
     // The RSC entry should shadow renderToReadableStream with a wrapper that
     // rewrites Flight HL hint "stylesheet" → "style" at the stream source,
     // so all consumers (SSR embed, client-side nav, server actions) get clean data.
@@ -3996,75 +3996,10 @@ describe("RSC Flight hint fix", () => {
     };
     const code = generateRscEntry("/tmp/test/app", [route]);
     expect(code).toContain("_renderToReadableStream");
-    expect(code).toContain('"style"$2');
-  });
-
-  it('fixFlightHints regex correctly replaces "stylesheet" with "style" in RSC Flight HL hints', () => {
-    // Replicate the HL hint rewrite regex from the renderToReadableStream wrapper
-    // in app-rsc-entry.ts. This rewrites the Flight stream at the source so all
-    // consumers (SSR embed, client-side nav, server actions) get clean data.
-    // Use the corrected regex: \d* (zero or more digits) to match the actual
-    // React Flight wire format where hints are emitted without a chunk ID,
-    // i.e. ":HL[...]" not "2:HL[...]". The old \d+ never matched in practice.
-    function fixFlightHints(text: string): string {
-      return text.replace(/(\d*:HL\[.*?),"stylesheet"(\]|,)/g, '$1,"style"$2');
-    }
-
-    // Test: actual React Flight wire format — NO numeric ID prefix for hints.
-    // React emits ":HL[...]" (emitHint writes ":H" + code + model).
-    expect(fixFlightHints(':HL["/assets/index.css","stylesheet"]')).toBe(
-      ':HL["/assets/index.css","style"]',
+    expect(code).toContain(
+      "normalizeReactFlightPreloadHints as __normalizeReactFlightPreloadHints",
     );
-
-    // Test: no-prefix with options (3-element array)
-    expect(fixFlightHints(':HL["/assets/index.css","stylesheet",{"crossOrigin":""}]')).toBe(
-      ':HL["/assets/index.css","style",{"crossOrigin":""}]',
-    );
-
-    // Test: basic HL hint for CSS (with explicit numeric ID — legacy / hypothetical)
-    expect(fixFlightHints('2:HL["/assets/index.css","stylesheet"]')).toBe(
-      '2:HL["/assets/index.css","style"]',
-    );
-
-    // Test: HL hint with options (3-element array, with explicit ID)
-    expect(fixFlightHints('2:HL["/assets/index.css","stylesheet",{"crossOrigin":""}]')).toBe(
-      '2:HL["/assets/index.css","style",{"crossOrigin":""}]',
-    );
-
-    // Test: should NOT modify non-HL lines containing "stylesheet"
-    expect(
-      fixFlightHints(
-        '0:D{"name":"index"}\n1:["$","link",null,{"rel":"stylesheet","href":"/file.css"}]',
-      ),
-    ).toBe('0:D{"name":"index"}\n1:["$","link",null,{"rel":"stylesheet","href":"/file.css"}]');
-
-    // Test: multiple HL hints in one chunk — no-prefix format
-    expect(fixFlightHints(':HL["/a.css","stylesheet"]\n:HL["/b.css","stylesheet"]')).toBe(
-      ':HL["/a.css","style"]\n:HL["/b.css","style"]',
-    );
-
-    // Test: multiple HL hints in one chunk — with IDs
-    expect(fixFlightHints('2:HL["/a.css","stylesheet"]\n3:HL["/b.css","stylesheet"]')).toBe(
-      '2:HL["/a.css","style"]\n3:HL["/b.css","style"]',
-    );
-
-    // Test: should NOT modify HL hints with other as values
-    expect(fixFlightHints(':HL["/font.woff2","font"]')).toBe(':HL["/font.woff2","font"]');
-
-    // Test: no change needed when already "style"
-    expect(fixFlightHints(':HL["/assets/index.css","style"]')).toBe(
-      ':HL["/assets/index.css","style"]',
-    );
-
-    // Test: mixed content — only HL hints should be modified (no-prefix format)
-    expect(
-      fixFlightHints('0:D{"name":"page"}\n:HL["/app.css","stylesheet"]\n3:["$","div",null,{}]'),
-    ).toBe('0:D{"name":"page"}\n:HL["/app.css","style"]\n3:["$","div",null,{}]');
-
-    // Test: mixed content — only HL hints should be modified (with ID)
-    expect(
-      fixFlightHints('0:D{"name":"page"}\n2:HL["/app.css","stylesheet"]\n3:["$","div",null,{}]'),
-    ).toBe('0:D{"name":"page"}\n2:HL["/app.css","style"]\n3:["$","div",null,{}]');
+    expect(code).toContain("return __normalizeReactFlightPreloadHints(_renderToReadableStream");
   });
 });
 // ── Client reference preloading (Issue #256) ─────────────────────────────────

--- a/tests/app-rsc-stream-hints.test.ts
+++ b/tests/app-rsc-stream-hints.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { normalizeReactFlightPreloadHints } from "../packages/vinext/src/server/rsc-stream-hints.js";
+
+function streamFromChunks(chunks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(encoder.encode(chunk));
+      }
+      controller.close();
+    },
+  });
+}
+
+async function readStream(stream: ReadableStream<Uint8Array>): Promise<string> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let text = "";
+
+  for (;;) {
+    const result = await reader.read();
+    if (result.done) break;
+    text += decoder.decode(result.value, { stream: true });
+  }
+
+  return text + decoder.decode();
+}
+
+describe("RSC stream hint helpers", () => {
+  it("rewrites React Flight stylesheet preload hints", async () => {
+    const stream = normalizeReactFlightPreloadHints(
+      streamFromChunks([
+        ':HL["/assets/app.css","stylesheet"]\n',
+        '2:HL["/assets/page.css","stylesheet",{"crossOrigin":""}]\n',
+        '3:HL["/assets/font.woff2","font"]\n',
+      ]),
+    );
+
+    await expect(readStream(stream)).resolves.toBe(
+      ':HL["/assets/app.css","style"]\n' +
+        '2:HL["/assets/page.css","style",{"crossOrigin":""}]\n' +
+        '3:HL["/assets/font.woff2","font"]\n',
+    );
+  });
+
+  it("buffers partial Flight lines across chunks before rewriting hints", async () => {
+    const stream = normalizeReactFlightPreloadHints(
+      streamFromChunks([':HL["/assets/app.css",', '"styles', 'heet"]\n0:D{"name":"page"}\n']),
+    );
+
+    await expect(readStream(stream)).resolves.toBe(
+      ':HL["/assets/app.css","style"]\n0:D{"name":"page"}\n',
+    );
+  });
+
+  it("rewrites a final unterminated Flight line during flush", async () => {
+    const stream = normalizeReactFlightPreloadHints(
+      streamFromChunks([':HL["/assets/app.css","stylesheet"]']),
+    );
+
+    await expect(readStream(stream)).resolves.toBe(':HL["/assets/app.css","style"]');
+  });
+});

--- a/tests/app-rsc-stream-hints.test.ts
+++ b/tests/app-rsc-stream-hints.test.ts
@@ -45,6 +45,26 @@ describe("RSC stream hint helpers", () => {
     );
   });
 
+  it("only rewrites stylesheet preload hints in mixed Flight content", async () => {
+    const stream = normalizeReactFlightPreloadHints(
+      streamFromChunks([
+        '0:D{"name":"page"}\n' +
+          ':HL["/assets/a.css","stylesheet",{"crossOrigin":""}]\n' +
+          '1:["$","link",null,{"rel":"stylesheet","href":"/assets/b.css"}]\n' +
+          ':HL["/assets/c.css","style"]\n' +
+          ':HL["/assets/d.css","stylesheet"]\n',
+      ]),
+    );
+
+    await expect(readStream(stream)).resolves.toBe(
+      '0:D{"name":"page"}\n' +
+        ':HL["/assets/a.css","style",{"crossOrigin":""}]\n' +
+        '1:["$","link",null,{"rel":"stylesheet","href":"/assets/b.css"}]\n' +
+        ':HL["/assets/c.css","style"]\n' +
+        ':HL["/assets/d.css","style"]\n',
+    );
+  });
+
   it("buffers partial Flight lines across chunks before rewriting hints", async () => {
     const stream = normalizeReactFlightPreloadHints(
       streamFromChunks([':HL["/assets/app.css",', '"styles', 'heet"]\n0:D{"name":"page"}\n']),

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -277,6 +277,16 @@ describe("App Router entry templates", () => {
     );
   });
 
+  it("generateRscEntry delegates React Flight preload hint normalization", () => {
+    const code = generateRscEntry("/tmp/test/app", minimalAppRoutes, null, [], null, "", false);
+
+    expect(code).toContain(
+      "normalizeReactFlightPreloadHints as __normalizeReactFlightPreloadHints",
+    );
+    expect(code).toContain("return __normalizeReactFlightPreloadHints(_renderToReadableStream");
+    expect(code).not.toContain("const _hlFixRe =");
+  });
+
   it("generateSsrEntry snapshot", () => {
     const code = generateSsrEntry();
     expect(stabilize(code)).toMatchSnapshot();


### PR DESCRIPTION
## What this changes
The App Router RSC entry now delegates React Flight preload hint stream normalization to a typed server helper instead of carrying the TransformStream implementation inline in generated code.

## Why
The generated RSC entry should mostly contain import tables, manifests, and thin runtime wiring. Keeping byte-stream buffering and hint rewriting inside the entry made the behavior harder to test directly and kept generated snapshots responsible for runtime stream semantics.

## Approach
- Added `normalizeReactFlightPreloadHints()` in `packages/vinext/src/server/rsc-stream-hints.ts`.
- Updated `generateRscEntry()` to import that helper and keep `renderToReadableStream()` as a one-line delegation wrapper.
- Added direct stream tests covering complete Flight lines, split chunks, and final unterminated lines.
- Updated generated-entry assertions and snapshots to lock down delegation instead of inline transform code.

## Validation
- `vp test run tests/app-rsc-stream-hints.test.ts tests/entry-templates.test.ts`
- `vp test run tests/app-router.test.ts -t "RSC Flight hint fix"`
- `vp check tests/app-rsc-stream-hints.test.ts tests/entry-templates.test.ts tests/app-router.test.ts packages/vinext/src/server/rsc-stream-hints.ts packages/vinext/src/entries/app-rsc-entry.ts`
- Commit hook: `tests/entry-templates.test.ts`, `vp check --fix`, and `knip --no-progress`

## Risks / follow-ups
This is intentionally limited to the low-conflict stream hint helper slice. It avoids metadata, middleware, ISR, route-handler cache, server action, and boundary code paths that currently have active overlapping PRs.