### PR TITLE
fix(shims): match Next metadata merge and Twitter inheritance

### DIFF
--- a/packages/vinext/src/server/app-page-head.ts
+++ b/packages/vinext/src/server/app-page-head.ts
@@ -1,6 +1,7 @@
 import {
   mergeMetadataEntries,
   mergeViewport,
+  postProcessMetadata,
   resolveModuleMetadata,
   resolveModuleViewport,
   type Metadata,
@@ -397,6 +398,10 @@ export async function resolveAppPageHead<TModule extends AppPageHeadModule>(
       `[vinext] File-based metadata resolution failed while rendering error boundary for ${options.routePath}:`,
       error,
     );
+  }
+
+  if (metadata) {
+    metadata = postProcessMetadata(metadata);
   }
 
   return {

--- a/packages/vinext/src/shims/metadata.tsx
+++ b/packages/vinext/src/shims/metadata.tsx
@@ -317,6 +317,48 @@ export function mergeMetadata(metadataList: Metadata[]): Metadata {
   );
 }
 
+/**
+ * Keys whose values are nested objects that should be shallow-merged
+ * rather than replaced outright when both parent and child define them.
+ * Matches Next.js per-subkey resolution for openGraph, twitter, icons,
+ * alternates, robots, and other.
+ */
+const DEEP_MERGE_KEYS = new Set<string>([
+  "openGraph",
+  "twitter",
+  "icons",
+  "alternates",
+  "robots",
+  "other",
+]);
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === "object" && value !== null && !Array.isArray(value) && !(value instanceof URL)
+  );
+}
+
+/**
+ * Merge metadata from multiple sources (layouts + page).
+ *
+ * The list is ordered [rootLayout, nestedLayout, ..., page].
+ * Title template from layouts applies to the page title but NOT to
+ * the segment that defines the template itself. `title.absolute`
+ * skips all templates. `title.default` is the fallback when no
+ * child provides a title.
+ *
+ * For top-level keys, later entries override earlier ones.
+ * For nested object keys (openGraph, twitter, icons, alternates,
+ * robots, other), sub-properties are shallow-merged so that a
+ * child layout can override individual fields without discarding
+ * sibling fields set by an ancestor.
+ *
+ * After merging, openGraph and twitter fields are cross-filled:
+ * twitter inherits title/description/images from openGraph (or
+ * from root metadata as fallback), and openGraph inherits
+ * title/description from root metadata when absent.
+ * This matches Next.js `postProcessMetadata` / `inheritFromMetadata`.
+ */
 export function mergeMetadataEntries(entries: readonly MetadataMergeEntry[]): Metadata {
   if (entries.length === 0) return {};
 
@@ -341,10 +383,20 @@ export function mergeMetadataEntries(entries: readonly MetadataMergeEntry[]): Me
       parentTemplate = meta.title.template;
     }
 
-    // Shallow merge — later entries override earlier for top-level keys
+    // Merge non-title keys
     for (const key of Object.keys(meta)) {
       if (key === "title") continue; // Handle title separately below
-      (merged as Record<string, unknown>)[key] = (meta as Record<string, unknown>)[key];
+
+      const incoming = (meta as Record<string, unknown>)[key];
+      const existing = (merged as Record<string, unknown>)[key];
+
+      if (DEEP_MERGE_KEYS.has(key) && isPlainObject(existing) && isPlainObject(incoming)) {
+        // Shallow merge nested objects (e.g. openGraph, twitter, icons, alternates, robots, other)
+        (merged as Record<string, unknown>)[key] = { ...existing, ...incoming };
+      } else {
+        // Plain replacement for everything else
+        (merged as Record<string, unknown>)[key] = incoming;
+      }
     }
 
     // Title resolution
@@ -373,6 +425,87 @@ export function mergeMetadataEntries(entries: readonly MetadataMergeEntry[]): Me
         // Template only with no default — no title to render
         merged.title = undefined;
       }
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // OG / Twitter inheritance (post-process)
+  // Ported from Next.js:
+  // https://github.com/vercel/next.js/blob/canary/packages/next/src/lib/metadata/resolve-metadata.ts
+  // -------------------------------------------------------------------------
+
+  // Helper to extract a usable string title from metadata
+  function resolveStringTitle(title: Metadata["title"]): string | undefined {
+    if (typeof title === "string") return title;
+    if (title && typeof title === "object") {
+      return title.absolute || title.default || undefined;
+    }
+    return undefined;
+  }
+
+  const resolvedTitle = resolveStringTitle(merged.title);
+
+  // openGraph inherits title/description from root metadata when absent
+  if (merged.openGraph && isPlainObject(merged.openGraph)) {
+    const og = merged.openGraph as Record<string, unknown>;
+    if (!og.title && resolvedTitle) {
+      og.title = resolvedTitle;
+    }
+    if (!og.description && merged.description) {
+      og.description = merged.description;
+    }
+  }
+
+  // twitter inherits title/description/images from openGraph (or root metadata)
+  if (merged.openGraph && isPlainObject(merged.openGraph)) {
+    const og = merged.openGraph as Record<string, unknown>;
+
+    // Build auto-fill props only for fields that are missing on twitter
+    const autoFill: Record<string, unknown> = {};
+
+    const tw =
+      merged.twitter && isPlainObject(merged.twitter)
+        ? (merged.twitter as Record<string, unknown>)
+        : null;
+
+    const hasTwTitle = tw ? Boolean(tw.title) : false;
+    const hasTwDescription = tw ? Boolean(tw.description) : false;
+    // Next.js checks hasOwnProperty('images') to distinguish "not set" from "explicitly empty"
+    const hasTwImages = tw ? Object.prototype.hasOwnProperty.call(tw, "images") : false;
+
+    if (!hasTwTitle) {
+      if (og.title) {
+        autoFill.title = og.title;
+      } else if (resolvedTitle) {
+        autoFill.title = resolvedTitle;
+      }
+    }
+    if (!hasTwDescription) {
+      autoFill.description = og.description || merged.description || undefined;
+    }
+    if (!hasTwImages) {
+      if (og.images) {
+        autoFill.images = og.images;
+      }
+    }
+
+    if (Object.keys(autoFill).length > 0) {
+      if (tw) {
+        merged.twitter = { ...tw, ...autoFill };
+      } else {
+        merged.twitter = autoFill as Metadata["twitter"];
+      }
+    }
+  }
+
+  // If twitter exists (either originally or via auto-fill), ensure card type is set.
+  // Next.js resolveTwitter defaults: summary_large_image when images present, else summary.
+  if (merged.twitter && isPlainObject(merged.twitter)) {
+    const tw = merged.twitter as Record<string, unknown>;
+    if (!tw.card) {
+      const images = tw.images;
+      const hasImages = Array.isArray(images) ? images.length > 0 : Boolean(images);
+      tw.card = hasImages ? "summary_large_image" : "summary";
     }
   }
 

--- a/packages/vinext/src/shims/metadata.tsx
+++ b/packages/vinext/src/shims/metadata.tsx
@@ -318,31 +318,18 @@ export function mergeMetadata(metadataList: Metadata[]): Metadata {
   return postProcessMetadata(merged);
 }
 
-/**
- * Keys whose values are nested objects that should be shallow-merged
- * rather than replaced outright when both parent and child define them.
- *
- * These match the fields where Next.js does per-subkey resolution via
- * dedicated resolvers (resolveOpenGraph, resolveTwitter, resolveIcons,
- * resolveAlternates, resolveRobots) rather than a full replacement.
- *
- * Fields like verification, appleWebApp, appLinks, and formatDetection
- * are intentionally excluded — Next.js replaces these wholesale via their
- * own resolvers, so we match that behavior.
- */
-const DEEP_MERGE_KEYS = new Set<string>([
-  "openGraph",
-  "twitter",
-  "icons",
-  "alternates",
-  "robots",
-  "other",
-]);
-
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return (
     typeof value === "object" && value !== null && !Array.isArray(value) && !(value instanceof URL)
   );
+}
+
+function isOtherMetadata(value: unknown): value is NonNullable<Metadata["other"]> {
+  if (!isPlainObject(value)) return false;
+  return Object.values(value).every((item) => {
+    if (typeof item === "string") return true;
+    return Array.isArray(item) && item.every((nestedItem) => typeof nestedItem === "string");
+  });
 }
 
 /**
@@ -360,9 +347,10 @@ function resolveStringTitle(title: Metadata["title"]): string | undefined {
  * Post-process merged metadata to cross-fill openGraph and Twitter fields.
  *
  * Next.js runs this once after all layouts/pages and file-based metadata
- * have been resolved. It auto-fills missing twitter:title/description/images
- * from openGraph (or from root metadata as fallback) and missing
- * openGraph:title/description from root metadata.
+ * have been resolved. When openGraph exists, it auto-fills missing
+ * twitter:title/description/images from openGraph (falling back to root
+ * metadata title/description). Existing openGraph/twitter objects also inherit
+ * missing title/description from root metadata.
  *
  * Ported from Next.js:
  * https://github.com/vercel/next.js/blob/canary/packages/next/src/lib/metadata/resolve-metadata.ts
@@ -387,47 +375,53 @@ export function postProcessMetadata(merged: Metadata): Metadata {
     result.openGraph = og;
   }
 
-  // twitter inherits title/description/images from openGraph (or root metadata)
-  const autoFill: {
-    title?: string;
-    description?: string;
-    images?: NonNullable<Metadata["twitter"]>["images"];
-  } = {};
+  if (result.openGraph) {
+    const autoFill: {
+      title?: string;
+      description?: string;
+      images?: NonNullable<Metadata["twitter"]>["images"];
+    } = {};
 
-  const existingTwitter = result.twitter;
-  const hasTwTitle = existingTwitter ? Boolean(existingTwitter.title) : false;
-  const hasTwDescription = existingTwitter ? Boolean(existingTwitter.description) : false;
-  // Next.js checks hasOwnProperty('images') to distinguish "not set" from "explicitly empty"
-  const hasTwImages = existingTwitter
-    ? Object.prototype.hasOwnProperty.call(existingTwitter, "images")
-    : false;
+    const existingTwitter = result.twitter;
+    const hasTwTitle = existingTwitter ? Boolean(existingTwitter.title) : false;
+    const hasTwDescription = existingTwitter ? Boolean(existingTwitter.description) : false;
+    const hasTwImages = existingTwitter
+      ? Object.prototype.hasOwnProperty.call(existingTwitter, "images") &&
+        Boolean(existingTwitter.images)
+      : false;
 
-  if (!hasTwTitle) {
-    if (result.openGraph?.title) {
-      autoFill.title = result.openGraph.title;
-    } else if (resolvedTitle) {
-      autoFill.title = resolvedTitle;
+    if (!hasTwTitle) {
+      if (result.openGraph.title) {
+        autoFill.title = result.openGraph.title;
+      } else if (resolvedTitle) {
+        autoFill.title = resolvedTitle;
+      }
     }
-  }
-  if (!hasTwDescription) {
-    if (result.openGraph?.description) {
-      autoFill.description = result.openGraph.description;
-    } else if (result.description) {
-      autoFill.description = result.description;
+    if (!hasTwDescription) {
+      autoFill.description = result.openGraph.description || result.description || undefined;
     }
-  }
-  if (!hasTwImages) {
-    if (result.openGraph?.images) {
+    if (!hasTwImages) {
       autoFill.images = result.openGraph.images;
     }
+
+    if (Object.keys(autoFill).length > 0) {
+      if (existingTwitter) {
+        result.twitter = { ...existingTwitter, ...autoFill };
+      } else {
+        result.twitter = autoFill;
+      }
+    }
   }
 
-  if (Object.keys(autoFill).length > 0) {
-    if (existingTwitter) {
-      result.twitter = { ...existingTwitter, ...autoFill };
-    } else {
-      result.twitter = autoFill;
+  if (result.twitter) {
+    const tw = { ...result.twitter };
+    if (!tw.title && resolvedTitle) {
+      tw.title = resolvedTitle;
     }
+    if (!tw.description && result.description) {
+      tw.description = result.description;
+    }
+    result.twitter = tw;
   }
 
   // If twitter exists (either originally or via auto-fill), ensure card type is set.
@@ -454,11 +448,8 @@ export function postProcessMetadata(merged: Metadata): Metadata {
  * skips all templates. `title.default` is the fallback when no
  * child provides a title.
  *
- * For top-level keys, later entries override earlier ones.
- * For nested object keys (openGraph, twitter, icons, alternates,
- * robots, other), sub-properties are shallow-merged so that a
- * child layout can override individual fields without discarding
- * sibling fields set by an ancestor.
+ * For top-level keys, later entries override earlier ones. `other` custom meta
+ * tags are the exception: Next.js merges those across segments.
  */
 export function mergeMetadataEntries(entries: readonly MetadataMergeEntry[]): Metadata {
   if (entries.length === 0) return {};
@@ -491,9 +482,8 @@ export function mergeMetadataEntries(entries: readonly MetadataMergeEntry[]): Me
       const incoming = meta[key];
       const existing = merged[key];
 
-      if (DEEP_MERGE_KEYS.has(key) && isPlainObject(existing) && isPlainObject(incoming)) {
-        // Shallow merge nested objects (e.g. openGraph, twitter, icons, alternates, robots, other)
-        merged[key] = { ...existing, ...incoming };
+      if (key === "other" && isOtherMetadata(existing) && isOtherMetadata(incoming)) {
+        merged.other = { ...existing, ...incoming };
       } else {
         // Plain replacement for everything else
         merged[key] = incoming;

--- a/packages/vinext/src/shims/metadata.tsx
+++ b/packages/vinext/src/shims/metadata.tsx
@@ -309,12 +309,13 @@ export type MetadataMergeEntry = {
  * Shallow merge: later entries override earlier ones (per Next.js docs).
  */
 export function mergeMetadata(metadataList: Metadata[]): Metadata {
-  return mergeMetadataEntries(
+  const merged = mergeMetadataEntries(
     metadataList.map((metadata, index) => ({
       isPage: index === metadataList.length - 1,
       metadata,
     })),
   );
+  return postProcessMetadata(merged);
 }
 
 /**
@@ -339,6 +340,101 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 }
 
 /**
+ * Extract a plain string title from a metadata title value.
+ */
+function resolveStringTitle(title: Metadata["title"]): string | undefined {
+  if (typeof title === "string") return title;
+  if (title && typeof title === "object") {
+    return title.absolute || title.default || undefined;
+  }
+  return undefined;
+}
+
+/**
+ * Post-process merged metadata to cross-fill openGraph and Twitter fields.
+ *
+ * Next.js runs this once after all layouts/pages and file-based metadata
+ * have been resolved. It auto-fills missing twitter:title/description/images
+ * from openGraph (or from root metadata as fallback) and missing
+ * openGraph:title/description from root metadata.
+ *
+ * Ported from Next.js:
+ * https://github.com/vercel/next.js/blob/canary/packages/next/src/lib/metadata/resolve-metadata.ts
+ */
+export function postProcessMetadata(merged: Metadata): Metadata {
+  const resolvedTitle = resolveStringTitle(merged.title);
+
+  // openGraph inherits title/description from root metadata when absent
+  if (merged.openGraph) {
+    const og = { ...merged.openGraph };
+    if (!og.title && resolvedTitle) {
+      og.title = resolvedTitle;
+    }
+    if (!og.description && merged.description) {
+      og.description = merged.description;
+    }
+    merged.openGraph = og;
+  }
+
+  // twitter inherits title/description/images from openGraph (or root metadata)
+  const autoFill: {
+    title?: string;
+    description?: string;
+    images?: NonNullable<Metadata["twitter"]>["images"];
+  } = {};
+
+  const existingTwitter = merged.twitter;
+  const hasTwTitle = existingTwitter ? Boolean(existingTwitter.title) : false;
+  const hasTwDescription = existingTwitter ? Boolean(existingTwitter.description) : false;
+  // Next.js checks hasOwnProperty('images') to distinguish "not set" from "explicitly empty"
+  const hasTwImages = existingTwitter
+    ? Object.prototype.hasOwnProperty.call(existingTwitter, "images")
+    : false;
+
+  if (!hasTwTitle) {
+    if (merged.openGraph?.title) {
+      autoFill.title = merged.openGraph.title;
+    } else if (resolvedTitle) {
+      autoFill.title = resolvedTitle;
+    }
+  }
+  if (!hasTwDescription) {
+    if (merged.openGraph?.description) {
+      autoFill.description = merged.openGraph.description;
+    } else if (merged.description) {
+      autoFill.description = merged.description;
+    }
+  }
+  if (!hasTwImages) {
+    if (merged.openGraph?.images) {
+      autoFill.images = merged.openGraph.images;
+    }
+  }
+
+  if (Object.keys(autoFill).length > 0) {
+    if (existingTwitter) {
+      merged.twitter = { ...existingTwitter, ...autoFill };
+    } else {
+      merged.twitter = autoFill;
+    }
+  }
+
+  // If twitter exists (either originally or via auto-fill), ensure card type is set.
+  // Next.js resolveTwitter defaults: summary_large_image when images present, else summary.
+  if (merged.twitter) {
+    const tw = { ...merged.twitter };
+    if (!tw.card) {
+      const images = tw.images;
+      const hasImages = Array.isArray(images) ? images.length > 0 : Boolean(images);
+      tw.card = hasImages ? "summary_large_image" : "summary";
+    }
+    merged.twitter = tw;
+  }
+
+  return merged;
+}
+
+/**
  * Merge metadata from multiple sources (layouts + page).
  *
  * The list is ordered [rootLayout, nestedLayout, ..., page].
@@ -352,12 +448,6 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
  * robots, other), sub-properties are shallow-merged so that a
  * child layout can override individual fields without discarding
  * sibling fields set by an ancestor.
- *
- * After merging, openGraph and twitter fields are cross-filled:
- * twitter inherits title/description/images from openGraph (or
- * from root metadata as fallback), and openGraph inherits
- * title/description from root metadata when absent.
- * This matches Next.js `postProcessMetadata` / `inheritFromMetadata`.
  */
 export function mergeMetadataEntries(entries: readonly MetadataMergeEntry[]): Metadata {
   if (entries.length === 0) return {};
@@ -387,15 +477,15 @@ export function mergeMetadataEntries(entries: readonly MetadataMergeEntry[]): Me
     for (const key of Object.keys(meta)) {
       if (key === "title") continue; // Handle title separately below
 
-      const incoming = (meta as Record<string, unknown>)[key];
-      const existing = (merged as Record<string, unknown>)[key];
+      const incoming = meta[key];
+      const existing = merged[key];
 
       if (DEEP_MERGE_KEYS.has(key) && isPlainObject(existing) && isPlainObject(incoming)) {
         // Shallow merge nested objects (e.g. openGraph, twitter, icons, alternates, robots, other)
-        (merged as Record<string, unknown>)[key] = { ...existing, ...incoming };
+        merged[key] = { ...existing, ...incoming };
       } else {
         // Plain replacement for everything else
-        (merged as Record<string, unknown>)[key] = incoming;
+        merged[key] = incoming;
       }
     }
 
@@ -425,87 +515,6 @@ export function mergeMetadataEntries(entries: readonly MetadataMergeEntry[]): Me
         // Template only with no default — no title to render
         merged.title = undefined;
       }
-    }
-  }
-
-  // -------------------------------------------------------------------------
-  // OG / Twitter inheritance (post-process)
-  // Ported from Next.js:
-  // https://github.com/vercel/next.js/blob/canary/packages/next/src/lib/metadata/resolve-metadata.ts
-  // -------------------------------------------------------------------------
-
-  // Helper to extract a usable string title from metadata
-  function resolveStringTitle(title: Metadata["title"]): string | undefined {
-    if (typeof title === "string") return title;
-    if (title && typeof title === "object") {
-      return title.absolute || title.default || undefined;
-    }
-    return undefined;
-  }
-
-  const resolvedTitle = resolveStringTitle(merged.title);
-
-  // openGraph inherits title/description from root metadata when absent
-  if (merged.openGraph && isPlainObject(merged.openGraph)) {
-    const og = merged.openGraph as Record<string, unknown>;
-    if (!og.title && resolvedTitle) {
-      og.title = resolvedTitle;
-    }
-    if (!og.description && merged.description) {
-      og.description = merged.description;
-    }
-  }
-
-  // twitter inherits title/description/images from openGraph (or root metadata)
-  if (merged.openGraph && isPlainObject(merged.openGraph)) {
-    const og = merged.openGraph as Record<string, unknown>;
-
-    // Build auto-fill props only for fields that are missing on twitter
-    const autoFill: Record<string, unknown> = {};
-
-    const tw =
-      merged.twitter && isPlainObject(merged.twitter)
-        ? (merged.twitter as Record<string, unknown>)
-        : null;
-
-    const hasTwTitle = tw ? Boolean(tw.title) : false;
-    const hasTwDescription = tw ? Boolean(tw.description) : false;
-    // Next.js checks hasOwnProperty('images') to distinguish "not set" from "explicitly empty"
-    const hasTwImages = tw ? Object.prototype.hasOwnProperty.call(tw, "images") : false;
-
-    if (!hasTwTitle) {
-      if (og.title) {
-        autoFill.title = og.title;
-      } else if (resolvedTitle) {
-        autoFill.title = resolvedTitle;
-      }
-    }
-    if (!hasTwDescription) {
-      autoFill.description = og.description || merged.description || undefined;
-    }
-    if (!hasTwImages) {
-      if (og.images) {
-        autoFill.images = og.images;
-      }
-    }
-
-    if (Object.keys(autoFill).length > 0) {
-      if (tw) {
-        merged.twitter = { ...tw, ...autoFill };
-      } else {
-        merged.twitter = autoFill as Metadata["twitter"];
-      }
-    }
-  }
-
-  // If twitter exists (either originally or via auto-fill), ensure card type is set.
-  // Next.js resolveTwitter defaults: summary_large_image when images present, else summary.
-  if (merged.twitter && isPlainObject(merged.twitter)) {
-    const tw = merged.twitter as Record<string, unknown>;
-    if (!tw.card) {
-      const images = tw.images;
-      const hasImages = Array.isArray(images) ? images.length > 0 : Boolean(images);
-      tw.card = hasImages ? "summary_large_image" : "summary";
     }
   }
 

--- a/packages/vinext/src/shims/metadata.tsx
+++ b/packages/vinext/src/shims/metadata.tsx
@@ -321,8 +321,14 @@ export function mergeMetadata(metadataList: Metadata[]): Metadata {
 /**
  * Keys whose values are nested objects that should be shallow-merged
  * rather than replaced outright when both parent and child define them.
- * Matches Next.js per-subkey resolution for openGraph, twitter, icons,
- * alternates, robots, and other.
+ *
+ * These match the fields where Next.js does per-subkey resolution via
+ * dedicated resolvers (resolveOpenGraph, resolveTwitter, resolveIcons,
+ * resolveAlternates, resolveRobots) rather than a full replacement.
+ *
+ * Fields like verification, appleWebApp, appLinks, and formatDetection
+ * are intentionally excluded — Next.js replaces these wholesale via their
+ * own resolvers, so we match that behavior.
  */
 const DEEP_MERGE_KEYS = new Set<string>([
   "openGraph",
@@ -345,7 +351,7 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 function resolveStringTitle(title: Metadata["title"]): string | undefined {
   if (typeof title === "string") return title;
   if (title && typeof title === "object") {
-    return title.absolute || title.default || undefined;
+    return title.absolute ?? title.default ?? undefined;
   }
   return undefined;
 }
@@ -362,18 +368,23 @@ function resolveStringTitle(title: Metadata["title"]): string | undefined {
  * https://github.com/vercel/next.js/blob/canary/packages/next/src/lib/metadata/resolve-metadata.ts
  */
 export function postProcessMetadata(merged: Metadata): Metadata {
-  const resolvedTitle = resolveStringTitle(merged.title);
+  // Shallow-clone to avoid mutating the caller's object.
+  // Both current call sites (mergeMetadata, resolveAppPageHead) pass
+  // freshly-constructed objects, but this guards against future misuse.
+  const result = { ...merged };
+
+  const resolvedTitle = resolveStringTitle(result.title);
 
   // openGraph inherits title/description from root metadata when absent
-  if (merged.openGraph) {
-    const og = { ...merged.openGraph };
+  if (result.openGraph) {
+    const og = { ...result.openGraph };
     if (!og.title && resolvedTitle) {
       og.title = resolvedTitle;
     }
-    if (!og.description && merged.description) {
-      og.description = merged.description;
+    if (!og.description && result.description) {
+      og.description = result.description;
     }
-    merged.openGraph = og;
+    result.openGraph = og;
   }
 
   // twitter inherits title/description/images from openGraph (or root metadata)
@@ -383,7 +394,7 @@ export function postProcessMetadata(merged: Metadata): Metadata {
     images?: NonNullable<Metadata["twitter"]>["images"];
   } = {};
 
-  const existingTwitter = merged.twitter;
+  const existingTwitter = result.twitter;
   const hasTwTitle = existingTwitter ? Boolean(existingTwitter.title) : false;
   const hasTwDescription = existingTwitter ? Boolean(existingTwitter.description) : false;
   // Next.js checks hasOwnProperty('images') to distinguish "not set" from "explicitly empty"
@@ -392,46 +403,46 @@ export function postProcessMetadata(merged: Metadata): Metadata {
     : false;
 
   if (!hasTwTitle) {
-    if (merged.openGraph?.title) {
-      autoFill.title = merged.openGraph.title;
+    if (result.openGraph?.title) {
+      autoFill.title = result.openGraph.title;
     } else if (resolvedTitle) {
       autoFill.title = resolvedTitle;
     }
   }
   if (!hasTwDescription) {
-    if (merged.openGraph?.description) {
-      autoFill.description = merged.openGraph.description;
-    } else if (merged.description) {
-      autoFill.description = merged.description;
+    if (result.openGraph?.description) {
+      autoFill.description = result.openGraph.description;
+    } else if (result.description) {
+      autoFill.description = result.description;
     }
   }
   if (!hasTwImages) {
-    if (merged.openGraph?.images) {
-      autoFill.images = merged.openGraph.images;
+    if (result.openGraph?.images) {
+      autoFill.images = result.openGraph.images;
     }
   }
 
   if (Object.keys(autoFill).length > 0) {
     if (existingTwitter) {
-      merged.twitter = { ...existingTwitter, ...autoFill };
+      result.twitter = { ...existingTwitter, ...autoFill };
     } else {
-      merged.twitter = autoFill;
+      result.twitter = autoFill;
     }
   }
 
   // If twitter exists (either originally or via auto-fill), ensure card type is set.
   // Next.js resolveTwitter defaults: summary_large_image when images present, else summary.
-  if (merged.twitter) {
-    const tw = { ...merged.twitter };
+  if (result.twitter) {
+    const tw = { ...result.twitter };
     if (!tw.card) {
       const images = tw.images;
       const hasImages = Array.isArray(images) ? images.length > 0 : Boolean(images);
       tw.card = hasImages ? "summary_large_image" : "summary";
     }
-    merged.twitter = tw;
+    result.twitter = tw;
   }
 
-  return merged;
+  return result;
 }
 
 /**

--- a/tests/app-page-head.test.ts
+++ b/tests/app-page-head.test.ts
@@ -180,11 +180,6 @@ describe("app page head resolution", () => {
     expect(result.metadata).toEqual({
       description: "Nested",
       title: "Root",
-      twitter: {
-        card: "summary",
-        description: "Nested",
-        title: "Root",
-      },
     });
     expect(nestedLayoutParamsSeen).toEqual([{}]);
   });

--- a/tests/app-page-head.test.ts
+++ b/tests/app-page-head.test.ts
@@ -128,9 +128,17 @@ describe("app page head resolution", () => {
     expect(result.metadata).toEqual({
       description: "tag next,vinext",
       openGraph: {
+        description: "tag next,vinext",
         images: ["/root-og.png", "/nested-og.png"],
+        title: "Post | Root",
       },
       title: "Post | Root",
+      twitter: {
+        card: "summary_large_image",
+        description: "tag next,vinext",
+        images: ["/root-og.png", "/nested-og.png"],
+        title: "Post | Root",
+      },
     });
     expect(result.viewport).toEqual({
       initialScale: 1,
@@ -172,6 +180,11 @@ describe("app page head resolution", () => {
     expect(result.metadata).toEqual({
       description: "Nested",
       title: "Root",
+      twitter: {
+        card: "summary",
+        description: "Nested",
+        title: "Root",
+      },
     });
     expect(nestedLayoutParamsSeen).toEqual([{}]);
   });
@@ -314,9 +327,15 @@ describe("app page head resolution", () => {
     expect(result.metadata).toEqual({
       description: "Root description",
       openGraph: {
+        description: "Root description",
         title: "Slot OG title",
       },
       title: "Page title",
+      twitter: {
+        card: "summary",
+        description: "Root description",
+        title: "Slot OG title",
+      },
     });
   });
 
@@ -366,9 +385,15 @@ describe("app page head resolution", () => {
     expect(result.metadata).toEqual({
       description: "Primary page",
       openGraph: {
+        description: "Primary page",
         title: "Slot OG title",
       },
       title: "Page",
+      twitter: {
+        card: "summary",
+        description: "Primary page",
+        title: "Slot OG title",
+      },
     });
   });
 

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -2337,6 +2337,17 @@ describe("metadata deep merge", () => {
       description: "Page desc",
     });
   });
+
+  it("child can clear a parent openGraph subkey by setting it to undefined", () => {
+    const result = mergeMetadata([
+      { openGraph: { title: "Root", images: ["/og.png"] } },
+      { openGraph: { images: undefined } },
+    ]);
+    expect(result.openGraph?.title).toBe("Root");
+    expect(result.openGraph?.images).toBeUndefined();
+    // Post-process: cleared og.images means twitter doesn't inherit images
+    expect(result.twitter?.images).toBeUndefined();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -2212,17 +2212,13 @@ describe("metadata title templates", () => {
       },
     ]);
 
-    // Next.js postProcessMetadata fills openGraph.description from metadata.description
-    // and auto-fills twitter from openGraph when twitter is not explicitly configured.
+    // mergeMetadataEntries does raw deep-merge only; post-processing is applied
+    // separately by postProcessMetadata (called by mergeMetadata and by
+    // resolveAppPageHead after file-based metadata is applied).
     expect(result).toEqual({
       description: "Page",
-      openGraph: { title: "Slot OG title", description: "Page" },
+      openGraph: { title: "Slot OG title" },
       title: "Page",
-      twitter: {
-        card: "summary",
-        description: "Page",
-        title: "Slot OG title",
-      },
     });
   });
 });
@@ -2385,6 +2381,13 @@ describe("metadata OG/Twitter inheritance", () => {
   it("auto-fills twitter:description from metadata.description when openGraph.description is absent", () => {
     const result = mergeMetadata([{ description: "Page Desc", openGraph: {} }]);
     expect(result.twitter?.description).toBe("Page Desc");
+  });
+
+  it("auto-fills twitter fields from metadata when openGraph is absent entirely", () => {
+    const result = mergeMetadata([{ title: "Page Title", description: "Page Desc" }]);
+    expect(result.twitter?.title).toBe("Page Title");
+    expect(result.twitter?.description).toBe("Page Desc");
+    expect(result.twitter?.card).toBe("summary");
   });
 
   it("does not overwrite explicitly set twitter fields", () => {

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -2178,8 +2178,10 @@ describe("metadata title templates", () => {
       { description: "From page" },
     ]);
     expect(result.description).toBe("From page");
-    // openGraph from layout should be inherited if page doesn't override it
-    expect(result.openGraph).toEqual({ title: "OG Layout" });
+    // openGraph from layout should be inherited if page doesn't override it.
+    // Next.js postProcessMetadata also fills openGraph.description from
+    // metadata.description when absent.
+    expect(result.openGraph).toEqual({ title: "OG Layout", description: "From page" });
   });
 
   it("simple string title without template passes through", () => {
@@ -2210,11 +2212,238 @@ describe("metadata title templates", () => {
       },
     ]);
 
+    // Next.js postProcessMetadata fills openGraph.description from metadata.description
+    // and auto-fills twitter from openGraph when twitter is not explicitly configured.
     expect(result).toEqual({
       description: "Page",
-      openGraph: { title: "Slot OG title" },
+      openGraph: { title: "Slot OG title", description: "Page" },
       title: "Page",
+      twitter: {
+        card: "summary",
+        description: "Page",
+        title: "Slot OG title",
+      },
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Metadata deep merge tests
+// Ported from Next.js behavior: test/e2e/app-dir/metadata/metadata.test.ts
+// https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/metadata/metadata.test.ts
+
+describe("metadata deep merge", () => {
+  let mergeMetadata: typeof import("../packages/vinext/src/shims/metadata.js").mergeMetadata;
+
+  beforeAll(async () => {
+    const mod = await import("../packages/vinext/src/shims/metadata.js");
+    mergeMetadata = mod.mergeMetadata;
+  });
+
+  it("deep-merges openGraph subkeys instead of replacing the whole object", () => {
+    const result = mergeMetadata([
+      { openGraph: { siteName: "My Site", images: ["/og-root.png"], locale: "en-US" } },
+      { openGraph: { title: "Child Page" } },
+    ]);
+    expect(result.openGraph).toEqual({
+      siteName: "My Site",
+      images: ["/og-root.png"],
+      locale: "en-US",
+      title: "Child Page",
+    });
+  });
+
+  it("deep-merges twitter subkeys instead of replacing the whole object", () => {
+    const result = mergeMetadata([
+      { twitter: { card: "summary", site: "@site" } },
+      { twitter: { title: "Tweet Title" } },
+    ]);
+    expect(result.twitter).toEqual({
+      card: "summary",
+      site: "@site",
+      title: "Tweet Title",
+    });
+  });
+
+  it("deep-merges alternates subkeys", () => {
+    const result = mergeMetadata([
+      { alternates: { canonical: "https://example.com", languages: { "en-US": "/en" } } },
+      { alternates: { media: { print: "/print" } } },
+    ]);
+    expect(result.alternates).toEqual({
+      canonical: "https://example.com",
+      languages: { "en-US": "/en" },
+      media: { print: "/print" },
+    });
+  });
+
+  it("deep-merges robots subkeys when both are objects", () => {
+    const result = mergeMetadata([
+      { robots: { index: true, follow: true, googleBot: { index: true } } },
+      { robots: { follow: false } },
+    ]);
+    expect(result.robots).toEqual({
+      index: true,
+      follow: false,
+      googleBot: { index: true },
+    });
+  });
+
+  it("replaces robots string with object outright", () => {
+    const result = mergeMetadata([{ robots: "index, follow" }, { robots: { index: false } }]);
+    expect(result.robots).toEqual({ index: false });
+  });
+
+  it("deep-merges icons when both are map objects", () => {
+    const result = mergeMetadata([
+      { icons: { icon: "/favicon.ico", apple: "/apple.png" } },
+      { icons: { shortcut: "/shortcut.png" } },
+    ]);
+    expect(result.icons).toEqual({
+      icon: "/favicon.ico",
+      apple: "/apple.png",
+      shortcut: "/shortcut.png",
+    });
+  });
+
+  it("replaces shorthand icon string with map object", () => {
+    const result = mergeMetadata([{ icons: "/favicon.ico" }, { icons: { apple: "/apple.png" } }]);
+    expect(result.icons).toEqual({ apple: "/apple.png" });
+  });
+
+  it("deep-merges other custom meta tags", () => {
+    const result = mergeMetadata([
+      { other: { foo: "bar", baz: "qux" } },
+      { other: { baz: "override", new: "value" } },
+    ]);
+    expect(result.other).toEqual({
+      foo: "bar",
+      baz: "override",
+      new: "value",
+    });
+  });
+
+  it("preserves root openGraph when page does not override it", () => {
+    const result = mergeMetadata([
+      { openGraph: { title: "OG Layout", siteName: "Site" } },
+      { keywords: ["page"] },
+    ]);
+    expect(result.openGraph).toEqual({ title: "OG Layout", siteName: "Site" });
+  });
+
+  it("inherits openGraph.description from metadata.description when missing", () => {
+    const result = mergeMetadata([
+      { openGraph: { title: "OG Layout" } },
+      { description: "Page desc" },
+    ]);
+    expect(result.openGraph).toEqual({
+      title: "OG Layout",
+      description: "Page desc",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Metadata OG/Twitter inheritance tests
+// Ported from Next.js behavior: packages/next/src/lib/metadata/resolve-metadata.ts
+// https://github.com/vercel/next.js/blob/canary/packages/next/src/lib/metadata/resolve-metadata.ts
+
+describe("metadata OG/Twitter inheritance", () => {
+  let mergeMetadata: typeof import("../packages/vinext/src/shims/metadata.js").mergeMetadata;
+  let MetadataHead: typeof import("../packages/vinext/src/shims/metadata.js").MetadataHead;
+  let React: typeof import("react");
+  let renderToStaticMarkup: typeof import("react-dom/server").renderToStaticMarkup;
+
+  beforeAll(async () => {
+    const mod = await import("../packages/vinext/src/shims/metadata.js");
+    mergeMetadata = mod.mergeMetadata;
+    MetadataHead = mod.MetadataHead;
+    React = await import("react");
+    renderToStaticMarkup = (await import("react-dom/server")).renderToStaticMarkup;
+  });
+
+  it("auto-fills twitter:title from openGraph:title", () => {
+    const result = mergeMetadata([{ openGraph: { title: "OG Title" } }]);
+    expect(result.twitter?.title).toBe("OG Title");
+  });
+
+  it("auto-fills twitter:description from openGraph:description", () => {
+    const result = mergeMetadata([{ openGraph: { description: "OG Desc" } }]);
+    expect(result.twitter?.description).toBe("OG Desc");
+  });
+
+  it("auto-fills twitter:images from openGraph:images", () => {
+    const result = mergeMetadata([{ openGraph: { images: ["/og.png"] } }]);
+    expect(result.twitter?.images).toEqual(["/og.png"]);
+  });
+
+  it("auto-fills twitter:title from metadata.title when openGraph.title is absent", () => {
+    const result = mergeMetadata([{ title: "Page Title", openGraph: {} }]);
+    expect(result.twitter?.title).toBe("Page Title");
+  });
+
+  it("auto-fills twitter:description from metadata.description when openGraph.description is absent", () => {
+    const result = mergeMetadata([{ description: "Page Desc", openGraph: {} }]);
+    expect(result.twitter?.description).toBe("Page Desc");
+  });
+
+  it("does not overwrite explicitly set twitter fields", () => {
+    const result = mergeMetadata([
+      { openGraph: { title: "OG Title", description: "OG Desc", images: ["/og.png"] } },
+      { twitter: { title: "Custom Twitter Title", description: "Custom Twitter Desc" } },
+    ]);
+    expect(result.twitter?.title).toBe("Custom Twitter Title");
+    expect(result.twitter?.description).toBe("Custom Twitter Desc");
+  });
+
+  it("does not auto-fill twitter:images when twitter.images is explicitly set to empty array", () => {
+    const result = mergeMetadata([
+      { openGraph: { images: ["/og.png"] } },
+      { twitter: { images: [] } },
+    ]);
+    expect(result.twitter?.images).toEqual([]);
+  });
+
+  it("auto-fills openGraph:title from metadata.title", () => {
+    const result = mergeMetadata([{ title: "Page Title", openGraph: {} }]);
+    expect(result.openGraph?.title).toBe("Page Title");
+  });
+
+  it("auto-fills openGraph:description from metadata.description", () => {
+    const result = mergeMetadata([{ description: "Page Desc", openGraph: {} }]);
+    expect(result.openGraph?.description).toBe("Page Desc");
+  });
+
+  it("renders twitter card tags when only openGraph is configured", () => {
+    const metadata = mergeMetadata([
+      {
+        openGraph: {
+          title: "My custom title",
+          description: "My custom description",
+          url: "https://example.com",
+          siteName: "My custom site name",
+          images: [{ url: "https://example.com/image.png", width: 800, height: 600 }],
+          locale: "en-US",
+          type: "website",
+        },
+      },
+    ]);
+    const html = renderToStaticMarkup(React.createElement(MetadataHead, { metadata }));
+    expect(html).toContain('name="twitter:card"');
+    expect(html).toContain('content="summary_large_image"');
+    expect(html).toContain('name="twitter:title"');
+    expect(html).toContain('content="My custom title"');
+    expect(html).toContain('name="twitter:description"');
+    expect(html).toContain('content="My custom description"');
+    expect(html).toContain('name="twitter:image"');
+    expect(html).toContain('content="https://example.com/image.png"');
+  });
+
+  it("renders twitter:card summary when no images are present", () => {
+    const metadata = mergeMetadata([{ openGraph: { title: "No Images" } }]);
+    const html = renderToStaticMarkup(React.createElement(MetadataHead, { metadata }));
+    expect(html).toContain('name="twitter:card"');
+    expect(html).toContain('content="summary"');
   });
 });
 

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -2212,8 +2212,8 @@ describe("metadata title templates", () => {
       },
     ]);
 
-    // mergeMetadataEntries does raw deep-merge only; post-processing is applied
-    // separately by postProcessMetadata (called by mergeMetadata and by
+    // mergeMetadataEntries does raw segment merging only; post-processing is
+    // applied separately by postProcessMetadata (called by mergeMetadata and by
     // resolveAppPageHead after file-based metadata is applied).
     expect(result).toEqual({
       description: "Page",
@@ -2224,11 +2224,13 @@ describe("metadata title templates", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Metadata deep merge tests
-// Ported from Next.js behavior: test/e2e/app-dir/metadata/metadata.test.ts
-// https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/metadata/metadata.test.ts
+// Metadata segment merge tests
+// Ported from Next.js behavior:
+// - docs: https://nextjs.org/docs/app/api-reference/functions/generate-metadata#merging
+// - source: packages/next/src/lib/metadata/resolve-metadata.ts
+// https://github.com/vercel/next.js/blob/canary/packages/next/src/lib/metadata/resolve-metadata.ts
 
-describe("metadata deep merge", () => {
+describe("metadata segment merge", () => {
   let mergeMetadata: typeof import("../packages/vinext/src/shims/metadata.js").mergeMetadata;
 
   beforeAll(async () => {
@@ -2236,52 +2238,45 @@ describe("metadata deep merge", () => {
     mergeMetadata = mod.mergeMetadata;
   });
 
-  it("deep-merges openGraph subkeys instead of replacing the whole object", () => {
+  it("replaces openGraph instead of deep-merging subkeys", () => {
     const result = mergeMetadata([
       { openGraph: { siteName: "My Site", images: ["/og-root.png"], locale: "en-US" } },
       { openGraph: { title: "Child Page" } },
     ]);
     expect(result.openGraph).toEqual({
-      siteName: "My Site",
-      images: ["/og-root.png"],
-      locale: "en-US",
       title: "Child Page",
     });
+    expect(result.twitter?.images).toBeUndefined();
   });
 
-  it("deep-merges twitter subkeys instead of replacing the whole object", () => {
+  it("replaces twitter instead of deep-merging subkeys", () => {
     const result = mergeMetadata([
       { twitter: { card: "summary", site: "@site" } },
       { twitter: { title: "Tweet Title" } },
     ]);
     expect(result.twitter).toEqual({
-      card: "summary",
-      site: "@site",
       title: "Tweet Title",
+      card: "summary",
     });
   });
 
-  it("deep-merges alternates subkeys", () => {
+  it("replaces alternates instead of deep-merging subkeys", () => {
     const result = mergeMetadata([
       { alternates: { canonical: "https://example.com", languages: { "en-US": "/en" } } },
       { alternates: { media: { print: "/print" } } },
     ]);
     expect(result.alternates).toEqual({
-      canonical: "https://example.com",
-      languages: { "en-US": "/en" },
       media: { print: "/print" },
     });
   });
 
-  it("deep-merges robots subkeys when both are objects", () => {
+  it("replaces robots instead of deep-merging subkeys", () => {
     const result = mergeMetadata([
       { robots: { index: true, follow: true, googleBot: { index: true } } },
       { robots: { follow: false } },
     ]);
     expect(result.robots).toEqual({
-      index: true,
       follow: false,
-      googleBot: { index: true },
     });
   });
 
@@ -2290,14 +2285,12 @@ describe("metadata deep merge", () => {
     expect(result.robots).toEqual({ index: false });
   });
 
-  it("deep-merges icons when both are map objects", () => {
+  it("replaces icons instead of deep-merging map objects", () => {
     const result = mergeMetadata([
       { icons: { icon: "/favicon.ico", apple: "/apple.png" } },
       { icons: { shortcut: "/shortcut.png" } },
     ]);
     expect(result.icons).toEqual({
-      icon: "/favicon.ico",
-      apple: "/apple.png",
       shortcut: "/shortcut.png",
     });
   });
@@ -2307,7 +2300,7 @@ describe("metadata deep merge", () => {
     expect(result.icons).toEqual({ apple: "/apple.png" });
   });
 
-  it("deep-merges other custom meta tags", () => {
+  it("merges other custom meta tags", () => {
     const result = mergeMetadata([
       { other: { foo: "bar", baz: "qux" } },
       { other: { baz: "override", new: "value" } },
@@ -2338,14 +2331,13 @@ describe("metadata deep merge", () => {
     });
   });
 
-  it("child can clear a parent openGraph subkey by setting it to undefined", () => {
+  it("child openGraph replaces the whole parent openGraph object", () => {
     const result = mergeMetadata([
       { openGraph: { title: "Root", images: ["/og.png"] } },
       { openGraph: { images: undefined } },
     ]);
-    expect(result.openGraph?.title).toBe("Root");
+    expect(result.openGraph?.title).toBeUndefined();
     expect(result.openGraph?.images).toBeUndefined();
-    // Post-process: cleared og.images means twitter doesn't inherit images
     expect(result.twitter?.images).toBeUndefined();
   });
 });
@@ -2394,8 +2386,13 @@ describe("metadata OG/Twitter inheritance", () => {
     expect(result.twitter?.description).toBe("Page Desc");
   });
 
-  it("auto-fills twitter fields from metadata when openGraph is absent entirely", () => {
+  it("does not create twitter fields from metadata when openGraph is absent entirely", () => {
     const result = mergeMetadata([{ title: "Page Title", description: "Page Desc" }]);
+    expect(result.twitter).toBeUndefined();
+  });
+
+  it("fills existing twitter title and description from metadata when openGraph is absent", () => {
+    const result = mergeMetadata([{ title: "Page Title", description: "Page Desc", twitter: {} }]);
     expect(result.twitter?.title).toBe("Page Title");
     expect(result.twitter?.description).toBe("Page Desc");
     expect(result.twitter?.card).toBe("summary");


### PR DESCRIPTION
## What this changes

Metadata merging now matches Next.js segment semantics while keeping the useful OpenGraph and Twitter post-processing from this branch.

Nested metadata objects such as `openGraph`, `twitter`, `icons`, `alternates`, and `robots` are replaced when a later segment defines the same key. Custom `other` metadata remains merged across segments, which is the explicit exception in Next's resolver.

The branch also keeps the final metadata post-processing pass so Twitter metadata can inherit from OpenGraph after layouts, pages, and file-based metadata have all been resolved.

## Why

The original branch treated most nested metadata objects as shallow-merge targets. That preserved stale parent fields when a child segment supplied a partial object, for example keeping a root OpenGraph image after a page defined only its own OpenGraph title.

Next documents metadata merging as shallow, and the source assigns current segment values for `openGraph`, `twitter`, `alternates`, `icons`, and `robots`. Only `other` is merged with prior metadata.

## Approach

- Removed broad nested-object merge handling.
- Kept an explicit `other` merge guarded by the supported custom metadata value shape.
- Gated Twitter auto-creation behind an existing `openGraph` object, matching Next's post-processing flow.
- Kept inheritance for existing OpenGraph and Twitter objects from top-level title and description.
- Kept post-processing after file-based metadata is applied so generated OG and Twitter image metadata participates in the final pass.

## Validation

- `vp test run tests/features.test.ts`
- `vp test run tests/app-page-head.test.ts`
- `vp check tests/features.test.ts tests/app-page-head.test.ts packages/vinext/src/shims/metadata.tsx`
- Commit hook ran `vp check --fix` and `knip`

## Risks / follow-ups

No known follow-up for the reviewed issue. This intentionally does not recursively merge nested metadata fields other than the supported `other` metadata map.

## References

- Next.js metadata merging docs: https://nextjs.org/docs/app/api-reference/functions/generate-metadata#merging
- Next.js metadata resolver: https://github.com/vercel/next.js/blob/canary/packages/next/src/lib/metadata/resolve-metadata.ts
