### PR TITLE
fix(dev): self-host Google Fonts in dev mode

### DIFF
--- a/packages/vinext/src/plugins/fonts.ts
+++ b/packages/vinext/src/plugins/fonts.ts
@@ -30,6 +30,7 @@ import MagicString from "magic-string";
 import { validateGoogleFontOptions } from "../build/google-fonts/validate.js";
 import { getFontAxes } from "../build/google-fonts/get-axes.js";
 import { buildGoogleFontsUrl } from "../build/google-fonts/build-url.js";
+import { CONTENT_TYPES } from "../server/static-file-cache.js";
 
 /**
  * Thrown when Google Fonts returns a non-2xx response. Distinct from a raw
@@ -641,7 +642,6 @@ export function _findCallEnd(code: string, objEnd: number): number | null {
 export function createGoogleFontsPlugin(fontGoogleShimPath: string, shimsDir: string): Plugin {
   // Vite does not bind `this` to the plugin object when calling hooks, so
   // plugin state must be held in closure variables rather than as properties.
-  let isBuild = false;
   const fontCache = new Map<string, string>(); // url -> local @font-face CSS
   let cacheDir = "";
 
@@ -650,8 +650,52 @@ export function createGoogleFontsPlugin(fontGoogleShimPath: string, shimsDir: st
     enforce: "pre",
 
     configResolved(config) {
-      isBuild = config.command === "build";
       cacheDir = path.join(config.root, ".vinext", "fonts");
+    },
+
+    // Dev-mode equivalent of the production `writeBundle` copy step. In dev
+    // there is no client output directory to copy files into, so the cached
+    // .vinext/fonts/ tree is served directly under the same URL prefix that
+    // `_rewriteCachedFontCssToServedUrls()` embeds into the @font-face CSS
+    // (`/<assetsDir>/_vinext_fonts/...`). Without this hook the rewritten
+    // URLs 404 — and once `_selfHostedCSS` is injected, the shim no longer
+    // emits the fonts.googleapis.com `<link>`, so a 404 here means no
+    // glyphs render at all (no CDN fallback path).
+    configureServer(server) {
+      if (!cacheDir) return;
+      const assetsDir =
+        server.environments?.client?.config?.build?.assetsDir ??
+        server.config?.build?.assetsDir ??
+        DEFAULT_ASSETS_DIR;
+      const urlPrefix = `/${assetsDir}/${VINEXT_FONT_URL_NAMESPACE}/`;
+      server.middlewares.use((req, res, next) => {
+        const url = req.url;
+        if (!url || !url.startsWith(urlPrefix)) return next();
+        const rawPath = url.slice(urlPrefix.length).split("?")[0];
+        let decoded: string;
+        try {
+          decoded = decodeURIComponent(rawPath);
+        } catch {
+          return next();
+        }
+        const filePath = path.resolve(cacheDir, decoded);
+        // Path traversal guard — `decoded` came from the URL, so refuse
+        // anything that escapes the cache root (e.g. `..%2F..%2Fetc/passwd`).
+        if (filePath !== cacheDir && !filePath.startsWith(cacheDir + path.sep)) {
+          return next();
+        }
+        fs.stat(filePath, (err, stat) => {
+          if (err || !stat.isFile()) return next();
+          const ext = path.extname(filePath).toLowerCase();
+          // CONTENT_TYPES is the same map prod-server uses, so fonts get
+          // identical MIME types in dev and prod. fetchAndCacheFont only
+          // ever writes .woff2/.woff/.ttf, all of which are covered.
+          res.setHeader("Content-Type", CONTENT_TYPES[ext] ?? "application/octet-stream");
+          res.setHeader("Cache-Control", "no-cache");
+          res.setHeader("Access-Control-Allow-Origin", "*");
+          fs.createReadStream(filePath).pipe(res);
+        });
+      });
     },
 
     transform: {
@@ -887,68 +931,72 @@ export function createGoogleFontsPlugin(fontGoogleShimPath: string, shimsDir: st
           hasChanges = true;
         }
 
-        if (isBuild) {
-          // Match: Identifier( — where the argument starts with {
-          // The regex intentionally does NOT capture the options object; we use
-          // _findBalancedObject() to handle nested braces correctly.
-          const namedCallRe = /\b([A-Za-z_$][A-Za-z0-9_$]*)\s*\(\s*(?=\{)/g;
-          let namedCallMatch;
-          while ((namedCallMatch = namedCallRe.exec(code)) !== null) {
-            const [fullMatch, localName] = namedCallMatch;
-            const importedName = fontLocals.get(localName);
-            if (!importedName) continue;
+        // Self-host injection runs in both dev and build. In dev, the
+        // companion `configureServer` hook serves the cached files
+        // directly from `.vinext/fonts/` so the rewritten URLs resolve
+        // against the dev origin; in build, the `writeBundle` hook copies
+        // them into the client output directory.
 
-            const callStart = namedCallMatch.index;
-            // The regex consumed up to (but not including) the '{' due to the
-            // lookahead — find the balanced object starting at the lookahead pos.
-            const openParenEnd = callStart + fullMatch.length;
-            const objRange = _findBalancedObject(code, openParenEnd);
-            if (!objRange) continue;
-            const optionsStr = code.slice(objRange[0], objRange[1]);
-            const callEnd = _findCallEnd(code, objRange[1]);
-            if (callEnd === null) continue;
+        // Match: Identifier( — where the argument starts with {
+        // The regex intentionally does NOT capture the options object; we use
+        // _findBalancedObject() to handle nested braces correctly.
+        const namedCallRe = /\b([A-Za-z_$][A-Za-z0-9_$]*)\s*\(\s*(?=\{)/g;
+        let namedCallMatch;
+        while ((namedCallMatch = namedCallRe.exec(code)) !== null) {
+          const [fullMatch, localName] = namedCallMatch;
+          const importedName = fontLocals.get(localName);
+          if (!importedName) continue;
 
-            if (overwrittenRanges.some(([start, end]) => callStart < end && callEnd > start)) {
-              continue;
-            }
+          const callStart = namedCallMatch.index;
+          // The regex consumed up to (but not including) the '{' due to the
+          // lookahead — find the balanced object starting at the lookahead pos.
+          const openParenEnd = callStart + fullMatch.length;
+          const objRange = _findBalancedObject(code, openParenEnd);
+          if (!objRange) continue;
+          const optionsStr = code.slice(objRange[0], objRange[1]);
+          const callEnd = _findCallEnd(code, objRange[1]);
+          if (callEnd === null) continue;
 
-            await injectSelfHostedCss(
-              callStart,
-              callEnd,
-              optionsStr,
-              importedName.replace(/_/g, " "),
-              localName,
-            );
+          if (overwrittenRanges.some(([start, end]) => callStart < end && callEnd > start)) {
+            continue;
           }
 
-          // Match: Identifier.Identifier( — where the argument starts with {
-          const memberCallRe =
-            /\b([A-Za-z_$][A-Za-z0-9_$]*)\.([A-Za-z_$][A-Za-z0-9_$]*)\s*\(\s*(?=\{)/g;
-          let memberCallMatch;
-          while ((memberCallMatch = memberCallRe.exec(code)) !== null) {
-            const [fullMatch, objectName, propName] = memberCallMatch;
-            if (!proxyObjectLocals.has(objectName)) continue;
+          await injectSelfHostedCss(
+            callStart,
+            callEnd,
+            optionsStr,
+            importedName.replace(/_/g, " "),
+            localName,
+          );
+        }
 
-            const callStart = memberCallMatch.index;
-            const openParenEnd = callStart + fullMatch.length;
-            const objRange = _findBalancedObject(code, openParenEnd);
-            if (!objRange) continue;
-            const optionsStr = code.slice(objRange[0], objRange[1]);
-            const callEnd = _findCallEnd(code, objRange[1]);
-            if (callEnd === null) continue;
+        // Match: Identifier.Identifier( — where the argument starts with {
+        const memberCallRe =
+          /\b([A-Za-z_$][A-Za-z0-9_$]*)\.([A-Za-z_$][A-Za-z0-9_$]*)\s*\(\s*(?=\{)/g;
+        let memberCallMatch;
+        while ((memberCallMatch = memberCallRe.exec(code)) !== null) {
+          const [fullMatch, objectName, propName] = memberCallMatch;
+          if (!proxyObjectLocals.has(objectName)) continue;
 
-            if (overwrittenRanges.some(([start, end]) => callStart < end && callEnd > start)) {
-              continue;
-            }
+          const callStart = memberCallMatch.index;
+          const openParenEnd = callStart + fullMatch.length;
+          const objRange = _findBalancedObject(code, openParenEnd);
+          if (!objRange) continue;
+          const optionsStr = code.slice(objRange[0], objRange[1]);
+          const callEnd = _findCallEnd(code, objRange[1]);
+          if (callEnd === null) continue;
 
-            await injectSelfHostedCss(
-              callStart,
-              callEnd,
-              optionsStr,
-              propertyNameToGoogleFontFamily(propName),
-              `${objectName}.${propName}`,
-            );
+          if (overwrittenRanges.some(([start, end]) => callStart < end && callEnd > start)) {
+            continue;
           }
+
+          await injectSelfHostedCss(
+            callStart,
+            callEnd,
+            optionsStr,
+            propertyNameToGoogleFontFamily(propName),
+            `${objectName}.${propName}`,
+          );
         }
 
         if (!hasChanges) return null;

--- a/tests/e2e/app-router/font-google.spec.ts
+++ b/tests/e2e/app-router/font-google.spec.ts
@@ -1,0 +1,15 @@
+import { test, expect } from "@playwright/test";
+
+test("dev mode self-hosts Google fonts", async ({ page, request }) => {
+  await page.goto("/font-google-test");
+  const html = await page.content();
+  expect(html).not.toContain("fonts.googleapis.com");
+  expect(html).toMatch(/<style data-vinext-fonts/);
+
+  const m = html.match(/href="(\/[^"]*_vinext_fonts\/[^"]+\.woff2)"/);
+  expect(m).not.toBeNull();
+  const res = await request.get(m![1]);
+  expect(res.status()).toBe(200);
+  expect(res.headers()["content-type"]).toBe("font/woff2");
+  expect((await res.body()).byteLength).toBeGreaterThan(1000);
+});

--- a/tests/fixtures/app-basic/app/font-google-test/layout.tsx
+++ b/tests/fixtures/app-basic/app/font-google-test/layout.tsx
@@ -1,0 +1,19 @@
+import { Geist, Geist_Mono } from "next/font/google";
+
+const geistSans = Geist({
+  variable: "--font-geist-sans",
+  subsets: ["latin"],
+});
+
+const geistMono = Geist_Mono({
+  variable: "--font-geist-mono",
+  subsets: ["latin"],
+});
+
+export default function FontGoogleTestLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className={`${geistSans.variable} ${geistMono.variable}`} data-font-google-test>
+      {children}
+    </div>
+  );
+}

--- a/tests/fixtures/app-basic/app/font-google-test/page.tsx
+++ b/tests/fixtures/app-basic/app/font-google-test/page.tsx
@@ -1,0 +1,8 @@
+export default function FontGoogleTestPage() {
+  return (
+    <main>
+      <h1>Font Google Test</h1>
+      <p>Self-hosted Geist + Geist_Mono regression page.</p>
+    </main>
+  );
+}

--- a/tests/font-google.test.ts
+++ b/tests/font-google.test.ts
@@ -422,10 +422,16 @@ describe("vinext:google-fonts plugin", () => {
   });
 
   it("rewrites named font imports in dev mode", async () => {
+    // Verifies the import-rewrite path runs in `command: "serve"` (it gates
+    // on the transform filter, not on the build mode). The constructor-call
+    // self-hosting branch also runs in dev now — covered separately by the
+    // Playwright spec under tests/e2e/font-google/ — so this unit test
+    // intentionally omits a constructor call to keep the assertion focused
+    // on the import shape and avoid coupling to a network fetch.
     const plugin = getGoogleFontsPlugin();
     initPlugin(plugin, { command: "serve" });
     const transform = unwrapHook(plugin.transform);
-    const code = `import { Inter } from 'next/font/google';\nconst inter = Inter({ weight: ['400'] });`;
+    const code = `import { Inter } from 'next/font/google';`;
     const result = await transform.call(plugin, code, "/app/layout.tsx");
     expect(result).not.toBeNull();
     expect(result.code).toContain("virtual:vinext-google-fonts?");
@@ -472,7 +478,7 @@ describe("vinext:google-fonts plugin", () => {
     const code = [
       `import type { Metadata } from 'next'`,
       `import { Inter } from 'next/font/google'`,
-      `const inter = Inter({ subsets: ['latin'] })`,
+      `export { Inter }`,
     ].join("\n");
     const result = await transform.call(plugin, code, "/app/layout.tsx");
     expect(result).not.toBeNull();
@@ -497,7 +503,7 @@ describe("vinext:google-fonts plugin", () => {
       `  Roboto,`,
       `  Architects_Daughter,`,
       `} from 'next/font/google'`,
-      `const inter = Inter({ subsets: ['latin'] })`,
+      `export { Inter, Roboto, Architects_Daughter }`,
     ].join("\n");
     const result = await transform.call(plugin, code, "/app/layout.tsx");
     expect(result).not.toBeNull();
@@ -541,7 +547,10 @@ describe("vinext:google-fonts plugin", () => {
     const plugin = getGoogleFontsPlugin();
     initPlugin(plugin, { command: "serve" });
     const transform = unwrapHook(plugin.transform);
-    const code = `import * as fonts from 'next/font/google';\nconst inter = fonts.Inter({ weight: ['400'] });`;
+    // No constructor call here — the assertion is about the namespace
+    // rewrite, and the call-site rewrite path (which would fetch from
+    // Google) is exercised by the build/dev integration tests.
+    const code = `import * as fonts from 'next/font/google';\nexport const Inter = fonts.Inter;`;
     const result = await transform.call(plugin, code, "/app/layout.tsx");
     expect(result).not.toBeNull();
     expect(result.code).toContain("__vinext_google_fonts_proxy_0");


### PR DESCRIPTION
## Summary

The build pipeline already rewrites `next/font/google` calls to embed self-hosted `@font-face` CSS pointing at `/<assetsDir>/_vinext_fonts/...`, but the call-site rewrite was gated behind `isBuild`. In dev:

- Those URLs 404'd because nothing copies the cached `.vinext/fonts/` files into the dev server's served paths.
- Once `_selfHostedCSS` is present, the shim no longer emits the `fonts.googleapis.com` `<link>` — so dev showed unstyled glyphs with no CDN fallback either.

This PR:
- Drops the build-only gate so the call-site rewrite (and `_selfHostedCSS` injection) runs in dev too.
- Adds a `configureServer` middleware that serves cached files directly from `.vinext/fonts/` under the same URL prefix `_rewriteCachedFontCssToServedUrls()` embeds.
- Reuses the prod `CONTENT_TYPES` map so dev and prod hand out identical MIME types.
- Cleans up the now-unused `isBuild` closure variable and the dead `{ }` block left after removing the gate.

## Regression test

`tests/e2e/app-router/font-google.spec.ts` navigates to a new `/font-google-test` route in the `app-basic` fixture that uses `Geist` + `Geist_Mono`, then:

1. Asserts no `fonts.googleapis.com` URL leaks into the HTML.
2. Asserts a `<style data-vinext-fonts>` block is present.
3. Pulls a preload URL out of the HTML and fetches it — verifies HTTP 200, `Content-Type: font/woff2`, and a real body. This is the layer that catches both the CDN-leakage and the middleware-broken regressions in one shot.

The spec runs under the existing `app-router` Playwright project, so no new CI matrix entry is needed.

## Test plan

- [x] `vp test tests/font-google.test.ts tests/font-google-build.test.ts` — 104 passed
- [x] `PLAYWRIGHT_PROJECT=app-router npx playwright test --project=app-router tests/e2e/app-router/font-google.spec.ts` — passing
- [ ] Verify CI green across all Playwright projects (the gate removal also affects `app-router`/`app-with-src` since they import `next/font/local`, which is a different plugin — but worth confirming nothing regresses)

🤖 Generated with [Claude Code](https://claude.com/claude-code)