### PR TITLE
chore(shims): delete unused deprecated exports

### DIFF
--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -1079,9 +1079,9 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
             stripRscCacheBustingSearchParam(parsed);
             const origUrl = new URL(currentHref, window.location.origin);
             let pathname = stripRscSuffix(parsed.pathname);
-            // toRscUrl strips trailing slash before appending .rsc, so the
-            // response URL loses it on the round-trip. Restore it when the
-            // original href had one so sites with trailingSlash:true don't
+            // createRscRequestUrl strips trailing slash before appending .rsc,
+            // so the response URL loses it on the round-trip. Restore it when
+            // the original href had one so sites with trailingSlash:true don't
             // incur an extra 308 to the canonical form on the error path.
             if (
               origUrl.pathname.length > 1 &&

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -295,25 +295,6 @@ export type PrefetchCacheEntry = {
   timestamp: number;
 };
 
-/**
- * Convert a pathname (with optional query/hash) to its .rsc URL.
- * Strips trailing slashes before appending `.rsc` so that cache keys
- * are consistent regardless of the `trailingSlash` config setting.
- *
- * @deprecated Use `createRscRequestUrl` so RSC requests include cache-busting
- * params for variant headers.
- */
-export function toRscUrl(href: string): string {
-  const [beforeHash] = href.split("#");
-  const qIdx = beforeHash.indexOf("?");
-  const pathname = qIdx === -1 ? beforeHash : beforeHash.slice(0, qIdx);
-  const query = qIdx === -1 ? "" : beforeHash.slice(qIdx);
-  // Strip trailing slash (but preserve "/" root) for consistent cache keys
-  const normalizedPath =
-    pathname.length > 1 && pathname.endsWith("/") ? pathname.slice(0, -1) : pathname;
-  return normalizedPath + ".rsc" + query;
-}
-
 export function getCurrentInterceptionContext(): string | null {
   if (isServer) {
     return null;

--- a/packages/vinext/src/shims/next-shims.d.ts
+++ b/packages/vinext/src/shims/next-shims.d.ts
@@ -118,11 +118,6 @@ declare module "next/navigation" {
   };
   export const MAX_PREFETCH_CACHE_SIZE: number;
   export const PREFETCH_CACHE_TTL: number;
-  /**
-   * @deprecated Use `createRscRequestUrl` so RSC requests include cache-busting
-   * params for variant headers.
-   */
-  export function toRscUrl(href: string): string;
   export function getPrefetchCache(): Map<string, PrefetchCacheEntry>;
   export function getPrefetchedUrls(): Set<string>;
   export function storePrefetchResponse(


### PR DESCRIPTION
## Summary

Deletes the deprecated `toRscUrl` export from the navigation shim and its matching ambient declaration. All internal callers already use `createRscRequestUrl`, which appends RSC cache-busting params for variant headers.

The originally-proposed `requestAsyncStorage` deletion was **not** performed — see "Verification" below for the reason.

## What changed

- `packages/vinext/src/shims/navigation.ts` — remove `toRscUrl(href)` function (deprecated, zero internal callers).
- `packages/vinext/src/shims/next-shims.d.ts` — remove the matching ambient `export function toRscUrl(href: string): string` declaration so the public type surface no longer advertises it.
- `packages/vinext/src/server/app-browser-entry.ts` — update a stale code comment that named `toRscUrl` to instead reference `createRscRequestUrl` (the actual current call site).

## Verification

### `toRscUrl` — safe to delete

```
$ grep -rn "toRscUrl" packages/ tests/ examples/
packages/vinext/src/server/app-browser-entry.ts:1082:            // toRscUrl strips trailing slash before appending .rsc, so the
packages/vinext/src/shims/navigation.ts:306:export function toRscUrl(href: string): string {
packages/vinext/src/shims/next-shims.d.ts:125:  export function toRscUrl(href: string): string;
```

Three hits: the function definition, the ambient type declaration, and one stale code comment. No call sites. After this PR:

```
$ grep -rn "toRscUrl" packages/ tests/ examples/
(no matches)
```

### `requestAsyncStorage` — kept (load-bearing)

The task originally also proposed deleting the `requestAsyncStorage` legacy alias in `shims/internal/work-unit-async-storage.ts`. Verification turned up multiple production-relevant uses, so it was left in place:

```
$ grep -rn "request-async-storage\|requestAsyncStorage" packages/ tests/ examples/
packages/vinext/src/check.ts:157:  "next/dist/client/components/request-async-storage.external": { ... }
packages/vinext/src/check.ts:161:  "next/dist/client/components/request-async-storage": { ... }
packages/vinext/src/index.ts:969:  "next/dist/client/components/request-async-storage.external": path.join(...)
packages/vinext/src/index.ts:974:  "next/dist/client/components/request-async-storage": path.join(...)
packages/vinext/src/shims/internal/work-unit-async-storage.ts:3: * and next/dist/client/components/request-async-storage.external
packages/vinext/src/shims/internal/work-unit-async-storage.ts:56: export const requestAsyncStorage = workUnitAsyncStorage;
tests/shims.test.ts:11577:    expect(mod.requestAsyncStorage).toBeDefined();
tests/shims.test.ts:11579:    expect(mod.workUnitAsyncStorage).toBe(mod.requestAsyncStorage);
```

The shim file is the resolution target for Next.js's legacy `next/dist/client/components/request-async-storage.external` module path (mapped in `index.ts`/`check.ts`). The shim's JSDoc explicitly states `@sentry/nextjs` runtime-resolves request context via this name, and `tests/shims.test.ts` asserts the alias is exported. Deleting it would break the Sentry integration path on Next.js 13.x/14.x-style imports.

## Test plan

- [x] `pnpm vp test run tests/app-router.test.ts tests/pages-router.test.ts` — 508 tests pass (one unrelated `afterAll` cleanup hook timed out tearing down `tmpDir`; pre-existing infra flake, no test assertions failed).
- [x] `pnpm fmt --write` — clean.
- [x] `pnpm knip` — clean.
- [ ] CI green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)