### PR TITLE
fix(rsc): exclude client shims from dep optimization

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -77,6 +77,10 @@ import { clientReferenceDedupPlugin } from "./plugins/client-reference-dedup.js"
 import { createInstrumentationClientTransformPlugin } from "./plugins/instrumentation-client.js";
 import { createOptimizeImportsPlugin } from "./plugins/optimize-imports.js";
 import { createOgInlineFetchAssetsPlugin, ogAssetsPlugin } from "./plugins/og-assets.js";
+import {
+  mergeOptimizeDepsExclude,
+  VINEXT_OPTIMIZE_DEPS_EXCLUDE,
+} from "./plugins/rsc-client-shim-excludes.js";
 import { createServerExternalsManifestPlugin } from "./plugins/server-externals-manifest.js";
 import {
   VIRTUAL_GOOGLE_FONTS,
@@ -1269,7 +1273,9 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         };
         viteConfig.optimizeDeps = {
           // @tailwindcss/oxide contains native .node bindings that Rolldown cannot process
-          exclude: [...new Set([...incomingExclude, "vinext", "@vercel/og", "@tailwindcss/oxide"])],
+          exclude: mergeOptimizeDepsExclude(incomingExclude, VINEXT_OPTIMIZE_DEPS_EXCLUDE, [
+            "@tailwindcss/oxide",
+          ]),
           ...(incomingInclude.length > 0 ? { include: incomingInclude } : {}),
           rolldownOptions: { plugins: [depOptimizeAliasPlugin] },
         };
@@ -1326,7 +1332,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                     },
                   }),
               optimizeDeps: {
-                exclude: [...new Set([...incomingExclude, "vinext", "@vercel/og"])],
+                exclude: mergeOptimizeDepsExclude(incomingExclude, VINEXT_OPTIMIZE_DEPS_EXCLUDE),
                 entries: optimizeEntries,
               },
               build: {
@@ -1351,7 +1357,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                     },
                   }),
               optimizeDeps: {
-                exclude: [...new Set([...incomingExclude, "vinext", "@vercel/og"])],
+                exclude: mergeOptimizeDepsExclude(incomingExclude, VINEXT_OPTIMIZE_DEPS_EXCLUDE),
                 entries: optimizeEntries,
               },
               build: {
@@ -1378,9 +1384,11 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                 // `fileTypeFromFile` only from its `node` condition via `index.js`,
                 // but the browser optimizer resolves to `core.js` which lacks it,
                 // causing MISSING_EXPORT build failures).
-                exclude: [
-                  ...new Set([...incomingExclude, "vinext", "@vercel/og", ...nextServerExternal]),
-                ],
+                exclude: mergeOptimizeDepsExclude(
+                  incomingExclude,
+                  VINEXT_OPTIMIZE_DEPS_EXCLUDE,
+                  nextServerExternal,
+                ),
                 // Crawl app/ source files up front so client-only deps imported
                 // by user components are discovered during startup instead of
                 // triggering a late re-optimisation + full page reload.

--- a/packages/vinext/src/plugins/rsc-client-shim-excludes.ts
+++ b/packages/vinext/src/plugins/rsc-client-shim-excludes.ts
@@ -8,6 +8,7 @@ const RSC_CLIENT_SHIM_OPTIMIZE_DEPS_EXCLUDE = Object.freeze([
   "vinext/shims/link",
   "vinext/shims/script",
   "vinext/shims/slot",
+  "vinext/shims/offline",
 ]);
 
 export const VINEXT_OPTIMIZE_DEPS_EXCLUDE = Object.freeze([

--- a/packages/vinext/src/plugins/rsc-client-shim-excludes.ts
+++ b/packages/vinext/src/plugins/rsc-client-shim-excludes.ts
@@ -1,0 +1,34 @@
+const RSC_CLIENT_SHIM_OPTIMIZE_DEPS_EXCLUDE = Object.freeze([
+  // @vitejs/plugin-rsc tracks package client references by the original
+  // bare source. If Vite pre-bundles these known client shims, the generated
+  // client-package proxy can lose the matching export metadata in dev.
+  "vinext/shims/error-boundary",
+  "vinext/shims/form",
+  "vinext/shims/layout-segment-context",
+  "vinext/shims/link",
+  "vinext/shims/script",
+  "vinext/shims/slot",
+]);
+
+export const VINEXT_OPTIMIZE_DEPS_EXCLUDE = Object.freeze([
+  "vinext",
+  "@vercel/og",
+  ...RSC_CLIENT_SHIM_OPTIMIZE_DEPS_EXCLUDE,
+]);
+
+export function mergeOptimizeDepsExclude(
+  ...excludeGroups: readonly (readonly string[])[]
+): string[] {
+  const seen = new Set<string>();
+  const merged: string[] = [];
+
+  for (const group of excludeGroups) {
+    for (const entry of group) {
+      if (seen.has(entry)) continue;
+      seen.add(entry);
+      merged.push(entry);
+    }
+  }
+
+  return merged;
+}

--- a/packages/vinext/src/plugins/rsc-client-shim-excludes.ts
+++ b/packages/vinext/src/plugins/rsc-client-shim-excludes.ts
@@ -20,15 +20,13 @@ export function mergeOptimizeDepsExclude(
   ...excludeGroups: readonly (readonly string[])[]
 ): string[] {
   const seen = new Set<string>();
-  const merged: string[] = [];
 
   for (const group of excludeGroups) {
     for (const entry of group) {
       if (seen.has(entry)) continue;
       seen.add(entry);
-      merged.push(entry);
     }
   }
 
-  return merged;
+  return [...seen];
 }

--- a/tests/build-optimization.test.ts
+++ b/tests/build-optimization.test.ts
@@ -112,6 +112,7 @@ describe("optimizeDeps.exclude for vinext", () => {
     "vinext/shims/link",
     "vinext/shims/script",
     "vinext/shims/slot",
+    "vinext/shims/offline",
   ];
 
   it("excludes vinext at top level for Pages Router builds", async () => {

--- a/tests/build-optimization.test.ts
+++ b/tests/build-optimization.test.ts
@@ -105,6 +105,15 @@ describe("clientManualChunks", () => {
 // ─── optimizeDeps.exclude — prevents esbuild scanning virtual module imports ─
 
 describe("optimizeDeps.exclude for vinext", () => {
+  const rscClientShimExcludes = [
+    "vinext/shims/error-boundary",
+    "vinext/shims/form",
+    "vinext/shims/layout-segment-context",
+    "vinext/shims/link",
+    "vinext/shims/script",
+    "vinext/shims/slot",
+  ];
+
   it("excludes vinext at top level for Pages Router builds", async () => {
     const vinext = (await import("../packages/vinext/src/index.js")).default;
     const plugins = vinext();
@@ -258,6 +267,12 @@ describe("optimizeDeps.exclude for vinext", () => {
       expect(result.environments.rsc.optimizeDeps?.exclude).toContain("vinext");
       expect(result.environments.ssr.optimizeDeps?.exclude).toContain("vinext");
       expect(result.environments.client.optimizeDeps?.exclude).toContain("vinext");
+      for (const shimExclude of rscClientShimExcludes) {
+        expect(result.optimizeDeps?.exclude).toContain(shimExclude);
+        expect(result.environments.rsc.optimizeDeps?.exclude).toContain(shimExclude);
+        expect(result.environments.ssr.optimizeDeps?.exclude).toContain(shimExclude);
+        expect(result.environments.client.optimizeDeps?.exclude).toContain(shimExclude);
+      }
     } finally {
       await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
     }


### PR DESCRIPTION
## What this changes

Adds vinext's known RSC client shim subpaths to the Vite dep optimizer exclude set for App Router projects. The exclude set is merged into the top-level, RSC, SSR, and client optimizer configs while preserving user-provided excludes and `serverExternalPackages`.

Closes #1008.

## Why

Next.js treats public App Router APIs such as `next/link`, `next/form`, and `next/script` as client modules:

- `next/link`: https://github.com/vercel/next.js/blob/ae61573e062e900050b8e6b24626e450accc4570/packages/next/src/client/app-dir/link.tsx#L1
- `next/form`: https://github.com/vercel/next.js/blob/ae61573e062e900050b8e6b24626e450accc4570/packages/next/src/client/app-dir/form.tsx#L1
- `next/script`: https://github.com/vercel/next.js/blob/ae61573e062e900050b8e6b24626e450accc4570/packages/next/src/client/script.tsx#L1
- Next's App Router E2E suite explicitly verifies `next/link` in Server Components: https://github.com/vercel/next.js/blob/ae61573e062e900050b8e6b24626e450accc4570/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts#L272-L286

vinext matches that shape with client shims. In dev, `@vitejs/plugin-rsc` records bare package sources resolved from the RSC graph and generates `client-package-proxy/<source>` modules from that metadata. The relevant source path is here: https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-rsc/src/plugin.ts

Before this change, vinext excluded the bare `vinext` package but not `vinext/shims/*`. That leaves known client shim subpaths eligible for dep optimization, which can make the package source recorded by plugin-rsc diverge from the optimized module that produced the client reference metadata. The result is the `clientReferenceMetaMap` miss reported in #1008.

## Approach

- Keep the fixed client shim list and exclude merge behavior in a normal plugin helper module.
- Reuse that helper from vinext's Vite config setup instead of spreading another inline `Set` expression through the config hook.
- Keep codegen out of the behavior. The generated entries continue to describe app shape, while the normal plugin module owns the optimizer policy.
- Scope the list to current vinext shims that are actual top-level client modules and can appear as package subpath imports: `error-boundary`, `form`, `layout-segment-context`, `link`, `script`, and `slot`.

## Validation

- `vp check packages/vinext/src/index.ts packages/vinext/src/plugins/rsc-client-shim-excludes.ts tests/build-optimization.test.ts`
- `vp test run tests/build-optimization.test.ts -t "optimizeDeps.exclude"`
- `vp test run tests/app-router.test.ts -t "renders next/link"`

## Risks / follow-ups

The main maintenance risk is list drift: if vinext adds another top-level `"use client"` shim that can be imported as `vinext/shims/<name>` from the RSC graph, it should be added to the helper list.
