### PR TITLE
refactor: Extract app route handler dispatch

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -33,24 +33,12 @@ const middlewareRequestHeadersPath = resolveEntryPath(
 const requestContextShimPath = resolveEntryPath("../shims/request-context.js", import.meta.url);
 const normalizePathModulePath = resolveEntryPath("../server/normalize-path.js", import.meta.url);
 const routingUtilsPath = resolveEntryPath("../routing/utils.js", import.meta.url);
-const appRouteHandlerRuntimePath = resolveEntryPath(
-  "../server/app-route-handler-runtime.js",
-  import.meta.url,
-);
-const appRouteHandlerPolicyPath = resolveEntryPath(
-  "../server/app-route-handler-policy.js",
-  import.meta.url,
-);
-const appRouteHandlerExecutionPath = resolveEntryPath(
-  "../server/app-route-handler-execution.js",
+const appRouteHandlerDispatchPath = resolveEntryPath(
+  "../server/app-route-handler-dispatch.js",
   import.meta.url,
 );
 const appServerActionExecutionPath = resolveEntryPath(
   "../server/app-server-action-execution.js",
-  import.meta.url,
-);
-const appRouteHandlerCachePath = resolveEntryPath(
-  "../server/app-route-handler-cache.js",
   import.meta.url,
 );
 const implicitTagsPath = resolveEntryPath("../server/implicit-tags.js", import.meta.url);
@@ -75,10 +63,6 @@ const appPageRequestPath = resolveEntryPath("../server/app-page-request.js", imp
 const appPageMethodPath = resolveEntryPath("../server/app-page-method.js", import.meta.url);
 const appStaticGenerationPath = resolveEntryPath(
   "../server/app-static-generation.js",
-  import.meta.url,
-);
-const appRouteHandlerResponsePath = resolveEntryPath(
-  "../server/app-route-handler-response.js",
   import.meta.url,
 );
 const appRscRouteMatchingPath = resolveEntryPath(
@@ -384,21 +368,11 @@ import { buildRequestHeadersFromMiddlewareResponse as __buildRequestHeadersFromM
 import { validateCsrfOrigin, validateServerActionPayload, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash } from ${JSON.stringify(requestPipelinePath)};
 import { applyAppMiddleware as __applyAppMiddleware } from ${JSON.stringify(appMiddlewarePath)};
 import {
-  isKnownDynamicAppRoute as __isKnownDynamicAppRoute,
-} from ${JSON.stringify(appRouteHandlerRuntimePath)};
-import {
-  getAppRouteHandlerRevalidateSeconds as __getAppRouteHandlerRevalidateSeconds,
-  hasAppRouteHandlerDefaultExport as __hasAppRouteHandlerDefaultExport,
-  resolveAppRouteHandlerMethod as __resolveAppRouteHandlerMethod,
-  shouldReadAppRouteHandlerCache as __shouldReadAppRouteHandlerCache,
-} from ${JSON.stringify(appRouteHandlerPolicyPath)};
-import {
-  executeAppRouteHandler as __executeAppRouteHandler,
-} from ${JSON.stringify(appRouteHandlerExecutionPath)};
+  dispatchAppRouteHandler as __dispatchAppRouteHandler,
+} from ${JSON.stringify(appRouteHandlerDispatchPath)};
 import {
   handleProgressiveServerActionRequest as __handleProgressiveServerActionRequest,
 } from ${JSON.stringify(appServerActionExecutionPath)};
-import { readAppRouteHandlerCacheResponse as __readAppRouteHandlerCacheResponse } from ${JSON.stringify(appRouteHandlerCachePath)};
 import { readAppPageCacheResponse as __readAppPageCacheResponse } from ${JSON.stringify(appPageCachePath)};
 import {
   buildAppPageFontLinkHeader as __buildAppPageFontLinkHeader,
@@ -449,9 +423,6 @@ import {
 import {
   createStaticGenerationHeadersContext as __createStaticGenerationHeadersContext,
 } from ${JSON.stringify(appStaticGenerationPath)};
-import {
-  applyRouteHandlerMiddlewareContext as __applyRouteHandlerMiddlewareContext,
-} from ${JSON.stringify(appRouteHandlerResponsePath)};
 import { buildPageCacheTags } from ${JSON.stringify(implicitTagsPath)};
 import { _consumeRequestScopedCacheLife, getCacheHandler } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from ${JSON.stringify(requestContextShimPath)};
@@ -1871,144 +1842,29 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
 
   // Handle route.ts API handlers
   if (route.routeHandler) {
-    const handler = route.routeHandler;
-    const method = request.method.toUpperCase();
-    const revalidateSeconds = __getAppRouteHandlerRevalidateSeconds(handler);
-    const __buildRouteHandlerPageCacheTags = function(pathname, extraTags) {
-      return buildPageCacheTags(pathname, extraTags, route.routeSegments, "route");
-    };
-    if (__hasAppRouteHandlerDefaultExport(handler) && process.env.NODE_ENV === "development") {
-      console.error(
-        "[vinext] Detected default export in route handler " + route.pattern + ". Export a named export for each HTTP method instead.",
-      );
-    }
-
-    const {
-      allowHeaderForOptions,
-      handlerFn,
-      isAutoHead,
-      shouldAutoRespondToOptions,
-    } = __resolveAppRouteHandlerMethod(handler, method);
-
-    if (shouldAutoRespondToOptions) {
-      __clearRequestContext();
-      return __applyRouteHandlerMiddlewareContext(
-        new Response(null, {
-          status: 204,
-          headers: { "Allow": allowHeaderForOptions },
-        }),
-        _mwCtx,
-      );
-    }
-
-    // ISR cache read for route handlers (production only).
-    // Only GET/HEAD (auto-HEAD) with finite revalidate > 0 are ISR-eligible.
-    // Known-dynamic handlers skip the read entirely so stale cache entries
-    // from earlier requests do not replay once the process has learned they
-    // access request-specific data.
-    if (
-      __shouldReadAppRouteHandlerCache({
-        dynamicConfig: handler.dynamic,
-        handlerFn,
-        isAutoHead,
-        isKnownDynamic: __isKnownDynamicAppRoute(route.pattern),
-        isProduction: process.env.NODE_ENV === "production",
-        method,
-        revalidateSeconds,
-      })
-    ) {
-      const __cachedRouteResponse = await __readAppRouteHandlerCacheResponse({
-        basePath: __basePath,
-        buildPageCacheTags: __buildRouteHandlerPageCacheTags,
-        cleanPathname,
-        clearRequestContext: function() {
-          __clearRequestContext();
-        },
-        consumeDynamicUsage,
-        dynamicConfig: handler.dynamic,
-        getCollectedFetchTags,
-        handlerFn,
-        i18n: __i18nConfig,
-        isAutoHead,
-        isrDebug: __isrDebug,
-        isrGet: __isrGet,
-        isrRouteKey: __isrRouteKey,
-        isrSet: __isrSet,
-        markDynamicUsage,
-        middlewareContext: _mwCtx,
-        params,
-        requestUrl: request.url,
-        revalidateSearchParams: url.searchParams,
-        revalidateSeconds,
-        routePattern: route.pattern,
-        runInRevalidationContext: async function(renderFn) {
-          const __revalHeadCtx = __createStaticGenerationHeadersContext({
-            dynamicConfig: handler.dynamic,
-            routeKind: "route",
-            routePattern: route.pattern,
-          });
-          const __revalUCtx = _createUnifiedCtx({
-            headersContext: __revalHeadCtx,
-            executionContext: _getRequestExecutionContext(),
-            unstableCacheRevalidation: "foreground",
-          });
-          await _runWithUnifiedCtx(__revalUCtx, async () => {
-            _ensureFetchPatch();
-            setCurrentFetchSoftTags(buildPageCacheTags(cleanPathname, [], route.routeSegments, "route"));
-            await renderFn();
-          });
-        },
-        scheduleBackgroundRegeneration(key, renderFn) {
-          __triggerBackgroundRegeneration(key, renderFn, { routePath: route.pattern, routeType: "route" });
-        },
-        setHeadersAccessPhase,
-        setNavigationContext,
-      });
-      if (__cachedRouteResponse) {
-        return __cachedRouteResponse;
-      }
-    }
-
-    if (typeof handlerFn === "function") {
-      return __executeAppRouteHandler({
-        basePath: __basePath,
-        buildPageCacheTags: __buildRouteHandlerPageCacheTags,
-        cleanPathname,
-        clearRequestContext: function() {
-          __clearRequestContext();
-        },
-        consumeDynamicUsage,
-        executionContext: _getRequestExecutionContext(),
-        getAndClearPendingCookies,
-        getCollectedFetchTags,
-        getDraftModeCookieHeader,
-        handler,
-        handlerFn,
-        i18n: __i18nConfig,
-        isAutoHead,
-        isProduction: process.env.NODE_ENV === "production",
-        isrDebug: __isrDebug,
-        isrRouteKey: __isrRouteKey,
-        isrSet: __isrSet,
-        markDynamicUsage,
-        method,
-        middlewareContext: _mwCtx,
-        middlewareRequestHeaders: _mwCtx.requestHeaders,
-        params: makeThenableParams(params),
-        reportRequestError: _reportRequestError,
-        request,
-        revalidateSeconds,
-        routePattern: route.pattern,
-        setHeadersAccessPhase,
-      });
-    }
-    __clearRequestContext();
-    return __applyRouteHandlerMiddlewareContext(
-      new Response(null, {
-        status: 405,
-      }),
-      _mwCtx,
-    );
+    return __dispatchAppRouteHandler({
+      basePath: __basePath,
+      cleanPathname,
+      clearRequestContext: function() {
+        __clearRequestContext();
+      },
+      i18n: __i18nConfig,
+      isrDebug: __isrDebug,
+      isrGet: __isrGet,
+      isrRouteKey: __isrRouteKey,
+      isrSet: __isrSet,
+      middlewareContext: _mwCtx,
+      middlewareRequestHeaders: _mwCtx.requestHeaders,
+      params,
+      request,
+      route: {
+        pattern: route.pattern,
+        routeHandler: route.routeHandler,
+        routeSegments: route.routeSegments,
+      },
+      scheduleBackgroundRegeneration: __triggerBackgroundRegeneration,
+      searchParams: url.searchParams,
+    });
   }
 
   // Build the component tree: layouts wrapping the page

--- a/packages/vinext/src/server/app-route-handler-dispatch.ts
+++ b/packages/vinext/src/server/app-route-handler-dispatch.ts
@@ -1,0 +1,264 @@
+import type { NextI18nConfig } from "../config/next-config.js";
+import {
+  getCollectedFetchTags,
+  ensureFetchPatch,
+  setCurrentFetchSoftTags,
+} from "../shims/fetch-cache.js";
+import {
+  consumeDynamicUsage,
+  getAndClearPendingCookies,
+  getDraftModeCookieHeader,
+  markDynamicUsage,
+  setHeadersAccessPhase,
+} from "../shims/headers.js";
+import { setNavigationContext } from "../shims/navigation.js";
+import { getRequestExecutionContext } from "../shims/request-context.js";
+import { createRequestContext, runWithRequestContext } from "../shims/unified-request-context.js";
+import type { ISRCacheEntry } from "./isr-cache.js";
+import {
+  getAppRouteHandlerRevalidateSeconds,
+  hasAppRouteHandlerDefaultExport,
+  resolveAppRouteHandlerMethod,
+  shouldReadAppRouteHandlerCache,
+  type AppRouteHandlerModule,
+} from "./app-route-handler-policy.js";
+import { readAppRouteHandlerCacheResponse } from "./app-route-handler-cache.js";
+import {
+  executeAppRouteHandler,
+  type AppRouteDebugLogger,
+  type AppRouteHandlerFunction,
+  type AppRouteParams,
+  type RouteHandlerCacheSetter,
+} from "./app-route-handler-execution.js";
+import { isKnownDynamicAppRoute } from "./app-route-handler-runtime.js";
+import {
+  applyRouteHandlerMiddlewareContext,
+  type RouteHandlerMiddlewareContext,
+} from "./app-route-handler-response.js";
+import { createStaticGenerationHeadersContext } from "./app-static-generation.js";
+import { buildPageCacheTags } from "./implicit-tags.js";
+import { reportRequestError } from "./instrumentation.js";
+
+type AppRouteHandlerDispatchRoute = {
+  pattern: string;
+  routeHandler: AppRouteHandlerModule;
+  routeSegments: string[];
+};
+
+type RouteHandlerCacheGetter = (key: string) => Promise<ISRCacheEntry | null>;
+type RouteHandlerBackgroundRegenerationErrorContext = {
+  routerKind: "App Router";
+  routePath: string;
+  routeType: "route";
+};
+type RouteHandlerBackgroundRegenerator = (
+  key: string,
+  renderFn: () => Promise<void>,
+  errorContext?: RouteHandlerBackgroundRegenerationErrorContext,
+) => void;
+
+type DispatchAppRouteHandlerOptions = {
+  basePath?: string;
+  cleanPathname: string;
+  clearRequestContext: () => void;
+  i18n?: NextI18nConfig | null;
+  isDevelopment?: boolean;
+  isProduction?: boolean;
+  isrDebug?: AppRouteDebugLogger;
+  isrGet: RouteHandlerCacheGetter;
+  isrRouteKey: (pathname: string) => string;
+  isrSet: RouteHandlerCacheSetter;
+  middlewareContext: RouteHandlerMiddlewareContext;
+  middlewareRequestHeaders?: Headers | null;
+  params: AppRouteParams;
+  request: Request;
+  route: AppRouteHandlerDispatchRoute;
+  scheduleBackgroundRegeneration: RouteHandlerBackgroundRegenerator;
+  searchParams: URLSearchParams;
+};
+
+function isAppRouteHandlerFunction(value: unknown): value is AppRouteHandlerFunction {
+  return typeof value === "function";
+}
+
+function makeThenableParams<T extends AppRouteParams>(params: T): Promise<T> & T {
+  const plain = { ...params };
+  return Object.assign(Promise.resolve(plain), plain);
+}
+
+function buildRouteHandlerPageCacheTags(
+  pathname: string,
+  extraTags: string[],
+  routeSegments: string[],
+): string[] {
+  return buildPageCacheTags(pathname, extraTags, routeSegments, "route");
+}
+
+async function runInRouteHandlerRevalidationContext(
+  options: {
+    cleanPathname: string;
+    dynamicConfig?: string;
+    routePattern: string;
+    routeSegments: string[];
+  },
+  renderFn: () => Promise<void>,
+): Promise<void> {
+  const headersContext = createStaticGenerationHeadersContext({
+    dynamicConfig: options.dynamicConfig,
+    routeKind: "route",
+    routePattern: options.routePattern,
+  });
+  const requestContext = createRequestContext({
+    headersContext,
+    executionContext: getRequestExecutionContext(),
+    unstableCacheRevalidation: "foreground",
+  });
+
+  await runWithRequestContext(requestContext, async () => {
+    ensureFetchPatch();
+    setCurrentFetchSoftTags(
+      buildRouteHandlerPageCacheTags(options.cleanPathname, [], options.routeSegments),
+    );
+    await renderFn();
+  });
+}
+
+export async function dispatchAppRouteHandler(
+  options: DispatchAppRouteHandlerOptions,
+): Promise<Response> {
+  const { route } = options;
+  const handler = route.routeHandler;
+  const method = options.request.method.toUpperCase();
+  const revalidateSeconds = getAppRouteHandlerRevalidateSeconds(handler);
+  const isDevelopment = options.isDevelopment ?? process.env.NODE_ENV === "development";
+  const isProduction = options.isProduction ?? process.env.NODE_ENV === "production";
+
+  if (hasAppRouteHandlerDefaultExport(handler) && isDevelopment) {
+    console.error(
+      "[vinext] Detected default export in route handler " +
+        route.pattern +
+        ". Export a named export for each HTTP method instead.",
+    );
+  }
+
+  const { allowHeaderForOptions, handlerFn, isAutoHead, shouldAutoRespondToOptions } =
+    resolveAppRouteHandlerMethod(handler, method);
+
+  if (shouldAutoRespondToOptions) {
+    options.clearRequestContext();
+    return applyRouteHandlerMiddlewareContext(
+      new Response(null, {
+        status: 204,
+        headers: { Allow: allowHeaderForOptions },
+      }),
+      options.middlewareContext,
+    );
+  }
+
+  const resolvedHandlerFn = isAppRouteHandlerFunction(handlerFn) ? handlerFn : undefined;
+
+  if (
+    revalidateSeconds !== null &&
+    shouldReadAppRouteHandlerCache({
+      dynamicConfig: handler.dynamic,
+      handlerFn: resolvedHandlerFn,
+      isAutoHead,
+      isKnownDynamic: isKnownDynamicAppRoute(route.pattern),
+      isProduction,
+      method,
+      revalidateSeconds,
+    }) &&
+    resolvedHandlerFn
+  ) {
+    const cachedRouteResponse = await readAppRouteHandlerCacheResponse({
+      basePath: options.basePath,
+      buildPageCacheTags(pathname, extraTags) {
+        return buildRouteHandlerPageCacheTags(pathname, extraTags, route.routeSegments);
+      },
+      cleanPathname: options.cleanPathname,
+      clearRequestContext: options.clearRequestContext,
+      consumeDynamicUsage,
+      dynamicConfig: handler.dynamic,
+      getCollectedFetchTags,
+      handlerFn: resolvedHandlerFn,
+      i18n: options.i18n,
+      isAutoHead,
+      isrDebug: options.isrDebug,
+      isrGet: options.isrGet,
+      isrRouteKey: options.isrRouteKey,
+      isrSet: options.isrSet,
+      markDynamicUsage,
+      middlewareContext: options.middlewareContext,
+      params: options.params,
+      requestUrl: options.request.url,
+      revalidateSearchParams: options.searchParams,
+      revalidateSeconds,
+      routePattern: route.pattern,
+      runInRevalidationContext(renderFn) {
+        return runInRouteHandlerRevalidationContext(
+          {
+            cleanPathname: options.cleanPathname,
+            dynamicConfig: handler.dynamic,
+            routePattern: route.pattern,
+            routeSegments: route.routeSegments,
+          },
+          renderFn,
+        );
+      },
+      scheduleBackgroundRegeneration(key, renderFn) {
+        options.scheduleBackgroundRegeneration(key, renderFn, {
+          routerKind: "App Router",
+          routePath: route.pattern,
+          routeType: "route",
+        });
+      },
+      setHeadersAccessPhase,
+      setNavigationContext,
+    });
+    if (cachedRouteResponse) {
+      return cachedRouteResponse;
+    }
+  }
+
+  if (resolvedHandlerFn) {
+    return executeAppRouteHandler({
+      basePath: options.basePath,
+      buildPageCacheTags(pathname, extraTags) {
+        return buildRouteHandlerPageCacheTags(pathname, extraTags, route.routeSegments);
+      },
+      cleanPathname: options.cleanPathname,
+      clearRequestContext: options.clearRequestContext,
+      consumeDynamicUsage,
+      executionContext: getRequestExecutionContext(),
+      getAndClearPendingCookies,
+      getCollectedFetchTags,
+      getDraftModeCookieHeader,
+      handler,
+      handlerFn: resolvedHandlerFn,
+      i18n: options.i18n,
+      isAutoHead,
+      isProduction,
+      isrDebug: options.isrDebug,
+      isrRouteKey: options.isrRouteKey,
+      isrSet: options.isrSet,
+      markDynamicUsage,
+      method,
+      middlewareContext: options.middlewareContext,
+      middlewareRequestHeaders: options.middlewareRequestHeaders,
+      params: makeThenableParams(options.params),
+      reportRequestError,
+      request: options.request,
+      revalidateSeconds,
+      routePattern: route.pattern,
+      setHeadersAccessPhase,
+    });
+  }
+
+  options.clearRequestContext();
+  return applyRouteHandlerMiddlewareContext(
+    new Response(null, {
+      status: 405,
+    }),
+    options.middlewareContext,
+  );
+}

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -34,21 +34,11 @@ import { buildRequestHeadersFromMiddlewareResponse as __buildRequestHeadersFromM
 import { validateCsrfOrigin, validateServerActionPayload, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
 import { applyAppMiddleware as __applyAppMiddleware } from "<ROOT>/packages/vinext/src/server/app-middleware.js";
 import {
-  isKnownDynamicAppRoute as __isKnownDynamicAppRoute,
-} from "<ROOT>/packages/vinext/src/server/app-route-handler-runtime.js";
-import {
-  getAppRouteHandlerRevalidateSeconds as __getAppRouteHandlerRevalidateSeconds,
-  hasAppRouteHandlerDefaultExport as __hasAppRouteHandlerDefaultExport,
-  resolveAppRouteHandlerMethod as __resolveAppRouteHandlerMethod,
-  shouldReadAppRouteHandlerCache as __shouldReadAppRouteHandlerCache,
-} from "<ROOT>/packages/vinext/src/server/app-route-handler-policy.js";
-import {
-  executeAppRouteHandler as __executeAppRouteHandler,
-} from "<ROOT>/packages/vinext/src/server/app-route-handler-execution.js";
+  dispatchAppRouteHandler as __dispatchAppRouteHandler,
+} from "<ROOT>/packages/vinext/src/server/app-route-handler-dispatch.js";
 import {
   handleProgressiveServerActionRequest as __handleProgressiveServerActionRequest,
 } from "<ROOT>/packages/vinext/src/server/app-server-action-execution.js";
-import { readAppRouteHandlerCacheResponse as __readAppRouteHandlerCacheResponse } from "<ROOT>/packages/vinext/src/server/app-route-handler-cache.js";
 import { readAppPageCacheResponse as __readAppPageCacheResponse } from "<ROOT>/packages/vinext/src/server/app-page-cache.js";
 import {
   buildAppPageFontLinkHeader as __buildAppPageFontLinkHeader,
@@ -99,9 +89,6 @@ import {
 import {
   createStaticGenerationHeadersContext as __createStaticGenerationHeadersContext,
 } from "<ROOT>/packages/vinext/src/server/app-static-generation.js";
-import {
-  applyRouteHandlerMiddlewareContext as __applyRouteHandlerMiddlewareContext,
-} from "<ROOT>/packages/vinext/src/server/app-route-handler-response.js";
 import { buildPageCacheTags } from "<ROOT>/packages/vinext/src/server/implicit-tags.js";
 import { _consumeRequestScopedCacheLife, getCacheHandler } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
@@ -1540,144 +1527,29 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
 
   // Handle route.ts API handlers
   if (route.routeHandler) {
-    const handler = route.routeHandler;
-    const method = request.method.toUpperCase();
-    const revalidateSeconds = __getAppRouteHandlerRevalidateSeconds(handler);
-    const __buildRouteHandlerPageCacheTags = function(pathname, extraTags) {
-      return buildPageCacheTags(pathname, extraTags, route.routeSegments, "route");
-    };
-    if (__hasAppRouteHandlerDefaultExport(handler) && process.env.NODE_ENV === "development") {
-      console.error(
-        "[vinext] Detected default export in route handler " + route.pattern + ". Export a named export for each HTTP method instead.",
-      );
-    }
-
-    const {
-      allowHeaderForOptions,
-      handlerFn,
-      isAutoHead,
-      shouldAutoRespondToOptions,
-    } = __resolveAppRouteHandlerMethod(handler, method);
-
-    if (shouldAutoRespondToOptions) {
-      __clearRequestContext();
-      return __applyRouteHandlerMiddlewareContext(
-        new Response(null, {
-          status: 204,
-          headers: { "Allow": allowHeaderForOptions },
-        }),
-        _mwCtx,
-      );
-    }
-
-    // ISR cache read for route handlers (production only).
-    // Only GET/HEAD (auto-HEAD) with finite revalidate > 0 are ISR-eligible.
-    // Known-dynamic handlers skip the read entirely so stale cache entries
-    // from earlier requests do not replay once the process has learned they
-    // access request-specific data.
-    if (
-      __shouldReadAppRouteHandlerCache({
-        dynamicConfig: handler.dynamic,
-        handlerFn,
-        isAutoHead,
-        isKnownDynamic: __isKnownDynamicAppRoute(route.pattern),
-        isProduction: process.env.NODE_ENV === "production",
-        method,
-        revalidateSeconds,
-      })
-    ) {
-      const __cachedRouteResponse = await __readAppRouteHandlerCacheResponse({
-        basePath: __basePath,
-        buildPageCacheTags: __buildRouteHandlerPageCacheTags,
-        cleanPathname,
-        clearRequestContext: function() {
-          __clearRequestContext();
-        },
-        consumeDynamicUsage,
-        dynamicConfig: handler.dynamic,
-        getCollectedFetchTags,
-        handlerFn,
-        i18n: __i18nConfig,
-        isAutoHead,
-        isrDebug: __isrDebug,
-        isrGet: __isrGet,
-        isrRouteKey: __isrRouteKey,
-        isrSet: __isrSet,
-        markDynamicUsage,
-        middlewareContext: _mwCtx,
-        params,
-        requestUrl: request.url,
-        revalidateSearchParams: url.searchParams,
-        revalidateSeconds,
-        routePattern: route.pattern,
-        runInRevalidationContext: async function(renderFn) {
-          const __revalHeadCtx = __createStaticGenerationHeadersContext({
-            dynamicConfig: handler.dynamic,
-            routeKind: "route",
-            routePattern: route.pattern,
-          });
-          const __revalUCtx = _createUnifiedCtx({
-            headersContext: __revalHeadCtx,
-            executionContext: _getRequestExecutionContext(),
-            unstableCacheRevalidation: "foreground",
-          });
-          await _runWithUnifiedCtx(__revalUCtx, async () => {
-            _ensureFetchPatch();
-            setCurrentFetchSoftTags(buildPageCacheTags(cleanPathname, [], route.routeSegments, "route"));
-            await renderFn();
-          });
-        },
-        scheduleBackgroundRegeneration(key, renderFn) {
-          __triggerBackgroundRegeneration(key, renderFn, { routePath: route.pattern, routeType: "route" });
-        },
-        setHeadersAccessPhase,
-        setNavigationContext,
-      });
-      if (__cachedRouteResponse) {
-        return __cachedRouteResponse;
-      }
-    }
-
-    if (typeof handlerFn === "function") {
-      return __executeAppRouteHandler({
-        basePath: __basePath,
-        buildPageCacheTags: __buildRouteHandlerPageCacheTags,
-        cleanPathname,
-        clearRequestContext: function() {
-          __clearRequestContext();
-        },
-        consumeDynamicUsage,
-        executionContext: _getRequestExecutionContext(),
-        getAndClearPendingCookies,
-        getCollectedFetchTags,
-        getDraftModeCookieHeader,
-        handler,
-        handlerFn,
-        i18n: __i18nConfig,
-        isAutoHead,
-        isProduction: process.env.NODE_ENV === "production",
-        isrDebug: __isrDebug,
-        isrRouteKey: __isrRouteKey,
-        isrSet: __isrSet,
-        markDynamicUsage,
-        method,
-        middlewareContext: _mwCtx,
-        middlewareRequestHeaders: _mwCtx.requestHeaders,
-        params: makeThenableParams(params),
-        reportRequestError: _reportRequestError,
-        request,
-        revalidateSeconds,
-        routePattern: route.pattern,
-        setHeadersAccessPhase,
-      });
-    }
-    __clearRequestContext();
-    return __applyRouteHandlerMiddlewareContext(
-      new Response(null, {
-        status: 405,
-      }),
-      _mwCtx,
-    );
+    return __dispatchAppRouteHandler({
+      basePath: __basePath,
+      cleanPathname,
+      clearRequestContext: function() {
+        __clearRequestContext();
+      },
+      i18n: __i18nConfig,
+      isrDebug: __isrDebug,
+      isrGet: __isrGet,
+      isrRouteKey: __isrRouteKey,
+      isrSet: __isrSet,
+      middlewareContext: _mwCtx,
+      middlewareRequestHeaders: _mwCtx.requestHeaders,
+      params,
+      request,
+      route: {
+        pattern: route.pattern,
+        routeHandler: route.routeHandler,
+        routeSegments: route.routeSegments,
+      },
+      scheduleBackgroundRegeneration: __triggerBackgroundRegeneration,
+      searchParams: url.searchParams,
+    });
   }
 
   // Build the component tree: layouts wrapping the page
@@ -2172,21 +2044,11 @@ import { buildRequestHeadersFromMiddlewareResponse as __buildRequestHeadersFromM
 import { validateCsrfOrigin, validateServerActionPayload, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
 import { applyAppMiddleware as __applyAppMiddleware } from "<ROOT>/packages/vinext/src/server/app-middleware.js";
 import {
-  isKnownDynamicAppRoute as __isKnownDynamicAppRoute,
-} from "<ROOT>/packages/vinext/src/server/app-route-handler-runtime.js";
-import {
-  getAppRouteHandlerRevalidateSeconds as __getAppRouteHandlerRevalidateSeconds,
-  hasAppRouteHandlerDefaultExport as __hasAppRouteHandlerDefaultExport,
-  resolveAppRouteHandlerMethod as __resolveAppRouteHandlerMethod,
-  shouldReadAppRouteHandlerCache as __shouldReadAppRouteHandlerCache,
-} from "<ROOT>/packages/vinext/src/server/app-route-handler-policy.js";
-import {
-  executeAppRouteHandler as __executeAppRouteHandler,
-} from "<ROOT>/packages/vinext/src/server/app-route-handler-execution.js";
+  dispatchAppRouteHandler as __dispatchAppRouteHandler,
+} from "<ROOT>/packages/vinext/src/server/app-route-handler-dispatch.js";
 import {
   handleProgressiveServerActionRequest as __handleProgressiveServerActionRequest,
 } from "<ROOT>/packages/vinext/src/server/app-server-action-execution.js";
-import { readAppRouteHandlerCacheResponse as __readAppRouteHandlerCacheResponse } from "<ROOT>/packages/vinext/src/server/app-route-handler-cache.js";
 import { readAppPageCacheResponse as __readAppPageCacheResponse } from "<ROOT>/packages/vinext/src/server/app-page-cache.js";
 import {
   buildAppPageFontLinkHeader as __buildAppPageFontLinkHeader,
@@ -2237,9 +2099,6 @@ import {
 import {
   createStaticGenerationHeadersContext as __createStaticGenerationHeadersContext,
 } from "<ROOT>/packages/vinext/src/server/app-static-generation.js";
-import {
-  applyRouteHandlerMiddlewareContext as __applyRouteHandlerMiddlewareContext,
-} from "<ROOT>/packages/vinext/src/server/app-route-handler-response.js";
 import { buildPageCacheTags } from "<ROOT>/packages/vinext/src/server/implicit-tags.js";
 import { _consumeRequestScopedCacheLife, getCacheHandler } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
@@ -3684,144 +3543,29 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
 
   // Handle route.ts API handlers
   if (route.routeHandler) {
-    const handler = route.routeHandler;
-    const method = request.method.toUpperCase();
-    const revalidateSeconds = __getAppRouteHandlerRevalidateSeconds(handler);
-    const __buildRouteHandlerPageCacheTags = function(pathname, extraTags) {
-      return buildPageCacheTags(pathname, extraTags, route.routeSegments, "route");
-    };
-    if (__hasAppRouteHandlerDefaultExport(handler) && process.env.NODE_ENV === "development") {
-      console.error(
-        "[vinext] Detected default export in route handler " + route.pattern + ". Export a named export for each HTTP method instead.",
-      );
-    }
-
-    const {
-      allowHeaderForOptions,
-      handlerFn,
-      isAutoHead,
-      shouldAutoRespondToOptions,
-    } = __resolveAppRouteHandlerMethod(handler, method);
-
-    if (shouldAutoRespondToOptions) {
-      __clearRequestContext();
-      return __applyRouteHandlerMiddlewareContext(
-        new Response(null, {
-          status: 204,
-          headers: { "Allow": allowHeaderForOptions },
-        }),
-        _mwCtx,
-      );
-    }
-
-    // ISR cache read for route handlers (production only).
-    // Only GET/HEAD (auto-HEAD) with finite revalidate > 0 are ISR-eligible.
-    // Known-dynamic handlers skip the read entirely so stale cache entries
-    // from earlier requests do not replay once the process has learned they
-    // access request-specific data.
-    if (
-      __shouldReadAppRouteHandlerCache({
-        dynamicConfig: handler.dynamic,
-        handlerFn,
-        isAutoHead,
-        isKnownDynamic: __isKnownDynamicAppRoute(route.pattern),
-        isProduction: process.env.NODE_ENV === "production",
-        method,
-        revalidateSeconds,
-      })
-    ) {
-      const __cachedRouteResponse = await __readAppRouteHandlerCacheResponse({
-        basePath: __basePath,
-        buildPageCacheTags: __buildRouteHandlerPageCacheTags,
-        cleanPathname,
-        clearRequestContext: function() {
-          __clearRequestContext();
-        },
-        consumeDynamicUsage,
-        dynamicConfig: handler.dynamic,
-        getCollectedFetchTags,
-        handlerFn,
-        i18n: __i18nConfig,
-        isAutoHead,
-        isrDebug: __isrDebug,
-        isrGet: __isrGet,
-        isrRouteKey: __isrRouteKey,
-        isrSet: __isrSet,
-        markDynamicUsage,
-        middlewareContext: _mwCtx,
-        params,
-        requestUrl: request.url,
-        revalidateSearchParams: url.searchParams,
-        revalidateSeconds,
-        routePattern: route.pattern,
-        runInRevalidationContext: async function(renderFn) {
-          const __revalHeadCtx = __createStaticGenerationHeadersContext({
-            dynamicConfig: handler.dynamic,
-            routeKind: "route",
-            routePattern: route.pattern,
-          });
-          const __revalUCtx = _createUnifiedCtx({
-            headersContext: __revalHeadCtx,
-            executionContext: _getRequestExecutionContext(),
-            unstableCacheRevalidation: "foreground",
-          });
-          await _runWithUnifiedCtx(__revalUCtx, async () => {
-            _ensureFetchPatch();
-            setCurrentFetchSoftTags(buildPageCacheTags(cleanPathname, [], route.routeSegments, "route"));
-            await renderFn();
-          });
-        },
-        scheduleBackgroundRegeneration(key, renderFn) {
-          __triggerBackgroundRegeneration(key, renderFn, { routePath: route.pattern, routeType: "route" });
-        },
-        setHeadersAccessPhase,
-        setNavigationContext,
-      });
-      if (__cachedRouteResponse) {
-        return __cachedRouteResponse;
-      }
-    }
-
-    if (typeof handlerFn === "function") {
-      return __executeAppRouteHandler({
-        basePath: __basePath,
-        buildPageCacheTags: __buildRouteHandlerPageCacheTags,
-        cleanPathname,
-        clearRequestContext: function() {
-          __clearRequestContext();
-        },
-        consumeDynamicUsage,
-        executionContext: _getRequestExecutionContext(),
-        getAndClearPendingCookies,
-        getCollectedFetchTags,
-        getDraftModeCookieHeader,
-        handler,
-        handlerFn,
-        i18n: __i18nConfig,
-        isAutoHead,
-        isProduction: process.env.NODE_ENV === "production",
-        isrDebug: __isrDebug,
-        isrRouteKey: __isrRouteKey,
-        isrSet: __isrSet,
-        markDynamicUsage,
-        method,
-        middlewareContext: _mwCtx,
-        middlewareRequestHeaders: _mwCtx.requestHeaders,
-        params: makeThenableParams(params),
-        reportRequestError: _reportRequestError,
-        request,
-        revalidateSeconds,
-        routePattern: route.pattern,
-        setHeadersAccessPhase,
-      });
-    }
-    __clearRequestContext();
-    return __applyRouteHandlerMiddlewareContext(
-      new Response(null, {
-        status: 405,
-      }),
-      _mwCtx,
-    );
+    return __dispatchAppRouteHandler({
+      basePath: __basePath,
+      cleanPathname,
+      clearRequestContext: function() {
+        __clearRequestContext();
+      },
+      i18n: __i18nConfig,
+      isrDebug: __isrDebug,
+      isrGet: __isrGet,
+      isrRouteKey: __isrRouteKey,
+      isrSet: __isrSet,
+      middlewareContext: _mwCtx,
+      middlewareRequestHeaders: _mwCtx.requestHeaders,
+      params,
+      request,
+      route: {
+        pattern: route.pattern,
+        routeHandler: route.routeHandler,
+        routeSegments: route.routeSegments,
+      },
+      scheduleBackgroundRegeneration: __triggerBackgroundRegeneration,
+      searchParams: url.searchParams,
+    });
   }
 
   // Build the component tree: layouts wrapping the page
@@ -4316,21 +4060,11 @@ import { buildRequestHeadersFromMiddlewareResponse as __buildRequestHeadersFromM
 import { validateCsrfOrigin, validateServerActionPayload, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
 import { applyAppMiddleware as __applyAppMiddleware } from "<ROOT>/packages/vinext/src/server/app-middleware.js";
 import {
-  isKnownDynamicAppRoute as __isKnownDynamicAppRoute,
-} from "<ROOT>/packages/vinext/src/server/app-route-handler-runtime.js";
-import {
-  getAppRouteHandlerRevalidateSeconds as __getAppRouteHandlerRevalidateSeconds,
-  hasAppRouteHandlerDefaultExport as __hasAppRouteHandlerDefaultExport,
-  resolveAppRouteHandlerMethod as __resolveAppRouteHandlerMethod,
-  shouldReadAppRouteHandlerCache as __shouldReadAppRouteHandlerCache,
-} from "<ROOT>/packages/vinext/src/server/app-route-handler-policy.js";
-import {
-  executeAppRouteHandler as __executeAppRouteHandler,
-} from "<ROOT>/packages/vinext/src/server/app-route-handler-execution.js";
+  dispatchAppRouteHandler as __dispatchAppRouteHandler,
+} from "<ROOT>/packages/vinext/src/server/app-route-handler-dispatch.js";
 import {
   handleProgressiveServerActionRequest as __handleProgressiveServerActionRequest,
 } from "<ROOT>/packages/vinext/src/server/app-server-action-execution.js";
-import { readAppRouteHandlerCacheResponse as __readAppRouteHandlerCacheResponse } from "<ROOT>/packages/vinext/src/server/app-route-handler-cache.js";
 import { readAppPageCacheResponse as __readAppPageCacheResponse } from "<ROOT>/packages/vinext/src/server/app-page-cache.js";
 import {
   buildAppPageFontLinkHeader as __buildAppPageFontLinkHeader,
@@ -4381,9 +4115,6 @@ import {
 import {
   createStaticGenerationHeadersContext as __createStaticGenerationHeadersContext,
 } from "<ROOT>/packages/vinext/src/server/app-static-generation.js";
-import {
-  applyRouteHandlerMiddlewareContext as __applyRouteHandlerMiddlewareContext,
-} from "<ROOT>/packages/vinext/src/server/app-route-handler-response.js";
 import { buildPageCacheTags } from "<ROOT>/packages/vinext/src/server/implicit-tags.js";
 import { _consumeRequestScopedCacheLife, getCacheHandler } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
@@ -5823,144 +5554,29 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
 
   // Handle route.ts API handlers
   if (route.routeHandler) {
-    const handler = route.routeHandler;
-    const method = request.method.toUpperCase();
-    const revalidateSeconds = __getAppRouteHandlerRevalidateSeconds(handler);
-    const __buildRouteHandlerPageCacheTags = function(pathname, extraTags) {
-      return buildPageCacheTags(pathname, extraTags, route.routeSegments, "route");
-    };
-    if (__hasAppRouteHandlerDefaultExport(handler) && process.env.NODE_ENV === "development") {
-      console.error(
-        "[vinext] Detected default export in route handler " + route.pattern + ". Export a named export for each HTTP method instead.",
-      );
-    }
-
-    const {
-      allowHeaderForOptions,
-      handlerFn,
-      isAutoHead,
-      shouldAutoRespondToOptions,
-    } = __resolveAppRouteHandlerMethod(handler, method);
-
-    if (shouldAutoRespondToOptions) {
-      __clearRequestContext();
-      return __applyRouteHandlerMiddlewareContext(
-        new Response(null, {
-          status: 204,
-          headers: { "Allow": allowHeaderForOptions },
-        }),
-        _mwCtx,
-      );
-    }
-
-    // ISR cache read for route handlers (production only).
-    // Only GET/HEAD (auto-HEAD) with finite revalidate > 0 are ISR-eligible.
-    // Known-dynamic handlers skip the read entirely so stale cache entries
-    // from earlier requests do not replay once the process has learned they
-    // access request-specific data.
-    if (
-      __shouldReadAppRouteHandlerCache({
-        dynamicConfig: handler.dynamic,
-        handlerFn,
-        isAutoHead,
-        isKnownDynamic: __isKnownDynamicAppRoute(route.pattern),
-        isProduction: process.env.NODE_ENV === "production",
-        method,
-        revalidateSeconds,
-      })
-    ) {
-      const __cachedRouteResponse = await __readAppRouteHandlerCacheResponse({
-        basePath: __basePath,
-        buildPageCacheTags: __buildRouteHandlerPageCacheTags,
-        cleanPathname,
-        clearRequestContext: function() {
-          __clearRequestContext();
-        },
-        consumeDynamicUsage,
-        dynamicConfig: handler.dynamic,
-        getCollectedFetchTags,
-        handlerFn,
-        i18n: __i18nConfig,
-        isAutoHead,
-        isrDebug: __isrDebug,
-        isrGet: __isrGet,
-        isrRouteKey: __isrRouteKey,
-        isrSet: __isrSet,
-        markDynamicUsage,
-        middlewareContext: _mwCtx,
-        params,
-        requestUrl: request.url,
-        revalidateSearchParams: url.searchParams,
-        revalidateSeconds,
-        routePattern: route.pattern,
-        runInRevalidationContext: async function(renderFn) {
-          const __revalHeadCtx = __createStaticGenerationHeadersContext({
-            dynamicConfig: handler.dynamic,
-            routeKind: "route",
-            routePattern: route.pattern,
-          });
-          const __revalUCtx = _createUnifiedCtx({
-            headersContext: __revalHeadCtx,
-            executionContext: _getRequestExecutionContext(),
-            unstableCacheRevalidation: "foreground",
-          });
-          await _runWithUnifiedCtx(__revalUCtx, async () => {
-            _ensureFetchPatch();
-            setCurrentFetchSoftTags(buildPageCacheTags(cleanPathname, [], route.routeSegments, "route"));
-            await renderFn();
-          });
-        },
-        scheduleBackgroundRegeneration(key, renderFn) {
-          __triggerBackgroundRegeneration(key, renderFn, { routePath: route.pattern, routeType: "route" });
-        },
-        setHeadersAccessPhase,
-        setNavigationContext,
-      });
-      if (__cachedRouteResponse) {
-        return __cachedRouteResponse;
-      }
-    }
-
-    if (typeof handlerFn === "function") {
-      return __executeAppRouteHandler({
-        basePath: __basePath,
-        buildPageCacheTags: __buildRouteHandlerPageCacheTags,
-        cleanPathname,
-        clearRequestContext: function() {
-          __clearRequestContext();
-        },
-        consumeDynamicUsage,
-        executionContext: _getRequestExecutionContext(),
-        getAndClearPendingCookies,
-        getCollectedFetchTags,
-        getDraftModeCookieHeader,
-        handler,
-        handlerFn,
-        i18n: __i18nConfig,
-        isAutoHead,
-        isProduction: process.env.NODE_ENV === "production",
-        isrDebug: __isrDebug,
-        isrRouteKey: __isrRouteKey,
-        isrSet: __isrSet,
-        markDynamicUsage,
-        method,
-        middlewareContext: _mwCtx,
-        middlewareRequestHeaders: _mwCtx.requestHeaders,
-        params: makeThenableParams(params),
-        reportRequestError: _reportRequestError,
-        request,
-        revalidateSeconds,
-        routePattern: route.pattern,
-        setHeadersAccessPhase,
-      });
-    }
-    __clearRequestContext();
-    return __applyRouteHandlerMiddlewareContext(
-      new Response(null, {
-        status: 405,
-      }),
-      _mwCtx,
-    );
+    return __dispatchAppRouteHandler({
+      basePath: __basePath,
+      cleanPathname,
+      clearRequestContext: function() {
+        __clearRequestContext();
+      },
+      i18n: __i18nConfig,
+      isrDebug: __isrDebug,
+      isrGet: __isrGet,
+      isrRouteKey: __isrRouteKey,
+      isrSet: __isrSet,
+      middlewareContext: _mwCtx,
+      middlewareRequestHeaders: _mwCtx.requestHeaders,
+      params,
+      request,
+      route: {
+        pattern: route.pattern,
+        routeHandler: route.routeHandler,
+        routeSegments: route.routeSegments,
+      },
+      scheduleBackgroundRegeneration: __triggerBackgroundRegeneration,
+      searchParams: url.searchParams,
+    });
   }
 
   // Build the component tree: layouts wrapping the page
@@ -6455,21 +6071,11 @@ import { buildRequestHeadersFromMiddlewareResponse as __buildRequestHeadersFromM
 import { validateCsrfOrigin, validateServerActionPayload, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
 import { applyAppMiddleware as __applyAppMiddleware } from "<ROOT>/packages/vinext/src/server/app-middleware.js";
 import {
-  isKnownDynamicAppRoute as __isKnownDynamicAppRoute,
-} from "<ROOT>/packages/vinext/src/server/app-route-handler-runtime.js";
-import {
-  getAppRouteHandlerRevalidateSeconds as __getAppRouteHandlerRevalidateSeconds,
-  hasAppRouteHandlerDefaultExport as __hasAppRouteHandlerDefaultExport,
-  resolveAppRouteHandlerMethod as __resolveAppRouteHandlerMethod,
-  shouldReadAppRouteHandlerCache as __shouldReadAppRouteHandlerCache,
-} from "<ROOT>/packages/vinext/src/server/app-route-handler-policy.js";
-import {
-  executeAppRouteHandler as __executeAppRouteHandler,
-} from "<ROOT>/packages/vinext/src/server/app-route-handler-execution.js";
+  dispatchAppRouteHandler as __dispatchAppRouteHandler,
+} from "<ROOT>/packages/vinext/src/server/app-route-handler-dispatch.js";
 import {
   handleProgressiveServerActionRequest as __handleProgressiveServerActionRequest,
 } from "<ROOT>/packages/vinext/src/server/app-server-action-execution.js";
-import { readAppRouteHandlerCacheResponse as __readAppRouteHandlerCacheResponse } from "<ROOT>/packages/vinext/src/server/app-route-handler-cache.js";
 import { readAppPageCacheResponse as __readAppPageCacheResponse } from "<ROOT>/packages/vinext/src/server/app-page-cache.js";
 import {
   buildAppPageFontLinkHeader as __buildAppPageFontLinkHeader,
@@ -6520,9 +6126,6 @@ import {
 import {
   createStaticGenerationHeadersContext as __createStaticGenerationHeadersContext,
 } from "<ROOT>/packages/vinext/src/server/app-static-generation.js";
-import {
-  applyRouteHandlerMiddlewareContext as __applyRouteHandlerMiddlewareContext,
-} from "<ROOT>/packages/vinext/src/server/app-route-handler-response.js";
 import { buildPageCacheTags } from "<ROOT>/packages/vinext/src/server/implicit-tags.js";
 import { _consumeRequestScopedCacheLife, getCacheHandler } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
@@ -7994,144 +7597,29 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
 
   // Handle route.ts API handlers
   if (route.routeHandler) {
-    const handler = route.routeHandler;
-    const method = request.method.toUpperCase();
-    const revalidateSeconds = __getAppRouteHandlerRevalidateSeconds(handler);
-    const __buildRouteHandlerPageCacheTags = function(pathname, extraTags) {
-      return buildPageCacheTags(pathname, extraTags, route.routeSegments, "route");
-    };
-    if (__hasAppRouteHandlerDefaultExport(handler) && process.env.NODE_ENV === "development") {
-      console.error(
-        "[vinext] Detected default export in route handler " + route.pattern + ". Export a named export for each HTTP method instead.",
-      );
-    }
-
-    const {
-      allowHeaderForOptions,
-      handlerFn,
-      isAutoHead,
-      shouldAutoRespondToOptions,
-    } = __resolveAppRouteHandlerMethod(handler, method);
-
-    if (shouldAutoRespondToOptions) {
-      __clearRequestContext();
-      return __applyRouteHandlerMiddlewareContext(
-        new Response(null, {
-          status: 204,
-          headers: { "Allow": allowHeaderForOptions },
-        }),
-        _mwCtx,
-      );
-    }
-
-    // ISR cache read for route handlers (production only).
-    // Only GET/HEAD (auto-HEAD) with finite revalidate > 0 are ISR-eligible.
-    // Known-dynamic handlers skip the read entirely so stale cache entries
-    // from earlier requests do not replay once the process has learned they
-    // access request-specific data.
-    if (
-      __shouldReadAppRouteHandlerCache({
-        dynamicConfig: handler.dynamic,
-        handlerFn,
-        isAutoHead,
-        isKnownDynamic: __isKnownDynamicAppRoute(route.pattern),
-        isProduction: process.env.NODE_ENV === "production",
-        method,
-        revalidateSeconds,
-      })
-    ) {
-      const __cachedRouteResponse = await __readAppRouteHandlerCacheResponse({
-        basePath: __basePath,
-        buildPageCacheTags: __buildRouteHandlerPageCacheTags,
-        cleanPathname,
-        clearRequestContext: function() {
-          __clearRequestContext();
-        },
-        consumeDynamicUsage,
-        dynamicConfig: handler.dynamic,
-        getCollectedFetchTags,
-        handlerFn,
-        i18n: __i18nConfig,
-        isAutoHead,
-        isrDebug: __isrDebug,
-        isrGet: __isrGet,
-        isrRouteKey: __isrRouteKey,
-        isrSet: __isrSet,
-        markDynamicUsage,
-        middlewareContext: _mwCtx,
-        params,
-        requestUrl: request.url,
-        revalidateSearchParams: url.searchParams,
-        revalidateSeconds,
-        routePattern: route.pattern,
-        runInRevalidationContext: async function(renderFn) {
-          const __revalHeadCtx = __createStaticGenerationHeadersContext({
-            dynamicConfig: handler.dynamic,
-            routeKind: "route",
-            routePattern: route.pattern,
-          });
-          const __revalUCtx = _createUnifiedCtx({
-            headersContext: __revalHeadCtx,
-            executionContext: _getRequestExecutionContext(),
-            unstableCacheRevalidation: "foreground",
-          });
-          await _runWithUnifiedCtx(__revalUCtx, async () => {
-            _ensureFetchPatch();
-            setCurrentFetchSoftTags(buildPageCacheTags(cleanPathname, [], route.routeSegments, "route"));
-            await renderFn();
-          });
-        },
-        scheduleBackgroundRegeneration(key, renderFn) {
-          __triggerBackgroundRegeneration(key, renderFn, { routePath: route.pattern, routeType: "route" });
-        },
-        setHeadersAccessPhase,
-        setNavigationContext,
-      });
-      if (__cachedRouteResponse) {
-        return __cachedRouteResponse;
-      }
-    }
-
-    if (typeof handlerFn === "function") {
-      return __executeAppRouteHandler({
-        basePath: __basePath,
-        buildPageCacheTags: __buildRouteHandlerPageCacheTags,
-        cleanPathname,
-        clearRequestContext: function() {
-          __clearRequestContext();
-        },
-        consumeDynamicUsage,
-        executionContext: _getRequestExecutionContext(),
-        getAndClearPendingCookies,
-        getCollectedFetchTags,
-        getDraftModeCookieHeader,
-        handler,
-        handlerFn,
-        i18n: __i18nConfig,
-        isAutoHead,
-        isProduction: process.env.NODE_ENV === "production",
-        isrDebug: __isrDebug,
-        isrRouteKey: __isrRouteKey,
-        isrSet: __isrSet,
-        markDynamicUsage,
-        method,
-        middlewareContext: _mwCtx,
-        middlewareRequestHeaders: _mwCtx.requestHeaders,
-        params: makeThenableParams(params),
-        reportRequestError: _reportRequestError,
-        request,
-        revalidateSeconds,
-        routePattern: route.pattern,
-        setHeadersAccessPhase,
-      });
-    }
-    __clearRequestContext();
-    return __applyRouteHandlerMiddlewareContext(
-      new Response(null, {
-        status: 405,
-      }),
-      _mwCtx,
-    );
+    return __dispatchAppRouteHandler({
+      basePath: __basePath,
+      cleanPathname,
+      clearRequestContext: function() {
+        __clearRequestContext();
+      },
+      i18n: __i18nConfig,
+      isrDebug: __isrDebug,
+      isrGet: __isrGet,
+      isrRouteKey: __isrRouteKey,
+      isrSet: __isrSet,
+      middlewareContext: _mwCtx,
+      middlewareRequestHeaders: _mwCtx.requestHeaders,
+      params,
+      request,
+      route: {
+        pattern: route.pattern,
+        routeHandler: route.routeHandler,
+        routeSegments: route.routeSegments,
+      },
+      scheduleBackgroundRegeneration: __triggerBackgroundRegeneration,
+      searchParams: url.searchParams,
+    });
   }
 
   // Build the component tree: layouts wrapping the page
@@ -8626,21 +8114,11 @@ import { buildRequestHeadersFromMiddlewareResponse as __buildRequestHeadersFromM
 import { validateCsrfOrigin, validateServerActionPayload, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
 import { applyAppMiddleware as __applyAppMiddleware } from "<ROOT>/packages/vinext/src/server/app-middleware.js";
 import {
-  isKnownDynamicAppRoute as __isKnownDynamicAppRoute,
-} from "<ROOT>/packages/vinext/src/server/app-route-handler-runtime.js";
-import {
-  getAppRouteHandlerRevalidateSeconds as __getAppRouteHandlerRevalidateSeconds,
-  hasAppRouteHandlerDefaultExport as __hasAppRouteHandlerDefaultExport,
-  resolveAppRouteHandlerMethod as __resolveAppRouteHandlerMethod,
-  shouldReadAppRouteHandlerCache as __shouldReadAppRouteHandlerCache,
-} from "<ROOT>/packages/vinext/src/server/app-route-handler-policy.js";
-import {
-  executeAppRouteHandler as __executeAppRouteHandler,
-} from "<ROOT>/packages/vinext/src/server/app-route-handler-execution.js";
+  dispatchAppRouteHandler as __dispatchAppRouteHandler,
+} from "<ROOT>/packages/vinext/src/server/app-route-handler-dispatch.js";
 import {
   handleProgressiveServerActionRequest as __handleProgressiveServerActionRequest,
 } from "<ROOT>/packages/vinext/src/server/app-server-action-execution.js";
-import { readAppRouteHandlerCacheResponse as __readAppRouteHandlerCacheResponse } from "<ROOT>/packages/vinext/src/server/app-route-handler-cache.js";
 import { readAppPageCacheResponse as __readAppPageCacheResponse } from "<ROOT>/packages/vinext/src/server/app-page-cache.js";
 import {
   buildAppPageFontLinkHeader as __buildAppPageFontLinkHeader,
@@ -8691,9 +8169,6 @@ import {
 import {
   createStaticGenerationHeadersContext as __createStaticGenerationHeadersContext,
 } from "<ROOT>/packages/vinext/src/server/app-static-generation.js";
-import {
-  applyRouteHandlerMiddlewareContext as __applyRouteHandlerMiddlewareContext,
-} from "<ROOT>/packages/vinext/src/server/app-route-handler-response.js";
 import { buildPageCacheTags } from "<ROOT>/packages/vinext/src/server/implicit-tags.js";
 import { _consumeRequestScopedCacheLife, getCacheHandler } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
@@ -10139,144 +9614,29 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
 
   // Handle route.ts API handlers
   if (route.routeHandler) {
-    const handler = route.routeHandler;
-    const method = request.method.toUpperCase();
-    const revalidateSeconds = __getAppRouteHandlerRevalidateSeconds(handler);
-    const __buildRouteHandlerPageCacheTags = function(pathname, extraTags) {
-      return buildPageCacheTags(pathname, extraTags, route.routeSegments, "route");
-    };
-    if (__hasAppRouteHandlerDefaultExport(handler) && process.env.NODE_ENV === "development") {
-      console.error(
-        "[vinext] Detected default export in route handler " + route.pattern + ". Export a named export for each HTTP method instead.",
-      );
-    }
-
-    const {
-      allowHeaderForOptions,
-      handlerFn,
-      isAutoHead,
-      shouldAutoRespondToOptions,
-    } = __resolveAppRouteHandlerMethod(handler, method);
-
-    if (shouldAutoRespondToOptions) {
-      __clearRequestContext();
-      return __applyRouteHandlerMiddlewareContext(
-        new Response(null, {
-          status: 204,
-          headers: { "Allow": allowHeaderForOptions },
-        }),
-        _mwCtx,
-      );
-    }
-
-    // ISR cache read for route handlers (production only).
-    // Only GET/HEAD (auto-HEAD) with finite revalidate > 0 are ISR-eligible.
-    // Known-dynamic handlers skip the read entirely so stale cache entries
-    // from earlier requests do not replay once the process has learned they
-    // access request-specific data.
-    if (
-      __shouldReadAppRouteHandlerCache({
-        dynamicConfig: handler.dynamic,
-        handlerFn,
-        isAutoHead,
-        isKnownDynamic: __isKnownDynamicAppRoute(route.pattern),
-        isProduction: process.env.NODE_ENV === "production",
-        method,
-        revalidateSeconds,
-      })
-    ) {
-      const __cachedRouteResponse = await __readAppRouteHandlerCacheResponse({
-        basePath: __basePath,
-        buildPageCacheTags: __buildRouteHandlerPageCacheTags,
-        cleanPathname,
-        clearRequestContext: function() {
-          __clearRequestContext();
-        },
-        consumeDynamicUsage,
-        dynamicConfig: handler.dynamic,
-        getCollectedFetchTags,
-        handlerFn,
-        i18n: __i18nConfig,
-        isAutoHead,
-        isrDebug: __isrDebug,
-        isrGet: __isrGet,
-        isrRouteKey: __isrRouteKey,
-        isrSet: __isrSet,
-        markDynamicUsage,
-        middlewareContext: _mwCtx,
-        params,
-        requestUrl: request.url,
-        revalidateSearchParams: url.searchParams,
-        revalidateSeconds,
-        routePattern: route.pattern,
-        runInRevalidationContext: async function(renderFn) {
-          const __revalHeadCtx = __createStaticGenerationHeadersContext({
-            dynamicConfig: handler.dynamic,
-            routeKind: "route",
-            routePattern: route.pattern,
-          });
-          const __revalUCtx = _createUnifiedCtx({
-            headersContext: __revalHeadCtx,
-            executionContext: _getRequestExecutionContext(),
-            unstableCacheRevalidation: "foreground",
-          });
-          await _runWithUnifiedCtx(__revalUCtx, async () => {
-            _ensureFetchPatch();
-            setCurrentFetchSoftTags(buildPageCacheTags(cleanPathname, [], route.routeSegments, "route"));
-            await renderFn();
-          });
-        },
-        scheduleBackgroundRegeneration(key, renderFn) {
-          __triggerBackgroundRegeneration(key, renderFn, { routePath: route.pattern, routeType: "route" });
-        },
-        setHeadersAccessPhase,
-        setNavigationContext,
-      });
-      if (__cachedRouteResponse) {
-        return __cachedRouteResponse;
-      }
-    }
-
-    if (typeof handlerFn === "function") {
-      return __executeAppRouteHandler({
-        basePath: __basePath,
-        buildPageCacheTags: __buildRouteHandlerPageCacheTags,
-        cleanPathname,
-        clearRequestContext: function() {
-          __clearRequestContext();
-        },
-        consumeDynamicUsage,
-        executionContext: _getRequestExecutionContext(),
-        getAndClearPendingCookies,
-        getCollectedFetchTags,
-        getDraftModeCookieHeader,
-        handler,
-        handlerFn,
-        i18n: __i18nConfig,
-        isAutoHead,
-        isProduction: process.env.NODE_ENV === "production",
-        isrDebug: __isrDebug,
-        isrRouteKey: __isrRouteKey,
-        isrSet: __isrSet,
-        markDynamicUsage,
-        method,
-        middlewareContext: _mwCtx,
-        middlewareRequestHeaders: _mwCtx.requestHeaders,
-        params: makeThenableParams(params),
-        reportRequestError: _reportRequestError,
-        request,
-        revalidateSeconds,
-        routePattern: route.pattern,
-        setHeadersAccessPhase,
-      });
-    }
-    __clearRequestContext();
-    return __applyRouteHandlerMiddlewareContext(
-      new Response(null, {
-        status: 405,
-      }),
-      _mwCtx,
-    );
+    return __dispatchAppRouteHandler({
+      basePath: __basePath,
+      cleanPathname,
+      clearRequestContext: function() {
+        __clearRequestContext();
+      },
+      i18n: __i18nConfig,
+      isrDebug: __isrDebug,
+      isrGet: __isrGet,
+      isrRouteKey: __isrRouteKey,
+      isrSet: __isrSet,
+      middlewareContext: _mwCtx,
+      middlewareRequestHeaders: _mwCtx.requestHeaders,
+      params,
+      request,
+      route: {
+        pattern: route.pattern,
+        routeHandler: route.routeHandler,
+        routeSegments: route.routeSegments,
+      },
+      scheduleBackgroundRegeneration: __triggerBackgroundRegeneration,
+      searchParams: url.searchParams,
+    });
   }
 
   // Build the component tree: layouts wrapping the page
@@ -10771,21 +10131,11 @@ import { buildRequestHeadersFromMiddlewareResponse as __buildRequestHeadersFromM
 import { validateCsrfOrigin, validateServerActionPayload, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
 import { applyAppMiddleware as __applyAppMiddleware } from "<ROOT>/packages/vinext/src/server/app-middleware.js";
 import {
-  isKnownDynamicAppRoute as __isKnownDynamicAppRoute,
-} from "<ROOT>/packages/vinext/src/server/app-route-handler-runtime.js";
-import {
-  getAppRouteHandlerRevalidateSeconds as __getAppRouteHandlerRevalidateSeconds,
-  hasAppRouteHandlerDefaultExport as __hasAppRouteHandlerDefaultExport,
-  resolveAppRouteHandlerMethod as __resolveAppRouteHandlerMethod,
-  shouldReadAppRouteHandlerCache as __shouldReadAppRouteHandlerCache,
-} from "<ROOT>/packages/vinext/src/server/app-route-handler-policy.js";
-import {
-  executeAppRouteHandler as __executeAppRouteHandler,
-} from "<ROOT>/packages/vinext/src/server/app-route-handler-execution.js";
+  dispatchAppRouteHandler as __dispatchAppRouteHandler,
+} from "<ROOT>/packages/vinext/src/server/app-route-handler-dispatch.js";
 import {
   handleProgressiveServerActionRequest as __handleProgressiveServerActionRequest,
 } from "<ROOT>/packages/vinext/src/server/app-server-action-execution.js";
-import { readAppRouteHandlerCacheResponse as __readAppRouteHandlerCacheResponse } from "<ROOT>/packages/vinext/src/server/app-route-handler-cache.js";
 import { readAppPageCacheResponse as __readAppPageCacheResponse } from "<ROOT>/packages/vinext/src/server/app-page-cache.js";
 import {
   buildAppPageFontLinkHeader as __buildAppPageFontLinkHeader,
@@ -10836,9 +10186,6 @@ import {
 import {
   createStaticGenerationHeadersContext as __createStaticGenerationHeadersContext,
 } from "<ROOT>/packages/vinext/src/server/app-static-generation.js";
-import {
-  applyRouteHandlerMiddlewareContext as __applyRouteHandlerMiddlewareContext,
-} from "<ROOT>/packages/vinext/src/server/app-route-handler-response.js";
 import { buildPageCacheTags } from "<ROOT>/packages/vinext/src/server/implicit-tags.js";
 import { _consumeRequestScopedCacheLife, getCacheHandler } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
@@ -12292,144 +11639,29 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
 
   // Handle route.ts API handlers
   if (route.routeHandler) {
-    const handler = route.routeHandler;
-    const method = request.method.toUpperCase();
-    const revalidateSeconds = __getAppRouteHandlerRevalidateSeconds(handler);
-    const __buildRouteHandlerPageCacheTags = function(pathname, extraTags) {
-      return buildPageCacheTags(pathname, extraTags, route.routeSegments, "route");
-    };
-    if (__hasAppRouteHandlerDefaultExport(handler) && process.env.NODE_ENV === "development") {
-      console.error(
-        "[vinext] Detected default export in route handler " + route.pattern + ". Export a named export for each HTTP method instead.",
-      );
-    }
-
-    const {
-      allowHeaderForOptions,
-      handlerFn,
-      isAutoHead,
-      shouldAutoRespondToOptions,
-    } = __resolveAppRouteHandlerMethod(handler, method);
-
-    if (shouldAutoRespondToOptions) {
-      __clearRequestContext();
-      return __applyRouteHandlerMiddlewareContext(
-        new Response(null, {
-          status: 204,
-          headers: { "Allow": allowHeaderForOptions },
-        }),
-        _mwCtx,
-      );
-    }
-
-    // ISR cache read for route handlers (production only).
-    // Only GET/HEAD (auto-HEAD) with finite revalidate > 0 are ISR-eligible.
-    // Known-dynamic handlers skip the read entirely so stale cache entries
-    // from earlier requests do not replay once the process has learned they
-    // access request-specific data.
-    if (
-      __shouldReadAppRouteHandlerCache({
-        dynamicConfig: handler.dynamic,
-        handlerFn,
-        isAutoHead,
-        isKnownDynamic: __isKnownDynamicAppRoute(route.pattern),
-        isProduction: process.env.NODE_ENV === "production",
-        method,
-        revalidateSeconds,
-      })
-    ) {
-      const __cachedRouteResponse = await __readAppRouteHandlerCacheResponse({
-        basePath: __basePath,
-        buildPageCacheTags: __buildRouteHandlerPageCacheTags,
-        cleanPathname,
-        clearRequestContext: function() {
-          __clearRequestContext();
-        },
-        consumeDynamicUsage,
-        dynamicConfig: handler.dynamic,
-        getCollectedFetchTags,
-        handlerFn,
-        i18n: __i18nConfig,
-        isAutoHead,
-        isrDebug: __isrDebug,
-        isrGet: __isrGet,
-        isrRouteKey: __isrRouteKey,
-        isrSet: __isrSet,
-        markDynamicUsage,
-        middlewareContext: _mwCtx,
-        params,
-        requestUrl: request.url,
-        revalidateSearchParams: url.searchParams,
-        revalidateSeconds,
-        routePattern: route.pattern,
-        runInRevalidationContext: async function(renderFn) {
-          const __revalHeadCtx = __createStaticGenerationHeadersContext({
-            dynamicConfig: handler.dynamic,
-            routeKind: "route",
-            routePattern: route.pattern,
-          });
-          const __revalUCtx = _createUnifiedCtx({
-            headersContext: __revalHeadCtx,
-            executionContext: _getRequestExecutionContext(),
-            unstableCacheRevalidation: "foreground",
-          });
-          await _runWithUnifiedCtx(__revalUCtx, async () => {
-            _ensureFetchPatch();
-            setCurrentFetchSoftTags(buildPageCacheTags(cleanPathname, [], route.routeSegments, "route"));
-            await renderFn();
-          });
-        },
-        scheduleBackgroundRegeneration(key, renderFn) {
-          __triggerBackgroundRegeneration(key, renderFn, { routePath: route.pattern, routeType: "route" });
-        },
-        setHeadersAccessPhase,
-        setNavigationContext,
-      });
-      if (__cachedRouteResponse) {
-        return __cachedRouteResponse;
-      }
-    }
-
-    if (typeof handlerFn === "function") {
-      return __executeAppRouteHandler({
-        basePath: __basePath,
-        buildPageCacheTags: __buildRouteHandlerPageCacheTags,
-        cleanPathname,
-        clearRequestContext: function() {
-          __clearRequestContext();
-        },
-        consumeDynamicUsage,
-        executionContext: _getRequestExecutionContext(),
-        getAndClearPendingCookies,
-        getCollectedFetchTags,
-        getDraftModeCookieHeader,
-        handler,
-        handlerFn,
-        i18n: __i18nConfig,
-        isAutoHead,
-        isProduction: process.env.NODE_ENV === "production",
-        isrDebug: __isrDebug,
-        isrRouteKey: __isrRouteKey,
-        isrSet: __isrSet,
-        markDynamicUsage,
-        method,
-        middlewareContext: _mwCtx,
-        middlewareRequestHeaders: _mwCtx.requestHeaders,
-        params: makeThenableParams(params),
-        reportRequestError: _reportRequestError,
-        request,
-        revalidateSeconds,
-        routePattern: route.pattern,
-        setHeadersAccessPhase,
-      });
-    }
-    __clearRequestContext();
-    return __applyRouteHandlerMiddlewareContext(
-      new Response(null, {
-        status: 405,
-      }),
-      _mwCtx,
-    );
+    return __dispatchAppRouteHandler({
+      basePath: __basePath,
+      cleanPathname,
+      clearRequestContext: function() {
+        __clearRequestContext();
+      },
+      i18n: __i18nConfig,
+      isrDebug: __isrDebug,
+      isrGet: __isrGet,
+      isrRouteKey: __isrRouteKey,
+      isrSet: __isrSet,
+      middlewareContext: _mwCtx,
+      middlewareRequestHeaders: _mwCtx.requestHeaders,
+      params,
+      request,
+      route: {
+        pattern: route.pattern,
+        routeHandler: route.routeHandler,
+        routeSegments: route.routeSegments,
+      },
+      scheduleBackgroundRegeneration: __triggerBackgroundRegeneration,
+      searchParams: url.searchParams,
+    });
   }
 
   // Build the component tree: layouts wrapping the page

--- a/tests/app-route-handler-dispatch.test.ts
+++ b/tests/app-route-handler-dispatch.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+import { dispatchAppRouteHandler } from "../packages/vinext/src/server/app-route-handler-dispatch.js";
+import type { CachedRouteValue } from "../packages/vinext/src/shims/cache.js";
+import type { ISRCacheEntry } from "../packages/vinext/src/server/isr-cache.js";
+
+function buildCachedRouteValue(body: string): CachedRouteValue {
+  return {
+    kind: "APP_ROUTE",
+    body: new TextEncoder().encode(body).buffer,
+    status: 200,
+    headers: {
+      "content-type": "text/plain",
+    },
+  };
+}
+
+function buildISRCacheEntry(value: CachedRouteValue, isStale = false): ISRCacheEntry {
+  return {
+    isStale,
+    value: {
+      lastModified: Date.now(),
+      value,
+    },
+  };
+}
+
+describe("app route handler dispatch", () => {
+  it("handles framework-generated OPTIONS responses and unsupported methods at the dispatch boundary", async () => {
+    const route = {
+      pattern: "/api/demo",
+      routeHandler: {
+        GET() {
+          throw new Error("GET should not run for OPTIONS or DELETE");
+        },
+        POST() {
+          throw new Error("POST should not run for OPTIONS or DELETE");
+        },
+      },
+      routeSegments: ["api", "demo"],
+    };
+    let clearCount = 0;
+
+    const optionsResponse = await dispatchAppRouteHandler({
+      cleanPathname: "/api/demo",
+      clearRequestContext() {
+        clearCount += 1;
+      },
+      i18n: null,
+      isDevelopment: false,
+      isProduction: false,
+      async isrGet() {
+        throw new Error("OPTIONS should not read route cache");
+      },
+      isrRouteKey(pathname) {
+        return "route:" + pathname;
+      },
+      async isrSet() {
+        throw new Error("OPTIONS should not write route cache");
+      },
+      middlewareContext: {
+        headers: new Headers([["x-middleware", "present"]]),
+        status: null,
+      },
+      middlewareRequestHeaders: null,
+      params: {},
+      request: new Request("https://example.com/api/demo", { method: "OPTIONS" }),
+      route,
+      scheduleBackgroundRegeneration() {
+        throw new Error("OPTIONS should not schedule regeneration");
+      },
+      searchParams: new URLSearchParams(),
+    });
+
+    expect(optionsResponse.status).toBe(204);
+    expect(optionsResponse.headers.get("allow")).toBe("GET, HEAD, OPTIONS, POST");
+    expect(optionsResponse.headers.get("x-middleware")).toBe("present");
+    await expect(optionsResponse.text()).resolves.toBe("");
+
+    const unsupportedResponse = await dispatchAppRouteHandler({
+      cleanPathname: "/api/demo",
+      clearRequestContext() {
+        clearCount += 1;
+      },
+      i18n: null,
+      isDevelopment: false,
+      isProduction: false,
+      async isrGet() {
+        throw new Error("DELETE should not read route cache");
+      },
+      isrRouteKey(pathname) {
+        return "route:" + pathname;
+      },
+      async isrSet() {
+        throw new Error("DELETE should not write route cache");
+      },
+      middlewareContext: {
+        headers: new Headers([["x-middleware-delete", "present"]]),
+        status: null,
+      },
+      middlewareRequestHeaders: null,
+      params: {},
+      request: new Request("https://example.com/api/demo", { method: "DELETE" }),
+      route,
+      scheduleBackgroundRegeneration() {
+        throw new Error("DELETE should not schedule regeneration");
+      },
+      searchParams: new URLSearchParams(),
+    });
+
+    expect(unsupportedResponse.status).toBe(405);
+    expect(unsupportedResponse.headers.get("x-middleware-delete")).toBe("present");
+    await expect(unsupportedResponse.text()).resolves.toBe("");
+    expect(clearCount).toBe(2);
+  });
+
+  it("reads eligible ISR route handler responses before executing user code", async () => {
+    const handlerSpy = vi.fn(() => new Response("should not run"));
+    let didClearRequestContext = false;
+    let requestedCacheKey: string | null = null;
+
+    const response = await dispatchAppRouteHandler({
+      cleanPathname: "/api/static",
+      clearRequestContext() {
+        didClearRequestContext = true;
+      },
+      i18n: null,
+      isDevelopment: false,
+      isProduction: true,
+      async isrGet(key) {
+        requestedCacheKey = key;
+        return buildISRCacheEntry(buildCachedRouteValue("from-cache"));
+      },
+      isrRouteKey(pathname) {
+        return "route:" + pathname;
+      },
+      async isrSet() {
+        throw new Error("cache hit should not write route cache");
+      },
+      middlewareContext: { headers: null, status: null },
+      middlewareRequestHeaders: null,
+      params: {},
+      request: new Request("https://example.com/api/static"),
+      route: {
+        pattern: "/api/static",
+        routeHandler: {
+          GET: handlerSpy,
+          revalidate: 60,
+        },
+        routeSegments: ["api", "static"],
+      },
+      scheduleBackgroundRegeneration() {
+        throw new Error("fresh cache hit should not schedule regeneration");
+      },
+      searchParams: new URLSearchParams(),
+    });
+
+    expect(requestedCacheKey).toBe("route:/api/static");
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-vinext-cache")).toBe("HIT");
+    await expect(response.text()).resolves.toBe("from-cache");
+    expect(handlerSpy).not.toHaveBeenCalled();
+    expect(didClearRequestContext).toBe(true);
+  });
+
+  it("attaches App Router route context when stale route handler cache schedules regeneration", async () => {
+    const handlerSpy = vi.fn(() => new Response("regenerated"));
+    let scheduledContext:
+      | {
+          routerKind: "App Router";
+          routePath: string;
+          routeType: "route";
+        }
+      | undefined;
+
+    const response = await dispatchAppRouteHandler({
+      cleanPathname: "/api/stale",
+      clearRequestContext() {},
+      i18n: null,
+      isDevelopment: false,
+      isProduction: true,
+      async isrGet() {
+        return buildISRCacheEntry(buildCachedRouteValue("stale"), true);
+      },
+      isrRouteKey(pathname) {
+        return "route:" + pathname;
+      },
+      async isrSet() {
+        throw new Error("stale response should not synchronously write route cache");
+      },
+      middlewareContext: { headers: null, status: null },
+      middlewareRequestHeaders: null,
+      params: {},
+      request: new Request("https://example.com/api/stale"),
+      route: {
+        pattern: "/api/stale",
+        routeHandler: {
+          GET: handlerSpy,
+          revalidate: 60,
+        },
+        routeSegments: ["api", "stale"],
+      },
+      scheduleBackgroundRegeneration(_key, _renderFn, errorContext) {
+        scheduledContext = errorContext;
+      },
+      searchParams: new URLSearchParams(),
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-vinext-cache")).toBe("STALE");
+    await expect(response.text()).resolves.toBe("stale");
+    expect(handlerSpy).not.toHaveBeenCalled();
+    expect(scheduledContext).toEqual({
+      routerKind: "App Router",
+      routePath: "/api/stale",
+      routeType: "route",
+    });
+  });
+});

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -4418,17 +4418,16 @@ describe("generateRscEntry ISR code generation", () => {
     expect(code).toContain("const __pendingRegenerations = new Map()");
   });
 
-  it("generated code threads collected fetch tags into page ISR writes", () => {
+  it("generated code threads collected fetch tags into page ISR writes and delegates route ISR", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes);
     expect(code).toContain("getCollectedFetchTags");
     expect(code).toContain("buildPageCacheTags");
     expect(code).toContain(
       'buildPageCacheTags(cleanPathname, [], route.routeSegments, route.routeHandler ? "route" : "page")',
     );
-    expect(code).toContain(
-      "const __buildRouteHandlerPageCacheTags = function(pathname, extraTags) {",
-    );
-    expect(code).toContain("buildPageCacheTags: __buildRouteHandlerPageCacheTags");
+    expect(code).toContain("dispatchAppRouteHandler as __dispatchAppRouteHandler");
+    expect(code).toContain("return __dispatchAppRouteHandler({");
+    expect(code).toContain("scheduleBackgroundRegeneration: __triggerBackgroundRegeneration");
     expect(code).toContain(
       'const __pageTags = buildPageCacheTags(cleanPathname, getCollectedFetchTags(), route.routeSegments, "page")',
     );
@@ -4725,22 +4724,22 @@ describe("generateRscEntry ISR code generation", () => {
 
   it("generated code contains APP_ROUTE ISR cache read for route handlers", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes);
-    // Route handler ISR reads now flow through the typed cache helper.
-    expect(code).toContain(
-      "readAppRouteHandlerCacheResponse as __readAppRouteHandlerCacheResponse",
-    );
-    expect(code).toContain("await __readAppRouteHandlerCacheResponse({");
+    // Route handler ISR reads now flow through the typed dispatch helper.
+    expect(code).toContain("dispatchAppRouteHandler as __dispatchAppRouteHandler");
+    expect(code).toContain("return __dispatchAppRouteHandler({");
     expect(code).toContain("isrGet: __isrGet");
-    expect(code).toContain("scheduleBackgroundRegeneration(key, renderFn) {");
+    expect(code).toContain("scheduleBackgroundRegeneration: __triggerBackgroundRegeneration");
+    expect(code).not.toContain("await __readAppRouteHandlerCacheResponse({");
   });
 
   it("generated code contains APP_ROUTE ISR cache write for route handlers", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes);
-    // Route handler ISR writes now flow through the typed execution helper.
-    expect(code).toContain("executeAppRouteHandler as __executeAppRouteHandler");
-    expect(code).toContain("return __executeAppRouteHandler({");
+    // Route handler ISR writes now flow through the typed dispatch helper.
+    expect(code).toContain("dispatchAppRouteHandler as __dispatchAppRouteHandler");
+    expect(code).toContain("return __dispatchAppRouteHandler({");
     expect(code).toContain("isrRouteKey: __isrRouteKey");
     expect(code).toContain("isrSet: __isrSet");
+    expect(code).not.toContain("return __executeAppRouteHandler({");
   });
 
   it("generated code merges middleware headers into intercept route responses", () => {


### PR DESCRIPTION
## What changed

This extracts App Router `route.ts` dispatch out of the generated RSC entry and into a normal typed runtime module: `server/app-route-handler-dispatch.ts`.

The generated entry now describes only the app shape and request seams for a matched route handler:

- route pattern, route handler module, and route segments
- request, params, search params, i18n/base path
- ISR storage hooks and request-context cleanup
- middleware response context

The new dispatcher owns the behavior previously embedded in codegen:

- default-export warning in dev
- HTTP method resolution, auto-`HEAD`, auto-`OPTIONS`, and 405 responses
- route handler ISR read path and stale regeneration context
- user handler execution, response finalization, middleware merge, and cache writes through the existing helper modules

## Why

Generated entries should describe the application shape. Normal modules should implement behavior. The old `route.ts` branch in `entries/app-rsc-entry.ts` was still making runtime decisions even though the lower-level policy/cache/execution helpers already existed.

This mirrors the shape of Next.js more closely: the build template creates a route module, and the route module owns request handling behavior.

Relevant Next.js references:

- [`app-route` build template creates `AppRouteRouteModule`](https://github.com/vercel/next.js/blob/e1bb911c14e4ea3c6bb8cc98871ffdee317d513f/packages/next/src/build/templates/app-route.ts#L48-L80)
- [`AppRouteRouteModule` initializes userland methods and route config](https://github.com/vercel/next.js/blob/e1bb911c14e4ea3c6bb8cc98871ffdee317d513f/packages/next/src/server/route-modules/app-route/module.ts#L325-L337)
- [`AppRouteRouteModule.handle()` owns request dispatch and response validation](https://github.com/vercel/next.js/blob/e1bb911c14e4ea3c6bb8cc98871ffdee317d513f/packages/next/src/server/route-modules/app-route/module.ts#L798-L981)
- [`autoImplementMethods()` owns auto-`HEAD`, auto-`OPTIONS`, and 405 defaults](https://github.com/vercel/next.js/blob/e1bb911c14e4ea3c6bb8cc98871ffdee317d513f/packages/next/src/server/route-modules/app-route/helpers/auto-implement-methods.ts#L11-L81)

## Tests

- `vp check packages/vinext/src/server/app-route-handler-dispatch.ts packages/vinext/src/entries/app-rsc-entry.ts tests/app-route-handler-dispatch.test.ts tests/app-router.test.ts tests/__snapshots__/entry-templates.test.ts.snap`
- `vp test run tests/app-route-handler-dispatch.test.ts tests/app-route-handler-execution.test.ts tests/app-route-handler-cache.test.ts tests/app-route-handler-policy.test.ts tests/app-route-handler-response.test.ts tests/app-router.test.ts tests/nextjs-compat/app-routes.test.ts tests/entry-templates.test.ts -t "app route handler dispatch|app route handler|APP_ROUTE ISR|route handler|Route Handlers|Basic HTTP methods|HEAD|OPTIONS|unimplemented method|route handler ISR|catch-all route handler|dev mode|App Router RSC entry template"`
- `vp test run tests/entry-templates.test.ts`
- `vp run vinext#build`
