### PR TITLE
fix(deploy): resolve wrangler .CMD shim on Windows

### DIFF
--- a/packages/vinext/src/deploy.ts
+++ b/packages/vinext/src/deploy.ts
@@ -1218,12 +1218,37 @@ export function buildWranglerDeployArgs(
   return { args, env };
 }
 
+/**
+ * Resolve the wrangler executable in node_modules.
+ *
+ * Walks up ancestor directories so the binary is found even when node_modules
+ * is hoisted to the workspace root in a monorepo.
+ *
+ * On Windows, `node_modules/.bin/` contains both a Unix shebang script (no
+ * extension) and a `.CMD` shim. Node's `execFileSync` uses CreateProcess(),
+ * which only resolves PATHEXT extensions (`.cmd`, `.exe`, ...) — spawning the
+ * bare-name shebang file fails with ENOENT even though the file exists. So on
+ * Windows we prefer the `.CMD` shim and only fall back to the bare name for a
+ * clearer error message if neither is present.
+ */
+export function resolveWranglerBin(
+  root: string,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  const candidates =
+    platform === "win32" ? [".bin/wrangler.CMD", ".bin/wrangler"] : [".bin/wrangler"];
+
+  for (const candidate of candidates) {
+    const found = _findInNodeModules(root, candidate);
+    if (found) return found;
+  }
+
+  // Not found — return platform-appropriate path under root for error clarity.
+  return path.join(root, "node_modules", ...candidates[0].split("/"));
+}
+
 function runWranglerDeploy(root: string, options: Pick<DeployOptions, "preview" | "env">): string {
-  // Walk up ancestor directories so the binary is found even when node_modules
-  // is hoisted to the workspace root in a monorepo.
-  const wranglerBin =
-    _findInNodeModules(root, ".bin/wrangler") ??
-    path.join(root, "node_modules", ".bin", "wrangler"); // fallback for error message clarity
+  const wranglerBin = resolveWranglerBin(root);
 
   const execOpts: ExecSyncOptions = {
     cwd: root,

--- a/packages/vinext/src/deploy.ts
+++ b/packages/vinext/src/deploy.ts
@@ -1236,7 +1236,7 @@ export function resolveWranglerBin(
   platform: NodeJS.Platform = process.platform,
 ): string {
   const candidates =
-    platform === "win32" ? [".bin/wrangler.CMD", ".bin/wrangler"] : [".bin/wrangler"];
+    platform === "win32" ? [".bin/wrangler.CMD", ".bin/wrangler.cmd", ".bin/wrangler"] : [".bin/wrangler"];
 
   for (const candidate of candidates) {
     const found = _findInNodeModules(root, candidate);

--- a/packages/vinext/src/deploy.ts
+++ b/packages/vinext/src/deploy.ts
@@ -1236,7 +1236,9 @@ export function resolveWranglerBin(
   platform: NodeJS.Platform = process.platform,
 ): string {
   const candidates =
-    platform === "win32" ? [".bin/wrangler.CMD", ".bin/wrangler.cmd", ".bin/wrangler"] : [".bin/wrangler"];
+    platform === "win32"
+      ? [".bin/wrangler.CMD", ".bin/wrangler.cmd", ".bin/wrangler"]
+      : [".bin/wrangler"];
 
   for (const candidate of candidates) {
     const found = _findInNodeModules(root, candidate);

--- a/tests/app-elements.test.ts
+++ b/tests/app-elements.test.ts
@@ -158,6 +158,7 @@ describe("AppElementsWire", () => {
     if (!isAppElementsRecord(payload)) return;
 
     expect(AppElementsWire.readMetadata(payload)).toEqual({
+      artifactCompatibility: createArtifactCompatibilityEnvelope(),
       interceptionContext: null,
       layoutFlags: { [AppElementsWire.encodeLayoutId("/")]: "s" },
       rootLayoutTreePath: "/",

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -15,6 +15,7 @@ import {
   renameCJSConfigs,
   buildWranglerDeployArgs,
   parseDeployArgs,
+  resolveWranglerBin,
   isPackageResolvable,
   viteConfigHasCloudflarePlugin,
   hasWranglerConfig,
@@ -92,6 +93,53 @@ describe("buildWranglerDeployArgs", () => {
 
   it("treats empty string env as production", () => {
     expect(buildWranglerDeployArgs({ env: "" })).toEqual({ args: ["deploy"], env: undefined });
+  });
+});
+
+// ─── Wrangler bin resolution (Windows shim handling) ────────────────────────
+
+describe("resolveWranglerBin", () => {
+  it("uses bare name on non-Windows platforms", () => {
+    mkdir(tmpDir, "node_modules/.bin");
+    writeFile(tmpDir, "node_modules/.bin/wrangler", "#!/usr/bin/env node");
+
+    const resolved = resolveWranglerBin(tmpDir, "linux");
+    expect(resolved).toBe(path.join(tmpDir, "node_modules", ".bin", "wrangler"));
+  });
+
+  it("prefers .CMD shim on Windows when present", () => {
+    mkdir(tmpDir, "node_modules/.bin");
+    writeFile(tmpDir, "node_modules/.bin/wrangler", "#!/usr/bin/env node");
+    writeFile(tmpDir, "node_modules/.bin/wrangler.CMD", "@ECHO off");
+
+    const resolved = resolveWranglerBin(tmpDir, "win32");
+    expect(resolved).toBe(path.join(tmpDir, "node_modules", ".bin", "wrangler.CMD"));
+  });
+
+  it("falls back to bare name on Windows if no .CMD shim exists", () => {
+    mkdir(tmpDir, "node_modules/.bin");
+    writeFile(tmpDir, "node_modules/.bin/wrangler", "#!/usr/bin/env node");
+
+    const resolved = resolveWranglerBin(tmpDir, "win32");
+    expect(resolved).toBe(path.join(tmpDir, "node_modules", ".bin", "wrangler"));
+  });
+
+  it("walks up to a hoisted workspace node_modules on Windows", () => {
+    mkdir(tmpDir, "apps/web");
+    mkdir(tmpDir, "node_modules/.bin");
+    writeFile(tmpDir, "node_modules/.bin/wrangler.CMD", "@ECHO off");
+
+    const resolved = resolveWranglerBin(path.join(tmpDir, "apps", "web"), "win32");
+    expect(resolved).toBe(path.join(tmpDir, "node_modules", ".bin", "wrangler.CMD"));
+  });
+
+  it("returns platform-appropriate fallback path when nothing is found", () => {
+    expect(resolveWranglerBin(tmpDir, "win32")).toBe(
+      path.join(tmpDir, "node_modules", ".bin", "wrangler.CMD"),
+    );
+    expect(resolveWranglerBin(tmpDir, "linux")).toBe(
+      path.join(tmpDir, "node_modules", ".bin", "wrangler"),
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #1095 — `vinext deploy` on Windows fails with `spawnSync wrangler ENOENT` because `runWranglerDeploy` invokes the bare-name `node_modules/.bin/wrangler` file. On Windows that file is a Unix shebang script with no PATHEXT extension, so `CreateProcess()` (used by `execFileSync`) refuses to execute it. The `.CMD` shim sitting next to it is the actual Windows-executable.

## Change

- Extract `resolveWranglerBin(root, platform?)` from `runWranglerDeploy`.
- On `win32` prefer `.bin/wrangler.CMD`, fall back to `.bin/wrangler` (covers oddball PMs that don't generate a `.CMD` shim).
- On other platforms behavior is unchanged: `.bin/wrangler` only.
- The unfound-fallback path is also platform-appropriate so the resulting ENOENT error message points at the actual file Node would have tried to spawn.
- `platform` is an injected parameter (defaulting to `process.platform`) so the helper is unit-testable without mutating globals.

Considered Option 2 (`cross-spawn`) and Option 3 (`shell: true`) from the bug report. Option 1 keeps the dep surface unchanged and matches the issue tracker's recommendation; happy to switch to `cross-spawn` if maintainers prefer.

## Tests

Five new cases in `tests/deploy.test.ts → describe("resolveWranglerBin")`:

- non-Windows uses bare name
- Windows prefers `.CMD` when both files exist
- Windows falls back to bare name when no `.CMD` exists
- monorepo hoisting works on Windows (walks up to ancestor `node_modules`)
- not-found fallback path is platform-appropriate

`pnpm test tests/deploy.test.ts` — 215 passed (210 existing + 5 new).
`pnpm exec vp check packages/vinext/src/deploy.ts tests/deploy.test.ts` — clean (formatting, lint, types).

## Test plan

- [x] Targeted Vitest run on `tests/deploy.test.ts` passes (Windows 11, Node 24.13.0, pnpm 10)
- [x] `vp check` clean on changed files
- [x] Manual verification on the original reproducer (Next.js 15 App Router on pnpm Turborepo workspace): `vinext deploy --preview` now invokes wrangler successfully on Windows
- [ ] CI Linux/macOS runs (regression check: bare name still resolves)
- [ ] If a Windows runner exists or gets added (issue mentions one was added in #31), exercising `vinext deploy --dry-run` there would catch any future regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)