### PR TITLE
feat(server): add disabled cache proof model

### DIFF
--- a/knip.ts
+++ b/knip.ts
@@ -70,6 +70,9 @@ export default {
         "src/server/app-request-context.ts",
         "src/server/app-rsc-error-handler.ts",
         "src/server/rsc-stream-hints.ts",
+        // #726-CACHE-01/04 defines the disabled proof boundary before runtime
+        // observation recording or cache reuse is wired in later slices.
+        "src/server/cache-proof.ts",
       ],
       project: ["src/**/*.{ts,tsx}"],
     },

--- a/packages/vinext/src/server/cache-proof.ts
+++ b/packages/vinext/src/server/cache-proof.ts
@@ -297,8 +297,8 @@ function compareDimensions(a: CacheVariantDimension, b: CacheVariantDimension): 
   );
 }
 
-function encodeNullable(value: string | null): string {
-  return value ?? "";
+function encodeNullable(value: string | null): string | null {
+  return value;
 }
 
 function assertNever(value: never): never {
@@ -445,7 +445,7 @@ function buildDimension(
 function isCacheProofBreakerFallback(
   value: CacheVariantDimension | CacheProofBreakerFallback,
 ): value is CacheProofBreakerFallback {
-  return "kind" in value;
+  return "code" in value;
 }
 
 function getDimensionBucket(
@@ -610,7 +610,7 @@ function boundaryOutcomesMatch(expected: BoundaryOutcome, candidate: BoundaryOut
     case "unauthorized":
       return candidate.kind === "unauthorized";
     case "unknown":
-      return candidate.kind === "unknown";
+      return false;
     default:
       return assertNever(expected);
   }

--- a/packages/vinext/src/server/cache-proof.ts
+++ b/packages/vinext/src/server/cache-proof.ts
@@ -1,0 +1,726 @@
+import type { AppRouteSemanticIds } from "../routing/app-route-graph.js";
+import { fnv1a64 } from "../utils/hash.js";
+
+export const CACHE_PROOF_MODEL_SCHEMA_VERSION = 0;
+export type CacheProofModelSchemaVersion = 0;
+
+export type CacheProofRejectionCode =
+  | "CP_MODEL_DISABLED"
+  | "CP_DIMENSION_COUNT_EXCEEDED"
+  | "CP_DIMENSION_NAME_MISSING"
+  | "CP_DIMENSION_NAME_TOO_LONG"
+  | "CP_DIMENSION_VALUE_COUNT_EXCEEDED"
+  | "CP_DIMENSION_VALUE_TOO_LONG"
+  | "CP_DIMENSION_VALUES_MISSING"
+  | "CP_ENCODED_VARIANT_TOO_LONG"
+  | "CP_ROUTE_VARIANT_CEILING_EXCEEDED"
+  | "CP_UNSAFE_PUBLIC_DIMENSION"
+  | "CP_BOUNDARY_OUTCOME_MISMATCH"
+  | "CP_BOUNDARY_OUTCOME_UNKNOWN";
+
+export type CacheProofTraceFieldValue = string | number | boolean | null | readonly string[];
+
+export type CacheProofTraceFields = Readonly<Record<string, CacheProofTraceFieldValue>>;
+
+export type CacheProofBreakerFallbackMode = "renderFresh" | "privateUncacheable";
+export type CacheProofFallbackScope = "affectedOutput" | "route";
+
+export type CacheProofBreakerFallback = Readonly<{
+  kind: "breakerFallback";
+  code: CacheProofRejectionCode;
+  mode: CacheProofBreakerFallbackMode;
+  scope: CacheProofFallbackScope;
+  fields: CacheProofTraceFields;
+}>;
+
+export type CacheVariantBudget = Readonly<{
+  maxDimensionCount: number;
+  maxDimensionNameLength: number;
+  maxDimensionValueLength: number;
+  maxEncodedLength: number;
+  maxValuesPerDimension: number;
+  maxVariantsPerRoute: number;
+}>;
+
+export const DEFAULT_CACHE_VARIANT_BUDGET = {
+  maxDimensionCount: 8,
+  maxDimensionNameLength: 64,
+  maxDimensionValueLength: 256,
+  maxEncodedLength: 1024,
+  maxValuesPerDimension: 8,
+  maxVariantsPerRoute: 64,
+} satisfies CacheVariantBudget;
+
+export type CacheVariantDimensionSource =
+  | "auth"
+  | "cookie"
+  | "custom"
+  | "draft-mode"
+  | "header"
+  | "interception"
+  | "mounted-slots"
+  | "params"
+  | "route"
+  | "search"
+  | "session";
+
+export type CacheVariantDimensionPrivacy = "internal" | "private" | "public";
+
+export type CacheVariantDimensionInput = Readonly<{
+  name: string;
+  privacy: CacheVariantDimensionPrivacy;
+  source: CacheVariantDimensionSource;
+  values: readonly string[];
+}>;
+
+export type CacheVariantDimension = Readonly<{
+  encoded: string;
+  name: string;
+  privacy: CacheVariantDimensionPrivacy;
+  source: CacheVariantDimensionSource;
+  valueCount: number;
+  valueHashes: readonly string[];
+}>;
+
+export type CacheProofOutputScope =
+  | Readonly<{
+      kind: "app-html";
+      renderEpoch: string | null;
+      rootBoundaryId: string | null;
+      routeId: string;
+    }>
+  | Readonly<{
+      kind: "app-rsc";
+      mountedSlotsFingerprint: string | null;
+      renderEpoch: string | null;
+      rootBoundaryId: string | null;
+      routeId: string;
+    }>
+  | Readonly<{
+      kind: "layout";
+      layoutId: string;
+      rootBoundaryId: string | null;
+      routeId: string;
+    }>
+  | Readonly<{
+      kind: "page";
+      pageId: string;
+      rootBoundaryId: string | null;
+      routeId: string;
+    }>
+  | Readonly<{
+      kind: "route-handler";
+      routeHandlerId: string;
+      routeId: string;
+    }>
+  | Readonly<{
+      kind: "slot";
+      rootBoundaryId: string | null;
+      routeId: string;
+      slotId: string;
+    }>
+  | Readonly<{
+      kind: "template";
+      rootBoundaryId: string | null;
+      routeId: string;
+      templateId: string;
+    }>;
+
+export type CacheVariant = Readonly<{
+  budget: CacheVariantBudget;
+  cacheKey: string;
+  dimensions: readonly CacheVariantDimension[];
+  encodedLength: number;
+  output: CacheProofOutputScope;
+  schemaVersion: CacheProofModelSchemaVersion;
+}>;
+
+export type BuildCacheVariantInput = Readonly<{
+  budget: CacheVariantBudget;
+  dimensions: readonly CacheVariantDimensionInput[];
+  existingVariantCount: number;
+  output: CacheProofOutputScope;
+}>;
+
+export type BuildCacheVariantResult =
+  | Readonly<{ kind: "variant"; variant: CacheVariant }>
+  | Readonly<{ kind: "breakerFallback"; fallback: CacheProofBreakerFallback }>;
+
+export type AppRouteCacheProofGraphScopeInput = Readonly<{
+  ids: AppRouteSemanticIds;
+}>;
+
+export type AppRouteCacheProofGraphScope = Readonly<{
+  layoutIds: readonly string[];
+  pageId: string | null;
+  routeHandlerId: string | null;
+  routeId: string;
+  slotIds: readonly string[];
+  templateIds: readonly string[];
+}>;
+
+export type BoundaryOutcome =
+  | Readonly<{ kind: "error"; digest?: string }>
+  | Readonly<{ kind: "forbidden" }>
+  | Readonly<{ kind: "globalError"; digest?: string }>
+  | Readonly<{ kind: "notFound" }>
+  | Readonly<{ kind: "redirect"; location: string; status: number }>
+  | Readonly<{ kind: "success" }>
+  | Readonly<{ kind: "unauthorized" }>
+  | Readonly<{ kind: "unknown" }>;
+
+export type BoundaryOutcomeCompatibility =
+  | Readonly<{
+      kind: "compatible";
+      outcome: BoundaryOutcome;
+      reason: "CP_BOUNDARY_OUTCOME_MATCH";
+    }>
+  | Readonly<{
+      candidate: BoundaryOutcome;
+      expected: BoundaryOutcome;
+      fallback: CacheProofBreakerFallback;
+      kind: "incompatible";
+    }>;
+
+export type RenderObservationCompleteness = "complete" | "partial" | "unknown";
+export type RenderCacheability = "private" | "public" | "uncacheable" | "unknown";
+export type RenderRequestApiKind =
+  | "connection"
+  | "cookies"
+  | "draftMode"
+  | "headers"
+  | "params"
+  | "searchParams";
+export type RenderRequestApiStatus = "notObserved" | "observed" | "unknown";
+
+export type RenderRequestApiObservation = Readonly<{
+  kind: RenderRequestApiKind;
+  status: RenderRequestApiStatus;
+}>;
+
+export type RenderObservation = Readonly<{
+  boundaryOutcome: BoundaryOutcome;
+  cacheTags: readonly string[];
+  cacheability: RenderCacheability;
+  completeness: RenderObservationCompleteness;
+  dynamicFetches: readonly string[];
+  output: CacheProofOutputScope;
+  pathTags: readonly string[];
+  requestApis: readonly RenderRequestApiObservation[];
+  schemaVersion: CacheProofModelSchemaVersion;
+}>;
+
+export type BuildRenderObservationInput = Readonly<{
+  boundaryOutcome: BoundaryOutcome;
+  cacheTags: readonly string[];
+  cacheability: RenderCacheability;
+  completeness: RenderObservationCompleteness;
+  dynamicFetches: readonly string[];
+  output: CacheProofOutputScope;
+  pathTags: readonly string[];
+  requestApis: readonly RenderRequestApiObservation[];
+}>;
+
+export type DisabledCacheProofDecision = Readonly<{
+  canReuse: false;
+  fallback: CacheProofBreakerFallback;
+  kind: "disabled";
+  observation: RenderObservation;
+  variant: CacheVariant;
+}>;
+
+export type CreateDisabledCacheProofDecisionInput = Readonly<{
+  observation: RenderObservation;
+  variant: CacheVariant;
+}>;
+
+const PUBLIC_UNSAFE_DIMENSION_SOURCES: ReadonlySet<CacheVariantDimensionSource> = new Set([
+  "auth",
+  "cookie",
+  "draft-mode",
+  "header",
+  "session",
+]);
+
+type CacheVariantDimensionAccumulator = {
+  name: string;
+  privacy: CacheVariantDimensionPrivacy;
+  source: CacheVariantDimensionSource;
+  values: string[];
+};
+
+type DimensionAccumulatorByName = Map<string, CacheVariantDimensionAccumulator>;
+type DimensionAccumulatorByPrivacy = Map<CacheVariantDimensionPrivacy, DimensionAccumulatorByName>;
+type DimensionAccumulatorBySource = Map<CacheVariantDimensionSource, DimensionAccumulatorByPrivacy>;
+
+function buildBreakerFallback(
+  code: CacheProofRejectionCode,
+  fields: CacheProofTraceFields = {},
+  mode: CacheProofBreakerFallbackMode = "renderFresh",
+  scope: CacheProofFallbackScope = "affectedOutput",
+): CacheProofBreakerFallback {
+  return {
+    kind: "breakerFallback",
+    code,
+    mode,
+    scope,
+    fields,
+  };
+}
+
+function sortedUnique(values: readonly string[]): string[] {
+  return [...new Set(values)].sort();
+}
+
+function normalizeDimensionName(name: string): string {
+  return name.trim().toLowerCase();
+}
+
+function redactValue(value: string): string {
+  return `h:${fnv1a64(value)}`;
+}
+
+function sortedUniqueRedacted(values: readonly string[]): string[] {
+  return sortedUnique(sortedUnique(values).map(redactValue));
+}
+
+function encodeParts(parts: readonly unknown[]): string {
+  return JSON.stringify(parts);
+}
+
+function compareDimensions(a: CacheVariantDimension, b: CacheVariantDimension): number {
+  return (
+    a.source.localeCompare(b.source) ||
+    a.name.localeCompare(b.name) ||
+    a.privacy.localeCompare(b.privacy)
+  );
+}
+
+function encodeNullable(value: string | null): string {
+  return value ?? "";
+}
+
+function assertNever(value: never): never {
+  throw new Error(`Unhandled cache proof variant: ${String(value)}`);
+}
+
+function encodeOutputScope(output: CacheProofOutputScope): string {
+  switch (output.kind) {
+    case "app-html":
+      return encodeParts([
+        output.kind,
+        output.routeId,
+        encodeNullable(output.rootBoundaryId),
+        encodeNullable(output.renderEpoch),
+      ]);
+    case "app-rsc":
+      return encodeParts([
+        output.kind,
+        output.routeId,
+        encodeNullable(output.rootBoundaryId),
+        encodeNullable(output.renderEpoch),
+        encodeNullable(output.mountedSlotsFingerprint),
+      ]);
+    case "layout":
+      return encodeParts([
+        output.kind,
+        output.routeId,
+        output.layoutId,
+        encodeNullable(output.rootBoundaryId),
+      ]);
+    case "page":
+      return encodeParts([
+        output.kind,
+        output.routeId,
+        output.pageId,
+        encodeNullable(output.rootBoundaryId),
+      ]);
+    case "route-handler":
+      return encodeParts([output.kind, output.routeId, output.routeHandlerId]);
+    case "slot":
+      return encodeParts([
+        output.kind,
+        output.routeId,
+        output.slotId,
+        encodeNullable(output.rootBoundaryId),
+      ]);
+    case "template":
+      return encodeParts([
+        output.kind,
+        output.routeId,
+        output.templateId,
+        encodeNullable(output.rootBoundaryId),
+      ]);
+    default:
+      return assertNever(output);
+  }
+}
+
+function validateBudgetNumber(name: string, value: number): CacheProofBreakerFallback | null {
+  if (Number.isInteger(value) && value >= 0) return null;
+  return buildBreakerFallback("CP_ROUTE_VARIANT_CEILING_EXCEEDED", {
+    budgetField: name,
+  });
+}
+
+function validateBudget(budget: CacheVariantBudget): CacheProofBreakerFallback | null {
+  return (
+    validateBudgetNumber("maxDimensionCount", budget.maxDimensionCount) ??
+    validateBudgetNumber("maxDimensionNameLength", budget.maxDimensionNameLength) ??
+    validateBudgetNumber("maxDimensionValueLength", budget.maxDimensionValueLength) ??
+    validateBudgetNumber("maxEncodedLength", budget.maxEncodedLength) ??
+    validateBudgetNumber("maxValuesPerDimension", budget.maxValuesPerDimension) ??
+    validateBudgetNumber("maxVariantsPerRoute", budget.maxVariantsPerRoute)
+  );
+}
+
+function buildDimension(
+  input: CacheVariantDimensionInput,
+  budget: CacheVariantBudget,
+): CacheVariantDimension | CacheProofBreakerFallback {
+  const name = normalizeDimensionName(input.name);
+  if (name.length === 0) {
+    return buildBreakerFallback("CP_DIMENSION_NAME_MISSING", {
+      source: input.source,
+    });
+  }
+  if (name.length > budget.maxDimensionNameLength) {
+    return buildBreakerFallback("CP_DIMENSION_NAME_TOO_LONG", {
+      maxLength: budget.maxDimensionNameLength,
+      nameHash: redactValue(name),
+      source: input.source,
+    });
+  }
+  if (input.privacy === "public" && PUBLIC_UNSAFE_DIMENSION_SOURCES.has(input.source)) {
+    return buildBreakerFallback(
+      "CP_UNSAFE_PUBLIC_DIMENSION",
+      {
+        name,
+        source: input.source,
+      },
+      "privateUncacheable",
+    );
+  }
+
+  const values = sortedUnique(input.values);
+  if (values.length === 0) {
+    return buildBreakerFallback("CP_DIMENSION_VALUES_MISSING", {
+      name,
+      source: input.source,
+    });
+  }
+  if (values.length > budget.maxValuesPerDimension) {
+    return buildBreakerFallback("CP_DIMENSION_VALUE_COUNT_EXCEEDED", {
+      maxValues: budget.maxValuesPerDimension,
+      name,
+      source: input.source,
+      valueCount: values.length,
+    });
+  }
+  for (const value of values) {
+    if (value.length > budget.maxDimensionValueLength) {
+      return buildBreakerFallback("CP_DIMENSION_VALUE_TOO_LONG", {
+        maxLength: budget.maxDimensionValueLength,
+        name,
+        source: input.source,
+        valueHash: redactValue(value),
+      });
+    }
+  }
+
+  const valueHashes = values.map(redactValue);
+  const encoded = encodeParts([input.source, input.privacy, name, valueHashes]);
+
+  return {
+    encoded,
+    name,
+    privacy: input.privacy,
+    source: input.source,
+    valueCount: valueHashes.length,
+    valueHashes,
+  };
+}
+
+function isCacheProofBreakerFallback(
+  value: CacheVariantDimension | CacheProofBreakerFallback,
+): value is CacheProofBreakerFallback {
+  return "kind" in value;
+}
+
+function getDimensionBucket(
+  bySource: DimensionAccumulatorBySource,
+  source: CacheVariantDimensionSource,
+  privacy: CacheVariantDimensionPrivacy,
+): DimensionAccumulatorByName {
+  const existingByPrivacy = bySource.get(source);
+  const byPrivacy = existingByPrivacy ?? new Map();
+  if (!existingByPrivacy) {
+    bySource.set(source, byPrivacy);
+  }
+
+  const existingByName = byPrivacy.get(privacy);
+  const byName = existingByName ?? new Map();
+  if (!existingByName) {
+    byPrivacy.set(privacy, byName);
+  }
+
+  return byName;
+}
+
+function mergeDimensionInputs(
+  dimensions: readonly CacheVariantDimensionInput[],
+): CacheVariantDimensionInput[] {
+  const bySource: DimensionAccumulatorBySource = new Map();
+  const orderedDimensions: CacheVariantDimensionAccumulator[] = [];
+
+  for (const dimension of dimensions) {
+    const name = normalizeDimensionName(dimension.name);
+    const bucket = getDimensionBucket(bySource, dimension.source, dimension.privacy);
+    const existing = bucket.get(name);
+    if (existing) {
+      existing.values.push(...dimension.values);
+      continue;
+    }
+    const accumulator = {
+      name,
+      privacy: dimension.privacy,
+      source: dimension.source,
+      values: [...dimension.values],
+    };
+    bucket.set(name, accumulator);
+    orderedDimensions.push(accumulator);
+  }
+
+  return orderedDimensions;
+}
+
+export function createAppRouteCacheProofGraphScope(
+  route: AppRouteCacheProofGraphScopeInput,
+): AppRouteCacheProofGraphScope {
+  return {
+    routeId: route.ids.route,
+    pageId: route.ids.page,
+    routeHandlerId: route.ids.routeHandler,
+    layoutIds: [...route.ids.layouts],
+    templateIds: [...route.ids.templates],
+    slotIds: sortedUnique(Object.values(route.ids.slots)),
+  };
+}
+
+export function buildCacheVariant(input: BuildCacheVariantInput): BuildCacheVariantResult {
+  const budgetFallback = validateBudget(input.budget);
+  if (budgetFallback) {
+    return {
+      kind: "breakerFallback",
+      fallback: budgetFallback,
+    };
+  }
+  if (input.existingVariantCount >= input.budget.maxVariantsPerRoute) {
+    return {
+      kind: "breakerFallback",
+      fallback: buildBreakerFallback(
+        "CP_ROUTE_VARIANT_CEILING_EXCEEDED",
+        {
+          existingVariantCount: input.existingVariantCount,
+          maxVariantsPerRoute: input.budget.maxVariantsPerRoute,
+          routeId: input.output.routeId,
+        },
+        "privateUncacheable",
+        "route",
+      ),
+    };
+  }
+  const dimensionInputs = mergeDimensionInputs(input.dimensions);
+  if (dimensionInputs.length > input.budget.maxDimensionCount) {
+    return {
+      kind: "breakerFallback",
+      fallback: buildBreakerFallback("CP_DIMENSION_COUNT_EXCEEDED", {
+        dimensionCount: dimensionInputs.length,
+        maxDimensionCount: input.budget.maxDimensionCount,
+        routeId: input.output.routeId,
+      }),
+    };
+  }
+
+  const dimensions: CacheVariantDimension[] = [];
+  for (const dimensionInput of dimensionInputs) {
+    const dimension = buildDimension(dimensionInput, input.budget);
+    if (isCacheProofBreakerFallback(dimension)) {
+      return {
+        kind: "breakerFallback",
+        fallback: dimension,
+      };
+    }
+    dimensions.push(dimension);
+  }
+  dimensions.sort(compareDimensions);
+
+  const encoded = [
+    `schema:${CACHE_PROOF_MODEL_SCHEMA_VERSION}`,
+    encodeOutputScope(input.output),
+    ...dimensions.map((dimension) => dimension.encoded),
+  ].join("|");
+
+  if (encoded.length > input.budget.maxEncodedLength) {
+    return {
+      kind: "breakerFallback",
+      fallback: buildBreakerFallback("CP_ENCODED_VARIANT_TOO_LONG", {
+        encodedHash: redactValue(encoded),
+        encodedLength: encoded.length,
+        maxEncodedLength: input.budget.maxEncodedLength,
+        routeId: input.output.routeId,
+      }),
+    };
+  }
+
+  return {
+    kind: "variant",
+    variant: {
+      schemaVersion: CACHE_PROOF_MODEL_SCHEMA_VERSION,
+      cacheKey: `cp0:${fnv1a64(encoded)}`,
+      output: input.output,
+      dimensions,
+      encodedLength: encoded.length,
+      budget: { ...input.budget },
+    },
+  };
+}
+
+function boundaryOutcomesMatch(expected: BoundaryOutcome, candidate: BoundaryOutcome): boolean {
+  switch (expected.kind) {
+    case "error":
+      return candidate.kind === "error" && (expected.digest ?? "") === (candidate.digest ?? "");
+    case "forbidden":
+      return candidate.kind === "forbidden";
+    case "globalError":
+      return (
+        candidate.kind === "globalError" && (expected.digest ?? "") === (candidate.digest ?? "")
+      );
+    case "notFound":
+      return candidate.kind === "notFound";
+    case "redirect":
+      return (
+        candidate.kind === "redirect" &&
+        expected.status === candidate.status &&
+        expected.location === candidate.location
+      );
+    case "success":
+      return candidate.kind === "success";
+    case "unauthorized":
+      return candidate.kind === "unauthorized";
+    case "unknown":
+      return candidate.kind === "unknown";
+    default:
+      return assertNever(expected);
+  }
+}
+
+export function buildBoundaryOutcomeCompatibility(input: {
+  candidate: BoundaryOutcome;
+  expected: BoundaryOutcome;
+}): BoundaryOutcomeCompatibility {
+  if (input.expected.kind === "unknown" || input.candidate.kind === "unknown") {
+    return {
+      kind: "incompatible",
+      expected: input.expected,
+      candidate: input.candidate,
+      fallback: buildBreakerFallback("CP_BOUNDARY_OUTCOME_UNKNOWN", {
+        candidateKind: input.candidate.kind,
+        expectedKind: input.expected.kind,
+      }),
+    };
+  }
+
+  if (boundaryOutcomesMatch(input.expected, input.candidate)) {
+    return {
+      kind: "compatible",
+      outcome: input.candidate,
+      reason: "CP_BOUNDARY_OUTCOME_MATCH",
+    };
+  }
+
+  return {
+    kind: "incompatible",
+    expected: input.expected,
+    candidate: input.candidate,
+    fallback: buildBreakerFallback("CP_BOUNDARY_OUTCOME_MISMATCH", {
+      candidateKind: input.candidate.kind,
+      expectedKind: input.expected.kind,
+    }),
+  };
+}
+
+function requestApiStatusRank(status: RenderRequestApiStatus): number {
+  switch (status) {
+    case "notObserved":
+      return 0;
+    case "unknown":
+      return 1;
+    case "observed":
+      return 2;
+    default:
+      return assertNever(status);
+  }
+}
+
+function normalizeRequestApiObservations(
+  observations: readonly RenderRequestApiObservation[],
+): RenderRequestApiObservation[] {
+  const byKind = new Map<RenderRequestApiKind, RenderRequestApiStatus>();
+  for (const observation of observations) {
+    const current = byKind.get(observation.kind);
+    if (
+      current === undefined ||
+      requestApiStatusRank(observation.status) > requestApiStatusRank(current)
+    ) {
+      byKind.set(observation.kind, observation.status);
+    }
+  }
+
+  return [...byKind.entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([kind, status]) => ({ kind, status }));
+}
+
+export function buildRenderObservation(input: BuildRenderObservationInput): RenderObservation {
+  return {
+    schemaVersion: CACHE_PROOF_MODEL_SCHEMA_VERSION,
+    output: input.output,
+    completeness: input.completeness,
+    boundaryOutcome: input.boundaryOutcome,
+    requestApis: normalizeRequestApiObservations(input.requestApis),
+    dynamicFetches: sortedUniqueRedacted(input.dynamicFetches),
+    cacheTags: sortedUnique(input.cacheTags),
+    pathTags: sortedUnique(input.pathTags),
+    cacheability: input.cacheability,
+  };
+}
+
+export function hasCompleteNegativeRequestApiProof(
+  observation: RenderObservation,
+  requiredApis: readonly RenderRequestApiKind[],
+): boolean {
+  if (observation.completeness !== "complete") return false;
+
+  const statuses = new Map<RenderRequestApiKind, RenderRequestApiStatus>();
+  for (const requestApi of observation.requestApis) {
+    statuses.set(requestApi.kind, requestApi.status);
+  }
+
+  for (const api of requiredApis) {
+    if (statuses.get(api) !== "notObserved") return false;
+  }
+  return true;
+}
+
+export function createDisabledCacheProofDecision(
+  input: CreateDisabledCacheProofDecisionInput,
+): DisabledCacheProofDecision {
+  return {
+    kind: "disabled",
+    canReuse: false,
+    variant: input.variant,
+    observation: input.observation,
+    fallback: buildBreakerFallback("CP_MODEL_DISABLED"),
+  };
+}

--- a/packages/vinext/src/server/cache-proof.ts
+++ b/packages/vinext/src/server/cache-proof.ts
@@ -13,6 +13,7 @@ export type CacheProofRejectionCode =
   | "CP_DIMENSION_VALUE_TOO_LONG"
   | "CP_DIMENSION_VALUES_MISSING"
   | "CP_ENCODED_VARIANT_TOO_LONG"
+  | "CP_INVALID_VARIANT_BUDGET"
   | "CP_ROUTE_VARIANT_CEILING_EXCEEDED"
   | "CP_UNSAFE_PUBLIC_DIMENSION"
   | "CP_BOUNDARY_OUTCOME_MISMATCH"
@@ -358,7 +359,7 @@ function encodeOutputScope(output: CacheProofOutputScope): string {
 
 function validateBudgetNumber(name: string, value: number): CacheProofBreakerFallback | null {
   if (Number.isInteger(value) && value >= 0) return null;
-  return buildBreakerFallback("CP_ROUTE_VARIANT_CEILING_EXCEEDED", {
+  return buildBreakerFallback("CP_INVALID_VARIANT_BUDGET", {
     budgetField: name,
   });
 }

--- a/tests/cache-proof.test.ts
+++ b/tests/cache-proof.test.ts
@@ -127,6 +127,39 @@ describe("disabled cache proof model", () => {
     expect(serializedVariant).not.toContain("asc");
   });
 
+  it("keeps null and empty-string output scope dimensions distinct", () => {
+    const absentEpoch = buildCacheVariant({
+      budget: DEFAULT_CACHE_VARIANT_BUDGET,
+      dimensions: [],
+      existingVariantCount: 0,
+      output: {
+        kind: "app-html",
+        renderEpoch: null,
+        rootBoundaryId: null,
+        routeId: "route:/",
+      },
+    });
+    const emptyEpoch = buildCacheVariant({
+      budget: DEFAULT_CACHE_VARIANT_BUDGET,
+      dimensions: [],
+      existingVariantCount: 0,
+      output: {
+        kind: "app-html",
+        renderEpoch: "",
+        rootBoundaryId: "",
+        routeId: "route:/",
+      },
+    });
+
+    expect(absentEpoch.kind).toBe("variant");
+    expect(emptyEpoch.kind).toBe("variant");
+    if (absentEpoch.kind !== "variant" || emptyEpoch.kind !== "variant") {
+      throw new Error("Expected both output scopes to produce cache variants");
+    }
+
+    expect(absentEpoch.variant.cacheKey).not.toBe(emptyEpoch.variant.cacheKey);
+  });
+
   it("returns breaker fallbacks for unsafe or over-budget variants", () => {
     const unsafePublicCookie = buildCacheVariant({
       budget: DEFAULT_CACHE_VARIANT_BUDGET,
@@ -254,10 +287,15 @@ describe("disabled cache proof model", () => {
         { kind: "cookies", status: "notObserved" },
       ],
     });
+    const missingApiKind = buildRenderObservation({
+      ...complete,
+      requestApis: [{ kind: "cookies", status: "notObserved" }],
+    });
 
     expect(hasCompleteNegativeRequestApiProof(complete, ["headers", "cookies"])).toBe(true);
     expect(hasCompleteNegativeRequestApiProof(partial, ["headers", "cookies"])).toBe(false);
     expect(hasCompleteNegativeRequestApiProof(observed, ["headers", "cookies"])).toBe(false);
+    expect(hasCompleteNegativeRequestApiProof(missingApiKind, ["headers", "cookies"])).toBe(false);
     expect(complete.cacheTags).toEqual(["posts"]);
     expect(JSON.stringify(complete.dynamicFetches)).not.toContain("secret");
   });

--- a/tests/cache-proof.test.ts
+++ b/tests/cache-proof.test.ts
@@ -199,6 +199,29 @@ describe("disabled cache proof model", () => {
       }),
       "CP_ROUTE_VARIANT_CEILING_EXCEEDED",
     );
+
+    const invalidBudget = buildCacheVariant({
+      budget: {
+        ...DEFAULT_CACHE_VARIANT_BUDGET,
+        maxEncodedLength: -1,
+      },
+      dimensions: [],
+      existingVariantCount: 0,
+      output: {
+        kind: "layout",
+        layoutId: "layout:/[tenant]",
+        rootBoundaryId: "layout:/",
+        routeId: "route:/:tenant",
+      },
+    });
+    expect(invalidBudget.kind).toBe("breakerFallback");
+    if (invalidBudget.kind !== "breakerFallback") {
+      throw new Error("Expected invalid cache variant budget to return a breaker fallback");
+    }
+    expect(invalidBudget.fallback).toMatchObject({
+      code: "CP_INVALID_VARIANT_BUDGET",
+      fields: { budgetField: "maxEncodedLength" },
+    });
   });
 
   it("requires complete negative request-api observations before absence is proof", () => {

--- a/tests/cache-proof.test.ts
+++ b/tests/cache-proof.test.ts
@@ -1,0 +1,311 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  buildBoundaryOutcomeCompatibility,
+  buildCacheVariant,
+  buildRenderObservation,
+  createAppRouteCacheProofGraphScope,
+  createDisabledCacheProofDecision,
+  DEFAULT_CACHE_VARIANT_BUDGET,
+  hasCompleteNegativeRequestApiProof,
+  type AppRouteCacheProofGraphScopeInput,
+  type CacheProofBreakerFallback,
+} from "../packages/vinext/src/server/cache-proof.js";
+
+function expectBreakerReason(
+  result: ReturnType<typeof buildCacheVariant>,
+  code: CacheProofBreakerFallback["code"],
+): CacheProofBreakerFallback {
+  expect(result.kind).toBe("breakerFallback");
+  if (result.kind !== "breakerFallback") {
+    throw new Error("Expected cache variant construction to return a breaker fallback");
+  }
+  expect(result.fallback.code).toBe(code);
+  return result.fallback;
+}
+
+describe("disabled cache proof model", () => {
+  it("normalizes route graph semantic ids for cache proof scopes", () => {
+    const route = {
+      ids: {
+        route: "route:/shop/:id",
+        page: "page:/shop/:id",
+        routeHandler: null,
+        layouts: ["layout:/", "layout:/shop/[id]"],
+        templates: [],
+        slots: {
+          "zebra@shop/[id]/@zebra": "slot:zebra:/shop/[id]",
+          "modal@shop/[id]/@modal": "slot:modal:/shop/[id]",
+          "modal-copy@shop/[id]/@modal": "slot:modal:/shop/[id]",
+        },
+      },
+    } satisfies AppRouteCacheProofGraphScopeInput;
+
+    const scope = createAppRouteCacheProofGraphScope(route);
+
+    expect(scope).toEqual({
+      routeId: "route:/shop/:id",
+      pageId: "page:/shop/:id",
+      routeHandlerId: null,
+      layoutIds: ["layout:/", "layout:/shop/[id]"],
+      templateIds: [],
+      slotIds: ["slot:modal:/shop/[id]", "slot:zebra:/shop/[id]"],
+    });
+  });
+
+  it("canonicalizes dimensions while keeping cache keys and traces redacted", () => {
+    const first = buildCacheVariant({
+      budget: DEFAULT_CACHE_VARIANT_BUDGET,
+      dimensions: [
+        {
+          name: "sort",
+          privacy: "public",
+          source: "search",
+          values: ["desc"],
+        },
+        {
+          name: "SORT",
+          privacy: "public",
+          source: "search",
+          values: ["asc", "asc"],
+        },
+        {
+          name: "id",
+          privacy: "public",
+          source: "params",
+          values: ["super-secret-token"],
+        },
+      ],
+      existingVariantCount: 0,
+      output: {
+        kind: "app-rsc",
+        mountedSlotsFingerprint: "slots:main",
+        renderEpoch: null,
+        rootBoundaryId: "layout:/",
+        routeId: "route:/shop/:id",
+      },
+    });
+    const second = buildCacheVariant({
+      budget: DEFAULT_CACHE_VARIANT_BUDGET,
+      dimensions: [
+        {
+          name: "id",
+          privacy: "public",
+          source: "params",
+          values: ["super-secret-token"],
+        },
+        {
+          name: "sort",
+          privacy: "public",
+          source: "search",
+          values: ["asc", "desc"],
+        },
+      ],
+      existingVariantCount: 0,
+      output: {
+        kind: "app-rsc",
+        mountedSlotsFingerprint: "slots:main",
+        renderEpoch: null,
+        rootBoundaryId: "layout:/",
+        routeId: "route:/shop/:id",
+      },
+    });
+
+    expect(first.kind).toBe("variant");
+    expect(second.kind).toBe("variant");
+    if (first.kind !== "variant" || second.kind !== "variant") {
+      throw new Error("Expected both inputs to produce cache variants");
+    }
+
+    expect(first.variant.cacheKey).toBe(second.variant.cacheKey);
+    expect(first.variant.dimensions.map((dimension) => dimension.name)).toEqual(["id", "sort"]);
+    expect(first.variant.dimensions[0].valueHashes).toHaveLength(1);
+    expect(first.variant.dimensions[1].valueHashes).toHaveLength(2);
+
+    const serializedVariant = JSON.stringify(first.variant);
+    expect(serializedVariant).not.toContain("super-secret-token");
+    expect(serializedVariant).not.toContain("desc");
+    expect(serializedVariant).not.toContain("asc");
+  });
+
+  it("returns breaker fallbacks for unsafe or over-budget variants", () => {
+    const unsafePublicCookie = buildCacheVariant({
+      budget: DEFAULT_CACHE_VARIANT_BUDGET,
+      dimensions: [
+        {
+          name: "session",
+          privacy: "public",
+          source: "cookie",
+          values: ["abc"],
+        },
+      ],
+      existingVariantCount: 0,
+      output: {
+        kind: "layout",
+        layoutId: "layout:/account",
+        rootBoundaryId: "layout:/",
+        routeId: "route:/account",
+      },
+    });
+
+    const fallback = expectBreakerReason(unsafePublicCookie, "CP_UNSAFE_PUBLIC_DIMENSION");
+    expect(JSON.stringify(fallback.fields)).not.toContain("abc");
+
+    expectBreakerReason(
+      buildCacheVariant({
+        budget: {
+          ...DEFAULT_CACHE_VARIANT_BUDGET,
+          maxDimensionValueLength: 4,
+        },
+        dimensions: [
+          {
+            name: "tenant",
+            privacy: "public",
+            source: "params",
+            values: ["customer-a"],
+          },
+        ],
+        existingVariantCount: 0,
+        output: {
+          kind: "layout",
+          layoutId: "layout:/[tenant]",
+          rootBoundaryId: "layout:/",
+          routeId: "route:/:tenant",
+        },
+      }),
+      "CP_DIMENSION_VALUE_TOO_LONG",
+    );
+
+    expectBreakerReason(
+      buildCacheVariant({
+        budget: {
+          ...DEFAULT_CACHE_VARIANT_BUDGET,
+          maxVariantsPerRoute: 2,
+        },
+        dimensions: [
+          {
+            name: "tenant",
+            privacy: "public",
+            source: "params",
+            values: ["a"],
+          },
+        ],
+        existingVariantCount: 2,
+        output: {
+          kind: "layout",
+          layoutId: "layout:/[tenant]",
+          rootBoundaryId: "layout:/",
+          routeId: "route:/:tenant",
+        },
+      }),
+      "CP_ROUTE_VARIANT_CEILING_EXCEEDED",
+    );
+  });
+
+  it("requires complete negative request-api observations before absence is proof", () => {
+    const complete = buildRenderObservation({
+      boundaryOutcome: { kind: "success" },
+      cacheability: "public",
+      cacheTags: ["posts", "posts"],
+      completeness: "complete",
+      dynamicFetches: ["https://api.example.test/posts?token=secret"],
+      output: {
+        kind: "layout",
+        layoutId: "layout:/blog",
+        rootBoundaryId: "layout:/",
+        routeId: "route:/blog",
+      },
+      pathTags: ["/blog"],
+      requestApis: [
+        { kind: "headers", status: "notObserved" },
+        { kind: "cookies", status: "notObserved" },
+      ],
+    });
+    const partial = buildRenderObservation({
+      ...complete,
+      completeness: "partial",
+    });
+    const observed = buildRenderObservation({
+      ...complete,
+      requestApis: [
+        { kind: "headers", status: "observed" },
+        { kind: "cookies", status: "notObserved" },
+      ],
+    });
+
+    expect(hasCompleteNegativeRequestApiProof(complete, ["headers", "cookies"])).toBe(true);
+    expect(hasCompleteNegativeRequestApiProof(partial, ["headers", "cookies"])).toBe(false);
+    expect(hasCompleteNegativeRequestApiProof(observed, ["headers", "cookies"])).toBe(false);
+    expect(complete.cacheTags).toEqual(["posts"]);
+    expect(JSON.stringify(complete.dynamicFetches)).not.toContain("secret");
+  });
+
+  it("treats boundary outcome compatibility as exact-match only", () => {
+    expect(
+      buildBoundaryOutcomeCompatibility({
+        candidate: { kind: "success" },
+        expected: { kind: "success" },
+      }).kind,
+    ).toBe("compatible");
+
+    const mismatch = buildBoundaryOutcomeCompatibility({
+      candidate: { kind: "notFound" },
+      expected: { kind: "success" },
+    });
+    expect(mismatch.kind).toBe("incompatible");
+    if (mismatch.kind === "incompatible") {
+      expect(mismatch.fallback.code).toBe("CP_BOUNDARY_OUTCOME_MISMATCH");
+    }
+
+    const unknown = buildBoundaryOutcomeCompatibility({
+      candidate: { kind: "unknown" },
+      expected: { kind: "success" },
+    });
+    expect(unknown.kind).toBe("incompatible");
+    if (unknown.kind === "incompatible") {
+      expect(unknown.fallback.code).toBe("CP_BOUNDARY_OUTCOME_UNKNOWN");
+    }
+  });
+
+  it("never authorizes runtime reuse while the proof model is disabled", () => {
+    const variant = buildCacheVariant({
+      budget: DEFAULT_CACHE_VARIANT_BUDGET,
+      dimensions: [],
+      existingVariantCount: 0,
+      output: {
+        kind: "app-html",
+        renderEpoch: null,
+        rootBoundaryId: "layout:/",
+        routeId: "route:/",
+      },
+    });
+
+    expect(variant.kind).toBe("variant");
+    if (variant.kind !== "variant") {
+      throw new Error("Expected cache variant construction to succeed");
+    }
+
+    const decision = createDisabledCacheProofDecision({
+      variant: variant.variant,
+      observation: buildRenderObservation({
+        boundaryOutcome: { kind: "success" },
+        cacheability: "public",
+        cacheTags: [],
+        completeness: "complete",
+        dynamicFetches: [],
+        output: variant.variant.output,
+        pathTags: [],
+        requestApis: [],
+      }),
+    });
+
+    expect(decision).toMatchObject({
+      canReuse: false,
+      kind: "disabled",
+      fallback: {
+        code: "CP_MODEL_DISABLED",
+        mode: "renderFresh",
+        scope: "affectedOutput",
+      },
+    });
+  });
+});


### PR DESCRIPTION
## What this changes
Implements #726-CACHE-01/04 from #726 by adding an intentionally disabled cache proof model for future route graph driven cache work.

The new model defines RenderObservation v0, CacheVariant v0, BoundaryOutcomeCompatibility v0, CacheVariantBudget, breaker fallback decisions, canonical redacted dimension representation, and a disabled decision that always returns canReuse false.

## Why
Issue #726 calls out the core invariant: no proof, no reuse, no skip, no visible commit. Runtime cache hits are not semantic proof, so this PR creates the proof vocabulary and breaker shape before any observation recording or runtime cache reuse is enabled.

## Approach
- Add packages/vinext/src/server/cache-proof.ts as a pure functional model with no runtime cache path imports.
- Tie cache proof route scope input to AppRouteSemanticIds so future cache facts stay anchored in the route graph boundary.
- Canonicalize dimensions by source/privacy/name, hash values before persistence or trace output, enforce dimension and variant budgets, and emit breaker fallbacks on uncertainty or unsafe public dimensions.
- Model boundary outcome compatibility as exact match only, with unknown outcomes falling back to fresh render.
- Register the disabled model as a Knip entry because this slice deliberately exports the v0 contract before later #726 slices wire runtime consumers.

Non-goals for this PR:
- no real render observation recording
- no cache hit enablement
- no public/private cacheability enforcement

Bonk: please read issue #726 to see the big picture before reviewing the cache proof boundary.

## Validation
- vp check --fix packages/vinext/src/server/cache-proof.ts tests/cache-proof.test.ts
- vp check --fix knip.ts packages/vinext/src/server/cache-proof.ts tests/cache-proof.test.ts
- vp run knip --no-progress
- vp test run tests/cache-proof.test.ts
- vp test run tests/cache-proof.test.ts tests/app-route-graph.test.ts tests/app-page-cache.test.ts tests/app-route-handler-cache.test.ts tests/isr-cache.test.ts
- vp run vinext#build

Full vp check note: formatting passed, but the existing repository check still reports unrelated issues in packages/vinext/src/server/request-pipeline.ts and benchmarks/vinext/vite.config.ts. The touched files pass targeted check, and Knip passes after registering this disabled boundary.

## Risks / follow-ups
This is intentionally authority-free scaffolding. Later #726 cache slices still need to record real observations, classify private/dynamic downgrade behavior, and keep cache hit authority behind proof checks rather than runtime cache presence.