### PR TITLE
refactor(app-router): fence AppElements wire-key construction

### DIFF
--- a/packages/vinext/src/build/layout-classification.ts
+++ b/packages/vinext/src/build/layout-classification.ts
@@ -14,6 +14,7 @@
  */
 
 import { classifyLayoutSegmentConfig } from "./report.js";
+import { AppElementsWire } from "../server/app-elements.js";
 import { createAppPageTreePath } from "../server/app-page-route-wiring.js";
 import type {
   ClassificationReason,
@@ -140,7 +141,9 @@ export function classifyAllRouteLayouts(
 
   for (const route of routes) {
     for (const layout of route.layouts) {
-      const layoutId = `layout:${createAppPageTreePath(route.routeSegments, layout.treePosition)}`;
+      const layoutId = AppElementsWire.encodeLayoutId(
+        createAppPageTreePath(route.routeSegments, layout.treePosition),
+      );
 
       if (result.has(layoutId)) continue;
 

--- a/packages/vinext/src/server/app-elements-wire.ts
+++ b/packages/vinext/src/server/app-elements-wire.ts
@@ -42,6 +42,13 @@ type AppElementsMetadata = {
   rootLayoutTreePath: string | null;
 };
 
+type AppElementsWireElementKey =
+  | { kind: "layout"; treePath: string }
+  | { interceptionContext: string | null; kind: "page"; path: string }
+  | { interceptionContext: string | null; kind: "route"; path: string }
+  | { kind: "slot"; name: string; treePath: string }
+  | { kind: "template"; treePath: string };
+
 type AppElementsWireMetadataInput = {
   interceptionContext: string | null;
   routeId: string;
@@ -75,12 +82,17 @@ type AppElementsWireCodec = {
   createMetadataEntries(input: AppElementsWireMetadataInput): AppElementsWireMetadataEntries;
   decode(elements: AppWireElements): AppElements;
   encodeCacheKey(rscUrl: string, interceptionContext: string | null): string;
+  encodeLayoutId(treePath: string): string;
   encodeOutgoingPayload(input: {
     element: ReactNode | Readonly<Record<string, ReactNode>>;
     layoutFlags: LayoutFlags;
   }): ReactNode | AppOutgoingElements;
   encodePageId(routePath: string, interceptionContext: string | null): string;
   encodeRouteId(routePath: string, interceptionContext: string | null): string;
+  encodeSlotId(slotName: string, treePath: string): string;
+  encodeTemplateId(treePath: string): string;
+  isSlotId(key: string): boolean;
+  parseElementKey(key: string): AppElementsWireElementKey | null;
   readMetadata(elements: Readonly<Record<string, unknown>>): AppElementsMetadata;
   withLayoutFlags<T extends Record<string, unknown>>(
     elements: T,
@@ -94,10 +106,7 @@ function appendInterceptionContext(identity: string, interceptionContext: string
     : `${identity}${APP_INTERCEPTION_SEPARATOR}${interceptionContext}`;
 }
 
-export function createAppPayloadRouteId(
-  routePath: string,
-  interceptionContext: string | null,
-): string {
+function createAppPayloadRouteId(routePath: string, interceptionContext: string | null): string {
   return appendInterceptionContext(`route:${routePath}`, interceptionContext);
 }
 
@@ -105,11 +114,77 @@ function createAppPayloadPageId(routePath: string, interceptionContext: string |
   return appendInterceptionContext(`page:${routePath}`, interceptionContext);
 }
 
-export function createAppPayloadCacheKey(
-  rscUrl: string,
-  interceptionContext: string | null,
-): string {
+function createAppPayloadLayoutId(treePath: string): string {
+  return `layout:${treePath}`;
+}
+
+function createAppPayloadTemplateId(treePath: string): string {
+  return `template:${treePath}`;
+}
+
+function createAppPayloadSlotId(slotName: string, treePath: string): string {
+  return `slot:${slotName}:${treePath}`;
+}
+
+function createAppPayloadCacheKey(rscUrl: string, interceptionContext: string | null): string {
   return appendInterceptionContext(rscUrl, interceptionContext);
+}
+
+function parsePathWithInterception(input: string): {
+  interceptionContext: string | null;
+  path: string;
+} | null {
+  const separatorIndex = input.indexOf(APP_INTERCEPTION_SEPARATOR);
+  const path = separatorIndex === -1 ? input : input.slice(0, separatorIndex);
+  if (!path.startsWith("/")) return null;
+
+  return {
+    interceptionContext: separatorIndex === -1 ? null : input.slice(separatorIndex + 1),
+    path,
+  };
+}
+
+function parseTreePath(input: string): string | null {
+  return input.startsWith("/") ? input : null;
+}
+
+function parseAppElementsWireElementKey(key: string): AppElementsWireElementKey | null {
+  if (key.startsWith("route:")) {
+    const parsed = parsePathWithInterception(key.slice("route:".length));
+    if (!parsed) return null;
+    return { interceptionContext: parsed.interceptionContext, kind: "route", path: parsed.path };
+  }
+
+  if (key.startsWith("page:")) {
+    const parsed = parsePathWithInterception(key.slice("page:".length));
+    if (!parsed) return null;
+    return { interceptionContext: parsed.interceptionContext, kind: "page", path: parsed.path };
+  }
+
+  if (key.startsWith("layout:")) {
+    const treePath = parseTreePath(key.slice("layout:".length));
+    return treePath ? { kind: "layout", treePath } : null;
+  }
+
+  if (key.startsWith("template:")) {
+    const treePath = parseTreePath(key.slice("template:".length));
+    return treePath ? { kind: "template", treePath } : null;
+  }
+
+  if (key.startsWith("slot:")) {
+    const body = key.slice("slot:".length);
+    const separatorIndex = body.indexOf(":");
+    if (separatorIndex <= 0) return null;
+    const name = body.slice(0, separatorIndex);
+    const treePath = parseTreePath(body.slice(separatorIndex + 1));
+    return treePath ? { kind: "slot", name, treePath } : null;
+  }
+
+  return null;
+}
+
+function isAppElementsWireSlotId(key: string): boolean {
+  return parseAppElementsWireElementKey(key)?.kind === "slot";
 }
 
 function createAppElementsWireMetadataEntries(
@@ -125,7 +200,7 @@ function createAppElementsWireMetadataEntries(
 export function normalizeAppElements(elements: AppWireElements): AppElements {
   let needsNormalization = false;
   for (const [key, value] of Object.entries(elements)) {
-    if (key.startsWith("slot:") && value === APP_UNMATCHED_SLOT_WIRE_VALUE) {
+    if (isAppElementsWireSlotId(key) && value === APP_UNMATCHED_SLOT_WIRE_VALUE) {
       needsNormalization = true;
       break;
     }
@@ -138,7 +213,9 @@ export function normalizeAppElements(elements: AppWireElements): AppElements {
   const normalized: Record<string, AppElementValue> = {};
   for (const [key, value] of Object.entries(elements)) {
     normalized[key] =
-      key.startsWith("slot:") && value === APP_UNMATCHED_SLOT_WIRE_VALUE ? UNMATCHED_SLOT : value;
+      isAppElementsWireSlotId(key) && value === APP_UNMATCHED_SLOT_WIRE_VALUE
+        ? UNMATCHED_SLOT
+        : value;
   }
 
   return normalized;
@@ -238,9 +315,14 @@ export const AppElementsWire: AppElementsWireCodec = {
   createMetadataEntries: createAppElementsWireMetadataEntries,
   decode: normalizeAppElements,
   encodeCacheKey: createAppPayloadCacheKey,
+  encodeLayoutId: createAppPayloadLayoutId,
   encodeOutgoingPayload: buildOutgoingAppPayload,
   encodePageId: createAppPayloadPageId,
   encodeRouteId: createAppPayloadRouteId,
+  encodeSlotId: createAppPayloadSlotId,
+  encodeTemplateId: createAppPayloadTemplateId,
+  isSlotId: isAppElementsWireSlotId,
+  parseElementKey: parseAppElementsWireElementKey,
   readMetadata: readAppElementsMetadata,
   withLayoutFlags,
 };

--- a/packages/vinext/src/server/app-elements-wire.ts
+++ b/packages/vinext/src/server/app-elements-wire.ts
@@ -144,6 +144,10 @@ function parsePathWithInterception(input: string): {
   };
 }
 
+/**
+ * AppElements tree paths are absolute route-tree paths on the wire.
+ * Bare segment names are not valid layout/template/slot tree identities.
+ */
 function parseTreePath(input: string): string | null {
   return input.startsWith("/") ? input : null;
 }
@@ -184,7 +188,10 @@ function parseAppElementsWireElementKey(key: string): AppElementsWireElementKey 
 }
 
 function isAppElementsWireSlotId(key: string): boolean {
-  return parseAppElementsWireElementKey(key)?.kind === "slot";
+  if (!key.startsWith("slot:")) return false;
+  const body = key.slice("slot:".length);
+  const separatorIndex = body.indexOf(":");
+  return separatorIndex > 0 && body.charCodeAt(separatorIndex + 1) === 0x2f;
 }
 
 function createAppElementsWireMetadataEntries(

--- a/packages/vinext/src/server/app-elements.ts
+++ b/packages/vinext/src/server/app-elements.ts
@@ -1,5 +1,5 @@
 import { normalizeMountedSlotsHeader } from "./app-mounted-slots-header.js";
-import { UNMATCHED_SLOT, type AppElements } from "./app-elements-wire.js";
+import { AppElementsWire, UNMATCHED_SLOT, type AppElements } from "./app-elements-wire.js";
 
 export {
   AppElementsWire,
@@ -10,8 +10,6 @@ export {
   APP_UNMATCHED_SLOT_WIRE_VALUE,
   UNMATCHED_SLOT,
   buildOutgoingAppPayload,
-  createAppPayloadCacheKey,
-  createAppPayloadRouteId,
   isAppElementsRecord,
   normalizeAppElements,
   readAppElementsMetadata,
@@ -30,7 +28,10 @@ export function getMountedSlotIds(elements: AppElements): string[] {
     .filter((key) => {
       const value = elements[key];
       return (
-        key.startsWith("slot:") && value !== null && value !== undefined && value !== UNMATCHED_SLOT
+        AppElementsWire.isSlotId(key) &&
+        value !== null &&
+        value !== undefined &&
+        value !== UNMATCHED_SLOT
       );
     })
     .sort();

--- a/packages/vinext/src/server/app-elements.ts
+++ b/packages/vinext/src/server/app-elements.ts
@@ -21,7 +21,7 @@ export {
   type LayoutFlags,
 } from "./app-elements-wire.js";
 
-// createAppPayloadPageId stays private because callers use AppElementsWire.encodePageId.
+// Raw constructor helpers stay private because callers use AppElementsWire codecs.
 
 export function getMountedSlotIds(elements: AppElements): string[] {
   return Object.keys(elements)

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -22,7 +22,7 @@ import {
   setCurrentFetchCacheMode,
   setCurrentFetchSoftTags,
 } from "vinext/shims/fetch-cache";
-import type { AppOutgoingElements } from "./app-elements.js";
+import { AppElementsWire, type AppOutgoingElements } from "./app-elements.js";
 import { readAppPageCacheResponse } from "./app-page-cache.js";
 import { resolveAppPageParentHttpAccessBoundaryModule } from "./app-page-boundary.js";
 import { readStreamAsText } from "../utils/text-stream.js";
@@ -571,7 +571,9 @@ export async function dispatchAppPage<TRoute extends AppPageDispatchRoute>(
     classification: {
       getLayoutId(index) {
         const treePosition = route.layoutTreePositions?.[index] ?? 0;
-        return "layout:" + createAppPageTreePath([...route.routeSegments], treePosition);
+        return AppElementsWire.encodeLayoutId(
+          createAppPageTreePath([...route.routeSegments], treePosition),
+        );
       },
       buildTimeClassifications: route.__buildTimeClassifications,
       buildTimeReasons: route.__buildTimeReasons,

--- a/packages/vinext/src/server/app-page-route-wiring.tsx
+++ b/packages/vinext/src/server/app-page-route-wiring.tsx
@@ -189,7 +189,7 @@ export function createAppPageLayoutEntries<
     return {
       errorModule: route.errors?.[index] ?? null,
       forbiddenModule: route.forbiddens?.[index] ?? null,
-      id: `layout:${treePath}`,
+      id: AppElementsWire.encodeLayoutId(treePath),
       layoutModule,
       notFoundModule: route.notFounds?.[index] ?? null,
       unauthorizedModule: route.unauthorizeds?.[index] ?? null,
@@ -209,7 +209,7 @@ function createAppPageTemplateEntries<TModule extends AppPageModule>(
     const treePosition = route.templateTreePositions?.[index] ?? 0;
     const treePath = createAppPageTreePath(route.routeSegments, treePosition);
     return {
-      id: `template:${treePath}`,
+      id: AppElementsWire.encodeTemplateId(treePath),
       templateModule,
       treePath,
       treePosition,
@@ -312,7 +312,7 @@ function createAppPageParallelSlotEntries<
       : [];
     parallelSlots[slotName] = (
       <LayoutSegmentProvider segmentMap={{ children: slotSegments }}>
-        <Slot id={`slot:${slotName}:${treePath}`} />
+        <Slot id={AppElementsWire.encodeSlotId(slotName, treePath)} />
       </LayoutSegmentProvider>
     );
   }
@@ -494,7 +494,7 @@ export function buildAppPageElements<
     const slotName = slot.name;
     const targetIndex = slot.layoutIndex >= 0 ? slot.layoutIndex : layoutEntries.length - 1;
     const treePath = layoutEntries[targetIndex]?.treePath ?? "/";
-    const slotId = `slot:${slotName}:${treePath}`;
+    const slotId = AppElementsWire.encodeSlotId(slotName, treePath);
     const slotOverride = resolveSlotOverride(slotKey, slotName);
     const slotParams = getEffectiveSlotParams(slotKey, slotName);
     const overrideOrPageComponent =

--- a/packages/vinext/src/shims/slot.tsx
+++ b/packages/vinext/src/shims/slot.tsx
@@ -1,7 +1,12 @@
 "use client";
 
 import * as React from "react";
-import { UNMATCHED_SLOT, type AppElementValue, type AppElements } from "../server/app-elements.js";
+import {
+  AppElementsWire,
+  UNMATCHED_SLOT,
+  type AppElementValue,
+  type AppElements,
+} from "../server/app-elements.js";
 import { notFound } from "./navigation.js";
 
 const EMPTY_ELEMENTS: AppElements = Object.freeze({});
@@ -32,7 +37,11 @@ export function mergeElements(
   // instead of firing notFound(). Only hard navigation (full page load) should 404.
   // This matches Next.js behavior for parallel route persistence.
   for (const key of Object.keys(merged)) {
-    if (key.startsWith("slot:") && merged[key] === UNMATCHED_SLOT && Object.hasOwn(prev, key)) {
+    if (
+      AppElementsWire.isSlotId(key) &&
+      merged[key] === UNMATCHED_SLOT &&
+      Object.hasOwn(prev, key)
+    ) {
       merged[key] = prev[key];
     }
   }
@@ -43,7 +52,7 @@ export function mergeElements(
   // slots that should be preserved.
   if (clearAbsentSlots) {
     for (const key of Object.keys(merged)) {
-      if (key.startsWith("slot:") && !Object.hasOwn(next, key)) {
+      if (AppElementsWire.isSlotId(key) && !Object.hasOwn(next, key)) {
         delete merged[key];
       }
     }
@@ -63,7 +72,7 @@ export function Slot({
   const elements = React.useContext(ElementsContext);
 
   if (!Object.hasOwn(elements, id)) {
-    if (process.env.NODE_ENV !== "production" && !id.startsWith("slot:")) {
+    if (process.env.NODE_ENV !== "production" && !AppElementsWire.isSlotId(id)) {
       if (!warnedMissingEntryIds.has(id)) {
         warnedMissingEntryIds.add(id);
         console.warn("[vinext] Missing App Router element entry during render: " + id);

--- a/tests/app-elements.test.ts
+++ b/tests/app-elements.test.ts
@@ -1,4 +1,6 @@
 import React from "react";
+import fs from "node:fs";
+import path from "node:path";
 import { describe, expect, it } from "vite-plus/test";
 import { UNMATCHED_SLOT } from "../packages/vinext/src/shims/slot.js";
 import {
@@ -9,8 +11,6 @@ import {
   APP_ROUTE_KEY,
   APP_UNMATCHED_SLOT_WIRE_VALUE,
   buildOutgoingAppPayload,
-  createAppPayloadCacheKey,
-  createAppPayloadRouteId,
   isAppElementsRecord,
   normalizeAppElements,
   readAppElementsMetadata,
@@ -75,6 +75,134 @@ describe("AppElementsWire", () => {
       [APP_ROUTE_KEY]: "route:/dashboard",
     });
   });
+
+  it("constructs and parses canonical element wire keys through the codec", () => {
+    const keys = [
+      AppElementsWire.encodeRouteId("/blog/[slug]", null),
+      AppElementsWire.encodeRouteId("/photos/42", "/feed"),
+      AppElementsWire.encodePageId("/blog/[slug]", null),
+      AppElementsWire.encodeLayoutId("/(marketing)/blog/[slug]"),
+      AppElementsWire.encodeTemplateId("/(marketing)/blog/[slug]"),
+      AppElementsWire.encodeSlotId("modal", "/feed"),
+    ];
+
+    expect(keys).toEqual([
+      "route:/blog/[slug]",
+      "route:/photos/42\0/feed",
+      "page:/blog/[slug]",
+      "layout:/(marketing)/blog/[slug]",
+      "template:/(marketing)/blog/[slug]",
+      "slot:modal:/feed",
+    ]);
+
+    expect(AppElementsWire.parseElementKey(keys[0])).toEqual({
+      interceptionContext: null,
+      kind: "route",
+      path: "/blog/[slug]",
+    });
+    expect(AppElementsWire.parseElementKey(keys[1])).toEqual({
+      interceptionContext: "/feed",
+      kind: "route",
+      path: "/photos/42",
+    });
+    expect(AppElementsWire.parseElementKey(keys[2])).toEqual({
+      interceptionContext: null,
+      kind: "page",
+      path: "/blog/[slug]",
+    });
+    expect(AppElementsWire.parseElementKey(keys[3])).toEqual({
+      kind: "layout",
+      treePath: "/(marketing)/blog/[slug]",
+    });
+    expect(AppElementsWire.parseElementKey(keys[4])).toEqual({
+      kind: "template",
+      treePath: "/(marketing)/blog/[slug]",
+    });
+    expect(AppElementsWire.parseElementKey(keys[5])).toEqual({
+      kind: "slot",
+      name: "modal",
+      treePath: "/feed",
+    });
+    expect(AppElementsWire.isSlotId(keys[5])).toBe(true);
+    expect(AppElementsWire.parseElementKey("__route")).toBeNull();
+    expect(AppElementsWire.parseElementKey("slot:modal")).toBeNull();
+  });
+
+  it("round-trips legacy-compatible payload metadata through the codec", () => {
+    const payload = AppElementsWire.encodeOutgoingPayload({
+      element: {
+        ...AppElementsWire.createMetadataEntries({
+          interceptionContext: null,
+          rootLayoutTreePath: "/",
+          routeId: AppElementsWire.encodeRouteId("/dashboard", null),
+        }),
+        [AppElementsWire.encodeLayoutId("/")]: "layout",
+        [AppElementsWire.encodePageId("/dashboard", null)]: "page",
+      },
+      layoutFlags: {
+        [AppElementsWire.encodeLayoutId("/")]: "s",
+      },
+    });
+
+    expect(isAppElementsRecord(payload)).toBe(true);
+    if (!isAppElementsRecord(payload)) return;
+
+    expect(AppElementsWire.readMetadata(payload)).toEqual({
+      interceptionContext: null,
+      layoutFlags: { [AppElementsWire.encodeLayoutId("/")]: "s" },
+      rootLayoutTreePath: "/",
+      routeId: "route:/dashboard",
+    });
+  });
+
+  it("keeps legacy unmatched-slot markers compatible while parsing slot keys", () => {
+    const slotId = AppElementsWire.encodeSlotId("modal", "/");
+    const decoded = AppElementsWire.decode({
+      [APP_ROOT_LAYOUT_KEY]: "/",
+      [APP_ROUTE_KEY]: AppElementsWire.encodeRouteId("/dashboard", null),
+      [slotId]: AppElementsWire.unmatchedSlotValue,
+    });
+
+    expect(decoded[slotId]).toBe(UNMATCHED_SLOT);
+    expect(AppElementsWire.parseElementKey(slotId)).toEqual({
+      kind: "slot",
+      name: "modal",
+      treePath: "/",
+    });
+  });
+
+  it("keeps raw AppElements wire-key construction inside the codec boundary", () => {
+    const root = path.resolve(import.meta.dirname, "..");
+    const sourceRoot = path.join(root, "packages/vinext/src");
+    const allowed = new Set([
+      path.join(sourceRoot, "routing/app-route-graph.ts"),
+      path.join(sourceRoot, "server/app-elements-wire.ts"),
+    ]);
+    const rawWireConstruction =
+      /`(?:route|page|layout|template):\$\{|`slot:\$\{|\.startsWith\("(?:slot|layout|page|route|template):"\)/;
+
+    const violations: string[] = [];
+    const visit = (dir: string): void => {
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const fullPath = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          visit(fullPath);
+          continue;
+        }
+        if (!entry.isFile() || !/\.(?:ts|tsx)$/.test(entry.name)) continue;
+        if (allowed.has(fullPath)) continue;
+
+        const source = fs.readFileSync(fullPath, "utf8");
+        if (rawWireConstruction.test(source)) {
+          violations.push(path.relative(root, fullPath));
+        }
+      }
+    };
+
+    visit(sourceRoot);
+
+    expect(violations).toEqual([]);
+  });
 });
 
 describe("app elements payload helpers", () => {
@@ -128,10 +256,10 @@ describe("app elements payload helpers", () => {
   });
 
   it("encodes intercepted route ids and cache keys with a NUL separator", () => {
-    expect(createAppPayloadRouteId("/photos/42", null)).toBe("route:/photos/42");
-    expect(createAppPayloadRouteId("/photos/42", "/feed")).toBe("route:/photos/42\0/feed");
-    expect(createAppPayloadCacheKey("/photos/42.rsc", null)).toBe("/photos/42.rsc");
-    expect(createAppPayloadCacheKey("/photos/42.rsc", "/feed")).toBe("/photos/42.rsc\0/feed");
+    expect(AppElementsWire.encodeRouteId("/photos/42", null)).toBe("route:/photos/42");
+    expect(AppElementsWire.encodeRouteId("/photos/42", "/feed")).toBe("route:/photos/42\0/feed");
+    expect(AppElementsWire.encodeCacheKey("/photos/42.rsc", null)).toBe("/photos/42.rsc");
+    expect(AppElementsWire.encodeCacheKey("/photos/42.rsc", "/feed")).toBe("/photos/42.rsc\0/feed");
   });
 
   it("preserves the request cache context when a direct-route payload omits it", () => {

--- a/tests/app-elements.test.ts
+++ b/tests/app-elements.test.ts
@@ -179,7 +179,11 @@ describe("AppElementsWire", () => {
       path.join(sourceRoot, "server/app-elements-wire.ts"),
     ]);
     const rawWireConstruction =
-      /`(?:route|page|layout|template):\$\{|`slot:\$\{|\.startsWith\("(?:slot|layout|page|route|template):"\)/;
+      /`(?:route|page|layout|template):\$\{|`slot:\$\{|["'](?:route|page|layout|template):["']\s*\+|["']slot:["']\s*\+|\.startsWith\(["'](?:slot|layout|page|route|template):["']\)/;
+
+    expect(rawWireConstruction.test('"slot:" + name + ":" + treePath')).toBe(true);
+    expect(rawWireConstruction.test('"layout:" + treePath')).toBe(true);
+    expect(rawWireConstruction.test("key.startsWith('slot:')")).toBe(true);
 
     const violations: string[] = [];
     const visit = (dir: string): void => {

--- a/tests/app-page-element-builder.test.ts
+++ b/tests/app-page-element-builder.test.ts
@@ -98,8 +98,8 @@ describe("buildPageElements", () => {
     const result = await buildPageElements(createBaseOptions({ route }));
 
     const record = result as Record<string, unknown>;
-    // The error payload uses createAppPayloadRouteId which prefixes "route:"
-    // to build the key and the __route metadata.
+    // The error payload uses the AppElementsWire route-id encoder for both
+    // the entry key and the __route metadata.
     expect(record[APP_ROUTE_KEY]).toBe("route:/test");
     expect(record[APP_INTERCEPTION_CONTEXT_KEY]).toBe(null);
     expect(Object.prototype.hasOwnProperty.call(record, APP_ROOT_LAYOUT_KEY)).toBe(true);

--- a/tests/prefetch-cache.test.ts
+++ b/tests/prefetch-cache.test.ts
@@ -10,7 +10,7 @@
  * vi.resetModules() + dynamic import().
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vite-plus/test";
-import { createAppPayloadCacheKey } from "../packages/vinext/src/server/app-elements.js";
+import { AppElementsWire } from "../packages/vinext/src/server/app-elements.js";
 
 type Navigation = typeof import("../packages/vinext/src/shims/navigation.js");
 let storePrefetchResponse: Navigation["storePrefetchResponse"];
@@ -116,7 +116,9 @@ describe("prefetch cache eviction", () => {
 
     expect(fetch).toHaveBeenCalledTimes(1);
     expect(fetchedUrl).toMatch(/^\/dashboard\.rsc\?tab=1&_rsc(?:=.+)?$/);
-    expect(getPrefetchedUrls().has(createAppPayloadCacheKey(String(fetchedUrl), "/"))).toBe(true);
+    expect(getPrefetchedUrls().has(AppElementsWire.encodeCacheKey(String(fetchedUrl), "/"))).toBe(
+      true,
+    );
   });
 
   it("reuses a prefetched response only when mounted-slot context matches", () => {
@@ -171,8 +173,8 @@ describe("prefetch cache eviction", () => {
     storePrefetchResponse("/photos/42.rsc", new Response("feed"), "/feed");
     storePrefetchResponse("/photos/42.rsc", new Response("gallery"), "/gallery");
 
-    const feedKey = createAppPayloadCacheKey("/photos/42.rsc", "/feed");
-    const galleryKey = createAppPayloadCacheKey("/photos/42.rsc", "/gallery");
+    const feedKey = AppElementsWire.encodeCacheKey("/photos/42.rsc", "/feed");
+    const galleryKey = AppElementsWire.encodeCacheKey("/photos/42.rsc", "/gallery");
     expect(feedKey).not.toBe(galleryKey);
     expect(getPrefetchCache().has(feedKey)).toBe(true);
     expect(getPrefetchCache().has(galleryKey)).toBe(true);


### PR DESCRIPTION
## What this changes
Implements task `#726-WIRE-02/03` from issue #726 by moving AppElements wire-key construction and parsing behind `AppElementsWire`.

The codec now owns constructors and parsers for route, page, layout, template, slot, cache, metadata, and unmatched-slot wire values. Render wiring, layout classification, browser slot merging, mounted-slot header construction, and prefetch cache tests now call the codec instead of assembling or recognizing raw `layout:`, `page:`, `template:`, or `slot:` keys directly.

## Why
Issue #726 calls out that the flat AppElements payload should stay as the transport, but raw wire keys must stop becoming router authority. Before this change, several code paths still constructed or interpreted wire keys with string templates or prefix checks outside the wire boundary, which made it easy for future router work to rebuild semantics around incidental payload strings.

Correctness oracle: Vinext internal invariant from #726. The wire format remains byte-compatible for existing payload keys and legacy metadata behavior, but ownership moves to `AppElementsWire`.

## Approach
- Added `AppElementsWire` constructors for layout, template, and slot element IDs, plus an element-key parser and slot-key predicate.
- Kept route graph semantic ID minting separate from the AppElements wire boundary, because graph IDs are route graph facts, not the transport codec.
- Made direct route/cache helper constructors private so callers use the codec object as the approved exported boundary.
- Added source-boundary coverage that rejects new raw AppElements wire-key construction outside `server/app-elements-wire.ts` and `routing/app-route-graph.ts`.

Non-goals:
- Does not promote route topology, slot preservation, cache authority, or NavigationPlanner semantics.
- Does not change the flat payload shape or legacy key strings.

Bonk: please read issue #726 before reviewing this PR so the big-picture AppElementsWire boundary and router-spine migration context is visible.

## Validation
- `vp test run tests/app-elements.test.ts tests/prefetch-cache.test.ts tests/app-page-element-builder.test.ts tests/slot.test.ts tests/app-page-route-wiring.test.ts tests/layout-classification.test.ts tests/app-browser-entry.test.ts tests/app-page-render.test.ts tests/app-page-execution.test.ts`
- `vp check` exits 0. It still reports the existing unrelated `typescript-eslint(no-redundant-type-constituents)` warning in `packages/vinext/src/server/request-pipeline.ts:604`.
- Commit hook ran `vp check --fix` and `knip --no-progress` successfully.

## Risks / follow-ups
The parser deliberately recognizes the existing legacy wire strings and rejects malformed keys as non-wire entries. Future #726 work can build stronger semantic IDs and planner decisions on top of this without relying on missing payload entries or raw key prefixes as proof.
