### PR TITLE
refactor: introduce createAppRscHandler

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -23,16 +23,12 @@ import { isProxyFile } from "../server/middleware.js";
 // Pre-computed absolute paths for generated-code imports. The virtual RSC
 // entry can't use relative imports (it has no real file location), so we
 // resolve these at code-generation time and embed them as absolute paths.
-const configMatchersPath = resolveEntryPath("../config/config-matchers.js", import.meta.url);
-const requestPipelinePath = resolveEntryPath("../server/request-pipeline.js", import.meta.url);
-const appMiddlewarePath = resolveEntryPath("../server/app-middleware.js", import.meta.url);
 const middlewareRequestHeadersPath = resolveEntryPath(
   "../server/middleware-request-headers.js",
   import.meta.url,
 );
-const requestContextShimPath = resolveEntryPath("../shims/request-context.js", import.meta.url);
 const normalizePathModulePath = resolveEntryPath("../server/normalize-path.js", import.meta.url);
-const routingUtilsPath = resolveEntryPath("../routing/utils.js", import.meta.url);
+const appRscHandlerPath = resolveEntryPath("../server/app-rsc-handler.js", import.meta.url);
 const appRouteHandlerDispatchPath = resolveEntryPath(
   "../server/app-route-handler-dispatch.js",
   import.meta.url,
@@ -42,7 +38,6 @@ const appServerActionExecutionPath = resolveEntryPath(
   import.meta.url,
 );
 const appRscErrorsPath = resolveEntryPath("../server/app-rsc-errors.js", import.meta.url);
-const implicitTagsPath = resolveEntryPath("../server/implicit-tags.js", import.meta.url);
 const appPageExecutionPath = resolveEntryPath("../server/app-page-execution.js", import.meta.url);
 const appPageBoundaryRenderPath = resolveEntryPath(
   "../server/app-page-boundary-render.js",
@@ -55,30 +50,15 @@ const appPageRouteWiringPath = resolveEntryPath(
 );
 const appPageHeadPath = resolveEntryPath("../server/app-page-head.js", import.meta.url);
 const appPageParamsPath = resolveEntryPath("../server/app-page-params.js", import.meta.url);
-const appPageResponsePath = resolveEntryPath("../server/app-page-response.js", import.meta.url);
 const appPageDispatchPath = resolveEntryPath("../server/app-page-dispatch.js", import.meta.url);
-const cspPath = resolveEntryPath("../server/csp.js", import.meta.url);
 const appRscRouteMatchingPath = resolveEntryPath(
   "../server/app-rsc-route-matching.js",
-  import.meta.url,
-);
-const appPrerenderEndpointsPath = resolveEntryPath(
-  "../server/app-prerender-endpoints.js",
-  import.meta.url,
-);
-const prerenderWorkUnitSetupPath = resolveEntryPath(
-  "../server/prerender-work-unit-setup.js",
   import.meta.url,
 );
 const rscStreamHintsPath = resolveEntryPath("../server/rsc-stream-hints.js", import.meta.url);
 const isrCachePath = resolveEntryPath("../server/isr-cache.js", import.meta.url);
 const rootParamsShimPath = resolveEntryPath("../shims/root-params.js", import.meta.url);
 const thenableParamsShimPath = resolveEntryPath("../shims/thenable-params.js", import.meta.url);
-const metadataRouteResponsePath = resolveEntryPath(
-  "../server/metadata-route-response.js",
-  import.meta.url,
-);
-const errorCausePath = resolveEntryPath("../utils/error-cause.js", import.meta.url);
 
 /**
  * Resolved config options relevant to App Router request handling.
@@ -161,9 +141,6 @@ async function __loadPrerenderPagesRoutes() {
 }
 `
     : "";
-  const prerenderPagesLoaderOption = hasPagesDir
-    ? "    loadPagesRoutes: __loadPrerenderPagesRoutes,\n"
-    : "";
 
   return `
 import {
@@ -184,17 +161,15 @@ function renderToReadableStream(model, options) {
 }
 import { createElement } from "react";
 import { setNavigationContext as _setNavigationContextOrig, getNavigationContext as _getNavigationContext } from "next/navigation";
-import { setHeadersContext, headersContextFromRequest, getDraftModeCookieHeader, getAndClearPendingCookies, consumeDynamicUsage, consumeInvalidDynamicUsageError, markDynamicUsage, getHeadersContext, setHeadersAccessPhase } from "next/headers";
+import { setHeadersContext, getDraftModeCookieHeader, getAndClearPendingCookies, markDynamicUsage, setHeadersAccessPhase } from "next/headers";
 import { mergeMetadata, resolveModuleMetadata, mergeViewport, resolveModuleViewport } from "vinext/metadata";
 ${middlewarePath ? `import * as middlewareModule from ${JSON.stringify(middlewarePath.replace(/\\/g, "/"))};` : ""}
 ${instrumentationPath ? `import * as _instrumentation from ${JSON.stringify(instrumentationPath.replace(/\\/g, "/"))};` : ""}
-import { handleMetadataRouteRequest as __handleMetadataRouteRequest } from ${JSON.stringify(metadataRouteResponsePath)};
-import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, isExternalUrl, proxyExternalRequest, sanitizeDestination } from ${JSON.stringify(configMatchersPath)};
-import { decodePathParams as __decodePathParams, normalizePath as __normalizePath } from ${JSON.stringify(normalizePathModulePath)};
-import { normalizePathnameForRouteMatch as __normalizePathnameForRouteMatch, normalizePathnameForRouteMatchStrict as __normalizePathnameForRouteMatchStrict } from ${JSON.stringify(routingUtilsPath)};
+import { decodePathParams as __decodePathParams } from ${JSON.stringify(normalizePathModulePath)};
 import { buildRequestHeadersFromMiddlewareResponse as __buildRequestHeadersFromMiddlewareResponse } from ${JSON.stringify(middlewareRequestHeadersPath)};
-import { applyConfigHeadersToResponse, resolvePublicFileRoute, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash } from ${JSON.stringify(requestPipelinePath)};
-import { applyAppMiddleware as __applyAppMiddleware } from ${JSON.stringify(appMiddlewarePath)};
+import {
+  createAppRscHandler as __createAppRscHandler,
+} from ${JSON.stringify(appRscHandlerPath)};
 import {
   dispatchAppRouteHandler as __dispatchAppRouteHandler,
 } from ${JSON.stringify(appRouteHandlerDispatchPath)};
@@ -234,38 +209,25 @@ import {
   resolveAppPageHead as __resolveAppPageHead,
 } from ${JSON.stringify(appPageHeadPath)};
 import {
-  mergeMiddlewareResponseHeaders as __mergeMiddlewareResponseHeaders,
-} from ${JSON.stringify(appPageResponsePath)};
-import {
   dispatchAppPage as __dispatchAppPage,
 } from ${JSON.stringify(appPageDispatchPath)};
-import { getScriptNonceFromHeaderSources as __getScriptNonceFromHeaderSources } from ${JSON.stringify(cspPath)};
-import { buildPageCacheTags } from ${JSON.stringify(implicitTagsPath)};
-import { getRequestExecutionContext as _getRequestExecutionContext } from ${JSON.stringify(requestContextShimPath)};
-import { setRootParams as __setRootParams, pickRootParams as __pickRootParams } from ${JSON.stringify(rootParamsShimPath)};
+import { setRootParams as __setRootParams } from ${JSON.stringify(rootParamsShimPath)};
 import { makeThenableParams } from ${JSON.stringify(thenableParamsShimPath)};
-import { ensureFetchPatch as _ensureFetchPatch, setCurrentFetchSoftTags } from "vinext/fetch-cache";
+import { setCurrentFetchSoftTags } from "vinext/fetch-cache";
 import {
   createAppRscRouteMatcher as __createAppRscRouteMatcher,
 } from ${JSON.stringify(appRscRouteMatchingPath)};
-import {
-  handleAppPrerenderEndpoint as __handleAppPrerenderEndpoint,
-} from ${JSON.stringify(appPrerenderEndpointsPath)};
 import {
   appIsrHtmlKey as __isrHtmlKey,
   appIsrRscKey as __isrRscKey,
   appIsrRouteKey as __isrRouteKey,
   isrGet as __isrGet,
   isrSet as __isrSet,
-  normalizeMountedSlotsHeader as __normalizeMountedSlotsHeader,
   triggerBackgroundRegeneration as __triggerBackgroundRegeneration,
 } from ${JSON.stringify(isrCachePath)};
 // Import server-only state module to register ALS-backed accessors.
 import "vinext/navigation-state";
-import { runWithPrerenderWorkUnit as __runWithPrerenderWorkUnit } from ${JSON.stringify(prerenderWorkUnitSetupPath)};
-import { runWithRequestContext as _runWithUnifiedCtx, createRequestContext as _createUnifiedCtx } from "vinext/unified-request-context";
 import { reportRequestError as _reportRequestError } from "vinext/instrumentation";
-import { flattenErrorCauses as __flattenErrorCauses } from ${JSON.stringify(errorCausePath)};
 import { getSSRFontLinks as _getSSRFontLinks, getSSRFontStyles as _getSSRFontStylesGoogle, getSSRFontPreloads as _getSSRFontPreloadsGoogle } from "next/font/google";
 import { getSSRFontStyles as _getSSRFontStylesLocal, getSSRFontPreloads as _getSSRFontPreloadsLocal } from "next/font/local";
 function _getSSRFontStyles() { return [..._getSSRFontStylesGoogle(), ..._getSSRFontStylesLocal()]; }
@@ -638,35 +600,6 @@ const __allowedOrigins = ${JSON.stringify(allowedOrigins)};
 
 ${generateDevOriginCheckCode(config?.allowedDevOrigins)}
 
-// ── Config pattern matching, redirects, rewrites, headers, CSRF validation,
-//    external URL proxy, cookie parsing, and request context are imported from
-//    config-matchers.ts and request-pipeline.ts (see import statements above).
-//    This eliminates ~250 lines of duplicated inline code and ensures the
-//    single-pass tokenizer in config-matchers.ts is used consistently
-//    (fixing the chained .replace() divergence flagged by CodeQL).
-
-/**
- * Build a request context from the live ALS HeadersContext, which reflects
- * any x-middleware-request-* header mutations applied by middleware.
- * Used for afterFiles and fallback rewrite has/missing evaluation — these
- * run after middleware in the App Router execution order.
- */
-function __buildPostMwRequestContext(request) {
-  const url = new URL(request.url);
-  const ctx = getHeadersContext();
-  if (!ctx) return requestContextFromRequest(request);
-  // ctx.cookies is a Map<string, string> (HeadersContext), but RequestContext
-  // requires a plain Record<string, string> for has/missing cookie evaluation
-  // (config-matchers.ts uses obj[key] not Map.get()). Convert here.
-  const cookiesRecord = Object.fromEntries(ctx.cookies);
-  return {
-    headers: ctx.headers,
-    cookies: cookiesRecord,
-    query: url.searchParams,
-    host: normalizeHost(ctx.headers.get("host"), url.hostname),
-  };
-}
-
 /**
  * Maximum server-action request body size.
  * Configurable via experimental.serverActions.bodySizeLimit in next.config.
@@ -694,448 +627,149 @@ ${routes
   .join("\n")}
 };
 
-export default async function handler(request, ctx) {
-  ${
-    instrumentationPath
-      ? `// Ensure instrumentation.register() has run before handling the first request.
-  // This is a no-op after the first call (guarded by __instrumentationInitialized).
-  await __ensureInstrumentation();
-  `
-      : ""
-  }
-  // Wrap the entire request in a single unified ALS scope for per-request
-  // isolation. All state modules (headers, navigation, cache, fetch-cache,
-  // execution-context) read from this store via isInsideUnifiedScope().
-  const headersCtx = headersContextFromRequest(request);
-  const __uCtx = _createUnifiedCtx({
-    headersContext: headersCtx,
-    executionContext: ctx ?? _getRequestExecutionContext() ?? null,
-    unstableCacheRevalidation: "background",
-  });
-  return _runWithUnifiedCtx(__uCtx, () =>
-    __runWithPrerenderWorkUnit(async () => {
-    _ensureFetchPatch();
-    const __reqCtx = requestContextFromRequest(request);
-    // Per-request container for middleware state. Passed into
-    // _handleRequest which fills in .headers and .status;
-    // avoids module-level variables that race on Workers.
-    const _mwCtx = { headers: null, requestHeaders: null, status: null };
-    let response;
-    try {
-      response = await _handleRequest(request, __reqCtx, _mwCtx);
-    } catch (err) {
-      // Dev only: embed err.cause chain into err.message/err.stack so Vite's
-      // dev-server "Internal server error:" logger (which builds output from
-      // message + stack only) reveals the underlying root cause (ECONNREFUSED,
-      // role missing, workerd socket error, etc.) instead of dropping it.
-      // Skipped in production because Node's util.inspect / workerd's logger
-      // already render .cause natively, so flattening would double-print it.
-      // NODE_ENV is build-time-replaced by Vite, so the prod bundle compiles
-      // this branch out entirely.
-      if (process.env.NODE_ENV !== "production") {
-        __flattenErrorCauses(err);
-      }
-      throw err;
-    }
-    // Apply custom headers from next.config.js to non-redirect responses.
-    // Skip redirects (3xx) because Response.redirect() creates immutable headers,
-    // and Next.js doesn't apply custom headers to redirects anyway.
-    if (response && response.headers && !(response.status >= 300 && response.status < 400)) {
-      if (__configHeaders.length) {
-        const url = new URL(request.url);
-        let pathname;
-        try { pathname = __normalizePath(__normalizePathnameForRouteMatch(url.pathname)); } catch { pathname = url.pathname; }
-        ${bp ? `if (pathname.startsWith(${JSON.stringify(bp)})) pathname = pathname.slice(${JSON.stringify(bp)}.length) || "/";` : ""}
-        applyConfigHeadersToResponse(response.headers, {
-          configHeaders: __configHeaders,
-          pathname,
-          requestContext: __reqCtx,
-        });
-      }
-    }
-    return response;
-    }, { route: () => new URL(request.url).pathname })
-  );
-}
-
-async function _handleRequest(request, __reqCtx, _mwCtx) {
-  const __reqStart = process.env.NODE_ENV !== "production" ? performance.now() : 0;
-  // __reqStart is included in the timing header so the Node logging middleware
-  // can compute true compile time as: handlerStart - middlewareStart.
-  // Format: "handlerStart,compileMs,renderMs" - all as integers (ms). Dev-only.
-  const url = new URL(request.url);
-
-  // ── Cross-origin request protection (dev only) ─────────────────────
-  // Block requests from non-localhost origins to prevent data exfiltration.
-  // Skipped in production — Vite replaces NODE_ENV at build time.
-  if (process.env.NODE_ENV !== "production") {
-    const __originBlock = __validateDevRequestOrigin(request);
-    if (__originBlock) return __originBlock;
-  }
-
-  // Guard against protocol-relative URL open redirects (see request-pipeline.ts).
-  const __protoGuard = guardProtocolRelativeUrl(url.pathname);
-  if (__protoGuard) return __protoGuard;
-
-  // Decode percent-encoding segment-wise and normalize pathname to canonical form.
-  // This preserves encoded path delimiters like %2F within a single segment.
-  // __normalizePath collapses //foo///bar → /foo/bar, resolves . and .. segments.
-  let decodedUrlPathname;
-  try { decodedUrlPathname = __normalizePathnameForRouteMatchStrict(url.pathname); } catch (e) {
-    return new Response("Bad Request", { status: 400 });
-  }
-  let pathname = __normalizePath(decodedUrlPathname);
-
-  ${
-    bp
-      ? `
-  if (!hasBasePath(pathname, __basePath) && !pathname.startsWith("/__vinext/")) {
-    return new Response("Not Found", { status: 404 });
-  }
-  // Strip basePath prefix
-  pathname = stripBasePath(pathname, __basePath);
-  `
-      : ""
-  }
-
-  const __prerenderEndpointResponse = await __handleAppPrerenderEndpoint(request, {
-    isPrerenderEnabled() {
-      return process.env.VINEXT_PRERENDER === "1";
-    },
-${prerenderPagesLoaderOption}
-    pathname,
-    rootParamNamesByPattern: rootParamNamesMap,
-    staticParamsMap: generateStaticParamsMap,
-  });
-  if (__prerenderEndpointResponse) return __prerenderEndpointResponse;
-
-  // Trailing slash normalization (redirect to canonical form)
-  const __tsRedirect = normalizeTrailingSlash(pathname, __basePath, __trailingSlash, url.search);
-  if (__tsRedirect) return __tsRedirect;
-
-  // ── Apply redirects from next.config.js ───────────────────────────────
-  if (__configRedirects.length) {
-    // Strip .rsc suffix before matching redirect rules - RSC (client-side nav) requests
-    // arrive as /some/path.rsc but redirect patterns are defined without it (e.g.
-    // /some/path). Without this, soft-nav fetches bypass all config redirects.
-    const __redirPathname = pathname.endsWith(".rsc") ? pathname.slice(0, -4) : pathname;
-    const __redir = matchRedirect(__redirPathname, __configRedirects, __reqCtx);
-    if (__redir) {
-      const __redirDest = sanitizeDestination(
-        __basePath &&
-          !isExternalUrl(__redir.destination) &&
-          !hasBasePath(__redir.destination, __basePath)
-          ? __basePath + __redir.destination
-          : __redir.destination
-      );
-      return new Response(null, {
-        status: __redir.permanent ? 308 : 307,
-        headers: { Location: __redirDest },
-      });
-    }
-  }
-
-  const isRscRequest = pathname.endsWith(".rsc") || request.headers.get("accept")?.includes("text/x-component");
-  // Read mounted-slots header once at the handler scope and thread it through
-  // every buildPageElements call site. Previously both the handler and
-  // buildPageElements read and normalized it independently, which invited
-  // silent drift if a future refactor changed only one path.
-  const __mountedSlotsHeader = __normalizeMountedSlotsHeader(
-    request.headers.get("x-vinext-mounted-slots"),
-  );
-  const interceptionContextHeader = request.headers.get("X-Vinext-Interception-Context")?.replaceAll("\0", "") || null;
-  let cleanPathname = pathname.replace(/\\.rsc$/, "");
-
-  // Middleware response headers and custom rewrite status are stored in
-  // _mwCtx (per-request container) so handler() can merge them into
-  // every response path without module-level state that races on Workers.
-
-  ${
-    middlewarePath
-      ? `
-  const __mwResult = await __applyAppMiddleware({
-    basePath: __basePath,
-    cleanPathname,
-    context: _mwCtx,
-    i18nConfig: __i18nConfig,
-    isProxy: ${JSON.stringify(isProxyFile(middlewarePath))},
-    module: middlewareModule,
-    request,
-  });
-  if (__mwResult.kind === "response") return __mwResult.response;
-  cleanPathname = __mwResult.cleanPathname;
-  if (__mwResult.search !== null) {
-    url.search = __mwResult.search;
-  }
-  `
-      : ""
-  }
-
-  const _scriptNonce = __getScriptNonceFromHeaderSources(request.headers, _mwCtx.headers);
-
-  // Build post-middleware request context for afterFiles/fallback rewrites.
-  // These run after middleware in the App Router execution order and should
-  // evaluate has/missing conditions against middleware-modified headers.
-  // When no middleware is present, this falls back to requestContextFromRequest.
-  const __postMwReqCtx = __buildPostMwRequestContext(request);
-
-  // ── Apply beforeFiles rewrites from next.config.js ────────────────────
-  // In App Router execution order, beforeFiles runs after middleware so that
-  // has/missing conditions can evaluate against middleware-modified headers.
-  if (__configRewrites.beforeFiles && __configRewrites.beforeFiles.length) {
-    const __rewritten = matchRewrite(cleanPathname, __configRewrites.beforeFiles, __postMwReqCtx);
-    if (__rewritten) {
-      if (isExternalUrl(__rewritten)) {
-        __clearRequestContext();
-        return proxyExternalRequest(request, __rewritten);
-      }
-      cleanPathname = __rewritten;
-    }
-  }
-
-  // ── Image optimization passthrough (dev mode — no transformation) ───────
-  if (cleanPathname === "/_vinext/image") {
-    const __imgResult = validateImageUrl(url.searchParams.get("url"), request.url);
-    if (__imgResult instanceof Response) return __imgResult;
-    // In dev, redirect to the original asset URL so Vite's static serving handles it.
-    return Response.redirect(new URL(__imgResult, url.origin).href, 302);
-  }
-
-  const metadataRouteResponse = await __handleMetadataRouteRequest({
-    metadataRoutes,
-    cleanPathname,
-    makeThenableParams,
-  });
-  if (metadataRouteResponse) return metadataRouteResponse;
-
-  // Serve public/ files as filesystem routes after middleware and before
-  // afterFiles/fallback rewrites, matching Next.js routing semantics.
-  const __publicFileResponse = resolvePublicFileRoute({
-    cleanPathname,
-    middlewareContext: _mwCtx,
-    pathname,
-    publicFiles: __publicFiles,
-    request,
-  });
-  if (__publicFileResponse) {
+export default __createAppRscHandler({
+  basePath: __basePath,
+  clearRequestContext() {
     __clearRequestContext();
-    return __publicFileResponse;
-  }
-
-  // Set navigation context for Server Components.
-  // Note: Headers context is already set by runWithRequestContext in the handler wrapper.
-  setNavigationContext({
-    pathname: cleanPathname,
-    searchParams: url.searchParams,
-    params: {},
-  });
-
-  // Handle server action POST requests
-  const actionId = request.headers.get("x-rsc-action") ?? request.headers.get("next-action");
-  const actionContentType = request.headers.get("content-type") || "";
-  const progressiveActionResponse = await __handleProgressiveServerActionRequest({
-    actionId,
-    allowedOrigins: __allowedOrigins,
+  },
+  configHeaders: __configHeaders,
+  configRedirects: __configRedirects,
+  configRewrites: __configRewrites,
+  dispatchMatchedPage({
     cleanPathname,
-    clearRequestContext() {
-      __clearRequestContext();
-    },
-    contentType: actionContentType,
-    decodeAction,
-    getAndClearPendingCookies,
-    getDraftModeCookieHeader,
-    maxActionBodySize: __MAX_ACTION_BODY_SIZE,
-    middlewareHeaders: _mwCtx.headers,
-    readFormDataWithLimit: __readFormDataWithLimit,
-    reportRequestError: _reportRequestError,
-    request,
-    setHeadersAccessPhase,
-  });
-  if (progressiveActionResponse) return progressiveActionResponse;
-
-  const serverActionResponse = await __handleServerActionRscRequest({
-    actionId,
-    allowedOrigins: __allowedOrigins,
-    buildPageElement({
-      route: actionRoute,
-      params: actionParams,
-      cleanPathname: actionCleanPathname,
-      interceptOpts,
-      searchParams,
-      isRscRequest: actionIsRscRequest,
-      request: actionRequest,
-      mountedSlotsHeader,
-    }) {
-      return buildPageElements(actionRoute, actionParams, actionCleanPathname, {
-        opts: interceptOpts,
-        searchParams,
-        isRscRequest: actionIsRscRequest,
-        request: actionRequest,
-        mountedSlotsHeader,
-      });
-    },
-    cleanPathname,
-    clearRequestContext() {
-      __clearRequestContext();
-    },
-    contentType: actionContentType,
-    createNotFoundElement(actionRouteId) {
-      return {
-        [__APP_INTERCEPTION_CONTEXT_KEY]: null,
-        __route: actionRouteId,
-        __rootLayout: null,
-        [actionRouteId]: createElement("div", null, "Page not found"),
-      };
-    },
-    createPayloadRouteId(pathnameToRender, interceptionContext) {
-      return __createAppPayloadRouteId(pathnameToRender, interceptionContext);
-    },
-    createRscOnErrorHandler(actionRequest, actionPathname, routePattern) {
-      return createRscOnErrorHandler(actionRequest, actionPathname, routePattern);
-    },
-    createTemporaryReferenceSet,
-    decodeReply,
-    findIntercept(pathnameToMatch) {
-      return findIntercept(pathnameToMatch, interceptionContextHeader);
-    },
-    getAndClearPendingCookies,
-    getDraftModeCookieHeader,
-    getRouteParamNames(sourceRoute) {
-      return sourceRoute.params;
-    },
-    getSourceRoute(sourceRouteIndex) {
-      return routes[sourceRouteIndex];
-    },
+    handlerStart,
+    interceptionContext,
     isRscRequest,
-    loadServerAction,
-    matchRoute(pathnameToMatch) {
-      return matchRoute(pathnameToMatch);
-    },
-    maxActionBodySize: __MAX_ACTION_BODY_SIZE,
-    middlewareHeaders: _mwCtx.headers,
-    middlewareStatus: _mwCtx.status,
-    mountedSlotsHeader: __mountedSlotsHeader,
-    readBodyWithLimit: __readBodyWithLimit,
-    readFormDataWithLimit: __readFormDataWithLimit,
-    renderToReadableStream,
-    reportRequestError: _reportRequestError,
-    request,
-    sanitizeErrorForClient(error) {
-      return __sanitizeErrorForClient(error);
-    },
-    searchParams: url.searchParams,
-    setHeadersAccessPhase,
-    setNavigationContext,
-    toInterceptOpts(intercept) {
-      return {
-        interceptionContext: interceptionContextHeader,
-        interceptLayouts: intercept.interceptLayouts,
-        interceptSlotKey: intercept.slotKey,
-        interceptPage: intercept.page,
-        interceptParams: intercept.matchedParams,
-      };
-    },
-  });
-  if (serverActionResponse) return serverActionResponse;
-
-  // ── Apply afterFiles rewrites from next.config.js ──────────────────────
-  if (__configRewrites.afterFiles && __configRewrites.afterFiles.length) {
-    const __afterRewritten = matchRewrite(cleanPathname, __configRewrites.afterFiles, __postMwReqCtx);
-    if (__afterRewritten) {
-      if (isExternalUrl(__afterRewritten)) {
-        __clearRequestContext();
-        return proxyExternalRequest(request, __afterRewritten);
-      }
-      cleanPathname = __afterRewritten;
-    }
-  }
-
-  let match = matchRoute(cleanPathname);
-
-  // ── Fallback rewrites from next.config.js (if no route matched) ───────
-  if (!match && __configRewrites.fallback && __configRewrites.fallback.length) {
-    const __fallbackRewritten = matchRewrite(cleanPathname, __configRewrites.fallback, __postMwReqCtx);
-    if (__fallbackRewritten) {
-      if (isExternalUrl(__fallbackRewritten)) {
-        __clearRequestContext();
-        return proxyExternalRequest(request, __fallbackRewritten);
-      }
-      cleanPathname = __fallbackRewritten;
-      match = matchRoute(cleanPathname);
-    }
-  }
-
-  if (!match) {
-    ${
-      hasPagesDir
-        ? `
-    // ── Pages Router fallback ────────────────────────────────────────────
-    // When a request doesn't match any App Router route, delegate to the
-    // Pages Router handler (available in the SSR environment). This covers
-    // both production request serving and prerender fetches from wrangler.
-    // RSC requests (.rsc suffix or Accept: text/x-component) cannot be
-    // handled by the Pages Router, so skip the delegation for those.
-    if (!isRscRequest) {
-      const __pagesEntry = await import.meta.viteRsc.loadModule("ssr", "index");
-      if (typeof __pagesEntry.renderPage === "function") {
-        const __pagesRequestHeaders = _mwCtx.requestHeaders
-          ? __buildRequestHeadersFromMiddlewareResponse(request.headers, _mwCtx.requestHeaders)
-          : null;
-        const __pagesRequest = __pagesRequestHeaders
-          ? new Request(request.url, { method: request.method, headers: __pagesRequestHeaders })
-          : request;
-        // Use segment-wise decoding to preserve encoded path delimiters (%2F).
-        // decodeURIComponent would turn /admin%2Fpanel into /admin/panel,
-        // changing the path structure and bypassing middleware matchers.
-        // Ported from Next.js: packages/next/src/server/lib/router-utils/decode-path-params.ts
-        // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/router-utils/decode-path-params.ts
-        const __pagesRes = await __pagesEntry.renderPage(
-          __pagesRequest,
-          __decodePathParams(url.pathname) + (url.search || ""),
-          {},
-          undefined,
-          _mwCtx.requestHeaders,
-        );
-        // Only return the Pages Router response if it matched a route
-        // (non-404). A 404 means the path isn't a Pages route either,
-        // so fall through to the App Router not-found page below.
-        if (__pagesRes.status !== 404) {
-          __clearRequestContext();
-          return __pagesRes;
-        }
-      }
-    }
-    `
-        : ""
-    }
-    // Render custom not-found page if available, otherwise plain 404
-    const notFoundResponse = await renderNotFoundPage(null, isRscRequest, request, undefined, _scriptNonce, _mwCtx);
-    if (notFoundResponse) return notFoundResponse;
-    __clearRequestContext();
-    const notFoundHeaders = new Headers();
-    __mergeMiddlewareResponseHeaders(notFoundHeaders, _mwCtx.headers);
-    return new Response("Not Found", { status: 404, headers: notFoundHeaders });
-  }
-
-  const { route, params } = match;
-
-  // Update navigation context with matched params
-  setNavigationContext({
-    pathname: cleanPathname,
-    searchParams: url.searchParams,
+    middlewareContext,
+    mountedSlotsHeader,
     params,
-  });
-  __setRootParams(__pickRootParams(params, route.rootParamNames));
-
-  // Handle route.ts API handlers
-  if (route.routeHandler) {
-    setCurrentFetchSoftTags(
-      buildPageCacheTags(cleanPathname, [], route.routeSegments, "route"),
-    );
+    request,
+    route,
+    scriptNonce,
+    searchParams,
+  }) {
+    const PageComponent = route.page?.default;
+    const _asyncRouteParams = makeThenableParams(params);
+    return __dispatchAppPage({
+      buildPageElement(targetRoute, targetParams, targetOpts, targetSearchParams) {
+        return buildPageElements(targetRoute, targetParams, cleanPathname, {
+          opts: targetOpts,
+          searchParams: targetSearchParams,
+          isRscRequest,
+          request,
+          mountedSlotsHeader,
+        });
+      },
+      cleanPathname,
+      clearRequestContext() {
+        __clearRequestContext();
+      },
+      createRscOnErrorHandler(pathname, routePath) {
+        return createRscOnErrorHandler(request, pathname, routePath);
+      },
+      debugClassification: __classDebug,
+      dynamicConfig: route.page?.dynamic,
+      dynamicParamsConfig: route.page?.dynamicParams,
+      findIntercept(pathname) {
+        return findIntercept(pathname, interceptionContext);
+      },
+      generateStaticParams: route.page?.generateStaticParams,
+      getFontLinks: _getSSRFontLinks,
+      getFontPreloads: _getSSRFontPreloads,
+      getFontStyles: _getSSRFontStyles,
+      getNavigationContext: _getNavigationContext,
+      getSourceRoute(sourceRouteIndex) {
+        return routes[sourceRouteIndex];
+      },
+      hasGenerateStaticParams: typeof route.page?.generateStaticParams === "function",
+      hasPageDefaultExport: !!PageComponent,
+      hasPageModule: !!route.page,
+      handlerStart,
+      interceptionContext,
+      isProduction: process.env.NODE_ENV === "production",
+      isRscRequest,
+      isrDebug: __isrDebug,
+      isrGet: __isrGet,
+      isrHtmlKey: __isrHtmlKey,
+      isrRscKey: __isrRscKey,
+      isrSet: __isrSet,
+      loadSsrHandler() {
+        return import.meta.viteRsc.loadModule("ssr", "index");
+      },
+      middlewareContext,
+      mountedSlotsHeader,
+      params,
+      probeLayoutAt(li) {
+        const LayoutComp = route.layouts[li]?.default;
+        if (!LayoutComp) return null;
+        return LayoutComp({
+          params: makeThenableParams(__resolveAppPageSegmentParams(
+            route.routeSegments,
+            route.layoutTreePositions?.[li] ?? 0,
+            params,
+          )),
+          children: null,
+        });
+      },
+      probePage() {
+        if (!PageComponent) return null;
+        const _asyncSearchParams = makeThenableParams(
+          __collectAppPageSearchParams(searchParams).searchParamsObject,
+        );
+        return PageComponent({ params: _asyncRouteParams, searchParams: _asyncSearchParams });
+      },
+      renderErrorBoundaryPage(renderErr) {
+        return renderErrorBoundaryPage(
+          route,
+          renderErr,
+          isRscRequest,
+          request,
+          params,
+          scriptNonce,
+          middlewareContext,
+        );
+      },
+      renderHttpAccessFallbackPage(statusCode, opts, currentMiddlewareContext) {
+        return renderHTTPAccessFallbackPage(
+          route,
+          statusCode,
+          isRscRequest,
+          request,
+          opts,
+          scriptNonce,
+          currentMiddlewareContext,
+        );
+      },
+      renderToReadableStream,
+      request,
+      revalidateSeconds: typeof route.page?.revalidate === "number" ? route.page.revalidate : null,
+      rootForbiddenModule,
+      rootNotFoundModule,
+      rootUnauthorizedModule,
+      route,
+      runWithSuppressedHookWarning(probe) {
+        return _suppressHookWarningAls.run(true, probe);
+      },
+      scheduleBackgroundRegeneration(key, renderFn, errorContext) {
+        __triggerBackgroundRegeneration(key, renderFn, errorContext);
+      },
+      scriptNonce,
+      searchParams,
+      setNavigationContext,
+    });
+  },
+  dispatchMatchedRouteHandler({
+    cleanPathname,
+    middlewareContext,
+    params,
+    request,
+    route,
+    searchParams,
+  }) {
     return __dispatchAppRouteHandler({
       basePath: __basePath,
       cleanPathname,
-      clearRequestContext: function() {
+      clearRequestContext() {
         __clearRequestContext();
       },
       i18n: __i18nConfig,
@@ -1143,8 +777,8 @@ ${prerenderPagesLoaderOption}
       isrGet: __isrGet,
       isrRouteKey: __isrRouteKey,
       isrSet: __isrSet,
-      middlewareContext: _mwCtx,
-      middlewareRequestHeaders: _mwCtx.requestHeaders,
+      middlewareContext,
+      middlewareRequestHeaders: middlewareContext.requestHeaders,
       params,
       request,
       route: {
@@ -1153,104 +787,175 @@ ${prerenderPagesLoaderOption}
         routeSegments: route.routeSegments,
       },
       scheduleBackgroundRegeneration: __triggerBackgroundRegeneration,
-      searchParams: url.searchParams,
+      searchParams,
     });
-  }
-
-  const PageComponent = route.page?.default;
-  const _asyncRouteParams = makeThenableParams(params);
-  return __dispatchAppPage({
-    buildPageElement(targetRoute, targetParams, targetOpts, targetSearchParams) {
-      return buildPageElements(targetRoute, targetParams, cleanPathname, {
-        opts: targetOpts,
-        searchParams: targetSearchParams,
-        isRscRequest,
-        request,
-        mountedSlotsHeader: __mountedSlotsHeader,
-      });
-    },
+  },
+  ${instrumentationPath ? "ensureInstrumentation: __ensureInstrumentation," : ""}
+  handleProgressiveActionRequest({
+    actionId,
     cleanPathname,
-    clearRequestContext() {
-      __clearRequestContext();
-    },
-    createRscOnErrorHandler(pathname, routePath) {
-      return createRscOnErrorHandler(request, pathname, routePath);
-    },
-    debugClassification: __classDebug,
-    dynamicConfig: route.page?.dynamic,
-    dynamicParamsConfig: route.page?.dynamicParams,
-    findIntercept(pathname) {
-      return findIntercept(pathname, interceptionContextHeader);
-    },
-    generateStaticParams: route.page?.generateStaticParams,
-    getFontLinks: _getSSRFontLinks,
-    getFontPreloads: _getSSRFontPreloads,
-    getFontStyles: _getSSRFontStyles,
-    getNavigationContext: _getNavigationContext,
-    getSourceRoute(sourceRouteIndex) {
-      return routes[sourceRouteIndex];
-    },
-    hasGenerateStaticParams: typeof route.page?.generateStaticParams === "function",
-    hasPageDefaultExport: !!PageComponent,
-    hasPageModule: !!route.page,
-    handlerStart: __reqStart,
-    interceptionContext: interceptionContextHeader,
-    isProduction: process.env.NODE_ENV === "production",
-    isRscRequest,
-    isrDebug: __isrDebug,
-    isrGet: __isrGet,
-    isrHtmlKey: __isrHtmlKey,
-    isrRscKey: __isrRscKey,
-    isrSet: __isrSet,
-    loadSsrHandler() {
-      return import.meta.viteRsc.loadModule("ssr", "index");
-    },
-    middlewareContext: _mwCtx,
-    mountedSlotsHeader: __mountedSlotsHeader,
-    params,
-    probeLayoutAt(li) {
-      const LayoutComp = route.layouts[li]?.default;
-      if (!LayoutComp) return null;
-      return LayoutComp({
-        params: makeThenableParams(__resolveAppPageSegmentParams(
-          route.routeSegments,
-          route.layoutTreePositions?.[li] ?? 0,
-          params,
-        )),
-        children: null,
-      });
-    },
-    probePage() {
-      if (!PageComponent) return null;
-      const _asyncSearchParams = makeThenableParams(
-        __collectAppPageSearchParams(url.searchParams).searchParamsObject,
-      );
-      return PageComponent({ params: _asyncRouteParams, searchParams: _asyncSearchParams });
-    },
-    renderErrorBoundaryPage(renderErr) {
-      return renderErrorBoundaryPage(route, renderErr, isRscRequest, request, params, _scriptNonce, _mwCtx);
-    },
-    renderHttpAccessFallbackPage(statusCode, opts, middlewareContext) {
-      return renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, opts, _scriptNonce, middlewareContext);
-    },
-    renderToReadableStream,
+    contentType,
+    middlewareContext,
     request,
-    revalidateSeconds: typeof route.page?.revalidate === "number" ? route.page.revalidate : null,
-    rootForbiddenModule,
-    rootNotFoundModule,
-    rootUnauthorizedModule,
-    route,
-    runWithSuppressedHookWarning(probe) {
-      return _suppressHookWarningAls.run(true, probe);
-    },
-    scheduleBackgroundRegeneration(key, renderFn, errorContext) {
-      __triggerBackgroundRegeneration(key, renderFn, errorContext);
-    },
-    scriptNonce: _scriptNonce,
-    searchParams: url.searchParams,
-    setNavigationContext,
-  });
-}
+  }) {
+    return __handleProgressiveServerActionRequest({
+      actionId,
+      allowedOrigins: __allowedOrigins,
+      cleanPathname,
+      clearRequestContext() {
+        __clearRequestContext();
+      },
+      contentType,
+      decodeAction,
+      getAndClearPendingCookies,
+      getDraftModeCookieHeader,
+      maxActionBodySize: __MAX_ACTION_BODY_SIZE,
+      middlewareHeaders: middlewareContext.headers,
+      readFormDataWithLimit: __readFormDataWithLimit,
+      reportRequestError: _reportRequestError,
+      request,
+      setHeadersAccessPhase,
+    });
+  },
+  handleServerActionRequest({
+    actionId,
+    cleanPathname,
+    contentType,
+    interceptionContext,
+    isRscRequest,
+    middlewareContext,
+    mountedSlotsHeader,
+    request,
+    searchParams,
+  }) {
+    return __handleServerActionRscRequest({
+      actionId,
+      allowedOrigins: __allowedOrigins,
+      buildPageElement({
+        route: actionRoute,
+        params: actionParams,
+        cleanPathname: actionCleanPathname,
+        interceptOpts,
+        searchParams: actionSearchParams,
+        isRscRequest: actionIsRscRequest,
+        request: actionRequest,
+        mountedSlotsHeader: actionMountedSlotsHeader,
+      }) {
+        return buildPageElements(actionRoute, actionParams, actionCleanPathname, {
+          opts: interceptOpts,
+          searchParams: actionSearchParams,
+          isRscRequest: actionIsRscRequest,
+          request: actionRequest,
+          mountedSlotsHeader: actionMountedSlotsHeader,
+        });
+      },
+      cleanPathname,
+      clearRequestContext() {
+        __clearRequestContext();
+      },
+      contentType,
+      createNotFoundElement(actionRouteId) {
+        return {
+          [__APP_INTERCEPTION_CONTEXT_KEY]: null,
+          __route: actionRouteId,
+          __rootLayout: null,
+          [actionRouteId]: createElement("div", null, "Page not found"),
+        };
+      },
+      createPayloadRouteId(pathnameToRender, currentInterceptionContext) {
+        return __createAppPayloadRouteId(pathnameToRender, currentInterceptionContext);
+      },
+      createRscOnErrorHandler(actionRequest, actionPathname, routePattern) {
+        return createRscOnErrorHandler(actionRequest, actionPathname, routePattern);
+      },
+      createTemporaryReferenceSet,
+      decodeReply,
+      findIntercept(pathnameToMatch) {
+        return findIntercept(pathnameToMatch, interceptionContext);
+      },
+      getAndClearPendingCookies,
+      getDraftModeCookieHeader,
+      getRouteParamNames(sourceRoute) {
+        return sourceRoute.params;
+      },
+      getSourceRoute(sourceRouteIndex) {
+        return routes[sourceRouteIndex];
+      },
+      isRscRequest,
+      loadServerAction,
+      matchRoute(pathnameToMatch) {
+        return matchRoute(pathnameToMatch);
+      },
+      maxActionBodySize: __MAX_ACTION_BODY_SIZE,
+      middlewareHeaders: middlewareContext.headers,
+      middlewareStatus: middlewareContext.status,
+      mountedSlotsHeader,
+      readBodyWithLimit: __readBodyWithLimit,
+      readFormDataWithLimit: __readFormDataWithLimit,
+      renderToReadableStream,
+      reportRequestError: _reportRequestError,
+      request,
+      sanitizeErrorForClient(error) {
+        return __sanitizeErrorForClient(error);
+      },
+      searchParams,
+      setHeadersAccessPhase,
+      setNavigationContext,
+      toInterceptOpts(intercept) {
+        return {
+          interceptionContext,
+          interceptLayouts: intercept.interceptLayouts,
+          interceptSlotKey: intercept.slotKey,
+          interceptPage: intercept.page,
+          interceptParams: intercept.matchedParams,
+        };
+      },
+    });
+  },
+  i18nConfig: __i18nConfig,
+  ${hasPagesDir ? "loadPagesRoutes: __loadPrerenderPagesRoutes," : ""}
+  makeThenableParams,
+  matchRoute(pathnameToMatch) {
+    return matchRoute(pathnameToMatch);
+  },
+  metadataRoutes,
+  middlewareIsProxy: ${JSON.stringify(middlewarePath ? isProxyFile(middlewarePath) : false)},
+  middlewareModule: ${middlewarePath ? "middlewareModule" : "null"},
+  publicFiles: __publicFiles,
+  renderNotFoundPage({ isRscRequest, matchedParams, middlewareContext, request, route, scriptNonce }) {
+    return renderNotFoundPage(route, isRscRequest, request, matchedParams, scriptNonce, middlewareContext);
+  },
+  ${
+    hasPagesDir
+      ? `async renderPagesFallback({ isRscRequest, middlewareContext, request, url }) {
+    if (isRscRequest) return null;
+    const __pagesEntry = await import.meta.viteRsc.loadModule("ssr", "index");
+    if (typeof __pagesEntry.renderPage !== "function") return null;
+    const __pagesRequestHeaders = middlewareContext.requestHeaders
+      ? __buildRequestHeadersFromMiddlewareResponse(request.headers, middlewareContext.requestHeaders)
+      : null;
+    const __pagesRequest = __pagesRequestHeaders
+      ? new Request(request.url, { method: request.method, headers: __pagesRequestHeaders })
+      : request;
+    const __pagesRes = await __pagesEntry.renderPage(
+      __pagesRequest,
+      __decodePathParams(url.pathname) + (url.search || ""),
+      {},
+      undefined,
+      middlewareContext.requestHeaders,
+    );
+    return __pagesRes.status === 404 ? null : __pagesRes;
+  },`
+      : ""
+  }
+  rootParamNamesMap,
+  setNavigationContext,
+  staticParamsMap: generateStaticParamsMap,
+  trailingSlash: __trailingSlash,
+  validateDevRequestOrigin(request) {
+    return __validateDevRequestOrigin(request);
+  },
+});
 
 if (import.meta.hot) {
   import.meta.hot.accept();

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -1,0 +1,556 @@
+import type {
+  NextHeader,
+  NextI18nConfig,
+  NextRedirect,
+  NextRewrite,
+} from "../config/next-config.js";
+import {
+  isExternalUrl,
+  matchRedirect,
+  matchRewrite,
+  normalizeHost,
+  proxyExternalRequest,
+  requestContextFromRequest,
+  sanitizeDestination,
+} from "../config/config-matchers.js";
+import { getHeadersContext, headersContextFromRequest } from "../shims/headers.js";
+import { ensureFetchPatch, setCurrentFetchSoftTags } from "../shims/fetch-cache.js";
+import { getRequestExecutionContext, type ExecutionContextLike } from "../shims/request-context.js";
+import { pickRootParams, setRootParams } from "../shims/root-params.js";
+import { createRequestContext, runWithRequestContext } from "../shims/unified-request-context.js";
+import {
+  normalizePathnameForRouteMatch,
+  normalizePathnameForRouteMatchStrict,
+} from "../routing/utils.js";
+import { flattenErrorCauses } from "../utils/error-cause.js";
+import { applyAppMiddleware } from "./app-middleware.js";
+import {
+  mergeMiddlewareResponseHeaders,
+  type AppPageMiddlewareContext,
+} from "./app-page-response.js";
+import { handleAppPrerenderEndpoint } from "./app-prerender-endpoints.js";
+import { normalizePath } from "./normalize-path.js";
+import { normalizeMountedSlotsHeader } from "./isr-cache.js";
+import { handleMetadataRouteRequest } from "./metadata-route-response.js";
+import { getScriptNonceFromHeaderSources } from "./csp.js";
+import {
+  applyConfigHeadersToResponse,
+  guardProtocolRelativeUrl,
+  hasBasePath,
+  normalizeTrailingSlash,
+  resolvePublicFileRoute,
+  stripBasePath,
+  validateImageUrl,
+} from "./request-pipeline.js";
+import { buildPageCacheTags } from "./implicit-tags.js";
+import type { MiddlewareModule } from "./middleware-runtime.js";
+
+type AppPageParams = Record<string, string | string[]>;
+
+type AppRscRouteMatch<TRoute> = {
+  params: AppPageParams;
+  route: TRoute;
+};
+
+type AppRscMiddlewareContext = AppPageMiddlewareContext & {
+  requestHeaders: Headers | null;
+};
+
+type AppRscHandlerRoute = {
+  page?: object | null;
+  pattern: string;
+  rootParamNames?: readonly string[];
+  routeHandler?: object | null;
+  routeSegments: readonly string[];
+};
+
+type DispatchMatchedPageOptions<TRoute> = {
+  cleanPathname: string;
+  handlerStart: number;
+  interceptionContext: string | null;
+  isRscRequest: boolean;
+  middlewareContext: AppRscMiddlewareContext;
+  mountedSlotsHeader: string | null;
+  params: AppPageParams;
+  request: Request;
+  route: TRoute;
+  scriptNonce?: string;
+  searchParams: URLSearchParams;
+};
+
+type DispatchMatchedRouteHandlerOptions<TRoute> = {
+  cleanPathname: string;
+  middlewareContext: AppRscMiddlewareContext;
+  params: AppPageParams;
+  request: Request;
+  route: TRoute;
+  searchParams: URLSearchParams;
+};
+
+type HandleServerActionRequestOptions = {
+  actionId: string | null;
+  cleanPathname: string;
+  contentType: string;
+  interceptionContext: string | null;
+  isRscRequest: boolean;
+  middlewareContext: AppRscMiddlewareContext;
+  mountedSlotsHeader: string | null;
+  request: Request;
+  searchParams: URLSearchParams;
+};
+
+type HandleProgressiveActionRequestOptions = {
+  actionId: string | null;
+  cleanPathname: string;
+  contentType: string;
+  middlewareContext: AppRscMiddlewareContext;
+  request: Request;
+};
+
+type RenderNotFoundPageOptions<TRoute> = {
+  isRscRequest: boolean;
+  matchedParams?: AppPageParams;
+  middlewareContext: AppRscMiddlewareContext;
+  request: Request;
+  route: TRoute | null;
+  scriptNonce?: string;
+};
+
+type RenderPagesFallbackOptions = {
+  isRscRequest: boolean;
+  middlewareContext: AppRscMiddlewareContext;
+  request: Request;
+  url: URL;
+};
+
+type NavigationContextValue = {
+  params: AppPageParams;
+  pathname: string;
+  searchParams: URLSearchParams;
+};
+
+type RequestContext = ReturnType<typeof requestContextFromRequest>;
+type MetadataRoutes = Parameters<typeof handleMetadataRouteRequest>[0]["metadataRoutes"];
+type MakeThenableParams = Parameters<typeof handleMetadataRouteRequest>[0]["makeThenableParams"];
+type StaticParamsMap = Parameters<typeof handleAppPrerenderEndpoint>[1]["staticParamsMap"];
+type RootParamNamesMap = Parameters<
+  typeof handleAppPrerenderEndpoint
+>[1]["rootParamNamesByPattern"];
+
+type CreateAppRscHandlerOptions<TRoute extends AppRscHandlerRoute> = {
+  basePath?: string;
+  clearRequestContext: () => void;
+  configHeaders: NextHeader[];
+  configRedirects: NextRedirect[];
+  configRewrites: {
+    afterFiles: NextRewrite[];
+    beforeFiles: NextRewrite[];
+    fallback: NextRewrite[];
+  };
+  dispatchMatchedPage: (options: DispatchMatchedPageOptions<TRoute>) => Promise<Response>;
+  dispatchMatchedRouteHandler: (
+    options: DispatchMatchedRouteHandlerOptions<TRoute>,
+  ) => Promise<Response>;
+  ensureInstrumentation?: () => Promise<void>;
+  handleProgressiveActionRequest: (
+    options: HandleProgressiveActionRequestOptions,
+  ) => Promise<Response | null>;
+  handleServerActionRequest: (
+    options: HandleServerActionRequestOptions,
+  ) => Promise<Response | null>;
+  i18nConfig?: NextI18nConfig | null;
+  loadPagesRoutes?: () => Promise<unknown>;
+  makeThenableParams: MakeThenableParams;
+  matchRoute: (pathname: string) => AppRscRouteMatch<TRoute> | null;
+  metadataRoutes: MetadataRoutes;
+  middlewareIsProxy?: boolean;
+  middlewareModule?: MiddlewareModule | null;
+  publicFiles: Set<string>;
+  renderNotFoundPage: (options: RenderNotFoundPageOptions<TRoute>) => Promise<Response | null>;
+  renderPagesFallback?: (options: RenderPagesFallbackOptions) => Promise<Response | null>;
+  rootParamNamesMap?: RootParamNamesMap;
+  setNavigationContext: (context: NavigationContextValue | null) => void;
+  staticParamsMap: StaticParamsMap;
+  trailingSlash?: boolean;
+  validateDevRequestOrigin?: (request: Request) => Response | null;
+};
+
+function buildPostMiddlewareRequestContext(request: Request): RequestContext {
+  const url = new URL(request.url);
+  const context = getHeadersContext();
+  if (!context) {
+    return requestContextFromRequest(request);
+  }
+
+  return {
+    headers: context.headers,
+    cookies: Object.fromEntries(context.cookies),
+    query: url.searchParams,
+    host: normalizeHost(context.headers.get("host"), url.hostname),
+  };
+}
+
+function isRedirectResponse(response: Response): boolean {
+  return response.status >= 300 && response.status < 400;
+}
+
+function stripRscSuffix(pathname: string): string {
+  return pathname.replace(/\.rsc$/, "");
+}
+
+function isExecutionContextLike(value: unknown): value is ExecutionContextLike {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  return typeof Reflect.get(value, "waitUntil") === "function";
+}
+
+async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
+  options: CreateAppRscHandlerOptions<TRoute>,
+  request: Request,
+  requestContext: RequestContext,
+): Promise<Response> {
+  const handlerStart = process.env.NODE_ENV !== "production" ? performance.now() : 0;
+  const url = new URL(request.url);
+
+  if (process.env.NODE_ENV !== "production") {
+    const originBlock = options.validateDevRequestOrigin?.(request);
+    if (originBlock) {
+      return originBlock;
+    }
+  }
+
+  const protocolGuard = guardProtocolRelativeUrl(url.pathname);
+  if (protocolGuard) {
+    return protocolGuard;
+  }
+
+  let decodedUrlPathname: string;
+  try {
+    decodedUrlPathname = normalizePathnameForRouteMatchStrict(url.pathname);
+  } catch {
+    return new Response("Bad Request", { status: 400 });
+  }
+
+  let pathname = normalizePath(decodedUrlPathname);
+  const basePath = options.basePath ?? "";
+  if (basePath) {
+    if (!hasBasePath(pathname, basePath) && !pathname.startsWith("/__vinext/")) {
+      return new Response("Not Found", { status: 404 });
+    }
+    pathname = stripBasePath(pathname, basePath);
+  }
+
+  const prerenderEndpointResponse = await handleAppPrerenderEndpoint(request, {
+    isPrerenderEnabled() {
+      return process.env.VINEXT_PRERENDER === "1";
+    },
+    loadPagesRoutes: options.loadPagesRoutes,
+    pathname,
+    rootParamNamesByPattern: options.rootParamNamesMap,
+    staticParamsMap: options.staticParamsMap,
+  });
+  if (prerenderEndpointResponse) {
+    return prerenderEndpointResponse;
+  }
+
+  const trailingSlashRedirect = normalizeTrailingSlash(
+    pathname,
+    basePath,
+    options.trailingSlash ?? false,
+    url.search,
+  );
+  if (trailingSlashRedirect) {
+    return trailingSlashRedirect;
+  }
+
+  if (options.configRedirects.length > 0) {
+    const redirectPathname = pathname.endsWith(".rsc") ? pathname.slice(0, -4) : pathname;
+    const redirect = matchRedirect(redirectPathname, options.configRedirects, requestContext);
+    if (redirect) {
+      const destination = sanitizeDestination(
+        basePath &&
+          !isExternalUrl(redirect.destination) &&
+          !hasBasePath(redirect.destination, basePath)
+          ? basePath + redirect.destination
+          : redirect.destination,
+      );
+      return new Response(null, {
+        status: redirect.permanent ? 308 : 307,
+        headers: { Location: destination },
+      });
+    }
+  }
+
+  const isRscRequest = Boolean(
+    pathname.endsWith(".rsc") || request.headers.get("accept")?.includes("text/x-component"),
+  );
+  const mountedSlotsHeader = normalizeMountedSlotsHeader(
+    request.headers.get("x-vinext-mounted-slots"),
+  );
+  const interceptionContext =
+    request.headers.get("X-Vinext-Interception-Context")?.replaceAll("\0", "") ?? null;
+  let cleanPathname = stripRscSuffix(pathname);
+  const middlewareContext: AppRscMiddlewareContext = {
+    headers: null,
+    requestHeaders: null,
+    status: null,
+  };
+
+  if (options.middlewareModule) {
+    const middlewareResult = await applyAppMiddleware({
+      basePath,
+      cleanPathname,
+      context: middlewareContext,
+      i18nConfig: options.i18nConfig ?? null,
+      isProxy: options.middlewareIsProxy ?? false,
+      module: options.middlewareModule,
+      request,
+    });
+    if (middlewareResult.kind === "response") {
+      return middlewareResult.response;
+    }
+    cleanPathname = middlewareResult.cleanPathname;
+    if (middlewareResult.search !== null) {
+      url.search = middlewareResult.search;
+    }
+  }
+
+  const scriptNonce = getScriptNonceFromHeaderSources(request.headers, middlewareContext.headers);
+  const postMiddlewareRequestContext = buildPostMiddlewareRequestContext(request);
+
+  if (options.configRewrites.beforeFiles.length > 0) {
+    const rewritten = matchRewrite(
+      cleanPathname,
+      options.configRewrites.beforeFiles,
+      postMiddlewareRequestContext,
+    );
+    if (rewritten) {
+      if (isExternalUrl(rewritten)) {
+        options.clearRequestContext();
+        return proxyExternalRequest(request, rewritten);
+      }
+      cleanPathname = rewritten;
+    }
+  }
+
+  if (cleanPathname === "/_vinext/image") {
+    const imageUrlResult = validateImageUrl(url.searchParams.get("url"), request.url);
+    if (imageUrlResult instanceof Response) {
+      return imageUrlResult;
+    }
+    return Response.redirect(new URL(imageUrlResult, url.origin).href, 302);
+  }
+
+  const metadataRouteResponse = await handleMetadataRouteRequest({
+    metadataRoutes: options.metadataRoutes,
+    cleanPathname,
+    makeThenableParams: options.makeThenableParams,
+  });
+  if (metadataRouteResponse) {
+    return metadataRouteResponse;
+  }
+
+  const publicFileResponse = resolvePublicFileRoute({
+    cleanPathname,
+    middlewareContext,
+    pathname,
+    publicFiles: options.publicFiles,
+    request,
+  });
+  if (publicFileResponse) {
+    options.clearRequestContext();
+    return publicFileResponse;
+  }
+
+  options.setNavigationContext({
+    pathname: cleanPathname,
+    searchParams: url.searchParams,
+    params: {},
+  });
+
+  const actionId = request.headers.get("x-rsc-action") ?? request.headers.get("next-action");
+  const actionContentType = request.headers.get("content-type") || "";
+
+  const progressiveActionResponse = await options.handleProgressiveActionRequest({
+    actionId,
+    cleanPathname,
+    contentType: actionContentType,
+    middlewareContext,
+    request,
+  });
+  if (progressiveActionResponse) {
+    return progressiveActionResponse;
+  }
+
+  const serverActionResponse = await options.handleServerActionRequest({
+    actionId,
+    cleanPathname,
+    contentType: actionContentType,
+    interceptionContext,
+    isRscRequest,
+    middlewareContext,
+    mountedSlotsHeader,
+    request,
+    searchParams: url.searchParams,
+  });
+  if (serverActionResponse) {
+    return serverActionResponse;
+  }
+
+  if (options.configRewrites.afterFiles.length > 0) {
+    const rewritten = matchRewrite(
+      cleanPathname,
+      options.configRewrites.afterFiles,
+      postMiddlewareRequestContext,
+    );
+    if (rewritten) {
+      if (isExternalUrl(rewritten)) {
+        options.clearRequestContext();
+        return proxyExternalRequest(request, rewritten);
+      }
+      cleanPathname = rewritten;
+    }
+  }
+
+  let match = options.matchRoute(cleanPathname);
+  if (!match && options.configRewrites.fallback.length > 0) {
+    const rewritten = matchRewrite(
+      cleanPathname,
+      options.configRewrites.fallback,
+      postMiddlewareRequestContext,
+    );
+    if (rewritten) {
+      if (isExternalUrl(rewritten)) {
+        options.clearRequestContext();
+        return proxyExternalRequest(request, rewritten);
+      }
+      cleanPathname = rewritten;
+      match = options.matchRoute(cleanPathname);
+    }
+  }
+
+  if (!match) {
+    const pagesFallbackResponse = await options.renderPagesFallback?.({
+      isRscRequest,
+      middlewareContext,
+      request,
+      url,
+    });
+    if (pagesFallbackResponse) {
+      options.clearRequestContext();
+      return pagesFallbackResponse;
+    }
+
+    const notFoundResponse = await options.renderNotFoundPage({
+      isRscRequest,
+      middlewareContext,
+      request,
+      route: null,
+      scriptNonce,
+    });
+    if (notFoundResponse) {
+      return notFoundResponse;
+    }
+
+    options.clearRequestContext();
+    const headers = new Headers();
+    mergeMiddlewareResponseHeaders(headers, middlewareContext.headers);
+    return new Response("Not Found", {
+      status: 404,
+      headers,
+    });
+  }
+
+  const { route, params } = match;
+  options.setNavigationContext({
+    pathname: cleanPathname,
+    searchParams: url.searchParams,
+    params,
+  });
+  setRootParams(pickRootParams(params, route.rootParamNames));
+
+  if (route.routeHandler) {
+    setCurrentFetchSoftTags(
+      buildPageCacheTags(cleanPathname, [], [...route.routeSegments], "route"),
+    );
+    return options.dispatchMatchedRouteHandler({
+      cleanPathname,
+      middlewareContext,
+      params,
+      request,
+      route,
+      searchParams: url.searchParams,
+    });
+  }
+
+  return options.dispatchMatchedPage({
+    cleanPathname,
+    handlerStart,
+    interceptionContext,
+    isRscRequest,
+    middlewareContext,
+    mountedSlotsHeader,
+    params,
+    request,
+    route,
+    scriptNonce,
+    searchParams: url.searchParams,
+  });
+}
+
+export function createAppRscHandler<TRoute extends AppRscHandlerRoute>(
+  options: CreateAppRscHandlerOptions<TRoute>,
+): (request: Request, ctx: unknown) => Promise<Response> {
+  return async function appRscHandler(request, ctx) {
+    if (options.ensureInstrumentation) {
+      await options.ensureInstrumentation();
+    }
+
+    const executionContext = isExecutionContextLike(ctx)
+      ? ctx
+      : (getRequestExecutionContext() ?? null);
+    const headersContext = headersContextFromRequest(request);
+    const requestContext = createRequestContext({
+      headersContext,
+      executionContext,
+      unstableCacheRevalidation: "background",
+    });
+
+    return runWithRequestContext(requestContext, async () => {
+      ensureFetchPatch();
+      const preMiddlewareRequestContext = requestContextFromRequest(request);
+      let response: Response;
+
+      try {
+        response = await handleAppRscRequest(options, request, preMiddlewareRequestContext);
+      } catch (error) {
+        if (process.env.NODE_ENV !== "production") {
+          flattenErrorCauses(error);
+        }
+        throw error;
+      }
+
+      if (options.configHeaders.length > 0 && !isRedirectResponse(response)) {
+        const url = new URL(request.url);
+        let pathname = url.pathname;
+        try {
+          pathname = normalizePath(normalizePathnameForRouteMatch(url.pathname));
+        } catch {
+          pathname = url.pathname;
+        }
+        const basePath = options.basePath ?? "";
+        if (basePath && pathname.startsWith(basePath)) {
+          pathname = pathname.slice(basePath.length) || "/";
+        }
+        applyConfigHeadersToResponse(response.headers, {
+          configHeaders: options.configHeaders,
+          pathname,
+          requestContext: preMiddlewareRequestContext,
+        });
+      }
+
+      return response;
+    });
+  };
+}

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -22,17 +22,15 @@ function renderToReadableStream(model, options) {
 }
 import { createElement } from "react";
 import { setNavigationContext as _setNavigationContextOrig, getNavigationContext as _getNavigationContext } from "next/navigation";
-import { setHeadersContext, headersContextFromRequest, getDraftModeCookieHeader, getAndClearPendingCookies, consumeDynamicUsage, consumeInvalidDynamicUsageError, markDynamicUsage, getHeadersContext, setHeadersAccessPhase } from "next/headers";
+import { setHeadersContext, getDraftModeCookieHeader, getAndClearPendingCookies, markDynamicUsage, setHeadersAccessPhase } from "next/headers";
 import { mergeMetadata, resolveModuleMetadata, mergeViewport, resolveModuleViewport } from "vinext/metadata";
 
 
-import { handleMetadataRouteRequest as __handleMetadataRouteRequest } from "<ROOT>/packages/vinext/src/server/metadata-route-response.js";
-import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, isExternalUrl, proxyExternalRequest, sanitizeDestination } from "<ROOT>/packages/vinext/src/config/config-matchers.js";
-import { decodePathParams as __decodePathParams, normalizePath as __normalizePath } from "<ROOT>/packages/vinext/src/server/normalize-path.js";
-import { normalizePathnameForRouteMatch as __normalizePathnameForRouteMatch, normalizePathnameForRouteMatchStrict as __normalizePathnameForRouteMatchStrict } from "<ROOT>/packages/vinext/src/routing/utils.js";
+import { decodePathParams as __decodePathParams } from "<ROOT>/packages/vinext/src/server/normalize-path.js";
 import { buildRequestHeadersFromMiddlewareResponse as __buildRequestHeadersFromMiddlewareResponse } from "<ROOT>/packages/vinext/src/server/middleware-request-headers.js";
-import { applyConfigHeadersToResponse, resolvePublicFileRoute, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
-import { applyAppMiddleware as __applyAppMiddleware } from "<ROOT>/packages/vinext/src/server/app-middleware.js";
+import {
+  createAppRscHandler as __createAppRscHandler,
+} from "<ROOT>/packages/vinext/src/server/app-rsc-handler.js";
 import {
   dispatchAppRouteHandler as __dispatchAppRouteHandler,
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-dispatch.js";
@@ -72,38 +70,25 @@ import {
   resolveAppPageHead as __resolveAppPageHead,
 } from "<ROOT>/packages/vinext/src/server/app-page-head.js";
 import {
-  mergeMiddlewareResponseHeaders as __mergeMiddlewareResponseHeaders,
-} from "<ROOT>/packages/vinext/src/server/app-page-response.js";
-import {
   dispatchAppPage as __dispatchAppPage,
 } from "<ROOT>/packages/vinext/src/server/app-page-dispatch.js";
-import { getScriptNonceFromHeaderSources as __getScriptNonceFromHeaderSources } from "<ROOT>/packages/vinext/src/server/csp.js";
-import { buildPageCacheTags } from "<ROOT>/packages/vinext/src/server/implicit-tags.js";
-import { getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
-import { setRootParams as __setRootParams, pickRootParams as __pickRootParams } from "<ROOT>/packages/vinext/src/shims/root-params.js";
+import { setRootParams as __setRootParams } from "<ROOT>/packages/vinext/src/shims/root-params.js";
 import { makeThenableParams } from "<ROOT>/packages/vinext/src/shims/thenable-params.js";
-import { ensureFetchPatch as _ensureFetchPatch, setCurrentFetchSoftTags } from "vinext/fetch-cache";
+import { setCurrentFetchSoftTags } from "vinext/fetch-cache";
 import {
   createAppRscRouteMatcher as __createAppRscRouteMatcher,
 } from "<ROOT>/packages/vinext/src/server/app-rsc-route-matching.js";
-import {
-  handleAppPrerenderEndpoint as __handleAppPrerenderEndpoint,
-} from "<ROOT>/packages/vinext/src/server/app-prerender-endpoints.js";
 import {
   appIsrHtmlKey as __isrHtmlKey,
   appIsrRscKey as __isrRscKey,
   appIsrRouteKey as __isrRouteKey,
   isrGet as __isrGet,
   isrSet as __isrSet,
-  normalizeMountedSlotsHeader as __normalizeMountedSlotsHeader,
   triggerBackgroundRegeneration as __triggerBackgroundRegeneration,
 } from "<ROOT>/packages/vinext/src/server/isr-cache.js";
 // Import server-only state module to register ALS-backed accessors.
 import "vinext/navigation-state";
-import { runWithPrerenderWorkUnit as __runWithPrerenderWorkUnit } from "<ROOT>/packages/vinext/src/server/prerender-work-unit-setup.js";
-import { runWithRequestContext as _runWithUnifiedCtx, createRequestContext as _createUnifiedCtx } from "vinext/unified-request-context";
 import { reportRequestError as _reportRequestError } from "vinext/instrumentation";
-import { flattenErrorCauses as __flattenErrorCauses } from "<ROOT>/packages/vinext/src/utils/error-cause.js";
 import { getSSRFontLinks as _getSSRFontLinks, getSSRFontStyles as _getSSRFontStylesGoogle, getSSRFontPreloads as _getSSRFontPreloadsGoogle } from "next/font/google";
 import { getSSRFontStyles as _getSSRFontStylesLocal, getSSRFontPreloads as _getSSRFontPreloadsLocal } from "next/font/local";
 function _getSSRFontStyles() { return [..._getSSRFontStylesGoogle(), ..._getSSRFontStylesLocal()]; }
@@ -621,35 +606,6 @@ function __validateDevRequestOrigin(request) {
 }
 
 
-// ── Config pattern matching, redirects, rewrites, headers, CSRF validation,
-//    external URL proxy, cookie parsing, and request context are imported from
-//    config-matchers.ts and request-pipeline.ts (see import statements above).
-//    This eliminates ~250 lines of duplicated inline code and ensures the
-//    single-pass tokenizer in config-matchers.ts is used consistently
-//    (fixing the chained .replace() divergence flagged by CodeQL).
-
-/**
- * Build a request context from the live ALS HeadersContext, which reflects
- * any x-middleware-request-* header mutations applied by middleware.
- * Used for afterFiles and fallback rewrite has/missing evaluation — these
- * run after middleware in the App Router execution order.
- */
-function __buildPostMwRequestContext(request) {
-  const url = new URL(request.url);
-  const ctx = getHeadersContext();
-  if (!ctx) return requestContextFromRequest(request);
-  // ctx.cookies is a Map<string, string> (HeadersContext), but RequestContext
-  // requires a plain Record<string, string> for has/missing cookie evaluation
-  // (config-matchers.ts uses obj[key] not Map.get()). Convert here.
-  const cookiesRecord = Object.fromEntries(ctx.cookies);
-  return {
-    headers: ctx.headers,
-    cookies: cookiesRecord,
-    query: url.searchParams,
-    host: normalizeHost(ctx.headers.get("host"), url.hostname),
-  };
-}
-
 /**
  * Maximum server-action request body size.
  * Configurable via experimental.serverActions.bodySizeLimit in next.config.
@@ -674,371 +630,149 @@ const rootParamNamesMap = {
 
 };
 
-export default async function handler(request, ctx) {
-  
-  // Wrap the entire request in a single unified ALS scope for per-request
-  // isolation. All state modules (headers, navigation, cache, fetch-cache,
-  // execution-context) read from this store via isInsideUnifiedScope().
-  const headersCtx = headersContextFromRequest(request);
-  const __uCtx = _createUnifiedCtx({
-    headersContext: headersCtx,
-    executionContext: ctx ?? _getRequestExecutionContext() ?? null,
-    unstableCacheRevalidation: "background",
-  });
-  return _runWithUnifiedCtx(__uCtx, () =>
-    __runWithPrerenderWorkUnit(async () => {
-    _ensureFetchPatch();
-    const __reqCtx = requestContextFromRequest(request);
-    // Per-request container for middleware state. Passed into
-    // _handleRequest which fills in .headers and .status;
-    // avoids module-level variables that race on Workers.
-    const _mwCtx = { headers: null, requestHeaders: null, status: null };
-    let response;
-    try {
-      response = await _handleRequest(request, __reqCtx, _mwCtx);
-    } catch (err) {
-      // Dev only: embed err.cause chain into err.message/err.stack so Vite's
-      // dev-server "Internal server error:" logger (which builds output from
-      // message + stack only) reveals the underlying root cause (ECONNREFUSED,
-      // role missing, workerd socket error, etc.) instead of dropping it.
-      // Skipped in production because Node's util.inspect / workerd's logger
-      // already render .cause natively, so flattening would double-print it.
-      // NODE_ENV is build-time-replaced by Vite, so the prod bundle compiles
-      // this branch out entirely.
-      if (process.env.NODE_ENV !== "production") {
-        __flattenErrorCauses(err);
-      }
-      throw err;
-    }
-    // Apply custom headers from next.config.js to non-redirect responses.
-    // Skip redirects (3xx) because Response.redirect() creates immutable headers,
-    // and Next.js doesn't apply custom headers to redirects anyway.
-    if (response && response.headers && !(response.status >= 300 && response.status < 400)) {
-      if (__configHeaders.length) {
-        const url = new URL(request.url);
-        let pathname;
-        try { pathname = __normalizePath(__normalizePathnameForRouteMatch(url.pathname)); } catch { pathname = url.pathname; }
-        
-        applyConfigHeadersToResponse(response.headers, {
-          configHeaders: __configHeaders,
-          pathname,
-          requestContext: __reqCtx,
-        });
-      }
-    }
-    return response;
-    }, { route: () => new URL(request.url).pathname })
-  );
-}
-
-async function _handleRequest(request, __reqCtx, _mwCtx) {
-  const __reqStart = process.env.NODE_ENV !== "production" ? performance.now() : 0;
-  // __reqStart is included in the timing header so the Node logging middleware
-  // can compute true compile time as: handlerStart - middlewareStart.
-  // Format: "handlerStart,compileMs,renderMs" - all as integers (ms). Dev-only.
-  const url = new URL(request.url);
-
-  // ── Cross-origin request protection (dev only) ─────────────────────
-  // Block requests from non-localhost origins to prevent data exfiltration.
-  // Skipped in production — Vite replaces NODE_ENV at build time.
-  if (process.env.NODE_ENV !== "production") {
-    const __originBlock = __validateDevRequestOrigin(request);
-    if (__originBlock) return __originBlock;
-  }
-
-  // Guard against protocol-relative URL open redirects (see request-pipeline.ts).
-  const __protoGuard = guardProtocolRelativeUrl(url.pathname);
-  if (__protoGuard) return __protoGuard;
-
-  // Decode percent-encoding segment-wise and normalize pathname to canonical form.
-  // This preserves encoded path delimiters like %2F within a single segment.
-  // __normalizePath collapses //foo///bar → /foo/bar, resolves . and .. segments.
-  let decodedUrlPathname;
-  try { decodedUrlPathname = __normalizePathnameForRouteMatchStrict(url.pathname); } catch (e) {
-    return new Response("Bad Request", { status: 400 });
-  }
-  let pathname = __normalizePath(decodedUrlPathname);
-
-  
-
-  const __prerenderEndpointResponse = await __handleAppPrerenderEndpoint(request, {
-    isPrerenderEnabled() {
-      return process.env.VINEXT_PRERENDER === "1";
-    },
-
-    pathname,
-    rootParamNamesByPattern: rootParamNamesMap,
-    staticParamsMap: generateStaticParamsMap,
-  });
-  if (__prerenderEndpointResponse) return __prerenderEndpointResponse;
-
-  // Trailing slash normalization (redirect to canonical form)
-  const __tsRedirect = normalizeTrailingSlash(pathname, __basePath, __trailingSlash, url.search);
-  if (__tsRedirect) return __tsRedirect;
-
-  // ── Apply redirects from next.config.js ───────────────────────────────
-  if (__configRedirects.length) {
-    // Strip .rsc suffix before matching redirect rules - RSC (client-side nav) requests
-    // arrive as /some/path.rsc but redirect patterns are defined without it (e.g.
-    // /some/path). Without this, soft-nav fetches bypass all config redirects.
-    const __redirPathname = pathname.endsWith(".rsc") ? pathname.slice(0, -4) : pathname;
-    const __redir = matchRedirect(__redirPathname, __configRedirects, __reqCtx);
-    if (__redir) {
-      const __redirDest = sanitizeDestination(
-        __basePath &&
-          !isExternalUrl(__redir.destination) &&
-          !hasBasePath(__redir.destination, __basePath)
-          ? __basePath + __redir.destination
-          : __redir.destination
-      );
-      return new Response(null, {
-        status: __redir.permanent ? 308 : 307,
-        headers: { Location: __redirDest },
-      });
-    }
-  }
-
-  const isRscRequest = pathname.endsWith(".rsc") || request.headers.get("accept")?.includes("text/x-component");
-  // Read mounted-slots header once at the handler scope and thread it through
-  // every buildPageElements call site. Previously both the handler and
-  // buildPageElements read and normalized it independently, which invited
-  // silent drift if a future refactor changed only one path.
-  const __mountedSlotsHeader = __normalizeMountedSlotsHeader(
-    request.headers.get("x-vinext-mounted-slots"),
-  );
-  const interceptionContextHeader = request.headers.get("X-Vinext-Interception-Context")?.replaceAll(" ", "") || null;
-  let cleanPathname = pathname.replace(/\\.rsc$/, "");
-
-  // Middleware response headers and custom rewrite status are stored in
-  // _mwCtx (per-request container) so handler() can merge them into
-  // every response path without module-level state that races on Workers.
-
-  
-
-  const _scriptNonce = __getScriptNonceFromHeaderSources(request.headers, _mwCtx.headers);
-
-  // Build post-middleware request context for afterFiles/fallback rewrites.
-  // These run after middleware in the App Router execution order and should
-  // evaluate has/missing conditions against middleware-modified headers.
-  // When no middleware is present, this falls back to requestContextFromRequest.
-  const __postMwReqCtx = __buildPostMwRequestContext(request);
-
-  // ── Apply beforeFiles rewrites from next.config.js ────────────────────
-  // In App Router execution order, beforeFiles runs after middleware so that
-  // has/missing conditions can evaluate against middleware-modified headers.
-  if (__configRewrites.beforeFiles && __configRewrites.beforeFiles.length) {
-    const __rewritten = matchRewrite(cleanPathname, __configRewrites.beforeFiles, __postMwReqCtx);
-    if (__rewritten) {
-      if (isExternalUrl(__rewritten)) {
-        __clearRequestContext();
-        return proxyExternalRequest(request, __rewritten);
-      }
-      cleanPathname = __rewritten;
-    }
-  }
-
-  // ── Image optimization passthrough (dev mode — no transformation) ───────
-  if (cleanPathname === "/_vinext/image") {
-    const __imgResult = validateImageUrl(url.searchParams.get("url"), request.url);
-    if (__imgResult instanceof Response) return __imgResult;
-    // In dev, redirect to the original asset URL so Vite's static serving handles it.
-    return Response.redirect(new URL(__imgResult, url.origin).href, 302);
-  }
-
-  const metadataRouteResponse = await __handleMetadataRouteRequest({
-    metadataRoutes,
-    cleanPathname,
-    makeThenableParams,
-  });
-  if (metadataRouteResponse) return metadataRouteResponse;
-
-  // Serve public/ files as filesystem routes after middleware and before
-  // afterFiles/fallback rewrites, matching Next.js routing semantics.
-  const __publicFileResponse = resolvePublicFileRoute({
-    cleanPathname,
-    middlewareContext: _mwCtx,
-    pathname,
-    publicFiles: __publicFiles,
-    request,
-  });
-  if (__publicFileResponse) {
+export default __createAppRscHandler({
+  basePath: __basePath,
+  clearRequestContext() {
     __clearRequestContext();
-    return __publicFileResponse;
-  }
-
-  // Set navigation context for Server Components.
-  // Note: Headers context is already set by runWithRequestContext in the handler wrapper.
-  setNavigationContext({
-    pathname: cleanPathname,
-    searchParams: url.searchParams,
-    params: {},
-  });
-
-  // Handle server action POST requests
-  const actionId = request.headers.get("x-rsc-action") ?? request.headers.get("next-action");
-  const actionContentType = request.headers.get("content-type") || "";
-  const progressiveActionResponse = await __handleProgressiveServerActionRequest({
-    actionId,
-    allowedOrigins: __allowedOrigins,
+  },
+  configHeaders: __configHeaders,
+  configRedirects: __configRedirects,
+  configRewrites: __configRewrites,
+  dispatchMatchedPage({
     cleanPathname,
-    clearRequestContext() {
-      __clearRequestContext();
-    },
-    contentType: actionContentType,
-    decodeAction,
-    getAndClearPendingCookies,
-    getDraftModeCookieHeader,
-    maxActionBodySize: __MAX_ACTION_BODY_SIZE,
-    middlewareHeaders: _mwCtx.headers,
-    readFormDataWithLimit: __readFormDataWithLimit,
-    reportRequestError: _reportRequestError,
-    request,
-    setHeadersAccessPhase,
-  });
-  if (progressiveActionResponse) return progressiveActionResponse;
-
-  const serverActionResponse = await __handleServerActionRscRequest({
-    actionId,
-    allowedOrigins: __allowedOrigins,
-    buildPageElement({
-      route: actionRoute,
-      params: actionParams,
-      cleanPathname: actionCleanPathname,
-      interceptOpts,
-      searchParams,
-      isRscRequest: actionIsRscRequest,
-      request: actionRequest,
-      mountedSlotsHeader,
-    }) {
-      return buildPageElements(actionRoute, actionParams, actionCleanPathname, {
-        opts: interceptOpts,
-        searchParams,
-        isRscRequest: actionIsRscRequest,
-        request: actionRequest,
-        mountedSlotsHeader,
-      });
-    },
-    cleanPathname,
-    clearRequestContext() {
-      __clearRequestContext();
-    },
-    contentType: actionContentType,
-    createNotFoundElement(actionRouteId) {
-      return {
-        [__APP_INTERCEPTION_CONTEXT_KEY]: null,
-        __route: actionRouteId,
-        __rootLayout: null,
-        [actionRouteId]: createElement("div", null, "Page not found"),
-      };
-    },
-    createPayloadRouteId(pathnameToRender, interceptionContext) {
-      return __createAppPayloadRouteId(pathnameToRender, interceptionContext);
-    },
-    createRscOnErrorHandler(actionRequest, actionPathname, routePattern) {
-      return createRscOnErrorHandler(actionRequest, actionPathname, routePattern);
-    },
-    createTemporaryReferenceSet,
-    decodeReply,
-    findIntercept(pathnameToMatch) {
-      return findIntercept(pathnameToMatch, interceptionContextHeader);
-    },
-    getAndClearPendingCookies,
-    getDraftModeCookieHeader,
-    getRouteParamNames(sourceRoute) {
-      return sourceRoute.params;
-    },
-    getSourceRoute(sourceRouteIndex) {
-      return routes[sourceRouteIndex];
-    },
+    handlerStart,
+    interceptionContext,
     isRscRequest,
-    loadServerAction,
-    matchRoute(pathnameToMatch) {
-      return matchRoute(pathnameToMatch);
-    },
-    maxActionBodySize: __MAX_ACTION_BODY_SIZE,
-    middlewareHeaders: _mwCtx.headers,
-    middlewareStatus: _mwCtx.status,
-    mountedSlotsHeader: __mountedSlotsHeader,
-    readBodyWithLimit: __readBodyWithLimit,
-    readFormDataWithLimit: __readFormDataWithLimit,
-    renderToReadableStream,
-    reportRequestError: _reportRequestError,
-    request,
-    sanitizeErrorForClient(error) {
-      return __sanitizeErrorForClient(error);
-    },
-    searchParams: url.searchParams,
-    setHeadersAccessPhase,
-    setNavigationContext,
-    toInterceptOpts(intercept) {
-      return {
-        interceptionContext: interceptionContextHeader,
-        interceptLayouts: intercept.interceptLayouts,
-        interceptSlotKey: intercept.slotKey,
-        interceptPage: intercept.page,
-        interceptParams: intercept.matchedParams,
-      };
-    },
-  });
-  if (serverActionResponse) return serverActionResponse;
-
-  // ── Apply afterFiles rewrites from next.config.js ──────────────────────
-  if (__configRewrites.afterFiles && __configRewrites.afterFiles.length) {
-    const __afterRewritten = matchRewrite(cleanPathname, __configRewrites.afterFiles, __postMwReqCtx);
-    if (__afterRewritten) {
-      if (isExternalUrl(__afterRewritten)) {
-        __clearRequestContext();
-        return proxyExternalRequest(request, __afterRewritten);
-      }
-      cleanPathname = __afterRewritten;
-    }
-  }
-
-  let match = matchRoute(cleanPathname);
-
-  // ── Fallback rewrites from next.config.js (if no route matched) ───────
-  if (!match && __configRewrites.fallback && __configRewrites.fallback.length) {
-    const __fallbackRewritten = matchRewrite(cleanPathname, __configRewrites.fallback, __postMwReqCtx);
-    if (__fallbackRewritten) {
-      if (isExternalUrl(__fallbackRewritten)) {
-        __clearRequestContext();
-        return proxyExternalRequest(request, __fallbackRewritten);
-      }
-      cleanPathname = __fallbackRewritten;
-      match = matchRoute(cleanPathname);
-    }
-  }
-
-  if (!match) {
-    
-    // Render custom not-found page if available, otherwise plain 404
-    const notFoundResponse = await renderNotFoundPage(null, isRscRequest, request, undefined, _scriptNonce, _mwCtx);
-    if (notFoundResponse) return notFoundResponse;
-    __clearRequestContext();
-    const notFoundHeaders = new Headers();
-    __mergeMiddlewareResponseHeaders(notFoundHeaders, _mwCtx.headers);
-    return new Response("Not Found", { status: 404, headers: notFoundHeaders });
-  }
-
-  const { route, params } = match;
-
-  // Update navigation context with matched params
-  setNavigationContext({
-    pathname: cleanPathname,
-    searchParams: url.searchParams,
+    middlewareContext,
+    mountedSlotsHeader,
     params,
-  });
-  __setRootParams(__pickRootParams(params, route.rootParamNames));
-
-  // Handle route.ts API handlers
-  if (route.routeHandler) {
-    setCurrentFetchSoftTags(
-      buildPageCacheTags(cleanPathname, [], route.routeSegments, "route"),
-    );
+    request,
+    route,
+    scriptNonce,
+    searchParams,
+  }) {
+    const PageComponent = route.page?.default;
+    const _asyncRouteParams = makeThenableParams(params);
+    return __dispatchAppPage({
+      buildPageElement(targetRoute, targetParams, targetOpts, targetSearchParams) {
+        return buildPageElements(targetRoute, targetParams, cleanPathname, {
+          opts: targetOpts,
+          searchParams: targetSearchParams,
+          isRscRequest,
+          request,
+          mountedSlotsHeader,
+        });
+      },
+      cleanPathname,
+      clearRequestContext() {
+        __clearRequestContext();
+      },
+      createRscOnErrorHandler(pathname, routePath) {
+        return createRscOnErrorHandler(request, pathname, routePath);
+      },
+      debugClassification: __classDebug,
+      dynamicConfig: route.page?.dynamic,
+      dynamicParamsConfig: route.page?.dynamicParams,
+      findIntercept(pathname) {
+        return findIntercept(pathname, interceptionContext);
+      },
+      generateStaticParams: route.page?.generateStaticParams,
+      getFontLinks: _getSSRFontLinks,
+      getFontPreloads: _getSSRFontPreloads,
+      getFontStyles: _getSSRFontStyles,
+      getNavigationContext: _getNavigationContext,
+      getSourceRoute(sourceRouteIndex) {
+        return routes[sourceRouteIndex];
+      },
+      hasGenerateStaticParams: typeof route.page?.generateStaticParams === "function",
+      hasPageDefaultExport: !!PageComponent,
+      hasPageModule: !!route.page,
+      handlerStart,
+      interceptionContext,
+      isProduction: process.env.NODE_ENV === "production",
+      isRscRequest,
+      isrDebug: __isrDebug,
+      isrGet: __isrGet,
+      isrHtmlKey: __isrHtmlKey,
+      isrRscKey: __isrRscKey,
+      isrSet: __isrSet,
+      loadSsrHandler() {
+        return import.meta.viteRsc.loadModule("ssr", "index");
+      },
+      middlewareContext,
+      mountedSlotsHeader,
+      params,
+      probeLayoutAt(li) {
+        const LayoutComp = route.layouts[li]?.default;
+        if (!LayoutComp) return null;
+        return LayoutComp({
+          params: makeThenableParams(__resolveAppPageSegmentParams(
+            route.routeSegments,
+            route.layoutTreePositions?.[li] ?? 0,
+            params,
+          )),
+          children: null,
+        });
+      },
+      probePage() {
+        if (!PageComponent) return null;
+        const _asyncSearchParams = makeThenableParams(
+          __collectAppPageSearchParams(searchParams).searchParamsObject,
+        );
+        return PageComponent({ params: _asyncRouteParams, searchParams: _asyncSearchParams });
+      },
+      renderErrorBoundaryPage(renderErr) {
+        return renderErrorBoundaryPage(
+          route,
+          renderErr,
+          isRscRequest,
+          request,
+          params,
+          scriptNonce,
+          middlewareContext,
+        );
+      },
+      renderHttpAccessFallbackPage(statusCode, opts, currentMiddlewareContext) {
+        return renderHTTPAccessFallbackPage(
+          route,
+          statusCode,
+          isRscRequest,
+          request,
+          opts,
+          scriptNonce,
+          currentMiddlewareContext,
+        );
+      },
+      renderToReadableStream,
+      request,
+      revalidateSeconds: typeof route.page?.revalidate === "number" ? route.page.revalidate : null,
+      rootForbiddenModule,
+      rootNotFoundModule,
+      rootUnauthorizedModule,
+      route,
+      runWithSuppressedHookWarning(probe) {
+        return _suppressHookWarningAls.run(true, probe);
+      },
+      scheduleBackgroundRegeneration(key, renderFn, errorContext) {
+        __triggerBackgroundRegeneration(key, renderFn, errorContext);
+      },
+      scriptNonce,
+      searchParams,
+      setNavigationContext,
+    });
+  },
+  dispatchMatchedRouteHandler({
+    cleanPathname,
+    middlewareContext,
+    params,
+    request,
+    route,
+    searchParams,
+  }) {
     return __dispatchAppRouteHandler({
       basePath: __basePath,
       cleanPathname,
-      clearRequestContext: function() {
+      clearRequestContext() {
         __clearRequestContext();
       },
       i18n: __i18nConfig,
@@ -1046,8 +780,8 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       isrGet: __isrGet,
       isrRouteKey: __isrRouteKey,
       isrSet: __isrSet,
-      middlewareContext: _mwCtx,
-      middlewareRequestHeaders: _mwCtx.requestHeaders,
+      middlewareContext,
+      middlewareRequestHeaders: middlewareContext.requestHeaders,
       params,
       request,
       route: {
@@ -1056,104 +790,153 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         routeSegments: route.routeSegments,
       },
       scheduleBackgroundRegeneration: __triggerBackgroundRegeneration,
-      searchParams: url.searchParams,
+      searchParams,
     });
-  }
-
-  const PageComponent = route.page?.default;
-  const _asyncRouteParams = makeThenableParams(params);
-  return __dispatchAppPage({
-    buildPageElement(targetRoute, targetParams, targetOpts, targetSearchParams) {
-      return buildPageElements(targetRoute, targetParams, cleanPathname, {
-        opts: targetOpts,
-        searchParams: targetSearchParams,
-        isRscRequest,
-        request,
-        mountedSlotsHeader: __mountedSlotsHeader,
-      });
-    },
+  },
+  
+  handleProgressiveActionRequest({
+    actionId,
     cleanPathname,
-    clearRequestContext() {
-      __clearRequestContext();
-    },
-    createRscOnErrorHandler(pathname, routePath) {
-      return createRscOnErrorHandler(request, pathname, routePath);
-    },
-    debugClassification: __classDebug,
-    dynamicConfig: route.page?.dynamic,
-    dynamicParamsConfig: route.page?.dynamicParams,
-    findIntercept(pathname) {
-      return findIntercept(pathname, interceptionContextHeader);
-    },
-    generateStaticParams: route.page?.generateStaticParams,
-    getFontLinks: _getSSRFontLinks,
-    getFontPreloads: _getSSRFontPreloads,
-    getFontStyles: _getSSRFontStyles,
-    getNavigationContext: _getNavigationContext,
-    getSourceRoute(sourceRouteIndex) {
-      return routes[sourceRouteIndex];
-    },
-    hasGenerateStaticParams: typeof route.page?.generateStaticParams === "function",
-    hasPageDefaultExport: !!PageComponent,
-    hasPageModule: !!route.page,
-    handlerStart: __reqStart,
-    interceptionContext: interceptionContextHeader,
-    isProduction: process.env.NODE_ENV === "production",
-    isRscRequest,
-    isrDebug: __isrDebug,
-    isrGet: __isrGet,
-    isrHtmlKey: __isrHtmlKey,
-    isrRscKey: __isrRscKey,
-    isrSet: __isrSet,
-    loadSsrHandler() {
-      return import.meta.viteRsc.loadModule("ssr", "index");
-    },
-    middlewareContext: _mwCtx,
-    mountedSlotsHeader: __mountedSlotsHeader,
-    params,
-    probeLayoutAt(li) {
-      const LayoutComp = route.layouts[li]?.default;
-      if (!LayoutComp) return null;
-      return LayoutComp({
-        params: makeThenableParams(__resolveAppPageSegmentParams(
-          route.routeSegments,
-          route.layoutTreePositions?.[li] ?? 0,
-          params,
-        )),
-        children: null,
-      });
-    },
-    probePage() {
-      if (!PageComponent) return null;
-      const _asyncSearchParams = makeThenableParams(
-        __collectAppPageSearchParams(url.searchParams).searchParamsObject,
-      );
-      return PageComponent({ params: _asyncRouteParams, searchParams: _asyncSearchParams });
-    },
-    renderErrorBoundaryPage(renderErr) {
-      return renderErrorBoundaryPage(route, renderErr, isRscRequest, request, params, _scriptNonce, _mwCtx);
-    },
-    renderHttpAccessFallbackPage(statusCode, opts, middlewareContext) {
-      return renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, opts, _scriptNonce, middlewareContext);
-    },
-    renderToReadableStream,
+    contentType,
+    middlewareContext,
     request,
-    revalidateSeconds: typeof route.page?.revalidate === "number" ? route.page.revalidate : null,
-    rootForbiddenModule,
-    rootNotFoundModule,
-    rootUnauthorizedModule,
-    route,
-    runWithSuppressedHookWarning(probe) {
-      return _suppressHookWarningAls.run(true, probe);
-    },
-    scheduleBackgroundRegeneration(key, renderFn, errorContext) {
-      __triggerBackgroundRegeneration(key, renderFn, errorContext);
-    },
-    scriptNonce: _scriptNonce,
-    searchParams: url.searchParams,
-    setNavigationContext,
-  });
-}
+  }) {
+    return __handleProgressiveServerActionRequest({
+      actionId,
+      allowedOrigins: __allowedOrigins,
+      cleanPathname,
+      clearRequestContext() {
+        __clearRequestContext();
+      },
+      contentType,
+      decodeAction,
+      getAndClearPendingCookies,
+      getDraftModeCookieHeader,
+      maxActionBodySize: __MAX_ACTION_BODY_SIZE,
+      middlewareHeaders: middlewareContext.headers,
+      readFormDataWithLimit: __readFormDataWithLimit,
+      reportRequestError: _reportRequestError,
+      request,
+      setHeadersAccessPhase,
+    });
+  },
+  handleServerActionRequest({
+    actionId,
+    cleanPathname,
+    contentType,
+    interceptionContext,
+    isRscRequest,
+    middlewareContext,
+    mountedSlotsHeader,
+    request,
+    searchParams,
+  }) {
+    return __handleServerActionRscRequest({
+      actionId,
+      allowedOrigins: __allowedOrigins,
+      buildPageElement({
+        route: actionRoute,
+        params: actionParams,
+        cleanPathname: actionCleanPathname,
+        interceptOpts,
+        searchParams: actionSearchParams,
+        isRscRequest: actionIsRscRequest,
+        request: actionRequest,
+        mountedSlotsHeader: actionMountedSlotsHeader,
+      }) {
+        return buildPageElements(actionRoute, actionParams, actionCleanPathname, {
+          opts: interceptOpts,
+          searchParams: actionSearchParams,
+          isRscRequest: actionIsRscRequest,
+          request: actionRequest,
+          mountedSlotsHeader: actionMountedSlotsHeader,
+        });
+      },
+      cleanPathname,
+      clearRequestContext() {
+        __clearRequestContext();
+      },
+      contentType,
+      createNotFoundElement(actionRouteId) {
+        return {
+          [__APP_INTERCEPTION_CONTEXT_KEY]: null,
+          __route: actionRouteId,
+          __rootLayout: null,
+          [actionRouteId]: createElement("div", null, "Page not found"),
+        };
+      },
+      createPayloadRouteId(pathnameToRender, currentInterceptionContext) {
+        return __createAppPayloadRouteId(pathnameToRender, currentInterceptionContext);
+      },
+      createRscOnErrorHandler(actionRequest, actionPathname, routePattern) {
+        return createRscOnErrorHandler(actionRequest, actionPathname, routePattern);
+      },
+      createTemporaryReferenceSet,
+      decodeReply,
+      findIntercept(pathnameToMatch) {
+        return findIntercept(pathnameToMatch, interceptionContext);
+      },
+      getAndClearPendingCookies,
+      getDraftModeCookieHeader,
+      getRouteParamNames(sourceRoute) {
+        return sourceRoute.params;
+      },
+      getSourceRoute(sourceRouteIndex) {
+        return routes[sourceRouteIndex];
+      },
+      isRscRequest,
+      loadServerAction,
+      matchRoute(pathnameToMatch) {
+        return matchRoute(pathnameToMatch);
+      },
+      maxActionBodySize: __MAX_ACTION_BODY_SIZE,
+      middlewareHeaders: middlewareContext.headers,
+      middlewareStatus: middlewareContext.status,
+      mountedSlotsHeader,
+      readBodyWithLimit: __readBodyWithLimit,
+      readFormDataWithLimit: __readFormDataWithLimit,
+      renderToReadableStream,
+      reportRequestError: _reportRequestError,
+      request,
+      sanitizeErrorForClient(error) {
+        return __sanitizeErrorForClient(error);
+      },
+      searchParams,
+      setHeadersAccessPhase,
+      setNavigationContext,
+      toInterceptOpts(intercept) {
+        return {
+          interceptionContext,
+          interceptLayouts: intercept.interceptLayouts,
+          interceptSlotKey: intercept.slotKey,
+          interceptPage: intercept.page,
+          interceptParams: intercept.matchedParams,
+        };
+      },
+    });
+  },
+  i18nConfig: __i18nConfig,
+  
+  makeThenableParams,
+  matchRoute(pathnameToMatch) {
+    return matchRoute(pathnameToMatch);
+  },
+  metadataRoutes,
+  middlewareIsProxy: false,
+  middlewareModule: null,
+  publicFiles: __publicFiles,
+  renderNotFoundPage({ isRscRequest, matchedParams, middlewareContext, request, route, scriptNonce }) {
+    return renderNotFoundPage(route, isRscRequest, request, matchedParams, scriptNonce, middlewareContext);
+  },
+  
+  rootParamNamesMap,
+  setNavigationContext,
+  staticParamsMap: generateStaticParamsMap,
+  trailingSlash: __trailingSlash,
+  validateDevRequestOrigin(request) {
+    return __validateDevRequestOrigin(request);
+  },
+});
 
 if (import.meta.hot) {
   import.meta.hot.accept();
@@ -1181,17 +964,15 @@ function renderToReadableStream(model, options) {
 }
 import { createElement } from "react";
 import { setNavigationContext as _setNavigationContextOrig, getNavigationContext as _getNavigationContext } from "next/navigation";
-import { setHeadersContext, headersContextFromRequest, getDraftModeCookieHeader, getAndClearPendingCookies, consumeDynamicUsage, consumeInvalidDynamicUsageError, markDynamicUsage, getHeadersContext, setHeadersAccessPhase } from "next/headers";
+import { setHeadersContext, getDraftModeCookieHeader, getAndClearPendingCookies, markDynamicUsage, setHeadersAccessPhase } from "next/headers";
 import { mergeMetadata, resolveModuleMetadata, mergeViewport, resolveModuleViewport } from "vinext/metadata";
 
 
-import { handleMetadataRouteRequest as __handleMetadataRouteRequest } from "<ROOT>/packages/vinext/src/server/metadata-route-response.js";
-import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, isExternalUrl, proxyExternalRequest, sanitizeDestination } from "<ROOT>/packages/vinext/src/config/config-matchers.js";
-import { decodePathParams as __decodePathParams, normalizePath as __normalizePath } from "<ROOT>/packages/vinext/src/server/normalize-path.js";
-import { normalizePathnameForRouteMatch as __normalizePathnameForRouteMatch, normalizePathnameForRouteMatchStrict as __normalizePathnameForRouteMatchStrict } from "<ROOT>/packages/vinext/src/routing/utils.js";
+import { decodePathParams as __decodePathParams } from "<ROOT>/packages/vinext/src/server/normalize-path.js";
 import { buildRequestHeadersFromMiddlewareResponse as __buildRequestHeadersFromMiddlewareResponse } from "<ROOT>/packages/vinext/src/server/middleware-request-headers.js";
-import { applyConfigHeadersToResponse, resolvePublicFileRoute, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
-import { applyAppMiddleware as __applyAppMiddleware } from "<ROOT>/packages/vinext/src/server/app-middleware.js";
+import {
+  createAppRscHandler as __createAppRscHandler,
+} from "<ROOT>/packages/vinext/src/server/app-rsc-handler.js";
 import {
   dispatchAppRouteHandler as __dispatchAppRouteHandler,
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-dispatch.js";
@@ -1231,38 +1012,25 @@ import {
   resolveAppPageHead as __resolveAppPageHead,
 } from "<ROOT>/packages/vinext/src/server/app-page-head.js";
 import {
-  mergeMiddlewareResponseHeaders as __mergeMiddlewareResponseHeaders,
-} from "<ROOT>/packages/vinext/src/server/app-page-response.js";
-import {
   dispatchAppPage as __dispatchAppPage,
 } from "<ROOT>/packages/vinext/src/server/app-page-dispatch.js";
-import { getScriptNonceFromHeaderSources as __getScriptNonceFromHeaderSources } from "<ROOT>/packages/vinext/src/server/csp.js";
-import { buildPageCacheTags } from "<ROOT>/packages/vinext/src/server/implicit-tags.js";
-import { getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
-import { setRootParams as __setRootParams, pickRootParams as __pickRootParams } from "<ROOT>/packages/vinext/src/shims/root-params.js";
+import { setRootParams as __setRootParams } from "<ROOT>/packages/vinext/src/shims/root-params.js";
 import { makeThenableParams } from "<ROOT>/packages/vinext/src/shims/thenable-params.js";
-import { ensureFetchPatch as _ensureFetchPatch, setCurrentFetchSoftTags } from "vinext/fetch-cache";
+import { setCurrentFetchSoftTags } from "vinext/fetch-cache";
 import {
   createAppRscRouteMatcher as __createAppRscRouteMatcher,
 } from "<ROOT>/packages/vinext/src/server/app-rsc-route-matching.js";
-import {
-  handleAppPrerenderEndpoint as __handleAppPrerenderEndpoint,
-} from "<ROOT>/packages/vinext/src/server/app-prerender-endpoints.js";
 import {
   appIsrHtmlKey as __isrHtmlKey,
   appIsrRscKey as __isrRscKey,
   appIsrRouteKey as __isrRouteKey,
   isrGet as __isrGet,
   isrSet as __isrSet,
-  normalizeMountedSlotsHeader as __normalizeMountedSlotsHeader,
   triggerBackgroundRegeneration as __triggerBackgroundRegeneration,
 } from "<ROOT>/packages/vinext/src/server/isr-cache.js";
 // Import server-only state module to register ALS-backed accessors.
 import "vinext/navigation-state";
-import { runWithPrerenderWorkUnit as __runWithPrerenderWorkUnit } from "<ROOT>/packages/vinext/src/server/prerender-work-unit-setup.js";
-import { runWithRequestContext as _runWithUnifiedCtx, createRequestContext as _createUnifiedCtx } from "vinext/unified-request-context";
 import { reportRequestError as _reportRequestError } from "vinext/instrumentation";
-import { flattenErrorCauses as __flattenErrorCauses } from "<ROOT>/packages/vinext/src/utils/error-cause.js";
 import { getSSRFontLinks as _getSSRFontLinks, getSSRFontStyles as _getSSRFontStylesGoogle, getSSRFontPreloads as _getSSRFontPreloadsGoogle } from "next/font/google";
 import { getSSRFontStyles as _getSSRFontStylesLocal, getSSRFontPreloads as _getSSRFontPreloadsLocal } from "next/font/local";
 function _getSSRFontStyles() { return [..._getSSRFontStylesGoogle(), ..._getSSRFontStylesLocal()]; }
@@ -1780,35 +1548,6 @@ function __validateDevRequestOrigin(request) {
 }
 
 
-// ── Config pattern matching, redirects, rewrites, headers, CSRF validation,
-//    external URL proxy, cookie parsing, and request context are imported from
-//    config-matchers.ts and request-pipeline.ts (see import statements above).
-//    This eliminates ~250 lines of duplicated inline code and ensures the
-//    single-pass tokenizer in config-matchers.ts is used consistently
-//    (fixing the chained .replace() divergence flagged by CodeQL).
-
-/**
- * Build a request context from the live ALS HeadersContext, which reflects
- * any x-middleware-request-* header mutations applied by middleware.
- * Used for afterFiles and fallback rewrite has/missing evaluation — these
- * run after middleware in the App Router execution order.
- */
-function __buildPostMwRequestContext(request) {
-  const url = new URL(request.url);
-  const ctx = getHeadersContext();
-  if (!ctx) return requestContextFromRequest(request);
-  // ctx.cookies is a Map<string, string> (HeadersContext), but RequestContext
-  // requires a plain Record<string, string> for has/missing cookie evaluation
-  // (config-matchers.ts uses obj[key] not Map.get()). Convert here.
-  const cookiesRecord = Object.fromEntries(ctx.cookies);
-  return {
-    headers: ctx.headers,
-    cookies: cookiesRecord,
-    query: url.searchParams,
-    host: normalizeHost(ctx.headers.get("host"), url.hostname),
-  };
-}
-
 /**
  * Maximum server-action request body size.
  * Configurable via experimental.serverActions.bodySizeLimit in next.config.
@@ -1833,377 +1572,149 @@ const rootParamNamesMap = {
 
 };
 
-export default async function handler(request, ctx) {
-  
-  // Wrap the entire request in a single unified ALS scope for per-request
-  // isolation. All state modules (headers, navigation, cache, fetch-cache,
-  // execution-context) read from this store via isInsideUnifiedScope().
-  const headersCtx = headersContextFromRequest(request);
-  const __uCtx = _createUnifiedCtx({
-    headersContext: headersCtx,
-    executionContext: ctx ?? _getRequestExecutionContext() ?? null,
-    unstableCacheRevalidation: "background",
-  });
-  return _runWithUnifiedCtx(__uCtx, () =>
-    __runWithPrerenderWorkUnit(async () => {
-    _ensureFetchPatch();
-    const __reqCtx = requestContextFromRequest(request);
-    // Per-request container for middleware state. Passed into
-    // _handleRequest which fills in .headers and .status;
-    // avoids module-level variables that race on Workers.
-    const _mwCtx = { headers: null, requestHeaders: null, status: null };
-    let response;
-    try {
-      response = await _handleRequest(request, __reqCtx, _mwCtx);
-    } catch (err) {
-      // Dev only: embed err.cause chain into err.message/err.stack so Vite's
-      // dev-server "Internal server error:" logger (which builds output from
-      // message + stack only) reveals the underlying root cause (ECONNREFUSED,
-      // role missing, workerd socket error, etc.) instead of dropping it.
-      // Skipped in production because Node's util.inspect / workerd's logger
-      // already render .cause natively, so flattening would double-print it.
-      // NODE_ENV is build-time-replaced by Vite, so the prod bundle compiles
-      // this branch out entirely.
-      if (process.env.NODE_ENV !== "production") {
-        __flattenErrorCauses(err);
-      }
-      throw err;
-    }
-    // Apply custom headers from next.config.js to non-redirect responses.
-    // Skip redirects (3xx) because Response.redirect() creates immutable headers,
-    // and Next.js doesn't apply custom headers to redirects anyway.
-    if (response && response.headers && !(response.status >= 300 && response.status < 400)) {
-      if (__configHeaders.length) {
-        const url = new URL(request.url);
-        let pathname;
-        try { pathname = __normalizePath(__normalizePathnameForRouteMatch(url.pathname)); } catch { pathname = url.pathname; }
-        if (pathname.startsWith("/base")) pathname = pathname.slice("/base".length) || "/";
-        applyConfigHeadersToResponse(response.headers, {
-          configHeaders: __configHeaders,
-          pathname,
-          requestContext: __reqCtx,
-        });
-      }
-    }
-    return response;
-    }, { route: () => new URL(request.url).pathname })
-  );
-}
-
-async function _handleRequest(request, __reqCtx, _mwCtx) {
-  const __reqStart = process.env.NODE_ENV !== "production" ? performance.now() : 0;
-  // __reqStart is included in the timing header so the Node logging middleware
-  // can compute true compile time as: handlerStart - middlewareStart.
-  // Format: "handlerStart,compileMs,renderMs" - all as integers (ms). Dev-only.
-  const url = new URL(request.url);
-
-  // ── Cross-origin request protection (dev only) ─────────────────────
-  // Block requests from non-localhost origins to prevent data exfiltration.
-  // Skipped in production — Vite replaces NODE_ENV at build time.
-  if (process.env.NODE_ENV !== "production") {
-    const __originBlock = __validateDevRequestOrigin(request);
-    if (__originBlock) return __originBlock;
-  }
-
-  // Guard against protocol-relative URL open redirects (see request-pipeline.ts).
-  const __protoGuard = guardProtocolRelativeUrl(url.pathname);
-  if (__protoGuard) return __protoGuard;
-
-  // Decode percent-encoding segment-wise and normalize pathname to canonical form.
-  // This preserves encoded path delimiters like %2F within a single segment.
-  // __normalizePath collapses //foo///bar → /foo/bar, resolves . and .. segments.
-  let decodedUrlPathname;
-  try { decodedUrlPathname = __normalizePathnameForRouteMatchStrict(url.pathname); } catch (e) {
-    return new Response("Bad Request", { status: 400 });
-  }
-  let pathname = __normalizePath(decodedUrlPathname);
-
-  
-  if (!hasBasePath(pathname, __basePath) && !pathname.startsWith("/__vinext/")) {
-    return new Response("Not Found", { status: 404 });
-  }
-  // Strip basePath prefix
-  pathname = stripBasePath(pathname, __basePath);
-  
-
-  const __prerenderEndpointResponse = await __handleAppPrerenderEndpoint(request, {
-    isPrerenderEnabled() {
-      return process.env.VINEXT_PRERENDER === "1";
-    },
-
-    pathname,
-    rootParamNamesByPattern: rootParamNamesMap,
-    staticParamsMap: generateStaticParamsMap,
-  });
-  if (__prerenderEndpointResponse) return __prerenderEndpointResponse;
-
-  // Trailing slash normalization (redirect to canonical form)
-  const __tsRedirect = normalizeTrailingSlash(pathname, __basePath, __trailingSlash, url.search);
-  if (__tsRedirect) return __tsRedirect;
-
-  // ── Apply redirects from next.config.js ───────────────────────────────
-  if (__configRedirects.length) {
-    // Strip .rsc suffix before matching redirect rules - RSC (client-side nav) requests
-    // arrive as /some/path.rsc but redirect patterns are defined without it (e.g.
-    // /some/path). Without this, soft-nav fetches bypass all config redirects.
-    const __redirPathname = pathname.endsWith(".rsc") ? pathname.slice(0, -4) : pathname;
-    const __redir = matchRedirect(__redirPathname, __configRedirects, __reqCtx);
-    if (__redir) {
-      const __redirDest = sanitizeDestination(
-        __basePath &&
-          !isExternalUrl(__redir.destination) &&
-          !hasBasePath(__redir.destination, __basePath)
-          ? __basePath + __redir.destination
-          : __redir.destination
-      );
-      return new Response(null, {
-        status: __redir.permanent ? 308 : 307,
-        headers: { Location: __redirDest },
-      });
-    }
-  }
-
-  const isRscRequest = pathname.endsWith(".rsc") || request.headers.get("accept")?.includes("text/x-component");
-  // Read mounted-slots header once at the handler scope and thread it through
-  // every buildPageElements call site. Previously both the handler and
-  // buildPageElements read and normalized it independently, which invited
-  // silent drift if a future refactor changed only one path.
-  const __mountedSlotsHeader = __normalizeMountedSlotsHeader(
-    request.headers.get("x-vinext-mounted-slots"),
-  );
-  const interceptionContextHeader = request.headers.get("X-Vinext-Interception-Context")?.replaceAll(" ", "") || null;
-  let cleanPathname = pathname.replace(/\\.rsc$/, "");
-
-  // Middleware response headers and custom rewrite status are stored in
-  // _mwCtx (per-request container) so handler() can merge them into
-  // every response path without module-level state that races on Workers.
-
-  
-
-  const _scriptNonce = __getScriptNonceFromHeaderSources(request.headers, _mwCtx.headers);
-
-  // Build post-middleware request context for afterFiles/fallback rewrites.
-  // These run after middleware in the App Router execution order and should
-  // evaluate has/missing conditions against middleware-modified headers.
-  // When no middleware is present, this falls back to requestContextFromRequest.
-  const __postMwReqCtx = __buildPostMwRequestContext(request);
-
-  // ── Apply beforeFiles rewrites from next.config.js ────────────────────
-  // In App Router execution order, beforeFiles runs after middleware so that
-  // has/missing conditions can evaluate against middleware-modified headers.
-  if (__configRewrites.beforeFiles && __configRewrites.beforeFiles.length) {
-    const __rewritten = matchRewrite(cleanPathname, __configRewrites.beforeFiles, __postMwReqCtx);
-    if (__rewritten) {
-      if (isExternalUrl(__rewritten)) {
-        __clearRequestContext();
-        return proxyExternalRequest(request, __rewritten);
-      }
-      cleanPathname = __rewritten;
-    }
-  }
-
-  // ── Image optimization passthrough (dev mode — no transformation) ───────
-  if (cleanPathname === "/_vinext/image") {
-    const __imgResult = validateImageUrl(url.searchParams.get("url"), request.url);
-    if (__imgResult instanceof Response) return __imgResult;
-    // In dev, redirect to the original asset URL so Vite's static serving handles it.
-    return Response.redirect(new URL(__imgResult, url.origin).href, 302);
-  }
-
-  const metadataRouteResponse = await __handleMetadataRouteRequest({
-    metadataRoutes,
-    cleanPathname,
-    makeThenableParams,
-  });
-  if (metadataRouteResponse) return metadataRouteResponse;
-
-  // Serve public/ files as filesystem routes after middleware and before
-  // afterFiles/fallback rewrites, matching Next.js routing semantics.
-  const __publicFileResponse = resolvePublicFileRoute({
-    cleanPathname,
-    middlewareContext: _mwCtx,
-    pathname,
-    publicFiles: __publicFiles,
-    request,
-  });
-  if (__publicFileResponse) {
+export default __createAppRscHandler({
+  basePath: __basePath,
+  clearRequestContext() {
     __clearRequestContext();
-    return __publicFileResponse;
-  }
-
-  // Set navigation context for Server Components.
-  // Note: Headers context is already set by runWithRequestContext in the handler wrapper.
-  setNavigationContext({
-    pathname: cleanPathname,
-    searchParams: url.searchParams,
-    params: {},
-  });
-
-  // Handle server action POST requests
-  const actionId = request.headers.get("x-rsc-action") ?? request.headers.get("next-action");
-  const actionContentType = request.headers.get("content-type") || "";
-  const progressiveActionResponse = await __handleProgressiveServerActionRequest({
-    actionId,
-    allowedOrigins: __allowedOrigins,
+  },
+  configHeaders: __configHeaders,
+  configRedirects: __configRedirects,
+  configRewrites: __configRewrites,
+  dispatchMatchedPage({
     cleanPathname,
-    clearRequestContext() {
-      __clearRequestContext();
-    },
-    contentType: actionContentType,
-    decodeAction,
-    getAndClearPendingCookies,
-    getDraftModeCookieHeader,
-    maxActionBodySize: __MAX_ACTION_BODY_SIZE,
-    middlewareHeaders: _mwCtx.headers,
-    readFormDataWithLimit: __readFormDataWithLimit,
-    reportRequestError: _reportRequestError,
-    request,
-    setHeadersAccessPhase,
-  });
-  if (progressiveActionResponse) return progressiveActionResponse;
-
-  const serverActionResponse = await __handleServerActionRscRequest({
-    actionId,
-    allowedOrigins: __allowedOrigins,
-    buildPageElement({
-      route: actionRoute,
-      params: actionParams,
-      cleanPathname: actionCleanPathname,
-      interceptOpts,
-      searchParams,
-      isRscRequest: actionIsRscRequest,
-      request: actionRequest,
-      mountedSlotsHeader,
-    }) {
-      return buildPageElements(actionRoute, actionParams, actionCleanPathname, {
-        opts: interceptOpts,
-        searchParams,
-        isRscRequest: actionIsRscRequest,
-        request: actionRequest,
-        mountedSlotsHeader,
-      });
-    },
-    cleanPathname,
-    clearRequestContext() {
-      __clearRequestContext();
-    },
-    contentType: actionContentType,
-    createNotFoundElement(actionRouteId) {
-      return {
-        [__APP_INTERCEPTION_CONTEXT_KEY]: null,
-        __route: actionRouteId,
-        __rootLayout: null,
-        [actionRouteId]: createElement("div", null, "Page not found"),
-      };
-    },
-    createPayloadRouteId(pathnameToRender, interceptionContext) {
-      return __createAppPayloadRouteId(pathnameToRender, interceptionContext);
-    },
-    createRscOnErrorHandler(actionRequest, actionPathname, routePattern) {
-      return createRscOnErrorHandler(actionRequest, actionPathname, routePattern);
-    },
-    createTemporaryReferenceSet,
-    decodeReply,
-    findIntercept(pathnameToMatch) {
-      return findIntercept(pathnameToMatch, interceptionContextHeader);
-    },
-    getAndClearPendingCookies,
-    getDraftModeCookieHeader,
-    getRouteParamNames(sourceRoute) {
-      return sourceRoute.params;
-    },
-    getSourceRoute(sourceRouteIndex) {
-      return routes[sourceRouteIndex];
-    },
+    handlerStart,
+    interceptionContext,
     isRscRequest,
-    loadServerAction,
-    matchRoute(pathnameToMatch) {
-      return matchRoute(pathnameToMatch);
-    },
-    maxActionBodySize: __MAX_ACTION_BODY_SIZE,
-    middlewareHeaders: _mwCtx.headers,
-    middlewareStatus: _mwCtx.status,
-    mountedSlotsHeader: __mountedSlotsHeader,
-    readBodyWithLimit: __readBodyWithLimit,
-    readFormDataWithLimit: __readFormDataWithLimit,
-    renderToReadableStream,
-    reportRequestError: _reportRequestError,
-    request,
-    sanitizeErrorForClient(error) {
-      return __sanitizeErrorForClient(error);
-    },
-    searchParams: url.searchParams,
-    setHeadersAccessPhase,
-    setNavigationContext,
-    toInterceptOpts(intercept) {
-      return {
-        interceptionContext: interceptionContextHeader,
-        interceptLayouts: intercept.interceptLayouts,
-        interceptSlotKey: intercept.slotKey,
-        interceptPage: intercept.page,
-        interceptParams: intercept.matchedParams,
-      };
-    },
-  });
-  if (serverActionResponse) return serverActionResponse;
-
-  // ── Apply afterFiles rewrites from next.config.js ──────────────────────
-  if (__configRewrites.afterFiles && __configRewrites.afterFiles.length) {
-    const __afterRewritten = matchRewrite(cleanPathname, __configRewrites.afterFiles, __postMwReqCtx);
-    if (__afterRewritten) {
-      if (isExternalUrl(__afterRewritten)) {
-        __clearRequestContext();
-        return proxyExternalRequest(request, __afterRewritten);
-      }
-      cleanPathname = __afterRewritten;
-    }
-  }
-
-  let match = matchRoute(cleanPathname);
-
-  // ── Fallback rewrites from next.config.js (if no route matched) ───────
-  if (!match && __configRewrites.fallback && __configRewrites.fallback.length) {
-    const __fallbackRewritten = matchRewrite(cleanPathname, __configRewrites.fallback, __postMwReqCtx);
-    if (__fallbackRewritten) {
-      if (isExternalUrl(__fallbackRewritten)) {
-        __clearRequestContext();
-        return proxyExternalRequest(request, __fallbackRewritten);
-      }
-      cleanPathname = __fallbackRewritten;
-      match = matchRoute(cleanPathname);
-    }
-  }
-
-  if (!match) {
-    
-    // Render custom not-found page if available, otherwise plain 404
-    const notFoundResponse = await renderNotFoundPage(null, isRscRequest, request, undefined, _scriptNonce, _mwCtx);
-    if (notFoundResponse) return notFoundResponse;
-    __clearRequestContext();
-    const notFoundHeaders = new Headers();
-    __mergeMiddlewareResponseHeaders(notFoundHeaders, _mwCtx.headers);
-    return new Response("Not Found", { status: 404, headers: notFoundHeaders });
-  }
-
-  const { route, params } = match;
-
-  // Update navigation context with matched params
-  setNavigationContext({
-    pathname: cleanPathname,
-    searchParams: url.searchParams,
+    middlewareContext,
+    mountedSlotsHeader,
     params,
-  });
-  __setRootParams(__pickRootParams(params, route.rootParamNames));
-
-  // Handle route.ts API handlers
-  if (route.routeHandler) {
-    setCurrentFetchSoftTags(
-      buildPageCacheTags(cleanPathname, [], route.routeSegments, "route"),
-    );
+    request,
+    route,
+    scriptNonce,
+    searchParams,
+  }) {
+    const PageComponent = route.page?.default;
+    const _asyncRouteParams = makeThenableParams(params);
+    return __dispatchAppPage({
+      buildPageElement(targetRoute, targetParams, targetOpts, targetSearchParams) {
+        return buildPageElements(targetRoute, targetParams, cleanPathname, {
+          opts: targetOpts,
+          searchParams: targetSearchParams,
+          isRscRequest,
+          request,
+          mountedSlotsHeader,
+        });
+      },
+      cleanPathname,
+      clearRequestContext() {
+        __clearRequestContext();
+      },
+      createRscOnErrorHandler(pathname, routePath) {
+        return createRscOnErrorHandler(request, pathname, routePath);
+      },
+      debugClassification: __classDebug,
+      dynamicConfig: route.page?.dynamic,
+      dynamicParamsConfig: route.page?.dynamicParams,
+      findIntercept(pathname) {
+        return findIntercept(pathname, interceptionContext);
+      },
+      generateStaticParams: route.page?.generateStaticParams,
+      getFontLinks: _getSSRFontLinks,
+      getFontPreloads: _getSSRFontPreloads,
+      getFontStyles: _getSSRFontStyles,
+      getNavigationContext: _getNavigationContext,
+      getSourceRoute(sourceRouteIndex) {
+        return routes[sourceRouteIndex];
+      },
+      hasGenerateStaticParams: typeof route.page?.generateStaticParams === "function",
+      hasPageDefaultExport: !!PageComponent,
+      hasPageModule: !!route.page,
+      handlerStart,
+      interceptionContext,
+      isProduction: process.env.NODE_ENV === "production",
+      isRscRequest,
+      isrDebug: __isrDebug,
+      isrGet: __isrGet,
+      isrHtmlKey: __isrHtmlKey,
+      isrRscKey: __isrRscKey,
+      isrSet: __isrSet,
+      loadSsrHandler() {
+        return import.meta.viteRsc.loadModule("ssr", "index");
+      },
+      middlewareContext,
+      mountedSlotsHeader,
+      params,
+      probeLayoutAt(li) {
+        const LayoutComp = route.layouts[li]?.default;
+        if (!LayoutComp) return null;
+        return LayoutComp({
+          params: makeThenableParams(__resolveAppPageSegmentParams(
+            route.routeSegments,
+            route.layoutTreePositions?.[li] ?? 0,
+            params,
+          )),
+          children: null,
+        });
+      },
+      probePage() {
+        if (!PageComponent) return null;
+        const _asyncSearchParams = makeThenableParams(
+          __collectAppPageSearchParams(searchParams).searchParamsObject,
+        );
+        return PageComponent({ params: _asyncRouteParams, searchParams: _asyncSearchParams });
+      },
+      renderErrorBoundaryPage(renderErr) {
+        return renderErrorBoundaryPage(
+          route,
+          renderErr,
+          isRscRequest,
+          request,
+          params,
+          scriptNonce,
+          middlewareContext,
+        );
+      },
+      renderHttpAccessFallbackPage(statusCode, opts, currentMiddlewareContext) {
+        return renderHTTPAccessFallbackPage(
+          route,
+          statusCode,
+          isRscRequest,
+          request,
+          opts,
+          scriptNonce,
+          currentMiddlewareContext,
+        );
+      },
+      renderToReadableStream,
+      request,
+      revalidateSeconds: typeof route.page?.revalidate === "number" ? route.page.revalidate : null,
+      rootForbiddenModule,
+      rootNotFoundModule,
+      rootUnauthorizedModule,
+      route,
+      runWithSuppressedHookWarning(probe) {
+        return _suppressHookWarningAls.run(true, probe);
+      },
+      scheduleBackgroundRegeneration(key, renderFn, errorContext) {
+        __triggerBackgroundRegeneration(key, renderFn, errorContext);
+      },
+      scriptNonce,
+      searchParams,
+      setNavigationContext,
+    });
+  },
+  dispatchMatchedRouteHandler({
+    cleanPathname,
+    middlewareContext,
+    params,
+    request,
+    route,
+    searchParams,
+  }) {
     return __dispatchAppRouteHandler({
       basePath: __basePath,
       cleanPathname,
-      clearRequestContext: function() {
+      clearRequestContext() {
         __clearRequestContext();
       },
       i18n: __i18nConfig,
@@ -2211,8 +1722,8 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       isrGet: __isrGet,
       isrRouteKey: __isrRouteKey,
       isrSet: __isrSet,
-      middlewareContext: _mwCtx,
-      middlewareRequestHeaders: _mwCtx.requestHeaders,
+      middlewareContext,
+      middlewareRequestHeaders: middlewareContext.requestHeaders,
       params,
       request,
       route: {
@@ -2221,104 +1732,153 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         routeSegments: route.routeSegments,
       },
       scheduleBackgroundRegeneration: __triggerBackgroundRegeneration,
-      searchParams: url.searchParams,
+      searchParams,
     });
-  }
-
-  const PageComponent = route.page?.default;
-  const _asyncRouteParams = makeThenableParams(params);
-  return __dispatchAppPage({
-    buildPageElement(targetRoute, targetParams, targetOpts, targetSearchParams) {
-      return buildPageElements(targetRoute, targetParams, cleanPathname, {
-        opts: targetOpts,
-        searchParams: targetSearchParams,
-        isRscRequest,
-        request,
-        mountedSlotsHeader: __mountedSlotsHeader,
-      });
-    },
+  },
+  
+  handleProgressiveActionRequest({
+    actionId,
     cleanPathname,
-    clearRequestContext() {
-      __clearRequestContext();
-    },
-    createRscOnErrorHandler(pathname, routePath) {
-      return createRscOnErrorHandler(request, pathname, routePath);
-    },
-    debugClassification: __classDebug,
-    dynamicConfig: route.page?.dynamic,
-    dynamicParamsConfig: route.page?.dynamicParams,
-    findIntercept(pathname) {
-      return findIntercept(pathname, interceptionContextHeader);
-    },
-    generateStaticParams: route.page?.generateStaticParams,
-    getFontLinks: _getSSRFontLinks,
-    getFontPreloads: _getSSRFontPreloads,
-    getFontStyles: _getSSRFontStyles,
-    getNavigationContext: _getNavigationContext,
-    getSourceRoute(sourceRouteIndex) {
-      return routes[sourceRouteIndex];
-    },
-    hasGenerateStaticParams: typeof route.page?.generateStaticParams === "function",
-    hasPageDefaultExport: !!PageComponent,
-    hasPageModule: !!route.page,
-    handlerStart: __reqStart,
-    interceptionContext: interceptionContextHeader,
-    isProduction: process.env.NODE_ENV === "production",
-    isRscRequest,
-    isrDebug: __isrDebug,
-    isrGet: __isrGet,
-    isrHtmlKey: __isrHtmlKey,
-    isrRscKey: __isrRscKey,
-    isrSet: __isrSet,
-    loadSsrHandler() {
-      return import.meta.viteRsc.loadModule("ssr", "index");
-    },
-    middlewareContext: _mwCtx,
-    mountedSlotsHeader: __mountedSlotsHeader,
-    params,
-    probeLayoutAt(li) {
-      const LayoutComp = route.layouts[li]?.default;
-      if (!LayoutComp) return null;
-      return LayoutComp({
-        params: makeThenableParams(__resolveAppPageSegmentParams(
-          route.routeSegments,
-          route.layoutTreePositions?.[li] ?? 0,
-          params,
-        )),
-        children: null,
-      });
-    },
-    probePage() {
-      if (!PageComponent) return null;
-      const _asyncSearchParams = makeThenableParams(
-        __collectAppPageSearchParams(url.searchParams).searchParamsObject,
-      );
-      return PageComponent({ params: _asyncRouteParams, searchParams: _asyncSearchParams });
-    },
-    renderErrorBoundaryPage(renderErr) {
-      return renderErrorBoundaryPage(route, renderErr, isRscRequest, request, params, _scriptNonce, _mwCtx);
-    },
-    renderHttpAccessFallbackPage(statusCode, opts, middlewareContext) {
-      return renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, opts, _scriptNonce, middlewareContext);
-    },
-    renderToReadableStream,
+    contentType,
+    middlewareContext,
     request,
-    revalidateSeconds: typeof route.page?.revalidate === "number" ? route.page.revalidate : null,
-    rootForbiddenModule,
-    rootNotFoundModule,
-    rootUnauthorizedModule,
-    route,
-    runWithSuppressedHookWarning(probe) {
-      return _suppressHookWarningAls.run(true, probe);
-    },
-    scheduleBackgroundRegeneration(key, renderFn, errorContext) {
-      __triggerBackgroundRegeneration(key, renderFn, errorContext);
-    },
-    scriptNonce: _scriptNonce,
-    searchParams: url.searchParams,
-    setNavigationContext,
-  });
-}
+  }) {
+    return __handleProgressiveServerActionRequest({
+      actionId,
+      allowedOrigins: __allowedOrigins,
+      cleanPathname,
+      clearRequestContext() {
+        __clearRequestContext();
+      },
+      contentType,
+      decodeAction,
+      getAndClearPendingCookies,
+      getDraftModeCookieHeader,
+      maxActionBodySize: __MAX_ACTION_BODY_SIZE,
+      middlewareHeaders: middlewareContext.headers,
+      readFormDataWithLimit: __readFormDataWithLimit,
+      reportRequestError: _reportRequestError,
+      request,
+      setHeadersAccessPhase,
+    });
+  },
+  handleServerActionRequest({
+    actionId,
+    cleanPathname,
+    contentType,
+    interceptionContext,
+    isRscRequest,
+    middlewareContext,
+    mountedSlotsHeader,
+    request,
+    searchParams,
+  }) {
+    return __handleServerActionRscRequest({
+      actionId,
+      allowedOrigins: __allowedOrigins,
+      buildPageElement({
+        route: actionRoute,
+        params: actionParams,
+        cleanPathname: actionCleanPathname,
+        interceptOpts,
+        searchParams: actionSearchParams,
+        isRscRequest: actionIsRscRequest,
+        request: actionRequest,
+        mountedSlotsHeader: actionMountedSlotsHeader,
+      }) {
+        return buildPageElements(actionRoute, actionParams, actionCleanPathname, {
+          opts: interceptOpts,
+          searchParams: actionSearchParams,
+          isRscRequest: actionIsRscRequest,
+          request: actionRequest,
+          mountedSlotsHeader: actionMountedSlotsHeader,
+        });
+      },
+      cleanPathname,
+      clearRequestContext() {
+        __clearRequestContext();
+      },
+      contentType,
+      createNotFoundElement(actionRouteId) {
+        return {
+          [__APP_INTERCEPTION_CONTEXT_KEY]: null,
+          __route: actionRouteId,
+          __rootLayout: null,
+          [actionRouteId]: createElement("div", null, "Page not found"),
+        };
+      },
+      createPayloadRouteId(pathnameToRender, currentInterceptionContext) {
+        return __createAppPayloadRouteId(pathnameToRender, currentInterceptionContext);
+      },
+      createRscOnErrorHandler(actionRequest, actionPathname, routePattern) {
+        return createRscOnErrorHandler(actionRequest, actionPathname, routePattern);
+      },
+      createTemporaryReferenceSet,
+      decodeReply,
+      findIntercept(pathnameToMatch) {
+        return findIntercept(pathnameToMatch, interceptionContext);
+      },
+      getAndClearPendingCookies,
+      getDraftModeCookieHeader,
+      getRouteParamNames(sourceRoute) {
+        return sourceRoute.params;
+      },
+      getSourceRoute(sourceRouteIndex) {
+        return routes[sourceRouteIndex];
+      },
+      isRscRequest,
+      loadServerAction,
+      matchRoute(pathnameToMatch) {
+        return matchRoute(pathnameToMatch);
+      },
+      maxActionBodySize: __MAX_ACTION_BODY_SIZE,
+      middlewareHeaders: middlewareContext.headers,
+      middlewareStatus: middlewareContext.status,
+      mountedSlotsHeader,
+      readBodyWithLimit: __readBodyWithLimit,
+      readFormDataWithLimit: __readFormDataWithLimit,
+      renderToReadableStream,
+      reportRequestError: _reportRequestError,
+      request,
+      sanitizeErrorForClient(error) {
+        return __sanitizeErrorForClient(error);
+      },
+      searchParams,
+      setHeadersAccessPhase,
+      setNavigationContext,
+      toInterceptOpts(intercept) {
+        return {
+          interceptionContext,
+          interceptLayouts: intercept.interceptLayouts,
+          interceptSlotKey: intercept.slotKey,
+          interceptPage: intercept.page,
+          interceptParams: intercept.matchedParams,
+        };
+      },
+    });
+  },
+  i18nConfig: __i18nConfig,
+  
+  makeThenableParams,
+  matchRoute(pathnameToMatch) {
+    return matchRoute(pathnameToMatch);
+  },
+  metadataRoutes,
+  middlewareIsProxy: false,
+  middlewareModule: null,
+  publicFiles: __publicFiles,
+  renderNotFoundPage({ isRscRequest, matchedParams, middlewareContext, request, route, scriptNonce }) {
+    return renderNotFoundPage(route, isRscRequest, request, matchedParams, scriptNonce, middlewareContext);
+  },
+  
+  rootParamNamesMap,
+  setNavigationContext,
+  staticParamsMap: generateStaticParamsMap,
+  trailingSlash: __trailingSlash,
+  validateDevRequestOrigin(request) {
+    return __validateDevRequestOrigin(request);
+  },
+});
 
 if (import.meta.hot) {
   import.meta.hot.accept();
@@ -2346,17 +1906,15 @@ function renderToReadableStream(model, options) {
 }
 import { createElement } from "react";
 import { setNavigationContext as _setNavigationContextOrig, getNavigationContext as _getNavigationContext } from "next/navigation";
-import { setHeadersContext, headersContextFromRequest, getDraftModeCookieHeader, getAndClearPendingCookies, consumeDynamicUsage, consumeInvalidDynamicUsageError, markDynamicUsage, getHeadersContext, setHeadersAccessPhase } from "next/headers";
+import { setHeadersContext, getDraftModeCookieHeader, getAndClearPendingCookies, markDynamicUsage, setHeadersAccessPhase } from "next/headers";
 import { mergeMetadata, resolveModuleMetadata, mergeViewport, resolveModuleViewport } from "vinext/metadata";
 
 
-import { handleMetadataRouteRequest as __handleMetadataRouteRequest } from "<ROOT>/packages/vinext/src/server/metadata-route-response.js";
-import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, isExternalUrl, proxyExternalRequest, sanitizeDestination } from "<ROOT>/packages/vinext/src/config/config-matchers.js";
-import { decodePathParams as __decodePathParams, normalizePath as __normalizePath } from "<ROOT>/packages/vinext/src/server/normalize-path.js";
-import { normalizePathnameForRouteMatch as __normalizePathnameForRouteMatch, normalizePathnameForRouteMatchStrict as __normalizePathnameForRouteMatchStrict } from "<ROOT>/packages/vinext/src/routing/utils.js";
+import { decodePathParams as __decodePathParams } from "<ROOT>/packages/vinext/src/server/normalize-path.js";
 import { buildRequestHeadersFromMiddlewareResponse as __buildRequestHeadersFromMiddlewareResponse } from "<ROOT>/packages/vinext/src/server/middleware-request-headers.js";
-import { applyConfigHeadersToResponse, resolvePublicFileRoute, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
-import { applyAppMiddleware as __applyAppMiddleware } from "<ROOT>/packages/vinext/src/server/app-middleware.js";
+import {
+  createAppRscHandler as __createAppRscHandler,
+} from "<ROOT>/packages/vinext/src/server/app-rsc-handler.js";
 import {
   dispatchAppRouteHandler as __dispatchAppRouteHandler,
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-dispatch.js";
@@ -2396,38 +1954,25 @@ import {
   resolveAppPageHead as __resolveAppPageHead,
 } from "<ROOT>/packages/vinext/src/server/app-page-head.js";
 import {
-  mergeMiddlewareResponseHeaders as __mergeMiddlewareResponseHeaders,
-} from "<ROOT>/packages/vinext/src/server/app-page-response.js";
-import {
   dispatchAppPage as __dispatchAppPage,
 } from "<ROOT>/packages/vinext/src/server/app-page-dispatch.js";
-import { getScriptNonceFromHeaderSources as __getScriptNonceFromHeaderSources } from "<ROOT>/packages/vinext/src/server/csp.js";
-import { buildPageCacheTags } from "<ROOT>/packages/vinext/src/server/implicit-tags.js";
-import { getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
-import { setRootParams as __setRootParams, pickRootParams as __pickRootParams } from "<ROOT>/packages/vinext/src/shims/root-params.js";
+import { setRootParams as __setRootParams } from "<ROOT>/packages/vinext/src/shims/root-params.js";
 import { makeThenableParams } from "<ROOT>/packages/vinext/src/shims/thenable-params.js";
-import { ensureFetchPatch as _ensureFetchPatch, setCurrentFetchSoftTags } from "vinext/fetch-cache";
+import { setCurrentFetchSoftTags } from "vinext/fetch-cache";
 import {
   createAppRscRouteMatcher as __createAppRscRouteMatcher,
 } from "<ROOT>/packages/vinext/src/server/app-rsc-route-matching.js";
-import {
-  handleAppPrerenderEndpoint as __handleAppPrerenderEndpoint,
-} from "<ROOT>/packages/vinext/src/server/app-prerender-endpoints.js";
 import {
   appIsrHtmlKey as __isrHtmlKey,
   appIsrRscKey as __isrRscKey,
   appIsrRouteKey as __isrRouteKey,
   isrGet as __isrGet,
   isrSet as __isrSet,
-  normalizeMountedSlotsHeader as __normalizeMountedSlotsHeader,
   triggerBackgroundRegeneration as __triggerBackgroundRegeneration,
 } from "<ROOT>/packages/vinext/src/server/isr-cache.js";
 // Import server-only state module to register ALS-backed accessors.
 import "vinext/navigation-state";
-import { runWithPrerenderWorkUnit as __runWithPrerenderWorkUnit } from "<ROOT>/packages/vinext/src/server/prerender-work-unit-setup.js";
-import { runWithRequestContext as _runWithUnifiedCtx, createRequestContext as _createUnifiedCtx } from "vinext/unified-request-context";
 import { reportRequestError as _reportRequestError } from "vinext/instrumentation";
-import { flattenErrorCauses as __flattenErrorCauses } from "<ROOT>/packages/vinext/src/utils/error-cause.js";
 import { getSSRFontLinks as _getSSRFontLinks, getSSRFontStyles as _getSSRFontStylesGoogle, getSSRFontPreloads as _getSSRFontPreloadsGoogle } from "next/font/google";
 import { getSSRFontStyles as _getSSRFontStylesLocal, getSSRFontPreloads as _getSSRFontPreloadsLocal } from "next/font/local";
 function _getSSRFontStyles() { return [..._getSSRFontStylesGoogle(), ..._getSSRFontStylesLocal()]; }
@@ -2946,35 +2491,6 @@ function __validateDevRequestOrigin(request) {
 }
 
 
-// ── Config pattern matching, redirects, rewrites, headers, CSRF validation,
-//    external URL proxy, cookie parsing, and request context are imported from
-//    config-matchers.ts and request-pipeline.ts (see import statements above).
-//    This eliminates ~250 lines of duplicated inline code and ensures the
-//    single-pass tokenizer in config-matchers.ts is used consistently
-//    (fixing the chained .replace() divergence flagged by CodeQL).
-
-/**
- * Build a request context from the live ALS HeadersContext, which reflects
- * any x-middleware-request-* header mutations applied by middleware.
- * Used for afterFiles and fallback rewrite has/missing evaluation — these
- * run after middleware in the App Router execution order.
- */
-function __buildPostMwRequestContext(request) {
-  const url = new URL(request.url);
-  const ctx = getHeadersContext();
-  if (!ctx) return requestContextFromRequest(request);
-  // ctx.cookies is a Map<string, string> (HeadersContext), but RequestContext
-  // requires a plain Record<string, string> for has/missing cookie evaluation
-  // (config-matchers.ts uses obj[key] not Map.get()). Convert here.
-  const cookiesRecord = Object.fromEntries(ctx.cookies);
-  return {
-    headers: ctx.headers,
-    cookies: cookiesRecord,
-    query: url.searchParams,
-    host: normalizeHost(ctx.headers.get("host"), url.hostname),
-  };
-}
-
 /**
  * Maximum server-action request body size.
  * Configurable via experimental.serverActions.bodySizeLimit in next.config.
@@ -2999,371 +2515,149 @@ const rootParamNamesMap = {
 
 };
 
-export default async function handler(request, ctx) {
-  
-  // Wrap the entire request in a single unified ALS scope for per-request
-  // isolation. All state modules (headers, navigation, cache, fetch-cache,
-  // execution-context) read from this store via isInsideUnifiedScope().
-  const headersCtx = headersContextFromRequest(request);
-  const __uCtx = _createUnifiedCtx({
-    headersContext: headersCtx,
-    executionContext: ctx ?? _getRequestExecutionContext() ?? null,
-    unstableCacheRevalidation: "background",
-  });
-  return _runWithUnifiedCtx(__uCtx, () =>
-    __runWithPrerenderWorkUnit(async () => {
-    _ensureFetchPatch();
-    const __reqCtx = requestContextFromRequest(request);
-    // Per-request container for middleware state. Passed into
-    // _handleRequest which fills in .headers and .status;
-    // avoids module-level variables that race on Workers.
-    const _mwCtx = { headers: null, requestHeaders: null, status: null };
-    let response;
-    try {
-      response = await _handleRequest(request, __reqCtx, _mwCtx);
-    } catch (err) {
-      // Dev only: embed err.cause chain into err.message/err.stack so Vite's
-      // dev-server "Internal server error:" logger (which builds output from
-      // message + stack only) reveals the underlying root cause (ECONNREFUSED,
-      // role missing, workerd socket error, etc.) instead of dropping it.
-      // Skipped in production because Node's util.inspect / workerd's logger
-      // already render .cause natively, so flattening would double-print it.
-      // NODE_ENV is build-time-replaced by Vite, so the prod bundle compiles
-      // this branch out entirely.
-      if (process.env.NODE_ENV !== "production") {
-        __flattenErrorCauses(err);
-      }
-      throw err;
-    }
-    // Apply custom headers from next.config.js to non-redirect responses.
-    // Skip redirects (3xx) because Response.redirect() creates immutable headers,
-    // and Next.js doesn't apply custom headers to redirects anyway.
-    if (response && response.headers && !(response.status >= 300 && response.status < 400)) {
-      if (__configHeaders.length) {
-        const url = new URL(request.url);
-        let pathname;
-        try { pathname = __normalizePath(__normalizePathnameForRouteMatch(url.pathname)); } catch { pathname = url.pathname; }
-        
-        applyConfigHeadersToResponse(response.headers, {
-          configHeaders: __configHeaders,
-          pathname,
-          requestContext: __reqCtx,
-        });
-      }
-    }
-    return response;
-    }, { route: () => new URL(request.url).pathname })
-  );
-}
-
-async function _handleRequest(request, __reqCtx, _mwCtx) {
-  const __reqStart = process.env.NODE_ENV !== "production" ? performance.now() : 0;
-  // __reqStart is included in the timing header so the Node logging middleware
-  // can compute true compile time as: handlerStart - middlewareStart.
-  // Format: "handlerStart,compileMs,renderMs" - all as integers (ms). Dev-only.
-  const url = new URL(request.url);
-
-  // ── Cross-origin request protection (dev only) ─────────────────────
-  // Block requests from non-localhost origins to prevent data exfiltration.
-  // Skipped in production — Vite replaces NODE_ENV at build time.
-  if (process.env.NODE_ENV !== "production") {
-    const __originBlock = __validateDevRequestOrigin(request);
-    if (__originBlock) return __originBlock;
-  }
-
-  // Guard against protocol-relative URL open redirects (see request-pipeline.ts).
-  const __protoGuard = guardProtocolRelativeUrl(url.pathname);
-  if (__protoGuard) return __protoGuard;
-
-  // Decode percent-encoding segment-wise and normalize pathname to canonical form.
-  // This preserves encoded path delimiters like %2F within a single segment.
-  // __normalizePath collapses //foo///bar → /foo/bar, resolves . and .. segments.
-  let decodedUrlPathname;
-  try { decodedUrlPathname = __normalizePathnameForRouteMatchStrict(url.pathname); } catch (e) {
-    return new Response("Bad Request", { status: 400 });
-  }
-  let pathname = __normalizePath(decodedUrlPathname);
-
-  
-
-  const __prerenderEndpointResponse = await __handleAppPrerenderEndpoint(request, {
-    isPrerenderEnabled() {
-      return process.env.VINEXT_PRERENDER === "1";
-    },
-
-    pathname,
-    rootParamNamesByPattern: rootParamNamesMap,
-    staticParamsMap: generateStaticParamsMap,
-  });
-  if (__prerenderEndpointResponse) return __prerenderEndpointResponse;
-
-  // Trailing slash normalization (redirect to canonical form)
-  const __tsRedirect = normalizeTrailingSlash(pathname, __basePath, __trailingSlash, url.search);
-  if (__tsRedirect) return __tsRedirect;
-
-  // ── Apply redirects from next.config.js ───────────────────────────────
-  if (__configRedirects.length) {
-    // Strip .rsc suffix before matching redirect rules - RSC (client-side nav) requests
-    // arrive as /some/path.rsc but redirect patterns are defined without it (e.g.
-    // /some/path). Without this, soft-nav fetches bypass all config redirects.
-    const __redirPathname = pathname.endsWith(".rsc") ? pathname.slice(0, -4) : pathname;
-    const __redir = matchRedirect(__redirPathname, __configRedirects, __reqCtx);
-    if (__redir) {
-      const __redirDest = sanitizeDestination(
-        __basePath &&
-          !isExternalUrl(__redir.destination) &&
-          !hasBasePath(__redir.destination, __basePath)
-          ? __basePath + __redir.destination
-          : __redir.destination
-      );
-      return new Response(null, {
-        status: __redir.permanent ? 308 : 307,
-        headers: { Location: __redirDest },
-      });
-    }
-  }
-
-  const isRscRequest = pathname.endsWith(".rsc") || request.headers.get("accept")?.includes("text/x-component");
-  // Read mounted-slots header once at the handler scope and thread it through
-  // every buildPageElements call site. Previously both the handler and
-  // buildPageElements read and normalized it independently, which invited
-  // silent drift if a future refactor changed only one path.
-  const __mountedSlotsHeader = __normalizeMountedSlotsHeader(
-    request.headers.get("x-vinext-mounted-slots"),
-  );
-  const interceptionContextHeader = request.headers.get("X-Vinext-Interception-Context")?.replaceAll(" ", "") || null;
-  let cleanPathname = pathname.replace(/\\.rsc$/, "");
-
-  // Middleware response headers and custom rewrite status are stored in
-  // _mwCtx (per-request container) so handler() can merge them into
-  // every response path without module-level state that races on Workers.
-
-  
-
-  const _scriptNonce = __getScriptNonceFromHeaderSources(request.headers, _mwCtx.headers);
-
-  // Build post-middleware request context for afterFiles/fallback rewrites.
-  // These run after middleware in the App Router execution order and should
-  // evaluate has/missing conditions against middleware-modified headers.
-  // When no middleware is present, this falls back to requestContextFromRequest.
-  const __postMwReqCtx = __buildPostMwRequestContext(request);
-
-  // ── Apply beforeFiles rewrites from next.config.js ────────────────────
-  // In App Router execution order, beforeFiles runs after middleware so that
-  // has/missing conditions can evaluate against middleware-modified headers.
-  if (__configRewrites.beforeFiles && __configRewrites.beforeFiles.length) {
-    const __rewritten = matchRewrite(cleanPathname, __configRewrites.beforeFiles, __postMwReqCtx);
-    if (__rewritten) {
-      if (isExternalUrl(__rewritten)) {
-        __clearRequestContext();
-        return proxyExternalRequest(request, __rewritten);
-      }
-      cleanPathname = __rewritten;
-    }
-  }
-
-  // ── Image optimization passthrough (dev mode — no transformation) ───────
-  if (cleanPathname === "/_vinext/image") {
-    const __imgResult = validateImageUrl(url.searchParams.get("url"), request.url);
-    if (__imgResult instanceof Response) return __imgResult;
-    // In dev, redirect to the original asset URL so Vite's static serving handles it.
-    return Response.redirect(new URL(__imgResult, url.origin).href, 302);
-  }
-
-  const metadataRouteResponse = await __handleMetadataRouteRequest({
-    metadataRoutes,
-    cleanPathname,
-    makeThenableParams,
-  });
-  if (metadataRouteResponse) return metadataRouteResponse;
-
-  // Serve public/ files as filesystem routes after middleware and before
-  // afterFiles/fallback rewrites, matching Next.js routing semantics.
-  const __publicFileResponse = resolvePublicFileRoute({
-    cleanPathname,
-    middlewareContext: _mwCtx,
-    pathname,
-    publicFiles: __publicFiles,
-    request,
-  });
-  if (__publicFileResponse) {
+export default __createAppRscHandler({
+  basePath: __basePath,
+  clearRequestContext() {
     __clearRequestContext();
-    return __publicFileResponse;
-  }
-
-  // Set navigation context for Server Components.
-  // Note: Headers context is already set by runWithRequestContext in the handler wrapper.
-  setNavigationContext({
-    pathname: cleanPathname,
-    searchParams: url.searchParams,
-    params: {},
-  });
-
-  // Handle server action POST requests
-  const actionId = request.headers.get("x-rsc-action") ?? request.headers.get("next-action");
-  const actionContentType = request.headers.get("content-type") || "";
-  const progressiveActionResponse = await __handleProgressiveServerActionRequest({
-    actionId,
-    allowedOrigins: __allowedOrigins,
+  },
+  configHeaders: __configHeaders,
+  configRedirects: __configRedirects,
+  configRewrites: __configRewrites,
+  dispatchMatchedPage({
     cleanPathname,
-    clearRequestContext() {
-      __clearRequestContext();
-    },
-    contentType: actionContentType,
-    decodeAction,
-    getAndClearPendingCookies,
-    getDraftModeCookieHeader,
-    maxActionBodySize: __MAX_ACTION_BODY_SIZE,
-    middlewareHeaders: _mwCtx.headers,
-    readFormDataWithLimit: __readFormDataWithLimit,
-    reportRequestError: _reportRequestError,
-    request,
-    setHeadersAccessPhase,
-  });
-  if (progressiveActionResponse) return progressiveActionResponse;
-
-  const serverActionResponse = await __handleServerActionRscRequest({
-    actionId,
-    allowedOrigins: __allowedOrigins,
-    buildPageElement({
-      route: actionRoute,
-      params: actionParams,
-      cleanPathname: actionCleanPathname,
-      interceptOpts,
-      searchParams,
-      isRscRequest: actionIsRscRequest,
-      request: actionRequest,
-      mountedSlotsHeader,
-    }) {
-      return buildPageElements(actionRoute, actionParams, actionCleanPathname, {
-        opts: interceptOpts,
-        searchParams,
-        isRscRequest: actionIsRscRequest,
-        request: actionRequest,
-        mountedSlotsHeader,
-      });
-    },
-    cleanPathname,
-    clearRequestContext() {
-      __clearRequestContext();
-    },
-    contentType: actionContentType,
-    createNotFoundElement(actionRouteId) {
-      return {
-        [__APP_INTERCEPTION_CONTEXT_KEY]: null,
-        __route: actionRouteId,
-        __rootLayout: null,
-        [actionRouteId]: createElement("div", null, "Page not found"),
-      };
-    },
-    createPayloadRouteId(pathnameToRender, interceptionContext) {
-      return __createAppPayloadRouteId(pathnameToRender, interceptionContext);
-    },
-    createRscOnErrorHandler(actionRequest, actionPathname, routePattern) {
-      return createRscOnErrorHandler(actionRequest, actionPathname, routePattern);
-    },
-    createTemporaryReferenceSet,
-    decodeReply,
-    findIntercept(pathnameToMatch) {
-      return findIntercept(pathnameToMatch, interceptionContextHeader);
-    },
-    getAndClearPendingCookies,
-    getDraftModeCookieHeader,
-    getRouteParamNames(sourceRoute) {
-      return sourceRoute.params;
-    },
-    getSourceRoute(sourceRouteIndex) {
-      return routes[sourceRouteIndex];
-    },
+    handlerStart,
+    interceptionContext,
     isRscRequest,
-    loadServerAction,
-    matchRoute(pathnameToMatch) {
-      return matchRoute(pathnameToMatch);
-    },
-    maxActionBodySize: __MAX_ACTION_BODY_SIZE,
-    middlewareHeaders: _mwCtx.headers,
-    middlewareStatus: _mwCtx.status,
-    mountedSlotsHeader: __mountedSlotsHeader,
-    readBodyWithLimit: __readBodyWithLimit,
-    readFormDataWithLimit: __readFormDataWithLimit,
-    renderToReadableStream,
-    reportRequestError: _reportRequestError,
-    request,
-    sanitizeErrorForClient(error) {
-      return __sanitizeErrorForClient(error);
-    },
-    searchParams: url.searchParams,
-    setHeadersAccessPhase,
-    setNavigationContext,
-    toInterceptOpts(intercept) {
-      return {
-        interceptionContext: interceptionContextHeader,
-        interceptLayouts: intercept.interceptLayouts,
-        interceptSlotKey: intercept.slotKey,
-        interceptPage: intercept.page,
-        interceptParams: intercept.matchedParams,
-      };
-    },
-  });
-  if (serverActionResponse) return serverActionResponse;
-
-  // ── Apply afterFiles rewrites from next.config.js ──────────────────────
-  if (__configRewrites.afterFiles && __configRewrites.afterFiles.length) {
-    const __afterRewritten = matchRewrite(cleanPathname, __configRewrites.afterFiles, __postMwReqCtx);
-    if (__afterRewritten) {
-      if (isExternalUrl(__afterRewritten)) {
-        __clearRequestContext();
-        return proxyExternalRequest(request, __afterRewritten);
-      }
-      cleanPathname = __afterRewritten;
-    }
-  }
-
-  let match = matchRoute(cleanPathname);
-
-  // ── Fallback rewrites from next.config.js (if no route matched) ───────
-  if (!match && __configRewrites.fallback && __configRewrites.fallback.length) {
-    const __fallbackRewritten = matchRewrite(cleanPathname, __configRewrites.fallback, __postMwReqCtx);
-    if (__fallbackRewritten) {
-      if (isExternalUrl(__fallbackRewritten)) {
-        __clearRequestContext();
-        return proxyExternalRequest(request, __fallbackRewritten);
-      }
-      cleanPathname = __fallbackRewritten;
-      match = matchRoute(cleanPathname);
-    }
-  }
-
-  if (!match) {
-    
-    // Render custom not-found page if available, otherwise plain 404
-    const notFoundResponse = await renderNotFoundPage(null, isRscRequest, request, undefined, _scriptNonce, _mwCtx);
-    if (notFoundResponse) return notFoundResponse;
-    __clearRequestContext();
-    const notFoundHeaders = new Headers();
-    __mergeMiddlewareResponseHeaders(notFoundHeaders, _mwCtx.headers);
-    return new Response("Not Found", { status: 404, headers: notFoundHeaders });
-  }
-
-  const { route, params } = match;
-
-  // Update navigation context with matched params
-  setNavigationContext({
-    pathname: cleanPathname,
-    searchParams: url.searchParams,
+    middlewareContext,
+    mountedSlotsHeader,
     params,
-  });
-  __setRootParams(__pickRootParams(params, route.rootParamNames));
-
-  // Handle route.ts API handlers
-  if (route.routeHandler) {
-    setCurrentFetchSoftTags(
-      buildPageCacheTags(cleanPathname, [], route.routeSegments, "route"),
-    );
+    request,
+    route,
+    scriptNonce,
+    searchParams,
+  }) {
+    const PageComponent = route.page?.default;
+    const _asyncRouteParams = makeThenableParams(params);
+    return __dispatchAppPage({
+      buildPageElement(targetRoute, targetParams, targetOpts, targetSearchParams) {
+        return buildPageElements(targetRoute, targetParams, cleanPathname, {
+          opts: targetOpts,
+          searchParams: targetSearchParams,
+          isRscRequest,
+          request,
+          mountedSlotsHeader,
+        });
+      },
+      cleanPathname,
+      clearRequestContext() {
+        __clearRequestContext();
+      },
+      createRscOnErrorHandler(pathname, routePath) {
+        return createRscOnErrorHandler(request, pathname, routePath);
+      },
+      debugClassification: __classDebug,
+      dynamicConfig: route.page?.dynamic,
+      dynamicParamsConfig: route.page?.dynamicParams,
+      findIntercept(pathname) {
+        return findIntercept(pathname, interceptionContext);
+      },
+      generateStaticParams: route.page?.generateStaticParams,
+      getFontLinks: _getSSRFontLinks,
+      getFontPreloads: _getSSRFontPreloads,
+      getFontStyles: _getSSRFontStyles,
+      getNavigationContext: _getNavigationContext,
+      getSourceRoute(sourceRouteIndex) {
+        return routes[sourceRouteIndex];
+      },
+      hasGenerateStaticParams: typeof route.page?.generateStaticParams === "function",
+      hasPageDefaultExport: !!PageComponent,
+      hasPageModule: !!route.page,
+      handlerStart,
+      interceptionContext,
+      isProduction: process.env.NODE_ENV === "production",
+      isRscRequest,
+      isrDebug: __isrDebug,
+      isrGet: __isrGet,
+      isrHtmlKey: __isrHtmlKey,
+      isrRscKey: __isrRscKey,
+      isrSet: __isrSet,
+      loadSsrHandler() {
+        return import.meta.viteRsc.loadModule("ssr", "index");
+      },
+      middlewareContext,
+      mountedSlotsHeader,
+      params,
+      probeLayoutAt(li) {
+        const LayoutComp = route.layouts[li]?.default;
+        if (!LayoutComp) return null;
+        return LayoutComp({
+          params: makeThenableParams(__resolveAppPageSegmentParams(
+            route.routeSegments,
+            route.layoutTreePositions?.[li] ?? 0,
+            params,
+          )),
+          children: null,
+        });
+      },
+      probePage() {
+        if (!PageComponent) return null;
+        const _asyncSearchParams = makeThenableParams(
+          __collectAppPageSearchParams(searchParams).searchParamsObject,
+        );
+        return PageComponent({ params: _asyncRouteParams, searchParams: _asyncSearchParams });
+      },
+      renderErrorBoundaryPage(renderErr) {
+        return renderErrorBoundaryPage(
+          route,
+          renderErr,
+          isRscRequest,
+          request,
+          params,
+          scriptNonce,
+          middlewareContext,
+        );
+      },
+      renderHttpAccessFallbackPage(statusCode, opts, currentMiddlewareContext) {
+        return renderHTTPAccessFallbackPage(
+          route,
+          statusCode,
+          isRscRequest,
+          request,
+          opts,
+          scriptNonce,
+          currentMiddlewareContext,
+        );
+      },
+      renderToReadableStream,
+      request,
+      revalidateSeconds: typeof route.page?.revalidate === "number" ? route.page.revalidate : null,
+      rootForbiddenModule,
+      rootNotFoundModule,
+      rootUnauthorizedModule,
+      route,
+      runWithSuppressedHookWarning(probe) {
+        return _suppressHookWarningAls.run(true, probe);
+      },
+      scheduleBackgroundRegeneration(key, renderFn, errorContext) {
+        __triggerBackgroundRegeneration(key, renderFn, errorContext);
+      },
+      scriptNonce,
+      searchParams,
+      setNavigationContext,
+    });
+  },
+  dispatchMatchedRouteHandler({
+    cleanPathname,
+    middlewareContext,
+    params,
+    request,
+    route,
+    searchParams,
+  }) {
     return __dispatchAppRouteHandler({
       basePath: __basePath,
       cleanPathname,
-      clearRequestContext: function() {
+      clearRequestContext() {
         __clearRequestContext();
       },
       i18n: __i18nConfig,
@@ -3371,8 +2665,8 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       isrGet: __isrGet,
       isrRouteKey: __isrRouteKey,
       isrSet: __isrSet,
-      middlewareContext: _mwCtx,
-      middlewareRequestHeaders: _mwCtx.requestHeaders,
+      middlewareContext,
+      middlewareRequestHeaders: middlewareContext.requestHeaders,
       params,
       request,
       route: {
@@ -3381,104 +2675,153 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         routeSegments: route.routeSegments,
       },
       scheduleBackgroundRegeneration: __triggerBackgroundRegeneration,
-      searchParams: url.searchParams,
+      searchParams,
     });
-  }
-
-  const PageComponent = route.page?.default;
-  const _asyncRouteParams = makeThenableParams(params);
-  return __dispatchAppPage({
-    buildPageElement(targetRoute, targetParams, targetOpts, targetSearchParams) {
-      return buildPageElements(targetRoute, targetParams, cleanPathname, {
-        opts: targetOpts,
-        searchParams: targetSearchParams,
-        isRscRequest,
-        request,
-        mountedSlotsHeader: __mountedSlotsHeader,
-      });
-    },
+  },
+  
+  handleProgressiveActionRequest({
+    actionId,
     cleanPathname,
-    clearRequestContext() {
-      __clearRequestContext();
-    },
-    createRscOnErrorHandler(pathname, routePath) {
-      return createRscOnErrorHandler(request, pathname, routePath);
-    },
-    debugClassification: __classDebug,
-    dynamicConfig: route.page?.dynamic,
-    dynamicParamsConfig: route.page?.dynamicParams,
-    findIntercept(pathname) {
-      return findIntercept(pathname, interceptionContextHeader);
-    },
-    generateStaticParams: route.page?.generateStaticParams,
-    getFontLinks: _getSSRFontLinks,
-    getFontPreloads: _getSSRFontPreloads,
-    getFontStyles: _getSSRFontStyles,
-    getNavigationContext: _getNavigationContext,
-    getSourceRoute(sourceRouteIndex) {
-      return routes[sourceRouteIndex];
-    },
-    hasGenerateStaticParams: typeof route.page?.generateStaticParams === "function",
-    hasPageDefaultExport: !!PageComponent,
-    hasPageModule: !!route.page,
-    handlerStart: __reqStart,
-    interceptionContext: interceptionContextHeader,
-    isProduction: process.env.NODE_ENV === "production",
-    isRscRequest,
-    isrDebug: __isrDebug,
-    isrGet: __isrGet,
-    isrHtmlKey: __isrHtmlKey,
-    isrRscKey: __isrRscKey,
-    isrSet: __isrSet,
-    loadSsrHandler() {
-      return import.meta.viteRsc.loadModule("ssr", "index");
-    },
-    middlewareContext: _mwCtx,
-    mountedSlotsHeader: __mountedSlotsHeader,
-    params,
-    probeLayoutAt(li) {
-      const LayoutComp = route.layouts[li]?.default;
-      if (!LayoutComp) return null;
-      return LayoutComp({
-        params: makeThenableParams(__resolveAppPageSegmentParams(
-          route.routeSegments,
-          route.layoutTreePositions?.[li] ?? 0,
-          params,
-        )),
-        children: null,
-      });
-    },
-    probePage() {
-      if (!PageComponent) return null;
-      const _asyncSearchParams = makeThenableParams(
-        __collectAppPageSearchParams(url.searchParams).searchParamsObject,
-      );
-      return PageComponent({ params: _asyncRouteParams, searchParams: _asyncSearchParams });
-    },
-    renderErrorBoundaryPage(renderErr) {
-      return renderErrorBoundaryPage(route, renderErr, isRscRequest, request, params, _scriptNonce, _mwCtx);
-    },
-    renderHttpAccessFallbackPage(statusCode, opts, middlewareContext) {
-      return renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, opts, _scriptNonce, middlewareContext);
-    },
-    renderToReadableStream,
+    contentType,
+    middlewareContext,
     request,
-    revalidateSeconds: typeof route.page?.revalidate === "number" ? route.page.revalidate : null,
-    rootForbiddenModule,
-    rootNotFoundModule,
-    rootUnauthorizedModule,
-    route,
-    runWithSuppressedHookWarning(probe) {
-      return _suppressHookWarningAls.run(true, probe);
-    },
-    scheduleBackgroundRegeneration(key, renderFn, errorContext) {
-      __triggerBackgroundRegeneration(key, renderFn, errorContext);
-    },
-    scriptNonce: _scriptNonce,
-    searchParams: url.searchParams,
-    setNavigationContext,
-  });
-}
+  }) {
+    return __handleProgressiveServerActionRequest({
+      actionId,
+      allowedOrigins: __allowedOrigins,
+      cleanPathname,
+      clearRequestContext() {
+        __clearRequestContext();
+      },
+      contentType,
+      decodeAction,
+      getAndClearPendingCookies,
+      getDraftModeCookieHeader,
+      maxActionBodySize: __MAX_ACTION_BODY_SIZE,
+      middlewareHeaders: middlewareContext.headers,
+      readFormDataWithLimit: __readFormDataWithLimit,
+      reportRequestError: _reportRequestError,
+      request,
+      setHeadersAccessPhase,
+    });
+  },
+  handleServerActionRequest({
+    actionId,
+    cleanPathname,
+    contentType,
+    interceptionContext,
+    isRscRequest,
+    middlewareContext,
+    mountedSlotsHeader,
+    request,
+    searchParams,
+  }) {
+    return __handleServerActionRscRequest({
+      actionId,
+      allowedOrigins: __allowedOrigins,
+      buildPageElement({
+        route: actionRoute,
+        params: actionParams,
+        cleanPathname: actionCleanPathname,
+        interceptOpts,
+        searchParams: actionSearchParams,
+        isRscRequest: actionIsRscRequest,
+        request: actionRequest,
+        mountedSlotsHeader: actionMountedSlotsHeader,
+      }) {
+        return buildPageElements(actionRoute, actionParams, actionCleanPathname, {
+          opts: interceptOpts,
+          searchParams: actionSearchParams,
+          isRscRequest: actionIsRscRequest,
+          request: actionRequest,
+          mountedSlotsHeader: actionMountedSlotsHeader,
+        });
+      },
+      cleanPathname,
+      clearRequestContext() {
+        __clearRequestContext();
+      },
+      contentType,
+      createNotFoundElement(actionRouteId) {
+        return {
+          [__APP_INTERCEPTION_CONTEXT_KEY]: null,
+          __route: actionRouteId,
+          __rootLayout: null,
+          [actionRouteId]: createElement("div", null, "Page not found"),
+        };
+      },
+      createPayloadRouteId(pathnameToRender, currentInterceptionContext) {
+        return __createAppPayloadRouteId(pathnameToRender, currentInterceptionContext);
+      },
+      createRscOnErrorHandler(actionRequest, actionPathname, routePattern) {
+        return createRscOnErrorHandler(actionRequest, actionPathname, routePattern);
+      },
+      createTemporaryReferenceSet,
+      decodeReply,
+      findIntercept(pathnameToMatch) {
+        return findIntercept(pathnameToMatch, interceptionContext);
+      },
+      getAndClearPendingCookies,
+      getDraftModeCookieHeader,
+      getRouteParamNames(sourceRoute) {
+        return sourceRoute.params;
+      },
+      getSourceRoute(sourceRouteIndex) {
+        return routes[sourceRouteIndex];
+      },
+      isRscRequest,
+      loadServerAction,
+      matchRoute(pathnameToMatch) {
+        return matchRoute(pathnameToMatch);
+      },
+      maxActionBodySize: __MAX_ACTION_BODY_SIZE,
+      middlewareHeaders: middlewareContext.headers,
+      middlewareStatus: middlewareContext.status,
+      mountedSlotsHeader,
+      readBodyWithLimit: __readBodyWithLimit,
+      readFormDataWithLimit: __readFormDataWithLimit,
+      renderToReadableStream,
+      reportRequestError: _reportRequestError,
+      request,
+      sanitizeErrorForClient(error) {
+        return __sanitizeErrorForClient(error);
+      },
+      searchParams,
+      setHeadersAccessPhase,
+      setNavigationContext,
+      toInterceptOpts(intercept) {
+        return {
+          interceptionContext,
+          interceptLayouts: intercept.interceptLayouts,
+          interceptSlotKey: intercept.slotKey,
+          interceptPage: intercept.page,
+          interceptParams: intercept.matchedParams,
+        };
+      },
+    });
+  },
+  i18nConfig: __i18nConfig,
+  
+  makeThenableParams,
+  matchRoute(pathnameToMatch) {
+    return matchRoute(pathnameToMatch);
+  },
+  metadataRoutes,
+  middlewareIsProxy: false,
+  middlewareModule: null,
+  publicFiles: __publicFiles,
+  renderNotFoundPage({ isRscRequest, matchedParams, middlewareContext, request, route, scriptNonce }) {
+    return renderNotFoundPage(route, isRscRequest, request, matchedParams, scriptNonce, middlewareContext);
+  },
+  
+  rootParamNamesMap,
+  setNavigationContext,
+  staticParamsMap: generateStaticParamsMap,
+  trailingSlash: __trailingSlash,
+  validateDevRequestOrigin(request) {
+    return __validateDevRequestOrigin(request);
+  },
+});
 
 if (import.meta.hot) {
   import.meta.hot.accept();
@@ -3506,17 +2849,15 @@ function renderToReadableStream(model, options) {
 }
 import { createElement } from "react";
 import { setNavigationContext as _setNavigationContextOrig, getNavigationContext as _getNavigationContext } from "next/navigation";
-import { setHeadersContext, headersContextFromRequest, getDraftModeCookieHeader, getAndClearPendingCookies, consumeDynamicUsage, consumeInvalidDynamicUsageError, markDynamicUsage, getHeadersContext, setHeadersAccessPhase } from "next/headers";
+import { setHeadersContext, getDraftModeCookieHeader, getAndClearPendingCookies, markDynamicUsage, setHeadersAccessPhase } from "next/headers";
 import { mergeMetadata, resolveModuleMetadata, mergeViewport, resolveModuleViewport } from "vinext/metadata";
 
 import * as _instrumentation from "/tmp/test/instrumentation.ts";
-import { handleMetadataRouteRequest as __handleMetadataRouteRequest } from "<ROOT>/packages/vinext/src/server/metadata-route-response.js";
-import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, isExternalUrl, proxyExternalRequest, sanitizeDestination } from "<ROOT>/packages/vinext/src/config/config-matchers.js";
-import { decodePathParams as __decodePathParams, normalizePath as __normalizePath } from "<ROOT>/packages/vinext/src/server/normalize-path.js";
-import { normalizePathnameForRouteMatch as __normalizePathnameForRouteMatch, normalizePathnameForRouteMatchStrict as __normalizePathnameForRouteMatchStrict } from "<ROOT>/packages/vinext/src/routing/utils.js";
+import { decodePathParams as __decodePathParams } from "<ROOT>/packages/vinext/src/server/normalize-path.js";
 import { buildRequestHeadersFromMiddlewareResponse as __buildRequestHeadersFromMiddlewareResponse } from "<ROOT>/packages/vinext/src/server/middleware-request-headers.js";
-import { applyConfigHeadersToResponse, resolvePublicFileRoute, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
-import { applyAppMiddleware as __applyAppMiddleware } from "<ROOT>/packages/vinext/src/server/app-middleware.js";
+import {
+  createAppRscHandler as __createAppRscHandler,
+} from "<ROOT>/packages/vinext/src/server/app-rsc-handler.js";
 import {
   dispatchAppRouteHandler as __dispatchAppRouteHandler,
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-dispatch.js";
@@ -3556,38 +2897,25 @@ import {
   resolveAppPageHead as __resolveAppPageHead,
 } from "<ROOT>/packages/vinext/src/server/app-page-head.js";
 import {
-  mergeMiddlewareResponseHeaders as __mergeMiddlewareResponseHeaders,
-} from "<ROOT>/packages/vinext/src/server/app-page-response.js";
-import {
   dispatchAppPage as __dispatchAppPage,
 } from "<ROOT>/packages/vinext/src/server/app-page-dispatch.js";
-import { getScriptNonceFromHeaderSources as __getScriptNonceFromHeaderSources } from "<ROOT>/packages/vinext/src/server/csp.js";
-import { buildPageCacheTags } from "<ROOT>/packages/vinext/src/server/implicit-tags.js";
-import { getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
-import { setRootParams as __setRootParams, pickRootParams as __pickRootParams } from "<ROOT>/packages/vinext/src/shims/root-params.js";
+import { setRootParams as __setRootParams } from "<ROOT>/packages/vinext/src/shims/root-params.js";
 import { makeThenableParams } from "<ROOT>/packages/vinext/src/shims/thenable-params.js";
-import { ensureFetchPatch as _ensureFetchPatch, setCurrentFetchSoftTags } from "vinext/fetch-cache";
+import { setCurrentFetchSoftTags } from "vinext/fetch-cache";
 import {
   createAppRscRouteMatcher as __createAppRscRouteMatcher,
 } from "<ROOT>/packages/vinext/src/server/app-rsc-route-matching.js";
-import {
-  handleAppPrerenderEndpoint as __handleAppPrerenderEndpoint,
-} from "<ROOT>/packages/vinext/src/server/app-prerender-endpoints.js";
 import {
   appIsrHtmlKey as __isrHtmlKey,
   appIsrRscKey as __isrRscKey,
   appIsrRouteKey as __isrRouteKey,
   isrGet as __isrGet,
   isrSet as __isrSet,
-  normalizeMountedSlotsHeader as __normalizeMountedSlotsHeader,
   triggerBackgroundRegeneration as __triggerBackgroundRegeneration,
 } from "<ROOT>/packages/vinext/src/server/isr-cache.js";
 // Import server-only state module to register ALS-backed accessors.
 import "vinext/navigation-state";
-import { runWithPrerenderWorkUnit as __runWithPrerenderWorkUnit } from "<ROOT>/packages/vinext/src/server/prerender-work-unit-setup.js";
-import { runWithRequestContext as _runWithUnifiedCtx, createRequestContext as _createUnifiedCtx } from "vinext/unified-request-context";
 import { reportRequestError as _reportRequestError } from "vinext/instrumentation";
-import { flattenErrorCauses as __flattenErrorCauses } from "<ROOT>/packages/vinext/src/utils/error-cause.js";
 import { getSSRFontLinks as _getSSRFontLinks, getSSRFontStyles as _getSSRFontStylesGoogle, getSSRFontPreloads as _getSSRFontPreloadsGoogle } from "next/font/google";
 import { getSSRFontStyles as _getSSRFontStylesLocal, getSSRFontPreloads as _getSSRFontPreloadsLocal } from "next/font/local";
 function _getSSRFontStyles() { return [..._getSSRFontStylesGoogle(), ..._getSSRFontStylesLocal()]; }
@@ -4135,35 +3463,6 @@ function __validateDevRequestOrigin(request) {
 }
 
 
-// ── Config pattern matching, redirects, rewrites, headers, CSRF validation,
-//    external URL proxy, cookie parsing, and request context are imported from
-//    config-matchers.ts and request-pipeline.ts (see import statements above).
-//    This eliminates ~250 lines of duplicated inline code and ensures the
-//    single-pass tokenizer in config-matchers.ts is used consistently
-//    (fixing the chained .replace() divergence flagged by CodeQL).
-
-/**
- * Build a request context from the live ALS HeadersContext, which reflects
- * any x-middleware-request-* header mutations applied by middleware.
- * Used for afterFiles and fallback rewrite has/missing evaluation — these
- * run after middleware in the App Router execution order.
- */
-function __buildPostMwRequestContext(request) {
-  const url = new URL(request.url);
-  const ctx = getHeadersContext();
-  if (!ctx) return requestContextFromRequest(request);
-  // ctx.cookies is a Map<string, string> (HeadersContext), but RequestContext
-  // requires a plain Record<string, string> for has/missing cookie evaluation
-  // (config-matchers.ts uses obj[key] not Map.get()). Convert here.
-  const cookiesRecord = Object.fromEntries(ctx.cookies);
-  return {
-    headers: ctx.headers,
-    cookies: cookiesRecord,
-    query: url.searchParams,
-    host: normalizeHost(ctx.headers.get("host"), url.hostname),
-  };
-}
-
 /**
  * Maximum server-action request body size.
  * Configurable via experimental.serverActions.bodySizeLimit in next.config.
@@ -4188,374 +3487,149 @@ const rootParamNamesMap = {
 
 };
 
-export default async function handler(request, ctx) {
-  // Ensure instrumentation.register() has run before handling the first request.
-  // This is a no-op after the first call (guarded by __instrumentationInitialized).
-  await __ensureInstrumentation();
-  
-  // Wrap the entire request in a single unified ALS scope for per-request
-  // isolation. All state modules (headers, navigation, cache, fetch-cache,
-  // execution-context) read from this store via isInsideUnifiedScope().
-  const headersCtx = headersContextFromRequest(request);
-  const __uCtx = _createUnifiedCtx({
-    headersContext: headersCtx,
-    executionContext: ctx ?? _getRequestExecutionContext() ?? null,
-    unstableCacheRevalidation: "background",
-  });
-  return _runWithUnifiedCtx(__uCtx, () =>
-    __runWithPrerenderWorkUnit(async () => {
-    _ensureFetchPatch();
-    const __reqCtx = requestContextFromRequest(request);
-    // Per-request container for middleware state. Passed into
-    // _handleRequest which fills in .headers and .status;
-    // avoids module-level variables that race on Workers.
-    const _mwCtx = { headers: null, requestHeaders: null, status: null };
-    let response;
-    try {
-      response = await _handleRequest(request, __reqCtx, _mwCtx);
-    } catch (err) {
-      // Dev only: embed err.cause chain into err.message/err.stack so Vite's
-      // dev-server "Internal server error:" logger (which builds output from
-      // message + stack only) reveals the underlying root cause (ECONNREFUSED,
-      // role missing, workerd socket error, etc.) instead of dropping it.
-      // Skipped in production because Node's util.inspect / workerd's logger
-      // already render .cause natively, so flattening would double-print it.
-      // NODE_ENV is build-time-replaced by Vite, so the prod bundle compiles
-      // this branch out entirely.
-      if (process.env.NODE_ENV !== "production") {
-        __flattenErrorCauses(err);
-      }
-      throw err;
-    }
-    // Apply custom headers from next.config.js to non-redirect responses.
-    // Skip redirects (3xx) because Response.redirect() creates immutable headers,
-    // and Next.js doesn't apply custom headers to redirects anyway.
-    if (response && response.headers && !(response.status >= 300 && response.status < 400)) {
-      if (__configHeaders.length) {
-        const url = new URL(request.url);
-        let pathname;
-        try { pathname = __normalizePath(__normalizePathnameForRouteMatch(url.pathname)); } catch { pathname = url.pathname; }
-        
-        applyConfigHeadersToResponse(response.headers, {
-          configHeaders: __configHeaders,
-          pathname,
-          requestContext: __reqCtx,
-        });
-      }
-    }
-    return response;
-    }, { route: () => new URL(request.url).pathname })
-  );
-}
-
-async function _handleRequest(request, __reqCtx, _mwCtx) {
-  const __reqStart = process.env.NODE_ENV !== "production" ? performance.now() : 0;
-  // __reqStart is included in the timing header so the Node logging middleware
-  // can compute true compile time as: handlerStart - middlewareStart.
-  // Format: "handlerStart,compileMs,renderMs" - all as integers (ms). Dev-only.
-  const url = new URL(request.url);
-
-  // ── Cross-origin request protection (dev only) ─────────────────────
-  // Block requests from non-localhost origins to prevent data exfiltration.
-  // Skipped in production — Vite replaces NODE_ENV at build time.
-  if (process.env.NODE_ENV !== "production") {
-    const __originBlock = __validateDevRequestOrigin(request);
-    if (__originBlock) return __originBlock;
-  }
-
-  // Guard against protocol-relative URL open redirects (see request-pipeline.ts).
-  const __protoGuard = guardProtocolRelativeUrl(url.pathname);
-  if (__protoGuard) return __protoGuard;
-
-  // Decode percent-encoding segment-wise and normalize pathname to canonical form.
-  // This preserves encoded path delimiters like %2F within a single segment.
-  // __normalizePath collapses //foo///bar → /foo/bar, resolves . and .. segments.
-  let decodedUrlPathname;
-  try { decodedUrlPathname = __normalizePathnameForRouteMatchStrict(url.pathname); } catch (e) {
-    return new Response("Bad Request", { status: 400 });
-  }
-  let pathname = __normalizePath(decodedUrlPathname);
-
-  
-
-  const __prerenderEndpointResponse = await __handleAppPrerenderEndpoint(request, {
-    isPrerenderEnabled() {
-      return process.env.VINEXT_PRERENDER === "1";
-    },
-
-    pathname,
-    rootParamNamesByPattern: rootParamNamesMap,
-    staticParamsMap: generateStaticParamsMap,
-  });
-  if (__prerenderEndpointResponse) return __prerenderEndpointResponse;
-
-  // Trailing slash normalization (redirect to canonical form)
-  const __tsRedirect = normalizeTrailingSlash(pathname, __basePath, __trailingSlash, url.search);
-  if (__tsRedirect) return __tsRedirect;
-
-  // ── Apply redirects from next.config.js ───────────────────────────────
-  if (__configRedirects.length) {
-    // Strip .rsc suffix before matching redirect rules - RSC (client-side nav) requests
-    // arrive as /some/path.rsc but redirect patterns are defined without it (e.g.
-    // /some/path). Without this, soft-nav fetches bypass all config redirects.
-    const __redirPathname = pathname.endsWith(".rsc") ? pathname.slice(0, -4) : pathname;
-    const __redir = matchRedirect(__redirPathname, __configRedirects, __reqCtx);
-    if (__redir) {
-      const __redirDest = sanitizeDestination(
-        __basePath &&
-          !isExternalUrl(__redir.destination) &&
-          !hasBasePath(__redir.destination, __basePath)
-          ? __basePath + __redir.destination
-          : __redir.destination
-      );
-      return new Response(null, {
-        status: __redir.permanent ? 308 : 307,
-        headers: { Location: __redirDest },
-      });
-    }
-  }
-
-  const isRscRequest = pathname.endsWith(".rsc") || request.headers.get("accept")?.includes("text/x-component");
-  // Read mounted-slots header once at the handler scope and thread it through
-  // every buildPageElements call site. Previously both the handler and
-  // buildPageElements read and normalized it independently, which invited
-  // silent drift if a future refactor changed only one path.
-  const __mountedSlotsHeader = __normalizeMountedSlotsHeader(
-    request.headers.get("x-vinext-mounted-slots"),
-  );
-  const interceptionContextHeader = request.headers.get("X-Vinext-Interception-Context")?.replaceAll(" ", "") || null;
-  let cleanPathname = pathname.replace(/\\.rsc$/, "");
-
-  // Middleware response headers and custom rewrite status are stored in
-  // _mwCtx (per-request container) so handler() can merge them into
-  // every response path without module-level state that races on Workers.
-
-  
-
-  const _scriptNonce = __getScriptNonceFromHeaderSources(request.headers, _mwCtx.headers);
-
-  // Build post-middleware request context for afterFiles/fallback rewrites.
-  // These run after middleware in the App Router execution order and should
-  // evaluate has/missing conditions against middleware-modified headers.
-  // When no middleware is present, this falls back to requestContextFromRequest.
-  const __postMwReqCtx = __buildPostMwRequestContext(request);
-
-  // ── Apply beforeFiles rewrites from next.config.js ────────────────────
-  // In App Router execution order, beforeFiles runs after middleware so that
-  // has/missing conditions can evaluate against middleware-modified headers.
-  if (__configRewrites.beforeFiles && __configRewrites.beforeFiles.length) {
-    const __rewritten = matchRewrite(cleanPathname, __configRewrites.beforeFiles, __postMwReqCtx);
-    if (__rewritten) {
-      if (isExternalUrl(__rewritten)) {
-        __clearRequestContext();
-        return proxyExternalRequest(request, __rewritten);
-      }
-      cleanPathname = __rewritten;
-    }
-  }
-
-  // ── Image optimization passthrough (dev mode — no transformation) ───────
-  if (cleanPathname === "/_vinext/image") {
-    const __imgResult = validateImageUrl(url.searchParams.get("url"), request.url);
-    if (__imgResult instanceof Response) return __imgResult;
-    // In dev, redirect to the original asset URL so Vite's static serving handles it.
-    return Response.redirect(new URL(__imgResult, url.origin).href, 302);
-  }
-
-  const metadataRouteResponse = await __handleMetadataRouteRequest({
-    metadataRoutes,
-    cleanPathname,
-    makeThenableParams,
-  });
-  if (metadataRouteResponse) return metadataRouteResponse;
-
-  // Serve public/ files as filesystem routes after middleware and before
-  // afterFiles/fallback rewrites, matching Next.js routing semantics.
-  const __publicFileResponse = resolvePublicFileRoute({
-    cleanPathname,
-    middlewareContext: _mwCtx,
-    pathname,
-    publicFiles: __publicFiles,
-    request,
-  });
-  if (__publicFileResponse) {
+export default __createAppRscHandler({
+  basePath: __basePath,
+  clearRequestContext() {
     __clearRequestContext();
-    return __publicFileResponse;
-  }
-
-  // Set navigation context for Server Components.
-  // Note: Headers context is already set by runWithRequestContext in the handler wrapper.
-  setNavigationContext({
-    pathname: cleanPathname,
-    searchParams: url.searchParams,
-    params: {},
-  });
-
-  // Handle server action POST requests
-  const actionId = request.headers.get("x-rsc-action") ?? request.headers.get("next-action");
-  const actionContentType = request.headers.get("content-type") || "";
-  const progressiveActionResponse = await __handleProgressiveServerActionRequest({
-    actionId,
-    allowedOrigins: __allowedOrigins,
+  },
+  configHeaders: __configHeaders,
+  configRedirects: __configRedirects,
+  configRewrites: __configRewrites,
+  dispatchMatchedPage({
     cleanPathname,
-    clearRequestContext() {
-      __clearRequestContext();
-    },
-    contentType: actionContentType,
-    decodeAction,
-    getAndClearPendingCookies,
-    getDraftModeCookieHeader,
-    maxActionBodySize: __MAX_ACTION_BODY_SIZE,
-    middlewareHeaders: _mwCtx.headers,
-    readFormDataWithLimit: __readFormDataWithLimit,
-    reportRequestError: _reportRequestError,
-    request,
-    setHeadersAccessPhase,
-  });
-  if (progressiveActionResponse) return progressiveActionResponse;
-
-  const serverActionResponse = await __handleServerActionRscRequest({
-    actionId,
-    allowedOrigins: __allowedOrigins,
-    buildPageElement({
-      route: actionRoute,
-      params: actionParams,
-      cleanPathname: actionCleanPathname,
-      interceptOpts,
-      searchParams,
-      isRscRequest: actionIsRscRequest,
-      request: actionRequest,
-      mountedSlotsHeader,
-    }) {
-      return buildPageElements(actionRoute, actionParams, actionCleanPathname, {
-        opts: interceptOpts,
-        searchParams,
-        isRscRequest: actionIsRscRequest,
-        request: actionRequest,
-        mountedSlotsHeader,
-      });
-    },
-    cleanPathname,
-    clearRequestContext() {
-      __clearRequestContext();
-    },
-    contentType: actionContentType,
-    createNotFoundElement(actionRouteId) {
-      return {
-        [__APP_INTERCEPTION_CONTEXT_KEY]: null,
-        __route: actionRouteId,
-        __rootLayout: null,
-        [actionRouteId]: createElement("div", null, "Page not found"),
-      };
-    },
-    createPayloadRouteId(pathnameToRender, interceptionContext) {
-      return __createAppPayloadRouteId(pathnameToRender, interceptionContext);
-    },
-    createRscOnErrorHandler(actionRequest, actionPathname, routePattern) {
-      return createRscOnErrorHandler(actionRequest, actionPathname, routePattern);
-    },
-    createTemporaryReferenceSet,
-    decodeReply,
-    findIntercept(pathnameToMatch) {
-      return findIntercept(pathnameToMatch, interceptionContextHeader);
-    },
-    getAndClearPendingCookies,
-    getDraftModeCookieHeader,
-    getRouteParamNames(sourceRoute) {
-      return sourceRoute.params;
-    },
-    getSourceRoute(sourceRouteIndex) {
-      return routes[sourceRouteIndex];
-    },
+    handlerStart,
+    interceptionContext,
     isRscRequest,
-    loadServerAction,
-    matchRoute(pathnameToMatch) {
-      return matchRoute(pathnameToMatch);
-    },
-    maxActionBodySize: __MAX_ACTION_BODY_SIZE,
-    middlewareHeaders: _mwCtx.headers,
-    middlewareStatus: _mwCtx.status,
-    mountedSlotsHeader: __mountedSlotsHeader,
-    readBodyWithLimit: __readBodyWithLimit,
-    readFormDataWithLimit: __readFormDataWithLimit,
-    renderToReadableStream,
-    reportRequestError: _reportRequestError,
-    request,
-    sanitizeErrorForClient(error) {
-      return __sanitizeErrorForClient(error);
-    },
-    searchParams: url.searchParams,
-    setHeadersAccessPhase,
-    setNavigationContext,
-    toInterceptOpts(intercept) {
-      return {
-        interceptionContext: interceptionContextHeader,
-        interceptLayouts: intercept.interceptLayouts,
-        interceptSlotKey: intercept.slotKey,
-        interceptPage: intercept.page,
-        interceptParams: intercept.matchedParams,
-      };
-    },
-  });
-  if (serverActionResponse) return serverActionResponse;
-
-  // ── Apply afterFiles rewrites from next.config.js ──────────────────────
-  if (__configRewrites.afterFiles && __configRewrites.afterFiles.length) {
-    const __afterRewritten = matchRewrite(cleanPathname, __configRewrites.afterFiles, __postMwReqCtx);
-    if (__afterRewritten) {
-      if (isExternalUrl(__afterRewritten)) {
-        __clearRequestContext();
-        return proxyExternalRequest(request, __afterRewritten);
-      }
-      cleanPathname = __afterRewritten;
-    }
-  }
-
-  let match = matchRoute(cleanPathname);
-
-  // ── Fallback rewrites from next.config.js (if no route matched) ───────
-  if (!match && __configRewrites.fallback && __configRewrites.fallback.length) {
-    const __fallbackRewritten = matchRewrite(cleanPathname, __configRewrites.fallback, __postMwReqCtx);
-    if (__fallbackRewritten) {
-      if (isExternalUrl(__fallbackRewritten)) {
-        __clearRequestContext();
-        return proxyExternalRequest(request, __fallbackRewritten);
-      }
-      cleanPathname = __fallbackRewritten;
-      match = matchRoute(cleanPathname);
-    }
-  }
-
-  if (!match) {
-    
-    // Render custom not-found page if available, otherwise plain 404
-    const notFoundResponse = await renderNotFoundPage(null, isRscRequest, request, undefined, _scriptNonce, _mwCtx);
-    if (notFoundResponse) return notFoundResponse;
-    __clearRequestContext();
-    const notFoundHeaders = new Headers();
-    __mergeMiddlewareResponseHeaders(notFoundHeaders, _mwCtx.headers);
-    return new Response("Not Found", { status: 404, headers: notFoundHeaders });
-  }
-
-  const { route, params } = match;
-
-  // Update navigation context with matched params
-  setNavigationContext({
-    pathname: cleanPathname,
-    searchParams: url.searchParams,
+    middlewareContext,
+    mountedSlotsHeader,
     params,
-  });
-  __setRootParams(__pickRootParams(params, route.rootParamNames));
-
-  // Handle route.ts API handlers
-  if (route.routeHandler) {
-    setCurrentFetchSoftTags(
-      buildPageCacheTags(cleanPathname, [], route.routeSegments, "route"),
-    );
+    request,
+    route,
+    scriptNonce,
+    searchParams,
+  }) {
+    const PageComponent = route.page?.default;
+    const _asyncRouteParams = makeThenableParams(params);
+    return __dispatchAppPage({
+      buildPageElement(targetRoute, targetParams, targetOpts, targetSearchParams) {
+        return buildPageElements(targetRoute, targetParams, cleanPathname, {
+          opts: targetOpts,
+          searchParams: targetSearchParams,
+          isRscRequest,
+          request,
+          mountedSlotsHeader,
+        });
+      },
+      cleanPathname,
+      clearRequestContext() {
+        __clearRequestContext();
+      },
+      createRscOnErrorHandler(pathname, routePath) {
+        return createRscOnErrorHandler(request, pathname, routePath);
+      },
+      debugClassification: __classDebug,
+      dynamicConfig: route.page?.dynamic,
+      dynamicParamsConfig: route.page?.dynamicParams,
+      findIntercept(pathname) {
+        return findIntercept(pathname, interceptionContext);
+      },
+      generateStaticParams: route.page?.generateStaticParams,
+      getFontLinks: _getSSRFontLinks,
+      getFontPreloads: _getSSRFontPreloads,
+      getFontStyles: _getSSRFontStyles,
+      getNavigationContext: _getNavigationContext,
+      getSourceRoute(sourceRouteIndex) {
+        return routes[sourceRouteIndex];
+      },
+      hasGenerateStaticParams: typeof route.page?.generateStaticParams === "function",
+      hasPageDefaultExport: !!PageComponent,
+      hasPageModule: !!route.page,
+      handlerStart,
+      interceptionContext,
+      isProduction: process.env.NODE_ENV === "production",
+      isRscRequest,
+      isrDebug: __isrDebug,
+      isrGet: __isrGet,
+      isrHtmlKey: __isrHtmlKey,
+      isrRscKey: __isrRscKey,
+      isrSet: __isrSet,
+      loadSsrHandler() {
+        return import.meta.viteRsc.loadModule("ssr", "index");
+      },
+      middlewareContext,
+      mountedSlotsHeader,
+      params,
+      probeLayoutAt(li) {
+        const LayoutComp = route.layouts[li]?.default;
+        if (!LayoutComp) return null;
+        return LayoutComp({
+          params: makeThenableParams(__resolveAppPageSegmentParams(
+            route.routeSegments,
+            route.layoutTreePositions?.[li] ?? 0,
+            params,
+          )),
+          children: null,
+        });
+      },
+      probePage() {
+        if (!PageComponent) return null;
+        const _asyncSearchParams = makeThenableParams(
+          __collectAppPageSearchParams(searchParams).searchParamsObject,
+        );
+        return PageComponent({ params: _asyncRouteParams, searchParams: _asyncSearchParams });
+      },
+      renderErrorBoundaryPage(renderErr) {
+        return renderErrorBoundaryPage(
+          route,
+          renderErr,
+          isRscRequest,
+          request,
+          params,
+          scriptNonce,
+          middlewareContext,
+        );
+      },
+      renderHttpAccessFallbackPage(statusCode, opts, currentMiddlewareContext) {
+        return renderHTTPAccessFallbackPage(
+          route,
+          statusCode,
+          isRscRequest,
+          request,
+          opts,
+          scriptNonce,
+          currentMiddlewareContext,
+        );
+      },
+      renderToReadableStream,
+      request,
+      revalidateSeconds: typeof route.page?.revalidate === "number" ? route.page.revalidate : null,
+      rootForbiddenModule,
+      rootNotFoundModule,
+      rootUnauthorizedModule,
+      route,
+      runWithSuppressedHookWarning(probe) {
+        return _suppressHookWarningAls.run(true, probe);
+      },
+      scheduleBackgroundRegeneration(key, renderFn, errorContext) {
+        __triggerBackgroundRegeneration(key, renderFn, errorContext);
+      },
+      scriptNonce,
+      searchParams,
+      setNavigationContext,
+    });
+  },
+  dispatchMatchedRouteHandler({
+    cleanPathname,
+    middlewareContext,
+    params,
+    request,
+    route,
+    searchParams,
+  }) {
     return __dispatchAppRouteHandler({
       basePath: __basePath,
       cleanPathname,
-      clearRequestContext: function() {
+      clearRequestContext() {
         __clearRequestContext();
       },
       i18n: __i18nConfig,
@@ -4563,8 +3637,8 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       isrGet: __isrGet,
       isrRouteKey: __isrRouteKey,
       isrSet: __isrSet,
-      middlewareContext: _mwCtx,
-      middlewareRequestHeaders: _mwCtx.requestHeaders,
+      middlewareContext,
+      middlewareRequestHeaders: middlewareContext.requestHeaders,
       params,
       request,
       route: {
@@ -4573,104 +3647,153 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         routeSegments: route.routeSegments,
       },
       scheduleBackgroundRegeneration: __triggerBackgroundRegeneration,
-      searchParams: url.searchParams,
+      searchParams,
     });
-  }
-
-  const PageComponent = route.page?.default;
-  const _asyncRouteParams = makeThenableParams(params);
-  return __dispatchAppPage({
-    buildPageElement(targetRoute, targetParams, targetOpts, targetSearchParams) {
-      return buildPageElements(targetRoute, targetParams, cleanPathname, {
-        opts: targetOpts,
-        searchParams: targetSearchParams,
-        isRscRequest,
-        request,
-        mountedSlotsHeader: __mountedSlotsHeader,
-      });
-    },
+  },
+  ensureInstrumentation: __ensureInstrumentation,
+  handleProgressiveActionRequest({
+    actionId,
     cleanPathname,
-    clearRequestContext() {
-      __clearRequestContext();
-    },
-    createRscOnErrorHandler(pathname, routePath) {
-      return createRscOnErrorHandler(request, pathname, routePath);
-    },
-    debugClassification: __classDebug,
-    dynamicConfig: route.page?.dynamic,
-    dynamicParamsConfig: route.page?.dynamicParams,
-    findIntercept(pathname) {
-      return findIntercept(pathname, interceptionContextHeader);
-    },
-    generateStaticParams: route.page?.generateStaticParams,
-    getFontLinks: _getSSRFontLinks,
-    getFontPreloads: _getSSRFontPreloads,
-    getFontStyles: _getSSRFontStyles,
-    getNavigationContext: _getNavigationContext,
-    getSourceRoute(sourceRouteIndex) {
-      return routes[sourceRouteIndex];
-    },
-    hasGenerateStaticParams: typeof route.page?.generateStaticParams === "function",
-    hasPageDefaultExport: !!PageComponent,
-    hasPageModule: !!route.page,
-    handlerStart: __reqStart,
-    interceptionContext: interceptionContextHeader,
-    isProduction: process.env.NODE_ENV === "production",
-    isRscRequest,
-    isrDebug: __isrDebug,
-    isrGet: __isrGet,
-    isrHtmlKey: __isrHtmlKey,
-    isrRscKey: __isrRscKey,
-    isrSet: __isrSet,
-    loadSsrHandler() {
-      return import.meta.viteRsc.loadModule("ssr", "index");
-    },
-    middlewareContext: _mwCtx,
-    mountedSlotsHeader: __mountedSlotsHeader,
-    params,
-    probeLayoutAt(li) {
-      const LayoutComp = route.layouts[li]?.default;
-      if (!LayoutComp) return null;
-      return LayoutComp({
-        params: makeThenableParams(__resolveAppPageSegmentParams(
-          route.routeSegments,
-          route.layoutTreePositions?.[li] ?? 0,
-          params,
-        )),
-        children: null,
-      });
-    },
-    probePage() {
-      if (!PageComponent) return null;
-      const _asyncSearchParams = makeThenableParams(
-        __collectAppPageSearchParams(url.searchParams).searchParamsObject,
-      );
-      return PageComponent({ params: _asyncRouteParams, searchParams: _asyncSearchParams });
-    },
-    renderErrorBoundaryPage(renderErr) {
-      return renderErrorBoundaryPage(route, renderErr, isRscRequest, request, params, _scriptNonce, _mwCtx);
-    },
-    renderHttpAccessFallbackPage(statusCode, opts, middlewareContext) {
-      return renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, opts, _scriptNonce, middlewareContext);
-    },
-    renderToReadableStream,
+    contentType,
+    middlewareContext,
     request,
-    revalidateSeconds: typeof route.page?.revalidate === "number" ? route.page.revalidate : null,
-    rootForbiddenModule,
-    rootNotFoundModule,
-    rootUnauthorizedModule,
-    route,
-    runWithSuppressedHookWarning(probe) {
-      return _suppressHookWarningAls.run(true, probe);
-    },
-    scheduleBackgroundRegeneration(key, renderFn, errorContext) {
-      __triggerBackgroundRegeneration(key, renderFn, errorContext);
-    },
-    scriptNonce: _scriptNonce,
-    searchParams: url.searchParams,
-    setNavigationContext,
-  });
-}
+  }) {
+    return __handleProgressiveServerActionRequest({
+      actionId,
+      allowedOrigins: __allowedOrigins,
+      cleanPathname,
+      clearRequestContext() {
+        __clearRequestContext();
+      },
+      contentType,
+      decodeAction,
+      getAndClearPendingCookies,
+      getDraftModeCookieHeader,
+      maxActionBodySize: __MAX_ACTION_BODY_SIZE,
+      middlewareHeaders: middlewareContext.headers,
+      readFormDataWithLimit: __readFormDataWithLimit,
+      reportRequestError: _reportRequestError,
+      request,
+      setHeadersAccessPhase,
+    });
+  },
+  handleServerActionRequest({
+    actionId,
+    cleanPathname,
+    contentType,
+    interceptionContext,
+    isRscRequest,
+    middlewareContext,
+    mountedSlotsHeader,
+    request,
+    searchParams,
+  }) {
+    return __handleServerActionRscRequest({
+      actionId,
+      allowedOrigins: __allowedOrigins,
+      buildPageElement({
+        route: actionRoute,
+        params: actionParams,
+        cleanPathname: actionCleanPathname,
+        interceptOpts,
+        searchParams: actionSearchParams,
+        isRscRequest: actionIsRscRequest,
+        request: actionRequest,
+        mountedSlotsHeader: actionMountedSlotsHeader,
+      }) {
+        return buildPageElements(actionRoute, actionParams, actionCleanPathname, {
+          opts: interceptOpts,
+          searchParams: actionSearchParams,
+          isRscRequest: actionIsRscRequest,
+          request: actionRequest,
+          mountedSlotsHeader: actionMountedSlotsHeader,
+        });
+      },
+      cleanPathname,
+      clearRequestContext() {
+        __clearRequestContext();
+      },
+      contentType,
+      createNotFoundElement(actionRouteId) {
+        return {
+          [__APP_INTERCEPTION_CONTEXT_KEY]: null,
+          __route: actionRouteId,
+          __rootLayout: null,
+          [actionRouteId]: createElement("div", null, "Page not found"),
+        };
+      },
+      createPayloadRouteId(pathnameToRender, currentInterceptionContext) {
+        return __createAppPayloadRouteId(pathnameToRender, currentInterceptionContext);
+      },
+      createRscOnErrorHandler(actionRequest, actionPathname, routePattern) {
+        return createRscOnErrorHandler(actionRequest, actionPathname, routePattern);
+      },
+      createTemporaryReferenceSet,
+      decodeReply,
+      findIntercept(pathnameToMatch) {
+        return findIntercept(pathnameToMatch, interceptionContext);
+      },
+      getAndClearPendingCookies,
+      getDraftModeCookieHeader,
+      getRouteParamNames(sourceRoute) {
+        return sourceRoute.params;
+      },
+      getSourceRoute(sourceRouteIndex) {
+        return routes[sourceRouteIndex];
+      },
+      isRscRequest,
+      loadServerAction,
+      matchRoute(pathnameToMatch) {
+        return matchRoute(pathnameToMatch);
+      },
+      maxActionBodySize: __MAX_ACTION_BODY_SIZE,
+      middlewareHeaders: middlewareContext.headers,
+      middlewareStatus: middlewareContext.status,
+      mountedSlotsHeader,
+      readBodyWithLimit: __readBodyWithLimit,
+      readFormDataWithLimit: __readFormDataWithLimit,
+      renderToReadableStream,
+      reportRequestError: _reportRequestError,
+      request,
+      sanitizeErrorForClient(error) {
+        return __sanitizeErrorForClient(error);
+      },
+      searchParams,
+      setHeadersAccessPhase,
+      setNavigationContext,
+      toInterceptOpts(intercept) {
+        return {
+          interceptionContext,
+          interceptLayouts: intercept.interceptLayouts,
+          interceptSlotKey: intercept.slotKey,
+          interceptPage: intercept.page,
+          interceptParams: intercept.matchedParams,
+        };
+      },
+    });
+  },
+  i18nConfig: __i18nConfig,
+  
+  makeThenableParams,
+  matchRoute(pathnameToMatch) {
+    return matchRoute(pathnameToMatch);
+  },
+  metadataRoutes,
+  middlewareIsProxy: false,
+  middlewareModule: null,
+  publicFiles: __publicFiles,
+  renderNotFoundPage({ isRscRequest, matchedParams, middlewareContext, request, route, scriptNonce }) {
+    return renderNotFoundPage(route, isRscRequest, request, matchedParams, scriptNonce, middlewareContext);
+  },
+  
+  rootParamNamesMap,
+  setNavigationContext,
+  staticParamsMap: generateStaticParamsMap,
+  trailingSlash: __trailingSlash,
+  validateDevRequestOrigin(request) {
+    return __validateDevRequestOrigin(request);
+  },
+});
 
 if (import.meta.hot) {
   import.meta.hot.accept();
@@ -4698,17 +3821,15 @@ function renderToReadableStream(model, options) {
 }
 import { createElement } from "react";
 import { setNavigationContext as _setNavigationContextOrig, getNavigationContext as _getNavigationContext } from "next/navigation";
-import { setHeadersContext, headersContextFromRequest, getDraftModeCookieHeader, getAndClearPendingCookies, consumeDynamicUsage, consumeInvalidDynamicUsageError, markDynamicUsage, getHeadersContext, setHeadersAccessPhase } from "next/headers";
+import { setHeadersContext, getDraftModeCookieHeader, getAndClearPendingCookies, markDynamicUsage, setHeadersAccessPhase } from "next/headers";
 import { mergeMetadata, resolveModuleMetadata, mergeViewport, resolveModuleViewport } from "vinext/metadata";
 
 
-import { handleMetadataRouteRequest as __handleMetadataRouteRequest } from "<ROOT>/packages/vinext/src/server/metadata-route-response.js";
-import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, isExternalUrl, proxyExternalRequest, sanitizeDestination } from "<ROOT>/packages/vinext/src/config/config-matchers.js";
-import { decodePathParams as __decodePathParams, normalizePath as __normalizePath } from "<ROOT>/packages/vinext/src/server/normalize-path.js";
-import { normalizePathnameForRouteMatch as __normalizePathnameForRouteMatch, normalizePathnameForRouteMatchStrict as __normalizePathnameForRouteMatchStrict } from "<ROOT>/packages/vinext/src/routing/utils.js";
+import { decodePathParams as __decodePathParams } from "<ROOT>/packages/vinext/src/server/normalize-path.js";
 import { buildRequestHeadersFromMiddlewareResponse as __buildRequestHeadersFromMiddlewareResponse } from "<ROOT>/packages/vinext/src/server/middleware-request-headers.js";
-import { applyConfigHeadersToResponse, resolvePublicFileRoute, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
-import { applyAppMiddleware as __applyAppMiddleware } from "<ROOT>/packages/vinext/src/server/app-middleware.js";
+import {
+  createAppRscHandler as __createAppRscHandler,
+} from "<ROOT>/packages/vinext/src/server/app-rsc-handler.js";
 import {
   dispatchAppRouteHandler as __dispatchAppRouteHandler,
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-dispatch.js";
@@ -4748,38 +3869,25 @@ import {
   resolveAppPageHead as __resolveAppPageHead,
 } from "<ROOT>/packages/vinext/src/server/app-page-head.js";
 import {
-  mergeMiddlewareResponseHeaders as __mergeMiddlewareResponseHeaders,
-} from "<ROOT>/packages/vinext/src/server/app-page-response.js";
-import {
   dispatchAppPage as __dispatchAppPage,
 } from "<ROOT>/packages/vinext/src/server/app-page-dispatch.js";
-import { getScriptNonceFromHeaderSources as __getScriptNonceFromHeaderSources } from "<ROOT>/packages/vinext/src/server/csp.js";
-import { buildPageCacheTags } from "<ROOT>/packages/vinext/src/server/implicit-tags.js";
-import { getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
-import { setRootParams as __setRootParams, pickRootParams as __pickRootParams } from "<ROOT>/packages/vinext/src/shims/root-params.js";
+import { setRootParams as __setRootParams } from "<ROOT>/packages/vinext/src/shims/root-params.js";
 import { makeThenableParams } from "<ROOT>/packages/vinext/src/shims/thenable-params.js";
-import { ensureFetchPatch as _ensureFetchPatch, setCurrentFetchSoftTags } from "vinext/fetch-cache";
+import { setCurrentFetchSoftTags } from "vinext/fetch-cache";
 import {
   createAppRscRouteMatcher as __createAppRscRouteMatcher,
 } from "<ROOT>/packages/vinext/src/server/app-rsc-route-matching.js";
-import {
-  handleAppPrerenderEndpoint as __handleAppPrerenderEndpoint,
-} from "<ROOT>/packages/vinext/src/server/app-prerender-endpoints.js";
 import {
   appIsrHtmlKey as __isrHtmlKey,
   appIsrRscKey as __isrRscKey,
   appIsrRouteKey as __isrRouteKey,
   isrGet as __isrGet,
   isrSet as __isrSet,
-  normalizeMountedSlotsHeader as __normalizeMountedSlotsHeader,
   triggerBackgroundRegeneration as __triggerBackgroundRegeneration,
 } from "<ROOT>/packages/vinext/src/server/isr-cache.js";
 // Import server-only state module to register ALS-backed accessors.
 import "vinext/navigation-state";
-import { runWithPrerenderWorkUnit as __runWithPrerenderWorkUnit } from "<ROOT>/packages/vinext/src/server/prerender-work-unit-setup.js";
-import { runWithRequestContext as _runWithUnifiedCtx, createRequestContext as _createUnifiedCtx } from "vinext/unified-request-context";
 import { reportRequestError as _reportRequestError } from "vinext/instrumentation";
-import { flattenErrorCauses as __flattenErrorCauses } from "<ROOT>/packages/vinext/src/utils/error-cause.js";
 import { getSSRFontLinks as _getSSRFontLinks, getSSRFontStyles as _getSSRFontStylesGoogle, getSSRFontPreloads as _getSSRFontPreloadsGoogle } from "next/font/google";
 import { getSSRFontStyles as _getSSRFontStylesLocal, getSSRFontPreloads as _getSSRFontPreloadsLocal } from "next/font/local";
 function _getSSRFontStyles() { return [..._getSSRFontStylesGoogle(), ..._getSSRFontStylesLocal()]; }
@@ -5307,35 +4415,6 @@ function __validateDevRequestOrigin(request) {
 }
 
 
-// ── Config pattern matching, redirects, rewrites, headers, CSRF validation,
-//    external URL proxy, cookie parsing, and request context are imported from
-//    config-matchers.ts and request-pipeline.ts (see import statements above).
-//    This eliminates ~250 lines of duplicated inline code and ensures the
-//    single-pass tokenizer in config-matchers.ts is used consistently
-//    (fixing the chained .replace() divergence flagged by CodeQL).
-
-/**
- * Build a request context from the live ALS HeadersContext, which reflects
- * any x-middleware-request-* header mutations applied by middleware.
- * Used for afterFiles and fallback rewrite has/missing evaluation — these
- * run after middleware in the App Router execution order.
- */
-function __buildPostMwRequestContext(request) {
-  const url = new URL(request.url);
-  const ctx = getHeadersContext();
-  if (!ctx) return requestContextFromRequest(request);
-  // ctx.cookies is a Map<string, string> (HeadersContext), but RequestContext
-  // requires a plain Record<string, string> for has/missing cookie evaluation
-  // (config-matchers.ts uses obj[key] not Map.get()). Convert here.
-  const cookiesRecord = Object.fromEntries(ctx.cookies);
-  return {
-    headers: ctx.headers,
-    cookies: cookiesRecord,
-    query: url.searchParams,
-    host: normalizeHost(ctx.headers.get("host"), url.hostname),
-  };
-}
-
 /**
  * Maximum server-action request body size.
  * Configurable via experimental.serverActions.bodySizeLimit in next.config.
@@ -5360,371 +4439,149 @@ const rootParamNamesMap = {
 
 };
 
-export default async function handler(request, ctx) {
-  
-  // Wrap the entire request in a single unified ALS scope for per-request
-  // isolation. All state modules (headers, navigation, cache, fetch-cache,
-  // execution-context) read from this store via isInsideUnifiedScope().
-  const headersCtx = headersContextFromRequest(request);
-  const __uCtx = _createUnifiedCtx({
-    headersContext: headersCtx,
-    executionContext: ctx ?? _getRequestExecutionContext() ?? null,
-    unstableCacheRevalidation: "background",
-  });
-  return _runWithUnifiedCtx(__uCtx, () =>
-    __runWithPrerenderWorkUnit(async () => {
-    _ensureFetchPatch();
-    const __reqCtx = requestContextFromRequest(request);
-    // Per-request container for middleware state. Passed into
-    // _handleRequest which fills in .headers and .status;
-    // avoids module-level variables that race on Workers.
-    const _mwCtx = { headers: null, requestHeaders: null, status: null };
-    let response;
-    try {
-      response = await _handleRequest(request, __reqCtx, _mwCtx);
-    } catch (err) {
-      // Dev only: embed err.cause chain into err.message/err.stack so Vite's
-      // dev-server "Internal server error:" logger (which builds output from
-      // message + stack only) reveals the underlying root cause (ECONNREFUSED,
-      // role missing, workerd socket error, etc.) instead of dropping it.
-      // Skipped in production because Node's util.inspect / workerd's logger
-      // already render .cause natively, so flattening would double-print it.
-      // NODE_ENV is build-time-replaced by Vite, so the prod bundle compiles
-      // this branch out entirely.
-      if (process.env.NODE_ENV !== "production") {
-        __flattenErrorCauses(err);
-      }
-      throw err;
-    }
-    // Apply custom headers from next.config.js to non-redirect responses.
-    // Skip redirects (3xx) because Response.redirect() creates immutable headers,
-    // and Next.js doesn't apply custom headers to redirects anyway.
-    if (response && response.headers && !(response.status >= 300 && response.status < 400)) {
-      if (__configHeaders.length) {
-        const url = new URL(request.url);
-        let pathname;
-        try { pathname = __normalizePath(__normalizePathnameForRouteMatch(url.pathname)); } catch { pathname = url.pathname; }
-        
-        applyConfigHeadersToResponse(response.headers, {
-          configHeaders: __configHeaders,
-          pathname,
-          requestContext: __reqCtx,
-        });
-      }
-    }
-    return response;
-    }, { route: () => new URL(request.url).pathname })
-  );
-}
-
-async function _handleRequest(request, __reqCtx, _mwCtx) {
-  const __reqStart = process.env.NODE_ENV !== "production" ? performance.now() : 0;
-  // __reqStart is included in the timing header so the Node logging middleware
-  // can compute true compile time as: handlerStart - middlewareStart.
-  // Format: "handlerStart,compileMs,renderMs" - all as integers (ms). Dev-only.
-  const url = new URL(request.url);
-
-  // ── Cross-origin request protection (dev only) ─────────────────────
-  // Block requests from non-localhost origins to prevent data exfiltration.
-  // Skipped in production — Vite replaces NODE_ENV at build time.
-  if (process.env.NODE_ENV !== "production") {
-    const __originBlock = __validateDevRequestOrigin(request);
-    if (__originBlock) return __originBlock;
-  }
-
-  // Guard against protocol-relative URL open redirects (see request-pipeline.ts).
-  const __protoGuard = guardProtocolRelativeUrl(url.pathname);
-  if (__protoGuard) return __protoGuard;
-
-  // Decode percent-encoding segment-wise and normalize pathname to canonical form.
-  // This preserves encoded path delimiters like %2F within a single segment.
-  // __normalizePath collapses //foo///bar → /foo/bar, resolves . and .. segments.
-  let decodedUrlPathname;
-  try { decodedUrlPathname = __normalizePathnameForRouteMatchStrict(url.pathname); } catch (e) {
-    return new Response("Bad Request", { status: 400 });
-  }
-  let pathname = __normalizePath(decodedUrlPathname);
-
-  
-
-  const __prerenderEndpointResponse = await __handleAppPrerenderEndpoint(request, {
-    isPrerenderEnabled() {
-      return process.env.VINEXT_PRERENDER === "1";
-    },
-
-    pathname,
-    rootParamNamesByPattern: rootParamNamesMap,
-    staticParamsMap: generateStaticParamsMap,
-  });
-  if (__prerenderEndpointResponse) return __prerenderEndpointResponse;
-
-  // Trailing slash normalization (redirect to canonical form)
-  const __tsRedirect = normalizeTrailingSlash(pathname, __basePath, __trailingSlash, url.search);
-  if (__tsRedirect) return __tsRedirect;
-
-  // ── Apply redirects from next.config.js ───────────────────────────────
-  if (__configRedirects.length) {
-    // Strip .rsc suffix before matching redirect rules - RSC (client-side nav) requests
-    // arrive as /some/path.rsc but redirect patterns are defined without it (e.g.
-    // /some/path). Without this, soft-nav fetches bypass all config redirects.
-    const __redirPathname = pathname.endsWith(".rsc") ? pathname.slice(0, -4) : pathname;
-    const __redir = matchRedirect(__redirPathname, __configRedirects, __reqCtx);
-    if (__redir) {
-      const __redirDest = sanitizeDestination(
-        __basePath &&
-          !isExternalUrl(__redir.destination) &&
-          !hasBasePath(__redir.destination, __basePath)
-          ? __basePath + __redir.destination
-          : __redir.destination
-      );
-      return new Response(null, {
-        status: __redir.permanent ? 308 : 307,
-        headers: { Location: __redirDest },
-      });
-    }
-  }
-
-  const isRscRequest = pathname.endsWith(".rsc") || request.headers.get("accept")?.includes("text/x-component");
-  // Read mounted-slots header once at the handler scope and thread it through
-  // every buildPageElements call site. Previously both the handler and
-  // buildPageElements read and normalized it independently, which invited
-  // silent drift if a future refactor changed only one path.
-  const __mountedSlotsHeader = __normalizeMountedSlotsHeader(
-    request.headers.get("x-vinext-mounted-slots"),
-  );
-  const interceptionContextHeader = request.headers.get("X-Vinext-Interception-Context")?.replaceAll(" ", "") || null;
-  let cleanPathname = pathname.replace(/\\.rsc$/, "");
-
-  // Middleware response headers and custom rewrite status are stored in
-  // _mwCtx (per-request container) so handler() can merge them into
-  // every response path without module-level state that races on Workers.
-
-  
-
-  const _scriptNonce = __getScriptNonceFromHeaderSources(request.headers, _mwCtx.headers);
-
-  // Build post-middleware request context for afterFiles/fallback rewrites.
-  // These run after middleware in the App Router execution order and should
-  // evaluate has/missing conditions against middleware-modified headers.
-  // When no middleware is present, this falls back to requestContextFromRequest.
-  const __postMwReqCtx = __buildPostMwRequestContext(request);
-
-  // ── Apply beforeFiles rewrites from next.config.js ────────────────────
-  // In App Router execution order, beforeFiles runs after middleware so that
-  // has/missing conditions can evaluate against middleware-modified headers.
-  if (__configRewrites.beforeFiles && __configRewrites.beforeFiles.length) {
-    const __rewritten = matchRewrite(cleanPathname, __configRewrites.beforeFiles, __postMwReqCtx);
-    if (__rewritten) {
-      if (isExternalUrl(__rewritten)) {
-        __clearRequestContext();
-        return proxyExternalRequest(request, __rewritten);
-      }
-      cleanPathname = __rewritten;
-    }
-  }
-
-  // ── Image optimization passthrough (dev mode — no transformation) ───────
-  if (cleanPathname === "/_vinext/image") {
-    const __imgResult = validateImageUrl(url.searchParams.get("url"), request.url);
-    if (__imgResult instanceof Response) return __imgResult;
-    // In dev, redirect to the original asset URL so Vite's static serving handles it.
-    return Response.redirect(new URL(__imgResult, url.origin).href, 302);
-  }
-
-  const metadataRouteResponse = await __handleMetadataRouteRequest({
-    metadataRoutes,
-    cleanPathname,
-    makeThenableParams,
-  });
-  if (metadataRouteResponse) return metadataRouteResponse;
-
-  // Serve public/ files as filesystem routes after middleware and before
-  // afterFiles/fallback rewrites, matching Next.js routing semantics.
-  const __publicFileResponse = resolvePublicFileRoute({
-    cleanPathname,
-    middlewareContext: _mwCtx,
-    pathname,
-    publicFiles: __publicFiles,
-    request,
-  });
-  if (__publicFileResponse) {
+export default __createAppRscHandler({
+  basePath: __basePath,
+  clearRequestContext() {
     __clearRequestContext();
-    return __publicFileResponse;
-  }
-
-  // Set navigation context for Server Components.
-  // Note: Headers context is already set by runWithRequestContext in the handler wrapper.
-  setNavigationContext({
-    pathname: cleanPathname,
-    searchParams: url.searchParams,
-    params: {},
-  });
-
-  // Handle server action POST requests
-  const actionId = request.headers.get("x-rsc-action") ?? request.headers.get("next-action");
-  const actionContentType = request.headers.get("content-type") || "";
-  const progressiveActionResponse = await __handleProgressiveServerActionRequest({
-    actionId,
-    allowedOrigins: __allowedOrigins,
+  },
+  configHeaders: __configHeaders,
+  configRedirects: __configRedirects,
+  configRewrites: __configRewrites,
+  dispatchMatchedPage({
     cleanPathname,
-    clearRequestContext() {
-      __clearRequestContext();
-    },
-    contentType: actionContentType,
-    decodeAction,
-    getAndClearPendingCookies,
-    getDraftModeCookieHeader,
-    maxActionBodySize: __MAX_ACTION_BODY_SIZE,
-    middlewareHeaders: _mwCtx.headers,
-    readFormDataWithLimit: __readFormDataWithLimit,
-    reportRequestError: _reportRequestError,
-    request,
-    setHeadersAccessPhase,
-  });
-  if (progressiveActionResponse) return progressiveActionResponse;
-
-  const serverActionResponse = await __handleServerActionRscRequest({
-    actionId,
-    allowedOrigins: __allowedOrigins,
-    buildPageElement({
-      route: actionRoute,
-      params: actionParams,
-      cleanPathname: actionCleanPathname,
-      interceptOpts,
-      searchParams,
-      isRscRequest: actionIsRscRequest,
-      request: actionRequest,
-      mountedSlotsHeader,
-    }) {
-      return buildPageElements(actionRoute, actionParams, actionCleanPathname, {
-        opts: interceptOpts,
-        searchParams,
-        isRscRequest: actionIsRscRequest,
-        request: actionRequest,
-        mountedSlotsHeader,
-      });
-    },
-    cleanPathname,
-    clearRequestContext() {
-      __clearRequestContext();
-    },
-    contentType: actionContentType,
-    createNotFoundElement(actionRouteId) {
-      return {
-        [__APP_INTERCEPTION_CONTEXT_KEY]: null,
-        __route: actionRouteId,
-        __rootLayout: null,
-        [actionRouteId]: createElement("div", null, "Page not found"),
-      };
-    },
-    createPayloadRouteId(pathnameToRender, interceptionContext) {
-      return __createAppPayloadRouteId(pathnameToRender, interceptionContext);
-    },
-    createRscOnErrorHandler(actionRequest, actionPathname, routePattern) {
-      return createRscOnErrorHandler(actionRequest, actionPathname, routePattern);
-    },
-    createTemporaryReferenceSet,
-    decodeReply,
-    findIntercept(pathnameToMatch) {
-      return findIntercept(pathnameToMatch, interceptionContextHeader);
-    },
-    getAndClearPendingCookies,
-    getDraftModeCookieHeader,
-    getRouteParamNames(sourceRoute) {
-      return sourceRoute.params;
-    },
-    getSourceRoute(sourceRouteIndex) {
-      return routes[sourceRouteIndex];
-    },
+    handlerStart,
+    interceptionContext,
     isRscRequest,
-    loadServerAction,
-    matchRoute(pathnameToMatch) {
-      return matchRoute(pathnameToMatch);
-    },
-    maxActionBodySize: __MAX_ACTION_BODY_SIZE,
-    middlewareHeaders: _mwCtx.headers,
-    middlewareStatus: _mwCtx.status,
-    mountedSlotsHeader: __mountedSlotsHeader,
-    readBodyWithLimit: __readBodyWithLimit,
-    readFormDataWithLimit: __readFormDataWithLimit,
-    renderToReadableStream,
-    reportRequestError: _reportRequestError,
-    request,
-    sanitizeErrorForClient(error) {
-      return __sanitizeErrorForClient(error);
-    },
-    searchParams: url.searchParams,
-    setHeadersAccessPhase,
-    setNavigationContext,
-    toInterceptOpts(intercept) {
-      return {
-        interceptionContext: interceptionContextHeader,
-        interceptLayouts: intercept.interceptLayouts,
-        interceptSlotKey: intercept.slotKey,
-        interceptPage: intercept.page,
-        interceptParams: intercept.matchedParams,
-      };
-    },
-  });
-  if (serverActionResponse) return serverActionResponse;
-
-  // ── Apply afterFiles rewrites from next.config.js ──────────────────────
-  if (__configRewrites.afterFiles && __configRewrites.afterFiles.length) {
-    const __afterRewritten = matchRewrite(cleanPathname, __configRewrites.afterFiles, __postMwReqCtx);
-    if (__afterRewritten) {
-      if (isExternalUrl(__afterRewritten)) {
-        __clearRequestContext();
-        return proxyExternalRequest(request, __afterRewritten);
-      }
-      cleanPathname = __afterRewritten;
-    }
-  }
-
-  let match = matchRoute(cleanPathname);
-
-  // ── Fallback rewrites from next.config.js (if no route matched) ───────
-  if (!match && __configRewrites.fallback && __configRewrites.fallback.length) {
-    const __fallbackRewritten = matchRewrite(cleanPathname, __configRewrites.fallback, __postMwReqCtx);
-    if (__fallbackRewritten) {
-      if (isExternalUrl(__fallbackRewritten)) {
-        __clearRequestContext();
-        return proxyExternalRequest(request, __fallbackRewritten);
-      }
-      cleanPathname = __fallbackRewritten;
-      match = matchRoute(cleanPathname);
-    }
-  }
-
-  if (!match) {
-    
-    // Render custom not-found page if available, otherwise plain 404
-    const notFoundResponse = await renderNotFoundPage(null, isRscRequest, request, undefined, _scriptNonce, _mwCtx);
-    if (notFoundResponse) return notFoundResponse;
-    __clearRequestContext();
-    const notFoundHeaders = new Headers();
-    __mergeMiddlewareResponseHeaders(notFoundHeaders, _mwCtx.headers);
-    return new Response("Not Found", { status: 404, headers: notFoundHeaders });
-  }
-
-  const { route, params } = match;
-
-  // Update navigation context with matched params
-  setNavigationContext({
-    pathname: cleanPathname,
-    searchParams: url.searchParams,
+    middlewareContext,
+    mountedSlotsHeader,
     params,
-  });
-  __setRootParams(__pickRootParams(params, route.rootParamNames));
-
-  // Handle route.ts API handlers
-  if (route.routeHandler) {
-    setCurrentFetchSoftTags(
-      buildPageCacheTags(cleanPathname, [], route.routeSegments, "route"),
-    );
+    request,
+    route,
+    scriptNonce,
+    searchParams,
+  }) {
+    const PageComponent = route.page?.default;
+    const _asyncRouteParams = makeThenableParams(params);
+    return __dispatchAppPage({
+      buildPageElement(targetRoute, targetParams, targetOpts, targetSearchParams) {
+        return buildPageElements(targetRoute, targetParams, cleanPathname, {
+          opts: targetOpts,
+          searchParams: targetSearchParams,
+          isRscRequest,
+          request,
+          mountedSlotsHeader,
+        });
+      },
+      cleanPathname,
+      clearRequestContext() {
+        __clearRequestContext();
+      },
+      createRscOnErrorHandler(pathname, routePath) {
+        return createRscOnErrorHandler(request, pathname, routePath);
+      },
+      debugClassification: __classDebug,
+      dynamicConfig: route.page?.dynamic,
+      dynamicParamsConfig: route.page?.dynamicParams,
+      findIntercept(pathname) {
+        return findIntercept(pathname, interceptionContext);
+      },
+      generateStaticParams: route.page?.generateStaticParams,
+      getFontLinks: _getSSRFontLinks,
+      getFontPreloads: _getSSRFontPreloads,
+      getFontStyles: _getSSRFontStyles,
+      getNavigationContext: _getNavigationContext,
+      getSourceRoute(sourceRouteIndex) {
+        return routes[sourceRouteIndex];
+      },
+      hasGenerateStaticParams: typeof route.page?.generateStaticParams === "function",
+      hasPageDefaultExport: !!PageComponent,
+      hasPageModule: !!route.page,
+      handlerStart,
+      interceptionContext,
+      isProduction: process.env.NODE_ENV === "production",
+      isRscRequest,
+      isrDebug: __isrDebug,
+      isrGet: __isrGet,
+      isrHtmlKey: __isrHtmlKey,
+      isrRscKey: __isrRscKey,
+      isrSet: __isrSet,
+      loadSsrHandler() {
+        return import.meta.viteRsc.loadModule("ssr", "index");
+      },
+      middlewareContext,
+      mountedSlotsHeader,
+      params,
+      probeLayoutAt(li) {
+        const LayoutComp = route.layouts[li]?.default;
+        if (!LayoutComp) return null;
+        return LayoutComp({
+          params: makeThenableParams(__resolveAppPageSegmentParams(
+            route.routeSegments,
+            route.layoutTreePositions?.[li] ?? 0,
+            params,
+          )),
+          children: null,
+        });
+      },
+      probePage() {
+        if (!PageComponent) return null;
+        const _asyncSearchParams = makeThenableParams(
+          __collectAppPageSearchParams(searchParams).searchParamsObject,
+        );
+        return PageComponent({ params: _asyncRouteParams, searchParams: _asyncSearchParams });
+      },
+      renderErrorBoundaryPage(renderErr) {
+        return renderErrorBoundaryPage(
+          route,
+          renderErr,
+          isRscRequest,
+          request,
+          params,
+          scriptNonce,
+          middlewareContext,
+        );
+      },
+      renderHttpAccessFallbackPage(statusCode, opts, currentMiddlewareContext) {
+        return renderHTTPAccessFallbackPage(
+          route,
+          statusCode,
+          isRscRequest,
+          request,
+          opts,
+          scriptNonce,
+          currentMiddlewareContext,
+        );
+      },
+      renderToReadableStream,
+      request,
+      revalidateSeconds: typeof route.page?.revalidate === "number" ? route.page.revalidate : null,
+      rootForbiddenModule,
+      rootNotFoundModule,
+      rootUnauthorizedModule,
+      route,
+      runWithSuppressedHookWarning(probe) {
+        return _suppressHookWarningAls.run(true, probe);
+      },
+      scheduleBackgroundRegeneration(key, renderFn, errorContext) {
+        __triggerBackgroundRegeneration(key, renderFn, errorContext);
+      },
+      scriptNonce,
+      searchParams,
+      setNavigationContext,
+    });
+  },
+  dispatchMatchedRouteHandler({
+    cleanPathname,
+    middlewareContext,
+    params,
+    request,
+    route,
+    searchParams,
+  }) {
     return __dispatchAppRouteHandler({
       basePath: __basePath,
       cleanPathname,
-      clearRequestContext: function() {
+      clearRequestContext() {
         __clearRequestContext();
       },
       i18n: __i18nConfig,
@@ -5732,8 +4589,8 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       isrGet: __isrGet,
       isrRouteKey: __isrRouteKey,
       isrSet: __isrSet,
-      middlewareContext: _mwCtx,
-      middlewareRequestHeaders: _mwCtx.requestHeaders,
+      middlewareContext,
+      middlewareRequestHeaders: middlewareContext.requestHeaders,
       params,
       request,
       route: {
@@ -5742,104 +4599,153 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         routeSegments: route.routeSegments,
       },
       scheduleBackgroundRegeneration: __triggerBackgroundRegeneration,
-      searchParams: url.searchParams,
+      searchParams,
     });
-  }
-
-  const PageComponent = route.page?.default;
-  const _asyncRouteParams = makeThenableParams(params);
-  return __dispatchAppPage({
-    buildPageElement(targetRoute, targetParams, targetOpts, targetSearchParams) {
-      return buildPageElements(targetRoute, targetParams, cleanPathname, {
-        opts: targetOpts,
-        searchParams: targetSearchParams,
-        isRscRequest,
-        request,
-        mountedSlotsHeader: __mountedSlotsHeader,
-      });
-    },
+  },
+  
+  handleProgressiveActionRequest({
+    actionId,
     cleanPathname,
-    clearRequestContext() {
-      __clearRequestContext();
-    },
-    createRscOnErrorHandler(pathname, routePath) {
-      return createRscOnErrorHandler(request, pathname, routePath);
-    },
-    debugClassification: __classDebug,
-    dynamicConfig: route.page?.dynamic,
-    dynamicParamsConfig: route.page?.dynamicParams,
-    findIntercept(pathname) {
-      return findIntercept(pathname, interceptionContextHeader);
-    },
-    generateStaticParams: route.page?.generateStaticParams,
-    getFontLinks: _getSSRFontLinks,
-    getFontPreloads: _getSSRFontPreloads,
-    getFontStyles: _getSSRFontStyles,
-    getNavigationContext: _getNavigationContext,
-    getSourceRoute(sourceRouteIndex) {
-      return routes[sourceRouteIndex];
-    },
-    hasGenerateStaticParams: typeof route.page?.generateStaticParams === "function",
-    hasPageDefaultExport: !!PageComponent,
-    hasPageModule: !!route.page,
-    handlerStart: __reqStart,
-    interceptionContext: interceptionContextHeader,
-    isProduction: process.env.NODE_ENV === "production",
-    isRscRequest,
-    isrDebug: __isrDebug,
-    isrGet: __isrGet,
-    isrHtmlKey: __isrHtmlKey,
-    isrRscKey: __isrRscKey,
-    isrSet: __isrSet,
-    loadSsrHandler() {
-      return import.meta.viteRsc.loadModule("ssr", "index");
-    },
-    middlewareContext: _mwCtx,
-    mountedSlotsHeader: __mountedSlotsHeader,
-    params,
-    probeLayoutAt(li) {
-      const LayoutComp = route.layouts[li]?.default;
-      if (!LayoutComp) return null;
-      return LayoutComp({
-        params: makeThenableParams(__resolveAppPageSegmentParams(
-          route.routeSegments,
-          route.layoutTreePositions?.[li] ?? 0,
-          params,
-        )),
-        children: null,
-      });
-    },
-    probePage() {
-      if (!PageComponent) return null;
-      const _asyncSearchParams = makeThenableParams(
-        __collectAppPageSearchParams(url.searchParams).searchParamsObject,
-      );
-      return PageComponent({ params: _asyncRouteParams, searchParams: _asyncSearchParams });
-    },
-    renderErrorBoundaryPage(renderErr) {
-      return renderErrorBoundaryPage(route, renderErr, isRscRequest, request, params, _scriptNonce, _mwCtx);
-    },
-    renderHttpAccessFallbackPage(statusCode, opts, middlewareContext) {
-      return renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, opts, _scriptNonce, middlewareContext);
-    },
-    renderToReadableStream,
+    contentType,
+    middlewareContext,
     request,
-    revalidateSeconds: typeof route.page?.revalidate === "number" ? route.page.revalidate : null,
-    rootForbiddenModule,
-    rootNotFoundModule,
-    rootUnauthorizedModule,
-    route,
-    runWithSuppressedHookWarning(probe) {
-      return _suppressHookWarningAls.run(true, probe);
-    },
-    scheduleBackgroundRegeneration(key, renderFn, errorContext) {
-      __triggerBackgroundRegeneration(key, renderFn, errorContext);
-    },
-    scriptNonce: _scriptNonce,
-    searchParams: url.searchParams,
-    setNavigationContext,
-  });
-}
+  }) {
+    return __handleProgressiveServerActionRequest({
+      actionId,
+      allowedOrigins: __allowedOrigins,
+      cleanPathname,
+      clearRequestContext() {
+        __clearRequestContext();
+      },
+      contentType,
+      decodeAction,
+      getAndClearPendingCookies,
+      getDraftModeCookieHeader,
+      maxActionBodySize: __MAX_ACTION_BODY_SIZE,
+      middlewareHeaders: middlewareContext.headers,
+      readFormDataWithLimit: __readFormDataWithLimit,
+      reportRequestError: _reportRequestError,
+      request,
+      setHeadersAccessPhase,
+    });
+  },
+  handleServerActionRequest({
+    actionId,
+    cleanPathname,
+    contentType,
+    interceptionContext,
+    isRscRequest,
+    middlewareContext,
+    mountedSlotsHeader,
+    request,
+    searchParams,
+  }) {
+    return __handleServerActionRscRequest({
+      actionId,
+      allowedOrigins: __allowedOrigins,
+      buildPageElement({
+        route: actionRoute,
+        params: actionParams,
+        cleanPathname: actionCleanPathname,
+        interceptOpts,
+        searchParams: actionSearchParams,
+        isRscRequest: actionIsRscRequest,
+        request: actionRequest,
+        mountedSlotsHeader: actionMountedSlotsHeader,
+      }) {
+        return buildPageElements(actionRoute, actionParams, actionCleanPathname, {
+          opts: interceptOpts,
+          searchParams: actionSearchParams,
+          isRscRequest: actionIsRscRequest,
+          request: actionRequest,
+          mountedSlotsHeader: actionMountedSlotsHeader,
+        });
+      },
+      cleanPathname,
+      clearRequestContext() {
+        __clearRequestContext();
+      },
+      contentType,
+      createNotFoundElement(actionRouteId) {
+        return {
+          [__APP_INTERCEPTION_CONTEXT_KEY]: null,
+          __route: actionRouteId,
+          __rootLayout: null,
+          [actionRouteId]: createElement("div", null, "Page not found"),
+        };
+      },
+      createPayloadRouteId(pathnameToRender, currentInterceptionContext) {
+        return __createAppPayloadRouteId(pathnameToRender, currentInterceptionContext);
+      },
+      createRscOnErrorHandler(actionRequest, actionPathname, routePattern) {
+        return createRscOnErrorHandler(actionRequest, actionPathname, routePattern);
+      },
+      createTemporaryReferenceSet,
+      decodeReply,
+      findIntercept(pathnameToMatch) {
+        return findIntercept(pathnameToMatch, interceptionContext);
+      },
+      getAndClearPendingCookies,
+      getDraftModeCookieHeader,
+      getRouteParamNames(sourceRoute) {
+        return sourceRoute.params;
+      },
+      getSourceRoute(sourceRouteIndex) {
+        return routes[sourceRouteIndex];
+      },
+      isRscRequest,
+      loadServerAction,
+      matchRoute(pathnameToMatch) {
+        return matchRoute(pathnameToMatch);
+      },
+      maxActionBodySize: __MAX_ACTION_BODY_SIZE,
+      middlewareHeaders: middlewareContext.headers,
+      middlewareStatus: middlewareContext.status,
+      mountedSlotsHeader,
+      readBodyWithLimit: __readBodyWithLimit,
+      readFormDataWithLimit: __readFormDataWithLimit,
+      renderToReadableStream,
+      reportRequestError: _reportRequestError,
+      request,
+      sanitizeErrorForClient(error) {
+        return __sanitizeErrorForClient(error);
+      },
+      searchParams,
+      setHeadersAccessPhase,
+      setNavigationContext,
+      toInterceptOpts(intercept) {
+        return {
+          interceptionContext,
+          interceptLayouts: intercept.interceptLayouts,
+          interceptSlotKey: intercept.slotKey,
+          interceptPage: intercept.page,
+          interceptParams: intercept.matchedParams,
+        };
+      },
+    });
+  },
+  i18nConfig: __i18nConfig,
+  
+  makeThenableParams,
+  matchRoute(pathnameToMatch) {
+    return matchRoute(pathnameToMatch);
+  },
+  metadataRoutes,
+  middlewareIsProxy: false,
+  middlewareModule: null,
+  publicFiles: __publicFiles,
+  renderNotFoundPage({ isRscRequest, matchedParams, middlewareContext, request, route, scriptNonce }) {
+    return renderNotFoundPage(route, isRscRequest, request, matchedParams, scriptNonce, middlewareContext);
+  },
+  
+  rootParamNamesMap,
+  setNavigationContext,
+  staticParamsMap: generateStaticParamsMap,
+  trailingSlash: __trailingSlash,
+  validateDevRequestOrigin(request) {
+    return __validateDevRequestOrigin(request);
+  },
+});
 
 if (import.meta.hot) {
   import.meta.hot.accept();
@@ -5867,17 +4773,15 @@ function renderToReadableStream(model, options) {
 }
 import { createElement } from "react";
 import { setNavigationContext as _setNavigationContextOrig, getNavigationContext as _getNavigationContext } from "next/navigation";
-import { setHeadersContext, headersContextFromRequest, getDraftModeCookieHeader, getAndClearPendingCookies, consumeDynamicUsage, consumeInvalidDynamicUsageError, markDynamicUsage, getHeadersContext, setHeadersAccessPhase } from "next/headers";
+import { setHeadersContext, getDraftModeCookieHeader, getAndClearPendingCookies, markDynamicUsage, setHeadersAccessPhase } from "next/headers";
 import { mergeMetadata, resolveModuleMetadata, mergeViewport, resolveModuleViewport } from "vinext/metadata";
 import * as middlewareModule from "/tmp/test/middleware.ts";
 
-import { handleMetadataRouteRequest as __handleMetadataRouteRequest } from "<ROOT>/packages/vinext/src/server/metadata-route-response.js";
-import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, isExternalUrl, proxyExternalRequest, sanitizeDestination } from "<ROOT>/packages/vinext/src/config/config-matchers.js";
-import { decodePathParams as __decodePathParams, normalizePath as __normalizePath } from "<ROOT>/packages/vinext/src/server/normalize-path.js";
-import { normalizePathnameForRouteMatch as __normalizePathnameForRouteMatch, normalizePathnameForRouteMatchStrict as __normalizePathnameForRouteMatchStrict } from "<ROOT>/packages/vinext/src/routing/utils.js";
+import { decodePathParams as __decodePathParams } from "<ROOT>/packages/vinext/src/server/normalize-path.js";
 import { buildRequestHeadersFromMiddlewareResponse as __buildRequestHeadersFromMiddlewareResponse } from "<ROOT>/packages/vinext/src/server/middleware-request-headers.js";
-import { applyConfigHeadersToResponse, resolvePublicFileRoute, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash } from "<ROOT>/packages/vinext/src/server/request-pipeline.js";
-import { applyAppMiddleware as __applyAppMiddleware } from "<ROOT>/packages/vinext/src/server/app-middleware.js";
+import {
+  createAppRscHandler as __createAppRscHandler,
+} from "<ROOT>/packages/vinext/src/server/app-rsc-handler.js";
 import {
   dispatchAppRouteHandler as __dispatchAppRouteHandler,
 } from "<ROOT>/packages/vinext/src/server/app-route-handler-dispatch.js";
@@ -5917,38 +4821,25 @@ import {
   resolveAppPageHead as __resolveAppPageHead,
 } from "<ROOT>/packages/vinext/src/server/app-page-head.js";
 import {
-  mergeMiddlewareResponseHeaders as __mergeMiddlewareResponseHeaders,
-} from "<ROOT>/packages/vinext/src/server/app-page-response.js";
-import {
   dispatchAppPage as __dispatchAppPage,
 } from "<ROOT>/packages/vinext/src/server/app-page-dispatch.js";
-import { getScriptNonceFromHeaderSources as __getScriptNonceFromHeaderSources } from "<ROOT>/packages/vinext/src/server/csp.js";
-import { buildPageCacheTags } from "<ROOT>/packages/vinext/src/server/implicit-tags.js";
-import { getRequestExecutionContext as _getRequestExecutionContext } from "<ROOT>/packages/vinext/src/shims/request-context.js";
-import { setRootParams as __setRootParams, pickRootParams as __pickRootParams } from "<ROOT>/packages/vinext/src/shims/root-params.js";
+import { setRootParams as __setRootParams } from "<ROOT>/packages/vinext/src/shims/root-params.js";
 import { makeThenableParams } from "<ROOT>/packages/vinext/src/shims/thenable-params.js";
-import { ensureFetchPatch as _ensureFetchPatch, setCurrentFetchSoftTags } from "vinext/fetch-cache";
+import { setCurrentFetchSoftTags } from "vinext/fetch-cache";
 import {
   createAppRscRouteMatcher as __createAppRscRouteMatcher,
 } from "<ROOT>/packages/vinext/src/server/app-rsc-route-matching.js";
-import {
-  handleAppPrerenderEndpoint as __handleAppPrerenderEndpoint,
-} from "<ROOT>/packages/vinext/src/server/app-prerender-endpoints.js";
 import {
   appIsrHtmlKey as __isrHtmlKey,
   appIsrRscKey as __isrRscKey,
   appIsrRouteKey as __isrRouteKey,
   isrGet as __isrGet,
   isrSet as __isrSet,
-  normalizeMountedSlotsHeader as __normalizeMountedSlotsHeader,
   triggerBackgroundRegeneration as __triggerBackgroundRegeneration,
 } from "<ROOT>/packages/vinext/src/server/isr-cache.js";
 // Import server-only state module to register ALS-backed accessors.
 import "vinext/navigation-state";
-import { runWithPrerenderWorkUnit as __runWithPrerenderWorkUnit } from "<ROOT>/packages/vinext/src/server/prerender-work-unit-setup.js";
-import { runWithRequestContext as _runWithUnifiedCtx, createRequestContext as _createUnifiedCtx } from "vinext/unified-request-context";
 import { reportRequestError as _reportRequestError } from "vinext/instrumentation";
-import { flattenErrorCauses as __flattenErrorCauses } from "<ROOT>/packages/vinext/src/utils/error-cause.js";
 import { getSSRFontLinks as _getSSRFontLinks, getSSRFontStyles as _getSSRFontStylesGoogle, getSSRFontPreloads as _getSSRFontPreloadsGoogle } from "next/font/google";
 import { getSSRFontStyles as _getSSRFontStylesLocal, getSSRFontPreloads as _getSSRFontPreloadsLocal } from "next/font/local";
 function _getSSRFontStyles() { return [..._getSSRFontStylesGoogle(), ..._getSSRFontStylesLocal()]; }
@@ -6466,35 +5357,6 @@ function __validateDevRequestOrigin(request) {
 }
 
 
-// ── Config pattern matching, redirects, rewrites, headers, CSRF validation,
-//    external URL proxy, cookie parsing, and request context are imported from
-//    config-matchers.ts and request-pipeline.ts (see import statements above).
-//    This eliminates ~250 lines of duplicated inline code and ensures the
-//    single-pass tokenizer in config-matchers.ts is used consistently
-//    (fixing the chained .replace() divergence flagged by CodeQL).
-
-/**
- * Build a request context from the live ALS HeadersContext, which reflects
- * any x-middleware-request-* header mutations applied by middleware.
- * Used for afterFiles and fallback rewrite has/missing evaluation — these
- * run after middleware in the App Router execution order.
- */
-function __buildPostMwRequestContext(request) {
-  const url = new URL(request.url);
-  const ctx = getHeadersContext();
-  if (!ctx) return requestContextFromRequest(request);
-  // ctx.cookies is a Map<string, string> (HeadersContext), but RequestContext
-  // requires a plain Record<string, string> for has/missing cookie evaluation
-  // (config-matchers.ts uses obj[key] not Map.get()). Convert here.
-  const cookiesRecord = Object.fromEntries(ctx.cookies);
-  return {
-    headers: ctx.headers,
-    cookies: cookiesRecord,
-    query: url.searchParams,
-    host: normalizeHost(ctx.headers.get("host"), url.hostname),
-  };
-}
-
 /**
  * Maximum server-action request body size.
  * Configurable via experimental.serverActions.bodySizeLimit in next.config.
@@ -6519,386 +5381,149 @@ const rootParamNamesMap = {
 
 };
 
-export default async function handler(request, ctx) {
-  
-  // Wrap the entire request in a single unified ALS scope for per-request
-  // isolation. All state modules (headers, navigation, cache, fetch-cache,
-  // execution-context) read from this store via isInsideUnifiedScope().
-  const headersCtx = headersContextFromRequest(request);
-  const __uCtx = _createUnifiedCtx({
-    headersContext: headersCtx,
-    executionContext: ctx ?? _getRequestExecutionContext() ?? null,
-    unstableCacheRevalidation: "background",
-  });
-  return _runWithUnifiedCtx(__uCtx, () =>
-    __runWithPrerenderWorkUnit(async () => {
-    _ensureFetchPatch();
-    const __reqCtx = requestContextFromRequest(request);
-    // Per-request container for middleware state. Passed into
-    // _handleRequest which fills in .headers and .status;
-    // avoids module-level variables that race on Workers.
-    const _mwCtx = { headers: null, requestHeaders: null, status: null };
-    let response;
-    try {
-      response = await _handleRequest(request, __reqCtx, _mwCtx);
-    } catch (err) {
-      // Dev only: embed err.cause chain into err.message/err.stack so Vite's
-      // dev-server "Internal server error:" logger (which builds output from
-      // message + stack only) reveals the underlying root cause (ECONNREFUSED,
-      // role missing, workerd socket error, etc.) instead of dropping it.
-      // Skipped in production because Node's util.inspect / workerd's logger
-      // already render .cause natively, so flattening would double-print it.
-      // NODE_ENV is build-time-replaced by Vite, so the prod bundle compiles
-      // this branch out entirely.
-      if (process.env.NODE_ENV !== "production") {
-        __flattenErrorCauses(err);
-      }
-      throw err;
-    }
-    // Apply custom headers from next.config.js to non-redirect responses.
-    // Skip redirects (3xx) because Response.redirect() creates immutable headers,
-    // and Next.js doesn't apply custom headers to redirects anyway.
-    if (response && response.headers && !(response.status >= 300 && response.status < 400)) {
-      if (__configHeaders.length) {
-        const url = new URL(request.url);
-        let pathname;
-        try { pathname = __normalizePath(__normalizePathnameForRouteMatch(url.pathname)); } catch { pathname = url.pathname; }
-        
-        applyConfigHeadersToResponse(response.headers, {
-          configHeaders: __configHeaders,
-          pathname,
-          requestContext: __reqCtx,
-        });
-      }
-    }
-    return response;
-    }, { route: () => new URL(request.url).pathname })
-  );
-}
-
-async function _handleRequest(request, __reqCtx, _mwCtx) {
-  const __reqStart = process.env.NODE_ENV !== "production" ? performance.now() : 0;
-  // __reqStart is included in the timing header so the Node logging middleware
-  // can compute true compile time as: handlerStart - middlewareStart.
-  // Format: "handlerStart,compileMs,renderMs" - all as integers (ms). Dev-only.
-  const url = new URL(request.url);
-
-  // ── Cross-origin request protection (dev only) ─────────────────────
-  // Block requests from non-localhost origins to prevent data exfiltration.
-  // Skipped in production — Vite replaces NODE_ENV at build time.
-  if (process.env.NODE_ENV !== "production") {
-    const __originBlock = __validateDevRequestOrigin(request);
-    if (__originBlock) return __originBlock;
-  }
-
-  // Guard against protocol-relative URL open redirects (see request-pipeline.ts).
-  const __protoGuard = guardProtocolRelativeUrl(url.pathname);
-  if (__protoGuard) return __protoGuard;
-
-  // Decode percent-encoding segment-wise and normalize pathname to canonical form.
-  // This preserves encoded path delimiters like %2F within a single segment.
-  // __normalizePath collapses //foo///bar → /foo/bar, resolves . and .. segments.
-  let decodedUrlPathname;
-  try { decodedUrlPathname = __normalizePathnameForRouteMatchStrict(url.pathname); } catch (e) {
-    return new Response("Bad Request", { status: 400 });
-  }
-  let pathname = __normalizePath(decodedUrlPathname);
-
-  
-
-  const __prerenderEndpointResponse = await __handleAppPrerenderEndpoint(request, {
-    isPrerenderEnabled() {
-      return process.env.VINEXT_PRERENDER === "1";
-    },
-
-    pathname,
-    rootParamNamesByPattern: rootParamNamesMap,
-    staticParamsMap: generateStaticParamsMap,
-  });
-  if (__prerenderEndpointResponse) return __prerenderEndpointResponse;
-
-  // Trailing slash normalization (redirect to canonical form)
-  const __tsRedirect = normalizeTrailingSlash(pathname, __basePath, __trailingSlash, url.search);
-  if (__tsRedirect) return __tsRedirect;
-
-  // ── Apply redirects from next.config.js ───────────────────────────────
-  if (__configRedirects.length) {
-    // Strip .rsc suffix before matching redirect rules - RSC (client-side nav) requests
-    // arrive as /some/path.rsc but redirect patterns are defined without it (e.g.
-    // /some/path). Without this, soft-nav fetches bypass all config redirects.
-    const __redirPathname = pathname.endsWith(".rsc") ? pathname.slice(0, -4) : pathname;
-    const __redir = matchRedirect(__redirPathname, __configRedirects, __reqCtx);
-    if (__redir) {
-      const __redirDest = sanitizeDestination(
-        __basePath &&
-          !isExternalUrl(__redir.destination) &&
-          !hasBasePath(__redir.destination, __basePath)
-          ? __basePath + __redir.destination
-          : __redir.destination
-      );
-      return new Response(null, {
-        status: __redir.permanent ? 308 : 307,
-        headers: { Location: __redirDest },
-      });
-    }
-  }
-
-  const isRscRequest = pathname.endsWith(".rsc") || request.headers.get("accept")?.includes("text/x-component");
-  // Read mounted-slots header once at the handler scope and thread it through
-  // every buildPageElements call site. Previously both the handler and
-  // buildPageElements read and normalized it independently, which invited
-  // silent drift if a future refactor changed only one path.
-  const __mountedSlotsHeader = __normalizeMountedSlotsHeader(
-    request.headers.get("x-vinext-mounted-slots"),
-  );
-  const interceptionContextHeader = request.headers.get("X-Vinext-Interception-Context")?.replaceAll(" ", "") || null;
-  let cleanPathname = pathname.replace(/\\.rsc$/, "");
-
-  // Middleware response headers and custom rewrite status are stored in
-  // _mwCtx (per-request container) so handler() can merge them into
-  // every response path without module-level state that races on Workers.
-
-  
-  const __mwResult = await __applyAppMiddleware({
-    basePath: __basePath,
-    cleanPathname,
-    context: _mwCtx,
-    i18nConfig: __i18nConfig,
-    isProxy: false,
-    module: middlewareModule,
-    request,
-  });
-  if (__mwResult.kind === "response") return __mwResult.response;
-  cleanPathname = __mwResult.cleanPathname;
-  if (__mwResult.search !== null) {
-    url.search = __mwResult.search;
-  }
-  
-
-  const _scriptNonce = __getScriptNonceFromHeaderSources(request.headers, _mwCtx.headers);
-
-  // Build post-middleware request context for afterFiles/fallback rewrites.
-  // These run after middleware in the App Router execution order and should
-  // evaluate has/missing conditions against middleware-modified headers.
-  // When no middleware is present, this falls back to requestContextFromRequest.
-  const __postMwReqCtx = __buildPostMwRequestContext(request);
-
-  // ── Apply beforeFiles rewrites from next.config.js ────────────────────
-  // In App Router execution order, beforeFiles runs after middleware so that
-  // has/missing conditions can evaluate against middleware-modified headers.
-  if (__configRewrites.beforeFiles && __configRewrites.beforeFiles.length) {
-    const __rewritten = matchRewrite(cleanPathname, __configRewrites.beforeFiles, __postMwReqCtx);
-    if (__rewritten) {
-      if (isExternalUrl(__rewritten)) {
-        __clearRequestContext();
-        return proxyExternalRequest(request, __rewritten);
-      }
-      cleanPathname = __rewritten;
-    }
-  }
-
-  // ── Image optimization passthrough (dev mode — no transformation) ───────
-  if (cleanPathname === "/_vinext/image") {
-    const __imgResult = validateImageUrl(url.searchParams.get("url"), request.url);
-    if (__imgResult instanceof Response) return __imgResult;
-    // In dev, redirect to the original asset URL so Vite's static serving handles it.
-    return Response.redirect(new URL(__imgResult, url.origin).href, 302);
-  }
-
-  const metadataRouteResponse = await __handleMetadataRouteRequest({
-    metadataRoutes,
-    cleanPathname,
-    makeThenableParams,
-  });
-  if (metadataRouteResponse) return metadataRouteResponse;
-
-  // Serve public/ files as filesystem routes after middleware and before
-  // afterFiles/fallback rewrites, matching Next.js routing semantics.
-  const __publicFileResponse = resolvePublicFileRoute({
-    cleanPathname,
-    middlewareContext: _mwCtx,
-    pathname,
-    publicFiles: __publicFiles,
-    request,
-  });
-  if (__publicFileResponse) {
+export default __createAppRscHandler({
+  basePath: __basePath,
+  clearRequestContext() {
     __clearRequestContext();
-    return __publicFileResponse;
-  }
-
-  // Set navigation context for Server Components.
-  // Note: Headers context is already set by runWithRequestContext in the handler wrapper.
-  setNavigationContext({
-    pathname: cleanPathname,
-    searchParams: url.searchParams,
-    params: {},
-  });
-
-  // Handle server action POST requests
-  const actionId = request.headers.get("x-rsc-action") ?? request.headers.get("next-action");
-  const actionContentType = request.headers.get("content-type") || "";
-  const progressiveActionResponse = await __handleProgressiveServerActionRequest({
-    actionId,
-    allowedOrigins: __allowedOrigins,
+  },
+  configHeaders: __configHeaders,
+  configRedirects: __configRedirects,
+  configRewrites: __configRewrites,
+  dispatchMatchedPage({
     cleanPathname,
-    clearRequestContext() {
-      __clearRequestContext();
-    },
-    contentType: actionContentType,
-    decodeAction,
-    getAndClearPendingCookies,
-    getDraftModeCookieHeader,
-    maxActionBodySize: __MAX_ACTION_BODY_SIZE,
-    middlewareHeaders: _mwCtx.headers,
-    readFormDataWithLimit: __readFormDataWithLimit,
-    reportRequestError: _reportRequestError,
-    request,
-    setHeadersAccessPhase,
-  });
-  if (progressiveActionResponse) return progressiveActionResponse;
-
-  const serverActionResponse = await __handleServerActionRscRequest({
-    actionId,
-    allowedOrigins: __allowedOrigins,
-    buildPageElement({
-      route: actionRoute,
-      params: actionParams,
-      cleanPathname: actionCleanPathname,
-      interceptOpts,
-      searchParams,
-      isRscRequest: actionIsRscRequest,
-      request: actionRequest,
-      mountedSlotsHeader,
-    }) {
-      return buildPageElements(actionRoute, actionParams, actionCleanPathname, {
-        opts: interceptOpts,
-        searchParams,
-        isRscRequest: actionIsRscRequest,
-        request: actionRequest,
-        mountedSlotsHeader,
-      });
-    },
-    cleanPathname,
-    clearRequestContext() {
-      __clearRequestContext();
-    },
-    contentType: actionContentType,
-    createNotFoundElement(actionRouteId) {
-      return {
-        [__APP_INTERCEPTION_CONTEXT_KEY]: null,
-        __route: actionRouteId,
-        __rootLayout: null,
-        [actionRouteId]: createElement("div", null, "Page not found"),
-      };
-    },
-    createPayloadRouteId(pathnameToRender, interceptionContext) {
-      return __createAppPayloadRouteId(pathnameToRender, interceptionContext);
-    },
-    createRscOnErrorHandler(actionRequest, actionPathname, routePattern) {
-      return createRscOnErrorHandler(actionRequest, actionPathname, routePattern);
-    },
-    createTemporaryReferenceSet,
-    decodeReply,
-    findIntercept(pathnameToMatch) {
-      return findIntercept(pathnameToMatch, interceptionContextHeader);
-    },
-    getAndClearPendingCookies,
-    getDraftModeCookieHeader,
-    getRouteParamNames(sourceRoute) {
-      return sourceRoute.params;
-    },
-    getSourceRoute(sourceRouteIndex) {
-      return routes[sourceRouteIndex];
-    },
+    handlerStart,
+    interceptionContext,
     isRscRequest,
-    loadServerAction,
-    matchRoute(pathnameToMatch) {
-      return matchRoute(pathnameToMatch);
-    },
-    maxActionBodySize: __MAX_ACTION_BODY_SIZE,
-    middlewareHeaders: _mwCtx.headers,
-    middlewareStatus: _mwCtx.status,
-    mountedSlotsHeader: __mountedSlotsHeader,
-    readBodyWithLimit: __readBodyWithLimit,
-    readFormDataWithLimit: __readFormDataWithLimit,
-    renderToReadableStream,
-    reportRequestError: _reportRequestError,
-    request,
-    sanitizeErrorForClient(error) {
-      return __sanitizeErrorForClient(error);
-    },
-    searchParams: url.searchParams,
-    setHeadersAccessPhase,
-    setNavigationContext,
-    toInterceptOpts(intercept) {
-      return {
-        interceptionContext: interceptionContextHeader,
-        interceptLayouts: intercept.interceptLayouts,
-        interceptSlotKey: intercept.slotKey,
-        interceptPage: intercept.page,
-        interceptParams: intercept.matchedParams,
-      };
-    },
-  });
-  if (serverActionResponse) return serverActionResponse;
-
-  // ── Apply afterFiles rewrites from next.config.js ──────────────────────
-  if (__configRewrites.afterFiles && __configRewrites.afterFiles.length) {
-    const __afterRewritten = matchRewrite(cleanPathname, __configRewrites.afterFiles, __postMwReqCtx);
-    if (__afterRewritten) {
-      if (isExternalUrl(__afterRewritten)) {
-        __clearRequestContext();
-        return proxyExternalRequest(request, __afterRewritten);
-      }
-      cleanPathname = __afterRewritten;
-    }
-  }
-
-  let match = matchRoute(cleanPathname);
-
-  // ── Fallback rewrites from next.config.js (if no route matched) ───────
-  if (!match && __configRewrites.fallback && __configRewrites.fallback.length) {
-    const __fallbackRewritten = matchRewrite(cleanPathname, __configRewrites.fallback, __postMwReqCtx);
-    if (__fallbackRewritten) {
-      if (isExternalUrl(__fallbackRewritten)) {
-        __clearRequestContext();
-        return proxyExternalRequest(request, __fallbackRewritten);
-      }
-      cleanPathname = __fallbackRewritten;
-      match = matchRoute(cleanPathname);
-    }
-  }
-
-  if (!match) {
-    
-    // Render custom not-found page if available, otherwise plain 404
-    const notFoundResponse = await renderNotFoundPage(null, isRscRequest, request, undefined, _scriptNonce, _mwCtx);
-    if (notFoundResponse) return notFoundResponse;
-    __clearRequestContext();
-    const notFoundHeaders = new Headers();
-    __mergeMiddlewareResponseHeaders(notFoundHeaders, _mwCtx.headers);
-    return new Response("Not Found", { status: 404, headers: notFoundHeaders });
-  }
-
-  const { route, params } = match;
-
-  // Update navigation context with matched params
-  setNavigationContext({
-    pathname: cleanPathname,
-    searchParams: url.searchParams,
+    middlewareContext,
+    mountedSlotsHeader,
     params,
-  });
-  __setRootParams(__pickRootParams(params, route.rootParamNames));
-
-  // Handle route.ts API handlers
-  if (route.routeHandler) {
-    setCurrentFetchSoftTags(
-      buildPageCacheTags(cleanPathname, [], route.routeSegments, "route"),
-    );
+    request,
+    route,
+    scriptNonce,
+    searchParams,
+  }) {
+    const PageComponent = route.page?.default;
+    const _asyncRouteParams = makeThenableParams(params);
+    return __dispatchAppPage({
+      buildPageElement(targetRoute, targetParams, targetOpts, targetSearchParams) {
+        return buildPageElements(targetRoute, targetParams, cleanPathname, {
+          opts: targetOpts,
+          searchParams: targetSearchParams,
+          isRscRequest,
+          request,
+          mountedSlotsHeader,
+        });
+      },
+      cleanPathname,
+      clearRequestContext() {
+        __clearRequestContext();
+      },
+      createRscOnErrorHandler(pathname, routePath) {
+        return createRscOnErrorHandler(request, pathname, routePath);
+      },
+      debugClassification: __classDebug,
+      dynamicConfig: route.page?.dynamic,
+      dynamicParamsConfig: route.page?.dynamicParams,
+      findIntercept(pathname) {
+        return findIntercept(pathname, interceptionContext);
+      },
+      generateStaticParams: route.page?.generateStaticParams,
+      getFontLinks: _getSSRFontLinks,
+      getFontPreloads: _getSSRFontPreloads,
+      getFontStyles: _getSSRFontStyles,
+      getNavigationContext: _getNavigationContext,
+      getSourceRoute(sourceRouteIndex) {
+        return routes[sourceRouteIndex];
+      },
+      hasGenerateStaticParams: typeof route.page?.generateStaticParams === "function",
+      hasPageDefaultExport: !!PageComponent,
+      hasPageModule: !!route.page,
+      handlerStart,
+      interceptionContext,
+      isProduction: process.env.NODE_ENV === "production",
+      isRscRequest,
+      isrDebug: __isrDebug,
+      isrGet: __isrGet,
+      isrHtmlKey: __isrHtmlKey,
+      isrRscKey: __isrRscKey,
+      isrSet: __isrSet,
+      loadSsrHandler() {
+        return import.meta.viteRsc.loadModule("ssr", "index");
+      },
+      middlewareContext,
+      mountedSlotsHeader,
+      params,
+      probeLayoutAt(li) {
+        const LayoutComp = route.layouts[li]?.default;
+        if (!LayoutComp) return null;
+        return LayoutComp({
+          params: makeThenableParams(__resolveAppPageSegmentParams(
+            route.routeSegments,
+            route.layoutTreePositions?.[li] ?? 0,
+            params,
+          )),
+          children: null,
+        });
+      },
+      probePage() {
+        if (!PageComponent) return null;
+        const _asyncSearchParams = makeThenableParams(
+          __collectAppPageSearchParams(searchParams).searchParamsObject,
+        );
+        return PageComponent({ params: _asyncRouteParams, searchParams: _asyncSearchParams });
+      },
+      renderErrorBoundaryPage(renderErr) {
+        return renderErrorBoundaryPage(
+          route,
+          renderErr,
+          isRscRequest,
+          request,
+          params,
+          scriptNonce,
+          middlewareContext,
+        );
+      },
+      renderHttpAccessFallbackPage(statusCode, opts, currentMiddlewareContext) {
+        return renderHTTPAccessFallbackPage(
+          route,
+          statusCode,
+          isRscRequest,
+          request,
+          opts,
+          scriptNonce,
+          currentMiddlewareContext,
+        );
+      },
+      renderToReadableStream,
+      request,
+      revalidateSeconds: typeof route.page?.revalidate === "number" ? route.page.revalidate : null,
+      rootForbiddenModule,
+      rootNotFoundModule,
+      rootUnauthorizedModule,
+      route,
+      runWithSuppressedHookWarning(probe) {
+        return _suppressHookWarningAls.run(true, probe);
+      },
+      scheduleBackgroundRegeneration(key, renderFn, errorContext) {
+        __triggerBackgroundRegeneration(key, renderFn, errorContext);
+      },
+      scriptNonce,
+      searchParams,
+      setNavigationContext,
+    });
+  },
+  dispatchMatchedRouteHandler({
+    cleanPathname,
+    middlewareContext,
+    params,
+    request,
+    route,
+    searchParams,
+  }) {
     return __dispatchAppRouteHandler({
       basePath: __basePath,
       cleanPathname,
-      clearRequestContext: function() {
+      clearRequestContext() {
         __clearRequestContext();
       },
       i18n: __i18nConfig,
@@ -6906,8 +5531,8 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       isrGet: __isrGet,
       isrRouteKey: __isrRouteKey,
       isrSet: __isrSet,
-      middlewareContext: _mwCtx,
-      middlewareRequestHeaders: _mwCtx.requestHeaders,
+      middlewareContext,
+      middlewareRequestHeaders: middlewareContext.requestHeaders,
       params,
       request,
       route: {
@@ -6916,104 +5541,153 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
         routeSegments: route.routeSegments,
       },
       scheduleBackgroundRegeneration: __triggerBackgroundRegeneration,
-      searchParams: url.searchParams,
+      searchParams,
     });
-  }
-
-  const PageComponent = route.page?.default;
-  const _asyncRouteParams = makeThenableParams(params);
-  return __dispatchAppPage({
-    buildPageElement(targetRoute, targetParams, targetOpts, targetSearchParams) {
-      return buildPageElements(targetRoute, targetParams, cleanPathname, {
-        opts: targetOpts,
-        searchParams: targetSearchParams,
-        isRscRequest,
-        request,
-        mountedSlotsHeader: __mountedSlotsHeader,
-      });
-    },
+  },
+  
+  handleProgressiveActionRequest({
+    actionId,
     cleanPathname,
-    clearRequestContext() {
-      __clearRequestContext();
-    },
-    createRscOnErrorHandler(pathname, routePath) {
-      return createRscOnErrorHandler(request, pathname, routePath);
-    },
-    debugClassification: __classDebug,
-    dynamicConfig: route.page?.dynamic,
-    dynamicParamsConfig: route.page?.dynamicParams,
-    findIntercept(pathname) {
-      return findIntercept(pathname, interceptionContextHeader);
-    },
-    generateStaticParams: route.page?.generateStaticParams,
-    getFontLinks: _getSSRFontLinks,
-    getFontPreloads: _getSSRFontPreloads,
-    getFontStyles: _getSSRFontStyles,
-    getNavigationContext: _getNavigationContext,
-    getSourceRoute(sourceRouteIndex) {
-      return routes[sourceRouteIndex];
-    },
-    hasGenerateStaticParams: typeof route.page?.generateStaticParams === "function",
-    hasPageDefaultExport: !!PageComponent,
-    hasPageModule: !!route.page,
-    handlerStart: __reqStart,
-    interceptionContext: interceptionContextHeader,
-    isProduction: process.env.NODE_ENV === "production",
-    isRscRequest,
-    isrDebug: __isrDebug,
-    isrGet: __isrGet,
-    isrHtmlKey: __isrHtmlKey,
-    isrRscKey: __isrRscKey,
-    isrSet: __isrSet,
-    loadSsrHandler() {
-      return import.meta.viteRsc.loadModule("ssr", "index");
-    },
-    middlewareContext: _mwCtx,
-    mountedSlotsHeader: __mountedSlotsHeader,
-    params,
-    probeLayoutAt(li) {
-      const LayoutComp = route.layouts[li]?.default;
-      if (!LayoutComp) return null;
-      return LayoutComp({
-        params: makeThenableParams(__resolveAppPageSegmentParams(
-          route.routeSegments,
-          route.layoutTreePositions?.[li] ?? 0,
-          params,
-        )),
-        children: null,
-      });
-    },
-    probePage() {
-      if (!PageComponent) return null;
-      const _asyncSearchParams = makeThenableParams(
-        __collectAppPageSearchParams(url.searchParams).searchParamsObject,
-      );
-      return PageComponent({ params: _asyncRouteParams, searchParams: _asyncSearchParams });
-    },
-    renderErrorBoundaryPage(renderErr) {
-      return renderErrorBoundaryPage(route, renderErr, isRscRequest, request, params, _scriptNonce, _mwCtx);
-    },
-    renderHttpAccessFallbackPage(statusCode, opts, middlewareContext) {
-      return renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, opts, _scriptNonce, middlewareContext);
-    },
-    renderToReadableStream,
+    contentType,
+    middlewareContext,
     request,
-    revalidateSeconds: typeof route.page?.revalidate === "number" ? route.page.revalidate : null,
-    rootForbiddenModule,
-    rootNotFoundModule,
-    rootUnauthorizedModule,
-    route,
-    runWithSuppressedHookWarning(probe) {
-      return _suppressHookWarningAls.run(true, probe);
-    },
-    scheduleBackgroundRegeneration(key, renderFn, errorContext) {
-      __triggerBackgroundRegeneration(key, renderFn, errorContext);
-    },
-    scriptNonce: _scriptNonce,
-    searchParams: url.searchParams,
-    setNavigationContext,
-  });
-}
+  }) {
+    return __handleProgressiveServerActionRequest({
+      actionId,
+      allowedOrigins: __allowedOrigins,
+      cleanPathname,
+      clearRequestContext() {
+        __clearRequestContext();
+      },
+      contentType,
+      decodeAction,
+      getAndClearPendingCookies,
+      getDraftModeCookieHeader,
+      maxActionBodySize: __MAX_ACTION_BODY_SIZE,
+      middlewareHeaders: middlewareContext.headers,
+      readFormDataWithLimit: __readFormDataWithLimit,
+      reportRequestError: _reportRequestError,
+      request,
+      setHeadersAccessPhase,
+    });
+  },
+  handleServerActionRequest({
+    actionId,
+    cleanPathname,
+    contentType,
+    interceptionContext,
+    isRscRequest,
+    middlewareContext,
+    mountedSlotsHeader,
+    request,
+    searchParams,
+  }) {
+    return __handleServerActionRscRequest({
+      actionId,
+      allowedOrigins: __allowedOrigins,
+      buildPageElement({
+        route: actionRoute,
+        params: actionParams,
+        cleanPathname: actionCleanPathname,
+        interceptOpts,
+        searchParams: actionSearchParams,
+        isRscRequest: actionIsRscRequest,
+        request: actionRequest,
+        mountedSlotsHeader: actionMountedSlotsHeader,
+      }) {
+        return buildPageElements(actionRoute, actionParams, actionCleanPathname, {
+          opts: interceptOpts,
+          searchParams: actionSearchParams,
+          isRscRequest: actionIsRscRequest,
+          request: actionRequest,
+          mountedSlotsHeader: actionMountedSlotsHeader,
+        });
+      },
+      cleanPathname,
+      clearRequestContext() {
+        __clearRequestContext();
+      },
+      contentType,
+      createNotFoundElement(actionRouteId) {
+        return {
+          [__APP_INTERCEPTION_CONTEXT_KEY]: null,
+          __route: actionRouteId,
+          __rootLayout: null,
+          [actionRouteId]: createElement("div", null, "Page not found"),
+        };
+      },
+      createPayloadRouteId(pathnameToRender, currentInterceptionContext) {
+        return __createAppPayloadRouteId(pathnameToRender, currentInterceptionContext);
+      },
+      createRscOnErrorHandler(actionRequest, actionPathname, routePattern) {
+        return createRscOnErrorHandler(actionRequest, actionPathname, routePattern);
+      },
+      createTemporaryReferenceSet,
+      decodeReply,
+      findIntercept(pathnameToMatch) {
+        return findIntercept(pathnameToMatch, interceptionContext);
+      },
+      getAndClearPendingCookies,
+      getDraftModeCookieHeader,
+      getRouteParamNames(sourceRoute) {
+        return sourceRoute.params;
+      },
+      getSourceRoute(sourceRouteIndex) {
+        return routes[sourceRouteIndex];
+      },
+      isRscRequest,
+      loadServerAction,
+      matchRoute(pathnameToMatch) {
+        return matchRoute(pathnameToMatch);
+      },
+      maxActionBodySize: __MAX_ACTION_BODY_SIZE,
+      middlewareHeaders: middlewareContext.headers,
+      middlewareStatus: middlewareContext.status,
+      mountedSlotsHeader,
+      readBodyWithLimit: __readBodyWithLimit,
+      readFormDataWithLimit: __readFormDataWithLimit,
+      renderToReadableStream,
+      reportRequestError: _reportRequestError,
+      request,
+      sanitizeErrorForClient(error) {
+        return __sanitizeErrorForClient(error);
+      },
+      searchParams,
+      setHeadersAccessPhase,
+      setNavigationContext,
+      toInterceptOpts(intercept) {
+        return {
+          interceptionContext,
+          interceptLayouts: intercept.interceptLayouts,
+          interceptSlotKey: intercept.slotKey,
+          interceptPage: intercept.page,
+          interceptParams: intercept.matchedParams,
+        };
+      },
+    });
+  },
+  i18nConfig: __i18nConfig,
+  
+  makeThenableParams,
+  matchRoute(pathnameToMatch) {
+    return matchRoute(pathnameToMatch);
+  },
+  metadataRoutes,
+  middlewareIsProxy: false,
+  middlewareModule: middlewareModule,
+  publicFiles: __publicFiles,
+  renderNotFoundPage({ isRscRequest, matchedParams, middlewareContext, request, route, scriptNonce }) {
+    return renderNotFoundPage(route, isRscRequest, request, matchedParams, scriptNonce, middlewareContext);
+  },
+  
+  rootParamNamesMap,
+  setNavigationContext,
+  staticParamsMap: generateStaticParamsMap,
+  trailingSlash: __trailingSlash,
+  validateDevRequestOrigin(request) {
+    return __validateDevRequestOrigin(request);
+  },
+});
 
 if (import.meta.hot) {
   import.meta.hot.accept();
@@ -7054,7 +5728,6 @@ const pageLoaders = {
   "/counter": () => import("<ROOT>/tests/fixtures/pages-basic/pages/counter.tsx"),
   "/dynamic-page": () => import("<ROOT>/tests/fixtures/pages-basic/pages/dynamic-page.tsx"),
   "/dynamic-ssr-false": () => import("<ROOT>/tests/fixtures/pages-basic/pages/dynamic-ssr-false.tsx"),
-  "/error-throw": () => import("<ROOT>/tests/fixtures/pages-basic/pages/error-throw.tsx"),
   "/header-override-delete": () => import("<ROOT>/tests/fixtures/pages-basic/pages/header-override-delete.tsx"),
   "/instrumentation-client": () => import("<ROOT>/tests/fixtures/pages-basic/pages/instrumentation-client.tsx"),
   "/isr-second-render-state": () => import("<ROOT>/tests/fixtures/pages-basic/pages/isr-second-render-state.tsx"),
@@ -7242,31 +5915,30 @@ import * as page_11 from "<ROOT>/tests/fixtures/pages-basic/pages/config-test.ts
 import * as page_12 from "<ROOT>/tests/fixtures/pages-basic/pages/counter.tsx";
 import * as page_13 from "<ROOT>/tests/fixtures/pages-basic/pages/dynamic-page.tsx";
 import * as page_14 from "<ROOT>/tests/fixtures/pages-basic/pages/dynamic-ssr-false.tsx";
-import * as page_15 from "<ROOT>/tests/fixtures/pages-basic/pages/error-throw.tsx";
-import * as page_16 from "<ROOT>/tests/fixtures/pages-basic/pages/header-override-delete.tsx";
-import * as page_17 from "<ROOT>/tests/fixtures/pages-basic/pages/instrumentation-client.tsx";
-import * as page_18 from "<ROOT>/tests/fixtures/pages-basic/pages/isr-second-render-state.tsx";
-import * as page_19 from "<ROOT>/tests/fixtures/pages-basic/pages/isr-test.tsx";
-import * as page_20 from "<ROOT>/tests/fixtures/pages-basic/pages/link-test.tsx";
-import * as page_21 from "<ROOT>/tests/fixtures/pages-basic/pages/mw-object-gated.tsx";
-import * as page_22 from "<ROOT>/tests/fixtures/pages-basic/pages/nav-test.tsx";
-import * as page_23 from "<ROOT>/tests/fixtures/pages-basic/pages/posts/missing.tsx";
-import * as page_24 from "<ROOT>/tests/fixtures/pages-basic/pages/redirect-xss.tsx";
-import * as page_25 from "<ROOT>/tests/fixtures/pages-basic/pages/router-events-test.tsx";
-import * as page_26 from "<ROOT>/tests/fixtures/pages-basic/pages/script-test.tsx";
-import * as page_27 from "<ROOT>/tests/fixtures/pages-basic/pages/shallow-test.tsx";
-import * as page_28 from "<ROOT>/tests/fixtures/pages-basic/pages/ssr.tsx";
-import * as page_29 from "<ROOT>/tests/fixtures/pages-basic/pages/ssr-headers.tsx";
-import * as page_30 from "<ROOT>/tests/fixtures/pages-basic/pages/ssr-res-end.tsx";
-import * as page_31 from "<ROOT>/tests/fixtures/pages-basic/pages/streaming-gssp-content-length.tsx";
-import * as page_32 from "<ROOT>/tests/fixtures/pages-basic/pages/streaming-ssr.tsx";
-import * as page_33 from "<ROOT>/tests/fixtures/pages-basic/pages/suspense-test.tsx";
-import * as page_34 from "<ROOT>/tests/fixtures/pages-basic/pages/articles/[id].tsx";
-import * as page_35 from "<ROOT>/tests/fixtures/pages-basic/pages/blog/[slug].tsx";
-import * as page_36 from "<ROOT>/tests/fixtures/pages-basic/pages/posts/[id].tsx";
-import * as page_37 from "<ROOT>/tests/fixtures/pages-basic/pages/products/[pid].tsx";
-import * as page_38 from "<ROOT>/tests/fixtures/pages-basic/pages/docs/[...slug].tsx";
-import * as page_39 from "<ROOT>/tests/fixtures/pages-basic/pages/sign-up/[[...sign-up]]/index.tsx";
+import * as page_15 from "<ROOT>/tests/fixtures/pages-basic/pages/header-override-delete.tsx";
+import * as page_16 from "<ROOT>/tests/fixtures/pages-basic/pages/instrumentation-client.tsx";
+import * as page_17 from "<ROOT>/tests/fixtures/pages-basic/pages/isr-second-render-state.tsx";
+import * as page_18 from "<ROOT>/tests/fixtures/pages-basic/pages/isr-test.tsx";
+import * as page_19 from "<ROOT>/tests/fixtures/pages-basic/pages/link-test.tsx";
+import * as page_20 from "<ROOT>/tests/fixtures/pages-basic/pages/mw-object-gated.tsx";
+import * as page_21 from "<ROOT>/tests/fixtures/pages-basic/pages/nav-test.tsx";
+import * as page_22 from "<ROOT>/tests/fixtures/pages-basic/pages/posts/missing.tsx";
+import * as page_23 from "<ROOT>/tests/fixtures/pages-basic/pages/redirect-xss.tsx";
+import * as page_24 from "<ROOT>/tests/fixtures/pages-basic/pages/router-events-test.tsx";
+import * as page_25 from "<ROOT>/tests/fixtures/pages-basic/pages/script-test.tsx";
+import * as page_26 from "<ROOT>/tests/fixtures/pages-basic/pages/shallow-test.tsx";
+import * as page_27 from "<ROOT>/tests/fixtures/pages-basic/pages/ssr.tsx";
+import * as page_28 from "<ROOT>/tests/fixtures/pages-basic/pages/ssr-headers.tsx";
+import * as page_29 from "<ROOT>/tests/fixtures/pages-basic/pages/ssr-res-end.tsx";
+import * as page_30 from "<ROOT>/tests/fixtures/pages-basic/pages/streaming-gssp-content-length.tsx";
+import * as page_31 from "<ROOT>/tests/fixtures/pages-basic/pages/streaming-ssr.tsx";
+import * as page_32 from "<ROOT>/tests/fixtures/pages-basic/pages/suspense-test.tsx";
+import * as page_33 from "<ROOT>/tests/fixtures/pages-basic/pages/articles/[id].tsx";
+import * as page_34 from "<ROOT>/tests/fixtures/pages-basic/pages/blog/[slug].tsx";
+import * as page_35 from "<ROOT>/tests/fixtures/pages-basic/pages/posts/[id].tsx";
+import * as page_36 from "<ROOT>/tests/fixtures/pages-basic/pages/products/[pid].tsx";
+import * as page_37 from "<ROOT>/tests/fixtures/pages-basic/pages/docs/[...slug].tsx";
+import * as page_38 from "<ROOT>/tests/fixtures/pages-basic/pages/sign-up/[[...sign-up]]/index.tsx";
 import * as api_0 from "<ROOT>/tests/fixtures/pages-basic/pages/api/binary.ts";
 import * as api_1 from "<ROOT>/tests/fixtures/pages-basic/pages/api/echo-body.ts";
 import * as api_2 from "<ROOT>/tests/fixtures/pages-basic/pages/api/error-route.ts";
@@ -7297,31 +5969,30 @@ export const pageRoutes = [
   { pattern: "/counter", patternParts: ["counter"], isDynamic: false, params: [], module: page_12, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/counter.tsx" },
   { pattern: "/dynamic-page", patternParts: ["dynamic-page"], isDynamic: false, params: [], module: page_13, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/dynamic-page.tsx" },
   { pattern: "/dynamic-ssr-false", patternParts: ["dynamic-ssr-false"], isDynamic: false, params: [], module: page_14, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/dynamic-ssr-false.tsx" },
-  { pattern: "/error-throw", patternParts: ["error-throw"], isDynamic: false, params: [], module: page_15, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/error-throw.tsx" },
-  { pattern: "/header-override-delete", patternParts: ["header-override-delete"], isDynamic: false, params: [], module: page_16, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/header-override-delete.tsx" },
-  { pattern: "/instrumentation-client", patternParts: ["instrumentation-client"], isDynamic: false, params: [], module: page_17, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/instrumentation-client.tsx" },
-  { pattern: "/isr-second-render-state", patternParts: ["isr-second-render-state"], isDynamic: false, params: [], module: page_18, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/isr-second-render-state.tsx" },
-  { pattern: "/isr-test", patternParts: ["isr-test"], isDynamic: false, params: [], module: page_19, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/isr-test.tsx" },
-  { pattern: "/link-test", patternParts: ["link-test"], isDynamic: false, params: [], module: page_20, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/link-test.tsx" },
-  { pattern: "/mw-object-gated", patternParts: ["mw-object-gated"], isDynamic: false, params: [], module: page_21, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/mw-object-gated.tsx" },
-  { pattern: "/nav-test", patternParts: ["nav-test"], isDynamic: false, params: [], module: page_22, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/nav-test.tsx" },
-  { pattern: "/posts/missing", patternParts: ["posts","missing"], isDynamic: false, params: [], module: page_23, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/posts/missing.tsx" },
-  { pattern: "/redirect-xss", patternParts: ["redirect-xss"], isDynamic: false, params: [], module: page_24, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/redirect-xss.tsx" },
-  { pattern: "/router-events-test", patternParts: ["router-events-test"], isDynamic: false, params: [], module: page_25, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/router-events-test.tsx" },
-  { pattern: "/script-test", patternParts: ["script-test"], isDynamic: false, params: [], module: page_26, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/script-test.tsx" },
-  { pattern: "/shallow-test", patternParts: ["shallow-test"], isDynamic: false, params: [], module: page_27, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/shallow-test.tsx" },
-  { pattern: "/ssr", patternParts: ["ssr"], isDynamic: false, params: [], module: page_28, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/ssr.tsx" },
-  { pattern: "/ssr-headers", patternParts: ["ssr-headers"], isDynamic: false, params: [], module: page_29, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/ssr-headers.tsx" },
-  { pattern: "/ssr-res-end", patternParts: ["ssr-res-end"], isDynamic: false, params: [], module: page_30, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/ssr-res-end.tsx" },
-  { pattern: "/streaming-gssp-content-length", patternParts: ["streaming-gssp-content-length"], isDynamic: false, params: [], module: page_31, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/streaming-gssp-content-length.tsx" },
-  { pattern: "/streaming-ssr", patternParts: ["streaming-ssr"], isDynamic: false, params: [], module: page_32, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/streaming-ssr.tsx" },
-  { pattern: "/suspense-test", patternParts: ["suspense-test"], isDynamic: false, params: [], module: page_33, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/suspense-test.tsx" },
-  { pattern: "/articles/:id", patternParts: ["articles",":id"], isDynamic: true, params: ["id"], module: page_34, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/articles/[id].tsx" },
-  { pattern: "/blog/:slug", patternParts: ["blog",":slug"], isDynamic: true, params: ["slug"], module: page_35, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/blog/[slug].tsx" },
-  { pattern: "/posts/:id", patternParts: ["posts",":id"], isDynamic: true, params: ["id"], module: page_36, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/posts/[id].tsx" },
-  { pattern: "/products/:pid", patternParts: ["products",":pid"], isDynamic: true, params: ["pid"], module: page_37, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/products/[pid].tsx" },
-  { pattern: "/docs/:slug+", patternParts: ["docs",":slug+"], isDynamic: true, params: ["slug"], module: page_38, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/docs/[...slug].tsx" },
-  { pattern: "/sign-up/:sign-up*", patternParts: ["sign-up",":sign-up*"], isDynamic: true, params: ["sign-up"], module: page_39, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/sign-up/[[...sign-up]]/index.tsx" }
+  { pattern: "/header-override-delete", patternParts: ["header-override-delete"], isDynamic: false, params: [], module: page_15, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/header-override-delete.tsx" },
+  { pattern: "/instrumentation-client", patternParts: ["instrumentation-client"], isDynamic: false, params: [], module: page_16, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/instrumentation-client.tsx" },
+  { pattern: "/isr-second-render-state", patternParts: ["isr-second-render-state"], isDynamic: false, params: [], module: page_17, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/isr-second-render-state.tsx" },
+  { pattern: "/isr-test", patternParts: ["isr-test"], isDynamic: false, params: [], module: page_18, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/isr-test.tsx" },
+  { pattern: "/link-test", patternParts: ["link-test"], isDynamic: false, params: [], module: page_19, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/link-test.tsx" },
+  { pattern: "/mw-object-gated", patternParts: ["mw-object-gated"], isDynamic: false, params: [], module: page_20, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/mw-object-gated.tsx" },
+  { pattern: "/nav-test", patternParts: ["nav-test"], isDynamic: false, params: [], module: page_21, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/nav-test.tsx" },
+  { pattern: "/posts/missing", patternParts: ["posts","missing"], isDynamic: false, params: [], module: page_22, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/posts/missing.tsx" },
+  { pattern: "/redirect-xss", patternParts: ["redirect-xss"], isDynamic: false, params: [], module: page_23, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/redirect-xss.tsx" },
+  { pattern: "/router-events-test", patternParts: ["router-events-test"], isDynamic: false, params: [], module: page_24, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/router-events-test.tsx" },
+  { pattern: "/script-test", patternParts: ["script-test"], isDynamic: false, params: [], module: page_25, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/script-test.tsx" },
+  { pattern: "/shallow-test", patternParts: ["shallow-test"], isDynamic: false, params: [], module: page_26, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/shallow-test.tsx" },
+  { pattern: "/ssr", patternParts: ["ssr"], isDynamic: false, params: [], module: page_27, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/ssr.tsx" },
+  { pattern: "/ssr-headers", patternParts: ["ssr-headers"], isDynamic: false, params: [], module: page_28, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/ssr-headers.tsx" },
+  { pattern: "/ssr-res-end", patternParts: ["ssr-res-end"], isDynamic: false, params: [], module: page_29, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/ssr-res-end.tsx" },
+  { pattern: "/streaming-gssp-content-length", patternParts: ["streaming-gssp-content-length"], isDynamic: false, params: [], module: page_30, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/streaming-gssp-content-length.tsx" },
+  { pattern: "/streaming-ssr", patternParts: ["streaming-ssr"], isDynamic: false, params: [], module: page_31, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/streaming-ssr.tsx" },
+  { pattern: "/suspense-test", patternParts: ["suspense-test"], isDynamic: false, params: [], module: page_32, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/suspense-test.tsx" },
+  { pattern: "/articles/:id", patternParts: ["articles",":id"], isDynamic: true, params: ["id"], module: page_33, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/articles/[id].tsx" },
+  { pattern: "/blog/:slug", patternParts: ["blog",":slug"], isDynamic: true, params: ["slug"], module: page_34, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/blog/[slug].tsx" },
+  { pattern: "/posts/:id", patternParts: ["posts",":id"], isDynamic: true, params: ["id"], module: page_35, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/posts/[id].tsx" },
+  { pattern: "/products/:pid", patternParts: ["products",":pid"], isDynamic: true, params: ["pid"], module: page_36, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/products/[pid].tsx" },
+  { pattern: "/docs/:slug+", patternParts: ["docs",":slug+"], isDynamic: true, params: ["slug"], module: page_37, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/docs/[...slug].tsx" },
+  { pattern: "/sign-up/:sign-up*", patternParts: ["sign-up",":sign-up*"], isDynamic: true, params: ["sign-up"], module: page_38, filePath: "<ROOT>/tests/fixtures/pages-basic/pages/sign-up/[[...sign-up]]/index.tsx" }
 ];
 const _pageRouteTrie = _buildRouteTrie(pageRoutes);
 

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -3475,7 +3475,7 @@ describe("App Router next.config.js features (generateRscEntry)", () => {
     },
   ] as any[];
 
-  it("generates redirect handling code when redirects are provided", () => {
+  it("embeds redirect config for createAppRscHandler when redirects are provided", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes, null, [], null, "", false, {
       redirects: [
         { source: "/old-about", destination: "/about", permanent: true },
@@ -3483,13 +3483,14 @@ describe("App Router next.config.js features (generateRscEntry)", () => {
       ],
     });
     expect(code).toContain("__configRedirects");
-    expect(code).toContain("matchRedirect");
+    expect(code).toContain("configRedirects: __configRedirects");
+    expect(code).toContain("createAppRscHandler as __createAppRscHandler");
     expect(code).toContain("/old-about");
     expect(code).toContain("/old-blog/:slug");
     expect(code).toContain("permanent");
   });
 
-  it("generates rewrite handling code when rewrites are provided", () => {
+  it("embeds rewrite config for createAppRscHandler when rewrites are provided", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes, null, [], null, "", false, {
       rewrites: {
         beforeFiles: [{ source: "/before-rewrite", destination: "/about" }],
@@ -3498,7 +3499,8 @@ describe("App Router next.config.js features (generateRscEntry)", () => {
       },
     });
     expect(code).toContain("__configRewrites");
-    expect(code).toContain("matchRewrite");
+    expect(code).toContain("configRewrites: __configRewrites");
+    expect(code).toContain("createAppRscHandler as __createAppRscHandler");
     expect(code).toContain("beforeFiles");
     expect(code).toContain("afterFiles");
     expect(code).toContain("fallback");
@@ -3507,12 +3509,13 @@ describe("App Router next.config.js features (generateRscEntry)", () => {
     expect(code).toContain("/fallback-rewrite");
   });
 
-  it("generates custom header handling code when headers are provided", () => {
+  it("embeds config headers for createAppRscHandler when headers are provided", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes, null, [], null, "", false, {
       headers: [{ source: "/api/(.*)", headers: [{ key: "X-Custom-Header", value: "vinext" }] }],
     });
     expect(code).toContain("__configHeaders");
-    expect(code).toContain("applyConfigHeadersToResponse");
+    expect(code).toContain("configHeaders: __configHeaders");
+    expect(code).toContain("createAppRscHandler as __createAppRscHandler");
     expect(code).toContain("X-Custom-Header");
     expect(code).toContain("vinext");
   });
@@ -3537,13 +3540,12 @@ describe("App Router next.config.js features (generateRscEntry)", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes, null, [], null, "", false, {
       redirects: [{ source: "/docs/:path*", destination: "/wiki/:path*", permanent: false }],
     });
-    // matchConfigPattern is now used internally by matchRedirect/matchRewrite via config-matchers import
-    expect(code).toContain("matchRedirect");
+    expect(code).toContain("configRedirects: __configRedirects");
     // Should handle catch-all patterns
     expect(code).toContain(":path*");
   });
 
-  it("threads proxy.ts identity into shared middleware runtime", () => {
+  it("threads proxy.ts identity into createAppRscHandler", () => {
     const code = generateRscEntry(
       "/tmp/test/app",
       minimalRoutes,
@@ -3553,13 +3555,12 @@ describe("App Router next.config.js features (generateRscEntry)", () => {
       "",
       false,
     );
-    expect(code).toContain("import { applyAppMiddleware as __applyAppMiddleware }");
-    expect(code).toContain("const __mwResult = await __applyAppMiddleware({");
-    expect(code).toContain("isProxy: true");
-    expect(code).toContain("module: middlewareModule");
+    expect(code).toContain("createAppRscHandler as __createAppRscHandler");
+    expect(code).toContain("middlewareIsProxy: true");
+    expect(code).toContain("middlewareModule: middlewareModule");
   });
 
-  it("seeds the Workers execution context for shared middleware runtime", () => {
+  it("delegates middleware execution details to createAppRscHandler", () => {
     const code = generateRscEntry(
       "/tmp/test/app",
       minimalRoutes,
@@ -3569,27 +3570,22 @@ describe("App Router next.config.js features (generateRscEntry)", () => {
       "",
       false,
     );
-    // Middleware waitUntil draining lives in the shared middleware runtime.
-    // The generated entry is responsible for seeding the per-request Workers
-    // execution context that shared runtime reads from.
-    expect(code).toContain("_getRequestExecutionContext()");
-    expect(code).toContain("executionContext: ctx ?? _getRequestExecutionContext() ?? null");
-    expect(code).toContain("const __mwResult = await __applyAppMiddleware({");
+    expect(code).toContain("createAppRscHandler as __createAppRscHandler");
+    expect(code).toContain("middlewareIsProxy: false");
+    expect(code).toContain("middlewareModule: middlewareModule");
+    expect(code).not.toContain("const __mwResult = await __applyAppMiddleware({");
   });
 
-  it("applies redirects before middleware in the handler", () => {
+  it("delegates redirect ordering to createAppRscHandler", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes, null, [], null, "", false, {
       redirects: [{ source: "/old", destination: "/new", permanent: true }],
     });
-    // The redirect check should appear before middleware and route matching
-    const redirectIdx = code.indexOf("matchRedirect(__redirPathname");
-    const routeMatchIdx = code.indexOf("matchRoute(cleanPathname");
-    expect(redirectIdx).toBeGreaterThan(-1);
-    expect(routeMatchIdx).toBeGreaterThan(-1);
-    expect(redirectIdx).toBeLessThan(routeMatchIdx);
+    expect(code).toContain("configRedirects: __configRedirects");
+    expect(code).toContain("createAppRscHandler as __createAppRscHandler");
+    expect(code).not.toContain("matchRedirect(__redirPathname");
   });
 
-  it("applies beforeFiles rewrites before route matching", () => {
+  it("delegates beforeFiles rewrite ordering to createAppRscHandler", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes, null, [], null, "", false, {
       rewrites: {
         beforeFiles: [{ source: "/old", destination: "/new" }],
@@ -3597,19 +3593,12 @@ describe("App Router next.config.js features (generateRscEntry)", () => {
         fallback: [],
       },
     });
-    const beforeIdx = code.indexOf("__configRewrites.beforeFiles");
-    const routeMatchIdx = code.indexOf("matchRoute(cleanPathname");
-    expect(beforeIdx).toBeGreaterThan(-1);
-    expect(routeMatchIdx).toBeGreaterThan(-1);
-    expect(beforeIdx).toBeLessThan(routeMatchIdx);
+    expect(code).toContain("configRewrites: __configRewrites");
+    expect(code).toContain('"beforeFiles":[{"source":"/old","destination":"/new"}]');
+    expect(code).not.toContain("matchRewrite(cleanPathname, __configRewrites.beforeFiles");
   });
 
-  it("strips .rsc suffix before matching beforeFiles rewrite rules", () => {
-    // RSC (soft-nav) requests arrive as /some/path.rsc but rewrite patterns
-    // are defined without the extension. The generated code must strip .rsc
-    // before calling matchRewrite for beforeFiles.
-    // beforeFiles now runs after middleware (using __postMwReqCtx), and
-    // cleanPathname has already had .rsc stripped at that point.
+  it("keeps .rsc rewrite normalization inside createAppRscHandler", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes, null, [], null, "", false, {
       rewrites: {
         beforeFiles: [{ source: "/old", destination: "/new" }],
@@ -3617,19 +3606,12 @@ describe("App Router next.config.js features (generateRscEntry)", () => {
         fallback: [],
       },
     });
-    // The generated code uses cleanPathname (already .rsc-stripped) when
-    // calling matchRewrite for beforeFiles.
-    const beforeFilesCallIdx = code.indexOf(
-      "matchRewrite(cleanPathname, __configRewrites.beforeFiles",
-    );
-    expect(beforeFilesCallIdx).toBeGreaterThan(-1);
-    // The cleanPathname assignment (stripping .rsc) must appear before the beforeFiles call
-    const cleanPathnameIdx = code.indexOf("cleanPathname = pathname.replace");
-    expect(cleanPathnameIdx).toBeGreaterThan(-1);
-    expect(cleanPathnameIdx).toBeLessThan(beforeFilesCallIdx);
+    expect(code).toContain("configRewrites: __configRewrites");
+    expect(code).toContain("createAppRscHandler as __createAppRscHandler");
+    expect(code).not.toContain("cleanPathname = pathname.replace");
   });
 
-  it("applies afterFiles rewrites in the handler code", () => {
+  it("embeds afterFiles rewrites for createAppRscHandler", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes, null, [], null, "", false, {
       rewrites: {
         beforeFiles: [],
@@ -3637,16 +3619,11 @@ describe("App Router next.config.js features (generateRscEntry)", () => {
         fallback: [],
       },
     });
-    expect(code).toContain("__configRewrites.afterFiles");
-    // afterFiles rewrite applies in the request handler, after beforeFiles
-    const afterIdx = code.indexOf("__configRewrites.afterFiles");
-    const beforeIdx = code.indexOf("__configRewrites.beforeFiles");
-    expect(afterIdx).toBeGreaterThan(-1);
-    expect(beforeIdx).toBeGreaterThan(-1);
-    expect(afterIdx).toBeGreaterThan(beforeIdx);
+    expect(code).toContain("configRewrites: __configRewrites");
+    expect(code).toContain('"afterFiles":[{"source":"/old","destination":"/new"}]');
   });
 
-  it("applies fallback rewrites when no route matches", () => {
+  it("embeds fallback rewrites for createAppRscHandler", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes, null, [], null, "", false, {
       rewrites: {
         beforeFiles: [],
@@ -3654,14 +3631,11 @@ describe("App Router next.config.js features (generateRscEntry)", () => {
         fallback: [{ source: "/fallback", destination: "/about" }],
       },
     });
-    // Fallback rewrites should be inside a "!match" block
-    expect(code).toContain("__configRewrites.fallback");
-    const fallbackIdx = code.indexOf("__configRewrites.fallback");
-    const noMatchIdx = code.indexOf("if (!match");
-    expect(fallbackIdx).toBeGreaterThan(noMatchIdx);
+    expect(code).toContain("configRewrites: __configRewrites");
+    expect(code).toContain('"fallback":[{"source":"/fallback","destination":"/about"}]');
   });
 
-  it("generates external URL proxy helpers for external rewrites", () => {
+  it("serializes external rewrites while keeping proxy helpers out of codegen", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes, null, [], null, "", false, {
       rewrites: {
         beforeFiles: [{ source: "/ph/:path*", destination: "https://us.i.posthog.com/:path*" }],
@@ -3669,11 +3643,9 @@ describe("App Router next.config.js features (generateRscEntry)", () => {
         fallback: [],
       },
     });
-    // Should include the external URL detection and proxy functions
-    expect(code).toContain("isExternalUrl");
-    expect(code).toContain("proxyExternalRequest");
-    // beforeFiles rewrite should check for external URL
-    expect(code).toContain("isExternalUrl(__rewritten)");
+    expect(code).toContain("https://us.i.posthog.com/:path*");
+    expect(code).toContain("configRewrites: __configRewrites");
+    expect(code).not.toContain("proxyExternalRequest(request,");
   });
 
   // Ported from Next.js: test/e2e/middleware-rewrites/test/index.test.ts
@@ -3688,14 +3660,13 @@ describe("App Router next.config.js features (generateRscEntry)", () => {
       "",
       false,
     );
-    expect(code).toContain("import { applyAppMiddleware as __applyAppMiddleware }");
-    expect(code).toContain("const __mwResult = await __applyAppMiddleware({");
-    expect(code).toContain("module: middlewareModule");
+    expect(code).toContain("createAppRscHandler as __createAppRscHandler");
+    expect(code).toContain("middlewareModule: middlewareModule");
     expect(code).not.toContain('mwResponse.headers.get("x-middleware-rewrite")');
     expect(code).not.toContain("__proxyExternalMiddlewareRewrite(");
   });
 
-  it("generates external URL checks for afterFiles rewrites", () => {
+  it("serializes external afterFiles rewrites without inline URL checks", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes, null, [], null, "", false, {
       rewrites: {
         beforeFiles: [],
@@ -3703,10 +3674,11 @@ describe("App Router next.config.js features (generateRscEntry)", () => {
         fallback: [],
       },
     });
-    expect(code).toContain("isExternalUrl(__afterRewritten)");
+    expect(code).toContain("https://api.example.com/:path*");
+    expect(code).not.toContain("isExternalUrl(__afterRewritten)");
   });
 
-  it("generates external URL checks for fallback rewrites", () => {
+  it("serializes external fallback rewrites without inline URL checks", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes, null, [], null, "", false, {
       rewrites: {
         beforeFiles: [],
@@ -3716,10 +3688,11 @@ describe("App Router next.config.js features (generateRscEntry)", () => {
         ],
       },
     });
-    expect(code).toContain("isExternalUrl(__fallbackRewritten)");
+    expect(code).toContain("https://fallback.example.com/:path*");
+    expect(code).not.toContain("isExternalUrl(__fallbackRewritten)");
   });
 
-  it("uses imported proxyExternalRequest which guards content-encoding stripping to Node runtime", () => {
+  it("keeps external proxy mechanics in createAppRscHandler", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes, null, [], null, "", false, {
       rewrites: {
         beforeFiles: [{ source: "/proxy/:path*", destination: "https://api.example.com/:path*" }],
@@ -3727,41 +3700,36 @@ describe("App Router next.config.js features (generateRscEntry)", () => {
         fallback: [],
       },
     });
-    // proxyExternalRequest is now imported from config-matchers (which contains
-    // the isNodeRuntime guard internally), so verify the import is used.
-    expect(code).toContain("proxyExternalRequest(request,");
+    expect(code).toContain("https://api.example.com/:path*");
+    expect(code).not.toContain("proxyExternalRequest(request,");
   });
 
-  it("adds basePath prefix to redirect destinations", () => {
+  it("passes basePath alongside redirect config", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes, null, [], null, "/app", false, {
       redirects: [{ source: "/old", destination: "/new", permanent: true }],
     });
-    // Generated code should prepend basePath to redirect destination
     expect(code).toContain("__basePath");
-    expect(code).toContain("!isExternalUrl(__redir.destination)");
-    expect(code).toContain("hasBasePath(__redir.destination, __basePath)");
+    expect(code).toContain("basePath: __basePath");
+    expect(code).toContain("configRedirects: __configRedirects");
   });
 
   it("generated RSC entry delegates server action requests to the shared helper", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes, null, [], null, "", false);
     expect(code).toContain("handleServerActionRscRequest as __handleServerActionRscRequest");
-    expect(code).toContain("const serverActionResponse = await __handleServerActionRscRequest({");
+    expect(code).toContain("handleServerActionRequest({");
+    expect(code).toContain("return __handleServerActionRscRequest({");
     expect(code).toContain("allowedOrigins: __allowedOrigins");
     expect(code).toContain("loadServerAction");
     expect(code).toContain("decodeReply");
-
-    const actionStart = code.indexOf("const serverActionResponse");
-    const routingStart = code.indexOf("// ── Apply afterFiles rewrites", actionStart);
-    expect(actionStart).toBeGreaterThan(-1);
-    expect(routingStart).toBeGreaterThan(actionStart);
+    expect(code).not.toContain("const __actionRerenderTarget =");
   });
 
   it("generated RSC entry wires server action body readers into the shared helper", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes, null, [], null, "", false);
-    const actionStart = code.indexOf("const serverActionResponse");
-    const actionEnd = code.indexOf("if (serverActionResponse)", actionStart);
+    const actionStart = code.indexOf("handleServerActionRequest({");
+    const actionEnd = code.indexOf("i18nConfig:", actionStart);
     const actionOptions = code.slice(actionStart, actionEnd);
-    expect(actionOptions).toContain("contentType: actionContentType");
+    expect(actionOptions).toContain("contentType,");
     expect(actionOptions).toContain("readBodyWithLimit: __readBodyWithLimit");
     expect(actionOptions).toContain("readFormDataWithLimit: __readFormDataWithLimit");
     expect(actionOptions).toContain("maxActionBodySize: __MAX_ACTION_BODY_SIZE");
@@ -3794,8 +3762,8 @@ describe("App Router next.config.js features (generateRscEntry)", () => {
 
   it("origin validation does not use x-forwarded-host", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes, null, [], null, "", false);
-    const actionStart = code.indexOf("const serverActionResponse");
-    const actionEnd = code.indexOf("if (serverActionResponse)", actionStart);
+    const actionStart = code.indexOf("handleServerActionRequest({");
+    const actionEnd = code.indexOf("i18nConfig:", actionStart);
     const actionOptions = code.slice(actionStart, actionEnd);
 
     // CSRF behavior belongs to the shared action helper. The generated entry
@@ -3813,15 +3781,8 @@ describe("App Router next.config.js features (generateRscEntry)", () => {
     // Should include the dev origin validation function definition
     expect(code).toContain("__validateDevRequestOrigin");
     expect(code).toContain("__safeDevHosts");
-    // Should call dev origin validation inside _handleRequest
-    const callSite = code.indexOf("const __originBlock = __validateDevRequestOrigin(request)");
-    const handleRequestIdx = code.indexOf(
-      "async function _handleRequest(request, __reqCtx, _mwCtx)",
-    );
-    expect(callSite).toBeGreaterThan(-1);
-    expect(handleRequestIdx).toBeGreaterThan(-1);
-    // The call should be inside the function body (after the function declaration)
-    expect(callSite).toBeGreaterThan(handleRequestIdx);
+    expect(code).toContain("validateDevRequestOrigin(request) {");
+    expect(code).toContain("return __validateDevRequestOrigin(request);");
   });
 
   it("embeds allowedDevOrigins in dev origin check code", () => {
@@ -4578,7 +4539,8 @@ describe("generateRscEntry ISR code generation", () => {
     expect(code).toContain("isrSet as __isrSet");
     expect(code).toContain("triggerBackgroundRegeneration as __triggerBackgroundRegeneration");
     expect(code).toContain("appIsrHtmlKey as __isrHtmlKey");
-    expect(code).toContain("normalizeMountedSlotsHeader as __normalizeMountedSlotsHeader");
+    expect(code).toContain("createAppRscHandler as __createAppRscHandler");
+    expect(code).not.toContain("normalizeMountedSlotsHeader as __normalizeMountedSlotsHeader");
     expect(code).not.toContain("async function __isrGet(");
     expect(code).not.toContain("function __isrCacheKey(");
     expect(code).not.toContain("const __pendingRegenerations = new Map()");
@@ -4586,23 +4548,22 @@ describe("generateRscEntry ISR code generation", () => {
 
   it("generated code delegates page dispatch and route ISR separately", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes);
-    expect(code).toContain("buildPageCacheTags");
-    expect(code).toContain('buildPageCacheTags(cleanPathname, [], route.routeSegments, "route")');
     expect(code).toContain("dispatchAppPage as __dispatchAppPage");
     expect(code).toContain("return __dispatchAppPage({");
     expect(code).toContain("dispatchAppRouteHandler as __dispatchAppRouteHandler");
     expect(code).toContain("return __dispatchAppRouteHandler({");
     expect(code).toContain("scheduleBackgroundRegeneration: __triggerBackgroundRegeneration");
     expect(code).toContain("isrSet: __isrSet");
+    expect(code).not.toContain("buildPageCacheTags(");
     expect(code).not.toContain("getCollectedFetchTags");
     expect(code).not.toContain("function __pageCacheTags(");
     expect(code).not.toContain('route.routeHandler ? "route" : "page"');
   });
 
-  it("generated handler exports async function handler(request, ctx)", () => {
+  it("generated handler exports the createAppRscHandler runtime factory", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes);
-    // The handler must accept a ctx param so ExecutionContext is threaded through
-    expect(code).toMatch(/export default async function handler\s*\(\s*request\s*,\s*ctx\s*\)/);
+    expect(code).toContain("createAppRscHandler as __createAppRscHandler");
+    expect(code).toContain("export default __createAppRscHandler({");
   });
 
   it("generated code leaves cache handler access to the ISR cache module", () => {
@@ -4629,9 +4590,9 @@ describe("generateRscEntry ISR code generation", () => {
     const code = generateRscEntry("/tmp/test/app", routes);
 
     expect(code).toContain("setRootParams as __setRootParams");
-    expect(code).toContain("pickRootParams as __pickRootParams");
     expect(code).toContain('rootParamNames: ["lang","locale"]');
-    expect(code).toContain("__setRootParams(__pickRootParams(params, route.rootParamNames));");
+    expect(code).toContain("const rootParamNamesMap = {");
+    expect(code).toContain("rootParamNamesMap,");
     expect(code).toContain("function __clearRequestContext() {");
     expect(code).toContain("__setRootParams(null);");
   });
@@ -4639,7 +4600,7 @@ describe("generateRscEntry ISR code generation", () => {
   it("generated root params selection is delegated to the runtime shim", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes);
 
-    expect(code).toContain("pickRootParams as __pickRootParams");
+    expect(code).toContain("rootParamNamesMap,");
     expect(code).not.toContain("function __pickRootParams(params, rootParamNames)");
   });
 
@@ -4669,7 +4630,9 @@ describe("generateRscEntry ISR code generation", () => {
       "buildPageElement(targetRoute, targetParams, targetOpts, targetSearchParams)",
     );
     expect(code).toContain("renderErrorBoundaryPage(renderErr) {");
-    expect(code).toContain("renderHttpAccessFallbackPage(statusCode, opts, middlewareContext) {");
+    expect(code).toContain(
+      "renderHttpAccessFallbackPage(statusCode, opts, currentMiddlewareContext) {",
+    );
     expect(code).toContain("getFontLinks: _getSSRFontLinks");
     expect(code).toContain("getFontPreloads: _getSSRFontPreloads");
     expect(code).toContain("getFontStyles: _getSSRFontStyles");
@@ -4772,17 +4735,17 @@ describe("generateRscEntry ISR code generation", () => {
 
     expect(code).toContain("const rootParamNamesMap = {");
     expect(code).toContain('"/:locale/blog/:slug": ["locale"]');
-    expect(code).toContain("rootParamNamesByPattern: rootParamNamesMap");
-    expect(code).toContain("handleAppPrerenderEndpoint as __handleAppPrerenderEndpoint");
+    expect(code).toContain("createAppRscHandler as __createAppRscHandler");
+    expect(code).toContain("rootParamNamesMap,");
+    expect(code).toContain("staticParamsMap: generateStaticParamsMap,");
   });
 
   it("generated code delegates page boundary rendering to typed helpers", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes);
     expect(code).toContain("renderAppPageErrorBoundary as __renderAppPageErrorBoundary");
     expect(code).toContain("renderAppPageHttpAccessFallback as __renderAppPageHttpAccessFallback");
-    expect(code).toContain(
-      "const _scriptNonce = __getScriptNonceFromHeaderSources(request.headers, _mwCtx.headers);",
-    );
+    expect(code).toContain("scriptNonce,");
+    expect(code).toContain("middlewareContext: middlewareContext ?? __APP_PAGE_EMPTY_MW_CTX");
     expect(code).toContain("return __renderAppPageHttpAccessFallback({");
     expect(code).toContain("return __renderAppPageErrorBoundary({");
   });
@@ -4792,10 +4755,9 @@ describe("generateRscEntry ISR code generation", () => {
 
     expect(code).toContain("const __APP_PAGE_EMPTY_MW_CTX = { headers: null, status: null };");
     expect(code).toContain("middlewareContext: middlewareContext ?? __APP_PAGE_EMPTY_MW_CTX");
-    expect(code).toContain("middlewareContext: _mwCtx");
-    expect(code).toContain("__mergeMiddlewareResponseHeaders(notFoundHeaders, _mwCtx.headers)");
+    expect(code).toContain("middlewareContext,");
     expect(code).toContain("renderHTTPAccessFallbackPage(route, statusCode");
-    expect(code).toContain("return renderErrorBoundaryPage(route, renderErr");
+    expect(code).toContain("renderErrorBoundaryPage(renderErr) {");
     expect(code).not.toContain("renderSpecialError(__buildSpecialError)");
   });
 
@@ -4830,7 +4792,7 @@ describe("generateRscEntry ISR code generation", () => {
     // Intercept response construction now lives in app-page-dispatch; generated
     // code passes the middleware response state into that helper.
     expect(code).toContain("return __dispatchAppPage({");
-    expect(code).toContain("middlewareContext: _mwCtx");
+    expect(code).toContain("middlewareContext,");
     expect(code).not.toContain("renderInterceptResponse(sourceRoute, interceptElement)");
   });
 
@@ -4838,26 +4800,28 @@ describe("generateRscEntry ISR code generation", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes);
     // The shared action helper owns response construction; generated code must
     // pass the middleware response state into that helper.
-    const actionStart = code.indexOf("const serverActionResponse");
-    const actionEnd = code.indexOf("if (serverActionResponse)", actionStart);
+    const actionStart = code.indexOf("handleServerActionRequest({");
+    const actionEnd = code.indexOf("i18nConfig:", actionStart);
     const actionOptions = code.slice(actionStart, actionEnd);
-    expect(actionOptions).toContain("middlewareHeaders: _mwCtx.headers");
-    expect(actionOptions).toContain("middlewareStatus: _mwCtx.status");
+    expect(actionOptions).toContain("middlewareHeaders: middlewareContext.headers");
+    expect(actionOptions).toContain("middlewareStatus: middlewareContext.status");
   });
 
-  it("generated code accepts both vinext and Next.js action header names", () => {
+  it("generated code leaves action header parsing to the shared runtime", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes);
-    expect(code).toContain(
+    expect(code).toContain("handleServerActionRequest({");
+    expect(code).toContain("return __handleServerActionRscRequest({");
+    expect(code).not.toContain(
       'request.headers.get("x-rsc-action") ?? request.headers.get("next-action")',
     );
   });
 
   it("generated code merges middleware headers into server action redirect responses", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes);
-    const actionStart = code.indexOf("const serverActionResponse");
-    const actionEnd = code.indexOf("if (serverActionResponse)", actionStart);
+    const actionStart = code.indexOf("handleServerActionRequest({");
+    const actionEnd = code.indexOf("i18nConfig:", actionStart);
     const actionOptions = code.slice(actionStart, actionEnd);
-    expect(actionOptions).toContain("middlewareHeaders: _mwCtx.headers");
+    expect(actionOptions).toContain("middlewareHeaders: middlewareContext.headers");
   });
 
   // Ported from Next.js: packages/next/src/client/components/redirect.ts

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+import { createAppRscHandler } from "../packages/vinext/src/server/app-rsc-handler.js";
+import { makeThenableParams } from "../packages/vinext/src/shims/thenable-params.js";
+
+type TestRoute = {
+  page?: { default?: unknown } | null;
+  params: readonly string[];
+  pattern: string;
+  rootParamNames?: readonly string[];
+  routeHandler?: { GET?: () => Response } | null;
+  routeSegments: readonly string[];
+};
+
+type TestMatch = {
+  params: Record<string, string | string[]>;
+  route: TestRoute;
+};
+
+type HandlerOptions = Parameters<typeof createAppRscHandler<TestRoute>>[0];
+
+function createPageRoute(): TestRoute {
+  return {
+    page: { default() {} },
+    params: [],
+    pattern: "/about",
+    routeSegments: ["about"],
+  };
+}
+
+function createHandler(overrides: Partial<HandlerOptions> = {}) {
+  const route = createPageRoute();
+
+  return createAppRscHandler<TestRoute>({
+    basePath: "/docs",
+    clearRequestContext: overrides.clearRequestContext ?? (() => {}),
+    configHeaders: [
+      {
+        source: "/about",
+        headers: [{ key: "x-test-header", value: "applied" }],
+      },
+    ],
+    configRedirects: [],
+    configRewrites: {
+      afterFiles: [],
+      beforeFiles: [],
+      fallback: [],
+    },
+    dispatchMatchedPage:
+      overrides.dispatchMatchedPage ??
+      (async () => new Response("page", { status: 200, headers: { "x-from-dispatch": "page" } })),
+    dispatchMatchedRouteHandler:
+      overrides.dispatchMatchedRouteHandler ?? (async () => new Response("route", { status: 200 })),
+    ensureInstrumentation: overrides.ensureInstrumentation ?? (async () => {}),
+    handleProgressiveActionRequest: overrides.handleProgressiveActionRequest ?? (async () => null),
+    handleServerActionRequest: overrides.handleServerActionRequest ?? (async () => null),
+    i18nConfig: overrides.i18nConfig ?? null,
+    matchRoute:
+      overrides.matchRoute ??
+      ((pathname: string): TestMatch | null =>
+        pathname === "/about"
+          ? {
+              params: {},
+              route,
+            }
+          : null),
+    makeThenableParams,
+    metadataRoutes: overrides.metadataRoutes ?? [],
+    middlewareModule: overrides.middlewareModule ?? null,
+    publicFiles: overrides.publicFiles ?? new Set<string>(),
+    renderNotFoundPage: overrides.renderNotFoundPage ?? (async () => null),
+    renderPagesFallback: overrides.renderPagesFallback ?? (async () => null),
+    staticParamsMap: {},
+    setNavigationContext: overrides.setNavigationContext ?? (() => {}),
+    trailingSlash: overrides.trailingSlash ?? false,
+    validateDevRequestOrigin: overrides.validateDevRequestOrigin ?? (() => null),
+  });
+}
+
+describe("app rsc handler", () => {
+  it("applies config headers to non-redirect responses after page dispatch", async () => {
+    const dispatchMatchedPage = vi.fn(async () => new Response("page", { status: 200 }));
+    const handler = createHandler({ dispatchMatchedPage });
+
+    const response = await handler(new Request("https://example.test/docs/about"), null);
+
+    expect(dispatchMatchedPage).toHaveBeenCalledTimes(1);
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-test-header")).toBe("applied");
+  });
+
+  it("skips config headers for redirect responses", async () => {
+    const handler = createHandler({
+      async dispatchMatchedPage() {
+        return Response.redirect("https://example.test/docs/next", 307);
+      },
+    });
+
+    const response = await handler(new Request("https://example.test/docs/about"), null);
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe("https://example.test/docs/next");
+    expect(response.headers.get("x-test-header")).toBeNull();
+  });
+});

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -521,8 +521,8 @@ describe("App Router entry templates", () => {
 
   it("generateRscEntry wires buildPageElements into the server-action helper", () => {
     const code = generateRscEntry("/tmp/test/app", minimalAppRoutes, null, [], null, "", false);
-    const actionStart = code.indexOf("const serverActionResponse");
-    const actionEnd = code.indexOf("if (serverActionResponse)", actionStart);
+    const actionStart = code.indexOf("handleServerActionRequest({");
+    const actionEnd = code.indexOf("i18nConfig:", actionStart);
     const helperOptions = code.slice(actionStart, actionEnd);
 
     expect(helperOptions).toContain("buildPageElement({");
@@ -533,7 +533,8 @@ describe("App Router entry templates", () => {
     const code = generateRscEntry("/tmp/test/app", minimalAppRoutes, null, [], null, "", false);
 
     expect(code).toContain("handleServerActionRscRequest as __handleServerActionRscRequest");
-    expect(code).toContain("const serverActionResponse = await __handleServerActionRscRequest({");
+    expect(code).toContain("handleServerActionRequest({");
+    expect(code).toContain("return __handleServerActionRscRequest({");
     expect(code).not.toContain("const __actionRerenderTarget =");
   });
 
@@ -549,6 +550,17 @@ describe("App Router entry templates", () => {
     );
     expect(code).not.toContain("const __pageBuildResult = await __buildAppPageElement");
     expect(code).not.toContain("return __renderAppPageLifecycle({");
+  });
+
+  it("generateRscEntry delegates top-level request handling to createAppRscHandler", () => {
+    const code = generateRscEntry("/tmp/test/app", minimalAppRoutes, null, [], null, "", false);
+    const stableCode = stabilize(code);
+
+    expect(stableCode).toContain('from "<ROOT>/packages/vinext/src/server/app-rsc-handler.js";');
+    expect(code).toContain("createAppRscHandler as __createAppRscHandler");
+    expect(code).toContain("export default __createAppRscHandler({");
+    expect(code).not.toContain("export default async function handler(");
+    expect(code).not.toContain("async function _handleRequest(");
   });
 
   it("generateRscEntry reuses the canonical tree-path helper for no-export page payloads", () => {
@@ -570,20 +582,15 @@ describe("App Router entry templates", () => {
     expect(code).not.toContain("const _hlFixRe =");
   });
 
-  it("generateRscEntry delegates internal prerender endpoints", () => {
+  it("generateRscEntry passes prerender dependencies into createAppRscHandler", () => {
     const code = generateRscEntry("/tmp/test/app", minimalAppRoutes, null, [], null, "", false, {
       hasPagesDir: true,
     });
-    const stableCode = stabilize(code);
 
-    expect(stableCode).toContain(
-      'from "<ROOT>/packages/vinext/src/server/app-prerender-endpoints.js";',
-    );
-    expect(code).toContain("handleAppPrerenderEndpoint as __handleAppPrerenderEndpoint");
-    expect(code).toContain(
-      "const __prerenderEndpointResponse = await __handleAppPrerenderEndpoint(",
-    );
+    expect(code).toContain("createAppRscHandler as __createAppRscHandler");
     expect(code).toContain("loadPagesRoutes: __loadPrerenderPagesRoutes,");
+    expect(code).toContain("staticParamsMap: generateStaticParamsMap,");
+    expect(code).toContain("rootParamNamesMap,");
     expect(code).not.toContain('if (pathname === "/__vinext/prerender/static-params")');
     expect(code).not.toContain('if (pathname === "/__vinext/prerender/pages-static-paths")');
   });


### PR DESCRIPTION
## Summary

This is stacked on #986

This introduces `createAppRscHandler()` and moves the top-level App Router RSC request lifecycle out of the generated entry and into a normal typed runtime module.

The generated entry now stays focused on app shape:
- route/module imports
- generated manifests and route maps
- thin closures that describe how to dispatch matched pages, route handlers, and server actions

The runtime helper now owns request behavior:
- dev origin checks and unified request context setup
- basePath / trailing-slash normalization
- prerender endpoints
- config redirects and rewrites
- middleware sequencing
- metadata and public file dispatch
- server action handoff
- pages fallback / not-found fallback
- post-response `next.config.js` header application

I also trimmed dead surface from the new seam by removing top-level handler options that were not actually consumed there (`allowedOrigins`, `maxActionBodySize`). Those remain owned by the action helpers, which is a better fit for the “codegen describes shape, normal modules implement behavior” split.

## Why

`app-rsc-entry.ts` had accumulated too much request orchestration. That made the generated output harder to reason about, harder to test directly, and too easy to grow in the wrong direction.

This refactor keeps codegen responsible for describing the app-specific graph while moving stable behavior into importable runtime code with focused tests.

That layering is closer to how Next.js is structured:
- the template builds the route module shape: [packages/next/src/build/templates/app-page.ts#L126-L142](https://github.com/vercel/next.js/blob/canary/packages/next/src/build/templates/app-page.ts#L126-L142)
- the route module exposes the runtime boundary and delegates to rendering logic: [packages/next/src/server/route-modules/app-page/module.ts#L85-L169](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/route-modules/app-page/module.ts#L85-L169)
- request/render orchestration lives in normal runtime code, not the template: [packages/next/src/server/app-render/app-render.tsx#L2568-L3063](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/app-render.tsx#L2568-L3063)
- the exported render entrypoint is a thin boundary over that runtime: [packages/next/src/server/app-render/app-render.tsx#L3077-L3095](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/app-render.tsx#L3077-L3095)

## Tests

- `vp check packages/vinext/src/entries/app-rsc-entry.ts packages/vinext/src/server/app-rsc-handler.ts tests/app-rsc-handler.test.ts tests/app-router.test.ts tests/entry-templates.test.ts`
- `vp test run tests/entry-templates.test.ts -u`
- `vp test run tests/app-rsc-handler.test.ts tests/app-page-dispatch.test.ts tests/entry-templates.test.ts tests/app-router.test.ts tests/app-page-render.test.ts tests/app-page-request.test.ts tests/app-page-cache.test.ts`
