### PR TITLE
refactor(app-router): extract app fallback renderer factory

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -44,8 +44,8 @@ const appServerActionExecutionPath = resolveEntryPath(
 const appRscErrorsPath = resolveEntryPath("../server/app-rsc-errors.js", import.meta.url);
 const implicitTagsPath = resolveEntryPath("../server/implicit-tags.js", import.meta.url);
 const appPageExecutionPath = resolveEntryPath("../server/app-page-execution.js", import.meta.url);
-const appPageBoundaryRenderPath = resolveEntryPath(
-  "../server/app-page-boundary-render.js",
+const appFallbackRendererPath = resolveEntryPath(
+  "../server/app-fallback-renderer.js",
   import.meta.url,
 );
 const appElementsPath = resolveEntryPath("../server/app-elements.js", import.meta.url);
@@ -213,9 +213,8 @@ import {
   resolveAppPageSpecialError as __resolveAppPageSpecialError,
 } from ${JSON.stringify(appPageExecutionPath)};
 import {
-  renderAppPageErrorBoundary as __renderAppPageErrorBoundary,
-  renderAppPageHttpAccessFallback as __renderAppPageHttpAccessFallback,
-} from ${JSON.stringify(appPageBoundaryRenderPath)};
+  createAppFallbackRenderer as __createAppFallbackRenderer,
+} from ${JSON.stringify(appFallbackRendererPath)};
 import {
   APP_INTERCEPTION_CONTEXT_KEY as __APP_INTERCEPTION_CONTEXT_KEY,
   createAppPayloadRouteId as __createAppPayloadRouteId,
@@ -416,96 +415,35 @@ const rootNotFoundModule = ${rootNotFoundVar ? rootNotFoundVar : "null"};
 const rootForbiddenModule = ${rootForbiddenVar ? rootForbiddenVar : "null"};
 const rootUnauthorizedModule = ${rootUnauthorizedVar ? rootUnauthorizedVar : "null"};
 const rootLayouts = [${rootLayoutVars.join(", ")}];
-const __APP_PAGE_EMPTY_MW_CTX = { headers: null, status: null };
 
-/**
- * Render an HTTP access fallback page (not-found/forbidden/unauthorized) with layouts and noindex meta.
- * Returns null if no matching component is available.
- *
- * @param opts.boundaryComponent - Override the boundary component (for layout-level notFound)
- * @param opts.layouts - Override the layouts to wrap with (for layout-level notFound, excludes the throwing layout)
- */
-async function renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, opts, scriptNonce, middlewareContext) {
-  return __renderAppPageHttpAccessFallback({
-    boundaryComponent: opts?.boundaryComponent ?? null,
+const __fallbackRenderer = __createAppFallbackRenderer({
+  rootBoundaries: {
+    rootForbiddenModule,
+    rootLayouts,
+    rootNotFoundModule,
+    rootUnauthorizedModule,
+  },
+  globalErrorModule: ${globalErrorVar ? globalErrorVar : "null"},
+  metadataRoutes,
+  ssrLoader() {
+    return import.meta.viteRsc.loadModule("ssr", "index");
+  },
+  fontProviders: {
     buildFontLinkHeader: __buildAppPageFontLinkHeader,
-    clearRequestContext() {
-      __clearRequestContext();
-    },
-    createRscOnErrorHandler(pathname, routePath) {
-      return createRscOnErrorHandler(request, pathname, routePath);
-    },
     getFontLinks: _getSSRFontLinks,
     getFontPreloads: _getSSRFontPreloads,
     getFontStyles: _getSSRFontStyles,
-    getNavigationContext: _getNavigationContext,
-    globalErrorModule: ${globalErrorVar ? globalErrorVar : "null"},
-    isRscRequest,
-    layoutModules: opts?.layouts ?? null,
-    loadSsrHandler() {
-      return import.meta.viteRsc.loadModule("ssr", "index");
-    },
-    makeThenableParams,
-    matchedParams: opts?.matchedParams ?? route?.params ?? {},
-    middlewareContext: middlewareContext ?? __APP_PAGE_EMPTY_MW_CTX,
-    metadataRoutes,
-    requestUrl: request.url,
-    resolveChildSegments: __resolveAppPageChildSegments,
-    rootForbiddenModule: rootForbiddenModule,
-    rootLayouts: rootLayouts,
-    rootNotFoundModule: rootNotFoundModule,
-    rootUnauthorizedModule: rootUnauthorizedModule,
-    route,
-    renderToReadableStream,
-    scriptNonce,
-    statusCode,
-  });
-}
-
-/** Convenience: render a not-found page (404) */
-async function renderNotFoundPage(route, isRscRequest, request, matchedParams, scriptNonce, middlewareContext) {
-  return renderHTTPAccessFallbackPage(route, 404, isRscRequest, request, { matchedParams }, scriptNonce, middlewareContext);
-}
-
-/**
- * Render an error.tsx boundary page when a server component or generateMetadata() throws.
- * Returns null if no error boundary component is available for this route.
- *
- * Next.js returns HTTP 200 when error.tsx catches an error (the error is "handled"
- * by the boundary). This matches that behavior intentionally.
- */
-async function renderErrorBoundaryPage(route, error, isRscRequest, request, matchedParams, scriptNonce, middlewareContext) {
-  return __renderAppPageErrorBoundary({
-    buildFontLinkHeader: __buildAppPageFontLinkHeader,
-    clearRequestContext() {
-      __clearRequestContext();
-    },
-    createRscOnErrorHandler(pathname, routePath) {
-      return createRscOnErrorHandler(request, pathname, routePath);
-    },
-    error,
-    getFontLinks: _getSSRFontLinks,
-    getFontPreloads: _getSSRFontPreloads,
-    getFontStyles: _getSSRFontStyles,
-    getNavigationContext: _getNavigationContext,
-    globalErrorModule: ${globalErrorVar ? globalErrorVar : "null"},
-    isRscRequest,
-    loadSsrHandler() {
-      return import.meta.viteRsc.loadModule("ssr", "index");
-    },
-    makeThenableParams,
-    matchedParams: matchedParams ?? route?.params ?? {},
-    middlewareContext: middlewareContext ?? __APP_PAGE_EMPTY_MW_CTX,
-    metadataRoutes,
-    requestUrl: request.url,
-    resolveChildSegments: __resolveAppPageChildSegments,
-    rootLayouts: rootLayouts,
-    route,
-    renderToReadableStream,
-    sanitizeErrorForClient: __sanitizeErrorForClient,
-    scriptNonce,
-  });
-}
+  },
+  makeThenableParams,
+  sanitizer: __sanitizeErrorForClient,
+  rscRenderer: renderToReadableStream,
+  getNavigationContext: _getNavigationContext,
+  resolveChildSegments: __resolveAppPageChildSegments,
+  clearRequestContext() {
+    __clearRequestContext();
+  },
+  createRscOnErrorHandler,
+});
 
 function matchRoute(url) {
   return __routeMatcher.matchRoute(url);
@@ -1109,7 +1047,7 @@ ${prerenderPagesLoaderOption}
         : ""
     }
     // Render custom not-found page if available, otherwise plain 404
-    const notFoundResponse = await renderNotFoundPage(null, isRscRequest, request, undefined, _scriptNonce, _mwCtx);
+    const notFoundResponse = await __fallbackRenderer.renderNotFound(null, isRscRequest, request, undefined, _scriptNonce, _mwCtx);
     if (notFoundResponse) return notFoundResponse;
     __clearRequestContext();
     const notFoundHeaders = new Headers();
@@ -1228,10 +1166,10 @@ ${prerenderPagesLoaderOption}
       return PageComponent({ params: _asyncRouteParams, searchParams: _asyncSearchParams });
     },
     renderErrorBoundaryPage(renderErr) {
-      return renderErrorBoundaryPage(route, renderErr, isRscRequest, request, params, _scriptNonce, _mwCtx);
+      return __fallbackRenderer.renderErrorBoundary(route, renderErr, isRscRequest, request, params, _scriptNonce, _mwCtx);
     },
     renderHttpAccessFallbackPage(statusCode, opts, middlewareContext) {
-      return renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, opts, _scriptNonce, middlewareContext);
+      return __fallbackRenderer.renderHttpAccessFallback(route, statusCode, isRscRequest, request, opts, _scriptNonce, middlewareContext);
     },
     renderToReadableStream,
     request,

--- a/packages/vinext/src/server/app-fallback-renderer.ts
+++ b/packages/vinext/src/server/app-fallback-renderer.ts
@@ -1,0 +1,212 @@
+import type { ReactNode } from "react";
+import type { AppPageParams } from "./app-page-boundary.js";
+import {
+  renderAppPageErrorBoundary,
+  renderAppPageHttpAccessFallback,
+  type AppPageBoundaryRoute,
+} from "./app-page-boundary-render.js";
+import type { AppPageFontPreload } from "./app-page-execution.js";
+import type { AppPageMiddlewareContext } from "./app-page-response.js";
+import type { AppPageSsrHandler } from "./app-page-stream.js";
+import type { MetadataFileRoute } from "./metadata-routes.js";
+import type { AppElements } from "./app-elements.js";
+
+// oxlint-disable-next-line @typescript-eslint/no-explicit-any
+type AppPageComponent = import("react").ComponentType<any>;
+type AppPageModule = Record<string, unknown> & {
+  default?: AppPageComponent | null | undefined;
+};
+type AppPageBoundaryOnError = (
+  error: unknown,
+  requestInfo: unknown,
+  errorContext: unknown,
+) => unknown;
+
+type AppFallbackRendererRootBoundaries<TModule extends AppPageModule = AppPageModule> = {
+  rootForbiddenModule?: TModule | null;
+  rootLayouts: readonly (TModule | null | undefined)[];
+  rootNotFoundModule?: TModule | null;
+  rootUnauthorizedModule?: TModule | null;
+};
+
+type AppFallbackRendererFontProviders = {
+  buildFontLinkHeader: (preloads: readonly AppPageFontPreload[] | null | undefined) => string;
+  getFontLinks: () => string[];
+  getFontPreloads: () => AppPageFontPreload[];
+  getFontStyles: () => string[];
+};
+
+type AppFallbackRendererOptions<TModule extends AppPageModule = AppPageModule> = {
+  clearRequestContext: () => void;
+  createRscOnErrorHandler: (
+    request: Request,
+    pathname: string,
+    routePath: string,
+  ) => AppPageBoundaryOnError;
+  fontProviders: AppFallbackRendererFontProviders;
+  getNavigationContext: () => unknown;
+  globalErrorModule?: TModule | null;
+  makeThenableParams: (params: AppPageParams) => unknown;
+  metadataRoutes: MetadataFileRoute[];
+  resolveChildSegments: (
+    routeSegments: readonly string[],
+    treePosition: number,
+    params: AppPageParams,
+  ) => string[];
+  rootBoundaries: AppFallbackRendererRootBoundaries<TModule>;
+  rscRenderer: (
+    element: ReactNode | AppElements,
+    options: { onError: AppPageBoundaryOnError },
+  ) => ReadableStream<Uint8Array>;
+  sanitizer: (error: Error) => Error;
+  ssrLoader: () => Promise<AppPageSsrHandler>;
+};
+
+type AppFallbackRenderer<TModule extends AppPageModule = AppPageModule> = {
+  renderErrorBoundary: (
+    route: AppPageBoundaryRoute<TModule> | null,
+    error: unknown,
+    isRscRequest: boolean,
+    request: Request,
+    matchedParams: AppPageParams | undefined,
+    scriptNonce: string | undefined,
+    middlewareContext: AppPageMiddlewareContext,
+  ) => Promise<Response | null>;
+  renderHttpAccessFallback: (
+    route: AppPageBoundaryRoute<TModule> | null,
+    statusCode: number,
+    isRscRequest: boolean,
+    request: Request,
+    opts: {
+      boundaryComponent?: AppPageComponent | null;
+      layouts?: readonly (TModule | null | undefined)[] | null;
+      matchedParams?: AppPageParams;
+    },
+    scriptNonce: string | undefined,
+    middlewareContext: AppPageMiddlewareContext,
+  ) => Promise<Response | null>;
+  renderNotFound: (
+    route: AppPageBoundaryRoute<TModule> | null,
+    isRscRequest: boolean,
+    request: Request,
+    matchedParams: AppPageParams | undefined,
+    scriptNonce: string | undefined,
+    middlewareContext: AppPageMiddlewareContext,
+  ) => Promise<Response | null>;
+};
+
+const EMPTY_MW_CTX: AppPageMiddlewareContext = { headers: null, status: null };
+
+export function createAppFallbackRenderer<TModule extends AppPageModule>(
+  options: AppFallbackRendererOptions<TModule>,
+): AppFallbackRenderer<TModule> {
+  const {
+    clearRequestContext,
+    createRscOnErrorHandler: buildRscOnErrorHandler,
+    fontProviders,
+    getNavigationContext,
+    globalErrorModule,
+    makeThenableParams,
+    metadataRoutes,
+    resolveChildSegments,
+    rootBoundaries,
+    rscRenderer,
+    sanitizer,
+    ssrLoader,
+  } = options;
+
+  const { rootForbiddenModule, rootLayouts, rootNotFoundModule, rootUnauthorizedModule } =
+    rootBoundaries;
+
+  return {
+    renderHttpAccessFallback(
+      route,
+      statusCode,
+      isRscRequest,
+      request,
+      opts,
+      scriptNonce,
+      middlewareContext,
+    ) {
+      return renderAppPageHttpAccessFallback({
+        boundaryComponent: opts?.boundaryComponent ?? null,
+        buildFontLinkHeader: fontProviders.buildFontLinkHeader,
+        clearRequestContext,
+        createRscOnErrorHandler(pathname, routePath) {
+          return buildRscOnErrorHandler(request, pathname, routePath);
+        },
+        getFontLinks: fontProviders.getFontLinks,
+        getFontPreloads: fontProviders.getFontPreloads,
+        getFontStyles: fontProviders.getFontStyles,
+        getNavigationContext,
+        globalErrorModule,
+        isRscRequest,
+        layoutModules: opts?.layouts ?? null,
+        loadSsrHandler: ssrLoader,
+        makeThenableParams,
+        matchedParams: opts?.matchedParams ?? route?.params ?? {},
+        middlewareContext: middlewareContext ?? EMPTY_MW_CTX,
+        metadataRoutes,
+        requestUrl: request.url,
+        resolveChildSegments,
+        rootForbiddenModule,
+        rootLayouts,
+        rootNotFoundModule,
+        rootUnauthorizedModule,
+        route,
+        renderToReadableStream: rscRenderer,
+        scriptNonce,
+        statusCode,
+      });
+    },
+
+    renderNotFound(route, isRscRequest, request, matchedParams, scriptNonce, middlewareContext) {
+      return this.renderHttpAccessFallback(
+        route,
+        404,
+        isRscRequest,
+        request,
+        { matchedParams },
+        scriptNonce,
+        middlewareContext,
+      );
+    },
+
+    renderErrorBoundary(
+      route,
+      error,
+      isRscRequest,
+      request,
+      matchedParams,
+      scriptNonce,
+      middlewareContext,
+    ) {
+      return renderAppPageErrorBoundary({
+        buildFontLinkHeader: fontProviders.buildFontLinkHeader,
+        clearRequestContext,
+        createRscOnErrorHandler(pathname, routePath) {
+          return buildRscOnErrorHandler(request, pathname, routePath);
+        },
+        error,
+        getFontLinks: fontProviders.getFontLinks,
+        getFontPreloads: fontProviders.getFontPreloads,
+        getFontStyles: fontProviders.getFontStyles,
+        getNavigationContext,
+        globalErrorModule,
+        isRscRequest,
+        loadSsrHandler: ssrLoader,
+        makeThenableParams,
+        matchedParams: matchedParams ?? route?.params ?? {},
+        middlewareContext: middlewareContext ?? EMPTY_MW_CTX,
+        metadataRoutes,
+        requestUrl: request.url,
+        resolveChildSegments,
+        rootLayouts,
+        route,
+        renderToReadableStream: rscRenderer,
+        sanitizeErrorForClient: sanitizer,
+        scriptNonce,
+      });
+    },
+  };
+}

--- a/packages/vinext/src/server/app-page-boundary-render.ts
+++ b/packages/vinext/src/server/app-page-boundary-render.ts
@@ -45,7 +45,7 @@ type AppPageBoundaryRscPayloadOptions<TModule extends AppPageModule = AppPageMod
   route?: AppPageBoundaryRoute<TModule> | null;
 };
 
-type AppPageBoundaryRoute<TModule extends AppPageModule = AppPageModule> = {
+export type AppPageBoundaryRoute<TModule extends AppPageModule = AppPageModule> = {
   error?: TModule | null;
   errors?: readonly (TModule | null | undefined)[] | null;
   forbidden?: TModule | null;

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -51,9 +51,8 @@ import {
   resolveAppPageSpecialError as __resolveAppPageSpecialError,
 } from "<ROOT>/packages/vinext/src/server/app-page-execution.js";
 import {
-  renderAppPageErrorBoundary as __renderAppPageErrorBoundary,
-  renderAppPageHttpAccessFallback as __renderAppPageHttpAccessFallback,
-} from "<ROOT>/packages/vinext/src/server/app-page-boundary-render.js";
+  createAppFallbackRenderer as __createAppFallbackRenderer,
+} from "<ROOT>/packages/vinext/src/server/app-fallback-renderer.js";
 import {
   APP_INTERCEPTION_CONTEXT_KEY as __APP_INTERCEPTION_CONTEXT_KEY,
   createAppPayloadRouteId as __createAppPayloadRouteId,
@@ -343,96 +342,35 @@ const rootNotFoundModule = null;
 const rootForbiddenModule = null;
 const rootUnauthorizedModule = null;
 const rootLayouts = [mod_1];
-const __APP_PAGE_EMPTY_MW_CTX = { headers: null, status: null };
 
-/**
- * Render an HTTP access fallback page (not-found/forbidden/unauthorized) with layouts and noindex meta.
- * Returns null if no matching component is available.
- *
- * @param opts.boundaryComponent - Override the boundary component (for layout-level notFound)
- * @param opts.layouts - Override the layouts to wrap with (for layout-level notFound, excludes the throwing layout)
- */
-async function renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, opts, scriptNonce, middlewareContext) {
-  return __renderAppPageHttpAccessFallback({
-    boundaryComponent: opts?.boundaryComponent ?? null,
+const __fallbackRenderer = __createAppFallbackRenderer({
+  rootBoundaries: {
+    rootForbiddenModule,
+    rootLayouts,
+    rootNotFoundModule,
+    rootUnauthorizedModule,
+  },
+  globalErrorModule: null,
+  metadataRoutes,
+  ssrLoader() {
+    return import.meta.viteRsc.loadModule("ssr", "index");
+  },
+  fontProviders: {
     buildFontLinkHeader: __buildAppPageFontLinkHeader,
-    clearRequestContext() {
-      __clearRequestContext();
-    },
-    createRscOnErrorHandler(pathname, routePath) {
-      return createRscOnErrorHandler(request, pathname, routePath);
-    },
     getFontLinks: _getSSRFontLinks,
     getFontPreloads: _getSSRFontPreloads,
     getFontStyles: _getSSRFontStyles,
-    getNavigationContext: _getNavigationContext,
-    globalErrorModule: null,
-    isRscRequest,
-    layoutModules: opts?.layouts ?? null,
-    loadSsrHandler() {
-      return import.meta.viteRsc.loadModule("ssr", "index");
-    },
-    makeThenableParams,
-    matchedParams: opts?.matchedParams ?? route?.params ?? {},
-    middlewareContext: middlewareContext ?? __APP_PAGE_EMPTY_MW_CTX,
-    metadataRoutes,
-    requestUrl: request.url,
-    resolveChildSegments: __resolveAppPageChildSegments,
-    rootForbiddenModule: rootForbiddenModule,
-    rootLayouts: rootLayouts,
-    rootNotFoundModule: rootNotFoundModule,
-    rootUnauthorizedModule: rootUnauthorizedModule,
-    route,
-    renderToReadableStream,
-    scriptNonce,
-    statusCode,
-  });
-}
-
-/** Convenience: render a not-found page (404) */
-async function renderNotFoundPage(route, isRscRequest, request, matchedParams, scriptNonce, middlewareContext) {
-  return renderHTTPAccessFallbackPage(route, 404, isRscRequest, request, { matchedParams }, scriptNonce, middlewareContext);
-}
-
-/**
- * Render an error.tsx boundary page when a server component or generateMetadata() throws.
- * Returns null if no error boundary component is available for this route.
- *
- * Next.js returns HTTP 200 when error.tsx catches an error (the error is "handled"
- * by the boundary). This matches that behavior intentionally.
- */
-async function renderErrorBoundaryPage(route, error, isRscRequest, request, matchedParams, scriptNonce, middlewareContext) {
-  return __renderAppPageErrorBoundary({
-    buildFontLinkHeader: __buildAppPageFontLinkHeader,
-    clearRequestContext() {
-      __clearRequestContext();
-    },
-    createRscOnErrorHandler(pathname, routePath) {
-      return createRscOnErrorHandler(request, pathname, routePath);
-    },
-    error,
-    getFontLinks: _getSSRFontLinks,
-    getFontPreloads: _getSSRFontPreloads,
-    getFontStyles: _getSSRFontStyles,
-    getNavigationContext: _getNavigationContext,
-    globalErrorModule: null,
-    isRscRequest,
-    loadSsrHandler() {
-      return import.meta.viteRsc.loadModule("ssr", "index");
-    },
-    makeThenableParams,
-    matchedParams: matchedParams ?? route?.params ?? {},
-    middlewareContext: middlewareContext ?? __APP_PAGE_EMPTY_MW_CTX,
-    metadataRoutes,
-    requestUrl: request.url,
-    resolveChildSegments: __resolveAppPageChildSegments,
-    rootLayouts: rootLayouts,
-    route,
-    renderToReadableStream,
-    sanitizeErrorForClient: __sanitizeErrorForClient,
-    scriptNonce,
-  });
-}
+  },
+  makeThenableParams,
+  sanitizer: __sanitizeErrorForClient,
+  rscRenderer: renderToReadableStream,
+  getNavigationContext: _getNavigationContext,
+  resolveChildSegments: __resolveAppPageChildSegments,
+  clearRequestContext() {
+    __clearRequestContext();
+  },
+  createRscOnErrorHandler,
+});
 
 function matchRoute(url) {
   return __routeMatcher.matchRoute(url);
@@ -1012,7 +950,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   if (!match) {
     
     // Render custom not-found page if available, otherwise plain 404
-    const notFoundResponse = await renderNotFoundPage(null, isRscRequest, request, undefined, _scriptNonce, _mwCtx);
+    const notFoundResponse = await __fallbackRenderer.renderNotFound(null, isRscRequest, request, undefined, _scriptNonce, _mwCtx);
     if (notFoundResponse) return notFoundResponse;
     __clearRequestContext();
     const notFoundHeaders = new Headers();
@@ -1131,10 +1069,10 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       return PageComponent({ params: _asyncRouteParams, searchParams: _asyncSearchParams });
     },
     renderErrorBoundaryPage(renderErr) {
-      return renderErrorBoundaryPage(route, renderErr, isRscRequest, request, params, _scriptNonce, _mwCtx);
+      return __fallbackRenderer.renderErrorBoundary(route, renderErr, isRscRequest, request, params, _scriptNonce, _mwCtx);
     },
     renderHttpAccessFallbackPage(statusCode, opts, middlewareContext) {
-      return renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, opts, _scriptNonce, middlewareContext);
+      return __fallbackRenderer.renderHttpAccessFallback(route, statusCode, isRscRequest, request, opts, _scriptNonce, middlewareContext);
     },
     renderToReadableStream,
     request,
@@ -1210,9 +1148,8 @@ import {
   resolveAppPageSpecialError as __resolveAppPageSpecialError,
 } from "<ROOT>/packages/vinext/src/server/app-page-execution.js";
 import {
-  renderAppPageErrorBoundary as __renderAppPageErrorBoundary,
-  renderAppPageHttpAccessFallback as __renderAppPageHttpAccessFallback,
-} from "<ROOT>/packages/vinext/src/server/app-page-boundary-render.js";
+  createAppFallbackRenderer as __createAppFallbackRenderer,
+} from "<ROOT>/packages/vinext/src/server/app-fallback-renderer.js";
 import {
   APP_INTERCEPTION_CONTEXT_KEY as __APP_INTERCEPTION_CONTEXT_KEY,
   createAppPayloadRouteId as __createAppPayloadRouteId,
@@ -1502,96 +1439,35 @@ const rootNotFoundModule = null;
 const rootForbiddenModule = null;
 const rootUnauthorizedModule = null;
 const rootLayouts = [mod_1];
-const __APP_PAGE_EMPTY_MW_CTX = { headers: null, status: null };
 
-/**
- * Render an HTTP access fallback page (not-found/forbidden/unauthorized) with layouts and noindex meta.
- * Returns null if no matching component is available.
- *
- * @param opts.boundaryComponent - Override the boundary component (for layout-level notFound)
- * @param opts.layouts - Override the layouts to wrap with (for layout-level notFound, excludes the throwing layout)
- */
-async function renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, opts, scriptNonce, middlewareContext) {
-  return __renderAppPageHttpAccessFallback({
-    boundaryComponent: opts?.boundaryComponent ?? null,
+const __fallbackRenderer = __createAppFallbackRenderer({
+  rootBoundaries: {
+    rootForbiddenModule,
+    rootLayouts,
+    rootNotFoundModule,
+    rootUnauthorizedModule,
+  },
+  globalErrorModule: null,
+  metadataRoutes,
+  ssrLoader() {
+    return import.meta.viteRsc.loadModule("ssr", "index");
+  },
+  fontProviders: {
     buildFontLinkHeader: __buildAppPageFontLinkHeader,
-    clearRequestContext() {
-      __clearRequestContext();
-    },
-    createRscOnErrorHandler(pathname, routePath) {
-      return createRscOnErrorHandler(request, pathname, routePath);
-    },
     getFontLinks: _getSSRFontLinks,
     getFontPreloads: _getSSRFontPreloads,
     getFontStyles: _getSSRFontStyles,
-    getNavigationContext: _getNavigationContext,
-    globalErrorModule: null,
-    isRscRequest,
-    layoutModules: opts?.layouts ?? null,
-    loadSsrHandler() {
-      return import.meta.viteRsc.loadModule("ssr", "index");
-    },
-    makeThenableParams,
-    matchedParams: opts?.matchedParams ?? route?.params ?? {},
-    middlewareContext: middlewareContext ?? __APP_PAGE_EMPTY_MW_CTX,
-    metadataRoutes,
-    requestUrl: request.url,
-    resolveChildSegments: __resolveAppPageChildSegments,
-    rootForbiddenModule: rootForbiddenModule,
-    rootLayouts: rootLayouts,
-    rootNotFoundModule: rootNotFoundModule,
-    rootUnauthorizedModule: rootUnauthorizedModule,
-    route,
-    renderToReadableStream,
-    scriptNonce,
-    statusCode,
-  });
-}
-
-/** Convenience: render a not-found page (404) */
-async function renderNotFoundPage(route, isRscRequest, request, matchedParams, scriptNonce, middlewareContext) {
-  return renderHTTPAccessFallbackPage(route, 404, isRscRequest, request, { matchedParams }, scriptNonce, middlewareContext);
-}
-
-/**
- * Render an error.tsx boundary page when a server component or generateMetadata() throws.
- * Returns null if no error boundary component is available for this route.
- *
- * Next.js returns HTTP 200 when error.tsx catches an error (the error is "handled"
- * by the boundary). This matches that behavior intentionally.
- */
-async function renderErrorBoundaryPage(route, error, isRscRequest, request, matchedParams, scriptNonce, middlewareContext) {
-  return __renderAppPageErrorBoundary({
-    buildFontLinkHeader: __buildAppPageFontLinkHeader,
-    clearRequestContext() {
-      __clearRequestContext();
-    },
-    createRscOnErrorHandler(pathname, routePath) {
-      return createRscOnErrorHandler(request, pathname, routePath);
-    },
-    error,
-    getFontLinks: _getSSRFontLinks,
-    getFontPreloads: _getSSRFontPreloads,
-    getFontStyles: _getSSRFontStyles,
-    getNavigationContext: _getNavigationContext,
-    globalErrorModule: null,
-    isRscRequest,
-    loadSsrHandler() {
-      return import.meta.viteRsc.loadModule("ssr", "index");
-    },
-    makeThenableParams,
-    matchedParams: matchedParams ?? route?.params ?? {},
-    middlewareContext: middlewareContext ?? __APP_PAGE_EMPTY_MW_CTX,
-    metadataRoutes,
-    requestUrl: request.url,
-    resolveChildSegments: __resolveAppPageChildSegments,
-    rootLayouts: rootLayouts,
-    route,
-    renderToReadableStream,
-    sanitizeErrorForClient: __sanitizeErrorForClient,
-    scriptNonce,
-  });
-}
+  },
+  makeThenableParams,
+  sanitizer: __sanitizeErrorForClient,
+  rscRenderer: renderToReadableStream,
+  getNavigationContext: _getNavigationContext,
+  resolveChildSegments: __resolveAppPageChildSegments,
+  clearRequestContext() {
+    __clearRequestContext();
+  },
+  createRscOnErrorHandler,
+});
 
 function matchRoute(url) {
   return __routeMatcher.matchRoute(url);
@@ -2177,7 +2053,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   if (!match) {
     
     // Render custom not-found page if available, otherwise plain 404
-    const notFoundResponse = await renderNotFoundPage(null, isRscRequest, request, undefined, _scriptNonce, _mwCtx);
+    const notFoundResponse = await __fallbackRenderer.renderNotFound(null, isRscRequest, request, undefined, _scriptNonce, _mwCtx);
     if (notFoundResponse) return notFoundResponse;
     __clearRequestContext();
     const notFoundHeaders = new Headers();
@@ -2296,10 +2172,10 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       return PageComponent({ params: _asyncRouteParams, searchParams: _asyncSearchParams });
     },
     renderErrorBoundaryPage(renderErr) {
-      return renderErrorBoundaryPage(route, renderErr, isRscRequest, request, params, _scriptNonce, _mwCtx);
+      return __fallbackRenderer.renderErrorBoundary(route, renderErr, isRscRequest, request, params, _scriptNonce, _mwCtx);
     },
     renderHttpAccessFallbackPage(statusCode, opts, middlewareContext) {
-      return renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, opts, _scriptNonce, middlewareContext);
+      return __fallbackRenderer.renderHttpAccessFallback(route, statusCode, isRscRequest, request, opts, _scriptNonce, middlewareContext);
     },
     renderToReadableStream,
     request,
@@ -2375,9 +2251,8 @@ import {
   resolveAppPageSpecialError as __resolveAppPageSpecialError,
 } from "<ROOT>/packages/vinext/src/server/app-page-execution.js";
 import {
-  renderAppPageErrorBoundary as __renderAppPageErrorBoundary,
-  renderAppPageHttpAccessFallback as __renderAppPageHttpAccessFallback,
-} from "<ROOT>/packages/vinext/src/server/app-page-boundary-render.js";
+  createAppFallbackRenderer as __createAppFallbackRenderer,
+} from "<ROOT>/packages/vinext/src/server/app-fallback-renderer.js";
 import {
   APP_INTERCEPTION_CONTEXT_KEY as __APP_INTERCEPTION_CONTEXT_KEY,
   createAppPayloadRouteId as __createAppPayloadRouteId,
@@ -2668,96 +2543,35 @@ const rootNotFoundModule = null;
 const rootForbiddenModule = null;
 const rootUnauthorizedModule = null;
 const rootLayouts = [mod_1];
-const __APP_PAGE_EMPTY_MW_CTX = { headers: null, status: null };
 
-/**
- * Render an HTTP access fallback page (not-found/forbidden/unauthorized) with layouts and noindex meta.
- * Returns null if no matching component is available.
- *
- * @param opts.boundaryComponent - Override the boundary component (for layout-level notFound)
- * @param opts.layouts - Override the layouts to wrap with (for layout-level notFound, excludes the throwing layout)
- */
-async function renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, opts, scriptNonce, middlewareContext) {
-  return __renderAppPageHttpAccessFallback({
-    boundaryComponent: opts?.boundaryComponent ?? null,
+const __fallbackRenderer = __createAppFallbackRenderer({
+  rootBoundaries: {
+    rootForbiddenModule,
+    rootLayouts,
+    rootNotFoundModule,
+    rootUnauthorizedModule,
+  },
+  globalErrorModule: mod_13,
+  metadataRoutes,
+  ssrLoader() {
+    return import.meta.viteRsc.loadModule("ssr", "index");
+  },
+  fontProviders: {
     buildFontLinkHeader: __buildAppPageFontLinkHeader,
-    clearRequestContext() {
-      __clearRequestContext();
-    },
-    createRscOnErrorHandler(pathname, routePath) {
-      return createRscOnErrorHandler(request, pathname, routePath);
-    },
     getFontLinks: _getSSRFontLinks,
     getFontPreloads: _getSSRFontPreloads,
     getFontStyles: _getSSRFontStyles,
-    getNavigationContext: _getNavigationContext,
-    globalErrorModule: mod_13,
-    isRscRequest,
-    layoutModules: opts?.layouts ?? null,
-    loadSsrHandler() {
-      return import.meta.viteRsc.loadModule("ssr", "index");
-    },
-    makeThenableParams,
-    matchedParams: opts?.matchedParams ?? route?.params ?? {},
-    middlewareContext: middlewareContext ?? __APP_PAGE_EMPTY_MW_CTX,
-    metadataRoutes,
-    requestUrl: request.url,
-    resolveChildSegments: __resolveAppPageChildSegments,
-    rootForbiddenModule: rootForbiddenModule,
-    rootLayouts: rootLayouts,
-    rootNotFoundModule: rootNotFoundModule,
-    rootUnauthorizedModule: rootUnauthorizedModule,
-    route,
-    renderToReadableStream,
-    scriptNonce,
-    statusCode,
-  });
-}
-
-/** Convenience: render a not-found page (404) */
-async function renderNotFoundPage(route, isRscRequest, request, matchedParams, scriptNonce, middlewareContext) {
-  return renderHTTPAccessFallbackPage(route, 404, isRscRequest, request, { matchedParams }, scriptNonce, middlewareContext);
-}
-
-/**
- * Render an error.tsx boundary page when a server component or generateMetadata() throws.
- * Returns null if no error boundary component is available for this route.
- *
- * Next.js returns HTTP 200 when error.tsx catches an error (the error is "handled"
- * by the boundary). This matches that behavior intentionally.
- */
-async function renderErrorBoundaryPage(route, error, isRscRequest, request, matchedParams, scriptNonce, middlewareContext) {
-  return __renderAppPageErrorBoundary({
-    buildFontLinkHeader: __buildAppPageFontLinkHeader,
-    clearRequestContext() {
-      __clearRequestContext();
-    },
-    createRscOnErrorHandler(pathname, routePath) {
-      return createRscOnErrorHandler(request, pathname, routePath);
-    },
-    error,
-    getFontLinks: _getSSRFontLinks,
-    getFontPreloads: _getSSRFontPreloads,
-    getFontStyles: _getSSRFontStyles,
-    getNavigationContext: _getNavigationContext,
-    globalErrorModule: mod_13,
-    isRscRequest,
-    loadSsrHandler() {
-      return import.meta.viteRsc.loadModule("ssr", "index");
-    },
-    makeThenableParams,
-    matchedParams: matchedParams ?? route?.params ?? {},
-    middlewareContext: middlewareContext ?? __APP_PAGE_EMPTY_MW_CTX,
-    metadataRoutes,
-    requestUrl: request.url,
-    resolveChildSegments: __resolveAppPageChildSegments,
-    rootLayouts: rootLayouts,
-    route,
-    renderToReadableStream,
-    sanitizeErrorForClient: __sanitizeErrorForClient,
-    scriptNonce,
-  });
-}
+  },
+  makeThenableParams,
+  sanitizer: __sanitizeErrorForClient,
+  rscRenderer: renderToReadableStream,
+  getNavigationContext: _getNavigationContext,
+  resolveChildSegments: __resolveAppPageChildSegments,
+  clearRequestContext() {
+    __clearRequestContext();
+  },
+  createRscOnErrorHandler,
+});
 
 function matchRoute(url) {
   return __routeMatcher.matchRoute(url);
@@ -3337,7 +3151,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   if (!match) {
     
     // Render custom not-found page if available, otherwise plain 404
-    const notFoundResponse = await renderNotFoundPage(null, isRscRequest, request, undefined, _scriptNonce, _mwCtx);
+    const notFoundResponse = await __fallbackRenderer.renderNotFound(null, isRscRequest, request, undefined, _scriptNonce, _mwCtx);
     if (notFoundResponse) return notFoundResponse;
     __clearRequestContext();
     const notFoundHeaders = new Headers();
@@ -3456,10 +3270,10 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       return PageComponent({ params: _asyncRouteParams, searchParams: _asyncSearchParams });
     },
     renderErrorBoundaryPage(renderErr) {
-      return renderErrorBoundaryPage(route, renderErr, isRscRequest, request, params, _scriptNonce, _mwCtx);
+      return __fallbackRenderer.renderErrorBoundary(route, renderErr, isRscRequest, request, params, _scriptNonce, _mwCtx);
     },
     renderHttpAccessFallbackPage(statusCode, opts, middlewareContext) {
-      return renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, opts, _scriptNonce, middlewareContext);
+      return __fallbackRenderer.renderHttpAccessFallback(route, statusCode, isRscRequest, request, opts, _scriptNonce, middlewareContext);
     },
     renderToReadableStream,
     request,
@@ -3535,9 +3349,8 @@ import {
   resolveAppPageSpecialError as __resolveAppPageSpecialError,
 } from "<ROOT>/packages/vinext/src/server/app-page-execution.js";
 import {
-  renderAppPageErrorBoundary as __renderAppPageErrorBoundary,
-  renderAppPageHttpAccessFallback as __renderAppPageHttpAccessFallback,
-} from "<ROOT>/packages/vinext/src/server/app-page-boundary-render.js";
+  createAppFallbackRenderer as __createAppFallbackRenderer,
+} from "<ROOT>/packages/vinext/src/server/app-fallback-renderer.js";
 import {
   APP_INTERCEPTION_CONTEXT_KEY as __APP_INTERCEPTION_CONTEXT_KEY,
   createAppPayloadRouteId as __createAppPayloadRouteId,
@@ -3857,96 +3670,35 @@ const rootNotFoundModule = null;
 const rootForbiddenModule = null;
 const rootUnauthorizedModule = null;
 const rootLayouts = [mod_1];
-const __APP_PAGE_EMPTY_MW_CTX = { headers: null, status: null };
 
-/**
- * Render an HTTP access fallback page (not-found/forbidden/unauthorized) with layouts and noindex meta.
- * Returns null if no matching component is available.
- *
- * @param opts.boundaryComponent - Override the boundary component (for layout-level notFound)
- * @param opts.layouts - Override the layouts to wrap with (for layout-level notFound, excludes the throwing layout)
- */
-async function renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, opts, scriptNonce, middlewareContext) {
-  return __renderAppPageHttpAccessFallback({
-    boundaryComponent: opts?.boundaryComponent ?? null,
+const __fallbackRenderer = __createAppFallbackRenderer({
+  rootBoundaries: {
+    rootForbiddenModule,
+    rootLayouts,
+    rootNotFoundModule,
+    rootUnauthorizedModule,
+  },
+  globalErrorModule: null,
+  metadataRoutes,
+  ssrLoader() {
+    return import.meta.viteRsc.loadModule("ssr", "index");
+  },
+  fontProviders: {
     buildFontLinkHeader: __buildAppPageFontLinkHeader,
-    clearRequestContext() {
-      __clearRequestContext();
-    },
-    createRscOnErrorHandler(pathname, routePath) {
-      return createRscOnErrorHandler(request, pathname, routePath);
-    },
     getFontLinks: _getSSRFontLinks,
     getFontPreloads: _getSSRFontPreloads,
     getFontStyles: _getSSRFontStyles,
-    getNavigationContext: _getNavigationContext,
-    globalErrorModule: null,
-    isRscRequest,
-    layoutModules: opts?.layouts ?? null,
-    loadSsrHandler() {
-      return import.meta.viteRsc.loadModule("ssr", "index");
-    },
-    makeThenableParams,
-    matchedParams: opts?.matchedParams ?? route?.params ?? {},
-    middlewareContext: middlewareContext ?? __APP_PAGE_EMPTY_MW_CTX,
-    metadataRoutes,
-    requestUrl: request.url,
-    resolveChildSegments: __resolveAppPageChildSegments,
-    rootForbiddenModule: rootForbiddenModule,
-    rootLayouts: rootLayouts,
-    rootNotFoundModule: rootNotFoundModule,
-    rootUnauthorizedModule: rootUnauthorizedModule,
-    route,
-    renderToReadableStream,
-    scriptNonce,
-    statusCode,
-  });
-}
-
-/** Convenience: render a not-found page (404) */
-async function renderNotFoundPage(route, isRscRequest, request, matchedParams, scriptNonce, middlewareContext) {
-  return renderHTTPAccessFallbackPage(route, 404, isRscRequest, request, { matchedParams }, scriptNonce, middlewareContext);
-}
-
-/**
- * Render an error.tsx boundary page when a server component or generateMetadata() throws.
- * Returns null if no error boundary component is available for this route.
- *
- * Next.js returns HTTP 200 when error.tsx catches an error (the error is "handled"
- * by the boundary). This matches that behavior intentionally.
- */
-async function renderErrorBoundaryPage(route, error, isRscRequest, request, matchedParams, scriptNonce, middlewareContext) {
-  return __renderAppPageErrorBoundary({
-    buildFontLinkHeader: __buildAppPageFontLinkHeader,
-    clearRequestContext() {
-      __clearRequestContext();
-    },
-    createRscOnErrorHandler(pathname, routePath) {
-      return createRscOnErrorHandler(request, pathname, routePath);
-    },
-    error,
-    getFontLinks: _getSSRFontLinks,
-    getFontPreloads: _getSSRFontPreloads,
-    getFontStyles: _getSSRFontStyles,
-    getNavigationContext: _getNavigationContext,
-    globalErrorModule: null,
-    isRscRequest,
-    loadSsrHandler() {
-      return import.meta.viteRsc.loadModule("ssr", "index");
-    },
-    makeThenableParams,
-    matchedParams: matchedParams ?? route?.params ?? {},
-    middlewareContext: middlewareContext ?? __APP_PAGE_EMPTY_MW_CTX,
-    metadataRoutes,
-    requestUrl: request.url,
-    resolveChildSegments: __resolveAppPageChildSegments,
-    rootLayouts: rootLayouts,
-    route,
-    renderToReadableStream,
-    sanitizeErrorForClient: __sanitizeErrorForClient,
-    scriptNonce,
-  });
-}
+  },
+  makeThenableParams,
+  sanitizer: __sanitizeErrorForClient,
+  rscRenderer: renderToReadableStream,
+  getNavigationContext: _getNavigationContext,
+  resolveChildSegments: __resolveAppPageChildSegments,
+  clearRequestContext() {
+    __clearRequestContext();
+  },
+  createRscOnErrorHandler,
+});
 
 function matchRoute(url) {
   return __routeMatcher.matchRoute(url);
@@ -4529,7 +4281,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   if (!match) {
     
     // Render custom not-found page if available, otherwise plain 404
-    const notFoundResponse = await renderNotFoundPage(null, isRscRequest, request, undefined, _scriptNonce, _mwCtx);
+    const notFoundResponse = await __fallbackRenderer.renderNotFound(null, isRscRequest, request, undefined, _scriptNonce, _mwCtx);
     if (notFoundResponse) return notFoundResponse;
     __clearRequestContext();
     const notFoundHeaders = new Headers();
@@ -4648,10 +4400,10 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       return PageComponent({ params: _asyncRouteParams, searchParams: _asyncSearchParams });
     },
     renderErrorBoundaryPage(renderErr) {
-      return renderErrorBoundaryPage(route, renderErr, isRscRequest, request, params, _scriptNonce, _mwCtx);
+      return __fallbackRenderer.renderErrorBoundary(route, renderErr, isRscRequest, request, params, _scriptNonce, _mwCtx);
     },
     renderHttpAccessFallbackPage(statusCode, opts, middlewareContext) {
-      return renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, opts, _scriptNonce, middlewareContext);
+      return __fallbackRenderer.renderHttpAccessFallback(route, statusCode, isRscRequest, request, opts, _scriptNonce, middlewareContext);
     },
     renderToReadableStream,
     request,
@@ -4727,9 +4479,8 @@ import {
   resolveAppPageSpecialError as __resolveAppPageSpecialError,
 } from "<ROOT>/packages/vinext/src/server/app-page-execution.js";
 import {
-  renderAppPageErrorBoundary as __renderAppPageErrorBoundary,
-  renderAppPageHttpAccessFallback as __renderAppPageHttpAccessFallback,
-} from "<ROOT>/packages/vinext/src/server/app-page-boundary-render.js";
+  createAppFallbackRenderer as __createAppFallbackRenderer,
+} from "<ROOT>/packages/vinext/src/server/app-fallback-renderer.js";
 import {
   APP_INTERCEPTION_CONTEXT_KEY as __APP_INTERCEPTION_CONTEXT_KEY,
   createAppPayloadRouteId as __createAppPayloadRouteId,
@@ -5029,96 +4780,35 @@ const rootNotFoundModule = null;
 const rootForbiddenModule = null;
 const rootUnauthorizedModule = null;
 const rootLayouts = [mod_1];
-const __APP_PAGE_EMPTY_MW_CTX = { headers: null, status: null };
 
-/**
- * Render an HTTP access fallback page (not-found/forbidden/unauthorized) with layouts and noindex meta.
- * Returns null if no matching component is available.
- *
- * @param opts.boundaryComponent - Override the boundary component (for layout-level notFound)
- * @param opts.layouts - Override the layouts to wrap with (for layout-level notFound, excludes the throwing layout)
- */
-async function renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, opts, scriptNonce, middlewareContext) {
-  return __renderAppPageHttpAccessFallback({
-    boundaryComponent: opts?.boundaryComponent ?? null,
+const __fallbackRenderer = __createAppFallbackRenderer({
+  rootBoundaries: {
+    rootForbiddenModule,
+    rootLayouts,
+    rootNotFoundModule,
+    rootUnauthorizedModule,
+  },
+  globalErrorModule: null,
+  metadataRoutes,
+  ssrLoader() {
+    return import.meta.viteRsc.loadModule("ssr", "index");
+  },
+  fontProviders: {
     buildFontLinkHeader: __buildAppPageFontLinkHeader,
-    clearRequestContext() {
-      __clearRequestContext();
-    },
-    createRscOnErrorHandler(pathname, routePath) {
-      return createRscOnErrorHandler(request, pathname, routePath);
-    },
     getFontLinks: _getSSRFontLinks,
     getFontPreloads: _getSSRFontPreloads,
     getFontStyles: _getSSRFontStyles,
-    getNavigationContext: _getNavigationContext,
-    globalErrorModule: null,
-    isRscRequest,
-    layoutModules: opts?.layouts ?? null,
-    loadSsrHandler() {
-      return import.meta.viteRsc.loadModule("ssr", "index");
-    },
-    makeThenableParams,
-    matchedParams: opts?.matchedParams ?? route?.params ?? {},
-    middlewareContext: middlewareContext ?? __APP_PAGE_EMPTY_MW_CTX,
-    metadataRoutes,
-    requestUrl: request.url,
-    resolveChildSegments: __resolveAppPageChildSegments,
-    rootForbiddenModule: rootForbiddenModule,
-    rootLayouts: rootLayouts,
-    rootNotFoundModule: rootNotFoundModule,
-    rootUnauthorizedModule: rootUnauthorizedModule,
-    route,
-    renderToReadableStream,
-    scriptNonce,
-    statusCode,
-  });
-}
-
-/** Convenience: render a not-found page (404) */
-async function renderNotFoundPage(route, isRscRequest, request, matchedParams, scriptNonce, middlewareContext) {
-  return renderHTTPAccessFallbackPage(route, 404, isRscRequest, request, { matchedParams }, scriptNonce, middlewareContext);
-}
-
-/**
- * Render an error.tsx boundary page when a server component or generateMetadata() throws.
- * Returns null if no error boundary component is available for this route.
- *
- * Next.js returns HTTP 200 when error.tsx catches an error (the error is "handled"
- * by the boundary). This matches that behavior intentionally.
- */
-async function renderErrorBoundaryPage(route, error, isRscRequest, request, matchedParams, scriptNonce, middlewareContext) {
-  return __renderAppPageErrorBoundary({
-    buildFontLinkHeader: __buildAppPageFontLinkHeader,
-    clearRequestContext() {
-      __clearRequestContext();
-    },
-    createRscOnErrorHandler(pathname, routePath) {
-      return createRscOnErrorHandler(request, pathname, routePath);
-    },
-    error,
-    getFontLinks: _getSSRFontLinks,
-    getFontPreloads: _getSSRFontPreloads,
-    getFontStyles: _getSSRFontStyles,
-    getNavigationContext: _getNavigationContext,
-    globalErrorModule: null,
-    isRscRequest,
-    loadSsrHandler() {
-      return import.meta.viteRsc.loadModule("ssr", "index");
-    },
-    makeThenableParams,
-    matchedParams: matchedParams ?? route?.params ?? {},
-    middlewareContext: middlewareContext ?? __APP_PAGE_EMPTY_MW_CTX,
-    metadataRoutes,
-    requestUrl: request.url,
-    resolveChildSegments: __resolveAppPageChildSegments,
-    rootLayouts: rootLayouts,
-    route,
-    renderToReadableStream,
-    sanitizeErrorForClient: __sanitizeErrorForClient,
-    scriptNonce,
-  });
-}
+  },
+  makeThenableParams,
+  sanitizer: __sanitizeErrorForClient,
+  rscRenderer: renderToReadableStream,
+  getNavigationContext: _getNavigationContext,
+  resolveChildSegments: __resolveAppPageChildSegments,
+  clearRequestContext() {
+    __clearRequestContext();
+  },
+  createRscOnErrorHandler,
+});
 
 function matchRoute(url) {
   return __routeMatcher.matchRoute(url);
@@ -5698,7 +5388,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   if (!match) {
     
     // Render custom not-found page if available, otherwise plain 404
-    const notFoundResponse = await renderNotFoundPage(null, isRscRequest, request, undefined, _scriptNonce, _mwCtx);
+    const notFoundResponse = await __fallbackRenderer.renderNotFound(null, isRscRequest, request, undefined, _scriptNonce, _mwCtx);
     if (notFoundResponse) return notFoundResponse;
     __clearRequestContext();
     const notFoundHeaders = new Headers();
@@ -5817,10 +5507,10 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       return PageComponent({ params: _asyncRouteParams, searchParams: _asyncSearchParams });
     },
     renderErrorBoundaryPage(renderErr) {
-      return renderErrorBoundaryPage(route, renderErr, isRscRequest, request, params, _scriptNonce, _mwCtx);
+      return __fallbackRenderer.renderErrorBoundary(route, renderErr, isRscRequest, request, params, _scriptNonce, _mwCtx);
     },
     renderHttpAccessFallbackPage(statusCode, opts, middlewareContext) {
-      return renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, opts, _scriptNonce, middlewareContext);
+      return __fallbackRenderer.renderHttpAccessFallback(route, statusCode, isRscRequest, request, opts, _scriptNonce, middlewareContext);
     },
     renderToReadableStream,
     request,
@@ -5896,9 +5586,8 @@ import {
   resolveAppPageSpecialError as __resolveAppPageSpecialError,
 } from "<ROOT>/packages/vinext/src/server/app-page-execution.js";
 import {
-  renderAppPageErrorBoundary as __renderAppPageErrorBoundary,
-  renderAppPageHttpAccessFallback as __renderAppPageHttpAccessFallback,
-} from "<ROOT>/packages/vinext/src/server/app-page-boundary-render.js";
+  createAppFallbackRenderer as __createAppFallbackRenderer,
+} from "<ROOT>/packages/vinext/src/server/app-fallback-renderer.js";
 import {
   APP_INTERCEPTION_CONTEXT_KEY as __APP_INTERCEPTION_CONTEXT_KEY,
   createAppPayloadRouteId as __createAppPayloadRouteId,
@@ -6188,96 +5877,35 @@ const rootNotFoundModule = null;
 const rootForbiddenModule = null;
 const rootUnauthorizedModule = null;
 const rootLayouts = [mod_1];
-const __APP_PAGE_EMPTY_MW_CTX = { headers: null, status: null };
 
-/**
- * Render an HTTP access fallback page (not-found/forbidden/unauthorized) with layouts and noindex meta.
- * Returns null if no matching component is available.
- *
- * @param opts.boundaryComponent - Override the boundary component (for layout-level notFound)
- * @param opts.layouts - Override the layouts to wrap with (for layout-level notFound, excludes the throwing layout)
- */
-async function renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, opts, scriptNonce, middlewareContext) {
-  return __renderAppPageHttpAccessFallback({
-    boundaryComponent: opts?.boundaryComponent ?? null,
+const __fallbackRenderer = __createAppFallbackRenderer({
+  rootBoundaries: {
+    rootForbiddenModule,
+    rootLayouts,
+    rootNotFoundModule,
+    rootUnauthorizedModule,
+  },
+  globalErrorModule: null,
+  metadataRoutes,
+  ssrLoader() {
+    return import.meta.viteRsc.loadModule("ssr", "index");
+  },
+  fontProviders: {
     buildFontLinkHeader: __buildAppPageFontLinkHeader,
-    clearRequestContext() {
-      __clearRequestContext();
-    },
-    createRscOnErrorHandler(pathname, routePath) {
-      return createRscOnErrorHandler(request, pathname, routePath);
-    },
     getFontLinks: _getSSRFontLinks,
     getFontPreloads: _getSSRFontPreloads,
     getFontStyles: _getSSRFontStyles,
-    getNavigationContext: _getNavigationContext,
-    globalErrorModule: null,
-    isRscRequest,
-    layoutModules: opts?.layouts ?? null,
-    loadSsrHandler() {
-      return import.meta.viteRsc.loadModule("ssr", "index");
-    },
-    makeThenableParams,
-    matchedParams: opts?.matchedParams ?? route?.params ?? {},
-    middlewareContext: middlewareContext ?? __APP_PAGE_EMPTY_MW_CTX,
-    metadataRoutes,
-    requestUrl: request.url,
-    resolveChildSegments: __resolveAppPageChildSegments,
-    rootForbiddenModule: rootForbiddenModule,
-    rootLayouts: rootLayouts,
-    rootNotFoundModule: rootNotFoundModule,
-    rootUnauthorizedModule: rootUnauthorizedModule,
-    route,
-    renderToReadableStream,
-    scriptNonce,
-    statusCode,
-  });
-}
-
-/** Convenience: render a not-found page (404) */
-async function renderNotFoundPage(route, isRscRequest, request, matchedParams, scriptNonce, middlewareContext) {
-  return renderHTTPAccessFallbackPage(route, 404, isRscRequest, request, { matchedParams }, scriptNonce, middlewareContext);
-}
-
-/**
- * Render an error.tsx boundary page when a server component or generateMetadata() throws.
- * Returns null if no error boundary component is available for this route.
- *
- * Next.js returns HTTP 200 when error.tsx catches an error (the error is "handled"
- * by the boundary). This matches that behavior intentionally.
- */
-async function renderErrorBoundaryPage(route, error, isRscRequest, request, matchedParams, scriptNonce, middlewareContext) {
-  return __renderAppPageErrorBoundary({
-    buildFontLinkHeader: __buildAppPageFontLinkHeader,
-    clearRequestContext() {
-      __clearRequestContext();
-    },
-    createRscOnErrorHandler(pathname, routePath) {
-      return createRscOnErrorHandler(request, pathname, routePath);
-    },
-    error,
-    getFontLinks: _getSSRFontLinks,
-    getFontPreloads: _getSSRFontPreloads,
-    getFontStyles: _getSSRFontStyles,
-    getNavigationContext: _getNavigationContext,
-    globalErrorModule: null,
-    isRscRequest,
-    loadSsrHandler() {
-      return import.meta.viteRsc.loadModule("ssr", "index");
-    },
-    makeThenableParams,
-    matchedParams: matchedParams ?? route?.params ?? {},
-    middlewareContext: middlewareContext ?? __APP_PAGE_EMPTY_MW_CTX,
-    metadataRoutes,
-    requestUrl: request.url,
-    resolveChildSegments: __resolveAppPageChildSegments,
-    rootLayouts: rootLayouts,
-    route,
-    renderToReadableStream,
-    sanitizeErrorForClient: __sanitizeErrorForClient,
-    scriptNonce,
-  });
-}
+  },
+  makeThenableParams,
+  sanitizer: __sanitizeErrorForClient,
+  rscRenderer: renderToReadableStream,
+  getNavigationContext: _getNavigationContext,
+  resolveChildSegments: __resolveAppPageChildSegments,
+  clearRequestContext() {
+    __clearRequestContext();
+  },
+  createRscOnErrorHandler,
+});
 
 function matchRoute(url) {
   return __routeMatcher.matchRoute(url);
@@ -6872,7 +6500,7 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   if (!match) {
     
     // Render custom not-found page if available, otherwise plain 404
-    const notFoundResponse = await renderNotFoundPage(null, isRscRequest, request, undefined, _scriptNonce, _mwCtx);
+    const notFoundResponse = await __fallbackRenderer.renderNotFound(null, isRscRequest, request, undefined, _scriptNonce, _mwCtx);
     if (notFoundResponse) return notFoundResponse;
     __clearRequestContext();
     const notFoundHeaders = new Headers();
@@ -6991,10 +6619,10 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
       return PageComponent({ params: _asyncRouteParams, searchParams: _asyncSearchParams });
     },
     renderErrorBoundaryPage(renderErr) {
-      return renderErrorBoundaryPage(route, renderErr, isRscRequest, request, params, _scriptNonce, _mwCtx);
+      return __fallbackRenderer.renderErrorBoundary(route, renderErr, isRscRequest, request, params, _scriptNonce, _mwCtx);
     },
     renderHttpAccessFallbackPage(statusCode, opts, middlewareContext) {
-      return renderHTTPAccessFallbackPage(route, statusCode, isRscRequest, request, opts, _scriptNonce, middlewareContext);
+      return __fallbackRenderer.renderHttpAccessFallback(route, statusCode, isRscRequest, request, opts, _scriptNonce, middlewareContext);
     },
     renderToReadableStream,
     request,

--- a/tests/app-fallback-renderer.test.ts
+++ b/tests/app-fallback-renderer.test.ts
@@ -1,0 +1,321 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+import React from "react";
+import ReactDOMServer from "react-dom/server";
+import { createAppFallbackRenderer } from "../packages/vinext/src/server/app-fallback-renderer.js";
+import type { AppElements } from "../packages/vinext/src/server/app-elements.js";
+
+function createStreamFromMarkup(markup: string): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(markup));
+      controller.close();
+    },
+  });
+}
+
+function renderElementToStream(element: React.ReactNode | AppElements): ReadableStream<Uint8Array> {
+  if (element !== null && typeof element === "object" && !React.isValidElement(element)) {
+    const record = element as Record<string, unknown>;
+    const routeId = record.__route;
+    if (typeof routeId === "string" && React.isValidElement(record[routeId])) {
+      return createStreamFromMarkup(
+        ReactDOMServer.renderToStaticMarkup(record[routeId] as React.ReactNode),
+      );
+    }
+    return createStreamFromMarkup(JSON.stringify(element));
+  }
+  return createStreamFromMarkup(ReactDOMServer.renderToStaticMarkup(element));
+}
+
+function createRenderer(overrides?: {
+  createRscOnErrorHandler?: (
+    request: Request,
+    pathname: string,
+    routePath: string,
+  ) => (error: unknown, requestInfo: unknown, errorContext: unknown) => unknown;
+  sanitizeErrorForClient?: (error: Error) => Error;
+}) {
+  const clearRequestContext = vi.fn();
+  const ssrLoader = vi.fn(async () => ({
+    async handleSsr(rscStream: ReadableStream<Uint8Array>) {
+      return rscStream;
+    },
+  }));
+
+  return {
+    clearRequestContext,
+    renderer: createAppFallbackRenderer({
+      clearRequestContext,
+      createRscOnErrorHandler: overrides?.createRscOnErrorHandler ?? (() => () => null),
+      fontProviders: {
+        buildFontLinkHeader(
+          preloads: readonly { href: string; type: string }[] | null | undefined,
+        ) {
+          if (!preloads || preloads.length === 0) return "";
+          return preloads.map((p) => `<${p.href}>; rel=preload`).join(", ");
+        },
+        getFontLinks() {
+          return ["/styles.css"];
+        },
+        getFontPreloads() {
+          return [{ href: "/font.woff2", type: "font/woff2" }];
+        },
+        getFontStyles() {
+          return [".font { font-family: Test; }"];
+        },
+      },
+      getNavigationContext() {
+        return { pathname: "/posts/missing" };
+      },
+      globalErrorModule: null,
+      makeThenableParams<T>(params: T) {
+        return params;
+      },
+      metadataRoutes: [],
+      resolveChildSegments() {
+        return [];
+      },
+      rootBoundaries: {
+        rootForbiddenModule: null,
+        rootLayouts: [],
+        rootNotFoundModule: null,
+        rootUnauthorizedModule: null,
+      },
+      rscRenderer: renderElementToStream,
+      sanitizer: overrides?.sanitizeErrorForClient ?? ((error: Error) => error),
+      ssrLoader,
+    }),
+    ssrLoader,
+  };
+}
+
+function NotFoundBoundary() {
+  return React.createElement("p", { "data-boundary": "not-found" }, "Missing page");
+}
+
+function RouteErrorBoundary({ error }: { error: Error }) {
+  return React.createElement("p", { "data-boundary": "route-error" }, `route:${error.message}`);
+}
+
+function ParamsLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: { slug?: string };
+}) {
+  return React.createElement("div", { "data-params-slug": params.slug ?? "none" }, children);
+}
+
+function OverrideLayout({ children }: { children: React.ReactNode }) {
+  return React.createElement("div", { "data-layout": "override" }, children);
+}
+
+type TestModule = {
+  default: React.ComponentType<any>;
+};
+
+const notFoundModule = { default: NotFoundBoundary } satisfies TestModule;
+const routeErrorModule = { default: RouteErrorBoundary } satisfies TestModule;
+const paramsLayoutModule = { default: ParamsLayout } satisfies TestModule;
+const overrideLayoutModule = { default: OverrideLayout } satisfies TestModule;
+
+describe("app fallback renderer factory", () => {
+  it("constructs once and passes request at call site", async () => {
+    const { renderer } = createRenderer();
+    const requestA = new Request("https://example.com/a");
+    const requestB = new Request("https://example.com/b");
+
+    // Both calls succeed with different requests — proves request is not
+    // captured in the factory closure but passed per-call.
+    const responseA = await renderer.renderNotFound(
+      {
+        notFound: notFoundModule,
+        params: {},
+        pattern: "/a",
+      },
+      false,
+      requestA,
+      undefined,
+      undefined,
+      { headers: null, status: null },
+    );
+    const responseB = await renderer.renderNotFound(
+      {
+        notFound: notFoundModule,
+        params: {},
+        pattern: "/b",
+      },
+      false,
+      requestB,
+      undefined,
+      undefined,
+      { headers: null, status: null },
+    );
+
+    expect(responseA?.status).toBe(404);
+    expect(responseB?.status).toBe(404);
+  });
+
+  it("delegates renderNotFound to renderHttpAccessFallback with status 404", async () => {
+    const { renderer, ssrLoader } = createRenderer();
+    const request = new Request("https://example.com/posts/missing");
+
+    const response = await renderer.renderNotFound(
+      {
+        notFound: notFoundModule,
+        params: { slug: "missing" },
+        pattern: "/posts/[slug]",
+      },
+      false,
+      request,
+      { slug: "missing" },
+      undefined,
+      { headers: null, status: null },
+    );
+
+    expect(response?.status).toBe(404);
+    expect(ssrLoader).toHaveBeenCalledTimes(1);
+
+    const html = await response?.text();
+    expect(html).toContain('data-boundary="not-found"');
+  });
+
+  it("renders error boundaries with sanitized errors", async () => {
+    const sanitizer = vi.fn((error: Error) => new Error(`safe:${error.message}`));
+    const { renderer, ssrLoader, clearRequestContext } = createRenderer({
+      sanitizeErrorForClient: sanitizer,
+    });
+    const request = new Request("https://example.com/posts/boom");
+
+    const response = await renderer.renderErrorBoundary(
+      {
+        error: routeErrorModule,
+        layouts: [],
+        params: { slug: "boom" },
+        pattern: "/posts/[slug]",
+      },
+      new Error("secret"),
+      false,
+      request,
+      { slug: "boom" },
+      undefined,
+      { headers: null, status: null },
+    );
+
+    expect(response?.status).toBe(200);
+    expect(sanitizer).toHaveBeenCalledTimes(1);
+    expect(ssrLoader).toHaveBeenCalledTimes(1);
+
+    const html = await response?.text();
+    // clearRequestContext is deferred until the stream is consumed.
+    expect(clearRequestContext).toHaveBeenCalledTimes(1);
+    expect(html).toContain('data-boundary="route-error"');
+    expect(html).toContain("route:safe:secret");
+  });
+
+  it("passes request to createRscOnErrorHandler at call time", async () => {
+    const createRscOnErrorHandler = vi.fn(
+      (_request: Request, _pathname: string, _routePath: string) => () => null,
+    );
+    const { renderer } = createRenderer({ createRscOnErrorHandler });
+    const request = new Request("https://example.com/posts/boom");
+
+    await renderer.renderErrorBoundary(
+      {
+        error: routeErrorModule,
+        layouts: [],
+        params: { slug: "boom" },
+        pattern: "/posts/[slug]",
+      },
+      new Error("boom"),
+      false,
+      request,
+      { slug: "boom" },
+      undefined,
+      { headers: null, status: null },
+    );
+
+    expect(createRscOnErrorHandler).toHaveBeenCalledTimes(1);
+    expect(createRscOnErrorHandler).toHaveBeenCalledWith(request, "/posts/boom", "/posts/[slug]");
+  });
+
+  it("uses empty middleware context when none is provided", async () => {
+    const { renderer } = createRenderer();
+    const request = new Request("https://example.com/posts/missing");
+
+    // Pass undefined middlewareContext — factory should fall back to empty.
+    const response = await renderer.renderNotFound(
+      {
+        notFound: notFoundModule,
+        params: { slug: "missing" },
+        pattern: "/posts/[slug]",
+      },
+      false,
+      request,
+      { slug: "missing" },
+      undefined,
+      undefined as unknown as { headers: null; status: null },
+    );
+
+    expect(response?.status).toBe(404);
+  });
+
+  it("falls back matchedParams to route.params when not provided", async () => {
+    const { renderer } = createRenderer();
+    const request = new Request("https://example.com/posts/missing");
+
+    // Call without matchedParams in opts — factory should fall back to route.params.
+    // Provide routeSegments + layoutTreePositions so the layout receives the slug param.
+    const response = await renderer.renderHttpAccessFallback(
+      {
+        layouts: [paramsLayoutModule],
+        layoutTreePositions: [1],
+        notFound: notFoundModule,
+        params: { slug: "from-route" },
+        pattern: "/[slug]",
+        routeSegments: ["[slug]"],
+      },
+      404,
+      false,
+      request,
+      {}, // no matchedParams, no boundaryComponent override
+      undefined,
+      { headers: null, status: null },
+    );
+
+    const html = await response?.text();
+    expect(html).toContain('data-params-slug="from-route"');
+    expect(html).toContain('data-boundary="not-found"');
+  });
+
+  it("uses opts.layouts override instead of route.layouts", async () => {
+    const { renderer } = createRenderer();
+    const request = new Request("https://example.com/posts/missing");
+
+    const response = await renderer.renderHttpAccessFallback(
+      {
+        layouts: [paramsLayoutModule], // route layout — should NOT appear
+        layoutTreePositions: [1],
+        notFound: notFoundModule,
+        params: { slug: "missing" },
+        pattern: "/[slug]",
+        routeSegments: ["[slug]"],
+      },
+      404,
+      false,
+      request,
+      {
+        layouts: [overrideLayoutModule], // override — SHOULD appear
+        matchedParams: { slug: "missing" },
+      },
+      undefined,
+      { headers: null, status: null },
+    );
+
+    const html = await response?.text();
+    expect(html).toContain('data-layout="override"');
+    expect(html).not.toContain("data-params-slug");
+    expect(html).toContain('data-boundary="not-found"');
+  });
+});

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -4669,7 +4669,9 @@ describe("generateRscEntry ISR code generation", () => {
       "buildPageElement(targetRoute, targetParams, targetOpts, targetSearchParams)",
     );
     expect(code).toContain("renderErrorBoundaryPage(renderErr) {");
+    expect(code).toContain("__fallbackRenderer.renderErrorBoundary(route, renderErr");
     expect(code).toContain("renderHttpAccessFallbackPage(statusCode, opts, middlewareContext) {");
+    expect(code).toContain("__fallbackRenderer.renderHttpAccessFallback(route, statusCode");
     expect(code).toContain("getFontLinks: _getSSRFontLinks");
     expect(code).toContain("getFontPreloads: _getSSRFontPreloads");
     expect(code).toContain("getFontStyles: _getSSRFontStyles");
@@ -4776,26 +4778,36 @@ describe("generateRscEntry ISR code generation", () => {
     expect(code).toContain("handleAppPrerenderEndpoint as __handleAppPrerenderEndpoint");
   });
 
-  it("generated code delegates page boundary rendering to typed helpers", () => {
+  it("generated code constructs a single fallback renderer factory", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes);
-    expect(code).toContain("renderAppPageErrorBoundary as __renderAppPageErrorBoundary");
-    expect(code).toContain("renderAppPageHttpAccessFallback as __renderAppPageHttpAccessFallback");
-    expect(code).toContain(
-      "const _scriptNonce = __getScriptNonceFromHeaderSources(request.headers, _mwCtx.headers);",
-    );
-    expect(code).toContain("return __renderAppPageHttpAccessFallback({");
-    expect(code).toContain("return __renderAppPageErrorBoundary({");
+    expect(code).toContain("createAppFallbackRenderer as __createAppFallbackRenderer");
+    expect(code).toContain("const __fallbackRenderer = __createAppFallbackRenderer({");
+    expect(code).toContain("rootBoundaries: {");
+    expect(code).toContain("rootForbiddenModule,");
+    expect(code).toContain("rootLayouts,");
+    expect(code).toContain("rootNotFoundModule,");
+    expect(code).toContain("rootUnauthorizedModule,");
+    expect(code).toContain("fontProviders: {");
+    expect(code).toContain("buildFontLinkHeader: __buildAppPageFontLinkHeader");
+    expect(code).toContain("getFontLinks: _getSSRFontLinks");
+    expect(code).toContain("getFontPreloads: _getSSRFontPreloads");
+    expect(code).toContain("getFontStyles: _getSSRFontStyles");
+    expect(code).toContain("sanitizer: __sanitizeErrorForClient");
+    expect(code).toContain("rscRenderer: renderToReadableStream");
+    expect(code).not.toContain("return __renderAppPageHttpAccessFallback({");
+    expect(code).not.toContain("return __renderAppPageErrorBoundary({");
   });
 
   it("generated code threads middleware context into page dispatch and boundary rendering", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes);
 
-    expect(code).toContain("const __APP_PAGE_EMPTY_MW_CTX = { headers: null, status: null };");
-    expect(code).toContain("middlewareContext: middlewareContext ?? __APP_PAGE_EMPTY_MW_CTX");
+    // Empty-middleware fallback is now internal to the factory module.
+    expect(code).not.toContain("const __APP_PAGE_EMPTY_MW_CTX = { headers: null, status: null };");
+    expect(code).not.toContain("middlewareContext: middlewareContext ?? __APP_PAGE_EMPTY_MW_CTX");
     expect(code).toContain("middlewareContext: _mwCtx");
     expect(code).toContain("__mergeMiddlewareResponseHeaders(notFoundHeaders, _mwCtx.headers)");
-    expect(code).toContain("renderHTTPAccessFallbackPage(route, statusCode");
-    expect(code).toContain("return renderErrorBoundaryPage(route, renderErr");
+    expect(code).toContain("__fallbackRenderer.renderHttpAccessFallback(route, statusCode");
+    expect(code).toContain("__fallbackRenderer.renderErrorBoundary(route, renderErr");
     expect(code).not.toContain("renderSpecialError(__buildSpecialError)");
   });
 


### PR DESCRIPTION
[Kimi 2.6]

## What this changes

Replaces three generated wrapper functions (`renderHTTPAccessFallbackPage`, `renderNotFoundPage`, `renderErrorBoundaryPage`) in the App Router RSC entry with a single factory `createAppFallbackRenderer()` that returns `{ renderHttpAccessFallback, renderNotFound, renderErrorBoundary }`.

The generated entry constructs the factory **once** at module level and calls the returned methods many times. App-level dependencies (root boundaries, font providers, metadata routes, SSR loader, thenable-params helper, sanitizer, RSC renderer) are pre-bound at construction time. The per-request `Request` object is passed at the call site and is no longer captured in any factory closure.

## Why

Previously each of the three wrappers reconstructed a large options object on every invocation, passing the same app-level constants over and over. The `request` parameter was also captured in each wrapper's closure, which inflated the dependency surface and made it hard to distinguish per-app from per-request state at a glance.

This follows the codebase principle: **codegen should describe the app shape; normal modules should implement behavior.**

## Approach

- New typed module: `packages/vinext/src/server/app-fallback-renderer.ts`
  - Exports `createAppFallbackRenderer(options)` with a strongly-typed options bag
  - Returns three render methods that delegate to the existing `renderAppPageHttpAccessFallback` and `renderAppPageErrorBoundary` helpers in `app-page-boundary-render.ts`
  - The empty-middleware fallback (`{ headers: null, status: null }`) moves into the factory module so generated code no longer needs to define it
- `packages/vinext/src/entries/app-rsc-entry.ts`
  - Removes ~90 lines of generated wrapper code
  - Adds a single `const __fallbackRenderer = __createAppFallbackRenderer({...})` construction
  - Call sites in `__dispatchAppPage` and the not-found fallback path now call `__fallbackRenderer.renderErrorBoundary(...)`, `__fallbackRenderer.renderHttpAccessFallback(...)`, and `__fallbackRenderer.renderNotFound(...)`
- `packages/vinext/src/server/app-page-boundary-render.ts`
  - Exports `AppPageBoundaryRoute` type so the factory can reference it without redeclaring

## Validation

- Added `tests/app-fallback-renderer.test.ts` with focused unit tests for:
  - Factory returns the three expected methods
  - `renderNotFound` delegates to `renderHttpAccessFallback` with status 404
  - Request is passed at call site (verified by calling with two different requests)
  - `createRscOnErrorHandler` receives the request at call time
  - Empty middleware context fallback works when none is provided
- Updated `tests/app-router.test.ts` generated-code assertions to verify:
  - `createAppFallbackRenderer as __createAppFallbackRenderer` is imported
  - `const __fallbackRenderer = __createAppFallbackRenderer({...})` appears in generated code
  - The old inline `return __renderAppPageHttpAccessFallback({...})` and `return __renderAppPageErrorBoundary({...})` are gone
  - Delegation closures inside `__dispatchAppPage` call `__fallbackRenderer.renderErrorBoundary` and `__fallbackRenderer.renderHttpAccessFallback`
- All existing tests pass:
  - `tests/app-router.test.ts` (316 tests)
  - `tests/app-page-boundary-render.test.ts` (12 tests)
  - `tests/app-page-dispatch.test.ts` (4 tests)
  - `tests/app-fallback-renderer.test.ts` (6 tests)

## Relevant Next.js source

This refactoring aligns vinext's App Router fallback/error-boundary rendering with the same architectural separation Next.js uses between its app-render pipeline and the underlying boundary components:

- Next.js app-render error/HTTP-fallback rendering logic: [`packages/next/src/server/app-render/app-render.tsx`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/app-render.tsx) (see `findPrerenderHTTPErrorBoundaryTree`, `getErrorRSCPayload`, and the `errorRSCPayload` / `errorServerStream` paths around L8400-L8480)
- Next.js HTTP access fallback boundary component: [`packages/next/src/client/components/http-access-fallback/error-boundary.tsx`](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/http-access-fallback/error-boundary.tsx)
- Next.js metadata boundary handling for not-found: [`packages/next/src/server/app-render/app-render.tsx`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/app-render.tsx) (see `createMetadataComponents` with `errorType: 'not-found'` around L2110-L2125)

## Risks / follow-ups

- None. This is a pure refactor: no public API changes, no behavioral changes. The factory delegates to the exact same `renderAppPageHttpAccessFallback` and `renderAppPageErrorBoundary` helpers that were already in use.