### PR TITLE
refactor(app-router): extract app page dispatch

### DIFF
--- a/knip.ts
+++ b/knip.ts
@@ -42,6 +42,7 @@ export default {
         // Runtime helpers imported by generated virtual entries. The imports
         // are emitted as strings, so knip cannot trace them statically.
         "src/server/app-middleware.ts",
+        "src/server/app-page-dispatch.ts",
         "src/server/app-page-head.ts",
         "src/server/app-prerender-static-params.ts",
         // Client-side instrumentation bundle: loaded as a side-effect module

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -43,9 +43,7 @@ const appServerActionExecutionPath = resolveEntryPath(
 );
 const appRscErrorsPath = resolveEntryPath("../server/app-rsc-errors.js", import.meta.url);
 const implicitTagsPath = resolveEntryPath("../server/implicit-tags.js", import.meta.url);
-const appPageCachePath = resolveEntryPath("../server/app-page-cache.js", import.meta.url);
 const appPageExecutionPath = resolveEntryPath("../server/app-page-execution.js", import.meta.url);
-const appPageBoundaryPath = resolveEntryPath("../server/app-page-boundary.js", import.meta.url);
 const appPageBoundaryRenderPath = resolveEntryPath(
   "../server/app-page-boundary-render.js",
   import.meta.url,
@@ -57,15 +55,9 @@ const appPageRouteWiringPath = resolveEntryPath(
 );
 const appPageHeadPath = resolveEntryPath("../server/app-page-head.js", import.meta.url);
 const appPageParamsPath = resolveEntryPath("../server/app-page-params.js", import.meta.url);
-const appPageRenderPath = resolveEntryPath("../server/app-page-render.js", import.meta.url);
 const appPageResponsePath = resolveEntryPath("../server/app-page-response.js", import.meta.url);
+const appPageDispatchPath = resolveEntryPath("../server/app-page-dispatch.js", import.meta.url);
 const cspPath = resolveEntryPath("../server/csp.js", import.meta.url);
-const appPageRequestPath = resolveEntryPath("../server/app-page-request.js", import.meta.url);
-const appPageMethodPath = resolveEntryPath("../server/app-page-method.js", import.meta.url);
-const appStaticGenerationPath = resolveEntryPath(
-  "../server/app-static-generation.js",
-  import.meta.url,
-);
 const appRscRouteMatchingPath = resolveEntryPath(
   "../server/app-rsc-route-matching.js",
   import.meta.url,
@@ -212,17 +204,10 @@ import {
   createRscOnErrorHandler as __createRscOnErrorHandler,
   sanitizeErrorForClient as __sanitizeErrorForClient,
 } from ${JSON.stringify(appRscErrorsPath)};
-import { readAppPageCacheResponse as __readAppPageCacheResponse } from ${JSON.stringify(appPageCachePath)};
 import {
   buildAppPageFontLinkHeader as __buildAppPageFontLinkHeader,
-  buildAppPageSpecialErrorResponse as __buildAppPageSpecialErrorResponse,
-  readAppPageTextStream as __readAppPageTextStream,
   resolveAppPageSpecialError as __resolveAppPageSpecialError,
-  teeAppPageRscStreamForCapture as __teeAppPageRscStreamForCapture,
 } from ${JSON.stringify(appPageExecutionPath)};
-import {
-  resolveAppPageParentHttpAccessBoundaryModule as __resolveAppPageParentHttpAccessBoundaryModule,
-} from ${JSON.stringify(appPageBoundaryPath)};
 import {
   renderAppPageErrorBoundary as __renderAppPageErrorBoundary,
   renderAppPageHttpAccessFallback as __renderAppPageHttpAccessFallback,
@@ -245,29 +230,17 @@ import {
   resolveAppPageHead as __resolveAppPageHead,
 } from ${JSON.stringify(appPageHeadPath)};
 import {
-  renderAppPageLifecycle as __renderAppPageLifecycle,
-} from ${JSON.stringify(appPageRenderPath)};
-import {
   mergeMiddlewareResponseHeaders as __mergeMiddlewareResponseHeaders,
 } from ${JSON.stringify(appPageResponsePath)};
+import {
+  dispatchAppPage as __dispatchAppPage,
+} from ${JSON.stringify(appPageDispatchPath)};
 import { getScriptNonceFromHeaderSources as __getScriptNonceFromHeaderSources } from ${JSON.stringify(cspPath)};
-import {
-  buildAppPageElement as __buildAppPageElement,
-  resolveAppPageIntercept as __resolveAppPageIntercept,
-  validateAppPageDynamicParams as __validateAppPageDynamicParams,
-} from ${JSON.stringify(appPageRequestPath)};
-import {
-  resolveAppPageMethodResponse as __resolveAppPageMethodResponse,
-} from ${JSON.stringify(appPageMethodPath)};
-import {
-  createStaticGenerationHeadersContext as __createStaticGenerationHeadersContext,
-} from ${JSON.stringify(appStaticGenerationPath)};
 import { buildPageCacheTags } from ${JSON.stringify(implicitTagsPath)};
-import { _consumeRequestScopedCacheLife } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from ${JSON.stringify(requestContextShimPath)};
 import { setRootParams as __setRootParams, pickRootParams as __pickRootParams } from ${JSON.stringify(rootParamsShimPath)};
 import { makeThenableParams } from ${JSON.stringify(thenableParamsShimPath)};
-import { ensureFetchPatch as _ensureFetchPatch, getCollectedFetchTags, setCurrentFetchSoftTags } from "vinext/fetch-cache";
+import { ensureFetchPatch as _ensureFetchPatch, setCurrentFetchSoftTags } from "vinext/fetch-cache";
 import {
   createAppRscRouteMatcher as __createAppRscRouteMatcher,
 } from ${JSON.stringify(appRscRouteMatchingPath)};
@@ -1138,9 +1111,6 @@ ${prerenderPagesLoaderOption}
   }
 
   const { route, params } = match;
-  setCurrentFetchSoftTags(
-    buildPageCacheTags(cleanPathname, [], route.routeSegments, route.routeHandler ? "route" : "page"),
-  );
 
   // Update navigation context with matched params
   setNavigationContext({
@@ -1152,6 +1122,9 @@ ${prerenderPagesLoaderOption}
 
   // Handle route.ts API handlers
   if (route.routeHandler) {
+    setCurrentFetchSoftTags(
+      buildPageCacheTags(cleanPathname, [], route.routeSegments, "route"),
+    );
     return __dispatchAppRouteHandler({
       basePath: __basePath,
       cleanPathname,
@@ -1177,343 +1150,56 @@ ${prerenderPagesLoaderOption}
     });
   }
 
-  // Build the component tree: layouts wrapping the page
-  const hasPageModule = !!route.page;
   const PageComponent = route.page?.default;
-  if (hasPageModule && !PageComponent) {
-    __clearRequestContext();
-    return new Response("Page has no default export", { status: 500 });
-  }
-
-  // Read route segment config from page module exports
-  let revalidateSeconds = typeof route.page?.revalidate === "number" ? route.page.revalidate : null;
-  const dynamicConfig = route.page?.dynamic; // 'auto' | 'force-dynamic' | 'force-static' | 'error'
-  const dynamicParamsConfig = route.page?.dynamicParams; // true (default) | false
-  const isForceStatic = dynamicConfig === "force-static";
-  const isDynamicError = dynamicConfig === "error";
-  const __methodResponse = __resolveAppPageMethodResponse({
-    dynamicConfig,
-    hasGenerateStaticParams: typeof route.page?.generateStaticParams === "function",
-    isDynamicRoute: route.isDynamic,
-    middlewareHeaders: _mwCtx.headers,
-    request,
-    revalidateSeconds,
-  });
-  if (__methodResponse) {
-    __clearRequestContext();
-    return __methodResponse;
-  }
-
-  // force-static: replace headers/cookies context with empty values and
-  // clear searchParams so dynamic APIs return defaults instead of real data
-  if (isForceStatic) {
-    setHeadersContext(__createStaticGenerationHeadersContext({
-      dynamicConfig,
-      routeKind: "page",
-      routePattern: route.pattern,
-    }));
-    setNavigationContext({
-      pathname: cleanPathname,
-      searchParams: new URLSearchParams(),
-      params,
-    });
-  }
-
-  // dynamic = 'error': install an access error so request APIs fail with the
-  // static-generation message even for legacy sync property access.
-  if (isDynamicError) {
-    setHeadersContext(__createStaticGenerationHeadersContext({
-      dynamicConfig,
-      routeKind: "page",
-      routePattern: route.pattern,
-    }));
-    setNavigationContext({
-      pathname: cleanPathname,
-      searchParams: new URLSearchParams(),
-      params,
-    });
-  }
-
-  // force-dynamic: set no-store Cache-Control
-  const isForceDynamic = dynamicConfig === "force-dynamic";
-
-  // ── ISR cache read (production only) ─────────────────────────────────────
-  // Read from cache BEFORE generateStaticParams and all rendering work.
-  // This is the critical performance optimization: on a cache hit we skip
-  // ALL expensive work (generateStaticParams, buildPageElement, layout probe,
-  // page probe, renderToReadableStream, SSR). Both HTML and RSC requests
-  // (client-side navigation / prefetch) are served from cache.
-  //
-  // HTML and RSC are stored under separate keys (matching Next.js's .html/.rsc
-  // file layout) so each request type reads and writes independently — no races,
-  // no partial-entry sentinels, no read-before-write hacks needed.
-  //
-  // force-static and dynamic='error' are compatible with ISR — they control
-  // how dynamic APIs behave during rendering, not whether results are cached.
-  // Only force-dynamic truly bypasses the ISR cache.
-  if (
-    process.env.NODE_ENV === "production" &&
-    !isForceDynamic &&
-    (isRscRequest || !_scriptNonce) &&
-    revalidateSeconds !== null && revalidateSeconds > 0 && revalidateSeconds !== Infinity
-  ) {
-    const __cachedPageResponse = await __readAppPageCacheResponse({
-      cleanPathname,
-      clearRequestContext: function() {
-        __clearRequestContext();
-      },
-      isRscRequest,
-      isrDebug: __isrDebug,
-      isrGet: __isrGet,
-      isrHtmlKey: __isrHtmlKey,
-      isrRscKey: __isrRscKey,
-      isrSet: __isrSet,
-      mountedSlotsHeader: __mountedSlotsHeader,
-      revalidateSeconds,
-      renderFreshPageForCache: async function() {
-        // Re-render the page to produce fresh HTML + RSC data for the cache
-        // Use an empty headers context for background regeneration — not the original
-        // user request — to prevent user-specific cookies/auth headers from leaking
-        // into content that is cached and served to all subsequent users.
-        const __revalHeadCtx = __createStaticGenerationHeadersContext({
-          dynamicConfig,
-          routeKind: "page",
-          routePattern: route.pattern,
-        });
-        const __revalUCtx = _createUnifiedCtx({
-          headersContext: __revalHeadCtx,
-          executionContext: _getRequestExecutionContext(),
-          unstableCacheRevalidation: "foreground",
-        });
-        return _runWithUnifiedCtx(__revalUCtx, async () => {
-          _ensureFetchPatch();
-          setCurrentFetchSoftTags(buildPageCacheTags(cleanPathname, [], route.routeSegments, "page"));
-          setNavigationContext({ pathname: cleanPathname, searchParams: new URLSearchParams(), params });
-          // Slot context (X-Vinext-Mounted-Slots) is inherited from the
-          // triggering request so the regen result is cached under the
-          // correct slot-variant key.
-          const __revalElement = await buildPageElements(
-            route,
-            params,
-            cleanPathname,
-            {
-              opts: undefined,
-              searchParams: new URLSearchParams(),
-              isRscRequest,
-              request,
-              mountedSlotsHeader: __mountedSlotsHeader,
-            },
-          );
-          const __revalOnError = createRscOnErrorHandler(request, cleanPathname, route.pattern);
-          const __revalRscStream = renderToReadableStream(__revalElement, { onError: __revalOnError });
-          const __revalRscCapture = __teeAppPageRscStreamForCapture(__revalRscStream, true);
-          const __revalFontData = { links: _getSSRFontLinks(), styles: _getSSRFontStyles(), preloads: _getSSRFontPreloads() };
-          const __revalSsrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
-          const __revalCapturedRscRef = { value: null };
-          const __revalHtmlStream = await __revalSsrEntry.handleSsr(
-            __revalRscCapture.ssrStream,
-            _getNavigationContext(),
-            __revalFontData,
-            __revalRscCapture.sideStream
-              ? { sideStream: __revalRscCapture.sideStream, capturedRscDataRef: __revalCapturedRscRef }
-              : undefined,
-          );
-          __clearRequestContext();
-          const __freshHtml = await __readAppPageTextStream(__revalHtmlStream);
-          const __freshRscData = __revalCapturedRscRef.value ? await __revalCapturedRscRef.value : null;
-          const __pageTags = buildPageCacheTags(cleanPathname, getCollectedFetchTags(), route.routeSegments, "page");
-          return { html: __freshHtml, rscData: __freshRscData, tags: __pageTags };
-        });
-      },
-      scheduleBackgroundRegeneration(key, renderFn) {
-        __triggerBackgroundRegeneration(key, renderFn, {
-          routerKind: "App Router",
-          routePath: route.pattern,
-          routeType: "render",
-        });
-      },
-    });
-    if (__cachedPageResponse) {
-      return __cachedPageResponse;
-    }
-  }
-
-  // dynamicParams = false: only params from generateStaticParams are allowed.
-  // This runs AFTER the ISR cache read so that a cache hit skips this work entirely.
-  const __dynamicParamsResponse = await __validateAppPageDynamicParams({
-    clearRequestContext() {
-      __clearRequestContext();
-    },
-    enforceStaticParamsOnly: dynamicParamsConfig === false,
-    generateStaticParams: route.page?.generateStaticParams,
-    isDynamicRoute: route.isDynamic,
-    logGenerateStaticParamsError(err) {
-      console.error("[vinext] generateStaticParams error:", err);
-    },
-    params,
-  });
-  if (__dynamicParamsResponse) {
-    return __dynamicParamsResponse;
-  }
-
-  // Check for intercepting routes on RSC requests (client-side navigation).
-  // If the target URL matches an intercepting route in a parallel slot,
-  // render the source route with the intercepting page in the slot.
-  const __interceptResult = await __resolveAppPageIntercept({
-    buildPageElement(interceptRoute, interceptParams, interceptOpts, interceptSearchParams) {
-      return buildPageElements(
-        interceptRoute,
-        interceptParams,
-        cleanPathname,
-        {
-          opts: interceptOpts,
-          searchParams: interceptSearchParams,
-          isRscRequest,
-          request,
-          mountedSlotsHeader: __mountedSlotsHeader,
-        },
-      );
-    },
-    cleanPathname,
-    currentRoute: route,
-    findIntercept(pathname) {
-      return findIntercept(pathname, interceptionContextHeader);
-    },
-    getRouteParamNames(sourceRoute) {
-      return sourceRoute.params;
-    },
-    getSourceRoute(sourceRouteIndex) {
-      return routes[sourceRouteIndex];
-    },
-    isRscRequest,
-    renderInterceptResponse(sourceRoute, interceptElement) {
-      const interceptOnError = createRscOnErrorHandler(
-        request,
-        cleanPathname,
-        sourceRoute.pattern,
-      );
-      const interceptStream = renderToReadableStream(interceptElement, {
-        onError: interceptOnError,
-      });
-      // Do NOT clear headers/navigation context here — the RSC stream is consumed lazily
-      // by the client, and async server components that run during consumption need the
-      // context to still be live. The AsyncLocalStorage scope from runWithRequestContext
-      // handles cleanup naturally when all async continuations complete.
-      const interceptHeaders = new Headers({
-        "Content-Type": "text/x-component; charset=utf-8",
-        "Vary": "RSC, Accept",
-      });
-      __mergeMiddlewareResponseHeaders(interceptHeaders, _mwCtx.headers);
-      return new Response(interceptStream, {
-        status: _mwCtx.status ?? 200,
-        headers: interceptHeaders,
-      });
-    },
-    searchParams: url.searchParams,
-    setNavigationContext,
-    toInterceptOpts(intercept) {
-      return {
-        interceptionContext: interceptionContextHeader,
-        interceptLayouts: intercept.interceptLayouts,
-        interceptSlotKey: intercept.slotKey,
-        interceptPage: intercept.page,
-        interceptParams: intercept.matchedParams,
-      };
-    },
-  });
-  if (__interceptResult.response) {
-    return __interceptResult.response;
-  }
-  const interceptOpts = __interceptResult.interceptOpts;
-
-  const __pageBuildResult = await __buildAppPageElement({
-    buildPageElement() {
-      return buildPageElements(route, params, cleanPathname, {
-        opts: interceptOpts,
-        searchParams: url.searchParams,
+  const _asyncRouteParams = makeThenableParams(params);
+  return __dispatchAppPage({
+    buildPageElement(targetRoute, targetParams, targetOpts, targetSearchParams) {
+      return buildPageElements(targetRoute, targetParams, cleanPathname, {
+        opts: targetOpts,
+        searchParams: targetSearchParams,
         isRscRequest,
         request,
         mountedSlotsHeader: __mountedSlotsHeader,
       });
     },
-    renderErrorBoundaryPage(buildErr) {
-      return renderErrorBoundaryPage(route, buildErr, isRscRequest, request, params, _scriptNonce, _mwCtx);
-    },
-    renderSpecialError(__buildSpecialError) {
-      return __buildAppPageSpecialErrorResponse({
-        clearRequestContext() {
-          __clearRequestContext();
-        },
-        middlewareContext: _mwCtx,
-        renderFallbackPage(statusCode) {
-          return renderHTTPAccessFallbackPage(
-            route,
-            statusCode,
-            isRscRequest,
-            request,
-            {
-              matchedParams: params,
-            },
-            _scriptNonce,
-            // buildAppPageSpecialErrorResponse merges _mwCtx onto this returned
-            // fallback response; keep this inner boundary render unmerged so
-            // additive headers like Set-Cookie and Vary are not duplicated.
-            null,
-          );
-        },
-        requestUrl: request.url,
-        specialError: __buildSpecialError,
-      });
-    },
-    resolveSpecialError: __resolveAppPageSpecialError,
-  });
-  if (__pageBuildResult.response) {
-    return __pageBuildResult.response;
-  }
-  const element = __pageBuildResult.element;
-
-  // Note: CSS is automatically injected by @vitejs/plugin-rsc's
-  // rscCssTransform — no manual loadCss() call needed.
-  const _hasLoadingBoundary = !!(route.loading && route.loading.default);
-  const _asyncRouteParams = makeThenableParams(params);
-  return __renderAppPageLifecycle({
     cleanPathname,
     clearRequestContext() {
       __clearRequestContext();
     },
-    consumeDynamicUsage,
-    consumeInvalidDynamicUsageError,
     createRscOnErrorHandler(pathname, routePath) {
       return createRscOnErrorHandler(request, pathname, routePath);
     },
-    element,
-    getDraftModeCookieHeader,
+    debugClassification: __classDebug,
+    dynamicConfig: route.page?.dynamic,
+    dynamicParamsConfig: route.page?.dynamicParams,
+    findIntercept(pathname) {
+      return findIntercept(pathname, interceptionContextHeader);
+    },
+    generateStaticParams: route.page?.generateStaticParams,
     getFontLinks: _getSSRFontLinks,
     getFontPreloads: _getSSRFontPreloads,
     getFontStyles: _getSSRFontStyles,
     getNavigationContext: _getNavigationContext,
-    getPageTags() {
-      return buildPageCacheTags(cleanPathname, getCollectedFetchTags(), route.routeSegments, "page");
+    getSourceRoute(sourceRouteIndex) {
+      return routes[sourceRouteIndex];
     },
-    getRequestCacheLife() {
-      return _consumeRequestScopedCacheLife();
-    },
+    hasGenerateStaticParams: typeof route.page?.generateStaticParams === "function",
+    hasPageDefaultExport: !!PageComponent,
+    hasPageModule: !!route.page,
     handlerStart: __reqStart,
-    hasLoadingBoundary: _hasLoadingBoundary,
-    isDynamicError,
-    isForceDynamic,
-    isForceStatic,
+    interceptionContext: interceptionContextHeader,
     isProduction: process.env.NODE_ENV === "production",
     isRscRequest,
     isrDebug: __isrDebug,
+    isrGet: __isrGet,
     isrHtmlKey: __isrHtmlKey,
     isrRscKey: __isrRscKey,
     isrSet: __isrSet,
-    layoutCount: route.layouts?.length ?? 0,
     loadSsrHandler() {
       return import.meta.viteRsc.loadModule("ssr", "index");
     },
     middlewareContext: _mwCtx,
+    mountedSlotsHeader: __mountedSlotsHeader,
     params,
     probeLayoutAt(li) {
       const LayoutComp = route.layouts[li]?.default;
@@ -1534,109 +1220,28 @@ ${prerenderPagesLoaderOption}
       );
       return PageComponent({ params: _asyncRouteParams, searchParams: _asyncSearchParams });
     },
-    classification: {
-      getLayoutId(index) {
-        const tp = route.layoutTreePositions?.[index] ?? 0;
-        return "layout:" + __createAppPageTreePath(route.routeSegments, tp);
-      },
-      buildTimeClassifications: route.__buildTimeClassifications,
-      buildTimeReasons: route.__buildTimeReasons,
-      debugClassification: __classDebug,
-      async runWithIsolatedDynamicScope(fn) {
-        const priorDynamic = consumeDynamicUsage();
-        try {
-          const result = await fn();
-          const dynamicDetected = consumeDynamicUsage();
-          return { result, dynamicDetected };
-        } finally {
-          consumeDynamicUsage();
-          if (priorDynamic) markDynamicUsage();
-        }
-      },
-    },
-    revalidateSeconds,
-    mountedSlotsHeader: __mountedSlotsHeader,
-    renderErrorBoundaryResponse(renderErr) {
+    renderErrorBoundaryPage(renderErr) {
       return renderErrorBoundaryPage(route, renderErr, isRscRequest, request, params, _scriptNonce, _mwCtx);
     },
-    async renderLayoutSpecialError(__layoutSpecialError, li) {
-      return __buildAppPageSpecialErrorResponse({
-        clearRequestContext() {
-          __clearRequestContext();
-        },
-        middlewareContext: _mwCtx,
-        renderFallbackPage(statusCode) {
-          const parentBoundary = __resolveAppPageParentHttpAccessBoundaryModule({
-            layoutIndex: li,
-            rootForbiddenModule: ${rootForbiddenVar ?? "null"},
-            rootNotFoundModule: ${rootNotFoundVar ?? "null"},
-            rootUnauthorizedModule: ${rootUnauthorizedVar ?? "null"},
-            routeForbiddenModules: route.forbiddens,
-            routeNotFoundModules: route.notFounds,
-            routeUnauthorizedModules: route.unauthorizeds,
-            statusCode,
-          })?.default ?? null;
-          const parentLayouts = route.layouts.slice(0, li);
-          return renderHTTPAccessFallbackPage(
-            route,
-            statusCode,
-            isRscRequest,
-            request,
-            {
-              boundaryComponent: parentBoundary,
-              layouts: parentLayouts,
-              matchedParams: params,
-            },
-            _scriptNonce,
-            // buildAppPageSpecialErrorResponse merges _mwCtx onto this returned
-            // fallback response; keep this inner boundary render unmerged so
-            // additive headers like Set-Cookie and Vary are not duplicated.
-            null,
-          );
-        },
-        requestUrl: request.url,
-        specialError: __layoutSpecialError,
-      });
-    },
-    async renderPageSpecialError(specialError) {
-      return __buildAppPageSpecialErrorResponse({
-        clearRequestContext() {
-          __clearRequestContext();
-        },
-        middlewareContext: _mwCtx,
-        renderFallbackPage(statusCode) {
-          return renderHTTPAccessFallbackPage(
-            route,
-            statusCode,
-            isRscRequest,
-            request,
-            {
-              matchedParams: params,
-            },
-            _scriptNonce,
-            // buildAppPageSpecialErrorResponse merges _mwCtx onto this returned
-            // fallback response; keep this inner boundary render unmerged so
-            // additive headers like Set-Cookie and Vary are not duplicated.
-            null,
-          );
-        },
-        requestUrl: request.url,
-        specialError,
-      });
+    renderHttpAccessFallbackPage(statusCode, opts, middlewareContext) {
+      return renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, opts, _scriptNonce, middlewareContext);
     },
     renderToReadableStream,
-    routeHasLocalBoundary: !!(route?.error?.default) || !!(route?.errors && route.errors.some(function(e) { return e?.default; })),
-    routePattern: route.pattern,
+    request,
+    revalidateSeconds: typeof route.page?.revalidate === "number" ? route.page.revalidate : null,
+    rootForbiddenModule,
+    rootNotFoundModule,
+    rootUnauthorizedModule,
+    route,
     runWithSuppressedHookWarning(probe) {
-      // Run inside ALS context so the module-level console.error patch suppresses
-      // "Invalid hook call" only for this request's probe — concurrent requests
-      // each have their own ALS store and are unaffected.
       return _suppressHookWarningAls.run(true, probe);
     },
-    scriptNonce: _scriptNonce,
-    waitUntil(__cachePromise) {
-      _getRequestExecutionContext()?.waitUntil(__cachePromise);
+    scheduleBackgroundRegeneration(key, renderFn, errorContext) {
+      __triggerBackgroundRegeneration(key, renderFn, errorContext);
     },
+    scriptNonce: _scriptNonce,
+    searchParams: url.searchParams,
+    setNavigationContext,
   });
 }
 

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -1,0 +1,632 @@
+import type { ReactNode } from "react";
+import type { ClassificationReason } from "../build/layout-classification-types.js";
+import { _consumeRequestScopedCacheLife, type CachedAppPageValue } from "../shims/cache.js";
+import {
+  consumeDynamicUsage,
+  consumeInvalidDynamicUsageError,
+  getDraftModeCookieHeader,
+  markDynamicUsage,
+  setHeadersContext,
+} from "../shims/headers.js";
+import { getRequestExecutionContext } from "../shims/request-context.js";
+import { createRequestContext, runWithRequestContext } from "../shims/unified-request-context.js";
+import {
+  ensureFetchPatch,
+  getCollectedFetchTags,
+  setCurrentFetchSoftTags,
+} from "../shims/fetch-cache.js";
+import type { AppOutgoingElements } from "./app-elements.js";
+import { readAppPageCacheResponse } from "./app-page-cache.js";
+import { resolveAppPageParentHttpAccessBoundaryModule } from "./app-page-boundary.js";
+import {
+  buildAppPageSpecialErrorResponse,
+  readAppPageTextStream,
+  resolveAppPageSpecialError,
+  teeAppPageRscStreamForCapture,
+  type AppPageFontPreload,
+  type AppPageSpecialError,
+  type LayoutClassificationOptions,
+} from "./app-page-execution.js";
+import { resolveAppPageMethodResponse } from "./app-page-method.js";
+import {
+  buildAppPageElement,
+  resolveAppPageIntercept,
+  validateAppPageDynamicParams,
+} from "./app-page-request.js";
+import { renderAppPageLifecycle } from "./app-page-render.js";
+import {
+  mergeMiddlewareResponseHeaders,
+  type AppPageMiddlewareContext,
+} from "./app-page-response.js";
+import { createAppPageTreePath } from "./app-page-route-wiring.js";
+import type { AppPageSsrHandler } from "./app-page-stream.js";
+import { createStaticGenerationHeadersContext } from "./app-static-generation.js";
+import { buildPageCacheTags } from "./implicit-tags.js";
+import type { ISRCacheEntry } from "./isr-cache.js";
+
+type AppPageParams = Record<string, string | string[]>;
+type AppPageElement = ReactNode | Readonly<Record<string, ReactNode>>;
+type AppPageRenderableElement = ReactNode | AppOutgoingElements;
+type AppPageBoundaryOnError = (
+  error: unknown,
+  requestInfo: unknown,
+  errorContext: unknown,
+) => unknown;
+type AppPageDebugLogger = (event: string, detail: string) => void;
+type AppPageCacheSetter = (
+  key: string,
+  data: CachedAppPageValue,
+  revalidateSeconds: number,
+  tags: string[],
+) => Promise<void>;
+type AppPageCacheGetter = (key: string) => Promise<ISRCacheEntry | null>;
+type AppPageBackgroundRegenerationErrorContext = {
+  routerKind: "App Router";
+  routePath: string;
+  routeType: "render";
+};
+type AppPageBackgroundRegenerator = (
+  key: string,
+  renderFn: () => Promise<void>,
+  errorContext?: AppPageBackgroundRegenerationErrorContext,
+) => void;
+
+type AppPageDispatchIntercept<TPage = unknown> = {
+  interceptLayouts?: readonly AppPageModule[] | null;
+  matchedParams: AppPageParams;
+  page: TPage;
+  slotKey: string;
+  sourceRouteIndex: number;
+};
+
+type AppPageDispatchInterceptOptions<TPage = unknown> = {
+  interceptionContext: string | null;
+  interceptLayouts?: readonly AppPageModule[] | null;
+  interceptPage: TPage;
+  interceptParams: AppPageParams;
+  interceptSlotKey: string;
+};
+
+type AppPageModule = {
+  default?: unknown;
+};
+
+type AppPageDispatchRoute = {
+  __buildTimeClassifications?: LayoutClassificationOptions["buildTimeClassifications"];
+  __buildTimeReasons?: LayoutClassificationOptions["buildTimeReasons"];
+  error?: AppPageModule | null;
+  errors?: readonly (AppPageModule | null | undefined)[];
+  forbiddens?: readonly (AppPageModule | null | undefined)[];
+  isDynamic: boolean;
+  layouts: readonly AppPageModule[];
+  layoutTreePositions?: readonly number[];
+  loading?: AppPageModule | null;
+  notFounds?: readonly (AppPageModule | null | undefined)[];
+  params: readonly string[];
+  pattern: string;
+  routeSegments: readonly string[];
+  unauthorizeds?: readonly (AppPageModule | null | undefined)[];
+};
+
+type DispatchAppPageOptions<TRoute extends AppPageDispatchRoute> = {
+  buildPageElement: (
+    route: TRoute,
+    params: AppPageParams,
+    opts: AppPageDispatchInterceptOptions | undefined,
+    searchParams: URLSearchParams,
+  ) => Promise<AppPageElement>;
+  cleanPathname: string;
+  clearRequestContext: () => void;
+  createRscOnErrorHandler: (pathname: string, routePath: string) => AppPageBoundaryOnError;
+  debugClassification?: (layoutId: string, reason: ClassificationReason) => void;
+  dynamicConfig?: string;
+  dynamicParamsConfig?: boolean;
+  findIntercept: (pathname: string) => AppPageDispatchIntercept | null;
+  generateStaticParams?: ((args: { params: AppPageParams }) => unknown) | null;
+  getFontLinks: () => string[];
+  getFontPreloads: () => AppPageFontPreload[];
+  getFontStyles: () => string[];
+  getNavigationContext: () => unknown;
+  getSourceRoute: (sourceRouteIndex: number) => TRoute | undefined;
+  hasGenerateStaticParams: boolean;
+  hasPageDefaultExport: boolean;
+  hasPageModule: boolean;
+  handlerStart: number;
+  interceptionContext: string | null;
+  isProduction: boolean;
+  isRscRequest: boolean;
+  isrDebug?: AppPageDebugLogger;
+  isrGet: AppPageCacheGetter;
+  isrHtmlKey: (pathname: string) => string;
+  isrRscKey: (pathname: string, mountedSlotsHeader?: string | null) => string;
+  isrSet: AppPageCacheSetter;
+  loadSsrHandler: () => Promise<AppPageSsrHandler>;
+  middlewareContext: AppPageMiddlewareContext;
+  mountedSlotsHeader?: string | null;
+  params: AppPageParams;
+  probeLayoutAt: (layoutIndex: number) => unknown;
+  probePage: () => unknown;
+  renderErrorBoundaryPage: (error: unknown) => Promise<Response | null>;
+  renderHttpAccessFallbackPage: (
+    statusCode: number,
+    opts: {
+      boundaryComponent?: unknown;
+      layouts?: readonly AppPageModule[];
+      matchedParams: AppPageParams;
+    },
+    middlewareContext: AppPageMiddlewareContext | null,
+  ) => Promise<Response | null>;
+  renderToReadableStream: (
+    element: AppPageRenderableElement,
+    options: { onError: AppPageBoundaryOnError },
+  ) => ReadableStream<Uint8Array>;
+  request: Request;
+  revalidateSeconds: number | null;
+  rootForbiddenModule?: AppPageModule | null;
+  rootNotFoundModule?: AppPageModule | null;
+  rootUnauthorizedModule?: AppPageModule | null;
+  route: TRoute;
+  runWithSuppressedHookWarning<T>(probe: () => Promise<T>): Promise<T>;
+  scheduleBackgroundRegeneration: AppPageBackgroundRegenerator;
+  scriptNonce?: string;
+  searchParams: URLSearchParams;
+  setNavigationContext: (context: {
+    params: AppPageParams;
+    pathname: string;
+    searchParams: URLSearchParams;
+  }) => void;
+};
+
+function shouldReadAppPageCache(options: {
+  isForceDynamic: boolean;
+  isProduction: boolean;
+  isRscRequest: boolean;
+  revalidateSeconds: number | null;
+  scriptNonce?: string;
+}): boolean {
+  return (
+    options.isProduction &&
+    !options.isForceDynamic &&
+    (options.isRscRequest || !options.scriptNonce) &&
+    options.revalidateSeconds !== null &&
+    options.revalidateSeconds > 0 &&
+    options.revalidateSeconds !== Infinity
+  );
+}
+
+function buildAppPageTags(
+  cleanPathname: string,
+  extraTags: string[],
+  routeSegments: readonly string[],
+): string[] {
+  return buildPageCacheTags(cleanPathname, extraTags, [...routeSegments], "page");
+}
+
+async function runAppPageRevalidationContext(
+  options: {
+    cleanPathname: string;
+    dynamicConfig?: string;
+    params: AppPageParams;
+    routePattern: string;
+    routeSegments: readonly string[];
+    setNavigationContext: DispatchAppPageOptions<AppPageDispatchRoute>["setNavigationContext"];
+  },
+  renderFn: () => Promise<{
+    html: string;
+    rscData: ArrayBuffer;
+    tags: string[];
+  }>,
+): Promise<{
+  html: string;
+  rscData: ArrayBuffer;
+  tags: string[];
+}> {
+  const headersContext = createStaticGenerationHeadersContext({
+    dynamicConfig: options.dynamicConfig,
+    routeKind: "page",
+    routePattern: options.routePattern,
+  });
+  const requestContext = createRequestContext({
+    headersContext,
+    executionContext: getRequestExecutionContext(),
+    unstableCacheRevalidation: "foreground",
+  });
+
+  return runWithRequestContext(requestContext, async () => {
+    ensureFetchPatch();
+    setCurrentFetchSoftTags(buildAppPageTags(options.cleanPathname, [], options.routeSegments));
+    options.setNavigationContext({
+      pathname: options.cleanPathname,
+      searchParams: new URLSearchParams(),
+      params: options.params,
+    });
+    return renderFn();
+  });
+}
+
+function getCapturedRscDataPromise(
+  capturedRscDataPromise: Promise<ArrayBuffer> | null,
+): Promise<ArrayBuffer> {
+  if (!capturedRscDataPromise) {
+    throw new Error(
+      "[vinext] Expected captured RSC data while regenerating an app page cache entry",
+    );
+  }
+
+  return capturedRscDataPromise;
+}
+
+function toInterceptOptions(
+  interceptionContext: string | null,
+  intercept: AppPageDispatchIntercept,
+): AppPageDispatchInterceptOptions {
+  return {
+    interceptionContext,
+    interceptLayouts: intercept.interceptLayouts,
+    interceptPage: intercept.page,
+    interceptParams: intercept.matchedParams,
+    interceptSlotKey: intercept.slotKey,
+  };
+}
+
+export async function dispatchAppPage<TRoute extends AppPageDispatchRoute>(
+  options: DispatchAppPageOptions<TRoute>,
+): Promise<Response> {
+  const route = options.route;
+  const dynamicConfig = options.dynamicConfig;
+  const currentRevalidateSeconds = options.revalidateSeconds;
+  const isForceStatic = dynamicConfig === "force-static";
+  const isDynamicError = dynamicConfig === "error";
+  const isForceDynamic = dynamicConfig === "force-dynamic";
+
+  setCurrentFetchSoftTags(buildAppPageTags(options.cleanPathname, [], route.routeSegments));
+
+  if (options.hasPageModule && !options.hasPageDefaultExport) {
+    options.clearRequestContext();
+    return new Response("Page has no default export", { status: 500 });
+  }
+
+  const methodResponse = resolveAppPageMethodResponse({
+    dynamicConfig,
+    hasGenerateStaticParams: options.hasGenerateStaticParams,
+    isDynamicRoute: route.isDynamic,
+    middlewareHeaders: options.middlewareContext.headers,
+    request: options.request,
+    revalidateSeconds: currentRevalidateSeconds,
+  });
+  if (methodResponse) {
+    options.clearRequestContext();
+    return methodResponse;
+  }
+
+  if (isForceStatic || isDynamicError) {
+    setHeadersContext(
+      createStaticGenerationHeadersContext({
+        dynamicConfig,
+        routeKind: "page",
+        routePattern: route.pattern,
+      }),
+    );
+    options.setNavigationContext({
+      pathname: options.cleanPathname,
+      searchParams: new URLSearchParams(),
+      params: options.params,
+    });
+  }
+
+  if (
+    shouldReadAppPageCache({
+      isForceDynamic,
+      isProduction: options.isProduction,
+      isRscRequest: options.isRscRequest,
+      revalidateSeconds: currentRevalidateSeconds,
+      scriptNonce: options.scriptNonce,
+    })
+  ) {
+    const cachedPageResponse = await readAppPageCacheResponse({
+      cleanPathname: options.cleanPathname,
+      clearRequestContext: options.clearRequestContext,
+      isRscRequest: options.isRscRequest,
+      isrDebug: options.isrDebug,
+      isrGet: options.isrGet,
+      isrHtmlKey: options.isrHtmlKey,
+      isrRscKey: options.isrRscKey,
+      isrSet: options.isrSet,
+      mountedSlotsHeader: options.mountedSlotsHeader,
+      revalidateSeconds: currentRevalidateSeconds ?? 0,
+      renderFreshPageForCache: async () =>
+        runAppPageRevalidationContext(
+          {
+            cleanPathname: options.cleanPathname,
+            dynamicConfig,
+            params: options.params,
+            routePattern: route.pattern,
+            routeSegments: route.routeSegments,
+            setNavigationContext: options.setNavigationContext,
+          },
+          async () => {
+            const revalidatedElement = await options.buildPageElement(
+              route,
+              options.params,
+              undefined,
+              new URLSearchParams(),
+            );
+            const revalidatedOnError = options.createRscOnErrorHandler(
+              options.cleanPathname,
+              route.pattern,
+            );
+            const revalidatedRscStream = options.renderToReadableStream(revalidatedElement, {
+              onError: revalidatedOnError,
+            });
+            const revalidatedRscCapture = teeAppPageRscStreamForCapture(revalidatedRscStream, true);
+            const revalidatedSsrEntry = await options.loadSsrHandler();
+            const revalidatedCapturedRscRef: { value: Promise<ArrayBuffer> | null } = {
+              value: null,
+            };
+            const revalidatedHtmlStream = await revalidatedSsrEntry.handleSsr(
+              revalidatedRscCapture.ssrStream,
+              options.getNavigationContext(),
+              {
+                links: options.getFontLinks(),
+                styles: options.getFontStyles(),
+                preloads: options.getFontPreloads(),
+              },
+              revalidatedRscCapture.sideStream
+                ? {
+                    sideStream: revalidatedRscCapture.sideStream,
+                    capturedRscDataRef: revalidatedCapturedRscRef,
+                  }
+                : undefined,
+            );
+            options.clearRequestContext();
+            const html = await readAppPageTextStream(revalidatedHtmlStream);
+            const rscData = await getCapturedRscDataPromise(revalidatedCapturedRscRef.value);
+            const tags = buildAppPageTags(
+              options.cleanPathname,
+              getCollectedFetchTags(),
+              route.routeSegments,
+            );
+            return { html, rscData, tags };
+          },
+        ),
+      scheduleBackgroundRegeneration(key, renderFn) {
+        options.scheduleBackgroundRegeneration(key, renderFn, {
+          routerKind: "App Router",
+          routePath: route.pattern,
+          routeType: "render",
+        });
+      },
+    });
+    if (cachedPageResponse) {
+      return cachedPageResponse;
+    }
+  }
+
+  const dynamicParamsResponse = await validateAppPageDynamicParams({
+    clearRequestContext: options.clearRequestContext,
+    enforceStaticParamsOnly: options.dynamicParamsConfig === false,
+    generateStaticParams: options.generateStaticParams,
+    isDynamicRoute: route.isDynamic,
+    logGenerateStaticParamsError(error) {
+      console.error("[vinext] generateStaticParams error:", error);
+    },
+    params: options.params,
+  });
+  if (dynamicParamsResponse) {
+    return dynamicParamsResponse;
+  }
+
+  const interceptResult = await resolveAppPageIntercept<
+    TRoute,
+    unknown,
+    AppPageDispatchInterceptOptions,
+    AppPageElement
+  >({
+    buildPageElement(interceptRoute, interceptParams, interceptOpts, interceptSearchParams) {
+      return options.buildPageElement(
+        interceptRoute,
+        interceptParams,
+        interceptOpts,
+        interceptSearchParams,
+      );
+    },
+    cleanPathname: options.cleanPathname,
+    currentRoute: route,
+    findIntercept(pathname) {
+      return options.findIntercept(pathname);
+    },
+    getRouteParamNames(sourceRoute) {
+      return sourceRoute.params;
+    },
+    getSourceRoute(sourceRouteIndex) {
+      return options.getSourceRoute(sourceRouteIndex);
+    },
+    isRscRequest: options.isRscRequest,
+    renderInterceptResponse(sourceRoute, interceptElement) {
+      const interceptOnError = options.createRscOnErrorHandler(
+        options.cleanPathname,
+        sourceRoute.pattern,
+      );
+      const interceptStream = options.renderToReadableStream(interceptElement, {
+        onError: interceptOnError,
+      });
+      const interceptHeaders = new Headers({
+        "Content-Type": "text/x-component; charset=utf-8",
+        Vary: "RSC, Accept",
+      });
+      mergeMiddlewareResponseHeaders(interceptHeaders, options.middlewareContext.headers);
+      return new Response(interceptStream, {
+        status: options.middlewareContext.status ?? 200,
+        headers: interceptHeaders,
+      });
+    },
+    searchParams: options.searchParams,
+    setNavigationContext: options.setNavigationContext,
+    toInterceptOpts(intercept) {
+      return toInterceptOptions(options.interceptionContext, intercept);
+    },
+  });
+  if (interceptResult.response) {
+    return interceptResult.response;
+  }
+
+  const pageBuildResult = await buildAppPageElement({
+    buildPageElement() {
+      return options.buildPageElement(
+        route,
+        options.params,
+        interceptResult.interceptOpts,
+        options.searchParams,
+      );
+    },
+    renderErrorBoundaryPage(buildError) {
+      return options.renderErrorBoundaryPage(buildError);
+    },
+    renderSpecialError(specialError) {
+      return renderPageSpecialError(options, specialError);
+    },
+    resolveSpecialError: resolveAppPageSpecialError,
+  });
+  if (pageBuildResult.response) {
+    return pageBuildResult.response;
+  }
+
+  return renderAppPageLifecycle({
+    cleanPathname: options.cleanPathname,
+    clearRequestContext: options.clearRequestContext,
+    consumeDynamicUsage,
+    consumeInvalidDynamicUsageError,
+    createRscOnErrorHandler(pathname, routePath) {
+      return options.createRscOnErrorHandler(pathname, routePath);
+    },
+    element: pageBuildResult.element,
+    getDraftModeCookieHeader,
+    getFontLinks: options.getFontLinks,
+    getFontPreloads: options.getFontPreloads,
+    getFontStyles: options.getFontStyles,
+    getNavigationContext: options.getNavigationContext,
+    getPageTags() {
+      return buildAppPageTags(options.cleanPathname, getCollectedFetchTags(), route.routeSegments);
+    },
+    getRequestCacheLife() {
+      return _consumeRequestScopedCacheLife();
+    },
+    handlerStart: options.handlerStart,
+    hasLoadingBoundary: Boolean(route.loading?.default),
+    isDynamicError,
+    isForceDynamic,
+    isForceStatic,
+    isProduction: options.isProduction,
+    isRscRequest: options.isRscRequest,
+    isrDebug: options.isrDebug,
+    isrHtmlKey: options.isrHtmlKey,
+    isrRscKey: options.isrRscKey,
+    isrSet: options.isrSet,
+    layoutCount: route.layouts.length,
+    loadSsrHandler: options.loadSsrHandler,
+    middlewareContext: options.middlewareContext,
+    params: options.params,
+    probeLayoutAt(layoutIndex) {
+      return options.probeLayoutAt(layoutIndex);
+    },
+    probePage() {
+      return options.probePage();
+    },
+    classification: {
+      getLayoutId(index) {
+        const treePosition = route.layoutTreePositions?.[index] ?? 0;
+        return "layout:" + createAppPageTreePath([...route.routeSegments], treePosition);
+      },
+      buildTimeClassifications: route.__buildTimeClassifications,
+      buildTimeReasons: route.__buildTimeReasons,
+      debugClassification: options.debugClassification,
+      async runWithIsolatedDynamicScope(fn) {
+        const priorDynamic = consumeDynamicUsage();
+        try {
+          const result = await fn();
+          const dynamicDetected = consumeDynamicUsage();
+          return { result, dynamicDetected };
+        } finally {
+          consumeDynamicUsage();
+          if (priorDynamic) markDynamicUsage();
+        }
+      },
+    },
+    revalidateSeconds: currentRevalidateSeconds,
+    mountedSlotsHeader: options.mountedSlotsHeader,
+    renderErrorBoundaryResponse(renderError) {
+      return options.renderErrorBoundaryPage(renderError);
+    },
+    renderLayoutSpecialError(specialError, layoutIndex) {
+      return renderLayoutSpecialError(options, specialError, layoutIndex);
+    },
+    renderPageSpecialError(specialError) {
+      return renderPageSpecialError(options, specialError);
+    },
+    renderToReadableStream: options.renderToReadableStream,
+    routeHasLocalBoundary: Boolean(
+      route.error?.default || route.errors?.some((errorModule) => errorModule?.default),
+    ),
+    routePattern: route.pattern,
+    runWithSuppressedHookWarning(probe) {
+      return options.runWithSuppressedHookWarning(probe);
+    },
+    scriptNonce: options.scriptNonce,
+    waitUntil(cachePromise) {
+      getRequestExecutionContext()?.waitUntil(cachePromise);
+    },
+  });
+}
+
+async function renderLayoutSpecialError<TRoute extends AppPageDispatchRoute>(
+  options: DispatchAppPageOptions<TRoute>,
+  specialError: AppPageSpecialError,
+  layoutIndex: number,
+): Promise<Response> {
+  return buildAppPageSpecialErrorResponse({
+    clearRequestContext: options.clearRequestContext,
+    middlewareContext: options.middlewareContext,
+    renderFallbackPage(statusCode) {
+      const parentBoundary = resolveAppPageParentHttpAccessBoundaryModule({
+        layoutIndex,
+        rootForbiddenModule: options.rootForbiddenModule,
+        rootNotFoundModule: options.rootNotFoundModule,
+        rootUnauthorizedModule: options.rootUnauthorizedModule,
+        routeForbiddenModules: options.route.forbiddens,
+        routeNotFoundModules: options.route.notFounds,
+        routeUnauthorizedModules: options.route.unauthorizeds,
+        statusCode,
+      })?.default;
+      return options.renderHttpAccessFallbackPage(
+        statusCode,
+        {
+          boundaryComponent: parentBoundary,
+          layouts: options.route.layouts.slice(0, layoutIndex),
+          matchedParams: options.params,
+        },
+        null,
+      );
+    },
+    requestUrl: options.request.url,
+    specialError,
+  });
+}
+
+async function renderPageSpecialError<TRoute extends AppPageDispatchRoute>(
+  options: DispatchAppPageOptions<TRoute>,
+  specialError: AppPageSpecialError,
+): Promise<Response> {
+  return buildAppPageSpecialErrorResponse({
+    clearRequestContext: options.clearRequestContext,
+    middlewareContext: options.middlewareContext,
+    renderFallbackPage(statusCode) {
+      return options.renderHttpAccessFallbackPage(
+        statusCode,
+        { matchedParams: options.params },
+        null,
+      );
+    },
+    requestUrl: options.request.url,
+    specialError,
+  });
+}

--- a/packages/vinext/src/server/app-page-request.ts
+++ b/packages/vinext/src/server/app-page-request.ts
@@ -70,20 +70,20 @@ type ResolveAppPageActionRerenderTargetResult<TRoute, TInterceptOpts> = {
   route: TRoute;
 };
 
-type ResolveAppPageInterceptOptions<TRoute, TPage, TInterceptOpts> = {
+type ResolveAppPageInterceptOptions<TRoute, TPage, TInterceptOpts, TElement> = {
   buildPageElement: (
     route: TRoute,
     params: AppPageParams,
     interceptOpts: TInterceptOpts | undefined,
     searchParams: URLSearchParams,
-  ) => Promise<unknown>;
+  ) => Promise<TElement>;
   cleanPathname: string;
   currentRoute: TRoute;
   findIntercept: (pathname: string) => AppPageInterceptMatch<TPage> | null;
   getRouteParamNames: (route: TRoute) => readonly string[];
   getSourceRoute: (sourceRouteIndex: number) => TRoute | undefined;
   isRscRequest: boolean;
-  renderInterceptResponse: (route: TRoute, element: unknown) => Promise<Response> | Response;
+  renderInterceptResponse: (route: TRoute, element: TElement) => Promise<Response> | Response;
   searchParams: URLSearchParams;
   setNavigationContext: (context: {
     params: AppPageParams;
@@ -267,8 +267,8 @@ export function resolveAppPageActionRerenderTarget<TRoute, TPage, TInterceptOpts
   };
 }
 
-export async function resolveAppPageIntercept<TRoute, TPage, TInterceptOpts>(
-  options: ResolveAppPageInterceptOptions<TRoute, TPage, TInterceptOpts>,
+export async function resolveAppPageIntercept<TRoute, TPage, TInterceptOpts, TElement>(
+  options: ResolveAppPageInterceptOptions<TRoute, TPage, TInterceptOpts, TElement>,
 ): Promise<ResolveAppPageInterceptResult<TInterceptOpts>> {
   const interceptState = resolveAppPageInterceptState({
     cleanPathname: options.cleanPathname,

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -46,17 +46,10 @@ import {
   createRscOnErrorHandler as __createRscOnErrorHandler,
   sanitizeErrorForClient as __sanitizeErrorForClient,
 } from "<ROOT>/packages/vinext/src/server/app-rsc-errors.js";
-import { readAppPageCacheResponse as __readAppPageCacheResponse } from "<ROOT>/packages/vinext/src/server/app-page-cache.js";
 import {
   buildAppPageFontLinkHeader as __buildAppPageFontLinkHeader,
-  buildAppPageSpecialErrorResponse as __buildAppPageSpecialErrorResponse,
-  readAppPageTextStream as __readAppPageTextStream,
   resolveAppPageSpecialError as __resolveAppPageSpecialError,
-  teeAppPageRscStreamForCapture as __teeAppPageRscStreamForCapture,
 } from "<ROOT>/packages/vinext/src/server/app-page-execution.js";
-import {
-  resolveAppPageParentHttpAccessBoundaryModule as __resolveAppPageParentHttpAccessBoundaryModule,
-} from "<ROOT>/packages/vinext/src/server/app-page-boundary.js";
 import {
   renderAppPageErrorBoundary as __renderAppPageErrorBoundary,
   renderAppPageHttpAccessFallback as __renderAppPageHttpAccessFallback,
@@ -79,29 +72,17 @@ import {
   resolveAppPageHead as __resolveAppPageHead,
 } from "<ROOT>/packages/vinext/src/server/app-page-head.js";
 import {
-  renderAppPageLifecycle as __renderAppPageLifecycle,
-} from "<ROOT>/packages/vinext/src/server/app-page-render.js";
-import {
   mergeMiddlewareResponseHeaders as __mergeMiddlewareResponseHeaders,
 } from "<ROOT>/packages/vinext/src/server/app-page-response.js";
+import {
+  dispatchAppPage as __dispatchAppPage,
+} from "<ROOT>/packages/vinext/src/server/app-page-dispatch.js";
 import { getScriptNonceFromHeaderSources as __getScriptNonceFromHeaderSources } from "<ROOT>/packages/vinext/src/server/csp.js";
-import {
-  buildAppPageElement as __buildAppPageElement,
-  resolveAppPageIntercept as __resolveAppPageIntercept,
-  validateAppPageDynamicParams as __validateAppPageDynamicParams,
-} from "<ROOT>/packages/vinext/src/server/app-page-request.js";
-import {
-  resolveAppPageMethodResponse as __resolveAppPageMethodResponse,
-} from "<ROOT>/packages/vinext/src/server/app-page-method.js";
-import {
-  createStaticGenerationHeadersContext as __createStaticGenerationHeadersContext,
-} from "<ROOT>/packages/vinext/src/server/app-static-generation.js";
 import { buildPageCacheTags } from "<ROOT>/packages/vinext/src/server/implicit-tags.js";
-import { _consumeRequestScopedCacheLife } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
 import { setRootParams as __setRootParams, pickRootParams as __pickRootParams } from "<ROOT>/packages/vinext/src/shims/root-params.js";
 import { makeThenableParams } from "<ROOT>/packages/vinext/src/shims/thenable-params.js";
-import { ensureFetchPatch as _ensureFetchPatch, getCollectedFetchTags, setCurrentFetchSoftTags } from "vinext/fetch-cache";
+import { ensureFetchPatch as _ensureFetchPatch, setCurrentFetchSoftTags } from "vinext/fetch-cache";
 import {
   createAppRscRouteMatcher as __createAppRscRouteMatcher,
 } from "<ROOT>/packages/vinext/src/server/app-rsc-route-matching.js";
@@ -1037,9 +1018,6 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   }
 
   const { route, params } = match;
-  setCurrentFetchSoftTags(
-    buildPageCacheTags(cleanPathname, [], route.routeSegments, route.routeHandler ? "route" : "page"),
-  );
 
   // Update navigation context with matched params
   setNavigationContext({
@@ -1051,6 +1029,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
 
   // Handle route.ts API handlers
   if (route.routeHandler) {
+    setCurrentFetchSoftTags(
+      buildPageCacheTags(cleanPathname, [], route.routeSegments, "route"),
+    );
     return __dispatchAppRouteHandler({
       basePath: __basePath,
       cleanPathname,
@@ -1076,343 +1057,56 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     });
   }
 
-  // Build the component tree: layouts wrapping the page
-  const hasPageModule = !!route.page;
   const PageComponent = route.page?.default;
-  if (hasPageModule && !PageComponent) {
-    __clearRequestContext();
-    return new Response("Page has no default export", { status: 500 });
-  }
-
-  // Read route segment config from page module exports
-  let revalidateSeconds = typeof route.page?.revalidate === "number" ? route.page.revalidate : null;
-  const dynamicConfig = route.page?.dynamic; // 'auto' | 'force-dynamic' | 'force-static' | 'error'
-  const dynamicParamsConfig = route.page?.dynamicParams; // true (default) | false
-  const isForceStatic = dynamicConfig === "force-static";
-  const isDynamicError = dynamicConfig === "error";
-  const __methodResponse = __resolveAppPageMethodResponse({
-    dynamicConfig,
-    hasGenerateStaticParams: typeof route.page?.generateStaticParams === "function",
-    isDynamicRoute: route.isDynamic,
-    middlewareHeaders: _mwCtx.headers,
-    request,
-    revalidateSeconds,
-  });
-  if (__methodResponse) {
-    __clearRequestContext();
-    return __methodResponse;
-  }
-
-  // force-static: replace headers/cookies context with empty values and
-  // clear searchParams so dynamic APIs return defaults instead of real data
-  if (isForceStatic) {
-    setHeadersContext(__createStaticGenerationHeadersContext({
-      dynamicConfig,
-      routeKind: "page",
-      routePattern: route.pattern,
-    }));
-    setNavigationContext({
-      pathname: cleanPathname,
-      searchParams: new URLSearchParams(),
-      params,
-    });
-  }
-
-  // dynamic = 'error': install an access error so request APIs fail with the
-  // static-generation message even for legacy sync property access.
-  if (isDynamicError) {
-    setHeadersContext(__createStaticGenerationHeadersContext({
-      dynamicConfig,
-      routeKind: "page",
-      routePattern: route.pattern,
-    }));
-    setNavigationContext({
-      pathname: cleanPathname,
-      searchParams: new URLSearchParams(),
-      params,
-    });
-  }
-
-  // force-dynamic: set no-store Cache-Control
-  const isForceDynamic = dynamicConfig === "force-dynamic";
-
-  // ── ISR cache read (production only) ─────────────────────────────────────
-  // Read from cache BEFORE generateStaticParams and all rendering work.
-  // This is the critical performance optimization: on a cache hit we skip
-  // ALL expensive work (generateStaticParams, buildPageElement, layout probe,
-  // page probe, renderToReadableStream, SSR). Both HTML and RSC requests
-  // (client-side navigation / prefetch) are served from cache.
-  //
-  // HTML and RSC are stored under separate keys (matching Next.js's .html/.rsc
-  // file layout) so each request type reads and writes independently — no races,
-  // no partial-entry sentinels, no read-before-write hacks needed.
-  //
-  // force-static and dynamic='error' are compatible with ISR — they control
-  // how dynamic APIs behave during rendering, not whether results are cached.
-  // Only force-dynamic truly bypasses the ISR cache.
-  if (
-    process.env.NODE_ENV === "production" &&
-    !isForceDynamic &&
-    (isRscRequest || !_scriptNonce) &&
-    revalidateSeconds !== null && revalidateSeconds > 0 && revalidateSeconds !== Infinity
-  ) {
-    const __cachedPageResponse = await __readAppPageCacheResponse({
-      cleanPathname,
-      clearRequestContext: function() {
-        __clearRequestContext();
-      },
-      isRscRequest,
-      isrDebug: __isrDebug,
-      isrGet: __isrGet,
-      isrHtmlKey: __isrHtmlKey,
-      isrRscKey: __isrRscKey,
-      isrSet: __isrSet,
-      mountedSlotsHeader: __mountedSlotsHeader,
-      revalidateSeconds,
-      renderFreshPageForCache: async function() {
-        // Re-render the page to produce fresh HTML + RSC data for the cache
-        // Use an empty headers context for background regeneration — not the original
-        // user request — to prevent user-specific cookies/auth headers from leaking
-        // into content that is cached and served to all subsequent users.
-        const __revalHeadCtx = __createStaticGenerationHeadersContext({
-          dynamicConfig,
-          routeKind: "page",
-          routePattern: route.pattern,
-        });
-        const __revalUCtx = _createUnifiedCtx({
-          headersContext: __revalHeadCtx,
-          executionContext: _getRequestExecutionContext(),
-          unstableCacheRevalidation: "foreground",
-        });
-        return _runWithUnifiedCtx(__revalUCtx, async () => {
-          _ensureFetchPatch();
-          setCurrentFetchSoftTags(buildPageCacheTags(cleanPathname, [], route.routeSegments, "page"));
-          setNavigationContext({ pathname: cleanPathname, searchParams: new URLSearchParams(), params });
-          // Slot context (X-Vinext-Mounted-Slots) is inherited from the
-          // triggering request so the regen result is cached under the
-          // correct slot-variant key.
-          const __revalElement = await buildPageElements(
-            route,
-            params,
-            cleanPathname,
-            {
-              opts: undefined,
-              searchParams: new URLSearchParams(),
-              isRscRequest,
-              request,
-              mountedSlotsHeader: __mountedSlotsHeader,
-            },
-          );
-          const __revalOnError = createRscOnErrorHandler(request, cleanPathname, route.pattern);
-          const __revalRscStream = renderToReadableStream(__revalElement, { onError: __revalOnError });
-          const __revalRscCapture = __teeAppPageRscStreamForCapture(__revalRscStream, true);
-          const __revalFontData = { links: _getSSRFontLinks(), styles: _getSSRFontStyles(), preloads: _getSSRFontPreloads() };
-          const __revalSsrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
-          const __revalCapturedRscRef = { value: null };
-          const __revalHtmlStream = await __revalSsrEntry.handleSsr(
-            __revalRscCapture.ssrStream,
-            _getNavigationContext(),
-            __revalFontData,
-            __revalRscCapture.sideStream
-              ? { sideStream: __revalRscCapture.sideStream, capturedRscDataRef: __revalCapturedRscRef }
-              : undefined,
-          );
-          __clearRequestContext();
-          const __freshHtml = await __readAppPageTextStream(__revalHtmlStream);
-          const __freshRscData = __revalCapturedRscRef.value ? await __revalCapturedRscRef.value : null;
-          const __pageTags = buildPageCacheTags(cleanPathname, getCollectedFetchTags(), route.routeSegments, "page");
-          return { html: __freshHtml, rscData: __freshRscData, tags: __pageTags };
-        });
-      },
-      scheduleBackgroundRegeneration(key, renderFn) {
-        __triggerBackgroundRegeneration(key, renderFn, {
-          routerKind: "App Router",
-          routePath: route.pattern,
-          routeType: "render",
-        });
-      },
-    });
-    if (__cachedPageResponse) {
-      return __cachedPageResponse;
-    }
-  }
-
-  // dynamicParams = false: only params from generateStaticParams are allowed.
-  // This runs AFTER the ISR cache read so that a cache hit skips this work entirely.
-  const __dynamicParamsResponse = await __validateAppPageDynamicParams({
-    clearRequestContext() {
-      __clearRequestContext();
-    },
-    enforceStaticParamsOnly: dynamicParamsConfig === false,
-    generateStaticParams: route.page?.generateStaticParams,
-    isDynamicRoute: route.isDynamic,
-    logGenerateStaticParamsError(err) {
-      console.error("[vinext] generateStaticParams error:", err);
-    },
-    params,
-  });
-  if (__dynamicParamsResponse) {
-    return __dynamicParamsResponse;
-  }
-
-  // Check for intercepting routes on RSC requests (client-side navigation).
-  // If the target URL matches an intercepting route in a parallel slot,
-  // render the source route with the intercepting page in the slot.
-  const __interceptResult = await __resolveAppPageIntercept({
-    buildPageElement(interceptRoute, interceptParams, interceptOpts, interceptSearchParams) {
-      return buildPageElements(
-        interceptRoute,
-        interceptParams,
-        cleanPathname,
-        {
-          opts: interceptOpts,
-          searchParams: interceptSearchParams,
-          isRscRequest,
-          request,
-          mountedSlotsHeader: __mountedSlotsHeader,
-        },
-      );
-    },
-    cleanPathname,
-    currentRoute: route,
-    findIntercept(pathname) {
-      return findIntercept(pathname, interceptionContextHeader);
-    },
-    getRouteParamNames(sourceRoute) {
-      return sourceRoute.params;
-    },
-    getSourceRoute(sourceRouteIndex) {
-      return routes[sourceRouteIndex];
-    },
-    isRscRequest,
-    renderInterceptResponse(sourceRoute, interceptElement) {
-      const interceptOnError = createRscOnErrorHandler(
-        request,
-        cleanPathname,
-        sourceRoute.pattern,
-      );
-      const interceptStream = renderToReadableStream(interceptElement, {
-        onError: interceptOnError,
-      });
-      // Do NOT clear headers/navigation context here — the RSC stream is consumed lazily
-      // by the client, and async server components that run during consumption need the
-      // context to still be live. The AsyncLocalStorage scope from runWithRequestContext
-      // handles cleanup naturally when all async continuations complete.
-      const interceptHeaders = new Headers({
-        "Content-Type": "text/x-component; charset=utf-8",
-        "Vary": "RSC, Accept",
-      });
-      __mergeMiddlewareResponseHeaders(interceptHeaders, _mwCtx.headers);
-      return new Response(interceptStream, {
-        status: _mwCtx.status ?? 200,
-        headers: interceptHeaders,
-      });
-    },
-    searchParams: url.searchParams,
-    setNavigationContext,
-    toInterceptOpts(intercept) {
-      return {
-        interceptionContext: interceptionContextHeader,
-        interceptLayouts: intercept.interceptLayouts,
-        interceptSlotKey: intercept.slotKey,
-        interceptPage: intercept.page,
-        interceptParams: intercept.matchedParams,
-      };
-    },
-  });
-  if (__interceptResult.response) {
-    return __interceptResult.response;
-  }
-  const interceptOpts = __interceptResult.interceptOpts;
-
-  const __pageBuildResult = await __buildAppPageElement({
-    buildPageElement() {
-      return buildPageElements(route, params, cleanPathname, {
-        opts: interceptOpts,
-        searchParams: url.searchParams,
+  const _asyncRouteParams = makeThenableParams(params);
+  return __dispatchAppPage({
+    buildPageElement(targetRoute, targetParams, targetOpts, targetSearchParams) {
+      return buildPageElements(targetRoute, targetParams, cleanPathname, {
+        opts: targetOpts,
+        searchParams: targetSearchParams,
         isRscRequest,
         request,
         mountedSlotsHeader: __mountedSlotsHeader,
       });
     },
-    renderErrorBoundaryPage(buildErr) {
-      return renderErrorBoundaryPage(route, buildErr, isRscRequest, request, params, _scriptNonce, _mwCtx);
-    },
-    renderSpecialError(__buildSpecialError) {
-      return __buildAppPageSpecialErrorResponse({
-        clearRequestContext() {
-          __clearRequestContext();
-        },
-        middlewareContext: _mwCtx,
-        renderFallbackPage(statusCode) {
-          return renderHTTPAccessFallbackPage(
-            route,
-            statusCode,
-            isRscRequest,
-            request,
-            {
-              matchedParams: params,
-            },
-            _scriptNonce,
-            // buildAppPageSpecialErrorResponse merges _mwCtx onto this returned
-            // fallback response; keep this inner boundary render unmerged so
-            // additive headers like Set-Cookie and Vary are not duplicated.
-            null,
-          );
-        },
-        requestUrl: request.url,
-        specialError: __buildSpecialError,
-      });
-    },
-    resolveSpecialError: __resolveAppPageSpecialError,
-  });
-  if (__pageBuildResult.response) {
-    return __pageBuildResult.response;
-  }
-  const element = __pageBuildResult.element;
-
-  // Note: CSS is automatically injected by @vitejs/plugin-rsc's
-  // rscCssTransform — no manual loadCss() call needed.
-  const _hasLoadingBoundary = !!(route.loading && route.loading.default);
-  const _asyncRouteParams = makeThenableParams(params);
-  return __renderAppPageLifecycle({
     cleanPathname,
     clearRequestContext() {
       __clearRequestContext();
     },
-    consumeDynamicUsage,
-    consumeInvalidDynamicUsageError,
     createRscOnErrorHandler(pathname, routePath) {
       return createRscOnErrorHandler(request, pathname, routePath);
     },
-    element,
-    getDraftModeCookieHeader,
+    debugClassification: __classDebug,
+    dynamicConfig: route.page?.dynamic,
+    dynamicParamsConfig: route.page?.dynamicParams,
+    findIntercept(pathname) {
+      return findIntercept(pathname, interceptionContextHeader);
+    },
+    generateStaticParams: route.page?.generateStaticParams,
     getFontLinks: _getSSRFontLinks,
     getFontPreloads: _getSSRFontPreloads,
     getFontStyles: _getSSRFontStyles,
     getNavigationContext: _getNavigationContext,
-    getPageTags() {
-      return buildPageCacheTags(cleanPathname, getCollectedFetchTags(), route.routeSegments, "page");
+    getSourceRoute(sourceRouteIndex) {
+      return routes[sourceRouteIndex];
     },
-    getRequestCacheLife() {
-      return _consumeRequestScopedCacheLife();
-    },
+    hasGenerateStaticParams: typeof route.page?.generateStaticParams === "function",
+    hasPageDefaultExport: !!PageComponent,
+    hasPageModule: !!route.page,
     handlerStart: __reqStart,
-    hasLoadingBoundary: _hasLoadingBoundary,
-    isDynamicError,
-    isForceDynamic,
-    isForceStatic,
+    interceptionContext: interceptionContextHeader,
     isProduction: process.env.NODE_ENV === "production",
     isRscRequest,
     isrDebug: __isrDebug,
+    isrGet: __isrGet,
     isrHtmlKey: __isrHtmlKey,
     isrRscKey: __isrRscKey,
     isrSet: __isrSet,
-    layoutCount: route.layouts?.length ?? 0,
     loadSsrHandler() {
       return import.meta.viteRsc.loadModule("ssr", "index");
     },
     middlewareContext: _mwCtx,
+    mountedSlotsHeader: __mountedSlotsHeader,
     params,
     probeLayoutAt(li) {
       const LayoutComp = route.layouts[li]?.default;
@@ -1433,109 +1127,28 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       );
       return PageComponent({ params: _asyncRouteParams, searchParams: _asyncSearchParams });
     },
-    classification: {
-      getLayoutId(index) {
-        const tp = route.layoutTreePositions?.[index] ?? 0;
-        return "layout:" + __createAppPageTreePath(route.routeSegments, tp);
-      },
-      buildTimeClassifications: route.__buildTimeClassifications,
-      buildTimeReasons: route.__buildTimeReasons,
-      debugClassification: __classDebug,
-      async runWithIsolatedDynamicScope(fn) {
-        const priorDynamic = consumeDynamicUsage();
-        try {
-          const result = await fn();
-          const dynamicDetected = consumeDynamicUsage();
-          return { result, dynamicDetected };
-        } finally {
-          consumeDynamicUsage();
-          if (priorDynamic) markDynamicUsage();
-        }
-      },
-    },
-    revalidateSeconds,
-    mountedSlotsHeader: __mountedSlotsHeader,
-    renderErrorBoundaryResponse(renderErr) {
+    renderErrorBoundaryPage(renderErr) {
       return renderErrorBoundaryPage(route, renderErr, isRscRequest, request, params, _scriptNonce, _mwCtx);
     },
-    async renderLayoutSpecialError(__layoutSpecialError, li) {
-      return __buildAppPageSpecialErrorResponse({
-        clearRequestContext() {
-          __clearRequestContext();
-        },
-        middlewareContext: _mwCtx,
-        renderFallbackPage(statusCode) {
-          const parentBoundary = __resolveAppPageParentHttpAccessBoundaryModule({
-            layoutIndex: li,
-            rootForbiddenModule: null,
-            rootNotFoundModule: null,
-            rootUnauthorizedModule: null,
-            routeForbiddenModules: route.forbiddens,
-            routeNotFoundModules: route.notFounds,
-            routeUnauthorizedModules: route.unauthorizeds,
-            statusCode,
-          })?.default ?? null;
-          const parentLayouts = route.layouts.slice(0, li);
-          return renderHTTPAccessFallbackPage(
-            route,
-            statusCode,
-            isRscRequest,
-            request,
-            {
-              boundaryComponent: parentBoundary,
-              layouts: parentLayouts,
-              matchedParams: params,
-            },
-            _scriptNonce,
-            // buildAppPageSpecialErrorResponse merges _mwCtx onto this returned
-            // fallback response; keep this inner boundary render unmerged so
-            // additive headers like Set-Cookie and Vary are not duplicated.
-            null,
-          );
-        },
-        requestUrl: request.url,
-        specialError: __layoutSpecialError,
-      });
-    },
-    async renderPageSpecialError(specialError) {
-      return __buildAppPageSpecialErrorResponse({
-        clearRequestContext() {
-          __clearRequestContext();
-        },
-        middlewareContext: _mwCtx,
-        renderFallbackPage(statusCode) {
-          return renderHTTPAccessFallbackPage(
-            route,
-            statusCode,
-            isRscRequest,
-            request,
-            {
-              matchedParams: params,
-            },
-            _scriptNonce,
-            // buildAppPageSpecialErrorResponse merges _mwCtx onto this returned
-            // fallback response; keep this inner boundary render unmerged so
-            // additive headers like Set-Cookie and Vary are not duplicated.
-            null,
-          );
-        },
-        requestUrl: request.url,
-        specialError,
-      });
+    renderHttpAccessFallbackPage(statusCode, opts, middlewareContext) {
+      return renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, opts, _scriptNonce, middlewareContext);
     },
     renderToReadableStream,
-    routeHasLocalBoundary: !!(route?.error?.default) || !!(route?.errors && route.errors.some(function(e) { return e?.default; })),
-    routePattern: route.pattern,
+    request,
+    revalidateSeconds: typeof route.page?.revalidate === "number" ? route.page.revalidate : null,
+    rootForbiddenModule,
+    rootNotFoundModule,
+    rootUnauthorizedModule,
+    route,
     runWithSuppressedHookWarning(probe) {
-      // Run inside ALS context so the module-level console.error patch suppresses
-      // "Invalid hook call" only for this request's probe — concurrent requests
-      // each have their own ALS store and are unaffected.
       return _suppressHookWarningAls.run(true, probe);
     },
-    scriptNonce: _scriptNonce,
-    waitUntil(__cachePromise) {
-      _getRequestExecutionContext()?.waitUntil(__cachePromise);
+    scheduleBackgroundRegeneration(key, renderFn, errorContext) {
+      __triggerBackgroundRegeneration(key, renderFn, errorContext);
     },
+    scriptNonce: _scriptNonce,
+    searchParams: url.searchParams,
+    setNavigationContext,
   });
 }
 
@@ -1589,17 +1202,10 @@ import {
   createRscOnErrorHandler as __createRscOnErrorHandler,
   sanitizeErrorForClient as __sanitizeErrorForClient,
 } from "<ROOT>/packages/vinext/src/server/app-rsc-errors.js";
-import { readAppPageCacheResponse as __readAppPageCacheResponse } from "<ROOT>/packages/vinext/src/server/app-page-cache.js";
 import {
   buildAppPageFontLinkHeader as __buildAppPageFontLinkHeader,
-  buildAppPageSpecialErrorResponse as __buildAppPageSpecialErrorResponse,
-  readAppPageTextStream as __readAppPageTextStream,
   resolveAppPageSpecialError as __resolveAppPageSpecialError,
-  teeAppPageRscStreamForCapture as __teeAppPageRscStreamForCapture,
 } from "<ROOT>/packages/vinext/src/server/app-page-execution.js";
-import {
-  resolveAppPageParentHttpAccessBoundaryModule as __resolveAppPageParentHttpAccessBoundaryModule,
-} from "<ROOT>/packages/vinext/src/server/app-page-boundary.js";
 import {
   renderAppPageErrorBoundary as __renderAppPageErrorBoundary,
   renderAppPageHttpAccessFallback as __renderAppPageHttpAccessFallback,
@@ -1622,29 +1228,17 @@ import {
   resolveAppPageHead as __resolveAppPageHead,
 } from "<ROOT>/packages/vinext/src/server/app-page-head.js";
 import {
-  renderAppPageLifecycle as __renderAppPageLifecycle,
-} from "<ROOT>/packages/vinext/src/server/app-page-render.js";
-import {
   mergeMiddlewareResponseHeaders as __mergeMiddlewareResponseHeaders,
 } from "<ROOT>/packages/vinext/src/server/app-page-response.js";
+import {
+  dispatchAppPage as __dispatchAppPage,
+} from "<ROOT>/packages/vinext/src/server/app-page-dispatch.js";
 import { getScriptNonceFromHeaderSources as __getScriptNonceFromHeaderSources } from "<ROOT>/packages/vinext/src/server/csp.js";
-import {
-  buildAppPageElement as __buildAppPageElement,
-  resolveAppPageIntercept as __resolveAppPageIntercept,
-  validateAppPageDynamicParams as __validateAppPageDynamicParams,
-} from "<ROOT>/packages/vinext/src/server/app-page-request.js";
-import {
-  resolveAppPageMethodResponse as __resolveAppPageMethodResponse,
-} from "<ROOT>/packages/vinext/src/server/app-page-method.js";
-import {
-  createStaticGenerationHeadersContext as __createStaticGenerationHeadersContext,
-} from "<ROOT>/packages/vinext/src/server/app-static-generation.js";
 import { buildPageCacheTags } from "<ROOT>/packages/vinext/src/server/implicit-tags.js";
-import { _consumeRequestScopedCacheLife } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
 import { setRootParams as __setRootParams, pickRootParams as __pickRootParams } from "<ROOT>/packages/vinext/src/shims/root-params.js";
 import { makeThenableParams } from "<ROOT>/packages/vinext/src/shims/thenable-params.js";
-import { ensureFetchPatch as _ensureFetchPatch, getCollectedFetchTags, setCurrentFetchSoftTags } from "vinext/fetch-cache";
+import { ensureFetchPatch as _ensureFetchPatch, setCurrentFetchSoftTags } from "vinext/fetch-cache";
 import {
   createAppRscRouteMatcher as __createAppRscRouteMatcher,
 } from "<ROOT>/packages/vinext/src/server/app-rsc-route-matching.js";
@@ -2586,9 +2180,6 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   }
 
   const { route, params } = match;
-  setCurrentFetchSoftTags(
-    buildPageCacheTags(cleanPathname, [], route.routeSegments, route.routeHandler ? "route" : "page"),
-  );
 
   // Update navigation context with matched params
   setNavigationContext({
@@ -2600,6 +2191,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
 
   // Handle route.ts API handlers
   if (route.routeHandler) {
+    setCurrentFetchSoftTags(
+      buildPageCacheTags(cleanPathname, [], route.routeSegments, "route"),
+    );
     return __dispatchAppRouteHandler({
       basePath: __basePath,
       cleanPathname,
@@ -2625,343 +2219,56 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     });
   }
 
-  // Build the component tree: layouts wrapping the page
-  const hasPageModule = !!route.page;
   const PageComponent = route.page?.default;
-  if (hasPageModule && !PageComponent) {
-    __clearRequestContext();
-    return new Response("Page has no default export", { status: 500 });
-  }
-
-  // Read route segment config from page module exports
-  let revalidateSeconds = typeof route.page?.revalidate === "number" ? route.page.revalidate : null;
-  const dynamicConfig = route.page?.dynamic; // 'auto' | 'force-dynamic' | 'force-static' | 'error'
-  const dynamicParamsConfig = route.page?.dynamicParams; // true (default) | false
-  const isForceStatic = dynamicConfig === "force-static";
-  const isDynamicError = dynamicConfig === "error";
-  const __methodResponse = __resolveAppPageMethodResponse({
-    dynamicConfig,
-    hasGenerateStaticParams: typeof route.page?.generateStaticParams === "function",
-    isDynamicRoute: route.isDynamic,
-    middlewareHeaders: _mwCtx.headers,
-    request,
-    revalidateSeconds,
-  });
-  if (__methodResponse) {
-    __clearRequestContext();
-    return __methodResponse;
-  }
-
-  // force-static: replace headers/cookies context with empty values and
-  // clear searchParams so dynamic APIs return defaults instead of real data
-  if (isForceStatic) {
-    setHeadersContext(__createStaticGenerationHeadersContext({
-      dynamicConfig,
-      routeKind: "page",
-      routePattern: route.pattern,
-    }));
-    setNavigationContext({
-      pathname: cleanPathname,
-      searchParams: new URLSearchParams(),
-      params,
-    });
-  }
-
-  // dynamic = 'error': install an access error so request APIs fail with the
-  // static-generation message even for legacy sync property access.
-  if (isDynamicError) {
-    setHeadersContext(__createStaticGenerationHeadersContext({
-      dynamicConfig,
-      routeKind: "page",
-      routePattern: route.pattern,
-    }));
-    setNavigationContext({
-      pathname: cleanPathname,
-      searchParams: new URLSearchParams(),
-      params,
-    });
-  }
-
-  // force-dynamic: set no-store Cache-Control
-  const isForceDynamic = dynamicConfig === "force-dynamic";
-
-  // ── ISR cache read (production only) ─────────────────────────────────────
-  // Read from cache BEFORE generateStaticParams and all rendering work.
-  // This is the critical performance optimization: on a cache hit we skip
-  // ALL expensive work (generateStaticParams, buildPageElement, layout probe,
-  // page probe, renderToReadableStream, SSR). Both HTML and RSC requests
-  // (client-side navigation / prefetch) are served from cache.
-  //
-  // HTML and RSC are stored under separate keys (matching Next.js's .html/.rsc
-  // file layout) so each request type reads and writes independently — no races,
-  // no partial-entry sentinels, no read-before-write hacks needed.
-  //
-  // force-static and dynamic='error' are compatible with ISR — they control
-  // how dynamic APIs behave during rendering, not whether results are cached.
-  // Only force-dynamic truly bypasses the ISR cache.
-  if (
-    process.env.NODE_ENV === "production" &&
-    !isForceDynamic &&
-    (isRscRequest || !_scriptNonce) &&
-    revalidateSeconds !== null && revalidateSeconds > 0 && revalidateSeconds !== Infinity
-  ) {
-    const __cachedPageResponse = await __readAppPageCacheResponse({
-      cleanPathname,
-      clearRequestContext: function() {
-        __clearRequestContext();
-      },
-      isRscRequest,
-      isrDebug: __isrDebug,
-      isrGet: __isrGet,
-      isrHtmlKey: __isrHtmlKey,
-      isrRscKey: __isrRscKey,
-      isrSet: __isrSet,
-      mountedSlotsHeader: __mountedSlotsHeader,
-      revalidateSeconds,
-      renderFreshPageForCache: async function() {
-        // Re-render the page to produce fresh HTML + RSC data for the cache
-        // Use an empty headers context for background regeneration — not the original
-        // user request — to prevent user-specific cookies/auth headers from leaking
-        // into content that is cached and served to all subsequent users.
-        const __revalHeadCtx = __createStaticGenerationHeadersContext({
-          dynamicConfig,
-          routeKind: "page",
-          routePattern: route.pattern,
-        });
-        const __revalUCtx = _createUnifiedCtx({
-          headersContext: __revalHeadCtx,
-          executionContext: _getRequestExecutionContext(),
-          unstableCacheRevalidation: "foreground",
-        });
-        return _runWithUnifiedCtx(__revalUCtx, async () => {
-          _ensureFetchPatch();
-          setCurrentFetchSoftTags(buildPageCacheTags(cleanPathname, [], route.routeSegments, "page"));
-          setNavigationContext({ pathname: cleanPathname, searchParams: new URLSearchParams(), params });
-          // Slot context (X-Vinext-Mounted-Slots) is inherited from the
-          // triggering request so the regen result is cached under the
-          // correct slot-variant key.
-          const __revalElement = await buildPageElements(
-            route,
-            params,
-            cleanPathname,
-            {
-              opts: undefined,
-              searchParams: new URLSearchParams(),
-              isRscRequest,
-              request,
-              mountedSlotsHeader: __mountedSlotsHeader,
-            },
-          );
-          const __revalOnError = createRscOnErrorHandler(request, cleanPathname, route.pattern);
-          const __revalRscStream = renderToReadableStream(__revalElement, { onError: __revalOnError });
-          const __revalRscCapture = __teeAppPageRscStreamForCapture(__revalRscStream, true);
-          const __revalFontData = { links: _getSSRFontLinks(), styles: _getSSRFontStyles(), preloads: _getSSRFontPreloads() };
-          const __revalSsrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
-          const __revalCapturedRscRef = { value: null };
-          const __revalHtmlStream = await __revalSsrEntry.handleSsr(
-            __revalRscCapture.ssrStream,
-            _getNavigationContext(),
-            __revalFontData,
-            __revalRscCapture.sideStream
-              ? { sideStream: __revalRscCapture.sideStream, capturedRscDataRef: __revalCapturedRscRef }
-              : undefined,
-          );
-          __clearRequestContext();
-          const __freshHtml = await __readAppPageTextStream(__revalHtmlStream);
-          const __freshRscData = __revalCapturedRscRef.value ? await __revalCapturedRscRef.value : null;
-          const __pageTags = buildPageCacheTags(cleanPathname, getCollectedFetchTags(), route.routeSegments, "page");
-          return { html: __freshHtml, rscData: __freshRscData, tags: __pageTags };
-        });
-      },
-      scheduleBackgroundRegeneration(key, renderFn) {
-        __triggerBackgroundRegeneration(key, renderFn, {
-          routerKind: "App Router",
-          routePath: route.pattern,
-          routeType: "render",
-        });
-      },
-    });
-    if (__cachedPageResponse) {
-      return __cachedPageResponse;
-    }
-  }
-
-  // dynamicParams = false: only params from generateStaticParams are allowed.
-  // This runs AFTER the ISR cache read so that a cache hit skips this work entirely.
-  const __dynamicParamsResponse = await __validateAppPageDynamicParams({
-    clearRequestContext() {
-      __clearRequestContext();
-    },
-    enforceStaticParamsOnly: dynamicParamsConfig === false,
-    generateStaticParams: route.page?.generateStaticParams,
-    isDynamicRoute: route.isDynamic,
-    logGenerateStaticParamsError(err) {
-      console.error("[vinext] generateStaticParams error:", err);
-    },
-    params,
-  });
-  if (__dynamicParamsResponse) {
-    return __dynamicParamsResponse;
-  }
-
-  // Check for intercepting routes on RSC requests (client-side navigation).
-  // If the target URL matches an intercepting route in a parallel slot,
-  // render the source route with the intercepting page in the slot.
-  const __interceptResult = await __resolveAppPageIntercept({
-    buildPageElement(interceptRoute, interceptParams, interceptOpts, interceptSearchParams) {
-      return buildPageElements(
-        interceptRoute,
-        interceptParams,
-        cleanPathname,
-        {
-          opts: interceptOpts,
-          searchParams: interceptSearchParams,
-          isRscRequest,
-          request,
-          mountedSlotsHeader: __mountedSlotsHeader,
-        },
-      );
-    },
-    cleanPathname,
-    currentRoute: route,
-    findIntercept(pathname) {
-      return findIntercept(pathname, interceptionContextHeader);
-    },
-    getRouteParamNames(sourceRoute) {
-      return sourceRoute.params;
-    },
-    getSourceRoute(sourceRouteIndex) {
-      return routes[sourceRouteIndex];
-    },
-    isRscRequest,
-    renderInterceptResponse(sourceRoute, interceptElement) {
-      const interceptOnError = createRscOnErrorHandler(
-        request,
-        cleanPathname,
-        sourceRoute.pattern,
-      );
-      const interceptStream = renderToReadableStream(interceptElement, {
-        onError: interceptOnError,
-      });
-      // Do NOT clear headers/navigation context here — the RSC stream is consumed lazily
-      // by the client, and async server components that run during consumption need the
-      // context to still be live. The AsyncLocalStorage scope from runWithRequestContext
-      // handles cleanup naturally when all async continuations complete.
-      const interceptHeaders = new Headers({
-        "Content-Type": "text/x-component; charset=utf-8",
-        "Vary": "RSC, Accept",
-      });
-      __mergeMiddlewareResponseHeaders(interceptHeaders, _mwCtx.headers);
-      return new Response(interceptStream, {
-        status: _mwCtx.status ?? 200,
-        headers: interceptHeaders,
-      });
-    },
-    searchParams: url.searchParams,
-    setNavigationContext,
-    toInterceptOpts(intercept) {
-      return {
-        interceptionContext: interceptionContextHeader,
-        interceptLayouts: intercept.interceptLayouts,
-        interceptSlotKey: intercept.slotKey,
-        interceptPage: intercept.page,
-        interceptParams: intercept.matchedParams,
-      };
-    },
-  });
-  if (__interceptResult.response) {
-    return __interceptResult.response;
-  }
-  const interceptOpts = __interceptResult.interceptOpts;
-
-  const __pageBuildResult = await __buildAppPageElement({
-    buildPageElement() {
-      return buildPageElements(route, params, cleanPathname, {
-        opts: interceptOpts,
-        searchParams: url.searchParams,
+  const _asyncRouteParams = makeThenableParams(params);
+  return __dispatchAppPage({
+    buildPageElement(targetRoute, targetParams, targetOpts, targetSearchParams) {
+      return buildPageElements(targetRoute, targetParams, cleanPathname, {
+        opts: targetOpts,
+        searchParams: targetSearchParams,
         isRscRequest,
         request,
         mountedSlotsHeader: __mountedSlotsHeader,
       });
     },
-    renderErrorBoundaryPage(buildErr) {
-      return renderErrorBoundaryPage(route, buildErr, isRscRequest, request, params, _scriptNonce, _mwCtx);
-    },
-    renderSpecialError(__buildSpecialError) {
-      return __buildAppPageSpecialErrorResponse({
-        clearRequestContext() {
-          __clearRequestContext();
-        },
-        middlewareContext: _mwCtx,
-        renderFallbackPage(statusCode) {
-          return renderHTTPAccessFallbackPage(
-            route,
-            statusCode,
-            isRscRequest,
-            request,
-            {
-              matchedParams: params,
-            },
-            _scriptNonce,
-            // buildAppPageSpecialErrorResponse merges _mwCtx onto this returned
-            // fallback response; keep this inner boundary render unmerged so
-            // additive headers like Set-Cookie and Vary are not duplicated.
-            null,
-          );
-        },
-        requestUrl: request.url,
-        specialError: __buildSpecialError,
-      });
-    },
-    resolveSpecialError: __resolveAppPageSpecialError,
-  });
-  if (__pageBuildResult.response) {
-    return __pageBuildResult.response;
-  }
-  const element = __pageBuildResult.element;
-
-  // Note: CSS is automatically injected by @vitejs/plugin-rsc's
-  // rscCssTransform — no manual loadCss() call needed.
-  const _hasLoadingBoundary = !!(route.loading && route.loading.default);
-  const _asyncRouteParams = makeThenableParams(params);
-  return __renderAppPageLifecycle({
     cleanPathname,
     clearRequestContext() {
       __clearRequestContext();
     },
-    consumeDynamicUsage,
-    consumeInvalidDynamicUsageError,
     createRscOnErrorHandler(pathname, routePath) {
       return createRscOnErrorHandler(request, pathname, routePath);
     },
-    element,
-    getDraftModeCookieHeader,
+    debugClassification: __classDebug,
+    dynamicConfig: route.page?.dynamic,
+    dynamicParamsConfig: route.page?.dynamicParams,
+    findIntercept(pathname) {
+      return findIntercept(pathname, interceptionContextHeader);
+    },
+    generateStaticParams: route.page?.generateStaticParams,
     getFontLinks: _getSSRFontLinks,
     getFontPreloads: _getSSRFontPreloads,
     getFontStyles: _getSSRFontStyles,
     getNavigationContext: _getNavigationContext,
-    getPageTags() {
-      return buildPageCacheTags(cleanPathname, getCollectedFetchTags(), route.routeSegments, "page");
+    getSourceRoute(sourceRouteIndex) {
+      return routes[sourceRouteIndex];
     },
-    getRequestCacheLife() {
-      return _consumeRequestScopedCacheLife();
-    },
+    hasGenerateStaticParams: typeof route.page?.generateStaticParams === "function",
+    hasPageDefaultExport: !!PageComponent,
+    hasPageModule: !!route.page,
     handlerStart: __reqStart,
-    hasLoadingBoundary: _hasLoadingBoundary,
-    isDynamicError,
-    isForceDynamic,
-    isForceStatic,
+    interceptionContext: interceptionContextHeader,
     isProduction: process.env.NODE_ENV === "production",
     isRscRequest,
     isrDebug: __isrDebug,
+    isrGet: __isrGet,
     isrHtmlKey: __isrHtmlKey,
     isrRscKey: __isrRscKey,
     isrSet: __isrSet,
-    layoutCount: route.layouts?.length ?? 0,
     loadSsrHandler() {
       return import.meta.viteRsc.loadModule("ssr", "index");
     },
     middlewareContext: _mwCtx,
+    mountedSlotsHeader: __mountedSlotsHeader,
     params,
     probeLayoutAt(li) {
       const LayoutComp = route.layouts[li]?.default;
@@ -2982,109 +2289,28 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       );
       return PageComponent({ params: _asyncRouteParams, searchParams: _asyncSearchParams });
     },
-    classification: {
-      getLayoutId(index) {
-        const tp = route.layoutTreePositions?.[index] ?? 0;
-        return "layout:" + __createAppPageTreePath(route.routeSegments, tp);
-      },
-      buildTimeClassifications: route.__buildTimeClassifications,
-      buildTimeReasons: route.__buildTimeReasons,
-      debugClassification: __classDebug,
-      async runWithIsolatedDynamicScope(fn) {
-        const priorDynamic = consumeDynamicUsage();
-        try {
-          const result = await fn();
-          const dynamicDetected = consumeDynamicUsage();
-          return { result, dynamicDetected };
-        } finally {
-          consumeDynamicUsage();
-          if (priorDynamic) markDynamicUsage();
-        }
-      },
-    },
-    revalidateSeconds,
-    mountedSlotsHeader: __mountedSlotsHeader,
-    renderErrorBoundaryResponse(renderErr) {
+    renderErrorBoundaryPage(renderErr) {
       return renderErrorBoundaryPage(route, renderErr, isRscRequest, request, params, _scriptNonce, _mwCtx);
     },
-    async renderLayoutSpecialError(__layoutSpecialError, li) {
-      return __buildAppPageSpecialErrorResponse({
-        clearRequestContext() {
-          __clearRequestContext();
-        },
-        middlewareContext: _mwCtx,
-        renderFallbackPage(statusCode) {
-          const parentBoundary = __resolveAppPageParentHttpAccessBoundaryModule({
-            layoutIndex: li,
-            rootForbiddenModule: null,
-            rootNotFoundModule: null,
-            rootUnauthorizedModule: null,
-            routeForbiddenModules: route.forbiddens,
-            routeNotFoundModules: route.notFounds,
-            routeUnauthorizedModules: route.unauthorizeds,
-            statusCode,
-          })?.default ?? null;
-          const parentLayouts = route.layouts.slice(0, li);
-          return renderHTTPAccessFallbackPage(
-            route,
-            statusCode,
-            isRscRequest,
-            request,
-            {
-              boundaryComponent: parentBoundary,
-              layouts: parentLayouts,
-              matchedParams: params,
-            },
-            _scriptNonce,
-            // buildAppPageSpecialErrorResponse merges _mwCtx onto this returned
-            // fallback response; keep this inner boundary render unmerged so
-            // additive headers like Set-Cookie and Vary are not duplicated.
-            null,
-          );
-        },
-        requestUrl: request.url,
-        specialError: __layoutSpecialError,
-      });
-    },
-    async renderPageSpecialError(specialError) {
-      return __buildAppPageSpecialErrorResponse({
-        clearRequestContext() {
-          __clearRequestContext();
-        },
-        middlewareContext: _mwCtx,
-        renderFallbackPage(statusCode) {
-          return renderHTTPAccessFallbackPage(
-            route,
-            statusCode,
-            isRscRequest,
-            request,
-            {
-              matchedParams: params,
-            },
-            _scriptNonce,
-            // buildAppPageSpecialErrorResponse merges _mwCtx onto this returned
-            // fallback response; keep this inner boundary render unmerged so
-            // additive headers like Set-Cookie and Vary are not duplicated.
-            null,
-          );
-        },
-        requestUrl: request.url,
-        specialError,
-      });
+    renderHttpAccessFallbackPage(statusCode, opts, middlewareContext) {
+      return renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, opts, _scriptNonce, middlewareContext);
     },
     renderToReadableStream,
-    routeHasLocalBoundary: !!(route?.error?.default) || !!(route?.errors && route.errors.some(function(e) { return e?.default; })),
-    routePattern: route.pattern,
+    request,
+    revalidateSeconds: typeof route.page?.revalidate === "number" ? route.page.revalidate : null,
+    rootForbiddenModule,
+    rootNotFoundModule,
+    rootUnauthorizedModule,
+    route,
     runWithSuppressedHookWarning(probe) {
-      // Run inside ALS context so the module-level console.error patch suppresses
-      // "Invalid hook call" only for this request's probe — concurrent requests
-      // each have their own ALS store and are unaffected.
       return _suppressHookWarningAls.run(true, probe);
     },
-    scriptNonce: _scriptNonce,
-    waitUntil(__cachePromise) {
-      _getRequestExecutionContext()?.waitUntil(__cachePromise);
+    scheduleBackgroundRegeneration(key, renderFn, errorContext) {
+      __triggerBackgroundRegeneration(key, renderFn, errorContext);
     },
+    scriptNonce: _scriptNonce,
+    searchParams: url.searchParams,
+    setNavigationContext,
   });
 }
 
@@ -3138,17 +2364,10 @@ import {
   createRscOnErrorHandler as __createRscOnErrorHandler,
   sanitizeErrorForClient as __sanitizeErrorForClient,
 } from "<ROOT>/packages/vinext/src/server/app-rsc-errors.js";
-import { readAppPageCacheResponse as __readAppPageCacheResponse } from "<ROOT>/packages/vinext/src/server/app-page-cache.js";
 import {
   buildAppPageFontLinkHeader as __buildAppPageFontLinkHeader,
-  buildAppPageSpecialErrorResponse as __buildAppPageSpecialErrorResponse,
-  readAppPageTextStream as __readAppPageTextStream,
   resolveAppPageSpecialError as __resolveAppPageSpecialError,
-  teeAppPageRscStreamForCapture as __teeAppPageRscStreamForCapture,
 } from "<ROOT>/packages/vinext/src/server/app-page-execution.js";
-import {
-  resolveAppPageParentHttpAccessBoundaryModule as __resolveAppPageParentHttpAccessBoundaryModule,
-} from "<ROOT>/packages/vinext/src/server/app-page-boundary.js";
 import {
   renderAppPageErrorBoundary as __renderAppPageErrorBoundary,
   renderAppPageHttpAccessFallback as __renderAppPageHttpAccessFallback,
@@ -3171,29 +2390,17 @@ import {
   resolveAppPageHead as __resolveAppPageHead,
 } from "<ROOT>/packages/vinext/src/server/app-page-head.js";
 import {
-  renderAppPageLifecycle as __renderAppPageLifecycle,
-} from "<ROOT>/packages/vinext/src/server/app-page-render.js";
-import {
   mergeMiddlewareResponseHeaders as __mergeMiddlewareResponseHeaders,
 } from "<ROOT>/packages/vinext/src/server/app-page-response.js";
+import {
+  dispatchAppPage as __dispatchAppPage,
+} from "<ROOT>/packages/vinext/src/server/app-page-dispatch.js";
 import { getScriptNonceFromHeaderSources as __getScriptNonceFromHeaderSources } from "<ROOT>/packages/vinext/src/server/csp.js";
-import {
-  buildAppPageElement as __buildAppPageElement,
-  resolveAppPageIntercept as __resolveAppPageIntercept,
-  validateAppPageDynamicParams as __validateAppPageDynamicParams,
-} from "<ROOT>/packages/vinext/src/server/app-page-request.js";
-import {
-  resolveAppPageMethodResponse as __resolveAppPageMethodResponse,
-} from "<ROOT>/packages/vinext/src/server/app-page-method.js";
-import {
-  createStaticGenerationHeadersContext as __createStaticGenerationHeadersContext,
-} from "<ROOT>/packages/vinext/src/server/app-static-generation.js";
 import { buildPageCacheTags } from "<ROOT>/packages/vinext/src/server/implicit-tags.js";
-import { _consumeRequestScopedCacheLife } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
 import { setRootParams as __setRootParams, pickRootParams as __pickRootParams } from "<ROOT>/packages/vinext/src/shims/root-params.js";
 import { makeThenableParams } from "<ROOT>/packages/vinext/src/shims/thenable-params.js";
-import { ensureFetchPatch as _ensureFetchPatch, getCollectedFetchTags, setCurrentFetchSoftTags } from "vinext/fetch-cache";
+import { ensureFetchPatch as _ensureFetchPatch, setCurrentFetchSoftTags } from "vinext/fetch-cache";
 import {
   createAppRscRouteMatcher as __createAppRscRouteMatcher,
 } from "<ROOT>/packages/vinext/src/server/app-rsc-route-matching.js";
@@ -4130,9 +3337,6 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   }
 
   const { route, params } = match;
-  setCurrentFetchSoftTags(
-    buildPageCacheTags(cleanPathname, [], route.routeSegments, route.routeHandler ? "route" : "page"),
-  );
 
   // Update navigation context with matched params
   setNavigationContext({
@@ -4144,6 +3348,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
 
   // Handle route.ts API handlers
   if (route.routeHandler) {
+    setCurrentFetchSoftTags(
+      buildPageCacheTags(cleanPathname, [], route.routeSegments, "route"),
+    );
     return __dispatchAppRouteHandler({
       basePath: __basePath,
       cleanPathname,
@@ -4169,343 +3376,56 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     });
   }
 
-  // Build the component tree: layouts wrapping the page
-  const hasPageModule = !!route.page;
   const PageComponent = route.page?.default;
-  if (hasPageModule && !PageComponent) {
-    __clearRequestContext();
-    return new Response("Page has no default export", { status: 500 });
-  }
-
-  // Read route segment config from page module exports
-  let revalidateSeconds = typeof route.page?.revalidate === "number" ? route.page.revalidate : null;
-  const dynamicConfig = route.page?.dynamic; // 'auto' | 'force-dynamic' | 'force-static' | 'error'
-  const dynamicParamsConfig = route.page?.dynamicParams; // true (default) | false
-  const isForceStatic = dynamicConfig === "force-static";
-  const isDynamicError = dynamicConfig === "error";
-  const __methodResponse = __resolveAppPageMethodResponse({
-    dynamicConfig,
-    hasGenerateStaticParams: typeof route.page?.generateStaticParams === "function",
-    isDynamicRoute: route.isDynamic,
-    middlewareHeaders: _mwCtx.headers,
-    request,
-    revalidateSeconds,
-  });
-  if (__methodResponse) {
-    __clearRequestContext();
-    return __methodResponse;
-  }
-
-  // force-static: replace headers/cookies context with empty values and
-  // clear searchParams so dynamic APIs return defaults instead of real data
-  if (isForceStatic) {
-    setHeadersContext(__createStaticGenerationHeadersContext({
-      dynamicConfig,
-      routeKind: "page",
-      routePattern: route.pattern,
-    }));
-    setNavigationContext({
-      pathname: cleanPathname,
-      searchParams: new URLSearchParams(),
-      params,
-    });
-  }
-
-  // dynamic = 'error': install an access error so request APIs fail with the
-  // static-generation message even for legacy sync property access.
-  if (isDynamicError) {
-    setHeadersContext(__createStaticGenerationHeadersContext({
-      dynamicConfig,
-      routeKind: "page",
-      routePattern: route.pattern,
-    }));
-    setNavigationContext({
-      pathname: cleanPathname,
-      searchParams: new URLSearchParams(),
-      params,
-    });
-  }
-
-  // force-dynamic: set no-store Cache-Control
-  const isForceDynamic = dynamicConfig === "force-dynamic";
-
-  // ── ISR cache read (production only) ─────────────────────────────────────
-  // Read from cache BEFORE generateStaticParams and all rendering work.
-  // This is the critical performance optimization: on a cache hit we skip
-  // ALL expensive work (generateStaticParams, buildPageElement, layout probe,
-  // page probe, renderToReadableStream, SSR). Both HTML and RSC requests
-  // (client-side navigation / prefetch) are served from cache.
-  //
-  // HTML and RSC are stored under separate keys (matching Next.js's .html/.rsc
-  // file layout) so each request type reads and writes independently — no races,
-  // no partial-entry sentinels, no read-before-write hacks needed.
-  //
-  // force-static and dynamic='error' are compatible with ISR — they control
-  // how dynamic APIs behave during rendering, not whether results are cached.
-  // Only force-dynamic truly bypasses the ISR cache.
-  if (
-    process.env.NODE_ENV === "production" &&
-    !isForceDynamic &&
-    (isRscRequest || !_scriptNonce) &&
-    revalidateSeconds !== null && revalidateSeconds > 0 && revalidateSeconds !== Infinity
-  ) {
-    const __cachedPageResponse = await __readAppPageCacheResponse({
-      cleanPathname,
-      clearRequestContext: function() {
-        __clearRequestContext();
-      },
-      isRscRequest,
-      isrDebug: __isrDebug,
-      isrGet: __isrGet,
-      isrHtmlKey: __isrHtmlKey,
-      isrRscKey: __isrRscKey,
-      isrSet: __isrSet,
-      mountedSlotsHeader: __mountedSlotsHeader,
-      revalidateSeconds,
-      renderFreshPageForCache: async function() {
-        // Re-render the page to produce fresh HTML + RSC data for the cache
-        // Use an empty headers context for background regeneration — not the original
-        // user request — to prevent user-specific cookies/auth headers from leaking
-        // into content that is cached and served to all subsequent users.
-        const __revalHeadCtx = __createStaticGenerationHeadersContext({
-          dynamicConfig,
-          routeKind: "page",
-          routePattern: route.pattern,
-        });
-        const __revalUCtx = _createUnifiedCtx({
-          headersContext: __revalHeadCtx,
-          executionContext: _getRequestExecutionContext(),
-          unstableCacheRevalidation: "foreground",
-        });
-        return _runWithUnifiedCtx(__revalUCtx, async () => {
-          _ensureFetchPatch();
-          setCurrentFetchSoftTags(buildPageCacheTags(cleanPathname, [], route.routeSegments, "page"));
-          setNavigationContext({ pathname: cleanPathname, searchParams: new URLSearchParams(), params });
-          // Slot context (X-Vinext-Mounted-Slots) is inherited from the
-          // triggering request so the regen result is cached under the
-          // correct slot-variant key.
-          const __revalElement = await buildPageElements(
-            route,
-            params,
-            cleanPathname,
-            {
-              opts: undefined,
-              searchParams: new URLSearchParams(),
-              isRscRequest,
-              request,
-              mountedSlotsHeader: __mountedSlotsHeader,
-            },
-          );
-          const __revalOnError = createRscOnErrorHandler(request, cleanPathname, route.pattern);
-          const __revalRscStream = renderToReadableStream(__revalElement, { onError: __revalOnError });
-          const __revalRscCapture = __teeAppPageRscStreamForCapture(__revalRscStream, true);
-          const __revalFontData = { links: _getSSRFontLinks(), styles: _getSSRFontStyles(), preloads: _getSSRFontPreloads() };
-          const __revalSsrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
-          const __revalCapturedRscRef = { value: null };
-          const __revalHtmlStream = await __revalSsrEntry.handleSsr(
-            __revalRscCapture.ssrStream,
-            _getNavigationContext(),
-            __revalFontData,
-            __revalRscCapture.sideStream
-              ? { sideStream: __revalRscCapture.sideStream, capturedRscDataRef: __revalCapturedRscRef }
-              : undefined,
-          );
-          __clearRequestContext();
-          const __freshHtml = await __readAppPageTextStream(__revalHtmlStream);
-          const __freshRscData = __revalCapturedRscRef.value ? await __revalCapturedRscRef.value : null;
-          const __pageTags = buildPageCacheTags(cleanPathname, getCollectedFetchTags(), route.routeSegments, "page");
-          return { html: __freshHtml, rscData: __freshRscData, tags: __pageTags };
-        });
-      },
-      scheduleBackgroundRegeneration(key, renderFn) {
-        __triggerBackgroundRegeneration(key, renderFn, {
-          routerKind: "App Router",
-          routePath: route.pattern,
-          routeType: "render",
-        });
-      },
-    });
-    if (__cachedPageResponse) {
-      return __cachedPageResponse;
-    }
-  }
-
-  // dynamicParams = false: only params from generateStaticParams are allowed.
-  // This runs AFTER the ISR cache read so that a cache hit skips this work entirely.
-  const __dynamicParamsResponse = await __validateAppPageDynamicParams({
-    clearRequestContext() {
-      __clearRequestContext();
-    },
-    enforceStaticParamsOnly: dynamicParamsConfig === false,
-    generateStaticParams: route.page?.generateStaticParams,
-    isDynamicRoute: route.isDynamic,
-    logGenerateStaticParamsError(err) {
-      console.error("[vinext] generateStaticParams error:", err);
-    },
-    params,
-  });
-  if (__dynamicParamsResponse) {
-    return __dynamicParamsResponse;
-  }
-
-  // Check for intercepting routes on RSC requests (client-side navigation).
-  // If the target URL matches an intercepting route in a parallel slot,
-  // render the source route with the intercepting page in the slot.
-  const __interceptResult = await __resolveAppPageIntercept({
-    buildPageElement(interceptRoute, interceptParams, interceptOpts, interceptSearchParams) {
-      return buildPageElements(
-        interceptRoute,
-        interceptParams,
-        cleanPathname,
-        {
-          opts: interceptOpts,
-          searchParams: interceptSearchParams,
-          isRscRequest,
-          request,
-          mountedSlotsHeader: __mountedSlotsHeader,
-        },
-      );
-    },
-    cleanPathname,
-    currentRoute: route,
-    findIntercept(pathname) {
-      return findIntercept(pathname, interceptionContextHeader);
-    },
-    getRouteParamNames(sourceRoute) {
-      return sourceRoute.params;
-    },
-    getSourceRoute(sourceRouteIndex) {
-      return routes[sourceRouteIndex];
-    },
-    isRscRequest,
-    renderInterceptResponse(sourceRoute, interceptElement) {
-      const interceptOnError = createRscOnErrorHandler(
-        request,
-        cleanPathname,
-        sourceRoute.pattern,
-      );
-      const interceptStream = renderToReadableStream(interceptElement, {
-        onError: interceptOnError,
-      });
-      // Do NOT clear headers/navigation context here — the RSC stream is consumed lazily
-      // by the client, and async server components that run during consumption need the
-      // context to still be live. The AsyncLocalStorage scope from runWithRequestContext
-      // handles cleanup naturally when all async continuations complete.
-      const interceptHeaders = new Headers({
-        "Content-Type": "text/x-component; charset=utf-8",
-        "Vary": "RSC, Accept",
-      });
-      __mergeMiddlewareResponseHeaders(interceptHeaders, _mwCtx.headers);
-      return new Response(interceptStream, {
-        status: _mwCtx.status ?? 200,
-        headers: interceptHeaders,
-      });
-    },
-    searchParams: url.searchParams,
-    setNavigationContext,
-    toInterceptOpts(intercept) {
-      return {
-        interceptionContext: interceptionContextHeader,
-        interceptLayouts: intercept.interceptLayouts,
-        interceptSlotKey: intercept.slotKey,
-        interceptPage: intercept.page,
-        interceptParams: intercept.matchedParams,
-      };
-    },
-  });
-  if (__interceptResult.response) {
-    return __interceptResult.response;
-  }
-  const interceptOpts = __interceptResult.interceptOpts;
-
-  const __pageBuildResult = await __buildAppPageElement({
-    buildPageElement() {
-      return buildPageElements(route, params, cleanPathname, {
-        opts: interceptOpts,
-        searchParams: url.searchParams,
+  const _asyncRouteParams = makeThenableParams(params);
+  return __dispatchAppPage({
+    buildPageElement(targetRoute, targetParams, targetOpts, targetSearchParams) {
+      return buildPageElements(targetRoute, targetParams, cleanPathname, {
+        opts: targetOpts,
+        searchParams: targetSearchParams,
         isRscRequest,
         request,
         mountedSlotsHeader: __mountedSlotsHeader,
       });
     },
-    renderErrorBoundaryPage(buildErr) {
-      return renderErrorBoundaryPage(route, buildErr, isRscRequest, request, params, _scriptNonce, _mwCtx);
-    },
-    renderSpecialError(__buildSpecialError) {
-      return __buildAppPageSpecialErrorResponse({
-        clearRequestContext() {
-          __clearRequestContext();
-        },
-        middlewareContext: _mwCtx,
-        renderFallbackPage(statusCode) {
-          return renderHTTPAccessFallbackPage(
-            route,
-            statusCode,
-            isRscRequest,
-            request,
-            {
-              matchedParams: params,
-            },
-            _scriptNonce,
-            // buildAppPageSpecialErrorResponse merges _mwCtx onto this returned
-            // fallback response; keep this inner boundary render unmerged so
-            // additive headers like Set-Cookie and Vary are not duplicated.
-            null,
-          );
-        },
-        requestUrl: request.url,
-        specialError: __buildSpecialError,
-      });
-    },
-    resolveSpecialError: __resolveAppPageSpecialError,
-  });
-  if (__pageBuildResult.response) {
-    return __pageBuildResult.response;
-  }
-  const element = __pageBuildResult.element;
-
-  // Note: CSS is automatically injected by @vitejs/plugin-rsc's
-  // rscCssTransform — no manual loadCss() call needed.
-  const _hasLoadingBoundary = !!(route.loading && route.loading.default);
-  const _asyncRouteParams = makeThenableParams(params);
-  return __renderAppPageLifecycle({
     cleanPathname,
     clearRequestContext() {
       __clearRequestContext();
     },
-    consumeDynamicUsage,
-    consumeInvalidDynamicUsageError,
     createRscOnErrorHandler(pathname, routePath) {
       return createRscOnErrorHandler(request, pathname, routePath);
     },
-    element,
-    getDraftModeCookieHeader,
+    debugClassification: __classDebug,
+    dynamicConfig: route.page?.dynamic,
+    dynamicParamsConfig: route.page?.dynamicParams,
+    findIntercept(pathname) {
+      return findIntercept(pathname, interceptionContextHeader);
+    },
+    generateStaticParams: route.page?.generateStaticParams,
     getFontLinks: _getSSRFontLinks,
     getFontPreloads: _getSSRFontPreloads,
     getFontStyles: _getSSRFontStyles,
     getNavigationContext: _getNavigationContext,
-    getPageTags() {
-      return buildPageCacheTags(cleanPathname, getCollectedFetchTags(), route.routeSegments, "page");
+    getSourceRoute(sourceRouteIndex) {
+      return routes[sourceRouteIndex];
     },
-    getRequestCacheLife() {
-      return _consumeRequestScopedCacheLife();
-    },
+    hasGenerateStaticParams: typeof route.page?.generateStaticParams === "function",
+    hasPageDefaultExport: !!PageComponent,
+    hasPageModule: !!route.page,
     handlerStart: __reqStart,
-    hasLoadingBoundary: _hasLoadingBoundary,
-    isDynamicError,
-    isForceDynamic,
-    isForceStatic,
+    interceptionContext: interceptionContextHeader,
     isProduction: process.env.NODE_ENV === "production",
     isRscRequest,
     isrDebug: __isrDebug,
+    isrGet: __isrGet,
     isrHtmlKey: __isrHtmlKey,
     isrRscKey: __isrRscKey,
     isrSet: __isrSet,
-    layoutCount: route.layouts?.length ?? 0,
     loadSsrHandler() {
       return import.meta.viteRsc.loadModule("ssr", "index");
     },
     middlewareContext: _mwCtx,
+    mountedSlotsHeader: __mountedSlotsHeader,
     params,
     probeLayoutAt(li) {
       const LayoutComp = route.layouts[li]?.default;
@@ -4526,109 +3446,28 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       );
       return PageComponent({ params: _asyncRouteParams, searchParams: _asyncSearchParams });
     },
-    classification: {
-      getLayoutId(index) {
-        const tp = route.layoutTreePositions?.[index] ?? 0;
-        return "layout:" + __createAppPageTreePath(route.routeSegments, tp);
-      },
-      buildTimeClassifications: route.__buildTimeClassifications,
-      buildTimeReasons: route.__buildTimeReasons,
-      debugClassification: __classDebug,
-      async runWithIsolatedDynamicScope(fn) {
-        const priorDynamic = consumeDynamicUsage();
-        try {
-          const result = await fn();
-          const dynamicDetected = consumeDynamicUsage();
-          return { result, dynamicDetected };
-        } finally {
-          consumeDynamicUsage();
-          if (priorDynamic) markDynamicUsage();
-        }
-      },
-    },
-    revalidateSeconds,
-    mountedSlotsHeader: __mountedSlotsHeader,
-    renderErrorBoundaryResponse(renderErr) {
+    renderErrorBoundaryPage(renderErr) {
       return renderErrorBoundaryPage(route, renderErr, isRscRequest, request, params, _scriptNonce, _mwCtx);
     },
-    async renderLayoutSpecialError(__layoutSpecialError, li) {
-      return __buildAppPageSpecialErrorResponse({
-        clearRequestContext() {
-          __clearRequestContext();
-        },
-        middlewareContext: _mwCtx,
-        renderFallbackPage(statusCode) {
-          const parentBoundary = __resolveAppPageParentHttpAccessBoundaryModule({
-            layoutIndex: li,
-            rootForbiddenModule: null,
-            rootNotFoundModule: null,
-            rootUnauthorizedModule: null,
-            routeForbiddenModules: route.forbiddens,
-            routeNotFoundModules: route.notFounds,
-            routeUnauthorizedModules: route.unauthorizeds,
-            statusCode,
-          })?.default ?? null;
-          const parentLayouts = route.layouts.slice(0, li);
-          return renderHTTPAccessFallbackPage(
-            route,
-            statusCode,
-            isRscRequest,
-            request,
-            {
-              boundaryComponent: parentBoundary,
-              layouts: parentLayouts,
-              matchedParams: params,
-            },
-            _scriptNonce,
-            // buildAppPageSpecialErrorResponse merges _mwCtx onto this returned
-            // fallback response; keep this inner boundary render unmerged so
-            // additive headers like Set-Cookie and Vary are not duplicated.
-            null,
-          );
-        },
-        requestUrl: request.url,
-        specialError: __layoutSpecialError,
-      });
-    },
-    async renderPageSpecialError(specialError) {
-      return __buildAppPageSpecialErrorResponse({
-        clearRequestContext() {
-          __clearRequestContext();
-        },
-        middlewareContext: _mwCtx,
-        renderFallbackPage(statusCode) {
-          return renderHTTPAccessFallbackPage(
-            route,
-            statusCode,
-            isRscRequest,
-            request,
-            {
-              matchedParams: params,
-            },
-            _scriptNonce,
-            // buildAppPageSpecialErrorResponse merges _mwCtx onto this returned
-            // fallback response; keep this inner boundary render unmerged so
-            // additive headers like Set-Cookie and Vary are not duplicated.
-            null,
-          );
-        },
-        requestUrl: request.url,
-        specialError,
-      });
+    renderHttpAccessFallbackPage(statusCode, opts, middlewareContext) {
+      return renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, opts, _scriptNonce, middlewareContext);
     },
     renderToReadableStream,
-    routeHasLocalBoundary: !!(route?.error?.default) || !!(route?.errors && route.errors.some(function(e) { return e?.default; })),
-    routePattern: route.pattern,
+    request,
+    revalidateSeconds: typeof route.page?.revalidate === "number" ? route.page.revalidate : null,
+    rootForbiddenModule,
+    rootNotFoundModule,
+    rootUnauthorizedModule,
+    route,
     runWithSuppressedHookWarning(probe) {
-      // Run inside ALS context so the module-level console.error patch suppresses
-      // "Invalid hook call" only for this request's probe — concurrent requests
-      // each have their own ALS store and are unaffected.
       return _suppressHookWarningAls.run(true, probe);
     },
-    scriptNonce: _scriptNonce,
-    waitUntil(__cachePromise) {
-      _getRequestExecutionContext()?.waitUntil(__cachePromise);
+    scheduleBackgroundRegeneration(key, renderFn, errorContext) {
+      __triggerBackgroundRegeneration(key, renderFn, errorContext);
     },
+    scriptNonce: _scriptNonce,
+    searchParams: url.searchParams,
+    setNavigationContext,
   });
 }
 
@@ -4682,17 +3521,10 @@ import {
   createRscOnErrorHandler as __createRscOnErrorHandler,
   sanitizeErrorForClient as __sanitizeErrorForClient,
 } from "<ROOT>/packages/vinext/src/server/app-rsc-errors.js";
-import { readAppPageCacheResponse as __readAppPageCacheResponse } from "<ROOT>/packages/vinext/src/server/app-page-cache.js";
 import {
   buildAppPageFontLinkHeader as __buildAppPageFontLinkHeader,
-  buildAppPageSpecialErrorResponse as __buildAppPageSpecialErrorResponse,
-  readAppPageTextStream as __readAppPageTextStream,
   resolveAppPageSpecialError as __resolveAppPageSpecialError,
-  teeAppPageRscStreamForCapture as __teeAppPageRscStreamForCapture,
 } from "<ROOT>/packages/vinext/src/server/app-page-execution.js";
-import {
-  resolveAppPageParentHttpAccessBoundaryModule as __resolveAppPageParentHttpAccessBoundaryModule,
-} from "<ROOT>/packages/vinext/src/server/app-page-boundary.js";
 import {
   renderAppPageErrorBoundary as __renderAppPageErrorBoundary,
   renderAppPageHttpAccessFallback as __renderAppPageHttpAccessFallback,
@@ -4715,29 +3547,17 @@ import {
   resolveAppPageHead as __resolveAppPageHead,
 } from "<ROOT>/packages/vinext/src/server/app-page-head.js";
 import {
-  renderAppPageLifecycle as __renderAppPageLifecycle,
-} from "<ROOT>/packages/vinext/src/server/app-page-render.js";
-import {
   mergeMiddlewareResponseHeaders as __mergeMiddlewareResponseHeaders,
 } from "<ROOT>/packages/vinext/src/server/app-page-response.js";
+import {
+  dispatchAppPage as __dispatchAppPage,
+} from "<ROOT>/packages/vinext/src/server/app-page-dispatch.js";
 import { getScriptNonceFromHeaderSources as __getScriptNonceFromHeaderSources } from "<ROOT>/packages/vinext/src/server/csp.js";
-import {
-  buildAppPageElement as __buildAppPageElement,
-  resolveAppPageIntercept as __resolveAppPageIntercept,
-  validateAppPageDynamicParams as __validateAppPageDynamicParams,
-} from "<ROOT>/packages/vinext/src/server/app-page-request.js";
-import {
-  resolveAppPageMethodResponse as __resolveAppPageMethodResponse,
-} from "<ROOT>/packages/vinext/src/server/app-page-method.js";
-import {
-  createStaticGenerationHeadersContext as __createStaticGenerationHeadersContext,
-} from "<ROOT>/packages/vinext/src/server/app-static-generation.js";
 import { buildPageCacheTags } from "<ROOT>/packages/vinext/src/server/implicit-tags.js";
-import { _consumeRequestScopedCacheLife } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
 import { setRootParams as __setRootParams, pickRootParams as __pickRootParams } from "<ROOT>/packages/vinext/src/shims/root-params.js";
 import { makeThenableParams } from "<ROOT>/packages/vinext/src/shims/thenable-params.js";
-import { ensureFetchPatch as _ensureFetchPatch, getCollectedFetchTags, setCurrentFetchSoftTags } from "vinext/fetch-cache";
+import { ensureFetchPatch as _ensureFetchPatch, setCurrentFetchSoftTags } from "vinext/fetch-cache";
 import {
   createAppRscRouteMatcher as __createAppRscRouteMatcher,
 } from "<ROOT>/packages/vinext/src/server/app-rsc-route-matching.js";
@@ -5706,9 +4526,6 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   }
 
   const { route, params } = match;
-  setCurrentFetchSoftTags(
-    buildPageCacheTags(cleanPathname, [], route.routeSegments, route.routeHandler ? "route" : "page"),
-  );
 
   // Update navigation context with matched params
   setNavigationContext({
@@ -5720,6 +4537,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
 
   // Handle route.ts API handlers
   if (route.routeHandler) {
+    setCurrentFetchSoftTags(
+      buildPageCacheTags(cleanPathname, [], route.routeSegments, "route"),
+    );
     return __dispatchAppRouteHandler({
       basePath: __basePath,
       cleanPathname,
@@ -5745,343 +4565,56 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     });
   }
 
-  // Build the component tree: layouts wrapping the page
-  const hasPageModule = !!route.page;
   const PageComponent = route.page?.default;
-  if (hasPageModule && !PageComponent) {
-    __clearRequestContext();
-    return new Response("Page has no default export", { status: 500 });
-  }
-
-  // Read route segment config from page module exports
-  let revalidateSeconds = typeof route.page?.revalidate === "number" ? route.page.revalidate : null;
-  const dynamicConfig = route.page?.dynamic; // 'auto' | 'force-dynamic' | 'force-static' | 'error'
-  const dynamicParamsConfig = route.page?.dynamicParams; // true (default) | false
-  const isForceStatic = dynamicConfig === "force-static";
-  const isDynamicError = dynamicConfig === "error";
-  const __methodResponse = __resolveAppPageMethodResponse({
-    dynamicConfig,
-    hasGenerateStaticParams: typeof route.page?.generateStaticParams === "function",
-    isDynamicRoute: route.isDynamic,
-    middlewareHeaders: _mwCtx.headers,
-    request,
-    revalidateSeconds,
-  });
-  if (__methodResponse) {
-    __clearRequestContext();
-    return __methodResponse;
-  }
-
-  // force-static: replace headers/cookies context with empty values and
-  // clear searchParams so dynamic APIs return defaults instead of real data
-  if (isForceStatic) {
-    setHeadersContext(__createStaticGenerationHeadersContext({
-      dynamicConfig,
-      routeKind: "page",
-      routePattern: route.pattern,
-    }));
-    setNavigationContext({
-      pathname: cleanPathname,
-      searchParams: new URLSearchParams(),
-      params,
-    });
-  }
-
-  // dynamic = 'error': install an access error so request APIs fail with the
-  // static-generation message even for legacy sync property access.
-  if (isDynamicError) {
-    setHeadersContext(__createStaticGenerationHeadersContext({
-      dynamicConfig,
-      routeKind: "page",
-      routePattern: route.pattern,
-    }));
-    setNavigationContext({
-      pathname: cleanPathname,
-      searchParams: new URLSearchParams(),
-      params,
-    });
-  }
-
-  // force-dynamic: set no-store Cache-Control
-  const isForceDynamic = dynamicConfig === "force-dynamic";
-
-  // ── ISR cache read (production only) ─────────────────────────────────────
-  // Read from cache BEFORE generateStaticParams and all rendering work.
-  // This is the critical performance optimization: on a cache hit we skip
-  // ALL expensive work (generateStaticParams, buildPageElement, layout probe,
-  // page probe, renderToReadableStream, SSR). Both HTML and RSC requests
-  // (client-side navigation / prefetch) are served from cache.
-  //
-  // HTML and RSC are stored under separate keys (matching Next.js's .html/.rsc
-  // file layout) so each request type reads and writes independently — no races,
-  // no partial-entry sentinels, no read-before-write hacks needed.
-  //
-  // force-static and dynamic='error' are compatible with ISR — they control
-  // how dynamic APIs behave during rendering, not whether results are cached.
-  // Only force-dynamic truly bypasses the ISR cache.
-  if (
-    process.env.NODE_ENV === "production" &&
-    !isForceDynamic &&
-    (isRscRequest || !_scriptNonce) &&
-    revalidateSeconds !== null && revalidateSeconds > 0 && revalidateSeconds !== Infinity
-  ) {
-    const __cachedPageResponse = await __readAppPageCacheResponse({
-      cleanPathname,
-      clearRequestContext: function() {
-        __clearRequestContext();
-      },
-      isRscRequest,
-      isrDebug: __isrDebug,
-      isrGet: __isrGet,
-      isrHtmlKey: __isrHtmlKey,
-      isrRscKey: __isrRscKey,
-      isrSet: __isrSet,
-      mountedSlotsHeader: __mountedSlotsHeader,
-      revalidateSeconds,
-      renderFreshPageForCache: async function() {
-        // Re-render the page to produce fresh HTML + RSC data for the cache
-        // Use an empty headers context for background regeneration — not the original
-        // user request — to prevent user-specific cookies/auth headers from leaking
-        // into content that is cached and served to all subsequent users.
-        const __revalHeadCtx = __createStaticGenerationHeadersContext({
-          dynamicConfig,
-          routeKind: "page",
-          routePattern: route.pattern,
-        });
-        const __revalUCtx = _createUnifiedCtx({
-          headersContext: __revalHeadCtx,
-          executionContext: _getRequestExecutionContext(),
-          unstableCacheRevalidation: "foreground",
-        });
-        return _runWithUnifiedCtx(__revalUCtx, async () => {
-          _ensureFetchPatch();
-          setCurrentFetchSoftTags(buildPageCacheTags(cleanPathname, [], route.routeSegments, "page"));
-          setNavigationContext({ pathname: cleanPathname, searchParams: new URLSearchParams(), params });
-          // Slot context (X-Vinext-Mounted-Slots) is inherited from the
-          // triggering request so the regen result is cached under the
-          // correct slot-variant key.
-          const __revalElement = await buildPageElements(
-            route,
-            params,
-            cleanPathname,
-            {
-              opts: undefined,
-              searchParams: new URLSearchParams(),
-              isRscRequest,
-              request,
-              mountedSlotsHeader: __mountedSlotsHeader,
-            },
-          );
-          const __revalOnError = createRscOnErrorHandler(request, cleanPathname, route.pattern);
-          const __revalRscStream = renderToReadableStream(__revalElement, { onError: __revalOnError });
-          const __revalRscCapture = __teeAppPageRscStreamForCapture(__revalRscStream, true);
-          const __revalFontData = { links: _getSSRFontLinks(), styles: _getSSRFontStyles(), preloads: _getSSRFontPreloads() };
-          const __revalSsrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
-          const __revalCapturedRscRef = { value: null };
-          const __revalHtmlStream = await __revalSsrEntry.handleSsr(
-            __revalRscCapture.ssrStream,
-            _getNavigationContext(),
-            __revalFontData,
-            __revalRscCapture.sideStream
-              ? { sideStream: __revalRscCapture.sideStream, capturedRscDataRef: __revalCapturedRscRef }
-              : undefined,
-          );
-          __clearRequestContext();
-          const __freshHtml = await __readAppPageTextStream(__revalHtmlStream);
-          const __freshRscData = __revalCapturedRscRef.value ? await __revalCapturedRscRef.value : null;
-          const __pageTags = buildPageCacheTags(cleanPathname, getCollectedFetchTags(), route.routeSegments, "page");
-          return { html: __freshHtml, rscData: __freshRscData, tags: __pageTags };
-        });
-      },
-      scheduleBackgroundRegeneration(key, renderFn) {
-        __triggerBackgroundRegeneration(key, renderFn, {
-          routerKind: "App Router",
-          routePath: route.pattern,
-          routeType: "render",
-        });
-      },
-    });
-    if (__cachedPageResponse) {
-      return __cachedPageResponse;
-    }
-  }
-
-  // dynamicParams = false: only params from generateStaticParams are allowed.
-  // This runs AFTER the ISR cache read so that a cache hit skips this work entirely.
-  const __dynamicParamsResponse = await __validateAppPageDynamicParams({
-    clearRequestContext() {
-      __clearRequestContext();
-    },
-    enforceStaticParamsOnly: dynamicParamsConfig === false,
-    generateStaticParams: route.page?.generateStaticParams,
-    isDynamicRoute: route.isDynamic,
-    logGenerateStaticParamsError(err) {
-      console.error("[vinext] generateStaticParams error:", err);
-    },
-    params,
-  });
-  if (__dynamicParamsResponse) {
-    return __dynamicParamsResponse;
-  }
-
-  // Check for intercepting routes on RSC requests (client-side navigation).
-  // If the target URL matches an intercepting route in a parallel slot,
-  // render the source route with the intercepting page in the slot.
-  const __interceptResult = await __resolveAppPageIntercept({
-    buildPageElement(interceptRoute, interceptParams, interceptOpts, interceptSearchParams) {
-      return buildPageElements(
-        interceptRoute,
-        interceptParams,
-        cleanPathname,
-        {
-          opts: interceptOpts,
-          searchParams: interceptSearchParams,
-          isRscRequest,
-          request,
-          mountedSlotsHeader: __mountedSlotsHeader,
-        },
-      );
-    },
-    cleanPathname,
-    currentRoute: route,
-    findIntercept(pathname) {
-      return findIntercept(pathname, interceptionContextHeader);
-    },
-    getRouteParamNames(sourceRoute) {
-      return sourceRoute.params;
-    },
-    getSourceRoute(sourceRouteIndex) {
-      return routes[sourceRouteIndex];
-    },
-    isRscRequest,
-    renderInterceptResponse(sourceRoute, interceptElement) {
-      const interceptOnError = createRscOnErrorHandler(
-        request,
-        cleanPathname,
-        sourceRoute.pattern,
-      );
-      const interceptStream = renderToReadableStream(interceptElement, {
-        onError: interceptOnError,
-      });
-      // Do NOT clear headers/navigation context here — the RSC stream is consumed lazily
-      // by the client, and async server components that run during consumption need the
-      // context to still be live. The AsyncLocalStorage scope from runWithRequestContext
-      // handles cleanup naturally when all async continuations complete.
-      const interceptHeaders = new Headers({
-        "Content-Type": "text/x-component; charset=utf-8",
-        "Vary": "RSC, Accept",
-      });
-      __mergeMiddlewareResponseHeaders(interceptHeaders, _mwCtx.headers);
-      return new Response(interceptStream, {
-        status: _mwCtx.status ?? 200,
-        headers: interceptHeaders,
-      });
-    },
-    searchParams: url.searchParams,
-    setNavigationContext,
-    toInterceptOpts(intercept) {
-      return {
-        interceptionContext: interceptionContextHeader,
-        interceptLayouts: intercept.interceptLayouts,
-        interceptSlotKey: intercept.slotKey,
-        interceptPage: intercept.page,
-        interceptParams: intercept.matchedParams,
-      };
-    },
-  });
-  if (__interceptResult.response) {
-    return __interceptResult.response;
-  }
-  const interceptOpts = __interceptResult.interceptOpts;
-
-  const __pageBuildResult = await __buildAppPageElement({
-    buildPageElement() {
-      return buildPageElements(route, params, cleanPathname, {
-        opts: interceptOpts,
-        searchParams: url.searchParams,
+  const _asyncRouteParams = makeThenableParams(params);
+  return __dispatchAppPage({
+    buildPageElement(targetRoute, targetParams, targetOpts, targetSearchParams) {
+      return buildPageElements(targetRoute, targetParams, cleanPathname, {
+        opts: targetOpts,
+        searchParams: targetSearchParams,
         isRscRequest,
         request,
         mountedSlotsHeader: __mountedSlotsHeader,
       });
     },
-    renderErrorBoundaryPage(buildErr) {
-      return renderErrorBoundaryPage(route, buildErr, isRscRequest, request, params, _scriptNonce, _mwCtx);
-    },
-    renderSpecialError(__buildSpecialError) {
-      return __buildAppPageSpecialErrorResponse({
-        clearRequestContext() {
-          __clearRequestContext();
-        },
-        middlewareContext: _mwCtx,
-        renderFallbackPage(statusCode) {
-          return renderHTTPAccessFallbackPage(
-            route,
-            statusCode,
-            isRscRequest,
-            request,
-            {
-              matchedParams: params,
-            },
-            _scriptNonce,
-            // buildAppPageSpecialErrorResponse merges _mwCtx onto this returned
-            // fallback response; keep this inner boundary render unmerged so
-            // additive headers like Set-Cookie and Vary are not duplicated.
-            null,
-          );
-        },
-        requestUrl: request.url,
-        specialError: __buildSpecialError,
-      });
-    },
-    resolveSpecialError: __resolveAppPageSpecialError,
-  });
-  if (__pageBuildResult.response) {
-    return __pageBuildResult.response;
-  }
-  const element = __pageBuildResult.element;
-
-  // Note: CSS is automatically injected by @vitejs/plugin-rsc's
-  // rscCssTransform — no manual loadCss() call needed.
-  const _hasLoadingBoundary = !!(route.loading && route.loading.default);
-  const _asyncRouteParams = makeThenableParams(params);
-  return __renderAppPageLifecycle({
     cleanPathname,
     clearRequestContext() {
       __clearRequestContext();
     },
-    consumeDynamicUsage,
-    consumeInvalidDynamicUsageError,
     createRscOnErrorHandler(pathname, routePath) {
       return createRscOnErrorHandler(request, pathname, routePath);
     },
-    element,
-    getDraftModeCookieHeader,
+    debugClassification: __classDebug,
+    dynamicConfig: route.page?.dynamic,
+    dynamicParamsConfig: route.page?.dynamicParams,
+    findIntercept(pathname) {
+      return findIntercept(pathname, interceptionContextHeader);
+    },
+    generateStaticParams: route.page?.generateStaticParams,
     getFontLinks: _getSSRFontLinks,
     getFontPreloads: _getSSRFontPreloads,
     getFontStyles: _getSSRFontStyles,
     getNavigationContext: _getNavigationContext,
-    getPageTags() {
-      return buildPageCacheTags(cleanPathname, getCollectedFetchTags(), route.routeSegments, "page");
+    getSourceRoute(sourceRouteIndex) {
+      return routes[sourceRouteIndex];
     },
-    getRequestCacheLife() {
-      return _consumeRequestScopedCacheLife();
-    },
+    hasGenerateStaticParams: typeof route.page?.generateStaticParams === "function",
+    hasPageDefaultExport: !!PageComponent,
+    hasPageModule: !!route.page,
     handlerStart: __reqStart,
-    hasLoadingBoundary: _hasLoadingBoundary,
-    isDynamicError,
-    isForceDynamic,
-    isForceStatic,
+    interceptionContext: interceptionContextHeader,
     isProduction: process.env.NODE_ENV === "production",
     isRscRequest,
     isrDebug: __isrDebug,
+    isrGet: __isrGet,
     isrHtmlKey: __isrHtmlKey,
     isrRscKey: __isrRscKey,
     isrSet: __isrSet,
-    layoutCount: route.layouts?.length ?? 0,
     loadSsrHandler() {
       return import.meta.viteRsc.loadModule("ssr", "index");
     },
     middlewareContext: _mwCtx,
+    mountedSlotsHeader: __mountedSlotsHeader,
     params,
     probeLayoutAt(li) {
       const LayoutComp = route.layouts[li]?.default;
@@ -6102,109 +4635,28 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       );
       return PageComponent({ params: _asyncRouteParams, searchParams: _asyncSearchParams });
     },
-    classification: {
-      getLayoutId(index) {
-        const tp = route.layoutTreePositions?.[index] ?? 0;
-        return "layout:" + __createAppPageTreePath(route.routeSegments, tp);
-      },
-      buildTimeClassifications: route.__buildTimeClassifications,
-      buildTimeReasons: route.__buildTimeReasons,
-      debugClassification: __classDebug,
-      async runWithIsolatedDynamicScope(fn) {
-        const priorDynamic = consumeDynamicUsage();
-        try {
-          const result = await fn();
-          const dynamicDetected = consumeDynamicUsage();
-          return { result, dynamicDetected };
-        } finally {
-          consumeDynamicUsage();
-          if (priorDynamic) markDynamicUsage();
-        }
-      },
-    },
-    revalidateSeconds,
-    mountedSlotsHeader: __mountedSlotsHeader,
-    renderErrorBoundaryResponse(renderErr) {
+    renderErrorBoundaryPage(renderErr) {
       return renderErrorBoundaryPage(route, renderErr, isRscRequest, request, params, _scriptNonce, _mwCtx);
     },
-    async renderLayoutSpecialError(__layoutSpecialError, li) {
-      return __buildAppPageSpecialErrorResponse({
-        clearRequestContext() {
-          __clearRequestContext();
-        },
-        middlewareContext: _mwCtx,
-        renderFallbackPage(statusCode) {
-          const parentBoundary = __resolveAppPageParentHttpAccessBoundaryModule({
-            layoutIndex: li,
-            rootForbiddenModule: null,
-            rootNotFoundModule: null,
-            rootUnauthorizedModule: null,
-            routeForbiddenModules: route.forbiddens,
-            routeNotFoundModules: route.notFounds,
-            routeUnauthorizedModules: route.unauthorizeds,
-            statusCode,
-          })?.default ?? null;
-          const parentLayouts = route.layouts.slice(0, li);
-          return renderHTTPAccessFallbackPage(
-            route,
-            statusCode,
-            isRscRequest,
-            request,
-            {
-              boundaryComponent: parentBoundary,
-              layouts: parentLayouts,
-              matchedParams: params,
-            },
-            _scriptNonce,
-            // buildAppPageSpecialErrorResponse merges _mwCtx onto this returned
-            // fallback response; keep this inner boundary render unmerged so
-            // additive headers like Set-Cookie and Vary are not duplicated.
-            null,
-          );
-        },
-        requestUrl: request.url,
-        specialError: __layoutSpecialError,
-      });
-    },
-    async renderPageSpecialError(specialError) {
-      return __buildAppPageSpecialErrorResponse({
-        clearRequestContext() {
-          __clearRequestContext();
-        },
-        middlewareContext: _mwCtx,
-        renderFallbackPage(statusCode) {
-          return renderHTTPAccessFallbackPage(
-            route,
-            statusCode,
-            isRscRequest,
-            request,
-            {
-              matchedParams: params,
-            },
-            _scriptNonce,
-            // buildAppPageSpecialErrorResponse merges _mwCtx onto this returned
-            // fallback response; keep this inner boundary render unmerged so
-            // additive headers like Set-Cookie and Vary are not duplicated.
-            null,
-          );
-        },
-        requestUrl: request.url,
-        specialError,
-      });
+    renderHttpAccessFallbackPage(statusCode, opts, middlewareContext) {
+      return renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, opts, _scriptNonce, middlewareContext);
     },
     renderToReadableStream,
-    routeHasLocalBoundary: !!(route?.error?.default) || !!(route?.errors && route.errors.some(function(e) { return e?.default; })),
-    routePattern: route.pattern,
+    request,
+    revalidateSeconds: typeof route.page?.revalidate === "number" ? route.page.revalidate : null,
+    rootForbiddenModule,
+    rootNotFoundModule,
+    rootUnauthorizedModule,
+    route,
     runWithSuppressedHookWarning(probe) {
-      // Run inside ALS context so the module-level console.error patch suppresses
-      // "Invalid hook call" only for this request's probe — concurrent requests
-      // each have their own ALS store and are unaffected.
       return _suppressHookWarningAls.run(true, probe);
     },
-    scriptNonce: _scriptNonce,
-    waitUntil(__cachePromise) {
-      _getRequestExecutionContext()?.waitUntil(__cachePromise);
+    scheduleBackgroundRegeneration(key, renderFn, errorContext) {
+      __triggerBackgroundRegeneration(key, renderFn, errorContext);
     },
+    scriptNonce: _scriptNonce,
+    searchParams: url.searchParams,
+    setNavigationContext,
   });
 }
 
@@ -6258,17 +4710,10 @@ import {
   createRscOnErrorHandler as __createRscOnErrorHandler,
   sanitizeErrorForClient as __sanitizeErrorForClient,
 } from "<ROOT>/packages/vinext/src/server/app-rsc-errors.js";
-import { readAppPageCacheResponse as __readAppPageCacheResponse } from "<ROOT>/packages/vinext/src/server/app-page-cache.js";
 import {
   buildAppPageFontLinkHeader as __buildAppPageFontLinkHeader,
-  buildAppPageSpecialErrorResponse as __buildAppPageSpecialErrorResponse,
-  readAppPageTextStream as __readAppPageTextStream,
   resolveAppPageSpecialError as __resolveAppPageSpecialError,
-  teeAppPageRscStreamForCapture as __teeAppPageRscStreamForCapture,
 } from "<ROOT>/packages/vinext/src/server/app-page-execution.js";
-import {
-  resolveAppPageParentHttpAccessBoundaryModule as __resolveAppPageParentHttpAccessBoundaryModule,
-} from "<ROOT>/packages/vinext/src/server/app-page-boundary.js";
 import {
   renderAppPageErrorBoundary as __renderAppPageErrorBoundary,
   renderAppPageHttpAccessFallback as __renderAppPageHttpAccessFallback,
@@ -6291,29 +4736,17 @@ import {
   resolveAppPageHead as __resolveAppPageHead,
 } from "<ROOT>/packages/vinext/src/server/app-page-head.js";
 import {
-  renderAppPageLifecycle as __renderAppPageLifecycle,
-} from "<ROOT>/packages/vinext/src/server/app-page-render.js";
-import {
   mergeMiddlewareResponseHeaders as __mergeMiddlewareResponseHeaders,
 } from "<ROOT>/packages/vinext/src/server/app-page-response.js";
+import {
+  dispatchAppPage as __dispatchAppPage,
+} from "<ROOT>/packages/vinext/src/server/app-page-dispatch.js";
 import { getScriptNonceFromHeaderSources as __getScriptNonceFromHeaderSources } from "<ROOT>/packages/vinext/src/server/csp.js";
-import {
-  buildAppPageElement as __buildAppPageElement,
-  resolveAppPageIntercept as __resolveAppPageIntercept,
-  validateAppPageDynamicParams as __validateAppPageDynamicParams,
-} from "<ROOT>/packages/vinext/src/server/app-page-request.js";
-import {
-  resolveAppPageMethodResponse as __resolveAppPageMethodResponse,
-} from "<ROOT>/packages/vinext/src/server/app-page-method.js";
-import {
-  createStaticGenerationHeadersContext as __createStaticGenerationHeadersContext,
-} from "<ROOT>/packages/vinext/src/server/app-static-generation.js";
 import { buildPageCacheTags } from "<ROOT>/packages/vinext/src/server/implicit-tags.js";
-import { _consumeRequestScopedCacheLife } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
 import { setRootParams as __setRootParams, pickRootParams as __pickRootParams } from "<ROOT>/packages/vinext/src/shims/root-params.js";
 import { makeThenableParams } from "<ROOT>/packages/vinext/src/shims/thenable-params.js";
-import { ensureFetchPatch as _ensureFetchPatch, getCollectedFetchTags, setCurrentFetchSoftTags } from "vinext/fetch-cache";
+import { ensureFetchPatch as _ensureFetchPatch, setCurrentFetchSoftTags } from "vinext/fetch-cache";
 import {
   createAppRscRouteMatcher as __createAppRscRouteMatcher,
 } from "<ROOT>/packages/vinext/src/server/app-rsc-route-matching.js";
@@ -7259,9 +5692,6 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   }
 
   const { route, params } = match;
-  setCurrentFetchSoftTags(
-    buildPageCacheTags(cleanPathname, [], route.routeSegments, route.routeHandler ? "route" : "page"),
-  );
 
   // Update navigation context with matched params
   setNavigationContext({
@@ -7273,6 +5703,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
 
   // Handle route.ts API handlers
   if (route.routeHandler) {
+    setCurrentFetchSoftTags(
+      buildPageCacheTags(cleanPathname, [], route.routeSegments, "route"),
+    );
     return __dispatchAppRouteHandler({
       basePath: __basePath,
       cleanPathname,
@@ -7298,343 +5731,56 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     });
   }
 
-  // Build the component tree: layouts wrapping the page
-  const hasPageModule = !!route.page;
   const PageComponent = route.page?.default;
-  if (hasPageModule && !PageComponent) {
-    __clearRequestContext();
-    return new Response("Page has no default export", { status: 500 });
-  }
-
-  // Read route segment config from page module exports
-  let revalidateSeconds = typeof route.page?.revalidate === "number" ? route.page.revalidate : null;
-  const dynamicConfig = route.page?.dynamic; // 'auto' | 'force-dynamic' | 'force-static' | 'error'
-  const dynamicParamsConfig = route.page?.dynamicParams; // true (default) | false
-  const isForceStatic = dynamicConfig === "force-static";
-  const isDynamicError = dynamicConfig === "error";
-  const __methodResponse = __resolveAppPageMethodResponse({
-    dynamicConfig,
-    hasGenerateStaticParams: typeof route.page?.generateStaticParams === "function",
-    isDynamicRoute: route.isDynamic,
-    middlewareHeaders: _mwCtx.headers,
-    request,
-    revalidateSeconds,
-  });
-  if (__methodResponse) {
-    __clearRequestContext();
-    return __methodResponse;
-  }
-
-  // force-static: replace headers/cookies context with empty values and
-  // clear searchParams so dynamic APIs return defaults instead of real data
-  if (isForceStatic) {
-    setHeadersContext(__createStaticGenerationHeadersContext({
-      dynamicConfig,
-      routeKind: "page",
-      routePattern: route.pattern,
-    }));
-    setNavigationContext({
-      pathname: cleanPathname,
-      searchParams: new URLSearchParams(),
-      params,
-    });
-  }
-
-  // dynamic = 'error': install an access error so request APIs fail with the
-  // static-generation message even for legacy sync property access.
-  if (isDynamicError) {
-    setHeadersContext(__createStaticGenerationHeadersContext({
-      dynamicConfig,
-      routeKind: "page",
-      routePattern: route.pattern,
-    }));
-    setNavigationContext({
-      pathname: cleanPathname,
-      searchParams: new URLSearchParams(),
-      params,
-    });
-  }
-
-  // force-dynamic: set no-store Cache-Control
-  const isForceDynamic = dynamicConfig === "force-dynamic";
-
-  // ── ISR cache read (production only) ─────────────────────────────────────
-  // Read from cache BEFORE generateStaticParams and all rendering work.
-  // This is the critical performance optimization: on a cache hit we skip
-  // ALL expensive work (generateStaticParams, buildPageElement, layout probe,
-  // page probe, renderToReadableStream, SSR). Both HTML and RSC requests
-  // (client-side navigation / prefetch) are served from cache.
-  //
-  // HTML and RSC are stored under separate keys (matching Next.js's .html/.rsc
-  // file layout) so each request type reads and writes independently — no races,
-  // no partial-entry sentinels, no read-before-write hacks needed.
-  //
-  // force-static and dynamic='error' are compatible with ISR — they control
-  // how dynamic APIs behave during rendering, not whether results are cached.
-  // Only force-dynamic truly bypasses the ISR cache.
-  if (
-    process.env.NODE_ENV === "production" &&
-    !isForceDynamic &&
-    (isRscRequest || !_scriptNonce) &&
-    revalidateSeconds !== null && revalidateSeconds > 0 && revalidateSeconds !== Infinity
-  ) {
-    const __cachedPageResponse = await __readAppPageCacheResponse({
-      cleanPathname,
-      clearRequestContext: function() {
-        __clearRequestContext();
-      },
-      isRscRequest,
-      isrDebug: __isrDebug,
-      isrGet: __isrGet,
-      isrHtmlKey: __isrHtmlKey,
-      isrRscKey: __isrRscKey,
-      isrSet: __isrSet,
-      mountedSlotsHeader: __mountedSlotsHeader,
-      revalidateSeconds,
-      renderFreshPageForCache: async function() {
-        // Re-render the page to produce fresh HTML + RSC data for the cache
-        // Use an empty headers context for background regeneration — not the original
-        // user request — to prevent user-specific cookies/auth headers from leaking
-        // into content that is cached and served to all subsequent users.
-        const __revalHeadCtx = __createStaticGenerationHeadersContext({
-          dynamicConfig,
-          routeKind: "page",
-          routePattern: route.pattern,
-        });
-        const __revalUCtx = _createUnifiedCtx({
-          headersContext: __revalHeadCtx,
-          executionContext: _getRequestExecutionContext(),
-          unstableCacheRevalidation: "foreground",
-        });
-        return _runWithUnifiedCtx(__revalUCtx, async () => {
-          _ensureFetchPatch();
-          setCurrentFetchSoftTags(buildPageCacheTags(cleanPathname, [], route.routeSegments, "page"));
-          setNavigationContext({ pathname: cleanPathname, searchParams: new URLSearchParams(), params });
-          // Slot context (X-Vinext-Mounted-Slots) is inherited from the
-          // triggering request so the regen result is cached under the
-          // correct slot-variant key.
-          const __revalElement = await buildPageElements(
-            route,
-            params,
-            cleanPathname,
-            {
-              opts: undefined,
-              searchParams: new URLSearchParams(),
-              isRscRequest,
-              request,
-              mountedSlotsHeader: __mountedSlotsHeader,
-            },
-          );
-          const __revalOnError = createRscOnErrorHandler(request, cleanPathname, route.pattern);
-          const __revalRscStream = renderToReadableStream(__revalElement, { onError: __revalOnError });
-          const __revalRscCapture = __teeAppPageRscStreamForCapture(__revalRscStream, true);
-          const __revalFontData = { links: _getSSRFontLinks(), styles: _getSSRFontStyles(), preloads: _getSSRFontPreloads() };
-          const __revalSsrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
-          const __revalCapturedRscRef = { value: null };
-          const __revalHtmlStream = await __revalSsrEntry.handleSsr(
-            __revalRscCapture.ssrStream,
-            _getNavigationContext(),
-            __revalFontData,
-            __revalRscCapture.sideStream
-              ? { sideStream: __revalRscCapture.sideStream, capturedRscDataRef: __revalCapturedRscRef }
-              : undefined,
-          );
-          __clearRequestContext();
-          const __freshHtml = await __readAppPageTextStream(__revalHtmlStream);
-          const __freshRscData = __revalCapturedRscRef.value ? await __revalCapturedRscRef.value : null;
-          const __pageTags = buildPageCacheTags(cleanPathname, getCollectedFetchTags(), route.routeSegments, "page");
-          return { html: __freshHtml, rscData: __freshRscData, tags: __pageTags };
-        });
-      },
-      scheduleBackgroundRegeneration(key, renderFn) {
-        __triggerBackgroundRegeneration(key, renderFn, {
-          routerKind: "App Router",
-          routePath: route.pattern,
-          routeType: "render",
-        });
-      },
-    });
-    if (__cachedPageResponse) {
-      return __cachedPageResponse;
-    }
-  }
-
-  // dynamicParams = false: only params from generateStaticParams are allowed.
-  // This runs AFTER the ISR cache read so that a cache hit skips this work entirely.
-  const __dynamicParamsResponse = await __validateAppPageDynamicParams({
-    clearRequestContext() {
-      __clearRequestContext();
-    },
-    enforceStaticParamsOnly: dynamicParamsConfig === false,
-    generateStaticParams: route.page?.generateStaticParams,
-    isDynamicRoute: route.isDynamic,
-    logGenerateStaticParamsError(err) {
-      console.error("[vinext] generateStaticParams error:", err);
-    },
-    params,
-  });
-  if (__dynamicParamsResponse) {
-    return __dynamicParamsResponse;
-  }
-
-  // Check for intercepting routes on RSC requests (client-side navigation).
-  // If the target URL matches an intercepting route in a parallel slot,
-  // render the source route with the intercepting page in the slot.
-  const __interceptResult = await __resolveAppPageIntercept({
-    buildPageElement(interceptRoute, interceptParams, interceptOpts, interceptSearchParams) {
-      return buildPageElements(
-        interceptRoute,
-        interceptParams,
-        cleanPathname,
-        {
-          opts: interceptOpts,
-          searchParams: interceptSearchParams,
-          isRscRequest,
-          request,
-          mountedSlotsHeader: __mountedSlotsHeader,
-        },
-      );
-    },
-    cleanPathname,
-    currentRoute: route,
-    findIntercept(pathname) {
-      return findIntercept(pathname, interceptionContextHeader);
-    },
-    getRouteParamNames(sourceRoute) {
-      return sourceRoute.params;
-    },
-    getSourceRoute(sourceRouteIndex) {
-      return routes[sourceRouteIndex];
-    },
-    isRscRequest,
-    renderInterceptResponse(sourceRoute, interceptElement) {
-      const interceptOnError = createRscOnErrorHandler(
-        request,
-        cleanPathname,
-        sourceRoute.pattern,
-      );
-      const interceptStream = renderToReadableStream(interceptElement, {
-        onError: interceptOnError,
-      });
-      // Do NOT clear headers/navigation context here — the RSC stream is consumed lazily
-      // by the client, and async server components that run during consumption need the
-      // context to still be live. The AsyncLocalStorage scope from runWithRequestContext
-      // handles cleanup naturally when all async continuations complete.
-      const interceptHeaders = new Headers({
-        "Content-Type": "text/x-component; charset=utf-8",
-        "Vary": "RSC, Accept",
-      });
-      __mergeMiddlewareResponseHeaders(interceptHeaders, _mwCtx.headers);
-      return new Response(interceptStream, {
-        status: _mwCtx.status ?? 200,
-        headers: interceptHeaders,
-      });
-    },
-    searchParams: url.searchParams,
-    setNavigationContext,
-    toInterceptOpts(intercept) {
-      return {
-        interceptionContext: interceptionContextHeader,
-        interceptLayouts: intercept.interceptLayouts,
-        interceptSlotKey: intercept.slotKey,
-        interceptPage: intercept.page,
-        interceptParams: intercept.matchedParams,
-      };
-    },
-  });
-  if (__interceptResult.response) {
-    return __interceptResult.response;
-  }
-  const interceptOpts = __interceptResult.interceptOpts;
-
-  const __pageBuildResult = await __buildAppPageElement({
-    buildPageElement() {
-      return buildPageElements(route, params, cleanPathname, {
-        opts: interceptOpts,
-        searchParams: url.searchParams,
+  const _asyncRouteParams = makeThenableParams(params);
+  return __dispatchAppPage({
+    buildPageElement(targetRoute, targetParams, targetOpts, targetSearchParams) {
+      return buildPageElements(targetRoute, targetParams, cleanPathname, {
+        opts: targetOpts,
+        searchParams: targetSearchParams,
         isRscRequest,
         request,
         mountedSlotsHeader: __mountedSlotsHeader,
       });
     },
-    renderErrorBoundaryPage(buildErr) {
-      return renderErrorBoundaryPage(route, buildErr, isRscRequest, request, params, _scriptNonce, _mwCtx);
-    },
-    renderSpecialError(__buildSpecialError) {
-      return __buildAppPageSpecialErrorResponse({
-        clearRequestContext() {
-          __clearRequestContext();
-        },
-        middlewareContext: _mwCtx,
-        renderFallbackPage(statusCode) {
-          return renderHTTPAccessFallbackPage(
-            route,
-            statusCode,
-            isRscRequest,
-            request,
-            {
-              matchedParams: params,
-            },
-            _scriptNonce,
-            // buildAppPageSpecialErrorResponse merges _mwCtx onto this returned
-            // fallback response; keep this inner boundary render unmerged so
-            // additive headers like Set-Cookie and Vary are not duplicated.
-            null,
-          );
-        },
-        requestUrl: request.url,
-        specialError: __buildSpecialError,
-      });
-    },
-    resolveSpecialError: __resolveAppPageSpecialError,
-  });
-  if (__pageBuildResult.response) {
-    return __pageBuildResult.response;
-  }
-  const element = __pageBuildResult.element;
-
-  // Note: CSS is automatically injected by @vitejs/plugin-rsc's
-  // rscCssTransform — no manual loadCss() call needed.
-  const _hasLoadingBoundary = !!(route.loading && route.loading.default);
-  const _asyncRouteParams = makeThenableParams(params);
-  return __renderAppPageLifecycle({
     cleanPathname,
     clearRequestContext() {
       __clearRequestContext();
     },
-    consumeDynamicUsage,
-    consumeInvalidDynamicUsageError,
     createRscOnErrorHandler(pathname, routePath) {
       return createRscOnErrorHandler(request, pathname, routePath);
     },
-    element,
-    getDraftModeCookieHeader,
+    debugClassification: __classDebug,
+    dynamicConfig: route.page?.dynamic,
+    dynamicParamsConfig: route.page?.dynamicParams,
+    findIntercept(pathname) {
+      return findIntercept(pathname, interceptionContextHeader);
+    },
+    generateStaticParams: route.page?.generateStaticParams,
     getFontLinks: _getSSRFontLinks,
     getFontPreloads: _getSSRFontPreloads,
     getFontStyles: _getSSRFontStyles,
     getNavigationContext: _getNavigationContext,
-    getPageTags() {
-      return buildPageCacheTags(cleanPathname, getCollectedFetchTags(), route.routeSegments, "page");
+    getSourceRoute(sourceRouteIndex) {
+      return routes[sourceRouteIndex];
     },
-    getRequestCacheLife() {
-      return _consumeRequestScopedCacheLife();
-    },
+    hasGenerateStaticParams: typeof route.page?.generateStaticParams === "function",
+    hasPageDefaultExport: !!PageComponent,
+    hasPageModule: !!route.page,
     handlerStart: __reqStart,
-    hasLoadingBoundary: _hasLoadingBoundary,
-    isDynamicError,
-    isForceDynamic,
-    isForceStatic,
+    interceptionContext: interceptionContextHeader,
     isProduction: process.env.NODE_ENV === "production",
     isRscRequest,
     isrDebug: __isrDebug,
+    isrGet: __isrGet,
     isrHtmlKey: __isrHtmlKey,
     isrRscKey: __isrRscKey,
     isrSet: __isrSet,
-    layoutCount: route.layouts?.length ?? 0,
     loadSsrHandler() {
       return import.meta.viteRsc.loadModule("ssr", "index");
     },
     middlewareContext: _mwCtx,
+    mountedSlotsHeader: __mountedSlotsHeader,
     params,
     probeLayoutAt(li) {
       const LayoutComp = route.layouts[li]?.default;
@@ -7655,109 +5801,28 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       );
       return PageComponent({ params: _asyncRouteParams, searchParams: _asyncSearchParams });
     },
-    classification: {
-      getLayoutId(index) {
-        const tp = route.layoutTreePositions?.[index] ?? 0;
-        return "layout:" + __createAppPageTreePath(route.routeSegments, tp);
-      },
-      buildTimeClassifications: route.__buildTimeClassifications,
-      buildTimeReasons: route.__buildTimeReasons,
-      debugClassification: __classDebug,
-      async runWithIsolatedDynamicScope(fn) {
-        const priorDynamic = consumeDynamicUsage();
-        try {
-          const result = await fn();
-          const dynamicDetected = consumeDynamicUsage();
-          return { result, dynamicDetected };
-        } finally {
-          consumeDynamicUsage();
-          if (priorDynamic) markDynamicUsage();
-        }
-      },
-    },
-    revalidateSeconds,
-    mountedSlotsHeader: __mountedSlotsHeader,
-    renderErrorBoundaryResponse(renderErr) {
+    renderErrorBoundaryPage(renderErr) {
       return renderErrorBoundaryPage(route, renderErr, isRscRequest, request, params, _scriptNonce, _mwCtx);
     },
-    async renderLayoutSpecialError(__layoutSpecialError, li) {
-      return __buildAppPageSpecialErrorResponse({
-        clearRequestContext() {
-          __clearRequestContext();
-        },
-        middlewareContext: _mwCtx,
-        renderFallbackPage(statusCode) {
-          const parentBoundary = __resolveAppPageParentHttpAccessBoundaryModule({
-            layoutIndex: li,
-            rootForbiddenModule: null,
-            rootNotFoundModule: null,
-            rootUnauthorizedModule: null,
-            routeForbiddenModules: route.forbiddens,
-            routeNotFoundModules: route.notFounds,
-            routeUnauthorizedModules: route.unauthorizeds,
-            statusCode,
-          })?.default ?? null;
-          const parentLayouts = route.layouts.slice(0, li);
-          return renderHTTPAccessFallbackPage(
-            route,
-            statusCode,
-            isRscRequest,
-            request,
-            {
-              boundaryComponent: parentBoundary,
-              layouts: parentLayouts,
-              matchedParams: params,
-            },
-            _scriptNonce,
-            // buildAppPageSpecialErrorResponse merges _mwCtx onto this returned
-            // fallback response; keep this inner boundary render unmerged so
-            // additive headers like Set-Cookie and Vary are not duplicated.
-            null,
-          );
-        },
-        requestUrl: request.url,
-        specialError: __layoutSpecialError,
-      });
-    },
-    async renderPageSpecialError(specialError) {
-      return __buildAppPageSpecialErrorResponse({
-        clearRequestContext() {
-          __clearRequestContext();
-        },
-        middlewareContext: _mwCtx,
-        renderFallbackPage(statusCode) {
-          return renderHTTPAccessFallbackPage(
-            route,
-            statusCode,
-            isRscRequest,
-            request,
-            {
-              matchedParams: params,
-            },
-            _scriptNonce,
-            // buildAppPageSpecialErrorResponse merges _mwCtx onto this returned
-            // fallback response; keep this inner boundary render unmerged so
-            // additive headers like Set-Cookie and Vary are not duplicated.
-            null,
-          );
-        },
-        requestUrl: request.url,
-        specialError,
-      });
+    renderHttpAccessFallbackPage(statusCode, opts, middlewareContext) {
+      return renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, opts, _scriptNonce, middlewareContext);
     },
     renderToReadableStream,
-    routeHasLocalBoundary: !!(route?.error?.default) || !!(route?.errors && route.errors.some(function(e) { return e?.default; })),
-    routePattern: route.pattern,
+    request,
+    revalidateSeconds: typeof route.page?.revalidate === "number" ? route.page.revalidate : null,
+    rootForbiddenModule,
+    rootNotFoundModule,
+    rootUnauthorizedModule,
+    route,
     runWithSuppressedHookWarning(probe) {
-      // Run inside ALS context so the module-level console.error patch suppresses
-      // "Invalid hook call" only for this request's probe — concurrent requests
-      // each have their own ALS store and are unaffected.
       return _suppressHookWarningAls.run(true, probe);
     },
-    scriptNonce: _scriptNonce,
-    waitUntil(__cachePromise) {
-      _getRequestExecutionContext()?.waitUntil(__cachePromise);
+    scheduleBackgroundRegeneration(key, renderFn, errorContext) {
+      __triggerBackgroundRegeneration(key, renderFn, errorContext);
     },
+    scriptNonce: _scriptNonce,
+    searchParams: url.searchParams,
+    setNavigationContext,
   });
 }
 
@@ -7811,17 +5876,10 @@ import {
   createRscOnErrorHandler as __createRscOnErrorHandler,
   sanitizeErrorForClient as __sanitizeErrorForClient,
 } from "<ROOT>/packages/vinext/src/server/app-rsc-errors.js";
-import { readAppPageCacheResponse as __readAppPageCacheResponse } from "<ROOT>/packages/vinext/src/server/app-page-cache.js";
 import {
   buildAppPageFontLinkHeader as __buildAppPageFontLinkHeader,
-  buildAppPageSpecialErrorResponse as __buildAppPageSpecialErrorResponse,
-  readAppPageTextStream as __readAppPageTextStream,
   resolveAppPageSpecialError as __resolveAppPageSpecialError,
-  teeAppPageRscStreamForCapture as __teeAppPageRscStreamForCapture,
 } from "<ROOT>/packages/vinext/src/server/app-page-execution.js";
-import {
-  resolveAppPageParentHttpAccessBoundaryModule as __resolveAppPageParentHttpAccessBoundaryModule,
-} from "<ROOT>/packages/vinext/src/server/app-page-boundary.js";
 import {
   renderAppPageErrorBoundary as __renderAppPageErrorBoundary,
   renderAppPageHttpAccessFallback as __renderAppPageHttpAccessFallback,
@@ -7844,29 +5902,17 @@ import {
   resolveAppPageHead as __resolveAppPageHead,
 } from "<ROOT>/packages/vinext/src/server/app-page-head.js";
 import {
-  renderAppPageLifecycle as __renderAppPageLifecycle,
-} from "<ROOT>/packages/vinext/src/server/app-page-render.js";
-import {
   mergeMiddlewareResponseHeaders as __mergeMiddlewareResponseHeaders,
 } from "<ROOT>/packages/vinext/src/server/app-page-response.js";
+import {
+  dispatchAppPage as __dispatchAppPage,
+} from "<ROOT>/packages/vinext/src/server/app-page-dispatch.js";
 import { getScriptNonceFromHeaderSources as __getScriptNonceFromHeaderSources } from "<ROOT>/packages/vinext/src/server/csp.js";
-import {
-  buildAppPageElement as __buildAppPageElement,
-  resolveAppPageIntercept as __resolveAppPageIntercept,
-  validateAppPageDynamicParams as __validateAppPageDynamicParams,
-} from "<ROOT>/packages/vinext/src/server/app-page-request.js";
-import {
-  resolveAppPageMethodResponse as __resolveAppPageMethodResponse,
-} from "<ROOT>/packages/vinext/src/server/app-page-method.js";
-import {
-  createStaticGenerationHeadersContext as __createStaticGenerationHeadersContext,
-} from "<ROOT>/packages/vinext/src/server/app-static-generation.js";
 import { buildPageCacheTags } from "<ROOT>/packages/vinext/src/server/implicit-tags.js";
-import { _consumeRequestScopedCacheLife } from "next/cache";
 import { getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
 import { setRootParams as __setRootParams, pickRootParams as __pickRootParams } from "<ROOT>/packages/vinext/src/shims/root-params.js";
 import { makeThenableParams } from "<ROOT>/packages/vinext/src/shims/thenable-params.js";
-import { ensureFetchPatch as _ensureFetchPatch, getCollectedFetchTags, setCurrentFetchSoftTags } from "vinext/fetch-cache";
+import { ensureFetchPatch as _ensureFetchPatch, setCurrentFetchSoftTags } from "vinext/fetch-cache";
 import {
   createAppRscRouteMatcher as __createAppRscRouteMatcher,
 } from "<ROOT>/packages/vinext/src/server/app-rsc-route-matching.js";
@@ -8817,9 +6863,6 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   }
 
   const { route, params } = match;
-  setCurrentFetchSoftTags(
-    buildPageCacheTags(cleanPathname, [], route.routeSegments, route.routeHandler ? "route" : "page"),
-  );
 
   // Update navigation context with matched params
   setNavigationContext({
@@ -8831,6 +6874,9 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
 
   // Handle route.ts API handlers
   if (route.routeHandler) {
+    setCurrentFetchSoftTags(
+      buildPageCacheTags(cleanPathname, [], route.routeSegments, "route"),
+    );
     return __dispatchAppRouteHandler({
       basePath: __basePath,
       cleanPathname,
@@ -8856,343 +6902,56 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     });
   }
 
-  // Build the component tree: layouts wrapping the page
-  const hasPageModule = !!route.page;
   const PageComponent = route.page?.default;
-  if (hasPageModule && !PageComponent) {
-    __clearRequestContext();
-    return new Response("Page has no default export", { status: 500 });
-  }
-
-  // Read route segment config from page module exports
-  let revalidateSeconds = typeof route.page?.revalidate === "number" ? route.page.revalidate : null;
-  const dynamicConfig = route.page?.dynamic; // 'auto' | 'force-dynamic' | 'force-static' | 'error'
-  const dynamicParamsConfig = route.page?.dynamicParams; // true (default) | false
-  const isForceStatic = dynamicConfig === "force-static";
-  const isDynamicError = dynamicConfig === "error";
-  const __methodResponse = __resolveAppPageMethodResponse({
-    dynamicConfig,
-    hasGenerateStaticParams: typeof route.page?.generateStaticParams === "function",
-    isDynamicRoute: route.isDynamic,
-    middlewareHeaders: _mwCtx.headers,
-    request,
-    revalidateSeconds,
-  });
-  if (__methodResponse) {
-    __clearRequestContext();
-    return __methodResponse;
-  }
-
-  // force-static: replace headers/cookies context with empty values and
-  // clear searchParams so dynamic APIs return defaults instead of real data
-  if (isForceStatic) {
-    setHeadersContext(__createStaticGenerationHeadersContext({
-      dynamicConfig,
-      routeKind: "page",
-      routePattern: route.pattern,
-    }));
-    setNavigationContext({
-      pathname: cleanPathname,
-      searchParams: new URLSearchParams(),
-      params,
-    });
-  }
-
-  // dynamic = 'error': install an access error so request APIs fail with the
-  // static-generation message even for legacy sync property access.
-  if (isDynamicError) {
-    setHeadersContext(__createStaticGenerationHeadersContext({
-      dynamicConfig,
-      routeKind: "page",
-      routePattern: route.pattern,
-    }));
-    setNavigationContext({
-      pathname: cleanPathname,
-      searchParams: new URLSearchParams(),
-      params,
-    });
-  }
-
-  // force-dynamic: set no-store Cache-Control
-  const isForceDynamic = dynamicConfig === "force-dynamic";
-
-  // ── ISR cache read (production only) ─────────────────────────────────────
-  // Read from cache BEFORE generateStaticParams and all rendering work.
-  // This is the critical performance optimization: on a cache hit we skip
-  // ALL expensive work (generateStaticParams, buildPageElement, layout probe,
-  // page probe, renderToReadableStream, SSR). Both HTML and RSC requests
-  // (client-side navigation / prefetch) are served from cache.
-  //
-  // HTML and RSC are stored under separate keys (matching Next.js's .html/.rsc
-  // file layout) so each request type reads and writes independently — no races,
-  // no partial-entry sentinels, no read-before-write hacks needed.
-  //
-  // force-static and dynamic='error' are compatible with ISR — they control
-  // how dynamic APIs behave during rendering, not whether results are cached.
-  // Only force-dynamic truly bypasses the ISR cache.
-  if (
-    process.env.NODE_ENV === "production" &&
-    !isForceDynamic &&
-    (isRscRequest || !_scriptNonce) &&
-    revalidateSeconds !== null && revalidateSeconds > 0 && revalidateSeconds !== Infinity
-  ) {
-    const __cachedPageResponse = await __readAppPageCacheResponse({
-      cleanPathname,
-      clearRequestContext: function() {
-        __clearRequestContext();
-      },
-      isRscRequest,
-      isrDebug: __isrDebug,
-      isrGet: __isrGet,
-      isrHtmlKey: __isrHtmlKey,
-      isrRscKey: __isrRscKey,
-      isrSet: __isrSet,
-      mountedSlotsHeader: __mountedSlotsHeader,
-      revalidateSeconds,
-      renderFreshPageForCache: async function() {
-        // Re-render the page to produce fresh HTML + RSC data for the cache
-        // Use an empty headers context for background regeneration — not the original
-        // user request — to prevent user-specific cookies/auth headers from leaking
-        // into content that is cached and served to all subsequent users.
-        const __revalHeadCtx = __createStaticGenerationHeadersContext({
-          dynamicConfig,
-          routeKind: "page",
-          routePattern: route.pattern,
-        });
-        const __revalUCtx = _createUnifiedCtx({
-          headersContext: __revalHeadCtx,
-          executionContext: _getRequestExecutionContext(),
-          unstableCacheRevalidation: "foreground",
-        });
-        return _runWithUnifiedCtx(__revalUCtx, async () => {
-          _ensureFetchPatch();
-          setCurrentFetchSoftTags(buildPageCacheTags(cleanPathname, [], route.routeSegments, "page"));
-          setNavigationContext({ pathname: cleanPathname, searchParams: new URLSearchParams(), params });
-          // Slot context (X-Vinext-Mounted-Slots) is inherited from the
-          // triggering request so the regen result is cached under the
-          // correct slot-variant key.
-          const __revalElement = await buildPageElements(
-            route,
-            params,
-            cleanPathname,
-            {
-              opts: undefined,
-              searchParams: new URLSearchParams(),
-              isRscRequest,
-              request,
-              mountedSlotsHeader: __mountedSlotsHeader,
-            },
-          );
-          const __revalOnError = createRscOnErrorHandler(request, cleanPathname, route.pattern);
-          const __revalRscStream = renderToReadableStream(__revalElement, { onError: __revalOnError });
-          const __revalRscCapture = __teeAppPageRscStreamForCapture(__revalRscStream, true);
-          const __revalFontData = { links: _getSSRFontLinks(), styles: _getSSRFontStyles(), preloads: _getSSRFontPreloads() };
-          const __revalSsrEntry = await import.meta.viteRsc.loadModule("ssr", "index");
-          const __revalCapturedRscRef = { value: null };
-          const __revalHtmlStream = await __revalSsrEntry.handleSsr(
-            __revalRscCapture.ssrStream,
-            _getNavigationContext(),
-            __revalFontData,
-            __revalRscCapture.sideStream
-              ? { sideStream: __revalRscCapture.sideStream, capturedRscDataRef: __revalCapturedRscRef }
-              : undefined,
-          );
-          __clearRequestContext();
-          const __freshHtml = await __readAppPageTextStream(__revalHtmlStream);
-          const __freshRscData = __revalCapturedRscRef.value ? await __revalCapturedRscRef.value : null;
-          const __pageTags = buildPageCacheTags(cleanPathname, getCollectedFetchTags(), route.routeSegments, "page");
-          return { html: __freshHtml, rscData: __freshRscData, tags: __pageTags };
-        });
-      },
-      scheduleBackgroundRegeneration(key, renderFn) {
-        __triggerBackgroundRegeneration(key, renderFn, {
-          routerKind: "App Router",
-          routePath: route.pattern,
-          routeType: "render",
-        });
-      },
-    });
-    if (__cachedPageResponse) {
-      return __cachedPageResponse;
-    }
-  }
-
-  // dynamicParams = false: only params from generateStaticParams are allowed.
-  // This runs AFTER the ISR cache read so that a cache hit skips this work entirely.
-  const __dynamicParamsResponse = await __validateAppPageDynamicParams({
-    clearRequestContext() {
-      __clearRequestContext();
-    },
-    enforceStaticParamsOnly: dynamicParamsConfig === false,
-    generateStaticParams: route.page?.generateStaticParams,
-    isDynamicRoute: route.isDynamic,
-    logGenerateStaticParamsError(err) {
-      console.error("[vinext] generateStaticParams error:", err);
-    },
-    params,
-  });
-  if (__dynamicParamsResponse) {
-    return __dynamicParamsResponse;
-  }
-
-  // Check for intercepting routes on RSC requests (client-side navigation).
-  // If the target URL matches an intercepting route in a parallel slot,
-  // render the source route with the intercepting page in the slot.
-  const __interceptResult = await __resolveAppPageIntercept({
-    buildPageElement(interceptRoute, interceptParams, interceptOpts, interceptSearchParams) {
-      return buildPageElements(
-        interceptRoute,
-        interceptParams,
-        cleanPathname,
-        {
-          opts: interceptOpts,
-          searchParams: interceptSearchParams,
-          isRscRequest,
-          request,
-          mountedSlotsHeader: __mountedSlotsHeader,
-        },
-      );
-    },
-    cleanPathname,
-    currentRoute: route,
-    findIntercept(pathname) {
-      return findIntercept(pathname, interceptionContextHeader);
-    },
-    getRouteParamNames(sourceRoute) {
-      return sourceRoute.params;
-    },
-    getSourceRoute(sourceRouteIndex) {
-      return routes[sourceRouteIndex];
-    },
-    isRscRequest,
-    renderInterceptResponse(sourceRoute, interceptElement) {
-      const interceptOnError = createRscOnErrorHandler(
-        request,
-        cleanPathname,
-        sourceRoute.pattern,
-      );
-      const interceptStream = renderToReadableStream(interceptElement, {
-        onError: interceptOnError,
-      });
-      // Do NOT clear headers/navigation context here — the RSC stream is consumed lazily
-      // by the client, and async server components that run during consumption need the
-      // context to still be live. The AsyncLocalStorage scope from runWithRequestContext
-      // handles cleanup naturally when all async continuations complete.
-      const interceptHeaders = new Headers({
-        "Content-Type": "text/x-component; charset=utf-8",
-        "Vary": "RSC, Accept",
-      });
-      __mergeMiddlewareResponseHeaders(interceptHeaders, _mwCtx.headers);
-      return new Response(interceptStream, {
-        status: _mwCtx.status ?? 200,
-        headers: interceptHeaders,
-      });
-    },
-    searchParams: url.searchParams,
-    setNavigationContext,
-    toInterceptOpts(intercept) {
-      return {
-        interceptionContext: interceptionContextHeader,
-        interceptLayouts: intercept.interceptLayouts,
-        interceptSlotKey: intercept.slotKey,
-        interceptPage: intercept.page,
-        interceptParams: intercept.matchedParams,
-      };
-    },
-  });
-  if (__interceptResult.response) {
-    return __interceptResult.response;
-  }
-  const interceptOpts = __interceptResult.interceptOpts;
-
-  const __pageBuildResult = await __buildAppPageElement({
-    buildPageElement() {
-      return buildPageElements(route, params, cleanPathname, {
-        opts: interceptOpts,
-        searchParams: url.searchParams,
+  const _asyncRouteParams = makeThenableParams(params);
+  return __dispatchAppPage({
+    buildPageElement(targetRoute, targetParams, targetOpts, targetSearchParams) {
+      return buildPageElements(targetRoute, targetParams, cleanPathname, {
+        opts: targetOpts,
+        searchParams: targetSearchParams,
         isRscRequest,
         request,
         mountedSlotsHeader: __mountedSlotsHeader,
       });
     },
-    renderErrorBoundaryPage(buildErr) {
-      return renderErrorBoundaryPage(route, buildErr, isRscRequest, request, params, _scriptNonce, _mwCtx);
-    },
-    renderSpecialError(__buildSpecialError) {
-      return __buildAppPageSpecialErrorResponse({
-        clearRequestContext() {
-          __clearRequestContext();
-        },
-        middlewareContext: _mwCtx,
-        renderFallbackPage(statusCode) {
-          return renderHTTPAccessFallbackPage(
-            route,
-            statusCode,
-            isRscRequest,
-            request,
-            {
-              matchedParams: params,
-            },
-            _scriptNonce,
-            // buildAppPageSpecialErrorResponse merges _mwCtx onto this returned
-            // fallback response; keep this inner boundary render unmerged so
-            // additive headers like Set-Cookie and Vary are not duplicated.
-            null,
-          );
-        },
-        requestUrl: request.url,
-        specialError: __buildSpecialError,
-      });
-    },
-    resolveSpecialError: __resolveAppPageSpecialError,
-  });
-  if (__pageBuildResult.response) {
-    return __pageBuildResult.response;
-  }
-  const element = __pageBuildResult.element;
-
-  // Note: CSS is automatically injected by @vitejs/plugin-rsc's
-  // rscCssTransform — no manual loadCss() call needed.
-  const _hasLoadingBoundary = !!(route.loading && route.loading.default);
-  const _asyncRouteParams = makeThenableParams(params);
-  return __renderAppPageLifecycle({
     cleanPathname,
     clearRequestContext() {
       __clearRequestContext();
     },
-    consumeDynamicUsage,
-    consumeInvalidDynamicUsageError,
     createRscOnErrorHandler(pathname, routePath) {
       return createRscOnErrorHandler(request, pathname, routePath);
     },
-    element,
-    getDraftModeCookieHeader,
+    debugClassification: __classDebug,
+    dynamicConfig: route.page?.dynamic,
+    dynamicParamsConfig: route.page?.dynamicParams,
+    findIntercept(pathname) {
+      return findIntercept(pathname, interceptionContextHeader);
+    },
+    generateStaticParams: route.page?.generateStaticParams,
     getFontLinks: _getSSRFontLinks,
     getFontPreloads: _getSSRFontPreloads,
     getFontStyles: _getSSRFontStyles,
     getNavigationContext: _getNavigationContext,
-    getPageTags() {
-      return buildPageCacheTags(cleanPathname, getCollectedFetchTags(), route.routeSegments, "page");
+    getSourceRoute(sourceRouteIndex) {
+      return routes[sourceRouteIndex];
     },
-    getRequestCacheLife() {
-      return _consumeRequestScopedCacheLife();
-    },
+    hasGenerateStaticParams: typeof route.page?.generateStaticParams === "function",
+    hasPageDefaultExport: !!PageComponent,
+    hasPageModule: !!route.page,
     handlerStart: __reqStart,
-    hasLoadingBoundary: _hasLoadingBoundary,
-    isDynamicError,
-    isForceDynamic,
-    isForceStatic,
+    interceptionContext: interceptionContextHeader,
     isProduction: process.env.NODE_ENV === "production",
     isRscRequest,
     isrDebug: __isrDebug,
+    isrGet: __isrGet,
     isrHtmlKey: __isrHtmlKey,
     isrRscKey: __isrRscKey,
     isrSet: __isrSet,
-    layoutCount: route.layouts?.length ?? 0,
     loadSsrHandler() {
       return import.meta.viteRsc.loadModule("ssr", "index");
     },
     middlewareContext: _mwCtx,
+    mountedSlotsHeader: __mountedSlotsHeader,
     params,
     probeLayoutAt(li) {
       const LayoutComp = route.layouts[li]?.default;
@@ -9213,109 +6972,28 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       );
       return PageComponent({ params: _asyncRouteParams, searchParams: _asyncSearchParams });
     },
-    classification: {
-      getLayoutId(index) {
-        const tp = route.layoutTreePositions?.[index] ?? 0;
-        return "layout:" + __createAppPageTreePath(route.routeSegments, tp);
-      },
-      buildTimeClassifications: route.__buildTimeClassifications,
-      buildTimeReasons: route.__buildTimeReasons,
-      debugClassification: __classDebug,
-      async runWithIsolatedDynamicScope(fn) {
-        const priorDynamic = consumeDynamicUsage();
-        try {
-          const result = await fn();
-          const dynamicDetected = consumeDynamicUsage();
-          return { result, dynamicDetected };
-        } finally {
-          consumeDynamicUsage();
-          if (priorDynamic) markDynamicUsage();
-        }
-      },
-    },
-    revalidateSeconds,
-    mountedSlotsHeader: __mountedSlotsHeader,
-    renderErrorBoundaryResponse(renderErr) {
+    renderErrorBoundaryPage(renderErr) {
       return renderErrorBoundaryPage(route, renderErr, isRscRequest, request, params, _scriptNonce, _mwCtx);
     },
-    async renderLayoutSpecialError(__layoutSpecialError, li) {
-      return __buildAppPageSpecialErrorResponse({
-        clearRequestContext() {
-          __clearRequestContext();
-        },
-        middlewareContext: _mwCtx,
-        renderFallbackPage(statusCode) {
-          const parentBoundary = __resolveAppPageParentHttpAccessBoundaryModule({
-            layoutIndex: li,
-            rootForbiddenModule: null,
-            rootNotFoundModule: null,
-            rootUnauthorizedModule: null,
-            routeForbiddenModules: route.forbiddens,
-            routeNotFoundModules: route.notFounds,
-            routeUnauthorizedModules: route.unauthorizeds,
-            statusCode,
-          })?.default ?? null;
-          const parentLayouts = route.layouts.slice(0, li);
-          return renderHTTPAccessFallbackPage(
-            route,
-            statusCode,
-            isRscRequest,
-            request,
-            {
-              boundaryComponent: parentBoundary,
-              layouts: parentLayouts,
-              matchedParams: params,
-            },
-            _scriptNonce,
-            // buildAppPageSpecialErrorResponse merges _mwCtx onto this returned
-            // fallback response; keep this inner boundary render unmerged so
-            // additive headers like Set-Cookie and Vary are not duplicated.
-            null,
-          );
-        },
-        requestUrl: request.url,
-        specialError: __layoutSpecialError,
-      });
-    },
-    async renderPageSpecialError(specialError) {
-      return __buildAppPageSpecialErrorResponse({
-        clearRequestContext() {
-          __clearRequestContext();
-        },
-        middlewareContext: _mwCtx,
-        renderFallbackPage(statusCode) {
-          return renderHTTPAccessFallbackPage(
-            route,
-            statusCode,
-            isRscRequest,
-            request,
-            {
-              matchedParams: params,
-            },
-            _scriptNonce,
-            // buildAppPageSpecialErrorResponse merges _mwCtx onto this returned
-            // fallback response; keep this inner boundary render unmerged so
-            // additive headers like Set-Cookie and Vary are not duplicated.
-            null,
-          );
-        },
-        requestUrl: request.url,
-        specialError,
-      });
+    renderHttpAccessFallbackPage(statusCode, opts, middlewareContext) {
+      return renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, opts, _scriptNonce, middlewareContext);
     },
     renderToReadableStream,
-    routeHasLocalBoundary: !!(route?.error?.default) || !!(route?.errors && route.errors.some(function(e) { return e?.default; })),
-    routePattern: route.pattern,
+    request,
+    revalidateSeconds: typeof route.page?.revalidate === "number" ? route.page.revalidate : null,
+    rootForbiddenModule,
+    rootNotFoundModule,
+    rootUnauthorizedModule,
+    route,
     runWithSuppressedHookWarning(probe) {
-      // Run inside ALS context so the module-level console.error patch suppresses
-      // "Invalid hook call" only for this request's probe — concurrent requests
-      // each have their own ALS store and are unaffected.
       return _suppressHookWarningAls.run(true, probe);
     },
-    scriptNonce: _scriptNonce,
-    waitUntil(__cachePromise) {
-      _getRequestExecutionContext()?.waitUntil(__cachePromise);
+    scheduleBackgroundRegeneration(key, renderFn, errorContext) {
+      __triggerBackgroundRegeneration(key, renderFn, errorContext);
     },
+    scriptNonce: _scriptNonce,
+    searchParams: url.searchParams,
+    setNavigationContext,
   });
 }
 

--- a/tests/app-page-dispatch.test.ts
+++ b/tests/app-page-dispatch.test.ts
@@ -1,0 +1,278 @@
+import React from "react";
+import { describe, expect, it, vi } from "vite-plus/test";
+import { dispatchAppPage } from "../packages/vinext/src/server/app-page-dispatch.js";
+import type { AppPageMiddlewareContext } from "../packages/vinext/src/server/app-page-response.js";
+import type { ISRCacheEntry } from "../packages/vinext/src/server/isr-cache.js";
+import type { CachedAppPageValue } from "../packages/vinext/src/shims/cache.js";
+
+type TestRoute = {
+  error?: { default?: unknown } | null;
+  errors?: readonly ({ default?: unknown } | null | undefined)[];
+  forbiddens?: readonly ({ default?: unknown } | null | undefined)[];
+  isDynamic: boolean;
+  layouts: readonly { default?: unknown }[];
+  layoutTreePositions?: readonly number[];
+  loading?: { default?: unknown } | null;
+  notFounds?: readonly ({ default?: unknown } | null | undefined)[];
+  params: readonly string[];
+  pattern: string;
+  routeSegments: readonly string[];
+  unauthorizeds?: readonly ({ default?: unknown } | null | undefined)[];
+};
+type DispatchOptions = Parameters<typeof dispatchAppPage<TestRoute>>[0];
+
+function createStream(chunks: string[]): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(new TextEncoder().encode(chunk));
+      }
+      controller.close();
+    },
+  });
+}
+
+function buildISRCacheEntry(value: CachedAppPageValue, isStale = false): ISRCacheEntry {
+  return {
+    isStale,
+    value: {
+      lastModified: Date.now(),
+      value,
+    },
+  };
+}
+
+function buildCachedAppPageValue(
+  html: string,
+  rscData?: ArrayBuffer,
+  status?: number,
+): CachedAppPageValue {
+  return {
+    kind: "APP_PAGE",
+    html,
+    rscData,
+    headers: undefined,
+    postponed: undefined,
+    status,
+  };
+}
+
+function createRoute(overrides: Partial<TestRoute> = {}): TestRoute {
+  return {
+    isDynamic: false,
+    layouts: [],
+    params: [],
+    pattern: "/posts/[slug]",
+    routeSegments: ["posts", "[slug]"],
+    ...overrides,
+  };
+}
+
+function createDispatchOptions(
+  overrides: {
+    buildPageElement?: DispatchOptions["buildPageElement"];
+    clearRequestContext?: DispatchOptions["clearRequestContext"];
+    generateStaticParams?: DispatchOptions["generateStaticParams"];
+    isProduction?: boolean;
+    isRscRequest?: boolean;
+    isrGet?: DispatchOptions["isrGet"];
+    middlewareContext?: AppPageMiddlewareContext;
+    renderToReadableStream?: DispatchOptions["renderToReadableStream"];
+    request?: Request;
+    revalidateSeconds?: number | null;
+    route?: TestRoute;
+    searchParams?: URLSearchParams;
+    setNavigationContext?: DispatchOptions["setNavigationContext"];
+  } = {},
+) {
+  const route = overrides.route ?? createRoute();
+  const buildPageElement =
+    overrides.buildPageElement ?? (async () => React.createElement("main", null, "page"));
+  const clearRequestContext = overrides.clearRequestContext ?? (() => {});
+  const isrGet = overrides.isrGet ?? (async () => null);
+  const setNavigationContext = overrides.setNavigationContext ?? (() => {});
+  const renderToReadableStream: DispatchOptions["renderToReadableStream"] =
+    overrides.renderToReadableStream ?? (() => createStream(["flight"]));
+  const options: DispatchOptions = {
+    buildPageElement,
+    cleanPathname: "/posts/hello",
+    clearRequestContext,
+    createRscOnErrorHandler() {
+      return () => null;
+    },
+    findIntercept() {
+      return null;
+    },
+    generateStaticParams: overrides.generateStaticParams ?? null,
+    getFontLinks() {
+      return [];
+    },
+    getFontPreloads() {
+      return [];
+    },
+    getFontStyles() {
+      return [];
+    },
+    getNavigationContext() {
+      return { pathname: "/posts/hello" };
+    },
+    getSourceRoute() {
+      return undefined;
+    },
+    hasGenerateStaticParams: typeof overrides.generateStaticParams === "function",
+    hasPageDefaultExport: true,
+    hasPageModule: true,
+    handlerStart: 10,
+    interceptionContext: null,
+    isProduction: overrides.isProduction ?? false,
+    isRscRequest: overrides.isRscRequest ?? false,
+    isrGet,
+    isrHtmlKey(pathname: string) {
+      return `html:${pathname}`;
+    },
+    isrRscKey(pathname: string, mountedSlotsHeader?: string | null) {
+      return mountedSlotsHeader ? `rsc:${pathname}:${mountedSlotsHeader}` : `rsc:${pathname}`;
+    },
+    isrSet: vi.fn(async () => {}),
+    async loadSsrHandler() {
+      return {
+        async handleSsr() {
+          return createStream(["<html>page</html>"]);
+        },
+      };
+    },
+    middlewareContext: overrides.middlewareContext ?? {
+      headers: null,
+      status: null,
+    },
+    params: { slug: "hello" },
+    probeLayoutAt() {
+      return null;
+    },
+    probePage() {
+      return null;
+    },
+    renderErrorBoundaryPage: vi.fn(async () => null),
+    renderHttpAccessFallbackPage: vi.fn(async () => null),
+    renderToReadableStream,
+    request: overrides.request ?? new Request("https://example.test/posts/hello"),
+    revalidateSeconds: overrides.revalidateSeconds ?? null,
+    route,
+    runWithSuppressedHookWarning<T>(probe: () => Promise<T>) {
+      return probe();
+    },
+    scheduleBackgroundRegeneration: vi.fn(),
+    searchParams: overrides.searchParams ?? new URLSearchParams(),
+    setNavigationContext,
+  };
+
+  return {
+    buildPageElement,
+    clearRequestContext,
+    isrGet,
+    route,
+    setNavigationContext,
+    options,
+  };
+}
+
+describe("app page dispatch", () => {
+  it("serves cached production HTML instead of revalidating params or rendering", async () => {
+    const { options } = createDispatchOptions({
+      async buildPageElement() {
+        throw new Error("cache hit should not render the page");
+      },
+      async generateStaticParams() {
+        throw new Error("cache hit should not validate static params");
+      },
+      isProduction: true,
+      isrGet: vi.fn(async () => buildISRCacheEntry(buildCachedAppPageValue("<html>cached</html>"))),
+      revalidateSeconds: 60,
+      route: createRoute({ isDynamic: true, params: ["slug"] }),
+    });
+
+    const response = await dispatchAppPage(options);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-vinext-cache")).toBe("HIT");
+    await expect(response.text()).resolves.toBe("<html>cached</html>");
+  });
+
+  it("returns method policy responses instead of rendering unsupported methods", async () => {
+    const { options } = createDispatchOptions({
+      async buildPageElement() {
+        throw new Error("unsupported methods should not render the page");
+      },
+      request: new Request("https://example.test/posts/hello", { method: "POST" }),
+    });
+
+    const response = await dispatchAppPage(options);
+
+    expect(response.status).toBe(405);
+    expect(response.headers.get("allow")).toBe("GET, HEAD");
+  });
+
+  it("returns not found for dynamicParams=false paths outside generated params", async () => {
+    const { options } = createDispatchOptions({
+      async buildPageElement() {
+        throw new Error("unknown static params should not render the page");
+      },
+      async generateStaticParams() {
+        return [{ slug: "known" }];
+      },
+      route: createRoute({ isDynamic: true, params: ["slug"] }),
+    });
+
+    const response = await dispatchAppPage({
+      ...options,
+      dynamicParamsConfig: false,
+    });
+
+    expect(response.status).toBe(404);
+    await expect(response.text()).resolves.toBe("Not Found");
+  });
+
+  it("serves intercepted RSC source-route payloads with middleware response state", async () => {
+    const sourceRoute = createRoute({ params: [], pattern: "/feed", routeSegments: ["feed"] });
+    const currentRoute = createRoute({ params: ["id"], pattern: "/photos/[id]" });
+    const middlewareHeaders = new Headers({ "x-from-middleware": "yes" });
+    const { options } = createDispatchOptions({
+      async buildPageElement(route, params, opts) {
+        return `${route.pattern}:${JSON.stringify(params)}:${opts?.interceptSlotKey ?? "direct"}`;
+      },
+      isRscRequest: true,
+      middlewareContext: {
+        headers: middlewareHeaders,
+        status: 202,
+      },
+      renderToReadableStream(element) {
+        if (typeof element !== "string") {
+          throw new Error("expected intercepted payload to be rendered from a string element");
+        }
+        return createStream([element]);
+      },
+      route: currentRoute,
+      searchParams: new URLSearchParams("from=feed"),
+    });
+
+    const response = await dispatchAppPage({
+      ...options,
+      findIntercept() {
+        return {
+          matchedParams: { id: "123" },
+          page: { default: "modal-page" },
+          slotKey: "modal@app/feed/@modal",
+          sourceRouteIndex: 1,
+        };
+      },
+      getSourceRoute(sourceRouteIndex) {
+        return sourceRouteIndex === 1 ? sourceRoute : undefined;
+      },
+    });
+
+    expect(response.status).toBe(202);
+    expect(response.headers.get("content-type")).toBe("text/x-component; charset=utf-8");
+    expect(response.headers.get("x-from-middleware")).toBe("yes");
+    await expect(response.text()).resolves.toBe("/feed:{}:modal@app/feed/@modal");
+  });
+});

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -3559,7 +3559,7 @@ describe("App Router next.config.js features (generateRscEntry)", () => {
     expect(code).toContain("module: middlewareModule");
   });
 
-  it("propagates middleware waitUntil promises to the Workers execution context", () => {
+  it("seeds the Workers execution context for shared middleware runtime", () => {
     const code = generateRscEntry(
       "/tmp/test/app",
       minimalRoutes,
@@ -3569,12 +3569,12 @@ describe("App Router next.config.js features (generateRscEntry)", () => {
       "",
       false,
     );
-    // drainWaitUntil() must be registered with the execution context so
-    // Workers keeps the isolate alive for background promises.
+    // Middleware waitUntil draining lives in the shared middleware runtime.
+    // The generated entry is responsible for seeding the per-request Workers
+    // execution context that shared runtime reads from.
     expect(code).toContain("_getRequestExecutionContext()");
-    expect(code).toContain("waitUntil");
-    // Must NOT discard the drainWaitUntil() return value
-    expect(code).not.toMatch(/^\s*mwFetchEvent\.drainWaitUntil\(\);$/m);
+    expect(code).toContain("executionContext: ctx ?? _getRequestExecutionContext() ?? null");
+    expect(code).toContain("const __mwResult = await __applyAppMiddleware({");
   });
 
   it("applies redirects before middleware in the handler", () => {
@@ -4584,20 +4584,19 @@ describe("generateRscEntry ISR code generation", () => {
     expect(code).not.toContain("const __pendingRegenerations = new Map()");
   });
 
-  it("generated code threads collected fetch tags into page ISR writes and delegates route ISR", () => {
+  it("generated code delegates page dispatch and route ISR separately", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes);
-    expect(code).toContain("getCollectedFetchTags");
-    expect(code).toContain(
-      'buildPageCacheTags(cleanPathname, [], route.routeSegments, route.routeHandler ? "route" : "page")',
-    );
+    expect(code).toContain("buildPageCacheTags");
+    expect(code).toContain('buildPageCacheTags(cleanPathname, [], route.routeSegments, "route")');
+    expect(code).toContain("dispatchAppPage as __dispatchAppPage");
+    expect(code).toContain("return __dispatchAppPage({");
     expect(code).toContain("dispatchAppRouteHandler as __dispatchAppRouteHandler");
     expect(code).toContain("return __dispatchAppRouteHandler({");
     expect(code).toContain("scheduleBackgroundRegeneration: __triggerBackgroundRegeneration");
-    expect(code).toContain(
-      'const __pageTags = buildPageCacheTags(cleanPathname, getCollectedFetchTags(), route.routeSegments, "page")',
-    );
     expect(code).toContain("isrSet: __isrSet");
+    expect(code).not.toContain("getCollectedFetchTags");
     expect(code).not.toContain("function __pageCacheTags(");
+    expect(code).not.toContain('route.routeHandler ? "route" : "page"');
   });
 
   it("generated handler exports async function handler(request, ctx)", () => {
@@ -4609,7 +4608,9 @@ describe("generateRscEntry ISR code generation", () => {
   it("generated code leaves cache handler access to the ISR cache module", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes);
     expect(code).not.toContain("getCacheHandler");
-    expect(code).toContain('"next/cache"');
+    expect(code).toContain("server/isr-cache.js");
+    expect(code).toContain("isrGet as __isrGet");
+    expect(code).toContain("isrSet as __isrSet");
   });
 
   it("generated code stores root layout params separately from leaf params", () => {
@@ -4660,53 +4661,26 @@ describe("generateRscEntry ISR code generation", () => {
     setRootParams(null);
   });
 
-  it("generated code delegates page response policy to typed helpers", () => {
+  it("generated code delegates app page dispatch to a typed helper", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes);
-    expect(code).toContain("renderAppPageLifecycle as __renderAppPageLifecycle");
-    expect(code).not.toContain("buildAppPageHtmlResponse as __buildAppPageHtmlResponse");
-    expect(code).not.toContain("buildAppPageRscResponse as __buildAppPageRscResponse");
-    expect(code).not.toContain(
-      "resolveAppPageHtmlResponsePolicy as __resolveAppPageHtmlResponsePolicy",
-    );
-    expect(code).not.toContain(
-      "resolveAppPageRscResponsePolicy as __resolveAppPageRscResponsePolicy",
-    );
-  });
-
-  it("generated code delegates page render lifecycle to a typed helper", () => {
-    const code = generateRscEntry("/tmp/test/app", minimalRoutes);
-    expect(code).toContain("renderAppPageLifecycle as __renderAppPageLifecycle");
-    expect(code).toContain("resolveAppPageSpecialError as __resolveAppPageSpecialError");
+    expect(code).toContain("dispatchAppPage as __dispatchAppPage");
+    expect(code).toContain("return __dispatchAppPage({");
     expect(code).toContain(
-      "buildAppPageSpecialErrorResponse as __buildAppPageSpecialErrorResponse",
+      "buildPageElement(targetRoute, targetParams, targetOpts, targetSearchParams)",
     );
-    expect(code).toContain("return __renderAppPageLifecycle({");
-  });
-
-  it("generated code handles SSR special errors without a legacy handleRenderError helper", () => {
-    const code = generateRscEntry("/tmp/test/app", minimalRoutes);
-    expect(code).toContain("renderErrorBoundaryResponse(renderErr) {");
-    expect(code).toContain("return renderErrorBoundaryPage(route, renderErr");
-    expect(code).not.toContain("handleRenderError(ssrErr)");
-  });
-
-  it("generated code delegates page HTML stream plumbing to typed helpers", () => {
-    const code = generateRscEntry("/tmp/test/app", minimalRoutes);
-    expect(code).toContain("renderAppPageLifecycle as __renderAppPageLifecycle");
+    expect(code).toContain("renderErrorBoundaryPage(renderErr) {");
+    expect(code).toContain("renderHttpAccessFallbackPage(statusCode, opts, middlewareContext) {");
     expect(code).toContain("getFontLinks: _getSSRFontLinks");
     expect(code).toContain("getFontPreloads: _getSSRFontPreloads");
     expect(code).toContain("getFontStyles: _getSSRFontStyles");
-    expect(code).toContain("getDraftModeCookieHeader");
-  });
-
-  it("generated code delegates page request orchestration to typed helpers", () => {
-    const code = generateRscEntry("/tmp/test/app", minimalRoutes);
-    expect(code).toContain("validateAppPageDynamicParams as __validateAppPageDynamicParams");
-    expect(code).toContain("resolveAppPageIntercept as __resolveAppPageIntercept");
-    expect(code).toContain("buildAppPageElement as __buildAppPageElement");
-    expect(code).toContain("const __dynamicParamsResponse = await __validateAppPageDynamicParams");
-    expect(code).toContain("const __interceptResult = await __resolveAppPageIntercept({");
-    expect(code).toContain("const __pageBuildResult = await __buildAppPageElement({");
+    expect(code).toContain("isrHtmlKey: __isrHtmlKey");
+    expect(code).toContain("isrRscKey: __isrRscKey");
+    expect(code).toContain("scheduleBackgroundRegeneration(key, renderFn, errorContext)");
+    expect(code).not.toContain("return __renderAppPageLifecycle({");
+    expect(code).not.toContain(
+      "const __dynamicParamsResponse = await __validateAppPageDynamicParams",
+    );
+    expect(code).not.toContain("const __pageBuildResult = await __buildAppPageElement");
   });
 
   it("generated code threads intercept layout modules through slot overrides", () => {
@@ -4813,116 +4787,16 @@ describe("generateRscEntry ISR code generation", () => {
     expect(code).toContain("return __renderAppPageErrorBoundary({");
   });
 
-  it("generated code threads middleware headers into page boundary and special-error responses", () => {
+  it("generated code threads middleware context into page dispatch and boundary rendering", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes);
 
     expect(code).toContain("const __APP_PAGE_EMPTY_MW_CTX = { headers: null, status: null };");
     expect(code).toContain("middlewareContext: middlewareContext ?? __APP_PAGE_EMPTY_MW_CTX");
     expect(code).toContain("middlewareContext: _mwCtx");
     expect(code).toContain("__mergeMiddlewareResponseHeaders(notFoundHeaders, _mwCtx.headers)");
-
-    const specialErrorStart = code.indexOf("renderSpecialError(__buildSpecialError)");
-    const specialErrorEnd = code.indexOf("resolveSpecialError:", specialErrorStart);
-    const specialErrorBody = code.slice(specialErrorStart, specialErrorEnd);
-    expect(specialErrorBody).toContain("middlewareContext: _mwCtx");
-    expect(specialErrorBody).toContain(
-      "additive headers like Set-Cookie and Vary are not duplicated.",
-    );
-    expect(specialErrorBody).toContain("null,");
-  });
-
-  it("generated code delegates page cache HIT handling to a typed helper", () => {
-    const code = generateRscEntry("/tmp/test/app", minimalRoutes);
-    expect(code).toContain("readAppPageCacheResponse as __readAppPageCacheResponse");
-    expect(code).toContain("await __readAppPageCacheResponse({");
-  });
-
-  it("generated code delegates page cache STALE handling to the same helper", () => {
-    const code = generateRscEntry("/tmp/test/app", minimalRoutes);
-    expect(code).toContain("readAppPageCacheResponse as __readAppPageCacheResponse");
-    expect(code).toContain("scheduleBackgroundRegeneration(key, renderFn) {");
-    expect(code).toContain('routerKind: "App Router"');
-    expect(code).toContain('routeType: "render"');
-    expect(code).toContain("renderFreshPageForCache: async function()");
-  });
-
-  it("generated code uses request execution context for background cache write", () => {
-    const code = generateRscEntry("/tmp/test/app", minimalRoutes);
-    expect(code).toContain("_getRequestExecutionContext()?.waitUntil");
-  });
-
-  it("generated code delegates live page rendering to the typed lifecycle helper", () => {
-    const code = generateRscEntry("/tmp/test/app", minimalRoutes);
-    expect(code).toContain("teeAppPageRscStreamForCapture as __teeAppPageRscStreamForCapture");
-    expect(code).toContain("readAppPageTextStream as __readAppPageTextStream");
-    expect(code).toContain("const __revalRscCapture = __teeAppPageRscStreamForCapture(");
-    expect(code).toContain("renderAppPageLifecycle as __renderAppPageLifecycle");
-  });
-
-  it("generated code stores rscData in the ISR cache entry", () => {
-    const code = generateRscEntry("/tmp/test/app", minimalRoutes);
-    expect(code).toContain("renderAppPageLifecycle as __renderAppPageLifecycle");
-    expect(code).toContain("getPageTags() {");
-    expect(code).toContain(
-      'return buildPageCacheTags(cleanPathname, getCollectedFetchTags(), route.routeSegments, "page")',
-    );
-    // Background regen still writes fresh RSC bytes directly.
-    expect(code).toContain("rscData: __freshRscData");
-  });
-
-  it("generated code threads page cache keys into the typed lifecycle helper", () => {
-    const code = generateRscEntry("/tmp/test/app", minimalRoutes);
-    expect(code).toContain("renderAppPageLifecycle as __renderAppPageLifecycle");
-    expect(code).toContain("isrHtmlKey: __isrHtmlKey");
-    expect(code).toContain("isrRscKey: __isrRscKey");
-  });
-
-  it("generated code treats html:'' partial entries as MISS for HTML requests", () => {
-    const code = generateRscEntry("/tmp/test/app", minimalRoutes);
-    // APP_PAGE ISR reads now flow through the typed page-cache helper.
-    expect(code).toContain("readAppPageCacheResponse as __readAppPageCacheResponse");
-    expect(code).toContain("await __readAppPageCacheResponse({");
-    expect(code).toContain("isrHtmlKey: __isrHtmlKey");
-    expect(code).toContain("isrRscKey: __isrRscKey");
-  });
-
-  it("generated code serves cached rscData for RSC requests on HIT", () => {
-    const code = generateRscEntry("/tmp/test/app", minimalRoutes);
-    // The helper receives the request type so it can serve cached RSC responses.
-    expect(code).toContain("readAppPageCacheResponse as __readAppPageCacheResponse");
-    expect(code).toContain("isRscRequest,");
-  });
-
-  it("ISR cache read fires before buildPageElement (early return on HIT)", () => {
-    const code = generateRscEntry("/tmp/test/app", minimalRoutes);
-    // The page-cache helper call must appear before the typed page-build helper
-    // so cache hits still short-circuit before the page render path starts.
-    const isrReadIdx = code.indexOf("await __readAppPageCacheResponse(");
-    const buildPageIdx = code.indexOf("const __pageBuildResult = await __buildAppPageElement");
-    expect(isrReadIdx).toBeGreaterThan(-1);
-    expect(buildPageIdx).toBeGreaterThan(-1);
-    expect(isrReadIdx).toBeLessThan(buildPageIdx);
-  });
-
-  it("ISR cache read fires before generateStaticParams (skips expensive work on HIT)", () => {
-    const code = generateRscEntry("/tmp/test/app", minimalRoutes);
-    // The page-cache helper call must appear before the dynamic params validation helper
-    // so cache hits skip the generateStaticParams path entirely.
-    const isrReadIdx = code.indexOf("await __readAppPageCacheResponse(");
-    const gspIdx = code.indexOf(
-      "const __dynamicParamsResponse = await __validateAppPageDynamicParams",
-    );
-    expect(isrReadIdx).toBeGreaterThan(-1);
-    expect(gspIdx).toBeGreaterThan(-1);
-    expect(isrReadIdx).toBeLessThan(gspIdx);
-  });
-
-  it("generated code delegates two-phase page cache logic to the typed lifecycle helper", () => {
-    const code = generateRscEntry("/tmp/test/app", minimalRoutes);
-    expect(code).toContain("renderAppPageLifecycle as __renderAppPageLifecycle");
-    expect(code).toContain("consumeDynamicUsage,");
-    expect(code).toContain("getRequestCacheLife() {");
-    expect(code).toContain("return _consumeRequestScopedCacheLife()");
+    expect(code).toContain("renderHTTPAccessFallbackPage(route, statusCode");
+    expect(code).toContain("return renderErrorBoundaryPage(route, renderErr");
+    expect(code).not.toContain("renderSpecialError(__buildSpecialError)");
   });
 
   // Route handler ISR code generation tests
@@ -4953,17 +4827,11 @@ describe("generateRscEntry ISR code generation", () => {
 
   it("generated code merges middleware headers into intercept route responses", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes);
-    // The renderInterceptResponse callback must call mergeMiddlewareResponseHeaders
-    // to apply middleware headers (auth cookies, CORS, security headers) to
-    // intercepting route RSC responses.
-    expect(code).toContain("mergeMiddlewareResponseHeaders");
-    // The call must appear between renderInterceptResponse and searchParams
-    // (the next callback in the options object), ensuring it's inside the
-    // intercept response construction path.
-    const interceptStart = code.indexOf("renderInterceptResponse(sourceRoute, interceptElement)");
-    const interceptEnd = code.indexOf("searchParams:", interceptStart);
-    const interceptBody = code.slice(interceptStart, interceptEnd);
-    expect(interceptBody).toContain("mergeMiddlewareResponseHeaders");
+    // Intercept response construction now lives in app-page-dispatch; generated
+    // code passes the middleware response state into that helper.
+    expect(code).toContain("return __dispatchAppPage({");
+    expect(code).toContain("middlewareContext: _mwCtx");
+    expect(code).not.toContain("renderInterceptResponse(sourceRoute, interceptElement)");
   });
 
   it("generated code merges middleware headers into server action re-render responses", () => {

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -537,6 +537,20 @@ describe("App Router entry templates", () => {
     expect(code).not.toContain("const __actionRerenderTarget =");
   });
 
+  it("generateRscEntry delegates app page dispatch to the shared helper", () => {
+    const code = generateRscEntry("/tmp/test/app", minimalAppRoutes, null, [], null, "", false);
+    const stableCode = stabilize(code);
+
+    expect(stableCode).toContain('from "<ROOT>/packages/vinext/src/server/app-page-dispatch.js";');
+    expect(code).toContain("dispatchAppPage as __dispatchAppPage");
+    expect(code).toContain("return __dispatchAppPage({");
+    expect(code).not.toContain(
+      "const __dynamicParamsResponse = await __validateAppPageDynamicParams",
+    );
+    expect(code).not.toContain("const __pageBuildResult = await __buildAppPageElement");
+    expect(code).not.toContain("return __renderAppPageLifecycle({");
+  });
+
   it("generateRscEntry reuses the canonical tree-path helper for no-export page payloads", () => {
     const code = generateRscEntry("/tmp/test/app", minimalAppRoutes, null, [], null, "", false);
 


### PR DESCRIPTION
## What changed

This extracts App Router page request orchestration out of the generated RSC entry and into `packages/vinext/src/server/app-page-dispatch.ts`.

The generated entry now describes app shape and request wiring only: matched route, params, component tree builder, boundary render callbacks, middleware context, cache keys, and module loaders. The normal runtime module owns behavior: method policy, force-static/error setup, ISR cache read/regeneration, dynamic params validation, intercepting route responses, page element build error handling, lifecycle render delegation, and special-error fallback routing.

## Why

This follows the principle that codegen should describe the app shape while normal modules implement behavior. The prior generated template mixed route-specific imports with a large page dispatch pipeline, which made orchestration harder to type, test, review, and evolve independently from route manifest generation.

## Behavior tests

Added `tests/app-page-dispatch.test.ts` with response-level behavior coverage for the new dispatch module:

- production page cache HIT serves cached HTML instead of revalidating params or rendering
- unsupported page methods return the method policy response instead of rendering
- `dynamicParams = false` returns 404 for paths outside generated params
- intercepted RSC source-route payloads preserve middleware status and headers

These tests assert HTTP-visible outcomes: status, headers, and response body. They avoid asserting dispatch call counts or generated implementation details.

## Next.js references

Next.js uses a similar separation between generated app-page shape and runtime page rendering modules:

- [App page build template creates an `AppPageRouteModule`](https://github.com/vercel/next.js/blob/ae61573e062e900050b8e6b24626e450accc4570/packages/next/src/build/templates/app-page.ts#L127)
- [Generated app-page template delegates into a render closure rather than owning all renderer internals](https://github.com/vercel/next.js/blob/ae61573e062e900050b8e6b24626e450accc4570/packages/next/src/build/templates/app-page.ts#L771)
- [`AppPageRouteModule` is the runtime module boundary for app page rendering](https://github.com/vercel/next.js/blob/ae61573e062e900050b8e6b24626e450accc4570/packages/next/src/server/route-modules/app-page/module.ts#L85)
- [`AppPageRouteModule.render()` delegates to `renderToHTMLOrFlight`](https://github.com/vercel/next.js/blob/ae61573e062e900050b8e6b24626e450accc4570/packages/next/src/server/route-modules/app-page/module.ts#L155)
- [`renderToHTMLOrFlightImpl` owns the app render orchestration](https://github.com/vercel/next.js/blob/ae61573e062e900050b8e6b24626e450accc4570/packages/next/src/server/app-render/app-render.tsx#L2568)
- [`renderToHTMLOrFlight` exposes the stable runtime entrypoint](https://github.com/vercel/next.js/blob/ae61573e062e900050b8e6b24626e450accc4570/packages/next/src/server/app-render/app-render.tsx#L3077)

## Validation

- `vp check --fix knip.ts packages/vinext/src/entries/app-rsc-entry.ts packages/vinext/src/server/app-page-dispatch.ts packages/vinext/src/server/app-page-request.ts tests/app-page-dispatch.test.ts tests/app-router.test.ts tests/entry-templates.test.ts tests/__snapshots__/entry-templates.test.ts.snap`
- `vp test run tests/app-page-dispatch.test.ts`
- `vp test run tests/app-page-dispatch.test.ts tests/entry-templates.test.ts tests/app-router.test.ts tests/app-page-render.test.ts tests/app-page-request.test.ts tests/app-page-cache.test.ts`
- `vp run knip --no-progress`
- Commit hook reran staged-file checks and Knip successfully.

## Risk coverage

Covered the main behavioral risks through dedicated dispatch behavior tests plus the App Router integration suite: dev/prod App Router rendering, RSC/HTML responses, ISR cache reads and writes, route handler separation, middleware header propagation, dynamic params validation, intercepting routes, not-found/forbidden/unauthorized boundaries, and generated-entry delegation assertions.

The generated-code tests intentionally assert only the delegation contract now. Runtime dispatch behavior is covered by `tests/app-page-dispatch.test.ts`, existing helper tests, and the App Router integration suite.
