### PR TITLE
feat(prerender): add concurrency flag

### DIFF
--- a/packages/vinext/src/build/run-prerender.ts
+++ b/packages/vinext/src/build/run-prerender.ts
@@ -93,6 +93,11 @@ type RunPrerenderOptions = {
    * Intended for tests that build to a custom outDir.
    */
   rscBundlePath?: string;
+  /**
+   * Maximum number of routes rendered in parallel.
+   * Defaults to prerenderApp/prerenderPages internal defaults when omitted.
+   */
+  concurrency?: number;
 };
 
 /**
@@ -213,6 +218,7 @@ export async function runPrerender(options: RunPrerenderOptions): Promise<Preren
         outDir,
         skipManifest: true,
         config,
+        concurrency: options.concurrency,
         rscBundlePath,
         // For hybrid builds pass the shared prod server via internal field.
         // prerenderApp will use it instead of starting its own.
@@ -246,6 +252,7 @@ export async function runPrerender(options: RunPrerenderOptions): Promise<Preren
         outDir,
         skipManifest: true,
         config,
+        concurrency: options.concurrency,
         // For hybrid builds pass the shared prod server; for single-router builds
         // fall back to the pages bundle path so prerenderPages starts its own.
         ...(sharedProdServer

--- a/packages/vinext/src/cli-args.ts
+++ b/packages/vinext/src/cli-args.ts
@@ -14,6 +14,7 @@ type ParsedArgs = {
   turbopack?: boolean;
   experimental?: boolean;
   prerenderAll?: boolean;
+  prerenderConcurrency?: number;
   precompress?: boolean;
 };
 
@@ -69,6 +70,17 @@ function parsePort(raw: string, flag: string): number {
   return parsed;
 }
 
+export function parsePositiveIntegerArg(raw: string, flag: string): number {
+  if (raw === "") {
+    throw new Error(`${flag} requires a value, but none was provided.`);
+  }
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${flag} expects a positive integer, but got "${raw}".`);
+  }
+  return parsed;
+}
+
 /**
  * Parse CLI arguments into a structured object.
  *
@@ -105,6 +117,13 @@ export function parseArgs(args: string[]): ParsedArgs {
         result.prerenderAll = true;
         break;
 
+      case "--prerender-concurrency": {
+        const raw = takeValue(arg, args, i);
+        i++;
+        result.prerenderConcurrency = parsePositiveIntegerArg(raw, arg);
+        break;
+      }
+
       case "--precompress":
         result.precompress = true;
         break;
@@ -137,6 +156,14 @@ export function parseArgs(args: string[]): ParsedArgs {
             throw new Error(`--hostname requires a value, but none was provided.`);
           }
           result.hostname = hostRaw;
+          break;
+        }
+        const prerenderConcurrencyRaw = tryEqualsForm(arg, "prerender-concurrency");
+        if (prerenderConcurrencyRaw !== null) {
+          result.prerenderConcurrency = parsePositiveIntegerArg(
+            prerenderConcurrencyRaw,
+            "--prerender-concurrency",
+          );
           break;
         }
         break;

--- a/packages/vinext/src/cli.ts
+++ b/packages/vinext/src/cli.ts
@@ -481,7 +481,10 @@ async function buildApp() {
       : "Pre-rendering all routes (output: 'export')...";
     process.stdout.write("\x1b[0m");
     console.log(`  ${label}`);
-    prerenderResult = await runPrerender({ root: process.cwd() });
+    prerenderResult = await runPrerender({
+      root: process.cwd(),
+      concurrency: parsed.prerenderConcurrency,
+    });
   }
 
   // Precompression runs as a Vite plugin writeBundle hook (vinext:precompress).
@@ -586,6 +589,7 @@ async function deployCommand() {
     dryRun: parsed.dryRun,
     name: parsed.name,
     prerenderAll: parsed.prerenderAll,
+    prerenderConcurrency: parsed.prerenderConcurrency,
     experimentalTPR: parsed.experimentalTPR,
     tprCoverage: parsed.tprCoverage,
     tprLimit: parsed.tprLimit,
@@ -656,6 +660,8 @@ function printHelp(cmd?: string) {
     --verbose            Show full Vite/Rollup build output (suppressed by default)
     --prerender-all      Pre-render discovered routes after building (future releases
                          will serve these files in vinext start)
+    --prerender-concurrency <count>
+                         Maximum number of routes to pre-render in parallel
     --precompress        Precompress static assets at build time (.br, .gz, .zst)
     -h, --help           Show this help
 `);
@@ -701,6 +707,8 @@ function printHelp(cmd?: string) {
     --dry-run                Generate config files without building or deploying
     --prerender-all          Pre-render discovered routes after building (future
                              releases will auto-populate the remote cache)
+    --prerender-concurrency <count>
+                             Maximum number of routes to pre-render in parallel
     -h, --help               Show this help
 
   Experimental:

--- a/packages/vinext/src/deploy.ts
+++ b/packages/vinext/src/deploy.ts
@@ -31,6 +31,7 @@ import { runTPR } from "./cloudflare/tpr.js";
 import { runPrerender } from "./build/run-prerender.js";
 import { loadDotenv } from "./config/dotenv.js";
 import { loadNextConfig, resolveNextConfig } from "./config/next-config.js";
+import { parsePositiveIntegerArg } from "./cli-args.js";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -49,6 +50,8 @@ type DeployOptions = {
   dryRun?: boolean;
   /** Pre-render all discovered routes into the dist output after building */
   prerenderAll?: boolean;
+  /** Maximum number of routes to prerender in parallel */
+  prerenderConcurrency?: number;
   /** Enable experimental TPR (Traffic-aware Pre-Rendering) */
   experimentalTPR?: boolean;
   /** TPR: traffic coverage percentage target (0–100, default: 90) */
@@ -70,6 +73,7 @@ const deployArgOptions = {
   "skip-build": { type: "boolean", default: false },
   "dry-run": { type: "boolean", default: false },
   "prerender-all": { type: "boolean", default: false },
+  "prerender-concurrency": { type: "string" },
   "experimental-tpr": { type: "boolean", default: false },
   "tpr-coverage": { type: "string" },
   "tpr-limit": { type: "string" },
@@ -97,6 +101,10 @@ export function parseDeployArgs(args: string[]) {
     skipBuild: values["skip-build"],
     dryRun: values["dry-run"],
     prerenderAll: values["prerender-all"],
+    prerenderConcurrency:
+      values["prerender-concurrency"] === undefined
+        ? undefined
+        : parsePositiveIntegerArg(values["prerender-concurrency"], "--prerender-concurrency"),
     experimentalTPR: values["experimental-tpr"],
     tprCoverage: parseIntArg("tpr-coverage", values["tpr-coverage"]),
     tprLimit: parseIntArg("tpr-limit", values["tpr-limit"]),
@@ -1364,7 +1372,7 @@ export async function deploy(options: DeployOptions): Promise<void> {
         process.setSourceMapsEnabled(true);
         Error.stackTraceLimit = Math.max(Error.stackTraceLimit, 50);
       }
-      await runPrerender({ root: info.root });
+      await runPrerender({ root: info.root, concurrency: options.prerenderConcurrency });
     }
   }
 

--- a/tests/cli-args.test.ts
+++ b/tests/cli-args.test.ts
@@ -194,6 +194,58 @@ describe("--hostname / -H", () => {
   });
 });
 
+// ─── --prerender-concurrency flag ──────────────────────────────────────────
+
+describe("--prerender-concurrency", () => {
+  it("parses a positive integer value", () => {
+    expect(parseArgs(["--prerender-concurrency", "4"])).toMatchObject({
+      prerenderConcurrency: 4,
+    });
+  });
+
+  it("parses --prerender-concurrency=value form", () => {
+    expect(parseArgs(["--prerender-concurrency=4"])).toMatchObject({
+      prerenderConcurrency: 4,
+    });
+  });
+
+  it("throws when --prerender-concurrency has no value", () => {
+    expect(() => parseArgs(["--prerender-concurrency"])).toThrow(
+      "--prerender-concurrency requires a value, but none was provided.",
+    );
+  });
+
+  it("throws when --prerender-concurrency value is another flag", () => {
+    expect(() => parseArgs(["--prerender-concurrency", "--prerender-all"])).toThrow(
+      '--prerender-concurrency requires a value, but got "--prerender-all" which looks like another flag.',
+    );
+  });
+
+  it("throws for empty --prerender-concurrency value", () => {
+    expect(() => parseArgs(["--prerender-concurrency="])).toThrow(
+      "--prerender-concurrency requires a value, but none was provided.",
+    );
+  });
+
+  it("throws for non-integer --prerender-concurrency value", () => {
+    expect(() => parseArgs(["--prerender-concurrency", "4.5"])).toThrow(
+      '--prerender-concurrency expects a positive integer, but got "4.5".',
+    );
+  });
+
+  it("throws for zero --prerender-concurrency value", () => {
+    expect(() => parseArgs(["--prerender-concurrency", "0"])).toThrow(
+      '--prerender-concurrency expects a positive integer, but got "0".',
+    );
+  });
+
+  it("throws for negative --prerender-concurrency value", () => {
+    expect(() => parseArgs(["--prerender-concurrency=-1"])).toThrow(
+      '--prerender-concurrency expects a positive integer, but got "-1".',
+    );
+  });
+});
+
 // ─── Combined flags ─────────────────────────────────────────────────────────
 
 describe("combined flags", () => {

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -146,6 +146,30 @@ describe("parseDeployArgs", () => {
     expect(parsed.tprWindow).toBe(48);
   });
 
+  it("parses --prerender-concurrency with space-separated value", () => {
+    expect(parseDeployArgs(["--prerender-concurrency", "4"]).prerenderConcurrency).toBe(4);
+  });
+
+  it("parses --prerender-concurrency=value form", () => {
+    expect(parseDeployArgs(["--prerender-concurrency=4"]).prerenderConcurrency).toBe(4);
+  });
+
+  it("throws for missing --prerender-concurrency value", () => {
+    expect(() => parseDeployArgs(["--prerender-concurrency"])).toThrow();
+  });
+
+  it("throws for invalid --prerender-concurrency value", () => {
+    expect(() => parseDeployArgs(["--prerender-concurrency", "abc"])).toThrow(
+      '--prerender-concurrency expects a positive integer, but got "abc".',
+    );
+  });
+
+  it("throws for zero --prerender-concurrency value", () => {
+    expect(() => parseDeployArgs(["--prerender-concurrency=0"])).toThrow(
+      '--prerender-concurrency expects a positive integer, but got "0".',
+    );
+  });
+
   it("trims whitespace from --env value", () => {
     expect(parseDeployArgs(["--env", "  staging  "]).env).toBe("staging");
   });

--- a/tests/run-prerender-concurrency.test.ts
+++ b/tests/run-prerender-concurrency.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const {
+  prerenderAppMock,
+  prerenderPagesMock,
+  writePrerenderIndexMock,
+  startProdServerMock,
+  appRouterMock,
+  pagesRouterMock,
+  apiRouterMock,
+} = vi.hoisted(() => ({
+  prerenderAppMock: vi.fn(async () => ({ routes: [] })),
+  prerenderPagesMock: vi.fn(async () => ({ routes: [] })),
+  writePrerenderIndexMock: vi.fn(),
+  startProdServerMock: vi.fn(async () => ({
+    server: { close: (callback: () => void) => callback() },
+    port: 3000,
+  })),
+  appRouterMock: vi.fn(async () => []),
+  pagesRouterMock: vi.fn(async () => []),
+  apiRouterMock: vi.fn(async () => []),
+}));
+
+vi.mock("../packages/vinext/src/build/prerender.js", () => ({
+  prerenderApp: prerenderAppMock,
+  prerenderPages: prerenderPagesMock,
+  writePrerenderIndex: writePrerenderIndexMock,
+  readPrerenderSecret: () => "secret",
+}));
+
+vi.mock("../packages/vinext/src/server/prod-server.js", () => ({
+  startProdServer: startProdServerMock,
+}));
+
+vi.mock("../packages/vinext/src/routing/app-router.js", () => ({
+  appRouter: appRouterMock,
+}));
+
+vi.mock("../packages/vinext/src/routing/pages-router.js", () => ({
+  pagesRouter: pagesRouterMock,
+  apiRouter: apiRouterMock,
+}));
+
+describe("runPrerender concurrency", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("passes configured concurrency to both app and pages prerender phases", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-run-prerender-concurrency-"));
+    fs.mkdirSync(path.join(root, "app"));
+    fs.mkdirSync(path.join(root, "pages"));
+
+    try {
+      const { runPrerender } = await import("../packages/vinext/src/build/run-prerender.js");
+
+      await runPrerender({
+        root,
+        concurrency: 4,
+        rscBundlePath: path.join(root, "dist", "server", "index.js"),
+      });
+
+      expect(prerenderAppMock).toHaveBeenCalledWith(expect.objectContaining({ concurrency: 4 }));
+      expect(prerenderPagesMock).toHaveBeenCalledWith(expect.objectContaining({ concurrency: 4 }));
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds a configurable prerender concurrency flag for the existing prerender worker pool:

- `vinext build --prerender-concurrency <count>`
- `vinext deploy --prerender-concurrency <count>`

The flag accepts positive integers in both space-separated and equals forms, and rejects missing, empty, zero, negative, non-integer, and flag-looking values. The validated value is threaded through `runPrerender()` to both App Router and Pages Router prerender phases, including hybrid builds. Defaults remain unchanged when the flag is omitted.

Part of #563.

## Validation

- `vp test run tests/cli-args.test.ts tests/deploy.test.ts tests/run-prerender-concurrency.test.ts`
- `vp check tests/cli-args.test.ts tests/deploy.test.ts tests/run-prerender-concurrency.test.ts`
- commit hook: `vp check --fix` on staged files
