### PR TITLE
fix: re-throw stream errors in pumpReader to prevent incomplete ISR cache data

### DIFF
--- a/packages/vinext/src/server/app-ssr-stream.ts
+++ b/packages/vinext/src/server/app-ssr-stream.ts
@@ -52,6 +52,7 @@ export function createRscEmbedTransform(
       if (process.env.NODE_ENV !== "production") {
         console.warn("[vinext] RSC embed stream read error:", error);
       }
+      throw error;
     } finally {
       reading = false;
     }

--- a/tests/app-ssr-stream.test.ts
+++ b/tests/app-ssr-stream.test.ts
@@ -100,6 +100,17 @@ describe("createRscEmbedTransform raw buffer (#981)", () => {
     expect(finalScripts).toContain("__VINEXT_RSC_CHUNKS__");
   });
 
+  it("rejects getRawBuffer when the stream errors (#1002)", async () => {
+    const errorStream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("partial"));
+        controller.error(new Error("stream broke"));
+      },
+    });
+    const transform = createRscEmbedTransform(errorStream);
+    await expect(transform.getRawBuffer()).rejects.toThrow("stream broke");
+  });
+
   it("preserves raw bytes before fixFlightHints transform", async () => {
     // Flight hints use as="stylesheet" which get fixed to as="style" in the
     // embed transform. Raw bytes must be the unmodified originals.


### PR DESCRIPTION
Fixes #1002

## Summary
- pumpReader() was silently swallowing stream read errors
- This caused getRawBuffer() to return incomplete/corrupted data to the ISR cache
- Added \"throw error;\" after the dev warning so pumpPromise properly rejects
- Existing error handling in scheduleAppPageRscCacheWrite (line 376) already handles the error path

## Test plan
- Existing tests pass (app-router.test.ts, isr-cache.test.ts)
- Build successful
- The fix is minimal and follows the pattern described in the issue