### PR TITLE
refactor(build): move route classification injection behind a typed planner

### DIFF
--- a/packages/vinext/src/build/route-classification-injector.ts
+++ b/packages/vinext/src/build/route-classification-injector.ts
@@ -1,0 +1,167 @@
+import {
+  classifyLayoutByModuleGraph,
+  isStaticModuleGraphResult,
+  moduleGraphReason,
+  type ModuleInfoProvider,
+} from "./layout-classification.js";
+import type { ModuleGraphStaticReason } from "./layout-classification-types.js";
+import {
+  buildGenerateBundleReplacement,
+  buildReasonsReplacement,
+  type RouteClassificationManifest,
+} from "./route-classification-manifest.js";
+
+/**
+ * Build-time route classification injection.
+ *
+ * Codegen describes route shape by emitting stable `__VINEXT_CLASS` stubs and
+ * per-route call sites. This module owns the behavioral side of replacing
+ * those stubs with build-time decisions once the final RSC module graph exists.
+ */
+
+export type RouteClassificationChunk = {
+  code: string;
+  fileName: string;
+};
+
+type RouteClassificationInjectionPlan =
+  | { kind: "skip" }
+  | {
+      code: string;
+      fileName: string;
+      kind: "patch";
+      map: null;
+    };
+
+type PlanRouteClassificationInjectionOptions = {
+  canonicalizeLayoutPath?: (path: string) => string;
+  chunks: readonly RouteClassificationChunk[];
+  dynamicShimPaths: ReadonlySet<string>;
+  enableDebugReasons: boolean;
+  manifest: RouteClassificationManifest;
+  moduleInfo: ModuleInfoProvider;
+};
+
+type BuildLayer2ClassificationsOptions = Pick<
+  PlanRouteClassificationInjectionOptions,
+  "canonicalizeLayoutPath" | "dynamicShimPaths" | "manifest" | "moduleInfo"
+>;
+
+// The `?` after the semicolon is intentional: Rolldown may or may not emit the
+// trailing semicolon depending on minification settings. This regex relies on
+// `__VINEXT_CLASS` retaining its name, which holds because RSC entry chunk
+// bindings are not subject to scope-hoisting renames.
+const CLASS_STUB_RE = /function __VINEXT_CLASS\(routeIdx\)\s*\{\s*return null;?\s*\}/;
+const REASONS_STUB_RE = /function __VINEXT_CLASS_REASONS\(routeIdx\)\s*\{\s*return null;?\s*\}/;
+
+function identityPath(path: string): string {
+  return path;
+}
+
+function findClassificationChunk(
+  chunks: readonly RouteClassificationChunk[],
+): RouteClassificationChunk | null {
+  // Skip the scan-phase build where the RSC entry code has been tree-shaken
+  // out entirely. In the real RSC build the chunk that carries our runtime code
+  // will reference `__VINEXT_CLASS` via per-route calls.
+  const chunksMentioningStub = chunks.filter((chunk) => chunk.code.includes("__VINEXT_CLASS"));
+  const chunksWithStubBody = chunksMentioningStub.filter((chunk) => CLASS_STUB_RE.test(chunk.code));
+
+  if (chunksMentioningStub.length === 0) {
+    return null;
+  }
+
+  if (chunksWithStubBody.length === 0) {
+    throw new Error(
+      `vinext: build-time classification — __VINEXT_CLASS is referenced in ${chunksMentioningStub
+        .map((chunk) => chunk.fileName)
+        .join(
+          ", ",
+        )} but no chunk contains the stub body. The generator and generateBundle have drifted.`,
+    );
+  }
+
+  if (chunksWithStubBody.length > 1) {
+    throw new Error(
+      `vinext: build-time classification — expected __VINEXT_CLASS stub in exactly one RSC chunk, found ${chunksWithStubBody.length}`,
+    );
+  }
+
+  return chunksWithStubBody[0] ?? null;
+}
+
+function buildLayer2Classifications(
+  options: BuildLayer2ClassificationsOptions,
+): Map<number, Map<number, ModuleGraphStaticReason>> {
+  const canonicalizeLayoutPath = options.canonicalizeLayoutPath ?? identityPath;
+  const layer2PerRoute = new Map<number, Map<number, ModuleGraphStaticReason>>();
+  const graphCache = new Map<string, ReturnType<typeof classifyLayoutByModuleGraph>>();
+
+  for (let routeIdx = 0; routeIdx < options.manifest.routes.length; routeIdx++) {
+    const route = options.manifest.routes[routeIdx]!;
+    const perRoute = new Map<number, ModuleGraphStaticReason>();
+
+    for (let layoutIdx = 0; layoutIdx < route.layoutPaths.length; layoutIdx++) {
+      if (route.layer1.has(layoutIdx)) continue;
+
+      const layoutModuleId = canonicalizeLayoutPath(route.layoutPaths[layoutIdx]!);
+      // If the layout module itself is not in the graph, we have no evidence
+      // either way. Do not claim it static, or we would skip the runtime probe
+      // for a layout we never actually analysed.
+      if (!options.moduleInfo.getModuleInfo(layoutModuleId)) continue;
+
+      let graphResult = graphCache.get(layoutModuleId);
+      if (graphResult === undefined) {
+        graphResult = classifyLayoutByModuleGraph(
+          layoutModuleId,
+          options.dynamicShimPaths,
+          options.moduleInfo,
+        );
+        graphCache.set(layoutModuleId, graphResult);
+      }
+
+      if (isStaticModuleGraphResult(graphResult)) {
+        perRoute.set(layoutIdx, moduleGraphReason(graphResult));
+      }
+    }
+
+    if (perRoute.size > 0) {
+      layer2PerRoute.set(routeIdx, perRoute);
+    }
+  }
+
+  return layer2PerRoute;
+}
+
+export function planRouteClassificationInjection(
+  options: PlanRouteClassificationInjectionOptions,
+): RouteClassificationInjectionPlan {
+  const target = findClassificationChunk(options.chunks);
+  if (!target) {
+    return { kind: "skip" };
+  }
+
+  if (options.enableDebugReasons && !REASONS_STUB_RE.test(target.code)) {
+    throw new Error(
+      "vinext: build-time classification — __VINEXT_CLASS_REASONS stub is missing alongside __VINEXT_CLASS. The generator and generateBundle have drifted.",
+    );
+  }
+
+  const layer2PerRoute = buildLayer2Classifications(options);
+  const replacement = buildGenerateBundleReplacement(options.manifest, layer2PerRoute);
+  const patchedBody = `function __VINEXT_CLASS(routeIdx) { return (${replacement})(routeIdx); }`;
+  let code = target.code.replace(CLASS_STUB_RE, patchedBody);
+
+  if (options.enableDebugReasons) {
+    const reasonsReplacement = buildReasonsReplacement(options.manifest, layer2PerRoute);
+    const patchedReasonsBody = `function __VINEXT_CLASS_REASONS(routeIdx) { return (${reasonsReplacement})(routeIdx); }`;
+    code = code.replace(REASONS_STUB_RE, patchedReasonsBody);
+  }
+
+  return {
+    code,
+    fileName: target.fileName,
+    kind: "patch",
+    map: null,
+  };
+}

--- a/packages/vinext/src/build/route-classification-injector.ts
+++ b/packages/vinext/src/build/route-classification-injector.ts
@@ -66,12 +66,13 @@ function findClassificationChunk(
   // will reference `__VINEXT_CLASS` via per-route calls.
   const chunksMentioningStub = chunks.filter((chunk) => chunk.code.includes("__VINEXT_CLASS"));
   const chunksWithStubBody = chunksMentioningStub.filter((chunk) => CLASS_STUB_RE.test(chunk.code));
+  const chunkWithStubBody = chunksWithStubBody[0];
 
   if (chunksMentioningStub.length === 0) {
     return null;
   }
 
-  if (chunksWithStubBody.length === 0) {
+  if (chunkWithStubBody === undefined) {
     throw new Error(
       `vinext: build-time classification — __VINEXT_CLASS is referenced in ${chunksMentioningStub
         .map((chunk) => chunk.fileName)
@@ -87,7 +88,7 @@ function findClassificationChunk(
     );
   }
 
-  return chunksWithStubBody[0] ?? null;
+  return chunkWithStubBody;
 }
 
 function buildLayer2Classifications(

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -19,17 +19,13 @@ import { generateRscEntry } from "./entries/app-rsc-entry.js";
 import { generateSsrEntry } from "./entries/app-ssr-entry.js";
 import { generateBrowserEntry } from "./entries/app-browser-entry.js";
 import {
-  buildGenerateBundleReplacement,
-  buildReasonsReplacement,
   collectRouteClassificationManifest,
   type RouteClassificationManifest,
 } from "./build/route-classification-manifest.js";
 import {
-  classifyLayoutByModuleGraph,
-  isStaticModuleGraphResult,
-  moduleGraphReason,
-} from "./build/layout-classification.js";
-import type { ModuleGraphStaticReason } from "./build/layout-classification-types.js";
+  planRouteClassificationInjection,
+  type RouteClassificationChunk,
+} from "./build/route-classification-injector.js";
 import { normalizePathnameForRouteMatchStrict } from "./routing/utils.js";
 import {
   findNextConfigPath,
@@ -1725,61 +1721,18 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
 
         const enableClassificationDebug = Boolean(process.env.VINEXT_DEBUG_CLASSIFICATION);
 
-        // The `?` after the semicolon is intentional: Rolldown may or may not
-        // emit the trailing semicolon depending on minification settings.
-        // This regex relies on `__VINEXT_CLASS` retaining its name, which holds
-        // because RSC entry chunk bindings are not subject to scope-hoisting renames.
-        const stubRe = /function __VINEXT_CLASS\(routeIdx\)\s*\{\s*return null;?\s*\}/;
-        const reasonsStubRe =
-          /function __VINEXT_CLASS_REASONS\(routeIdx\)\s*\{\s*return null;?\s*\}/;
-
-        // Skip the scan-phase build where the RSC entry code has been
-        // tree-shaken out entirely. In the real RSC build the chunk that
-        // carries our runtime code will reference `__VINEXT_CLASS` via the
-        // per-route literal `__buildTimeClassifications: __VINEXT_CLASS(N)`,
-        // which Rolldown emits verbatim.
-        //
-        // If we see a chunk that mentions __VINEXT_CLASS but none of them
-        // contain the stub body we recognise, something upstream reshaped the
-        // generated source and we would silently degrade back to the Layer 3
-        // runtime probe. Fail loudly instead so regressions surface at build
-        // time rather than as a mysterious perf cliff at request time.
-        const chunksMentioningStub: Array<{
-          chunk: Extract<(typeof bundle)[string], { type: "chunk" }>;
-          fileName: string;
-        }> = [];
-        const chunksWithStubBody: Array<{
-          chunk: Extract<(typeof bundle)[string], { type: "chunk" }>;
-          fileName: string;
-        }> = [];
+        const chunks: RouteClassificationChunk[] = [];
+        const chunksByFileName = new Map<
+          string,
+          Extract<(typeof bundle)[string], { type: "chunk" }>
+        >();
         for (const chunk of Object.values(bundle)) {
           if (chunk.type !== "chunk") continue;
-          if (!chunk.code.includes("__VINEXT_CLASS")) continue;
-          chunksMentioningStub.push({ chunk, fileName: chunk.fileName });
-          if (stubRe.test(chunk.code)) {
-            chunksWithStubBody.push({ chunk, fileName: chunk.fileName });
-          }
-        }
-
-        if (chunksMentioningStub.length === 0) return;
-        if (chunksWithStubBody.length === 0) {
-          throw new Error(
-            `vinext: build-time classification — __VINEXT_CLASS is referenced in ${chunksMentioningStub
-              .map((c) => c.fileName)
-              .join(
-                ", ",
-              )} but no chunk contains the stub body. The generator and generateBundle have drifted.`,
-          );
-        }
-        if (chunksWithStubBody.length > 1) {
-          throw new Error(
-            `vinext: build-time classification — expected __VINEXT_CLASS stub in exactly one RSC chunk, found ${chunksWithStubBody.length}`,
-          );
-        }
-        if (enableClassificationDebug && !reasonsStubRe.test(chunksWithStubBody[0]!.chunk.code)) {
-          throw new Error(
-            "vinext: build-time classification — __VINEXT_CLASS_REASONS stub is missing alongside __VINEXT_CLASS. The generator and generateBundle have drifted.",
-          );
+          chunks.push({
+            code: chunk.code,
+            fileName: chunk.fileName,
+          });
+          chunksByFileName.set(chunk.fileName, chunk);
         }
 
         // `canonicalize` and `dynamicShimPaths` are hoisted to plugin init
@@ -1804,61 +1757,28 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           },
         };
 
-        const layer2PerRoute = new Map<number, Map<number, ModuleGraphStaticReason>>();
-        const graphCache = new Map<string, ReturnType<typeof classifyLayoutByModuleGraph>>();
-        for (let routeIdx = 0; routeIdx < rscClassificationManifest.routes.length; routeIdx++) {
-          const route = rscClassificationManifest.routes[routeIdx]!;
-          const perRoute = new Map<number, ModuleGraphStaticReason>();
-          for (let layoutIdx = 0; layoutIdx < route.layoutPaths.length; layoutIdx++) {
-            // Skip layouts already decided by Layer 1 — segment config is
-            // authoritative, so there is no need to walk the module graph.
-            if (route.layer1.has(layoutIdx)) continue;
-            const layoutModuleId = canonicalize(route.layoutPaths[layoutIdx]!);
-            // If the layout module itself is not in the graph, we have no
-            // evidence either way — do NOT claim it static, or we would skip
-            // the runtime probe for a layout we never actually analysed.
-            // `classifyLayoutByModuleGraph` returns "static" for an empty
-            // traversal, so the seed presence check has to happen here.
-            if (!moduleInfo.getModuleInfo(layoutModuleId)) continue;
-            let graphResult = graphCache.get(layoutModuleId);
-            if (graphResult === undefined) {
-              graphResult = classifyLayoutByModuleGraph(
-                layoutModuleId,
-                dynamicShimPaths,
-                moduleInfo,
-              );
-              graphCache.set(layoutModuleId, graphResult);
-            }
-            if (isStaticModuleGraphResult(graphResult)) {
-              perRoute.set(layoutIdx, moduleGraphReason(graphResult));
-            }
-          }
-          if (perRoute.size > 0) {
-            layer2PerRoute.set(routeIdx, perRoute);
-          }
-        }
+        const patchPlan = planRouteClassificationInjection({
+          canonicalizeLayoutPath: canonicalize,
+          chunks,
+          dynamicShimPaths,
+          enableDebugReasons: enableClassificationDebug,
+          manifest: rscClassificationManifest,
+          moduleInfo,
+        });
+        if (patchPlan.kind === "skip") return;
 
-        const replacement = buildGenerateBundleReplacement(
-          rscClassificationManifest,
-          layer2PerRoute,
-        );
-        const patchedBody = `function __VINEXT_CLASS(routeIdx) { return (${replacement})(routeIdx); }`;
-        const target = chunksWithStubBody[0]!.chunk;
-        target.code = target.code.replace(stubRe, patchedBody);
-
-        if (enableClassificationDebug) {
-          const reasonsReplacement = buildReasonsReplacement(
-            rscClassificationManifest,
-            layer2PerRoute,
+        const target = chunksByFileName.get(patchPlan.fileName);
+        if (!target) {
+          throw new Error(
+            `vinext: build-time classification — patch target ${patchPlan.fileName} disappeared from the RSC bundle`,
           );
-          const patchedReasonsBody = `function __VINEXT_CLASS_REASONS(routeIdx) { return (${reasonsReplacement})(routeIdx); }`;
-          target.code = target.code.replace(reasonsStubRe, patchedReasonsBody);
         }
+        target.code = patchPlan.code;
 
         // The patched body is longer than the stub, so any existing source map
         // would be stale. RSC entry source maps are not served or consumed, so
         // nulling the map is safe and prevents stale-map confusion in tooling.
-        target.map = null;
+        target.map = patchPlan.map;
         // Consume the manifest exactly once per RSC entry load. Clearing here
         // prevents a stale manifest from leaking into a subsequent generateBundle
         // call if the load hook is not re-triggered (e.g., in non-standard rebuild paths).

--- a/tests/route-classification-injector.test.ts
+++ b/tests/route-classification-injector.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "vite-plus/test";
+import { planRouteClassificationInjection } from "../packages/vinext/src/build/route-classification-injector.js";
+import type { RouteClassificationManifest } from "../packages/vinext/src/build/route-classification-manifest.js";
+
+function makeManifest(): RouteClassificationManifest {
+  return {
+    routes: [
+      {
+        pattern: "/",
+        layoutPaths: ["/app/layout.tsx", "/app/blog/layout.tsx"],
+        layer1: new Map([[0, "dynamic"]]),
+        layer1Reasons: new Map([
+          [
+            0,
+            {
+              layer: "segment-config",
+              key: "dynamic",
+              value: "force-dynamic",
+            },
+          ],
+        ]),
+      },
+    ],
+  };
+}
+
+function makeChunk(code: string, fileName = "server/app.js") {
+  return {
+    code,
+    fileName,
+  };
+}
+
+const STUBS = [
+  "function __VINEXT_CLASS(routeIdx) { return null; }",
+  "function __VINEXT_CLASS_REASONS(routeIdx) { return null; }",
+  "const route = { __buildTimeClassifications: __VINEXT_CLASS(0) };",
+].join("\n");
+
+describe("planRouteClassificationInjection", () => {
+  it("skips chunks that do not mention the classification dispatch", () => {
+    const plan = planRouteClassificationInjection({
+      chunks: [makeChunk("export const value = 1;")],
+      dynamicShimPaths: new Set(),
+      enableDebugReasons: false,
+      manifest: makeManifest(),
+      moduleInfo: {
+        getModuleInfo() {
+          return null;
+        },
+      },
+    });
+
+    expect(plan.kind).toBe("skip");
+  });
+
+  it("patches the classification stub and invalidates the target source map", () => {
+    const plan = planRouteClassificationInjection({
+      chunks: [makeChunk(STUBS)],
+      dynamicShimPaths: new Set(),
+      enableDebugReasons: false,
+      manifest: makeManifest(),
+      moduleInfo: {
+        getModuleInfo(moduleId) {
+          if (moduleId === "/app/blog/layout.tsx") {
+            return { importedIds: [], dynamicImportedIds: [] };
+          }
+          return null;
+        },
+      },
+    });
+
+    expect(plan).toMatchObject({
+      kind: "patch",
+      fileName: "server/app.js",
+      map: null,
+    });
+    if (plan.kind !== "patch") throw new Error("Expected patch plan");
+    expect(plan.code).not.toContain("function __VINEXT_CLASS(routeIdx) { return null; }");
+    expect(plan.code).toContain("function __VINEXT_CLASS(routeIdx) { return ((routeIdx) => {");
+    expect(plan.code).toContain('case 0: return new Map([[0, "dynamic"], [1, "static"]]);');
+    expect(plan.code).toContain("function __VINEXT_CLASS_REASONS(routeIdx) { return null; }");
+  });
+
+  it("does not claim a layout static when the seed module is absent from the graph", () => {
+    const plan = planRouteClassificationInjection({
+      chunks: [makeChunk(STUBS)],
+      dynamicShimPaths: new Set(),
+      enableDebugReasons: false,
+      manifest: makeManifest(),
+      moduleInfo: {
+        getModuleInfo() {
+          return null;
+        },
+      },
+    });
+
+    if (plan.kind !== "patch") throw new Error("Expected patch plan");
+    expect(plan.code).toContain('case 0: return new Map([[0, "dynamic"]]);');
+    expect(plan.code).not.toContain('[1, "static"]');
+  });
+
+  it("patches the debug reasons sidecar when debug reasons are enabled", () => {
+    const plan = planRouteClassificationInjection({
+      chunks: [makeChunk(STUBS)],
+      dynamicShimPaths: new Set(),
+      enableDebugReasons: true,
+      manifest: makeManifest(),
+      moduleInfo: {
+        getModuleInfo(moduleId) {
+          if (moduleId === "/app/blog/layout.tsx") {
+            return { importedIds: [], dynamicImportedIds: [] };
+          }
+          return null;
+        },
+      },
+    });
+
+    if (plan.kind !== "patch") throw new Error("Expected patch plan");
+    expect(plan.code).not.toContain("function __VINEXT_CLASS_REASONS(routeIdx) { return null; }");
+    expect(plan.code).toContain(
+      "function __VINEXT_CLASS_REASONS(routeIdx) { return ((routeIdx) => {",
+    );
+    expect(plan.code).toContain('[1, { layer: "module-graph", result: "static" }]');
+  });
+
+  it("fails loudly when the dispatch is referenced but the stub body is absent", () => {
+    expect(() =>
+      planRouteClassificationInjection({
+        chunks: [makeChunk("const route = { __buildTimeClassifications: __VINEXT_CLASS(0) };")],
+        dynamicShimPaths: new Set(),
+        enableDebugReasons: false,
+        manifest: makeManifest(),
+        moduleInfo: {
+          getModuleInfo() {
+            return null;
+          },
+        },
+      }),
+    ).toThrow(/referenced in server\/app\.js but no chunk contains the stub body/);
+  });
+
+  it("fails loudly when debug reasons are enabled but the reasons stub is missing", () => {
+    expect(() =>
+      planRouteClassificationInjection({
+        chunks: [
+          makeChunk(
+            [
+              "function __VINEXT_CLASS(routeIdx) { return null; }",
+              "const route = { __buildTimeClassifications: __VINEXT_CLASS(0) };",
+            ].join("\n"),
+          ),
+        ],
+        dynamicShimPaths: new Set(),
+        enableDebugReasons: true,
+        manifest: makeManifest(),
+        moduleInfo: {
+          getModuleInfo() {
+            return null;
+          },
+        },
+      }),
+    ).toThrow(/__VINEXT_CLASS_REASONS stub is missing/);
+  });
+});

--- a/tests/route-classification-injector.test.ts
+++ b/tests/route-classification-injector.test.ts
@@ -140,6 +140,22 @@ describe("planRouteClassificationInjection", () => {
     ).toThrow(/referenced in server\/app\.js but no chunk contains the stub body/);
   });
 
+  it("fails loudly when multiple chunks contain the dispatch stub body", () => {
+    expect(() =>
+      planRouteClassificationInjection({
+        chunks: [makeChunk(STUBS, "server/app-a.js"), makeChunk(STUBS, "server/app-b.js")],
+        dynamicShimPaths: new Set(),
+        enableDebugReasons: false,
+        manifest: makeManifest(),
+        moduleInfo: {
+          getModuleInfo() {
+            return null;
+          },
+        },
+      }),
+    ).toThrow(/expected __VINEXT_CLASS stub in exactly one RSC chunk, found 2/);
+  });
+
   it("fails loudly when debug reasons are enabled but the reasons stub is missing", () => {
     expect(() =>
       planRouteClassificationInjection({


### PR DESCRIPTION
## What this changes
Moves build-time route classification injection out of the Vite `generateBundle` hook and into a normal typed module. The hook now only adapts final RSC chunks and module info, then applies the patch plan returned by `route-classification-injector`.

This follows the project principle: codegen should describe the app shape; normal modules should implement behavior. The generated RSC entry still emits stable `__VINEXT_CLASS` and `__VINEXT_CLASS_REASONS` stubs plus per-route call sites. The new module owns drift detection, Layer 2 module-graph classification, Layer 1 priority, debug reason patching, and source-map invalidation.

## Why
The previous hook mixed Vite shell concerns with classification behavior, so important edge cases were only practical to exercise through plugin integration builds. That made a compatibility-sensitive path harder to reason about and easier to regress when generated source shape, Rolldown output, or classification policy changes.

Relevant Next.js source context:
- [App segment config parsing](https://github.com/vercel/next.js/blob/canary/packages/next/src/build/segment-config/app/app-segment-config.ts)
- [App route segment collection](https://github.com/vercel/next.js/blob/canary/packages/next/src/build/segment-config/app/app-segments.ts)
- [Runtime handling for `dynamic` and `revalidate` segment config](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/create-component-tree.tsx#L279-L360)
- [Dynamic usage tracking during app rendering](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/dynamic-rendering.ts)

## Approach
- Add `planRouteClassificationInjection()` as the functional core for the final RSC classification patch.
- Keep Vite-specific work in `index.ts`: gather chunks, adapt Rollup/Rolldown module info, apply the returned patch, and clear the consumed manifest.
- Preserve existing behavior for scan-phase no-ops, missing stub drift errors, multiple stub errors, debug sidecar patching, Layer 1 priority over module graph results, and stale source-map invalidation.

## Validation
- `vp test run tests/route-classification-injector.test.ts tests/route-classification-manifest.test.ts tests/build-time-classification-integration.test.ts`
- `vp check packages/vinext/src/build/route-classification-injector.ts packages/vinext/src/index.ts tests/route-classification-injector.test.ts`
- `vp run vinext#build`

`vp run vinext#build` completed with the existing package-build unresolved virtual module warnings for `virtual:vinext-rsc-entry`, `private-next-instrumentation-client`, and `virtual:vite-rsc/client-references`.

## Risks / follow-ups
This is intentionally scoped to classification injection. It does not change the generated RSC entry shape, route manifest collection, or runtime probe behavior.