### PR TITLE
fix(app-router): validate RSC cache-busting params

### DIFF
--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -78,6 +78,7 @@ import {
 import {
   createRscRequestHeaders,
   createRscRequestUrl,
+  stripRscCacheBustingSearchParam,
   VINEXT_RSC_CONTENT_TYPE,
   VINEXT_RSC_MOUNTED_SLOTS_HEADER,
 } from "./app-rsc-cache-busting.js";
@@ -1039,6 +1040,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
           let hardNavTarget = currentHref;
           if (responseUrl) {
             const parsed = new URL(responseUrl, window.location.origin);
+            stripRscCacheBustingSearchParam(parsed);
             const origUrl = new URL(currentHref, window.location.origin);
             let pathname = parsed.pathname.replace(/\.rsc$/, "");
             // toRscUrl strips trailing slash before appending .rsc, so the
@@ -1063,6 +1065,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
         }
 
         const finalUrl = new URL(navResponseUrl ?? navResponse.url, window.location.origin);
+        stripRscCacheBustingSearchParam(finalUrl);
         const requestedUrl = new URL(rscUrl, window.location.origin);
 
         if (finalUrl.pathname !== requestedUrl.pathname) {

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -31,7 +31,6 @@ import {
   snapshotRscResponse,
   setMountedSlotsHeader,
   setNavigationContext,
-  toRscUrl,
   type CachedRscResponse,
   type ClientNavigationRenderSnapshot,
 } from "vinext/shims/navigation";
@@ -76,6 +75,12 @@ import {
   getServerActionNotFoundClientMessage,
   isServerActionNotFoundResponse,
 } from "./server-action-not-found.js";
+import {
+  createRscRequestHeaders,
+  createRscRequestUrl,
+  VINEXT_RSC_CONTENT_TYPE,
+  VINEXT_RSC_MOUNTED_SLOTS_HEADER,
+} from "./app-rsc-cache-busting.js";
 
 type SearchParamInput = ConstructorParameters<typeof URLSearchParams>[0];
 
@@ -390,14 +395,6 @@ function getRequestState(
   }
 }
 
-function createRscRequestHeaders(interceptionContext: string | null): Headers {
-  const headers = new Headers({ Accept: "text/x-component" });
-  if (interceptionContext !== null) {
-    headers.set("X-Vinext-Interception-Context", interceptionContext);
-  }
-  return headers;
-}
-
 // Dev-only callback invoked when DevRecoveryBoundary catches. The replaced
 // subtree means NavigationCommitSignal's useLayoutEffect never fires, so the
 // URL update for the in-flight navigation would otherwise be lost. Force-drain
@@ -696,7 +693,11 @@ async function readInitialRscStream(): Promise<ReadableStream<Uint8Array> | null
     return createProgressiveRscStream();
   }
 
-  const rscResponse = await fetch(toRscUrl(window.location.pathname + window.location.search));
+  const rscHeaders = createRscRequestHeaders();
+  const rscResponse = await fetch(
+    await createRscRequestUrl(window.location.pathname + window.location.search, rscHeaders),
+    { credentials: "include", headers: rscHeaders },
+  );
 
   if (!rscResponse.ok) {
     return recoverFromBadInitialRscResponse(`returned ${rscResponse.status}`);
@@ -706,7 +707,7 @@ async function readInitialRscStream(): Promise<ReadableStream<Uint8Array> | null
   // parsed as RSC and would throw the same opaque parse error this fallback
   // exists to prevent.
   const contentType = rscResponse.headers.get("content-type") ?? "";
-  if (!contentType.startsWith("text/x-component")) {
+  if (!contentType.startsWith(VINEXT_RSC_CONTENT_TYPE)) {
     return recoverFromBadInitialRscResponse(
       `returned non-RSC content-type "${contentType || "(missing)"}"`,
     );
@@ -755,11 +756,14 @@ function registerServerActionCallback(): void {
       previousNextUrl: currentState.previousNextUrl,
     });
 
-    const fetchResponse = await fetch(toRscUrl(window.location.pathname + window.location.search), {
-      method: "POST",
-      headers,
-      body,
-    });
+    const fetchResponse = await fetch(
+      await createRscRequestUrl(window.location.pathname + window.location.search, headers),
+      {
+        method: "POST",
+        headers,
+        body,
+      },
+    );
 
     if (isServerActionNotFoundResponse(fetchResponse)) {
       throw new Error(getServerActionNotFoundClientMessage(id));
@@ -910,7 +914,6 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
         }
 
         const url = new URL(currentHref, window.location.origin);
-        const rscUrl = toRscUrl(url.pathname + url.search);
         const requestState = getRequestState(navigationKind, currentPrevNextUrl);
         const requestInterceptionContext = requestState.interceptionContext;
         const requestPreviousNextUrl = requestState.previousNextUrl;
@@ -932,6 +935,13 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
 
         const elementsAtNavStart = getBrowserRouterState().elements;
         const mountedSlotsHeader = getMountedSlotIdsHeader(elementsAtNavStart);
+        const requestHeaders = createRscRequestHeaders({
+          interceptionContext: requestInterceptionContext,
+        });
+        if (mountedSlotsHeader) {
+          requestHeaders.set(VINEXT_RSC_MOUNTED_SLOTS_HEADER, mountedSlotsHeader);
+        }
+        const rscUrl = await createRscRequestUrl(url.pathname + url.search, requestHeaders);
         const cachedRoute = getVisitedResponse(
           rscUrl,
           requestInterceptionContext,
@@ -995,10 +1005,6 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
         }
 
         if (!navResponse) {
-          const requestHeaders = createRscRequestHeaders(requestInterceptionContext);
-          if (mountedSlotsHeader) {
-            requestHeaders.set("X-Vinext-Mounted-Slots", mountedSlotsHeader);
-          }
           navResponse = await fetch(rscUrl, {
             headers: requestHeaders,
             credentials: "include",
@@ -1218,10 +1224,17 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
         // Interception context on HMR re-renders is intentionally deferred:
         // preserving intercepted modal state across HMR reloads is out of scope
         // for the previousNextUrl mechanism.
+        const hmrHeaders = createRscRequestHeaders();
         await browserNavigationController.hmrReplaceTree(
           normalizeAppElementsPromise(
             createFromFetch<AppWireElements>(
-              fetch(toRscUrl(window.location.pathname + window.location.search)),
+              fetch(
+                await createRscRequestUrl(
+                  window.location.pathname + window.location.search,
+                  hmrHeaders,
+                ),
+                { headers: hmrHeaders },
+              ),
             ),
           ),
           navigationSnapshot,

--- a/packages/vinext/src/server/app-browser-state.ts
+++ b/packages/vinext/src/server/app-browser-state.ts
@@ -6,6 +6,7 @@ import {
   type AppElements,
   type LayoutFlags,
 } from "./app-elements.js";
+import { createRscRequestHeaders } from "./app-rsc-cache-busting.js";
 import type { ClientNavigationRenderSnapshot } from "vinext/shims/navigation";
 
 const VINEXT_PREVIOUS_NEXT_URL_HISTORY_STATE_KEY = "__vinext_previousNextUrl";
@@ -120,10 +121,8 @@ type ResolveServerActionRequestStateResult = {
 export function resolveServerActionRequestState(
   options: ResolveServerActionRequestStateOptions,
 ): ResolveServerActionRequestStateResult {
-  const headers = new Headers({
-    Accept: "text/x-component",
-    "x-rsc-action": options.actionId,
-  });
+  const headers = createRscRequestHeaders();
+  headers.set("x-rsc-action", options.actionId);
 
   const interceptionContext = resolveInterceptionContextFromPreviousNextUrl(
     options.previousNextUrl,

--- a/packages/vinext/src/server/app-page-boundary.ts
+++ b/packages/vinext/src/server/app-page-boundary.ts
@@ -1,4 +1,5 @@
 import { mergeMiddlewareResponseHeaders } from "./middleware-response-headers.js";
+import { VINEXT_RSC_VARY_HEADER } from "./app-rsc-cache-busting.js";
 import { resolveAppPageSegmentParams } from "./app-page-params.js";
 
 export type AppPageParams = Record<string, string | string[]>;
@@ -226,7 +227,7 @@ export async function renderAppPageBoundaryResponse<TElement>(
     // their ALS-backed state while the stream is being read.
     const headers = new Headers({
       "Content-Type": "text/x-component; charset=utf-8",
-      Vary: "RSC, Accept",
+      Vary: VINEXT_RSC_VARY_HEADER,
     });
     mergeMiddlewareResponseHeaders(headers, options.middlewareHeaders ?? null);
 

--- a/packages/vinext/src/server/app-page-cache.ts
+++ b/packages/vinext/src/server/app-page-cache.ts
@@ -1,4 +1,5 @@
 import type { CachedAppPageValue, CacheControlMetadata } from "vinext/shims/cache";
+import { VINEXT_RSC_VARY_HEADER } from "./app-rsc-cache-busting.js";
 import { buildCachedRevalidateCacheControl } from "./cache-control.js";
 import { buildAppPageCacheValue, type ISRCacheEntry } from "./isr-cache.js";
 
@@ -157,7 +158,7 @@ export function buildAppPageCachedResponse(
       : (options.cacheControl.expire ?? options.expireSeconds);
   const headers = {
     "Cache-Control": buildAppPageCacheControl(options.cacheState, revalidateSeconds, expireSeconds),
-    Vary: "RSC, Accept",
+    Vary: VINEXT_RSC_VARY_HEADER,
     "X-Vinext-Cache": options.cacheState,
   };
 

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -618,6 +618,7 @@ async function renderLayoutSpecialError<TRoute extends AppPageDispatchRoute>(
 ): Promise<Response> {
   return buildAppPageSpecialErrorResponse({
     clearRequestContext: options.clearRequestContext,
+    isRscRequest: options.isRscRequest,
     middlewareContext: options.middlewareContext,
     renderFallbackPage(statusCode) {
       const parentBoundary = resolveAppPageParentHttpAccessBoundaryModule({
@@ -640,7 +641,7 @@ async function renderLayoutSpecialError<TRoute extends AppPageDispatchRoute>(
         null,
       );
     },
-    requestUrl: options.request.url,
+    request: options.request,
     specialError,
   });
 }
@@ -651,6 +652,7 @@ async function renderPageSpecialError<TRoute extends AppPageDispatchRoute>(
 ): Promise<Response> {
   return buildAppPageSpecialErrorResponse({
     clearRequestContext: options.clearRequestContext,
+    isRscRequest: options.isRscRequest,
     middlewareContext: options.middlewareContext,
     renderFallbackPage(statusCode) {
       return options.renderHttpAccessFallbackPage(
@@ -659,7 +661,7 @@ async function renderPageSpecialError<TRoute extends AppPageDispatchRoute>(
         null,
       );
     },
-    requestUrl: options.request.url,
+    request: options.request,
     specialError,
   });
 }

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -45,6 +45,7 @@ import {
   mergeMiddlewareResponseHeaders,
   type AppPageMiddlewareContext,
 } from "./app-page-response.js";
+import { VINEXT_RSC_VARY_HEADER } from "./app-rsc-cache-busting.js";
 import { createAppPageTreePath } from "./app-page-route-wiring.js";
 import type { AppPageSsrHandler } from "./app-page-stream.js";
 import { createStaticGenerationHeadersContext } from "./app-static-generation.js";
@@ -479,7 +480,7 @@ export async function dispatchAppPage<TRoute extends AppPageDispatchRoute>(
       });
       const interceptHeaders = new Headers({
         "Content-Type": "text/x-component; charset=utf-8",
-        Vary: "RSC, Accept",
+        Vary: VINEXT_RSC_VARY_HEADER,
       });
       mergeMiddlewareResponseHeaders(interceptHeaders, options.middlewareContext.headers);
       return new Response(interceptStream, {

--- a/packages/vinext/src/server/app-page-execution.ts
+++ b/packages/vinext/src/server/app-page-execution.ts
@@ -1,5 +1,6 @@
 import type { LayoutFlags } from "./app-elements.js";
 import type { ClassificationReason } from "../build/layout-classification-types.js";
+import { createRscRedirectLocation } from "./app-rsc-cache-busting.js";
 import { mergeMiddlewareResponseHeaders } from "./middleware-response-headers.js";
 
 export type { LayoutFlags };
@@ -23,9 +24,10 @@ type AppPageRscStreamCapture = {
 
 type BuildAppPageSpecialErrorResponseOptions = {
   clearRequestContext: () => void;
+  isRscRequest: boolean;
   middlewareContext?: { headers: Headers | null };
   renderFallbackPage?: (statusCode: number) => Promise<Response | null>;
-  requestUrl: string;
+  request: Request;
   specialError: AppPageSpecialError;
 };
 
@@ -133,8 +135,11 @@ export async function buildAppPageSpecialErrorResponse(
 ): Promise<Response> {
   if (options.specialError.kind === "redirect") {
     options.clearRequestContext();
+    const location = options.isRscRequest
+      ? await createRscRedirectLocation(options.specialError.location, options.request)
+      : new URL(options.specialError.location, options.request.url).toString();
     const headers = new Headers({
-      Location: new URL(options.specialError.location, options.requestUrl).toString(),
+      Location: location,
     });
     // Middleware may contribute response headers here, but redirect() owns the
     // status. Do not apply middlewareContext.status on special-error responses.

--- a/packages/vinext/src/server/app-page-response.ts
+++ b/packages/vinext/src/server/app-page-response.ts
@@ -4,6 +4,7 @@ import {
   STATIC_CACHE_CONTROL,
 } from "./cache-control.js";
 import { mergeMiddlewareResponseHeaders } from "./middleware-response-headers.js";
+import { VINEXT_RSC_VARY_HEADER } from "./app-rsc-cache-busting.js";
 
 export type AppPageMiddlewareContext = {
   headers: Headers | null;
@@ -191,7 +192,7 @@ export function buildAppPageRscResponse(
 ): Response {
   const headers = new Headers({
     "Content-Type": "text/x-component; charset=utf-8",
-    Vary: "RSC, Accept",
+    Vary: VINEXT_RSC_VARY_HEADER,
   });
 
   if (options.params && Object.keys(options.params).length > 0) {
@@ -225,7 +226,7 @@ export function buildAppPageHtmlResponse(
 ): Response {
   const headers = new Headers({
     "Content-Type": "text/html; charset=utf-8",
-    Vary: "RSC, Accept",
+    Vary: VINEXT_RSC_VARY_HEADER,
   });
 
   if (options.policy.cacheControl) {

--- a/packages/vinext/src/server/app-page-stream.ts
+++ b/packages/vinext/src/server/app-page-stream.ts
@@ -1,4 +1,5 @@
 import type { AppPageFontPreload } from "./app-page-execution.js";
+import { VINEXT_RSC_VARY_HEADER } from "./app-rsc-cache-busting.js";
 import { mergeMiddlewareResponseHeaders } from "./middleware-response-headers.js";
 
 export type AppPageFontData = {
@@ -164,7 +165,7 @@ export async function renderAppPageHtmlResponse(
 
   const headers = new Headers({
     "Content-Type": "text/html; charset=utf-8",
-    Vary: "RSC, Accept",
+    Vary: VINEXT_RSC_VARY_HEADER,
   });
 
   if (options.fontLinkHeader) {

--- a/packages/vinext/src/server/app-rsc-cache-busting.ts
+++ b/packages/vinext/src/server/app-rsc-cache-busting.ts
@@ -1,0 +1,180 @@
+import { fnv1a64 } from "../utils/hash.js";
+
+export const VINEXT_RSC_CACHE_BUSTING_SEARCH_PARAM = "_rsc";
+export const VINEXT_RSC_CONTENT_TYPE = "text/x-component";
+export const VINEXT_RSC_MOUNTED_SLOTS_HEADER = "X-Vinext-Mounted-Slots";
+
+const VINEXT_RSC_HEADER = "RSC";
+const VINEXT_RSC_INTERCEPTION_CONTEXT_HEADER = "X-Vinext-Interception-Context";
+const NEXT_ROUTER_STATE_TREE_HEADER = "Next-Router-State-Tree";
+const NEXT_ROUTER_PREFETCH_HEADER = "Next-Router-Prefetch";
+const NEXT_ROUTER_SEGMENT_PREFETCH_HEADER = "Next-Router-Segment-Prefetch";
+const NEXT_URL_HEADER = "Next-Url";
+
+export const VINEXT_RSC_VARY_HEADER = [
+  VINEXT_RSC_HEADER,
+  "Accept",
+  NEXT_ROUTER_STATE_TREE_HEADER,
+  NEXT_ROUTER_PREFETCH_HEADER,
+  NEXT_ROUTER_SEGMENT_PREFETCH_HEADER,
+  NEXT_URL_HEADER,
+  VINEXT_RSC_INTERCEPTION_CONTEXT_HEADER,
+  VINEXT_RSC_MOUNTED_SLOTS_HEADER,
+].join(", ");
+
+const CACHE_BUSTING_DIGEST_BYTES = 12;
+const textEncoder = new TextEncoder();
+
+type CreateRscRequestHeadersOptions = {
+  interceptionContext?: string | null;
+  mountedSlotsHeader?: string | null;
+};
+
+type ResolveInvalidRscCacheBustingRequestOptions = {
+  isRscRequest: boolean;
+  request: Request;
+};
+
+function encodeBase64Url(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+
+  return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/, "");
+}
+
+function normalizeHeaderValue(value: string | null): string {
+  return value ?? "0";
+}
+
+function createCacheBustingInput(headers: Headers): string | null {
+  const values = [
+    headers.get(NEXT_ROUTER_PREFETCH_HEADER),
+    headers.get(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER),
+    headers.get(NEXT_ROUTER_STATE_TREE_HEADER),
+    headers.get(NEXT_URL_HEADER),
+    headers.get(VINEXT_RSC_INTERCEPTION_CONTEXT_HEADER),
+    headers.get(VINEXT_RSC_MOUNTED_SLOTS_HEADER),
+  ];
+
+  if (values.every((value) => value === null)) {
+    return null;
+  }
+
+  return values.map(normalizeHeaderValue).join(",");
+}
+
+async function sha256CacheBustingHash(input: string): Promise<string> {
+  const digest = await globalThis.crypto.subtle.digest("SHA-256", textEncoder.encode(input));
+  return encodeBase64Url(new Uint8Array(digest).subarray(0, CACHE_BUSTING_DIGEST_BYTES));
+}
+
+function computeLegacyRscCacheBustingSearchParam(headers: Headers): string {
+  const input = createCacheBustingInput(headers);
+  return input === null ? "" : fnv1a64(input);
+}
+
+function getSearchPairsWithoutRscCacheBusting(url: URL): string[] {
+  const rawQuery = url.search.startsWith("?") ? url.search.slice(1) : url.search;
+  return rawQuery
+    .split("&")
+    .filter(
+      (pair) =>
+        pair.length > 0 &&
+        pair !== VINEXT_RSC_CACHE_BUSTING_SEARCH_PARAM &&
+        !pair.startsWith(`${VINEXT_RSC_CACHE_BUSTING_SEARCH_PARAM}=`),
+    );
+}
+
+export async function computeRscCacheBustingSearchParam(headers: Headers): Promise<string> {
+  const input = createCacheBustingInput(headers);
+  if (input === null) {
+    return "";
+  }
+
+  if (typeof globalThis.crypto?.subtle?.digest === "function") {
+    return sha256CacheBustingHash(input);
+  }
+
+  return fnv1a64(input);
+}
+
+export function setRscCacheBustingSearchParam(url: URL, hash: string): void {
+  const pairs = getSearchPairsWithoutRscCacheBusting(url);
+
+  pairs.push(
+    hash.length > 0
+      ? `${VINEXT_RSC_CACHE_BUSTING_SEARCH_PARAM}=${hash}`
+      : VINEXT_RSC_CACHE_BUSTING_SEARCH_PARAM,
+  );
+  url.search = `?${pairs.join("&")}`;
+}
+
+export function stripRscCacheBustingSearchParam(url: URL): void {
+  const pairs = getSearchPairsWithoutRscCacheBusting(url);
+  url.search = pairs.length > 0 ? `?${pairs.join("&")}` : "";
+}
+
+export function createRscRequestHeaders(options: CreateRscRequestHeadersOptions = {}): Headers {
+  const headers = new Headers({
+    Accept: VINEXT_RSC_CONTENT_TYPE,
+    [VINEXT_RSC_HEADER]: "1",
+  });
+
+  if (options.interceptionContext !== undefined && options.interceptionContext !== null) {
+    headers.set(VINEXT_RSC_INTERCEPTION_CONTEXT_HEADER, options.interceptionContext);
+  }
+
+  if (options.mountedSlotsHeader !== undefined && options.mountedSlotsHeader !== null) {
+    headers.set(VINEXT_RSC_MOUNTED_SLOTS_HEADER, options.mountedSlotsHeader);
+  }
+
+  return headers;
+}
+
+function toRscRequestPath(href: string): string {
+  const hashIndex = href.indexOf("#");
+  const beforeHash = hashIndex === -1 ? href : href.slice(0, hashIndex);
+  const queryIndex = beforeHash.indexOf("?");
+  const pathname = queryIndex === -1 ? beforeHash : beforeHash.slice(0, queryIndex);
+  const query = queryIndex === -1 ? "" : beforeHash.slice(queryIndex);
+  const normalizedPath =
+    pathname.length > 1 && pathname.endsWith("/") ? pathname.slice(0, -1) : pathname;
+  return `${normalizedPath}.rsc${query}`;
+}
+
+export async function createRscRequestUrl(href: string, headers: Headers): Promise<string> {
+  const url = new URL(toRscRequestPath(href), "http://vinext.local");
+  const hash = await computeRscCacheBustingSearchParam(headers);
+  setRscCacheBustingSearchParam(url, hash);
+  return `${url.pathname}${url.search}`;
+}
+
+export async function resolveInvalidRscCacheBustingRequest(
+  options: ResolveInvalidRscCacheBustingRequestOptions,
+): Promise<Response | null> {
+  if (
+    !options.isRscRequest ||
+    (options.request.method !== "GET" && options.request.method !== "HEAD")
+  ) {
+    return null;
+  }
+
+  const url = new URL(options.request.url);
+  const actualHash = url.searchParams.get(VINEXT_RSC_CACHE_BUSTING_SEARCH_PARAM);
+  const expectedHash = await computeRscCacheBustingSearchParam(options.request.headers);
+  const legacyHash = computeLegacyRscCacheBustingSearchParam(options.request.headers);
+
+  if (actualHash === expectedHash || (actualHash !== null && actualHash === legacyHash)) {
+    return null;
+  }
+
+  setRscCacheBustingSearchParam(url, expectedHash);
+  return new Response(null, {
+    status: 307,
+    headers: {
+      Location: `${url.pathname}${url.search}`,
+    },
+  });
+}

--- a/packages/vinext/src/server/app-rsc-cache-busting.ts
+++ b/packages/vinext/src/server/app-rsc-cache-busting.ts
@@ -1,5 +1,11 @@
 import { fnv1a64 } from "../utils/hash.js";
 
+/**
+ * RSC cache-busting hashes cover the headers that make a `.rsc` payload vary.
+ * Client-side variant headers must survive transit through CDNs and reverse
+ * proxies; stripping them changes the server hash and turns stale URLs into
+ * repeated canonicalization redirects.
+ */
 export const VINEXT_RSC_CACHE_BUSTING_SEARCH_PARAM = "_rsc";
 export const VINEXT_RSC_CONTENT_TYPE = "text/x-component";
 export const VINEXT_RSC_MOUNTED_SLOTS_HEADER = "X-Vinext-Mounted-Slots";
@@ -49,6 +55,8 @@ function normalizeHeaderValue(value: string | null): string {
 }
 
 function createCacheBustingInput(headers: Headers): string | null {
+  // The order of these values determines the hash. Changing it is a breaking
+  // cache-key change and requires accepting the previous hash during rollout.
   const values = [
     headers.get(NEXT_ROUTER_PREFETCH_HEADER),
     headers.get(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER),
@@ -79,12 +87,20 @@ function getSearchPairsWithoutRscCacheBusting(url: URL): string[] {
   const rawQuery = url.search.startsWith("?") ? url.search.slice(1) : url.search;
   return rawQuery
     .split("&")
-    .filter(
-      (pair) =>
-        pair.length > 0 &&
-        pair !== VINEXT_RSC_CACHE_BUSTING_SEARCH_PARAM &&
-        !pair.startsWith(`${VINEXT_RSC_CACHE_BUSTING_SEARCH_PARAM}=`),
+    .filter((pair) => pair.length > 0 && !isRscCacheBustingSearchPair(pair));
+}
+
+function isRscCacheBustingSearchPair(pair: string): boolean {
+  const separatorIndex = pair.indexOf("=");
+  const rawKey = separatorIndex === -1 ? pair : pair.slice(0, separatorIndex);
+
+  try {
+    return (
+      decodeURIComponent(rawKey.replaceAll("+", " ")) === VINEXT_RSC_CACHE_BUSTING_SEARCH_PARAM
     );
+  } catch {
+    return rawKey === VINEXT_RSC_CACHE_BUSTING_SEARCH_PARAM;
+  }
 }
 
 export async function computeRscCacheBustingSearchParam(headers: Headers): Promise<string> {
@@ -93,11 +109,7 @@ export async function computeRscCacheBustingSearchParam(headers: Headers): Promi
     return "";
   }
 
-  if (typeof globalThis.crypto?.subtle?.digest === "function") {
-    return sha256CacheBustingHash(input);
-  }
-
-  return fnv1a64(input);
+  return sha256CacheBustingHash(input);
 }
 
 export function setRscCacheBustingSearchParam(url: URL, hash: string): void {
@@ -151,6 +163,24 @@ export async function createRscRequestUrl(href: string, headers: Headers): Promi
   return `${url.pathname}${url.search}`;
 }
 
+export async function createRscRedirectLocation(
+  location: string,
+  request: Request,
+): Promise<string> {
+  const requestUrl = new URL(request.url);
+  const destinationUrl = new URL(location, requestUrl);
+
+  if (destinationUrl.origin !== requestUrl.origin) {
+    return destinationUrl.toString();
+  }
+
+  const rscPath = await createRscRequestUrl(
+    `${destinationUrl.pathname}${destinationUrl.search}`,
+    request.headers,
+  );
+  return `${destinationUrl.origin}${rscPath}`;
+}
+
 export async function resolveInvalidRscCacheBustingRequest(
   options: ResolveInvalidRscCacheBustingRequestOptions,
 ): Promise<Response | null> {
@@ -164,9 +194,17 @@ export async function resolveInvalidRscCacheBustingRequest(
   const url = new URL(options.request.url);
   const actualHash = url.searchParams.get(VINEXT_RSC_CACHE_BUSTING_SEARCH_PARAM);
   const expectedHash = await computeRscCacheBustingSearchParam(options.request.headers);
-  const legacyHash = computeLegacyRscCacheBustingSearchParam(options.request.headers);
 
-  if (actualHash === expectedHash || (actualHash !== null && actualHash === legacyHash)) {
+  if (actualHash === null && expectedHash === "") {
+    return null;
+  }
+
+  const legacyHash =
+    actualHash !== null && actualHash !== expectedHash
+      ? computeLegacyRscCacheBustingSearchParam(options.request.headers)
+      : null;
+
+  if (actualHash === expectedHash || (legacyHash !== null && actualHash === legacyHash)) {
     return null;
   }
 

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -25,6 +25,7 @@ import { hasBasePath } from "../utils/base-path.js";
 import { applyAppMiddleware, type AppMiddlewareContext } from "./app-middleware.js";
 import { mergeMiddlewareResponseHeaders } from "./app-page-response.js";
 import { handleAppPrerenderEndpoint } from "./app-prerender-endpoints.js";
+import { resolveInvalidRscCacheBustingRequest } from "./app-rsc-cache-busting.js";
 import { finalizeAppRscResponse } from "./app-rsc-response-finalizer.js";
 import { normalizeRscRequest } from "./app-rsc-request-normalization.js";
 import { getScriptNonceFromHeaderSources } from "./csp.js";
@@ -259,6 +260,12 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
       headers: { Location: destination },
     });
   }
+
+  const rscCacheBustingRedirect = await resolveInvalidRscCacheBustingRequest({
+    isRscRequest,
+    request,
+  });
+  if (rscCacheBustingRedirect) return rscCacheBustingRedirect;
 
   const middlewareContext: AppRscMiddlewareContext = {
     headers: null,

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -26,6 +26,7 @@ import { applyAppMiddleware, type AppMiddlewareContext } from "./app-middleware.
 import { mergeMiddlewareResponseHeaders } from "./app-page-response.js";
 import { handleAppPrerenderEndpoint } from "./app-prerender-endpoints.js";
 import {
+  createRscRedirectLocation,
   resolveInvalidRscCacheBustingRequest,
   stripRscCacheBustingSearchParam,
 } from "./app-rsc-cache-busting.js";
@@ -258,9 +259,12 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
     const destination = sanitizeDestination(
       redirectDestinationWithBasePath(redirect.destination, options.basePath),
     );
+    const location = isRscRequest
+      ? await createRscRedirectLocation(destination, request)
+      : destination;
     return new Response(null, {
       status: redirect.permanent ? 308 : 307,
-      headers: { Location: destination },
+      headers: { Location: location },
     });
   }
 

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -259,9 +259,10 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
     const destination = sanitizeDestination(
       redirectDestinationWithBasePath(redirect.destination, options.basePath),
     );
-    const location = isRscRequest
-      ? await createRscRedirectLocation(destination, request)
-      : destination;
+    const location =
+      isRscRequest && request.headers.get("RSC") === "1"
+        ? await createRscRedirectLocation(destination, request)
+        : destination;
     return new Response(null, {
       status: redirect.permanent ? 308 : 307,
       headers: { Location: location },

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -25,7 +25,10 @@ import { hasBasePath } from "../utils/base-path.js";
 import { applyAppMiddleware, type AppMiddlewareContext } from "./app-middleware.js";
 import { mergeMiddlewareResponseHeaders } from "./app-page-response.js";
 import { handleAppPrerenderEndpoint } from "./app-prerender-endpoints.js";
-import { resolveInvalidRscCacheBustingRequest } from "./app-rsc-cache-busting.js";
+import {
+  resolveInvalidRscCacheBustingRequest,
+  stripRscCacheBustingSearchParam,
+} from "./app-rsc-cache-busting.js";
 import { finalizeAppRscResponse } from "./app-rsc-response-finalizer.js";
 import { normalizeRscRequest } from "./app-rsc-request-normalization.js";
 import { getScriptNonceFromHeaderSources } from "./csp.js";
@@ -329,6 +332,10 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
   if (publicFileResponse) {
     options.clearRequestContext();
     return publicFileResponse;
+  }
+
+  if (isRscRequest) {
+    stripRscCacheBustingSearchParam(url);
   }
 
   options.setNavigationContext({

--- a/packages/vinext/src/server/app-rsc-request-normalization.ts
+++ b/packages/vinext/src/server/app-rsc-request-normalization.ts
@@ -13,7 +13,7 @@ export type NormalizedRscRequest = {
   pathname: string;
   /** Pathname with `.rsc` suffix removed. Used for route matching and navigation context. */
   cleanPathname: string;
-  /** True when the client requests the RSC payload (.rsc suffix or Accept: text/x-component). */
+  /** True when the client requests the RSC payload (.rsc suffix, RSC: 1, or Accept: text/x-component). */
   isRscRequest: boolean;
   /** Sanitized X-Vinext-Interception-Context header (null bytes stripped). null when absent. */
   interceptionContextHeader: string | null;
@@ -38,7 +38,7 @@ export type NormalizedRscRequest = {
  *   4. Collapse double-slashes, resolve `.` and `..` segments (normalizePath)
  *   5. basePath check + strip — 404 when pathname lacks the basePath prefix.
  *      `/__vinext/` bypasses this for internal prerender endpoints.
- *   6. RSC detection: `.rsc` suffix or `Accept: text/x-component`
+ *   6. RSC detection: `.rsc` suffix, `RSC: 1`, or `Accept: text/x-component`
  *   7. cleanPathname — pathname with `.rsc` suffix stripped
  *   8. Sanitize X-Vinext-Interception-Context — strip null bytes (header injection)
  *   9. Normalize x-vinext-mounted-slots — dedup and sort for canonical cache keys
@@ -85,6 +85,7 @@ export function normalizeRscRequest(
   // Steps 6-7: RSC detection and cleanPathname.
   const isRscRequest =
     pathname.endsWith(".rsc") ||
+    request.headers.get("rsc") === "1" ||
     (request.headers.get("accept")?.includes("text/x-component") ?? false);
   const cleanPathname = pathname.replace(/\.rsc$/, "");
 

--- a/packages/vinext/src/server/app-rsc-request-normalization.ts
+++ b/packages/vinext/src/server/app-rsc-request-normalization.ts
@@ -13,7 +13,7 @@ export type NormalizedRscRequest = {
   pathname: string;
   /** Pathname with `.rsc` suffix removed. Used for route matching and navigation context. */
   cleanPathname: string;
-  /** True when the client requests the RSC payload (.rsc suffix, RSC: 1, or Accept: text/x-component). */
+  /** True when the request targets a canonical `.rsc` payload URL. */
   isRscRequest: boolean;
   /** Sanitized X-Vinext-Interception-Context header (null bytes stripped). null when absent. */
   interceptionContextHeader: string | null;
@@ -38,7 +38,9 @@ export type NormalizedRscRequest = {
  *   4. Collapse double-slashes, resolve `.` and `..` segments (normalizePath)
  *   5. basePath check + strip — 404 when pathname lacks the basePath prefix.
  *      `/__vinext/` bypasses this for internal prerender endpoints.
- *   6. RSC detection: `.rsc` suffix, `RSC: 1`, or `Accept: text/x-component`
+ *   6. RSC detection: `.rsc` suffix only. RSC headers do not select payload
+ *      rendering at the canonical HTML URL, so caches that ignore Vary cannot
+ *      store Flight responses under HTML URLs.
  *   7. cleanPathname — pathname with `.rsc` suffix stripped
  *   8. Sanitize X-Vinext-Interception-Context — strip null bytes (header injection)
  *   9. Normalize x-vinext-mounted-slots — dedup and sort for canonical cache keys
@@ -83,10 +85,7 @@ export function normalizeRscRequest(
   }
 
   // Steps 6-7: RSC detection and cleanPathname.
-  const isRscRequest =
-    pathname.endsWith(".rsc") ||
-    request.headers.get("rsc") === "1" ||
-    (request.headers.get("accept")?.includes("text/x-component") ?? false);
+  const isRscRequest = pathname.endsWith(".rsc");
   const cleanPathname = pathname.replace(/\.rsc$/, "");
 
   // Step 8: Sanitize X-Vinext-Interception-Context.

--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -1,5 +1,6 @@
 import type { HeadersAccessPhase } from "vinext/shims/headers";
 import { type FetchCacheMode, setCurrentFetchCacheMode } from "vinext/shims/fetch-cache";
+import { VINEXT_RSC_VARY_HEADER } from "./app-rsc-cache-busting.js";
 import { resolveAppPageActionRerenderTarget } from "./app-page-request.js";
 import { mergeMiddlewareResponseHeaders } from "./middleware-response-headers.js";
 import { validateCsrfOrigin, validateServerActionPayload } from "./request-pipeline.js";
@@ -579,7 +580,7 @@ export async function handleServerActionRscRequest<
       options.clearRequestContext();
       const redirectHeaders = new Headers({
         "Content-Type": "text/x-component; charset=utf-8",
-        Vary: "RSC, Accept",
+        Vary: VINEXT_RSC_VARY_HEADER,
       });
       mergeMiddlewareResponseHeaders(redirectHeaders, options.middlewareHeaders);
       redirectHeaders.set("x-action-redirect", actionRedirect.url);
@@ -647,7 +648,7 @@ export async function handleServerActionRscRequest<
 
     const actionHeaders = new Headers({
       "Content-Type": "text/x-component; charset=utf-8",
-      Vary: "RSC, Accept",
+      Vary: VINEXT_RSC_VARY_HEADER,
     });
     mergeMiddlewareResponseHeaders(actionHeaders, options.middlewareHeaders);
     const actionResponse = new Response(rscStream, {

--- a/packages/vinext/src/server/middleware-response-headers.ts
+++ b/packages/vinext/src/server/middleware-response-headers.ts
@@ -2,22 +2,27 @@ const ADDITIVE_RESPONSE_HEADER_NAMES = new Set(["set-cookie", "vary"]);
 
 function mergeVaryHeader(target: Headers, value: string): void {
   const existing = target.get("Vary");
-  if (!existing) {
-    target.set("Vary", value);
+  const tokens = (existing ? `${existing}, ${value}` : value)
+    .split(",")
+    .map((token) => token.trim())
+    .filter((token) => token.length > 0);
+
+  // Per RFC 9110, `Vary: *` means the response varies on all request fields.
+  // Combining `*` with field names changes semantics and may be treated
+  // inconsistently by caches. Collapse to `*` if any token is `*`.
+  if (tokens.some((token) => token === "*")) {
+    target.set("Vary", "*");
     return;
   }
 
   const seen = new Set<string>();
   const merged: string[] = [];
-  for (const token of `${existing}, ${value}`.split(",")) {
-    const trimmed = token.trim();
-    if (!trimmed) continue;
-
-    const normalized = trimmed.toLowerCase();
+  for (const token of tokens) {
+    const normalized = token.toLowerCase();
     if (seen.has(normalized)) continue;
 
     seen.add(normalized);
-    merged.push(trimmed);
+    merged.push(token);
   }
 
   target.set("Vary", merged.join(", "));

--- a/packages/vinext/src/server/middleware-response-headers.ts
+++ b/packages/vinext/src/server/middleware-response-headers.ts
@@ -1,5 +1,28 @@
 const ADDITIVE_RESPONSE_HEADER_NAMES = new Set(["set-cookie", "vary"]);
 
+function mergeVaryHeader(target: Headers, value: string): void {
+  const existing = target.get("Vary");
+  if (!existing) {
+    target.set("Vary", value);
+    return;
+  }
+
+  const seen = new Set<string>();
+  const merged: string[] = [];
+  for (const token of `${existing}, ${value}`.split(",")) {
+    const trimmed = token.trim();
+    if (!trimmed) continue;
+
+    const normalized = trimmed.toLowerCase();
+    if (seen.has(normalized)) continue;
+
+    seen.add(normalized);
+    merged.push(trimmed);
+  }
+
+  target.set("Vary", merged.join(", "));
+}
+
 /**
  * Merge middleware response headers into a target Headers object.
  *
@@ -16,6 +39,11 @@ export function mergeMiddlewareResponseHeaders(
   }
 
   for (const [key, value] of middlewareHeaders) {
+    if (key.toLowerCase() === "vary") {
+      mergeVaryHeader(target, value);
+      continue;
+    }
+
     if (ADDITIVE_RESPONSE_HEADER_NAMES.has(key.toLowerCase())) {
       target.append(key, value);
       continue;

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -22,13 +22,17 @@ import React, {
 // so this resolves both via the Vite plugin and in direct vitest imports)
 import {
   getCurrentInterceptionContext,
-  toRscUrl,
   getPrefetchedUrls,
   getMountedSlotsHeader,
   navigateClientSide,
   prefetchRscResponse,
 } from "./navigation.js";
 import { createAppPayloadCacheKey } from "../server/app-elements.js";
+import {
+  createRscRequestHeaders,
+  createRscRequestUrl,
+  VINEXT_RSC_MOUNTED_SLOTS_HEADER,
+} from "../server/app-rsc-cache-busting.js";
 import { isDangerousScheme } from "./url-safety.js";
 import {
   resolveRelativeHref,
@@ -127,50 +131,50 @@ function prefetchUrl(href: string): void {
 
   const fullHref = toBrowserNavigationHref(prefetchHref, window.location.href, __basePath);
 
-  // Distinguish the same visible URL when it is prefetched from different
-  // interception sources such as /feed vs /gallery.
-  const rscUrl = toRscUrl(fullHref);
-  const interceptionContext = getCurrentInterceptionContext();
-  const cacheKey = createAppPayloadCacheKey(rscUrl, interceptionContext);
-  const prefetched = getPrefetchedUrls();
-  if (prefetched.has(cacheKey)) return;
-  prefetched.add(cacheKey);
-
   const schedule = window.requestIdleCallback ?? ((fn: () => void) => setTimeout(fn, 100));
 
   schedule(() => {
-    if (typeof window.__VINEXT_RSC_NAVIGATE__ === "function") {
-      const mountedSlotsHeader = getMountedSlotsHeader();
-      const headers = new Headers({ Accept: "text/x-component" });
-      if (mountedSlotsHeader) {
-        headers.set("X-Vinext-Mounted-Slots", mountedSlotsHeader);
+    void (async () => {
+      if (typeof window.__VINEXT_RSC_NAVIGATE__ === "function") {
+        const interceptionContext = getCurrentInterceptionContext();
+        const mountedSlotsHeader = getMountedSlotsHeader();
+        const headers = createRscRequestHeaders({ interceptionContext });
+        if (mountedSlotsHeader) {
+          headers.set(VINEXT_RSC_MOUNTED_SLOTS_HEADER, mountedSlotsHeader);
+        }
+        // Distinguish the same visible URL when it is prefetched from different
+        // request contexts such as /feed vs /gallery or different mounted slots.
+        const rscUrl = await createRscRequestUrl(fullHref, headers);
+        const cacheKey = createAppPayloadCacheKey(rscUrl, interceptionContext);
+        const prefetched = getPrefetchedUrls();
+        if (prefetched.has(cacheKey)) return;
+        prefetched.add(cacheKey);
+        prefetchRscResponse(
+          rscUrl,
+          fetch(rscUrl, {
+            headers,
+            credentials: "include",
+            priority: "low" as const,
+            // @ts-expect-error — purpose is a valid fetch option in some browsers
+            purpose: "prefetch",
+          }),
+          interceptionContext,
+          mountedSlotsHeader,
+        );
+      } else if ((window.__NEXT_DATA__ as VinextNextData | undefined)?.__vinext?.pageModuleUrl) {
+        // Pages Router: inject a prefetch link for the target page module
+        // We can't easily resolve the target page's module URL from the Link,
+        // so we create a <link rel="prefetch"> for the HTML page which helps
+        // the browser's preload scanner.
+        const link = document.createElement("link");
+        link.rel = "prefetch";
+        link.href = fullHref;
+        link.as = "document";
+        document.head.appendChild(link);
       }
-      if (interceptionContext !== null) {
-        headers.set("X-Vinext-Interception-Context", interceptionContext);
-      }
-      prefetchRscResponse(
-        rscUrl,
-        fetch(rscUrl, {
-          headers,
-          credentials: "include",
-          priority: "low" as const,
-          // @ts-expect-error — purpose is a valid fetch option in some browsers
-          purpose: "prefetch",
-        }),
-        interceptionContext,
-        mountedSlotsHeader,
-      );
-    } else if ((window.__NEXT_DATA__ as VinextNextData | undefined)?.__vinext?.pageModuleUrl) {
-      // Pages Router: inject a prefetch link for the target page module
-      // We can't easily resolve the target page's module URL from the Link,
-      // so we create a <link rel="prefetch"> for the HTML page which helps
-      // the browser's preload scanner.
-      const link = document.createElement("link");
-      link.rel = "prefetch";
-      link.href = fullHref;
-      link.as = "document";
-      document.head.appendChild(link);
-    }
+    })().catch((error) => {
+      console.error("[vinext] RSC prefetch setup error:", error);
+    });
   });
 }
 

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -299,6 +299,9 @@ export type PrefetchCacheEntry = {
  * Convert a pathname (with optional query/hash) to its .rsc URL.
  * Strips trailing slashes before appending `.rsc` so that cache keys
  * are consistent regardless of the `trailingSlash` config setting.
+ *
+ * @deprecated Use `createRscRequestUrl` so RSC requests include cache-busting
+ * params for variant headers.
  */
 export function toRscUrl(href: string): string {
   const [beforeHash] = href.split("#");
@@ -1291,10 +1294,20 @@ const _appRouter = {
     assertSafeNavigationUrl(href);
     if (isServer) return;
     void (async () => {
+      // Normalize same-origin absolute URLs to local paths; no-op for external
+      // origins so we don't pollute the prefetch cache with a same-path .rsc on
+      // the current origin. Mirrors Link's prefetchUrl and navigateClientSide.
+      let prefetchHref = href;
+      if (href.startsWith("http://") || href.startsWith("https://") || href.startsWith("//")) {
+        const localPath = toSameOriginAppPath(href, __basePath);
+        if (localPath == null) return;
+        prefetchHref = localPath;
+      }
+
       // Prefetch the RSC payload for the target route and store in cache.
       // We must add to prefetchedUrls manually for deduplication.
       // prefetchRscResponse only manages the cache Map, not the URL set.
-      const fullHref = toBrowserNavigationHref(href, window.location.href, __basePath);
+      const fullHref = toBrowserNavigationHref(prefetchHref, window.location.href, __basePath);
       const interceptionContext = getCurrentInterceptionContext();
       const mountedSlotsHeader = getMountedSlotsHeader();
       const headers = createRscRequestHeaders({ interceptionContext });

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -13,6 +13,11 @@
 import * as React from "react";
 import { notifyAppRouterTransitionStart } from "../client/instrumentation-client-state.js";
 import { createAppPayloadCacheKey } from "../server/app-elements.js";
+import {
+  createRscRequestHeaders,
+  createRscRequestUrl,
+  VINEXT_RSC_MOUNTED_SLOTS_HEADER,
+} from "../server/app-rsc-cache-busting.js";
 import { toBrowserNavigationHref, toSameOriginAppPath } from "./url-utils.js";
 import { stripBasePath } from "../utils/base-path.js";
 import { ReadonlyURLSearchParams } from "./readonly-url-search-params.js";
@@ -1285,34 +1290,35 @@ const _appRouter = {
   prefetch(href: string): void {
     assertSafeNavigationUrl(href);
     if (isServer) return;
-    // Prefetch the RSC payload for the target route and store in cache.
-    // We must add to prefetchedUrls manually for deduplication.
-    // prefetchRscResponse only manages the cache Map, not the URL set.
-    const fullHref = toBrowserNavigationHref(href, window.location.href, __basePath);
-    const rscUrl = toRscUrl(fullHref);
-    const interceptionContext = getCurrentInterceptionContext();
-    const cacheKey = createAppPayloadCacheKey(rscUrl, interceptionContext);
-    const prefetched = getPrefetchedUrls();
-    if (prefetched.has(cacheKey)) return;
-    prefetched.add(cacheKey);
-    const mountedSlotsHeader = getMountedSlotsHeader();
-    const headers = new Headers({ Accept: "text/x-component" });
-    if (mountedSlotsHeader) {
-      headers.set("X-Vinext-Mounted-Slots", mountedSlotsHeader);
-    }
-    if (interceptionContext !== null) {
-      headers.set("X-Vinext-Interception-Context", interceptionContext);
-    }
-    prefetchRscResponse(
-      rscUrl,
-      fetch(rscUrl, {
-        headers,
-        credentials: "include",
-        priority: "low" as RequestInit["priority"],
-      }),
-      interceptionContext,
-      mountedSlotsHeader,
-    );
+    void (async () => {
+      // Prefetch the RSC payload for the target route and store in cache.
+      // We must add to prefetchedUrls manually for deduplication.
+      // prefetchRscResponse only manages the cache Map, not the URL set.
+      const fullHref = toBrowserNavigationHref(href, window.location.href, __basePath);
+      const interceptionContext = getCurrentInterceptionContext();
+      const mountedSlotsHeader = getMountedSlotsHeader();
+      const headers = createRscRequestHeaders({ interceptionContext });
+      if (mountedSlotsHeader) {
+        headers.set(VINEXT_RSC_MOUNTED_SLOTS_HEADER, mountedSlotsHeader);
+      }
+      const rscUrl = await createRscRequestUrl(fullHref, headers);
+      const cacheKey = createAppPayloadCacheKey(rscUrl, interceptionContext);
+      const prefetched = getPrefetchedUrls();
+      if (prefetched.has(cacheKey)) return;
+      prefetched.add(cacheKey);
+      prefetchRscResponse(
+        rscUrl,
+        fetch(rscUrl, {
+          headers,
+          credentials: "include",
+          priority: "low" as RequestInit["priority"],
+        }),
+        interceptionContext,
+        mountedSlotsHeader,
+      );
+    })().catch((error) => {
+      console.error("[vinext] RSC prefetch setup error:", error);
+    });
   },
 };
 

--- a/packages/vinext/src/shims/next-shims.d.ts
+++ b/packages/vinext/src/shims/next-shims.d.ts
@@ -118,6 +118,10 @@ declare module "next/navigation" {
   };
   export const MAX_PREFETCH_CACHE_SIZE: number;
   export const PREFETCH_CACHE_TTL: number;
+  /**
+   * @deprecated Use `createRscRequestUrl` so RSC requests include cache-busting
+   * params for variant headers.
+   */
   export function toRscUrl(href: string): string;
   export function getPrefetchCache(): Map<string, PrefetchCacheEntry>;
   export function getPrefetchedUrls(): Set<string>;

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -946,7 +946,7 @@ describe("mounted slot helpers", () => {
 });
 
 describe("resolveServerActionRequestState", () => {
-  it("includes only Accept and x-rsc-action when previousNextUrl is null and no slots are mounted", () => {
+  it("includes only the RSC markers and x-rsc-action when previousNextUrl is null and no slots are mounted", () => {
     const elements = createResolvedElements("route:/settings", "/");
 
     const { headers } = resolveServerActionRequestState({
@@ -956,8 +956,9 @@ describe("resolveServerActionRequestState", () => {
       previousNextUrl: null,
     });
 
-    expect(Array.from(headers.keys()).sort()).toEqual(["accept", "x-rsc-action"]);
+    expect(Array.from(headers.keys()).sort()).toEqual(["accept", "rsc", "x-rsc-action"]);
     expect(headers.get("accept")).toBe("text/x-component");
+    expect(headers.get("rsc")).toBe("1");
     expect(headers.get("x-rsc-action")).toBe("action-abc");
   });
 

--- a/tests/app-page-boundary-render.test.ts
+++ b/tests/app-page-boundary-render.test.ts
@@ -7,6 +7,7 @@ import {
 } from "../packages/vinext/src/server/app-page-boundary-render.js";
 import type { AppElements } from "../packages/vinext/src/server/app-elements.js";
 import type { MetadataFileRoute } from "../packages/vinext/src/server/metadata-routes.js";
+import { VINEXT_RSC_VARY_HEADER } from "../packages/vinext/src/server/app-rsc-cache-busting.js";
 
 function createStreamFromMarkup(markup: string): ReadableStream<Uint8Array> {
   return new ReadableStream({
@@ -280,7 +281,7 @@ describe("app page boundary render helpers", () => {
 
     expect(response?.status).toBe(404);
     expect(response?.headers.get("x-middleware-security")).toBe("present");
-    expect(response?.headers.get("vary")).toBe("RSC, Accept, x-auth-state");
+    expect(response?.headers.get("vary")).toBe(`${VINEXT_RSC_VARY_HEADER}, x-auth-state`);
     expect(response?.headers.getSetCookie()).toContain("session=rotated; Path=/; HttpOnly");
   });
 
@@ -332,7 +333,7 @@ describe("app page boundary render helpers", () => {
 
     expect(response?.status).toBe(404);
     expect(response?.headers.get("x-middleware-security")).toBe("present");
-    expect(response?.headers.get("vary")).toBe("RSC, Accept, x-auth-state");
+    expect(response?.headers.get("vary")).toBe(`${VINEXT_RSC_VARY_HEADER}, x-auth-state`);
     expect(response?.headers.getSetCookie()).toContain("session=rotated; Path=/; HttpOnly");
   });
 
@@ -405,7 +406,7 @@ describe("app page boundary render helpers", () => {
 
     expect(response?.status).toBe(200);
     expect(response?.headers.get("x-middleware-security")).toBe("present");
-    expect(response?.headers.get("vary")).toBe("RSC, Accept, x-auth-state");
+    expect(response?.headers.get("vary")).toBe(`${VINEXT_RSC_VARY_HEADER}, x-auth-state`);
     expect(response?.headers.getSetCookie()).toContain("session=rotated; Path=/; HttpOnly");
   });
 

--- a/tests/app-page-execution.test.ts
+++ b/tests/app-page-execution.test.ts
@@ -61,8 +61,9 @@ describe("app page execution helpers", () => {
 
     const redirectResponse = await buildAppPageSpecialErrorResponse({
       clearRequestContext,
+      isRscRequest: false,
       middlewareContext: createMiddlewareContext(),
-      requestUrl: "https://example.com/start",
+      request: new Request("https://example.com/start"),
       specialError: {
         kind: "redirect",
         location: "/redirected",
@@ -81,6 +82,7 @@ describe("app page execution helpers", () => {
 
     const fallbackResponse = await buildAppPageSpecialErrorResponse({
       clearRequestContext,
+      isRscRequest: false,
       middlewareContext: createMiddlewareContext(),
       renderFallbackPage(statusCode) {
         return Promise.resolve(
@@ -90,7 +92,7 @@ describe("app page execution helpers", () => {
           }),
         );
       },
-      requestUrl: "https://example.com/start",
+      request: new Request("https://example.com/start"),
       specialError: {
         kind: "http-access-fallback",
         statusCode: 404,
@@ -115,11 +117,12 @@ describe("app page execution helpers", () => {
 
     const response = await buildAppPageSpecialErrorResponse({
       clearRequestContext,
+      isRscRequest: false,
       middlewareContext: createMiddlewareContext(),
       renderFallbackPage() {
         return Promise.resolve(null);
       },
-      requestUrl: "https://example.com/start",
+      request: new Request("https://example.com/start"),
       specialError: {
         kind: "http-access-fallback",
         statusCode: 401,
@@ -132,6 +135,30 @@ describe("app page execution helpers", () => {
     expect(response.headers.getSetCookie()).toContain("session=rotated; Path=/; HttpOnly");
     await expect(response.text()).resolves.toBe("Unauthorized");
     expect(clearRequestContext).toHaveBeenCalledTimes(1);
+  });
+
+  it("canonicalizes same-origin RSC redirect locations to .rsc URLs", async () => {
+    const response = await buildAppPageSpecialErrorResponse({
+      clearRequestContext: vi.fn(),
+      isRscRequest: true,
+      request: new Request("https://example.com/start.rsc", {
+        headers: {
+          Accept: "text/x-component",
+          RSC: "1",
+          "Next-Router-State-Tree": "tree",
+        },
+      }),
+      specialError: {
+        kind: "redirect",
+        location: "/redirected?tab=1",
+        statusCode: 307,
+      },
+    });
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toMatch(
+      /^https:\/\/example\.com\/redirected\.rsc\?tab=1&_rsc=/,
+    );
   });
 
   it("probes layouts from inner to outer and stops on a handled special response", async () => {

--- a/tests/app-page-response.test.ts
+++ b/tests/app-page-response.test.ts
@@ -432,4 +432,34 @@ describe("mergeMiddlewareResponseHeaders", () => {
 
     expect(target.get("Vary")).toBe(`${VINEXT_RSC_VARY_HEADER}, X-Auth-State`);
   });
+
+  it("preserves wildcard Vary semantics when appending middleware headers", () => {
+    const target = new Headers({ Vary: "RSC, Accept" });
+    const mwHeaders = new Headers();
+    mwHeaders.set("Vary", "*, X-Auth-State");
+
+    mergeMiddlewareResponseHeaders(target, mwHeaders);
+
+    expect(target.get("Vary")).toBe("*");
+  });
+
+  it("preserves wildcard Vary semantics when target already has Vary wildcard", () => {
+    const target = new Headers({ Vary: "*" });
+    const mwHeaders = new Headers();
+    mwHeaders.set("Vary", "X-Auth-State");
+
+    mergeMiddlewareResponseHeaders(target, mwHeaders);
+
+    expect(target.get("Vary")).toBe("*");
+  });
+
+  it("preserves wildcard Vary semantics when middleware is the first Vary source", () => {
+    const target = new Headers();
+    const mwHeaders = new Headers();
+    mwHeaders.set("Vary", "*, X-Auth-State");
+
+    mergeMiddlewareResponseHeaders(target, mwHeaders);
+
+    expect(target.get("Vary")).toBe("*");
+  });
 });

--- a/tests/app-page-response.test.ts
+++ b/tests/app-page-response.test.ts
@@ -6,6 +6,7 @@ import {
   resolveAppPageHtmlResponsePolicy,
   resolveAppPageRscResponsePolicy,
 } from "../packages/vinext/src/server/app-page-response.js";
+import { VINEXT_RSC_VARY_HEADER } from "../packages/vinext/src/server/app-rsc-cache-busting.js";
 
 function createBody(text: string): ReadableStream {
   return new ReadableStream({
@@ -309,7 +310,7 @@ describe("app page response helpers", () => {
     expect(response.headers.get("x-vinext-params")).toBe(encodeURIComponent('{"slug":"test"}'));
     expect(response.headers.get("cache-control")).toBe("private, max-age=5");
     expect(response.headers.get("x-vinext-cache")).toBe("MISS");
-    expect(response.headers.get("vary")).toBe("RSC, Accept, Next-Router-State-Tree");
+    expect(response.headers.get("vary")).toBe(VINEXT_RSC_VARY_HEADER);
     expect(response.headers.get("x-vinext-timing")).toBe("10,5,-1");
     await expect(response.text()).resolves.toBe("flight");
   });
@@ -365,7 +366,7 @@ describe("app page response helpers", () => {
     expect(response.headers.get("content-type")).toBe("text/html; charset=utf-8");
     expect(response.headers.get("cache-control")).toBe("private, max-age=5");
     expect(response.headers.get("x-vinext-cache")).toBe("STATIC");
-    expect(response.headers.get("vary")).toBe("RSC, Accept, Next-Router-State-Tree");
+    expect(response.headers.get("vary")).toBe(VINEXT_RSC_VARY_HEADER);
     expect(response.headers.get("link")).toBe(
       "</font.woff2>; rel=preload; as=font; type=font/woff2; crossorigin",
     );
@@ -420,5 +421,15 @@ describe("mergeMiddlewareResponseHeaders", () => {
     mergeMiddlewareResponseHeaders(target, mwHeaders);
 
     expect(target.get("Vary")).toBe("RSC, Accept, Next-Router-State-Tree");
+  });
+
+  it("deduplicates Vary values when appending middleware headers", () => {
+    const target = new Headers({ Vary: VINEXT_RSC_VARY_HEADER });
+    const mwHeaders = new Headers();
+    mwHeaders.set("Vary", "next-router-state-tree, X-Auth-State");
+
+    mergeMiddlewareResponseHeaders(target, mwHeaders);
+
+    expect(target.get("Vary")).toBe(`${VINEXT_RSC_VARY_HEADER}, X-Auth-State`);
   });
 });

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -1642,11 +1642,12 @@ describe("App Router integration", () => {
   });
 
   it("blocks RSC stream requests with cross-origin Origin header", async () => {
-    const res = await fetch(`${baseUrl}/about`, {
+    const res = await fetch(`${baseUrl}/about.rsc`, {
       headers: {
         Origin: "https://evil.com",
         Host: new URL(baseUrl).host,
         Accept: "text/x-component",
+        RSC: "1",
       },
     });
     expect(res.status).toBe(403);
@@ -1981,12 +1982,12 @@ describe("App Router Production server (startProdServer)", () => {
     expect(res.headers.get("content-type")).toContain("text/x-component");
   });
 
-  it("returns RSC stream for Accept: text/x-component", async () => {
+  it("returns HTML for header-only RSC requests at canonical page URLs", async () => {
     const res = await fetch(`${baseUrl}/about`, {
-      headers: { Accept: "text/x-component" },
+      headers: { Accept: "text/x-component", RSC: "1" },
     });
     expect(res.status).toBe(200);
-    expect(res.headers.get("content-type")).toContain("text/x-component");
+    expect(res.headers.get("content-type")).toContain("text/html");
   });
 
   it("serves route handlers (GET /api/hello)", async () => {
@@ -2202,8 +2203,8 @@ describe("App Router Production server (startProdServer)", () => {
   });
 
   it("page ISR + searchParams: RSC requests stay dynamic instead of serving cached query data", async () => {
-    const res1 = await fetch(`${baseUrl}/isr-dynamic-search?filter=crimson`, {
-      headers: { Accept: "text/x-component" },
+    const res1 = await fetch(`${baseUrl}/isr-dynamic-search.rsc?filter=crimson`, {
+      headers: { Accept: "text/x-component", RSC: "1" },
     });
     expect(res1.status).toBe(200);
     expect(res1.headers.get("content-type")).toContain("text/x-component");
@@ -2211,8 +2212,8 @@ describe("App Router Production server (startProdServer)", () => {
     const rsc1 = await res1.text();
     expect(rsc1).toContain("crimson");
 
-    const res2 = await fetch(`${baseUrl}/isr-dynamic-search?filter=indigo`, {
-      headers: { Accept: "text/x-component" },
+    const res2 = await fetch(`${baseUrl}/isr-dynamic-search.rsc?filter=indigo`, {
+      headers: { Accept: "text/x-component", RSC: "1" },
     });
     expect(res2.status).toBe(200);
     expect(res2.headers.get("x-vinext-cache")).toBeNull();

--- a/tests/app-rsc-cache-busting.test.ts
+++ b/tests/app-rsc-cache-busting.test.ts
@@ -5,6 +5,7 @@ import {
   createRscRequestUrl,
   resolveInvalidRscCacheBustingRequest,
   setRscCacheBustingSearchParam,
+  stripRscCacheBustingSearchParam,
   VINEXT_RSC_CACHE_BUSTING_SEARCH_PARAM,
   VINEXT_RSC_VARY_HEADER,
 } from "../packages/vinext/src/server/app-rsc-cache-busting.js";
@@ -49,6 +50,22 @@ describe("App Router RSC cache-busting", () => {
     setRscCacheBustingSearchParam(url, "fresh");
 
     expect(`${url.pathname}${url.search}`).toBe("/photos/42.rsc?tab=latest&_rsc=fresh");
+  });
+
+  it("strips internal _rsc params before exposing response URLs to browser navigation", () => {
+    const url = new URL("https://example.com/photos/42.rsc?tab=latest&_rsc=fresh&view=modal");
+
+    stripRscCacheBustingSearchParam(url);
+
+    expect(`${url.pathname}${url.search}`).toBe("/photos/42.rsc?tab=latest&view=modal");
+  });
+
+  it("strips bare internal _rsc params without rewriting unrelated query encoding", () => {
+    const url = new URL("https://example.com/search.rsc?q=custom%20spacing&_rsc");
+
+    stripRscCacheBustingSearchParam(url);
+
+    expect(`${url.pathname}${url.search}`).toBe("/search.rsc?q=custom%20spacing");
   });
 
   it("redirects RSC requests with missing cache-busting params to the canonical URL", async () => {

--- a/tests/app-rsc-cache-busting.test.ts
+++ b/tests/app-rsc-cache-busting.test.ts
@@ -9,6 +9,7 @@ import {
   VINEXT_RSC_CACHE_BUSTING_SEARCH_PARAM,
   VINEXT_RSC_VARY_HEADER,
 } from "../packages/vinext/src/server/app-rsc-cache-busting.js";
+import { fnv1a64 } from "../packages/vinext/src/utils/hash.js";
 
 describe("App Router RSC cache-busting", () => {
   it("adds a bare _rsc search param when no variant headers are present", async () => {
@@ -52,12 +53,36 @@ describe("App Router RSC cache-busting", () => {
     expect(`${url.pathname}${url.search}`).toBe("/photos/42.rsc?tab=latest&_rsc=fresh");
   });
 
+  it("replaces encoded reserved _rsc query keys", () => {
+    const url = new URL("https://example.com/photos/42.rsc?%5Frsc=stale&tab=latest");
+
+    setRscCacheBustingSearchParam(url, "fresh");
+
+    expect(`${url.pathname}${url.search}`).toBe("/photos/42.rsc?tab=latest&_rsc=fresh");
+  });
+
+  it("does not treat query keys containing _rsc as cache-busting params", () => {
+    const url = new URL("https://example.com/photos/42.rsc?filter_rsc=1&_rsc=stale");
+
+    setRscCacheBustingSearchParam(url, "fresh");
+
+    expect(`${url.pathname}${url.search}`).toBe("/photos/42.rsc?filter_rsc=1&_rsc=fresh");
+  });
+
   it("strips internal _rsc params before exposing response URLs to browser navigation", () => {
     const url = new URL("https://example.com/photos/42.rsc?tab=latest&_rsc=fresh&view=modal");
 
     stripRscCacheBustingSearchParam(url);
 
     expect(`${url.pathname}${url.search}`).toBe("/photos/42.rsc?tab=latest&view=modal");
+  });
+
+  it("strips encoded reserved _rsc query keys before exposing response URLs", () => {
+    const url = new URL("https://example.com/photos/42.rsc?filter_rsc=1&%5Frsc=stale");
+
+    stripRscCacheBustingSearchParam(url);
+
+    expect(`${url.pathname}${url.search}`).toBe("/photos/42.rsc?filter_rsc=1");
   });
 
   it("strips bare internal _rsc params without rewriting unrelated query encoding", () => {
@@ -82,10 +107,44 @@ describe("App Router RSC cache-busting", () => {
     expect(response?.headers.get("Location")).toBe(`/photos/42.rsc?tab=latest&_rsc=${hash}`);
   });
 
+  it("redirects encoded stale _rsc keys to a canonical non-looping URL", async () => {
+    const headers = createRscRequestHeaders();
+    const request = new Request("https://example.com/photos/42.rsc?%5Frsc=stale", { headers });
+
+    const response = await resolveInvalidRscCacheBustingRequest({
+      isRscRequest: true,
+      request,
+    });
+
+    expect(response?.status).toBe(307);
+    expect(response?.headers.get("Location")).toBe("/photos/42.rsc?_rsc");
+  });
+
+  it("accepts RSC requests without cache-busting params when no variant headers are present", async () => {
+    const headers = createRscRequestHeaders();
+    const request = new Request("https://example.com/photos/42.rsc?tab=latest", { headers });
+
+    await expect(
+      resolveInvalidRscCacheBustingRequest({ isRscRequest: true, request }),
+    ).resolves.toBeNull();
+  });
+
   it("accepts RSC requests whose cache-busting param matches the request headers", async () => {
     const headers = createRscRequestHeaders({ mountedSlotsHeader: "slot:modal:/" });
     const url = await createRscRequestUrl("/photos/42", headers);
     const request = new Request(`https://example.com${url}`, { headers });
+
+    await expect(
+      resolveInvalidRscCacheBustingRequest({ isRscRequest: true, request }),
+    ).resolves.toBeNull();
+  });
+
+  it("accepts legacy FNV cache-busting params during rolling upgrades", async () => {
+    const headers = createRscRequestHeaders({ mountedSlotsHeader: "slot:modal:/" });
+    const legacyHash = fnv1a64("0,0,0,0,0,slot:modal:/");
+    const request = new Request(`https://example.com/photos/42.rsc?_rsc=${legacyHash}`, {
+      headers,
+    });
 
     await expect(
       resolveInvalidRscCacheBustingRequest({ isRscRequest: true, request }),

--- a/tests/app-rsc-cache-busting.test.ts
+++ b/tests/app-rsc-cache-busting.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  computeRscCacheBustingSearchParam,
+  createRscRequestHeaders,
+  createRscRequestUrl,
+  resolveInvalidRscCacheBustingRequest,
+  setRscCacheBustingSearchParam,
+  VINEXT_RSC_CACHE_BUSTING_SEARCH_PARAM,
+  VINEXT_RSC_VARY_HEADER,
+} from "../packages/vinext/src/server/app-rsc-cache-busting.js";
+
+describe("App Router RSC cache-busting", () => {
+  it("adds a bare _rsc search param when no variant headers are present", async () => {
+    const headers = createRscRequestHeaders();
+
+    await expect(createRscRequestUrl("/dashboard?tab=activity", headers)).resolves.toBe(
+      "/dashboard.rsc?tab=activity&_rsc",
+    );
+  });
+
+  it("hashes Vinext RSC variant headers into the request URL", async () => {
+    const headers = createRscRequestHeaders({
+      interceptionContext: "/feed",
+      mountedSlotsHeader: "slot:modal:/ slot:sidebar:/",
+    });
+
+    const hash = await computeRscCacheBustingSearchParam(headers);
+
+    expect(hash).not.toBe("");
+    await expect(createRscRequestUrl("/photos/42", headers)).resolves.toBe(
+      `/photos/42.rsc?${VINEXT_RSC_CACHE_BUSTING_SEARCH_PARAM}=${hash}`,
+    );
+  });
+
+  it("changes the hash when a varying header changes", async () => {
+    const feedHash = await computeRscCacheBustingSearchParam(
+      createRscRequestHeaders({ interceptionContext: "/feed" }),
+    );
+    const galleryHash = await computeRscCacheBustingSearchParam(
+      createRscRequestHeaders({ interceptionContext: "/gallery" }),
+    );
+
+    expect(feedHash).not.toBe(galleryHash);
+  });
+
+  it("preserves existing query params while replacing stale _rsc values", () => {
+    const url = new URL("https://example.com/photos/42.rsc?tab=latest&_rsc=stale");
+
+    setRscCacheBustingSearchParam(url, "fresh");
+
+    expect(`${url.pathname}${url.search}`).toBe("/photos/42.rsc?tab=latest&_rsc=fresh");
+  });
+
+  it("redirects RSC requests with missing cache-busting params to the canonical URL", async () => {
+    const headers = createRscRequestHeaders({ interceptionContext: "/feed" });
+    const request = new Request("https://example.com/photos/42.rsc?tab=latest", { headers });
+    const hash = await computeRscCacheBustingSearchParam(headers);
+
+    const response = await resolveInvalidRscCacheBustingRequest({
+      isRscRequest: true,
+      request,
+    });
+
+    expect(response?.status).toBe(307);
+    expect(response?.headers.get("Location")).toBe(`/photos/42.rsc?tab=latest&_rsc=${hash}`);
+  });
+
+  it("accepts RSC requests whose cache-busting param matches the request headers", async () => {
+    const headers = createRscRequestHeaders({ mountedSlotsHeader: "slot:modal:/" });
+    const url = await createRscRequestUrl("/photos/42", headers);
+    const request = new Request(`https://example.com${url}`, { headers });
+
+    await expect(
+      resolveInvalidRscCacheBustingRequest({ isRscRequest: true, request }),
+    ).resolves.toBeNull();
+  });
+
+  it("ignores non-RSC and mutating requests", async () => {
+    const headers = createRscRequestHeaders({ interceptionContext: "/feed" });
+
+    await expect(
+      resolveInvalidRscCacheBustingRequest({
+        isRscRequest: false,
+        request: new Request("https://example.com/photos/42", { headers }),
+      }),
+    ).resolves.toBeNull();
+    await expect(
+      resolveInvalidRscCacheBustingRequest({
+        isRscRequest: true,
+        request: new Request("https://example.com/photos/42.rsc", { headers, method: "POST" }),
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it("exports the full Vary value for RSC-bearing App Router responses", () => {
+    expect(VINEXT_RSC_VARY_HEADER).toBe(
+      "RSC, Accept, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch, Next-Url, X-Vinext-Interception-Context, X-Vinext-Mounted-Slots",
+    );
+  });
+});

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -1,4 +1,9 @@
 import { describe, expect, it, vi } from "vite-plus/test";
+import {
+  computeRscCacheBustingSearchParam,
+  createRscRequestHeaders,
+  createRscRequestUrl,
+} from "../packages/vinext/src/server/app-rsc-cache-busting.js";
 import { createAppRscHandler } from "../packages/vinext/src/server/app-rsc-handler.js";
 import { makeThenableParams } from "../packages/vinext/src/shims/thenable-params.js";
 
@@ -97,6 +102,95 @@ describe("createAppRscHandler", () => {
     expect(response.headers.get("location")).toBe("/docs/about");
     expect(response.headers.get("x-test-header")).toBeNull();
     expect(dispatchMatchedPage).not.toHaveBeenCalled();
+  });
+
+  it("canonicalizes config redirect locations for RSC requests", async () => {
+    const headers = createRscRequestHeaders({ mountedSlotsHeader: "slot:modal:/" });
+    const expectedHash = await computeRscCacheBustingSearchParam(headers);
+    const handler = createHandler({
+      configHeaders: [],
+      configRedirects: [{ source: "/old-about", destination: "/about?from=old", permanent: false }],
+    });
+
+    const response = await handler(
+      new Request("https://example.test/docs/old-about.rsc", { headers }),
+      null,
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe(
+      `https://example.test/docs/about.rsc?from=old&_rsc=${expectedHash}`,
+    );
+  });
+
+  it("redirects invalid RSC cache-busting requests before middleware", async () => {
+    const middleware = vi.fn(() => new Response("middleware"));
+    const dispatchMatchedPage = vi.fn(async () => new Response("page", { status: 200 }));
+    const headers = createRscRequestHeaders({ mountedSlotsHeader: "slot:modal:/" });
+    const expectedHash = await computeRscCacheBustingSearchParam(headers);
+    const handler = createHandler({
+      configHeaders: [],
+      dispatchMatchedPage,
+      middlewareModule: { default: middleware },
+    });
+
+    const response = await handler(
+      new Request("https://example.test/docs/about.rsc?tab=latest", { headers }),
+      null,
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe(
+      `/docs/about.rsc?tab=latest&_rsc=${expectedHash}`,
+    );
+    expect(middleware).not.toHaveBeenCalled();
+    expect(dispatchMatchedPage).not.toHaveBeenCalled();
+  });
+
+  it("does not render RSC payloads at HTML URLs marked only by RSC headers", async () => {
+    const dispatchMatchedPage = vi.fn(async () => new Response("page", { status: 200 }));
+    const handler = createHandler({
+      configHeaders: [],
+      dispatchMatchedPage,
+    });
+
+    const response = await handler(
+      new Request("https://example.test/docs/about", {
+        headers: createRscRequestHeaders(),
+      }),
+      null,
+    );
+
+    expect(response.status).toBe(200);
+    expect(dispatchMatchedPage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cleanPathname: "/about",
+        isRscRequest: false,
+      }),
+    );
+  });
+
+  it("strips internal RSC cache-busting params before setting navigation context", async () => {
+    const setNavigationContext = vi.fn();
+    const headers = createRscRequestHeaders();
+    const rscUrl = await createRscRequestUrl("/docs/about?tab=latest", headers);
+    const handler = createHandler({
+      configHeaders: [],
+      setNavigationContext,
+    });
+
+    const response = await handler(new Request(`https://example.test${rscUrl}`, { headers }), null);
+
+    expect(response.status).toBe(200);
+    expect(setNavigationContext).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        pathname: "/about",
+        params: {},
+      }),
+    );
+    const context = setNavigationContext.mock.lastCall?.[0];
+    expect(context?.searchParams.get("tab")).toBe("latest");
+    expect(context?.searchParams.has("_rsc")).toBe(false);
   });
 
   it("runs beforeFiles rewrites before route matching", async () => {

--- a/tests/app-rsc-request-normalization.test.ts
+++ b/tests/app-rsc-request-normalization.test.ts
@@ -190,19 +190,18 @@ describe("normalizeRscRequest — RSC detection and cleanPathname", () => {
     expect(result.cleanPathname).toBe("/about");
   });
 
-  it("detects RSC request by Accept: text/x-component header", () => {
+  it("does not select RSC rendering by Accept: text/x-component header alone", () => {
     const result = normalized(
       normalizeRscRequest(req("/about", { accept: "text/x-component" }), ""),
     );
-    expect(result.isRscRequest).toBe(true);
+    expect(result.isRscRequest).toBe(false);
   });
 
-  it("cleanPathname equals pathname when no .rsc suffix (Accept-header RSC)", () => {
-    // Route matching must use cleanPathname. With Accept-header RSC and no suffix,
-    // cleanPathname should equal pathname so the correct route is matched.
+  it("cleanPathname equals pathname when RSC headers appear on an HTML URL", () => {
     const result = normalized(
       normalizeRscRequest(req("/about", { accept: "text/x-component" }), ""),
     );
+    expect(result.isRscRequest).toBe(false);
     expect(result.cleanPathname).toBe("/about");
   });
 
@@ -212,7 +211,7 @@ describe("normalizeRscRequest — RSC detection and cleanPathname", () => {
     expect(result.cleanPathname).toBe("/about");
   });
 
-  it("strips .rsc suffix from cleanPathname even when isRscRequest is also set by Accept header", () => {
+  it("strips .rsc suffix from cleanPathname when RSC headers are also present", () => {
     const result = normalized(
       normalizeRscRequest(req("/about.rsc", { accept: "text/x-component" }), ""),
     );

--- a/tests/app-server-action-execution.test.ts
+++ b/tests/app-server-action-execution.test.ts
@@ -8,6 +8,7 @@ import {
   readActionFormDataWithLimit,
   type HandleProgressiveServerActionRequestOptions,
 } from "../packages/vinext/src/server/app-server-action-execution.js";
+import { VINEXT_RSC_VARY_HEADER } from "../packages/vinext/src/server/app-rsc-cache-busting.js";
 
 type TestRoute = {
   id: string;
@@ -588,7 +589,7 @@ describe("app server action execution helpers", () => {
 
     expect(response?.status).toBe(200);
     expect(response?.headers.get("content-type")).toBe("text/x-component; charset=utf-8");
-    expect(response?.headers.get("vary")).toBe("RSC, Accept");
+    expect(response?.headers.get("vary")).toBe(VINEXT_RSC_VARY_HEADER);
     expect(response?.headers.get("x-middleware")).toBe("present");
     expect(response?.headers.getSetCookie()).toEqual(["action=1; Path=/", "draft=1; Path=/"]);
     expect(await response?.text()).toBe("flight-payload");

--- a/tests/e2e/app-router/advanced.spec.ts
+++ b/tests/e2e/app-router/advanced.spec.ts
@@ -1,11 +1,27 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 
 const BASE = "http://localhost:4174";
 
-async function waitForAppRouterHydration(page: import("@playwright/test").Page) {
+async function waitForAppRouterHydration(page: Page) {
   await page.waitForFunction(() => typeof window.__VINEXT_RSC_NAVIGATE__ === "function", null, {
     timeout: 10_000,
   });
+}
+
+function normalizePrefetchCacheKey(key: string): string {
+  const [url = "", context] = key.split("\0");
+  const normalizedUrl = url.replace(/[?&]_rsc(?:=[^&]*)?/, "");
+  return context === undefined ? normalizedUrl : `${normalizedUrl}\0${context}`;
+}
+
+async function readPhotoPrefetchCacheKeys(page: Page): Promise<string[]> {
+  const keys = await page.evaluate(() =>
+    Array.from(window.__VINEXT_RSC_PREFETCH_CACHE__?.keys() ?? []).filter((key) =>
+      key.includes("/photos/42.rsc"),
+    ),
+  );
+
+  return keys.map(normalizePrefetchCacheKey).sort();
 }
 
 test.describe("Parallel Routes", () => {
@@ -277,26 +293,14 @@ test.describe("Intercepting Routes", () => {
     await page.goto(`${BASE}/feed`);
     await waitForAppRouterHydration(page);
     await expect
-      .poll(async () =>
-        page.evaluate(() =>
-          Array.from(window.__VINEXT_RSC_PREFETCH_CACHE__?.keys() ?? []).filter((key) =>
-            key.includes("/photos/42.rsc"),
-          ),
-        ),
-      )
+      .poll(async () => readPhotoPrefetchCacheKeys(page))
       .toEqual(["/photos/42.rsc\u0000/feed"]);
 
     await page.click("#gallery-link");
     await page.waitForURL(`${BASE}/gallery`);
     await waitForAppRouterHydration(page);
     await expect
-      .poll(async () =>
-        page.evaluate(() =>
-          Array.from(window.__VINEXT_RSC_PREFETCH_CACHE__?.keys() ?? [])
-            .filter((key) => key.includes("/photos/42.rsc"))
-            .sort(),
-        ),
-      )
+      .poll(async () => readPhotoPrefetchCacheKeys(page))
       .toEqual(["/photos/42.rsc\u0000/feed", "/photos/42.rsc\u0000/gallery"]);
   });
 });

--- a/tests/e2e/cloudflare-workers/navigation.spec.ts
+++ b/tests/e2e/cloudflare-workers/navigation.spec.ts
@@ -32,8 +32,8 @@ test.describe("Cloudflare Workers Navigation", () => {
 
   test("RSC endpoint returns flight data for client navigation", async ({ request }) => {
     // The .rsc URL should return RSC flight payload (not HTML)
-    const response = await request.get(`${BASE}/about`, {
-      headers: { Accept: "text/x-component" },
+    const response = await request.get(`${BASE}/about.rsc`, {
+      headers: { Accept: "text/x-component", RSC: "1" },
     });
 
     expect(response.status()).toBe(200);

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -372,13 +372,11 @@ describe("App Router entry templates", () => {
     }
   });
 
-  it("generateRscEntry delegates RSC cache-busting validation to the shared helper", () => {
+  it("generateRscEntry delegates App Router request handling to the typed helper", () => {
     const code = generateRscEntry("/tmp/test/app", minimalAppRoutes, null, [], null, "", false);
 
-    expect(code).toContain("app-rsc-cache-busting.js");
-    expect(code).toContain(
-      "const __rscCacheBustingRedirect = await __resolveInvalidRscCacheBustingRequest({",
-    );
+    expect(code).toContain("app-rsc-handler.js");
+    expect(code).toContain("export default __createAppRscHandler({");
     expect(code).not.toContain("computeRscCacheBustingSearchParam(");
   });
 

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -372,6 +372,16 @@ describe("App Router entry templates", () => {
     }
   });
 
+  it("generateRscEntry delegates RSC cache-busting validation to the shared helper", () => {
+    const code = generateRscEntry("/tmp/test/app", minimalAppRoutes, null, [], null, "", false);
+
+    expect(code).toContain("app-rsc-cache-busting.js");
+    expect(code).toContain(
+      "const __rscCacheBustingRedirect = await __resolveInvalidRscCacheBustingRequest({",
+    );
+    expect(code).not.toContain("computeRscCacheBustingSearchParam(");
+  });
+
   it("generateRscEntry delegates React Flight preload hint normalization", () => {
     const code = generateRscEntry("/tmp/test/app", minimalAppRoutes, null, [], null, "", false);
 

--- a/tests/nextjs-compat/rsc-basic.test.ts
+++ b/tests/nextjs-compat/rsc-basic.test.ts
@@ -81,7 +81,7 @@ describe("Next.js compat: rsc-basic", () => {
   // Next.js: 'should return RSC response with correct content-type'
   // Source: https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
   it("RSC response has correct content-type", async () => {
-    const res = await fetch(`${baseUrl}/nextjs-compat/rsc-server`, {
+    const res = await fetch(`${baseUrl}/nextjs-compat/rsc-server.rsc`, {
       headers: {
         RSC: "1",
         Accept: "text/x-component",
@@ -94,7 +94,7 @@ describe("Next.js compat: rsc-basic", () => {
   // Next.js: 'should return RSC response with rendered content'
   // Source: https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
   it("RSC response contains rendered content", async () => {
-    const res = await fetch(`${baseUrl}/nextjs-compat/rsc-server`, {
+    const res = await fetch(`${baseUrl}/nextjs-compat/rsc-server.rsc`, {
       headers: {
         RSC: "1",
         Accept: "text/x-component",

--- a/tests/nextjs-compat/rsc-context-lazy-stream.test.ts
+++ b/tests/nextjs-compat/rsc-context-lazy-stream.test.ts
@@ -27,11 +27,9 @@
  *   page.tsx      — calls notFound(), triggering renderHTTPAccessFallbackPage()
  *   not-found.tsx — rendered by renderHTTPAccessFallbackPage() inside the layout
  *
- * The test sends Accept: text/x-component (the real RSC request header —
- * isRscRequest is determined by accept.includes("text/x-component"), NOT by
- * an "RSC" header) with x-rsc-context-test: <sentinel> and asserts the sentinel
- * value appears in the RSC flight response, proving the layout's headers() call
- * ran successfully during lazy stream consumption.
+ * The test sends a canonical .rsc request with x-rsc-context-test: <sentinel>
+ * and asserts the sentinel value appears in the RSC flight response, proving
+ * the layout's headers() call ran successfully during lazy stream consumption.
  *
  * ── Bug 2: __VINEXT_RSC_NAV__ missing from HTML (hydration mismatch) ────────
  *
@@ -90,9 +88,10 @@ beforeAll(async () => {
   // Warm up both fixtures so the first real test in each suite doesn't pay
   // the cold-start compilation cost.
   await Promise.all([
-    fetch(`${_baseUrl}/nextjs-compat/rsc-context-lazy-stream`, {
+    fetch(`${_baseUrl}/nextjs-compat/rsc-context-lazy-stream.rsc`, {
       headers: {
         Accept: "text/x-component",
+        RSC: "1",
         "x-rsc-context-test": "warmup",
       },
     }),
@@ -144,9 +143,10 @@ describe("RSC lazy stream: headers() context survives until stream is consumed",
   // correct context and SENTINEL appears in the RSC flight response.
 
   it("RSC request: layout headers() context survives lazy stream consumption (regression)", async () => {
-    const res = await fetch(`${_baseUrl}${LAZY_ROUTE}`, {
+    const res = await fetch(`${_baseUrl}${LAZY_ROUTE}.rsc`, {
       headers: {
         Accept: "text/x-component",
+        RSC: "1",
         "x-rsc-context-test": SENTINEL,
       },
     });
@@ -167,9 +167,10 @@ describe("RSC lazy stream: headers() context survives until stream is consumed",
   });
 
   it("RSC request: data-request-id is not 'missing' (context was not null)", async () => {
-    const res = await fetch(`${_baseUrl}${LAZY_ROUTE}`, {
+    const res = await fetch(`${_baseUrl}${LAZY_ROUTE}.rsc`, {
       headers: {
         Accept: "text/x-component",
+        RSC: "1",
         "x-rsc-context-test": SENTINEL,
       },
     });

--- a/tests/prefetch-cache.test.ts
+++ b/tests/prefetch-cache.test.ts
@@ -22,13 +22,20 @@ let MAX_PREFETCH_CACHE_SIZE: Navigation["MAX_PREFETCH_CACHE_SIZE"];
 let PREFETCH_CACHE_TTL: Navigation["PREFETCH_CACHE_TTL"];
 let snapshotRscResponse: Navigation["snapshotRscResponse"];
 let restoreRscResponse: Navigation["restoreRscResponse"];
+let useRouter: Navigation["useRouter"];
 
 beforeEach(async () => {
   // Set window BEFORE importing so isServer evaluates to false
   (globalThis as any).window = {
     __VINEXT_RSC_PREFETCH_CACHE__: new Map(),
     __VINEXT_RSC_PREFETCHED_URLS__: new Set(),
-    location: { pathname: "/", search: "", hash: "", href: "http://localhost/" },
+    location: {
+      origin: "http://localhost",
+      pathname: "/",
+      search: "",
+      hash: "",
+      href: "http://localhost/",
+    },
     addEventListener: () => {},
     history: { pushState: () => {}, replaceState: () => {}, state: null },
     dispatchEvent: () => {},
@@ -44,11 +51,13 @@ beforeEach(async () => {
   PREFETCH_CACHE_TTL = nav.PREFETCH_CACHE_TTL;
   snapshotRscResponse = nav.snapshotRscResponse;
   restoreRscResponse = nav.restoreRscResponse;
+  useRouter = nav.useRouter;
 });
 
 afterEach(() => {
   vi.restoreAllMocks();
   delete (globalThis as any).window;
+  delete (globalThis as any).fetch;
 });
 
 /** Helper: fill cache with `count` entries at a given timestamp. */
@@ -72,7 +81,39 @@ function fillCache(count: number, timestamp: number, keyPrefix = "/page-"): void
   }
 }
 
+async function waitForPrefetchSetup(): Promise<void> {
+  await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
 describe("prefetch cache eviction", () => {
+  it("router.prefetch ignores external absolute URLs", async () => {
+    const fetch = vi.fn();
+    (globalThis as any).fetch = fetch;
+
+    useRouter().prefetch("https://external.example/dashboard");
+    await waitForPrefetchSetup();
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(getPrefetchedUrls().size).toBe(0);
+  });
+
+  it("router.prefetch normalizes same-origin absolute URLs before caching", async () => {
+    let fetchedUrl: unknown;
+    const fetch = vi.fn(async (input: RequestInfo | URL) => {
+      fetchedUrl = input;
+      return new Response("flight", { headers: { "content-type": "text/x-component" } });
+    });
+    (globalThis as any).fetch = fetch;
+
+    useRouter().prefetch("http://localhost/dashboard?tab=1");
+    await waitForPrefetchSetup();
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetchedUrl).toMatch(/^\/dashboard\.rsc\?tab=1&_rsc(?:=.+)?$/);
+    expect(getPrefetchedUrls().has(createAppPayloadCacheKey(String(fetchedUrl), "/"))).toBe(true);
+  });
+
   it("reuses a prefetched response only when mounted-slot context matches", () => {
     const cache = getPrefetchCache();
     const prefetched = getPrefetchedUrls();


### PR DESCRIPTION
## What this changes

Adds a shared App Router RSC cache-busting helper and wires generated RSC entries to reject malformed RSC requests by redirecting them to the canonical `_rsc` URL. Client-side RSC fetches now send `RSC: 1` plus a cache-busting `_rsc` search param derived from the request headers that can change the RSC payload.

The shared helper also centralizes the App Router RSC `Vary` header set and includes both Next-compatible headers and Vinext-specific variant headers:

- `RSC`
- `Accept`
- `Next-Router-State-Tree`
- `Next-Router-Prefetch`
- `Next-Router-Segment-Prefetch`
- `Next-Url`
- `X-Vinext-Interception-Context`
- `X-Vinext-Mounted-Slots`

Fixes #988.

## Why

Next.js now treats the URL as the defensive cache key for RSC requests because some CDNs do not respect `Vary`. The relevant upstream behavior is:

- Next sends `RSC: 1` on Flight fetches: https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/router-reducer/fetch-server-response.ts#L147-L155
- Next appends a cache-busting `_rsc` search param before fetching: https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/router-reducer/fetch-server-response.ts#L532-L537
- Next computes a compact SHA-256-derived header hash: https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/router/utils/cache-busting-search-param.ts#L47-L77
- Next validates the incoming hash and redirects mismatches to the canonical URL: https://github.com/vercel/next.js/blob/canary/packages/next/src/server/base-server.ts#L2051-L2123
- Next includes the RSC variant headers in `Vary`, with `Next-Url` added for interception-sensitive routes: https://github.com/vercel/next.js/blob/canary/packages/next/src/server/base-server.ts#L2003-L2023 and https://github.com/vercel/next.js/blob/canary/packages/next/src/server/route-modules/app-page/module.ts#L188-L195

Vinext uses `.rsc` URLs rather than the exact same visible URL for HTML and RSC, so the HTML-vs-RSC variant is already separated by pathname. The gap is still real because Vinext's `.rsc` response can vary by request headers such as mounted slots and interception context. A CDN that keys only by URL could serve the wrong RSC payload for another slot or interception context.

## Approach

- Add `server/app-rsc-cache-busting.ts` as the normal module that owns request headers, `_rsc` hashing, canonical redirect validation, and the shared RSC `Vary` value.
- Keep `entries/app-rsc-entry.ts` as app-shape codegen: it imports the helper, computes `isRscRequest`, and delegates validation.
- Update browser navigation, link prefetch, router prefetch, initial hydration fetches, HMR fetches, and server-action fetches to build canonical RSC request URLs through the helper.
- Update App Router response helpers to use the shared `Vary` value.
- De-duplicate `Vary` tokens when merging middleware headers, so middleware can add its own Vary values without duplicating the base App Router set.

## Validation

- `vp check`
- `vp run knip --no-progress`
- `vp test run tests/app-rsc-cache-busting.test.ts tests/app-browser-entry.test.ts tests/prefetch-cache.test.ts tests/entry-templates.test.ts`
- `vp test run tests/app-rsc-cache-busting.test.ts tests/app-browser-entry.test.ts tests/app-page-cache.test.ts tests/app-page-response.test.ts tests/app-page-boundary-render.test.ts tests/app-page-stream.test.ts tests/app-server-action-execution.test.ts tests/entry-templates.test.ts`
- `vp test run tests/app-router.test.ts -t "RSC"`

## Risks / follow-ups

This intentionally adapts the Next.js invariant to Vinext's current `.rsc` URL model instead of switching Vinext to same-URL Flight fetches. The hash includes Next-compatible RSC variant headers for forward compatibility and the Vinext-specific headers that currently affect payload shape.
