### PR TITLE
refactor(routing+server): unify route-match preamble and middleware header merge

### DIFF
--- a/packages/vinext/src/routing/app-router.ts
+++ b/packages/vinext/src/routing/app-router.ts
@@ -13,9 +13,8 @@
  * - Error: app/error.tsx -> ErrorBoundary
  * - Not Found: app/not-found.tsx
  */
-import { normalizePathnameForRouteMatch } from "./utils.js";
 import { createValidFileMatcher, type ValidFileMatcher } from "./file-matcher.js";
-import { buildRouteTrie, trieMatch, type TrieNode } from "./route-trie.js";
+import { createRouteTrieCache, matchRouteWithTrie } from "./route-matching.js";
 import { buildAppRouteGraph, type AppRoute, type AppRouteGraphRoute } from "./app-route-graph.js";
 export type { AppRoute } from "./app-route-graph.js";
 export { computeRootParamNames } from "./app-route-graph.js";
@@ -53,16 +52,7 @@ export async function appRouter(
 }
 
 // Trie cache — keyed by route array identity (same array = same trie)
-const appTrieCache = new WeakMap<AppRoute[], TrieNode<AppRoute>>();
-
-function getOrBuildAppTrie(routes: AppRoute[]): TrieNode<AppRoute> {
-  let trie = appTrieCache.get(routes);
-  if (!trie) {
-    trie = buildRouteTrie(routes);
-    appTrieCache.set(routes, trie);
-  }
-  return trie;
-}
+const appTrieCache = createRouteTrieCache<AppRoute>();
 
 /**
  * Match a URL against App Router routes.
@@ -71,12 +61,5 @@ export function matchAppRoute(
   url: string,
   routes: AppRoute[],
 ): { route: AppRoute; params: Record<string, string | string[]> } | null {
-  const pathname = url.split("?")[0];
-  let normalizedUrl = pathname === "/" ? "/" : pathname.replace(/\/$/, "");
-  normalizedUrl = normalizePathnameForRouteMatch(normalizedUrl);
-
-  // Split URL once, look up via trie
-  const urlParts = normalizedUrl.split("/").filter(Boolean);
-  const trie = getOrBuildAppTrie(routes);
-  return trieMatch(trie, urlParts);
+  return matchRouteWithTrie(url, routes, appTrieCache);
 }

--- a/packages/vinext/src/routing/pages-router.ts
+++ b/packages/vinext/src/routing/pages-router.ts
@@ -1,12 +1,12 @@
 import path from "node:path";
-import { compareRoutes, decodeRouteSegment, normalizePathnameForRouteMatch } from "./utils.js";
+import { compareRoutes, decodeRouteSegment } from "./utils.js";
 import {
   createValidFileMatcher,
   scanWithExtensions,
   type ValidFileMatcher,
 } from "./file-matcher.js";
 import { patternToNextFormat, validateRoutePatterns } from "./route-validation.js";
-import { buildRouteTrie, trieMatch, type TrieNode } from "./route-trie.js";
+import { createRouteTrieCache, matchRouteWithTrie } from "./route-matching.js";
 
 export type Route = {
   /** URL pattern, e.g. "/" or "/about" or "/posts/:id" */
@@ -163,16 +163,7 @@ function fileToRoute(file: string, pagesDir: string, matcher: ValidFileMatcher):
 }
 
 // Trie cache — keyed by route array identity (same array = same trie)
-const trieCache = new WeakMap<Route[], TrieNode<Route>>();
-
-function getOrBuildTrie(routes: Route[]): TrieNode<Route> {
-  let trie = trieCache.get(routes);
-  if (!trie) {
-    trie = buildRouteTrie(routes);
-    trieCache.set(routes, trie);
-  }
-  return trie;
-}
+const trieCache = createRouteTrieCache<Route>();
 
 /**
  * Match a URL path against a route pattern.
@@ -182,15 +173,7 @@ export function matchRoute(
   url: string,
   routes: Route[],
 ): { route: Route; params: Record<string, string | string[]> } | null {
-  // Normalize: strip query string and trailing slash
-  const pathname = url.split("?")[0];
-  let normalizedUrl = pathname === "/" ? "/" : pathname.replace(/\/$/, "");
-  normalizedUrl = normalizePathnameForRouteMatch(normalizedUrl);
-
-  // Split URL once, look up via trie
-  const urlParts = normalizedUrl.split("/").filter(Boolean);
-  const trie = getOrBuildTrie(routes);
-  return trieMatch(trie, urlParts);
+  return matchRouteWithTrie(url, routes, trieCache);
 }
 
 /**

--- a/packages/vinext/src/routing/route-matching.ts
+++ b/packages/vinext/src/routing/route-matching.ts
@@ -1,0 +1,58 @@
+/**
+ * Shared route-match preamble used by both Pages Router and App Router.
+ *
+ * Both routers normalize URLs and call `trieMatch` with nearly-identical
+ * preamble: strip query, trailing-slash normalize, run
+ * `normalizePathnameForRouteMatch`, split into url parts, then look up via a
+ * per-routes-array trie cache. This module factors that out so each router
+ * just calls `matchRouteWithTrie(url, routes)`.
+ */
+import { normalizePathnameForRouteMatch } from "./utils.js";
+import { buildRouteTrie, trieMatch, type TrieNode } from "./route-trie.js";
+
+// Trie cache — keyed by route array identity (same array = same trie).
+// Each caller gets its own cache via `createRouteTrieCache()`, so different
+// route shapes (Pages routes vs App routes) don't share a cache slot.
+type RouteTrieCache<R extends { patternParts: string[] }> = WeakMap<R[], TrieNode<R>>;
+
+export function createRouteTrieCache<R extends { patternParts: string[] }>(): RouteTrieCache<R> {
+  return new WeakMap<R[], TrieNode<R>>();
+}
+
+function getOrBuildTrie<R extends { patternParts: string[] }>(
+  cache: RouteTrieCache<R>,
+  routes: R[],
+): TrieNode<R> {
+  let trie = cache.get(routes);
+  if (!trie) {
+    trie = buildRouteTrie(routes);
+    cache.set(routes, trie);
+  }
+  return trie;
+}
+
+/**
+ * Match a URL path against a list of routes via the shared preamble:
+ *   1. strip query string
+ *   2. trailing-slash normalize (preserving root "/")
+ *   3. run `normalizePathnameForRouteMatch`
+ *   4. split into url parts and look up via the (cached) trie
+ *
+ * Generic over the route shape; both Pages `Route` and App `AppRoute`
+ * satisfy `{ patternParts: string[] }`.
+ */
+export function matchRouteWithTrie<R extends { patternParts: string[] }>(
+  url: string,
+  routes: R[],
+  cache: RouteTrieCache<R>,
+): { route: R; params: Record<string, string | string[]> } | null {
+  // Normalize: strip query string and trailing slash
+  const pathname = url.split("?")[0];
+  let normalizedUrl = pathname === "/" ? "/" : pathname.replace(/\/$/, "");
+  normalizedUrl = normalizePathnameForRouteMatch(normalizedUrl);
+
+  // Split URL once, look up via trie
+  const urlParts = normalizedUrl.split("/").filter(Boolean);
+  const trie = getOrBuildTrie(cache, routes);
+  return trieMatch(trie, urlParts);
+}


### PR DESCRIPTION
## Summary

### Part A — route-matching preamble (shipped)
Both Pages Router (`matchRoute` in `routing/pages-router.ts`) and App Router (`matchAppRoute` in `routing/app-router.ts`) had nearly identical preambles around `trieMatch`: strip query, trailing-slash normalize, run `normalizePathnameForRouteMatch`, split into url parts, then look up via a per-routes-array `WeakMap` trie cache. Each side also had its own `getOrBuildTrie` helper.

Extracted into a new `routing/route-matching.ts`:
- `matchRouteWithTrie<R extends { patternParts: string[] }>(url, routes, cache)` — generic over the route shape; both `Route` (Pages) and `AppRoute` satisfy the constraint.
- `createRouteTrieCache<R>()` — each router still owns its own cache instance, so different route shapes don't share a slot.

`matchRoute` and `matchAppRoute` are now thin wrappers; the public API is unchanged.

### Part B — pages middleware header merge (deferred)
Originally planned to migrate `applyGsspHeaders` (in `server/pages-page-response.ts`) to the shared `mergeMiddlewareResponseHeaders` helper. After reading both sides carefully, the semantics are non-trivially divergent:

- `applyGsspHeaders` reads from `PagesGsspResponse.getHeaders()`, which returns Node-style `OutgoingHttpHeaders` (`Record<string, string | number | boolean | string[]>`). The shared helper iterates a Web `Headers` object.
- `applyGsspHeaders` joins non-cookie `string[]` values with `", "` and uses `set()`. The shared helper has no such path.
- `applyGsspHeaders` does not Vary-merge (it would `, `-join + `set` if Vary ever arrived as an array, which collapses RFC 9110 `*` semantics differently from `mergeVaryHeader`).
- `applyGsspHeaders` only appends Set-Cookie when the value is an array; a singular string falls through to `set()`. The shared helper always appends.
- It also forces `Content-Type: text/html` and returns `statusCode`.

Collapsing those into the shared helper without breaking subtle production semantics needs either a Node-headers adapter or a meaningful API extension. Per the conservative-parity directive, deferring as a separate PR rather than risking silent behavior change here.

Pure refactor; no behavior change. Follow-up to #1058.

## Files
- `packages/vinext/src/routing/route-matching.ts` (new) — generic `matchRouteWithTrie` + `createRouteTrieCache`.
- `packages/vinext/src/routing/pages-router.ts` — `matchRoute` delegates to shared helper.
- `packages/vinext/src/routing/app-router.ts` — `matchAppRoute` delegates to shared helper.

## Test plan
- [x] `pnpm vp test run tests/app-router.test.ts tests/routing.test.ts tests/route-trie.test.ts` — 481 passed.
- [x] `pnpm vp test run tests/pages-router.test.ts` — 200 passed (one pre-existing `afterAll` teardown timeout in the `allowedDevOrigins` suite, unrelated to this change; reproduces on `main`).
- [x] `pnpm fmt --write` clean.
- [x] `pnpm knip` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)