### PR TITLE
refactor(app-router): gate browser state writes with approved visible commits

### DIFF
--- a/packages/vinext/src/server/app-browser-navigation-controller.ts
+++ b/packages/vinext/src/server/app-browser-navigation-controller.ts
@@ -6,16 +6,17 @@ import {
 } from "vinext/shims/navigation";
 import type { ClientNavigationRenderSnapshot } from "vinext/shims/navigation";
 import {
+  applyApprovedVisibleCommit,
+  approvePendingNavigationCommit,
+  createApprovedVisibleCommit,
   createPendingNavigationCommit,
+  createVisibleCommitDecision,
   resolveAndClassifyNavigationCommit,
-  resolvePendingNavigationCommitDisposition,
-  routerReducer,
-  type AppRouterAction,
   type AppRouterState,
+  type ApprovedVisibleCommit,
   type OperationLane,
-  type PendingOperationRecord,
 } from "./app-browser-state.js";
-import type { AppElements, LayoutFlags } from "./app-elements.js";
+import type { AppElements } from "./app-elements.js";
 
 export type HistoryUpdateMode = "push" | "replace";
 
@@ -236,12 +237,12 @@ export function createAppBrowserNavigationController(
 
   function resolvePendingBrowserRouterState(
     pending: PendingBrowserRouterState | null | undefined,
-    action: AppRouterAction,
+    commit: ApprovedVisibleCommit,
   ): void {
     if (!pending || pending.settled) return;
 
     pending.settled = true;
-    pending.resolve(routerReducer(getBrowserRouterState(), action));
+    pending.resolve(applyApprovedVisibleCommit(getBrowserRouterState(), commit));
 
     if (activePendingBrowserRouterState === pending) {
       activePendingBrowserRouterState = null;
@@ -322,17 +323,11 @@ export function createAppBrowserNavigationController(
     // initialized-setter error.
     if (!hasBrowserRouterState()) return;
 
-    dispatchBrowserTree(
-      pending.action.elements,
-      navigationSnapshot,
-      pending.action.renderId,
-      "replace",
-      pending.interceptionContext,
-      pending.action.layoutFlags,
-      pending.previousNextUrl,
-      pending.routeId,
-      pending.rootLayoutTreePath,
-      pending.action.operation,
+    dispatchApprovedVisibleCommit(
+      createApprovedVisibleCommit({
+        decision: createVisibleCommitDecision(),
+        pending,
+      }),
       null,
       false,
     );
@@ -366,44 +361,23 @@ export function createAppBrowserNavigationController(
     return children;
   }
 
-  function dispatchBrowserTree(
-    elements: AppElements,
-    navigationSnapshot: ClientNavigationRenderSnapshot,
-    renderId: number,
-    actionType: "navigate" | "replace" | "traverse",
-    interceptionContext: string | null,
-    layoutFlags: LayoutFlags,
-    previousNextUrl: string | null,
-    routeId: string,
-    rootLayoutTreePath: string | null,
-    operation: PendingOperationRecord,
+  function dispatchApprovedVisibleCommit(
+    commit: ApprovedVisibleCommit,
     pendingRouterState: PendingBrowserRouterState | null,
     useTransitionMode: boolean,
   ): void {
     const setter = getBrowserRouterStateSetter();
-    const action: AppRouterAction = {
-      elements,
-      interceptionContext,
-      layoutFlags,
-      navigationSnapshot,
-      operation,
-      previousNextUrl,
-      renderId,
-      rootLayoutTreePath,
-      routeId,
-      type: actionType,
-    };
 
     const applyAction = () => {
       if (pendingRouterState) {
         // The programmatic navigation is already running inside React.startTransition
         // (from router.push/replace/refresh), so resolving the deferred promise is
         // sufficient — no additional startTransition wrapper is needed below.
-        resolvePendingBrowserRouterState(pendingRouterState, action);
+        resolvePendingBrowserRouterState(pendingRouterState, commit);
         return;
       }
 
-      setter(routerReducer(getBrowserRouterState(), action));
+      setter(applyApprovedVisibleCommit(getBrowserRouterState(), commit));
     };
 
     if (useTransitionMode) {
@@ -447,25 +421,30 @@ export function createAppBrowserNavigationController(
         type: options.actionType,
       });
 
-      const disposition = resolvePendingNavigationCommitDisposition({
+      const approval = approvePendingNavigationCommit({
         activeNavigationId,
-        currentRootLayoutTreePath: currentState.rootLayoutTreePath,
-        nextRootLayoutTreePath: pending.rootLayoutTreePath,
+        currentState,
+        pending,
         startedNavigationId: options.navId,
       });
 
-      if (disposition === "skip") {
+      if (approval.decision.disposition === "no-commit") {
         settlePendingBrowserRouterState(options.pendingRouterState);
         pendingNavigationCommits.delete(renderId);
         resolveCommitted?.();
         return;
       }
 
-      if (disposition === "hard-navigate") {
+      if (approval.decision.disposition === "hard-navigate") {
         settlePendingBrowserRouterState(options.pendingRouterState);
         pendingNavigationCommits.delete(renderId);
         window.location.assign(options.targetHref);
         return;
+      }
+
+      const approvedCommit = approval.approvedCommit;
+      if (approvedCommit === null) {
+        throw new Error("[vinext] Commit decision did not approve a visible commit");
       }
 
       queuePrePaintNavigationEffect(
@@ -475,22 +454,13 @@ export function createAppBrowserNavigationController(
           historyUpdateMode: options.historyUpdateMode,
           navId: options.navId,
           params: options.params,
-          previousNextUrl: pending.previousNextUrl,
+          previousNextUrl: approvedCommit.previousNextUrl,
         }),
       );
       activateNavigationSnapshot();
       snapshotActivated = true;
-      dispatchBrowserTree(
-        pending.action.elements,
-        options.navigationSnapshot,
-        renderId,
-        options.actionType,
-        pending.interceptionContext,
-        pending.action.layoutFlags,
-        pending.previousNextUrl,
-        pending.routeId,
-        pending.rootLayoutTreePath,
-        pending.action.operation,
+      dispatchApprovedVisibleCommit(
+        approvedCommit,
         options.pendingRouterState,
         options.useTransition ?? true,
       );
@@ -522,11 +492,11 @@ export function createAppBrowserNavigationController(
     // need a stronger commit-version gate than activeNavigationId alone.
     const {
       disposition,
-      pending,
+      approvedCommit,
       // Intentionally retained as #726-OPS-01 trace-shell scaffolding. The
-      // current same-URL action path still commits through legacy control flow;
-      // later lifecycle gates can consume this trace without changing the
-      // classifier contract again.
+      // same-URL action path still exposes the legacy disposition for caller
+      // compatibility; later lifecycle gates can consume this trace without
+      // changing the classifier contract again.
       trace: _navigationTrace,
     } = await resolveAndClassifyNavigationCommit({
       activeNavigationId,
@@ -544,21 +514,8 @@ export function createAppBrowserNavigationController(
       return undefined;
     }
 
-    if (disposition === "dispatch") {
-      dispatchBrowserTree(
-        pending.action.elements,
-        navigationSnapshot,
-        pending.action.renderId,
-        "navigate",
-        pending.interceptionContext,
-        pending.action.layoutFlags,
-        pending.previousNextUrl,
-        pending.routeId,
-        pending.rootLayoutTreePath,
-        pending.action.operation,
-        null,
-        false,
-      );
+    if (approvedCommit) {
+      dispatchApprovedVisibleCommit(approvedCommit, null, false);
     }
 
     // Same-URL server actions still return their action value even if the UI

--- a/packages/vinext/src/server/app-browser-navigation-controller.ts
+++ b/packages/vinext/src/server/app-browser-navigation-controller.ts
@@ -7,10 +7,9 @@ import {
 import type { ClientNavigationRenderSnapshot } from "vinext/shims/navigation";
 import {
   applyApprovedVisibleCommit,
+  approveHmrVisibleCommit,
   approvePendingNavigationCommit,
-  createApprovedVisibleCommit,
   createPendingNavigationCommit,
-  createVisibleCommitDecision,
   resolveAndClassifyNavigationCommit,
   type AppRouterState,
   type ApprovedVisibleCommit,
@@ -323,14 +322,7 @@ export function createAppBrowserNavigationController(
     // initialized-setter error.
     if (!hasBrowserRouterState()) return;
 
-    dispatchApprovedVisibleCommit(
-      createApprovedVisibleCommit({
-        decision: createVisibleCommitDecision(),
-        pending,
-      }),
-      null,
-      false,
-    );
+    dispatchApprovedVisibleCommit(approveHmrVisibleCommit(pending), null, false);
   }
 
   function NavigationCommitSignal(

--- a/packages/vinext/src/server/app-browser-navigation-controller.ts
+++ b/packages/vinext/src/server/app-browser-navigation-controller.ts
@@ -485,12 +485,11 @@ export function createAppBrowserNavigationController(
     // the same race, and Next.js has similar behavior. Tightening this would
     // need a stronger commit-version gate than activeNavigationId alone.
     const {
-      disposition,
       approvedCommit,
+      decision,
       // Intentionally retained as #726-OPS-01 trace-shell scaffolding. The
-      // same-URL action path still exposes the legacy disposition for caller
-      // compatibility; later lifecycle gates can consume this trace without
-      // changing the classifier contract again.
+      // same-URL action path can consume this trace once later lifecycle gates
+      // need an observable commit explanation.
       trace: _navigationTrace,
     } = await resolveAndClassifyNavigationCommit({
       activeNavigationId,
@@ -503,7 +502,7 @@ export function createAppBrowserNavigationController(
       type: "navigate",
     });
 
-    if (disposition === "hard-navigate") {
+    if (decision.disposition === "hard-navigate") {
       window.location.assign(window.location.href);
       return undefined;
     }

--- a/packages/vinext/src/server/app-browser-navigation-controller.ts
+++ b/packages/vinext/src/server/app-browser-navigation-controller.ts
@@ -6,15 +6,17 @@ import {
 } from "vinext/shims/navigation";
 import type { ClientNavigationRenderSnapshot } from "vinext/shims/navigation";
 import {
+  createPendingNavigationCommit,
+  type AppRouterState,
+  type OperationLane,
+} from "./app-browser-state.js";
+import {
   applyApprovedVisibleCommit,
   approveHmrVisibleCommit,
   approvePendingNavigationCommit,
-  createPendingNavigationCommit,
   resolveAndClassifyNavigationCommit,
-  type AppRouterState,
   type ApprovedVisibleCommit,
-  type OperationLane,
-} from "./app-browser-state.js";
+} from "./app-browser-visible-commit.js";
 import type { AppElements } from "./app-elements.js";
 
 export type HistoryUpdateMode = "push" | "replace";

--- a/packages/vinext/src/server/app-browser-state.ts
+++ b/packages/vinext/src/server/app-browser-state.ts
@@ -79,7 +79,7 @@ type PendingNavigationCommitDispositionDecision = {
   disposition: PendingNavigationCommitDisposition;
   trace: NavigationTrace;
 };
-export type VisibleCommitDecision = {
+type VisibleCommitDecision = {
   disposition: "commit";
   trace: NavigationTrace;
 };
@@ -360,7 +360,7 @@ function resolvePendingNavigationCommitDecision(options: {
   }
 }
 
-export function createVisibleCommitDecision(
+function createVisibleCommitDecision(
   trace: NavigationTrace = createNavigationTrace(NavigationTraceReasonCodes.commitCurrent),
 ): VisibleCommitDecision {
   return { disposition: "commit", trace };
@@ -393,7 +393,7 @@ export function resolvePendingNavigationCommitDispositionDecision(options: {
   };
 }
 
-export function createApprovedVisibleCommit(options: {
+function createApprovedVisibleCommit(options: {
   decision: VisibleCommitDecision;
   pending: PendingNavigationCommit;
 }): ApprovedVisibleCommit {
@@ -406,6 +406,17 @@ export function createApprovedVisibleCommit(options: {
     rootLayoutTreePath: options.pending.rootLayoutTreePath,
     routeId: options.pending.routeId,
   };
+}
+
+export function approveHmrVisibleCommit(pending: PendingNavigationCommit): ApprovedVisibleCommit {
+  if (pending.action.operation.lane !== "hmr") {
+    throw new Error("[vinext] HMR visible commit approval requires an HMR pending operation");
+  }
+
+  return createApprovedVisibleCommit({
+    decision: createVisibleCommitDecision(),
+    pending,
+  });
 }
 
 export function approvePendingNavigationCommit(options: {

--- a/packages/vinext/src/server/app-browser-state.ts
+++ b/packages/vinext/src/server/app-browser-state.ts
@@ -66,7 +66,7 @@ export type AppRouterAction = {
   type: "navigate" | "replace" | "traverse";
 };
 
-type PendingNavigationCommit = {
+export type PendingNavigationCommit = {
   action: AppRouterAction;
   interceptionContext: string | null;
   previousNextUrl: string | null;
@@ -74,48 +74,9 @@ type PendingNavigationCommit = {
   routeId: string;
 };
 
-type PendingNavigationCommitDisposition = "dispatch" | "hard-navigate" | "skip";
+export type PendingNavigationCommitDisposition = "dispatch" | "hard-navigate" | "skip";
 type PendingNavigationCommitDispositionDecision = {
   disposition: PendingNavigationCommitDisposition;
-  trace: NavigationTrace;
-};
-type VisibleCommitDecision = {
-  disposition: "commit";
-  trace: NavigationTrace;
-};
-type HardNavigateCommitDecision = {
-  disposition: "hard-navigate";
-  trace: NavigationTrace;
-};
-type NoCommitDecision = {
-  disposition: "no-commit";
-  trace: NavigationTrace;
-};
-type CommitDecision = VisibleCommitDecision | HardNavigateCommitDecision | NoCommitDecision;
-const approvedVisibleCommitBrand: unique symbol = Symbol("ApprovedVisibleCommit");
-export type ApprovedVisibleCommit = {
-  readonly [approvedVisibleCommitBrand]: true;
-  readonly action: AppRouterAction;
-  readonly decision: VisibleCommitDecision;
-  readonly interceptionContext: string | null;
-  readonly previousNextUrl: string | null;
-  readonly rootLayoutTreePath: string | null;
-  readonly routeId: string;
-};
-type VisibleCommitApproval = {
-  approvedCommit: ApprovedVisibleCommit;
-  decision: VisibleCommitDecision;
-};
-type NonVisibleCommitApproval = {
-  approvedCommit: null;
-  decision: HardNavigateCommitDecision | NoCommitDecision;
-};
-type CommitApproval = VisibleCommitApproval | NonVisibleCommitApproval;
-type ClassifiedPendingNavigationCommit = {
-  approvedCommit: ApprovedVisibleCommit | null;
-  decision: CommitDecision;
-  disposition: PendingNavigationCommitDisposition;
-  pending: PendingNavigationCommit;
   trace: NavigationTrace;
 };
 
@@ -300,13 +261,6 @@ export function routerReducer(state: AppRouterState, action: AppRouterAction): A
   }
 }
 
-export function applyApprovedVisibleCommit(
-  state: AppRouterState,
-  commit: ApprovedVisibleCommit,
-): AppRouterState {
-  return routerReducer(state, commit.action);
-}
-
 export function shouldHardNavigate(
   currentRootLayoutTreePath: string | null,
   nextRootLayoutTreePath: string | null,
@@ -338,34 +292,6 @@ export function resolvePendingNavigationCommitDisposition(options: {
   return "dispatch";
 }
 
-function resolvePendingNavigationCommitDecision(options: {
-  activeNavigationId: number;
-  currentRootLayoutTreePath: string | null;
-  nextRootLayoutTreePath: string | null;
-  startedNavigationId: number;
-}): CommitDecision {
-  const { disposition, trace } = resolvePendingNavigationCommitDispositionDecision(options);
-
-  switch (disposition) {
-    case "skip":
-      return { disposition: "no-commit", trace };
-    case "hard-navigate":
-      return { disposition: "hard-navigate", trace };
-    case "dispatch":
-      return createVisibleCommitDecision(trace);
-    default: {
-      const _exhaustive: never = disposition;
-      throw new Error("[vinext] Unknown navigation commit disposition: " + String(_exhaustive));
-    }
-  }
-}
-
-function createVisibleCommitDecision(
-  trace: NavigationTrace = createNavigationTrace(NavigationTraceReasonCodes.commitCurrent),
-): VisibleCommitDecision {
-  return { disposition: "commit", trace };
-}
-
 export function resolvePendingNavigationCommitDispositionDecision(options: {
   activeNavigationId: number;
   currentRootLayoutTreePath: string | null;
@@ -391,67 +317,6 @@ export function resolvePendingNavigationCommitDispositionDecision(options: {
       traceFields,
     ),
   };
-}
-
-function createApprovedVisibleCommit(options: {
-  decision: VisibleCommitDecision;
-  pending: PendingNavigationCommit;
-}): ApprovedVisibleCommit {
-  return {
-    [approvedVisibleCommitBrand]: true,
-    action: options.pending.action,
-    decision: options.decision,
-    interceptionContext: options.pending.interceptionContext,
-    previousNextUrl: options.pending.previousNextUrl,
-    rootLayoutTreePath: options.pending.rootLayoutTreePath,
-    routeId: options.pending.routeId,
-  };
-}
-
-export function approveHmrVisibleCommit(pending: PendingNavigationCommit): ApprovedVisibleCommit {
-  if (pending.action.operation.lane !== "hmr") {
-    throw new Error("[vinext] HMR visible commit approval requires an HMR pending operation");
-  }
-
-  return createApprovedVisibleCommit({
-    decision: createVisibleCommitDecision(),
-    pending,
-  });
-}
-
-export function approvePendingNavigationCommit(options: {
-  activeNavigationId: number;
-  currentState: AppRouterState;
-  pending: PendingNavigationCommit;
-  startedNavigationId: number;
-}): CommitApproval {
-  const decision = resolvePendingNavigationCommitDecision({
-    activeNavigationId: options.activeNavigationId,
-    currentRootLayoutTreePath: options.currentState.rootLayoutTreePath,
-    nextRootLayoutTreePath: options.pending.rootLayoutTreePath,
-    startedNavigationId: options.startedNavigationId,
-  });
-
-  switch (decision.disposition) {
-    case "commit":
-      return {
-        approvedCommit: createApprovedVisibleCommit({
-          decision,
-          pending: options.pending,
-        }),
-        decision,
-      };
-    case "hard-navigate":
-    case "no-commit":
-      return {
-        approvedCommit: null,
-        decision,
-      };
-    default: {
-      const _exhaustive: never = decision;
-      throw new Error("[vinext] Unknown commit decision: " + String(_exhaustive));
-    }
-  }
 }
 
 function getPendingNavigationCommitDispositionTraceCode(options: {
@@ -514,58 +379,4 @@ export async function createPendingNavigationCommit(options: {
     rootLayoutTreePath: metadata.rootLayoutTreePath,
     routeId: metadata.routeId,
   };
-}
-
-export async function resolveAndClassifyNavigationCommit(options: {
-  activeNavigationId: number;
-  currentState: AppRouterState;
-  navigationSnapshot: ClientNavigationRenderSnapshot;
-  nextElements: Promise<AppElements>;
-  operationLane: OperationLane;
-  previousNextUrl?: string | null;
-  renderId: number;
-  startedNavigationId: number;
-  type: "navigate" | "replace" | "traverse";
-}): Promise<ClassifiedPendingNavigationCommit> {
-  const pending = await createPendingNavigationCommit({
-    currentState: options.currentState,
-    nextElements: options.nextElements,
-    navigationSnapshot: options.navigationSnapshot,
-    operationLane: options.operationLane,
-    previousNextUrl: options.previousNextUrl,
-    renderId: options.renderId,
-    type: options.type,
-  });
-
-  const approval = approvePendingNavigationCommit({
-    activeNavigationId: options.activeNavigationId,
-    currentState: options.currentState,
-    pending,
-    startedNavigationId: options.startedNavigationId,
-  });
-
-  return {
-    approvedCommit: approval.approvedCommit,
-    decision: approval.decision,
-    disposition: commitDecisionToPendingNavigationCommitDisposition(approval.decision),
-    pending,
-    trace: approval.decision.trace,
-  };
-}
-
-function commitDecisionToPendingNavigationCommitDisposition(
-  decision: CommitDecision,
-): PendingNavigationCommitDisposition {
-  switch (decision.disposition) {
-    case "commit":
-      return "dispatch";
-    case "hard-navigate":
-      return "hard-navigate";
-    case "no-commit":
-      return "skip";
-    default: {
-      const _exhaustive: never = decision;
-      throw new Error("[vinext] Unknown commit decision: " + String(_exhaustive));
-    }
-  }
 }

--- a/packages/vinext/src/server/app-browser-state.ts
+++ b/packages/vinext/src/server/app-browser-state.ts
@@ -79,7 +79,41 @@ type PendingNavigationCommitDispositionDecision = {
   disposition: PendingNavigationCommitDisposition;
   trace: NavigationTrace;
 };
+export type VisibleCommitDecision = {
+  disposition: "commit";
+  trace: NavigationTrace;
+};
+type HardNavigateCommitDecision = {
+  disposition: "hard-navigate";
+  trace: NavigationTrace;
+};
+type NoCommitDecision = {
+  disposition: "no-commit";
+  trace: NavigationTrace;
+};
+type CommitDecision = VisibleCommitDecision | HardNavigateCommitDecision | NoCommitDecision;
+const approvedVisibleCommitBrand: unique symbol = Symbol("ApprovedVisibleCommit");
+export type ApprovedVisibleCommit = {
+  readonly [approvedVisibleCommitBrand]: true;
+  readonly action: AppRouterAction;
+  readonly decision: VisibleCommitDecision;
+  readonly interceptionContext: string | null;
+  readonly previousNextUrl: string | null;
+  readonly rootLayoutTreePath: string | null;
+  readonly routeId: string;
+};
+type VisibleCommitApproval = {
+  approvedCommit: ApprovedVisibleCommit;
+  decision: VisibleCommitDecision;
+};
+type NonVisibleCommitApproval = {
+  approvedCommit: null;
+  decision: HardNavigateCommitDecision | NoCommitDecision;
+};
+type CommitApproval = VisibleCommitApproval | NonVisibleCommitApproval;
 type ClassifiedPendingNavigationCommit = {
+  approvedCommit: ApprovedVisibleCommit | null;
+  decision: CommitDecision;
   disposition: PendingNavigationCommitDisposition;
   pending: PendingNavigationCommit;
   trace: NavigationTrace;
@@ -266,6 +300,13 @@ export function routerReducer(state: AppRouterState, action: AppRouterAction): A
   }
 }
 
+export function applyApprovedVisibleCommit(
+  state: AppRouterState,
+  commit: ApprovedVisibleCommit,
+): AppRouterState {
+  return routerReducer(state, commit.action);
+}
+
 export function shouldHardNavigate(
   currentRootLayoutTreePath: string | null,
   nextRootLayoutTreePath: string | null,
@@ -297,6 +338,34 @@ export function resolvePendingNavigationCommitDisposition(options: {
   return "dispatch";
 }
 
+function resolvePendingNavigationCommitDecision(options: {
+  activeNavigationId: number;
+  currentRootLayoutTreePath: string | null;
+  nextRootLayoutTreePath: string | null;
+  startedNavigationId: number;
+}): CommitDecision {
+  const { disposition, trace } = resolvePendingNavigationCommitDispositionDecision(options);
+
+  switch (disposition) {
+    case "skip":
+      return { disposition: "no-commit", trace };
+    case "hard-navigate":
+      return { disposition: "hard-navigate", trace };
+    case "dispatch":
+      return createVisibleCommitDecision(trace);
+    default: {
+      const _exhaustive: never = disposition;
+      throw new Error("[vinext] Unknown navigation commit disposition: " + String(_exhaustive));
+    }
+  }
+}
+
+export function createVisibleCommitDecision(
+  trace: NavigationTrace = createNavigationTrace(NavigationTraceReasonCodes.commitCurrent),
+): VisibleCommitDecision {
+  return { disposition: "commit", trace };
+}
+
 export function resolvePendingNavigationCommitDispositionDecision(options: {
   activeNavigationId: number;
   currentRootLayoutTreePath: string | null;
@@ -322,6 +391,56 @@ export function resolvePendingNavigationCommitDispositionDecision(options: {
       traceFields,
     ),
   };
+}
+
+export function createApprovedVisibleCommit(options: {
+  decision: VisibleCommitDecision;
+  pending: PendingNavigationCommit;
+}): ApprovedVisibleCommit {
+  return {
+    [approvedVisibleCommitBrand]: true,
+    action: options.pending.action,
+    decision: options.decision,
+    interceptionContext: options.pending.interceptionContext,
+    previousNextUrl: options.pending.previousNextUrl,
+    rootLayoutTreePath: options.pending.rootLayoutTreePath,
+    routeId: options.pending.routeId,
+  };
+}
+
+export function approvePendingNavigationCommit(options: {
+  activeNavigationId: number;
+  currentState: AppRouterState;
+  pending: PendingNavigationCommit;
+  startedNavigationId: number;
+}): CommitApproval {
+  const decision = resolvePendingNavigationCommitDecision({
+    activeNavigationId: options.activeNavigationId,
+    currentRootLayoutTreePath: options.currentState.rootLayoutTreePath,
+    nextRootLayoutTreePath: options.pending.rootLayoutTreePath,
+    startedNavigationId: options.startedNavigationId,
+  });
+
+  switch (decision.disposition) {
+    case "commit":
+      return {
+        approvedCommit: createApprovedVisibleCommit({
+          decision,
+          pending: options.pending,
+        }),
+        decision,
+      };
+    case "hard-navigate":
+    case "no-commit":
+      return {
+        approvedCommit: null,
+        decision,
+      };
+    default: {
+      const _exhaustive: never = decision;
+      throw new Error("[vinext] Unknown commit decision: " + String(_exhaustive));
+    }
+  }
 }
 
 function getPendingNavigationCommitDispositionTraceCode(options: {
@@ -407,16 +526,35 @@ export async function resolveAndClassifyNavigationCommit(options: {
     type: options.type,
   });
 
-  const decision = resolvePendingNavigationCommitDispositionDecision({
+  const approval = approvePendingNavigationCommit({
     activeNavigationId: options.activeNavigationId,
-    currentRootLayoutTreePath: options.currentState.rootLayoutTreePath,
-    nextRootLayoutTreePath: pending.rootLayoutTreePath,
+    currentState: options.currentState,
+    pending,
     startedNavigationId: options.startedNavigationId,
   });
 
   return {
-    disposition: decision.disposition,
+    approvedCommit: approval.approvedCommit,
+    decision: approval.decision,
+    disposition: commitDecisionToPendingNavigationCommitDisposition(approval.decision),
     pending,
-    trace: decision.trace,
+    trace: approval.decision.trace,
   };
+}
+
+function commitDecisionToPendingNavigationCommitDisposition(
+  decision: CommitDecision,
+): PendingNavigationCommitDisposition {
+  switch (decision.disposition) {
+    case "commit":
+      return "dispatch";
+    case "hard-navigate":
+      return "hard-navigate";
+    case "no-commit":
+      return "skip";
+    default: {
+      const _exhaustive: never = decision;
+      throw new Error("[vinext] Unknown commit decision: " + String(_exhaustive));
+    }
+  }
 }

--- a/packages/vinext/src/server/app-browser-state.ts
+++ b/packages/vinext/src/server/app-browser-state.ts
@@ -74,7 +74,7 @@ export type PendingNavigationCommit = {
   routeId: string;
 };
 
-export type PendingNavigationCommitDisposition = "dispatch" | "hard-navigate" | "skip";
+type PendingNavigationCommitDisposition = "dispatch" | "hard-navigate" | "skip";
 type PendingNavigationCommitDispositionDecision = {
   disposition: PendingNavigationCommitDisposition;
   trace: NavigationTrace;

--- a/packages/vinext/src/server/app-browser-visible-commit.ts
+++ b/packages/vinext/src/server/app-browser-visible-commit.ts
@@ -8,7 +8,6 @@ import {
   type AppRouterState,
   type OperationLane,
   type PendingNavigationCommit,
-  type PendingNavigationCommitDisposition,
 } from "./app-browser-state.js";
 import {
   NavigationTraceReasonCodes,
@@ -51,7 +50,6 @@ type CommitApproval = VisibleCommitApproval | NonVisibleCommitApproval;
 type ClassifiedPendingNavigationCommit = {
   approvedCommit: ApprovedVisibleCommit | null;
   decision: CommitDecision;
-  disposition: PendingNavigationCommitDisposition;
   pending: PendingNavigationCommit;
   trace: NavigationTrace;
 };
@@ -183,25 +181,7 @@ export async function resolveAndClassifyNavigationCommit(options: {
   return {
     approvedCommit: approval.approvedCommit,
     decision: approval.decision,
-    disposition: commitDecisionToPendingNavigationCommitDisposition(approval.decision),
     pending,
     trace: approval.decision.trace,
   };
-}
-
-function commitDecisionToPendingNavigationCommitDisposition(
-  decision: CommitDecision,
-): PendingNavigationCommitDisposition {
-  switch (decision.disposition) {
-    case "commit":
-      return "dispatch";
-    case "hard-navigate":
-      return "hard-navigate";
-    case "no-commit":
-      return "skip";
-    default: {
-      const _exhaustive: never = decision;
-      throw new Error("[vinext] Unknown commit decision: " + String(_exhaustive));
-    }
-  }
 }

--- a/packages/vinext/src/server/app-browser-visible-commit.ts
+++ b/packages/vinext/src/server/app-browser-visible-commit.ts
@@ -1,0 +1,207 @@
+import type { ClientNavigationRenderSnapshot } from "vinext/shims/navigation";
+import type { AppElements } from "./app-elements.js";
+import {
+  createPendingNavigationCommit,
+  resolvePendingNavigationCommitDispositionDecision,
+  routerReducer,
+  type AppRouterAction,
+  type AppRouterState,
+  type OperationLane,
+  type PendingNavigationCommit,
+  type PendingNavigationCommitDisposition,
+} from "./app-browser-state.js";
+import {
+  NavigationTraceReasonCodes,
+  createNavigationTrace,
+  type NavigationTrace,
+} from "./navigation-trace.js";
+
+type VisibleCommitDecision = {
+  disposition: "commit";
+  trace: NavigationTrace;
+};
+type HardNavigateCommitDecision = {
+  disposition: "hard-navigate";
+  trace: NavigationTrace;
+};
+type NoCommitDecision = {
+  disposition: "no-commit";
+  trace: NavigationTrace;
+};
+type CommitDecision = VisibleCommitDecision | HardNavigateCommitDecision | NoCommitDecision;
+const approvedVisibleCommitBrand: unique symbol = Symbol("ApprovedVisibleCommit");
+export type ApprovedVisibleCommit = {
+  readonly [approvedVisibleCommitBrand]: true;
+  readonly action: AppRouterAction;
+  readonly decision: VisibleCommitDecision;
+  readonly interceptionContext: string | null;
+  readonly previousNextUrl: string | null;
+  readonly rootLayoutTreePath: string | null;
+  readonly routeId: string;
+};
+type VisibleCommitApproval = {
+  approvedCommit: ApprovedVisibleCommit;
+  decision: VisibleCommitDecision;
+};
+type NonVisibleCommitApproval = {
+  approvedCommit: null;
+  decision: HardNavigateCommitDecision | NoCommitDecision;
+};
+type CommitApproval = VisibleCommitApproval | NonVisibleCommitApproval;
+type ClassifiedPendingNavigationCommit = {
+  approvedCommit: ApprovedVisibleCommit | null;
+  decision: CommitDecision;
+  disposition: PendingNavigationCommitDisposition;
+  pending: PendingNavigationCommit;
+  trace: NavigationTrace;
+};
+
+export function applyApprovedVisibleCommit(
+  state: AppRouterState,
+  commit: ApprovedVisibleCommit,
+): AppRouterState {
+  return routerReducer(state, commit.action);
+}
+
+function resolvePendingNavigationCommitDecision(options: {
+  activeNavigationId: number;
+  currentRootLayoutTreePath: string | null;
+  nextRootLayoutTreePath: string | null;
+  startedNavigationId: number;
+}): CommitDecision {
+  const { disposition, trace } = resolvePendingNavigationCommitDispositionDecision(options);
+
+  switch (disposition) {
+    case "skip":
+      return { disposition: "no-commit", trace };
+    case "hard-navigate":
+      return { disposition: "hard-navigate", trace };
+    case "dispatch":
+      return createVisibleCommitDecision(trace);
+    default: {
+      const _exhaustive: never = disposition;
+      throw new Error("[vinext] Unknown navigation commit disposition: " + String(_exhaustive));
+    }
+  }
+}
+
+function createVisibleCommitDecision(
+  trace: NavigationTrace = createNavigationTrace(NavigationTraceReasonCodes.commitCurrent),
+): VisibleCommitDecision {
+  return { disposition: "commit", trace };
+}
+
+function createApprovedVisibleCommit(options: {
+  decision: VisibleCommitDecision;
+  pending: PendingNavigationCommit;
+}): ApprovedVisibleCommit {
+  return {
+    [approvedVisibleCommitBrand]: true,
+    action: options.pending.action,
+    decision: options.decision,
+    interceptionContext: options.pending.interceptionContext,
+    previousNextUrl: options.pending.previousNextUrl,
+    rootLayoutTreePath: options.pending.rootLayoutTreePath,
+    routeId: options.pending.routeId,
+  };
+}
+
+export function approveHmrVisibleCommit(pending: PendingNavigationCommit): ApprovedVisibleCommit {
+  if (pending.action.operation.lane !== "hmr") {
+    throw new Error("[vinext] HMR visible commit approval requires an HMR pending operation");
+  }
+
+  return createApprovedVisibleCommit({
+    decision: createVisibleCommitDecision(),
+    pending,
+  });
+}
+
+export function approvePendingNavigationCommit(options: {
+  activeNavigationId: number;
+  currentState: AppRouterState;
+  pending: PendingNavigationCommit;
+  startedNavigationId: number;
+}): CommitApproval {
+  const decision = resolvePendingNavigationCommitDecision({
+    activeNavigationId: options.activeNavigationId,
+    currentRootLayoutTreePath: options.currentState.rootLayoutTreePath,
+    nextRootLayoutTreePath: options.pending.rootLayoutTreePath,
+    startedNavigationId: options.startedNavigationId,
+  });
+
+  switch (decision.disposition) {
+    case "commit":
+      return {
+        approvedCommit: createApprovedVisibleCommit({
+          decision,
+          pending: options.pending,
+        }),
+        decision,
+      };
+    case "hard-navigate":
+    case "no-commit":
+      return {
+        approvedCommit: null,
+        decision,
+      };
+    default: {
+      const _exhaustive: never = decision;
+      throw new Error("[vinext] Unknown commit decision: " + String(_exhaustive));
+    }
+  }
+}
+
+export async function resolveAndClassifyNavigationCommit(options: {
+  activeNavigationId: number;
+  currentState: AppRouterState;
+  navigationSnapshot: ClientNavigationRenderSnapshot;
+  nextElements: Promise<AppElements>;
+  operationLane: OperationLane;
+  previousNextUrl?: string | null;
+  renderId: number;
+  startedNavigationId: number;
+  type: "navigate" | "replace" | "traverse";
+}): Promise<ClassifiedPendingNavigationCommit> {
+  const pending = await createPendingNavigationCommit({
+    currentState: options.currentState,
+    nextElements: options.nextElements,
+    navigationSnapshot: options.navigationSnapshot,
+    operationLane: options.operationLane,
+    previousNextUrl: options.previousNextUrl,
+    renderId: options.renderId,
+    type: options.type,
+  });
+
+  const approval = approvePendingNavigationCommit({
+    activeNavigationId: options.activeNavigationId,
+    currentState: options.currentState,
+    pending,
+    startedNavigationId: options.startedNavigationId,
+  });
+
+  return {
+    approvedCommit: approval.approvedCommit,
+    decision: approval.decision,
+    disposition: commitDecisionToPendingNavigationCommitDisposition(approval.decision),
+    pending,
+    trace: approval.decision.trace,
+  };
+}
+
+function commitDecisionToPendingNavigationCommitDisposition(
+  decision: CommitDecision,
+): PendingNavigationCommitDisposition {
+  switch (decision.disposition) {
+    case "commit":
+      return "dispatch";
+    case "hard-navigate":
+      return "hard-navigate";
+    case "no-commit":
+      return "skip";
+    default: {
+      const _exhaustive: never = decision;
+      throw new Error("[vinext] Unknown commit decision: " + String(_exhaustive));
+    }
+  }
+}

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -676,6 +676,9 @@ describe("app browser entry state helpers", () => {
       startedNavigationId: 7,
     });
     expect(staleApproval.decision.disposition).toBe("no-commit");
+    expect(staleApproval.decision.trace.entries[0]?.code).toBe(
+      NavigationTraceReasonCodes.staleOperation,
+    );
     expect(staleApproval.approvedCommit).toBeNull();
 
     const hardNavigateApproval = approvePendingNavigationCommit({
@@ -685,6 +688,9 @@ describe("app browser entry state helpers", () => {
       startedNavigationId: 8,
     });
     expect(hardNavigateApproval.decision.disposition).toBe("hard-navigate");
+    expect(hardNavigateApproval.decision.trace.entries[0]?.code).toBe(
+      NavigationTraceReasonCodes.rootBoundaryChanged,
+    );
     expect(hardNavigateApproval.approvedCommit).toBeNull();
   });
 
@@ -1254,7 +1260,7 @@ describe("app browser navigation lifecycle settlement", () => {
       type: "navigate",
     });
 
-    expect(result.disposition).toBe("skip");
+    expect(result.decision.disposition).toBe("no-commit");
     expect(result.pending.routeId).toBe("route:/dashboard");
   });
 
@@ -1442,7 +1448,7 @@ describe("app browser entry previousNextUrl helpers", () => {
       type: "navigate",
     });
 
-    expect(result.disposition).toBe("hard-navigate");
+    expect(result.decision.disposition).toBe("hard-navigate");
     expect(result.pending.routeId).toBe("route:/dashboard");
     expect(result.pending.action.renderId).toBe(3);
     expect(result.trace.entries[0]?.code).toBe(NavigationTraceReasonCodes.rootBoundaryChanged);

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -20,6 +20,7 @@ import {
   createOperationRecord,
   createPendingNavigationCommit,
   applyApprovedVisibleCommit,
+  approveHmrVisibleCommit,
   approvePendingNavigationCommit,
   readHistoryStatePreviousNextUrl,
   resolveAndClassifyNavigationCommit,
@@ -533,6 +534,48 @@ describe("app browser entry state helpers", () => {
       state: "committed",
       visibleCommitVersion: 1,
     });
+  });
+
+  it("approves HMR visible commits through a named trusted recovery path", async () => {
+    const currentState = createState();
+    const pending = await createPendingNavigationCommit({
+      currentState,
+      nextElements: Promise.resolve(
+        createResolvedElements("route:/hmr", "/", null, {
+          "page:/hmr": React.createElement("main", null, "hmr"),
+        }),
+      ),
+      navigationSnapshot: currentState.navigationSnapshot,
+      operationLane: "hmr",
+      renderId: 14,
+      type: "replace",
+    });
+
+    const approvedCommit = approveHmrVisibleCommit(pending);
+    const nextState = applyApprovedVisibleCommit(currentState, approvedCommit);
+
+    expect(nextState.routeId).toBe("route:/hmr");
+    expect(nextState.activeOperation).toMatchObject({
+      id: 14,
+      lane: "hmr",
+      state: "committed",
+    });
+  });
+
+  it("rejects non-HMR commits on the HMR approval path", async () => {
+    const currentState = createState();
+    const pending = await createPendingNavigationCommit({
+      currentState,
+      nextElements: Promise.resolve(createResolvedElements("route:/dashboard", "/")),
+      navigationSnapshot: currentState.navigationSnapshot,
+      operationLane: "navigation",
+      renderId: 15,
+      type: "replace",
+    });
+
+    expect(() => approveHmrVisibleCommit(pending)).toThrow(
+      "[vinext] HMR visible commit approval requires an HMR pending operation",
+    );
   });
 
   it("applies approved replace commits without preserving old elements", async () => {

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -19,11 +19,7 @@ import {
   createHistoryStateWithPreviousNextUrl,
   createOperationRecord,
   createPendingNavigationCommit,
-  applyApprovedVisibleCommit,
-  approveHmrVisibleCommit,
-  approvePendingNavigationCommit,
   readHistoryStatePreviousNextUrl,
-  resolveAndClassifyNavigationCommit,
   resolveInterceptionContextFromPreviousNextUrl,
   resolveServerActionRequestState,
   routerReducer,
@@ -32,6 +28,12 @@ import {
   shouldHardNavigate,
   type AppRouterState,
 } from "../packages/vinext/src/server/app-browser-state.js";
+import {
+  applyApprovedVisibleCommit,
+  approveHmrVisibleCommit,
+  approvePendingNavigationCommit,
+  resolveAndClassifyNavigationCommit,
+} from "../packages/vinext/src/server/app-browser-visible-commit.js";
 import {
   NAVIGATION_TRACE_SCHEMA_VERSION,
   NavigationTraceReasonCodes,

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -19,6 +19,8 @@ import {
   createHistoryStateWithPreviousNextUrl,
   createOperationRecord,
   createPendingNavigationCommit,
+  applyApprovedVisibleCommit,
+  approvePendingNavigationCommit,
   readHistoryStatePreviousNextUrl,
   resolveAndClassifyNavigationCommit,
   resolveInterceptionContextFromPreviousNextUrl,
@@ -491,6 +493,156 @@ describe("app browser entry state helpers", () => {
     expect(refreshCommit.previousNextUrl).toBe("/feed");
   });
 
+  it("creates an approved visible commit only after the current operation decision allows mutation", async () => {
+    const currentState = createState();
+    const pending = await createPendingNavigationCommit({
+      currentState,
+      nextElements: Promise.resolve(
+        createResolvedElements("route:/dashboard", "/", null, {
+          "page:/dashboard": React.createElement("main", null, "dashboard"),
+        }),
+      ),
+      navigationSnapshot: currentState.navigationSnapshot,
+      operationLane: "navigation",
+      renderId: 11,
+      type: "navigate",
+    });
+
+    const approval = approvePendingNavigationCommit({
+      activeNavigationId: 4,
+      currentState,
+      pending,
+      startedNavigationId: 4,
+    });
+
+    expect(approval.decision.disposition).toBe("commit");
+    if (approval.decision.disposition !== "commit") {
+      throw new Error("Expected visible commit approval");
+    }
+    if (approval.approvedCommit === null) {
+      throw new Error("Expected approved visible commit");
+    }
+
+    const nextState = applyApprovedVisibleCommit(currentState, approval.approvedCommit);
+    expect(nextState.routeId).toBe("route:/dashboard");
+    expect(nextState.visibleCommitVersion).toBe(1);
+    expect(nextState.activeOperation).toMatchObject({
+      id: 11,
+      lane: "navigation",
+      startedVisibleCommitVersion: 0,
+      state: "committed",
+      visibleCommitVersion: 1,
+    });
+  });
+
+  it("applies approved replace commits without preserving old elements", async () => {
+    const currentState = createState({
+      elements: createResolvedElements("route:/initial", "/", null, {
+        "layout:/old": React.createElement("div", null, "old"),
+      }),
+    });
+    const nextElements = createResolvedElements("route:/next", "/", null, {
+      "page:/next": React.createElement("main", null, "next"),
+    });
+    const pending = await createPendingNavigationCommit({
+      currentState,
+      nextElements: Promise.resolve(nextElements),
+      navigationSnapshot: currentState.navigationSnapshot,
+      operationLane: "navigation",
+      renderId: 12,
+      type: "replace",
+    });
+
+    const approval = approvePendingNavigationCommit({
+      activeNavigationId: 4,
+      currentState,
+      pending,
+      startedNavigationId: 4,
+    });
+
+    if (approval.approvedCommit === null) {
+      throw new Error("Expected approved visible commit");
+    }
+
+    const nextState = applyApprovedVisibleCommit(currentState, approval.approvedCommit);
+    expect(nextState.elements).toBe(nextElements);
+    expect(Object.hasOwn(nextState.elements, "layout:/old")).toBe(false);
+    expect(nextState.activeOperation).toMatchObject({
+      id: 12,
+      lane: "navigation",
+      state: "committed",
+    });
+  });
+
+  it("applies approved traverse commits with stale slot cleanup", async () => {
+    const currentState = createState({
+      elements: createResolvedElements("route:/feed/comments", "/", null, {
+        "slot:modal:/feed": React.createElement("div", null, "modal"),
+      }),
+    });
+    const pending = await createPendingNavigationCommit({
+      currentState,
+      nextElements: Promise.resolve(createResolvedElements("route:/feed", "/")),
+      navigationSnapshot: currentState.navigationSnapshot,
+      operationLane: "traverse",
+      previousNextUrl: null,
+      renderId: 13,
+      type: "traverse",
+    });
+
+    const approval = approvePendingNavigationCommit({
+      activeNavigationId: 4,
+      currentState,
+      pending,
+      startedNavigationId: 4,
+    });
+
+    if (approval.approvedCommit === null) {
+      throw new Error("Expected approved visible commit");
+    }
+
+    const nextState = applyApprovedVisibleCommit(currentState, approval.approvedCommit);
+    expect(nextState.routeId).toBe("route:/feed");
+    expect(Object.hasOwn(nextState.elements, "slot:modal:/feed")).toBe(false);
+    expect(nextState.activeOperation).toMatchObject({
+      id: 13,
+      lane: "traverse",
+      state: "committed",
+    });
+  });
+
+  it("does not create approved visible commits for stale or hard-navigation decisions", async () => {
+    const currentState = createState({
+      rootLayoutTreePath: "/(marketing)",
+    });
+    const pending = await createPendingNavigationCommit({
+      currentState,
+      nextElements: Promise.resolve(createResolvedElements("route:/dashboard", "/(dashboard)")),
+      navigationSnapshot: currentState.navigationSnapshot,
+      operationLane: "navigation",
+      renderId: 12,
+      type: "navigate",
+    });
+
+    const staleApproval = approvePendingNavigationCommit({
+      activeNavigationId: 8,
+      currentState,
+      pending,
+      startedNavigationId: 7,
+    });
+    expect(staleApproval.decision.disposition).toBe("no-commit");
+    expect(staleApproval.approvedCommit).toBeNull();
+
+    const hardNavigateApproval = approvePendingNavigationCommit({
+      activeNavigationId: 8,
+      currentState,
+      pending,
+      startedNavigationId: 8,
+    });
+    expect(hardNavigateApproval.decision.disposition).toBe("hard-navigate");
+    expect(hardNavigateApproval.approvedCommit).toBeNull();
+  });
+
   it("merges layoutFlags on navigate", () => {
     const state = createState({ layoutFlags: { "layout:/": "s", "layout:/old": "d" } });
     const nextState = routerReducer(state, {
@@ -929,7 +1081,7 @@ describe("app browser navigation lifecycle settlement", () => {
       // Yield so C's async payload resolves and state is committed.
       // renderNavigationPayload returns a promise that settles only when
       // NavigationCommitSignal fires (a React component not mounted in
-      // unit tests). The state mutation through dispatchBrowserTree is
+      // unit tests). The state mutation through dispatchApprovedVisibleCommit is
       // synchronous when useTransition=false, so we verify via stateRef.
       await Promise.resolve();
       await Promise.resolve();


### PR DESCRIPTION
## What this changes

Implements `#726-CORE-02/03` from #726.

This introduces `CommitDecision` and `ApprovedVisibleCommit` as the explicit proof object for visible App Router browser commits. Navigation and same-URL server-action state writes now flow through lifecycle approval before visible browser state can be reduced, and HMR uses a named recovery approval path instead of generic proof construction.

## Why

Issue #726 is moving the browser navigation lifecycle toward explicit commit authority. The current code already had operation records and `visibleCommitVersion`, but each browser writer still held its own implicit approval check before calling the reducer. That made future stale-result gates and planner work easier to bypass accidentally.

This PR is the intended thin spine step: no proof, no visible commit transaction.

## Approach

- Add `app-browser-visible-commit.ts` as the visible browser mutation authority module.
- Keep `app-browser-state.ts` focused on state shape, reducer mechanics, pending commit construction, history helpers, server-action request headers, and legacy disposition tracing.
- Add a commit decision layer that maps the existing `dispatch`, `skip`, and `hard-navigate` semantics to `commit`, `no-commit`, and `hard-navigate` decisions.
- Add `ApprovedVisibleCommit` as a nominal commit proof and route visible state reduction through `applyApprovedVisibleCommit`.
- Keep the generic proof constructors private inside `app-browser-visible-commit.ts`.
- Expose `approvePendingNavigationCommit()` as the navigation lifecycle gate.
- Expose `approveHmrVisibleCommit()` as the named trusted HMR recovery path, with a lane guard so non-HMR pending commits cannot use it as a generic approval escape hatch.
- Replace the controller's raw `dispatchBrowserTree` path with `dispatchApprovedVisibleCommit` for navigation, same-URL action payloads, and HMR.
- Have same-URL action payload handling read the authoritative `CommitDecision` directly, with the legacy disposition shape kept private to the older state-level classifier.
- Preserve current behavior.

Non-goals for this PR, matching `#726-CORE-02/03`:

- stale same-URL server-action rejection
- `NavigationPlanner`
- cache semantics

## Validation

- `vp check packages/vinext/src/server/app-browser-state.ts packages/vinext/src/server/app-browser-visible-commit.ts packages/vinext/src/server/app-browser-navigation-controller.ts tests/app-browser-entry.test.ts`
- `vp test run tests/app-browser-entry.test.ts tests/app-route-graph.test.ts`
- `vp run vinext#build`
- Commit hook ran `vp check --fix` and `knip --no-progress`

## Bonk

Bonk, please read issue #726 before reviewing so the `ApprovedVisibleCommit` boundary is evaluated in the larger lifecycle and planner roadmap context, not as an isolated refactor.
