### PR TITLE
refactor(app-router): introduce AppElementsWire boundary

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -211,8 +211,7 @@ import {
   createAppFallbackRenderer as __createAppFallbackRenderer,
 } from ${JSON.stringify(appFallbackRendererPath)};
 import {
-  APP_INTERCEPTION_CONTEXT_KEY as __APP_INTERCEPTION_CONTEXT_KEY,
-  createAppPayloadRouteId as __createAppPayloadRouteId,
+  AppElementsWire as __AppElementsWire,
 } from ${JSON.stringify(appElementsPath)};
 import {
   resolveAppPageChildSegments as __resolveAppPageChildSegments,
@@ -672,14 +671,16 @@ export default __createAppRscHandler({
       contentType,
       createNotFoundElement(actionRouteId) {
         return {
-          [__APP_INTERCEPTION_CONTEXT_KEY]: null,
-          __route: actionRouteId,
-          __rootLayout: null,
+          ...__AppElementsWire.createMetadataEntries({
+            interceptionContext: null,
+            rootLayoutTreePath: null,
+            routeId: actionRouteId,
+          }),
           [actionRouteId]: createElement("div", null, "Page not found"),
         };
       },
       createPayloadRouteId(pathnameToRender, currentInterceptionContext) {
-        return __createAppPayloadRouteId(pathnameToRender, currentInterceptionContext);
+        return __AppElementsWire.encodeRouteId(pathnameToRender, currentInterceptionContext);
       },
       createRscOnErrorHandler(actionRequest, actionPathname, routePattern) {
         return createRscOnErrorHandler(actionRequest, actionPathname, routePattern);

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -46,10 +46,8 @@ import {
   type PendingBrowserRouterState,
 } from "./app-browser-navigation-controller.js";
 import {
-  createAppPayloadCacheKey,
+  AppElementsWire,
   getMountedSlotIdsHeader,
-  normalizeAppElements,
-  readAppElementsMetadata,
   resolveVisitedResponseInterceptionContext,
   type AppElements,
   type AppWireElements,
@@ -289,7 +287,7 @@ function getVisitedResponse(
   mountedSlotsHeader: string | null,
   navigationKind: NavigationKind,
 ): VisitedResponseCacheEntry | null {
-  const cacheKey = createAppPayloadCacheKey(rscUrl, interceptionContext);
+  const cacheKey = AppElementsWire.encodeCacheKey(rscUrl, interceptionContext);
   const cached = visitedResponseCache.get(cacheKey);
   if (!cached) {
     return null;
@@ -333,7 +331,7 @@ function storeVisitedResponseSnapshot(
   snapshot: CachedRscResponse,
   params: Record<string, string | string[]>,
 ): void {
-  const cacheKey = createAppPayloadCacheKey(rscUrl, interceptionContext);
+  const cacheKey = AppElementsWire.encodeCacheKey(rscUrl, interceptionContext);
   visitedResponseCache.delete(cacheKey);
   evictVisitedResponseCacheIfNeeded();
   const now = Date.now();
@@ -409,11 +407,11 @@ function handleDevRecoveryBoundaryCatch(resetKey: number): void {
   browserNavigationController.drainPrePaintEffects(resetKey);
 }
 
-function normalizeAppElementsPromise(payload: Promise<AppWireElements>): Promise<AppElements> {
+function decodeAppElementsPromise(payload: Promise<AppWireElements>): Promise<AppElements> {
   // Wrap in Promise.resolve() because createFromReadableStream() returns a
   // React Flight thenable whose .then() returns undefined (not a new Promise).
   // Without the wrap, chaining .then() produces undefined → use() crashes.
-  return Promise.resolve(payload).then((elements) => normalizeAppElements(elements));
+  return Promise.resolve(payload).then((elements) => AppElementsWire.decode(elements));
 }
 
 function BrowserRoot({
@@ -424,7 +422,7 @@ function BrowserRoot({
   initialNavigationSnapshot: ClientNavigationRenderSnapshot;
 }) {
   const resolvedElements = use(initialElements);
-  const initialMetadata = readAppElementsMetadata(resolvedElements);
+  const initialMetadata = AppElementsWire.readMetadata(resolvedElements);
   const [treeStateValue, setTreeStateValue] = useState<AppRouterState | Promise<AppRouterState>>({
     elements: resolvedElements,
     interceptionContext: initialMetadata.interceptionContext,
@@ -816,12 +814,12 @@ function registerServerActionCallback(): void {
     // redirects), this would need renderNavigationPayload().
     if (isServerActionResult(result)) {
       return commitSameUrlNavigatePayload(
-        Promise.resolve(normalizeAppElements(result.root)),
+        Promise.resolve(AppElementsWire.decode(result.root)),
         result.returnValue,
       );
     }
 
-    return commitSameUrlNavigatePayload(Promise.resolve(normalizeAppElements(result)));
+    return commitSameUrlNavigatePayload(Promise.resolve(AppElementsWire.decode(result)));
   });
 }
 
@@ -843,7 +841,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
     installDevErrorOverlay();
   }
 
-  const root = normalizeAppElementsPromise(createFromReadableStream<AppWireElements>(rscStream));
+  const root = decodeAppElementsPromise(createFromReadableStream<AppWireElements>(rscStream));
   const initialNavigationSnapshot = createClientNavigationRenderSnapshot(
     window.location.href,
     latestClientParams,
@@ -967,7 +965,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
             currentHref,
             cachedParams,
           );
-          const cachedPayload = normalizeAppElementsPromise(
+          const cachedPayload = decodeAppElementsPromise(
             createFromFetch<AppWireElements>(
               Promise.resolve(restoreRscResponse(cachedRoute.response)),
             ),
@@ -1106,7 +1104,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
 
         if (!browserNavigationController.isCurrentNavigation(navId)) return;
 
-        const rscPayload = normalizeAppElementsPromise(
+        const rscPayload = decodeAppElementsPromise(
           createFromFetch<AppWireElements>(Promise.resolve(restoreRscResponse(responseSnapshot))),
         );
 
@@ -1132,7 +1130,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
         // back/forward navigation could replay a snapshot from a navigation that
         // never actually rendered successfully.
         const resolvedElements = await rscPayload;
-        const metadata = readAppElementsMetadata(resolvedElements);
+        const metadata = AppElementsWire.readMetadata(resolvedElements);
         storeVisitedResponseSnapshot(
           rscUrl,
           resolveVisitedResponseInterceptionContext(
@@ -1229,7 +1227,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
         // for the previousNextUrl mechanism.
         const hmrHeaders = createRscRequestHeaders();
         await browserNavigationController.hmrReplaceTree(
-          normalizeAppElementsPromise(
+          decodeAppElementsPromise(
             createFromFetch<AppWireElements>(
               fetch(
                 await createRscRequestUrl(

--- a/packages/vinext/src/server/app-browser-state.ts
+++ b/packages/vinext/src/server/app-browser-state.ts
@@ -1,8 +1,8 @@
 import { mergeElements } from "vinext/shims/slot";
 import { stripBasePath } from "../utils/base-path.js";
 import {
+  AppElementsWire,
   getMountedSlotIdsHeader,
-  readAppElementsMetadata,
   type AppElements,
   type LayoutFlags,
 } from "./app-elements.js";
@@ -212,7 +212,7 @@ export async function createPendingNavigationCommit(options: {
   type: "navigate" | "replace" | "traverse";
 }): Promise<PendingNavigationCommit> {
   const elements = await options.nextElements;
-  const metadata = readAppElementsMetadata(elements);
+  const metadata = AppElementsWire.readMetadata(elements);
   const previousNextUrl =
     options.previousNextUrl !== undefined
       ? options.previousNextUrl

--- a/packages/vinext/src/server/app-elements-wire.ts
+++ b/packages/vinext/src/server/app-elements-wire.ts
@@ -145,7 +145,7 @@ export function normalizeAppElements(elements: AppWireElements): AppElements {
 }
 
 function isLayoutFlagsRecord(value: unknown): value is LayoutFlags {
-  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
   for (const v of Object.values(value)) {
     if (v !== "s" && v !== "d") return false;
   }
@@ -226,6 +226,8 @@ export function readAppElementsMetadata(
 }
 
 export const AppElementsWire: AppElementsWireCodec = {
+  // WIRE follow-ups use these stable key names when moving payload readers and writers
+  // behind the codec boundary.
   keys: {
     interceptionContext: APP_INTERCEPTION_CONTEXT_KEY,
     layoutFlags: APP_LAYOUT_FLAGS_KEY,

--- a/packages/vinext/src/server/app-elements-wire.ts
+++ b/packages/vinext/src/server/app-elements-wire.ts
@@ -1,0 +1,244 @@
+import { isValidElement, type ReactNode } from "react";
+
+const APP_INTERCEPTION_SEPARATOR = "\0";
+
+export const APP_INTERCEPTION_CONTEXT_KEY = "__interceptionContext";
+export const APP_LAYOUT_FLAGS_KEY = "__layoutFlags";
+export const APP_ROUTE_KEY = "__route";
+export const APP_ROOT_LAYOUT_KEY = "__rootLayout";
+export const APP_UNMATCHED_SLOT_WIRE_VALUE = "__VINEXT_UNMATCHED_SLOT__";
+
+export const UNMATCHED_SLOT = Symbol.for("vinext.unmatchedSlot");
+
+export type AppElementValue = ReactNode | typeof UNMATCHED_SLOT | string | null;
+type AppWireElementValue = ReactNode | string | null;
+
+export type AppElements = Readonly<Record<string, AppElementValue>>;
+export type AppWireElements = Readonly<Record<string, AppWireElementValue>>;
+
+/**
+ * Per-layout static/dynamic flags. `"s"` = static (skippable on next nav);
+ * `"d"` = dynamic (must always render).
+ *
+ * Lifecycle (partial — later PRs extend this):
+ *
+ *   1. PROBE   — probeAppPageLayouts (server/app-page-execution.ts) returns
+ *                LayoutFlags for every layout in the route at render time.
+ *
+ *   2. ATTACH  — AppElementsWire.encodeOutgoingPayload writes `__layoutFlags`
+ *                into the outgoing App Router payload record.
+ *
+ *   3. WIRE    — renderToReadableStream serializes the record as RSC row 0.
+ *
+ *   4. PARSE   — AppElementsWire.readMetadata extracts layoutFlags from the
+ *                wire payload on the client side.
+ */
+export type LayoutFlags = Readonly<Record<string, "s" | "d">>;
+
+type AppElementsMetadata = {
+  interceptionContext: string | null;
+  layoutFlags: LayoutFlags;
+  routeId: string;
+  rootLayoutTreePath: string | null;
+};
+
+type AppElementsWireMetadataInput = {
+  interceptionContext: string | null;
+  routeId: string;
+  rootLayoutTreePath: string | null;
+};
+
+type AppElementsWireMetadataEntries = Readonly<{
+  [APP_ROUTE_KEY]: string;
+  [APP_INTERCEPTION_CONTEXT_KEY]: string | null;
+  [APP_ROOT_LAYOUT_KEY]: string | null;
+}>;
+
+/**
+ * The outgoing wire payload shape. Includes ReactNode values for the
+ * rendered tree plus metadata values like LayoutFlags attached under
+ * known keys (e.g. __layoutFlags). Distinct from AppElements / AppWireElements
+ * which only carry render-time values.
+ */
+export type AppOutgoingElements = Readonly<Record<string, ReactNode | LayoutFlags>>;
+
+type AppElementsWireKeys = {
+  readonly interceptionContext: typeof APP_INTERCEPTION_CONTEXT_KEY;
+  readonly layoutFlags: typeof APP_LAYOUT_FLAGS_KEY;
+  readonly rootLayout: typeof APP_ROOT_LAYOUT_KEY;
+  readonly route: typeof APP_ROUTE_KEY;
+};
+
+type AppElementsWireCodec = {
+  readonly keys: AppElementsWireKeys;
+  readonly unmatchedSlotValue: typeof APP_UNMATCHED_SLOT_WIRE_VALUE;
+  createMetadataEntries(input: AppElementsWireMetadataInput): AppElementsWireMetadataEntries;
+  decode(elements: AppWireElements): AppElements;
+  encodeCacheKey(rscUrl: string, interceptionContext: string | null): string;
+  encodeOutgoingPayload(input: {
+    element: ReactNode | Readonly<Record<string, ReactNode>>;
+    layoutFlags: LayoutFlags;
+  }): ReactNode | AppOutgoingElements;
+  encodePageId(routePath: string, interceptionContext: string | null): string;
+  encodeRouteId(routePath: string, interceptionContext: string | null): string;
+  readMetadata(elements: Readonly<Record<string, unknown>>): AppElementsMetadata;
+  withLayoutFlags<T extends Record<string, unknown>>(
+    elements: T,
+    layoutFlags: LayoutFlags,
+  ): T & { [APP_LAYOUT_FLAGS_KEY]: LayoutFlags };
+};
+
+function appendInterceptionContext(identity: string, interceptionContext: string | null): string {
+  return interceptionContext === null
+    ? identity
+    : `${identity}${APP_INTERCEPTION_SEPARATOR}${interceptionContext}`;
+}
+
+export function createAppPayloadRouteId(
+  routePath: string,
+  interceptionContext: string | null,
+): string {
+  return appendInterceptionContext(`route:${routePath}`, interceptionContext);
+}
+
+function createAppPayloadPageId(routePath: string, interceptionContext: string | null): string {
+  return appendInterceptionContext(`page:${routePath}`, interceptionContext);
+}
+
+export function createAppPayloadCacheKey(
+  rscUrl: string,
+  interceptionContext: string | null,
+): string {
+  return appendInterceptionContext(rscUrl, interceptionContext);
+}
+
+function createAppElementsWireMetadataEntries(
+  input: AppElementsWireMetadataInput,
+): AppElementsWireMetadataEntries {
+  return {
+    [APP_ROUTE_KEY]: input.routeId,
+    [APP_INTERCEPTION_CONTEXT_KEY]: input.interceptionContext,
+    [APP_ROOT_LAYOUT_KEY]: input.rootLayoutTreePath,
+  };
+}
+
+export function normalizeAppElements(elements: AppWireElements): AppElements {
+  let needsNormalization = false;
+  for (const [key, value] of Object.entries(elements)) {
+    if (key.startsWith("slot:") && value === APP_UNMATCHED_SLOT_WIRE_VALUE) {
+      needsNormalization = true;
+      break;
+    }
+  }
+
+  if (!needsNormalization) {
+    return elements;
+  }
+
+  const normalized: Record<string, AppElementValue> = {};
+  for (const [key, value] of Object.entries(elements)) {
+    normalized[key] =
+      key.startsWith("slot:") && value === APP_UNMATCHED_SLOT_WIRE_VALUE ? UNMATCHED_SLOT : value;
+  }
+
+  return normalized;
+}
+
+function isLayoutFlagsRecord(value: unknown): value is LayoutFlags {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  for (const v of Object.values(value)) {
+    if (v !== "s" && v !== "d") return false;
+  }
+  return true;
+}
+
+function parseLayoutFlags(value: unknown): LayoutFlags {
+  if (isLayoutFlagsRecord(value)) return value;
+  return {};
+}
+
+/**
+ * Type predicate for a plain (non-null, non-array) record of app payload values.
+ * Used to distinguish the App Router payload object from bare React elements at
+ * the render boundary. Narrows to `Readonly<Record<string, unknown>>` because
+ * the outgoing payload carries heterogeneous values (ReactNodes for the rendered
+ * tree, plus metadata like `__layoutFlags` which is a plain object). Delegates
+ * to React's canonical `isValidElement` so we don't depend on React's internal
+ * `$$typeof` marker scheme.
+ */
+export function isAppElementsRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+  if (typeof value !== "object" || value === null) return false;
+  if (Array.isArray(value)) return false;
+  if (isValidElement(value)) return false;
+  return true;
+}
+
+export function withLayoutFlags<T extends Record<string, unknown>>(
+  elements: T,
+  layoutFlags: LayoutFlags,
+): T & { [APP_LAYOUT_FLAGS_KEY]: LayoutFlags } {
+  return { ...elements, [APP_LAYOUT_FLAGS_KEY]: layoutFlags };
+}
+
+export function buildOutgoingAppPayload(input: {
+  element: ReactNode | Readonly<Record<string, ReactNode>>;
+  layoutFlags: LayoutFlags;
+}): ReactNode | AppOutgoingElements {
+  if (!isAppElementsRecord(input.element)) {
+    return input.element;
+  }
+  return withLayoutFlags(input.element, input.layoutFlags);
+}
+
+export function readAppElementsMetadata(
+  elements: Readonly<Record<string, unknown>>,
+): AppElementsMetadata {
+  const routeId = elements[APP_ROUTE_KEY];
+  if (typeof routeId !== "string") {
+    throw new Error("[vinext] Missing __route string in App Router payload");
+  }
+
+  const interceptionContext = elements[APP_INTERCEPTION_CONTEXT_KEY];
+  if (
+    interceptionContext !== undefined &&
+    interceptionContext !== null &&
+    typeof interceptionContext !== "string"
+  ) {
+    throw new Error("[vinext] Invalid __interceptionContext in App Router payload");
+  }
+
+  const rootLayoutTreePath = elements[APP_ROOT_LAYOUT_KEY];
+  if (rootLayoutTreePath === undefined) {
+    throw new Error("[vinext] Missing __rootLayout key in App Router payload");
+  }
+  if (rootLayoutTreePath !== null && typeof rootLayoutTreePath !== "string") {
+    throw new Error("[vinext] Invalid __rootLayout in App Router payload: expected string or null");
+  }
+
+  const layoutFlags = parseLayoutFlags(elements[APP_LAYOUT_FLAGS_KEY]);
+
+  return {
+    interceptionContext: interceptionContext ?? null,
+    layoutFlags,
+    routeId,
+    rootLayoutTreePath,
+  };
+}
+
+export const AppElementsWire: AppElementsWireCodec = {
+  keys: {
+    interceptionContext: APP_INTERCEPTION_CONTEXT_KEY,
+    layoutFlags: APP_LAYOUT_FLAGS_KEY,
+    rootLayout: APP_ROOT_LAYOUT_KEY,
+    route: APP_ROUTE_KEY,
+  },
+  unmatchedSlotValue: APP_UNMATCHED_SLOT_WIRE_VALUE,
+  createMetadataEntries: createAppElementsWireMetadataEntries,
+  decode: normalizeAppElements,
+  encodeCacheKey: createAppPayloadCacheKey,
+  encodeOutgoingPayload: buildOutgoingAppPayload,
+  encodePageId: createAppPayloadPageId,
+  encodeRouteId: createAppPayloadRouteId,
+  readMetadata: readAppElementsMetadata,
+  withLayoutFlags,
+};

--- a/packages/vinext/src/server/app-elements.ts
+++ b/packages/vinext/src/server/app-elements.ts
@@ -1,47 +1,27 @@
-import { isValidElement, type ReactNode } from "react";
 import { normalizeMountedSlotsHeader } from "./app-mounted-slots-header.js";
+import { UNMATCHED_SLOT, type AppElements } from "./app-elements-wire.js";
 
-const APP_INTERCEPTION_SEPARATOR = "\0";
-
-export const APP_INTERCEPTION_CONTEXT_KEY = "__interceptionContext";
-export const APP_LAYOUT_FLAGS_KEY = "__layoutFlags";
-export const APP_ROUTE_KEY = "__route";
-export const APP_ROOT_LAYOUT_KEY = "__rootLayout";
-export const APP_UNMATCHED_SLOT_WIRE_VALUE = "__VINEXT_UNMATCHED_SLOT__";
-
-export const UNMATCHED_SLOT = Symbol.for("vinext.unmatchedSlot");
-
-export type AppElementValue = ReactNode | typeof UNMATCHED_SLOT | string | null;
-type AppWireElementValue = ReactNode | string | null;
-
-export type AppElements = Readonly<Record<string, AppElementValue>>;
-export type AppWireElements = Readonly<Record<string, AppWireElementValue>>;
-
-/**
- * Per-layout static/dynamic flags. `"s"` = static (skippable on next nav);
- * `"d"` = dynamic (must always render).
- *
- * Lifecycle (partial — later PRs extend this):
- *
- *   1. PROBE   — probeAppPageLayouts (server/app-page-execution.ts) returns
- *                LayoutFlags for every layout in the route at render time.
- *
- *   2. ATTACH  — withLayoutFlags (this file) writes `__layoutFlags` into the
- *                outgoing App Router payload record.
- *
- *   3. WIRE    — renderToReadableStream serializes the record as RSC row 0.
- *
- *   4. PARSE   — readAppElementsMetadata (this file) extracts layoutFlags from
- *                the wire payload on the client side.
- */
-export type LayoutFlags = Readonly<Record<string, "s" | "d">>;
-
-type AppElementsMetadata = {
-  interceptionContext: string | null;
-  layoutFlags: LayoutFlags;
-  routeId: string;
-  rootLayoutTreePath: string | null;
-};
+export {
+  AppElementsWire,
+  APP_INTERCEPTION_CONTEXT_KEY,
+  APP_LAYOUT_FLAGS_KEY,
+  APP_ROOT_LAYOUT_KEY,
+  APP_ROUTE_KEY,
+  APP_UNMATCHED_SLOT_WIRE_VALUE,
+  UNMATCHED_SLOT,
+  buildOutgoingAppPayload,
+  createAppPayloadCacheKey,
+  createAppPayloadRouteId,
+  isAppElementsRecord,
+  normalizeAppElements,
+  readAppElementsMetadata,
+  withLayoutFlags,
+  type AppElementValue,
+  type AppElements,
+  type AppOutgoingElements,
+  type AppWireElements,
+  type LayoutFlags,
+} from "./app-elements-wire.js";
 
 export function getMountedSlotIds(elements: AppElements): string[] {
   return Object.keys(elements)
@@ -58,166 +38,9 @@ export function getMountedSlotIdsHeader(elements: AppElements): string | null {
   return normalizeMountedSlotsHeader(getMountedSlotIds(elements).join(" "));
 }
 
-function appendInterceptionContext(identity: string, interceptionContext: string | null): string {
-  return interceptionContext === null
-    ? identity
-    : `${identity}${APP_INTERCEPTION_SEPARATOR}${interceptionContext}`;
-}
-
-export function createAppPayloadRouteId(
-  routePath: string,
-  interceptionContext: string | null,
-): string {
-  return appendInterceptionContext(`route:${routePath}`, interceptionContext);
-}
-
-export function createAppPayloadPageId(
-  routePath: string,
-  interceptionContext: string | null,
-): string {
-  return appendInterceptionContext(`page:${routePath}`, interceptionContext);
-}
-
-export function createAppPayloadCacheKey(
-  rscUrl: string,
-  interceptionContext: string | null,
-): string {
-  return appendInterceptionContext(rscUrl, interceptionContext);
-}
-
 export function resolveVisitedResponseInterceptionContext(
   requestInterceptionContext: string | null,
   payloadInterceptionContext: string | null,
 ): string | null {
   return payloadInterceptionContext ?? requestInterceptionContext;
-}
-
-export function normalizeAppElements(elements: AppWireElements): AppElements {
-  let needsNormalization = false;
-  for (const [key, value] of Object.entries(elements)) {
-    if (key.startsWith("slot:") && value === APP_UNMATCHED_SLOT_WIRE_VALUE) {
-      needsNormalization = true;
-      break;
-    }
-  }
-
-  if (!needsNormalization) {
-    return elements;
-  }
-
-  const normalized: Record<string, AppElementValue> = {};
-  for (const [key, value] of Object.entries(elements)) {
-    normalized[key] =
-      key.startsWith("slot:") && value === APP_UNMATCHED_SLOT_WIRE_VALUE ? UNMATCHED_SLOT : value;
-  }
-
-  return normalized;
-}
-
-function isLayoutFlagsRecord(value: unknown): value is LayoutFlags {
-  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
-  for (const v of Object.values(value)) {
-    if (v !== "s" && v !== "d") return false;
-  }
-  return true;
-}
-
-function parseLayoutFlags(value: unknown): LayoutFlags {
-  if (isLayoutFlagsRecord(value)) return value;
-  return {};
-}
-
-/**
- * Type predicate for a plain (non-null, non-array) record of app payload values.
- * Used to distinguish the App Router payload object from bare React elements at
- * the render boundary. Narrows to `Readonly<Record<string, unknown>>` because
- * the outgoing payload carries heterogeneous values (ReactNodes for the rendered
- * tree, plus metadata like `__layoutFlags` which is a plain object). Delegates
- * to React's canonical `isValidElement` so we don't depend on React's internal
- * `$$typeof` marker scheme.
- */
-export function isAppElementsRecord(value: unknown): value is Readonly<Record<string, unknown>> {
-  if (typeof value !== "object" || value === null) return false;
-  if (Array.isArray(value)) return false;
-  if (isValidElement(value)) return false;
-  return true;
-}
-
-/**
- * Pure: returns a new record with `__layoutFlags` attached. Owns the write
- * boundary for the layout flags key so the write side sits next to
- * `readAppElementsMetadata`.
- *
- * See `LayoutFlags` type docblock in this file for lifecycle.
- */
-export function withLayoutFlags<T extends Record<string, unknown>>(
-  elements: T,
-  layoutFlags: LayoutFlags,
-): T & { [APP_LAYOUT_FLAGS_KEY]: LayoutFlags } {
-  return { ...elements, [APP_LAYOUT_FLAGS_KEY]: layoutFlags };
-}
-
-/**
- * The outgoing wire payload shape. Includes ReactNode values for the
- * rendered tree plus metadata values like LayoutFlags attached under
- * known keys (e.g. __layoutFlags). Distinct from AppElements / AppWireElements
- * which only carry render-time values.
- */
-export type AppOutgoingElements = Readonly<Record<string, ReactNode | LayoutFlags>>;
-
-/**
- * Pure: builds the outgoing payload for the wire. Non-record inputs (e.g. a
- * bare React element) are returned unchanged. Record inputs get a fresh copy
- * with `__layoutFlags` attached. Never mutates `input.element`.
- */
-export function buildOutgoingAppPayload(input: {
-  element: ReactNode | Readonly<Record<string, ReactNode>>;
-  layoutFlags: LayoutFlags;
-}): ReactNode | AppOutgoingElements {
-  if (!isAppElementsRecord(input.element)) {
-    return input.element;
-  }
-  return withLayoutFlags(input.element, input.layoutFlags);
-}
-
-/**
- * Parses metadata from the wire payload. Accepts `Record<string, unknown>`
- * because the RSC payload carries heterogeneous values (React elements,
- * strings, and plain objects like layout flags) under the same record type.
- *
- * See `LayoutFlags` type docblock in this file for lifecycle.
- */
-export function readAppElementsMetadata(
-  elements: Readonly<Record<string, unknown>>,
-): AppElementsMetadata {
-  const routeId = elements[APP_ROUTE_KEY];
-  if (typeof routeId !== "string") {
-    throw new Error("[vinext] Missing __route string in App Router payload");
-  }
-
-  const interceptionContext = elements[APP_INTERCEPTION_CONTEXT_KEY];
-  if (
-    interceptionContext !== undefined &&
-    interceptionContext !== null &&
-    typeof interceptionContext !== "string"
-  ) {
-    throw new Error("[vinext] Invalid __interceptionContext in App Router payload");
-  }
-
-  const rootLayoutTreePath = elements[APP_ROOT_LAYOUT_KEY];
-  if (rootLayoutTreePath === undefined) {
-    throw new Error("[vinext] Missing __rootLayout key in App Router payload");
-  }
-  if (rootLayoutTreePath !== null && typeof rootLayoutTreePath !== "string") {
-    throw new Error("[vinext] Invalid __rootLayout in App Router payload: expected string or null");
-  }
-
-  const layoutFlags = parseLayoutFlags(elements[APP_LAYOUT_FLAGS_KEY]);
-
-  return {
-    interceptionContext: interceptionContext ?? null,
-    layoutFlags,
-    routeId,
-    rootLayoutTreePath,
-  };
 }

--- a/packages/vinext/src/server/app-elements.ts
+++ b/packages/vinext/src/server/app-elements.ts
@@ -23,6 +23,8 @@ export {
   type LayoutFlags,
 } from "./app-elements-wire.js";
 
+// createAppPayloadPageId stays private because callers use AppElementsWire.encodePageId.
+
 export function getMountedSlotIds(elements: AppElements): string[] {
   return Object.keys(elements)
     .filter((key) => {

--- a/packages/vinext/src/server/app-page-boundary-render.ts
+++ b/packages/vinext/src/server/app-page-boundary-render.ts
@@ -19,13 +19,7 @@ import {
   renderAppPageHtmlResponse,
   type AppPageSsrHandler,
 } from "./app-page-stream.js";
-import {
-  APP_INTERCEPTION_CONTEXT_KEY,
-  APP_ROOT_LAYOUT_KEY,
-  APP_ROUTE_KEY,
-  createAppPayloadRouteId,
-  type AppElements,
-} from "./app-elements.js";
+import { AppElementsWire, type AppElements } from "./app-elements.js";
 import { createAppPageLayoutEntries } from "./app-page-route-wiring.js";
 
 // oxlint-disable-next-line @typescript-eslint/no-explicit-any
@@ -219,12 +213,14 @@ function resolveHttpAccessFallbackHeadLayoutTreePositions<TModule extends AppPag
 function createAppPageBoundaryRscPayload<TModule extends AppPageModule>(
   options: AppPageBoundaryRscPayloadOptions<TModule>,
 ): AppElements {
-  const routeId = createAppPayloadRouteId(options.pathname, null);
+  const routeId = AppElementsWire.encodeRouteId(options.pathname, null);
 
   return {
-    [APP_INTERCEPTION_CONTEXT_KEY]: null,
-    [APP_ROUTE_KEY]: routeId,
-    [APP_ROOT_LAYOUT_KEY]: resolveAppPageBoundaryRootLayoutTreePath(options.route),
+    ...AppElementsWire.createMetadataEntries({
+      interceptionContext: null,
+      rootLayoutTreePath: resolveAppPageBoundaryRootLayoutTreePath(options.route),
+      routeId,
+    }),
     [routeId]: options.element,
   };
 }

--- a/packages/vinext/src/server/app-page-element-builder.ts
+++ b/packages/vinext/src/server/app-page-element-builder.ts
@@ -10,11 +10,7 @@ import {
   type AppPageRouteWiringRoute,
   type AppPageSlotOverride,
 } from "./app-page-route-wiring.js";
-import {
-  APP_INTERCEPTION_CONTEXT_KEY,
-  createAppPayloadRouteId,
-  type AppElements,
-} from "./app-elements.js";
+import { AppElementsWire, type AppElements } from "./app-elements.js";
 import type { AppPageParams } from "./app-page-boundary.js";
 import { matchRoutePattern } from "../routing/route-pattern.js";
 import type { MetadataFileRoute } from "./metadata-routes.js";
@@ -116,16 +112,18 @@ export async function buildPageElements<
 
   if (hasPageModule && !PageComponent) {
     const interceptionContext = opts?.interceptionContext ?? null;
-    const noExportRouteId = createAppPayloadRouteId(routePath, interceptionContext);
+    const noExportRouteId = AppElementsWire.encodeRouteId(routePath, interceptionContext);
     let noExportRootLayout: string | null = null;
     if (route.layouts?.length > 0) {
       const treePosition = route.layoutTreePositions?.[0] ?? 0;
       noExportRootLayout = createAppPageTreePath(route.routeSegments, treePosition);
     }
     return {
-      [APP_INTERCEPTION_CONTEXT_KEY]: interceptionContext,
-      __route: noExportRouteId,
-      __rootLayout: noExportRootLayout,
+      ...AppElementsWire.createMetadataEntries({
+        interceptionContext,
+        rootLayoutTreePath: noExportRootLayout,
+        routeId: noExportRouteId,
+      }),
       [noExportRouteId]: createElement("div", null, "Page has no default export"),
     };
   }

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import type { CachedAppPageValue } from "vinext/shims/cache";
-import { buildOutgoingAppPayload, type AppOutgoingElements } from "./app-elements.js";
+import { AppElementsWire, type AppOutgoingElements } from "./app-elements.js";
 import {
   finalizeAppPageHtmlCacheResponse,
   finalizeAppPageRscCacheResponse,
@@ -254,7 +254,7 @@ export async function renderAppPageLifecycle(
   // Render the CANONICAL element. The outgoing payload carries per-layout
   // static/dynamic flags under `__layoutFlags` so the client can later tell
   // which layouts are safe to skip on subsequent navigations.
-  const outgoingElement = buildOutgoingAppPayload({
+  const outgoingElement = AppElementsWire.encodeOutgoingPayload({
     element: options.element,
     layoutFlags,
   });

--- a/packages/vinext/src/server/app-page-route-wiring.tsx
+++ b/packages/vinext/src/server/app-page-route-wiring.tsx
@@ -330,7 +330,6 @@ export function buildAppPageElements<
   TModule extends AppPageModule,
   TErrorModule extends AppPageErrorModule,
 >(options: BuildAppPageElementsOptions<TModule, TErrorModule>): AppElements {
-  const elements: Record<string, ReactNode | string | null> = {};
   const interceptionContext = options.interceptionContext ?? null;
   const routeId = AppElementsWire.encodeRouteId(options.routePath, interceptionContext);
   const pageId = AppElementsWire.encodePageId(options.routePath, interceptionContext);
@@ -355,6 +354,13 @@ export function buildAppPageElements<
   const templateDependenciesBeforeById = new Map<string, AppRenderDependency[]>();
   const pageDependencies: AppRenderDependency[] = [];
   const rootLayoutTreePath = layoutEntries[0]?.treePath ?? null;
+  const elements: Record<string, ReactNode | string | null> = {
+    ...AppElementsWire.createMetadataEntries({
+      interceptionContext,
+      rootLayoutTreePath,
+      routeId,
+    }),
+  };
   const slotNameCounts = new Map<string, number>();
   for (const slot of Object.values(options.route.slots ?? {})) {
     const slotName = slot.name;
@@ -407,14 +413,6 @@ export function buildAppPageElements<
     pageDependencies.push(templateDependency);
   }
 
-  Object.assign(
-    elements,
-    AppElementsWire.createMetadataEntries({
-      interceptionContext,
-      rootLayoutTreePath,
-      routeId,
-    }),
-  );
   elements[pageId] = renderAfterAppDependencies(options.element, pageDependencies);
 
   for (const templateEntry of templateEntries) {

--- a/packages/vinext/src/server/app-page-route-wiring.tsx
+++ b/packages/vinext/src/server/app-page-route-wiring.tsx
@@ -1,13 +1,5 @@
 import { Suspense, type ComponentType, type ReactNode } from "react";
-import {
-  APP_INTERCEPTION_CONTEXT_KEY,
-  APP_ROOT_LAYOUT_KEY,
-  APP_ROUTE_KEY,
-  APP_UNMATCHED_SLOT_WIRE_VALUE,
-  createAppPayloadPageId,
-  createAppPayloadRouteId,
-  type AppElements,
-} from "./app-elements.js";
+import { AppElementsWire, type AppElements } from "./app-elements.js";
 import {
   ErrorBoundary,
   ForbiddenBoundary,
@@ -340,8 +332,8 @@ export function buildAppPageElements<
 >(options: BuildAppPageElementsOptions<TModule, TErrorModule>): AppElements {
   const elements: Record<string, ReactNode | string | null> = {};
   const interceptionContext = options.interceptionContext ?? null;
-  const routeId = createAppPayloadRouteId(options.routePath, interceptionContext);
-  const pageId = createAppPayloadPageId(options.routePath, interceptionContext);
+  const routeId = AppElementsWire.encodeRouteId(options.routePath, interceptionContext);
+  const pageId = AppElementsWire.encodePageId(options.routePath, interceptionContext);
   const layoutEntries = createAppPageLayoutEntries(options.route);
   const templateEntries = createAppPageTemplateEntries(options.route);
   const layoutEntriesByTreePosition = new Map<number, AppPageLayoutEntry<TModule, TErrorModule>>();
@@ -415,9 +407,14 @@ export function buildAppPageElements<
     pageDependencies.push(templateDependency);
   }
 
-  elements[APP_ROUTE_KEY] = routeId;
-  elements[APP_INTERCEPTION_CONTEXT_KEY] = interceptionContext;
-  elements[APP_ROOT_LAYOUT_KEY] = rootLayoutTreePath;
+  Object.assign(
+    elements,
+    AppElementsWire.createMetadataEntries({
+      interceptionContext,
+      rootLayoutTreePath,
+      routeId,
+    }),
+  );
   elements[pageId] = renderAfterAppDependencies(options.element, pageDependencies);
 
   for (const templateEntry of templateEntries) {
@@ -518,7 +515,7 @@ export function buildAppPageElements<
     const slotComponent = overrideOrPageComponent ?? defaultComponent;
 
     if (!slotComponent) {
-      elements[slotId] = APP_UNMATCHED_SLOT_WIRE_VALUE;
+      elements[slotId] = AppElementsWire.unmatchedSlotValue;
       continue;
     }
 

--- a/packages/vinext/src/server/app-ssr-entry.ts
+++ b/packages/vinext/src/server/app-ssr-entry.ts
@@ -24,11 +24,7 @@ import {
 } from "./html.js";
 import { createRscEmbedTransform, createTickBufferedTransform } from "./app-ssr-stream.js";
 import { deferUntilStreamConsumed } from "./app-page-stream.js";
-import {
-  normalizeAppElements,
-  readAppElementsMetadata,
-  type AppWireElements,
-} from "./app-elements.js";
+import { AppElementsWire, type AppWireElements } from "./app-elements.js";
 import { ElementsContext, Slot } from "vinext/shims/slot";
 
 export type FontPreload = {
@@ -217,8 +213,8 @@ export async function handleSsr(
           flightRoot = createFromReadableStream<AppWireElements>(ssrStream);
         }
         const wireElements = use(flightRoot);
-        const elements = normalizeAppElements(wireElements);
-        const metadata = readAppElementsMetadata(elements);
+        const elements = AppElementsWire.decode(wireElements);
+        const metadata = AppElementsWire.readMetadata(elements);
         return createReactElement(
           ElementsContext.Provider,
           { value: elements },

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -27,7 +27,7 @@ import {
   navigateClientSide,
   prefetchRscResponse,
 } from "./navigation.js";
-import { createAppPayloadCacheKey } from "../server/app-elements.js";
+import { AppElementsWire } from "../server/app-elements.js";
 import {
   createRscRequestHeaders,
   createRscRequestUrl,
@@ -145,7 +145,7 @@ function prefetchUrl(href: string): void {
         // Distinguish the same visible URL when it is prefetched from different
         // request contexts such as /feed vs /gallery or different mounted slots.
         const rscUrl = await createRscRequestUrl(fullHref, headers);
-        const cacheKey = createAppPayloadCacheKey(rscUrl, interceptionContext);
+        const cacheKey = AppElementsWire.encodeCacheKey(rscUrl, interceptionContext);
         const prefetched = getPrefetchedUrls();
         if (prefetched.has(cacheKey)) return;
         prefetched.add(cacheKey);

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -12,7 +12,7 @@
 // bindings are just `undefined` on the namespace object and we can guard at runtime.
 import * as React from "react";
 import { notifyAppRouterTransitionStart } from "../client/instrumentation-client-state.js";
-import { createAppPayloadCacheKey } from "../server/app-elements.js";
+import { AppElementsWire } from "../server/app-elements.js";
 import {
   createRscRequestHeaders,
   createRscRequestUrl,
@@ -401,7 +401,7 @@ export function storePrefetchResponse(
   response: Response,
   interceptionContext: string | null = null,
 ): void {
-  const cacheKey = createAppPayloadCacheKey(rscUrl, interceptionContext);
+  const cacheKey = AppElementsWire.encodeCacheKey(rscUrl, interceptionContext);
   evictPrefetchCacheIfNeeded();
   const entry: PrefetchCacheEntry = { timestamp: Date.now() };
   entry.pending = snapshotRscResponse(response)
@@ -475,7 +475,7 @@ export function prefetchRscResponse(
   interceptionContext: string | null = null,
   mountedSlotsHeader: string | null = null,
 ): void {
-  const cacheKey = createAppPayloadCacheKey(rscUrl, interceptionContext);
+  const cacheKey = AppElementsWire.encodeCacheKey(rscUrl, interceptionContext);
   const cache = getPrefetchCache();
   const prefetched = getPrefetchedUrls();
   const now = Date.now();
@@ -521,7 +521,7 @@ export function consumePrefetchResponse(
   interceptionContext: string | null = null,
   mountedSlotsHeader: string | null = null,
 ): CachedRscResponse | null {
-  const cacheKey = createAppPayloadCacheKey(rscUrl, interceptionContext);
+  const cacheKey = AppElementsWire.encodeCacheKey(rscUrl, interceptionContext);
   const cache = getPrefetchCache();
   const entry = cache.get(cacheKey);
   if (!entry) return null;
@@ -1315,7 +1315,7 @@ const _appRouter = {
         headers.set(VINEXT_RSC_MOUNTED_SLOTS_HEADER, mountedSlotsHeader);
       }
       const rscUrl = await createRscRequestUrl(fullHref, headers);
-      const cacheKey = createAppPayloadCacheKey(rscUrl, interceptionContext);
+      const cacheKey = AppElementsWire.encodeCacheKey(rscUrl, interceptionContext);
       const prefetched = getPrefetchedUrls();
       if (prefetched.has(cacheKey)) return;
       prefetched.add(cacheKey);

--- a/tests/app-elements.test.ts
+++ b/tests/app-elements.test.ts
@@ -2,6 +2,7 @@ import React from "react";
 import { describe, expect, it } from "vite-plus/test";
 import { UNMATCHED_SLOT } from "../packages/vinext/src/shims/slot.js";
 import {
+  AppElementsWire,
   APP_INTERCEPTION_CONTEXT_KEY,
   APP_LAYOUT_FLAGS_KEY,
   APP_ROOT_LAYOUT_KEY,
@@ -16,6 +17,65 @@ import {
   resolveVisitedResponseInterceptionContext,
   withLayoutFlags,
 } from "../packages/vinext/src/server/app-elements.js";
+
+describe("AppElementsWire", () => {
+  it("encodes outgoing record payloads without mutating caller-owned records", () => {
+    const element = {
+      "layout:/": "root-layout",
+      "page:/blog": "blog-page",
+    };
+
+    const encoded = AppElementsWire.encodeOutgoingPayload({
+      element,
+      layoutFlags: { "layout:/": "s" },
+    });
+
+    expect(encoded).not.toBe(element);
+    expect(isAppElementsRecord(encoded)).toBe(true);
+    if (isAppElementsRecord(encoded)) {
+      expect(encoded).toEqual({
+        "layout:/": "root-layout",
+        "page:/blog": "blog-page",
+        [APP_LAYOUT_FLAGS_KEY]: { "layout:/": "s" },
+      });
+    }
+    expect(element).toEqual({
+      "layout:/": "root-layout",
+      "page:/blog": "blog-page",
+    });
+  });
+
+  it("decodes wire payloads and reads metadata through one codec boundary", () => {
+    const decoded = AppElementsWire.decode({
+      [APP_INTERCEPTION_CONTEXT_KEY]: "/feed",
+      [APP_ROOT_LAYOUT_KEY]: "/",
+      [APP_ROUTE_KEY]: AppElementsWire.encodeRouteId("/photos/42", "/feed"),
+      "slot:modal:/": AppElementsWire.unmatchedSlotValue,
+    });
+
+    expect(decoded["slot:modal:/"]).toBe(UNMATCHED_SLOT);
+    expect(AppElementsWire.readMetadata(decoded)).toEqual({
+      interceptionContext: "/feed",
+      layoutFlags: {},
+      rootLayoutTreePath: "/",
+      routeId: "route:/photos/42\0/feed",
+    });
+  });
+
+  it("creates the canonical metadata entries for outgoing AppElements records", () => {
+    const metadata = AppElementsWire.createMetadataEntries({
+      interceptionContext: null,
+      rootLayoutTreePath: "/(dashboard)",
+      routeId: AppElementsWire.encodeRouteId("/dashboard", null),
+    });
+
+    expect(metadata).toEqual({
+      [APP_INTERCEPTION_CONTEXT_KEY]: null,
+      [APP_ROOT_LAYOUT_KEY]: "/(dashboard)",
+      [APP_ROUTE_KEY]: "route:/dashboard",
+    });
+  });
+});
 
 describe("app elements payload helpers", () => {
   it("normalizes the unmatched-slot wire marker to UNMATCHED_SLOT for slot entries", () => {


### PR DESCRIPTION
## What this changes
Introduces #726-WIRE-01 by making AppElements wire transport pass through an explicit AppElementsWire codec boundary.

Production App Router callers now use AppElementsWire for route ids, page ids, cache keys, metadata entries, outgoing payload layout flags, wire decode, and metadata reads. The existing app-elements module remains as the compatibility barrel for current helper imports, but current production encode/decode/write paths no longer assemble raw AppElements wire metadata directly.

## Why
Issue #726 calls out the flat keyed AppElements payload as a transport bridge, not the router brain. Before this PR, route identity, cache identity, metadata writes, unmatched-slot transport, and payload parsing were spread across call sites as individual helper calls and raw keys. That makes later ownership work harder because there is no single place to reason about the RSC/HTML payload boundary.

Correctness oracle: Vinext internal invariant. This PR preserves current observable App Router behavior while introducing an enforceable wire owner for the next #726 waves.

## Approach
Add server/app-elements-wire.ts as the codec owner for:

- wire constants and the unmatched-slot transport sentinel
- AppElements and AppWireElements decode
- route, page, and cache key encoding
- canonical metadata entry creation
- outgoing payload shaping with layout flags
- metadata parsing and payload-record detection

Then route the current production call sites through AppElementsWire:

- RSC route wiring, fallback boundaries, no-default-export payloads, and generated RSC action not-found payloads
- SSR and browser RSC decode plus metadata reads
- visited-response and prefetch cache key construction
- next/link and next/navigation prefetch dedupe keys

This intentionally does not promote topology, slot ownership, lifecycle authority, or cache semantics. Those remain later #726 waves.

## Validation
- vp test run tests/app-elements.test.ts tests/slot.test.ts tests/app-browser-entry.test.ts tests/app-page-element-builder.test.ts tests/app-page-render.test.ts tests/app-page-route-wiring.test.ts tests/app-fallback-renderer.test.ts tests/app-router.test.ts tests/entry-templates.test.ts tests/link.test.ts tests/prefetch-cache.test.ts
- vp check packages/vinext/src/server/app-elements-wire.ts packages/vinext/src/server/app-elements.ts packages/vinext/src/server/app-page-route-wiring.tsx packages/vinext/src/server/app-page-boundary-render.ts packages/vinext/src/server/app-page-element-builder.ts packages/vinext/src/server/app-page-render.ts packages/vinext/src/server/app-ssr-entry.ts packages/vinext/src/server/app-browser-state.ts packages/vinext/src/server/app-browser-entry.ts packages/vinext/src/shims/navigation.ts packages/vinext/src/shims/link.tsx packages/vinext/src/entries/app-rsc-entry.ts tests/app-elements.test.ts
- vp run vinext#build

The focused test matrix passed 530 tests. The build completed with the repo's existing virtual-module unresolved-import warnings.

## Risks / follow-ups
Open PR overlap risk exists around App Router generated entry and browser navigation files, especially #1057, #922, #698, #647, #488, #404 and older dirty PRs. This branch is based on current upstream/main and currently publishes cleanly from there.

WIRE-02 should remove or lint against raw wire-key construction outside AppElementsWire. This PR deliberately leaves legacy helper exports where covered by existing compatibility tests so the ownership migration stays reviewable.