### PR TITLE
refactor(server): dedupe TextDecoder stream consumption

### DIFF
--- a/packages/vinext/src/server/app-page-cache.ts
+++ b/packages/vinext/src/server/app-page-cache.ts
@@ -2,6 +2,7 @@ import type { CachedAppPageValue, CacheControlMetadata } from "vinext/shims/cach
 import { VINEXT_RSC_VARY_HEADER } from "./app-rsc-cache-busting.js";
 import { buildCachedRevalidateCacheControl } from "./cache-control.js";
 import { buildAppPageCacheValue, type ISRCacheEntry } from "./isr-cache.js";
+import { readStreamAsText } from "../utils/text-stream.js";
 
 type AppPageDebugLogger = (event: string, detail: string) => void;
 type AppPageCacheGetter = (key: string) => Promise<ISRCacheEntry | null>;
@@ -322,17 +323,7 @@ export function finalizeAppPageHtmlCacheResponse(
 
   const cachePromise = (async () => {
     try {
-      const reader = streamForCache.getReader();
-      const decoder = new TextDecoder();
-      const chunks: string[] = [];
-      for (;;) {
-        const { done, value } = await reader.read();
-        if (done) {
-          break;
-        }
-        chunks.push(decoder.decode(value, { stream: true }));
-      }
-      chunks.push(decoder.decode());
+      const cachedHtml = await readStreamAsText(streamForCache);
 
       if (options.consumeDynamicUsage()) {
         options.isrDebug?.("HTML cache write skipped (dynamic usage during render)", htmlKey);
@@ -353,7 +344,7 @@ export function finalizeAppPageHtmlCacheResponse(
       const writes = [
         options.isrSet(
           htmlKey,
-          buildAppPageCacheValue(chunks.join(""), undefined, 200),
+          buildAppPageCacheValue(cachedHtml, undefined, 200),
           cachePolicy.revalidateSeconds,
           pageTags,
           cachePolicy.expireSeconds,

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -25,9 +25,9 @@ import {
 import type { AppOutgoingElements } from "./app-elements.js";
 import { readAppPageCacheResponse } from "./app-page-cache.js";
 import { resolveAppPageParentHttpAccessBoundaryModule } from "./app-page-boundary.js";
+import { readStreamAsText } from "../utils/text-stream.js";
 import {
   buildAppPageSpecialErrorResponse,
-  readAppPageTextStream,
   resolveAppPageSpecialError,
   teeAppPageRscStreamForCapture,
   type AppPageFontPreload,
@@ -399,7 +399,7 @@ export async function dispatchAppPage<TRoute extends AppPageDispatchRoute>(
                   }
                 : undefined,
             );
-            const html = await readAppPageTextStream(revalidatedHtmlStream);
+            const html = await readStreamAsText(revalidatedHtmlStream);
             const rscData = await getCapturedRscDataPromise(revalidatedCapturedRscRef.value);
             const cacheLife = _consumeRequestScopedCacheLife();
             options.clearRequestContext();

--- a/packages/vinext/src/server/app-page-execution.ts
+++ b/packages/vinext/src/server/app-page-execution.ts
@@ -340,23 +340,6 @@ export async function probeAppPageComponent(
   });
 }
 
-export async function readAppPageTextStream(stream: ReadableStream<Uint8Array>): Promise<string> {
-  const reader = stream.getReader();
-  const decoder = new TextDecoder();
-  const chunks: string[] = [];
-
-  for (;;) {
-    const { done, value } = await reader.read();
-    if (done) {
-      break;
-    }
-    chunks.push(decoder.decode(value, { stream: true }));
-  }
-
-  chunks.push(decoder.decode());
-  return chunks.join("");
-}
-
 export async function readAppPageBinaryStream(
   stream: ReadableStream<Uint8Array>,
 ): Promise<ArrayBuffer> {

--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -9,6 +9,7 @@ import {
   parseNextRedirectDigest,
 } from "./next-error-digest.js";
 import { validateCsrfOrigin, validateServerActionPayload } from "./request-pipeline.js";
+import { readStreamAsTextWithLimit } from "../utils/text-stream.js";
 import {
   createServerActionNotFoundResponse,
   getServerActionNotFoundMessage,
@@ -192,26 +193,9 @@ function getServerActionFailureMessage(error: unknown): string {
 
 export async function readActionBodyWithLimit(request: Request, maxBytes: number): Promise<string> {
   if (!request.body) return "";
-
-  const reader = request.body.getReader();
-  const decoder = new TextDecoder();
-  const chunks: string[] = [];
-  let totalSize = 0;
-
-  for (;;) {
-    const result = await reader.read();
-    if (result.done) break;
-
-    totalSize += result.value.byteLength;
-    if (totalSize > maxBytes) {
-      await reader.cancel();
-      throw new Error("Request body too large");
-    }
-    chunks.push(decoder.decode(result.value, { stream: true }));
-  }
-
-  chunks.push(decoder.decode());
-  return chunks.join("");
+  return readStreamAsTextWithLimit(request.body, maxBytes, () => {
+    throw new Error("Request body too large");
+  });
 }
 
 export async function readActionFormDataWithLimit(

--- a/packages/vinext/src/server/pages-node-compat.ts
+++ b/packages/vinext/src/server/pages-node-compat.ts
@@ -1,5 +1,6 @@
 import { decode as decodeQueryString } from "node:querystring";
 import { parseCookies } from "../config/config-matchers.js";
+import { readStreamAsTextWithLimit } from "../utils/text-stream.js";
 import { PagesBodyParseError, getMediaType, isJsonMediaType } from "./pages-media-type.js";
 
 const MAX_PAGES_API_BODY_SIZE = 1 * 1024 * 1024;
@@ -57,28 +58,9 @@ async function readPagesRequestBodyWithLimit(request: Request, maxBytes: number)
     return "";
   }
 
-  const reader = request.body.getReader();
-  const decoder = new TextDecoder();
-  const chunks: string[] = [];
-  let totalSize = 0;
-
-  for (;;) {
-    const result = await reader.read();
-    if (result.done) {
-      break;
-    }
-
-    totalSize += result.value.byteLength;
-    if (totalSize > maxBytes) {
-      await reader.cancel();
-      throw new PagesBodyParseError("Request body too large", 413);
-    }
-
-    chunks.push(decoder.decode(result.value, { stream: true }));
-  }
-
-  chunks.push(decoder.decode());
-  return chunks.join("");
+  return readStreamAsTextWithLimit(request.body, maxBytes, () => {
+    throw new PagesBodyParseError("Request body too large", 413);
+  });
 }
 
 export async function parsePagesApiBody(

--- a/packages/vinext/src/server/pages-page-response.ts
+++ b/packages/vinext/src/server/pages-page-response.ts
@@ -5,6 +5,7 @@ import { getRequestExecutionContext } from "vinext/shims/request-context";
 import { buildRevalidateCacheControl } from "./cache-control.js";
 import { createInlineScriptTag, createNonceAttribute, escapeHtmlAttr } from "./html.js";
 import { reportRequestError } from "./instrumentation.js";
+import { readStreamAsText } from "../utils/text-stream.js";
 
 type PagesFontPreload = {
   href: string;
@@ -193,26 +194,6 @@ async function buildPagesCompositeStream(
   });
 }
 
-async function recordStreamToString(stream: ReadableStream<Uint8Array>): Promise<string> {
-  const reader = stream.getReader();
-  const decoder = new TextDecoder();
-  const chunks: string[] = [];
-
-  try {
-    for (;;) {
-      const chunk = await reader.read();
-      if (chunk.done) {
-        break;
-      }
-      chunks.push(decoder.decode(chunk.value, { stream: true }));
-    }
-    chunks.push(decoder.decode());
-    return chunks.join("");
-  } finally {
-    reader.releaseLock();
-  }
-}
-
 async function reportPagesIsrCacheWriteError(
   error: unknown,
   cacheKey: string,
@@ -245,7 +226,7 @@ function schedulePagesIsrCacheWrite(options: {
   stream: ReadableStream<Uint8Array>;
   setCache: RenderPagesPageResponseOptions["isrSet"];
 }): void {
-  const cacheWritePromise = recordStreamToString(options.stream)
+  const cacheWritePromise = readStreamAsText(options.stream)
     .then((bodyHtml) =>
       options.setCache(
         options.cacheKey,

--- a/packages/vinext/src/utils/text-stream.ts
+++ b/packages/vinext/src/utils/text-stream.ts
@@ -1,0 +1,72 @@
+/**
+ * Helpers for the repeated `new TextDecoder()` + `ReadableStream` chunk-loop
+ * pattern used across the server. Each helper handles the streaming-decode
+ * boundary correctly (final empty `decoder.decode()` flush so any incomplete
+ * trailing UTF-8 sequence is reported).
+ *
+ * Sites with additional load-bearing behaviour (line-buffered transforms,
+ * raw-byte accumulators, mixed string/Uint8Array streams, cache-key body
+ * canonicalisation) intentionally still inline their own decoder.
+ */
+
+/**
+ * Drain a UTF-8 byte stream and return the full decoded text. The stream
+ * reader is released on both success and failure.
+ */
+export async function readStreamAsText(stream: ReadableStream<Uint8Array>): Promise<string> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  const chunks: string[] = [];
+
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      chunks.push(decoder.decode(value, { stream: true }));
+    }
+    chunks.push(decoder.decode());
+    return chunks.join("");
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+/**
+ * Drain a UTF-8 byte stream up to `maxBytes` of *raw* input, returning the
+ * decoded text. If the raw size limit is exceeded, the reader is cancelled
+ * and `onLimitExceeded` is invoked; it MUST throw — its return type is
+ * `never` to enforce that. Each caller passes its own error type.
+ *
+ * The size check is on raw bytes (pre-decode) to bound memory before
+ * paying the decoder cost.
+ */
+export async function readStreamAsTextWithLimit(
+  stream: ReadableStream<Uint8Array>,
+  maxBytes: number,
+  onLimitExceeded: () => never,
+): Promise<string> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  const chunks: string[] = [];
+  let totalSize = 0;
+
+  for (;;) {
+    const result = await reader.read();
+    if (result.done) {
+      break;
+    }
+
+    totalSize += result.value.byteLength;
+    if (totalSize > maxBytes) {
+      await reader.cancel();
+      onLimitExceeded();
+    }
+
+    chunks.push(decoder.decode(result.value, { stream: true }));
+  }
+
+  chunks.push(decoder.decode());
+  return chunks.join("");
+}

--- a/packages/vinext/src/utils/text-stream.ts
+++ b/packages/vinext/src/utils/text-stream.ts
@@ -52,21 +52,25 @@ export async function readStreamAsTextWithLimit(
   const chunks: string[] = [];
   let totalSize = 0;
 
-  for (;;) {
-    const result = await reader.read();
-    if (result.done) {
-      break;
+  try {
+    for (;;) {
+      const result = await reader.read();
+      if (result.done) {
+        break;
+      }
+
+      totalSize += result.value.byteLength;
+      if (totalSize > maxBytes) {
+        await reader.cancel();
+        onLimitExceeded();
+      }
+
+      chunks.push(decoder.decode(result.value, { stream: true }));
     }
 
-    totalSize += result.value.byteLength;
-    if (totalSize > maxBytes) {
-      await reader.cancel();
-      onLimitExceeded();
-    }
-
-    chunks.push(decoder.decode(result.value, { stream: true }));
+    chunks.push(decoder.decode());
+    return chunks.join("");
+  } finally {
+    reader.releaseLock();
   }
-
-  chunks.push(decoder.decode());
-  return chunks.join("");
 }

--- a/tests/app-page-execution.test.ts
+++ b/tests/app-page-execution.test.ts
@@ -4,10 +4,10 @@ import {
   buildAppPageSpecialErrorResponse,
   probeAppPageComponent,
   probeAppPageLayouts,
-  readAppPageTextStream,
   resolveAppPageSpecialError,
   teeAppPageRscStreamForCapture,
 } from "../packages/vinext/src/server/app-page-execution.js";
+import { readStreamAsText } from "../packages/vinext/src/utils/text-stream.js";
 
 function createStream(chunks: string[]): ReadableStream<Uint8Array> {
   return new ReadableStream({
@@ -367,8 +367,8 @@ describe("app page execution helpers", () => {
     expect(capture.sideStream).toBeInstanceOf(ReadableStream);
 
     // Both streams should contain identical data (teed from same source)
-    const ssrText = await readAppPageTextStream(capture.ssrStream);
-    const sideText = await readAppPageTextStream(capture.sideStream!);
+    const ssrText = await readStreamAsText(capture.ssrStream);
+    const sideText = await readStreamAsText(capture.sideStream!);
     expect(ssrText).toBe("flight-chunk");
     expect(sideText).toBe("flight-chunk");
   });


### PR DESCRIPTION
## Summary

Follow-up to the dedupe round (#1058, #1069-#1081). Extracts the repeated `new TextDecoder()` + `ReadableStream` chunk-loop into two helpers in `packages/vinext/src/utils/text-stream.ts`:

- `readStreamAsText(stream)` for the consume-to-single-string shape
- `readStreamAsTextWithLimit(stream, maxBytes, onLimitExceeded)` for the size-limited shape (callback throws so each caller keeps its own error type)

## Files changed

Deduped:
- `packages/vinext/src/server/app-page-cache.ts` (ISR HTML cache write)
- `packages/vinext/src/server/pages-page-response.ts` (`recordStreamToString` removed; was only called once)
- `packages/vinext/src/server/app-server-action-execution.ts` (`readActionBodyWithLimit`)
- `packages/vinext/src/server/pages-node-compat.ts` (`readPagesRequestBodyWithLimit`)

New helper:
- `packages/vinext/src/utils/text-stream.ts`

## Intentionally left inline

These five sites have load-bearing differences that don't fit either helper:

- `rsc-stream-hints.ts` - line-buffered `TransformStream` with `carry` for partial Flight lines
- `app-ssr-stream.ts` (`createRscEmbedTransform`) - interleaves raw-byte accumulation with `fixFlightHints`
- `app-ssr-stream.ts` (`createTickBufferedTransform`) - HTML transform applying `fixPreloadAs`
- `shims/fetch-cache.ts` - mixed string/Uint8Array stream, tee handling, custom `BodyTooLargeForCacheKeyError`, decoder also reused for non-stream `Uint8Array` body

So 4 of 9 sites cleanly deduped; 5 left alone. Pure refactor; no behaviour change at the deduped sites except a minor robustness improvement: `readStreamAsText` releases the reader lock in `finally` (the inline copy in `app-page-cache.ts` did not). The streams there are wholly consumed and not reused, so this is observably equivalent.

## Test plan

- [x] `pnpm vp test run tests/app-router.test.ts tests/pages-router.test.ts` (508 tests pass; the only failure is a pre-existing flaky `afterAll` cleanup hook in `Pages Router allowedDevOrigins config` that does not run any deduped code path)
- [x] `pnpm fmt --write`
- [x] `pnpm knip` (clean)
- [ ] CI required checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)