### PR TITLE
perf(app-router): coalesce client reference preloads

### DIFF
--- a/packages/vinext/src/global.d.ts
+++ b/packages/vinext/src/global.d.ts
@@ -275,6 +275,15 @@ declare global {
    */
   // oxlint-disable-next-line no-var
   var __VINEXT_onRequestErrorHandler__: OnRequestErrorHandler | undefined;
+
+  /**
+   * Vite RSC's SSR-side client-reference module loader.
+   * Set by `@vitejs/plugin-rsc` and read by the App Router SSR entry before
+   * React consumes the Flight stream, so first-request client references are
+   * already resolved when Fizz renders the shell.
+   */
+  // oxlint-disable-next-line no-var
+  var __vite_rsc_client_require__: ((id: string) => Promise<unknown>) | undefined;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/vinext/src/server/app-client-reference-preloader.ts
+++ b/packages/vinext/src/server/app-client-reference-preloader.ts
@@ -1,0 +1,100 @@
+type ClientReferenceRequire = (id: string) => Promise<unknown>;
+
+type ClientReferenceMap = Readonly<Record<string, unknown>>;
+
+type ClientReferencePreloaderOptions = {
+  getReferences: () => ClientReferenceMap | undefined;
+  getClientRequire: () => ClientReferenceRequire | undefined;
+  onPreloadError?: (id: string, error: unknown) => void;
+};
+
+type ClientReferencePreloader = {
+  preload: (referenceIds?: Iterable<string>) => Promise<void>;
+};
+
+const resolvedPreload = Promise.resolve();
+
+export function createClientReferencePreloader(
+  options: ClientReferencePreloaderOptions,
+): ClientReferencePreloader {
+  let allReferencesPreloaded = false;
+  let allReferencesPreloadPromise: Promise<void> | null = null;
+  const preloadedReferences = new Set<string>();
+  const referencePreloadPromises = new Map<string, Promise<void>>();
+
+  function preloadReference(id: string, clientRequire: ClientReferenceRequire): Promise<void> {
+    if (preloadedReferences.has(id)) {
+      return resolvedPreload;
+    }
+
+    const existing = referencePreloadPromises.get(id);
+    if (existing) {
+      return existing;
+    }
+
+    const preloadPromise = clientRequire(id)
+      .catch((error) => {
+        options.onPreloadError?.(id, error);
+      })
+      .then(() => {
+        preloadedReferences.add(id);
+      })
+      .finally(() => {
+        referencePreloadPromises.delete(id);
+      });
+
+    referencePreloadPromises.set(id, preloadPromise);
+    return preloadPromise;
+  }
+
+  function preloadReferenceSet(
+    referenceIds: Iterable<string>,
+    refs: ClientReferenceMap,
+    clientRequire: ClientReferenceRequire,
+  ): Promise<void> {
+    const pending: Promise<void>[] = [];
+
+    for (const id of referenceIds) {
+      if (Object.hasOwn(refs, id)) {
+        pending.push(preloadReference(id, clientRequire));
+      }
+    }
+
+    if (pending.length === 0) {
+      return resolvedPreload;
+    }
+
+    return Promise.all(pending).then(() => {});
+  }
+
+  return {
+    preload(referenceIds) {
+      const refs = options.getReferences();
+      const clientRequire = options.getClientRequire();
+      if (!refs || !clientRequire) {
+        return resolvedPreload;
+      }
+
+      if (referenceIds) {
+        return preloadReferenceSet(referenceIds, refs, clientRequire);
+      }
+
+      if (allReferencesPreloaded) {
+        return resolvedPreload;
+      }
+      if (allReferencesPreloadPromise) {
+        return allReferencesPreloadPromise;
+      }
+
+      allReferencesPreloadPromise = preloadReferenceSet(Object.keys(refs), refs, clientRequire)
+        .then(() => {
+          allReferencesPreloaded = true;
+        })
+        .finally(() => {
+          allReferencesPreloadPromise = null;
+        });
+
+      return allReferencesPreloadPromise;
+    },
+  };
+}

--- a/packages/vinext/src/server/app-ssr-entry.ts
+++ b/packages/vinext/src/server/app-ssr-entry.ts
@@ -4,7 +4,7 @@ import type { ReactNode } from "react";
 import { Fragment, createElement as createReactElement, use } from "react";
 import { createFromReadableStream } from "@vitejs/plugin-rsc/ssr";
 import { renderToReadableStream, renderToStaticMarkup } from "react-dom/server.edge";
-import * as clientReferences from "virtual:vite-rsc/client-references";
+import clientReferences from "virtual:vite-rsc/client-references";
 import type { NavigationContext } from "vinext/shims/navigation";
 import {
   ServerInsertedHTMLContext,
@@ -30,6 +30,7 @@ import {
   type AppWireElements,
 } from "./app-elements.js";
 import { ElementsContext, Slot } from "vinext/shims/slot";
+import { createClientReferencePreloader } from "./app-client-reference-preloader.js";
 
 export type FontPreload = {
   href: string;
@@ -42,37 +43,19 @@ export type FontData = {
   preloads?: FontPreload[];
 };
 
-type ClientRequire = (id: string) => Promise<unknown>;
-
-let clientRefsPreloaded = false;
-
-function getClientReferenceRequire(): ClientRequire | undefined {
-  return (
-    globalThis as typeof globalThis & {
-      __vite_rsc_client_require__?: ClientRequire;
+const clientReferencePreloader = createClientReferencePreloader({
+  getReferences() {
+    return clientReferences;
+  },
+  getClientRequire() {
+    return globalThis.__vite_rsc_client_require__;
+  },
+  onPreloadError(id, error) {
+    if (process.env.NODE_ENV !== "production") {
+      console.warn("[vinext] failed to preload client ref:", id, error);
     }
-  ).__vite_rsc_client_require__;
-}
-
-async function preloadClientReferences(): Promise<void> {
-  if (clientRefsPreloaded) return;
-
-  const refs = (clientReferences as { default?: Record<string, unknown> }).default;
-  const clientRequire = getClientReferenceRequire();
-  if (!refs || !clientRequire) return;
-
-  await Promise.all(
-    Object.keys(refs).map((id) =>
-      clientRequire(id).catch((error) => {
-        if (process.env.NODE_ENV !== "production") {
-          console.warn("[vinext] failed to preload client ref:", id, error);
-        }
-      }),
-    ),
-  );
-
-  clientRefsPreloaded = true;
-}
+  },
+});
 
 function ssrErrorDigest(input: string): string {
   let hash = 5381;
@@ -178,7 +161,7 @@ export async function handleSsr(
   },
 ): Promise<ReadableStream<Uint8Array>> {
   return runWithNavigationContext(async () => {
-    await preloadClientReferences();
+    await clientReferencePreloader.preload();
 
     if (navContext) {
       setNavigationContext(navContext);

--- a/tests/app-client-reference-preloader.test.ts
+++ b/tests/app-client-reference-preloader.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import { createClientReferencePreloader } from "../packages/vinext/src/server/app-client-reference-preloader.js";
+
+function createDeferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolveDeferred: () => void = () => {
+    throw new Error("deferred promise was not initialized");
+  };
+  const promise = new Promise<void>((resolve) => {
+    resolveDeferred = () => resolve();
+  });
+  return { promise, resolve: resolveDeferred };
+}
+
+describe("app client reference preloader", () => {
+  it("shares one in-flight preload across concurrent cold SSR calls", async () => {
+    const refs = { "comp-a": true, "comp-b": true, "comp-c": true };
+    const calls: string[] = [];
+    const preloadGate = createDeferred();
+
+    const preloader = createClientReferencePreloader({
+      getReferences: () => refs,
+      getClientRequire: () => async (id) => {
+        calls.push(id);
+        await preloadGate.promise;
+      },
+    });
+
+    const first = preloader.preload();
+    const second = preloader.preload();
+    const third = preloader.preload();
+
+    expect(second).toBe(first);
+    expect(third).toBe(first);
+    expect(calls).toEqual(["comp-a", "comp-b", "comp-c"]);
+
+    preloadGate.resolve();
+    await Promise.all([first, second, third]);
+
+    await preloader.preload();
+    expect(calls).toEqual(["comp-a", "comp-b", "comp-c"]);
+  });
+
+  it("does not mark preload complete when references or client require are unavailable", async () => {
+    const refs = { "comp-a": true };
+    let currentRefs: Record<string, unknown> | undefined;
+    let currentRequire: ((id: string) => Promise<unknown>) | undefined;
+    const calls: string[] = [];
+
+    const preloader = createClientReferencePreloader({
+      getReferences: () => currentRefs,
+      getClientRequire: () => currentRequire,
+    });
+
+    await preloader.preload();
+
+    currentRefs = refs;
+    await preloader.preload();
+
+    currentRequire = async (id) => {
+      calls.push(id);
+    };
+    await preloader.preload();
+
+    expect(calls).toEqual(["comp-a"]);
+  });
+
+  it("dedupes overlapping scoped preload requests per reference id", async () => {
+    const calls: string[] = [];
+    const preloadGate = createDeferred();
+    const preloader = createClientReferencePreloader({
+      getReferences: () => ({ "comp-a": true, "comp-b": true, "comp-c": true }),
+      getClientRequire: () => async (id) => {
+        calls.push(id);
+        await preloadGate.promise;
+      },
+    });
+
+    const firstRoute = preloader.preload(["comp-a", "comp-b"]);
+    const secondRoute = preloader.preload(["comp-b", "comp-c"]);
+
+    expect(calls).toEqual(["comp-a", "comp-b", "comp-c"]);
+
+    preloadGate.resolve();
+    await Promise.all([firstRoute, secondRoute]);
+
+    await preloader.preload(["comp-b"]);
+    expect(calls).toEqual(["comp-a", "comp-b", "comp-c"]);
+  });
+
+  it("reports individual preload failures and completes the manifest pass", async () => {
+    const reported: Array<{ id: string; error: unknown }> = [];
+    const calls: string[] = [];
+    const preloader = createClientReferencePreloader({
+      getReferences: () => ({ "comp-a": true, "comp-b": true }),
+      getClientRequire: () => async (id) => {
+        calls.push(id);
+        if (id === "comp-a") {
+          throw new Error("load failed");
+        }
+      },
+      onPreloadError: (id, error) => reported.push({ id, error }),
+    });
+
+    await preloader.preload();
+    await preloader.preload();
+
+    expect(calls).toEqual(["comp-a", "comp-b"]);
+    expect(reported).toHaveLength(1);
+    expect(reported[0]?.id).toBe("comp-a");
+    expect(reported[0]?.error).toBeInstanceOf(Error);
+  });
+});


### PR DESCRIPTION
## What this changes
App Router SSR now shares a single in-flight client-reference preload during cold starts instead of letting concurrent first requests each iterate the full `virtual:vite-rsc/client-references` manifest and allocate their own `Promise.all` fan-out.

The preload logic moved out of `app-ssr-entry.ts` into a typed helper that:

- coalesces the global manifest preload promise
- dedupes work per client-reference id
- keeps completed references on a zero-allocation fast path
- preserves the existing non-fatal dev warning behavior for individual preload failures
- exposes a scoped `preload(referenceIds)` shape for a future route-level manifest without losing cross-route per-id dedupe

## Why
The existing preload is required for correctness: first-request SSR can fail if React consumes the Flight stream before Vite RSC client references have resolved. But the state only tracked completion. During a cold burst, every request entering before the boolean flipped repeated manifest key iteration and promise fan-out even though Vite RSC memoized the underlying imports.

This keeps the correctness barrier and removes the duplicate orchestration work.

## Approach
`handleSsr` still awaits client-reference preload before creating the SSR tree. The difference is that it now delegates to `createClientReferencePreloader`, which owns the concurrency contract directly and is covered by focused unit tests.

I did not synthesize a route-to-client-reference manifest in this PR. `@vitejs/plugin-rsc` currently owns the reliable client-reference graph behind private build metadata, while the public virtual module is app-global. Guessing that graph from transformed module IDs would be fragile for package client references and production hash keys.

The new helper is intentionally shaped so a future generated route manifest can pass scoped ids once Vinext has trustworthy build metadata. That likely lines up with the RouteManifest/resource-dependency pieces of #726, not the entire #726 roadmap: once Vinext has authoritative route-to-module facts, SSR can call `preload(routeClientReferenceIds)` for the matched route while retaining the same per-id dedupe and correctness barrier introduced here.

## Validation
- `vp check packages/vinext/src/server/app-client-reference-preloader.ts packages/vinext/src/server/app-ssr-entry.ts packages/vinext/src/global.d.ts tests/app-client-reference-preloader.test.ts`
- `vp test run tests/app-client-reference-preloader.test.ts`
- `vp test run tests/app-client-reference-preloader.test.ts tests/app-router.test.ts`
- `vp run vinext#build`

## Risks / follow-ups
The preloader intentionally treats individual client-reference preload failures as reported-but-complete, matching the previous best-effort behavior in `app-ssr-entry.ts`. A future route-scoped manifest should be generated from authoritative RouteManifest/resource-dependency metadata from #726, not from source filename heuristics or Flight stream parsing.