### PR TITLE
fix(page-request): catch generateStaticParams errors per-source, not per-loop

### DIFF
--- a/packages/vinext/src/server/app-page-request.ts
+++ b/packages/vinext/src/server/app-page-request.ts
@@ -257,8 +257,8 @@ export async function validateAppPageDynamicParams(
     return new Response("Not Found", { status: 404 });
   }
 
-  try {
-    for (const source of generateStaticParamsSources) {
+  for (const source of generateStaticParamsSources) {
+    try {
       const staticParams = await source.generateStaticParams({
         params: pickRouteParams(options.params, source.parentParamNames),
       });
@@ -266,9 +266,9 @@ export async function validateAppPageDynamicParams(
         options.clearRequestContext();
         return new Response("Not Found", { status: 404 });
       }
+    } catch (error) {
+      options.logGenerateStaticParamsError?.(error);
     }
-  } catch (error) {
-    options.logGenerateStaticParamsError?.(error);
   }
 
   return null;

--- a/tests/app-page-request.test.ts
+++ b/tests/app-page-request.test.ts
@@ -127,6 +127,31 @@ describe("app page request helpers", () => {
     expect(logGenerateStaticParamsError).toHaveBeenCalledTimes(1);
   });
 
+  it("checks remaining sources when an earlier generateStaticParams source throws", async () => {
+    const clearRequestContext = vi.fn();
+    const logGenerateStaticParamsError = vi.fn();
+    const throwsSource = vi.fn(() => {
+      throw new Error("source 1 failed");
+    });
+    const rejectsSource = vi.fn(async () => [{ slug: "other" }]);
+
+    const response = await validateAppPageDynamicParams({
+      clearRequestContext,
+      enforceStaticParamsOnly: true,
+      generateStaticParams: [throwsSource, rejectsSource],
+      isDynamicRoute: true,
+      logGenerateStaticParamsError,
+      params: { slug: "target" },
+    });
+
+    // First source threw → logged, then second source checked → rejected → 404.
+    expect(response?.status).toBe(404);
+    expect(clearRequestContext).toHaveBeenCalledTimes(1);
+    expect(logGenerateStaticParamsError).toHaveBeenCalledTimes(1);
+    expect(throwsSource).toHaveBeenCalledTimes(1);
+    expect(rejectsSource).toHaveBeenCalledTimes(1);
+  });
+
   it("renders intercepted source routes on RSC navigations", async () => {
     const setNavigationContext = vi.fn();
     const buildPageElementMock = vi.fn(async () => ({ type: "intercept-element" }));


### PR DESCRIPTION
## Summary
- Fixes a bug where a throwing `generateStaticParams` source short-circuited validation of remaining sources in `validateAppPageDynamicParams`
- Previously the try-catch wrapped the entire loop; now each source is independently guarded so a throw in source 1 doesn't skip source 2

## Changes
- Move try-catch inside the `for` loop in `validateAppPageDynamicParams`
- Add regression test for multi-source scenario where the first source throws and the second rejects the params

## Risk
Low. The existing single-source throw test continues to pass. The new behavior only differs when there are 2+ generateStaticParams sources and an earlier one throws — the remaining sources are now checked instead of skipped.