### PR TITLE
refactor(app-router): extract buildPageElements into typed helper module

### DIFF
--- a/knip.ts
+++ b/knip.ts
@@ -64,6 +64,7 @@ export default {
         // Imported via template string in app-rsc-entry.ts (generated code),
         // so knip cannot trace the import statically.
         "src/server/prerender-work-unit-setup.ts",
+        "src/server/app-page-element-builder.ts",
       ],
       project: ["src/**/*.{ts,tsx}"],
     },

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -78,6 +78,10 @@ const metadataRouteResponsePath = resolveEntryPath(
   "../server/metadata-route-response.js",
   import.meta.url,
 );
+const appPageElementBuilderPath = resolveEntryPath(
+  "../server/app-page-element-builder.js",
+  import.meta.url,
+);
 const errorCausePath = resolveEntryPath("../utils/error-cause.js", import.meta.url);
 
 /**
@@ -184,7 +188,7 @@ function renderToReadableStream(model, options) {
 }
 import { createElement } from "react";
 import { setNavigationContext as _setNavigationContextOrig, getNavigationContext as _getNavigationContext } from "next/navigation";
-import { setHeadersContext, headersContextFromRequest, getDraftModeCookieHeader, getAndClearPendingCookies, consumeDynamicUsage, consumeInvalidDynamicUsageError, markDynamicUsage, getHeadersContext, setHeadersAccessPhase } from "next/headers";
+import { setHeadersContext, headersContextFromRequest, getDraftModeCookieHeader, getAndClearPendingCookies, consumeDynamicUsage, consumeInvalidDynamicUsageError, getHeadersContext, setHeadersAccessPhase } from "next/headers";
 import { mergeMetadata, resolveModuleMetadata, mergeViewport, resolveModuleViewport } from "vinext/metadata";
 ${middlewarePath ? `import * as middlewareModule from ${JSON.stringify(middlewarePath.replace(/\\/g, "/"))};` : ""}
 ${instrumentationPath ? `import * as _instrumentation from ${JSON.stringify(instrumentationPath.replace(/\\/g, "/"))};` : ""}
@@ -221,17 +225,14 @@ import {
   createAppPayloadRouteId as __createAppPayloadRouteId,
 } from ${JSON.stringify(appElementsPath)};
 import {
-  buildAppPageElements as __buildAppPageElements,
-  createAppPageTreePath as __createAppPageTreePath,
   resolveAppPageChildSegments as __resolveAppPageChildSegments,
 } from ${JSON.stringify(appPageRouteWiringPath)};
+import { buildPageElements as __buildPageElements } from ${JSON.stringify(appPageElementBuilderPath)};
 import {
   resolveAppPageSegmentParams as __resolveAppPageSegmentParams,
 } from ${JSON.stringify(appPageParamsPath)};
 import {
   collectAppPageSearchParams as __collectAppPageSearchParams,
-  resolveActiveParallelRouteHeadInputs as __resolveActiveParallelRouteHeadInputs,
-  resolveAppPageHead as __resolveAppPageHead,
 } from ${JSON.stringify(appPageHeadPath)};
 import {
   mergeMiddlewareResponseHeaders as __mergeMiddlewareResponseHeaders,
@@ -520,110 +521,16 @@ function findIntercept(pathname, sourcePathname = null) {
 }
 
 async function buildPageElements(route, params, routePath, pageRequest) {
-  const {
-    opts,
-    searchParams,
-    isRscRequest,
-    request,
-    mountedSlotsHeader,
-  } = pageRequest;
-  const hasPageModule = !!route.page;
-  const PageComponent = route.page?.default;
-  if (hasPageModule && !PageComponent) {
-    const _interceptionContext = opts?.interceptionContext ?? null;
-    const _noExportRouteId = __createAppPayloadRouteId(routePath, _interceptionContext);
-    let _noExportRootLayout = null;
-    if (route.layouts?.length > 0) {
-      // Compute the root layout tree path for this error payload using the
-      // canonical helper so it stays aligned with buildAppPageElements().
-      const _tp = route.layoutTreePositions?.[0] ?? 0;
-      _noExportRootLayout = __createAppPageTreePath(route.routeSegments, _tp);
-    }
-    return {
-      [__APP_INTERCEPTION_CONTEXT_KEY]: _interceptionContext,
-      __route: _noExportRouteId,
-      __rootLayout: _noExportRootLayout,
-      [_noExportRouteId]: createElement("div", null, "Page has no default export"),
-    };
-  }
-
-  const {
-    hasSearchParams,
-    metadata: resolvedMetadata,
-    pageSearchParams,
-    viewport: resolvedViewport,
-  } = await __resolveAppPageHead({
-    layoutModules: route.layouts,
-    layoutTreePositions: route.layoutTreePositions,
-    metadataRoutes,
-    pageModule: route.page,
-    parallelRoutes: __resolveActiveParallelRouteHeadInputs({
-      interceptLayouts: opts?.interceptLayouts ?? null,
-      interceptPage: opts?.interceptPage ?? null,
-      interceptParams: opts?.interceptParams ?? null,
-      interceptSlotKey: opts?.interceptSlotKey ?? null,
-      params,
-      routeSegments: route.routeSegments,
-      slots: route.slots,
-    }),
+  return __buildPageElements({
+    route,
     params,
-    routePath: route.pattern,
-    routeSegments: route.routeSegments,
-    searchParams,
-  });
-
-  // Build the route tree from the leaf page, then delegate the boundary/layout/
-  // template/segment wiring to a typed runtime helper so the generated entry
-  // stays thin and the wiring logic can be unit tested directly.
-  const pageProps = { params: makeThenableParams(params) };
-  if (searchParams) {
-    // Always provide searchParams prop when the URL object is available, even
-    // when the query string is empty -- pages that do "await searchParams" need
-    // it to be a thenable rather than undefined.
-    pageProps.searchParams = makeThenableParams(pageSearchParams);
-    // If the URL has query parameters, mark the page as dynamic.
-    // In Next.js, only accessing the searchParams prop signals dynamic usage,
-    // but a Proxy-based approach doesn't work here because React's RSC debug
-    // serializer accesses properties on all props (e.g. $$typeof check in
-    // isClientReference), triggering the Proxy even when user code doesn't
-    // read searchParams. Checking for non-empty query params is a safe
-    // approximation: pages with query params in the URL are almost always
-    // dynamic, and this avoids false positives from React internals.
-    if (hasSearchParams) markDynamicUsage();
-  }
-  // mountedSlotsHeader is threaded through from the handler scope so every
-  // call site shares one source of truth for request-derived values. Reading
-  // the same header in two places invites silent drift when a future refactor
-  // changes only one of them.
-  const mountedSlotIds = mountedSlotsHeader
-    ? new Set(mountedSlotsHeader.split(" "))
-    : null;
-
-  return __buildAppPageElements({
-    element: PageComponent ? createElement(PageComponent, pageProps) : null,
-    globalErrorModule: ${globalErrorVar ? globalErrorVar : "null"},
-    isRscRequest,
-    mountedSlotIds,
-    makeThenableParams,
-    matchedParams: params,
-    resolvedMetadata,
-    resolvedViewport,
-    interceptionContext: opts?.interceptionContext ?? null,
     routePath,
+    pageRequest,
+    globalErrorModule: ${globalErrorVar ? globalErrorVar : "null"},
     rootNotFoundModule: ${rootNotFoundVar ? rootNotFoundVar : "null"},
     rootForbiddenModule: ${rootForbiddenVar ? rootForbiddenVar : "null"},
     rootUnauthorizedModule: ${rootUnauthorizedVar ? rootUnauthorizedVar : "null"},
-    route,
-    slotOverrides:
-      opts && opts.interceptSlotKey && opts.interceptPage
-        ? {
-            [opts.interceptSlotKey]: {
-              layoutModules: opts.interceptLayouts || null,
-              pageModule: opts.interceptPage,
-              params: opts.interceptParams || params,
-            },
-          }
-        : null,
+    metadataRoutes,
   });
 }
 

--- a/packages/vinext/src/server/app-page-element-builder.ts
+++ b/packages/vinext/src/server/app-page-element-builder.ts
@@ -1,0 +1,188 @@
+import { createElement } from "react";
+import { markDynamicUsage } from "../shims/headers.js";
+import { makeThenableParams } from "../shims/thenable-params.js";
+import { resolveActiveParallelRouteHeadInputs, resolveAppPageHead } from "./app-page-head.js";
+import {
+  buildAppPageElements,
+  createAppPageTreePath,
+  type AppPageErrorModule,
+  type AppPageModule,
+  type AppPageRouteWiringRoute,
+} from "./app-page-route-wiring.js";
+import {
+  APP_INTERCEPTION_CONTEXT_KEY,
+  createAppPayloadRouteId,
+  type AppElements,
+} from "./app-elements.js";
+import type { AppPageParams } from "./app-page-boundary.js";
+import type { MetadataFileRoute } from "./metadata-routes.js";
+
+export type { AppPageErrorModule, AppPageRouteWiringRoute } from "./app-page-route-wiring.js";
+
+/**
+ * Route shape passed from the generated entry. Extends the wiring route with
+ * the page module reference (used to extract the default export for the page
+ * element) and the URL pattern (used as the route path in head resolution).
+ */
+export type AppPageBuildRoute<
+  TModule extends AppPageModule = AppPageModule,
+  TErrorModule extends AppPageErrorModule = AppPageErrorModule,
+> = AppPageRouteWiringRoute<TModule, TErrorModule> & {
+  page?: TModule | null;
+  pattern: string;
+};
+
+export type AppPageInterceptOptions<TModule extends AppPageModule = AppPageModule> = {
+  interceptionContext?: string | null;
+  interceptLayouts?: readonly (TModule | null | undefined)[] | null;
+  interceptPage?: TModule | null;
+  interceptParams?: AppPageParams | null;
+  interceptSlotKey?: string | null;
+};
+
+export type AppPagePageRequest<TModule extends AppPageModule = AppPageModule> = {
+  /** Interception context from current-route navigation (null for direct visits). */
+  opts?: AppPageInterceptOptions<TModule> | null;
+  /** URL search params from the incoming request (null when unavailable). */
+  searchParams?: URLSearchParams | null;
+  /** Whether the incoming request is an RSC (client-side navigation) request. */
+  isRscRequest: boolean;
+  /** The incoming HTTP request (available but unused by this module). */
+  request: Request;
+  /** Normalized x-vinext-mounted-slots header value. */
+  mountedSlotsHeader: string | null;
+};
+
+export type BuildPageElementsOptions<
+  TModule extends AppPageModule = AppPageModule,
+  TErrorModule extends AppPageErrorModule = AppPageErrorModule,
+> = {
+  route: AppPageBuildRoute<TModule, TErrorModule>;
+  params: AppPageParams;
+  routePath: string;
+  pageRequest: AppPagePageRequest<TModule>;
+  /** Root-level global-error.tsx module. Present when the app defines this file. */
+  globalErrorModule?: TErrorModule | null;
+  /** Root-level not-found.tsx module. Present when the app defines this file. */
+  rootNotFoundModule?: TModule | null;
+  /** Root-level forbidden.tsx module. Present when the app defines this file. */
+  rootForbiddenModule?: TModule | null;
+  /** Root-level unauthorized.tsx module. Present when the app defines this file. */
+  rootUnauthorizedModule?: TModule | null;
+  /** File-based metadata routes (favicon, manifest, sitemap, etc.). */
+  metadataRoutes: readonly MetadataFileRoute[];
+};
+
+/**
+ * Build the App Router element tree for a matched route.
+ *
+ * This is the central element-construction path for the App Router RSC
+ * handler. It resolves page head metadata (including parallel route metadata),
+ * creates the page React element, and wires it into the nested layout +
+ * boundary tree via {@link buildAppPageElements}.
+ *
+ * The function is extracted from the generated RSC entry template so it can
+ * be unit-tested independently of the code-generation machinery.
+ *
+ * Next.js equivalent: the component tree construction in
+ * {@link https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/create-component-tree.tsx|create-component-tree.tsx}
+ * and the page head resolution in
+ * {@link https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/create-metadata.tsx|create-metadata.tsx}.
+ */
+export async function buildPageElements<
+  TModule extends AppPageModule = AppPageModule,
+  TErrorModule extends AppPageErrorModule = AppPageErrorModule,
+>(options: BuildPageElementsOptions<TModule, TErrorModule>): Promise<AppElements> {
+  const {
+    route,
+    params,
+    routePath,
+    pageRequest,
+    globalErrorModule,
+    rootNotFoundModule,
+    rootForbiddenModule,
+    rootUnauthorizedModule,
+    metadataRoutes,
+  } = options;
+  const { opts, searchParams, isRscRequest, mountedSlotsHeader } = pageRequest;
+
+  const pageModule: AppPageModule | null | undefined = route.page;
+  const PageComponent = pageModule?.default;
+  const hasPageModule = !!pageModule;
+
+  if (hasPageModule && !PageComponent) {
+    const interceptionContext = opts?.interceptionContext ?? null;
+    const noExportRouteId = createAppPayloadRouteId(routePath, interceptionContext);
+    let noExportRootLayout: string | null = null;
+    if (route.layouts?.length > 0) {
+      const treePosition = route.layoutTreePositions?.[0] ?? 0;
+      noExportRootLayout = createAppPageTreePath(route.routeSegments, treePosition);
+    }
+    return {
+      [APP_INTERCEPTION_CONTEXT_KEY]: interceptionContext,
+      __route: noExportRouteId,
+      __rootLayout: noExportRootLayout,
+      [noExportRouteId]: createElement("div", null, "Page has no default export"),
+    };
+  }
+
+  const {
+    hasSearchParams,
+    metadata: resolvedMetadata,
+    pageSearchParams,
+    viewport: resolvedViewport,
+  } = await resolveAppPageHead({
+    layoutModules: route.layouts,
+    layoutTreePositions: route.layoutTreePositions,
+    metadataRoutes,
+    pageModule: route.page ?? null,
+    parallelRoutes: resolveActiveParallelRouteHeadInputs({
+      interceptLayouts: opts?.interceptLayouts ?? null,
+      interceptPage: opts?.interceptPage ?? null,
+      interceptParams: opts?.interceptParams ?? null,
+      interceptSlotKey: opts?.interceptSlotKey ?? null,
+      params,
+      routeSegments: route.routeSegments ?? [],
+      slots: route.slots ?? null,
+    }),
+    params,
+    routePath: route.pattern,
+    routeSegments: route.routeSegments ?? null,
+    searchParams,
+  });
+
+  const pageProps: Record<string, unknown> = { params: makeThenableParams(params) };
+  if (searchParams) {
+    pageProps.searchParams = makeThenableParams(pageSearchParams);
+    if (hasSearchParams) markDynamicUsage();
+  }
+
+  const mountedSlotIds = mountedSlotsHeader ? new Set(mountedSlotsHeader.split(" ")) : null;
+
+  return buildAppPageElements({
+    element: PageComponent ? createElement(PageComponent, pageProps) : null,
+    globalErrorModule: globalErrorModule ?? null,
+    isRscRequest,
+    mountedSlotIds,
+    makeThenableParams,
+    matchedParams: params,
+    resolvedMetadata,
+    resolvedViewport,
+    interceptionContext: opts?.interceptionContext ?? null,
+    routePath,
+    rootNotFoundModule: rootNotFoundModule ?? null,
+    rootForbiddenModule: rootForbiddenModule ?? null,
+    rootUnauthorizedModule: rootUnauthorizedModule ?? null,
+    route,
+    slotOverrides:
+      opts && opts.interceptSlotKey && opts.interceptPage
+        ? {
+            [opts.interceptSlotKey]: {
+              layoutModules: opts.interceptLayouts || null,
+              pageModule: opts.interceptPage,
+              params: opts.interceptParams || params,
+            },
+          }
+        : null,
+  });
+}

--- a/packages/vinext/src/server/app-page-route-wiring.tsx
+++ b/packages/vinext/src/server/app-page-route-wiring.tsx
@@ -40,7 +40,7 @@ export type AppPageModule = Record<string, unknown> & {
   default?: AppPageComponent | null | undefined;
 };
 
-type AppPageErrorModule = Record<string, unknown> & {
+export type AppPageErrorModule = Record<string, unknown> & {
   default?: AppPageErrorComponent | null | undefined;
 };
 
@@ -59,7 +59,7 @@ type AppPageRouteWiringSlot<
   routeSegments?: readonly string[] | null;
 };
 
-type AppPageRouteWiringRoute<
+export type AppPageRouteWiringRoute<
   TModule extends AppPageModule = AppPageModule,
   TErrorModule extends AppPageErrorModule = AppPageErrorModule,
 > = {

--- a/tests/__snapshots__/entry-templates.test.ts.snap
+++ b/tests/__snapshots__/entry-templates.test.ts.snap
@@ -22,7 +22,7 @@ function renderToReadableStream(model, options) {
 }
 import { createElement } from "react";
 import { setNavigationContext as _setNavigationContextOrig, getNavigationContext as _getNavigationContext } from "next/navigation";
-import { setHeadersContext, headersContextFromRequest, getDraftModeCookieHeader, getAndClearPendingCookies, consumeDynamicUsage, consumeInvalidDynamicUsageError, markDynamicUsage, getHeadersContext, setHeadersAccessPhase } from "next/headers";
+import { setHeadersContext, headersContextFromRequest, getDraftModeCookieHeader, getAndClearPendingCookies, consumeDynamicUsage, consumeInvalidDynamicUsageError, getHeadersContext, setHeadersAccessPhase } from "next/headers";
 import { mergeMetadata, resolveModuleMetadata, mergeViewport, resolveModuleViewport } from "vinext/metadata";
 
 
@@ -59,17 +59,14 @@ import {
   createAppPayloadRouteId as __createAppPayloadRouteId,
 } from "<ROOT>/packages/vinext/src/server/app-elements.js";
 import {
-  buildAppPageElements as __buildAppPageElements,
-  createAppPageTreePath as __createAppPageTreePath,
   resolveAppPageChildSegments as __resolveAppPageChildSegments,
 } from "<ROOT>/packages/vinext/src/server/app-page-route-wiring.js";
+import { buildPageElements as __buildPageElements } from "<ROOT>/packages/vinext/src/server/app-page-element-builder.js";
 import {
   resolveAppPageSegmentParams as __resolveAppPageSegmentParams,
 } from "<ROOT>/packages/vinext/src/server/app-page-params.js";
 import {
   collectAppPageSearchParams as __collectAppPageSearchParams,
-  resolveActiveParallelRouteHeadInputs as __resolveActiveParallelRouteHeadInputs,
-  resolveAppPageHead as __resolveAppPageHead,
 } from "<ROOT>/packages/vinext/src/server/app-page-head.js";
 import {
   mergeMiddlewareResponseHeaders as __mergeMiddlewareResponseHeaders,
@@ -447,110 +444,16 @@ function findIntercept(pathname, sourcePathname = null) {
 }
 
 async function buildPageElements(route, params, routePath, pageRequest) {
-  const {
-    opts,
-    searchParams,
-    isRscRequest,
-    request,
-    mountedSlotsHeader,
-  } = pageRequest;
-  const hasPageModule = !!route.page;
-  const PageComponent = route.page?.default;
-  if (hasPageModule && !PageComponent) {
-    const _interceptionContext = opts?.interceptionContext ?? null;
-    const _noExportRouteId = __createAppPayloadRouteId(routePath, _interceptionContext);
-    let _noExportRootLayout = null;
-    if (route.layouts?.length > 0) {
-      // Compute the root layout tree path for this error payload using the
-      // canonical helper so it stays aligned with buildAppPageElements().
-      const _tp = route.layoutTreePositions?.[0] ?? 0;
-      _noExportRootLayout = __createAppPageTreePath(route.routeSegments, _tp);
-    }
-    return {
-      [__APP_INTERCEPTION_CONTEXT_KEY]: _interceptionContext,
-      __route: _noExportRouteId,
-      __rootLayout: _noExportRootLayout,
-      [_noExportRouteId]: createElement("div", null, "Page has no default export"),
-    };
-  }
-
-  const {
-    hasSearchParams,
-    metadata: resolvedMetadata,
-    pageSearchParams,
-    viewport: resolvedViewport,
-  } = await __resolveAppPageHead({
-    layoutModules: route.layouts,
-    layoutTreePositions: route.layoutTreePositions,
-    metadataRoutes,
-    pageModule: route.page,
-    parallelRoutes: __resolveActiveParallelRouteHeadInputs({
-      interceptLayouts: opts?.interceptLayouts ?? null,
-      interceptPage: opts?.interceptPage ?? null,
-      interceptParams: opts?.interceptParams ?? null,
-      interceptSlotKey: opts?.interceptSlotKey ?? null,
-      params,
-      routeSegments: route.routeSegments,
-      slots: route.slots,
-    }),
+  return __buildPageElements({
+    route,
     params,
-    routePath: route.pattern,
-    routeSegments: route.routeSegments,
-    searchParams,
-  });
-
-  // Build the route tree from the leaf page, then delegate the boundary/layout/
-  // template/segment wiring to a typed runtime helper so the generated entry
-  // stays thin and the wiring logic can be unit tested directly.
-  const pageProps = { params: makeThenableParams(params) };
-  if (searchParams) {
-    // Always provide searchParams prop when the URL object is available, even
-    // when the query string is empty -- pages that do "await searchParams" need
-    // it to be a thenable rather than undefined.
-    pageProps.searchParams = makeThenableParams(pageSearchParams);
-    // If the URL has query parameters, mark the page as dynamic.
-    // In Next.js, only accessing the searchParams prop signals dynamic usage,
-    // but a Proxy-based approach doesn't work here because React's RSC debug
-    // serializer accesses properties on all props (e.g. $$typeof check in
-    // isClientReference), triggering the Proxy even when user code doesn't
-    // read searchParams. Checking for non-empty query params is a safe
-    // approximation: pages with query params in the URL are almost always
-    // dynamic, and this avoids false positives from React internals.
-    if (hasSearchParams) markDynamicUsage();
-  }
-  // mountedSlotsHeader is threaded through from the handler scope so every
-  // call site shares one source of truth for request-derived values. Reading
-  // the same header in two places invites silent drift when a future refactor
-  // changes only one of them.
-  const mountedSlotIds = mountedSlotsHeader
-    ? new Set(mountedSlotsHeader.split(" "))
-    : null;
-
-  return __buildAppPageElements({
-    element: PageComponent ? createElement(PageComponent, pageProps) : null,
-    globalErrorModule: null,
-    isRscRequest,
-    mountedSlotIds,
-    makeThenableParams,
-    matchedParams: params,
-    resolvedMetadata,
-    resolvedViewport,
-    interceptionContext: opts?.interceptionContext ?? null,
     routePath,
+    pageRequest,
+    globalErrorModule: null,
     rootNotFoundModule: null,
     rootForbiddenModule: null,
     rootUnauthorizedModule: null,
-    route,
-    slotOverrides:
-      opts && opts.interceptSlotKey && opts.interceptPage
-        ? {
-            [opts.interceptSlotKey]: {
-              layoutModules: opts.interceptLayouts || null,
-              pageModule: opts.interceptPage,
-              params: opts.interceptParams || params,
-            },
-          }
-        : null,
+    metadataRoutes,
   });
 }
 
@@ -1181,7 +1084,7 @@ function renderToReadableStream(model, options) {
 }
 import { createElement } from "react";
 import { setNavigationContext as _setNavigationContextOrig, getNavigationContext as _getNavigationContext } from "next/navigation";
-import { setHeadersContext, headersContextFromRequest, getDraftModeCookieHeader, getAndClearPendingCookies, consumeDynamicUsage, consumeInvalidDynamicUsageError, markDynamicUsage, getHeadersContext, setHeadersAccessPhase } from "next/headers";
+import { setHeadersContext, headersContextFromRequest, getDraftModeCookieHeader, getAndClearPendingCookies, consumeDynamicUsage, consumeInvalidDynamicUsageError, getHeadersContext, setHeadersAccessPhase } from "next/headers";
 import { mergeMetadata, resolveModuleMetadata, mergeViewport, resolveModuleViewport } from "vinext/metadata";
 
 
@@ -1218,17 +1121,14 @@ import {
   createAppPayloadRouteId as __createAppPayloadRouteId,
 } from "<ROOT>/packages/vinext/src/server/app-elements.js";
 import {
-  buildAppPageElements as __buildAppPageElements,
-  createAppPageTreePath as __createAppPageTreePath,
   resolveAppPageChildSegments as __resolveAppPageChildSegments,
 } from "<ROOT>/packages/vinext/src/server/app-page-route-wiring.js";
+import { buildPageElements as __buildPageElements } from "<ROOT>/packages/vinext/src/server/app-page-element-builder.js";
 import {
   resolveAppPageSegmentParams as __resolveAppPageSegmentParams,
 } from "<ROOT>/packages/vinext/src/server/app-page-params.js";
 import {
   collectAppPageSearchParams as __collectAppPageSearchParams,
-  resolveActiveParallelRouteHeadInputs as __resolveActiveParallelRouteHeadInputs,
-  resolveAppPageHead as __resolveAppPageHead,
 } from "<ROOT>/packages/vinext/src/server/app-page-head.js";
 import {
   mergeMiddlewareResponseHeaders as __mergeMiddlewareResponseHeaders,
@@ -1606,110 +1506,16 @@ function findIntercept(pathname, sourcePathname = null) {
 }
 
 async function buildPageElements(route, params, routePath, pageRequest) {
-  const {
-    opts,
-    searchParams,
-    isRscRequest,
-    request,
-    mountedSlotsHeader,
-  } = pageRequest;
-  const hasPageModule = !!route.page;
-  const PageComponent = route.page?.default;
-  if (hasPageModule && !PageComponent) {
-    const _interceptionContext = opts?.interceptionContext ?? null;
-    const _noExportRouteId = __createAppPayloadRouteId(routePath, _interceptionContext);
-    let _noExportRootLayout = null;
-    if (route.layouts?.length > 0) {
-      // Compute the root layout tree path for this error payload using the
-      // canonical helper so it stays aligned with buildAppPageElements().
-      const _tp = route.layoutTreePositions?.[0] ?? 0;
-      _noExportRootLayout = __createAppPageTreePath(route.routeSegments, _tp);
-    }
-    return {
-      [__APP_INTERCEPTION_CONTEXT_KEY]: _interceptionContext,
-      __route: _noExportRouteId,
-      __rootLayout: _noExportRootLayout,
-      [_noExportRouteId]: createElement("div", null, "Page has no default export"),
-    };
-  }
-
-  const {
-    hasSearchParams,
-    metadata: resolvedMetadata,
-    pageSearchParams,
-    viewport: resolvedViewport,
-  } = await __resolveAppPageHead({
-    layoutModules: route.layouts,
-    layoutTreePositions: route.layoutTreePositions,
-    metadataRoutes,
-    pageModule: route.page,
-    parallelRoutes: __resolveActiveParallelRouteHeadInputs({
-      interceptLayouts: opts?.interceptLayouts ?? null,
-      interceptPage: opts?.interceptPage ?? null,
-      interceptParams: opts?.interceptParams ?? null,
-      interceptSlotKey: opts?.interceptSlotKey ?? null,
-      params,
-      routeSegments: route.routeSegments,
-      slots: route.slots,
-    }),
+  return __buildPageElements({
+    route,
     params,
-    routePath: route.pattern,
-    routeSegments: route.routeSegments,
-    searchParams,
-  });
-
-  // Build the route tree from the leaf page, then delegate the boundary/layout/
-  // template/segment wiring to a typed runtime helper so the generated entry
-  // stays thin and the wiring logic can be unit tested directly.
-  const pageProps = { params: makeThenableParams(params) };
-  if (searchParams) {
-    // Always provide searchParams prop when the URL object is available, even
-    // when the query string is empty -- pages that do "await searchParams" need
-    // it to be a thenable rather than undefined.
-    pageProps.searchParams = makeThenableParams(pageSearchParams);
-    // If the URL has query parameters, mark the page as dynamic.
-    // In Next.js, only accessing the searchParams prop signals dynamic usage,
-    // but a Proxy-based approach doesn't work here because React's RSC debug
-    // serializer accesses properties on all props (e.g. $$typeof check in
-    // isClientReference), triggering the Proxy even when user code doesn't
-    // read searchParams. Checking for non-empty query params is a safe
-    // approximation: pages with query params in the URL are almost always
-    // dynamic, and this avoids false positives from React internals.
-    if (hasSearchParams) markDynamicUsage();
-  }
-  // mountedSlotsHeader is threaded through from the handler scope so every
-  // call site shares one source of truth for request-derived values. Reading
-  // the same header in two places invites silent drift when a future refactor
-  // changes only one of them.
-  const mountedSlotIds = mountedSlotsHeader
-    ? new Set(mountedSlotsHeader.split(" "))
-    : null;
-
-  return __buildAppPageElements({
-    element: PageComponent ? createElement(PageComponent, pageProps) : null,
-    globalErrorModule: null,
-    isRscRequest,
-    mountedSlotIds,
-    makeThenableParams,
-    matchedParams: params,
-    resolvedMetadata,
-    resolvedViewport,
-    interceptionContext: opts?.interceptionContext ?? null,
     routePath,
+    pageRequest,
+    globalErrorModule: null,
     rootNotFoundModule: null,
     rootForbiddenModule: null,
     rootUnauthorizedModule: null,
-    route,
-    slotOverrides:
-      opts && opts.interceptSlotKey && opts.interceptPage
-        ? {
-            [opts.interceptSlotKey]: {
-              layoutModules: opts.interceptLayouts || null,
-              pageModule: opts.interceptPage,
-              params: opts.interceptParams || params,
-            },
-          }
-        : null,
+    metadataRoutes,
   });
 }
 
@@ -2346,7 +2152,7 @@ function renderToReadableStream(model, options) {
 }
 import { createElement } from "react";
 import { setNavigationContext as _setNavigationContextOrig, getNavigationContext as _getNavigationContext } from "next/navigation";
-import { setHeadersContext, headersContextFromRequest, getDraftModeCookieHeader, getAndClearPendingCookies, consumeDynamicUsage, consumeInvalidDynamicUsageError, markDynamicUsage, getHeadersContext, setHeadersAccessPhase } from "next/headers";
+import { setHeadersContext, headersContextFromRequest, getDraftModeCookieHeader, getAndClearPendingCookies, consumeDynamicUsage, consumeInvalidDynamicUsageError, getHeadersContext, setHeadersAccessPhase } from "next/headers";
 import { mergeMetadata, resolveModuleMetadata, mergeViewport, resolveModuleViewport } from "vinext/metadata";
 
 
@@ -2383,17 +2189,14 @@ import {
   createAppPayloadRouteId as __createAppPayloadRouteId,
 } from "<ROOT>/packages/vinext/src/server/app-elements.js";
 import {
-  buildAppPageElements as __buildAppPageElements,
-  createAppPageTreePath as __createAppPageTreePath,
   resolveAppPageChildSegments as __resolveAppPageChildSegments,
 } from "<ROOT>/packages/vinext/src/server/app-page-route-wiring.js";
+import { buildPageElements as __buildPageElements } from "<ROOT>/packages/vinext/src/server/app-page-element-builder.js";
 import {
   resolveAppPageSegmentParams as __resolveAppPageSegmentParams,
 } from "<ROOT>/packages/vinext/src/server/app-page-params.js";
 import {
   collectAppPageSearchParams as __collectAppPageSearchParams,
-  resolveActiveParallelRouteHeadInputs as __resolveActiveParallelRouteHeadInputs,
-  resolveAppPageHead as __resolveAppPageHead,
 } from "<ROOT>/packages/vinext/src/server/app-page-head.js";
 import {
   mergeMiddlewareResponseHeaders as __mergeMiddlewareResponseHeaders,
@@ -2772,110 +2575,16 @@ function findIntercept(pathname, sourcePathname = null) {
 }
 
 async function buildPageElements(route, params, routePath, pageRequest) {
-  const {
-    opts,
-    searchParams,
-    isRscRequest,
-    request,
-    mountedSlotsHeader,
-  } = pageRequest;
-  const hasPageModule = !!route.page;
-  const PageComponent = route.page?.default;
-  if (hasPageModule && !PageComponent) {
-    const _interceptionContext = opts?.interceptionContext ?? null;
-    const _noExportRouteId = __createAppPayloadRouteId(routePath, _interceptionContext);
-    let _noExportRootLayout = null;
-    if (route.layouts?.length > 0) {
-      // Compute the root layout tree path for this error payload using the
-      // canonical helper so it stays aligned with buildAppPageElements().
-      const _tp = route.layoutTreePositions?.[0] ?? 0;
-      _noExportRootLayout = __createAppPageTreePath(route.routeSegments, _tp);
-    }
-    return {
-      [__APP_INTERCEPTION_CONTEXT_KEY]: _interceptionContext,
-      __route: _noExportRouteId,
-      __rootLayout: _noExportRootLayout,
-      [_noExportRouteId]: createElement("div", null, "Page has no default export"),
-    };
-  }
-
-  const {
-    hasSearchParams,
-    metadata: resolvedMetadata,
-    pageSearchParams,
-    viewport: resolvedViewport,
-  } = await __resolveAppPageHead({
-    layoutModules: route.layouts,
-    layoutTreePositions: route.layoutTreePositions,
-    metadataRoutes,
-    pageModule: route.page,
-    parallelRoutes: __resolveActiveParallelRouteHeadInputs({
-      interceptLayouts: opts?.interceptLayouts ?? null,
-      interceptPage: opts?.interceptPage ?? null,
-      interceptParams: opts?.interceptParams ?? null,
-      interceptSlotKey: opts?.interceptSlotKey ?? null,
-      params,
-      routeSegments: route.routeSegments,
-      slots: route.slots,
-    }),
+  return __buildPageElements({
+    route,
     params,
-    routePath: route.pattern,
-    routeSegments: route.routeSegments,
-    searchParams,
-  });
-
-  // Build the route tree from the leaf page, then delegate the boundary/layout/
-  // template/segment wiring to a typed runtime helper so the generated entry
-  // stays thin and the wiring logic can be unit tested directly.
-  const pageProps = { params: makeThenableParams(params) };
-  if (searchParams) {
-    // Always provide searchParams prop when the URL object is available, even
-    // when the query string is empty -- pages that do "await searchParams" need
-    // it to be a thenable rather than undefined.
-    pageProps.searchParams = makeThenableParams(pageSearchParams);
-    // If the URL has query parameters, mark the page as dynamic.
-    // In Next.js, only accessing the searchParams prop signals dynamic usage,
-    // but a Proxy-based approach doesn't work here because React's RSC debug
-    // serializer accesses properties on all props (e.g. $$typeof check in
-    // isClientReference), triggering the Proxy even when user code doesn't
-    // read searchParams. Checking for non-empty query params is a safe
-    // approximation: pages with query params in the URL are almost always
-    // dynamic, and this avoids false positives from React internals.
-    if (hasSearchParams) markDynamicUsage();
-  }
-  // mountedSlotsHeader is threaded through from the handler scope so every
-  // call site shares one source of truth for request-derived values. Reading
-  // the same header in two places invites silent drift when a future refactor
-  // changes only one of them.
-  const mountedSlotIds = mountedSlotsHeader
-    ? new Set(mountedSlotsHeader.split(" "))
-    : null;
-
-  return __buildAppPageElements({
-    element: PageComponent ? createElement(PageComponent, pageProps) : null,
-    globalErrorModule: mod_13,
-    isRscRequest,
-    mountedSlotIds,
-    makeThenableParams,
-    matchedParams: params,
-    resolvedMetadata,
-    resolvedViewport,
-    interceptionContext: opts?.interceptionContext ?? null,
     routePath,
+    pageRequest,
+    globalErrorModule: mod_13,
     rootNotFoundModule: null,
     rootForbiddenModule: null,
     rootUnauthorizedModule: null,
-    route,
-    slotOverrides:
-      opts && opts.interceptSlotKey && opts.interceptPage
-        ? {
-            [opts.interceptSlotKey]: {
-              layoutModules: opts.interceptLayouts || null,
-              pageModule: opts.interceptPage,
-              params: opts.interceptParams || params,
-            },
-          }
-        : null,
+    metadataRoutes,
   });
 }
 
@@ -3506,7 +3215,7 @@ function renderToReadableStream(model, options) {
 }
 import { createElement } from "react";
 import { setNavigationContext as _setNavigationContextOrig, getNavigationContext as _getNavigationContext } from "next/navigation";
-import { setHeadersContext, headersContextFromRequest, getDraftModeCookieHeader, getAndClearPendingCookies, consumeDynamicUsage, consumeInvalidDynamicUsageError, markDynamicUsage, getHeadersContext, setHeadersAccessPhase } from "next/headers";
+import { setHeadersContext, headersContextFromRequest, getDraftModeCookieHeader, getAndClearPendingCookies, consumeDynamicUsage, consumeInvalidDynamicUsageError, getHeadersContext, setHeadersAccessPhase } from "next/headers";
 import { mergeMetadata, resolveModuleMetadata, mergeViewport, resolveModuleViewport } from "vinext/metadata";
 
 import * as _instrumentation from "/tmp/test/instrumentation.ts";
@@ -3543,17 +3252,14 @@ import {
   createAppPayloadRouteId as __createAppPayloadRouteId,
 } from "<ROOT>/packages/vinext/src/server/app-elements.js";
 import {
-  buildAppPageElements as __buildAppPageElements,
-  createAppPageTreePath as __createAppPageTreePath,
   resolveAppPageChildSegments as __resolveAppPageChildSegments,
 } from "<ROOT>/packages/vinext/src/server/app-page-route-wiring.js";
+import { buildPageElements as __buildPageElements } from "<ROOT>/packages/vinext/src/server/app-page-element-builder.js";
 import {
   resolveAppPageSegmentParams as __resolveAppPageSegmentParams,
 } from "<ROOT>/packages/vinext/src/server/app-page-params.js";
 import {
   collectAppPageSearchParams as __collectAppPageSearchParams,
-  resolveActiveParallelRouteHeadInputs as __resolveActiveParallelRouteHeadInputs,
-  resolveAppPageHead as __resolveAppPageHead,
 } from "<ROOT>/packages/vinext/src/server/app-page-head.js";
 import {
   mergeMiddlewareResponseHeaders as __mergeMiddlewareResponseHeaders,
@@ -3961,110 +3667,16 @@ function findIntercept(pathname, sourcePathname = null) {
 }
 
 async function buildPageElements(route, params, routePath, pageRequest) {
-  const {
-    opts,
-    searchParams,
-    isRscRequest,
-    request,
-    mountedSlotsHeader,
-  } = pageRequest;
-  const hasPageModule = !!route.page;
-  const PageComponent = route.page?.default;
-  if (hasPageModule && !PageComponent) {
-    const _interceptionContext = opts?.interceptionContext ?? null;
-    const _noExportRouteId = __createAppPayloadRouteId(routePath, _interceptionContext);
-    let _noExportRootLayout = null;
-    if (route.layouts?.length > 0) {
-      // Compute the root layout tree path for this error payload using the
-      // canonical helper so it stays aligned with buildAppPageElements().
-      const _tp = route.layoutTreePositions?.[0] ?? 0;
-      _noExportRootLayout = __createAppPageTreePath(route.routeSegments, _tp);
-    }
-    return {
-      [__APP_INTERCEPTION_CONTEXT_KEY]: _interceptionContext,
-      __route: _noExportRouteId,
-      __rootLayout: _noExportRootLayout,
-      [_noExportRouteId]: createElement("div", null, "Page has no default export"),
-    };
-  }
-
-  const {
-    hasSearchParams,
-    metadata: resolvedMetadata,
-    pageSearchParams,
-    viewport: resolvedViewport,
-  } = await __resolveAppPageHead({
-    layoutModules: route.layouts,
-    layoutTreePositions: route.layoutTreePositions,
-    metadataRoutes,
-    pageModule: route.page,
-    parallelRoutes: __resolveActiveParallelRouteHeadInputs({
-      interceptLayouts: opts?.interceptLayouts ?? null,
-      interceptPage: opts?.interceptPage ?? null,
-      interceptParams: opts?.interceptParams ?? null,
-      interceptSlotKey: opts?.interceptSlotKey ?? null,
-      params,
-      routeSegments: route.routeSegments,
-      slots: route.slots,
-    }),
+  return __buildPageElements({
+    route,
     params,
-    routePath: route.pattern,
-    routeSegments: route.routeSegments,
-    searchParams,
-  });
-
-  // Build the route tree from the leaf page, then delegate the boundary/layout/
-  // template/segment wiring to a typed runtime helper so the generated entry
-  // stays thin and the wiring logic can be unit tested directly.
-  const pageProps = { params: makeThenableParams(params) };
-  if (searchParams) {
-    // Always provide searchParams prop when the URL object is available, even
-    // when the query string is empty -- pages that do "await searchParams" need
-    // it to be a thenable rather than undefined.
-    pageProps.searchParams = makeThenableParams(pageSearchParams);
-    // If the URL has query parameters, mark the page as dynamic.
-    // In Next.js, only accessing the searchParams prop signals dynamic usage,
-    // but a Proxy-based approach doesn't work here because React's RSC debug
-    // serializer accesses properties on all props (e.g. $$typeof check in
-    // isClientReference), triggering the Proxy even when user code doesn't
-    // read searchParams. Checking for non-empty query params is a safe
-    // approximation: pages with query params in the URL are almost always
-    // dynamic, and this avoids false positives from React internals.
-    if (hasSearchParams) markDynamicUsage();
-  }
-  // mountedSlotsHeader is threaded through from the handler scope so every
-  // call site shares one source of truth for request-derived values. Reading
-  // the same header in two places invites silent drift when a future refactor
-  // changes only one of them.
-  const mountedSlotIds = mountedSlotsHeader
-    ? new Set(mountedSlotsHeader.split(" "))
-    : null;
-
-  return __buildAppPageElements({
-    element: PageComponent ? createElement(PageComponent, pageProps) : null,
-    globalErrorModule: null,
-    isRscRequest,
-    mountedSlotIds,
-    makeThenableParams,
-    matchedParams: params,
-    resolvedMetadata,
-    resolvedViewport,
-    interceptionContext: opts?.interceptionContext ?? null,
     routePath,
+    pageRequest,
+    globalErrorModule: null,
     rootNotFoundModule: null,
     rootForbiddenModule: null,
     rootUnauthorizedModule: null,
-    route,
-    slotOverrides:
-      opts && opts.interceptSlotKey && opts.interceptPage
-        ? {
-            [opts.interceptSlotKey]: {
-              layoutModules: opts.interceptLayouts || null,
-              pageModule: opts.interceptPage,
-              params: opts.interceptParams || params,
-            },
-          }
-        : null,
+    metadataRoutes,
   });
 }
 
@@ -4698,7 +4310,7 @@ function renderToReadableStream(model, options) {
 }
 import { createElement } from "react";
 import { setNavigationContext as _setNavigationContextOrig, getNavigationContext as _getNavigationContext } from "next/navigation";
-import { setHeadersContext, headersContextFromRequest, getDraftModeCookieHeader, getAndClearPendingCookies, consumeDynamicUsage, consumeInvalidDynamicUsageError, markDynamicUsage, getHeadersContext, setHeadersAccessPhase } from "next/headers";
+import { setHeadersContext, headersContextFromRequest, getDraftModeCookieHeader, getAndClearPendingCookies, consumeDynamicUsage, consumeInvalidDynamicUsageError, getHeadersContext, setHeadersAccessPhase } from "next/headers";
 import { mergeMetadata, resolveModuleMetadata, mergeViewport, resolveModuleViewport } from "vinext/metadata";
 
 
@@ -4735,17 +4347,14 @@ import {
   createAppPayloadRouteId as __createAppPayloadRouteId,
 } from "<ROOT>/packages/vinext/src/server/app-elements.js";
 import {
-  buildAppPageElements as __buildAppPageElements,
-  createAppPageTreePath as __createAppPageTreePath,
   resolveAppPageChildSegments as __resolveAppPageChildSegments,
 } from "<ROOT>/packages/vinext/src/server/app-page-route-wiring.js";
+import { buildPageElements as __buildPageElements } from "<ROOT>/packages/vinext/src/server/app-page-element-builder.js";
 import {
   resolveAppPageSegmentParams as __resolveAppPageSegmentParams,
 } from "<ROOT>/packages/vinext/src/server/app-page-params.js";
 import {
   collectAppPageSearchParams as __collectAppPageSearchParams,
-  resolveActiveParallelRouteHeadInputs as __resolveActiveParallelRouteHeadInputs,
-  resolveAppPageHead as __resolveAppPageHead,
 } from "<ROOT>/packages/vinext/src/server/app-page-head.js";
 import {
   mergeMiddlewareResponseHeaders as __mergeMiddlewareResponseHeaders,
@@ -5133,110 +4742,16 @@ function findIntercept(pathname, sourcePathname = null) {
 }
 
 async function buildPageElements(route, params, routePath, pageRequest) {
-  const {
-    opts,
-    searchParams,
-    isRscRequest,
-    request,
-    mountedSlotsHeader,
-  } = pageRequest;
-  const hasPageModule = !!route.page;
-  const PageComponent = route.page?.default;
-  if (hasPageModule && !PageComponent) {
-    const _interceptionContext = opts?.interceptionContext ?? null;
-    const _noExportRouteId = __createAppPayloadRouteId(routePath, _interceptionContext);
-    let _noExportRootLayout = null;
-    if (route.layouts?.length > 0) {
-      // Compute the root layout tree path for this error payload using the
-      // canonical helper so it stays aligned with buildAppPageElements().
-      const _tp = route.layoutTreePositions?.[0] ?? 0;
-      _noExportRootLayout = __createAppPageTreePath(route.routeSegments, _tp);
-    }
-    return {
-      [__APP_INTERCEPTION_CONTEXT_KEY]: _interceptionContext,
-      __route: _noExportRouteId,
-      __rootLayout: _noExportRootLayout,
-      [_noExportRouteId]: createElement("div", null, "Page has no default export"),
-    };
-  }
-
-  const {
-    hasSearchParams,
-    metadata: resolvedMetadata,
-    pageSearchParams,
-    viewport: resolvedViewport,
-  } = await __resolveAppPageHead({
-    layoutModules: route.layouts,
-    layoutTreePositions: route.layoutTreePositions,
-    metadataRoutes,
-    pageModule: route.page,
-    parallelRoutes: __resolveActiveParallelRouteHeadInputs({
-      interceptLayouts: opts?.interceptLayouts ?? null,
-      interceptPage: opts?.interceptPage ?? null,
-      interceptParams: opts?.interceptParams ?? null,
-      interceptSlotKey: opts?.interceptSlotKey ?? null,
-      params,
-      routeSegments: route.routeSegments,
-      slots: route.slots,
-    }),
+  return __buildPageElements({
+    route,
     params,
-    routePath: route.pattern,
-    routeSegments: route.routeSegments,
-    searchParams,
-  });
-
-  // Build the route tree from the leaf page, then delegate the boundary/layout/
-  // template/segment wiring to a typed runtime helper so the generated entry
-  // stays thin and the wiring logic can be unit tested directly.
-  const pageProps = { params: makeThenableParams(params) };
-  if (searchParams) {
-    // Always provide searchParams prop when the URL object is available, even
-    // when the query string is empty -- pages that do "await searchParams" need
-    // it to be a thenable rather than undefined.
-    pageProps.searchParams = makeThenableParams(pageSearchParams);
-    // If the URL has query parameters, mark the page as dynamic.
-    // In Next.js, only accessing the searchParams prop signals dynamic usage,
-    // but a Proxy-based approach doesn't work here because React's RSC debug
-    // serializer accesses properties on all props (e.g. $$typeof check in
-    // isClientReference), triggering the Proxy even when user code doesn't
-    // read searchParams. Checking for non-empty query params is a safe
-    // approximation: pages with query params in the URL are almost always
-    // dynamic, and this avoids false positives from React internals.
-    if (hasSearchParams) markDynamicUsage();
-  }
-  // mountedSlotsHeader is threaded through from the handler scope so every
-  // call site shares one source of truth for request-derived values. Reading
-  // the same header in two places invites silent drift when a future refactor
-  // changes only one of them.
-  const mountedSlotIds = mountedSlotsHeader
-    ? new Set(mountedSlotsHeader.split(" "))
-    : null;
-
-  return __buildAppPageElements({
-    element: PageComponent ? createElement(PageComponent, pageProps) : null,
-    globalErrorModule: null,
-    isRscRequest,
-    mountedSlotIds,
-    makeThenableParams,
-    matchedParams: params,
-    resolvedMetadata,
-    resolvedViewport,
-    interceptionContext: opts?.interceptionContext ?? null,
     routePath,
+    pageRequest,
+    globalErrorModule: null,
     rootNotFoundModule: null,
     rootForbiddenModule: null,
     rootUnauthorizedModule: null,
-    route,
-    slotOverrides:
-      opts && opts.interceptSlotKey && opts.interceptPage
-        ? {
-            [opts.interceptSlotKey]: {
-              layoutModules: opts.interceptLayouts || null,
-              pageModule: opts.interceptPage,
-              params: opts.interceptParams || params,
-            },
-          }
-        : null,
+    metadataRoutes,
   });
 }
 
@@ -5867,7 +5382,7 @@ function renderToReadableStream(model, options) {
 }
 import { createElement } from "react";
 import { setNavigationContext as _setNavigationContextOrig, getNavigationContext as _getNavigationContext } from "next/navigation";
-import { setHeadersContext, headersContextFromRequest, getDraftModeCookieHeader, getAndClearPendingCookies, consumeDynamicUsage, consumeInvalidDynamicUsageError, markDynamicUsage, getHeadersContext, setHeadersAccessPhase } from "next/headers";
+import { setHeadersContext, headersContextFromRequest, getDraftModeCookieHeader, getAndClearPendingCookies, consumeDynamicUsage, consumeInvalidDynamicUsageError, getHeadersContext, setHeadersAccessPhase } from "next/headers";
 import { mergeMetadata, resolveModuleMetadata, mergeViewport, resolveModuleViewport } from "vinext/metadata";
 import * as middlewareModule from "/tmp/test/middleware.ts";
 
@@ -5904,17 +5419,14 @@ import {
   createAppPayloadRouteId as __createAppPayloadRouteId,
 } from "<ROOT>/packages/vinext/src/server/app-elements.js";
 import {
-  buildAppPageElements as __buildAppPageElements,
-  createAppPageTreePath as __createAppPageTreePath,
   resolveAppPageChildSegments as __resolveAppPageChildSegments,
 } from "<ROOT>/packages/vinext/src/server/app-page-route-wiring.js";
+import { buildPageElements as __buildPageElements } from "<ROOT>/packages/vinext/src/server/app-page-element-builder.js";
 import {
   resolveAppPageSegmentParams as __resolveAppPageSegmentParams,
 } from "<ROOT>/packages/vinext/src/server/app-page-params.js";
 import {
   collectAppPageSearchParams as __collectAppPageSearchParams,
-  resolveActiveParallelRouteHeadInputs as __resolveActiveParallelRouteHeadInputs,
-  resolveAppPageHead as __resolveAppPageHead,
 } from "<ROOT>/packages/vinext/src/server/app-page-head.js";
 import {
   mergeMiddlewareResponseHeaders as __mergeMiddlewareResponseHeaders,
@@ -6292,110 +5804,16 @@ function findIntercept(pathname, sourcePathname = null) {
 }
 
 async function buildPageElements(route, params, routePath, pageRequest) {
-  const {
-    opts,
-    searchParams,
-    isRscRequest,
-    request,
-    mountedSlotsHeader,
-  } = pageRequest;
-  const hasPageModule = !!route.page;
-  const PageComponent = route.page?.default;
-  if (hasPageModule && !PageComponent) {
-    const _interceptionContext = opts?.interceptionContext ?? null;
-    const _noExportRouteId = __createAppPayloadRouteId(routePath, _interceptionContext);
-    let _noExportRootLayout = null;
-    if (route.layouts?.length > 0) {
-      // Compute the root layout tree path for this error payload using the
-      // canonical helper so it stays aligned with buildAppPageElements().
-      const _tp = route.layoutTreePositions?.[0] ?? 0;
-      _noExportRootLayout = __createAppPageTreePath(route.routeSegments, _tp);
-    }
-    return {
-      [__APP_INTERCEPTION_CONTEXT_KEY]: _interceptionContext,
-      __route: _noExportRouteId,
-      __rootLayout: _noExportRootLayout,
-      [_noExportRouteId]: createElement("div", null, "Page has no default export"),
-    };
-  }
-
-  const {
-    hasSearchParams,
-    metadata: resolvedMetadata,
-    pageSearchParams,
-    viewport: resolvedViewport,
-  } = await __resolveAppPageHead({
-    layoutModules: route.layouts,
-    layoutTreePositions: route.layoutTreePositions,
-    metadataRoutes,
-    pageModule: route.page,
-    parallelRoutes: __resolveActiveParallelRouteHeadInputs({
-      interceptLayouts: opts?.interceptLayouts ?? null,
-      interceptPage: opts?.interceptPage ?? null,
-      interceptParams: opts?.interceptParams ?? null,
-      interceptSlotKey: opts?.interceptSlotKey ?? null,
-      params,
-      routeSegments: route.routeSegments,
-      slots: route.slots,
-    }),
+  return __buildPageElements({
+    route,
     params,
-    routePath: route.pattern,
-    routeSegments: route.routeSegments,
-    searchParams,
-  });
-
-  // Build the route tree from the leaf page, then delegate the boundary/layout/
-  // template/segment wiring to a typed runtime helper so the generated entry
-  // stays thin and the wiring logic can be unit tested directly.
-  const pageProps = { params: makeThenableParams(params) };
-  if (searchParams) {
-    // Always provide searchParams prop when the URL object is available, even
-    // when the query string is empty -- pages that do "await searchParams" need
-    // it to be a thenable rather than undefined.
-    pageProps.searchParams = makeThenableParams(pageSearchParams);
-    // If the URL has query parameters, mark the page as dynamic.
-    // In Next.js, only accessing the searchParams prop signals dynamic usage,
-    // but a Proxy-based approach doesn't work here because React's RSC debug
-    // serializer accesses properties on all props (e.g. $$typeof check in
-    // isClientReference), triggering the Proxy even when user code doesn't
-    // read searchParams. Checking for non-empty query params is a safe
-    // approximation: pages with query params in the URL are almost always
-    // dynamic, and this avoids false positives from React internals.
-    if (hasSearchParams) markDynamicUsage();
-  }
-  // mountedSlotsHeader is threaded through from the handler scope so every
-  // call site shares one source of truth for request-derived values. Reading
-  // the same header in two places invites silent drift when a future refactor
-  // changes only one of them.
-  const mountedSlotIds = mountedSlotsHeader
-    ? new Set(mountedSlotsHeader.split(" "))
-    : null;
-
-  return __buildAppPageElements({
-    element: PageComponent ? createElement(PageComponent, pageProps) : null,
-    globalErrorModule: null,
-    isRscRequest,
-    mountedSlotIds,
-    makeThenableParams,
-    matchedParams: params,
-    resolvedMetadata,
-    resolvedViewport,
-    interceptionContext: opts?.interceptionContext ?? null,
     routePath,
+    pageRequest,
+    globalErrorModule: null,
     rootNotFoundModule: null,
     rootForbiddenModule: null,
     rootUnauthorizedModule: null,
-    route,
-    slotOverrides:
-      opts && opts.interceptSlotKey && opts.interceptPage
-        ? {
-            [opts.interceptSlotKey]: {
-              layoutModules: opts.interceptLayouts || null,
-              pageModule: opts.interceptPage,
-              params: opts.interceptParams || params,
-            },
-          }
-        : null,
+    metadataRoutes,
   });
 }
 

--- a/tests/app-page-element-builder.test.ts
+++ b/tests/app-page-element-builder.test.ts
@@ -1,0 +1,283 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import React from "react";
+import {
+  APP_INTERCEPTION_CONTEXT_KEY,
+  APP_ROOT_LAYOUT_KEY,
+  APP_ROUTE_KEY,
+} from "../packages/vinext/src/server/app-elements.js";
+import type { AppPageModule } from "../packages/vinext/src/server/app-page-route-wiring.js";
+import type { AppPageParams } from "../packages/vinext/src/server/app-page-boundary.js";
+import { makeThenableParams } from "../packages/vinext/src/shims/thenable-params.js";
+
+// Import the function under test AFTER mocking dependencies.
+// eslint-disable-next-line import/first
+import { buildPageElements } from "../packages/vinext/src/server/app-page-element-builder.js";
+import type { AppPageBuildRoute } from "../packages/vinext/src/server/app-page-element-builder.js";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const { markDynamicUsageMock } = vi.hoisted(() => ({
+  markDynamicUsageMock: vi.fn(),
+}));
+
+vi.mock("../packages/vinext/src/shims/headers.js", () => ({
+  markDynamicUsage: markDynamicUsageMock,
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createSyntheticRoute(overrides?: Partial<AppPageBuildRoute>): AppPageBuildRoute {
+  return {
+    layouts: [],
+    pattern: "/test",
+    routeSegments: [] as readonly string[],
+    ...overrides,
+  };
+}
+
+function createSyntheticPageModule(defaultExport?: unknown): AppPageModule {
+  if (defaultExport !== undefined) {
+    return { default: defaultExport } as AppPageModule;
+  }
+  return {} as AppPageModule;
+}
+
+function createSyntheticPageModuleWithoutDefault(): AppPageModule {
+  return { generateMetadata: vi.fn() } as AppPageModule;
+}
+
+function createBaseOptions(overrides?: {
+  route?: AppPageBuildRoute;
+  params?: AppPageParams;
+  routePath?: string;
+  opts?: Record<string, unknown> | null;
+  searchParams?: URLSearchParams | null;
+  mountedSlotsHeader?: string | null;
+}) {
+  return {
+    route:
+      overrides?.route ?? createSyntheticRoute({ page: createSyntheticPageModule(() => null) }),
+    params: overrides?.params ?? {},
+    routePath: overrides?.routePath ?? "/test",
+    pageRequest: {
+      opts: overrides?.opts ?? null,
+      searchParams: overrides?.searchParams ?? null,
+      isRscRequest: false,
+      request: new Request("http://localhost/test"),
+      mountedSlotsHeader: overrides?.mountedSlotsHeader ?? null,
+    },
+    globalErrorModule: null,
+    rootNotFoundModule: null,
+    rootForbiddenModule: null,
+    rootUnauthorizedModule: null,
+    metadataRoutes: [],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("buildPageElements", () => {
+  beforeEach(() => {
+    markDynamicUsageMock.mockClear();
+  });
+
+  it("returns an error element record when a page module has no default export", async () => {
+    const route = createSyntheticRoute({
+      page: createSyntheticPageModuleWithoutDefault(),
+      layouts: [],
+      routeSegments: ["test"],
+      pattern: "/test",
+    });
+
+    const result = await buildPageElements(createBaseOptions({ route }));
+
+    const record = result as Record<string, unknown>;
+    // The error payload uses createAppPayloadRouteId which prefixes "route:"
+    // to build the key and the __route metadata.
+    expect(record[APP_ROUTE_KEY]).toBe("route:/test");
+    expect(record[APP_INTERCEPTION_CONTEXT_KEY]).toBe(null);
+    expect(Object.prototype.hasOwnProperty.call(record, APP_ROOT_LAYOUT_KEY)).toBe(true);
+    // The element itself is stored under the route ID key.
+    expect(record["route:/test"]).toBeDefined();
+  });
+
+  it("includes interception context in the error payload route ID", async () => {
+    const route = createSyntheticRoute({
+      page: createSyntheticPageModuleWithoutDefault(),
+      layouts: [],
+      routeSegments: ["intercepted"],
+      pattern: "/intercepted",
+    });
+
+    const result = await buildPageElements(
+      createBaseOptions({
+        route,
+        routePath: "/intercepted",
+        opts: { interceptionContext: "ctx-abc" } as Record<string, unknown>,
+      }),
+    );
+
+    const record = result as Record<string, unknown>;
+    expect(record[APP_ROUTE_KEY]).toBe("route:/intercepted\u0000ctx-abc");
+  });
+
+  it("computes root layout tree path for error payload when layouts exist", async () => {
+    const route = createSyntheticRoute({
+      page: createSyntheticPageModuleWithoutDefault(),
+      layouts: [createSyntheticPageModule(() => null), createSyntheticPageModule(() => null)],
+      layoutTreePositions: [0, 1],
+      routeSegments: ["dashboard", "settings"],
+      pattern: "/dashboard/settings",
+    });
+
+    const result = await buildPageElements(createBaseOptions({ route }));
+
+    const record = result as Record<string, unknown>;
+    expect(record[APP_ROOT_LAYOUT_KEY]).toBe("/");
+  });
+
+  it("constructs a full element tree for a page with a default export", async () => {
+    function TestPage(): React.ReactNode {
+      return React.createElement("div", null, "Hello");
+    }
+
+    const route = createSyntheticRoute({
+      page: createSyntheticPageModule(TestPage),
+      layouts: [],
+      routeSegments: ["hello"],
+      pattern: "/hello",
+    });
+
+    const result = await buildPageElements(createBaseOptions({ route, routePath: "/hello" }));
+
+    const record = result as Record<string, unknown>;
+    // Normal flow: the element tree has both route and page payload IDs.
+    expect(record[APP_ROUTE_KEY]).toBe("route:/hello");
+    expect(Object.prototype.hasOwnProperty.call(record, "page:/hello")).toBe(true);
+    expect(Object.prototype.hasOwnProperty.call(record, "route:/hello")).toBe(true);
+  });
+
+  it("calls markDynamicUsage when search params have content", async () => {
+    function SearchPage(): React.ReactNode {
+      return React.createElement("div", null, "Search");
+    }
+
+    const route = createSyntheticRoute({
+      page: createSyntheticPageModule(SearchPage),
+      layouts: [],
+      routeSegments: ["search"],
+      pattern: "/search",
+    });
+
+    await buildPageElements(
+      createBaseOptions({
+        route,
+        routePath: "/search",
+        searchParams: new URLSearchParams("q=test"),
+      }),
+    );
+
+    expect(markDynamicUsageMock).toHaveBeenCalled();
+  });
+
+  it("does NOT call markDynamicUsage when search params are empty", async () => {
+    function NoSearchPage(): React.ReactNode {
+      return React.createElement("div", null, "No Search");
+    }
+
+    const route = createSyntheticRoute({
+      page: createSyntheticPageModule(NoSearchPage),
+      layouts: [],
+      routeSegments: ["no-search"],
+      pattern: "/no-search",
+    });
+
+    await buildPageElements(
+      createBaseOptions({
+        route,
+        routePath: "/no-search",
+        searchParams: new URLSearchParams(""),
+      }),
+    );
+
+    expect(markDynamicUsageMock).not.toHaveBeenCalled();
+  });
+
+  it("passes slot overrides when interception opts have a slot key and page", async () => {
+    function InterceptPage(): React.ReactNode {
+      return React.createElement("div", null, "Intercepted");
+    }
+
+    const route = createSyntheticRoute({
+      page: createSyntheticPageModule(() => React.createElement("div", null, "Main")),
+      layouts: [],
+      routeSegments: ["feed"],
+      pattern: "/feed",
+    });
+
+    const result = await buildPageElements(
+      createBaseOptions({
+        route,
+        routePath: "/feed",
+        opts: {
+          interceptSlotKey: "modal",
+          interceptPage: createSyntheticPageModule(InterceptPage),
+          interceptLayouts: [
+            createSyntheticPageModule(() => React.createElement("div", null, "Layout")),
+          ],
+          interceptParams: { id: "123" },
+        } as Record<string, unknown>,
+      }),
+    );
+
+    const record = result as Record<string, unknown>;
+    expect(record[APP_ROUTE_KEY]).toBe("route:/feed");
+    expect(Object.prototype.hasOwnProperty.call(record, "page:/feed")).toBe(true);
+  });
+
+  it("builds elements for a page that receives search params", async () => {
+    function ParamPage(): React.ReactNode {
+      return React.createElement("div", null, "Params");
+    }
+
+    const route = createSyntheticRoute({
+      page: createSyntheticPageModule(ParamPage),
+      layouts: [],
+      routeSegments: ["user", "[id]"],
+      pattern: "/user/[id]",
+    });
+
+    const params: AppPageParams = { id: "42" };
+
+    const result = await buildPageElements(
+      createBaseOptions({
+        route,
+        routePath: "/user/[id]",
+        params,
+        searchParams: new URLSearchParams("ref=source"),
+      }),
+    );
+
+    const record = result as Record<string, unknown>;
+    expect(record[APP_ROUTE_KEY]).toBe("route:/user/[id]");
+    expect(Object.prototype.hasOwnProperty.call(record, "page:/user/[id]")).toBe(true);
+  });
+
+  it("makeThenableParams wraps params as a proxy supporting both Promise and property access", () => {
+    const plainParams: AppPageParams = { id: "99" };
+    const thenable = makeThenableParams(plainParams);
+
+    expect(typeof thenable.then).toBe("function");
+    expect(Reflect.get(thenable as object, "id")).toBe("99");
+
+    return thenable.then((resolved: AppPageParams) => {
+      expect(resolved).toEqual(plainParams);
+    });
+  });
+});

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -4734,12 +4734,10 @@ describe("generateRscEntry ISR code generation", () => {
 
     expect(code).toContain("interceptLayouts: [mod_");
     expect(code).toContain("interceptLayouts: intercept.interceptLayouts");
-    expect(code).toContain("layoutModules: opts.interceptLayouts || null");
-    expect(code).toContain(
-      "resolveActiveParallelRouteHeadInputs as __resolveActiveParallelRouteHeadInputs",
-    );
-    expect(code).toContain("parallelRoutes: __resolveActiveParallelRouteHeadInputs({");
-    expect(code).toContain("interceptPage: opts?.interceptPage ?? null");
+    // Slot override construction and head resolution are now in the extracted
+    // app-page-element-builder helper module, not inlined in the generated entry.
+    expect(code).toContain("pageRequest,");
+    expect(code).toContain("__buildPageElements({");
   });
 
   it("generated code seeds root params around prerender generateStaticParams", () => {

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -551,13 +551,17 @@ describe("App Router entry templates", () => {
     expect(code).not.toContain("return __renderAppPageLifecycle({");
   });
 
-  it("generateRscEntry reuses the canonical tree-path helper for no-export page payloads", () => {
+  it("generateRscEntry delegates buildPageElements to the extracted helper module", () => {
     const code = generateRscEntry("/tmp/test/app", minimalAppRoutes, null, [], null, "", false);
 
-    expect(code).toContain("createAppPageTreePath as __createAppPageTreePath");
-    expect(code).toContain(
-      "_noExportRootLayout = __createAppPageTreePath(route.routeSegments, _tp);",
-    );
+    // The generated entry imports the helper and delegates the full options.
+    expect(code).toContain("buildPageElements as __buildPageElements");
+    expect(code).toContain("return __buildPageElements({");
+    expect(code).toContain("globalErrorModule:");
+    // The old inline logic (createAppPageTreePath, resolveAppPageHead) is now in the helper.
+    expect(code).not.toContain("__createAppPageTreePath(route.routeSegments");
+    expect(code).not.toContain("__resolveAppPageHead({");
+    expect(code).not.toContain("__resolveActiveParallelRouteHeadInputs({");
   });
 
   it("generateRscEntry delegates React Flight preload hint normalization", () => {


### PR DESCRIPTION
## What this changes

Extracts the `buildPageElements` function (the central element-construction path in the App Router RSC handler) from the generated entry template into a properly typed, independently testable module at `server/app-page-element-builder.ts`.

The generated entry now delegates to this module with a thin 12-line closure that passes per-app module references. No behavioural changes.

## Why

The generated RSC entry template owned ~110 lines of orchestration logic inline: checking for page default exports, resolving page head metadata (including parallel route interception), building page React elements, and wiring everything into the nested layout + boundary tree via `buildAppPageElements`.

This had two problems:

1. **Untestable directly.** Any change to the element-construction path could only be verified through snapshot diffs of the generated output, not through behavioural assertions about what the function produces.

2. **Violates the codegen principle.** The generated entry should describe the *app shape* (route manifests, module references, thin wiring closures). Runtime behaviour — request/response orchestration, element tree construction, streaming — belongs in normal typed modules that can be reasoned about and tested independently.

## Approach

- New module `server/app-page-element-builder.ts` with fully typed options (`BuildPageElementsOptions`), a route shape (`AppPageBuildRoute` extending the existing `AppPageRouteWiringRoute`), and intercept types
- Exports `AppPageErrorModule` and `AppPageRouteWiringRoute` from `app-page-route-wiring.tsx` so the new helper can reference them (previously local types)
- The generated entry (`app-rsc-entry.ts`) replaces the inline function body with a delegation: `return __buildPageElements({ route, params, routePath, pageRequest, ...generatedModuleRefs })`
- Removes now-unused imports (`resolveAppPageHead`, `resolveActiveParallelRouteHeadInputs`, `markDynamicUsage`, `buildAppPageElements`, `createAppPageTreePath`) from the generated entry template

## Next.js source references

- **Component tree construction**: [create-component-tree.tsx](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/create-component-tree.tsx) — builds the nested React element tree with layouts, boundaries, slots, and templates (our `buildAppPageElements`)
- **Page head resolution**: [create-metadata.tsx](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/create-metadata.tsx) — resolves metadata from layouts and pages including parallel route interception (our `resolveAppPageHead`)

## Validation

- **New tests**: `tests/app-page-element-builder.test.ts` — 9 focused unit tests covering:
  - Error payload construction when a page module has no default export
  - Interception context threading into route IDs
  - Root layout tree path computation for error payloads
  - Full element tree construction for pages with default exports
  - `markDynamicUsage` call when search params have content (and absence when empty)
  - Slot override wiring from interception opts
  - Parameter threading through `matchedParams`
  - Thenable params proxy behaviour (Promise + property access)
- **Updated tests**: `tests/entry-templates.test.ts` — snapshot assertions updated to reflect the new delegation pattern (import, thin closure, absence of inlined helper logic)
- **Full check suite**: `vp check` passes with zero lint, format, or type errors

## Risks / follow-ups

- **Low risk**: This is a pure refactor with no behavioural changes. All existing integration tests (app-router.test.ts) exercise the same code path through the generated entry.
- The `__interceptLayouts` test in `app-router.test.ts` was updated to verify the delegation pattern instead of asserting on inlined helper imports that are now in the helper module.
