### PR TITLE
refactor: extract instrumentation lazy init to server/instrumentation-runtime.ts

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -79,6 +79,10 @@ const metadataRouteResponsePath = resolveEntryPath(
   import.meta.url,
 );
 const errorCausePath = resolveEntryPath("../utils/error-cause.js", import.meta.url);
+const instrumentationRuntimePath = resolveEntryPath(
+  "../server/instrumentation-runtime.js",
+  import.meta.url,
+);
 
 /**
  * Resolved config options relevant to App Router request handling.
@@ -187,7 +191,12 @@ import { setNavigationContext as _setNavigationContextOrig, getNavigationContext
 import { setHeadersContext, headersContextFromRequest, getDraftModeCookieHeader, getAndClearPendingCookies, consumeDynamicUsage, consumeInvalidDynamicUsageError, markDynamicUsage, getHeadersContext, setHeadersAccessPhase } from "next/headers";
 import { mergeMetadata, resolveModuleMetadata, mergeViewport, resolveModuleViewport } from "vinext/metadata";
 ${middlewarePath ? `import * as middlewareModule from ${JSON.stringify(middlewarePath.replace(/\\/g, "/"))};` : ""}
-${instrumentationPath ? `import * as _instrumentation from ${JSON.stringify(instrumentationPath.replace(/\\/g, "/"))};` : ""}
+${
+  instrumentationPath
+    ? `import * as _instrumentation from ${JSON.stringify(instrumentationPath.replace(/\\/g, "/"))};
+import { ensureInstrumentationRegistered as __ensureInstrumentationRegistered } from ${JSON.stringify(instrumentationRuntimePath)};`
+    : ""
+}
 import { handleMetadataRouteRequest as __handleMetadataRouteRequest } from ${JSON.stringify(metadataRouteResponsePath)};
 import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, isExternalUrl, proxyExternalRequest, sanitizeDestination } from ${JSON.stringify(configMatchersPath)};
 import { decodePathParams as __decodePathParams, normalizePath as __normalizePath } from ${JSON.stringify(normalizePathModulePath)};
@@ -351,37 +360,10 @@ ${imports.join("\n")}
 
 ${
   instrumentationPath
-    ? `// Run instrumentation register() exactly once, lazily on the first request.
-// Previously this was a top-level await, which blocked the entire module graph
-// from finishing initialization until register() resolved — adding that latency
-// to every cold start. Moving it here preserves the "runs before any request is
-// handled" guarantee while not blocking V8 isolate initialization.
-// On Cloudflare Workers, module evaluation happens synchronously in the isolate
-// startup phase; a top-level await extends that phase and increases cold-start
-// wall time for all requests, not just the first.
-let __instrumentationInitialized = false;
-let __instrumentationInitPromise = null;
-async function __ensureInstrumentation() {
-  if (process.env.VINEXT_PRERENDER === "1") return;
-  if (__instrumentationInitialized) return;
-  if (__instrumentationInitPromise) return __instrumentationInitPromise;
-  __instrumentationInitPromise = (async () => {
-    if (typeof _instrumentation.register === "function") {
-      await _instrumentation.register();
-    }
-    // Store the onRequestError handler on globalThis so it is visible to
-    // reportRequestError() (imported as _reportRequestError above) regardless
-    // of which Vite environment module graph it is called from. With
-    // @vitejs/plugin-rsc the RSC and SSR environments run in the same Node.js
-    // process and share globalThis. With @cloudflare/vite-plugin everything
-    // runs inside the Worker so globalThis is the Worker's global — also correct.
-    if (typeof _instrumentation.onRequestError === "function") {
-      globalThis.__VINEXT_onRequestErrorHandler__ = _instrumentation.onRequestError;
-    }
-    __instrumentationInitialized = true;
-  })();
-  return __instrumentationInitPromise;
-}`
+    ? `// Lazy instrumentation initialisation is handled by ensureInstrumentationRegistered
+// (imported from vinext/instrumentation-runtime). The generated entry only passes
+// the user module in; all bookkeeping (initialized flag, shared promise, prerender
+// skip) lives in the typed helper so it can be unit-tested independently.`
     : ""
 }
 
@@ -698,8 +680,9 @@ export default async function handler(request, ctx) {
   ${
     instrumentationPath
       ? `// Ensure instrumentation.register() has run before handling the first request.
-  // This is a no-op after the first call (guarded by __instrumentationInitialized).
-  await __ensureInstrumentation();
+  // This is a no-op after the first call (guarded by the shared promise in
+  // ensureInstrumentationRegistered).
+  await __ensureInstrumentationRegistered(_instrumentation);
   `
       : ""
   }

--- a/packages/vinext/src/server/instrumentation-runtime.ts
+++ b/packages/vinext/src/server/instrumentation-runtime.ts
@@ -1,0 +1,76 @@
+/**
+ * Lazy, idempotent instrumentation initialisation.
+ *
+ * The generated App Router RSC entry calls this on the first request instead
+ * of embedding the bookkeeping directly in codegen. This keeps the entry
+ * module thin (it only describes the app shape) while the actual runtime
+ * behaviour lives in a normal typed module that can be unit-tested.
+ *
+ * ## Why lazy?
+ *
+ * A top-level `await` at module evaluation time blocks the entire V8 isolate
+ * startup phase. On Cloudflare Workers that latency is added to every cold
+ * start. Moving the `register()` call into the first request handler keeps
+ * module evaluation synchronous while still guaranteeing that instrumentation
+ * runs before any request is handled.
+ *
+ * ## Why idempotent?
+ *
+ * The same handler may be invoked concurrently (e.g. on a warm Worker).
+ * A module-level `initialized` flag + a shared promise ensure that
+ * `register()` is called exactly once even when multiple requests race.
+ *
+ * ## Next.js semantics
+ *
+ * Next.js calls `register()` once when the server process starts, before any
+ * request handling. Our lazy init preserves that guarantee because the first
+ * request cannot proceed past this call until `register()` has resolved.
+ *
+ * References:
+ * - https://nextjs.org/docs/app/building-your-application/optimizing/instrumentation
+ */
+
+import type { OnRequestErrorHandler } from "./instrumentation.js";
+
+let initialized = false;
+let initPromise: Promise<void> | null = null;
+
+function isOnRequestErrorHandler(value: unknown): value is OnRequestErrorHandler {
+  return typeof value === "function";
+}
+
+/**
+ * Ensure the instrumentation module's `register()` and `onRequestError`
+ * hooks have been applied exactly once.
+ *
+ * @param instrumentationModule - The imported `instrumentation.ts` module.
+ *   Passed as an argument so the generated entry can import it normally
+ *   without this helper needing to know the module path.
+ */
+export async function ensureInstrumentationRegistered(
+  instrumentationModule: Record<string, unknown>,
+): Promise<void> {
+  if (process.env.VINEXT_PRERENDER === "1") return;
+  if (initialized) return;
+  if (initPromise) return initPromise;
+
+  initPromise = (async () => {
+    if (typeof instrumentationModule.register === "function") {
+      await instrumentationModule.register();
+    }
+
+    // Store the onRequestError handler on globalThis so it is visible to
+    // reportRequestError() regardless of which Vite environment module graph
+    // it is called from. With @vitejs/plugin-rsc the RSC and SSR environments
+    // run in the same Node.js process and share globalThis. With
+    // @cloudflare/vite-plugin everything runs inside the Worker so globalThis
+    // is the Worker's global — also correct.
+    if (isOnRequestErrorHandler(instrumentationModule.onRequestError)) {
+      globalThis.__VINEXT_onRequestErrorHandler__ = instrumentationModule.onRequestError;
+    }
+
+    initialized = true;
+  })();
+
+  return initPromise;
+}

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -3510,6 +3510,7 @@ import { setHeadersContext, headersContextFromRequest, getDraftModeCookieHeader,
 import { mergeMetadata, resolveModuleMetadata, mergeViewport, resolveModuleViewport } from "vinext/metadata";
 
 import * as _instrumentation from "/tmp/test/instrumentation.ts";
+import { ensureInstrumentationRegistered as __ensureInstrumentationRegistered } from "<ROOT>/packages/vinext/src/server/instrumentation-runtime.js";
 import { handleMetadataRouteRequest as __handleMetadataRouteRequest } from "<ROOT>/packages/vinext/src/server/metadata-route-response.js";
 import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, isExternalUrl, proxyExternalRequest, sanitizeDestination } from "<ROOT>/packages/vinext/src/config/config-matchers.js";
 import { decodePathParams as __decodePathParams, normalizePath as __normalizePath } from "<ROOT>/packages/vinext/src/server/normalize-path.js";
@@ -3683,37 +3684,10 @@ import * as mod_10 from "/tmp/test/app/dashboard/not-found.tsx";
 import * as mod_11 from "/tmp/test/app/dashboard/forbidden.tsx";
 import * as mod_12 from "/tmp/test/app/dashboard/unauthorized.tsx";
 
-// Run instrumentation register() exactly once, lazily on the first request.
-// Previously this was a top-level await, which blocked the entire module graph
-// from finishing initialization until register() resolved — adding that latency
-// to every cold start. Moving it here preserves the "runs before any request is
-// handled" guarantee while not blocking V8 isolate initialization.
-// On Cloudflare Workers, module evaluation happens synchronously in the isolate
-// startup phase; a top-level await extends that phase and increases cold-start
-// wall time for all requests, not just the first.
-let __instrumentationInitialized = false;
-let __instrumentationInitPromise = null;
-async function __ensureInstrumentation() {
-  if (process.env.VINEXT_PRERENDER === "1") return;
-  if (__instrumentationInitialized) return;
-  if (__instrumentationInitPromise) return __instrumentationInitPromise;
-  __instrumentationInitPromise = (async () => {
-    if (typeof _instrumentation.register === "function") {
-      await _instrumentation.register();
-    }
-    // Store the onRequestError handler on globalThis so it is visible to
-    // reportRequestError() (imported as _reportRequestError above) regardless
-    // of which Vite environment module graph it is called from. With
-    // @vitejs/plugin-rsc the RSC and SSR environments run in the same Node.js
-    // process and share globalThis. With @cloudflare/vite-plugin everything
-    // runs inside the Worker so globalThis is the Worker's global — also correct.
-    if (typeof _instrumentation.onRequestError === "function") {
-      globalThis.__VINEXT_onRequestErrorHandler__ = _instrumentation.onRequestError;
-    }
-    __instrumentationInitialized = true;
-  })();
-  return __instrumentationInitPromise;
-}
+// Lazy instrumentation initialisation is handled by ensureInstrumentationRegistered
+// (imported from vinext/instrumentation-runtime). The generated entry only passes
+// the user module in; all bookkeeping (initialized flag, shared promise, prerender
+// skip) lives in the typed helper so it can be unit-tested independently.
 
 // Build-time layout classification dispatch. Replaced in generateBundle
 // with a switch statement that returns a pre-computed per-layout
@@ -4190,8 +4164,9 @@ const rootParamNamesMap = {
 
 export default async function handler(request, ctx) {
   // Ensure instrumentation.register() has run before handling the first request.
-  // This is a no-op after the first call (guarded by __instrumentationInitialized).
-  await __ensureInstrumentation();
+  // This is a no-op after the first call (guarded by the shared promise in
+  // ensureInstrumentationRegistered).
+  await __ensureInstrumentationRegistered(_instrumentation);
   
   // Wrap the entire request in a single unified ALS scope for per-request
   // isolation. All state modules (headers, navigation, cache, fetch-cache,

--- a/tests/instrumentation.test.ts
+++ b/tests/instrumentation.test.ts
@@ -169,6 +169,90 @@ describe("runInstrumentation", () => {
   });
 });
 
+describe("ensureInstrumentationRegistered", () => {
+  let ensureInstrumentationRegistered: typeof import("../packages/vinext/src/server/instrumentation-runtime.js").ensureInstrumentationRegistered;
+  let reportRequestError: typeof import("../packages/vinext/src/server/instrumentation.js").reportRequestError;
+
+  const sampleRequest = { path: "/test", method: "GET", headers: {} };
+  const sampleContext = {
+    routerKind: "App Router" as const,
+    routePath: "/test",
+    routeType: "render" as const,
+  };
+
+  beforeEach(async () => {
+    vi.resetModules();
+    delete globalThis.__VINEXT_onRequestErrorHandler__;
+    delete process.env.VINEXT_PRERENDER;
+    const mod = await import("../packages/vinext/src/server/instrumentation-runtime.js");
+    ensureInstrumentationRegistered = mod.ensureInstrumentationRegistered;
+    const instMod = await import("../packages/vinext/src/server/instrumentation.js");
+    reportRequestError = instMod.reportRequestError;
+  });
+
+  afterEach(() => {
+    delete globalThis.__VINEXT_onRequestErrorHandler__;
+    delete process.env.VINEXT_PRERENDER;
+  });
+
+  it("calls register() when exported", async () => {
+    const register = vi.fn();
+
+    await ensureInstrumentationRegistered({ register });
+
+    expect(register).toHaveBeenCalledOnce();
+  });
+
+  it("wires onRequestError so reportRequestError invokes it", async () => {
+    const onRequestError = vi.fn();
+    const error = new Error("boom");
+
+    await ensureInstrumentationRegistered({ onRequestError });
+    await reportRequestError(error, sampleRequest, sampleContext);
+
+    expect(onRequestError).toHaveBeenCalledWith(error, sampleRequest, sampleContext);
+  });
+
+  it("is idempotent — register() called only once across concurrent awaits", async () => {
+    const register = vi.fn();
+    const mod = { register };
+
+    await Promise.all([
+      ensureInstrumentationRegistered(mod),
+      ensureInstrumentationRegistered(mod),
+      ensureInstrumentationRegistered(mod),
+    ]);
+
+    expect(register).toHaveBeenCalledOnce();
+  });
+
+  it("is idempotent — sequential awaits do not re-call register()", async () => {
+    const register = vi.fn();
+    const mod = { register };
+
+    await ensureInstrumentationRegistered(mod);
+    await ensureInstrumentationRegistered(mod);
+
+    expect(register).toHaveBeenCalledOnce();
+  });
+
+  it("no-ops when VINEXT_PRERENDER is set", async () => {
+    process.env.VINEXT_PRERENDER = "1";
+    const register = vi.fn();
+
+    await ensureInstrumentationRegistered({ register });
+
+    expect(register).not.toHaveBeenCalled();
+  });
+
+  it("does not throw when module has no register or onRequestError", async () => {
+    await ensureInstrumentationRegistered({});
+
+    // Should not throw
+    await reportRequestError(new Error("boom"), sampleRequest, sampleContext);
+  });
+});
+
 describe("reportRequestError", () => {
   let runInstrumentation: typeof import("../packages/vinext/src/server/instrumentation.js").runInstrumentation;
   let reportRequestError: typeof import("../packages/vinext/src/server/instrumentation.js").reportRequestError;


### PR DESCRIPTION
Testing Kimi2.6

## Summary

Extracts the 25-line `__ensureInstrumentation` block from the generated App Router RSC entry into a normal, typed, unit-testable module: `server/instrumentation-runtime.ts`.

**Principle:** Codegen should describe the app shape; normal modules should implement behavior.

## What changed

### Before
`entries/app-rsc-entry.ts` emitted ~25 lines of inline generated code for every App Router project that uses `instrumentation.ts`:

- Module-level mutable state (`__instrumentationInitialized`, `__instrumentationInitPromise`)
- An idempotent `async function __ensureInstrumentation()` 
- `register()` and `onRequestError` wiring
- `VINEXT_PRERENDER` short-circuit

This is the canonical "imperative shell with mutable bookkeeping" pattern. Embedding it in a template string makes it untestable, hard to review, and easy to drift between dev/prod paths.

### After

1. **New module:** `packages/vinext/src/server/instrumentation-runtime.ts` exports `ensureInstrumentationRegistered(instrumentationModule)`.
2. **Generated entry:** imports the helper and calls `await ensureInstrumentationRegistered(_instrumentation)` — two lines instead of twenty-five.
3. **Tests:** Added focused unit tests for idempotency, concurrent racing, prerender skipping, and graceful handling of modules without `register`/`onRequestError`.

## Why this matters

- **Testability:** The lazy-init semantics (shared promise, dedup, env-gate) are now covered by Vitest unit tests instead of only by integration tests.
- **Entry thinness:** The generated RSC entry stays focused on route-specific imports, manifests, and thin closures — exactly what codegen should own.
- **Dev/prod parity:** Since both dev and prod use the same `ensureInstrumentationRegistered` import, fixes or additions to instrumentation behavior automatically apply everywhere.

## Next.js references

Next.js supports `instrumentation.ts` via a `register()` hook called once at server startup, plus an optional `onRequestError()` handler. The semantics we preserve:

- **Lazy init on first request** (not top-level await) to avoid blocking V8 isolate startup — see how Next.js defers instrumentation registration in the dev server:
  - [`packages/next/src/server/dev/next-dev-server.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/dev/next-dev-server.ts)
- **Global wiring for `onRequestError`** so the handler is reachable across module graphs — Next.js stores the hook on a shared instrumentation instance:
  - [`packages/next/src/server/lib/instrumentation/internal-lifecycle.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/instrumentation/internal-lifecycle.ts)
- **Official docs:**
  - https://nextjs.org/docs/app/building-your-application/optimizing/instrumentation

## Test plan

```bash
# New unit tests for the extracted helper
pnpm test tests/instrumentation.test.ts

# Snapshot update for generated entry templates
pnpm test tests/entry-templates.test.ts

# App Router integration (covers instrumentation in dev + prod)
pnpm test tests/app-router.test.ts
```

All pass locally.