### PR TITLE
refactor: extract app rsc manifest construction

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -7,7 +7,7 @@
  *
  * Previously housed in server/app-dev-server.ts.
  */
-import fs from "node:fs";
+import { buildAppRscManifestCode } from "./app-rsc-manifest.js";
 import { resolveEntryPath } from "./runtime-entry-module.js";
 import type {
   NextHeader,
@@ -151,207 +151,18 @@ export function generateRscEntry(
   const i18nConfig = config?.i18n ?? null;
   const hasPagesDir = config?.hasPagesDir ?? false;
   const publicFiles = config?.publicFiles ?? [];
-  // Build import map for all page and layout files
-  const imports: string[] = [];
-  const importMap: Map<string, string> = new Map();
-  let importIdx = 0;
-
-  function getImportVar(filePath: string): string {
-    if (importMap.has(filePath)) return importMap.get(filePath)!;
-    const varName = `mod_${importIdx++}`;
-    const absPath = filePath.replace(/\\/g, "/");
-    imports.push(`import * as ${varName} from ${JSON.stringify(absPath)};`);
-    importMap.set(filePath, varName);
-    return varName;
-  }
-
-  // Pre-register all modules
-  for (const route of routes) {
-    if (route.pagePath) getImportVar(route.pagePath);
-    if (route.routePath) getImportVar(route.routePath);
-    for (const layout of route.layouts) getImportVar(layout);
-    for (const tmpl of route.templates) getImportVar(tmpl);
-    if (route.loadingPath) getImportVar(route.loadingPath);
-    if (route.errorPath) getImportVar(route.errorPath);
-    if (route.layoutErrorPaths) {
-      for (const ep of route.layoutErrorPaths) {
-        if (ep) getImportVar(ep);
-      }
-    }
-    if (route.notFoundPath) getImportVar(route.notFoundPath);
-    for (const nfp of route.notFoundPaths || []) {
-      if (nfp) getImportVar(nfp);
-    }
-    if (route.forbiddenPath) getImportVar(route.forbiddenPath);
-    for (const fp of route.forbiddenPaths || []) {
-      if (fp) getImportVar(fp);
-    }
-    if (route.unauthorizedPath) getImportVar(route.unauthorizedPath);
-    for (const up of route.unauthorizedPaths || []) {
-      if (up) getImportVar(up);
-    }
-    // Register parallel slot modules
-    for (const slot of route.parallelSlots) {
-      if (slot.pagePath) getImportVar(slot.pagePath);
-      if (slot.defaultPath) getImportVar(slot.defaultPath);
-      if (slot.layoutPath) getImportVar(slot.layoutPath);
-      if (slot.loadingPath) getImportVar(slot.loadingPath);
-      if (slot.errorPath) getImportVar(slot.errorPath);
-      // Register intercepting route modules
-      for (const ir of slot.interceptingRoutes) {
-        getImportVar(ir.pagePath);
-        for (const layoutPath of ir.layoutPaths) {
-          getImportVar(layoutPath);
-        }
-      }
-    }
-  }
-
-  // Build route table as serialized JS
-  const routeEntries = routes.map((route, routeIdx) => {
-    const layoutVars = route.layouts.map((l) => getImportVar(l));
-    const templateVars = route.templates.map((t) => getImportVar(t));
-    const notFoundVars = (route.notFoundPaths || []).map((nf) => (nf ? getImportVar(nf) : "null"));
-    const forbiddenVars = (route.forbiddenPaths || []).map((fp) =>
-      fp ? getImportVar(fp) : "null",
-    );
-    const unauthorizedVars = (route.unauthorizedPaths || []).map((up) =>
-      up ? getImportVar(up) : "null",
-    );
-    const slotEntries = route.parallelSlots.map((slot) => {
-      const interceptEntries = slot.interceptingRoutes.map(
-        (ir) => `        {
-          convention: ${JSON.stringify(ir.convention)},
-          targetPattern: ${JSON.stringify(ir.targetPattern)},
-          interceptLayouts: [${ir.layoutPaths.map((layoutPath) => getImportVar(layoutPath)).join(", ")}],
-          page: ${getImportVar(ir.pagePath)},
-          params: ${JSON.stringify(ir.params)},
-        }`,
-      );
-      return `      ${JSON.stringify(slot.key)}: {
-        name: ${JSON.stringify(slot.name)},
-        page: ${slot.pagePath ? getImportVar(slot.pagePath) : "null"},
-        default: ${slot.defaultPath ? getImportVar(slot.defaultPath) : "null"},
-        layout: ${slot.layoutPath ? getImportVar(slot.layoutPath) : "null"},
-        loading: ${slot.loadingPath ? getImportVar(slot.loadingPath) : "null"},
-        error: ${slot.errorPath ? getImportVar(slot.errorPath) : "null"},
-        layoutIndex: ${slot.layoutIndex},
-        routeSegments: ${JSON.stringify(slot.routeSegments)},
-        intercepts: [
-${interceptEntries.join(",\n")}
-        ],
-      }`;
-    });
-    const layoutErrorVars = (route.layoutErrorPaths || []).map((ep) =>
-      ep ? getImportVar(ep) : "null",
-    );
-    return `  {
-    __buildTimeClassifications: __VINEXT_CLASS(${routeIdx}), // evaluated once at module load
-    __buildTimeReasons: __classDebug ? __VINEXT_CLASS_REASONS(${routeIdx}) : null,
-    pattern: ${JSON.stringify(route.pattern)},
-    patternParts: ${JSON.stringify(route.patternParts)},
-    isDynamic: ${route.isDynamic},
-    params: ${JSON.stringify(route.params)},
-    rootParamNames: ${JSON.stringify(route.rootParamNames ?? [])},
-    page: ${route.pagePath ? getImportVar(route.pagePath) : "null"},
-    routeHandler: ${route.routePath ? getImportVar(route.routePath) : "null"},
-    layouts: [${layoutVars.join(", ")}],
-    routeSegments: ${JSON.stringify(route.routeSegments)},
-    templateTreePositions: ${JSON.stringify(route.templateTreePositions)},
-    layoutTreePositions: ${JSON.stringify(route.layoutTreePositions)},
-    templates: [${templateVars.join(", ")}],
-    errors: [${layoutErrorVars.join(", ")}],
-    slots: {
-${slotEntries.join(",\n")}
-    },
-    loading: ${route.loadingPath ? getImportVar(route.loadingPath) : "null"},
-    error: ${route.errorPath ? getImportVar(route.errorPath) : "null"},
-    notFound: ${route.notFoundPath ? getImportVar(route.notFoundPath) : "null"},
-    notFounds: [${notFoundVars.join(", ")}],
-    forbidden: ${route.forbiddenPath ? getImportVar(route.forbiddenPath) : "null"},
-    forbiddens: [${forbiddenVars.join(", ")}],
-    unauthorized: ${route.unauthorizedPath ? getImportVar(route.unauthorizedPath) : "null"},
-    unauthorizeds: [${unauthorizedVars.join(", ")}],
-  }`;
-  });
-
-  // Find root not-found/forbidden/unauthorized pages and root layouts for global error handling
-  const rootRoute = routes.find((r) => r.pattern === "/");
-  const rootNotFoundVar = rootRoute?.notFoundPath ? getImportVar(rootRoute.notFoundPath) : null;
-  const rootForbiddenVar = rootRoute?.forbiddenPath ? getImportVar(rootRoute.forbiddenPath) : null;
-  const rootUnauthorizedVar = rootRoute?.unauthorizedPath
-    ? getImportVar(rootRoute.unauthorizedPath)
-    : null;
-  const rootLayoutVars = rootRoute ? rootRoute.layouts.map((l) => getImportVar(l)) : [];
-
-  // Global error boundary (app/global-error.tsx)
-  const globalErrorVar = globalErrorPath ? getImportVar(globalErrorPath) : null;
-
-  // Build metadata route handling
-  const effectiveMetaRoutes = metadataRoutes ?? [];
-  const dynamicMetaRoutes = effectiveMetaRoutes.filter((r) => r.isDynamic);
-
-  // Import dynamic metadata modules
-  for (const mr of dynamicMetaRoutes) {
-    getImportVar(mr.filePath);
-  }
-
-  // Build metadata route table
-  // For static metadata files, read the file content at code-generation time
-  // and embed it as base64. This ensures static metadata files work on runtimes
-  // without filesystem access (e.g., Cloudflare Workers).
-  //
-  // For metadata routes in dynamic segments (e.g., /blog/[slug]/opengraph-image),
-  // generate patternParts so the runtime can use shared route-pattern matching
-  // instead of strict equality — the same matching used for intercept routes.
-  const metaRouteEntries = effectiveMetaRoutes.map((mr) => {
-    // Convert dynamic segments in servedUrl to the shared route-pattern format.
-    // Keep in sync with routing/app-router.ts patternParts generation.
-    //   [param]       → :param
-    //   [...param]    → :param+
-    //   [[...param]]  → :param*
-    const patternParts =
-      mr.isDynamic && mr.servedUrl.includes("[")
-        ? JSON.stringify(
-            mr.servedUrl
-              .split("/")
-              .filter(Boolean)
-              .map((seg) => {
-                if (seg.startsWith("[[...") && seg.endsWith("]]"))
-                  return ":" + seg.slice(5, -2) + "*";
-                if (seg.startsWith("[...") && seg.endsWith("]"))
-                  return ":" + seg.slice(4, -1) + "+";
-                if (seg.startsWith("[") && seg.endsWith("]")) return ":" + seg.slice(1, -1);
-                return seg;
-              }),
-          )
-        : null;
-
-    if (mr.isDynamic) {
-      return `  {
-    type: ${JSON.stringify(mr.type)},
-    isDynamic: true,
-    servedUrl: ${JSON.stringify(mr.servedUrl)},
-    contentType: ${JSON.stringify(mr.contentType)},
-    module: ${getImportVar(mr.filePath)},${patternParts ? `\n    patternParts: ${patternParts},` : ""}
-  }`;
-    }
-    // Static: read file and embed as base64
-    let fileDataBase64 = "";
-    try {
-      const buf = fs.readFileSync(mr.filePath);
-      fileDataBase64 = buf.toString("base64");
-    } catch {
-      // File unreadable — will serve empty response at runtime
-    }
-    return `  {
-    type: ${JSON.stringify(mr.type)},
-    isDynamic: false,
-    servedUrl: ${JSON.stringify(mr.servedUrl)},
-    contentType: ${JSON.stringify(mr.contentType)},
-    fileDataBase64: ${JSON.stringify(fileDataBase64)},
-  }`;
-  });
+  const manifestCode = buildAppRscManifestCode({ routes, metadataRoutes, globalErrorPath });
+  const {
+    imports,
+    routeEntries,
+    metaRouteEntries,
+    generateStaticParamsEntries,
+    rootNotFoundVar,
+    rootForbiddenVar,
+    rootUnauthorizedVar,
+    rootLayoutVars,
+    globalErrorVar,
+  } = manifestCode;
 
   return `
 import {
@@ -376,7 +187,7 @@ import { setHeadersContext, headersContextFromRequest, getDraftModeCookieHeader,
 import { mergeMetadata, resolveModuleMetadata, mergeViewport, resolveModuleViewport } from "vinext/metadata";
 ${middlewarePath ? `import * as middlewareModule from ${JSON.stringify(middlewarePath.replace(/\\/g, "/"))};` : ""}
 ${instrumentationPath ? `import * as _instrumentation from ${JSON.stringify(instrumentationPath.replace(/\\/g, "/"))};` : ""}
-${effectiveMetaRoutes.length > 0 ? `import { sitemapToXml, robotsToText, manifestToJson } from ${JSON.stringify(metadataRoutesPath)};` : ""}
+${metaRouteEntries.length > 0 ? `import { sitemapToXml, robotsToText, manifestToJson } from ${JSON.stringify(metadataRoutesPath)};` : ""}
 import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, matchHeaders, isExternalUrl, proxyExternalRequest, sanitizeDestination } from ${JSON.stringify(configMatchersPath)};
 import { decodePathParams as __decodePathParams, normalizePath as __normalizePath } from ${JSON.stringify(normalizePathModulePath)};
 import { normalizePathnameForRouteMatch as __normalizePathnameForRouteMatch, normalizePathnameForRouteMatchStrict as __normalizePathnameForRouteMatchStrict } from ${JSON.stringify(routingUtilsPath)};
@@ -1138,13 +949,7 @@ export const generateStaticParamsMap = {
 // to provide parent params for nested dynamic routes, but they don't have a pagePath
 // so they are excluded here. Supporting layout-level generateStaticParams requires
 // scanning layout.tsx files separately and including them in this map.
-${routes
-  .filter((r) => r.isDynamic && r.pagePath)
-  .map(
-    (r) =>
-      `  ${JSON.stringify(r.pattern)}: ${getImportVar(r.pagePath!)}?.generateStaticParams ?? null,`,
-  )
-  .join("\n")}
+${generateStaticParamsEntries.join("\n")}
 };
 
 export default async function handler(request, ctx) {

--- a/packages/vinext/src/entries/app-rsc-manifest.ts
+++ b/packages/vinext/src/entries/app-rsc-manifest.ts
@@ -1,0 +1,264 @@
+import fs from "node:fs";
+import type { AppRoute } from "../routing/app-router.js";
+import type { MetadataFileRoute } from "../server/metadata-routes.js";
+
+type AppRscManifestCode = {
+  imports: string[];
+  routeEntries: string[];
+  metaRouteEntries: string[];
+  generateStaticParamsEntries: string[];
+  rootNotFoundVar: string | null;
+  rootForbiddenVar: string | null;
+  rootUnauthorizedVar: string | null;
+  rootLayoutVars: string[];
+  globalErrorVar: string | null;
+};
+
+type BuildAppRscManifestCodeOptions = {
+  routes: AppRoute[];
+  metadataRoutes?: MetadataFileRoute[];
+  globalErrorPath?: string | null;
+};
+
+type ImportAllocator = {
+  getImportVar(filePath: string): string;
+  imports: string[];
+};
+
+function createImportAllocator(): ImportAllocator {
+  const imports: string[] = [];
+  const importMap = new Map<string, string>();
+  let importIdx = 0;
+
+  return {
+    imports,
+    getImportVar(filePath) {
+      const existing = importMap.get(filePath);
+      if (existing) return existing;
+
+      const varName = `mod_${importIdx++}`;
+      const absPath = filePath.replace(/\\/g, "/");
+      imports.push(`import * as ${varName} from ${JSON.stringify(absPath)};`);
+      importMap.set(filePath, varName);
+      return varName;
+    },
+  };
+}
+
+function registerRouteModules(routes: AppRoute[], imports: ImportAllocator): void {
+  for (const route of routes) {
+    if (route.pagePath) imports.getImportVar(route.pagePath);
+    if (route.routePath) imports.getImportVar(route.routePath);
+    for (const layout of route.layouts) imports.getImportVar(layout);
+    for (const tmpl of route.templates) imports.getImportVar(tmpl);
+    if (route.loadingPath) imports.getImportVar(route.loadingPath);
+    if (route.errorPath) imports.getImportVar(route.errorPath);
+    if (route.layoutErrorPaths) {
+      for (const ep of route.layoutErrorPaths) {
+        if (ep) imports.getImportVar(ep);
+      }
+    }
+    if (route.notFoundPath) imports.getImportVar(route.notFoundPath);
+    for (const nfp of route.notFoundPaths || []) {
+      if (nfp) imports.getImportVar(nfp);
+    }
+    if (route.forbiddenPath) imports.getImportVar(route.forbiddenPath);
+    for (const fp of route.forbiddenPaths || []) {
+      if (fp) imports.getImportVar(fp);
+    }
+    if (route.unauthorizedPath) imports.getImportVar(route.unauthorizedPath);
+    for (const up of route.unauthorizedPaths || []) {
+      if (up) imports.getImportVar(up);
+    }
+    for (const slot of route.parallelSlots) {
+      if (slot.pagePath) imports.getImportVar(slot.pagePath);
+      if (slot.defaultPath) imports.getImportVar(slot.defaultPath);
+      if (slot.layoutPath) imports.getImportVar(slot.layoutPath);
+      if (slot.loadingPath) imports.getImportVar(slot.loadingPath);
+      if (slot.errorPath) imports.getImportVar(slot.errorPath);
+      for (const ir of slot.interceptingRoutes) {
+        imports.getImportVar(ir.pagePath);
+        for (const layoutPath of ir.layoutPaths) {
+          imports.getImportVar(layoutPath);
+        }
+      }
+    }
+  }
+}
+
+function buildRouteEntries(routes: AppRoute[], imports: ImportAllocator): string[] {
+  return routes.map((route, routeIdx) => {
+    const layoutVars = route.layouts.map((l) => imports.getImportVar(l));
+    const templateVars = route.templates.map((t) => imports.getImportVar(t));
+    const notFoundVars = (route.notFoundPaths || []).map((nf) =>
+      nf ? imports.getImportVar(nf) : "null",
+    );
+    const forbiddenVars = (route.forbiddenPaths || []).map((fp) =>
+      fp ? imports.getImportVar(fp) : "null",
+    );
+    const unauthorizedVars = (route.unauthorizedPaths || []).map((up) =>
+      up ? imports.getImportVar(up) : "null",
+    );
+    const slotEntries = route.parallelSlots.map((slot) => {
+      const interceptEntries = slot.interceptingRoutes.map(
+        (ir) => `        {
+          convention: ${JSON.stringify(ir.convention)},
+          targetPattern: ${JSON.stringify(ir.targetPattern)},
+          interceptLayouts: [${ir.layoutPaths.map((layoutPath) => imports.getImportVar(layoutPath)).join(", ")}],
+          page: ${imports.getImportVar(ir.pagePath)},
+          params: ${JSON.stringify(ir.params)},
+        }`,
+      );
+      return `      ${JSON.stringify(slot.key)}: {
+        name: ${JSON.stringify(slot.name)},
+        page: ${slot.pagePath ? imports.getImportVar(slot.pagePath) : "null"},
+        default: ${slot.defaultPath ? imports.getImportVar(slot.defaultPath) : "null"},
+        layout: ${slot.layoutPath ? imports.getImportVar(slot.layoutPath) : "null"},
+        loading: ${slot.loadingPath ? imports.getImportVar(slot.loadingPath) : "null"},
+        error: ${slot.errorPath ? imports.getImportVar(slot.errorPath) : "null"},
+        layoutIndex: ${slot.layoutIndex},
+        routeSegments: ${JSON.stringify(slot.routeSegments)},
+        intercepts: [
+${interceptEntries.join(",\n")}
+        ],
+      }`;
+    });
+    const layoutErrorVars = (route.layoutErrorPaths || []).map((ep) =>
+      ep ? imports.getImportVar(ep) : "null",
+    );
+    return `  {
+    __buildTimeClassifications: __VINEXT_CLASS(${routeIdx}), // evaluated once at module load
+    __buildTimeReasons: __classDebug ? __VINEXT_CLASS_REASONS(${routeIdx}) : null,
+    pattern: ${JSON.stringify(route.pattern)},
+    patternParts: ${JSON.stringify(route.patternParts)},
+    isDynamic: ${route.isDynamic},
+    params: ${JSON.stringify(route.params)},
+    rootParamNames: ${JSON.stringify(route.rootParamNames ?? [])},
+    page: ${route.pagePath ? imports.getImportVar(route.pagePath) : "null"},
+    routeHandler: ${route.routePath ? imports.getImportVar(route.routePath) : "null"},
+    layouts: [${layoutVars.join(", ")}],
+    routeSegments: ${JSON.stringify(route.routeSegments)},
+    templateTreePositions: ${JSON.stringify(route.templateTreePositions)},
+    layoutTreePositions: ${JSON.stringify(route.layoutTreePositions)},
+    templates: [${templateVars.join(", ")}],
+    errors: [${layoutErrorVars.join(", ")}],
+    slots: {
+${slotEntries.join(",\n")}
+    },
+    loading: ${route.loadingPath ? imports.getImportVar(route.loadingPath) : "null"},
+    error: ${route.errorPath ? imports.getImportVar(route.errorPath) : "null"},
+    notFound: ${route.notFoundPath ? imports.getImportVar(route.notFoundPath) : "null"},
+    notFounds: [${notFoundVars.join(", ")}],
+    forbidden: ${route.forbiddenPath ? imports.getImportVar(route.forbiddenPath) : "null"},
+    forbiddens: [${forbiddenVars.join(", ")}],
+    unauthorized: ${route.unauthorizedPath ? imports.getImportVar(route.unauthorizedPath) : "null"},
+    unauthorizeds: [${unauthorizedVars.join(", ")}],
+  }`;
+  });
+}
+
+function buildMetadataPatternParts(route: MetadataFileRoute): string | null {
+  if (!route.isDynamic || !route.servedUrl.includes("[")) return null;
+
+  return JSON.stringify(
+    route.servedUrl
+      .split("/")
+      .filter(Boolean)
+      .map((seg) => {
+        if (seg.startsWith("[[...") && seg.endsWith("]]")) return ":" + seg.slice(5, -2) + "*";
+        if (seg.startsWith("[...") && seg.endsWith("]")) return ":" + seg.slice(4, -1) + "+";
+        if (seg.startsWith("[") && seg.endsWith("]")) return ":" + seg.slice(1, -1);
+        return seg;
+      }),
+  );
+}
+
+function readStaticMetadataFileBase64(route: MetadataFileRoute): string {
+  try {
+    return fs.readFileSync(route.filePath).toString("base64");
+  } catch (error) {
+    throw new Error(`[vinext] Failed to read static metadata route file: ${route.filePath}`, {
+      cause: error,
+    });
+  }
+}
+
+function buildMetadataRouteEntries(
+  metadataRoutes: MetadataFileRoute[],
+  imports: ImportAllocator,
+): string[] {
+  return metadataRoutes.map((mr) => {
+    const patternParts = buildMetadataPatternParts(mr);
+
+    if (mr.isDynamic) {
+      return `  {
+    type: ${JSON.stringify(mr.type)},
+    isDynamic: true,
+    servedUrl: ${JSON.stringify(mr.servedUrl)},
+    contentType: ${JSON.stringify(mr.contentType)},
+    module: ${imports.getImportVar(mr.filePath)},${patternParts ? `\n    patternParts: ${patternParts},` : ""}
+  }`;
+    }
+
+    return `  {
+    type: ${JSON.stringify(mr.type)},
+    isDynamic: false,
+    servedUrl: ${JSON.stringify(mr.servedUrl)},
+    contentType: ${JSON.stringify(mr.contentType)},
+    fileDataBase64: ${JSON.stringify(readStaticMetadataFileBase64(mr))},
+  }`;
+  });
+}
+
+function buildGenerateStaticParamsEntries(routes: AppRoute[], imports: ImportAllocator): string[] {
+  const entries: string[] = [];
+  for (const route of routes) {
+    if (!route.isDynamic || !route.pagePath) continue;
+    entries.push(
+      `  ${JSON.stringify(route.pattern)}: ${imports.getImportVar(route.pagePath)}?.generateStaticParams ?? null,`,
+    );
+  }
+  return entries;
+}
+
+export function buildAppRscManifestCode(
+  options: BuildAppRscManifestCodeOptions,
+): AppRscManifestCode {
+  const imports = createImportAllocator();
+  const metadataRoutes = options.metadataRoutes ?? [];
+
+  registerRouteModules(options.routes, imports);
+  const routeEntries = buildRouteEntries(options.routes, imports);
+
+  const rootRoute = options.routes.find((r) => r.pattern === "/");
+  const rootNotFoundVar = rootRoute?.notFoundPath
+    ? imports.getImportVar(rootRoute.notFoundPath)
+    : null;
+  const rootForbiddenVar = rootRoute?.forbiddenPath
+    ? imports.getImportVar(rootRoute.forbiddenPath)
+    : null;
+  const rootUnauthorizedVar = rootRoute?.unauthorizedPath
+    ? imports.getImportVar(rootRoute.unauthorizedPath)
+    : null;
+  const rootLayoutVars = rootRoute ? rootRoute.layouts.map((l) => imports.getImportVar(l)) : [];
+  const globalErrorVar = options.globalErrorPath
+    ? imports.getImportVar(options.globalErrorPath)
+    : null;
+
+  const dynamicMetadataRoutes = metadataRoutes.filter((r) => r.isDynamic);
+  for (const route of dynamicMetadataRoutes) {
+    imports.getImportVar(route.filePath);
+  }
+
+  return {
+    imports: imports.imports,
+    routeEntries,
+    metaRouteEntries: buildMetadataRouteEntries(metadataRoutes, imports),
+    generateStaticParamsEntries: buildGenerateStaticParamsEntries(options.routes, imports),
+    rootNotFoundVar,
+    rootForbiddenVar,
+    rootUnauthorizedVar,
+    rootLayoutVars,
+    globalErrorVar,
+  };
+}

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -10,8 +10,11 @@
  *   Vite's pluginContainer.load() on the virtual module IDs.
  */
 import path from "node:path";
+import fs from "node:fs";
+import os from "node:os";
 import { describe, it, expect, afterAll } from "vite-plus/test";
 import { createServer, type ViteDevServer } from "vite-plus";
+import { buildAppRscManifestCode } from "../packages/vinext/src/entries/app-rsc-manifest.js";
 import { generateRscEntry } from "../packages/vinext/src/entries/app-rsc-entry.js";
 import type { AppRouterConfig } from "../packages/vinext/src/entries/app-rsc-entry.js";
 import { generateSsrEntry } from "../packages/vinext/src/entries/app-ssr-entry.js";
@@ -123,6 +126,175 @@ const minimalAppRoutes: AppRoute[] = [
 // Pages Router snapshots below. Run `pnpm test tests/entry-templates.test.ts -u`
 // to update them after intentional fixture changes.
 const PAGES_FIXTURE_DIR = path.resolve(import.meta.dirname, "./fixtures/pages-basic");
+
+// ── App Router manifest construction ─────────────────────────────────
+
+describe("App Router generated manifest construction", () => {
+  it("constructs route module imports and route entries from the scanned app shape", () => {
+    const routes = [
+      {
+        pattern: "/",
+        patternParts: [],
+        pagePath: "/tmp/test/app/page.tsx",
+        routePath: null,
+        layouts: ["/tmp/test/app/layout.tsx"],
+        templates: [],
+        parallelSlots: [],
+        loadingPath: null,
+        errorPath: null,
+        layoutErrorPaths: [null],
+        notFoundPath: "/tmp/test/app/not-found.tsx",
+        notFoundPaths: ["/tmp/test/app/not-found.tsx"],
+        forbiddenPath: "/tmp/test/app/forbidden.tsx",
+        forbiddenPaths: ["/tmp/test/app/forbidden.tsx"],
+        unauthorizedPath: "/tmp/test/app/unauthorized.tsx",
+        unauthorizedPaths: ["/tmp/test/app/unauthorized.tsx"],
+        routeSegments: [],
+        templateTreePositions: [],
+        layoutTreePositions: [0],
+        isDynamic: false,
+        params: [],
+      },
+      {
+        pattern: "/dashboard/:id",
+        patternParts: ["dashboard", ":id"],
+        pagePath: "/tmp/test/app/dashboard/[id]/page.tsx",
+        routePath: "/tmp/test/app/dashboard/[id]/route.ts",
+        layouts: ["/tmp/test/app/layout.tsx", "/tmp/test/app/dashboard/layout.tsx"],
+        templates: ["/tmp/test/app/dashboard/template.tsx"],
+        parallelSlots: [
+          {
+            key: "modal:/tmp/test/app/dashboard/@modal",
+            name: "modal",
+            ownerDir: "/tmp/test/app/dashboard/@modal",
+            pagePath: "/tmp/test/app/dashboard/@modal/page.tsx",
+            defaultPath: "/tmp/test/app/dashboard/@modal/default.tsx",
+            layoutPath: "/tmp/test/app/dashboard/@modal/layout.tsx",
+            loadingPath: "/tmp/test/app/dashboard/@modal/loading.tsx",
+            errorPath: "/tmp/test/app/dashboard/@modal/error.tsx",
+            interceptingRoutes: [
+              {
+                convention: ".",
+                targetPattern: "/photos/:photoId",
+                pagePath: "/tmp/test/app/dashboard/@modal/(.)photos/[photoId]/page.tsx",
+                layoutPaths: ["/tmp/test/app/dashboard/@modal/(.)photos/layout.tsx"],
+                params: ["photoId"],
+              },
+            ],
+            layoutIndex: 1,
+            routeSegments: ["@modal"],
+          },
+        ],
+        loadingPath: "/tmp/test/app/dashboard/loading.tsx",
+        errorPath: "/tmp/test/app/dashboard/error.tsx",
+        layoutErrorPaths: [null, "/tmp/test/app/dashboard/error.tsx"],
+        notFoundPath: "/tmp/test/app/dashboard/not-found.tsx",
+        notFoundPaths: ["/tmp/test/app/not-found.tsx", "/tmp/test/app/dashboard/not-found.tsx"],
+        forbiddenPath: null,
+        forbiddenPaths: ["/tmp/test/app/forbidden.tsx", null],
+        unauthorizedPath: null,
+        unauthorizedPaths: ["/tmp/test/app/unauthorized.tsx", null],
+        routeSegments: ["dashboard", "[id]"],
+        templateTreePositions: [1],
+        layoutTreePositions: [0, 1],
+        isDynamic: true,
+        params: ["id"],
+        rootParamNames: ["id"],
+      },
+    ] satisfies AppRoute[];
+
+    const manifest = buildAppRscManifestCode({
+      routes,
+      metadataRoutes: [],
+      globalErrorPath: "/tmp/test/app/global-error.tsx",
+    });
+
+    const imports = manifest.imports.join("\n");
+    expect(imports.match(/\/tmp\/test\/app\/layout\.tsx/g)).toHaveLength(1);
+    expect(imports).toContain('import * as mod_0 from "/tmp/test/app/page.tsx";');
+    expect(imports).toContain(
+      'import * as mod_17 from "/tmp/test/app/dashboard/@modal/(.)photos/[photoId]/page.tsx";',
+    );
+    expect(imports).toContain('import * as mod_19 from "/tmp/test/app/global-error.tsx";');
+
+    expect(manifest.rootNotFoundVar).toBe("mod_2");
+    expect(manifest.rootForbiddenVar).toBe("mod_3");
+    expect(manifest.rootUnauthorizedVar).toBe("mod_4");
+    expect(manifest.rootLayoutVars).toEqual(["mod_1"]);
+    expect(manifest.globalErrorVar).toBe("mod_19");
+
+    const dynamicRouteEntry = manifest.routeEntries[1];
+    expect(dynamicRouteEntry).toContain('pattern: "/dashboard/:id"');
+    expect(dynamicRouteEntry).toContain("routeHandler: mod_6");
+    expect(dynamicRouteEntry).toContain("layouts: [mod_1, mod_7]");
+    expect(dynamicRouteEntry).toContain('"modal:/tmp/test/app/dashboard/@modal": {');
+    expect(dynamicRouteEntry).toContain("interceptLayouts: [mod_18]");
+    expect(dynamicRouteEntry).toContain("page: mod_17");
+    expect(dynamicRouteEntry).toContain('params: ["photoId"]');
+    expect(manifest.generateStaticParamsEntries).toEqual([
+      '  "/dashboard/:id": mod_5?.generateStaticParams ?? null,',
+    ]);
+  });
+
+  it("embeds static metadata files and imports dynamic metadata modules", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-app-rsc-manifest-"));
+    try {
+      const staticManifestPath = path.join(tmpDir, "manifest.webmanifest");
+      fs.writeFileSync(staticManifestPath, '{"name":"Vinext"}');
+
+      const manifest = buildAppRscManifestCode({
+        routes: minimalAppRoutes,
+        metadataRoutes: [
+          {
+            type: "manifest",
+            isDynamic: false,
+            filePath: staticManifestPath,
+            servedUrl: "/manifest.webmanifest",
+            contentType: "application/manifest+json",
+          },
+          {
+            type: "opengraph-image",
+            isDynamic: true,
+            filePath: "/tmp/test/app/blog/[slug]/opengraph-image.tsx",
+            servedUrl: "/blog/[slug]/opengraph-image",
+            contentType: "image/png",
+          },
+        ],
+        globalErrorPath: null,
+      });
+
+      const entries = manifest.metaRouteEntries.join("\n");
+      expect(entries).toContain(
+        `fileDataBase64: ${JSON.stringify(Buffer.from('{"name":"Vinext"}').toString("base64"))}`,
+      );
+      expect(entries).toContain("module: mod_11");
+      expect(manifest.imports).toContain(
+        'import * as mod_11 from "/tmp/test/app/blog/[slug]/opengraph-image.tsx";',
+      );
+      expect(entries).toContain('patternParts: ["blog",":slug","opengraph-image"]');
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("throws a build-time error when a discovered static metadata file cannot be read", () => {
+    expect(() =>
+      buildAppRscManifestCode({
+        routes: minimalAppRoutes,
+        metadataRoutes: [
+          {
+            type: "manifest",
+            isDynamic: false,
+            filePath: "/tmp/test/app/missing-manifest.webmanifest",
+            servedUrl: "/manifest.webmanifest",
+            contentType: "application/manifest+json",
+          },
+        ],
+        globalErrorPath: null,
+      }),
+    ).toThrow("[vinext] Failed to read static metadata route file");
+  });
+});
 
 // ── App Router entry templates ────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Extracts the App Router RSC generated-manifest construction out of `generateRscEntry()` into `app-rsc-manifest.ts`.

The generator now treats the app shape as an explicit construction boundary:

- route module import allocation
- route entry serialization
- root fallback/global-error module references
- metadata route entries
- `generateStaticParams` map entries

`generateRscEntry()` keeps request/runtime codegen ownership and consumes the manifest-construction result.

## Why

`app-rsc-entry.ts` had accumulated app-shape responsibilities inside the top-level RSC entry generator. That made the generated runtime path harder to review because file-system route shape, module import allocation, metadata route handling, and request lifecycle code all lived in one function.

This mirrors the separation Next.js keeps between its generated App Router tree shape and the runtime route module that consumes it:

- Next.js app-page template receives an injected `tree` and passes it as `userland.loaderTree`: [packages/next/src/build/templates/app-page.ts](https://github.com/vercel/next.js/blob/e1bb911c14e4ea3c6bb8cc98871ffdee317d513f/packages/next/src/build/templates/app-page.ts#L100-L138)
- Next.js `LoaderTree` makes segment modules and parallel routes explicit: [packages/next/src/server/lib/app-dir-module.ts](https://github.com/vercel/next.js/blob/e1bb911c14e4ea3c6bb8cc98871ffdee317d513f/packages/next/src/server/lib/app-dir-module.ts#L6-L28)
- Next.js parses loader-tree shape through a dedicated helper: [packages/next/src/shared/lib/router/utils/parse-loader-tree.ts](https://github.com/vercel/next.js/blob/e1bb911c14e4ea3c6bb8cc98871ffdee317d513f/packages/next/src/shared/lib/router/utils/parse-loader-tree.ts#L4-L20)
- Build-time static path logic traverses that tree, including parallel routes: [packages/next/src/build/static-paths/utils.ts](https://github.com/vercel/next.js/blob/e1bb911c14e4ea3c6bb8cc98871ffdee317d513f/packages/next/src/build/static-paths/utils.ts#L113-L193)

Vinext still uses its own scanned `AppRoute` model, but this PR makes the equivalent app-shape-to-generated-manifest step explicit and testable.

## Notes

Static metadata files are now read through the extracted manifest helper. If a discovered static metadata file cannot be read, the helper throws a build-time error with the file path instead of generating an empty runtime response.

## Tests

- `vp test run tests/entry-templates.test.ts`
- `vp check`
- `vp run vinext#build`
- commit hook: `vp check --fix`, `knip --no-progress`