### PR TITLE
refactor(entries): drop dead locale helpers and dedupe path normalization

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -8,7 +8,7 @@
  * Previously housed in server/app-dev-server.ts.
  */
 import { buildAppRscManifestCode } from "./app-rsc-manifest.js";
-import { resolveEntryPath } from "./runtime-entry-module.js";
+import { resolveEntryPath, normalizePathSeparators } from "./runtime-entry-module.js";
 import type {
   NextHeader,
   NextI18nConfig,
@@ -180,10 +180,10 @@ import { createElement } from "react";
 import { getNavigationContext as _getNavigationContext } from "next/navigation";
 import { headersContextFromRequest, getDraftModeCookieHeader, getAndClearPendingCookies, consumeDynamicUsage, consumeInvalidDynamicUsageError, setHeadersAccessPhase } from "next/headers";
 import { mergeMetadata, resolveModuleMetadata, mergeViewport, resolveModuleViewport } from "vinext/metadata";
-${middlewarePath ? `import * as middlewareModule from ${JSON.stringify(middlewarePath.replace(/\\/g, "/"))};` : ""}
+${middlewarePath ? `import * as middlewareModule from ${JSON.stringify(normalizePathSeparators(middlewarePath))};` : ""}
 ${
   instrumentationPath
-    ? `import * as _instrumentation from ${JSON.stringify(instrumentationPath.replace(/\\/g, "/"))};
+    ? `import * as _instrumentation from ${JSON.stringify(normalizePathSeparators(instrumentationPath))};
 import { ensureInstrumentationRegistered as __ensureInstrumentationRegistered } from ${JSON.stringify(instrumentationRuntimePath)};`
     : ""
 }

--- a/packages/vinext/src/entries/app-rsc-manifest.ts
+++ b/packages/vinext/src/entries/app-rsc-manifest.ts
@@ -1,6 +1,7 @@
 import type { AppRoute } from "../routing/app-router.js";
 import { createMetadataRouteEntriesSource } from "../server/metadata-route-build-data.js";
 import type { MetadataFileRoute } from "../server/metadata-routes.js";
+import { normalizePathSeparators } from "./runtime-entry-module.js";
 
 type AppRscManifestCode = {
   imports: string[];
@@ -39,7 +40,7 @@ function createImportAllocator(): ImportAllocator {
       if (existing) return existing;
 
       const varName = `mod_${importIdx++}`;
-      const absPath = filePath.replace(/\\/g, "/");
+      const absPath = normalizePathSeparators(filePath);
       imports.push(`import * as ${varName} from ${JSON.stringify(absPath)};`);
       importMap.set(filePath, varName);
       return varName;

--- a/packages/vinext/src/entries/pages-client-entry.ts
+++ b/packages/vinext/src/entries/pages-client-entry.ts
@@ -17,6 +17,7 @@ import {
 import { createValidFileMatcher } from "../routing/file-matcher.js";
 import { type ResolvedNextConfig } from "../config/next-config.js";
 import { findFileWithExts } from "./pages-entry-helpers.js";
+import { normalizePathSeparators } from "./runtime-entry-module.js";
 
 export async function generateClientEntry(
   pagesDir: string,
@@ -32,7 +33,7 @@ export async function generateClientEntry(
   // Keys must use Next.js bracket format (e.g. "/user/[id]") to match
   // __NEXT_DATA__.page which is set via patternToNextFormat() during SSR.
   const loaderEntries = pageRoutes.map((r: Route) => {
-    const absPath = r.filePath.replace(/\\/g, "/");
+    const absPath = normalizePathSeparators(r.filePath);
     const nextFormatPattern = pagesPatternToNextFormat(r.pattern);
     // JSON.stringify safely escapes quotes, backslashes, and special chars in
     // both the route pattern and the absolute file path.
@@ -40,7 +41,7 @@ export async function generateClientEntry(
     return `  ${JSON.stringify(nextFormatPattern)}: () => import(${JSON.stringify(absPath)})`;
   });
 
-  const appFileBase = appFilePath?.replace(/\\/g, "/");
+  const appFileBase = appFilePath ? normalizePathSeparators(appFilePath) : undefined;
 
   return `
 import "vinext/instrumentation-client";

--- a/packages/vinext/src/entries/pages-server-entry.ts
+++ b/packages/vinext/src/entries/pages-server-entry.ts
@@ -7,7 +7,7 @@
  *
  * Extracted from index.ts.
  */
-import { resolveEntryPath } from "./runtime-entry-module.js";
+import { resolveEntryPath, normalizePathSeparators } from "./runtime-entry-module.js";
 import { pagesRouter, apiRouter, type Route } from "../routing/pages-router.js";
 import { createValidFileMatcher } from "../routing/file-matcher.js";
 import { type ResolvedNextConfig } from "../config/next-config.js";
@@ -45,18 +45,18 @@ export async function generateServerEntry(
   // Generate import statements using absolute paths since virtual
   // modules don't have a real file location for relative resolution.
   const pageImports = pageRoutes.map((r: Route, i: number) => {
-    const absPath = r.filePath.replace(/\\/g, "/");
+    const absPath = normalizePathSeparators(r.filePath);
     return `import * as page_${i} from ${JSON.stringify(absPath)};`;
   });
 
   const apiImports = apiRoutes.map((r: Route, i: number) => {
-    const absPath = r.filePath.replace(/\\/g, "/");
+    const absPath = normalizePathSeparators(r.filePath);
     return `import * as api_${i} from ${JSON.stringify(absPath)};`;
   });
 
   // Build the route table — include filePath for SSR manifest lookup
   const pageRouteEntries = pageRoutes.map((r: Route, i: number) => {
-    const absPath = r.filePath.replace(/\\/g, "/");
+    const absPath = normalizePathSeparators(r.filePath);
     return `  { pattern: ${JSON.stringify(r.pattern)}, patternParts: ${JSON.stringify(r.patternParts)}, isDynamic: ${r.isDynamic}, params: ${JSON.stringify(r.params)}, module: page_${i}, filePath: ${JSON.stringify(absPath)} }`;
   });
 
@@ -70,12 +70,12 @@ export async function generateServerEntry(
   const docFilePath = findFileWithExts(pagesDir, "_document", fileMatcher);
   const appImportCode =
     appFilePath !== null
-      ? `import { default as AppComponent } from ${JSON.stringify(appFilePath.replace(/\\/g, "/"))};`
+      ? `import { default as AppComponent } from ${JSON.stringify(normalizePathSeparators(appFilePath))};`
       : `const AppComponent = null;`;
 
   const docImportCode =
     docFilePath !== null
-      ? `import { default as DocumentComponent } from ${JSON.stringify(docFilePath.replace(/\\/g, "/"))};`
+      ? `import { default as DocumentComponent } from ${JSON.stringify(normalizePathSeparators(docFilePath))};`
       : `const DocumentComponent = null;`;
 
   // Serialize i18n config for embedding in the server entry
@@ -121,7 +121,7 @@ export async function generateServerEntry(
   // The onRequestError handler is stored on globalThis so it is visible across
   // all code within the Worker (same global scope).
   const instrumentationImportCode = instrumentationPath
-    ? `import * as _instrumentation from ${JSON.stringify(instrumentationPath.replace(/\\/g, "/"))};`
+    ? `import * as _instrumentation from ${JSON.stringify(normalizePathSeparators(instrumentationPath))};`
     : "";
 
   const instrumentationInitCode = instrumentationPath
@@ -140,7 +140,7 @@ if (typeof _instrumentation.onRequestError === "function") {
 
   // Generate middleware code if middleware.ts exists
   const middlewareImportCode = middlewarePath
-    ? `import * as middlewareModule from ${JSON.stringify(middlewarePath.replace(/\\/g, "/"))};`
+    ? `import * as middlewareModule from ${JSON.stringify(normalizePathSeparators(middlewarePath))};`
     : "";
 
   // The matcher config is read from the middleware module at request time.
@@ -407,43 +407,6 @@ function collectAssetTags(manifest, moduleIds, scriptNonce) {
     }
   }
   return tags.join("\\n  ");
-}
-
-// i18n helpers
-function extractLocale(url) {
-  if (!i18nConfig) return { locale: undefined, url, hadPrefix: false };
-  const pathname = url.split("?")[0];
-  const parts = pathname.split("/").filter(Boolean);
-  const query = url.includes("?") ? url.slice(url.indexOf("?")) : "";
-  if (parts.length > 0 && i18nConfig.locales.includes(parts[0])) {
-    const locale = parts[0];
-    const rest = "/" + parts.slice(1).join("/");
-    return { locale, url: (rest || "/") + query, hadPrefix: true };
-  }
-  return { locale: i18nConfig.defaultLocale, url, hadPrefix: false };
-}
-
-function detectLocaleFromHeaders(headers) {
-  if (!i18nConfig) return null;
-  const acceptLang = headers.get("accept-language");
-  if (!acceptLang) return null;
-  const langs = acceptLang.split(",").map(function(part) {
-    const pieces = part.trim().split(";");
-    const q = pieces[1] ? parseFloat(pieces[1].replace("q=", "")) : 1;
-    return { lang: pieces[0].trim().toLowerCase(), q: q };
-  }).sort(function(a, b) { return b.q - a.q; });
-  for (let k = 0; k < langs.length; k++) {
-    const lang = langs[k].lang;
-    for (let j = 0; j < i18nConfig.locales.length; j++) {
-      if (i18nConfig.locales[j].toLowerCase() === lang) return i18nConfig.locales[j];
-    }
-    const prefix = lang.split("-")[0];
-    for (let j = 0; j < i18nConfig.locales.length; j++) {
-      const loc = i18nConfig.locales[j].toLowerCase();
-      if (loc === prefix || loc.startsWith(prefix + "-")) return i18nConfig.locales[j];
-    }
-  }
-  return null;
 }
 
 export async function renderPage(request, url, manifest, ctx, middlewareHeaders) {

--- a/packages/vinext/src/entries/runtime-entry-module.ts
+++ b/packages/vinext/src/entries/runtime-entry-module.ts
@@ -2,18 +2,30 @@ import fs from "node:fs";
 import { fileURLToPath } from "node:url";
 
 /**
+ * Convert Windows-style backslash path separators to forward slashes.
+ *
+ * Generated entry modules embed absolute filesystem paths inside `import`
+ * statements. On Windows the OS-native paths use `\` which is invalid in JS
+ * module specifiers, so every entry generator normalizes paths through this
+ * helper before stringifying them into the emitted code.
+ */
+export function normalizePathSeparators(p: string): string {
+  return p.replace(/\\/g, "/");
+}
+
+/**
  * Resolve a sibling module path relative to a caller's `import.meta.url`,
  * returning a forward-slash path safe for embedding in generated code.
  *
  * This is the single place that owns the
- * `fileURLToPath(new URL(rel, base)).replace(/\\/g, "/")` idiom so callers
- * don't duplicate it.
+ * `fileURLToPath(new URL(rel, base))` + path-separator normalization idiom so
+ * callers don't duplicate it.
  *
  * @param rel  - Relative path to the target module (e.g. `"../server/foo.js"`)
  * @param base - The caller's `import.meta.url`
  */
 export function resolveEntryPath(rel: string, base: string): string {
-  return fileURLToPath(new URL(rel, base)).replace(/\\/g, "/");
+  return normalizePathSeparators(fileURLToPath(new URL(rel, base)));
 }
 
 /**


### PR DESCRIPTION
## Summary

Two small cleanups in the codegen-template entry files. Follow-up to #1058 and #1069.

### Drop dead locale helpers in `pages-server-entry.ts`
PR #1069 flagged `parseCookieLocaleFromHeader` (already gone — likely removed in #1058), `extractLocale`, and `detectLocaleFromHeaders` as suspected dead code in the generated Pages Router server entry. Verified across the entire repo (sources, tests, fixtures, generated template strings) that the two remaining helpers (`extractLocale`, `detectLocaleFromHeaders`) had no callers — the entry uses `resolvePagesI18nRequest` from `server/pages-i18n.ts` instead. Deleted both. (`detectLocaleFromHeaders` does still exist as an unrelated *exported* function in `server/dev-server.ts`, with its own tests — that one is untouched.)

### Dedupe path-separator normalization
The `path.replace(/\\/g, "/")` idiom — used to convert Windows-style backslash separators when embedding absolute paths into generated `import` statements — was duplicated 12 times across the entry files. Added a shared `normalizePathSeparators(p)` helper next to the existing `resolveEntryPath` in `entries/runtime-entry-module.ts` and used it everywhere. `resolveEntryPath` itself now also delegates to it. Only outer-level (build-time) occurrences were replaced; the in-template `pathname.replace(/\\/$/, "")` inside generated code (which runs in a different context) was left alone.

## Files changed

- `packages/vinext/src/entries/runtime-entry-module.ts` — added `normalizePathSeparators` export, `resolveEntryPath` reuses it
- `packages/vinext/src/entries/pages-server-entry.ts` — deleted dead `extractLocale` + `detectLocaleFromHeaders`; replaced 7 path-normalize calls
- `packages/vinext/src/entries/pages-client-entry.ts` — replaced 2 path-normalize calls
- `packages/vinext/src/entries/app-rsc-entry.ts` — replaced 2 path-normalize calls (inside the outer return-template's `${...}` interpolations, which evaluate at build time)
- `packages/vinext/src/entries/app-rsc-manifest.ts` — replaced 1 path-normalize call

Pure refactor + dead-code removal, no behavior change.

## Test plan

- [x] `pnpm vp test run tests/app-router.test.ts tests/pages-router.test.ts` — all 700 tests pass
- [x] `pnpm knip` — clean
- [x] `pnpm fmt --write` on touched files