### PR TITLE
refactor(shims): dedupe cookie value serialization

### DIFF
--- a/packages/vinext/src/shims/headers.ts
+++ b/packages/vinext/src/shims/headers.ts
@@ -10,6 +10,11 @@
 
 import { AsyncLocalStorage } from "node:async_hooks";
 import { buildRequestHeadersFromMiddlewareResponse } from "../server/middleware-request-headers.js";
+import {
+  serializeSetCookie,
+  validateCookieAttributeValue,
+  validateCookieName,
+} from "./internal/cookie-serialize.js";
 import { parseCookieHeader } from "./internal/parse-cookie-header.js";
 import {
   isInsideUnifiedScope,
@@ -813,36 +818,6 @@ export async function draftMode(): Promise<DraftModeResult> {
 }
 
 // ---------------------------------------------------------------------------
-// Cookie name/value validation (RFC 6265)
-// ---------------------------------------------------------------------------
-
-/**
- * RFC 6265 §4.1.1: cookie-name is a token (RFC 2616 §2.2).
- * Allowed: any visible ASCII (0x21-0x7E) except separators: ()<>@,;:\"/[]?={}
- */
-const VALID_COOKIE_NAME_RE =
-  /^[\x21\x23-\x27\x2A\x2B\x2D\x2E\x30-\x39\x41-\x5A\x5E-\x7A\x7C\x7E]+$/;
-
-function validateCookieName(name: string): void {
-  if (!name || !VALID_COOKIE_NAME_RE.test(name)) {
-    throw new Error(`Invalid cookie name: ${JSON.stringify(name)}`);
-  }
-}
-
-/**
- * Validate cookie attribute values (path, domain) to prevent injection
- * via semicolons, newlines, or other control characters.
- */
-function validateCookieAttributeValue(value: string, attributeName: string): void {
-  for (let i = 0; i < value.length; i++) {
-    const code = value.charCodeAt(i);
-    if (code <= 0x1f || code === 0x7f || value[i] === ";") {
-      throw new Error(`Invalid cookie ${attributeName} value: ${JSON.stringify(value)}`);
-    }
-  }
-}
-
-// ---------------------------------------------------------------------------
 // RequestCookies implementation
 // ---------------------------------------------------------------------------
 
@@ -922,22 +897,7 @@ class RequestCookies {
     // Update the local cookie map
     this._cookies.set(cookieName, cookieValue);
 
-    // Build Set-Cookie header string
-    const parts = [`${cookieName}=${encodeURIComponent(cookieValue)}`];
-    const path = opts?.path ?? "/";
-    validateCookieAttributeValue(path, "Path");
-    parts.push(`Path=${path}`);
-    if (opts?.domain) {
-      validateCookieAttributeValue(opts.domain, "Domain");
-      parts.push(`Domain=${opts.domain}`);
-    }
-    if (opts?.maxAge !== undefined) parts.push(`Max-Age=${opts.maxAge}`);
-    if (opts?.expires) parts.push(`Expires=${opts.expires.toUTCString()}`);
-    if (opts?.httpOnly) parts.push("HttpOnly");
-    if (opts?.secure) parts.push("Secure");
-    if (opts?.sameSite) parts.push(`SameSite=${opts.sameSite}`);
-
-    _getState().pendingSetCookies.push(parts.join("; "));
+    _getState().pendingSetCookies.push(serializeSetCookie(cookieName, cookieValue, opts));
     return this;
   }
 

--- a/packages/vinext/src/shims/internal/cookie-serialize.ts
+++ b/packages/vinext/src/shims/internal/cookie-serialize.ts
@@ -1,0 +1,83 @@
+/**
+ * Shared Set-Cookie serialization for the next/headers and next/server shims.
+ *
+ * Two call sites — `cookies().set()` in headers.ts and `ResponseCookies.set()`
+ * in server.ts — produce identical Set-Cookie header strings. Keep the
+ * encoding, attribute order, and validation in one place so subtle RFC 6265
+ * details (escaping, attribute ordering, etc.) cannot drift between them.
+ *
+ * Note: this is a value-encoding helper for response cookies only. The
+ * request `Cookie:` header serialization in `RequestCookies._serialize`
+ * (server.ts) intentionally lives separately — it builds a different format
+ * (no attributes, just `name=value; name=value`) and shouldn't share this
+ * code.
+ */
+
+export type SerializeSetCookieOptions = {
+  path?: string;
+  domain?: string;
+  maxAge?: number;
+  expires?: Date;
+  httpOnly?: boolean;
+  secure?: boolean;
+  sameSite?: "Strict" | "Lax" | "None";
+};
+
+/**
+ * RFC 6265 §4.1.1: cookie-name is a token (RFC 2616 §2.2).
+ * Allowed: any visible ASCII (0x21-0x7E) except separators: ()<>@,;:\"/[]?={}
+ */
+const VALID_COOKIE_NAME_RE =
+  /^[\x21\x23-\x27\x2A\x2B\x2D\x2E\x30-\x39\x41-\x5A\x5E-\x7A\x7C\x7E]+$/;
+
+export function validateCookieName(name: string): void {
+  if (!name || !VALID_COOKIE_NAME_RE.test(name)) {
+    throw new Error(`Invalid cookie name: ${JSON.stringify(name)}`);
+  }
+}
+
+/**
+ * Validate cookie attribute values (path, domain) to prevent injection
+ * via semicolons, newlines, or other control characters.
+ */
+export function validateCookieAttributeValue(value: string, attributeName: string): void {
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i);
+    if (code <= 0x1f || code === 0x7f || value[i] === ";") {
+      throw new Error(`Invalid cookie ${attributeName} value: ${JSON.stringify(value)}`);
+    }
+  }
+}
+
+/**
+ * Build a Set-Cookie header string from a cookie name, value, and attributes.
+ *
+ * - Encodes the value with `encodeURIComponent`.
+ * - Defaults `Path` to `/` (matching @edge-runtime/cookies and Next.js).
+ * - Validates path/domain to reject control characters and semicolons.
+ * - Emits attributes in the order: Path, Domain, Max-Age, Expires, HttpOnly,
+ *   Secure, SameSite.
+ *
+ * The caller is responsible for validating the cookie name (typically before
+ * mutating any internal state) via `validateCookieName`.
+ */
+export function serializeSetCookie(
+  name: string,
+  value: string,
+  options?: SerializeSetCookieOptions,
+): string {
+  const parts = [`${name}=${encodeURIComponent(value)}`];
+  const path = options?.path ?? "/";
+  validateCookieAttributeValue(path, "Path");
+  parts.push(`Path=${path}`);
+  if (options?.domain) {
+    validateCookieAttributeValue(options.domain, "Domain");
+    parts.push(`Domain=${options.domain}`);
+  }
+  if (options?.maxAge !== undefined) parts.push(`Max-Age=${options.maxAge}`);
+  if (options?.expires) parts.push(`Expires=${options.expires.toUTCString()}`);
+  if (options?.httpOnly) parts.push("HttpOnly");
+  if (options?.secure) parts.push("Secure");
+  if (options?.sameSite) parts.push(`SameSite=${options.sameSite}`);
+  return parts.join("; ");
+}

--- a/packages/vinext/src/shims/internal/cookie-serialize.ts
+++ b/packages/vinext/src/shims/internal/cookie-serialize.ts
@@ -13,7 +13,7 @@
  * code.
  */
 
-export type SerializeSetCookieOptions = {
+type SerializeSetCookieOptions = {
   path?: string;
   domain?: string;
   maxAge?: number;

--- a/packages/vinext/src/shims/server.ts
+++ b/packages/vinext/src/shims/server.ts
@@ -10,6 +10,7 @@
  */
 
 import { encodeMiddlewareRequestHeaders } from "../server/middleware-request-headers.js";
+import { serializeSetCookie, validateCookieName } from "./internal/cookie-serialize.js";
 import { parseCookieHeader } from "./internal/parse-cookie-header.js";
 import { getRequestExecutionContext } from "./request-context.js";
 import { assertSafeNavigationUrl } from "./url-safety.js";
@@ -645,28 +646,6 @@ export function sealRequestCookies(cookies: RequestCookies): RequestCookies {
   });
 }
 
-/**
- * RFC 6265 §4.1.1: cookie-name is a token (RFC 2616 §2.2).
- * Allowed: any visible ASCII (0x21-0x7E) except separators: ()<>@,;:\"/[]?={}
- */
-const VALID_COOKIE_NAME_RE =
-  /^[\x21\x23-\x27\x2A\x2B\x2D\x2E\x30-\x39\x41-\x5A\x5E-\x7A\x7C\x7E]+$/;
-
-function validateCookieName(name: string): void {
-  if (!name || !VALID_COOKIE_NAME_RE.test(name)) {
-    throw new Error(`Invalid cookie name: ${JSON.stringify(name)}`);
-  }
-}
-
-function validateCookieAttributeValue(value: string, attributeName: string): void {
-  for (let i = 0; i < value.length; i++) {
-    const code = value.charCodeAt(i);
-    if (code <= 0x1f || code === 0x7f || value[i] === ";") {
-      throw new Error(`Invalid cookie ${attributeName} value: ${JSON.stringify(value)}`);
-    }
-  }
-}
-
 export class ResponseCookies {
   private _headers: Headers;
   /** Internal map keyed by cookie name — single source of truth. */
@@ -700,21 +679,8 @@ export class ResponseCookies {
     const [name, value, opts] = parseCookieSetArgs(args);
     validateCookieName(name);
 
-    const parts = [`${name}=${encodeURIComponent(value)}`];
-    const path = opts?.path ?? "/";
-    validateCookieAttributeValue(path, "Path");
-    parts.push(`Path=${path}`);
-    if (opts?.domain) {
-      validateCookieAttributeValue(opts.domain, "Domain");
-      parts.push(`Domain=${opts.domain}`);
-    }
-    if (opts?.maxAge !== undefined) parts.push(`Max-Age=${opts.maxAge}`);
-    if (opts?.expires) parts.push(`Expires=${opts.expires.toUTCString()}`);
-    if (opts?.httpOnly) parts.push("HttpOnly");
-    if (opts?.secure) parts.push("Secure");
-    if (opts?.sameSite) parts.push(`SameSite=${opts.sameSite}`);
-
-    this._parsed.set(name, { serialized: parts.join("; "), entry: { name, value } });
+    const serialized = serializeSetCookie(name, value, opts);
+    this._parsed.set(name, { serialized, entry: { name, value } });
     this._syncHeaders();
     return this;
   }


### PR DESCRIPTION
## Summary

Extract the shared Set-Cookie serialization from the next/headers and next/server shims into a single helper at `packages/vinext/src/shims/internal/cookie-serialize.ts`. Follow-up to #1049.

The two call sites — `cookies().set()` in `headers.ts` and `ResponseCookies.set()` in `server.ts` — were producing byte-for-byte identical Set-Cookie strings via copy-pasted code (same `encodeURIComponent(value)`, same default `Path=/`, same attribute order: Path → Domain → Max-Age → Expires → HttpOnly → Secure → SameSite, same validators). Pure refactor — no behavior change.

The third candidate site, `RequestCookies._serialize` in `server.ts:574`, builds a request `Cookie:` header (`name=value; name=value`, no attributes) — different format, intentionally left alone.

## What moved

`packages/vinext/src/shims/internal/cookie-serialize.ts` (new):
- `serializeSetCookie(name, value, options)` — builds the full Set-Cookie value string
- `validateCookieName(name)` — RFC 6265 §4.1.1 token validator
- `validateCookieAttributeValue(value, attr)` — control-char/semicolon guard

The validators were also duplicated verbatim across both files; consolidating them avoids subtle drift.

## Why a separate module instead of importing across shims

`server.ts` deliberately avoids static-importing `headers.ts` because of a Vite "use cache" transform issue (existing comment in `server.ts:18-30`). The new helper lives under `internal/` alongside `parse-cookie-header.ts`, mirroring the existing pattern.

## Files changed

- `packages/vinext/src/shims/internal/cookie-serialize.ts` (new, 84 lines)
- `packages/vinext/src/shims/headers.ts` (-43 lines, unchanged behavior)
- `packages/vinext/src/shims/server.ts` (-37 lines, unchanged behavior)

Net: 9 insertions, 79 deletions across the two existing files.

## Test plan

- [x] `pnpm vp test run tests/app-router.test.ts` — 308 tests pass
- [x] `pnpm vp test run tests/pages-router.test.ts` — 200 tests pass (one pre-existing `afterAll` timeout in the unrelated `allowedDevOrigins` suite, reproduces on `main` without these changes)
- [x] `pnpm vp test run tests/shims.test.ts tests/app-route-handler-execution.test.ts tests/app-page-execution.test.ts tests/api-handler.test.ts` — 912 tests pass
- [x] `pnpm tsc --noEmit` (in `packages/vinext`) — clean
- [x] `pnpm fmt --write` on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)