### PR TITLE
fix(app-router): return action-not-found for stale server actions

### DIFF
--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -77,6 +77,10 @@ import {
 import { ElementsContext, Slot } from "../shims/slot.js";
 import { devOnCaughtError } from "./app-browser-error.js";
 import { DANGEROUS_URL_BLOCK_MESSAGE, isDangerousScheme } from "../shims/url-safety.js";
+import {
+  getServerActionNotFoundClientMessage,
+  isServerActionNotFoundResponse,
+} from "./server-action-not-found.js";
 
 type SearchParamInput = ConstructorParameters<typeof URLSearchParams>[0];
 
@@ -1008,6 +1012,10 @@ function registerServerActionCallback(): void {
       headers,
       body,
     });
+
+    if (isServerActionNotFoundResponse(fetchResponse)) {
+      throw new Error(getServerActionNotFoundClientMessage(id));
+    }
 
     const actionRedirect = fetchResponse.headers.get("x-action-redirect");
     if (actionRedirect) {

--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -2,6 +2,11 @@ import type { HeadersAccessPhase } from "../shims/headers.js";
 import { resolveAppPageActionRerenderTarget } from "./app-page-request.js";
 import { mergeMiddlewareResponseHeaders } from "./middleware-response-headers.js";
 import { validateCsrfOrigin, validateServerActionPayload } from "./request-pipeline.js";
+import {
+  createServerActionNotFoundResponse,
+  getServerActionNotFoundMessage,
+  isServerActionNotFoundError,
+} from "./server-action-not-found.js";
 
 type AppPageParams = Record<string, string | string[]>;
 
@@ -126,7 +131,7 @@ export type HandleServerActionRscRequestOptions<
   getRouteParamNames: (route: TRoute) => readonly string[];
   getSourceRoute: (sourceRouteIndex: number) => TRoute | undefined;
   isRscRequest: boolean;
-  loadServerAction: (actionId: string) => Promise<AppServerActionFunction>;
+  loadServerAction: (actionId: string) => Promise<unknown>;
   matchRoute: (pathname: string) => AppServerActionMatch<TRoute> | null;
   maxActionBodySize: number;
   middlewareHeaders: Headers | null;
@@ -163,6 +168,10 @@ type ActionControlResponse =
 
 function isRequestBodyTooLarge(error: unknown): boolean {
   return error instanceof Error && error.message === "Request body too large";
+}
+
+function isAppServerActionFunction(action: unknown): action is AppServerActionFunction {
+  return typeof action === "function";
 }
 
 function normalizeError(error: unknown): Error {
@@ -267,6 +276,19 @@ function createServerActionErrorResponse(
   );
 }
 
+function createActionNotFoundResponse(
+  actionId: string | null,
+  options: {
+    clearRequestContext: () => void;
+    getAndClearPendingCookies: () => string[];
+  },
+): Response {
+  options.getAndClearPendingCookies();
+  console.warn(getServerActionNotFoundMessage(actionId));
+  options.clearRequestContext();
+  return createServerActionNotFoundResponse();
+}
+
 export function isProgressiveServerActionRequest(
   request: Pick<Request, "method">,
   contentType: string,
@@ -367,6 +389,13 @@ export async function handleProgressiveServerActionRequest(
       headers,
     });
   } catch (error) {
+    if (isServerActionNotFoundError(error, null)) {
+      return createActionNotFoundResponse(null, {
+        clearRequestContext: options.clearRequestContext,
+        getAndClearPendingCookies: options.getAndClearPendingCookies,
+      });
+    }
+
     options.getAndClearPendingCookies();
     // Next.js rethrows generic MPA action errors into its page render path.
     // vinext does not yet implement that form-state render path, so unexpected
@@ -439,9 +468,29 @@ export async function handleServerActionRscRequest<
       return payloadResponse;
     }
 
+    let action: unknown;
+    try {
+      action = await options.loadServerAction(options.actionId);
+    } catch (error) {
+      if (isServerActionNotFoundError(error, options.actionId)) {
+        return createActionNotFoundResponse(options.actionId, {
+          clearRequestContext: options.clearRequestContext,
+          getAndClearPendingCookies: options.getAndClearPendingCookies,
+        });
+      }
+
+      throw error;
+    }
+
+    if (!isAppServerActionFunction(action)) {
+      return createActionNotFoundResponse(options.actionId, {
+        clearRequestContext: options.clearRequestContext,
+        getAndClearPendingCookies: options.getAndClearPendingCookies,
+      });
+    }
+
     const temporaryReferences = options.createTemporaryReferenceSet();
     const args = await options.decodeReply(body, { temporaryReferences });
-    const action = await options.loadServerAction(options.actionId);
     let returnValue: AppServerActionReturnValue;
     let actionRedirect: AppServerActionRedirect | null = null;
     const previousHeadersPhase = options.setHeadersAccessPhase("action");

--- a/packages/vinext/src/server/server-action-not-found.ts
+++ b/packages/vinext/src/server/server-action-not-found.ts
@@ -1,0 +1,58 @@
+const SERVER_ACTION_NOT_FOUND_DOCS =
+  "https://nextjs.org/docs/messages/failed-to-find-server-action";
+
+const SERVER_ACTION_NOT_FOUND_HEADER = "x-nextjs-action-not-found";
+const SERVER_ACTION_NOT_FOUND_BODY = "Server action not found.";
+
+function getServerActionNotFoundPrefix(actionId: string | null): string {
+  return `Failed to find Server Action${actionId ? ` "${actionId}"` : ""}.`;
+}
+
+export function getServerActionNotFoundMessage(actionId: string | null): string {
+  return `${getServerActionNotFoundPrefix(
+    actionId,
+  )} This request might be from an older or newer deployment.\nRead more: ${SERVER_ACTION_NOT_FOUND_DOCS}`;
+}
+
+export function getServerActionNotFoundClientMessage(actionId: string): string {
+  return `Server Action "${actionId}" was not found on the server. \nRead more: ${SERVER_ACTION_NOT_FOUND_DOCS}`;
+}
+
+function getUnknownMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return typeof error === "string" ? error : "";
+}
+
+export function isServerActionNotFoundError(error: unknown, actionId: string | null): boolean {
+  const message = getUnknownMessage(error);
+  if (!message) {
+    return false;
+  }
+
+  if (!actionId) {
+    return message.startsWith("Failed to find Server Action");
+  }
+
+  if (message.startsWith(getServerActionNotFoundPrefix(actionId))) {
+    return true;
+  }
+
+  return Boolean(actionId && message.includes(`[vite-rsc] invalid server reference '${actionId}'`));
+}
+
+export function createServerActionNotFoundResponse(): Response {
+  return new Response(SERVER_ACTION_NOT_FOUND_BODY, {
+    status: 404,
+    headers: {
+      [SERVER_ACTION_NOT_FOUND_HEADER]: "1",
+      "content-type": "text/plain",
+    },
+  });
+}
+
+export function isServerActionNotFoundResponse(response: Pick<Response, "headers">): boolean {
+  return response.headers.get(SERVER_ACTION_NOT_FOUND_HEADER) === "1";
+}

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -1481,8 +1481,8 @@ describe("App Router integration", () => {
   });
 
   it("allows server action POST with matching Origin header", async () => {
-    // This will fail with 500 (action not found) rather than 403,
-    // proving the CSRF check passed and execution reached the action handler.
+    // Ported from Next.js: test/e2e/app-dir/no-server-actions/no-server-actions.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/no-server-actions/no-server-actions.test.ts
     const res = await fetch(`${baseUrl}/actions.rsc`, {
       method: "POST",
       headers: {
@@ -1493,9 +1493,9 @@ describe("App Router integration", () => {
       },
       body: "[]",
     });
-    // Should NOT be 403 — the CSRF check passes for same-origin.
-    // It may be 500 because the action ID doesn't exist, which is fine.
-    expect(res.status).not.toBe(403);
+    expect(res.status).toBe(404);
+    expect(res.headers.get("x-nextjs-action-not-found")).toBe("1");
+    expect(await res.text()).toBe("Server action not found.");
   });
 
   it("allows server action POST without Origin header (non-fetch navigation)", async () => {
@@ -1508,8 +1508,8 @@ describe("App Router integration", () => {
       },
       body: "[]",
     });
-    // Should NOT be 403 — missing Origin is allowed.
-    expect(res.status).not.toBe(403);
+    expect(res.status).toBe(404);
+    expect(res.headers.get("x-nextjs-action-not-found")).toBe("1");
   });
 
   it("rejects cyclic multipart server action payloads before decodeReply", async () => {

--- a/tests/app-server-action-execution.test.ts
+++ b/tests/app-server-action-execution.test.ts
@@ -428,6 +428,48 @@ describe("app server action execution helpers", () => {
     errorSpy.mockRestore();
   });
 
+  // Ported from Next.js: test/e2e/app-dir/no-server-actions/no-server-actions.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/no-server-actions/no-server-actions.test.ts
+  it("returns the action-not-found response for progressive action decode misses", async () => {
+    const reportedErrors: Error[] = [];
+    const clearContext = vi.fn();
+
+    const response = await handleProgressiveServerActionRequest(
+      createOptions({
+        clearRequestContext: clearContext,
+        async decodeAction() {
+          throw new Error(
+            "Failed to find Server Action. This request might be from an older or newer deployment.\nRead more: https://nextjs.org/docs/messages/failed-to-find-server-action",
+          );
+        },
+        reportRequestError(error) {
+          reportedErrors.push(error);
+        },
+      }),
+    );
+
+    expect(response?.status).toBe(404);
+    expect(response?.headers.get("x-nextjs-action-not-found")).toBe("1");
+    expect(await response?.text()).toBe("Server action not found.");
+    expect(reportedErrors).toEqual([]);
+    expect(clearContext).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns action-not-found for progressive decode misses that include an action id", async () => {
+    const response = await handleProgressiveServerActionRequest(
+      createOptions({
+        async decodeAction() {
+          throw new Error(
+            'Failed to find Server Action "stale-action-id". This request might be from an older or newer deployment.\nRead more: https://nextjs.org/docs/messages/failed-to-find-server-action',
+          );
+        },
+      }),
+    );
+
+    expect(response?.status).toBe(404);
+    expect(response?.headers.get("x-nextjs-action-not-found")).toBe("1");
+  });
+
   it("returns null for non-fetch RSC action requests", async () => {
     const response = await handleServerActionRscRequest(
       createRscOptions({
@@ -466,7 +508,9 @@ describe("app server action execution helpers", () => {
         },
         loadServerAction(actionId) {
           expect(actionId).toBe("action-id");
-          return Promise.resolve((first, second) => `${String(first)}:${String(second)}`);
+          return Promise.resolve(
+            (first: unknown, second: unknown) => `${String(first)}:${String(second)}`,
+          );
         },
         middlewareHeaders: new Headers([["x-middleware", "present"]]),
         renderToReadableStream(model, options) {
@@ -516,6 +560,77 @@ describe("app server action execution helpers", () => {
     expect(response?.status).toBe(400);
     expect(await response?.text()).toBe("Invalid server action payload");
     expect(decodeReply).not.toHaveBeenCalled();
+  });
+
+  // Ported from Next.js: test/e2e/app-dir/no-server-actions/no-server-actions.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/no-server-actions/no-server-actions.test.ts
+  it("returns the Next.js action-not-found response for stale fetch action ids", async () => {
+    const decodeReply = vi.fn();
+    const renderToReadableStream = vi.fn();
+    const reportRequestError = vi.fn();
+    const clearRequestContext = vi.fn();
+
+    const response = await handleServerActionRscRequest(
+      createRscOptions({
+        actionId: "stale-action-id",
+        clearRequestContext,
+        decodeReply,
+        loadServerAction() {
+          return Promise.reject(new Error("[vite-rsc] invalid server reference 'stale-action-id'"));
+        },
+        renderToReadableStream,
+        reportRequestError,
+      }),
+    );
+
+    expect(response?.status).toBe(404);
+    expect(response?.headers.get("x-nextjs-action-not-found")).toBe("1");
+    expect(response?.headers.get("content-type")).toBe("text/plain");
+    expect(await response?.text()).toBe("Server action not found.");
+    expect(decodeReply).not.toHaveBeenCalled();
+    expect(renderToReadableStream).not.toHaveBeenCalled();
+    expect(reportRequestError).not.toHaveBeenCalled();
+    expect(clearRequestContext).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns action-not-found when a server action export is missing", async () => {
+    const decodeReply = vi.fn();
+
+    const response = await handleServerActionRscRequest(
+      createRscOptions({
+        decodeReply,
+        loadServerAction() {
+          return Promise.resolve(undefined);
+        },
+      }),
+    );
+
+    expect(response?.status).toBe(404);
+    expect(response?.headers.get("x-nextjs-action-not-found")).toBe("1");
+    expect(await response?.text()).toBe("Server action not found.");
+    expect(decodeReply).not.toHaveBeenCalled();
+  });
+
+  it("keeps unrelated server action loader failures on the generic error path", async () => {
+    const reportedErrors: Error[] = [];
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const response = await handleServerActionRscRequest(
+      createRscOptions({
+        loadServerAction() {
+          return Promise.reject(new Error("module graph crashed"));
+        },
+        reportRequestError(error) {
+          reportedErrors.push(error);
+        },
+      }),
+    );
+
+    expect(response?.status).toBe(500);
+    expect(await response?.text()).toBe("Server action failed: module graph crashed");
+    expect(reportedErrors.map((error) => error.message)).toEqual(["module graph crashed"]);
+
+    errorSpy.mockRestore();
   });
 
   it("encodes fetch-action redirects as RSC control headers", async () => {


### PR DESCRIPTION
## What this changes
Vinext now returns the Next.js action-not-found protocol for unknown or stale App Router Server Action ids:

- `404` response status
- `x-nextjs-action-not-found: 1`
- `Server action not found.` response body
- client-side action callback throws the matching not-found error before attempting to decode a Flight payload

## Why
Stale Server Action ids can happen during deployment skew or from an older client tab. Before this change, `loadServerAction()` failures fell through the generic server action error reporter and returned `500`, which made expected skew look like an application failure and skipped the client recovery signal.

Next.js treats this as a dedicated not-found protocol:

- Server response header/status: [`handleUnrecognizedFetchAction`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/action-handler.ts#L562-L577)
- Fetch action id validation before decoding args: [`getActionModIdOrError` call](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/action-handler.ts#L764-L768) and [`getActionModIdOrError`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/action-handler.ts#L1348-L1369)
- Client interpretation of `x-nextjs-action-not-found`: [`server-action-reducer.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts#L173-L178)
- Observable e2e contract: [`no-server-actions.test.ts`](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/no-server-actions/no-server-actions.test.ts#L8-L47)

## Approach
The action-not-found behavior is implemented in a normal runtime module, `server-action-not-found.ts`, and the generated/runtime entry paths only wire through that behavior. This keeps with the project rule that codegen describes app shape while normal modules implement behavior.

The RSC action helper now treats `loadServerAction()` as an external runtime boundary returning `unknown`, narrows it before invocation, and maps only recognized missing-action cases to the action-not-found response. Unrelated loader failures still go through the existing generic 500 reporter path.

## Validation
- `vp test run tests/app-server-action-execution.test.ts`
- `vp test run tests/app-router.test.ts -t "allows server action POST"`
- `vp test run tests/app-server-action-execution.test.ts tests/app-router.test.ts -t "allows server action POST|stale fetch action ids|progressive action decode misses|server action export is missing|unrelated server action loader failures"`
- `vp run vinext#build`
- `vp check`

Note: in this fresh worktree, running `vp check` before `vp run vinext#build` failed because `benchmarks/vinext/vite.config.ts` could not resolve the workspace `vinext` package. After the package build created the local dist artifacts, `vp check` passed cleanly.

## Risks / follow-ups
The missing-action classifier is intentionally narrow: it recognizes Next.js' failed-action messages and Vite RSC's invalid server reference message, while preserving generic loader failures as 500s. Malformed action payload validation still runs before action lookup in Vinext to preserve the existing payload-hardening behavior.
