### PR TITLE
fix(hmr): await router state readiness before rsc:update dispatch

### DIFF
--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -1480,9 +1480,15 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
       try {
         // HMR can fire before BrowserRoot's layout effect publishes
         // browserRouterStateRef (e.g. saving a file while the initial RSC
-        // stream is still suspended). Wait for readiness to avoid
-        // getBrowserRouterState() throwing.
+        // stream is still suspended), or while it is between unmount and
+        // remount. Wait for readiness, then re-check the ref — readiness can
+        // race with cleanup, which nulls the ref again. Skip silently when
+        // the tree is not currently mounted; the next HMR push or full
+        // reload will reconcile.
         await waitForBrowserRouterStateReady();
+        if (!browserRouterStateRef) {
+          return;
+        }
         clearClientNavigationCaches();
         const navigationSnapshot = createClientNavigationRenderSnapshot(
           window.location.href,

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -1508,6 +1508,13 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
           renderId: ++nextNavigationRenderId,
           type: "replace",
         });
+        // createPendingNavigationCommit awaits the new RSC payload. While
+        // suspended, the prior broken render can unmount BrowserRoot, which
+        // clears setBrowserRouterState. Re-check before dispatching so a
+        // racing unmount doesn't surface as "setter is not initialized".
+        if (!setBrowserRouterState) {
+          return;
+        }
         dispatchBrowserTree(
           pending.action.elements,
           navigationSnapshot,

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -1478,6 +1478,11 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
   if (import.meta.hot) {
     import.meta.hot.on("rsc:update", async () => {
       try {
+        // HMR can fire before BrowserRoot's layout effect publishes
+        // browserRouterStateRef (e.g. saving a file while the initial RSC
+        // stream is still suspended). Wait for readiness to avoid
+        // getBrowserRouterState() throwing.
+        await waitForBrowserRouterStateReady();
         clearClientNavigationCaches();
         const navigationSnapshot = createClientNavigationRenderSnapshot(
           window.location.href,


### PR DESCRIPTION
## Summary
- The `rsc:update` HMR handler in `app-browser-entry.ts` called `getBrowserRouterState()` directly, which throws when `browserRouterStateRef` is null.
- `browserRouterStateRef` is only published inside `BrowserRoot`'s layout effect, so an HMR event that fires while the initial RSC stream is still suspended (or after the tree has been torn down by an error) produces a noisy console error: `[vinext] RSC HMR error: Error: [vinext] Browser router state is not initialized`.
- Await `waitForBrowserRouterStateReady()` at the top of the handler, mirroring the pattern already used by `__VINEXT_RSC_NAVIGATE__`.

## Test plan
- [ ] Trigger HMR (save a server file) while the initial RSC stream is still in flight — confirm the console error no longer appears.
- [ ] Normal HMR after the page has hydrated still applies updates as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)