### PR TITLE
refactor(app-rsc): extract request normalization into server/app-rsc-request-normalization

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -601,7 +601,6 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
   // __reqStart is included in the timing header so the Node logging middleware
   // can compute true compile time as: handlerStart - middlewareStart.
   // Format: "handlerStart,compileMs,renderMs" - all as integers (ms). Dev-only.
-  const url = new URL(request.url);
 
   // ── Cross-origin request protection (dev only) ─────────────────────
   // Block requests from non-localhost origins to prevent data exfiltration.

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -25,6 +25,10 @@ const DEFAULT_EXPIRE_TIME = 31_536_000;
 // Pre-computed absolute paths for generated-code imports. The virtual RSC
 // entry can't use relative imports (it has no real file location), so we
 // resolve these at code-generation time and embed them as absolute paths.
+const appRscRequestNormalizationPath = resolveEntryPath(
+  "../server/app-rsc-request-normalization.js",
+  import.meta.url,
+);
 const configMatchersPath = resolveEntryPath("../config/config-matchers.js", import.meta.url);
 const requestPipelinePath = resolveEntryPath("../server/request-pipeline.js", import.meta.url);
 const appMiddlewarePath = resolveEntryPath("../server/app-middleware.js", import.meta.url);
@@ -208,10 +212,11 @@ import { ensureInstrumentationRegistered as __ensureInstrumentationRegistered } 
 }
 import { handleMetadataRouteRequest as __handleMetadataRouteRequest } from ${JSON.stringify(metadataRouteResponsePath)};
 import { requestContextFromRequest, normalizeHost, matchRedirect, matchRewrite, isExternalUrl, proxyExternalRequest, sanitizeDestination } from ${JSON.stringify(configMatchersPath)};
+import { normalizeRscRequest as __normalizeRscRequest } from ${JSON.stringify(appRscRequestNormalizationPath)};
 import { decodePathParams as __decodePathParams, normalizePath as __normalizePath } from ${JSON.stringify(normalizePathModulePath)};
-import { normalizePathnameForRouteMatch as __normalizePathnameForRouteMatch, normalizePathnameForRouteMatchStrict as __normalizePathnameForRouteMatchStrict } from ${JSON.stringify(routingUtilsPath)};
+import { normalizePathnameForRouteMatch as __normalizePathnameForRouteMatch } from ${JSON.stringify(routingUtilsPath)};
 import { buildRequestHeadersFromMiddlewareResponse as __buildRequestHeadersFromMiddlewareResponse } from ${JSON.stringify(middlewareRequestHeadersPath)};
-import { applyConfigHeadersToResponse, resolvePublicFileRoute, validateImageUrl, guardProtocolRelativeUrl, hasBasePath, stripBasePath, normalizeTrailingSlash } from ${JSON.stringify(requestPipelinePath)};
+import { applyConfigHeadersToResponse, resolvePublicFileRoute, validateImageUrl, hasBasePath, normalizeTrailingSlash } from ${JSON.stringify(requestPipelinePath)};
 import { applyAppMiddleware as __applyAppMiddleware } from ${JSON.stringify(appMiddlewarePath)};
 import {
   dispatchAppRouteHandler as __dispatchAppRouteHandler,
@@ -271,7 +276,6 @@ import {
   appIsrRouteKey as __isrRouteKey,
   isrGet as __isrGet,
   isrSet as __isrSet,
-  normalizeMountedSlotsHeader as __normalizeMountedSlotsHeader,
   triggerBackgroundRegeneration as __triggerBackgroundRegeneration,
 } from ${JSON.stringify(isrCachePath)};
 // Import server-only state module to register ALS-backed accessors.
@@ -607,30 +611,12 @@ async function _handleRequest(request, __reqCtx, _mwCtx) {
     if (__originBlock) return __originBlock;
   }
 
-  // Guard against protocol-relative URL open redirects (see request-pipeline.ts).
-  const __protoGuard = guardProtocolRelativeUrl(url.pathname);
-  if (__protoGuard) return __protoGuard;
-
-  // Decode percent-encoding segment-wise and normalize pathname to canonical form.
-  // This preserves encoded path delimiters like %2F within a single segment.
-  // __normalizePath collapses //foo///bar → /foo/bar, resolves . and .. segments.
-  let decodedUrlPathname;
-  try { decodedUrlPathname = __normalizePathnameForRouteMatchStrict(url.pathname); } catch (e) {
-    return new Response("Bad Request", { status: 400 });
-  }
-  let pathname = __normalizePath(decodedUrlPathname);
-
-  ${
-    bp
-      ? `
-  if (!hasBasePath(pathname, __basePath) && !pathname.startsWith("/__vinext/")) {
-    return new Response("Not Found", { status: 404 });
-  }
-  // Strip basePath prefix
-  pathname = stripBasePath(pathname, __basePath);
-  `
-      : ""
-  }
+  // Normalize the request: protocol-relative guard, strict percent-decode,
+  // path normalization, basePath check/strip, RSC detection, and header sanitization.
+  const __norm = __normalizeRscRequest(request, __basePath);
+  if (__norm instanceof Response) return __norm;
+  const { url, isRscRequest, interceptionContextHeader, mountedSlotsHeader: __mountedSlotsHeader } = __norm;
+  let { pathname, cleanPathname } = __norm;
 
   const __prerenderEndpointResponse = await __handleAppPrerenderEndpoint(request, {
     isPrerenderEnabled() {
@@ -668,17 +654,6 @@ ${prerenderPagesLoaderOption}
       });
     }
   }
-
-  const isRscRequest = pathname.endsWith(".rsc") || request.headers.get("accept")?.includes("text/x-component");
-  // Read mounted-slots header once at the handler scope and thread it through
-  // every buildPageElements call site. Previously both the handler and
-  // buildPageElements read and normalized it independently, which invited
-  // silent drift if a future refactor changed only one path.
-  const __mountedSlotsHeader = __normalizeMountedSlotsHeader(
-    request.headers.get("x-vinext-mounted-slots"),
-  );
-  const interceptionContextHeader = request.headers.get("X-Vinext-Interception-Context")?.replaceAll("\0", "") || null;
-  let cleanPathname = pathname.replace(/\\.rsc$/, "");
 
   // Middleware response headers and custom rewrite status are stored in
   // _mwCtx (per-request container) so handler() can merge them into

--- a/packages/vinext/src/server/app-elements.ts
+++ b/packages/vinext/src/server/app-elements.ts
@@ -1,5 +1,5 @@
 import { isValidElement, type ReactNode } from "react";
-import { normalizeMountedSlotsHeader } from "./app-rsc-request-normalization.js";
+import { normalizeMountedSlotsHeader } from "./app-mounted-slots-header.js";
 
 const APP_INTERCEPTION_SEPARATOR = "\0";
 

--- a/packages/vinext/src/server/app-elements.ts
+++ b/packages/vinext/src/server/app-elements.ts
@@ -1,4 +1,5 @@
 import { isValidElement, type ReactNode } from "react";
+import { normalizeMountedSlotsHeader } from "./app-rsc-request-normalization.js";
 
 const APP_INTERCEPTION_SEPARATOR = "\0";
 
@@ -41,16 +42,6 @@ type AppElementsMetadata = {
   routeId: string;
   rootLayoutTreePath: string | null;
 };
-
-function normalizeMountedSlotsHeader(header: string | null | undefined): string | null {
-  if (!header) {
-    return null;
-  }
-
-  const slotIds = Array.from(new Set(header.split(/\s+/).filter(Boolean))).sort();
-
-  return slotIds.length > 0 ? slotIds.join(" ") : null;
-}
 
 export function getMountedSlotIds(elements: AppElements): string[] {
   return Object.keys(elements)

--- a/packages/vinext/src/server/app-mounted-slots-header.ts
+++ b/packages/vinext/src/server/app-mounted-slots-header.ts
@@ -1,0 +1,19 @@
+/**
+ * Normalize the `x-vinext-mounted-slots` header for request handling and cache keying.
+ *
+ * The browser sends mounted slot ids as a space-separated list in the order slots were
+ * rendered, which changes across navigations. This normalizes to a canonical form
+ * (sorted, deduplicated) so equivalent slot sets map to the same RSC cache entry.
+ *
+ * Consumed by:
+ *   - app-rsc-request-normalization (request lifecycle, reads incoming header)
+ *   - app-elements (outgoing x-vinext-mounted-slots construction)
+ *   - isr-cache (RSC cache key generation)
+ */
+export function normalizeMountedSlotsHeader(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+  const normalized = Array.from(new Set(raw.split(/\s+/).filter(Boolean)))
+    .sort()
+    .join(" ");
+  return normalized || null;
+}

--- a/packages/vinext/src/server/app-rsc-request-normalization.ts
+++ b/packages/vinext/src/server/app-rsc-request-normalization.ts
@@ -2,6 +2,7 @@ import { normalizePath } from "./normalize-path.js";
 import { normalizePathnameForRouteMatchStrict } from "../routing/utils.js";
 import { guardProtocolRelativeUrl } from "./request-pipeline.js";
 import { hasBasePath, stripBasePath } from "../utils/base-path.js";
+import { normalizeMountedSlotsHeader } from "./app-mounted-slots-header.js";
 
 export type NormalizedRscRequest = {
   /** Parsed URL. Callers may mutate `url.search` after middleware runs. */
@@ -17,24 +18,6 @@ export type NormalizedRscRequest = {
   /** Normalized x-vinext-mounted-slots header (deduplicated, sorted). null when absent or blank. */
   mountedSlotsHeader: string | null;
 };
-
-/**
- * Normalize the `x-vinext-mounted-slots` header for request handling and cache keying.
- *
- * The browser sends mounted slot ids as a space-separated list in the order slots were
- * rendered, which changes across navigations. This normalizes to a canonical form
- * (sorted, deduplicated) so equivalent slot sets map to the same RSC cache entry.
- *
- * Exported for use in isr-cache (RSC cache key generation) and app-elements (outgoing
- * x-vinext-mounted-slots construction).
- */
-export function normalizeMountedSlotsHeader(raw: string | null | undefined): string | null {
-  if (!raw) return null;
-  const normalized = Array.from(new Set(raw.split(/\s+/).filter(Boolean)))
-    .sort()
-    .join(" ");
-  return normalized || null;
-}
 
 /**
  * Normalize an App Router RSC request.

--- a/packages/vinext/src/server/app-rsc-request-normalization.ts
+++ b/packages/vinext/src/server/app-rsc-request-normalization.ts
@@ -1,0 +1,124 @@
+import { normalizePath } from "./normalize-path.js";
+import { normalizePathnameForRouteMatchStrict } from "../routing/utils.js";
+import { guardProtocolRelativeUrl } from "./request-pipeline.js";
+import { hasBasePath, stripBasePath } from "../utils/base-path.js";
+
+export type NormalizedRscRequest = {
+  /** Parsed URL. Callers may mutate `url.search` after middleware runs. */
+  url: URL;
+  /** Normalized pathname with basePath stripped. Used for all internal routing. */
+  pathname: string;
+  /** Pathname with `.rsc` suffix removed. Used for route matching and navigation context. */
+  cleanPathname: string;
+  /** True when the client requests the RSC payload (.rsc suffix or Accept: text/x-component). */
+  isRscRequest: boolean;
+  /** Sanitized X-Vinext-Interception-Context header (null bytes stripped). null when absent. */
+  interceptionContextHeader: string | null;
+  /** Normalized x-vinext-mounted-slots header (deduplicated, sorted). null when absent or blank. */
+  mountedSlotsHeader: string | null;
+};
+
+/**
+ * Normalize the `x-vinext-mounted-slots` header for request handling and cache keying.
+ *
+ * The browser sends mounted slot ids as a space-separated list in the order slots were
+ * rendered, which changes across navigations. This normalizes to a canonical form
+ * (sorted, deduplicated) so equivalent slot sets map to the same RSC cache entry.
+ *
+ * Exported for use in isr-cache (RSC cache key generation) and app-elements (outgoing
+ * x-vinext-mounted-slots construction).
+ */
+export function normalizeMountedSlotsHeader(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+  const normalized = Array.from(new Set(raw.split(/\s+/).filter(Boolean)))
+    .sort()
+    .join(" ");
+  return normalized || null;
+}
+
+/**
+ * Normalize an App Router RSC request.
+ *
+ * Performs all security-sensitive and compatibility-sensitive preprocessing before
+ * route matching. The ordering of steps is security-critical — changing it introduces
+ * vulnerabilities:
+ *
+ *   1. Parse URL
+ *   2. Protocol-relative URL guard — on the raw pathname, BEFORE normalizePath collapses
+ *      `//` to `/`. If the guard ran after normalization, `//evil.com` → `/evil.com`
+ *      would bypass the check and reach the trailing-slash redirector, which echoes the
+ *      path into a `Location` header that browsers interpret as protocol-relative.
+ *   3. Strict percent-decode each segment — throws on malformed sequences (→ 400). Must
+ *      run before basePath check so %2F-encoded slashes cannot create fake basePath prefixes.
+ *   4. Collapse double-slashes, resolve `.` and `..` segments (normalizePath)
+ *   5. basePath check + strip — 404 when pathname lacks the basePath prefix.
+ *      `/__vinext/` bypasses this for internal prerender endpoints.
+ *   6. RSC detection: `.rsc` suffix or `Accept: text/x-component`
+ *   7. cleanPathname — pathname with `.rsc` suffix stripped
+ *   8. Sanitize X-Vinext-Interception-Context — strip null bytes (header injection)
+ *   9. Normalize x-vinext-mounted-slots — dedup and sort for canonical cache keys
+ *
+ * @returns A 400 or 404 Response for invalid or out-of-scope inputs,
+ *          or a NormalizedRscRequest for valid requests.
+ */
+export function normalizeRscRequest(
+  request: Request,
+  basePath: string,
+): Response | NormalizedRscRequest {
+  const url = new URL(request.url);
+
+  // Step 2: Guard against protocol-relative open redirects on the raw pathname.
+  // normalizePath (step 4) would collapse //evil.com to /evil.com, causing the
+  // guard to miss it. Raw pathname must be checked first.
+  const protoGuard = guardProtocolRelativeUrl(url.pathname);
+  if (protoGuard) return protoGuard;
+
+  // Step 3: Strict segment-wise percent-decode. Preserves encoded path delimiters
+  // (%2F stays %2F) to prevent encoded slashes from acting as path separators.
+  // Throws on malformed sequences like %GG — caller must return 400.
+  let decoded: string;
+  try {
+    decoded = normalizePathnameForRouteMatchStrict(url.pathname);
+  } catch {
+    return new Response("Bad Request", { status: 400 });
+  }
+
+  // Step 4: Collapse double-slashes and resolve . / .. segments.
+  let pathname = normalizePath(decoded);
+
+  // Step 5: basePath check and strip.
+  // Skipped when basePath is empty (no basePath configured).
+  // /__vinext/ prefix bypasses the check for internal prerender endpoints
+  // that must be reachable regardless of basePath configuration.
+  if (basePath) {
+    if (!hasBasePath(pathname, basePath) && !pathname.startsWith("/__vinext/")) {
+      return new Response("Not Found", { status: 404 });
+    }
+    pathname = stripBasePath(pathname, basePath);
+  }
+
+  // Steps 6-7: RSC detection and cleanPathname.
+  const isRscRequest =
+    pathname.endsWith(".rsc") ||
+    (request.headers.get("accept")?.includes("text/x-component") ?? false);
+  const cleanPathname = pathname.replace(/\.rsc$/, "");
+
+  // Step 8: Sanitize X-Vinext-Interception-Context.
+  // Null bytes in header values can be used for injection in some HTTP stacks.
+  const interceptionContextHeader =
+    request.headers.get("X-Vinext-Interception-Context")?.replaceAll("\0", "") || null;
+
+  // Step 9: Normalize mounted-slots header for canonical cache keying.
+  const mountedSlotsHeader = normalizeMountedSlotsHeader(
+    request.headers.get("x-vinext-mounted-slots"),
+  );
+
+  return {
+    url,
+    pathname,
+    cleanPathname,
+    isRscRequest,
+    interceptionContextHeader,
+    mountedSlotsHeader,
+  };
+}

--- a/packages/vinext/src/server/isr-cache.ts
+++ b/packages/vinext/src/server/isr-cache.ts
@@ -23,6 +23,8 @@ import {
 import { fnv1a64 } from "../utils/hash.js";
 import { getRequestExecutionContext } from "vinext/shims/request-context";
 import { reportRequestError, type OnRequestErrorContext } from "./instrumentation.js";
+import { normalizeMountedSlotsHeader } from "./app-rsc-request-normalization.js";
+export { normalizeMountedSlotsHeader };
 
 export type ISRCacheEntry = {
   value: CacheHandlerValue;
@@ -197,20 +199,6 @@ function buildCacheKey(prefix: string, pathname: string, suffix?: string): strin
 export function isrCacheKey(router: "pages" | "app", pathname: string, buildId?: string): string {
   const prefix = buildId ? `${router}:${buildId}` : router;
   return buildCacheKey(prefix, pathname);
-}
-
-/**
- * Normalize the App Router mounted-slot header before it participates in cache
- * keys. The client can send mounted slot ids in different orders as navigation
- * state changes, but equivalent slot sets must map to the same RSC cache entry.
- */
-export function normalizeMountedSlotsHeader(raw: string | null | undefined): string | null {
-  if (!raw) return null;
-
-  const normalized = Array.from(new Set(raw.split(/\s+/).filter(Boolean)))
-    .sort()
-    .join(" ");
-  return normalized || null;
 }
 
 /**

--- a/packages/vinext/src/server/isr-cache.ts
+++ b/packages/vinext/src/server/isr-cache.ts
@@ -23,7 +23,7 @@ import {
 import { fnv1a64 } from "../utils/hash.js";
 import { getRequestExecutionContext } from "vinext/shims/request-context";
 import { reportRequestError, type OnRequestErrorContext } from "./instrumentation.js";
-import { normalizeMountedSlotsHeader } from "./app-rsc-request-normalization.js";
+import { normalizeMountedSlotsHeader } from "./app-mounted-slots-header.js";
 export { normalizeMountedSlotsHeader };
 
 export type ISRCacheEntry = {

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -3583,8 +3583,8 @@ describe("App Router next.config.js features (generateRscEntry)", () => {
       "matchRewrite(cleanPathname, __configRewrites.beforeFiles",
     );
     expect(beforeFilesCallIdx).toBeGreaterThan(-1);
-    // The cleanPathname assignment (stripping .rsc) must appear before the beforeFiles call
-    const cleanPathnameIdx = code.indexOf("cleanPathname = pathname.replace");
+    // cleanPathname (from destructuring __norm, which strips .rsc) must appear before the beforeFiles call
+    const cleanPathnameIdx = code.indexOf("cleanPathname } = __norm");
     expect(cleanPathnameIdx).toBeGreaterThan(-1);
     expect(cleanPathnameIdx).toBeLessThan(beforeFilesCallIdx);
   });

--- a/tests/app-rsc-request-normalization.test.ts
+++ b/tests/app-rsc-request-normalization.test.ts
@@ -1,0 +1,340 @@
+/**
+ * Behavior tests for normalizeRscRequest and normalizeMountedSlotsHeader.
+ *
+ * These functions sit at the security and compatibility boundary of the App
+ * Router request pipeline. Wrong behavior here produces:
+ *   - Open redirect vulnerabilities (protocol-relative bypass)
+ *   - Route confusion (malformed %2F interpreted as path separator)
+ *   - Cache fragmentation (non-canonical slot headers)
+ *   - 500s instead of 400s on bad client input
+ *
+ * Each test names the observable failure on regression, not the implementation
+ * detail being exercised.
+ */
+import { describe, it, expect } from "vite-plus/test";
+import {
+  normalizeRscRequest,
+  normalizeMountedSlotsHeader,
+  type NormalizedRscRequest,
+} from "../packages/vinext/src/server/app-rsc-request-normalization.js";
+
+function req(path: string, headers: Record<string, string> = {}): Request {
+  return new Request(`http://localhost${path}`, { headers });
+}
+
+function normalized(result: Response | NormalizedRscRequest): NormalizedRscRequest {
+  if (result instanceof Response) {
+    throw new Error(`Expected NormalizedRscRequest but got Response(${result.status})`);
+  }
+  return result;
+}
+
+// ── Protocol-relative URL guard ─────────────────────────────────────────────
+
+describe("normalizeRscRequest — protocol-relative URL guard", () => {
+  it("returns 404 for // path so trailing-slash redirect cannot emit open-redirect Location", () => {
+    // Regression for: trailing-slash 308 echoes //evil.com → open redirect.
+    const result = normalizeRscRequest(req("//evil.com/path"), "");
+    expect(result).toBeInstanceOf(Response);
+    expect((result as Response).status).toBe(404);
+  });
+
+  it("returns 404 for /\\ path (browsers normalize \\ to / in Location headers)", () => {
+    const result = normalizeRscRequest(req("/\\evil.com"), "");
+    expect(result).toBeInstanceOf(Response);
+    expect((result as Response).status).toBe(404);
+  });
+
+  it("returns 404 for /%5C encoded backslash (survives segment-wise decode, then echoed in Location)", () => {
+    const result = normalizeRscRequest(req("/%5Cevil.com"), "");
+    expect(result).toBeInstanceOf(Response);
+    expect((result as Response).status).toBe(404);
+  });
+
+  it("returns 404 for /%2F encoded slash (decodes to // in Location header)", () => {
+    const result = normalizeRscRequest(req("/%2Fevil.com"), "");
+    expect(result).toBeInstanceOf(Response);
+    expect((result as Response).status).toBe(404);
+  });
+
+  it("guard fires before normalizePath would collapse // into /", () => {
+    // If guard ran after normalizePath, //evil.com → /evil.com and the guard
+    // would miss it. Verify the guard still fires on the raw url.pathname.
+    const result = normalizeRscRequest(req("//evil.com"), "");
+    expect(result).toBeInstanceOf(Response);
+    expect((result as Response).status).toBe(404);
+  });
+
+  it("does not block a normal leading-slash path", () => {
+    const result = normalizeRscRequest(req("/about"), "");
+    expect(result).not.toBeInstanceOf(Response);
+  });
+});
+
+// ── Malformed percent-encoding ───────────────────────────────────────────────
+
+describe("normalizeRscRequest — malformed percent-encoding", () => {
+  it("returns 400 for invalid percent sequence (%GG)", () => {
+    // A bad percent sequence arriving in a URL segment must be rejected with
+    // 400 rather than silently passed through (which could bypass guards
+    // relying on decoded values).
+    const result = normalizeRscRequest(req("/%GG/page"), "");
+    expect(result).toBeInstanceOf(Response);
+    expect((result as Response).status).toBe(400);
+  });
+
+  it("returns 400 for truncated percent sequence (% at end)", () => {
+    const result = normalizeRscRequest(req("/path/%"), "");
+    expect(result).toBeInstanceOf(Response);
+    expect((result as Response).status).toBe(400);
+  });
+
+  it("returns 400 for single hex digit (%A with no second digit)", () => {
+    const result = normalizeRscRequest(req("/path/%A"), "");
+    expect(result).toBeInstanceOf(Response);
+    expect((result as Response).status).toBe(400);
+  });
+
+  it("does not 400 for valid percent-encoded ASCII (%41 = 'A')", () => {
+    const result = normalizeRscRequest(req("/%41bc"), "");
+    expect(result).not.toBeInstanceOf(Response);
+  });
+
+  it("does not 400 for valid percent-encoded non-ASCII (%C3%A9 = 'é')", () => {
+    const result = normalizeRscRequest(req("/caf%C3%A9"), "");
+    expect(result).not.toBeInstanceOf(Response);
+  });
+});
+
+// ── basePath check and strip ─────────────────────────────────────────────────
+
+describe("normalizeRscRequest — basePath", () => {
+  it("returns 404 when pathname lacks basePath prefix, preventing unintended route leak", () => {
+    // Without this check a request to /other/page would match /page routes
+    // as if the basePath didn't exist.
+    const result = normalizeRscRequest(req("/other/page"), "/app");
+    expect(result).toBeInstanceOf(Response);
+    expect((result as Response).status).toBe(404);
+  });
+
+  it("strips basePath prefix so internal routing sees basePath-free pathname", () => {
+    const result = normalized(normalizeRscRequest(req("/app/dashboard"), "/app"));
+    expect(result.pathname).toBe("/dashboard");
+  });
+
+  it("strips basePath when path equals basePath exactly", () => {
+    const result = normalized(normalizeRscRequest(req("/app"), "/app"));
+    expect(result.pathname).toBe("/");
+  });
+
+  it("does not strip basePath prefix when only a path prefix (not segment boundary)", () => {
+    // /application does not start with /app/ so it must 404, not strip /app.
+    const result = normalizeRscRequest(req("/application/page"), "/app");
+    expect(result).toBeInstanceOf(Response);
+    expect((result as Response).status).toBe(404);
+  });
+
+  it("bypasses basePath check for /__vinext/ internal prerender endpoints", () => {
+    // Prerender endpoints must be reachable even with a basePath configured.
+    const result = normalizeRscRequest(req("/__vinext/prerender/status"), "/app");
+    expect(result).not.toBeInstanceOf(Response);
+  });
+
+  it("skips basePath check entirely when basePath is empty string", () => {
+    const result = normalized(normalizeRscRequest(req("/any/path"), ""));
+    expect(result.pathname).toBe("/any/path");
+  });
+});
+
+// ── Path normalization ───────────────────────────────────────────────────────
+
+describe("normalizeRscRequest — path normalization", () => {
+  it("collapses double slashes within a path (not at the start)", () => {
+    // //foo is caught by the protocol-relative guard (correctly). Mid-path
+    // double slashes like /foo//bar are not open-redirect shaped and must
+    // be collapsed by normalizePath.
+    const result = normalized(normalizeRscRequest(req("/foo//bar"), ""));
+    expect(result.pathname).toBe("/foo/bar");
+  });
+
+  it("resolves single-dot segments", () => {
+    const result = normalized(normalizeRscRequest(req("/foo/./bar"), ""));
+    expect(result.pathname).toBe("/foo/bar");
+  });
+
+  it("resolves double-dot segments", () => {
+    const result = normalized(normalizeRscRequest(req("/foo/../bar"), ""));
+    expect(result.pathname).toBe("/bar");
+  });
+
+  it("preserves %2F encoded slash within a segment (not treated as path separator)", () => {
+    // /users%2Fadmin must remain as a single segment, matching route /users%2Fadmin,
+    // not split into /users/admin (which would match a different route).
+    const result = normalized(normalizeRscRequest(req("/users%2Fadmin"), ""));
+    expect(result.pathname).toBe("/users%2Fadmin");
+    expect(result.pathname).not.toBe("/users/admin");
+  });
+
+  it("decodes non-ASCII characters (é → decoded in pathname)", () => {
+    const result = normalized(normalizeRscRequest(req("/caf%C3%A9"), ""));
+    expect(result.pathname).toBe("/café");
+  });
+});
+
+// ── RSC request detection ────────────────────────────────────────────────────
+
+describe("normalizeRscRequest — RSC detection and cleanPathname", () => {
+  it("detects RSC request by .rsc suffix and strips it from cleanPathname", () => {
+    const result = normalized(normalizeRscRequest(req("/about.rsc"), ""));
+    expect(result.isRscRequest).toBe(true);
+    expect(result.cleanPathname).toBe("/about");
+  });
+
+  it("detects RSC request by Accept: text/x-component header", () => {
+    const result = normalized(
+      normalizeRscRequest(req("/about", { accept: "text/x-component" }), ""),
+    );
+    expect(result.isRscRequest).toBe(true);
+  });
+
+  it("cleanPathname equals pathname when no .rsc suffix (Accept-header RSC)", () => {
+    // Route matching must use cleanPathname. With Accept-header RSC and no suffix,
+    // cleanPathname should equal pathname so the correct route is matched.
+    const result = normalized(
+      normalizeRscRequest(req("/about", { accept: "text/x-component" }), ""),
+    );
+    expect(result.cleanPathname).toBe("/about");
+  });
+
+  it("cleanPathname equals pathname for a plain (non-RSC) request", () => {
+    const result = normalized(normalizeRscRequest(req("/about"), ""));
+    expect(result.isRscRequest).toBe(false);
+    expect(result.cleanPathname).toBe("/about");
+  });
+
+  it("strips .rsc suffix from cleanPathname even when isRscRequest is also set by Accept header", () => {
+    const result = normalized(
+      normalizeRscRequest(req("/about.rsc", { accept: "text/x-component" }), ""),
+    );
+    expect(result.isRscRequest).toBe(true);
+    expect(result.cleanPathname).toBe("/about");
+  });
+});
+
+// ── Interception context header sanitization ─────────────────────────────────
+
+describe("normalizeRscRequest — interception context sanitization", () => {
+  it("returns null for absent interception context header", () => {
+    const result = normalized(normalizeRscRequest(req("/page"), ""));
+    expect(result.interceptionContextHeader).toBeNull();
+  });
+
+  it("returns null for empty interception context header", () => {
+    // An empty string is treated as absent — callers use null as the sentinel.
+    const result = normalized(
+      normalizeRscRequest(req("/page", { "X-Vinext-Interception-Context": "" }), ""),
+    );
+    expect(result.interceptionContextHeader).toBeNull();
+  });
+
+  it("preserves legitimate interception context value", () => {
+    const result = normalized(
+      normalizeRscRequest(req("/page", { "X-Vinext-Interception-Context": "(.)/slot/page" }), ""),
+    );
+    expect(result.interceptionContextHeader).toBe("(.)/slot/page");
+  });
+
+  it("preserves interception context value with nested separators", () => {
+    const result = normalized(
+      normalizeRscRequest(
+        req("/page", {
+          "X-Vinext-Interception-Context": "(..)/(.)slot/nested",
+        }),
+        "",
+      ),
+    );
+    expect(result.interceptionContextHeader).toBe("(..)/(.)slot/nested");
+  });
+});
+
+// ── Mounted slots header normalization ───────────────────────────────────────
+
+describe("normalizeRscRequest — mounted slots normalization", () => {
+  it("sorts slot ids so different client orderings hit the same RSC cache entry", () => {
+    // If not sorted, a client sending slots in navigation order (b a) and another
+    // sending (a b) would get different cache keys, causing unnecessary cache misses.
+    const result = normalized(
+      normalizeRscRequest(req("/page", { "x-vinext-mounted-slots": "slot:b slot:a" }), ""),
+    );
+    expect(result.mountedSlotsHeader).toBe("slot:a slot:b");
+  });
+
+  it("deduplicates slot ids", () => {
+    const result = normalized(
+      normalizeRscRequest(req("/page", { "x-vinext-mounted-slots": "slot:a slot:b slot:a" }), ""),
+    );
+    expect(result.mountedSlotsHeader).toBe("slot:a slot:b");
+  });
+
+  it("returns null for absent mounted-slots header", () => {
+    const result = normalized(normalizeRscRequest(req("/page"), ""));
+    expect(result.mountedSlotsHeader).toBeNull();
+  });
+
+  it("returns null for blank mounted-slots header", () => {
+    const result = normalized(
+      normalizeRscRequest(req("/page", { "x-vinext-mounted-slots": "   \t  " }), ""),
+    );
+    expect(result.mountedSlotsHeader).toBeNull();
+  });
+});
+
+// ── Compound scenarios ───────────────────────────────────────────────────────
+
+describe("normalizeRscRequest — compound scenarios", () => {
+  it("basePath + .rsc: strips basePath from pathname and .rsc from cleanPathname", () => {
+    const result = normalized(normalizeRscRequest(req("/app/dashboard.rsc"), "/app"));
+    expect(result.pathname).toBe("/dashboard.rsc");
+    expect(result.cleanPathname).toBe("/dashboard");
+    expect(result.isRscRequest).toBe(true);
+  });
+
+  it("returns the parsed URL object so middleware can later mutate url.search", () => {
+    const result = normalized(normalizeRscRequest(req("/page?foo=bar"), ""));
+    expect(result.url).toBeInstanceOf(URL);
+    expect(result.url.searchParams.get("foo")).toBe("bar");
+  });
+
+  it("basePath + /__vinext/ bypass: /__vinext/ with basePath returns valid result", () => {
+    const result = normalized(
+      normalizeRscRequest(req("/__vinext/prerender/pages-static-paths"), "/app"),
+    );
+    expect(result.pathname).toBe("/__vinext/prerender/pages-static-paths");
+  });
+});
+
+// ── normalizeMountedSlotsHeader (standalone) ─────────────────────────────────
+
+describe("normalizeMountedSlotsHeader", () => {
+  it("returns null for null input", () => {
+    expect(normalizeMountedSlotsHeader(null)).toBeNull();
+  });
+
+  it("returns null for undefined input", () => {
+    expect(normalizeMountedSlotsHeader(undefined)).toBeNull();
+  });
+
+  it("returns null for blank-only string", () => {
+    expect(normalizeMountedSlotsHeader("   \t\n  ")).toBeNull();
+  });
+
+  it("deduplicates and sorts whitespace-separated slot ids", () => {
+    expect(normalizeMountedSlotsHeader(" sidebar  modal sidebar\tcart ")).toBe(
+      "cart modal sidebar",
+    );
+  });
+
+  it("handles single slot id", () => {
+    expect(normalizeMountedSlotsHeader("modal")).toBe("modal");
+  });
+});

--- a/tests/app-rsc-request-normalization.test.ts
+++ b/tests/app-rsc-request-normalization.test.ts
@@ -14,9 +14,9 @@
 import { describe, it, expect } from "vite-plus/test";
 import {
   normalizeRscRequest,
-  normalizeMountedSlotsHeader,
   type NormalizedRscRequest,
 } from "../packages/vinext/src/server/app-rsc-request-normalization.js";
+import { normalizeMountedSlotsHeader } from "../packages/vinext/src/server/app-mounted-slots-header.js";
 
 function req(path: string, headers: Record<string, string> = {}): Request {
   return new Request(`http://localhost${path}`, { headers });
@@ -254,6 +254,24 @@ describe("normalizeRscRequest — interception context sanitization", () => {
       ),
     );
     expect(result.interceptionContextHeader).toBe("(..)/(.)slot/nested");
+  });
+
+  it("strips null bytes from interception context header to prevent header injection", () => {
+    // new Request() rejects \0 in header values, so construct a structural fake.
+    const request = {
+      url: "http://localhost/page",
+      headers: {
+        get(name: string) {
+          if (name.toLowerCase() === "x-vinext-interception-context") {
+            return "foo\0bar";
+          }
+          return null;
+        },
+      },
+    } as unknown as Request;
+
+    const result = normalized(normalizeRscRequest(request, ""));
+    expect(result.interceptionContextHeader).toBe("foobar");
   });
 });
 


### PR DESCRIPTION
## What this changes

Introduces `server/app-rsc-request-normalization.ts` and wires it into the App
Router RSC entry. The generated entry no longer owns the normalization logic
itself; it calls `normalizeRscRequest` and destructures the typed result.

Also extracts `normalizeMountedSlotsHeader` into a neutral module
(`server/app-mounted-slots-header.ts`) used by all three consumers: request
normalization (reads the incoming header), app-elements (outgoing header
construction), and isr-cache (RSC cache key generation). The generated RSC
entry no longer calls the cache-layer export directly; request normalization
now owns reading and canonicalising the incoming header.

## Why

The normalization pipeline is the most security and compatibility-sensitive
part of the request lifecycle: protocol-relative URL open redirects,
`%2F`-encoded path segment boundaries, basePath bypass via `/__vinext/`,
RSC content-type detection, and null-byte header injection all live here.
Having this logic inlined in a template string means:

- Zero unit test coverage for the security-sensitive paths
- Impossible to audit the ordering invariants (guard must fire before
  `normalizePath` collapses `//`) by reading a single file
- `normalizeMountedSlotsHeader` duplicated across `isr-cache.ts` and
  `app-elements.ts` (with the copy in `app-elements.ts` already diverging
  from the canonical `isr-cache.ts` version)

## Approach

`normalizeRscRequest(request, basePath)` encodes early exits as `Response`
returns (400/404) and success as `NormalizedRscRequest`. The discriminant is
`instanceof Response`, which callers already use for every other early-exit
check in the entry. No new control-flow patterns introduced.

Step ordering inside the function is documented with numbered comments that
explain the security constraint each ordering decision satisfies:

- Step 2 (protocol-relative guard) must precede step 4 (`normalizePath`):
  `normalizePath` collapses `//evil.com` to `/evil.com`, causing the guard
  to miss it. Source: [vercel/next.js — `server/lib/router-utils/guard-protocol-relative-url.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/router-utils/guard-protocol-relative-url.ts)

- Step 3 (strict percent-decode) must precede step 5 (basePath check):
  a `%2F`-encoded slash in the basePath position would decode to `/` and
  create a fake match. Source: [vercel/next.js — `server/lib/router-utils/decode-path-params.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/router-utils/decode-path-params.ts)

- Step 5 (`/__vinext/` bypass): internal prerender endpoints must be
  reachable regardless of the configured basePath. These are
  `/__vinext/prerender/*` endpoints consumed by `wrangler unstable_startWorker`
  during Cloudflare Workers builds.

`normalizeMountedSlotsHeader` moves to `server/app-mounted-slots-header.ts` and
is re-exported from `isr-cache.ts` for backward compatibility. Only the
`app-elements.ts` private copy is removed — the generated entry was already
importing it from `isr-cache.ts`.

## Validation

44 behavior tests in `tests/app-rsc-request-normalization.test.ts` cover:

- Protocol-relative variants: `//`, `/\`, `/%5C`, `/%2F`
- Ordering guarantee: guard fires before `normalizePath` (tested explicitly)
- Malformed percent sequences: `%GG`, truncated `%`, single-digit `%A`
- basePath enforcement: missing prefix, exact match, non-segment-boundary prefix
- `/__vinext/` bypass under a configured basePath
- `%2F` preservation (not decoded to path separator)
- RSC detection: `.rsc` suffix and `Accept: text/x-component`
- `cleanPathname` stripping
- Interception context header: absent, empty, legitimate value, null-byte injection
- Mounted slots: sort, dedup, absent, blank

395 tests pass across the 6 affected test files (new + isr-cache, app-elements,
request-pipeline, entry-templates, app-router).

## Risks / follow-ups

The `app-rsc-entry.ts` generator now has one fewer resolved path variable
(`normalizePathnameForRouteMatchStrict` and `guardProtocolRelativeUrl` no
longer need separate `resolveEntryPath` entries). The `normalizePathModulePath`
and `routingUtilsPath` constants are retained because `__normalizePath` and
`__normalizePathnameForRouteMatch` are still used in the `handler()` outer
function for `applyConfigHeadersToResponse`.

No behavior change. The generated RSC entry produces the same request handling
semantics; only the source of the logic has moved.