### PR TITLE
feat(app-router): add artifact compatibility metadata

### DIFF
--- a/packages/vinext/src/server/app-elements-wire.ts
+++ b/packages/vinext/src/server/app-elements-wire.ts
@@ -191,13 +191,6 @@ export function withLayoutFlags<T extends Record<string, unknown>>(
   return { ...elements, [APP_LAYOUT_FLAGS_KEY]: layoutFlags };
 }
 
-function withArtifactCompatibilityEnvelope<T extends Record<string, unknown>>(
-  elements: T,
-  artifactCompatibility: ArtifactCompatibilityEnvelope,
-): T & { [APP_ARTIFACT_COMPATIBILITY_KEY]: ArtifactCompatibilityEnvelope } {
-  return { ...elements, [APP_ARTIFACT_COMPATIBILITY_KEY]: artifactCompatibility };
-}
-
 export function buildOutgoingAppPayload(input: {
   element: ReactNode | Readonly<Record<string, ReactNode>>;
   artifactCompatibility?: ArtifactCompatibilityEnvelope;
@@ -206,10 +199,23 @@ export function buildOutgoingAppPayload(input: {
   if (!isAppElementsRecord(input.element)) {
     return input.element;
   }
-  return withArtifactCompatibilityEnvelope(
-    withLayoutFlags(input.element, input.layoutFlags),
-    input.artifactCompatibility ?? createArtifactCompatibilityEnvelope(),
-  );
+  return {
+    ...input.element,
+    [APP_LAYOUT_FLAGS_KEY]: input.layoutFlags,
+    [APP_ARTIFACT_COMPATIBILITY_KEY]:
+      input.artifactCompatibility ?? createArtifactCompatibilityEnvelope(),
+  };
+}
+
+function readArtifactCompatibilityMetadata(value: unknown): ArtifactCompatibilityEnvelope {
+  if (value === undefined) return createArtifactCompatibilityEnvelope();
+
+  const artifactCompatibility = parseArtifactCompatibilityEnvelope(value);
+  // TODO(#726-COMPAT-04): hard-fail malformed compatibility metadata once
+  // cache/skip consumers depend on this proof. During Wave01 the field is
+  // emitted as scaffolding, so bad or future-version values degrade like
+  // missing __layoutFlags instead of crashing render paths that do not read it.
+  return artifactCompatibility ?? createArtifactCompatibilityEnvelope();
 }
 
 export function readAppElementsMetadata(
@@ -238,14 +244,9 @@ export function readAppElementsMetadata(
   }
 
   const layoutFlags = parseLayoutFlags(elements[APP_LAYOUT_FLAGS_KEY]);
-  const artifactCompatibilityValue = elements[APP_ARTIFACT_COMPATIBILITY_KEY];
-  const artifactCompatibility =
-    artifactCompatibilityValue === undefined
-      ? createArtifactCompatibilityEnvelope()
-      : parseArtifactCompatibilityEnvelope(artifactCompatibilityValue);
-  if (!artifactCompatibility) {
-    throw new Error("[vinext] Invalid __artifactCompatibility in App Router payload");
-  }
+  const artifactCompatibility = readArtifactCompatibilityMetadata(
+    elements[APP_ARTIFACT_COMPATIBILITY_KEY],
+  );
 
   return {
     artifactCompatibility,

--- a/packages/vinext/src/server/app-elements.ts
+++ b/packages/vinext/src/server/app-elements.ts
@@ -1,8 +1,14 @@
 import { isValidElement, type ReactNode } from "react";
+import {
+  createArtifactCompatibilityEnvelope,
+  parseArtifactCompatibilityEnvelope,
+  type ArtifactCompatibilityEnvelope,
+} from "./artifact-compatibility.js";
 import { normalizeMountedSlotsHeader } from "./app-mounted-slots-header.js";
 
 const APP_INTERCEPTION_SEPARATOR = "\0";
 
+export const APP_ARTIFACT_COMPATIBILITY_KEY = "__artifactCompatibility";
 export const APP_INTERCEPTION_CONTEXT_KEY = "__interceptionContext";
 export const APP_LAYOUT_FLAGS_KEY = "__layoutFlags";
 export const APP_ROUTE_KEY = "__route";
@@ -37,6 +43,7 @@ export type AppWireElements = Readonly<Record<string, AppWireElementValue>>;
 export type LayoutFlags = Readonly<Record<string, "s" | "d">>;
 
 type AppElementsMetadata = {
+  artifactCompatibility: ArtifactCompatibilityEnvelope;
   interceptionContext: string | null;
   layoutFlags: LayoutFlags;
   routeId: string;
@@ -157,27 +164,40 @@ export function withLayoutFlags<T extends Record<string, unknown>>(
   return { ...elements, [APP_LAYOUT_FLAGS_KEY]: layoutFlags };
 }
 
+function withArtifactCompatibilityEnvelope<T extends Record<string, unknown>>(
+  elements: T,
+  artifactCompatibility: ArtifactCompatibilityEnvelope,
+): T & { [APP_ARTIFACT_COMPATIBILITY_KEY]: ArtifactCompatibilityEnvelope } {
+  return { ...elements, [APP_ARTIFACT_COMPATIBILITY_KEY]: artifactCompatibility };
+}
+
 /**
  * The outgoing wire payload shape. Includes ReactNode values for the
  * rendered tree plus metadata values like LayoutFlags attached under
  * known keys (e.g. __layoutFlags). Distinct from AppElements / AppWireElements
  * which only carry render-time values.
  */
-export type AppOutgoingElements = Readonly<Record<string, ReactNode | LayoutFlags>>;
+export type AppOutgoingElements = Readonly<
+  Record<string, ReactNode | LayoutFlags | ArtifactCompatibilityEnvelope>
+>;
 
 /**
  * Pure: builds the outgoing payload for the wire. Non-record inputs (e.g. a
  * bare React element) are returned unchanged. Record inputs get a fresh copy
- * with `__layoutFlags` attached. Never mutates `input.element`.
+ * with payload metadata attached. Never mutates `input.element`.
  */
 export function buildOutgoingAppPayload(input: {
   element: ReactNode | Readonly<Record<string, ReactNode>>;
   layoutFlags: LayoutFlags;
+  artifactCompatibility?: ArtifactCompatibilityEnvelope;
 }): ReactNode | AppOutgoingElements {
   if (!isAppElementsRecord(input.element)) {
     return input.element;
   }
-  return withLayoutFlags(input.element, input.layoutFlags);
+  return withArtifactCompatibilityEnvelope(
+    withLayoutFlags(input.element, input.layoutFlags),
+    input.artifactCompatibility ?? createArtifactCompatibilityEnvelope(),
+  );
 }
 
 /**
@@ -213,8 +233,17 @@ export function readAppElementsMetadata(
   }
 
   const layoutFlags = parseLayoutFlags(elements[APP_LAYOUT_FLAGS_KEY]);
+  const artifactCompatibilityValue = elements[APP_ARTIFACT_COMPATIBILITY_KEY];
+  const artifactCompatibility =
+    artifactCompatibilityValue === undefined
+      ? createArtifactCompatibilityEnvelope()
+      : parseArtifactCompatibilityEnvelope(artifactCompatibilityValue);
+  if (!artifactCompatibility) {
+    throw new Error("[vinext] Invalid __artifactCompatibility in App Router payload");
+  }
 
   return {
+    artifactCompatibility,
     interceptionContext: interceptionContext ?? null,
     layoutFlags,
     routeId,

--- a/packages/vinext/src/server/app-elements.ts
+++ b/packages/vinext/src/server/app-elements.ts
@@ -194,6 +194,8 @@ export function buildOutgoingAppPayload(input: {
   if (!isAppElementsRecord(input.element)) {
     return input.element;
   }
+  // Emit an unknown-proof envelope even before concrete graph/deployment facts
+  // exist so every App Router artifact has a stable compatibility slot.
   return withArtifactCompatibilityEnvelope(
     withLayoutFlags(input.element, input.layoutFlags),
     input.artifactCompatibility ?? createArtifactCompatibilityEnvelope(),

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -1,6 +1,11 @@
 import type { ReactNode } from "react";
 import type { CachedAppPageValue } from "vinext/shims/cache";
-import { buildOutgoingAppPayload, type AppOutgoingElements } from "./app-elements.js";
+import {
+  APP_ROOT_LAYOUT_KEY,
+  buildOutgoingAppPayload,
+  isAppElementsRecord,
+  type AppOutgoingElements,
+} from "./app-elements.js";
 import {
   finalizeAppPageHtmlCacheResponse,
   finalizeAppPageRscCacheResponse,
@@ -32,6 +37,11 @@ import {
   shouldRerenderAppPageWithGlobalError,
   type AppPageSsrHandler,
 } from "./app-page-stream.js";
+import {
+  createArtifactCompatibilityEnvelope,
+  createArtifactCompatibilityGraphVersion,
+  type ArtifactCompatibilityEnvelope,
+} from "./artifact-compatibility.js";
 
 type AppPageBoundaryOnError = (
   error: unknown,
@@ -159,6 +169,30 @@ function applyRequestCacheLife(options: {
   return { expireSeconds, revalidateSeconds };
 }
 
+function readRootBoundaryId(element: Readonly<Record<string, unknown>>): string | null {
+  const rootLayoutTreePath = element[APP_ROOT_LAYOUT_KEY];
+  return typeof rootLayoutTreePath === "string" ? rootLayoutTreePath : null;
+}
+
+function createAppPageArtifactCompatibility(
+  element: ReactNode | Readonly<Record<string, ReactNode>>,
+  routePattern: string,
+): ArtifactCompatibilityEnvelope | undefined {
+  if (!isAppElementsRecord(element)) {
+    return undefined;
+  }
+
+  const rootBoundaryId = readRootBoundaryId(element);
+  return createArtifactCompatibilityEnvelope({
+    graphVersion: createArtifactCompatibilityGraphVersion({
+      routePattern,
+      rootBoundaryId,
+    }),
+    deploymentVersion: process.env.__VINEXT_BUILD_ID ?? null,
+    rootBoundaryId,
+  });
+}
+
 /**
  * Wraps an RSC response body to report invalid dynamic usage errors after the
  * stream is fully consumed. In dev mode, errors from cookies()/headers() inside
@@ -254,9 +288,14 @@ export async function renderAppPageLifecycle(
   // Render the CANONICAL element. The outgoing payload carries per-layout
   // static/dynamic flags under `__layoutFlags` so the client can later tell
   // which layouts are safe to skip on subsequent navigations.
+  const artifactCompatibility = createAppPageArtifactCompatibility(
+    options.element,
+    options.routePattern,
+  );
   const outgoingElement = buildOutgoingAppPayload({
     element: options.element,
     layoutFlags,
+    ...(artifactCompatibility ? { artifactCompatibility } : {}),
   });
 
   const compileEnd = options.isProduction ? undefined : performance.now();

--- a/packages/vinext/src/server/artifact-compatibility.ts
+++ b/packages/vinext/src/server/artifact-compatibility.ts
@@ -1,3 +1,5 @@
+import { fnv1a64 } from "../utils/hash.js";
+
 export const ARTIFACT_COMPATIBILITY_SCHEMA_VERSION = 1;
 
 // These versions describe separate protocol layers. They start in lockstep,
@@ -23,6 +25,42 @@ type ArtifactCompatibilityEnvelopeInput = Readonly<{
   renderEpoch?: string | null;
 }>;
 
+type ArtifactCompatibilityFallback = "renderFresh";
+
+type ArtifactCompatibilityUnknownReason =
+  | "graphVersionUnknown"
+  | "deploymentVersionUnknown"
+  | "rootBoundaryIdUnknown"
+  | "renderEpochUnknown";
+
+type ArtifactCompatibilityIncompatibleReason =
+  | "appElementsSchemaVersionMismatch"
+  | "deploymentVersionMismatch"
+  | "graphVersionMismatch"
+  | "renderEpochMismatch"
+  | "rootBoundaryIdMismatch"
+  | "rscPayloadSchemaVersionMismatch"
+  | "schemaVersionMismatch";
+
+type ArtifactCompatibilityDecision = Readonly<
+  | { kind: "compatible" }
+  | {
+      kind: "unknown";
+      fallback: ArtifactCompatibilityFallback;
+      reason: ArtifactCompatibilityUnknownReason;
+    }
+  | {
+      kind: "incompatible";
+      fallback: ArtifactCompatibilityFallback;
+      reason: ArtifactCompatibilityIncompatibleReason;
+    }
+>;
+
+type ArtifactCompatibilityGraphVersionInput = Readonly<{
+  routePattern: string;
+  rootBoundaryId: string | null;
+}>;
+
 export function createArtifactCompatibilityEnvelope(
   input: ArtifactCompatibilityEnvelopeInput = {},
 ): ArtifactCompatibilityEnvelope {
@@ -35,6 +73,13 @@ export function createArtifactCompatibilityEnvelope(
     rootBoundaryId: input.rootBoundaryId ?? null,
     renderEpoch: input.renderEpoch ?? null,
   };
+}
+
+export function createArtifactCompatibilityGraphVersion(
+  input: ArtifactCompatibilityGraphVersionInput,
+): string {
+  const fingerprint = fnv1a64(JSON.stringify([input.routePattern, input.rootBoundaryId]));
+  return `app-route-graph:${fingerprint}`;
 }
 
 function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
@@ -75,4 +120,78 @@ export function parseArtifactCompatibilityEnvelope(
     rootBoundaryId: value.rootBoundaryId,
     renderEpoch: value.renderEpoch,
   };
+}
+
+function incompatible(
+  reason: ArtifactCompatibilityIncompatibleReason,
+): ArtifactCompatibilityDecision {
+  return { kind: "incompatible", fallback: "renderFresh", reason };
+}
+
+function unknown(reason: ArtifactCompatibilityUnknownReason): ArtifactCompatibilityDecision {
+  return { kind: "unknown", fallback: "renderFresh", reason };
+}
+
+function compareKnownField(
+  currentValue: string | null,
+  candidateValue: string | null,
+  unknownReason: ArtifactCompatibilityUnknownReason,
+  mismatchReason: ArtifactCompatibilityIncompatibleReason,
+): ArtifactCompatibilityDecision | null {
+  if (currentValue === null || candidateValue === null) {
+    return unknown(unknownReason);
+  }
+  if (currentValue !== candidateValue) {
+    return incompatible(mismatchReason);
+  }
+  return null;
+}
+
+export function evaluateArtifactCompatibility(
+  current: ArtifactCompatibilityEnvelope,
+  candidate: ArtifactCompatibilityEnvelope,
+): ArtifactCompatibilityDecision {
+  if (current.schemaVersion !== candidate.schemaVersion) {
+    return incompatible("schemaVersionMismatch");
+  }
+  if (current.appElementsSchemaVersion !== candidate.appElementsSchemaVersion) {
+    return incompatible("appElementsSchemaVersionMismatch");
+  }
+  if (current.rscPayloadSchemaVersion !== candidate.rscPayloadSchemaVersion) {
+    return incompatible("rscPayloadSchemaVersionMismatch");
+  }
+
+  const graphDecision = compareKnownField(
+    current.graphVersion,
+    candidate.graphVersion,
+    "graphVersionUnknown",
+    "graphVersionMismatch",
+  );
+  if (graphDecision) return graphDecision;
+
+  const deploymentDecision = compareKnownField(
+    current.deploymentVersion,
+    candidate.deploymentVersion,
+    "deploymentVersionUnknown",
+    "deploymentVersionMismatch",
+  );
+  if (deploymentDecision) return deploymentDecision;
+
+  const rootBoundaryDecision = compareKnownField(
+    current.rootBoundaryId,
+    candidate.rootBoundaryId,
+    "rootBoundaryIdUnknown",
+    "rootBoundaryIdMismatch",
+  );
+  if (rootBoundaryDecision) return rootBoundaryDecision;
+
+  const renderEpochDecision = compareKnownField(
+    current.renderEpoch,
+    candidate.renderEpoch,
+    "renderEpochUnknown",
+    "renderEpochMismatch",
+  );
+  if (renderEpochDecision) return renderEpochDecision;
+
+  return { kind: "compatible" };
 }

--- a/packages/vinext/src/server/artifact-compatibility.ts
+++ b/packages/vinext/src/server/artifact-compatibility.ts
@@ -1,4 +1,8 @@
 export const ARTIFACT_COMPATIBILITY_SCHEMA_VERSION = 1;
+
+// These versions describe separate protocol layers. They start in lockstep,
+// but future rolling deploy work can bump the envelope shape independently
+// from the flat AppElements record or the serialized RSC payload.
 export const APP_ELEMENTS_SCHEMA_VERSION = 1;
 export const RSC_PAYLOAD_SCHEMA_VERSION = 1;
 
@@ -53,6 +57,9 @@ export function parseArtifactCompatibilityEnvelope(
   value: unknown,
 ): ArtifactCompatibilityEnvelope | null {
   if (!isRecord(value)) return null;
+  // The Wave01 skeleton intentionally collapses version mismatch and malformed
+  // metadata into "not current". Cache/skip callers must split those cases
+  // before treating unknown compatibility as anything other than a miss/reject.
   if (!hasCurrentSchemaVersions(value)) return null;
   if (!isStringOrNull(value.graphVersion)) return null;
   if (!isStringOrNull(value.deploymentVersion)) return null;

--- a/packages/vinext/src/server/artifact-compatibility.ts
+++ b/packages/vinext/src/server/artifact-compatibility.ts
@@ -2,9 +2,9 @@ import { fnv1a64 } from "../utils/hash.js";
 
 export const ARTIFACT_COMPATIBILITY_SCHEMA_VERSION = 1;
 
-// These versions describe separate protocol layers. They start in lockstep,
-// but future rolling deploy work can bump the envelope shape independently
-// from the flat AppElements record or the serialized RSC payload.
+// These versions describe separate protocol layers. For example, a future
+// rolling deploy can bump the flat AppElements row shape while keeping the
+// envelope object and serialized RSC transport version stable.
 export const APP_ELEMENTS_SCHEMA_VERSION = 1;
 export const RSC_PAYLOAD_SCHEMA_VERSION = 1;
 
@@ -111,6 +111,9 @@ export function parseArtifactCompatibilityEnvelope(
   if (!isStringOrNull(value.rootBoundaryId)) return null;
   if (!isStringOrNull(value.renderEpoch)) return null;
 
+  // This parser intentionally returns a normalized current-version proof. A
+  // future-compatible reader should introduce a separate parsed type instead of
+  // widening this Wave01 envelope after the current-version checks above.
   return {
     schemaVersion: ARTIFACT_COMPATIBILITY_SCHEMA_VERSION,
     graphVersion: value.graphVersion,
@@ -151,6 +154,8 @@ export function evaluateArtifactCompatibility(
   current: ArtifactCompatibilityEnvelope,
   candidate: ArtifactCompatibilityEnvelope,
 ): ArtifactCompatibilityDecision {
+  // Pre-positioned for #726-COMPAT-04/05, where cache and visited-response
+  // reuse paths will compare the current render proof with a candidate payload.
   if (current.schemaVersion !== candidate.schemaVersion) {
     return incompatible("schemaVersionMismatch");
   }

--- a/packages/vinext/src/server/artifact-compatibility.ts
+++ b/packages/vinext/src/server/artifact-compatibility.ts
@@ -1,0 +1,71 @@
+export const ARTIFACT_COMPATIBILITY_SCHEMA_VERSION = 1;
+export const APP_ELEMENTS_SCHEMA_VERSION = 1;
+export const RSC_PAYLOAD_SCHEMA_VERSION = 1;
+
+export type ArtifactCompatibilityEnvelope = Readonly<{
+  schemaVersion: typeof ARTIFACT_COMPATIBILITY_SCHEMA_VERSION;
+  graphVersion: string | null;
+  deploymentVersion: string | null;
+  appElementsSchemaVersion: typeof APP_ELEMENTS_SCHEMA_VERSION;
+  rscPayloadSchemaVersion: typeof RSC_PAYLOAD_SCHEMA_VERSION;
+  rootBoundaryId: string | null;
+  renderEpoch: string | null;
+}>;
+
+type ArtifactCompatibilityEnvelopeInput = Readonly<{
+  graphVersion?: string | null;
+  deploymentVersion?: string | null;
+  rootBoundaryId?: string | null;
+  renderEpoch?: string | null;
+}>;
+
+export function createArtifactCompatibilityEnvelope(
+  input: ArtifactCompatibilityEnvelopeInput = {},
+): ArtifactCompatibilityEnvelope {
+  return {
+    schemaVersion: ARTIFACT_COMPATIBILITY_SCHEMA_VERSION,
+    graphVersion: input.graphVersion ?? null,
+    deploymentVersion: input.deploymentVersion ?? null,
+    appElementsSchemaVersion: APP_ELEMENTS_SCHEMA_VERSION,
+    rscPayloadSchemaVersion: RSC_PAYLOAD_SCHEMA_VERSION,
+    rootBoundaryId: input.rootBoundaryId ?? null,
+    renderEpoch: input.renderEpoch ?? null,
+  };
+}
+
+function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isStringOrNull(value: unknown): value is string | null {
+  return typeof value === "string" || value === null;
+}
+
+function hasCurrentSchemaVersions(record: Readonly<Record<string, unknown>>): boolean {
+  return (
+    record.schemaVersion === ARTIFACT_COMPATIBILITY_SCHEMA_VERSION &&
+    record.appElementsSchemaVersion === APP_ELEMENTS_SCHEMA_VERSION &&
+    record.rscPayloadSchemaVersion === RSC_PAYLOAD_SCHEMA_VERSION
+  );
+}
+
+export function parseArtifactCompatibilityEnvelope(
+  value: unknown,
+): ArtifactCompatibilityEnvelope | null {
+  if (!isRecord(value)) return null;
+  if (!hasCurrentSchemaVersions(value)) return null;
+  if (!isStringOrNull(value.graphVersion)) return null;
+  if (!isStringOrNull(value.deploymentVersion)) return null;
+  if (!isStringOrNull(value.rootBoundaryId)) return null;
+  if (!isStringOrNull(value.renderEpoch)) return null;
+
+  return {
+    schemaVersion: ARTIFACT_COMPATIBILITY_SCHEMA_VERSION,
+    graphVersion: value.graphVersion,
+    deploymentVersion: value.deploymentVersion,
+    appElementsSchemaVersion: APP_ELEMENTS_SCHEMA_VERSION,
+    rscPayloadSchemaVersion: RSC_PAYLOAD_SCHEMA_VERSION,
+    rootBoundaryId: value.rootBoundaryId,
+    renderEpoch: value.renderEpoch,
+  };
+}

--- a/tests/app-elements.test.ts
+++ b/tests/app-elements.test.ts
@@ -260,44 +260,56 @@ describe("app elements payload helpers", () => {
     });
   });
 
-  it("rejects malformed artifact compatibility metadata", () => {
-    expect(() =>
-      readAppElementsMetadata({
-        ...normalizeAppElements({
-          [APP_ROOT_LAYOUT_KEY]: "/",
-          [APP_ROUTE_KEY]: "route:/dashboard",
-        }),
-        [APP_ARTIFACT_COMPATIBILITY_KEY]: {
-          schemaVersion: ARTIFACT_COMPATIBILITY_SCHEMA_VERSION,
-          graphVersion: 123,
-          deploymentVersion: null,
-          appElementsSchemaVersion: APP_ELEMENTS_SCHEMA_VERSION,
-          rscPayloadSchemaVersion: RSC_PAYLOAD_SCHEMA_VERSION,
-          rootBoundaryId: null,
-          renderEpoch: null,
-        },
+  it("defaults malformed artifact compatibility metadata to unknown proof", () => {
+    const metadata = readAppElementsMetadata({
+      ...normalizeAppElements({
+        [APP_ROOT_LAYOUT_KEY]: "/",
+        [APP_ROUTE_KEY]: "route:/dashboard",
       }),
-    ).toThrow("[vinext] Invalid __artifactCompatibility in App Router payload");
+      [APP_ARTIFACT_COMPATIBILITY_KEY]: {
+        schemaVersion: ARTIFACT_COMPATIBILITY_SCHEMA_VERSION,
+        graphVersion: 123,
+        deploymentVersion: null,
+        appElementsSchemaVersion: APP_ELEMENTS_SCHEMA_VERSION,
+        rscPayloadSchemaVersion: RSC_PAYLOAD_SCHEMA_VERSION,
+        rootBoundaryId: null,
+        renderEpoch: null,
+      },
+    });
+
+    expect(metadata.artifactCompatibility).toEqual(createArtifactCompatibilityEnvelope());
   });
 
-  it("rejects artifact compatibility with an unrecognized schema version", () => {
-    expect(() =>
-      readAppElementsMetadata({
-        ...normalizeAppElements({
-          [APP_ROOT_LAYOUT_KEY]: "/",
-          [APP_ROUTE_KEY]: "route:/dashboard",
-        }),
-        [APP_ARTIFACT_COMPATIBILITY_KEY]: {
-          schemaVersion: 99,
-          graphVersion: null,
-          deploymentVersion: null,
-          appElementsSchemaVersion: APP_ELEMENTS_SCHEMA_VERSION,
-          rscPayloadSchemaVersion: RSC_PAYLOAD_SCHEMA_VERSION,
-          rootBoundaryId: null,
-          renderEpoch: null,
-        },
+  it("defaults artifact compatibility with an unrecognized schema version to unknown proof", () => {
+    const metadata = readAppElementsMetadata({
+      ...normalizeAppElements({
+        [APP_ROOT_LAYOUT_KEY]: "/",
+        [APP_ROUTE_KEY]: "route:/dashboard",
       }),
-    ).toThrow("[vinext] Invalid __artifactCompatibility in App Router payload");
+      [APP_ARTIFACT_COMPATIBILITY_KEY]: {
+        schemaVersion: 99,
+        graphVersion: null,
+        deploymentVersion: null,
+        appElementsSchemaVersion: APP_ELEMENTS_SCHEMA_VERSION,
+        rscPayloadSchemaVersion: RSC_PAYLOAD_SCHEMA_VERSION,
+        rootBoundaryId: null,
+        renderEpoch: null,
+      },
+    });
+
+    expect(metadata.artifactCompatibility).toEqual(createArtifactCompatibilityEnvelope());
+  });
+
+  it("defaults non-object artifact compatibility metadata to unknown proof", () => {
+    const metadata = readAppElementsMetadata({
+      ...normalizeAppElements({
+        [APP_ROOT_LAYOUT_KEY]: "/",
+        [APP_ROUTE_KEY]: "route:/dashboard",
+      }),
+      [APP_ARTIFACT_COMPATIBILITY_KEY]: "garbage",
+    });
+
+    expect(metadata.artifactCompatibility).toEqual(createArtifactCompatibilityEnvelope());
   });
 });
 

--- a/tests/app-elements.test.ts
+++ b/tests/app-elements.test.ts
@@ -2,6 +2,7 @@ import React from "react";
 import { describe, expect, it } from "vite-plus/test";
 import { UNMATCHED_SLOT } from "../packages/vinext/src/shims/slot.js";
 import {
+  APP_ARTIFACT_COMPATIBILITY_KEY,
   APP_INTERCEPTION_CONTEXT_KEY,
   APP_LAYOUT_FLAGS_KEY,
   APP_ROOT_LAYOUT_KEY,
@@ -16,6 +17,12 @@ import {
   resolveVisitedResponseInterceptionContext,
   withLayoutFlags,
 } from "../packages/vinext/src/server/app-elements.js";
+import {
+  APP_ELEMENTS_SCHEMA_VERSION,
+  ARTIFACT_COMPATIBILITY_SCHEMA_VERSION,
+  createArtifactCompatibilityEnvelope,
+  RSC_PAYLOAD_SCHEMA_VERSION,
+} from "../packages/vinext/src/server/artifact-compatibility.js";
 
 describe("app elements payload helpers", () => {
   it("normalizes the unmatched-slot wire marker to UNMATCHED_SLOT for slot entries", () => {
@@ -151,6 +158,64 @@ describe("app elements payload helpers", () => {
 
     expect(metadata.layoutFlags).toEqual({});
   });
+
+  it("reads artifact compatibility envelope metadata", () => {
+    const envelope = createArtifactCompatibilityEnvelope({
+      graphVersion: "graph-a",
+      deploymentVersion: "deploy-a",
+      rootBoundaryId: "root-a",
+    });
+    const metadata = readAppElementsMetadata({
+      ...normalizeAppElements({
+        [APP_ROOT_LAYOUT_KEY]: "/",
+        [APP_ROUTE_KEY]: "route:/dashboard",
+        "route:/dashboard": React.createElement("div", null, "route"),
+      }),
+      [APP_ARTIFACT_COMPATIBILITY_KEY]: envelope,
+    });
+
+    expect(metadata.artifactCompatibility).toEqual(envelope);
+  });
+
+  it("defaults missing artifact compatibility to unknown proof for legacy payloads", () => {
+    const metadata = readAppElementsMetadata(
+      normalizeAppElements({
+        [APP_ROOT_LAYOUT_KEY]: "/",
+        [APP_ROUTE_KEY]: "route:/dashboard",
+        "route:/dashboard": React.createElement("div", null, "route"),
+      }),
+    );
+
+    expect(metadata.artifactCompatibility).toEqual({
+      schemaVersion: ARTIFACT_COMPATIBILITY_SCHEMA_VERSION,
+      graphVersion: null,
+      deploymentVersion: null,
+      appElementsSchemaVersion: APP_ELEMENTS_SCHEMA_VERSION,
+      rscPayloadSchemaVersion: RSC_PAYLOAD_SCHEMA_VERSION,
+      rootBoundaryId: null,
+      renderEpoch: null,
+    });
+  });
+
+  it("rejects malformed artifact compatibility metadata", () => {
+    expect(() =>
+      readAppElementsMetadata({
+        ...normalizeAppElements({
+          [APP_ROOT_LAYOUT_KEY]: "/",
+          [APP_ROUTE_KEY]: "route:/dashboard",
+        }),
+        [APP_ARTIFACT_COMPATIBILITY_KEY]: {
+          schemaVersion: ARTIFACT_COMPATIBILITY_SCHEMA_VERSION,
+          graphVersion: 123,
+          deploymentVersion: null,
+          appElementsSchemaVersion: APP_ELEMENTS_SCHEMA_VERSION,
+          rscPayloadSchemaVersion: RSC_PAYLOAD_SCHEMA_VERSION,
+          rootBoundaryId: null,
+          renderEpoch: null,
+        },
+      }),
+    ).toThrow("[vinext] Invalid __artifactCompatibility in App Router payload");
+  });
 });
 
 describe("isAppElementsRecord", () => {
@@ -244,6 +309,7 @@ describe("buildOutgoingAppPayload", () => {
     expect(element).toEqual(snapshot);
     expect(Object.keys(element)).toEqual(Object.keys(snapshot));
     expect(APP_LAYOUT_FLAGS_KEY in element).toBe(false);
+    expect(APP_ARTIFACT_COMPATIBILITY_KEY in element).toBe(false);
   });
 
   it("attaches __layoutFlags on the returned record", () => {
@@ -254,6 +320,30 @@ describe("buildOutgoingAppPayload", () => {
     expect(isAppElementsRecord(result)).toBe(true);
     if (isAppElementsRecord(result)) {
       expect(result[APP_LAYOUT_FLAGS_KEY]).toEqual({ "layout:/": "s" });
+    }
+  });
+
+  it("attaches __artifactCompatibility on the returned record", () => {
+    const result = buildOutgoingAppPayload({
+      element: { "page:/": "page" },
+      layoutFlags: { "layout:/": "s" },
+      artifactCompatibility: createArtifactCompatibilityEnvelope({
+        graphVersion: "graph-a",
+        deploymentVersion: "deploy-a",
+        rootBoundaryId: "root-a",
+      }),
+    });
+    expect(isAppElementsRecord(result)).toBe(true);
+    if (isAppElementsRecord(result)) {
+      expect(result[APP_ARTIFACT_COMPATIBILITY_KEY]).toEqual({
+        schemaVersion: ARTIFACT_COMPATIBILITY_SCHEMA_VERSION,
+        graphVersion: "graph-a",
+        deploymentVersion: "deploy-a",
+        appElementsSchemaVersion: APP_ELEMENTS_SCHEMA_VERSION,
+        rscPayloadSchemaVersion: RSC_PAYLOAD_SCHEMA_VERSION,
+        rootBoundaryId: "root-a",
+        renderEpoch: null,
+      });
     }
   });
 

--- a/tests/app-elements.test.ts
+++ b/tests/app-elements.test.ts
@@ -216,6 +216,26 @@ describe("app elements payload helpers", () => {
       }),
     ).toThrow("[vinext] Invalid __artifactCompatibility in App Router payload");
   });
+
+  it("rejects artifact compatibility with an unrecognized schema version", () => {
+    expect(() =>
+      readAppElementsMetadata({
+        ...normalizeAppElements({
+          [APP_ROOT_LAYOUT_KEY]: "/",
+          [APP_ROUTE_KEY]: "route:/dashboard",
+        }),
+        [APP_ARTIFACT_COMPATIBILITY_KEY]: {
+          schemaVersion: 99,
+          graphVersion: null,
+          deploymentVersion: null,
+          appElementsSchemaVersion: APP_ELEMENTS_SCHEMA_VERSION,
+          rscPayloadSchemaVersion: RSC_PAYLOAD_SCHEMA_VERSION,
+          rootBoundaryId: null,
+          renderEpoch: null,
+        },
+      }),
+    ).toThrow("[vinext] Invalid __artifactCompatibility in App Router payload");
+  });
 });
 
 describe("isAppElementsRecord", () => {

--- a/tests/app-elements.test.ts
+++ b/tests/app-elements.test.ts
@@ -21,6 +21,7 @@ import {
   APP_ELEMENTS_SCHEMA_VERSION,
   ARTIFACT_COMPATIBILITY_SCHEMA_VERSION,
   createArtifactCompatibilityEnvelope,
+  evaluateArtifactCompatibility,
   RSC_PAYLOAD_SCHEMA_VERSION,
 } from "../packages/vinext/src/server/artifact-compatibility.js";
 
@@ -398,5 +399,120 @@ describe("buildOutgoingAppPayload", () => {
       expect(result["page:/blog"]).toBe("blog-page");
       expect(result["layout:/"]).toBe("root-layout");
     }
+  });
+});
+
+describe("artifact compatibility proof evaluation", () => {
+  it("returns compatible only when every current proof field is known and equal", () => {
+    const current = createArtifactCompatibilityEnvelope({
+      graphVersion: "graph-a",
+      deploymentVersion: "deploy-a",
+      rootBoundaryId: "root-a",
+      renderEpoch: "epoch-a",
+    });
+
+    expect(evaluateArtifactCompatibility(current, current)).toEqual({
+      kind: "compatible",
+    });
+  });
+
+  it("falls back to renderFresh when graph compatibility is unknown", () => {
+    const current = createArtifactCompatibilityEnvelope({
+      graphVersion: "graph-a",
+      deploymentVersion: "deploy-a",
+      rootBoundaryId: "root-a",
+      renderEpoch: "epoch-a",
+    });
+    const candidate = createArtifactCompatibilityEnvelope({
+      deploymentVersion: "deploy-a",
+      rootBoundaryId: "root-a",
+      renderEpoch: "epoch-a",
+    });
+
+    expect(evaluateArtifactCompatibility(current, candidate)).toEqual({
+      kind: "unknown",
+      fallback: "renderFresh",
+      reason: "graphVersionUnknown",
+    });
+  });
+
+  it("falls back to renderFresh when deployment compatibility is unknown", () => {
+    const current = createArtifactCompatibilityEnvelope({
+      graphVersion: "graph-a",
+      deploymentVersion: "deploy-a",
+      rootBoundaryId: "root-a",
+      renderEpoch: "epoch-a",
+    });
+    const candidate = createArtifactCompatibilityEnvelope({
+      graphVersion: "graph-a",
+      rootBoundaryId: "root-a",
+      renderEpoch: "epoch-a",
+    });
+
+    expect(evaluateArtifactCompatibility(current, candidate)).toEqual({
+      kind: "unknown",
+      fallback: "renderFresh",
+      reason: "deploymentVersionUnknown",
+    });
+  });
+
+  it("falls back to renderFresh when root boundary compatibility is unknown", () => {
+    const current = createArtifactCompatibilityEnvelope({
+      graphVersion: "graph-a",
+      deploymentVersion: "deploy-a",
+      rootBoundaryId: "root-a",
+      renderEpoch: "epoch-a",
+    });
+    const candidate = createArtifactCompatibilityEnvelope({
+      graphVersion: "graph-a",
+      deploymentVersion: "deploy-a",
+      renderEpoch: "epoch-a",
+    });
+
+    expect(evaluateArtifactCompatibility(current, candidate)).toEqual({
+      kind: "unknown",
+      fallback: "renderFresh",
+      reason: "rootBoundaryIdUnknown",
+    });
+  });
+
+  it("does not promote matching graph and deployment metadata to reuse proof when renderEpoch is unknown", () => {
+    const current = createArtifactCompatibilityEnvelope({
+      graphVersion: "graph-a",
+      deploymentVersion: "deploy-a",
+      rootBoundaryId: "root-a",
+    });
+    const candidate = createArtifactCompatibilityEnvelope({
+      graphVersion: "graph-a",
+      deploymentVersion: "deploy-a",
+      rootBoundaryId: "root-a",
+    });
+
+    expect(evaluateArtifactCompatibility(current, candidate)).toEqual({
+      kind: "unknown",
+      fallback: "renderFresh",
+      reason: "renderEpochUnknown",
+    });
+  });
+
+  it("rejects a known deployment mismatch instead of using the unknown fallback", () => {
+    const current = createArtifactCompatibilityEnvelope({
+      graphVersion: "graph-a",
+      deploymentVersion: "deploy-a",
+      rootBoundaryId: "root-a",
+      renderEpoch: "epoch-a",
+    });
+    const candidate = createArtifactCompatibilityEnvelope({
+      graphVersion: "graph-a",
+      deploymentVersion: "deploy-b",
+      rootBoundaryId: "root-a",
+      renderEpoch: "epoch-a",
+    });
+
+    expect(evaluateArtifactCompatibility(current, candidate)).toEqual({
+      kind: "incompatible",
+      fallback: "renderFresh",
+      reason: "deploymentVersionMismatch",
+    });
   });
 });

--- a/tests/app-page-render.test.ts
+++ b/tests/app-page-render.test.ts
@@ -2,10 +2,18 @@ import type { ReactNode } from "react";
 import { describe, expect, it, vi } from "vite-plus/test";
 import React from "react";
 import {
+  APP_ARTIFACT_COMPATIBILITY_KEY,
   APP_LAYOUT_FLAGS_KEY,
+  APP_ROOT_LAYOUT_KEY,
   isAppElementsRecord,
   type AppOutgoingElements,
 } from "../packages/vinext/src/server/app-elements.js";
+import {
+  APP_ELEMENTS_SCHEMA_VERSION,
+  ARTIFACT_COMPATIBILITY_SCHEMA_VERSION,
+  createArtifactCompatibilityGraphVersion,
+  RSC_PAYLOAD_SCHEMA_VERSION,
+} from "../packages/vinext/src/server/artifact-compatibility.js";
 import type { LayoutClassificationOptions } from "../packages/vinext/src/server/app-page-execution.js";
 import { renderAppPageLifecycle } from "../packages/vinext/src/server/app-page-render.js";
 
@@ -766,6 +774,41 @@ describe("layoutFlags injection into RSC payload", () => {
 
     await renderAppPageLifecycle(options);
     expect(getCapturedElement()[APP_LAYOUT_FLAGS_KEY]).toEqual({});
+  });
+
+  it("injects concrete artifact compatibility metadata from the render boundary", async () => {
+    const originalBuildId = process.env.__VINEXT_BUILD_ID;
+    process.env.__VINEXT_BUILD_ID = "deploy-test";
+    const { options, getCapturedElement } = createRscOptions({
+      element: {
+        [APP_ROOT_LAYOUT_KEY]: "/(shop)",
+        "layout:/(shop)": "shop-layout",
+        "page:/shop": "shop-page",
+      },
+    });
+
+    try {
+      await renderAppPageLifecycle(options);
+    } finally {
+      if (originalBuildId === undefined) {
+        delete process.env.__VINEXT_BUILD_ID;
+      } else {
+        process.env.__VINEXT_BUILD_ID = originalBuildId;
+      }
+    }
+
+    expect(getCapturedElement()[APP_ARTIFACT_COMPATIBILITY_KEY]).toEqual({
+      schemaVersion: ARTIFACT_COMPATIBILITY_SCHEMA_VERSION,
+      graphVersion: createArtifactCompatibilityGraphVersion({
+        routePattern: "/test",
+        rootBoundaryId: "/(shop)",
+      }),
+      deploymentVersion: "deploy-test",
+      appElementsSchemaVersion: APP_ELEMENTS_SCHEMA_VERSION,
+      rscPayloadSchemaVersion: RSC_PAYLOAD_SCHEMA_VERSION,
+      rootBoundaryId: "/(shop)",
+      renderEpoch: null,
+    });
   });
 
   it("injects __layoutFlags for multiple independently classified layouts", async () => {


### PR DESCRIPTION
## What this changes
Implements `#726-COMPAT-01` plus `#726-COMPAT-02/03` from #726.

This PR adds the App Router artifact compatibility envelope, attaches concrete render-boundary metadata to outgoing record payloads, and defines a conservative compatibility evaluator for future cache/skip callers.

## Why
Issue #726 requires every reusable or skippable artifact to carry compatibility proof before cache reuse or skip transport can depend on it. The rule for this slice is deliberately strict: no proof, no reuse. Unknown compatibility is represented as a render-fresh fallback, never as positive compatibility proof.

## Approach
- Add `packages/vinext/src/server/artifact-compatibility.ts` with schema constants, `ArtifactCompatibilityEnvelope`, constructor/parser helpers, a route/root graph fingerprint helper, and `evaluateArtifactCompatibility()`.
- Keep legacy/malformed wire parsing fail-closed: missing legacy metadata defaults to an unknown-proof envelope; malformed or future-schema metadata is rejected.
- Attach compatibility metadata in `renderAppPageLifecycle` when the outgoing App Router payload is a record:
  - graph metadata from route pattern plus root boundary fingerprint
  - deployment metadata from `process.env.__VINEXT_BUILD_ID`
  - schema metadata from the envelope constants
  - `rootBoundaryId` from `__rootLayout` when available
  - `renderEpoch: null` until a real epoch owner exists
- Preserve current semantics: no cache reuse, no skip transport, and no rolling-deploy protocol completeness in this PR.

## Correctness oracle
Vinext internal invariant from #726: no reusable or skippable artifact should gain implicit compatibility proof from cache presence, artifact presence, or wire shape. Unknown graph/deployment/root/epoch compatibility must return a render-fresh fallback, and only fully known matching metadata can produce `compatible`.

A focused Next.js source/test search for `artifact compatibility`, `compatibility envelope`, `renderEpoch`, `deploymentVersion`, and `graphVersion` found no public Next.js behavior to port for this internal Vinext protocol. This PR does not claim public Next.js behavior parity for rolling deploys.

## Validation
- `vp test run tests/app-elements.test.ts tests/app-page-render.test.ts`
- `vp check packages/vinext/src/server/artifact-compatibility.ts packages/vinext/src/server/app-elements.ts packages/vinext/src/server/app-page-render.ts tests/app-elements.test.ts tests/app-page-render.test.ts`
- `vp run vinext#build`

## Risks / follow-ups
- The `graphVersion` helper is a narrow route/root fingerprint until the RouteManifest graphVersion from GRAPH-02/03 exists.
- `renderEpoch` is carried but remains `null`, so current artifacts cannot become positive reuse proof solely from matching graph/deployment/root metadata.
- `#726-COMPAT-04/05` should add old-client/new-server coverage and hard-navigation loop prevention before any broader deployment fallback behavior depends on this envelope.

Refs #726
