### PR TITLE
refactor: extract app prerender endpoints

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -85,6 +85,10 @@ const appRscRouteMatchingPath = resolveEntryPath(
   "../server/app-rsc-route-matching.js",
   import.meta.url,
 );
+const appPrerenderEndpointsPath = resolveEntryPath(
+  "../server/app-prerender-endpoints.js",
+  import.meta.url,
+);
 const rscStreamHintsPath = resolveEntryPath("../server/rsc-stream-hints.js", import.meta.url);
 const metadataRoutesPath = resolveEntryPath("../server/metadata-routes.js", import.meta.url);
 const rootParamsShimPath = resolveEntryPath("../shims/root-params.js", import.meta.url);
@@ -163,6 +167,17 @@ export function generateRscEntry(
     rootLayoutVars,
     globalErrorVar,
   } = manifestCode;
+  const loadPrerenderPagesRoutesCode = hasPagesDir
+    ? `
+async function __loadPrerenderPagesRoutes() {
+  const __gspSsrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
+  return __gspSsrEntry.pageRoutes;
+}
+`
+    : "";
+  const prerenderPagesLoaderOption = hasPagesDir
+    ? "    loadPagesRoutes: __loadPrerenderPagesRoutes,\n"
+    : "";
 
   return `
 import {
@@ -272,6 +287,9 @@ import {
   createAppRscRouteMatcher as __createAppRscRouteMatcher,
   matchAppRscRoutePattern as __matchAppRscRoutePattern,
 } from ${JSON.stringify(appRscRouteMatchingPath)};
+import {
+  handleAppPrerenderEndpoint as __handleAppPrerenderEndpoint,
+} from ${JSON.stringify(appPrerenderEndpointsPath)};
 // Import server-only state module to register ALS-backed accessors.
 import "vinext/navigation-state";
 import { runWithRequestContext as _runWithUnifiedCtx, createRequestContext as _createUnifiedCtx } from "vinext/unified-request-context";
@@ -281,7 +299,7 @@ import { getSSRFontLinks as _getSSRFontLinks, getSSRFontStyles as _getSSRFontSty
 import { getSSRFontStyles as _getSSRFontStylesLocal, getSSRFontPreloads as _getSSRFontPreloadsLocal } from "next/font/local";
 function _getSSRFontStyles() { return [..._getSSRFontStylesGoogle(), ..._getSSRFontStylesLocal()]; }
 function _getSSRFontPreloads() { return [..._getSSRFontPreloadsGoogle(), ..._getSSRFontPreloadsLocal()]; }
-${hasPagesDir ? `// Note: pageRoutes loaded lazily via SSR env in /__vinext/prerender/pages-static-paths handler` : ""}
+${hasPagesDir ? `// Pages Router routes are loaded lazily from the SSR environment for internal prerender requests.` : ""}
 
 // ALS used to suppress the expected "Invalid hook call" dev warning when
 // layout/page components are probed outside React's render cycle. Patching
@@ -964,7 +982,7 @@ export const generateStaticParamsMap = {
 // so they are excluded here. Supporting layout-level generateStaticParams requires
 // scanning layout.tsx files separately and including them in this map.
 ${generateStaticParamsEntries.join("\n")}
-};
+};${loadPrerenderPagesRoutesCode}
 
 export default async function handler(request, ctx) {
   ${
@@ -1078,78 +1096,15 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       : ""
   }
 
-  // ── Prerender: static-params endpoint ────────────────────────────────
-  // Internal endpoint used by prerenderApp() during build to fetch
-  // generateStaticParams results via wrangler unstable_startWorker.
-  // Gated on VINEXT_PRERENDER=1 to prevent exposure in normal deployments.
-  // For Node builds, process.env.VINEXT_PRERENDER is set directly by the
-  // prerender orchestrator. For CF Workers builds, wrangler unstable_startWorker
-  // injects VINEXT_PRERENDER as a binding which Miniflare exposes via process.env
-  // in bundled workers. The /__vinext/ prefix ensures no user route ever conflicts.
-  if (pathname === "/__vinext/prerender/static-params") {
-    if (process.env.VINEXT_PRERENDER !== "1") {
-      return new Response("Not Found", { status: 404 });
-    }
-    const pattern = url.searchParams.get("pattern");
-    if (!pattern) return new Response("missing pattern", { status: 400 });
-    const fn = generateStaticParamsMap[pattern];
-    if (typeof fn !== "function") return new Response("null", { status: 200, headers: { "content-type": "application/json" } });
-    try {
-      const parentParams = url.searchParams.get("parentParams");
-      const raw = parentParams ? JSON.parse(parentParams) : {};
-      // Ensure params is a plain object — reject primitives, arrays, and null
-      // so user-authored generateStaticParams always receives { params: {} }
-      // rather than { params: 5 } or similar if input is malformed.
-      const params = (typeof raw === "object" && raw !== null && !Array.isArray(raw)) ? raw : {};
-      const result = await fn({ params });
-      return new Response(JSON.stringify(result), { status: 200, headers: { "content-type": "application/json" } });
-    } catch (e) {
-      return new Response(JSON.stringify({ error: String(e) }), { status: 500, headers: { "content-type": "application/json" } });
-    }
-  }
-
-  ${
-    hasPagesDir
-      ? `
-  // ── Prerender: pages-static-paths endpoint ───────────────────────────
-  // Internal endpoint used by prerenderPages() during a CF Workers hybrid
-  // build to call getStaticPaths() for dynamic Pages Router routes via
-  // wrangler unstable_startWorker. Returns JSON-serialised getStaticPaths result.
-  // Gated on VINEXT_PRERENDER=1 to prevent exposure in normal deployments.
-  // See static-params endpoint above for process.env vs CF vars notes.
-  //
-  // pageRoutes lives in the SSR environment (virtual:vinext-server-entry).
-  // We load it lazily via import.meta.viteRsc.loadModule — the same pattern
-  // used by handleSsr() elsewhere in this template. At build time, Vite's RSC
-  // plugin transforms this call into a bundled cross-environment import, so it
-  // works correctly in the CF Workers production bundle running in Miniflare.
-  if (pathname === "/__vinext/prerender/pages-static-paths") {
-    if (process.env.VINEXT_PRERENDER !== "1") {
-      return new Response("Not Found", { status: 404 });
-    }
-    const __gspPattern = url.searchParams.get("pattern");
-    if (!__gspPattern) return new Response("missing pattern", { status: 400 });
-    try {
-      const __gspSsrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
-      const __pagesRoutes = __gspSsrEntry.pageRoutes;
-      const __gspRoute = Array.isArray(__pagesRoutes)
-        ? __pagesRoutes.find((r) => r.pattern === __gspPattern)
-        : undefined;
-      if (!__gspRoute || typeof __gspRoute.module?.getStaticPaths !== "function") {
-        return new Response("null", { status: 200, headers: { "content-type": "application/json" } });
-      }
-      const __localesParam = url.searchParams.get("locales");
-      const __locales = __localesParam ? JSON.parse(__localesParam) : [];
-      const __defaultLocale = url.searchParams.get("defaultLocale") ?? "";
-      const __gspResult = await __gspRoute.module.getStaticPaths({ locales: __locales, defaultLocale: __defaultLocale });
-      return new Response(JSON.stringify(__gspResult), { status: 200, headers: { "content-type": "application/json" } });
-    } catch (e) {
-      return new Response(JSON.stringify({ error: String(e) }), { status: 500, headers: { "content-type": "application/json" } });
-    }
-  }
-  `
-      : ""
-  }
+  const __prerenderEndpointResponse = await __handleAppPrerenderEndpoint(request, {
+    isPrerenderEnabled() {
+      return process.env.VINEXT_PRERENDER === "1";
+    },
+${prerenderPagesLoaderOption}
+    pathname,
+    staticParamsMap: generateStaticParamsMap,
+  });
+  if (__prerenderEndpointResponse) return __prerenderEndpointResponse;
 
   // Trailing slash normalization (redirect to canonical form)
   const __tsRedirect = normalizeTrailingSlash(pathname, __basePath, __trailingSlash, url.search);

--- a/packages/vinext/src/server/app-prerender-endpoints.ts
+++ b/packages/vinext/src/server/app-prerender-endpoints.ts
@@ -1,0 +1,156 @@
+type AppPrerenderParams = Record<string, unknown>;
+
+type GenerateStaticParams = (args: { params: AppPrerenderParams }) => unknown;
+
+type AppPrerenderStaticParamsMap = Record<string, GenerateStaticParams | null | undefined>;
+
+type AppPrerenderPageRoute = {
+  pattern: string;
+  module?: {
+    getStaticPaths?: (opts: { locales: string[]; defaultLocale: string }) => unknown;
+  };
+};
+
+type HandleAppPrerenderEndpointOptions = {
+  isPrerenderEnabled?: () => boolean;
+  loadPagesRoutes?: () => Promise<unknown>;
+  pathname: string;
+  staticParamsMap: AppPrerenderStaticParamsMap;
+};
+
+const STATIC_PARAMS_ENDPOINT = "/__vinext/prerender/static-params";
+const PAGES_STATIC_PATHS_ENDPOINT = "/__vinext/prerender/pages-static-paths";
+const JSON_HEADERS = { "content-type": "application/json" };
+
+export async function handleAppPrerenderEndpoint(
+  request: Request,
+  options: HandleAppPrerenderEndpointOptions,
+): Promise<Response | null> {
+  if (options.pathname === STATIC_PARAMS_ENDPOINT) {
+    return handleStaticParamsEndpoint(request, options);
+  }
+
+  if (options.pathname === PAGES_STATIC_PATHS_ENDPOINT) {
+    if (!options.loadPagesRoutes) return null;
+    return handlePagesStaticPathsEndpoint(request, options);
+  }
+
+  return null;
+}
+
+async function handleStaticParamsEndpoint(
+  request: Request,
+  options: HandleAppPrerenderEndpointOptions,
+): Promise<Response> {
+  if (!isEnabled(options)) {
+    return new Response("Not Found", { status: 404 });
+  }
+
+  const url = new URL(request.url);
+  const pattern = url.searchParams.get("pattern");
+  if (!pattern) return new Response("missing pattern", { status: 400 });
+
+  const generateStaticParams = options.staticParamsMap[pattern];
+  if (typeof generateStaticParams !== "function") {
+    return jsonNullResponse();
+  }
+
+  try {
+    const params = parseParentParams(url.searchParams.get("parentParams"));
+    const result = await generateStaticParams({ params });
+    return jsonResponse(result);
+  } catch (error) {
+    return jsonResponse({ error: String(error) }, 500);
+  }
+}
+
+async function handlePagesStaticPathsEndpoint(
+  request: Request,
+  options: HandleAppPrerenderEndpointOptions,
+): Promise<Response> {
+  if (!isEnabled(options)) {
+    return new Response("Not Found", { status: 404 });
+  }
+
+  const url = new URL(request.url);
+  const pattern = url.searchParams.get("pattern");
+  if (!pattern) return new Response("missing pattern", { status: 400 });
+
+  try {
+    const pageRoutes = await options.loadPagesRoutes?.();
+    const route = findPageRoute(pageRoutes, pattern);
+    const getStaticPaths = route?.module?.getStaticPaths;
+    if (typeof getStaticPaths !== "function") {
+      return jsonNullResponse();
+    }
+
+    const locales = parseLocales(url.searchParams.get("locales"));
+    const defaultLocale = url.searchParams.get("defaultLocale") ?? "";
+    const result = await getStaticPaths({ locales, defaultLocale });
+    return jsonResponse(result);
+  } catch (error) {
+    return jsonResponse({ error: String(error) }, 500);
+  }
+}
+
+function isEnabled(options: HandleAppPrerenderEndpointOptions): boolean {
+  return options.isPrerenderEnabled?.() ?? false;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    headers: JSON_HEADERS,
+    status,
+  });
+}
+
+function jsonNullResponse(): Response {
+  return new Response("null", {
+    headers: JSON_HEADERS,
+    status: 200,
+  });
+}
+
+function parseParentParams(raw: string | null): AppPrerenderParams {
+  if (!raw) return {};
+
+  const value = JSON.parse(raw);
+  if (!isPlainObject(value)) return {};
+
+  return Object.fromEntries(Object.entries(value));
+}
+
+function parseLocales(raw: string | null): string[] {
+  if (!raw) return [];
+
+  const value = JSON.parse(raw);
+  if (!Array.isArray(value)) return [];
+
+  return value.filter((locale) => typeof locale === "string");
+}
+
+function findPageRoute(value: unknown, pattern: string): AppPrerenderPageRoute | undefined {
+  if (!Array.isArray(value)) return undefined;
+
+  for (const route of value) {
+    if (isPageRoute(route) && route.pattern === pattern) {
+      return route;
+    }
+  }
+
+  return undefined;
+}
+
+function isPageRoute(value: unknown): value is AppPrerenderPageRoute {
+  if (!isPlainObject(value) || typeof value.pattern !== "string") return false;
+  if (value.module === undefined) return true;
+  if (!isPlainObject(value.module)) return false;
+
+  return (
+    value.module.getStaticPaths === undefined || typeof value.module.getStaticPaths === "function"
+  );
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -111,6 +111,9 @@ import {
   createAppRscRouteMatcher as __createAppRscRouteMatcher,
   matchAppRscRoutePattern as __matchAppRscRoutePattern,
 } from "<ROOT>/packages/vinext/src/server/app-rsc-route-matching.js";
+import {
+  handleAppPrerenderEndpoint as __handleAppPrerenderEndpoint,
+} from "<ROOT>/packages/vinext/src/server/app-prerender-endpoints.js";
 // Import server-only state module to register ALS-backed accessors.
 import "vinext/navigation-state";
 import { runWithRequestContext as _runWithUnifiedCtx, createRequestContext as _createUnifiedCtx } from "vinext/unified-request-context";
@@ -1043,37 +1046,15 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
 
   
 
-  // ── Prerender: static-params endpoint ────────────────────────────────
-  // Internal endpoint used by prerenderApp() during build to fetch
-  // generateStaticParams results via wrangler unstable_startWorker.
-  // Gated on VINEXT_PRERENDER=1 to prevent exposure in normal deployments.
-  // For Node builds, process.env.VINEXT_PRERENDER is set directly by the
-  // prerender orchestrator. For CF Workers builds, wrangler unstable_startWorker
-  // injects VINEXT_PRERENDER as a binding which Miniflare exposes via process.env
-  // in bundled workers. The /__vinext/ prefix ensures no user route ever conflicts.
-  if (pathname === "/__vinext/prerender/static-params") {
-    if (process.env.VINEXT_PRERENDER !== "1") {
-      return new Response("Not Found", { status: 404 });
-    }
-    const pattern = url.searchParams.get("pattern");
-    if (!pattern) return new Response("missing pattern", { status: 400 });
-    const fn = generateStaticParamsMap[pattern];
-    if (typeof fn !== "function") return new Response("null", { status: 200, headers: { "content-type": "application/json" } });
-    try {
-      const parentParams = url.searchParams.get("parentParams");
-      const raw = parentParams ? JSON.parse(parentParams) : {};
-      // Ensure params is a plain object — reject primitives, arrays, and null
-      // so user-authored generateStaticParams always receives { params: {} }
-      // rather than { params: 5 } or similar if input is malformed.
-      const params = (typeof raw === "object" && raw !== null && !Array.isArray(raw)) ? raw : {};
-      const result = await fn({ params });
-      return new Response(JSON.stringify(result), { status: 200, headers: { "content-type": "application/json" } });
-    } catch (e) {
-      return new Response(JSON.stringify({ error: String(e) }), { status: 500, headers: { "content-type": "application/json" } });
-    }
-  }
+  const __prerenderEndpointResponse = await __handleAppPrerenderEndpoint(request, {
+    isPrerenderEnabled() {
+      return process.env.VINEXT_PRERENDER === "1";
+    },
 
-  
+    pathname,
+    staticParamsMap: generateStaticParamsMap,
+  });
+  if (__prerenderEndpointResponse) return __prerenderEndpointResponse;
 
   // Trailing slash normalization (redirect to canonical form)
   const __tsRedirect = normalizeTrailingSlash(pathname, __basePath, __trailingSlash, url.search);
@@ -2249,6 +2230,9 @@ import {
   createAppRscRouteMatcher as __createAppRscRouteMatcher,
   matchAppRscRoutePattern as __matchAppRscRoutePattern,
 } from "<ROOT>/packages/vinext/src/server/app-rsc-route-matching.js";
+import {
+  handleAppPrerenderEndpoint as __handleAppPrerenderEndpoint,
+} from "<ROOT>/packages/vinext/src/server/app-prerender-endpoints.js";
 // Import server-only state module to register ALS-backed accessors.
 import "vinext/navigation-state";
 import { runWithRequestContext as _runWithUnifiedCtx, createRequestContext as _createUnifiedCtx } from "vinext/unified-request-context";
@@ -3187,37 +3171,15 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   pathname = stripBasePath(pathname, __basePath);
   
 
-  // ── Prerender: static-params endpoint ────────────────────────────────
-  // Internal endpoint used by prerenderApp() during build to fetch
-  // generateStaticParams results via wrangler unstable_startWorker.
-  // Gated on VINEXT_PRERENDER=1 to prevent exposure in normal deployments.
-  // For Node builds, process.env.VINEXT_PRERENDER is set directly by the
-  // prerender orchestrator. For CF Workers builds, wrangler unstable_startWorker
-  // injects VINEXT_PRERENDER as a binding which Miniflare exposes via process.env
-  // in bundled workers. The /__vinext/ prefix ensures no user route ever conflicts.
-  if (pathname === "/__vinext/prerender/static-params") {
-    if (process.env.VINEXT_PRERENDER !== "1") {
-      return new Response("Not Found", { status: 404 });
-    }
-    const pattern = url.searchParams.get("pattern");
-    if (!pattern) return new Response("missing pattern", { status: 400 });
-    const fn = generateStaticParamsMap[pattern];
-    if (typeof fn !== "function") return new Response("null", { status: 200, headers: { "content-type": "application/json" } });
-    try {
-      const parentParams = url.searchParams.get("parentParams");
-      const raw = parentParams ? JSON.parse(parentParams) : {};
-      // Ensure params is a plain object — reject primitives, arrays, and null
-      // so user-authored generateStaticParams always receives { params: {} }
-      // rather than { params: 5 } or similar if input is malformed.
-      const params = (typeof raw === "object" && raw !== null && !Array.isArray(raw)) ? raw : {};
-      const result = await fn({ params });
-      return new Response(JSON.stringify(result), { status: 200, headers: { "content-type": "application/json" } });
-    } catch (e) {
-      return new Response(JSON.stringify({ error: String(e) }), { status: 500, headers: { "content-type": "application/json" } });
-    }
-  }
+  const __prerenderEndpointResponse = await __handleAppPrerenderEndpoint(request, {
+    isPrerenderEnabled() {
+      return process.env.VINEXT_PRERENDER === "1";
+    },
 
-  
+    pathname,
+    staticParamsMap: generateStaticParamsMap,
+  });
+  if (__prerenderEndpointResponse) return __prerenderEndpointResponse;
 
   // Trailing slash normalization (redirect to canonical form)
   const __tsRedirect = normalizeTrailingSlash(pathname, __basePath, __trailingSlash, url.search);
@@ -4393,6 +4355,9 @@ import {
   createAppRscRouteMatcher as __createAppRscRouteMatcher,
   matchAppRscRoutePattern as __matchAppRscRoutePattern,
 } from "<ROOT>/packages/vinext/src/server/app-rsc-route-matching.js";
+import {
+  handleAppPrerenderEndpoint as __handleAppPrerenderEndpoint,
+} from "<ROOT>/packages/vinext/src/server/app-prerender-endpoints.js";
 // Import server-only state module to register ALS-backed accessors.
 import "vinext/navigation-state";
 import { runWithRequestContext as _runWithUnifiedCtx, createRequestContext as _createUnifiedCtx } from "vinext/unified-request-context";
@@ -5326,37 +5291,15 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
 
   
 
-  // ── Prerender: static-params endpoint ────────────────────────────────
-  // Internal endpoint used by prerenderApp() during build to fetch
-  // generateStaticParams results via wrangler unstable_startWorker.
-  // Gated on VINEXT_PRERENDER=1 to prevent exposure in normal deployments.
-  // For Node builds, process.env.VINEXT_PRERENDER is set directly by the
-  // prerender orchestrator. For CF Workers builds, wrangler unstable_startWorker
-  // injects VINEXT_PRERENDER as a binding which Miniflare exposes via process.env
-  // in bundled workers. The /__vinext/ prefix ensures no user route ever conflicts.
-  if (pathname === "/__vinext/prerender/static-params") {
-    if (process.env.VINEXT_PRERENDER !== "1") {
-      return new Response("Not Found", { status: 404 });
-    }
-    const pattern = url.searchParams.get("pattern");
-    if (!pattern) return new Response("missing pattern", { status: 400 });
-    const fn = generateStaticParamsMap[pattern];
-    if (typeof fn !== "function") return new Response("null", { status: 200, headers: { "content-type": "application/json" } });
-    try {
-      const parentParams = url.searchParams.get("parentParams");
-      const raw = parentParams ? JSON.parse(parentParams) : {};
-      // Ensure params is a plain object — reject primitives, arrays, and null
-      // so user-authored generateStaticParams always receives { params: {} }
-      // rather than { params: 5 } or similar if input is malformed.
-      const params = (typeof raw === "object" && raw !== null && !Array.isArray(raw)) ? raw : {};
-      const result = await fn({ params });
-      return new Response(JSON.stringify(result), { status: 200, headers: { "content-type": "application/json" } });
-    } catch (e) {
-      return new Response(JSON.stringify({ error: String(e) }), { status: 500, headers: { "content-type": "application/json" } });
-    }
-  }
+  const __prerenderEndpointResponse = await __handleAppPrerenderEndpoint(request, {
+    isPrerenderEnabled() {
+      return process.env.VINEXT_PRERENDER === "1";
+    },
 
-  
+    pathname,
+    staticParamsMap: generateStaticParamsMap,
+  });
+  if (__prerenderEndpointResponse) return __prerenderEndpointResponse;
 
   // Trailing slash normalization (redirect to canonical form)
   const __tsRedirect = normalizeTrailingSlash(pathname, __basePath, __trailingSlash, url.search);
@@ -6532,6 +6475,9 @@ import {
   createAppRscRouteMatcher as __createAppRscRouteMatcher,
   matchAppRscRoutePattern as __matchAppRscRoutePattern,
 } from "<ROOT>/packages/vinext/src/server/app-rsc-route-matching.js";
+import {
+  handleAppPrerenderEndpoint as __handleAppPrerenderEndpoint,
+} from "<ROOT>/packages/vinext/src/server/app-prerender-endpoints.js";
 // Import server-only state module to register ALS-backed accessors.
 import "vinext/navigation-state";
 import { runWithRequestContext as _runWithUnifiedCtx, createRequestContext as _createUnifiedCtx } from "vinext/unified-request-context";
@@ -7497,37 +7443,15 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
 
   
 
-  // ── Prerender: static-params endpoint ────────────────────────────────
-  // Internal endpoint used by prerenderApp() during build to fetch
-  // generateStaticParams results via wrangler unstable_startWorker.
-  // Gated on VINEXT_PRERENDER=1 to prevent exposure in normal deployments.
-  // For Node builds, process.env.VINEXT_PRERENDER is set directly by the
-  // prerender orchestrator. For CF Workers builds, wrangler unstable_startWorker
-  // injects VINEXT_PRERENDER as a binding which Miniflare exposes via process.env
-  // in bundled workers. The /__vinext/ prefix ensures no user route ever conflicts.
-  if (pathname === "/__vinext/prerender/static-params") {
-    if (process.env.VINEXT_PRERENDER !== "1") {
-      return new Response("Not Found", { status: 404 });
-    }
-    const pattern = url.searchParams.get("pattern");
-    if (!pattern) return new Response("missing pattern", { status: 400 });
-    const fn = generateStaticParamsMap[pattern];
-    if (typeof fn !== "function") return new Response("null", { status: 200, headers: { "content-type": "application/json" } });
-    try {
-      const parentParams = url.searchParams.get("parentParams");
-      const raw = parentParams ? JSON.parse(parentParams) : {};
-      // Ensure params is a plain object — reject primitives, arrays, and null
-      // so user-authored generateStaticParams always receives { params: {} }
-      // rather than { params: 5 } or similar if input is malformed.
-      const params = (typeof raw === "object" && raw !== null && !Array.isArray(raw)) ? raw : {};
-      const result = await fn({ params });
-      return new Response(JSON.stringify(result), { status: 200, headers: { "content-type": "application/json" } });
-    } catch (e) {
-      return new Response(JSON.stringify({ error: String(e) }), { status: 500, headers: { "content-type": "application/json" } });
-    }
-  }
+  const __prerenderEndpointResponse = await __handleAppPrerenderEndpoint(request, {
+    isPrerenderEnabled() {
+      return process.env.VINEXT_PRERENDER === "1";
+    },
 
-  
+    pathname,
+    staticParamsMap: generateStaticParamsMap,
+  });
+  if (__prerenderEndpointResponse) return __prerenderEndpointResponse;
 
   // Trailing slash normalization (redirect to canonical form)
   const __tsRedirect = normalizeTrailingSlash(pathname, __basePath, __trailingSlash, url.search);
@@ -8703,6 +8627,9 @@ import {
   createAppRscRouteMatcher as __createAppRscRouteMatcher,
   matchAppRscRoutePattern as __matchAppRscRoutePattern,
 } from "<ROOT>/packages/vinext/src/server/app-rsc-route-matching.js";
+import {
+  handleAppPrerenderEndpoint as __handleAppPrerenderEndpoint,
+} from "<ROOT>/packages/vinext/src/server/app-prerender-endpoints.js";
 // Import server-only state module to register ALS-backed accessors.
 import "vinext/navigation-state";
 import { runWithRequestContext as _runWithUnifiedCtx, createRequestContext as _createUnifiedCtx } from "vinext/unified-request-context";
@@ -9642,37 +9569,15 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
 
   
 
-  // ── Prerender: static-params endpoint ────────────────────────────────
-  // Internal endpoint used by prerenderApp() during build to fetch
-  // generateStaticParams results via wrangler unstable_startWorker.
-  // Gated on VINEXT_PRERENDER=1 to prevent exposure in normal deployments.
-  // For Node builds, process.env.VINEXT_PRERENDER is set directly by the
-  // prerender orchestrator. For CF Workers builds, wrangler unstable_startWorker
-  // injects VINEXT_PRERENDER as a binding which Miniflare exposes via process.env
-  // in bundled workers. The /__vinext/ prefix ensures no user route ever conflicts.
-  if (pathname === "/__vinext/prerender/static-params") {
-    if (process.env.VINEXT_PRERENDER !== "1") {
-      return new Response("Not Found", { status: 404 });
-    }
-    const pattern = url.searchParams.get("pattern");
-    if (!pattern) return new Response("missing pattern", { status: 400 });
-    const fn = generateStaticParamsMap[pattern];
-    if (typeof fn !== "function") return new Response("null", { status: 200, headers: { "content-type": "application/json" } });
-    try {
-      const parentParams = url.searchParams.get("parentParams");
-      const raw = parentParams ? JSON.parse(parentParams) : {};
-      // Ensure params is a plain object — reject primitives, arrays, and null
-      // so user-authored generateStaticParams always receives { params: {} }
-      // rather than { params: 5 } or similar if input is malformed.
-      const params = (typeof raw === "object" && raw !== null && !Array.isArray(raw)) ? raw : {};
-      const result = await fn({ params });
-      return new Response(JSON.stringify(result), { status: 200, headers: { "content-type": "application/json" } });
-    } catch (e) {
-      return new Response(JSON.stringify({ error: String(e) }), { status: 500, headers: { "content-type": "application/json" } });
-    }
-  }
+  const __prerenderEndpointResponse = await __handleAppPrerenderEndpoint(request, {
+    isPrerenderEnabled() {
+      return process.env.VINEXT_PRERENDER === "1";
+    },
 
-  
+    pathname,
+    staticParamsMap: generateStaticParamsMap,
+  });
+  if (__prerenderEndpointResponse) return __prerenderEndpointResponse;
 
   // Trailing slash normalization (redirect to canonical form)
   const __tsRedirect = normalizeTrailingSlash(pathname, __basePath, __trailingSlash, url.search);
@@ -10848,6 +10753,9 @@ import {
   createAppRscRouteMatcher as __createAppRscRouteMatcher,
   matchAppRscRoutePattern as __matchAppRscRoutePattern,
 } from "<ROOT>/packages/vinext/src/server/app-rsc-route-matching.js";
+import {
+  handleAppPrerenderEndpoint as __handleAppPrerenderEndpoint,
+} from "<ROOT>/packages/vinext/src/server/app-prerender-endpoints.js";
 // Import server-only state module to register ALS-backed accessors.
 import "vinext/navigation-state";
 import { runWithRequestContext as _runWithUnifiedCtx, createRequestContext as _createUnifiedCtx } from "vinext/unified-request-context";
@@ -11780,37 +11688,15 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
 
   
 
-  // ── Prerender: static-params endpoint ────────────────────────────────
-  // Internal endpoint used by prerenderApp() during build to fetch
-  // generateStaticParams results via wrangler unstable_startWorker.
-  // Gated on VINEXT_PRERENDER=1 to prevent exposure in normal deployments.
-  // For Node builds, process.env.VINEXT_PRERENDER is set directly by the
-  // prerender orchestrator. For CF Workers builds, wrangler unstable_startWorker
-  // injects VINEXT_PRERENDER as a binding which Miniflare exposes via process.env
-  // in bundled workers. The /__vinext/ prefix ensures no user route ever conflicts.
-  if (pathname === "/__vinext/prerender/static-params") {
-    if (process.env.VINEXT_PRERENDER !== "1") {
-      return new Response("Not Found", { status: 404 });
-    }
-    const pattern = url.searchParams.get("pattern");
-    if (!pattern) return new Response("missing pattern", { status: 400 });
-    const fn = generateStaticParamsMap[pattern];
-    if (typeof fn !== "function") return new Response("null", { status: 200, headers: { "content-type": "application/json" } });
-    try {
-      const parentParams = url.searchParams.get("parentParams");
-      const raw = parentParams ? JSON.parse(parentParams) : {};
-      // Ensure params is a plain object — reject primitives, arrays, and null
-      // so user-authored generateStaticParams always receives { params: {} }
-      // rather than { params: 5 } or similar if input is malformed.
-      const params = (typeof raw === "object" && raw !== null && !Array.isArray(raw)) ? raw : {};
-      const result = await fn({ params });
-      return new Response(JSON.stringify(result), { status: 200, headers: { "content-type": "application/json" } });
-    } catch (e) {
-      return new Response(JSON.stringify({ error: String(e) }), { status: 500, headers: { "content-type": "application/json" } });
-    }
-  }
+  const __prerenderEndpointResponse = await __handleAppPrerenderEndpoint(request, {
+    isPrerenderEnabled() {
+      return process.env.VINEXT_PRERENDER === "1";
+    },
 
-  
+    pathname,
+    staticParamsMap: generateStaticParamsMap,
+  });
+  if (__prerenderEndpointResponse) return __prerenderEndpointResponse;
 
   // Trailing slash normalization (redirect to canonical form)
   const __tsRedirect = normalizeTrailingSlash(pathname, __basePath, __trailingSlash, url.search);

--- a/tests/app-prerender-endpoints.test.ts
+++ b/tests/app-prerender-endpoints.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+import { handleAppPrerenderEndpoint } from "../packages/vinext/src/server/app-prerender-endpoints.js";
+
+type TestPageRoute = {
+  pattern: string;
+  module?: {
+    getStaticPaths?: (opts: { locales: string[]; defaultLocale: string }) => unknown;
+  };
+};
+
+describe("App prerender endpoint helpers", () => {
+  it("falls through for non-prerender requests", async () => {
+    const response = await handleAppPrerenderEndpoint(new Request("http://localhost/blog/post"), {
+      isPrerenderEnabled: () => true,
+      pathname: "/blog/post",
+      staticParamsMap: {},
+    });
+
+    expect(response).toBeNull();
+  });
+
+  it("returns 404 for prerender endpoints outside prerender mode", async () => {
+    const response = await handleAppPrerenderEndpoint(
+      new Request("http://localhost/__vinext/prerender/static-params?pattern=/blog/:slug"),
+      {
+        isPrerenderEnabled: () => false,
+        pathname: "/__vinext/prerender/static-params",
+        staticParamsMap: {
+          "/blog/:slug": () => [{ slug: "hello" }],
+        },
+      },
+    );
+
+    expect(response?.status).toBe(404);
+    await expect(response?.text()).resolves.toBe("Not Found");
+  });
+
+  it("calls generateStaticParams with object parent params and serializes the result", async () => {
+    const generateStaticParams = vi.fn(({ params }) => [
+      { category: params.category, slug: "hello" },
+    ]);
+
+    const response = await handleAppPrerenderEndpoint(
+      new Request(
+        "http://localhost/__vinext/prerender/static-params?pattern=/blog/:slug&parentParams=%7B%22category%22%3A%22docs%22%7D",
+      ),
+      {
+        isPrerenderEnabled: () => true,
+        pathname: "/__vinext/prerender/static-params",
+        staticParamsMap: {
+          "/blog/:slug": generateStaticParams,
+        },
+      },
+    );
+
+    expect(generateStaticParams).toHaveBeenCalledWith({ params: { category: "docs" } });
+    expect(response?.status).toBe(200);
+    await expect(response?.json()).resolves.toEqual([{ category: "docs", slug: "hello" }]);
+  });
+
+  it("passes empty parent params when static param input is not an object", async () => {
+    const generateStaticParams = vi.fn(() => []);
+
+    const response = await handleAppPrerenderEndpoint(
+      new Request(
+        "http://localhost/__vinext/prerender/static-params?pattern=/blog/:slug&parentParams=5",
+      ),
+      {
+        isPrerenderEnabled: () => true,
+        pathname: "/__vinext/prerender/static-params",
+        staticParamsMap: {
+          "/blog/:slug": generateStaticParams,
+        },
+      },
+    );
+
+    expect(generateStaticParams).toHaveBeenCalledWith({ params: {} });
+    expect(response?.status).toBe(200);
+  });
+
+  it("loads Pages Router routes lazily and calls getStaticPaths", async () => {
+    const getStaticPaths = vi.fn(() => ({
+      fallback: false,
+      paths: [{ params: { id: "first" } }],
+    }));
+    const pageRoutes: TestPageRoute[] = [
+      {
+        module: { getStaticPaths },
+        pattern: "/posts/:id",
+      },
+    ];
+
+    const response = await handleAppPrerenderEndpoint(
+      new Request(
+        "http://localhost/__vinext/prerender/pages-static-paths?pattern=/posts/:id&locales=%5B%22en%22%5D&defaultLocale=en",
+      ),
+      {
+        isPrerenderEnabled: () => true,
+        loadPagesRoutes: async () => pageRoutes,
+        pathname: "/__vinext/prerender/pages-static-paths",
+        staticParamsMap: {},
+      },
+    );
+
+    expect(getStaticPaths).toHaveBeenCalledWith({ defaultLocale: "en", locales: ["en"] });
+    expect(response?.status).toBe(200);
+    await expect(response?.json()).resolves.toEqual({
+      fallback: false,
+      paths: [{ params: { id: "first" } }],
+    });
+  });
+
+  it("returns JSON null when the requested prerender function is absent", async () => {
+    const staticParamsResponse = await handleAppPrerenderEndpoint(
+      new Request("http://localhost/__vinext/prerender/static-params?pattern=/missing"),
+      {
+        isPrerenderEnabled: () => true,
+        pathname: "/__vinext/prerender/static-params",
+        staticParamsMap: {},
+      },
+    );
+    const pagesResponse = await handleAppPrerenderEndpoint(
+      new Request("http://localhost/__vinext/prerender/pages-static-paths?pattern=/missing"),
+      {
+        isPrerenderEnabled: () => true,
+        loadPagesRoutes: async () => [],
+        pathname: "/__vinext/prerender/pages-static-paths",
+        staticParamsMap: {},
+      },
+    );
+
+    expect(staticParamsResponse?.status).toBe(200);
+    await expect(staticParamsResponse?.text()).resolves.toBe("null");
+    expect(pagesResponse?.status).toBe(200);
+    await expect(pagesResponse?.text()).resolves.toBe("null");
+  });
+
+  it("returns JSON null when the Pages Router loader returns a non-route shape", async () => {
+    const response = await handleAppPrerenderEndpoint(
+      new Request("http://localhost/__vinext/prerender/pages-static-paths?pattern=/missing"),
+      {
+        isPrerenderEnabled: () => true,
+        loadPagesRoutes: async () => ({ pageRoutes: [] }),
+        pathname: "/__vinext/prerender/pages-static-paths",
+        staticParamsMap: {},
+      },
+    );
+
+    expect(response?.status).toBe(200);
+    await expect(response?.text()).resolves.toBe("null");
+  });
+
+  it("returns explicit endpoint errors for missing query fields and thrown user functions", async () => {
+    const missingPatternResponse = await handleAppPrerenderEndpoint(
+      new Request("http://localhost/__vinext/prerender/static-params"),
+      {
+        isPrerenderEnabled: () => true,
+        pathname: "/__vinext/prerender/static-params",
+        staticParamsMap: {},
+      },
+    );
+    const thrownResponse = await handleAppPrerenderEndpoint(
+      new Request("http://localhost/__vinext/prerender/static-params?pattern=/blog/:slug"),
+      {
+        isPrerenderEnabled: () => true,
+        pathname: "/__vinext/prerender/static-params",
+        staticParamsMap: {
+          "/blog/:slug": () => {
+            throw new Error("boom");
+          },
+        },
+      },
+    );
+
+    expect(missingPatternResponse?.status).toBe(400);
+    await expect(missingPatternResponse?.text()).resolves.toBe("missing pattern");
+    expect(thrownResponse?.status).toBe(500);
+    await expect(thrownResponse?.json()).resolves.toEqual({ error: "Error: boom" });
+  });
+});

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -459,6 +459,24 @@ describe("App Router entry templates", () => {
     expect(code).not.toContain("const _hlFixRe =");
   });
 
+  it("generateRscEntry delegates internal prerender endpoints", () => {
+    const code = generateRscEntry("/tmp/test/app", minimalAppRoutes, null, [], null, "", false, {
+      hasPagesDir: true,
+    });
+    const stableCode = stabilize(code);
+
+    expect(stableCode).toContain(
+      'from "<ROOT>/packages/vinext/src/server/app-prerender-endpoints.js";',
+    );
+    expect(code).toContain("handleAppPrerenderEndpoint as __handleAppPrerenderEndpoint");
+    expect(code).toContain(
+      "const __prerenderEndpointResponse = await __handleAppPrerenderEndpoint(",
+    );
+    expect(code).toContain("loadPagesRoutes: __loadPrerenderPagesRoutes,");
+    expect(code).not.toContain('if (pathname === "/__vinext/prerender/static-params")');
+    expect(code).not.toContain('if (pathname === "/__vinext/prerender/pages-static-paths")');
+  });
+
   it("generateSsrEntry snapshot", () => {
     const code = generateSsrEntry();
     expect(stabilize(code)).toMatchSnapshot();


### PR DESCRIPTION
## Summary

- Move App Router internal prerender endpoint behavior out of the generated RSC entry and into `server/app-prerender-endpoints.ts`.
- Keep codegen focused on app shape: `generateStaticParamsMap` and the optional Pages Router SSR route-loader closure are still emitted by the entry.
- Add direct helper coverage for static params, Pages `getStaticPaths`, disabled prerender mode, malformed/absent route data, and endpoint errors.
- Update entry-template assertions/snapshots so `/__vinext/prerender/*` request handling does not drift back into generated code.

## Why

The generated RSC entry had accumulated request parsing, prerender-mode gating, static params dispatch, Pages `getStaticPaths` dispatch, JSON response shaping, and error handling for `/__vinext/prerender/*`. That violates the intended boundary: codegen should describe the app shape; normal modules should implement behavior.

This keeps route-specific app data in codegen while moving the runtime behavior into a typed module that can be tested without generating or executing the full entry.

## Next.js references

- Next.js records app static path results from build workers as `workerResult.prerenderedRoutes`: [`packages/next/src/build/index.ts#L2384-L2408`](https://github.com/vercel/next.js/blob/e1bb911c14e4ea3c6bb8cc98871ffdee317d513f/packages/next/src/build/index.ts#L2384-L2408)
- Next.js production serving reads static path/fallback data from the prerender manifest: [`packages/next/src/server/base-server.ts#L1949-L1971`](https://github.com/vercel/next.js/blob/e1bb911c14e4ea3c6bb8cc98871ffdee317d513f/packages/next/src/server/base-server.ts#L1949-L1971)
- Next.js dev serving invokes dynamic static path resolution through the server runtime flow: [`packages/next/src/server/base-server.ts#L2351-L2367`](https://github.com/vercel/next.js/blob/e1bb911c14e4ea3c6bb8cc98871ffdee317d513f/packages/next/src/server/base-server.ts#L2351-L2367)
- Pages Router templates hoist `getStaticPaths` from userland into route modules: [`packages/next/src/build/templates/pages.ts#L17-L23`](https://github.com/vercel/next.js/blob/e1bb911c14e4ea3c6bb8cc98871ffdee317d513f/packages/next/src/build/templates/pages.ts#L17-L23)
- App page runtime consumes build-time fallback route params from prerender metadata: [`packages/next/src/build/templates/app-page.ts#L1108-L1124`](https://github.com/vercel/next.js/blob/e1bb911c14e4ea3c6bb8cc98871ffdee317d513f/packages/next/src/build/templates/app-page.ts#L1108-L1124)

## Validation

- `vp test run tests/app-prerender-endpoints.test.ts tests/entry-templates.test.ts tests/prerender.test.ts`
- `vp check`
- `vp run vinext#build`
