### PR TITLE
fix(routing): decode matched params with decodeURIComponent

### DIFF
--- a/packages/vinext/src/routing/route-pattern.ts
+++ b/packages/vinext/src/routing/route-pattern.ts
@@ -86,6 +86,25 @@ export function fillRoutePatternSegments(
   return resolvedSegments.length > 0 ? `/${resolvedSegments.join("/")}` : "/";
 }
 
+function decodePatternParam(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+function decodePatternParams(params: RoutePatternParams): void {
+  for (const key of Object.keys(params)) {
+    const value = params[key];
+    if (Array.isArray(value)) {
+      params[key] = value.map(decodePatternParam);
+    } else {
+      params[key] = decodePatternParam(value);
+    }
+  }
+}
+
 export function matchRoutePattern(
   urlParts: readonly string[],
   patternParts: readonly string[],
@@ -135,5 +154,7 @@ export function matchRoutePattern(
     return matchFrom(urlIndex + 1, patternIndex + 1);
   }
 
-  return matchFrom(0, 0) ? params : null;
+  if (!matchFrom(0, 0)) return null;
+  decodePatternParams(params);
+  return params;
 }

--- a/packages/vinext/src/routing/route-trie.ts
+++ b/packages/vinext/src/routing/route-trie.ts
@@ -119,8 +119,35 @@ export function buildRouteTrie<R extends { patternParts: string[] }>(routes: R[]
   return root;
 }
 
+function decodeParam(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+function decodeParams(params: Record<string, string | string[]>): void {
+  for (const key of Object.keys(params)) {
+    const value = params[key];
+    if (Array.isArray(value)) {
+      params[key] = value.map(decodeParam);
+    } else {
+      params[key] = decodeParam(value);
+    }
+  }
+}
+
 /**
  * Match a URL against the trie.
+ *
+ * Returns decoded param values — `decodeURIComponent` is applied to
+ * individual param entries so that `%2F` → `/`, `%23` → `#`, etc.
+ * Segment boundaries (the original `/` splits) are preserved by the
+ * upstream normalization layer; this step only decodes the captured
+ * param strings the caller sees.
+ *
+ * Mirrors Next.js route-matcher.ts:25-27.
  *
  * @param root - Trie root built by `buildRouteTrie`
  * @param urlParts - Pre-split URL segments (no empty strings)
@@ -130,7 +157,11 @@ export function trieMatch<R>(
   root: TrieNode<R>,
   urlParts: string[],
 ): { route: R; params: Record<string, string | string[]> } | null {
-  return match(root, urlParts, 0);
+  const result = match(root, urlParts, 0);
+  if (result) {
+    decodeParams(result.params);
+  }
+  return result;
 }
 
 function createParams(): Record<string, string | string[]> {

--- a/tests/app-rsc-route-matching.test.ts
+++ b/tests/app-rsc-route-matching.test.ts
@@ -49,11 +49,13 @@ describe("App RSC route matching", () => {
     });
   });
 
-  it("does not decode path segments during route matching", () => {
+  // Ported from Next.js: route-matcher.ts decodeURIComponent behaviour
+  // https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/router/utils/route-matcher.ts#L25-L27
+  it("decodes matched params via decodeURIComponent (mirrors Next.js)", () => {
     const matcher = createAppRscRouteMatcher([route("/files/:name", ["files", ":name"])]);
 
     expect(matcher.matchRoute("/files/a%2Fb")).toMatchObject({
-      params: { name: "a%2Fb" },
+      params: { name: "a/b" },
     });
   });
 

--- a/tests/route-pattern.test.ts
+++ b/tests/route-pattern.test.ts
@@ -67,3 +67,31 @@ describe("route pattern helpers", () => {
     expect(matchRoutePattern(["docs", "icon"], ["docs+", "icon"])).toBeNull();
   });
 });
+
+// Ported from Next.js: route-matcher.ts decodeURIComponent behaviour
+// https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/router/utils/route-matcher.ts#L25-L27
+describe("matchRoutePattern param decoding", () => {
+  it("decodes %2F, %23, %3F in dynamic segment params without splitting segments", () => {
+    expect(matchRoutePattern(["files", "a%2Fb"], ["files", ":name"])).toEqual({ name: "a/b" });
+    expect(matchRoutePattern(["files", "a%23b"], ["files", ":name"])).toEqual({ name: "a#b" });
+    expect(matchRoutePattern(["files", "a%3Fb"], ["files", ":name"])).toEqual({ name: "a?b" });
+  });
+
+  it("decodes each element of catch-all and optional catch-all arrays individually", () => {
+    expect(matchRoutePattern(["docs", "a%2Fb", "c%23d"], ["docs", ":rest+"])).toEqual({
+      rest: ["a/b", "c#d"],
+    });
+
+    expect(matchRoutePattern(["docs", "a%2Fb", "c%23d"], ["docs", ":rest*"])).toEqual({
+      rest: ["a/b", "c#d"],
+    });
+  });
+
+  it("preserves malformed percent escapes without throwing", () => {
+    expect(matchRoutePattern(["files", "a%GGb"], ["files", ":name"])).toEqual({ name: "a%GGb" });
+  });
+
+  it("applies exactly one decodeURIComponent pass (double-encoded stays single-encoded)", () => {
+    expect(matchRoutePattern(["files", "a%252Fb"], ["files", ":name"])).toEqual({ name: "a%2Fb" });
+  });
+});

--- a/tests/route-trie.test.ts
+++ b/tests/route-trie.test.ts
@@ -447,4 +447,43 @@ describe("buildRouteTrie + trieMatch", () => {
       expect(result!.route).toBe(route1);
     });
   });
+
+  // Ported from Next.js: route-matcher.ts decodeURIComponent behaviour
+  // https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/router/utils/route-matcher.ts#L25-L27
+  // Also: test/production/pages-dir/production/test/index.test.ts "should handle failed param decoding"
+  // https://github.com/vercel/next.js/blob/canary/test/production/pages-dir/production/test/index.test.ts#L1082
+  describe("param decoding", () => {
+    it("decodes %2F, %23, %3F in dynamic segment params without splitting segments", () => {
+      // /files/[name] matching /files/a%2Fb → param "a/b" (not "a", "b")
+      const trie = buildRouteTrie([r("/files/:name")]);
+      expect(trieMatch(trie, ["files", "a%2Fb"])!.params).toEqual({ name: "a/b" });
+      expect(trieMatch(trie, ["files", "a%23b"])!.params).toEqual({ name: "a#b" });
+      expect(trieMatch(trie, ["files", "a%3Fb"])!.params).toEqual({ name: "a?b" });
+    });
+
+    it("decodes each element of catch-all and optional catch-all arrays individually", () => {
+      const catchAllTrie = buildRouteTrie([r("/docs/:rest+")]);
+      expect(trieMatch(catchAllTrie, ["docs", "a%2Fb", "c%23d"])!.params).toEqual({
+        rest: ["a/b", "c#d"],
+      });
+
+      const optionalTrie = buildRouteTrie([r("/docs/:rest*")]);
+      expect(trieMatch(optionalTrie, ["docs", "a%2Fb", "c%23d"])!.params).toEqual({
+        rest: ["a/b", "c#d"],
+      });
+    });
+
+    it("preserves malformed percent escapes without throwing", () => {
+      // Next.js throws DecodeError (400) on malformed, but vinext's
+      // normalization layer already validates percent-encoding. The matcher
+      // layer preserves un-decodable values rather than crashing.
+      const trie = buildRouteTrie([r("/files/:name")]);
+      expect(trieMatch(trie, ["files", "a%GGb"])!.params).toEqual({ name: "a%GGb" });
+    });
+
+    it("applies exactly one decodeURIComponent pass (double-encoded stays single-encoded)", () => {
+      const trie = buildRouteTrie([r("/files/:name")]);
+      expect(trieMatch(trie, ["files", "a%252Fb"])!.params).toEqual({ name: "a%2Fb" });
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Dynamic params captured by the route matcher are now decoded with `decodeURIComponent`, matching Next.js behavior
- `%2F` → `/`, `%23` → `#`, `%3F` → `?` in param values (pages, route handlers, metadata, `useParams`)
- Decode applies to both single dynamic params and individual catch-all array elements

## Problem

Vinext's segment-safe normalization preserves encoded delimiters for correct route matching (so `/files/a%2Fb` matches `/files/[name]` instead of splitting on the encoded slash). However, the captured param values were returned undecoded: the trie would correctly match but return `name = "a%2Fb"` instead of `name = "a/b"`.

Next.js applies `decodeURIComponent` at the route-matcher level:  
https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/router/utils/route-matcher.ts#L25-L27

This divergence affects every consumer of matched params: page components, `generateMetadata`, route handlers, and `useParams`.

## Fix

Add `decodeURIComponent` wrappers at the two route matching entry points:

- `trieMatch` in `packages/vinext/src/routing/route-trie.ts` — used by the App Router and Pages Router trie-based matchers
- `matchRoutePattern` in `packages/vinext/src/routing/route-pattern.ts` — used for slot-specific param extraction, route handlers, and metadata routes

The decode helpers handle both string and `string[]` (catch-all) param values and gracefully preserve malformed percent escapes (the normalization layer already validates encoding in the strict request path).

## Tests

| Edge case | Coverage |
|---|---|
| `%2F`, `%23`, `%3F` in dynamic segment | Decoded without splitting segments |
| Catch-all and optional catch-all arrays | Each element individually decoded |
| Malformed `%GG` | Preserved without throwing |
| Double-encoded `%252F` | Single decode pass only (→ `%2F`) |

## Verification

- `vp test run tests/route-trie.test.ts` — 64 tests pass
- `vp test run tests/route-pattern.test.ts` — 9 tests pass  
- `vp test run tests/routing.test.ts tests/route-sorting.test.ts` — 143 tests pass
- `vp test run tests/app-router.test.ts` — 300 tests pass
- `vp test run tests/pages-router.test.ts` — 200 tests pass
- `vp lint` — 0 warnings, 0 errors

## References

- Next.js route-matcher.ts decode: https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/router/utils/route-matcher.ts#L25-L27
- Next.js test for failed param decoding: https://github.com/vercel/next.js/blob/canary/test/production/pages-dir/production/test/index.test.ts#L1082