### PR TITLE
fix: accept experimental.swcEnvOptions config without erroring

### DIFF
--- a/packages/vinext/src/check.ts
+++ b/packages/vinext/src/check.ts
@@ -173,6 +173,10 @@ const CONFIG_SUPPORT: Record<string, { status: Status; detail?: string }> = {
     detail:
       "config recognized; vinext uses unified RSC navigation payloads so per-segment prefetch inlining is a no-op",
   },
+  "experimental.swcEnvOptions": {
+    status: "unsupported",
+    detail: "polyfill injection via SWC not applicable; vinext uses Vite for transforms",
+  },
   "i18n.domains": {
     status: "partial",
     detail: "supported for Pages Router; App Router unchanged",

--- a/packages/vinext/src/check.ts
+++ b/packages/vinext/src/check.ts
@@ -175,7 +175,8 @@ const CONFIG_SUPPORT: Record<string, { status: Status; detail?: string }> = {
   },
   "experimental.swcEnvOptions": {
     status: "unsupported",
-    detail: "polyfill injection via SWC not applicable; vinext uses Vite for transforms",
+    detail:
+      "not applicable; vinext uses Vite instead of SWC. A Vite-compatible polyfill solution may be explored in the future.",
   },
   "i18n.domains": {
     status: "partial",

--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -601,8 +601,8 @@ export async function resolveNextConfig(
   // transforms, not SWC, so automatic polyfill injection is not applicable.
   if (experimental?.swcEnvOptions !== undefined) {
     console.warn(
-      '[vinext] next.config option "experimental.swcEnvOptions" is not yet supported and will be ignored. ' +
-        "vinext uses Vite for transforms, not SWC, so automatic polyfill injection via core-js is not applicable.",
+      '[vinext] next.config option "experimental.swcEnvOptions" is not applicable and will be ignored (vinext uses Vite, not SWC). ' +
+        "A Vite-compatible polyfill solution may be explored in the future.",
     );
   }
 

--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -597,6 +597,15 @@ export async function resolveNextConfig(
       ? (legacyServerComponentsExternal as string[])
       : [];
 
+  // Warn about unsupported experimental.swcEnvOptions. vinext uses Vite for
+  // transforms, not SWC, so automatic polyfill injection is not applicable.
+  if (experimental?.swcEnvOptions !== undefined) {
+    console.warn(
+      '[vinext] next.config option "experimental.swcEnvOptions" is not yet supported and will be ignored. ' +
+        "vinext uses Vite for transforms, not SWC, so automatic polyfill injection via core-js is not applicable.",
+    );
+  }
+
   // Warn about unsupported webpack usage. We preserve alias injection and
   // extract MDX settings, but all other webpack customization is still ignored.
   if (config.webpack !== undefined) {

--- a/tests/check.test.ts
+++ b/tests/check.test.ts
@@ -363,6 +363,25 @@ describe("analyzeConfig", () => {
     expect(items.find((i) => i.name === "experimental.prefetchInlining")?.status).toBe("partial");
   });
 
+  it("detects experimental.swcEnvOptions as unsupported", () => {
+    writeFile(
+      "next.config.mjs",
+      `export default {
+        experimental: {
+          swcEnvOptions: {
+            mode: "usage",
+            coreJs: "3",
+          },
+        },
+      };`,
+    );
+
+    const items = analyzeConfig(tmpDir);
+    const item = items.find((i) => i.name === "experimental.swcEnvOptions");
+    expect(item?.status).toBe("unsupported");
+    expect(item?.detail).toContain("polyfill injection");
+  });
+
   it("detects allowedDevOrigins as supported", () => {
     writeFile(
       "next.config.mjs",
@@ -397,6 +416,7 @@ describe("analyzeConfig", () => {
     ["experimental.typedRoutes", "experimental", "typedRoutes: true"],
     ["experimental.serverActions", "experimental", "serverActions: { allowedOrigins: [] }"],
     ["experimental.prefetchInlining", "experimental", "prefetchInlining: true"],
+    ["experimental.swcEnvOptions", "experimental", 'swcEnvOptions: { mode: "usage" }'],
     ["i18n.domains", "i18n", "domains: []"],
   ])("detects %s via generic dot-notation handling", (name, parent, body) => {
     writeFile("next.config.mjs", `export default { ${parent}: { ${body} } };`);

--- a/tests/check.test.ts
+++ b/tests/check.test.ts
@@ -379,7 +379,7 @@ describe("analyzeConfig", () => {
     const items = analyzeConfig(tmpDir);
     const item = items.find((i) => i.name === "experimental.swcEnvOptions");
     expect(item?.status).toBe("unsupported");
-    expect(item?.detail).toContain("polyfill injection");
+    expect(item?.detail).toContain("not applicable");
   });
 
   it("detects allowedDevOrigins as supported", () => {

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -753,6 +753,42 @@ describe("resolveNextConfig external rewrite warning", () => {
   });
 });
 
+describe("resolveNextConfig swcEnvOptions warning", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("emits a warning when experimental.swcEnvOptions is set", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await resolveNextConfig({
+      experimental: { swcEnvOptions: { mode: "usage" } },
+    });
+
+    const swcWarning = warn.mock.calls.find(
+      (call) => typeof call[0] === "string" && call[0].includes("swcEnvOptions"),
+    );
+
+    expect(swcWarning).toBeDefined();
+    expect(swcWarning![0]).toContain("swcEnvOptions");
+    expect(swcWarning![0]).toContain("not applicable");
+    expect(swcWarning![0]).toContain("vinext uses Vite");
+  });
+
+  it("does not warn when experimental.swcEnvOptions is not set", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await resolveNextConfig({
+      experimental: {},
+    });
+
+    const swcWarning = warn.mock.calls.find(
+      (call) => typeof call[0] === "string" && call[0].includes("swcEnvOptions"),
+    );
+    expect(swcWarning).toBeUndefined();
+  });
+});
+
 describe("resolveNextConfig cacheHandler", () => {
   it("resolves file:// URLs to filesystem paths", async () => {
     const resolved = await resolveNextConfig({


### PR DESCRIPTION
Fixes #774

## Summary
- Accept `experimental.swcEnvOptions` in config without erroring (vinext uses Vite for transforms, not SWC)
- Add `CONFIG_SUPPORT` entry in `check.ts` (unsupported with detail message)
- Emit console.warn when `experimental.swcEnvOptions` is present during config resolution
- Add tests for `analyzeConfig` detection and dot-notation matching

## Test plan
- Added `experimental.swcEnvOptions` to `CONFIG_SUPPORT` in `check.ts`
- Added explicit test for unsupported status detection
- Added entry to `it.each` dot-notation test table
- All 162 tests pass (`tests/check.test.ts`, `tests/next-config.test.ts`)