### PR TITLE
fix: filter internal Next.js headers from inbound requests

### DIFF
--- a/packages/vinext/src/deploy.ts
+++ b/packages/vinext/src/deploy.ts
@@ -597,7 +597,16 @@ export default {
 
       // Strip internal headers from inbound requests so they cannot be
       // forged to influence routing or impersonate internal state.
-      filterInternalHeaders(request.headers);
+      // Request.headers is immutable in Workers, so build a clean copy.
+      {
+        const filteredHeaders = filterInternalHeaders(request.headers);
+        request = new Request(request.url, {
+          method: request.method,
+          headers: filteredHeaders,
+          body: request.body,
+          duplex: request.body ? "half" : undefined,
+        });
+      }
 
       // ── 1. Strip basePath ─────────────────────────────────────────
       {

--- a/packages/vinext/src/deploy.ts
+++ b/packages/vinext/src/deploy.ts
@@ -521,7 +521,7 @@ import {
   proxyExternalRequest,
   sanitizeDestination,
 } from "vinext/config/config-matchers";
-import { applyConfigHeadersToHeaderRecord } from "vinext/server/request-pipeline";
+import { applyConfigHeadersToHeaderRecord, filterInternalHeaders } from "vinext/server/request-pipeline";
 
 // @ts-expect-error -- virtual module resolved by vinext at build time
 import { renderPage, handleApiRoute, runMiddleware, vinextConfig } from "virtual:vinext-server-entry";
@@ -594,6 +594,10 @@ export default {
       if (isOpenRedirectShaped(pathname)) {
         return new Response("404 Not Found", { status: 404 });
       }
+
+      // Strip internal headers from inbound requests so they cannot be
+      // forged to influence routing or impersonate internal state.
+      filterInternalHeaders(request.headers);
 
       // ── 1. Strip basePath ─────────────────────────────────────────
       {

--- a/packages/vinext/src/deploy.ts
+++ b/packages/vinext/src/deploy.ts
@@ -521,7 +521,11 @@ import {
   proxyExternalRequest,
   sanitizeDestination,
 } from "vinext/config/config-matchers";
-import { applyConfigHeadersToHeaderRecord, filterInternalHeaders } from "vinext/server/request-pipeline";
+import {
+  applyConfigHeadersToHeaderRecord,
+  cloneRequestWithHeaders,
+  filterInternalHeaders,
+} from "vinext/server/request-pipeline";
 
 // @ts-expect-error -- virtual module resolved by vinext at build time
 import { renderPage, handleApiRoute, runMiddleware, vinextConfig } from "virtual:vinext-server-entry";
@@ -600,9 +604,7 @@ export default {
       // Request.headers is immutable in Workers, so build a clean copy.
       {
         const filteredHeaders = filterInternalHeaders(request.headers);
-        request = new Request(request, {
-          headers: filteredHeaders,
-        });
+        request = cloneRequestWithHeaders(request, filteredHeaders);
       }
 
       // ── 1. Strip basePath ─────────────────────────────────────────

--- a/packages/vinext/src/deploy.ts
+++ b/packages/vinext/src/deploy.ts
@@ -600,11 +600,8 @@ export default {
       // Request.headers is immutable in Workers, so build a clean copy.
       {
         const filteredHeaders = filterInternalHeaders(request.headers);
-        request = new Request(request.url, {
-          method: request.method,
+        request = new Request(request, {
           headers: filteredHeaders,
-          body: request.body,
-          duplex: request.body ? "half" : undefined,
         });
       }
 

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -44,7 +44,11 @@ import {
 import { findMiddlewareFile, runMiddleware } from "./server/middleware.js";
 import { logRequest, now } from "./server/request-log.js";
 import { normalizePath } from "./server/normalize-path.js";
-import { isOpenRedirectShaped } from "./server/request-pipeline.js";
+import {
+  filterInternalHeaders,
+  INTERNAL_HEADERS,
+  isOpenRedirectShaped,
+} from "./server/request-pipeline.js";
 import {
   findInstrumentationClientFile,
   findInstrumentationFile,
@@ -2368,6 +2372,14 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                     .map(([k, v]) => [k, Array.isArray(v) ? v.join(", ") : String(v)]),
                 ),
               );
+              // Strip internal headers from inbound requests so they cannot be
+              // forged to influence routing or impersonate internal state.
+              // Both the middleware Request (built below) and the SSR handler
+              // (which reads req.headers directly) must see clean headers.
+              filterInternalHeaders(nodeRequestHeaders);
+              for (const header of INTERNAL_HEADERS) {
+                delete req.headers[header];
+              }
 
               const requestOrigin = `http://${req.headers.host || "localhost"}`;
               const preMiddlewareReqUrl = new URL(url, requestOrigin);

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -2365,7 +2365,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
               // preMiddlewareReqCtx and the middleware Request itself. Intentionally
               // captured once here — applyRequestHeadersToNodeRequest() mutates
               // req.headers later, but by then this Headers object is no longer read.
-              const nodeRequestHeaders = new Headers(
+              const rawHeaders = new Headers(
                 Object.fromEntries(
                   Object.entries(req.headers)
                     .filter(([, v]) => v !== undefined)
@@ -2376,7 +2376,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
               // forged to influence routing or impersonate internal state.
               // Both the middleware Request (built below) and the SSR handler
               // (which reads req.headers directly) must see clean headers.
-              filterInternalHeaders(nodeRequestHeaders);
+              const nodeRequestHeaders = filterInternalHeaders(rawHeaders);
               for (const header of INTERNAL_HEADERS) {
                 delete req.headers[header];
               }

--- a/packages/vinext/src/server/app-router-entry.ts
+++ b/packages/vinext/src/server/app-router-entry.ts
@@ -16,7 +16,11 @@
 import rscHandler from "virtual:vinext-rsc-entry";
 import { runWithExecutionContext, type ExecutionContextLike } from "vinext/shims/request-context";
 import { resolveStaticAssetSignal } from "./worker-utils.js";
-import { filterInternalHeaders, isOpenRedirectShaped } from "./request-pipeline.js";
+import {
+  cloneRequestWithHeaders,
+  filterInternalHeaders,
+  isOpenRedirectShaped,
+} from "./request-pipeline.js";
 
 type WorkerAssetEnv = {
   ASSETS?: {
@@ -55,9 +59,7 @@ export default {
     // Builds a new Headers — Request.headers is immutable in Workers.
     {
       const filteredHeaders = filterInternalHeaders(request.headers);
-      request = new Request(request, {
-        headers: filteredHeaders,
-      });
+      request = cloneRequestWithHeaders(request, filteredHeaders);
     }
 
     // Do NOT decode/normalize the pathname here. The RSC handler

--- a/packages/vinext/src/server/app-router-entry.ts
+++ b/packages/vinext/src/server/app-router-entry.ts
@@ -55,12 +55,8 @@ export default {
     // Builds a new Headers — Request.headers is immutable in Workers.
     {
       const filteredHeaders = filterInternalHeaders(request.headers);
-      request = new Request(request.url, {
-        method: request.method,
+      request = new Request(request, {
         headers: filteredHeaders,
-        body: request.body,
-        // @ts-expect-error — duplex needed for streaming request bodies
-        duplex: request.body ? "half" : undefined,
       });
     }
 

--- a/packages/vinext/src/server/app-router-entry.ts
+++ b/packages/vinext/src/server/app-router-entry.ts
@@ -16,7 +16,7 @@
 import rscHandler from "virtual:vinext-rsc-entry";
 import { runWithExecutionContext, type ExecutionContextLike } from "vinext/shims/request-context";
 import { resolveStaticAssetSignal } from "./worker-utils.js";
-import { isOpenRedirectShaped } from "./request-pipeline.js";
+import { filterInternalHeaders, isOpenRedirectShaped } from "./request-pipeline.js";
 
 type WorkerAssetEnv = {
   ASSETS?: {
@@ -49,6 +49,10 @@ export default {
       // Malformed percent-encoding (e.g. /%E0%A4%A) — return 400 instead of throwing.
       return new Response("Bad Request", { status: 400 });
     }
+
+    // Strip internal headers from inbound requests before any handler or
+    // middleware sees them. Must happen before the RSC handler runs.
+    filterInternalHeaders(request.headers);
 
     // Do NOT decode/normalize the pathname here. The RSC handler
     // (virtual:vinext-rsc-entry) is the single point of decoding — it calls

--- a/packages/vinext/src/server/app-router-entry.ts
+++ b/packages/vinext/src/server/app-router-entry.ts
@@ -52,7 +52,17 @@ export default {
 
     // Strip internal headers from inbound requests before any handler or
     // middleware sees them. Must happen before the RSC handler runs.
-    filterInternalHeaders(request.headers);
+    // Builds a new Headers — Request.headers is immutable in Workers.
+    {
+      const filteredHeaders = filterInternalHeaders(request.headers);
+      request = new Request(request.url, {
+        method: request.method,
+        headers: filteredHeaders,
+        body: request.body,
+        // @ts-expect-error — duplex needed for streaming request bodies
+        duplex: request.body ? "half" : undefined,
+      });
+    }
 
     // Do NOT decode/normalize the pathname here. The RSC handler
     // (virtual:vinext-rsc-entry) is the single point of decoding — it calls

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -221,15 +221,6 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
     if (originBlock) return originBlock;
   }
 
-  // Strip internal headers from inbound requests before any handler or
-  // middleware sees them. Must happen before normalizeRscRequest() so the
-  // normalization layer never reads forged internal headers.
-  // Builds a new Headers — Request.headers is immutable in Workers.
-  {
-    const filteredHeaders = filterInternalHeaders(request.headers);
-    request = cloneRequestWithHeaders(request, filteredHeaders);
-  }
-
   const normalized = normalizeRscRequest(request, options.basePath);
   if (normalized instanceof Response) return normalized;
 
@@ -463,8 +454,17 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
 export function createAppRscHandler<TRoute extends AppRscHandlerRoute>(
   options: CreateAppRscHandlerOptions<TRoute>,
 ): (request: Request, ctx: unknown) => Promise<Response> {
-  return async function appRscHandler(request, ctx) {
+  return async function appRscHandler(rawRequest, ctx) {
     await options.ensureInstrumentation?.();
+
+    // Strip forged internal headers at the App Router request boundary.
+    // Must happen BEFORE headersContextFromRequest() and
+    // requestContextFromRequest() so the captured context never contains
+    // attacker-controlled internal headers. This is the correct boundary
+    // for pure App Router requests; in hybrid app+pages mode the connect
+    // handler already filtered headers upstream and x-vinext-mw-ctx
+    // (not in INTERNAL_HEADERS) carries the forwarded middleware context.
+    const request = cloneRequestWithHeaders(rawRequest, filterInternalHeaders(rawRequest.headers));
 
     const executionContext = isExecutionContextLike(ctx)
       ? ctx

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -34,6 +34,7 @@ import type { MiddlewareModule } from "./middleware-runtime.js";
 import { runWithPrerenderWorkUnit } from "./prerender-work-unit-setup.js";
 import { buildPostMwRequestContext } from "./app-post-middleware-context.js";
 import {
+  cloneRequestWithHeaders,
   filterInternalHeaders,
   normalizeTrailingSlash,
   resolvePublicFileRoute,
@@ -226,9 +227,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
   // Builds a new Headers — Request.headers is immutable in Workers.
   {
     const filteredHeaders = filterInternalHeaders(request.headers);
-    request = new Request(request, {
-      headers: filteredHeaders,
-    });
+    request = cloneRequestWithHeaders(request, filteredHeaders);
   }
 
   const normalized = normalizeRscRequest(request, options.basePath);

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -464,7 +464,17 @@ export function createAppRscHandler<TRoute extends AppRscHandlerRoute>(
     // for pure App Router requests; in hybrid app+pages mode the connect
     // handler already filtered headers upstream and x-vinext-mw-ctx
     // (not in INTERNAL_HEADERS) carries the forwarded middleware context.
-    const request = cloneRequestWithHeaders(rawRequest, filterInternalHeaders(rawRequest.headers));
+    // srvx's NodeRequestHeaders reads from rawHeaders for iteration but falls
+    // back to req.headers for .get() / .has(). In the dev server we add
+    // x-vinext-mw-ctx to req.headers after the Request is built, so it is
+    // visible to .get() but lost when filterInternalHeaders iterates. Read it
+    // BEFORE iterating so applyForwardedMiddlewareContext can skip middleware.
+    const mwCtx = rawRequest.headers.get("x-vinext-mw-ctx");
+    const filteredHeaders = filterInternalHeaders(rawRequest.headers);
+    if (mwCtx !== null) {
+      filteredHeaders.set("x-vinext-mw-ctx", mwCtx);
+    }
+    const request = cloneRequestWithHeaders(rawRequest, filteredHeaders);
 
     const executionContext = isExecutionContextLike(ctx)
       ? ctx

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -226,12 +226,8 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
   // Builds a new Headers — Request.headers is immutable in Workers.
   {
     const filteredHeaders = filterInternalHeaders(request.headers);
-    request = new Request(request.url, {
-      method: request.method,
+    request = new Request(request, {
       headers: filteredHeaders,
-      body: request.body,
-      // @ts-expect-error — duplex needed for streaming request bodies
-      duplex: request.body ? "half" : undefined,
     });
   }
 

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -223,7 +223,17 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
   // Strip internal headers from inbound requests before any handler or
   // middleware sees them. Must happen before normalizeRscRequest() so the
   // normalization layer never reads forged internal headers.
-  filterInternalHeaders(request.headers);
+  // Builds a new Headers — Request.headers is immutable in Workers.
+  {
+    const filteredHeaders = filterInternalHeaders(request.headers);
+    request = new Request(request.url, {
+      method: request.method,
+      headers: filteredHeaders,
+      body: request.body,
+      // @ts-expect-error — duplex needed for streaming request bodies
+      duplex: request.body ? "half" : undefined,
+    });
+  }
 
   const normalized = normalizeRscRequest(request, options.basePath);
   if (normalized instanceof Response) return normalized;

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -34,6 +34,7 @@ import type { MiddlewareModule } from "./middleware-runtime.js";
 import { runWithPrerenderWorkUnit } from "./prerender-work-unit-setup.js";
 import { buildPostMwRequestContext } from "./app-post-middleware-context.js";
 import {
+  filterInternalHeaders,
   normalizeTrailingSlash,
   resolvePublicFileRoute,
   validateImageUrl,
@@ -218,6 +219,11 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
     const originBlock = options.validateDevRequestOrigin?.(request);
     if (originBlock) return originBlock;
   }
+
+  // Strip internal headers from inbound requests before any handler or
+  // middleware sees them. Must happen before normalizeRscRequest() so the
+  // normalization layer never reads forged internal headers.
+  filterInternalHeaders(request.headers);
 
   const normalized = normalizeRscRequest(request, options.basePath);
   if (normalized instanceof Response) return normalized;

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -45,7 +45,11 @@ import {
   type ImageConfig,
 } from "./image-optimization.js";
 import { normalizePath } from "./normalize-path.js";
-import { applyConfigHeadersToHeaderRecord, isOpenRedirectShaped } from "./request-pipeline.js";
+import {
+  applyConfigHeadersToHeaderRecord,
+  filterInternalHeaders,
+  isOpenRedirectShaped,
+} from "./request-pipeline.js";
 import { hasBasePath, stripBasePath } from "../utils/base-path.js";
 import { computeLazyChunks } from "../utils/lazy-chunks.js";
 import { manifestFileWithBase } from "../utils/manifest-paths.js";
@@ -696,6 +700,8 @@ function nodeToWebRequest(req: IncomingMessage, urlOverride?: string): Request {
       headers.set(key, value);
     }
   }
+  // Strip internal headers that should not be honored from external requests.
+  filterInternalHeaders(headers);
 
   const method = req.method ?? "GET";
   const hasBody = method !== "GET" && method !== "HEAD";
@@ -1387,6 +1393,9 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
         if (v) h.set(k, Array.isArray(v) ? v.join(", ") : v);
         return h;
       }, new Headers());
+      // Strip internal headers from inbound requests before any handler or
+      // middleware sees them.
+      filterInternalHeaders(reqHeaders);
       const method = req.method ?? "GET";
       const hasBody = method !== "GET" && method !== "HEAD";
       let webRequest = new Request(`${protocol}://${hostHeader}${url}`, {

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -691,17 +691,17 @@ function nodeToWebRequest(req: IncomingMessage, urlOverride?: string): Request {
   const origin = `${proto}://${host}`;
   const url = new URL(urlOverride ?? req.url ?? "/", origin);
 
-  const headers = new Headers();
+  const rawHeaders = new Headers();
   for (const [key, value] of Object.entries(req.headers)) {
     if (value === undefined) continue;
     if (Array.isArray(value)) {
-      for (const v of value) headers.append(key, v);
+      for (const v of value) rawHeaders.append(key, v);
     } else {
-      headers.set(key, value);
+      rawHeaders.set(key, value);
     }
   }
   // Strip internal headers that should not be honored from external requests.
-  filterInternalHeaders(headers);
+  const headers = filterInternalHeaders(rawHeaders);
 
   const method = req.method ?? "GET";
   const hasBody = method !== "GET" && method !== "HEAD";
@@ -1389,13 +1389,13 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
         : undefined;
       const protocol = rawProtocol === "https" || rawProtocol === "http" ? rawProtocol : "http";
       const hostHeader = resolveHost(req, `${host}:${port}`);
-      const reqHeaders = Object.entries(req.headers).reduce((h, [k, v]) => {
+      const rawReqHeaders = Object.entries(req.headers).reduce((h, [k, v]) => {
         if (v) h.set(k, Array.isArray(v) ? v.join(", ") : v);
         return h;
       }, new Headers());
       // Strip internal headers from inbound requests before any handler or
       // middleware sees them.
-      filterInternalHeaders(reqHeaders);
+      const reqHeaders = filterInternalHeaders(rawReqHeaders);
       const method = req.method ?? "GET";
       const hasBody = method !== "GET" && method !== "HEAD";
       let webRequest = new Request(`${protocol}://${hostHeader}${url}`, {

--- a/packages/vinext/src/server/request-pipeline.ts
+++ b/packages/vinext/src/server/request-pipeline.ts
@@ -577,10 +577,20 @@ export const INTERNAL_HEADERS = [
  * Must be called at every request entry point BEFORE middleware, routing,
  * or any handler logic accesses the request headers.
  *
- * @param headers - The request Headers object to modify in place
+ * Returns a new Headers object with internal headers removed. The input
+ * is never mutated — Request.headers is immutable in Workers/miniflare
+ * environments (see applyMiddlewareRequestHeaders in config-matchers.ts
+ * for the same cloning pattern).
+ *
+ * @param headers - The source Headers (never modified)
+ * @returns A new Headers with INTERNAL_HEADERS removed
  */
-export function filterInternalHeaders(headers: Headers): void {
-  for (const header of INTERNAL_HEADERS) {
-    headers.delete(header);
+export function filterInternalHeaders(headers: Headers): Headers {
+  const filtered = new Headers();
+  for (const [key, value] of headers) {
+    if (!INTERNAL_HEADERS.includes(key.toLowerCase())) {
+      filtered.append(key, value);
+    }
   }
+  return filtered;
 }

--- a/packages/vinext/src/server/request-pipeline.ts
+++ b/packages/vinext/src/server/request-pipeline.ts
@@ -544,3 +544,43 @@ export function processMiddlewareHeaders(headers: Headers): void {
     headers.delete(key);
   }
 }
+
+/**
+ * Headers that are only used internally by Next.js and must not be honored
+ * from external requests. An attacker could forge these to influence routing
+ * or impersonate internal data fetches.
+ *
+ * Ported from Next.js `INTERNAL_HEADERS`:
+ * https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/server-ipc/utils.ts
+ *
+ * Next.js strips these via `filterInternalHeaders()` at the router-server
+ * entry point before any handler sees the request:
+ * https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/router-server.ts
+ */
+export const INTERNAL_HEADERS = [
+  "x-middleware-rewrite",
+  "x-middleware-redirect",
+  "x-middleware-set-cookie",
+  "x-middleware-skip",
+  "x-middleware-override-headers",
+  "x-middleware-next",
+  "x-now-route-matches",
+  "x-matched-path",
+  "x-nextjs-data",
+  "x-next-resume-state-length",
+];
+
+/**
+ * Strip internal headers from an inbound request so they cannot be forged by
+ * an external attacker to influence routing or impersonate internal state.
+ *
+ * Must be called at every request entry point BEFORE middleware, routing,
+ * or any handler logic accesses the request headers.
+ *
+ * @param headers - The request Headers object to modify in place
+ */
+export function filterInternalHeaders(headers: Headers): void {
+  for (const header of INTERNAL_HEADERS) {
+    headers.delete(header);
+  }
+}

--- a/packages/vinext/src/server/request-pipeline.ts
+++ b/packages/vinext/src/server/request-pipeline.ts
@@ -611,8 +611,9 @@ function getRequestCf(request: Request): unknown | undefined {
  * a RequestInit with best-effort metadata.
  */
 export function cloneRequestWithHeaders(request: Request, headers: Headers): Request {
+  let cloned: Request;
   try {
-    return new Request(request, { headers });
+    cloned = new Request(request, { headers });
   } catch {
     const init: RequestInitWithCf = {
       method: request.method,
@@ -631,10 +632,16 @@ export function cloneRequestWithHeaders(request: Request, headers: Headers): Req
       // @ts-expect-error — duplex needed for streaming request bodies
       init.duplex = "half";
     }
-    const cf = getRequestCf(request);
-    if (cf !== undefined) {
-      init.cf = cf;
-    }
-    return new Request(request.url, init);
+    cloned = new Request(request.url, init);
   }
+  const cf = getRequestCf(request);
+  if (cf !== undefined) {
+    // new Request() does not copy Workers-specific cf, so re-attach it.
+    Object.defineProperty(cloned, "cf", {
+      value: cf,
+      enumerable: true,
+      configurable: true,
+    });
+  }
+  return cloned;
 }

--- a/packages/vinext/src/server/request-pipeline.ts
+++ b/packages/vinext/src/server/request-pipeline.ts
@@ -598,10 +598,8 @@ export function filterInternalHeaders(headers: Headers): Headers {
 }
 
 function getRequestCf(request: Request): unknown | undefined {
-  if ("cf" in request) {
-    return (request as { cf?: unknown }).cf;
-  }
-  return undefined;
+  const cf = Reflect.get(request, "cf");
+  return cf === undefined ? undefined : cf;
 }
 
 /**

--- a/packages/vinext/src/server/request-pipeline.ts
+++ b/packages/vinext/src/server/request-pipeline.ts
@@ -570,6 +570,8 @@ export const INTERNAL_HEADERS = [
   "x-next-resume-state-length",
 ];
 
+type RequestInitWithCf = RequestInit & { cf?: unknown };
+
 /**
  * Strip internal headers from an inbound request so they cannot be forged by
  * an external attacker to influence routing or impersonate internal state.
@@ -593,4 +595,48 @@ export function filterInternalHeaders(headers: Headers): Headers {
     }
   }
   return filtered;
+}
+
+function getRequestCf(request: Request): unknown | undefined {
+  if ("cf" in request) {
+    return (request as { cf?: unknown }).cf;
+  }
+  return undefined;
+}
+
+/**
+ * Clone a Request while overriding headers, preserving metadata when possible.
+ *
+ * Some runtimes (Workers) allow `new Request(request, { headers })` which
+ * retains redirect/signal/cf data. Others (Node/undici across realms) can throw
+ * when cloning a foreign Request instance. In that case, fall back to building
+ * a RequestInit with best-effort metadata.
+ */
+export function cloneRequestWithHeaders(request: Request, headers: Headers): Request {
+  try {
+    return new Request(request, { headers });
+  } catch {
+    const init: RequestInitWithCf = {
+      method: request.method,
+      headers,
+      body: request.body ?? undefined,
+      redirect: request.redirect,
+      signal: request.signal,
+      integrity: request.integrity,
+      cache: request.cache,
+      mode: request.mode,
+      credentials: request.credentials,
+      referrer: request.referrer,
+      referrerPolicy: request.referrerPolicy,
+    };
+    if (request.body) {
+      // @ts-expect-error — duplex needed for streaming request bodies
+      init.duplex = "half";
+    }
+    const cf = getRequestCf(request);
+    if (cf !== undefined) {
+      init.cf = cf;
+    }
+    return new Request(request.url, init);
+  }
 }

--- a/tests/request-pipeline.test.ts
+++ b/tests/request-pipeline.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vite-plus/test";
 import {
   applyConfigHeadersToHeaderRecord,
   applyConfigHeadersToResponse,
+  cloneRequestWithHeaders,
   createStaticFileSignal,
   filterInternalHeaders,
   guardProtocolRelativeUrl,
@@ -748,5 +749,99 @@ describe("filterInternalHeaders", () => {
     const headers = new Headers();
     const result = filterInternalHeaders(headers);
     expect([...result.keys()]).toEqual([]);
+  });
+});
+
+// ── cloneRequestWithHeaders ──────────────────────────────────────────────
+//
+// The Request-constructor pattern `new Request(request, { headers })` preserves
+// metadata in Workers (redirect, signal, cf) but can throw in Node/undici when
+// the input is a foreign Request instance (cross-realm or subclass). The helper
+// falls back to a manual RequestInit that copies every known metadata field.
+//
+// These tests lock down the helper so it can't be "simplified" back into the
+// broken URL-constructor pattern that drops body/redirect/signal semantics.
+
+describe("cloneRequestWithHeaders", () => {
+  it("preserves method", () => {
+    const original = new Request("http://localhost/test", { method: "POST" });
+    const cloned = cloneRequestWithHeaders(original, new Headers({ "x-foo": "bar" }));
+    expect(cloned.method).toBe("POST");
+  });
+
+  it("preserves URL", () => {
+    const original = new Request("http://localhost/some/path?q=1");
+    const cloned = cloneRequestWithHeaders(original, new Headers());
+    expect(cloned.url).toBe("http://localhost/some/path?q=1");
+  });
+
+  it("preserves redirect mode", () => {
+    const original = new Request("http://localhost", { redirect: "manual" });
+    const cloned = cloneRequestWithHeaders(original, new Headers());
+    expect(cloned.redirect).toBe("manual");
+  });
+
+  it("preserves signal", () => {
+    const controller = new AbortController();
+    const original = new Request("http://localhost", { signal: controller.signal });
+    const cloned = cloneRequestWithHeaders(original, new Headers());
+    // Signal identity is not guaranteed (new Request may create a following signal).
+    // But both signals share the same aborted state at construction time.
+    expect(cloned.signal.aborted).toBe(false);
+    controller.abort();
+    expect(cloned.signal.aborted).toBe(true);
+  });
+
+  it("preserves body readability for streaming requests", async () => {
+    const bodyText = "hello world";
+    const original = new Request("http://localhost", {
+      method: "POST",
+      body: bodyText,
+    });
+    const cloned = cloneRequestWithHeaders(original, new Headers());
+    expect(cloned.method).toBe("POST");
+    const text = await cloned.text();
+    expect(text).toBe(bodyText);
+  });
+
+  it("preserves cf property when defined via Object.defineProperty", () => {
+    const original = new Request("http://localhost");
+    Object.defineProperty(original, "cf", {
+      value: { country: "US" },
+      enumerable: true,
+      configurable: true,
+    });
+    const cloned = cloneRequestWithHeaders(original, new Headers());
+    expect(Reflect.get(cloned, "cf")).toEqual({ country: "US" });
+  });
+
+  it("replaces headers while preserving all other metadata", () => {
+    const controller = new AbortController();
+    const original = new Request("http://localhost/path?x=1", {
+      method: "PUT",
+      headers: new Headers({ "x-old": "remove-me", "keep-me": "val" }),
+      redirect: "error",
+      signal: controller.signal,
+    });
+    const newHeaders = new Headers({ "x-new": "added", "keep-me": "still-here" });
+    const cloned = cloneRequestWithHeaders(original, newHeaders);
+
+    // Headers replaced
+    expect(cloned.headers.get("x-old")).toBeNull();
+    expect(cloned.headers.get("keep-me")).toBe("still-here");
+    expect(cloned.headers.get("x-new")).toBe("added");
+    // Metadata preserved
+    expect(cloned.method).toBe("PUT");
+    expect(cloned.url).toBe("http://localhost/path?x=1");
+    expect(cloned.redirect).toBe("error");
+    expect(cloned.signal.aborted).toBe(false);
+  });
+
+  it("handles GET request (no body) correctly", () => {
+    const original = new Request("http://localhost", { method: "GET" });
+    const cloned = cloneRequestWithHeaders(original, new Headers({ accept: "text/html" }));
+    expect(cloned.method).toBe("GET");
+    expect(cloned.body).toBeNull();
+    expect(cloned.headers.get("accept")).toBe("text/html");
   });
 });

--- a/tests/request-pipeline.test.ts
+++ b/tests/request-pipeline.test.ts
@@ -3,7 +3,9 @@ import {
   applyConfigHeadersToHeaderRecord,
   applyConfigHeadersToResponse,
   createStaticFileSignal,
+  filterInternalHeaders,
   guardProtocolRelativeUrl,
+  INTERNAL_HEADERS,
   isOpenRedirectShaped,
   hasBasePath,
   stripBasePath,
@@ -636,5 +638,110 @@ describe("processMiddlewareHeaders", () => {
     processMiddlewareHeaders(headers);
     expect(headers.get("content-type")).toBe("text/html");
     expect(headers.get("x-custom")).toBe("keep");
+  });
+});
+
+// ── INTERNAL_HEADERS / filterInternalHeaders ─────────────────────────────
+//
+// Ported from Next.js INTERNAL_HEADERS:
+// https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/server-ipc/utils.ts
+//
+// Next.js strips these via filterInternalHeaders() at the router-server
+// entry point before any handler sees the request:
+// https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/router-server.ts
+
+describe("INTERNAL_HEADERS", () => {
+  it("matches Next.js's exact header list", () => {
+    // Keep in sync with Next.js:
+    // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/server-ipc/utils.ts
+    const expected = [
+      "x-middleware-rewrite",
+      "x-middleware-redirect",
+      "x-middleware-set-cookie",
+      "x-middleware-skip",
+      "x-middleware-override-headers",
+      "x-middleware-next",
+      "x-now-route-matches",
+      "x-matched-path",
+      "x-nextjs-data",
+      "x-next-resume-state-length",
+    ];
+    expect(INTERNAL_HEADERS).toEqual(expected);
+  });
+});
+
+describe("filterInternalHeaders", () => {
+  it("strips all INTERNAL_HEADERS from the Headers object", () => {
+    const headers = new Headers();
+    for (const name of INTERNAL_HEADERS) {
+      headers.set(name, "forged");
+    }
+    headers.set("user-agent", "test");
+    headers.set("cookie", "session=abc");
+
+    filterInternalHeaders(headers);
+
+    for (const name of INTERNAL_HEADERS) {
+      expect(headers.has(name)).toBe(false);
+    }
+    expect(headers.get("user-agent")).toBe("test");
+    expect(headers.get("cookie")).toBe("session=abc");
+  });
+
+  it("strips headers case-insensitively", () => {
+    // HTTP headers are case-insensitive; Headers.delete is spec-compliant.
+    const headers = new Headers();
+    headers.set("X-Nextjs-Data", "1");
+    headers.set("X-Matched-Path", "/admin");
+    filterInternalHeaders(headers);
+    expect(headers.has("X-Nextjs-Data")).toBe(false);
+    expect(headers.has("x-nextjs-data")).toBe(false);
+    expect(headers.has("X-Matched-Path")).toBe(false);
+    expect(headers.has("x-matched-path")).toBe(false);
+  });
+
+  it("is a no-op when no internal headers are present", () => {
+    const headers = new Headers();
+    headers.set("user-agent", "test");
+    headers.set("accept", "text/html");
+    filterInternalHeaders(headers);
+    expect(headers.get("user-agent")).toBe("test");
+    expect(headers.get("accept")).toBe("text/html");
+    expect(headers.has("x-nextjs-data")).toBe(false);
+    expect(headers.has("x-matched-path")).toBe(false);
+  });
+
+  it("strips a subset of internal headers while preserving others", () => {
+    const headers = new Headers({
+      "x-nextjs-data": "1",
+      "x-matched-path": "/admin",
+      "x-custom": "keep-me",
+      "x-forwarded-for": "10.0.0.1",
+    });
+    filterInternalHeaders(headers);
+    expect(headers.has("x-nextjs-data")).toBe(false);
+    expect(headers.has("x-matched-path")).toBe(false);
+    expect(headers.get("x-custom")).toBe("keep-me");
+    expect(headers.get("x-forwarded-for")).toBe("10.0.0.1");
+  });
+
+  it("strips x-middleware-rewrite forged as a request header", () => {
+    // An attacker could forge x-middleware-rewrite to try to influence
+    // routing. This test ensures it is stripped at the entry point.
+    const headers = new Headers({
+      "x-middleware-rewrite": "/evil/admin",
+      "x-middleware-next": "1",
+      cookie: "auth=valid",
+    });
+    filterInternalHeaders(headers);
+    expect(headers.has("x-middleware-rewrite")).toBe(false);
+    expect(headers.has("x-middleware-next")).toBe(false);
+    expect(headers.get("cookie")).toBe("auth=valid");
+  });
+
+  it("works on an empty Headers object", () => {
+    const headers = new Headers();
+    filterInternalHeaders(headers);
+    expect([...headers.keys()]).toEqual([]);
   });
 });

--- a/tests/request-pipeline.test.ts
+++ b/tests/request-pipeline.test.ts
@@ -679,36 +679,43 @@ describe("filterInternalHeaders", () => {
     headers.set("user-agent", "test");
     headers.set("cookie", "session=abc");
 
-    filterInternalHeaders(headers);
+    const result = filterInternalHeaders(headers);
 
+    // Original is unchanged (function returns a new copy, never mutates)
     for (const name of INTERNAL_HEADERS) {
-      expect(headers.has(name)).toBe(false);
+      expect(headers.has(name)).toBe(true);
     }
-    expect(headers.get("user-agent")).toBe("test");
-    expect(headers.get("cookie")).toBe("session=abc");
+    // Result has internal headers stripped
+    for (const name of INTERNAL_HEADERS) {
+      expect(result.has(name)).toBe(false);
+    }
+    expect(result.get("user-agent")).toBe("test");
+    expect(result.get("cookie")).toBe("session=abc");
   });
 
   it("strips headers case-insensitively", () => {
-    // HTTP headers are case-insensitive; Headers.delete is spec-compliant.
     const headers = new Headers();
     headers.set("X-Nextjs-Data", "1");
     headers.set("X-Matched-Path", "/admin");
-    filterInternalHeaders(headers);
-    expect(headers.has("X-Nextjs-Data")).toBe(false);
-    expect(headers.has("x-nextjs-data")).toBe(false);
-    expect(headers.has("X-Matched-Path")).toBe(false);
-    expect(headers.has("x-matched-path")).toBe(false);
+    const result = filterInternalHeaders(headers);
+    expect(result.has("X-Nextjs-Data")).toBe(false);
+    expect(result.has("x-nextjs-data")).toBe(false);
+    expect(result.has("X-Matched-Path")).toBe(false);
+    expect(result.has("x-matched-path")).toBe(false);
   });
 
   it("is a no-op when no internal headers are present", () => {
     const headers = new Headers();
     headers.set("user-agent", "test");
     headers.set("accept", "text/html");
-    filterInternalHeaders(headers);
+    const result = filterInternalHeaders(headers);
+    expect(result.get("user-agent")).toBe("test");
+    expect(result.get("accept")).toBe("text/html");
+    expect(result.has("x-nextjs-data")).toBe(false);
+    expect(result.has("x-matched-path")).toBe(false);
+    // Original headers are preserved
     expect(headers.get("user-agent")).toBe("test");
     expect(headers.get("accept")).toBe("text/html");
-    expect(headers.has("x-nextjs-data")).toBe(false);
-    expect(headers.has("x-matched-path")).toBe(false);
   });
 
   it("strips a subset of internal headers while preserving others", () => {
@@ -718,30 +725,28 @@ describe("filterInternalHeaders", () => {
       "x-custom": "keep-me",
       "x-forwarded-for": "10.0.0.1",
     });
-    filterInternalHeaders(headers);
-    expect(headers.has("x-nextjs-data")).toBe(false);
-    expect(headers.has("x-matched-path")).toBe(false);
-    expect(headers.get("x-custom")).toBe("keep-me");
-    expect(headers.get("x-forwarded-for")).toBe("10.0.0.1");
+    const result = filterInternalHeaders(headers);
+    expect(result.has("x-nextjs-data")).toBe(false);
+    expect(result.has("x-matched-path")).toBe(false);
+    expect(result.get("x-custom")).toBe("keep-me");
+    expect(result.get("x-forwarded-for")).toBe("10.0.0.1");
   });
 
   it("strips x-middleware-rewrite forged as a request header", () => {
-    // An attacker could forge x-middleware-rewrite to try to influence
-    // routing. This test ensures it is stripped at the entry point.
     const headers = new Headers({
       "x-middleware-rewrite": "/evil/admin",
       "x-middleware-next": "1",
       cookie: "auth=valid",
     });
-    filterInternalHeaders(headers);
-    expect(headers.has("x-middleware-rewrite")).toBe(false);
-    expect(headers.has("x-middleware-next")).toBe(false);
-    expect(headers.get("cookie")).toBe("auth=valid");
+    const result = filterInternalHeaders(headers);
+    expect(result.has("x-middleware-rewrite")).toBe(false);
+    expect(result.has("x-middleware-next")).toBe(false);
+    expect(result.get("cookie")).toBe("auth=valid");
   });
 
   it("works on an empty Headers object", () => {
     const headers = new Headers();
-    filterInternalHeaders(headers);
-    expect([...headers.keys()]).toEqual([]);
+    const result = filterInternalHeaders(headers);
+    expect([...result.keys()]).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

- Adds `filterInternalHeaders()` to strip internal Next.js headers from inbound requests at all entry points, matching Next.js behavior
- Prevents attackers from forging `x-nextjs-data`, `x-matched-path`, `x-now-route-matches`, `x-next-resume-state-length`, and `x-middleware-*` headers to influence routing or impersonate internal state

## Problem

Next.js calls [`filterInternalHeaders()`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/server-ipc/utils.ts#L55-L63) at the [router-server entry point](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/router-server.ts#L231) before any handler or middleware sees the request. This strips the [`INTERNAL_HEADERS`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/server-ipc/utils.ts#L42-L53) list from the request.

vinext was not filtering any of these headers. All four headers reached middleware as user-controlled request headers.

## Fix

Added `INTERNAL_HEADERS` constant and `filterInternalHeaders(headers: Headers)` to `server/request-pipeline.ts`, ported directly from Next.js. Wired into every request entry point:

| Entry point | File |
|---|---|
| App Router handler | `server/app-rsc-handler.ts` |
| CF Worker App Router entry | `server/app-router-entry.ts` |
| Node prod-server (App + Pages) | `server/prod-server.ts` (nodeToWebRequest + Pages path) |
| Dev server Pages Router middleware path | `index.ts` |
| Generated Pages Router worker entry | `deploy.ts` |

Filtering runs **before** middleware, config matching, and routing — no subsystem sees forged internal headers. The `x-middleware-*` headers are stripped from **requests** but NOT from middleware **responses** — the middleware protocol (which reads `x-middleware-*` from `Response.headers`, not `Request.headers`) continues to work correctly.

## Tests

Added 8 unit tests in `tests/request-pipeline.test.ts`:
- Exact header list matches Next.js `INTERNAL_HEADERS`
- All internal headers stripped while preserving others
- Case-insensitive deletion (HTTP spec compliance)
- No-op on empty/clean headers
- Forged `x-middleware-rewrite` + `x-middleware-next` stripped
- Subset stripping preserves unrelated headers

All related tests pass (request-pipeline: 78, deploy: 210, app-router: 300, features: 267, pages-router: 200).