### PR TITLE
fix(server): reject invalid HTTP methods with 400 in app route handlers

### DIFF
--- a/packages/vinext/src/server/app-route-handler-dispatch.ts
+++ b/packages/vinext/src/server/app-route-handler-dispatch.ts
@@ -30,7 +30,7 @@ import {
   type AppRouteParams,
   type RouteHandlerCacheSetter,
 } from "./app-route-handler-execution.js";
-import { isKnownDynamicAppRoute } from "./app-route-handler-runtime.js";
+import { isKnownDynamicAppRoute, isValidHTTPMethod } from "./app-route-handler-runtime.js";
 import {
   applyRouteHandlerMiddlewareContext,
   type RouteHandlerMiddlewareContext,
@@ -139,6 +139,17 @@ export async function dispatchAppRouteHandler(
       "[vinext] Detected default export in route handler " +
         route.pattern +
         ". Export a named export for each HTTP method instead.",
+    );
+  }
+
+  // Reject non-standard HTTP methods before any auto-OPTIONS/405 logic.
+  // Next.js returns 400 for invalid methods; vinext mirrors that behavior.
+  // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/route-modules/app-route/module.ts#L390-L392
+  if (!isValidHTTPMethod(method)) {
+    options.clearRequestContext();
+    return applyRouteHandlerMiddlewareContext(
+      new Response(null, { status: 400 }),
+      options.middlewareContext,
     );
   }
 

--- a/packages/vinext/src/server/app-route-handler-runtime.ts
+++ b/packages/vinext/src/server/app-route-handler-runtime.ts
@@ -22,6 +22,17 @@ export type RouteHandlerHttpMethod = (typeof ROUTE_HANDLER_HTTP_METHODS)[number]
 
 export type RouteHandlerModule = Partial<Record<RouteHandlerHttpMethod | "default", unknown>>;
 
+/**
+ * Checks whether a string is a recognized HTTP method for App Router route
+ * handlers. Invalid methods must be rejected with 400 before any auto-OPTIONS
+ * or 405 logic runs.
+ *
+ * @see https://github.com/vercel/next.js/blob/canary/packages/next/src/server/web/http.ts
+ */
+export function isValidHTTPMethod(maybeMethod: string): maybeMethod is RouteHandlerHttpMethod {
+  return (ROUTE_HANDLER_HTTP_METHODS as readonly string[]).includes(maybeMethod);
+}
+
 export function collectRouteHandlerMethods(handler: RouteHandlerModule): RouteHandlerHttpMethod[] {
   const methods = ROUTE_HANDLER_HTTP_METHODS.filter(
     (method) => typeof handler[method] === "function",

--- a/tests/app-route-handler-dispatch.test.ts
+++ b/tests/app-route-handler-dispatch.test.ts
@@ -25,6 +25,57 @@ function buildISRCacheEntry(value: CachedRouteValue, isStale = false): ISRCacheE
 }
 
 describe("app route handler dispatch", () => {
+  it("rejects invalid HTTP methods with 400 before auto-OPTIONS/405 logic", async () => {
+    // Ported from Next.js: test/e2e/app-dir/app-routes/app-custom-routes.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/app-routes/app-custom-routes.test.ts#L531-L538
+    const route = {
+      pattern: "/api/status",
+      routeHandler: {
+        GET() {
+          throw new Error("GET should not run for invalid methods");
+        },
+      },
+      routeSegments: ["api", "status"],
+    };
+    let clearCount = 0;
+
+    const invalidMethodResponse = await dispatchAppRouteHandler({
+      cleanPathname: "/api/status",
+      clearRequestContext() {
+        clearCount += 1;
+      },
+      i18n: null,
+      isDevelopment: false,
+      isProduction: false,
+      async isrGet() {
+        throw new Error("invalid method should not read route cache");
+      },
+      isrRouteKey(pathname) {
+        return "route:" + pathname;
+      },
+      async isrSet() {
+        throw new Error("invalid method should not write route cache");
+      },
+      middlewareContext: {
+        headers: new Headers([["x-middleware", "present"]]),
+        status: null,
+      },
+      middlewareRequestHeaders: null,
+      params: {},
+      request: new Request("https://example.com/api/status", { method: "HEADER" }),
+      route,
+      scheduleBackgroundRegeneration() {
+        throw new Error("invalid method should not schedule regeneration");
+      },
+      searchParams: new URLSearchParams(),
+    });
+
+    expect(invalidMethodResponse.status).toBe(400);
+    expect(invalidMethodResponse.headers.get("x-middleware")).toBe("present");
+    await expect(invalidMethodResponse.text()).resolves.toBe("");
+    expect(clearCount).toBe(1);
+  });
+
   it("handles framework-generated OPTIONS responses and unsupported methods at the dispatch boundary", async () => {
     const route = {
       pattern: "/api/demo",


### PR DESCRIPTION
## Summary

Vinext previously uppercased the request method and fell through to the normal 405 response for any unrecognized method. Next.js rejects non-standard methods with **400 Bad Request** before dispatch.

## Changes

- **Add `isValidHTTPMethod()` predicate** to `app-route-handler-runtime.ts`, co-located with the existing `ROUTE_HANDLER_HTTP_METHODS` constant.
- **Return empty 400** in `dispatchAppRouteHandler()` before any auto-OPTIONS or 405 logic, matching Next.js behavior.
- **Port the Next.js test** that verifies `HEADER` => 400.

## Next.js source reference

- Handler validation: [`packages/next/src/server/route-modules/app-route/module.ts#L390-L392`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/route-modules/app-route/module.ts#L390-L392)
- Test case: [`test/e2e/app-dir/app-routes/app-custom-routes.test.ts#L531-L538`](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/app-routes/app-custom-routes.test.ts#L531-L538)
- HTTP method constants: [`packages/next/src/server/web/http.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/web/http.ts)

## Verification

- `vp test run tests/app-route-handler-dispatch.test.ts tests/app-route-handler-policy.test.ts tests/app-route-handler-runtime.test.ts` — 25/25 passing
- `vp test run tests/app-router.test.ts -t "route handler"` — 28/28 passing