### PR TITLE
fix(isr): honor route expire ceilings

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -2,10 +2,6 @@ name: Setup
 description: Setup
 
 inputs:
-  vite-plus-version:
-    description: Vite+ version to install
-    required: false
-    default: 0.1.17
   node-version:
     description: Node.js version to use
     required: false
@@ -24,7 +20,6 @@ runs:
     - name: Setup Vite+
       uses: voidzero-dev/setup-vp@dc86dedacad12dfe5b3e525b735a327fcd1f6477 # v1
       with:
-        version: ${{ inputs.vite-plus-version }}
         node-version: ${{ inputs.node-version }}
         cache: ${{ inputs.cache }}
         run-install: ${{ inputs.run-install }}

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -2,6 +2,10 @@ name: Setup
 description: Setup
 
 inputs:
+  vite-plus-version:
+    description: Vite+ version to install
+    required: false
+    default: 0.1.17
   node-version:
     description: Node.js version to use
     required: false
@@ -20,6 +24,7 @@ runs:
     - name: Setup Vite+
       uses: voidzero-dev/setup-vp@dc86dedacad12dfe5b3e525b735a327fcd1f6477 # v1
       with:
+        version: ${{ inputs.vite-plus-version }}
         node-version: ${{ inputs.node-version }}
         cache: ${{ inputs.cache }}
         run-install: ${{ inputs.run-install }}

--- a/packages/vinext/src/build/prerender.ts
+++ b/packages/vinext/src/build/prerender.ts
@@ -1245,7 +1245,7 @@ function resolveRenderedExpireSeconds(options: {
 function parseCacheControlSeconds(cacheControl: string, directive: string): number | undefined {
   for (const part of cacheControl.split(",")) {
     const [rawName, rawValue] = part.trim().split("=", 2);
-    if (rawName.toLowerCase() !== directive) continue;
+    if (rawName.trim().toLowerCase() !== directive) continue;
     if (rawValue === undefined) return undefined;
 
     const value = Number(rawValue.trim());

--- a/packages/vinext/src/build/prerender.ts
+++ b/packages/vinext/src/build/prerender.ts
@@ -1219,15 +1219,22 @@ function resolveRenderedCacheControl(
     requestCacheLife.revalidate ?? (staleWhileRevalidate === undefined ? undefined : sMaxage);
   return {
     expire:
-      requestCacheLife.expire ?? resolveRenderedExpireSeconds(cacheControl, fallbackExpireSeconds),
+      requestCacheLife.expire ??
+      resolveRenderedExpireSeconds({
+        fallbackExpireSeconds,
+        sMaxage,
+        staleWhileRevalidate,
+      }),
     ...(revalidate === undefined ? {} : { revalidate }),
   };
 }
 
-function resolveRenderedExpireSeconds(cacheControl: string, fallbackExpireSeconds: number): number {
-  const sMaxage = parseCacheControlSeconds(cacheControl, "s-maxage");
-  const staleWhileRevalidate = parseCacheControlSeconds(cacheControl, "stale-while-revalidate");
-
+function resolveRenderedExpireSeconds(options: {
+  fallbackExpireSeconds: number;
+  sMaxage?: number;
+  staleWhileRevalidate?: number;
+}): number {
+  const { fallbackExpireSeconds, sMaxage, staleWhileRevalidate } = options;
   if (sMaxage === undefined || staleWhileRevalidate === undefined) {
     return fallbackExpireSeconds;
   }

--- a/packages/vinext/src/build/prerender.ts
+++ b/packages/vinext/src/build/prerender.ts
@@ -24,9 +24,14 @@ import type { Route } from "../routing/pages-router.js";
 import type { AppRoute } from "../routing/app-router.js";
 import type { ResolvedNextConfig } from "../config/next-config.js";
 import { classifyPagesRoute, classifyAppRoute } from "./report.js";
-import { createValidFileMatcher, type ValidFileMatcher } from "../routing/file-matcher.js";
-import { NoOpCacheHandler, setCacheHandler, getCacheHandler } from "vinext/shims/cache";
+import {
+  NoOpCacheHandler,
+  setCacheHandler,
+  getCacheHandler,
+  _consumeRequestScopedCacheLife,
+} from "vinext/shims/cache";
 import { runWithHeadersContext, headersContextFromRequest } from "vinext/shims/headers";
+import { createValidFileMatcher, type ValidFileMatcher } from "../routing/file-matcher.js";
 import { startProdServer } from "../server/prod-server.js";
 import { readPrerenderSecret } from "./server-manifest.js";
 export { readPrerenderSecret } from "./server-manifest.js";
@@ -53,6 +58,7 @@ export type PrerenderRouteResult =
       status: "rendered";
       outputFiles: string[];
       revalidate: number | false;
+      expire?: number;
       /**
        * The concrete prerendered URL path, e.g. `/blog/hello-world`.
        * Only present when the route is dynamic and `path` differs from `route`.
@@ -599,6 +605,9 @@ export async function prerenderPages({
             status: "rendered",
             outputFiles,
             revalidate,
+            // Pages Router cache metadata comes only from getStaticProps.revalidate;
+            // Next.js applies expireTime as the fallback when no route expire exists.
+            ...(typeof revalidate === "number" ? { expire: config.expireTime } : {}),
             router: "pages",
             ...(urlPath !== route.pattern ? { path: urlPath } : {}),
           };
@@ -1012,17 +1021,41 @@ export async function prerenderApp({
         // reaches the worker isolate. The wrapping is a no-op for the CF path but
         // harmless — and it keeps renderUrl() shape-compatible across both modes.
         const htmlRequest = new Request(`http://localhost${urlPath}`);
-        const htmlRes = await runWithHeadersContext(headersContextFromRequest(htmlRequest), () =>
-          rscHandler(htmlRequest),
+        const htmlRender = await runWithHeadersContext(
+          headersContextFromRequest(htmlRequest),
+          async () => {
+            const response = await rscHandler(htmlRequest);
+            const cacheControl = response.headers.get("cache-control") ?? "";
+            if (!response.ok || (isSpeculative && cacheControl.includes("no-store"))) {
+              await response.body?.cancel();
+              return {
+                cacheControl,
+                html: null,
+                ok: response.ok,
+                requestCacheLife: null,
+                status: response.status,
+              };
+            }
+
+            const html = await response.text();
+            return {
+              cacheControl,
+              html,
+              ok: true,
+              requestCacheLife: _consumeRequestScopedCacheLife(),
+              status: response.status,
+            };
+          },
         );
-        if (!htmlRes.ok) {
+        const htmlCacheControl = htmlRender.cacheControl;
+        if (!htmlRender.ok) {
           if (isSpeculative) {
             return { route: routePattern, status: "skipped", reason: "dynamic" };
           }
           return {
             route: routePattern,
             status: "error",
-            error: `RSC handler returned ${htmlRes.status}`,
+            error: `RSC handler returned ${htmlRender.status}`,
           };
         }
 
@@ -1031,14 +1064,19 @@ export async function prerenderApp({
         // render, the server sets Cache-Control: no-store. We treat this as a
         // signal that the route is dynamic and should be skipped.
         if (isSpeculative) {
-          const cacheControl = htmlRes.headers.get("cache-control") ?? "";
-          if (cacheControl.includes("no-store")) {
-            await htmlRes.body?.cancel();
+          if (htmlCacheControl.includes("no-store")) {
             return { route: routePattern, status: "skipped", reason: "dynamic" };
           }
         }
 
-        const html = await htmlRes.text();
+        if (htmlRender.html === null) {
+          return {
+            route: routePattern,
+            status: "error",
+            error: "RSC handler returned no prerender HTML",
+          };
+        }
+        const html = htmlRender.html;
 
         // Fetch RSC payload via a second invocation with RSC headers
         // TODO: Extract RSC payload from the first response instead of invoking the handler twice.
@@ -1068,11 +1106,26 @@ export async function prerenderApp({
           outputFiles.push(rscOutputPath);
         }
 
+        const renderedCacheControl = resolveRenderedCacheControl(
+          htmlRender.requestCacheLife ?? {},
+          htmlCacheControl,
+          config.expireTime,
+        );
+        const renderedRevalidate =
+          typeof revalidate === "number"
+            ? renderedCacheControl.revalidate === undefined
+              ? revalidate
+              : Math.min(revalidate, renderedCacheControl.revalidate)
+            : (renderedCacheControl.revalidate ?? revalidate);
+
         return {
           route: routePattern,
           status: "rendered",
           outputFiles,
-          revalidate,
+          revalidate: renderedRevalidate,
+          ...(typeof renderedRevalidate === "number"
+            ? { expire: renderedCacheControl.expire }
+            : {}),
           router: "app",
           ...(urlPath !== routePattern ? { path: urlPath } : {}),
         };
@@ -1155,6 +1208,48 @@ export function getRscOutputPath(urlPath: string): string {
   return urlPath.replace(/^\//, "") + ".rsc";
 }
 
+function resolveRenderedCacheControl(
+  requestCacheLife: { expire?: number; revalidate?: number },
+  cacheControl: string,
+  fallbackExpireSeconds: number,
+): { expire: number; revalidate?: number } {
+  const sMaxage = parseCacheControlSeconds(cacheControl, "s-maxage");
+  const staleWhileRevalidate = parseCacheControlSeconds(cacheControl, "stale-while-revalidate");
+  const revalidate =
+    requestCacheLife.revalidate ?? (staleWhileRevalidate === undefined ? undefined : sMaxage);
+  return {
+    expire:
+      requestCacheLife.expire ?? resolveRenderedExpireSeconds(cacheControl, fallbackExpireSeconds),
+    ...(revalidate === undefined ? {} : { revalidate }),
+  };
+}
+
+function resolveRenderedExpireSeconds(cacheControl: string, fallbackExpireSeconds: number): number {
+  const sMaxage = parseCacheControlSeconds(cacheControl, "s-maxage");
+  const staleWhileRevalidate = parseCacheControlSeconds(cacheControl, "stale-while-revalidate");
+
+  if (sMaxage === undefined || staleWhileRevalidate === undefined) {
+    return fallbackExpireSeconds;
+  }
+
+  return sMaxage + staleWhileRevalidate;
+}
+
+function parseCacheControlSeconds(cacheControl: string, directive: string): number | undefined {
+  for (const part of cacheControl.split(",")) {
+    const [rawName, rawValue] = part.trim().split("=", 2);
+    if (rawName.toLowerCase() !== directive) continue;
+    if (rawValue === undefined) return undefined;
+
+    const value = Number(rawValue.trim());
+    if (!Number.isFinite(value) || value < 0) return undefined;
+
+    return value;
+  }
+
+  return undefined;
+}
+
 // ─── Build index ──────────────────────────────────────────────────────────────
 
 /**
@@ -1177,6 +1272,7 @@ export function writePrerenderIndex(
         route: r.route,
         status: r.status,
         revalidate: r.revalidate,
+        ...(typeof r.revalidate === "number" ? { expire: r.expire } : {}),
         router: r.router,
         ...(r.path ? { path: r.path } : {}),
       };

--- a/packages/vinext/src/cloudflare/kv-cache-handler.ts
+++ b/packages/vinext/src/cloudflare/kv-cache-handler.ts
@@ -33,6 +33,7 @@ import { Buffer } from "node:buffer";
 import type {
   CacheHandler,
   CacheHandlerValue,
+  CacheControlMetadata,
   CachedAppPageValue,
   CachedRouteValue,
   CachedImageValue,
@@ -42,6 +43,7 @@ import {
   getRequestExecutionContext,
   type ExecutionContextLike,
 } from "vinext/shims/request-context";
+import { isUnknownRecord, readCacheControlNumberField } from "../utils/cache-control-metadata.js";
 
 // ---------------------------------------------------------------------------
 // Serialized cache value types — ArrayBuffer fields replaced with base64 strings
@@ -89,6 +91,10 @@ type KVCacheEntry = {
   lastModified: number;
   /** Absolute timestamp (ms) after which the entry is "stale" (but still served). */
   revalidateAt: number | null;
+  /** Absolute timestamp (ms) after which the entry must block on fresh render. */
+  expireAt?: number | null;
+  /** Effective cache-control policy used for response headers. */
+  cacheControl?: CacheControlMetadata;
 };
 
 /** Key prefix for tag invalidation timestamps. */
@@ -223,18 +229,25 @@ export class KVCacheHandler implements CacheHandler {
       return null;
     }
 
-    // Check time-based expiry — return stale with cacheState
+    if (entry.expireAt !== undefined && entry.expireAt !== null && Date.now() > entry.expireAt) {
+      this._deleteInBackground(kvKey);
+      return null;
+    }
+
+    // Check time-based revalidation — return stale with cacheState
     if (entry.revalidateAt !== null && Date.now() > entry.revalidateAt) {
       return {
         lastModified: entry.lastModified,
         value: restoredValue,
         cacheState: "stale",
+        cacheControl: entry.cacheControl,
       };
     }
 
     return {
       lastModified: entry.lastModified,
       value: restoredValue,
+      cacheControl: entry.cacheControl,
     };
   }
 
@@ -314,22 +327,29 @@ export class KVCacheHandler implements CacheHandler {
     // Resolve effective revalidate — data overrides ctx.
     // revalidate: 0 means "don't cache", so skip storage entirely.
     let effectiveRevalidate: number | undefined;
-    if (ctx) {
-      // oxlint-disable-next-line @typescript-eslint/no-explicit-any
-      const revalidate = (ctx as any).cacheControl?.revalidate ?? (ctx as any).revalidate;
-      if (typeof revalidate === "number") {
-        effectiveRevalidate = revalidate;
-      }
-    }
+    let effectiveExpire: number | undefined;
+    effectiveRevalidate = readCacheControlNumberField(ctx, "revalidate");
+    effectiveExpire = readCacheControlNumberField(ctx, "expire");
     if (data && "revalidate" in data && typeof data.revalidate === "number") {
       effectiveRevalidate = data.revalidate;
     }
     if (effectiveRevalidate === 0) return Promise.resolve();
 
+    const now = Date.now();
     const revalidateAt =
       typeof effectiveRevalidate === "number" && effectiveRevalidate > 0
-        ? Date.now() + effectiveRevalidate * 1000
+        ? now + effectiveRevalidate * 1000
         : null;
+    const expireAt =
+      typeof effectiveExpire === "number" && effectiveExpire > 0
+        ? now + effectiveExpire * 1000
+        : null;
+    const cacheControl =
+      typeof effectiveRevalidate === "number"
+        ? effectiveExpire === undefined
+          ? { revalidate: effectiveRevalidate }
+          : { revalidate: effectiveRevalidate, expire: effectiveExpire }
+        : undefined;
 
     // Prepare entry — convert ArrayBuffers to base64 for JSON storage
     const serializable = data ? serializeForJSON(data) : null;
@@ -337,8 +357,10 @@ export class KVCacheHandler implements CacheHandler {
     const entry: KVCacheEntry = {
       value: serializable,
       tags,
-      lastModified: Date.now(),
+      lastModified: now,
       revalidateAt,
+      expireAt,
+      cacheControl,
     };
 
     // KV TTL is decoupled from the revalidation period.
@@ -508,6 +530,16 @@ function validateCacheEntry(raw: unknown): KVCacheEntry | null {
   if (typeof obj.lastModified !== "number") return null;
   if (!Array.isArray(obj.tags)) return null;
   if (obj.revalidateAt !== null && typeof obj.revalidateAt !== "number") return null;
+  if (obj.expireAt !== undefined && obj.expireAt !== null && typeof obj.expireAt !== "number") {
+    return null;
+  }
+  if (obj.cacheControl !== undefined) {
+    if (!isUnknownRecord(obj.cacheControl)) return null;
+    if (typeof obj.cacheControl.revalidate !== "number") return null;
+    if (obj.cacheControl.expire !== undefined && typeof obj.cacheControl.expire !== "number") {
+      return null;
+    }
+  }
 
   // value must be null or a valid cache value object with a known kind
   if (obj.value !== null) {

--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -180,6 +180,8 @@ export type NextConfig = {
   pageExtensions?: string[];
   /** Extra origins allowed to access the dev server. */
   allowedDevOrigins?: string[];
+  /** Maximum age in seconds for stale ISR entries before blocking regeneration. */
+  expireTime?: number;
   /**
    * Enable Cache Components (Next.js 16).
    * When true, enables the "use cache" directive for pages, components, and functions.
@@ -261,6 +263,8 @@ export type ResolvedNextConfig = {
   optimizePackageImports: string[];
   /** Parsed body size limit for server actions in bytes (from experimental.serverActions.bodySizeLimit). Defaults to 1MB. */
   serverActionsBodySizeLimit: number;
+  /** Route-level expire fallback in seconds for ISR entries with numeric revalidate. */
+  expireTime: number;
   /**
    * Packages that should be treated as server-external (not bundled by Vite).
    * Sourced from `serverExternalPackages` or the legacy
@@ -291,6 +295,7 @@ export type ResolvedNextConfig = {
 };
 
 const CONFIG_FILES = ["next.config.ts", "next.config.mjs", "next.config.js", "next.config.cjs"];
+const DEFAULT_EXPIRE_TIME = 31_536_000;
 
 /**
  * Check whether an error indicates a CJS module was loaded in an ESM context
@@ -514,6 +519,7 @@ export async function resolveNextConfig(
       serverActionsAllowedOrigins: [],
       optimizePackageImports: [],
       serverActionsBodySizeLimit: 1 * 1024 * 1024,
+      expireTime: DEFAULT_EXPIRE_TIME,
       serverExternalPackages: [],
       cacheHandler: undefined,
       cacheMaxMemorySize: undefined,
@@ -693,6 +699,7 @@ export async function resolveNextConfig(
     serverActionsAllowedOrigins,
     optimizePackageImports,
     serverActionsBodySizeLimit,
+    expireTime: typeof config.expireTime === "number" ? config.expireTime : DEFAULT_EXPIRE_TIME,
     serverExternalPackages,
     cacheHandler,
     cacheMaxMemorySize,

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -1195,6 +1195,7 @@ ${prerenderPagesLoaderOption}
     hasPageModule: !!route.page,
     handlerStart: __reqStart,
     interceptionContext: interceptionContextHeader,
+    expireSeconds: __expireTime,
     isProduction: process.env.NODE_ENV === "production",
     isRscRequest,
     isrDebug: __isrDebug,

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -20,6 +20,8 @@ import { generateDevOriginCheckCode } from "../server/dev-origin-check.js";
 import type { MetadataFileRoute } from "../server/metadata-routes.js";
 import { isProxyFile } from "../server/middleware.js";
 
+const DEFAULT_EXPIRE_TIME = 31_536_000;
+
 // Pre-computed absolute paths for generated-code imports. The virtual RSC
 // entry can't use relative imports (it has no real file location), so we
 // resolve these at code-generation time and embed them as absolute paths.
@@ -98,6 +100,8 @@ export type AppRouterConfig = {
   allowedDevOrigins?: string[];
   /** Body size limit for server actions in bytes (from experimental.serverActions.bodySizeLimit). */
   bodySizeLimit?: number;
+  /** Route-level expire fallback in seconds for ISR entries with numeric revalidate. */
+  expireTime?: number;
   /** Internationalization routing config for middleware matcher locale handling. */
   i18n?: NextI18nConfig | null;
   /**
@@ -138,6 +142,7 @@ export function generateRscEntry(
   const headers = config?.headers ?? [];
   const allowedOrigins = config?.allowedOrigins ?? [];
   const bodySizeLimit = config?.bodySizeLimit ?? 1 * 1024 * 1024;
+  const expireTime = config?.expireTime ?? DEFAULT_EXPIRE_TIME;
   const i18nConfig = config?.i18n ?? null;
   const hasPagesDir = config?.hasPagesDir ?? false;
   const publicFiles = config?.publicFiles ?? [];
@@ -635,6 +640,7 @@ const __configRewrites = ${JSON.stringify(rewrites)};
 const __configHeaders = ${JSON.stringify(headers)};
 const __publicFiles = new Set(${JSON.stringify(publicFiles)});
 const __allowedOrigins = ${JSON.stringify(allowedOrigins)};
+const __expireTime = ${JSON.stringify(expireTime)};
 
 ${generateDevOriginCheckCode(config?.allowedDevOrigins)}
 

--- a/packages/vinext/src/entries/pages-server-entry.ts
+++ b/packages/vinext/src/entries/pages-server-entry.ts
@@ -100,6 +100,7 @@ export async function generateServerEntry(
     redirects: nextConfig?.redirects ?? [],
     rewrites: nextConfig?.rewrites ?? { beforeFiles: [], afterFiles: [], fallback: [] },
     headers: nextConfig?.headers ?? [],
+    expireTime: nextConfig?.expireTime,
     i18n: nextConfig?.i18n ?? null,
     images: {
       deviceSizes: nextConfig?.images?.deviceSizes,
@@ -217,8 +218,8 @@ export const vinextConfig = ${vinextConfigJson};
 function isrGet(key) {
   return __sharedIsrGet(key);
 }
-function isrSet(key, data, revalidateSeconds, tags) {
-  return __sharedIsrSet(key, data, revalidateSeconds, tags);
+function isrSet(key, data, revalidateSeconds, tags, expireSeconds) {
+  return __sharedIsrSet(key, data, revalidateSeconds, tags, expireSeconds);
 }
 function triggerBackgroundRegeneration(key, renderFn, errorContext) {
   return __sharedTriggerBackgroundRegeneration(key, renderFn, errorContext);
@@ -577,6 +578,7 @@ async function _renderPage(request, url, manifest, middlewareHeaders) {
         isrCacheKey,
         isrGet,
         isrSet,
+        expireSeconds: vinextConfig.expireTime,
         pageModule,
         params,
         query,
@@ -649,6 +651,7 @@ async function _renderPage(request, url, manifest, middlewareHeaders) {
         getSSRHeadHTML: typeof getSSRHeadHTML === "function" ? getSSRHeadHTML : undefined,
         gsspRes,
         isrCacheKey,
+        expireSeconds: vinextConfig.expireTime,
         isrRevalidateSeconds,
         isrSet,
         i18n: {

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -1681,6 +1681,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
               allowedOrigins: nextConfig?.serverActionsAllowedOrigins,
               allowedDevOrigins: nextConfig?.allowedDevOrigins,
               bodySizeLimit: nextConfig?.serverActionsBodySizeLimit,
+              expireTime: nextConfig?.expireTime,
               i18n: nextConfig?.i18n,
               hasPagesDir,
               publicFiles: scanPublicFileRoutes(root),

--- a/packages/vinext/src/server/app-page-cache.ts
+++ b/packages/vinext/src/server/app-page-cache.ts
@@ -151,7 +151,10 @@ export function buildAppPageCachedResponse(
   // falsy statuses still fall back to 200 rather than being forwarded through.
   const status = cachedValue.status || 200;
   const revalidateSeconds = options.cacheControl?.revalidate ?? options.revalidateSeconds;
-  const expireSeconds = options.cacheControl?.expire ?? options.expireSeconds;
+  const expireSeconds =
+    options.cacheControl === undefined
+      ? undefined
+      : (options.cacheControl.expire ?? options.expireSeconds);
   const headers = {
     "Cache-Control": buildAppPageCacheControl(options.cacheState, revalidateSeconds, expireSeconds),
     Vary: "RSC, Accept",

--- a/packages/vinext/src/server/app-page-cache.ts
+++ b/packages/vinext/src/server/app-page-cache.ts
@@ -136,7 +136,7 @@ function resolveAppPageCacheWritePolicy(options: {
     expireSeconds = requestCacheLife.expire;
   }
 
-  if (revalidateSeconds === null || revalidateSeconds <= 0 || revalidateSeconds === Infinity) {
+  if (revalidateSeconds === null || revalidateSeconds <= 0 || !Number.isFinite(revalidateSeconds)) {
     return null;
   }
 

--- a/packages/vinext/src/server/app-page-cache.ts
+++ b/packages/vinext/src/server/app-page-cache.ts
@@ -12,6 +12,10 @@ type AppPageCacheSetter = (
   expireSeconds?: number,
 ) => Promise<void>;
 type AppPageBackgroundRegenerator = (key: string, renderFn: () => Promise<void>) => void;
+type AppPageRequestCacheLife = {
+  revalidate?: number;
+  expire?: number;
+};
 
 type AppPageCacheRenderResult = {
   cacheControl?: CacheControlMetadata;
@@ -50,12 +54,13 @@ type FinalizeAppPageHtmlCacheResponseOptions = {
   cleanPathname: string;
   consumeDynamicUsage: () => boolean;
   getPageTags: () => string[];
+  getRequestCacheLife?: () => AppPageRequestCacheLife | null;
   isrDebug?: AppPageDebugLogger;
   isrHtmlKey: (pathname: string) => string;
   isrRscKey: (pathname: string, mountedSlotsHeader?: string | null) => string;
   isrSet: AppPageCacheSetter;
   expireSeconds?: number;
-  revalidateSeconds: number;
+  revalidateSeconds: number | null;
   waitUntil?: (promise: Promise<void>) => void;
 };
 
@@ -65,12 +70,13 @@ type ScheduleAppPageRscCacheWriteOptions = {
   consumeDynamicUsage: () => boolean;
   dynamicUsedDuringBuild: boolean;
   getPageTags: () => string[];
+  getRequestCacheLife?: () => AppPageRequestCacheLife | null;
   isrDebug?: AppPageDebugLogger;
   isrRscKey: (pathname: string, mountedSlotsHeader?: string | null) => string;
   isrSet: AppPageCacheSetter;
   mountedSlotsHeader?: string | null;
   expireSeconds?: number;
-  revalidateSeconds: number;
+  revalidateSeconds: number | null;
   waitUntil?: (promise: Promise<void>) => void;
 };
 
@@ -107,6 +113,32 @@ function buildAppPageCacheControl(
 
 function getCachedAppPageValue(entry: ISRCacheEntry | null): CachedAppPageValue | null {
   return entry?.value.value && entry.value.value.kind === "APP_PAGE" ? entry.value.value : null;
+}
+
+function resolveAppPageCacheWritePolicy(options: {
+  expireSeconds?: number;
+  requestCacheLife?: AppPageRequestCacheLife | null;
+  revalidateSeconds: number | null;
+}): { expireSeconds?: number; revalidateSeconds: number } | null {
+  let revalidateSeconds = options.revalidateSeconds;
+  let expireSeconds = options.expireSeconds;
+  const requestCacheLife = options.requestCacheLife;
+
+  if (requestCacheLife?.revalidate !== undefined) {
+    revalidateSeconds =
+      revalidateSeconds === null
+        ? requestCacheLife.revalidate
+        : Math.min(revalidateSeconds, requestCacheLife.revalidate);
+  }
+  if (requestCacheLife?.expire !== undefined) {
+    expireSeconds = requestCacheLife.expire;
+  }
+
+  if (revalidateSeconds === null || revalidateSeconds <= 0 || revalidateSeconds === Infinity) {
+    return null;
+  }
+
+  return { expireSeconds, revalidateSeconds };
 }
 
 export function buildAppPageCachedResponse(
@@ -278,6 +310,7 @@ export function finalizeAppPageHtmlCacheResponse(
   // consumed. Until that late dynamic check finishes, downstream shared caches
   // must not cache the speculative MISS response.
   clientHeaders.set("Cache-Control", NO_STORE_CACHE_CONTROL);
+  clientHeaders.set("X-Vinext-Cache", "MISS");
 
   const cachePromise = (async () => {
     try {
@@ -298,14 +331,24 @@ export function finalizeAppPageHtmlCacheResponse(
         return;
       }
 
+      const cachePolicy = resolveAppPageCacheWritePolicy({
+        expireSeconds: options.expireSeconds,
+        requestCacheLife: options.getRequestCacheLife?.(),
+        revalidateSeconds: options.revalidateSeconds,
+      });
+      if (!cachePolicy) {
+        options.isrDebug?.("HTML cache write skipped (no cache policy)", htmlKey);
+        return;
+      }
+
       const pageTags = options.getPageTags();
       const writes = [
         options.isrSet(
           htmlKey,
           buildAppPageCacheValue(chunks.join(""), undefined, 200),
-          options.revalidateSeconds,
+          cachePolicy.revalidateSeconds,
           pageTags,
-          options.expireSeconds,
+          cachePolicy.expireSeconds,
         ),
       ];
 
@@ -315,9 +358,9 @@ export function finalizeAppPageHtmlCacheResponse(
             options.isrSet(
               rscKey,
               buildAppPageCacheValue("", rscData, 200),
-              options.revalidateSeconds,
+              cachePolicy.revalidateSeconds,
               pageTags,
-              options.expireSeconds,
+              cachePolicy.expireSeconds,
             ),
           ),
         );
@@ -353,6 +396,7 @@ export function finalizeAppPageRscCacheResponse(
   // late request API was used, the client-facing MISS response must not enter a
   // shared cache.
   clientHeaders.set("Cache-Control", NO_STORE_CACHE_CONTROL);
+  clientHeaders.set("X-Vinext-Cache", "MISS");
 
   return new Response(response.body, {
     status: response.status,
@@ -384,12 +428,22 @@ export function scheduleAppPageRscCacheWrite(
         return;
       }
 
+      const cachePolicy = resolveAppPageCacheWritePolicy({
+        expireSeconds: options.expireSeconds,
+        requestCacheLife: options.getRequestCacheLife?.(),
+        revalidateSeconds: options.revalidateSeconds,
+      });
+      if (!cachePolicy) {
+        options.isrDebug?.("RSC cache write skipped (no cache policy)", rscKey);
+        return;
+      }
+
       await options.isrSet(
         rscKey,
         buildAppPageCacheValue("", rscData, 200),
-        options.revalidateSeconds,
+        cachePolicy.revalidateSeconds,
         options.getPageTags(),
-        options.expireSeconds,
+        cachePolicy.expireSeconds,
       );
       options.isrDebug?.("RSC cache written", rscKey);
     } catch (cacheError) {

--- a/packages/vinext/src/server/app-page-cache.ts
+++ b/packages/vinext/src/server/app-page-cache.ts
@@ -1,4 +1,5 @@
-import type { CachedAppPageValue } from "vinext/shims/cache";
+import type { CachedAppPageValue, CacheControlMetadata } from "vinext/shims/cache";
+import { buildCachedRevalidateCacheControl } from "./cache-control.js";
 import { buildAppPageCacheValue, type ISRCacheEntry } from "./isr-cache.js";
 
 type AppPageDebugLogger = (event: string, detail: string) => void;
@@ -8,17 +9,21 @@ type AppPageCacheSetter = (
   data: CachedAppPageValue,
   revalidateSeconds: number,
   tags: string[],
+  expireSeconds?: number,
 ) => Promise<void>;
 type AppPageBackgroundRegenerator = (key: string, renderFn: () => Promise<void>) => void;
 
 type AppPageCacheRenderResult = {
+  cacheControl?: CacheControlMetadata;
   html: string;
   rscData: ArrayBuffer;
   tags: string[];
 };
 
 type BuildAppPageCachedResponseOptions = {
+  cacheControl?: CacheControlMetadata;
   cacheState: "HIT" | "STALE";
+  expireSeconds?: number;
   isRscRequest: boolean;
   mountedSlotsHeader?: string | null;
   revalidateSeconds: number;
@@ -34,6 +39,7 @@ type ReadAppPageCacheResponseOptions = {
   isrRscKey: (pathname: string, mountedSlotsHeader?: string | null) => string;
   isrSet: AppPageCacheSetter;
   mountedSlotsHeader?: string | null;
+  expireSeconds?: number;
   revalidateSeconds: number;
   renderFreshPageForCache: () => Promise<AppPageCacheRenderResult>;
   scheduleBackgroundRegeneration: AppPageBackgroundRegenerator;
@@ -48,6 +54,7 @@ type FinalizeAppPageHtmlCacheResponseOptions = {
   isrHtmlKey: (pathname: string) => string;
   isrRscKey: (pathname: string, mountedSlotsHeader?: string | null) => string;
   isrSet: AppPageCacheSetter;
+  expireSeconds?: number;
   revalidateSeconds: number;
   waitUntil?: (promise: Promise<void>) => void;
 };
@@ -62,6 +69,7 @@ type ScheduleAppPageRscCacheWriteOptions = {
   isrRscKey: (pathname: string, mountedSlotsHeader?: string | null) => string;
   isrSet: AppPageCacheSetter;
   mountedSlotsHeader?: string | null;
+  expireSeconds?: number;
   revalidateSeconds: number;
   waitUntil?: (promise: Promise<void>) => void;
 };
@@ -92,12 +100,9 @@ export function buildAppPageCacheTags(pathname: string, extraTags: readonly stri
 function buildAppPageCacheControl(
   cacheState: BuildAppPageCachedResponseOptions["cacheState"],
   revalidateSeconds: number,
+  expireSeconds?: number,
 ): string {
-  if (cacheState === "STALE") {
-    return "s-maxage=0, stale-while-revalidate";
-  }
-
-  return `s-maxage=${revalidateSeconds}, stale-while-revalidate`;
+  return buildCachedRevalidateCacheControl(cacheState, revalidateSeconds, expireSeconds);
 }
 
 function getCachedAppPageValue(entry: ISRCacheEntry | null): CachedAppPageValue | null {
@@ -111,8 +116,10 @@ export function buildAppPageCachedResponse(
   // Preserve the legacy fallback semantics from the generated entry: invalid
   // falsy statuses still fall back to 200 rather than being forwarded through.
   const status = cachedValue.status || 200;
+  const revalidateSeconds = options.cacheControl?.revalidate ?? options.revalidateSeconds;
+  const expireSeconds = options.cacheControl?.expire ?? options.expireSeconds;
   const headers = {
-    "Cache-Control": buildAppPageCacheControl(options.cacheState, options.revalidateSeconds),
+    "Cache-Control": buildAppPageCacheControl(options.cacheState, revalidateSeconds, expireSeconds),
     Vary: "RSC, Accept",
     "X-Vinext-Cache": options.cacheState,
   };
@@ -163,6 +170,8 @@ export async function readAppPageCacheResponse(
     if (cachedValue && !cached?.isStale) {
       const hitResponse = buildAppPageCachedResponse(cachedValue, {
         cacheState: "HIT",
+        cacheControl: cached?.value.cacheControl,
+        expireSeconds: options.expireSeconds,
         isRscRequest: options.isRscRequest,
         mountedSlotsHeader: options.mountedSlotsHeader,
         revalidateSeconds: options.revalidateSeconds,
@@ -189,12 +198,16 @@ export async function readAppPageCacheResponse(
       // their next STALE read.
       options.scheduleBackgroundRegeneration(options.cleanPathname, async () => {
         const revalidatedPage = await options.renderFreshPageForCache();
+        const revalidateSeconds =
+          revalidatedPage.cacheControl?.revalidate ?? options.revalidateSeconds;
+        const expireSeconds = revalidatedPage.cacheControl?.expire ?? options.expireSeconds;
         const writes = [
           options.isrSet(
             options.isrRscKey(options.cleanPathname, options.mountedSlotsHeader),
             buildAppPageCacheValue("", revalidatedPage.rscData, 200),
-            options.revalidateSeconds,
+            revalidateSeconds,
             revalidatedPage.tags,
+            expireSeconds,
           ),
         ];
 
@@ -207,8 +220,9 @@ export async function readAppPageCacheResponse(
             options.isrSet(
               options.isrHtmlKey(options.cleanPathname),
               buildAppPageCacheValue(revalidatedPage.html, undefined, 200),
-              options.revalidateSeconds,
+              revalidateSeconds,
               revalidatedPage.tags,
+              expireSeconds,
             ),
           );
         }
@@ -219,6 +233,8 @@ export async function readAppPageCacheResponse(
 
       const staleResponse = buildAppPageCachedResponse(cachedValue, {
         cacheState: "STALE",
+        cacheControl: cached.value.cacheControl,
+        expireSeconds: options.expireSeconds,
         isRscRequest: options.isRscRequest,
         mountedSlotsHeader: options.mountedSlotsHeader,
         revalidateSeconds: options.revalidateSeconds,
@@ -289,6 +305,7 @@ export function finalizeAppPageHtmlCacheResponse(
           buildAppPageCacheValue(chunks.join(""), undefined, 200),
           options.revalidateSeconds,
           pageTags,
+          options.expireSeconds,
         ),
       ];
 
@@ -300,6 +317,7 @@ export function finalizeAppPageHtmlCacheResponse(
               buildAppPageCacheValue("", rscData, 200),
               options.revalidateSeconds,
               pageTags,
+              options.expireSeconds,
             ),
           ),
         );
@@ -371,6 +389,7 @@ export function scheduleAppPageRscCacheWrite(
         buildAppPageCacheValue("", rscData, 200),
         options.revalidateSeconds,
         options.getPageTags(),
+        options.expireSeconds,
       );
       options.isrDebug?.("RSC cache written", rscKey);
     } catch (cacheError) {

--- a/packages/vinext/src/server/app-page-cache.ts
+++ b/packages/vinext/src/server/app-page-cache.ts
@@ -59,6 +59,7 @@ type FinalizeAppPageHtmlCacheResponseOptions = {
   isrHtmlKey: (pathname: string) => string;
   isrRscKey: (pathname: string, mountedSlotsHeader?: string | null) => string;
   isrSet: AppPageCacheSetter;
+  preserveClientResponseHeaders?: boolean;
   expireSeconds?: number;
   revalidateSeconds: number | null;
   waitUntil?: (promise: Promise<void>) => void;
@@ -75,6 +76,7 @@ type ScheduleAppPageRscCacheWriteOptions = {
   isrRscKey: (pathname: string, mountedSlotsHeader?: string | null) => string;
   isrSet: AppPageCacheSetter;
   mountedSlotsHeader?: string | null;
+  preserveClientResponseHeaders?: boolean;
   expireSeconds?: number;
   revalidateSeconds: number | null;
   waitUntil?: (promise: Promise<void>) => void;
@@ -306,11 +308,13 @@ export function finalizeAppPageHtmlCacheResponse(
   const htmlKey = options.isrHtmlKey(options.cleanPathname);
   const rscKey = options.isrRscKey(options.cleanPathname, null);
   const clientHeaders = new Headers(response.headers);
-  // HTML Server Components can access request APIs while the stream is being
-  // consumed. Until that late dynamic check finishes, downstream shared caches
-  // must not cache the speculative MISS response.
-  clientHeaders.set("Cache-Control", NO_STORE_CACHE_CONTROL);
-  clientHeaders.set("X-Vinext-Cache", "MISS");
+  if (options.preserveClientResponseHeaders !== true) {
+    // HTML Server Components can access request APIs while the stream is being
+    // consumed. Until that late dynamic check finishes, downstream shared caches
+    // must not cache a response whose ISR policy was known before streaming.
+    clientHeaders.set("Cache-Control", NO_STORE_CACHE_CONTROL);
+    clientHeaders.set("X-Vinext-Cache", "MISS");
+  }
 
   const cachePromise = (async () => {
     try {
@@ -391,10 +395,14 @@ export function finalizeAppPageRscCacheResponse(
     return response;
   }
 
+  if (options.preserveClientResponseHeaders === true) {
+    return response;
+  }
+
   const clientHeaders = new Headers(response.headers);
   // RSC payloads are also streamed lazily. Until the captured stream proves no
   // late request API was used, the client-facing MISS response must not enter a
-  // shared cache.
+  // shared cache when the ISR policy was known before streaming.
   clientHeaders.set("Cache-Control", NO_STORE_CACHE_CONTROL);
   clientHeaders.set("X-Vinext-Cache", "MISS");
 

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -536,6 +536,7 @@ export async function dispatchAppPage<TRoute extends AppPageDispatchRoute>(
     isDynamicError,
     isForceDynamic,
     isForceStatic,
+    isPrerender: process.env.VINEXT_PRERENDER === "1",
     isProduction: options.isProduction,
     isRscRequest: options.isRscRequest,
     isrDebug: options.isrDebug,

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -335,6 +335,8 @@ export async function dispatchAppPage<TRoute extends AppPageDispatchRoute>(
       isrSet: options.isrSet,
       mountedSlotsHeader: options.mountedSlotsHeader,
       expireSeconds: options.expireSeconds,
+      // cacheLife-only routes discover their actual revalidate during the
+      // fresh render; this seed only gets them into the cache read path.
       revalidateSeconds: currentRevalidateSeconds ?? 0,
       renderFreshPageForCache: async () =>
         runAppPageRevalidationContext(

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -1,6 +1,10 @@
 import type { ReactNode } from "react";
 import type { ClassificationReason } from "../build/layout-classification-types.js";
-import { _consumeRequestScopedCacheLife, type CachedAppPageValue } from "vinext/shims/cache";
+import {
+  _consumeRequestScopedCacheLife,
+  _peekRequestScopedCacheLife,
+  type CachedAppPageValue,
+} from "vinext/shims/cache";
 import {
   consumeDynamicUsage,
   consumeInvalidDynamicUsageError,
@@ -523,6 +527,9 @@ export async function dispatchAppPage<TRoute extends AppPageDispatchRoute>(
     },
     getRequestCacheLife() {
       return _consumeRequestScopedCacheLife();
+    },
+    peekRequestCacheLife() {
+      return _peekRequestScopedCacheLife();
     },
     handlerStart: options.handlerStart,
     hasLoadingBoundary: Boolean(route.loading?.default),

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -58,6 +58,7 @@ type AppPageCacheSetter = (
   data: CachedAppPageValue,
   revalidateSeconds: number,
   tags: string[],
+  expireSeconds?: number,
 ) => Promise<void>;
 type AppPageCacheGetter = (key: string) => Promise<ISRCacheEntry | null>;
 type AppPageBackgroundRegenerationErrorContext = {
@@ -146,6 +147,7 @@ type DispatchAppPageOptions<TRoute extends AppPageDispatchRoute> = {
   params: AppPageParams;
   probeLayoutAt: (layoutIndex: number) => unknown;
   probePage: () => unknown;
+  expireSeconds?: number;
   renderErrorBoundaryPage: (error: unknown) => Promise<Response | null>;
   renderHttpAccessFallbackPage: (
     statusCode: number,
@@ -188,9 +190,8 @@ function shouldReadAppPageCache(options: {
     options.isProduction &&
     !options.isForceDynamic &&
     (options.isRscRequest || !options.scriptNonce) &&
-    options.revalidateSeconds !== null &&
-    options.revalidateSeconds > 0 &&
-    options.revalidateSeconds !== Infinity
+    (options.revalidateSeconds === null ||
+      (options.revalidateSeconds > 0 && options.revalidateSeconds !== Infinity))
   );
 }
 
@@ -333,6 +334,7 @@ export async function dispatchAppPage<TRoute extends AppPageDispatchRoute>(
       isrRscKey: options.isrRscKey,
       isrSet: options.isrSet,
       mountedSlotsHeader: options.mountedSlotsHeader,
+      expireSeconds: options.expireSeconds,
       revalidateSeconds: currentRevalidateSeconds ?? 0,
       renderFreshPageForCache: async () =>
         runAppPageRevalidationContext(
@@ -378,15 +380,24 @@ export async function dispatchAppPage<TRoute extends AppPageDispatchRoute>(
                   }
                 : undefined,
             );
-            options.clearRequestContext();
             const html = await readAppPageTextStream(revalidatedHtmlStream);
             const rscData = await getCapturedRscDataPromise(revalidatedCapturedRscRef.value);
+            const cacheLife = _consumeRequestScopedCacheLife();
+            options.clearRequestContext();
             const tags = buildAppPageTags(
               options.cleanPathname,
               getCollectedFetchTags(),
               route.routeSegments,
             );
-            return { html, rscData, tags };
+            return {
+              html,
+              rscData,
+              tags,
+              cacheControl:
+                typeof cacheLife?.revalidate === "number"
+                  ? { revalidate: cacheLife.revalidate, expire: cacheLife.expire }
+                  : undefined,
+            };
           },
         ),
       scheduleBackgroundRegeneration(key, renderFn) {
@@ -522,6 +533,7 @@ export async function dispatchAppPage<TRoute extends AppPageDispatchRoute>(
     isrHtmlKey: options.isrHtmlKey,
     isrRscKey: options.isrRscKey,
     isrSet: options.isrSet,
+    expireSeconds: options.expireSeconds,
     layoutCount: route.layouts.length,
     loadSsrHandler: options.loadSsrHandler,
     middlewareContext: options.middlewareContext,

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -261,6 +261,8 @@ export async function renderAppPageLifecycle(
           : Math.min(revalidateSeconds, requestCacheLife.revalidate);
     }
     if (requestCacheLife?.expire !== undefined) {
+      // cacheLife() supplies the effective hard-expire ceiling for this render,
+      // so it replaces the config fallback instead of min-merging with it.
       expireSeconds = requestCacheLife.expire;
     }
 
@@ -398,6 +400,8 @@ export async function renderAppPageLifecycle(
         : Math.min(revalidateSeconds, requestCacheLife.revalidate);
   }
   if (requestCacheLife?.expire !== undefined) {
+    // cacheLife() supplies the effective hard-expire ceiling for this render,
+    // so it replaces the config fallback instead of min-merging with it.
     expireSeconds = requestCacheLife.expire;
   }
 

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -129,6 +129,9 @@ function buildResponseTiming(
 function readRequestCacheLifeForPrerender(
   options: Pick<RenderAppPageLifecycleOptions, "getRequestCacheLife" | "peekRequestCacheLife">,
 ): AppPageRequestCacheLife | null {
+  // Prefer the non-destructive reader so prerender.ts can consume metadata
+  // after the handler returns. The consume fallback supports older entry glue
+  // and is only safe because this path reads at most once per prerender.
   return options.peekRequestCacheLife?.() ?? options.getRequestCacheLife();
 }
 

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -65,6 +65,7 @@ type RenderAppPageLifecycleOptions = {
   getNavigationContext: () => unknown;
   getPageTags: () => string[];
   getRequestCacheLife: () => AppPageRequestCacheLife | null;
+  peekRequestCacheLife?: () => AppPageRequestCacheLife | null;
   getDraftModeCookieHeader: () => string | null | undefined;
   handlerStart: number;
   hasLoadingBoundary: boolean;
@@ -123,6 +124,36 @@ function buildResponseTiming(
     renderEnd: options.renderEnd,
     responseKind: options.responseKind,
   };
+}
+
+function readRequestCacheLifeForPrerender(
+  options: Pick<RenderAppPageLifecycleOptions, "getRequestCacheLife" | "peekRequestCacheLife">,
+): AppPageRequestCacheLife | null {
+  return options.peekRequestCacheLife?.() ?? options.getRequestCacheLife();
+}
+
+function applyRequestCacheLife(options: {
+  expireSeconds?: number;
+  requestCacheLife: AppPageRequestCacheLife | null;
+  revalidateSeconds: number | null;
+}): { expireSeconds?: number; revalidateSeconds: number | null } {
+  let revalidateSeconds = options.revalidateSeconds;
+  let expireSeconds = options.expireSeconds;
+  const requestCacheLife = options.requestCacheLife;
+
+  if (requestCacheLife?.revalidate !== undefined) {
+    revalidateSeconds =
+      revalidateSeconds === null
+        ? requestCacheLife.revalidate
+        : Math.min(revalidateSeconds, requestCacheLife.revalidate);
+  }
+  if (requestCacheLife?.expire !== undefined) {
+    // cacheLife() supplies the effective hard-expire ceiling for this render,
+    // so it replaces the config fallback instead of min-merging with it.
+    expireSeconds = requestCacheLife.expire;
+  }
+
+  return { expireSeconds, revalidateSeconds };
 }
 
 /**
@@ -254,18 +285,11 @@ export async function renderAppPageLifecycle(
   if (options.isRscRequest) {
     if (options.isPrerender === true) {
       await settleCapturedRscRenderForCacheMetadata(capturedRscDataRef.value);
-      const requestCacheLife = options.getRequestCacheLife();
-      if (requestCacheLife?.revalidate !== undefined) {
-        revalidateSeconds =
-          revalidateSeconds === null
-            ? requestCacheLife.revalidate
-            : Math.min(revalidateSeconds, requestCacheLife.revalidate);
-      }
-      if (requestCacheLife?.expire !== undefined) {
-        // cacheLife() supplies the effective hard-expire ceiling for this render,
-        // so it replaces the config fallback instead of min-merging with it.
-        expireSeconds = requestCacheLife.expire;
-      }
+      ({ expireSeconds, revalidateSeconds } = applyRequestCacheLife({
+        expireSeconds,
+        requestCacheLife: readRequestCacheLifeForPrerender(options),
+        revalidateSeconds,
+      }));
     }
 
     const dynamicUsedDuringBuild = options.consumeDynamicUsage();
@@ -392,23 +416,14 @@ export async function renderAppPageLifecycle(
   // Eagerly read values that must be captured before the stream is consumed.
   if (options.isPrerender === true) {
     await settleCapturedRscRenderForCacheMetadata(capturedRscDataRef.value);
+    ({ expireSeconds, revalidateSeconds } = applyRequestCacheLife({
+      expireSeconds,
+      requestCacheLife: readRequestCacheLifeForPrerender(options),
+      revalidateSeconds,
+    }));
   }
   const draftCookie = options.getDraftModeCookieHeader();
   const dynamicUsedDuringRender = options.consumeDynamicUsage();
-  if (options.isPrerender === true) {
-    const requestCacheLife = options.getRequestCacheLife();
-    if (requestCacheLife?.revalidate !== undefined) {
-      revalidateSeconds =
-        revalidateSeconds === null
-          ? requestCacheLife.revalidate
-          : Math.min(revalidateSeconds, requestCacheLife.revalidate);
-    }
-    if (requestCacheLife?.expire !== undefined) {
-      // cacheLife() supplies the effective hard-expire ceiling for this render,
-      // so it replaces the config fallback instead of min-merging with it.
-      expireSeconds = requestCacheLife.expire;
-    }
-  }
 
   // Defer clearRequestContext() until the HTML stream is fully consumed by the
   // HTTP layer. The RSC/SSR pipeline is lazy — Server Components execute while

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -252,18 +252,20 @@ export async function renderAppPageLifecycle(
   }
 
   if (options.isRscRequest) {
-    await settleCapturedRscRenderForCacheMetadata(capturedRscDataRef.value);
-    const requestCacheLife = options.getRequestCacheLife();
-    if (requestCacheLife?.revalidate !== undefined) {
-      revalidateSeconds =
-        revalidateSeconds === null
-          ? requestCacheLife.revalidate
-          : Math.min(revalidateSeconds, requestCacheLife.revalidate);
-    }
-    if (requestCacheLife?.expire !== undefined) {
-      // cacheLife() supplies the effective hard-expire ceiling for this render,
-      // so it replaces the config fallback instead of min-merging with it.
-      expireSeconds = requestCacheLife.expire;
+    if (options.isPrerender === true) {
+      await settleCapturedRscRenderForCacheMetadata(capturedRscDataRef.value);
+      const requestCacheLife = options.getRequestCacheLife();
+      if (requestCacheLife?.revalidate !== undefined) {
+        revalidateSeconds =
+          revalidateSeconds === null
+            ? requestCacheLife.revalidate
+            : Math.min(revalidateSeconds, requestCacheLife.revalidate);
+      }
+      if (requestCacheLife?.expire !== undefined) {
+        // cacheLife() supplies the effective hard-expire ceiling for this render,
+        // so it replaces the config fallback instead of min-merging with it.
+        expireSeconds = requestCacheLife.expire;
+      }
     }
 
     const dynamicUsedDuringBuild = options.consumeDynamicUsage();
@@ -308,24 +310,22 @@ export async function renderAppPageLifecycle(
 
     return finalizeAppPageRscCacheResponse(devRscResponse, {
       capturedRscDataPromise:
-        options.isProduction &&
-        revalidateSeconds !== null &&
-        revalidateSeconds > 0 &&
-        revalidateSeconds !== Infinity
-          ? capturedRscDataRef.value
-          : null,
+        options.isProduction && shouldCaptureRscForCacheMetadata ? capturedRscDataRef.value : null,
       cleanPathname: options.cleanPathname,
       consumeDynamicUsage: options.consumeDynamicUsage,
       dynamicUsedDuringBuild,
       getPageTags() {
         return options.getPageTags();
       },
+      getRequestCacheLife() {
+        return options.getRequestCacheLife();
+      },
       isrDebug: options.isrDebug,
       isrRscKey: options.isrRscKey,
       isrSet: options.isrSet,
       mountedSlotsHeader: options.mountedSlotsHeader,
       expireSeconds,
-      revalidateSeconds: revalidateSeconds ?? 0,
+      revalidateSeconds,
       waitUntil(promise) {
         options.waitUntil?.(promise);
       },
@@ -389,20 +389,24 @@ export async function renderAppPageLifecycle(
   }
 
   // Eagerly read values that must be captured before the stream is consumed.
-  await settleCapturedRscRenderForCacheMetadata(capturedRscDataRef.value);
+  if (options.isPrerender === true) {
+    await settleCapturedRscRenderForCacheMetadata(capturedRscDataRef.value);
+  }
   const draftCookie = options.getDraftModeCookieHeader();
   const dynamicUsedDuringRender = options.consumeDynamicUsage();
-  const requestCacheLife = options.getRequestCacheLife();
-  if (requestCacheLife?.revalidate !== undefined) {
-    revalidateSeconds =
-      revalidateSeconds === null
-        ? requestCacheLife.revalidate
-        : Math.min(revalidateSeconds, requestCacheLife.revalidate);
-  }
-  if (requestCacheLife?.expire !== undefined) {
-    // cacheLife() supplies the effective hard-expire ceiling for this render,
-    // so it replaces the config fallback instead of min-merging with it.
-    expireSeconds = requestCacheLife.expire;
+  if (options.isPrerender === true) {
+    const requestCacheLife = options.getRequestCacheLife();
+    if (requestCacheLife?.revalidate !== undefined) {
+      revalidateSeconds =
+        revalidateSeconds === null
+          ? requestCacheLife.revalidate
+          : Math.min(revalidateSeconds, requestCacheLife.revalidate);
+    }
+    if (requestCacheLife?.expire !== undefined) {
+      // cacheLife() supplies the effective hard-expire ceiling for this render,
+      // so it replaces the config fallback instead of min-merging with it.
+      expireSeconds = requestCacheLife.expire;
+    }
   }
 
   // Defer clearRequestContext() until the HTML stream is fully consumed by the
@@ -433,7 +437,16 @@ export async function renderAppPageLifecycle(
     responseKind: "html",
   });
 
-  if (htmlResponsePolicy.shouldWriteToCache) {
+  const shouldSpeculativelyWriteCache =
+    options.isProduction &&
+    shouldCaptureRscForCacheMetadata &&
+    revalidateSeconds === null &&
+    !options.isDynamicError &&
+    !options.isForceStatic &&
+    !options.scriptNonce &&
+    !dynamicUsedDuringRender;
+
+  if (htmlResponsePolicy.shouldWriteToCache || shouldSpeculativelyWriteCache) {
     const isrResponse = buildAppPageHtmlResponse(safeHtmlStream, {
       draftCookie,
       fontLinkHeader,
@@ -453,12 +466,15 @@ export async function renderAppPageLifecycle(
       getPageTags() {
         return options.getPageTags();
       },
+      getRequestCacheLife() {
+        return options.getRequestCacheLife();
+      },
       isrDebug: options.isrDebug,
       isrHtmlKey: options.isrHtmlKey,
       isrRscKey: options.isrRscKey,
       isrSet: options.isrSet,
       expireSeconds,
-      revalidateSeconds: revalidateSeconds ?? 0,
+      revalidateSeconds,
       waitUntil(cachePromise) {
         options.waitUntil?.(cachePromise);
       },

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -324,6 +324,7 @@ export async function renderAppPageLifecycle(
       isrRscKey: options.isrRscKey,
       isrSet: options.isrSet,
       mountedSlotsHeader: options.mountedSlotsHeader,
+      preserveClientResponseHeaders: rscResponsePolicy.cacheState !== "MISS",
       expireSeconds,
       revalidateSeconds,
       waitUntil(promise) {
@@ -473,6 +474,7 @@ export async function renderAppPageLifecycle(
       isrHtmlKey: options.isrHtmlKey,
       isrRscKey: options.isrRscKey,
       isrSet: options.isrSet,
+      preserveClientResponseHeaders: !htmlResponsePolicy.shouldWriteToCache,
       expireSeconds,
       revalidateSeconds,
       waitUntil(cachePromise) {

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -44,10 +44,12 @@ type AppPageCacheSetter = (
   data: CachedAppPageValue,
   revalidateSeconds: number,
   tags: string[],
+  expireSeconds?: number,
 ) => Promise<void>;
 
 type AppPageRequestCacheLife = {
   revalidate?: number;
+  expire?: number;
 };
 
 type RenderAppPageLifecycleOptions = {
@@ -69,6 +71,7 @@ type RenderAppPageLifecycleOptions = {
   isDynamicError: boolean;
   isForceDynamic: boolean;
   isForceStatic: boolean;
+  isPrerender?: boolean;
   isProduction: boolean;
   isRscRequest: boolean;
   isrDebug?: AppPageDebugLogger;
@@ -81,6 +84,7 @@ type RenderAppPageLifecycleOptions = {
   params: Record<string, unknown>;
   probeLayoutAt: (layoutIndex: number) => unknown;
   probePage: () => unknown;
+  expireSeconds?: number;
   revalidateSeconds: number | null;
   renderErrorBoundaryResponse: (error: unknown) => Promise<Response | null>;
   renderLayoutSpecialError: (
@@ -229,14 +233,12 @@ export async function renderAppPageLifecycle(
   });
 
   let revalidateSeconds = options.revalidateSeconds;
-  const rscCapture = teeAppPageRscStreamForCapture(
-    rscStream,
-    options.isProduction &&
-      revalidateSeconds !== null &&
-      revalidateSeconds > 0 &&
-      revalidateSeconds !== Infinity &&
-      !options.isForceDynamic,
-  );
+  let expireSeconds = options.expireSeconds;
+  const shouldCaptureRscForCacheMetadata =
+    (options.isProduction || options.isPrerender === true) &&
+    (revalidateSeconds === null || (revalidateSeconds > 0 && revalidateSeconds !== Infinity)) &&
+    !options.isForceDynamic;
+  const rscCapture = teeAppPageRscStreamForCapture(rscStream, shouldCaptureRscForCacheMetadata);
   const rscForResponse = rscCapture.ssrStream;
 
   // When the fused tee (#981) is active, the sideStream carries both the embed
@@ -250,6 +252,18 @@ export async function renderAppPageLifecycle(
   }
 
   if (options.isRscRequest) {
+    await settleCapturedRscRenderForCacheMetadata(capturedRscDataRef.value);
+    const requestCacheLife = options.getRequestCacheLife();
+    if (requestCacheLife?.revalidate !== undefined) {
+      revalidateSeconds =
+        revalidateSeconds === null
+          ? requestCacheLife.revalidate
+          : Math.min(revalidateSeconds, requestCacheLife.revalidate);
+    }
+    if (requestCacheLife?.expire !== undefined) {
+      expireSeconds = requestCacheLife.expire;
+    }
+
     const dynamicUsedDuringBuild = options.consumeDynamicUsage();
     const rscResponsePolicy = resolveAppPageRscResponsePolicy({
       dynamicUsedDuringBuild,
@@ -257,6 +271,7 @@ export async function renderAppPageLifecycle(
       isForceDynamic: options.isForceDynamic,
       isForceStatic: options.isForceStatic,
       isProduction: options.isProduction,
+      expireSeconds,
       revalidateSeconds,
     });
     const rscResponse = buildAppPageRscResponse(rscForResponse, {
@@ -290,7 +305,13 @@ export async function renderAppPageLifecycle(
         : rscResponse;
 
     return finalizeAppPageRscCacheResponse(devRscResponse, {
-      capturedRscDataPromise: options.isProduction ? capturedRscDataRef.value : null,
+      capturedRscDataPromise:
+        options.isProduction &&
+        revalidateSeconds !== null &&
+        revalidateSeconds > 0 &&
+        revalidateSeconds !== Infinity
+          ? capturedRscDataRef.value
+          : null,
       cleanPathname: options.cleanPathname,
       consumeDynamicUsage: options.consumeDynamicUsage,
       dynamicUsedDuringBuild,
@@ -301,6 +322,7 @@ export async function renderAppPageLifecycle(
       isrRscKey: options.isrRscKey,
       isrSet: options.isrSet,
       mountedSlotsHeader: options.mountedSlotsHeader,
+      expireSeconds,
       revalidateSeconds: revalidateSeconds ?? 0,
       waitUntil(promise) {
         options.waitUntil?.(promise);
@@ -365,11 +387,18 @@ export async function renderAppPageLifecycle(
   }
 
   // Eagerly read values that must be captured before the stream is consumed.
+  await settleCapturedRscRenderForCacheMetadata(capturedRscDataRef.value);
   const draftCookie = options.getDraftModeCookieHeader();
   const dynamicUsedDuringRender = options.consumeDynamicUsage();
   const requestCacheLife = options.getRequestCacheLife();
-  if (requestCacheLife?.revalidate !== undefined && revalidateSeconds === null) {
-    revalidateSeconds = requestCacheLife.revalidate;
+  if (requestCacheLife?.revalidate !== undefined) {
+    revalidateSeconds =
+      revalidateSeconds === null
+        ? requestCacheLife.revalidate
+        : Math.min(revalidateSeconds, requestCacheLife.revalidate);
+  }
+  if (requestCacheLife?.expire !== undefined) {
+    expireSeconds = requestCacheLife.expire;
   }
 
   // Defer clearRequestContext() until the HTML stream is fully consumed by the
@@ -389,6 +418,7 @@ export async function renderAppPageLifecycle(
     isForceDynamic: options.isForceDynamic,
     isForceStatic: options.isForceStatic,
     isProduction: options.isProduction,
+    expireSeconds,
     revalidateSeconds,
   });
   const htmlResponseTiming = buildResponseTiming({
@@ -407,6 +437,11 @@ export async function renderAppPageLifecycle(
       policy: htmlResponsePolicy,
       timing: htmlResponseTiming,
     });
+
+    if (options.isPrerender === true) {
+      return isrResponse;
+    }
+
     return finalizeAppPageHtmlCacheResponse(isrResponse, {
       capturedRscDataPromise: capturedRscDataRef.value,
       cleanPathname: options.cleanPathname,
@@ -418,6 +453,7 @@ export async function renderAppPageLifecycle(
       isrHtmlKey: options.isrHtmlKey,
       isrRscKey: options.isrRscKey,
       isrSet: options.isrSet,
+      expireSeconds,
       revalidateSeconds: revalidateSeconds ?? 0,
       waitUntil(cachePromise) {
         options.waitUntil?.(cachePromise);
@@ -432,4 +468,20 @@ export async function renderAppPageLifecycle(
     policy: htmlResponsePolicy,
     timing: htmlResponseTiming,
   });
+}
+
+async function settleCapturedRscRenderForCacheMetadata(
+  capturedRscDataPromise: Promise<ArrayBuffer> | null,
+): Promise<void> {
+  if (!capturedRscDataPromise) {
+    return;
+  }
+
+  try {
+    await capturedRscDataPromise;
+  } catch {
+    // The response stream and cache-write path own render error propagation.
+    // This pre-read only makes "use cache" metadata available before headers
+    // and ISR seed metadata are finalized.
+  }
 }

--- a/packages/vinext/src/server/app-page-response.ts
+++ b/packages/vinext/src/server/app-page-response.ts
@@ -1,3 +1,8 @@
+import {
+  buildRevalidateCacheControl,
+  NO_STORE_CACHE_CONTROL,
+  STATIC_CACHE_CONTROL,
+} from "./cache-control.js";
 import { mergeMiddlewareResponseHeaders } from "./middleware-response-headers.js";
 
 export type AppPageMiddlewareContext = {
@@ -22,6 +27,7 @@ type ResolveAppPageResponsePolicyBaseOptions = {
   isForceDynamic: boolean;
   isForceStatic: boolean;
   isProduction: boolean;
+  expireSeconds?: number;
   revalidateSeconds: number | null;
 };
 
@@ -53,13 +59,6 @@ type BuildAppPageHtmlResponseOptions = {
   policy: AppPageResponsePolicy;
   timing?: AppPageResponseTiming;
 };
-
-const STATIC_CACHE_CONTROL = "s-maxage=31536000, stale-while-revalidate";
-const NO_STORE_CACHE_CONTROL = "no-store, must-revalidate";
-
-function buildRevalidateCacheControl(revalidateSeconds: number): string {
-  return `s-maxage=${revalidateSeconds}, stale-while-revalidate`;
-}
 
 function applyTimingHeader(headers: Headers, timing?: AppPageResponseTiming): void {
   if (!timing) {
@@ -106,7 +105,7 @@ export function resolveAppPageRscResponsePolicy(
 
   if (options.revalidateSeconds) {
     return {
-      cacheControl: buildRevalidateCacheControl(options.revalidateSeconds),
+      cacheControl: buildRevalidateCacheControl(options.revalidateSeconds, options.expireSeconds),
       // Emit MISS as part of the initial RSC response shape rather than bolting
       // it on later in the cache-write block so response construction stays
       // centralized in this helper. This matches the eventual write path: the
@@ -167,7 +166,7 @@ export function resolveAppPageHtmlResponsePolicy(
     options.revalidateSeconds !== Infinity
   ) {
     return {
-      cacheControl: buildRevalidateCacheControl(options.revalidateSeconds),
+      cacheControl: buildRevalidateCacheControl(options.revalidateSeconds, options.expireSeconds),
       cacheState: options.isProduction ? "MISS" : undefined,
       shouldWriteToCache: options.isProduction,
     };

--- a/packages/vinext/src/server/app-route-handler-cache.ts
+++ b/packages/vinext/src/server/app-route-handler-cache.ts
@@ -43,6 +43,7 @@ type ReadAppRouteHandlerCacheOptions = {
   params: AppRouteParams;
   requestUrl: string;
   revalidateSearchParams: URLSearchParams;
+  expireSeconds?: number;
   revalidateSeconds: number;
   routePattern: string;
   runInRevalidationContext: RouteHandlerRevalidationContextRunner;
@@ -76,6 +77,8 @@ export async function readAppRouteHandlerCacheResponse(
       return applyRouteHandlerMiddlewareContext(
         buildRouteHandlerCachedResponse(cachedValue, {
           cacheState: "HIT",
+          cacheControl: cached?.value.cacheControl,
+          expireSeconds: options.expireSeconds,
           isHead: options.isAutoHead,
           revalidateSeconds: options.revalidateSeconds,
         }),
@@ -122,7 +125,13 @@ export async function readAppRouteHandlerCacheResponse(
             options.getCollectedFetchTags(),
           );
           const routeCacheValue = await buildAppRouteCacheValue(response);
-          await options.isrSet(routeKey, routeCacheValue, options.revalidateSeconds, routeTags);
+          await options.isrSet(
+            routeKey,
+            routeCacheValue,
+            options.revalidateSeconds,
+            routeTags,
+            options.expireSeconds,
+          );
           options.isrDebug?.("route regen complete", routeKey);
         });
       });
@@ -132,6 +141,8 @@ export async function readAppRouteHandlerCacheResponse(
       return applyRouteHandlerMiddlewareContext(
         buildRouteHandlerCachedResponse(staleValue, {
           cacheState: "STALE",
+          cacheControl: cached.value.cacheControl,
+          expireSeconds: options.expireSeconds,
           isHead: options.isAutoHead,
           revalidateSeconds: options.revalidateSeconds,
         }),

--- a/packages/vinext/src/server/app-route-handler-dispatch.ts
+++ b/packages/vinext/src/server/app-route-handler-dispatch.ts
@@ -61,6 +61,7 @@ type DispatchAppRouteHandlerOptions = {
   basePath?: string;
   cleanPathname: string;
   clearRequestContext: () => void;
+  expireSeconds?: number;
   i18n?: NextI18nConfig | null;
   isDevelopment?: boolean;
   isProduction?: boolean;
@@ -192,6 +193,7 @@ export async function dispatchAppRouteHandler(
       params: options.params,
       requestUrl: options.request.url,
       revalidateSearchParams: options.searchParams,
+      expireSeconds: options.expireSeconds,
       revalidateSeconds,
       routePattern: route.pattern,
       runInRevalidationContext(renderFn) {
@@ -248,6 +250,7 @@ export async function dispatchAppRouteHandler(
       params: makeThenableParams(options.params),
       reportRequestError,
       request: options.request,
+      expireSeconds: options.expireSeconds,
       revalidateSeconds,
       routePattern: route.pattern,
       setHeadersAccessPhase,

--- a/packages/vinext/src/server/app-route-handler-execution.ts
+++ b/packages/vinext/src/server/app-route-handler-execution.ts
@@ -40,6 +40,7 @@ export type RouteHandlerCacheSetter = (
   data: CachedRouteValue,
   revalidateSeconds: number,
   tags: string[],
+  expireSeconds?: number,
 ) => Promise<void>;
 type AppRouteErrorReporter = (
   error: Error,
@@ -84,6 +85,7 @@ type ExecuteAppRouteHandlerOptions = {
   method: string;
   middlewareContext: RouteHandlerMiddlewareContext;
   reportRequestError: AppRouteErrorReporter;
+  expireSeconds?: number;
   revalidateSeconds: number | null;
   routePattern: string;
   setHeadersAccessPhase: (phase: HeadersAccessPhase) => HeadersAccessPhase;
@@ -162,7 +164,7 @@ export async function executeAppRouteHandler(
       if (revalidateSeconds == null) {
         throw new Error("Expected route handler revalidate seconds");
       }
-      applyRouteHandlerRevalidateHeader(response, revalidateSeconds);
+      applyRouteHandlerRevalidateHeader(response, revalidateSeconds, options.expireSeconds);
     }
 
     if (
@@ -190,7 +192,13 @@ export async function executeAppRouteHandler(
       const routeWritePromise = (async () => {
         try {
           const routeCacheValue = await buildAppRouteCacheValue(routeClone);
-          await options.isrSet(routeKey, routeCacheValue, revalidateSeconds, routeTags);
+          await options.isrSet(
+            routeKey,
+            routeCacheValue,
+            revalidateSeconds,
+            routeTags,
+            options.expireSeconds,
+          );
           options.isrDebug?.("route cache written", routeKey);
         } catch (cacheErr) {
           console.error("[vinext] ISR route cache write error:", cacheErr);

--- a/packages/vinext/src/server/app-route-handler-response.ts
+++ b/packages/vinext/src/server/app-route-handler-response.ts
@@ -1,4 +1,5 @@
-import type { CachedRouteValue } from "vinext/shims/cache";
+import type { CachedRouteValue, CacheControlMetadata } from "vinext/shims/cache";
+import { buildCachedRevalidateCacheControl, NEVER_CACHE_CONTROL } from "./cache-control.js";
 import { mergeMiddlewareResponseHeaders } from "./middleware-response-headers.js";
 import { processMiddlewareHeaders } from "./request-pipeline.js";
 
@@ -8,7 +9,9 @@ export type RouteHandlerMiddlewareContext = {
 };
 
 type BuildRouteHandlerCachedResponseOptions = {
+  cacheControl?: CacheControlMetadata;
   cacheState: "HIT" | "STALE";
+  expireSeconds?: number;
   isHead: boolean;
   revalidateSeconds: number;
 };
@@ -18,10 +21,6 @@ type FinalizeRouteHandlerResponseOptions = {
   draftCookie?: string | null;
   isHead: boolean;
 };
-
-// Matches Next.js's getCacheControlHeader for revalidate === 0.
-// See .nextjs-ref/packages/next/src/server/lib/cache-control.ts.
-const NEVER_CACHE_CONTROL = "private, no-cache, no-store, max-age=0, must-revalidate";
 
 const APP_ROUTE_REWRITE_ERROR =
   "NextResponse.rewrite() was used in a app route handler, this is not currently supported. Please remove the invocation to continue.";
@@ -38,6 +37,7 @@ function hasMiddlewareHeader(headers: Headers): boolean {
 function buildRouteHandlerCacheControl(
   cacheState: BuildRouteHandlerCachedResponseOptions["cacheState"],
   revalidateSeconds: number,
+  expireSeconds?: number,
 ): string {
   if (revalidateSeconds === 0) {
     // A cached response is never produced for revalidate = 0 (the ISR write
@@ -47,11 +47,7 @@ function buildRouteHandlerCacheControl(
     return NEVER_CACHE_CONTROL;
   }
 
-  if (cacheState === "STALE") {
-    return "s-maxage=0, stale-while-revalidate";
-  }
-
-  return `s-maxage=${revalidateSeconds}, stale-while-revalidate`;
+  return buildCachedRevalidateCacheControl(cacheState, revalidateSeconds, expireSeconds);
 }
 
 export function applyRouteHandlerMiddlewareContext(
@@ -99,9 +95,11 @@ export function buildRouteHandlerCachedResponse(
     }
   }
   headers.set("X-Vinext-Cache", options.cacheState);
+  const revalidateSeconds = options.cacheControl?.revalidate ?? options.revalidateSeconds;
+  const expireSeconds = options.cacheControl?.expire ?? options.expireSeconds;
   headers.set(
     "Cache-Control",
-    buildRouteHandlerCacheControl(options.cacheState, options.revalidateSeconds),
+    buildRouteHandlerCacheControl(options.cacheState, revalidateSeconds, expireSeconds),
   );
 
   return new Response(options.isHead ? null : cachedValue.body, {
@@ -113,8 +111,12 @@ export function buildRouteHandlerCachedResponse(
 export function applyRouteHandlerRevalidateHeader(
   response: Response,
   revalidateSeconds: number,
+  expireSeconds?: number,
 ): void {
-  response.headers.set("cache-control", buildRouteHandlerCacheControl("HIT", revalidateSeconds));
+  response.headers.set(
+    "cache-control",
+    buildRouteHandlerCacheControl("HIT", revalidateSeconds, expireSeconds),
+  );
 }
 
 export function markRouteHandlerCacheMiss(response: Response): void {

--- a/packages/vinext/src/server/app-route-handler-response.ts
+++ b/packages/vinext/src/server/app-route-handler-response.ts
@@ -96,7 +96,10 @@ export function buildRouteHandlerCachedResponse(
   }
   headers.set("X-Vinext-Cache", options.cacheState);
   const revalidateSeconds = options.cacheControl?.revalidate ?? options.revalidateSeconds;
-  const expireSeconds = options.cacheControl?.expire ?? options.expireSeconds;
+  const expireSeconds =
+    options.cacheControl === undefined
+      ? undefined
+      : (options.cacheControl.expire ?? options.expireSeconds);
   headers.set(
     "Cache-Control",
     buildRouteHandlerCacheControl(options.cacheState, revalidateSeconds, expireSeconds),

--- a/packages/vinext/src/server/cache-control.ts
+++ b/packages/vinext/src/server/cache-control.ts
@@ -18,14 +18,19 @@ export function buildRevalidateCacheControl(
   revalidateSeconds: number,
   expireSeconds?: number,
 ): string {
-  const staleWhileRevalidate =
-    expireSeconds === undefined
-      ? ", stale-while-revalidate"
-      : revalidateSeconds < expireSeconds
-        ? `, stale-while-revalidate=${expireSeconds - revalidateSeconds}`
-        : "";
+  if (expireSeconds === undefined) {
+    return `s-maxage=${revalidateSeconds}, stale-while-revalidate`;
+  }
 
-  return `s-maxage=${revalidateSeconds}${staleWhileRevalidate}`;
+  // `expire <= revalidate` is a zero-width stale window: downstream caches
+  // should refetch after s-maxage instead of serving stale.
+  if (revalidateSeconds >= expireSeconds) {
+    return `s-maxage=${revalidateSeconds}`;
+  }
+
+  return `s-maxage=${revalidateSeconds}, stale-while-revalidate=${
+    expireSeconds - revalidateSeconds
+  }`;
 }
 
 /**

--- a/packages/vinext/src/server/cache-control.ts
+++ b/packages/vinext/src/server/cache-control.ts
@@ -1,0 +1,45 @@
+export const NEVER_CACHE_CONTROL = "private, no-cache, no-store, max-age=0, must-revalidate";
+
+export const STATIC_CACHE_CONTROL = "s-maxage=31536000, stale-while-revalidate";
+
+const STALE_REVALIDATE_CACHE_CONTROL = "s-maxage=0, stale-while-revalidate";
+
+export const NO_STORE_CACHE_CONTROL = "no-store, must-revalidate";
+
+/**
+ * Matches Next.js's `getCacheControlHeader` stale window semantics while
+ * preserving vinext's legacy unbounded SWR header when no expire ceiling is
+ * available yet.
+ *
+ * Next.js source:
+ * https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/cache-control.ts
+ */
+export function buildRevalidateCacheControl(
+  revalidateSeconds: number,
+  expireSeconds?: number,
+): string {
+  const staleWhileRevalidate =
+    expireSeconds === undefined
+      ? ", stale-while-revalidate"
+      : revalidateSeconds < expireSeconds
+        ? `, stale-while-revalidate=${expireSeconds - revalidateSeconds}`
+        : "";
+
+  return `s-maxage=${revalidateSeconds}${staleWhileRevalidate}`;
+}
+
+export function buildCachedRevalidateCacheControl(
+  cacheState: "HIT" | "STALE",
+  revalidateSeconds: number,
+  expireSeconds?: number,
+): string {
+  // When expire is known, match Next.js and emit the route policy even for
+  // vinext-served STALE entries. The hard-expire gate has already decided the
+  // stale payload is still usable, and downstream caches should see the same
+  // finite SWR window Next.js would emit from cacheControl metadata.
+  if (cacheState === "STALE" && expireSeconds === undefined) {
+    return STALE_REVALIDATE_CACHE_CONTROL;
+  }
+
+  return buildRevalidateCacheControl(revalidateSeconds, expireSeconds);
+}

--- a/packages/vinext/src/server/cache-control.ts
+++ b/packages/vinext/src/server/cache-control.ts
@@ -28,6 +28,13 @@ export function buildRevalidateCacheControl(
   return `s-maxage=${revalidateSeconds}${staleWhileRevalidate}`;
 }
 
+/**
+ * Builds Cache-Control for ISR cache reads. HIT responses and STALE responses
+ * with stored expire metadata use the same route policy because Next.js derives
+ * this header from cache-control metadata, not from the cache hit/stale state.
+ * STALE entries without expire metadata keep vinext's legacy `s-maxage=0`
+ * fallback so older cache entries are not treated as newly fresh downstream.
+ */
 export function buildCachedRevalidateCacheControl(
   cacheState: "HIT" | "STALE",
   revalidateSeconds: number,

--- a/packages/vinext/src/server/isr-cache.ts
+++ b/packages/vinext/src/server/isr-cache.ts
@@ -66,6 +66,7 @@ export async function isrSet(
       expireSeconds === undefined
         ? { revalidate: revalidateSeconds }
         : { revalidate: revalidateSeconds, expire: expireSeconds },
+    revalidate: revalidateSeconds,
     tags: tags ?? [],
   });
 }

--- a/packages/vinext/src/server/isr-cache.ts
+++ b/packages/vinext/src/server/isr-cache.ts
@@ -40,6 +40,9 @@ export async function isrGet(key: string): Promise<ISRCacheEntry | null> {
   const handler = getCacheHandler();
   const result = await handler.get(key);
   if (!result || !result.value) return null;
+  // Built-in handlers hard-delete expired entries and return null, but custom
+  // CacheHandler implementations may surface expiry explicitly.
+  if (result.cacheState === "expired") return null;
 
   return {
     value: result,
@@ -55,10 +58,14 @@ export async function isrSet(
   data: IncrementalCacheValue,
   revalidateSeconds: number,
   tags?: string[],
+  expireSeconds?: number,
 ): Promise<void> {
   const handler = getCacheHandler();
   await handler.set(key, data, {
-    revalidate: revalidateSeconds,
+    cacheControl:
+      expireSeconds === undefined
+        ? { revalidate: revalidateSeconds }
+        : { revalidate: revalidateSeconds, expire: expireSeconds },
     tags: tags ?? [],
   });
 }

--- a/packages/vinext/src/server/isr-cache.ts
+++ b/packages/vinext/src/server/isr-cache.ts
@@ -66,6 +66,8 @@ export async function isrSet(
       expireSeconds === undefined
         ? { revalidate: revalidateSeconds }
         : { revalidate: revalidateSeconds, expire: expireSeconds },
+    // `revalidate` is the legacy vinext CacheHandler context field. `expire`
+    // is new metadata and intentionally only lives inside cacheControl.
     revalidate: revalidateSeconds,
     tags: tags ?? [],
   });

--- a/packages/vinext/src/server/pages-page-data.ts
+++ b/packages/vinext/src/server/pages-page-data.ts
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import type { Route } from "../routing/pages-router.js";
-import type { CachedPagesValue } from "vinext/shims/cache";
+import type { CachedPagesValue, CacheControlMetadata } from "vinext/shims/cache";
+import { buildCachedRevalidateCacheControl } from "./cache-control.js";
 import { buildPagesCacheValue, type ISRCacheEntry } from "./isr-cache.js";
 import {
   buildPagesNextDataScript,
@@ -90,7 +91,9 @@ export type ResolvePagesPageDataOptions = {
     data: CachedPagesValue,
     revalidateSeconds: number,
     tags?: string[],
+    expireSeconds?: number,
   ) => Promise<void>;
+  expireSeconds?: number;
   pageModule: PagesPageModule;
   params: Record<string, unknown>;
   query: Record<string, unknown>;
@@ -158,14 +161,19 @@ function buildPagesCacheResponse(
   cacheState: "HIT" | "STALE",
   fontLinkHeader: string,
   revalidateSeconds?: number,
+  expireSeconds?: number,
+  cacheControl?: CacheControlMetadata,
 ): Response {
+  const effectiveRevalidateSeconds = cacheControl?.revalidate ?? revalidateSeconds ?? 60;
+  const effectiveExpireSeconds = cacheControl?.expire ?? expireSeconds;
   const headers: Record<string, string> = {
     "Content-Type": "text/html",
     "X-Vinext-Cache": cacheState,
-    "Cache-Control":
-      cacheState === "HIT"
-        ? `s-maxage=${revalidateSeconds ?? 60}, stale-while-revalidate`
-        : "s-maxage=0, stale-while-revalidate",
+    "Cache-Control": buildCachedRevalidateCacheControl(
+      cacheState,
+      effectiveRevalidateSeconds,
+      effectiveExpireSeconds,
+    ),
   };
 
   if (fontLinkHeader) {
@@ -314,7 +322,9 @@ export async function resolvePagesPageData(
           cachedValue.html,
           "HIT",
           options.fontLinkHeader,
-          (cachedValue as CachedPagesValue & { revalidate?: number }).revalidate,
+          undefined,
+          options.expireSeconds,
+          cached.value.cacheControl,
         ),
       };
     }
@@ -353,6 +363,8 @@ export async function resolvePagesPageData(
                 cacheKey,
                 buildPagesCacheValue(freshHtml, freshResult.props),
                 freshResult.revalidate,
+                undefined,
+                options.expireSeconds,
               );
             }
           });
@@ -366,7 +378,14 @@ export async function resolvePagesPageData(
 
       return {
         kind: "response",
-        response: buildPagesCacheResponse(cachedValue.html, "STALE", options.fontLinkHeader),
+        response: buildPagesCacheResponse(
+          cachedValue.html,
+          "STALE",
+          options.fontLinkHeader,
+          undefined,
+          options.expireSeconds,
+          cached.value.cacheControl,
+        ),
       };
     }
 

--- a/packages/vinext/src/server/pages-page-data.ts
+++ b/packages/vinext/src/server/pages-page-data.ts
@@ -164,6 +164,9 @@ function buildPagesCacheResponse(
   expireSeconds?: number,
   cacheControl?: CacheControlMetadata,
 ): Response {
+  // Legacy cache entries written before cacheControl metadata existed can still
+  // hit this path without a persisted revalidate value; keep the historic
+  // 60-second fallback for that migration window.
   const effectiveRevalidateSeconds = cacheControl?.revalidate ?? revalidateSeconds ?? 60;
   const effectiveExpireSeconds = cacheControl?.expire ?? expireSeconds;
   const headers: Record<string, string> = {

--- a/packages/vinext/src/server/pages-page-data.ts
+++ b/packages/vinext/src/server/pages-page-data.ts
@@ -168,7 +168,8 @@ function buildPagesCacheResponse(
   // hit this path without a persisted revalidate value; keep the historic
   // 60-second fallback for that migration window.
   const effectiveRevalidateSeconds = cacheControl?.revalidate ?? revalidateSeconds ?? 60;
-  const effectiveExpireSeconds = cacheControl?.expire ?? expireSeconds;
+  const effectiveExpireSeconds =
+    cacheControl === undefined ? undefined : (cacheControl.expire ?? expireSeconds);
   const headers: Record<string, string> = {
     "Content-Type": "text/html",
     "X-Vinext-Cache": cacheState,

--- a/packages/vinext/src/server/pages-page-response.ts
+++ b/packages/vinext/src/server/pages-page-response.ts
@@ -1,5 +1,6 @@
 import React, { type ComponentType, type ReactNode } from "react";
 import { withScriptNonce } from "vinext/shims/script-nonce-context";
+import { buildRevalidateCacheControl } from "./cache-control.js";
 import { createInlineScriptTag, createNonceAttribute, escapeHtmlAttr } from "./html.js";
 
 type PagesFontPreload = {
@@ -37,6 +38,7 @@ type RenderPagesPageResponseOptions = {
   getSSRHeadHTML?: (() => string) | undefined;
   gsspRes: PagesGsspResponse | null;
   isrCacheKey: (router: string, pathname: string) => string;
+  expireSeconds?: number;
   isrRevalidateSeconds: number | null;
   isrSet: (
     key: string,
@@ -48,6 +50,8 @@ type RenderPagesPageResponseOptions = {
       status: undefined;
     },
     revalidateSeconds: number,
+    tags?: string[],
+    expireSeconds?: number,
   ) => Promise<void>;
   i18n: PagesI18nRenderContext;
   pageProps: Record<string, unknown>;
@@ -294,6 +298,8 @@ export async function renderPagesPageResponse(
         status: undefined,
       },
       options.isrRevalidateSeconds,
+      undefined,
+      options.expireSeconds,
     );
   }
 
@@ -305,7 +311,7 @@ export async function renderPagesPageResponse(
   } else if (options.isrRevalidateSeconds) {
     responseHeaders.set(
       "Cache-Control",
-      `s-maxage=${options.isrRevalidateSeconds}, stale-while-revalidate`,
+      buildRevalidateCacheControl(options.isrRevalidateSeconds, options.expireSeconds),
     );
     responseHeaders.set("X-Vinext-Cache", "MISS");
   }

--- a/packages/vinext/src/server/seed-cache.ts
+++ b/packages/vinext/src/server/seed-cache.ts
@@ -47,6 +47,7 @@ type PrerenderManifestRoute = {
   route: string;
   status: string;
   revalidate?: number | false;
+  expire?: number;
   path?: string;
   router?: "app" | "pages";
 };
@@ -89,11 +90,20 @@ export async function seedMemoryCacheFromPrerender(serverDir: string): Promise<n
     const pathname = route.path ?? route.route;
     const baseKey = isrCacheKey("app", pathname, buildId);
     const revalidateSeconds = typeof route.revalidate === "number" ? route.revalidate : undefined;
+    const expireSeconds = typeof route.expire === "number" ? route.expire : undefined;
 
     if (
-      await seedHtml(handler, prerenderDir, baseKey, pathname, trailingSlash, revalidateSeconds)
+      await seedHtml(
+        handler,
+        prerenderDir,
+        baseKey,
+        pathname,
+        trailingSlash,
+        revalidateSeconds,
+        expireSeconds,
+      )
     ) {
-      await seedRsc(handler, prerenderDir, baseKey, pathname, revalidateSeconds);
+      await seedRsc(handler, prerenderDir, baseKey, pathname, revalidateSeconds, expireSeconds);
       seeded++;
     }
   }
@@ -107,8 +117,14 @@ export async function seedMemoryCacheFromPrerender(serverDir: string): Promise<n
  * Build the CacheHandler context object from a revalidate value.
  * `revalidate: undefined` (static routes) → empty context → no expiry.
  */
-function revalidateCtx(seconds: number | undefined): Record<string, unknown> {
-  return seconds !== undefined ? { revalidate: seconds } : {};
+function revalidateCtx(
+  revalidateSeconds: number | undefined,
+  expireSeconds: number | undefined,
+): Record<string, unknown> {
+  if (revalidateSeconds === undefined) return {};
+  return expireSeconds === undefined
+    ? { cacheControl: { revalidate: revalidateSeconds } }
+    : { cacheControl: { revalidate: revalidateSeconds, expire: expireSeconds } };
 }
 
 /**
@@ -122,6 +138,7 @@ async function seedHtml(
   pathname: string,
   trailingSlash: boolean,
   revalidateSeconds: number | undefined,
+  expireSeconds: number | undefined,
 ): Promise<boolean> {
   const relPath = getOutputPath(pathname, trailingSlash);
   const fullPath = path.join(prerenderDir, relPath);
@@ -137,7 +154,7 @@ async function seedHtml(
   };
 
   const key = baseKey + ":html";
-  await handler.set(key, htmlValue, revalidateCtx(revalidateSeconds));
+  await handler.set(key, htmlValue, revalidateCtx(revalidateSeconds, expireSeconds));
 
   if (revalidateSeconds !== undefined) {
     setRevalidateDuration(key, revalidateSeconds);
@@ -156,6 +173,7 @@ async function seedRsc(
   baseKey: string,
   pathname: string,
   revalidateSeconds: number | undefined,
+  expireSeconds: number | undefined,
 ): Promise<void> {
   const relPath = getRscOutputPath(pathname);
   const fullPath = path.join(prerenderDir, relPath);
@@ -175,7 +193,7 @@ async function seedRsc(
   };
 
   const key = baseKey + ":rsc";
-  await handler.set(key, rscValue, revalidateCtx(revalidateSeconds));
+  await handler.set(key, rscValue, revalidateCtx(revalidateSeconds, expireSeconds));
 
   if (revalidateSeconds !== undefined) {
     setRevalidateDuration(key, revalidateSeconds);

--- a/packages/vinext/src/server/seed-cache.ts
+++ b/packages/vinext/src/server/seed-cache.ts
@@ -123,8 +123,11 @@ function revalidateCtx(
 ): Record<string, unknown> {
   if (revalidateSeconds === undefined) return {};
   return expireSeconds === undefined
-    ? { cacheControl: { revalidate: revalidateSeconds } }
-    : { cacheControl: { revalidate: revalidateSeconds, expire: expireSeconds } };
+    ? { cacheControl: { revalidate: revalidateSeconds }, revalidate: revalidateSeconds }
+    : {
+        cacheControl: { revalidate: revalidateSeconds, expire: expireSeconds },
+        revalidate: revalidateSeconds,
+      };
 }
 
 /**

--- a/packages/vinext/src/shims/cache-runtime.ts
+++ b/packages/vinext/src/shims/cache-runtime.ts
@@ -32,7 +32,9 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import {
   getCacheHandler,
   cacheLifeProfiles,
+  _setRequestScopedCacheLife,
   _registerCacheContextAccessor,
+  type CacheControlMetadata,
   type CacheLifeConfig,
 } from "./cache.js";
 import {
@@ -388,10 +390,7 @@ export function registerCachedFunction<T extends (...args: any[]) => Promise<any
     // In dev mode, always execute fresh — skip shared cache lookup/storage.
     // This ensures HMR changes are reflected immediately.
     if (isDev) {
-      return cacheContextStorage.run(
-        { tags: [], lifeConfigs: [], variant: cacheVariant || "default" },
-        () => fn(...args),
-      );
+      return executeWithContext(fn, args, cacheVariant);
     }
 
     // Shared cache ("use cache" / "use cache: remote")
@@ -405,10 +404,14 @@ export function registerCachedFunction<T extends (...args: any[]) => Promise<any
           // RSC-serialized entry: base64 → bytes → stream → deserialize
           const bytes = base64ToUint8(existing.value.data.body);
           const stream = uint8ToStream(bytes);
-          return await rsc.createFromReadableStream(stream);
+          const result = await rsc.createFromReadableStream(stream);
+          recordRequestScopedCacheControl(existing.cacheControl);
+          return result;
         }
         // JSON-serialized entry (legacy or no RSC available)
-        return JSON.parse(existing.value.data.body);
+        const result = JSON.parse(existing.value.data.body);
+        recordRequestScopedCacheControl(existing.cacheControl);
+        return result;
       } catch {
         // Corrupted entry, fall through to re-execute
       }
@@ -425,6 +428,7 @@ export function registerCachedFunction<T extends (...args: any[]) => Promise<any
 
     // Resolve effective cache life from collected configs
     const effectiveLife = resolveCacheLife(ctx.lifeConfigs);
+    recordRequestScopedCacheLife(effectiveLife);
     const revalidateSeconds =
       effectiveLife.revalidate ?? cacheLifeProfiles.default.revalidate ?? 900;
 
@@ -462,7 +466,10 @@ export function registerCachedFunction<T extends (...args: any[]) => Promise<any
       await handler.set(cacheKey, cacheValue, {
         fetchCache: true,
         tags: ctx.tags,
-        revalidate: revalidateSeconds,
+        cacheControl: {
+          revalidate: revalidateSeconds,
+          expire: effectiveLife.expire,
+        },
       });
     } catch {
       // Result not serializable — skip caching, still return the result
@@ -472,6 +479,18 @@ export function registerCachedFunction<T extends (...args: any[]) => Promise<any
   };
 
   return cachedFn as T;
+}
+
+function recordRequestScopedCacheControl(cacheControl: CacheControlMetadata | undefined): void {
+  if (cacheControl === undefined) return;
+  _setRequestScopedCacheLife({
+    revalidate: cacheControl.revalidate,
+    expire: cacheControl.expire,
+  });
+}
+
+function recordRequestScopedCacheLife(cacheLife: CacheLifeConfig): void {
+  _setRequestScopedCacheLife(cacheLife);
 }
 
 // ---------------------------------------------------------------------------
@@ -491,7 +510,9 @@ async function executeWithContext<T extends (...args: any[]) => Promise<any>>(
     variant: variant || "default",
   };
 
-  return cacheContextStorage.run(ctx, () => fn(...args));
+  const result = await cacheContextStorage.run(ctx, () => fn(...args));
+  recordRequestScopedCacheLife(resolveCacheLife(ctx.lifeConfigs));
+  return result;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/vinext/src/shims/cache.ts
+++ b/packages/vinext/src/shims/cache.ts
@@ -615,6 +615,17 @@ export function _setRequestScopedCacheLife(config: CacheLifeConfig): void {
 }
 
 /**
+ * Read the request-scoped cache life without clearing it. Prerender response
+ * shaping needs the metadata before the manifest writer consumes it after the
+ * body has been fully rendered.
+ * @internal
+ */
+export function _peekRequestScopedCacheLife(): CacheLifeConfig | null {
+  const config = _getCacheState().requestScopedCacheLife;
+  return config === null ? null : { ...config };
+}
+
+/**
  * Consume and reset the request-scoped cache life. Returns null if none was set.
  * @internal
  */

--- a/packages/vinext/src/shims/cache.ts
+++ b/packages/vinext/src/shims/cache.ts
@@ -27,6 +27,7 @@ import {
 } from "./unified-request-context.js";
 import { workUnitAsyncStorage } from "./internal/work-unit-async-storage.js";
 import { makeHangingPromise } from "./internal/make-hanging-promise.js";
+import { readCacheControlNumberField } from "../utils/cache-control-metadata.js";
 
 // ---------------------------------------------------------------------------
 // Lazy accessor for cache context — avoids circular imports with cache-runtime.
@@ -59,7 +60,13 @@ export type CacheHandlerValue = {
   lastModified: number;
   age?: number;
   cacheState?: string;
+  cacheControl?: CacheControlMetadata;
   value: IncrementalCacheValue | null;
+};
+
+export type CacheControlMetadata = {
+  revalidate: number;
+  expire?: number;
 };
 
 /** Discriminated union of cache value types. */
@@ -176,6 +183,8 @@ type MemoryEntry = {
   tags: string[];
   lastModified: number;
   revalidateAt: number | null;
+  expireAt: number | null;
+  cacheControl?: CacheControlMetadata;
 };
 
 function readStringArrayField(ctx: Record<string, unknown> | undefined, field: string): string[] {
@@ -183,19 +192,6 @@ function readStringArrayField(ctx: Record<string, unknown> | undefined, field: s
   if (!Array.isArray(value)) return [];
   return value.filter((item): item is string => typeof item === "string");
 }
-
-/**
- * Shape of the optional `ctx` argument passed to `CacheHandler.set()`.
- * Covers both the older `{ revalidate: number }` shape and the newer
- * `{ cacheControl: { revalidate: number } }` shape (Next.js 16).
- */
-type SetCtx = {
-  tags?: string[];
-  fetchCache?: boolean;
-  revalidate?: number;
-  cacheControl?: { revalidate?: number };
-  [key: string]: unknown;
-};
 
 export class MemoryCacheHandler implements CacheHandler {
   private store = new Map<string, MemoryEntry>();
@@ -223,19 +219,28 @@ export class MemoryCacheHandler implements CacheHandler {
       }
     }
 
-    // Check time-based expiry — return stale entry with cacheState="stale"
+    // Check hard expiry first. Past `expire`, Next.js blocks on fresh
+    // regeneration instead of serving stale with background work.
+    if (entry.expireAt !== null && Date.now() > entry.expireAt) {
+      this.store.delete(key);
+      return null;
+    }
+
+    // Check time-based revalidation — return stale entry with cacheState="stale"
     // instead of deleting, so ISR can serve stale-while-revalidate
     if (entry.revalidateAt !== null && Date.now() > entry.revalidateAt) {
       return {
         lastModified: entry.lastModified,
         value: entry.value,
         cacheState: "stale",
+        cacheControl: entry.cacheControl,
       };
     }
 
     return {
       lastModified: entry.lastModified,
       value: entry.value,
+      cacheControl: entry.cacheControl,
     };
   }
 
@@ -244,40 +249,49 @@ export class MemoryCacheHandler implements CacheHandler {
     data: IncrementalCacheValue | null,
     ctx?: Record<string, unknown>,
   ): Promise<void> {
-    const typedCtx = ctx as SetCtx | undefined;
     const tagSet = new Set<string>();
     if (data && "tags" in data && Array.isArray(data.tags)) {
       for (const t of data.tags) tagSet.add(t);
     }
-    if (typedCtx && Array.isArray(typedCtx.tags)) {
-      for (const t of typedCtx.tags) tagSet.add(t);
+    for (const t of readStringArrayField(ctx, "tags")) {
+      tagSet.add(t);
     }
     const tags = [...tagSet];
 
     // Resolve effective revalidate — data overrides ctx.
     // revalidate: 0 means "don't cache", so skip storage entirely.
     let effectiveRevalidate: number | undefined;
-    if (typedCtx) {
-      const revalidate = typedCtx.cacheControl?.revalidate ?? typedCtx.revalidate;
-      if (typeof revalidate === "number") {
-        effectiveRevalidate = revalidate;
-      }
-    }
+    let effectiveExpire: number | undefined;
+    effectiveRevalidate = readCacheControlNumberField(ctx, "revalidate");
+    effectiveExpire = readCacheControlNumberField(ctx, "expire");
     if (data && "revalidate" in data && typeof data.revalidate === "number") {
       effectiveRevalidate = data.revalidate;
     }
     if (effectiveRevalidate === 0) return;
 
+    const now = Date.now();
     const revalidateAt =
       typeof effectiveRevalidate === "number" && effectiveRevalidate > 0
-        ? Date.now() + effectiveRevalidate * 1000
+        ? now + effectiveRevalidate * 1000
         : null;
+    const expireAt =
+      typeof effectiveExpire === "number" && effectiveExpire > 0
+        ? now + effectiveExpire * 1000
+        : null;
+    const cacheControl =
+      typeof effectiveRevalidate === "number"
+        ? effectiveExpire === undefined
+          ? { revalidate: effectiveRevalidate }
+          : { revalidate: effectiveRevalidate, expire: effectiveExpire }
+        : undefined;
 
     this.store.set(key, {
       value: data,
       tags,
-      lastModified: Date.now(),
+      lastModified: now,
       revalidateAt,
+      expireAt,
+      cacheControl,
     });
   }
 
@@ -569,8 +583,8 @@ export function _initRequestScopedCacheState(): void {
 }
 
 /**
- * Set a request-scoped cache life config. Called by cacheLife() when outside
- * a "use cache" function context.
+ * Set a request-scoped cache life config. Called by cacheLife() so the route
+ * render can inherit cache policy from file-level and nested "use cache" work.
  * @internal
  */
 export function _setRequestScopedCacheLife(config: CacheLifeConfig): void {
@@ -684,6 +698,7 @@ export function cacheLife(profile: string | CacheLifeConfig): void {
     const ctx = _getCacheContextFn?.();
     if (ctx) {
       ctx.lifeConfigs.push(resolvedConfig);
+      _setRequestScopedCacheLife(resolvedConfig);
       return;
     }
   } catch {

--- a/packages/vinext/src/shims/cache.ts
+++ b/packages/vinext/src/shims/cache.ts
@@ -688,7 +688,7 @@ export function cacheLife(profile: string | CacheLifeConfig): void {
     ) {
       console.warn("[vinext] cacheLife: expire must be >= revalidate");
     }
-    resolvedConfig = { ...profile };
+    resolvedConfig = { ...cacheLifeProfiles.default, ...profile };
   } else {
     return;
   }

--- a/packages/vinext/src/utils/cache-control-metadata.ts
+++ b/packages/vinext/src/utils/cache-control-metadata.ts
@@ -1,0 +1,20 @@
+export function isUnknownRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function readRecordField(
+  ctx: Record<string, unknown> | undefined,
+  field: string,
+): Record<string, unknown> | undefined {
+  const value = ctx?.[field];
+  return isUnknownRecord(value) ? value : undefined;
+}
+
+export function readCacheControlNumberField(
+  ctx: Record<string, unknown> | undefined,
+  field: string,
+): number | undefined {
+  const cacheControl = readRecordField(ctx, "cacheControl");
+  const value = cacheControl?.[field] ?? ctx?.[field];
+  return typeof value === "number" ? value : undefined;
+}

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -562,6 +562,7 @@ const __configRewrites = {"beforeFiles":[],"afterFiles":[],"fallback":[]};
 const __configHeaders = [];
 const __publicFiles = new Set([]);
 const __allowedOrigins = [];
+const __expireTime = 31536000;
 
 
 // ── Dev server origin verification ──────────────────────────────────────
@@ -1722,6 +1723,7 @@ const __configRewrites = {"beforeFiles":[{"source":"/api/:path*","destination":"
 const __configHeaders = [{"source":"/api/:path*","headers":[{"key":"X-Custom","value":"test"}]}];
 const __publicFiles = new Set([]);
 const __allowedOrigins = ["https://example.com"];
+const __expireTime = 31536000;
 
 
 // ── Dev server origin verification ──────────────────────────────────────
@@ -2889,6 +2891,7 @@ const __configRewrites = {"beforeFiles":[],"afterFiles":[],"fallback":[]};
 const __configHeaders = [];
 const __publicFiles = new Set([]);
 const __allowedOrigins = [];
+const __expireTime = 31536000;
 
 
 // ── Dev server origin verification ──────────────────────────────────────
@@ -4079,6 +4082,7 @@ const __configRewrites = {"beforeFiles":[],"afterFiles":[],"fallback":[]};
 const __configHeaders = [];
 const __publicFiles = new Set([]);
 const __allowedOrigins = [];
+const __expireTime = 31536000;
 
 
 // ── Dev server origin verification ──────────────────────────────────────
@@ -5252,6 +5256,7 @@ const __configRewrites = {"beforeFiles":[],"afterFiles":[],"fallback":[]};
 const __configHeaders = [];
 const __publicFiles = new Set([]);
 const __allowedOrigins = [];
+const __expireTime = 31536000;
 
 
 // ── Dev server origin verification ──────────────────────────────────────
@@ -6412,6 +6417,7 @@ const __configRewrites = {"beforeFiles":[],"afterFiles":[],"fallback":[]};
 const __configHeaders = [];
 const __publicFiles = new Set([]);
 const __allowedOrigins = [];
+const __expireTime = 31536000;
 
 
 // ── Dev server origin verification ──────────────────────────────────────

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -1098,6 +1098,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     hasPageModule: !!route.page,
     handlerStart: __reqStart,
     interceptionContext: interceptionContextHeader,
+    expireSeconds: __expireTime,
     isProduction: process.env.NODE_ENV === "production",
     isRscRequest,
     isrDebug: __isrDebug,
@@ -2263,6 +2264,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     hasPageModule: !!route.page,
     handlerStart: __reqStart,
     interceptionContext: interceptionContextHeader,
+    expireSeconds: __expireTime,
     isProduction: process.env.NODE_ENV === "production",
     isRscRequest,
     isrDebug: __isrDebug,
@@ -3423,6 +3425,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     hasPageModule: !!route.page,
     handlerStart: __reqStart,
     interceptionContext: interceptionContextHeader,
+    expireSeconds: __expireTime,
     isProduction: process.env.NODE_ENV === "production",
     isRscRequest,
     isrDebug: __isrDebug,
@@ -4615,6 +4618,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     hasPageModule: !!route.page,
     handlerStart: __reqStart,
     interceptionContext: interceptionContextHeader,
+    expireSeconds: __expireTime,
     isProduction: process.env.NODE_ENV === "production",
     isRscRequest,
     isrDebug: __isrDebug,
@@ -5784,6 +5788,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     hasPageModule: !!route.page,
     handlerStart: __reqStart,
     interceptionContext: interceptionContextHeader,
+    expireSeconds: __expireTime,
     isProduction: process.env.NODE_ENV === "production",
     isRscRequest,
     isrDebug: __isrDebug,
@@ -6958,6 +6963,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     hasPageModule: !!route.page,
     handlerStart: __reqStart,
     interceptionContext: interceptionContextHeader,
+    expireSeconds: __expireTime,
     isProduction: process.env.NODE_ENV === "production",
     isRscRequest,
     isrDebug: __isrDebug,
@@ -7191,13 +7197,13 @@ const i18nConfig = null;
 const buildId = "test-build-id";
 
 // Full resolved config for production server (embedded at build time)
-export const vinextConfig = {"basePath":"","trailingSlash":false,"redirects":[{"source":"/old-about","destination":"/about","permanent":true},{"source":"/repeat-redirect/:id","destination":"/docs/:id/:id","permanent":false},{"source":"/redirect-before-middleware-rewrite","destination":"/about","permanent":false},{"source":"/redirect-before-middleware-response","destination":"/about","permanent":false}],"rewrites":{"beforeFiles":[{"source":"/before-rewrite","destination":"/about"},{"source":"/repeat-rewrite/:id","destination":"/docs/:id/:id"},{"source":"/mw-gated-before","has":[{"type":"cookie","key":"mw-before-user"}],"destination":"/about"}],"afterFiles":[{"source":"/after-rewrite","destination":"/about"},{"source":"/mw-gated-rewrite","has":[{"type":"cookie","key":"mw-user"}],"destination":"/about"}],"fallback":[{"source":"/fallback-rewrite","destination":"/about"}]},"headers":[{"source":"/api/(.*)","headers":[{"key":"X-Custom-Header","value":"vinext"}]},{"source":"/about","has":[{"type":"cookie","key":"logged-in"}],"headers":[{"key":"X-Auth-Only-Header","value":"1"}]},{"source":"/about","missing":[{"type":"cookie","key":"logged-in"}],"headers":[{"key":"X-Guest-Only-Header","value":"1"}]},{"source":"/ssr","headers":[{"key":"Vary","value":"Accept-Language"}]},{"source":"/headers-before-middleware-rewrite","headers":[{"key":"X-Rewrite-Source-Header","value":"1"}]}],"i18n":null,"images":{}};
+export const vinextConfig = {"basePath":"","trailingSlash":false,"redirects":[{"source":"/old-about","destination":"/about","permanent":true},{"source":"/repeat-redirect/:id","destination":"/docs/:id/:id","permanent":false},{"source":"/redirect-before-middleware-rewrite","destination":"/about","permanent":false},{"source":"/redirect-before-middleware-response","destination":"/about","permanent":false}],"rewrites":{"beforeFiles":[{"source":"/before-rewrite","destination":"/about"},{"source":"/repeat-rewrite/:id","destination":"/docs/:id/:id"},{"source":"/mw-gated-before","has":[{"type":"cookie","key":"mw-before-user"}],"destination":"/about"}],"afterFiles":[{"source":"/after-rewrite","destination":"/about"},{"source":"/mw-gated-rewrite","has":[{"type":"cookie","key":"mw-user"}],"destination":"/about"}],"fallback":[{"source":"/fallback-rewrite","destination":"/about"}]},"headers":[{"source":"/api/(.*)","headers":[{"key":"X-Custom-Header","value":"vinext"}]},{"source":"/about","has":[{"type":"cookie","key":"logged-in"}],"headers":[{"key":"X-Auth-Only-Header","value":"1"}]},{"source":"/about","missing":[{"type":"cookie","key":"logged-in"}],"headers":[{"key":"X-Guest-Only-Header","value":"1"}]},{"source":"/ssr","headers":[{"key":"Vary","value":"Accept-Language"}]},{"source":"/headers-before-middleware-rewrite","headers":[{"key":"X-Rewrite-Source-Header","value":"1"}]}],"expireTime":31536000,"i18n":null,"images":{}};
 
 function isrGet(key) {
   return __sharedIsrGet(key);
 }
-function isrSet(key, data, revalidateSeconds, tags) {
-  return __sharedIsrSet(key, data, revalidateSeconds, tags);
+function isrSet(key, data, revalidateSeconds, tags, expireSeconds) {
+  return __sharedIsrSet(key, data, revalidateSeconds, tags, expireSeconds);
 }
 function triggerBackgroundRegeneration(key, renderFn, errorContext) {
   return __sharedTriggerBackgroundRegeneration(key, renderFn, errorContext);
@@ -7652,6 +7658,7 @@ async function _renderPage(request, url, manifest, middlewareHeaders) {
         isrCacheKey,
         isrGet,
         isrSet,
+        expireSeconds: vinextConfig.expireTime,
         pageModule,
         params,
         query,
@@ -7724,6 +7731,7 @@ async function _renderPage(request, url, manifest, middlewareHeaders) {
         getSSRHeadHTML: typeof getSSRHeadHTML === "function" ? getSSRHeadHTML : undefined,
         gsspRes,
         isrCacheKey,
+        expireSeconds: vinextConfig.expireTime,
         isrRevalidateSeconds,
         isrSet,
         i18n: {

--- a/tests/app-page-cache.test.ts
+++ b/tests/app-page-cache.test.ts
@@ -10,10 +10,15 @@ import {
 import type { ISRCacheEntry } from "../packages/vinext/src/server/isr-cache.js";
 import type { CachedAppPageValue } from "../packages/vinext/src/shims/cache.js";
 
-function buildISRCacheEntry(value: CachedAppPageValue, isStale = false): ISRCacheEntry {
+function buildISRCacheEntry(
+  value: CachedAppPageValue,
+  isStale = false,
+  cacheControl?: { revalidate: number; expire?: number },
+): ISRCacheEntry {
   return {
     isStale,
     value: {
+      cacheControl,
       lastModified: Date.now(),
       value,
     },
@@ -54,22 +59,55 @@ describe("app page cache helpers", () => {
 
     const htmlResponse = buildAppPageCachedResponse(cachedValue, {
       cacheState: "HIT",
+      expireSeconds: 300,
       isRscRequest: false,
       revalidateSeconds: 60,
     });
     expect(htmlResponse?.status).toBe(201);
     expect(htmlResponse?.headers.get("content-type")).toBe("text/html; charset=utf-8");
+    expect(htmlResponse?.headers.get("cache-control")).toBe(
+      "s-maxage=60, stale-while-revalidate=240",
+    );
     expect(htmlResponse?.headers.get("x-vinext-cache")).toBe("HIT");
     await expect(htmlResponse?.text()).resolves.toBe("<h1>cached</h1>");
 
     const rscResponse = buildAppPageCachedResponse(cachedValue, {
       cacheState: "STALE",
+      expireSeconds: 300,
       isRscRequest: true,
       revalidateSeconds: 60,
     });
     expect(rscResponse?.headers.get("content-type")).toBe("text/x-component; charset=utf-8");
-    expect(rscResponse?.headers.get("cache-control")).toBe("s-maxage=0, stale-while-revalidate");
+    expect(rscResponse?.headers.get("cache-control")).toBe(
+      "s-maxage=60, stale-while-revalidate=240",
+    );
     expect(await rscResponse?.arrayBuffer()).toEqual(rscData);
+  });
+
+  it("uses stored cache-control metadata instead of global config for cached HIT responses", async () => {
+    const cachedValue = buildCachedAppPageValue("<h1>cached</h1>");
+
+    const response = await readAppPageCacheResponse({
+      cleanPathname: "/cached",
+      clearRequestContext: vi.fn(),
+      isRscRequest: false,
+      isrGet: vi.fn(async () =>
+        buildISRCacheEntry(cachedValue, false, { revalidate: 60, expire: 300 }),
+      ),
+      isrHtmlKey(pathname) {
+        return `html:${pathname}`;
+      },
+      isrRscKey(pathname) {
+        return `rsc:${pathname}`;
+      },
+      isrSet: vi.fn(async () => {}),
+      expireSeconds: 31_536_000,
+      revalidateSeconds: 60,
+      renderFreshPageForCache: vi.fn(),
+      scheduleBackgroundRegeneration: vi.fn(),
+    });
+
+    expect(response?.headers.get("cache-control")).toBe("s-maxage=60, stale-while-revalidate=240");
   });
 
   it("falls back to 200 for falsy cached status values", () => {
@@ -175,6 +213,7 @@ describe("app page cache helpers", () => {
       key: string;
       html: string;
       hasRscData: boolean;
+      expireSeconds: number | undefined;
       revalidateSeconds: number;
       tags: string[];
     }> = [];
@@ -193,19 +232,22 @@ describe("app page cache helpers", () => {
       isrRscKey(pathname, mountedSlotsHeader) {
         return `rsc:${pathname}:${mountedSlotsHeader ?? "none"}`;
       },
-      async isrSet(key, data, revalidateSeconds, tags) {
+      async isrSet(key, data, revalidateSeconds, tags, expireSeconds) {
         isrSetCalls.push({
           key,
           html: data.html,
           hasRscData: Boolean(data.rscData),
+          expireSeconds,
           revalidateSeconds,
           tags,
         });
       },
       mountedSlotsHeader: "slot:auth:/",
+      expireSeconds: 300,
       revalidateSeconds: 60,
       async renderFreshPageForCache() {
         return {
+          cacheControl: { revalidate: 10, expire: 20 },
           html: "<h1>fresh</h1>",
           rscData,
           tags: ["/stale", "_N_T_/stale"],
@@ -226,7 +268,8 @@ describe("app page cache helpers", () => {
         key: "rsc:/stale:slot:auth:/",
         html: "",
         hasRscData: true,
-        revalidateSeconds: 60,
+        expireSeconds: 20,
+        revalidateSeconds: 10,
         tags: ["/stale", "_N_T_/stale"],
       },
     ]);
@@ -234,7 +277,11 @@ describe("app page cache helpers", () => {
 
   it("serves stale HTML entries and regenerates HTML plus canonical RSC cache keys", async () => {
     const scheduledRegenerations: Array<() => Promise<void>> = [];
-    const isrSetCalls: Array<string> = [];
+    const isrSetCalls: Array<{
+      key: string;
+      expireSeconds: number | undefined;
+      revalidateSeconds: number;
+    }> = [];
     const rscData = new TextEncoder().encode("fresh-flight").buffer;
 
     const response = await readAppPageCacheResponse({
@@ -250,12 +297,14 @@ describe("app page cache helpers", () => {
       isrRscKey(pathname, mountedSlotsHeader) {
         return `rsc:${pathname}:${mountedSlotsHeader ?? "none"}`;
       },
-      async isrSet(key) {
-        isrSetCalls.push(key);
+      async isrSet(key, _data, revalidateSeconds, _tags, expireSeconds) {
+        isrSetCalls.push({ key, expireSeconds, revalidateSeconds });
       },
+      expireSeconds: 300,
       revalidateSeconds: 60,
       async renderFreshPageForCache() {
         return {
+          cacheControl: { revalidate: 10, expire: 20 },
           html: "<h1>fresh</h1>",
           rscData,
           tags: ["/stale-html", "_N_T_/stale-html"],
@@ -268,7 +317,10 @@ describe("app page cache helpers", () => {
 
     expect(response?.headers.get("x-vinext-cache")).toBe("STALE");
     await scheduledRegenerations[0]();
-    expect(isrSetCalls).toEqual(["rsc:/stale-html:none", "html:/stale-html"]);
+    expect(isrSetCalls).toEqual([
+      { key: "rsc:/stale-html:none", expireSeconds: 20, revalidateSeconds: 10 },
+      { key: "html:/stale-html", expireSeconds: 20, revalidateSeconds: 10 },
+    ]);
   });
 
   it("still schedules stale regeneration when the stale payload is unusable for this request", async () => {
@@ -352,6 +404,7 @@ describe("app page cache helpers", () => {
       key: string;
       html: string;
       hasRscData: boolean;
+      expireSeconds: number | undefined;
       revalidateSeconds: number;
       tags: string[];
     }> = [];
@@ -386,15 +439,17 @@ describe("app page cache helpers", () => {
         isrRscKey(pathname) {
           return "rsc:" + pathname;
         },
-        async isrSet(key, data, revalidateSeconds, tags) {
+        async isrSet(key, data, revalidateSeconds, tags, expireSeconds) {
           isrSetCalls.push({
             key,
             html: data.html,
             hasRscData: Boolean(data.rscData),
+            expireSeconds,
             revalidateSeconds,
             tags,
           });
         },
+        expireSeconds: 300,
         revalidateSeconds: 60,
         waitUntil(promise) {
           pendingCacheWrites.push(promise);
@@ -415,6 +470,7 @@ describe("app page cache helpers", () => {
         key: "html:/fresh",
         html: "<h1>fresh</h1>",
         hasRscData: false,
+        expireSeconds: 300,
         revalidateSeconds: 60,
         tags: ["/fresh", "_N_T_/fresh"],
       },
@@ -422,6 +478,7 @@ describe("app page cache helpers", () => {
         key: "rsc:/fresh",
         html: "",
         hasRscData: true,
+        expireSeconds: 300,
         revalidateSeconds: 60,
         tags: ["/fresh", "_N_T_/fresh"],
       },
@@ -490,6 +547,7 @@ describe("app page cache helpers", () => {
       key: string;
       html: string;
       hasRscData: boolean;
+      expireSeconds: number | undefined;
       revalidateSeconds: number;
       tags: string[];
     }> = [];
@@ -510,15 +568,17 @@ describe("app page cache helpers", () => {
       isrRscKey(pathname) {
         return "rsc:" + pathname;
       },
-      async isrSet(key, data, revalidateSeconds, tags) {
+      async isrSet(key, data, revalidateSeconds, tags, expireSeconds) {
         isrSetCalls.push({
           key,
           html: data.html,
           hasRscData: Boolean(data.rscData),
+          expireSeconds,
           revalidateSeconds,
           tags,
         });
       },
+      expireSeconds: 300,
       revalidateSeconds: 60,
       waitUntil(promise) {
         pendingCacheWrites.push(promise);
@@ -535,6 +595,7 @@ describe("app page cache helpers", () => {
         key: "rsc:/fresh-rsc",
         html: "",
         hasRscData: true,
+        expireSeconds: 300,
         revalidateSeconds: 60,
         tags: ["/fresh-rsc", "_N_T_/fresh-rsc"],
       },

--- a/tests/app-page-cache.test.ts
+++ b/tests/app-page-cache.test.ts
@@ -65,9 +65,7 @@ describe("app page cache helpers", () => {
     });
     expect(htmlResponse?.status).toBe(201);
     expect(htmlResponse?.headers.get("content-type")).toBe("text/html; charset=utf-8");
-    expect(htmlResponse?.headers.get("cache-control")).toBe(
-      "s-maxage=60, stale-while-revalidate=240",
-    );
+    expect(htmlResponse?.headers.get("cache-control")).toBe("s-maxage=60, stale-while-revalidate");
     expect(htmlResponse?.headers.get("x-vinext-cache")).toBe("HIT");
     await expect(htmlResponse?.text()).resolves.toBe("<h1>cached</h1>");
 
@@ -78,9 +76,7 @@ describe("app page cache helpers", () => {
       revalidateSeconds: 60,
     });
     expect(rscResponse?.headers.get("content-type")).toBe("text/x-component; charset=utf-8");
-    expect(rscResponse?.headers.get("cache-control")).toBe(
-      "s-maxage=60, stale-while-revalidate=240",
-    );
+    expect(rscResponse?.headers.get("cache-control")).toBe("s-maxage=0, stale-while-revalidate");
     expect(await rscResponse?.arrayBuffer()).toEqual(rscData);
   });
 
@@ -108,6 +104,34 @@ describe("app page cache helpers", () => {
     });
 
     expect(response?.headers.get("cache-control")).toBe("s-maxage=60, stale-while-revalidate=240");
+  });
+
+  it("preserves legacy STALE headers when cached entries lack cache-control metadata", async () => {
+    const cachedValue = buildCachedAppPageValue("<h1>cached</h1>");
+
+    const response = await readAppPageCacheResponse({
+      cleanPathname: "/cached",
+      clearRequestContext: vi.fn(),
+      isRscRequest: false,
+      isrGet: vi.fn(async () => buildISRCacheEntry(cachedValue, true)),
+      isrHtmlKey(pathname) {
+        return `html:${pathname}`;
+      },
+      isrRscKey(pathname) {
+        return `rsc:${pathname}`;
+      },
+      isrSet: vi.fn(async () => {}),
+      expireSeconds: 31_536_000,
+      revalidateSeconds: 60,
+      renderFreshPageForCache: vi.fn(async () => ({
+        html: "<h1>fresh</h1>",
+        rscData: new ArrayBuffer(0),
+        tags: [],
+      })),
+      scheduleBackgroundRegeneration: vi.fn(),
+    });
+
+    expect(response?.headers.get("cache-control")).toBe("s-maxage=0, stale-while-revalidate");
   });
 
   it("falls back to 200 for falsy cached status values", () => {

--- a/tests/app-page-cache.test.ts
+++ b/tests/app-page-cache.test.ts
@@ -710,4 +710,46 @@ describe("app page cache helpers", () => {
       ["RSC cache write skipped (dynamic usage during render)", "rsc:/dynamic-rsc"],
     ]);
   });
+
+  it("skips cache writes when request cacheLife resolves to a non-finite revalidate", async () => {
+    const pendingCacheWrites: Promise<void>[] = [];
+    const debugCalls: Array<[string, string]> = [];
+    const isrSet = vi.fn();
+
+    const didSchedule = scheduleAppPageRscCacheWrite({
+      capturedRscDataPromise: Promise.resolve(new TextEncoder().encode("flight").buffer),
+      cleanPathname: "/invalid-cache-life",
+      consumeDynamicUsage() {
+        return false;
+      },
+      dynamicUsedDuringBuild: false,
+      getPageTags() {
+        return ["/invalid-cache-life"];
+      },
+      getRequestCacheLife() {
+        return { revalidate: Number.NaN };
+      },
+      isrDebug(event, detail) {
+        debugCalls.push([event, detail]);
+      },
+      isrRscKey(pathname) {
+        return "rsc:" + pathname;
+      },
+      isrSet,
+      revalidateSeconds: null,
+      waitUntil(promise) {
+        pendingCacheWrites.push(promise);
+      },
+    });
+
+    expect(didSchedule).toBe(true);
+    expect(pendingCacheWrites).toHaveLength(1);
+
+    await pendingCacheWrites[0];
+
+    expect(isrSet).not.toHaveBeenCalled();
+    expect(debugCalls).toEqual([
+      ["RSC cache write skipped (no cache policy)", "rsc:/invalid-cache-life"],
+    ]);
+  });
 });

--- a/tests/app-page-render.test.ts
+++ b/tests/app-page-render.test.ts
@@ -326,8 +326,8 @@ describe("app page render lifecycle", () => {
     ).resolves.toBe("returned");
 
     const response = await responsePromise;
-    expect(response.headers.get("cache-control")).toBe("no-store, must-revalidate");
-    expect(response.headers.get("x-vinext-cache")).toBe("MISS");
+    expect(response.headers.get("cache-control")).toBeNull();
+    expect(response.headers.get("x-vinext-cache")).toBeNull();
     expect(common.waitUntilPromises).toHaveLength(1);
 
     releaseRsc.resolve();
@@ -428,8 +428,8 @@ describe("app page render lifecycle", () => {
     ).resolves.toBe("returned");
 
     const response = await responsePromise;
-    expect(response.headers.get("cache-control")).toBe("no-store, must-revalidate");
-    expect(response.headers.get("x-vinext-cache")).toBe("MISS");
+    expect(response.headers.get("cache-control")).toBeNull();
+    expect(response.headers.get("x-vinext-cache")).toBeNull();
     expect(common.waitUntilPromises).toHaveLength(1);
 
     releaseRsc.resolve();
@@ -451,6 +451,43 @@ describe("app page render lifecycle", () => {
       ["_N_T_/posts/post"],
       9,
     );
+  });
+
+  it("preserves original production RSC response headers when speculative cacheLife never appears", async () => {
+    const common = createCommonOptions();
+
+    const response = await renderAppPageLifecycle({
+      ...common.options,
+      isProduction: true,
+      isRscRequest: true,
+      revalidateSeconds: null,
+    });
+
+    expect(response.headers.get("cache-control")).toBeNull();
+    expect(response.headers.get("x-vinext-cache")).toBeNull();
+    expect(common.waitUntilPromises).toHaveLength(1);
+
+    await expect(response.text()).resolves.toBe("flight-data");
+    await Promise.all(common.waitUntilPromises);
+    expect(common.isrSet).not.toHaveBeenCalled();
+  });
+
+  it("preserves original production HTML response headers when speculative cacheLife never appears", async () => {
+    const common = createCommonOptions();
+
+    const response = await renderAppPageLifecycle({
+      ...common.options,
+      isProduction: true,
+      revalidateSeconds: null,
+    });
+
+    expect(response.headers.get("cache-control")).toBeNull();
+    expect(response.headers.get("x-vinext-cache")).toBeNull();
+    expect(common.waitUntilPromises).toHaveLength(1);
+
+    await expect(response.text()).resolves.toBe("<html>page</html>");
+    await Promise.all(common.waitUntilPromises);
+    expect(common.isrSet).not.toHaveBeenCalled();
   });
 
   it("captures prerender cache metadata before building non-production HTML responses", async () => {

--- a/tests/app-page-render.test.ts
+++ b/tests/app-page-render.test.ts
@@ -562,6 +562,45 @@ describe("app page render lifecycle", () => {
     expect(common.isrSet).not.toHaveBeenCalled();
   });
 
+  it("preserves prerender cache metadata for the manifest writer after shaping headers", async () => {
+    const common = createCommonOptions();
+    let requestCacheLife: { revalidate: number; expire: number } | null = null;
+    const consumeRequestCacheLife = () => {
+      const value = requestCacheLife;
+      requestCacheLife = null;
+      return value;
+    };
+
+    const response = await renderAppPageLifecycle({
+      ...common.options,
+      getRequestCacheLife: consumeRequestCacheLife,
+      isPrerender: true,
+      isProduction: false,
+      peekRequestCacheLife() {
+        return requestCacheLife;
+      },
+      renderToReadableStream() {
+        let sent = false;
+        return new ReadableStream<Uint8Array>({
+          pull(controller) {
+            if (sent) {
+              controller.close();
+              return;
+            }
+            requestCacheLife = { revalidate: 1, expire: 1 };
+            controller.enqueue(new TextEncoder().encode("flight-data"));
+            sent = true;
+          },
+        });
+      },
+      revalidateSeconds: null,
+    });
+
+    expect(response.headers.get("cache-control")).toBe("s-maxage=1");
+    await expect(response.text()).resolves.toBe("<html>page</html>");
+    expect(consumeRequestCacheLife()).toEqual({ revalidate: 1, expire: 1 });
+  });
+
   it("preserves prerender cache metadata headers in production mode without ISR writes", async () => {
     const common = createCommonOptions();
     let requestCacheLife: { revalidate: number; expire: number } | null = null;

--- a/tests/app-page-render.test.ts
+++ b/tests/app-page-render.test.ts
@@ -278,6 +278,7 @@ describe("app page render lifecycle", () => {
       expect.objectContaining({ kind: "APP_PAGE" }),
       60,
       ["_N_T_/posts/post"],
+      undefined,
     );
     expect(consumeDynamicUsage).toHaveBeenCalledTimes(2);
   });
@@ -324,6 +325,7 @@ describe("app page render lifecycle", () => {
       expect.objectContaining({ kind: "APP_PAGE" }),
       30,
       ["_N_T_/posts/post"],
+      undefined,
     );
     expect(common.isrSet).toHaveBeenNthCalledWith(
       2,
@@ -331,7 +333,117 @@ describe("app page render lifecycle", () => {
       expect.objectContaining({ kind: "APP_PAGE" }),
       30,
       ["_N_T_/posts/post"],
+      undefined,
     );
+  });
+
+  it("captures prerender cache metadata before building non-production HTML responses", async () => {
+    const common = createCommonOptions();
+    let requestCacheLife: { revalidate: number; expire: number } | null = null;
+
+    const response = await renderAppPageLifecycle({
+      ...common.options,
+      getRequestCacheLife() {
+        const value = requestCacheLife;
+        requestCacheLife = null;
+        return value;
+      },
+      isPrerender: true,
+      isProduction: false,
+      renderToReadableStream() {
+        let sent = false;
+        return new ReadableStream<Uint8Array>({
+          pull(controller) {
+            if (sent) {
+              controller.close();
+              return;
+            }
+            requestCacheLife = { revalidate: 1, expire: 3 };
+            controller.enqueue(new TextEncoder().encode("flight-data"));
+            sent = true;
+          },
+        });
+      },
+      revalidateSeconds: 1,
+    });
+
+    expect(response.headers.get("cache-control")).toBe("s-maxage=1, stale-while-revalidate=2");
+    expect(response.headers.get("x-vinext-cache")).toBeNull();
+    await expect(response.text()).resolves.toBe("<html>page</html>");
+    expect(common.waitUntilPromises).toHaveLength(0);
+    expect(common.isrSet).not.toHaveBeenCalled();
+  });
+
+  it("captures prerender cache metadata when cacheLife provides the only revalidate value", async () => {
+    const common = createCommonOptions();
+    let requestCacheLife: { revalidate: number; expire: number } | null = null;
+
+    const response = await renderAppPageLifecycle({
+      ...common.options,
+      getRequestCacheLife() {
+        const value = requestCacheLife;
+        requestCacheLife = null;
+        return value;
+      },
+      isPrerender: true,
+      isProduction: false,
+      renderToReadableStream() {
+        let sent = false;
+        return new ReadableStream<Uint8Array>({
+          pull(controller) {
+            if (sent) {
+              controller.close();
+              return;
+            }
+            requestCacheLife = { revalidate: 1, expire: 3 };
+            controller.enqueue(new TextEncoder().encode("flight-data"));
+            sent = true;
+          },
+        });
+      },
+      revalidateSeconds: null,
+    });
+
+    expect(response.headers.get("cache-control")).toBe("s-maxage=1, stale-while-revalidate=2");
+    await expect(response.text()).resolves.toBe("<html>page</html>");
+    expect(common.isrSet).not.toHaveBeenCalled();
+  });
+
+  it("preserves prerender cache metadata headers in production mode without ISR writes", async () => {
+    const common = createCommonOptions();
+    let requestCacheLife: { revalidate: number; expire: number } | null = null;
+
+    const response = await renderAppPageLifecycle({
+      ...common.options,
+      getRequestCacheLife() {
+        const value = requestCacheLife;
+        requestCacheLife = null;
+        return value;
+      },
+      isPrerender: true,
+      isProduction: true,
+      renderToReadableStream() {
+        let sent = false;
+        return new ReadableStream<Uint8Array>({
+          pull(controller) {
+            if (sent) {
+              controller.close();
+              return;
+            }
+            requestCacheLife = { revalidate: 1, expire: 3 };
+            controller.enqueue(new TextEncoder().encode("flight-data"));
+            sent = true;
+          },
+        });
+      },
+      revalidateSeconds: null,
+    });
+
+    expect(response.headers.get("cache-control")).toBe("s-maxage=1, stale-while-revalidate=2");
+    expect(response.headers.get("x-vinext-cache")).toBe("MISS");
+    await expect(response.text()).resolves.toBe("<html>page</html>");
+    expect(common.waitUntilPromises).toHaveLength(0);
+    expect(common.isrSet).not.toHaveBeenCalled();
   });
 
   it("disables HTML ISR caching when the response carries a script nonce", async () => {

--- a/tests/app-page-render.test.ts
+++ b/tests/app-page-render.test.ts
@@ -27,6 +27,16 @@ function createStream(chunks: string[]): ReadableStream<Uint8Array> {
   });
 }
 
+function createDeferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, reject, resolve };
+}
+
 function createCommonOptions() {
   const waitUntilPromises: Promise<void>[] = [];
   const renderToReadableStream = vi.fn(() => createStream(["flight-data"]));
@@ -283,6 +293,55 @@ describe("app page render lifecycle", () => {
     expect(consumeDynamicUsage).toHaveBeenCalledTimes(2);
   });
 
+  it("does not wait for the full captured RSC payload before returning production RSC responses", async () => {
+    const common = createCommonOptions();
+    const releaseRsc = createDeferred();
+
+    const responsePromise = renderAppPageLifecycle({
+      ...common.options,
+      getRequestCacheLife() {
+        return { revalidate: 7, expire: 11 };
+      },
+      isProduction: true,
+      isRscRequest: true,
+      renderToReadableStream() {
+        let sent = false;
+        return new ReadableStream<Uint8Array>({
+          async pull(controller) {
+            if (sent) {
+              await releaseRsc.promise;
+              controller.close();
+              return;
+            }
+            sent = true;
+            controller.enqueue(new TextEncoder().encode("flight"));
+          },
+        });
+      },
+      revalidateSeconds: null,
+    });
+
+    await expect(
+      Promise.race([responsePromise.then(() => "returned"), releaseRsc.promise.then(() => "done")]),
+    ).resolves.toBe("returned");
+
+    const response = await responsePromise;
+    expect(response.headers.get("cache-control")).toBe("no-store, must-revalidate");
+    expect(response.headers.get("x-vinext-cache")).toBe("MISS");
+    expect(common.waitUntilPromises).toHaveLength(1);
+
+    releaseRsc.resolve();
+    await expect(response.text()).resolves.toBe("flight");
+    await Promise.all(common.waitUntilPromises);
+    expect(common.isrSet).toHaveBeenCalledWith(
+      "rsc:/posts/post",
+      expect.objectContaining({ kind: "APP_PAGE" }),
+      7,
+      ["_N_T_/posts/post"],
+      11,
+    );
+  });
+
   it("rerenders HTML responses with the error boundary when a global RSC error was captured", async () => {
     const common = createCommonOptions();
 
@@ -334,6 +393,63 @@ describe("app page render lifecycle", () => {
       30,
       ["_N_T_/posts/post"],
       undefined,
+    );
+  });
+
+  it("does not wait for cacheLife-only RSC capture before returning production HTML responses", async () => {
+    const common = createCommonOptions();
+    const releaseRsc = createDeferred();
+
+    const responsePromise = renderAppPageLifecycle({
+      ...common.options,
+      getRequestCacheLife() {
+        return { revalidate: 5, expire: 9 };
+      },
+      isProduction: true,
+      renderToReadableStream() {
+        let sent = false;
+        return new ReadableStream<Uint8Array>({
+          async pull(controller) {
+            if (sent) {
+              await releaseRsc.promise;
+              controller.close();
+              return;
+            }
+            sent = true;
+            controller.enqueue(new TextEncoder().encode("flight"));
+          },
+        });
+      },
+      revalidateSeconds: null,
+    });
+
+    await expect(
+      Promise.race([responsePromise.then(() => "returned"), releaseRsc.promise.then(() => "done")]),
+    ).resolves.toBe("returned");
+
+    const response = await responsePromise;
+    expect(response.headers.get("cache-control")).toBe("no-store, must-revalidate");
+    expect(response.headers.get("x-vinext-cache")).toBe("MISS");
+    expect(common.waitUntilPromises).toHaveLength(1);
+
+    releaseRsc.resolve();
+    await expect(response.text()).resolves.toBe("<html>page</html>");
+    await Promise.all(common.waitUntilPromises);
+    expect(common.isrSet).toHaveBeenNthCalledWith(
+      1,
+      "html:/posts/post",
+      expect.objectContaining({ kind: "APP_PAGE" }),
+      5,
+      ["_N_T_/posts/post"],
+      9,
+    );
+    expect(common.isrSet).toHaveBeenNthCalledWith(
+      2,
+      "rsc:/posts/post",
+      expect.objectContaining({ kind: "APP_PAGE" }),
+      5,
+      ["_N_T_/posts/post"],
+      9,
     );
   });
 

--- a/tests/app-page-response.test.ts
+++ b/tests/app-page-response.test.ts
@@ -35,6 +35,7 @@ describe("app page response helpers", () => {
     expect(
       resolveAppPageRscResponsePolicy({
         dynamicUsedDuringBuild: false,
+        expireSeconds: 300,
         isDynamicError: false,
         isForceDynamic: false,
         isForceStatic: false,
@@ -42,7 +43,7 @@ describe("app page response helpers", () => {
         revalidateSeconds: 60,
       }),
     ).toEqual({
-      cacheControl: "s-maxage=60, stale-while-revalidate",
+      cacheControl: "s-maxage=60, stale-while-revalidate=240",
       cacheState: "MISS",
     });
   });

--- a/tests/app-route-handler-cache.test.ts
+++ b/tests/app-route-handler-cache.test.ts
@@ -110,6 +110,7 @@ describe("app route handler cache helpers", () => {
     const scheduledRegenerations: Array<() => Promise<void>> = [];
     const isrSetCalls: Array<{
       key: string;
+      expireSeconds: number | undefined;
       revalidateSeconds: number;
       tags: string[];
     }> = [];
@@ -139,15 +140,16 @@ describe("app route handler cache helpers", () => {
       isrRouteKey(pathname) {
         return "route:" + pathname;
       },
-      async isrSet(key, value, revalidateSeconds, tags) {
+      async isrSet(key, value, revalidateSeconds, tags, expireSeconds) {
         expect(value.kind).toBe("APP_ROUTE");
-        isrSetCalls.push({ key, revalidateSeconds, tags });
+        isrSetCalls.push({ key, expireSeconds, revalidateSeconds, tags });
       },
       markDynamicUsage: dynamicUsage.markDynamicUsage,
       middlewareContext: { headers: null, status: null },
       params: { slug: "demo" },
       requestUrl: "https://example.com/base/api/stale?ping=pong",
       revalidateSearchParams: new URLSearchParams("ping=pong"),
+      expireSeconds: 300,
       revalidateSeconds: 60,
       routePattern: "/api/stale",
       async runInRevalidationContext(renderFn) {
@@ -173,6 +175,7 @@ describe("app route handler cache helpers", () => {
     expect(isrSetCalls).toEqual([
       {
         key: "route:/api/stale",
+        expireSeconds: 300,
         revalidateSeconds: 60,
         tags: ["/api/stale", "tag:regen"],
       },

--- a/tests/app-route-handler-execution.test.ts
+++ b/tests/app-route-handler-execution.test.ts
@@ -109,6 +109,7 @@ describe("app route handler execution helpers", () => {
     const waitUntilPromises: Promise<unknown>[] = [];
     const isrSetCalls: Array<{
       key: string;
+      expireSeconds: number | undefined;
       revalidateSeconds: number;
       tags: string[];
     }> = [];
@@ -154,9 +155,9 @@ describe("app route handler execution helpers", () => {
       isrRouteKey(pathname) {
         return "route:" + pathname;
       },
-      async isrSet(key, value, revalidateSeconds, tags) {
+      async isrSet(key, value, revalidateSeconds, tags, expireSeconds) {
         expect(value.kind).toBe("APP_ROUTE");
-        isrSetCalls.push({ key, revalidateSeconds, tags });
+        isrSetCalls.push({ key, expireSeconds, revalidateSeconds, tags });
       },
       markDynamicUsage: dynamicUsage.markDynamicUsage,
       method: "GET",
@@ -169,6 +170,7 @@ describe("app route handler execution helpers", () => {
         reportCalls.push(error);
       },
       request: new Request("https://example.com/api/static-data"),
+      expireSeconds: 300,
       revalidateSeconds: 60,
       routePattern: "/api/static-data",
       setHeadersAccessPhase(phase) {
@@ -180,7 +182,7 @@ describe("app route handler execution helpers", () => {
     await Promise.all(waitUntilPromises);
 
     expect(response.status).toBe(202);
-    expect(response.headers.get("cache-control")).toBe("s-maxage=60, stale-while-revalidate");
+    expect(response.headers.get("cache-control")).toBe("s-maxage=60, stale-while-revalidate=240");
     expect(response.headers.get("x-vinext-cache")).toBe("MISS");
     expect(response.headers.get("x-middleware")).toBe("present");
     expect(response.headers.getSetCookie?.()).toEqual(["session=1; Path=/", "draft=1; Path=/"]);
@@ -188,6 +190,7 @@ describe("app route handler execution helpers", () => {
     expect(isrSetCalls).toEqual([
       {
         key: "route:/api/static-data",
+        expireSeconds: 300,
         revalidateSeconds: 60,
         tags: ["/api/static-data", "tag:demo"],
       },

--- a/tests/app-route-handler-response.test.ts
+++ b/tests/app-route-handler-response.test.ts
@@ -101,7 +101,7 @@ describe("app route handler response helpers", () => {
       revalidateSeconds: 60,
     });
     expect(hit.headers.get("x-vinext-cache")).toBe("HIT");
-    expect(hit.headers.get("cache-control")).toBe("s-maxage=60, stale-while-revalidate=240");
+    expect(hit.headers.get("cache-control")).toBe("s-maxage=60, stale-while-revalidate");
     await expect(hit.text()).resolves.toBe("from-cache");
 
     const staleHead = buildRouteHandlerCachedResponse(cachedValue, {
@@ -111,7 +111,7 @@ describe("app route handler response helpers", () => {
       revalidateSeconds: 60,
     });
     expect(staleHead.headers.get("x-vinext-cache")).toBe("STALE");
-    expect(staleHead.headers.get("cache-control")).toBe("s-maxage=60, stale-while-revalidate=240");
+    expect(staleHead.headers.get("cache-control")).toBe("s-maxage=0, stale-while-revalidate");
     await expect(staleHead.text()).resolves.toBe("");
   });
 

--- a/tests/app-route-handler-response.test.ts
+++ b/tests/app-route-handler-response.test.ts
@@ -96,21 +96,37 @@ describe("app route handler response helpers", () => {
 
     const hit = buildRouteHandlerCachedResponse(cachedValue, {
       cacheState: "HIT",
+      expireSeconds: 300,
       isHead: false,
       revalidateSeconds: 60,
     });
     expect(hit.headers.get("x-vinext-cache")).toBe("HIT");
-    expect(hit.headers.get("cache-control")).toBe("s-maxage=60, stale-while-revalidate");
+    expect(hit.headers.get("cache-control")).toBe("s-maxage=60, stale-while-revalidate=240");
     await expect(hit.text()).resolves.toBe("from-cache");
 
     const staleHead = buildRouteHandlerCachedResponse(cachedValue, {
       cacheState: "STALE",
+      expireSeconds: 300,
       isHead: true,
       revalidateSeconds: 60,
     });
     expect(staleHead.headers.get("x-vinext-cache")).toBe("STALE");
-    expect(staleHead.headers.get("cache-control")).toBe("s-maxage=0, stale-while-revalidate");
+    expect(staleHead.headers.get("cache-control")).toBe("s-maxage=60, stale-while-revalidate=240");
     await expect(staleHead.text()).resolves.toBe("");
+  });
+
+  it("prefers stored cache-control metadata over caller defaults", () => {
+    const cachedValue = buildCachedRouteValue("from-cache");
+
+    const response = buildRouteHandlerCachedResponse(cachedValue, {
+      cacheControl: { revalidate: 15, expire: 300 },
+      cacheState: "HIT",
+      expireSeconds: 31_536_000,
+      isHead: false,
+      revalidateSeconds: 60,
+    });
+
+    expect(response.headers.get("cache-control")).toBe("s-maxage=15, stale-while-revalidate=285");
   });
 
   it("serializes APP_ROUTE cache values without cache bookkeeping headers", async () => {

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -4605,16 +4605,14 @@ describe("generateRscEntry ISR code generation", () => {
     expect(code).toMatch(/export default async function handler\s*\(\s*request\s*,\s*ctx\s*\)/);
   });
 
-  it("generated code delegates ISR cache access to shared runtime helpers", () => {
+  it("generated code imports ISR cache access from the shared runtime module", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes);
-    expect(code).toContain("isrGet as __sharedIsrGet");
-    expect(code).toContain("isrSet as __sharedIsrSet");
-    expect(code).toContain("return __sharedIsrGet(key);");
-    expect(code).toContain("return __sharedIsrSet(");
-    expect(code).not.toContain("getCacheHandler");
     expect(code).toContain("server/isr-cache.js");
     expect(code).toContain("isrGet as __isrGet");
     expect(code).toContain("isrSet as __isrSet");
+    expect(code).not.toContain("getCacheHandler");
+    expect(code).not.toContain("isrGet as __sharedIsrGet");
+    expect(code).not.toContain("return __sharedIsrGet(key);");
   });
 
   it("generated code stores root layout params separately from leaf params", () => {

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -4605,8 +4605,12 @@ describe("generateRscEntry ISR code generation", () => {
     expect(code).toMatch(/export default async function handler\s*\(\s*request\s*,\s*ctx\s*\)/);
   });
 
-  it("generated code leaves cache handler access to the ISR cache module", () => {
+  it("generated code delegates ISR cache access to shared runtime helpers", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes);
+    expect(code).toContain("isrGet as __sharedIsrGet");
+    expect(code).toContain("isrSet as __sharedIsrSet");
+    expect(code).toContain("return __sharedIsrGet(key);");
+    expect(code).toContain("return __sharedIsrSet(");
     expect(code).not.toContain("getCacheHandler");
     expect(code).toContain("server/isr-cache.js");
     expect(code).toContain("isrGet as __isrGet");

--- a/tests/cache-control.test.ts
+++ b/tests/cache-control.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  buildCachedRevalidateCacheControl,
+  buildRevalidateCacheControl,
+} from "../packages/vinext/src/server/cache-control.js";
+
+describe("cache-control helpers", () => {
+  it("uses Next.js expire minus revalidate for finite SWR windows", () => {
+    expect(buildRevalidateCacheControl(60, 300)).toBe("s-maxage=60, stale-while-revalidate=240");
+  });
+
+  it("omits stale-while-revalidate when expire does not exceed revalidate", () => {
+    expect(buildRevalidateCacheControl(300, 300)).toBe("s-maxage=300");
+  });
+
+  it("preserves vinext's legacy unbounded SWR header when expire is unknown", () => {
+    expect(buildRevalidateCacheControl(60)).toBe("s-maxage=60, stale-while-revalidate");
+  });
+
+  it("uses route policy for STALE cached responses when expire is known", () => {
+    expect(buildCachedRevalidateCacheControl("STALE", 60, 300)).toBe(
+      "s-maxage=60, stale-while-revalidate=240",
+    );
+  });
+
+  it("preserves legacy STALE cached response headers when expire is unknown", () => {
+    expect(buildCachedRevalidateCacheControl("STALE", 60)).toBe(
+      "s-maxage=0, stale-while-revalidate",
+    );
+  });
+});

--- a/tests/cache-control.test.ts
+++ b/tests/cache-control.test.ts
@@ -23,9 +23,19 @@ describe("cache-control helpers", () => {
     );
   });
 
+  it("uses route policy for HIT cached responses when expire is known", () => {
+    expect(buildCachedRevalidateCacheControl("HIT", 60, 300)).toBe(
+      "s-maxage=60, stale-while-revalidate=240",
+    );
+  });
+
   it("preserves legacy STALE cached response headers when expire is unknown", () => {
     expect(buildCachedRevalidateCacheControl("STALE", 60)).toBe(
       "s-maxage=0, stale-while-revalidate",
     );
+  });
+
+  it("keeps the full expire window when revalidate is zero", () => {
+    expect(buildRevalidateCacheControl(0, 300)).toBe("s-maxage=0, stale-while-revalidate=300");
   });
 });

--- a/tests/fixtures/app-basic/app/prerender-cache-life-only/page.tsx
+++ b/tests/fixtures/app-basic/app/prerender-cache-life-only/page.tsx
@@ -1,0 +1,13 @@
+"use cache";
+
+import { cacheLife } from "next/cache";
+
+export default function PrerenderCacheLifeOnlyPage() {
+  cacheLife({ revalidate: 1, expire: 3 });
+
+  return (
+    <div data-testid="prerender-cache-life-only-page">
+      <h1>Prerender Cache Life Only</h1>
+    </div>
+  );
+}

--- a/tests/fixtures/app-basic/app/prerender-cache-life/page.tsx
+++ b/tests/fixtures/app-basic/app/prerender-cache-life/page.tsx
@@ -1,0 +1,15 @@
+"use cache";
+
+import { cacheLife } from "next/cache";
+
+export const revalidate = 1;
+
+export default function PrerenderCacheLifePage() {
+  cacheLife({ revalidate: 1, expire: 3 });
+
+  return (
+    <div data-testid="prerender-cache-life-page">
+      <h1>Prerender Cache Life</h1>
+    </div>
+  );
+}

--- a/tests/isr-cache.test.ts
+++ b/tests/isr-cache.test.ts
@@ -263,6 +263,27 @@ describe("ISR expire ceiling", () => {
     await expect(isrGet("expire-test")).resolves.toBeNull();
   });
 
+  it("preserves legacy revalidate context while writing cache-control metadata", async () => {
+    let setContext: Record<string, unknown> | undefined;
+    setCacheHandler({
+      async get() {
+        return null;
+      },
+      async set(_key, _data, ctx) {
+        setContext = ctx;
+      },
+      async revalidateTag() {},
+    });
+
+    await isrSet("compat-test", buildPagesCacheValue("<html>cached</html>", {}), 60, ["tag"], 300);
+
+    expect(setContext).toEqual({
+      cacheControl: { revalidate: 60, expire: 300 },
+      revalidate: 60,
+      tags: ["tag"],
+    });
+  });
+
   it("treats cache handlers that report expired entries as hard misses", async () => {
     setCacheHandler({
       async get() {

--- a/tests/isr-cache.test.ts
+++ b/tests/isr-cache.test.ts
@@ -14,6 +14,8 @@ import {
   appIsrHtmlKey,
   appIsrRscKey,
   appIsrRouteKey,
+  isrGet,
+  isrSet,
   buildPagesCacheValue,
   buildAppPageCacheValue,
   normalizeMountedSlotsHeader,
@@ -235,6 +237,46 @@ describe("setRevalidateDuration / getRevalidateDuration", () => {
   it("handles zero duration", () => {
     setRevalidateDuration("test-key-3", 0);
     expect(getRevalidateDuration("test-key-3")).toBe(0);
+  });
+});
+
+// ─── Expire ceiling handling ────────────────────────────────────────────
+
+describe("ISR expire ceiling", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    setCacheHandler(new MemoryCacheHandler());
+  });
+
+  it("serves stale within expire and treats entries beyond expire as hard misses", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(1_000);
+
+    await isrSet("expire-test", buildPagesCacheValue("<html>cached</html>", {}), 1, [], 3);
+
+    vi.setSystemTime(2_500);
+    const stale = await isrGet("expire-test");
+    expect(stale?.isStale).toBe(true);
+    expect(stale?.value.value?.kind).toBe("PAGES");
+
+    vi.setSystemTime(4_500);
+    await expect(isrGet("expire-test")).resolves.toBeNull();
+  });
+
+  it("treats cache handlers that report expired entries as hard misses", async () => {
+    setCacheHandler({
+      async get() {
+        return {
+          lastModified: Date.now() - 10_000,
+          cacheState: "expired",
+          value: buildPagesCacheValue("<html>expired</html>", {}),
+        };
+      },
+      async set() {},
+      async revalidateTag() {},
+    });
+
+    await expect(isrGet("expired-handler-entry")).resolves.toBeNull();
   });
 });
 

--- a/tests/kv-cache-handler.test.ts
+++ b/tests/kv-cache-handler.test.ts
@@ -216,6 +216,22 @@ describe("KVCacheHandler", () => {
       expect(kv.delete).toHaveBeenCalledWith("cache:bad-reval");
     });
 
+    it("rejects entry with invalid expireAt type", async () => {
+      store.set(
+        "cache:bad-expire",
+        JSON.stringify({
+          value: null,
+          tags: [],
+          lastModified: 123,
+          revalidateAt: null,
+          expireAt: "not-a-number",
+        }),
+      );
+      const result = await handler.get("bad-expire");
+      expect(result).toBeNull();
+      expect(kv.delete).toHaveBeenCalledWith("cache:bad-expire");
+    });
+
     it("rejects entry with unknown value kind", async () => {
       store.set("cache:bad-kind", validEntry({ kind: "UNKNOWN_KIND", data: {} }));
       const result = await handler.get("bad-kind");
@@ -358,6 +374,10 @@ describe("KVCacheHandler", () => {
   // -------------------------------------------------------------------------
 
   describe("set and get round-trip", () => {
+    beforeEach(() => {
+      vi.useRealTimers();
+    });
+
     it("round-trips APP_ROUTE with ArrayBuffer body", async () => {
       const bodyBytes = new TextEncoder().encode("response body");
       await handler.set("rt-route", {
@@ -414,6 +434,32 @@ describe("KVCacheHandler", () => {
         "_N_T_/revalidate-tag-test",
         "test-data",
       ]);
+    });
+
+    it("serves stale within expire and returns a hard miss beyond expire", async () => {
+      vi.useFakeTimers({ toFake: ["Date"] });
+      vi.setSystemTime(1_000);
+
+      await handler.set(
+        "expire-test",
+        {
+          kind: "PAGES",
+          html: "<html>cached</html>",
+          pageData: {},
+          headers: undefined,
+          status: 200,
+        },
+        { cacheControl: { revalidate: 1, expire: 3 } },
+      );
+
+      vi.setSystemTime(2_500);
+      const stale = await handler.get("expire-test");
+      expect(stale?.cacheState).toBe("stale");
+      expect(stale?.value?.kind).toBe("PAGES");
+
+      vi.setSystemTime(4_500);
+      await expect(handler.get("expire-test")).resolves.toBeNull();
+      expect(kv.delete).toHaveBeenCalledWith("cache:expire-test");
     });
   });
 

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -447,6 +447,18 @@ describe("resolveNextConfig hashSalt", () => {
   });
 });
 
+describe("resolveNextConfig expireTime", () => {
+  it("defaults to the Next.js route expire fallback", async () => {
+    const resolved = await resolveNextConfig(null);
+    expect(resolved.expireTime).toBe(31_536_000);
+  });
+
+  it("uses configured expireTime", async () => {
+    const resolved = await resolveNextConfig({ expireTime: 2 });
+    expect(resolved.expireTime).toBe(2);
+  });
+});
+
 describe("detectNextIntlConfig", () => {
   let tmpDir: string;
 
@@ -480,6 +492,7 @@ describe("detectNextIntlConfig", () => {
       cacheMaxMemorySize: undefined,
       hashSalt: "",
       enablePrerenderSourceMaps: true,
+      expireTime: 31_536_000,
       buildId: "test-build-id",
       ...overrides,
     };

--- a/tests/pages-page-data.test.ts
+++ b/tests/pages-page-data.test.ts
@@ -39,6 +39,7 @@ function createOptions(
     },
     isrGet: vi.fn().mockResolvedValue(null),
     isrSet: vi.fn(async () => {}),
+    expireSeconds: 300,
     pageModule: {},
     params: { slug: "post" },
     query: { slug: "post" },
@@ -207,7 +208,9 @@ describe("pages page data", () => {
 
     expect(result.response.status).toBe(200);
     expect(result.response.headers.get("x-vinext-cache")).toBe("STALE");
-    expect(result.response.headers.get("cache-control")).toBe("s-maxage=0, stale-while-revalidate");
+    expect(result.response.headers.get("cache-control")).toBe(
+      "s-maxage=60, stale-while-revalidate=240",
+    );
     expect(result.response.headers.get("link")).toBe(
       "</font.woff2>; rel=preload; as=font; type=font/woff2; crossorigin",
     );
@@ -231,6 +234,47 @@ describe("pages page data", () => {
         pageData: { title: "fresh" },
       }),
       15,
+      undefined,
+      300,
+    );
+  });
+
+  it("uses stored cache-control metadata for Pages Router cached HIT responses", async () => {
+    const result = await resolvePagesPageData(
+      createOptions({
+        expireSeconds: 31_536_000,
+        isrGet: vi.fn().mockResolvedValue({
+          isStale: false,
+          value: {
+            cacheControl: { revalidate: 15, expire: 300 },
+            lastModified: 1,
+            value: {
+              kind: "PAGES",
+              html: "<html><body>cached</body></html>",
+              pageData: { cached: true },
+              headers: undefined,
+              status: undefined,
+            },
+          },
+        }),
+        pageModule: {
+          async getStaticProps() {
+            return {
+              props: { title: "fresh" },
+              revalidate: 15,
+            };
+          },
+        },
+      }),
+    );
+
+    expect(result.kind).toBe("response");
+    if (result.kind !== "response") {
+      throw new Error("expected response result");
+    }
+    expect(result.response.headers.get("x-vinext-cache")).toBe("HIT");
+    expect(result.response.headers.get("cache-control")).toBe(
+      "s-maxage=15, stale-while-revalidate=285",
     );
   });
 

--- a/tests/pages-page-data.test.ts
+++ b/tests/pages-page-data.test.ts
@@ -208,9 +208,7 @@ describe("pages page data", () => {
 
     expect(result.response.status).toBe(200);
     expect(result.response.headers.get("x-vinext-cache")).toBe("STALE");
-    expect(result.response.headers.get("cache-control")).toBe(
-      "s-maxage=60, stale-while-revalidate=240",
-    );
+    expect(result.response.headers.get("cache-control")).toBe("s-maxage=0, stale-while-revalidate");
     expect(result.response.headers.get("link")).toBe(
       "</font.woff2>; rel=preload; as=font; type=font/woff2; crossorigin",
     );

--- a/tests/pages-page-response.test.ts
+++ b/tests/pages-page-response.test.ts
@@ -144,13 +144,14 @@ describe("pages page response", () => {
     const response = await renderPagesPageResponse({
       ...common.options,
       DocumentComponent: null,
+      expireSeconds: 300,
       getSSRHeadHTML: undefined,
       isrRevalidateSeconds: 60,
       routeUrl: "/posts/post?draft=0",
     });
 
     expect(response.status).toBe(200);
-    expect(response.headers.get("cache-control")).toBe("s-maxage=60, stale-while-revalidate");
+    expect(response.headers.get("cache-control")).toBe("s-maxage=60, stale-while-revalidate=240");
     expect(response.headers.get("x-vinext-cache")).toBe("MISS");
     await expect(response.text()).resolves.toContain("<div>live-body</div>");
 
@@ -165,6 +166,8 @@ describe("pages page response", () => {
         pageData: { title: "hello" },
       }),
       60,
+      undefined,
+      300,
     );
   });
 

--- a/tests/prerender.test.ts
+++ b/tests/prerender.test.ts
@@ -338,6 +338,40 @@ describe("prerenderApp — default mode (app-basic)", () => {
     expect(r).toMatchObject({ route: "/revalidate-test", status: "rendered", revalidate: 60 });
   });
 
+  it("uses the rendered cacheLife expire value for App Router ISR prerender entries", () => {
+    const r = findRoute(results, "/prerender-cache-life");
+    expect(r).toMatchObject({
+      route: "/prerender-cache-life",
+      status: "rendered",
+      revalidate: 1,
+      expire: 3,
+    });
+
+    const indexPath = path.join(outDir, "vinext-prerender.json");
+    const index = JSON.parse(fs.readFileSync(indexPath, "utf-8"));
+    const manifestRoute = index.routes.find(
+      (route: { route: string }) => route.route === "/prerender-cache-life",
+    );
+    expect(manifestRoute).toMatchObject({ revalidate: 1, expire: 3 });
+  });
+
+  it("infers App Router ISR prerender metadata from cacheLife without route revalidate", () => {
+    const r = findRoute(results, "/prerender-cache-life-only");
+    expect(r).toMatchObject({
+      route: "/prerender-cache-life-only",
+      status: "rendered",
+      revalidate: 1,
+      expire: 3,
+    });
+
+    const indexPath = path.join(outDir, "vinext-prerender.json");
+    const index = JSON.parse(fs.readFileSync(indexPath, "utf-8"));
+    const manifestRoute = index.routes.find(
+      (route: { route: string }) => route.route === "/prerender-cache-life-only",
+    );
+    expect(manifestRoute).toMatchObject({ revalidate: 1, expire: 3 });
+  });
+
   // ── Dynamic routes — skipped ───────────────────────────────────────────────
 
   it("skips force-dynamic page", () => {

--- a/tests/seed-cache.test.ts
+++ b/tests/seed-cache.test.ts
@@ -13,6 +13,9 @@ import {
   MemoryCacheHandler,
   setCacheHandler,
   getCacheHandler,
+  type CacheHandler,
+  type CacheHandlerValue,
+  type IncrementalCacheValue,
 } from "../packages/vinext/src/shims/cache.js";
 import { isrCacheKey, getRevalidateDuration } from "../packages/vinext/src/server/isr-cache.js";
 import { seedMemoryCacheFromPrerender } from "../packages/vinext/src/server/seed-cache.js";
@@ -211,6 +214,45 @@ describe("seedMemoryCacheFromPrerender", () => {
     const baseKey = isrCacheKey("app", "/isr", buildId);
     expect(getRevalidateDuration(baseKey + ":html")).toBe(45);
     expect(getRevalidateDuration(baseKey + ":rsc")).toBe(45);
+  });
+
+  it("preserves legacy revalidate context while writing cache-control metadata", async () => {
+    const contexts: Record<string, unknown>[] = [];
+    const handler: CacheHandler = {
+      async get(): Promise<CacheHandlerValue | null> {
+        return null;
+      },
+      async set(
+        _key: string,
+        _data: IncrementalCacheValue | null,
+        ctx?: Record<string, unknown>,
+      ): Promise<void> {
+        contexts.push(ctx ?? {});
+      },
+      async revalidateTag(): Promise<void> {
+        // not used by this test
+      },
+    };
+    setCacheHandler(handler);
+
+    setupPrerenderFixture(
+      serverDir,
+      {
+        buildId: "seed-context-test",
+        routes: [{ route: "/isr", status: "rendered", revalidate: 60, expire: 300, router: "app" }],
+      },
+      {
+        "isr.html": "<html>ISR</html>",
+        "isr.rsc": "RSC isr",
+      },
+    );
+
+    await seedMemoryCacheFromPrerender(serverDir);
+
+    expect(contexts).toEqual([
+      { cacheControl: { revalidate: 60, expire: 300 }, revalidate: 60 },
+      { cacheControl: { revalidate: 60, expire: 300 }, revalidate: 60 },
+    ]);
   });
 
   it("does not set revalidate duration for static routes", async () => {

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -2174,6 +2174,20 @@ describe("next/cache shim", () => {
     consoleWarn.mockRestore();
   });
 
+  it("cacheLife inline configs inherit default profile values for omitted fields", async () => {
+    const { cacheLife, _consumeRequestScopedCacheLife, _runWithCacheState } =
+      await import("../packages/vinext/src/shims/cache.js");
+
+    await _runWithCacheState(async () => {
+      cacheLife({ expire: 60 });
+
+      expect(_consumeRequestScopedCacheLife()).toEqual({
+        revalidate: 900,
+        expire: 60,
+      });
+    });
+  });
+
   it("exports cacheTag as a no-op function", async () => {
     const { cacheTag } = await import("../packages/vinext/src/shims/cache.js");
     expect(typeof cacheTag).toBe("function");

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -2175,16 +2175,25 @@ describe("next/cache shim", () => {
   });
 
   it("cacheLife inline configs inherit default profile values for omitted fields", async () => {
-    const { cacheLife, _consumeRequestScopedCacheLife, _runWithCacheState } =
-      await import("../packages/vinext/src/shims/cache.js");
+    const {
+      cacheLife,
+      _consumeRequestScopedCacheLife,
+      _peekRequestScopedCacheLife,
+      _runWithCacheState,
+    } = await import("../packages/vinext/src/shims/cache.js");
 
     await _runWithCacheState(async () => {
       cacheLife({ expire: 60 });
 
+      expect(_peekRequestScopedCacheLife()).toEqual({
+        revalidate: 900,
+        expire: 60,
+      });
       expect(_consumeRequestScopedCacheLife()).toEqual({
         revalidate: 900,
         expire: 60,
       });
+      expect(_peekRequestScopedCacheLife()).toBeNull();
     });
   });
 


### PR DESCRIPTION
## Summary

Closes https://github.com/cloudflare/vinext/issues/957.

Next.js now treats a route-level expire ceiling as the boundary between stale-while-revalidate and blocking regeneration. Vinext was only tracking revalidate, so every time-expired ISR entry stayed eligible for stale serving forever. This PR adds the missing expire dimension and wires it through App Router pages, App Route handlers, Pages Router routes, prerender seeding, and cached function writes.

## Next.js references

- Upstream fix: https://github.com/vercel/next.js/commit/8e4cfc50627cd3e321ef2db4f798e46698a2fbb8
- Upstream PR: https://github.com/vercel/next.js/pull/93211
- Next.js cache header semantics: https://github.com/vercel/next.js/blob/e1bb911c14e4ea3c6bb8cc98871ffdee317d513f/packages/next/src/server/lib/cache-control.ts#L17-L31
- App page fallback to nextConfig.expireTime: https://github.com/vercel/next.js/blob/e1bb911c14e4ea3c6bb8cc98871ffdee317d513f/packages/next/src/build/templates/app-page.ts#L1598-L1609
- App route cacheControl carries revalidate and expire: https://github.com/vercel/next.js/blob/e1bb911c14e4ea3c6bb8cc98871ffdee317d513f/packages/next/src/build/templates/app-route.ts#L381-L402
- Pages handler fallback to nextConfig.expireTime: https://github.com/vercel/next.js/blob/e1bb911c14e4ea3c6bb8cc98871ffdee317d513f/packages/next/src/server/route-modules/pages/pages-handler.ts#L606-L613

## What changed

- Memory and KV cache entries now store both revalidateAt and expireAt.
- ISR reads return a hard miss once an entry is beyond expire, while preserving SWR for entries that are stale but still within expire.
- next.config expireTime is resolved with the Next.js one-year default and passed through generated App and Pages entry wiring.
- App pages, App route handlers, Pages routes, prerender manifests, seeded prerenders, and cacheLife-backed cached functions now pass expire alongside revalidate.
- Cache-Control response helpers now emit finite stale-while-revalidate windows when expire is known, matching Next.js getCacheControlHeader.
- The App Router generated entry only describes app shape and delegates ISR mechanics to server/isr-cache.ts.

## Validation

- vp check
- vp test run tests/cache-control.test.ts tests/isr-cache.test.ts tests/kv-cache-handler.test.ts tests/app-page-cache.test.ts tests/app-page-response.test.ts tests/app-page-render.test.ts tests/app-route-handler-response.test.ts tests/app-route-handler-cache.test.ts tests/app-route-handler-execution.test.ts tests/pages-page-data.test.ts tests/pages-page-response.test.ts tests/next-config.test.ts tests/prerender.test.ts tests/deploy.test.ts tests/entry-templates.test.ts