### PR TITLE
refactor(server): dedupe forbidden response construction

### DIFF
--- a/packages/vinext/src/server/dev-origin-check.ts
+++ b/packages/vinext/src/server/dev-origin-check.ts
@@ -147,12 +147,16 @@ export function generateDevOriginCheckCode(allowedDevOrigins?: string[]): string
 const __allowedDevOrigins = ${origins};
 const __safeDevHosts = ["localhost", "127.0.0.1", "[::1]"];
 
+function __forbidden() {
+  return new Response("Forbidden", { status: 403, headers: { "Content-Type": "text/plain" } });
+}
+
 function __validateDevRequestOrigin(request) {
   // Check Sec-Fetch headers (catches <script> tag exfiltration)
   if (request.headers.get("sec-fetch-mode") === "no-cors" &&
       request.headers.get("sec-fetch-site") === "cross-site") {
     console.warn("[vinext] Blocked cross-site no-cors request to " + new URL(request.url).pathname);
-    return new Response("Forbidden", { status: 403, headers: { "Content-Type": "text/plain" } });
+    return __forbidden();
   }
 
   const origin = request.headers.get("origin");
@@ -162,7 +166,7 @@ function __validateDevRequestOrigin(request) {
   if (origin === "null") {
     if (!__allowedDevOrigins.includes("null")) {
       console.warn("[vinext] Blocked request with Origin: null. Add \\"null\\" to allowedDevOrigins to allow sandboxed contexts.");
-      return new Response("Forbidden", { status: 403, headers: { "Content-Type": "text/plain" } });
+      return __forbidden();
     }
     return null;
   }
@@ -171,7 +175,7 @@ function __validateDevRequestOrigin(request) {
   try {
     originHostname = new URL(origin).hostname.toLowerCase();
   } catch {
-    return new Response("Forbidden", { status: 403, headers: { "Content-Type": "text/plain" } });
+    return __forbidden();
   }
 
   // Allow localhost, 127.0.0.1, [::1], and *.localhost
@@ -195,7 +199,7 @@ function __validateDevRequestOrigin(request) {
     \`[vinext] Blocked cross-origin request from "\${origin}" to \${new URL(request.url).pathname}. \` +
     \`To allow this origin, add it to allowedDevOrigins in next.config.js.\`
   );
-  return new Response("Forbidden", { status: 403, headers: { "Content-Type": "text/plain" } });
+  return __forbidden();
 }
 `;
 }

--- a/packages/vinext/src/server/request-pipeline.ts
+++ b/packages/vinext/src/server/request-pipeline.ts
@@ -17,6 +17,16 @@ import { matchHeaders } from "../config/config-matchers.js";
  */
 
 /**
+ * Build a 403 Forbidden plain-text response.
+ *
+ * Centralizes the `new Response("Forbidden", { status: 403, ... })` pattern
+ * shared by CSRF origin validation and dev-server origin checks.
+ */
+export function forbiddenResponse(): Response {
+  return new Response("Forbidden", { status: 403, headers: { "Content-Type": "text/plain" } });
+}
+
+/**
  * Guard against protocol-relative URL open redirects.
  *
  * Paths like `//example.com/` would be redirected to `//example.com` by the
@@ -312,14 +322,14 @@ export function validateCsrfOrigin(
     console.warn(
       `[vinext] CSRF origin "null" blocked for server action. To allow requests from sandboxed contexts, add "null" to experimental.serverActions.allowedOrigins.`,
     );
-    return new Response("Forbidden", { status: 403, headers: { "Content-Type": "text/plain" } });
+    return forbiddenResponse();
   }
 
   let originHost: string;
   try {
     originHost = new URL(originHeader).host.toLowerCase();
   } catch {
-    return new Response("Forbidden", { status: 403, headers: { "Content-Type": "text/plain" } });
+    return forbiddenResponse();
   }
 
   // Only use the Host header for origin comparison — never trust
@@ -341,7 +351,7 @@ export function validateCsrfOrigin(
   console.warn(
     `[vinext] CSRF origin mismatch: origin "${originHost}" does not match host "${hostHeader}". Blocking server action request.`,
   );
-  return new Response("Forbidden", { status: 403, headers: { "Content-Type": "text/plain" } });
+  return forbiddenResponse();
 }
 
 /**


### PR DESCRIPTION
## Summary

- Follow-up dedupe scan after #1049: the literal `new Response("Forbidden", { status: 403, headers: { "Content-Type": "text/plain" } })` was repeated 7 times across two server files.
- Adds a `forbiddenResponse()` helper in `request-pipeline.ts` and replaces the 3 byte-identical call sites in `validateCsrfOrigin`.
- For the 4 occurrences inside `generateDevOriginCheckCode()` — which emits inline JS that runs in the RSC Vite environment and cannot import TS modules — introduces a local `__forbidden()` helper inside the generated code so the duplication is eliminated there too.
- Pure refactor, no behavior change. All call sites were verified byte-equivalent before merging.

## Touched files

- `packages/vinext/src/server/request-pipeline.ts` — adds exported `forbiddenResponse()`; replaces 3 inline literals.
- `packages/vinext/src/server/dev-origin-check.ts` — emits a local `__forbidden()` helper inside the codegen template; replaces 4 inline literals in the generated JS.

## Test plan

- [x] `pnpm vp test run tests/app-router.test.ts tests/pages-router.test.ts` — 508 tests pass. (One unrelated `afterAll` cleanup-hook timeout under heavy concurrent load; reruns of the touched suite, including `Pages Router allowedDevOrigins config`, all pass.)
- [x] `pnpm fmt:check` — clean.
- [ ] CI green on the draft PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)