### PR TITLE
fix(app): apply layout segment config to pages

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -59,6 +59,8 @@ const appPageHeadPath = resolveEntryPath("../server/app-page-head.js", import.me
 const appPageParamsPath = resolveEntryPath("../server/app-page-params.js", import.meta.url);
 const appPageResponsePath = resolveEntryPath("../server/app-page-response.js", import.meta.url);
 const appPageDispatchPath = resolveEntryPath("../server/app-page-dispatch.js", import.meta.url);
+const appPageRequestPath = resolveEntryPath("../server/app-page-request.js", import.meta.url);
+const appSegmentConfigPath = resolveEntryPath("../server/app-segment-config.js", import.meta.url);
 const cspPath = resolveEntryPath("../server/csp.js", import.meta.url);
 const appRscRouteMatchingPath = resolveEntryPath(
   "../server/app-rsc-route-matching.js",
@@ -253,6 +255,13 @@ import {
 import {
   dispatchAppPage as __dispatchAppPage,
 } from ${JSON.stringify(appPageDispatchPath)};
+import {
+  resolveAppPageGenerateStaticParamsSources as __resolveAppPageGenerateStaticParamsSources,
+} from ${JSON.stringify(appPageRequestPath)};
+import {
+  resolveAppPageFetchCacheMode as __resolveAppPageFetchCacheMode,
+  resolveAppPageSegmentConfig as __resolveAppPageSegmentConfig,
+} from ${JSON.stringify(appSegmentConfigPath)};
 import { getScriptNonceFromHeaderSources as __getScriptNonceFromHeaderSources } from ${JSON.stringify(cspPath)};
 import { buildPageCacheTags } from ${JSON.stringify(implicitTagsPath)};
 import { getRequestExecutionContext as _getRequestExecutionContext } from ${JSON.stringify(requestContextShimPath)};
@@ -314,6 +323,13 @@ function __clearRequestContext() {
   setHeadersContext(null);
   setNavigationContext(null);
   // setNavigationContext(null) already clears root params internally
+}
+
+function __resolveRouteFetchCacheMode(route) {
+  return __resolveAppPageFetchCacheMode({
+    layouts: route.layouts,
+    page: route.page,
+  });
 }
 
 // Note: cache entries are written with \`headers: undefined\`. Next.js stores
@@ -853,6 +869,9 @@ ${prerenderPagesLoaderOption}
     readFormDataWithLimit: __readFormDataWithLimit,
     renderToReadableStream,
     reportRequestError: _reportRequestError,
+    resolveRouteFetchCacheMode(actionRoute) {
+      return __resolveRouteFetchCacheMode(actionRoute);
+    },
     request,
     sanitizeErrorForClient(error) {
       return __sanitizeErrorForClient(error);
@@ -992,6 +1011,16 @@ ${prerenderPagesLoaderOption}
   }
 
   const PageComponent = route.page?.default;
+  const __segmentConfig = __resolveAppPageSegmentConfig({
+    layouts: route.layouts,
+    page: route.page,
+  });
+  const __generateStaticParams = __resolveAppPageGenerateStaticParamsSources({
+    layouts: route.layouts,
+    layoutTreePositions: route.layoutTreePositions,
+    page: route.page,
+    routeSegments: route.routeSegments,
+  });
   const _asyncRouteParams = makeThenableParams(params);
   return __dispatchAppPage({
     buildPageElement(targetRoute, targetParams, targetOpts, targetSearchParams) {
@@ -1011,12 +1040,13 @@ ${prerenderPagesLoaderOption}
       return createRscOnErrorHandler(request, pathname, routePath);
     },
     debugClassification: __classDebug,
-    dynamicConfig: route.page?.dynamic,
-    dynamicParamsConfig: route.page?.dynamicParams,
+    dynamicConfig: __segmentConfig.dynamicConfig,
+    dynamicParamsConfig: __segmentConfig.dynamicParamsConfig,
+    fetchCache: __segmentConfig.fetchCache ?? null,
     findIntercept(pathname) {
       return findIntercept(pathname, interceptionContextHeader);
     },
-    generateStaticParams: route.page?.generateStaticParams,
+    generateStaticParams: __generateStaticParams,
     getFontLinks: _getSSRFontLinks,
     getFontPreloads: _getSSRFontPreloads,
     getFontStyles: _getSSRFontStyles,
@@ -1024,7 +1054,7 @@ ${prerenderPagesLoaderOption}
     getSourceRoute(sourceRouteIndex) {
       return routes[sourceRouteIndex];
     },
-    hasGenerateStaticParams: typeof route.page?.generateStaticParams === "function",
+    hasGenerateStaticParams: __generateStaticParams.length > 0,
     hasPageDefaultExport: !!PageComponent,
     hasPageModule: !!route.page,
     handlerStart: __reqStart,
@@ -1070,7 +1100,10 @@ ${prerenderPagesLoaderOption}
     },
     renderToReadableStream,
     request,
-    revalidateSeconds: typeof route.page?.revalidate === "number" ? route.page.revalidate : null,
+    revalidateSeconds: __segmentConfig.revalidateSeconds,
+    resolveRouteFetchCacheMode(targetRoute) {
+      return __resolveRouteFetchCacheMode(targetRoute);
+    },
     rootForbiddenModule,
     rootNotFoundModule,
     rootUnauthorizedModule,

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -16,7 +16,9 @@ import { getRequestExecutionContext } from "vinext/shims/request-context";
 import { createRequestContext, runWithRequestContext } from "vinext/shims/unified-request-context";
 import {
   ensureFetchPatch,
+  type FetchCacheMode,
   getCollectedFetchTags,
+  setCurrentFetchCacheMode,
   setCurrentFetchSoftTags,
 } from "vinext/shims/fetch-cache";
 import type { AppOutgoingElements } from "./app-elements.js";
@@ -126,6 +128,7 @@ type DispatchAppPageOptions<TRoute extends AppPageDispatchRoute> = {
   debugClassification?: (layoutId: string, reason: ClassificationReason) => void;
   dynamicConfig?: string;
   dynamicParamsConfig?: boolean;
+  fetchCache?: FetchCacheMode | null;
   findIntercept: (pathname: string) => AppPageDispatchIntercept | null;
   generateStaticParams?: ((args: { params: AppPageParams }) => unknown) | null;
   getFontLinks: () => string[];
@@ -168,6 +171,7 @@ type DispatchAppPageOptions<TRoute extends AppPageDispatchRoute> = {
   ) => ReadableStream<Uint8Array>;
   request: Request;
   revalidateSeconds: number | null;
+  resolveRouteFetchCacheMode?: (route: TRoute) => FetchCacheMode | null;
   rootForbiddenModule?: AppPageModule | null;
   rootNotFoundModule?: AppPageModule | null;
   rootUnauthorizedModule?: AppPageModule | null;
@@ -210,6 +214,7 @@ function buildAppPageTags(
 async function runAppPageRevalidationContext(
   options: {
     cleanPathname: string;
+    currentFetchCacheMode?: FetchCacheMode | null;
     dynamicConfig?: string;
     params: AppPageParams;
     routePattern: string;
@@ -233,6 +238,7 @@ async function runAppPageRevalidationContext(
   });
   const requestContext = createRequestContext({
     headersContext,
+    currentFetchCacheMode: options.currentFetchCacheMode ?? null,
     executionContext: getRequestExecutionContext(),
     unstableCacheRevalidation: "foreground",
   });
@@ -285,6 +291,7 @@ export async function dispatchAppPage<TRoute extends AppPageDispatchRoute>(
   const isForceDynamic = dynamicConfig === "force-dynamic";
 
   setCurrentFetchSoftTags(buildAppPageTags(options.cleanPathname, [], route.routeSegments));
+  setCurrentFetchCacheMode(options.fetchCache ?? null);
 
   if (options.hasPageModule && !options.hasPageDefaultExport) {
     options.clearRequestContext();
@@ -346,6 +353,7 @@ export async function dispatchAppPage<TRoute extends AppPageDispatchRoute>(
         runAppPageRevalidationContext(
           {
             cleanPathname: options.cleanPathname,
+            currentFetchCacheMode: options.fetchCache ?? null,
             dynamicConfig,
             params: options.params,
             routePattern: route.pattern,
@@ -440,6 +448,7 @@ export async function dispatchAppPage<TRoute extends AppPageDispatchRoute>(
     AppPageElement
   >({
     buildPageElement(interceptRoute, interceptParams, interceptOpts, interceptSearchParams) {
+      setCurrentFetchCacheMode(options.resolveRouteFetchCacheMode?.(interceptRoute) ?? null);
       return options.buildPageElement(
         interceptRoute,
         interceptParams,

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -38,6 +38,7 @@ import {
   buildAppPageElement,
   resolveAppPageIntercept,
   validateAppPageDynamicParams,
+  type ValidateAppPageDynamicParamsOptions,
 } from "./app-page-request.js";
 import { renderAppPageLifecycle } from "./app-page-render.js";
 import {
@@ -130,7 +131,7 @@ type DispatchAppPageOptions<TRoute extends AppPageDispatchRoute> = {
   dynamicParamsConfig?: boolean;
   fetchCache?: FetchCacheMode | null;
   findIntercept: (pathname: string) => AppPageDispatchIntercept | null;
-  generateStaticParams?: ((args: { params: AppPageParams }) => unknown) | null;
+  generateStaticParams?: ValidateAppPageDynamicParamsOptions["generateStaticParams"];
   getFontLinks: () => string[];
   getFontPreloads: () => AppPageFontPreload[];
   getFontStyles: () => string[];

--- a/packages/vinext/src/server/app-page-params.ts
+++ b/packages/vinext/src/server/app-page-params.ts
@@ -1,6 +1,6 @@
 import type { AppPageParams } from "./app-page-boundary.js";
 
-function getSegmentParamName(segment: string): string | null {
+export function getAppPageSegmentParamName(segment: string): string | null {
   if (segment.startsWith("[[...") && segment.endsWith("]]") && segment.length > 7) {
     return segment.slice(5, -2);
   }
@@ -36,7 +36,7 @@ export function resolveAppPageSegmentParams(
 
   for (let index = 0; index < end; index++) {
     const segment = segments[index];
-    const paramName = getSegmentParamName(segment);
+    const paramName = getAppPageSegmentParamName(segment);
     if (!paramName) {
       continue;
     }

--- a/packages/vinext/src/server/app-page-request.ts
+++ b/packages/vinext/src/server/app-page-request.ts
@@ -1,14 +1,35 @@
 import type { AppPageSpecialError } from "./app-page-execution.js";
 
 type AppPageParams = Record<string, string | string[]>;
+type GenerateStaticParams = (args: { params: AppPageParams }) => unknown;
+
+type GenerateStaticParamsModule = {
+  generateStaticParams?: GenerateStaticParams | null;
+};
+
+type GenerateStaticParamsSource = {
+  generateStaticParams: GenerateStaticParams;
+  parentParamNames: readonly string[];
+};
 
 type ValidateAppPageDynamicParamsOptions = {
   clearRequestContext: () => void;
   enforceStaticParamsOnly: boolean;
-  generateStaticParams?: ((args: { params: AppPageParams }) => unknown) | null;
+  generateStaticParams?:
+    | GenerateStaticParams
+    | GenerateStaticParamsSource
+    | readonly (GenerateStaticParams | GenerateStaticParamsSource | null | undefined)[]
+    | null;
   isDynamicRoute: boolean;
   logGenerateStaticParamsError?: (error: unknown) => void;
   params: AppPageParams;
+};
+
+type ResolveAppPageGenerateStaticParamsSourcesOptions = {
+  layouts?: readonly (GenerateStaticParamsModule | null | undefined)[];
+  layoutTreePositions?: readonly number[];
+  page?: GenerateStaticParamsModule | null;
+  routeSegments: readonly string[];
 };
 
 type BuildAppPageElementOptions<TElement> = {
@@ -114,6 +135,71 @@ function pickRouteParams(
   return params;
 }
 
+function dynamicParamNameFromRouteSegment(segment: string): string | null {
+  if (segment.startsWith("[[...") && segment.endsWith("]]")) return segment.slice(5, -2);
+  if (segment.startsWith("[...") && segment.endsWith("]")) return segment.slice(4, -1);
+  if (segment.startsWith("[") && segment.endsWith("]")) return segment.slice(1, -1);
+
+  if (!segment.startsWith(":")) return null;
+
+  const name = segment.slice(1).replace(/[+*?]$/, "");
+  return name || null;
+}
+
+function collectParentParamNames(
+  routeSegments: readonly string[],
+  boundaryPosition: number,
+): string[] {
+  const limit = Math.max(0, Math.min(boundaryPosition, routeSegments.length));
+  const names: string[] = [];
+
+  for (const segment of routeSegments.slice(0, limit)) {
+    const name = dynamicParamNameFromRouteSegment(segment);
+    if (name && !names.includes(name)) {
+      names.push(name);
+    }
+  }
+
+  return names;
+}
+
+function getLayoutGenerateStaticParamsBoundary(layoutTreePosition: number | undefined): number {
+  // A layout at app/[id]/layout.tsx has tree position 1, but its
+  // generateStaticParams belongs to the [id] segment and receives only parent
+  // params from segments before [id].
+  return (layoutTreePosition ?? 0) - 1;
+}
+
+export function resolveAppPageGenerateStaticParamsSources(
+  options: ResolveAppPageGenerateStaticParamsSourcesOptions,
+): GenerateStaticParamsSource[] {
+  const sources: GenerateStaticParamsSource[] = [];
+
+  options.layouts?.forEach((layout, index) => {
+    if (typeof layout?.generateStaticParams !== "function") return;
+
+    sources.push({
+      generateStaticParams: layout.generateStaticParams,
+      parentParamNames: collectParentParamNames(
+        options.routeSegments,
+        getLayoutGenerateStaticParamsBoundary(options.layoutTreePositions?.[index]),
+      ),
+    });
+  });
+
+  if (typeof options.page?.generateStaticParams === "function") {
+    sources.push({
+      generateStaticParams: options.page.generateStaticParams,
+      parentParamNames: collectParentParamNames(
+        options.routeSegments,
+        Math.max(0, options.routeSegments.length - 1),
+      ),
+    });
+  }
+
+  return sources;
+}
+
 function areStaticParamsAllowed(
   params: AppPageParams,
   staticParams: readonly Record<string, unknown>[],
@@ -148,22 +234,48 @@ function areStaticParamsAllowed(
   );
 }
 
+function normalizeGenerateStaticParams(
+  generateStaticParams: ValidateAppPageDynamicParamsOptions["generateStaticParams"],
+): GenerateStaticParamsSource[] {
+  const sources = Array.isArray(generateStaticParams)
+    ? generateStaticParams
+    : [generateStaticParams];
+
+  return sources.flatMap((source) => {
+    if (typeof source === "function") {
+      return [{ generateStaticParams: source, parentParamNames: [] }];
+    }
+
+    if (typeof source?.generateStaticParams === "function") {
+      return [source];
+    }
+
+    return [];
+  });
+}
+
 export async function validateAppPageDynamicParams(
   options: ValidateAppPageDynamicParamsOptions,
 ): Promise<Response | null> {
-  if (
-    !options.enforceStaticParamsOnly ||
-    !options.isDynamicRoute ||
-    typeof options.generateStaticParams !== "function"
-  ) {
+  if (!options.enforceStaticParamsOnly || !options.isDynamicRoute) {
     return null;
   }
 
+  const generateStaticParamsSources = normalizeGenerateStaticParams(options.generateStaticParams);
+  if (generateStaticParamsSources.length === 0) {
+    options.clearRequestContext();
+    return new Response("Not Found", { status: 404 });
+  }
+
   try {
-    const staticParams = await options.generateStaticParams({ params: options.params });
-    if (Array.isArray(staticParams) && !areStaticParamsAllowed(options.params, staticParams)) {
-      options.clearRequestContext();
-      return new Response("Not Found", { status: 404 });
+    for (const source of generateStaticParamsSources) {
+      const staticParams = await source.generateStaticParams({
+        params: pickRouteParams(options.params, source.parentParamNames),
+      });
+      if (Array.isArray(staticParams) && !areStaticParamsAllowed(options.params, staticParams)) {
+        options.clearRequestContext();
+        return new Response("Not Found", { status: 404 });
+      }
     }
   } catch (error) {
     options.logGenerateStaticParamsError?.(error);

--- a/packages/vinext/src/server/app-page-request.ts
+++ b/packages/vinext/src/server/app-page-request.ts
@@ -1,4 +1,5 @@
 import type { AppPageSpecialError } from "./app-page-execution.js";
+import { getAppPageSegmentParamName } from "./app-page-params.js";
 
 type AppPageParams = Record<string, string | string[]>;
 type GenerateStaticParams = (args: { params: AppPageParams }) => unknown;
@@ -12,7 +13,7 @@ type GenerateStaticParamsSource = {
   parentParamNames: readonly string[];
 };
 
-type ValidateAppPageDynamicParamsOptions = {
+export type ValidateAppPageDynamicParamsOptions = {
   clearRequestContext: () => void;
   enforceStaticParamsOnly: boolean;
   generateStaticParams?:
@@ -135,17 +136,6 @@ function pickRouteParams(
   return params;
 }
 
-function dynamicParamNameFromRouteSegment(segment: string): string | null {
-  if (segment.startsWith("[[...") && segment.endsWith("]]")) return segment.slice(5, -2);
-  if (segment.startsWith("[...") && segment.endsWith("]")) return segment.slice(4, -1);
-  if (segment.startsWith("[") && segment.endsWith("]")) return segment.slice(1, -1);
-
-  if (!segment.startsWith(":")) return null;
-
-  const name = segment.slice(1).replace(/[+*?]$/, "");
-  return name || null;
-}
-
 function collectParentParamNames(
   routeSegments: readonly string[],
   boundaryPosition: number,
@@ -154,7 +144,7 @@ function collectParentParamNames(
   const names: string[] = [];
 
   for (const segment of routeSegments.slice(0, limit)) {
-    const name = dynamicParamNameFromRouteSegment(segment);
+    const name = getAppPageSegmentParamName(segment);
     if (name && !names.includes(name)) {
       names.push(name);
     }

--- a/packages/vinext/src/server/app-segment-config.ts
+++ b/packages/vinext/src/server/app-segment-config.ts
@@ -1,0 +1,181 @@
+type AppRouteSegmentDynamic = "auto" | "error" | "force-dynamic" | "force-static";
+
+type AppRouteSegmentFetchCache =
+  | "auto"
+  | "default-cache"
+  | "default-no-store"
+  | "force-cache"
+  | "force-no-store"
+  | "only-cache"
+  | "only-no-store";
+
+type AppRouteSegmentConfigModule = {
+  dynamic?: unknown;
+  dynamicParams?: unknown;
+  fetchCache?: unknown;
+  revalidate?: unknown;
+};
+
+type EffectiveAppPageSegmentConfig = {
+  dynamicConfig?: AppRouteSegmentDynamic;
+  dynamicParamsConfig?: boolean;
+  fetchCache?: AppRouteSegmentFetchCache;
+  revalidateSeconds: number | null;
+};
+
+type ResolveAppPageSegmentConfigOptions = {
+  layouts?: readonly (AppRouteSegmentConfigModule | null | undefined)[];
+  page?: AppRouteSegmentConfigModule | null;
+};
+
+const DYNAMIC_VALUES = new Set<unknown>(["auto", "error", "force-dynamic", "force-static"]);
+const FETCH_CACHE_VALUES = new Set<unknown>([
+  "auto",
+  "default-cache",
+  "default-no-store",
+  "force-cache",
+  "force-no-store",
+  "only-cache",
+  "only-no-store",
+]);
+
+function isRouteSegmentDynamic(value: unknown): value is AppRouteSegmentDynamic {
+  return DYNAMIC_VALUES.has(value);
+}
+
+function isRouteSegmentFetchCache(value: unknown): value is AppRouteSegmentFetchCache {
+  return FETCH_CACHE_VALUES.has(value);
+}
+
+function resolveRevalidateSeconds(current: number | null, value: unknown): number | null {
+  // TODO: Next.js also accepts `revalidate = false` for indefinite caching.
+  // Existing vinext code ignores non-numeric values; keep that behavior until
+  // the cache layer can represent "cache forever" distinctly from "unset".
+  if (typeof value !== "number") {
+    return current;
+  }
+
+  if (current === null) {
+    return value;
+  }
+
+  return value < current ? value : current;
+}
+
+function isCacheFetchCacheMode(value: AppRouteSegmentFetchCache): boolean {
+  return value === "default-cache" || value === "force-cache" || value === "only-cache";
+}
+
+function describeFetchCacheConflict(value: AppRouteSegmentFetchCache): string {
+  return `Route segment config has incompatible fetchCache values including "${value}".`;
+}
+
+/**
+ * Resolve the route segment config that applies to an App page route.
+ *
+ * Next.js collects config from every segment in the loader tree and reduces it
+ * into the effective route config. The generated vinext entry already knows
+ * the concrete layout/page modules for a route, so it should only describe
+ * those modules and delegate the behavior to this helper.
+ */
+export function resolveAppPageSegmentConfig(
+  options: ResolveAppPageSegmentConfigOptions,
+): EffectiveAppPageSegmentConfig {
+  const segments = [...(options.layouts ?? []), options.page];
+  // Reduction strategies differ by field:
+  // - dynamic: child segments override parents.
+  // - dynamicParams: false is sticky across the route tree.
+  // - fetchCache: force/only modes take route-level precedence and reject conflicts.
+  // - revalidate: the shortest numeric interval wins.
+  const config: EffectiveAppPageSegmentConfig = {
+    revalidateSeconds: null,
+  };
+  let hasForceCache = false;
+  let hasForceNoStore = false;
+  let hasOnlyCache = false;
+  let hasOnlyNoStore = false;
+  let hasParentDefaultNoStore = false;
+
+  for (const segment of segments) {
+    if (!segment) continue;
+
+    if (isRouteSegmentDynamic(segment.dynamic)) {
+      config.dynamicConfig = segment.dynamic;
+    }
+
+    if (segment.dynamicParams === false) {
+      config.dynamicParamsConfig = false;
+    } else if (segment.dynamicParams === true && config.dynamicParamsConfig !== false) {
+      config.dynamicParamsConfig = true;
+    }
+
+    if (isRouteSegmentFetchCache(segment.fetchCache)) {
+      const fetchCache = segment.fetchCache;
+
+      if (hasParentDefaultNoStore && (fetchCache === "auto" || isCacheFetchCacheMode(fetchCache))) {
+        throw new Error(describeFetchCacheConflict(fetchCache));
+      }
+
+      if (fetchCache === "force-cache") hasForceCache = true;
+      if (fetchCache === "force-no-store") hasForceNoStore = true;
+      if (fetchCache === "only-cache") hasOnlyCache = true;
+      if (fetchCache === "only-no-store") hasOnlyNoStore = true;
+
+      const hasCacheEnforcer = hasForceCache || hasOnlyCache;
+      const hasNoStoreEnforcer = hasForceNoStore || hasOnlyNoStore;
+      if (hasCacheEnforcer && hasNoStoreEnforcer) {
+        throw new Error(describeFetchCacheConflict(fetchCache));
+      }
+
+      if (fetchCache === "default-no-store") {
+        hasParentDefaultNoStore = true;
+      }
+
+      if (hasForceCache) {
+        config.fetchCache = "force-cache";
+      } else if (hasForceNoStore) {
+        config.fetchCache = "force-no-store";
+      } else if (hasOnlyCache) {
+        config.fetchCache = "only-cache";
+      } else if (hasOnlyNoStore) {
+        config.fetchCache = "only-no-store";
+      } else {
+        config.fetchCache = fetchCache;
+      }
+    }
+
+    config.revalidateSeconds = resolveRevalidateSeconds(
+      config.revalidateSeconds,
+      segment.revalidate,
+    );
+  }
+
+  if (config.dynamicConfig === "force-dynamic") {
+    config.revalidateSeconds = 0;
+  }
+
+  // Top-level dynamic modes supply fetchCache defaults unless a segment does.
+  if (config.fetchCache === undefined) {
+    if (config.dynamicConfig === "force-dynamic") {
+      config.fetchCache = "force-no-store";
+    } else if (config.dynamicConfig === "error") {
+      config.fetchCache = "only-cache";
+    }
+  }
+
+  // Static-only dynamic modes change the default, but explicit dynamicParams wins.
+  if (
+    config.dynamicParamsConfig === undefined &&
+    (config.dynamicConfig === "error" || config.dynamicConfig === "force-static")
+  ) {
+    config.dynamicParamsConfig = false;
+  }
+
+  return config;
+}
+
+export function resolveAppPageFetchCacheMode(
+  options: ResolveAppPageSegmentConfigOptions,
+): AppRouteSegmentFetchCache | null {
+  return resolveAppPageSegmentConfig(options).fetchCache ?? null;
+}

--- a/packages/vinext/src/server/app-segment-config.ts
+++ b/packages/vinext/src/server/app-segment-config.ts
@@ -1,13 +1,6 @@
-type AppRouteSegmentDynamic = "auto" | "error" | "force-dynamic" | "force-static";
+import type { FetchCacheMode } from "vinext/shims/fetch-cache";
 
-type AppRouteSegmentFetchCache =
-  | "auto"
-  | "default-cache"
-  | "default-no-store"
-  | "force-cache"
-  | "force-no-store"
-  | "only-cache"
-  | "only-no-store";
+type AppRouteSegmentDynamic = "auto" | "error" | "force-dynamic" | "force-static";
 
 type AppRouteSegmentConfigModule = {
   dynamic?: unknown;
@@ -19,7 +12,7 @@ type AppRouteSegmentConfigModule = {
 type EffectiveAppPageSegmentConfig = {
   dynamicConfig?: AppRouteSegmentDynamic;
   dynamicParamsConfig?: boolean;
-  fetchCache?: AppRouteSegmentFetchCache;
+  fetchCache?: FetchCacheMode;
   revalidateSeconds: number | null;
 };
 
@@ -43,7 +36,7 @@ function isRouteSegmentDynamic(value: unknown): value is AppRouteSegmentDynamic 
   return DYNAMIC_VALUES.has(value);
 }
 
-function isRouteSegmentFetchCache(value: unknown): value is AppRouteSegmentFetchCache {
+function isRouteSegmentFetchCache(value: unknown): value is FetchCacheMode {
   return FETCH_CACHE_VALUES.has(value);
 }
 
@@ -62,11 +55,11 @@ function resolveRevalidateSeconds(current: number | null, value: unknown): numbe
   return value < current ? value : current;
 }
 
-function isCacheFetchCacheMode(value: AppRouteSegmentFetchCache): boolean {
+function isCacheFetchCacheMode(value: FetchCacheMode): boolean {
   return value === "default-cache" || value === "force-cache" || value === "only-cache";
 }
 
-function describeFetchCacheConflict(value: AppRouteSegmentFetchCache): string {
+function describeFetchCacheConflict(value: FetchCacheMode): string {
   return `Route segment config has incompatible fetchCache values including "${value}".`;
 }
 
@@ -176,6 +169,6 @@ export function resolveAppPageSegmentConfig(
 
 export function resolveAppPageFetchCacheMode(
   options: ResolveAppPageSegmentConfigOptions,
-): AppRouteSegmentFetchCache | null {
+): FetchCacheMode | null {
   return resolveAppPageSegmentConfig(options).fetchCache ?? null;
 }

--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -1,4 +1,5 @@
 import type { HeadersAccessPhase } from "vinext/shims/headers";
+import { type FetchCacheMode, setCurrentFetchCacheMode } from "vinext/shims/fetch-cache";
 import { resolveAppPageActionRerenderTarget } from "./app-page-request.js";
 import { mergeMiddlewareResponseHeaders } from "./middleware-response-headers.js";
 import { validateCsrfOrigin, validateServerActionPayload } from "./request-pipeline.js";
@@ -144,6 +145,7 @@ export type HandleServerActionRscRequestOptions<
     options: RenderServerActionRscStreamOptions<TTemporaryReferences>,
   ) => BodyInit | null | Promise<BodyInit | null>;
   reportRequestError: AppServerActionErrorReporter;
+  resolveRouteFetchCacheMode?: (route: TRoute) => FetchCacheMode | null;
   request: Request;
   sanitizeErrorForClient: (error: unknown) => unknown;
   searchParams: URLSearchParams;
@@ -611,6 +613,9 @@ export async function handleServerActionRscRequest<
         searchParams: options.searchParams,
         params: actionRerenderTarget.navigationParams,
       });
+      setCurrentFetchCacheMode(
+        options.resolveRouteFetchCacheMode?.(actionRerenderTarget.route) ?? null,
+      );
       element = options.buildPageElement({
         cleanPathname: options.cleanPathname,
         interceptOpts: actionRerenderTarget.interceptOpts,

--- a/packages/vinext/src/shims/fetch-cache.ts
+++ b/packages/vinext/src/shims/fetch-cache.ts
@@ -469,7 +469,17 @@ const originalFetch: typeof globalThis.fetch = (_gFetch[_ORIG_FETCH_KEY] ??=
 export type FetchCacheState = {
   currentRequestTags: string[];
   currentFetchSoftTags: string[];
+  currentFetchCacheMode: FetchCacheMode | null;
 };
+
+export type FetchCacheMode =
+  | "auto"
+  | "default-cache"
+  | "default-no-store"
+  | "force-cache"
+  | "force-no-store"
+  | "only-cache"
+  | "only-no-store";
 
 const _ALS_KEY = Symbol.for("vinext.fetchCache.als");
 const _FALLBACK_KEY = Symbol.for("vinext.fetchCache.fallback");
@@ -480,6 +490,7 @@ const _als = (_g[_ALS_KEY] ??=
 const _fallbackState = (_g[_FALLBACK_KEY] ??= {
   currentRequestTags: [],
   currentFetchSoftTags: [],
+  currentFetchCacheMode: null,
 } satisfies FetchCacheState) as FetchCacheState;
 
 function _getState(): FetchCacheState {
@@ -496,6 +507,7 @@ function _getState(): FetchCacheState {
 function _resetFallbackState(): void {
   _fallbackState.currentRequestTags = [];
   _fallbackState.currentFetchSoftTags = [];
+  _fallbackState.currentFetchCacheMode = null;
 }
 
 /**
@@ -518,6 +530,90 @@ export function setCurrentFetchSoftTags(tags: string[]): void {
   _getState().currentFetchSoftTags = [...tags];
 }
 
+export function setCurrentFetchCacheMode(mode: FetchCacheMode | null): void {
+  _getState().currentFetchCacheMode = mode;
+}
+
+function isNoStoreFetch(
+  cacheDirective: RequestCache | undefined,
+  nextOpts: NextFetchOptions | undefined,
+): boolean {
+  return (
+    cacheDirective === "no-store" ||
+    cacheDirective === "no-cache" ||
+    nextOpts?.revalidate === false ||
+    nextOpts?.revalidate === 0
+  );
+}
+
+function isCacheableFetch(
+  cacheDirective: RequestCache | undefined,
+  nextOpts: NextFetchOptions | undefined,
+): boolean {
+  return (
+    cacheDirective === "force-cache" ||
+    (typeof nextOpts?.revalidate === "number" && nextOpts.revalidate > 0)
+  );
+}
+
+function hasExplicitRevalidateValue(nextOpts: NextFetchOptions | undefined): boolean {
+  return nextOpts?.revalidate !== undefined;
+}
+
+function resolveSegmentCacheDirective(
+  cacheDirective: RequestCache | undefined,
+  nextOpts: NextFetchOptions | undefined,
+  mode: FetchCacheMode | null,
+): RequestCache | undefined {
+  if (!mode || mode === "auto") {
+    return cacheDirective;
+  }
+
+  switch (mode) {
+    case "force-cache":
+      return "force-cache";
+    case "force-no-store":
+      return "no-store";
+    case "only-cache": {
+      if (isNoStoreFetch(cacheDirective, nextOpts)) {
+        throw new Error(
+          'Route segment config `fetchCache = "only-cache"` conflicts with no-store fetch.',
+        );
+      }
+      return cacheDirective ?? "force-cache";
+    }
+    case "only-no-store": {
+      if (isCacheableFetch(cacheDirective, nextOpts)) {
+        throw new Error(
+          'Route segment config `fetchCache = "only-no-store"` conflicts with cacheable fetch.',
+        );
+      }
+      return cacheDirective ?? "no-store";
+    }
+    case "default-cache":
+      return cacheDirective ?? (hasExplicitRevalidateValue(nextOpts) ? undefined : "force-cache");
+    case "default-no-store":
+      return cacheDirective ?? (hasExplicitRevalidateValue(nextOpts) ? undefined : "no-store");
+  }
+
+  return cacheDirective;
+}
+
+function getFetchCacheDirective(
+  input: string | URL | Request,
+  init: RequestInit | undefined,
+): RequestCache | undefined {
+  if (init?.cache !== undefined) {
+    return init.cache;
+  }
+  // Request.cache defaults to "default" even when the caller did not pass a
+  // cache mode, so keep segment defaults free to apply in that case.
+  if (!(input instanceof Request) || input.cache === "default") {
+    return undefined;
+  }
+  return input.cache;
+}
+
 /**
  * Create a patched fetch function with Next.js caching semantics.
  *
@@ -536,7 +632,11 @@ function createPatchedFetch(): typeof globalThis.fetch {
     const nextOpts = (init as ExtendedRequestInit | undefined)?.next as
       | NextFetchOptions
       | undefined;
-    const cacheDirective = init?.cache;
+    const cacheDirective = resolveSegmentCacheDirective(
+      getFetchCacheDirective(input, init),
+      nextOpts,
+      _getState().currentFetchCacheMode,
+    );
 
     // Determine caching behavior:
     // - cache: 'no-store' → skip cache entirely
@@ -559,7 +659,7 @@ function createPatchedFetch(): typeof globalThis.fetch {
       nextOpts?.revalidate === 0
     ) {
       // Strip the `next` property before passing to real fetch
-      const cleanInit = stripNextFromInit(init);
+      const cleanInit = stripNextFromInit(init, cacheDirective);
       return originalFetch(input, cleanInit);
     }
 
@@ -572,7 +672,7 @@ function createPatchedFetch(): typeof globalThis.fetch {
       cacheDirective === "force-cache" ||
       (typeof nextOpts?.revalidate === "number" && nextOpts.revalidate > 0);
     if (!hasExplicitCacheOpt && hasAuthHeaders(input, init)) {
-      const cleanInit = stripNextFromInit(init);
+      const cleanInit = stripNextFromInit(init, cacheDirective);
       return originalFetch(input, cleanInit);
     }
 
@@ -594,23 +694,27 @@ function createPatchedFetch(): typeof globalThis.fetch {
         revalidateSeconds = 31536000;
       } else {
         // next: {} with no revalidate or tags — pass through
-        const cleanInit = stripNextFromInit(init);
+        const cleanInit = stripNextFromInit(init, cacheDirective);
         return originalFetch(input, cleanInit);
       }
     }
 
     const tags = nextOpts?.tags ?? [];
     const softTags = _getState().currentFetchSoftTags;
+    let fetchInit = stripNextFromInit(init, cacheDirective);
     let cacheKey: string;
     try {
-      cacheKey = await buildFetchCacheKey(input, init);
+      cacheKey = await buildFetchCacheKey(input, fetchInit);
+      // Cache-key generation may consume and stash request bodies on fetchInit;
+      // normalize again so the real fetch receives the restored body.
+      fetchInit = stripNextFromInit(fetchInit, cacheDirective);
     } catch (err) {
       if (
         err instanceof BodyTooLargeForCacheKeyError ||
         err instanceof SkipCacheKeyGenerationError
       ) {
-        const cleanInit = stripNextFromInit(init);
-        return originalFetch(input, cleanInit);
+        fetchInit = stripNextFromInit(fetchInit, cacheDirective);
+        return originalFetch(input, fetchInit);
       }
       throw err;
     }
@@ -647,8 +751,7 @@ function createPatchedFetch(): typeof globalThis.fetch {
         // Background refetch — deduped so only one in-flight refetch runs
         // per cache key, preventing thundering herd on popular endpoints.
         if (!pendingRefetches.has(cacheKey)) {
-          const cleanInit = stripNextFromInit(init);
-          const refetchPromise = originalFetch(input, cleanInit)
+          const refetchPromise = originalFetch(input, fetchInit)
             .then(async (freshResp) => {
               // Only cache 200 responses — a transient error or unexpected
               // status must not overwrite previously-good cached data.
@@ -730,8 +833,7 @@ function createPatchedFetch(): typeof globalThis.fetch {
     }
 
     // Cache miss — fetch from network
-    const cleanInit = stripNextFromInit(init);
-    const response = await originalFetch(input, cleanInit);
+    const response = await originalFetch(input, fetchInit);
 
     // Only cache 200 responses
     if (response.status === 200) {
@@ -780,10 +882,18 @@ function createPatchedFetch(): typeof globalThis.fetch {
  * The `next` property is not a standard fetch option and would cause warnings
  * in some environments.
  */
-function stripNextFromInit(init?: RequestInit): RequestInit | undefined {
-  if (!init) return init;
+function stripNextFromInit(
+  init?: RequestInit,
+  cacheOverride?: RequestCache,
+): RequestInit | undefined {
+  if (!init) {
+    return cacheOverride === undefined ? undefined : { cache: cacheOverride };
+  }
   const castInit = init as ExtendedRequestInit;
   const { next: _next, _ogBody, ...rest } = castInit;
+  if (cacheOverride !== undefined) {
+    rest.cache = cacheOverride;
+  }
   // Restore the original body if it was stashed by serializeBody (e.g. after
   // consuming a ReadableStream for cache key generation).
   if (_ogBody !== undefined) {
@@ -844,7 +954,10 @@ export async function runWithFetchCache<T>(fn: () => Promise<T>): Promise<T> {
       uCtx.currentFetchSoftTags = [];
     }, fn);
   }
-  return _als.run({ currentRequestTags: [], currentFetchSoftTags: [] }, fn);
+  return _als.run(
+    { currentRequestTags: [], currentFetchSoftTags: [], currentFetchCacheMode: null },
+    fn,
+  );
 }
 
 /**

--- a/packages/vinext/src/shims/unified-request-context.ts
+++ b/packages/vinext/src/shims/unified-request-context.ts
@@ -99,6 +99,7 @@ export function createRequestContext(opts?: Partial<UnifiedRequestContext>): Uni
     _privateCache: null,
     currentRequestTags: [],
     currentFetchSoftTags: [],
+    currentFetchCacheMode: null,
     executionContext: _getInheritedExecutionContext(), // inherits from standalone ALS if present
     requestCache: new WeakMap(),
     ssrContext: null,

--- a/tests/app-page-request.test.ts
+++ b/tests/app-page-request.test.ts
@@ -5,6 +5,7 @@ import {
   resolveAppPageActionRerenderTarget,
   resolveAppPageIntercept,
   resolveAppPageInterceptMatch,
+  resolveAppPageGenerateStaticParamsSources,
   validateAppPageDynamicParams,
 } from "../packages/vinext/src/server/app-page-request.js";
 
@@ -27,6 +28,22 @@ describe("app page request helpers", () => {
     expect(clearRequestContext).toHaveBeenCalledTimes(1);
   });
 
+  it("returns 404 when dynamicParams=false has no static params sources", async () => {
+    const clearRequestContext = vi.fn();
+
+    const response = await validateAppPageDynamicParams({
+      clearRequestContext,
+      enforceStaticParamsOnly: true,
+      generateStaticParams: undefined,
+      isDynamicRoute: true,
+      params: { slug: "anything" },
+    });
+
+    expect(response?.status).toBe(404);
+    await expect(response?.text()).resolves.toBe("Not Found");
+    expect(clearRequestContext).toHaveBeenCalledTimes(1);
+  });
+
   it("allows matching static params, including nested parent params", async () => {
     const clearRequestContext = vi.fn();
 
@@ -42,6 +59,54 @@ describe("app page request helpers", () => {
 
     expect(response).toBeNull();
     expect(clearRequestContext).not.toHaveBeenCalled();
+  });
+
+  it("requires every segment generateStaticParams source to allow the params", async () => {
+    const clearRequestContext = vi.fn();
+    const layoutGenerateStaticParams = async () => [{ category: "docs" }];
+    const pageGenerateStaticParams = async () => [{ slug: "intro" }];
+
+    const response = await validateAppPageDynamicParams({
+      clearRequestContext,
+      enforceStaticParamsOnly: true,
+      generateStaticParams: [layoutGenerateStaticParams, pageGenerateStaticParams],
+      isDynamicRoute: true,
+      params: { category: "docs", slug: "missing" },
+    });
+
+    expect(response?.status).toBe(404);
+    expect(clearRequestContext).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes parent-only params to each generateStaticParams source", async () => {
+    const clearRequestContext = vi.fn();
+    const categoryGenerateStaticParams = vi.fn(() => [{ category: "docs" }]);
+    const itemGenerateStaticParams = vi.fn(
+      ({ params }: { params: Record<string, string | string[]> }) => {
+        if (params.category !== "docs" || params.slug !== undefined) {
+          return [];
+        }
+        return [{ slug: "intro" }];
+      },
+    );
+
+    const response = await validateAppPageDynamicParams({
+      clearRequestContext,
+      enforceStaticParamsOnly: true,
+      generateStaticParams: resolveAppPageGenerateStaticParamsSources({
+        layouts: [null, { generateStaticParams: categoryGenerateStaticParams }],
+        layoutTreePositions: [0, 1],
+        page: { generateStaticParams: itemGenerateStaticParams },
+        routeSegments: ["[category]", "[slug]"],
+      }),
+      isDynamicRoute: true,
+      params: { category: "docs", slug: "intro" },
+    });
+
+    expect(response).toBeNull();
+    expect(clearRequestContext).not.toHaveBeenCalled();
+    expect(categoryGenerateStaticParams).toHaveBeenCalledWith({ params: {} });
+    expect(itemGenerateStaticParams).toHaveBeenCalledWith({ params: { category: "docs" } });
   });
 
   it("logs and falls through when generateStaticParams throws", async () => {

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -1335,6 +1335,53 @@ describe("App Router integration", () => {
     expect(html).toContain("any-random-slug");
   });
 
+  it("applies dynamicParams = false exported from a layout to child pages", async () => {
+    const known = await fetch(`${baseUrl}/layout-segment-config/dynamic/known`);
+    expect(known.status).toBe(200);
+    expect(await known.text()).toContain('data-testid="layout-segment-config-dynamic"');
+
+    const unknown = await fetch(`${baseUrl}/layout-segment-config/dynamic/unknown`);
+    expect(unknown.status).toBe(404);
+  });
+
+  it("uses layout-level generateStaticParams when enforcing dynamicParams = false", async () => {
+    const known = await fetch(`${baseUrl}/layout-segment-config/layout-gsp/known`);
+    expect(known.status).toBe(200);
+    expect(await known.text()).toContain('data-testid="layout-segment-config-layout-gsp"');
+
+    const unknown = await fetch(`${baseUrl}/layout-segment-config/layout-gsp/unknown`);
+    expect(unknown.status).toBe(404);
+  });
+
+  it("returns 404 when dynamicParams = false has no generateStaticParams sources", async () => {
+    const res = await fetch(`${baseUrl}/layout-segment-config/no-gsp/anything`);
+    expect(res.status).toBe(404);
+  });
+
+  it("passes parent-only params to nested generateStaticParams during dynamicParams validation", async () => {
+    const known = await fetch(`${baseUrl}/layout-segment-config/nested-gsp/docs/intro`);
+    expect(known.status).toBe(200);
+    expect(await known.text()).toContain('data-testid="layout-segment-config-nested-gsp"');
+
+    const unknown = await fetch(`${baseUrl}/layout-segment-config/nested-gsp/docs/missing`);
+    expect(unknown.status).toBe(404);
+  });
+
+  it("defaults dynamicParams to false under a dynamic = 'error' layout", async () => {
+    const known = await fetch(`${baseUrl}/layout-segment-config/dynamic-error/known`);
+    expect(known.status).toBe(200);
+    expect(await known.text()).toContain('data-testid="layout-segment-config-dynamic-error"');
+
+    const unknown = await fetch(`${baseUrl}/layout-segment-config/dynamic-error/unknown`);
+    expect(unknown.status).toBe(404);
+  });
+
+  it("applies dynamic = 'error' as only-cache fetch policy", async () => {
+    const res = await fetch(`${baseUrl}/layout-segment-config/dynamic-error-fetch`);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("only-cache");
+  });
+
   it("generateStaticParams receives parent params in nested dynamic routes", async () => {
     // /shop/[category]/[item] — the item page's generateStaticParams receives { category }
     const res = await fetch(`${baseUrl}/shop/electronics/phone`);
@@ -1375,6 +1422,23 @@ describe("App Router integration", () => {
     const cacheControl = res.headers.get("cache-control");
     expect(cacheControl).toContain("s-maxage=60");
     expect(cacheControl).toContain("stale-while-revalidate");
+  });
+
+  it("applies revalidate exported from a layout to child pages", async () => {
+    const res = await fetch(`${baseUrl}/layout-segment-config/revalidate`);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain('data-testid="layout-segment-config-revalidate"');
+
+    const cacheControl = res.headers.get("cache-control");
+    expect(cacheControl).toContain("s-maxage=30");
+    expect(cacheControl).toContain("stale-while-revalidate");
+  });
+
+  it("applies dynamic = 'force-dynamic' exported from a layout to child pages", async () => {
+    const res = await fetch(`${baseUrl}/layout-segment-config/force-dynamic`);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain('data-testid="layout-segment-config-force-dynamic"');
+    expect(res.headers.get("cache-control")).toContain("no-store");
   });
 
   it("search page renders Form component with SSR", async () => {

--- a/tests/app-segment-config.test.ts
+++ b/tests/app-segment-config.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveAppPageFetchCacheMode,
+  resolveAppPageSegmentConfig,
+} from "../packages/vinext/src/server/app-segment-config.js";
+
+describe("resolveAppPageSegmentConfig", () => {
+  it("returns defaults when no segment config is present", () => {
+    expect(resolveAppPageSegmentConfig({})).toEqual({
+      revalidateSeconds: null,
+    });
+  });
+
+  it("merges route segment config from layouts and the page", () => {
+    expect(
+      resolveAppPageSegmentConfig({
+        layouts: [
+          { revalidate: 120, dynamicParams: false, fetchCache: "default-cache" },
+          { dynamic: "error", revalidate: 60 },
+        ],
+        page: { dynamic: "force-static", revalidate: 300 },
+      }),
+    ).toEqual({
+      dynamicConfig: "force-static",
+      dynamicParamsConfig: false,
+      fetchCache: "default-cache",
+      revalidateSeconds: 60,
+    });
+  });
+
+  it("treats force-dynamic from any effective segment as revalidate zero", () => {
+    expect(
+      resolveAppPageSegmentConfig({
+        layouts: [{ revalidate: 60 }],
+        page: { dynamic: "force-dynamic" },
+      }),
+    ).toEqual({
+      dynamicConfig: "force-dynamic",
+      fetchCache: "force-no-store",
+      revalidateSeconds: 0,
+    });
+  });
+
+  it("derives fetchCache from static-only dynamic modes", () => {
+    expect(
+      resolveAppPageSegmentConfig({
+        layouts: [{ dynamic: "error" }],
+        page: {},
+      }),
+    ).toEqual({
+      dynamicConfig: "error",
+      dynamicParamsConfig: false,
+      fetchCache: "only-cache",
+      revalidateSeconds: null,
+    });
+  });
+
+  it("lets explicit fetchCache override the dynamic mode default", () => {
+    expect(
+      resolveAppPageSegmentConfig({
+        layouts: [{ dynamic: "error" }],
+        page: { fetchCache: "default-cache" },
+      }),
+    ).toEqual({
+      dynamicConfig: "error",
+      dynamicParamsConfig: false,
+      fetchCache: "default-cache",
+      revalidateSeconds: null,
+    });
+  });
+
+  it("resolves fetchCache force modes with route-level precedence", () => {
+    expect(
+      resolveAppPageSegmentConfig({
+        layouts: [{ fetchCache: "only-cache" }],
+        page: { fetchCache: "force-cache" },
+      }).fetchCache,
+    ).toBe("force-cache");
+
+    expect(
+      resolveAppPageSegmentConfig({
+        layouts: [{ fetchCache: "force-no-store" }],
+        page: { fetchCache: "only-no-store" },
+      }).fetchCache,
+    ).toBe("force-no-store");
+  });
+
+  it("rejects incompatible cross-segment fetchCache modes", () => {
+    expect(() =>
+      resolveAppPageSegmentConfig({
+        layouts: [{ fetchCache: "only-cache" }],
+        page: { fetchCache: "only-no-store" },
+      }),
+    ).toThrow(/incompatible fetchCache/);
+
+    expect(() =>
+      resolveAppPageSegmentConfig({
+        layouts: [{ fetchCache: "force-cache" }],
+        page: { fetchCache: "force-no-store" },
+      }),
+    ).toThrow(/incompatible fetchCache/);
+
+    expect(() =>
+      resolveAppPageSegmentConfig({
+        layouts: [{ fetchCache: "default-no-store" }],
+        page: { fetchCache: "auto" },
+      }),
+    ).toThrow(/incompatible fetchCache/);
+  });
+
+  it("ignores unknown dynamic values", () => {
+    expect(
+      resolveAppPageSegmentConfig({
+        layouts: [{ dynamic: "sometimes" }],
+        page: { dynamic: "force-static" },
+      }),
+    ).toEqual({
+      dynamicConfig: "force-static",
+      dynamicParamsConfig: false,
+      revalidateSeconds: null,
+    });
+  });
+
+  it("defaults dynamicParams to false for static-only dynamic modes", () => {
+    expect(
+      resolveAppPageSegmentConfig({
+        layouts: [{ dynamic: "error" }],
+        page: {},
+      }),
+    ).toEqual({
+      dynamicConfig: "error",
+      dynamicParamsConfig: false,
+      fetchCache: "only-cache",
+      revalidateSeconds: null,
+    });
+
+    expect(
+      resolveAppPageSegmentConfig({
+        layouts: [{ dynamic: "force-static" }],
+        page: {},
+      }),
+    ).toEqual({
+      dynamicConfig: "force-static",
+      dynamicParamsConfig: false,
+      revalidateSeconds: null,
+    });
+  });
+
+  it("lets explicit dynamicParams override static-only dynamic defaults", () => {
+    expect(
+      resolveAppPageSegmentConfig({
+        layouts: [{ dynamic: "error" }],
+        page: { dynamicParams: true },
+      }),
+    ).toEqual({
+      dynamicConfig: "error",
+      dynamicParamsConfig: true,
+      fetchCache: "only-cache",
+      revalidateSeconds: null,
+    });
+  });
+
+  it("keeps explicit dynamicParams false sticky across child segments", () => {
+    expect(
+      resolveAppPageSegmentConfig({
+        layouts: [{ dynamicParams: false }],
+        page: { dynamicParams: true },
+      }),
+    ).toEqual({
+      dynamicParamsConfig: false,
+      revalidateSeconds: null,
+    });
+  });
+
+  it("resolves just the fetchCache mode for route-specific render scopes", () => {
+    expect(
+      resolveAppPageFetchCacheMode({
+        layouts: [{ fetchCache: "only-cache" }],
+        page: {},
+      }),
+    ).toBe("only-cache");
+
+    expect(
+      resolveAppPageFetchCacheMode({
+        layouts: [{ revalidate: 60 }],
+        page: {},
+      }),
+    ).toBeNull();
+  });
+});

--- a/tests/fetch-cache.test.ts
+++ b/tests/fetch-cache.test.ts
@@ -37,6 +37,7 @@ const {
   withFetchCache,
   runWithFetchCache,
   getCollectedFetchTags,
+  setCurrentFetchCacheMode,
   setCurrentFetchSoftTags,
   getOriginalFetch,
   _resetPendingRefetches,
@@ -99,6 +100,156 @@ describe("fetch cache shim", () => {
     const data2 = await res2.json();
     expect(data2.count).toBe(1); // Cached
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("segment fetchCache default-cache caches fetches without per-fetch options", async () => {
+    setCurrentFetchCacheMode("default-cache");
+
+    const res1 = await fetch("https://api.example.com/segment-default-cache");
+    const data1 = await res1.json();
+    expect(data1.count).toBe(1);
+
+    const res2 = await fetch("https://api.example.com/segment-default-cache");
+    const data2 = await res2.json();
+    expect(data2.count).toBe(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("segment fetchCache default-cache caches Request inputs without per-fetch options", async () => {
+    setCurrentFetchCacheMode("default-cache");
+
+    const res1 = await fetch(new Request("https://api.example.com/segment-request-default-cache"));
+    const data1 = await res1.json();
+    expect(data1.count).toBe(1);
+
+    const res2 = await fetch(new Request("https://api.example.com/segment-request-default-cache"));
+    const data2 = await res2.json();
+    expect(data2.count).toBe(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("segment fetchCache default-cache caches fetches with metadata-only next options", async () => {
+    setCurrentFetchCacheMode("default-cache");
+
+    const res1 = await fetch("https://api.example.com/segment-default-cache-tags", {
+      next: { tags: ["segment-default-cache-tags"] },
+    });
+    const data1 = await res1.json();
+    expect(data1.count).toBe(1);
+
+    const res2 = await fetch("https://api.example.com/segment-default-cache-tags", {
+      next: { tags: ["segment-default-cache-tags"] },
+    });
+    const data2 = await res2.json();
+    expect(data2.count).toBe(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("segment fetchCache default-cache does not override explicit no-store", async () => {
+    setCurrentFetchCacheMode("default-cache");
+
+    const res1 = await fetch("https://api.example.com/segment-explicit-no-store", {
+      cache: "no-store",
+    });
+    const data1 = await res1.json();
+    expect(data1.count).toBe(1);
+
+    const res2 = await fetch("https://api.example.com/segment-explicit-no-store", {
+      cache: "no-store",
+    });
+    const data2 = await res2.json();
+    expect(data2.count).toBe(2);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("segment fetchCache default-no-store bypasses cache with metadata-only next options", async () => {
+    setCurrentFetchCacheMode("default-no-store");
+
+    const res1 = await fetch("https://api.example.com/segment-default-no-store-tags", {
+      next: { tags: ["segment-default-no-store-tags"] },
+    });
+    const data1 = await res1.json();
+    expect(data1.count).toBe(1);
+
+    const res2 = await fetch("https://api.example.com/segment-default-no-store-tags", {
+      next: { tags: ["segment-default-no-store-tags"] },
+    });
+    const data2 = await res2.json();
+    expect(data2.count).toBe(2);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("segment fetchCache force-no-store overrides explicit force-cache", async () => {
+    setCurrentFetchCacheMode("force-no-store");
+
+    const res1 = await fetch("https://api.example.com/segment-force-no-store", {
+      cache: "force-cache",
+    });
+    const data1 = await res1.json();
+    expect(data1.count).toBe(1);
+
+    const res2 = await fetch("https://api.example.com/segment-force-no-store", {
+      cache: "force-cache",
+    });
+    const data2 = await res2.json();
+    expect(data2.count).toBe(2);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("segment fetchCache force-no-store forwards no-store to the real fetch", async () => {
+    setCurrentFetchCacheMode("force-no-store");
+
+    await fetch("https://api.example.com/segment-force-no-store-init", {
+      cache: "force-cache",
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith("https://api.example.com/segment-force-no-store-init", {
+      cache: "no-store",
+    });
+  });
+
+  it("segment fetchCache only-cache rejects no-store fetches", async () => {
+    setCurrentFetchCacheMode("only-cache");
+
+    await expect(
+      fetch("https://api.example.com/segment-only-cache", {
+        cache: "no-store",
+      }),
+    ).rejects.toThrow(/only-cache/);
+  });
+
+  it("segment fetchCache only-cache rejects no-store Request inputs", async () => {
+    setCurrentFetchCacheMode("only-cache");
+
+    await expect(
+      fetch(
+        new Request("https://api.example.com/segment-only-cache-request", {
+          cache: "no-store",
+        }),
+      ),
+    ).rejects.toThrow(/only-cache/);
+  });
+
+  it("segment fetchCache only-no-store rejects cacheable fetches", async () => {
+    setCurrentFetchCacheMode("only-no-store");
+
+    await expect(
+      fetch("https://api.example.com/segment-only-no-store", {
+        cache: "force-cache",
+      }),
+    ).rejects.toThrow(/only-no-store/);
+  });
+
+  it("segment fetchCache only-no-store rejects cacheable Request inputs", async () => {
+    setCurrentFetchCacheMode("only-no-store");
+
+    await expect(
+      fetch(
+        new Request("https://api.example.com/segment-only-no-store-request", {
+          cache: "force-cache",
+        }),
+      ),
+    ).rejects.toThrow(/only-no-store/);
   });
 
   // ── No caching (no-store, revalidate: 0, revalidate: false) ─────────

--- a/tests/fixtures/app-basic/app/feed/page.tsx
+++ b/tests/fixtures/app-basic/app/feed/page.tsx
@@ -1,6 +1,8 @@
 import Link from "next/link";
 
-export default function FeedPage() {
+export default async function FeedPage() {
+  await fetch("data:text/plain,feed-source", { cache: "no-store" });
+
   return (
     <div data-testid="feed-page">
       <h1>Photo Feed</h1>

--- a/tests/fixtures/app-basic/app/layout-segment-config/dynamic-error-fetch/page.tsx
+++ b/tests/fixtures/app-basic/app/layout-segment-config/dynamic-error-fetch/page.tsx
@@ -1,0 +1,6 @@
+export const dynamic = "error";
+
+export default async function Page() {
+  await fetch("https://example.com/not-cacheable", { cache: "no-store" });
+  return <p data-testid="layout-segment-config-dynamic-error-fetch">Should not render</p>;
+}

--- a/tests/fixtures/app-basic/app/layout-segment-config/dynamic-error/[id]/layout.tsx
+++ b/tests/fixtures/app-basic/app/layout-segment-config/dynamic-error/[id]/layout.tsx
@@ -1,0 +1,5 @@
+export const dynamic = "error";
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/tests/fixtures/app-basic/app/layout-segment-config/dynamic-error/[id]/page.tsx
+++ b/tests/fixtures/app-basic/app/layout-segment-config/dynamic-error/[id]/page.tsx
@@ -1,0 +1,8 @@
+export function generateStaticParams() {
+  return [{ id: "known" }];
+}
+
+export default async function Page({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  return <p data-testid="layout-segment-config-dynamic-error">Known {id}</p>;
+}

--- a/tests/fixtures/app-basic/app/layout-segment-config/dynamic/[id]/layout.tsx
+++ b/tests/fixtures/app-basic/app/layout-segment-config/dynamic/[id]/layout.tsx
@@ -1,0 +1,5 @@
+export const dynamicParams = false;
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/tests/fixtures/app-basic/app/layout-segment-config/dynamic/[id]/page.tsx
+++ b/tests/fixtures/app-basic/app/layout-segment-config/dynamic/[id]/page.tsx
@@ -1,0 +1,8 @@
+export function generateStaticParams() {
+  return [{ id: "known" }];
+}
+
+export default async function Page({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  return <p data-testid="layout-segment-config-dynamic">Known {id}</p>;
+}

--- a/tests/fixtures/app-basic/app/layout-segment-config/force-dynamic/layout.tsx
+++ b/tests/fixtures/app-basic/app/layout-segment-config/force-dynamic/layout.tsx
@@ -1,0 +1,5 @@
+export const dynamic = "force-dynamic";
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/tests/fixtures/app-basic/app/layout-segment-config/force-dynamic/page.tsx
+++ b/tests/fixtures/app-basic/app/layout-segment-config/force-dynamic/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p data-testid="layout-segment-config-force-dynamic">{Date.now()}</p>;
+}

--- a/tests/fixtures/app-basic/app/layout-segment-config/layout-gsp/[id]/layout.tsx
+++ b/tests/fixtures/app-basic/app/layout-segment-config/layout-gsp/[id]/layout.tsx
@@ -1,0 +1,9 @@
+export const dynamicParams = false;
+
+export function generateStaticParams() {
+  return [{ id: "known" }];
+}
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/tests/fixtures/app-basic/app/layout-segment-config/layout-gsp/[id]/page.tsx
+++ b/tests/fixtures/app-basic/app/layout-segment-config/layout-gsp/[id]/page.tsx
@@ -1,0 +1,5 @@
+export default async function Page({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+
+  return <div data-testid="layout-segment-config-layout-gsp">Layout GSP {id}</div>;
+}

--- a/tests/fixtures/app-basic/app/layout-segment-config/nested-gsp/[category]/[slug]/page.tsx
+++ b/tests/fixtures/app-basic/app/layout-segment-config/nested-gsp/[category]/[slug]/page.tsx
@@ -1,0 +1,20 @@
+export function generateStaticParams({ params }: { params: { category?: string; slug?: string } }) {
+  if (params.category !== "docs" || params.slug !== undefined) {
+    throw new Error("expected only parent category params");
+  }
+
+  return [{ slug: "intro" }];
+}
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ category: string; slug: string }>;
+}) {
+  const { category, slug } = await params;
+  return (
+    <p data-testid="layout-segment-config-nested-gsp">
+      Nested GSP {category}/{slug}
+    </p>
+  );
+}

--- a/tests/fixtures/app-basic/app/layout-segment-config/nested-gsp/[category]/layout.tsx
+++ b/tests/fixtures/app-basic/app/layout-segment-config/nested-gsp/[category]/layout.tsx
@@ -1,0 +1,11 @@
+import type { ReactNode } from "react";
+
+export const dynamicParams = false;
+
+export function generateStaticParams() {
+  return [{ category: "docs" }];
+}
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/tests/fixtures/app-basic/app/layout-segment-config/no-gsp/[id]/layout.tsx
+++ b/tests/fixtures/app-basic/app/layout-segment-config/no-gsp/[id]/layout.tsx
@@ -1,0 +1,5 @@
+export const dynamicParams = false;
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/tests/fixtures/app-basic/app/layout-segment-config/no-gsp/[id]/page.tsx
+++ b/tests/fixtures/app-basic/app/layout-segment-config/no-gsp/[id]/page.tsx
@@ -1,0 +1,4 @@
+export default async function Page({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  return <p data-testid="layout-segment-config-no-gsp">No GSP {id}</p>;
+}

--- a/tests/fixtures/app-basic/app/layout-segment-config/revalidate/layout.tsx
+++ b/tests/fixtures/app-basic/app/layout-segment-config/revalidate/layout.tsx
@@ -1,0 +1,5 @@
+export const revalidate = 30;
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/tests/fixtures/app-basic/app/layout-segment-config/revalidate/page.tsx
+++ b/tests/fixtures/app-basic/app/layout-segment-config/revalidate/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p data-testid="layout-segment-config-revalidate">Layout revalidate</p>;
+}

--- a/tests/fixtures/app-basic/app/photos/[id]/page.tsx
+++ b/tests/fixtures/app-basic/app/photos/[id]/page.tsx
@@ -1,4 +1,6 @@
 // Full photo page — rendered on direct navigation to /photos/[id].
+export const fetchCache = "only-cache";
+
 export default function PhotoPage({ params }: { params: { id: string } }) {
   return (
     <div data-testid="photo-page">


### PR DESCRIPTION
## Summary
- resolve App page segment config from the full matched layout -> page module chain instead of only `route.page`
- apply layout-level `dynamic`, `revalidate`, `dynamicParams`, and `fetchCache` to App page request handling
- keep codegen thin: the generated RSC entry lists route modules and delegates config reduction to `server/app-segment-config`

## Next.js compatibility evidence
- Next.js collects App page segments from the route loader tree before reducing config: https://github.com/vercel/next.js/blob/canary/packages/next/src/build/segment-config/app/app-segments.ts#L86-L123
- Next.js reduces route config across collected segments, including `dynamic`, `fetchCache`, and shortest numeric `revalidate`: https://github.com/vercel/next.js/blob/canary/packages/next/src/build/utils.ts#L1001-L1041
- Next.js treats `dynamicParams = false` as effective if any generated segment disables dynamic params: https://github.com/vercel/next.js/blob/canary/packages/next/src/build/static-paths/app.ts#L907-L959

## Tests
- `vp test run tests/app-segment-config.test.ts tests/fetch-cache.test.ts tests/entry-templates.test.ts`
- `vp test run tests/app-router.test.ts -t "dynamicParams = false exported from a layout|revalidate exported from a layout|force-dynamic' exported from a layout"`
- `vp check packages/vinext/src/server/app-segment-config.ts packages/vinext/src/shims/fetch-cache.ts packages/vinext/src/shims/unified-request-context.ts packages/vinext/src/entries/app-rsc-entry.ts tests/app-segment-config.test.ts tests/fetch-cache.test.ts tests/app-router.test.ts`


