### PR TITLE
perf(pages): cache ISR misses from streamed render

### DIFF
--- a/packages/vinext/src/entries/pages-server-entry.ts
+++ b/packages/vinext/src/entries/pages-server-entry.ts
@@ -665,7 +665,6 @@ async function _renderPage(request, url, manifest, middlewareHeaders) {
         renderDocumentToString(element) {
           return renderToStringAsync(element);
         },
-        renderIsrPassToStringAsync,
         renderToReadableStream(element) {
           return renderToReadableStream(element);
         },

--- a/packages/vinext/src/server/pages-page-response.ts
+++ b/packages/vinext/src/server/pages-page-response.ts
@@ -1,7 +1,10 @@
 import React, { type ComponentType, type ReactNode } from "react";
+import type { CachedPagesValue } from "vinext/shims/cache";
 import { withScriptNonce } from "vinext/shims/script-nonce-context";
+import { getRequestExecutionContext } from "vinext/shims/request-context";
 import { buildRevalidateCacheControl } from "./cache-control.js";
 import { createInlineScriptTag, createNonceAttribute, escapeHtmlAttr } from "./html.js";
+import { reportRequestError } from "./instrumentation.js";
 
 type PagesFontPreload = {
   href: string;
@@ -42,13 +45,7 @@ type RenderPagesPageResponseOptions = {
   isrRevalidateSeconds: number | null;
   isrSet: (
     key: string,
-    data: {
-      kind: "PAGES";
-      html: string;
-      pageData: Record<string, unknown>;
-      headers: undefined;
-      status: undefined;
-    },
+    data: CachedPagesValue,
     revalidateSeconds: number,
     tags?: string[],
     expireSeconds?: number,
@@ -57,7 +54,6 @@ type RenderPagesPageResponseOptions = {
   pageProps: Record<string, unknown>;
   params: Record<string, unknown>;
   renderDocumentToString: (element: ReactNode) => Promise<string>;
-  renderIsrPassToStringAsync: (element: ReactNode) => Promise<string>;
   renderToReadableStream: (element: ReactNode) => Promise<ReadableStream<Uint8Array>>;
   resetSSRHead?: (() => void) | undefined;
   routePattern: string;
@@ -197,6 +193,77 @@ async function buildPagesCompositeStream(
   });
 }
 
+async function recordStreamToString(stream: ReadableStream<Uint8Array>): Promise<string> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  const chunks: string[] = [];
+
+  try {
+    for (;;) {
+      const chunk = await reader.read();
+      if (chunk.done) {
+        break;
+      }
+      chunks.push(decoder.decode(chunk.value, { stream: true }));
+    }
+    chunks.push(decoder.decode());
+    return chunks.join("");
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+function reportPagesIsrCacheWriteError(
+  error: unknown,
+  cacheKey: string,
+  routePattern: string,
+): Promise<void> {
+  console.error(`[vinext] Pages ISR cache write failed for ${cacheKey}:`, error);
+  return reportRequestError(
+    error instanceof Error ? error : new Error(String(error)),
+    { path: cacheKey, method: "GET", headers: {} },
+    {
+      routerKind: "Pages Router",
+      routePath: routePattern,
+      routeType: "render",
+    },
+  );
+}
+
+function schedulePagesIsrCacheWrite(options: {
+  cacheKey: string;
+  expireSeconds?: number;
+  pageData: Record<string, unknown>;
+  revalidateSeconds: number;
+  routePattern: string;
+  shellPrefix: string;
+  shellSuffix: string;
+  stream: ReadableStream<Uint8Array>;
+  setCache: RenderPagesPageResponseOptions["isrSet"];
+}): void {
+  const cacheWritePromise = recordStreamToString(options.stream)
+    .then((bodyHtml) =>
+      options.setCache(
+        options.cacheKey,
+        {
+          kind: "PAGES",
+          html: options.shellPrefix + bodyHtml + options.shellSuffix,
+          pageData: options.pageData,
+          headers: undefined,
+          status: undefined,
+        },
+        options.revalidateSeconds,
+        undefined,
+        options.expireSeconds,
+      ),
+    )
+    .catch((error: unknown) =>
+      reportPagesIsrCacheWriteError(error, options.cacheKey, options.routePattern),
+    );
+
+  getRequestExecutionContext()?.waitUntil(cacheWritePromise);
+}
+
 function applyGsspHeaders(headers: Headers, gsspRes: PagesGsspResponse | null): number {
   if (!gsspRes) {
     return 200;
@@ -270,8 +337,8 @@ export async function renderPagesPageResponse(
   const markerIndex = shellHtml.indexOf(bodyMarker);
   const shellPrefix = shellHtml.slice(0, markerIndex);
   const shellSuffix = shellHtml.slice(markerIndex + bodyMarker.length);
-  const compositeStream = await buildPagesCompositeStream(bodyStream, shellPrefix, shellSuffix);
 
+  let responseBodyStream = bodyStream;
   if (
     // Keep nonce-bearing pages out of ISR writes: rewritePagesCachedHtml()
     // later matches the cached __NEXT_DATA__ block via a bare <script> marker.
@@ -279,29 +346,30 @@ export async function renderPagesPageResponse(
     options.isrRevalidateSeconds !== null &&
     options.isrRevalidateSeconds > 0
   ) {
-    const isrElement = React.createElement(
-      React.Fragment,
-      null,
-      options.createPageElement(options.pageProps),
-    );
-    const isrHtml = await options.renderIsrPassToStringAsync(isrElement);
-    const fullHtml = shellPrefix + isrHtml + shellSuffix;
+    const cacheBodyStreamPair = bodyStream.tee();
+    responseBodyStream = cacheBodyStreamPair[0];
+    const cacheBodyStream = cacheBodyStreamPair[1];
     const isrPathname = options.routeUrl.split("?")[0];
     const cacheKey = options.isrCacheKey("pages", isrPathname);
-    await options.isrSet(
+
+    schedulePagesIsrCacheWrite({
       cacheKey,
-      {
-        kind: "PAGES",
-        html: fullHtml,
-        pageData: options.pageProps,
-        headers: undefined,
-        status: undefined,
-      },
-      options.isrRevalidateSeconds,
-      undefined,
-      options.expireSeconds,
-    );
+      expireSeconds: options.expireSeconds,
+      pageData: options.pageProps,
+      revalidateSeconds: options.isrRevalidateSeconds,
+      routePattern: options.routePattern,
+      setCache: options.isrSet,
+      shellPrefix,
+      shellSuffix,
+      stream: cacheBodyStream,
+    });
   }
+
+  const compositeStream = await buildPagesCompositeStream(
+    responseBodyStream,
+    shellPrefix,
+    shellSuffix,
+  );
 
   const responseHeaders = new Headers({ "Content-Type": "text/html" });
   const finalStatus = applyGsspHeaders(responseHeaders, options.gsspRes);
@@ -319,12 +387,16 @@ export async function renderPagesPageResponse(
     responseHeaders.set("Link", options.fontLinkHeader);
   }
 
-  const response = new Response(compositeStream, {
-    status: finalStatus,
-    headers: responseHeaders,
-  }) as PagesStreamedHtmlResponse;
+  const response: PagesStreamedHtmlResponse = Object.assign(
+    new Response(compositeStream, {
+      status: finalStatus,
+      headers: responseHeaders,
+    }),
+    {
+      __vinextStreamedHtmlResponse: true,
+    },
+  );
   // Mark the normal streamed HTML render so the Node prod server can strip
   // stale Content-Length only for this path, not for custom gSSP responses.
-  response.__vinextStreamedHtmlResponse = true;
   return response;
 }

--- a/packages/vinext/src/server/pages-page-response.ts
+++ b/packages/vinext/src/server/pages-page-response.ts
@@ -213,21 +213,25 @@ async function recordStreamToString(stream: ReadableStream<Uint8Array>): Promise
   }
 }
 
-function reportPagesIsrCacheWriteError(
+async function reportPagesIsrCacheWriteError(
   error: unknown,
   cacheKey: string,
   routePattern: string,
 ): Promise<void> {
   console.error(`[vinext] Pages ISR cache write failed for ${cacheKey}:`, error);
-  return reportRequestError(
-    error instanceof Error ? error : new Error(String(error)),
-    { path: cacheKey, method: "GET", headers: {} },
-    {
-      routerKind: "Pages Router",
-      routePath: routePattern,
-      routeType: "render",
-    },
-  );
+  try {
+    await reportRequestError(
+      error instanceof Error ? error : new Error(String(error)),
+      { path: cacheKey, method: "GET", headers: {} },
+      {
+        routerKind: "Pages Router",
+        routePath: routePattern,
+        routeType: "render",
+      },
+    );
+  } catch {
+    // Cache-write failure reporting must never make the background task reject.
+  }
 }
 
 function schedulePagesIsrCacheWrite(options: {

--- a/tests/pages-page-response.test.ts
+++ b/tests/pages-page-response.test.ts
@@ -14,6 +14,31 @@ function createStream(chunks: string[]): ReadableStream<Uint8Array> {
   });
 }
 
+function createByteStream(chunks: Uint8Array[]): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(chunk);
+      }
+      controller.close();
+    },
+  });
+}
+
+function createFailingStream(error: Error): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode("<div>partial"));
+      controller.error(error);
+    },
+  });
+}
+
+async function settleMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
 function createCommonOptions() {
   const clearSsrContext = vi.fn();
   const createPageElement = vi.fn((pageProps: Record<string, unknown>) =>
@@ -65,7 +90,6 @@ function createCommonOptions() {
       pageProps: { title: "hello" },
       params: { slug: "post" },
       renderDocumentToString,
-      renderIsrPassToStringAsync,
       renderToReadableStream,
       resetSSRHead: vi.fn(),
       routePattern: "/posts/[slug]",
@@ -138,7 +162,7 @@ describe("pages page response", () => {
     expect(response.headers.getSetCookie()).toEqual(["a=1; Path=/", "b=2; Path=/"]);
   });
 
-  it("writes the ISR HTML cache entry for cacheable page responses", async () => {
+  it("records the streamed body into the ISR HTML cache without a second page render", async () => {
     const common = createCommonOptions();
 
     const response = await renderPagesPageResponse({
@@ -154,21 +178,78 @@ describe("pages page response", () => {
     expect(response.headers.get("cache-control")).toBe("s-maxage=60, stale-while-revalidate=240");
     expect(response.headers.get("x-vinext-cache")).toBe("MISS");
     await expect(response.text()).resolves.toContain("<div>live-body</div>");
+    await settleMicrotasks();
 
-    expect(common.createPageElement).toHaveBeenCalledTimes(2);
-    expect(common.renderIsrPassToStringAsync).toHaveBeenCalledTimes(1);
+    expect(common.createPageElement).toHaveBeenCalledTimes(1);
+    expect(common.renderIsrPassToStringAsync).not.toHaveBeenCalled();
     expect(common.isrSet).toHaveBeenCalledTimes(1);
     expect(common.isrSet).toHaveBeenCalledWith(
       "pages:/posts/post",
       expect.objectContaining({
         kind: "PAGES",
-        html: expect.stringContaining("<div>cached-body</div>"),
+        html: expect.stringContaining("<div>live-body</div>"),
         pageData: { title: "hello" },
       }),
       60,
       undefined,
       300,
     );
+  });
+
+  it("records split UTF-8 chunks without corrupting cached ISR HTML", async () => {
+    const common = createCommonOptions();
+    common.renderToReadableStream.mockResolvedValue(
+      createByteStream([
+        new Uint8Array([0xe2]),
+        new Uint8Array([0x82, 0xac]),
+        new TextEncoder().encode("<div>live-body</div>"),
+      ]),
+    );
+
+    const response = await renderPagesPageResponse({
+      ...common.options,
+      isrRevalidateSeconds: 60,
+    });
+
+    await expect(response.text()).resolves.toContain("\u20ac<div>live-body</div>");
+    await settleMicrotasks();
+
+    expect(common.isrSet).toHaveBeenCalledWith(
+      "pages:/posts/post",
+      expect.objectContaining({
+        html: expect.stringContaining("\u20ac<div>live-body</div>"),
+      }),
+      60,
+      undefined,
+      undefined,
+    );
+  });
+
+  it("does not write a Pages ISR cache entry when the streamed render fails", async () => {
+    const common = createCommonOptions();
+    common.renderToReadableStream.mockResolvedValue(
+      createFailingStream(new Error("stream failed")),
+    );
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      const response = await renderPagesPageResponse({
+        ...common.options,
+        isrRevalidateSeconds: 60,
+      });
+
+      await expect(response.text()).rejects.toThrow("stream failed");
+      await settleMicrotasks();
+
+      expect(common.renderIsrPassToStringAsync).not.toHaveBeenCalled();
+      expect(common.isrSet).not.toHaveBeenCalled();
+      expect(consoleError).toHaveBeenCalledWith(
+        "[vinext] Pages ISR cache write failed for pages:/posts/post:",
+        expect.any(Error),
+      );
+    } finally {
+      consoleError.mockRestore();
+    }
   });
 
   it("adds nonce attributes to inline scripts and font tags when provided", async () => {

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -401,7 +401,7 @@ describe("Pages Router integration", () => {
     expect(headSection).toContain("Hello vinext");
   });
 
-  it("keeps ISR cache-fill rerenders isolated from the streamed render state", async () => {
+  it("caches the streamed ISR render without carrying prior render state", async () => {
     const firstRes = await fetch(`${baseUrl}/isr-second-render-state`);
     expect(firstRes.status).toBe(200);
     expect(firstRes.headers.get("x-vinext-cache")).toBe("MISS");


### PR DESCRIPTION
## What this changes

Pages Router ISR cache misses now cache the same body stream used for the live HTML response instead of rendering the page a second time just to build cache HTML.

The response path keeps the existing render-before-head-collection order, tees the completed body stream when ISR is eligible, sends one branch to the client, and records the other branch into the Pages ISR cache. Nonce-bearing responses still skip ISR writes.

## Why

`renderPagesPageResponse` previously rendered the page once for the live response, then created a second page element and called `renderIsrPassToStringAsync()` to generate cached HTML. That second pass can repeat userland render work, data reads, Suspense work, and render-scoped state mutations on every Pages ISR MISS.

Next.js Pages ISR stores the generated `RenderResult` from the response cache path rather than constructing a second React tree for the cache fill. Vinext can do better for Workers by preserving streaming to the client while recording the same streamed body for persistence.

## Approach

- Keep the page render before shell/head collection so `next/head`, styled-jsx, and server-inserted HTML state are populated before shell assembly.
- For cacheable nonce-free Pages ISR responses, tee the body stream after shell assembly.
- Send branch A through the existing shell/body/shell composite response stream.
- Drain branch B with streaming UTF-8 decoding and write `shellPrefix + body + shellSuffix` to ISR cache.
- Report cache recording or cache write failures through the Pages Router render error path and avoid writing partial HTML.
- Remove the now-unused `renderIsrPassToStringAsync` dependency from the Pages response helper call.

## Validation

- `vp check packages/vinext/src/server/pages-page-response.ts packages/vinext/src/entries/pages-server-entry.ts tests/pages-page-response.test.ts tests/pages-router.test.ts`
- `vp test run tests/pages-page-response.test.ts tests/pages-page-data.test.ts`
- `vp test run tests/pages-router.test.ts -t "caches the streamed ISR render|Pages Router production fixture"`
- `vp test run tests/features.test.ts -t "ISR \\(Pages Router\\)"`
- `vp run vinext#build`

The package build exits 0 and still emits the existing unresolved virtual-module warnings for virtual RSC/instrumentation imports.

## Risks / follow-ups

This follows the existing App Router pattern of scheduling cache writes through `ExecutionContext.waitUntil()` when available. An immediate second request after a MISS can only hit once the cache backend has completed the write, which matches the asynchronous cache-write direction already used for App Router HTML caching.