### PR TITLE
fix: correct route-level boundary nesting order to match Next.js

### DIFF
--- a/packages/vinext/src/server/app-page-route-wiring.tsx
+++ b/packages/vinext/src/server/app-page-route-wiring.tsx
@@ -556,11 +556,8 @@ export function buildAppPageElements<
     options.route.errors && options.route.errors.length > 0
       ? options.route.errors[options.route.errors.length - 1]
       : null;
-  const pageErrorComponent = getErrorBoundaryExport(options.route.error);
-  if (pageErrorComponent && options.route.error !== lastLayoutErrorModule) {
-    routeChildren = <ErrorBoundary fallback={pageErrorComponent}>{routeChildren}</ErrorBoundary>;
-  }
-
+  // Next.js nesting (outer to inner): Error > NotFound > children.
+  // Building bottom-up means NotFoundBoundary must wrap first, then ErrorBoundary.
   const notFoundComponent =
     getDefaultExport(options.route.notFound) ?? getDefaultExport(options.rootNotFoundModule);
   if (notFoundComponent) {
@@ -568,6 +565,11 @@ export function buildAppPageElements<
     routeChildren = (
       <NotFoundBoundary fallback={<NotFoundComponent />}>{routeChildren}</NotFoundBoundary>
     );
+  }
+
+  const pageErrorComponent = getErrorBoundaryExport(options.route.error);
+  if (pageErrorComponent && options.route.error !== lastLayoutErrorModule) {
+    routeChildren = <ErrorBoundary fallback={pageErrorComponent}>{routeChildren}</ErrorBoundary>;
   }
 
   for (let index = orderedTreePositions.length - 1; index >= 0; index--) {


### PR DESCRIPTION
Fixes #962

## Summary
- Swapped NotFoundBoundary and ErrorBoundary wrapping order at the route level in `app-page-route-wiring.tsx`
- Next.js nests ErrorBoundary outermost relative to NotFoundBoundary; vinext had this inverted
- The segment-level ordering was already correct; only the route-level code was fixed

## Test plan
- All existing tests pass: 321 app-router tests, 264 features tests, 528 nextjs-compat tests
- Build, lint, format, and typecheck all pass