### PR TITLE
perf(prerender): reuse embedded RSC payload

### DIFF
--- a/packages/vinext/src/build/prerender.ts
+++ b/packages/vinext/src/build/prerender.ts
@@ -293,6 +293,8 @@ export function extractRscPayloadFromPrerenderedHtml(html: string): ExtractRscPa
       continue;
     }
 
+    // Legacy embeds are parsed once for compatibility; modern chunk scripts take
+    // priority below if both protocols are present in the same HTML.
     if (legacyPayload === null) {
       legacyPayload = extractLegacyRscPayload(script);
       if (legacyPayload !== null) {
@@ -335,7 +337,9 @@ export function extractRscPayloadFromPrerenderedHtml(html: string): ExtractRscPa
   }
 
   if (sawRscMarker) {
-    throw new Error("[vinext] Malformed prerender RSC embed: no RSC chunks were found");
+    throw new Error(
+      "[vinext] Malformed prerender RSC embed: RSC protocol markers present but no data chunks found",
+    );
   }
 
   return {
@@ -1241,6 +1245,9 @@ export async function prerenderApp({
         }
         const html = htmlRender.html;
 
+        // Embedded chunks include fixFlightHints transforms from createRscEmbedTransform.
+        // The RSC entry applies the same fix at the source, so extracted and
+        // separately requested .rsc output stay equivalent.
         const extractedRsc = extractRscPayloadFromPrerenderedHtml(html);
         let rscData: string | null;
         if (extractedRsc.status === "ok") {

--- a/packages/vinext/src/build/prerender.ts
+++ b/packages/vinext/src/build/prerender.ts
@@ -187,9 +187,13 @@ const RSC_CHUNK_SCRIPT_PREFIX = "self.__VINEXT_RSC_CHUNKS__=self.__VINEXT_RSC_CH
 const RSC_DONE_MARKER = "__VINEXT_RSC_DONE__=true";
 const LEGACY_RSC_MARKER = "__VINEXT_RSC__=";
 
+function isWhitespace(char: string): boolean {
+  return char === " " || char === "\t" || char === "\n" || char === "\r";
+}
+
 function parseEmbeddedJsonString(script: string, start: number): { value: string; next: number } {
   let index = start;
-  while (/\s/.test(script[index] ?? "")) index++;
+  while (isWhitespace(script[index] ?? "")) index++;
 
   if (script[index] !== '"') {
     throw new Error("[vinext] Malformed prerender RSC embed: chunk payload is not a JSON string");
@@ -208,13 +212,18 @@ function parseEmbeddedJsonString(script: string, start: number): { value: string
     }
     if (char === '"') {
       const jsonSource = script.slice(index, cursor + 1);
-      const parsed: unknown = JSON.parse(jsonSource);
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(jsonSource);
+      } catch {
+        throw new Error("[vinext] Malformed prerender RSC embed: invalid chunk JSON");
+      }
       if (typeof parsed !== "string") {
         throw new Error("[vinext] Malformed prerender RSC embed: chunk payload is not a string");
       }
 
       let next = cursor + 1;
-      while (/\s/.test(script[next] ?? "")) next++;
+      while (isWhitespace(script[next] ?? "")) next++;
       if (script[next] !== ")") {
         throw new Error("[vinext] Malformed prerender RSC embed: chunk push is unterminated");
       }
@@ -228,9 +237,9 @@ function parseEmbeddedJsonString(script: string, start: number): { value: string
 
 function assertOnlyTrailingSemicolon(script: string, start: number, message: string): void {
   let index = start;
-  while (/\s/.test(script[index] ?? "")) index++;
+  while (isWhitespace(script[index] ?? "")) index++;
   if (script[index] === ";") index++;
-  while (/\s/.test(script[index] ?? "")) index++;
+  while (isWhitespace(script[index] ?? "")) index++;
   if (index !== script.length) {
     throw new Error(message);
   }
@@ -245,7 +254,12 @@ function extractLegacyRscPayload(script: string): string | null {
   if (!trimmedScript.startsWith(`self.${LEGACY_RSC_MARKER}`)) return null;
 
   const jsonSource = trimmedScript.slice(`self.${LEGACY_RSC_MARKER}`.length).trim();
-  const parsed: unknown = JSON.parse(jsonSource);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(jsonSource);
+  } catch {
+    throw new Error("[vinext] Malformed legacy prerender RSC embed: invalid JSON");
+  }
 
   if (typeof parsed !== "object" || parsed === null || !("rsc" in parsed)) {
     throw new Error("[vinext] Malformed legacy prerender RSC embed: missing rsc array");
@@ -260,6 +274,8 @@ function extractLegacyRscPayload(script: string): string | null {
 }
 
 export function extractRscPayloadFromPrerenderedHtml(html: string): ExtractRscPayloadResult {
+  // Safe because safeJsonStringify (used by createRscEmbedTransform) escapes
+  // all '<' and '>' in embedded JSON, preventing false </script> matches.
   const scriptPattern = /<script(?:\s[^>]*)?>([\s\S]*?)<\/script>/gi;
   const chunks: string[] = [];
   let sawRscMarker = false;
@@ -287,7 +303,10 @@ export function extractRscPayloadFromPrerenderedHtml(html: string): ExtractRscPa
 
     if (trimmedScript.startsWith(RSC_CHUNK_SCRIPT_PREFIX)) {
       sawRscMarker = true;
-      const markerIndex = trimmedScript.indexOf(RSC_CHUNK_PUSH_MARKER);
+      const markerIndex = trimmedScript.indexOf(
+        RSC_CHUNK_PUSH_MARKER,
+        RSC_CHUNK_SCRIPT_PREFIX.length,
+      );
       if (markerIndex === -1) {
         throw new Error("[vinext] Malformed prerender RSC embed: chunk push is missing");
       }

--- a/packages/vinext/src/build/prerender.ts
+++ b/packages/vinext/src/build/prerender.ts
@@ -178,174 +178,75 @@ const NOT_FOUND_SENTINEL_PATH = "/__vinext_nonexistent_for_404__";
 
 const DEFAULT_CONCURRENCY = Math.min(os.availableParallelism(), 8);
 
-type ExtractRscPayloadResult =
-  | { status: "ok"; payload: string }
-  | { status: "fallback"; reason: string };
-
-const RSC_CHUNK_PUSH_MARKER = "__VINEXT_RSC_CHUNKS__.push(";
 const RSC_CHUNK_SCRIPT_PREFIX = "self.__VINEXT_RSC_CHUNKS__=self.__VINEXT_RSC_CHUNKS__||[];";
 const RSC_DONE_MARKER = "__VINEXT_RSC_DONE__=true";
-const LEGACY_RSC_MARKER = "__VINEXT_RSC__=";
+// Full literal that createRscEmbedTransform concatenates before the
+// safeJsonStringify(chunk) argument. Keep this in sync with the writer at
+// packages/vinext/src/server/app-ssr-stream.ts:73.
+const RSC_CHUNK_FULL_PREFIX = `${RSC_CHUNK_SCRIPT_PREFIX}self.__VINEXT_RSC_CHUNKS__.push(`;
 
-function isWhitespace(char: string): boolean {
-  return char === " " || char === "\t" || char === "\n" || char === "\r";
-}
-
-function parseEmbeddedJsonString(script: string, start: number): { value: string; next: number } {
-  let index = start;
-  while (isWhitespace(script[index] ?? "")) index++;
-
-  if (script[index] !== '"') {
-    throw new Error("[vinext] Malformed prerender RSC embed: chunk payload is not a JSON string");
-  }
-
-  let escaped = false;
-  for (let cursor = index + 1; cursor < script.length; cursor++) {
-    const char = script[cursor];
-    if (escaped) {
-      escaped = false;
-      continue;
-    }
-    if (char === "\\") {
-      escaped = true;
-      continue;
-    }
-    if (char === '"') {
-      const jsonSource = script.slice(index, cursor + 1);
-      let parsed: unknown;
-      try {
-        parsed = JSON.parse(jsonSource);
-      } catch {
-        throw new Error("[vinext] Malformed prerender RSC embed: invalid chunk JSON");
-      }
-      if (typeof parsed !== "string") {
-        throw new Error("[vinext] Malformed prerender RSC embed: chunk payload is not a string");
-      }
-
-      let next = cursor + 1;
-      while (isWhitespace(script[next] ?? "")) next++;
-      if (script[next] !== ")") {
-        throw new Error("[vinext] Malformed prerender RSC embed: chunk push is unterminated");
-      }
-
-      return { value: parsed, next: next + 1 };
-    }
-  }
-
-  throw new Error("[vinext] Malformed prerender RSC embed: chunk JSON string is unterminated");
-}
-
-function assertOnlyTrailingSemicolon(script: string, start: number, message: string): void {
-  let index = start;
-  while (isWhitespace(script[index] ?? "")) index++;
-  if (script[index] === ";") index++;
-  while (isWhitespace(script[index] ?? "")) index++;
-  if (index !== script.length) {
-    throw new Error(message);
-  }
-}
-
-function isStringArray(value: unknown): value is string[] {
-  return Array.isArray(value) && value.every((item) => typeof item === "string");
-}
-
-function extractLegacyRscPayload(script: string): string | null {
-  const trimmedScript = script.trim().replace(/;$/, "");
-  if (!trimmedScript.startsWith(`self.${LEGACY_RSC_MARKER}`)) return null;
-
-  const jsonSource = trimmedScript.slice(`self.${LEGACY_RSC_MARKER}`.length).trim();
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(jsonSource);
-  } catch {
-    throw new Error("[vinext] Malformed legacy prerender RSC embed: invalid JSON");
-  }
-
-  if (typeof parsed !== "object" || parsed === null || !("rsc" in parsed)) {
-    throw new Error("[vinext] Malformed legacy prerender RSC embed: missing rsc array");
-  }
-
-  const rsc = parsed.rsc;
-  if (!isStringArray(rsc)) {
-    throw new Error("[vinext] Malformed legacy prerender RSC embed: rsc is not a string array");
-  }
-
-  return rsc.join("");
-}
-
-export function extractRscPayloadFromPrerenderedHtml(html: string): ExtractRscPayloadResult {
-  // Safe because safeJsonStringify (used by createRscEmbedTransform) escapes
-  // all '<' and '>' in embedded JSON, preventing false </script> matches.
+/**
+ * Reconstruct the RSC payload from a prerender HTML response by parsing the
+ * inline bootstrap chunk scripts emitted by createRscEmbedTransform.
+ *
+ * Always throws on malformed or missing markers — the writer is in-tree, so
+ * any anomaly is a vinext-internal regression we want to surface loudly
+ * rather than silently double-rendering via a fallback request.
+ *
+ * Safe regex usage: safeJsonStringify (used by createRscEmbedTransform) escapes
+ * all '<' and '>' in the embedded JSON, preventing false </script> matches.
+ */
+export function extractRscPayloadFromPrerenderedHtml(html: string): string {
   const scriptPattern = /<script(?:\s[^>]*)?>([\s\S]*?)<\/script>/gi;
   const chunks: string[] = [];
-  let sawRscMarker = false;
   let sawDone = false;
-  let legacyPayload: string | null = null;
   let match: RegExpExecArray | null;
 
   while ((match = scriptPattern.exec(html)) !== null) {
-    const script = match[1] ?? "";
-    const trimmedScript = script.trim().replace(/;$/, "");
+    const script = (match[1] ?? "").trim().replace(/;$/, "");
 
-    if (trimmedScript === `self.${RSC_DONE_MARKER}`) {
-      sawRscMarker = true;
+    if (script === `self.${RSC_DONE_MARKER}`) {
       sawDone = true;
       continue;
     }
 
-    // Legacy embeds are parsed once for compatibility; modern chunk scripts take
-    // priority below if both protocols are present in the same HTML.
-    if (legacyPayload === null) {
-      legacyPayload = extractLegacyRscPayload(script);
-      if (legacyPayload !== null) {
-        sawRscMarker = true;
-        continue;
-      }
-    }
-
-    if (trimmedScript.startsWith(RSC_CHUNK_SCRIPT_PREFIX)) {
-      sawRscMarker = true;
-      const markerIndex = trimmedScript.indexOf(
-        RSC_CHUNK_PUSH_MARKER,
-        RSC_CHUNK_SCRIPT_PREFIX.length,
-      );
-      if (markerIndex === -1) {
-        throw new Error("[vinext] Malformed prerender RSC embed: chunk push is missing");
-      }
-      const parsed = parseEmbeddedJsonString(
-        trimmedScript,
-        markerIndex + RSC_CHUNK_PUSH_MARKER.length,
-      );
-      assertOnlyTrailingSemicolon(
-        trimmedScript,
-        parsed.next,
-        "[vinext] Malformed prerender RSC embed: unexpected trailing code after chunk push",
-      );
-      chunks.push(parsed.value);
+    if (script.startsWith(RSC_CHUNK_SCRIPT_PREFIX)) {
+      chunks.push(parseRscChunkPushArgument(script));
     }
   }
 
-  if (chunks.length > 0) {
-    if (!sawDone) {
-      throw new Error("[vinext] Malformed prerender RSC embed: missing __VINEXT_RSC_DONE__ marker");
-    }
-    return { status: "ok", payload: chunks.join("") };
+  if (chunks.length === 0) {
+    throw new Error("[vinext] Malformed prerender RSC embed: no chunk scripts found in HTML");
+  }
+  if (!sawDone) {
+    throw new Error("[vinext] Malformed prerender RSC embed: missing __VINEXT_RSC_DONE__ marker");
   }
 
-  if (legacyPayload !== null) {
-    return { status: "ok", payload: legacyPayload };
-  }
+  return chunks.join("");
+}
 
-  if (sawRscMarker) {
-    throw new Error(
-      "[vinext] Malformed prerender RSC embed: RSC protocol markers present but no data chunks found",
-    );
+/**
+ * Parse the JSON-string argument of a single chunk-push script. The script
+ * shape is exactly `<prefix>(<safeJsonStringify(chunk)>)` because the writer
+ * concatenates those literals — so the body always starts with the full
+ * prefix and ends with `)`. JSON.parse on the slice catches any tampering or
+ * trailing code.
+ */
+function parseRscChunkPushArgument(script: string): string {
+  if (!script.startsWith(RSC_CHUNK_FULL_PREFIX) || !script.endsWith(")")) {
+    throw new Error("[vinext] Malformed prerender RSC embed: unexpected chunk script shape");
   }
-
-  return {
-    status: "fallback",
-    reason: "no recognized Vinext RSC embed markers found in HTML",
-  };
+  const jsonSource = script.slice(RSC_CHUNK_FULL_PREFIX.length, -1);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(jsonSource);
+  } catch {
+    throw new Error("[vinext] Malformed prerender RSC embed: invalid chunk JSON");
+  }
+  if (typeof parsed !== "string") {
+    throw new Error("[vinext] Malformed prerender RSC embed: chunk payload is not a string");
+  }
+  return parsed;
 }
 
 /**
@@ -1245,25 +1146,12 @@ export async function prerenderApp({
         }
         const html = htmlRender.html;
 
-        // Embedded chunks include fixFlightHints transforms from createRscEmbedTransform.
-        // The RSC entry applies the same fix at the source, so extracted and
-        // separately requested .rsc output stay equivalent.
-        const extractedRsc = extractRscPayloadFromPrerenderedHtml(html);
-        let rscData: string | null;
-        if (extractedRsc.status === "ok") {
-          rscData = extractedRsc.payload;
-        } else {
-          console.warn(
-            `[vinext] Warning: ${extractedRsc.reason}. Falling back to a separate RSC prerender request for ${urlPath}.`,
-          );
-          const rscRequest = new Request(`http://localhost${urlPath}`, {
-            headers: { Accept: "text/x-component", RSC: "1" },
-          });
-          const rscRes = await runWithHeadersContext(headersContextFromRequest(rscRequest), () =>
-            rscHandler(rscRequest),
-          );
-          rscData = rscRes.ok ? await rscRes.text() : null;
-        }
+        // Reconstruct the RSC payload from the inline bootstrap chunks already
+        // streamed into the HTML body. The chunks went through fixFlightHints
+        // (createRscEmbedTransform applies it before pushing each chunk into
+        // the embed scripts), so the resulting `.rsc` file contains the
+        // rewritten Flight form rather than raw Flight bytes.
+        const rscData = extractRscPayloadFromPrerenderedHtml(html);
 
         const outputFiles: string[] = [];
 
@@ -1275,13 +1163,11 @@ export async function prerenderApp({
         outputFiles.push(htmlOutputPath);
 
         // Write RSC payload (.rsc file)
-        if (rscData !== null) {
-          const rscOutputPath = getRscOutputPath(urlPath);
-          const rscFullPath = path.join(outDir, rscOutputPath);
-          fs.mkdirSync(path.dirname(rscFullPath), { recursive: true });
-          fs.writeFileSync(rscFullPath, rscData, "utf-8");
-          outputFiles.push(rscOutputPath);
-        }
+        const rscOutputPath = getRscOutputPath(urlPath);
+        const rscFullPath = path.join(outDir, rscOutputPath);
+        fs.mkdirSync(path.dirname(rscFullPath), { recursive: true });
+        fs.writeFileSync(rscFullPath, rscData, "utf-8");
+        outputFiles.push(rscOutputPath);
 
         const renderedCacheControl = resolveRenderedCacheControl(
           htmlRender.requestCacheLife ?? {},

--- a/packages/vinext/src/build/prerender.ts
+++ b/packages/vinext/src/build/prerender.ts
@@ -189,14 +189,18 @@ const RSC_CHUNK_FULL_PREFIX = `${RSC_CHUNK_SCRIPT_PREFIX}self.__VINEXT_RSC_CHUNK
  * Reconstruct the RSC payload from a prerender HTML response by parsing the
  * inline bootstrap chunk scripts emitted by createRscEmbedTransform.
  *
- * Always throws on malformed or missing markers — the writer is in-tree, so
- * any anomaly is a vinext-internal regression we want to surface loudly
- * rather than silently double-rendering via a fallback request.
+ * Returns null when the HTML contains no chunk scripts at all — the caller
+ * should fall back to a second handler invocation. This is reachable when
+ * middleware short-circuits the App Router pipeline with a custom 200 HTML
+ * response that never went through createRscEmbedTransform.
+ *
+ * Throws on partial or malformed embeds (chunks present but no done marker,
+ * tampered chunk JSON, etc.) — those are real vinext-internal regressions.
  *
  * Safe regex usage: safeJsonStringify (used by createRscEmbedTransform) escapes
  * all '<' and '>' in the embedded JSON, preventing false </script> matches.
  */
-export function extractRscPayloadFromPrerenderedHtml(html: string): string {
+export function extractRscPayloadFromPrerenderedHtml(html: string): string | null {
   const scriptPattern = /<script(?:\s[^>]*)?>([\s\S]*?)<\/script>/gi;
   const chunks: string[] = [];
   let sawDone = false;
@@ -215,8 +219,15 @@ export function extractRscPayloadFromPrerenderedHtml(html: string): string {
     }
   }
 
+  // No chunks AND no done marker → middleware/early-return path. Caller falls
+  // back to a second invocation with `RSC: 1`.
+  if (chunks.length === 0 && !sawDone) {
+    return null;
+  }
   if (chunks.length === 0) {
-    throw new Error("[vinext] Malformed prerender RSC embed: no chunk scripts found in HTML");
+    throw new Error(
+      "[vinext] Malformed prerender RSC embed: done marker present without chunk scripts",
+    );
   }
   if (!sawDone) {
     throw new Error("[vinext] Malformed prerender RSC embed: missing __VINEXT_RSC_DONE__ marker");
@@ -1151,7 +1162,21 @@ export async function prerenderApp({
         // (createRscEmbedTransform applies it before pushing each chunk into
         // the embed scripts), so the resulting `.rsc` file contains the
         // rewritten Flight form rather than raw Flight bytes.
-        const rscData = extractRscPayloadFromPrerenderedHtml(html);
+        //
+        // Falls back to a second invocation with `RSC: 1` when the HTML has
+        // no chunk scripts at all — covers cases where middleware
+        // short-circuits the App Router pipeline with a custom 200 HTML
+        // response that never went through createRscEmbedTransform.
+        let rscData = extractRscPayloadFromPrerenderedHtml(html);
+        if (rscData === null) {
+          const rscRequest = new Request(`http://localhost${urlPath}`, {
+            headers: { Accept: "text/x-component", RSC: "1" },
+          });
+          const rscRes = await runWithHeadersContext(headersContextFromRequest(rscRequest), () =>
+            rscHandler(rscRequest),
+          );
+          rscData = rscRes.ok ? await rscRes.text() : "";
+        }
 
         const outputFiles: string[] = [];
 

--- a/packages/vinext/src/build/prerender.ts
+++ b/packages/vinext/src/build/prerender.ts
@@ -178,6 +178,153 @@ const NOT_FOUND_SENTINEL_PATH = "/__vinext_nonexistent_for_404__";
 
 const DEFAULT_CONCURRENCY = Math.min(os.availableParallelism(), 8);
 
+type ExtractRscPayloadResult =
+  | { status: "ok"; payload: string }
+  | { status: "fallback"; reason: string };
+
+const RSC_CHUNK_PUSH_MARKER = "__VINEXT_RSC_CHUNKS__.push(";
+const RSC_CHUNK_SCRIPT_PREFIX = "self.__VINEXT_RSC_CHUNKS__=self.__VINEXT_RSC_CHUNKS__||[];";
+const RSC_DONE_MARKER = "__VINEXT_RSC_DONE__=true";
+const LEGACY_RSC_MARKER = "__VINEXT_RSC__=";
+
+function parseEmbeddedJsonString(script: string, start: number): { value: string; next: number } {
+  let index = start;
+  while (/\s/.test(script[index] ?? "")) index++;
+
+  if (script[index] !== '"') {
+    throw new Error("[vinext] Malformed prerender RSC embed: chunk payload is not a JSON string");
+  }
+
+  let escaped = false;
+  for (let cursor = index + 1; cursor < script.length; cursor++) {
+    const char = script[cursor];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (char === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (char === '"') {
+      const jsonSource = script.slice(index, cursor + 1);
+      const parsed: unknown = JSON.parse(jsonSource);
+      if (typeof parsed !== "string") {
+        throw new Error("[vinext] Malformed prerender RSC embed: chunk payload is not a string");
+      }
+
+      let next = cursor + 1;
+      while (/\s/.test(script[next] ?? "")) next++;
+      if (script[next] !== ")") {
+        throw new Error("[vinext] Malformed prerender RSC embed: chunk push is unterminated");
+      }
+
+      return { value: parsed, next: next + 1 };
+    }
+  }
+
+  throw new Error("[vinext] Malformed prerender RSC embed: chunk JSON string is unterminated");
+}
+
+function assertOnlyTrailingSemicolon(script: string, start: number, message: string): void {
+  let index = start;
+  while (/\s/.test(script[index] ?? "")) index++;
+  if (script[index] === ";") index++;
+  while (/\s/.test(script[index] ?? "")) index++;
+  if (index !== script.length) {
+    throw new Error(message);
+  }
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "string");
+}
+
+function extractLegacyRscPayload(script: string): string | null {
+  const trimmedScript = script.trim().replace(/;$/, "");
+  if (!trimmedScript.startsWith(`self.${LEGACY_RSC_MARKER}`)) return null;
+
+  const jsonSource = trimmedScript.slice(`self.${LEGACY_RSC_MARKER}`.length).trim();
+  const parsed: unknown = JSON.parse(jsonSource);
+
+  if (typeof parsed !== "object" || parsed === null || !("rsc" in parsed)) {
+    throw new Error("[vinext] Malformed legacy prerender RSC embed: missing rsc array");
+  }
+
+  const rsc = parsed.rsc;
+  if (!isStringArray(rsc)) {
+    throw new Error("[vinext] Malformed legacy prerender RSC embed: rsc is not a string array");
+  }
+
+  return rsc.join("");
+}
+
+export function extractRscPayloadFromPrerenderedHtml(html: string): ExtractRscPayloadResult {
+  const scriptPattern = /<script(?:\s[^>]*)?>([\s\S]*?)<\/script>/gi;
+  const chunks: string[] = [];
+  let sawRscMarker = false;
+  let sawDone = false;
+  let legacyPayload: string | null = null;
+  let match: RegExpExecArray | null;
+
+  while ((match = scriptPattern.exec(html)) !== null) {
+    const script = match[1] ?? "";
+    const trimmedScript = script.trim().replace(/;$/, "");
+
+    if (trimmedScript === `self.${RSC_DONE_MARKER}`) {
+      sawRscMarker = true;
+      sawDone = true;
+      continue;
+    }
+
+    if (legacyPayload === null) {
+      legacyPayload = extractLegacyRscPayload(script);
+      if (legacyPayload !== null) {
+        sawRscMarker = true;
+        continue;
+      }
+    }
+
+    if (trimmedScript.startsWith(RSC_CHUNK_SCRIPT_PREFIX)) {
+      sawRscMarker = true;
+      const markerIndex = trimmedScript.indexOf(RSC_CHUNK_PUSH_MARKER);
+      if (markerIndex === -1) {
+        throw new Error("[vinext] Malformed prerender RSC embed: chunk push is missing");
+      }
+      const parsed = parseEmbeddedJsonString(
+        trimmedScript,
+        markerIndex + RSC_CHUNK_PUSH_MARKER.length,
+      );
+      assertOnlyTrailingSemicolon(
+        trimmedScript,
+        parsed.next,
+        "[vinext] Malformed prerender RSC embed: unexpected trailing code after chunk push",
+      );
+      chunks.push(parsed.value);
+    }
+  }
+
+  if (chunks.length > 0) {
+    if (!sawDone) {
+      throw new Error("[vinext] Malformed prerender RSC embed: missing __VINEXT_RSC_DONE__ marker");
+    }
+    return { status: "ok", payload: chunks.join("") };
+  }
+
+  if (legacyPayload !== null) {
+    return { status: "ok", payload: legacyPayload };
+  }
+
+  if (sawRscMarker) {
+    throw new Error("[vinext] Malformed prerender RSC embed: no RSC chunks were found");
+  }
+
+  return {
+    status: "fallback",
+    reason: "no recognized Vinext RSC embed markers found in HTML",
+  };
+}
+
 /**
  * Run an array of async tasks with bounded concurrency.
  * Results are returned in the same order as `items`.
@@ -1074,15 +1221,22 @@ export async function prerenderApp({
         }
         const html = htmlRender.html;
 
-        // Fetch RSC payload via a second invocation with RSC headers
-        // TODO: Extract RSC payload from the first response instead of invoking the handler twice.
-        const rscRequest = new Request(`http://localhost${urlPath}`, {
-          headers: { Accept: "text/x-component", RSC: "1" },
-        });
-        const rscRes = await runWithHeadersContext(headersContextFromRequest(rscRequest), () =>
-          rscHandler(rscRequest),
-        );
-        const rscData = rscRes.ok ? await rscRes.text() : null;
+        const extractedRsc = extractRscPayloadFromPrerenderedHtml(html);
+        let rscData: string | null;
+        if (extractedRsc.status === "ok") {
+          rscData = extractedRsc.payload;
+        } else {
+          console.warn(
+            `[vinext] Warning: ${extractedRsc.reason}. Falling back to a separate RSC prerender request for ${urlPath}.`,
+          );
+          const rscRequest = new Request(`http://localhost${urlPath}`, {
+            headers: { Accept: "text/x-component", RSC: "1" },
+          });
+          const rscRes = await runWithHeadersContext(headersContextFromRequest(rscRequest), () =>
+            rscHandler(rscRequest),
+          );
+          rscData = rscRes.ok ? await rscRes.text() : null;
+        }
 
         const outputFiles: string[] = [];
 

--- a/packages/vinext/src/build/prerender.ts
+++ b/packages/vinext/src/build/prerender.ts
@@ -1175,7 +1175,13 @@ export async function prerenderApp({
           const rscRes = await runWithHeadersContext(headersContextFromRequest(rscRequest), () =>
             rscHandler(rscRequest),
           );
-          rscData = rscRes.ok ? await rscRes.text() : "";
+          if (!rscRes.ok) {
+            await rscRes.body?.cancel();
+            throw new Error(
+              `[vinext] prerenderApp: RSC fallback returned ${rscRes.status} for ${urlPath}`,
+            );
+          }
+          rscData = await rscRes.text();
         }
 
         const outputFiles: string[] = [];

--- a/tests/app-elements.test.ts
+++ b/tests/app-elements.test.ts
@@ -158,6 +158,7 @@ describe("AppElementsWire", () => {
     if (!isAppElementsRecord(payload)) return;
 
     expect(AppElementsWire.readMetadata(payload)).toEqual({
+      artifactCompatibility: createArtifactCompatibilityEnvelope(),
       interceptionContext: null,
       layoutFlags: { [AppElementsWire.encodeLayoutId("/")]: "s" },
       rootLayoutTreePath: "/",

--- a/tests/prerender.test.ts
+++ b/tests/prerender.test.ts
@@ -84,15 +84,10 @@ describe("extractRscPayloadFromPrerenderedHtml", () => {
       "<script>self.__VINEXT_RSC_DONE__=true</script>" +
       "</body></html>";
 
-    const result = extractRscPayloadFromPrerenderedHtml(html);
-
-    expect(result).toEqual({
-      status: "ok",
-      payload: chunks.join(""),
-    });
+    expect(extractRscPayloadFromPrerenderedHtml(html)).toBe(chunks.join(""));
   });
 
-  it("rejects incomplete streamed RSC embeds instead of falling back", () => {
+  it("throws when the done marker is missing", () => {
     const html =
       "<html><body>" +
       `<script>self.__VINEXT_RSC_CHUNKS__=self.__VINEXT_RSC_CHUNKS__||[];self.__VINEXT_RSC_CHUNKS__.push(${safeJsonStringify("0:[]\n")})</script>` +
@@ -110,17 +105,22 @@ describe("extractRscPayloadFromPrerenderedHtml", () => {
     expect(() => extractRscPayloadFromPrerenderedHtml(html)).toThrow(/missing __VINEXT_RSC_DONE__/);
   });
 
-  it("rejects streamed RSC chunk scripts with trailing code after the payload push", () => {
+  it("rejects chunk scripts with trailing code after the payload push", () => {
     const html =
       "<html><body>" +
       `<script>self.__VINEXT_RSC_CHUNKS__=self.__VINEXT_RSC_CHUNKS__||[];self.__VINEXT_RSC_CHUNKS__.push(${safeJsonStringify("0:[]\n")})alert(1)</script>` +
       "<script>self.__VINEXT_RSC_DONE__=true</script>" +
       "</body></html>";
 
-    expect(() => extractRscPayloadFromPrerenderedHtml(html)).toThrow(/unexpected trailing code/);
+    // JSON.parse rejects the slice (which includes the `)` and `alert(1` after
+    // the JSON-encoded string), so this is reported as malformed JSON rather
+    // than a separate "trailing code" diagnostic.
+    expect(() => extractRscPayloadFromPrerenderedHtml(html)).toThrow(
+      "[vinext] Malformed prerender RSC embed: invalid chunk JSON",
+    );
   });
 
-  it("rejects streamed RSC chunk scripts with invalid JSON using a Vinext error", () => {
+  it("rejects chunk scripts with invalid JSON", () => {
     const html =
       "<html><body>" +
       '<script>self.__VINEXT_RSC_CHUNKS__=self.__VINEXT_RSC_CHUNKS__||[];self.__VINEXT_RSC_CHUNKS__.push("\\uZZZZ")</script>' +
@@ -132,37 +132,17 @@ describe("extractRscPayloadFromPrerenderedHtml", () => {
     );
   });
 
-  it("reconstructs the legacy embedded RSC payload shape", () => {
-    const html = `<script>self.__VINEXT_RSC__=${safeJsonStringify({
-      rsc: ["0:legacy\n", "1:payload\n"],
-    })}</script>`;
-
-    expect(extractRscPayloadFromPrerenderedHtml(html)).toEqual({
-      status: "ok",
-      payload: "0:legacy\n1:payload\n",
-    });
-  });
-
-  it("rejects legacy embedded RSC payloads with invalid JSON using a Vinext error", () => {
-    const html = `<script>self.__VINEXT_RSC__={"rsc":[}</script>`;
-
-    expect(() => extractRscPayloadFromPrerenderedHtml(html)).toThrow(
-      "[vinext] Malformed legacy prerender RSC embed: invalid JSON",
+  it("throws when no chunk scripts are present", () => {
+    expect(() => extractRscPayloadFromPrerenderedHtml("<html><body>legacy</body></html>")).toThrow(
+      "[vinext] Malformed prerender RSC embed: no chunk scripts found in HTML",
     );
   });
 
-  it("uses an explicit compatibility fallback when no Vinext RSC embed exists", () => {
-    expect(extractRscPayloadFromPrerenderedHtml("<html><body>legacy</body></html>")).toEqual({
-      status: "fallback",
-      reason: "no recognized Vinext RSC embed markers found in HTML",
-    });
-  });
-
-  it("rejects empty streamed RSC protocol markers with a specific error", () => {
+  it("throws when only the done marker is present without any chunks", () => {
     const html = "<html><body><script>self.__VINEXT_RSC_DONE__=true</script></body></html>";
 
     expect(() => extractRscPayloadFromPrerenderedHtml(html)).toThrow(
-      "[vinext] Malformed prerender RSC embed: RSC protocol markers present but no data chunks found",
+      "[vinext] Malformed prerender RSC embed: no chunk scripts found in HTML",
     );
   });
 });
@@ -227,66 +207,6 @@ describe("prerenderApp — RSC extraction", () => {
       });
       expect(fs.readFileSync(path.join(outDir, "index.rsc"), "utf-8")).toBe(rscPayload);
       expect(rscRequestCount).toBe(0);
-    } finally {
-      await closeServer(server);
-      fs.rmSync(root, { recursive: true, force: true });
-    }
-  });
-
-  it("falls back to a separate RSC request when rendered HTML has no RSC markers", async () => {
-    const root = tmpDir("vinext-prerender-rsc-fallback-");
-    const outDir = path.join(root, "out");
-    const appDir = path.join(root, "app");
-    const pagePath = path.join(appDir, "page.tsx");
-    fs.mkdirSync(appDir, { recursive: true });
-    fs.writeFileSync(
-      pagePath,
-      "export const dynamic = 'force-static';\nexport default function Page() { return null; }\n",
-    );
-
-    const rscPayload = '0:["$","div",null,{"children":"from fallback"}]\n';
-    let rscRequestCount = 0;
-    const server = createServer((req, res) => {
-      if (req.headers.rsc === "1" || req.headers.accept === "text/x-component") {
-        rscRequestCount++;
-        res.setHeader("content-type", "text/x-component");
-        res.end(rscPayload);
-        return;
-      }
-
-      if (req.url === "/__vinext_nonexistent_for_404__") {
-        res.statusCode = 404;
-        res.end("<html><body>not found</body></html>");
-        return;
-      }
-
-      res.setHeader("content-type", "text/html");
-      res.end("<html><body>plain html shell</body></html>");
-    });
-
-    const port = await listen(server);
-    try {
-      const { prerenderApp } = await import("../packages/vinext/src/build/prerender.js");
-      const { appRouter } = await import("../packages/vinext/src/routing/app-router.js");
-      const { resolveNextConfig } = await import("../packages/vinext/src/config/next-config.js");
-      const routes = await appRouter(appDir);
-      const config = await resolveNextConfig({});
-
-      const prerenderResult = await prerenderApp({
-        mode: "default",
-        rscBundlePath: path.join(root, "dist", "server", "index.js"),
-        routes,
-        outDir,
-        config,
-        _prodServer: { server, port },
-      });
-
-      expect(findRoute(prerenderResult.routes, "/")).toMatchObject({
-        route: "/",
-        status: "rendered",
-      });
-      expect(fs.readFileSync(path.join(outDir, "index.rsc"), "utf-8")).toBe(rscPayload);
-      expect(rscRequestCount).toBe(1);
     } finally {
       await closeServer(server);
       fs.rmSync(root, { recursive: true, force: true });

--- a/tests/prerender.test.ts
+++ b/tests/prerender.test.ts
@@ -157,6 +157,14 @@ describe("extractRscPayloadFromPrerenderedHtml", () => {
       reason: "no recognized Vinext RSC embed markers found in HTML",
     });
   });
+
+  it("rejects empty streamed RSC protocol markers with a specific error", () => {
+    const html = "<html><body><script>self.__VINEXT_RSC_DONE__=true</script></body></html>";
+
+    expect(() => extractRscPayloadFromPrerenderedHtml(html)).toThrow(
+      "[vinext] Malformed prerender RSC embed: RSC protocol markers present but no data chunks found",
+    );
+  });
 });
 
 describe("prerenderApp — RSC extraction", () => {

--- a/tests/prerender.test.ts
+++ b/tests/prerender.test.ts
@@ -132,17 +132,20 @@ describe("extractRscPayloadFromPrerenderedHtml", () => {
     );
   });
 
-  it("throws when no chunk scripts are present", () => {
-    expect(() => extractRscPayloadFromPrerenderedHtml("<html><body>legacy</body></html>")).toThrow(
-      "[vinext] Malformed prerender RSC embed: no chunk scripts found in HTML",
-    );
+  it("returns null when no chunk scripts and no done marker are present (middleware short-circuit)", () => {
+    // Middleware that returns a custom 200 HTML body bypasses the App Router
+    // pipeline entirely — no chunks, no done marker. The driver detects this
+    // null and falls back to a second invocation with `RSC: 1`.
+    expect(extractRscPayloadFromPrerenderedHtml("<html><body>legacy</body></html>")).toBeNull();
   });
 
   it("throws when only the done marker is present without any chunks", () => {
+    // Half-emitted embed (done marker but no chunks) is a real bug — partial
+    // emission shouldn't fall back silently.
     const html = "<html><body><script>self.__VINEXT_RSC_DONE__=true</script></body></html>";
 
     expect(() => extractRscPayloadFromPrerenderedHtml(html)).toThrow(
-      "[vinext] Malformed prerender RSC embed: no chunk scripts found in HTML",
+      "[vinext] Malformed prerender RSC embed: done marker present without chunk scripts",
     );
   });
 });
@@ -207,6 +210,84 @@ describe("prerenderApp — RSC extraction", () => {
       });
       expect(fs.readFileSync(path.join(outDir, "index.rsc"), "utf-8")).toBe(rscPayload);
       expect(rscRequestCount).toBe(0);
+    } finally {
+      await closeServer(server);
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to a second RSC: 1 invocation when middleware short-circuits with custom HTML", async () => {
+    // Middleware that returns a 200 HTML body bypasses the App Router
+    // pipeline — the response contains no embed chunks. The driver must
+    // recover by issuing a second invocation with `RSC: 1` and use whatever
+    // that returns as the .rsc file.
+    const root = tmpDir("vinext-prerender-rsc-fallback-");
+    const outDir = path.join(root, "out");
+    const appDir = path.join(root, "app");
+    const pagePath = path.join(appDir, "page.tsx");
+    fs.mkdirSync(appDir, { recursive: true });
+    fs.writeFileSync(
+      pagePath,
+      "export const dynamic = 'force-static';\nexport default function Page() { return null; }\n",
+    );
+
+    const middlewareHtml = "<html><body>middleware short-circuit</body></html>";
+    const fallbackRscPayload = '0:["$","div",null,{"children":"from fallback"}]\n';
+    let pageRequestCount = 0;
+    let rscRequestCount = 0;
+    const server = createServer((req, res) => {
+      const isRsc = req.headers.rsc === "1" || req.headers.accept === "text/x-component";
+
+      if (req.url === "/__vinext_nonexistent_for_404__") {
+        res.statusCode = 404;
+        res.end("<html><body>not found</body></html>");
+        return;
+      }
+
+      if (isRsc) {
+        rscRequestCount++;
+        res.setHeader("content-type", "text/x-component");
+        res.end(fallbackRscPayload);
+        return;
+      }
+
+      // Page request: middleware short-circuits with plain HTML and no
+      // RSC embed chunks — exercising the fallback path.
+      pageRequestCount++;
+      res.setHeader("content-type", "text/html");
+      res.end(middlewareHtml);
+    });
+
+    const port = await listen(server);
+    try {
+      const { prerenderApp } = await import("../packages/vinext/src/build/prerender.js");
+      const { appRouter } = await import("../packages/vinext/src/routing/app-router.js");
+      const { resolveNextConfig } = await import("../packages/vinext/src/config/next-config.js");
+      const routes = await appRouter(appDir);
+      const config = await resolveNextConfig({});
+
+      const prerenderResult = await prerenderApp({
+        mode: "default",
+        rscBundlePath: path.join(root, "dist", "server", "index.js"),
+        routes,
+        outDir,
+        config,
+        _prodServer: { server, port },
+      });
+
+      expect(findRoute(prerenderResult.routes, "/")).toMatchObject({
+        route: "/",
+        status: "rendered",
+      });
+
+      // HTML on disk is the middleware response.
+      expect(fs.readFileSync(path.join(outDir, "index.html"), "utf-8")).toBe(middlewareHtml);
+      // .rsc on disk is the fallback RSC: 1 response.
+      expect(fs.readFileSync(path.join(outDir, "index.rsc"), "utf-8")).toBe(fallbackRscPayload);
+
+      // Exactly one page request and one RSC fallback request per route.
+      expect(pageRequestCount).toBe(1);
+      expect(rscRequestCount).toBe(1);
     } finally {
       await closeServer(server);
       fs.rmSync(root, { recursive: true, force: true });

--- a/tests/prerender.test.ts
+++ b/tests/prerender.test.ts
@@ -120,6 +120,18 @@ describe("extractRscPayloadFromPrerenderedHtml", () => {
     expect(() => extractRscPayloadFromPrerenderedHtml(html)).toThrow(/unexpected trailing code/);
   });
 
+  it("rejects streamed RSC chunk scripts with invalid JSON using a Vinext error", () => {
+    const html =
+      "<html><body>" +
+      '<script>self.__VINEXT_RSC_CHUNKS__=self.__VINEXT_RSC_CHUNKS__||[];self.__VINEXT_RSC_CHUNKS__.push("\\uZZZZ")</script>' +
+      "<script>self.__VINEXT_RSC_DONE__=true</script>" +
+      "</body></html>";
+
+    expect(() => extractRscPayloadFromPrerenderedHtml(html)).toThrow(
+      "[vinext] Malformed prerender RSC embed: invalid chunk JSON",
+    );
+  });
+
   it("reconstructs the legacy embedded RSC payload shape", () => {
     const html = `<script>self.__VINEXT_RSC__=${safeJsonStringify({
       rsc: ["0:legacy\n", "1:payload\n"],
@@ -129,6 +141,14 @@ describe("extractRscPayloadFromPrerenderedHtml", () => {
       status: "ok",
       payload: "0:legacy\n1:payload\n",
     });
+  });
+
+  it("rejects legacy embedded RSC payloads with invalid JSON using a Vinext error", () => {
+    const html = `<script>self.__VINEXT_RSC__={"rsc":[}</script>`;
+
+    expect(() => extractRscPayloadFromPrerenderedHtml(html)).toThrow(
+      "[vinext] Malformed legacy prerender RSC embed: invalid JSON",
+    );
   });
 
   it("uses an explicit compatibility fallback when no Vinext RSC embed exists", () => {
@@ -199,6 +219,66 @@ describe("prerenderApp — RSC extraction", () => {
       });
       expect(fs.readFileSync(path.join(outDir, "index.rsc"), "utf-8")).toBe(rscPayload);
       expect(rscRequestCount).toBe(0);
+    } finally {
+      await closeServer(server);
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to a separate RSC request when rendered HTML has no RSC markers", async () => {
+    const root = tmpDir("vinext-prerender-rsc-fallback-");
+    const outDir = path.join(root, "out");
+    const appDir = path.join(root, "app");
+    const pagePath = path.join(appDir, "page.tsx");
+    fs.mkdirSync(appDir, { recursive: true });
+    fs.writeFileSync(
+      pagePath,
+      "export const dynamic = 'force-static';\nexport default function Page() { return null; }\n",
+    );
+
+    const rscPayload = '0:["$","div",null,{"children":"from fallback"}]\n';
+    let rscRequestCount = 0;
+    const server = createServer((req, res) => {
+      if (req.headers.rsc === "1" || req.headers.accept === "text/x-component") {
+        rscRequestCount++;
+        res.setHeader("content-type", "text/x-component");
+        res.end(rscPayload);
+        return;
+      }
+
+      if (req.url === "/__vinext_nonexistent_for_404__") {
+        res.statusCode = 404;
+        res.end("<html><body>not found</body></html>");
+        return;
+      }
+
+      res.setHeader("content-type", "text/html");
+      res.end("<html><body>plain html shell</body></html>");
+    });
+
+    const port = await listen(server);
+    try {
+      const { prerenderApp } = await import("../packages/vinext/src/build/prerender.js");
+      const { appRouter } = await import("../packages/vinext/src/routing/app-router.js");
+      const { resolveNextConfig } = await import("../packages/vinext/src/config/next-config.js");
+      const routes = await appRouter(appDir);
+      const config = await resolveNextConfig({});
+
+      const prerenderResult = await prerenderApp({
+        mode: "default",
+        rscBundlePath: path.join(root, "dist", "server", "index.js"),
+        routes,
+        outDir,
+        config,
+        _prodServer: { server, port },
+      });
+
+      expect(findRoute(prerenderResult.routes, "/")).toMatchObject({
+        route: "/",
+        status: "rendered",
+      });
+      expect(fs.readFileSync(path.join(outDir, "index.rsc"), "utf-8")).toBe(rscPayload);
+      expect(rscRequestCount).toBe(1);
     } finally {
       await closeServer(server);
       fs.rmSync(root, { recursive: true, force: true });

--- a/tests/prerender.test.ts
+++ b/tests/prerender.test.ts
@@ -10,14 +10,17 @@
  */
 import { describe, it, expect, beforeAll, afterAll } from "vite-plus/test";
 import fs from "node:fs";
+import { createServer, type Server } from "node:http";
 import os from "node:os";
 import path from "node:path";
 import { buildPagesFixture, buildAppFixture, buildCloudflareAppFixture } from "./helpers.js";
 import {
+  extractRscPayloadFromPrerenderedHtml,
   resolveParentParams,
   type PrerenderRouteResult,
   type StaticParamsMap,
 } from "../packages/vinext/src/build/prerender.js";
+import { safeJsonStringify } from "../packages/vinext/src/server/html.js";
 import type { AppRoute } from "../packages/vinext/src/routing/app-router.js";
 
 const PAGES_FIXTURE = path.resolve(import.meta.dirname, "./fixtures/pages-basic");
@@ -36,6 +39,172 @@ function findRoute(
 ): PrerenderRouteResult | undefined {
   return results.find((r) => r.route === route || ("path" in r && r.path === route));
 }
+
+function listen(server: Server): Promise<number> {
+  return new Promise((resolve, reject) => {
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (typeof address === "object" && address !== null) {
+        resolve(address.port);
+      } else {
+        reject(new Error("test server did not expose a TCP port"));
+      }
+    });
+  });
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
+
+// ─── App Router RSC payload extraction ───────────────────────────────────────
+
+describe("extractRscPayloadFromPrerenderedHtml", () => {
+  it("reconstructs streamed RSC chunks from inline bootstrap scripts", () => {
+    const chunks = [
+      '0:D{"name":"layout"}\n',
+      '1:["$","div",null,{"children":"hello ) world"}]\n',
+      '2:["$","span",null,{"children":"</script><script>alert(1)</script>"}]\n',
+    ];
+    const html =
+      "<html><body>" +
+      chunks
+        .map(
+          (chunk) =>
+            "<script>self.__VINEXT_RSC_CHUNKS__=self.__VINEXT_RSC_CHUNKS__||[];" +
+            `self.__VINEXT_RSC_CHUNKS__.push(${safeJsonStringify(chunk)})</script>`,
+        )
+        .join("") +
+      "<script>self.__VINEXT_RSC_DONE__=true</script>" +
+      "</body></html>";
+
+    const result = extractRscPayloadFromPrerenderedHtml(html);
+
+    expect(result).toEqual({
+      status: "ok",
+      payload: chunks.join(""),
+    });
+  });
+
+  it("rejects incomplete streamed RSC embeds instead of falling back", () => {
+    const html =
+      "<html><body>" +
+      `<script>self.__VINEXT_RSC_CHUNKS__=self.__VINEXT_RSC_CHUNKS__||[];self.__VINEXT_RSC_CHUNKS__.push(${safeJsonStringify("0:[]\n")})</script>` +
+      "</body></html>";
+
+    expect(() => extractRscPayloadFromPrerenderedHtml(html)).toThrow(/missing __VINEXT_RSC_DONE__/);
+  });
+
+  it("does not treat marker-looking RSC payload text as the done control script", () => {
+    const html =
+      "<html><body>" +
+      `<script>self.__VINEXT_RSC_CHUNKS__=self.__VINEXT_RSC_CHUNKS__||[];self.__VINEXT_RSC_CHUNKS__.push(${safeJsonStringify('0:["__VINEXT_RSC_DONE__=true"]\n')})</script>` +
+      "</body></html>";
+
+    expect(() => extractRscPayloadFromPrerenderedHtml(html)).toThrow(/missing __VINEXT_RSC_DONE__/);
+  });
+
+  it("rejects streamed RSC chunk scripts with trailing code after the payload push", () => {
+    const html =
+      "<html><body>" +
+      `<script>self.__VINEXT_RSC_CHUNKS__=self.__VINEXT_RSC_CHUNKS__||[];self.__VINEXT_RSC_CHUNKS__.push(${safeJsonStringify("0:[]\n")})alert(1)</script>` +
+      "<script>self.__VINEXT_RSC_DONE__=true</script>" +
+      "</body></html>";
+
+    expect(() => extractRscPayloadFromPrerenderedHtml(html)).toThrow(/unexpected trailing code/);
+  });
+
+  it("reconstructs the legacy embedded RSC payload shape", () => {
+    const html = `<script>self.__VINEXT_RSC__=${safeJsonStringify({
+      rsc: ["0:legacy\n", "1:payload\n"],
+    })}</script>`;
+
+    expect(extractRscPayloadFromPrerenderedHtml(html)).toEqual({
+      status: "ok",
+      payload: "0:legacy\n1:payload\n",
+    });
+  });
+
+  it("uses an explicit compatibility fallback when no Vinext RSC embed exists", () => {
+    expect(extractRscPayloadFromPrerenderedHtml("<html><body>legacy</body></html>")).toEqual({
+      status: "fallback",
+      reason: "no recognized Vinext RSC embed markers found in HTML",
+    });
+  });
+});
+
+describe("prerenderApp — RSC extraction", () => {
+  it("writes the .rsc file from rendered HTML without a second RSC request", async () => {
+    const root = tmpDir("vinext-prerender-rsc-dedupe-");
+    const outDir = path.join(root, "out");
+    const appDir = path.join(root, "app");
+    const pagePath = path.join(appDir, "page.tsx");
+    fs.mkdirSync(appDir, { recursive: true });
+    fs.writeFileSync(
+      pagePath,
+      "export const dynamic = 'force-static';\nexport default function Page() { return null; }\n",
+    );
+
+    const rscPayload = '0:["$","div",null,{"children":"from html"}]\n';
+    let rscRequestCount = 0;
+    const server = createServer((req, res) => {
+      if (req.headers.rsc === "1" || req.headers.accept === "text/x-component") {
+        rscRequestCount++;
+        res.statusCode = 500;
+        res.end("unexpected RSC request");
+        return;
+      }
+
+      if (req.url === "/__vinext_nonexistent_for_404__") {
+        res.statusCode = 404;
+        res.end("<html><body>not found</body></html>");
+        return;
+      }
+
+      res.setHeader("content-type", "text/html");
+      res.end(
+        "<html><body>" +
+          `<script>self.__VINEXT_RSC_CHUNKS__=self.__VINEXT_RSC_CHUNKS__||[];self.__VINEXT_RSC_CHUNKS__.push(${safeJsonStringify(rscPayload)})</script>` +
+          "<script>self.__VINEXT_RSC_DONE__=true</script>" +
+          "</body></html>",
+      );
+    });
+
+    const port = await listen(server);
+    try {
+      const { prerenderApp } = await import("../packages/vinext/src/build/prerender.js");
+      const { appRouter } = await import("../packages/vinext/src/routing/app-router.js");
+      const { resolveNextConfig } = await import("../packages/vinext/src/config/next-config.js");
+      const routes = await appRouter(appDir);
+      const config = await resolveNextConfig({});
+
+      const prerenderResult = await prerenderApp({
+        mode: "default",
+        rscBundlePath: path.join(root, "dist", "server", "index.js"),
+        routes,
+        outDir,
+        config,
+        _prodServer: { server, port },
+      });
+
+      expect(findRoute(prerenderResult.routes, "/")).toMatchObject({
+        route: "/",
+        status: "rendered",
+      });
+      expect(fs.readFileSync(path.join(outDir, "index.rsc"), "utf-8")).toBe(rscPayload);
+      expect(rscRequestCount).toBe(0);
+    } finally {
+      await closeServer(server);
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
 
 // ─── Pages Router ─────────────────────────────────────────────────────────────
 

--- a/tests/prerender.test.ts
+++ b/tests/prerender.test.ts
@@ -293,6 +293,74 @@ describe("prerenderApp — RSC extraction", () => {
       fs.rmSync(root, { recursive: true, force: true });
     }
   });
+
+  it("errors without writing .rsc when the middleware short-circuit fallback RSC request fails", async () => {
+    const root = tmpDir("vinext-prerender-rsc-fallback-failure-");
+    const outDir = path.join(root, "out");
+    const appDir = path.join(root, "app");
+    const pagePath = path.join(appDir, "page.tsx");
+    fs.mkdirSync(appDir, { recursive: true });
+    fs.writeFileSync(
+      pagePath,
+      "export const dynamic = 'force-static';\nexport default function Page() { return null; }\n",
+    );
+
+    const middlewareHtml = "<html><body>middleware short-circuit</body></html>";
+    let pageRequestCount = 0;
+    let rscRequestCount = 0;
+    const server = createServer((req, res) => {
+      const isRsc = req.headers.rsc === "1" || req.headers.accept === "text/x-component";
+
+      if (req.url === "/__vinext_nonexistent_for_404__") {
+        res.statusCode = 404;
+        res.end("<html><body>not found</body></html>");
+        return;
+      }
+
+      if (isRsc) {
+        rscRequestCount++;
+        res.statusCode = 500;
+        res.end("fallback failed");
+        return;
+      }
+
+      pageRequestCount++;
+      res.setHeader("content-type", "text/html");
+      res.end(middlewareHtml);
+    });
+
+    const port = await listen(server);
+    try {
+      const { prerenderApp } = await import("../packages/vinext/src/build/prerender.js");
+      const { appRouter } = await import("../packages/vinext/src/routing/app-router.js");
+      const { resolveNextConfig } = await import("../packages/vinext/src/config/next-config.js");
+      const routes = await appRouter(appDir);
+      const config = await resolveNextConfig({});
+
+      const prerenderResult = await prerenderApp({
+        mode: "default",
+        rscBundlePath: path.join(root, "dist", "server", "index.js"),
+        routes,
+        outDir,
+        config,
+        _prodServer: { server, port },
+      });
+
+      const route = findRoute(prerenderResult.routes, "/");
+      expect(route).toMatchObject({
+        route: "/",
+        status: "error",
+      });
+      if (route?.status !== "error") throw new Error("expected route to fail prerender");
+      expect(route.error).toContain("[vinext] prerenderApp: RSC fallback returned 500 for /");
+      expect(fs.existsSync(path.join(outDir, "index.rsc"))).toBe(false);
+      expect(pageRequestCount).toBe(1);
+      expect(rscRequestCount).toBe(1);
+    } finally {
+      await closeServer(server);
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
 });
 
 // ─── Pages Router ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What this changes
App Router prerender now reconstructs the canonical `.rsc` payload from the streamed RSC chunk scripts already embedded in the prerendered HTML response. When extraction succeeds, prerender avoids the previous second `RSC: 1` handler invocation.

## Why
The prerender pipeline already renders HTML first, and that HTML includes streamed Flight chunks for hydration. Reusing those chunks avoids duplicate App Router work during static output generation.

## Approach
- Parse Vinext's modern streamed RSC chunk protocol: `self.__VINEXT_RSC_CHUNKS__...push(<safeJsonStringify(chunk)>)` plus `self.__VINEXT_RSC_DONE__=true`.
- Preserve the HTML-safe JSON encoding semantics used by `createRscEmbedTransform`.
- Fall back to a second `RSC: 1` request only when HTML has no RSC chunk scripts at all, which covers middleware/custom HTML responses that bypass the App Router HTML stream.
- Treat partial or malformed embeds as errors instead of silently falling back.
- Fail the route when the fallback RSC request returns a non-OK response so prerender never writes an empty or corrupt `.rsc` artifact.

## Validation
- `vp test run tests/prerender.test.ts -t "RSC extraction|middleware short-circuit fallback RSC request fails|falls back to a second RSC"`
- `vp check tests/prerender.test.ts packages/vinext/src/build/prerender.ts`
- Commit hook `vp check --fix` plus `knip --no-progress`

## Notes
- This extractor intentionally targets the current modern chunk/done protocol; legacy browser bootstrap support is not part of the prerender extractor.
- `tests/app-elements.test.ts` was updated to include `artifactCompatibility` after merging current `main` so CI matches the current AppElements metadata contract.
- Full test suite was not run locally.

Refs #563