### PR TITLE
fix: validate CLI --port / --hostname values, reject missing/flags-as-values

### DIFF
--- a/packages/vinext/src/cli-args.ts
+++ b/packages/vinext/src/cli-args.ts
@@ -1,0 +1,147 @@
+/**
+ * CLI argument parser for the vinext CLI.
+ *
+ * Parses flags for `vinext dev`, `vinext start`, `vinext build`, etc.
+ * Validates that value-taking flags (`--port`, `--hostname`) have actual values
+ * rather than silently consuming the next flag or returning NaN/undefined.
+ */
+
+type ParsedArgs = {
+  port?: number;
+  hostname?: string;
+  help?: boolean;
+  verbose?: boolean;
+  turbopack?: boolean;
+  experimental?: boolean;
+  prerenderAll?: boolean;
+  precompress?: boolean;
+};
+
+// Matches long flags (--foo) and single-letter short flags (-x).
+// Digits and multi-char sequences (e.g. -1, -abc) are excluded by [a-zA-Z] and $.
+const FLAG_PATTERN = /^(?:--|-[a-zA-Z]$)/;
+
+/**
+ * Consume the next positional argument as a value for a flag.
+ *
+ * Throws if:
+ * - No argument follows (end of argv)
+ * - The value is an empty string
+ * - The next argument is another flag (--long or -x short form)
+ */
+function takeValue(flag: string, args: string[], i: number): string {
+  const next = args[i + 1];
+  if (next === undefined || next === "") {
+    throw new Error(`${flag} requires a value, but none was provided.`);
+  }
+  if (FLAG_PATTERN.test(next)) {
+    throw new Error(`${flag} requires a value, but got "${next}" which looks like another flag.`);
+  }
+  return next;
+}
+
+/**
+ * Try to extract a value from `--flag=value` form.
+ * Returns the raw value, or null if the arg doesn't match this flag's = form.
+ */
+function tryEqualsForm(arg: string, flagName: string): string | null {
+  const prefix = `--${flagName}=`;
+  return arg.startsWith(prefix) ? arg.slice(prefix.length) : null;
+}
+
+/**
+ * Parse a port string into a valid TCP port number (0-65535).
+ *
+ * Uses `Number()` instead of `parseInt()` so that trailing garbage
+ * (`4000abc`) is rejected rather than silently truncated to 4000.
+ */
+function parsePort(raw: string, flag: string): number {
+  if (raw === "") {
+    throw new Error(`${flag} requires a value, but none was provided.`);
+  }
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed)) {
+    throw new Error(`${flag} expects an integer, but got "${raw}".`);
+  }
+  if (parsed < 0 || parsed > 65535) {
+    throw new Error(`${flag} expects a valid port (0-65535), but got "${raw}".`);
+  }
+  return parsed;
+}
+
+/**
+ * Parse CLI arguments into a structured object.
+ *
+ * Handles both `--flag value` and `--flag=value` forms for value-taking flags.
+ *
+ * Used by `vinext dev`, `build`, `start`, `lint`, `check`, and `init` commands.
+ * The `deploy` command uses `parseDeployArgs` (a `node:util` wrapper) for its
+ * own flag set including `--env`, `--skip-build`, etc.
+ */
+export function parseArgs(args: string[]): ParsedArgs {
+  const result: ParsedArgs = {};
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+
+    switch (arg) {
+      case "--help":
+      case "-h":
+        result.help = true;
+        break;
+
+      case "--verbose":
+        result.verbose = true;
+        break;
+
+      case "--turbopack":
+        result.turbopack = true;
+        break;
+
+      case "--experimental-https":
+        result.experimental = true;
+        break;
+
+      case "--prerender-all":
+        result.prerenderAll = true;
+        break;
+
+      case "--precompress":
+        result.precompress = true;
+        break;
+
+      case "--port":
+      case "-p": {
+        const raw = takeValue(arg, args, i);
+        i++;
+        result.port = parsePort(raw, arg);
+        break;
+      }
+
+      case "--hostname":
+      case "-H": {
+        result.hostname = takeValue(arg, args, i);
+        i++;
+        break;
+      }
+
+      default: {
+        // Handle --flag=value forms (e.g. --port=3000, --hostname=0.0.0.0).
+        const eqRaw = tryEqualsForm(arg, "port");
+        if (eqRaw !== null) {
+          result.port = parsePort(eqRaw, "--port");
+          break;
+        }
+        const hostRaw = tryEqualsForm(arg, "hostname");
+        if (hostRaw !== null) {
+          if (hostRaw === "") {
+            throw new Error(`--hostname requires a value, but none was provided.`);
+          }
+          result.hostname = hostRaw;
+          break;
+        }
+        break;
+      }
+    }
+  }
+  return result;
+}

--- a/packages/vinext/src/cli.ts
+++ b/packages/vinext/src/cli.ts
@@ -29,6 +29,7 @@ import { loadDotenv } from "./config/dotenv.js";
 import { loadNextConfig, resolveNextConfig, PHASE_PRODUCTION_BUILD } from "./config/next-config.js";
 import { emitStandaloneOutput } from "./build/standalone.js";
 import { resolveVinextPackageRoot } from "./utils/vinext-root.js";
+import { parseArgs } from "./cli-args.js";
 
 // ─── Resolve Vite from the project root ────────────────────────────────────────
 //
@@ -92,47 +93,6 @@ const VERSION = JSON.parse(fs.readFileSync(new URL("../package.json", import.met
 
 const command = process.argv[2];
 const rawArgs = process.argv.slice(3);
-
-type ParsedArgs = {
-  port?: number;
-  hostname?: string;
-  help?: boolean;
-  verbose?: boolean;
-  turbopack?: boolean; // accepted for compat, always ignored
-  experimental?: boolean; // accepted for compat, always ignored
-  prerenderAll?: boolean;
-  precompress?: boolean;
-};
-
-function parseArgs(args: string[]): ParsedArgs {
-  const result: ParsedArgs = {};
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i];
-    if (arg === "--help" || arg === "-h") {
-      result.help = true;
-    } else if (arg === "--verbose") {
-      result.verbose = true;
-    } else if (arg === "--turbopack") {
-      result.turbopack = true; // no-op, accepted for script compat
-    } else if (arg === "--experimental-https") {
-      result.experimental = true; // no-op
-    } else if (arg === "--prerender-all") {
-      result.prerenderAll = true;
-    } else if (arg === "--precompress") {
-      result.precompress = true;
-      process.env.VINEXT_PRECOMPRESS = "1";
-    } else if (arg === "--port" || arg === "-p") {
-      result.port = parseInt(args[++i], 10);
-    } else if (arg.startsWith("--port=")) {
-      result.port = parseInt(arg.split("=")[1], 10);
-    } else if (arg === "--hostname" || arg === "-H") {
-      result.hostname = args[++i];
-    } else if (arg.startsWith("--hostname=")) {
-      result.hostname = arg.split("=")[1];
-    }
-  }
-  return result;
-}
 
 // ─── Build logger ─────────────────────────────────────────────────────────────
 
@@ -353,6 +313,10 @@ async function dev() {
 async function buildApp() {
   const parsed = parseArgs(rawArgs);
   if (parsed.help) return printHelp("build");
+
+  if (parsed.precompress) {
+    process.env.VINEXT_PRECOMPRESS = "1";
+  }
 
   loadDotenv({
     root: process.cwd(),

--- a/tests/cli-args.test.ts
+++ b/tests/cli-args.test.ts
@@ -1,0 +1,247 @@
+/**
+ * CLI argument parser tests.
+ *
+ * Tests the parseArgs function extracted from cli.ts, validating that:
+ *  - Value-taking flags (`--port`, `--hostname`) error on missing values
+ *  - Value-taking flags error when the next arg is another flag
+ *  - `--port` uses strict integer parsing (Number, not parseInt) and range checks
+ *  - `--flag=value` forms work correctly
+ *  - Boolean flags work as expected
+ *  - Both long and short forms (`--port`/`-p`, `--hostname`/`-H`) are handled
+ */
+import { describe, it, expect } from "vite-plus/test";
+import { parseArgs } from "../packages/vinext/src/cli-args.js";
+
+// ─── Boolean flags ──────────────────────────────────────────────────────────
+
+describe("boolean flags", () => {
+  it("sets help for --help", () => {
+    expect(parseArgs(["--help"])).toMatchObject({ help: true });
+  });
+
+  it("sets help for -h", () => {
+    expect(parseArgs(["-h"])).toMatchObject({ help: true });
+  });
+
+  it("sets verbose", () => {
+    expect(parseArgs(["--verbose"])).toMatchObject({ verbose: true });
+  });
+
+  it("sets turbopack", () => {
+    expect(parseArgs(["--turbopack"])).toMatchObject({ turbopack: true });
+  });
+
+  it("sets experimental for --experimental-https", () => {
+    expect(parseArgs(["--experimental-https"])).toMatchObject({ experimental: true });
+  });
+
+  it("sets prerenderAll for --prerender-all", () => {
+    expect(parseArgs(["--prerender-all"])).toMatchObject({ prerenderAll: true });
+  });
+
+  it("sets precompress for --precompress", () => {
+    expect(parseArgs(["--precompress"])).toMatchObject({ precompress: true });
+  });
+});
+
+// ─── --port flag ────────────────────────────────────────────────────────────
+
+describe("--port / -p", () => {
+  it("parses a numeric port value", () => {
+    expect(parseArgs(["--port", "4000"])).toMatchObject({ port: 4000 });
+  });
+
+  it("parses -p short form", () => {
+    expect(parseArgs(["-p", "4000"])).toMatchObject({ port: 4000 });
+  });
+
+  it("parses --port=value form", () => {
+    expect(parseArgs(["--port=8080"])).toMatchObject({ port: 8080 });
+  });
+
+  it("parses port zero", () => {
+    expect(parseArgs(["--port", "0"])).toMatchObject({ port: 0 });
+  });
+
+  it("parses port 65535 (max valid)", () => {
+    expect(parseArgs(["--port", "65535"])).toMatchObject({ port: 65535 });
+  });
+
+  // ─── Error: missing value ─────────────────────────────────────────────────
+
+  it("throws when --port has no value (end of args)", () => {
+    expect(() => parseArgs(["--port"])).toThrow("--port requires a value, but none was provided.");
+  });
+
+  it("throws when -p has no value (end of args)", () => {
+    expect(() => parseArgs(["-p"])).toThrow("-p requires a value, but none was provided.");
+  });
+
+  it("throws when --port value is another flag", () => {
+    expect(() => parseArgs(["--port", "--hostname", "0.0.0.0"])).toThrow(
+      '--port requires a value, but got "--hostname" which looks like another flag.',
+    );
+  });
+
+  it("throws when -p value is another flag", () => {
+    expect(() => parseArgs(["-p", "-H", "0.0.0.0"])).toThrow(
+      '-p requires a value, but got "-H" which looks like another flag.',
+    );
+  });
+
+  // ─── Error: invalid value ─────────────────────────────────────────────────
+
+  it("throws for non-numeric port", () => {
+    expect(() => parseArgs(["--port", "abc"])).toThrow('--port expects an integer, but got "abc".');
+  });
+
+  it("throws for --port= with non-numeric value", () => {
+    expect(() => parseArgs(["--port=abc"])).toThrow('--port expects an integer, but got "abc".');
+  });
+
+  it("throws for empty string port", () => {
+    expect(() => parseArgs(["--port", ""])).toThrow(
+      "--port requires a value, but none was provided.",
+    );
+  });
+
+  it("throws for trailing garbage (Number is strict where parseInt is not)", () => {
+    expect(() => parseArgs(["--port", "4000abc"])).toThrow(
+      '--port expects an integer, but got "4000abc".',
+    );
+  });
+
+  it("throws for float port", () => {
+    expect(() => parseArgs(["--port", "4000.5"])).toThrow(
+      '--port expects an integer, but got "4000.5".',
+    );
+  });
+
+  // ─── Error: out of range ──────────────────────────────────────────────────
+
+  it("throws for negative port", () => {
+    expect(() => parseArgs(["--port", "-1"])).toThrow(
+      '--port expects a valid port (0-65535), but got "-1".',
+    );
+  });
+
+  it("throws for port above 65535", () => {
+    expect(() => parseArgs(["--port", "65536"])).toThrow(
+      '--port expects a valid port (0-65535), but got "65536".',
+    );
+  });
+
+  it("throws for --port= with negative value", () => {
+    expect(() => parseArgs(["--port=-1"])).toThrow(
+      '--port expects a valid port (0-65535), but got "-1".',
+    );
+  });
+});
+
+// ─── --hostname flag ────────────────────────────────────────────────────────
+
+describe("--hostname / -H", () => {
+  it("parses a hostname value", () => {
+    expect(parseArgs(["--hostname", "0.0.0.0"])).toMatchObject({ hostname: "0.0.0.0" });
+  });
+
+  it("parses -H short form", () => {
+    expect(parseArgs(["-H", "localhost"])).toMatchObject({ hostname: "localhost" });
+  });
+
+  it("parses --hostname=value form", () => {
+    expect(parseArgs(["--hostname=0.0.0.0"])).toMatchObject({ hostname: "0.0.0.0" });
+  });
+
+  // ─── Error: missing value ─────────────────────────────────────────────────
+
+  it("throws when --hostname has no value (end of args)", () => {
+    expect(() => parseArgs(["--hostname"])).toThrow(
+      "--hostname requires a value, but none was provided.",
+    );
+  });
+
+  it("throws when -H has no value (end of args)", () => {
+    expect(() => parseArgs(["-H"])).toThrow("-H requires a value, but none was provided.");
+  });
+
+  it("throws when --hostname value is another flag", () => {
+    expect(() => parseArgs(["--hostname", "--port", "3000"])).toThrow(
+      '--hostname requires a value, but got "--port" which looks like another flag.',
+    );
+  });
+
+  it("throws when --hostname value is a short flag", () => {
+    expect(() => parseArgs(["--hostname", "-p"])).toThrow(
+      '--hostname requires a value, but got "-p" which looks like another flag.',
+    );
+  });
+
+  it("throws when --hostname= has empty value", () => {
+    expect(() => parseArgs(["--hostname="])).toThrow(
+      "--hostname requires a value, but none was provided.",
+    );
+  });
+
+  it("throws when --hostname value is empty string (space-separated)", () => {
+    expect(() => parseArgs(["--hostname", ""])).toThrow(
+      "--hostname requires a value, but none was provided.",
+    );
+  });
+
+  it("throws when -H value is empty string", () => {
+    expect(() => parseArgs(["-H", ""])).toThrow("-H requires a value, but none was provided.");
+  });
+});
+
+// ─── Combined flags ─────────────────────────────────────────────────────────
+
+describe("combined flags", () => {
+  it("parses port and hostname together", () => {
+    expect(parseArgs(["--port", "4000", "--hostname", "0.0.0.0"])).toMatchObject({
+      port: 4000,
+      hostname: "0.0.0.0",
+    });
+  });
+
+  it("parses short forms together", () => {
+    expect(parseArgs(["-p", "4000", "-H", "localhost"])).toMatchObject({
+      port: 4000,
+      hostname: "localhost",
+    });
+  });
+
+  it("parses =value forms together", () => {
+    expect(parseArgs(["--port=4000", "--hostname=0.0.0.0"])).toMatchObject({
+      port: 4000,
+      hostname: "0.0.0.0",
+    });
+  });
+
+  it("parses boolean flags alongside value flags", () => {
+    expect(parseArgs(["--verbose", "--port", "4000", "--hostname", "localhost"])).toMatchObject({
+      verbose: true,
+      port: 4000,
+      hostname: "localhost",
+    });
+  });
+});
+
+// ─── Edge cases ─────────────────────────────────────────────────────────────
+
+describe("edge cases", () => {
+  it("returns empty object for empty args", () => {
+    expect(parseArgs([])).toEqual({});
+  });
+
+  it("skips duplicate --port (last wins)", () => {
+    expect(parseArgs(["--port", "3000", "--port", "4000"])).toMatchObject({ port: 4000 });
+  });
+
+  it("skips unrecognized flags", () => {
+    const result = parseArgs(["--unknown", "value"]);
+    expect(result).not.toHaveProperty("unknown");
+    expect(result).not.toHaveProperty("port");
+    expect(result).not.toHaveProperty("hostname");
+  });
+});


### PR DESCRIPTION
Fixes #1012

## Summary
The vinext CLI argument parser silently consumed missing values for --port / -p and --hostname / -H flags, causing:
1. NaN port → random ephemeral bind
2. Undefined hostname → fallback to localhost
3. Flag-eating typos where --hostname is consumed as a port value

This change adds validation that throws clear, actionable errors.

### What changed
- Extracted parseArgs to cli-args.ts module for testability
- Added takeValue() validation rejecting missing values and flags-as-values
- Added integer validation for --port
- Moved --precompress env var side effect into buildApp call site
- 33 unit tests in tests/cli-args.test.ts

### Behavior parity
Next.js CLI uses similar validation via [next/src/cli/next-dev.ts](https://github.com/vercel/next.js/blob/canary/packages/next/src/cli/next-dev.ts). Error messages follow the standard flag-requires-a-value convention.

## Test plan
33 tests covering: missing value at end of args, flag consumed as value, non-numeric port, long/short forms, =value forms, boolean flags, combined flags, edge cases.