### PR TITLE
fix(routing): match inherited slot params against routePath, not request.url

### DIFF
--- a/packages/vinext/src/routing/app-route-graph.ts
+++ b/packages/vinext/src/routing/app-route-graph.ts
@@ -436,11 +436,28 @@ function discoverSlotSubRoutes(routes: AppRoute[], matcher: ValidFileMatcher): A
  * Skips the root page.tsx (already handled as the slot's main page)
  * and intercepting route directories.
  */
-function findSlotSubPages(
-  slotDir: string,
-  matcher: ValidFileMatcher,
-): Array<{ relativePath: string; pagePath: string }> {
-  const results: Array<{ relativePath: string; pagePath: string }> = [];
+type SlotSubPageEntry = { relativePath: string; pagePath: string };
+
+// Per-build memo: a slot directory's sub-pages depend only on the directory
+// contents and the matcher's accepted extensions. Inherited slots get scanned
+// once per descendant route, so without memoization a route N segments deep
+// pays O(N) full subtree walks for every shared ancestor slot.
+//
+// Keyed by matcher (one matcher per build) so the cache is naturally scoped
+// to a single build run and gets collected when the build finishes — no
+// cross-build pollution in long-lived dev servers.
+const findSlotSubPagesCache = new WeakMap<ValidFileMatcher, Map<string, SlotSubPageEntry[]>>();
+
+function findSlotSubPages(slotDir: string, matcher: ValidFileMatcher): SlotSubPageEntry[] {
+  let perMatcher = findSlotSubPagesCache.get(matcher);
+  if (!perMatcher) {
+    perMatcher = new Map();
+    findSlotSubPagesCache.set(matcher, perMatcher);
+  }
+  const cached = perMatcher.get(slotDir);
+  if (cached) return cached;
+
+  const results: SlotSubPageEntry[] = [];
 
   function scan(dir: string): void {
     if (!fs.existsSync(dir)) return;
@@ -464,6 +481,7 @@ function findSlotSubPages(
   }
 
   scan(slotDir);
+  perMatcher.set(slotDir, results);
   return results;
 }
 
@@ -858,20 +876,22 @@ function findMirroredSlotPage(
 } | null {
   if (segmentsBelow.length === 0) return null;
 
+  // Convert once: both tiers need the URL form of the route's segments below
+  // this directory.
+  const routeUrl = convertSegmentsToRouteParts([...segmentsBelow]);
+
   // Tier 1: literal filesystem match.
   const literalDir = path.join(slotDir, ...segmentsBelow);
   const literalPage = findFile(literalDir, "page", matcher);
   if (literalPage) {
-    const converted = convertSegmentsToRouteParts([...segmentsBelow]);
     return {
       pagePath: literalPage,
       segments: [...segmentsBelow],
-      slotUrlSegments: converted?.urlSegments ?? [],
-      slotParamNames: converted?.params ?? [],
+      slotUrlSegments: routeUrl?.urlSegments ?? [],
+      slotParamNames: routeUrl?.params ?? [],
     };
   }
 
-  const routeUrl = convertSegmentsToRouteParts([...segmentsBelow]);
   if (!routeUrl || routeUrl.urlSegments.length === 0) return null;
 
   // Tier 2: enumerate slot sub-pages and pick the most-specific compatible

--- a/packages/vinext/src/server/app-page-element-builder.ts
+++ b/packages/vinext/src/server/app-page-element-builder.ts
@@ -163,7 +163,7 @@ export async function buildPageElements<
 
   const mountedSlotIds = mountedSlotsHeader ? new Set(mountedSlotsHeader.split(" ")) : null;
 
-  const slotOverrides = buildSlotOverrides(route, params, pageRequest.request, opts);
+  const slotOverrides = buildSlotOverrides(route, params, routePath, opts);
 
   return buildAppPageElements({
     element: PageComponent ? createElement(PageComponent, pageProps) : null,
@@ -190,14 +190,18 @@ export async function buildPageElements<
  *    and its layouts when the request is intercepted into this slot).
  *  - Slot-specific param extraction for inherited slots whose URL pattern
  *    has different param names than the route's. The runtime matches the
- *    request URL against `slot.slotPatternParts` to produce slot-scoped
- *    params, which `app-page-route-wiring` then hands to the slot page
- *    instead of the route's matched params.
+ *    cleaned request path against `slot.slotPatternParts` to produce
+ *    slot-scoped params, which `app-page-route-wiring` then hands to the
+ *    slot page instead of the route's matched params.
+ *
+ * `routePath` is the already-normalized request pathname (basePath stripped,
+ * RSC suffix removed). Re-parsing `request.url` here would re-introduce the
+ * basePath and silently break the match for any app that configures one.
  */
 function buildSlotOverrides<TModule extends AppPageModule, TErrorModule extends AppPageErrorModule>(
   route: AppPageBuildRoute<TModule, TErrorModule>,
   routeParams: AppPageParams,
-  request: Request,
+  routePath: string,
   opts?: AppPageInterceptOptions<TModule> | null,
 ): Readonly<Record<string, AppPageSlotOverride<TModule>>> | null {
   const overrides: Record<string, AppPageSlotOverride<TModule>> = {};
@@ -225,7 +229,7 @@ function buildSlotOverrides<TModule extends AppPageModule, TErrorModule extends 
       if (paramNames && paramNames.every((name) => routeParamSet.has(name))) continue;
 
       if (urlParts === null) {
-        urlParts = new URL(request.url).pathname.split("/").filter(Boolean);
+        urlParts = routePath.split("/").filter(Boolean);
       }
       const matched = matchRoutePattern(urlParts, patternParts);
       if (!matched) continue;

--- a/tests/app-page-element-builder.test.ts
+++ b/tests/app-page-element-builder.test.ts
@@ -269,6 +269,66 @@ describe("buildPageElements", () => {
     expect(Object.prototype.hasOwnProperty.call(record, "page:/user/[id]")).toBe(true);
   });
 
+  it("extracts slot params from routePath, not request.url, so basePath does not break the match", async () => {
+    function MainPage(): React.ReactNode {
+      return React.createElement("div", null, "main");
+    }
+    function SlotPage(): React.ReactNode {
+      return React.createElement("span", null, "slot");
+    }
+
+    // Inherited slot whose mirrored sub-page has a dynamic marker (`:name`)
+    // with a different name than the route's (`:id`). The slotPatternParts
+    // are app-relative — basePath was already stripped during graph build.
+    const route = createSyntheticRoute({
+      page: createSyntheticPageModule(MainPage),
+      layouts: [],
+      routeSegments: ["distinct", "[id]"],
+      pattern: "/distinct/[id]",
+      params: ["id"],
+      slots: {
+        "@bc": {
+          name: "bc",
+          page: createSyntheticPageModule(SlotPage),
+          layoutIndex: -1,
+          routeSegments: ["distinct", "[id]"],
+          slotPatternParts: ["distinct", ":name"],
+          slotParamNames: ["name"],
+        },
+      },
+    });
+
+    // Simulate a basePath-configured app: request URL still carries `/base`,
+    // but the entry passes the cleaned pathname as routePath. The fix must
+    // match against routePath, not against `new URL(request.url).pathname`.
+    const result = await buildPageElements({
+      ...createBaseOptions({
+        route,
+        params: { id: "alice" },
+        routePath: "/distinct/alice",
+      }),
+      pageRequest: {
+        opts: null,
+        searchParams: null,
+        isRscRequest: false,
+        request: new Request("http://localhost/base/distinct/alice"),
+        mountedSlotsHeader: null,
+      },
+    });
+
+    const record = result as Record<string, unknown>;
+    const slotElement = record["slot:bc:/"] as React.ReactElement<{
+      params: PromiseLike<AppPageParams>;
+    }>;
+    expect(slotElement).toBeDefined();
+    const slotParams = await slotElement.props.params;
+    // Without the fix, urlParts would be ["base","distinct","alice"], the
+    // pattern match would fail, and slotParams would silently fall back to
+    // the route's matched params ({ id: "alice" }) — leaving the slot
+    // page's `name` undefined. With the fix, the slot gets its own params.
+    expect(slotParams).toEqual({ name: "alice" });
+  });
+
   it("makeThenableParams wraps params as a proxy supporting both Promise and property access", () => {
     const plainParams: AppPageParams = { id: "99" };
     const thenable = makeThenableParams(plainParams);


### PR DESCRIPTION
Follow-up to [#1039](https://github.com/cloudflare/vinext/pull/1039), addressing two items I missed during review.

## Summary

- **Bug under `basePath`**: `buildSlotOverrides` was deriving the URL parts to match against `slot.slotPatternParts` from `request.url`. The original request URL still carries the configured `basePath`, but `slotPatternParts` is built from app-relative segments only — so for any basePath-configured app, the pattern match silently failed and slot params fell back to the route's matched params (the exact bug #1039 was supposed to fix). Switched to the already-normalized `routePath` parameter (basePath stripped, RSC suffix removed) that `buildPageElements` already receives.
- **Memoize `findSlotSubPages`**: cached per-build via a `WeakMap` keyed by the matcher. Inherited slots get scanned once per descendant route, so without memoization a route N segments deep paid O(N) full subtree walks for every shared ancestor slot. Cache lifetime tracks the matcher (one per build), so a long-lived dev server doesn't accumulate state across builds.
- **Dedupe**: `findMirroredSlotPage` was calling `convertSegmentsToRouteParts(segmentsBelow)` twice when the literal-tier match missed. Hoisted it out so both tiers reuse the conversion.

## Test plan

- [x] New unit test in `tests/app-page-element-builder.test.ts` exercises the basePath regression: request URL is `http://localhost/base/distinct/alice` while `routePath` is `/distinct/alice`, slot has `slotPatternParts: ["distinct", ":name"]`. Without the fix, `urlParts` would be `["base","distinct","alice"]`, the match would fail, and the slot's resolved `params` would silently lose the `name` value. With the fix, `slotParams` resolves to `{ name: "alice" }`.
- [x] `pnpm exec vp test run --project unit` — 3524 tests pass.
- [x] `pnpm check` — only pre-existing failure (`benchmarks/vinext/vite.config.ts` cannot resolve `vinext` until the package is built; same on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)