### PR TITLE
refactor(utils): dedupe trailing-slash and basePath normalization

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -71,7 +71,7 @@ import { scanMetadataFiles } from "./server/metadata-routes.js";
 import { buildRequestHeadersFromMiddlewareResponse } from "./server/middleware-request-headers.js";
 import { detectPackageManager } from "./utils/project.js";
 import { manifestFileWithBase, manifestFilesWithBase } from "./utils/manifest-paths.js";
-import { hasBasePath } from "./utils/base-path.js";
+import { hasBasePath, removeTrailingSlash } from "./utils/base-path.js";
 import { asyncHooksStubPlugin } from "./plugins/async-hooks-stub.js";
 import { clientReferenceDedupPlugin } from "./plugins/client-reference-dedup.js";
 import { createInstrumentationClientTransformPlugin } from "./plugins/instrumentation-client.js";
@@ -2347,7 +2347,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                 } else if (!nextConfig.trailingSlash && hasTrailing) {
                   // trailingSlash: false (default) — redirect /about/ → /about
                   const qs = url.includes("?") ? url.slice(url.indexOf("?")) : "";
-                  const dest = bp + pathname.replace(/\/+$/, "") + qs;
+                  const dest = bp + removeTrailingSlash(pathname) + qs;
                   res.writeHead(308, { Location: dest });
                   res.end();
                   return;

--- a/packages/vinext/src/routing/route-validation.ts
+++ b/packages/vinext/src/routing/route-validation.ts
@@ -4,6 +4,8 @@
  * https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/router/utils/sorted-routes.ts
  */
 
+import { removeTrailingSlash } from "../utils/base-path.js";
+
 class UrlNode {
   placeholder = true;
   children = new Map<string, UrlNode>();
@@ -158,9 +160,7 @@ export function patternToNextFormat(pattern: string): string {
 }
 
 function normalizeRoutePattern(pattern: string): string {
-  if (pattern === "/") return "/";
-  const normalized = pattern.replace(/\/+$/, "");
-  return normalized === "" ? "/" : normalized;
+  return removeTrailingSlash(pattern);
 }
 
 export function validateRoutePatterns(patterns: readonly string[]): void {

--- a/packages/vinext/src/server/app-page-execution.ts
+++ b/packages/vinext/src/server/app-page-execution.ts
@@ -3,6 +3,7 @@ import type { ClassificationReason } from "../build/layout-classification-types.
 import { createRscRedirectLocation } from "./app-rsc-cache-busting.js";
 import { mergeMiddlewareResponseHeaders } from "./middleware-response-headers.js";
 import { parseNextHttpErrorDigest, parseNextRedirectDigest } from "./next-error-digest.js";
+import { hasBasePath } from "../utils/base-path.js";
 
 export type { LayoutFlags };
 export type { ClassificationReason };
@@ -174,7 +175,7 @@ function applyAppPageRedirectBasePath(
   if (!basePath || resolved.origin !== requestOrigin) {
     return resolved.toString();
   }
-  if (resolved.pathname === basePath || resolved.pathname.startsWith(`${basePath}/`)) {
+  if (hasBasePath(resolved.pathname, basePath)) {
     return resolved.toString();
   }
   resolved.pathname = resolved.pathname === "/" ? basePath : `${basePath}${resolved.pathname}`;

--- a/packages/vinext/src/server/middleware-matcher.ts
+++ b/packages/vinext/src/server/middleware-matcher.ts
@@ -5,6 +5,7 @@ import {
   type RequestContext,
 } from "../config/config-matchers.js";
 import type { HasCondition, NextI18nConfig } from "../config/next-config.js";
+import { removeTrailingSlash } from "../utils/base-path.js";
 
 export type MiddlewareMatcherObject = {
   source: string;
@@ -120,7 +121,7 @@ function stripLocalePrefix(pathname: string, i18nConfig: NextI18nConfig): string
   }
 
   const stripped = "/" + segments.slice(2).join("/");
-  return stripped === "/" ? "/" : stripped.replace(/\/+$/, "") || "/";
+  return removeTrailingSlash(stripped);
 }
 
 export function matchPattern(pathname: string, pattern: string): boolean {

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -50,7 +50,7 @@ import {
   filterInternalHeaders,
   isOpenRedirectShaped,
 } from "./request-pipeline.js";
-import { hasBasePath, stripBasePath } from "../utils/base-path.js";
+import { hasBasePath, stripBasePath, removeTrailingSlash } from "../utils/base-path.js";
 import { computeLazyChunks } from "../utils/lazy-chunks.js";
 import { manifestFileWithBase } from "../utils/manifest-paths.js";
 import { normalizePathnameForRouteMatchStrict } from "../routing/utils.js";
@@ -1377,7 +1377,7 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
           return;
         } else if (!trailingSlash && hasTrailing) {
           const qs = url.includes("?") ? url.slice(url.indexOf("?")) : "";
-          res.writeHead(308, { Location: basePath + pathname.replace(/\/+$/, "") + qs });
+          res.writeHead(308, { Location: basePath + removeTrailingSlash(pathname) + qs });
           res.end();
           return;
         }

--- a/packages/vinext/src/server/request-pipeline.ts
+++ b/packages/vinext/src/server/request-pipeline.ts
@@ -1,4 +1,4 @@
-import { hasBasePath, stripBasePath } from "../utils/base-path.js";
+import { hasBasePath, stripBasePath, removeTrailingSlash } from "../utils/base-path.js";
 import type { NextHeader } from "../config/next-config.js";
 import type { RequestContext } from "../config/config-matchers.js";
 import { matchHeaders } from "../config/config-matchers.js";
@@ -285,7 +285,7 @@ export function normalizeTrailingSlash(
   if (!trailingSlash && hasTrailing) {
     return new Response(null, {
       status: 308,
-      headers: { Location: basePath + pathname.replace(/\/+$/, "") + search },
+      headers: { Location: basePath + removeTrailingSlash(pathname) + search },
     });
   }
   return null;

--- a/packages/vinext/src/shims/server.ts
+++ b/packages/vinext/src/shims/server.ts
@@ -14,6 +14,7 @@ import { serializeSetCookie, validateCookieName } from "./internal/cookie-serial
 import { parseCookieHeader } from "./internal/parse-cookie-header.js";
 import { getRequestExecutionContext } from "./request-context.js";
 import { assertSafeNavigationUrl } from "./url-safety.js";
+import { stripBasePath } from "../utils/base-path.js";
 
 // ---------------------------------------------------------------------------
 // Inlined cache-scope guard for after()
@@ -311,10 +312,7 @@ export class NextURL {
   /** Strip basePath prefix from the internal pathname. */
   private _stripBasePath(): void {
     if (!this._basePath) return;
-    const { pathname } = this._url;
-    if (pathname === this._basePath || pathname.startsWith(this._basePath + "/")) {
-      this._url.pathname = pathname.slice(this._basePath.length) || "/";
-    }
+    this._url.pathname = stripBasePath(this._url.pathname, this._basePath);
   }
 
   /** Extract locale from pathname, stripping it from the internal URL. */

--- a/packages/vinext/src/utils/base-path.ts
+++ b/packages/vinext/src/utils/base-path.ts
@@ -22,3 +22,14 @@ export function stripBasePath(pathname: string, basePath: string): string {
   if (!hasBasePath(pathname, basePath)) return pathname;
   return pathname.slice(basePath.length) || "/";
 }
+
+/**
+ * Remove trailing slashes from a pathname while preserving the root "/".
+ * Collapses any number of trailing slashes ("/a//" → "/a"). Used by the
+ * trailing-slash redirect path and route pattern normalization.
+ */
+export function removeTrailingSlash(pathname: string): string {
+  if (pathname === "/") return "/";
+  const stripped = pathname.replace(/\/+$/, "");
+  return stripped === "" ? "/" : stripped;
+}

--- a/packages/vinext/src/utils/base-path.ts
+++ b/packages/vinext/src/utils/base-path.ts
@@ -30,6 +30,7 @@ export function stripBasePath(pathname: string, basePath: string): string {
  */
 export function removeTrailingSlash(pathname: string): string {
   if (pathname === "/") return "/";
-  const stripped = pathname.replace(/\/+$/, "");
-  return stripped === "" ? "/" : stripped;
+  let end = pathname.length;
+  while (end > 0 && pathname.charCodeAt(end - 1) === 47 /* "/" */) end--;
+  return end === 0 ? "/" : pathname.slice(0, end);
 }


### PR DESCRIPTION
## Summary

- Add `removeTrailingSlash` helper to `packages/vinext/src/utils/base-path.ts` that strips trailing slashes while preserving the root `/` (and collapsing repeated slashes like `/a//` to `/a`).
- Migrate the four `pathname.replace(/\/+$/, \"\")` sites that match this normalization (`index.ts`, `server/prod-server.ts`, `server/request-pipeline.ts`, `server/middleware-matcher.ts`, `routing/route-validation.ts`) to call the helper.
- Migrate two ad-hoc basePath sites (`server/app-page-execution.ts` `applyAppPageRedirectBasePath`, `shims/server.ts` `_stripBasePath`) to the existing `hasBasePath` / `stripBasePath` helpers.
- Skipped: `cloudflare/tpr.ts` (operates on a host string, not a pathname), `utils/manifest-paths.ts` (intentionally trims to empty for the `/` base case), and the inlined helpers inside the `deploy.ts` worker code template (intentionally inlined because that code runs in Cloudflare Workers and cannot import from local source at build time).

Pure refactor; no behaviour change. Follow-up to #1058.

## Test plan

- [x] `pnpm vp test run tests/app-router.test.ts tests/pages-router.test.ts` (508 tests passed; one unrelated `afterAll` hook timeout in pages-router allowedDevOrigins suite)
- [x] `pnpm vp test run tests/request-pipeline.test.ts tests/shims.test.ts tests/next-config.test.ts` (992 tests passed)
- [x] `pnpm vp test run tests/route-trie.test.ts tests/route-sorting.test.ts tests/app-route-graph.test.ts tests/app-page-execution.test.ts` (145 tests passed)
- [x] `pnpm fmt --write`
- [x] `pnpm knip` (clean)

Generated with [Claude Code](https://claude.com/claude-code)