### PR TITLE
fix(dev): exclude private-next-instrumentation-client from optimizeDeps

### DIFF
--- a/packages/vinext/src/plugins/rsc-client-shim-excludes.ts
+++ b/packages/vinext/src/plugins/rsc-client-shim-excludes.ts
@@ -14,6 +14,10 @@ const RSC_CLIENT_SHIM_OPTIMIZE_DEPS_EXCLUDE = Object.freeze([
 export const VINEXT_OPTIMIZE_DEPS_EXCLUDE = Object.freeze([
   "vinext",
   "@vercel/og",
+  // Aliased to the user's instrumentation-client source file (or an empty
+  // shim). Not a real npm dep, so pre-bundling it would break HMR and cause
+  // a "new dependencies optimized" reload on the first request.
+  "private-next-instrumentation-client",
   ...RSC_CLIENT_SHIM_OPTIMIZE_DEPS_EXCLUDE,
 ]);
 


### PR DESCRIPTION
## Summary
- The \`private-next-instrumentation-client\` bare specifier is aliased to either the user's \`instrumentation-client.{ts,js}\` source file or vinext's empty-module shim. Neither belongs in Vite's pre-bundled deps cache.
- Without this exclude, Vite's dep scanner treats the unknown bare specifier as an npm dep on the first request, pre-bundles it, and triggers a full page reload (\`✨ optimized dependencies changed. reloading\`).
- Adding it to \`VINEXT_OPTIMIZE_DEPS_EXCLUDE\` propagates the exclude to all four environments (top-level, rsc, ssr, client) and lets the alias plugin resolve normally.

## Test plan
- [ ] Start dev server in an app that defines an \`instrumentation-client.ts\`; confirm no \`new dependencies optimized: private-next-instrumentation-client\` log on first request.
- [ ] Edit \`instrumentation-client.ts\` and verify HMR still applies without a full reload.
- [ ] Start dev server in an app *without* an \`instrumentation-client.ts\` and confirm no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)