### PR TITLE
refactor(server): dedupe action/page/route-handler error response building

### DIFF
--- a/packages/vinext/src/server/app-page-execution.ts
+++ b/packages/vinext/src/server/app-page-execution.ts
@@ -2,6 +2,7 @@ import type { LayoutFlags } from "./app-elements.js";
 import type { ClassificationReason } from "../build/layout-classification-types.js";
 import { createRscRedirectLocation } from "./app-rsc-cache-busting.js";
 import { mergeMiddlewareResponseHeaders } from "./middleware-response-headers.js";
+import { parseNextHttpErrorDigest, parseNextRedirectDigest } from "./next-error-digest.js";
 
 export type { LayoutFlags };
 export type { ClassificationReason };
@@ -130,19 +131,20 @@ export function resolveAppPageSpecialError(error: unknown): AppPageSpecialError 
 
   const digest = String(error.digest);
 
-  if (digest.startsWith("NEXT_REDIRECT;")) {
-    const parts = digest.split(";");
+  const redirect = parseNextRedirectDigest(digest);
+  if (redirect) {
     return {
       kind: "redirect",
-      location: decodeURIComponent(parts[2]),
-      statusCode: parts[3] ? parseInt(parts[3], 10) : 307,
+      location: redirect.url,
+      statusCode: redirect.status,
     };
   }
 
-  if (digest === "NEXT_NOT_FOUND" || digest.startsWith("NEXT_HTTP_ERROR_FALLBACK;")) {
+  const httpError = parseNextHttpErrorDigest(digest);
+  if (httpError) {
     return {
       kind: "http-access-fallback",
-      statusCode: digest === "NEXT_NOT_FOUND" ? 404 : parseInt(digest.split(";")[1], 10),
+      statusCode: httpError.status,
     };
   }
 

--- a/packages/vinext/src/server/app-route-handler-policy.ts
+++ b/packages/vinext/src/server/app-route-handler-policy.ts
@@ -4,6 +4,7 @@ import {
   type RouteHandlerHttpMethod,
   type RouteHandlerModule,
 } from "./app-route-handler-runtime.js";
+import { parseNextHttpErrorDigest, parseNextRedirectDigest } from "./next-error-digest.js";
 
 export type AppRouteHandlerModule = {
   dynamic?: string;
@@ -177,20 +178,20 @@ export function resolveAppRouteHandlerSpecialError(
   }
 
   const digest = String(error.digest);
-  if (digest.startsWith("NEXT_REDIRECT;")) {
-    const parts = digest.split(";");
-    const redirectUrl = decodeURIComponent(parts[2]);
+  const redirect = parseNextRedirectDigest(digest);
+  if (redirect) {
     return {
       kind: "redirect",
-      location: new URL(redirectUrl, requestUrl).toString(),
-      statusCode: options?.isAction ? 303 : parts[3] ? parseInt(parts[3], 10) : 307,
+      location: new URL(redirect.url, requestUrl).toString(),
+      statusCode: options?.isAction ? 303 : redirect.status,
     };
   }
 
-  if (digest === "NEXT_NOT_FOUND" || digest.startsWith("NEXT_HTTP_ERROR_FALLBACK;")) {
+  const httpError = parseNextHttpErrorDigest(digest);
+  if (httpError) {
     return {
       kind: "status",
-      statusCode: digest === "NEXT_NOT_FOUND" ? 404 : parseInt(digest.split(";")[1], 10),
+      statusCode: httpError.status,
     };
   }
 

--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -3,6 +3,11 @@ import { type FetchCacheMode, setCurrentFetchCacheMode } from "vinext/shims/fetc
 import { VINEXT_RSC_VARY_HEADER } from "./app-rsc-cache-busting.js";
 import { resolveAppPageActionRerenderTarget } from "./app-page-request.js";
 import { mergeMiddlewareResponseHeaders } from "./middleware-response-headers.js";
+import {
+  getNextErrorDigest,
+  parseNextHttpErrorDigest,
+  parseNextRedirectDigest,
+} from "./next-error-digest.js";
 import { validateCsrfOrigin, validateServerActionPayload } from "./request-pipeline.js";
 import {
   createServerActionNotFoundResponse,
@@ -243,40 +248,27 @@ export async function readActionFormDataWithLimit(
   }).formData();
 }
 
-function getErrorDigest(error: unknown): string | null {
-  if (!error || typeof error !== "object" || !("digest" in error)) {
-    return null;
-  }
-
-  return String(error.digest);
-}
-
 function getActionControlResponse(error: unknown): ActionControlResponse | null {
-  const digest = getErrorDigest(error);
+  const digest = getNextErrorDigest(error);
   if (!digest) return null;
 
-  if (digest.startsWith("NEXT_REDIRECT;")) {
-    const parts = digest.split(";");
-    const encodedUrl = parts[2];
-    if (!encodedUrl) {
-      return null;
-    }
-
+  const redirect = parseNextRedirectDigest(digest);
+  if (redirect) {
     return {
       kind: "redirect",
-      url: decodeURIComponent(encodedUrl),
+      url: redirect.url,
     };
   }
 
-  if (digest === "NEXT_NOT_FOUND" || digest.startsWith("NEXT_HTTP_ERROR_FALLBACK;")) {
-    const statusCode = digest === "NEXT_NOT_FOUND" ? 404 : parseInt(digest.split(";")[1], 10);
-    if (!Number.isInteger(statusCode)) {
+  const httpError = parseNextHttpErrorDigest(digest);
+  if (httpError) {
+    if (!Number.isInteger(httpError.status)) {
       return null;
     }
 
     return {
       kind: "status",
-      statusCode,
+      statusCode: httpError.status,
     };
   }
 
@@ -284,27 +276,26 @@ function getActionControlResponse(error: unknown): ActionControlResponse | null 
 }
 
 function getActionRedirect(error: unknown): AppServerActionRedirect | null {
-  const digest = getErrorDigest(error);
-  if (!digest?.startsWith("NEXT_REDIRECT;")) {
-    return null;
-  }
+  const digest = getNextErrorDigest(error);
+  if (!digest) return null;
 
-  const parts = digest.split(";");
-  const encodedUrl = parts[2];
-  if (!encodedUrl) {
-    return null;
-  }
+  const redirect = parseNextRedirectDigest(digest);
+  if (!redirect) return null;
 
   return {
-    status: parts[3] ? parseInt(parts[3], 10) : 307,
-    type: parts[1] || "push",
-    url: decodeURIComponent(encodedUrl),
+    status: redirect.status,
+    type: redirect.type,
+    url: redirect.url,
   };
 }
 
 function isActionHttpFallback(error: unknown): boolean {
-  const digest = getErrorDigest(error);
-  return digest === "NEXT_NOT_FOUND" || digest?.startsWith("NEXT_HTTP_ERROR_FALLBACK;") === true;
+  const digest = getNextErrorDigest(error);
+  return digest !== null && parseNextHttpErrorDigest(digest) !== null;
+}
+
+function payloadTooLargeResponse(): Response {
+  return new Response("Payload Too Large", { status: 413 });
 }
 
 function createServerActionErrorResponse(
@@ -377,7 +368,7 @@ export async function handleProgressiveServerActionRequest(
   const contentLength = parseInt(options.request.headers.get("content-length") || "0", 10);
   if (contentLength > options.maxActionBodySize) {
     options.clearRequestContext();
-    return new Response("Payload Too Large", { status: 413 });
+    return payloadTooLargeResponse();
   }
 
   try {
@@ -393,7 +384,7 @@ export async function handleProgressiveServerActionRequest(
     } catch (error) {
       if (isRequestBodyTooLarge(error)) {
         options.clearRequestContext();
-        return new Response("Payload Too Large", { status: 413 });
+        return payloadTooLargeResponse();
       }
       throw error;
     }
@@ -506,7 +497,7 @@ export async function handleServerActionRscRequest<
   const contentLength = parseInt(options.request.headers.get("content-length") || "0", 10);
   if (contentLength > options.maxActionBodySize) {
     options.clearRequestContext();
-    return new Response("Payload Too Large", { status: 413 });
+    return payloadTooLargeResponse();
   }
 
   try {
@@ -518,7 +509,7 @@ export async function handleServerActionRscRequest<
     } catch (error) {
       if (isRequestBodyTooLarge(error)) {
         options.clearRequestContext();
-        return new Response("Payload Too Large", { status: 413 });
+        return payloadTooLargeResponse();
       }
       throw error;
     }

--- a/packages/vinext/src/server/next-error-digest.ts
+++ b/packages/vinext/src/server/next-error-digest.ts
@@ -1,0 +1,75 @@
+/**
+ * Helpers for parsing Next.js error `digest` strings shared across the App
+ * Router execution paths (server actions, page renders, route handlers).
+ *
+ * Next.js encodes special control flow as thrown errors carrying a `digest`
+ * field with one of these formats:
+ *  - `NEXT_REDIRECT;<type>;<encodedUrl>;<status>` — `redirect()` / `permanentRedirect()`
+ *  - `NEXT_NOT_FOUND` — `notFound()`
+ *  - `NEXT_HTTP_ERROR_FALLBACK;<status>` — `forbidden()` / `unauthorized()` / etc.
+ *
+ * Each call site needs slightly different post-processing (URL resolution
+ * against the request, 303-vs-307 status overrides for actions, etc.), so
+ * these helpers only handle the parsing — callers shape the result.
+ */
+
+type NextRedirectDigest = {
+  status: number;
+  type: string;
+  url: string;
+};
+
+type NextHttpErrorDigest = {
+  status: number;
+};
+
+/**
+ * Pulls a stringified `digest` off an unknown thrown value, or returns null
+ * when the value is not a digest-bearing error.
+ */
+export function getNextErrorDigest(error: unknown): string | null {
+  if (!error || typeof error !== "object" || !("digest" in error)) {
+    return null;
+  }
+
+  return String(error.digest);
+}
+
+/**
+ * Parses a `NEXT_REDIRECT;<type>;<encodedUrl>;<status>` digest. Returns null
+ * when the digest is not a redirect digest or the encoded URL segment is
+ * missing. The `url` is decoded with `decodeURIComponent`; the `status`
+ * defaults to 307 when omitted; the `type` defaults to "push".
+ */
+export function parseNextRedirectDigest(digest: string): NextRedirectDigest | null {
+  if (!digest.startsWith("NEXT_REDIRECT;")) {
+    return null;
+  }
+
+  const parts = digest.split(";");
+  const encodedUrl = parts[2];
+  if (!encodedUrl) {
+    return null;
+  }
+
+  return {
+    status: parts[3] ? parseInt(parts[3], 10) : 307,
+    type: parts[1] || "push",
+    url: decodeURIComponent(encodedUrl),
+  };
+}
+
+/**
+ * Parses a `NEXT_NOT_FOUND` or `NEXT_HTTP_ERROR_FALLBACK;<status>` digest.
+ * Returns `{ status: 404 }` for `NEXT_NOT_FOUND` and the parsed status code
+ * for the fallback form. Returns null otherwise.
+ */
+export function parseNextHttpErrorDigest(digest: string): NextHttpErrorDigest | null {
+  if (digest === "NEXT_NOT_FOUND") {
+    return { status: 404 };
+  }
+  if (digest.startsWith("NEXT_HTTP_ERROR_FALLBACK;")) {
+    return { status: parseInt(digest.split(";")[1], 10) };
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary

- Extract the four byte-identical `new Response(\"Payload Too Large\", { status: 413 })` calls in `app-server-action-execution.ts` into a local `payloadTooLargeResponse()` helper.
- Extract the three near-identical NEXT_REDIRECT / NEXT_NOT_FOUND / NEXT_HTTP_ERROR_FALLBACK `error.digest` parsers into a new shared module `packages/vinext/src/server/next-error-digest.ts` exposing `getNextErrorDigest`, `parseNextRedirectDigest`, and `parseNextHttpErrorDigest`.

Follow-up to #1058.

## Files changed

- `packages/vinext/src/server/next-error-digest.ts` (new) — shared digest parsing helpers.
- `packages/vinext/src/server/app-server-action-execution.ts` — uses the new helpers in `getActionControlResponse`, `getActionRedirect`, and `isActionHttpFallback`; replaces 4× inline 413 responses with a local `payloadTooLargeResponse()` (only used in this file).
- `packages/vinext/src/server/app-page-execution.ts` — `resolveAppPageSpecialError` now uses the shared parsers.
- `packages/vinext/src/server/app-route-handler-policy.ts` — `resolveAppRouteHandlerSpecialError` now uses the shared parsers.

## Preserved per-call-site behaviour

The shared parsers return only the raw shape (`{ type, url, status }` for redirects, `{ status }` for HTTP error fallbacks). Each caller still owns its own post-processing:

- `app-server-action-execution.ts` keeps the `Number.isInteger(statusCode)` guard for HTTP error digests in `getActionControlResponse`.
- `app-server-action-execution.ts` `getActionRedirect` keeps the full `{ status, type, url }` shape (only this site uses the redirect `type`).
- `app-route-handler-policy.ts` keeps `new URL(redirectUrl, requestUrl).toString()` resolution and the `isAction ? 303 : redirect.status` override.
- `app-page-execution.ts` keeps the basePath-and-cookie merging at the call site.

## Minor unification

`parseNextRedirectDigest` returns `null` when the encoded URL segment is missing — matching the existing guard in `app-server-action-execution.ts`. The page and route-handler call sites previously would have thrown `URIError` from `decodeURIComponent(undefined)` for a malformed `NEXT_REDIRECT;` digest with no URL; they now treat it as not-a-redirect and let the error propagate. This case is unreachable for any digest Next.js actually emits.

## Test plan

- [x] `pnpm vp test run tests/app-router.test.ts` — 308 tests pass
- [x] `pnpm fmt --write` on touched files — clean
- [x] `pnpm knip` — clean
- [x] `tsc --noEmit` on the vinext package — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)