### PR TITLE
feat(app-router): track visible commit versions for browser operations

### DIFF
--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -60,6 +60,7 @@ import {
   resolveInterceptionContextFromPreviousNextUrl,
   resolveServerActionRequestState,
   type AppRouterState,
+  type OperationLane,
 } from "./app-browser-state.js";
 import { DevRecoveryBoundary } from "vinext/shims/error-boundary";
 import { ElementsContext, Slot } from "vinext/shims/slot";
@@ -100,6 +101,21 @@ type NavigationKind = "navigate" | "traverse" | "refresh";
 // Both call sites must stay in sync — update here if NavigationKind gains new values.
 function toActionType(kind: NavigationKind): "navigate" | "traverse" {
   return kind === "traverse" ? "traverse" : "navigate";
+}
+
+function toOperationLane(kind: NavigationKind): OperationLane {
+  switch (kind) {
+    case "navigate":
+      return "navigation";
+    case "refresh":
+      return "refresh";
+    case "traverse":
+      return "traverse";
+    default: {
+      const _exhaustive: never = kind;
+      throw new Error("[vinext] Unknown navigation kind: " + String(_exhaustive));
+    }
+  }
 }
 
 type VisitedResponseCacheEntry = {
@@ -234,6 +250,7 @@ async function renderNavigationPayload(
   pendingRouterState: PendingBrowserRouterState | null,
   useTransition = true,
   actionType: "navigate" | "replace" | "traverse" = "navigate",
+  operationLane: OperationLane = "navigation",
 ): Promise<void> {
   try {
     return await browserNavigationController.renderNavigationPayload({
@@ -245,6 +262,7 @@ async function renderNavigationPayload(
       historyUpdateMode,
       navigationSnapshot,
       nextElements: payload,
+      operationLane,
       params,
       pendingRouterState,
       previousNextUrl,
@@ -426,6 +444,7 @@ function BrowserRoot({
   const resolvedElements = use(initialElements);
   const initialMetadata = readAppElementsMetadata(resolvedElements);
   const [treeStateValue, setTreeStateValue] = useState<AppRouterState | Promise<AppRouterState>>({
+    activeOperation: null,
     elements: resolvedElements,
     interceptionContext: initialMetadata.interceptionContext,
     layoutFlags: initialMetadata.layoutFlags,
@@ -434,6 +453,7 @@ function BrowserRoot({
     renderId: 0,
     rootLayoutTreePath: initialMetadata.rootLayoutTreePath,
     routeId: initialMetadata.routeId,
+    visibleCommitVersion: 0,
   });
   const treeState = isRouterStatePromise(treeStateValue) ? use(treeStateValue) : treeStateValue;
 
@@ -984,6 +1004,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
             pendingRouterState,
             isSameRoute,
             toActionType(navigationKind),
+            toOperationLane(navigationKind),
           );
           return;
         }
@@ -1123,6 +1144,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
           pendingRouterState,
           isSameRoute,
           toActionType(navigationKind),
+          toOperationLane(navigationKind),
         );
         // Don't cache the response if this navigation was superseded during
         // renderNavigationPayload's await — the elements were never dispatched.

--- a/packages/vinext/src/server/app-browser-navigation-controller.ts
+++ b/packages/vinext/src/server/app-browser-navigation-controller.ts
@@ -12,6 +12,8 @@ import {
   routerReducer,
   type AppRouterAction,
   type AppRouterState,
+  type OperationLane,
+  type PendingOperationRecord,
 } from "./app-browser-state.js";
 import type { AppElements, LayoutFlags } from "./app-elements.js";
 
@@ -57,6 +59,7 @@ type BrowserNavigationController = {
     historyUpdateMode: HistoryUpdateMode | undefined;
     navigationSnapshot: ClientNavigationRenderSnapshot;
     nextElements: Promise<AppElements>;
+    operationLane: OperationLane;
     params: Record<string, string | string[]>;
     pendingRouterState: PendingBrowserRouterState | null;
     previousNextUrl: string | null;
@@ -308,6 +311,7 @@ export function createAppBrowserNavigationController(
       currentState,
       nextElements,
       navigationSnapshot,
+      operationLane: "hmr",
       renderId,
       type: "replace",
     });
@@ -328,6 +332,7 @@ export function createAppBrowserNavigationController(
       pending.previousNextUrl,
       pending.routeId,
       pending.rootLayoutTreePath,
+      pending.action.operation,
       null,
       false,
     );
@@ -371,6 +376,7 @@ export function createAppBrowserNavigationController(
     previousNextUrl: string | null,
     routeId: string,
     rootLayoutTreePath: string | null,
+    operation: PendingOperationRecord,
     pendingRouterState: PendingBrowserRouterState | null,
     useTransitionMode: boolean,
   ): void {
@@ -380,6 +386,7 @@ export function createAppBrowserNavigationController(
       interceptionContext,
       layoutFlags,
       navigationSnapshot,
+      operation,
       previousNextUrl,
       renderId,
       rootLayoutTreePath,
@@ -412,6 +419,7 @@ export function createAppBrowserNavigationController(
     historyUpdateMode: HistoryUpdateMode | undefined;
     navigationSnapshot: ClientNavigationRenderSnapshot;
     nextElements: Promise<AppElements>;
+    operationLane: OperationLane;
     params: Record<string, string | string[]>;
     pendingRouterState: PendingBrowserRouterState | null;
     previousNextUrl: string | null;
@@ -433,6 +441,7 @@ export function createAppBrowserNavigationController(
         currentState,
         nextElements: options.nextElements,
         navigationSnapshot: options.navigationSnapshot,
+        operationLane: options.operationLane,
         previousNextUrl: options.previousNextUrl,
         renderId,
         type: options.actionType,
@@ -481,6 +490,7 @@ export function createAppBrowserNavigationController(
         pending.previousNextUrl,
         pending.routeId,
         pending.rootLayoutTreePath,
+        pending.action.operation,
         options.pendingRouterState,
         options.useTransition ?? true,
       );
@@ -516,6 +526,7 @@ export function createAppBrowserNavigationController(
       navigationSnapshot,
       nextElements,
       renderId: allocateRenderId(),
+      operationLane: "server-action",
       startedNavigationId,
       type: "navigate",
     });
@@ -536,6 +547,7 @@ export function createAppBrowserNavigationController(
         pending.previousNextUrl,
         pending.routeId,
         pending.rootLayoutTreePath,
+        pending.action.operation,
         null,
         false,
       );

--- a/packages/vinext/src/server/app-browser-state.ts
+++ b/packages/vinext/src/server/app-browser-state.ts
@@ -15,7 +15,27 @@ type HistoryStateRecord = {
   [key: string]: unknown;
 };
 
+export type OperationLane = "navigation" | "refresh" | "traverse" | "server-action" | "hmr";
+
+type OperationRecordBase = {
+  id: number;
+  lane: OperationLane;
+  startedVisibleCommitVersion: number;
+};
+
+export type PendingOperationRecord = OperationRecordBase & {
+  state: "pending";
+};
+
+export type CommittedOperationRecord = OperationRecordBase & {
+  state: "committed";
+  visibleCommitVersion: number;
+};
+
+export type OperationRecord = PendingOperationRecord | CommittedOperationRecord;
+
 export type AppRouterState = {
+  activeOperation: OperationRecord | null;
   elements: AppElements;
   interceptionContext: string | null;
   layoutFlags: LayoutFlags;
@@ -24,6 +44,7 @@ export type AppRouterState = {
   navigationSnapshot: ClientNavigationRenderSnapshot;
   rootLayoutTreePath: string | null;
   routeId: string;
+  visibleCommitVersion: number;
 };
 
 export type AppRouterAction = {
@@ -31,6 +52,7 @@ export type AppRouterAction = {
   interceptionContext: string | null;
   layoutFlags: LayoutFlags;
   navigationSnapshot: ClientNavigationRenderSnapshot;
+  operation: PendingOperationRecord;
   previousNextUrl: string | null;
   renderId: number;
   rootLayoutTreePath: string | null;
@@ -82,6 +104,32 @@ export function createHistoryStateWithPreviousNextUrl(
 export function readHistoryStatePreviousNextUrl(state: unknown): string | null {
   const value = cloneHistoryState(state)[VINEXT_PREVIOUS_NEXT_URL_HISTORY_STATE_KEY];
   return typeof value === "string" ? value : null;
+}
+
+export function createOperationRecord(options: {
+  id: number;
+  lane: OperationLane;
+  startedVisibleCommitVersion: number;
+}): PendingOperationRecord {
+  return {
+    id: options.id,
+    lane: options.lane,
+    startedVisibleCommitVersion: options.startedVisibleCommitVersion,
+    state: "pending",
+  };
+}
+
+function commitOperationRecord(
+  operation: PendingOperationRecord,
+  visibleCommitVersion: number,
+): CommittedOperationRecord {
+  return {
+    id: operation.id,
+    lane: operation.lane,
+    startedVisibleCommitVersion: operation.startedVisibleCommitVersion,
+    state: "committed",
+    visibleCommitVersion,
+  };
 }
 
 export function resolveInterceptionContextFromPreviousNextUrl(
@@ -140,31 +188,66 @@ export function resolveServerActionRequestState(
   return { headers };
 }
 
+type AppRouterStateWithoutCommitMetadata = {
+  elements: AppElements;
+  interceptionContext: string | null;
+  layoutFlags: LayoutFlags;
+  navigationSnapshot: ClientNavigationRenderSnapshot;
+  previousNextUrl: string | null;
+  renderId: number;
+  rootLayoutTreePath: string | null;
+  routeId: string;
+};
+
+function commitVisibleRouterState(
+  state: AppRouterState,
+  nextState: AppRouterStateWithoutCommitMetadata,
+  operation: PendingOperationRecord,
+): AppRouterState {
+  // Advances when the browser router accepts a new visible router-state commit.
+  // This is the lifecycle baseline used to reject stale async results; it is
+  // not a React DOM paint signal.
+  const visibleCommitVersion = state.visibleCommitVersion + 1;
+  return {
+    ...nextState,
+    activeOperation: commitOperationRecord(operation, visibleCommitVersion),
+    visibleCommitVersion,
+  };
+}
+
 export function routerReducer(state: AppRouterState, action: AppRouterAction): AppRouterState {
   switch (action.type) {
     case "traverse":
     case "navigate":
-      return {
-        elements: mergeElements(state.elements, action.elements, action.type === "traverse"),
-        interceptionContext: action.interceptionContext,
-        layoutFlags: { ...state.layoutFlags, ...action.layoutFlags },
-        navigationSnapshot: action.navigationSnapshot,
-        previousNextUrl: action.previousNextUrl,
-        renderId: action.renderId,
-        rootLayoutTreePath: action.rootLayoutTreePath,
-        routeId: action.routeId,
-      };
+      return commitVisibleRouterState(
+        state,
+        {
+          elements: mergeElements(state.elements, action.elements, action.type === "traverse"),
+          interceptionContext: action.interceptionContext,
+          layoutFlags: { ...state.layoutFlags, ...action.layoutFlags },
+          navigationSnapshot: action.navigationSnapshot,
+          previousNextUrl: action.previousNextUrl,
+          renderId: action.renderId,
+          rootLayoutTreePath: action.rootLayoutTreePath,
+          routeId: action.routeId,
+        },
+        action.operation,
+      );
     case "replace":
-      return {
-        elements: action.elements,
-        interceptionContext: action.interceptionContext,
-        layoutFlags: action.layoutFlags,
-        navigationSnapshot: action.navigationSnapshot,
-        previousNextUrl: action.previousNextUrl,
-        renderId: action.renderId,
-        rootLayoutTreePath: action.rootLayoutTreePath,
-        routeId: action.routeId,
-      };
+      return commitVisibleRouterState(
+        state,
+        {
+          elements: action.elements,
+          interceptionContext: action.interceptionContext,
+          layoutFlags: action.layoutFlags,
+          navigationSnapshot: action.navigationSnapshot,
+          previousNextUrl: action.previousNextUrl,
+          renderId: action.renderId,
+          rootLayoutTreePath: action.rootLayoutTreePath,
+          routeId: action.routeId,
+        },
+        action.operation,
+      );
     default: {
       const _exhaustive: never = action.type;
       throw new Error("[vinext] Unknown router action: " + String(_exhaustive));
@@ -207,6 +290,7 @@ export async function createPendingNavigationCommit(options: {
   currentState: AppRouterState;
   nextElements: Promise<AppElements>;
   navigationSnapshot: ClientNavigationRenderSnapshot;
+  operationLane: OperationLane;
   previousNextUrl?: string | null;
   renderId: number;
   type: "navigate" | "replace" | "traverse";
@@ -224,6 +308,11 @@ export async function createPendingNavigationCommit(options: {
       interceptionContext: metadata.interceptionContext,
       layoutFlags: metadata.layoutFlags,
       navigationSnapshot: options.navigationSnapshot,
+      operation: createOperationRecord({
+        id: options.renderId,
+        lane: options.operationLane,
+        startedVisibleCommitVersion: options.currentState.visibleCommitVersion,
+      }),
       previousNextUrl,
       renderId: options.renderId,
       rootLayoutTreePath: metadata.rootLayoutTreePath,
@@ -243,6 +332,7 @@ export async function resolveAndClassifyNavigationCommit(options: {
   currentState: AppRouterState;
   navigationSnapshot: ClientNavigationRenderSnapshot;
   nextElements: Promise<AppElements>;
+  operationLane: OperationLane;
   previousNextUrl?: string | null;
   renderId: number;
   startedNavigationId: number;
@@ -252,6 +342,7 @@ export async function resolveAndClassifyNavigationCommit(options: {
     currentState: options.currentState,
     nextElements: options.nextElements,
     navigationSnapshot: options.navigationSnapshot,
+    operationLane: options.operationLane,
     previousNextUrl: options.previousNextUrl,
     renderId: options.renderId,
     type: options.type,

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -17,6 +17,7 @@ import { createClientNavigationRenderSnapshot } from "../packages/vinext/src/shi
 import * as navigationShim from "../packages/vinext/src/shims/navigation.js";
 import {
   createHistoryStateWithPreviousNextUrl,
+  createOperationRecord,
   createPendingNavigationCommit,
   readHistoryStatePreviousNextUrl,
   resolveAndClassifyNavigationCommit,
@@ -48,12 +49,25 @@ function createState(overrides: Partial<AppRouterState> = {}): AppRouterState {
     layoutFlags: {},
     navigationSnapshot: createClientNavigationRenderSnapshot("https://example.com/initial", {}),
     renderId: 0,
+    activeOperation: null,
     interceptionContext: null,
     previousNextUrl: null,
     rootLayoutTreePath: "/",
     routeId: "route:/initial",
+    visibleCommitVersion: 0,
     ...overrides,
   };
+}
+
+function createTestOperation(
+  state: AppRouterState,
+  id = 1,
+): ReturnType<typeof createOperationRecord> {
+  return createOperationRecord({
+    id,
+    lane: "navigation",
+    startedVisibleCommitVersion: state.visibleCommitVersion,
+  });
 }
 
 function createControllerHarness(initialState: AppRouterState = createState()) {
@@ -101,6 +115,7 @@ describe("app browser entry state helpers", () => {
       currentState: createState(),
       nextElements: Promise.resolve(createResolvedElements("route:/dashboard", "/")),
       navigationSnapshot: createState().navigationSnapshot,
+      operationLane: "navigation",
       type: "navigate",
     });
   });
@@ -112,28 +127,35 @@ describe("app browser entry state helpers", () => {
     const nextElements = createResolvedElements("route:/next", "/", null, {
       "page:/next": React.createElement("main", null, "next"),
     });
+    const state = createState({
+      elements: previousElements,
+    });
 
-    const nextState = routerReducer(
-      createState({
-        elements: previousElements,
-      }),
-      {
-        elements: nextElements,
-        interceptionContext: null,
-        layoutFlags: {},
-        navigationSnapshot: createState().navigationSnapshot,
-        previousNextUrl: null,
-        renderId: 1,
-        rootLayoutTreePath: "/",
-        routeId: "route:/next",
-        type: "navigate",
-      },
-    );
+    const nextState = routerReducer(state, {
+      elements: nextElements,
+      interceptionContext: null,
+      layoutFlags: {},
+      navigationSnapshot: createState().navigationSnapshot,
+      operation: createTestOperation(state),
+      previousNextUrl: null,
+      renderId: 1,
+      rootLayoutTreePath: "/",
+      routeId: "route:/next",
+      type: "navigate",
+    });
 
     expect(nextState.routeId).toBe("route:/next");
     expect(nextState.interceptionContext).toBeNull();
     expect(nextState.previousNextUrl).toBeNull();
     expect(nextState.rootLayoutTreePath).toBe("/");
+    expect(nextState.visibleCommitVersion).toBe(1);
+    expect(nextState.activeOperation).toMatchObject({
+      id: 1,
+      lane: "navigation",
+      startedVisibleCommitVersion: 0,
+      state: "committed",
+      visibleCommitVersion: 1,
+    });
     expect(nextState.elements).toMatchObject({
       "layout:/": expect.anything(),
       "page:/next": expect.anything(),
@@ -145,11 +167,13 @@ describe("app browser entry state helpers", () => {
       "page:/next": React.createElement("main", null, "next"),
     });
 
-    const nextState = routerReducer(createState(), {
+    const state = createState();
+    const nextState = routerReducer(state, {
       elements: nextElements,
       interceptionContext: null,
       layoutFlags: {},
       navigationSnapshot: createState().navigationSnapshot,
+      operation: createTestOperation(state),
       previousNextUrl: null,
       renderId: 1,
       rootLayoutTreePath: "/",
@@ -165,6 +189,43 @@ describe("app browser entry state helpers", () => {
     });
   });
 
+  it("increments the visible commit version once per visible reducer commit", () => {
+    const initialState = createState();
+    const firstState = routerReducer(initialState, {
+      elements: createResolvedElements("route:/one", "/"),
+      interceptionContext: null,
+      layoutFlags: {},
+      navigationSnapshot: initialState.navigationSnapshot,
+      operation: createTestOperation(initialState, 101),
+      previousNextUrl: null,
+      renderId: 1,
+      rootLayoutTreePath: "/",
+      routeId: "route:/one",
+      type: "navigate",
+    });
+    const secondState = routerReducer(firstState, {
+      elements: createResolvedElements("route:/two", "/"),
+      interceptionContext: null,
+      layoutFlags: {},
+      navigationSnapshot: firstState.navigationSnapshot,
+      operation: createTestOperation(firstState, 102),
+      previousNextUrl: null,
+      renderId: 2,
+      rootLayoutTreePath: "/",
+      routeId: "route:/two",
+      type: "navigate",
+    });
+
+    expect(firstState.visibleCommitVersion).toBe(1);
+    expect(secondState.visibleCommitVersion).toBe(2);
+    expect(secondState.activeOperation).toMatchObject({
+      id: 102,
+      startedVisibleCommitVersion: 1,
+      state: "committed",
+      visibleCommitVersion: 2,
+    });
+  });
+
   it("carries interception context through pending navigation commits", async () => {
     const pending = await createPendingNavigationCommit({
       currentState: createState(),
@@ -174,6 +235,7 @@ describe("app browser entry state helpers", () => {
         }),
       ),
       navigationSnapshot: createState().navigationSnapshot,
+      operationLane: "navigation",
       previousNextUrl: "/feed",
       renderId: 1,
       type: "navigate",
@@ -201,6 +263,7 @@ describe("app browser entry state helpers", () => {
       currentState: interceptedState,
       nextElements: Promise.resolve(createResolvedElements("route:/feed", "/")),
       navigationSnapshot: createState().navigationSnapshot,
+      operationLane: "traverse",
       previousNextUrl: null,
       renderId: 2,
       type: "traverse",
@@ -218,6 +281,7 @@ describe("app browser entry state helpers", () => {
       currentState,
       nextElements: Promise.resolve(createResolvedElements("route:/dashboard", "/(dashboard)")),
       navigationSnapshot: currentState.navigationSnapshot,
+      operationLane: "navigation",
       renderId: 1,
       type: "navigate",
     });
@@ -242,6 +306,7 @@ describe("app browser entry state helpers", () => {
       currentState: createState(),
       nextElements,
       navigationSnapshot: createState().navigationSnapshot,
+      operationLane: "navigation",
       renderId: 1,
       type: "navigate",
     }).then((result) => {
@@ -269,12 +334,45 @@ describe("app browser entry state helpers", () => {
     expect(result.routeId).toBe("route:/dashboard");
   });
 
+  it("creates pending operation records from the current visible commit version", async () => {
+    const currentState = createState({
+      visibleCommitVersion: 4,
+    });
+
+    const pending = await createPendingNavigationCommit({
+      currentState,
+      nextElements: Promise.resolve(createResolvedElements("route:/dashboard", "/")),
+      navigationSnapshot: currentState.navigationSnapshot,
+      operationLane: "refresh",
+      renderId: 9,
+      type: "navigate",
+    });
+
+    expect(pending.action.operation).toEqual({
+      id: 9,
+      lane: "refresh",
+      startedVisibleCommitVersion: 4,
+      state: "pending",
+    });
+
+    const committedState = routerReducer(currentState, pending.action);
+    expect(committedState.visibleCommitVersion).toBe(5);
+    expect(committedState.activeOperation).toEqual({
+      id: 9,
+      lane: "refresh",
+      startedVisibleCommitVersion: 4,
+      state: "committed",
+      visibleCommitVersion: 5,
+    });
+  });
+
   it("skips a pending commit when a newer navigation has become active", async () => {
     const currentState = createState();
     const pending = await createPendingNavigationCommit({
       currentState,
       nextElements: Promise.resolve(createResolvedElements("route:/dashboard", "/")),
       navigationSnapshot: currentState.navigationSnapshot,
+      operationLane: "navigation",
       renderId: 1,
       type: "navigate",
     });
@@ -294,6 +392,7 @@ describe("app browser entry state helpers", () => {
       currentState: createState(),
       nextElements: Promise.resolve(createResolvedElements("route:/dashboard", "/")),
       navigationSnapshot: createState().navigationSnapshot,
+      operationLane: "refresh",
       previousNextUrl: "/feed",
       renderId: 1,
       type: "navigate",
@@ -306,20 +405,19 @@ describe("app browser entry state helpers", () => {
   });
 
   it("merges layoutFlags on navigate", () => {
-    const nextState = routerReducer(
-      createState({ layoutFlags: { "layout:/": "s", "layout:/old": "d" } }),
-      {
-        elements: createResolvedElements("route:/next", "/"),
-        interceptionContext: null,
-        layoutFlags: { "layout:/": "s", "layout:/blog": "d" },
-        navigationSnapshot: createState().navigationSnapshot,
-        previousNextUrl: null,
-        renderId: 1,
-        rootLayoutTreePath: "/",
-        routeId: "route:/next",
-        type: "navigate",
-      },
-    );
+    const state = createState({ layoutFlags: { "layout:/": "s", "layout:/old": "d" } });
+    const nextState = routerReducer(state, {
+      elements: createResolvedElements("route:/next", "/"),
+      interceptionContext: null,
+      layoutFlags: { "layout:/": "s", "layout:/blog": "d" },
+      navigationSnapshot: createState().navigationSnapshot,
+      operation: createTestOperation(state),
+      previousNextUrl: null,
+      renderId: 1,
+      rootLayoutTreePath: "/",
+      routeId: "route:/next",
+      type: "navigate",
+    });
 
     // Navigate merges: old flags preserved, new flags override
     expect(nextState.layoutFlags).toEqual({
@@ -330,31 +428,32 @@ describe("app browser entry state helpers", () => {
   });
 
   it("replaces layoutFlags on replace", () => {
-    const nextState = routerReducer(
-      createState({ layoutFlags: { "layout:/": "s", "layout:/old": "d" } }),
-      {
-        elements: createResolvedElements("route:/next", "/"),
-        interceptionContext: null,
-        layoutFlags: { "layout:/": "d" },
-        navigationSnapshot: createState().navigationSnapshot,
-        previousNextUrl: null,
-        renderId: 1,
-        rootLayoutTreePath: "/",
-        routeId: "route:/next",
-        type: "replace",
-      },
-    );
+    const state = createState({ layoutFlags: { "layout:/": "s", "layout:/old": "d" } });
+    const nextState = routerReducer(state, {
+      elements: createResolvedElements("route:/next", "/"),
+      interceptionContext: null,
+      layoutFlags: { "layout:/": "d" },
+      navigationSnapshot: createState().navigationSnapshot,
+      operation: createTestOperation(state),
+      previousNextUrl: null,
+      renderId: 1,
+      rootLayoutTreePath: "/",
+      routeId: "route:/next",
+      type: "replace",
+    });
 
     // Replace: only new flags
     expect(nextState.layoutFlags).toEqual({ "layout:/": "d" });
   });
 
   it("stores previousNextUrl on navigate actions", () => {
-    const nextState = routerReducer(createState(), {
+    const state = createState();
+    const nextState = routerReducer(state, {
       elements: createResolvedElements("route:/photos/42\0/feed", "/", "/feed"),
       interceptionContext: "/feed",
       layoutFlags: {},
       navigationSnapshot: createState().navigationSnapshot,
+      operation: createTestOperation(state),
       previousNextUrl: "/feed",
       renderId: 1,
       rootLayoutTreePath: "/",
@@ -412,6 +511,7 @@ describe("app browser navigation controller", () => {
         historyUpdateMode: "push",
         navigationSnapshot: stateRef.current.navigationSnapshot,
         nextElements,
+        operationLane: "navigation",
         params: {},
         pendingRouterState: null,
         previousNextUrl: null,
@@ -474,6 +574,7 @@ describe("app browser navigation controller", () => {
         historyUpdateMode: "push",
         navigationSnapshot: stateRef.current.navigationSnapshot,
         nextElements,
+        operationLane: "navigation",
         params: {},
         pendingRouterState,
         previousNextUrl: null,
@@ -511,6 +612,7 @@ describe("app browser navigation controller", () => {
         historyUpdateMode: "push",
         navigationSnapshot: createClientNavigationRenderSnapshot("https://example.com/initial", {}),
         nextElements,
+        operationLane: "navigation",
         params: {},
         pendingRouterState: null,
         previousNextUrl: null,
@@ -555,6 +657,7 @@ describe("app browser navigation controller", () => {
         historyUpdateMode: "push",
         navigationSnapshot: stateRef.current.navigationSnapshot,
         nextElements,
+        operationLane: "navigation",
         params: {},
         pendingRouterState: null,
         previousNextUrl: null,
@@ -615,6 +718,13 @@ describe("app browser navigation controller", () => {
       expect(assign).not.toHaveBeenCalled();
       expect(stateRef.current.routeId).toBe("route:/settings/account");
       expect(stateRef.current.previousNextUrl).toBeNull();
+      expect(stateRef.current.visibleCommitVersion).toBe(1);
+      expect(stateRef.current.activeOperation).toMatchObject({
+        lane: "server-action",
+        startedVisibleCommitVersion: 0,
+        state: "committed",
+        visibleCommitVersion: 1,
+      });
     } finally {
       detach();
     }
@@ -706,6 +816,7 @@ describe("app browser entry previousNextUrl helpers", () => {
       currentState,
       navigationSnapshot: currentState.navigationSnapshot,
       nextElements: Promise.resolve(createResolvedElements("route:/dashboard", "/(dashboard)")),
+      operationLane: "server-action",
       renderId: 3,
       startedNavigationId: 7,
       type: "navigate",
@@ -735,6 +846,7 @@ describe("app browser entry previousNextUrl helpers", () => {
       interceptionContext: null,
       layoutFlags: {},
       navigationSnapshot: createState().navigationSnapshot,
+      operation: createTestOperation(state),
       previousNextUrl: null,
       renderId: 1,
       rootLayoutTreePath: "/",
@@ -758,6 +870,7 @@ describe("app browser entry previousNextUrl helpers", () => {
       interceptionContext: null,
       layoutFlags: {},
       navigationSnapshot: createState().navigationSnapshot,
+      operation: createTestOperation(state),
       previousNextUrl: null,
       renderId: 1,
       rootLayoutTreePath: "/",

--- a/tests/prefetch-cache.test.ts
+++ b/tests/prefetch-cache.test.ts
@@ -81,9 +81,14 @@ function fillCache(count: number, timestamp: number, keyPrefix = "/page-"): void
   }
 }
 
-async function waitForPrefetchSetup(): Promise<void> {
-  await Promise.resolve();
-  await new Promise((resolve) => setTimeout(resolve, 0));
+async function waitForPrefetchSetup(isReady: () => boolean = () => true): Promise<void> {
+  const deadline = Date.now() + 1_000;
+
+  do {
+    await Promise.resolve();
+    if (isReady()) return;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  } while (Date.now() < deadline);
 }
 
 describe("prefetch cache eviction", () => {
@@ -107,7 +112,7 @@ describe("prefetch cache eviction", () => {
     (globalThis as any).fetch = fetch;
 
     useRouter().prefetch("http://localhost/dashboard?tab=1");
-    await waitForPrefetchSetup();
+    await waitForPrefetchSetup(() => fetch.mock.calls.length > 0);
 
     expect(fetch).toHaveBeenCalledTimes(1);
     expect(fetchedUrl).toMatch(/^\/dashboard\.rsc\?tab=1&_rsc(?:=.+)?$/);


### PR DESCRIPTION
## What this changes

Implements `#726-CORE-01` from #726 by adding the first browser-visible lifecycle spine to the App Router browser state. Browser router state now carries `visibleCommitVersion` and the operation that produced the currently visible router-state commit.

## Why

Issue #726 calls out that `activeNavigationId` is not enough lifecycle authority for same-URL refresh and server-action races. Before this PR, browser-visible router state changed without a versioned commit baseline or a typed operation record, which made later stale-result gates impossible to express cleanly.

`visibleCommitVersion` intentionally names the router lifecycle commit baseline from #726. It advances when the reducer accepts a new visible router-state commit; it is not a React DOM paint signal.

## Approach

- Add `OperationRecord` types with explicit lanes for navigation, refresh, traverse, server-action, and HMR work.
- Add `visibleCommitVersion` and `activeOperation` to `AppRouterState`, initialized at hydration version `0`.
- Make pending navigation commits capture their lane and starting visible commit version when the RSC payload resolves into a pending commit.
- Route reducer commits through one helper, `commitVisibleRouterState`, which is the only owner that increments `visibleCommitVersion` and stamps the committed operation.
- Thread explicit lanes through cached navigation, fetched navigation, same-URL server actions, and HMR replacement without changing current merge/replace/root-layout behavior.
- Harden the prefetch-cache unit test that CI exposed as timing-sensitive by waiting for the async `router.prefetch()` fetch side effect instead of assuming one timer tick is enough.

Non-goals for this PR: it does not introduce `ApprovedVisibleCommit`, `NavigationPlanner`, broad cache coherence, or the stale same-URL server-action rejection planned for later `#726-CORE-04`. This PR intentionally creates the versioned ownership data those later gates need.

## Validation

- `vp check packages/vinext/src/server/app-browser-state.ts packages/vinext/src/server/app-browser-navigation-controller.ts packages/vinext/src/server/app-browser-entry.ts tests/app-browser-entry.test.ts tests/prefetch-cache.test.ts`
- `vp test run tests/app-browser-entry.test.ts tests/prefetch-cache.test.ts`
- `vp test run --project unit`
- `git diff --check`
- Commit hook: `vp check --fix` plus `knip --no-progress`

## Risks / follow-ups

The known same-URL server-action stale commit race is still deliberately left in place and documented in code. The observable behavior is unchanged here; follow-up `#726-CORE-04` should use `startedVisibleCommitVersion` to reject or reroute stale same-URL commits.
