### PR TITLE
refactor(i18n): dedupe NEXT_LOCALE cookie parsing

### DIFF
--- a/packages/vinext/src/entries/pages-server-entry.ts
+++ b/packages/vinext/src/entries/pages-server-entry.ts
@@ -443,16 +443,6 @@ function detectLocaleFromHeaders(headers) {
   return null;
 }
 
-function parseCookieLocaleFromHeader(cookieHeader) {
-  if (!i18nConfig || !cookieHeader) return null;
-  const match = cookieHeader.match(/(?:^|;\\s*)NEXT_LOCALE=([^;]*)/);
-  if (!match) return null;
-  var value;
-  try { value = decodeURIComponent(match[1].trim()); } catch (e) { return null; }
-  if (i18nConfig.locales.indexOf(value) !== -1) return value;
-  return null;
-}
-
 export async function renderPage(request, url, manifest, ctx, middlewareHeaders) {
   if (ctx) return _runWithExecutionContext(ctx, () => _renderPage(request, url, manifest, middlewareHeaders));
   return _renderPage(request, url, manifest, middlewareHeaders);


### PR DESCRIPTION
## Summary

- Remove the dead `parseCookieLocaleFromHeader` helper from the Pages SSR entry template (`packages/vinext/src/entries/pages-server-entry.ts`). It duplicated the regex + `decodeURIComponent` pattern already exported from `packages/vinext/src/server/pages-i18n.ts`.
- The duplicate had no callers in the generated server entry — locale resolution flows through `resolvePagesI18nRequest`, which already calls the canonical `parseCookieLocaleFromHeader` from `pages-i18n.ts` internally.
- Follow-up to #1049 (which extracted a similar helper for param decoding).

## Why deletion rather than import-and-call

I started by checking whether the entry should `import { parseCookieLocaleFromHeader }` from `pages-i18n.ts`. It turns out the local copy in the entry template is dead code: defined inside the SSR-entry template literal but never invoked. The single locale-resolution call site (`_renderPage`) already delegates to `resolvePagesI18nRequest`, so the cleanest dedupe is removal of the duplicate definition rather than a dangling import.

The two implementations were behaviorally equivalent (same regex `/(?:^|;\s*)NEXT_LOCALE=([^;]*)/`, same `decodeURIComponent(match[1].trim())`, same allow-list check against `i18nConfig.locales`). No behavior change.

## Files changed

- `packages/vinext/src/entries/pages-server-entry.ts` — remove dead `parseCookieLocaleFromHeader` (10 lines deleted).

## Out-of-scope notes

Two adjacent helpers in the same template are also dead code: `extractLocale` and `detectLocaleFromHeaders`. Left untouched per "only fix what's in scope" — happy to clean them up in a separate PR.

## Test plan

- [x] `pnpm vp test run tests/pages-router.test.ts` — 200/200 pass
- [x] `pnpm fmt --write` on touched file
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)