### PR TITLE
feat(app-router): trace approved visible commit outcomes

### DIFF
--- a/packages/vinext/src/server/app-browser-state.ts
+++ b/packages/vinext/src/server/app-browser-state.ts
@@ -1,4 +1,3 @@
-import { mergeElements } from "vinext/shims/slot";
 import { stripBasePath } from "../utils/base-path.js";
 import {
   AppElementsWire,
@@ -112,7 +111,7 @@ export function readHistoryStatePreviousNextUrl(state: unknown): string | null {
   return typeof value === "string" ? value : null;
 }
 
-export function createOperationRecord(options: {
+function createOperationRecord(options: {
   id: number;
   lane: OperationLane;
   startedVisibleCommitVersion: number;
@@ -122,19 +121,6 @@ export function createOperationRecord(options: {
     lane: options.lane,
     startedVisibleCommitVersion: options.startedVisibleCommitVersion,
     state: "pending",
-  };
-}
-
-function commitOperationRecord(
-  operation: PendingOperationRecord,
-  visibleCommitVersion: number,
-): CommittedOperationRecord {
-  return {
-    id: operation.id,
-    lane: operation.lane,
-    startedVisibleCommitVersion: operation.startedVisibleCommitVersion,
-    state: "committed",
-    visibleCommitVersion,
   };
 }
 
@@ -192,73 +178,6 @@ export function resolveServerActionRequestState(
   }
 
   return { headers };
-}
-
-type AppRouterStateWithoutCommitMetadata = {
-  elements: AppElements;
-  interceptionContext: string | null;
-  layoutFlags: LayoutFlags;
-  navigationSnapshot: ClientNavigationRenderSnapshot;
-  previousNextUrl: string | null;
-  renderId: number;
-  rootLayoutTreePath: string | null;
-  routeId: string;
-};
-
-function commitVisibleRouterState(
-  state: AppRouterState,
-  nextState: AppRouterStateWithoutCommitMetadata,
-  operation: PendingOperationRecord,
-): AppRouterState {
-  // Advances when the browser router accepts a new visible router-state commit.
-  // This is the lifecycle baseline used to reject stale async results; it is
-  // not a React DOM paint signal.
-  const visibleCommitVersion = state.visibleCommitVersion + 1;
-  return {
-    ...nextState,
-    activeOperation: commitOperationRecord(operation, visibleCommitVersion),
-    visibleCommitVersion,
-  };
-}
-
-export function routerReducer(state: AppRouterState, action: AppRouterAction): AppRouterState {
-  switch (action.type) {
-    case "traverse":
-    case "navigate":
-      return commitVisibleRouterState(
-        state,
-        {
-          elements: mergeElements(state.elements, action.elements, action.type === "traverse"),
-          interceptionContext: action.interceptionContext,
-          layoutFlags: { ...state.layoutFlags, ...action.layoutFlags },
-          navigationSnapshot: action.navigationSnapshot,
-          previousNextUrl: action.previousNextUrl,
-          renderId: action.renderId,
-          rootLayoutTreePath: action.rootLayoutTreePath,
-          routeId: action.routeId,
-        },
-        action.operation,
-      );
-    case "replace":
-      return commitVisibleRouterState(
-        state,
-        {
-          elements: action.elements,
-          interceptionContext: action.interceptionContext,
-          layoutFlags: action.layoutFlags,
-          navigationSnapshot: action.navigationSnapshot,
-          previousNextUrl: action.previousNextUrl,
-          renderId: action.renderId,
-          rootLayoutTreePath: action.rootLayoutTreePath,
-          routeId: action.routeId,
-        },
-        action.operation,
-      );
-    default: {
-      const _exhaustive: never = action.type;
-      throw new Error("[vinext] Unknown router action: " + String(_exhaustive));
-    }
-  }
 }
 
 export function shouldHardNavigate(

--- a/packages/vinext/src/server/app-browser-visible-commit.ts
+++ b/packages/vinext/src/server/app-browser-visible-commit.ts
@@ -1,18 +1,24 @@
 import type { ClientNavigationRenderSnapshot } from "vinext/shims/navigation";
+import { mergeElements } from "vinext/shims/slot";
 import type { AppElements } from "./app-elements.js";
 import {
   createPendingNavigationCommit,
   resolvePendingNavigationCommitDispositionDecision,
-  routerReducer,
   type AppRouterAction,
   type AppRouterState,
+  type CommittedOperationRecord,
   type OperationLane,
   type PendingNavigationCommit,
+  type PendingOperationRecord,
 } from "./app-browser-state.js";
 import {
   NavigationTraceReasonCodes,
+  NavigationTraceTransactionCodes,
   createNavigationTrace,
+  prependNavigationTraceEntry,
   type NavigationTrace,
+  type NavigationTraceFields,
+  type NavigationTraceTransactionCode,
 } from "./navigation-trace.js";
 
 type VisibleCommitDecision = {
@@ -58,7 +64,85 @@ export function applyApprovedVisibleCommit(
   state: AppRouterState,
   commit: ApprovedVisibleCommit,
 ): AppRouterState {
-  return routerReducer(state, commit.action);
+  assertApprovedVisibleCommit(commit);
+  return reduceApprovedVisibleCommitState(state, commit.action);
+}
+
+function assertApprovedVisibleCommit(commit: ApprovedVisibleCommit): void {
+  if (commit[approvedVisibleCommitBrand] !== true) {
+    throw new Error("[vinext] Visible router state mutation requires ApprovedVisibleCommit");
+  }
+}
+
+function commitOperationRecord(
+  operation: PendingOperationRecord,
+  visibleCommitVersion: number,
+): CommittedOperationRecord {
+  return {
+    id: operation.id,
+    lane: operation.lane,
+    startedVisibleCommitVersion: operation.startedVisibleCommitVersion,
+    state: "committed",
+    visibleCommitVersion,
+  };
+}
+
+function commitVisibleRouterState(
+  state: AppRouterState,
+  nextState: Omit<AppRouterState, "activeOperation" | "visibleCommitVersion">,
+  operation: PendingOperationRecord,
+): AppRouterState {
+  // Single owner for visibleCommitVersion: only an ApprovedVisibleCommit may
+  // advance it, and every accepted visible mutation advances it exactly once.
+  const visibleCommitVersion = state.visibleCommitVersion + 1;
+  return {
+    ...nextState,
+    activeOperation: commitOperationRecord(operation, visibleCommitVersion),
+    visibleCommitVersion,
+  };
+}
+
+function reduceApprovedVisibleCommitState(
+  state: AppRouterState,
+  action: AppRouterAction,
+): AppRouterState {
+  switch (action.type) {
+    case "traverse":
+    case "navigate":
+      return commitVisibleRouterState(
+        state,
+        {
+          elements: mergeElements(state.elements, action.elements, action.type === "traverse"),
+          interceptionContext: action.interceptionContext,
+          layoutFlags: { ...state.layoutFlags, ...action.layoutFlags },
+          navigationSnapshot: action.navigationSnapshot,
+          previousNextUrl: action.previousNextUrl,
+          renderId: action.renderId,
+          rootLayoutTreePath: action.rootLayoutTreePath,
+          routeId: action.routeId,
+        },
+        action.operation,
+      );
+    case "replace":
+      return commitVisibleRouterState(
+        state,
+        {
+          elements: action.elements,
+          interceptionContext: action.interceptionContext,
+          layoutFlags: action.layoutFlags,
+          navigationSnapshot: action.navigationSnapshot,
+          previousNextUrl: action.previousNextUrl,
+          renderId: action.renderId,
+          rootLayoutTreePath: action.rootLayoutTreePath,
+          routeId: action.routeId,
+        },
+        action.operation,
+      );
+    default: {
+      const _exhaustive: never = action.type;
+      throw new Error("[vinext] Unknown router action: " + String(_exhaustive));
+    }
+  }
 }
 
 function resolvePendingNavigationCommitDecision(options: {
@@ -106,13 +190,76 @@ function createApprovedVisibleCommit(options: {
   };
 }
 
+function createCommitTransactionFields(pending: PendingNavigationCommit): NavigationTraceFields {
+  return {
+    operationLane: pending.action.operation.lane,
+    pendingOperationId: pending.action.operation.id,
+    startedVisibleCommitVersion: pending.action.operation.startedVisibleCommitVersion,
+  };
+}
+
+function prependCommitTransactionTrace(
+  trace: NavigationTrace,
+  code: NavigationTraceTransactionCode,
+  pending: PendingNavigationCommit,
+): NavigationTrace {
+  return prependNavigationTraceEntry(trace, code, createCommitTransactionFields(pending));
+}
+
+function addCommitTransactionTrace(
+  decision: CommitDecision,
+  pending: PendingNavigationCommit,
+): CommitDecision {
+  switch (decision.disposition) {
+    case "commit":
+      return {
+        ...decision,
+        trace: prependCommitTransactionTrace(
+          decision.trace,
+          NavigationTraceTransactionCodes.visibleCommit,
+          pending,
+        ),
+      };
+    case "hard-navigate":
+      return {
+        ...decision,
+        trace: prependCommitTransactionTrace(
+          decision.trace,
+          NavigationTraceTransactionCodes.hardNavigate,
+          pending,
+        ),
+      };
+    case "no-commit":
+      return {
+        ...decision,
+        trace: prependCommitTransactionTrace(
+          decision.trace,
+          NavigationTraceTransactionCodes.noCommit,
+          pending,
+        ),
+      };
+    default: {
+      const _exhaustive: never = decision;
+      throw new Error("[vinext] Unknown commit decision: " + String(_exhaustive));
+    }
+  }
+}
+
 export function approveHmrVisibleCommit(pending: PendingNavigationCommit): ApprovedVisibleCommit {
   if (pending.action.operation.lane !== "hmr") {
     throw new Error("[vinext] HMR visible commit approval requires an HMR pending operation");
   }
 
+  const decision = addCommitTransactionTrace(createVisibleCommitDecision(), pending);
+  // This guard is a type narrowing assertion: createVisibleCommitDecision()
+  // structurally produces a commit decision, and addCommitTransactionTrace()
+  // must preserve that disposition while adding operator trace context.
+  if (decision.disposition !== "commit") {
+    throw new Error("[vinext] HMR visible commit approval did not produce a commit decision");
+  }
+
   return createApprovedVisibleCommit({
-    decision: createVisibleCommitDecision(),
+    decision,
     pending,
   });
 }
@@ -123,14 +270,17 @@ export function approvePendingNavigationCommit(options: {
   pending: PendingNavigationCommit;
   startedNavigationId: number;
 }): CommitApproval {
-  const decision = resolvePendingNavigationCommitDecision({
-    activeNavigationId: options.activeNavigationId,
-    currentVisibleCommitVersion: options.currentState.visibleCommitVersion,
-    currentRootLayoutTreePath: options.currentState.rootLayoutTreePath,
-    nextRootLayoutTreePath: options.pending.rootLayoutTreePath,
-    startedNavigationId: options.startedNavigationId,
-    startedVisibleCommitVersion: options.pending.action.operation.startedVisibleCommitVersion,
-  });
+  const decision = addCommitTransactionTrace(
+    resolvePendingNavigationCommitDecision({
+      activeNavigationId: options.activeNavigationId,
+      currentVisibleCommitVersion: options.currentState.visibleCommitVersion,
+      currentRootLayoutTreePath: options.currentState.rootLayoutTreePath,
+      nextRootLayoutTreePath: options.pending.rootLayoutTreePath,
+      startedNavigationId: options.startedNavigationId,
+      startedVisibleCommitVersion: options.pending.action.operation.startedVisibleCommitVersion,
+    }),
+    options.pending,
+  );
 
   switch (decision.disposition) {
     case "commit":

--- a/packages/vinext/src/server/navigation-trace.ts
+++ b/packages/vinext/src/server/navigation-trace.ts
@@ -14,13 +14,31 @@ export const NavigationTraceReasonCodes = {
   staleOperation: "NC_STALE";
 }>;
 
+export const NavigationTraceTransactionCodes = {
+  hardNavigate: "NT_HARD_NAVIGATE",
+  noCommit: "NT_NO_COMMIT",
+  visibleCommit: "NT_VISIBLE_COMMIT",
+} satisfies Readonly<{
+  hardNavigate: "NT_HARD_NAVIGATE";
+  noCommit: "NT_NO_COMMIT";
+  visibleCommit: "NT_VISIBLE_COMMIT";
+}>;
+
 export type NavigationTraceReasonCode =
   (typeof NavigationTraceReasonCodes)[keyof typeof NavigationTraceReasonCodes];
+
+export type NavigationTraceTransactionCode =
+  (typeof NavigationTraceTransactionCodes)[keyof typeof NavigationTraceTransactionCodes];
+
+export type NavigationTraceCode = NavigationTraceReasonCode | NavigationTraceTransactionCode;
 
 export type NavigationTraceFieldName =
   | "activeNavigationId"
   | "currentRootLayoutTreePath"
   | "nextRootLayoutTreePath"
+  | "operationLane"
+  | "pendingOperationId"
+  | "startedVisibleCommitVersion"
   | "startedNavigationId";
 
 export type NavigationTraceFieldValue = string | number | boolean | null;
@@ -30,7 +48,7 @@ export type NavigationTraceFields = Readonly<
 >;
 
 export type NavigationTraceEntry = Readonly<{
-  code: NavigationTraceReasonCode;
+  code: NavigationTraceCode;
   fields: NavigationTraceFields;
 }>;
 
@@ -40,7 +58,7 @@ export type NavigationTrace = Readonly<{
 }>;
 
 function createNavigationTraceEntry(
-  code: NavigationTraceReasonCode,
+  code: NavigationTraceCode,
   fields: NavigationTraceFields = {},
 ): NavigationTraceEntry {
   return {
@@ -50,11 +68,22 @@ function createNavigationTraceEntry(
 }
 
 export function createNavigationTrace(
-  code: NavigationTraceReasonCode,
+  code: NavigationTraceCode,
   fields: NavigationTraceFields = {},
 ): NavigationTrace {
   return {
     schemaVersion: NAVIGATION_TRACE_SCHEMA_VERSION,
     entries: [createNavigationTraceEntry(code, fields)],
+  };
+}
+
+export function prependNavigationTraceEntry(
+  trace: NavigationTrace,
+  code: NavigationTraceCode,
+  fields: NavigationTraceFields = {},
+): NavigationTrace {
+  return {
+    schemaVersion: trace.schemaVersion,
+    entries: [createNavigationTraceEntry(code, fields), ...trace.entries],
   };
 }

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -5,6 +5,7 @@ import { createAppBrowserNavigationController } from "../packages/vinext/src/ser
 import { devOnCaughtError } from "../packages/vinext/src/server/dev-error-overlay.js";
 import {
   APP_INTERCEPTION_CONTEXT_KEY,
+  APP_LAYOUT_FLAGS_KEY,
   APP_ROOT_LAYOUT_KEY,
   APP_ROUTE_KEY,
   UNMATCHED_SLOT,
@@ -17,16 +18,15 @@ import { createClientNavigationRenderSnapshot } from "../packages/vinext/src/shi
 import * as navigationShim from "../packages/vinext/src/shims/navigation.js";
 import {
   createHistoryStateWithPreviousNextUrl,
-  createOperationRecord,
   createPendingNavigationCommit,
   readHistoryStatePreviousNextUrl,
   resolveInterceptionContextFromPreviousNextUrl,
   resolveServerActionRequestState,
-  routerReducer,
   resolvePendingNavigationCommitDisposition,
   resolvePendingNavigationCommitDispositionDecision,
   shouldHardNavigate,
   type AppRouterState,
+  type OperationLane,
 } from "../packages/vinext/src/server/app-browser-state.js";
 import {
   applyApprovedVisibleCommit,
@@ -37,6 +37,7 @@ import {
 import {
   NAVIGATION_TRACE_SCHEMA_VERSION,
   NavigationTraceReasonCodes,
+  NavigationTraceTransactionCodes,
   createNavigationTrace,
 } from "../packages/vinext/src/server/navigation-trace.js";
 
@@ -70,17 +71,6 @@ function createState(overrides: Partial<AppRouterState> = {}): AppRouterState {
   };
 }
 
-function createTestOperation(
-  state: AppRouterState,
-  id = 1,
-): ReturnType<typeof createOperationRecord> {
-  return createOperationRecord({
-    id,
-    lane: "navigation",
-    startedVisibleCommitVersion: state.visibleCommitVersion,
-  });
-}
-
 function createControllerHarness(initialState: AppRouterState = createState()) {
   const controller = createAppBrowserNavigationController();
   const stateRef: { current: AppRouterState } = { current: initialState };
@@ -97,6 +87,59 @@ function createControllerHarness(initialState: AppRouterState = createState()) {
     setBrowserRouterState,
     stateRef,
   };
+}
+
+type ApprovedTestCommitOptions = {
+  activeNavigationId?: number;
+  extraEntries?: Record<string, unknown>;
+  interceptionContext?: string | null;
+  layoutFlags?: AppRouterState["layoutFlags"];
+  navigationSnapshot?: AppRouterState["navigationSnapshot"];
+  operationLane?: OperationLane;
+  previousNextUrl?: string | null;
+  renderId?: number;
+  rootLayoutTreePath: string | null;
+  routeId: string;
+  startedNavigationId?: number;
+  type?: "navigate" | "replace" | "traverse";
+};
+
+async function applyApprovedTestCommit(
+  state: AppRouterState,
+  options: ApprovedTestCommitOptions,
+): Promise<AppRouterState> {
+  const pending = await createPendingNavigationCommit({
+    currentState: state,
+    nextElements: Promise.resolve(
+      createResolvedElements(
+        options.routeId,
+        options.rootLayoutTreePath,
+        options.interceptionContext ?? null,
+        {
+          [APP_LAYOUT_FLAGS_KEY]: options.layoutFlags ?? {},
+          ...options.extraEntries,
+        },
+      ),
+    ),
+    navigationSnapshot: options.navigationSnapshot ?? state.navigationSnapshot,
+    operationLane: options.operationLane ?? "navigation",
+    previousNextUrl: options.previousNextUrl,
+    renderId: options.renderId ?? 1,
+    type: options.type ?? "navigate",
+  });
+  const activeNavigationId = options.activeNavigationId ?? 1;
+  const approval = approvePendingNavigationCommit({
+    activeNavigationId,
+    currentState: state,
+    pending,
+    startedNavigationId: options.startedNavigationId ?? activeNavigationId,
+  });
+
+  if (approval.approvedCommit === null) {
+    throw new Error("Expected approved visible commit");
+  }
+
+  return applyApprovedVisibleCommit(state, approval.approvedCommit);
 }
 
 function stubWindow(href: string) {
@@ -131,28 +174,20 @@ describe("app browser entry state helpers", () => {
     });
   });
 
-  it("merges elements on navigate", async () => {
+  it("merges elements on approved navigate commits", async () => {
     const previousElements = createResolvedElements("route:/initial", "/", null, {
       "layout:/": React.createElement("div", null, "layout"),
-    });
-    const nextElements = createResolvedElements("route:/next", "/", null, {
-      "page:/next": React.createElement("main", null, "next"),
     });
     const state = createState({
       elements: previousElements,
     });
 
-    const nextState = routerReducer(state, {
-      elements: nextElements,
-      interceptionContext: null,
-      layoutFlags: {},
-      navigationSnapshot: createState().navigationSnapshot,
-      operation: createTestOperation(state),
-      previousNextUrl: null,
-      renderId: 1,
+    const nextState = await applyApprovedTestCommit(state, {
+      extraEntries: {
+        "page:/next": React.createElement("main", null, "next"),
+      },
       rootLayoutTreePath: "/",
       routeId: "route:/next",
-      type: "navigate",
     });
 
     expect(nextState.routeId).toBe("route:/next");
@@ -173,24 +208,31 @@ describe("app browser entry state helpers", () => {
     });
   });
 
-  it("replaces elements on replace", () => {
+  it("replaces elements on approved replace commits", async () => {
     const nextElements = createResolvedElements("route:/next", "/", null, {
       "page:/next": React.createElement("main", null, "next"),
     });
 
     const state = createState();
-    const nextState = routerReducer(state, {
-      elements: nextElements,
-      interceptionContext: null,
-      layoutFlags: {},
-      navigationSnapshot: createState().navigationSnapshot,
-      operation: createTestOperation(state),
-      previousNextUrl: null,
+    const pending = await createPendingNavigationCommit({
+      currentState: state,
+      nextElements: Promise.resolve(nextElements),
+      navigationSnapshot: state.navigationSnapshot,
+      operationLane: "navigation",
       renderId: 1,
-      rootLayoutTreePath: "/",
-      routeId: "route:/next",
       type: "replace",
     });
+    const approval = approvePendingNavigationCommit({
+      activeNavigationId: 1,
+      currentState: state,
+      pending,
+      startedNavigationId: 1,
+    });
+    if (approval.approvedCommit === null) {
+      throw new Error("Expected approved visible commit");
+    }
+
+    const nextState = applyApprovedVisibleCommit(state, approval.approvedCommit);
 
     expect(nextState.elements).toBe(nextElements);
     expect(nextState.interceptionContext).toBeNull();
@@ -200,31 +242,17 @@ describe("app browser entry state helpers", () => {
     });
   });
 
-  it("increments the visible commit version once per visible reducer commit", () => {
+  it("increments the visible commit version once per approved visible commit", async () => {
     const initialState = createState();
-    const firstState = routerReducer(initialState, {
-      elements: createResolvedElements("route:/one", "/"),
-      interceptionContext: null,
-      layoutFlags: {},
-      navigationSnapshot: initialState.navigationSnapshot,
-      operation: createTestOperation(initialState, 101),
-      previousNextUrl: null,
-      renderId: 1,
+    const firstState = await applyApprovedTestCommit(initialState, {
+      renderId: 101,
       rootLayoutTreePath: "/",
       routeId: "route:/one",
-      type: "navigate",
     });
-    const secondState = routerReducer(firstState, {
-      elements: createResolvedElements("route:/two", "/"),
-      interceptionContext: null,
-      layoutFlags: {},
-      navigationSnapshot: firstState.navigationSnapshot,
-      operation: createTestOperation(firstState, 102),
-      previousNextUrl: null,
-      renderId: 2,
+    const secondState = await applyApprovedTestCommit(firstState, {
+      renderId: 102,
       rootLayoutTreePath: "/",
       routeId: "route:/two",
-      type: "navigate",
     });
 
     expect(firstState.visibleCommitVersion).toBe(1);
@@ -235,6 +263,12 @@ describe("app browser entry state helpers", () => {
       state: "committed",
       visibleCommitVersion: 2,
     });
+  });
+
+  it("does not export a raw visible state reducer outside the approved commit boundary", async () => {
+    const stateModule = await import("../packages/vinext/src/server/app-browser-state.js");
+
+    expect(Object.hasOwn(stateModule, "routerReducer")).toBe(false);
   });
 
   it("carries interception context through pending navigation commits", async () => {
@@ -368,7 +402,17 @@ describe("app browser entry state helpers", () => {
       state: "pending",
     });
 
-    const committedState = routerReducer(currentState, pending.action);
+    const approval = approvePendingNavigationCommit({
+      activeNavigationId: 1,
+      currentState,
+      pending,
+      startedNavigationId: 1,
+    });
+    if (approval.approvedCommit === null) {
+      throw new Error("Expected approved visible commit");
+    }
+
+    const committedState = applyApprovedVisibleCommit(currentState, approval.approvedCommit);
     expect(committedState.visibleCommitVersion).toBe(5);
     expect(committedState.activeOperation).toEqual({
       id: 9,
@@ -557,6 +601,27 @@ describe("app browser entry state helpers", () => {
     if (approval.approvedCommit === null) {
       throw new Error("Expected approved visible commit");
     }
+    expect(approval.decision.trace.entries).toEqual([
+      {
+        code: NavigationTraceTransactionCodes.visibleCommit,
+        fields: {
+          operationLane: "navigation",
+          pendingOperationId: 11,
+          startedVisibleCommitVersion: 0,
+        },
+      },
+      {
+        code: NavigationTraceReasonCodes.commitCurrent,
+        fields: {
+          activeNavigationId: 4,
+          currentRootLayoutTreePath: "/",
+          currentVisibleCommitVersion: 0,
+          nextRootLayoutTreePath: "/",
+          startedNavigationId: 4,
+          startedVisibleCommitVersion: 0,
+        },
+      },
+    ]);
 
     const nextState = applyApprovedVisibleCommit(currentState, approval.approvedCommit);
     expect(nextState.routeId).toBe("route:/dashboard");
@@ -568,6 +633,34 @@ describe("app browser entry state helpers", () => {
       state: "committed",
       visibleCommitVersion: 1,
     });
+  });
+
+  it("traces unknown root-layout approval as a visible commit with an uncertainty reason", async () => {
+    const currentState = createState();
+    const pending = await createPendingNavigationCommit({
+      currentState,
+      nextElements: Promise.resolve(createResolvedElements("route:/legacy-payload", null)),
+      navigationSnapshot: currentState.navigationSnapshot,
+      operationLane: "navigation",
+      renderId: 16,
+      type: "navigate",
+    });
+
+    const approval = approvePendingNavigationCommit({
+      activeNavigationId: 6,
+      currentState,
+      pending,
+      startedNavigationId: 6,
+    });
+
+    expect(approval.decision.disposition).toBe("commit");
+    expect(approval.decision.trace.entries[0]?.code).toBe(
+      NavigationTraceTransactionCodes.visibleCommit,
+    );
+    expect(approval.decision.trace.entries[1]?.code).toBe(
+      NavigationTraceReasonCodes.rootBoundaryUnknown,
+    );
+    expect(approval.approvedCommit).not.toBeNull();
   });
 
   it("approves HMR visible commits through a named trusted recovery path", async () => {
@@ -586,6 +679,14 @@ describe("app browser entry state helpers", () => {
     });
 
     const approvedCommit = approveHmrVisibleCommit(pending);
+    expect(approvedCommit.decision.trace.entries[0]).toEqual({
+      code: NavigationTraceTransactionCodes.visibleCommit,
+      fields: {
+        operationLane: "hmr",
+        pendingOperationId: 14,
+        startedVisibleCommitVersion: 0,
+      },
+    });
     const nextState = applyApprovedVisibleCommit(currentState, approvedCommit);
 
     expect(nextState.routeId).toBe("route:/hmr");
@@ -709,6 +810,9 @@ describe("app browser entry state helpers", () => {
     });
     expect(staleApproval.decision.disposition).toBe("no-commit");
     expect(staleApproval.decision.trace.entries[0]?.code).toBe(
+      NavigationTraceTransactionCodes.noCommit,
+    );
+    expect(staleApproval.decision.trace.entries[1]?.code).toBe(
       NavigationTraceReasonCodes.staleOperation,
     );
     expect(staleApproval.approvedCommit).toBeNull();
@@ -721,24 +825,20 @@ describe("app browser entry state helpers", () => {
     });
     expect(hardNavigateApproval.decision.disposition).toBe("hard-navigate");
     expect(hardNavigateApproval.decision.trace.entries[0]?.code).toBe(
+      NavigationTraceTransactionCodes.hardNavigate,
+    );
+    expect(hardNavigateApproval.decision.trace.entries[1]?.code).toBe(
       NavigationTraceReasonCodes.rootBoundaryChanged,
     );
     expect(hardNavigateApproval.approvedCommit).toBeNull();
   });
 
-  it("merges layoutFlags on navigate", () => {
+  it("merges layoutFlags on approved navigate commits", async () => {
     const state = createState({ layoutFlags: { "layout:/": "s", "layout:/old": "d" } });
-    const nextState = routerReducer(state, {
-      elements: createResolvedElements("route:/next", "/"),
-      interceptionContext: null,
+    const nextState = await applyApprovedTestCommit(state, {
       layoutFlags: { "layout:/": "s", "layout:/blog": "d" },
-      navigationSnapshot: createState().navigationSnapshot,
-      operation: createTestOperation(state),
-      previousNextUrl: null,
-      renderId: 1,
       rootLayoutTreePath: "/",
       routeId: "route:/next",
-      type: "navigate",
     });
 
     // Navigate merges: old flags preserved, new flags override
@@ -749,16 +849,10 @@ describe("app browser entry state helpers", () => {
     });
   });
 
-  it("replaces layoutFlags on replace", () => {
+  it("replaces layoutFlags on approved replace commits", async () => {
     const state = createState({ layoutFlags: { "layout:/": "s", "layout:/old": "d" } });
-    const nextState = routerReducer(state, {
-      elements: createResolvedElements("route:/next", "/"),
-      interceptionContext: null,
+    const nextState = await applyApprovedTestCommit(state, {
       layoutFlags: { "layout:/": "d" },
-      navigationSnapshot: createState().navigationSnapshot,
-      operation: createTestOperation(state),
-      previousNextUrl: null,
-      renderId: 1,
       rootLayoutTreePath: "/",
       routeId: "route:/next",
       type: "replace",
@@ -768,19 +862,13 @@ describe("app browser entry state helpers", () => {
     expect(nextState.layoutFlags).toEqual({ "layout:/": "d" });
   });
 
-  it("stores previousNextUrl on navigate actions", () => {
+  it("stores previousNextUrl on approved navigate commits", async () => {
     const state = createState();
-    const nextState = routerReducer(state, {
-      elements: createResolvedElements("route:/photos/42\0/feed", "/", "/feed"),
+    const nextState = await applyApprovedTestCommit(state, {
       interceptionContext: "/feed",
-      layoutFlags: {},
-      navigationSnapshot: createState().navigationSnapshot,
-      operation: createTestOperation(state),
       previousNextUrl: "/feed",
-      renderId: 1,
       rootLayoutTreePath: "/",
       routeId: "route:/photos/42\0/feed",
-      type: "navigate",
     });
 
     expect(nextState.interceptionContext).toBe("/feed");
@@ -1599,7 +1687,8 @@ describe("app browser entry previousNextUrl helpers", () => {
     expect(result.decision.disposition).toBe("hard-navigate");
     expect(result.pending.routeId).toBe("route:/dashboard");
     expect(result.pending.action.renderId).toBe(3);
-    expect(result.trace.entries[0]?.code).toBe(NavigationTraceReasonCodes.rootBoundaryChanged);
+    expect(result.trace.entries[0]?.code).toBe(NavigationTraceTransactionCodes.hardNavigate);
+    expect(result.trace.entries[1]?.code).toBe(NavigationTraceReasonCodes.rootBoundaryChanged);
   });
 
   it("creates navigation trace entries without retaining field ownership", () => {
@@ -1622,22 +1711,15 @@ describe("app browser entry previousNextUrl helpers", () => {
     expect(shouldHardNavigate("/", null)).toBe(false);
   });
 
-  it("clears stale parallel slots on traverse", () => {
+  it("clears stale parallel slots on approved traverse commits", async () => {
     const state = createState({
       elements: createResolvedElements("route:/feed", "/", null, {
         "slot:modal:/feed": React.createElement("div", null, "modal"),
       }),
     });
-    const nextElements = createResolvedElements("route:/feed", "/");
 
-    const nextState = routerReducer(state, {
-      elements: nextElements,
-      interceptionContext: null,
-      layoutFlags: {},
-      navigationSnapshot: createState().navigationSnapshot,
-      operation: createTestOperation(state),
+    const nextState = await applyApprovedTestCommit(state, {
       previousNextUrl: null,
-      renderId: 1,
       rootLayoutTreePath: "/",
       routeId: "route:/feed",
       type: "traverse",
@@ -1646,25 +1728,16 @@ describe("app browser entry previousNextUrl helpers", () => {
     expect(Object.hasOwn(nextState.elements, "slot:modal:/feed")).toBe(false);
   });
 
-  it("preserves absent parallel slots on navigate", () => {
+  it("preserves absent parallel slots on approved navigate commits", async () => {
     const state = createState({
       elements: createResolvedElements("route:/feed", "/", null, {
         "slot:modal:/feed": React.createElement("div", null, "modal"),
       }),
     });
-    const nextElements = createResolvedElements("route:/feed/comments", "/");
 
-    const nextState = routerReducer(state, {
-      elements: nextElements,
-      interceptionContext: null,
-      layoutFlags: {},
-      navigationSnapshot: createState().navigationSnapshot,
-      operation: createTestOperation(state),
-      previousNextUrl: null,
-      renderId: 1,
+    const nextState = await applyApprovedTestCommit(state, {
       rootLayoutTreePath: "/",
       routeId: "route:/feed/comments",
-      type: "navigate",
     });
 
     expect(Object.hasOwn(nextState.elements, "slot:modal:/feed")).toBe(true);


### PR DESCRIPTION
## What this changes
Implements `#726-OPS-02/03` from #726: visible commit invariants and transaction trace codes.

This PR makes the approved visible commit path the only exported way to mutate browser-visible App Router state. The previous raw reducer export is no longer available, and the single `visibleCommitVersion` increment now lives inside the `ApprovedVisibleCommit` boundary.

It also adds transaction-level navigation trace codes for the three approval outcomes:

- `NT_VISIBLE_COMMIT`
- `NT_NO_COMMIT`
- `NT_HARD_NAVIGATE`

Those transaction entries are prepended to the existing reason entries such as `NC_COMMIT`, `NC_STALE`, `NC_ROOT`, and `NC_ROOT_UNKNOWN`, so operators can see both what happened and why.

Bonk: please read issue #726 to see the big picture behind this slice before reviewing the local mechanics.

## Why
Issue #726 is building toward a lifecycle model where visible state mutation, stale result rejection, hard navigation fallback, and future cache or skip decisions have observable authority boundaries. Without an explicit transaction outcome in the trace, `noCommit`, visible commit, and hard navigation paths are harder to audit. Without fencing the raw reducer export, future code can accidentally bypass the approved commit boundary.

## Approach
The browser state module still owns pending operation creation, route compatibility decisions, and reason traces. The visible commit module now owns the actual visible state reducer and the one place where `visibleCommitVersion` advances.

Approval now wraps every decision trace with a transaction entry carrying the operation lane, pending operation id, and started visible commit version. Current behavior for navigate, replace, traverse, HMR recovery, stale commits, unknown-root soft fallback, and root-boundary hard navigation is preserved.

## Validation
- `vp test run tests/app-browser-entry.test.ts` passes: 66 tests
- `vp check tests/app-browser-entry.test.ts packages/vinext/src/server/app-browser-visible-commit.ts packages/vinext/src/server/app-browser-state.ts packages/vinext/src/server/navigation-trace.ts` passes with no warnings, lint errors, or type errors
- `vp run vinext#build` passes, with the repo's existing virtual/external unresolved import warnings during pack
- `vp check` exits 0 across the repo, with one pre-existing warning in `packages/vinext/src/server/request-pipeline.ts:604`

## Risks / follow-ups
This intentionally does not add broad runtime logging, cache metrics, skip metrics, stale same-URL server-action rejection, or planner behavior. It is scoped to the visible commit invariant and approval-path trace codes requested by `#726-OPS-02/03`.
