### PR TITLE
fix(router): gate refresh and traverse outcomes

### DIFF
--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -43,6 +43,7 @@ import {
 import {
   createAppBrowserNavigationController,
   type HistoryUpdateMode,
+  type NavigationPayloadOutcome,
   type PendingBrowserRouterState,
 } from "./app-browser-navigation-controller.js";
 import {
@@ -263,7 +264,7 @@ async function renderNavigationPayload(
   useTransition = true,
   actionType: "navigate" | "replace" | "traverse" = "navigate",
   operationLane: OperationLane = "navigation",
-): Promise<void> {
+): Promise<NavigationPayloadOutcome> {
   try {
     return await browserNavigationController.renderNavigationPayload({
       actionType,
@@ -1141,7 +1142,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
 
         if (!browserNavigationController.isCurrentNavigation(navId)) return;
 
-        await renderNavigationPayload(
+        const renderOutcome = await renderNavigationPayload(
           rscPayload,
           navigationSnapshot,
           currentHref,
@@ -1154,6 +1155,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
           toActionType(navigationKind),
           toOperationLane(navigationKind),
         );
+        if (renderOutcome !== "committed") return;
         // Don't cache the response if this navigation was superseded during
         // renderNavigationPayload's await — the elements were never dispatched.
         if (!browserNavigationController.isCurrentNavigation(navId)) return;

--- a/packages/vinext/src/server/app-browser-navigation-controller.ts
+++ b/packages/vinext/src/server/app-browser-navigation-controller.ts
@@ -26,6 +26,7 @@ export type PendingBrowserRouterState = {
   resolve: (state: AppRouterState) => void;
   settled: boolean;
 };
+export type NavigationPayloadOutcome = "committed" | "no-commit" | "hard-navigate";
 
 type BrowserNavigationCommitEffectFactory = (options: {
   href: string;
@@ -68,7 +69,7 @@ type BrowserNavigationController = {
     targetHref: string;
     navId: number;
     useTransition?: boolean;
-  }): Promise<void>;
+  }): Promise<NavigationPayloadOutcome>;
   commitSameUrlNavigatePayload(
     nextElements: Promise<AppElements>,
     navigationSnapshot: ClientNavigationRenderSnapshot,
@@ -394,7 +395,7 @@ export function createAppBrowserNavigationController(
     targetHref: string;
     navId: number;
     useTransition?: boolean;
-  }): Promise<void> {
+  }): Promise<NavigationPayloadOutcome> {
     const renderId = allocateRenderId();
     let resolveCommitted: (() => void) | undefined;
     const committed = new Promise<void>((resolve) => {
@@ -404,9 +405,9 @@ export function createAppBrowserNavigationController(
 
     let snapshotActivated = false;
     try {
-      const currentState = getBrowserRouterState();
+      const startedState = getBrowserRouterState();
       const pending = await createPendingNavigationCommit({
-        currentState,
+        currentState: startedState,
         nextElements: options.nextElements,
         navigationSnapshot: options.navigationSnapshot,
         operationLane: options.operationLane,
@@ -417,7 +418,7 @@ export function createAppBrowserNavigationController(
 
       const approval = approvePendingNavigationCommit({
         activeNavigationId,
-        currentState,
+        currentState: getBrowserRouterState(),
         pending,
         startedNavigationId: options.navId,
       });
@@ -426,14 +427,14 @@ export function createAppBrowserNavigationController(
         settlePendingBrowserRouterState(options.pendingRouterState);
         pendingNavigationCommits.delete(renderId);
         resolveCommitted?.();
-        return;
+        return "no-commit";
       }
 
       if (approval.decision.disposition === "hard-navigate") {
         settlePendingBrowserRouterState(options.pendingRouterState);
         pendingNavigationCommits.delete(renderId);
         window.location.assign(options.targetHref);
-        return;
+        return "hard-navigate";
       }
 
       const approvedCommit = approval.approvedCommit;
@@ -469,7 +470,7 @@ export function createAppBrowserNavigationController(
       throw error;
     }
 
-    return committed;
+    return committed.then(() => "committed");
   }
 
   async function commitSameUrlNavigatePayload(
@@ -479,11 +480,6 @@ export function createAppBrowserNavigationController(
   ): Promise<unknown> {
     const currentState = getBrowserRouterState();
     const startedNavigationId = activeNavigationId;
-    // Known limitation: if a same-URL navigation fully commits while this
-    // server action is awaiting resolveAndClassifyNavigationCommit(), the action
-    // can still dispatch its older payload afterward. The old pre-2c code had
-    // the same race, and Next.js has similar behavior. Tightening this would
-    // need a stronger commit-version gate than activeNavigationId alone.
     const {
       approvedCommit,
       decision,
@@ -494,6 +490,8 @@ export function createAppBrowserNavigationController(
     } = await resolveAndClassifyNavigationCommit({
       activeNavigationId,
       currentState,
+      getActiveNavigationId: () => activeNavigationId,
+      getCurrentState: getBrowserRouterState,
       navigationSnapshot,
       nextElements,
       renderId: allocateRenderId(),

--- a/packages/vinext/src/server/app-browser-state.ts
+++ b/packages/vinext/src/server/app-browser-state.ts
@@ -277,11 +277,17 @@ export function shouldHardNavigate(
 
 export function resolvePendingNavigationCommitDisposition(options: {
   activeNavigationId: number;
+  currentVisibleCommitVersion: number;
   currentRootLayoutTreePath: string | null;
   nextRootLayoutTreePath: string | null;
   startedNavigationId: number;
+  startedVisibleCommitVersion: number;
 }): PendingNavigationCommitDisposition {
   if (options.startedNavigationId !== options.activeNavigationId) {
+    return "skip";
+  }
+
+  if (options.startedVisibleCommitVersion !== options.currentVisibleCommitVersion) {
     return "skip";
   }
 
@@ -294,16 +300,20 @@ export function resolvePendingNavigationCommitDisposition(options: {
 
 export function resolvePendingNavigationCommitDispositionDecision(options: {
   activeNavigationId: number;
+  currentVisibleCommitVersion: number;
   currentRootLayoutTreePath: string | null;
   nextRootLayoutTreePath: string | null;
   startedNavigationId: number;
+  startedVisibleCommitVersion: number;
 }): PendingNavigationCommitDispositionDecision {
   const disposition = resolvePendingNavigationCommitDisposition(options);
   const traceFields = {
     activeNavigationId: options.activeNavigationId,
     currentRootLayoutTreePath: options.currentRootLayoutTreePath,
+    currentVisibleCommitVersion: options.currentVisibleCommitVersion,
     nextRootLayoutTreePath: options.nextRootLayoutTreePath,
     startedNavigationId: options.startedNavigationId,
+    startedVisibleCommitVersion: options.startedVisibleCommitVersion,
   };
 
   return {

--- a/packages/vinext/src/server/app-browser-visible-commit.ts
+++ b/packages/vinext/src/server/app-browser-visible-commit.ts
@@ -63,9 +63,11 @@ export function applyApprovedVisibleCommit(
 
 function resolvePendingNavigationCommitDecision(options: {
   activeNavigationId: number;
+  currentVisibleCommitVersion: number;
   currentRootLayoutTreePath: string | null;
   nextRootLayoutTreePath: string | null;
   startedNavigationId: number;
+  startedVisibleCommitVersion: number;
 }): CommitDecision {
   const { disposition, trace } = resolvePendingNavigationCommitDispositionDecision(options);
 
@@ -123,9 +125,11 @@ export function approvePendingNavigationCommit(options: {
 }): CommitApproval {
   const decision = resolvePendingNavigationCommitDecision({
     activeNavigationId: options.activeNavigationId,
+    currentVisibleCommitVersion: options.currentState.visibleCommitVersion,
     currentRootLayoutTreePath: options.currentState.rootLayoutTreePath,
     nextRootLayoutTreePath: options.pending.rootLayoutTreePath,
     startedNavigationId: options.startedNavigationId,
+    startedVisibleCommitVersion: options.pending.action.operation.startedVisibleCommitVersion,
   });
 
   switch (decision.disposition) {
@@ -153,6 +157,8 @@ export function approvePendingNavigationCommit(options: {
 export async function resolveAndClassifyNavigationCommit(options: {
   activeNavigationId: number;
   currentState: AppRouterState;
+  getActiveNavigationId?: () => number;
+  getCurrentState?: () => AppRouterState;
   navigationSnapshot: ClientNavigationRenderSnapshot;
   nextElements: Promise<AppElements>;
   operationLane: OperationLane;
@@ -171,9 +177,10 @@ export async function resolveAndClassifyNavigationCommit(options: {
     type: options.type,
   });
 
+  const currentState = options.getCurrentState?.() ?? options.currentState;
   const approval = approvePendingNavigationCommit({
-    activeNavigationId: options.activeNavigationId,
-    currentState: options.currentState,
+    activeNavigationId: options.getActiveNavigationId?.() ?? options.activeNavigationId,
+    currentState,
     pending,
     startedNavigationId: options.startedNavigationId,
   });

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -290,6 +290,7 @@ export type CachedRscResponse = {
 };
 
 export type PrefetchCacheEntry = {
+  outcome: "pending" | "cache-seeded";
   snapshot?: CachedRscResponse;
   pending?: Promise<void>;
   timestamp: number;
@@ -384,7 +385,7 @@ export function storePrefetchResponse(
 ): void {
   const cacheKey = AppElementsWire.encodeCacheKey(rscUrl, interceptionContext);
   evictPrefetchCacheIfNeeded();
-  const entry: PrefetchCacheEntry = { timestamp: Date.now() };
+  const entry: PrefetchCacheEntry = { outcome: "pending", timestamp: Date.now() };
   entry.pending = snapshotRscResponse(response)
     .then((snapshot) => {
       entry.snapshot = snapshot;
@@ -394,6 +395,9 @@ export function storePrefetchResponse(
     })
     .finally(() => {
       entry.pending = undefined;
+      if (entry.snapshot) {
+        entry.outcome = "cache-seeded";
+      }
     });
   getPrefetchCache().set(cacheKey, entry);
 }
@@ -461,7 +465,7 @@ export function prefetchRscResponse(
   const prefetched = getPrefetchedUrls();
   const now = Date.now();
 
-  const entry: PrefetchCacheEntry = { timestamp: now };
+  const entry: PrefetchCacheEntry = { outcome: "pending", timestamp: now };
 
   entry.pending = fetchPromise
     .then(async (response) => {
@@ -483,6 +487,9 @@ export function prefetchRscResponse(
     })
     .finally(() => {
       entry.pending = undefined;
+      if (entry.snapshot) {
+        entry.outcome = "cache-seeded";
+      }
     });
 
   // Insert the new entry before evicting. FIFO evicts from the front of the
@@ -508,7 +515,7 @@ export function consumePrefetchResponse(
   if (!entry) return null;
 
   // Don't consume pending entries — let the navigation fetch independently.
-  if (entry.pending) return null;
+  if (entry.pending || entry.outcome !== "cache-seeded") return null;
 
   cache.delete(cacheKey);
   getPrefetchedUrls().delete(cacheKey);

--- a/packages/vinext/src/shims/next-shims.d.ts
+++ b/packages/vinext/src/shims/next-shims.d.ts
@@ -112,8 +112,17 @@ declare module "next/navigation" {
   export function getLayoutSegmentContext(): import("react").Context<string[]> | null;
 
   // RSC prefetch cache utilities (shared between link.tsx and browser entry)
+  export type CachedRscResponse = {
+    buffer: ArrayBuffer;
+    contentType: string;
+    mountedSlotsHeader?: string | null;
+    paramsHeader: string | null;
+    url: string;
+  };
   export type PrefetchCacheEntry = {
-    response: Response;
+    outcome: "pending" | "cache-seeded";
+    snapshot?: CachedRscResponse;
+    pending?: Promise<void>;
     timestamp: number;
   };
   export const MAX_PREFETCH_CACHE_SIZE: number;
@@ -125,6 +134,19 @@ declare module "next/navigation" {
     response: Response,
     interceptionContext?: string | null,
   ): void;
+  export function snapshotRscResponse(response: Response): Promise<CachedRscResponse>;
+  export function restoreRscResponse(cached: CachedRscResponse, copy?: boolean): Response;
+  export function prefetchRscResponse(
+    rscUrl: string,
+    fetchPromise: Promise<Response>,
+    interceptionContext?: string | null,
+    mountedSlotsHeader?: string | null,
+  ): void;
+  export function consumePrefetchResponse(
+    rscUrl: string,
+    interceptionContext?: string | null,
+    mountedSlotsHeader?: string | null,
+  ): CachedRscResponse | null;
 }
 
 declare module "next/image" {

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -300,9 +300,11 @@ describe("app browser entry state helpers", () => {
     expect(
       resolvePendingNavigationCommitDisposition({
         activeNavigationId: 3,
+        currentVisibleCommitVersion: currentState.visibleCommitVersion,
         currentRootLayoutTreePath: currentState.rootLayoutTreePath,
         nextRootLayoutTreePath: pending.rootLayoutTreePath,
         startedNavigationId: 3,
+        startedVisibleCommitVersion: pending.action.operation.startedVisibleCommitVersion,
       }),
     ).toBe("hard-navigate");
   });
@@ -391,19 +393,98 @@ describe("app browser entry state helpers", () => {
     expect(
       resolvePendingNavigationCommitDisposition({
         activeNavigationId: 5,
+        currentVisibleCommitVersion: currentState.visibleCommitVersion,
         currentRootLayoutTreePath: currentState.rootLayoutTreePath,
         nextRootLayoutTreePath: pending.rootLayoutTreePath,
         startedNavigationId: 4,
+        startedVisibleCommitVersion: pending.action.operation.startedVisibleCommitVersion,
       }),
     ).toBe("skip");
+  });
+
+  it("skips a refresh commit when visible state changed after the refresh started", async () => {
+    const refreshStartState = createState({ visibleCommitVersion: 4 });
+    const latestState = createState({
+      routeId: "route:/hmr",
+      visibleCommitVersion: 5,
+    });
+    const pending = await createPendingNavigationCommit({
+      currentState: refreshStartState,
+      nextElements: Promise.resolve(createResolvedElements("route:/dashboard", "/")),
+      navigationSnapshot: refreshStartState.navigationSnapshot,
+      operationLane: "refresh",
+      renderId: 22,
+      type: "navigate",
+    });
+
+    const approval = approvePendingNavigationCommit({
+      activeNavigationId: 7,
+      currentState: latestState,
+      pending,
+      startedNavigationId: 7,
+    });
+
+    expect(approval.decision.disposition).toBe("no-commit");
+    expect(approval.decision.trace.entries[0]).toEqual({
+      code: NavigationTraceReasonCodes.staleOperation,
+      fields: {
+        activeNavigationId: 7,
+        currentRootLayoutTreePath: "/",
+        currentVisibleCommitVersion: 5,
+        nextRootLayoutTreePath: "/",
+        startedNavigationId: 7,
+        startedVisibleCommitVersion: 4,
+      },
+    });
+    expect(approval.approvedCommit).toBeNull();
+  });
+
+  it("skips a traverse commit when visible state changed after traversal started", async () => {
+    const traverseStartState = createState({ visibleCommitVersion: 2 });
+    const latestState = createState({
+      routeId: "route:/newer",
+      visibleCommitVersion: 3,
+    });
+    const pending = await createPendingNavigationCommit({
+      currentState: traverseStartState,
+      nextElements: Promise.resolve(createResolvedElements("route:/previous", "/")),
+      navigationSnapshot: traverseStartState.navigationSnapshot,
+      operationLane: "traverse",
+      previousNextUrl: null,
+      renderId: 23,
+      type: "traverse",
+    });
+
+    const approval = approvePendingNavigationCommit({
+      activeNavigationId: 8,
+      currentState: latestState,
+      pending,
+      startedNavigationId: 8,
+    });
+
+    expect(approval.decision.disposition).toBe("no-commit");
+    expect(approval.decision.trace.entries[0]).toEqual({
+      code: NavigationTraceReasonCodes.staleOperation,
+      fields: {
+        activeNavigationId: 8,
+        currentRootLayoutTreePath: "/",
+        currentVisibleCommitVersion: 3,
+        nextRootLayoutTreePath: "/",
+        startedNavigationId: 8,
+        startedVisibleCommitVersion: 2,
+      },
+    });
+    expect(approval.approvedCommit).toBeNull();
   });
 
   it("traces stale pending commits with compact reason codes and structured fields", () => {
     const decision = resolvePendingNavigationCommitDispositionDecision({
       activeNavigationId: 5,
+      currentVisibleCommitVersion: 0,
       currentRootLayoutTreePath: "/",
       nextRootLayoutTreePath: "/(dashboard)",
       startedNavigationId: 4,
+      startedVisibleCommitVersion: 0,
     });
 
     expect(decision.disposition).toBe("skip");
@@ -415,8 +496,10 @@ describe("app browser entry state helpers", () => {
           fields: {
             activeNavigationId: 5,
             currentRootLayoutTreePath: "/",
+            currentVisibleCommitVersion: 0,
             nextRootLayoutTreePath: "/(dashboard)",
             startedNavigationId: 4,
+            startedVisibleCommitVersion: 0,
           },
         },
       ],
@@ -426,9 +509,11 @@ describe("app browser entry state helpers", () => {
   it("traces root-boundary hard navigation decisions", () => {
     const decision = resolvePendingNavigationCommitDispositionDecision({
       activeNavigationId: 2,
+      currentVisibleCommitVersion: 1,
       currentRootLayoutTreePath: "/(marketing)",
       nextRootLayoutTreePath: "/(dashboard)",
       startedNavigationId: 2,
+      startedVisibleCommitVersion: 1,
     });
 
     expect(decision.disposition).toBe("hard-navigate");
@@ -438,8 +523,10 @@ describe("app browser entry state helpers", () => {
         fields: {
           activeNavigationId: 2,
           currentRootLayoutTreePath: "/(marketing)",
+          currentVisibleCommitVersion: 1,
           nextRootLayoutTreePath: "/(dashboard)",
           startedNavigationId: 2,
+          startedVisibleCommitVersion: 1,
         },
       },
     ]);
@@ -448,9 +535,11 @@ describe("app browser entry state helpers", () => {
   it("traces unknown root-layout identity as a legacy soft-commit fallback", () => {
     const decision = resolvePendingNavigationCommitDispositionDecision({
       activeNavigationId: 2,
+      currentVisibleCommitVersion: 1,
       currentRootLayoutTreePath: "/",
       nextRootLayoutTreePath: null,
       startedNavigationId: 2,
+      startedVisibleCommitVersion: 1,
     });
 
     expect(decision.disposition).toBe("dispatch");
@@ -460,9 +549,11 @@ describe("app browser entry state helpers", () => {
   it("traces matching root-layout dispatches as current commits", () => {
     const decision = resolvePendingNavigationCommitDispositionDecision({
       activeNavigationId: 2,
+      currentVisibleCommitVersion: 1,
       currentRootLayoutTreePath: "/",
       nextRootLayoutTreePath: "/",
       startedNavigationId: 2,
+      startedVisibleCommitVersion: 1,
     });
 
     expect(decision.disposition).toBe("dispatch");
@@ -472,8 +563,10 @@ describe("app browser entry state helpers", () => {
         fields: {
           activeNavigationId: 2,
           currentRootLayoutTreePath: "/",
+          currentVisibleCommitVersion: 1,
           nextRootLayoutTreePath: "/",
           startedNavigationId: 2,
+          startedVisibleCommitVersion: 1,
         },
       },
     ]);
@@ -922,7 +1015,7 @@ describe("app browser navigation controller", () => {
         }),
       );
 
-      await expect(renderPromise).resolves.toBeUndefined();
+      await expect(renderPromise).resolves.toBe("no-commit");
       expect(createNavigationCommitEffect).not.toHaveBeenCalled();
       expect(assign).not.toHaveBeenCalled();
     } finally {
@@ -1248,6 +1341,114 @@ describe("app browser navigation lifecycle settlement", () => {
     }
   });
 
+  it("keeps a newer visible commit when an older refresh resolves late", async () => {
+    const { controller, detach, stateRef } = createControllerHarness();
+    let resolveRefresh!: (elements: AppElements) => void;
+    const refreshPayload = new Promise<AppElements>((resolve) => {
+      resolveRefresh = resolve;
+    });
+
+    try {
+      const refreshNav = controller.beginNavigation();
+      void controller.renderNavigationPayload({
+        actionType: "navigate",
+        createNavigationCommitEffect: () => () => {},
+        historyUpdateMode: undefined,
+        navigationSnapshot: stateRef.current.navigationSnapshot,
+        nextElements: refreshPayload,
+        operationLane: "refresh",
+        params: {},
+        pendingRouterState: null,
+        previousNextUrl: null,
+        targetHref: "https://example.com/initial",
+        navId: refreshNav,
+        useTransition: false,
+      });
+
+      await controller.hmrReplaceTree(
+        Promise.resolve(
+          createResolvedElements("route:/hmr", "/", null, {
+            "page:/hmr": React.createElement("main", null, "hmr"),
+          }),
+        ),
+        stateRef.current.navigationSnapshot,
+      );
+      expect(stateRef.current.routeId).toBe("route:/hmr");
+
+      resolveRefresh(
+        createResolvedElements("route:/initial-refreshed", "/", null, {
+          "page:/initial": React.createElement("main", null, "refreshed"),
+        }),
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(stateRef.current.routeId).toBe("route:/hmr");
+      expect(stateRef.current.activeOperation).toMatchObject({
+        lane: "hmr",
+        state: "committed",
+        visibleCommitVersion: 1,
+      });
+    } finally {
+      detach();
+    }
+  });
+
+  it("settles pending state without patching visible UI when an older traverse resolves late", async () => {
+    const { controller, detach, stateRef } = createControllerHarness();
+    let resolveTraverse!: (elements: AppElements) => void;
+    const traversePayload = new Promise<AppElements>((resolve) => {
+      resolveTraverse = resolve;
+    });
+
+    try {
+      const traversePendingState = controller.beginPendingBrowserRouterState();
+      const traverseNav = controller.beginNavigation();
+      void controller.renderNavigationPayload({
+        actionType: "traverse",
+        createNavigationCommitEffect: () => () => {},
+        historyUpdateMode: undefined,
+        navigationSnapshot: stateRef.current.navigationSnapshot,
+        nextElements: traversePayload,
+        operationLane: "traverse",
+        params: {},
+        pendingRouterState: traversePendingState,
+        previousNextUrl: null,
+        targetHref: "https://example.com/previous",
+        navId: traverseNav,
+        useTransition: false,
+      });
+
+      await controller.hmrReplaceTree(
+        Promise.resolve(
+          createResolvedElements("route:/hmr", "/", null, {
+            "page:/hmr": React.createElement("main", null, "hmr"),
+          }),
+        ),
+        stateRef.current.navigationSnapshot,
+      );
+
+      resolveTraverse(
+        createResolvedElements("route:/previous", "/", null, {
+          "page:/previous": React.createElement("main", null, "previous"),
+        }),
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+
+      await expect(traversePendingState.promise).resolves.toBe(stateRef.current);
+      expect(traversePendingState.settled).toBe(true);
+      expect(stateRef.current.routeId).toBe("route:/hmr");
+      expect(stateRef.current.activeOperation).toMatchObject({
+        lane: "hmr",
+        state: "committed",
+        visibleCommitVersion: 1,
+      });
+    } finally {
+      detach();
+    }
+  });
+
   it("resolveAndClassifyNavigationCommit classifies skip when IDs have diverged", async () => {
     const result = await resolveAndClassifyNavigationCommit({
       activeNavigationId: 9,
@@ -1330,7 +1531,7 @@ describe("app browser root-layout hard navigation", () => {
         useTransition: false,
       });
 
-      await expect(renderPromise).resolves.toBeUndefined();
+      await expect(renderPromise).resolves.toBe("hard-navigate");
       expect(assign).toHaveBeenCalledTimes(1);
       expect(assign).toHaveBeenCalledWith("https://example.com/dashboard");
       expect(createNavigationCommitEffect).not.toHaveBeenCalled();

--- a/tests/prefetch-cache.test.ts
+++ b/tests/prefetch-cache.test.ts
@@ -75,6 +75,7 @@ function fillCache(count: number, timestamp: number, keyPrefix = "/page-"): void
         paramsHeader: null,
         url: key,
       },
+      outcome: "cache-seeded",
       timestamp,
     });
     prefetched.add(key);
@@ -133,7 +134,7 @@ describe("prefetch cache eviction", () => {
       url: rscUrl,
     };
 
-    cache.set(rscUrl, { snapshot, timestamp: Date.now() });
+    cache.set(rscUrl, { outcome: "cache-seeded", snapshot, timestamp: Date.now() });
     prefetched.add(rscUrl);
 
     expect(consumePrefetchResponse(rscUrl, null, "slot:auth:/")).toEqual(snapshot);
@@ -147,6 +148,7 @@ describe("prefetch cache eviction", () => {
     const rscUrl = "/dashboard.rsc";
 
     cache.set(rscUrl, {
+      outcome: "cache-seeded",
       snapshot: {
         buffer: new TextEncoder().encode("flight").buffer,
         contentType: "text/x-component",
@@ -194,6 +196,55 @@ describe("prefetch cache eviction", () => {
     expect(restored.headers.get("content-type")).toBe("text/x-component; charset=utf-8");
     expect(restored.headers.get("x-vinext-params")).toBe(encodeURIComponent('{"id":"2"}'));
     await expect(restored.text()).resolves.toBe("flight");
+  });
+
+  it("settles router.prefetch as a consumable cache-seeded response without visible navigation", async () => {
+    let resolveResponse!: (response: Response) => void;
+    const fetchPromise = new Promise<Response>((resolve) => {
+      resolveResponse = resolve;
+    });
+    let fetchedUrl: RequestInfo | URL | undefined;
+    const fetch = vi.fn((input: RequestInfo | URL) => {
+      fetchedUrl = input;
+      return fetchPromise;
+    });
+    const navigate = vi.fn();
+    (globalThis as any).fetch = fetch;
+    (globalThis as any).window.__VINEXT_RSC_NAVIGATE__ = navigate;
+
+    useRouter().prefetch("/dashboard");
+    await waitForPrefetchSetup(() => fetch.mock.calls.length > 0);
+
+    if (fetchedUrl === undefined) {
+      throw new Error("Expected router.prefetch to fetch an RSC URL");
+    }
+
+    const rscUrl =
+      typeof fetchedUrl === "string"
+        ? fetchedUrl
+        : fetchedUrl instanceof URL
+          ? fetchedUrl.href
+          : fetchedUrl.url;
+    const cacheKey = AppElementsWire.encodeCacheKey(rscUrl, "/");
+
+    expect(getPrefetchCache().get(cacheKey)?.outcome).toBe("pending");
+
+    resolveResponse(new Response("flight", { headers: { "content-type": "text/x-component" } }));
+    await waitForPrefetchSetup(
+      () =>
+        getPrefetchCache().get(cacheKey)?.outcome === "cache-seeded" &&
+        getPrefetchCache().get(cacheKey)?.pending === undefined,
+    );
+
+    const entry = getPrefetchCache().get(cacheKey);
+    expect(entry?.outcome).toBe("cache-seeded");
+    expect(entry?.pending).toBeUndefined();
+
+    const consumed = consumePrefetchResponse(rscUrl, "/", null);
+    expect(consumed?.mountedSlotsHeader).toBeNull();
+    expect(getPrefetchCache().has(cacheKey)).toBe(false);
+    expect(getPrefetchedUrls().has(cacheKey)).toBe(false);
+    expect(navigate).not.toHaveBeenCalled();
   });
 
   it("sweeps all expired entries before FIFO", () => {


### PR DESCRIPTION
## What changed

Implements #726-CORE-05/06A and #726-CORE-06B from issue #726.

- Treat refresh, prefetch, and traverse completion as lifecycle outcomes instead of assuming every resolved payload is still allowed to affect the visible router tree.
- Gate pending refresh, traverse, navigation, and same-URL navigation commits by both active navigation id and the visible commit version captured when the operation started.
- Return explicit browser navigation payload outcomes: committed, no-commit, and hard-navigate. Stale and hard-navigation payloads now settle pending router state without dispatching visible UI updates.
- Only seed the visited-response cache after a payload actually commits, so late refresh or traverse results cannot masquerade as rendered responses.
- Make router.prefetch expose cache-seeded only after the RSC snapshot is ready and pending work has been cleared, and consume entries only in that settled state.
- Update the next/navigation ambient shim declarations to match the runtime prefetch cache shape.

## Why

Issue #726 calls out a class of stale async navigation results where an older operation can resolve after a newer visible commit. The previous gate only checked the active navigation id. That was not enough for operations such as refresh and traverse, because a newer visible commit can occur without changing the same operation token. The existing pending operation shape already captured startedVisibleCommitVersion, so this patch uses that value as the lifecycle boundary.

For prefetch, the required outcome is cache seed only. The cache entry now stays pending until the response snapshot is actually consumable, and prefetch still never calls the visible navigation entry point.

## Validation

- vp test run tests/app-browser-entry.test.ts tests/prefetch-cache.test.ts
- vp test run tests/shims.test.ts -t "useRouter|prefetch|refresh"
- vp check packages/vinext/src/server/app-browser-state.ts packages/vinext/src/server/app-browser-visible-commit.ts packages/vinext/src/server/app-browser-navigation-controller.ts packages/vinext/src/server/app-browser-entry.ts packages/vinext/src/shims/navigation.ts packages/vinext/src/shims/next-shims.d.ts tests/app-browser-entry.test.ts tests/prefetch-cache.test.ts
- git diff --check

## Non-goals

- Full refresh lane model or cache reuse authority.
- Full back/forward intent model or Activity preservation.

Bonk: please read issue #726 for the big picture before reviewing this patch. The lifecycle-gate work here is one slice of that larger router determinism plan.