### PR TITLE
refactor(app-rsc): extract response finalisation into server/app-rsc-response-finalizer

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -38,7 +38,6 @@ const middlewareRequestHeadersPath = resolveEntryPath(
 );
 const requestContextShimPath = resolveEntryPath("../shims/request-context.js", import.meta.url);
 const normalizePathModulePath = resolveEntryPath("../server/normalize-path.js", import.meta.url);
-const routingUtilsPath = resolveEntryPath("../routing/utils.js", import.meta.url);
 const appRouteHandlerDispatchPath = resolveEntryPath(
   "../server/app-route-handler-dispatch.js",
   import.meta.url,
@@ -104,6 +103,10 @@ const appRscErrorHandlerPath = resolveEntryPath(
 const appRequestContextPath = resolveEntryPath("../server/app-request-context.js", import.meta.url);
 const appHookWarningSuppressionPath = resolveEntryPath(
   "../server/app-hook-warning-suppression.js",
+  import.meta.url,
+);
+const appRscResponseFinalizerPath = resolveEntryPath(
+  "../server/app-rsc-response-finalizer.js",
   import.meta.url,
 );
 
@@ -221,10 +224,10 @@ import { handleMetadataRouteRequest as __handleMetadataRouteRequest } from ${JSO
 import { requestContextFromRequest, matchRedirect, matchRewrite, isExternalUrl, proxyExternalRequest, sanitizeDestination } from ${JSON.stringify(configMatchersPath)};
 import { normalizeRscRequest as __normalizeRscRequest } from ${JSON.stringify(appRscRequestNormalizationPath)};
 import { buildPostMwRequestContext } from ${JSON.stringify(appPostMiddlewareContextPath)};
-import { decodePathParams as __decodePathParams, normalizePath as __normalizePath } from ${JSON.stringify(normalizePathModulePath)};
-import { normalizePathnameForRouteMatch as __normalizePathnameForRouteMatch } from ${JSON.stringify(routingUtilsPath)};
+import { decodePathParams as __decodePathParams } from ${JSON.stringify(normalizePathModulePath)};
 import { buildRequestHeadersFromMiddlewareResponse as __buildRequestHeadersFromMiddlewareResponse } from ${JSON.stringify(middlewareRequestHeadersPath)};
-import { applyConfigHeadersToResponse, resolvePublicFileRoute, validateImageUrl, hasBasePath, normalizeTrailingSlash } from ${JSON.stringify(requestPipelinePath)};
+import { resolvePublicFileRoute, validateImageUrl, hasBasePath, normalizeTrailingSlash } from ${JSON.stringify(requestPipelinePath)};
+import { finalizeAppRscResponse as __finalizeAppRscResponse } from ${JSON.stringify(appRscResponseFinalizerPath)};
 import { applyAppMiddleware as __applyAppMiddleware } from ${JSON.stringify(appMiddlewarePath)};
 import {
   dispatchAppRouteHandler as __dispatchAppRouteHandler,
@@ -522,23 +525,11 @@ export default async function handler(request, ctx) {
       }
       throw err;
     }
-    // Apply custom headers from next.config.js to non-redirect responses.
-    // Skip redirects (3xx) because Response.redirect() creates immutable headers,
-    // and Next.js doesn't apply custom headers to redirects anyway.
-    if (response && response.headers && !(response.status >= 300 && response.status < 400)) {
-      if (__configHeaders.length) {
-        const url = new URL(request.url);
-        let pathname;
-        try { pathname = __normalizePath(__normalizePathnameForRouteMatch(url.pathname)); } catch { pathname = url.pathname; }
-        ${bp ? `if (pathname.startsWith(${JSON.stringify(bp)})) pathname = pathname.slice(${JSON.stringify(bp)}.length) || "/";` : ""}
-        applyConfigHeadersToResponse(response.headers, {
-          configHeaders: __configHeaders,
-          pathname,
-          requestContext: __reqCtx,
-        });
-      }
-    }
-    return response;
+    return __finalizeAppRscResponse(response, request, {
+      basePath: __basePath,
+      configHeaders: __configHeaders,
+      requestContext: __reqCtx,
+    });
     }, { route: () => new URL(request.url).pathname })
   );
 }

--- a/packages/vinext/src/server/app-rsc-response-finalizer.ts
+++ b/packages/vinext/src/server/app-rsc-response-finalizer.ts
@@ -1,0 +1,70 @@
+import type { NextHeader } from "../config/next-config.js";
+import type { RequestContext } from "../config/config-matchers.js";
+import { applyConfigHeadersToResponse } from "./request-pipeline.js";
+import { stripBasePath } from "../utils/base-path.js";
+import { normalizePath } from "./normalize-path.js";
+import { normalizePathnameForRouteMatch } from "../routing/utils.js";
+
+type FinalizeAppRscResponseOptions = {
+  basePath: string;
+  configHeaders: NextHeader[];
+  /**
+   * Original pre-middleware request context.
+   * Next.js evaluates config header has/missing conditions against the
+   * unmodified incoming request, so callers must pass the snapshot taken
+   * before middleware runs.
+   */
+  requestContext: RequestContext;
+};
+
+/**
+ * Apply next.config.js response headers to an App Router response.
+ *
+ * Called once per request in the outer handler() wrapper, after all route
+ * handling, so that every response path (page, route handler, server action,
+ * metadata, not-found) gets headers applied consistently.
+ *
+ * Skips 3xx redirect responses. Response.redirect() creates immutable
+ * headers that throw on mutation, and Next.js does not apply config headers
+ * to redirects regardless.
+ */
+export function finalizeAppRscResponse(
+  response: Response,
+  request: Request,
+  options: FinalizeAppRscResponseOptions,
+): Response {
+  // 3xx responses: Response.redirect() headers are immutable (throws on write),
+  // and Next.js deliberately excludes config headers from redirect responses.
+  if (response.status >= 300 && response.status < 400) {
+    return response;
+  }
+
+  if (!options.configHeaders.length) {
+    return response;
+  }
+
+  const url = new URL(request.url);
+  let pathname: string;
+  try {
+    pathname = normalizePath(normalizePathnameForRouteMatch(url.pathname));
+  } catch {
+    // Malformed percent-encoding. The request reached this point only because
+    // normalizePathnameForRouteMatchStrict ran earlier and returned 400 for
+    // truly-malformed paths. This catch exists as a safety net for edge cases;
+    // keep the historical raw-path fallback rather than crashing the response.
+    pathname = url.pathname;
+  }
+
+  // Config header sources are defined without basePath prefix. Strip basePath
+  // at a segment boundary (not a string prefix) so /app2/page with basePath
+  // /app is not incorrectly treated as /app with suffix /2/page.
+  pathname = stripBasePath(pathname, options.basePath);
+
+  applyConfigHeadersToResponse(response.headers, {
+    configHeaders: options.configHeaders,
+    pathname,
+    requestContext: options.requestContext,
+  });
+
+  return response;
+}

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -3512,7 +3512,7 @@ describe("App Router next.config.js features (generateRscEntry)", () => {
       headers: [{ source: "/api/(.*)", headers: [{ key: "X-Custom-Header", value: "vinext" }] }],
     });
     expect(code).toContain("__configHeaders");
-    expect(code).toContain("applyConfigHeadersToResponse");
+    expect(code).toContain("finalizeAppRscResponse");
     expect(code).toContain("X-Custom-Header");
     expect(code).toContain("vinext");
   });

--- a/tests/app-rsc-request-normalization.test.ts
+++ b/tests/app-rsc-request-normalization.test.ts
@@ -255,7 +255,6 @@ describe("normalizeRscRequest — interception context sanitization", () => {
     );
     expect(result.interceptionContextHeader).toBe("(..)/(.)slot/nested");
   });
-<<<<<<< HEAD
 
   it("strips null bytes from interception context header to prevent header injection", () => {
     // new Request() rejects \0 in header values, so construct a structural fake.

--- a/tests/app-rsc-request-normalization.test.ts
+++ b/tests/app-rsc-request-normalization.test.ts
@@ -255,6 +255,7 @@ describe("normalizeRscRequest — interception context sanitization", () => {
     );
     expect(result.interceptionContextHeader).toBe("(..)/(.)slot/nested");
   });
+<<<<<<< HEAD
 
   it("strips null bytes from interception context header to prevent header injection", () => {
     // new Request() rejects \0 in header values, so construct a structural fake.

--- a/tests/app-rsc-response-finalizer.test.ts
+++ b/tests/app-rsc-response-finalizer.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from "vite-plus/test";
+import { finalizeAppRscResponse } from "../packages/vinext/src/server/app-rsc-response-finalizer.js";
+import type { RequestContext } from "../packages/vinext/src/config/config-matchers.js";
+
+function makeRequestContext(headers: Headers = new Headers()): RequestContext {
+  return {
+    headers,
+    cookies: {},
+    query: new URLSearchParams(),
+    host: "example.com",
+  };
+}
+
+// ── config headers applied to non-redirect responses ────────────────────
+
+describe("finalizeAppRscResponse — config header application", () => {
+  it("applies a matching config header to a 200 response", () => {
+    // Behavior: /about page response gets x-added header from next.config.js headers[].
+    // Regression: expected null to be "config"
+    const response = new Response("body", { status: 200 });
+    const request = new Request("http://example.com/about");
+
+    finalizeAppRscResponse(response, request, {
+      basePath: "",
+      configHeaders: [{ source: "/about", headers: [{ key: "x-added", value: "config" }] }],
+      requestContext: makeRequestContext(),
+    });
+
+    expect(response.headers.get("x-added")).toBe("config");
+  });
+
+  it("does not apply config headers when none are configured", () => {
+    // Behavior: empty configHeaders list → response returned as-is with no mutation.
+    // Regression: unexpected header appears, or function throws.
+    const response = new Response("body", { status: 200, headers: { "x-existing": "keep" } });
+    const request = new Request("http://example.com/about");
+
+    const result = finalizeAppRscResponse(response, request, {
+      basePath: "",
+      configHeaders: [],
+      requestContext: makeRequestContext(),
+    });
+
+    expect(result).toBe(response);
+    expect(result.headers.get("x-existing")).toBe("keep");
+  });
+
+  it("does not apply config headers when source pattern does not match", () => {
+    // Behavior: /blog response is unaffected by a config header scoped to /about.
+    // Regression: expected "config" to be null.
+    const response = new Response("body", { status: 200 });
+    const request = new Request("http://example.com/blog");
+
+    finalizeAppRscResponse(response, request, {
+      basePath: "",
+      configHeaders: [{ source: "/about", headers: [{ key: "x-added", value: "config" }] }],
+      requestContext: makeRequestContext(),
+    });
+
+    expect(response.headers.get("x-added")).toBeNull();
+  });
+});
+
+// ── redirect responses skipped ──────────────────────────────────────────
+
+describe("finalizeAppRscResponse — redirect responses are not mutated", () => {
+  it("does not throw when called with an immutable 307 redirect response", () => {
+    // Behavior: Response.redirect() creates immutable headers; calling finalizeAppRscResponse
+    // on such a response must never throw "Cannot modify immutable headers".
+    // Regression: TypeError: Cannot modify immutable headers
+    const response = Response.redirect("http://example.com/new", 307);
+    const request = new Request("http://example.com/old");
+
+    expect(() =>
+      finalizeAppRscResponse(response, request, {
+        basePath: "",
+        configHeaders: [{ source: "/old", headers: [{ key: "x-added", value: "yes" }] }],
+        requestContext: makeRequestContext(),
+      }),
+    ).not.toThrow();
+  });
+
+  it("does not apply config headers to a mutable 308 permanent redirect", () => {
+    // Behavior: 308 redirect responses skip config header application regardless of mutability.
+    // Regression: expected "yes" to be null — header applied to redirect response.
+    const response = new Response(null, { status: 308, headers: { Location: "/new" } });
+    const request = new Request("http://example.com/old");
+
+    finalizeAppRscResponse(response, request, {
+      basePath: "",
+      configHeaders: [{ source: "/old", headers: [{ key: "x-added", value: "yes" }] }],
+      requestContext: makeRequestContext(),
+    });
+
+    expect(response.headers.get("x-added")).toBeNull();
+  });
+});
+
+// ── basePath stripping ──────────────────────────────────────────────────
+
+describe("finalizeAppRscResponse — basePath stripping before pattern matching", () => {
+  it("strips basePath before matching config header source patterns", () => {
+    // Behavior: config header source "/about" applies to request "/app/about" when basePath="/app".
+    // Regression: expected null to be "config" — header not matched because /app/about ≠ /about.
+    const response = new Response("body", { status: 200 });
+    const request = new Request("http://example.com/app/about");
+
+    finalizeAppRscResponse(response, request, {
+      basePath: "/app",
+      configHeaders: [{ source: "/about", headers: [{ key: "x-added", value: "config" }] }],
+      requestContext: makeRequestContext(),
+    });
+
+    expect(response.headers.get("x-added")).toBe("config");
+  });
+
+  it("does not strip basePath when pathname only shares a string prefix (segment boundary)", () => {
+    // Behavior: /app2/page with basePath /app must not strip /app, because /app2 is a
+    // different path segment. The config header source "/2/page" must not match.
+    // Regression: expected "yes" to be null — basePath incorrectly stripped past segment
+    // boundary, turning /app2/page into /2/page which then matched the source.
+    const response = new Response("body", { status: 200 });
+    const request = new Request("http://example.com/app2/page");
+
+    finalizeAppRscResponse(response, request, {
+      basePath: "/app",
+      configHeaders: [{ source: "/2/page", headers: [{ key: "x-wrong-strip", value: "yes" }] }],
+      requestContext: makeRequestContext(),
+    });
+
+    expect(response.headers.get("x-wrong-strip")).toBeNull();
+  });
+
+  it("strips nested basePath correctly", () => {
+    // Behavior: config header source "/guide" applies to /docs/v2/guide when basePath="/docs/v2".
+    // Regression: expected null to be "config".
+    const response = new Response("body", { status: 200 });
+    const request = new Request("http://example.com/docs/v2/guide");
+
+    finalizeAppRscResponse(response, request, {
+      basePath: "/docs/v2",
+      configHeaders: [{ source: "/guide", headers: [{ key: "x-added", value: "config" }] }],
+      requestContext: makeRequestContext(),
+    });
+
+    expect(response.headers.get("x-added")).toBe("config");
+  });
+});
+
+// ── request context snapshot ────────────────────────────────────────────
+
+describe("finalizeAppRscResponse — has/missing conditions use original request context", () => {
+  it("applies header only when has-condition matches the provided request context", () => {
+    // Behavior: config header with has[type=header] applies only when the original request
+    // carries the expected header. The requestContext is the pre-middleware snapshot.
+    // Regression: header applied unconditionally (requestContext ignored).
+    const response = new Response("body", { status: 200 });
+    const request = new Request("http://example.com/about");
+    const reqCtxWithFlag = makeRequestContext(new Headers({ "x-preview": "1" }));
+
+    finalizeAppRscResponse(response, request, {
+      basePath: "",
+      configHeaders: [
+        {
+          source: "/about",
+          has: [{ type: "header", key: "x-preview", value: "1" }],
+          headers: [{ key: "x-conditional", value: "yes" }],
+        },
+      ],
+      requestContext: reqCtxWithFlag,
+    });
+
+    expect(response.headers.get("x-conditional")).toBe("yes");
+  });
+
+  it("does not apply header when has-condition does not match the request context", () => {
+    // Behavior: header skipped when the has-condition fails for the original request.
+    // Regression: expected "yes" to be null — condition bypassed.
+    const response = new Response("body", { status: 200 });
+    const request = new Request("http://example.com/about");
+
+    finalizeAppRscResponse(response, request, {
+      basePath: "",
+      configHeaders: [
+        {
+          source: "/about",
+          has: [{ type: "header", key: "x-preview", value: "1" }],
+          headers: [{ key: "x-conditional", value: "yes" }],
+        },
+      ],
+      requestContext: makeRequestContext(), // no x-preview header
+    });
+
+    expect(response.headers.get("x-conditional")).toBeNull();
+  });
+});


### PR DESCRIPTION
Based on #1034
## What this changes

Extracts the App Router response finalisation step from an inline template string in the generated `handler()` function into a dedicated typed module: `server/app-rsc-response-finalizer.ts`.

The extracted module owns:
- Skipping 3xx redirect responses. [`Response.redirect()`](https://developer.mozilla.org/en-US/docs/Web/API/Response/redirect_static) creates immutable `Headers` that throw `TypeError: Cannot modify immutable headers` on write. [Next.js also excludes config headers from redirects](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/app-render.tsx).
- Segment-wise pathname normalisation before pattern matching (decode + collapse).
- basePath stripping at a **segment boundary** before matching config header sources.
- Applying matched config headers via `applyConfigHeadersToResponse` without overwriting middleware-set headers.

The generated entry is reduced to a single delegation call.

## Why

Every response variant (page, route handler, server action, metadata, not-found) passes through `handler()`. The shared finalisation logic lived in a template string with no direct tests and no reuse path. Per the architecture rule: codegen describes app shape; normal modules implement behaviour.

**Bug fixed in the same change:** the inline basePath strip used `pathname.startsWith(basePath)`, which is a string-prefix match. `/app2/page` with `basePath=/app` would be incorrectly stripped to `/2/page`, potentially causing wrong config headers to apply. `stripBasePath()` enforces a path-separator boundary.

Refs #1020.

## Approach

New module imports from existing typed helpers only:
- `applyConfigHeadersToResponse` from `server/request-pipeline.ts` ([source](https://github.com/NathanDrake2406/vinext/blob/main/packages/vinext/src/server/request-pipeline.ts#L166))
- `stripBasePath` from `utils/base-path.ts` for segment-boundary correctness
- `normalizePath` + `normalizePathnameForRouteMatch` for pathname normalisation

Generated entry drops two imports (`applyConfigHeadersToResponse`, `normalizePathnameForRouteMatch`) that are now internal to the helper.

## Validation

New test file `tests/app-rsc-response-finalizer.test.ts` — 10 tests covering:
- Header applied to 200 response
- `configHeaders: []` is a no-op (returns same response object)
- Source pattern miss leaves response untouched
- Immutable 307 (`Response.redirect()`) does not throw
- Mutable 308 response does not get config headers applied
- basePath stripped before source matching
- basePath segment-boundary correctness (regression for the `startsWith` bug)
- Nested basePath stripped correctly
- `has`-condition match applies header
- `has`-condition miss skips header

Entry template snapshot updated automatically by pre-commit hook. `vp check` clean.

## Risks / follow-ups

- `mergeMiddlewareResponseHeaders` in the plain-text 404 path inside `_handleRequest` is not yet moved; that path is simpler and lower risk. Can be a follow-up if desired.
- The module currently has one caller (the generated App Router entry). The Pages Router production server (`server/prod-server.ts`) has its own header finalisation path that is separately out of scope for this PR.