### PR TITLE
refactor(app-router): extract RSC runtime primitives

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -41,6 +41,7 @@ const appServerActionExecutionPath = resolveEntryPath(
   "../server/app-server-action-execution.js",
   import.meta.url,
 );
+const appRscErrorsPath = resolveEntryPath("../server/app-rsc-errors.js", import.meta.url);
 const implicitTagsPath = resolveEntryPath("../server/implicit-tags.js", import.meta.url);
 const appPageCachePath = resolveEntryPath("../server/app-page-cache.js", import.meta.url);
 const appPageExecutionPath = resolveEntryPath("../server/app-page-execution.js", import.meta.url);
@@ -75,6 +76,7 @@ const appPrerenderEndpointsPath = resolveEntryPath(
 );
 const rscStreamHintsPath = resolveEntryPath("../server/rsc-stream-hints.js", import.meta.url);
 const metadataRoutesPath = resolveEntryPath("../server/metadata-routes.js", import.meta.url);
+const isrCachePath = resolveEntryPath("../server/isr-cache.js", import.meta.url);
 const rootParamsShimPath = resolveEntryPath("../shims/root-params.js", import.meta.url);
 const errorCausePath = resolveEntryPath("../utils/error-cause.js", import.meta.url);
 
@@ -199,7 +201,13 @@ import {
 import {
   handleProgressiveServerActionRequest as __handleProgressiveServerActionRequest,
   handleServerActionRscRequest as __handleServerActionRscRequest,
+  readActionBodyWithLimit as __readBodyWithLimit,
+  readActionFormDataWithLimit as __readFormDataWithLimit,
 } from ${JSON.stringify(appServerActionExecutionPath)};
+import {
+  createRscOnErrorHandler as __createRscOnErrorHandler,
+  sanitizeErrorForClient as __sanitizeErrorForClient,
+} from ${JSON.stringify(appRscErrorsPath)};
 import { readAppPageCacheResponse as __readAppPageCacheResponse } from ${JSON.stringify(appPageCachePath)};
 import {
   buildAppPageFontLinkHeader as __buildAppPageFontLinkHeader,
@@ -250,7 +258,7 @@ import {
   createStaticGenerationHeadersContext as __createStaticGenerationHeadersContext,
 } from ${JSON.stringify(appStaticGenerationPath)};
 import { buildPageCacheTags } from ${JSON.stringify(implicitTagsPath)};
-import { _consumeRequestScopedCacheLife, getCacheHandler } from "next/cache";
+import { _consumeRequestScopedCacheLife } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from ${JSON.stringify(requestContextShimPath)};
 import { setRootParams as __setRootParams, pickRootParams as __pickRootParams } from ${JSON.stringify(rootParamsShimPath)};
 import { ensureFetchPatch as _ensureFetchPatch, getCollectedFetchTags, setCurrentFetchSoftTags } from "vinext/fetch-cache";
@@ -261,6 +269,15 @@ import {
 import {
   handleAppPrerenderEndpoint as __handleAppPrerenderEndpoint,
 } from ${JSON.stringify(appPrerenderEndpointsPath)};
+import {
+  appIsrHtmlKey as __isrHtmlKey,
+  appIsrRscKey as __isrRscKey,
+  appIsrRouteKey as __isrRouteKey,
+  isrGet as __isrGet,
+  isrSet as __isrSet,
+  normalizeMountedSlotsHeader as __normalizeMountedSlotsHeader,
+  triggerBackgroundRegeneration as __triggerBackgroundRegeneration,
+} from ${JSON.stringify(isrCachePath)};
 // Import server-only state module to register ALS-backed accessors.
 import "vinext/navigation-state";
 import { runWithRequestContext as _runWithUnifiedCtx, createRequestContext as _createUnifiedCtx } from "vinext/unified-request-context";
@@ -302,25 +319,6 @@ function __clearRequestContext() {
   // setNavigationContext(null) already clears root params internally
 }
 
-// ISR cache is disabled in dev mode — every request re-renders fresh,
-// matching Next.js dev behavior. Cache-Control headers are still emitted
-// based on export const revalidate for testing purposes.
-// Production ISR uses the MemoryCacheHandler (or configured KV handler).
-//
-// These helpers are inlined instead of imported from isr-cache.js because
-// the virtual RSC entry module runs in the RSC Vite environment which
-// cannot use dynamic imports at the module-evaluation level for server-only
-// modules, and direct imports must use the pre-computed absolute paths.
-async function __isrGet(key) {
-  const handler = getCacheHandler();
-  const result = await handler.get(key);
-  if (!result || !result.value) return null;
-  return { value: result, isStale: result.cacheState === "stale" };
-}
-async function __isrSet(key, data, revalidateSeconds, tags) {
-  const handler = getCacheHandler();
-  await handler.set(key, data, { revalidate: revalidateSeconds, tags: Array.isArray(tags) ? tags : [] });
-}
 // Note: cache entries are written with \`headers: undefined\`. Next.js stores
 // response headers (e.g. set-cookie from cookies().set() during render) in the
 // cache entry so they can be replayed on HIT. We don't do this because:
@@ -331,82 +329,6 @@ async function __isrSet(key, data, revalidateSeconds, tags) {
 // In practice this means ISR-cached responses won't replay render-time set-cookie
 // headers — but that case is already prevented by the dynamic-usage opt-out.
 // TODO: capture render-time response headers for full Next.js parity.
-const __pendingRegenerations = new Map();
-function __triggerBackgroundRegeneration(key, renderFn, errorContext) {
-  if (__pendingRegenerations.has(key)) return;
-  const promise = renderFn()
-    .catch((err) => {
-      console.error("[vinext] ISR regen failed for " + key + ":", err);
-      if (errorContext) {
-        void _reportRequestError(
-          err instanceof Error ? err : new Error(String(err)),
-          { path: key, method: "GET", headers: {} },
-          {
-            routerKind: "App Router",
-            routePath: errorContext.routePath,
-            routeType: errorContext.routeType,
-            revalidateReason: "stale",
-          },
-        );
-      }
-    })
-    .finally(() => __pendingRegenerations.delete(key));
-  __pendingRegenerations.set(key, promise);
-  const ctx = _getRequestExecutionContext();
-  if (ctx && typeof ctx.waitUntil === "function") ctx.waitUntil(promise);
-}
-// HTML and RSC are stored under separate keys — matching Next.js's file-system
-// layout (.html / .rsc) — so each request type reads and writes its own key
-// independently with no races or partial-entry sentinels.
-//
-// Key format: "app:<buildId>:<pathname>:<suffix>"
-// Long-pathname fallback: "app:<buildId>:__hash:<fnv1a64(pathname)>:<suffix>"
-// Without buildId (should not happen in production): "app:<pathname>:<suffix>"
-// The 200-char threshold keeps the full key well under Cloudflare KV's 512-byte limit
-// even after adding the build ID and suffix. FNV-1a 64 is used for the hash (two
-// 32-bit rounds) to give a ~64-bit output with negligible collision probability for
-// realistic pathname lengths.
-// Keep prefix construction and hashing logic in sync with isrCacheKey() in server/isr-cache.ts.
-function __isrFnv1a64(s) {
-  // h1 uses the standard FNV-1a 32-bit offset basis (0x811c9dc5).
-  let h1 = 0x811c9dc5;
-  for (let i = 0; i < s.length; i++) { h1 ^= s.charCodeAt(i); h1 = (h1 * 0x01000193) >>> 0; }
-  // h2 uses a different seed (0x050c5d1f — the FNV-1a hash of the string "vinext")
-  // so the two rounds are independently seeded and their outputs are decorrelated.
-  // Concatenating two independently-seeded 32-bit FNV-1a hashes gives an effective
-  // 64-bit hash. A random non-standard seed would also work; we derive it from a
-  // fixed string so the choice is auditable and deterministic across rebuilds.
-  let h2 = 0x050c5d1f;
-  for (let i = 0; i < s.length; i++) { h2 ^= s.charCodeAt(i); h2 = (h2 * 0x01000193) >>> 0; }
-  return h1.toString(36) + h2.toString(36);
-}
-function __isrCacheKey(pathname, suffix) {
-  const normalized = pathname === "/" ? "/" : pathname.replace(/\\/$/, "");
-  // __VINEXT_BUILD_ID is replaced at compile time by Vite's define plugin.
-  const buildId = process.env.__VINEXT_BUILD_ID;
-  const prefix = buildId ? "app:" + buildId : "app";
-  const key = prefix + ":" + normalized + ":" + suffix;
-  if (key.length <= 200) return key;
-  // Pathname too long — hash it to keep under KV's 512-byte key limit.
-  return prefix + ":__hash:" + __isrFnv1a64(normalized) + ":" + suffix;
-}
-function __isrHtmlKey(pathname) { return __isrCacheKey(pathname, "html"); }
-function __isrRscKey(pathname, mountedSlotsHeader) {
-  if (!mountedSlotsHeader) return __isrCacheKey(pathname, "rsc");
-  return __isrCacheKey(pathname, "rsc:" + __isrFnv1a64(mountedSlotsHeader));
-}
-function __normalizeMountedSlotsHeader(raw) {
-  if (!raw) return null;
-  const normalized = Array.from(
-    new Set(
-      raw
-        .split(/\\s+/)
-        .filter(Boolean),
-    ),
-  ).sort().join(" ");
-  return normalized || null;
-}
-function __isrRouteKey(pathname) { return __isrCacheKey(pathname, "route"); }
 // Verbose cache logging — opt in with NEXT_PRIVATE_DEBUG_CACHE=1.
 // Matches the env var Next.js uses for its own cache debug output so operators
 // have a single knob for all cache tracing.
@@ -438,110 +360,6 @@ function makeThenableParams(obj) {
   return Object.assign(Promise.resolve(plain), plain);
 }
 
-// djb2 hash — matches Next.js's stringHash for digest generation.
-// Produces a stable numeric string from error message + stack.
-function __errorDigest(str) {
-  let hash = 5381;
-  for (let i = str.length - 1; i >= 0; i--) {
-    hash = (hash * 33) ^ str.charCodeAt(i);
-  }
-  return (hash >>> 0).toString();
-}
-
-// Sanitize an error for client consumption. In production, replaces the error
-// with a generic Error that only carries a digest hash (matching Next.js
-// behavior). In development, returns the original error for debugging.
-// Navigation errors (redirect, notFound, etc.) are always passed through
-// unchanged since their digests are used for client-side routing.
-function __sanitizeErrorForClient(error) {
-  // Navigation errors must pass through with their digest intact
-  if (__resolveAppPageSpecialError(error)) {
-    return error;
-  }
-  // In development, pass through the original error for debugging
-  if (process.env.NODE_ENV !== "production") {
-    return error;
-  }
-  // In production, create a sanitized error with only a digest hash
-  const msg = error instanceof Error ? error.message : String(error);
-  const stack = error instanceof Error ? (error.stack || "") : "";
-  const sanitized = new Error(
-    "An error occurred in the Server Components render. " +
-    "The specific message is omitted in production builds to avoid leaking sensitive details. " +
-    "A digest property is included on this error instance which may provide additional details about the nature of the error."
-  );
-  sanitized.digest = __errorDigest(msg + stack);
-  return sanitized;
-}
-
-// onError callback for renderToReadableStream — preserves the digest for
-// Next.js navigation errors (redirect, notFound, forbidden, unauthorized)
-// thrown during RSC streaming (e.g. inside Suspense boundaries).
-// For non-navigation errors in production, generates a digest hash so the
-// error can be correlated with server logs without leaking details.
-function rscOnError(error, requestInfo, errorContext) {
-  if (error && typeof error === "object" && "digest" in error) {
-    return String(error.digest);
-  }
-
-  // In dev, detect the "Only plain objects" RSC serialization error and emit
-  // an actionable hint. This error occurs when a Server Component passes a
-  // class instance, ES module namespace object, or null-prototype object as a
-  // prop to a Client Component.
-  //
-  // Root cause: Vite bundles modules as true ESM (module namespace objects
-  // have a null-like internal slot), while Next.js's webpack build produces
-  // plain CJS-wrapped objects with __esModule:true. React's RSC serializer
-  // accepts the latter as plain objects but rejects the former — which means
-  // code that accidentally passes "import * as X" works in webpack/Next.js
-  // but correctly fails in vinext.
-  //
-  // Common triggers:
-  //   - "import * as utils from './utils'" passed as a prop
-  //   - class instances (new Foo()) passed as props
-  //   - Date / Map / Set instances passed as props
-  //   - Objects with Object.create(null) (null prototype)
-  if (
-    process.env.NODE_ENV !== "production" &&
-    error instanceof Error &&
-    error.message.includes("Only plain objects, and a few built-ins, can be passed to Client Components")
-  ) {
-    console.error(
-      "[vinext] RSC serialization error: a non-plain object was passed from a Server Component to a Client Component.\\n" +
-      "\\n" +
-      "Common causes:\\n" +
-      "  * Passing a module namespace (import * as X) directly as a prop.\\n" +
-      "    Unlike Next.js (webpack), Vite produces real ESM module namespace objects\\n" +
-      "    which are not serializable. Fix: pass individual values instead,\\n" +
-      "    e.g. <Comp value={module.value} />\\n" +
-      "  * Passing a class instance (new Foo()) as a prop.\\n" +
-      "    Fix: convert to a plain object, e.g. { id: foo.id, name: foo.name }\\n" +
-      "  * Passing a Date, Map, or Set. Use .toISOString(), [...map.entries()], etc.\\n" +
-      "  * Passing Object.create(null). Use { ...obj } to restore a prototype.\\n" +
-      "\\n" +
-      "Original error:",
-      error.message,
-    );
-    return undefined;
-  }
-
-  if (requestInfo && errorContext && error) {
-    _reportRequestError(
-      error instanceof Error ? error : new Error(String(error)),
-      requestInfo,
-      errorContext,
-    );
-  }
-
-  // In production, generate a digest hash for non-navigation errors
-  if (process.env.NODE_ENV === "production" && error) {
-    const msg = error instanceof Error ? error.message : String(error);
-    const stack = error instanceof Error ? (error.stack || "") : "";
-    return __errorDigest(msg + stack);
-  }
-  return undefined;
-}
-
 function createRscOnErrorHandler(request, pathname, routePath) {
   const requestInfo = {
     path: pathname,
@@ -553,9 +371,11 @@ function createRscOnErrorHandler(request, pathname, routePath) {
     routePath: routePath || pathname,
     routeType: "render",
   };
-  return function(error) {
-    return rscOnError(error, requestInfo, errorContext);
-  };
+  return __createRscOnErrorHandler({
+    errorContext,
+    reportRequestError: _reportRequestError,
+    requestInfo,
+  });
 }
 
 ${imports.join("\n")}
@@ -885,63 +705,6 @@ function __buildPostMwRequestContext(request) {
  * Prevents unbounded request body buffering.
  */
 var __MAX_ACTION_BODY_SIZE = ${JSON.stringify(bodySizeLimit)};
-
-/**
- * Read a request body as text with a size limit.
- * Enforces the limit on the actual byte stream to prevent bypasses
- * via chunked transfer-encoding where Content-Length is absent or spoofed.
- */
-async function __readBodyWithLimit(request, maxBytes) {
-  if (!request.body) return "";
-  var reader = request.body.getReader();
-  var decoder = new TextDecoder();
-  var chunks = [];
-  var totalSize = 0;
-  for (;;) {
-    var result = await reader.read();
-    if (result.done) break;
-    totalSize += result.value.byteLength;
-    if (totalSize > maxBytes) {
-      reader.cancel();
-      throw new Error("Request body too large");
-    }
-    chunks.push(decoder.decode(result.value, { stream: true }));
-  }
-  chunks.push(decoder.decode());
-  return chunks.join("");
-}
-
-/**
- * Read a request body as FormData with a size limit.
- * Consumes the body stream with a byte counter and then parses the
- * collected bytes as multipart form data via the Response constructor.
- */
-async function __readFormDataWithLimit(request, maxBytes) {
-  if (!request.body) return new FormData();
-  var reader = request.body.getReader();
-  var chunks = [];
-  var totalSize = 0;
-  for (;;) {
-    var result = await reader.read();
-    if (result.done) break;
-    totalSize += result.value.byteLength;
-    if (totalSize > maxBytes) {
-      reader.cancel();
-      throw new Error("Request body too large");
-    }
-    chunks.push(result.value);
-  }
-  // Reconstruct a Response with the original Content-Type so that
-  // the FormData parser can handle multipart boundaries correctly.
-  var combined = new Uint8Array(totalSize);
-  var offset = 0;
-  for (var chunk of chunks) {
-    combined.set(chunk, offset);
-    offset += chunk.byteLength;
-  }
-  var contentType = request.headers.get("content-type") || "";
-  return new Response(combined, { headers: { "Content-Type": contentType } }).formData();
-}
 
 // Map from route pattern to generateStaticParams function.
 // Used by the prerender phase to enumerate dynamic route URLs without
@@ -1635,7 +1398,11 @@ ${prerenderPagesLoaderOption}
         });
       },
       scheduleBackgroundRegeneration(key, renderFn) {
-        __triggerBackgroundRegeneration(key, renderFn, { routePath: route.pattern, routeType: "render" });
+        __triggerBackgroundRegeneration(key, renderFn, {
+          routerKind: "App Router",
+          routePath: route.pattern,
+          routeType: "render",
+        });
       },
     });
     if (__cachedPageResponse) {

--- a/packages/vinext/src/server/app-rsc-errors.ts
+++ b/packages/vinext/src/server/app-rsc-errors.ts
@@ -31,26 +31,12 @@ function hasDigest(error: unknown): error is { digest: unknown } {
   return Boolean(error && typeof error === "object" && "digest" in error);
 }
 
-function getErrorMessage(error: unknown): string {
-  if (error instanceof Error) return error.message;
-  if (typeof error === "string") return error;
-  if (typeof error === "number" || typeof error === "boolean" || typeof error === "bigint") {
-    return error.toString();
-  }
-  if (typeof error === "symbol") {
-    return error.description ? `Symbol(${error.description})` : "Symbol()";
-  }
-  if (error === null) return "null";
-  if (error === undefined) return "undefined";
+function getThrownValueMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
 
-  try {
-    const serialized = JSON.stringify(error);
-    if (serialized) return serialized;
-  } catch {
-    // Fall through to Object.prototype.toString for cyclic or host objects.
-  }
-
-  return Object.prototype.toString.call(error);
+function getThrownValueStack(error: unknown): string {
+  return error instanceof Error ? error.stack || "" : "";
 }
 
 /**
@@ -64,7 +50,7 @@ export function errorDigest(input: string): string {
   return (hash >>> 0).toString();
 }
 
-export function sanitizeErrorForClient(error: Error, nodeEnv = process.env.NODE_ENV): DigestError {
+export function sanitizeErrorForClient(error: unknown, nodeEnv = process.env.NODE_ENV): unknown {
   if (resolveAppPageSpecialError(error)) {
     return error;
   }
@@ -78,7 +64,7 @@ export function sanitizeErrorForClient(error: Error, nodeEnv = process.env.NODE_
       "The specific message is omitted in production builds to avoid leaking sensitive details. " +
       "A digest property is included on this error instance which may provide additional details about the nature of the error.",
   );
-  sanitized.digest = errorDigest(error.message + (error.stack || ""));
+  sanitized.digest = errorDigest(getThrownValueMessage(error) + getThrownValueStack(error));
   return sanitized;
 }
 
@@ -120,16 +106,14 @@ export function createRscOnErrorHandler(
 
     if (options.requestInfo && options.errorContext && error) {
       options.reportRequestError(
-        error instanceof Error ? error : new Error(getErrorMessage(error)),
+        error instanceof Error ? error : new Error(getThrownValueMessage(error)),
         options.requestInfo,
         options.errorContext,
       );
     }
 
     if (nodeEnv === "production" && error) {
-      const message = getErrorMessage(error);
-      const stack = error instanceof Error ? error.stack || "" : "";
-      return errorDigest(message + stack);
+      return errorDigest(getThrownValueMessage(error) + getThrownValueStack(error));
     }
 
     return undefined;

--- a/packages/vinext/src/server/app-rsc-errors.ts
+++ b/packages/vinext/src/server/app-rsc-errors.ts
@@ -1,0 +1,137 @@
+import { resolveAppPageSpecialError } from "./app-page-execution.js";
+
+type DigestError = Error & { digest?: string };
+
+type RscRequestInfo = {
+  path: string;
+  method: string;
+  headers: Record<string, string>;
+};
+
+type RscErrorContext = {
+  routerKind: "App Router";
+  routePath: string;
+  routeType: "render";
+};
+
+type RscErrorReporter = (
+  error: Error,
+  requestInfo: RscRequestInfo,
+  errorContext: RscErrorContext,
+) => void;
+
+type CreateRscOnErrorHandlerOptions = {
+  errorContext: RscErrorContext | null;
+  nodeEnv?: string;
+  reportRequestError: RscErrorReporter;
+  requestInfo: RscRequestInfo | null;
+};
+
+function hasDigest(error: unknown): error is { digest: unknown } {
+  return Boolean(error && typeof error === "object" && "digest" in error);
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  if (typeof error === "number" || typeof error === "boolean" || typeof error === "bigint") {
+    return error.toString();
+  }
+  if (typeof error === "symbol") {
+    return error.description ? `Symbol(${error.description})` : "Symbol()";
+  }
+  if (error === null) return "null";
+  if (error === undefined) return "undefined";
+
+  try {
+    const serialized = JSON.stringify(error);
+    if (serialized) return serialized;
+  } catch {
+    // Fall through to Object.prototype.toString for cyclic or host objects.
+  }
+
+  return Object.prototype.toString.call(error);
+}
+
+/**
+ * djb2 hash matching Next.js's string-hash package for RSC error digests.
+ */
+export function errorDigest(input: string): string {
+  let hash = 5381;
+  for (let i = input.length - 1; i >= 0; i--) {
+    hash = (hash * 33) ^ input.charCodeAt(i);
+  }
+  return (hash >>> 0).toString();
+}
+
+export function sanitizeErrorForClient(error: Error, nodeEnv = process.env.NODE_ENV): DigestError {
+  if (resolveAppPageSpecialError(error)) {
+    return error;
+  }
+
+  if (nodeEnv !== "production") {
+    return error;
+  }
+
+  const sanitized: DigestError = new Error(
+    "An error occurred in the Server Components render. " +
+      "The specific message is omitted in production builds to avoid leaking sensitive details. " +
+      "A digest property is included on this error instance which may provide additional details about the nature of the error.",
+  );
+  sanitized.digest = errorDigest(error.message + (error.stack || ""));
+  return sanitized;
+}
+
+export function createRscOnErrorHandler(
+  options: CreateRscOnErrorHandlerOptions,
+): (error: unknown) => string | undefined {
+  return (error) => {
+    const nodeEnv = options.nodeEnv ?? process.env.NODE_ENV;
+
+    if (hasDigest(error)) {
+      return String(error.digest);
+    }
+
+    if (
+      nodeEnv !== "production" &&
+      error instanceof Error &&
+      error.message.includes(
+        "Only plain objects, and a few built-ins, can be passed to Client Components",
+      )
+    ) {
+      console.error(
+        "[vinext] RSC serialization error: a non-plain object was passed from a Server Component to a Client Component.\n" +
+          "\n" +
+          "Common causes:\n" +
+          "  * Passing a module namespace (import * as X) directly as a prop.\n" +
+          "    Unlike Next.js (webpack), Vite produces real ESM module namespace objects\n" +
+          "    which are not serializable. Fix: pass individual values instead,\n" +
+          "    e.g. <Comp value={module.value} />\n" +
+          "  * Passing a class instance (new Foo()) as a prop.\n" +
+          "    Fix: convert to a plain object, e.g. { id: foo.id, name: foo.name }\n" +
+          "  * Passing a Date, Map, or Set. Use .toISOString(), [...map.entries()], etc.\n" +
+          "  * Passing Object.create(null). Use { ...obj } to restore a prototype.\n" +
+          "\n" +
+          "Original error:",
+        error.message,
+      );
+      return undefined;
+    }
+
+    if (options.requestInfo && options.errorContext && error) {
+      options.reportRequestError(
+        error instanceof Error ? error : new Error(getErrorMessage(error)),
+        options.requestInfo,
+        options.errorContext,
+      );
+    }
+
+    if (nodeEnv === "production" && error) {
+      const message = getErrorMessage(error);
+      const stack = error instanceof Error ? error.stack || "" : "";
+      return errorDigest(message + stack);
+    }
+
+    return undefined;
+  };
+}

--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -173,6 +173,64 @@ function getErrorMessage(error: unknown): string {
   return error instanceof Error && error.message ? error.message : String(error);
 }
 
+export async function readActionBodyWithLimit(request: Request, maxBytes: number): Promise<string> {
+  if (!request.body) return "";
+
+  const reader = request.body.getReader();
+  const decoder = new TextDecoder();
+  const chunks: string[] = [];
+  let totalSize = 0;
+
+  for (;;) {
+    const result = await reader.read();
+    if (result.done) break;
+
+    totalSize += result.value.byteLength;
+    if (totalSize > maxBytes) {
+      await reader.cancel();
+      throw new Error("Request body too large");
+    }
+    chunks.push(decoder.decode(result.value, { stream: true }));
+  }
+
+  chunks.push(decoder.decode());
+  return chunks.join("");
+}
+
+export async function readActionFormDataWithLimit(
+  request: Request,
+  maxBytes: number,
+): Promise<FormData> {
+  if (!request.body) return new FormData();
+
+  const reader = request.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalSize = 0;
+
+  for (;;) {
+    const result = await reader.read();
+    if (result.done) break;
+
+    totalSize += result.value.byteLength;
+    if (totalSize > maxBytes) {
+      await reader.cancel();
+      throw new Error("Request body too large");
+    }
+    chunks.push(result.value);
+  }
+
+  const combined = new Uint8Array(totalSize);
+  let offset = 0;
+  for (const chunk of chunks) {
+    combined.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+
+  return new Response(combined, {
+    headers: { "Content-Type": request.headers.get("content-type") || "" },
+  }).formData();
+}
+
 function getErrorDigest(error: unknown): string | null {
   if (!error || typeof error !== "object" || !("digest" in error)) {
     return null;

--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -169,7 +169,7 @@ function normalizeError(error: unknown): Error {
   return error instanceof Error ? error : new Error(String(error));
 }
 
-function getErrorMessage(error: unknown): string {
+function getServerActionFailureMessage(error: unknown): string {
   return error instanceof Error && error.message ? error.message : String(error);
 }
 
@@ -320,7 +320,7 @@ function createServerActionErrorResponse(
   return new Response(
     process.env.NODE_ENV === "production"
       ? "Internal Server Error"
-      : "Server action failed: " + getErrorMessage(error),
+      : "Server action failed: " + getServerActionFailureMessage(error),
     { status: 500 },
   );
 }
@@ -443,7 +443,7 @@ export async function handleProgressiveServerActionRequest(
     return new Response(
       process.env.NODE_ENV === "production"
         ? "Internal Server Error"
-        : "Server action failed: " + getErrorMessage(error),
+        : "Server action failed: " + getServerActionFailureMessage(error),
       { status: 500 },
     );
   }

--- a/packages/vinext/src/server/isr-cache.ts
+++ b/packages/vinext/src/server/isr-cache.ts
@@ -168,16 +168,25 @@ export function buildAppPageCacheValue(
   };
 }
 
+function normalizeCachePathname(pathname: string): string {
+  return pathname === "/" ? "/" : pathname.replace(/\/$/, "");
+}
+
+function buildCacheKey(prefix: string, pathname: string, suffix?: string): string {
+  const normalized = normalizeCachePathname(pathname);
+  const suffixPart = suffix ? `:${suffix}` : "";
+  const key = `${prefix}:${normalized}${suffixPart}`;
+  if (key.length <= 200) return key;
+  return `${prefix}:__hash:${fnv1a64(normalized)}${suffixPart}`;
+}
+
 /**
  * Compute an ISR cache key for a given router type and pathname.
  * Long pathnames are hashed to stay within KV key-length limits (512 bytes).
  */
 export function isrCacheKey(router: "pages" | "app", pathname: string, buildId?: string): string {
-  const normalized = pathname === "/" ? "/" : pathname.replace(/\/$/, "");
   const prefix = buildId ? `${router}:${buildId}` : router;
-  const key = `${prefix}:${normalized}`;
-  if (key.length <= 200) return key;
-  return `${prefix}:__hash:${fnv1a64(normalized)}`;
+  return buildCacheKey(prefix, pathname);
 }
 
 /**
@@ -206,11 +215,8 @@ function appIsrCacheKey(
   suffix: string,
   buildId = process.env.__VINEXT_BUILD_ID,
 ): string {
-  const normalized = pathname === "/" ? "/" : pathname.replace(/\/$/, "");
   const prefix = buildId ? `app:${buildId}` : "app";
-  const key = `${prefix}:${normalized}:${suffix}`;
-  if (key.length <= 200) return key;
-  return `${prefix}:__hash:${fnv1a64(normalized)}:${suffix}`;
+  return buildCacheKey(prefix, pathname, suffix);
 }
 
 export function appIsrHtmlKey(pathname: string): string {

--- a/packages/vinext/src/server/isr-cache.ts
+++ b/packages/vinext/src/server/isr-cache.ts
@@ -180,6 +180,53 @@ export function isrCacheKey(router: "pages" | "app", pathname: string, buildId?:
   return `${prefix}:__hash:${fnv1a64(normalized)}`;
 }
 
+/**
+ * Normalize the App Router mounted-slot header before it participates in cache
+ * keys. The client can send mounted slot ids in different orders as navigation
+ * state changes, but equivalent slot sets must map to the same RSC cache entry.
+ */
+export function normalizeMountedSlotsHeader(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+
+  const normalized = Array.from(new Set(raw.split(/\s+/).filter(Boolean)))
+    .sort()
+    .join(" ");
+  return normalized || null;
+}
+
+/**
+ * Compute an App Router ISR key for one cache artifact.
+ *
+ * App pages store HTML, RSC payloads, and route-handler responses separately.
+ * The suffix mirrors Next.js's separate on-disk app artifacts while keeping the
+ * Cloudflare KV key under its 512-byte limit for long pathnames.
+ */
+function appIsrCacheKey(
+  pathname: string,
+  suffix: string,
+  buildId = process.env.__VINEXT_BUILD_ID,
+): string {
+  const normalized = pathname === "/" ? "/" : pathname.replace(/\/$/, "");
+  const prefix = buildId ? `app:${buildId}` : "app";
+  const key = `${prefix}:${normalized}:${suffix}`;
+  if (key.length <= 200) return key;
+  return `${prefix}:__hash:${fnv1a64(normalized)}:${suffix}`;
+}
+
+export function appIsrHtmlKey(pathname: string): string {
+  return appIsrCacheKey(pathname, "html");
+}
+
+export function appIsrRscKey(pathname: string, mountedSlotsHeader?: string | null): string {
+  const normalizedMountedSlotsHeader = normalizeMountedSlotsHeader(mountedSlotsHeader);
+  if (!normalizedMountedSlotsHeader) return appIsrCacheKey(pathname, "rsc");
+  return appIsrCacheKey(pathname, `rsc:${fnv1a64(normalizedMountedSlotsHeader)}`);
+}
+
+export function appIsrRouteKey(pathname: string): string {
+  return appIsrCacheKey(pathname, "route");
+}
+
 // ---------------------------------------------------------------------------
 // Revalidate duration tracking — remembers how long each ISR key's TTL is
 // so we can emit correct Cache-Control headers on cache hits.

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -39,7 +39,13 @@ import {
 import {
   handleProgressiveServerActionRequest as __handleProgressiveServerActionRequest,
   handleServerActionRscRequest as __handleServerActionRscRequest,
+  readActionBodyWithLimit as __readBodyWithLimit,
+  readActionFormDataWithLimit as __readFormDataWithLimit,
 } from "<ROOT>/packages/vinext/src/server/app-server-action-execution.js";
+import {
+  createRscOnErrorHandler as __createRscOnErrorHandler,
+  sanitizeErrorForClient as __sanitizeErrorForClient,
+} from "<ROOT>/packages/vinext/src/server/app-rsc-errors.js";
 import { readAppPageCacheResponse as __readAppPageCacheResponse } from "<ROOT>/packages/vinext/src/server/app-page-cache.js";
 import {
   buildAppPageFontLinkHeader as __buildAppPageFontLinkHeader,
@@ -90,7 +96,7 @@ import {
   createStaticGenerationHeadersContext as __createStaticGenerationHeadersContext,
 } from "<ROOT>/packages/vinext/src/server/app-static-generation.js";
 import { buildPageCacheTags } from "<ROOT>/packages/vinext/src/server/implicit-tags.js";
-import { _consumeRequestScopedCacheLife, getCacheHandler } from "next/cache";
+import { _consumeRequestScopedCacheLife } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
 import { setRootParams as __setRootParams, pickRootParams as __pickRootParams } from "<ROOT>/packages/vinext/src/shims/root-params.js";
 import { ensureFetchPatch as _ensureFetchPatch, getCollectedFetchTags, setCurrentFetchSoftTags } from "vinext/fetch-cache";
@@ -101,6 +107,15 @@ import {
 import {
   handleAppPrerenderEndpoint as __handleAppPrerenderEndpoint,
 } from "<ROOT>/packages/vinext/src/server/app-prerender-endpoints.js";
+import {
+  appIsrHtmlKey as __isrHtmlKey,
+  appIsrRscKey as __isrRscKey,
+  appIsrRouteKey as __isrRouteKey,
+  isrGet as __isrGet,
+  isrSet as __isrSet,
+  normalizeMountedSlotsHeader as __normalizeMountedSlotsHeader,
+  triggerBackgroundRegeneration as __triggerBackgroundRegeneration,
+} from "<ROOT>/packages/vinext/src/server/isr-cache.js";
 // Import server-only state module to register ALS-backed accessors.
 import "vinext/navigation-state";
 import { runWithRequestContext as _runWithUnifiedCtx, createRequestContext as _createUnifiedCtx } from "vinext/unified-request-context";
@@ -142,25 +157,6 @@ function __clearRequestContext() {
   // setNavigationContext(null) already clears root params internally
 }
 
-// ISR cache is disabled in dev mode — every request re-renders fresh,
-// matching Next.js dev behavior. Cache-Control headers are still emitted
-// based on export const revalidate for testing purposes.
-// Production ISR uses the MemoryCacheHandler (or configured KV handler).
-//
-// These helpers are inlined instead of imported from isr-cache.js because
-// the virtual RSC entry module runs in the RSC Vite environment which
-// cannot use dynamic imports at the module-evaluation level for server-only
-// modules, and direct imports must use the pre-computed absolute paths.
-async function __isrGet(key) {
-  const handler = getCacheHandler();
-  const result = await handler.get(key);
-  if (!result || !result.value) return null;
-  return { value: result, isStale: result.cacheState === "stale" };
-}
-async function __isrSet(key, data, revalidateSeconds, tags) {
-  const handler = getCacheHandler();
-  await handler.set(key, data, { revalidate: revalidateSeconds, tags: Array.isArray(tags) ? tags : [] });
-}
 // Note: cache entries are written with \`headers: undefined\`. Next.js stores
 // response headers (e.g. set-cookie from cookies().set() during render) in the
 // cache entry so they can be replayed on HIT. We don't do this because:
@@ -171,82 +167,6 @@ async function __isrSet(key, data, revalidateSeconds, tags) {
 // In practice this means ISR-cached responses won't replay render-time set-cookie
 // headers — but that case is already prevented by the dynamic-usage opt-out.
 // TODO: capture render-time response headers for full Next.js parity.
-const __pendingRegenerations = new Map();
-function __triggerBackgroundRegeneration(key, renderFn, errorContext) {
-  if (__pendingRegenerations.has(key)) return;
-  const promise = renderFn()
-    .catch((err) => {
-      console.error("[vinext] ISR regen failed for " + key + ":", err);
-      if (errorContext) {
-        void _reportRequestError(
-          err instanceof Error ? err : new Error(String(err)),
-          { path: key, method: "GET", headers: {} },
-          {
-            routerKind: "App Router",
-            routePath: errorContext.routePath,
-            routeType: errorContext.routeType,
-            revalidateReason: "stale",
-          },
-        );
-      }
-    })
-    .finally(() => __pendingRegenerations.delete(key));
-  __pendingRegenerations.set(key, promise);
-  const ctx = _getRequestExecutionContext();
-  if (ctx && typeof ctx.waitUntil === "function") ctx.waitUntil(promise);
-}
-// HTML and RSC are stored under separate keys — matching Next.js's file-system
-// layout (.html / .rsc) — so each request type reads and writes its own key
-// independently with no races or partial-entry sentinels.
-//
-// Key format: "app:<buildId>:<pathname>:<suffix>"
-// Long-pathname fallback: "app:<buildId>:__hash:<fnv1a64(pathname)>:<suffix>"
-// Without buildId (should not happen in production): "app:<pathname>:<suffix>"
-// The 200-char threshold keeps the full key well under Cloudflare KV's 512-byte limit
-// even after adding the build ID and suffix. FNV-1a 64 is used for the hash (two
-// 32-bit rounds) to give a ~64-bit output with negligible collision probability for
-// realistic pathname lengths.
-// Keep prefix construction and hashing logic in sync with isrCacheKey() in server/isr-cache.ts.
-function __isrFnv1a64(s) {
-  // h1 uses the standard FNV-1a 32-bit offset basis (0x811c9dc5).
-  let h1 = 0x811c9dc5;
-  for (let i = 0; i < s.length; i++) { h1 ^= s.charCodeAt(i); h1 = (h1 * 0x01000193) >>> 0; }
-  // h2 uses a different seed (0x050c5d1f — the FNV-1a hash of the string "vinext")
-  // so the two rounds are independently seeded and their outputs are decorrelated.
-  // Concatenating two independently-seeded 32-bit FNV-1a hashes gives an effective
-  // 64-bit hash. A random non-standard seed would also work; we derive it from a
-  // fixed string so the choice is auditable and deterministic across rebuilds.
-  let h2 = 0x050c5d1f;
-  for (let i = 0; i < s.length; i++) { h2 ^= s.charCodeAt(i); h2 = (h2 * 0x01000193) >>> 0; }
-  return h1.toString(36) + h2.toString(36);
-}
-function __isrCacheKey(pathname, suffix) {
-  const normalized = pathname === "/" ? "/" : pathname.replace(/\\/$/, "");
-  // __VINEXT_BUILD_ID is replaced at compile time by Vite's define plugin.
-  const buildId = process.env.__VINEXT_BUILD_ID;
-  const prefix = buildId ? "app:" + buildId : "app";
-  const key = prefix + ":" + normalized + ":" + suffix;
-  if (key.length <= 200) return key;
-  // Pathname too long — hash it to keep under KV's 512-byte key limit.
-  return prefix + ":__hash:" + __isrFnv1a64(normalized) + ":" + suffix;
-}
-function __isrHtmlKey(pathname) { return __isrCacheKey(pathname, "html"); }
-function __isrRscKey(pathname, mountedSlotsHeader) {
-  if (!mountedSlotsHeader) return __isrCacheKey(pathname, "rsc");
-  return __isrCacheKey(pathname, "rsc:" + __isrFnv1a64(mountedSlotsHeader));
-}
-function __normalizeMountedSlotsHeader(raw) {
-  if (!raw) return null;
-  const normalized = Array.from(
-    new Set(
-      raw
-        .split(/\\s+/)
-        .filter(Boolean),
-    ),
-  ).sort().join(" ");
-  return normalized || null;
-}
-function __isrRouteKey(pathname) { return __isrCacheKey(pathname, "route"); }
 // Verbose cache logging — opt in with NEXT_PRIVATE_DEBUG_CACHE=1.
 // Matches the env var Next.js uses for its own cache debug output so operators
 // have a single knob for all cache tracing.
@@ -278,110 +198,6 @@ function makeThenableParams(obj) {
   return Object.assign(Promise.resolve(plain), plain);
 }
 
-// djb2 hash — matches Next.js's stringHash for digest generation.
-// Produces a stable numeric string from error message + stack.
-function __errorDigest(str) {
-  let hash = 5381;
-  for (let i = str.length - 1; i >= 0; i--) {
-    hash = (hash * 33) ^ str.charCodeAt(i);
-  }
-  return (hash >>> 0).toString();
-}
-
-// Sanitize an error for client consumption. In production, replaces the error
-// with a generic Error that only carries a digest hash (matching Next.js
-// behavior). In development, returns the original error for debugging.
-// Navigation errors (redirect, notFound, etc.) are always passed through
-// unchanged since their digests are used for client-side routing.
-function __sanitizeErrorForClient(error) {
-  // Navigation errors must pass through with their digest intact
-  if (__resolveAppPageSpecialError(error)) {
-    return error;
-  }
-  // In development, pass through the original error for debugging
-  if (process.env.NODE_ENV !== "production") {
-    return error;
-  }
-  // In production, create a sanitized error with only a digest hash
-  const msg = error instanceof Error ? error.message : String(error);
-  const stack = error instanceof Error ? (error.stack || "") : "";
-  const sanitized = new Error(
-    "An error occurred in the Server Components render. " +
-    "The specific message is omitted in production builds to avoid leaking sensitive details. " +
-    "A digest property is included on this error instance which may provide additional details about the nature of the error."
-  );
-  sanitized.digest = __errorDigest(msg + stack);
-  return sanitized;
-}
-
-// onError callback for renderToReadableStream — preserves the digest for
-// Next.js navigation errors (redirect, notFound, forbidden, unauthorized)
-// thrown during RSC streaming (e.g. inside Suspense boundaries).
-// For non-navigation errors in production, generates a digest hash so the
-// error can be correlated with server logs without leaking details.
-function rscOnError(error, requestInfo, errorContext) {
-  if (error && typeof error === "object" && "digest" in error) {
-    return String(error.digest);
-  }
-
-  // In dev, detect the "Only plain objects" RSC serialization error and emit
-  // an actionable hint. This error occurs when a Server Component passes a
-  // class instance, ES module namespace object, or null-prototype object as a
-  // prop to a Client Component.
-  //
-  // Root cause: Vite bundles modules as true ESM (module namespace objects
-  // have a null-like internal slot), while Next.js's webpack build produces
-  // plain CJS-wrapped objects with __esModule:true. React's RSC serializer
-  // accepts the latter as plain objects but rejects the former — which means
-  // code that accidentally passes "import * as X" works in webpack/Next.js
-  // but correctly fails in vinext.
-  //
-  // Common triggers:
-  //   - "import * as utils from './utils'" passed as a prop
-  //   - class instances (new Foo()) passed as props
-  //   - Date / Map / Set instances passed as props
-  //   - Objects with Object.create(null) (null prototype)
-  if (
-    process.env.NODE_ENV !== "production" &&
-    error instanceof Error &&
-    error.message.includes("Only plain objects, and a few built-ins, can be passed to Client Components")
-  ) {
-    console.error(
-      "[vinext] RSC serialization error: a non-plain object was passed from a Server Component to a Client Component.\\n" +
-      "\\n" +
-      "Common causes:\\n" +
-      "  * Passing a module namespace (import * as X) directly as a prop.\\n" +
-      "    Unlike Next.js (webpack), Vite produces real ESM module namespace objects\\n" +
-      "    which are not serializable. Fix: pass individual values instead,\\n" +
-      "    e.g. <Comp value={module.value} />\\n" +
-      "  * Passing a class instance (new Foo()) as a prop.\\n" +
-      "    Fix: convert to a plain object, e.g. { id: foo.id, name: foo.name }\\n" +
-      "  * Passing a Date, Map, or Set. Use .toISOString(), [...map.entries()], etc.\\n" +
-      "  * Passing Object.create(null). Use { ...obj } to restore a prototype.\\n" +
-      "\\n" +
-      "Original error:",
-      error.message,
-    );
-    return undefined;
-  }
-
-  if (requestInfo && errorContext && error) {
-    _reportRequestError(
-      error instanceof Error ? error : new Error(String(error)),
-      requestInfo,
-      errorContext,
-    );
-  }
-
-  // In production, generate a digest hash for non-navigation errors
-  if (process.env.NODE_ENV === "production" && error) {
-    const msg = error instanceof Error ? error.message : String(error);
-    const stack = error instanceof Error ? (error.stack || "") : "";
-    return __errorDigest(msg + stack);
-  }
-  return undefined;
-}
-
 function createRscOnErrorHandler(request, pathname, routePath) {
   const requestInfo = {
     path: pathname,
@@ -393,9 +209,11 @@ function createRscOnErrorHandler(request, pathname, routePath) {
     routePath: routePath || pathname,
     routeType: "render",
   };
-  return function(error) {
-    return rscOnError(error, requestInfo, errorContext);
-  };
+  return __createRscOnErrorHandler({
+    errorContext,
+    reportRequestError: _reportRequestError,
+    requestInfo,
+  });
 }
 
 import * as mod_0 from "/tmp/test/app/page.tsx";
@@ -868,63 +686,6 @@ function __buildPostMwRequestContext(request) {
  * Prevents unbounded request body buffering.
  */
 var __MAX_ACTION_BODY_SIZE = 1048576;
-
-/**
- * Read a request body as text with a size limit.
- * Enforces the limit on the actual byte stream to prevent bypasses
- * via chunked transfer-encoding where Content-Length is absent or spoofed.
- */
-async function __readBodyWithLimit(request, maxBytes) {
-  if (!request.body) return "";
-  var reader = request.body.getReader();
-  var decoder = new TextDecoder();
-  var chunks = [];
-  var totalSize = 0;
-  for (;;) {
-    var result = await reader.read();
-    if (result.done) break;
-    totalSize += result.value.byteLength;
-    if (totalSize > maxBytes) {
-      reader.cancel();
-      throw new Error("Request body too large");
-    }
-    chunks.push(decoder.decode(result.value, { stream: true }));
-  }
-  chunks.push(decoder.decode());
-  return chunks.join("");
-}
-
-/**
- * Read a request body as FormData with a size limit.
- * Consumes the body stream with a byte counter and then parses the
- * collected bytes as multipart form data via the Response constructor.
- */
-async function __readFormDataWithLimit(request, maxBytes) {
-  if (!request.body) return new FormData();
-  var reader = request.body.getReader();
-  var chunks = [];
-  var totalSize = 0;
-  for (;;) {
-    var result = await reader.read();
-    if (result.done) break;
-    totalSize += result.value.byteLength;
-    if (totalSize > maxBytes) {
-      reader.cancel();
-      throw new Error("Request body too large");
-    }
-    chunks.push(result.value);
-  }
-  // Reconstruct a Response with the original Content-Type so that
-  // the FormData parser can handle multipart boundaries correctly.
-  var combined = new Uint8Array(totalSize);
-  var offset = 0;
-  for (var chunk of chunks) {
-    combined.set(chunk, offset);
-    offset += chunk.byteLength;
-  }
-  var contentType = request.headers.get("content-type") || "";
-  return new Response(combined, { headers: { "Content-Type": contentType } }).formData();
-}
 
 // Map from route pattern to generateStaticParams function.
 // Used by the prerender phase to enumerate dynamic route URLs without
@@ -1541,7 +1302,11 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         });
       },
       scheduleBackgroundRegeneration(key, renderFn) {
-        __triggerBackgroundRegeneration(key, renderFn, { routePath: route.pattern, routeType: "render" });
+        __triggerBackgroundRegeneration(key, renderFn, {
+          routerKind: "App Router",
+          routePath: route.pattern,
+          routeType: "render",
+        });
       },
     });
     if (__cachedPageResponse) {
@@ -1893,7 +1658,13 @@ import {
 import {
   handleProgressiveServerActionRequest as __handleProgressiveServerActionRequest,
   handleServerActionRscRequest as __handleServerActionRscRequest,
+  readActionBodyWithLimit as __readBodyWithLimit,
+  readActionFormDataWithLimit as __readFormDataWithLimit,
 } from "<ROOT>/packages/vinext/src/server/app-server-action-execution.js";
+import {
+  createRscOnErrorHandler as __createRscOnErrorHandler,
+  sanitizeErrorForClient as __sanitizeErrorForClient,
+} from "<ROOT>/packages/vinext/src/server/app-rsc-errors.js";
 import { readAppPageCacheResponse as __readAppPageCacheResponse } from "<ROOT>/packages/vinext/src/server/app-page-cache.js";
 import {
   buildAppPageFontLinkHeader as __buildAppPageFontLinkHeader,
@@ -1944,7 +1715,7 @@ import {
   createStaticGenerationHeadersContext as __createStaticGenerationHeadersContext,
 } from "<ROOT>/packages/vinext/src/server/app-static-generation.js";
 import { buildPageCacheTags } from "<ROOT>/packages/vinext/src/server/implicit-tags.js";
-import { _consumeRequestScopedCacheLife, getCacheHandler } from "next/cache";
+import { _consumeRequestScopedCacheLife } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
 import { setRootParams as __setRootParams, pickRootParams as __pickRootParams } from "<ROOT>/packages/vinext/src/shims/root-params.js";
 import { ensureFetchPatch as _ensureFetchPatch, getCollectedFetchTags, setCurrentFetchSoftTags } from "vinext/fetch-cache";
@@ -1955,6 +1726,15 @@ import {
 import {
   handleAppPrerenderEndpoint as __handleAppPrerenderEndpoint,
 } from "<ROOT>/packages/vinext/src/server/app-prerender-endpoints.js";
+import {
+  appIsrHtmlKey as __isrHtmlKey,
+  appIsrRscKey as __isrRscKey,
+  appIsrRouteKey as __isrRouteKey,
+  isrGet as __isrGet,
+  isrSet as __isrSet,
+  normalizeMountedSlotsHeader as __normalizeMountedSlotsHeader,
+  triggerBackgroundRegeneration as __triggerBackgroundRegeneration,
+} from "<ROOT>/packages/vinext/src/server/isr-cache.js";
 // Import server-only state module to register ALS-backed accessors.
 import "vinext/navigation-state";
 import { runWithRequestContext as _runWithUnifiedCtx, createRequestContext as _createUnifiedCtx } from "vinext/unified-request-context";
@@ -1996,25 +1776,6 @@ function __clearRequestContext() {
   // setNavigationContext(null) already clears root params internally
 }
 
-// ISR cache is disabled in dev mode — every request re-renders fresh,
-// matching Next.js dev behavior. Cache-Control headers are still emitted
-// based on export const revalidate for testing purposes.
-// Production ISR uses the MemoryCacheHandler (or configured KV handler).
-//
-// These helpers are inlined instead of imported from isr-cache.js because
-// the virtual RSC entry module runs in the RSC Vite environment which
-// cannot use dynamic imports at the module-evaluation level for server-only
-// modules, and direct imports must use the pre-computed absolute paths.
-async function __isrGet(key) {
-  const handler = getCacheHandler();
-  const result = await handler.get(key);
-  if (!result || !result.value) return null;
-  return { value: result, isStale: result.cacheState === "stale" };
-}
-async function __isrSet(key, data, revalidateSeconds, tags) {
-  const handler = getCacheHandler();
-  await handler.set(key, data, { revalidate: revalidateSeconds, tags: Array.isArray(tags) ? tags : [] });
-}
 // Note: cache entries are written with \`headers: undefined\`. Next.js stores
 // response headers (e.g. set-cookie from cookies().set() during render) in the
 // cache entry so they can be replayed on HIT. We don't do this because:
@@ -2025,82 +1786,6 @@ async function __isrSet(key, data, revalidateSeconds, tags) {
 // In practice this means ISR-cached responses won't replay render-time set-cookie
 // headers — but that case is already prevented by the dynamic-usage opt-out.
 // TODO: capture render-time response headers for full Next.js parity.
-const __pendingRegenerations = new Map();
-function __triggerBackgroundRegeneration(key, renderFn, errorContext) {
-  if (__pendingRegenerations.has(key)) return;
-  const promise = renderFn()
-    .catch((err) => {
-      console.error("[vinext] ISR regen failed for " + key + ":", err);
-      if (errorContext) {
-        void _reportRequestError(
-          err instanceof Error ? err : new Error(String(err)),
-          { path: key, method: "GET", headers: {} },
-          {
-            routerKind: "App Router",
-            routePath: errorContext.routePath,
-            routeType: errorContext.routeType,
-            revalidateReason: "stale",
-          },
-        );
-      }
-    })
-    .finally(() => __pendingRegenerations.delete(key));
-  __pendingRegenerations.set(key, promise);
-  const ctx = _getRequestExecutionContext();
-  if (ctx && typeof ctx.waitUntil === "function") ctx.waitUntil(promise);
-}
-// HTML and RSC are stored under separate keys — matching Next.js's file-system
-// layout (.html / .rsc) — so each request type reads and writes its own key
-// independently with no races or partial-entry sentinels.
-//
-// Key format: "app:<buildId>:<pathname>:<suffix>"
-// Long-pathname fallback: "app:<buildId>:__hash:<fnv1a64(pathname)>:<suffix>"
-// Without buildId (should not happen in production): "app:<pathname>:<suffix>"
-// The 200-char threshold keeps the full key well under Cloudflare KV's 512-byte limit
-// even after adding the build ID and suffix. FNV-1a 64 is used for the hash (two
-// 32-bit rounds) to give a ~64-bit output with negligible collision probability for
-// realistic pathname lengths.
-// Keep prefix construction and hashing logic in sync with isrCacheKey() in server/isr-cache.ts.
-function __isrFnv1a64(s) {
-  // h1 uses the standard FNV-1a 32-bit offset basis (0x811c9dc5).
-  let h1 = 0x811c9dc5;
-  for (let i = 0; i < s.length; i++) { h1 ^= s.charCodeAt(i); h1 = (h1 * 0x01000193) >>> 0; }
-  // h2 uses a different seed (0x050c5d1f — the FNV-1a hash of the string "vinext")
-  // so the two rounds are independently seeded and their outputs are decorrelated.
-  // Concatenating two independently-seeded 32-bit FNV-1a hashes gives an effective
-  // 64-bit hash. A random non-standard seed would also work; we derive it from a
-  // fixed string so the choice is auditable and deterministic across rebuilds.
-  let h2 = 0x050c5d1f;
-  for (let i = 0; i < s.length; i++) { h2 ^= s.charCodeAt(i); h2 = (h2 * 0x01000193) >>> 0; }
-  return h1.toString(36) + h2.toString(36);
-}
-function __isrCacheKey(pathname, suffix) {
-  const normalized = pathname === "/" ? "/" : pathname.replace(/\\/$/, "");
-  // __VINEXT_BUILD_ID is replaced at compile time by Vite's define plugin.
-  const buildId = process.env.__VINEXT_BUILD_ID;
-  const prefix = buildId ? "app:" + buildId : "app";
-  const key = prefix + ":" + normalized + ":" + suffix;
-  if (key.length <= 200) return key;
-  // Pathname too long — hash it to keep under KV's 512-byte key limit.
-  return prefix + ":__hash:" + __isrFnv1a64(normalized) + ":" + suffix;
-}
-function __isrHtmlKey(pathname) { return __isrCacheKey(pathname, "html"); }
-function __isrRscKey(pathname, mountedSlotsHeader) {
-  if (!mountedSlotsHeader) return __isrCacheKey(pathname, "rsc");
-  return __isrCacheKey(pathname, "rsc:" + __isrFnv1a64(mountedSlotsHeader));
-}
-function __normalizeMountedSlotsHeader(raw) {
-  if (!raw) return null;
-  const normalized = Array.from(
-    new Set(
-      raw
-        .split(/\\s+/)
-        .filter(Boolean),
-    ),
-  ).sort().join(" ");
-  return normalized || null;
-}
-function __isrRouteKey(pathname) { return __isrCacheKey(pathname, "route"); }
 // Verbose cache logging — opt in with NEXT_PRIVATE_DEBUG_CACHE=1.
 // Matches the env var Next.js uses for its own cache debug output so operators
 // have a single knob for all cache tracing.
@@ -2132,110 +1817,6 @@ function makeThenableParams(obj) {
   return Object.assign(Promise.resolve(plain), plain);
 }
 
-// djb2 hash — matches Next.js's stringHash for digest generation.
-// Produces a stable numeric string from error message + stack.
-function __errorDigest(str) {
-  let hash = 5381;
-  for (let i = str.length - 1; i >= 0; i--) {
-    hash = (hash * 33) ^ str.charCodeAt(i);
-  }
-  return (hash >>> 0).toString();
-}
-
-// Sanitize an error for client consumption. In production, replaces the error
-// with a generic Error that only carries a digest hash (matching Next.js
-// behavior). In development, returns the original error for debugging.
-// Navigation errors (redirect, notFound, etc.) are always passed through
-// unchanged since their digests are used for client-side routing.
-function __sanitizeErrorForClient(error) {
-  // Navigation errors must pass through with their digest intact
-  if (__resolveAppPageSpecialError(error)) {
-    return error;
-  }
-  // In development, pass through the original error for debugging
-  if (process.env.NODE_ENV !== "production") {
-    return error;
-  }
-  // In production, create a sanitized error with only a digest hash
-  const msg = error instanceof Error ? error.message : String(error);
-  const stack = error instanceof Error ? (error.stack || "") : "";
-  const sanitized = new Error(
-    "An error occurred in the Server Components render. " +
-    "The specific message is omitted in production builds to avoid leaking sensitive details. " +
-    "A digest property is included on this error instance which may provide additional details about the nature of the error."
-  );
-  sanitized.digest = __errorDigest(msg + stack);
-  return sanitized;
-}
-
-// onError callback for renderToReadableStream — preserves the digest for
-// Next.js navigation errors (redirect, notFound, forbidden, unauthorized)
-// thrown during RSC streaming (e.g. inside Suspense boundaries).
-// For non-navigation errors in production, generates a digest hash so the
-// error can be correlated with server logs without leaking details.
-function rscOnError(error, requestInfo, errorContext) {
-  if (error && typeof error === "object" && "digest" in error) {
-    return String(error.digest);
-  }
-
-  // In dev, detect the "Only plain objects" RSC serialization error and emit
-  // an actionable hint. This error occurs when a Server Component passes a
-  // class instance, ES module namespace object, or null-prototype object as a
-  // prop to a Client Component.
-  //
-  // Root cause: Vite bundles modules as true ESM (module namespace objects
-  // have a null-like internal slot), while Next.js's webpack build produces
-  // plain CJS-wrapped objects with __esModule:true. React's RSC serializer
-  // accepts the latter as plain objects but rejects the former — which means
-  // code that accidentally passes "import * as X" works in webpack/Next.js
-  // but correctly fails in vinext.
-  //
-  // Common triggers:
-  //   - "import * as utils from './utils'" passed as a prop
-  //   - class instances (new Foo()) passed as props
-  //   - Date / Map / Set instances passed as props
-  //   - Objects with Object.create(null) (null prototype)
-  if (
-    process.env.NODE_ENV !== "production" &&
-    error instanceof Error &&
-    error.message.includes("Only plain objects, and a few built-ins, can be passed to Client Components")
-  ) {
-    console.error(
-      "[vinext] RSC serialization error: a non-plain object was passed from a Server Component to a Client Component.\\n" +
-      "\\n" +
-      "Common causes:\\n" +
-      "  * Passing a module namespace (import * as X) directly as a prop.\\n" +
-      "    Unlike Next.js (webpack), Vite produces real ESM module namespace objects\\n" +
-      "    which are not serializable. Fix: pass individual values instead,\\n" +
-      "    e.g. <Comp value={module.value} />\\n" +
-      "  * Passing a class instance (new Foo()) as a prop.\\n" +
-      "    Fix: convert to a plain object, e.g. { id: foo.id, name: foo.name }\\n" +
-      "  * Passing a Date, Map, or Set. Use .toISOString(), [...map.entries()], etc.\\n" +
-      "  * Passing Object.create(null). Use { ...obj } to restore a prototype.\\n" +
-      "\\n" +
-      "Original error:",
-      error.message,
-    );
-    return undefined;
-  }
-
-  if (requestInfo && errorContext && error) {
-    _reportRequestError(
-      error instanceof Error ? error : new Error(String(error)),
-      requestInfo,
-      errorContext,
-    );
-  }
-
-  // In production, generate a digest hash for non-navigation errors
-  if (process.env.NODE_ENV === "production" && error) {
-    const msg = error instanceof Error ? error.message : String(error);
-    const stack = error instanceof Error ? (error.stack || "") : "";
-    return __errorDigest(msg + stack);
-  }
-  return undefined;
-}
-
 function createRscOnErrorHandler(request, pathname, routePath) {
   const requestInfo = {
     path: pathname,
@@ -2247,9 +1828,11 @@ function createRscOnErrorHandler(request, pathname, routePath) {
     routePath: routePath || pathname,
     routeType: "render",
   };
-  return function(error) {
-    return rscOnError(error, requestInfo, errorContext);
-  };
+  return __createRscOnErrorHandler({
+    errorContext,
+    reportRequestError: _reportRequestError,
+    requestInfo,
+  });
 }
 
 import * as mod_0 from "/tmp/test/app/page.tsx";
@@ -2722,63 +2305,6 @@ function __buildPostMwRequestContext(request) {
  * Prevents unbounded request body buffering.
  */
 var __MAX_ACTION_BODY_SIZE = 1048576;
-
-/**
- * Read a request body as text with a size limit.
- * Enforces the limit on the actual byte stream to prevent bypasses
- * via chunked transfer-encoding where Content-Length is absent or spoofed.
- */
-async function __readBodyWithLimit(request, maxBytes) {
-  if (!request.body) return "";
-  var reader = request.body.getReader();
-  var decoder = new TextDecoder();
-  var chunks = [];
-  var totalSize = 0;
-  for (;;) {
-    var result = await reader.read();
-    if (result.done) break;
-    totalSize += result.value.byteLength;
-    if (totalSize > maxBytes) {
-      reader.cancel();
-      throw new Error("Request body too large");
-    }
-    chunks.push(decoder.decode(result.value, { stream: true }));
-  }
-  chunks.push(decoder.decode());
-  return chunks.join("");
-}
-
-/**
- * Read a request body as FormData with a size limit.
- * Consumes the body stream with a byte counter and then parses the
- * collected bytes as multipart form data via the Response constructor.
- */
-async function __readFormDataWithLimit(request, maxBytes) {
-  if (!request.body) return new FormData();
-  var reader = request.body.getReader();
-  var chunks = [];
-  var totalSize = 0;
-  for (;;) {
-    var result = await reader.read();
-    if (result.done) break;
-    totalSize += result.value.byteLength;
-    if (totalSize > maxBytes) {
-      reader.cancel();
-      throw new Error("Request body too large");
-    }
-    chunks.push(result.value);
-  }
-  // Reconstruct a Response with the original Content-Type so that
-  // the FormData parser can handle multipart boundaries correctly.
-  var combined = new Uint8Array(totalSize);
-  var offset = 0;
-  for (var chunk of chunks) {
-    combined.set(chunk, offset);
-    offset += chunk.byteLength;
-  }
-  var contentType = request.headers.get("content-type") || "";
-  return new Response(combined, { headers: { "Content-Type": contentType } }).formData();
-}
 
 // Map from route pattern to generateStaticParams function.
 // Used by the prerender phase to enumerate dynamic route URLs without
@@ -3401,7 +2927,11 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         });
       },
       scheduleBackgroundRegeneration(key, renderFn) {
-        __triggerBackgroundRegeneration(key, renderFn, { routePath: route.pattern, routeType: "render" });
+        __triggerBackgroundRegeneration(key, renderFn, {
+          routerKind: "App Router",
+          routePath: route.pattern,
+          routeType: "render",
+        });
       },
     });
     if (__cachedPageResponse) {
@@ -3753,7 +3283,13 @@ import {
 import {
   handleProgressiveServerActionRequest as __handleProgressiveServerActionRequest,
   handleServerActionRscRequest as __handleServerActionRscRequest,
+  readActionBodyWithLimit as __readBodyWithLimit,
+  readActionFormDataWithLimit as __readFormDataWithLimit,
 } from "<ROOT>/packages/vinext/src/server/app-server-action-execution.js";
+import {
+  createRscOnErrorHandler as __createRscOnErrorHandler,
+  sanitizeErrorForClient as __sanitizeErrorForClient,
+} from "<ROOT>/packages/vinext/src/server/app-rsc-errors.js";
 import { readAppPageCacheResponse as __readAppPageCacheResponse } from "<ROOT>/packages/vinext/src/server/app-page-cache.js";
 import {
   buildAppPageFontLinkHeader as __buildAppPageFontLinkHeader,
@@ -3804,7 +3340,7 @@ import {
   createStaticGenerationHeadersContext as __createStaticGenerationHeadersContext,
 } from "<ROOT>/packages/vinext/src/server/app-static-generation.js";
 import { buildPageCacheTags } from "<ROOT>/packages/vinext/src/server/implicit-tags.js";
-import { _consumeRequestScopedCacheLife, getCacheHandler } from "next/cache";
+import { _consumeRequestScopedCacheLife } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
 import { setRootParams as __setRootParams, pickRootParams as __pickRootParams } from "<ROOT>/packages/vinext/src/shims/root-params.js";
 import { ensureFetchPatch as _ensureFetchPatch, getCollectedFetchTags, setCurrentFetchSoftTags } from "vinext/fetch-cache";
@@ -3815,6 +3351,15 @@ import {
 import {
   handleAppPrerenderEndpoint as __handleAppPrerenderEndpoint,
 } from "<ROOT>/packages/vinext/src/server/app-prerender-endpoints.js";
+import {
+  appIsrHtmlKey as __isrHtmlKey,
+  appIsrRscKey as __isrRscKey,
+  appIsrRouteKey as __isrRouteKey,
+  isrGet as __isrGet,
+  isrSet as __isrSet,
+  normalizeMountedSlotsHeader as __normalizeMountedSlotsHeader,
+  triggerBackgroundRegeneration as __triggerBackgroundRegeneration,
+} from "<ROOT>/packages/vinext/src/server/isr-cache.js";
 // Import server-only state module to register ALS-backed accessors.
 import "vinext/navigation-state";
 import { runWithRequestContext as _runWithUnifiedCtx, createRequestContext as _createUnifiedCtx } from "vinext/unified-request-context";
@@ -3856,25 +3401,6 @@ function __clearRequestContext() {
   // setNavigationContext(null) already clears root params internally
 }
 
-// ISR cache is disabled in dev mode — every request re-renders fresh,
-// matching Next.js dev behavior. Cache-Control headers are still emitted
-// based on export const revalidate for testing purposes.
-// Production ISR uses the MemoryCacheHandler (or configured KV handler).
-//
-// These helpers are inlined instead of imported from isr-cache.js because
-// the virtual RSC entry module runs in the RSC Vite environment which
-// cannot use dynamic imports at the module-evaluation level for server-only
-// modules, and direct imports must use the pre-computed absolute paths.
-async function __isrGet(key) {
-  const handler = getCacheHandler();
-  const result = await handler.get(key);
-  if (!result || !result.value) return null;
-  return { value: result, isStale: result.cacheState === "stale" };
-}
-async function __isrSet(key, data, revalidateSeconds, tags) {
-  const handler = getCacheHandler();
-  await handler.set(key, data, { revalidate: revalidateSeconds, tags: Array.isArray(tags) ? tags : [] });
-}
 // Note: cache entries are written with \`headers: undefined\`. Next.js stores
 // response headers (e.g. set-cookie from cookies().set() during render) in the
 // cache entry so they can be replayed on HIT. We don't do this because:
@@ -3885,82 +3411,6 @@ async function __isrSet(key, data, revalidateSeconds, tags) {
 // In practice this means ISR-cached responses won't replay render-time set-cookie
 // headers — but that case is already prevented by the dynamic-usage opt-out.
 // TODO: capture render-time response headers for full Next.js parity.
-const __pendingRegenerations = new Map();
-function __triggerBackgroundRegeneration(key, renderFn, errorContext) {
-  if (__pendingRegenerations.has(key)) return;
-  const promise = renderFn()
-    .catch((err) => {
-      console.error("[vinext] ISR regen failed for " + key + ":", err);
-      if (errorContext) {
-        void _reportRequestError(
-          err instanceof Error ? err : new Error(String(err)),
-          { path: key, method: "GET", headers: {} },
-          {
-            routerKind: "App Router",
-            routePath: errorContext.routePath,
-            routeType: errorContext.routeType,
-            revalidateReason: "stale",
-          },
-        );
-      }
-    })
-    .finally(() => __pendingRegenerations.delete(key));
-  __pendingRegenerations.set(key, promise);
-  const ctx = _getRequestExecutionContext();
-  if (ctx && typeof ctx.waitUntil === "function") ctx.waitUntil(promise);
-}
-// HTML and RSC are stored under separate keys — matching Next.js's file-system
-// layout (.html / .rsc) — so each request type reads and writes its own key
-// independently with no races or partial-entry sentinels.
-//
-// Key format: "app:<buildId>:<pathname>:<suffix>"
-// Long-pathname fallback: "app:<buildId>:__hash:<fnv1a64(pathname)>:<suffix>"
-// Without buildId (should not happen in production): "app:<pathname>:<suffix>"
-// The 200-char threshold keeps the full key well under Cloudflare KV's 512-byte limit
-// even after adding the build ID and suffix. FNV-1a 64 is used for the hash (two
-// 32-bit rounds) to give a ~64-bit output with negligible collision probability for
-// realistic pathname lengths.
-// Keep prefix construction and hashing logic in sync with isrCacheKey() in server/isr-cache.ts.
-function __isrFnv1a64(s) {
-  // h1 uses the standard FNV-1a 32-bit offset basis (0x811c9dc5).
-  let h1 = 0x811c9dc5;
-  for (let i = 0; i < s.length; i++) { h1 ^= s.charCodeAt(i); h1 = (h1 * 0x01000193) >>> 0; }
-  // h2 uses a different seed (0x050c5d1f — the FNV-1a hash of the string "vinext")
-  // so the two rounds are independently seeded and their outputs are decorrelated.
-  // Concatenating two independently-seeded 32-bit FNV-1a hashes gives an effective
-  // 64-bit hash. A random non-standard seed would also work; we derive it from a
-  // fixed string so the choice is auditable and deterministic across rebuilds.
-  let h2 = 0x050c5d1f;
-  for (let i = 0; i < s.length; i++) { h2 ^= s.charCodeAt(i); h2 = (h2 * 0x01000193) >>> 0; }
-  return h1.toString(36) + h2.toString(36);
-}
-function __isrCacheKey(pathname, suffix) {
-  const normalized = pathname === "/" ? "/" : pathname.replace(/\\/$/, "");
-  // __VINEXT_BUILD_ID is replaced at compile time by Vite's define plugin.
-  const buildId = process.env.__VINEXT_BUILD_ID;
-  const prefix = buildId ? "app:" + buildId : "app";
-  const key = prefix + ":" + normalized + ":" + suffix;
-  if (key.length <= 200) return key;
-  // Pathname too long — hash it to keep under KV's 512-byte key limit.
-  return prefix + ":__hash:" + __isrFnv1a64(normalized) + ":" + suffix;
-}
-function __isrHtmlKey(pathname) { return __isrCacheKey(pathname, "html"); }
-function __isrRscKey(pathname, mountedSlotsHeader) {
-  if (!mountedSlotsHeader) return __isrCacheKey(pathname, "rsc");
-  return __isrCacheKey(pathname, "rsc:" + __isrFnv1a64(mountedSlotsHeader));
-}
-function __normalizeMountedSlotsHeader(raw) {
-  if (!raw) return null;
-  const normalized = Array.from(
-    new Set(
-      raw
-        .split(/\\s+/)
-        .filter(Boolean),
-    ),
-  ).sort().join(" ");
-  return normalized || null;
-}
-function __isrRouteKey(pathname) { return __isrCacheKey(pathname, "route"); }
 // Verbose cache logging — opt in with NEXT_PRIVATE_DEBUG_CACHE=1.
 // Matches the env var Next.js uses for its own cache debug output so operators
 // have a single knob for all cache tracing.
@@ -3992,110 +3442,6 @@ function makeThenableParams(obj) {
   return Object.assign(Promise.resolve(plain), plain);
 }
 
-// djb2 hash — matches Next.js's stringHash for digest generation.
-// Produces a stable numeric string from error message + stack.
-function __errorDigest(str) {
-  let hash = 5381;
-  for (let i = str.length - 1; i >= 0; i--) {
-    hash = (hash * 33) ^ str.charCodeAt(i);
-  }
-  return (hash >>> 0).toString();
-}
-
-// Sanitize an error for client consumption. In production, replaces the error
-// with a generic Error that only carries a digest hash (matching Next.js
-// behavior). In development, returns the original error for debugging.
-// Navigation errors (redirect, notFound, etc.) are always passed through
-// unchanged since their digests are used for client-side routing.
-function __sanitizeErrorForClient(error) {
-  // Navigation errors must pass through with their digest intact
-  if (__resolveAppPageSpecialError(error)) {
-    return error;
-  }
-  // In development, pass through the original error for debugging
-  if (process.env.NODE_ENV !== "production") {
-    return error;
-  }
-  // In production, create a sanitized error with only a digest hash
-  const msg = error instanceof Error ? error.message : String(error);
-  const stack = error instanceof Error ? (error.stack || "") : "";
-  const sanitized = new Error(
-    "An error occurred in the Server Components render. " +
-    "The specific message is omitted in production builds to avoid leaking sensitive details. " +
-    "A digest property is included on this error instance which may provide additional details about the nature of the error."
-  );
-  sanitized.digest = __errorDigest(msg + stack);
-  return sanitized;
-}
-
-// onError callback for renderToReadableStream — preserves the digest for
-// Next.js navigation errors (redirect, notFound, forbidden, unauthorized)
-// thrown during RSC streaming (e.g. inside Suspense boundaries).
-// For non-navigation errors in production, generates a digest hash so the
-// error can be correlated with server logs without leaking details.
-function rscOnError(error, requestInfo, errorContext) {
-  if (error && typeof error === "object" && "digest" in error) {
-    return String(error.digest);
-  }
-
-  // In dev, detect the "Only plain objects" RSC serialization error and emit
-  // an actionable hint. This error occurs when a Server Component passes a
-  // class instance, ES module namespace object, or null-prototype object as a
-  // prop to a Client Component.
-  //
-  // Root cause: Vite bundles modules as true ESM (module namespace objects
-  // have a null-like internal slot), while Next.js's webpack build produces
-  // plain CJS-wrapped objects with __esModule:true. React's RSC serializer
-  // accepts the latter as plain objects but rejects the former — which means
-  // code that accidentally passes "import * as X" works in webpack/Next.js
-  // but correctly fails in vinext.
-  //
-  // Common triggers:
-  //   - "import * as utils from './utils'" passed as a prop
-  //   - class instances (new Foo()) passed as props
-  //   - Date / Map / Set instances passed as props
-  //   - Objects with Object.create(null) (null prototype)
-  if (
-    process.env.NODE_ENV !== "production" &&
-    error instanceof Error &&
-    error.message.includes("Only plain objects, and a few built-ins, can be passed to Client Components")
-  ) {
-    console.error(
-      "[vinext] RSC serialization error: a non-plain object was passed from a Server Component to a Client Component.\\n" +
-      "\\n" +
-      "Common causes:\\n" +
-      "  * Passing a module namespace (import * as X) directly as a prop.\\n" +
-      "    Unlike Next.js (webpack), Vite produces real ESM module namespace objects\\n" +
-      "    which are not serializable. Fix: pass individual values instead,\\n" +
-      "    e.g. <Comp value={module.value} />\\n" +
-      "  * Passing a class instance (new Foo()) as a prop.\\n" +
-      "    Fix: convert to a plain object, e.g. { id: foo.id, name: foo.name }\\n" +
-      "  * Passing a Date, Map, or Set. Use .toISOString(), [...map.entries()], etc.\\n" +
-      "  * Passing Object.create(null). Use { ...obj } to restore a prototype.\\n" +
-      "\\n" +
-      "Original error:",
-      error.message,
-    );
-    return undefined;
-  }
-
-  if (requestInfo && errorContext && error) {
-    _reportRequestError(
-      error instanceof Error ? error : new Error(String(error)),
-      requestInfo,
-      errorContext,
-    );
-  }
-
-  // In production, generate a digest hash for non-navigation errors
-  if (process.env.NODE_ENV === "production" && error) {
-    const msg = error instanceof Error ? error.message : String(error);
-    const stack = error instanceof Error ? (error.stack || "") : "";
-    return __errorDigest(msg + stack);
-  }
-  return undefined;
-}
-
 function createRscOnErrorHandler(request, pathname, routePath) {
   const requestInfo = {
     path: pathname,
@@ -4107,9 +3453,11 @@ function createRscOnErrorHandler(request, pathname, routePath) {
     routePath: routePath || pathname,
     routeType: "render",
   };
-  return function(error) {
-    return rscOnError(error, requestInfo, errorContext);
-  };
+  return __createRscOnErrorHandler({
+    errorContext,
+    reportRequestError: _reportRequestError,
+    requestInfo,
+  });
 }
 
 import * as mod_0 from "/tmp/test/app/page.tsx";
@@ -4583,63 +3931,6 @@ function __buildPostMwRequestContext(request) {
  * Prevents unbounded request body buffering.
  */
 var __MAX_ACTION_BODY_SIZE = 1048576;
-
-/**
- * Read a request body as text with a size limit.
- * Enforces the limit on the actual byte stream to prevent bypasses
- * via chunked transfer-encoding where Content-Length is absent or spoofed.
- */
-async function __readBodyWithLimit(request, maxBytes) {
-  if (!request.body) return "";
-  var reader = request.body.getReader();
-  var decoder = new TextDecoder();
-  var chunks = [];
-  var totalSize = 0;
-  for (;;) {
-    var result = await reader.read();
-    if (result.done) break;
-    totalSize += result.value.byteLength;
-    if (totalSize > maxBytes) {
-      reader.cancel();
-      throw new Error("Request body too large");
-    }
-    chunks.push(decoder.decode(result.value, { stream: true }));
-  }
-  chunks.push(decoder.decode());
-  return chunks.join("");
-}
-
-/**
- * Read a request body as FormData with a size limit.
- * Consumes the body stream with a byte counter and then parses the
- * collected bytes as multipart form data via the Response constructor.
- */
-async function __readFormDataWithLimit(request, maxBytes) {
-  if (!request.body) return new FormData();
-  var reader = request.body.getReader();
-  var chunks = [];
-  var totalSize = 0;
-  for (;;) {
-    var result = await reader.read();
-    if (result.done) break;
-    totalSize += result.value.byteLength;
-    if (totalSize > maxBytes) {
-      reader.cancel();
-      throw new Error("Request body too large");
-    }
-    chunks.push(result.value);
-  }
-  // Reconstruct a Response with the original Content-Type so that
-  // the FormData parser can handle multipart boundaries correctly.
-  var combined = new Uint8Array(totalSize);
-  var offset = 0;
-  for (var chunk of chunks) {
-    combined.set(chunk, offset);
-    offset += chunk.byteLength;
-  }
-  var contentType = request.headers.get("content-type") || "";
-  return new Response(combined, { headers: { "Content-Type": contentType } }).formData();
-}
 
 // Map from route pattern to generateStaticParams function.
 // Used by the prerender phase to enumerate dynamic route URLs without
@@ -5256,7 +4547,11 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         });
       },
       scheduleBackgroundRegeneration(key, renderFn) {
-        __triggerBackgroundRegeneration(key, renderFn, { routePath: route.pattern, routeType: "render" });
+        __triggerBackgroundRegeneration(key, renderFn, {
+          routerKind: "App Router",
+          routePath: route.pattern,
+          routeType: "render",
+        });
       },
     });
     if (__cachedPageResponse) {
@@ -5608,7 +4903,13 @@ import {
 import {
   handleProgressiveServerActionRequest as __handleProgressiveServerActionRequest,
   handleServerActionRscRequest as __handleServerActionRscRequest,
+  readActionBodyWithLimit as __readBodyWithLimit,
+  readActionFormDataWithLimit as __readFormDataWithLimit,
 } from "<ROOT>/packages/vinext/src/server/app-server-action-execution.js";
+import {
+  createRscOnErrorHandler as __createRscOnErrorHandler,
+  sanitizeErrorForClient as __sanitizeErrorForClient,
+} from "<ROOT>/packages/vinext/src/server/app-rsc-errors.js";
 import { readAppPageCacheResponse as __readAppPageCacheResponse } from "<ROOT>/packages/vinext/src/server/app-page-cache.js";
 import {
   buildAppPageFontLinkHeader as __buildAppPageFontLinkHeader,
@@ -5659,7 +4960,7 @@ import {
   createStaticGenerationHeadersContext as __createStaticGenerationHeadersContext,
 } from "<ROOT>/packages/vinext/src/server/app-static-generation.js";
 import { buildPageCacheTags } from "<ROOT>/packages/vinext/src/server/implicit-tags.js";
-import { _consumeRequestScopedCacheLife, getCacheHandler } from "next/cache";
+import { _consumeRequestScopedCacheLife } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
 import { setRootParams as __setRootParams, pickRootParams as __pickRootParams } from "<ROOT>/packages/vinext/src/shims/root-params.js";
 import { ensureFetchPatch as _ensureFetchPatch, getCollectedFetchTags, setCurrentFetchSoftTags } from "vinext/fetch-cache";
@@ -5670,6 +4971,15 @@ import {
 import {
   handleAppPrerenderEndpoint as __handleAppPrerenderEndpoint,
 } from "<ROOT>/packages/vinext/src/server/app-prerender-endpoints.js";
+import {
+  appIsrHtmlKey as __isrHtmlKey,
+  appIsrRscKey as __isrRscKey,
+  appIsrRouteKey as __isrRouteKey,
+  isrGet as __isrGet,
+  isrSet as __isrSet,
+  normalizeMountedSlotsHeader as __normalizeMountedSlotsHeader,
+  triggerBackgroundRegeneration as __triggerBackgroundRegeneration,
+} from "<ROOT>/packages/vinext/src/server/isr-cache.js";
 // Import server-only state module to register ALS-backed accessors.
 import "vinext/navigation-state";
 import { runWithRequestContext as _runWithUnifiedCtx, createRequestContext as _createUnifiedCtx } from "vinext/unified-request-context";
@@ -5711,25 +5021,6 @@ function __clearRequestContext() {
   // setNavigationContext(null) already clears root params internally
 }
 
-// ISR cache is disabled in dev mode — every request re-renders fresh,
-// matching Next.js dev behavior. Cache-Control headers are still emitted
-// based on export const revalidate for testing purposes.
-// Production ISR uses the MemoryCacheHandler (or configured KV handler).
-//
-// These helpers are inlined instead of imported from isr-cache.js because
-// the virtual RSC entry module runs in the RSC Vite environment which
-// cannot use dynamic imports at the module-evaluation level for server-only
-// modules, and direct imports must use the pre-computed absolute paths.
-async function __isrGet(key) {
-  const handler = getCacheHandler();
-  const result = await handler.get(key);
-  if (!result || !result.value) return null;
-  return { value: result, isStale: result.cacheState === "stale" };
-}
-async function __isrSet(key, data, revalidateSeconds, tags) {
-  const handler = getCacheHandler();
-  await handler.set(key, data, { revalidate: revalidateSeconds, tags: Array.isArray(tags) ? tags : [] });
-}
 // Note: cache entries are written with \`headers: undefined\`. Next.js stores
 // response headers (e.g. set-cookie from cookies().set() during render) in the
 // cache entry so they can be replayed on HIT. We don't do this because:
@@ -5740,82 +5031,6 @@ async function __isrSet(key, data, revalidateSeconds, tags) {
 // In practice this means ISR-cached responses won't replay render-time set-cookie
 // headers — but that case is already prevented by the dynamic-usage opt-out.
 // TODO: capture render-time response headers for full Next.js parity.
-const __pendingRegenerations = new Map();
-function __triggerBackgroundRegeneration(key, renderFn, errorContext) {
-  if (__pendingRegenerations.has(key)) return;
-  const promise = renderFn()
-    .catch((err) => {
-      console.error("[vinext] ISR regen failed for " + key + ":", err);
-      if (errorContext) {
-        void _reportRequestError(
-          err instanceof Error ? err : new Error(String(err)),
-          { path: key, method: "GET", headers: {} },
-          {
-            routerKind: "App Router",
-            routePath: errorContext.routePath,
-            routeType: errorContext.routeType,
-            revalidateReason: "stale",
-          },
-        );
-      }
-    })
-    .finally(() => __pendingRegenerations.delete(key));
-  __pendingRegenerations.set(key, promise);
-  const ctx = _getRequestExecutionContext();
-  if (ctx && typeof ctx.waitUntil === "function") ctx.waitUntil(promise);
-}
-// HTML and RSC are stored under separate keys — matching Next.js's file-system
-// layout (.html / .rsc) — so each request type reads and writes its own key
-// independently with no races or partial-entry sentinels.
-//
-// Key format: "app:<buildId>:<pathname>:<suffix>"
-// Long-pathname fallback: "app:<buildId>:__hash:<fnv1a64(pathname)>:<suffix>"
-// Without buildId (should not happen in production): "app:<pathname>:<suffix>"
-// The 200-char threshold keeps the full key well under Cloudflare KV's 512-byte limit
-// even after adding the build ID and suffix. FNV-1a 64 is used for the hash (two
-// 32-bit rounds) to give a ~64-bit output with negligible collision probability for
-// realistic pathname lengths.
-// Keep prefix construction and hashing logic in sync with isrCacheKey() in server/isr-cache.ts.
-function __isrFnv1a64(s) {
-  // h1 uses the standard FNV-1a 32-bit offset basis (0x811c9dc5).
-  let h1 = 0x811c9dc5;
-  for (let i = 0; i < s.length; i++) { h1 ^= s.charCodeAt(i); h1 = (h1 * 0x01000193) >>> 0; }
-  // h2 uses a different seed (0x050c5d1f — the FNV-1a hash of the string "vinext")
-  // so the two rounds are independently seeded and their outputs are decorrelated.
-  // Concatenating two independently-seeded 32-bit FNV-1a hashes gives an effective
-  // 64-bit hash. A random non-standard seed would also work; we derive it from a
-  // fixed string so the choice is auditable and deterministic across rebuilds.
-  let h2 = 0x050c5d1f;
-  for (let i = 0; i < s.length; i++) { h2 ^= s.charCodeAt(i); h2 = (h2 * 0x01000193) >>> 0; }
-  return h1.toString(36) + h2.toString(36);
-}
-function __isrCacheKey(pathname, suffix) {
-  const normalized = pathname === "/" ? "/" : pathname.replace(/\\/$/, "");
-  // __VINEXT_BUILD_ID is replaced at compile time by Vite's define plugin.
-  const buildId = process.env.__VINEXT_BUILD_ID;
-  const prefix = buildId ? "app:" + buildId : "app";
-  const key = prefix + ":" + normalized + ":" + suffix;
-  if (key.length <= 200) return key;
-  // Pathname too long — hash it to keep under KV's 512-byte key limit.
-  return prefix + ":__hash:" + __isrFnv1a64(normalized) + ":" + suffix;
-}
-function __isrHtmlKey(pathname) { return __isrCacheKey(pathname, "html"); }
-function __isrRscKey(pathname, mountedSlotsHeader) {
-  if (!mountedSlotsHeader) return __isrCacheKey(pathname, "rsc");
-  return __isrCacheKey(pathname, "rsc:" + __isrFnv1a64(mountedSlotsHeader));
-}
-function __normalizeMountedSlotsHeader(raw) {
-  if (!raw) return null;
-  const normalized = Array.from(
-    new Set(
-      raw
-        .split(/\\s+/)
-        .filter(Boolean),
-    ),
-  ).sort().join(" ");
-  return normalized || null;
-}
-function __isrRouteKey(pathname) { return __isrCacheKey(pathname, "route"); }
 // Verbose cache logging — opt in with NEXT_PRIVATE_DEBUG_CACHE=1.
 // Matches the env var Next.js uses for its own cache debug output so operators
 // have a single knob for all cache tracing.
@@ -5847,110 +5062,6 @@ function makeThenableParams(obj) {
   return Object.assign(Promise.resolve(plain), plain);
 }
 
-// djb2 hash — matches Next.js's stringHash for digest generation.
-// Produces a stable numeric string from error message + stack.
-function __errorDigest(str) {
-  let hash = 5381;
-  for (let i = str.length - 1; i >= 0; i--) {
-    hash = (hash * 33) ^ str.charCodeAt(i);
-  }
-  return (hash >>> 0).toString();
-}
-
-// Sanitize an error for client consumption. In production, replaces the error
-// with a generic Error that only carries a digest hash (matching Next.js
-// behavior). In development, returns the original error for debugging.
-// Navigation errors (redirect, notFound, etc.) are always passed through
-// unchanged since their digests are used for client-side routing.
-function __sanitizeErrorForClient(error) {
-  // Navigation errors must pass through with their digest intact
-  if (__resolveAppPageSpecialError(error)) {
-    return error;
-  }
-  // In development, pass through the original error for debugging
-  if (process.env.NODE_ENV !== "production") {
-    return error;
-  }
-  // In production, create a sanitized error with only a digest hash
-  const msg = error instanceof Error ? error.message : String(error);
-  const stack = error instanceof Error ? (error.stack || "") : "";
-  const sanitized = new Error(
-    "An error occurred in the Server Components render. " +
-    "The specific message is omitted in production builds to avoid leaking sensitive details. " +
-    "A digest property is included on this error instance which may provide additional details about the nature of the error."
-  );
-  sanitized.digest = __errorDigest(msg + stack);
-  return sanitized;
-}
-
-// onError callback for renderToReadableStream — preserves the digest for
-// Next.js navigation errors (redirect, notFound, forbidden, unauthorized)
-// thrown during RSC streaming (e.g. inside Suspense boundaries).
-// For non-navigation errors in production, generates a digest hash so the
-// error can be correlated with server logs without leaking details.
-function rscOnError(error, requestInfo, errorContext) {
-  if (error && typeof error === "object" && "digest" in error) {
-    return String(error.digest);
-  }
-
-  // In dev, detect the "Only plain objects" RSC serialization error and emit
-  // an actionable hint. This error occurs when a Server Component passes a
-  // class instance, ES module namespace object, or null-prototype object as a
-  // prop to a Client Component.
-  //
-  // Root cause: Vite bundles modules as true ESM (module namespace objects
-  // have a null-like internal slot), while Next.js's webpack build produces
-  // plain CJS-wrapped objects with __esModule:true. React's RSC serializer
-  // accepts the latter as plain objects but rejects the former — which means
-  // code that accidentally passes "import * as X" works in webpack/Next.js
-  // but correctly fails in vinext.
-  //
-  // Common triggers:
-  //   - "import * as utils from './utils'" passed as a prop
-  //   - class instances (new Foo()) passed as props
-  //   - Date / Map / Set instances passed as props
-  //   - Objects with Object.create(null) (null prototype)
-  if (
-    process.env.NODE_ENV !== "production" &&
-    error instanceof Error &&
-    error.message.includes("Only plain objects, and a few built-ins, can be passed to Client Components")
-  ) {
-    console.error(
-      "[vinext] RSC serialization error: a non-plain object was passed from a Server Component to a Client Component.\\n" +
-      "\\n" +
-      "Common causes:\\n" +
-      "  * Passing a module namespace (import * as X) directly as a prop.\\n" +
-      "    Unlike Next.js (webpack), Vite produces real ESM module namespace objects\\n" +
-      "    which are not serializable. Fix: pass individual values instead,\\n" +
-      "    e.g. <Comp value={module.value} />\\n" +
-      "  * Passing a class instance (new Foo()) as a prop.\\n" +
-      "    Fix: convert to a plain object, e.g. { id: foo.id, name: foo.name }\\n" +
-      "  * Passing a Date, Map, or Set. Use .toISOString(), [...map.entries()], etc.\\n" +
-      "  * Passing Object.create(null). Use { ...obj } to restore a prototype.\\n" +
-      "\\n" +
-      "Original error:",
-      error.message,
-    );
-    return undefined;
-  }
-
-  if (requestInfo && errorContext && error) {
-    _reportRequestError(
-      error instanceof Error ? error : new Error(String(error)),
-      requestInfo,
-      errorContext,
-    );
-  }
-
-  // In production, generate a digest hash for non-navigation errors
-  if (process.env.NODE_ENV === "production" && error) {
-    const msg = error instanceof Error ? error.message : String(error);
-    const stack = error instanceof Error ? (error.stack || "") : "";
-    return __errorDigest(msg + stack);
-  }
-  return undefined;
-}
-
 function createRscOnErrorHandler(request, pathname, routePath) {
   const requestInfo = {
     path: pathname,
@@ -5962,9 +5073,11 @@ function createRscOnErrorHandler(request, pathname, routePath) {
     routePath: routePath || pathname,
     routeType: "render",
   };
-  return function(error) {
-    return rscOnError(error, requestInfo, errorContext);
-  };
+  return __createRscOnErrorHandler({
+    errorContext,
+    reportRequestError: _reportRequestError,
+    requestInfo,
+  });
 }
 
 import * as mod_0 from "/tmp/test/app/page.tsx";
@@ -6467,63 +5580,6 @@ function __buildPostMwRequestContext(request) {
  * Prevents unbounded request body buffering.
  */
 var __MAX_ACTION_BODY_SIZE = 1048576;
-
-/**
- * Read a request body as text with a size limit.
- * Enforces the limit on the actual byte stream to prevent bypasses
- * via chunked transfer-encoding where Content-Length is absent or spoofed.
- */
-async function __readBodyWithLimit(request, maxBytes) {
-  if (!request.body) return "";
-  var reader = request.body.getReader();
-  var decoder = new TextDecoder();
-  var chunks = [];
-  var totalSize = 0;
-  for (;;) {
-    var result = await reader.read();
-    if (result.done) break;
-    totalSize += result.value.byteLength;
-    if (totalSize > maxBytes) {
-      reader.cancel();
-      throw new Error("Request body too large");
-    }
-    chunks.push(decoder.decode(result.value, { stream: true }));
-  }
-  chunks.push(decoder.decode());
-  return chunks.join("");
-}
-
-/**
- * Read a request body as FormData with a size limit.
- * Consumes the body stream with a byte counter and then parses the
- * collected bytes as multipart form data via the Response constructor.
- */
-async function __readFormDataWithLimit(request, maxBytes) {
-  if (!request.body) return new FormData();
-  var reader = request.body.getReader();
-  var chunks = [];
-  var totalSize = 0;
-  for (;;) {
-    var result = await reader.read();
-    if (result.done) break;
-    totalSize += result.value.byteLength;
-    if (totalSize > maxBytes) {
-      reader.cancel();
-      throw new Error("Request body too large");
-    }
-    chunks.push(result.value);
-  }
-  // Reconstruct a Response with the original Content-Type so that
-  // the FormData parser can handle multipart boundaries correctly.
-  var combined = new Uint8Array(totalSize);
-  var offset = 0;
-  for (var chunk of chunks) {
-    combined.set(chunk, offset);
-    offset += chunk.byteLength;
-  }
-  var contentType = request.headers.get("content-type") || "";
-  return new Response(combined, { headers: { "Content-Type": contentType } }).formData();
-}
 
 // Map from route pattern to generateStaticParams function.
 // Used by the prerender phase to enumerate dynamic route URLs without
@@ -7143,7 +6199,11 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         });
       },
       scheduleBackgroundRegeneration(key, renderFn) {
-        __triggerBackgroundRegeneration(key, renderFn, { routePath: route.pattern, routeType: "render" });
+        __triggerBackgroundRegeneration(key, renderFn, {
+          routerKind: "App Router",
+          routePath: route.pattern,
+          routeType: "render",
+        });
       },
     });
     if (__cachedPageResponse) {
@@ -7495,7 +6555,13 @@ import {
 import {
   handleProgressiveServerActionRequest as __handleProgressiveServerActionRequest,
   handleServerActionRscRequest as __handleServerActionRscRequest,
+  readActionBodyWithLimit as __readBodyWithLimit,
+  readActionFormDataWithLimit as __readFormDataWithLimit,
 } from "<ROOT>/packages/vinext/src/server/app-server-action-execution.js";
+import {
+  createRscOnErrorHandler as __createRscOnErrorHandler,
+  sanitizeErrorForClient as __sanitizeErrorForClient,
+} from "<ROOT>/packages/vinext/src/server/app-rsc-errors.js";
 import { readAppPageCacheResponse as __readAppPageCacheResponse } from "<ROOT>/packages/vinext/src/server/app-page-cache.js";
 import {
   buildAppPageFontLinkHeader as __buildAppPageFontLinkHeader,
@@ -7546,7 +6612,7 @@ import {
   createStaticGenerationHeadersContext as __createStaticGenerationHeadersContext,
 } from "<ROOT>/packages/vinext/src/server/app-static-generation.js";
 import { buildPageCacheTags } from "<ROOT>/packages/vinext/src/server/implicit-tags.js";
-import { _consumeRequestScopedCacheLife, getCacheHandler } from "next/cache";
+import { _consumeRequestScopedCacheLife } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
 import { setRootParams as __setRootParams, pickRootParams as __pickRootParams } from "<ROOT>/packages/vinext/src/shims/root-params.js";
 import { ensureFetchPatch as _ensureFetchPatch, getCollectedFetchTags, setCurrentFetchSoftTags } from "vinext/fetch-cache";
@@ -7557,6 +6623,15 @@ import {
 import {
   handleAppPrerenderEndpoint as __handleAppPrerenderEndpoint,
 } from "<ROOT>/packages/vinext/src/server/app-prerender-endpoints.js";
+import {
+  appIsrHtmlKey as __isrHtmlKey,
+  appIsrRscKey as __isrRscKey,
+  appIsrRouteKey as __isrRouteKey,
+  isrGet as __isrGet,
+  isrSet as __isrSet,
+  normalizeMountedSlotsHeader as __normalizeMountedSlotsHeader,
+  triggerBackgroundRegeneration as __triggerBackgroundRegeneration,
+} from "<ROOT>/packages/vinext/src/server/isr-cache.js";
 // Import server-only state module to register ALS-backed accessors.
 import "vinext/navigation-state";
 import { runWithRequestContext as _runWithUnifiedCtx, createRequestContext as _createUnifiedCtx } from "vinext/unified-request-context";
@@ -7598,25 +6673,6 @@ function __clearRequestContext() {
   // setNavigationContext(null) already clears root params internally
 }
 
-// ISR cache is disabled in dev mode — every request re-renders fresh,
-// matching Next.js dev behavior. Cache-Control headers are still emitted
-// based on export const revalidate for testing purposes.
-// Production ISR uses the MemoryCacheHandler (or configured KV handler).
-//
-// These helpers are inlined instead of imported from isr-cache.js because
-// the virtual RSC entry module runs in the RSC Vite environment which
-// cannot use dynamic imports at the module-evaluation level for server-only
-// modules, and direct imports must use the pre-computed absolute paths.
-async function __isrGet(key) {
-  const handler = getCacheHandler();
-  const result = await handler.get(key);
-  if (!result || !result.value) return null;
-  return { value: result, isStale: result.cacheState === "stale" };
-}
-async function __isrSet(key, data, revalidateSeconds, tags) {
-  const handler = getCacheHandler();
-  await handler.set(key, data, { revalidate: revalidateSeconds, tags: Array.isArray(tags) ? tags : [] });
-}
 // Note: cache entries are written with \`headers: undefined\`. Next.js stores
 // response headers (e.g. set-cookie from cookies().set() during render) in the
 // cache entry so they can be replayed on HIT. We don't do this because:
@@ -7627,82 +6683,6 @@ async function __isrSet(key, data, revalidateSeconds, tags) {
 // In practice this means ISR-cached responses won't replay render-time set-cookie
 // headers — but that case is already prevented by the dynamic-usage opt-out.
 // TODO: capture render-time response headers for full Next.js parity.
-const __pendingRegenerations = new Map();
-function __triggerBackgroundRegeneration(key, renderFn, errorContext) {
-  if (__pendingRegenerations.has(key)) return;
-  const promise = renderFn()
-    .catch((err) => {
-      console.error("[vinext] ISR regen failed for " + key + ":", err);
-      if (errorContext) {
-        void _reportRequestError(
-          err instanceof Error ? err : new Error(String(err)),
-          { path: key, method: "GET", headers: {} },
-          {
-            routerKind: "App Router",
-            routePath: errorContext.routePath,
-            routeType: errorContext.routeType,
-            revalidateReason: "stale",
-          },
-        );
-      }
-    })
-    .finally(() => __pendingRegenerations.delete(key));
-  __pendingRegenerations.set(key, promise);
-  const ctx = _getRequestExecutionContext();
-  if (ctx && typeof ctx.waitUntil === "function") ctx.waitUntil(promise);
-}
-// HTML and RSC are stored under separate keys — matching Next.js's file-system
-// layout (.html / .rsc) — so each request type reads and writes its own key
-// independently with no races or partial-entry sentinels.
-//
-// Key format: "app:<buildId>:<pathname>:<suffix>"
-// Long-pathname fallback: "app:<buildId>:__hash:<fnv1a64(pathname)>:<suffix>"
-// Without buildId (should not happen in production): "app:<pathname>:<suffix>"
-// The 200-char threshold keeps the full key well under Cloudflare KV's 512-byte limit
-// even after adding the build ID and suffix. FNV-1a 64 is used for the hash (two
-// 32-bit rounds) to give a ~64-bit output with negligible collision probability for
-// realistic pathname lengths.
-// Keep prefix construction and hashing logic in sync with isrCacheKey() in server/isr-cache.ts.
-function __isrFnv1a64(s) {
-  // h1 uses the standard FNV-1a 32-bit offset basis (0x811c9dc5).
-  let h1 = 0x811c9dc5;
-  for (let i = 0; i < s.length; i++) { h1 ^= s.charCodeAt(i); h1 = (h1 * 0x01000193) >>> 0; }
-  // h2 uses a different seed (0x050c5d1f — the FNV-1a hash of the string "vinext")
-  // so the two rounds are independently seeded and their outputs are decorrelated.
-  // Concatenating two independently-seeded 32-bit FNV-1a hashes gives an effective
-  // 64-bit hash. A random non-standard seed would also work; we derive it from a
-  // fixed string so the choice is auditable and deterministic across rebuilds.
-  let h2 = 0x050c5d1f;
-  for (let i = 0; i < s.length; i++) { h2 ^= s.charCodeAt(i); h2 = (h2 * 0x01000193) >>> 0; }
-  return h1.toString(36) + h2.toString(36);
-}
-function __isrCacheKey(pathname, suffix) {
-  const normalized = pathname === "/" ? "/" : pathname.replace(/\\/$/, "");
-  // __VINEXT_BUILD_ID is replaced at compile time by Vite's define plugin.
-  const buildId = process.env.__VINEXT_BUILD_ID;
-  const prefix = buildId ? "app:" + buildId : "app";
-  const key = prefix + ":" + normalized + ":" + suffix;
-  if (key.length <= 200) return key;
-  // Pathname too long — hash it to keep under KV's 512-byte key limit.
-  return prefix + ":__hash:" + __isrFnv1a64(normalized) + ":" + suffix;
-}
-function __isrHtmlKey(pathname) { return __isrCacheKey(pathname, "html"); }
-function __isrRscKey(pathname, mountedSlotsHeader) {
-  if (!mountedSlotsHeader) return __isrCacheKey(pathname, "rsc");
-  return __isrCacheKey(pathname, "rsc:" + __isrFnv1a64(mountedSlotsHeader));
-}
-function __normalizeMountedSlotsHeader(raw) {
-  if (!raw) return null;
-  const normalized = Array.from(
-    new Set(
-      raw
-        .split(/\\s+/)
-        .filter(Boolean),
-    ),
-  ).sort().join(" ");
-  return normalized || null;
-}
-function __isrRouteKey(pathname) { return __isrCacheKey(pathname, "route"); }
 // Verbose cache logging — opt in with NEXT_PRIVATE_DEBUG_CACHE=1.
 // Matches the env var Next.js uses for its own cache debug output so operators
 // have a single knob for all cache tracing.
@@ -7734,110 +6714,6 @@ function makeThenableParams(obj) {
   return Object.assign(Promise.resolve(plain), plain);
 }
 
-// djb2 hash — matches Next.js's stringHash for digest generation.
-// Produces a stable numeric string from error message + stack.
-function __errorDigest(str) {
-  let hash = 5381;
-  for (let i = str.length - 1; i >= 0; i--) {
-    hash = (hash * 33) ^ str.charCodeAt(i);
-  }
-  return (hash >>> 0).toString();
-}
-
-// Sanitize an error for client consumption. In production, replaces the error
-// with a generic Error that only carries a digest hash (matching Next.js
-// behavior). In development, returns the original error for debugging.
-// Navigation errors (redirect, notFound, etc.) are always passed through
-// unchanged since their digests are used for client-side routing.
-function __sanitizeErrorForClient(error) {
-  // Navigation errors must pass through with their digest intact
-  if (__resolveAppPageSpecialError(error)) {
-    return error;
-  }
-  // In development, pass through the original error for debugging
-  if (process.env.NODE_ENV !== "production") {
-    return error;
-  }
-  // In production, create a sanitized error with only a digest hash
-  const msg = error instanceof Error ? error.message : String(error);
-  const stack = error instanceof Error ? (error.stack || "") : "";
-  const sanitized = new Error(
-    "An error occurred in the Server Components render. " +
-    "The specific message is omitted in production builds to avoid leaking sensitive details. " +
-    "A digest property is included on this error instance which may provide additional details about the nature of the error."
-  );
-  sanitized.digest = __errorDigest(msg + stack);
-  return sanitized;
-}
-
-// onError callback for renderToReadableStream — preserves the digest for
-// Next.js navigation errors (redirect, notFound, forbidden, unauthorized)
-// thrown during RSC streaming (e.g. inside Suspense boundaries).
-// For non-navigation errors in production, generates a digest hash so the
-// error can be correlated with server logs without leaking details.
-function rscOnError(error, requestInfo, errorContext) {
-  if (error && typeof error === "object" && "digest" in error) {
-    return String(error.digest);
-  }
-
-  // In dev, detect the "Only plain objects" RSC serialization error and emit
-  // an actionable hint. This error occurs when a Server Component passes a
-  // class instance, ES module namespace object, or null-prototype object as a
-  // prop to a Client Component.
-  //
-  // Root cause: Vite bundles modules as true ESM (module namespace objects
-  // have a null-like internal slot), while Next.js's webpack build produces
-  // plain CJS-wrapped objects with __esModule:true. React's RSC serializer
-  // accepts the latter as plain objects but rejects the former — which means
-  // code that accidentally passes "import * as X" works in webpack/Next.js
-  // but correctly fails in vinext.
-  //
-  // Common triggers:
-  //   - "import * as utils from './utils'" passed as a prop
-  //   - class instances (new Foo()) passed as props
-  //   - Date / Map / Set instances passed as props
-  //   - Objects with Object.create(null) (null prototype)
-  if (
-    process.env.NODE_ENV !== "production" &&
-    error instanceof Error &&
-    error.message.includes("Only plain objects, and a few built-ins, can be passed to Client Components")
-  ) {
-    console.error(
-      "[vinext] RSC serialization error: a non-plain object was passed from a Server Component to a Client Component.\\n" +
-      "\\n" +
-      "Common causes:\\n" +
-      "  * Passing a module namespace (import * as X) directly as a prop.\\n" +
-      "    Unlike Next.js (webpack), Vite produces real ESM module namespace objects\\n" +
-      "    which are not serializable. Fix: pass individual values instead,\\n" +
-      "    e.g. <Comp value={module.value} />\\n" +
-      "  * Passing a class instance (new Foo()) as a prop.\\n" +
-      "    Fix: convert to a plain object, e.g. { id: foo.id, name: foo.name }\\n" +
-      "  * Passing a Date, Map, or Set. Use .toISOString(), [...map.entries()], etc.\\n" +
-      "  * Passing Object.create(null). Use { ...obj } to restore a prototype.\\n" +
-      "\\n" +
-      "Original error:",
-      error.message,
-    );
-    return undefined;
-  }
-
-  if (requestInfo && errorContext && error) {
-    _reportRequestError(
-      error instanceof Error ? error : new Error(String(error)),
-      requestInfo,
-      errorContext,
-    );
-  }
-
-  // In production, generate a digest hash for non-navigation errors
-  if (process.env.NODE_ENV === "production" && error) {
-    const msg = error instanceof Error ? error.message : String(error);
-    const stack = error instanceof Error ? (error.stack || "") : "";
-    return __errorDigest(msg + stack);
-  }
-  return undefined;
-}
-
 function createRscOnErrorHandler(request, pathname, routePath) {
   const requestInfo = {
     path: pathname,
@@ -7849,9 +6725,11 @@ function createRscOnErrorHandler(request, pathname, routePath) {
     routePath: routePath || pathname,
     routeType: "render",
   };
-  return function(error) {
-    return rscOnError(error, requestInfo, errorContext);
-  };
+  return __createRscOnErrorHandler({
+    errorContext,
+    reportRequestError: _reportRequestError,
+    requestInfo,
+  });
 }
 
 import * as mod_0 from "/tmp/test/app/page.tsx";
@@ -8331,63 +7209,6 @@ function __buildPostMwRequestContext(request) {
  * Prevents unbounded request body buffering.
  */
 var __MAX_ACTION_BODY_SIZE = 1048576;
-
-/**
- * Read a request body as text with a size limit.
- * Enforces the limit on the actual byte stream to prevent bypasses
- * via chunked transfer-encoding where Content-Length is absent or spoofed.
- */
-async function __readBodyWithLimit(request, maxBytes) {
-  if (!request.body) return "";
-  var reader = request.body.getReader();
-  var decoder = new TextDecoder();
-  var chunks = [];
-  var totalSize = 0;
-  for (;;) {
-    var result = await reader.read();
-    if (result.done) break;
-    totalSize += result.value.byteLength;
-    if (totalSize > maxBytes) {
-      reader.cancel();
-      throw new Error("Request body too large");
-    }
-    chunks.push(decoder.decode(result.value, { stream: true }));
-  }
-  chunks.push(decoder.decode());
-  return chunks.join("");
-}
-
-/**
- * Read a request body as FormData with a size limit.
- * Consumes the body stream with a byte counter and then parses the
- * collected bytes as multipart form data via the Response constructor.
- */
-async function __readFormDataWithLimit(request, maxBytes) {
-  if (!request.body) return new FormData();
-  var reader = request.body.getReader();
-  var chunks = [];
-  var totalSize = 0;
-  for (;;) {
-    var result = await reader.read();
-    if (result.done) break;
-    totalSize += result.value.byteLength;
-    if (totalSize > maxBytes) {
-      reader.cancel();
-      throw new Error("Request body too large");
-    }
-    chunks.push(result.value);
-  }
-  // Reconstruct a Response with the original Content-Type so that
-  // the FormData parser can handle multipart boundaries correctly.
-  var combined = new Uint8Array(totalSize);
-  var offset = 0;
-  for (var chunk of chunks) {
-    combined.set(chunk, offset);
-    offset += chunk.byteLength;
-  }
-  var contentType = request.headers.get("content-type") || "";
-  return new Response(combined, { headers: { "Content-Type": contentType } }).formData();
-}
 
 // Map from route pattern to generateStaticParams function.
 // Used by the prerender phase to enumerate dynamic route URLs without
@@ -9004,7 +7825,11 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         });
       },
       scheduleBackgroundRegeneration(key, renderFn) {
-        __triggerBackgroundRegeneration(key, renderFn, { routePath: route.pattern, routeType: "render" });
+        __triggerBackgroundRegeneration(key, renderFn, {
+          routerKind: "App Router",
+          routePath: route.pattern,
+          routeType: "render",
+        });
       },
     });
     if (__cachedPageResponse) {
@@ -9356,7 +8181,13 @@ import {
 import {
   handleProgressiveServerActionRequest as __handleProgressiveServerActionRequest,
   handleServerActionRscRequest as __handleServerActionRscRequest,
+  readActionBodyWithLimit as __readBodyWithLimit,
+  readActionFormDataWithLimit as __readFormDataWithLimit,
 } from "<ROOT>/packages/vinext/src/server/app-server-action-execution.js";
+import {
+  createRscOnErrorHandler as __createRscOnErrorHandler,
+  sanitizeErrorForClient as __sanitizeErrorForClient,
+} from "<ROOT>/packages/vinext/src/server/app-rsc-errors.js";
 import { readAppPageCacheResponse as __readAppPageCacheResponse } from "<ROOT>/packages/vinext/src/server/app-page-cache.js";
 import {
   buildAppPageFontLinkHeader as __buildAppPageFontLinkHeader,
@@ -9407,7 +8238,7 @@ import {
   createStaticGenerationHeadersContext as __createStaticGenerationHeadersContext,
 } from "<ROOT>/packages/vinext/src/server/app-static-generation.js";
 import { buildPageCacheTags } from "<ROOT>/packages/vinext/src/server/implicit-tags.js";
-import { _consumeRequestScopedCacheLife, getCacheHandler } from "next/cache";
+import { _consumeRequestScopedCacheLife } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
 import { setRootParams as __setRootParams, pickRootParams as __pickRootParams } from "<ROOT>/packages/vinext/src/shims/root-params.js";
 import { ensureFetchPatch as _ensureFetchPatch, getCollectedFetchTags, setCurrentFetchSoftTags } from "vinext/fetch-cache";
@@ -9418,6 +8249,15 @@ import {
 import {
   handleAppPrerenderEndpoint as __handleAppPrerenderEndpoint,
 } from "<ROOT>/packages/vinext/src/server/app-prerender-endpoints.js";
+import {
+  appIsrHtmlKey as __isrHtmlKey,
+  appIsrRscKey as __isrRscKey,
+  appIsrRouteKey as __isrRouteKey,
+  isrGet as __isrGet,
+  isrSet as __isrSet,
+  normalizeMountedSlotsHeader as __normalizeMountedSlotsHeader,
+  triggerBackgroundRegeneration as __triggerBackgroundRegeneration,
+} from "<ROOT>/packages/vinext/src/server/isr-cache.js";
 // Import server-only state module to register ALS-backed accessors.
 import "vinext/navigation-state";
 import { runWithRequestContext as _runWithUnifiedCtx, createRequestContext as _createUnifiedCtx } from "vinext/unified-request-context";
@@ -9459,25 +8299,6 @@ function __clearRequestContext() {
   // setNavigationContext(null) already clears root params internally
 }
 
-// ISR cache is disabled in dev mode — every request re-renders fresh,
-// matching Next.js dev behavior. Cache-Control headers are still emitted
-// based on export const revalidate for testing purposes.
-// Production ISR uses the MemoryCacheHandler (or configured KV handler).
-//
-// These helpers are inlined instead of imported from isr-cache.js because
-// the virtual RSC entry module runs in the RSC Vite environment which
-// cannot use dynamic imports at the module-evaluation level for server-only
-// modules, and direct imports must use the pre-computed absolute paths.
-async function __isrGet(key) {
-  const handler = getCacheHandler();
-  const result = await handler.get(key);
-  if (!result || !result.value) return null;
-  return { value: result, isStale: result.cacheState === "stale" };
-}
-async function __isrSet(key, data, revalidateSeconds, tags) {
-  const handler = getCacheHandler();
-  await handler.set(key, data, { revalidate: revalidateSeconds, tags: Array.isArray(tags) ? tags : [] });
-}
 // Note: cache entries are written with \`headers: undefined\`. Next.js stores
 // response headers (e.g. set-cookie from cookies().set() during render) in the
 // cache entry so they can be replayed on HIT. We don't do this because:
@@ -9488,82 +8309,6 @@ async function __isrSet(key, data, revalidateSeconds, tags) {
 // In practice this means ISR-cached responses won't replay render-time set-cookie
 // headers — but that case is already prevented by the dynamic-usage opt-out.
 // TODO: capture render-time response headers for full Next.js parity.
-const __pendingRegenerations = new Map();
-function __triggerBackgroundRegeneration(key, renderFn, errorContext) {
-  if (__pendingRegenerations.has(key)) return;
-  const promise = renderFn()
-    .catch((err) => {
-      console.error("[vinext] ISR regen failed for " + key + ":", err);
-      if (errorContext) {
-        void _reportRequestError(
-          err instanceof Error ? err : new Error(String(err)),
-          { path: key, method: "GET", headers: {} },
-          {
-            routerKind: "App Router",
-            routePath: errorContext.routePath,
-            routeType: errorContext.routeType,
-            revalidateReason: "stale",
-          },
-        );
-      }
-    })
-    .finally(() => __pendingRegenerations.delete(key));
-  __pendingRegenerations.set(key, promise);
-  const ctx = _getRequestExecutionContext();
-  if (ctx && typeof ctx.waitUntil === "function") ctx.waitUntil(promise);
-}
-// HTML and RSC are stored under separate keys — matching Next.js's file-system
-// layout (.html / .rsc) — so each request type reads and writes its own key
-// independently with no races or partial-entry sentinels.
-//
-// Key format: "app:<buildId>:<pathname>:<suffix>"
-// Long-pathname fallback: "app:<buildId>:__hash:<fnv1a64(pathname)>:<suffix>"
-// Without buildId (should not happen in production): "app:<pathname>:<suffix>"
-// The 200-char threshold keeps the full key well under Cloudflare KV's 512-byte limit
-// even after adding the build ID and suffix. FNV-1a 64 is used for the hash (two
-// 32-bit rounds) to give a ~64-bit output with negligible collision probability for
-// realistic pathname lengths.
-// Keep prefix construction and hashing logic in sync with isrCacheKey() in server/isr-cache.ts.
-function __isrFnv1a64(s) {
-  // h1 uses the standard FNV-1a 32-bit offset basis (0x811c9dc5).
-  let h1 = 0x811c9dc5;
-  for (let i = 0; i < s.length; i++) { h1 ^= s.charCodeAt(i); h1 = (h1 * 0x01000193) >>> 0; }
-  // h2 uses a different seed (0x050c5d1f — the FNV-1a hash of the string "vinext")
-  // so the two rounds are independently seeded and their outputs are decorrelated.
-  // Concatenating two independently-seeded 32-bit FNV-1a hashes gives an effective
-  // 64-bit hash. A random non-standard seed would also work; we derive it from a
-  // fixed string so the choice is auditable and deterministic across rebuilds.
-  let h2 = 0x050c5d1f;
-  for (let i = 0; i < s.length; i++) { h2 ^= s.charCodeAt(i); h2 = (h2 * 0x01000193) >>> 0; }
-  return h1.toString(36) + h2.toString(36);
-}
-function __isrCacheKey(pathname, suffix) {
-  const normalized = pathname === "/" ? "/" : pathname.replace(/\\/$/, "");
-  // __VINEXT_BUILD_ID is replaced at compile time by Vite's define plugin.
-  const buildId = process.env.__VINEXT_BUILD_ID;
-  const prefix = buildId ? "app:" + buildId : "app";
-  const key = prefix + ":" + normalized + ":" + suffix;
-  if (key.length <= 200) return key;
-  // Pathname too long — hash it to keep under KV's 512-byte key limit.
-  return prefix + ":__hash:" + __isrFnv1a64(normalized) + ":" + suffix;
-}
-function __isrHtmlKey(pathname) { return __isrCacheKey(pathname, "html"); }
-function __isrRscKey(pathname, mountedSlotsHeader) {
-  if (!mountedSlotsHeader) return __isrCacheKey(pathname, "rsc");
-  return __isrCacheKey(pathname, "rsc:" + __isrFnv1a64(mountedSlotsHeader));
-}
-function __normalizeMountedSlotsHeader(raw) {
-  if (!raw) return null;
-  const normalized = Array.from(
-    new Set(
-      raw
-        .split(/\\s+/)
-        .filter(Boolean),
-    ),
-  ).sort().join(" ");
-  return normalized || null;
-}
-function __isrRouteKey(pathname) { return __isrCacheKey(pathname, "route"); }
 // Verbose cache logging — opt in with NEXT_PRIVATE_DEBUG_CACHE=1.
 // Matches the env var Next.js uses for its own cache debug output so operators
 // have a single knob for all cache tracing.
@@ -9595,110 +8340,6 @@ function makeThenableParams(obj) {
   return Object.assign(Promise.resolve(plain), plain);
 }
 
-// djb2 hash — matches Next.js's stringHash for digest generation.
-// Produces a stable numeric string from error message + stack.
-function __errorDigest(str) {
-  let hash = 5381;
-  for (let i = str.length - 1; i >= 0; i--) {
-    hash = (hash * 33) ^ str.charCodeAt(i);
-  }
-  return (hash >>> 0).toString();
-}
-
-// Sanitize an error for client consumption. In production, replaces the error
-// with a generic Error that only carries a digest hash (matching Next.js
-// behavior). In development, returns the original error for debugging.
-// Navigation errors (redirect, notFound, etc.) are always passed through
-// unchanged since their digests are used for client-side routing.
-function __sanitizeErrorForClient(error) {
-  // Navigation errors must pass through with their digest intact
-  if (__resolveAppPageSpecialError(error)) {
-    return error;
-  }
-  // In development, pass through the original error for debugging
-  if (process.env.NODE_ENV !== "production") {
-    return error;
-  }
-  // In production, create a sanitized error with only a digest hash
-  const msg = error instanceof Error ? error.message : String(error);
-  const stack = error instanceof Error ? (error.stack || "") : "";
-  const sanitized = new Error(
-    "An error occurred in the Server Components render. " +
-    "The specific message is omitted in production builds to avoid leaking sensitive details. " +
-    "A digest property is included on this error instance which may provide additional details about the nature of the error."
-  );
-  sanitized.digest = __errorDigest(msg + stack);
-  return sanitized;
-}
-
-// onError callback for renderToReadableStream — preserves the digest for
-// Next.js navigation errors (redirect, notFound, forbidden, unauthorized)
-// thrown during RSC streaming (e.g. inside Suspense boundaries).
-// For non-navigation errors in production, generates a digest hash so the
-// error can be correlated with server logs without leaking details.
-function rscOnError(error, requestInfo, errorContext) {
-  if (error && typeof error === "object" && "digest" in error) {
-    return String(error.digest);
-  }
-
-  // In dev, detect the "Only plain objects" RSC serialization error and emit
-  // an actionable hint. This error occurs when a Server Component passes a
-  // class instance, ES module namespace object, or null-prototype object as a
-  // prop to a Client Component.
-  //
-  // Root cause: Vite bundles modules as true ESM (module namespace objects
-  // have a null-like internal slot), while Next.js's webpack build produces
-  // plain CJS-wrapped objects with __esModule:true. React's RSC serializer
-  // accepts the latter as plain objects but rejects the former — which means
-  // code that accidentally passes "import * as X" works in webpack/Next.js
-  // but correctly fails in vinext.
-  //
-  // Common triggers:
-  //   - "import * as utils from './utils'" passed as a prop
-  //   - class instances (new Foo()) passed as props
-  //   - Date / Map / Set instances passed as props
-  //   - Objects with Object.create(null) (null prototype)
-  if (
-    process.env.NODE_ENV !== "production" &&
-    error instanceof Error &&
-    error.message.includes("Only plain objects, and a few built-ins, can be passed to Client Components")
-  ) {
-    console.error(
-      "[vinext] RSC serialization error: a non-plain object was passed from a Server Component to a Client Component.\\n" +
-      "\\n" +
-      "Common causes:\\n" +
-      "  * Passing a module namespace (import * as X) directly as a prop.\\n" +
-      "    Unlike Next.js (webpack), Vite produces real ESM module namespace objects\\n" +
-      "    which are not serializable. Fix: pass individual values instead,\\n" +
-      "    e.g. <Comp value={module.value} />\\n" +
-      "  * Passing a class instance (new Foo()) as a prop.\\n" +
-      "    Fix: convert to a plain object, e.g. { id: foo.id, name: foo.name }\\n" +
-      "  * Passing a Date, Map, or Set. Use .toISOString(), [...map.entries()], etc.\\n" +
-      "  * Passing Object.create(null). Use { ...obj } to restore a prototype.\\n" +
-      "\\n" +
-      "Original error:",
-      error.message,
-    );
-    return undefined;
-  }
-
-  if (requestInfo && errorContext && error) {
-    _reportRequestError(
-      error instanceof Error ? error : new Error(String(error)),
-      requestInfo,
-      errorContext,
-    );
-  }
-
-  // In production, generate a digest hash for non-navigation errors
-  if (process.env.NODE_ENV === "production" && error) {
-    const msg = error instanceof Error ? error.message : String(error);
-    const stack = error instanceof Error ? (error.stack || "") : "";
-    return __errorDigest(msg + stack);
-  }
-  return undefined;
-}
-
 function createRscOnErrorHandler(request, pathname, routePath) {
   const requestInfo = {
     path: pathname,
@@ -9710,9 +8351,11 @@ function createRscOnErrorHandler(request, pathname, routePath) {
     routePath: routePath || pathname,
     routeType: "render",
   };
-  return function(error) {
-    return rscOnError(error, requestInfo, errorContext);
-  };
+  return __createRscOnErrorHandler({
+    errorContext,
+    reportRequestError: _reportRequestError,
+    requestInfo,
+  });
 }
 
 import * as mod_0 from "/tmp/test/app/page.tsx";
@@ -10185,63 +8828,6 @@ function __buildPostMwRequestContext(request) {
  * Prevents unbounded request body buffering.
  */
 var __MAX_ACTION_BODY_SIZE = 1048576;
-
-/**
- * Read a request body as text with a size limit.
- * Enforces the limit on the actual byte stream to prevent bypasses
- * via chunked transfer-encoding where Content-Length is absent or spoofed.
- */
-async function __readBodyWithLimit(request, maxBytes) {
-  if (!request.body) return "";
-  var reader = request.body.getReader();
-  var decoder = new TextDecoder();
-  var chunks = [];
-  var totalSize = 0;
-  for (;;) {
-    var result = await reader.read();
-    if (result.done) break;
-    totalSize += result.value.byteLength;
-    if (totalSize > maxBytes) {
-      reader.cancel();
-      throw new Error("Request body too large");
-    }
-    chunks.push(decoder.decode(result.value, { stream: true }));
-  }
-  chunks.push(decoder.decode());
-  return chunks.join("");
-}
-
-/**
- * Read a request body as FormData with a size limit.
- * Consumes the body stream with a byte counter and then parses the
- * collected bytes as multipart form data via the Response constructor.
- */
-async function __readFormDataWithLimit(request, maxBytes) {
-  if (!request.body) return new FormData();
-  var reader = request.body.getReader();
-  var chunks = [];
-  var totalSize = 0;
-  for (;;) {
-    var result = await reader.read();
-    if (result.done) break;
-    totalSize += result.value.byteLength;
-    if (totalSize > maxBytes) {
-      reader.cancel();
-      throw new Error("Request body too large");
-    }
-    chunks.push(result.value);
-  }
-  // Reconstruct a Response with the original Content-Type so that
-  // the FormData parser can handle multipart boundaries correctly.
-  var combined = new Uint8Array(totalSize);
-  var offset = 0;
-  for (var chunk of chunks) {
-    combined.set(chunk, offset);
-    offset += chunk.byteLength;
-  }
-  var contentType = request.headers.get("content-type") || "";
-  return new Response(combined, { headers: { "Content-Type": contentType } }).formData();
-}
 
 // Map from route pattern to generateStaticParams function.
 // Used by the prerender phase to enumerate dynamic route URLs without
@@ -10873,7 +9459,11 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         });
       },
       scheduleBackgroundRegeneration(key, renderFn) {
-        __triggerBackgroundRegeneration(key, renderFn, { routePath: route.pattern, routeType: "render" });
+        __triggerBackgroundRegeneration(key, renderFn, {
+          routerKind: "App Router",
+          routePath: route.pattern,
+          routeType: "render",
+        });
       },
     });
     if (__cachedPageResponse) {

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -3657,130 +3657,23 @@ describe("App Router next.config.js features (generateRscEntry)", () => {
     }
   });
 
-  describe("rscOnError: non-plain object dev hint", () => {
-    it("includes detection for the 'Only plain objects' RSC serialization error", () => {
+  describe("RSC error runtime delegation", () => {
+    it("imports RSC error helpers from a normal server module", () => {
       const code = generateRscEntry("/tmp/test/app", minimalRoutes, null, [], null, "", false);
-      expect(code).toContain(
-        "Only plain objects, and a few built-ins, can be passed to Client Components",
-      );
+
+      expect(code).toContain("createRscOnErrorHandler as __createRscOnErrorHandler");
+      expect(code).toContain("sanitizeErrorForClient as __sanitizeErrorForClient");
+      expect(code).toContain("server/app-rsc-errors.js");
     });
 
-    it("guards the dev hint behind a NODE_ENV !== production check", () => {
+    it("keeps request-specific onError wiring in the generated entry", () => {
       const code = generateRscEntry("/tmp/test/app", minimalRoutes, null, [], null, "", false);
-      // The hint must be suppressed in production builds
-      expect(code).toContain('process.env.NODE_ENV !== "production"');
-    });
 
-    it("includes actionable guidance about module namespace objects in the hint", () => {
-      const code = generateRscEntry("/tmp/test/app", minimalRoutes, null, [], null, "", false);
-      expect(code).toContain("import * as X");
-      expect(code).toContain("[vinext] RSC serialization error");
-    });
-
-    it("includes actionable guidance about class instances in the hint", () => {
-      const code = generateRscEntry("/tmp/test/app", minimalRoutes, null, [], null, "", false);
-      expect(code).toContain("class instance");
-    });
-
-    it("does not affect the digest return path for navigation errors", () => {
-      const code = generateRscEntry("/tmp/test/app", minimalRoutes, null, [], null, "", false);
-      // The existing digest path (redirect/notFound) must still be present
-      expect(code).toContain('"digest" in error');
-      expect(code).toContain("String(error.digest)");
-    });
-
-    // Runtime tests: extract the rscOnError function from the generated code
-    // and evaluate it. This catches syntax errors and logic bugs that the
-    // string-presence tests above would miss (e.g. unterminated strings,
-    // wrong return values, broken control flow).
-    describe("runtime behavior", () => {
-      let rscOnError: (error: unknown) => string | undefined;
-      let prodRscOnError: (error: unknown) => string | undefined;
-      let digestFn: string;
-      let onErrorFn: string;
-
-      beforeAll(() => {
-        const code = generateRscEntry("/tmp/test/app", minimalRoutes, null, [], null, "", false);
-
-        // Extract a top-level function from the generated code by matching
-        // balanced braces (simple regex can't handle nested braces).
-        function extractFunction(src: string, name: string): string {
-          const marker = `function ${name}(`;
-          const start = src.indexOf(marker);
-          if (start === -1) throw new Error(`Could not find ${name} in generated code`);
-          const braceStart = src.indexOf("{", start);
-          let depth = 0;
-          for (let i = braceStart; i < src.length; i++) {
-            if (src[i] === "{") depth++;
-            else if (src[i] === "}") depth--;
-            if (depth === 0) return src.slice(start, i + 1);
-          }
-          throw new Error(`Unbalanced braces in ${name}`);
-        }
-
-        digestFn = extractFunction(code, "__errorDigest");
-        onErrorFn = extractFunction(code, "rscOnError");
-
-        const body = `${digestFn}\n${onErrorFn}\nreturn rscOnError;`;
-        // oxlint-disable-next-line no-new-func, @typescript-eslint/no-implied-eval -- reconstructing emitted runtime code is the behavior under test
-        const factory = new Function("process", body);
-        rscOnError = factory({ env: { NODE_ENV: "development" } });
-        prodRscOnError = factory({ env: { NODE_ENV: "production" } });
-      });
-
-      it("returns the digest string for navigation errors (redirect/notFound)", () => {
-        const error = Object.assign(new Error("NEXT_REDIRECT"), {
-          digest: "NEXT_REDIRECT;push;/dashboard;307",
-        });
-        expect(rscOnError(error)).toBe("NEXT_REDIRECT;push;/dashboard;307");
-      });
-
-      it("logs an actionable hint and returns undefined for RSC serialization errors", () => {
-        const spy = vi.spyOn(console, "error").mockImplementation(() => {});
-        try {
-          const error = new Error(
-            "Only plain objects, and a few built-ins, can be passed to Client Components from Server Components. " +
-              "Objects with toJSON methods are not supported. Module namespace objects are not supported.",
-          );
-          const result = rscOnError(error);
-          expect(result).toBeUndefined();
-          expect(spy).toHaveBeenCalledOnce();
-          expect(spy.mock.calls[0]![0]).toContain("[vinext] RSC serialization error");
-        } finally {
-          spy.mockRestore();
-        }
-      });
-
-      it("returns undefined for generic errors in dev (no digest, no serialization match)", () => {
-        const spy = vi.spyOn(console, "error").mockImplementation(() => {});
-        try {
-          const result = rscOnError(new Error("something went wrong"));
-          expect(result).toBeUndefined();
-          // Should NOT log the hint for unrelated errors
-          expect(spy).not.toHaveBeenCalled();
-        } finally {
-          spy.mockRestore();
-        }
-      });
-
-      it("does not swallow strings thrown in Server Components", () => {
-        const result = prodRscOnError("this is a test string");
-        // Should return a digest hash (not undefined), indicating the string
-        // was processed through the normal error path
-        expect(result).toBeDefined();
-        expect(typeof result).toBe("string");
-        expect((result as string).length).toBeGreaterThan(0);
-        // The digest should be based on the string content
-        const result2 = prodRscOnError("different string");
-        expect(result2).not.toBe(result);
-      });
-
-      it("does not have an early return for string thrown values in generated code", () => {
-        // Next.js had a bug where typeof thrownValue === 'string' returned
-        // early, swallowing the error before logging. Verify the generated
-        // rscOnError has no such early-return path.
-        expect(onErrorFn).not.toContain("typeof thrownValue === 'string'");
-      });
+      expect(code).toContain("return __createRscOnErrorHandler({");
+      expect(code).toContain("reportRequestError: _reportRequestError");
+      expect(code).toContain("requestInfo,");
+      expect(code).not.toContain("function rscOnError(");
+      expect(code).not.toContain("function __errorDigest(");
     });
   });
 
@@ -4446,13 +4339,16 @@ describe("generateRscEntry ISR code generation", () => {
     expect(code).toContain('process.env.NODE_ENV === "production"');
   });
 
-  it("generated code contains ISR inline helper functions", () => {
+  it("generated code delegates ISR cache primitives to the typed cache module", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes);
-    expect(code).toContain("async function __isrGet(");
-    expect(code).toContain("async function __isrSet(");
-    expect(code).toContain("function __triggerBackgroundRegeneration(");
-    expect(code).toContain("function __isrCacheKey(");
-    expect(code).toContain("const __pendingRegenerations = new Map()");
+    expect(code).toContain("isrGet as __isrGet");
+    expect(code).toContain("isrSet as __isrSet");
+    expect(code).toContain("triggerBackgroundRegeneration as __triggerBackgroundRegeneration");
+    expect(code).toContain("appIsrHtmlKey as __isrHtmlKey");
+    expect(code).toContain("normalizeMountedSlotsHeader as __normalizeMountedSlotsHeader");
+    expect(code).not.toContain("async function __isrGet(");
+    expect(code).not.toContain("function __isrCacheKey(");
+    expect(code).not.toContain("const __pendingRegenerations = new Map()");
   });
 
   it("generated code threads collected fetch tags into page ISR writes and delegates route ISR", () => {
@@ -4468,7 +4364,7 @@ describe("generateRscEntry ISR code generation", () => {
     expect(code).toContain(
       'const __pageTags = buildPageCacheTags(cleanPathname, getCollectedFetchTags(), route.routeSegments, "page")',
     );
-    expect(code).toContain("Array.isArray(tags) ? tags : []");
+    expect(code).toContain("isrSet: __isrSet");
   });
 
   it("generated handler exports async function handler(request, ctx)", () => {
@@ -4477,9 +4373,9 @@ describe("generateRscEntry ISR code generation", () => {
     expect(code).toMatch(/export default async function handler\s*\(\s*request\s*,\s*ctx\s*\)/);
   });
 
-  it("generated code imports getCacheHandler from next/cache", () => {
+  it("generated code leaves cache handler access to the ISR cache module", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes);
-    expect(code).toContain("getCacheHandler");
+    expect(code).not.toContain("getCacheHandler");
     expect(code).toContain('"next/cache"');
   });
 
@@ -4671,6 +4567,8 @@ describe("generateRscEntry ISR code generation", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes);
     expect(code).toContain("readAppPageCacheResponse as __readAppPageCacheResponse");
     expect(code).toContain("scheduleBackgroundRegeneration(key, renderFn) {");
+    expect(code).toContain('routerKind: "App Router"');
+    expect(code).toContain('routeType: "render"');
     expect(code).toContain("renderFreshPageForCache: async function()");
   });
 

--- a/tests/app-rsc-errors.test.ts
+++ b/tests/app-rsc-errors.test.ts
@@ -5,6 +5,15 @@ import {
   sanitizeErrorForClient,
 } from "../packages/vinext/src/server/app-rsc-errors.js";
 
+type DigestCarrier = Error & { digest: unknown };
+
+function expectDigestError(value: unknown): DigestCarrier {
+  if (!(value instanceof Error) || !("digest" in value)) {
+    throw new Error("expected production sanitization to return a digest error");
+  }
+  return value;
+}
+
 describe("app RSC error primitives", () => {
   it("uses the same stable digest hash shape as Next.js stringHash", () => {
     expect(errorDigest("message-stack")).toBe("701844781");
@@ -29,10 +38,20 @@ describe("app RSC error primitives", () => {
     error.stack = "stack";
 
     const sanitized = sanitizeErrorForClient(error, "production");
+    const digestError = expectDigestError(sanitized);
 
     expect(sanitized).not.toBe(error);
-    expect(sanitized.message).toContain("omitted in production");
-    expect(sanitized.digest).toBe(errorDigest("secret detailsstack"));
+    expect(digestError.message).toContain("omitted in production");
+    expect(digestError.digest).toBe(errorDigest("secret detailsstack"));
+  });
+
+  it("preserves the previous String(error) digest input for non-Error values", () => {
+    const thrownValue = { message: "object detail" };
+
+    const sanitized = sanitizeErrorForClient(thrownValue, "production");
+
+    expect(sanitized).toBeInstanceOf(Error);
+    expect(expectDigestError(sanitized).digest).toBe(errorDigest("[object Object]"));
   });
 
   it("returns existing digest strings from the RSC onError path", () => {
@@ -73,6 +92,24 @@ describe("app RSC error primitives", () => {
         routeType: "render",
       },
     );
+  });
+
+  it("reports non-Error thrown values with the previous String(error) message", () => {
+    const reportRequestError = vi.fn();
+    const onError = createRscOnErrorHandler({
+      errorContext: { routerKind: "App Router", routePath: "/feed", routeType: "render" },
+      nodeEnv: "production",
+      reportRequestError,
+      requestInfo: { path: "/feed", method: "GET", headers: {} },
+    });
+
+    const thrownValue = { message: "object detail" };
+
+    expect(onError(thrownValue)).toBe(errorDigest("[object Object]"));
+    expect(reportRequestError).toHaveBeenCalledOnce();
+    expect(reportRequestError.mock.calls[0]?.[0]).toMatchObject({
+      message: "[object Object]",
+    });
   });
 
   it("uses process.env.NODE_ENV when no explicit environment is provided", () => {

--- a/tests/app-rsc-errors.test.ts
+++ b/tests/app-rsc-errors.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+import {
+  createRscOnErrorHandler,
+  errorDigest,
+  sanitizeErrorForClient,
+} from "../packages/vinext/src/server/app-rsc-errors.js";
+
+describe("app RSC error primitives", () => {
+  it("uses the same stable digest hash shape as Next.js stringHash", () => {
+    expect(errorDigest("message-stack")).toBe("701844781");
+  });
+
+  it("passes through navigation digest errors during sanitization", () => {
+    const redirectError = Object.assign(new Error("redirect"), {
+      digest: "NEXT_REDIRECT;push;%2Fdashboard;307",
+    });
+
+    expect(sanitizeErrorForClient(redirectError, "production")).toBe(redirectError);
+  });
+
+  it("returns the original error outside production", () => {
+    const error = new Error("debuggable");
+
+    expect(sanitizeErrorForClient(error, "development")).toBe(error);
+  });
+
+  it("replaces generic production errors with a digest-only error", () => {
+    const error = new Error("secret details");
+    error.stack = "stack";
+
+    const sanitized = sanitizeErrorForClient(error, "production");
+
+    expect(sanitized).not.toBe(error);
+    expect(sanitized.message).toContain("omitted in production");
+    expect(sanitized.digest).toBe(errorDigest("secret detailsstack"));
+  });
+
+  it("returns existing digest strings from the RSC onError path", () => {
+    const onError = createRscOnErrorHandler({
+      errorContext: null,
+      nodeEnv: "production",
+      reportRequestError() {},
+      requestInfo: null,
+    });
+
+    expect(onError({ digest: "NEXT_NOT_FOUND" })).toBe("NEXT_NOT_FOUND");
+  });
+
+  it("reports generic RSC render errors before returning a production digest", () => {
+    const reportRequestError = vi.fn();
+    const onError = createRscOnErrorHandler({
+      errorContext: { routerKind: "App Router", routePath: "/feed", routeType: "render" },
+      nodeEnv: "production",
+      reportRequestError,
+      requestInfo: { path: "/feed", method: "GET", headers: {} },
+    });
+
+    const error = new Error("render failed");
+    error.stack = "stack";
+
+    expect(onError(error)).toBe(errorDigest("render failedstack"));
+    expect(reportRequestError).toHaveBeenCalledOnce();
+    expect(reportRequestError).toHaveBeenCalledWith(
+      error,
+      {
+        path: "/feed",
+        method: "GET",
+        headers: {},
+      },
+      {
+        routerKind: "App Router",
+        routePath: "/feed",
+        routeType: "render",
+      },
+    );
+  });
+
+  it("uses process.env.NODE_ENV when no explicit environment is provided", () => {
+    const previousNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+
+    try {
+      const onError = createRscOnErrorHandler({
+        errorContext: null,
+        reportRequestError() {},
+        requestInfo: null,
+      });
+      const error = new Error("from env");
+      error.stack = "";
+
+      expect(onError(error)).toBe(errorDigest("from env"));
+    } finally {
+      process.env.NODE_ENV = previousNodeEnv;
+    }
+  });
+});

--- a/tests/app-server-action-execution.test.ts
+++ b/tests/app-server-action-execution.test.ts
@@ -4,6 +4,8 @@ import {
   handleProgressiveServerActionRequest,
   isProgressiveServerActionRequest,
   type HandleServerActionRscRequestOptions,
+  readActionBodyWithLimit,
+  readActionFormDataWithLimit,
   type HandleProgressiveServerActionRequestOptions,
 } from "../packages/vinext/src/server/app-server-action-execution.js";
 
@@ -53,6 +55,24 @@ function createMultipartBodyRequest(body: FormData): Request {
       origin: "https://example.com",
     },
   });
+}
+
+function createStreamBodyRequest(body: string, headers?: HeadersInit): Request {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(encoder.encode(body));
+      controller.close();
+    },
+  });
+  const init: RequestInit & { duplex: "half" } = {
+    method: "POST",
+    body: stream,
+    duplex: "half",
+    headers,
+  };
+
+  return new Request("https://example.com/action", init);
 }
 
 function createOptions(
@@ -201,6 +221,41 @@ function createRscOptions(
 }
 
 describe("app server action execution helpers", () => {
+  it("reads streamed action text bodies and enforces the byte limit", async () => {
+    const validRequest = new Request("https://example.com/action", {
+      method: "POST",
+      body: "hello",
+    });
+
+    await expect(readActionBodyWithLimit(validRequest, 5)).resolves.toBe("hello");
+
+    const oversizedRequest = createStreamBodyRequest("hello!");
+
+    await expect(readActionBodyWithLimit(oversizedRequest, 5)).rejects.toThrow(
+      "Request body too large",
+    );
+  });
+
+  it("reads multipart action form data and enforces the streamed byte limit", async () => {
+    const body = new FormData();
+    body.set("field", "value");
+    const validRequest = new Request("https://example.com/action", {
+      method: "POST",
+      body,
+    });
+
+    const formData = await readActionFormDataWithLimit(validRequest, 1024);
+    expect(formData.get("field")).toBe("value");
+
+    const oversizedRequest = createStreamBodyRequest("x".repeat(64), {
+      "content-type": validRequest.headers.get("content-type") ?? "",
+    });
+
+    await expect(readActionFormDataWithLimit(oversizedRequest, 16)).rejects.toThrow(
+      "Request body too large",
+    );
+  });
+
   it("identifies progressive multipart server action submissions", () => {
     expect(
       isProgressiveServerActionRequest(

--- a/tests/isr-cache.test.ts
+++ b/tests/isr-cache.test.ts
@@ -8,11 +8,15 @@
  * These complement the integration-level ISR tests in features.test.ts
  * by testing the ISR cache layer in isolation.
  */
-import { describe, it, expect, vi, beforeEach } from "vite-plus/test";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vite-plus/test";
 import {
   isrCacheKey,
+  appIsrHtmlKey,
+  appIsrRscKey,
+  appIsrRouteKey,
   buildPagesCacheValue,
   buildAppPageCacheValue,
+  normalizeMountedSlotsHeader,
   setRevalidateDuration,
   getRevalidateDuration,
   triggerBackgroundRegeneration,
@@ -106,6 +110,64 @@ describe("isrCacheKey", () => {
   it("without buildId format is unchanged (backward compat)", () => {
     expect(isrCacheKey("pages", "/about")).toBe("pages:/about");
     expect(isrCacheKey("app", "/dashboard")).toBe("app:/dashboard");
+  });
+});
+
+describe("App Router ISR cache key primitives", () => {
+  const originalBuildId = process.env.__VINEXT_BUILD_ID;
+
+  afterEach(() => {
+    if (originalBuildId === undefined) {
+      delete process.env.__VINEXT_BUILD_ID;
+      return;
+    }
+
+    process.env.__VINEXT_BUILD_ID = originalBuildId;
+  });
+
+  it("builds separate html, rsc, and route keys from the normalized pathname", () => {
+    delete process.env.__VINEXT_BUILD_ID;
+
+    expect(appIsrHtmlKey("/about/")).toBe("app:/about:html");
+    expect(appIsrRscKey("/about/")).toBe("app:/about:rsc");
+    expect(appIsrRouteKey("/api/feed/")).toBe("app:/api/feed:route");
+  });
+
+  it("includes the build id when present", () => {
+    process.env.__VINEXT_BUILD_ID = "build-42";
+
+    expect(appIsrHtmlKey("/dashboard")).toBe("app:build-42:/dashboard:html");
+  });
+
+  it("hashes long pathname keys while preserving the cache entry suffix", () => {
+    delete process.env.__VINEXT_BUILD_ID;
+
+    const key = appIsrRscKey("/" + "a".repeat(250));
+
+    expect(key).toMatch(/^app:__hash:[a-z0-9]+:rsc$/);
+  });
+
+  it("keys mounted-slot RSC variants by normalized mounted-slot header", () => {
+    delete process.env.__VINEXT_BUILD_ID;
+
+    const first = appIsrRscKey("/feed", "modal sidebar");
+    const second = appIsrRscKey("/feed", "sidebar modal");
+
+    expect(first).toBe(second);
+    expect(first).toMatch(/^app:\/feed:rsc:[a-z0-9]+$/);
+  });
+});
+
+describe("normalizeMountedSlotsHeader", () => {
+  it("returns null for missing or blank mounted-slot headers", () => {
+    expect(normalizeMountedSlotsHeader(null)).toBeNull();
+    expect(normalizeMountedSlotsHeader("   \t\n  ")).toBeNull();
+  });
+
+  it("deduplicates and sorts whitespace-separated slot ids", () => {
+    expect(normalizeMountedSlotsHeader(" sidebar  modal sidebar\tcart ")).toBe(
+      "cart modal sidebar",
+    );
   });
 });
 


### PR DESCRIPTION
## What this changes
Moves the small App Router RSC runtime primitives out of `entries/app-rsc-entry.ts` and into typed server modules:

- App ISR key construction, mounted-slot normalization, cache get/set, and background regeneration now come from `server/isr-cache.ts`.
- Server-action text and multipart body readers now live beside the server-action execution helpers.
- RSC error digest generation, client sanitization, and `renderToReadableStream` `onError` handling now live in `server/app-rsc-errors.ts`.

The generated RSC entry now describes app shape and request-specific wiring: route imports, route tables, manifest data, and callbacks that bind the current request context.

## Why
`app-rsc-entry.ts` is generated code, so every inline runtime helper makes the template harder to inspect and harder to test directly. The pressure here is not a behavior gap, it is ownership: codegen should describe the app shape, while normal modules should own behavior.

This also gives us direct unit coverage for the runtime contracts that were previously covered mostly by generated-code snapshots.

## Approach
The branch keeps the generated entry's observable wiring intact but replaces inline helper bodies with absolute imports resolved by the generator. The focused helpers preserve the existing runtime contracts:

- App page ISR still uses separate HTML/RSC/route cache keys and keeps mounted-slot RSC variants distinct.
- Action body readers still enforce the configured byte limit on the stream, not only `Content-Length`.
- Production RSC errors still produce string-hash style digests, while navigation digest errors pass through unchanged.

Relevant Next.js source references:

- Next.js generates RSC error digests with `stringHash(err.message + stack)` in [`create-error-handler.tsx`](https://github.com/vercel/next.js/blob/e1bb911c14e4ea3c6bb8cc98871ffdee317d513f/packages/next/src/server/app-render/create-error-handler.tsx#L66-L108).
- Next.js enforces the default 1 MB server action body limit through a stream transform in [`action-handler.ts`](https://github.com/vercel/next.js/blob/e1bb911c14e4ea3c6bb8cc98871ffdee317d513f/packages/next/src/server/app-render/action-handler.ts#L888-L918).
- Next.js stores App Page HTML and RSC artifacts separately in the filesystem cache read path in [`file-system-cache.ts`](https://github.com/vercel/next.js/blob/e1bb911c14e4ea3c6bb8cc98871ffdee317d513f/packages/next/src/server/lib/incremental-cache/file-system-cache.ts#L232-L250) and write path in [`file-system-cache.ts`](https://github.com/vercel/next.js/blob/e1bb911c14e4ea3c6bb8cc98871ffdee317d513f/packages/next/src/server/lib/incremental-cache/file-system-cache.ts#L393-L410).

## Validation
- `vp test run tests/isr-cache.test.ts tests/app-server-action-execution.test.ts tests/app-rsc-errors.test.ts tests/entry-templates.test.ts`
- `vp test run tests/app-router.test.ts`
- `vp test run tests/app-router.test.ts -t "RSC error runtime delegation|reports server component render errors via instrumentation in production|redirect\(\) inside Suspense|notFound\(\) inside Suspense"`
- `vp check`
- `git diff --check`

## Risks / follow-ups
This intentionally leaves the larger server-action POST orchestration in the generated entry. This PR only extracts the small primitives needed to prove the pattern with a low-risk diff.
