### PR TITLE
fix(thenable-params): protect well-known properties and unify page/route handler implementation

### DIFF
--- a/packages/vinext/src/server/app-route-handler-cache.ts
+++ b/packages/vinext/src/server/app-route-handler-cache.ts
@@ -9,6 +9,7 @@ import {
   buildRouteHandlerCachedResponse,
 } from "./app-route-handler-response.js";
 import { markKnownDynamicAppRoute } from "./app-route-handler-runtime.js";
+import { makeThenableParams } from "vinext/shims/thenable-params";
 import {
   runAppRouteHandler,
   type AppRouteDebugLogger,
@@ -105,7 +106,7 @@ export async function readAppRouteHandlerCacheResponse(
             handlerFn: options.handlerFn,
             i18n: options.i18n,
             markDynamicUsage: options.markDynamicUsage,
-            params: options.params,
+            params: makeThenableParams(options.params),
             request: new Request(options.requestUrl, { method: "GET" }),
             routePattern: options.routePattern,
             setHeadersAccessPhase: options.setHeadersAccessPhase,

--- a/packages/vinext/src/server/app-route-handler-dispatch.ts
+++ b/packages/vinext/src/server/app-route-handler-dispatch.ts
@@ -37,6 +37,7 @@ import {
 } from "./app-route-handler-response.js";
 import { createStaticGenerationHeadersContext } from "./app-static-generation.js";
 import { buildPageCacheTags } from "./implicit-tags.js";
+import { makeThenableParams } from "vinext/shims/thenable-params";
 import { reportRequestError } from "./instrumentation.js";
 
 type AppRouteHandlerDispatchRoute = {
@@ -80,11 +81,6 @@ type DispatchAppRouteHandlerOptions = {
 
 function isAppRouteHandlerFunction(value: unknown): value is AppRouteHandlerFunction {
   return typeof value === "function";
-}
-
-function makeThenableParams<T extends AppRouteParams>(params: T): Promise<T> & T {
-  const plain = { ...params };
-  return Object.assign(Promise.resolve(plain), plain);
 }
 
 function buildRouteHandlerPageCacheTags(

--- a/packages/vinext/src/shims/thenable-params.ts
+++ b/packages/vinext/src/shims/thenable-params.ts
@@ -2,17 +2,77 @@ function hasParamProperty<T extends Record<string, unknown>>(obj: T, prop: Prope
   return Object.prototype.hasOwnProperty.call(obj, prop);
 }
 
-function isPromiseMethod(prop: PropertyKey): boolean {
-  return prop === "then" || prop === "catch" || prop === "finally";
+// Properties that cannot be shadowed by param names because they need to
+// remain the true underlying value for Promises / React to work correctly.
+//
+// Next.js comments out `value` and `error` in reflect-utils.ts because they
+// use `Promise.resolve(underlyingParams)` directly in production, so React
+// mutations on the promise object are never shadowed. vinext uses a Proxy
+// that intercepts sync reads through a separate `plain` object, which means
+// a param named `value` or `error` would shadow React's `.status`/`.value`
+// attachments that React adds to resolved promises for `use()` caching.
+// https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/utils/reflect-utils.ts
+const WELL_KNOWN_PROPERTIES = [
+  // Object prototype
+  "hasOwnProperty",
+  "isPrototypeOf",
+  "propertyIsEnumerable",
+  "toString",
+  "valueOf",
+  "toLocaleString",
+
+  // Promise prototype
+  "then",
+  "catch",
+  "finally",
+
+  // React Promise extension (status is explicitly reserved by Next.js;
+  // value/error are reserved here because our Proxy-based approach creates
+  // a shadowing risk that native Promise does not have)
+  "status",
+  "value",
+  "error",
+
+  // React introspection
+  "displayName",
+  "_debugInfo",
+
+  // Common tested properties
+  "toJSON",
+  "$$typeof",
+  "__esModule",
+
+  // Tested by flight when checking for iterables
+  "@@iterator",
+] as const;
+
+// The type-level set of well-known properties is derived directly from the
+// runtime array above, so they can never drift out of sync. These properties
+// are omitted from the synchronous intersection because the Proxy returns
+// Promise/React internals for them, not the param value. After awaiting, the
+// resolved object contains the actual param values for all keys.
+type WellKnownProperty = (typeof WELL_KNOWN_PROPERTIES)[number];
+
+const wellKnownProperties = new Set<PropertyKey>(WELL_KNOWN_PROPERTIES);
+
+function isWellKnownProperty(prop: PropertyKey): boolean {
+  return wellKnownProperties.has(prop);
 }
 
-export function makeThenableParams<T extends Record<string, unknown>>(obj: T) {
+export type ThenableParams<T extends Record<string, unknown>> = Promise<T> &
+  Omit<T, WellKnownProperty>;
+
+export function makeThenableParams<T extends Record<string, unknown>>(obj: T): ThenableParams<T> {
   const plain = { ...obj };
   const promise = Promise.resolve(plain);
 
+  // The Proxy implements both Promise and plain-object behaviour so that
+  // `await params` and `params.id` both work. TypeScript's Proxy type
+  // cannot express this intersection precisely — the cast is isolated to
+  // the boundary so the handler above stays fully type-checked.
   return new Proxy(promise, {
     get(target, prop, receiver) {
-      if (!isPromiseMethod(prop) && hasParamProperty(plain, prop)) {
+      if (!isWellKnownProperty(prop) && hasParamProperty(plain, prop)) {
         return Reflect.get(plain, prop);
       }
 
@@ -20,7 +80,7 @@ export function makeThenableParams<T extends Record<string, unknown>>(obj: T) {
       return typeof value === "function" ? value.bind(target) : value;
     },
     getOwnPropertyDescriptor(target, prop) {
-      if (!isPromiseMethod(prop) && hasParamProperty(plain, prop)) {
+      if (!isWellKnownProperty(prop) && hasParamProperty(plain, prop)) {
         return {
           configurable: true,
           enumerable: true,
@@ -32,10 +92,12 @@ export function makeThenableParams<T extends Record<string, unknown>>(obj: T) {
       return Reflect.getOwnPropertyDescriptor(target, prop);
     },
     has(target, prop) {
-      return Reflect.has(target, prop) || hasParamProperty(plain, prop);
+      return (
+        Reflect.has(target, prop) || (!isWellKnownProperty(prop) && hasParamProperty(plain, prop))
+      );
     },
     ownKeys() {
-      return Reflect.ownKeys(plain).filter((prop) => !isPromiseMethod(prop));
+      return Reflect.ownKeys(plain).filter((prop) => !isWellKnownProperty(prop));
     },
-  });
+  }) as unknown as ThenableParams<T>;
 }

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -112,6 +112,20 @@ describe("App Router integration", () => {
     expect(html).toContain("hello-world");
   });
 
+  // Ported from Next.js: test/e2e/app-dir/cache-components/cache-components.params.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/cache-components/cache-components.params.test.ts
+  it("renders pages with params named then, catch, finally, and status", async () => {
+    const { res, html } = await fetchHtml(baseUrl, "/params-shadow/foo/bar/baz/qux");
+    expect(res.status).toBe(200);
+    expect(html).toContain("Params Shadow Test");
+    expect(textContentByTestId(html, "then")).toBe("foo");
+    expect(textContentByTestId(html, "catch")).toBe("bar");
+    expect(textContentByTestId(html, "finally")).toBe("baz");
+    expect(textContentByTestId(html, "status")).toBe("qux");
+    // The params object must remain thenable (Promise methods are not shadowed)
+    expect(textContentByTestId(html, "is-thenable")).toBe("yes");
+  });
+
   it("does not collapse encoded slashes onto nested routes in dev", async () => {
     const encodedRes = await fetch(`${baseUrl}/headers%2Foverride-from-middleware`);
     expect(encodedRes.status).toBe(404);
@@ -690,6 +704,20 @@ describe("App Router integration", () => {
     expect(res.status).toBe(200);
     const data = await res.json();
     expect(data).toEqual({ id: "99", name: "Widget" });
+  });
+
+  // Ported from Next.js: test/e2e/app-dir/cache-components/cache-components.params.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/cache-components/cache-components.params.test.ts
+  it("passes params named then, catch, finally, and status to route handlers", async () => {
+    const res = await fetch(`${baseUrl}/api/params-shadow/foo/bar/baz/qux`);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.then).toBe("foo");
+    expect(data.catch).toBe("bar");
+    expect(data.finally).toBe("baz");
+    expect(data.status).toBe("qux");
+    // The params object must remain thenable (Promise methods are not shadowed)
+    expect(data.isThenable).toBe(true);
   });
 
   it("ignores default export route handlers and returns 405", async () => {

--- a/tests/fixtures/app-basic/app/api/params-shadow/[then]/[catch]/[finally]/[status]/route.ts
+++ b/tests/fixtures/app-basic/app/api/params-shadow/[then]/[catch]/[finally]/[status]/route.ts
@@ -1,0 +1,17 @@
+// Tests that params named then, catch, finally, and status work correctly
+// in route handlers. The thenable wrapper must protect well-known properties
+// so that await still works, while making the actual param values available
+// after resolution.
+export async function GET(
+  request: Request,
+  { params }: { params: { then: string; catch: string; finally: string; status: string } },
+) {
+  const resolved = await params;
+  return Response.json({
+    then: resolved.then,
+    catch: resolved.catch,
+    finally: resolved.finally,
+    status: resolved.status,
+    isThenable: typeof params.then === "function",
+  });
+}

--- a/tests/fixtures/app-basic/app/params-shadow/[then]/[catch]/[finally]/[status]/page.tsx
+++ b/tests/fixtures/app-basic/app/params-shadow/[then]/[catch]/[finally]/[status]/page.tsx
@@ -1,0 +1,20 @@
+// Tests that params named then, catch, finally, and status work correctly.
+// These names shadow Promise/React well-known properties, so the thenable
+// wrapper must protect them until the params are awaited.
+export default async function ParamsShadowPage({
+  params,
+}: {
+  params: { then: string; catch: string; finally: string; status: string };
+}) {
+  const resolved = await params;
+  return (
+    <main>
+      <h1>Params Shadow Test</h1>
+      <p data-testid="then">{resolved.then}</p>
+      <p data-testid="catch">{resolved.catch}</p>
+      <p data-testid="finally">{resolved.finally}</p>
+      <p data-testid="status">{resolved.status}</p>
+      <p data-testid="is-thenable">{typeof params.then === "function" ? "yes" : "no"}</p>
+    </main>
+  );
+}

--- a/tests/thenable-params.test.ts
+++ b/tests/thenable-params.test.ts
@@ -2,11 +2,90 @@ import { describe, expect, it } from "vite-plus/test";
 import { makeThenableParams } from "../packages/vinext/src/shims/thenable-params.js";
 
 describe("makeThenableParams", () => {
-  it("preserves empty params through sync keys and awaiting", async () => {
-    const params = makeThenableParams({});
+  it("is awaitable even when params contain then", async () => {
+    // eslint-disable-next-line unicorn/no-thenable
+    const params = makeThenableParams({ then: "foo" });
+    // If `then` were shadowing Promise.prototype.then, `await` would try to
+    // treat the object as a thenable and call `then` with resolve/reject,
+    // producing garbage or hanging. This must resolve to the plain object.
+    const resolved = await params;
+    // eslint-disable-next-line unicorn/no-thenable
+    expect(resolved).toEqual({ then: "foo" });
+  });
 
-    expect(Object.keys(params)).toEqual([]);
-    expect(await params).toEqual({});
+  it("allows sync access to non-well-known params", () => {
+    // eslint-disable-next-line unicorn/no-thenable
+    const params = makeThenableParams({ slug: "post", then: "foo" });
+    expect(params.slug).toBe("post");
+  });
+
+  it("protects Promise methods from shadowing so the object stays thenable", () => {
+    // eslint-disable-next-line unicorn/no-thenable
+    const params = makeThenableParams({ then: "foo", catch: "bar", finally: "baz" });
+
+    expect(typeof params.then).toBe("function");
+    expect(typeof params.catch).toBe("function");
+    expect(typeof params.finally).toBe("function");
+  });
+
+  it("protects React Promise status from shadowing", () => {
+    const params = makeThenableParams({ status: "ok" });
+
+    // React uses `status` on Promises for introspection; it must not be
+    // shadowed by a param of the same name. Use Reflect.get because the
+    // type system omits well-known properties from the sync intersection.
+    expect(Reflect.get(params, "status")).not.toBe("ok");
+  });
+
+  it("protects React Promise value and error from shadowing", () => {
+    const params = makeThenableParams({ value: "foo", error: "bar" });
+
+    // React may mutate resolved promises to attach `.value` and `.error`
+    // for `use()` caching. Our Proxy must not return the param value for
+    // these keys, or React would read the wrong value on re-render.
+    expect(Reflect.get(params, "value")).not.toBe("foo");
+    expect(Reflect.get(params, "error")).not.toBe("bar");
+  });
+
+  it("excludes well-known properties from enumeration", () => {
+    /* eslint-disable unicorn/no-thenable */
+    const params = makeThenableParams({
+      slug: "post",
+      then: "foo",
+      catch: "bar",
+      finally: "baz",
+      status: "ok",
+      value: "val",
+      error: "err",
+      toString: "str",
+    });
+    /* eslint-enable unicorn/no-thenable */
+
+    const keys = Object.keys(params);
+    expect(keys).toEqual(["slug"]);
+  });
+
+  it("makes well-known param values available after awaiting", async () => {
+    /* eslint-disable unicorn/no-thenable */
+    const params = makeThenableParams({
+      slug: "post",
+      then: "foo",
+      catch: "bar",
+      finally: "baz",
+      status: "ok",
+      value: "val",
+      error: "err",
+    });
+    /* eslint-enable unicorn/no-thenable */
+
+    const resolved = await params;
+    expect(resolved.slug).toBe("post");
+    expect(resolved.then).toBe("foo");
+    expect(resolved.catch).toBe("bar");
+    expect(resolved.finally).toBe("baz");
+    expect(resolved.status).toBe("ok");
+    expect(resolved.value).toBe("val");
+    expect(resolved.error).toBe("err");
   });
 
   it("preserves catch-all array params through sync and awaited access", async () => {
@@ -17,21 +96,10 @@ describe("makeThenableParams", () => {
     expect(await params).toEqual({ slug: ["a", "b"] });
   });
 
-  it("keeps Promise methods usable when params contain Promise method names", async () => {
-    const source: Record<string, string> = { slug: "post" };
-    Reflect.set(source, "catch", "catch-param");
-    Reflect.set(source, "finally", "finally-param");
-    Reflect.set(source, "then", "then-param");
-    const params = makeThenableParams(source);
+  it("preserves empty params through sync keys and awaiting", async () => {
+    const params = makeThenableParams({});
 
-    expect(Reflect.get(params, "slug")).toBe("post");
-    expect(typeof Reflect.get(params, "then")).toBe("function");
-    expect(typeof Reflect.get(params, "catch")).toBe("function");
-    expect(typeof Reflect.get(params, "finally")).toBe("function");
-    expect(Object.keys(params)).toEqual(["slug"]);
-
-    const awaited = await params;
-    expect(awaited).toEqual(source);
-    expect(Reflect.get(awaited, "then")).toBe("then-param");
+    expect(Object.keys(params)).toEqual([]);
+    expect(await params).toEqual({});
   });
 });


### PR DESCRIPTION
## What this changes

Unifies thenable params construction for App Router pages and route handlers under a single shared implementation, and expands the protected property set from `then/catch/finally` to the full well-known property list that Next.js reserves.

## Why

Route handlers used a local `Object.assign(Promise.resolve(...), params)` helper that did not protect **any** well-known properties from shadowing. If a route segment were named `then`, `catch`, `finally`, or `status`, the resulting params object would shadow the Promise/React methods and break `await params`, React introspection, or spread behaviour.

Page params used a stronger Proxy, but it only guarded `then/catch/finally`, missing React's Promise `status` field and other well-known properties like `toString`, `hasOwnProperty`, etc.

This inconsistency meant pages and route handlers behaved differently for the same URL segments, and certain param names could silently break runtime behaviour.

## Approach

- Expanded `packages/vinext/src/shims/thenable-params.ts` to protect the full well-known property set defined in Next.js `reflect-utils.ts`:
  - Promise prototype: `then`, `catch`, `finally`
  - React Promise extension: `status`
  - Object prototype: `hasOwnProperty`, `isPrototypeOf`, `propertyIsEnumerable`, `toString`, `valueOf`, `toLocaleString`
  - React introspection: `displayName`, `_debugInfo`
  - Common tested properties: `toJSON`, `$$typeof`, `__esModule`, `@@iterator`
- Replaced the weak local `makeThenableParams` in `app-route-handler-dispatch.ts` with the shared shim, eliminating the duplicate implementation.
- Added explicit `ThenableParams<T>` return type to document the contract at the boundary.

## Validation

- Unit tests (`tests/thenable-params.test.ts`) now verify:
  - `await params` works when params contain `then`
  - Sync access to non-well-known params still works
  - `params.then` / `params.catch` / `params.finally` remain functions (Promise methods are not shadowed)
  - `params.status` is protected from React Promise shadowing
  - `Object.keys(params)` excludes well-known properties
  - After `await params`, the resolved object contains the actual param values

- App Router integration tests (`tests/app-router.test.ts`) now verify:
  - Pages render correctly with params named `then`, `catch`, `finally`, and `status`
  - Route handlers return correct JSON with the same param names
  - The params object remains thenable before awaiting

## Risks / follow-ups

None. This is a pure bugfix that makes route handler params behave identically to page params. No public API changes.

## References

- Next.js `wellKnownProperties` source: [packages/next/src/shared/lib/utils/reflect-utils.ts](https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/utils/reflect-utils.ts)
- Next.js param shadowing tests: [test/e2e/app-dir/cache-components/cache-components.params.test.ts](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/cache-components/cache-components.params.test.ts)