### PR TITLE
refactor(routing): dedupe findFileWithExtensions helper

### DIFF
--- a/packages/vinext/src/build/prerender.ts
+++ b/packages/vinext/src/build/prerender.ts
@@ -31,7 +31,11 @@ import {
   _consumeRequestScopedCacheLife,
 } from "vinext/shims/cache";
 import { runWithHeadersContext, headersContextFromRequest } from "vinext/shims/headers";
-import { createValidFileMatcher, type ValidFileMatcher } from "../routing/file-matcher.js";
+import {
+  createValidFileMatcher,
+  findFileWithExtensions,
+  type ValidFileMatcher,
+} from "../routing/file-matcher.js";
 import { startProdServer } from "../server/prod-server.js";
 import { readPrerenderSecret } from "./server-manifest.js";
 export { readPrerenderSecret } from "./server-manifest.js";
@@ -204,10 +208,6 @@ async function runWithConcurrency<T, R>(
 }
 
 // ─── Helpers (shared with static-export.ts) ───────────────────────────────────
-
-function findFileWithExtensions(basePath: string, matcher: ValidFileMatcher): boolean {
-  return matcher.dottedExtensions.some((ext) => fs.existsSync(basePath + ext));
-}
 
 /**
  * Build a URL path from a route pattern and params.

--- a/packages/vinext/src/build/prerender.ts
+++ b/packages/vinext/src/build/prerender.ts
@@ -31,11 +31,7 @@ import {
   _consumeRequestScopedCacheLife,
 } from "vinext/shims/cache";
 import { runWithHeadersContext, headersContextFromRequest } from "vinext/shims/headers";
-import {
-  createValidFileMatcher,
-  findFileWithExtensions,
-  type ValidFileMatcher,
-} from "../routing/file-matcher.js";
+import { createValidFileMatcher, findFileWithExtensions } from "../routing/file-matcher.js";
 import { startProdServer } from "../server/prod-server.js";
 import { readPrerenderSecret } from "./server-manifest.js";
 export { readPrerenderSecret } from "./server-manifest.js";

--- a/packages/vinext/src/routing/file-matcher.ts
+++ b/packages/vinext/src/routing/file-matcher.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import { glob } from "node:fs/promises";
 
 const DEFAULT_PAGE_EXTENSIONS = ["tsx", "ts", "jsx", "js"] as const;
@@ -82,6 +83,11 @@ export function createValidFileMatcher(
       return filePath.replace(extensionRegex, "");
     },
   };
+}
+
+/** Check if a file exists with any configured page extension. */
+export function findFileWithExtensions(basePath: string, matcher: ValidFileMatcher): boolean {
+  return matcher.dottedExtensions.some((ext) => existsSync(basePath + ext));
 }
 
 /**

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -29,11 +29,14 @@ import { createInlineScriptTag, createNonceAttribute, safeJsonStringify } from "
 import { getScriptNonceFromNodeHeaderSources } from "./csp.js";
 import { parseQueryString as parseQuery } from "../utils/query.js";
 import path from "node:path";
-import fs from "node:fs";
 import React from "react";
 import { renderToReadableStream } from "react-dom/server.edge";
 import { logRequest, now } from "./request-log.js";
-import { createValidFileMatcher, type ValidFileMatcher } from "../routing/file-matcher.js";
+import {
+  createValidFileMatcher,
+  findFileWithExtensions,
+  type ValidFileMatcher,
+} from "../routing/file-matcher.js";
 import {
   extractLocaleFromUrl as extractLocaleFromUrlShared,
   detectLocaleFromAcceptLanguage,
@@ -195,11 +198,6 @@ async function streamPageToResponse(
 
   // Write the document suffix (closing tags, scripts)
   res.end(suffix);
-}
-
-/** Check if a file exists with any configured page extension. */
-function findFileWithExtensions(basePath: string, matcher: ValidFileMatcher): boolean {
-  return matcher.dottedExtensions.some((ext) => fs.existsSync(basePath + ext));
 }
 
 /**


### PR DESCRIPTION
## Summary

- Extract the `matcher.dottedExtensions.some((ext) => existsSync(basePath + ext))` one-liner into a single shared helper in `routing/file-matcher.ts`.
- Replace the two identical local copies in `build/prerender.ts` and `server/dev-server.ts` with the shared export.
- Pure refactor: same return type, same semantics. Follow-up to #1058.

## Files changed

- `packages/vinext/src/routing/file-matcher.ts` — add `findFileWithExtensions` export (+ `existsSync` import).
- `packages/vinext/src/build/prerender.ts` — drop local helper, import shared one.
- `packages/vinext/src/server/dev-server.ts` — drop local helper, import shared one. Removed now-unused `import fs from "node:fs"`.

## Test plan

- [x] `pnpm vp test run tests/app-router.test.ts tests/pages-router.test.ts` (508 tests pass)
- [x] `pnpm fmt --write` on touched files
- [x] `pnpm knip` (clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)