### PR TITLE
feat(app-router): add navigation trace reason-code shell

### DIFF
--- a/packages/vinext/src/server/app-browser-navigation-controller.ts
+++ b/packages/vinext/src/server/app-browser-navigation-controller.ts
@@ -510,7 +510,15 @@ export function createAppBrowserNavigationController(
     // can still dispatch its older payload afterward. The old pre-2c code had
     // the same race, and Next.js has similar behavior. Tightening this would
     // need a stronger commit-version gate than activeNavigationId alone.
-    const { disposition, pending } = await resolveAndClassifyNavigationCommit({
+    const {
+      disposition,
+      pending,
+      // Intentionally retained as #726-OPS-01 trace-shell scaffolding. The
+      // current same-URL action path still commits through legacy control flow;
+      // later lifecycle gates can consume this trace without changing the
+      // classifier contract again.
+      trace: _navigationTrace,
+    } = await resolveAndClassifyNavigationCommit({
       activeNavigationId,
       currentState,
       navigationSnapshot,

--- a/packages/vinext/src/server/app-browser-state.ts
+++ b/packages/vinext/src/server/app-browser-state.ts
@@ -7,6 +7,12 @@ import {
   type LayoutFlags,
 } from "./app-elements.js";
 import { createRscRequestHeaders } from "./app-rsc-cache-busting.js";
+import {
+  NavigationTraceReasonCodes,
+  createNavigationTrace,
+  type NavigationTrace,
+  type NavigationTraceReasonCode,
+} from "./navigation-trace.js";
 import type { ClientNavigationRenderSnapshot } from "vinext/shims/navigation";
 
 const VINEXT_PREVIOUS_NEXT_URL_HISTORY_STATE_KEY = "__vinext_previousNextUrl";
@@ -47,9 +53,14 @@ type PendingNavigationCommit = {
 };
 
 type PendingNavigationCommitDisposition = "dispatch" | "hard-navigate" | "skip";
+type PendingNavigationCommitDispositionDecision = {
+  disposition: PendingNavigationCommitDisposition;
+  trace: NavigationTrace;
+};
 type ClassifiedPendingNavigationCommit = {
   disposition: PendingNavigationCommitDisposition;
   pending: PendingNavigationCommit;
+  trace: NavigationTrace;
 };
 
 function cloneHistoryState(state: unknown): HistoryStateRecord {
@@ -203,6 +214,54 @@ export function resolvePendingNavigationCommitDisposition(options: {
   return "dispatch";
 }
 
+export function resolvePendingNavigationCommitDispositionDecision(options: {
+  activeNavigationId: number;
+  currentRootLayoutTreePath: string | null;
+  nextRootLayoutTreePath: string | null;
+  startedNavigationId: number;
+}): PendingNavigationCommitDispositionDecision {
+  const disposition = resolvePendingNavigationCommitDisposition(options);
+  const traceFields = {
+    activeNavigationId: options.activeNavigationId,
+    currentRootLayoutTreePath: options.currentRootLayoutTreePath,
+    nextRootLayoutTreePath: options.nextRootLayoutTreePath,
+    startedNavigationId: options.startedNavigationId,
+  };
+
+  return {
+    disposition,
+    trace: createNavigationTrace(
+      getPendingNavigationCommitDispositionTraceCode({
+        currentRootLayoutTreePath: options.currentRootLayoutTreePath,
+        disposition,
+        nextRootLayoutTreePath: options.nextRootLayoutTreePath,
+      }),
+      traceFields,
+    ),
+  };
+}
+
+function getPendingNavigationCommitDispositionTraceCode(options: {
+  currentRootLayoutTreePath: string | null;
+  disposition: PendingNavigationCommitDisposition;
+  nextRootLayoutTreePath: string | null;
+}): NavigationTraceReasonCode {
+  switch (options.disposition) {
+    case "skip":
+      return NavigationTraceReasonCodes.staleOperation;
+    case "hard-navigate":
+      return NavigationTraceReasonCodes.rootBoundaryChanged;
+    case "dispatch":
+      return options.currentRootLayoutTreePath === null || options.nextRootLayoutTreePath === null
+        ? NavigationTraceReasonCodes.rootBoundaryUnknown
+        : NavigationTraceReasonCodes.commitCurrent;
+    default: {
+      const _exhaustive: never = options.disposition;
+      throw new Error("[vinext] Unknown navigation commit disposition: " + String(_exhaustive));
+    }
+  }
+}
+
 export async function createPendingNavigationCommit(options: {
   currentState: AppRouterState;
   nextElements: Promise<AppElements>;
@@ -257,13 +316,16 @@ export async function resolveAndClassifyNavigationCommit(options: {
     type: options.type,
   });
 
+  const decision = resolvePendingNavigationCommitDispositionDecision({
+    activeNavigationId: options.activeNavigationId,
+    currentRootLayoutTreePath: options.currentState.rootLayoutTreePath,
+    nextRootLayoutTreePath: pending.rootLayoutTreePath,
+    startedNavigationId: options.startedNavigationId,
+  });
+
   return {
-    disposition: resolvePendingNavigationCommitDisposition({
-      activeNavigationId: options.activeNavigationId,
-      currentRootLayoutTreePath: options.currentState.rootLayoutTreePath,
-      nextRootLayoutTreePath: pending.rootLayoutTreePath,
-      startedNavigationId: options.startedNavigationId,
-    }),
+    disposition: decision.disposition,
     pending,
+    trace: decision.trace,
   };
 }

--- a/packages/vinext/src/server/navigation-trace.ts
+++ b/packages/vinext/src/server/navigation-trace.ts
@@ -1,0 +1,72 @@
+export const NAVIGATION_TRACE_SCHEMA_VERSION = 0;
+
+export type NavigationTraceSchemaVersion = 0;
+
+export type NavigationTraceReasonCode = "NC_COMMIT" | "NC_ROOT" | "NC_ROOT_UNKNOWN" | "NC_STALE";
+
+type NavigationTraceReasonCodeMap = {
+  commitCurrent: NavigationTraceReasonCode;
+  rootBoundaryChanged: NavigationTraceReasonCode;
+  rootBoundaryUnknown: NavigationTraceReasonCode;
+  staleOperation: NavigationTraceReasonCode;
+};
+
+export const NavigationTraceReasonCodes = {
+  commitCurrent: "NC_COMMIT",
+  rootBoundaryChanged: "NC_ROOT",
+  rootBoundaryUnknown: "NC_ROOT_UNKNOWN",
+  staleOperation: "NC_STALE",
+} satisfies NavigationTraceReasonCodeMap;
+
+export type NavigationTraceFieldName =
+  | "activeNavigationId"
+  | "currentRootLayoutTreePath"
+  | "nextRootLayoutTreePath"
+  | "startedNavigationId";
+
+export type NavigationTraceFieldValue = string | number | boolean | null;
+
+export type NavigationTraceFields = Readonly<
+  Partial<Record<NavigationTraceFieldName, NavigationTraceFieldValue>>
+>;
+
+export type NavigationTraceEntry = Readonly<{
+  code: NavigationTraceReasonCode;
+  fields: NavigationTraceFields;
+}>;
+
+export type NavigationTrace = Readonly<{
+  schemaVersion: NavigationTraceSchemaVersion;
+  entries: readonly NavigationTraceEntry[];
+}>;
+
+function createNavigationTraceEntry(
+  code: NavigationTraceReasonCode,
+  fields: NavigationTraceFields = {},
+): NavigationTraceEntry {
+  return {
+    code,
+    fields: { ...fields },
+  };
+}
+
+export function createNavigationTrace(
+  code: NavigationTraceReasonCode,
+  fields: NavigationTraceFields = {},
+): NavigationTrace {
+  return {
+    schemaVersion: NAVIGATION_TRACE_SCHEMA_VERSION,
+    entries: [createNavigationTraceEntry(code, fields)],
+  };
+}
+
+export function appendNavigationTrace(
+  trace: NavigationTrace,
+  code: NavigationTraceReasonCode,
+  fields: NavigationTraceFields = {},
+): NavigationTrace {
+  return {
+    schemaVersion: NAVIGATION_TRACE_SCHEMA_VERSION,
+    entries: [...trace.entries, createNavigationTraceEntry(code, fields)],
+  };
+}

--- a/packages/vinext/src/server/navigation-trace.ts
+++ b/packages/vinext/src/server/navigation-trace.ts
@@ -2,21 +2,20 @@ export const NAVIGATION_TRACE_SCHEMA_VERSION = 0;
 
 export type NavigationTraceSchemaVersion = 0;
 
-export type NavigationTraceReasonCode = "NC_COMMIT" | "NC_ROOT" | "NC_ROOT_UNKNOWN" | "NC_STALE";
-
-type NavigationTraceReasonCodeMap = {
-  commitCurrent: NavigationTraceReasonCode;
-  rootBoundaryChanged: NavigationTraceReasonCode;
-  rootBoundaryUnknown: NavigationTraceReasonCode;
-  staleOperation: NavigationTraceReasonCode;
-};
-
 export const NavigationTraceReasonCodes = {
   commitCurrent: "NC_COMMIT",
   rootBoundaryChanged: "NC_ROOT",
   rootBoundaryUnknown: "NC_ROOT_UNKNOWN",
   staleOperation: "NC_STALE",
-} satisfies NavigationTraceReasonCodeMap;
+} satisfies Readonly<{
+  commitCurrent: "NC_COMMIT";
+  rootBoundaryChanged: "NC_ROOT";
+  rootBoundaryUnknown: "NC_ROOT_UNKNOWN";
+  staleOperation: "NC_STALE";
+}>;
+
+export type NavigationTraceReasonCode =
+  (typeof NavigationTraceReasonCodes)[keyof typeof NavigationTraceReasonCodes];
 
 export type NavigationTraceFieldName =
   | "activeNavigationId"
@@ -57,16 +56,5 @@ export function createNavigationTrace(
   return {
     schemaVersion: NAVIGATION_TRACE_SCHEMA_VERSION,
     entries: [createNavigationTraceEntry(code, fields)],
-  };
-}
-
-export function appendNavigationTrace(
-  trace: NavigationTrace,
-  code: NavigationTraceReasonCode,
-  fields: NavigationTraceFields = {},
-): NavigationTrace {
-  return {
-    schemaVersion: NAVIGATION_TRACE_SCHEMA_VERSION,
-    entries: [...trace.entries, createNavigationTraceEntry(code, fields)],
   };
 }

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -31,7 +31,6 @@ import {
 import {
   NAVIGATION_TRACE_SCHEMA_VERSION,
   NavigationTraceReasonCodes,
-  appendNavigationTrace,
   createNavigationTrace,
 } from "../packages/vinext/src/server/navigation-trace.js";
 
@@ -353,6 +352,28 @@ describe("app browser entry state helpers", () => {
 
     expect(decision.disposition).toBe("dispatch");
     expect(decision.trace.entries[0]?.code).toBe(NavigationTraceReasonCodes.rootBoundaryUnknown);
+  });
+
+  it("traces matching root-layout dispatches as current commits", () => {
+    const decision = resolvePendingNavigationCommitDispositionDecision({
+      activeNavigationId: 2,
+      currentRootLayoutTreePath: "/",
+      nextRootLayoutTreePath: "/",
+      startedNavigationId: 2,
+    });
+
+    expect(decision.disposition).toBe("dispatch");
+    expect(decision.trace.entries).toEqual([
+      {
+        code: NavigationTraceReasonCodes.commitCurrent,
+        fields: {
+          activeNavigationId: 2,
+          currentRootLayoutTreePath: "/",
+          nextRootLayoutTreePath: "/",
+          startedNavigationId: 2,
+        },
+      },
+    ]);
   });
 
   it("builds a merge commit for refresh and server-action payloads", async () => {
@@ -783,29 +804,17 @@ describe("app browser entry previousNextUrl helpers", () => {
     expect(result.trace.entries[0]?.code).toBe(NavigationTraceReasonCodes.rootBoundaryChanged);
   });
 
-  it("appends navigation trace entries without mutating existing records", () => {
+  it("creates navigation trace entries without retaining field ownership", () => {
     const fields = { activeNavigationId: 1 };
-    const initialTrace = createNavigationTrace(NavigationTraceReasonCodes.commitCurrent, fields);
+    const trace = createNavigationTrace(NavigationTraceReasonCodes.commitCurrent, fields);
 
     fields.activeNavigationId = 2;
 
-    const nextTrace = appendNavigationTrace(
-      initialTrace,
-      NavigationTraceReasonCodes.staleOperation,
-      {
-        activeNavigationId: 3,
-      },
-    );
-
-    expect(initialTrace.entries).toEqual([
+    expect(trace.entries).toEqual([
       {
         code: NavigationTraceReasonCodes.commitCurrent,
         fields: { activeNavigationId: 1 },
       },
-    ]);
-    expect(nextTrace.entries.map((entry) => entry.code)).toEqual([
-      NavigationTraceReasonCodes.commitCurrent,
-      NavigationTraceReasonCodes.staleOperation,
     ]);
   });
 

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -24,9 +24,16 @@ import {
   resolveServerActionRequestState,
   routerReducer,
   resolvePendingNavigationCommitDisposition,
+  resolvePendingNavigationCommitDispositionDecision,
   shouldHardNavigate,
   type AppRouterState,
 } from "../packages/vinext/src/server/app-browser-state.js";
+import {
+  NAVIGATION_TRACE_SCHEMA_VERSION,
+  NavigationTraceReasonCodes,
+  appendNavigationTrace,
+  createNavigationTrace,
+} from "../packages/vinext/src/server/navigation-trace.js";
 
 function createResolvedElements(
   routeId: string,
@@ -287,6 +294,65 @@ describe("app browser entry state helpers", () => {
         startedNavigationId: 4,
       }),
     ).toBe("skip");
+  });
+
+  it("traces stale pending commits with compact reason codes and structured fields", () => {
+    const decision = resolvePendingNavigationCommitDispositionDecision({
+      activeNavigationId: 5,
+      currentRootLayoutTreePath: "/",
+      nextRootLayoutTreePath: "/(dashboard)",
+      startedNavigationId: 4,
+    });
+
+    expect(decision.disposition).toBe("skip");
+    expect(decision.trace).toEqual({
+      schemaVersion: NAVIGATION_TRACE_SCHEMA_VERSION,
+      entries: [
+        {
+          code: NavigationTraceReasonCodes.staleOperation,
+          fields: {
+            activeNavigationId: 5,
+            currentRootLayoutTreePath: "/",
+            nextRootLayoutTreePath: "/(dashboard)",
+            startedNavigationId: 4,
+          },
+        },
+      ],
+    });
+  });
+
+  it("traces root-boundary hard navigation decisions", () => {
+    const decision = resolvePendingNavigationCommitDispositionDecision({
+      activeNavigationId: 2,
+      currentRootLayoutTreePath: "/(marketing)",
+      nextRootLayoutTreePath: "/(dashboard)",
+      startedNavigationId: 2,
+    });
+
+    expect(decision.disposition).toBe("hard-navigate");
+    expect(decision.trace.entries).toEqual([
+      {
+        code: NavigationTraceReasonCodes.rootBoundaryChanged,
+        fields: {
+          activeNavigationId: 2,
+          currentRootLayoutTreePath: "/(marketing)",
+          nextRootLayoutTreePath: "/(dashboard)",
+          startedNavigationId: 2,
+        },
+      },
+    ]);
+  });
+
+  it("traces unknown root-layout identity as a legacy soft-commit fallback", () => {
+    const decision = resolvePendingNavigationCommitDispositionDecision({
+      activeNavigationId: 2,
+      currentRootLayoutTreePath: "/",
+      nextRootLayoutTreePath: null,
+      startedNavigationId: 2,
+    });
+
+    expect(decision.disposition).toBe("dispatch");
+    expect(decision.trace.entries[0]?.code).toBe(NavigationTraceReasonCodes.rootBoundaryUnknown);
   });
 
   it("builds a merge commit for refresh and server-action payloads", async () => {
@@ -714,6 +780,33 @@ describe("app browser entry previousNextUrl helpers", () => {
     expect(result.disposition).toBe("hard-navigate");
     expect(result.pending.routeId).toBe("route:/dashboard");
     expect(result.pending.action.renderId).toBe(3);
+    expect(result.trace.entries[0]?.code).toBe(NavigationTraceReasonCodes.rootBoundaryChanged);
+  });
+
+  it("appends navigation trace entries without mutating existing records", () => {
+    const fields = { activeNavigationId: 1 };
+    const initialTrace = createNavigationTrace(NavigationTraceReasonCodes.commitCurrent, fields);
+
+    fields.activeNavigationId = 2;
+
+    const nextTrace = appendNavigationTrace(
+      initialTrace,
+      NavigationTraceReasonCodes.staleOperation,
+      {
+        activeNavigationId: 3,
+      },
+    );
+
+    expect(initialTrace.entries).toEqual([
+      {
+        code: NavigationTraceReasonCodes.commitCurrent,
+        fields: { activeNavigationId: 1 },
+      },
+    ]);
+    expect(nextTrace.entries.map((entry) => entry.code)).toEqual([
+      NavigationTraceReasonCodes.commitCurrent,
+      NavigationTraceReasonCodes.staleOperation,
+    ]);
   });
 
   it("treats null root-layout identities as soft-navigation compatible", () => {


### PR DESCRIPTION
## What this changes
Adds the `#726-OPS-01` compact navigation trace shell for the App Router navigation commit seam. Pending commit classification can now opt into a structured `NavigationTrace` with compact reason codes for current dispatch, stale operation skip, root-boundary hard navigation, and unknown root-layout legacy fallback.

## Why
Issue #726 calls out that `NavigationTrace` should use compact reason codes and structured fields instead of narrative logs. The current commit classification path only returned a string disposition, which made follow-up lifecycle work choose between losing operational context or inventing ad hoc logs at each call site.

## Approach
Added `packages/vinext/src/server/navigation-trace.ts` with schema version 0, compact reason codes, structured field names, and small trace construction helpers.

Threaded traces through `resolvePendingNavigationCommitDispositionDecision()` while preserving the existing `resolvePendingNavigationCommitDisposition()` string-only helper as the allocation-light hot-path API used by browser navigation. `resolveAndClassifyNavigationCommit()` stays on the allocation-light disposition path because the current controller does not consume traces yet.

Non-goals: this does not promote new navigation planner semantics, change visible commit behavior, add runtime logging, or claim cache or skip-transport authority. It is the trace contract shell only.

## Validation
- `vp test run tests/app-browser-entry.test.ts`
- `vp check packages/vinext/src/server/navigation-trace.ts packages/vinext/src/server/app-browser-state.ts tests/app-browser-entry.test.ts`
- `vp run knip --no-progress`
- pre-commit hook: `vp check --fix` and `knip --no-progress`

## Risks / follow-ups
The trace field set is intentionally narrow to stay parallel-safe with the other Wave01 branches. Later #726 OPS tasks can extend the field/code taxonomy as more semantic owners move behind typed commit decisions.
