### PR TITLE
refactor(app-router): delegate RSC route matching

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -77,7 +77,10 @@ const appRouteHandlerResponsePath = resolveEntryPath(
   "../server/app-route-handler-response.js",
   import.meta.url,
 );
-const routeTriePath = resolveEntryPath("../routing/route-trie.js", import.meta.url);
+const appRscRouteMatchingPath = resolveEntryPath(
+  "../server/app-rsc-route-matching.js",
+  import.meta.url,
+);
 const metadataRoutesPath = resolveEntryPath("../server/metadata-routes.js", import.meta.url);
 const rootParamsShimPath = resolveEntryPath("../shims/root-params.js", import.meta.url);
 const errorCausePath = resolveEntryPath("../utils/error-cause.js", import.meta.url);
@@ -279,10 +282,10 @@ ${slotEntries.join(",\n")}
   // without filesystem access (e.g., Cloudflare Workers).
   //
   // For metadata routes in dynamic segments (e.g., /blog/[slug]/opengraph-image),
-  // generate patternParts so the runtime can use matchPattern() instead of strict
-  // equality — the same matching used for intercept routes.
+  // generate patternParts so the runtime can use shared route-pattern matching
+  // instead of strict equality — the same matching used for intercept routes.
   const metaRouteEntries = effectiveMetaRoutes.map((mr) => {
-    // Convert dynamic segments in servedUrl to matchPattern format.
+    // Convert dynamic segments in servedUrl to the shared route-pattern format.
     // Keep in sync with routing/app-router.ts patternParts generation.
     //   [param]       → :param
     //   [...param]    → :param+
@@ -441,7 +444,10 @@ import { _consumeRequestScopedCacheLife, getCacheHandler } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from ${JSON.stringify(requestContextShimPath)};
 import { setRootParams as __setRootParams, pickRootParams as __pickRootParams } from ${JSON.stringify(rootParamsShimPath)};
 import { ensureFetchPatch as _ensureFetchPatch, getCollectedFetchTags, setCurrentFetchSoftTags } from "vinext/fetch-cache";
-import { buildRouteTrie as _buildRouteTrie, trieMatch as _trieMatch } from ${JSON.stringify(routeTriePath)};
+import {
+  createAppRscRouteMatcher as __createAppRscRouteMatcher,
+  matchAppRscRoutePattern as __matchAppRscRoutePattern,
+} from ${JSON.stringify(appRscRouteMatchingPath)};
 // Import server-only state module to register ALS-backed accessors.
 import "vinext/navigation-state";
 import { runWithRequestContext as _runWithUnifiedCtx, createRequestContext as _createUnifiedCtx } from "vinext/unified-request-context";
@@ -612,11 +618,11 @@ const __classDebug = process.env.VINEXT_DEBUG_CLASSIFICATION
     }
   : undefined;
 
-// Normalize null-prototype objects from matchPattern() into thenable objects
+// Normalize null-prototype objects from route-pattern matching into thenable objects
 // that work both as Promises (for Next.js 15+ async params) and as plain
 // objects with synchronous property access (for pre-15 code like params.id).
 //
-// matchPattern() uses Object.create(null), producing objects without
+// route-pattern matching uses Object.create(null), producing objects without
 // Object.prototype. The RSC serializer rejects these. Spreading ({...obj})
 // restores a normal prototype. Object.assign onto the Promise preserves
 // synchronous property access (params.id, params.slug) that existing
@@ -805,7 +811,7 @@ function __VINEXT_CLASS_REASONS(routeIdx) {
 const routes = [
 ${routeEntries.join(",\n")}
 ];
-const _routeTrie = _buildRouteTrie(routes);
+const __routeMatcher = __createAppRscRouteMatcher(routes);
 
 const metadataRoutes = [
 ${metaRouteEntries.join(",\n")}
@@ -905,13 +911,7 @@ async function renderErrorBoundaryPage(route, error, isRscRequest, request, matc
 }
 
 function matchRoute(url) {
-  const pathname = url.split("?")[0];
-  let normalizedUrl = pathname === "/" ? "/" : pathname.replace(/\\/$/, "");
-   // NOTE: Do NOT decodeURIComponent here. The caller is responsible for decoding
-   // the pathname exactly once at the request entry point. Decoding again here
-   // would cause inconsistent path matching between middleware and routing.
-  const urlParts = normalizedUrl.split("/").filter(Boolean);
-  return _trieMatch(_routeTrie, urlParts);
+  return __routeMatcher.matchRoute(url);
 }
 
 function __createStaticFileSignal(pathname, _mwCtx) {
@@ -929,86 +929,12 @@ function __createStaticFileSignal(pathname, _mwCtx) {
   });
 }
 
-// matchPattern is kept for findIntercept (linear scan over small interceptLookup array).
-function matchPattern(urlParts, patternParts) {
-  const params = Object.create(null);
-  for (let i = 0; i < patternParts.length; i++) {
-    const pp = patternParts[i];
-    if (pp.endsWith("+")) {
-      if (i !== patternParts.length - 1) return null;
-      const paramName = pp.slice(1, -1);
-      const remaining = urlParts.slice(i);
-      if (remaining.length === 0) return null;
-      params[paramName] = remaining;
-      return params;
-    }
-    if (pp.endsWith("*")) {
-      if (i !== patternParts.length - 1) return null;
-      const paramName = pp.slice(1, -1);
-      params[paramName] = urlParts.slice(i);
-      return params;
-    }
-    if (pp.startsWith(":")) {
-      if (i >= urlParts.length) return null;
-      params[pp.slice(1)] = urlParts[i];
-      continue;
-    }
-    if (i >= urlParts.length || urlParts[i] !== pp) return null;
-  }
-  if (urlParts.length !== patternParts.length) return null;
-  return params;
-}
-
-function mergeMatchedParams(sourceParams, targetParams) {
-  return Object.assign(Object.create(null), sourceParams, targetParams);
-}
-
-// Build a global intercepting route lookup for RSC navigation.
-// Maps target URL patterns to { sourceRouteIndex, slotKey, interceptPage, interceptLayouts, params }.
-const interceptLookup = [];
-for (let ri = 0; ri < routes.length; ri++) {
-  const r = routes[ri];
-  if (!r.slots) continue;
-  for (const [slotKey, slotMod] of Object.entries(r.slots)) {
-    if (!slotMod.intercepts) continue;
-    for (const intercept of slotMod.intercepts) {
-      interceptLookup.push({
-        sourceRouteIndex: ri,
-        slotKey,
-        targetPattern: intercept.targetPattern,
-        targetPatternParts: intercept.targetPattern.split("/").filter(Boolean),
-        interceptLayouts: intercept.interceptLayouts,
-        page: intercept.page,
-        params: intercept.params,
-      });
-    }
-  }
-}
-
 /**
  * Check if a pathname matches any intercepting route.
  * Returns the match info or null.
  */
 function findIntercept(pathname, sourcePathname = null) {
-  const urlParts = pathname.split("/").filter(Boolean);
-  for (const entry of interceptLookup) {
-    const params = matchPattern(urlParts, entry.targetPatternParts);
-    if (params !== null) {
-      let sourceParams = Object.create(null);
-      if (sourcePathname !== null) {
-        const sourceRoute = routes[entry.sourceRouteIndex];
-        const sourceParts = sourcePathname.split("/").filter(Boolean);
-        const matchedSourceParams = sourceRoute
-          ? matchPattern(sourceParts, sourceRoute.patternParts)
-          : null;
-        if (matchedSourceParams !== null) {
-          sourceParams = matchedSourceParams;
-        }
-      }
-      return { ...entry, matchedParams: mergeMatchedParams(sourceParams, params) };
-    }
-  }
-  return null;
+  return __routeMatcher.findIntercept(pathname, sourcePathname);
 }
 
 async function buildPageElements(route, params, routePath, pageRequest) {
@@ -1738,7 +1664,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     var _metaParams = null;
     if (metaRoute.patternParts) {
       var _metaUrlParts = cleanPathname.split("/").filter(Boolean);
-      _metaParams = matchPattern(_metaUrlParts, metaRoute.patternParts);
+      _metaParams = __matchAppRscRoutePattern(_metaUrlParts, metaRoute.patternParts);
       if (!_metaParams) continue;
     } else if (cleanPathname !== metaRoute.servedUrl) {
       continue;

--- a/packages/vinext/src/server/app-rsc-route-matching.ts
+++ b/packages/vinext/src/server/app-rsc-route-matching.ts
@@ -1,0 +1,139 @@
+import { buildRouteTrie, trieMatch } from "../routing/route-trie.js";
+
+type AppRscRouteParams = Record<string, string | string[]>;
+
+type AppRscInterceptForMatching = {
+  targetPattern: string;
+  interceptLayouts: readonly unknown[];
+  page: unknown;
+  params: readonly string[];
+};
+
+type AppRscSlotForMatching = {
+  intercepts?: readonly AppRscInterceptForMatching[];
+};
+
+type AppRscRouteForMatching = {
+  patternParts: string[];
+  slots?: Record<string, AppRscSlotForMatching>;
+};
+
+type AppRscInterceptMatch = AppRscInterceptLookupEntry & {
+  matchedParams: AppRscRouteParams;
+};
+
+type AppRscInterceptLookupEntry = {
+  sourceRouteIndex: number;
+  slotKey: string;
+  targetPattern: string;
+  targetPatternParts: string[];
+  interceptLayouts: readonly unknown[];
+  page: unknown;
+  params: readonly string[];
+};
+
+export function createAppRscRouteMatcher<Route extends AppRscRouteForMatching>(
+  routes: Route[],
+): {
+  matchRoute(url: string): { route: Route; params: AppRscRouteParams } | null;
+  findIntercept(pathname: string, sourcePathname?: string | null): AppRscInterceptMatch | null;
+} {
+  const routeTrie = buildRouteTrie(routes);
+  const interceptLookup = createInterceptLookup(routes);
+
+  return {
+    matchRoute(url) {
+      const pathname = url.split("?")[0];
+      const normalizedUrl = pathname === "/" ? "/" : pathname.replace(/\/$/, "");
+      // The request entry point owns decoding. Matching here preserves the
+      // already-normalized segment bytes so middleware and routing stay aligned.
+      const urlParts = normalizedUrl.split("/").filter(Boolean);
+      return trieMatch(routeTrie, urlParts);
+    },
+    findIntercept(pathname, sourcePathname = null) {
+      const urlParts = pathname.split("/").filter(Boolean);
+      for (const entry of interceptLookup) {
+        const params = matchAppRscRoutePattern(urlParts, entry.targetPatternParts);
+        if (params !== null) {
+          let sourceParams: AppRscRouteParams = Object.create(null);
+          if (sourcePathname !== null) {
+            const sourceRoute = routes[entry.sourceRouteIndex];
+            const sourceParts = sourcePathname.split("/").filter(Boolean);
+            const matchedSourceParams = sourceRoute
+              ? matchAppRscRoutePattern(sourceParts, sourceRoute.patternParts)
+              : null;
+            if (matchedSourceParams !== null) {
+              sourceParams = matchedSourceParams;
+            }
+          }
+          return { ...entry, matchedParams: mergeMatchedParams(sourceParams, params) };
+        }
+      }
+      return null;
+    },
+  };
+}
+
+function createInterceptLookup<Route extends AppRscRouteForMatching>(
+  routes: Route[],
+): AppRscInterceptLookupEntry[] {
+  const interceptLookup: AppRscInterceptLookupEntry[] = [];
+  for (let routeIndex = 0; routeIndex < routes.length; routeIndex++) {
+    const route = routes[routeIndex];
+    if (!route.slots) continue;
+    for (const [slotKey, slotModule] of Object.entries(route.slots)) {
+      if (!slotModule.intercepts) continue;
+      for (const intercept of slotModule.intercepts) {
+        interceptLookup.push({
+          sourceRouteIndex: routeIndex,
+          slotKey,
+          targetPattern: intercept.targetPattern,
+          targetPatternParts: intercept.targetPattern.split("/").filter(Boolean),
+          interceptLayouts: intercept.interceptLayouts,
+          page: intercept.page,
+          params: intercept.params,
+        });
+      }
+    }
+  }
+  return interceptLookup;
+}
+
+export function matchAppRscRoutePattern(
+  urlParts: string[],
+  patternParts: string[],
+): AppRscRouteParams | null {
+  const params: AppRscRouteParams = Object.create(null);
+  for (let i = 0; i < patternParts.length; i++) {
+    const patternPart = patternParts[i];
+    if (patternPart.startsWith(":") && patternPart.endsWith("+")) {
+      if (i !== patternParts.length - 1) return null;
+      const paramName = patternPart.slice(1, -1);
+      const remaining = urlParts.slice(i);
+      if (remaining.length === 0) return null;
+      params[paramName] = remaining;
+      return params;
+    }
+    if (patternPart.startsWith(":") && patternPart.endsWith("*")) {
+      if (i !== patternParts.length - 1) return null;
+      const paramName = patternPart.slice(1, -1);
+      params[paramName] = urlParts.slice(i);
+      return params;
+    }
+    if (patternPart.startsWith(":")) {
+      if (i >= urlParts.length) return null;
+      params[patternPart.slice(1)] = urlParts[i];
+      continue;
+    }
+    if (i >= urlParts.length || urlParts[i] !== patternPart) return null;
+  }
+  if (urlParts.length !== patternParts.length) return null;
+  return params;
+}
+
+function mergeMatchedParams(
+  sourceParams: AppRscRouteParams,
+  targetParams: AppRscRouteParams,
+): AppRscRouteParams {
+  return Object.assign(Object.create(null), sourceParams, targetParams);
+}

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -114,7 +114,10 @@ import { _consumeRequestScopedCacheLife, getCacheHandler } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
 import { setRootParams as __setRootParams, pickRootParams as __pickRootParams } from "<ROOT>/packages/vinext/src/shims/root-params.js";
 import { ensureFetchPatch as _ensureFetchPatch, getCollectedFetchTags, setCurrentFetchSoftTags } from "vinext/fetch-cache";
-import { buildRouteTrie as _buildRouteTrie, trieMatch as _trieMatch } from "<ROOT>/packages/vinext/src/routing/route-trie.js";
+import {
+  createAppRscRouteMatcher as __createAppRscRouteMatcher,
+  matchAppRscRoutePattern as __matchAppRscRoutePattern,
+} from "<ROOT>/packages/vinext/src/server/app-rsc-route-matching.js";
 // Import server-only state module to register ALS-backed accessors.
 import "vinext/navigation-state";
 import { runWithRequestContext as _runWithUnifiedCtx, createRequestContext as _createUnifiedCtx } from "vinext/unified-request-context";
@@ -285,11 +288,11 @@ const __classDebug = process.env.VINEXT_DEBUG_CLASSIFICATION
     }
   : undefined;
 
-// Normalize null-prototype objects from matchPattern() into thenable objects
+// Normalize null-prototype objects from route-pattern matching into thenable objects
 // that work both as Promises (for Next.js 15+ async params) and as plain
 // objects with synchronous property access (for pre-15 code like params.id).
 //
-// matchPattern() uses Object.create(null), producing objects without
+// route-pattern matching uses Object.create(null), producing objects without
 // Object.prototype. The RSC serializer rejects these. Spreading ({...obj})
 // restores a normal prototype. Object.assign onto the Promise preserves
 // synchronous property access (params.id, params.slug) that existing
@@ -557,7 +560,7 @@ const routes = [
     unauthorized: null,
   }
 ];
-const _routeTrie = _buildRouteTrie(routes);
+const __routeMatcher = __createAppRscRouteMatcher(routes);
 
 const metadataRoutes = [
 
@@ -657,13 +660,7 @@ async function renderErrorBoundaryPage(route, error, isRscRequest, request, matc
 }
 
 function matchRoute(url) {
-  const pathname = url.split("?")[0];
-  let normalizedUrl = pathname === "/" ? "/" : pathname.replace(/\\/$/, "");
-   // NOTE: Do NOT decodeURIComponent here. The caller is responsible for decoding
-   // the pathname exactly once at the request entry point. Decoding again here
-   // would cause inconsistent path matching between middleware and routing.
-  const urlParts = normalizedUrl.split("/").filter(Boolean);
-  return _trieMatch(_routeTrie, urlParts);
+  return __routeMatcher.matchRoute(url);
 }
 
 function __createStaticFileSignal(pathname, _mwCtx) {
@@ -681,86 +678,12 @@ function __createStaticFileSignal(pathname, _mwCtx) {
   });
 }
 
-// matchPattern is kept for findIntercept (linear scan over small interceptLookup array).
-function matchPattern(urlParts, patternParts) {
-  const params = Object.create(null);
-  for (let i = 0; i < patternParts.length; i++) {
-    const pp = patternParts[i];
-    if (pp.endsWith("+")) {
-      if (i !== patternParts.length - 1) return null;
-      const paramName = pp.slice(1, -1);
-      const remaining = urlParts.slice(i);
-      if (remaining.length === 0) return null;
-      params[paramName] = remaining;
-      return params;
-    }
-    if (pp.endsWith("*")) {
-      if (i !== patternParts.length - 1) return null;
-      const paramName = pp.slice(1, -1);
-      params[paramName] = urlParts.slice(i);
-      return params;
-    }
-    if (pp.startsWith(":")) {
-      if (i >= urlParts.length) return null;
-      params[pp.slice(1)] = urlParts[i];
-      continue;
-    }
-    if (i >= urlParts.length || urlParts[i] !== pp) return null;
-  }
-  if (urlParts.length !== patternParts.length) return null;
-  return params;
-}
-
-function mergeMatchedParams(sourceParams, targetParams) {
-  return Object.assign(Object.create(null), sourceParams, targetParams);
-}
-
-// Build a global intercepting route lookup for RSC navigation.
-// Maps target URL patterns to { sourceRouteIndex, slotKey, interceptPage, interceptLayouts, params }.
-const interceptLookup = [];
-for (let ri = 0; ri < routes.length; ri++) {
-  const r = routes[ri];
-  if (!r.slots) continue;
-  for (const [slotKey, slotMod] of Object.entries(r.slots)) {
-    if (!slotMod.intercepts) continue;
-    for (const intercept of slotMod.intercepts) {
-      interceptLookup.push({
-        sourceRouteIndex: ri,
-        slotKey,
-        targetPattern: intercept.targetPattern,
-        targetPatternParts: intercept.targetPattern.split("/").filter(Boolean),
-        interceptLayouts: intercept.interceptLayouts,
-        page: intercept.page,
-        params: intercept.params,
-      });
-    }
-  }
-}
-
 /**
  * Check if a pathname matches any intercepting route.
  * Returns the match info or null.
  */
 function findIntercept(pathname, sourcePathname = null) {
-  const urlParts = pathname.split("/").filter(Boolean);
-  for (const entry of interceptLookup) {
-    const params = matchPattern(urlParts, entry.targetPatternParts);
-    if (params !== null) {
-      let sourceParams = Object.create(null);
-      if (sourcePathname !== null) {
-        const sourceRoute = routes[entry.sourceRouteIndex];
-        const sourceParts = sourcePathname.split("/").filter(Boolean);
-        const matchedSourceParams = sourceRoute
-          ? matchPattern(sourceParts, sourceRoute.patternParts)
-          : null;
-        if (matchedSourceParams !== null) {
-          sourceParams = matchedSourceParams;
-        }
-      }
-      return { ...entry, matchedParams: mergeMatchedParams(sourceParams, params) };
-    }
-  }
-  return null;
+  return __routeMatcher.findIntercept(pathname, sourcePathname);
 }
 
 async function buildPageElements(route, params, routePath, pageRequest) {
@@ -1455,7 +1378,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     var _metaParams = null;
     if (metaRoute.patternParts) {
       var _metaUrlParts = cleanPathname.split("/").filter(Boolean);
-      _metaParams = matchPattern(_metaUrlParts, metaRoute.patternParts);
+      _metaParams = __matchAppRscRoutePattern(_metaUrlParts, metaRoute.patternParts);
       if (!_metaParams) continue;
     } else if (cleanPathname !== metaRoute.servedUrl) {
       continue;
@@ -2510,7 +2433,10 @@ import { _consumeRequestScopedCacheLife, getCacheHandler } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
 import { setRootParams as __setRootParams, pickRootParams as __pickRootParams } from "<ROOT>/packages/vinext/src/shims/root-params.js";
 import { ensureFetchPatch as _ensureFetchPatch, getCollectedFetchTags, setCurrentFetchSoftTags } from "vinext/fetch-cache";
-import { buildRouteTrie as _buildRouteTrie, trieMatch as _trieMatch } from "<ROOT>/packages/vinext/src/routing/route-trie.js";
+import {
+  createAppRscRouteMatcher as __createAppRscRouteMatcher,
+  matchAppRscRoutePattern as __matchAppRscRoutePattern,
+} from "<ROOT>/packages/vinext/src/server/app-rsc-route-matching.js";
 // Import server-only state module to register ALS-backed accessors.
 import "vinext/navigation-state";
 import { runWithRequestContext as _runWithUnifiedCtx, createRequestContext as _createUnifiedCtx } from "vinext/unified-request-context";
@@ -2681,11 +2607,11 @@ const __classDebug = process.env.VINEXT_DEBUG_CLASSIFICATION
     }
   : undefined;
 
-// Normalize null-prototype objects from matchPattern() into thenable objects
+// Normalize null-prototype objects from route-pattern matching into thenable objects
 // that work both as Promises (for Next.js 15+ async params) and as plain
 // objects with synchronous property access (for pre-15 code like params.id).
 //
-// matchPattern() uses Object.create(null), producing objects without
+// route-pattern matching uses Object.create(null), producing objects without
 // Object.prototype. The RSC serializer rejects these. Spreading ({...obj})
 // restores a normal prototype. Object.assign onto the Promise preserves
 // synchronous property access (params.id, params.slug) that existing
@@ -2953,7 +2879,7 @@ const routes = [
     unauthorized: null,
   }
 ];
-const _routeTrie = _buildRouteTrie(routes);
+const __routeMatcher = __createAppRscRouteMatcher(routes);
 
 const metadataRoutes = [
 
@@ -3053,13 +2979,7 @@ async function renderErrorBoundaryPage(route, error, isRscRequest, request, matc
 }
 
 function matchRoute(url) {
-  const pathname = url.split("?")[0];
-  let normalizedUrl = pathname === "/" ? "/" : pathname.replace(/\\/$/, "");
-   // NOTE: Do NOT decodeURIComponent here. The caller is responsible for decoding
-   // the pathname exactly once at the request entry point. Decoding again here
-   // would cause inconsistent path matching between middleware and routing.
-  const urlParts = normalizedUrl.split("/").filter(Boolean);
-  return _trieMatch(_routeTrie, urlParts);
+  return __routeMatcher.matchRoute(url);
 }
 
 function __createStaticFileSignal(pathname, _mwCtx) {
@@ -3077,86 +2997,12 @@ function __createStaticFileSignal(pathname, _mwCtx) {
   });
 }
 
-// matchPattern is kept for findIntercept (linear scan over small interceptLookup array).
-function matchPattern(urlParts, patternParts) {
-  const params = Object.create(null);
-  for (let i = 0; i < patternParts.length; i++) {
-    const pp = patternParts[i];
-    if (pp.endsWith("+")) {
-      if (i !== patternParts.length - 1) return null;
-      const paramName = pp.slice(1, -1);
-      const remaining = urlParts.slice(i);
-      if (remaining.length === 0) return null;
-      params[paramName] = remaining;
-      return params;
-    }
-    if (pp.endsWith("*")) {
-      if (i !== patternParts.length - 1) return null;
-      const paramName = pp.slice(1, -1);
-      params[paramName] = urlParts.slice(i);
-      return params;
-    }
-    if (pp.startsWith(":")) {
-      if (i >= urlParts.length) return null;
-      params[pp.slice(1)] = urlParts[i];
-      continue;
-    }
-    if (i >= urlParts.length || urlParts[i] !== pp) return null;
-  }
-  if (urlParts.length !== patternParts.length) return null;
-  return params;
-}
-
-function mergeMatchedParams(sourceParams, targetParams) {
-  return Object.assign(Object.create(null), sourceParams, targetParams);
-}
-
-// Build a global intercepting route lookup for RSC navigation.
-// Maps target URL patterns to { sourceRouteIndex, slotKey, interceptPage, interceptLayouts, params }.
-const interceptLookup = [];
-for (let ri = 0; ri < routes.length; ri++) {
-  const r = routes[ri];
-  if (!r.slots) continue;
-  for (const [slotKey, slotMod] of Object.entries(r.slots)) {
-    if (!slotMod.intercepts) continue;
-    for (const intercept of slotMod.intercepts) {
-      interceptLookup.push({
-        sourceRouteIndex: ri,
-        slotKey,
-        targetPattern: intercept.targetPattern,
-        targetPatternParts: intercept.targetPattern.split("/").filter(Boolean),
-        interceptLayouts: intercept.interceptLayouts,
-        page: intercept.page,
-        params: intercept.params,
-      });
-    }
-  }
-}
-
 /**
  * Check if a pathname matches any intercepting route.
  * Returns the match info or null.
  */
 function findIntercept(pathname, sourcePathname = null) {
-  const urlParts = pathname.split("/").filter(Boolean);
-  for (const entry of interceptLookup) {
-    const params = matchPattern(urlParts, entry.targetPatternParts);
-    if (params !== null) {
-      let sourceParams = Object.create(null);
-      if (sourcePathname !== null) {
-        const sourceRoute = routes[entry.sourceRouteIndex];
-        const sourceParts = sourcePathname.split("/").filter(Boolean);
-        const matchedSourceParams = sourceRoute
-          ? matchPattern(sourceParts, sourceRoute.patternParts)
-          : null;
-        if (matchedSourceParams !== null) {
-          sourceParams = matchedSourceParams;
-        }
-      }
-      return { ...entry, matchedParams: mergeMatchedParams(sourceParams, params) };
-    }
-  }
-  return null;
+  return __routeMatcher.findIntercept(pathname, sourcePathname);
 }
 
 async function buildPageElements(route, params, routePath, pageRequest) {
@@ -3857,7 +3703,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     var _metaParams = null;
     if (metaRoute.patternParts) {
       var _metaUrlParts = cleanPathname.split("/").filter(Boolean);
-      _metaParams = matchPattern(_metaUrlParts, metaRoute.patternParts);
+      _metaParams = __matchAppRscRoutePattern(_metaUrlParts, metaRoute.patternParts);
       if (!_metaParams) continue;
     } else if (cleanPathname !== metaRoute.servedUrl) {
       continue;
@@ -4912,7 +4758,10 @@ import { _consumeRequestScopedCacheLife, getCacheHandler } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
 import { setRootParams as __setRootParams, pickRootParams as __pickRootParams } from "<ROOT>/packages/vinext/src/shims/root-params.js";
 import { ensureFetchPatch as _ensureFetchPatch, getCollectedFetchTags, setCurrentFetchSoftTags } from "vinext/fetch-cache";
-import { buildRouteTrie as _buildRouteTrie, trieMatch as _trieMatch } from "<ROOT>/packages/vinext/src/routing/route-trie.js";
+import {
+  createAppRscRouteMatcher as __createAppRscRouteMatcher,
+  matchAppRscRoutePattern as __matchAppRscRoutePattern,
+} from "<ROOT>/packages/vinext/src/server/app-rsc-route-matching.js";
 // Import server-only state module to register ALS-backed accessors.
 import "vinext/navigation-state";
 import { runWithRequestContext as _runWithUnifiedCtx, createRequestContext as _createUnifiedCtx } from "vinext/unified-request-context";
@@ -5083,11 +4932,11 @@ const __classDebug = process.env.VINEXT_DEBUG_CLASSIFICATION
     }
   : undefined;
 
-// Normalize null-prototype objects from matchPattern() into thenable objects
+// Normalize null-prototype objects from route-pattern matching into thenable objects
 // that work both as Promises (for Next.js 15+ async params) and as plain
 // objects with synchronous property access (for pre-15 code like params.id).
 //
-// matchPattern() uses Object.create(null), producing objects without
+// route-pattern matching uses Object.create(null), producing objects without
 // Object.prototype. The RSC serializer rejects these. Spreading ({...obj})
 // restores a normal prototype. Object.assign onto the Promise preserves
 // synchronous property access (params.id, params.slug) that existing
@@ -5356,7 +5205,7 @@ const routes = [
     unauthorized: null,
   }
 ];
-const _routeTrie = _buildRouteTrie(routes);
+const __routeMatcher = __createAppRscRouteMatcher(routes);
 
 const metadataRoutes = [
 
@@ -5456,13 +5305,7 @@ async function renderErrorBoundaryPage(route, error, isRscRequest, request, matc
 }
 
 function matchRoute(url) {
-  const pathname = url.split("?")[0];
-  let normalizedUrl = pathname === "/" ? "/" : pathname.replace(/\\/$/, "");
-   // NOTE: Do NOT decodeURIComponent here. The caller is responsible for decoding
-   // the pathname exactly once at the request entry point. Decoding again here
-   // would cause inconsistent path matching between middleware and routing.
-  const urlParts = normalizedUrl.split("/").filter(Boolean);
-  return _trieMatch(_routeTrie, urlParts);
+  return __routeMatcher.matchRoute(url);
 }
 
 function __createStaticFileSignal(pathname, _mwCtx) {
@@ -5480,86 +5323,12 @@ function __createStaticFileSignal(pathname, _mwCtx) {
   });
 }
 
-// matchPattern is kept for findIntercept (linear scan over small interceptLookup array).
-function matchPattern(urlParts, patternParts) {
-  const params = Object.create(null);
-  for (let i = 0; i < patternParts.length; i++) {
-    const pp = patternParts[i];
-    if (pp.endsWith("+")) {
-      if (i !== patternParts.length - 1) return null;
-      const paramName = pp.slice(1, -1);
-      const remaining = urlParts.slice(i);
-      if (remaining.length === 0) return null;
-      params[paramName] = remaining;
-      return params;
-    }
-    if (pp.endsWith("*")) {
-      if (i !== patternParts.length - 1) return null;
-      const paramName = pp.slice(1, -1);
-      params[paramName] = urlParts.slice(i);
-      return params;
-    }
-    if (pp.startsWith(":")) {
-      if (i >= urlParts.length) return null;
-      params[pp.slice(1)] = urlParts[i];
-      continue;
-    }
-    if (i >= urlParts.length || urlParts[i] !== pp) return null;
-  }
-  if (urlParts.length !== patternParts.length) return null;
-  return params;
-}
-
-function mergeMatchedParams(sourceParams, targetParams) {
-  return Object.assign(Object.create(null), sourceParams, targetParams);
-}
-
-// Build a global intercepting route lookup for RSC navigation.
-// Maps target URL patterns to { sourceRouteIndex, slotKey, interceptPage, interceptLayouts, params }.
-const interceptLookup = [];
-for (let ri = 0; ri < routes.length; ri++) {
-  const r = routes[ri];
-  if (!r.slots) continue;
-  for (const [slotKey, slotMod] of Object.entries(r.slots)) {
-    if (!slotMod.intercepts) continue;
-    for (const intercept of slotMod.intercepts) {
-      interceptLookup.push({
-        sourceRouteIndex: ri,
-        slotKey,
-        targetPattern: intercept.targetPattern,
-        targetPatternParts: intercept.targetPattern.split("/").filter(Boolean),
-        interceptLayouts: intercept.interceptLayouts,
-        page: intercept.page,
-        params: intercept.params,
-      });
-    }
-  }
-}
-
 /**
  * Check if a pathname matches any intercepting route.
  * Returns the match info or null.
  */
 function findIntercept(pathname, sourcePathname = null) {
-  const urlParts = pathname.split("/").filter(Boolean);
-  for (const entry of interceptLookup) {
-    const params = matchPattern(urlParts, entry.targetPatternParts);
-    if (params !== null) {
-      let sourceParams = Object.create(null);
-      if (sourcePathname !== null) {
-        const sourceRoute = routes[entry.sourceRouteIndex];
-        const sourceParts = sourcePathname.split("/").filter(Boolean);
-        const matchedSourceParams = sourceRoute
-          ? matchPattern(sourceParts, sourceRoute.patternParts)
-          : null;
-        if (matchedSourceParams !== null) {
-          sourceParams = matchedSourceParams;
-        }
-      }
-      return { ...entry, matchedParams: mergeMatchedParams(sourceParams, params) };
-    }
-  }
-  return null;
+  return __routeMatcher.findIntercept(pathname, sourcePathname);
 }
 
 async function buildPageElements(route, params, routePath, pageRequest) {
@@ -6254,7 +6023,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     var _metaParams = null;
     if (metaRoute.patternParts) {
       var _metaUrlParts = cleanPathname.split("/").filter(Boolean);
-      _metaParams = matchPattern(_metaUrlParts, metaRoute.patternParts);
+      _metaParams = __matchAppRscRoutePattern(_metaUrlParts, metaRoute.patternParts);
       if (!_metaParams) continue;
     } else if (cleanPathname !== metaRoute.servedUrl) {
       continue;
@@ -7309,7 +7078,10 @@ import { _consumeRequestScopedCacheLife, getCacheHandler } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
 import { setRootParams as __setRootParams, pickRootParams as __pickRootParams } from "<ROOT>/packages/vinext/src/shims/root-params.js";
 import { ensureFetchPatch as _ensureFetchPatch, getCollectedFetchTags, setCurrentFetchSoftTags } from "vinext/fetch-cache";
-import { buildRouteTrie as _buildRouteTrie, trieMatch as _trieMatch } from "<ROOT>/packages/vinext/src/routing/route-trie.js";
+import {
+  createAppRscRouteMatcher as __createAppRscRouteMatcher,
+  matchAppRscRoutePattern as __matchAppRscRoutePattern,
+} from "<ROOT>/packages/vinext/src/server/app-rsc-route-matching.js";
 // Import server-only state module to register ALS-backed accessors.
 import "vinext/navigation-state";
 import { runWithRequestContext as _runWithUnifiedCtx, createRequestContext as _createUnifiedCtx } from "vinext/unified-request-context";
@@ -7480,11 +7252,11 @@ const __classDebug = process.env.VINEXT_DEBUG_CLASSIFICATION
     }
   : undefined;
 
-// Normalize null-prototype objects from matchPattern() into thenable objects
+// Normalize null-prototype objects from route-pattern matching into thenable objects
 // that work both as Promises (for Next.js 15+ async params) and as plain
 // objects with synchronous property access (for pre-15 code like params.id).
 //
-// matchPattern() uses Object.create(null), producing objects without
+// route-pattern matching uses Object.create(null), producing objects without
 // Object.prototype. The RSC serializer rejects these. Spreading ({...obj})
 // restores a normal prototype. Object.assign onto the Promise preserves
 // synchronous property access (params.id, params.slug) that existing
@@ -7782,7 +7554,7 @@ const routes = [
     unauthorized: null,
   }
 ];
-const _routeTrie = _buildRouteTrie(routes);
+const __routeMatcher = __createAppRscRouteMatcher(routes);
 
 const metadataRoutes = [
 
@@ -7882,13 +7654,7 @@ async function renderErrorBoundaryPage(route, error, isRscRequest, request, matc
 }
 
 function matchRoute(url) {
-  const pathname = url.split("?")[0];
-  let normalizedUrl = pathname === "/" ? "/" : pathname.replace(/\\/$/, "");
-   // NOTE: Do NOT decodeURIComponent here. The caller is responsible for decoding
-   // the pathname exactly once at the request entry point. Decoding again here
-   // would cause inconsistent path matching between middleware and routing.
-  const urlParts = normalizedUrl.split("/").filter(Boolean);
-  return _trieMatch(_routeTrie, urlParts);
+  return __routeMatcher.matchRoute(url);
 }
 
 function __createStaticFileSignal(pathname, _mwCtx) {
@@ -7906,86 +7672,12 @@ function __createStaticFileSignal(pathname, _mwCtx) {
   });
 }
 
-// matchPattern is kept for findIntercept (linear scan over small interceptLookup array).
-function matchPattern(urlParts, patternParts) {
-  const params = Object.create(null);
-  for (let i = 0; i < patternParts.length; i++) {
-    const pp = patternParts[i];
-    if (pp.endsWith("+")) {
-      if (i !== patternParts.length - 1) return null;
-      const paramName = pp.slice(1, -1);
-      const remaining = urlParts.slice(i);
-      if (remaining.length === 0) return null;
-      params[paramName] = remaining;
-      return params;
-    }
-    if (pp.endsWith("*")) {
-      if (i !== patternParts.length - 1) return null;
-      const paramName = pp.slice(1, -1);
-      params[paramName] = urlParts.slice(i);
-      return params;
-    }
-    if (pp.startsWith(":")) {
-      if (i >= urlParts.length) return null;
-      params[pp.slice(1)] = urlParts[i];
-      continue;
-    }
-    if (i >= urlParts.length || urlParts[i] !== pp) return null;
-  }
-  if (urlParts.length !== patternParts.length) return null;
-  return params;
-}
-
-function mergeMatchedParams(sourceParams, targetParams) {
-  return Object.assign(Object.create(null), sourceParams, targetParams);
-}
-
-// Build a global intercepting route lookup for RSC navigation.
-// Maps target URL patterns to { sourceRouteIndex, slotKey, interceptPage, interceptLayouts, params }.
-const interceptLookup = [];
-for (let ri = 0; ri < routes.length; ri++) {
-  const r = routes[ri];
-  if (!r.slots) continue;
-  for (const [slotKey, slotMod] of Object.entries(r.slots)) {
-    if (!slotMod.intercepts) continue;
-    for (const intercept of slotMod.intercepts) {
-      interceptLookup.push({
-        sourceRouteIndex: ri,
-        slotKey,
-        targetPattern: intercept.targetPattern,
-        targetPatternParts: intercept.targetPattern.split("/").filter(Boolean),
-        interceptLayouts: intercept.interceptLayouts,
-        page: intercept.page,
-        params: intercept.params,
-      });
-    }
-  }
-}
-
 /**
  * Check if a pathname matches any intercepting route.
  * Returns the match info or null.
  */
 function findIntercept(pathname, sourcePathname = null) {
-  const urlParts = pathname.split("/").filter(Boolean);
-  for (const entry of interceptLookup) {
-    const params = matchPattern(urlParts, entry.targetPatternParts);
-    if (params !== null) {
-      let sourceParams = Object.create(null);
-      if (sourcePathname !== null) {
-        const sourceRoute = routes[entry.sourceRouteIndex];
-        const sourceParts = sourcePathname.split("/").filter(Boolean);
-        const matchedSourceParams = sourceRoute
-          ? matchPattern(sourceParts, sourceRoute.patternParts)
-          : null;
-        if (matchedSourceParams !== null) {
-          sourceParams = matchedSourceParams;
-        }
-      }
-      return { ...entry, matchedParams: mergeMatchedParams(sourceParams, params) };
-    }
-  }
-  return null;
+  return __routeMatcher.findIntercept(pathname, sourcePathname);
 }
 
 async function buildPageElements(route, params, routePath, pageRequest) {
@@ -8683,7 +8375,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     var _metaParams = null;
     if (metaRoute.patternParts) {
       var _metaUrlParts = cleanPathname.split("/").filter(Boolean);
-      _metaParams = matchPattern(_metaUrlParts, metaRoute.patternParts);
+      _metaParams = __matchAppRscRoutePattern(_metaUrlParts, metaRoute.patternParts);
       if (!_metaParams) continue;
     } else if (cleanPathname !== metaRoute.servedUrl) {
       continue;
@@ -9738,7 +9430,10 @@ import { _consumeRequestScopedCacheLife, getCacheHandler } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
 import { setRootParams as __setRootParams, pickRootParams as __pickRootParams } from "<ROOT>/packages/vinext/src/shims/root-params.js";
 import { ensureFetchPatch as _ensureFetchPatch, getCollectedFetchTags, setCurrentFetchSoftTags } from "vinext/fetch-cache";
-import { buildRouteTrie as _buildRouteTrie, trieMatch as _trieMatch } from "<ROOT>/packages/vinext/src/routing/route-trie.js";
+import {
+  createAppRscRouteMatcher as __createAppRscRouteMatcher,
+  matchAppRscRoutePattern as __matchAppRscRoutePattern,
+} from "<ROOT>/packages/vinext/src/server/app-rsc-route-matching.js";
 // Import server-only state module to register ALS-backed accessors.
 import "vinext/navigation-state";
 import { runWithRequestContext as _runWithUnifiedCtx, createRequestContext as _createUnifiedCtx } from "vinext/unified-request-context";
@@ -9909,11 +9604,11 @@ const __classDebug = process.env.VINEXT_DEBUG_CLASSIFICATION
     }
   : undefined;
 
-// Normalize null-prototype objects from matchPattern() into thenable objects
+// Normalize null-prototype objects from route-pattern matching into thenable objects
 // that work both as Promises (for Next.js 15+ async params) and as plain
 // objects with synchronous property access (for pre-15 code like params.id).
 //
-// matchPattern() uses Object.create(null), producing objects without
+// route-pattern matching uses Object.create(null), producing objects without
 // Object.prototype. The RSC serializer rejects these. Spreading ({...obj})
 // restores a normal prototype. Object.assign onto the Promise preserves
 // synchronous property access (params.id, params.slug) that existing
@@ -10182,7 +9877,7 @@ const routes = [
     unauthorized: null,
   }
 ];
-const _routeTrie = _buildRouteTrie(routes);
+const __routeMatcher = __createAppRscRouteMatcher(routes);
 
 const metadataRoutes = [
   {
@@ -10288,13 +9983,7 @@ async function renderErrorBoundaryPage(route, error, isRscRequest, request, matc
 }
 
 function matchRoute(url) {
-  const pathname = url.split("?")[0];
-  let normalizedUrl = pathname === "/" ? "/" : pathname.replace(/\\/$/, "");
-   // NOTE: Do NOT decodeURIComponent here. The caller is responsible for decoding
-   // the pathname exactly once at the request entry point. Decoding again here
-   // would cause inconsistent path matching between middleware and routing.
-  const urlParts = normalizedUrl.split("/").filter(Boolean);
-  return _trieMatch(_routeTrie, urlParts);
+  return __routeMatcher.matchRoute(url);
 }
 
 function __createStaticFileSignal(pathname, _mwCtx) {
@@ -10312,86 +10001,12 @@ function __createStaticFileSignal(pathname, _mwCtx) {
   });
 }
 
-// matchPattern is kept for findIntercept (linear scan over small interceptLookup array).
-function matchPattern(urlParts, patternParts) {
-  const params = Object.create(null);
-  for (let i = 0; i < patternParts.length; i++) {
-    const pp = patternParts[i];
-    if (pp.endsWith("+")) {
-      if (i !== patternParts.length - 1) return null;
-      const paramName = pp.slice(1, -1);
-      const remaining = urlParts.slice(i);
-      if (remaining.length === 0) return null;
-      params[paramName] = remaining;
-      return params;
-    }
-    if (pp.endsWith("*")) {
-      if (i !== patternParts.length - 1) return null;
-      const paramName = pp.slice(1, -1);
-      params[paramName] = urlParts.slice(i);
-      return params;
-    }
-    if (pp.startsWith(":")) {
-      if (i >= urlParts.length) return null;
-      params[pp.slice(1)] = urlParts[i];
-      continue;
-    }
-    if (i >= urlParts.length || urlParts[i] !== pp) return null;
-  }
-  if (urlParts.length !== patternParts.length) return null;
-  return params;
-}
-
-function mergeMatchedParams(sourceParams, targetParams) {
-  return Object.assign(Object.create(null), sourceParams, targetParams);
-}
-
-// Build a global intercepting route lookup for RSC navigation.
-// Maps target URL patterns to { sourceRouteIndex, slotKey, interceptPage, interceptLayouts, params }.
-const interceptLookup = [];
-for (let ri = 0; ri < routes.length; ri++) {
-  const r = routes[ri];
-  if (!r.slots) continue;
-  for (const [slotKey, slotMod] of Object.entries(r.slots)) {
-    if (!slotMod.intercepts) continue;
-    for (const intercept of slotMod.intercepts) {
-      interceptLookup.push({
-        sourceRouteIndex: ri,
-        slotKey,
-        targetPattern: intercept.targetPattern,
-        targetPatternParts: intercept.targetPattern.split("/").filter(Boolean),
-        interceptLayouts: intercept.interceptLayouts,
-        page: intercept.page,
-        params: intercept.params,
-      });
-    }
-  }
-}
-
 /**
  * Check if a pathname matches any intercepting route.
  * Returns the match info or null.
  */
 function findIntercept(pathname, sourcePathname = null) {
-  const urlParts = pathname.split("/").filter(Boolean);
-  for (const entry of interceptLookup) {
-    const params = matchPattern(urlParts, entry.targetPatternParts);
-    if (params !== null) {
-      let sourceParams = Object.create(null);
-      if (sourcePathname !== null) {
-        const sourceRoute = routes[entry.sourceRouteIndex];
-        const sourceParts = sourcePathname.split("/").filter(Boolean);
-        const matchedSourceParams = sourceRoute
-          ? matchPattern(sourceParts, sourceRoute.patternParts)
-          : null;
-        if (matchedSourceParams !== null) {
-          sourceParams = matchedSourceParams;
-        }
-      }
-      return { ...entry, matchedParams: mergeMatchedParams(sourceParams, params) };
-    }
-  }
-  return null;
+  return __routeMatcher.findIntercept(pathname, sourcePathname);
 }
 
 async function buildPageElements(route, params, routePath, pageRequest) {
@@ -11086,7 +10701,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     var _metaParams = null;
     if (metaRoute.patternParts) {
       var _metaUrlParts = cleanPathname.split("/").filter(Boolean);
-      _metaParams = matchPattern(_metaUrlParts, metaRoute.patternParts);
+      _metaParams = __matchAppRscRoutePattern(_metaUrlParts, metaRoute.patternParts);
       if (!_metaParams) continue;
     } else if (cleanPathname !== metaRoute.servedUrl) {
       continue;
@@ -12141,7 +11756,10 @@ import { _consumeRequestScopedCacheLife, getCacheHandler } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
 import { setRootParams as __setRootParams, pickRootParams as __pickRootParams } from "<ROOT>/packages/vinext/src/shims/root-params.js";
 import { ensureFetchPatch as _ensureFetchPatch, getCollectedFetchTags, setCurrentFetchSoftTags } from "vinext/fetch-cache";
-import { buildRouteTrie as _buildRouteTrie, trieMatch as _trieMatch } from "<ROOT>/packages/vinext/src/routing/route-trie.js";
+import {
+  createAppRscRouteMatcher as __createAppRscRouteMatcher,
+  matchAppRscRoutePattern as __matchAppRscRoutePattern,
+} from "<ROOT>/packages/vinext/src/server/app-rsc-route-matching.js";
 // Import server-only state module to register ALS-backed accessors.
 import "vinext/navigation-state";
 import { runWithRequestContext as _runWithUnifiedCtx, createRequestContext as _createUnifiedCtx } from "vinext/unified-request-context";
@@ -12312,11 +11930,11 @@ const __classDebug = process.env.VINEXT_DEBUG_CLASSIFICATION
     }
   : undefined;
 
-// Normalize null-prototype objects from matchPattern() into thenable objects
+// Normalize null-prototype objects from route-pattern matching into thenable objects
 // that work both as Promises (for Next.js 15+ async params) and as plain
 // objects with synchronous property access (for pre-15 code like params.id).
 //
-// matchPattern() uses Object.create(null), producing objects without
+// route-pattern matching uses Object.create(null), producing objects without
 // Object.prototype. The RSC serializer rejects these. Spreading ({...obj})
 // restores a normal prototype. Object.assign onto the Promise preserves
 // synchronous property access (params.id, params.slug) that existing
@@ -12584,7 +12202,7 @@ const routes = [
     unauthorized: null,
   }
 ];
-const _routeTrie = _buildRouteTrie(routes);
+const __routeMatcher = __createAppRscRouteMatcher(routes);
 
 const metadataRoutes = [
 
@@ -12684,13 +12302,7 @@ async function renderErrorBoundaryPage(route, error, isRscRequest, request, matc
 }
 
 function matchRoute(url) {
-  const pathname = url.split("?")[0];
-  let normalizedUrl = pathname === "/" ? "/" : pathname.replace(/\\/$/, "");
-   // NOTE: Do NOT decodeURIComponent here. The caller is responsible for decoding
-   // the pathname exactly once at the request entry point. Decoding again here
-   // would cause inconsistent path matching between middleware and routing.
-  const urlParts = normalizedUrl.split("/").filter(Boolean);
-  return _trieMatch(_routeTrie, urlParts);
+  return __routeMatcher.matchRoute(url);
 }
 
 function __createStaticFileSignal(pathname, _mwCtx) {
@@ -12708,86 +12320,12 @@ function __createStaticFileSignal(pathname, _mwCtx) {
   });
 }
 
-// matchPattern is kept for findIntercept (linear scan over small interceptLookup array).
-function matchPattern(urlParts, patternParts) {
-  const params = Object.create(null);
-  for (let i = 0; i < patternParts.length; i++) {
-    const pp = patternParts[i];
-    if (pp.endsWith("+")) {
-      if (i !== patternParts.length - 1) return null;
-      const paramName = pp.slice(1, -1);
-      const remaining = urlParts.slice(i);
-      if (remaining.length === 0) return null;
-      params[paramName] = remaining;
-      return params;
-    }
-    if (pp.endsWith("*")) {
-      if (i !== patternParts.length - 1) return null;
-      const paramName = pp.slice(1, -1);
-      params[paramName] = urlParts.slice(i);
-      return params;
-    }
-    if (pp.startsWith(":")) {
-      if (i >= urlParts.length) return null;
-      params[pp.slice(1)] = urlParts[i];
-      continue;
-    }
-    if (i >= urlParts.length || urlParts[i] !== pp) return null;
-  }
-  if (urlParts.length !== patternParts.length) return null;
-  return params;
-}
-
-function mergeMatchedParams(sourceParams, targetParams) {
-  return Object.assign(Object.create(null), sourceParams, targetParams);
-}
-
-// Build a global intercepting route lookup for RSC navigation.
-// Maps target URL patterns to { sourceRouteIndex, slotKey, interceptPage, interceptLayouts, params }.
-const interceptLookup = [];
-for (let ri = 0; ri < routes.length; ri++) {
-  const r = routes[ri];
-  if (!r.slots) continue;
-  for (const [slotKey, slotMod] of Object.entries(r.slots)) {
-    if (!slotMod.intercepts) continue;
-    for (const intercept of slotMod.intercepts) {
-      interceptLookup.push({
-        sourceRouteIndex: ri,
-        slotKey,
-        targetPattern: intercept.targetPattern,
-        targetPatternParts: intercept.targetPattern.split("/").filter(Boolean),
-        interceptLayouts: intercept.interceptLayouts,
-        page: intercept.page,
-        params: intercept.params,
-      });
-    }
-  }
-}
-
 /**
  * Check if a pathname matches any intercepting route.
  * Returns the match info or null.
  */
 function findIntercept(pathname, sourcePathname = null) {
-  const urlParts = pathname.split("/").filter(Boolean);
-  for (const entry of interceptLookup) {
-    const params = matchPattern(urlParts, entry.targetPatternParts);
-    if (params !== null) {
-      let sourceParams = Object.create(null);
-      if (sourcePathname !== null) {
-        const sourceRoute = routes[entry.sourceRouteIndex];
-        const sourceParts = sourcePathname.split("/").filter(Boolean);
-        const matchedSourceParams = sourceRoute
-          ? matchPattern(sourceParts, sourceRoute.patternParts)
-          : null;
-        if (matchedSourceParams !== null) {
-          sourceParams = matchedSourceParams;
-        }
-      }
-      return { ...entry, matchedParams: mergeMatchedParams(sourceParams, params) };
-    }
-  }
-  return null;
+  return __routeMatcher.findIntercept(pathname, sourcePathname);
 }
 
 async function buildPageElements(route, params, routePath, pageRequest) {
@@ -13849,7 +13387,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     var _metaParams = null;
     if (metaRoute.patternParts) {
       var _metaUrlParts = cleanPathname.split("/").filter(Boolean);
-      _metaParams = matchPattern(_metaUrlParts, metaRoute.patternParts);
+      _metaParams = __matchAppRscRoutePattern(_metaUrlParts, metaRoute.patternParts);
       if (!_metaParams) continue;
     } else if (cleanPathname !== metaRoute.servedUrl) {
       continue;

--- a/tests/app-rsc-route-matching.test.ts
+++ b/tests/app-rsc-route-matching.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  createAppRscRouteMatcher,
+  matchAppRscRoutePattern,
+} from "../packages/vinext/src/server/app-rsc-route-matching.js";
+
+describe("App RSC route matching", () => {
+  it("matches app routes through the shared route trie", () => {
+    const matcher = createAppRscRouteMatcher([
+      route("/", []),
+      route("/blog/:slug", ["blog", ":slug"]),
+      route("/docs/:path+", ["docs", ":path+"]),
+      route("/shop/:path*", ["shop", ":path*"]),
+    ]);
+
+    expect(matcher.matchRoute("/blog/hello-world/")).toMatchObject({
+      route: { pattern: "/blog/:slug" },
+      params: { slug: "hello-world" },
+    });
+    expect(matcher.matchRoute("/docs")).toBeNull();
+    expect(matcher.matchRoute("/docs/guides/rsc")).toMatchObject({
+      route: { pattern: "/docs/:path+" },
+      params: { path: ["guides", "rsc"] },
+    });
+    expect(matcher.matchRoute("/shop")).toMatchObject({
+      route: { pattern: "/shop/:path*" },
+      params: { path: [] },
+    });
+  });
+
+  it("does not decode path segments during route matching", () => {
+    const matcher = createAppRscRouteMatcher([route("/files/:name", ["files", ":name"])]);
+
+    expect(matcher.matchRoute("/files/a%2Fb")).toMatchObject({
+      params: { name: "a%2Fb" },
+    });
+  });
+
+  it("matches standalone route patterns for dynamic metadata routes", () => {
+    expect(
+      matchAppRscRoutePattern(["blog", "hello", "sitemap.xml"], ["blog", ":slug", "sitemap.xml"]),
+    ).toMatchObject({
+      slug: "hello",
+    });
+  });
+
+  it("treats static segments ending in plus or star as literals", () => {
+    expect(matchAppRscRoutePattern(["c++", "intro"], ["c++", ":slug"])).toMatchObject({
+      slug: "intro",
+    });
+
+    const starResult = matchAppRscRoutePattern(["file*"], ["file*"]);
+    expect(starResult).not.toBeNull();
+    expect(Object.keys(starResult ?? {})).toEqual([]);
+  });
+
+  it("finds intercepting routes and merges source and target params", () => {
+    const matcher = createAppRscRouteMatcher([
+      route("/feed/:id", ["feed", ":id"], {
+        modal: {
+          intercepts: [
+            {
+              targetPattern: "/photos/:id",
+              interceptLayouts: ["modal-layout"],
+              page: "photo-page",
+              params: ["id"],
+            },
+          ],
+        },
+      }),
+    ]);
+
+    expect(matcher.findIntercept("/photos/target-id", "/feed/source-id")).toMatchObject({
+      sourceRouteIndex: 0,
+      slotKey: "modal",
+      targetPattern: "/photos/:id",
+      page: "photo-page",
+      matchedParams: { id: "target-id" },
+    });
+  });
+});
+
+function route(
+  pattern: string,
+  patternParts: string[],
+  slots?: Record<string, { intercepts?: TestIntercept[] }>,
+): TestRoute {
+  return {
+    pattern,
+    patternParts,
+    slots,
+  };
+}
+
+type TestRoute = {
+  pattern: string;
+  patternParts: string[];
+  slots?: Record<string, { intercepts?: TestIntercept[] }>;
+};
+
+type TestIntercept = {
+  targetPattern: string;
+  interceptLayouts: readonly unknown[];
+  page: unknown;
+  params: string[];
+};

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -233,6 +233,20 @@ describe("App Router entry templates", () => {
     expect(stabilize(code)).toMatchSnapshot();
   });
 
+  it("generateRscEntry delegates route matching to the shared helper", () => {
+    const code = generateRscEntry("/tmp/test/app", minimalAppRoutes, null, [], null, "", false);
+    const stableCode = stabilize(code);
+
+    expect(stableCode).toContain(
+      'from "<ROOT>/packages/vinext/src/server/app-rsc-route-matching.js";',
+    );
+    expect(code).toContain("const __routeMatcher = __createAppRscRouteMatcher(routes);");
+    expect(code).toContain("return __routeMatcher.matchRoute(url);");
+    expect(code).toContain("return __routeMatcher.findIntercept(pathname, sourcePathname);");
+    expect(code).not.toContain("const interceptLookup = [];");
+    expect(code).not.toContain("function mergeMatchedParams(");
+  });
+
   it("generateRscEntry uses buildPageElements in the server-action re-render path", () => {
     const code = generateRscEntry("/tmp/test/app", minimalAppRoutes, null, [], null, "", false);
     // PR 2c returns the flat elements payload instead of the monolithic page


### PR DESCRIPTION
## What this changes
Moves App Router RSC route matching, intercept lookup construction, intercept param merging, and dynamic metadata route pattern matching out of the generated RSC entry and into `server/app-rsc-route-matching.ts`.

This PR is independent of #952 and is based on `main`. It may conflict lightly with other `app-rsc-entry.ts` refactors if they merge first, but it does not require the stream-hints PR to land.

## Why
`app-rsc-entry.ts` still owned request-path matching behavior inside generated source strings. That made the behavior hard to unit test directly and kept real runtime logic in the codegen layer.

## Approach
- Add a typed runtime helper for RSC route matching and intercept matching.
- Keep unavoidable route import and manifest emission in the generator, since route modules need generated import bindings.
- Delegate generated `matchRoute`, `findIntercept`, and dynamic metadata route pattern matching to the helper.
- Replace the earlier string-emitter extraction with focused helper tests and entry-template delegation assertions.

## Validation
- `vp test run tests/app-rsc-route-matching.test.ts tests/entry-templates.test.ts`
- `vp check packages/vinext/src/server/app-rsc-route-matching.ts packages/vinext/src/entries/app-rsc-entry.ts tests/app-rsc-route-matching.test.ts tests/entry-templates.test.ts tests/__snapshots__/entry-templates.test.ts.snap`
- `vp run vinext#build`

Build completed with the existing unresolved virtual import warnings for vinext virtual modules.

## Risks / follow-ups
This keeps route manifest import emission in `app-rsc-entry.ts` because those generated imports still need lexical module bindings. A later slice can target another runtime subsystem, but this PR avoids metadata emission, ISR, middleware, actions, and boundary behavior.