### PR TITLE
fix: unstable_io() returns hanging promise during prerendering

### DIFF
--- a/knip.ts
+++ b/knip.ts
@@ -55,6 +55,15 @@ export default {
         "src/shims/internal/api-utils.ts",
         "src/shims/internal/app-router-context.ts",
         "src/shims/internal/utils.ts",
+        // Typed WorkUnitStore exports consumed by cache.ts via AsyncLocalStorage
+        // generic — knip cannot trace type-only dependencies through ALS.
+        "src/shims/internal/work-unit-async-storage.ts",
+        // Imported via template string in app-rsc-entry.ts (generated code),
+        // so knip cannot trace the import statically.
+        "src/server/prerender-work-unit-setup.ts",
+        // makeHangingPromise is imported by cache.ts, but knip sometimes loses
+        // the trace through barrel-free internal modules.
+        "src/shims/internal/make-hanging-promise.ts",
       ],
       project: ["src/**/*.{ts,tsx}"],
     },

--- a/knip.ts
+++ b/knip.ts
@@ -61,9 +61,6 @@ export default {
         // Imported via template string in app-rsc-entry.ts (generated code),
         // so knip cannot trace the import statically.
         "src/server/prerender-work-unit-setup.ts",
-        // makeHangingPromise is imported by cache.ts, but knip sometimes loses
-        // the trace through barrel-free internal modules.
-        "src/shims/internal/make-hanging-promise.ts",
       ],
       project: ["src/**/*.{ts,tsx}"],
     },

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -76,6 +76,10 @@ const appPrerenderEndpointsPath = resolveEntryPath(
 const rscStreamHintsPath = resolveEntryPath("../server/rsc-stream-hints.js", import.meta.url);
 const metadataRoutesPath = resolveEntryPath("../server/metadata-routes.js", import.meta.url);
 const rootParamsShimPath = resolveEntryPath("../shims/root-params.js", import.meta.url);
+const prerenderWorkUnitSetupPath = resolveEntryPath(
+  "../server/prerender-work-unit-setup.js",
+  import.meta.url,
+);
 const errorCausePath = resolveEntryPath("../utils/error-cause.js", import.meta.url);
 
 /**
@@ -266,6 +270,7 @@ import "vinext/navigation-state";
 import { runWithRequestContext as _runWithUnifiedCtx, createRequestContext as _createUnifiedCtx } from "vinext/unified-request-context";
 import { reportRequestError as _reportRequestError } from "vinext/instrumentation";
 import { flattenErrorCauses as __flattenErrorCauses } from ${JSON.stringify(errorCausePath)};
+import { runWithPrerenderWorkUnit as __runWithPrerenderWorkUnit } from ${JSON.stringify(prerenderWorkUnitSetupPath)};
 import { getSSRFontLinks as _getSSRFontLinks, getSSRFontStyles as _getSSRFontStylesGoogle, getSSRFontPreloads as _getSSRFontPreloadsGoogle } from "next/font/google";
 import { getSSRFontStyles as _getSSRFontStylesLocal, getSSRFontPreloads as _getSSRFontPreloadsLocal } from "next/font/local";
 function _getSSRFontStyles() { return [..._getSSRFontStylesGoogle(), ..._getSSRFontStylesLocal()]; }
@@ -973,7 +978,8 @@ export default async function handler(request, ctx) {
     executionContext: ctx ?? _getRequestExecutionContext() ?? null,
     unstableCacheRevalidation: "background",
   });
-  return _runWithUnifiedCtx(__uCtx, async () => {
+  return _runWithUnifiedCtx(__uCtx, () =>
+    __runWithPrerenderWorkUnit(async () => {
     _ensureFetchPatch();
     const __reqCtx = requestContextFromRequest(request);
     // Per-request container for middleware state. Passed into
@@ -1024,7 +1030,8 @@ export default async function handler(request, ctx) {
       }
     }
     return response;
-  });
+    })
+  );
 }
 
 async function _handleRequest(request, __reqCtx, _mwCtx) {

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -41,6 +41,7 @@ const appServerActionExecutionPath = resolveEntryPath(
   "../server/app-server-action-execution.js",
   import.meta.url,
 );
+const appRscErrorsPath = resolveEntryPath("../server/app-rsc-errors.js", import.meta.url);
 const implicitTagsPath = resolveEntryPath("../server/implicit-tags.js", import.meta.url);
 const appPageCachePath = resolveEntryPath("../server/app-page-cache.js", import.meta.url);
 const appPageExecutionPath = resolveEntryPath("../server/app-page-execution.js", import.meta.url);
@@ -73,11 +74,16 @@ const appPrerenderEndpointsPath = resolveEntryPath(
   "../server/app-prerender-endpoints.js",
   import.meta.url,
 );
-const rscStreamHintsPath = resolveEntryPath("../server/rsc-stream-hints.js", import.meta.url);
-const metadataRoutesPath = resolveEntryPath("../server/metadata-routes.js", import.meta.url);
-const rootParamsShimPath = resolveEntryPath("../shims/root-params.js", import.meta.url);
 const prerenderWorkUnitSetupPath = resolveEntryPath(
   "../server/prerender-work-unit-setup.js",
+  import.meta.url,
+);
+const rscStreamHintsPath = resolveEntryPath("../server/rsc-stream-hints.js", import.meta.url);
+const isrCachePath = resolveEntryPath("../server/isr-cache.js", import.meta.url);
+const rootParamsShimPath = resolveEntryPath("../shims/root-params.js", import.meta.url);
+const thenableParamsShimPath = resolveEntryPath("../shims/thenable-params.js", import.meta.url);
+const metadataRouteResponsePath = resolveEntryPath(
+  "../server/metadata-route-response.js",
   import.meta.url,
 );
 const errorCausePath = resolveEntryPath("../utils/error-cause.js", import.meta.url);
@@ -186,16 +192,16 @@ function renderToReadableStream(model, options) {
 }
 import { createElement } from "react";
 import { setNavigationContext as _setNavigationContextOrig, getNavigationContext as _getNavigationContext } from "next/navigation";
-import { setHeadersContext, headersContextFromRequest, getDraftModeCookieHeader, getAndClearPendingCookies, consumeDynamicUsage, markDynamicUsage, getHeadersContext, setHeadersAccessPhase } from "next/headers";
+import { setHeadersContext, headersContextFromRequest, getDraftModeCookieHeader, getAndClearPendingCookies, consumeDynamicUsage, consumeInvalidDynamicUsageError, markDynamicUsage, getHeadersContext, setHeadersAccessPhase } from "next/headers";
 import { mergeMetadata, resolveModuleMetadata, mergeViewport, resolveModuleViewport } from "vinext/metadata";
 ${middlewarePath ? `import * as middlewareModule from ${JSON.stringify(middlewarePath.replace(/\\/g, "/"))};` : ""}
 ${instrumentationPath ? `import * as _instrumentation from ${JSON.stringify(instrumentationPath.replace(/\\/g, "/"))};` : ""}
-${metaRouteEntries.length > 0 ? `import { sitemapToXml, robotsToText, manifestToJson } from ${JSON.stringify(metadataRoutesPath)};` : ""}
-import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, matchHeaders, isExternalUrl, proxyExternalRequest, sanitizeDestination } from ${JSON.stringify(configMatchersPath)};
+import { handleMetadataRouteRequest as __handleMetadataRouteRequest } from ${JSON.stringify(metadataRouteResponsePath)};
+import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, isExternalUrl, proxyExternalRequest, sanitizeDestination } from ${JSON.stringify(configMatchersPath)};
 import { decodePathParams as __decodePathParams, normalizePath as __normalizePath } from ${JSON.stringify(normalizePathModulePath)};
 import { normalizePathnameForRouteMatch as __normalizePathnameForRouteMatch, normalizePathnameForRouteMatchStrict as __normalizePathnameForRouteMatchStrict } from ${JSON.stringify(routingUtilsPath)};
 import { buildRequestHeadersFromMiddlewareResponse as __buildRequestHeadersFromMiddlewareResponse } from ${JSON.stringify(middlewareRequestHeadersPath)};
-import { validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash } from ${JSON.stringify(requestPipelinePath)};
+import { applyConfigHeadersToResponse, resolvePublicFileRoute, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash } from ${JSON.stringify(requestPipelinePath)};
 import { applyAppMiddleware as __applyAppMiddleware } from ${JSON.stringify(appMiddlewarePath)};
 import {
   dispatchAppRouteHandler as __dispatchAppRouteHandler,
@@ -203,7 +209,13 @@ import {
 import {
   handleProgressiveServerActionRequest as __handleProgressiveServerActionRequest,
   handleServerActionRscRequest as __handleServerActionRscRequest,
+  readActionBodyWithLimit as __readBodyWithLimit,
+  readActionFormDataWithLimit as __readFormDataWithLimit,
 } from ${JSON.stringify(appServerActionExecutionPath)};
+import {
+  createRscOnErrorHandler as __createRscOnErrorHandler,
+  sanitizeErrorForClient as __sanitizeErrorForClient,
+} from ${JSON.stringify(appRscErrorsPath)};
 import { readAppPageCacheResponse as __readAppPageCacheResponse } from ${JSON.stringify(appPageCachePath)};
 import {
   buildAppPageFontLinkHeader as __buildAppPageFontLinkHeader,
@@ -233,6 +245,7 @@ import {
 } from ${JSON.stringify(appPageParamsPath)};
 import {
   collectAppPageSearchParams as __collectAppPageSearchParams,
+  resolveActiveParallelRouteHeadInputs as __resolveActiveParallelRouteHeadInputs,
   resolveAppPageHead as __resolveAppPageHead,
 } from ${JSON.stringify(appPageHeadPath)};
 import {
@@ -254,23 +267,32 @@ import {
   createStaticGenerationHeadersContext as __createStaticGenerationHeadersContext,
 } from ${JSON.stringify(appStaticGenerationPath)};
 import { buildPageCacheTags } from ${JSON.stringify(implicitTagsPath)};
-import { _consumeRequestScopedCacheLife, getCacheHandler } from "next/cache";
+import { _consumeRequestScopedCacheLife } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from ${JSON.stringify(requestContextShimPath)};
 import { setRootParams as __setRootParams, pickRootParams as __pickRootParams } from ${JSON.stringify(rootParamsShimPath)};
+import { makeThenableParams } from ${JSON.stringify(thenableParamsShimPath)};
 import { ensureFetchPatch as _ensureFetchPatch, getCollectedFetchTags, setCurrentFetchSoftTags } from "vinext/fetch-cache";
 import {
   createAppRscRouteMatcher as __createAppRscRouteMatcher,
-  matchAppRscRoutePattern as __matchAppRscRoutePattern,
 } from ${JSON.stringify(appRscRouteMatchingPath)};
 import {
   handleAppPrerenderEndpoint as __handleAppPrerenderEndpoint,
 } from ${JSON.stringify(appPrerenderEndpointsPath)};
+import {
+  appIsrHtmlKey as __isrHtmlKey,
+  appIsrRscKey as __isrRscKey,
+  appIsrRouteKey as __isrRouteKey,
+  isrGet as __isrGet,
+  isrSet as __isrSet,
+  normalizeMountedSlotsHeader as __normalizeMountedSlotsHeader,
+  triggerBackgroundRegeneration as __triggerBackgroundRegeneration,
+} from ${JSON.stringify(isrCachePath)};
 // Import server-only state module to register ALS-backed accessors.
 import "vinext/navigation-state";
+import { runWithPrerenderWorkUnit as __runWithPrerenderWorkUnit } from ${JSON.stringify(prerenderWorkUnitSetupPath)};
 import { runWithRequestContext as _runWithUnifiedCtx, createRequestContext as _createUnifiedCtx } from "vinext/unified-request-context";
 import { reportRequestError as _reportRequestError } from "vinext/instrumentation";
 import { flattenErrorCauses as __flattenErrorCauses } from ${JSON.stringify(errorCausePath)};
-import { runWithPrerenderWorkUnit as __runWithPrerenderWorkUnit } from ${JSON.stringify(prerenderWorkUnitSetupPath)};
 import { getSSRFontLinks as _getSSRFontLinks, getSSRFontStyles as _getSSRFontStylesGoogle, getSSRFontPreloads as _getSSRFontPreloadsGoogle } from "next/font/google";
 import { getSSRFontStyles as _getSSRFontStylesLocal, getSSRFontPreloads as _getSSRFontPreloadsLocal } from "next/font/local";
 function _getSSRFontStyles() { return [..._getSSRFontStylesGoogle(), ..._getSSRFontStylesLocal()]; }
@@ -307,25 +329,6 @@ function __clearRequestContext() {
   // setNavigationContext(null) already clears root params internally
 }
 
-// ISR cache is disabled in dev mode — every request re-renders fresh,
-// matching Next.js dev behavior. Cache-Control headers are still emitted
-// based on export const revalidate for testing purposes.
-// Production ISR uses the MemoryCacheHandler (or configured KV handler).
-//
-// These helpers are inlined instead of imported from isr-cache.js because
-// the virtual RSC entry module runs in the RSC Vite environment which
-// cannot use dynamic imports at the module-evaluation level for server-only
-// modules, and direct imports must use the pre-computed absolute paths.
-async function __isrGet(key) {
-  const handler = getCacheHandler();
-  const result = await handler.get(key);
-  if (!result || !result.value) return null;
-  return { value: result, isStale: result.cacheState === "stale" };
-}
-async function __isrSet(key, data, revalidateSeconds, tags) {
-  const handler = getCacheHandler();
-  await handler.set(key, data, { revalidate: revalidateSeconds, tags: Array.isArray(tags) ? tags : [] });
-}
 // Note: cache entries are written with \`headers: undefined\`. Next.js stores
 // response headers (e.g. set-cookie from cookies().set() during render) in the
 // cache entry so they can be replayed on HIT. We don't do this because:
@@ -336,82 +339,6 @@ async function __isrSet(key, data, revalidateSeconds, tags) {
 // In practice this means ISR-cached responses won't replay render-time set-cookie
 // headers — but that case is already prevented by the dynamic-usage opt-out.
 // TODO: capture render-time response headers for full Next.js parity.
-const __pendingRegenerations = new Map();
-function __triggerBackgroundRegeneration(key, renderFn, errorContext) {
-  if (__pendingRegenerations.has(key)) return;
-  const promise = renderFn()
-    .catch((err) => {
-      console.error("[vinext] ISR regen failed for " + key + ":", err);
-      if (errorContext) {
-        void _reportRequestError(
-          err instanceof Error ? err : new Error(String(err)),
-          { path: key, method: "GET", headers: {} },
-          {
-            routerKind: "App Router",
-            routePath: errorContext.routePath,
-            routeType: errorContext.routeType,
-            revalidateReason: "stale",
-          },
-        );
-      }
-    })
-    .finally(() => __pendingRegenerations.delete(key));
-  __pendingRegenerations.set(key, promise);
-  const ctx = _getRequestExecutionContext();
-  if (ctx && typeof ctx.waitUntil === "function") ctx.waitUntil(promise);
-}
-// HTML and RSC are stored under separate keys — matching Next.js's file-system
-// layout (.html / .rsc) — so each request type reads and writes its own key
-// independently with no races or partial-entry sentinels.
-//
-// Key format: "app:<buildId>:<pathname>:<suffix>"
-// Long-pathname fallback: "app:<buildId>:__hash:<fnv1a64(pathname)>:<suffix>"
-// Without buildId (should not happen in production): "app:<pathname>:<suffix>"
-// The 200-char threshold keeps the full key well under Cloudflare KV's 512-byte limit
-// even after adding the build ID and suffix. FNV-1a 64 is used for the hash (two
-// 32-bit rounds) to give a ~64-bit output with negligible collision probability for
-// realistic pathname lengths.
-// Keep prefix construction and hashing logic in sync with isrCacheKey() in server/isr-cache.ts.
-function __isrFnv1a64(s) {
-  // h1 uses the standard FNV-1a 32-bit offset basis (0x811c9dc5).
-  let h1 = 0x811c9dc5;
-  for (let i = 0; i < s.length; i++) { h1 ^= s.charCodeAt(i); h1 = (h1 * 0x01000193) >>> 0; }
-  // h2 uses a different seed (0x050c5d1f — the FNV-1a hash of the string "vinext")
-  // so the two rounds are independently seeded and their outputs are decorrelated.
-  // Concatenating two independently-seeded 32-bit FNV-1a hashes gives an effective
-  // 64-bit hash. A random non-standard seed would also work; we derive it from a
-  // fixed string so the choice is auditable and deterministic across rebuilds.
-  let h2 = 0x050c5d1f;
-  for (let i = 0; i < s.length; i++) { h2 ^= s.charCodeAt(i); h2 = (h2 * 0x01000193) >>> 0; }
-  return h1.toString(36) + h2.toString(36);
-}
-function __isrCacheKey(pathname, suffix) {
-  const normalized = pathname === "/" ? "/" : pathname.replace(/\\/$/, "");
-  // __VINEXT_BUILD_ID is replaced at compile time by Vite's define plugin.
-  const buildId = process.env.__VINEXT_BUILD_ID;
-  const prefix = buildId ? "app:" + buildId : "app";
-  const key = prefix + ":" + normalized + ":" + suffix;
-  if (key.length <= 200) return key;
-  // Pathname too long — hash it to keep under KV's 512-byte key limit.
-  return prefix + ":__hash:" + __isrFnv1a64(normalized) + ":" + suffix;
-}
-function __isrHtmlKey(pathname) { return __isrCacheKey(pathname, "html"); }
-function __isrRscKey(pathname, mountedSlotsHeader) {
-  if (!mountedSlotsHeader) return __isrCacheKey(pathname, "rsc");
-  return __isrCacheKey(pathname, "rsc:" + __isrFnv1a64(mountedSlotsHeader));
-}
-function __normalizeMountedSlotsHeader(raw) {
-  if (!raw) return null;
-  const normalized = Array.from(
-    new Set(
-      raw
-        .split(/\\s+/)
-        .filter(Boolean),
-    ),
-  ).sort().join(" ");
-  return normalized || null;
-}
-function __isrRouteKey(pathname) { return __isrCacheKey(pathname, "route"); }
 // Verbose cache logging — opt in with NEXT_PRIVATE_DEBUG_CACHE=1.
 // Matches the env var Next.js uses for its own cache debug output so operators
 // have a single knob for all cache tracing.
@@ -429,124 +356,6 @@ const __classDebug = process.env.VINEXT_DEBUG_CLASSIFICATION
     }
   : undefined;
 
-// Normalize null-prototype objects from route-pattern matching into thenable objects
-// that work both as Promises (for Next.js 15+ async params) and as plain
-// objects with synchronous property access (for pre-15 code like params.id).
-//
-// route-pattern matching uses Object.create(null), producing objects without
-// Object.prototype. The RSC serializer rejects these. Spreading ({...obj})
-// restores a normal prototype. Object.assign onto the Promise preserves
-// synchronous property access (params.id, params.slug) that existing
-// components and test fixtures rely on.
-function makeThenableParams(obj) {
-  const plain = { ...obj };
-  return Object.assign(Promise.resolve(plain), plain);
-}
-
-// djb2 hash — matches Next.js's stringHash for digest generation.
-// Produces a stable numeric string from error message + stack.
-function __errorDigest(str) {
-  let hash = 5381;
-  for (let i = str.length - 1; i >= 0; i--) {
-    hash = (hash * 33) ^ str.charCodeAt(i);
-  }
-  return (hash >>> 0).toString();
-}
-
-// Sanitize an error for client consumption. In production, replaces the error
-// with a generic Error that only carries a digest hash (matching Next.js
-// behavior). In development, returns the original error for debugging.
-// Navigation errors (redirect, notFound, etc.) are always passed through
-// unchanged since their digests are used for client-side routing.
-function __sanitizeErrorForClient(error) {
-  // Navigation errors must pass through with their digest intact
-  if (__resolveAppPageSpecialError(error)) {
-    return error;
-  }
-  // In development, pass through the original error for debugging
-  if (process.env.NODE_ENV !== "production") {
-    return error;
-  }
-  // In production, create a sanitized error with only a digest hash
-  const msg = error instanceof Error ? error.message : String(error);
-  const stack = error instanceof Error ? (error.stack || "") : "";
-  const sanitized = new Error(
-    "An error occurred in the Server Components render. " +
-    "The specific message is omitted in production builds to avoid leaking sensitive details. " +
-    "A digest property is included on this error instance which may provide additional details about the nature of the error."
-  );
-  sanitized.digest = __errorDigest(msg + stack);
-  return sanitized;
-}
-
-// onError callback for renderToReadableStream — preserves the digest for
-// Next.js navigation errors (redirect, notFound, forbidden, unauthorized)
-// thrown during RSC streaming (e.g. inside Suspense boundaries).
-// For non-navigation errors in production, generates a digest hash so the
-// error can be correlated with server logs without leaking details.
-function rscOnError(error, requestInfo, errorContext) {
-  if (error && typeof error === "object" && "digest" in error) {
-    return String(error.digest);
-  }
-
-  // In dev, detect the "Only plain objects" RSC serialization error and emit
-  // an actionable hint. This error occurs when a Server Component passes a
-  // class instance, ES module namespace object, or null-prototype object as a
-  // prop to a Client Component.
-  //
-  // Root cause: Vite bundles modules as true ESM (module namespace objects
-  // have a null-like internal slot), while Next.js's webpack build produces
-  // plain CJS-wrapped objects with __esModule:true. React's RSC serializer
-  // accepts the latter as plain objects but rejects the former — which means
-  // code that accidentally passes "import * as X" works in webpack/Next.js
-  // but correctly fails in vinext.
-  //
-  // Common triggers:
-  //   - "import * as utils from './utils'" passed as a prop
-  //   - class instances (new Foo()) passed as props
-  //   - Date / Map / Set instances passed as props
-  //   - Objects with Object.create(null) (null prototype)
-  if (
-    process.env.NODE_ENV !== "production" &&
-    error instanceof Error &&
-    error.message.includes("Only plain objects, and a few built-ins, can be passed to Client Components")
-  ) {
-    console.error(
-      "[vinext] RSC serialization error: a non-plain object was passed from a Server Component to a Client Component.\\n" +
-      "\\n" +
-      "Common causes:\\n" +
-      "  * Passing a module namespace (import * as X) directly as a prop.\\n" +
-      "    Unlike Next.js (webpack), Vite produces real ESM module namespace objects\\n" +
-      "    which are not serializable. Fix: pass individual values instead,\\n" +
-      "    e.g. <Comp value={module.value} />\\n" +
-      "  * Passing a class instance (new Foo()) as a prop.\\n" +
-      "    Fix: convert to a plain object, e.g. { id: foo.id, name: foo.name }\\n" +
-      "  * Passing a Date, Map, or Set. Use .toISOString(), [...map.entries()], etc.\\n" +
-      "  * Passing Object.create(null). Use { ...obj } to restore a prototype.\\n" +
-      "\\n" +
-      "Original error:",
-      error.message,
-    );
-    return undefined;
-  }
-
-  if (requestInfo && errorContext && error) {
-    _reportRequestError(
-      error instanceof Error ? error : new Error(String(error)),
-      requestInfo,
-      errorContext,
-    );
-  }
-
-  // In production, generate a digest hash for non-navigation errors
-  if (process.env.NODE_ENV === "production" && error) {
-    const msg = error instanceof Error ? error.message : String(error);
-    const stack = error instanceof Error ? (error.stack || "") : "";
-    return __errorDigest(msg + stack);
-  }
-  return undefined;
-}
-
 function createRscOnErrorHandler(request, pathname, routePath) {
   const requestInfo = {
     path: pathname,
@@ -558,9 +367,11 @@ function createRscOnErrorHandler(request, pathname, routePath) {
     routePath: routePath || pathname,
     routeType: "render",
   };
-  return function(error) {
-    return rscOnError(error, requestInfo, errorContext);
-  };
+  return __createRscOnErrorHandler({
+    errorContext,
+    reportRequestError: _reportRequestError,
+    requestInfo,
+  });
 }
 
 ${imports.join("\n")}
@@ -664,6 +475,7 @@ async function renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, req
     makeThenableParams,
     matchedParams: opts?.matchedParams ?? route?.params ?? {},
     middlewareContext: middlewareContext ?? __APP_PAGE_EMPTY_MW_CTX,
+    metadataRoutes,
     requestUrl: request.url,
     resolveChildSegments: __resolveAppPageChildSegments,
     rootForbiddenModule: rootForbiddenModule,
@@ -711,6 +523,7 @@ async function renderErrorBoundaryPage(route, error, isRscRequest, request, matc
     makeThenableParams,
     matchedParams: matchedParams ?? route?.params ?? {},
     middlewareContext: middlewareContext ?? __APP_PAGE_EMPTY_MW_CTX,
+    metadataRoutes,
     requestUrl: request.url,
     resolveChildSegments: __resolveAppPageChildSegments,
     rootLayouts: rootLayouts,
@@ -723,21 +536,6 @@ async function renderErrorBoundaryPage(route, error, isRscRequest, request, matc
 
 function matchRoute(url) {
   return __routeMatcher.matchRoute(url);
-}
-
-function __createStaticFileSignal(pathname, _mwCtx) {
-  const headers = new Headers({
-    "x-vinext-static-file": encodeURIComponent(pathname),
-  });
-  if (_mwCtx.headers) {
-    for (const [key, value] of _mwCtx.headers) {
-      headers.append(key, value);
-    }
-  }
-  return new Response(null, {
-    status: _mwCtx.status ?? 200,
-    headers,
-  });
 }
 
 /**
@@ -776,18 +574,30 @@ async function buildPageElements(route, params, routePath, pageRequest) {
     };
   }
 
-  const __headResult = await __resolveAppPageHead({
+  const {
+    hasSearchParams,
+    metadata: resolvedMetadata,
+    pageSearchParams,
+    viewport: resolvedViewport,
+  } = await __resolveAppPageHead({
     layoutModules: route.layouts,
     layoutTreePositions: route.layoutTreePositions,
+    metadataRoutes,
     pageModule: route.page,
+    parallelRoutes: __resolveActiveParallelRouteHeadInputs({
+      interceptLayouts: opts?.interceptLayouts ?? null,
+      interceptPage: opts?.interceptPage ?? null,
+      interceptParams: opts?.interceptParams ?? null,
+      interceptSlotKey: opts?.interceptSlotKey ?? null,
+      params,
+      routeSegments: route.routeSegments,
+      slots: route.slots,
+    }),
     params,
+    routePath: route.pattern,
     routeSegments: route.routeSegments,
     searchParams,
   });
-  const spObj = __headResult.searchParamsObject;
-  const hasSearchParams = __headResult.hasSearchParams;
-  const resolvedMetadata = __headResult.metadata;
-  const resolvedViewport = __headResult.viewport;
 
   // Build the route tree from the leaf page, then delegate the boundary/layout/
   // template/segment wiring to a typed runtime helper so the generated entry
@@ -797,7 +607,7 @@ async function buildPageElements(route, params, routePath, pageRequest) {
     // Always provide searchParams prop when the URL object is available, even
     // when the query string is empty -- pages that do "await searchParams" need
     // it to be a thenable rather than undefined.
-    pageProps.searchParams = makeThenableParams(spObj);
+    pageProps.searchParams = makeThenableParams(pageSearchParams);
     // If the URL has query parameters, mark the page as dynamic.
     // In Next.js, only accessing the searchParams prop signals dynamic usage,
     // but a Proxy-based approach doesn't work here because React's RSC debug
@@ -828,6 +638,8 @@ async function buildPageElements(route, params, routePath, pageRequest) {
     interceptionContext: opts?.interceptionContext ?? null,
     routePath,
     rootNotFoundModule: ${rootNotFoundVar ? rootNotFoundVar : "null"},
+    rootForbiddenModule: ${rootForbiddenVar ? rootForbiddenVar : "null"},
+    rootUnauthorizedModule: ${rootUnauthorizedVar ? rootUnauthorizedVar : "null"},
     route,
     slotOverrides:
       opts && opts.interceptSlotKey && opts.interceptPage
@@ -891,63 +703,6 @@ function __buildPostMwRequestContext(request) {
  */
 var __MAX_ACTION_BODY_SIZE = ${JSON.stringify(bodySizeLimit)};
 
-/**
- * Read a request body as text with a size limit.
- * Enforces the limit on the actual byte stream to prevent bypasses
- * via chunked transfer-encoding where Content-Length is absent or spoofed.
- */
-async function __readBodyWithLimit(request, maxBytes) {
-  if (!request.body) return "";
-  var reader = request.body.getReader();
-  var decoder = new TextDecoder();
-  var chunks = [];
-  var totalSize = 0;
-  for (;;) {
-    var result = await reader.read();
-    if (result.done) break;
-    totalSize += result.value.byteLength;
-    if (totalSize > maxBytes) {
-      reader.cancel();
-      throw new Error("Request body too large");
-    }
-    chunks.push(decoder.decode(result.value, { stream: true }));
-  }
-  chunks.push(decoder.decode());
-  return chunks.join("");
-}
-
-/**
- * Read a request body as FormData with a size limit.
- * Consumes the body stream with a byte counter and then parses the
- * collected bytes as multipart form data via the Response constructor.
- */
-async function __readFormDataWithLimit(request, maxBytes) {
-  if (!request.body) return new FormData();
-  var reader = request.body.getReader();
-  var chunks = [];
-  var totalSize = 0;
-  for (;;) {
-    var result = await reader.read();
-    if (result.done) break;
-    totalSize += result.value.byteLength;
-    if (totalSize > maxBytes) {
-      reader.cancel();
-      throw new Error("Request body too large");
-    }
-    chunks.push(result.value);
-  }
-  // Reconstruct a Response with the original Content-Type so that
-  // the FormData parser can handle multipart boundaries correctly.
-  var combined = new Uint8Array(totalSize);
-  var offset = 0;
-  for (var chunk of chunks) {
-    combined.set(chunk, offset);
-    offset += chunk.byteLength;
-  }
-  var contentType = request.headers.get("content-type") || "";
-  return new Response(combined, { headers: { "Content-Type": contentType } }).formData();
-}
-
 // Map from route pattern to generateStaticParams function.
 // Used by the prerender phase to enumerate dynamic route URLs without
 // loading route modules via the dev server.
@@ -959,6 +714,12 @@ export const generateStaticParamsMap = {
 // scanning layout.tsx files separately and including them in this map.
 ${generateStaticParamsEntries.join("\n")}
 };${loadPrerenderPagesRoutesCode}
+const rootParamNamesMap = {
+${routes
+  .filter((r) => r.isDynamic && r.pagePath && r.rootParamNames && r.rootParamNames.length > 0)
+  .map((r) => `  ${JSON.stringify(r.pattern)}: ${JSON.stringify(r.rootParamNames)},`)
+  .join("\n")}
+};
 
 export default async function handler(request, ctx) {
   ${
@@ -1012,21 +773,11 @@ export default async function handler(request, ctx) {
         let pathname;
         try { pathname = __normalizePath(__normalizePathnameForRouteMatch(url.pathname)); } catch { pathname = url.pathname; }
         ${bp ? `if (pathname.startsWith(${JSON.stringify(bp)})) pathname = pathname.slice(${JSON.stringify(bp)}.length) || "/";` : ""}
-        const extraHeaders = matchHeaders(pathname, __configHeaders, __reqCtx);
-        for (const h of extraHeaders) {
-          // Use append() for headers where multiple values must coexist
-          // (Vary, Set-Cookie). Using set() on these would destroy
-          // existing values like "Vary: RSC, Accept" which are critical
-          // for correct CDN caching behavior.
-          const lk = h.key.toLowerCase();
-          if (lk === "vary" || lk === "set-cookie") {
-            response.headers.append(h.key, h.value);
-          } else if (!response.headers.has(lk)) {
-            // Middleware headers take precedence: skip config keys already
-            // set by middleware so middleware headers always win.
-            response.headers.set(h.key, h.value);
-          }
-        }
+        applyConfigHeadersToResponse(response.headers, {
+          configHeaders: __configHeaders,
+          pathname,
+          requestContext: __reqCtx,
+        });
       }
     }
     return response;
@@ -1080,6 +831,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     },
 ${prerenderPagesLoaderOption}
     pathname,
+    rootParamNamesByPattern: rootParamNamesMap,
     staticParamsMap: generateStaticParamsMap,
   });
   if (__prerenderEndpointResponse) return __prerenderEndpointResponse;
@@ -1176,90 +928,25 @@ ${prerenderPagesLoaderOption}
     return Response.redirect(new URL(__imgResult, url.origin).href, 302);
   }
 
-  // Handle metadata routes (sitemap.xml, robots.txt, manifest.webmanifest, etc.)
-  for (const metaRoute of metadataRoutes) {
-    // generateSitemaps() support — paginated sitemaps at /{prefix}/sitemap/{id}.xml
-    // When a sitemap module exports generateSitemaps, the base URL (e.g. /products/sitemap.xml)
-    // is no longer served. Instead, individual sitemaps are served at /products/sitemap/{id}.xml.
-    if (
-      metaRoute.type === "sitemap" &&
-      metaRoute.isDynamic &&
-      typeof metaRoute.module.generateSitemaps === "function"
-    ) {
-      const sitemapPrefix = metaRoute.servedUrl.slice(0, -4); // strip ".xml"
-      // Match exactly /{prefix}/{id}.xml — one segment only (no slashes in id)
-      if (cleanPathname.startsWith(sitemapPrefix + "/") && cleanPathname.endsWith(".xml")) {
-        const rawId = cleanPathname.slice(sitemapPrefix.length + 1, -4);
-        if (rawId.includes("/")) continue; // multi-segment — not a paginated sitemap
-        const sitemaps = await metaRoute.module.generateSitemaps();
-        const matched = sitemaps.find(function(s) { return String(s.id) === rawId; });
-        if (!matched) return new Response("Not Found", { status: 404 });
-        // Pass the original typed id from generateSitemaps() so numeric IDs stay numeric.
-        // TODO: wrap with makeThenableParams-style Promise when upgrading to Next.js 16
-        // full-Promise param semantics (id becomes Promise<string> in v16).
-        const result = await metaRoute.module.default({ id: matched.id });
-        if (result instanceof Response) return result;
-        return new Response(sitemapToXml(result), {
-          headers: { "Content-Type": metaRoute.contentType },
-        });
-      }
-      // Skip — the base servedUrl is not served when generateSitemaps exists
-      continue;
-    }
-    // Match metadata route — use pattern matching for dynamic segments,
-    // strict equality for static paths.
-    var _metaParams = null;
-    if (metaRoute.patternParts) {
-      var _metaUrlParts = cleanPathname.split("/").filter(Boolean);
-      _metaParams = __matchAppRscRoutePattern(_metaUrlParts, metaRoute.patternParts);
-      if (!_metaParams) continue;
-    } else if (cleanPathname !== metaRoute.servedUrl) {
-      continue;
-    }
-    if (metaRoute.isDynamic) {
-      // Dynamic metadata route — call the default export and serialize
-      const metaFn = metaRoute.module.default;
-      if (typeof metaFn === "function") {
-        const result = await metaFn({ params: makeThenableParams(_metaParams || {}) });
-        let body;
-        // If it's already a Response (e.g., ImageResponse), return directly
-        if (result instanceof Response) return result;
-        // Serialize based on type
-        if (metaRoute.type === "sitemap") body = sitemapToXml(result);
-        else if (metaRoute.type === "robots") body = robotsToText(result);
-        else if (metaRoute.type === "manifest") body = manifestToJson(result);
-        else body = JSON.stringify(result);
-        return new Response(body, {
-          headers: { "Content-Type": metaRoute.contentType },
-        });
-      }
-    } else {
-      // Static metadata file — decode from embedded base64 data
-      try {
-        const binary = atob(metaRoute.fileDataBase64);
-        const bytes = new Uint8Array(binary.length);
-        for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
-        return new Response(bytes, {
-          headers: {
-            "Content-Type": metaRoute.contentType,
-            "Cache-Control": "public, max-age=0, must-revalidate",
-          },
-        });
-      } catch {
-        return new Response("Not Found", { status: 404 });
-      }
-    }
-  }
+  const metadataRouteResponse = await __handleMetadataRouteRequest({
+    metadataRoutes,
+    cleanPathname,
+    makeThenableParams,
+  });
+  if (metadataRouteResponse) return metadataRouteResponse;
 
   // Serve public/ files as filesystem routes after middleware and before
   // afterFiles/fallback rewrites, matching Next.js routing semantics.
-  if (
-    (request.method === "GET" || request.method === "HEAD") &&
-    !pathname.endsWith(".rsc") &&
-    __publicFiles.has(cleanPathname)
-  ) {
+  const __publicFileResponse = resolvePublicFileRoute({
+    cleanPathname,
+    middlewareContext: _mwCtx,
+    pathname,
+    publicFiles: __publicFiles,
+    request,
+  });
+  if (__publicFileResponse) {
     __clearRequestContext();
-    return __createStaticFileSignal(cleanPathname, _mwCtx);
+    return __publicFileResponse;
   }
 
   // Set navigation context for Server Components.
@@ -1642,7 +1329,11 @@ ${prerenderPagesLoaderOption}
         });
       },
       scheduleBackgroundRegeneration(key, renderFn) {
-        __triggerBackgroundRegeneration(key, renderFn, { routePath: route.pattern, routeType: "render" });
+        __triggerBackgroundRegeneration(key, renderFn, {
+          routerKind: "App Router",
+          routePath: route.pattern,
+          routeType: "render",
+        });
       },
     });
     if (__cachedPageResponse) {
@@ -1794,6 +1485,7 @@ ${prerenderPagesLoaderOption}
       __clearRequestContext();
     },
     consumeDynamicUsage,
+    consumeInvalidDynamicUsageError,
     createRscOnErrorHandler(pathname, routePath) {
       return createRscOnErrorHandler(request, pathname, routePath);
     },

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -978,6 +978,8 @@ export default async function handler(request, ctx) {
     executionContext: ctx ?? _getRequestExecutionContext() ?? null,
     unstableCacheRevalidation: "background",
   });
+  // Extract pathname for prerender work unit store (used by unstable_io() for error messages)
+  const __pathname = new URL(request.url).pathname;
   return _runWithUnifiedCtx(__uCtx, () =>
     __runWithPrerenderWorkUnit(async () => {
     _ensureFetchPatch();
@@ -1949,7 +1951,7 @@ ${prerenderPagesLoaderOption}
       _getRequestExecutionContext()?.waitUntil(__cachePromise);
     },
   });
-}
+}, { route: __pathname })
 
 if (import.meta.hot) {
   import.meta.hot.accept();

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -1032,7 +1032,7 @@ export default async function handler(request, ctx) {
       }
     }
     return response;
-    })
+    }, { route: __pathname })
   );
 }
 
@@ -1951,7 +1951,7 @@ ${prerenderPagesLoaderOption}
       _getRequestExecutionContext()?.waitUntil(__cachePromise);
     },
   });
-}, { route: __pathname })
+}
 
 if (import.meta.hot) {
   import.meta.hot.accept();

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -978,8 +978,6 @@ export default async function handler(request, ctx) {
     executionContext: ctx ?? _getRequestExecutionContext() ?? null,
     unstableCacheRevalidation: "background",
   });
-  // Extract pathname for prerender work unit store (used by unstable_io() for error messages)
-  const __pathname = new URL(request.url).pathname;
   return _runWithUnifiedCtx(__uCtx, () =>
     __runWithPrerenderWorkUnit(async () => {
     _ensureFetchPatch();
@@ -1032,7 +1030,7 @@ export default async function handler(request, ctx) {
       }
     }
     return response;
-    }, { route: __pathname })
+    }, { route: () => new URL(request.url).pathname })
   );
 }
 

--- a/packages/vinext/src/server/prerender-work-unit-setup.ts
+++ b/packages/vinext/src/server/prerender-work-unit-setup.ts
@@ -6,19 +6,28 @@
  * detect the prerender context and return hanging promises.
  *
  * Used by: app-rsc-entry.ts handler template.
+ *
+ * TODO: If future dynamic APIs need request-scoped stores for normal (non-prerender)
+ * requests, add a `{ type: "request" }` store during normal request handling.
  */
 import { workUnitAsyncStorage } from "../shims/internal/work-unit-async-storage.js";
 
-export function runWithPrerenderWorkUnit<T>(fn: () => Promise<T>): Promise<T> {
+export function runWithPrerenderWorkUnit<T>(
+  fn: () => Promise<T>,
+  options?: { route?: string },
+): Promise<T> {
   if (process.env.VINEXT_PRERENDER === "1") {
     const controller = new AbortController();
-    return workUnitAsyncStorage.run(
-      {
-        type: "prerender",
-        renderSignal: controller.signal,
-      },
-      fn,
-    );
+    return workUnitAsyncStorage
+      .run(
+        {
+          type: "prerender",
+          renderSignal: controller.signal,
+          route: options?.route,
+        },
+        fn,
+      )
+      .finally(() => controller.abort());
   }
   return fn();
 }

--- a/packages/vinext/src/server/prerender-work-unit-setup.ts
+++ b/packages/vinext/src/server/prerender-work-unit-setup.ts
@@ -1,0 +1,24 @@
+/**
+ * Sets up the work unit async storage for prerendering.
+ *
+ * When VINEXT_PRERENDER=1, wraps execution in a workUnitAsyncStorage.run()
+ * with a PrerenderStore so that dynamic APIs (e.g., unstable_io()) can
+ * detect the prerender context and return hanging promises.
+ *
+ * Used by: app-rsc-entry.ts handler template.
+ */
+import { workUnitAsyncStorage } from "../shims/internal/work-unit-async-storage.js";
+
+export function runWithPrerenderWorkUnit<T>(fn: () => Promise<T>): Promise<T> {
+  if (process.env.VINEXT_PRERENDER === "1") {
+    const controller = new AbortController();
+    return workUnitAsyncStorage.run(
+      {
+        type: "prerender",
+        renderSignal: controller.signal,
+      },
+      fn,
+    );
+  }
+  return fn();
+}

--- a/packages/vinext/src/server/prerender-work-unit-setup.ts
+++ b/packages/vinext/src/server/prerender-work-unit-setup.ts
@@ -14,16 +14,17 @@ import { workUnitAsyncStorage } from "../shims/internal/work-unit-async-storage.
 
 export function runWithPrerenderWorkUnit<T>(
   fn: () => Promise<T>,
-  options?: { route?: string },
+  options?: { route?: string | (() => string) },
 ): Promise<T> {
   if (process.env.VINEXT_PRERENDER === "1") {
     const controller = new AbortController();
+    const route = typeof options?.route === "function" ? options.route() : options?.route;
     return workUnitAsyncStorage
       .run(
         {
           type: "prerender",
           renderSignal: controller.signal,
-          route: options?.route,
+          route,
         },
         fn,
       )

--- a/packages/vinext/src/shims/cache.ts
+++ b/packages/vinext/src/shims/cache.ts
@@ -485,7 +485,7 @@ export function unstable_io(): Promise<void> {
         // the prerender is aborted or completed.
         return makeHangingPromise(
           workUnitStore.renderSignal,
-          /* route */ "unknown",
+          /* route */ workUnitStore.route ?? "unknown",
           "`unstable_io()`",
         );
       case "cache":
@@ -496,6 +496,7 @@ export function unstable_io(): Promise<void> {
         return _resolvedIOPromise;
       default:
         workUnitStore satisfies never;
+        return _resolvedIOPromise;
     }
   }
 

--- a/packages/vinext/src/shims/cache.ts
+++ b/packages/vinext/src/shims/cache.ts
@@ -25,6 +25,8 @@ import {
   getRequestContext,
   runWithUnifiedStateMutation,
 } from "./unified-request-context.js";
+import { workUnitAsyncStorage } from "./internal/work-unit-async-storage.js";
+import { makeHangingPromise } from "./internal/make-hanging-promise.js";
 
 // ---------------------------------------------------------------------------
 // Lazy accessor for cache context — avoids circular imports with cache-runtime.
@@ -447,17 +449,57 @@ const _resolvedIOPromise: Promise<void> = Promise.resolve(undefined);
 (_resolvedIOPromise as unknown as Record<string, unknown>).value = undefined;
 
 /**
- * Marks an IO boundary in server components by returning a resolved promise.
+ * Marks an IO boundary in server components by returning a resolved promise
+ * during requests and a hanging promise during prerendering.
  *
  * See: https://github.com/vercel/next.js/pull/92521
  * Guard removed: https://github.com/vercel/next.js/pull/92923
  *
- * In Next.js, `unstable_io()` during prerendering contexts returns a hanging
- * promise to prevent execution past the IO boundary. vinext does support
- * prerendering (static export, --prerender-all, TPR), but the hanging IO
- * boundary behavior is not yet implemented, so this always resolves immediately.
+ * Ported from Next.js: packages/next/src/server/request/io.ts
+ * https://github.com/vercel/next.js/blob/canary/packages/next/src/server/request/io.ts
+ *
+ * Behavior by work unit type:
+ * - request → resolve immediately (no delay needed for dynamic SSR)
+ * - prerender / prerender-client / prerender-runtime → hang (prevent
+ *   execution past IO boundary during static generation)
+ * - cache / private-cache / unstable-cache → resolve immediately
+ *   (caches capture IO results at fill time)
+ * - generate-static-params → resolve immediately (build time, no prerender to stall)
+ * - prerender-legacy → resolve immediately (no cache components)
+ *
+ * When no work unit store is present (e.g. client-side, standalone script),
+ * resolves immediately — matching the browser/client implementation.
  */
 export function unstable_io(): Promise<void> {
+  const workUnitStore = workUnitAsyncStorage.getStore();
+
+  if (workUnitStore) {
+    switch (workUnitStore.type) {
+      case "request":
+        return _resolvedIOPromise;
+      case "prerender":
+      case "prerender-client":
+      case "prerender-runtime":
+        // Prevent execution past the IO boundary during prerendering.
+        // The hanging promise suspends React's render indefinitely until
+        // the prerender is aborted or completed.
+        return makeHangingPromise(
+          workUnitStore.renderSignal,
+          /* route */ "unknown",
+          "`unstable_io()`",
+        );
+      case "cache":
+      case "private-cache":
+      case "unstable-cache":
+      case "generate-static-params":
+      case "prerender-legacy":
+        return _resolvedIOPromise;
+      default:
+        workUnitStore satisfies never;
+    }
+  }
+
+  // No work store — outside rendering context (client, standalone script).
   return _resolvedIOPromise;
 }
 

--- a/packages/vinext/src/shims/internal/make-hanging-promise.ts
+++ b/packages/vinext/src/shims/internal/make-hanging-promise.ts
@@ -32,7 +32,9 @@ export function makeHangingPromise<T>(
   expression: string,
 ): Promise<T> {
   if (signal.aborted) {
-    return Promise.reject(new HangingPromiseRejectionError(route, expression));
+    const rejected = Promise.reject(new HangingPromiseRejectionError(route, expression));
+    rejected.catch(suppressUnhandledRejection);
+    return rejected;
   }
   const hangingPromise = new Promise<T>((_, reject) => {
     const boundRejection = reject.bind(null, new HangingPromiseRejectionError(route, expression));
@@ -48,6 +50,7 @@ export function makeHangingPromise<T>(
           for (let i = 0; i < listeners.length; i++) {
             listeners[i]();
           }
+          listeners.length = 0;
         },
         { once: true },
       );

--- a/packages/vinext/src/shims/internal/make-hanging-promise.ts
+++ b/packages/vinext/src/shims/internal/make-hanging-promise.ts
@@ -1,0 +1,61 @@
+/**
+ * makeHangingPromise — returns a promise that never resolves during prerendering.
+ *
+ * When prerendering, `unstable_io()` must return a hanging promise to prevent
+ * React from executing past the IO boundary. The promise never resolves—it only
+ * rejects if the render signal is aborted (e.g., due to a dynamic error or
+ * cache-fill completion).
+ *
+ * Ported from Next.js: packages/next/src/server/dynamic-rendering-utils.ts
+ * https://github.com/vercel/next.js/blob/canary/packages/next/src/server/dynamic-rendering-utils.ts
+ */
+
+class HangingPromiseRejectionError extends Error {
+  constructor(route: string, expression: string) {
+    super(
+      `Route ${route} used ${expression} during prerendering but the render was aborted. ` +
+        `This is expected when prerendering is cut short (e.g. due to a dynamic access).`,
+    );
+    this.name = "HangingPromiseRejectionError";
+  }
+}
+
+const abortListenersBySignal = new WeakMap<AbortSignal, (() => void)[]>();
+
+function suppressUnhandledRejection(): void {
+  // intentionally empty — suppresses "unhandled rejection" warnings
+}
+
+export function makeHangingPromise<T>(
+  signal: AbortSignal,
+  route: string,
+  expression: string,
+): Promise<T> {
+  if (signal.aborted) {
+    return Promise.reject(new HangingPromiseRejectionError(route, expression));
+  }
+  const hangingPromise = new Promise<T>((_, reject) => {
+    const boundRejection = reject.bind(null, new HangingPromiseRejectionError(route, expression));
+    const currentListeners = abortListenersBySignal.get(signal);
+    if (currentListeners) {
+      currentListeners.push(boundRejection);
+    } else {
+      const listeners = [boundRejection];
+      abortListenersBySignal.set(signal, listeners);
+      signal.addEventListener(
+        "abort",
+        () => {
+          for (let i = 0; i < listeners.length; i++) {
+            listeners[i]();
+          }
+        },
+        { once: true },
+      );
+    }
+  });
+  // Suppress unhandled rejection — the promise is expected to be used with
+  // React's use() which handles rejections. If never awaited, the abort
+  // rejection is a no-op cleanup.
+  hangingPromise.catch(suppressUnhandledRejection);
+  return hangingPromise;
+}

--- a/packages/vinext/src/shims/internal/work-unit-async-storage.ts
+++ b/packages/vinext/src/shims/internal/work-unit-async-storage.ts
@@ -21,6 +21,8 @@ export type PrerenderStore = {
   readonly type: "prerender" | "prerender-client" | "prerender-runtime";
   /** AbortSignal that fires when the prerender is cancelled or completed. */
   readonly renderSignal: AbortSignal;
+  /** Optional route identifier for debugging and error messages. */
+  readonly route?: string;
 };
 
 export type CacheStore = {

--- a/packages/vinext/src/shims/internal/work-unit-async-storage.ts
+++ b/packages/vinext/src/shims/internal/work-unit-async-storage.ts
@@ -2,13 +2,53 @@
  * Shim for next/dist/server/app-render/work-unit-async-storage.external
  * and next/dist/client/components/request-async-storage.external
  *
- * Used by: @sentry/nextjs (runtime resolve for request context injection).
- * Provides a minimal AsyncLocalStorage-like export that Sentry can detect
- * and use without crashing.
+ * Tracks the current rendering context type so that dynamic APIs
+ * (unstable_io, headers, cookies, etc.) can branch on whether they're
+ * inside a request, prerender, cache scope, or other context.
+ *
+ * Used by: @sentry/nextjs (runtime resolve for request context injection),
+ * unstable_io() for hanging-promise behavior during prerendering.
  */
 import { AsyncLocalStorage } from "node:async_hooks";
 
-export const workUnitAsyncStorage = new AsyncLocalStorage<unknown>();
+// ── WorkUnitStore discriminated union ───────────────────────────────────
+
+export type RequestStore = {
+  readonly type: "request";
+};
+
+export type PrerenderStore = {
+  readonly type: "prerender" | "prerender-client" | "prerender-runtime";
+  /** AbortSignal that fires when the prerender is cancelled or completed. */
+  readonly renderSignal: AbortSignal;
+};
+
+export type CacheStore = {
+  readonly type: "cache" | "private-cache" | "unstable-cache";
+};
+
+export type GenerateStaticParamsStore = {
+  readonly type: "generate-static-params";
+};
+
+export type PrerenderLegacyStore = {
+  readonly type: "prerender-legacy";
+};
+
+/**
+ * Discriminated union of all known work unit types.
+ * Matches Next.js's WorkUnitStore: packages/next/src/server/app-render/work-unit-async-storage.external.ts
+ */
+export type WorkUnitStore =
+  | RequestStore
+  | PrerenderStore
+  | CacheStore
+  | GenerateStaticParamsStore
+  | PrerenderLegacyStore;
+
+export type WorkUnitAsyncStorage = AsyncLocalStorage<WorkUnitStore>;
+
+export const workUnitAsyncStorage: WorkUnitAsyncStorage = new AsyncLocalStorage();
 
 // Legacy name (Next 13.x–14.x)
 export const requestAsyncStorage = workUnitAsyncStorage;

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -22,16 +22,16 @@ function renderToReadableStream(model, options) {
 }
 import { createElement } from "react";
 import { setNavigationContext as _setNavigationContextOrig, getNavigationContext as _getNavigationContext } from "next/navigation";
-import { setHeadersContext, headersContextFromRequest, getDraftModeCookieHeader, getAndClearPendingCookies, consumeDynamicUsage, markDynamicUsage, getHeadersContext, setHeadersAccessPhase } from "next/headers";
+import { setHeadersContext, headersContextFromRequest, getDraftModeCookieHeader, getAndClearPendingCookies, consumeDynamicUsage, consumeInvalidDynamicUsageError, markDynamicUsage, getHeadersContext, setHeadersAccessPhase } from "next/headers";
 import { mergeMetadata, resolveModuleMetadata, mergeViewport, resolveModuleViewport } from "vinext/metadata";
 
 
-
-import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, matchHeaders, isExternalUrl, proxyExternalRequest, sanitizeDestination } from "<ROOT>/packages/vinext/src/config/config-matchers.js";
+import { handleMetadataRouteRequest as __handleMetadataRouteRequest } from "<ROOT>/packages/vinext/src/server/metadata-route-response.js";
+import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, isExternalUrl, proxyExternalRequest, sanitizeDestination } from "<ROOT>/packages/vinext/src/config/config-matchers.js";
 import { decodePathParams as __decodePathParams, normalizePath as __normalizePath } from "<ROOT>/packages/vinext/src/server/normalize-path.js";
 import { normalizePathnameForRouteMatch as __normalizePathnameForRouteMatch, normalizePathnameForRouteMatchStrict as __normalizePathnameForRouteMatchStrict } from "<ROOT>/packages/vinext/src/routing/utils.js";
 import { buildRequestHeadersFromMiddlewareResponse as __buildRequestHeadersFromMiddlewareResponse } from "<ROOT>/packages/vinext/src/server/middleware-request-headers.js";
-import { validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
+import { applyConfigHeadersToResponse, resolvePublicFileRoute, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
 import { applyAppMiddleware as __applyAppMiddleware } from "<ROOT>/packages/vinext/src/server/app-middleware.js";
 import {
   dispatchAppRouteHandler as __dispatchAppRouteHandler,
@@ -39,7 +39,13 @@ import {
 import {
   handleProgressiveServerActionRequest as __handleProgressiveServerActionRequest,
   handleServerActionRscRequest as __handleServerActionRscRequest,
+  readActionBodyWithLimit as __readBodyWithLimit,
+  readActionFormDataWithLimit as __readFormDataWithLimit,
 } from "<ROOT>/packages/vinext/src/server/app-server-action-execution.js";
+import {
+  createRscOnErrorHandler as __createRscOnErrorHandler,
+  sanitizeErrorForClient as __sanitizeErrorForClient,
+} from "<ROOT>/packages/vinext/src/server/app-rsc-errors.js";
 import { readAppPageCacheResponse as __readAppPageCacheResponse } from "<ROOT>/packages/vinext/src/server/app-page-cache.js";
 import {
   buildAppPageFontLinkHeader as __buildAppPageFontLinkHeader,
@@ -69,6 +75,7 @@ import {
 } from "<ROOT>/packages/vinext/src/server/app-page-params.js";
 import {
   collectAppPageSearchParams as __collectAppPageSearchParams,
+  resolveActiveParallelRouteHeadInputs as __resolveActiveParallelRouteHeadInputs,
   resolveAppPageHead as __resolveAppPageHead,
 } from "<ROOT>/packages/vinext/src/server/app-page-head.js";
 import {
@@ -90,23 +97,32 @@ import {
   createStaticGenerationHeadersContext as __createStaticGenerationHeadersContext,
 } from "<ROOT>/packages/vinext/src/server/app-static-generation.js";
 import { buildPageCacheTags } from "<ROOT>/packages/vinext/src/server/implicit-tags.js";
-import { _consumeRequestScopedCacheLife, getCacheHandler } from "next/cache";
+import { _consumeRequestScopedCacheLife } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
 import { setRootParams as __setRootParams, pickRootParams as __pickRootParams } from "<ROOT>/packages/vinext/src/shims/root-params.js";
+import { makeThenableParams } from "<ROOT>/packages/vinext/src/shims/thenable-params.js";
 import { ensureFetchPatch as _ensureFetchPatch, getCollectedFetchTags, setCurrentFetchSoftTags } from "vinext/fetch-cache";
 import {
   createAppRscRouteMatcher as __createAppRscRouteMatcher,
-  matchAppRscRoutePattern as __matchAppRscRoutePattern,
 } from "<ROOT>/packages/vinext/src/server/app-rsc-route-matching.js";
 import {
   handleAppPrerenderEndpoint as __handleAppPrerenderEndpoint,
 } from "<ROOT>/packages/vinext/src/server/app-prerender-endpoints.js";
+import {
+  appIsrHtmlKey as __isrHtmlKey,
+  appIsrRscKey as __isrRscKey,
+  appIsrRouteKey as __isrRouteKey,
+  isrGet as __isrGet,
+  isrSet as __isrSet,
+  normalizeMountedSlotsHeader as __normalizeMountedSlotsHeader,
+  triggerBackgroundRegeneration as __triggerBackgroundRegeneration,
+} from "<ROOT>/packages/vinext/src/server/isr-cache.js";
 // Import server-only state module to register ALS-backed accessors.
 import "vinext/navigation-state";
+import { runWithPrerenderWorkUnit as __runWithPrerenderWorkUnit } from "<ROOT>/packages/vinext/src/server/prerender-work-unit-setup.js";
 import { runWithRequestContext as _runWithUnifiedCtx, createRequestContext as _createUnifiedCtx } from "vinext/unified-request-context";
 import { reportRequestError as _reportRequestError } from "vinext/instrumentation";
 import { flattenErrorCauses as __flattenErrorCauses } from "<ROOT>/packages/vinext/src/utils/error-cause.js";
-import { runWithPrerenderWorkUnit as __runWithPrerenderWorkUnit } from "<ROOT>/packages/vinext/src/server/prerender-work-unit-setup.js";
 import { getSSRFontLinks as _getSSRFontLinks, getSSRFontStyles as _getSSRFontStylesGoogle, getSSRFontPreloads as _getSSRFontPreloadsGoogle } from "next/font/google";
 import { getSSRFontStyles as _getSSRFontStylesLocal, getSSRFontPreloads as _getSSRFontPreloadsLocal } from "next/font/local";
 function _getSSRFontStyles() { return [..._getSSRFontStylesGoogle(), ..._getSSRFontStylesLocal()]; }
@@ -143,25 +159,6 @@ function __clearRequestContext() {
   // setNavigationContext(null) already clears root params internally
 }
 
-// ISR cache is disabled in dev mode — every request re-renders fresh,
-// matching Next.js dev behavior. Cache-Control headers are still emitted
-// based on export const revalidate for testing purposes.
-// Production ISR uses the MemoryCacheHandler (or configured KV handler).
-//
-// These helpers are inlined instead of imported from isr-cache.js because
-// the virtual RSC entry module runs in the RSC Vite environment which
-// cannot use dynamic imports at the module-evaluation level for server-only
-// modules, and direct imports must use the pre-computed absolute paths.
-async function __isrGet(key) {
-  const handler = getCacheHandler();
-  const result = await handler.get(key);
-  if (!result || !result.value) return null;
-  return { value: result, isStale: result.cacheState === "stale" };
-}
-async function __isrSet(key, data, revalidateSeconds, tags) {
-  const handler = getCacheHandler();
-  await handler.set(key, data, { revalidate: revalidateSeconds, tags: Array.isArray(tags) ? tags : [] });
-}
 // Note: cache entries are written with \`headers: undefined\`. Next.js stores
 // response headers (e.g. set-cookie from cookies().set() during render) in the
 // cache entry so they can be replayed on HIT. We don't do this because:
@@ -172,82 +169,6 @@ async function __isrSet(key, data, revalidateSeconds, tags) {
 // In practice this means ISR-cached responses won't replay render-time set-cookie
 // headers — but that case is already prevented by the dynamic-usage opt-out.
 // TODO: capture render-time response headers for full Next.js parity.
-const __pendingRegenerations = new Map();
-function __triggerBackgroundRegeneration(key, renderFn, errorContext) {
-  if (__pendingRegenerations.has(key)) return;
-  const promise = renderFn()
-    .catch((err) => {
-      console.error("[vinext] ISR regen failed for " + key + ":", err);
-      if (errorContext) {
-        void _reportRequestError(
-          err instanceof Error ? err : new Error(String(err)),
-          { path: key, method: "GET", headers: {} },
-          {
-            routerKind: "App Router",
-            routePath: errorContext.routePath,
-            routeType: errorContext.routeType,
-            revalidateReason: "stale",
-          },
-        );
-      }
-    })
-    .finally(() => __pendingRegenerations.delete(key));
-  __pendingRegenerations.set(key, promise);
-  const ctx = _getRequestExecutionContext();
-  if (ctx && typeof ctx.waitUntil === "function") ctx.waitUntil(promise);
-}
-// HTML and RSC are stored under separate keys — matching Next.js's file-system
-// layout (.html / .rsc) — so each request type reads and writes its own key
-// independently with no races or partial-entry sentinels.
-//
-// Key format: "app:<buildId>:<pathname>:<suffix>"
-// Long-pathname fallback: "app:<buildId>:__hash:<fnv1a64(pathname)>:<suffix>"
-// Without buildId (should not happen in production): "app:<pathname>:<suffix>"
-// The 200-char threshold keeps the full key well under Cloudflare KV's 512-byte limit
-// even after adding the build ID and suffix. FNV-1a 64 is used for the hash (two
-// 32-bit rounds) to give a ~64-bit output with negligible collision probability for
-// realistic pathname lengths.
-// Keep prefix construction and hashing logic in sync with isrCacheKey() in server/isr-cache.ts.
-function __isrFnv1a64(s) {
-  // h1 uses the standard FNV-1a 32-bit offset basis (0x811c9dc5).
-  let h1 = 0x811c9dc5;
-  for (let i = 0; i < s.length; i++) { h1 ^= s.charCodeAt(i); h1 = (h1 * 0x01000193) >>> 0; }
-  // h2 uses a different seed (0x050c5d1f — the FNV-1a hash of the string "vinext")
-  // so the two rounds are independently seeded and their outputs are decorrelated.
-  // Concatenating two independently-seeded 32-bit FNV-1a hashes gives an effective
-  // 64-bit hash. A random non-standard seed would also work; we derive it from a
-  // fixed string so the choice is auditable and deterministic across rebuilds.
-  let h2 = 0x050c5d1f;
-  for (let i = 0; i < s.length; i++) { h2 ^= s.charCodeAt(i); h2 = (h2 * 0x01000193) >>> 0; }
-  return h1.toString(36) + h2.toString(36);
-}
-function __isrCacheKey(pathname, suffix) {
-  const normalized = pathname === "/" ? "/" : pathname.replace(/\\/$/, "");
-  // __VINEXT_BUILD_ID is replaced at compile time by Vite's define plugin.
-  const buildId = process.env.__VINEXT_BUILD_ID;
-  const prefix = buildId ? "app:" + buildId : "app";
-  const key = prefix + ":" + normalized + ":" + suffix;
-  if (key.length <= 200) return key;
-  // Pathname too long — hash it to keep under KV's 512-byte key limit.
-  return prefix + ":__hash:" + __isrFnv1a64(normalized) + ":" + suffix;
-}
-function __isrHtmlKey(pathname) { return __isrCacheKey(pathname, "html"); }
-function __isrRscKey(pathname, mountedSlotsHeader) {
-  if (!mountedSlotsHeader) return __isrCacheKey(pathname, "rsc");
-  return __isrCacheKey(pathname, "rsc:" + __isrFnv1a64(mountedSlotsHeader));
-}
-function __normalizeMountedSlotsHeader(raw) {
-  if (!raw) return null;
-  const normalized = Array.from(
-    new Set(
-      raw
-        .split(/\\s+/)
-        .filter(Boolean),
-    ),
-  ).sort().join(" ");
-  return normalized || null;
-}
-function __isrRouteKey(pathname) { return __isrCacheKey(pathname, "route"); }
 // Verbose cache logging — opt in with NEXT_PRIVATE_DEBUG_CACHE=1.
 // Matches the env var Next.js uses for its own cache debug output so operators
 // have a single knob for all cache tracing.
@@ -265,124 +186,6 @@ const __classDebug = process.env.VINEXT_DEBUG_CLASSIFICATION
     }
   : undefined;
 
-// Normalize null-prototype objects from route-pattern matching into thenable objects
-// that work both as Promises (for Next.js 15+ async params) and as plain
-// objects with synchronous property access (for pre-15 code like params.id).
-//
-// route-pattern matching uses Object.create(null), producing objects without
-// Object.prototype. The RSC serializer rejects these. Spreading ({...obj})
-// restores a normal prototype. Object.assign onto the Promise preserves
-// synchronous property access (params.id, params.slug) that existing
-// components and test fixtures rely on.
-function makeThenableParams(obj) {
-  const plain = { ...obj };
-  return Object.assign(Promise.resolve(plain), plain);
-}
-
-// djb2 hash — matches Next.js's stringHash for digest generation.
-// Produces a stable numeric string from error message + stack.
-function __errorDigest(str) {
-  let hash = 5381;
-  for (let i = str.length - 1; i >= 0; i--) {
-    hash = (hash * 33) ^ str.charCodeAt(i);
-  }
-  return (hash >>> 0).toString();
-}
-
-// Sanitize an error for client consumption. In production, replaces the error
-// with a generic Error that only carries a digest hash (matching Next.js
-// behavior). In development, returns the original error for debugging.
-// Navigation errors (redirect, notFound, etc.) are always passed through
-// unchanged since their digests are used for client-side routing.
-function __sanitizeErrorForClient(error) {
-  // Navigation errors must pass through with their digest intact
-  if (__resolveAppPageSpecialError(error)) {
-    return error;
-  }
-  // In development, pass through the original error for debugging
-  if (process.env.NODE_ENV !== "production") {
-    return error;
-  }
-  // In production, create a sanitized error with only a digest hash
-  const msg = error instanceof Error ? error.message : String(error);
-  const stack = error instanceof Error ? (error.stack || "") : "";
-  const sanitized = new Error(
-    "An error occurred in the Server Components render. " +
-    "The specific message is omitted in production builds to avoid leaking sensitive details. " +
-    "A digest property is included on this error instance which may provide additional details about the nature of the error."
-  );
-  sanitized.digest = __errorDigest(msg + stack);
-  return sanitized;
-}
-
-// onError callback for renderToReadableStream — preserves the digest for
-// Next.js navigation errors (redirect, notFound, forbidden, unauthorized)
-// thrown during RSC streaming (e.g. inside Suspense boundaries).
-// For non-navigation errors in production, generates a digest hash so the
-// error can be correlated with server logs without leaking details.
-function rscOnError(error, requestInfo, errorContext) {
-  if (error && typeof error === "object" && "digest" in error) {
-    return String(error.digest);
-  }
-
-  // In dev, detect the "Only plain objects" RSC serialization error and emit
-  // an actionable hint. This error occurs when a Server Component passes a
-  // class instance, ES module namespace object, or null-prototype object as a
-  // prop to a Client Component.
-  //
-  // Root cause: Vite bundles modules as true ESM (module namespace objects
-  // have a null-like internal slot), while Next.js's webpack build produces
-  // plain CJS-wrapped objects with __esModule:true. React's RSC serializer
-  // accepts the latter as plain objects but rejects the former — which means
-  // code that accidentally passes "import * as X" works in webpack/Next.js
-  // but correctly fails in vinext.
-  //
-  // Common triggers:
-  //   - "import * as utils from './utils'" passed as a prop
-  //   - class instances (new Foo()) passed as props
-  //   - Date / Map / Set instances passed as props
-  //   - Objects with Object.create(null) (null prototype)
-  if (
-    process.env.NODE_ENV !== "production" &&
-    error instanceof Error &&
-    error.message.includes("Only plain objects, and a few built-ins, can be passed to Client Components")
-  ) {
-    console.error(
-      "[vinext] RSC serialization error: a non-plain object was passed from a Server Component to a Client Component.\\n" +
-      "\\n" +
-      "Common causes:\\n" +
-      "  * Passing a module namespace (import * as X) directly as a prop.\\n" +
-      "    Unlike Next.js (webpack), Vite produces real ESM module namespace objects\\n" +
-      "    which are not serializable. Fix: pass individual values instead,\\n" +
-      "    e.g. <Comp value={module.value} />\\n" +
-      "  * Passing a class instance (new Foo()) as a prop.\\n" +
-      "    Fix: convert to a plain object, e.g. { id: foo.id, name: foo.name }\\n" +
-      "  * Passing a Date, Map, or Set. Use .toISOString(), [...map.entries()], etc.\\n" +
-      "  * Passing Object.create(null). Use { ...obj } to restore a prototype.\\n" +
-      "\\n" +
-      "Original error:",
-      error.message,
-    );
-    return undefined;
-  }
-
-  if (requestInfo && errorContext && error) {
-    _reportRequestError(
-      error instanceof Error ? error : new Error(String(error)),
-      requestInfo,
-      errorContext,
-    );
-  }
-
-  // In production, generate a digest hash for non-navigation errors
-  if (process.env.NODE_ENV === "production" && error) {
-    const msg = error instanceof Error ? error.message : String(error);
-    const stack = error instanceof Error ? (error.stack || "") : "";
-    return __errorDigest(msg + stack);
-  }
-  return undefined;
-}
-
 function createRscOnErrorHandler(request, pathname, routePath) {
   const requestInfo = {
     path: pathname,
@@ -394,9 +197,11 @@ function createRscOnErrorHandler(request, pathname, routePath) {
     routePath: routePath || pathname,
     routeType: "render",
   };
-  return function(error) {
-    return rscOnError(error, requestInfo, errorContext);
-  };
+  return __createRscOnErrorHandler({
+    errorContext,
+    reportRequestError: _reportRequestError,
+    requestInfo,
+  });
 }
 
 import * as mod_0 from "/tmp/test/app/page.tsx";
@@ -587,6 +392,7 @@ async function renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, req
     makeThenableParams,
     matchedParams: opts?.matchedParams ?? route?.params ?? {},
     middlewareContext: middlewareContext ?? __APP_PAGE_EMPTY_MW_CTX,
+    metadataRoutes,
     requestUrl: request.url,
     resolveChildSegments: __resolveAppPageChildSegments,
     rootForbiddenModule: rootForbiddenModule,
@@ -634,6 +440,7 @@ async function renderErrorBoundaryPage(route, error, isRscRequest, request, matc
     makeThenableParams,
     matchedParams: matchedParams ?? route?.params ?? {},
     middlewareContext: middlewareContext ?? __APP_PAGE_EMPTY_MW_CTX,
+    metadataRoutes,
     requestUrl: request.url,
     resolveChildSegments: __resolveAppPageChildSegments,
     rootLayouts: rootLayouts,
@@ -646,21 +453,6 @@ async function renderErrorBoundaryPage(route, error, isRscRequest, request, matc
 
 function matchRoute(url) {
   return __routeMatcher.matchRoute(url);
-}
-
-function __createStaticFileSignal(pathname, _mwCtx) {
-  const headers = new Headers({
-    "x-vinext-static-file": encodeURIComponent(pathname),
-  });
-  if (_mwCtx.headers) {
-    for (const [key, value] of _mwCtx.headers) {
-      headers.append(key, value);
-    }
-  }
-  return new Response(null, {
-    status: _mwCtx.status ?? 200,
-    headers,
-  });
 }
 
 /**
@@ -699,18 +491,30 @@ async function buildPageElements(route, params, routePath, pageRequest) {
     };
   }
 
-  const __headResult = await __resolveAppPageHead({
+  const {
+    hasSearchParams,
+    metadata: resolvedMetadata,
+    pageSearchParams,
+    viewport: resolvedViewport,
+  } = await __resolveAppPageHead({
     layoutModules: route.layouts,
     layoutTreePositions: route.layoutTreePositions,
+    metadataRoutes,
     pageModule: route.page,
+    parallelRoutes: __resolveActiveParallelRouteHeadInputs({
+      interceptLayouts: opts?.interceptLayouts ?? null,
+      interceptPage: opts?.interceptPage ?? null,
+      interceptParams: opts?.interceptParams ?? null,
+      interceptSlotKey: opts?.interceptSlotKey ?? null,
+      params,
+      routeSegments: route.routeSegments,
+      slots: route.slots,
+    }),
     params,
+    routePath: route.pattern,
     routeSegments: route.routeSegments,
     searchParams,
   });
-  const spObj = __headResult.searchParamsObject;
-  const hasSearchParams = __headResult.hasSearchParams;
-  const resolvedMetadata = __headResult.metadata;
-  const resolvedViewport = __headResult.viewport;
 
   // Build the route tree from the leaf page, then delegate the boundary/layout/
   // template/segment wiring to a typed runtime helper so the generated entry
@@ -720,7 +524,7 @@ async function buildPageElements(route, params, routePath, pageRequest) {
     // Always provide searchParams prop when the URL object is available, even
     // when the query string is empty -- pages that do "await searchParams" need
     // it to be a thenable rather than undefined.
-    pageProps.searchParams = makeThenableParams(spObj);
+    pageProps.searchParams = makeThenableParams(pageSearchParams);
     // If the URL has query parameters, mark the page as dynamic.
     // In Next.js, only accessing the searchParams prop signals dynamic usage,
     // but a Proxy-based approach doesn't work here because React's RSC debug
@@ -751,6 +555,8 @@ async function buildPageElements(route, params, routePath, pageRequest) {
     interceptionContext: opts?.interceptionContext ?? null,
     routePath,
     rootNotFoundModule: null,
+    rootForbiddenModule: null,
+    rootUnauthorizedModule: null,
     route,
     slotOverrides:
       opts && opts.interceptSlotKey && opts.interceptPage
@@ -870,63 +676,6 @@ function __buildPostMwRequestContext(request) {
  */
 var __MAX_ACTION_BODY_SIZE = 1048576;
 
-/**
- * Read a request body as text with a size limit.
- * Enforces the limit on the actual byte stream to prevent bypasses
- * via chunked transfer-encoding where Content-Length is absent or spoofed.
- */
-async function __readBodyWithLimit(request, maxBytes) {
-  if (!request.body) return "";
-  var reader = request.body.getReader();
-  var decoder = new TextDecoder();
-  var chunks = [];
-  var totalSize = 0;
-  for (;;) {
-    var result = await reader.read();
-    if (result.done) break;
-    totalSize += result.value.byteLength;
-    if (totalSize > maxBytes) {
-      reader.cancel();
-      throw new Error("Request body too large");
-    }
-    chunks.push(decoder.decode(result.value, { stream: true }));
-  }
-  chunks.push(decoder.decode());
-  return chunks.join("");
-}
-
-/**
- * Read a request body as FormData with a size limit.
- * Consumes the body stream with a byte counter and then parses the
- * collected bytes as multipart form data via the Response constructor.
- */
-async function __readFormDataWithLimit(request, maxBytes) {
-  if (!request.body) return new FormData();
-  var reader = request.body.getReader();
-  var chunks = [];
-  var totalSize = 0;
-  for (;;) {
-    var result = await reader.read();
-    if (result.done) break;
-    totalSize += result.value.byteLength;
-    if (totalSize > maxBytes) {
-      reader.cancel();
-      throw new Error("Request body too large");
-    }
-    chunks.push(result.value);
-  }
-  // Reconstruct a Response with the original Content-Type so that
-  // the FormData parser can handle multipart boundaries correctly.
-  var combined = new Uint8Array(totalSize);
-  var offset = 0;
-  for (var chunk of chunks) {
-    combined.set(chunk, offset);
-    offset += chunk.byteLength;
-  }
-  var contentType = request.headers.get("content-type") || "";
-  return new Response(combined, { headers: { "Content-Type": contentType } }).formData();
-}
-
 // Map from route pattern to generateStaticParams function.
 // Used by the prerender phase to enumerate dynamic route URLs without
 // loading route modules via the dev server.
@@ -937,6 +686,9 @@ export const generateStaticParamsMap = {
 // so they are excluded here. Supporting layout-level generateStaticParams requires
 // scanning layout.tsx files separately and including them in this map.
   "/blog/:slug": mod_3?.generateStaticParams ?? null,
+};
+const rootParamNamesMap = {
+
 };
 
 export default async function handler(request, ctx) {
@@ -984,21 +736,11 @@ export default async function handler(request, ctx) {
         let pathname;
         try { pathname = __normalizePath(__normalizePathnameForRouteMatch(url.pathname)); } catch { pathname = url.pathname; }
         
-        const extraHeaders = matchHeaders(pathname, __configHeaders, __reqCtx);
-        for (const h of extraHeaders) {
-          // Use append() for headers where multiple values must coexist
-          // (Vary, Set-Cookie). Using set() on these would destroy
-          // existing values like "Vary: RSC, Accept" which are critical
-          // for correct CDN caching behavior.
-          const lk = h.key.toLowerCase();
-          if (lk === "vary" || lk === "set-cookie") {
-            response.headers.append(h.key, h.value);
-          } else if (!response.headers.has(lk)) {
-            // Middleware headers take precedence: skip config keys already
-            // set by middleware so middleware headers always win.
-            response.headers.set(h.key, h.value);
-          }
-        }
+        applyConfigHeadersToResponse(response.headers, {
+          configHeaders: __configHeaders,
+          pathname,
+          requestContext: __reqCtx,
+        });
       }
     }
     return response;
@@ -1042,6 +784,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     },
 
     pathname,
+    rootParamNamesByPattern: rootParamNamesMap,
     staticParamsMap: generateStaticParamsMap,
   });
   if (__prerenderEndpointResponse) return __prerenderEndpointResponse;
@@ -1119,90 +862,25 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     return Response.redirect(new URL(__imgResult, url.origin).href, 302);
   }
 
-  // Handle metadata routes (sitemap.xml, robots.txt, manifest.webmanifest, etc.)
-  for (const metaRoute of metadataRoutes) {
-    // generateSitemaps() support — paginated sitemaps at /{prefix}/sitemap/{id}.xml
-    // When a sitemap module exports generateSitemaps, the base URL (e.g. /products/sitemap.xml)
-    // is no longer served. Instead, individual sitemaps are served at /products/sitemap/{id}.xml.
-    if (
-      metaRoute.type === "sitemap" &&
-      metaRoute.isDynamic &&
-      typeof metaRoute.module.generateSitemaps === "function"
-    ) {
-      const sitemapPrefix = metaRoute.servedUrl.slice(0, -4); // strip ".xml"
-      // Match exactly /{prefix}/{id}.xml — one segment only (no slashes in id)
-      if (cleanPathname.startsWith(sitemapPrefix + "/") && cleanPathname.endsWith(".xml")) {
-        const rawId = cleanPathname.slice(sitemapPrefix.length + 1, -4);
-        if (rawId.includes("/")) continue; // multi-segment — not a paginated sitemap
-        const sitemaps = await metaRoute.module.generateSitemaps();
-        const matched = sitemaps.find(function(s) { return String(s.id) === rawId; });
-        if (!matched) return new Response("Not Found", { status: 404 });
-        // Pass the original typed id from generateSitemaps() so numeric IDs stay numeric.
-        // TODO: wrap with makeThenableParams-style Promise when upgrading to Next.js 16
-        // full-Promise param semantics (id becomes Promise<string> in v16).
-        const result = await metaRoute.module.default({ id: matched.id });
-        if (result instanceof Response) return result;
-        return new Response(sitemapToXml(result), {
-          headers: { "Content-Type": metaRoute.contentType },
-        });
-      }
-      // Skip — the base servedUrl is not served when generateSitemaps exists
-      continue;
-    }
-    // Match metadata route — use pattern matching for dynamic segments,
-    // strict equality for static paths.
-    var _metaParams = null;
-    if (metaRoute.patternParts) {
-      var _metaUrlParts = cleanPathname.split("/").filter(Boolean);
-      _metaParams = __matchAppRscRoutePattern(_metaUrlParts, metaRoute.patternParts);
-      if (!_metaParams) continue;
-    } else if (cleanPathname !== metaRoute.servedUrl) {
-      continue;
-    }
-    if (metaRoute.isDynamic) {
-      // Dynamic metadata route — call the default export and serialize
-      const metaFn = metaRoute.module.default;
-      if (typeof metaFn === "function") {
-        const result = await metaFn({ params: makeThenableParams(_metaParams || {}) });
-        let body;
-        // If it's already a Response (e.g., ImageResponse), return directly
-        if (result instanceof Response) return result;
-        // Serialize based on type
-        if (metaRoute.type === "sitemap") body = sitemapToXml(result);
-        else if (metaRoute.type === "robots") body = robotsToText(result);
-        else if (metaRoute.type === "manifest") body = manifestToJson(result);
-        else body = JSON.stringify(result);
-        return new Response(body, {
-          headers: { "Content-Type": metaRoute.contentType },
-        });
-      }
-    } else {
-      // Static metadata file — decode from embedded base64 data
-      try {
-        const binary = atob(metaRoute.fileDataBase64);
-        const bytes = new Uint8Array(binary.length);
-        for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
-        return new Response(bytes, {
-          headers: {
-            "Content-Type": metaRoute.contentType,
-            "Cache-Control": "public, max-age=0, must-revalidate",
-          },
-        });
-      } catch {
-        return new Response("Not Found", { status: 404 });
-      }
-    }
-  }
+  const metadataRouteResponse = await __handleMetadataRouteRequest({
+    metadataRoutes,
+    cleanPathname,
+    makeThenableParams,
+  });
+  if (metadataRouteResponse) return metadataRouteResponse;
 
   // Serve public/ files as filesystem routes after middleware and before
   // afterFiles/fallback rewrites, matching Next.js routing semantics.
-  if (
-    (request.method === "GET" || request.method === "HEAD") &&
-    !pathname.endsWith(".rsc") &&
-    __publicFiles.has(cleanPathname)
-  ) {
+  const __publicFileResponse = resolvePublicFileRoute({
+    cleanPathname,
+    middlewareContext: _mwCtx,
+    pathname,
+    publicFiles: __publicFiles,
+    request,
+  });
+  if (__publicFileResponse) {
     __clearRequestContext();
-    return __createStaticFileSignal(cleanPathname, _mwCtx);
+    return __publicFileResponse;
   }
 
   // Set navigation context for Server Components.
@@ -1544,7 +1222,11 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         });
       },
       scheduleBackgroundRegeneration(key, renderFn) {
-        __triggerBackgroundRegeneration(key, renderFn, { routePath: route.pattern, routeType: "render" });
+        __triggerBackgroundRegeneration(key, renderFn, {
+          routerKind: "App Router",
+          routePath: route.pattern,
+          routeType: "render",
+        });
       },
     });
     if (__cachedPageResponse) {
@@ -1696,6 +1378,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       __clearRequestContext();
     },
     consumeDynamicUsage,
+    consumeInvalidDynamicUsageError,
     createRscOnErrorHandler(pathname, routePath) {
       return createRscOnErrorHandler(request, pathname, routePath);
     },
@@ -1879,16 +1562,16 @@ function renderToReadableStream(model, options) {
 }
 import { createElement } from "react";
 import { setNavigationContext as _setNavigationContextOrig, getNavigationContext as _getNavigationContext } from "next/navigation";
-import { setHeadersContext, headersContextFromRequest, getDraftModeCookieHeader, getAndClearPendingCookies, consumeDynamicUsage, markDynamicUsage, getHeadersContext, setHeadersAccessPhase } from "next/headers";
+import { setHeadersContext, headersContextFromRequest, getDraftModeCookieHeader, getAndClearPendingCookies, consumeDynamicUsage, consumeInvalidDynamicUsageError, markDynamicUsage, getHeadersContext, setHeadersAccessPhase } from "next/headers";
 import { mergeMetadata, resolveModuleMetadata, mergeViewport, resolveModuleViewport } from "vinext/metadata";
 
 
-
-import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, matchHeaders, isExternalUrl, proxyExternalRequest, sanitizeDestination } from "<ROOT>/packages/vinext/src/config/config-matchers.js";
+import { handleMetadataRouteRequest as __handleMetadataRouteRequest } from "<ROOT>/packages/vinext/src/server/metadata-route-response.js";
+import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, isExternalUrl, proxyExternalRequest, sanitizeDestination } from "<ROOT>/packages/vinext/src/config/config-matchers.js";
 import { decodePathParams as __decodePathParams, normalizePath as __normalizePath } from "<ROOT>/packages/vinext/src/server/normalize-path.js";
 import { normalizePathnameForRouteMatch as __normalizePathnameForRouteMatch, normalizePathnameForRouteMatchStrict as __normalizePathnameForRouteMatchStrict } from "<ROOT>/packages/vinext/src/routing/utils.js";
 import { buildRequestHeadersFromMiddlewareResponse as __buildRequestHeadersFromMiddlewareResponse } from "<ROOT>/packages/vinext/src/server/middleware-request-headers.js";
-import { validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
+import { applyConfigHeadersToResponse, resolvePublicFileRoute, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
 import { applyAppMiddleware as __applyAppMiddleware } from "<ROOT>/packages/vinext/src/server/app-middleware.js";
 import {
   dispatchAppRouteHandler as __dispatchAppRouteHandler,
@@ -1896,7 +1579,13 @@ import {
 import {
   handleProgressiveServerActionRequest as __handleProgressiveServerActionRequest,
   handleServerActionRscRequest as __handleServerActionRscRequest,
+  readActionBodyWithLimit as __readBodyWithLimit,
+  readActionFormDataWithLimit as __readFormDataWithLimit,
 } from "<ROOT>/packages/vinext/src/server/app-server-action-execution.js";
+import {
+  createRscOnErrorHandler as __createRscOnErrorHandler,
+  sanitizeErrorForClient as __sanitizeErrorForClient,
+} from "<ROOT>/packages/vinext/src/server/app-rsc-errors.js";
 import { readAppPageCacheResponse as __readAppPageCacheResponse } from "<ROOT>/packages/vinext/src/server/app-page-cache.js";
 import {
   buildAppPageFontLinkHeader as __buildAppPageFontLinkHeader,
@@ -1926,6 +1615,7 @@ import {
 } from "<ROOT>/packages/vinext/src/server/app-page-params.js";
 import {
   collectAppPageSearchParams as __collectAppPageSearchParams,
+  resolveActiveParallelRouteHeadInputs as __resolveActiveParallelRouteHeadInputs,
   resolveAppPageHead as __resolveAppPageHead,
 } from "<ROOT>/packages/vinext/src/server/app-page-head.js";
 import {
@@ -1947,23 +1637,32 @@ import {
   createStaticGenerationHeadersContext as __createStaticGenerationHeadersContext,
 } from "<ROOT>/packages/vinext/src/server/app-static-generation.js";
 import { buildPageCacheTags } from "<ROOT>/packages/vinext/src/server/implicit-tags.js";
-import { _consumeRequestScopedCacheLife, getCacheHandler } from "next/cache";
+import { _consumeRequestScopedCacheLife } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
 import { setRootParams as __setRootParams, pickRootParams as __pickRootParams } from "<ROOT>/packages/vinext/src/shims/root-params.js";
+import { makeThenableParams } from "<ROOT>/packages/vinext/src/shims/thenable-params.js";
 import { ensureFetchPatch as _ensureFetchPatch, getCollectedFetchTags, setCurrentFetchSoftTags } from "vinext/fetch-cache";
 import {
   createAppRscRouteMatcher as __createAppRscRouteMatcher,
-  matchAppRscRoutePattern as __matchAppRscRoutePattern,
 } from "<ROOT>/packages/vinext/src/server/app-rsc-route-matching.js";
 import {
   handleAppPrerenderEndpoint as __handleAppPrerenderEndpoint,
 } from "<ROOT>/packages/vinext/src/server/app-prerender-endpoints.js";
+import {
+  appIsrHtmlKey as __isrHtmlKey,
+  appIsrRscKey as __isrRscKey,
+  appIsrRouteKey as __isrRouteKey,
+  isrGet as __isrGet,
+  isrSet as __isrSet,
+  normalizeMountedSlotsHeader as __normalizeMountedSlotsHeader,
+  triggerBackgroundRegeneration as __triggerBackgroundRegeneration,
+} from "<ROOT>/packages/vinext/src/server/isr-cache.js";
 // Import server-only state module to register ALS-backed accessors.
 import "vinext/navigation-state";
+import { runWithPrerenderWorkUnit as __runWithPrerenderWorkUnit } from "<ROOT>/packages/vinext/src/server/prerender-work-unit-setup.js";
 import { runWithRequestContext as _runWithUnifiedCtx, createRequestContext as _createUnifiedCtx } from "vinext/unified-request-context";
 import { reportRequestError as _reportRequestError } from "vinext/instrumentation";
 import { flattenErrorCauses as __flattenErrorCauses } from "<ROOT>/packages/vinext/src/utils/error-cause.js";
-import { runWithPrerenderWorkUnit as __runWithPrerenderWorkUnit } from "<ROOT>/packages/vinext/src/server/prerender-work-unit-setup.js";
 import { getSSRFontLinks as _getSSRFontLinks, getSSRFontStyles as _getSSRFontStylesGoogle, getSSRFontPreloads as _getSSRFontPreloadsGoogle } from "next/font/google";
 import { getSSRFontStyles as _getSSRFontStylesLocal, getSSRFontPreloads as _getSSRFontPreloadsLocal } from "next/font/local";
 function _getSSRFontStyles() { return [..._getSSRFontStylesGoogle(), ..._getSSRFontStylesLocal()]; }
@@ -2000,25 +1699,6 @@ function __clearRequestContext() {
   // setNavigationContext(null) already clears root params internally
 }
 
-// ISR cache is disabled in dev mode — every request re-renders fresh,
-// matching Next.js dev behavior. Cache-Control headers are still emitted
-// based on export const revalidate for testing purposes.
-// Production ISR uses the MemoryCacheHandler (or configured KV handler).
-//
-// These helpers are inlined instead of imported from isr-cache.js because
-// the virtual RSC entry module runs in the RSC Vite environment which
-// cannot use dynamic imports at the module-evaluation level for server-only
-// modules, and direct imports must use the pre-computed absolute paths.
-async function __isrGet(key) {
-  const handler = getCacheHandler();
-  const result = await handler.get(key);
-  if (!result || !result.value) return null;
-  return { value: result, isStale: result.cacheState === "stale" };
-}
-async function __isrSet(key, data, revalidateSeconds, tags) {
-  const handler = getCacheHandler();
-  await handler.set(key, data, { revalidate: revalidateSeconds, tags: Array.isArray(tags) ? tags : [] });
-}
 // Note: cache entries are written with \`headers: undefined\`. Next.js stores
 // response headers (e.g. set-cookie from cookies().set() during render) in the
 // cache entry so they can be replayed on HIT. We don't do this because:
@@ -2029,82 +1709,6 @@ async function __isrSet(key, data, revalidateSeconds, tags) {
 // In practice this means ISR-cached responses won't replay render-time set-cookie
 // headers — but that case is already prevented by the dynamic-usage opt-out.
 // TODO: capture render-time response headers for full Next.js parity.
-const __pendingRegenerations = new Map();
-function __triggerBackgroundRegeneration(key, renderFn, errorContext) {
-  if (__pendingRegenerations.has(key)) return;
-  const promise = renderFn()
-    .catch((err) => {
-      console.error("[vinext] ISR regen failed for " + key + ":", err);
-      if (errorContext) {
-        void _reportRequestError(
-          err instanceof Error ? err : new Error(String(err)),
-          { path: key, method: "GET", headers: {} },
-          {
-            routerKind: "App Router",
-            routePath: errorContext.routePath,
-            routeType: errorContext.routeType,
-            revalidateReason: "stale",
-          },
-        );
-      }
-    })
-    .finally(() => __pendingRegenerations.delete(key));
-  __pendingRegenerations.set(key, promise);
-  const ctx = _getRequestExecutionContext();
-  if (ctx && typeof ctx.waitUntil === "function") ctx.waitUntil(promise);
-}
-// HTML and RSC are stored under separate keys — matching Next.js's file-system
-// layout (.html / .rsc) — so each request type reads and writes its own key
-// independently with no races or partial-entry sentinels.
-//
-// Key format: "app:<buildId>:<pathname>:<suffix>"
-// Long-pathname fallback: "app:<buildId>:__hash:<fnv1a64(pathname)>:<suffix>"
-// Without buildId (should not happen in production): "app:<pathname>:<suffix>"
-// The 200-char threshold keeps the full key well under Cloudflare KV's 512-byte limit
-// even after adding the build ID and suffix. FNV-1a 64 is used for the hash (two
-// 32-bit rounds) to give a ~64-bit output with negligible collision probability for
-// realistic pathname lengths.
-// Keep prefix construction and hashing logic in sync with isrCacheKey() in server/isr-cache.ts.
-function __isrFnv1a64(s) {
-  // h1 uses the standard FNV-1a 32-bit offset basis (0x811c9dc5).
-  let h1 = 0x811c9dc5;
-  for (let i = 0; i < s.length; i++) { h1 ^= s.charCodeAt(i); h1 = (h1 * 0x01000193) >>> 0; }
-  // h2 uses a different seed (0x050c5d1f — the FNV-1a hash of the string "vinext")
-  // so the two rounds are independently seeded and their outputs are decorrelated.
-  // Concatenating two independently-seeded 32-bit FNV-1a hashes gives an effective
-  // 64-bit hash. A random non-standard seed would also work; we derive it from a
-  // fixed string so the choice is auditable and deterministic across rebuilds.
-  let h2 = 0x050c5d1f;
-  for (let i = 0; i < s.length; i++) { h2 ^= s.charCodeAt(i); h2 = (h2 * 0x01000193) >>> 0; }
-  return h1.toString(36) + h2.toString(36);
-}
-function __isrCacheKey(pathname, suffix) {
-  const normalized = pathname === "/" ? "/" : pathname.replace(/\\/$/, "");
-  // __VINEXT_BUILD_ID is replaced at compile time by Vite's define plugin.
-  const buildId = process.env.__VINEXT_BUILD_ID;
-  const prefix = buildId ? "app:" + buildId : "app";
-  const key = prefix + ":" + normalized + ":" + suffix;
-  if (key.length <= 200) return key;
-  // Pathname too long — hash it to keep under KV's 512-byte key limit.
-  return prefix + ":__hash:" + __isrFnv1a64(normalized) + ":" + suffix;
-}
-function __isrHtmlKey(pathname) { return __isrCacheKey(pathname, "html"); }
-function __isrRscKey(pathname, mountedSlotsHeader) {
-  if (!mountedSlotsHeader) return __isrCacheKey(pathname, "rsc");
-  return __isrCacheKey(pathname, "rsc:" + __isrFnv1a64(mountedSlotsHeader));
-}
-function __normalizeMountedSlotsHeader(raw) {
-  if (!raw) return null;
-  const normalized = Array.from(
-    new Set(
-      raw
-        .split(/\\s+/)
-        .filter(Boolean),
-    ),
-  ).sort().join(" ");
-  return normalized || null;
-}
-function __isrRouteKey(pathname) { return __isrCacheKey(pathname, "route"); }
 // Verbose cache logging — opt in with NEXT_PRIVATE_DEBUG_CACHE=1.
 // Matches the env var Next.js uses for its own cache debug output so operators
 // have a single knob for all cache tracing.
@@ -2122,124 +1726,6 @@ const __classDebug = process.env.VINEXT_DEBUG_CLASSIFICATION
     }
   : undefined;
 
-// Normalize null-prototype objects from route-pattern matching into thenable objects
-// that work both as Promises (for Next.js 15+ async params) and as plain
-// objects with synchronous property access (for pre-15 code like params.id).
-//
-// route-pattern matching uses Object.create(null), producing objects without
-// Object.prototype. The RSC serializer rejects these. Spreading ({...obj})
-// restores a normal prototype. Object.assign onto the Promise preserves
-// synchronous property access (params.id, params.slug) that existing
-// components and test fixtures rely on.
-function makeThenableParams(obj) {
-  const plain = { ...obj };
-  return Object.assign(Promise.resolve(plain), plain);
-}
-
-// djb2 hash — matches Next.js's stringHash for digest generation.
-// Produces a stable numeric string from error message + stack.
-function __errorDigest(str) {
-  let hash = 5381;
-  for (let i = str.length - 1; i >= 0; i--) {
-    hash = (hash * 33) ^ str.charCodeAt(i);
-  }
-  return (hash >>> 0).toString();
-}
-
-// Sanitize an error for client consumption. In production, replaces the error
-// with a generic Error that only carries a digest hash (matching Next.js
-// behavior). In development, returns the original error for debugging.
-// Navigation errors (redirect, notFound, etc.) are always passed through
-// unchanged since their digests are used for client-side routing.
-function __sanitizeErrorForClient(error) {
-  // Navigation errors must pass through with their digest intact
-  if (__resolveAppPageSpecialError(error)) {
-    return error;
-  }
-  // In development, pass through the original error for debugging
-  if (process.env.NODE_ENV !== "production") {
-    return error;
-  }
-  // In production, create a sanitized error with only a digest hash
-  const msg = error instanceof Error ? error.message : String(error);
-  const stack = error instanceof Error ? (error.stack || "") : "";
-  const sanitized = new Error(
-    "An error occurred in the Server Components render. " +
-    "The specific message is omitted in production builds to avoid leaking sensitive details. " +
-    "A digest property is included on this error instance which may provide additional details about the nature of the error."
-  );
-  sanitized.digest = __errorDigest(msg + stack);
-  return sanitized;
-}
-
-// onError callback for renderToReadableStream — preserves the digest for
-// Next.js navigation errors (redirect, notFound, forbidden, unauthorized)
-// thrown during RSC streaming (e.g. inside Suspense boundaries).
-// For non-navigation errors in production, generates a digest hash so the
-// error can be correlated with server logs without leaking details.
-function rscOnError(error, requestInfo, errorContext) {
-  if (error && typeof error === "object" && "digest" in error) {
-    return String(error.digest);
-  }
-
-  // In dev, detect the "Only plain objects" RSC serialization error and emit
-  // an actionable hint. This error occurs when a Server Component passes a
-  // class instance, ES module namespace object, or null-prototype object as a
-  // prop to a Client Component.
-  //
-  // Root cause: Vite bundles modules as true ESM (module namespace objects
-  // have a null-like internal slot), while Next.js's webpack build produces
-  // plain CJS-wrapped objects with __esModule:true. React's RSC serializer
-  // accepts the latter as plain objects but rejects the former — which means
-  // code that accidentally passes "import * as X" works in webpack/Next.js
-  // but correctly fails in vinext.
-  //
-  // Common triggers:
-  //   - "import * as utils from './utils'" passed as a prop
-  //   - class instances (new Foo()) passed as props
-  //   - Date / Map / Set instances passed as props
-  //   - Objects with Object.create(null) (null prototype)
-  if (
-    process.env.NODE_ENV !== "production" &&
-    error instanceof Error &&
-    error.message.includes("Only plain objects, and a few built-ins, can be passed to Client Components")
-  ) {
-    console.error(
-      "[vinext] RSC serialization error: a non-plain object was passed from a Server Component to a Client Component.\\n" +
-      "\\n" +
-      "Common causes:\\n" +
-      "  * Passing a module namespace (import * as X) directly as a prop.\\n" +
-      "    Unlike Next.js (webpack), Vite produces real ESM module namespace objects\\n" +
-      "    which are not serializable. Fix: pass individual values instead,\\n" +
-      "    e.g. <Comp value={module.value} />\\n" +
-      "  * Passing a class instance (new Foo()) as a prop.\\n" +
-      "    Fix: convert to a plain object, e.g. { id: foo.id, name: foo.name }\\n" +
-      "  * Passing a Date, Map, or Set. Use .toISOString(), [...map.entries()], etc.\\n" +
-      "  * Passing Object.create(null). Use { ...obj } to restore a prototype.\\n" +
-      "\\n" +
-      "Original error:",
-      error.message,
-    );
-    return undefined;
-  }
-
-  if (requestInfo && errorContext && error) {
-    _reportRequestError(
-      error instanceof Error ? error : new Error(String(error)),
-      requestInfo,
-      errorContext,
-    );
-  }
-
-  // In production, generate a digest hash for non-navigation errors
-  if (process.env.NODE_ENV === "production" && error) {
-    const msg = error instanceof Error ? error.message : String(error);
-    const stack = error instanceof Error ? (error.stack || "") : "";
-    return __errorDigest(msg + stack);
-  }
-  return undefined;
-}
-
 function createRscOnErrorHandler(request, pathname, routePath) {
   const requestInfo = {
     path: pathname,
@@ -2251,9 +1737,11 @@ function createRscOnErrorHandler(request, pathname, routePath) {
     routePath: routePath || pathname,
     routeType: "render",
   };
-  return function(error) {
-    return rscOnError(error, requestInfo, errorContext);
-  };
+  return __createRscOnErrorHandler({
+    errorContext,
+    reportRequestError: _reportRequestError,
+    requestInfo,
+  });
 }
 
 import * as mod_0 from "/tmp/test/app/page.tsx";
@@ -2444,6 +1932,7 @@ async function renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, req
     makeThenableParams,
     matchedParams: opts?.matchedParams ?? route?.params ?? {},
     middlewareContext: middlewareContext ?? __APP_PAGE_EMPTY_MW_CTX,
+    metadataRoutes,
     requestUrl: request.url,
     resolveChildSegments: __resolveAppPageChildSegments,
     rootForbiddenModule: rootForbiddenModule,
@@ -2491,6 +1980,7 @@ async function renderErrorBoundaryPage(route, error, isRscRequest, request, matc
     makeThenableParams,
     matchedParams: matchedParams ?? route?.params ?? {},
     middlewareContext: middlewareContext ?? __APP_PAGE_EMPTY_MW_CTX,
+    metadataRoutes,
     requestUrl: request.url,
     resolveChildSegments: __resolveAppPageChildSegments,
     rootLayouts: rootLayouts,
@@ -2503,21 +1993,6 @@ async function renderErrorBoundaryPage(route, error, isRscRequest, request, matc
 
 function matchRoute(url) {
   return __routeMatcher.matchRoute(url);
-}
-
-function __createStaticFileSignal(pathname, _mwCtx) {
-  const headers = new Headers({
-    "x-vinext-static-file": encodeURIComponent(pathname),
-  });
-  if (_mwCtx.headers) {
-    for (const [key, value] of _mwCtx.headers) {
-      headers.append(key, value);
-    }
-  }
-  return new Response(null, {
-    status: _mwCtx.status ?? 200,
-    headers,
-  });
 }
 
 /**
@@ -2556,18 +2031,30 @@ async function buildPageElements(route, params, routePath, pageRequest) {
     };
   }
 
-  const __headResult = await __resolveAppPageHead({
+  const {
+    hasSearchParams,
+    metadata: resolvedMetadata,
+    pageSearchParams,
+    viewport: resolvedViewport,
+  } = await __resolveAppPageHead({
     layoutModules: route.layouts,
     layoutTreePositions: route.layoutTreePositions,
+    metadataRoutes,
     pageModule: route.page,
+    parallelRoutes: __resolveActiveParallelRouteHeadInputs({
+      interceptLayouts: opts?.interceptLayouts ?? null,
+      interceptPage: opts?.interceptPage ?? null,
+      interceptParams: opts?.interceptParams ?? null,
+      interceptSlotKey: opts?.interceptSlotKey ?? null,
+      params,
+      routeSegments: route.routeSegments,
+      slots: route.slots,
+    }),
     params,
+    routePath: route.pattern,
     routeSegments: route.routeSegments,
     searchParams,
   });
-  const spObj = __headResult.searchParamsObject;
-  const hasSearchParams = __headResult.hasSearchParams;
-  const resolvedMetadata = __headResult.metadata;
-  const resolvedViewport = __headResult.viewport;
 
   // Build the route tree from the leaf page, then delegate the boundary/layout/
   // template/segment wiring to a typed runtime helper so the generated entry
@@ -2577,7 +2064,7 @@ async function buildPageElements(route, params, routePath, pageRequest) {
     // Always provide searchParams prop when the URL object is available, even
     // when the query string is empty -- pages that do "await searchParams" need
     // it to be a thenable rather than undefined.
-    pageProps.searchParams = makeThenableParams(spObj);
+    pageProps.searchParams = makeThenableParams(pageSearchParams);
     // If the URL has query parameters, mark the page as dynamic.
     // In Next.js, only accessing the searchParams prop signals dynamic usage,
     // but a Proxy-based approach doesn't work here because React's RSC debug
@@ -2608,6 +2095,8 @@ async function buildPageElements(route, params, routePath, pageRequest) {
     interceptionContext: opts?.interceptionContext ?? null,
     routePath,
     rootNotFoundModule: null,
+    rootForbiddenModule: null,
+    rootUnauthorizedModule: null,
     route,
     slotOverrides:
       opts && opts.interceptSlotKey && opts.interceptPage
@@ -2727,63 +2216,6 @@ function __buildPostMwRequestContext(request) {
  */
 var __MAX_ACTION_BODY_SIZE = 1048576;
 
-/**
- * Read a request body as text with a size limit.
- * Enforces the limit on the actual byte stream to prevent bypasses
- * via chunked transfer-encoding where Content-Length is absent or spoofed.
- */
-async function __readBodyWithLimit(request, maxBytes) {
-  if (!request.body) return "";
-  var reader = request.body.getReader();
-  var decoder = new TextDecoder();
-  var chunks = [];
-  var totalSize = 0;
-  for (;;) {
-    var result = await reader.read();
-    if (result.done) break;
-    totalSize += result.value.byteLength;
-    if (totalSize > maxBytes) {
-      reader.cancel();
-      throw new Error("Request body too large");
-    }
-    chunks.push(decoder.decode(result.value, { stream: true }));
-  }
-  chunks.push(decoder.decode());
-  return chunks.join("");
-}
-
-/**
- * Read a request body as FormData with a size limit.
- * Consumes the body stream with a byte counter and then parses the
- * collected bytes as multipart form data via the Response constructor.
- */
-async function __readFormDataWithLimit(request, maxBytes) {
-  if (!request.body) return new FormData();
-  var reader = request.body.getReader();
-  var chunks = [];
-  var totalSize = 0;
-  for (;;) {
-    var result = await reader.read();
-    if (result.done) break;
-    totalSize += result.value.byteLength;
-    if (totalSize > maxBytes) {
-      reader.cancel();
-      throw new Error("Request body too large");
-    }
-    chunks.push(result.value);
-  }
-  // Reconstruct a Response with the original Content-Type so that
-  // the FormData parser can handle multipart boundaries correctly.
-  var combined = new Uint8Array(totalSize);
-  var offset = 0;
-  for (var chunk of chunks) {
-    combined.set(chunk, offset);
-    offset += chunk.byteLength;
-  }
-  var contentType = request.headers.get("content-type") || "";
-  return new Response(combined, { headers: { "Content-Type": contentType } }).formData();
-}
-
 // Map from route pattern to generateStaticParams function.
 // Used by the prerender phase to enumerate dynamic route URLs without
 // loading route modules via the dev server.
@@ -2794,6 +2226,9 @@ export const generateStaticParamsMap = {
 // so they are excluded here. Supporting layout-level generateStaticParams requires
 // scanning layout.tsx files separately and including them in this map.
   "/blog/:slug": mod_3?.generateStaticParams ?? null,
+};
+const rootParamNamesMap = {
+
 };
 
 export default async function handler(request, ctx) {
@@ -2841,21 +2276,11 @@ export default async function handler(request, ctx) {
         let pathname;
         try { pathname = __normalizePath(__normalizePathnameForRouteMatch(url.pathname)); } catch { pathname = url.pathname; }
         if (pathname.startsWith("/base")) pathname = pathname.slice("/base".length) || "/";
-        const extraHeaders = matchHeaders(pathname, __configHeaders, __reqCtx);
-        for (const h of extraHeaders) {
-          // Use append() for headers where multiple values must coexist
-          // (Vary, Set-Cookie). Using set() on these would destroy
-          // existing values like "Vary: RSC, Accept" which are critical
-          // for correct CDN caching behavior.
-          const lk = h.key.toLowerCase();
-          if (lk === "vary" || lk === "set-cookie") {
-            response.headers.append(h.key, h.value);
-          } else if (!response.headers.has(lk)) {
-            // Middleware headers take precedence: skip config keys already
-            // set by middleware so middleware headers always win.
-            response.headers.set(h.key, h.value);
-          }
-        }
+        applyConfigHeadersToResponse(response.headers, {
+          configHeaders: __configHeaders,
+          pathname,
+          requestContext: __reqCtx,
+        });
       }
     }
     return response;
@@ -2905,6 +2330,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     },
 
     pathname,
+    rootParamNamesByPattern: rootParamNamesMap,
     staticParamsMap: generateStaticParamsMap,
   });
   if (__prerenderEndpointResponse) return __prerenderEndpointResponse;
@@ -2982,90 +2408,25 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     return Response.redirect(new URL(__imgResult, url.origin).href, 302);
   }
 
-  // Handle metadata routes (sitemap.xml, robots.txt, manifest.webmanifest, etc.)
-  for (const metaRoute of metadataRoutes) {
-    // generateSitemaps() support — paginated sitemaps at /{prefix}/sitemap/{id}.xml
-    // When a sitemap module exports generateSitemaps, the base URL (e.g. /products/sitemap.xml)
-    // is no longer served. Instead, individual sitemaps are served at /products/sitemap/{id}.xml.
-    if (
-      metaRoute.type === "sitemap" &&
-      metaRoute.isDynamic &&
-      typeof metaRoute.module.generateSitemaps === "function"
-    ) {
-      const sitemapPrefix = metaRoute.servedUrl.slice(0, -4); // strip ".xml"
-      // Match exactly /{prefix}/{id}.xml — one segment only (no slashes in id)
-      if (cleanPathname.startsWith(sitemapPrefix + "/") && cleanPathname.endsWith(".xml")) {
-        const rawId = cleanPathname.slice(sitemapPrefix.length + 1, -4);
-        if (rawId.includes("/")) continue; // multi-segment — not a paginated sitemap
-        const sitemaps = await metaRoute.module.generateSitemaps();
-        const matched = sitemaps.find(function(s) { return String(s.id) === rawId; });
-        if (!matched) return new Response("Not Found", { status: 404 });
-        // Pass the original typed id from generateSitemaps() so numeric IDs stay numeric.
-        // TODO: wrap with makeThenableParams-style Promise when upgrading to Next.js 16
-        // full-Promise param semantics (id becomes Promise<string> in v16).
-        const result = await metaRoute.module.default({ id: matched.id });
-        if (result instanceof Response) return result;
-        return new Response(sitemapToXml(result), {
-          headers: { "Content-Type": metaRoute.contentType },
-        });
-      }
-      // Skip — the base servedUrl is not served when generateSitemaps exists
-      continue;
-    }
-    // Match metadata route — use pattern matching for dynamic segments,
-    // strict equality for static paths.
-    var _metaParams = null;
-    if (metaRoute.patternParts) {
-      var _metaUrlParts = cleanPathname.split("/").filter(Boolean);
-      _metaParams = __matchAppRscRoutePattern(_metaUrlParts, metaRoute.patternParts);
-      if (!_metaParams) continue;
-    } else if (cleanPathname !== metaRoute.servedUrl) {
-      continue;
-    }
-    if (metaRoute.isDynamic) {
-      // Dynamic metadata route — call the default export and serialize
-      const metaFn = metaRoute.module.default;
-      if (typeof metaFn === "function") {
-        const result = await metaFn({ params: makeThenableParams(_metaParams || {}) });
-        let body;
-        // If it's already a Response (e.g., ImageResponse), return directly
-        if (result instanceof Response) return result;
-        // Serialize based on type
-        if (metaRoute.type === "sitemap") body = sitemapToXml(result);
-        else if (metaRoute.type === "robots") body = robotsToText(result);
-        else if (metaRoute.type === "manifest") body = manifestToJson(result);
-        else body = JSON.stringify(result);
-        return new Response(body, {
-          headers: { "Content-Type": metaRoute.contentType },
-        });
-      }
-    } else {
-      // Static metadata file — decode from embedded base64 data
-      try {
-        const binary = atob(metaRoute.fileDataBase64);
-        const bytes = new Uint8Array(binary.length);
-        for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
-        return new Response(bytes, {
-          headers: {
-            "Content-Type": metaRoute.contentType,
-            "Cache-Control": "public, max-age=0, must-revalidate",
-          },
-        });
-      } catch {
-        return new Response("Not Found", { status: 404 });
-      }
-    }
-  }
+  const metadataRouteResponse = await __handleMetadataRouteRequest({
+    metadataRoutes,
+    cleanPathname,
+    makeThenableParams,
+  });
+  if (metadataRouteResponse) return metadataRouteResponse;
 
   // Serve public/ files as filesystem routes after middleware and before
   // afterFiles/fallback rewrites, matching Next.js routing semantics.
-  if (
-    (request.method === "GET" || request.method === "HEAD") &&
-    !pathname.endsWith(".rsc") &&
-    __publicFiles.has(cleanPathname)
-  ) {
+  const __publicFileResponse = resolvePublicFileRoute({
+    cleanPathname,
+    middlewareContext: _mwCtx,
+    pathname,
+    publicFiles: __publicFiles,
+    request,
+  });
+  if (__publicFileResponse) {
     __clearRequestContext();
-    return __createStaticFileSignal(cleanPathname, _mwCtx);
+    return __publicFileResponse;
   }
 
   // Set navigation context for Server Components.
@@ -3407,7 +2768,11 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         });
       },
       scheduleBackgroundRegeneration(key, renderFn) {
-        __triggerBackgroundRegeneration(key, renderFn, { routePath: route.pattern, routeType: "render" });
+        __triggerBackgroundRegeneration(key, renderFn, {
+          routerKind: "App Router",
+          routePath: route.pattern,
+          routeType: "render",
+        });
       },
     });
     if (__cachedPageResponse) {
@@ -3559,6 +2924,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       __clearRequestContext();
     },
     consumeDynamicUsage,
+    consumeInvalidDynamicUsageError,
     createRscOnErrorHandler(pathname, routePath) {
       return createRscOnErrorHandler(request, pathname, routePath);
     },
@@ -3742,16 +3108,16 @@ function renderToReadableStream(model, options) {
 }
 import { createElement } from "react";
 import { setNavigationContext as _setNavigationContextOrig, getNavigationContext as _getNavigationContext } from "next/navigation";
-import { setHeadersContext, headersContextFromRequest, getDraftModeCookieHeader, getAndClearPendingCookies, consumeDynamicUsage, markDynamicUsage, getHeadersContext, setHeadersAccessPhase } from "next/headers";
+import { setHeadersContext, headersContextFromRequest, getDraftModeCookieHeader, getAndClearPendingCookies, consumeDynamicUsage, consumeInvalidDynamicUsageError, markDynamicUsage, getHeadersContext, setHeadersAccessPhase } from "next/headers";
 import { mergeMetadata, resolveModuleMetadata, mergeViewport, resolveModuleViewport } from "vinext/metadata";
 
 
-
-import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, matchHeaders, isExternalUrl, proxyExternalRequest, sanitizeDestination } from "<ROOT>/packages/vinext/src/config/config-matchers.js";
+import { handleMetadataRouteRequest as __handleMetadataRouteRequest } from "<ROOT>/packages/vinext/src/server/metadata-route-response.js";
+import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, isExternalUrl, proxyExternalRequest, sanitizeDestination } from "<ROOT>/packages/vinext/src/config/config-matchers.js";
 import { decodePathParams as __decodePathParams, normalizePath as __normalizePath } from "<ROOT>/packages/vinext/src/server/normalize-path.js";
 import { normalizePathnameForRouteMatch as __normalizePathnameForRouteMatch, normalizePathnameForRouteMatchStrict as __normalizePathnameForRouteMatchStrict } from "<ROOT>/packages/vinext/src/routing/utils.js";
 import { buildRequestHeadersFromMiddlewareResponse as __buildRequestHeadersFromMiddlewareResponse } from "<ROOT>/packages/vinext/src/server/middleware-request-headers.js";
-import { validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
+import { applyConfigHeadersToResponse, resolvePublicFileRoute, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
 import { applyAppMiddleware as __applyAppMiddleware } from "<ROOT>/packages/vinext/src/server/app-middleware.js";
 import {
   dispatchAppRouteHandler as __dispatchAppRouteHandler,
@@ -3759,7 +3125,13 @@ import {
 import {
   handleProgressiveServerActionRequest as __handleProgressiveServerActionRequest,
   handleServerActionRscRequest as __handleServerActionRscRequest,
+  readActionBodyWithLimit as __readBodyWithLimit,
+  readActionFormDataWithLimit as __readFormDataWithLimit,
 } from "<ROOT>/packages/vinext/src/server/app-server-action-execution.js";
+import {
+  createRscOnErrorHandler as __createRscOnErrorHandler,
+  sanitizeErrorForClient as __sanitizeErrorForClient,
+} from "<ROOT>/packages/vinext/src/server/app-rsc-errors.js";
 import { readAppPageCacheResponse as __readAppPageCacheResponse } from "<ROOT>/packages/vinext/src/server/app-page-cache.js";
 import {
   buildAppPageFontLinkHeader as __buildAppPageFontLinkHeader,
@@ -3789,6 +3161,7 @@ import {
 } from "<ROOT>/packages/vinext/src/server/app-page-params.js";
 import {
   collectAppPageSearchParams as __collectAppPageSearchParams,
+  resolveActiveParallelRouteHeadInputs as __resolveActiveParallelRouteHeadInputs,
   resolveAppPageHead as __resolveAppPageHead,
 } from "<ROOT>/packages/vinext/src/server/app-page-head.js";
 import {
@@ -3810,23 +3183,32 @@ import {
   createStaticGenerationHeadersContext as __createStaticGenerationHeadersContext,
 } from "<ROOT>/packages/vinext/src/server/app-static-generation.js";
 import { buildPageCacheTags } from "<ROOT>/packages/vinext/src/server/implicit-tags.js";
-import { _consumeRequestScopedCacheLife, getCacheHandler } from "next/cache";
+import { _consumeRequestScopedCacheLife } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
 import { setRootParams as __setRootParams, pickRootParams as __pickRootParams } from "<ROOT>/packages/vinext/src/shims/root-params.js";
+import { makeThenableParams } from "<ROOT>/packages/vinext/src/shims/thenable-params.js";
 import { ensureFetchPatch as _ensureFetchPatch, getCollectedFetchTags, setCurrentFetchSoftTags } from "vinext/fetch-cache";
 import {
   createAppRscRouteMatcher as __createAppRscRouteMatcher,
-  matchAppRscRoutePattern as __matchAppRscRoutePattern,
 } from "<ROOT>/packages/vinext/src/server/app-rsc-route-matching.js";
 import {
   handleAppPrerenderEndpoint as __handleAppPrerenderEndpoint,
 } from "<ROOT>/packages/vinext/src/server/app-prerender-endpoints.js";
+import {
+  appIsrHtmlKey as __isrHtmlKey,
+  appIsrRscKey as __isrRscKey,
+  appIsrRouteKey as __isrRouteKey,
+  isrGet as __isrGet,
+  isrSet as __isrSet,
+  normalizeMountedSlotsHeader as __normalizeMountedSlotsHeader,
+  triggerBackgroundRegeneration as __triggerBackgroundRegeneration,
+} from "<ROOT>/packages/vinext/src/server/isr-cache.js";
 // Import server-only state module to register ALS-backed accessors.
 import "vinext/navigation-state";
+import { runWithPrerenderWorkUnit as __runWithPrerenderWorkUnit } from "<ROOT>/packages/vinext/src/server/prerender-work-unit-setup.js";
 import { runWithRequestContext as _runWithUnifiedCtx, createRequestContext as _createUnifiedCtx } from "vinext/unified-request-context";
 import { reportRequestError as _reportRequestError } from "vinext/instrumentation";
 import { flattenErrorCauses as __flattenErrorCauses } from "<ROOT>/packages/vinext/src/utils/error-cause.js";
-import { runWithPrerenderWorkUnit as __runWithPrerenderWorkUnit } from "<ROOT>/packages/vinext/src/server/prerender-work-unit-setup.js";
 import { getSSRFontLinks as _getSSRFontLinks, getSSRFontStyles as _getSSRFontStylesGoogle, getSSRFontPreloads as _getSSRFontPreloadsGoogle } from "next/font/google";
 import { getSSRFontStyles as _getSSRFontStylesLocal, getSSRFontPreloads as _getSSRFontPreloadsLocal } from "next/font/local";
 function _getSSRFontStyles() { return [..._getSSRFontStylesGoogle(), ..._getSSRFontStylesLocal()]; }
@@ -3863,25 +3245,6 @@ function __clearRequestContext() {
   // setNavigationContext(null) already clears root params internally
 }
 
-// ISR cache is disabled in dev mode — every request re-renders fresh,
-// matching Next.js dev behavior. Cache-Control headers are still emitted
-// based on export const revalidate for testing purposes.
-// Production ISR uses the MemoryCacheHandler (or configured KV handler).
-//
-// These helpers are inlined instead of imported from isr-cache.js because
-// the virtual RSC entry module runs in the RSC Vite environment which
-// cannot use dynamic imports at the module-evaluation level for server-only
-// modules, and direct imports must use the pre-computed absolute paths.
-async function __isrGet(key) {
-  const handler = getCacheHandler();
-  const result = await handler.get(key);
-  if (!result || !result.value) return null;
-  return { value: result, isStale: result.cacheState === "stale" };
-}
-async function __isrSet(key, data, revalidateSeconds, tags) {
-  const handler = getCacheHandler();
-  await handler.set(key, data, { revalidate: revalidateSeconds, tags: Array.isArray(tags) ? tags : [] });
-}
 // Note: cache entries are written with \`headers: undefined\`. Next.js stores
 // response headers (e.g. set-cookie from cookies().set() during render) in the
 // cache entry so they can be replayed on HIT. We don't do this because:
@@ -3892,82 +3255,6 @@ async function __isrSet(key, data, revalidateSeconds, tags) {
 // In practice this means ISR-cached responses won't replay render-time set-cookie
 // headers — but that case is already prevented by the dynamic-usage opt-out.
 // TODO: capture render-time response headers for full Next.js parity.
-const __pendingRegenerations = new Map();
-function __triggerBackgroundRegeneration(key, renderFn, errorContext) {
-  if (__pendingRegenerations.has(key)) return;
-  const promise = renderFn()
-    .catch((err) => {
-      console.error("[vinext] ISR regen failed for " + key + ":", err);
-      if (errorContext) {
-        void _reportRequestError(
-          err instanceof Error ? err : new Error(String(err)),
-          { path: key, method: "GET", headers: {} },
-          {
-            routerKind: "App Router",
-            routePath: errorContext.routePath,
-            routeType: errorContext.routeType,
-            revalidateReason: "stale",
-          },
-        );
-      }
-    })
-    .finally(() => __pendingRegenerations.delete(key));
-  __pendingRegenerations.set(key, promise);
-  const ctx = _getRequestExecutionContext();
-  if (ctx && typeof ctx.waitUntil === "function") ctx.waitUntil(promise);
-}
-// HTML and RSC are stored under separate keys — matching Next.js's file-system
-// layout (.html / .rsc) — so each request type reads and writes its own key
-// independently with no races or partial-entry sentinels.
-//
-// Key format: "app:<buildId>:<pathname>:<suffix>"
-// Long-pathname fallback: "app:<buildId>:__hash:<fnv1a64(pathname)>:<suffix>"
-// Without buildId (should not happen in production): "app:<pathname>:<suffix>"
-// The 200-char threshold keeps the full key well under Cloudflare KV's 512-byte limit
-// even after adding the build ID and suffix. FNV-1a 64 is used for the hash (two
-// 32-bit rounds) to give a ~64-bit output with negligible collision probability for
-// realistic pathname lengths.
-// Keep prefix construction and hashing logic in sync with isrCacheKey() in server/isr-cache.ts.
-function __isrFnv1a64(s) {
-  // h1 uses the standard FNV-1a 32-bit offset basis (0x811c9dc5).
-  let h1 = 0x811c9dc5;
-  for (let i = 0; i < s.length; i++) { h1 ^= s.charCodeAt(i); h1 = (h1 * 0x01000193) >>> 0; }
-  // h2 uses a different seed (0x050c5d1f — the FNV-1a hash of the string "vinext")
-  // so the two rounds are independently seeded and their outputs are decorrelated.
-  // Concatenating two independently-seeded 32-bit FNV-1a hashes gives an effective
-  // 64-bit hash. A random non-standard seed would also work; we derive it from a
-  // fixed string so the choice is auditable and deterministic across rebuilds.
-  let h2 = 0x050c5d1f;
-  for (let i = 0; i < s.length; i++) { h2 ^= s.charCodeAt(i); h2 = (h2 * 0x01000193) >>> 0; }
-  return h1.toString(36) + h2.toString(36);
-}
-function __isrCacheKey(pathname, suffix) {
-  const normalized = pathname === "/" ? "/" : pathname.replace(/\\/$/, "");
-  // __VINEXT_BUILD_ID is replaced at compile time by Vite's define plugin.
-  const buildId = process.env.__VINEXT_BUILD_ID;
-  const prefix = buildId ? "app:" + buildId : "app";
-  const key = prefix + ":" + normalized + ":" + suffix;
-  if (key.length <= 200) return key;
-  // Pathname too long — hash it to keep under KV's 512-byte key limit.
-  return prefix + ":__hash:" + __isrFnv1a64(normalized) + ":" + suffix;
-}
-function __isrHtmlKey(pathname) { return __isrCacheKey(pathname, "html"); }
-function __isrRscKey(pathname, mountedSlotsHeader) {
-  if (!mountedSlotsHeader) return __isrCacheKey(pathname, "rsc");
-  return __isrCacheKey(pathname, "rsc:" + __isrFnv1a64(mountedSlotsHeader));
-}
-function __normalizeMountedSlotsHeader(raw) {
-  if (!raw) return null;
-  const normalized = Array.from(
-    new Set(
-      raw
-        .split(/\\s+/)
-        .filter(Boolean),
-    ),
-  ).sort().join(" ");
-  return normalized || null;
-}
-function __isrRouteKey(pathname) { return __isrCacheKey(pathname, "route"); }
 // Verbose cache logging — opt in with NEXT_PRIVATE_DEBUG_CACHE=1.
 // Matches the env var Next.js uses for its own cache debug output so operators
 // have a single knob for all cache tracing.
@@ -3985,124 +3272,6 @@ const __classDebug = process.env.VINEXT_DEBUG_CLASSIFICATION
     }
   : undefined;
 
-// Normalize null-prototype objects from route-pattern matching into thenable objects
-// that work both as Promises (for Next.js 15+ async params) and as plain
-// objects with synchronous property access (for pre-15 code like params.id).
-//
-// route-pattern matching uses Object.create(null), producing objects without
-// Object.prototype. The RSC serializer rejects these. Spreading ({...obj})
-// restores a normal prototype. Object.assign onto the Promise preserves
-// synchronous property access (params.id, params.slug) that existing
-// components and test fixtures rely on.
-function makeThenableParams(obj) {
-  const plain = { ...obj };
-  return Object.assign(Promise.resolve(plain), plain);
-}
-
-// djb2 hash — matches Next.js's stringHash for digest generation.
-// Produces a stable numeric string from error message + stack.
-function __errorDigest(str) {
-  let hash = 5381;
-  for (let i = str.length - 1; i >= 0; i--) {
-    hash = (hash * 33) ^ str.charCodeAt(i);
-  }
-  return (hash >>> 0).toString();
-}
-
-// Sanitize an error for client consumption. In production, replaces the error
-// with a generic Error that only carries a digest hash (matching Next.js
-// behavior). In development, returns the original error for debugging.
-// Navigation errors (redirect, notFound, etc.) are always passed through
-// unchanged since their digests are used for client-side routing.
-function __sanitizeErrorForClient(error) {
-  // Navigation errors must pass through with their digest intact
-  if (__resolveAppPageSpecialError(error)) {
-    return error;
-  }
-  // In development, pass through the original error for debugging
-  if (process.env.NODE_ENV !== "production") {
-    return error;
-  }
-  // In production, create a sanitized error with only a digest hash
-  const msg = error instanceof Error ? error.message : String(error);
-  const stack = error instanceof Error ? (error.stack || "") : "";
-  const sanitized = new Error(
-    "An error occurred in the Server Components render. " +
-    "The specific message is omitted in production builds to avoid leaking sensitive details. " +
-    "A digest property is included on this error instance which may provide additional details about the nature of the error."
-  );
-  sanitized.digest = __errorDigest(msg + stack);
-  return sanitized;
-}
-
-// onError callback for renderToReadableStream — preserves the digest for
-// Next.js navigation errors (redirect, notFound, forbidden, unauthorized)
-// thrown during RSC streaming (e.g. inside Suspense boundaries).
-// For non-navigation errors in production, generates a digest hash so the
-// error can be correlated with server logs without leaking details.
-function rscOnError(error, requestInfo, errorContext) {
-  if (error && typeof error === "object" && "digest" in error) {
-    return String(error.digest);
-  }
-
-  // In dev, detect the "Only plain objects" RSC serialization error and emit
-  // an actionable hint. This error occurs when a Server Component passes a
-  // class instance, ES module namespace object, or null-prototype object as a
-  // prop to a Client Component.
-  //
-  // Root cause: Vite bundles modules as true ESM (module namespace objects
-  // have a null-like internal slot), while Next.js's webpack build produces
-  // plain CJS-wrapped objects with __esModule:true. React's RSC serializer
-  // accepts the latter as plain objects but rejects the former — which means
-  // code that accidentally passes "import * as X" works in webpack/Next.js
-  // but correctly fails in vinext.
-  //
-  // Common triggers:
-  //   - "import * as utils from './utils'" passed as a prop
-  //   - class instances (new Foo()) passed as props
-  //   - Date / Map / Set instances passed as props
-  //   - Objects with Object.create(null) (null prototype)
-  if (
-    process.env.NODE_ENV !== "production" &&
-    error instanceof Error &&
-    error.message.includes("Only plain objects, and a few built-ins, can be passed to Client Components")
-  ) {
-    console.error(
-      "[vinext] RSC serialization error: a non-plain object was passed from a Server Component to a Client Component.\\n" +
-      "\\n" +
-      "Common causes:\\n" +
-      "  * Passing a module namespace (import * as X) directly as a prop.\\n" +
-      "    Unlike Next.js (webpack), Vite produces real ESM module namespace objects\\n" +
-      "    which are not serializable. Fix: pass individual values instead,\\n" +
-      "    e.g. <Comp value={module.value} />\\n" +
-      "  * Passing a class instance (new Foo()) as a prop.\\n" +
-      "    Fix: convert to a plain object, e.g. { id: foo.id, name: foo.name }\\n" +
-      "  * Passing a Date, Map, or Set. Use .toISOString(), [...map.entries()], etc.\\n" +
-      "  * Passing Object.create(null). Use { ...obj } to restore a prototype.\\n" +
-      "\\n" +
-      "Original error:",
-      error.message,
-    );
-    return undefined;
-  }
-
-  if (requestInfo && errorContext && error) {
-    _reportRequestError(
-      error instanceof Error ? error : new Error(String(error)),
-      requestInfo,
-      errorContext,
-    );
-  }
-
-  // In production, generate a digest hash for non-navigation errors
-  if (process.env.NODE_ENV === "production" && error) {
-    const msg = error instanceof Error ? error.message : String(error);
-    const stack = error instanceof Error ? (error.stack || "") : "";
-    return __errorDigest(msg + stack);
-  }
-  return undefined;
-}
-
 function createRscOnErrorHandler(request, pathname, routePath) {
   const requestInfo = {
     path: pathname,
@@ -4114,9 +3283,11 @@ function createRscOnErrorHandler(request, pathname, routePath) {
     routePath: routePath || pathname,
     routeType: "render",
   };
-  return function(error) {
-    return rscOnError(error, requestInfo, errorContext);
-  };
+  return __createRscOnErrorHandler({
+    errorContext,
+    reportRequestError: _reportRequestError,
+    requestInfo,
+  });
 }
 
 import * as mod_0 from "/tmp/test/app/page.tsx";
@@ -4308,6 +3479,7 @@ async function renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, req
     makeThenableParams,
     matchedParams: opts?.matchedParams ?? route?.params ?? {},
     middlewareContext: middlewareContext ?? __APP_PAGE_EMPTY_MW_CTX,
+    metadataRoutes,
     requestUrl: request.url,
     resolveChildSegments: __resolveAppPageChildSegments,
     rootForbiddenModule: rootForbiddenModule,
@@ -4355,6 +3527,7 @@ async function renderErrorBoundaryPage(route, error, isRscRequest, request, matc
     makeThenableParams,
     matchedParams: matchedParams ?? route?.params ?? {},
     middlewareContext: middlewareContext ?? __APP_PAGE_EMPTY_MW_CTX,
+    metadataRoutes,
     requestUrl: request.url,
     resolveChildSegments: __resolveAppPageChildSegments,
     rootLayouts: rootLayouts,
@@ -4367,21 +3540,6 @@ async function renderErrorBoundaryPage(route, error, isRscRequest, request, matc
 
 function matchRoute(url) {
   return __routeMatcher.matchRoute(url);
-}
-
-function __createStaticFileSignal(pathname, _mwCtx) {
-  const headers = new Headers({
-    "x-vinext-static-file": encodeURIComponent(pathname),
-  });
-  if (_mwCtx.headers) {
-    for (const [key, value] of _mwCtx.headers) {
-      headers.append(key, value);
-    }
-  }
-  return new Response(null, {
-    status: _mwCtx.status ?? 200,
-    headers,
-  });
 }
 
 /**
@@ -4420,18 +3578,30 @@ async function buildPageElements(route, params, routePath, pageRequest) {
     };
   }
 
-  const __headResult = await __resolveAppPageHead({
+  const {
+    hasSearchParams,
+    metadata: resolvedMetadata,
+    pageSearchParams,
+    viewport: resolvedViewport,
+  } = await __resolveAppPageHead({
     layoutModules: route.layouts,
     layoutTreePositions: route.layoutTreePositions,
+    metadataRoutes,
     pageModule: route.page,
+    parallelRoutes: __resolveActiveParallelRouteHeadInputs({
+      interceptLayouts: opts?.interceptLayouts ?? null,
+      interceptPage: opts?.interceptPage ?? null,
+      interceptParams: opts?.interceptParams ?? null,
+      interceptSlotKey: opts?.interceptSlotKey ?? null,
+      params,
+      routeSegments: route.routeSegments,
+      slots: route.slots,
+    }),
     params,
+    routePath: route.pattern,
     routeSegments: route.routeSegments,
     searchParams,
   });
-  const spObj = __headResult.searchParamsObject;
-  const hasSearchParams = __headResult.hasSearchParams;
-  const resolvedMetadata = __headResult.metadata;
-  const resolvedViewport = __headResult.viewport;
 
   // Build the route tree from the leaf page, then delegate the boundary/layout/
   // template/segment wiring to a typed runtime helper so the generated entry
@@ -4441,7 +3611,7 @@ async function buildPageElements(route, params, routePath, pageRequest) {
     // Always provide searchParams prop when the URL object is available, even
     // when the query string is empty -- pages that do "await searchParams" need
     // it to be a thenable rather than undefined.
-    pageProps.searchParams = makeThenableParams(spObj);
+    pageProps.searchParams = makeThenableParams(pageSearchParams);
     // If the URL has query parameters, mark the page as dynamic.
     // In Next.js, only accessing the searchParams prop signals dynamic usage,
     // but a Proxy-based approach doesn't work here because React's RSC debug
@@ -4472,6 +3642,8 @@ async function buildPageElements(route, params, routePath, pageRequest) {
     interceptionContext: opts?.interceptionContext ?? null,
     routePath,
     rootNotFoundModule: null,
+    rootForbiddenModule: null,
+    rootUnauthorizedModule: null,
     route,
     slotOverrides:
       opts && opts.interceptSlotKey && opts.interceptPage
@@ -4591,63 +3763,6 @@ function __buildPostMwRequestContext(request) {
  */
 var __MAX_ACTION_BODY_SIZE = 1048576;
 
-/**
- * Read a request body as text with a size limit.
- * Enforces the limit on the actual byte stream to prevent bypasses
- * via chunked transfer-encoding where Content-Length is absent or spoofed.
- */
-async function __readBodyWithLimit(request, maxBytes) {
-  if (!request.body) return "";
-  var reader = request.body.getReader();
-  var decoder = new TextDecoder();
-  var chunks = [];
-  var totalSize = 0;
-  for (;;) {
-    var result = await reader.read();
-    if (result.done) break;
-    totalSize += result.value.byteLength;
-    if (totalSize > maxBytes) {
-      reader.cancel();
-      throw new Error("Request body too large");
-    }
-    chunks.push(decoder.decode(result.value, { stream: true }));
-  }
-  chunks.push(decoder.decode());
-  return chunks.join("");
-}
-
-/**
- * Read a request body as FormData with a size limit.
- * Consumes the body stream with a byte counter and then parses the
- * collected bytes as multipart form data via the Response constructor.
- */
-async function __readFormDataWithLimit(request, maxBytes) {
-  if (!request.body) return new FormData();
-  var reader = request.body.getReader();
-  var chunks = [];
-  var totalSize = 0;
-  for (;;) {
-    var result = await reader.read();
-    if (result.done) break;
-    totalSize += result.value.byteLength;
-    if (totalSize > maxBytes) {
-      reader.cancel();
-      throw new Error("Request body too large");
-    }
-    chunks.push(result.value);
-  }
-  // Reconstruct a Response with the original Content-Type so that
-  // the FormData parser can handle multipart boundaries correctly.
-  var combined = new Uint8Array(totalSize);
-  var offset = 0;
-  for (var chunk of chunks) {
-    combined.set(chunk, offset);
-    offset += chunk.byteLength;
-  }
-  var contentType = request.headers.get("content-type") || "";
-  return new Response(combined, { headers: { "Content-Type": contentType } }).formData();
-}
-
 // Map from route pattern to generateStaticParams function.
 // Used by the prerender phase to enumerate dynamic route URLs without
 // loading route modules via the dev server.
@@ -4658,6 +3773,9 @@ export const generateStaticParamsMap = {
 // so they are excluded here. Supporting layout-level generateStaticParams requires
 // scanning layout.tsx files separately and including them in this map.
   "/blog/:slug": mod_3?.generateStaticParams ?? null,
+};
+const rootParamNamesMap = {
+
 };
 
 export default async function handler(request, ctx) {
@@ -4705,21 +3823,11 @@ export default async function handler(request, ctx) {
         let pathname;
         try { pathname = __normalizePath(__normalizePathnameForRouteMatch(url.pathname)); } catch { pathname = url.pathname; }
         
-        const extraHeaders = matchHeaders(pathname, __configHeaders, __reqCtx);
-        for (const h of extraHeaders) {
-          // Use append() for headers where multiple values must coexist
-          // (Vary, Set-Cookie). Using set() on these would destroy
-          // existing values like "Vary: RSC, Accept" which are critical
-          // for correct CDN caching behavior.
-          const lk = h.key.toLowerCase();
-          if (lk === "vary" || lk === "set-cookie") {
-            response.headers.append(h.key, h.value);
-          } else if (!response.headers.has(lk)) {
-            // Middleware headers take precedence: skip config keys already
-            // set by middleware so middleware headers always win.
-            response.headers.set(h.key, h.value);
-          }
-        }
+        applyConfigHeadersToResponse(response.headers, {
+          configHeaders: __configHeaders,
+          pathname,
+          requestContext: __reqCtx,
+        });
       }
     }
     return response;
@@ -4763,6 +3871,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     },
 
     pathname,
+    rootParamNamesByPattern: rootParamNamesMap,
     staticParamsMap: generateStaticParamsMap,
   });
   if (__prerenderEndpointResponse) return __prerenderEndpointResponse;
@@ -4840,90 +3949,25 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     return Response.redirect(new URL(__imgResult, url.origin).href, 302);
   }
 
-  // Handle metadata routes (sitemap.xml, robots.txt, manifest.webmanifest, etc.)
-  for (const metaRoute of metadataRoutes) {
-    // generateSitemaps() support — paginated sitemaps at /{prefix}/sitemap/{id}.xml
-    // When a sitemap module exports generateSitemaps, the base URL (e.g. /products/sitemap.xml)
-    // is no longer served. Instead, individual sitemaps are served at /products/sitemap/{id}.xml.
-    if (
-      metaRoute.type === "sitemap" &&
-      metaRoute.isDynamic &&
-      typeof metaRoute.module.generateSitemaps === "function"
-    ) {
-      const sitemapPrefix = metaRoute.servedUrl.slice(0, -4); // strip ".xml"
-      // Match exactly /{prefix}/{id}.xml — one segment only (no slashes in id)
-      if (cleanPathname.startsWith(sitemapPrefix + "/") && cleanPathname.endsWith(".xml")) {
-        const rawId = cleanPathname.slice(sitemapPrefix.length + 1, -4);
-        if (rawId.includes("/")) continue; // multi-segment — not a paginated sitemap
-        const sitemaps = await metaRoute.module.generateSitemaps();
-        const matched = sitemaps.find(function(s) { return String(s.id) === rawId; });
-        if (!matched) return new Response("Not Found", { status: 404 });
-        // Pass the original typed id from generateSitemaps() so numeric IDs stay numeric.
-        // TODO: wrap with makeThenableParams-style Promise when upgrading to Next.js 16
-        // full-Promise param semantics (id becomes Promise<string> in v16).
-        const result = await metaRoute.module.default({ id: matched.id });
-        if (result instanceof Response) return result;
-        return new Response(sitemapToXml(result), {
-          headers: { "Content-Type": metaRoute.contentType },
-        });
-      }
-      // Skip — the base servedUrl is not served when generateSitemaps exists
-      continue;
-    }
-    // Match metadata route — use pattern matching for dynamic segments,
-    // strict equality for static paths.
-    var _metaParams = null;
-    if (metaRoute.patternParts) {
-      var _metaUrlParts = cleanPathname.split("/").filter(Boolean);
-      _metaParams = __matchAppRscRoutePattern(_metaUrlParts, metaRoute.patternParts);
-      if (!_metaParams) continue;
-    } else if (cleanPathname !== metaRoute.servedUrl) {
-      continue;
-    }
-    if (metaRoute.isDynamic) {
-      // Dynamic metadata route — call the default export and serialize
-      const metaFn = metaRoute.module.default;
-      if (typeof metaFn === "function") {
-        const result = await metaFn({ params: makeThenableParams(_metaParams || {}) });
-        let body;
-        // If it's already a Response (e.g., ImageResponse), return directly
-        if (result instanceof Response) return result;
-        // Serialize based on type
-        if (metaRoute.type === "sitemap") body = sitemapToXml(result);
-        else if (metaRoute.type === "robots") body = robotsToText(result);
-        else if (metaRoute.type === "manifest") body = manifestToJson(result);
-        else body = JSON.stringify(result);
-        return new Response(body, {
-          headers: { "Content-Type": metaRoute.contentType },
-        });
-      }
-    } else {
-      // Static metadata file — decode from embedded base64 data
-      try {
-        const binary = atob(metaRoute.fileDataBase64);
-        const bytes = new Uint8Array(binary.length);
-        for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
-        return new Response(bytes, {
-          headers: {
-            "Content-Type": metaRoute.contentType,
-            "Cache-Control": "public, max-age=0, must-revalidate",
-          },
-        });
-      } catch {
-        return new Response("Not Found", { status: 404 });
-      }
-    }
-  }
+  const metadataRouteResponse = await __handleMetadataRouteRequest({
+    metadataRoutes,
+    cleanPathname,
+    makeThenableParams,
+  });
+  if (metadataRouteResponse) return metadataRouteResponse;
 
   // Serve public/ files as filesystem routes after middleware and before
   // afterFiles/fallback rewrites, matching Next.js routing semantics.
-  if (
-    (request.method === "GET" || request.method === "HEAD") &&
-    !pathname.endsWith(".rsc") &&
-    __publicFiles.has(cleanPathname)
-  ) {
+  const __publicFileResponse = resolvePublicFileRoute({
+    cleanPathname,
+    middlewareContext: _mwCtx,
+    pathname,
+    publicFiles: __publicFiles,
+    request,
+  });
+  if (__publicFileResponse) {
     __clearRequestContext();
-    return __createStaticFileSignal(cleanPathname, _mwCtx);
+    return __publicFileResponse;
   }
 
   // Set navigation context for Server Components.
@@ -5265,7 +4309,11 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         });
       },
       scheduleBackgroundRegeneration(key, renderFn) {
-        __triggerBackgroundRegeneration(key, renderFn, { routePath: route.pattern, routeType: "render" });
+        __triggerBackgroundRegeneration(key, renderFn, {
+          routerKind: "App Router",
+          routePath: route.pattern,
+          routeType: "render",
+        });
       },
     });
     if (__cachedPageResponse) {
@@ -5417,6 +4465,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       __clearRequestContext();
     },
     consumeDynamicUsage,
+    consumeInvalidDynamicUsageError,
     createRscOnErrorHandler(pathname, routePath) {
       return createRscOnErrorHandler(request, pathname, routePath);
     },
@@ -5600,16 +4649,16 @@ function renderToReadableStream(model, options) {
 }
 import { createElement } from "react";
 import { setNavigationContext as _setNavigationContextOrig, getNavigationContext as _getNavigationContext } from "next/navigation";
-import { setHeadersContext, headersContextFromRequest, getDraftModeCookieHeader, getAndClearPendingCookies, consumeDynamicUsage, markDynamicUsage, getHeadersContext, setHeadersAccessPhase } from "next/headers";
+import { setHeadersContext, headersContextFromRequest, getDraftModeCookieHeader, getAndClearPendingCookies, consumeDynamicUsage, consumeInvalidDynamicUsageError, markDynamicUsage, getHeadersContext, setHeadersAccessPhase } from "next/headers";
 import { mergeMetadata, resolveModuleMetadata, mergeViewport, resolveModuleViewport } from "vinext/metadata";
 
 import * as _instrumentation from "/tmp/test/instrumentation.ts";
-
-import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, matchHeaders, isExternalUrl, proxyExternalRequest, sanitizeDestination } from "<ROOT>/packages/vinext/src/config/config-matchers.js";
+import { handleMetadataRouteRequest as __handleMetadataRouteRequest } from "<ROOT>/packages/vinext/src/server/metadata-route-response.js";
+import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, isExternalUrl, proxyExternalRequest, sanitizeDestination } from "<ROOT>/packages/vinext/src/config/config-matchers.js";
 import { decodePathParams as __decodePathParams, normalizePath as __normalizePath } from "<ROOT>/packages/vinext/src/server/normalize-path.js";
 import { normalizePathnameForRouteMatch as __normalizePathnameForRouteMatch, normalizePathnameForRouteMatchStrict as __normalizePathnameForRouteMatchStrict } from "<ROOT>/packages/vinext/src/routing/utils.js";
 import { buildRequestHeadersFromMiddlewareResponse as __buildRequestHeadersFromMiddlewareResponse } from "<ROOT>/packages/vinext/src/server/middleware-request-headers.js";
-import { validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
+import { applyConfigHeadersToResponse, resolvePublicFileRoute, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
 import { applyAppMiddleware as __applyAppMiddleware } from "<ROOT>/packages/vinext/src/server/app-middleware.js";
 import {
   dispatchAppRouteHandler as __dispatchAppRouteHandler,
@@ -5617,7 +4666,13 @@ import {
 import {
   handleProgressiveServerActionRequest as __handleProgressiveServerActionRequest,
   handleServerActionRscRequest as __handleServerActionRscRequest,
+  readActionBodyWithLimit as __readBodyWithLimit,
+  readActionFormDataWithLimit as __readFormDataWithLimit,
 } from "<ROOT>/packages/vinext/src/server/app-server-action-execution.js";
+import {
+  createRscOnErrorHandler as __createRscOnErrorHandler,
+  sanitizeErrorForClient as __sanitizeErrorForClient,
+} from "<ROOT>/packages/vinext/src/server/app-rsc-errors.js";
 import { readAppPageCacheResponse as __readAppPageCacheResponse } from "<ROOT>/packages/vinext/src/server/app-page-cache.js";
 import {
   buildAppPageFontLinkHeader as __buildAppPageFontLinkHeader,
@@ -5647,6 +4702,7 @@ import {
 } from "<ROOT>/packages/vinext/src/server/app-page-params.js";
 import {
   collectAppPageSearchParams as __collectAppPageSearchParams,
+  resolveActiveParallelRouteHeadInputs as __resolveActiveParallelRouteHeadInputs,
   resolveAppPageHead as __resolveAppPageHead,
 } from "<ROOT>/packages/vinext/src/server/app-page-head.js";
 import {
@@ -5668,23 +4724,32 @@ import {
   createStaticGenerationHeadersContext as __createStaticGenerationHeadersContext,
 } from "<ROOT>/packages/vinext/src/server/app-static-generation.js";
 import { buildPageCacheTags } from "<ROOT>/packages/vinext/src/server/implicit-tags.js";
-import { _consumeRequestScopedCacheLife, getCacheHandler } from "next/cache";
+import { _consumeRequestScopedCacheLife } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
 import { setRootParams as __setRootParams, pickRootParams as __pickRootParams } from "<ROOT>/packages/vinext/src/shims/root-params.js";
+import { makeThenableParams } from "<ROOT>/packages/vinext/src/shims/thenable-params.js";
 import { ensureFetchPatch as _ensureFetchPatch, getCollectedFetchTags, setCurrentFetchSoftTags } from "vinext/fetch-cache";
 import {
   createAppRscRouteMatcher as __createAppRscRouteMatcher,
-  matchAppRscRoutePattern as __matchAppRscRoutePattern,
 } from "<ROOT>/packages/vinext/src/server/app-rsc-route-matching.js";
 import {
   handleAppPrerenderEndpoint as __handleAppPrerenderEndpoint,
 } from "<ROOT>/packages/vinext/src/server/app-prerender-endpoints.js";
+import {
+  appIsrHtmlKey as __isrHtmlKey,
+  appIsrRscKey as __isrRscKey,
+  appIsrRouteKey as __isrRouteKey,
+  isrGet as __isrGet,
+  isrSet as __isrSet,
+  normalizeMountedSlotsHeader as __normalizeMountedSlotsHeader,
+  triggerBackgroundRegeneration as __triggerBackgroundRegeneration,
+} from "<ROOT>/packages/vinext/src/server/isr-cache.js";
 // Import server-only state module to register ALS-backed accessors.
 import "vinext/navigation-state";
+import { runWithPrerenderWorkUnit as __runWithPrerenderWorkUnit } from "<ROOT>/packages/vinext/src/server/prerender-work-unit-setup.js";
 import { runWithRequestContext as _runWithUnifiedCtx, createRequestContext as _createUnifiedCtx } from "vinext/unified-request-context";
 import { reportRequestError as _reportRequestError } from "vinext/instrumentation";
 import { flattenErrorCauses as __flattenErrorCauses } from "<ROOT>/packages/vinext/src/utils/error-cause.js";
-import { runWithPrerenderWorkUnit as __runWithPrerenderWorkUnit } from "<ROOT>/packages/vinext/src/server/prerender-work-unit-setup.js";
 import { getSSRFontLinks as _getSSRFontLinks, getSSRFontStyles as _getSSRFontStylesGoogle, getSSRFontPreloads as _getSSRFontPreloadsGoogle } from "next/font/google";
 import { getSSRFontStyles as _getSSRFontStylesLocal, getSSRFontPreloads as _getSSRFontPreloadsLocal } from "next/font/local";
 function _getSSRFontStyles() { return [..._getSSRFontStylesGoogle(), ..._getSSRFontStylesLocal()]; }
@@ -5721,25 +4786,6 @@ function __clearRequestContext() {
   // setNavigationContext(null) already clears root params internally
 }
 
-// ISR cache is disabled in dev mode — every request re-renders fresh,
-// matching Next.js dev behavior. Cache-Control headers are still emitted
-// based on export const revalidate for testing purposes.
-// Production ISR uses the MemoryCacheHandler (or configured KV handler).
-//
-// These helpers are inlined instead of imported from isr-cache.js because
-// the virtual RSC entry module runs in the RSC Vite environment which
-// cannot use dynamic imports at the module-evaluation level for server-only
-// modules, and direct imports must use the pre-computed absolute paths.
-async function __isrGet(key) {
-  const handler = getCacheHandler();
-  const result = await handler.get(key);
-  if (!result || !result.value) return null;
-  return { value: result, isStale: result.cacheState === "stale" };
-}
-async function __isrSet(key, data, revalidateSeconds, tags) {
-  const handler = getCacheHandler();
-  await handler.set(key, data, { revalidate: revalidateSeconds, tags: Array.isArray(tags) ? tags : [] });
-}
 // Note: cache entries are written with \`headers: undefined\`. Next.js stores
 // response headers (e.g. set-cookie from cookies().set() during render) in the
 // cache entry so they can be replayed on HIT. We don't do this because:
@@ -5750,82 +4796,6 @@ async function __isrSet(key, data, revalidateSeconds, tags) {
 // In practice this means ISR-cached responses won't replay render-time set-cookie
 // headers — but that case is already prevented by the dynamic-usage opt-out.
 // TODO: capture render-time response headers for full Next.js parity.
-const __pendingRegenerations = new Map();
-function __triggerBackgroundRegeneration(key, renderFn, errorContext) {
-  if (__pendingRegenerations.has(key)) return;
-  const promise = renderFn()
-    .catch((err) => {
-      console.error("[vinext] ISR regen failed for " + key + ":", err);
-      if (errorContext) {
-        void _reportRequestError(
-          err instanceof Error ? err : new Error(String(err)),
-          { path: key, method: "GET", headers: {} },
-          {
-            routerKind: "App Router",
-            routePath: errorContext.routePath,
-            routeType: errorContext.routeType,
-            revalidateReason: "stale",
-          },
-        );
-      }
-    })
-    .finally(() => __pendingRegenerations.delete(key));
-  __pendingRegenerations.set(key, promise);
-  const ctx = _getRequestExecutionContext();
-  if (ctx && typeof ctx.waitUntil === "function") ctx.waitUntil(promise);
-}
-// HTML and RSC are stored under separate keys — matching Next.js's file-system
-// layout (.html / .rsc) — so each request type reads and writes its own key
-// independently with no races or partial-entry sentinels.
-//
-// Key format: "app:<buildId>:<pathname>:<suffix>"
-// Long-pathname fallback: "app:<buildId>:__hash:<fnv1a64(pathname)>:<suffix>"
-// Without buildId (should not happen in production): "app:<pathname>:<suffix>"
-// The 200-char threshold keeps the full key well under Cloudflare KV's 512-byte limit
-// even after adding the build ID and suffix. FNV-1a 64 is used for the hash (two
-// 32-bit rounds) to give a ~64-bit output with negligible collision probability for
-// realistic pathname lengths.
-// Keep prefix construction and hashing logic in sync with isrCacheKey() in server/isr-cache.ts.
-function __isrFnv1a64(s) {
-  // h1 uses the standard FNV-1a 32-bit offset basis (0x811c9dc5).
-  let h1 = 0x811c9dc5;
-  for (let i = 0; i < s.length; i++) { h1 ^= s.charCodeAt(i); h1 = (h1 * 0x01000193) >>> 0; }
-  // h2 uses a different seed (0x050c5d1f — the FNV-1a hash of the string "vinext")
-  // so the two rounds are independently seeded and their outputs are decorrelated.
-  // Concatenating two independently-seeded 32-bit FNV-1a hashes gives an effective
-  // 64-bit hash. A random non-standard seed would also work; we derive it from a
-  // fixed string so the choice is auditable and deterministic across rebuilds.
-  let h2 = 0x050c5d1f;
-  for (let i = 0; i < s.length; i++) { h2 ^= s.charCodeAt(i); h2 = (h2 * 0x01000193) >>> 0; }
-  return h1.toString(36) + h2.toString(36);
-}
-function __isrCacheKey(pathname, suffix) {
-  const normalized = pathname === "/" ? "/" : pathname.replace(/\\/$/, "");
-  // __VINEXT_BUILD_ID is replaced at compile time by Vite's define plugin.
-  const buildId = process.env.__VINEXT_BUILD_ID;
-  const prefix = buildId ? "app:" + buildId : "app";
-  const key = prefix + ":" + normalized + ":" + suffix;
-  if (key.length <= 200) return key;
-  // Pathname too long — hash it to keep under KV's 512-byte key limit.
-  return prefix + ":__hash:" + __isrFnv1a64(normalized) + ":" + suffix;
-}
-function __isrHtmlKey(pathname) { return __isrCacheKey(pathname, "html"); }
-function __isrRscKey(pathname, mountedSlotsHeader) {
-  if (!mountedSlotsHeader) return __isrCacheKey(pathname, "rsc");
-  return __isrCacheKey(pathname, "rsc:" + __isrFnv1a64(mountedSlotsHeader));
-}
-function __normalizeMountedSlotsHeader(raw) {
-  if (!raw) return null;
-  const normalized = Array.from(
-    new Set(
-      raw
-        .split(/\\s+/)
-        .filter(Boolean),
-    ),
-  ).sort().join(" ");
-  return normalized || null;
-}
-function __isrRouteKey(pathname) { return __isrCacheKey(pathname, "route"); }
 // Verbose cache logging — opt in with NEXT_PRIVATE_DEBUG_CACHE=1.
 // Matches the env var Next.js uses for its own cache debug output so operators
 // have a single knob for all cache tracing.
@@ -5843,124 +4813,6 @@ const __classDebug = process.env.VINEXT_DEBUG_CLASSIFICATION
     }
   : undefined;
 
-// Normalize null-prototype objects from route-pattern matching into thenable objects
-// that work both as Promises (for Next.js 15+ async params) and as plain
-// objects with synchronous property access (for pre-15 code like params.id).
-//
-// route-pattern matching uses Object.create(null), producing objects without
-// Object.prototype. The RSC serializer rejects these. Spreading ({...obj})
-// restores a normal prototype. Object.assign onto the Promise preserves
-// synchronous property access (params.id, params.slug) that existing
-// components and test fixtures rely on.
-function makeThenableParams(obj) {
-  const plain = { ...obj };
-  return Object.assign(Promise.resolve(plain), plain);
-}
-
-// djb2 hash — matches Next.js's stringHash for digest generation.
-// Produces a stable numeric string from error message + stack.
-function __errorDigest(str) {
-  let hash = 5381;
-  for (let i = str.length - 1; i >= 0; i--) {
-    hash = (hash * 33) ^ str.charCodeAt(i);
-  }
-  return (hash >>> 0).toString();
-}
-
-// Sanitize an error for client consumption. In production, replaces the error
-// with a generic Error that only carries a digest hash (matching Next.js
-// behavior). In development, returns the original error for debugging.
-// Navigation errors (redirect, notFound, etc.) are always passed through
-// unchanged since their digests are used for client-side routing.
-function __sanitizeErrorForClient(error) {
-  // Navigation errors must pass through with their digest intact
-  if (__resolveAppPageSpecialError(error)) {
-    return error;
-  }
-  // In development, pass through the original error for debugging
-  if (process.env.NODE_ENV !== "production") {
-    return error;
-  }
-  // In production, create a sanitized error with only a digest hash
-  const msg = error instanceof Error ? error.message : String(error);
-  const stack = error instanceof Error ? (error.stack || "") : "";
-  const sanitized = new Error(
-    "An error occurred in the Server Components render. " +
-    "The specific message is omitted in production builds to avoid leaking sensitive details. " +
-    "A digest property is included on this error instance which may provide additional details about the nature of the error."
-  );
-  sanitized.digest = __errorDigest(msg + stack);
-  return sanitized;
-}
-
-// onError callback for renderToReadableStream — preserves the digest for
-// Next.js navigation errors (redirect, notFound, forbidden, unauthorized)
-// thrown during RSC streaming (e.g. inside Suspense boundaries).
-// For non-navigation errors in production, generates a digest hash so the
-// error can be correlated with server logs without leaking details.
-function rscOnError(error, requestInfo, errorContext) {
-  if (error && typeof error === "object" && "digest" in error) {
-    return String(error.digest);
-  }
-
-  // In dev, detect the "Only plain objects" RSC serialization error and emit
-  // an actionable hint. This error occurs when a Server Component passes a
-  // class instance, ES module namespace object, or null-prototype object as a
-  // prop to a Client Component.
-  //
-  // Root cause: Vite bundles modules as true ESM (module namespace objects
-  // have a null-like internal slot), while Next.js's webpack build produces
-  // plain CJS-wrapped objects with __esModule:true. React's RSC serializer
-  // accepts the latter as plain objects but rejects the former — which means
-  // code that accidentally passes "import * as X" works in webpack/Next.js
-  // but correctly fails in vinext.
-  //
-  // Common triggers:
-  //   - "import * as utils from './utils'" passed as a prop
-  //   - class instances (new Foo()) passed as props
-  //   - Date / Map / Set instances passed as props
-  //   - Objects with Object.create(null) (null prototype)
-  if (
-    process.env.NODE_ENV !== "production" &&
-    error instanceof Error &&
-    error.message.includes("Only plain objects, and a few built-ins, can be passed to Client Components")
-  ) {
-    console.error(
-      "[vinext] RSC serialization error: a non-plain object was passed from a Server Component to a Client Component.\\n" +
-      "\\n" +
-      "Common causes:\\n" +
-      "  * Passing a module namespace (import * as X) directly as a prop.\\n" +
-      "    Unlike Next.js (webpack), Vite produces real ESM module namespace objects\\n" +
-      "    which are not serializable. Fix: pass individual values instead,\\n" +
-      "    e.g. <Comp value={module.value} />\\n" +
-      "  * Passing a class instance (new Foo()) as a prop.\\n" +
-      "    Fix: convert to a plain object, e.g. { id: foo.id, name: foo.name }\\n" +
-      "  * Passing a Date, Map, or Set. Use .toISOString(), [...map.entries()], etc.\\n" +
-      "  * Passing Object.create(null). Use { ...obj } to restore a prototype.\\n" +
-      "\\n" +
-      "Original error:",
-      error.message,
-    );
-    return undefined;
-  }
-
-  if (requestInfo && errorContext && error) {
-    _reportRequestError(
-      error instanceof Error ? error : new Error(String(error)),
-      requestInfo,
-      errorContext,
-    );
-  }
-
-  // In production, generate a digest hash for non-navigation errors
-  if (process.env.NODE_ENV === "production" && error) {
-    const msg = error instanceof Error ? error.message : String(error);
-    const stack = error instanceof Error ? (error.stack || "") : "";
-    return __errorDigest(msg + stack);
-  }
-  return undefined;
-}
-
 function createRscOnErrorHandler(request, pathname, routePath) {
   const requestInfo = {
     path: pathname,
@@ -5972,9 +4824,11 @@ function createRscOnErrorHandler(request, pathname, routePath) {
     routePath: routePath || pathname,
     routeType: "render",
   };
-  return function(error) {
-    return rscOnError(error, requestInfo, errorContext);
-  };
+  return __createRscOnErrorHandler({
+    errorContext,
+    reportRequestError: _reportRequestError,
+    requestInfo,
+  });
 }
 
 import * as mod_0 from "/tmp/test/app/page.tsx";
@@ -6195,6 +5049,7 @@ async function renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, req
     makeThenableParams,
     matchedParams: opts?.matchedParams ?? route?.params ?? {},
     middlewareContext: middlewareContext ?? __APP_PAGE_EMPTY_MW_CTX,
+    metadataRoutes,
     requestUrl: request.url,
     resolveChildSegments: __resolveAppPageChildSegments,
     rootForbiddenModule: rootForbiddenModule,
@@ -6242,6 +5097,7 @@ async function renderErrorBoundaryPage(route, error, isRscRequest, request, matc
     makeThenableParams,
     matchedParams: matchedParams ?? route?.params ?? {},
     middlewareContext: middlewareContext ?? __APP_PAGE_EMPTY_MW_CTX,
+    metadataRoutes,
     requestUrl: request.url,
     resolveChildSegments: __resolveAppPageChildSegments,
     rootLayouts: rootLayouts,
@@ -6254,21 +5110,6 @@ async function renderErrorBoundaryPage(route, error, isRscRequest, request, matc
 
 function matchRoute(url) {
   return __routeMatcher.matchRoute(url);
-}
-
-function __createStaticFileSignal(pathname, _mwCtx) {
-  const headers = new Headers({
-    "x-vinext-static-file": encodeURIComponent(pathname),
-  });
-  if (_mwCtx.headers) {
-    for (const [key, value] of _mwCtx.headers) {
-      headers.append(key, value);
-    }
-  }
-  return new Response(null, {
-    status: _mwCtx.status ?? 200,
-    headers,
-  });
 }
 
 /**
@@ -6307,18 +5148,30 @@ async function buildPageElements(route, params, routePath, pageRequest) {
     };
   }
 
-  const __headResult = await __resolveAppPageHead({
+  const {
+    hasSearchParams,
+    metadata: resolvedMetadata,
+    pageSearchParams,
+    viewport: resolvedViewport,
+  } = await __resolveAppPageHead({
     layoutModules: route.layouts,
     layoutTreePositions: route.layoutTreePositions,
+    metadataRoutes,
     pageModule: route.page,
+    parallelRoutes: __resolveActiveParallelRouteHeadInputs({
+      interceptLayouts: opts?.interceptLayouts ?? null,
+      interceptPage: opts?.interceptPage ?? null,
+      interceptParams: opts?.interceptParams ?? null,
+      interceptSlotKey: opts?.interceptSlotKey ?? null,
+      params,
+      routeSegments: route.routeSegments,
+      slots: route.slots,
+    }),
     params,
+    routePath: route.pattern,
     routeSegments: route.routeSegments,
     searchParams,
   });
-  const spObj = __headResult.searchParamsObject;
-  const hasSearchParams = __headResult.hasSearchParams;
-  const resolvedMetadata = __headResult.metadata;
-  const resolvedViewport = __headResult.viewport;
 
   // Build the route tree from the leaf page, then delegate the boundary/layout/
   // template/segment wiring to a typed runtime helper so the generated entry
@@ -6328,7 +5181,7 @@ async function buildPageElements(route, params, routePath, pageRequest) {
     // Always provide searchParams prop when the URL object is available, even
     // when the query string is empty -- pages that do "await searchParams" need
     // it to be a thenable rather than undefined.
-    pageProps.searchParams = makeThenableParams(spObj);
+    pageProps.searchParams = makeThenableParams(pageSearchParams);
     // If the URL has query parameters, mark the page as dynamic.
     // In Next.js, only accessing the searchParams prop signals dynamic usage,
     // but a Proxy-based approach doesn't work here because React's RSC debug
@@ -6359,6 +5212,8 @@ async function buildPageElements(route, params, routePath, pageRequest) {
     interceptionContext: opts?.interceptionContext ?? null,
     routePath,
     rootNotFoundModule: null,
+    rootForbiddenModule: null,
+    rootUnauthorizedModule: null,
     route,
     slotOverrides:
       opts && opts.interceptSlotKey && opts.interceptPage
@@ -6478,63 +5333,6 @@ function __buildPostMwRequestContext(request) {
  */
 var __MAX_ACTION_BODY_SIZE = 1048576;
 
-/**
- * Read a request body as text with a size limit.
- * Enforces the limit on the actual byte stream to prevent bypasses
- * via chunked transfer-encoding where Content-Length is absent or spoofed.
- */
-async function __readBodyWithLimit(request, maxBytes) {
-  if (!request.body) return "";
-  var reader = request.body.getReader();
-  var decoder = new TextDecoder();
-  var chunks = [];
-  var totalSize = 0;
-  for (;;) {
-    var result = await reader.read();
-    if (result.done) break;
-    totalSize += result.value.byteLength;
-    if (totalSize > maxBytes) {
-      reader.cancel();
-      throw new Error("Request body too large");
-    }
-    chunks.push(decoder.decode(result.value, { stream: true }));
-  }
-  chunks.push(decoder.decode());
-  return chunks.join("");
-}
-
-/**
- * Read a request body as FormData with a size limit.
- * Consumes the body stream with a byte counter and then parses the
- * collected bytes as multipart form data via the Response constructor.
- */
-async function __readFormDataWithLimit(request, maxBytes) {
-  if (!request.body) return new FormData();
-  var reader = request.body.getReader();
-  var chunks = [];
-  var totalSize = 0;
-  for (;;) {
-    var result = await reader.read();
-    if (result.done) break;
-    totalSize += result.value.byteLength;
-    if (totalSize > maxBytes) {
-      reader.cancel();
-      throw new Error("Request body too large");
-    }
-    chunks.push(result.value);
-  }
-  // Reconstruct a Response with the original Content-Type so that
-  // the FormData parser can handle multipart boundaries correctly.
-  var combined = new Uint8Array(totalSize);
-  var offset = 0;
-  for (var chunk of chunks) {
-    combined.set(chunk, offset);
-    offset += chunk.byteLength;
-  }
-  var contentType = request.headers.get("content-type") || "";
-  return new Response(combined, { headers: { "Content-Type": contentType } }).formData();
-}
-
 // Map from route pattern to generateStaticParams function.
 // Used by the prerender phase to enumerate dynamic route URLs without
 // loading route modules via the dev server.
@@ -6545,6 +5343,9 @@ export const generateStaticParamsMap = {
 // so they are excluded here. Supporting layout-level generateStaticParams requires
 // scanning layout.tsx files separately and including them in this map.
   "/blog/:slug": mod_3?.generateStaticParams ?? null,
+};
+const rootParamNamesMap = {
+
 };
 
 export default async function handler(request, ctx) {
@@ -6595,21 +5396,11 @@ export default async function handler(request, ctx) {
         let pathname;
         try { pathname = __normalizePath(__normalizePathnameForRouteMatch(url.pathname)); } catch { pathname = url.pathname; }
         
-        const extraHeaders = matchHeaders(pathname, __configHeaders, __reqCtx);
-        for (const h of extraHeaders) {
-          // Use append() for headers where multiple values must coexist
-          // (Vary, Set-Cookie). Using set() on these would destroy
-          // existing values like "Vary: RSC, Accept" which are critical
-          // for correct CDN caching behavior.
-          const lk = h.key.toLowerCase();
-          if (lk === "vary" || lk === "set-cookie") {
-            response.headers.append(h.key, h.value);
-          } else if (!response.headers.has(lk)) {
-            // Middleware headers take precedence: skip config keys already
-            // set by middleware so middleware headers always win.
-            response.headers.set(h.key, h.value);
-          }
-        }
+        applyConfigHeadersToResponse(response.headers, {
+          configHeaders: __configHeaders,
+          pathname,
+          requestContext: __reqCtx,
+        });
       }
     }
     return response;
@@ -6653,6 +5444,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     },
 
     pathname,
+    rootParamNamesByPattern: rootParamNamesMap,
     staticParamsMap: generateStaticParamsMap,
   });
   if (__prerenderEndpointResponse) return __prerenderEndpointResponse;
@@ -6730,90 +5522,25 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     return Response.redirect(new URL(__imgResult, url.origin).href, 302);
   }
 
-  // Handle metadata routes (sitemap.xml, robots.txt, manifest.webmanifest, etc.)
-  for (const metaRoute of metadataRoutes) {
-    // generateSitemaps() support — paginated sitemaps at /{prefix}/sitemap/{id}.xml
-    // When a sitemap module exports generateSitemaps, the base URL (e.g. /products/sitemap.xml)
-    // is no longer served. Instead, individual sitemaps are served at /products/sitemap/{id}.xml.
-    if (
-      metaRoute.type === "sitemap" &&
-      metaRoute.isDynamic &&
-      typeof metaRoute.module.generateSitemaps === "function"
-    ) {
-      const sitemapPrefix = metaRoute.servedUrl.slice(0, -4); // strip ".xml"
-      // Match exactly /{prefix}/{id}.xml — one segment only (no slashes in id)
-      if (cleanPathname.startsWith(sitemapPrefix + "/") && cleanPathname.endsWith(".xml")) {
-        const rawId = cleanPathname.slice(sitemapPrefix.length + 1, -4);
-        if (rawId.includes("/")) continue; // multi-segment — not a paginated sitemap
-        const sitemaps = await metaRoute.module.generateSitemaps();
-        const matched = sitemaps.find(function(s) { return String(s.id) === rawId; });
-        if (!matched) return new Response("Not Found", { status: 404 });
-        // Pass the original typed id from generateSitemaps() so numeric IDs stay numeric.
-        // TODO: wrap with makeThenableParams-style Promise when upgrading to Next.js 16
-        // full-Promise param semantics (id becomes Promise<string> in v16).
-        const result = await metaRoute.module.default({ id: matched.id });
-        if (result instanceof Response) return result;
-        return new Response(sitemapToXml(result), {
-          headers: { "Content-Type": metaRoute.contentType },
-        });
-      }
-      // Skip — the base servedUrl is not served when generateSitemaps exists
-      continue;
-    }
-    // Match metadata route — use pattern matching for dynamic segments,
-    // strict equality for static paths.
-    var _metaParams = null;
-    if (metaRoute.patternParts) {
-      var _metaUrlParts = cleanPathname.split("/").filter(Boolean);
-      _metaParams = __matchAppRscRoutePattern(_metaUrlParts, metaRoute.patternParts);
-      if (!_metaParams) continue;
-    } else if (cleanPathname !== metaRoute.servedUrl) {
-      continue;
-    }
-    if (metaRoute.isDynamic) {
-      // Dynamic metadata route — call the default export and serialize
-      const metaFn = metaRoute.module.default;
-      if (typeof metaFn === "function") {
-        const result = await metaFn({ params: makeThenableParams(_metaParams || {}) });
-        let body;
-        // If it's already a Response (e.g., ImageResponse), return directly
-        if (result instanceof Response) return result;
-        // Serialize based on type
-        if (metaRoute.type === "sitemap") body = sitemapToXml(result);
-        else if (metaRoute.type === "robots") body = robotsToText(result);
-        else if (metaRoute.type === "manifest") body = manifestToJson(result);
-        else body = JSON.stringify(result);
-        return new Response(body, {
-          headers: { "Content-Type": metaRoute.contentType },
-        });
-      }
-    } else {
-      // Static metadata file — decode from embedded base64 data
-      try {
-        const binary = atob(metaRoute.fileDataBase64);
-        const bytes = new Uint8Array(binary.length);
-        for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
-        return new Response(bytes, {
-          headers: {
-            "Content-Type": metaRoute.contentType,
-            "Cache-Control": "public, max-age=0, must-revalidate",
-          },
-        });
-      } catch {
-        return new Response("Not Found", { status: 404 });
-      }
-    }
-  }
+  const metadataRouteResponse = await __handleMetadataRouteRequest({
+    metadataRoutes,
+    cleanPathname,
+    makeThenableParams,
+  });
+  if (metadataRouteResponse) return metadataRouteResponse;
 
   // Serve public/ files as filesystem routes after middleware and before
   // afterFiles/fallback rewrites, matching Next.js routing semantics.
-  if (
-    (request.method === "GET" || request.method === "HEAD") &&
-    !pathname.endsWith(".rsc") &&
-    __publicFiles.has(cleanPathname)
-  ) {
+  const __publicFileResponse = resolvePublicFileRoute({
+    cleanPathname,
+    middlewareContext: _mwCtx,
+    pathname,
+    publicFiles: __publicFiles,
+    request,
+  });
+  if (__publicFileResponse) {
     __clearRequestContext();
-    return __createStaticFileSignal(cleanPathname, _mwCtx);
+    return __publicFileResponse;
   }
 
   // Set navigation context for Server Components.
@@ -7155,7 +5882,11 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         });
       },
       scheduleBackgroundRegeneration(key, renderFn) {
-        __triggerBackgroundRegeneration(key, renderFn, { routePath: route.pattern, routeType: "render" });
+        __triggerBackgroundRegeneration(key, renderFn, {
+          routerKind: "App Router",
+          routePath: route.pattern,
+          routeType: "render",
+        });
       },
     });
     if (__cachedPageResponse) {
@@ -7307,6 +6038,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       __clearRequestContext();
     },
     consumeDynamicUsage,
+    consumeInvalidDynamicUsageError,
     createRscOnErrorHandler(pathname, routePath) {
       return createRscOnErrorHandler(request, pathname, routePath);
     },
@@ -7490,16 +6222,16 @@ function renderToReadableStream(model, options) {
 }
 import { createElement } from "react";
 import { setNavigationContext as _setNavigationContextOrig, getNavigationContext as _getNavigationContext } from "next/navigation";
-import { setHeadersContext, headersContextFromRequest, getDraftModeCookieHeader, getAndClearPendingCookies, consumeDynamicUsage, markDynamicUsage, getHeadersContext, setHeadersAccessPhase } from "next/headers";
+import { setHeadersContext, headersContextFromRequest, getDraftModeCookieHeader, getAndClearPendingCookies, consumeDynamicUsage, consumeInvalidDynamicUsageError, markDynamicUsage, getHeadersContext, setHeadersAccessPhase } from "next/headers";
 import { mergeMetadata, resolveModuleMetadata, mergeViewport, resolveModuleViewport } from "vinext/metadata";
 
 
-import { sitemapToXml, robotsToText, manifestToJson } from "<ROOT>/packages/vinext/src/server/metadata-routes.js";
-import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, matchHeaders, isExternalUrl, proxyExternalRequest, sanitizeDestination } from "<ROOT>/packages/vinext/src/config/config-matchers.js";
+import { handleMetadataRouteRequest as __handleMetadataRouteRequest } from "<ROOT>/packages/vinext/src/server/metadata-route-response.js";
+import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, isExternalUrl, proxyExternalRequest, sanitizeDestination } from "<ROOT>/packages/vinext/src/config/config-matchers.js";
 import { decodePathParams as __decodePathParams, normalizePath as __normalizePath } from "<ROOT>/packages/vinext/src/server/normalize-path.js";
 import { normalizePathnameForRouteMatch as __normalizePathnameForRouteMatch, normalizePathnameForRouteMatchStrict as __normalizePathnameForRouteMatchStrict } from "<ROOT>/packages/vinext/src/routing/utils.js";
 import { buildRequestHeadersFromMiddlewareResponse as __buildRequestHeadersFromMiddlewareResponse } from "<ROOT>/packages/vinext/src/server/middleware-request-headers.js";
-import { validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
+import { applyConfigHeadersToResponse, resolvePublicFileRoute, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
 import { applyAppMiddleware as __applyAppMiddleware } from "<ROOT>/packages/vinext/src/server/app-middleware.js";
 import {
   dispatchAppRouteHandler as __dispatchAppRouteHandler,
@@ -7507,7 +6239,13 @@ import {
 import {
   handleProgressiveServerActionRequest as __handleProgressiveServerActionRequest,
   handleServerActionRscRequest as __handleServerActionRscRequest,
+  readActionBodyWithLimit as __readBodyWithLimit,
+  readActionFormDataWithLimit as __readFormDataWithLimit,
 } from "<ROOT>/packages/vinext/src/server/app-server-action-execution.js";
+import {
+  createRscOnErrorHandler as __createRscOnErrorHandler,
+  sanitizeErrorForClient as __sanitizeErrorForClient,
+} from "<ROOT>/packages/vinext/src/server/app-rsc-errors.js";
 import { readAppPageCacheResponse as __readAppPageCacheResponse } from "<ROOT>/packages/vinext/src/server/app-page-cache.js";
 import {
   buildAppPageFontLinkHeader as __buildAppPageFontLinkHeader,
@@ -7537,6 +6275,7 @@ import {
 } from "<ROOT>/packages/vinext/src/server/app-page-params.js";
 import {
   collectAppPageSearchParams as __collectAppPageSearchParams,
+  resolveActiveParallelRouteHeadInputs as __resolveActiveParallelRouteHeadInputs,
   resolveAppPageHead as __resolveAppPageHead,
 } from "<ROOT>/packages/vinext/src/server/app-page-head.js";
 import {
@@ -7558,23 +6297,32 @@ import {
   createStaticGenerationHeadersContext as __createStaticGenerationHeadersContext,
 } from "<ROOT>/packages/vinext/src/server/app-static-generation.js";
 import { buildPageCacheTags } from "<ROOT>/packages/vinext/src/server/implicit-tags.js";
-import { _consumeRequestScopedCacheLife, getCacheHandler } from "next/cache";
+import { _consumeRequestScopedCacheLife } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
 import { setRootParams as __setRootParams, pickRootParams as __pickRootParams } from "<ROOT>/packages/vinext/src/shims/root-params.js";
+import { makeThenableParams } from "<ROOT>/packages/vinext/src/shims/thenable-params.js";
 import { ensureFetchPatch as _ensureFetchPatch, getCollectedFetchTags, setCurrentFetchSoftTags } from "vinext/fetch-cache";
 import {
   createAppRscRouteMatcher as __createAppRscRouteMatcher,
-  matchAppRscRoutePattern as __matchAppRscRoutePattern,
 } from "<ROOT>/packages/vinext/src/server/app-rsc-route-matching.js";
 import {
   handleAppPrerenderEndpoint as __handleAppPrerenderEndpoint,
 } from "<ROOT>/packages/vinext/src/server/app-prerender-endpoints.js";
+import {
+  appIsrHtmlKey as __isrHtmlKey,
+  appIsrRscKey as __isrRscKey,
+  appIsrRouteKey as __isrRouteKey,
+  isrGet as __isrGet,
+  isrSet as __isrSet,
+  normalizeMountedSlotsHeader as __normalizeMountedSlotsHeader,
+  triggerBackgroundRegeneration as __triggerBackgroundRegeneration,
+} from "<ROOT>/packages/vinext/src/server/isr-cache.js";
 // Import server-only state module to register ALS-backed accessors.
 import "vinext/navigation-state";
+import { runWithPrerenderWorkUnit as __runWithPrerenderWorkUnit } from "<ROOT>/packages/vinext/src/server/prerender-work-unit-setup.js";
 import { runWithRequestContext as _runWithUnifiedCtx, createRequestContext as _createUnifiedCtx } from "vinext/unified-request-context";
 import { reportRequestError as _reportRequestError } from "vinext/instrumentation";
 import { flattenErrorCauses as __flattenErrorCauses } from "<ROOT>/packages/vinext/src/utils/error-cause.js";
-import { runWithPrerenderWorkUnit as __runWithPrerenderWorkUnit } from "<ROOT>/packages/vinext/src/server/prerender-work-unit-setup.js";
 import { getSSRFontLinks as _getSSRFontLinks, getSSRFontStyles as _getSSRFontStylesGoogle, getSSRFontPreloads as _getSSRFontPreloadsGoogle } from "next/font/google";
 import { getSSRFontStyles as _getSSRFontStylesLocal, getSSRFontPreloads as _getSSRFontPreloadsLocal } from "next/font/local";
 function _getSSRFontStyles() { return [..._getSSRFontStylesGoogle(), ..._getSSRFontStylesLocal()]; }
@@ -7611,25 +6359,6 @@ function __clearRequestContext() {
   // setNavigationContext(null) already clears root params internally
 }
 
-// ISR cache is disabled in dev mode — every request re-renders fresh,
-// matching Next.js dev behavior. Cache-Control headers are still emitted
-// based on export const revalidate for testing purposes.
-// Production ISR uses the MemoryCacheHandler (or configured KV handler).
-//
-// These helpers are inlined instead of imported from isr-cache.js because
-// the virtual RSC entry module runs in the RSC Vite environment which
-// cannot use dynamic imports at the module-evaluation level for server-only
-// modules, and direct imports must use the pre-computed absolute paths.
-async function __isrGet(key) {
-  const handler = getCacheHandler();
-  const result = await handler.get(key);
-  if (!result || !result.value) return null;
-  return { value: result, isStale: result.cacheState === "stale" };
-}
-async function __isrSet(key, data, revalidateSeconds, tags) {
-  const handler = getCacheHandler();
-  await handler.set(key, data, { revalidate: revalidateSeconds, tags: Array.isArray(tags) ? tags : [] });
-}
 // Note: cache entries are written with \`headers: undefined\`. Next.js stores
 // response headers (e.g. set-cookie from cookies().set() during render) in the
 // cache entry so they can be replayed on HIT. We don't do this because:
@@ -7640,82 +6369,6 @@ async function __isrSet(key, data, revalidateSeconds, tags) {
 // In practice this means ISR-cached responses won't replay render-time set-cookie
 // headers — but that case is already prevented by the dynamic-usage opt-out.
 // TODO: capture render-time response headers for full Next.js parity.
-const __pendingRegenerations = new Map();
-function __triggerBackgroundRegeneration(key, renderFn, errorContext) {
-  if (__pendingRegenerations.has(key)) return;
-  const promise = renderFn()
-    .catch((err) => {
-      console.error("[vinext] ISR regen failed for " + key + ":", err);
-      if (errorContext) {
-        void _reportRequestError(
-          err instanceof Error ? err : new Error(String(err)),
-          { path: key, method: "GET", headers: {} },
-          {
-            routerKind: "App Router",
-            routePath: errorContext.routePath,
-            routeType: errorContext.routeType,
-            revalidateReason: "stale",
-          },
-        );
-      }
-    })
-    .finally(() => __pendingRegenerations.delete(key));
-  __pendingRegenerations.set(key, promise);
-  const ctx = _getRequestExecutionContext();
-  if (ctx && typeof ctx.waitUntil === "function") ctx.waitUntil(promise);
-}
-// HTML and RSC are stored under separate keys — matching Next.js's file-system
-// layout (.html / .rsc) — so each request type reads and writes its own key
-// independently with no races or partial-entry sentinels.
-//
-// Key format: "app:<buildId>:<pathname>:<suffix>"
-// Long-pathname fallback: "app:<buildId>:__hash:<fnv1a64(pathname)>:<suffix>"
-// Without buildId (should not happen in production): "app:<pathname>:<suffix>"
-// The 200-char threshold keeps the full key well under Cloudflare KV's 512-byte limit
-// even after adding the build ID and suffix. FNV-1a 64 is used for the hash (two
-// 32-bit rounds) to give a ~64-bit output with negligible collision probability for
-// realistic pathname lengths.
-// Keep prefix construction and hashing logic in sync with isrCacheKey() in server/isr-cache.ts.
-function __isrFnv1a64(s) {
-  // h1 uses the standard FNV-1a 32-bit offset basis (0x811c9dc5).
-  let h1 = 0x811c9dc5;
-  for (let i = 0; i < s.length; i++) { h1 ^= s.charCodeAt(i); h1 = (h1 * 0x01000193) >>> 0; }
-  // h2 uses a different seed (0x050c5d1f — the FNV-1a hash of the string "vinext")
-  // so the two rounds are independently seeded and their outputs are decorrelated.
-  // Concatenating two independently-seeded 32-bit FNV-1a hashes gives an effective
-  // 64-bit hash. A random non-standard seed would also work; we derive it from a
-  // fixed string so the choice is auditable and deterministic across rebuilds.
-  let h2 = 0x050c5d1f;
-  for (let i = 0; i < s.length; i++) { h2 ^= s.charCodeAt(i); h2 = (h2 * 0x01000193) >>> 0; }
-  return h1.toString(36) + h2.toString(36);
-}
-function __isrCacheKey(pathname, suffix) {
-  const normalized = pathname === "/" ? "/" : pathname.replace(/\\/$/, "");
-  // __VINEXT_BUILD_ID is replaced at compile time by Vite's define plugin.
-  const buildId = process.env.__VINEXT_BUILD_ID;
-  const prefix = buildId ? "app:" + buildId : "app";
-  const key = prefix + ":" + normalized + ":" + suffix;
-  if (key.length <= 200) return key;
-  // Pathname too long — hash it to keep under KV's 512-byte key limit.
-  return prefix + ":__hash:" + __isrFnv1a64(normalized) + ":" + suffix;
-}
-function __isrHtmlKey(pathname) { return __isrCacheKey(pathname, "html"); }
-function __isrRscKey(pathname, mountedSlotsHeader) {
-  if (!mountedSlotsHeader) return __isrCacheKey(pathname, "rsc");
-  return __isrCacheKey(pathname, "rsc:" + __isrFnv1a64(mountedSlotsHeader));
-}
-function __normalizeMountedSlotsHeader(raw) {
-  if (!raw) return null;
-  const normalized = Array.from(
-    new Set(
-      raw
-        .split(/\\s+/)
-        .filter(Boolean),
-    ),
-  ).sort().join(" ");
-  return normalized || null;
-}
-function __isrRouteKey(pathname) { return __isrCacheKey(pathname, "route"); }
 // Verbose cache logging — opt in with NEXT_PRIVATE_DEBUG_CACHE=1.
 // Matches the env var Next.js uses for its own cache debug output so operators
 // have a single knob for all cache tracing.
@@ -7733,124 +6386,6 @@ const __classDebug = process.env.VINEXT_DEBUG_CLASSIFICATION
     }
   : undefined;
 
-// Normalize null-prototype objects from route-pattern matching into thenable objects
-// that work both as Promises (for Next.js 15+ async params) and as plain
-// objects with synchronous property access (for pre-15 code like params.id).
-//
-// route-pattern matching uses Object.create(null), producing objects without
-// Object.prototype. The RSC serializer rejects these. Spreading ({...obj})
-// restores a normal prototype. Object.assign onto the Promise preserves
-// synchronous property access (params.id, params.slug) that existing
-// components and test fixtures rely on.
-function makeThenableParams(obj) {
-  const plain = { ...obj };
-  return Object.assign(Promise.resolve(plain), plain);
-}
-
-// djb2 hash — matches Next.js's stringHash for digest generation.
-// Produces a stable numeric string from error message + stack.
-function __errorDigest(str) {
-  let hash = 5381;
-  for (let i = str.length - 1; i >= 0; i--) {
-    hash = (hash * 33) ^ str.charCodeAt(i);
-  }
-  return (hash >>> 0).toString();
-}
-
-// Sanitize an error for client consumption. In production, replaces the error
-// with a generic Error that only carries a digest hash (matching Next.js
-// behavior). In development, returns the original error for debugging.
-// Navigation errors (redirect, notFound, etc.) are always passed through
-// unchanged since their digests are used for client-side routing.
-function __sanitizeErrorForClient(error) {
-  // Navigation errors must pass through with their digest intact
-  if (__resolveAppPageSpecialError(error)) {
-    return error;
-  }
-  // In development, pass through the original error for debugging
-  if (process.env.NODE_ENV !== "production") {
-    return error;
-  }
-  // In production, create a sanitized error with only a digest hash
-  const msg = error instanceof Error ? error.message : String(error);
-  const stack = error instanceof Error ? (error.stack || "") : "";
-  const sanitized = new Error(
-    "An error occurred in the Server Components render. " +
-    "The specific message is omitted in production builds to avoid leaking sensitive details. " +
-    "A digest property is included on this error instance which may provide additional details about the nature of the error."
-  );
-  sanitized.digest = __errorDigest(msg + stack);
-  return sanitized;
-}
-
-// onError callback for renderToReadableStream — preserves the digest for
-// Next.js navigation errors (redirect, notFound, forbidden, unauthorized)
-// thrown during RSC streaming (e.g. inside Suspense boundaries).
-// For non-navigation errors in production, generates a digest hash so the
-// error can be correlated with server logs without leaking details.
-function rscOnError(error, requestInfo, errorContext) {
-  if (error && typeof error === "object" && "digest" in error) {
-    return String(error.digest);
-  }
-
-  // In dev, detect the "Only plain objects" RSC serialization error and emit
-  // an actionable hint. This error occurs when a Server Component passes a
-  // class instance, ES module namespace object, or null-prototype object as a
-  // prop to a Client Component.
-  //
-  // Root cause: Vite bundles modules as true ESM (module namespace objects
-  // have a null-like internal slot), while Next.js's webpack build produces
-  // plain CJS-wrapped objects with __esModule:true. React's RSC serializer
-  // accepts the latter as plain objects but rejects the former — which means
-  // code that accidentally passes "import * as X" works in webpack/Next.js
-  // but correctly fails in vinext.
-  //
-  // Common triggers:
-  //   - "import * as utils from './utils'" passed as a prop
-  //   - class instances (new Foo()) passed as props
-  //   - Date / Map / Set instances passed as props
-  //   - Objects with Object.create(null) (null prototype)
-  if (
-    process.env.NODE_ENV !== "production" &&
-    error instanceof Error &&
-    error.message.includes("Only plain objects, and a few built-ins, can be passed to Client Components")
-  ) {
-    console.error(
-      "[vinext] RSC serialization error: a non-plain object was passed from a Server Component to a Client Component.\\n" +
-      "\\n" +
-      "Common causes:\\n" +
-      "  * Passing a module namespace (import * as X) directly as a prop.\\n" +
-      "    Unlike Next.js (webpack), Vite produces real ESM module namespace objects\\n" +
-      "    which are not serializable. Fix: pass individual values instead,\\n" +
-      "    e.g. <Comp value={module.value} />\\n" +
-      "  * Passing a class instance (new Foo()) as a prop.\\n" +
-      "    Fix: convert to a plain object, e.g. { id: foo.id, name: foo.name }\\n" +
-      "  * Passing a Date, Map, or Set. Use .toISOString(), [...map.entries()], etc.\\n" +
-      "  * Passing Object.create(null). Use { ...obj } to restore a prototype.\\n" +
-      "\\n" +
-      "Original error:",
-      error.message,
-    );
-    return undefined;
-  }
-
-  if (requestInfo && errorContext && error) {
-    _reportRequestError(
-      error instanceof Error ? error : new Error(String(error)),
-      requestInfo,
-      errorContext,
-    );
-  }
-
-  // In production, generate a digest hash for non-navigation errors
-  if (process.env.NODE_ENV === "production" && error) {
-    const msg = error instanceof Error ? error.message : String(error);
-    const stack = error instanceof Error ? (error.stack || "") : "";
-    return __errorDigest(msg + stack);
-  }
-  return undefined;
-}
-
 function createRscOnErrorHandler(request, pathname, routePath) {
   const requestInfo = {
     path: pathname,
@@ -7862,9 +6397,11 @@ function createRscOnErrorHandler(request, pathname, routePath) {
     routePath: routePath || pathname,
     routeType: "render",
   };
-  return function(error) {
-    return rscOnError(error, requestInfo, errorContext);
-  };
+  return __createRscOnErrorHandler({
+    errorContext,
+    reportRequestError: _reportRequestError,
+    requestInfo,
+  });
 }
 
 import * as mod_0 from "/tmp/test/app/page.tsx";
@@ -8062,6 +6599,7 @@ async function renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, req
     makeThenableParams,
     matchedParams: opts?.matchedParams ?? route?.params ?? {},
     middlewareContext: middlewareContext ?? __APP_PAGE_EMPTY_MW_CTX,
+    metadataRoutes,
     requestUrl: request.url,
     resolveChildSegments: __resolveAppPageChildSegments,
     rootForbiddenModule: rootForbiddenModule,
@@ -8109,6 +6647,7 @@ async function renderErrorBoundaryPage(route, error, isRscRequest, request, matc
     makeThenableParams,
     matchedParams: matchedParams ?? route?.params ?? {},
     middlewareContext: middlewareContext ?? __APP_PAGE_EMPTY_MW_CTX,
+    metadataRoutes,
     requestUrl: request.url,
     resolveChildSegments: __resolveAppPageChildSegments,
     rootLayouts: rootLayouts,
@@ -8121,21 +6660,6 @@ async function renderErrorBoundaryPage(route, error, isRscRequest, request, matc
 
 function matchRoute(url) {
   return __routeMatcher.matchRoute(url);
-}
-
-function __createStaticFileSignal(pathname, _mwCtx) {
-  const headers = new Headers({
-    "x-vinext-static-file": encodeURIComponent(pathname),
-  });
-  if (_mwCtx.headers) {
-    for (const [key, value] of _mwCtx.headers) {
-      headers.append(key, value);
-    }
-  }
-  return new Response(null, {
-    status: _mwCtx.status ?? 200,
-    headers,
-  });
 }
 
 /**
@@ -8174,18 +6698,30 @@ async function buildPageElements(route, params, routePath, pageRequest) {
     };
   }
 
-  const __headResult = await __resolveAppPageHead({
+  const {
+    hasSearchParams,
+    metadata: resolvedMetadata,
+    pageSearchParams,
+    viewport: resolvedViewport,
+  } = await __resolveAppPageHead({
     layoutModules: route.layouts,
     layoutTreePositions: route.layoutTreePositions,
+    metadataRoutes,
     pageModule: route.page,
+    parallelRoutes: __resolveActiveParallelRouteHeadInputs({
+      interceptLayouts: opts?.interceptLayouts ?? null,
+      interceptPage: opts?.interceptPage ?? null,
+      interceptParams: opts?.interceptParams ?? null,
+      interceptSlotKey: opts?.interceptSlotKey ?? null,
+      params,
+      routeSegments: route.routeSegments,
+      slots: route.slots,
+    }),
     params,
+    routePath: route.pattern,
     routeSegments: route.routeSegments,
     searchParams,
   });
-  const spObj = __headResult.searchParamsObject;
-  const hasSearchParams = __headResult.hasSearchParams;
-  const resolvedMetadata = __headResult.metadata;
-  const resolvedViewport = __headResult.viewport;
 
   // Build the route tree from the leaf page, then delegate the boundary/layout/
   // template/segment wiring to a typed runtime helper so the generated entry
@@ -8195,7 +6731,7 @@ async function buildPageElements(route, params, routePath, pageRequest) {
     // Always provide searchParams prop when the URL object is available, even
     // when the query string is empty -- pages that do "await searchParams" need
     // it to be a thenable rather than undefined.
-    pageProps.searchParams = makeThenableParams(spObj);
+    pageProps.searchParams = makeThenableParams(pageSearchParams);
     // If the URL has query parameters, mark the page as dynamic.
     // In Next.js, only accessing the searchParams prop signals dynamic usage,
     // but a Proxy-based approach doesn't work here because React's RSC debug
@@ -8226,6 +6762,8 @@ async function buildPageElements(route, params, routePath, pageRequest) {
     interceptionContext: opts?.interceptionContext ?? null,
     routePath,
     rootNotFoundModule: null,
+    rootForbiddenModule: null,
+    rootUnauthorizedModule: null,
     route,
     slotOverrides:
       opts && opts.interceptSlotKey && opts.interceptPage
@@ -8345,63 +6883,6 @@ function __buildPostMwRequestContext(request) {
  */
 var __MAX_ACTION_BODY_SIZE = 1048576;
 
-/**
- * Read a request body as text with a size limit.
- * Enforces the limit on the actual byte stream to prevent bypasses
- * via chunked transfer-encoding where Content-Length is absent or spoofed.
- */
-async function __readBodyWithLimit(request, maxBytes) {
-  if (!request.body) return "";
-  var reader = request.body.getReader();
-  var decoder = new TextDecoder();
-  var chunks = [];
-  var totalSize = 0;
-  for (;;) {
-    var result = await reader.read();
-    if (result.done) break;
-    totalSize += result.value.byteLength;
-    if (totalSize > maxBytes) {
-      reader.cancel();
-      throw new Error("Request body too large");
-    }
-    chunks.push(decoder.decode(result.value, { stream: true }));
-  }
-  chunks.push(decoder.decode());
-  return chunks.join("");
-}
-
-/**
- * Read a request body as FormData with a size limit.
- * Consumes the body stream with a byte counter and then parses the
- * collected bytes as multipart form data via the Response constructor.
- */
-async function __readFormDataWithLimit(request, maxBytes) {
-  if (!request.body) return new FormData();
-  var reader = request.body.getReader();
-  var chunks = [];
-  var totalSize = 0;
-  for (;;) {
-    var result = await reader.read();
-    if (result.done) break;
-    totalSize += result.value.byteLength;
-    if (totalSize > maxBytes) {
-      reader.cancel();
-      throw new Error("Request body too large");
-    }
-    chunks.push(result.value);
-  }
-  // Reconstruct a Response with the original Content-Type so that
-  // the FormData parser can handle multipart boundaries correctly.
-  var combined = new Uint8Array(totalSize);
-  var offset = 0;
-  for (var chunk of chunks) {
-    combined.set(chunk, offset);
-    offset += chunk.byteLength;
-  }
-  var contentType = request.headers.get("content-type") || "";
-  return new Response(combined, { headers: { "Content-Type": contentType } }).formData();
-}
-
 // Map from route pattern to generateStaticParams function.
 // Used by the prerender phase to enumerate dynamic route URLs without
 // loading route modules via the dev server.
@@ -8412,6 +6893,9 @@ export const generateStaticParamsMap = {
 // so they are excluded here. Supporting layout-level generateStaticParams requires
 // scanning layout.tsx files separately and including them in this map.
   "/blog/:slug": mod_3?.generateStaticParams ?? null,
+};
+const rootParamNamesMap = {
+
 };
 
 export default async function handler(request, ctx) {
@@ -8459,21 +6943,11 @@ export default async function handler(request, ctx) {
         let pathname;
         try { pathname = __normalizePath(__normalizePathnameForRouteMatch(url.pathname)); } catch { pathname = url.pathname; }
         
-        const extraHeaders = matchHeaders(pathname, __configHeaders, __reqCtx);
-        for (const h of extraHeaders) {
-          // Use append() for headers where multiple values must coexist
-          // (Vary, Set-Cookie). Using set() on these would destroy
-          // existing values like "Vary: RSC, Accept" which are critical
-          // for correct CDN caching behavior.
-          const lk = h.key.toLowerCase();
-          if (lk === "vary" || lk === "set-cookie") {
-            response.headers.append(h.key, h.value);
-          } else if (!response.headers.has(lk)) {
-            // Middleware headers take precedence: skip config keys already
-            // set by middleware so middleware headers always win.
-            response.headers.set(h.key, h.value);
-          }
-        }
+        applyConfigHeadersToResponse(response.headers, {
+          configHeaders: __configHeaders,
+          pathname,
+          requestContext: __reqCtx,
+        });
       }
     }
     return response;
@@ -8517,6 +6991,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     },
 
     pathname,
+    rootParamNamesByPattern: rootParamNamesMap,
     staticParamsMap: generateStaticParamsMap,
   });
   if (__prerenderEndpointResponse) return __prerenderEndpointResponse;
@@ -8594,90 +7069,25 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     return Response.redirect(new URL(__imgResult, url.origin).href, 302);
   }
 
-  // Handle metadata routes (sitemap.xml, robots.txt, manifest.webmanifest, etc.)
-  for (const metaRoute of metadataRoutes) {
-    // generateSitemaps() support — paginated sitemaps at /{prefix}/sitemap/{id}.xml
-    // When a sitemap module exports generateSitemaps, the base URL (e.g. /products/sitemap.xml)
-    // is no longer served. Instead, individual sitemaps are served at /products/sitemap/{id}.xml.
-    if (
-      metaRoute.type === "sitemap" &&
-      metaRoute.isDynamic &&
-      typeof metaRoute.module.generateSitemaps === "function"
-    ) {
-      const sitemapPrefix = metaRoute.servedUrl.slice(0, -4); // strip ".xml"
-      // Match exactly /{prefix}/{id}.xml — one segment only (no slashes in id)
-      if (cleanPathname.startsWith(sitemapPrefix + "/") && cleanPathname.endsWith(".xml")) {
-        const rawId = cleanPathname.slice(sitemapPrefix.length + 1, -4);
-        if (rawId.includes("/")) continue; // multi-segment — not a paginated sitemap
-        const sitemaps = await metaRoute.module.generateSitemaps();
-        const matched = sitemaps.find(function(s) { return String(s.id) === rawId; });
-        if (!matched) return new Response("Not Found", { status: 404 });
-        // Pass the original typed id from generateSitemaps() so numeric IDs stay numeric.
-        // TODO: wrap with makeThenableParams-style Promise when upgrading to Next.js 16
-        // full-Promise param semantics (id becomes Promise<string> in v16).
-        const result = await metaRoute.module.default({ id: matched.id });
-        if (result instanceof Response) return result;
-        return new Response(sitemapToXml(result), {
-          headers: { "Content-Type": metaRoute.contentType },
-        });
-      }
-      // Skip — the base servedUrl is not served when generateSitemaps exists
-      continue;
-    }
-    // Match metadata route — use pattern matching for dynamic segments,
-    // strict equality for static paths.
-    var _metaParams = null;
-    if (metaRoute.patternParts) {
-      var _metaUrlParts = cleanPathname.split("/").filter(Boolean);
-      _metaParams = __matchAppRscRoutePattern(_metaUrlParts, metaRoute.patternParts);
-      if (!_metaParams) continue;
-    } else if (cleanPathname !== metaRoute.servedUrl) {
-      continue;
-    }
-    if (metaRoute.isDynamic) {
-      // Dynamic metadata route — call the default export and serialize
-      const metaFn = metaRoute.module.default;
-      if (typeof metaFn === "function") {
-        const result = await metaFn({ params: makeThenableParams(_metaParams || {}) });
-        let body;
-        // If it's already a Response (e.g., ImageResponse), return directly
-        if (result instanceof Response) return result;
-        // Serialize based on type
-        if (metaRoute.type === "sitemap") body = sitemapToXml(result);
-        else if (metaRoute.type === "robots") body = robotsToText(result);
-        else if (metaRoute.type === "manifest") body = manifestToJson(result);
-        else body = JSON.stringify(result);
-        return new Response(body, {
-          headers: { "Content-Type": metaRoute.contentType },
-        });
-      }
-    } else {
-      // Static metadata file — decode from embedded base64 data
-      try {
-        const binary = atob(metaRoute.fileDataBase64);
-        const bytes = new Uint8Array(binary.length);
-        for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
-        return new Response(bytes, {
-          headers: {
-            "Content-Type": metaRoute.contentType,
-            "Cache-Control": "public, max-age=0, must-revalidate",
-          },
-        });
-      } catch {
-        return new Response("Not Found", { status: 404 });
-      }
-    }
-  }
+  const metadataRouteResponse = await __handleMetadataRouteRequest({
+    metadataRoutes,
+    cleanPathname,
+    makeThenableParams,
+  });
+  if (metadataRouteResponse) return metadataRouteResponse;
 
   // Serve public/ files as filesystem routes after middleware and before
   // afterFiles/fallback rewrites, matching Next.js routing semantics.
-  if (
-    (request.method === "GET" || request.method === "HEAD") &&
-    !pathname.endsWith(".rsc") &&
-    __publicFiles.has(cleanPathname)
-  ) {
+  const __publicFileResponse = resolvePublicFileRoute({
+    cleanPathname,
+    middlewareContext: _mwCtx,
+    pathname,
+    publicFiles: __publicFiles,
+    request,
+  });
+  if (__publicFileResponse) {
     __clearRequestContext();
-    return __createStaticFileSignal(cleanPathname, _mwCtx);
+    return __publicFileResponse;
   }
 
   // Set navigation context for Server Components.
@@ -9019,7 +7429,11 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         });
       },
       scheduleBackgroundRegeneration(key, renderFn) {
-        __triggerBackgroundRegeneration(key, renderFn, { routePath: route.pattern, routeType: "render" });
+        __triggerBackgroundRegeneration(key, renderFn, {
+          routerKind: "App Router",
+          routePath: route.pattern,
+          routeType: "render",
+        });
       },
     });
     if (__cachedPageResponse) {
@@ -9171,6 +7585,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       __clearRequestContext();
     },
     consumeDynamicUsage,
+    consumeInvalidDynamicUsageError,
     createRscOnErrorHandler(pathname, routePath) {
       return createRscOnErrorHandler(request, pathname, routePath);
     },
@@ -9354,16 +7769,16 @@ function renderToReadableStream(model, options) {
 }
 import { createElement } from "react";
 import { setNavigationContext as _setNavigationContextOrig, getNavigationContext as _getNavigationContext } from "next/navigation";
-import { setHeadersContext, headersContextFromRequest, getDraftModeCookieHeader, getAndClearPendingCookies, consumeDynamicUsage, markDynamicUsage, getHeadersContext, setHeadersAccessPhase } from "next/headers";
+import { setHeadersContext, headersContextFromRequest, getDraftModeCookieHeader, getAndClearPendingCookies, consumeDynamicUsage, consumeInvalidDynamicUsageError, markDynamicUsage, getHeadersContext, setHeadersAccessPhase } from "next/headers";
 import { mergeMetadata, resolveModuleMetadata, mergeViewport, resolveModuleViewport } from "vinext/metadata";
 import * as middlewareModule from "/tmp/test/middleware.ts";
 
-
-import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, matchHeaders, isExternalUrl, proxyExternalRequest, sanitizeDestination } from "<ROOT>/packages/vinext/src/config/config-matchers.js";
+import { handleMetadataRouteRequest as __handleMetadataRouteRequest } from "<ROOT>/packages/vinext/src/server/metadata-route-response.js";
+import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, isExternalUrl, proxyExternalRequest, sanitizeDestination } from "<ROOT>/packages/vinext/src/config/config-matchers.js";
 import { decodePathParams as __decodePathParams, normalizePath as __normalizePath } from "<ROOT>/packages/vinext/src/server/normalize-path.js";
 import { normalizePathnameForRouteMatch as __normalizePathnameForRouteMatch, normalizePathnameForRouteMatchStrict as __normalizePathnameForRouteMatchStrict } from "<ROOT>/packages/vinext/src/routing/utils.js";
 import { buildRequestHeadersFromMiddlewareResponse as __buildRequestHeadersFromMiddlewareResponse } from "<ROOT>/packages/vinext/src/server/middleware-request-headers.js";
-import { validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
+import { applyConfigHeadersToResponse, resolvePublicFileRoute, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
 import { applyAppMiddleware as __applyAppMiddleware } from "<ROOT>/packages/vinext/src/server/app-middleware.js";
 import {
   dispatchAppRouteHandler as __dispatchAppRouteHandler,
@@ -9371,7 +7786,13 @@ import {
 import {
   handleProgressiveServerActionRequest as __handleProgressiveServerActionRequest,
   handleServerActionRscRequest as __handleServerActionRscRequest,
+  readActionBodyWithLimit as __readBodyWithLimit,
+  readActionFormDataWithLimit as __readFormDataWithLimit,
 } from "<ROOT>/packages/vinext/src/server/app-server-action-execution.js";
+import {
+  createRscOnErrorHandler as __createRscOnErrorHandler,
+  sanitizeErrorForClient as __sanitizeErrorForClient,
+} from "<ROOT>/packages/vinext/src/server/app-rsc-errors.js";
 import { readAppPageCacheResponse as __readAppPageCacheResponse } from "<ROOT>/packages/vinext/src/server/app-page-cache.js";
 import {
   buildAppPageFontLinkHeader as __buildAppPageFontLinkHeader,
@@ -9401,6 +7822,7 @@ import {
 } from "<ROOT>/packages/vinext/src/server/app-page-params.js";
 import {
   collectAppPageSearchParams as __collectAppPageSearchParams,
+  resolveActiveParallelRouteHeadInputs as __resolveActiveParallelRouteHeadInputs,
   resolveAppPageHead as __resolveAppPageHead,
 } from "<ROOT>/packages/vinext/src/server/app-page-head.js";
 import {
@@ -9422,23 +7844,32 @@ import {
   createStaticGenerationHeadersContext as __createStaticGenerationHeadersContext,
 } from "<ROOT>/packages/vinext/src/server/app-static-generation.js";
 import { buildPageCacheTags } from "<ROOT>/packages/vinext/src/server/implicit-tags.js";
-import { _consumeRequestScopedCacheLife, getCacheHandler } from "next/cache";
+import { _consumeRequestScopedCacheLife } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
 import { setRootParams as __setRootParams, pickRootParams as __pickRootParams } from "<ROOT>/packages/vinext/src/shims/root-params.js";
+import { makeThenableParams } from "<ROOT>/packages/vinext/src/shims/thenable-params.js";
 import { ensureFetchPatch as _ensureFetchPatch, getCollectedFetchTags, setCurrentFetchSoftTags } from "vinext/fetch-cache";
 import {
   createAppRscRouteMatcher as __createAppRscRouteMatcher,
-  matchAppRscRoutePattern as __matchAppRscRoutePattern,
 } from "<ROOT>/packages/vinext/src/server/app-rsc-route-matching.js";
 import {
   handleAppPrerenderEndpoint as __handleAppPrerenderEndpoint,
 } from "<ROOT>/packages/vinext/src/server/app-prerender-endpoints.js";
+import {
+  appIsrHtmlKey as __isrHtmlKey,
+  appIsrRscKey as __isrRscKey,
+  appIsrRouteKey as __isrRouteKey,
+  isrGet as __isrGet,
+  isrSet as __isrSet,
+  normalizeMountedSlotsHeader as __normalizeMountedSlotsHeader,
+  triggerBackgroundRegeneration as __triggerBackgroundRegeneration,
+} from "<ROOT>/packages/vinext/src/server/isr-cache.js";
 // Import server-only state module to register ALS-backed accessors.
 import "vinext/navigation-state";
+import { runWithPrerenderWorkUnit as __runWithPrerenderWorkUnit } from "<ROOT>/packages/vinext/src/server/prerender-work-unit-setup.js";
 import { runWithRequestContext as _runWithUnifiedCtx, createRequestContext as _createUnifiedCtx } from "vinext/unified-request-context";
 import { reportRequestError as _reportRequestError } from "vinext/instrumentation";
 import { flattenErrorCauses as __flattenErrorCauses } from "<ROOT>/packages/vinext/src/utils/error-cause.js";
-import { runWithPrerenderWorkUnit as __runWithPrerenderWorkUnit } from "<ROOT>/packages/vinext/src/server/prerender-work-unit-setup.js";
 import { getSSRFontLinks as _getSSRFontLinks, getSSRFontStyles as _getSSRFontStylesGoogle, getSSRFontPreloads as _getSSRFontPreloadsGoogle } from "next/font/google";
 import { getSSRFontStyles as _getSSRFontStylesLocal, getSSRFontPreloads as _getSSRFontPreloadsLocal } from "next/font/local";
 function _getSSRFontStyles() { return [..._getSSRFontStylesGoogle(), ..._getSSRFontStylesLocal()]; }
@@ -9475,25 +7906,6 @@ function __clearRequestContext() {
   // setNavigationContext(null) already clears root params internally
 }
 
-// ISR cache is disabled in dev mode — every request re-renders fresh,
-// matching Next.js dev behavior. Cache-Control headers are still emitted
-// based on export const revalidate for testing purposes.
-// Production ISR uses the MemoryCacheHandler (or configured KV handler).
-//
-// These helpers are inlined instead of imported from isr-cache.js because
-// the virtual RSC entry module runs in the RSC Vite environment which
-// cannot use dynamic imports at the module-evaluation level for server-only
-// modules, and direct imports must use the pre-computed absolute paths.
-async function __isrGet(key) {
-  const handler = getCacheHandler();
-  const result = await handler.get(key);
-  if (!result || !result.value) return null;
-  return { value: result, isStale: result.cacheState === "stale" };
-}
-async function __isrSet(key, data, revalidateSeconds, tags) {
-  const handler = getCacheHandler();
-  await handler.set(key, data, { revalidate: revalidateSeconds, tags: Array.isArray(tags) ? tags : [] });
-}
 // Note: cache entries are written with \`headers: undefined\`. Next.js stores
 // response headers (e.g. set-cookie from cookies().set() during render) in the
 // cache entry so they can be replayed on HIT. We don't do this because:
@@ -9504,82 +7916,6 @@ async function __isrSet(key, data, revalidateSeconds, tags) {
 // In practice this means ISR-cached responses won't replay render-time set-cookie
 // headers — but that case is already prevented by the dynamic-usage opt-out.
 // TODO: capture render-time response headers for full Next.js parity.
-const __pendingRegenerations = new Map();
-function __triggerBackgroundRegeneration(key, renderFn, errorContext) {
-  if (__pendingRegenerations.has(key)) return;
-  const promise = renderFn()
-    .catch((err) => {
-      console.error("[vinext] ISR regen failed for " + key + ":", err);
-      if (errorContext) {
-        void _reportRequestError(
-          err instanceof Error ? err : new Error(String(err)),
-          { path: key, method: "GET", headers: {} },
-          {
-            routerKind: "App Router",
-            routePath: errorContext.routePath,
-            routeType: errorContext.routeType,
-            revalidateReason: "stale",
-          },
-        );
-      }
-    })
-    .finally(() => __pendingRegenerations.delete(key));
-  __pendingRegenerations.set(key, promise);
-  const ctx = _getRequestExecutionContext();
-  if (ctx && typeof ctx.waitUntil === "function") ctx.waitUntil(promise);
-}
-// HTML and RSC are stored under separate keys — matching Next.js's file-system
-// layout (.html / .rsc) — so each request type reads and writes its own key
-// independently with no races or partial-entry sentinels.
-//
-// Key format: "app:<buildId>:<pathname>:<suffix>"
-// Long-pathname fallback: "app:<buildId>:__hash:<fnv1a64(pathname)>:<suffix>"
-// Without buildId (should not happen in production): "app:<pathname>:<suffix>"
-// The 200-char threshold keeps the full key well under Cloudflare KV's 512-byte limit
-// even after adding the build ID and suffix. FNV-1a 64 is used for the hash (two
-// 32-bit rounds) to give a ~64-bit output with negligible collision probability for
-// realistic pathname lengths.
-// Keep prefix construction and hashing logic in sync with isrCacheKey() in server/isr-cache.ts.
-function __isrFnv1a64(s) {
-  // h1 uses the standard FNV-1a 32-bit offset basis (0x811c9dc5).
-  let h1 = 0x811c9dc5;
-  for (let i = 0; i < s.length; i++) { h1 ^= s.charCodeAt(i); h1 = (h1 * 0x01000193) >>> 0; }
-  // h2 uses a different seed (0x050c5d1f — the FNV-1a hash of the string "vinext")
-  // so the two rounds are independently seeded and their outputs are decorrelated.
-  // Concatenating two independently-seeded 32-bit FNV-1a hashes gives an effective
-  // 64-bit hash. A random non-standard seed would also work; we derive it from a
-  // fixed string so the choice is auditable and deterministic across rebuilds.
-  let h2 = 0x050c5d1f;
-  for (let i = 0; i < s.length; i++) { h2 ^= s.charCodeAt(i); h2 = (h2 * 0x01000193) >>> 0; }
-  return h1.toString(36) + h2.toString(36);
-}
-function __isrCacheKey(pathname, suffix) {
-  const normalized = pathname === "/" ? "/" : pathname.replace(/\\/$/, "");
-  // __VINEXT_BUILD_ID is replaced at compile time by Vite's define plugin.
-  const buildId = process.env.__VINEXT_BUILD_ID;
-  const prefix = buildId ? "app:" + buildId : "app";
-  const key = prefix + ":" + normalized + ":" + suffix;
-  if (key.length <= 200) return key;
-  // Pathname too long — hash it to keep under KV's 512-byte key limit.
-  return prefix + ":__hash:" + __isrFnv1a64(normalized) + ":" + suffix;
-}
-function __isrHtmlKey(pathname) { return __isrCacheKey(pathname, "html"); }
-function __isrRscKey(pathname, mountedSlotsHeader) {
-  if (!mountedSlotsHeader) return __isrCacheKey(pathname, "rsc");
-  return __isrCacheKey(pathname, "rsc:" + __isrFnv1a64(mountedSlotsHeader));
-}
-function __normalizeMountedSlotsHeader(raw) {
-  if (!raw) return null;
-  const normalized = Array.from(
-    new Set(
-      raw
-        .split(/\\s+/)
-        .filter(Boolean),
-    ),
-  ).sort().join(" ");
-  return normalized || null;
-}
-function __isrRouteKey(pathname) { return __isrCacheKey(pathname, "route"); }
 // Verbose cache logging — opt in with NEXT_PRIVATE_DEBUG_CACHE=1.
 // Matches the env var Next.js uses for its own cache debug output so operators
 // have a single knob for all cache tracing.
@@ -9597,124 +7933,6 @@ const __classDebug = process.env.VINEXT_DEBUG_CLASSIFICATION
     }
   : undefined;
 
-// Normalize null-prototype objects from route-pattern matching into thenable objects
-// that work both as Promises (for Next.js 15+ async params) and as plain
-// objects with synchronous property access (for pre-15 code like params.id).
-//
-// route-pattern matching uses Object.create(null), producing objects without
-// Object.prototype. The RSC serializer rejects these. Spreading ({...obj})
-// restores a normal prototype. Object.assign onto the Promise preserves
-// synchronous property access (params.id, params.slug) that existing
-// components and test fixtures rely on.
-function makeThenableParams(obj) {
-  const plain = { ...obj };
-  return Object.assign(Promise.resolve(plain), plain);
-}
-
-// djb2 hash — matches Next.js's stringHash for digest generation.
-// Produces a stable numeric string from error message + stack.
-function __errorDigest(str) {
-  let hash = 5381;
-  for (let i = str.length - 1; i >= 0; i--) {
-    hash = (hash * 33) ^ str.charCodeAt(i);
-  }
-  return (hash >>> 0).toString();
-}
-
-// Sanitize an error for client consumption. In production, replaces the error
-// with a generic Error that only carries a digest hash (matching Next.js
-// behavior). In development, returns the original error for debugging.
-// Navigation errors (redirect, notFound, etc.) are always passed through
-// unchanged since their digests are used for client-side routing.
-function __sanitizeErrorForClient(error) {
-  // Navigation errors must pass through with their digest intact
-  if (__resolveAppPageSpecialError(error)) {
-    return error;
-  }
-  // In development, pass through the original error for debugging
-  if (process.env.NODE_ENV !== "production") {
-    return error;
-  }
-  // In production, create a sanitized error with only a digest hash
-  const msg = error instanceof Error ? error.message : String(error);
-  const stack = error instanceof Error ? (error.stack || "") : "";
-  const sanitized = new Error(
-    "An error occurred in the Server Components render. " +
-    "The specific message is omitted in production builds to avoid leaking sensitive details. " +
-    "A digest property is included on this error instance which may provide additional details about the nature of the error."
-  );
-  sanitized.digest = __errorDigest(msg + stack);
-  return sanitized;
-}
-
-// onError callback for renderToReadableStream — preserves the digest for
-// Next.js navigation errors (redirect, notFound, forbidden, unauthorized)
-// thrown during RSC streaming (e.g. inside Suspense boundaries).
-// For non-navigation errors in production, generates a digest hash so the
-// error can be correlated with server logs without leaking details.
-function rscOnError(error, requestInfo, errorContext) {
-  if (error && typeof error === "object" && "digest" in error) {
-    return String(error.digest);
-  }
-
-  // In dev, detect the "Only plain objects" RSC serialization error and emit
-  // an actionable hint. This error occurs when a Server Component passes a
-  // class instance, ES module namespace object, or null-prototype object as a
-  // prop to a Client Component.
-  //
-  // Root cause: Vite bundles modules as true ESM (module namespace objects
-  // have a null-like internal slot), while Next.js's webpack build produces
-  // plain CJS-wrapped objects with __esModule:true. React's RSC serializer
-  // accepts the latter as plain objects but rejects the former — which means
-  // code that accidentally passes "import * as X" works in webpack/Next.js
-  // but correctly fails in vinext.
-  //
-  // Common triggers:
-  //   - "import * as utils from './utils'" passed as a prop
-  //   - class instances (new Foo()) passed as props
-  //   - Date / Map / Set instances passed as props
-  //   - Objects with Object.create(null) (null prototype)
-  if (
-    process.env.NODE_ENV !== "production" &&
-    error instanceof Error &&
-    error.message.includes("Only plain objects, and a few built-ins, can be passed to Client Components")
-  ) {
-    console.error(
-      "[vinext] RSC serialization error: a non-plain object was passed from a Server Component to a Client Component.\\n" +
-      "\\n" +
-      "Common causes:\\n" +
-      "  * Passing a module namespace (import * as X) directly as a prop.\\n" +
-      "    Unlike Next.js (webpack), Vite produces real ESM module namespace objects\\n" +
-      "    which are not serializable. Fix: pass individual values instead,\\n" +
-      "    e.g. <Comp value={module.value} />\\n" +
-      "  * Passing a class instance (new Foo()) as a prop.\\n" +
-      "    Fix: convert to a plain object, e.g. { id: foo.id, name: foo.name }\\n" +
-      "  * Passing a Date, Map, or Set. Use .toISOString(), [...map.entries()], etc.\\n" +
-      "  * Passing Object.create(null). Use { ...obj } to restore a prototype.\\n" +
-      "\\n" +
-      "Original error:",
-      error.message,
-    );
-    return undefined;
-  }
-
-  if (requestInfo && errorContext && error) {
-    _reportRequestError(
-      error instanceof Error ? error : new Error(String(error)),
-      requestInfo,
-      errorContext,
-    );
-  }
-
-  // In production, generate a digest hash for non-navigation errors
-  if (process.env.NODE_ENV === "production" && error) {
-    const msg = error instanceof Error ? error.message : String(error);
-    const stack = error instanceof Error ? (error.stack || "") : "";
-    return __errorDigest(msg + stack);
-  }
-  return undefined;
-}
-
 function createRscOnErrorHandler(request, pathname, routePath) {
   const requestInfo = {
     path: pathname,
@@ -9726,9 +7944,11 @@ function createRscOnErrorHandler(request, pathname, routePath) {
     routePath: routePath || pathname,
     routeType: "render",
   };
-  return function(error) {
-    return rscOnError(error, requestInfo, errorContext);
-  };
+  return __createRscOnErrorHandler({
+    errorContext,
+    reportRequestError: _reportRequestError,
+    requestInfo,
+  });
 }
 
 import * as mod_0 from "/tmp/test/app/page.tsx";
@@ -9919,6 +8139,7 @@ async function renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, req
     makeThenableParams,
     matchedParams: opts?.matchedParams ?? route?.params ?? {},
     middlewareContext: middlewareContext ?? __APP_PAGE_EMPTY_MW_CTX,
+    metadataRoutes,
     requestUrl: request.url,
     resolveChildSegments: __resolveAppPageChildSegments,
     rootForbiddenModule: rootForbiddenModule,
@@ -9966,6 +8187,7 @@ async function renderErrorBoundaryPage(route, error, isRscRequest, request, matc
     makeThenableParams,
     matchedParams: matchedParams ?? route?.params ?? {},
     middlewareContext: middlewareContext ?? __APP_PAGE_EMPTY_MW_CTX,
+    metadataRoutes,
     requestUrl: request.url,
     resolveChildSegments: __resolveAppPageChildSegments,
     rootLayouts: rootLayouts,
@@ -9978,21 +8200,6 @@ async function renderErrorBoundaryPage(route, error, isRscRequest, request, matc
 
 function matchRoute(url) {
   return __routeMatcher.matchRoute(url);
-}
-
-function __createStaticFileSignal(pathname, _mwCtx) {
-  const headers = new Headers({
-    "x-vinext-static-file": encodeURIComponent(pathname),
-  });
-  if (_mwCtx.headers) {
-    for (const [key, value] of _mwCtx.headers) {
-      headers.append(key, value);
-    }
-  }
-  return new Response(null, {
-    status: _mwCtx.status ?? 200,
-    headers,
-  });
 }
 
 /**
@@ -10031,18 +8238,30 @@ async function buildPageElements(route, params, routePath, pageRequest) {
     };
   }
 
-  const __headResult = await __resolveAppPageHead({
+  const {
+    hasSearchParams,
+    metadata: resolvedMetadata,
+    pageSearchParams,
+    viewport: resolvedViewport,
+  } = await __resolveAppPageHead({
     layoutModules: route.layouts,
     layoutTreePositions: route.layoutTreePositions,
+    metadataRoutes,
     pageModule: route.page,
+    parallelRoutes: __resolveActiveParallelRouteHeadInputs({
+      interceptLayouts: opts?.interceptLayouts ?? null,
+      interceptPage: opts?.interceptPage ?? null,
+      interceptParams: opts?.interceptParams ?? null,
+      interceptSlotKey: opts?.interceptSlotKey ?? null,
+      params,
+      routeSegments: route.routeSegments,
+      slots: route.slots,
+    }),
     params,
+    routePath: route.pattern,
     routeSegments: route.routeSegments,
     searchParams,
   });
-  const spObj = __headResult.searchParamsObject;
-  const hasSearchParams = __headResult.hasSearchParams;
-  const resolvedMetadata = __headResult.metadata;
-  const resolvedViewport = __headResult.viewport;
 
   // Build the route tree from the leaf page, then delegate the boundary/layout/
   // template/segment wiring to a typed runtime helper so the generated entry
@@ -10052,7 +8271,7 @@ async function buildPageElements(route, params, routePath, pageRequest) {
     // Always provide searchParams prop when the URL object is available, even
     // when the query string is empty -- pages that do "await searchParams" need
     // it to be a thenable rather than undefined.
-    pageProps.searchParams = makeThenableParams(spObj);
+    pageProps.searchParams = makeThenableParams(pageSearchParams);
     // If the URL has query parameters, mark the page as dynamic.
     // In Next.js, only accessing the searchParams prop signals dynamic usage,
     // but a Proxy-based approach doesn't work here because React's RSC debug
@@ -10083,6 +8302,8 @@ async function buildPageElements(route, params, routePath, pageRequest) {
     interceptionContext: opts?.interceptionContext ?? null,
     routePath,
     rootNotFoundModule: null,
+    rootForbiddenModule: null,
+    rootUnauthorizedModule: null,
     route,
     slotOverrides:
       opts && opts.interceptSlotKey && opts.interceptPage
@@ -10202,63 +8423,6 @@ function __buildPostMwRequestContext(request) {
  */
 var __MAX_ACTION_BODY_SIZE = 1048576;
 
-/**
- * Read a request body as text with a size limit.
- * Enforces the limit on the actual byte stream to prevent bypasses
- * via chunked transfer-encoding where Content-Length is absent or spoofed.
- */
-async function __readBodyWithLimit(request, maxBytes) {
-  if (!request.body) return "";
-  var reader = request.body.getReader();
-  var decoder = new TextDecoder();
-  var chunks = [];
-  var totalSize = 0;
-  for (;;) {
-    var result = await reader.read();
-    if (result.done) break;
-    totalSize += result.value.byteLength;
-    if (totalSize > maxBytes) {
-      reader.cancel();
-      throw new Error("Request body too large");
-    }
-    chunks.push(decoder.decode(result.value, { stream: true }));
-  }
-  chunks.push(decoder.decode());
-  return chunks.join("");
-}
-
-/**
- * Read a request body as FormData with a size limit.
- * Consumes the body stream with a byte counter and then parses the
- * collected bytes as multipart form data via the Response constructor.
- */
-async function __readFormDataWithLimit(request, maxBytes) {
-  if (!request.body) return new FormData();
-  var reader = request.body.getReader();
-  var chunks = [];
-  var totalSize = 0;
-  for (;;) {
-    var result = await reader.read();
-    if (result.done) break;
-    totalSize += result.value.byteLength;
-    if (totalSize > maxBytes) {
-      reader.cancel();
-      throw new Error("Request body too large");
-    }
-    chunks.push(result.value);
-  }
-  // Reconstruct a Response with the original Content-Type so that
-  // the FormData parser can handle multipart boundaries correctly.
-  var combined = new Uint8Array(totalSize);
-  var offset = 0;
-  for (var chunk of chunks) {
-    combined.set(chunk, offset);
-    offset += chunk.byteLength;
-  }
-  var contentType = request.headers.get("content-type") || "";
-  return new Response(combined, { headers: { "Content-Type": contentType } }).formData();
-}
-
 // Map from route pattern to generateStaticParams function.
 // Used by the prerender phase to enumerate dynamic route URLs without
 // loading route modules via the dev server.
@@ -10269,6 +8433,9 @@ export const generateStaticParamsMap = {
 // so they are excluded here. Supporting layout-level generateStaticParams requires
 // scanning layout.tsx files separately and including them in this map.
   "/blog/:slug": mod_3?.generateStaticParams ?? null,
+};
+const rootParamNamesMap = {
+
 };
 
 export default async function handler(request, ctx) {
@@ -10316,21 +8483,11 @@ export default async function handler(request, ctx) {
         let pathname;
         try { pathname = __normalizePath(__normalizePathnameForRouteMatch(url.pathname)); } catch { pathname = url.pathname; }
         
-        const extraHeaders = matchHeaders(pathname, __configHeaders, __reqCtx);
-        for (const h of extraHeaders) {
-          // Use append() for headers where multiple values must coexist
-          // (Vary, Set-Cookie). Using set() on these would destroy
-          // existing values like "Vary: RSC, Accept" which are critical
-          // for correct CDN caching behavior.
-          const lk = h.key.toLowerCase();
-          if (lk === "vary" || lk === "set-cookie") {
-            response.headers.append(h.key, h.value);
-          } else if (!response.headers.has(lk)) {
-            // Middleware headers take precedence: skip config keys already
-            // set by middleware so middleware headers always win.
-            response.headers.set(h.key, h.value);
-          }
-        }
+        applyConfigHeadersToResponse(response.headers, {
+          configHeaders: __configHeaders,
+          pathname,
+          requestContext: __reqCtx,
+        });
       }
     }
     return response;
@@ -10374,6 +8531,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     },
 
     pathname,
+    rootParamNamesByPattern: rootParamNamesMap,
     staticParamsMap: generateStaticParamsMap,
   });
   if (__prerenderEndpointResponse) return __prerenderEndpointResponse;
@@ -10466,90 +8624,25 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     return Response.redirect(new URL(__imgResult, url.origin).href, 302);
   }
 
-  // Handle metadata routes (sitemap.xml, robots.txt, manifest.webmanifest, etc.)
-  for (const metaRoute of metadataRoutes) {
-    // generateSitemaps() support — paginated sitemaps at /{prefix}/sitemap/{id}.xml
-    // When a sitemap module exports generateSitemaps, the base URL (e.g. /products/sitemap.xml)
-    // is no longer served. Instead, individual sitemaps are served at /products/sitemap/{id}.xml.
-    if (
-      metaRoute.type === "sitemap" &&
-      metaRoute.isDynamic &&
-      typeof metaRoute.module.generateSitemaps === "function"
-    ) {
-      const sitemapPrefix = metaRoute.servedUrl.slice(0, -4); // strip ".xml"
-      // Match exactly /{prefix}/{id}.xml — one segment only (no slashes in id)
-      if (cleanPathname.startsWith(sitemapPrefix + "/") && cleanPathname.endsWith(".xml")) {
-        const rawId = cleanPathname.slice(sitemapPrefix.length + 1, -4);
-        if (rawId.includes("/")) continue; // multi-segment — not a paginated sitemap
-        const sitemaps = await metaRoute.module.generateSitemaps();
-        const matched = sitemaps.find(function(s) { return String(s.id) === rawId; });
-        if (!matched) return new Response("Not Found", { status: 404 });
-        // Pass the original typed id from generateSitemaps() so numeric IDs stay numeric.
-        // TODO: wrap with makeThenableParams-style Promise when upgrading to Next.js 16
-        // full-Promise param semantics (id becomes Promise<string> in v16).
-        const result = await metaRoute.module.default({ id: matched.id });
-        if (result instanceof Response) return result;
-        return new Response(sitemapToXml(result), {
-          headers: { "Content-Type": metaRoute.contentType },
-        });
-      }
-      // Skip — the base servedUrl is not served when generateSitemaps exists
-      continue;
-    }
-    // Match metadata route — use pattern matching for dynamic segments,
-    // strict equality for static paths.
-    var _metaParams = null;
-    if (metaRoute.patternParts) {
-      var _metaUrlParts = cleanPathname.split("/").filter(Boolean);
-      _metaParams = __matchAppRscRoutePattern(_metaUrlParts, metaRoute.patternParts);
-      if (!_metaParams) continue;
-    } else if (cleanPathname !== metaRoute.servedUrl) {
-      continue;
-    }
-    if (metaRoute.isDynamic) {
-      // Dynamic metadata route — call the default export and serialize
-      const metaFn = metaRoute.module.default;
-      if (typeof metaFn === "function") {
-        const result = await metaFn({ params: makeThenableParams(_metaParams || {}) });
-        let body;
-        // If it's already a Response (e.g., ImageResponse), return directly
-        if (result instanceof Response) return result;
-        // Serialize based on type
-        if (metaRoute.type === "sitemap") body = sitemapToXml(result);
-        else if (metaRoute.type === "robots") body = robotsToText(result);
-        else if (metaRoute.type === "manifest") body = manifestToJson(result);
-        else body = JSON.stringify(result);
-        return new Response(body, {
-          headers: { "Content-Type": metaRoute.contentType },
-        });
-      }
-    } else {
-      // Static metadata file — decode from embedded base64 data
-      try {
-        const binary = atob(metaRoute.fileDataBase64);
-        const bytes = new Uint8Array(binary.length);
-        for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
-        return new Response(bytes, {
-          headers: {
-            "Content-Type": metaRoute.contentType,
-            "Cache-Control": "public, max-age=0, must-revalidate",
-          },
-        });
-      } catch {
-        return new Response("Not Found", { status: 404 });
-      }
-    }
-  }
+  const metadataRouteResponse = await __handleMetadataRouteRequest({
+    metadataRoutes,
+    cleanPathname,
+    makeThenableParams,
+  });
+  if (metadataRouteResponse) return metadataRouteResponse;
 
   // Serve public/ files as filesystem routes after middleware and before
   // afterFiles/fallback rewrites, matching Next.js routing semantics.
-  if (
-    (request.method === "GET" || request.method === "HEAD") &&
-    !pathname.endsWith(".rsc") &&
-    __publicFiles.has(cleanPathname)
-  ) {
+  const __publicFileResponse = resolvePublicFileRoute({
+    cleanPathname,
+    middlewareContext: _mwCtx,
+    pathname,
+    publicFiles: __publicFiles,
+    request,
+  });
+  if (__publicFileResponse) {
     __clearRequestContext();
-    return __createStaticFileSignal(cleanPathname, _mwCtx);
+    return __publicFileResponse;
   }
 
   // Set navigation context for Server Components.
@@ -10891,7 +8984,11 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         });
       },
       scheduleBackgroundRegeneration(key, renderFn) {
-        __triggerBackgroundRegeneration(key, renderFn, { routePath: route.pattern, routeType: "render" });
+        __triggerBackgroundRegeneration(key, renderFn, {
+          routerKind: "App Router",
+          routePath: route.pattern,
+          routeType: "render",
+        });
       },
     });
     if (__cachedPageResponse) {
@@ -11043,6 +9140,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       __clearRequestContext();
     },
     consumeDynamicUsage,
+    consumeInvalidDynamicUsageError,
     createRscOnErrorHandler(pathname, routePath) {
       return createRscOnErrorHandler(request, pathname, routePath);
     },

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -950,8 +950,6 @@ export default async function handler(request, ctx) {
     executionContext: ctx ?? _getRequestExecutionContext() ?? null,
     unstableCacheRevalidation: "background",
   });
-  // Extract pathname for prerender work unit store (used by unstable_io() for error messages)
-  const __pathname = new URL(request.url).pathname;
   return _runWithUnifiedCtx(__uCtx, () =>
     __runWithPrerenderWorkUnit(async () => {
     _ensureFetchPatch();
@@ -1004,7 +1002,7 @@ export default async function handler(request, ctx) {
       }
     }
     return response;
-    }, { route: __pathname })
+    }, { route: () => new URL(request.url).pathname })
   );
 }
 
@@ -2809,8 +2807,6 @@ export default async function handler(request, ctx) {
     executionContext: ctx ?? _getRequestExecutionContext() ?? null,
     unstableCacheRevalidation: "background",
   });
-  // Extract pathname for prerender work unit store (used by unstable_io() for error messages)
-  const __pathname = new URL(request.url).pathname;
   return _runWithUnifiedCtx(__uCtx, () =>
     __runWithPrerenderWorkUnit(async () => {
     _ensureFetchPatch();
@@ -2863,7 +2859,7 @@ export default async function handler(request, ctx) {
       }
     }
     return response;
-    }, { route: __pathname })
+    }, { route: () => new URL(request.url).pathname })
   );
 }
 
@@ -4675,8 +4671,6 @@ export default async function handler(request, ctx) {
     executionContext: ctx ?? _getRequestExecutionContext() ?? null,
     unstableCacheRevalidation: "background",
   });
-  // Extract pathname for prerender work unit store (used by unstable_io() for error messages)
-  const __pathname = new URL(request.url).pathname;
   return _runWithUnifiedCtx(__uCtx, () =>
     __runWithPrerenderWorkUnit(async () => {
     _ensureFetchPatch();
@@ -4729,7 +4723,7 @@ export default async function handler(request, ctx) {
       }
     }
     return response;
-    }, { route: __pathname })
+    }, { route: () => new URL(request.url).pathname })
   );
 }
 
@@ -6567,8 +6561,6 @@ export default async function handler(request, ctx) {
     executionContext: ctx ?? _getRequestExecutionContext() ?? null,
     unstableCacheRevalidation: "background",
   });
-  // Extract pathname for prerender work unit store (used by unstable_io() for error messages)
-  const __pathname = new URL(request.url).pathname;
   return _runWithUnifiedCtx(__uCtx, () =>
     __runWithPrerenderWorkUnit(async () => {
     _ensureFetchPatch();
@@ -6621,7 +6613,7 @@ export default async function handler(request, ctx) {
       }
     }
     return response;
-    }, { route: __pathname })
+    }, { route: () => new URL(request.url).pathname })
   );
 }
 
@@ -8433,8 +8425,6 @@ export default async function handler(request, ctx) {
     executionContext: ctx ?? _getRequestExecutionContext() ?? null,
     unstableCacheRevalidation: "background",
   });
-  // Extract pathname for prerender work unit store (used by unstable_io() for error messages)
-  const __pathname = new URL(request.url).pathname;
   return _runWithUnifiedCtx(__uCtx, () =>
     __runWithPrerenderWorkUnit(async () => {
     _ensureFetchPatch();
@@ -8487,7 +8477,7 @@ export default async function handler(request, ctx) {
       }
     }
     return response;
-    }, { route: __pathname })
+    }, { route: () => new URL(request.url).pathname })
   );
 }
 
@@ -10292,8 +10282,6 @@ export default async function handler(request, ctx) {
     executionContext: ctx ?? _getRequestExecutionContext() ?? null,
     unstableCacheRevalidation: "background",
   });
-  // Extract pathname for prerender work unit store (used by unstable_io() for error messages)
-  const __pathname = new URL(request.url).pathname;
   return _runWithUnifiedCtx(__uCtx, () =>
     __runWithPrerenderWorkUnit(async () => {
     _ensureFetchPatch();
@@ -10346,7 +10334,7 @@ export default async function handler(request, ctx) {
       }
     }
     return response;
-    }, { route: __pathname })
+    }, { route: () => new URL(request.url).pathname })
   );
 }
 

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -106,6 +106,7 @@ import "vinext/navigation-state";
 import { runWithRequestContext as _runWithUnifiedCtx, createRequestContext as _createUnifiedCtx } from "vinext/unified-request-context";
 import { reportRequestError as _reportRequestError } from "vinext/instrumentation";
 import { flattenErrorCauses as __flattenErrorCauses } from "<ROOT>/packages/vinext/src/utils/error-cause.js";
+import { runWithPrerenderWorkUnit as __runWithPrerenderWorkUnit } from "<ROOT>/packages/vinext/src/server/prerender-work-unit-setup.js";
 import { getSSRFontLinks as _getSSRFontLinks, getSSRFontStyles as _getSSRFontStylesGoogle, getSSRFontPreloads as _getSSRFontPreloadsGoogle } from "next/font/google";
 import { getSSRFontStyles as _getSSRFontStylesLocal, getSSRFontPreloads as _getSSRFontPreloadsLocal } from "next/font/local";
 function _getSSRFontStyles() { return [..._getSSRFontStylesGoogle(), ..._getSSRFontStylesLocal()]; }
@@ -949,7 +950,8 @@ export default async function handler(request, ctx) {
     executionContext: ctx ?? _getRequestExecutionContext() ?? null,
     unstableCacheRevalidation: "background",
   });
-  return _runWithUnifiedCtx(__uCtx, async () => {
+  return _runWithUnifiedCtx(__uCtx, () =>
+    __runWithPrerenderWorkUnit(async () => {
     _ensureFetchPatch();
     const __reqCtx = requestContextFromRequest(request);
     // Per-request container for middleware state. Passed into
@@ -1000,7 +1002,8 @@ export default async function handler(request, ctx) {
       }
     }
     return response;
-  });
+    })
+  );
 }
 
 async function _handleRequest(request, __reqCtx, _mwCtx) {
@@ -1960,6 +1963,7 @@ import "vinext/navigation-state";
 import { runWithRequestContext as _runWithUnifiedCtx, createRequestContext as _createUnifiedCtx } from "vinext/unified-request-context";
 import { reportRequestError as _reportRequestError } from "vinext/instrumentation";
 import { flattenErrorCauses as __flattenErrorCauses } from "<ROOT>/packages/vinext/src/utils/error-cause.js";
+import { runWithPrerenderWorkUnit as __runWithPrerenderWorkUnit } from "<ROOT>/packages/vinext/src/server/prerender-work-unit-setup.js";
 import { getSSRFontLinks as _getSSRFontLinks, getSSRFontStyles as _getSSRFontStylesGoogle, getSSRFontPreloads as _getSSRFontPreloadsGoogle } from "next/font/google";
 import { getSSRFontStyles as _getSSRFontStylesLocal, getSSRFontPreloads as _getSSRFontPreloadsLocal } from "next/font/local";
 function _getSSRFontStyles() { return [..._getSSRFontStylesGoogle(), ..._getSSRFontStylesLocal()]; }
@@ -2803,7 +2807,8 @@ export default async function handler(request, ctx) {
     executionContext: ctx ?? _getRequestExecutionContext() ?? null,
     unstableCacheRevalidation: "background",
   });
-  return _runWithUnifiedCtx(__uCtx, async () => {
+  return _runWithUnifiedCtx(__uCtx, () =>
+    __runWithPrerenderWorkUnit(async () => {
     _ensureFetchPatch();
     const __reqCtx = requestContextFromRequest(request);
     // Per-request container for middleware state. Passed into
@@ -2854,7 +2859,8 @@ export default async function handler(request, ctx) {
       }
     }
     return response;
-  });
+    })
+  );
 }
 
 async function _handleRequest(request, __reqCtx, _mwCtx) {
@@ -3820,6 +3826,7 @@ import "vinext/navigation-state";
 import { runWithRequestContext as _runWithUnifiedCtx, createRequestContext as _createUnifiedCtx } from "vinext/unified-request-context";
 import { reportRequestError as _reportRequestError } from "vinext/instrumentation";
 import { flattenErrorCauses as __flattenErrorCauses } from "<ROOT>/packages/vinext/src/utils/error-cause.js";
+import { runWithPrerenderWorkUnit as __runWithPrerenderWorkUnit } from "<ROOT>/packages/vinext/src/server/prerender-work-unit-setup.js";
 import { getSSRFontLinks as _getSSRFontLinks, getSSRFontStyles as _getSSRFontStylesGoogle, getSSRFontPreloads as _getSSRFontPreloadsGoogle } from "next/font/google";
 import { getSSRFontStyles as _getSSRFontStylesLocal, getSSRFontPreloads as _getSSRFontPreloadsLocal } from "next/font/local";
 function _getSSRFontStyles() { return [..._getSSRFontStylesGoogle(), ..._getSSRFontStylesLocal()]; }
@@ -4664,7 +4671,8 @@ export default async function handler(request, ctx) {
     executionContext: ctx ?? _getRequestExecutionContext() ?? null,
     unstableCacheRevalidation: "background",
   });
-  return _runWithUnifiedCtx(__uCtx, async () => {
+  return _runWithUnifiedCtx(__uCtx, () =>
+    __runWithPrerenderWorkUnit(async () => {
     _ensureFetchPatch();
     const __reqCtx = requestContextFromRequest(request);
     // Per-request container for middleware state. Passed into
@@ -4715,7 +4723,8 @@ export default async function handler(request, ctx) {
       }
     }
     return response;
-  });
+    })
+  );
 }
 
 async function _handleRequest(request, __reqCtx, _mwCtx) {
@@ -5675,6 +5684,7 @@ import "vinext/navigation-state";
 import { runWithRequestContext as _runWithUnifiedCtx, createRequestContext as _createUnifiedCtx } from "vinext/unified-request-context";
 import { reportRequestError as _reportRequestError } from "vinext/instrumentation";
 import { flattenErrorCauses as __flattenErrorCauses } from "<ROOT>/packages/vinext/src/utils/error-cause.js";
+import { runWithPrerenderWorkUnit as __runWithPrerenderWorkUnit } from "<ROOT>/packages/vinext/src/server/prerender-work-unit-setup.js";
 import { getSSRFontLinks as _getSSRFontLinks, getSSRFontStyles as _getSSRFontStylesGoogle, getSSRFontPreloads as _getSSRFontPreloadsGoogle } from "next/font/google";
 import { getSSRFontStyles as _getSSRFontStylesLocal, getSSRFontPreloads as _getSSRFontPreloadsLocal } from "next/font/local";
 function _getSSRFontStyles() { return [..._getSSRFontStylesGoogle(), ..._getSSRFontStylesLocal()]; }
@@ -6551,7 +6561,8 @@ export default async function handler(request, ctx) {
     executionContext: ctx ?? _getRequestExecutionContext() ?? null,
     unstableCacheRevalidation: "background",
   });
-  return _runWithUnifiedCtx(__uCtx, async () => {
+  return _runWithUnifiedCtx(__uCtx, () =>
+    __runWithPrerenderWorkUnit(async () => {
     _ensureFetchPatch();
     const __reqCtx = requestContextFromRequest(request);
     // Per-request container for middleware state. Passed into
@@ -6602,7 +6613,8 @@ export default async function handler(request, ctx) {
       }
     }
     return response;
-  });
+    })
+  );
 }
 
 async function _handleRequest(request, __reqCtx, _mwCtx) {
@@ -7562,6 +7574,7 @@ import "vinext/navigation-state";
 import { runWithRequestContext as _runWithUnifiedCtx, createRequestContext as _createUnifiedCtx } from "vinext/unified-request-context";
 import { reportRequestError as _reportRequestError } from "vinext/instrumentation";
 import { flattenErrorCauses as __flattenErrorCauses } from "<ROOT>/packages/vinext/src/utils/error-cause.js";
+import { runWithPrerenderWorkUnit as __runWithPrerenderWorkUnit } from "<ROOT>/packages/vinext/src/server/prerender-work-unit-setup.js";
 import { getSSRFontLinks as _getSSRFontLinks, getSSRFontStyles as _getSSRFontStylesGoogle, getSSRFontPreloads as _getSSRFontPreloadsGoogle } from "next/font/google";
 import { getSSRFontStyles as _getSSRFontStylesLocal, getSSRFontPreloads as _getSSRFontPreloadsLocal } from "next/font/local";
 function _getSSRFontStyles() { return [..._getSSRFontStylesGoogle(), ..._getSSRFontStylesLocal()]; }
@@ -8412,7 +8425,8 @@ export default async function handler(request, ctx) {
     executionContext: ctx ?? _getRequestExecutionContext() ?? null,
     unstableCacheRevalidation: "background",
   });
-  return _runWithUnifiedCtx(__uCtx, async () => {
+  return _runWithUnifiedCtx(__uCtx, () =>
+    __runWithPrerenderWorkUnit(async () => {
     _ensureFetchPatch();
     const __reqCtx = requestContextFromRequest(request);
     // Per-request container for middleware state. Passed into
@@ -8463,7 +8477,8 @@ export default async function handler(request, ctx) {
       }
     }
     return response;
-  });
+    })
+  );
 }
 
 async function _handleRequest(request, __reqCtx, _mwCtx) {
@@ -9423,6 +9438,7 @@ import "vinext/navigation-state";
 import { runWithRequestContext as _runWithUnifiedCtx, createRequestContext as _createUnifiedCtx } from "vinext/unified-request-context";
 import { reportRequestError as _reportRequestError } from "vinext/instrumentation";
 import { flattenErrorCauses as __flattenErrorCauses } from "<ROOT>/packages/vinext/src/utils/error-cause.js";
+import { runWithPrerenderWorkUnit as __runWithPrerenderWorkUnit } from "<ROOT>/packages/vinext/src/server/prerender-work-unit-setup.js";
 import { getSSRFontLinks as _getSSRFontLinks, getSSRFontStyles as _getSSRFontStylesGoogle, getSSRFontPreloads as _getSSRFontPreloadsGoogle } from "next/font/google";
 import { getSSRFontStyles as _getSSRFontStylesLocal, getSSRFontPreloads as _getSSRFontPreloadsLocal } from "next/font/local";
 function _getSSRFontStyles() { return [..._getSSRFontStylesGoogle(), ..._getSSRFontStylesLocal()]; }
@@ -10266,7 +10282,8 @@ export default async function handler(request, ctx) {
     executionContext: ctx ?? _getRequestExecutionContext() ?? null,
     unstableCacheRevalidation: "background",
   });
-  return _runWithUnifiedCtx(__uCtx, async () => {
+  return _runWithUnifiedCtx(__uCtx, () =>
+    __runWithPrerenderWorkUnit(async () => {
     _ensureFetchPatch();
     const __reqCtx = requestContextFromRequest(request);
     // Per-request container for middleware state. Passed into
@@ -10317,7 +10334,8 @@ export default async function handler(request, ctx) {
       }
     }
     return response;
-  });
+    })
+  );
 }
 
 async function _handleRequest(request, __reqCtx, _mwCtx) {

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -950,6 +950,8 @@ export default async function handler(request, ctx) {
     executionContext: ctx ?? _getRequestExecutionContext() ?? null,
     unstableCacheRevalidation: "background",
   });
+  // Extract pathname for prerender work unit store (used by unstable_io() for error messages)
+  const __pathname = new URL(request.url).pathname;
   return _runWithUnifiedCtx(__uCtx, () =>
     __runWithPrerenderWorkUnit(async () => {
     _ensureFetchPatch();
@@ -1002,7 +1004,7 @@ export default async function handler(request, ctx) {
       }
     }
     return response;
-    })
+    }, { route: __pathname })
   );
 }
 
@@ -2807,6 +2809,8 @@ export default async function handler(request, ctx) {
     executionContext: ctx ?? _getRequestExecutionContext() ?? null,
     unstableCacheRevalidation: "background",
   });
+  // Extract pathname for prerender work unit store (used by unstable_io() for error messages)
+  const __pathname = new URL(request.url).pathname;
   return _runWithUnifiedCtx(__uCtx, () =>
     __runWithPrerenderWorkUnit(async () => {
     _ensureFetchPatch();
@@ -2859,7 +2863,7 @@ export default async function handler(request, ctx) {
       }
     }
     return response;
-    })
+    }, { route: __pathname })
   );
 }
 
@@ -4671,6 +4675,8 @@ export default async function handler(request, ctx) {
     executionContext: ctx ?? _getRequestExecutionContext() ?? null,
     unstableCacheRevalidation: "background",
   });
+  // Extract pathname for prerender work unit store (used by unstable_io() for error messages)
+  const __pathname = new URL(request.url).pathname;
   return _runWithUnifiedCtx(__uCtx, () =>
     __runWithPrerenderWorkUnit(async () => {
     _ensureFetchPatch();
@@ -4723,7 +4729,7 @@ export default async function handler(request, ctx) {
       }
     }
     return response;
-    })
+    }, { route: __pathname })
   );
 }
 
@@ -6561,6 +6567,8 @@ export default async function handler(request, ctx) {
     executionContext: ctx ?? _getRequestExecutionContext() ?? null,
     unstableCacheRevalidation: "background",
   });
+  // Extract pathname for prerender work unit store (used by unstable_io() for error messages)
+  const __pathname = new URL(request.url).pathname;
   return _runWithUnifiedCtx(__uCtx, () =>
     __runWithPrerenderWorkUnit(async () => {
     _ensureFetchPatch();
@@ -6613,7 +6621,7 @@ export default async function handler(request, ctx) {
       }
     }
     return response;
-    })
+    }, { route: __pathname })
   );
 }
 
@@ -8425,6 +8433,8 @@ export default async function handler(request, ctx) {
     executionContext: ctx ?? _getRequestExecutionContext() ?? null,
     unstableCacheRevalidation: "background",
   });
+  // Extract pathname for prerender work unit store (used by unstable_io() for error messages)
+  const __pathname = new URL(request.url).pathname;
   return _runWithUnifiedCtx(__uCtx, () =>
     __runWithPrerenderWorkUnit(async () => {
     _ensureFetchPatch();
@@ -8477,7 +8487,7 @@ export default async function handler(request, ctx) {
       }
     }
     return response;
-    })
+    }, { route: __pathname })
   );
 }
 
@@ -10282,6 +10292,8 @@ export default async function handler(request, ctx) {
     executionContext: ctx ?? _getRequestExecutionContext() ?? null,
     unstableCacheRevalidation: "background",
   });
+  // Extract pathname for prerender work unit store (used by unstable_io() for error messages)
+  const __pathname = new URL(request.url).pathname;
   return _runWithUnifiedCtx(__uCtx, () =>
     __runWithPrerenderWorkUnit(async () => {
     _ensureFetchPatch();
@@ -10334,7 +10346,7 @@ export default async function handler(request, ctx) {
       }
     }
     return response;
-    })
+    }, { route: __pathname })
   );
 }
 

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -1481,8 +1481,8 @@ describe("App Router integration", () => {
   });
 
   it("allows server action POST with matching Origin header", async () => {
-    // This will fail with 500 (action not found) rather than 403,
-    // proving the CSRF check passed and execution reached the action handler.
+    // Ported from Next.js: test/e2e/app-dir/no-server-actions/no-server-actions.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/no-server-actions/no-server-actions.test.ts
     const res = await fetch(`${baseUrl}/actions.rsc`, {
       method: "POST",
       headers: {
@@ -1493,9 +1493,9 @@ describe("App Router integration", () => {
       },
       body: "[]",
     });
-    // Should NOT be 403 — the CSRF check passes for same-origin.
-    // It may be 500 because the action ID doesn't exist, which is fine.
-    expect(res.status).not.toBe(403);
+    expect(res.status).toBe(404);
+    expect(res.headers.get("x-nextjs-action-not-found")).toBe("1");
+    expect(await res.text()).toBe("Server action not found.");
   });
 
   it("allows server action POST without Origin header (non-fetch navigation)", async () => {
@@ -1508,8 +1508,8 @@ describe("App Router integration", () => {
       },
       body: "[]",
     });
-    // Should NOT be 403 — missing Origin is allowed.
-    expect(res.status).not.toBe(403);
+    expect(res.status).toBe(404);
+    expect(res.headers.get("x-nextjs-action-not-found")).toBe("1");
   });
 
   it("rejects cyclic multipart server action payloads before decodeReply", async () => {
@@ -2269,11 +2269,19 @@ describe("App Router Production server (startProdServer)", () => {
     // Wait for cache entry to become stale (revalidate=1, generous margin for slow CI)
     await new Promise((resolve) => setTimeout(resolve, 2000));
 
-    // STALE — serves stale data, triggers background regen
+    // STALE — serves stale data, triggers background regen.
+    // The stale response must return quickly: it must NOT block on the
+    // background regeneration. Measure total duration to catch regressions.
+    const staleStart = Date.now();
     const staleRes = await fetch(`${baseUrl}/api/static-data`);
+    const staleDuration = Date.now() - staleStart;
     expect(staleRes.headers.get("x-vinext-cache")).toBe("STALE");
     const staleBody = await staleRes.json();
     expect(staleBody.timestamp).toBe(cachedTimestamp); // Still the old data
+
+    // The stale response must arrive promptly; background regen runs
+    // out-of-band via ctx.waitUntil(). Allow 500ms for cold-start latency.
+    expect(staleDuration).toBeLessThan(500);
 
     // Poll until background regen completes (up to 5s)
     const deadline = Date.now() + 5000;
@@ -2288,6 +2296,48 @@ describe("App Router Production server (startProdServer)", () => {
     // HIT — fresh data from background regen
     expect(freshRes.headers.get("x-vinext-cache")).toBe("HIT");
     expect(freshBody.timestamp).not.toBe(cachedTimestamp); // New data
+  });
+
+  // Test pattern ported from Next.js:
+  // test/e2e/app-dir/use-cache-swr/use-cache-swr.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/use-cache-swr/use-cache-swr.test.ts
+  // (adapted from "use cache" SWR to route handler ISR with export const revalidate)
+  it("route handler ISR: STALE completes quickly without blocking on background regen", async () => {
+    // /api/slow-isr has revalidate=1 and a 1s handler delay.
+    // Populate the cache (cold request, takes ~1s).
+    const coldStart = Date.now();
+    const cold = await fetch(`${baseUrl}/api/slow-isr`);
+    expect(cold.status).toBe(200);
+    const coldBody = await cold.json();
+    const coldDuration = Date.now() - coldStart;
+    expect(coldDuration).toBeGreaterThanOrEqual(700); // roughly 1s handler delay
+
+    // Wait for the 1s revalidate window to expire.
+    await new Promise((resolve) => setTimeout(resolve, 1500));
+
+    // Stale request: must return the cached value quickly (< 500ms), not
+    // the full 1s handler duration. If the response is blocked on background
+    // regeneration, this will take ≥ 1s and fail.
+    const staleStart = Date.now();
+    const stale = await fetch(`${baseUrl}/api/slow-isr`);
+    const staleDuration = Date.now() - staleStart;
+    expect(stale.headers.get("x-vinext-cache")).toBe("STALE");
+    const staleBody = await stale.json();
+    expect(staleBody.timestamp).toBe(coldBody.timestamp); // Still the old data
+    expect(staleDuration).toBeLessThan(500);
+
+    // Wait for background regen to complete, then verify fresh data.
+    const deadline = Date.now() + 5000;
+    let freshRes: Response;
+    let freshBody: { timestamp: number };
+    do {
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      freshRes = await fetch(`${baseUrl}/api/slow-isr`);
+      freshBody = await freshRes.json();
+    } while (freshRes.headers.get("x-vinext-cache") !== "HIT" && Date.now() < deadline);
+
+    expect(freshRes.headers.get("x-vinext-cache")).toBe("HIT");
+    expect(freshBody.timestamp).not.toBe(coldBody.timestamp);
   });
 
   it("route handler ISR: auto-HEAD returns cached headers with empty body", async () => {
@@ -2732,7 +2782,9 @@ describe("App Router Static export", () => {
         layoutErrorPaths: [],
         notFoundPath: null,
         notFoundPaths: [],
+        forbiddenPaths: [],
         forbiddenPath: null,
+        unauthorizedPaths: [],
         unauthorizedPath: null,
         isDynamic: true,
         params: ["id"],
@@ -2777,7 +2829,9 @@ describe("App Router Static export", () => {
         layoutErrorPaths: [],
         notFoundPath: null,
         notFoundPaths: [],
+        forbiddenPaths: [],
         forbiddenPath: null,
+        unauthorizedPaths: [],
         unauthorizedPath: null,
         isDynamic: false,
         params: [],
@@ -2865,9 +2919,10 @@ describe("metadata routes integration (App Router)", () => {
     const appDir = path.resolve(import.meta.dirname, "./fixtures/app-basic/app");
     const routes = scanMetadataFiles(appDir);
 
-    const iconRoute = routes.find((r: { type: string }) => r.type === "icon");
+    const iconRoute = routes.find(
+      (r: { type: string; isDynamic: boolean }) => r.type === "icon" && r.isDynamic,
+    );
     expect(iconRoute).toBeDefined();
-    // Dynamic icon.tsx should take priority over static icon.png at same URL
     expect(iconRoute!.isDynamic).toBe(true);
     expect(iconRoute!.servedUrl).toBe("/icon");
     expect(iconRoute!.contentType).toBe("image/png");
@@ -2881,7 +2936,7 @@ describe("metadata routes integration (App Router)", () => {
     const appleIcon = routes.find((r: { type: string }) => r.type === "apple-icon");
     expect(appleIcon).toBeDefined();
     expect(appleIcon!.isDynamic).toBe(false);
-    expect(appleIcon!.servedUrl).toBe("/apple-icon");
+    expect(appleIcon!.servedUrl).toBe("/apple-icon.png");
     expect(appleIcon!.contentType).toBe("image/png");
   });
 
@@ -2892,15 +2947,15 @@ describe("metadata routes integration (App Router)", () => {
 
     const ogImage = routes.find(
       (r: { type: string; servedUrl: string }) =>
-        r.type === "opengraph-image" && r.servedUrl === "/about/opengraph-image",
+        r.type === "opengraph-image" && r.servedUrl === "/about/opengraph-image.png",
     );
     expect(ogImage).toBeDefined();
     expect(ogImage!.isDynamic).toBe(false);
     expect(ogImage!.contentType).toBe("image/png");
   });
 
-  it("serves static /apple-icon as PNG with cache headers", async () => {
-    const res = await fetch(`${baseUrl}/apple-icon`);
+  it("serves static /apple-icon.png as PNG with cache headers", async () => {
+    const res = await fetch(`${baseUrl}/apple-icon.png`);
     expect(res.status).toBe(200);
     expect(res.headers.get("content-type")).toBe("image/png");
     expect(res.headers.get("cache-control")).toBe("public, max-age=0, must-revalidate");
@@ -2913,14 +2968,128 @@ describe("metadata routes integration (App Router)", () => {
     expect(magic[3]).toBe(0x47); // G
   });
 
-  it("serves nested static /about/opengraph-image as PNG", async () => {
-    const res = await fetch(`${baseUrl}/about/opengraph-image`);
+  it("serves nested static /about/opengraph-image.png as PNG", async () => {
+    const res = await fetch(`${baseUrl}/about/opengraph-image.png`);
     expect(res.status).toBe(200);
     expect(res.headers.get("content-type")).toBe("image/png");
     const buf = await res.arrayBuffer();
     const magic = new Uint8Array(buf.slice(0, 4));
     expect(magic[0]).toBe(0x89);
     expect(magic[1]).toBe(0x50);
+  });
+
+  it("injects file-based metadata into head tags for static metadata files", async () => {
+    // Ported from Next.js: test/e2e/app-dir/metadata-static-file/metadata-static-file-static-route.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/metadata-static-file/metadata-static-file-static-route.test.ts
+    const res = await fetch(`${baseUrl}/metadata-static`);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+
+    expect(html).toMatch(/<link[^>]+rel="icon"[^>]+href="[^"]*\/favicon\.ico(?:\?[^"]+)?"[^>]*>/);
+    expect(html).toMatch(
+      /<link[^>]+rel="apple-touch-icon"[^>]+href="[^"]*\/metadata-static\/apple-icon\.png(?:\?[^"]+)?"[^>]*>/,
+    );
+    expect(html).toMatch(
+      /<link[^>]+rel="icon"[^>]+href="[^"]*\/metadata-static\/icon\.png(?:\?[^"]+)?"[^>]*>/,
+    );
+    expect(html).toMatch(
+      /<meta[^>]+property="og:image"[^>]+content="[^"]*\/metadata-static\/opengraph-image\.png(?:\?[^"]+)?"[^>]*>/,
+    );
+    expect(html).toMatch(
+      /<meta[^>]+property="og:image:alt"[^>]+content="Static OG image alt text[^"]*"[^>]*>/,
+    );
+    expect(html).toMatch(
+      /<meta[^>]+name="twitter:image"[^>]+content="[^"]*\/metadata-static\/twitter-image\.png(?:\?[^"]+)?"[^>]*>/,
+    );
+    expect(html).toMatch(
+      /<meta[^>]+name="twitter:image:alt"[^>]+content="Static Twitter image alt text[^"]*"[^>]*>/,
+    );
+    expect(html).toMatch(/<link[^>]+rel="manifest"[^>]+href="[^"]*\/manifest\.webmanifest"[^>]*>/);
+  });
+
+  it("injects sizes=any for static SVG icon metadata routes", async () => {
+    // Ported from Next.js: test/e2e/app-dir/metadata-svg-icon/metadata-svg-icon.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/metadata-svg-icon/metadata-svg-icon.test.ts
+    const res = await fetch(`${baseUrl}/metadata-svg-icon`);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+
+    expect(html).toMatch(
+      /<link[^>]+rel="icon"[^>]+href="[^"]*\/metadata-svg-icon\/icon\.svg(?:\?[^"]+)?"[^>]+sizes="any"[^>]+type="image\/svg\+xml"[^>]*>/,
+    );
+  });
+
+  it("renders icons.icon descriptor object metadata without crashing", async () => {
+    const res = await fetch(`${baseUrl}/metadata-icons-object`);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+
+    expect(html).toMatch(
+      /<link[^>]+rel="icon"[^>]+href="[^"]*\/metadata-icons-object\/object-icon\.png"[^>]+sizes="96x96"[^>]+type="image\/png"[^>]*>/,
+    );
+  });
+
+  it("injects dynamic metadata image routes into the head", async () => {
+    // Ported from Next.js: test/e2e/app-dir/metadata/metadata.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/metadata/metadata.test.ts
+    const homeRes = await fetch(`${baseUrl}/`);
+    expect(homeRes.status).toBe(200);
+    const homeHtml = await homeRes.text();
+    expect(homeHtml).toMatch(
+      /<link[^>]+rel="icon"[^>]+href="[^"]*\/favicon\.ico(?:\?[^"]+)?"[^>]*>/,
+    );
+    expect(homeHtml).toMatch(
+      /<link[^>]+rel="icon"[^>]+href="[^"]*\/icon(?:\?[^"]+)?"[^>]+sizes="32x32"[^>]+type="image\/png"[^>]*>/,
+    );
+
+    const blogRes = await fetch(`${baseUrl}/blog/hello-world`);
+    expect(blogRes.status).toBe(200);
+    const blogHtml = await blogRes.text();
+    expect(blogHtml).toMatch(
+      /<meta[^>]+property="og:image"[^>]+content="[^"]*\/blog\/hello-world\/opengraph-image(?:\?[^"]+)?"[^>]*>/,
+    );
+    expect(blogHtml).toMatch(/<meta[^>]+property="og:image:width"[^>]+content="1200"[^>]*>/);
+    expect(blogHtml).toMatch(/<meta[^>]+property="og:image:height"[^>]+content="630"[^>]*>/);
+    expect(blogHtml).toMatch(/<meta[^>]+property="og:image:type"[^>]+content="image\/png"[^>]*>/);
+    expect(blogHtml).toMatch(
+      /<meta[^>]+property="og:image:alt"[^>]+content="Blog post open graph image"[^>]*>/,
+    );
+  });
+
+  it("injects multiple generateImageMetadata icon routes into the head", async () => {
+    // Ported from Next.js: test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
+    const res = await fetch(`${baseUrl}/metadata-multi-image/big`);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+
+    expect(html).toMatch(
+      /<link[^>]+rel="icon"[^>]+href="[^"]*\/metadata-multi-image\/big\/icon\/big-small(?:\?[^"]+)?"[^>]+sizes="48x48"[^>]+type="image\/png"[^>]*>/,
+    );
+    expect(html).toMatch(
+      /<link[^>]+rel="icon"[^>]+href="[^"]*\/metadata-multi-image\/big\/icon\/big-medium(?:\?[^"]+)?"[^>]+sizes="72x72"[^>]+type="image\/png"[^>]*>/,
+    );
+  });
+
+  it("uses placeholder urls for static metadata files in dynamic segments", async () => {
+    // Ported from Next.js: test/e2e/app-dir/metadata-static-file/metadata-static-file-dynamic-route.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/metadata-static-file/metadata-static-file-dynamic-route.test.ts
+    const res = await fetch(`${baseUrl}/metadata-dynamic-static/hello-world`);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+
+    expect(html).toMatch(
+      /<link[^>]+rel="apple-touch-icon"[^>]+href="[^"]*\/metadata-dynamic-static\/-\/apple-icon\.png(?:\?[^"]+)?"[^>]*>/,
+    );
+    expect(html).toMatch(
+      /<link[^>]+rel="icon"[^>]+href="[^"]*\/metadata-dynamic-static\/-\/icon\.png(?:\?[^"]+)?"[^>]*>/,
+    );
+    expect(html).toMatch(
+      /<meta[^>]+property="og:image"[^>]+content="[^"]*\/metadata-dynamic-static\/-\/opengraph-image\.png(?:\?[^"]+)?"[^>]*>/,
+    );
+    expect(html).toMatch(
+      /<meta[^>]+name="twitter:image"[^>]+content="[^"]*\/metadata-dynamic-static\/-\/twitter-image\.png(?:\?[^"]+)?"[^>]*>/,
+    );
   });
 
   it("scanMetadataFiles discovers static favicon.ico at root", async () => {
@@ -3021,6 +3190,33 @@ describe("metadata routes integration (App Router)", () => {
     expect(ogImage!.isDynamic).toBe(true);
   });
 
+  it("scanMetadataFiles discovers static metadata files in dynamic segments with placeholders", async () => {
+    const { scanMetadataFiles } = await import("../packages/vinext/src/server/metadata-routes.js");
+    const appDir = path.resolve(import.meta.dirname, "./fixtures/app-basic/app");
+    const routes = scanMetadataFiles(appDir);
+    const icon = routes.find(
+      (r: { type: string; servedUrl: string }) =>
+        r.type === "icon" && r.servedUrl === "/metadata-dynamic-static/-/icon.png",
+    );
+    expect(icon).toBeDefined();
+    expect(icon!.isDynamic).toBe(false);
+  });
+
+  it("serves static metadata files in dynamic segments from placeholder urls", async () => {
+    const res = await fetch(`${baseUrl}/metadata-dynamic-static/-/icon.png`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("image/png");
+  });
+
+  it("injects file-based metadata into not-found fallback pages", async () => {
+    const res = await fetch(`${baseUrl}/missing-metadata-page`);
+    expect(res.status).toBe(404);
+    const html = await res.text();
+    expect(html).toMatch(/<link[^>]+rel="icon"[^>]+href="[^"]*\/favicon\.ico(?:\?[^"]+)?"[^>]*>/);
+    expect(html).toMatch(/<link[^>]+rel="icon"[^>]+href="[^"]*\/icon(?:\?[^"]+)?"[^>]*>/);
+    expect(html).toMatch(/<link[^>]+rel="manifest"[^>]+href="[^"]*\/manifest\.webmanifest"[^>]*>/);
+  });
+
   it("serves dynamic opengraph-image in dynamic segment with params", async () => {
     const res = await fetch(`${baseUrl}/blog/hello-world/opengraph-image`);
     expect(res.status).toBe(200);
@@ -3034,6 +3230,33 @@ describe("metadata routes integration (App Router)", () => {
     expect(res.status).toBe(200);
     const text = await res.text();
     expect(text).toBe("og:my-post");
+  });
+
+  it("serves dynamic icon routes generated by generateImageMetadata", async () => {
+    // Ported from Next.js: test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
+    const res = await fetch(`${baseUrl}/metadata-multi-image/big/icon/big-small`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("image/png");
+  });
+
+  it("returns 404 for unknown generateImageMetadata ids", async () => {
+    // Ported from Next.js: test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
+    const res = await fetch(`${baseUrl}/metadata-multi-image/big/icon/missing`);
+    expect(res.status).toBe(404);
+  });
+
+  it("serves generateImageMetadata ids after catch-all metadata route params", async () => {
+    const res = await fetch(`${baseUrl}/metadata-multi-catchall/a/b/icon/a-b-small`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("image/png");
+  });
+
+  it("serves valid generateImageMetadata ids when invalid siblings are present", async () => {
+    const res = await fetch(`${baseUrl}/metadata-invalid-id-sibling/icon/good`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("image/png");
   });
 });
 
@@ -3201,7 +3424,9 @@ describe("App Router next.config.js features (generateRscEntry)", () => {
       errorPath: null,
       layoutErrorPaths: [null],
       notFoundPath: null,
+      forbiddenPaths: [],
       forbiddenPath: null,
+      unauthorizedPaths: [],
       unauthorizedPath: null,
       routeSegments: [],
       layoutTreePositions: [0],
@@ -3219,7 +3444,9 @@ describe("App Router next.config.js features (generateRscEntry)", () => {
       errorPath: null,
       layoutErrorPaths: [null],
       notFoundPath: null,
+      forbiddenPaths: [],
       forbiddenPath: null,
+      unauthorizedPaths: [],
       unauthorizedPath: null,
       routeSegments: [],
       layoutTreePositions: [0],
@@ -3237,7 +3464,9 @@ describe("App Router next.config.js features (generateRscEntry)", () => {
       errorPath: null,
       layoutErrorPaths: [null],
       notFoundPath: null,
+      forbiddenPaths: [],
       forbiddenPath: null,
+      unauthorizedPaths: [],
       unauthorizedPath: null,
       routeSegments: [],
       layoutTreePositions: [0],
@@ -3657,17 +3886,24 @@ describe("App Router next.config.js features (generateRscEntry)", () => {
     }
   });
 
-  describe("rscOnError: non-plain object dev hint", () => {
-    it("imports error handling helpers from app-rsc-errors module", () => {
+  describe("RSC error runtime delegation", () => {
+    it("imports RSC error helpers from a normal server module", () => {
       const code = generateRscEntry("/tmp/test/app", minimalRoutes, null, [], null, "", false);
-      // Error handling was extracted to app-rsc-errors.ts (refactor #964)
-      expect(code).toContain("sanitizeErrorForClient");
-      expect(code).toContain("flattenErrorCauses");
+
+      expect(code).toContain("createRscOnErrorHandler as __createRscOnErrorHandler");
+      expect(code).toContain("sanitizeErrorForClient as __sanitizeErrorForClient");
+      expect(code).toContain("server/app-rsc-errors.js");
     });
 
-    // Runtime behavior tests moved to app-rsc-errors.test.ts since the
-    // rscOnError and __errorDigest functions were extracted to a typed runtime
-    // helper (see refactor: extract RSC runtime primitives #964).
+    it("keeps request-specific onError wiring in the generated entry", () => {
+      const code = generateRscEntry("/tmp/test/app", minimalRoutes, null, [], null, "", false);
+
+      expect(code).toContain("return __createRscOnErrorHandler({");
+      expect(code).toContain("reportRequestError: _reportRequestError");
+      expect(code).toContain("requestInfo,");
+      expect(code).not.toContain("function rscOnError(");
+      expect(code).not.toContain("function __errorDigest(");
+    });
   });
 
   describe("build-time classification dispatch stub", () => {
@@ -3909,7 +4145,9 @@ describe("RSC Flight hint fix", () => {
       layoutErrorPaths: [null],
       notFoundPath: null,
       notFoundPaths: [null],
+      forbiddenPaths: [],
       forbiddenPath: null,
+      unauthorizedPaths: [],
       unauthorizedPath: null,
       routeSegments: [],
       layoutTreePositions: [0],
@@ -4318,7 +4556,9 @@ describe("generateRscEntry ISR code generation", () => {
       errorPath: null,
       layoutErrorPaths: [null],
       notFoundPath: null,
+      forbiddenPaths: [],
       forbiddenPath: null,
+      unauthorizedPaths: [],
       unauthorizedPath: null,
       routeSegments: [],
       layoutTreePositions: [0],
@@ -4332,18 +4572,21 @@ describe("generateRscEntry ISR code generation", () => {
     expect(code).toContain('process.env.NODE_ENV === "production"');
   });
 
-  it("generated code imports ISR helpers from isr-cache module", () => {
+  it("generated code delegates ISR cache primitives to the typed cache module", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes);
     expect(code).toContain("isrGet as __isrGet");
     expect(code).toContain("isrSet as __isrSet");
     expect(code).toContain("triggerBackgroundRegeneration as __triggerBackgroundRegeneration");
-    expect(code).toContain("appIsrRouteKey as __isrRouteKey");
+    expect(code).toContain("appIsrHtmlKey as __isrHtmlKey");
+    expect(code).toContain("normalizeMountedSlotsHeader as __normalizeMountedSlotsHeader");
+    expect(code).not.toContain("async function __isrGet(");
+    expect(code).not.toContain("function __isrCacheKey(");
+    expect(code).not.toContain("const __pendingRegenerations = new Map()");
   });
 
   it("generated code threads collected fetch tags into page ISR writes and delegates route ISR", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes);
     expect(code).toContain("getCollectedFetchTags");
-    expect(code).toContain("buildPageCacheTags");
     expect(code).toContain(
       'buildPageCacheTags(cleanPathname, [], route.routeSegments, route.routeHandler ? "route" : "page")',
     );
@@ -4353,13 +4596,20 @@ describe("generateRscEntry ISR code generation", () => {
     expect(code).toContain(
       'const __pageTags = buildPageCacheTags(cleanPathname, getCollectedFetchTags(), route.routeSegments, "page")',
     );
-    // The Array.isArray fallback has been moved to the typed helper in isr-cache.ts
+    expect(code).toContain("isrSet: __isrSet");
+    expect(code).not.toContain("function __pageCacheTags(");
   });
 
   it("generated handler exports async function handler(request, ctx)", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes);
     // The handler must accept a ctx param so ExecutionContext is threaded through
     expect(code).toMatch(/export default async function handler\s*\(\s*request\s*,\s*ctx\s*\)/);
+  });
+
+  it("generated code leaves cache handler access to the ISR cache module", () => {
+    const code = generateRscEntry("/tmp/test/app", minimalRoutes);
+    expect(code).not.toContain("getCacheHandler");
+    expect(code).toContain('"next/cache"');
   });
 
   it("generated code stores root layout params separately from leaf params", () => {
@@ -4462,6 +4712,7 @@ describe("generateRscEntry ISR code generation", () => {
   it("generated code threads intercept layout modules through slot overrides", () => {
     const routeWithInterceptLayouts: AppRoute = {
       errorPath: null,
+      forbiddenPaths: [],
       forbiddenPath: null,
       isDynamic: false,
       layoutErrorPaths: [null],
@@ -4501,6 +4752,7 @@ describe("generateRscEntry ISR code generation", () => {
       routeSegments: [],
       templates: [],
       templateTreePositions: [],
+      unauthorizedPaths: [],
       unauthorizedPath: null,
     };
 
@@ -4509,6 +4761,45 @@ describe("generateRscEntry ISR code generation", () => {
     expect(code).toContain("interceptLayouts: [mod_");
     expect(code).toContain("interceptLayouts: intercept.interceptLayouts");
     expect(code).toContain("layoutModules: opts.interceptLayouts || null");
+    expect(code).toContain(
+      "resolveActiveParallelRouteHeadInputs as __resolveActiveParallelRouteHeadInputs",
+    );
+    expect(code).toContain("parallelRoutes: __resolveActiveParallelRouteHeadInputs({");
+    expect(code).toContain("interceptPage: opts?.interceptPage ?? null");
+  });
+
+  it("generated code seeds root params around prerender generateStaticParams", () => {
+    const routeWithRootParams: AppRoute = {
+      errorPath: null,
+      forbiddenPath: null,
+      forbiddenPaths: [],
+      isDynamic: true,
+      layoutErrorPaths: [null],
+      layouts: ["/tmp/test/app/[locale]/layout.tsx"],
+      layoutTreePositions: [1],
+      loadingPath: null,
+      notFoundPath: null,
+      notFoundPaths: [null],
+      pagePath: "/tmp/test/app/[locale]/blog/[slug]/page.tsx",
+      parallelSlots: [],
+      params: ["locale", "slug"],
+      pattern: "/:locale/blog/:slug",
+      patternParts: [":locale", "blog", ":slug"],
+      rootParamNames: ["locale"],
+      routePath: null,
+      routeSegments: ["[locale]", "blog", "[slug]"],
+      templates: [],
+      templateTreePositions: [],
+      unauthorizedPaths: [],
+      unauthorizedPath: null,
+    };
+
+    const code = generateRscEntry("/tmp/test/app", [routeWithRootParams]);
+
+    expect(code).toContain("const rootParamNamesMap = {");
+    expect(code).toContain('"/:locale/blog/:slug": ["locale"]');
+    expect(code).toContain("rootParamNamesByPattern: rootParamNamesMap");
+    expect(code).toContain("handleAppPrerenderEndpoint as __handleAppPrerenderEndpoint");
   });
 
   it("generated code delegates page boundary rendering to typed helpers", () => {
@@ -4550,6 +4841,8 @@ describe("generateRscEntry ISR code generation", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes);
     expect(code).toContain("readAppPageCacheResponse as __readAppPageCacheResponse");
     expect(code).toContain("scheduleBackgroundRegeneration(key, renderFn) {");
+    expect(code).toContain('routerKind: "App Router"');
+    expect(code).toContain('routeType: "render"');
     expect(code).toContain("renderFreshPageForCache: async function()");
   });
 

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -3283,7 +3283,7 @@ describe("App Router next.config.js features (generateRscEntry)", () => {
       headers: [{ source: "/api/(.*)", headers: [{ key: "X-Custom-Header", value: "vinext" }] }],
     });
     expect(code).toContain("__configHeaders");
-    expect(code).toContain("matchHeaders");
+    expect(code).toContain("applyConfigHeadersToResponse");
     expect(code).toContain("X-Custom-Header");
     expect(code).toContain("vinext");
   });
@@ -3658,130 +3658,16 @@ describe("App Router next.config.js features (generateRscEntry)", () => {
   });
 
   describe("rscOnError: non-plain object dev hint", () => {
-    it("includes detection for the 'Only plain objects' RSC serialization error", () => {
+    it("imports error handling helpers from app-rsc-errors module", () => {
       const code = generateRscEntry("/tmp/test/app", minimalRoutes, null, [], null, "", false);
-      expect(code).toContain(
-        "Only plain objects, and a few built-ins, can be passed to Client Components",
-      );
+      // Error handling was extracted to app-rsc-errors.ts (refactor #964)
+      expect(code).toContain("sanitizeErrorForClient");
+      expect(code).toContain("flattenErrorCauses");
     });
 
-    it("guards the dev hint behind a NODE_ENV !== production check", () => {
-      const code = generateRscEntry("/tmp/test/app", minimalRoutes, null, [], null, "", false);
-      // The hint must be suppressed in production builds
-      expect(code).toContain('process.env.NODE_ENV !== "production"');
-    });
-
-    it("includes actionable guidance about module namespace objects in the hint", () => {
-      const code = generateRscEntry("/tmp/test/app", minimalRoutes, null, [], null, "", false);
-      expect(code).toContain("import * as X");
-      expect(code).toContain("[vinext] RSC serialization error");
-    });
-
-    it("includes actionable guidance about class instances in the hint", () => {
-      const code = generateRscEntry("/tmp/test/app", minimalRoutes, null, [], null, "", false);
-      expect(code).toContain("class instance");
-    });
-
-    it("does not affect the digest return path for navigation errors", () => {
-      const code = generateRscEntry("/tmp/test/app", minimalRoutes, null, [], null, "", false);
-      // The existing digest path (redirect/notFound) must still be present
-      expect(code).toContain('"digest" in error');
-      expect(code).toContain("String(error.digest)");
-    });
-
-    // Runtime tests: extract the rscOnError function from the generated code
-    // and evaluate it. This catches syntax errors and logic bugs that the
-    // string-presence tests above would miss (e.g. unterminated strings,
-    // wrong return values, broken control flow).
-    describe("runtime behavior", () => {
-      let rscOnError: (error: unknown) => string | undefined;
-      let prodRscOnError: (error: unknown) => string | undefined;
-      let digestFn: string;
-      let onErrorFn: string;
-
-      beforeAll(() => {
-        const code = generateRscEntry("/tmp/test/app", minimalRoutes, null, [], null, "", false);
-
-        // Extract a top-level function from the generated code by matching
-        // balanced braces (simple regex can't handle nested braces).
-        function extractFunction(src: string, name: string): string {
-          const marker = `function ${name}(`;
-          const start = src.indexOf(marker);
-          if (start === -1) throw new Error(`Could not find ${name} in generated code`);
-          const braceStart = src.indexOf("{", start);
-          let depth = 0;
-          for (let i = braceStart; i < src.length; i++) {
-            if (src[i] === "{") depth++;
-            else if (src[i] === "}") depth--;
-            if (depth === 0) return src.slice(start, i + 1);
-          }
-          throw new Error(`Unbalanced braces in ${name}`);
-        }
-
-        digestFn = extractFunction(code, "__errorDigest");
-        onErrorFn = extractFunction(code, "rscOnError");
-
-        const body = `${digestFn}\n${onErrorFn}\nreturn rscOnError;`;
-        // oxlint-disable-next-line no-new-func, @typescript-eslint/no-implied-eval -- reconstructing emitted runtime code is the behavior under test
-        const factory = new Function("process", body);
-        rscOnError = factory({ env: { NODE_ENV: "development" } });
-        prodRscOnError = factory({ env: { NODE_ENV: "production" } });
-      });
-
-      it("returns the digest string for navigation errors (redirect/notFound)", () => {
-        const error = Object.assign(new Error("NEXT_REDIRECT"), {
-          digest: "NEXT_REDIRECT;push;/dashboard;307",
-        });
-        expect(rscOnError(error)).toBe("NEXT_REDIRECT;push;/dashboard;307");
-      });
-
-      it("logs an actionable hint and returns undefined for RSC serialization errors", () => {
-        const spy = vi.spyOn(console, "error").mockImplementation(() => {});
-        try {
-          const error = new Error(
-            "Only plain objects, and a few built-ins, can be passed to Client Components from Server Components. " +
-              "Objects with toJSON methods are not supported. Module namespace objects are not supported.",
-          );
-          const result = rscOnError(error);
-          expect(result).toBeUndefined();
-          expect(spy).toHaveBeenCalledOnce();
-          expect(spy.mock.calls[0]![0]).toContain("[vinext] RSC serialization error");
-        } finally {
-          spy.mockRestore();
-        }
-      });
-
-      it("returns undefined for generic errors in dev (no digest, no serialization match)", () => {
-        const spy = vi.spyOn(console, "error").mockImplementation(() => {});
-        try {
-          const result = rscOnError(new Error("something went wrong"));
-          expect(result).toBeUndefined();
-          // Should NOT log the hint for unrelated errors
-          expect(spy).not.toHaveBeenCalled();
-        } finally {
-          spy.mockRestore();
-        }
-      });
-
-      it("does not swallow strings thrown in Server Components", () => {
-        const result = prodRscOnError("this is a test string");
-        // Should return a digest hash (not undefined), indicating the string
-        // was processed through the normal error path
-        expect(result).toBeDefined();
-        expect(typeof result).toBe("string");
-        expect((result as string).length).toBeGreaterThan(0);
-        // The digest should be based on the string content
-        const result2 = prodRscOnError("different string");
-        expect(result2).not.toBe(result);
-      });
-
-      it("does not have an early return for string thrown values in generated code", () => {
-        // Next.js had a bug where typeof thrownValue === 'string' returned
-        // early, swallowing the error before logging. Verify the generated
-        // rscOnError has no such early-return path.
-        expect(onErrorFn).not.toContain("typeof thrownValue === 'string'");
-      });
-    });
+    // Runtime behavior tests moved to app-rsc-errors.test.ts since the
+    // rscOnError and __errorDigest functions were extracted to a typed runtime
+    // helper (see refactor: extract RSC runtime primitives #964).
   });
 
   describe("build-time classification dispatch stub", () => {
@@ -4446,13 +4332,12 @@ describe("generateRscEntry ISR code generation", () => {
     expect(code).toContain('process.env.NODE_ENV === "production"');
   });
 
-  it("generated code contains ISR inline helper functions", () => {
+  it("generated code imports ISR helpers from isr-cache module", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes);
-    expect(code).toContain("async function __isrGet(");
-    expect(code).toContain("async function __isrSet(");
-    expect(code).toContain("function __triggerBackgroundRegeneration(");
-    expect(code).toContain("function __isrCacheKey(");
-    expect(code).toContain("const __pendingRegenerations = new Map()");
+    expect(code).toContain("isrGet as __isrGet");
+    expect(code).toContain("isrSet as __isrSet");
+    expect(code).toContain("triggerBackgroundRegeneration as __triggerBackgroundRegeneration");
+    expect(code).toContain("appIsrRouteKey as __isrRouteKey");
   });
 
   it("generated code threads collected fetch tags into page ISR writes and delegates route ISR", () => {
@@ -4468,19 +4353,13 @@ describe("generateRscEntry ISR code generation", () => {
     expect(code).toContain(
       'const __pageTags = buildPageCacheTags(cleanPathname, getCollectedFetchTags(), route.routeSegments, "page")',
     );
-    expect(code).toContain("Array.isArray(tags) ? tags : []");
+    // The Array.isArray fallback has been moved to the typed helper in isr-cache.ts
   });
 
   it("generated handler exports async function handler(request, ctx)", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes);
     // The handler must accept a ctx param so ExecutionContext is threaded through
     expect(code).toMatch(/export default async function handler\s*\(\s*request\s*,\s*ctx\s*\)/);
-  });
-
-  it("generated code imports getCacheHandler from next/cache", () => {
-    const code = generateRscEntry("/tmp/test/app", minimalRoutes);
-    expect(code).toContain("getCacheHandler");
-    expect(code).toContain('"next/cache"');
   });
 
   it("generated code stores root layout params separately from leaf params", () => {

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -1915,6 +1915,87 @@ describe("next/cache shim", () => {
     expect(r1).toBe(r2);
   });
 
+  // Ported from Next.js: packages/next/src/server/request/io.ts
+  // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/request/io.ts
+  it("unstable_io returns a hanging promise during prerender", async () => {
+    const { unstable_io } = await import("../packages/vinext/src/shims/cache.js");
+    const { workUnitAsyncStorage } =
+      await import("../packages/vinext/src/shims/internal/work-unit-async-storage.js");
+
+    const controller = new AbortController();
+
+    // run() returns whatever the callback returns — a hanging promise.
+    const hanging = workUnitAsyncStorage.run(
+      { type: "prerender", renderSignal: controller.signal },
+      unstable_io,
+    );
+
+    // The promise should not be resolved or rejected (it's "hanging")
+    expect(hanging).toBeInstanceOf(Promise);
+    // It should NOT be a fulfilled thenable
+    expect((hanging as any).status).toBeUndefined();
+
+    // Clean up by aborting the signal
+    controller.abort();
+  });
+
+  it("unstable_io resolves immediately with request store", async () => {
+    const { unstable_io } = await import("../packages/vinext/src/shims/cache.js");
+    const { workUnitAsyncStorage } =
+      await import("../packages/vinext/src/shims/internal/work-unit-async-storage.js");
+
+    const promise = workUnitAsyncStorage.run({ type: "request" }, unstable_io);
+
+    expect(promise).toBeInstanceOf(Promise);
+    await expect(promise).resolves.toBeUndefined();
+  });
+
+  it("unstable_io resolves immediately with cache store", async () => {
+    const { unstable_io } = await import("../packages/vinext/src/shims/cache.js");
+    const { workUnitAsyncStorage } =
+      await import("../packages/vinext/src/shims/internal/work-unit-async-storage.js");
+
+    const promise = workUnitAsyncStorage.run({ type: "cache" }, unstable_io);
+
+    expect(promise).toBeInstanceOf(Promise);
+    await expect(promise).resolves.toBeUndefined();
+  });
+
+  it("unstable_io rejects hanging promise on abort when prerendering", async () => {
+    const { unstable_io } = await import("../packages/vinext/src/shims/cache.js");
+    const { workUnitAsyncStorage } =
+      await import("../packages/vinext/src/shims/internal/work-unit-async-storage.js");
+
+    const controller = new AbortController();
+
+    const hanging = workUnitAsyncStorage.run(
+      { type: "prerender", renderSignal: controller.signal },
+      unstable_io,
+    );
+
+    expect(hanging).toBeInstanceOf(Promise);
+
+    // Abort the signal — the hanging promise should reject
+    controller.abort();
+    await expect(hanging).rejects.toThrow(/unstable_io/i);
+  });
+
+  it("unstable_io returns rejected promise when signal already aborted", async () => {
+    const { unstable_io } = await import("../packages/vinext/src/shims/cache.js");
+    const { workUnitAsyncStorage } =
+      await import("../packages/vinext/src/shims/internal/work-unit-async-storage.js");
+
+    const controller = new AbortController();
+    controller.abort(); // already aborted
+
+    const promise = workUnitAsyncStorage.run(
+      { type: "prerender", renderSignal: controller.signal },
+      unstable_io,
+    );
+
+    await expect(promise).rejects.toThrow(/prerendering/i);
+  });
+
   it("setCacheHandler swaps the active handler", async () => {
     const { setCacheHandler, getCacheHandler, unstable_cache } =
       await import("../packages/vinext/src/shims/cache.js");

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -2001,6 +2001,42 @@ describe("next/cache shim", () => {
     await expect(promise).rejects.toThrow(/prerendering/i);
   });
 
+  it("unstable_io does not emit unhandled rejection when signal already aborted", async () => {
+    const { unstable_io } = await import("../packages/vinext/src/shims/cache.js");
+    const { workUnitAsyncStorage } =
+      await import("../packages/vinext/src/shims/internal/work-unit-async-storage.js");
+
+    const unhandledRejections: unknown[] = [];
+    const onUnhandledRejection = (reason: unknown) => {
+      unhandledRejections.push(reason);
+    };
+    process.on("unhandledRejection", onUnhandledRejection);
+
+    try {
+      const controller = new AbortController();
+      controller.abort(); // already aborted
+
+      const promise = workUnitAsyncStorage.run(
+        { type: "prerender", renderSignal: controller.signal, route: "/test" },
+        unstable_io,
+      );
+
+      // Wait a tick for potential unhandled rejection to be detected
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // Await the promise to handle the rejection
+      try {
+        await promise;
+      } catch {
+        // expected
+      }
+
+      expect(unhandledRejections.length).toBe(0);
+    } finally {
+      process.off("unhandledRejection", onUnhandledRejection);
+    }
+  });
+
   it("setCacheHandler swaps the active handler", async () => {
     const { setCacheHandler, getCacheHandler, unstable_cache } =
       await import("../packages/vinext/src/shims/cache.js");

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -1932,8 +1932,13 @@ describe("next/cache shim", () => {
 
     // The promise should not be resolved or rejected (it's "hanging")
     expect(hanging).toBeInstanceOf(Promise);
-    // It should NOT be a fulfilled thenable
-    expect((hanging as any).status).toBeUndefined();
+
+    // Verify it's still hanging using Promise.race (more portable than V8 internals)
+    const result = await Promise.race([
+      hanging.then(() => "resolved"),
+      new Promise((r) => setTimeout(() => r("still-hanging"), 50)),
+    ]);
+    expect(result).toBe("still-hanging");
 
     // Clean up by aborting the signal
     controller.abort();


### PR DESCRIPTION
Fixes #972

## Summary

- unstable_io() now branches on work unit store type, matching Next.js implementation in packages/next/src/server/request/io.ts
- During prerendering (prerender/prerender-client/prerender-runtime), returns a hanging promise that suspends React past the IO boundary
- During requests, cache scopes, and other contexts, resolves immediately (existing behavior)
- When no work unit store is present, falls back to resolved promise (client/standalone)

## What changed

- **New**: make-hanging-promise.ts — promise that never resolves, rejects when AbortSignal fires (ported from Next.js dynamic-rendering-utils.ts)
- **Modified**: work-unit-async-storage.ts — typed WorkUnitStore discriminated union with store types
- **Modified**: cache.ts — unstable_io() checks work unit store type and delegates to makeHangingPromise during prerendering
- **New**: prerender-work-unit-setup.ts — helper that sets up prerender store in workUnitAsyncStorage when VINEXT_PRERENDER=1
- **Modified**: app-rsc-entry.ts — wraps request handler in prerender work unit scope
- **Updated**: entry template snapshots to reflect generated code changes

## Test plan

- Added 5 new tests in tests/shims.test.ts covering: hanging promise during prerender, resolved promise with request/cache stores, rejection on abort, rejection on pre-aborted signal
- All 835 existing shim tests pass
- Entry template snapshot tests updated