### PR TITLE
fix(app-router): preserve falsy thrown values in error boundaries

### DIFF
--- a/packages/vinext/src/server/app-page-route-wiring.tsx
+++ b/packages/vinext/src/server/app-page-route-wiring.tsx
@@ -28,13 +28,13 @@ import { resolveAppPageSegmentParams } from "./app-page-params.js";
 
 type AppPageComponentProps = {
   children?: ReactNode;
-  error?: Error;
+  error?: unknown;
   params?: unknown;
   reset?: () => void;
 } & Record<string, unknown>;
 
 type AppPageComponent = ComponentType<AppPageComponentProps>;
-type AppPageErrorComponent = ComponentType<{ error: Error; reset: () => void }>;
+type AppPageErrorComponent = ComponentType<{ error: unknown; reset: () => void }>;
 
 export type AppPageModule = Record<string, unknown> & {
   default?: AppPageComponent | null | undefined;

--- a/packages/vinext/src/shims/error-boundary.tsx
+++ b/packages/vinext/src/shims/error-boundary.tsx
@@ -6,8 +6,12 @@ import React from "react";
 import { usePathname } from "./navigation.js";
 
 export type ErrorBoundaryProps = {
-  fallback: React.ComponentType<{ error: Error; reset: () => void }>;
+  fallback: React.ComponentType<{ error: unknown; reset: () => void }>;
   children: React.ReactNode;
+};
+
+type CapturedError = {
+  thrownValue: unknown;
 };
 
 type ErrorBoundaryInnerProps = {
@@ -15,7 +19,7 @@ type ErrorBoundaryInnerProps = {
 } & ErrorBoundaryProps;
 
 export type ErrorBoundaryState = {
-  error: Error | null;
+  error: CapturedError | null;
   previousPathname: string;
 };
 
@@ -43,7 +47,7 @@ export class ErrorBoundaryInner extends React.Component<
     return { error: state.error, previousPathname: props.pathname };
   }
 
-  static getDerivedStateFromError(error: Error): Partial<ErrorBoundaryState> {
+  static getDerivedStateFromError(error: unknown): Partial<ErrorBoundaryState> {
     // notFound(), forbidden(), unauthorized(), and redirect() must propagate
     // past error boundaries. Re-throw them so they bubble up to the
     // framework's HTTP access fallback / redirect handler.
@@ -57,7 +61,7 @@ export class ErrorBoundaryInner extends React.Component<
         throw error;
       }
     }
-    return { error };
+    return { error: { thrownValue: error } };
   }
 
   reset = () => {
@@ -67,7 +71,7 @@ export class ErrorBoundaryInner extends React.Component<
   render() {
     if (this.state.error) {
       const FallbackComponent = this.props.fallback;
-      return <FallbackComponent error={this.state.error} reset={this.reset} />;
+      return <FallbackComponent error={this.state.error.thrownValue} reset={this.reset} />;
     }
     return this.props.children;
   }
@@ -129,7 +133,7 @@ class NotFoundBoundaryInner extends React.Component<
     return { notFound: state.notFound, previousPathname: props.pathname };
   }
 
-  static getDerivedStateFromError(error: Error): Partial<NotFoundBoundaryState> {
+  static getDerivedStateFromError(error: unknown): Partial<NotFoundBoundaryState> {
     if (error && typeof error === "object" && "digest" in error) {
       const digest = String(error.digest);
       if (digest === "NEXT_NOT_FOUND" || digest === "NEXT_HTTP_ERROR_FALLBACK;404") {
@@ -198,7 +202,7 @@ export class ForbiddenBoundaryInner extends React.Component<
     return { forbidden: state.forbidden, previousPathname: props.pathname };
   }
 
-  static getDerivedStateFromError(error: Error): Partial<ForbiddenBoundaryState> {
+  static getDerivedStateFromError(error: unknown): Partial<ForbiddenBoundaryState> {
     if (error && typeof error === "object" && "digest" in error) {
       const digest = String(error.digest);
       if (digest === "NEXT_HTTP_ERROR_FALLBACK;403") {
@@ -262,7 +266,7 @@ export class UnauthorizedBoundaryInner extends React.Component<
     return { unauthorized: state.unauthorized, previousPathname: props.pathname };
   }
 
-  static getDerivedStateFromError(error: Error): Partial<UnauthorizedBoundaryState> {
+  static getDerivedStateFromError(error: unknown): Partial<UnauthorizedBoundaryState> {
     if (error && typeof error === "object" && "digest" in error) {
       const digest = String(error.digest);
       if (digest === "NEXT_HTTP_ERROR_FALLBACK;401") {

--- a/tests/e2e/app-router/error-handling.spec.ts
+++ b/tests/e2e/app-router/error-handling.spec.ts
@@ -44,6 +44,30 @@ test.describe("Error Boundaries", () => {
     await expect(resetButton).toHaveText("Try again");
   });
 
+  test("error.tsx catches falsy values thrown by client components", async ({ page }) => {
+    // Ported from Next.js: test/e2e/app-dir/errors/index.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/errors/index.test.ts
+    const cases = [
+      ["undefined", "undefined"],
+      ["null", "null"],
+      ["zero", "0"],
+      ["empty-string", ""],
+      ["false", "false"],
+    ] satisfies readonly (readonly [string, string])[];
+
+    for (const [name, expectedText] of cases) {
+      await page.goto(`${BASE}/falsy-error-boundary-test`);
+      await expect(page.locator('[data-testid="falsy-error-content"]')).toBeVisible();
+      const trigger = page.locator(`[data-testid="throw-${name}"]`);
+      await expect(trigger).toBeEnabled();
+      await trigger.click();
+      await expect(page.locator('[data-testid="falsy-error-boundary"]')).toBeVisible({
+        timeout: 5000,
+      });
+      await expect(page.locator('[data-testid="falsy-error-message"]')).toHaveText(expectedText);
+    }
+  });
+
   test("server component error renders error.tsx boundary with 200", async ({ page }) => {
     const response = await page.goto(`${BASE}/error-server-test`);
     // Next.js returns 200 when error.tsx catches an error (it's "handled")

--- a/tests/error-boundary.test.ts
+++ b/tests/error-boundary.test.ts
@@ -28,22 +28,22 @@ vi.mock("next/navigation", () => ({
 // query-aware. These tests lock our shim to that behavior.
 
 type ErrorBoundaryInnerConstructor = {
-  getDerivedStateFromError(error: Error): Partial<{
-    error: Error | null;
+  getDerivedStateFromError(error: unknown): Partial<{
+    error: { thrownValue: unknown } | null;
     previousPathname: string;
   }>;
   getDerivedStateFromProps(
     props: {
       children: React.ReactNode;
-      fallback: React.ComponentType<{ error: Error; reset: () => void }>;
+      fallback: React.ComponentType<{ error: unknown; reset: () => void }>;
       pathname: string;
     },
     state: {
-      error: Error | null;
+      error: { thrownValue: unknown } | null;
       previousPathname: string;
     },
   ): {
-    error: Error | null;
+    error: { thrownValue: unknown } | null;
     previousPathname: string;
   } | null;
 };
@@ -116,7 +116,7 @@ describe("ErrorBoundary digest patterns", () => {
 
 // Test the actual ErrorBoundary.getDerivedStateFromError classification.
 // The real method THROWS for digest errors (re-throwing them past the boundary)
-// and returns { error } for regular errors (catching them).
+// and wraps regular thrown values so falsy values remain distinguishable from no error.
 describe("ErrorBoundary digest classification (actual class)", () => {
   let ErrorBoundaryInnerClass: ErrorBoundaryInnerConstructor | null = null;
   let ErrorBoundaryInner: ErrorBoundaryInnerConstructor | null = null;
@@ -164,21 +164,33 @@ describe("ErrorBoundary digest classification (actual class)", () => {
     const e = new Error("oops");
     expect(ErrorBoundaryInnerClass).not.toBeNull();
     const state = ErrorBoundaryInnerClass?.getDerivedStateFromError(e);
-    expect(state).toMatchObject({ error: e });
+    expect(state).toEqual({ error: { thrownValue: e } });
   });
 
   it("catches errors with unknown digest", () => {
     const e = Object.assign(new Error(), { digest: "CUSTOM_ERROR" });
     expect(ErrorBoundaryInnerClass).not.toBeNull();
     const state = ErrorBoundaryInnerClass?.getDerivedStateFromError(e);
-    expect(state).toMatchObject({ error: e });
+    expect(state).toEqual({ error: { thrownValue: e } });
   });
 
   it("catches errors with empty digest", () => {
     const e = Object.assign(new Error(), { digest: "" });
     expect(ErrorBoundaryInnerClass).not.toBeNull();
     const state = ErrorBoundaryInnerClass?.getDerivedStateFromError(e);
-    expect(state).toMatchObject({ error: e });
+    expect(state).toEqual({ error: { thrownValue: e } });
+  });
+
+  it("catches falsy thrown values instead of treating them as empty state", () => {
+    // Ported from Next.js: test/e2e/app-dir/errors/index.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/errors/index.test.ts
+    expect(ErrorBoundaryInnerClass).not.toBeNull();
+
+    const falsyThrownValues = [undefined, null, 0, "", false];
+    for (const thrownValue of falsyThrownValues) {
+      const state = ErrorBoundaryInnerClass?.getDerivedStateFromError(thrownValue);
+      expect(state).toEqual({ error: { thrownValue } });
+    }
   });
 
   it("resets caught errors when the pathname changes", () => {
@@ -198,7 +210,7 @@ describe("ErrorBoundary digest classification (actual class)", () => {
         pathname: "/next",
       },
       {
-        error: new Error("stuck"),
+        error: { thrownValue: new Error("stuck") },
         previousPathname: "/previous",
       },
     );
@@ -239,7 +251,7 @@ describe("ErrorBoundary digest classification (actual class)", () => {
     );
 
     expect(stateAfterProps).toEqual({
-      error,
+      error: { thrownValue: error },
       previousPathname: "/error-test",
     });
   });
@@ -249,7 +261,7 @@ describe("ErrorBoundary digest classification (actual class)", () => {
 // Catches NEXT_HTTP_ERROR_FALLBACK;403 and re-throws everything else.
 describe("ForbiddenBoundary digest classification", () => {
   let ForbiddenBoundaryInnerClass: {
-    getDerivedStateFromError(error: Error): Partial<{ forbidden: boolean }>;
+    getDerivedStateFromError(error: unknown): Partial<{ forbidden: boolean }>;
   } | null = null;
 
   beforeAll(async () => {
@@ -293,7 +305,7 @@ describe("ForbiddenBoundary digest classification", () => {
 // Catches NEXT_HTTP_ERROR_FALLBACK;401 and re-throws everything else.
 describe("UnauthorizedBoundary digest classification", () => {
   let UnauthorizedBoundaryInnerClass: {
-    getDerivedStateFromError(error: Error): Partial<{ unauthorized: boolean }>;
+    getDerivedStateFromError(error: unknown): Partial<{ unauthorized: boolean }>;
   } | null = null;
 
   beforeAll(async () => {

--- a/tests/fixtures/app-basic/app/falsy-error-boundary-test/error.tsx
+++ b/tests/fixtures/app-basic/app/falsy-error-boundary-test/error.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+export default function FalsyErrorBoundary({
+  error,
+  reset,
+}: {
+  error: unknown;
+  reset: () => void;
+}) {
+  return (
+    <div data-testid="falsy-error-boundary">
+      <p data-testid="falsy-error-message">{String(error)}</p>
+      <button data-testid="falsy-error-reset" onClick={reset}>
+        Try again
+      </button>
+    </div>
+  );
+}

--- a/tests/fixtures/app-basic/app/falsy-error-boundary-test/page.tsx
+++ b/tests/fixtures/app-basic/app/falsy-error-boundary-test/page.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const noThrow = Symbol("no throw");
+
+const falsyThrownValues = [
+  ["undefined", undefined],
+  ["null", null],
+  ["zero", 0],
+  ["empty-string", ""],
+  ["false", false],
+] satisfies readonly (readonly [string, unknown])[];
+
+export default function FalsyErrorBoundaryTestPage() {
+  const [thrownValue, setThrownValue] = useState<unknown>(noThrow);
+  const [isHydrated, setIsHydrated] = useState(false);
+
+  useEffect(() => {
+    setIsHydrated(true);
+  }, []);
+
+  if (thrownValue !== noThrow) {
+    throw thrownValue;
+  }
+
+  return (
+    <main>
+      <h1>Falsy Error Boundary Test</h1>
+      <p data-testid="falsy-error-content">Ready</p>
+      {falsyThrownValues.map(([name, value]) => (
+        <button
+          data-testid={`throw-${name}`}
+          disabled={!isHydrated}
+          key={name}
+          onClick={() => {
+            setThrownValue(value);
+          }}
+        >
+          Throw {name}
+        </button>
+      ))}
+    </main>
+  );
+}


### PR DESCRIPTION
## What this changes
App Router error boundaries now preserve falsy thrown values such as `undefined`, `null`, `0`, `""`, and `false` instead of treating them as no captured error. Segment error boundary props now accept `unknown`, matching the fact that JavaScript can throw non-`Error` values.

Fixes #989.

## Why
Next.js fixed the same failure mode in [vercel/next.js#93134](https://github.com/vercel/next.js/pull/93134) via [ea541987d1735493c63b52d0b6e673d4435cbb20](https://github.com/vercel/next.js/commit/ea541987d1735493c63b52d0b6e673d4435cbb20). The important invariant is that boundary state must distinguish “no error” from “an error was thrown with a falsy value”.

Relevant upstream source:

- [Next.js `ErrorBoundaryHandlerState` wraps thrown values](https://github.com/vercel/next.js/blob/ea541987d1735493c63b52d0b6e673d4435cbb20/packages/next/src/client/components/error-boundary.tsx#L36-L64)
- [Next.js renders the unwrapped `thrownValue`](https://github.com/vercel/next.js/blob/ea541987d1735493c63b52d0b6e673d4435cbb20/packages/next/src/client/components/error-boundary.tsx#L102-L117)
- [Next.js applies the same shape to `unstable_catchError`](https://github.com/vercel/next.js/blob/ea541987d1735493c63b52d0b6e673d4435cbb20/packages/next/src/client/components/catch-error.tsx#L31-L65)
- [Next.js falsy throw regression coverage](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/errors/index.test.ts)

## Approach
- Changed vinext App Router error boundary state from raw `Error | null` to `null | { thrownValue: unknown }`.
- Kept existing router-control rethrows for not-found, HTTP access fallback, and redirects.
- Updated App Router route wiring types so error boundary components receive `unknown`, not an incorrectly narrowed `Error`.
- Added unit coverage for the state contract and browser coverage for client components throwing each falsy literal.

## Validation
- `vp test run tests/error-boundary.test.ts`
- `vp check packages/vinext/src/shims/error-boundary.tsx packages/vinext/src/server/app-page-route-wiring.tsx tests/error-boundary.test.ts tests/e2e/app-router/error-handling.spec.ts tests/fixtures/app-basic/app/falsy-error-boundary-test/error.tsx tests/fixtures/app-basic/app/falsy-error-boundary-test/page.tsx`
- `vp run vinext#build`
- `PLAYWRIGHT_PROJECT=app-router vp run test:e2e tests/e2e/app-router/error-handling.spec.ts`

## Risks / follow-ups
This PR intentionally scopes the change to vinext's existing App Router error-boundary shim. The HTTP access fallback boundaries already track explicit boolean/status state, and redirects continue through the existing digest rethrow path.