### PR TITLE
feat(prerender): log server startup

### DIFF
--- a/packages/vinext/src/build/prerender.ts
+++ b/packages/vinext/src/build/prerender.ts
@@ -413,6 +413,7 @@ export async function prerenderPages({
             // either _prodServer or pagesBundlePath is provided.
             outDir: path.dirname(path.dirname(pagesBundlePath!)),
             noCompression: true,
+            purpose: "prerender",
           });
           ownedProdServerHandle = srv;
           return srv;
@@ -746,6 +747,7 @@ export async function prerenderApp({
             host: "127.0.0.1",
             outDir: path.dirname(serverDir),
             noCompression: true,
+            purpose: "prerender",
           });
           ownedProdServerHandle = srv;
           return srv;

--- a/packages/vinext/src/build/run-prerender.ts
+++ b/packages/vinext/src/build/run-prerender.ts
@@ -192,6 +192,7 @@ export async function runPrerender(options: RunPrerenderOptions): Promise<Preren
         host: "127.0.0.1",
         outDir: path.dirname(serverDir),
         noCompression: true,
+        purpose: "prerender",
       });
 
       // Read the prerender secret from vinext-server.json so it can be passed

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -80,6 +80,12 @@ export type ProdServerOptions = {
   outDir?: string;
   /** Disable compression (default: false) */
   noCompression?: boolean;
+  /**
+   * Narrow startup context for callers that need a more precise log line.
+   * Omitted for normal `vinext start` so the existing production-server output
+   * remains stable.
+   */
+  purpose?: "prerender";
 };
 
 /** Content types that benefit from compression. */
@@ -255,6 +261,16 @@ type ResponseWithVinextStreamingMetadata = Response & {
 
 function isVinextStreamedHtmlResponse(response: Response): boolean {
   return (response as ResponseWithVinextStreamingMetadata).__vinextStreamedHtmlResponse === true;
+}
+
+function logProdServerStarted(host: string, port: number, purpose: ProdServerOptions["purpose"]) {
+  const url = `http://${host}:${port}`;
+  if (purpose === "prerender") {
+    console.log(`[vinext] Production server for prerendering running at ${url}`);
+    return;
+  }
+
+  console.log(`[vinext] Production server running at ${url}`);
 }
 
 /**
@@ -833,6 +849,7 @@ export async function startProdServer(options: ProdServerOptions = {}) {
     host = "0.0.0.0",
     outDir = path.resolve("dist"),
     noCompression = false,
+    purpose,
   } = options;
 
   const compress = !noCompression;
@@ -852,10 +869,10 @@ export async function startProdServer(options: ProdServerOptions = {}) {
   }
 
   if (isAppRouter) {
-    return startAppRouterServer({ port, host, clientDir, rscEntryPath, compress });
+    return startAppRouterServer({ port, host, clientDir, rscEntryPath, compress, purpose });
   }
 
-  return startPagesRouterServer({ port, host, clientDir, serverEntryPath, compress });
+  return startPagesRouterServer({ port, host, clientDir, serverEntryPath, compress, purpose });
 }
 
 // ─── App Router Production Server ─────────────────────────────────────────────
@@ -866,6 +883,7 @@ type AppRouterServerOptions = {
   clientDir: string;
   rscEntryPath: string;
   compress: boolean;
+  purpose?: ProdServerOptions["purpose"];
 };
 
 type WorkerAppRouterEntry = {
@@ -921,7 +939,7 @@ function resolveAppRouterHandler(entry: unknown): (request: Request) => Promise<
  * 4. Stream the Web Response back (with optional compression)
  */
 async function startAppRouterServer(options: AppRouterServerOptions) {
-  const { port, host, clientDir, rscEntryPath, compress } = options;
+  const { port, host, clientDir, rscEntryPath, compress, purpose } = options;
 
   // Load image config written at build time by vinext:image-config plugin.
   // This provides SVG/security header settings for the image optimization endpoint.
@@ -1128,7 +1146,7 @@ async function startAppRouterServer(options: AppRouterServerOptions) {
     server.listen(port, host, () => {
       const addr = server.address();
       const actualPort = typeof addr === "object" && addr ? addr.port : port;
-      console.log(`[vinext] Production server running at http://${host}:${actualPort}`);
+      logProdServerStarted(host, actualPort, purpose);
       resolve();
     });
   });
@@ -1146,6 +1164,7 @@ type PagesRouterServerOptions = {
   clientDir: string;
   serverEntryPath: string;
   compress: boolean;
+  purpose?: ProdServerOptions["purpose"];
 };
 
 /**
@@ -1158,7 +1177,7 @@ type PagesRouterServerOptions = {
  * - vinextConfig — embedded next.config.js settings
  */
 async function startPagesRouterServer(options: PagesRouterServerOptions) {
-  const { port, host, clientDir, serverEntryPath, compress } = options;
+  const { port, host, clientDir, serverEntryPath, compress, purpose } = options;
 
   // Import the server entry module (use file:// URL for reliable dynamic import).
   // Cache-bust with mtime so that rebuilds to the same output path always load
@@ -1727,7 +1746,7 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
     server.listen(port, host, () => {
       const addr = server.address();
       const actualPort = typeof addr === "object" && addr ? addr.port : port;
-      console.log(`[vinext] Production server running at http://${host}:${actualPort}`);
+      logProdServerStarted(host, actualPort, purpose);
       resolve();
     });
   });

--- a/tests/prod-server-logs.test.ts
+++ b/tests/prod-server-logs.test.ts
@@ -1,0 +1,127 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+
+function createPagesBuild(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-prod-server-logs-"));
+  const distDir = path.join(root, "dist");
+  const clientDir = path.join(distDir, "client");
+  const serverDir = path.join(distDir, "server");
+
+  fs.mkdirSync(clientDir, { recursive: true });
+  fs.mkdirSync(serverDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(serverDir, "entry.js"),
+    [
+      "export const vinextConfig = {};",
+      "export async function renderPage() { return new Response('ok', { headers: { 'content-type': 'text/html' } }); }",
+      "export async function handleApiRoute() { return new Response('api'); }",
+      "export async function runMiddleware() { return null; }",
+      "",
+    ].join("\n"),
+  );
+
+  return root;
+}
+
+function createAppBuild(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-prod-server-app-logs-"));
+  const distDir = path.join(root, "dist");
+  const clientDir = path.join(distDir, "client");
+  const serverDir = path.join(distDir, "server");
+
+  fs.mkdirSync(clientDir, { recursive: true });
+  fs.mkdirSync(serverDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(serverDir, "index.js"),
+    [
+      "export default async function handler() {",
+      "  return new Response('ok', { headers: { 'content-type': 'text/html' } });",
+      "}",
+      "",
+    ].join("\n"),
+  );
+
+  return root;
+}
+
+describe("startProdServer logging", () => {
+  const roots: string[] = [];
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    for (const root of roots.splice(0)) {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps the generic production server log by default", async () => {
+    const root = createPagesBuild();
+    roots.push(root);
+    const messages: string[] = [];
+    vi.spyOn(console, "log").mockImplementation((message: string) => {
+      messages.push(message);
+    });
+
+    const { startProdServer } = await import("../packages/vinext/src/server/prod-server.js");
+    const { server, port } = await startProdServer({
+      port: 0,
+      host: "127.0.0.1",
+      outDir: path.join(root, "dist"),
+      noCompression: true,
+    });
+
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+
+    expect(messages).toEqual([`[vinext] Production server running at http://127.0.0.1:${port}`]);
+  });
+
+  it("logs a prerender-specific production server URL when requested", async () => {
+    const root = createPagesBuild();
+    roots.push(root);
+    const messages: string[] = [];
+    vi.spyOn(console, "log").mockImplementation((message: string) => {
+      messages.push(message);
+    });
+
+    const { startProdServer } = await import("../packages/vinext/src/server/prod-server.js");
+    const { server, port } = await startProdServer({
+      port: 0,
+      host: "127.0.0.1",
+      outDir: path.join(root, "dist"),
+      noCompression: true,
+      purpose: "prerender",
+    });
+
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+
+    expect(messages).toEqual([
+      `[vinext] Production server for prerendering running at http://127.0.0.1:${port}`,
+    ]);
+  });
+
+  it("uses the prerender-specific startup log for App Router production servers", async () => {
+    const root = createAppBuild();
+    roots.push(root);
+    const messages: string[] = [];
+    vi.spyOn(console, "log").mockImplementation((message: string) => {
+      messages.push(message);
+    });
+
+    const { startProdServer } = await import("../packages/vinext/src/server/prod-server.js");
+    const { server, port } = await startProdServer({
+      port: 0,
+      host: "127.0.0.1",
+      outDir: path.join(root, "dist"),
+      noCompression: true,
+      purpose: "prerender",
+    });
+
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+
+    expect(messages).toEqual([
+      `[vinext] Production server for prerendering running at http://127.0.0.1:${port}`,
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- Add a prerender-specific production server startup log that includes the actual local URL/port.
- Keep the default production server startup log unchanged for normal `vinext start`.
- Thread the narrow `purpose: "prerender"` option through app-only, pages-only, and hybrid/shared prerender server startup paths.
- Add focused coverage for Pages Router, App Router, and default production server startup logs.

Part of #563.

## Validation

- `vp test run tests/prod-server-logs.test.ts`
- `vp test run tests/prerender.test.ts -t "runPrerender — output"`
- `vp check tests/prod-server-logs.test.ts packages/vinext/src/server/prod-server.ts packages/vinext/src/build/prerender.ts packages/vinext/src/build/run-prerender.ts`
