### PR TITLE
fix(routing): omit empty optional catch-all params

### DIFF
--- a/packages/vinext/src/routing/route-trie.ts
+++ b/packages/vinext/src/routing/route-trie.ts
@@ -133,6 +133,10 @@ export function trieMatch<R>(
   return match(root, urlParts, 0);
 }
 
+function createParams(): Record<string, string | string[]> {
+  return Object.create(null);
+}
+
 function match<R>(
   node: TrieNode<R>,
   urlParts: string[],
@@ -142,14 +146,15 @@ function match<R>(
   if (index === urlParts.length) {
     // Exact match at this node
     if (node.route !== null) {
-      return { route: node.route, params: Object.create(null) };
+      return { route: node.route, params: createParams() };
     }
 
     // Optional catch-all with 0 segments
     if (node.optionalCatchAllChild !== null) {
-      const params: Record<string, string | string[]> = Object.create(null);
-      params[node.optionalCatchAllChild.paramName] = [];
-      return { route: node.optionalCatchAllChild.route, params };
+      return {
+        route: node.optionalCatchAllChild.route,
+        params: createParams(),
+      };
     }
 
     return null;
@@ -178,7 +183,7 @@ function match<R>(
   // 3. Try catch-all (1+ remaining segments)
   if (node.catchAllChild !== null) {
     const remaining = urlParts.slice(index);
-    const params: Record<string, string | string[]> = Object.create(null);
+    const params = createParams();
     params[node.catchAllChild.paramName] = remaining;
     return { route: node.catchAllChild.route, params };
   }
@@ -186,7 +191,7 @@ function match<R>(
   // 4. Try optional catch-all (0+ remaining segments)
   if (node.optionalCatchAllChild !== null) {
     const remaining = urlParts.slice(index);
-    const params: Record<string, string | string[]> = Object.create(null);
+    const params = createParams();
     params[node.optionalCatchAllChild.paramName] = remaining;
     return { route: node.optionalCatchAllChild.route, params };
   }

--- a/packages/vinext/src/server/app-rsc-route-matching.ts
+++ b/packages/vinext/src/server/app-rsc-route-matching.ts
@@ -32,6 +32,10 @@ type AppRscInterceptLookupEntry = {
   params: readonly string[];
 };
 
+function createRouteParams(): AppRscRouteParams {
+  return Object.create(null);
+}
+
 export function createAppRscRouteMatcher<Route extends AppRscRouteForMatching>(
   routes: Route[],
 ): {
@@ -55,7 +59,7 @@ export function createAppRscRouteMatcher<Route extends AppRscRouteForMatching>(
       for (const entry of interceptLookup) {
         const params = matchAppRscRoutePattern(urlParts, entry.targetPatternParts);
         if (params !== null) {
-          let sourceParams: AppRscRouteParams = Object.create(null);
+          let sourceParams = createRouteParams();
           if (sourcePathname !== null) {
             const sourceRoute = routes[entry.sourceRouteIndex];
             const sourceParts = sourcePathname.split("/").filter(Boolean);
@@ -103,7 +107,7 @@ export function matchAppRscRoutePattern(
   urlParts: string[],
   patternParts: string[],
 ): AppRscRouteParams | null {
-  const params: AppRscRouteParams = Object.create(null);
+  const params = createRouteParams();
   for (let i = 0; i < patternParts.length; i++) {
     const patternPart = patternParts[i];
     if (patternPart.startsWith(":") && patternPart.endsWith("+")) {
@@ -117,7 +121,10 @@ export function matchAppRscRoutePattern(
     if (patternPart.startsWith(":") && patternPart.endsWith("*")) {
       if (i !== patternParts.length - 1) return null;
       const paramName = patternPart.slice(1, -1);
-      params[paramName] = urlParts.slice(i);
+      const remaining = urlParts.slice(i);
+      if (remaining.length > 0) {
+        params[paramName] = remaining;
+      }
       return params;
     }
     if (patternPart.startsWith(":")) {
@@ -135,5 +142,5 @@ function mergeMatchedParams(
   sourceParams: AppRscRouteParams,
   targetParams: AppRscRouteParams,
 ): AppRscRouteParams {
-  return Object.assign(Object.create(null), sourceParams, targetParams);
+  return Object.assign(createRouteParams(), sourceParams, targetParams);
 }

--- a/tests/app-rsc-route-matching.test.ts
+++ b/tests/app-rsc-route-matching.test.ts
@@ -22,9 +22,30 @@ describe("App RSC route matching", () => {
       route: { pattern: "/docs/:path+" },
       params: { path: ["guides", "rsc"] },
     });
-    expect(matcher.matchRoute("/shop")).toMatchObject({
-      route: { pattern: "/shop/:path*" },
-      params: { path: [] },
+    const result = matcher.matchRoute("/shop");
+    expect(result).not.toBeNull();
+    expect(result!.route.pattern).toBe("/shop/:path*");
+    expect(result!.params).toEqual({});
+  });
+
+  it("omits optional catch-all params when zero segments are matched", () => {
+    // Next.js represents a missing optional catch-all param as absent at the
+    // route-match boundary; app rendering later treats that as the `null`
+    // tree segment for optional catch-all.
+    // https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/router/utils/route-matcher.ts
+    // https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/router/utils/get-dynamic-param.test.ts
+    const matcher = createAppRscRouteMatcher([route("/shop/:path*", ["shop", ":path*"])]);
+
+    const result = matcher.matchRoute("/shop");
+    expect(result).not.toBeNull();
+    expect(result!.route.pattern).toBe("/shop/:path*");
+    expect(result!.params).toEqual({});
+  });
+
+  it("omits optional catch-all params from standalone route pattern matches", () => {
+    expect(matchAppRscRoutePattern(["shop"], ["shop", ":path*"])).toEqual({});
+    expect(matchAppRscRoutePattern(["shop", "a", "b"], ["shop", ":path*"])).toEqual({
+      path: ["a", "b"],
     });
   });
 

--- a/tests/route-trie.test.ts
+++ b/tests/route-trie.test.ts
@@ -115,13 +115,17 @@ describe("buildRouteTrie + trieMatch", () => {
   });
 
   describe("optional catch-all routes", () => {
-    it("matches optional catch-all with zero segments", () => {
+    it("matches optional catch-all with zero segments without materializing the param", () => {
+      // Next.js route-regex makes the optional catch-all capture group optional, and
+      // route-matcher only writes params for defined capture groups:
+      // https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/router/utils/route-regex.ts
+      // https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/router/utils/route-matcher.ts
       const routes = [r("/docs/:path*")];
       const trie = buildRouteTrie(routes);
 
       const result = trieMatch(trie, ["docs"]);
       expect(result).not.toBeNull();
-      expect(result!.params).toEqual({ path: [] });
+      expect(result!.params).toEqual({});
     });
 
     it("matches optional catch-all with one segment", () => {
@@ -140,6 +144,16 @@ describe("buildRouteTrie + trieMatch", () => {
       const result = trieMatch(trie, ["docs", "api", "ref"]);
       expect(result).not.toBeNull();
       expect(result!.params).toEqual({ path: ["api", "ref"] });
+    });
+
+    it("matches root-level optional catch-all with zero segments without materializing the param", () => {
+      const routes = [r("/:path*")];
+      const trie = buildRouteTrie(routes);
+
+      const result = trieMatch(trie, []);
+      expect(result).not.toBeNull();
+      expect(result!.route.pattern).toBe("/:path*");
+      expect(result!.params).toEqual({});
     });
   });
 
@@ -280,7 +294,10 @@ describe("buildRouteTrie + trieMatch", () => {
         if (pp.endsWith("*")) {
           if (i !== patternParts.length - 1) return null;
           const paramName = pp.slice(1, -1);
-          params[paramName] = urlParts.slice(i);
+          const remaining = urlParts.slice(i);
+          if (remaining.length > 0) {
+            params[paramName] = remaining;
+          }
           return params;
         }
         if (pp.startsWith(":")) {

--- a/tests/routing.test.ts
+++ b/tests/routing.test.ts
@@ -984,7 +984,7 @@ describe("matchAppRoute - URL matching", () => {
     const result = matchAppRoute("/optional", routes);
     expect(result).not.toBeNull();
     expect(result!.route.pattern).toBe("/optional/:path*");
-    expect(result!.params.path).toEqual([]);
+    expect(result!.params).not.toHaveProperty("path");
   });
 
   it("matches optional catch-all with multiple segments", async () => {
@@ -1518,7 +1518,7 @@ describe("matchAppRoute - URL matching", () => {
     const result = matchAppRoute("/sign-in", routes);
     expect(result).not.toBeNull();
     expect(result!.route.pattern).toBe("/sign-in/:sign-in*");
-    expect(result!.params["sign-in"]).toEqual([]);
+    expect(result!.params).not.toHaveProperty("sign-in");
   });
 
   it("matches hyphenated optional catch-all with segments", async () => {
@@ -1666,7 +1666,7 @@ describe("pagesRouter - hyphenated param names", () => {
     const result = matchRoute("/sign-up", routes);
     expect(result).not.toBeNull();
     expect(result!.route.pattern).toBe("/sign-up/:sign-up*");
-    expect(result!.params["sign-up"]).toEqual([]);
+    expect(result!.params).not.toHaveProperty("sign-up");
   });
 
   it("matches hyphenated optional catch-all with segments", async () => {


### PR DESCRIPTION
## What this changes
Optional catch-all routes now omit the param key when the route matches with zero remaining segments. For example, `/shop` matching `/shop/[[...path]]` now produces `{}` instead of `{ path: [] }`, while `/shop/a/b` still produces `{ path: ["a", "b"] }`.

## Why
Next.js treats the zero-segment optional catch-all case as a missing capture, not as an empty captured array. The relevant source path is:

- [`route-regex.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/router/utils/route-regex.ts#L120) emits an optional repeated capture for optional catch-all params.
- [`route-matcher.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/router/utils/route-matcher.ts#L33-L42) only writes a param when the regex capture is defined.
- [`get-dynamic-param.test.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/router/utils/get-dynamic-param.test.ts#L159-L167) covers the downstream app-router interpretation of an absent optional catch-all param as a `null` tree segment.

vinext's route trie instead materialized the zero-segment optional catch-all as `[]`, which made app/pages route params observably diverge from Next.js.

## Approach
The fix keeps app shape in codegen and behavior in normal modules:

- Update the shared route trie so the zero-segment optional catch-all branch returns an empty params object while non-empty optional catch-all matches still assign the remaining segment array.
- Apply the same absent-key semantics to standalone app RSC pattern matching used outside the route trie.
- Add regression coverage at the trie boundary, the app RSC matcher boundary, and the pages/app route fixture boundary, including hyphenated param names.

## Validation
- `vp test run tests/route-trie.test.ts tests/app-rsc-route-matching.test.ts tests/routing.test.ts`
- `vp test run tests/pages-router.test.ts tests/app-router.test.ts -t "optional catch-all"`
- `vp check packages/vinext/src/routing/route-trie.ts packages/vinext/src/server/app-rsc-route-matching.ts tests/route-trie.test.ts tests/app-rsc-route-matching.test.ts tests/routing.test.ts`

## Risks / follow-ups
This is a compatibility change for the zero-segment optional catch-all params shape. Code that depended on vinext's previous `[]` value for missing optional catch-all params will need to use the same `params.slug ?? []` pattern that works in Next.js.
