### PR TITLE
fix(headers): align draft mode cookie attributes with Next.js

### DIFF
--- a/packages/vinext/src/shims/headers.ts
+++ b/packages/vinext/src/shims/headers.ts
@@ -687,6 +687,7 @@ export function getAndClearPendingCookies(): string[] {
 
 // Draft mode cookie name (matches Next.js convention)
 const DRAFT_MODE_COOKIE = "__prerender_bypass";
+const DRAFT_MODE_EXPIRED_DATE = new Date(0).toUTCString();
 
 // Draft mode secret — generated once at build time via Vite `define` so the
 // __prerender_bypass cookie is consistent across all server instances (e.g.
@@ -722,6 +723,13 @@ type DraftModeResult = {
   disable(): void;
 };
 
+function draftModeCookieAttributes(): string {
+  if (typeof process !== "undefined" && process.env?.NODE_ENV === "development") {
+    return "Path=/; HttpOnly; SameSite=Lax";
+  }
+  return "Path=/; HttpOnly; SameSite=None; Secure";
+}
+
 /**
  * Draft mode — check/toggle via a `__prerender_bypass` cookie.
  *
@@ -751,9 +759,7 @@ export async function draftMode(): Promise<DraftModeResult> {
       if (state.headersContext) {
         state.headersContext.cookies.set(DRAFT_MODE_COOKIE, secret);
       }
-      const secure =
-        typeof process !== "undefined" && process.env?.NODE_ENV === "production" ? "; Secure" : "";
-      state.draftModeCookieHeader = `${DRAFT_MODE_COOKIE}=${secret}; Path=/; HttpOnly; SameSite=Lax${secure}`;
+      state.draftModeCookieHeader = `${DRAFT_MODE_COOKIE}=${secret}; ${draftModeCookieAttributes()}`;
     },
     disable(): void {
       if (state.headersContext?.accessError) {
@@ -762,9 +768,7 @@ export async function draftMode(): Promise<DraftModeResult> {
       if (state.headersContext) {
         state.headersContext.cookies.delete(DRAFT_MODE_COOKIE);
       }
-      const secure =
-        typeof process !== "undefined" && process.env?.NODE_ENV === "production" ? "; Secure" : "";
-      state.draftModeCookieHeader = `${DRAFT_MODE_COOKIE}=; Path=/; HttpOnly; SameSite=Lax${secure}; Max-Age=0`;
+      state.draftModeCookieHeader = `${DRAFT_MODE_COOKIE}=; ${draftModeCookieAttributes()}; Expires=${DRAFT_MODE_EXPIRED_DATE}`;
     },
   };
 }

--- a/tests/nextjs-compat/draft-mode.test.ts
+++ b/tests/nextjs-compat/draft-mode.test.ts
@@ -100,6 +100,58 @@ describe("Next.js compat: draft-mode", () => {
     }
   });
 
+  it("draftMode().enable() uses cross-site cookie attributes in production", async () => {
+    const {
+      draftMode: draftModeFn,
+      getDraftModeCookieHeader,
+      runWithHeadersContext,
+      headersContextFromRequest,
+    } = await import("../../packages/vinext/src/shims/headers.js");
+
+    const origEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+    try {
+      const ctx = headersContextFromRequest(new Request("https://preview.example.com/test"));
+      await runWithHeadersContext(ctx, async () => {
+        const dm = await draftModeFn();
+        dm.enable();
+        const cookieHeader = getDraftModeCookieHeader();
+        expect(cookieHeader).toBeDefined();
+        expect(cookieHeader).toMatch(/;\s*SameSite=None/i);
+        expect(cookieHeader).toMatch(/;\s*Secure/i);
+      });
+    } finally {
+      process.env.NODE_ENV = origEnv;
+    }
+  });
+
+  it("draftMode().disable() clears with Next.js production cookie attributes", async () => {
+    const {
+      draftMode: draftModeFn,
+      getDraftModeCookieHeader,
+      runWithHeadersContext,
+      headersContextFromRequest,
+    } = await import("../../packages/vinext/src/shims/headers.js");
+
+    const origEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+    try {
+      const ctx = headersContextFromRequest(new Request("https://preview.example.com/test"));
+      await runWithHeadersContext(ctx, async () => {
+        const dm = await draftModeFn();
+        dm.disable();
+        const cookieHeader = getDraftModeCookieHeader();
+        expect(cookieHeader).toBeDefined();
+        expect(cookieHeader).toMatch(/;\s*SameSite=None/i);
+        expect(cookieHeader).toMatch(/;\s*Secure/i);
+        expect(cookieHeader).toMatch(/;\s*Expires=Thu, 01 Jan 1970 00:00:00 GMT/i);
+        expect(cookieHeader).not.toMatch(/;\s*Max-Age=0/i);
+      });
+    } finally {
+      process.env.NODE_ENV = origEnv;
+    }
+  });
+
   it("draftMode().enable() cookie omits Secure flag in development", async () => {
     const res = await fetch(`${baseUrl}/nextjs-compat/api/draft-enable`);
     const setCookies = res.headers.getSetCookie();

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -1188,7 +1188,8 @@ describe("next/headers shim", () => {
     expect(dm2.isEnabled).toBe(false);
 
     const cookieHeader = getDraftModeCookieHeader();
-    expect(cookieHeader).toContain("Max-Age=0");
+    expect(cookieHeader).toContain("Expires=Thu, 01 Jan 1970 00:00:00 GMT");
+    expect(cookieHeader).not.toContain("Max-Age=0");
     setHeadersContext(null);
   });
 


### PR DESCRIPTION
## What this changes
Vinext draft-mode cookies now match Next.js production cookie semantics. `draftMode().enable()` emits `SameSite=None; Secure` outside development, and `draftMode().disable()` clears the bypass cookie with an expired date while preserving the same production attributes.

## Why
The existing shim always emitted `SameSite=Lax` and cleared with `Max-Age=0`. That diverges from Next.js and can prevent production preview flows from receiving the `__prerender_bypass` cookie in cross-site contexts, leaving `draftMode().isEnabled` false even after enabling draft mode.

Next.js references:
- App Router `DraftModeProvider.enable()` uses `sameSite: process.env.NODE_ENV !== 'development' ? 'none' : 'lax'` and `secure: process.env.NODE_ENV !== 'development'`: [draft-mode-provider.ts#L68-L75](https://github.com/vercel/next.js/blob/ae61573e062e900050b8e6b24626e450accc4570/packages/next/src/server/async-storage/draft-mode-provider.ts#L68-L75)
- App Router `DraftModeProvider.disable()` clears via `expires: new Date(0)` with the same cookie attributes: [draft-mode-provider.ts#L80-L92](https://github.com/vercel/next.js/blob/ae61573e062e900050b8e6b24626e450accc4570/packages/next/src/server/async-storage/draft-mode-provider.ts#L80-L92)
- Pages/API preview helpers use the same production `sameSite` and `secure` policy: [api-resolver.ts#L131-L160](https://github.com/vercel/next.js/blob/ae61573e062e900050b8e6b24626e450accc4570/packages/next/src/server/api-utils/node/api-resolver.ts#L131-L160)

## Approach
The draft-mode cookie behavior stays in the normal `next/headers` shim module. Generated entries still only ask the shim for the pending draft-mode cookie header, so codegen remains app-shape wiring rather than owning cookie policy.

The implementation adds a small helper for draft-mode cookie attributes:
- development: `Path=/; HttpOnly; SameSite=Lax`
- non-development: `Path=/; HttpOnly; SameSite=None; Secure`

Disable now emits `Expires=Thu, 01 Jan 1970 00:00:00 GMT` instead of `Max-Age=0`, matching Next.js's documented source comment and avoiding a cookie-clear form Next.js explicitly does not use.

## Validation
- `vp test run tests/nextjs-compat/draft-mode.test.ts -t "cross-site|Next.js production cookie attributes"` failed before the fix with `SameSite=Lax` and `Max-Age=0`.
- `vp test run tests/nextjs-compat/draft-mode.test.ts`
- `vp test run tests/shims.test.ts -t "draftMode"`
- `vp lint`
- `vp fmt`
- `vp check`

## Risks / follow-ups
This intentionally changes only draft-mode cookie serialization. Request parsing, secret validation, generated entry wiring, and route-handler response plumbing are unchanged.