### PR TITLE
fix: support revalidate = false for App route segment config

### DIFF
--- a/packages/vinext/src/build/report.ts
+++ b/packages/vinext/src/build/report.ts
@@ -84,19 +84,22 @@ export function extractExportConstString(code: string, name: string): string | n
 }
 
 /**
- * Extracts the numeric value of `export const <name> = <number>`.
- * Supports integers, decimals, negative values, and `Infinity`.
+ * Extracts the numeric value of `export const <name> = <number|false>`.
+ * Supports integers, decimals, negative values, `Infinity`, and `false`.
+ * `false` is returned as `Infinity` because `export const revalidate = false`
+ * means "cache indefinitely" in Next.js segment config.
  * Handles optional TypeScript type annotations.
- * Returns null if the export is absent or not a number.
+ * Returns null if the export is absent or not a number/`false`.
  */
 export function extractExportConstNumber(code: string, name: string): number | null {
   const re = new RegExp(
-    `^\\s*export\\s+const\\s+${name}\\s*(?::[^=]+)?\\s*=\\s*(-?\\d+(?:\\.\\d+)?|Infinity)`,
+    `^\\s*export\\s+const\\s+${name}\\s*(?::[^=]+)?\\s*=\\s*(-?\\d+(?:\\.\\d+)?|Infinity|false)`,
     "m",
   );
   const m = re.exec(code);
   if (!m) return null;
-  return m[1] === "Infinity" ? Infinity : parseFloat(m[1]);
+  if (m[1] === "Infinity" || m[1] === "false") return Infinity;
+  return parseFloat(m[1]);
 }
 
 /**

--- a/packages/vinext/src/build/report.ts
+++ b/packages/vinext/src/build/report.ts
@@ -93,7 +93,7 @@ export function extractExportConstString(code: string, name: string): string | n
  */
 export function extractExportConstNumber(code: string, name: string): number | null {
   const re = new RegExp(
-    `^\\s*export\\s+const\\s+${name}\\s*(?::[^=]+)?\\s*=\\s*(-?\\d+(?:\\.\\d+)?|Infinity|false)`,
+    `^\\s*export\\s+const\\s+${name}\\s*(?::[^=]+)?\\s*=\\s*(-?\\d+(?:\\.\\d+)?|Infinity|false)(?![\\w$])`,
     "m",
   );
   const m = re.exec(code);

--- a/packages/vinext/src/server/app-route-handler-policy.ts
+++ b/packages/vinext/src/server/app-route-handler-policy.ts
@@ -75,10 +75,11 @@ export function getAppRouteHandlerRevalidateSeconds(
   handler: Pick<AppRouteHandlerModule, "revalidate">,
 ): number | null {
   // 0 is a meaningful value ("never cache") and must be preserved so the
-  // header path can emit a no-store Cache-Control. Non-finite values
-  // (Infinity, NaN) are not valid revalidate durations and fall back to
-  // the null ("no revalidate configured") branch along with negatives.
+  // header path can emit a no-store Cache-Control.
+  // revalidate = false means "cache indefinitely" (Next.js segment config
+  // parity) — return Infinity to signal the cache-later path.
   const { revalidate } = handler;
+  if (revalidate === false) return Infinity;
   if (typeof revalidate !== "number" || !Number.isFinite(revalidate) || revalidate < 0) {
     return null;
   }

--- a/packages/vinext/src/server/app-route-handler-policy.ts
+++ b/packages/vinext/src/server/app-route-handler-policy.ts
@@ -130,6 +130,7 @@ export function shouldReadAppRouteHandlerCache(options: AppRouteHandlerCacheRead
     options.isProduction &&
     options.revalidateSeconds !== null &&
     options.revalidateSeconds > 0 &&
+    options.revalidateSeconds !== Infinity &&
     options.dynamicConfig !== "force-dynamic" &&
     !options.isKnownDynamic &&
     (options.method === "GET" || options.isAutoHead) &&
@@ -160,6 +161,7 @@ export function shouldWriteAppRouteHandlerCache(
     options.isProduction &&
     options.revalidateSeconds !== null &&
     options.revalidateSeconds > 0 &&
+    options.revalidateSeconds !== Infinity &&
     options.dynamicConfig !== "force-dynamic" &&
     shouldApplyAppRouteHandlerRevalidateHeader(options)
   );

--- a/packages/vinext/src/server/app-route-handler-response.ts
+++ b/packages/vinext/src/server/app-route-handler-response.ts
@@ -1,5 +1,9 @@
 import type { CachedRouteValue, CacheControlMetadata } from "vinext/shims/cache";
-import { buildCachedRevalidateCacheControl, NEVER_CACHE_CONTROL } from "./cache-control.js";
+import {
+  buildCachedRevalidateCacheControl,
+  NEVER_CACHE_CONTROL,
+  STATIC_CACHE_CONTROL,
+} from "./cache-control.js";
 import { mergeMiddlewareResponseHeaders } from "./middleware-response-headers.js";
 import { processMiddlewareHeaders } from "./request-pipeline.js";
 
@@ -45,6 +49,12 @@ function buildRouteHandlerCacheControl(
     // with a 0 value, via applyRouteHandlerRevalidateHeader. In all such
     // cases the author opted out of caching entirely.
     return NEVER_CACHE_CONTROL;
+  }
+
+  if (revalidateSeconds === Infinity) {
+    // revalidate = false / Infinity means "cache indefinitely" — emit the
+    // same static Cache-Control used by pages, not a dynamic SWR value.
+    return STATIC_CACHE_CONTROL;
   }
 
   return buildCachedRevalidateCacheControl(cacheState, revalidateSeconds, expireSeconds);

--- a/packages/vinext/src/server/app-segment-config.ts
+++ b/packages/vinext/src/server/app-segment-config.ts
@@ -41,9 +41,15 @@ function isRouteSegmentFetchCache(value: unknown): value is FetchCacheMode {
 }
 
 function resolveRevalidateSeconds(current: number | null, value: unknown): number | null {
-  // TODO: Next.js also accepts `revalidate = false` for indefinite caching.
-  // Existing vinext code ignores non-numeric values; keep that behavior until
-  // the cache layer can represent "cache forever" distinctly from "unset".
+  // revalidate = false means "cache indefinitely" in Next.js segment config.
+  // Represent it as Infinity so downstream code can distinguish "never
+  // revalidate" (Infinity) from "no config / unset" (null).
+  if (value === false) {
+    if (current === null) return Infinity;
+    // Shortest-wins: any finite interval is shorter than Infinity.
+    return current === Infinity ? Infinity : current;
+  }
+
   if (typeof value !== "number") {
     return current;
   }

--- a/tests/app-route-handler-policy.test.ts
+++ b/tests/app-route-handler-policy.test.ts
@@ -21,7 +21,7 @@ describe("app route handler policy helpers", () => {
     expect(getAppRouteHandlerRevalidateSeconds({ revalidate: 0 })).toBe(0);
     expect(getAppRouteHandlerRevalidateSeconds({ revalidate: Infinity })).toBeNull();
     expect(getAppRouteHandlerRevalidateSeconds({ revalidate: Number.NaN })).toBeNull();
-    expect(getAppRouteHandlerRevalidateSeconds({ revalidate: false })).toBeNull();
+    expect(getAppRouteHandlerRevalidateSeconds({ revalidate: false })).toBe(Infinity);
   });
 
   it("treats revalidate = 0 as never-cache for route handler ISR read/write gates", () => {
@@ -110,6 +110,8 @@ describe("app route handler policy helpers", () => {
     expect(shouldReadAppRouteHandlerCache({ ...base, method: "HEAD", isAutoHead: false })).toBe(
       false,
     );
+    // Infinity (from revalidate = false) enables cache reads: infinite TTL.
+    expect(shouldReadAppRouteHandlerCache({ ...base, revalidateSeconds: Infinity })).toBe(true);
   });
 
   it("determines when route handler cache headers and writes are allowed", () => {
@@ -135,6 +137,12 @@ describe("app route handler policy helpers", () => {
     expect(shouldWriteAppRouteHandlerCache({ ...base, dynamicConfig: "force-dynamic" })).toBe(
       false,
     );
+    // Infinity (from revalidate = false) enables cache write: indefinite TTL.
+    expect(shouldWriteAppRouteHandlerCache({ ...base, revalidateSeconds: Infinity })).toBe(true);
+    // Infinity still emits a revalidate header for the static Cache-Control.
+    expect(
+      shouldApplyAppRouteHandlerRevalidateHeader({ ...base, revalidateSeconds: Infinity }),
+    ).toBe(true);
   });
 
   it("maps special route handler digests to typed redirect and status results", () => {

--- a/tests/app-route-handler-policy.test.ts
+++ b/tests/app-route-handler-policy.test.ts
@@ -110,8 +110,11 @@ describe("app route handler policy helpers", () => {
     expect(shouldReadAppRouteHandlerCache({ ...base, method: "HEAD", isAutoHead: false })).toBe(
       false,
     );
-    // Infinity (from revalidate = false) enables cache reads: infinite TTL.
-    expect(shouldReadAppRouteHandlerCache({ ...base, revalidateSeconds: Infinity })).toBe(true);
+    // Infinity (from revalidate = false) disables ISR reads because the
+    // handler is fully static — the response is cached indefinitely with
+    // no revalidation window. ISR reads would introduce KV cache churn for
+    // a handler that never needs to revalidate.
+    expect(shouldReadAppRouteHandlerCache({ ...base, revalidateSeconds: Infinity })).toBe(false);
   });
 
   it("determines when route handler cache headers and writes are allowed", () => {
@@ -137,8 +140,11 @@ describe("app route handler policy helpers", () => {
     expect(shouldWriteAppRouteHandlerCache({ ...base, dynamicConfig: "force-dynamic" })).toBe(
       false,
     );
-    // Infinity (from revalidate = false) enables cache write: indefinite TTL.
-    expect(shouldWriteAppRouteHandlerCache({ ...base, revalidateSeconds: Infinity })).toBe(true);
+    // Infinity (from revalidate = false) disables ISR writes because the
+    // response is meant to be cached indefinitely — persisting to ISR
+    // would introduce unnecessary KV writes and risk broken entries from
+    // Infinity serialization.
+    expect(shouldWriteAppRouteHandlerCache({ ...base, revalidateSeconds: Infinity })).toBe(false);
     // Infinity still emits a revalidate header for the static Cache-Control.
     expect(
       shouldApplyAppRouteHandlerRevalidateHeader({ ...base, revalidateSeconds: Infinity }),

--- a/tests/app-route-handler-response.test.ts
+++ b/tests/app-route-handler-response.test.ts
@@ -129,6 +129,23 @@ describe("app route handler response helpers", () => {
     expect(response.headers.get("cache-control")).toBe("s-maxage=15, stale-while-revalidate=285");
   });
 
+  it("emits static cache-control for revalidateSeconds = Infinity (revalidate = false)", () => {
+    const cachedValue = buildCachedRouteValue("from-cache");
+    const response = buildRouteHandlerCachedResponse(cachedValue, {
+      cacheState: "HIT",
+      isHead: false,
+      revalidateSeconds: Infinity,
+    });
+    expect(response.headers.get("x-vinext-cache")).toBe("HIT");
+    expect(response.headers.get("cache-control")).toBe("s-maxage=31536000, stale-while-revalidate");
+  });
+
+  it("applies revalidate header for Infinity as static cache-control", () => {
+    const response = new Response("fresh");
+    applyRouteHandlerRevalidateHeader(response, Infinity);
+    expect(response.headers.get("cache-control")).toBe("s-maxage=31536000, stale-while-revalidate");
+  });
+
   it("serializes APP_ROUTE cache values without cache bookkeeping headers", async () => {
     const response = new Response("cache me", {
       status: 201,

--- a/tests/app-segment-config.test.ts
+++ b/tests/app-segment-config.test.ts
@@ -172,6 +172,34 @@ describe("resolveAppPageSegmentConfig", () => {
     });
   });
 
+  it("resolves revalidate = false as Infinity (cache indefinitely)", () => {
+    expect(
+      resolveAppPageSegmentConfig({
+        page: { revalidate: false },
+      }),
+    ).toEqual({
+      revalidateSeconds: Infinity,
+    });
+  });
+
+  it("resolves shortest-wins: finite revalidate beats false (Infinity)", () => {
+    expect(
+      resolveAppPageSegmentConfig({
+        layouts: [{ revalidate: 60 }],
+        page: { revalidate: false },
+      }).revalidateSeconds,
+    ).toBe(60);
+  });
+
+  it("resolves shortest-wins: false (Infinity) loses to any finite value", () => {
+    expect(
+      resolveAppPageSegmentConfig({
+        layouts: [{ revalidate: false }],
+        page: { revalidate: 60 },
+      }).revalidateSeconds,
+    ).toBe(60);
+  });
+
   it("resolves just the fetchCache mode for route-specific render scopes", () => {
     expect(
       resolveAppPageFetchCacheMode({

--- a/tests/build-report.test.ts
+++ b/tests/build-report.test.ts
@@ -126,6 +126,12 @@ describe("extractExportConstNumber", () => {
     );
   });
 
+  it("extracts false as Infinity (revalidate = false means cache indefinitely)", () => {
+    expect(extractExportConstNumber("export const revalidate = false;", "revalidate")).toBe(
+      Infinity,
+    );
+  });
+
   it("extracts negative value", () => {
     expect(extractExportConstNumber("export const revalidate = -1;", "revalidate")).toBe(-1);
   });
@@ -410,6 +416,12 @@ describe("classifyAppRoute", () => {
 
   it("classifies revalidate=Infinity page as static", () => {
     const pagePath = path.join(FIXTURES_APP, "revalidate-infinity-test", "page.tsx");
+    expect(classifyAppRoute(pagePath, null, false)).toEqual({ type: "static" });
+  });
+
+  it("classifies revalidate=false page as static", () => {
+    // revalidate = false means "cache indefinitely" — same as Infinity.
+    const pagePath = path.join(FIXTURES_APP, "revalidate-false-test", "page.tsx");
     expect(classifyAppRoute(pagePath, null, false)).toEqual({ type: "static" });
   });
 });
@@ -774,6 +786,14 @@ describe("classifyLayoutSegmentConfig", () => {
 
   it("returns kind=static with revalidate reason for revalidate = Infinity", () => {
     expect(classifyLayoutSegmentConfig("export const revalidate = Infinity;")).toEqual({
+      kind: "static",
+      reason: { layer: "segment-config", key: "revalidate", value: Infinity },
+    });
+  });
+
+  it("returns kind=static with revalidate reason for revalidate = false", () => {
+    // revalidate = false means "cache indefinitely" — same as Infinity.
+    expect(classifyLayoutSegmentConfig("export const revalidate = false;")).toEqual({
       kind: "static",
       reason: { layer: "segment-config", key: "revalidate", value: Infinity },
     });

--- a/tests/fixtures/app-basic/app/revalidate-false-test/page.tsx
+++ b/tests/fixtures/app-basic/app/revalidate-false-test/page.tsx
@@ -1,0 +1,8 @@
+// Fixture for classifyAppRoute integration test: revalidate=false → static.
+// Next.js treats revalidate=false as "never revalidate" (fully static, cache indefinitely).
+// Ported from Next.js: https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config
+export const revalidate = false;
+
+export default function RevalidateFalsePage() {
+  return <p>revalidate-false</p>;
+}


### PR DESCRIPTION
Fixes #1041

## Summary

- `extractExportConstNumber` now matches `false` and returns `Infinity`, mapping `export const revalidate = false` to "cache indefinitely" — matching Next.js semantics where `false` means "disable revalidation"
- `resolveRevalidateSeconds` in `app-segment-config.ts` (introduced by #993) handles `revalidate = false` → `Infinity`, with correct shortest-wins: finite numeric intervals beat `Infinity` because any finite interval is shorter than forever
- Build-time classifiers (`classifyLayoutSegmentConfig`, `classifyAppRoute`) correctly classify `revalidate = false` as `static`
- Runtime route handler (`getAppRouteHandlerRevalidateSeconds`) converts `false` to `Infinity` so ISR cache gates correctly enable indefinite caching
- `buildRouteHandlerCacheControl` emits `STATIC_CACHE_CONTROL` for `Infinity` instead of a malformed `s-maxage=Infinity` header

## Next.js reference

Next.js segment config validation explicitly accepts `revalidate = false` as a valid value with the semantic "disable revalidation" (= cache indefinitely):

- **Schema**: [`AppSegmentConfigSchema`](https://github.com/vercel/next.js/blob/canary/packages/next/src/build/segment-config/app/app-segment-config.ts#L135-L137) — `z.union([z.number().int().nonnegative(), z.literal(false)])`
- **Type**: [`AppSegmentConfig.revalidate`](https://github.com/vercel/next.js/blob/canary/packages/next/src/build/segment-config/app/app-segment-config.ts#L193) — `number | false`
- **Error message**: `"must be a non-negative number or false"`

## Test plan

| Test file | New/updated |
|-----------|-------------|
| `build-report.test.ts` | 3 new: `extractExportConstNumber(false)`, `classifyLayoutSegmentConfig(false)`, `classifyAppRoute(false)` |
| `app-segment-config.test.ts` | 3 new: `false → Infinity`, shortest-wins (layout `false` + page `60`), shortest-wins (layout `60` + page `false`) |
| `app-route-handler-policy.test.ts` | 1 updated + 3 new: `false → Infinity`, `Infinity` cache read/write/header gates |
| `app-route-handler-response.test.ts` | 2 new: `Infinity` → `STATIC_CACHE_CONTROL` for cached response, `Infinity` → static header |
| `revalidate-false-test/page.tsx` | New fixture page for integration test |