### PR TITLE
refactor(als): dedupe AsyncLocalStorage globalThis registration

### DIFF
--- a/packages/vinext/src/shims/cache-runtime.ts
+++ b/packages/vinext/src/shims/cache-runtime.ts
@@ -28,7 +28,6 @@
  * - "use cache: private"  — per-request cache (not shared across requests)
  */
 
-import { AsyncLocalStorage } from "node:async_hooks";
 import {
   getCacheHandler,
   cacheLifeProfiles,
@@ -37,6 +36,7 @@ import {
   type CacheControlMetadata,
   type CacheLifeConfig,
 } from "./cache.js";
+import { getOrCreateAls } from "./internal/als-registry.js";
 import {
   isInsideUnifiedScope,
   getRequestContext,
@@ -58,10 +58,7 @@ export type CacheContext = {
 
 // Store on globalThis via Symbol so headers.ts can detect "use cache" scope
 // without a direct import (avoiding circular dependencies).
-const _CONTEXT_ALS_KEY = Symbol.for("vinext.cacheRuntime.contextAls");
-const _gCacheRuntime = globalThis as unknown as Record<PropertyKey, unknown>;
-export const cacheContextStorage = (_gCacheRuntime[_CONTEXT_ALS_KEY] ??=
-  new AsyncLocalStorage<CacheContext>()) as AsyncLocalStorage<CacheContext>;
+export const cacheContextStorage = getOrCreateAls<CacheContext>("vinext.cacheRuntime.contextAls");
 
 // Register the context accessor so cacheLife()/cacheTag() in cache.ts can
 // access the context without a circular import.
@@ -252,11 +249,9 @@ export type PrivateCacheState = {
   _privateCache: Map<string, unknown> | null;
 };
 
-const _PRIVATE_ALS_KEY = Symbol.for("vinext.cacheRuntime.privateAls");
 const _PRIVATE_FALLBACK_KEY = Symbol.for("vinext.cacheRuntime.privateFallback");
 const _g = globalThis as unknown as Record<PropertyKey, unknown>;
-const _privateAls = (_g[_PRIVATE_ALS_KEY] ??=
-  new AsyncLocalStorage<PrivateCacheState>()) as AsyncLocalStorage<PrivateCacheState>;
+const _privateAls = getOrCreateAls<PrivateCacheState>("vinext.cacheRuntime.privateAls");
 
 const _privateFallbackState = (_g[_PRIVATE_FALLBACK_KEY] ??= {
   _privateCache: new Map<string, unknown>(),

--- a/packages/vinext/src/shims/cache.ts
+++ b/packages/vinext/src/shims/cache.ts
@@ -18,7 +18,7 @@
  */
 
 import { markDynamicUsage as _markDynamic } from "./headers.js";
-import { AsyncLocalStorage } from "node:async_hooks";
+import { getOrCreateAls } from "./internal/als-registry.js";
 import { fnv1a64 } from "../utils/hash.js";
 import {
   isInsideUnifiedScope,
@@ -533,11 +533,9 @@ export type CacheState = {
   unstableCacheRevalidation: UnstableCacheRevalidationMode;
 };
 
-const _ALS_KEY = Symbol.for("vinext.cache.als");
 const _FALLBACK_KEY = Symbol.for("vinext.cache.fallback");
 const _g = globalThis as unknown as Record<PropertyKey, unknown>;
-const _cacheAls = (_g[_ALS_KEY] ??=
-  new AsyncLocalStorage<CacheState>()) as AsyncLocalStorage<CacheState>;
+const _cacheAls = getOrCreateAls<CacheState>("vinext.cache.als");
 
 const _cacheFallbackState = (_g[_FALLBACK_KEY] ??= {
   requestScopedCacheLife: null,
@@ -752,9 +750,7 @@ export function cacheTag(...tags: string[]): void {
  * Stored on globalThis via Symbol so headers.ts can detect the scope without
  * a direct import (avoiding circular dependencies).
  */
-const _UNSTABLE_CACHE_ALS_KEY = Symbol.for("vinext.unstableCache.als");
-const _unstableCacheAls = (_g[_UNSTABLE_CACHE_ALS_KEY] ??=
-  new AsyncLocalStorage<boolean>()) as AsyncLocalStorage<boolean>;
+const _unstableCacheAls = getOrCreateAls<boolean>("vinext.unstableCache.als");
 
 /**
  * Wrapper used to serialize `unstable_cache` results so that `undefined` can

--- a/packages/vinext/src/shims/fetch-cache.ts
+++ b/packages/vinext/src/shims/fetch-cache.ts
@@ -20,8 +20,8 @@
  */
 
 import { getCacheHandler, type CachedFetchValue } from "./cache.js";
+import { getOrCreateAls } from "./internal/als-registry.js";
 import { getRequestExecutionContext } from "./request-context.js";
-import { AsyncLocalStorage } from "node:async_hooks";
 import {
   isInsideUnifiedScope,
   getRequestContext,
@@ -481,11 +481,9 @@ export type FetchCacheMode =
   | "only-cache"
   | "only-no-store";
 
-const _ALS_KEY = Symbol.for("vinext.fetchCache.als");
 const _FALLBACK_KEY = Symbol.for("vinext.fetchCache.fallback");
 const _g = globalThis as unknown as Record<PropertyKey, unknown>;
-const _als = (_g[_ALS_KEY] ??=
-  new AsyncLocalStorage<FetchCacheState>()) as AsyncLocalStorage<FetchCacheState>;
+const _als = getOrCreateAls<FetchCacheState>("vinext.fetchCache.als");
 
 const _fallbackState = (_g[_FALLBACK_KEY] ??= {
   currentRequestTags: [],

--- a/packages/vinext/src/shims/head-state.ts
+++ b/packages/vinext/src/shims/head-state.ts
@@ -9,8 +9,8 @@
  */
 
 import type React from "react";
-import { AsyncLocalStorage } from "node:async_hooks";
 import { _registerHeadStateAccessors } from "./head.js";
+import { getOrCreateAls } from "./internal/als-registry.js";
 import {
   getRequestContext,
   isInsideUnifiedScope,
@@ -25,10 +25,9 @@ export type HeadState = {
   ssrHeadChildren: React.ReactNode[];
 };
 
-const _ALS_KEY = Symbol.for("vinext.head.als");
 const _FALLBACK_KEY = Symbol.for("vinext.head.fallback");
 const _g = globalThis as unknown as Record<PropertyKey, unknown>;
-const _als = (_g[_ALS_KEY] ??= new AsyncLocalStorage<HeadState>()) as AsyncLocalStorage<HeadState>;
+const _als = getOrCreateAls<HeadState>("vinext.head.als");
 
 const _fallbackState = (_g[_FALLBACK_KEY] ??= {
   ssrHeadChildren: [],

--- a/packages/vinext/src/shims/headers.ts
+++ b/packages/vinext/src/shims/headers.ts
@@ -8,8 +8,9 @@
  * We support both the sync (legacy) and async patterns.
  */
 
-import { AsyncLocalStorage } from "node:async_hooks";
+import type { AsyncLocalStorage } from "node:async_hooks";
 import { buildRequestHeadersFromMiddlewareResponse } from "../server/middleware-request-headers.js";
+import { getOrCreateAls } from "./internal/als-registry.js";
 import {
   serializeSetCookie,
   validateCookieAttributeValue,
@@ -55,11 +56,9 @@ export type VinextHeadersShimState = {
 //   (next/headers) always share it.
 // - We use AsyncLocalStorage so concurrent requests don't stomp each other's
 //   headers/cookies/dynamic-usage state.
-const _ALS_KEY = Symbol.for("vinext.nextHeadersShim.als");
 const _FALLBACK_KEY = Symbol.for("vinext.nextHeadersShim.fallback");
 const _g = globalThis as unknown as Record<PropertyKey, unknown>;
-const _als = (_g[_ALS_KEY] ??=
-  new AsyncLocalStorage<VinextHeadersShimState>()) as AsyncLocalStorage<VinextHeadersShimState>;
+const _als = getOrCreateAls<VinextHeadersShimState>("vinext.nextHeadersShim.als");
 
 const _fallbackState = (_g[_FALLBACK_KEY] ??= {
   headersContext: null,

--- a/packages/vinext/src/shims/i18n-state.ts
+++ b/packages/vinext/src/shims/i18n-state.ts
@@ -9,8 +9,8 @@
  * be bundled for the browser.
  */
 
-import { AsyncLocalStorage } from "node:async_hooks";
 import { _registerI18nStateAccessors, type I18nContext } from "./i18n-context.js";
+import { getOrCreateAls } from "./internal/als-registry.js";
 import {
   getRequestContext,
   isInsideUnifiedScope,
@@ -25,10 +25,9 @@ export type I18nState = {
   i18nContext: I18nContext | null;
 };
 
-const _ALS_KEY = Symbol.for("vinext.i18n.als");
 const _FALLBACK_KEY = Symbol.for("vinext.i18n.fallback");
 const _g = globalThis as unknown as Record<PropertyKey, unknown>;
-const _als = (_g[_ALS_KEY] ??= new AsyncLocalStorage<I18nState>()) as AsyncLocalStorage<I18nState>;
+const _als = getOrCreateAls<I18nState>("vinext.i18n.als");
 
 const _fallbackState = (_g[_FALLBACK_KEY] ??= {
   i18nContext: null,

--- a/packages/vinext/src/shims/internal/als-registry.ts
+++ b/packages/vinext/src/shims/internal/als-registry.ts
@@ -1,0 +1,53 @@
+/**
+ * Shared helper for registering AsyncLocalStorage instances on `globalThis`
+ * via `Symbol.for(...)` so that they survive multiple module instances.
+ *
+ * Why this helper exists
+ * ----------------------
+ * Vite's multi-environment setup (RSC / SSR / client) and HMR can load a
+ * single source module under several different specifiers, producing more
+ * than one module instance at runtime. If each instance kept its own
+ * module-local `new AsyncLocalStorage()`, request-scoped state would silently
+ * fork across instances — `headers()` in one environment wouldn't see what
+ * `connection()` registered in another, concurrent requests would stomp each
+ * other, etc.
+ *
+ * The fix every shim was applying inline:
+ *
+ *   const _ALS_KEY = Symbol.for("vinext.foo.als");
+ *   const _g = globalThis as unknown as Record<PropertyKey, unknown>;
+ *   const _als = (_g[_ALS_KEY] ??=
+ *     new AsyncLocalStorage<T>()) as AsyncLocalStorage<T>;
+ *
+ * This helper packages that pattern.
+ *
+ * Cross-bundle singleton property — preserved
+ * -------------------------------------------
+ * - `Symbol.for(key)` consults the global symbol registry and returns the
+ *   same symbol regardless of which module instance calls it.
+ * - `globalThis[sym]` is a single slot shared by every module instance.
+ * - `??=` only assigns when the slot is empty, so the first caller wins and
+ *   every subsequent caller (in any module instance) reads the same ALS.
+ *
+ * The helper module itself never holds the ALS by reference — it always
+ * round-trips through `globalThis`. So even if this helper file is itself
+ * loaded under multiple module instances, every copy still hands back the
+ * one true ALS for a given key.
+ */
+
+import { AsyncLocalStorage } from "node:async_hooks";
+
+const _g = globalThis as unknown as Record<PropertyKey, unknown>;
+
+/**
+ * Get (or lazily create) the AsyncLocalStorage registered on `globalThis`
+ * under `Symbol.for(key)`. Multiple callers — including callers in different
+ * module instances — that pass the same `key` receive the same ALS instance.
+ *
+ * @param key - String key fed to `Symbol.for(...)`. By convention vinext
+ *   shims use a dotted namespace such as `"vinext.cache.als"`.
+ */
+export function getOrCreateAls<T>(key: string): AsyncLocalStorage<T> {
+  const sym = Symbol.for(key);
+  return (_g[sym] ??= new AsyncLocalStorage<T>()) as AsyncLocalStorage<T>;
+}

--- a/packages/vinext/src/shims/navigation-state.ts
+++ b/packages/vinext/src/shims/navigation-state.ts
@@ -11,7 +11,7 @@
  * uses a registration pattern so it works in both environments.
  */
 
-import { AsyncLocalStorage } from "node:async_hooks";
+import { getOrCreateAls } from "./internal/als-registry.js";
 import {
   _registerStateAccessors,
   type NavigationContext,
@@ -32,11 +32,9 @@ export type NavigationState = {
   serverInsertedHTMLCallbacks: Array<() => unknown>;
 };
 
-const _ALS_KEY = Symbol.for("vinext.navigation.als");
 const _FALLBACK_KEY = Symbol.for("vinext.navigation.fallback");
 const _g = globalThis as unknown as Record<PropertyKey, unknown>;
-const _als = (_g[_ALS_KEY] ??=
-  new AsyncLocalStorage<NavigationState>()) as AsyncLocalStorage<NavigationState>;
+const _als = getOrCreateAls<NavigationState>("vinext.navigation.als");
 
 const _fallbackState = (_g[_FALLBACK_KEY] ??= {
   serverContext: null,

--- a/packages/vinext/src/shims/request-context.ts
+++ b/packages/vinext/src/shims/request-context.ts
@@ -21,7 +21,7 @@
  *   ctx?.waitUntil(somePromise);
  */
 
-import { AsyncLocalStorage } from "node:async_hooks";
+import { getOrCreateAls } from "./internal/als-registry.js";
 import {
   isInsideUnifiedScope,
   getRequestContext,
@@ -47,10 +47,7 @@ export type ExecutionContextLike = {
 // share the same instance and see the same per-request context.
 // ---------------------------------------------------------------------------
 
-const _ALS_KEY = Symbol.for("vinext.requestContext.als");
-const _g = globalThis as unknown as Record<PropertyKey, unknown>;
-const _als = (_g[_ALS_KEY] ??=
-  new AsyncLocalStorage<ExecutionContextLike | null>()) as AsyncLocalStorage<ExecutionContextLike | null>;
+const _als = getOrCreateAls<ExecutionContextLike | null>("vinext.requestContext.als");
 
 // ---------------------------------------------------------------------------
 // Public API

--- a/packages/vinext/src/shims/router-state.ts
+++ b/packages/vinext/src/shims/router-state.ts
@@ -8,8 +8,8 @@
  * be bundled for the browser.
  */
 
-import { AsyncLocalStorage } from "node:async_hooks";
 import { _registerRouterStateAccessors } from "./router.js";
+import { getOrCreateAls } from "./internal/als-registry.js";
 import {
   getRequestContext,
   isInsideUnifiedScope,
@@ -33,11 +33,9 @@ export type RouterState = {
   ssrContext: SSRContext | null;
 };
 
-const _ALS_KEY = Symbol.for("vinext.router.als");
 const _FALLBACK_KEY = Symbol.for("vinext.router.fallback");
 const _g = globalThis as unknown as Record<PropertyKey, unknown>;
-const _als = (_g[_ALS_KEY] ??=
-  new AsyncLocalStorage<RouterState>()) as AsyncLocalStorage<RouterState>;
+const _als = getOrCreateAls<RouterState>("vinext.router.als");
 
 const _fallbackState = (_g[_FALLBACK_KEY] ??= {
   ssrContext: null,

--- a/packages/vinext/src/shims/unified-request-context.ts
+++ b/packages/vinext/src/shims/unified-request-context.ts
@@ -10,7 +10,8 @@
  * outside (SSR environment, Pages Router, tests).
  */
 
-import { AsyncLocalStorage } from "node:async_hooks";
+import type { AsyncLocalStorage } from "node:async_hooks";
+import { getOrCreateAls } from "./internal/als-registry.js";
 import type {
   CacheState,
   ExecutionContextLike,
@@ -59,11 +60,9 @@ export type UnifiedRequestContext = {
 // (RSC/SSR/client) share the same instance.
 // ---------------------------------------------------------------------------
 
-const _ALS_KEY = Symbol.for("vinext.unifiedRequestContext.als");
 const _REQUEST_CONTEXT_ALS_KEY = Symbol.for("vinext.requestContext.als");
 const _g = globalThis as unknown as Record<PropertyKey, unknown>;
-const _als = (_g[_ALS_KEY] ??=
-  new AsyncLocalStorage<UnifiedRequestContext>()) as AsyncLocalStorage<UnifiedRequestContext>;
+const _als = getOrCreateAls<UnifiedRequestContext>("vinext.unifiedRequestContext.als");
 
 function _getInheritedExecutionContext(): ExecutionContextLike | null {
   const unifiedStore = _als.getStore();


### PR DESCRIPTION
## Summary

Extracts the repeated `Symbol.for(...) + globalThis ??= new AsyncLocalStorage<T>()`
pattern into a single helper, `getOrCreateAls<T>(key: string)`, in
`packages/vinext/src/shims/internal/als-registry.ts`.

The pattern was inlined in 12 sites across 10 modules:

- `shims/headers.ts` — `vinext.nextHeadersShim.als`
- `shims/cache.ts` — `vinext.cache.als`, `vinext.unstableCache.als`
- `shims/cache-runtime.ts` — `vinext.cacheRuntime.contextAls` (exported), `vinext.cacheRuntime.privateAls`
- `shims/fetch-cache.ts` — `vinext.fetchCache.als`
- `shims/request-context.ts` — `vinext.requestContext.als`
- `shims/unified-request-context.ts` — `vinext.unifiedRequestContext.als`
- `shims/router-state.ts` — `vinext.router.als`
- `shims/i18n-state.ts` — `vinext.i18n.als`
- `shims/head-state.ts` — `vinext.head.als`
- `shims/navigation-state.ts` — `vinext.navigation.als`

The 12 sites used identical structure: same `Symbol.for(key)` registry-side
lookup, same `??=` semantics, same fallback-type `AsyncLocalStorage<T>()`.
No site initialised the ALS with a sentinel store value or wrapped it in a
container object — they were all clean candidates.

Net: 11 files changed, +77/-46 (the new helper module is the bulk of
`+77`; call sites collapse from 4 lines to 1).

## Cross-bundle singleton property — preserved

This is the load-bearing invariant for ALS bugs and is the reason the
inline pattern existed in the first place. The helper preserves it:

- `Symbol.for(key)` consults the **global symbol registry** and returns the
  same symbol no matter which module instance calls it.
- `globalThis[sym]` is one slot shared by every module instance.
- `??=` only assigns when the slot is empty, so the first caller wins and
  every later caller (in any module instance, in any Vite environment)
  reads the same `AsyncLocalStorage` instance.

The helper module itself never closes over the ALS — it always
round-trips through `globalThis`. So even if `als-registry.ts` is loaded
under multiple specifiers (Vite RSC/SSR/client environments, HMR), every
copy hands back the one true ALS for a given key. There is no new
"ownership-by-reference" layer introduced by the helper.

The unrelated `_FALLBACK_KEY` / `_fallbackState` pattern in some shims
(plain-object cross-bundle singletons with shape varying per call site)
is intentionally left inline.

## Files changed

- `packages/vinext/src/shims/internal/als-registry.ts` (new)
- `packages/vinext/src/shims/headers.ts`
- `packages/vinext/src/shims/cache.ts`
- `packages/vinext/src/shims/cache-runtime.ts`
- `packages/vinext/src/shims/fetch-cache.ts`
- `packages/vinext/src/shims/request-context.ts`
- `packages/vinext/src/shims/unified-request-context.ts`
- `packages/vinext/src/shims/router-state.ts`
- `packages/vinext/src/shims/i18n-state.ts`
- `packages/vinext/src/shims/head-state.ts`
- `packages/vinext/src/shims/navigation-state.ts`

Follow-up to #1058.

## Test plan

- [x] `pnpm fmt --write` on touched files
- [x] `npx tsc --noEmit` in `packages/vinext` — clean
- [x] `pnpm knip` — clean
- [x] `pnpm vp test run` for `app-router`, `pages-router`, `cache-control`, `cache-for-request`, `fetch-cache`, `head`, `request-context`, `unified-request-context`, `pages-router-concurrency` — 683 tests passing. The single suite-level failure (`pages-router.test.ts > allowedDevOrigins config` `afterAll` timeout) reproduces on clean `main` with the changes stashed; it is a pre-existing flaky teardown unrelated to this refactor.
- [ ] CI runs full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)