### PR TITLE
refactor: extract server action RSC flow

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -381,7 +381,7 @@ import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, 
 import { decodePathParams as __decodePathParams, normalizePath as __normalizePath } from ${JSON.stringify(normalizePathModulePath)};
 import { normalizePathnameForRouteMatch as __normalizePathnameForRouteMatch, normalizePathnameForRouteMatchStrict as __normalizePathnameForRouteMatchStrict } from ${JSON.stringify(routingUtilsPath)};
 import { buildRequestHeadersFromMiddlewareResponse as __buildRequestHeadersFromMiddlewareResponse } from ${JSON.stringify(middlewareRequestHeadersPath)};
-import { validateCsrfOrigin, validateServerActionPayload, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash } from ${JSON.stringify(requestPipelinePath)};
+import { validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash } from ${JSON.stringify(requestPipelinePath)};
 import { applyAppMiddleware as __applyAppMiddleware } from ${JSON.stringify(appMiddlewarePath)};
 import {
   isKnownDynamicAppRoute as __isKnownDynamicAppRoute,
@@ -397,6 +397,7 @@ import {
 } from ${JSON.stringify(appRouteHandlerExecutionPath)};
 import {
   handleProgressiveServerActionRequest as __handleProgressiveServerActionRequest,
+  handleServerActionRscRequest as __handleServerActionRscRequest,
 } from ${JSON.stringify(appServerActionExecutionPath)};
 import { readAppRouteHandlerCacheResponse as __readAppRouteHandlerCacheResponse } from ${JSON.stringify(appRouteHandlerCachePath)};
 import { readAppPageCacheResponse as __readAppPageCacheResponse } from ${JSON.stringify(appPageCachePath)};
@@ -438,7 +439,6 @@ import {
 } from ${JSON.stringify(appPageResponsePath)};
 import { getScriptNonceFromHeaderSources as __getScriptNonceFromHeaderSources } from ${JSON.stringify(cspPath)};
 import {
-  resolveAppPageActionRerenderTarget as __resolveAppPageActionRerenderTarget,
   buildAppPageElement as __buildAppPageElement,
   resolveAppPageIntercept as __resolveAppPageIntercept,
   validateAppPageDynamicParams as __validateAppPageDynamicParams,
@@ -1541,227 +1541,90 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   });
   if (progressiveActionResponse) return progressiveActionResponse;
 
-  if (request.method === "POST" && actionId) {
-    // ── CSRF protection ─────────────────────────────────────────────────
-    // Verify that the Origin header matches the Host header to prevent
-    // cross-site request forgery, matching Next.js server action behavior.
-    const csrfResponse = validateCsrfOrigin(request, __allowedOrigins);
-    if (csrfResponse) return csrfResponse;
-
-    // ── Body size limit ─────────────────────────────────────────────────
-    // Reject payloads larger than the configured limit.
-    // Check Content-Length as a fast path, then enforce on the actual
-    // stream to prevent bypasses via chunked transfer-encoding.
-    const contentLength = parseInt(request.headers.get("content-length") || "0", 10);
-    if (contentLength > __MAX_ACTION_BODY_SIZE) {
-      __clearRequestContext();
-      return new Response("Payload Too Large", { status: 413 });
-    }
-
-    try {
-      let body;
-      try {
-        body = actionContentType.startsWith("multipart/form-data")
-          ? await __readFormDataWithLimit(request, __MAX_ACTION_BODY_SIZE)
-          : await __readBodyWithLimit(request, __MAX_ACTION_BODY_SIZE);
-      } catch (sizeErr) {
-        if (sizeErr && sizeErr.message === "Request body too large") {
-          __clearRequestContext();
-          return new Response("Payload Too Large", { status: 413 });
-        }
-        throw sizeErr;
-      }
-      const payloadResponse = await validateServerActionPayload(body);
-      if (payloadResponse) {
-        __clearRequestContext();
-        return payloadResponse;
-      }
-      const temporaryReferences = createTemporaryReferenceSet();
-      const args = await decodeReply(body, { temporaryReferences });
-      const action = await loadServerAction(actionId);
-      let returnValue;
-      let actionRedirect = null;
-      const previousHeadersPhase = setHeadersAccessPhase("action");
-      try {
-        try {
-          const data = await action.apply(null, args);
-          returnValue = { ok: true, data };
-        } catch (e) {
-          // Detect redirect() / permanentRedirect() called inside the action.
-          // These throw errors with digest "NEXT_REDIRECT;replace;url[;status]".
-          // The URL is encodeURIComponent-encoded to prevent semicolons in the URL
-          // from corrupting the delimiter-based digest format.
-          if (e && typeof e === "object" && "digest" in e) {
-            const digest = String(e.digest);
-            if (digest.startsWith("NEXT_REDIRECT;")) {
-              const parts = digest.split(";");
-              actionRedirect = {
-                url: decodeURIComponent(parts[2]),
-                type: parts[1] || "push",          // "push" or "replace"
-                status: parts[3] ? parseInt(parts[3], 10) : 307,
-              };
-              returnValue = { ok: true, data: undefined };
-            } else if (digest === "NEXT_NOT_FOUND" || digest.startsWith("NEXT_HTTP_ERROR_FALLBACK;")) {
-              // notFound() / forbidden() / unauthorized() in action — package as error
-              returnValue = { ok: false, data: e };
-            } else {
-              // Non-navigation digest error — sanitize in production to avoid
-              // leaking internal details (connection strings, paths, etc.)
-              console.error("[vinext] Server action error:", e);
-              returnValue = { ok: false, data: __sanitizeErrorForClient(e) };
-            }
-          } else {
-            // Unhandled error — sanitize in production to avoid leaking
-            // internal details (database errors, file paths, stack traces, etc.)
-            console.error("[vinext] Server action error:", e);
-            returnValue = { ok: false, data: __sanitizeErrorForClient(e) };
-          }
-        }
-      } finally {
-        setHeadersAccessPhase(previousHeadersPhase);
-      }
-
-      // If the action called redirect(), signal the client to navigate.
-      // We can't use a real HTTP redirect (the fetch would follow it automatically
-      // and receive a page HTML instead of RSC stream). Instead, we return a 200
-      // with x-action-redirect header that the client entry detects and handles.
-      if (actionRedirect) {
-        const actionPendingCookies = getAndClearPendingCookies();
-        const actionDraftCookie = getDraftModeCookieHeader();
-        __clearRequestContext();
-        const redirectHeaders = new Headers({
-          "Content-Type": "text/x-component; charset=utf-8",
-          "Vary": "RSC, Accept",
-        });
-        __mergeMiddlewareResponseHeaders(redirectHeaders, _mwCtx.headers);
-        redirectHeaders.set("x-action-redirect", actionRedirect.url);
-        redirectHeaders.set("x-action-redirect-type", actionRedirect.type);
-        redirectHeaders.set("x-action-redirect-status", String(actionRedirect.status));
-        for (const cookie of actionPendingCookies) {
-          redirectHeaders.append("Set-Cookie", cookie);
-        }
-        if (actionDraftCookie) redirectHeaders.append("Set-Cookie", actionDraftCookie);
-        // Send an empty RSC-like body (client will navigate instead of parsing)
-        return new Response("", { status: 200, headers: redirectHeaders });
-      }
-
-      // After the action, re-render the current page so the client
-      // gets an updated React tree reflecting any mutations.
-      //
-      // When the original request came from inside an intercepted modal
-      // (X-Vinext-Interception-Context present + source route still
-      // matches), rebuild the intercepted tree — otherwise the modal would
-      // unmount and the direct route would render in its place. Mirrors
-      // the interception resolution used by the GET path.
-      const match = matchRoute(cleanPathname);
-      let element;
-      let errorPattern = match ? match.route.pattern : cleanPathname;
-      if (match) {
-        const { route: actionRoute, params: actionParams } = match;
-        const __actionRerenderTarget = __resolveAppPageActionRerenderTarget({
-          cleanPathname,
-          currentParams: actionParams,
-          currentRoute: actionRoute,
-          findIntercept(pathname) {
-            return findIntercept(pathname, interceptionContextHeader);
-          },
-          getRouteParamNames(sourceRoute) {
-            return sourceRoute.params;
-          },
-          getSourceRoute(sourceRouteIndex) {
-            return routes[sourceRouteIndex];
-          },
-          isRscRequest,
-          toInterceptOpts(intercept) {
-            return {
-              interceptionContext: interceptionContextHeader,
-              interceptLayouts: intercept.interceptLayouts,
-              interceptSlotKey: intercept.slotKey,
-              interceptPage: intercept.page,
-              interceptParams: intercept.matchedParams,
-            };
-          },
-        });
-
-        setNavigationContext({
-          pathname: cleanPathname,
-          searchParams: url.searchParams,
-          params: __actionRerenderTarget.navigationParams,
-        });
-        element = buildPageElements(
-          __actionRerenderTarget.route,
-          __actionRerenderTarget.params,
-          cleanPathname,
-          {
-            opts: __actionRerenderTarget.interceptOpts,
-            searchParams: url.searchParams,
-            isRscRequest,
-            request,
-            mountedSlotsHeader: __mountedSlotsHeader,
-          },
-        );
-        errorPattern = __actionRerenderTarget.route.pattern;
-      } else {
-        const _actionRouteId = __createAppPayloadRouteId(cleanPathname, null);
-        element = {
-          [__APP_INTERCEPTION_CONTEXT_KEY]: null,
-          __route: _actionRouteId,
-          __rootLayout: null,
-          [_actionRouteId]: createElement("div", null, "Page not found"),
-        };
-      }
-
-      const onRenderError = createRscOnErrorHandler(
-        request,
-        cleanPathname,
-        errorPattern,
-      );
-      const rscStream = renderToReadableStream(
-        { root: element, returnValue },
-        { temporaryReferences, onError: onRenderError },
-      );
-
-      // Collect cookies set during the action synchronously (before stream is consumed).
-      // Do NOT clear headers/navigation context here — the RSC stream is consumed lazily
-      // by the client, and async server components that run during consumption need the
-      // context to still be live. The AsyncLocalStorage scope from runWithRequestContext
-      // handles cleanup naturally when all async continuations complete.
-      const actionPendingCookies = getAndClearPendingCookies();
-      const actionDraftCookie = getDraftModeCookieHeader();
-
-      const actionHeaders = new Headers({
-        "Content-Type": "text/x-component; charset=utf-8",
-        "Vary": "RSC, Accept",
+  const serverActionResponse = await __handleServerActionRscRequest({
+    actionId,
+    allowedOrigins: __allowedOrigins,
+    buildPageElement({
+      route: actionRoute,
+      params: actionParams,
+      cleanPathname: actionCleanPathname,
+      interceptOpts,
+      searchParams,
+      isRscRequest: actionIsRscRequest,
+      request: actionRequest,
+      mountedSlotsHeader,
+    }) {
+      return buildPageElements(actionRoute, actionParams, actionCleanPathname, {
+        opts: interceptOpts,
+        searchParams,
+        isRscRequest: actionIsRscRequest,
+        request: actionRequest,
+        mountedSlotsHeader,
       });
-      __mergeMiddlewareResponseHeaders(actionHeaders, _mwCtx.headers);
-      const actionResponse = new Response(rscStream, {
-        status: _mwCtx.status ?? 200,
-        headers: actionHeaders,
-      });
-      if (actionPendingCookies.length > 0 || actionDraftCookie) {
-        for (const cookie of actionPendingCookies) {
-          actionResponse.headers.append("Set-Cookie", cookie);
-        }
-        if (actionDraftCookie) actionResponse.headers.append("Set-Cookie", actionDraftCookie);
-      }
-      return actionResponse;
-    } catch (err) {
-      getAndClearPendingCookies(); // Clear pending cookies on error
-      console.error("[vinext] Server action error:", err);
-      _reportRequestError(
-        err instanceof Error ? err : new Error(String(err)),
-        { path: cleanPathname, method: request.method, headers: Object.fromEntries(request.headers.entries()) },
-        { routerKind: "App Router", routePath: cleanPathname, routeType: "action" },
-      );
+    },
+    cleanPathname,
+    clearRequestContext() {
       __clearRequestContext();
-      return new Response(
-        process.env.NODE_ENV === "production"
-          ? "Internal Server Error"
-          : "Server action failed: " + (err && err.message ? err.message : String(err)),
-        { status: 500 },
-      );
-    }
-  }
+    },
+    contentType: actionContentType,
+    createNotFoundElement(actionRouteId) {
+      return {
+        [__APP_INTERCEPTION_CONTEXT_KEY]: null,
+        __route: actionRouteId,
+        __rootLayout: null,
+        [actionRouteId]: createElement("div", null, "Page not found"),
+      };
+    },
+    createPayloadRouteId(pathnameToRender, interceptionContext) {
+      return __createAppPayloadRouteId(pathnameToRender, interceptionContext);
+    },
+    createRscOnErrorHandler(actionRequest, actionPathname, routePattern) {
+      return createRscOnErrorHandler(actionRequest, actionPathname, routePattern);
+    },
+    createTemporaryReferenceSet,
+    decodeReply,
+    findIntercept(pathnameToMatch) {
+      return findIntercept(pathnameToMatch, interceptionContextHeader);
+    },
+    getAndClearPendingCookies,
+    getDraftModeCookieHeader,
+    getRouteParamNames(sourceRoute) {
+      return sourceRoute.params;
+    },
+    getSourceRoute(sourceRouteIndex) {
+      return routes[sourceRouteIndex];
+    },
+    isRscRequest,
+    loadServerAction,
+    matchRoute(pathnameToMatch) {
+      return matchRoute(pathnameToMatch);
+    },
+    maxActionBodySize: __MAX_ACTION_BODY_SIZE,
+    middlewareHeaders: _mwCtx.headers,
+    middlewareStatus: _mwCtx.status,
+    mountedSlotsHeader: __mountedSlotsHeader,
+    readBodyWithLimit: __readBodyWithLimit,
+    readFormDataWithLimit: __readFormDataWithLimit,
+    renderToReadableStream,
+    reportRequestError: _reportRequestError,
+    request,
+    sanitizeErrorForClient(error) {
+      return __sanitizeErrorForClient(error);
+    },
+    searchParams: url.searchParams,
+    setHeadersAccessPhase,
+    setNavigationContext,
+    toInterceptOpts(intercept) {
+      return {
+        interceptionContext: interceptionContextHeader,
+        interceptLayouts: intercept.interceptLayouts,
+        interceptSlotKey: intercept.slotKey,
+        interceptPage: intercept.page,
+        interceptParams: intercept.matchedParams,
+      };
+    },
+  });
+  if (serverActionResponse) return serverActionResponse;
 
   // ── Apply afterFiles rewrites from next.config.js ──────────────────────
   if (__configRewrites.afterFiles && __configRewrites.afterFiles.length) {

--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -1,6 +1,9 @@
 import type { HeadersAccessPhase } from "../shims/headers.js";
+import { resolveAppPageActionRerenderTarget } from "./app-page-request.js";
 import { mergeMiddlewareResponseHeaders } from "./middleware-response-headers.js";
 import { validateCsrfOrigin, validateServerActionPayload } from "./request-pipeline.js";
+
+type AppPageParams = Record<string, string | string[]>;
 
 type AppServerActionErrorReporter = (
   error: Error,
@@ -11,6 +14,67 @@ type AppServerActionErrorReporter = (
 type AppServerActionDecoder = (body: FormData) => Promise<unknown>;
 
 type ReadFormDataWithLimit = (request: Request, maxBytes: number) => Promise<FormData>;
+
+type ReadBodyWithLimit = (request: Request, maxBytes: number) => Promise<string>;
+
+type AppServerActionFunction = (...args: unknown[]) => unknown;
+
+type AppServerActionReturnValue =
+  | {
+      data: unknown;
+      ok: true;
+    }
+  | {
+      data: unknown;
+      ok: false;
+    };
+
+type AppServerActionRedirect = {
+  status: number;
+  type: string;
+  url: string;
+};
+
+type AppServerActionRoute = {
+  pattern: string;
+};
+
+type AppServerActionMatch<TRoute extends AppServerActionRoute> = {
+  params: AppPageParams;
+  route: TRoute;
+};
+
+type AppServerActionIntercept<TPage = unknown> = {
+  matchedParams: AppPageParams;
+  page: TPage;
+  slotKey: string;
+  sourceRouteIndex: number;
+};
+
+type BuildServerActionPageElementOptions<TRoute extends AppServerActionRoute, TInterceptOpts> = {
+  cleanPathname: string;
+  interceptOpts: TInterceptOpts | undefined;
+  isRscRequest: boolean;
+  mountedSlotsHeader: string | null;
+  params: AppPageParams;
+  request: Request;
+  route: TRoute;
+  searchParams: URLSearchParams;
+};
+
+type AppServerActionRscModel<TElement> = {
+  returnValue: AppServerActionReturnValue;
+  root: TElement;
+};
+
+type RenderServerActionRscStreamOptions<TTemporaryReferences> = {
+  onError: (error: unknown) => unknown;
+  temporaryReferences: TTemporaryReferences;
+};
+
+type DecodeServerActionReplyOptions<TTemporaryReferences> = {
+  temporaryReferences: TTemporaryReferences;
+};
 
 export type HandleProgressiveServerActionRequestOptions = {
   actionId: string | null;
@@ -27,6 +91,64 @@ export type HandleProgressiveServerActionRequestOptions = {
   reportRequestError: AppServerActionErrorReporter;
   request: Request;
   setHeadersAccessPhase: (phase: HeadersAccessPhase) => HeadersAccessPhase;
+};
+
+export type HandleServerActionRscRequestOptions<
+  TElement,
+  TRoute extends AppServerActionRoute,
+  TInterceptOpts,
+  TTemporaryReferences,
+  TPage = unknown,
+> = {
+  actionId: string | null;
+  allowedOrigins: string[];
+  buildPageElement: (
+    options: BuildServerActionPageElementOptions<TRoute, TInterceptOpts>,
+  ) => TElement;
+  cleanPathname: string;
+  clearRequestContext: () => void;
+  contentType: string;
+  createNotFoundElement: (routeId: string) => TElement;
+  createPayloadRouteId: (pathname: string, interceptionContext: string | null) => string;
+  createRscOnErrorHandler: (
+    request: Request,
+    pathname: string,
+    pattern: string,
+  ) => (error: unknown) => unknown;
+  createTemporaryReferenceSet: () => TTemporaryReferences;
+  decodeReply: (
+    body: string | FormData,
+    options: DecodeServerActionReplyOptions<TTemporaryReferences>,
+  ) => Promise<unknown[]> | unknown[];
+  findIntercept: (pathname: string) => AppServerActionIntercept<TPage> | null;
+  getAndClearPendingCookies: () => string[];
+  getDraftModeCookieHeader: () => string | null | undefined;
+  getRouteParamNames: (route: TRoute) => readonly string[];
+  getSourceRoute: (sourceRouteIndex: number) => TRoute | undefined;
+  isRscRequest: boolean;
+  loadServerAction: (actionId: string) => Promise<AppServerActionFunction>;
+  matchRoute: (pathname: string) => AppServerActionMatch<TRoute> | null;
+  maxActionBodySize: number;
+  middlewareHeaders: Headers | null;
+  middlewareStatus: number | null | undefined;
+  mountedSlotsHeader: string | null;
+  readBodyWithLimit: ReadBodyWithLimit;
+  readFormDataWithLimit: ReadFormDataWithLimit;
+  renderToReadableStream: (
+    model: AppServerActionRscModel<TElement>,
+    options: RenderServerActionRscStreamOptions<TTemporaryReferences>,
+  ) => BodyInit | null | Promise<BodyInit | null>;
+  reportRequestError: AppServerActionErrorReporter;
+  request: Request;
+  sanitizeErrorForClient: (error: unknown) => unknown;
+  searchParams: URLSearchParams;
+  setHeadersAccessPhase: (phase: HeadersAccessPhase) => HeadersAccessPhase;
+  setNavigationContext: (context: {
+    params: AppPageParams;
+    pathname: string;
+    searchParams: URLSearchParams;
+  }) => void;
+  toInterceptOpts: (intercept: AppServerActionIntercept<TPage>) => TInterceptOpts;
 };
 
 type ActionControlResponse =
@@ -51,12 +173,18 @@ function getErrorMessage(error: unknown): string {
   return error instanceof Error && error.message ? error.message : String(error);
 }
 
-function getActionControlResponse(error: unknown): ActionControlResponse | null {
+function getErrorDigest(error: unknown): string | null {
   if (!error || typeof error !== "object" || !("digest" in error)) {
     return null;
   }
 
-  const digest = String(error.digest);
+  return String(error.digest);
+}
+
+function getActionControlResponse(error: unknown): ActionControlResponse | null {
+  const digest = getErrorDigest(error);
+  if (!digest) return null;
+
   if (digest.startsWith("NEXT_REDIRECT;")) {
     const parts = digest.split(";");
     const encodedUrl = parts[2];
@@ -83,6 +211,60 @@ function getActionControlResponse(error: unknown): ActionControlResponse | null 
   }
 
   return null;
+}
+
+function getActionRedirect(error: unknown): AppServerActionRedirect | null {
+  const digest = getErrorDigest(error);
+  if (!digest?.startsWith("NEXT_REDIRECT;")) {
+    return null;
+  }
+
+  const parts = digest.split(";");
+  const encodedUrl = parts[2];
+  if (!encodedUrl) {
+    return null;
+  }
+
+  return {
+    status: parts[3] ? parseInt(parts[3], 10) : 307,
+    type: parts[1] || "push",
+    url: decodeURIComponent(encodedUrl),
+  };
+}
+
+function isActionHttpFallback(error: unknown): boolean {
+  const digest = getErrorDigest(error);
+  return digest === "NEXT_NOT_FOUND" || digest?.startsWith("NEXT_HTTP_ERROR_FALLBACK;") === true;
+}
+
+function createServerActionErrorResponse(
+  error: unknown,
+  options: {
+    cleanPathname: string;
+    clearRequestContext: () => void;
+    getAndClearPendingCookies: () => string[];
+    reportRequestError: AppServerActionErrorReporter;
+    request: Request;
+  },
+): Response {
+  options.getAndClearPendingCookies();
+  console.error("[vinext] Server action error:", error);
+  options.reportRequestError(
+    normalizeError(error),
+    {
+      path: options.cleanPathname,
+      method: options.request.method,
+      headers: Object.fromEntries(options.request.headers.entries()),
+    },
+    { routerKind: "App Router", routePath: options.cleanPathname, routeType: "action" },
+  );
+  options.clearRequestContext();
+  return new Response(
+    process.env.NODE_ENV === "production"
+      ? "Internal Server Error"
+      : "Server action failed: " + getErrorMessage(error),
+    { status: 500 },
+  );
 }
 
 export function isProgressiveServerActionRequest(
@@ -206,5 +388,174 @@ export async function handleProgressiveServerActionRequest(
         : "Server action failed: " + getErrorMessage(error),
       { status: 500 },
     );
+  }
+}
+
+export async function handleServerActionRscRequest<
+  TElement,
+  TRoute extends AppServerActionRoute,
+  TInterceptOpts,
+  TTemporaryReferences,
+  TPage = unknown,
+>(
+  options: HandleServerActionRscRequestOptions<
+    TElement,
+    TRoute,
+    TInterceptOpts,
+    TTemporaryReferences,
+    TPage
+  >,
+): Promise<Response | null> {
+  if (options.request.method.toUpperCase() !== "POST" || !options.actionId) {
+    return null;
+  }
+
+  const csrfResponse = validateCsrfOrigin(options.request, options.allowedOrigins);
+  if (csrfResponse) return csrfResponse;
+
+  const contentLength = parseInt(options.request.headers.get("content-length") || "0", 10);
+  if (contentLength > options.maxActionBodySize) {
+    options.clearRequestContext();
+    return new Response("Payload Too Large", { status: 413 });
+  }
+
+  try {
+    let body: string | FormData;
+    try {
+      body = options.contentType.startsWith("multipart/form-data")
+        ? await options.readFormDataWithLimit(options.request, options.maxActionBodySize)
+        : await options.readBodyWithLimit(options.request, options.maxActionBodySize);
+    } catch (error) {
+      if (isRequestBodyTooLarge(error)) {
+        options.clearRequestContext();
+        return new Response("Payload Too Large", { status: 413 });
+      }
+      throw error;
+    }
+
+    const payloadResponse = await validateServerActionPayload(body);
+    if (payloadResponse) {
+      options.clearRequestContext();
+      return payloadResponse;
+    }
+
+    const temporaryReferences = options.createTemporaryReferenceSet();
+    const args = await options.decodeReply(body, { temporaryReferences });
+    const action = await options.loadServerAction(options.actionId);
+    let returnValue: AppServerActionReturnValue;
+    let actionRedirect: AppServerActionRedirect | null = null;
+    const previousHeadersPhase = options.setHeadersAccessPhase("action");
+    try {
+      try {
+        const data = await action.apply(null, args);
+        returnValue = { ok: true, data };
+      } catch (error) {
+        actionRedirect = getActionRedirect(error);
+        if (actionRedirect) {
+          returnValue = { ok: true, data: undefined };
+        } else if (isActionHttpFallback(error)) {
+          returnValue = { ok: false, data: error };
+        } else {
+          console.error("[vinext] Server action error:", error);
+          returnValue = { ok: false, data: options.sanitizeErrorForClient(error) };
+        }
+      }
+    } finally {
+      options.setHeadersAccessPhase(previousHeadersPhase);
+    }
+
+    if (actionRedirect) {
+      const actionPendingCookies = options.getAndClearPendingCookies();
+      const actionDraftCookie = options.getDraftModeCookieHeader();
+      options.clearRequestContext();
+      const redirectHeaders = new Headers({
+        "Content-Type": "text/x-component; charset=utf-8",
+        Vary: "RSC, Accept",
+      });
+      mergeMiddlewareResponseHeaders(redirectHeaders, options.middlewareHeaders);
+      redirectHeaders.set("x-action-redirect", actionRedirect.url);
+      redirectHeaders.set("x-action-redirect-type", actionRedirect.type);
+      redirectHeaders.set("x-action-redirect-status", String(actionRedirect.status));
+      for (const cookie of actionPendingCookies) {
+        redirectHeaders.append("Set-Cookie", cookie);
+      }
+      if (actionDraftCookie) redirectHeaders.append("Set-Cookie", actionDraftCookie);
+      return new Response("", { status: 200, headers: redirectHeaders });
+    }
+
+    const match = options.matchRoute(options.cleanPathname);
+    let element: TElement;
+    let errorPattern = match ? match.route.pattern : options.cleanPathname;
+    if (match) {
+      const { route: actionRoute, params: actionParams } = match;
+      const actionRerenderTarget = resolveAppPageActionRerenderTarget({
+        cleanPathname: options.cleanPathname,
+        currentParams: actionParams,
+        currentRoute: actionRoute,
+        findIntercept: options.findIntercept,
+        getRouteParamNames: options.getRouteParamNames,
+        getSourceRoute: options.getSourceRoute,
+        isRscRequest: options.isRscRequest,
+        toInterceptOpts: options.toInterceptOpts,
+      });
+
+      options.setNavigationContext({
+        pathname: options.cleanPathname,
+        searchParams: options.searchParams,
+        params: actionRerenderTarget.navigationParams,
+      });
+      element = options.buildPageElement({
+        cleanPathname: options.cleanPathname,
+        interceptOpts: actionRerenderTarget.interceptOpts,
+        isRscRequest: options.isRscRequest,
+        mountedSlotsHeader: options.mountedSlotsHeader,
+        params: actionRerenderTarget.params,
+        request: options.request,
+        route: actionRerenderTarget.route,
+        searchParams: options.searchParams,
+      });
+      errorPattern = actionRerenderTarget.route.pattern;
+    } else {
+      const actionRouteId = options.createPayloadRouteId(options.cleanPathname, null);
+      element = options.createNotFoundElement(actionRouteId);
+    }
+
+    const onRenderError = options.createRscOnErrorHandler(
+      options.request,
+      options.cleanPathname,
+      errorPattern,
+    );
+    const rscStream = await options.renderToReadableStream(
+      { root: element, returnValue },
+      { temporaryReferences, onError: onRenderError },
+    );
+
+    const actionPendingCookies = options.getAndClearPendingCookies();
+    const actionDraftCookie = options.getDraftModeCookieHeader();
+
+    const actionHeaders = new Headers({
+      "Content-Type": "text/x-component; charset=utf-8",
+      Vary: "RSC, Accept",
+    });
+    mergeMiddlewareResponseHeaders(actionHeaders, options.middlewareHeaders);
+    const actionResponse = new Response(rscStream, {
+      status: options.middlewareStatus ?? 200,
+      headers: actionHeaders,
+    });
+    if (actionPendingCookies.length > 0 || actionDraftCookie) {
+      for (const cookie of actionPendingCookies) {
+        actionResponse.headers.append("Set-Cookie", cookie);
+      }
+      if (actionDraftCookie) actionResponse.headers.append("Set-Cookie", actionDraftCookie);
+    }
+    return actionResponse;
+  } catch (error) {
+    return createServerActionErrorResponse(error, {
+      cleanPathname: options.cleanPathname,
+      clearRequestContext: options.clearRequestContext,
+      getAndClearPendingCookies: options.getAndClearPendingCookies,
+      reportRequestError: options.reportRequestError,
+      request: options.request,
+    });
   }
 }

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -31,7 +31,7 @@ import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, 
 import { decodePathParams as __decodePathParams, normalizePath as __normalizePath } from "<ROOT>/packages/vinext/src/server/normalize-path.js";
 import { normalizePathnameForRouteMatch as __normalizePathnameForRouteMatch, normalizePathnameForRouteMatchStrict as __normalizePathnameForRouteMatchStrict } from "<ROOT>/packages/vinext/src/routing/utils.js";
 import { buildRequestHeadersFromMiddlewareResponse as __buildRequestHeadersFromMiddlewareResponse } from "<ROOT>/packages/vinext/src/server/middleware-request-headers.js";
-import { validateCsrfOrigin, validateServerActionPayload, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
+import { validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
 import { applyAppMiddleware as __applyAppMiddleware } from "<ROOT>/packages/vinext/src/server/app-middleware.js";
 import {
   isKnownDynamicAppRoute as __isKnownDynamicAppRoute,
@@ -47,6 +47,7 @@ import {
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-execution.js";
 import {
   handleProgressiveServerActionRequest as __handleProgressiveServerActionRequest,
+  handleServerActionRscRequest as __handleServerActionRscRequest,
 } from "<ROOT>/packages/vinext/src/server/app-server-action-execution.js";
 import { readAppRouteHandlerCacheResponse as __readAppRouteHandlerCacheResponse } from "<ROOT>/packages/vinext/src/server/app-route-handler-cache.js";
 import { readAppPageCacheResponse as __readAppPageCacheResponse } from "<ROOT>/packages/vinext/src/server/app-page-cache.js";
@@ -88,7 +89,6 @@ import {
 } from "<ROOT>/packages/vinext/src/server/app-page-response.js";
 import { getScriptNonceFromHeaderSources as __getScriptNonceFromHeaderSources } from "<ROOT>/packages/vinext/src/server/csp.js";
 import {
-  resolveAppPageActionRerenderTarget as __resolveAppPageActionRerenderTarget,
   buildAppPageElement as __buildAppPageElement,
   resolveAppPageIntercept as __resolveAppPageIntercept,
   validateAppPageDynamicParams as __validateAppPageDynamicParams,
@@ -1251,227 +1251,90 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   });
   if (progressiveActionResponse) return progressiveActionResponse;
 
-  if (request.method === "POST" && actionId) {
-    // ── CSRF protection ─────────────────────────────────────────────────
-    // Verify that the Origin header matches the Host header to prevent
-    // cross-site request forgery, matching Next.js server action behavior.
-    const csrfResponse = validateCsrfOrigin(request, __allowedOrigins);
-    if (csrfResponse) return csrfResponse;
-
-    // ── Body size limit ─────────────────────────────────────────────────
-    // Reject payloads larger than the configured limit.
-    // Check Content-Length as a fast path, then enforce on the actual
-    // stream to prevent bypasses via chunked transfer-encoding.
-    const contentLength = parseInt(request.headers.get("content-length") || "0", 10);
-    if (contentLength > __MAX_ACTION_BODY_SIZE) {
-      __clearRequestContext();
-      return new Response("Payload Too Large", { status: 413 });
-    }
-
-    try {
-      let body;
-      try {
-        body = actionContentType.startsWith("multipart/form-data")
-          ? await __readFormDataWithLimit(request, __MAX_ACTION_BODY_SIZE)
-          : await __readBodyWithLimit(request, __MAX_ACTION_BODY_SIZE);
-      } catch (sizeErr) {
-        if (sizeErr && sizeErr.message === "Request body too large") {
-          __clearRequestContext();
-          return new Response("Payload Too Large", { status: 413 });
-        }
-        throw sizeErr;
-      }
-      const payloadResponse = await validateServerActionPayload(body);
-      if (payloadResponse) {
-        __clearRequestContext();
-        return payloadResponse;
-      }
-      const temporaryReferences = createTemporaryReferenceSet();
-      const args = await decodeReply(body, { temporaryReferences });
-      const action = await loadServerAction(actionId);
-      let returnValue;
-      let actionRedirect = null;
-      const previousHeadersPhase = setHeadersAccessPhase("action");
-      try {
-        try {
-          const data = await action.apply(null, args);
-          returnValue = { ok: true, data };
-        } catch (e) {
-          // Detect redirect() / permanentRedirect() called inside the action.
-          // These throw errors with digest "NEXT_REDIRECT;replace;url[;status]".
-          // The URL is encodeURIComponent-encoded to prevent semicolons in the URL
-          // from corrupting the delimiter-based digest format.
-          if (e && typeof e === "object" && "digest" in e) {
-            const digest = String(e.digest);
-            if (digest.startsWith("NEXT_REDIRECT;")) {
-              const parts = digest.split(";");
-              actionRedirect = {
-                url: decodeURIComponent(parts[2]),
-                type: parts[1] || "push",          // "push" or "replace"
-                status: parts[3] ? parseInt(parts[3], 10) : 307,
-              };
-              returnValue = { ok: true, data: undefined };
-            } else if (digest === "NEXT_NOT_FOUND" || digest.startsWith("NEXT_HTTP_ERROR_FALLBACK;")) {
-              // notFound() / forbidden() / unauthorized() in action — package as error
-              returnValue = { ok: false, data: e };
-            } else {
-              // Non-navigation digest error — sanitize in production to avoid
-              // leaking internal details (connection strings, paths, etc.)
-              console.error("[vinext] Server action error:", e);
-              returnValue = { ok: false, data: __sanitizeErrorForClient(e) };
-            }
-          } else {
-            // Unhandled error — sanitize in production to avoid leaking
-            // internal details (database errors, file paths, stack traces, etc.)
-            console.error("[vinext] Server action error:", e);
-            returnValue = { ok: false, data: __sanitizeErrorForClient(e) };
-          }
-        }
-      } finally {
-        setHeadersAccessPhase(previousHeadersPhase);
-      }
-
-      // If the action called redirect(), signal the client to navigate.
-      // We can't use a real HTTP redirect (the fetch would follow it automatically
-      // and receive a page HTML instead of RSC stream). Instead, we return a 200
-      // with x-action-redirect header that the client entry detects and handles.
-      if (actionRedirect) {
-        const actionPendingCookies = getAndClearPendingCookies();
-        const actionDraftCookie = getDraftModeCookieHeader();
-        __clearRequestContext();
-        const redirectHeaders = new Headers({
-          "Content-Type": "text/x-component; charset=utf-8",
-          "Vary": "RSC, Accept",
-        });
-        __mergeMiddlewareResponseHeaders(redirectHeaders, _mwCtx.headers);
-        redirectHeaders.set("x-action-redirect", actionRedirect.url);
-        redirectHeaders.set("x-action-redirect-type", actionRedirect.type);
-        redirectHeaders.set("x-action-redirect-status", String(actionRedirect.status));
-        for (const cookie of actionPendingCookies) {
-          redirectHeaders.append("Set-Cookie", cookie);
-        }
-        if (actionDraftCookie) redirectHeaders.append("Set-Cookie", actionDraftCookie);
-        // Send an empty RSC-like body (client will navigate instead of parsing)
-        return new Response("", { status: 200, headers: redirectHeaders });
-      }
-
-      // After the action, re-render the current page so the client
-      // gets an updated React tree reflecting any mutations.
-      //
-      // When the original request came from inside an intercepted modal
-      // (X-Vinext-Interception-Context present + source route still
-      // matches), rebuild the intercepted tree — otherwise the modal would
-      // unmount and the direct route would render in its place. Mirrors
-      // the interception resolution used by the GET path.
-      const match = matchRoute(cleanPathname);
-      let element;
-      let errorPattern = match ? match.route.pattern : cleanPathname;
-      if (match) {
-        const { route: actionRoute, params: actionParams } = match;
-        const __actionRerenderTarget = __resolveAppPageActionRerenderTarget({
-          cleanPathname,
-          currentParams: actionParams,
-          currentRoute: actionRoute,
-          findIntercept(pathname) {
-            return findIntercept(pathname, interceptionContextHeader);
-          },
-          getRouteParamNames(sourceRoute) {
-            return sourceRoute.params;
-          },
-          getSourceRoute(sourceRouteIndex) {
-            return routes[sourceRouteIndex];
-          },
-          isRscRequest,
-          toInterceptOpts(intercept) {
-            return {
-              interceptionContext: interceptionContextHeader,
-              interceptLayouts: intercept.interceptLayouts,
-              interceptSlotKey: intercept.slotKey,
-              interceptPage: intercept.page,
-              interceptParams: intercept.matchedParams,
-            };
-          },
-        });
-
-        setNavigationContext({
-          pathname: cleanPathname,
-          searchParams: url.searchParams,
-          params: __actionRerenderTarget.navigationParams,
-        });
-        element = buildPageElements(
-          __actionRerenderTarget.route,
-          __actionRerenderTarget.params,
-          cleanPathname,
-          {
-            opts: __actionRerenderTarget.interceptOpts,
-            searchParams: url.searchParams,
-            isRscRequest,
-            request,
-            mountedSlotsHeader: __mountedSlotsHeader,
-          },
-        );
-        errorPattern = __actionRerenderTarget.route.pattern;
-      } else {
-        const _actionRouteId = __createAppPayloadRouteId(cleanPathname, null);
-        element = {
-          [__APP_INTERCEPTION_CONTEXT_KEY]: null,
-          __route: _actionRouteId,
-          __rootLayout: null,
-          [_actionRouteId]: createElement("div", null, "Page not found"),
-        };
-      }
-
-      const onRenderError = createRscOnErrorHandler(
-        request,
-        cleanPathname,
-        errorPattern,
-      );
-      const rscStream = renderToReadableStream(
-        { root: element, returnValue },
-        { temporaryReferences, onError: onRenderError },
-      );
-
-      // Collect cookies set during the action synchronously (before stream is consumed).
-      // Do NOT clear headers/navigation context here — the RSC stream is consumed lazily
-      // by the client, and async server components that run during consumption need the
-      // context to still be live. The AsyncLocalStorage scope from runWithRequestContext
-      // handles cleanup naturally when all async continuations complete.
-      const actionPendingCookies = getAndClearPendingCookies();
-      const actionDraftCookie = getDraftModeCookieHeader();
-
-      const actionHeaders = new Headers({
-        "Content-Type": "text/x-component; charset=utf-8",
-        "Vary": "RSC, Accept",
+  const serverActionResponse = await __handleServerActionRscRequest({
+    actionId,
+    allowedOrigins: __allowedOrigins,
+    buildPageElement({
+      route: actionRoute,
+      params: actionParams,
+      cleanPathname: actionCleanPathname,
+      interceptOpts,
+      searchParams,
+      isRscRequest: actionIsRscRequest,
+      request: actionRequest,
+      mountedSlotsHeader,
+    }) {
+      return buildPageElements(actionRoute, actionParams, actionCleanPathname, {
+        opts: interceptOpts,
+        searchParams,
+        isRscRequest: actionIsRscRequest,
+        request: actionRequest,
+        mountedSlotsHeader,
       });
-      __mergeMiddlewareResponseHeaders(actionHeaders, _mwCtx.headers);
-      const actionResponse = new Response(rscStream, {
-        status: _mwCtx.status ?? 200,
-        headers: actionHeaders,
-      });
-      if (actionPendingCookies.length > 0 || actionDraftCookie) {
-        for (const cookie of actionPendingCookies) {
-          actionResponse.headers.append("Set-Cookie", cookie);
-        }
-        if (actionDraftCookie) actionResponse.headers.append("Set-Cookie", actionDraftCookie);
-      }
-      return actionResponse;
-    } catch (err) {
-      getAndClearPendingCookies(); // Clear pending cookies on error
-      console.error("[vinext] Server action error:", err);
-      _reportRequestError(
-        err instanceof Error ? err : new Error(String(err)),
-        { path: cleanPathname, method: request.method, headers: Object.fromEntries(request.headers.entries()) },
-        { routerKind: "App Router", routePath: cleanPathname, routeType: "action" },
-      );
+    },
+    cleanPathname,
+    clearRequestContext() {
       __clearRequestContext();
-      return new Response(
-        process.env.NODE_ENV === "production"
-          ? "Internal Server Error"
-          : "Server action failed: " + (err && err.message ? err.message : String(err)),
-        { status: 500 },
-      );
-    }
-  }
+    },
+    contentType: actionContentType,
+    createNotFoundElement(actionRouteId) {
+      return {
+        [__APP_INTERCEPTION_CONTEXT_KEY]: null,
+        __route: actionRouteId,
+        __rootLayout: null,
+        [actionRouteId]: createElement("div", null, "Page not found"),
+      };
+    },
+    createPayloadRouteId(pathnameToRender, interceptionContext) {
+      return __createAppPayloadRouteId(pathnameToRender, interceptionContext);
+    },
+    createRscOnErrorHandler(actionRequest, actionPathname, routePattern) {
+      return createRscOnErrorHandler(actionRequest, actionPathname, routePattern);
+    },
+    createTemporaryReferenceSet,
+    decodeReply,
+    findIntercept(pathnameToMatch) {
+      return findIntercept(pathnameToMatch, interceptionContextHeader);
+    },
+    getAndClearPendingCookies,
+    getDraftModeCookieHeader,
+    getRouteParamNames(sourceRoute) {
+      return sourceRoute.params;
+    },
+    getSourceRoute(sourceRouteIndex) {
+      return routes[sourceRouteIndex];
+    },
+    isRscRequest,
+    loadServerAction,
+    matchRoute(pathnameToMatch) {
+      return matchRoute(pathnameToMatch);
+    },
+    maxActionBodySize: __MAX_ACTION_BODY_SIZE,
+    middlewareHeaders: _mwCtx.headers,
+    middlewareStatus: _mwCtx.status,
+    mountedSlotsHeader: __mountedSlotsHeader,
+    readBodyWithLimit: __readBodyWithLimit,
+    readFormDataWithLimit: __readFormDataWithLimit,
+    renderToReadableStream,
+    reportRequestError: _reportRequestError,
+    request,
+    sanitizeErrorForClient(error) {
+      return __sanitizeErrorForClient(error);
+    },
+    searchParams: url.searchParams,
+    setHeadersAccessPhase,
+    setNavigationContext,
+    toInterceptOpts(intercept) {
+      return {
+        interceptionContext: interceptionContextHeader,
+        interceptLayouts: intercept.interceptLayouts,
+        interceptSlotKey: intercept.slotKey,
+        interceptPage: intercept.page,
+        interceptParams: intercept.matchedParams,
+      };
+    },
+  });
+  if (serverActionResponse) return serverActionResponse;
 
   // ── Apply afterFiles rewrites from next.config.js ──────────────────────
   if (__configRewrites.afterFiles && __configRewrites.afterFiles.length) {
@@ -2151,7 +2014,7 @@ import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, 
 import { decodePathParams as __decodePathParams, normalizePath as __normalizePath } from "<ROOT>/packages/vinext/src/server/normalize-path.js";
 import { normalizePathnameForRouteMatch as __normalizePathnameForRouteMatch, normalizePathnameForRouteMatchStrict as __normalizePathnameForRouteMatchStrict } from "<ROOT>/packages/vinext/src/routing/utils.js";
 import { buildRequestHeadersFromMiddlewareResponse as __buildRequestHeadersFromMiddlewareResponse } from "<ROOT>/packages/vinext/src/server/middleware-request-headers.js";
-import { validateCsrfOrigin, validateServerActionPayload, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
+import { validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
 import { applyAppMiddleware as __applyAppMiddleware } from "<ROOT>/packages/vinext/src/server/app-middleware.js";
 import {
   isKnownDynamicAppRoute as __isKnownDynamicAppRoute,
@@ -2167,6 +2030,7 @@ import {
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-execution.js";
 import {
   handleProgressiveServerActionRequest as __handleProgressiveServerActionRequest,
+  handleServerActionRscRequest as __handleServerActionRscRequest,
 } from "<ROOT>/packages/vinext/src/server/app-server-action-execution.js";
 import { readAppRouteHandlerCacheResponse as __readAppRouteHandlerCacheResponse } from "<ROOT>/packages/vinext/src/server/app-route-handler-cache.js";
 import { readAppPageCacheResponse as __readAppPageCacheResponse } from "<ROOT>/packages/vinext/src/server/app-page-cache.js";
@@ -2208,7 +2072,6 @@ import {
 } from "<ROOT>/packages/vinext/src/server/app-page-response.js";
 import { getScriptNonceFromHeaderSources as __getScriptNonceFromHeaderSources } from "<ROOT>/packages/vinext/src/server/csp.js";
 import {
-  resolveAppPageActionRerenderTarget as __resolveAppPageActionRerenderTarget,
   buildAppPageElement as __buildAppPageElement,
   resolveAppPageIntercept as __resolveAppPageIntercept,
   validateAppPageDynamicParams as __validateAppPageDynamicParams,
@@ -3377,227 +3240,90 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   });
   if (progressiveActionResponse) return progressiveActionResponse;
 
-  if (request.method === "POST" && actionId) {
-    // ── CSRF protection ─────────────────────────────────────────────────
-    // Verify that the Origin header matches the Host header to prevent
-    // cross-site request forgery, matching Next.js server action behavior.
-    const csrfResponse = validateCsrfOrigin(request, __allowedOrigins);
-    if (csrfResponse) return csrfResponse;
-
-    // ── Body size limit ─────────────────────────────────────────────────
-    // Reject payloads larger than the configured limit.
-    // Check Content-Length as a fast path, then enforce on the actual
-    // stream to prevent bypasses via chunked transfer-encoding.
-    const contentLength = parseInt(request.headers.get("content-length") || "0", 10);
-    if (contentLength > __MAX_ACTION_BODY_SIZE) {
-      __clearRequestContext();
-      return new Response("Payload Too Large", { status: 413 });
-    }
-
-    try {
-      let body;
-      try {
-        body = actionContentType.startsWith("multipart/form-data")
-          ? await __readFormDataWithLimit(request, __MAX_ACTION_BODY_SIZE)
-          : await __readBodyWithLimit(request, __MAX_ACTION_BODY_SIZE);
-      } catch (sizeErr) {
-        if (sizeErr && sizeErr.message === "Request body too large") {
-          __clearRequestContext();
-          return new Response("Payload Too Large", { status: 413 });
-        }
-        throw sizeErr;
-      }
-      const payloadResponse = await validateServerActionPayload(body);
-      if (payloadResponse) {
-        __clearRequestContext();
-        return payloadResponse;
-      }
-      const temporaryReferences = createTemporaryReferenceSet();
-      const args = await decodeReply(body, { temporaryReferences });
-      const action = await loadServerAction(actionId);
-      let returnValue;
-      let actionRedirect = null;
-      const previousHeadersPhase = setHeadersAccessPhase("action");
-      try {
-        try {
-          const data = await action.apply(null, args);
-          returnValue = { ok: true, data };
-        } catch (e) {
-          // Detect redirect() / permanentRedirect() called inside the action.
-          // These throw errors with digest "NEXT_REDIRECT;replace;url[;status]".
-          // The URL is encodeURIComponent-encoded to prevent semicolons in the URL
-          // from corrupting the delimiter-based digest format.
-          if (e && typeof e === "object" && "digest" in e) {
-            const digest = String(e.digest);
-            if (digest.startsWith("NEXT_REDIRECT;")) {
-              const parts = digest.split(";");
-              actionRedirect = {
-                url: decodeURIComponent(parts[2]),
-                type: parts[1] || "push",          // "push" or "replace"
-                status: parts[3] ? parseInt(parts[3], 10) : 307,
-              };
-              returnValue = { ok: true, data: undefined };
-            } else if (digest === "NEXT_NOT_FOUND" || digest.startsWith("NEXT_HTTP_ERROR_FALLBACK;")) {
-              // notFound() / forbidden() / unauthorized() in action — package as error
-              returnValue = { ok: false, data: e };
-            } else {
-              // Non-navigation digest error — sanitize in production to avoid
-              // leaking internal details (connection strings, paths, etc.)
-              console.error("[vinext] Server action error:", e);
-              returnValue = { ok: false, data: __sanitizeErrorForClient(e) };
-            }
-          } else {
-            // Unhandled error — sanitize in production to avoid leaking
-            // internal details (database errors, file paths, stack traces, etc.)
-            console.error("[vinext] Server action error:", e);
-            returnValue = { ok: false, data: __sanitizeErrorForClient(e) };
-          }
-        }
-      } finally {
-        setHeadersAccessPhase(previousHeadersPhase);
-      }
-
-      // If the action called redirect(), signal the client to navigate.
-      // We can't use a real HTTP redirect (the fetch would follow it automatically
-      // and receive a page HTML instead of RSC stream). Instead, we return a 200
-      // with x-action-redirect header that the client entry detects and handles.
-      if (actionRedirect) {
-        const actionPendingCookies = getAndClearPendingCookies();
-        const actionDraftCookie = getDraftModeCookieHeader();
-        __clearRequestContext();
-        const redirectHeaders = new Headers({
-          "Content-Type": "text/x-component; charset=utf-8",
-          "Vary": "RSC, Accept",
-        });
-        __mergeMiddlewareResponseHeaders(redirectHeaders, _mwCtx.headers);
-        redirectHeaders.set("x-action-redirect", actionRedirect.url);
-        redirectHeaders.set("x-action-redirect-type", actionRedirect.type);
-        redirectHeaders.set("x-action-redirect-status", String(actionRedirect.status));
-        for (const cookie of actionPendingCookies) {
-          redirectHeaders.append("Set-Cookie", cookie);
-        }
-        if (actionDraftCookie) redirectHeaders.append("Set-Cookie", actionDraftCookie);
-        // Send an empty RSC-like body (client will navigate instead of parsing)
-        return new Response("", { status: 200, headers: redirectHeaders });
-      }
-
-      // After the action, re-render the current page so the client
-      // gets an updated React tree reflecting any mutations.
-      //
-      // When the original request came from inside an intercepted modal
-      // (X-Vinext-Interception-Context present + source route still
-      // matches), rebuild the intercepted tree — otherwise the modal would
-      // unmount and the direct route would render in its place. Mirrors
-      // the interception resolution used by the GET path.
-      const match = matchRoute(cleanPathname);
-      let element;
-      let errorPattern = match ? match.route.pattern : cleanPathname;
-      if (match) {
-        const { route: actionRoute, params: actionParams } = match;
-        const __actionRerenderTarget = __resolveAppPageActionRerenderTarget({
-          cleanPathname,
-          currentParams: actionParams,
-          currentRoute: actionRoute,
-          findIntercept(pathname) {
-            return findIntercept(pathname, interceptionContextHeader);
-          },
-          getRouteParamNames(sourceRoute) {
-            return sourceRoute.params;
-          },
-          getSourceRoute(sourceRouteIndex) {
-            return routes[sourceRouteIndex];
-          },
-          isRscRequest,
-          toInterceptOpts(intercept) {
-            return {
-              interceptionContext: interceptionContextHeader,
-              interceptLayouts: intercept.interceptLayouts,
-              interceptSlotKey: intercept.slotKey,
-              interceptPage: intercept.page,
-              interceptParams: intercept.matchedParams,
-            };
-          },
-        });
-
-        setNavigationContext({
-          pathname: cleanPathname,
-          searchParams: url.searchParams,
-          params: __actionRerenderTarget.navigationParams,
-        });
-        element = buildPageElements(
-          __actionRerenderTarget.route,
-          __actionRerenderTarget.params,
-          cleanPathname,
-          {
-            opts: __actionRerenderTarget.interceptOpts,
-            searchParams: url.searchParams,
-            isRscRequest,
-            request,
-            mountedSlotsHeader: __mountedSlotsHeader,
-          },
-        );
-        errorPattern = __actionRerenderTarget.route.pattern;
-      } else {
-        const _actionRouteId = __createAppPayloadRouteId(cleanPathname, null);
-        element = {
-          [__APP_INTERCEPTION_CONTEXT_KEY]: null,
-          __route: _actionRouteId,
-          __rootLayout: null,
-          [_actionRouteId]: createElement("div", null, "Page not found"),
-        };
-      }
-
-      const onRenderError = createRscOnErrorHandler(
-        request,
-        cleanPathname,
-        errorPattern,
-      );
-      const rscStream = renderToReadableStream(
-        { root: element, returnValue },
-        { temporaryReferences, onError: onRenderError },
-      );
-
-      // Collect cookies set during the action synchronously (before stream is consumed).
-      // Do NOT clear headers/navigation context here — the RSC stream is consumed lazily
-      // by the client, and async server components that run during consumption need the
-      // context to still be live. The AsyncLocalStorage scope from runWithRequestContext
-      // handles cleanup naturally when all async continuations complete.
-      const actionPendingCookies = getAndClearPendingCookies();
-      const actionDraftCookie = getDraftModeCookieHeader();
-
-      const actionHeaders = new Headers({
-        "Content-Type": "text/x-component; charset=utf-8",
-        "Vary": "RSC, Accept",
+  const serverActionResponse = await __handleServerActionRscRequest({
+    actionId,
+    allowedOrigins: __allowedOrigins,
+    buildPageElement({
+      route: actionRoute,
+      params: actionParams,
+      cleanPathname: actionCleanPathname,
+      interceptOpts,
+      searchParams,
+      isRscRequest: actionIsRscRequest,
+      request: actionRequest,
+      mountedSlotsHeader,
+    }) {
+      return buildPageElements(actionRoute, actionParams, actionCleanPathname, {
+        opts: interceptOpts,
+        searchParams,
+        isRscRequest: actionIsRscRequest,
+        request: actionRequest,
+        mountedSlotsHeader,
       });
-      __mergeMiddlewareResponseHeaders(actionHeaders, _mwCtx.headers);
-      const actionResponse = new Response(rscStream, {
-        status: _mwCtx.status ?? 200,
-        headers: actionHeaders,
-      });
-      if (actionPendingCookies.length > 0 || actionDraftCookie) {
-        for (const cookie of actionPendingCookies) {
-          actionResponse.headers.append("Set-Cookie", cookie);
-        }
-        if (actionDraftCookie) actionResponse.headers.append("Set-Cookie", actionDraftCookie);
-      }
-      return actionResponse;
-    } catch (err) {
-      getAndClearPendingCookies(); // Clear pending cookies on error
-      console.error("[vinext] Server action error:", err);
-      _reportRequestError(
-        err instanceof Error ? err : new Error(String(err)),
-        { path: cleanPathname, method: request.method, headers: Object.fromEntries(request.headers.entries()) },
-        { routerKind: "App Router", routePath: cleanPathname, routeType: "action" },
-      );
+    },
+    cleanPathname,
+    clearRequestContext() {
       __clearRequestContext();
-      return new Response(
-        process.env.NODE_ENV === "production"
-          ? "Internal Server Error"
-          : "Server action failed: " + (err && err.message ? err.message : String(err)),
-        { status: 500 },
-      );
-    }
-  }
+    },
+    contentType: actionContentType,
+    createNotFoundElement(actionRouteId) {
+      return {
+        [__APP_INTERCEPTION_CONTEXT_KEY]: null,
+        __route: actionRouteId,
+        __rootLayout: null,
+        [actionRouteId]: createElement("div", null, "Page not found"),
+      };
+    },
+    createPayloadRouteId(pathnameToRender, interceptionContext) {
+      return __createAppPayloadRouteId(pathnameToRender, interceptionContext);
+    },
+    createRscOnErrorHandler(actionRequest, actionPathname, routePattern) {
+      return createRscOnErrorHandler(actionRequest, actionPathname, routePattern);
+    },
+    createTemporaryReferenceSet,
+    decodeReply,
+    findIntercept(pathnameToMatch) {
+      return findIntercept(pathnameToMatch, interceptionContextHeader);
+    },
+    getAndClearPendingCookies,
+    getDraftModeCookieHeader,
+    getRouteParamNames(sourceRoute) {
+      return sourceRoute.params;
+    },
+    getSourceRoute(sourceRouteIndex) {
+      return routes[sourceRouteIndex];
+    },
+    isRscRequest,
+    loadServerAction,
+    matchRoute(pathnameToMatch) {
+      return matchRoute(pathnameToMatch);
+    },
+    maxActionBodySize: __MAX_ACTION_BODY_SIZE,
+    middlewareHeaders: _mwCtx.headers,
+    middlewareStatus: _mwCtx.status,
+    mountedSlotsHeader: __mountedSlotsHeader,
+    readBodyWithLimit: __readBodyWithLimit,
+    readFormDataWithLimit: __readFormDataWithLimit,
+    renderToReadableStream,
+    reportRequestError: _reportRequestError,
+    request,
+    sanitizeErrorForClient(error) {
+      return __sanitizeErrorForClient(error);
+    },
+    searchParams: url.searchParams,
+    setHeadersAccessPhase,
+    setNavigationContext,
+    toInterceptOpts(intercept) {
+      return {
+        interceptionContext: interceptionContextHeader,
+        interceptLayouts: intercept.interceptLayouts,
+        interceptSlotKey: intercept.slotKey,
+        interceptPage: intercept.page,
+        interceptParams: intercept.matchedParams,
+      };
+    },
+  });
+  if (serverActionResponse) return serverActionResponse;
 
   // ── Apply afterFiles rewrites from next.config.js ──────────────────────
   if (__configRewrites.afterFiles && __configRewrites.afterFiles.length) {
@@ -4277,7 +4003,7 @@ import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, 
 import { decodePathParams as __decodePathParams, normalizePath as __normalizePath } from "<ROOT>/packages/vinext/src/server/normalize-path.js";
 import { normalizePathnameForRouteMatch as __normalizePathnameForRouteMatch, normalizePathnameForRouteMatchStrict as __normalizePathnameForRouteMatchStrict } from "<ROOT>/packages/vinext/src/routing/utils.js";
 import { buildRequestHeadersFromMiddlewareResponse as __buildRequestHeadersFromMiddlewareResponse } from "<ROOT>/packages/vinext/src/server/middleware-request-headers.js";
-import { validateCsrfOrigin, validateServerActionPayload, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
+import { validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
 import { applyAppMiddleware as __applyAppMiddleware } from "<ROOT>/packages/vinext/src/server/app-middleware.js";
 import {
   isKnownDynamicAppRoute as __isKnownDynamicAppRoute,
@@ -4293,6 +4019,7 @@ import {
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-execution.js";
 import {
   handleProgressiveServerActionRequest as __handleProgressiveServerActionRequest,
+  handleServerActionRscRequest as __handleServerActionRscRequest,
 } from "<ROOT>/packages/vinext/src/server/app-server-action-execution.js";
 import { readAppRouteHandlerCacheResponse as __readAppRouteHandlerCacheResponse } from "<ROOT>/packages/vinext/src/server/app-route-handler-cache.js";
 import { readAppPageCacheResponse as __readAppPageCacheResponse } from "<ROOT>/packages/vinext/src/server/app-page-cache.js";
@@ -4334,7 +4061,6 @@ import {
 } from "<ROOT>/packages/vinext/src/server/app-page-response.js";
 import { getScriptNonceFromHeaderSources as __getScriptNonceFromHeaderSources } from "<ROOT>/packages/vinext/src/server/csp.js";
 import {
-  resolveAppPageActionRerenderTarget as __resolveAppPageActionRerenderTarget,
   buildAppPageElement as __buildAppPageElement,
   resolveAppPageIntercept as __resolveAppPageIntercept,
   validateAppPageDynamicParams as __validateAppPageDynamicParams,
@@ -5498,227 +5224,90 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   });
   if (progressiveActionResponse) return progressiveActionResponse;
 
-  if (request.method === "POST" && actionId) {
-    // ── CSRF protection ─────────────────────────────────────────────────
-    // Verify that the Origin header matches the Host header to prevent
-    // cross-site request forgery, matching Next.js server action behavior.
-    const csrfResponse = validateCsrfOrigin(request, __allowedOrigins);
-    if (csrfResponse) return csrfResponse;
-
-    // ── Body size limit ─────────────────────────────────────────────────
-    // Reject payloads larger than the configured limit.
-    // Check Content-Length as a fast path, then enforce on the actual
-    // stream to prevent bypasses via chunked transfer-encoding.
-    const contentLength = parseInt(request.headers.get("content-length") || "0", 10);
-    if (contentLength > __MAX_ACTION_BODY_SIZE) {
-      __clearRequestContext();
-      return new Response("Payload Too Large", { status: 413 });
-    }
-
-    try {
-      let body;
-      try {
-        body = actionContentType.startsWith("multipart/form-data")
-          ? await __readFormDataWithLimit(request, __MAX_ACTION_BODY_SIZE)
-          : await __readBodyWithLimit(request, __MAX_ACTION_BODY_SIZE);
-      } catch (sizeErr) {
-        if (sizeErr && sizeErr.message === "Request body too large") {
-          __clearRequestContext();
-          return new Response("Payload Too Large", { status: 413 });
-        }
-        throw sizeErr;
-      }
-      const payloadResponse = await validateServerActionPayload(body);
-      if (payloadResponse) {
-        __clearRequestContext();
-        return payloadResponse;
-      }
-      const temporaryReferences = createTemporaryReferenceSet();
-      const args = await decodeReply(body, { temporaryReferences });
-      const action = await loadServerAction(actionId);
-      let returnValue;
-      let actionRedirect = null;
-      const previousHeadersPhase = setHeadersAccessPhase("action");
-      try {
-        try {
-          const data = await action.apply(null, args);
-          returnValue = { ok: true, data };
-        } catch (e) {
-          // Detect redirect() / permanentRedirect() called inside the action.
-          // These throw errors with digest "NEXT_REDIRECT;replace;url[;status]".
-          // The URL is encodeURIComponent-encoded to prevent semicolons in the URL
-          // from corrupting the delimiter-based digest format.
-          if (e && typeof e === "object" && "digest" in e) {
-            const digest = String(e.digest);
-            if (digest.startsWith("NEXT_REDIRECT;")) {
-              const parts = digest.split(";");
-              actionRedirect = {
-                url: decodeURIComponent(parts[2]),
-                type: parts[1] || "push",          // "push" or "replace"
-                status: parts[3] ? parseInt(parts[3], 10) : 307,
-              };
-              returnValue = { ok: true, data: undefined };
-            } else if (digest === "NEXT_NOT_FOUND" || digest.startsWith("NEXT_HTTP_ERROR_FALLBACK;")) {
-              // notFound() / forbidden() / unauthorized() in action — package as error
-              returnValue = { ok: false, data: e };
-            } else {
-              // Non-navigation digest error — sanitize in production to avoid
-              // leaking internal details (connection strings, paths, etc.)
-              console.error("[vinext] Server action error:", e);
-              returnValue = { ok: false, data: __sanitizeErrorForClient(e) };
-            }
-          } else {
-            // Unhandled error — sanitize in production to avoid leaking
-            // internal details (database errors, file paths, stack traces, etc.)
-            console.error("[vinext] Server action error:", e);
-            returnValue = { ok: false, data: __sanitizeErrorForClient(e) };
-          }
-        }
-      } finally {
-        setHeadersAccessPhase(previousHeadersPhase);
-      }
-
-      // If the action called redirect(), signal the client to navigate.
-      // We can't use a real HTTP redirect (the fetch would follow it automatically
-      // and receive a page HTML instead of RSC stream). Instead, we return a 200
-      // with x-action-redirect header that the client entry detects and handles.
-      if (actionRedirect) {
-        const actionPendingCookies = getAndClearPendingCookies();
-        const actionDraftCookie = getDraftModeCookieHeader();
-        __clearRequestContext();
-        const redirectHeaders = new Headers({
-          "Content-Type": "text/x-component; charset=utf-8",
-          "Vary": "RSC, Accept",
-        });
-        __mergeMiddlewareResponseHeaders(redirectHeaders, _mwCtx.headers);
-        redirectHeaders.set("x-action-redirect", actionRedirect.url);
-        redirectHeaders.set("x-action-redirect-type", actionRedirect.type);
-        redirectHeaders.set("x-action-redirect-status", String(actionRedirect.status));
-        for (const cookie of actionPendingCookies) {
-          redirectHeaders.append("Set-Cookie", cookie);
-        }
-        if (actionDraftCookie) redirectHeaders.append("Set-Cookie", actionDraftCookie);
-        // Send an empty RSC-like body (client will navigate instead of parsing)
-        return new Response("", { status: 200, headers: redirectHeaders });
-      }
-
-      // After the action, re-render the current page so the client
-      // gets an updated React tree reflecting any mutations.
-      //
-      // When the original request came from inside an intercepted modal
-      // (X-Vinext-Interception-Context present + source route still
-      // matches), rebuild the intercepted tree — otherwise the modal would
-      // unmount and the direct route would render in its place. Mirrors
-      // the interception resolution used by the GET path.
-      const match = matchRoute(cleanPathname);
-      let element;
-      let errorPattern = match ? match.route.pattern : cleanPathname;
-      if (match) {
-        const { route: actionRoute, params: actionParams } = match;
-        const __actionRerenderTarget = __resolveAppPageActionRerenderTarget({
-          cleanPathname,
-          currentParams: actionParams,
-          currentRoute: actionRoute,
-          findIntercept(pathname) {
-            return findIntercept(pathname, interceptionContextHeader);
-          },
-          getRouteParamNames(sourceRoute) {
-            return sourceRoute.params;
-          },
-          getSourceRoute(sourceRouteIndex) {
-            return routes[sourceRouteIndex];
-          },
-          isRscRequest,
-          toInterceptOpts(intercept) {
-            return {
-              interceptionContext: interceptionContextHeader,
-              interceptLayouts: intercept.interceptLayouts,
-              interceptSlotKey: intercept.slotKey,
-              interceptPage: intercept.page,
-              interceptParams: intercept.matchedParams,
-            };
-          },
-        });
-
-        setNavigationContext({
-          pathname: cleanPathname,
-          searchParams: url.searchParams,
-          params: __actionRerenderTarget.navigationParams,
-        });
-        element = buildPageElements(
-          __actionRerenderTarget.route,
-          __actionRerenderTarget.params,
-          cleanPathname,
-          {
-            opts: __actionRerenderTarget.interceptOpts,
-            searchParams: url.searchParams,
-            isRscRequest,
-            request,
-            mountedSlotsHeader: __mountedSlotsHeader,
-          },
-        );
-        errorPattern = __actionRerenderTarget.route.pattern;
-      } else {
-        const _actionRouteId = __createAppPayloadRouteId(cleanPathname, null);
-        element = {
-          [__APP_INTERCEPTION_CONTEXT_KEY]: null,
-          __route: _actionRouteId,
-          __rootLayout: null,
-          [_actionRouteId]: createElement("div", null, "Page not found"),
-        };
-      }
-
-      const onRenderError = createRscOnErrorHandler(
-        request,
-        cleanPathname,
-        errorPattern,
-      );
-      const rscStream = renderToReadableStream(
-        { root: element, returnValue },
-        { temporaryReferences, onError: onRenderError },
-      );
-
-      // Collect cookies set during the action synchronously (before stream is consumed).
-      // Do NOT clear headers/navigation context here — the RSC stream is consumed lazily
-      // by the client, and async server components that run during consumption need the
-      // context to still be live. The AsyncLocalStorage scope from runWithRequestContext
-      // handles cleanup naturally when all async continuations complete.
-      const actionPendingCookies = getAndClearPendingCookies();
-      const actionDraftCookie = getDraftModeCookieHeader();
-
-      const actionHeaders = new Headers({
-        "Content-Type": "text/x-component; charset=utf-8",
-        "Vary": "RSC, Accept",
+  const serverActionResponse = await __handleServerActionRscRequest({
+    actionId,
+    allowedOrigins: __allowedOrigins,
+    buildPageElement({
+      route: actionRoute,
+      params: actionParams,
+      cleanPathname: actionCleanPathname,
+      interceptOpts,
+      searchParams,
+      isRscRequest: actionIsRscRequest,
+      request: actionRequest,
+      mountedSlotsHeader,
+    }) {
+      return buildPageElements(actionRoute, actionParams, actionCleanPathname, {
+        opts: interceptOpts,
+        searchParams,
+        isRscRequest: actionIsRscRequest,
+        request: actionRequest,
+        mountedSlotsHeader,
       });
-      __mergeMiddlewareResponseHeaders(actionHeaders, _mwCtx.headers);
-      const actionResponse = new Response(rscStream, {
-        status: _mwCtx.status ?? 200,
-        headers: actionHeaders,
-      });
-      if (actionPendingCookies.length > 0 || actionDraftCookie) {
-        for (const cookie of actionPendingCookies) {
-          actionResponse.headers.append("Set-Cookie", cookie);
-        }
-        if (actionDraftCookie) actionResponse.headers.append("Set-Cookie", actionDraftCookie);
-      }
-      return actionResponse;
-    } catch (err) {
-      getAndClearPendingCookies(); // Clear pending cookies on error
-      console.error("[vinext] Server action error:", err);
-      _reportRequestError(
-        err instanceof Error ? err : new Error(String(err)),
-        { path: cleanPathname, method: request.method, headers: Object.fromEntries(request.headers.entries()) },
-        { routerKind: "App Router", routePath: cleanPathname, routeType: "action" },
-      );
+    },
+    cleanPathname,
+    clearRequestContext() {
       __clearRequestContext();
-      return new Response(
-        process.env.NODE_ENV === "production"
-          ? "Internal Server Error"
-          : "Server action failed: " + (err && err.message ? err.message : String(err)),
-        { status: 500 },
-      );
-    }
-  }
+    },
+    contentType: actionContentType,
+    createNotFoundElement(actionRouteId) {
+      return {
+        [__APP_INTERCEPTION_CONTEXT_KEY]: null,
+        __route: actionRouteId,
+        __rootLayout: null,
+        [actionRouteId]: createElement("div", null, "Page not found"),
+      };
+    },
+    createPayloadRouteId(pathnameToRender, interceptionContext) {
+      return __createAppPayloadRouteId(pathnameToRender, interceptionContext);
+    },
+    createRscOnErrorHandler(actionRequest, actionPathname, routePattern) {
+      return createRscOnErrorHandler(actionRequest, actionPathname, routePattern);
+    },
+    createTemporaryReferenceSet,
+    decodeReply,
+    findIntercept(pathnameToMatch) {
+      return findIntercept(pathnameToMatch, interceptionContextHeader);
+    },
+    getAndClearPendingCookies,
+    getDraftModeCookieHeader,
+    getRouteParamNames(sourceRoute) {
+      return sourceRoute.params;
+    },
+    getSourceRoute(sourceRouteIndex) {
+      return routes[sourceRouteIndex];
+    },
+    isRscRequest,
+    loadServerAction,
+    matchRoute(pathnameToMatch) {
+      return matchRoute(pathnameToMatch);
+    },
+    maxActionBodySize: __MAX_ACTION_BODY_SIZE,
+    middlewareHeaders: _mwCtx.headers,
+    middlewareStatus: _mwCtx.status,
+    mountedSlotsHeader: __mountedSlotsHeader,
+    readBodyWithLimit: __readBodyWithLimit,
+    readFormDataWithLimit: __readFormDataWithLimit,
+    renderToReadableStream,
+    reportRequestError: _reportRequestError,
+    request,
+    sanitizeErrorForClient(error) {
+      return __sanitizeErrorForClient(error);
+    },
+    searchParams: url.searchParams,
+    setHeadersAccessPhase,
+    setNavigationContext,
+    toInterceptOpts(intercept) {
+      return {
+        interceptionContext: interceptionContextHeader,
+        interceptLayouts: intercept.interceptLayouts,
+        interceptSlotKey: intercept.slotKey,
+        interceptPage: intercept.page,
+        interceptParams: intercept.matchedParams,
+      };
+    },
+  });
+  if (serverActionResponse) return serverActionResponse;
 
   // ── Apply afterFiles rewrites from next.config.js ──────────────────────
   if (__configRewrites.afterFiles && __configRewrites.afterFiles.length) {
@@ -6398,7 +5987,7 @@ import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, 
 import { decodePathParams as __decodePathParams, normalizePath as __normalizePath } from "<ROOT>/packages/vinext/src/server/normalize-path.js";
 import { normalizePathnameForRouteMatch as __normalizePathnameForRouteMatch, normalizePathnameForRouteMatchStrict as __normalizePathnameForRouteMatchStrict } from "<ROOT>/packages/vinext/src/routing/utils.js";
 import { buildRequestHeadersFromMiddlewareResponse as __buildRequestHeadersFromMiddlewareResponse } from "<ROOT>/packages/vinext/src/server/middleware-request-headers.js";
-import { validateCsrfOrigin, validateServerActionPayload, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
+import { validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
 import { applyAppMiddleware as __applyAppMiddleware } from "<ROOT>/packages/vinext/src/server/app-middleware.js";
 import {
   isKnownDynamicAppRoute as __isKnownDynamicAppRoute,
@@ -6414,6 +6003,7 @@ import {
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-execution.js";
 import {
   handleProgressiveServerActionRequest as __handleProgressiveServerActionRequest,
+  handleServerActionRscRequest as __handleServerActionRscRequest,
 } from "<ROOT>/packages/vinext/src/server/app-server-action-execution.js";
 import { readAppRouteHandlerCacheResponse as __readAppRouteHandlerCacheResponse } from "<ROOT>/packages/vinext/src/server/app-route-handler-cache.js";
 import { readAppPageCacheResponse as __readAppPageCacheResponse } from "<ROOT>/packages/vinext/src/server/app-page-cache.js";
@@ -6455,7 +6045,6 @@ import {
 } from "<ROOT>/packages/vinext/src/server/app-page-response.js";
 import { getScriptNonceFromHeaderSources as __getScriptNonceFromHeaderSources } from "<ROOT>/packages/vinext/src/server/csp.js";
 import {
-  resolveAppPageActionRerenderTarget as __resolveAppPageActionRerenderTarget,
   buildAppPageElement as __buildAppPageElement,
   resolveAppPageIntercept as __resolveAppPageIntercept,
   validateAppPageDynamicParams as __validateAppPageDynamicParams,
@@ -7651,227 +7240,90 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   });
   if (progressiveActionResponse) return progressiveActionResponse;
 
-  if (request.method === "POST" && actionId) {
-    // ── CSRF protection ─────────────────────────────────────────────────
-    // Verify that the Origin header matches the Host header to prevent
-    // cross-site request forgery, matching Next.js server action behavior.
-    const csrfResponse = validateCsrfOrigin(request, __allowedOrigins);
-    if (csrfResponse) return csrfResponse;
-
-    // ── Body size limit ─────────────────────────────────────────────────
-    // Reject payloads larger than the configured limit.
-    // Check Content-Length as a fast path, then enforce on the actual
-    // stream to prevent bypasses via chunked transfer-encoding.
-    const contentLength = parseInt(request.headers.get("content-length") || "0", 10);
-    if (contentLength > __MAX_ACTION_BODY_SIZE) {
-      __clearRequestContext();
-      return new Response("Payload Too Large", { status: 413 });
-    }
-
-    try {
-      let body;
-      try {
-        body = actionContentType.startsWith("multipart/form-data")
-          ? await __readFormDataWithLimit(request, __MAX_ACTION_BODY_SIZE)
-          : await __readBodyWithLimit(request, __MAX_ACTION_BODY_SIZE);
-      } catch (sizeErr) {
-        if (sizeErr && sizeErr.message === "Request body too large") {
-          __clearRequestContext();
-          return new Response("Payload Too Large", { status: 413 });
-        }
-        throw sizeErr;
-      }
-      const payloadResponse = await validateServerActionPayload(body);
-      if (payloadResponse) {
-        __clearRequestContext();
-        return payloadResponse;
-      }
-      const temporaryReferences = createTemporaryReferenceSet();
-      const args = await decodeReply(body, { temporaryReferences });
-      const action = await loadServerAction(actionId);
-      let returnValue;
-      let actionRedirect = null;
-      const previousHeadersPhase = setHeadersAccessPhase("action");
-      try {
-        try {
-          const data = await action.apply(null, args);
-          returnValue = { ok: true, data };
-        } catch (e) {
-          // Detect redirect() / permanentRedirect() called inside the action.
-          // These throw errors with digest "NEXT_REDIRECT;replace;url[;status]".
-          // The URL is encodeURIComponent-encoded to prevent semicolons in the URL
-          // from corrupting the delimiter-based digest format.
-          if (e && typeof e === "object" && "digest" in e) {
-            const digest = String(e.digest);
-            if (digest.startsWith("NEXT_REDIRECT;")) {
-              const parts = digest.split(";");
-              actionRedirect = {
-                url: decodeURIComponent(parts[2]),
-                type: parts[1] || "push",          // "push" or "replace"
-                status: parts[3] ? parseInt(parts[3], 10) : 307,
-              };
-              returnValue = { ok: true, data: undefined };
-            } else if (digest === "NEXT_NOT_FOUND" || digest.startsWith("NEXT_HTTP_ERROR_FALLBACK;")) {
-              // notFound() / forbidden() / unauthorized() in action — package as error
-              returnValue = { ok: false, data: e };
-            } else {
-              // Non-navigation digest error — sanitize in production to avoid
-              // leaking internal details (connection strings, paths, etc.)
-              console.error("[vinext] Server action error:", e);
-              returnValue = { ok: false, data: __sanitizeErrorForClient(e) };
-            }
-          } else {
-            // Unhandled error — sanitize in production to avoid leaking
-            // internal details (database errors, file paths, stack traces, etc.)
-            console.error("[vinext] Server action error:", e);
-            returnValue = { ok: false, data: __sanitizeErrorForClient(e) };
-          }
-        }
-      } finally {
-        setHeadersAccessPhase(previousHeadersPhase);
-      }
-
-      // If the action called redirect(), signal the client to navigate.
-      // We can't use a real HTTP redirect (the fetch would follow it automatically
-      // and receive a page HTML instead of RSC stream). Instead, we return a 200
-      // with x-action-redirect header that the client entry detects and handles.
-      if (actionRedirect) {
-        const actionPendingCookies = getAndClearPendingCookies();
-        const actionDraftCookie = getDraftModeCookieHeader();
-        __clearRequestContext();
-        const redirectHeaders = new Headers({
-          "Content-Type": "text/x-component; charset=utf-8",
-          "Vary": "RSC, Accept",
-        });
-        __mergeMiddlewareResponseHeaders(redirectHeaders, _mwCtx.headers);
-        redirectHeaders.set("x-action-redirect", actionRedirect.url);
-        redirectHeaders.set("x-action-redirect-type", actionRedirect.type);
-        redirectHeaders.set("x-action-redirect-status", String(actionRedirect.status));
-        for (const cookie of actionPendingCookies) {
-          redirectHeaders.append("Set-Cookie", cookie);
-        }
-        if (actionDraftCookie) redirectHeaders.append("Set-Cookie", actionDraftCookie);
-        // Send an empty RSC-like body (client will navigate instead of parsing)
-        return new Response("", { status: 200, headers: redirectHeaders });
-      }
-
-      // After the action, re-render the current page so the client
-      // gets an updated React tree reflecting any mutations.
-      //
-      // When the original request came from inside an intercepted modal
-      // (X-Vinext-Interception-Context present + source route still
-      // matches), rebuild the intercepted tree — otherwise the modal would
-      // unmount and the direct route would render in its place. Mirrors
-      // the interception resolution used by the GET path.
-      const match = matchRoute(cleanPathname);
-      let element;
-      let errorPattern = match ? match.route.pattern : cleanPathname;
-      if (match) {
-        const { route: actionRoute, params: actionParams } = match;
-        const __actionRerenderTarget = __resolveAppPageActionRerenderTarget({
-          cleanPathname,
-          currentParams: actionParams,
-          currentRoute: actionRoute,
-          findIntercept(pathname) {
-            return findIntercept(pathname, interceptionContextHeader);
-          },
-          getRouteParamNames(sourceRoute) {
-            return sourceRoute.params;
-          },
-          getSourceRoute(sourceRouteIndex) {
-            return routes[sourceRouteIndex];
-          },
-          isRscRequest,
-          toInterceptOpts(intercept) {
-            return {
-              interceptionContext: interceptionContextHeader,
-              interceptLayouts: intercept.interceptLayouts,
-              interceptSlotKey: intercept.slotKey,
-              interceptPage: intercept.page,
-              interceptParams: intercept.matchedParams,
-            };
-          },
-        });
-
-        setNavigationContext({
-          pathname: cleanPathname,
-          searchParams: url.searchParams,
-          params: __actionRerenderTarget.navigationParams,
-        });
-        element = buildPageElements(
-          __actionRerenderTarget.route,
-          __actionRerenderTarget.params,
-          cleanPathname,
-          {
-            opts: __actionRerenderTarget.interceptOpts,
-            searchParams: url.searchParams,
-            isRscRequest,
-            request,
-            mountedSlotsHeader: __mountedSlotsHeader,
-          },
-        );
-        errorPattern = __actionRerenderTarget.route.pattern;
-      } else {
-        const _actionRouteId = __createAppPayloadRouteId(cleanPathname, null);
-        element = {
-          [__APP_INTERCEPTION_CONTEXT_KEY]: null,
-          __route: _actionRouteId,
-          __rootLayout: null,
-          [_actionRouteId]: createElement("div", null, "Page not found"),
-        };
-      }
-
-      const onRenderError = createRscOnErrorHandler(
-        request,
-        cleanPathname,
-        errorPattern,
-      );
-      const rscStream = renderToReadableStream(
-        { root: element, returnValue },
-        { temporaryReferences, onError: onRenderError },
-      );
-
-      // Collect cookies set during the action synchronously (before stream is consumed).
-      // Do NOT clear headers/navigation context here — the RSC stream is consumed lazily
-      // by the client, and async server components that run during consumption need the
-      // context to still be live. The AsyncLocalStorage scope from runWithRequestContext
-      // handles cleanup naturally when all async continuations complete.
-      const actionPendingCookies = getAndClearPendingCookies();
-      const actionDraftCookie = getDraftModeCookieHeader();
-
-      const actionHeaders = new Headers({
-        "Content-Type": "text/x-component; charset=utf-8",
-        "Vary": "RSC, Accept",
+  const serverActionResponse = await __handleServerActionRscRequest({
+    actionId,
+    allowedOrigins: __allowedOrigins,
+    buildPageElement({
+      route: actionRoute,
+      params: actionParams,
+      cleanPathname: actionCleanPathname,
+      interceptOpts,
+      searchParams,
+      isRscRequest: actionIsRscRequest,
+      request: actionRequest,
+      mountedSlotsHeader,
+    }) {
+      return buildPageElements(actionRoute, actionParams, actionCleanPathname, {
+        opts: interceptOpts,
+        searchParams,
+        isRscRequest: actionIsRscRequest,
+        request: actionRequest,
+        mountedSlotsHeader,
       });
-      __mergeMiddlewareResponseHeaders(actionHeaders, _mwCtx.headers);
-      const actionResponse = new Response(rscStream, {
-        status: _mwCtx.status ?? 200,
-        headers: actionHeaders,
-      });
-      if (actionPendingCookies.length > 0 || actionDraftCookie) {
-        for (const cookie of actionPendingCookies) {
-          actionResponse.headers.append("Set-Cookie", cookie);
-        }
-        if (actionDraftCookie) actionResponse.headers.append("Set-Cookie", actionDraftCookie);
-      }
-      return actionResponse;
-    } catch (err) {
-      getAndClearPendingCookies(); // Clear pending cookies on error
-      console.error("[vinext] Server action error:", err);
-      _reportRequestError(
-        err instanceof Error ? err : new Error(String(err)),
-        { path: cleanPathname, method: request.method, headers: Object.fromEntries(request.headers.entries()) },
-        { routerKind: "App Router", routePath: cleanPathname, routeType: "action" },
-      );
+    },
+    cleanPathname,
+    clearRequestContext() {
       __clearRequestContext();
-      return new Response(
-        process.env.NODE_ENV === "production"
-          ? "Internal Server Error"
-          : "Server action failed: " + (err && err.message ? err.message : String(err)),
-        { status: 500 },
-      );
-    }
-  }
+    },
+    contentType: actionContentType,
+    createNotFoundElement(actionRouteId) {
+      return {
+        [__APP_INTERCEPTION_CONTEXT_KEY]: null,
+        __route: actionRouteId,
+        __rootLayout: null,
+        [actionRouteId]: createElement("div", null, "Page not found"),
+      };
+    },
+    createPayloadRouteId(pathnameToRender, interceptionContext) {
+      return __createAppPayloadRouteId(pathnameToRender, interceptionContext);
+    },
+    createRscOnErrorHandler(actionRequest, actionPathname, routePattern) {
+      return createRscOnErrorHandler(actionRequest, actionPathname, routePattern);
+    },
+    createTemporaryReferenceSet,
+    decodeReply,
+    findIntercept(pathnameToMatch) {
+      return findIntercept(pathnameToMatch, interceptionContextHeader);
+    },
+    getAndClearPendingCookies,
+    getDraftModeCookieHeader,
+    getRouteParamNames(sourceRoute) {
+      return sourceRoute.params;
+    },
+    getSourceRoute(sourceRouteIndex) {
+      return routes[sourceRouteIndex];
+    },
+    isRscRequest,
+    loadServerAction,
+    matchRoute(pathnameToMatch) {
+      return matchRoute(pathnameToMatch);
+    },
+    maxActionBodySize: __MAX_ACTION_BODY_SIZE,
+    middlewareHeaders: _mwCtx.headers,
+    middlewareStatus: _mwCtx.status,
+    mountedSlotsHeader: __mountedSlotsHeader,
+    readBodyWithLimit: __readBodyWithLimit,
+    readFormDataWithLimit: __readFormDataWithLimit,
+    renderToReadableStream,
+    reportRequestError: _reportRequestError,
+    request,
+    sanitizeErrorForClient(error) {
+      return __sanitizeErrorForClient(error);
+    },
+    searchParams: url.searchParams,
+    setHeadersAccessPhase,
+    setNavigationContext,
+    toInterceptOpts(intercept) {
+      return {
+        interceptionContext: interceptionContextHeader,
+        interceptLayouts: intercept.interceptLayouts,
+        interceptSlotKey: intercept.slotKey,
+        interceptPage: intercept.page,
+        interceptParams: intercept.matchedParams,
+      };
+    },
+  });
+  if (serverActionResponse) return serverActionResponse;
 
   // ── Apply afterFiles rewrites from next.config.js ──────────────────────
   if (__configRewrites.afterFiles && __configRewrites.afterFiles.length) {
@@ -8551,7 +8003,7 @@ import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, 
 import { decodePathParams as __decodePathParams, normalizePath as __normalizePath } from "<ROOT>/packages/vinext/src/server/normalize-path.js";
 import { normalizePathnameForRouteMatch as __normalizePathnameForRouteMatch, normalizePathnameForRouteMatchStrict as __normalizePathnameForRouteMatchStrict } from "<ROOT>/packages/vinext/src/routing/utils.js";
 import { buildRequestHeadersFromMiddlewareResponse as __buildRequestHeadersFromMiddlewareResponse } from "<ROOT>/packages/vinext/src/server/middleware-request-headers.js";
-import { validateCsrfOrigin, validateServerActionPayload, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
+import { validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
 import { applyAppMiddleware as __applyAppMiddleware } from "<ROOT>/packages/vinext/src/server/app-middleware.js";
 import {
   isKnownDynamicAppRoute as __isKnownDynamicAppRoute,
@@ -8567,6 +8019,7 @@ import {
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-execution.js";
 import {
   handleProgressiveServerActionRequest as __handleProgressiveServerActionRequest,
+  handleServerActionRscRequest as __handleServerActionRscRequest,
 } from "<ROOT>/packages/vinext/src/server/app-server-action-execution.js";
 import { readAppRouteHandlerCacheResponse as __readAppRouteHandlerCacheResponse } from "<ROOT>/packages/vinext/src/server/app-route-handler-cache.js";
 import { readAppPageCacheResponse as __readAppPageCacheResponse } from "<ROOT>/packages/vinext/src/server/app-page-cache.js";
@@ -8608,7 +8061,6 @@ import {
 } from "<ROOT>/packages/vinext/src/server/app-page-response.js";
 import { getScriptNonceFromHeaderSources as __getScriptNonceFromHeaderSources } from "<ROOT>/packages/vinext/src/server/csp.js";
 import {
-  resolveAppPageActionRerenderTarget as __resolveAppPageActionRerenderTarget,
   buildAppPageElement as __buildAppPageElement,
   resolveAppPageIntercept as __resolveAppPageIntercept,
   validateAppPageDynamicParams as __validateAppPageDynamicParams,
@@ -9778,227 +9230,90 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   });
   if (progressiveActionResponse) return progressiveActionResponse;
 
-  if (request.method === "POST" && actionId) {
-    // ── CSRF protection ─────────────────────────────────────────────────
-    // Verify that the Origin header matches the Host header to prevent
-    // cross-site request forgery, matching Next.js server action behavior.
-    const csrfResponse = validateCsrfOrigin(request, __allowedOrigins);
-    if (csrfResponse) return csrfResponse;
-
-    // ── Body size limit ─────────────────────────────────────────────────
-    // Reject payloads larger than the configured limit.
-    // Check Content-Length as a fast path, then enforce on the actual
-    // stream to prevent bypasses via chunked transfer-encoding.
-    const contentLength = parseInt(request.headers.get("content-length") || "0", 10);
-    if (contentLength > __MAX_ACTION_BODY_SIZE) {
-      __clearRequestContext();
-      return new Response("Payload Too Large", { status: 413 });
-    }
-
-    try {
-      let body;
-      try {
-        body = actionContentType.startsWith("multipart/form-data")
-          ? await __readFormDataWithLimit(request, __MAX_ACTION_BODY_SIZE)
-          : await __readBodyWithLimit(request, __MAX_ACTION_BODY_SIZE);
-      } catch (sizeErr) {
-        if (sizeErr && sizeErr.message === "Request body too large") {
-          __clearRequestContext();
-          return new Response("Payload Too Large", { status: 413 });
-        }
-        throw sizeErr;
-      }
-      const payloadResponse = await validateServerActionPayload(body);
-      if (payloadResponse) {
-        __clearRequestContext();
-        return payloadResponse;
-      }
-      const temporaryReferences = createTemporaryReferenceSet();
-      const args = await decodeReply(body, { temporaryReferences });
-      const action = await loadServerAction(actionId);
-      let returnValue;
-      let actionRedirect = null;
-      const previousHeadersPhase = setHeadersAccessPhase("action");
-      try {
-        try {
-          const data = await action.apply(null, args);
-          returnValue = { ok: true, data };
-        } catch (e) {
-          // Detect redirect() / permanentRedirect() called inside the action.
-          // These throw errors with digest "NEXT_REDIRECT;replace;url[;status]".
-          // The URL is encodeURIComponent-encoded to prevent semicolons in the URL
-          // from corrupting the delimiter-based digest format.
-          if (e && typeof e === "object" && "digest" in e) {
-            const digest = String(e.digest);
-            if (digest.startsWith("NEXT_REDIRECT;")) {
-              const parts = digest.split(";");
-              actionRedirect = {
-                url: decodeURIComponent(parts[2]),
-                type: parts[1] || "push",          // "push" or "replace"
-                status: parts[3] ? parseInt(parts[3], 10) : 307,
-              };
-              returnValue = { ok: true, data: undefined };
-            } else if (digest === "NEXT_NOT_FOUND" || digest.startsWith("NEXT_HTTP_ERROR_FALLBACK;")) {
-              // notFound() / forbidden() / unauthorized() in action — package as error
-              returnValue = { ok: false, data: e };
-            } else {
-              // Non-navigation digest error — sanitize in production to avoid
-              // leaking internal details (connection strings, paths, etc.)
-              console.error("[vinext] Server action error:", e);
-              returnValue = { ok: false, data: __sanitizeErrorForClient(e) };
-            }
-          } else {
-            // Unhandled error — sanitize in production to avoid leaking
-            // internal details (database errors, file paths, stack traces, etc.)
-            console.error("[vinext] Server action error:", e);
-            returnValue = { ok: false, data: __sanitizeErrorForClient(e) };
-          }
-        }
-      } finally {
-        setHeadersAccessPhase(previousHeadersPhase);
-      }
-
-      // If the action called redirect(), signal the client to navigate.
-      // We can't use a real HTTP redirect (the fetch would follow it automatically
-      // and receive a page HTML instead of RSC stream). Instead, we return a 200
-      // with x-action-redirect header that the client entry detects and handles.
-      if (actionRedirect) {
-        const actionPendingCookies = getAndClearPendingCookies();
-        const actionDraftCookie = getDraftModeCookieHeader();
-        __clearRequestContext();
-        const redirectHeaders = new Headers({
-          "Content-Type": "text/x-component; charset=utf-8",
-          "Vary": "RSC, Accept",
-        });
-        __mergeMiddlewareResponseHeaders(redirectHeaders, _mwCtx.headers);
-        redirectHeaders.set("x-action-redirect", actionRedirect.url);
-        redirectHeaders.set("x-action-redirect-type", actionRedirect.type);
-        redirectHeaders.set("x-action-redirect-status", String(actionRedirect.status));
-        for (const cookie of actionPendingCookies) {
-          redirectHeaders.append("Set-Cookie", cookie);
-        }
-        if (actionDraftCookie) redirectHeaders.append("Set-Cookie", actionDraftCookie);
-        // Send an empty RSC-like body (client will navigate instead of parsing)
-        return new Response("", { status: 200, headers: redirectHeaders });
-      }
-
-      // After the action, re-render the current page so the client
-      // gets an updated React tree reflecting any mutations.
-      //
-      // When the original request came from inside an intercepted modal
-      // (X-Vinext-Interception-Context present + source route still
-      // matches), rebuild the intercepted tree — otherwise the modal would
-      // unmount and the direct route would render in its place. Mirrors
-      // the interception resolution used by the GET path.
-      const match = matchRoute(cleanPathname);
-      let element;
-      let errorPattern = match ? match.route.pattern : cleanPathname;
-      if (match) {
-        const { route: actionRoute, params: actionParams } = match;
-        const __actionRerenderTarget = __resolveAppPageActionRerenderTarget({
-          cleanPathname,
-          currentParams: actionParams,
-          currentRoute: actionRoute,
-          findIntercept(pathname) {
-            return findIntercept(pathname, interceptionContextHeader);
-          },
-          getRouteParamNames(sourceRoute) {
-            return sourceRoute.params;
-          },
-          getSourceRoute(sourceRouteIndex) {
-            return routes[sourceRouteIndex];
-          },
-          isRscRequest,
-          toInterceptOpts(intercept) {
-            return {
-              interceptionContext: interceptionContextHeader,
-              interceptLayouts: intercept.interceptLayouts,
-              interceptSlotKey: intercept.slotKey,
-              interceptPage: intercept.page,
-              interceptParams: intercept.matchedParams,
-            };
-          },
-        });
-
-        setNavigationContext({
-          pathname: cleanPathname,
-          searchParams: url.searchParams,
-          params: __actionRerenderTarget.navigationParams,
-        });
-        element = buildPageElements(
-          __actionRerenderTarget.route,
-          __actionRerenderTarget.params,
-          cleanPathname,
-          {
-            opts: __actionRerenderTarget.interceptOpts,
-            searchParams: url.searchParams,
-            isRscRequest,
-            request,
-            mountedSlotsHeader: __mountedSlotsHeader,
-          },
-        );
-        errorPattern = __actionRerenderTarget.route.pattern;
-      } else {
-        const _actionRouteId = __createAppPayloadRouteId(cleanPathname, null);
-        element = {
-          [__APP_INTERCEPTION_CONTEXT_KEY]: null,
-          __route: _actionRouteId,
-          __rootLayout: null,
-          [_actionRouteId]: createElement("div", null, "Page not found"),
-        };
-      }
-
-      const onRenderError = createRscOnErrorHandler(
-        request,
-        cleanPathname,
-        errorPattern,
-      );
-      const rscStream = renderToReadableStream(
-        { root: element, returnValue },
-        { temporaryReferences, onError: onRenderError },
-      );
-
-      // Collect cookies set during the action synchronously (before stream is consumed).
-      // Do NOT clear headers/navigation context here — the RSC stream is consumed lazily
-      // by the client, and async server components that run during consumption need the
-      // context to still be live. The AsyncLocalStorage scope from runWithRequestContext
-      // handles cleanup naturally when all async continuations complete.
-      const actionPendingCookies = getAndClearPendingCookies();
-      const actionDraftCookie = getDraftModeCookieHeader();
-
-      const actionHeaders = new Headers({
-        "Content-Type": "text/x-component; charset=utf-8",
-        "Vary": "RSC, Accept",
+  const serverActionResponse = await __handleServerActionRscRequest({
+    actionId,
+    allowedOrigins: __allowedOrigins,
+    buildPageElement({
+      route: actionRoute,
+      params: actionParams,
+      cleanPathname: actionCleanPathname,
+      interceptOpts,
+      searchParams,
+      isRscRequest: actionIsRscRequest,
+      request: actionRequest,
+      mountedSlotsHeader,
+    }) {
+      return buildPageElements(actionRoute, actionParams, actionCleanPathname, {
+        opts: interceptOpts,
+        searchParams,
+        isRscRequest: actionIsRscRequest,
+        request: actionRequest,
+        mountedSlotsHeader,
       });
-      __mergeMiddlewareResponseHeaders(actionHeaders, _mwCtx.headers);
-      const actionResponse = new Response(rscStream, {
-        status: _mwCtx.status ?? 200,
-        headers: actionHeaders,
-      });
-      if (actionPendingCookies.length > 0 || actionDraftCookie) {
-        for (const cookie of actionPendingCookies) {
-          actionResponse.headers.append("Set-Cookie", cookie);
-        }
-        if (actionDraftCookie) actionResponse.headers.append("Set-Cookie", actionDraftCookie);
-      }
-      return actionResponse;
-    } catch (err) {
-      getAndClearPendingCookies(); // Clear pending cookies on error
-      console.error("[vinext] Server action error:", err);
-      _reportRequestError(
-        err instanceof Error ? err : new Error(String(err)),
-        { path: cleanPathname, method: request.method, headers: Object.fromEntries(request.headers.entries()) },
-        { routerKind: "App Router", routePath: cleanPathname, routeType: "action" },
-      );
+    },
+    cleanPathname,
+    clearRequestContext() {
       __clearRequestContext();
-      return new Response(
-        process.env.NODE_ENV === "production"
-          ? "Internal Server Error"
-          : "Server action failed: " + (err && err.message ? err.message : String(err)),
-        { status: 500 },
-      );
-    }
-  }
+    },
+    contentType: actionContentType,
+    createNotFoundElement(actionRouteId) {
+      return {
+        [__APP_INTERCEPTION_CONTEXT_KEY]: null,
+        __route: actionRouteId,
+        __rootLayout: null,
+        [actionRouteId]: createElement("div", null, "Page not found"),
+      };
+    },
+    createPayloadRouteId(pathnameToRender, interceptionContext) {
+      return __createAppPayloadRouteId(pathnameToRender, interceptionContext);
+    },
+    createRscOnErrorHandler(actionRequest, actionPathname, routePattern) {
+      return createRscOnErrorHandler(actionRequest, actionPathname, routePattern);
+    },
+    createTemporaryReferenceSet,
+    decodeReply,
+    findIntercept(pathnameToMatch) {
+      return findIntercept(pathnameToMatch, interceptionContextHeader);
+    },
+    getAndClearPendingCookies,
+    getDraftModeCookieHeader,
+    getRouteParamNames(sourceRoute) {
+      return sourceRoute.params;
+    },
+    getSourceRoute(sourceRouteIndex) {
+      return routes[sourceRouteIndex];
+    },
+    isRscRequest,
+    loadServerAction,
+    matchRoute(pathnameToMatch) {
+      return matchRoute(pathnameToMatch);
+    },
+    maxActionBodySize: __MAX_ACTION_BODY_SIZE,
+    middlewareHeaders: _mwCtx.headers,
+    middlewareStatus: _mwCtx.status,
+    mountedSlotsHeader: __mountedSlotsHeader,
+    readBodyWithLimit: __readBodyWithLimit,
+    readFormDataWithLimit: __readFormDataWithLimit,
+    renderToReadableStream,
+    reportRequestError: _reportRequestError,
+    request,
+    sanitizeErrorForClient(error) {
+      return __sanitizeErrorForClient(error);
+    },
+    searchParams: url.searchParams,
+    setHeadersAccessPhase,
+    setNavigationContext,
+    toInterceptOpts(intercept) {
+      return {
+        interceptionContext: interceptionContextHeader,
+        interceptLayouts: intercept.interceptLayouts,
+        interceptSlotKey: intercept.slotKey,
+        interceptPage: intercept.page,
+        interceptParams: intercept.matchedParams,
+      };
+    },
+  });
+  if (serverActionResponse) return serverActionResponse;
 
   // ── Apply afterFiles rewrites from next.config.js ──────────────────────
   if (__configRewrites.afterFiles && __configRewrites.afterFiles.length) {
@@ -10678,7 +9993,7 @@ import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, 
 import { decodePathParams as __decodePathParams, normalizePath as __normalizePath } from "<ROOT>/packages/vinext/src/server/normalize-path.js";
 import { normalizePathnameForRouteMatch as __normalizePathnameForRouteMatch, normalizePathnameForRouteMatchStrict as __normalizePathnameForRouteMatchStrict } from "<ROOT>/packages/vinext/src/routing/utils.js";
 import { buildRequestHeadersFromMiddlewareResponse as __buildRequestHeadersFromMiddlewareResponse } from "<ROOT>/packages/vinext/src/server/middleware-request-headers.js";
-import { validateCsrfOrigin, validateServerActionPayload, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
+import { validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
 import { applyAppMiddleware as __applyAppMiddleware } from "<ROOT>/packages/vinext/src/server/app-middleware.js";
 import {
   isKnownDynamicAppRoute as __isKnownDynamicAppRoute,
@@ -10694,6 +10009,7 @@ import {
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-execution.js";
 import {
   handleProgressiveServerActionRequest as __handleProgressiveServerActionRequest,
+  handleServerActionRscRequest as __handleServerActionRscRequest,
 } from "<ROOT>/packages/vinext/src/server/app-server-action-execution.js";
 import { readAppRouteHandlerCacheResponse as __readAppRouteHandlerCacheResponse } from "<ROOT>/packages/vinext/src/server/app-route-handler-cache.js";
 import { readAppPageCacheResponse as __readAppPageCacheResponse } from "<ROOT>/packages/vinext/src/server/app-page-cache.js";
@@ -10735,7 +10051,6 @@ import {
 } from "<ROOT>/packages/vinext/src/server/app-page-response.js";
 import { getScriptNonceFromHeaderSources as __getScriptNonceFromHeaderSources } from "<ROOT>/packages/vinext/src/server/csp.js";
 import {
-  resolveAppPageActionRerenderTarget as __resolveAppPageActionRerenderTarget,
   buildAppPageElement as __buildAppPageElement,
   resolveAppPageIntercept as __resolveAppPageIntercept,
   validateAppPageDynamicParams as __validateAppPageDynamicParams,
@@ -11913,227 +11228,90 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   });
   if (progressiveActionResponse) return progressiveActionResponse;
 
-  if (request.method === "POST" && actionId) {
-    // ── CSRF protection ─────────────────────────────────────────────────
-    // Verify that the Origin header matches the Host header to prevent
-    // cross-site request forgery, matching Next.js server action behavior.
-    const csrfResponse = validateCsrfOrigin(request, __allowedOrigins);
-    if (csrfResponse) return csrfResponse;
-
-    // ── Body size limit ─────────────────────────────────────────────────
-    // Reject payloads larger than the configured limit.
-    // Check Content-Length as a fast path, then enforce on the actual
-    // stream to prevent bypasses via chunked transfer-encoding.
-    const contentLength = parseInt(request.headers.get("content-length") || "0", 10);
-    if (contentLength > __MAX_ACTION_BODY_SIZE) {
-      __clearRequestContext();
-      return new Response("Payload Too Large", { status: 413 });
-    }
-
-    try {
-      let body;
-      try {
-        body = actionContentType.startsWith("multipart/form-data")
-          ? await __readFormDataWithLimit(request, __MAX_ACTION_BODY_SIZE)
-          : await __readBodyWithLimit(request, __MAX_ACTION_BODY_SIZE);
-      } catch (sizeErr) {
-        if (sizeErr && sizeErr.message === "Request body too large") {
-          __clearRequestContext();
-          return new Response("Payload Too Large", { status: 413 });
-        }
-        throw sizeErr;
-      }
-      const payloadResponse = await validateServerActionPayload(body);
-      if (payloadResponse) {
-        __clearRequestContext();
-        return payloadResponse;
-      }
-      const temporaryReferences = createTemporaryReferenceSet();
-      const args = await decodeReply(body, { temporaryReferences });
-      const action = await loadServerAction(actionId);
-      let returnValue;
-      let actionRedirect = null;
-      const previousHeadersPhase = setHeadersAccessPhase("action");
-      try {
-        try {
-          const data = await action.apply(null, args);
-          returnValue = { ok: true, data };
-        } catch (e) {
-          // Detect redirect() / permanentRedirect() called inside the action.
-          // These throw errors with digest "NEXT_REDIRECT;replace;url[;status]".
-          // The URL is encodeURIComponent-encoded to prevent semicolons in the URL
-          // from corrupting the delimiter-based digest format.
-          if (e && typeof e === "object" && "digest" in e) {
-            const digest = String(e.digest);
-            if (digest.startsWith("NEXT_REDIRECT;")) {
-              const parts = digest.split(";");
-              actionRedirect = {
-                url: decodeURIComponent(parts[2]),
-                type: parts[1] || "push",          // "push" or "replace"
-                status: parts[3] ? parseInt(parts[3], 10) : 307,
-              };
-              returnValue = { ok: true, data: undefined };
-            } else if (digest === "NEXT_NOT_FOUND" || digest.startsWith("NEXT_HTTP_ERROR_FALLBACK;")) {
-              // notFound() / forbidden() / unauthorized() in action — package as error
-              returnValue = { ok: false, data: e };
-            } else {
-              // Non-navigation digest error — sanitize in production to avoid
-              // leaking internal details (connection strings, paths, etc.)
-              console.error("[vinext] Server action error:", e);
-              returnValue = { ok: false, data: __sanitizeErrorForClient(e) };
-            }
-          } else {
-            // Unhandled error — sanitize in production to avoid leaking
-            // internal details (database errors, file paths, stack traces, etc.)
-            console.error("[vinext] Server action error:", e);
-            returnValue = { ok: false, data: __sanitizeErrorForClient(e) };
-          }
-        }
-      } finally {
-        setHeadersAccessPhase(previousHeadersPhase);
-      }
-
-      // If the action called redirect(), signal the client to navigate.
-      // We can't use a real HTTP redirect (the fetch would follow it automatically
-      // and receive a page HTML instead of RSC stream). Instead, we return a 200
-      // with x-action-redirect header that the client entry detects and handles.
-      if (actionRedirect) {
-        const actionPendingCookies = getAndClearPendingCookies();
-        const actionDraftCookie = getDraftModeCookieHeader();
-        __clearRequestContext();
-        const redirectHeaders = new Headers({
-          "Content-Type": "text/x-component; charset=utf-8",
-          "Vary": "RSC, Accept",
-        });
-        __mergeMiddlewareResponseHeaders(redirectHeaders, _mwCtx.headers);
-        redirectHeaders.set("x-action-redirect", actionRedirect.url);
-        redirectHeaders.set("x-action-redirect-type", actionRedirect.type);
-        redirectHeaders.set("x-action-redirect-status", String(actionRedirect.status));
-        for (const cookie of actionPendingCookies) {
-          redirectHeaders.append("Set-Cookie", cookie);
-        }
-        if (actionDraftCookie) redirectHeaders.append("Set-Cookie", actionDraftCookie);
-        // Send an empty RSC-like body (client will navigate instead of parsing)
-        return new Response("", { status: 200, headers: redirectHeaders });
-      }
-
-      // After the action, re-render the current page so the client
-      // gets an updated React tree reflecting any mutations.
-      //
-      // When the original request came from inside an intercepted modal
-      // (X-Vinext-Interception-Context present + source route still
-      // matches), rebuild the intercepted tree — otherwise the modal would
-      // unmount and the direct route would render in its place. Mirrors
-      // the interception resolution used by the GET path.
-      const match = matchRoute(cleanPathname);
-      let element;
-      let errorPattern = match ? match.route.pattern : cleanPathname;
-      if (match) {
-        const { route: actionRoute, params: actionParams } = match;
-        const __actionRerenderTarget = __resolveAppPageActionRerenderTarget({
-          cleanPathname,
-          currentParams: actionParams,
-          currentRoute: actionRoute,
-          findIntercept(pathname) {
-            return findIntercept(pathname, interceptionContextHeader);
-          },
-          getRouteParamNames(sourceRoute) {
-            return sourceRoute.params;
-          },
-          getSourceRoute(sourceRouteIndex) {
-            return routes[sourceRouteIndex];
-          },
-          isRscRequest,
-          toInterceptOpts(intercept) {
-            return {
-              interceptionContext: interceptionContextHeader,
-              interceptLayouts: intercept.interceptLayouts,
-              interceptSlotKey: intercept.slotKey,
-              interceptPage: intercept.page,
-              interceptParams: intercept.matchedParams,
-            };
-          },
-        });
-
-        setNavigationContext({
-          pathname: cleanPathname,
-          searchParams: url.searchParams,
-          params: __actionRerenderTarget.navigationParams,
-        });
-        element = buildPageElements(
-          __actionRerenderTarget.route,
-          __actionRerenderTarget.params,
-          cleanPathname,
-          {
-            opts: __actionRerenderTarget.interceptOpts,
-            searchParams: url.searchParams,
-            isRscRequest,
-            request,
-            mountedSlotsHeader: __mountedSlotsHeader,
-          },
-        );
-        errorPattern = __actionRerenderTarget.route.pattern;
-      } else {
-        const _actionRouteId = __createAppPayloadRouteId(cleanPathname, null);
-        element = {
-          [__APP_INTERCEPTION_CONTEXT_KEY]: null,
-          __route: _actionRouteId,
-          __rootLayout: null,
-          [_actionRouteId]: createElement("div", null, "Page not found"),
-        };
-      }
-
-      const onRenderError = createRscOnErrorHandler(
-        request,
-        cleanPathname,
-        errorPattern,
-      );
-      const rscStream = renderToReadableStream(
-        { root: element, returnValue },
-        { temporaryReferences, onError: onRenderError },
-      );
-
-      // Collect cookies set during the action synchronously (before stream is consumed).
-      // Do NOT clear headers/navigation context here — the RSC stream is consumed lazily
-      // by the client, and async server components that run during consumption need the
-      // context to still be live. The AsyncLocalStorage scope from runWithRequestContext
-      // handles cleanup naturally when all async continuations complete.
-      const actionPendingCookies = getAndClearPendingCookies();
-      const actionDraftCookie = getDraftModeCookieHeader();
-
-      const actionHeaders = new Headers({
-        "Content-Type": "text/x-component; charset=utf-8",
-        "Vary": "RSC, Accept",
+  const serverActionResponse = await __handleServerActionRscRequest({
+    actionId,
+    allowedOrigins: __allowedOrigins,
+    buildPageElement({
+      route: actionRoute,
+      params: actionParams,
+      cleanPathname: actionCleanPathname,
+      interceptOpts,
+      searchParams,
+      isRscRequest: actionIsRscRequest,
+      request: actionRequest,
+      mountedSlotsHeader,
+    }) {
+      return buildPageElements(actionRoute, actionParams, actionCleanPathname, {
+        opts: interceptOpts,
+        searchParams,
+        isRscRequest: actionIsRscRequest,
+        request: actionRequest,
+        mountedSlotsHeader,
       });
-      __mergeMiddlewareResponseHeaders(actionHeaders, _mwCtx.headers);
-      const actionResponse = new Response(rscStream, {
-        status: _mwCtx.status ?? 200,
-        headers: actionHeaders,
-      });
-      if (actionPendingCookies.length > 0 || actionDraftCookie) {
-        for (const cookie of actionPendingCookies) {
-          actionResponse.headers.append("Set-Cookie", cookie);
-        }
-        if (actionDraftCookie) actionResponse.headers.append("Set-Cookie", actionDraftCookie);
-      }
-      return actionResponse;
-    } catch (err) {
-      getAndClearPendingCookies(); // Clear pending cookies on error
-      console.error("[vinext] Server action error:", err);
-      _reportRequestError(
-        err instanceof Error ? err : new Error(String(err)),
-        { path: cleanPathname, method: request.method, headers: Object.fromEntries(request.headers.entries()) },
-        { routerKind: "App Router", routePath: cleanPathname, routeType: "action" },
-      );
+    },
+    cleanPathname,
+    clearRequestContext() {
       __clearRequestContext();
-      return new Response(
-        process.env.NODE_ENV === "production"
-          ? "Internal Server Error"
-          : "Server action failed: " + (err && err.message ? err.message : String(err)),
-        { status: 500 },
-      );
-    }
-  }
+    },
+    contentType: actionContentType,
+    createNotFoundElement(actionRouteId) {
+      return {
+        [__APP_INTERCEPTION_CONTEXT_KEY]: null,
+        __route: actionRouteId,
+        __rootLayout: null,
+        [actionRouteId]: createElement("div", null, "Page not found"),
+      };
+    },
+    createPayloadRouteId(pathnameToRender, interceptionContext) {
+      return __createAppPayloadRouteId(pathnameToRender, interceptionContext);
+    },
+    createRscOnErrorHandler(actionRequest, actionPathname, routePattern) {
+      return createRscOnErrorHandler(actionRequest, actionPathname, routePattern);
+    },
+    createTemporaryReferenceSet,
+    decodeReply,
+    findIntercept(pathnameToMatch) {
+      return findIntercept(pathnameToMatch, interceptionContextHeader);
+    },
+    getAndClearPendingCookies,
+    getDraftModeCookieHeader,
+    getRouteParamNames(sourceRoute) {
+      return sourceRoute.params;
+    },
+    getSourceRoute(sourceRouteIndex) {
+      return routes[sourceRouteIndex];
+    },
+    isRscRequest,
+    loadServerAction,
+    matchRoute(pathnameToMatch) {
+      return matchRoute(pathnameToMatch);
+    },
+    maxActionBodySize: __MAX_ACTION_BODY_SIZE,
+    middlewareHeaders: _mwCtx.headers,
+    middlewareStatus: _mwCtx.status,
+    mountedSlotsHeader: __mountedSlotsHeader,
+    readBodyWithLimit: __readBodyWithLimit,
+    readFormDataWithLimit: __readFormDataWithLimit,
+    renderToReadableStream,
+    reportRequestError: _reportRequestError,
+    request,
+    sanitizeErrorForClient(error) {
+      return __sanitizeErrorForClient(error);
+    },
+    searchParams: url.searchParams,
+    setHeadersAccessPhase,
+    setNavigationContext,
+    toInterceptOpts(intercept) {
+      return {
+        interceptionContext: interceptionContextHeader,
+        interceptLayouts: intercept.interceptLayouts,
+        interceptSlotKey: intercept.slotKey,
+        interceptPage: intercept.page,
+        interceptParams: intercept.matchedParams,
+      };
+    },
+  });
+  if (serverActionResponse) return serverActionResponse;
 
   // ── Apply afterFiles rewrites from next.config.js ──────────────────────
   if (__configRewrites.afterFiles && __configRewrites.afterFiles.length) {

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -3505,28 +3505,29 @@ describe("App Router next.config.js features (generateRscEntry)", () => {
     expect(code).toContain("hasBasePath(__redir.destination, __basePath)");
   });
 
-  it("generates CSRF origin validation code for server actions", () => {
+  it("generated RSC entry delegates server action requests to the shared helper", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes, null, [], null, "", false);
-    // Should import the CSRF validation function from request-pipeline
-    expect(code).toContain("validateCsrfOrigin");
-    // Should call CSRF validation before processing server actions
-    const csrfIdx = code.indexOf("validateCsrfOrigin(request");
-    const actionIdx = code.indexOf("loadServerAction(actionId)");
-    expect(csrfIdx).toBeGreaterThan(-1);
-    expect(actionIdx).toBeGreaterThan(-1);
-    expect(csrfIdx).toBeLessThan(actionIdx);
+    expect(code).toContain("handleServerActionRscRequest as __handleServerActionRscRequest");
+    expect(code).toContain("const serverActionResponse = await __handleServerActionRscRequest({");
+    expect(code).toContain("allowedOrigins: __allowedOrigins");
+    expect(code).toContain("loadServerAction");
+    expect(code).toContain("decodeReply");
+
+    const actionStart = code.indexOf("const serverActionResponse");
+    const routingStart = code.indexOf("// ── Apply afterFiles rewrites", actionStart);
+    expect(actionStart).toBeGreaterThan(-1);
+    expect(routingStart).toBeGreaterThan(actionStart);
   });
 
-  it("generates server action payload validation before decodeReply", () => {
+  it("generated RSC entry wires server action body readers into the shared helper", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes, null, [], null, "", false);
-    expect(code).toContain("validateServerActionPayload(body)");
-
-    const payloadValidationIdx = code.indexOf("validateServerActionPayload(body)");
-    const decodeIdx = code.indexOf("decodeReply(body, { temporaryReferences })");
-
-    expect(payloadValidationIdx).toBeGreaterThan(-1);
-    expect(decodeIdx).toBeGreaterThan(-1);
-    expect(payloadValidationIdx).toBeLessThan(decodeIdx);
+    const actionStart = code.indexOf("const serverActionResponse");
+    const actionEnd = code.indexOf("if (serverActionResponse)", actionStart);
+    const actionOptions = code.slice(actionStart, actionEnd);
+    expect(actionOptions).toContain("contentType: actionContentType");
+    expect(actionOptions).toContain("readBodyWithLimit: __readBodyWithLimit");
+    expect(actionOptions).toContain("readFormDataWithLimit: __readFormDataWithLimit");
+    expect(actionOptions).toContain("maxActionBodySize: __MAX_ACTION_BODY_SIZE");
   });
 
   it("embeds allowedOrigins when provided", () => {
@@ -3556,11 +3557,16 @@ describe("App Router next.config.js features (generateRscEntry)", () => {
 
   it("origin validation does not use x-forwarded-host", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes, null, [], null, "", false);
-    // validateCsrfOrigin is now imported from request-pipeline.ts rather than
-    // inlined. The imported function uses host header only (not x-forwarded-host).
-    // Verify the call site passes allowed origins to the imported function.
-    expect(code).toContain("validateCsrfOrigin(request, __allowedOrigins)");
-    // The generated code should NOT define an inline __validateCsrfOrigin function
+    const actionStart = code.indexOf("const serverActionResponse");
+    const actionEnd = code.indexOf("if (serverActionResponse)", actionStart);
+    const actionOptions = code.slice(actionStart, actionEnd);
+
+    // CSRF behavior belongs to the shared action helper. The generated entry
+    // should only pass the original Request and configured origins through.
+    expect(actionOptions).toContain("request,");
+    expect(actionOptions).toContain("allowedOrigins: __allowedOrigins");
+    expect(actionOptions).not.toContain("x-forwarded-host");
+    expect(code).not.toContain("validateCsrfOrigin(request, __allowedOrigins)");
     expect(code).not.toContain("function __validateCsrfOrigin");
   });
 
@@ -4760,13 +4766,13 @@ describe("generateRscEntry ISR code generation", () => {
 
   it("generated code merges middleware headers into server action re-render responses", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes);
-    // The server action re-render path must call mergeMiddlewareResponseHeaders
-    // to apply middleware headers to the RSC response containing the re-rendered page.
-    // Find the action response construction area (after actionHeaders, before catch)
-    const actionHeadersIdx = code.indexOf("const actionHeaders =");
-    const actionCatchIdx = code.indexOf("} catch (err)", actionHeadersIdx);
-    const actionResponseBody = code.slice(actionHeadersIdx, actionCatchIdx);
-    expect(actionResponseBody).toContain("mergeMiddlewareResponseHeaders");
+    // The shared action helper owns response construction; generated code must
+    // pass the middleware response state into that helper.
+    const actionStart = code.indexOf("const serverActionResponse");
+    const actionEnd = code.indexOf("if (serverActionResponse)", actionStart);
+    const actionOptions = code.slice(actionStart, actionEnd);
+    expect(actionOptions).toContain("middlewareHeaders: _mwCtx.headers");
+    expect(actionOptions).toContain("middlewareStatus: _mwCtx.status");
   });
 
   it("generated code accepts both vinext and Next.js action header names", () => {
@@ -4778,36 +4784,19 @@ describe("generateRscEntry ISR code generation", () => {
 
   it("generated code merges middleware headers into server action redirect responses", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes);
-    // The server action redirect path must call mergeMiddlewareResponseHeaders
-    // to apply middleware headers to the redirect response.
-    const redirectStart = code.indexOf("if (actionRedirect)");
-    const redirectEnd = code.indexOf('return new Response(""', redirectStart);
-    const redirectBody = code.slice(redirectStart, redirectEnd);
-    expect(redirectBody).toContain("mergeMiddlewareResponseHeaders");
-    // Framework-owned redirect headers must be written after the middleware merge
-    // so middleware cannot clobber the target URL or redirect type.
-    const mergeIndex = redirectBody.indexOf("__mergeMiddlewareResponseHeaders");
-    const redirectHeaderIndex = redirectBody.indexOf('redirectHeaders.set("x-action-redirect"');
-    expect(mergeIndex).toBeGreaterThan(-1);
-    expect(redirectHeaderIndex).toBeGreaterThan(-1);
-    expect(mergeIndex).toBeLessThan(redirectHeaderIndex);
+    const actionStart = code.indexOf("const serverActionResponse");
+    const actionEnd = code.indexOf("if (serverActionResponse)", actionStart);
+    const actionOptions = code.slice(actionStart, actionEnd);
+    expect(actionOptions).toContain("middlewareHeaders: _mwCtx.headers");
   });
 
   // Ported from Next.js: packages/next/src/client/components/redirect.ts
   // In Next.js, redirect() defaults to "push" in Server Action context so
   // the Back button works after form submissions. The empty sentinel in the
   // digest (parts[1] === "") should resolve to "push" in the action handler.
-  it("generated action handler defaults empty redirect type to 'push'", () => {
+  it("generated RSC entry leaves server action redirect digest handling to the shared helper", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes);
-    // Find the action redirect digest parsing block
-    const digestStart = code.indexOf('if (digest.startsWith("NEXT_REDIRECT;"))');
-    const actionRedirectEnd = code.indexOf(
-      "returnValue = { ok: true, data: undefined }",
-      digestStart,
-    );
-    const digestBlock = code.slice(digestStart, actionRedirectEnd);
-    // The fallback for empty type must be "push", not "replace"
-    expect(digestBlock).toContain('parts[1] || "push"');
-    expect(digestBlock).not.toContain('parts[1] || "replace"');
+    expect(code).not.toContain('digest.startsWith("NEXT_REDIRECT;")');
+    expect(code).toContain("handleServerActionRscRequest as __handleServerActionRscRequest");
   });
 });

--- a/tests/app-server-action-execution.test.ts
+++ b/tests/app-server-action-execution.test.ts
@@ -1,9 +1,30 @@
 import { describe, expect, it, vi } from "vite-plus/test";
 import {
+  handleServerActionRscRequest,
   handleProgressiveServerActionRequest,
   isProgressiveServerActionRequest,
+  type HandleServerActionRscRequestOptions,
   type HandleProgressiveServerActionRequestOptions,
 } from "../packages/vinext/src/server/app-server-action-execution.js";
+
+type TestRoute = {
+  id: string;
+  params: readonly string[];
+  pattern: string;
+};
+
+type TestInterceptOptions = {
+  slot: string;
+};
+
+type TestTemporaryReferences = {
+  marker: string;
+};
+
+type TestActionModel = {
+  returnValue: unknown;
+  root: string;
+};
 
 function createMultipartRequest(headers?: HeadersInit): Request {
   const requestHeaders = new Headers({
@@ -61,6 +82,119 @@ function createOptions(
     request: createMultipartRequest(),
     setHeadersAccessPhase() {
       return "render";
+    },
+    ...overrides,
+  };
+}
+
+function createFetchActionRequest(headers?: HeadersInit): Request {
+  const requestHeaders = new Headers({
+    "content-type": "text/plain;charset=UTF-8",
+    host: "example.com",
+    origin: "https://example.com",
+    "x-rsc-action": "action-id",
+  });
+  if (headers) {
+    for (const [key, value] of new Headers(headers)) {
+      requestHeaders.set(key, value);
+    }
+  }
+
+  return new Request("https://example.com/dashboard?tab=activity", {
+    body: "encoded-flight-body",
+    method: "POST",
+    headers: requestHeaders,
+  });
+}
+
+function createRscOptions(
+  overrides: Partial<
+    HandleServerActionRscRequestOptions<
+      string,
+      TestRoute,
+      TestInterceptOptions,
+      TestTemporaryReferences
+    >
+  > = {},
+): HandleServerActionRscRequestOptions<
+  string,
+  TestRoute,
+  TestInterceptOptions,
+  TestTemporaryReferences
+> {
+  const route: TestRoute = { id: "dashboard", params: [], pattern: "/dashboard" };
+
+  return {
+    actionId: "action-id",
+    allowedOrigins: [],
+    buildPageElement({ route: matchedRoute, params, interceptOpts }) {
+      return `${matchedRoute.id}:${JSON.stringify(params)}:${interceptOpts?.slot ?? "none"}`;
+    },
+    cleanPathname: "/dashboard",
+    clearRequestContext() {},
+    contentType: "text/plain;charset=UTF-8",
+    createNotFoundElement(routeId) {
+      return `not-found:${routeId}`;
+    },
+    createPayloadRouteId(pathname, interceptionContext) {
+      return `${pathname}:${interceptionContext ?? "none"}`;
+    },
+    createRscOnErrorHandler(_request, pathname, pattern) {
+      return () => `${pathname}:${pattern}`;
+    },
+    createTemporaryReferenceSet() {
+      return { marker: "refs" };
+    },
+    decodeReply() {
+      return Promise.resolve([]);
+    },
+    findIntercept() {
+      return null;
+    },
+    getAndClearPendingCookies() {
+      return [];
+    },
+    getDraftModeCookieHeader() {
+      return null;
+    },
+    getRouteParamNames(matchedRoute) {
+      return matchedRoute.params;
+    },
+    getSourceRoute() {
+      return undefined;
+    },
+    isRscRequest: true,
+    loadServerAction() {
+      return Promise.resolve(() => "action-result");
+    },
+    matchRoute() {
+      return { params: {}, route };
+    },
+    maxActionBodySize: 1024,
+    middlewareHeaders: null,
+    middlewareStatus: null,
+    mountedSlotsHeader: null,
+    readBodyWithLimit() {
+      return Promise.resolve("encoded-flight-body");
+    },
+    readFormDataWithLimit() {
+      return Promise.resolve(new FormData());
+    },
+    renderToReadableStream(model) {
+      return new Response(JSON.stringify(model)).body;
+    },
+    reportRequestError() {},
+    request: createFetchActionRequest(),
+    sanitizeErrorForClient(error) {
+      return error;
+    },
+    searchParams: new URLSearchParams("tab=activity"),
+    setHeadersAccessPhase() {
+      return "render";
+    },
+    setNavigationContext() {},
+    toInterceptOpts(intercept) {
+      return { slot: intercept.slotKey };
     },
     ...overrides,
   };
@@ -292,5 +426,152 @@ describe("app server action execution helpers", () => {
     expect(clearContext).toHaveBeenCalledTimes(1);
 
     errorSpy.mockRestore();
+  });
+
+  it("returns null for non-fetch RSC action requests", async () => {
+    const response = await handleServerActionRscRequest(
+      createRscOptions({
+        actionId: null,
+        loadServerAction: vi.fn(),
+      }),
+    );
+
+    expect(response).toBeNull();
+  });
+
+  it("executes fetch actions and returns a rerendered RSC payload", async () => {
+    const phaseCalls: string[] = [];
+    const navigationContexts: Array<{
+      params: Record<string, string | string[]>;
+      pathname: string;
+    }> = [];
+    const temporaryReferences = { marker: "test-refs" };
+    let renderedModel: TestActionModel | null = null;
+
+    const response = await handleServerActionRscRequest(
+      createRscOptions({
+        createTemporaryReferenceSet() {
+          return temporaryReferences;
+        },
+        decodeReply(body, options) {
+          expect(body).toBe("encoded-flight-body");
+          expect(options.temporaryReferences).toBe(temporaryReferences);
+          return Promise.resolve(["first", "second"]);
+        },
+        getAndClearPendingCookies() {
+          return ["action=1; Path=/"];
+        },
+        getDraftModeCookieHeader() {
+          return "draft=1; Path=/";
+        },
+        loadServerAction(actionId) {
+          expect(actionId).toBe("action-id");
+          return Promise.resolve((first, second) => `${String(first)}:${String(second)}`);
+        },
+        middlewareHeaders: new Headers([["x-middleware", "present"]]),
+        renderToReadableStream(model, options) {
+          renderedModel = model;
+          expect(options.temporaryReferences).toBe(temporaryReferences);
+          return new Response("flight-payload").body;
+        },
+        setHeadersAccessPhase(phase) {
+          phaseCalls.push(phase);
+          return "render";
+        },
+        setNavigationContext(context) {
+          navigationContexts.push({
+            params: context.params,
+            pathname: context.pathname,
+          });
+        },
+      }),
+    );
+
+    expect(response?.status).toBe(200);
+    expect(response?.headers.get("content-type")).toBe("text/x-component; charset=utf-8");
+    expect(response?.headers.get("vary")).toBe("RSC, Accept");
+    expect(response?.headers.get("x-middleware")).toBe("present");
+    expect(response?.headers.getSetCookie()).toEqual(["action=1; Path=/", "draft=1; Path=/"]);
+    expect(await response?.text()).toBe("flight-payload");
+    expect(renderedModel).toEqual({
+      root: "dashboard:{}:none",
+      returnValue: { ok: true, data: "first:second" },
+    });
+    expect(phaseCalls).toEqual(["action", "render"]);
+    expect(navigationContexts).toEqual([{ params: {}, pathname: "/dashboard" }]);
+  });
+
+  it("rejects malformed fetch-action payloads before decodeReply", async () => {
+    const decodeReply = vi.fn();
+
+    const response = await handleServerActionRscRequest(
+      createRscOptions({
+        readBodyWithLimit() {
+          return Promise.resolve('{"0":"$Q1"}');
+        },
+        decodeReply,
+      }),
+    );
+
+    expect(response?.status).toBe(400);
+    expect(await response?.text()).toBe("Invalid server action payload");
+    expect(decodeReply).not.toHaveBeenCalled();
+  });
+
+  it("encodes fetch-action redirects as RSC control headers", async () => {
+    const clearContext = vi.fn();
+    const renderToReadableStream = vi.fn();
+
+    const response = await handleServerActionRscRequest(
+      createRscOptions({
+        clearRequestContext: clearContext,
+        getAndClearPendingCookies() {
+          return ["action=1; Path=/"];
+        },
+        loadServerAction() {
+          return Promise.resolve(() => {
+            throw { digest: "NEXT_REDIRECT;;%2Ftarget%3Fok%3D1;308" };
+          });
+        },
+        middlewareHeaders: new Headers([["x-middleware", "present"]]),
+        renderToReadableStream,
+      }),
+    );
+
+    expect(response?.status).toBe(200);
+    expect(response?.headers.get("x-action-redirect")).toBe("/target?ok=1");
+    expect(response?.headers.get("x-action-redirect-type")).toBe("push");
+    expect(response?.headers.get("x-action-redirect-status")).toBe("308");
+    expect(response?.headers.get("x-middleware")).toBe("present");
+    expect(response?.headers.getSetCookie()).toEqual(["action=1; Path=/"]);
+    expect(await response?.text()).toBe("");
+    expect(clearContext).toHaveBeenCalledTimes(1);
+    expect(renderToReadableStream).not.toHaveBeenCalled();
+  });
+
+  it("packages access fallback digests into the action return payload", async () => {
+    let renderedModel: TestActionModel | null = null;
+    const notFoundError = { digest: "NEXT_NOT_FOUND" };
+
+    const response = await handleServerActionRscRequest(
+      createRscOptions({
+        loadServerAction() {
+          return Promise.resolve(() => {
+            throw notFoundError;
+          });
+        },
+        renderToReadableStream(model) {
+          renderedModel = model;
+          return new Response("fallback-flight").body;
+        },
+      }),
+    );
+
+    expect(response?.status).toBe(200);
+    expect(await response?.text()).toBe("fallback-flight");
+    expect(renderedModel).toEqual({
+      root: "dashboard:{}:none",
+      returnValue: { ok: false, data: notFoundError },
+    });
   });
 });

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -247,25 +247,22 @@ describe("App Router entry templates", () => {
     expect(code).not.toContain("function mergeMatchedParams(");
   });
 
-  it("generateRscEntry uses buildPageElements in the server-action re-render path", () => {
+  it("generateRscEntry wires buildPageElements into the server-action helper", () => {
     const code = generateRscEntry("/tmp/test/app", minimalAppRoutes, null, [], null, "", false);
-    // PR 2c returns the flat elements payload instead of the monolithic page
-    // element, so the action re-render path should rebuild the keyed map.
-    const actionRerenderIdx = code.indexOf(
-      "// After the action, re-render the current page so the client",
-    );
-    expect(actionRerenderIdx).toBeGreaterThan(-1);
-    const rerenderSlice = code.slice(actionRerenderIdx, actionRerenderIdx + 2500);
-    expect(rerenderSlice).toContain("element = buildPageElements(");
+    const actionStart = code.indexOf("const serverActionResponse");
+    const actionEnd = code.indexOf("if (serverActionResponse)", actionStart);
+    const helperOptions = code.slice(actionStart, actionEnd);
+
+    expect(helperOptions).toContain("buildPageElement({");
+    expect(helperOptions).toContain("return buildPageElements(actionRoute, actionParams");
   });
 
-  it("generateRscEntry delegates action rerender target selection to the shared helper", () => {
+  it("generateRscEntry delegates server action flow to the shared helper", () => {
     const code = generateRscEntry("/tmp/test/app", minimalAppRoutes, null, [], null, "", false);
 
-    expect(code).toContain(
-      "resolveAppPageActionRerenderTarget as __resolveAppPageActionRerenderTarget",
-    );
-    expect(code).toContain("const __actionRerenderTarget = __resolveAppPageActionRerenderTarget({");
+    expect(code).toContain("handleServerActionRscRequest as __handleServerActionRscRequest");
+    expect(code).toContain("const serverActionResponse = await __handleServerActionRscRequest({");
+    expect(code).not.toContain("const __actionRerenderTarget =");
   });
 
   it("generateRscEntry reuses the canonical tree-path helper for no-export page payloads", () => {


### PR DESCRIPTION
## Summary

Extract the fetch/RSC server action POST flow out of the generated App Router RSC entry and into `packages/vinext/src/server/app-server-action-execution.ts`.

The generated entry now describes app shape and route-specific wiring only: action headers, route matching, element construction, request-scoped callbacks, and route table access. The normal server module owns behavior: CSRF checks, body limits, payload validation, action execution phase, redirect control headers, action return packaging, middleware/cookie header merging, and RSC response construction.

## Next.js references

- Next.js centralizes app server action handling in [`handleAction`](https://github.com/vercel/next.js/blob/e1bb911c14e4ea3c6bb8cc98871ffdee317d513f/packages/next/src/server/app-render/action-handler.ts#L529-L545).
- Next.js classifies fetch actions by the `next-action` header in [`getServerActionRequestMetadata`](https://github.com/vercel/next.js/blob/e1bb911c14e4ea3c6bb8cc98871ffdee317d513f/packages/next/src/server/lib/server-action-request-meta.ts#L18-L43).
- Next.js separates MPA action decoding/fallthrough from fetch action decoding in [`action-handler.ts`](https://github.com/vercel/next.js/blob/e1bb911c14e4ea3c6bb8cc98871ffdee317d513f/packages/next/src/server/app-render/action-handler.ts#L984-L1044).
- Next.js executes the action, then generates Flight/RSC output for fetch actions in [`action-handler.ts`](https://github.com/vercel/next.js/blob/e1bb911c14e4ea3c6bb8cc98871ffdee317d513f/packages/next/src/server/app-render/action-handler.ts#L1128-L1170).
- Next.js keeps redirect and thrown-error handling in the action module, including redirect-as-client-router result and rejected action result Flight generation: [`action-handler.ts`](https://github.com/vercel/next.js/blob/e1bb911c14e4ea3c6bb8cc98871ffdee317d513f/packages/next/src/server/app-render/action-handler.ts#L1178-L1278).

## Tests

- `vp test run tests/app-server-action-execution.test.ts tests/entry-templates.test.ts`
- `vp test run tests/app-router.test.ts -t "server action"`
- `vp check`

## Notes

This is intentionally a refactor of ownership, not a behavior change. Existing generated-entry assertions that locked down inline action implementation were moved to helper-focused behavior tests and generated-entry wiring tests.
