### PR TITLE
fix(navigation): hard-nav to target when render error tears down the tree

### DIFF
--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -75,7 +75,7 @@ import {
   type AppRouterState,
 } from "./app-browser-state.js";
 import { ElementsContext, Slot } from "vinext/shims/slot";
-import { devOnCaughtError } from "./app-browser-error.js";
+import { createOnUncaughtError, devOnCaughtError } from "./app-browser-error.js";
 import { DANGEROUS_URL_BLOCK_MESSAGE, isDangerousScheme } from "vinext/shims/url-safety";
 import {
   getServerActionNotFoundClientMessage,
@@ -151,6 +151,12 @@ let browserRouterStateHasCommitted = false;
 // the HMR handler to distinguish "still hydrating" (wait) from "was up, then
 // torn down by a render error" (full reload to recover).
 let browserRouterStateHasEverCommitted = false;
+// Most recent navigation target that has been dispatched but not yet committed.
+// Read by the onUncaughtError handler so a render error tearing down the tree
+// can land the browser on the URL the user was actually navigating to, instead
+// of stranding them on the previous URL with a blank page. Cleared once the
+// commit effect runs (URL update succeeded) or the navigation is superseded.
+let pendingNavigationRecoveryHref: string | null = null;
 
 function isServerActionResult(value: unknown): value is ServerActionResult {
   return !!value && typeof value === "object" && "root" in value;
@@ -342,6 +348,8 @@ function createNavigationCommitEffect(
       pushHistoryStateWithoutNotify(historyState, "", href);
     }
 
+    // URL has been updated; the recovery hard-nav target is no longer needed.
+    pendingNavigationRecoveryHref = null;
     commitClientNavigationState(navId);
   };
 }
@@ -781,6 +789,10 @@ async function renderNavigationPayload(
     );
     activateNavigationSnapshot();
     snapshotActivated = true;
+    // Record the target so onUncaughtError can land the browser on this URL
+    // if the dispatched tree throws during render. Cleared in the commit
+    // effect on success and in the catch below on synchronous failure.
+    pendingNavigationRecoveryHref = targetHref;
     dispatchBrowserTree(
       pending.action.elements,
       navigationSnapshot,
@@ -807,6 +819,10 @@ async function renderNavigationPayload(
     }
     settlePendingBrowserRouterState(pendingRouterState);
     resolve?.();
+    // The outer navigateRsc catch handles the hard-nav for synchronous
+    // failures; clear the recovery href so a later async error from a stale
+    // navigation doesn't trigger a redundant hard-nav.
+    pendingNavigationRecoveryHref = null;
     throw error;
   }
 
@@ -1129,13 +1145,16 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
     window.location.href,
   );
 
+  const onUncaughtError = createOnUncaughtError(() => pendingNavigationRecoveryHref);
   window.__VINEXT_RSC_ROOT__ = hydrateRoot(
     document,
     createElement(BrowserRoot, {
       initialElements: root,
       initialNavigationSnapshot,
     }),
-    import.meta.env.DEV ? { onCaughtError: devOnCaughtError } : undefined,
+    import.meta.env.DEV
+      ? { onCaughtError: devOnCaughtError, onUncaughtError }
+      : { onUncaughtError },
   );
   window.__VINEXT_HYDRATED_AT = performance.now();
 

--- a/packages/vinext/src/server/app-browser-error.ts
+++ b/packages/vinext/src/server/app-browser-error.ts
@@ -13,3 +13,26 @@ export function devOnCaughtError(
     console.error("The above error occurred in a React component:\n" + errorInfo.componentStack);
   }
 }
+
+// Build the onUncaughtError handler for hydrateRoot. When a render error
+// tears down the tree without an error boundary catching, the
+// NavigationCommitSignal layout effect never runs, so the URL update for
+// the in-flight navigation is lost — the user sees a blank page on the
+// previous URL. Hard-navigate to the intended target so the server can
+// render its actual error UI for that route. getRecoveryHref reads the
+// in-flight navigation target and returns null when nothing is pending
+// (e.g. an error during initial hydration).
+export function createOnUncaughtError(
+  getRecoveryHref: () => string | null,
+): (error: unknown, errorInfo: { componentStack?: string }) => void {
+  return (error, errorInfo) => {
+    console.error(error);
+    if (errorInfo?.componentStack) {
+      console.error("The above error occurred in a React component:\n" + errorInfo.componentStack);
+    }
+    const recoveryHref = getRecoveryHref();
+    if (recoveryHref !== null) {
+      window.location.assign(recoveryHref);
+    }
+  };
+}

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -1,6 +1,9 @@
 import React from "react";
 import { describe, expect, it, vi } from "vite-plus/test";
-import { devOnCaughtError } from "../packages/vinext/src/server/app-browser-error.js";
+import {
+  createOnUncaughtError,
+  devOnCaughtError,
+} from "../packages/vinext/src/server/app-browser-error.js";
 import {
   APP_INTERCEPTION_CONTEXT_KEY,
   APP_ROOT_LAYOUT_KEY,
@@ -505,6 +508,84 @@ describe("devOnCaughtError (hydrateRoot dev handler)", () => {
     try {
       devOnCaughtError(new Error("regression"), {});
       expect(consoleSpy.mock.calls.length).toBeGreaterThan(0);
+    } finally {
+      consoleSpy.mockRestore();
+    }
+  });
+});
+
+describe("createOnUncaughtError (hydrateRoot uncaught handler)", () => {
+  function withFakeWindow<T>(fn: (assignSpy: ReturnType<typeof vi.fn>) => T): T {
+    const assignSpy = vi.fn();
+    const originalWindow = (globalThis as { window?: unknown }).window;
+    (globalThis as { window?: unknown }).window = {
+      location: { assign: assignSpy },
+    };
+    try {
+      return fn(assignSpy);
+    } finally {
+      if (originalWindow === undefined) {
+        delete (globalThis as { window?: unknown }).window;
+      } else {
+        (globalThis as { window?: unknown }).window = originalWindow;
+      }
+    }
+  }
+
+  it("hard-navigates to the recovery href when one is pending", () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      withFakeWindow((assignSpy) => {
+        const handler = createOnUncaughtError(() => "/broken-route");
+        handler(new Error("render boom"), {});
+        expect(assignSpy).toHaveBeenCalledWith("/broken-route");
+      });
+    } finally {
+      consoleSpy.mockRestore();
+    }
+  });
+
+  it("does not navigate when no navigation is in flight (initial hydration error)", () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      withFakeWindow((assignSpy) => {
+        const handler = createOnUncaughtError(() => null);
+        handler(new Error("hydration boom"), {});
+        expect(assignSpy).not.toHaveBeenCalled();
+      });
+    } finally {
+      consoleSpy.mockRestore();
+    }
+  });
+
+  it("logs the error and component stack regardless of recovery", () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      withFakeWindow(() => {
+        const handler = createOnUncaughtError(() => null);
+        const err = new Error("boom");
+        handler(err, { componentStack: "\n    at Page (page.tsx:10)" });
+        const loggedFirst = consoleSpy.mock.calls[0]?.[0];
+        expect(loggedFirst).toBe(err);
+        expect(String(consoleSpy.mock.calls[1]?.[0])).toContain("page.tsx:10");
+      });
+    } finally {
+      consoleSpy.mockRestore();
+    }
+  });
+
+  it("reads the recovery href lazily so newer navigations win", () => {
+    // Module-level pendingNavigationRecoveryHref is reassigned across
+    // navigations; the handler must read it at call time, not at construction.
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      withFakeWindow((assignSpy) => {
+        let current: string | null = "/first";
+        const handler = createOnUncaughtError(() => current);
+        current = "/second";
+        handler(new Error("late error"), {});
+        expect(assignSpy).toHaveBeenCalledWith("/second");
+      });
     } finally {
       consoleSpy.mockRestore();
     }


### PR DESCRIPTION
## Summary
- When an RSC payload contains an error reference for a slot (e.g. a server component throws), `createPendingNavigationCommit` only awaits the top-level elements promise — it doesn't see the rejected nested reference, so the dispatch goes through.
- React then renders, the slot throws when `use()` unwraps the rejected reference, and without an `error.tsx` boundary above `NavigationCommitSignal` the entire root unmounts.
- The URL update lives in `NavigationCommitSignal`'s pre-paint layout effect, which never runs when the commit fails. Result: stale URL, blank page, console-only error.

## Fix
- Track the in-flight navigation target in a module-level `pendingNavigationRecoveryHref`. Set it just before `dispatchBrowserTree`; clear it once the commit effect updates history (and on the synchronous catch path).
- Add an `onUncaughtError` handler to `hydrateRoot` that reads the recovery href at fire time and `window.location.assign()`s to it. The user lands on the URL they clicked and the server can render its actual error UI for that route.
- Wire the handler in both dev and prod (previously only `onCaughtError` was registered, dev-only).

## Tests
- Four new unit tests in `tests/app-browser-entry.test.ts` cover: hard-nav on pending recovery href, no-op when nothing is pending (initial hydration error), error + component stack always logged, lazy read so newer navigations win.
- Full unit suite: 3399 passing.

## Test plan
- [ ] Click a link to a route whose server component throws — browser should land on the new URL with the server error visible, instead of staying on the old URL with a blank page.
- [ ] Normal navigation to a working route is unaffected.
- [ ] Initial hydration errors (no pending navigation) still surface to the console without a spurious redirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)