### PR TITLE
fix(fonts): stabilize next/font/google runtime registrations

### DIFF
--- a/packages/vinext/src/shims/font-google-base.ts
+++ b/packages/vinext/src/shims/font-google-base.ts
@@ -109,7 +109,11 @@ function toVarName(family: string): string {
 }
 
 function fontClassSegment(family: string): string {
-  return family.toLowerCase().replace(/\s+/g, "_");
+  const segment = family
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+  return segment || "font";
 }
 
 function normalizeStringOption(value: string | string[] | undefined): string {
@@ -150,7 +154,7 @@ function createFontIdentity(
       normalizeStringOption(options.weight),
       normalizeStringOption(options.style),
       normalizeStringOption(options.subsets),
-      options.display ?? "",
+      options.display ?? "swap",
       normalizeBooleanOption(options.preload),
       normalizeStringOption(options.fallback),
       normalizeStringOrBooleanOption(options.adjustFontFallback),

--- a/packages/vinext/src/shims/font-google-base.ts
+++ b/packages/vinext/src/shims/font-google-base.ts
@@ -14,9 +14,9 @@ import { buildGoogleFontsUrl as buildUrlFromAxes } from "../build/google-fonts/b
  * Usage:
  *   import { Inter } from 'next/font/google';
  *   const inter = Inter({ subsets: ['latin'], weight: ['400', '700'] });
- *   // inter.className -> unique CSS class
+ *   // inter.className -> stable CSS class for this font/options pair
  *   // inter.style -> { fontFamily: "'Inter', sans-serif" }
- *   // inter.variable -> CSS variable name like '--font-inter'
+ *   // inter.variable -> CSS class that sets the font CSS variable
  */
 
 /**
@@ -77,9 +77,6 @@ function sanitizeFallback(name: string): string {
   return `'${escapeCSSString(trimmed)}'`;
 }
 
-// Counter for generating unique class names
-let classCounter = 0;
-
 // Track which font stylesheets have been injected (SSR + client)
 const injectedFonts = new Set<string>();
 
@@ -101,12 +98,66 @@ export type FontResult = {
   variable?: string;
 };
 
+type FontLoaderOptions = FontOptions & { _selfHostedCSS?: string };
+
 /**
  * Convert a font family name to a CSS variable name.
  * e.g., "Inter" -> "--font-inter", "Roboto Mono" -> "--font-roboto-mono"
  */
 function toVarName(family: string): string {
   return "--font-" + family.toLowerCase().replace(/\s+/g, "-");
+}
+
+function fontClassSegment(family: string): string {
+  return family.toLowerCase().replace(/\s+/g, "_");
+}
+
+function normalizeStringOption(value: string | string[] | undefined): string {
+  if (!value) return "";
+  return (Array.isArray(value) ? value : [value]).join(",");
+}
+
+function normalizeBooleanOption(value: boolean | undefined): string {
+  if (value === undefined) return "";
+  return value ? "1" : "0";
+}
+
+function normalizeStringOrBooleanOption(value: boolean | string | undefined): string {
+  if (value === undefined) return "";
+  return typeof value === "boolean" ? normalizeBooleanOption(value) : value;
+}
+
+function hashString(value: string): string {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < value.length; i++) {
+    hash ^= value.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash.toString(36).padStart(7, "0");
+}
+
+function createFontIdentity(
+  family: string,
+  options: FontLoaderOptions,
+  cssVarName: string,
+  fontFamily: string,
+): string {
+  return hashString(
+    [
+      family,
+      fontFamily,
+      cssVarName,
+      normalizeStringOption(options.weight),
+      normalizeStringOption(options.style),
+      normalizeStringOption(options.subsets),
+      options.display ?? "",
+      normalizeBooleanOption(options.preload),
+      normalizeStringOption(options.fallback),
+      normalizeStringOrBooleanOption(options.adjustFontFallback),
+      normalizeStringOption(options.axes),
+      options._selfHostedCSS ?? "",
+    ].join("\0"),
+  );
 }
 
 /**
@@ -212,9 +263,6 @@ function injectClassNameRule(className: string, fontFamily: string): void {
 /** Track which variable class CSS rules have been injected. */
 const injectedVariableRules = new Set<string>();
 
-/** Track which :root CSS variable rules have been injected. */
-const injectedRootVariables = new Set<string>();
-
 /**
  * Inject a CSS rule that sets a CSS variable on an element.
  * This is what makes `<html className={inter.variable}>` set the CSS variable
@@ -236,15 +284,7 @@ function injectVariableClassRule(
 
   // Only set the CSS variable — do NOT set font-family.
   // This matches Next.js behavior where .variable classes only define CSS variables.
-  let css = `.${variableClassName} { ${cssVarName}: ${fontFamily}; }\n`;
-
-  // Also inject at :root so CSS variable inheritance works throughout the page.
-  // This ensures Tailwind utilities like `font-sans` that reference these
-  // variables via var(--font-geist-sans) work correctly.
-  if (!injectedRootVariables.has(cssVarName)) {
-    injectedRootVariables.add(cssVarName);
-    css += `:root { ${cssVarName}: ${fontFamily}; }\n`;
-  }
+  const css = `.${variableClassName} { ${cssVarName}: ${fontFamily}; }\n`;
 
   // On server, store the CSS for SSR injection
   if (typeof document === "undefined") {
@@ -368,12 +408,10 @@ function injectSelfHostedCSS(css: string): void {
   document.head.appendChild(style);
 }
 
-export type FontLoader = (options?: FontOptions & { _selfHostedCSS?: string }) => FontResult;
+export type FontLoader = (options?: FontLoaderOptions) => FontResult;
 
 export function createFontLoader(family: string): FontLoader {
-  return function fontLoader(options: FontOptions & { _selfHostedCSS?: string } = {}): FontResult {
-    const id = classCounter++;
-    const className = `__font_${family.toLowerCase().replace(/\s+/g, "_")}_${id}`;
+  return function fontLoader(options: FontLoaderOptions = {}): FontResult {
     const fallback = options.fallback ?? ["sans-serif"];
     // Sanitize each fallback name to prevent CSS injection via crafted values
     const fontFamily = `'${escapeCSSString(family)}', ${fallback.map(sanitizeFallback).join(", ")}`;
@@ -383,9 +421,12 @@ export function createFontLoader(family: string): FontLoader {
     const cssVarName = options.variable
       ? (sanitizeCSSVarName(options.variable) ?? defaultVarName)
       : defaultVarName;
+    const id = createFontIdentity(family, options, cssVarName, fontFamily);
+    const classSegment = fontClassSegment(family);
+    const className = `__font_${classSegment}_${id}`;
     // In Next.js, `variable` returns a CLASS NAME that sets the CSS variable.
     // Users apply this class to set the CSS variable on that element.
-    const variableClassName = `__variable_${family.toLowerCase().replace(/\s+/g, "_")}_${id}`;
+    const variableClassName = `__variable_${classSegment}_${id}`;
 
     if (options._selfHostedCSS) {
       // Self-hosted mode: inject local @font-face CSS instead of CDN link
@@ -422,8 +463,11 @@ export function createFontLoader(family: string): FontLoader {
 // Export a Proxy that creates font loaders for any Google Font family.
 // Usage: import { Inter } from 'next/font/google'
 // The proxy intercepts property access and returns a loader for that font.
-const googleFonts = new Proxy({} as Record<string, (options?: FontOptions) => FontResult>, {
-  get(_target, prop: string) {
+const googleFontLoaders: Record<string, FontLoader> = {};
+
+const googleFonts = new Proxy(googleFontLoaders, {
+  get(_target, prop: string | symbol) {
+    if (typeof prop !== "string") return undefined;
     if (prop === "__esModule") return true;
     if (prop === "default") return googleFonts;
     // Convert export-style names to proper font family names:

--- a/packages/vinext/src/shims/font-google-base.ts
+++ b/packages/vinext/src/shims/font-google-base.ts
@@ -116,9 +116,32 @@ function fontClassSegment(family: string): string {
   return segment || "font";
 }
 
-function normalizeStringOption(value: string | string[] | undefined): string {
+function normalizeStringSetOption(value: string | string[] | undefined): string {
   if (!value) return "";
-  return (Array.isArray(value) ? value : [value]).join(",");
+  const values = Array.isArray(value) ? value : [value];
+  return [...new Set(values.map((item) => item.trim()).filter(Boolean))].sort().join(",");
+}
+
+function normalizeWeightOption(value: string | string[] | undefined): string {
+  const normalized = normalizeStringSetOption(value);
+  return normalized === "variable" ? "" : normalized;
+}
+
+function normalizeStyleOption(value: string | string[] | undefined): string {
+  const values = new Set(
+    (Array.isArray(value) ? value : value ? [value] : [])
+      .map((item) => item.trim())
+      .filter(Boolean),
+  );
+  const hasItalic = values.has("italic");
+  const hasNormal = values.has("normal");
+  if (!hasItalic) return "";
+  return hasNormal ? "italic,normal" : "italic";
+}
+
+function normalizeFallbackOption(value: string[] | undefined): string {
+  if (!value) return "";
+  return value.map((item) => item.trim()).join(",");
 }
 
 function normalizeBooleanOption(value: boolean | undefined): string {
@@ -151,14 +174,14 @@ function createFontIdentity(
       family,
       fontFamily,
       cssVarName,
-      normalizeStringOption(options.weight),
-      normalizeStringOption(options.style),
-      normalizeStringOption(options.subsets),
+      normalizeWeightOption(options.weight),
+      normalizeStyleOption(options.style),
+      normalizeStringSetOption(options.subsets),
       options.display ?? "swap",
       normalizeBooleanOption(options.preload),
-      normalizeStringOption(options.fallback),
+      normalizeFallbackOption(options.fallback),
       normalizeStringOrBooleanOption(options.adjustFontFallback),
-      normalizeStringOption(options.axes),
+      normalizeStringSetOption(options.axes),
       options._selfHostedCSS ?? "",
     ].join("\0"),
   );

--- a/packages/vinext/src/shims/font-google-base.ts
+++ b/packages/vinext/src/shims/font-google-base.ts
@@ -167,19 +167,18 @@ function createFontIdentity(
   family: string,
   options: FontLoaderOptions,
   cssVarName: string,
-  fontFamily: string,
+  fallback: string[],
 ): string {
   return hashString(
     [
       family,
-      fontFamily,
       cssVarName,
       normalizeWeightOption(options.weight),
       normalizeStyleOption(options.style),
       normalizeStringSetOption(options.subsets),
       options.display ?? "swap",
       normalizeBooleanOption(options.preload),
-      normalizeFallbackOption(options.fallback),
+      normalizeFallbackOption(fallback),
       normalizeStringOrBooleanOption(options.adjustFontFallback),
       normalizeStringSetOption(options.axes),
       options._selfHostedCSS ?? "",
@@ -448,7 +447,7 @@ export function createFontLoader(family: string): FontLoader {
     const cssVarName = options.variable
       ? (sanitizeCSSVarName(options.variable) ?? defaultVarName)
       : defaultVarName;
-    const id = createFontIdentity(family, options, cssVarName, fontFamily);
+    const id = createFontIdentity(family, options, cssVarName, fallback);
     const classSegment = fontClassSegment(family);
     const className = `__font_${classSegment}_${id}`;
     // In Next.js, `variable` returns a CLASS NAME that sets the CSS variable.

--- a/tests/font-google.test.ts
+++ b/tests/font-google.test.ts
@@ -47,10 +47,10 @@ describe("next/font/google shim", () => {
     const { createFontLoader } = await import("../packages/vinext/src/shims/font-google.js");
     const Inter = createFontLoader("Inter");
     const result = Inter({ weight: ["400", "700"], subsets: ["latin"] });
-    expect(result.className).toMatch(/^__font_inter_\d+$/);
+    expect(result.className).toMatch(/^__font_inter_[a-z0-9]+$/);
     expect(result.style.fontFamily).toContain("Inter");
     // variable returns a class name that sets the CSS variable, not the variable name itself
-    expect(result.variable).toMatch(/^__variable_inter_\d+$/);
+    expect(result.variable).toMatch(/^__variable_inter_[a-z0-9]+$/);
   });
 
   it("supports custom variable name", async () => {
@@ -58,7 +58,7 @@ describe("next/font/google shim", () => {
     const Inter = createFontLoader("Inter");
     const result = Inter({ weight: ["400"], variable: "--my-font" });
     // variable returns a class name that sets the CSS variable, not the variable name itself
-    expect(result.variable).toMatch(/^__variable_inter_\d+$/);
+    expect(result.variable).toMatch(/^__variable_inter_[a-z0-9]+$/);
   });
 
   it("supports custom fallback fonts", async () => {
@@ -81,7 +81,7 @@ describe("next/font/google shim", () => {
     const mod = await import("../packages/vinext/src/shims/font-google.js");
     const fonts = mod.default as any;
     const roboto = fonts.Roboto({ weight: ["400"] });
-    expect(roboto.className).toMatch(/^__font_roboto_\d+$/);
+    expect(roboto.className).toMatch(/^__font_roboto_[a-z0-9]+$/);
     expect(roboto.style.fontFamily).toContain("Roboto");
   });
 
@@ -210,8 +210,46 @@ describe("next/font/google shim", () => {
     const loader = mod.createFontLoader("Inter");
     expect(typeof loader).toBe("function");
     const result = loader({ weight: ["400"] });
-    expect(result.className).toMatch(/^__font_inter_\d+$/);
+    expect(result.className).toMatch(/^__font_inter_[a-z0-9]+$/);
     expect(result.style.fontFamily).toContain("Inter");
+  });
+
+  it("uses a stable class identity for equivalent font calls", async () => {
+    const { createFontLoader } = await import("../packages/vinext/src/shims/font-google.js");
+    const Inter = createFontLoader("Inter");
+    const first = Inter({ weight: ["400"], subsets: ["latin"], variable: "--font-primary" });
+    const second = Inter({ weight: ["400"], subsets: ["latin"], variable: "--font-primary" });
+
+    expect(second.className).toBe(first.className);
+    expect(second.variable).toBe(first.variable);
+  });
+
+  it("does not emit Next-incompatible :root font variable rules", async () => {
+    const { createFontLoader, getSSRFontStyles } =
+      await import("../packages/vinext/src/shims/font-google.js");
+    const Sen = createFontLoader("Sen");
+    const Outfit = createFontLoader("Outfit");
+
+    Sen({ subsets: ["latin"], variable: "--font-primary" });
+    Outfit({ subsets: ["latin"], variable: "--font-primary" });
+
+    const styles = getSSRFontStyles().join("\n");
+    expect(styles).not.toContain(":root");
+    expect(styles).toContain("--font-primary: 'Sen'");
+    expect(styles).toContain("--font-primary: 'Outfit'");
+  });
+
+  it("does not grow SSR style output for repeated equivalent font calls", async () => {
+    const { createFontLoader, getSSRFontStyles } =
+      await import("../packages/vinext/src/shims/font-google.js");
+    const Inter = createFontLoader("Inter");
+
+    Inter({ weight: ["400"], subsets: ["latin"], variable: "--font-primary" });
+    const stylesAfterFirstCall = getSSRFontStyles();
+    Inter({ weight: ["400"], subsets: ["latin"], variable: "--font-primary" });
+    const stylesAfterSecondCall = getSSRFontStyles();
+
+    expect(stylesAfterSecondCall).toEqual(stylesAfterFirstCall);
   });
 
   it("proxy handles underscore-style names", async () => {
@@ -302,7 +340,6 @@ describe("next/font/google shim", () => {
   it("accepts valid CSS variable names", async () => {
     const mod = await import("../packages/vinext/src/shims/font-google.js");
     const Inter = mod.createFontLoader("Inter");
-    const beforeStyles = mod.getSSRFontStyles().length;
     const result = Inter({
       weight: ["400"],
       variable: "--font-inter",
@@ -310,8 +347,7 @@ describe("next/font/google shim", () => {
     expect(result.className).toBeDefined();
     // Should use the provided variable name in the CSS
     const styles = mod.getSSRFontStyles();
-    const newStyles = styles.slice(beforeStyles);
-    const hasVar = newStyles.some((s: string) => s.includes("--font-inter"));
+    const hasVar = styles.some((s: string) => s.includes("--font-inter"));
     expect(hasVar).toBe(true);
   });
 });

--- a/tests/font-google.test.ts
+++ b/tests/font-google.test.ts
@@ -224,6 +224,16 @@ describe("next/font/google shim", () => {
     expect(second.variable).toBe(first.variable);
   });
 
+  it("normalizes explicit display swap to the same identity as the default", async () => {
+    const { createFontLoader } = await import("../packages/vinext/src/shims/font-google.js");
+    const DisplayDefault = createFontLoader("Display Default");
+    const implicit = DisplayDefault({ weight: ["400"], subsets: ["latin"] });
+    const explicit = DisplayDefault({ weight: ["400"], subsets: ["latin"], display: "swap" });
+
+    expect(explicit.className).toBe(implicit.className);
+    expect(explicit.variable).toBe(implicit.variable);
+  });
+
   it("does not emit Next-incompatible :root font variable rules", async () => {
     const { createFontLoader, getSSRFontStyles } =
       await import("../packages/vinext/src/shims/font-google.js");
@@ -289,6 +299,19 @@ describe("next/font/google shim", () => {
     expect(result.style.fontFamily).not.toMatch(/[^\\]'; }/);
   });
 
+  it("sanitizes generated class selectors for crafted font family names", async () => {
+    const mod = await import("../packages/vinext/src/shims/font-google.js");
+    const fonts = mod.default as any;
+    const result = fonts["Evil']; } body { color: red; } .x { font-family: '"]({
+      weight: ["400"],
+    });
+
+    expect(result.className).toMatch(/^__font_[a-z0-9_-]+_[a-z0-9]+$/);
+    expect(result.variable).toMatch(/^__variable_[a-z0-9_-]+_[a-z0-9]+$/);
+    expect(result.className).not.toMatch(/[;{}'"\s]/);
+    expect(result.variable).not.toMatch(/[;{}'"\s]/);
+  });
+
   it("escapes backslashes in font family names", async () => {
     const mod = await import("../packages/vinext/src/shims/font-google.js");
     const fonts = mod.default as any;
@@ -339,16 +362,19 @@ describe("next/font/google shim", () => {
 
   it("accepts valid CSS variable names", async () => {
     const mod = await import("../packages/vinext/src/shims/font-google.js");
-    const Inter = mod.createFontLoader("Inter");
-    const result = Inter({
+    const ValidVarTest = mod.createFontLoader("Valid Var Test");
+    const beforeStyles = mod.getSSRFontStyles();
+    const result = ValidVarTest({
       weight: ["400"],
-      variable: "--font-inter",
+      variable: "--font-valid-var-test",
     });
     expect(result.className).toBeDefined();
-    // Should use the provided variable name in the CSS
+    expect(result.variable).toBeDefined();
+
     const styles = mod.getSSRFontStyles();
-    const hasVar = styles.some((s: string) => s.includes("--font-inter"));
-    expect(hasVar).toBe(true);
+    const addedStyles = styles.slice(beforeStyles.length);
+    expect(addedStyles.some((s: string) => s.includes(`.${result.variable}`))).toBe(true);
+    expect(addedStyles.some((s: string) => s.includes("--font-valid-var-test"))).toBe(true);
   });
 });
 

--- a/tests/font-google.test.ts
+++ b/tests/font-google.test.ts
@@ -234,6 +234,25 @@ describe("next/font/google shim", () => {
     expect(explicit.variable).toBe(implicit.variable);
   });
 
+  it("normalizes identity inputs that emit equivalent Google font output", async () => {
+    const { createFontLoader } = await import("../packages/vinext/src/shims/font-google.js");
+    const CanonicalIdentity = createFontLoader("Canonical Identity");
+    const canonical = CanonicalIdentity({
+      weight: ["400", "700"],
+      subsets: ["latin", "latin-ext"],
+      fallback: ["Arial", "Helvetica"],
+    });
+    const equivalent = CanonicalIdentity({
+      weight: ["700", "400"],
+      style: ["normal"],
+      subsets: ["latin-ext", "latin"],
+      fallback: [" Arial ", "Helvetica"],
+    });
+
+    expect(equivalent.className).toBe(canonical.className);
+    expect(equivalent.variable).toBe(canonical.variable);
+  });
+
   it("does not emit Next-incompatible :root font variable rules", async () => {
     const { createFontLoader, getSSRFontStyles } =
       await import("../packages/vinext/src/shims/font-google.js");

--- a/tests/font-google.test.ts
+++ b/tests/font-google.test.ts
@@ -253,19 +253,34 @@ describe("next/font/google shim", () => {
     expect(equivalent.variable).toBe(canonical.variable);
   });
 
+  it("normalizes the default fallback to the same identity as an explicit fallback", async () => {
+    const { createFontLoader } = await import("../packages/vinext/src/shims/font-google.js");
+    const DefaultFallback = createFontLoader("Default Fallback");
+    const implicit = DefaultFallback({ weight: ["400"], subsets: ["latin"] });
+    const explicit = DefaultFallback({
+      weight: ["400"],
+      subsets: ["latin"],
+      fallback: ["sans-serif"],
+    });
+
+    expect(explicit.className).toBe(implicit.className);
+    expect(explicit.variable).toBe(implicit.variable);
+  });
+
   it("does not emit Next-incompatible :root font variable rules", async () => {
     const { createFontLoader, getSSRFontStyles } =
       await import("../packages/vinext/src/shims/font-google.js");
-    const Sen = createFontLoader("Sen");
-    const Outfit = createFontLoader("Outfit");
+    const beforeStyles = getSSRFontStyles();
+    const Sen = createFontLoader("Root Rule Sen");
+    const Outfit = createFontLoader("Root Rule Outfit");
 
     Sen({ subsets: ["latin"], variable: "--font-primary" });
     Outfit({ subsets: ["latin"], variable: "--font-primary" });
 
-    const styles = getSSRFontStyles().join("\n");
+    const styles = getSSRFontStyles().slice(beforeStyles.length).join("\n");
     expect(styles).not.toContain(":root");
-    expect(styles).toContain("--font-primary: 'Sen'");
-    expect(styles).toContain("--font-primary: 'Outfit'");
+    expect(styles).toContain("--font-primary: 'Root Rule Sen'");
+    expect(styles).toContain("--font-primary: 'Root Rule Outfit'");
   });
 
   it("does not grow SSR style output for repeated equivalent font calls", async () => {


### PR DESCRIPTION
## What this changes

Fixes #883.

The `next/font/google` runtime shim now gives each `(family, options)` registration a deterministic class identity instead of using a module-level counter. Repeated equivalent calls now reuse the same `className` and `variable` class, so dev HMR re-evaluation no longer appends a new pair of SSR style rules every time the app module reloads.

This also removes the shim-only `:root { --font-... }` emission. Google font variables now live only on the returned `.variable` class, matching Next.js behavior.

## Why

The issue is not really three separate bugs. Counter runaway, stale head rules, and pinned `:root` variables all come from the same bad invariant: the shim treated every runtime call as a new font registration even when the call represented the same font and options.

Next.js avoids this shape entirely:

- SWC rewrites calls like `Inter({ subsets: ["latin"] })` into a font CSS module request: [`next-font-loader/index.ts` lines 18-30](https://github.com/vercel/next.js/blob/ae61573e062e900050b8e6b24626e450accc4570/packages/next/src/build/webpack/loaders/next-font-loader/index.ts#L18-L30).
- The loader hashes the font CSS content for stable class identity: [`next-font-loader/index.ts` lines 128-134](https://github.com/vercel/next.js/blob/ae61573e062e900050b8e6b24626e450accc4570/packages/next/src/build/webpack/loaders/next-font-loader/index.ts#L128-L134).
- css-loader turns `className` and `variable` exports into `__${exportName}_${fontFamilyHash}`: [`next-font.ts` lines 44-53](https://github.com/vercel/next.js/blob/ae61573e062e900050b8e6b24626e450accc4570/packages/next/src/build/webpack/config/blocks/css/loaders/next-font.ts#L44-L53).
- The PostCSS plugin emits a `.className` rule and, when requested, a `.variable` rule. It does not emit a `:root` rule: [`postcss-next-font.ts` lines 138-174](https://github.com/vercel/next.js/blob/ae61573e062e900050b8e6b24626e450accc4570/packages/next/src/build/webpack/loaders/next-font-loader/postcss-next-font.ts#L138-L174).

## Approach

- Replace `classCounter++` with a deterministic FNV-based identity over the font family, effective font-family string, CSS variable name, public font options, and self-hosted CSS.
- Reuse existing class/style dedupe sets by making equivalent calls produce equivalent class names.
- Remove `injectedRootVariables` and the `:root` rule path.
- Keep dynamic/proxy font calls on the existing runtime fallback. A full dev-time virtual CSS module transform can be a separate architecture PR.

## Validation

- Added regression tests for stable class identity, no `:root` font variable emission, and no SSR style growth for repeated equivalent calls.
- Updated class-name shape assertions from counter-only suffixes to stable alphanumeric suffixes.
- `vp test run tests/font-google.test.ts`
- `vp test run tests/shims.test.ts -t "next/font/google shim"`
- `vp check`
- `vp run vinext#build`

## Risks / follow-ups

Apps that accidentally relied on vinext injecting font variables at `:root` without applying the returned `.variable` class will need to apply `font.variable`, which is the Next.js-compatible usage. This PR intentionally does not attempt the larger Phase 2 architecture where dev font calls become Vite-owned virtual CSS modules.