### PR TITLE
refactor(app-browser-entry): dedupe encoded JSON header parsing

### DIFF
--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -114,6 +114,19 @@ const MAX_TRAVERSAL_CACHE_TTL = 30 * 60_000;
 const browserNavigationController = createAppBrowserNavigationController();
 const NavigationCommitSignal = browserNavigationController.NavigationCommitSignal;
 
+// Parses a URI-encoded JSON value carried in a response header (e.g.
+// `X-Vinext-Params`). Returns `null` on missing or malformed input so callers
+// can fall back to their own defaults. Silent by design — these headers are
+// best-effort hydration data and a parse failure should not break navigation.
+function parseEncodedJsonHeader<T>(value: string | null): T | null {
+  if (!value) return null;
+  try {
+    return JSON.parse(decodeURIComponent(value)) as T;
+  } catch {
+    return null;
+  }
+}
+
 function isRouterStatePromise(
   value: AppRouterState | Promise<AppRouterState>,
 ): value is Promise<AppRouterState> {
@@ -723,14 +736,17 @@ async function readInitialRscStream(): Promise<ReadableStream<Uint8Array> | null
   // same path after a transient failure still gets one recovery attempt.
   clearReloadFlag();
 
-  let params: Record<string, string | string[]> = {};
-  const paramsHeader = rscResponse.headers.get("X-Vinext-Params");
-  if (paramsHeader) {
+  // Ignore malformed param headers and continue with hydration. The original
+  // try/catch also swallowed errors from applyClientParams; preserve that.
+  const parsedParams = parseEncodedJsonHeader<Record<string, string | string[]>>(
+    rscResponse.headers.get("X-Vinext-Params"),
+  );
+  const params: Record<string, string | string[]> = parsedParams ?? {};
+  if (parsedParams) {
     try {
-      params = JSON.parse(decodeURIComponent(paramsHeader)) as Record<string, string | string[]>;
-      applyClientParams(params);
+      applyClientParams(parsedParams);
     } catch {
-      // Ignore malformed param headers and continue with hydration.
+      // Ignore — matches the previous combined try/catch behavior.
     }
   }
 
@@ -1087,18 +1103,11 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
           continue;
         }
 
-        let navParams: Record<string, string | string[]> = {};
-        const paramsHeader = navResponse.headers.get("X-Vinext-Params");
-        if (paramsHeader) {
-          try {
-            navParams = JSON.parse(decodeURIComponent(paramsHeader)) as Record<
-              string,
-              string | string[]
-            >;
-          } catch {
-            // navParams stays as {}
-          }
-        }
+        // navParams falls back to {} on a missing or malformed header.
+        const navParams: Record<string, string | string[]> =
+          parseEncodedJsonHeader<Record<string, string | string[]>>(
+            navResponse.headers.get("X-Vinext-Params"),
+          ) ?? {};
         // Build snapshot from local params, not latestClientParams
         const navigationSnapshot = createClientNavigationRenderSnapshot(currentHref, navParams);
 


### PR DESCRIPTION
## Summary

- Extract the repeated `try { JSON.parse(decodeURIComponent(headerValue)) } catch { ... }` pattern used to hydrate params from the `X-Vinext-Params` header into a single local helper, `parseEncodedJsonHeader<T>(value: string | null): T | null`.
- Both call sites in `packages/vinext/src/server/app-browser-entry.ts` (the initial RSC hydration path and the in-flight navigation path) now share the helper.
- Pure refactor — no behavior change.

Follow-up to #1049.

## Files changed

- `packages/vinext/src/server/app-browser-entry.ts` — adds the helper at the top of the file and updates the two call sites.

## Notes on behavior preservation

The two original blocks had a subtle difference:

- The first call site (initial RSC response) parsed the header **and** called `applyClientParams(params)` inside the same `try`, so the catch silently swallowed any error from `applyClientParams` as well.
- The second call site only parsed.

The helper itself only handles parsing. To preserve the original error-swallowing semantics at the first call site, `applyClientParams` is wrapped in a small dedicated `try/catch` there. The helper does not log or surface errors — silent by design, matching the pre-existing behavior.

A quick `grep -rn "JSON.parse(decodeURIComponent" packages/vinext/src/` confirmed the pattern only appears in this file, so a module-private helper (rather than a shared utility) is sufficient.

## Test plan

- [x] `pnpm vp test run tests/app-router.test.ts` — 308 tests pass
- [x] `pnpm fmt --write` on the touched file
- [x] Manual diff review to confirm structural-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)