### PR TITLE
fix: align metadataRouteSuffix exemption list with Next.js

### DIFF
--- a/packages/vinext/src/server/metadata-routes.ts
+++ b/packages/vinext/src/server/metadata-routes.ts
@@ -461,9 +461,10 @@ export type MetadataFileRoute = {
 };
 
 function metadataRouteSuffix(parentSegments: string[], metaType: string): string {
-  if (metaType === "sitemap" || metaType === "robots" || metaType === "manifest") {
-    // Sitemap is exempt per Next.js. Robots and manifest are also safe to
-    // exempt because they are root-only in vinext, so invisible parents never apply.
+  if (metaType === "sitemap") {
+    // Sitemap is exempt per Next.js (robots/manifest are root-only, so
+    // invisible parents never apply — but we keep the exemption list
+    // matching getMetadataRouteSuffix for defensive consistency).
     return "";
   }
 


### PR DESCRIPTION
Fixes #963

## Summary
- Removed extra `robots` and `manifest` exemptions from `metadataRouteSuffix` to match `getMetadataRouteSuffix` and Next.js
- Both functions now only exempt `sitemap` from hash suffixes
- The extra exemptions were latent (robots/manifest are root-only), but the inconsistency could cause bugs if `nestable` ever changes

## Test plan
- Existing `tests/metadata-routes.test.ts` (69 tests) pass
- Existing `tests/app-router.test.ts` metadata tests pass