### PR TITLE
refactor(entries): dedupe ISR wrapper codegen and config serialization

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -153,13 +153,13 @@ export function generateRscEntry(
     expireTimeJson,
   } = serializeAppConfig(
     {
-      basePath: basePath ?? "",
-      trailingSlash: trailingSlash ?? false,
+      basePath,
+      trailingSlash,
       redirects: config?.redirects,
       rewrites: config?.rewrites,
       headers: config?.headers,
       expireTime: config?.expireTime,
-      i18n: config?.i18n ?? null,
+      i18n: config?.i18n,
     },
     DEFAULT_EXPIRE_TIME,
   );

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -8,7 +8,11 @@
  * Previously housed in server/app-dev-server.ts.
  */
 import { buildAppRscManifestCode } from "./app-rsc-manifest.js";
-import { resolveEntryPath, normalizePathSeparators } from "./runtime-entry-module.js";
+import {
+  normalizePathSeparators,
+  resolveEntryPath,
+  serializeAppConfig,
+} from "./runtime-entry-module.js";
 import type {
   NextHeader,
   NextI18nConfig,
@@ -133,17 +137,32 @@ export function generateRscEntry(
   config?: AppRouterConfig,
   instrumentationPath?: string | null,
 ): string {
-  const bp = basePath ?? "";
-  const ts = trailingSlash ?? false;
-  const redirects = config?.redirects ?? [];
-  const rewrites = config?.rewrites ?? { beforeFiles: [], afterFiles: [], fallback: [] };
-  const headers = config?.headers ?? [];
   const allowedOrigins = config?.allowedOrigins ?? [];
   const bodySizeLimit = config?.bodySizeLimit ?? 1 * 1024 * 1024;
-  const expireTime = config?.expireTime ?? DEFAULT_EXPIRE_TIME;
-  const i18nConfig = config?.i18n ?? null;
   const hasPagesDir = config?.hasPagesDir ?? false;
   const publicFiles = config?.publicFiles ?? [];
+  // Routing/i18n/cache config that's also embedded by the Pages entry.
+  // Keep the JSON.stringify chain in one place so both generators stay in sync.
+  const {
+    basePathJson,
+    trailingSlashJson,
+    i18nJson,
+    redirectsJson,
+    rewritesJson,
+    headersJson,
+    expireTimeJson,
+  } = serializeAppConfig(
+    {
+      basePath: basePath ?? "",
+      trailingSlash: trailingSlash ?? false,
+      redirects: config?.redirects,
+      rewrites: config?.rewrites,
+      headers: config?.headers,
+      expireTime: config?.expireTime,
+      i18n: config?.i18n ?? null,
+    },
+    DEFAULT_EXPIRE_TIME,
+  );
   const manifestCode = buildAppRscManifestCode({ routes, metadataRoutes, globalErrorPath });
   const {
     imports,
@@ -398,15 +417,15 @@ async function buildPageElements(route, params, routePath, pageRequest) {
   });
 }
 
-const __basePath = ${JSON.stringify(bp)};
-const __trailingSlash = ${JSON.stringify(ts)};
-const __i18nConfig = ${JSON.stringify(i18nConfig)};
-const __configRedirects = ${JSON.stringify(redirects)};
-const __configRewrites = ${JSON.stringify(rewrites)};
-const __configHeaders = ${JSON.stringify(headers)};
+const __basePath = ${basePathJson};
+const __trailingSlash = ${trailingSlashJson};
+const __i18nConfig = ${i18nJson};
+const __configRedirects = ${redirectsJson};
+const __configRewrites = ${rewritesJson};
+const __configHeaders = ${headersJson};
 const __publicFiles = new Set(${JSON.stringify(publicFiles)});
 const __allowedOrigins = ${JSON.stringify(allowedOrigins)};
-const __expireTime = ${JSON.stringify(expireTime)};
+const __expireTime = ${expireTimeJson};
 
 ${generateDevOriginCheckCode(config?.allowedDevOrigins)}
 

--- a/packages/vinext/src/entries/pages-server-entry.ts
+++ b/packages/vinext/src/entries/pages-server-entry.ts
@@ -7,7 +7,12 @@
  *
  * Extracted from index.ts.
  */
-import { resolveEntryPath, normalizePathSeparators } from "./runtime-entry-module.js";
+import {
+  generateIsrWrapperCode,
+  normalizePathSeparators,
+  resolveEntryPath,
+  serializePagesConfig,
+} from "./runtime-entry-module.js";
 import { pagesRouter, apiRouter, type Route } from "../routing/pages-router.js";
 import { createValidFileMatcher } from "../routing/file-matcher.js";
 import { type ResolvedNextConfig } from "../config/next-config.js";
@@ -78,38 +83,14 @@ export async function generateServerEntry(
       ? `import { default as DocumentComponent } from ${JSON.stringify(normalizePathSeparators(docFilePath))};`
       : `const DocumentComponent = null;`;
 
-  // Serialize i18n config for embedding in the server entry
-  const i18nConfigJson = nextConfig?.i18n
-    ? JSON.stringify({
-        locales: nextConfig.i18n.locales,
-        defaultLocale: nextConfig.i18n.defaultLocale,
-        localeDetection: nextConfig.i18n.localeDetection,
-        domains: nextConfig.i18n.domains,
-      })
-    : "null";
+  // Serialize i18n + full resolved config for embedding in the server entry.
+  // The full config (redirects, rewrites, headers, basePath, trailingSlash, …)
+  // is embedded so prod-server.ts can apply them without loading
+  // next.config.js at runtime.
+  const { i18nConfigJson, vinextConfigJson } = serializePagesConfig(nextConfig);
 
   // Embed the resolved build ID at build time
   const buildIdJson = JSON.stringify(nextConfig?.buildId ?? null);
-
-  // Serialize the full resolved config for the production server.
-  // This embeds redirects, rewrites, headers, basePath, trailingSlash
-  // so prod-server.ts can apply them without loading next.config.js at runtime.
-  const vinextConfigJson = JSON.stringify({
-    basePath: nextConfig?.basePath ?? "",
-    trailingSlash: nextConfig?.trailingSlash ?? false,
-    redirects: nextConfig?.redirects ?? [],
-    rewrites: nextConfig?.rewrites ?? { beforeFiles: [], afterFiles: [], fallback: [] },
-    headers: nextConfig?.headers ?? [],
-    expireTime: nextConfig?.expireTime,
-    i18n: nextConfig?.i18n ?? null,
-    images: {
-      deviceSizes: nextConfig?.images?.deviceSizes,
-      imageSizes: nextConfig?.images?.imageSizes,
-      dangerouslyAllowSVG: nextConfig?.images?.dangerouslyAllowSVG,
-      contentDispositionType: nextConfig?.images?.contentDispositionType,
-      contentSecurityPolicy: nextConfig?.images?.contentSecurityPolicy,
-    },
-  });
 
   // Generate instrumentation code if instrumentation.ts exists.
   // For production (Cloudflare Workers), instrumentation.ts is bundled into the
@@ -215,18 +196,7 @@ const buildId = ${buildIdJson};
 // Full resolved config for production server (embedded at build time)
 export const vinextConfig = ${vinextConfigJson};
 
-function isrGet(key) {
-  return __sharedIsrGet(key);
-}
-function isrSet(key, data, revalidateSeconds, tags, expireSeconds) {
-  return __sharedIsrSet(key, data, revalidateSeconds, tags, expireSeconds);
-}
-function triggerBackgroundRegeneration(key, renderFn, errorContext) {
-  return __sharedTriggerBackgroundRegeneration(key, renderFn, errorContext);
-}
-function isrCacheKey(router, pathname) {
-  return __sharedIsrCacheKey(router, pathname, buildId || undefined);
-}
+${generateIsrWrapperCode()}
 
 async function renderToStringAsync(element) {
   const stream = await renderToReadableStream(element);

--- a/packages/vinext/src/entries/runtime-entry-module.ts
+++ b/packages/vinext/src/entries/runtime-entry-module.ts
@@ -70,6 +70,7 @@ type EntryConfigInput = {
   headers?: NextHeader[];
   expireTime?: number;
   i18n?: NextI18nConfig | null;
+  /** Pages-only — consumed by `serializePagesConfig` for `vinextConfigJson`; ignored by `serializeAppConfig`. */
   images?: {
     deviceSizes?: number[];
     imageSizes?: number[];

--- a/packages/vinext/src/entries/runtime-entry-module.ts
+++ b/packages/vinext/src/entries/runtime-entry-module.ts
@@ -1,6 +1,13 @@
 import fs from "node:fs";
 import { fileURLToPath } from "node:url";
 
+import type {
+  NextHeader,
+  NextI18nConfig,
+  NextRedirect,
+  NextRewrite,
+} from "../config/next-config.js";
+
 /**
  * Convert Windows-style backslash path separators to forward slashes.
  *
@@ -45,4 +52,143 @@ export function resolveRuntimeEntryModule(name: string): string {
   }
 
   return resolveEntryPath(`../server/${name}.js`, import.meta.url);
+}
+
+/**
+ * Subset of resolved Next config consumed by the entry-config serializers.
+ *
+ * Both Pages and App generators receive the same `ResolvedNextConfig` upstream
+ * but only need a handful of routing/i18n/cache fields. Typing the helpers
+ * against this minimal shape keeps `runtime-entry-module.ts` from depending on
+ * the full `ResolvedNextConfig` import surface.
+ */
+type EntryConfigInput = {
+  basePath?: string;
+  trailingSlash?: boolean;
+  redirects?: NextRedirect[];
+  rewrites?: { beforeFiles: NextRewrite[]; afterFiles: NextRewrite[]; fallback: NextRewrite[] };
+  headers?: NextHeader[];
+  expireTime?: number;
+  i18n?: NextI18nConfig | null;
+  images?: {
+    deviceSizes?: number[];
+    imageSizes?: number[];
+    dangerouslyAllowSVG?: boolean;
+    contentDispositionType?: string;
+    contentSecurityPolicy?: string;
+  };
+};
+
+/**
+ * Serialize the config bundle embedded in the Pages Router server entry.
+ *
+ * Returns two JSON literal strings ready to drop into the generated module:
+ *   - `vinextConfigJson` — the full config snapshot exported as `vinextConfig`
+ *     (basePath, trailingSlash, redirects/rewrites/headers, expireTime, i18n,
+ *     images) so `prod-server.ts` can apply them without re-loading
+ *     `next.config.js` at runtime.
+ *   - `i18nConfigJson` — a narrower projection used directly by the SSR entry
+ *     for locale detection (`null` when i18n is not configured).
+ *
+ * Centralizing this shape avoids duplicate `JSON.stringify` chains drifting
+ * between entry generators.
+ */
+export function serializePagesConfig(nextConfig: EntryConfigInput | null | undefined): {
+  vinextConfigJson: string;
+  i18nConfigJson: string;
+} {
+  const i18nConfigJson = nextConfig?.i18n
+    ? JSON.stringify({
+        locales: nextConfig.i18n.locales,
+        defaultLocale: nextConfig.i18n.defaultLocale,
+        localeDetection: nextConfig.i18n.localeDetection,
+        domains: nextConfig.i18n.domains,
+      })
+    : "null";
+
+  const vinextConfigJson = JSON.stringify({
+    basePath: nextConfig?.basePath ?? "",
+    trailingSlash: nextConfig?.trailingSlash ?? false,
+    redirects: nextConfig?.redirects ?? [],
+    rewrites: nextConfig?.rewrites ?? { beforeFiles: [], afterFiles: [], fallback: [] },
+    headers: nextConfig?.headers ?? [],
+    expireTime: nextConfig?.expireTime,
+    i18n: nextConfig?.i18n ?? null,
+    images: {
+      deviceSizes: nextConfig?.images?.deviceSizes,
+      imageSizes: nextConfig?.images?.imageSizes,
+      dangerouslyAllowSVG: nextConfig?.images?.dangerouslyAllowSVG,
+      contentDispositionType: nextConfig?.images?.contentDispositionType,
+      contentSecurityPolicy: nextConfig?.images?.contentSecurityPolicy,
+    },
+  });
+
+  return { vinextConfigJson, i18nConfigJson };
+}
+
+/**
+ * Serialize the per-field config literals embedded in the App Router RSC entry.
+ *
+ * Unlike Pages (which exports a single `vinextConfig` object), the RSC entry
+ * embeds each field as its own top-level `const` so generated-code references
+ * stay terse. This helper returns the JSON-stringified literal for each one,
+ * applying the same defaults the RSC entry used inline before extraction.
+ *
+ * @param config       Resolved config slice (same shape Pages consumes).
+ * @param defaultExpireTime  Fallback value for `expireTime`. The RSC entry uses
+ *   `DEFAULT_EXPIRE_TIME = 31_536_000` from `app-rsc-entry.ts`; passing it in
+ *   keeps the constant ownership unchanged.
+ */
+export function serializeAppConfig(
+  config: EntryConfigInput | null | undefined,
+  defaultExpireTime: number,
+): {
+  basePathJson: string;
+  trailingSlashJson: string;
+  i18nJson: string;
+  redirectsJson: string;
+  rewritesJson: string;
+  headersJson: string;
+  expireTimeJson: string;
+} {
+  return {
+    basePathJson: JSON.stringify(config?.basePath ?? ""),
+    trailingSlashJson: JSON.stringify(config?.trailingSlash ?? false),
+    i18nJson: JSON.stringify(config?.i18n ?? null),
+    redirectsJson: JSON.stringify(config?.redirects ?? []),
+    rewritesJson: JSON.stringify(
+      config?.rewrites ?? { beforeFiles: [], afterFiles: [], fallback: [] },
+    ),
+    headersJson: JSON.stringify(config?.headers ?? []),
+    expireTimeJson: JSON.stringify(config?.expireTime ?? defaultExpireTime),
+  };
+}
+
+/**
+ * Generate the four ISR forwarder functions that wrap the shared `isr-cache`
+ * helpers in a Pages/App server entry.
+ *
+ * The wrappers exist so the rest of the generated module can call short,
+ * stable names (`isrGet`, `isrSet`, `isrCacheKey`,
+ * `triggerBackgroundRegeneration`) regardless of how the underlying module
+ * exposes them, and so the cache-key helper can close over the build ID
+ * without every call site repeating it.
+ *
+ * Assumes the surrounding entry has already imported the `__shared*` symbols
+ * from `isr-cache.js` (under those exact aliases) and declared a `buildId`
+ * binding in scope.
+ */
+export function generateIsrWrapperCode(): string {
+  return `function isrGet(key) {
+  return __sharedIsrGet(key);
+}
+function isrSet(key, data, revalidateSeconds, tags, expireSeconds) {
+  return __sharedIsrSet(key, data, revalidateSeconds, tags, expireSeconds);
+}
+function triggerBackgroundRegeneration(key, renderFn, errorContext) {
+  return __sharedTriggerBackgroundRegeneration(key, renderFn, errorContext);
+}
+function isrCacheKey(router, pathname) {
+  return __sharedIsrCacheKey(router, pathname, buildId || undefined);
+}`;
 }


### PR DESCRIPTION
## Summary

Pure refactor of the entry-template generators to consolidate the bits that pages-server-entry.ts and app-rsc-entry.ts copy-pasted from each other:

- **A. ISR wrappers** — `pages-server-entry.ts` emitted four thin forwarder functions (`isrGet` / `isrSet` / `isrCacheKey` / `triggerBackgroundRegeneration`) over the shared `__sharedIsr*` imports. Extracted to `generateIsrWrapperCode()` in `runtime-entry-module.ts` so future entries can reuse the block.
- **B. Config serialization** — both generators serialized the same Resolved­NextConfig slice (basePath, trailingSlash, redirects, rewrites, headers, expireTime, i18n) via near-identical `JSON.stringify` chains. Extracted as two helpers in `runtime-entry-module.ts`:
  - `serializePagesConfig()` returns the compound `vinextConfigJson` object plus the narrower `i18nConfigJson` projection consumed by the SSR entry.
  - `serializeAppConfig()` returns per-field JSON literals matching the App Router RSC entry's `__basePath` / `__configRedirects` / `__expireTime` style. The existing `DEFAULT_EXPIRE_TIME` stays in `app-rsc-entry.ts` and is passed in.

The emitted runtime code is byte-identical to before (each replacement re-derives the same `JSON.stringify` chain on the same input). Verified by inspecting the per-field diff plus a full pass of `tests/app-router.test.ts` and `tests/pages-router.test.ts` (508/508 passing; one teardown-hook flake unrelated to this change). Follow-up to #1058 and #1079.

### Files changed

- `packages/vinext/src/entries/runtime-entry-module.ts` — new `generateIsrWrapperCode()`, `serializePagesConfig()`, `serializeAppConfig()`, and a private `EntryConfigInput` type.
- `packages/vinext/src/entries/pages-server-entry.ts` — calls the two helpers.
- `packages/vinext/src/entries/app-rsc-entry.ts` — calls `serializeAppConfig()`; the `bp` / `ts` / `redirects` / etc. locals collapse into the destructured JSON literals.

## Test plan

- [x] `pnpm vp test run tests/app-router.test.ts tests/pages-router.test.ts` — 508/508 passing.
- [x] `pnpm fmt --write` clean.
- [x] `pnpm knip` clean (no unused exports).
- [x] `tsc --noEmit` clean.
- [x] Diff inspection: each replaced `JSON.stringify(x)` reduces to the same chain on the same input, so emitted-string output is byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)