### PR TITLE
refactor(build): dedupe JSON file safe-read pattern

### DIFF
--- a/packages/vinext/src/build/server-manifest.ts
+++ b/packages/vinext/src/build/server-manifest.ts
@@ -7,7 +7,7 @@
  */
 
 import path from "node:path";
-import fs from "node:fs";
+import { readJsonFile } from "../utils/safe-json-file.js";
 
 /**
  * Read the prerender secret from `vinext-server.json` in `serverDir`.
@@ -18,10 +18,6 @@ import fs from "node:fs";
  */
 export function readPrerenderSecret(serverDir: string): string | undefined {
   const manifestPath = path.join(serverDir, "vinext-server.json");
-  try {
-    const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf-8"));
-    return manifest.prerenderSecret as string | undefined;
-  } catch {
-    return undefined;
-  }
+  const manifest = readJsonFile<{ prerenderSecret?: string }>(manifestPath);
+  return manifest?.prerenderSecret;
 }

--- a/packages/vinext/src/build/standalone.ts
+++ b/packages/vinext/src/build/standalone.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { createRequire } from "node:module";
+import { readJsonFile } from "../utils/safe-json-file.js";
 import { resolveVinextPackageRoot } from "../utils/vinext-root.js";
 
 type PackageJson = {
@@ -61,14 +62,15 @@ function readServerExternalsManifest(serverDir: string): string[] {
   if (!fs.existsSync(manifestPath)) {
     return [];
   }
-  try {
-    return JSON.parse(fs.readFileSync(manifestPath, "utf-8")) as string[];
-  } catch (err) {
-    console.warn(
-      `[vinext] Warning: failed to parse ${manifestPath}, proceeding without externals manifest: ${String(err)}`,
-    );
-    return [];
-  }
+  return (
+    readJsonFile<string[]>(manifestPath, {
+      onError: (err) => {
+        console.warn(
+          `[vinext] Warning: failed to parse ${manifestPath}, proceeding without externals manifest: ${String(err)}`,
+        );
+      },
+    }) ?? []
+  );
 }
 
 function resolvePackageJsonPath(packageName: string, resolver: NodeRequire): string | null {

--- a/packages/vinext/src/utils/safe-json-file.ts
+++ b/packages/vinext/src/utils/safe-json-file.ts
@@ -1,0 +1,24 @@
+import fs from "node:fs";
+
+/**
+ * Read and parse a JSON file, returning `null` if the file is missing,
+ * unreadable, or contains invalid JSON.
+ *
+ * Pass `onError` to log/observe failures while still receiving `null`. The
+ * callback is invoked for any thrown error from `readFileSync` or
+ * `JSON.parse` (e.g. `ENOENT`, syntax errors).
+ *
+ * Callers that need a default value other than `null` should map the result:
+ *   `readJsonFile<string[]>(p) ?? []`
+ */
+export function readJsonFile<T>(
+  filePath: string,
+  options?: { onError?: (err: unknown) => void },
+): T | null {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, "utf-8")) as T;
+  } catch (err) {
+    options?.onError?.(err);
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

Follow-up to #1058. Extracts the repeated `try { JSON.parse(readFileSync(...)) } catch` pattern from build pipeline files into a single shared helper.

New helper: `packages/vinext/src/utils/safe-json-file.ts`

```ts
readJsonFile<T>(path: string, options?: { onError?: (err: unknown) => void }): T | null
```

Returns `null` on any read/parse failure. Optional `onError` lets callers log/observe errors while still receiving `null`. Callers map `null` to whatever fallback they need (`?? []`, `?? undefined`, etc.).

## Files changed

- `packages/vinext/src/utils/safe-json-file.ts` — new helper.
- `packages/vinext/src/build/server-manifest.ts` — `readPrerenderSecret` now uses `readJsonFile`. Public signature unchanged (`string | undefined`).
- `packages/vinext/src/build/standalone.ts` — `readServerExternalsManifest` now uses `readJsonFile` with the existing `onError` warning preserved. The `existsSync` gate is kept so an existing-but-malformed file still triggers the warning.

## Subtle differences between the original sites

- `readPrerenderSecret` swallowed errors silently and returned `undefined` — preserved by mapping the helper's `null` to `undefined` via optional chaining on the parsed object.
- `readServerExternalsManifest` logged via `console.warn` and returned `[]` — preserved by passing an `onError` callback and using `?? []`.
- `readPackageJson` in `standalone.ts` is **not** the same pattern — it is a thin parse wrapper with no try/catch and no fallback (it propagates errors). Left untouched to preserve its throwing semantics; callers rely on it.

## Test plan

- [x] `pnpm vp test run tests/app-router.test.ts tests/pages-router.test.ts` — 508 passed
- [x] `pnpm fmt --write` on touched files
- [x] `pnpm knip` — clean (no unused exports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)