### PR TITLE
refactor(metadata): share route pattern helpers

### DIFF
--- a/packages/vinext/src/routing/route-pattern.ts
+++ b/packages/vinext/src/routing/route-pattern.ts
@@ -90,7 +90,7 @@ export function matchRoutePattern(
   urlParts: readonly string[],
   patternParts: readonly string[],
 ): RoutePatternParams | null {
-  const params: RoutePatternParams = {};
+  const params: RoutePatternParams = Object.create(null);
 
   function matchFrom(urlIndex: number, patternIndex: number): boolean {
     if (patternIndex === patternParts.length) {

--- a/packages/vinext/src/routing/route-pattern.ts
+++ b/packages/vinext/src/routing/route-pattern.ts
@@ -1,0 +1,139 @@
+export type RoutePatternParams = Record<string, string | string[]>;
+
+function routePatternPart(segment: string): string {
+  if (segment.startsWith("[[...") && segment.endsWith("]]")) {
+    return `:${segment.slice(5, -2)}*`;
+  }
+  if (segment.startsWith("[...") && segment.endsWith("]")) {
+    return `:${segment.slice(4, -1)}+`;
+  }
+  if (segment.startsWith("[") && segment.endsWith("]")) {
+    return `:${segment.slice(1, -1)}`;
+  }
+  return segment;
+}
+
+export function routePatternParts(pathname: string): string[] {
+  return pathname.split("/").filter(Boolean).map(routePatternPart);
+}
+
+export function routePattern(pathname: string): string {
+  const parts = routePatternParts(pathname);
+  return parts.length > 0 ? `/${parts.join("/")}` : "";
+}
+
+function appendParamValue(target: string[], value: string | string[]): void {
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      target.push(entry);
+    }
+    return;
+  }
+
+  target.push(value);
+}
+
+export function fillRoutePatternSegments(
+  pathname: string,
+  params: RoutePatternParams,
+): string | null {
+  const segments = pathname.split("/").filter(Boolean);
+  const resolvedSegments: string[] = [];
+
+  for (const segment of segments) {
+    if (segment.startsWith("[[...") && segment.endsWith("]]")) {
+      const paramName = segment.slice(5, -2);
+      const value = params[paramName];
+      if (value !== undefined && value !== "") {
+        if (Array.isArray(value) && value.length === 0) {
+          continue;
+        }
+        appendParamValue(resolvedSegments, value);
+      }
+      continue;
+    }
+
+    if (segment.startsWith("[...") && segment.endsWith("]")) {
+      const paramName = segment.slice(4, -1);
+      const value = params[paramName];
+      if (value === undefined || (Array.isArray(value) ? value.length === 0 : value === "")) {
+        return null;
+      }
+      appendParamValue(resolvedSegments, value);
+      continue;
+    }
+
+    if (segment.startsWith("[") && segment.endsWith("]")) {
+      const paramName = segment.slice(1, -1);
+      const value = params[paramName];
+      if (typeof value === "string") {
+        resolvedSegments.push(value);
+        continue;
+      }
+      if (Array.isArray(value) && value.length > 0) {
+        if (value.length > 1) {
+          return null;
+        }
+        resolvedSegments.push(value[0]);
+        continue;
+      }
+      return null;
+    }
+
+    resolvedSegments.push(segment);
+  }
+
+  return resolvedSegments.length > 0 ? `/${resolvedSegments.join("/")}` : "/";
+}
+
+export function matchRoutePattern(
+  urlParts: readonly string[],
+  patternParts: readonly string[],
+): RoutePatternParams | null {
+  const params: RoutePatternParams = {};
+
+  function matchFrom(urlIndex: number, patternIndex: number): boolean {
+    if (patternIndex === patternParts.length) {
+      return urlIndex === urlParts.length;
+    }
+
+    const patternPart = patternParts[patternIndex];
+    if (patternPart.startsWith(":") && (patternPart.endsWith("+") || patternPart.endsWith("*"))) {
+      const paramName = patternPart.slice(1, -1);
+      const minLength = patternPart.endsWith("+") ? 1 : 0;
+      for (let endIndex = urlIndex + minLength; endIndex <= urlParts.length; endIndex++) {
+        const value = urlParts.slice(urlIndex, endIndex);
+        if (value.length > 0) {
+          params[paramName] = value;
+        } else {
+          delete params[paramName];
+        }
+        if (matchFrom(endIndex, patternIndex + 1)) {
+          return true;
+        }
+      }
+      delete params[paramName];
+      return false;
+    }
+
+    if (patternPart.startsWith(":")) {
+      if (urlIndex >= urlParts.length) {
+        return false;
+      }
+      const paramName = patternPart.slice(1);
+      params[paramName] = urlParts[urlIndex];
+      if (matchFrom(urlIndex + 1, patternIndex + 1)) {
+        return true;
+      }
+      delete params[paramName];
+      return false;
+    }
+
+    if (urlIndex >= urlParts.length || urlParts[urlIndex] !== patternPart) {
+      return false;
+    }
+    return matchFrom(urlIndex + 1, patternIndex + 1);
+  }
+
+  return matchFrom(0, 0) ? params : null;
+}

--- a/packages/vinext/src/server/app-rsc-route-matching.ts
+++ b/packages/vinext/src/server/app-rsc-route-matching.ts
@@ -1,9 +1,5 @@
 import { buildRouteTrie, trieMatch } from "../routing/route-trie.js";
-import {
-  matchRoutePattern,
-  routePatternParts,
-  type RoutePatternParams,
-} from "../routing/route-pattern.js";
+import { matchRoutePattern, type RoutePatternParams } from "../routing/route-pattern.js";
 
 type AppRscRouteParams = RoutePatternParams;
 
@@ -97,7 +93,7 @@ function createInterceptLookup<Route extends AppRscRouteForMatching>(
           sourceRouteIndex: routeIndex,
           slotKey,
           targetPattern: intercept.targetPattern,
-          targetPatternParts: routePatternParts(intercept.targetPattern),
+          targetPatternParts: intercept.targetPattern.split("/").filter(Boolean),
           interceptLayouts: intercept.interceptLayouts,
           page: intercept.page,
           params: intercept.params,

--- a/packages/vinext/src/server/app-rsc-route-matching.ts
+++ b/packages/vinext/src/server/app-rsc-route-matching.ts
@@ -1,6 +1,11 @@
 import { buildRouteTrie, trieMatch } from "../routing/route-trie.js";
+import {
+  matchRoutePattern,
+  routePatternParts,
+  type RoutePatternParams,
+} from "../routing/route-pattern.js";
 
-type AppRscRouteParams = Record<string, string | string[]>;
+type AppRscRouteParams = RoutePatternParams;
 
 type AppRscInterceptForMatching = {
   targetPattern: string;
@@ -92,7 +97,7 @@ function createInterceptLookup<Route extends AppRscRouteForMatching>(
           sourceRouteIndex: routeIndex,
           slotKey,
           targetPattern: intercept.targetPattern,
-          targetPatternParts: intercept.targetPattern.split("/").filter(Boolean),
+          targetPatternParts: routePatternParts(intercept.targetPattern),
           interceptLayouts: intercept.interceptLayouts,
           page: intercept.page,
           params: intercept.params,
@@ -107,35 +112,7 @@ export function matchAppRscRoutePattern(
   urlParts: string[],
   patternParts: string[],
 ): AppRscRouteParams | null {
-  const params = createRouteParams();
-  for (let i = 0; i < patternParts.length; i++) {
-    const patternPart = patternParts[i];
-    if (patternPart.startsWith(":") && patternPart.endsWith("+")) {
-      if (i !== patternParts.length - 1) return null;
-      const paramName = patternPart.slice(1, -1);
-      const remaining = urlParts.slice(i);
-      if (remaining.length === 0) return null;
-      params[paramName] = remaining;
-      return params;
-    }
-    if (patternPart.startsWith(":") && patternPart.endsWith("*")) {
-      if (i !== patternParts.length - 1) return null;
-      const paramName = patternPart.slice(1, -1);
-      const remaining = urlParts.slice(i);
-      if (remaining.length > 0) {
-        params[paramName] = remaining;
-      }
-      return params;
-    }
-    if (patternPart.startsWith(":")) {
-      if (i >= urlParts.length) return null;
-      params[patternPart.slice(1)] = urlParts[i];
-      continue;
-    }
-    if (i >= urlParts.length || urlParts[i] !== patternPart) return null;
-  }
-  if (urlParts.length !== patternParts.length) return null;
-  return params;
+  return matchRoutePattern(urlParts, patternParts);
 }
 
 function mergeMatchedParams(

--- a/packages/vinext/src/server/file-based-metadata.ts
+++ b/packages/vinext/src/server/file-based-metadata.ts
@@ -1,5 +1,6 @@
 import type { Metadata } from "../shims/metadata.js";
 import { makeThenableParams } from "../shims/thenable-params.js";
+import { fillRoutePatternSegments, routePattern } from "../routing/route-pattern.js";
 import {
   getMetadataImageRouteKind,
   getMetadataRouteKind,
@@ -111,26 +112,6 @@ function routeSpecificity(route: MetadataFileRoute): number {
   return route.routeSegments?.length ?? routeScore(route.routePrefix);
 }
 
-function normalizeRoutePrefixPattern(routePrefix: string): string {
-  const segments = routePrefix
-    .split("/")
-    .filter(Boolean)
-    .map((segment) => {
-      if (segment.startsWith("[[...") && segment.endsWith("]]")) {
-        return `:${segment.slice(5, -2)}*`;
-      }
-      if (segment.startsWith("[...") && segment.endsWith("]")) {
-        return `:${segment.slice(4, -1)}+`;
-      }
-      if (segment.startsWith("[") && segment.endsWith("]")) {
-        return `:${segment.slice(1, -1)}`;
-      }
-      return segment;
-    });
-
-  return segments.length > 0 ? `/${segments.join("/")}` : "";
-}
-
 function selectDeepestRoutes(
   metadataRoutes: readonly MetadataFileRoute[] | null | undefined,
   kind: MetadataRouteHeadData["kind"],
@@ -173,8 +154,8 @@ function selectDeepestRoutes(
     }
 
     const routePrefix = route.routePrefix;
-    const resolvedRoutePrefix = fillMetadataRouteSegments(routePrefix, params);
-    const normalizedRoutePrefix = normalizeRoutePrefixPattern(routePrefix);
+    const resolvedRoutePrefix = fillRoutePatternSegments(routePrefix, params);
+    const normalizedRoutePrefix = routePattern(routePrefix);
     if (
       !routeApplies(routePath, routePrefix) &&
       !routeApplies(routePath, normalizedRoutePrefix) &&
@@ -241,25 +222,25 @@ function normalizeIconValue(value: unknown): IconEntry | null {
   return normalizeIconDescriptor(value);
 }
 
+function normalizeIconValueList(values: readonly unknown[]): IconEntry[] {
+  const normalizedEntries: IconEntry[] = [];
+  for (const value of values) {
+    const normalizedValue = normalizeIconValue(value);
+    if (normalizedValue) {
+      normalizedEntries.push(normalizedValue);
+    }
+  }
+  return normalizedEntries;
+}
+
 function normalizeIconEntries(icon: NonNullable<Metadata["icons"]>): IconEntry[] {
-  if (isStringOrUrl(icon)) {
-    return [{ url: icon }];
+  const normalizedTopLevelValue = normalizeIconValue(icon);
+  if (normalizedTopLevelValue) {
+    return [normalizedTopLevelValue];
   }
 
   if (Array.isArray(icon)) {
-    const normalizedEntries: IconEntry[] = [];
-    for (const value of icon) {
-      const normalizedValue = normalizeIconValue(value);
-      if (normalizedValue) {
-        normalizedEntries.push(normalizedValue);
-      }
-    }
-    return normalizedEntries;
-  }
-
-  const normalizedTopLevelValue = normalizeIconDescriptor(icon);
-  if (normalizedTopLevelValue) {
-    return [normalizedTopLevelValue];
+    return normalizeIconValueList(icon);
   }
 
   if (!isIconMap(icon)) {
@@ -272,14 +253,7 @@ function normalizeIconEntries(icon: NonNullable<Metadata["icons"]>): IconEntry[]
   }
 
   if (Array.isArray(iconValue)) {
-    const normalizedEntries: IconEntry[] = [];
-    for (const value of iconValue) {
-      const normalizedValue = normalizeIconValue(value);
-      if (normalizedValue) {
-        normalizedEntries.push(normalizedValue);
-      }
-    }
-    return normalizedEntries;
+    return normalizeIconValueList(iconValue);
   }
 
   const normalizedValue = normalizeIconValue(iconValue);
@@ -290,7 +264,7 @@ function isIconMap(value: Metadata["icons"]): value is IconMap {
   if (!value || typeof value !== "object" || value instanceof URL || Array.isArray(value)) {
     return false;
   }
-  return normalizeIconDescriptor(value) === null;
+  return normalizeIconValue(value) === null;
 }
 
 function cloneIconMap(value: Metadata["icons"]): IconMap {
@@ -368,67 +342,6 @@ function buildSocialEntry(headData: MetadataRouteHeadData): SocialImageEntry | n
     socialEntry.type = headData.type;
   }
   return socialEntry;
-}
-
-function appendParamValue(target: string[], value: string | string[]): void {
-  if (Array.isArray(value)) {
-    for (const entry of value) {
-      target.push(entry);
-    }
-    return;
-  }
-
-  target.push(value);
-}
-
-function fillMetadataRouteSegments(servedUrl: string, params: AppPageParams): string | null {
-  const segments = servedUrl.split("/").filter(Boolean);
-  const resolvedSegments: string[] = [];
-
-  for (const segment of segments) {
-    if (segment.startsWith("[[...") && segment.endsWith("]]")) {
-      const paramName = segment.slice(5, -2);
-      const value = params[paramName];
-      if (value !== undefined && value !== "") {
-        if (Array.isArray(value) && value.length === 0) {
-          continue;
-        }
-        appendParamValue(resolvedSegments, value);
-      }
-      continue;
-    }
-
-    if (segment.startsWith("[...") && segment.endsWith("]")) {
-      const paramName = segment.slice(4, -1);
-      const value = params[paramName];
-      if (value === undefined || (Array.isArray(value) ? value.length === 0 : value === "")) {
-        return null;
-      }
-      appendParamValue(resolvedSegments, value);
-      continue;
-    }
-
-    if (segment.startsWith("[") && segment.endsWith("]")) {
-      const paramName = segment.slice(1, -1);
-      const value = params[paramName];
-      if (typeof value === "string") {
-        resolvedSegments.push(value);
-        continue;
-      }
-      if (Array.isArray(value) && value.length > 0) {
-        if (value.length > 1) {
-          return null;
-        }
-        resolvedSegments.push(value[0]);
-        continue;
-      }
-      return null;
-    }
-
-    resolvedSegments.push(segment);
-  }
-
-  return resolvedSegments.length > 0 ? `/${resolvedSegments.join("/")}` : "/";
 }
 
 function normalizeMetadataImageId(route: MetadataFileRoute, id: string | number): string | null {
@@ -600,7 +513,7 @@ async function resolveRouteHeadData(
   }
 
   // servedUrl must stay query-free here; content hashes are appended after dynamic segment filling.
-  const resolvedUrl = fillMetadataRouteSegments(route.servedUrl, params);
+  const resolvedUrl = fillRoutePatternSegments(route.servedUrl, params);
   if (!resolvedUrl) {
     console.warn(
       `[vinext] Skipping metadata route ${route.servedUrl} because params did not fill all dynamic segments.`,

--- a/packages/vinext/src/server/metadata-route-build-data.ts
+++ b/packages/vinext/src/server/metadata-route-build-data.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import fs from "node:fs";
 import { imageSize } from "image-size";
+import { routePatternParts } from "../routing/route-pattern.js";
 import {
   getMetadataRouteKind,
   type MetadataFileRoute,
@@ -190,24 +191,11 @@ function pushEntryProperty(lines: string[], key: string, value: unknown): void {
   }
 }
 
-function metadataRoutePatternPart(segment: string): string {
-  if (segment.startsWith("[[...") && segment.endsWith("]]")) {
-    return `:${segment.slice(5, -2)}*`;
-  }
-  if (segment.startsWith("[...") && segment.endsWith("]")) {
-    return `:${segment.slice(4, -1)}+`;
-  }
-  if (segment.startsWith("[") && segment.endsWith("]")) {
-    return `:${segment.slice(1, -1)}`;
-  }
-  return segment;
-}
-
 function createMetadataRoutePatternParts(route: MetadataFileRoute): readonly string[] | null {
   if (!route.isDynamic || !route.servedUrl.includes("[")) {
     return null;
   }
-  return route.servedUrl.split("/").filter(Boolean).map(metadataRoutePatternPart);
+  return routePatternParts(route.servedUrl);
 }
 
 function getDynamicMetadataRouteModuleName(

--- a/packages/vinext/src/server/metadata-routes.ts
+++ b/packages/vinext/src/server/metadata-routes.ts
@@ -17,6 +17,7 @@
  */
 import fs from "node:fs";
 import path from "node:path";
+import { matchRoutePattern } from "../routing/route-pattern.js";
 
 // -------------------------------------------------------------------
 // Types matching Next.js MetadataRoute
@@ -530,47 +531,7 @@ export function matchMetadataRoutePattern(
   urlParts: string[],
   patternParts: string[],
 ): Record<string, string | string[]> | null {
-  const params: Record<string, string | string[]> = Object.create(null);
-
-  function matchFrom(urlIndex: number, patternIndex: number): boolean {
-    if (patternIndex === patternParts.length) {
-      return urlIndex === urlParts.length;
-    }
-
-    const patternPart = patternParts[patternIndex];
-    if (patternPart.startsWith(":") && (patternPart.endsWith("+") || patternPart.endsWith("*"))) {
-      const paramName = patternPart.slice(1, -1);
-      const minLength = patternPart.endsWith("+") ? 1 : 0;
-      for (let endIndex = urlIndex + minLength; endIndex <= urlParts.length; endIndex++) {
-        params[paramName] = urlParts.slice(urlIndex, endIndex);
-        if (matchFrom(endIndex, patternIndex + 1)) {
-          return true;
-        }
-      }
-      delete params[paramName];
-      return false;
-    }
-
-    if (patternPart.startsWith(":")) {
-      if (urlIndex >= urlParts.length) {
-        return false;
-      }
-      const paramName = patternPart.slice(1);
-      params[paramName] = urlParts[urlIndex];
-      if (matchFrom(urlIndex + 1, patternIndex + 1)) {
-        return true;
-      }
-      delete params[paramName];
-      return false;
-    }
-
-    if (urlIndex >= urlParts.length || urlParts[urlIndex] !== patternPart) {
-      return false;
-    }
-    return matchFrom(urlIndex + 1, patternIndex + 1);
-  }
-
-  return matchFrom(0, 0) ? params : null;
+  return matchRoutePattern(urlParts, patternParts);
 }
 
 function metadataRouteSuffix(parentSegments: string[], metaType: string): string {

--- a/packages/vinext/src/shims/metadata.tsx
+++ b/packages/vinext/src/shims/metadata.tsx
@@ -432,44 +432,29 @@ function isIconsMap(value: IconsMetadata): value is IconsMap {
   );
 }
 
-function normalizeIconHeadEntry(icon: IconInput): IconDescriptor {
-  if (typeof icon === "string" || icon instanceof URL) {
-    return { url: icon };
+function normalizeUrlDescriptor<T extends { url: string | URL }>(
+  value: string | URL | T,
+  createDescriptor: (url: string | URL) => T,
+): T {
+  if (typeof value === "string" || value instanceof URL) {
+    return createDescriptor(value);
   }
-  return icon;
+  return value;
 }
 
-function normalizeIconHeadEntries(icon: IconInput | IconInput[] | undefined): IconDescriptor[] {
-  if (!icon) {
+function normalizeUrlDescriptorEntries<T extends { url: string | URL }>(
+  value: string | URL | T | Array<string | URL | T> | undefined,
+  createDescriptor: (url: string | URL) => T,
+): T[] {
+  if (!value) {
     return [];
   }
 
-  if (Array.isArray(icon)) {
-    return icon.map(normalizeIconHeadEntry);
+  if (Array.isArray(value)) {
+    return value.map((entry) => normalizeUrlDescriptor(entry, createDescriptor));
   }
 
-  return [normalizeIconHeadEntry(icon)];
-}
-
-function normalizeAppleIconHeadEntry(apple: AppleIconInput): AppleIconDescriptor {
-  if (typeof apple === "string" || apple instanceof URL) {
-    return { url: apple };
-  }
-  return apple;
-}
-
-function normalizeAppleIconHeadEntries(
-  apple: AppleIconInput | AppleIconInput[] | undefined,
-): AppleIconDescriptor[] {
-  if (!apple) {
-    return [];
-  }
-
-  if (Array.isArray(apple)) {
-    return apple.map(normalizeAppleIconHeadEntry);
-  }
-
-  return [normalizeAppleIconHeadEntry(apple)];
+  return [normalizeUrlDescriptor(value, createDescriptor)];
 }
 
 export function MetadataHead({ metadata }: { metadata: Metadata }) {
@@ -764,8 +749,8 @@ export function MetadataHead({ metadata }: { metadata: Metadata }) {
   // Icons
   if (metadata.icons) {
     const iconEntries = isIconsMap(metadata.icons)
-      ? normalizeIconHeadEntries(metadata.icons.icon)
-      : normalizeIconHeadEntries(metadata.icons);
+      ? normalizeUrlDescriptorEntries(metadata.icons.icon, (url): IconDescriptor => ({ url }))
+      : normalizeUrlDescriptorEntries(metadata.icons, (url): IconDescriptor => ({ url }));
 
     // Shortcut icon
     if (isIconsMap(metadata.icons) && metadata.icons.shortcut) {
@@ -793,7 +778,10 @@ export function MetadataHead({ metadata }: { metadata: Metadata }) {
     }
     // Apple touch icon
     if (isIconsMap(metadata.icons) && metadata.icons.apple) {
-      for (const a of normalizeAppleIconHeadEntries(metadata.icons.apple)) {
+      for (const a of normalizeUrlDescriptorEntries(
+        metadata.icons.apple,
+        (url): AppleIconDescriptor => ({ url }),
+      )) {
         elements.push(
           <link
             key={key++}

--- a/tests/app-rsc-route-matching.test.ts
+++ b/tests/app-rsc-route-matching.test.ts
@@ -99,6 +99,30 @@ describe("App RSC route matching", () => {
       matchedParams: { id: "target-id" },
     });
   });
+
+  it("preserves bracket-shaped literal segments in intercept target patterns", () => {
+    const matcher = createAppRscRouteMatcher([
+      route("/feed", ["feed"], {
+        modal: {
+          intercepts: [
+            {
+              targetPattern: "/photos/[literal]",
+              interceptLayouts: ["modal-layout"],
+              page: "literal-photo-page",
+              params: [],
+            },
+          ],
+        },
+      }),
+    ]);
+
+    expect(matcher.findIntercept("/photos/[literal]", "/feed")).toMatchObject({
+      targetPattern: "/photos/[literal]",
+      page: "literal-photo-page",
+      matchedParams: {},
+    });
+    expect(matcher.findIntercept("/photos/anything", "/feed")).toBeNull();
+  });
 });
 
 function route(

--- a/tests/route-pattern.test.ts
+++ b/tests/route-pattern.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  fillRoutePatternSegments,
+  matchRoutePattern,
+  routePattern,
+  routePatternParts,
+} from "../packages/vinext/src/routing/route-pattern.js";
+
+describe("route pattern helpers", () => {
+  it("normalizes app route segments into vinext pattern parts", () => {
+    expect(routePatternParts("/docs/[section]/[[...slug]]/icon")).toEqual([
+      "docs",
+      ":section",
+      ":slug*",
+      "icon",
+    ]);
+    expect(routePattern("/shop/[...slug]/opengraph-image")).toBe("/shop/:slug+/opengraph-image");
+    expect(routePattern("/")).toBe("");
+  });
+
+  it("fills dynamic route segments from params and rejects incomplete paths", () => {
+    expect(
+      fillRoutePatternSegments("/docs/[section]/[[...slug]]/icon", {
+        section: "api",
+      }),
+    ).toBe("/docs/api/icon");
+    expect(
+      fillRoutePatternSegments("/docs/[section]/[[...slug]]/icon", {
+        section: "api",
+        slug: ["routing", "metadata"],
+      }),
+    ).toBe("/docs/api/routing/metadata/icon");
+    expect(fillRoutePatternSegments("/docs/[...slug]/icon", {})).toBeNull();
+    expect(fillRoutePatternSegments("/docs/[section]/icon", { section: ["a", "b"] })).toBeNull();
+  });
+
+  it("matches dynamic pattern parts with catch-all segments before suffixes", () => {
+    expect(
+      matchRoutePattern(
+        ["metadata-multi-catchall", "a", "b", "icon"],
+        ["metadata-multi-catchall", ":slug+", "icon"],
+      ),
+    ).toEqual({ slug: ["a", "b"] });
+    expect(matchRoutePattern(["shop"], ["shop", ":slug*"])).toEqual({});
+    expect(
+      matchRoutePattern(
+        ["metadata-multi-catchall", "icon"],
+        ["metadata-multi-catchall", ":slug+", "icon"],
+      ),
+    ).toBeNull();
+  });
+
+  it("treats literal route segments ending in pattern markers as literals", () => {
+    expect(matchRoutePattern(["docs+", "icon"], ["docs+", "icon"])).toEqual({});
+    expect(matchRoutePattern(["docs", "icon"], ["docs+", "icon"])).toBeNull();
+  });
+});

--- a/tests/route-pattern.test.ts
+++ b/tests/route-pattern.test.ts
@@ -50,6 +50,18 @@ describe("route pattern helpers", () => {
     ).toBeNull();
   });
 
+  it("stores prototype-named params as own values", () => {
+    const singleParam = matchRoutePattern(["first"], [":__proto__"]);
+
+    expect(Object.hasOwn(singleParam ?? {}, "__proto__")).toBe(true);
+    expect(singleParam?.__proto__).toBe("first");
+
+    const catchAllParam = matchRoutePattern(["first", "second", "icon"], [":__proto__+", "icon"]);
+
+    expect(Object.hasOwn(catchAllParam ?? {}, "__proto__")).toBe(true);
+    expect(catchAllParam?.__proto__).toEqual(["first", "second"]);
+  });
+
   it("treats literal route segments ending in pattern markers as literals", () => {
     expect(matchRoutePattern(["docs+", "icon"], ["docs+", "icon"])).toEqual({});
     expect(matchRoutePattern(["docs", "icon"], ["docs+", "icon"])).toBeNull();


### PR DESCRIPTION
## What this changes

This is a follow-up to James's review comments on #891 about duplicated metadata helper logic:

- [normalizeIconValue and normalizeIconDescriptor could probably be merged](https://github.com/cloudflare/vinext/pull/891#discussion_r3169851093)
- [the same icon normalization logic could be reusable](https://github.com/cloudflare/vinext/pull/891#discussion_r3169864749)
- [metadata route pattern conversion duplicated normalizeRoutePrefixPattern](https://github.com/cloudflare/vinext/pull/891#discussion_r3169950415)
- [the repeated split/filter/map route pattern pipeline could be shared](https://github.com/cloudflare/vinext/pull/891#discussion_r3169957050)
- [route patterns may want a generic internal format](https://github.com/cloudflare/vinext/pull/891#discussion_r3170026627)
- [some metadata logic may be duplicated between server and shims](https://github.com/cloudflare/vinext/pull/891#discussion_r3170044468)

The PR adds a normal routing module, `packages/vinext/src/routing/route-pattern.ts`, that owns app-route segment pattern conversion, dynamic segment filling, and pattern matching. Metadata route build data, metadata route runtime matching, file-based metadata head injection, and App RSC intercept matching now consume that shared behavior instead of keeping local copies.

It also consolidates the duplicated icon descriptor normalization in both `file-based-metadata.ts` and `metadata.tsx` without changing observable metadata output.

## Why

The codegen boundary should describe the app shape, while normal modules implement behavior. The previous #891 implementation already moved most runtime metadata work out of generated entries, but some generic route behavior still lived inside metadata-specific modules. That made the code harder to audit and made future routing parity fixes more likely to fork across metadata, App RSC, and shim paths.

## Approach

- Move route pattern helpers into `routing/route-pattern.ts`.
- Reuse those helpers from metadata build data, metadata runtime matching, file-based metadata, and App RSC route matching.
- Keep metadata-specific wrappers only where they still express metadata behavior. Generic segment parsing and matching now live outside metadata modules.
- Collapse icon descriptor normalization to one list-normalization path per module, while preserving string, URL, descriptor, array, and icon-map inputs.

## Next.js references

The shared helper is intentionally aligned with the same observable contracts Next uses in separate places:

- Next metadata route filling and static metadata segment normalization: [`packages/next/src/lib/metadata/get-metadata-route.ts`](https://github.com/vercel/next.js/blob/ae61573e062e900050b8e6b24626e450accc4570/packages/next/src/lib/metadata/get-metadata-route.ts#L61-L132)
- Next dynamic path interpolation for optional and catch-all params: [`packages/next/src/server/server-utils.ts`](https://github.com/vercel/next.js/blob/ae61573e062e900050b8e6b24626e450accc4570/packages/next/src/server/server-utils.ts#L75-L107)
- Next route matcher param extraction for repeat params: [`packages/next/src/shared/lib/router/utils/route-matcher.ts`](https://github.com/vercel/next.js/blob/ae61573e062e900050b8e6b24626e450accc4570/packages/next/src/shared/lib/router/utils/route-matcher.ts#L17-L49)

## Validation

- `vp test run tests/route-pattern.test.ts tests/metadata-route-build-data.test.ts tests/metadata-routes.test.ts tests/file-based-metadata.test.ts tests/app-rsc-route-matching.test.ts tests/shims.test.ts` passed: 952 tests.
- `vp check` passed: 1071 files formatted, 457 files checked with no warnings, lint errors, or type errors.
- `vp run vinext#build` passed. The existing virtual-module unresolved import warnings are preserved build behavior.

## Risks / follow-ups

The new matcher accepts catch-all pattern parts before a suffix, which metadata image routes need for `generateImageMetadata()` ID suffixes. App RSC intercept matching now uses the same matcher, but normal App route matching still goes through the route trie.
