### PR TITLE
fix: forward invalid dynamic usage errors on client-side navigations in dev

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -182,7 +182,7 @@ function renderToReadableStream(model, options) {
 }
 import { createElement } from "react";
 import { setNavigationContext as _setNavigationContextOrig, getNavigationContext as _getNavigationContext } from "next/navigation";
-import { setHeadersContext, headersContextFromRequest, getDraftModeCookieHeader, getAndClearPendingCookies, consumeDynamicUsage, markDynamicUsage, getHeadersContext, setHeadersAccessPhase } from "next/headers";
+import { setHeadersContext, headersContextFromRequest, getDraftModeCookieHeader, getAndClearPendingCookies, consumeDynamicUsage, consumeInvalidDynamicUsageError, markDynamicUsage, getHeadersContext, setHeadersAccessPhase } from "next/headers";
 import { mergeMetadata, resolveModuleMetadata, mergeViewport, resolveModuleViewport } from "vinext/metadata";
 ${middlewarePath ? `import * as middlewareModule from ${JSON.stringify(middlewarePath.replace(/\\/g, "/"))};` : ""}
 ${instrumentationPath ? `import * as _instrumentation from ${JSON.stringify(instrumentationPath.replace(/\\/g, "/"))};` : ""}
@@ -1787,6 +1787,7 @@ ${prerenderPagesLoaderOption}
       __clearRequestContext();
     },
     consumeDynamicUsage,
+    consumeInvalidDynamicUsageError,
     createRscOnErrorHandler(pathname, routePath) {
       return createRscOnErrorHandler(request, pathname, routePath);
     },

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -267,6 +267,13 @@ export async function renderAppPageLifecycle(
     // workStore.invalidDynamicUsageError is checked after the accumulated chunks
     // promise resolves (app-render.tsx generateDynamicFlightRenderResultWithStagesInDev).
     // Ported from Next.js: https://github.com/vercel/next.js/commit/f5e54c06726b571a042fce67417e40a29f6b8689
+    //
+    // Note: This only covers RSC responses (client-side navigations). The HTML path
+    // (initial page loads) intentionally defers this coverage — the error is still
+    // thrown through the RSC pipeline and captured by rscErrorTracker.onRenderError
+    // if uncaught by user code. Full parity with Next.js would require checking
+    // invalidDynamicUsageError after SSR rendering, which is deferred as out of scope
+    // for this PR focused on client-side navigations.
     const devRscResponse =
       !options.isProduction && rscResponse.body && options.consumeInvalidDynamicUsageError
         ? wrapRscResponseForDevErrorReporting(rscResponse, options.consumeInvalidDynamicUsageError)

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -53,6 +53,8 @@ type RenderAppPageLifecycleOptions = {
   cleanPathname: string;
   clearRequestContext: () => void;
   consumeDynamicUsage: () => boolean;
+  /** Read and clear any invalid dynamic usage error recorded during render (dev-only). */
+  consumeInvalidDynamicUsageError?: () => unknown;
   createRscOnErrorHandler: (pathname: string, routePath: string) => AppPageBoundaryOnError;
   getFontLinks: () => string[];
   getFontPreloads: () => AppPageFontPreload[];
@@ -116,6 +118,68 @@ function buildResponseTiming(
     renderEnd: options.renderEnd,
     responseKind: options.responseKind,
   };
+}
+
+/**
+ * Wraps an RSC response body to report invalid dynamic usage errors after the
+ * stream is fully consumed. In dev mode, errors from cookies()/headers() inside
+ * "use cache" may be caught by user try/catch and silently swallowed — this
+ * wrapper waits for the stream to drain and surfaces any recorded error to the
+ * terminal (and, via HMR, the browser dev overlay).
+ * Ported from Next.js: https://github.com/vercel/next.js/commit/f5e54c06726b571a042fce67417e40a29f6b8689
+ */
+function wrapRscResponseForDevErrorReporting(
+  response: Response,
+  consumeInvalidDynamicUsageError: () => unknown,
+): Response {
+  const originalBody = response.body;
+  if (!originalBody) return response;
+
+  let consumed = false;
+  const onConsumed = () => {
+    if (consumed) return;
+    consumed = true;
+    const error = consumeInvalidDynamicUsageError();
+    if (error) {
+      console.error("[vinext] Invalid dynamic usage:", error);
+    }
+  };
+
+  const cleanup = new TransformStream<Uint8Array, Uint8Array>({
+    flush() {
+      onConsumed();
+    },
+  });
+
+  const piped = originalBody.pipeThrough(cleanup);
+  const reader = piped.getReader();
+  const wrappedStream = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      return reader.read().then(
+        ({ done, value }) => {
+          if (done) {
+            controller.close();
+          } else {
+            controller.enqueue(value);
+          }
+        },
+        (streamError) => {
+          onConsumed();
+          controller.error(streamError);
+        },
+      );
+    },
+    cancel(reason) {
+      onConsumed();
+      return reader.cancel(reason);
+    },
+  });
+
+  return new Response(wrappedStream, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
 }
 
 export async function renderAppPageLifecycle(
@@ -198,7 +262,17 @@ export async function renderAppPageLifecycle(
       }),
     });
 
-    return finalizeAppPageRscCacheResponse(rscResponse, {
+    // In dev mode, wrap the RSC response body to forward invalid dynamic usage
+    // errors after the stream is consumed. This mirrors Next.js behavior where
+    // workStore.invalidDynamicUsageError is checked after the accumulated chunks
+    // promise resolves (app-render.tsx generateDynamicFlightRenderResultWithStagesInDev).
+    // Ported from Next.js: https://github.com/vercel/next.js/commit/f5e54c06726b571a042fce67417e40a29f6b8689
+    const devRscResponse =
+      !options.isProduction && rscResponse.body && options.consumeInvalidDynamicUsageError
+        ? wrapRscResponseForDevErrorReporting(rscResponse, options.consumeInvalidDynamicUsageError)
+        : rscResponse;
+
+    return finalizeAppPageRscCacheResponse(devRscResponse, {
       capturedRscDataPromise: options.isProduction ? isrRscDataPromise : null,
       cleanPathname: options.cleanPathname,
       consumeDynamicUsage: options.consumeDynamicUsage,

--- a/packages/vinext/src/shims/headers.ts
+++ b/packages/vinext/src/shims/headers.ts
@@ -36,6 +36,8 @@ export type HeadersAccessPhase = "render" | "action" | "route-handler";
 export type VinextHeadersShimState = {
   headersContext: HeadersContext | null;
   dynamicUsageDetected: boolean;
+  /** Error recorded by throwIfInsideCacheScope for dev diagnostics, persists even if caught by user code. */
+  invalidDynamicUsageError: unknown;
   pendingSetCookies: string[];
   draftModeCookieHeader: string | null;
   phase: HeadersAccessPhase;
@@ -57,6 +59,7 @@ const _als = (_g[_ALS_KEY] ??=
 const _fallbackState = (_g[_FALLBACK_KEY] ??= {
   headersContext: null,
   dynamicUsageDetected: false,
+  invalidDynamicUsageError: null,
   pendingSetCookies: [],
   draftModeCookieHeader: null,
   phase: "render",
@@ -202,19 +205,54 @@ function _isInsideUnstableCache(): boolean {
  */
 export function throwIfInsideCacheScope(apiName: string): void {
   if (_isInsideUseCache()) {
-    throw new Error(
+    const error = new Error(
       `\`${apiName}\` cannot be called inside "use cache". ` +
         `If you need this data inside a cached function, call \`${apiName}\` ` +
         "outside and pass the required data as an argument.",
     );
+    // Record the error on the request context so it survives user try/catch
+    // and can be forwarded to the dev overlay on client-side navigations.
+    // Ported from Next.js: workStore.invalidDynamicUsageError assignment in
+    // packages/next/src/server/app-render/app-render.tsx
+    // https://github.com/vercel/next.js/commit/f5e54c06726b571a042fce67417e40a29f6b8689
+    try {
+      const ctx = getRequestContext();
+      if (ctx) ctx.invalidDynamicUsageError = error;
+    } catch {
+      // Ignore — best-effort recording for dev diagnostics
+    }
+    throw error;
   }
   if (_isInsideUnstableCache()) {
-    throw new Error(
+    const error = new Error(
       `\`${apiName}\` cannot be called inside a function cached with \`unstable_cache()\`. ` +
         `If you need this data inside a cached function, call \`${apiName}\` ` +
         "outside and pass the required data as an argument.",
     );
+    try {
+      const ctx = getRequestContext();
+      if (ctx) ctx.invalidDynamicUsageError = error;
+    } catch {
+      // Ignore
+    }
+    throw error;
   }
+}
+
+/**
+ * Check, consume, and return any invalid dynamic usage error recorded during
+ * the render (e.g. cookies() called inside "use cache"). This error persists
+ * even if the throw was caught by user-code try/catch, so it can surface on
+ * client-side navigations where the static shell validation is skipped.
+ * Ported from Next.js: workStore.invalidDynamicUsageError in
+ * packages/next/src/server/app-render/app-render.tsx
+ * https://github.com/vercel/next.js/commit/f5e54c06726b571a042fce67417e40a29f6b8689
+ */
+export function consumeInvalidDynamicUsageError(): unknown {
+  const state = _getState();
+  const err = state.invalidDynamicUsageError;
+  state.invalidDynamicUsageError = null;
+  return err;
 }
 
 /**
@@ -310,6 +348,7 @@ export function runWithHeadersContext<T>(
   const state: VinextHeadersShimState = {
     headersContext: ctx,
     dynamicUsageDetected: false,
+    invalidDynamicUsageError: null,
     pendingSetCookies: [],
     draftModeCookieHeader: null,
     phase: "render",

--- a/packages/vinext/src/shims/server.ts
+++ b/packages/vinext/src/shims/server.ts
@@ -36,19 +36,41 @@ const _g = globalThis as unknown as Record<PropertyKey, unknown>;
 function _throwIfInsideCacheScope(apiName: string): void {
   const cacheAls = _g[_USE_CACHE_ALS_KEY] as { getStore(): unknown } | undefined;
   if (cacheAls?.getStore() != null) {
-    throw new Error(
+    const error = new Error(
       `\`${apiName}\` cannot be called inside "use cache". ` +
         `If you need this data inside a cached function, call \`${apiName}\` ` +
         "outside and pass the required data as an argument.",
     );
+    // Record the error on the request context so it survives user try/catch
+    // and can be forwarded to the dev overlay on client-side navigations.
+    try {
+      const _unifiedAls = _g[Symbol.for("vinext.unifiedRequestContext.als")] as
+        | { getStore(): unknown }
+        | undefined;
+      const ctx = _unifiedAls?.getStore() as Record<string, unknown> | undefined;
+      if (ctx) ctx.invalidDynamicUsageError = error;
+    } catch {
+      // Ignore — best-effort recording for dev diagnostics
+    }
+    throw error;
   }
   const unstableAls = _g[_UNSTABLE_CACHE_ALS_KEY] as { getStore(): unknown } | undefined;
   if (unstableAls?.getStore() === true) {
-    throw new Error(
+    const error = new Error(
       `\`${apiName}\` cannot be called inside a function cached with \`unstable_cache()\`. ` +
         `If you need this data inside a cached function, call \`${apiName}\` ` +
         "outside and pass the required data as an argument.",
     );
+    try {
+      const _unifiedAls = _g[Symbol.for("vinext.unifiedRequestContext.als")] as
+        | { getStore(): unknown }
+        | undefined;
+      const ctx = _unifiedAls?.getStore() as Record<string, unknown> | undefined;
+      if (ctx) ctx.invalidDynamicUsageError = error;
+    } catch {
+      // Ignore
+    }
+    throw error;
   }
 }
 

--- a/packages/vinext/src/shims/server.ts
+++ b/packages/vinext/src/shims/server.ts
@@ -33,6 +33,22 @@ const _USE_CACHE_ALS_KEY = Symbol.for("vinext.cacheRuntime.contextAls");
 const _UNSTABLE_CACHE_ALS_KEY = Symbol.for("vinext.unstableCache.als");
 const _g = globalThis as unknown as Record<PropertyKey, unknown>;
 
+/**
+ * Record an invalid dynamic usage error on the request context so it survives
+ * user try/catch and can be forwarded to the dev overlay on client-side navigations.
+ */
+function _recordInvalidDynamicUsageError(error: Error): void {
+  try {
+    const _unifiedAls = _g[Symbol.for("vinext.unifiedRequestContext.als")] as
+      | { getStore(): unknown }
+      | undefined;
+    const ctx = _unifiedAls?.getStore() as Record<string, unknown> | undefined;
+    if (ctx) ctx.invalidDynamicUsageError = error;
+  } catch {
+    // Ignore — best-effort recording for dev diagnostics
+  }
+}
+
 function _throwIfInsideCacheScope(apiName: string): void {
   const cacheAls = _g[_USE_CACHE_ALS_KEY] as { getStore(): unknown } | undefined;
   if (cacheAls?.getStore() != null) {
@@ -41,17 +57,7 @@ function _throwIfInsideCacheScope(apiName: string): void {
         `If you need this data inside a cached function, call \`${apiName}\` ` +
         "outside and pass the required data as an argument.",
     );
-    // Record the error on the request context so it survives user try/catch
-    // and can be forwarded to the dev overlay on client-side navigations.
-    try {
-      const _unifiedAls = _g[Symbol.for("vinext.unifiedRequestContext.als")] as
-        | { getStore(): unknown }
-        | undefined;
-      const ctx = _unifiedAls?.getStore() as Record<string, unknown> | undefined;
-      if (ctx) ctx.invalidDynamicUsageError = error;
-    } catch {
-      // Ignore — best-effort recording for dev diagnostics
-    }
+    _recordInvalidDynamicUsageError(error);
     throw error;
   }
   const unstableAls = _g[_UNSTABLE_CACHE_ALS_KEY] as { getStore(): unknown } | undefined;
@@ -61,15 +67,7 @@ function _throwIfInsideCacheScope(apiName: string): void {
         `If you need this data inside a cached function, call \`${apiName}\` ` +
         "outside and pass the required data as an argument.",
     );
-    try {
-      const _unifiedAls = _g[Symbol.for("vinext.unifiedRequestContext.als")] as
-        | { getStore(): unknown }
-        | undefined;
-      const ctx = _unifiedAls?.getStore() as Record<string, unknown> | undefined;
-      if (ctx) ctx.invalidDynamicUsageError = error;
-    } catch {
-      // Ignore
-    }
+    _recordInvalidDynamicUsageError(error);
     throw error;
   }
 }

--- a/packages/vinext/src/shims/unified-request-context.ts
+++ b/packages/vinext/src/shims/unified-request-context.ts
@@ -87,6 +87,7 @@ export function createRequestContext(opts?: Partial<UnifiedRequestContext>): Uni
   return {
     headersContext: null,
     dynamicUsageDetected: false,
+    invalidDynamicUsageError: null,
     pendingSetCookies: [],
     draftModeCookieHeader: null,
     phase: "render",

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -22,7 +22,7 @@ function renderToReadableStream(model, options) {
 }
 import { createElement } from "react";
 import { setNavigationContext as _setNavigationContextOrig, getNavigationContext as _getNavigationContext } from "next/navigation";
-import { setHeadersContext, headersContextFromRequest, getDraftModeCookieHeader, getAndClearPendingCookies, consumeDynamicUsage, markDynamicUsage, getHeadersContext, setHeadersAccessPhase } from "next/headers";
+import { setHeadersContext, headersContextFromRequest, getDraftModeCookieHeader, getAndClearPendingCookies, consumeDynamicUsage, consumeInvalidDynamicUsageError, markDynamicUsage, getHeadersContext, setHeadersAccessPhase } from "next/headers";
 import { mergeMetadata, resolveModuleMetadata, mergeViewport, resolveModuleViewport } from "vinext/metadata";
 
 
@@ -1693,6 +1693,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       __clearRequestContext();
     },
     consumeDynamicUsage,
+    consumeInvalidDynamicUsageError,
     createRscOnErrorHandler(pathname, routePath) {
       return createRscOnErrorHandler(request, pathname, routePath);
     },
@@ -1876,7 +1877,7 @@ function renderToReadableStream(model, options) {
 }
 import { createElement } from "react";
 import { setNavigationContext as _setNavigationContextOrig, getNavigationContext as _getNavigationContext } from "next/navigation";
-import { setHeadersContext, headersContextFromRequest, getDraftModeCookieHeader, getAndClearPendingCookies, consumeDynamicUsage, markDynamicUsage, getHeadersContext, setHeadersAccessPhase } from "next/headers";
+import { setHeadersContext, headersContextFromRequest, getDraftModeCookieHeader, getAndClearPendingCookies, consumeDynamicUsage, consumeInvalidDynamicUsageError, markDynamicUsage, getHeadersContext, setHeadersAccessPhase } from "next/headers";
 import { mergeMetadata, resolveModuleMetadata, mergeViewport, resolveModuleViewport } from "vinext/metadata";
 
 
@@ -3553,6 +3554,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       __clearRequestContext();
     },
     consumeDynamicUsage,
+    consumeInvalidDynamicUsageError,
     createRscOnErrorHandler(pathname, routePath) {
       return createRscOnErrorHandler(request, pathname, routePath);
     },
@@ -3736,7 +3738,7 @@ function renderToReadableStream(model, options) {
 }
 import { createElement } from "react";
 import { setNavigationContext as _setNavigationContextOrig, getNavigationContext as _getNavigationContext } from "next/navigation";
-import { setHeadersContext, headersContextFromRequest, getDraftModeCookieHeader, getAndClearPendingCookies, consumeDynamicUsage, markDynamicUsage, getHeadersContext, setHeadersAccessPhase } from "next/headers";
+import { setHeadersContext, headersContextFromRequest, getDraftModeCookieHeader, getAndClearPendingCookies, consumeDynamicUsage, consumeInvalidDynamicUsageError, markDynamicUsage, getHeadersContext, setHeadersAccessPhase } from "next/headers";
 import { mergeMetadata, resolveModuleMetadata, mergeViewport, resolveModuleViewport } from "vinext/metadata";
 
 
@@ -5408,6 +5410,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       __clearRequestContext();
     },
     consumeDynamicUsage,
+    consumeInvalidDynamicUsageError,
     createRscOnErrorHandler(pathname, routePath) {
       return createRscOnErrorHandler(request, pathname, routePath);
     },
@@ -5591,7 +5594,7 @@ function renderToReadableStream(model, options) {
 }
 import { createElement } from "react";
 import { setNavigationContext as _setNavigationContextOrig, getNavigationContext as _getNavigationContext } from "next/navigation";
-import { setHeadersContext, headersContextFromRequest, getDraftModeCookieHeader, getAndClearPendingCookies, consumeDynamicUsage, markDynamicUsage, getHeadersContext, setHeadersAccessPhase } from "next/headers";
+import { setHeadersContext, headersContextFromRequest, getDraftModeCookieHeader, getAndClearPendingCookies, consumeDynamicUsage, consumeInvalidDynamicUsageError, markDynamicUsage, getHeadersContext, setHeadersAccessPhase } from "next/headers";
 import { mergeMetadata, resolveModuleMetadata, mergeViewport, resolveModuleViewport } from "vinext/metadata";
 
 import * as _instrumentation from "/tmp/test/instrumentation.ts";
@@ -7295,6 +7298,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       __clearRequestContext();
     },
     consumeDynamicUsage,
+    consumeInvalidDynamicUsageError,
     createRscOnErrorHandler(pathname, routePath) {
       return createRscOnErrorHandler(request, pathname, routePath);
     },
@@ -7478,7 +7482,7 @@ function renderToReadableStream(model, options) {
 }
 import { createElement } from "react";
 import { setNavigationContext as _setNavigationContextOrig, getNavigationContext as _getNavigationContext } from "next/navigation";
-import { setHeadersContext, headersContextFromRequest, getDraftModeCookieHeader, getAndClearPendingCookies, consumeDynamicUsage, markDynamicUsage, getHeadersContext, setHeadersAccessPhase } from "next/headers";
+import { setHeadersContext, headersContextFromRequest, getDraftModeCookieHeader, getAndClearPendingCookies, consumeDynamicUsage, consumeInvalidDynamicUsageError, markDynamicUsage, getHeadersContext, setHeadersAccessPhase } from "next/headers";
 import { mergeMetadata, resolveModuleMetadata, mergeViewport, resolveModuleViewport } from "vinext/metadata";
 
 
@@ -9156,6 +9160,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       __clearRequestContext();
     },
     consumeDynamicUsage,
+    consumeInvalidDynamicUsageError,
     createRscOnErrorHandler(pathname, routePath) {
       return createRscOnErrorHandler(request, pathname, routePath);
     },
@@ -9339,7 +9344,7 @@ function renderToReadableStream(model, options) {
 }
 import { createElement } from "react";
 import { setNavigationContext as _setNavigationContextOrig, getNavigationContext as _getNavigationContext } from "next/navigation";
-import { setHeadersContext, headersContextFromRequest, getDraftModeCookieHeader, getAndClearPendingCookies, consumeDynamicUsage, markDynamicUsage, getHeadersContext, setHeadersAccessPhase } from "next/headers";
+import { setHeadersContext, headersContextFromRequest, getDraftModeCookieHeader, getAndClearPendingCookies, consumeDynamicUsage, consumeInvalidDynamicUsageError, markDynamicUsage, getHeadersContext, setHeadersAccessPhase } from "next/headers";
 import { mergeMetadata, resolveModuleMetadata, mergeViewport, resolveModuleViewport } from "vinext/metadata";
 import * as middlewareModule from "/tmp/test/middleware.ts";
 
@@ -11025,6 +11030,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       __clearRequestContext();
     },
     consumeDynamicUsage,
+    consumeInvalidDynamicUsageError,
     createRscOnErrorHandler(pathname, routePath) {
       return createRscOnErrorHandler(request, pathname, routePath);
     },

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -12381,6 +12381,69 @@ describe("cache scope guards for dynamic APIs", () => {
 
     setCacheHandler(new MemoryCacheHandler());
   });
+
+  // Ported from Next.js: workStore.invalidDynamicUsageError in
+  // packages/next/src/server/app-render/app-render.tsx
+  // https://github.com/vercel/next.js/commit/f5e54c06726b571a042fce67417e40a29f6b8689
+  it("records invalid dynamic usage error on request context (survives try/catch)", async () => {
+    const { cacheContextStorage } = await import("../packages/vinext/src/shims/cache-runtime.js");
+    const { setHeadersContext, throwIfInsideCacheScope, consumeInvalidDynamicUsageError } =
+      await import("../packages/vinext/src/shims/headers.js");
+    const { createRequestContext, runWithRequestContext } =
+      await import("../packages/vinext/src/shims/unified-request-context.js");
+
+    setHeadersContext({ headers: new Headers(), cookies: new Map() });
+
+    const ctx = createRequestContext({
+      headersContext: { headers: new Headers(), cookies: new Map() },
+    });
+    let recordedError: unknown = null;
+
+    await runWithRequestContext(ctx, async () => {
+      try {
+        await cacheContextStorage.run(
+          { tags: [], lifeConfigs: [], variant: "default" },
+          async () => {
+            throwIfInsideCacheScope("cookies()");
+          },
+        );
+      } catch {
+        // User try/catch — the error should still be recorded on the context
+      }
+      recordedError = consumeInvalidDynamicUsageError();
+    });
+
+    expect(recordedError).toBeInstanceOf(Error);
+    expect((recordedError as Error).message).toContain('cannot be called inside "use cache"');
+
+    // After consumption, the error is cleared
+    expect(consumeInvalidDynamicUsageError()).toBeNull();
+
+    setHeadersContext(null);
+  });
+
+  it("consumeInvalidDynamicUsageError returns null when no error was recorded", async () => {
+    const { consumeInvalidDynamicUsageError } =
+      await import("../packages/vinext/src/shims/headers.js");
+    const { createRequestContext, runWithRequestContext } =
+      await import("../packages/vinext/src/shims/unified-request-context.js");
+
+    const ctx = createRequestContext();
+    let result: unknown;
+
+    await runWithRequestContext(ctx, async () => {
+      result = consumeInvalidDynamicUsageError();
+    });
+
+    expect(result!).toBeNull();
+  });
+
+  it("consumeInvalidDynamicUsageError works outside unified request scope", async () => {
+    const { consumeInvalidDynamicUsageError } =
+      await import("../packages/vinext/src/shims/headers.js");
+    // Should return null without throwing when no unified scope is active
+    expect(consumeInvalidDynamicUsageError()).toBeNull();
+  });
 });
 
 describe("shim alias map .js variants", () => {


### PR DESCRIPTION
Fixes #958

## Summary

- Records errors from `throwIfInsideCacheScope()` on the per-request context so they survive user-code `try`/`catch` and can surface on client-side navigations
- In dev mode, wraps the RSC response body to check for recorded errors after stream consumption and logs them to `console.error`
- Adds `consumeInvalidDynamicUsageError()` to `next/headers` for consuming the recorded error
- Updates `_throwIfInsideCacheScope` in `server.ts` (used by `after()`) with the same recording behavior

Ported from Next.js: vercel/next.js@f5e54c0 (#93184)

## Test plan

- Added 3 unit tests to `tests/shims.test.ts`:
  - Error recording survives user try/catch
  - `consumeInvalidDynamicUsageError` returns null when no error recorded
  - `consumeInvalidDynamicUsageError` works outside unified request scope
- All existing tests pass (shims, app-router, entry-templates, features, unified-request-context, app-page-render)