### PR TITLE
refactor(routing): dedupe param decoding into shared helper

### DIFF
--- a/packages/vinext/src/routing/route-pattern.ts
+++ b/packages/vinext/src/routing/route-pattern.ts
@@ -1,3 +1,5 @@
+import { decodeMatchedParams } from "./utils";
+
 export type RoutePatternParams = Record<string, string | string[]>;
 
 function routePatternPart(segment: string): string {
@@ -86,25 +88,6 @@ export function fillRoutePatternSegments(
   return resolvedSegments.length > 0 ? `/${resolvedSegments.join("/")}` : "/";
 }
 
-function decodePatternParam(value: string): string {
-  try {
-    return decodeURIComponent(value);
-  } catch {
-    return value;
-  }
-}
-
-function decodePatternParams(params: RoutePatternParams): void {
-  for (const key of Object.keys(params)) {
-    const value = params[key];
-    if (Array.isArray(value)) {
-      params[key] = value.map(decodePatternParam);
-    } else {
-      params[key] = decodePatternParam(value);
-    }
-  }
-}
-
 export function matchRoutePattern(
   urlParts: readonly string[],
   patternParts: readonly string[],
@@ -155,6 +138,6 @@ export function matchRoutePattern(
   }
 
   if (!matchFrom(0, 0)) return null;
-  decodePatternParams(params);
+  decodeMatchedParams(params);
   return params;
 }

--- a/packages/vinext/src/routing/route-trie.ts
+++ b/packages/vinext/src/routing/route-trie.ts
@@ -1,3 +1,5 @@
+import { decodeMatchedParams } from "./utils";
+
 /**
  * Trie (prefix tree) for O(depth) route matching.
  *
@@ -119,25 +121,6 @@ export function buildRouteTrie<R extends { patternParts: string[] }>(routes: R[]
   return root;
 }
 
-function decodeParam(value: string): string {
-  try {
-    return decodeURIComponent(value);
-  } catch {
-    return value;
-  }
-}
-
-function decodeParams(params: Record<string, string | string[]>): void {
-  for (const key of Object.keys(params)) {
-    const value = params[key];
-    if (Array.isArray(value)) {
-      params[key] = value.map(decodeParam);
-    } else {
-      params[key] = decodeParam(value);
-    }
-  }
-}
-
 /**
  * Match a URL against the trie.
  *
@@ -159,7 +142,7 @@ export function trieMatch<R>(
 ): { route: R; params: Record<string, string | string[]> } | null {
   const result = match(root, urlParts, 0);
   if (result) {
-    decodeParams(result.params);
+    decodeMatchedParams(result.params);
   }
   return result;
 }

--- a/packages/vinext/src/routing/utils.ts
+++ b/packages/vinext/src/routing/utils.ts
@@ -130,3 +130,28 @@ export function normalizePathnameForRouteMatchStrict(pathname: string): string {
     .map((segment) => decodeRouteSegmentStrict(segment))
     .join("/");
 }
+
+function decodeMatchedParam(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+/**
+ * Decode captured route params with `decodeURIComponent`, mirroring Next.js
+ * route-matcher.ts:25-27. Mutates the params object in place. Catch-all
+ * arrays are decoded element-wise. Malformed escapes are preserved (the
+ * strict normalization layer rejects them at the request boundary).
+ */
+export function decodeMatchedParams(params: Record<string, string | string[]>): void {
+  for (const key of Object.keys(params)) {
+    const value = params[key];
+    if (Array.isArray(value)) {
+      params[key] = value.map(decodeMatchedParam);
+    } else {
+      params[key] = decodeMatchedParam(value);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Extract the identical `decodeParam`/`decodeParams` and `decodePatternParam`/`decodePatternParams` helpers from `route-trie.ts` and `route-pattern.ts` into a single `decodeMatchedParams` in `routing/utils.ts`.
- Both call sites (`trieMatch`, `matchRoutePattern`) now share the same implementation.

## Context

Follows up on review feedback from [#1049](https://github.com/cloudflare/vinext/pull/1049):

> `decodeParam`/`decodeParams` in `route-trie.ts` and `decodePatternParam`/`decodePatternParams` in `route-pattern.ts` are identical. Suggested extracting to a shared helper in `routing/utils.ts`.

Pure refactor — no behavior change. The shared helper preserves the same try/catch fallback for malformed escapes and the same in-place mutation semantics.

## Test plan

- [x] `vp test run tests/route-trie.test.ts tests/route-pattern.test.ts` — 73 tests pass
- [x] `vp test run tests/routing.test.ts tests/route-sorting.test.ts tests/app-router.test.ts tests/pages-router.test.ts` — all 716 routing-adjacent tests pass
- [x] `vp fmt --check` on touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)