### PR TITLE
fix(dev): avoid app reloads for colocated files

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -14,6 +14,7 @@ import { createValidFileMatcher } from "./routing/file-matcher.js";
 import { createSSRHandler } from "./server/dev-server.js";
 import { handleApiRoute } from "./server/api-handler.js";
 import { installSocketErrorBackstop } from "./server/socket-error-backstop.js";
+import { shouldInvalidateAppRouteFile } from "./server/dev-route-files.js";
 import { createDirectRunner } from "./server/dev-module-runner.js";
 import { generateRscEntry } from "./entries/app-rsc-entry.js";
 import { generateSsrEntry } from "./entries/app-ssr-entry.js";
@@ -1980,7 +1981,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
       },
 
       configureServer(server: ViteDevServer) {
-        // Watch pages directory for file additions/removals to invalidate route cache.
+        // Watch route files for additions/removals to invalidate route cache.
         const pageExtensions = fileMatcher.extensionRegex;
 
         // Build a long-lived ModuleRunner for loading all Pages Router modules
@@ -2037,6 +2038,12 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           }
         }
 
+        function invalidateAppRoutingModules() {
+          invalidateAppRouteCache();
+          invalidateRscEntryModule();
+          invalidateRootParamsModule();
+        }
+
         // Node throws on unhandled 'error' events on sockets. When a browser
         // drops the connection mid-response (common in dev: HMR triggers a
         // reload while an RSC stream is still flushing), the next res.write
@@ -2053,20 +2060,16 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           if (hasPagesDir && filePath.startsWith(pagesDir) && pageExtensions.test(filePath)) {
             invalidateRouteCache(pagesDir);
           }
-          if (hasAppDir && filePath.startsWith(appDir) && pageExtensions.test(filePath)) {
-            invalidateAppRouteCache();
-            invalidateRscEntryModule();
-            invalidateRootParamsModule();
+          if (hasAppDir && shouldInvalidateAppRouteFile(appDir, filePath, fileMatcher)) {
+            invalidateAppRoutingModules();
           }
         });
         server.watcher.on("unlink", (filePath: string) => {
           if (hasPagesDir && filePath.startsWith(pagesDir) && pageExtensions.test(filePath)) {
             invalidateRouteCache(pagesDir);
           }
-          if (hasAppDir && filePath.startsWith(appDir) && pageExtensions.test(filePath)) {
-            invalidateAppRouteCache();
-            invalidateRscEntryModule();
-            invalidateRootParamsModule();
+          if (hasAppDir && shouldInvalidateAppRouteFile(appDir, filePath, fileMatcher)) {
+            invalidateAppRoutingModules();
           }
         });
 

--- a/packages/vinext/src/server/dev-route-files.ts
+++ b/packages/vinext/src/server/dev-route-files.ts
@@ -1,0 +1,94 @@
+import path from "node:path";
+import type { ValidFileMatcher } from "../routing/file-matcher.js";
+import { matchMetadataFileBaseName, METADATA_FILE_MAP } from "./metadata-routes.js";
+
+const APP_ROUTER_STRUCTURE_FILES = [
+  "page",
+  "route",
+  "layout",
+  "default",
+  "template",
+  "loading",
+  "error",
+  "not-found",
+  "forbidden",
+  "unauthorized",
+];
+
+function isInsideDirectory(dir: string, filePath: string): boolean {
+  const relativePath = path.relative(dir, filePath);
+  return relativePath !== "" && !relativePath.startsWith("..") && !path.isAbsolute(relativePath);
+}
+
+function relativeParts(dir: string, filePath: string): string[] {
+  return path.relative(dir, filePath).split(path.sep).filter(Boolean);
+}
+
+function isPrivateAppPath(parts: readonly string[]): boolean {
+  return parts.slice(0, -1).some((part) => part.startsWith("_"));
+}
+
+function visibleRoutePrefix(parts: readonly string[]): string {
+  const visibleParts = parts
+    .slice(0, -1)
+    .filter((part) => !(part.startsWith("(") && part.endsWith(")")) && !part.startsWith("@"));
+  return visibleParts.length === 0 ? "" : `/${visibleParts.join("/")}`;
+}
+
+function stripLastExtension(fileName: string): { baseName: string; extension: string } {
+  const extension = path.extname(fileName);
+  return {
+    baseName: extension ? fileName.slice(0, -extension.length) : fileName,
+    extension,
+  };
+}
+
+function isAppRouterStructureFile(fileName: string, matcher: ValidFileMatcher): boolean {
+  const { baseName } = stripLastExtension(fileName);
+  return APP_ROUTER_STRUCTURE_FILES.includes(baseName) && matcher.extensionRegex.test(fileName);
+}
+
+function isRootGlobalError(parts: readonly string[], matcher: ValidFileMatcher): boolean {
+  if (parts.length !== 1) return false;
+  const fileName = parts[0];
+  if (!fileName) return false;
+  const { baseName } = stripLastExtension(fileName);
+  return baseName === "global-error" && matcher.extensionRegex.test(fileName);
+}
+
+function isMetadataRouteFile(parts: readonly string[]): boolean {
+  const fileName = parts[parts.length - 1];
+  if (!fileName) return false;
+  const { baseName, extension } = stripLastExtension(fileName);
+  if (!extension) return false;
+
+  const routePrefix = visibleRoutePrefix(parts);
+  for (const [metaType, config] of Object.entries(METADATA_FILE_MAP)) {
+    if (!matchMetadataFileBaseName(metaType, baseName)) continue;
+    if (!config.nestable && routePrefix !== "") return false;
+    if (config.staticExtensions.includes(extension)) return true;
+    if (config.dynamicExtensions.includes(extension)) return true;
+  }
+
+  return false;
+}
+
+export function shouldInvalidateAppRouteFile(
+  appDir: string,
+  filePath: string,
+  matcher: ValidFileMatcher,
+): boolean {
+  if (!isInsideDirectory(appDir, filePath)) return false;
+
+  const parts = relativeParts(appDir, filePath);
+  if (parts.length === 0 || isPrivateAppPath(parts)) return false;
+
+  const fileName = parts[parts.length - 1];
+  if (!fileName) return false;
+
+  return (
+    isAppRouterStructureFile(fileName, matcher) ||
+    isRootGlobalError(parts, matcher) ||
+    isMetadataRouteFile(parts)
+  );
+}

--- a/packages/vinext/src/server/metadata-routes.ts
+++ b/packages/vinext/src/server/metadata-routes.ts
@@ -596,7 +596,7 @@ function getMetadataServedUrl(
   return withMetadataSuffix(config.urlPath, suffix);
 }
 
-function matchMetadataFileBaseName(metaType: string, baseName: string): string | null {
+export function matchMetadataFileBaseName(metaType: string, baseName: string): string | null {
   if (baseName === metaType) {
     return baseName;
   }

--- a/tests/file-matcher.test.ts
+++ b/tests/file-matcher.test.ts
@@ -3,6 +3,7 @@ import {
   createValidFileMatcher,
   normalizePageExtensions,
 } from "../packages/vinext/src/routing/file-matcher.js";
+import { shouldInvalidateAppRouteFile } from "../packages/vinext/src/server/dev-route-files.js";
 
 describe("file matcher", () => {
   it("normalizes pageExtensions with defaults and preserves configured values", () => {
@@ -40,5 +41,46 @@ describe("file matcher", () => {
     expect(matcher.stripExtension("about.mdx")).toBe("about");
     expect(matcher.stripExtension("index.m+d")).toBe("index");
     expect(matcher.stripExtension("about.tsx")).toBe("about.tsx");
+  });
+
+  it("classifies only app route structure files as dev route invalidations", () => {
+    // Mirrors Next.js dev route discovery:
+    // packages/next/src/server/lib/find-page-file.ts
+    // packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+    const matcher = createValidFileMatcher(["tsx", "ts", "jsx", "js", "mdx"]);
+    const appDir = "/project/app";
+
+    expect(shouldInvalidateAppRouteFile(appDir, "/project/app/page.tsx", matcher)).toBe(true);
+    expect(shouldInvalidateAppRouteFile(appDir, "/project/app/blog/route.ts", matcher)).toBe(true);
+    expect(shouldInvalidateAppRouteFile(appDir, "/project/app/blog/layout.tsx", matcher)).toBe(
+      true,
+    );
+    expect(shouldInvalidateAppRouteFile(appDir, "/project/app/blog/loading.jsx", matcher)).toBe(
+      true,
+    );
+    expect(shouldInvalidateAppRouteFile(appDir, "/project/app/blog/not-found.mdx", matcher)).toBe(
+      true,
+    );
+    expect(shouldInvalidateAppRouteFile(appDir, "/project/app/@modal/default.tsx", matcher)).toBe(
+      true,
+    );
+    expect(shouldInvalidateAppRouteFile(appDir, "/project/app/robots.ts", matcher)).toBe(true);
+    expect(
+      shouldInvalidateAppRouteFile(appDir, "/project/app/blog/opengraph-image.png", matcher),
+    ).toBe(true);
+
+    expect(
+      shouldInvalidateAppRouteFile(appDir, "/project/app/components/Button.tsx", matcher),
+    ).toBe(false);
+    expect(shouldInvalidateAppRouteFile(appDir, "/project/app/blog/page.css", matcher)).toBe(false);
+    expect(shouldInvalidateAppRouteFile(appDir, "/project/app/_private/page.tsx", matcher)).toBe(
+      false,
+    );
+    expect(shouldInvalidateAppRouteFile(appDir, "/project/app-utils/page.tsx", matcher)).toBe(
+      false,
+    );
+    expect(shouldInvalidateAppRouteFile(appDir, "/project/app/blog/robots.ts", matcher)).toBe(
+      false,
+    );
   });
 });


### PR DESCRIPTION
## What this changes
Stops the App Router dev watcher from invalidating the generated route entry and sending a full reload when ordinary colocated files are added or removed under `app/`, such as `app/components/Button.tsx`.

The watcher now invalidates only files that can affect App Router structure or generated metadata route entries: route conventions such as `page`, `route`, `layout`, `template`, `loading`, `error`, access fallback files, root `global-error`, and vinext metadata route files.

Fixes #1013.

## Why
Next.js explicitly treats arbitrary project files in `app/` as safely colocated and non-routable. The source backs that up in the route discovery matcher:

- [`createValidFileMatcher` builds leaf-only app route matchers](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/find-page-file.ts#L79-L172)
- [Next.js dev bundler skips non-app-router page files after handling layouts/root not-found](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts#L619-L679)
- [Build route discovery filters app files through the app router page/layout/default/root-not-found predicates](https://github.com/vercel/next.js/blob/canary/packages/next/src/build/route-discovery.ts#L86-L116)

vinext was using only the broad page extension regex for `app/` watcher add/unlink events, so any `.ts`, `.tsx`, `.js`, or `.jsx` file under `app/` looked route-affecting and triggered a full reload.

## Approach
Add a small pure predicate, `shouldInvalidateAppRouteFile`, that mirrors vinext's current App Router and metadata discovery boundaries:

- rejects files outside the exact `app/` directory, fixing sibling-prefix cases like `app-utils/`
- rejects private `_` folders
- accepts App Router structure conventions that change the generated route tree or RSC entry wiring
- accepts vinext's dynamic and static metadata route files using the existing metadata route map

The watcher still keeps the broad extension behavior for the Pages Router, since every matching file under `pages/` is routable by design unless filtered elsewhere.

## Validation
- `vp test run tests/file-matcher.test.ts`
- `vp test run tests/file-matcher.test.ts tests/page-extensions-routing.test.ts`
- `vp check tests/file-matcher.test.ts packages/vinext/src/server/dev-route-files.ts packages/vinext/src/index.ts packages/vinext/src/server/metadata-routes.ts`
- `vp run vinext#build`

The package build completed successfully with the existing virtual-module externalization warnings for `private-next-instrumentation-client`, `virtual:vinext-rsc-entry`, and `virtual:vite-rsc/client-references`.

## Risks / follow-ups
The metadata side intentionally follows vinext's current `scanMetadataFiles` behavior, not every future Next.js metadata convention. If vinext expands metadata route support later, this predicate should be updated with the same source of truth.