### PR TITLE
fix(prerender): render layout-only parallel slot routes

### DIFF
--- a/packages/vinext/src/build/prerender.ts
+++ b/packages/vinext/src/build/prerender.ts
@@ -23,7 +23,7 @@ import type { Server as HttpServer } from "node:http";
 import type { Route } from "../routing/pages-router.js";
 import type { AppRoute } from "../routing/app-router.js";
 import type { ResolvedNextConfig } from "../config/next-config.js";
-import { classifyPagesRoute, classifyAppRoute } from "./report.js";
+import { classifyPagesRoute, classifyAppRoute, getAppRouteRenderEntryPath } from "./report.js";
 import {
   NoOpCacheHandler,
   setCacheHandler,
@@ -836,20 +836,21 @@ export async function prerenderApp({
     const urlsToRender: UrlToRender[] = [];
 
     for (const route of routes) {
-      // API-only route handler (no page component)
-      if (route.routePath && !route.pagePath) {
+      const renderEntryPath = getAppRouteRenderEntryPath(route);
+
+      if (!renderEntryPath && route.routePath) {
         results.push({ route: route.pattern, status: "skipped", reason: "api" });
         continue;
       }
 
-      if (!route.pagePath) continue;
+      if (!renderEntryPath) continue;
 
       // Use static analysis classification, but note its limitations for dynamic URLs:
       // classifyAppRoute() returns 'ssr' for dynamic URLs with no explicit config,
       // meaning "unknown — could have generateStaticParams". We must check
       // generateStaticParams first before applying the ssr skip/error logic.
       const { type, revalidate: classifiedRevalidate } = classifyAppRoute(
-        route.pagePath,
+        renderEntryPath,
         route.routePath,
         route.isDynamic,
       );

--- a/packages/vinext/src/build/report.ts
+++ b/packages/vinext/src/build/report.ts
@@ -43,6 +43,23 @@ export type RouteRow = {
   prerendered?: boolean;
 };
 
+type AppRouteRenderEntry = Pick<AppRoute, "pagePath" | "routePath" | "parallelSlots">;
+
+export function getAppRouteRenderEntryPath(route: AppRouteRenderEntry): string | null {
+  if (route.pagePath) return route.pagePath;
+  if (route.routePath) return null;
+
+  for (const slot of route.parallelSlots) {
+    if (slot.pagePath) return slot.pagePath;
+  }
+
+  for (const slot of route.parallelSlots) {
+    if (slot.defaultPath) return slot.defaultPath;
+  }
+
+  return null;
+}
+
 // ─── Regex-based export detection ────────────────────────────────────────────
 
 /**
@@ -794,7 +811,12 @@ export function buildReportRows(options: {
   }
 
   for (const route of options.appRoutes ?? []) {
-    const { type, revalidate } = classifyAppRoute(route.pagePath, route.routePath, route.isDynamic);
+    const renderEntryPath = getAppRouteRenderEntryPath(route);
+    const { type, revalidate } = classifyAppRoute(
+      renderEntryPath,
+      route.routePath,
+      route.isDynamic,
+    );
     if (type === "unknown" && renderedRoutes.has(route.pattern)) {
       // Speculative prerender confirmed this route is static.
       rows.push({ pattern: route.pattern, type: "static", prerendered: true });

--- a/tests/build-report.test.ts
+++ b/tests/build-report.test.ts
@@ -21,7 +21,7 @@ import {
   formatBuildReport,
   printBuildReport,
 } from "../packages/vinext/src/build/report.js";
-import { invalidateAppRouteCache } from "../packages/vinext/src/routing/app-router.js";
+import { appRouter, invalidateAppRouteCache } from "../packages/vinext/src/routing/app-router.js";
 import { invalidateRouteCache } from "../packages/vinext/src/routing/pages-router.js";
 
 const FIXTURES_PAGES = path.resolve("tests/fixtures/pages-basic/pages");
@@ -492,6 +492,21 @@ describe("buildReportRows", () => {
     const rows = buildReportRows({ pageRoutes });
     expect(rows[0].pattern).toBe("/aaa");
     expect(rows[1].pattern).toBe("/zzz");
+  });
+
+  it("classifies layout-only parallel-slot app routes from their render entry", async () => {
+    invalidateAppRouteCache();
+    const routes = await appRouter(FIXTURES_APP);
+    const rows = buildReportRows({ appRoutes: routes });
+
+    expect(rows.find((row) => row.pattern === "/parallel-nested/home")).toMatchObject({
+      pattern: "/parallel-nested/home",
+      type: "unknown",
+    });
+    expect(rows.find((row) => row.pattern === "/slot-collision")).toMatchObject({
+      pattern: "/slot-collision",
+      type: "unknown",
+    });
   });
 });
 

--- a/tests/prerender.test.ts
+++ b/tests/prerender.test.ts
@@ -478,6 +478,31 @@ describe("prerenderApp — default mode (app-basic)", () => {
     expect(r).toMatchObject({ route: "/dashboard", status: "rendered", revalidate: false });
   });
 
+  it("renders layout-only routes whose content comes from parallel slots", () => {
+    // Ported from Next.js: test/e2e/app-dir/parallel-routes-and-interception/parallel-routes-and-interception.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/parallel-routes-and-interception/parallel-routes-and-interception.test.ts
+    const parent = findRoute(results, "/parallel-nested/home");
+    expect(parent).toMatchObject({
+      route: "/parallel-nested/home",
+      status: "rendered",
+      revalidate: false,
+    });
+
+    const nested = findRoute(results, "/parallel-nested/home/nested");
+    expect(nested).toMatchObject({
+      route: "/parallel-nested/home/nested",
+      status: "rendered",
+      revalidate: false,
+    });
+
+    const defaultOnly = findRoute(results, "/slot-collision");
+    expect(defaultOnly).toMatchObject({
+      route: "/slot-collision",
+      status: "rendered",
+      revalidate: false,
+    });
+  });
+
   it("skips /headers-test (unknown route that calls headers())", () => {
     const r = findRoute(results, "/headers-test");
     // headers-test calls headers() — should be skipped as dynamic


### PR DESCRIPTION
## What this changes

Layout-only App Router routes that render through parallel slot content now participate in prerender and static export. Routes such as `/parallel-nested/home`, `/parallel-nested/home/nested`, and `/slot-collision` are rendered instead of being silently omitted from `vinext-prerender.json` and exported output.

## Why

The prerender loop used `route.pagePath` as the only signal that an App Router route had renderable UI. That is too narrow for parallel routes: a segment can have `layout.tsx` with no `page.tsx`, while its visible content is supplied by a parallel slot page or default module.

Next.js models this differently:

- [`normalizeAppPath()` ignores `@slot` path segments when deriving the request path](https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/router/utils/app-paths.ts)
- [`getLayoutOrPageModule()` can load a `defaultPage` as the page module for the default segment](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/app-dir-module.ts)
- The relevant behavior is covered by the Next.js parallel routes test for nested parallel routes without a page component: [`parallel-routes-and-interception.test.ts`](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/parallel-routes-and-interception/parallel-routes-and-interception.test.ts)

## Approach

Add a shared `getAppRouteRenderEntryPath()` helper that defines the App Router render-entry contract for build-time consumers:

- children `page.tsx` remains the primary render entry
- route handlers without UI remain API-only
- layout-only UI routes fall back to the first parallel slot `pagePath`, then the first slot `defaultPath`

Both prerender collection and build-report classification use that helper, so route reporting and static generation agree on whether a route is renderable.

## Validation

- `vp test run tests/prerender.test.ts`
- `vp test run tests/build-report.test.ts`
- `vp test run tests/routing.test.ts -t "layout routes whose own content is parallel slot pages|nested parallel slot sub-routes from layout-only parent"`
- `vp test run tests/build-report.test.ts tests/prerender.test.ts tests/routing.test.ts -t "layout-only parallel-slot app routes|layout-only routes|layout routes whose own content is parallel slot pages|nested parallel slot sub-routes from layout-only parent"`
- `vp check packages/vinext/src/build/prerender.ts packages/vinext/src/build/report.ts tests/prerender.test.ts tests/build-report.test.ts`

## Risks / follow-ups

This intentionally does not change route graph discovery or request-time rendering. It only fixes build-time route collection/classification for routes already discovered and renderable by the App Router runtime.

Closes #1052
