### PR TITLE
refactor: Extract early config header and public file pipeline

### DIFF
--- a/packages/vinext/package.json
+++ b/packages/vinext/package.json
@@ -41,6 +41,10 @@
       "types": "./dist/server/image-optimization.d.ts",
       "import": "./dist/server/image-optimization.js"
     },
+    "./server/request-pipeline": {
+      "types": "./dist/server/request-pipeline.d.ts",
+      "import": "./dist/server/request-pipeline.js"
+    },
     "./server/app-router-entry": {
       "types": "./dist/server/app-router-entry.d.ts",
       "import": "./dist/server/app-router-entry.js"

--- a/packages/vinext/src/deploy.ts
+++ b/packages/vinext/src/deploy.ts
@@ -515,13 +515,13 @@ import type { ImageConfig } from "vinext/server/image-optimization";
 import {
   matchRedirect,
   matchRewrite,
-  matchHeaders,
   requestContextFromRequest,
   applyMiddlewareRequestHeaders,
   isExternalUrl,
   proxyExternalRequest,
   sanitizeDestination,
 } from "vinext/config/config-matchers";
+import { applyConfigHeadersToHeaderRecord } from "vinext/server/request-pipeline";
 
 // @ts-expect-error -- virtual module resolved by vinext at build time
 import { renderPage, handleApiRoute, runMiddleware, vinextConfig } from "virtual:vinext-server-entry";
@@ -749,26 +749,11 @@ export default {
       // Middleware headers take precedence: skip config keys already set
       // by middleware so middleware always wins for the same key.
       if (configHeaders.length) {
-        const matched = matchHeaders(pathname, configHeaders, reqCtx);
-        for (const h of matched) {
-          const lk = h.key.toLowerCase();
-          if (lk === "set-cookie") {
-            const existing = middlewareHeaders[lk];
-            if (Array.isArray(existing)) {
-              existing.push(h.value);
-            } else if (existing) {
-              middlewareHeaders[lk] = [existing as string, h.value];
-            } else {
-              middlewareHeaders[lk] = [h.value];
-            }
-          } else if (lk === "vary" && middlewareHeaders[lk]) {
-            middlewareHeaders[lk] += ", " + h.value;
-          } else if (!(lk in middlewareHeaders)) {
-            // Middleware headers take precedence: only set if middleware
-            // did not already place this key on the response.
-            middlewareHeaders[lk] = h.value;
-          }
-        }
+        applyConfigHeadersToHeaderRecord(middlewareHeaders, {
+          configHeaders,
+          pathname,
+          requestContext: reqCtx,
+        });
       }
 
       if (isExternalUrl(resolvedUrl)) {

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -187,11 +187,11 @@ import { mergeMetadata, resolveModuleMetadata, mergeViewport, resolveModuleViewp
 ${middlewarePath ? `import * as middlewareModule from ${JSON.stringify(middlewarePath.replace(/\\/g, "/"))};` : ""}
 ${instrumentationPath ? `import * as _instrumentation from ${JSON.stringify(instrumentationPath.replace(/\\/g, "/"))};` : ""}
 ${metaRouteEntries.length > 0 ? `import { sitemapToXml, robotsToText, manifestToJson } from ${JSON.stringify(metadataRoutesPath)};` : ""}
-import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, matchHeaders, isExternalUrl, proxyExternalRequest, sanitizeDestination } from ${JSON.stringify(configMatchersPath)};
+import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, isExternalUrl, proxyExternalRequest, sanitizeDestination } from ${JSON.stringify(configMatchersPath)};
 import { decodePathParams as __decodePathParams, normalizePath as __normalizePath } from ${JSON.stringify(normalizePathModulePath)};
 import { normalizePathnameForRouteMatch as __normalizePathnameForRouteMatch, normalizePathnameForRouteMatchStrict as __normalizePathnameForRouteMatchStrict } from ${JSON.stringify(routingUtilsPath)};
 import { buildRequestHeadersFromMiddlewareResponse as __buildRequestHeadersFromMiddlewareResponse } from ${JSON.stringify(middlewareRequestHeadersPath)};
-import { validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash } from ${JSON.stringify(requestPipelinePath)};
+import { applyConfigHeadersToResponse, resolvePublicFileRoute, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash } from ${JSON.stringify(requestPipelinePath)};
 import { applyAppMiddleware as __applyAppMiddleware } from ${JSON.stringify(appMiddlewarePath)};
 import {
   dispatchAppRouteHandler as __dispatchAppRouteHandler,
@@ -720,21 +720,6 @@ function matchRoute(url) {
   return __routeMatcher.matchRoute(url);
 }
 
-function __createStaticFileSignal(pathname, _mwCtx) {
-  const headers = new Headers({
-    "x-vinext-static-file": encodeURIComponent(pathname),
-  });
-  if (_mwCtx.headers) {
-    for (const [key, value] of _mwCtx.headers) {
-      headers.append(key, value);
-    }
-  }
-  return new Response(null, {
-    status: _mwCtx.status ?? 200,
-    headers,
-  });
-}
-
 /**
  * Check if a pathname matches any intercepting route.
  * Returns the match info or null.
@@ -1006,21 +991,11 @@ export default async function handler(request, ctx) {
         let pathname;
         try { pathname = __normalizePath(__normalizePathnameForRouteMatch(url.pathname)); } catch { pathname = url.pathname; }
         ${bp ? `if (pathname.startsWith(${JSON.stringify(bp)})) pathname = pathname.slice(${JSON.stringify(bp)}.length) || "/";` : ""}
-        const extraHeaders = matchHeaders(pathname, __configHeaders, __reqCtx);
-        for (const h of extraHeaders) {
-          // Use append() for headers where multiple values must coexist
-          // (Vary, Set-Cookie). Using set() on these would destroy
-          // existing values like "Vary: RSC, Accept" which are critical
-          // for correct CDN caching behavior.
-          const lk = h.key.toLowerCase();
-          if (lk === "vary" || lk === "set-cookie") {
-            response.headers.append(h.key, h.value);
-          } else if (!response.headers.has(lk)) {
-            // Middleware headers take precedence: skip config keys already
-            // set by middleware so middleware headers always win.
-            response.headers.set(h.key, h.value);
-          }
-        }
+        applyConfigHeadersToResponse(response.headers, {
+          configHeaders: __configHeaders,
+          pathname,
+          requestContext: __reqCtx,
+        });
       }
     }
     return response;
@@ -1246,13 +1221,16 @@ ${prerenderPagesLoaderOption}
 
   // Serve public/ files as filesystem routes after middleware and before
   // afterFiles/fallback rewrites, matching Next.js routing semantics.
-  if (
-    (request.method === "GET" || request.method === "HEAD") &&
-    !pathname.endsWith(".rsc") &&
-    __publicFiles.has(cleanPathname)
-  ) {
+  const __publicFileResponse = resolvePublicFileRoute({
+    cleanPathname,
+    middlewareContext: _mwCtx,
+    pathname,
+    publicFiles: __publicFiles,
+    request,
+  });
+  if (__publicFileResponse) {
     __clearRequestContext();
-    return __createStaticFileSignal(cleanPathname, _mwCtx);
+    return __publicFileResponse;
   }
 
   // Set navigation context for Server Components.

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -28,7 +28,6 @@ import { StaticFileCache, CONTENT_TYPES, etagFromFilenameHash } from "./static-f
 import {
   matchRedirect,
   matchRewrite,
-  matchHeaders,
   requestContextFromRequest,
   applyMiddlewareRequestHeaders,
   isExternalUrl,
@@ -46,7 +45,7 @@ import {
   type ImageConfig,
 } from "./image-optimization.js";
 import { normalizePath } from "./normalize-path.js";
-import { isOpenRedirectShaped } from "./request-pipeline.js";
+import { applyConfigHeadersToHeaderRecord, isOpenRedirectShaped } from "./request-pipeline.js";
 import { hasBasePath, stripBasePath } from "../utils/base-path.js";
 import { computeLazyChunks } from "../utils/lazy-chunks.js";
 import { manifestFileWithBase } from "../utils/manifest-paths.js";
@@ -1535,26 +1534,11 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
       // This runs before step 5b so config headers are included in static
       // public directory file responses (matching Next.js behavior).
       if (configHeaders.length) {
-        const matched = matchHeaders(pathname, configHeaders, reqCtx);
-        for (const h of matched) {
-          const lk = h.key.toLowerCase();
-          if (lk === "set-cookie") {
-            const existing = middlewareHeaders[lk];
-            if (Array.isArray(existing)) {
-              existing.push(h.value);
-            } else if (existing) {
-              middlewareHeaders[lk] = [existing as string, h.value];
-            } else {
-              middlewareHeaders[lk] = [h.value];
-            }
-          } else if (lk === "vary" && middlewareHeaders[lk]) {
-            middlewareHeaders[lk] += ", " + h.value;
-          } else if (!(lk in middlewareHeaders)) {
-            // Middleware headers take precedence: only set if middleware
-            // did not already place this key on the response.
-            middlewareHeaders[lk] = h.value;
-          }
-        }
+        applyConfigHeadersToHeaderRecord(middlewareHeaders, {
+          configHeaders,
+          pathname,
+          requestContext: reqCtx,
+        });
       }
 
       if (isExternalUrl(resolvedUrl)) {

--- a/packages/vinext/src/server/request-pipeline.ts
+++ b/packages/vinext/src/server/request-pipeline.ts
@@ -1,12 +1,15 @@
 import { hasBasePath, stripBasePath } from "../utils/base-path.js";
+import type { NextHeader } from "../config/next-config.js";
+import type { RequestContext } from "../config/config-matchers.js";
+import { matchHeaders } from "../config/config-matchers.js";
 
 /**
  * Shared request pipeline utilities.
  *
- * Extracted from the App Router RSC entry (entries/app-rsc-entry.ts) to enable
- * reuse across entry points. Currently consumed by app-rsc-entry.ts;
- * dev-server.ts, prod-server.ts, and index.ts still have inline versions
- * that should be migrated in follow-up work.
+ * Extracted from generated entries and server hot paths to keep codegen focused
+ * on app shape while normal modules own request behavior. Some dev-server and
+ * worker-template setup code still has inline normalization that should be
+ * migrated in follow-up work.
  *
  * These utilities handle the common request lifecycle steps: protocol-
  * relative URL guards, basePath stripping, trailing slash normalization,
@@ -96,6 +99,137 @@ export function isOpenRedirectShaped(rawPathname: string): boolean {
  * @returns The pathname with basePath removed
  */
 export { hasBasePath, stripBasePath };
+
+export type HeaderRecord = Record<string, string | string[]>;
+
+type ApplyConfigHeadersOptions = {
+  configHeaders: NextHeader[];
+  pathname: string;
+  requestContext: RequestContext;
+};
+
+type StaticFileSignalContext = {
+  headers: Headers | null;
+  status: number | null;
+};
+
+type ResolvePublicFileRouteOptions = {
+  cleanPathname: string;
+  middlewareContext: StaticFileSignalContext;
+  pathname: string;
+  publicFiles: ReadonlySet<string>;
+  request: Request;
+};
+
+function findHeaderRecordKey(headers: HeaderRecord, lowerName: string): string | undefined {
+  for (const key of Object.keys(headers)) {
+    if (key.toLowerCase() === lowerName) return key;
+  }
+  return undefined;
+}
+
+function appendHeaderRecord(headers: HeaderRecord, lowerName: string, value: string): void {
+  const key = findHeaderRecordKey(headers, lowerName) ?? lowerName;
+  const existing = headers[key];
+  if (existing === undefined) {
+    headers[key] = value;
+    return;
+  }
+  if (Array.isArray(existing)) {
+    existing.push(value);
+    return;
+  }
+  headers[key] = [existing, value];
+}
+
+function appendVaryHeaderRecord(headers: HeaderRecord, value: string): void {
+  const key = findHeaderRecordKey(headers, "vary") ?? "vary";
+  const existing = headers[key];
+  if (existing === undefined) {
+    headers[key] = value;
+    return;
+  }
+  if (Array.isArray(existing)) {
+    existing.push(value);
+    return;
+  }
+  headers[key] = existing + ", " + value;
+}
+
+/**
+ * Apply matched next.config.js headers to a Web Headers object.
+ *
+ * Next.js evaluates config header match conditions against the original
+ * request snapshot. Middleware response headers still win for the same
+ * response key, while multi-value headers are additive.
+ */
+export function applyConfigHeadersToResponse(
+  responseHeaders: Headers,
+  options: ApplyConfigHeadersOptions,
+): void {
+  const matched = matchHeaders(options.pathname, options.configHeaders, options.requestContext);
+  for (const header of matched) {
+    const lowerName = header.key.toLowerCase();
+    if (lowerName === "vary" || lowerName === "set-cookie") {
+      responseHeaders.append(header.key, header.value);
+    } else if (!responseHeaders.has(lowerName)) {
+      responseHeaders.set(header.key, header.value);
+    }
+  }
+}
+
+/**
+ * Apply matched next.config.js headers to the early response header record used
+ * by Node and Worker Pages Router pipelines before a concrete response exists.
+ */
+export function applyConfigHeadersToHeaderRecord(
+  headers: HeaderRecord,
+  options: ApplyConfigHeadersOptions,
+): void {
+  const matched = matchHeaders(options.pathname, options.configHeaders, options.requestContext);
+  for (const header of matched) {
+    const lowerName = header.key.toLowerCase();
+    if (lowerName === "set-cookie") {
+      appendHeaderRecord(headers, lowerName, header.value);
+    } else if (lowerName === "vary") {
+      appendVaryHeaderRecord(headers, header.value);
+    } else if (findHeaderRecordKey(headers, lowerName) === undefined) {
+      headers[lowerName] = header.value;
+    }
+  }
+}
+
+export function createStaticFileSignal(
+  pathname: string,
+  context: StaticFileSignalContext,
+): Response {
+  const headers = new Headers({
+    "x-vinext-static-file": encodeURIComponent(pathname),
+  });
+  if (context.headers) {
+    for (const [key, value] of context.headers) {
+      headers.append(key, value);
+    }
+  }
+  return new Response(null, {
+    status: context.status ?? 200,
+    headers,
+  });
+}
+
+/**
+ * Resolve the public/ filesystem-route slot in the Next.js routing order.
+ *
+ * Public files are checked after middleware and before afterFiles/fallback
+ * rewrites. The generated App Router entry provides the public-file set; this
+ * helper owns the request-method and RSC exclusions plus static-file signaling.
+ */
+export function resolvePublicFileRoute(options: ResolvePublicFileRouteOptions): Response | null {
+  if (options.request.method !== "GET" && options.request.method !== "HEAD") return null;
+  if (options.pathname.endsWith(".rsc")) return null;
+  if (!options.publicFiles.has(options.cleanPathname)) return null;
+  return createStaticFileSignal(options.cleanPathname, options.middlewareContext);
+}
 
 /**
  * Check if the pathname needs a trailing slash redirect, and return the

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -27,11 +27,11 @@ import { mergeMetadata, resolveModuleMetadata, mergeViewport, resolveModuleViewp
 
 
 
-import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, matchHeaders, isExternalUrl, proxyExternalRequest, sanitizeDestination } from "<ROOT>/packages/vinext/src/config/config-matchers.js";
+import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, isExternalUrl, proxyExternalRequest, sanitizeDestination } from "<ROOT>/packages/vinext/src/config/config-matchers.js";
 import { decodePathParams as __decodePathParams, normalizePath as __normalizePath } from "<ROOT>/packages/vinext/src/server/normalize-path.js";
 import { normalizePathnameForRouteMatch as __normalizePathnameForRouteMatch, normalizePathnameForRouteMatchStrict as __normalizePathnameForRouteMatchStrict } from "<ROOT>/packages/vinext/src/routing/utils.js";
 import { buildRequestHeadersFromMiddlewareResponse as __buildRequestHeadersFromMiddlewareResponse } from "<ROOT>/packages/vinext/src/server/middleware-request-headers.js";
-import { validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
+import { applyConfigHeadersToResponse, resolvePublicFileRoute, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
 import { applyAppMiddleware as __applyAppMiddleware } from "<ROOT>/packages/vinext/src/server/app-middleware.js";
 import {
   dispatchAppRouteHandler as __dispatchAppRouteHandler,
@@ -647,21 +647,6 @@ function matchRoute(url) {
   return __routeMatcher.matchRoute(url);
 }
 
-function __createStaticFileSignal(pathname, _mwCtx) {
-  const headers = new Headers({
-    "x-vinext-static-file": encodeURIComponent(pathname),
-  });
-  if (_mwCtx.headers) {
-    for (const [key, value] of _mwCtx.headers) {
-      headers.append(key, value);
-    }
-  }
-  return new Response(null, {
-    status: _mwCtx.status ?? 200,
-    headers,
-  });
-}
-
 /**
  * Check if a pathname matches any intercepting route.
  * Returns the match info or null.
@@ -982,21 +967,11 @@ export default async function handler(request, ctx) {
         let pathname;
         try { pathname = __normalizePath(__normalizePathnameForRouteMatch(url.pathname)); } catch { pathname = url.pathname; }
         
-        const extraHeaders = matchHeaders(pathname, __configHeaders, __reqCtx);
-        for (const h of extraHeaders) {
-          // Use append() for headers where multiple values must coexist
-          // (Vary, Set-Cookie). Using set() on these would destroy
-          // existing values like "Vary: RSC, Accept" which are critical
-          // for correct CDN caching behavior.
-          const lk = h.key.toLowerCase();
-          if (lk === "vary" || lk === "set-cookie") {
-            response.headers.append(h.key, h.value);
-          } else if (!response.headers.has(lk)) {
-            // Middleware headers take precedence: skip config keys already
-            // set by middleware so middleware headers always win.
-            response.headers.set(h.key, h.value);
-          }
-        }
+        applyConfigHeadersToResponse(response.headers, {
+          configHeaders: __configHeaders,
+          pathname,
+          requestContext: __reqCtx,
+        });
       }
     }
     return response;
@@ -1193,13 +1168,16 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
 
   // Serve public/ files as filesystem routes after middleware and before
   // afterFiles/fallback rewrites, matching Next.js routing semantics.
-  if (
-    (request.method === "GET" || request.method === "HEAD") &&
-    !pathname.endsWith(".rsc") &&
-    __publicFiles.has(cleanPathname)
-  ) {
+  const __publicFileResponse = resolvePublicFileRoute({
+    cleanPathname,
+    middlewareContext: _mwCtx,
+    pathname,
+    publicFiles: __publicFiles,
+    request,
+  });
+  if (__publicFileResponse) {
     __clearRequestContext();
-    return __createStaticFileSignal(cleanPathname, _mwCtx);
+    return __publicFileResponse;
   }
 
   // Set navigation context for Server Components.
@@ -1881,11 +1859,11 @@ import { mergeMetadata, resolveModuleMetadata, mergeViewport, resolveModuleViewp
 
 
 
-import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, matchHeaders, isExternalUrl, proxyExternalRequest, sanitizeDestination } from "<ROOT>/packages/vinext/src/config/config-matchers.js";
+import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, isExternalUrl, proxyExternalRequest, sanitizeDestination } from "<ROOT>/packages/vinext/src/config/config-matchers.js";
 import { decodePathParams as __decodePathParams, normalizePath as __normalizePath } from "<ROOT>/packages/vinext/src/server/normalize-path.js";
 import { normalizePathnameForRouteMatch as __normalizePathnameForRouteMatch, normalizePathnameForRouteMatchStrict as __normalizePathnameForRouteMatchStrict } from "<ROOT>/packages/vinext/src/routing/utils.js";
 import { buildRequestHeadersFromMiddlewareResponse as __buildRequestHeadersFromMiddlewareResponse } from "<ROOT>/packages/vinext/src/server/middleware-request-headers.js";
-import { validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
+import { applyConfigHeadersToResponse, resolvePublicFileRoute, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
 import { applyAppMiddleware as __applyAppMiddleware } from "<ROOT>/packages/vinext/src/server/app-middleware.js";
 import {
   dispatchAppRouteHandler as __dispatchAppRouteHandler,
@@ -2501,21 +2479,6 @@ function matchRoute(url) {
   return __routeMatcher.matchRoute(url);
 }
 
-function __createStaticFileSignal(pathname, _mwCtx) {
-  const headers = new Headers({
-    "x-vinext-static-file": encodeURIComponent(pathname),
-  });
-  if (_mwCtx.headers) {
-    for (const [key, value] of _mwCtx.headers) {
-      headers.append(key, value);
-    }
-  }
-  return new Response(null, {
-    status: _mwCtx.status ?? 200,
-    headers,
-  });
-}
-
 /**
  * Check if a pathname matches any intercepting route.
  * Returns the match info or null.
@@ -2836,21 +2799,11 @@ export default async function handler(request, ctx) {
         let pathname;
         try { pathname = __normalizePath(__normalizePathnameForRouteMatch(url.pathname)); } catch { pathname = url.pathname; }
         if (pathname.startsWith("/base")) pathname = pathname.slice("/base".length) || "/";
-        const extraHeaders = matchHeaders(pathname, __configHeaders, __reqCtx);
-        for (const h of extraHeaders) {
-          // Use append() for headers where multiple values must coexist
-          // (Vary, Set-Cookie). Using set() on these would destroy
-          // existing values like "Vary: RSC, Accept" which are critical
-          // for correct CDN caching behavior.
-          const lk = h.key.toLowerCase();
-          if (lk === "vary" || lk === "set-cookie") {
-            response.headers.append(h.key, h.value);
-          } else if (!response.headers.has(lk)) {
-            // Middleware headers take precedence: skip config keys already
-            // set by middleware so middleware headers always win.
-            response.headers.set(h.key, h.value);
-          }
-        }
+        applyConfigHeadersToResponse(response.headers, {
+          configHeaders: __configHeaders,
+          pathname,
+          requestContext: __reqCtx,
+        });
       }
     }
     return response;
@@ -3053,13 +3006,16 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
 
   // Serve public/ files as filesystem routes after middleware and before
   // afterFiles/fallback rewrites, matching Next.js routing semantics.
-  if (
-    (request.method === "GET" || request.method === "HEAD") &&
-    !pathname.endsWith(".rsc") &&
-    __publicFiles.has(cleanPathname)
-  ) {
+  const __publicFileResponse = resolvePublicFileRoute({
+    cleanPathname,
+    middlewareContext: _mwCtx,
+    pathname,
+    publicFiles: __publicFiles,
+    request,
+  });
+  if (__publicFileResponse) {
     __clearRequestContext();
-    return __createStaticFileSignal(cleanPathname, _mwCtx);
+    return __publicFileResponse;
   }
 
   // Set navigation context for Server Components.
@@ -3741,11 +3697,11 @@ import { mergeMetadata, resolveModuleMetadata, mergeViewport, resolveModuleViewp
 
 
 
-import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, matchHeaders, isExternalUrl, proxyExternalRequest, sanitizeDestination } from "<ROOT>/packages/vinext/src/config/config-matchers.js";
+import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, isExternalUrl, proxyExternalRequest, sanitizeDestination } from "<ROOT>/packages/vinext/src/config/config-matchers.js";
 import { decodePathParams as __decodePathParams, normalizePath as __normalizePath } from "<ROOT>/packages/vinext/src/server/normalize-path.js";
 import { normalizePathnameForRouteMatch as __normalizePathnameForRouteMatch, normalizePathnameForRouteMatchStrict as __normalizePathnameForRouteMatchStrict } from "<ROOT>/packages/vinext/src/routing/utils.js";
 import { buildRequestHeadersFromMiddlewareResponse as __buildRequestHeadersFromMiddlewareResponse } from "<ROOT>/packages/vinext/src/server/middleware-request-headers.js";
-import { validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
+import { applyConfigHeadersToResponse, resolvePublicFileRoute, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
 import { applyAppMiddleware as __applyAppMiddleware } from "<ROOT>/packages/vinext/src/server/app-middleware.js";
 import {
   dispatchAppRouteHandler as __dispatchAppRouteHandler,
@@ -4362,21 +4318,6 @@ function matchRoute(url) {
   return __routeMatcher.matchRoute(url);
 }
 
-function __createStaticFileSignal(pathname, _mwCtx) {
-  const headers = new Headers({
-    "x-vinext-static-file": encodeURIComponent(pathname),
-  });
-  if (_mwCtx.headers) {
-    for (const [key, value] of _mwCtx.headers) {
-      headers.append(key, value);
-    }
-  }
-  return new Response(null, {
-    status: _mwCtx.status ?? 200,
-    headers,
-  });
-}
-
 /**
  * Check if a pathname matches any intercepting route.
  * Returns the match info or null.
@@ -4697,21 +4638,11 @@ export default async function handler(request, ctx) {
         let pathname;
         try { pathname = __normalizePath(__normalizePathnameForRouteMatch(url.pathname)); } catch { pathname = url.pathname; }
         
-        const extraHeaders = matchHeaders(pathname, __configHeaders, __reqCtx);
-        for (const h of extraHeaders) {
-          // Use append() for headers where multiple values must coexist
-          // (Vary, Set-Cookie). Using set() on these would destroy
-          // existing values like "Vary: RSC, Accept" which are critical
-          // for correct CDN caching behavior.
-          const lk = h.key.toLowerCase();
-          if (lk === "vary" || lk === "set-cookie") {
-            response.headers.append(h.key, h.value);
-          } else if (!response.headers.has(lk)) {
-            // Middleware headers take precedence: skip config keys already
-            // set by middleware so middleware headers always win.
-            response.headers.set(h.key, h.value);
-          }
-        }
+        applyConfigHeadersToResponse(response.headers, {
+          configHeaders: __configHeaders,
+          pathname,
+          requestContext: __reqCtx,
+        });
       }
     }
     return response;
@@ -4908,13 +4839,16 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
 
   // Serve public/ files as filesystem routes after middleware and before
   // afterFiles/fallback rewrites, matching Next.js routing semantics.
-  if (
-    (request.method === "GET" || request.method === "HEAD") &&
-    !pathname.endsWith(".rsc") &&
-    __publicFiles.has(cleanPathname)
-  ) {
+  const __publicFileResponse = resolvePublicFileRoute({
+    cleanPathname,
+    middlewareContext: _mwCtx,
+    pathname,
+    publicFiles: __publicFiles,
+    request,
+  });
+  if (__publicFileResponse) {
     __clearRequestContext();
-    return __createStaticFileSignal(cleanPathname, _mwCtx);
+    return __publicFileResponse;
   }
 
   // Set navigation context for Server Components.
@@ -5596,11 +5530,11 @@ import { mergeMetadata, resolveModuleMetadata, mergeViewport, resolveModuleViewp
 
 import * as _instrumentation from "/tmp/test/instrumentation.ts";
 
-import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, matchHeaders, isExternalUrl, proxyExternalRequest, sanitizeDestination } from "<ROOT>/packages/vinext/src/config/config-matchers.js";
+import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, isExternalUrl, proxyExternalRequest, sanitizeDestination } from "<ROOT>/packages/vinext/src/config/config-matchers.js";
 import { decodePathParams as __decodePathParams, normalizePath as __normalizePath } from "<ROOT>/packages/vinext/src/server/normalize-path.js";
 import { normalizePathnameForRouteMatch as __normalizePathnameForRouteMatch, normalizePathnameForRouteMatchStrict as __normalizePathnameForRouteMatchStrict } from "<ROOT>/packages/vinext/src/routing/utils.js";
 import { buildRequestHeadersFromMiddlewareResponse as __buildRequestHeadersFromMiddlewareResponse } from "<ROOT>/packages/vinext/src/server/middleware-request-headers.js";
-import { validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
+import { applyConfigHeadersToResponse, resolvePublicFileRoute, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
 import { applyAppMiddleware as __applyAppMiddleware } from "<ROOT>/packages/vinext/src/server/app-middleware.js";
 import {
   dispatchAppRouteHandler as __dispatchAppRouteHandler,
@@ -6246,21 +6180,6 @@ function matchRoute(url) {
   return __routeMatcher.matchRoute(url);
 }
 
-function __createStaticFileSignal(pathname, _mwCtx) {
-  const headers = new Headers({
-    "x-vinext-static-file": encodeURIComponent(pathname),
-  });
-  if (_mwCtx.headers) {
-    for (const [key, value] of _mwCtx.headers) {
-      headers.append(key, value);
-    }
-  }
-  return new Response(null, {
-    status: _mwCtx.status ?? 200,
-    headers,
-  });
-}
-
 /**
  * Check if a pathname matches any intercepting route.
  * Returns the match info or null.
@@ -6584,21 +6503,11 @@ export default async function handler(request, ctx) {
         let pathname;
         try { pathname = __normalizePath(__normalizePathnameForRouteMatch(url.pathname)); } catch { pathname = url.pathname; }
         
-        const extraHeaders = matchHeaders(pathname, __configHeaders, __reqCtx);
-        for (const h of extraHeaders) {
-          // Use append() for headers where multiple values must coexist
-          // (Vary, Set-Cookie). Using set() on these would destroy
-          // existing values like "Vary: RSC, Accept" which are critical
-          // for correct CDN caching behavior.
-          const lk = h.key.toLowerCase();
-          if (lk === "vary" || lk === "set-cookie") {
-            response.headers.append(h.key, h.value);
-          } else if (!response.headers.has(lk)) {
-            // Middleware headers take precedence: skip config keys already
-            // set by middleware so middleware headers always win.
-            response.headers.set(h.key, h.value);
-          }
-        }
+        applyConfigHeadersToResponse(response.headers, {
+          configHeaders: __configHeaders,
+          pathname,
+          requestContext: __reqCtx,
+        });
       }
     }
     return response;
@@ -6795,13 +6704,16 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
 
   // Serve public/ files as filesystem routes after middleware and before
   // afterFiles/fallback rewrites, matching Next.js routing semantics.
-  if (
-    (request.method === "GET" || request.method === "HEAD") &&
-    !pathname.endsWith(".rsc") &&
-    __publicFiles.has(cleanPathname)
-  ) {
+  const __publicFileResponse = resolvePublicFileRoute({
+    cleanPathname,
+    middlewareContext: _mwCtx,
+    pathname,
+    publicFiles: __publicFiles,
+    request,
+  });
+  if (__publicFileResponse) {
     __clearRequestContext();
-    return __createStaticFileSignal(cleanPathname, _mwCtx);
+    return __publicFileResponse;
   }
 
   // Set navigation context for Server Components.
@@ -7483,11 +7395,11 @@ import { mergeMetadata, resolveModuleMetadata, mergeViewport, resolveModuleViewp
 
 
 import { sitemapToXml, robotsToText, manifestToJson } from "<ROOT>/packages/vinext/src/server/metadata-routes.js";
-import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, matchHeaders, isExternalUrl, proxyExternalRequest, sanitizeDestination } from "<ROOT>/packages/vinext/src/config/config-matchers.js";
+import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, isExternalUrl, proxyExternalRequest, sanitizeDestination } from "<ROOT>/packages/vinext/src/config/config-matchers.js";
 import { decodePathParams as __decodePathParams, normalizePath as __normalizePath } from "<ROOT>/packages/vinext/src/server/normalize-path.js";
 import { normalizePathnameForRouteMatch as __normalizePathnameForRouteMatch, normalizePathnameForRouteMatchStrict as __normalizePathnameForRouteMatchStrict } from "<ROOT>/packages/vinext/src/routing/utils.js";
 import { buildRequestHeadersFromMiddlewareResponse as __buildRequestHeadersFromMiddlewareResponse } from "<ROOT>/packages/vinext/src/server/middleware-request-headers.js";
-import { validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
+import { applyConfigHeadersToResponse, resolvePublicFileRoute, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
 import { applyAppMiddleware as __applyAppMiddleware } from "<ROOT>/packages/vinext/src/server/app-middleware.js";
 import {
   dispatchAppRouteHandler as __dispatchAppRouteHandler,
@@ -8110,21 +8022,6 @@ function matchRoute(url) {
   return __routeMatcher.matchRoute(url);
 }
 
-function __createStaticFileSignal(pathname, _mwCtx) {
-  const headers = new Headers({
-    "x-vinext-static-file": encodeURIComponent(pathname),
-  });
-  if (_mwCtx.headers) {
-    for (const [key, value] of _mwCtx.headers) {
-      headers.append(key, value);
-    }
-  }
-  return new Response(null, {
-    status: _mwCtx.status ?? 200,
-    headers,
-  });
-}
-
 /**
  * Check if a pathname matches any intercepting route.
  * Returns the match info or null.
@@ -8445,21 +8342,11 @@ export default async function handler(request, ctx) {
         let pathname;
         try { pathname = __normalizePath(__normalizePathnameForRouteMatch(url.pathname)); } catch { pathname = url.pathname; }
         
-        const extraHeaders = matchHeaders(pathname, __configHeaders, __reqCtx);
-        for (const h of extraHeaders) {
-          // Use append() for headers where multiple values must coexist
-          // (Vary, Set-Cookie). Using set() on these would destroy
-          // existing values like "Vary: RSC, Accept" which are critical
-          // for correct CDN caching behavior.
-          const lk = h.key.toLowerCase();
-          if (lk === "vary" || lk === "set-cookie") {
-            response.headers.append(h.key, h.value);
-          } else if (!response.headers.has(lk)) {
-            // Middleware headers take precedence: skip config keys already
-            // set by middleware so middleware headers always win.
-            response.headers.set(h.key, h.value);
-          }
-        }
+        applyConfigHeadersToResponse(response.headers, {
+          configHeaders: __configHeaders,
+          pathname,
+          requestContext: __reqCtx,
+        });
       }
     }
     return response;
@@ -8656,13 +8543,16 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
 
   // Serve public/ files as filesystem routes after middleware and before
   // afterFiles/fallback rewrites, matching Next.js routing semantics.
-  if (
-    (request.method === "GET" || request.method === "HEAD") &&
-    !pathname.endsWith(".rsc") &&
-    __publicFiles.has(cleanPathname)
-  ) {
+  const __publicFileResponse = resolvePublicFileRoute({
+    cleanPathname,
+    middlewareContext: _mwCtx,
+    pathname,
+    publicFiles: __publicFiles,
+    request,
+  });
+  if (__publicFileResponse) {
     __clearRequestContext();
-    return __createStaticFileSignal(cleanPathname, _mwCtx);
+    return __publicFileResponse;
   }
 
   // Set navigation context for Server Components.
@@ -9344,11 +9234,11 @@ import { mergeMetadata, resolveModuleMetadata, mergeViewport, resolveModuleViewp
 import * as middlewareModule from "/tmp/test/middleware.ts";
 
 
-import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, matchHeaders, isExternalUrl, proxyExternalRequest, sanitizeDestination } from "<ROOT>/packages/vinext/src/config/config-matchers.js";
+import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, isExternalUrl, proxyExternalRequest, sanitizeDestination } from "<ROOT>/packages/vinext/src/config/config-matchers.js";
 import { decodePathParams as __decodePathParams, normalizePath as __normalizePath } from "<ROOT>/packages/vinext/src/server/normalize-path.js";
 import { normalizePathnameForRouteMatch as __normalizePathnameForRouteMatch, normalizePathnameForRouteMatchStrict as __normalizePathnameForRouteMatchStrict } from "<ROOT>/packages/vinext/src/routing/utils.js";
 import { buildRequestHeadersFromMiddlewareResponse as __buildRequestHeadersFromMiddlewareResponse } from "<ROOT>/packages/vinext/src/server/middleware-request-headers.js";
-import { validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
+import { applyConfigHeadersToResponse, resolvePublicFileRoute, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
 import { applyAppMiddleware as __applyAppMiddleware } from "<ROOT>/packages/vinext/src/server/app-middleware.js";
 import {
   dispatchAppRouteHandler as __dispatchAppRouteHandler,
@@ -9964,21 +9854,6 @@ function matchRoute(url) {
   return __routeMatcher.matchRoute(url);
 }
 
-function __createStaticFileSignal(pathname, _mwCtx) {
-  const headers = new Headers({
-    "x-vinext-static-file": encodeURIComponent(pathname),
-  });
-  if (_mwCtx.headers) {
-    for (const [key, value] of _mwCtx.headers) {
-      headers.append(key, value);
-    }
-  }
-  return new Response(null, {
-    status: _mwCtx.status ?? 200,
-    headers,
-  });
-}
-
 /**
  * Check if a pathname matches any intercepting route.
  * Returns the match info or null.
@@ -10299,21 +10174,11 @@ export default async function handler(request, ctx) {
         let pathname;
         try { pathname = __normalizePath(__normalizePathnameForRouteMatch(url.pathname)); } catch { pathname = url.pathname; }
         
-        const extraHeaders = matchHeaders(pathname, __configHeaders, __reqCtx);
-        for (const h of extraHeaders) {
-          // Use append() for headers where multiple values must coexist
-          // (Vary, Set-Cookie). Using set() on these would destroy
-          // existing values like "Vary: RSC, Accept" which are critical
-          // for correct CDN caching behavior.
-          const lk = h.key.toLowerCase();
-          if (lk === "vary" || lk === "set-cookie") {
-            response.headers.append(h.key, h.value);
-          } else if (!response.headers.has(lk)) {
-            // Middleware headers take precedence: skip config keys already
-            // set by middleware so middleware headers always win.
-            response.headers.set(h.key, h.value);
-          }
-        }
+        applyConfigHeadersToResponse(response.headers, {
+          configHeaders: __configHeaders,
+          pathname,
+          requestContext: __reqCtx,
+        });
       }
     }
     return response;
@@ -10525,13 +10390,16 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
 
   // Serve public/ files as filesystem routes after middleware and before
   // afterFiles/fallback rewrites, matching Next.js routing semantics.
-  if (
-    (request.method === "GET" || request.method === "HEAD") &&
-    !pathname.endsWith(".rsc") &&
-    __publicFiles.has(cleanPathname)
-  ) {
+  const __publicFileResponse = resolvePublicFileRoute({
+    cleanPathname,
+    middlewareContext: _mwCtx,
+    pathname,
+    publicFiles: __publicFiles,
+    request,
+  });
+  if (__publicFileResponse) {
     __clearRequestContext();
-    return __createStaticFileSignal(cleanPathname, _mwCtx);
+    return __publicFileResponse;
   }
 
   // Set navigation context for Server Components.

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -3283,7 +3283,7 @@ describe("App Router next.config.js features (generateRscEntry)", () => {
       headers: [{ source: "/api/(.*)", headers: [{ key: "X-Custom-Header", value: "vinext" }] }],
     });
     expect(code).toContain("__configHeaders");
-    expect(code).toContain("matchHeaders");
+    expect(code).toContain("applyConfigHeadersToResponse");
     expect(code).toContain("X-Custom-Header");
     expect(code).toContain("vinext");
   });

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -507,10 +507,11 @@ describe("generatePagesRouterWorkerEntry", () => {
     expect(content).toContain('from "vinext/config/config-matchers"');
     expect(content).toContain("matchRedirect");
     expect(content).toContain("matchRewrite");
-    expect(content).toContain("matchHeaders");
     expect(content).toContain("requestContextFromRequest");
     expect(content).toContain("isExternalUrl");
     expect(content).toContain("proxyExternalRequest");
+    expect(content).toContain('from "vinext/server/request-pipeline"');
+    expect(content).toContain("applyConfigHeadersToHeaderRecord");
   });
 
   it("runs middleware before routing", () => {
@@ -593,7 +594,8 @@ describe("generatePagesRouterWorkerEntry", () => {
   it("applies next.config.js custom headers", () => {
     const content = generatePagesRouterWorkerEntry();
     expect(content).toContain("configHeaders");
-    expect(content).toContain("matchHeaders(pathname");
+    expect(content).toContain("applyConfigHeadersToHeaderRecord");
+    expect(content).toContain('from "vinext/server/request-pipeline"');
   });
 
   it("handles basePath stripping and creates a new request with stripped URL for middleware", () => {

--- a/tests/request-pipeline.test.ts
+++ b/tests/request-pipeline.test.ts
@@ -1,10 +1,14 @@
 import { describe, it, expect } from "vite-plus/test";
 import {
+  applyConfigHeadersToHeaderRecord,
+  applyConfigHeadersToResponse,
+  createStaticFileSignal,
   guardProtocolRelativeUrl,
   isOpenRedirectShaped,
   hasBasePath,
   stripBasePath,
   normalizeTrailingSlash,
+  resolvePublicFileRoute,
   validateCsrfOrigin,
   validateServerActionPayload,
   validateImageUrl,
@@ -153,6 +157,158 @@ describe("stripBasePath", () => {
     expect(stripBasePath("/application/about", "/app")).toBe("/application/about");
     expect(stripBasePath("/app2", "/app")).toBe("/app2");
     expect(stripBasePath("/apple", "/app")).toBe("/apple");
+  });
+});
+
+// ── config headers ──────────────────────────────────────────────────────
+
+describe("applyConfigHeadersToResponse", () => {
+  it("matches against the original request context and preserves middleware response precedence", () => {
+    const response = new Response("ok", {
+      headers: {
+        "x-middleware": "winner",
+        vary: "RSC",
+      },
+    });
+    const request = new Request("https://example.com/about?preview=1", {
+      headers: {
+        cookie: "mode=preview",
+        "x-enable-header": "yes",
+      },
+    });
+
+    applyConfigHeadersToResponse(response.headers, {
+      configHeaders: [
+        {
+          source: "/about",
+          has: [
+            { type: "header", key: "x-enable-header", value: "yes" },
+            { type: "cookie", key: "mode", value: "preview" },
+            { type: "query", key: "preview", value: "1" },
+          ],
+          headers: [
+            { key: "x-middleware", value: "config-loses" },
+            { key: "x-added", value: "config" },
+            { key: "vary", value: "Accept" },
+            { key: "set-cookie", value: "from=config; Path=/" },
+          ],
+        },
+      ],
+      pathname: "/about",
+      requestContext: {
+        headers: request.headers,
+        cookies: { mode: "preview" },
+        query: new URL(request.url).searchParams,
+        host: "example.com",
+      },
+    });
+
+    expect(response.headers.get("x-middleware")).toBe("winner");
+    expect(response.headers.get("x-added")).toBe("config");
+    expect(response.headers.get("vary")).toBe("RSC, Accept");
+    expect(response.headers.get("set-cookie")).toBe("from=config; Path=/");
+  });
+});
+
+describe("applyConfigHeadersToHeaderRecord", () => {
+  it("adds config headers into the early response header record without overwriting middleware", () => {
+    const headers: Record<string, string | string[]> = {
+      "x-middleware": "winner",
+      vary: "RSC",
+      "set-cookie": ["mw=1; Path=/"],
+    };
+
+    applyConfigHeadersToHeaderRecord(headers, {
+      configHeaders: [
+        {
+          source: "/logo.svg",
+          headers: [
+            { key: "x-middleware", value: "config-loses" },
+            { key: "x-added", value: "config" },
+            { key: "vary", value: "Accept" },
+            { key: "set-cookie", value: "cfg=1; Path=/" },
+          ],
+        },
+      ],
+      pathname: "/logo.svg",
+      requestContext: {
+        headers: new Headers(),
+        cookies: {},
+        query: new URLSearchParams(),
+        host: "example.com",
+      },
+    });
+
+    expect(headers["x-middleware"]).toBe("winner");
+    expect(headers["x-added"]).toBe("config");
+    expect(headers.vary).toBe("RSC, Accept");
+    expect(headers["set-cookie"]).toEqual(["mw=1; Path=/", "cfg=1; Path=/"]);
+  });
+});
+
+// ── public file routing ─────────────────────────────────────────────────
+
+describe("resolvePublicFileRoute", () => {
+  it("signals GET public files and preserves middleware headers/status", () => {
+    const response = resolvePublicFileRoute({
+      cleanPathname: "/logo.svg",
+      middlewareContext: {
+        headers: new Headers({ "x-from-middleware": "1" }),
+        status: 203,
+      },
+      pathname: "/logo.svg",
+      publicFiles: new Set(["/logo.svg"]),
+      request: new Request("https://example.com/logo.svg"),
+    });
+
+    expect(response).not.toBeNull();
+    expect(response!.status).toBe(203);
+    expect(response!.headers.get("x-vinext-static-file")).toBe("%2Flogo.svg");
+    expect(response!.headers.get("x-from-middleware")).toBe("1");
+  });
+
+  it("does not signal non-GET/HEAD, RSC, or missing public file requests", () => {
+    const publicFiles = new Set(["/logo.svg", "/about.rsc"]);
+    const middlewareContext = { headers: null, status: null };
+
+    expect(
+      resolvePublicFileRoute({
+        cleanPathname: "/logo.svg",
+        middlewareContext,
+        pathname: "/logo.svg",
+        publicFiles,
+        request: new Request("https://example.com/logo.svg", { method: "POST" }),
+      }),
+    ).toBeNull();
+    expect(
+      resolvePublicFileRoute({
+        cleanPathname: "/about.rsc",
+        middlewareContext,
+        pathname: "/about.rsc",
+        publicFiles,
+        request: new Request("https://example.com/about.rsc"),
+      }),
+    ).toBeNull();
+    expect(
+      resolvePublicFileRoute({
+        cleanPathname: "/missing.svg",
+        middlewareContext,
+        pathname: "/missing.svg",
+        publicFiles,
+        request: new Request("https://example.com/missing.svg"),
+      }),
+    ).toBeNull();
+  });
+
+  it("creates standalone static file signals from normal modules", () => {
+    const response = createStaticFileSignal("/robots.txt", {
+      headers: new Headers({ "cache-control": "no-store" }),
+      status: 202,
+    });
+
+    expect(response.status).toBe(202);
+    expect(response.headers.get("x-vinext-static-file")).toBe("%2Frobots.txt");
+    expect(response.headers.get("cache-control")).toBe("no-store");
   });
 });
 


### PR DESCRIPTION
## Summary

- Move `next.config.js` header application into `request-pipeline` helpers for both Web `Headers` and early header records.
- Move App Router public-file static response resolution into `request-pipeline`, leaving generated RSC entry code to describe app shape and route manifests.
- Reuse the same config-header helper from the Pages production server and generated Pages Worker entry; export `vinext/server/request-pipeline` for generated worker code.
- Add focused tests for original-request matcher context, middleware/config header precedence, multi-value header appends, and public-file routing policy.

## Next.js references

Vinext should keep the route policy aligned with Next.js while keeping behavior out of generated templates:

- Next.js documents the request order as `headers`, `redirects`, proxy/middleware, `beforeFiles`, then filesystem routes including `public/`: https://github.com/vercel/next.js/blob/canary/docs/01-app/03-api-reference/03-file-conventions/proxy.mdx
- Next.js `resolve-routes.ts` models that same order with `fsChecker.headers`, `fsChecker.redirects`, middleware, `rewrites.beforeFiles`, and filesystem checks: https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/router-utils/resolve-routes.ts
- The redirects docs explicitly call out that redirects are checked before filesystem routes, including `/public` files: https://github.com/vercel/next.js/blob/canary/docs/01-app/03-api-reference/05-config/01-next-config-js/redirects.mdx
- Next.js filesystem routing handles public/static asset matching in `filesystem.ts`: https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/router-utils/filesystem.ts
- Next.js integration coverage includes public files after rewrites and public-file precedence over dynamic routes: https://github.com/vercel/next.js/blob/canary/test/integration/custom-routes/test/index.test.ts and https://github.com/vercel/next.js/blob/canary/test/integration/dynamic-routing/test/index.test.ts

## Tests

- `vp test run tests/request-pipeline.test.ts`
- `vp test run tests/app-router.test.ts -t "custom header handling|empty config arrays|rewrite handling code|config pattern"`
- `vp test run tests/deploy.test.ts -t "next.config.js custom headers|next.config.js redirects|next.config.js rewrites|basePath stripping"`
- `vp test run tests/request-pipeline.test.ts tests/deploy.test.ts`
- `vp test run tests/app-router.test.ts -t "custom headers from next.config.js|serves public files from the build output|serves public files under basePath|App Router next.config.js features"`
- `vp test run tests/entry-templates.test.ts`
- `vp fmt --check packages/vinext/src/server/request-pipeline.ts packages/vinext/src/entries/app-rsc-entry.ts packages/vinext/src/server/prod-server.ts packages/vinext/src/deploy.ts tests/request-pipeline.test.ts tests/app-router.test.ts tests/deploy.test.ts packages/vinext/package.json`
- `vp check`
- `vp run vinext#build`
