### PR TITLE
fix(app-routes): preserve returned cookie precedence

### DIFF
--- a/packages/vinext/src/server/app-route-handler-response.ts
+++ b/packages/vinext/src/server/app-route-handler-response.ts
@@ -113,6 +113,54 @@ export function markRouteHandlerCacheMiss(response: Response): void {
   response.headers.set("X-Vinext-Cache", "MISS");
 }
 
+function getSetCookieName(cookie: string): string | null {
+  const equalsIndex = cookie.indexOf("=");
+  if (equalsIndex <= 0) {
+    return null;
+  }
+  return cookie.slice(0, equalsIndex);
+}
+
+function applyMutableCookieFallbacks(headers: Headers, pendingCookies: string[]): void {
+  if (pendingCookies.length === 0) {
+    return;
+  }
+
+  const returnedCookies = headers.getSetCookie();
+  const returnedCookieNames = new Set<string>();
+  for (const cookie of returnedCookies) {
+    const name = getSetCookieName(cookie);
+    if (name) {
+      returnedCookieNames.add(name);
+    }
+  }
+
+  const fallbackCookies = new Map<string, string>();
+  const unkeyedFallbackCookies: string[] = [];
+  for (const cookie of pendingCookies) {
+    const name = getSetCookieName(cookie);
+    if (!name) {
+      unkeyedFallbackCookies.push(cookie);
+      continue;
+    }
+
+    if (!returnedCookieNames.has(name)) {
+      fallbackCookies.set(name, cookie);
+    }
+  }
+
+  headers.delete("Set-Cookie");
+  for (const cookie of unkeyedFallbackCookies) {
+    headers.append("Set-Cookie", cookie);
+  }
+  for (const cookie of fallbackCookies.values()) {
+    headers.append("Set-Cookie", cookie);
+  }
+  for (const cookie of returnedCookies) {
+    headers.append("Set-Cookie", cookie);
+  }
+}
+
 export async function buildAppRouteCacheValue(response: Response): Promise<CachedRouteValue> {
   const body = await response.arrayBuffer();
   const headers: CachedRouteValue["headers"] = {};
@@ -144,9 +192,7 @@ export function finalizeRouteHandlerResponse(
   }
 
   const headers = new Headers(response.headers);
-  for (const cookie of pendingCookies) {
-    headers.append("Set-Cookie", cookie);
-  }
+  applyMutableCookieFallbacks(headers, pendingCookies);
   if (draftCookie) {
     headers.append("Set-Cookie", draftCookie);
   }

--- a/tests/app-route-handler-response.test.ts
+++ b/tests/app-route-handler-response.test.ts
@@ -210,6 +210,35 @@ describe("app route handler response helpers", () => {
     await expect(result.text()).resolves.toBe("");
   });
 
+  it("uses mutable cookies as fallbacks and keeps returned response cookies final", async () => {
+    // Matches Next.js appendMutableCookies:
+    // packages/next/src/server/web/spec-extension/adapters/request-cookies.ts
+    // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/web/spec-extension/adapters/request-cookies.ts
+    const response = new Response("body", {
+      headers: [
+        ["Set-Cookie", "session=returned; Path=/; HttpOnly"],
+        ["Set-Cookie", "response-only=1; Path=/"],
+      ],
+    });
+
+    const result = finalizeRouteHandlerResponse(response, {
+      pendingCookies: [
+        "session=mutable; Path=/",
+        "mutable-only=first; Path=/",
+        "mutable-only=final; Path=/; Secure",
+      ],
+      draftCookie: null,
+      isHead: false,
+    });
+
+    expect(result.headers.getSetCookie()).toEqual([
+      "mutable-only=final; Path=/; Secure",
+      "session=returned; Path=/; HttpOnly",
+      "response-only=1; Path=/",
+    ]);
+    await expect(result.text()).resolves.toBe("body");
+  });
+
   it("applies revalidate and MISS headers separately", () => {
     const response = new Response("hello");
 

--- a/tests/fixtures/app-basic/app/nextjs-compat/api/cookie-precedence/route.ts
+++ b/tests/fixtures/app-basic/app/nextjs-compat/api/cookie-precedence/route.ts
@@ -1,0 +1,14 @@
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  const jar = await cookies();
+  jar.set("session", "mutable", { path: "/" });
+  jar.set("mutable-only", "first", { path: "/" });
+  jar.set("mutable-only", "final", { path: "/", secure: true });
+
+  const response = NextResponse.json({ ok: true });
+  response.cookies.set("session", "returned", { path: "/", httpOnly: true });
+  response.cookies.set("response-only", "1", { path: "/" });
+  return response;
+}

--- a/tests/nextjs-compat/set-cookies.test.ts
+++ b/tests/nextjs-compat/set-cookies.test.ts
@@ -63,6 +63,21 @@ describe("Next.js compat: set-cookies", () => {
     expect(setCookies.some((c) => c.includes("theme=dark"))).toBe(true);
   });
 
+  it("returned response cookies take precedence over mutable cookies with the same name", async () => {
+    // Next.js app route handlers merge mutable cookies as fallbacks before
+    // reapplying returned response cookies as the final values.
+    // Source: https://github.com/vercel/next.js/blob/canary/packages/next/src/server/web/spec-extension/adapters/request-cookies.ts
+    const res = await fetch(`${baseUrl}/nextjs-compat/api/cookie-precedence`);
+    const setCookies = res.headers.getSetCookie();
+
+    expect(setCookies).toHaveLength(3);
+    expect(setCookies.some((c) => c.startsWith("session=returned;"))).toBe(true);
+    expect(setCookies.some((c) => c.startsWith("response-only=1;"))).toBe(true);
+    expect(setCookies.some((c) => c.startsWith("mutable-only=final;"))).toBe(true);
+    expect(setCookies.some((c) => c.startsWith("session=mutable;"))).toBe(false);
+    expect(setCookies.some((c) => c.startsWith("mutable-only=first;"))).toBe(false);
+  });
+
   // ── cookies().delete() ──────────────────────────────────────
   // Next.js: deleting a cookie produces Set-Cookie with Max-Age=0
 


### PR DESCRIPTION
## What this changes
App Route handler finalization now treats cookies produced by `cookies().set()` as fallback `Set-Cookie` values. Cookies already present on the returned `Response` are re-applied last, so same-name returned response cookies remain the final values.

## Why
vinext previously cloned the returned response headers and appended pending mutable cookies afterward. When a route both mutates `cookies()` and returns a `Response` or `NextResponse` with a cookie of the same name, the mutable cookie appeared later in `Set-Cookie` order and could override the returned response cookie.

Next.js does the opposite. Its `appendMutableCookies` helper records returned response cookies, sets mutable cookies as fallbacks, then sets the original returned cookies as final values: https://github.com/vercel/next.js/blob/canary/packages/next/src/server/web/spec-extension/adapters/request-cookies.ts#L72-L98

The App Route module calls that helper after a handler returns a `Response`: https://github.com/vercel/next.js/blob/canary/packages/next/src/server/route-modules/app-route/module.ts#L783-L792

## Approach
The finalizer now extracts returned `Set-Cookie` names, deduplicates pending mutable cookies by name so the last mutation wins, skips mutable cookies shadowed by returned response cookies, and then writes fallbacks before the returned response cookies. This mirrors Next.js without normalizing cookie attributes or changing unrelated header behavior.

## Validation
- `vp test run tests/app-route-handler-response.test.ts tests/nextjs-compat/set-cookies.test.ts`
- `vp check packages/vinext/src/server/app-route-handler-response.ts tests/app-route-handler-response.test.ts tests/nextjs-compat/set-cookies.test.ts tests/fixtures/app-basic/app/nextjs-compat/api/cookie-precedence/route.ts`

## Risks / follow-ups
This is scoped to App Route handler response finalization. Server Action redirect cookie paths already have no returned response cookie to merge against, so they are intentionally outside this change.