### PR TITLE
refactor(server): dedupe HTTP error response builders

### DIFF
--- a/packages/vinext/src/server/app-middleware.ts
+++ b/packages/vinext/src/server/app-middleware.ts
@@ -6,6 +6,7 @@ import { buildRequestHeadersFromMiddlewareResponse } from "./middleware-request-
 import { mergeMiddlewareResponseHeaders } from "./middleware-response-headers.js";
 import { executeMiddleware, type MiddlewareModule } from "./middleware-runtime.js";
 import { processMiddlewareHeaders } from "./request-pipeline.js";
+import { internalServerErrorResponse } from "./http-error-responses.js";
 
 export type AppMiddlewareContext = {
   headers: Headers | null;
@@ -202,7 +203,7 @@ export async function applyAppMiddleware(
       if (result.response) {
         return { kind: "response", response: result.response };
       }
-      return { kind: "response", response: new Response("Internal Server Error", { status: 500 }) };
+      return { kind: "response", response: internalServerErrorResponse() };
     }
 
     if (result.responseHeaders) {

--- a/packages/vinext/src/server/app-page-method.ts
+++ b/packages/vinext/src/server/app-page-method.ts
@@ -1,5 +1,6 @@
 import { isPossibleAppRouteActionRequest } from "./app-route-handler-policy.js";
 import { mergeMiddlewareResponseHeaders } from "./middleware-response-headers.js";
+import { methodNotAllowedResponse } from "./http-error-responses.js";
 
 type AppPageMethodPolicyOptions = {
   dynamicConfig?: string;
@@ -55,10 +56,6 @@ export function resolveAppPageMethodResponse(
 
   const headers = new Headers();
   mergeMiddlewareResponseHeaders(headers, options.middlewareHeaders ?? null);
-  headers.set("Allow", "GET, HEAD");
 
-  return new Response("Method Not Allowed", {
-    headers,
-    status: 405,
-  });
+  return methodNotAllowedResponse("GET, HEAD", { headers });
 }

--- a/packages/vinext/src/server/app-page-request.ts
+++ b/packages/vinext/src/server/app-page-request.ts
@@ -1,5 +1,6 @@
 import type { AppPageSpecialError } from "./app-page-execution.js";
 import { getAppPageSegmentParamName } from "./app-page-params.js";
+import { notFoundResponse } from "./http-error-responses.js";
 
 type AppPageParams = Record<string, string | string[]>;
 type GenerateStaticParams = (args: { params: AppPageParams }) => unknown;
@@ -254,7 +255,7 @@ export async function validateAppPageDynamicParams(
   const generateStaticParamsSources = normalizeGenerateStaticParams(options.generateStaticParams);
   if (generateStaticParamsSources.length === 0) {
     options.clearRequestContext();
-    return new Response("Not Found", { status: 404 });
+    return notFoundResponse();
   }
 
   for (const source of generateStaticParamsSources) {
@@ -264,7 +265,7 @@ export async function validateAppPageDynamicParams(
       });
       if (Array.isArray(staticParams) && !areStaticParamsAllowed(options.params, staticParams)) {
         options.clearRequestContext();
-        return new Response("Not Found", { status: 404 });
+        return notFoundResponse();
       }
     } catch (error) {
       options.logGenerateStaticParamsError?.(error);

--- a/packages/vinext/src/server/app-prerender-endpoints.ts
+++ b/packages/vinext/src/server/app-prerender-endpoints.ts
@@ -1,4 +1,5 @@
 import { callAppPrerenderStaticParams } from "./app-prerender-static-params.js";
+import { notFoundResponse } from "./http-error-responses.js";
 import type { RootParams } from "vinext/shims/root-params";
 
 type GenerateStaticParams = (args: { params: RootParams }) => unknown;
@@ -46,7 +47,7 @@ async function handleStaticParamsEndpoint(
   options: HandleAppPrerenderEndpointOptions,
 ): Promise<Response> {
   if (!isEnabled(options)) {
-    return new Response("Not Found", { status: 404 });
+    return notFoundResponse();
   }
 
   const url = new URL(request.url);
@@ -77,7 +78,7 @@ async function handlePagesStaticPathsEndpoint(
   options: HandleAppPrerenderEndpointOptions,
 ): Promise<Response> {
   if (!isEnabled(options)) {
-    return new Response("Not Found", { status: 404 });
+    return notFoundResponse();
   }
 
   const url = new URL(request.url);

--- a/packages/vinext/src/server/app-router-entry.ts
+++ b/packages/vinext/src/server/app-router-entry.ts
@@ -21,6 +21,7 @@ import {
   filterInternalHeaders,
   isOpenRedirectShaped,
 } from "./request-pipeline.js";
+import { badRequestResponse, notFoundResponse } from "./http-error-responses.js";
 
 type WorkerAssetEnv = {
   ASSETS?: {
@@ -41,7 +42,7 @@ export default {
     // percent-encoded variants are caught — encoded forms survive segment-wise
     // decoding and would otherwise reach trailing-slash redirect emitters.
     if (isOpenRedirectShaped(url.pathname)) {
-      return new Response("404 Not Found", { status: 404 });
+      return notFoundResponse();
     }
 
     // Validate that percent-encoding is well-formed. The RSC handler performs
@@ -51,7 +52,7 @@ export default {
       decodeURIComponent(url.pathname);
     } catch {
       // Malformed percent-encoding (e.g. /%E0%A4%A) — return 400 instead of throwing.
-      return new Response("Bad Request", { status: 400 });
+      return badRequestResponse();
     }
 
     // Strip internal headers from inbound requests before any handler or
@@ -86,7 +87,7 @@ export default {
     }
 
     if (result === null || result === undefined) {
-      return new Response("Not Found", { status: 404 });
+      return notFoundResponse();
     }
 
     return new Response(String(result), { status: 200 });

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -33,6 +33,7 @@ import {
 } from "./app-rsc-cache-busting.js";
 import { finalizeAppRscResponse } from "./app-rsc-response-finalizer.js";
 import { normalizeRscRequest } from "./app-rsc-request-normalization.js";
+import { notFoundResponse } from "./http-error-responses.js";
 import { getScriptNonceFromHeaderSources } from "./csp.js";
 import { buildPageCacheTags } from "./implicit-tags.js";
 import { handleMetadataRouteRequest } from "./metadata-route-response.js";
@@ -419,19 +420,19 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
       return pagesFallbackResponse;
     }
 
-    const notFoundResponse = await options.renderNotFound({
+    const renderedNotFoundResponse = await options.renderNotFound({
       isRscRequest,
       middlewareContext,
       request,
       route: null,
       scriptNonce,
     });
-    if (notFoundResponse) return notFoundResponse;
+    if (renderedNotFoundResponse) return renderedNotFoundResponse;
 
     options.clearRequestContext();
     const headers = new Headers();
     mergeMiddlewareResponseHeaders(headers, middlewareContext.headers);
-    return new Response("Not Found", { status: 404, headers });
+    return notFoundResponse({ headers });
   }
 
   const { route, params } = match;

--- a/packages/vinext/src/server/app-rsc-request-normalization.ts
+++ b/packages/vinext/src/server/app-rsc-request-normalization.ts
@@ -4,6 +4,7 @@ import { guardProtocolRelativeUrl } from "./request-pipeline.js";
 import { hasBasePath, stripBasePath } from "../utils/base-path.js";
 import { normalizeMountedSlotsHeader } from "./app-mounted-slots-header.js";
 import { stripRscSuffix } from "./app-rsc-cache-busting.js";
+import { badRequestResponse, notFoundResponse } from "./http-error-responses.js";
 
 export { normalizeMountedSlotsHeader } from "./app-mounted-slots-header.js";
 
@@ -68,7 +69,7 @@ export function normalizeRscRequest(
   try {
     decoded = normalizePathnameForRouteMatchStrict(url.pathname);
   } catch {
-    return new Response("Bad Request", { status: 400 });
+    return badRequestResponse();
   }
 
   // Step 4: Collapse double-slashes and resolve . / .. segments.
@@ -80,7 +81,7 @@ export function normalizeRscRequest(
   // that must be reachable regardless of basePath configuration.
   if (basePath) {
     if (!hasBasePath(pathname, basePath) && !pathname.startsWith("/__vinext/")) {
-      return new Response("Not Found", { status: 404 });
+      return notFoundResponse();
     }
     pathname = stripBasePath(pathname, basePath);
   }

--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -15,6 +15,7 @@ import {
   getServerActionNotFoundMessage,
   isServerActionNotFoundError,
 } from "./server-action-not-found.js";
+import { internalServerErrorResponse, payloadTooLargeResponse } from "./http-error-responses.js";
 
 type AppPageParams = Record<string, string | string[]>;
 
@@ -278,10 +279,6 @@ function isActionHttpFallback(error: unknown): boolean {
   return digest !== null && parseNextHttpErrorDigest(digest) !== null;
 }
 
-function payloadTooLargeResponse(): Response {
-  return new Response("Payload Too Large", { status: 413 });
-}
-
 function createServerActionErrorResponse(
   error: unknown,
   options: {
@@ -304,11 +301,10 @@ function createServerActionErrorResponse(
     { routerKind: "App Router", routePath: options.cleanPathname, routeType: "action" },
   );
   options.clearRequestContext();
-  return new Response(
+  return internalServerErrorResponse(
     process.env.NODE_ENV === "production"
-      ? "Internal Server Error"
+      ? undefined
       : "Server action failed: " + getServerActionFailureMessage(error),
-    { status: 500 },
   );
 }
 
@@ -447,11 +443,10 @@ export async function handleProgressiveServerActionRequest(
       { routerKind: "App Router", routePath: options.cleanPathname, routeType: "action" },
     );
     options.clearRequestContext();
-    return new Response(
+    return internalServerErrorResponse(
       process.env.NODE_ENV === "production"
-        ? "Internal Server Error"
+        ? undefined
         : "Server action failed: " + getServerActionFailureMessage(error),
-      { status: 500 },
     );
   }
 }

--- a/packages/vinext/src/server/app-ssr-entry.ts
+++ b/packages/vinext/src/server/app-ssr-entry.ts
@@ -15,6 +15,7 @@ import {
 } from "vinext/shims/navigation";
 import { runWithNavigationContext } from "vinext/shims/navigation-state";
 import { isOpenRedirectShaped } from "./request-pipeline.js";
+import { notFoundResponse } from "./http-error-responses.js";
 import { withScriptNonce } from "vinext/shims/script-nonce-context";
 import {
   createInlineScriptTag,
@@ -268,7 +269,7 @@ export default {
     // Block protocol-relative URL open redirects (including percent-encoded
     // variants like /%5Cevil.com/). See request-pipeline.ts for details.
     if (isOpenRedirectShaped(url.pathname)) {
-      return new Response("404 Not Found", { status: 404 });
+      return notFoundResponse();
     }
 
     const rscModule = await import.meta.viteRsc.loadModule<{
@@ -281,7 +282,7 @@ export default {
     }
 
     if (result == null) {
-      return new Response("Not Found", { status: 404 });
+      return notFoundResponse();
     }
 
     return new Response(String(result), { status: 200 });

--- a/packages/vinext/src/server/http-error-responses.ts
+++ b/packages/vinext/src/server/http-error-responses.ts
@@ -1,0 +1,90 @@
+/**
+ * Shared HTTP error response builders.
+ *
+ * Centralizes the canonical `new Response("...", { status: 4xx | 5xx })` patterns
+ * that previously were scattered across server modules. Each helper standardizes
+ * the canonical body for its status; the optional `headers` argument lets callers
+ * merge middleware/middleware-context headers without re-implementing the
+ * `new Response(...)` boilerplate.
+ *
+ * Sites with route-specific bodies (e.g. `"404 - API route not found"`,
+ * `"Image not found"`, generated worker templates) intentionally remain inline
+ * because their bodies are either tested-against fixtures or run inside template
+ * strings that have no access to runtime imports.
+ *
+ * Follow-up to #1058 / #1071 / #1078, which extracted the first batch of these
+ * helpers (action/page error responses, `forbiddenResponse`, `payloadTooLargeResponse`).
+ */
+
+type ErrorResponseInit = {
+  headers?: HeadersInit;
+};
+
+/**
+ * Build a 400 Bad Request plain-text response.
+ *
+ * Used for malformed percent-encoding, invalid HTTP methods (where Next.js
+ * returns 400), and other request-shape validation failures.
+ */
+export function badRequestResponse(init?: ErrorResponseInit): Response {
+  return new Response("Bad Request", { status: 400, headers: init?.headers });
+}
+
+/**
+ * Build a 403 Forbidden plain-text response.
+ *
+ * Used by CSRF origin validation and dev-server origin checks.
+ */
+export function forbiddenResponse(): Response {
+  return new Response("Forbidden", { status: 403, headers: { "Content-Type": "text/plain" } });
+}
+
+/**
+ * Build a 404 Not Found plain-text response.
+ *
+ * The `headers` option lets call sites merge middleware response headers into
+ * the 404, matching the pattern used by `app-rsc-handler` after a route match
+ * fails but middleware has already contributed headers.
+ */
+export function notFoundResponse(init?: ErrorResponseInit): Response {
+  return new Response("Not Found", { status: 404, headers: init?.headers });
+}
+
+/**
+ * Build a 405 Method Not Allowed plain-text response with the `Allow` header set.
+ *
+ * `allowedMethods` is rendered as the comma-separated `Allow` header value.
+ * Existing headers (e.g. middleware response headers) can be merged via `init.headers`;
+ * the `Allow` header takes precedence and overwrites any colliding entry.
+ */
+export function methodNotAllowedResponse(
+  allowedMethods: string,
+  init?: ErrorResponseInit,
+): Response {
+  const headers = new Headers(init?.headers);
+  headers.set("Allow", allowedMethods);
+  return new Response("Method Not Allowed", { status: 405, headers });
+}
+
+/**
+ * Build a 413 Payload Too Large plain-text response.
+ *
+ * Used by server action body-size enforcement.
+ */
+export function payloadTooLargeResponse(): Response {
+  return new Response("Payload Too Large", { status: 413 });
+}
+
+/**
+ * Build a 500 Internal Server Error plain-text response.
+ *
+ * The `message` argument lets dev-mode handlers surface failure details while
+ * production paths fall back to the canonical body. Pass `undefined` (or omit)
+ * to use the canonical "Internal Server Error" body.
+ */
+export function internalServerErrorResponse(message?: string, init?: ErrorResponseInit): Response {
+  return new Response(message ?? "Internal Server Error", {
+    status: 500,
+    headers: init?.headers,
+  });
+}

--- a/packages/vinext/src/server/image-optimization.ts
+++ b/packages/vinext/src/server/image-optimization.ts
@@ -17,6 +17,8 @@
  * as-is (no transformation) with security headers applied.
  */
 
+import { badRequestResponse } from "./http-error-responses.js";
+
 /** The pathname that triggers image optimization. */
 export const IMAGE_OPTIMIZATION_PATH = "/_vinext/image";
 
@@ -216,7 +218,7 @@ export async function handleImageOptimization(
   const params = parseImageParams(url, allowedWidths);
 
   if (!params) {
-    return new Response("Bad Request", { status: 400 });
+    return badRequestResponse();
   }
 
   const { imageUrl, width, quality } = params;

--- a/packages/vinext/src/server/metadata-route-response.ts
+++ b/packages/vinext/src/server/metadata-route-response.ts
@@ -9,6 +9,7 @@ import {
   type RobotsConfig,
   type SitemapEntry,
 } from "./metadata-routes.js";
+import { notFoundResponse } from "./http-error-responses.js";
 
 type AppPageParams = Record<string, string | string[]>;
 type MetadataRouteFunction = (props: Record<string, unknown>) => unknown;
@@ -186,7 +187,7 @@ async function handleGeneratedSitemap(
 
   const matchedId = findGeneratedSitemapId(await functions.generateSitemaps({}), rawId);
   if (!matchedId) {
-    return new Response("Not Found", { status: 404 });
+    return notFoundResponse();
   }
 
   const result = await functions.defaultExport({
@@ -243,18 +244,18 @@ async function callDynamicMetadataRoute(
 ): Promise<Response> {
   if (!functions.defaultExport) {
     console.warn(`[vinext] Dynamic metadata route ${route.servedUrl} has no default export.`);
-    return new Response("Not Found", { status: 404 });
+    return notFoundResponse();
   }
 
   const paramsThenable = makeThenableParams(match.params ?? {});
   let result: unknown;
   if (functions.hasGeneratedImageMetadata) {
     if (match.imageId === null || !isValidMetadataImageId(match.imageId)) {
-      return new Response("Not Found", { status: 404 });
+      return notFoundResponse();
     }
 
     if (!functions.generateImageMetadata) {
-      return new Response("Not Found", { status: 404 });
+      return notFoundResponse();
     }
 
     const matchedImageId = findGeneratedImageId(
@@ -263,7 +264,7 @@ async function callDynamicMetadataRoute(
       route.servedUrl,
     );
     if (!matchedImageId) {
-      return new Response("Not Found", { status: 404 });
+      return notFoundResponse();
     }
 
     result = await functions.defaultExport({

--- a/packages/vinext/src/server/middleware-runtime.ts
+++ b/packages/vinext/src/server/middleware-runtime.ts
@@ -10,6 +10,7 @@ import { normalizePath } from "./normalize-path.js";
 import { MatcherConfig, matchesMiddleware } from "./middleware-matcher.js";
 import { shouldKeepMiddlewareHeader } from "./middleware-request-headers.js";
 import { processMiddlewareHeaders } from "./request-pipeline.js";
+import { badRequestResponse, internalServerErrorResponse } from "./http-error-responses.js";
 
 export type MiddlewareModule = Record<string, unknown>;
 
@@ -122,7 +123,7 @@ function resolveMiddlewarePathname(request: Request): string | Response {
   try {
     return normalizePath(normalizePathnameForRouteMatchStrict(url.pathname));
   } catch {
-    return new Response("Bad Request", { status: 400 });
+    return badRequestResponse();
   }
 }
 
@@ -193,7 +194,7 @@ export async function executeMiddleware(
       : "Internal Server Error";
     return {
       continue: false,
-      response: new Response(message, { status: 500 }),
+      response: internalServerErrorResponse(message),
       waitUntilPromises,
     };
   }

--- a/packages/vinext/src/server/pages-api-route.ts
+++ b/packages/vinext/src/server/pages-api-route.ts
@@ -8,6 +8,7 @@ import {
   type PagesReqResResponse,
   PagesApiBodyParseError,
 } from "./pages-node-compat.js";
+import { internalServerErrorResponse } from "./http-error-responses.js";
 
 type PagesApiRouteModule = {
   default?: (req: PagesReqResRequest, res: PagesReqResResponse) => void | Promise<void>;
@@ -77,6 +78,6 @@ export async function handlePagesApiRoute(options: HandlePagesApiRouteOptions): 
       error instanceof Error ? error : new Error(String(error)),
       route.pattern,
     );
-    return new Response("Internal Server Error", { status: 500 });
+    return internalServerErrorResponse();
   }
 }

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -50,6 +50,7 @@ import {
   filterInternalHeaders,
   isOpenRedirectShaped,
 } from "./request-pipeline.js";
+import { notFoundResponse } from "./http-error-responses.js";
 import { hasBasePath, stripBasePath, removeTrailingSlash } from "../utils/base-path.js";
 import { computeLazyChunks } from "../utils/lazy-chunks.js";
 import { manifestFileWithBase } from "../utils/manifest-paths.js";
@@ -1104,10 +1105,7 @@ async function startAppRouterServer(options: AppRouterServerOptions) {
           return;
         }
         await sendWebResponse(
-          new Response("Not Found", {
-            status: 404,
-            headers: toWebHeaders(staticResponseHeaders),
-          }),
+          notFoundResponse({ headers: toWebHeaders(staticResponseHeaders) }),
           req,
           res,
           compress,

--- a/packages/vinext/src/server/request-pipeline.ts
+++ b/packages/vinext/src/server/request-pipeline.ts
@@ -2,6 +2,7 @@ import { hasBasePath, stripBasePath, removeTrailingSlash } from "../utils/base-p
 import type { NextHeader } from "../config/next-config.js";
 import type { RequestContext } from "../config/config-matchers.js";
 import { matchHeaders } from "../config/config-matchers.js";
+import { forbiddenResponse, notFoundResponse } from "./http-error-responses.js";
 
 /**
  * Shared request pipeline utilities.
@@ -14,17 +15,10 @@ import { matchHeaders } from "../config/config-matchers.js";
  * These utilities handle the common request lifecycle steps: protocol-
  * relative URL guards, basePath stripping, trailing slash normalization,
  * and CSRF origin validation.
- */
-
-/**
- * Build a 403 Forbidden plain-text response.
  *
- * Centralizes the `new Response("Forbidden", { status: 403, ... })` pattern
- * shared by CSRF origin validation and dev-server origin checks.
+ * Plain-text error response builders (forbidden / not-found / etc.) live in
+ * `./http-error-responses.ts`.
  */
-export function forbiddenResponse(): Response {
-  return new Response("Forbidden", { status: 403, headers: { "Content-Type": "text/plain" } });
-}
 
 /**
  * Guard against protocol-relative URL open redirects.
@@ -50,7 +44,7 @@ export function forbiddenResponse(): Response {
  */
 export function guardProtocolRelativeUrl(rawPathname: string): Response | null {
   if (isOpenRedirectShaped(rawPathname)) {
-    return new Response("404 Not Found", { status: 404 });
+    return notFoundResponse();
   }
   return null;
 }
@@ -271,7 +265,7 @@ export function normalizeTrailingSlash(
   // browser would resolve as protocol-relative, even if a caller somehow
   // bypassed the upstream guard.
   if (isOpenRedirectShaped(pathname)) {
-    return new Response("404 Not Found", { status: 404 });
+    return notFoundResponse();
   }
   const hasTrailing = pathname.endsWith("/");
   // RSC (client-side navigation) requests arrive as /path.rsc — don't


### PR DESCRIPTION
## Summary

Follow-up to #1058 / #1071 / #1078. Extracts a fresh batch of `new Response(...)` HTTP error builders into a shared module, `packages/vinext/src/server/http-error-responses.ts`. Now home to:

- `badRequestResponse(init?)` — 400 "Bad Request"
- `forbiddenResponse()` — 403 "Forbidden" (moved from `request-pipeline.ts`)
- `notFoundResponse(init?)` — 404 "Not Found"
- `methodNotAllowedResponse(allowedMethods, init?)` — 405 "Method Not Allowed" with `Allow` header
- `payloadTooLargeResponse()` — 413 "Payload Too Large" (moved from `app-server-action-execution.ts`)
- `internalServerErrorResponse(message?, init?)` — 500 "Internal Server Error"

Each helper accepts an optional `headers` init so callers (e.g. `app-rsc-handler`, `app-page-method`, `prod-server`) can merge middleware response headers without re-implementing the `new Response(...)` boilerplate.

### Standardized status codes / sites touched

- **404 → "Not Found"**
  - `app-page-request.ts` (×2) — `validateAppPageDynamicParams`
  - `app-prerender-endpoints.ts` (×2) — disabled prerender endpoints
  - `app-rsc-handler.ts` — plain 404 fallback (with merged middleware headers)
  - `app-rsc-request-normalization.ts` — basePath miss
  - `app-router-entry.ts` (×2) — protocol-relative guard, null result
  - `app-ssr-entry.ts` (×2) — protocol-relative guard, null result
  - `metadata-route-response.ts` (×5) — sitemap/image/dynamic 404s
  - `prod-server.ts` — Node static-served 404 (with merged static headers)
  - `request-pipeline.ts` (×2) — `guardProtocolRelativeUrl`, `normalizeTrailingSlash`
- **400 → "Bad Request"**
  - `app-router-entry.ts`, `app-rsc-request-normalization.ts`, `image-optimization.ts`, `middleware-runtime.ts`
- **405 → "Method Not Allowed"** (with `Allow: GET, HEAD`)
  - `app-page-method.ts`
- **500 → "Internal Server Error"**
  - `app-middleware.ts`, `pages-api-route.ts`
  - `middleware-runtime.ts` (dev-mode dynamic message via `internalServerErrorResponse(message)`)
  - `app-server-action-execution.ts` (×2; prod = canonical, dev = "Server action failed: ..." via `internalServerErrorResponse(message)`)
- **413 → "Payload Too Large"** (`payloadTooLargeResponse` is now the shared symbol)

### Body string changes (intentional, called out)

Five sites that previously returned the body `"404 Not Found"` (the protocol-relative open-redirect guards in `request-pipeline.ts` ×2, `app-router-entry.ts`, `app-ssr-entry.ts`, plus the trailing-slash defense-in-depth check) now return the canonical `"Not Found"` body. Status code (404) and absence of `Content-Type` are unchanged. The sibling generated-worker template strings in `deploy.ts` keep the old body to avoid touching codegen output.

### Sites left inline (intentional)

- **Template-string sites** (cannot import runtime helpers without restructuring codegen): `deploy.ts`, `entries/pages-server-entry.ts`, `server/dev-origin-check.ts`.
- **Test-asserted custom bodies**: `pages-api-route.ts:47` and `prod-server.ts:1593` keep `"404 - API route not found"` (asserted in `tests/pages-api-route.test.ts:148`); `pages-api-route.ts:53` keeps `"API route does not export a default function"`.
- **Single-occurrence custom messages**: `app-page-dispatch.ts:303` (`"Page has no default export"`); `pages-page-data.ts:139` (`"404"`); `image-optimization.ts` (×4: `"Image not found"`, `"The requested resource is not an allowed image type"`); `app-prerender-endpoints.ts` (×2: `"missing pattern"`); `request-pipeline.ts` (image-URL validation custom bodies).
- **Null-body status responses**: `app-route-handler-dispatch.ts` (`new Response(null, { status: 400 / 405 })`), `app-route-handler-execution.ts` (`status: 500` with null body) — different shape from text-body helpers.
- **Single-use 502 / 504**: `config-matchers.ts` (proxy gateway responses).

## Test plan

- [x] `pnpm vp test run tests/app-router.test.ts` — 308 passed
- [x] `pnpm vp test run tests/pages-router.test.ts` — 200 tests pass (pre-existing afterAll cleanup hook timeout, unrelated to this change; verified by stashing the diff and reproducing on main)
- [x] `pnpm vp test run tests/app-rsc-handler.test.ts tests/app-prerender-endpoints.test.ts tests/app-page-request.test.ts tests/pages-api-route.test.ts tests/api-handler.test.ts tests/app-page-dispatch.test.ts tests/metadata-route-response.test.ts tests/app-page-route-wiring.test.ts tests/app-page-execution.test.ts tests/app-route-handler-policy.test.ts tests/image-optimization-parity.test.ts tests/image-config.test.ts tests/app-post-middleware-context.test.ts` — 230 passed
- [x] `pnpm fmt --write`
- [x] `pnpm knip` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)