### PR TITLE
perf(prerender): reuse captured RSC bytes via response side-channel

### DIFF
--- a/packages/vinext/src/build/prerender.ts
+++ b/packages/vinext/src/build/prerender.ts
@@ -1019,6 +1019,10 @@ export async function prerenderApp({
         // (devWorker.fetch) so the ALS context set up here on the Node side never
         // reaches the worker isolate. The wrapping is a no-op for the CF path but
         // harmless — and it keeps renderUrl() shape-compatible across both modes.
+        // The prod-server is in prerender mode (VINEXT_PRERENDER=1) so HTML
+        // responses for App Router carry the raw RSC bytes appended to the
+        // body, advertised via `x-vinext-rsc-byte-length`. Mirrors Next.js's
+        // `metadata.flightData` side-channel: one render emits both halves.
         const htmlRequest = new Request(`http://localhost${urlPath}`);
         const htmlRender = await runWithHeadersContext(
           headersContextFromRequest(htmlRequest),
@@ -1030,16 +1034,38 @@ export async function prerenderApp({
               return {
                 cacheControl,
                 html: null,
+                rsc: null,
                 ok: response.ok,
                 requestCacheLife: null,
                 status: response.status,
               };
             }
 
-            const html = await response.text();
+            const rscByteLengthHeader = response.headers.get("x-vinext-rsc-byte-length");
+            if (!rscByteLengthHeader) {
+              throw new Error(
+                "[vinext] Prerender HTML response missing x-vinext-rsc-byte-length header",
+              );
+            }
+            const rscByteLength = Number(rscByteLengthHeader);
+            if (!Number.isFinite(rscByteLength) || rscByteLength < 0) {
+              throw new Error(
+                `[vinext] Invalid x-vinext-rsc-byte-length header value: ${rscByteLengthHeader}`,
+              );
+            }
+
+            const buffer = new Uint8Array(await response.arrayBuffer());
+            if (rscByteLength > buffer.byteLength) {
+              throw new Error(
+                `[vinext] x-vinext-rsc-byte-length (${rscByteLength}) exceeds response body length (${buffer.byteLength})`,
+              );
+            }
+            const splitAt = buffer.byteLength - rscByteLength;
+            const decoder = new TextDecoder();
             return {
               cacheControl,
-              html,
+              html: decoder.decode(buffer.subarray(0, splitAt)),
+              rsc: decoder.decode(buffer.subarray(splitAt)),
               ok: true,
               requestCacheLife: _consumeRequestScopedCacheLife(),
               status: response.status,
@@ -1076,16 +1102,7 @@ export async function prerenderApp({
           };
         }
         const html = htmlRender.html;
-
-        // Fetch RSC payload via a second invocation with RSC headers
-        // TODO: Extract RSC payload from the first response instead of invoking the handler twice.
-        const rscRequest = new Request(`http://localhost${urlPath}`, {
-          headers: { Accept: "text/x-component", RSC: "1" },
-        });
-        const rscRes = await runWithHeadersContext(headersContextFromRequest(rscRequest), () =>
-          rscHandler(rscRequest),
-        );
-        const rscData = rscRes.ok ? await rscRes.text() : null;
+        const rscData = htmlRender.rsc;
 
         const outputFiles: string[] = [];
 

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -250,6 +250,49 @@ function wrapRscResponseForDevErrorReporting(
   });
 }
 
+/**
+ * Concatenate the captured raw RSC bytes onto the end of the HTML response
+ * body and advertise their byte length via `x-vinext-rsc-byte-length`. The
+ * prerender driver reads the body as one buffer and splits at
+ * `total - x-vinext-rsc-byte-length`. This avoids a second handler invocation
+ * per route — the same render produces both halves.
+ *
+ * Only invoked when the prod-server is in prerender mode (VINEXT_PRERENDER=1)
+ * and the request is for HTML (not an RSC request). Production runtime is
+ * unaffected because `isPrerender` is false there.
+ */
+async function appendCapturedRscToHtmlResponse(
+  response: Response,
+  capturedRscDataPromise: Promise<ArrayBuffer>,
+): Promise<Response> {
+  if (!response.body) return response;
+
+  // Buffer the HTML body into memory to keep the protocol simple: a single
+  // body buffer of [HTML][RSC] with the RSC length declared as a header.
+  // Prerender HTML is already buffered downstream by the driver (it calls
+  // `response.text()`), so we don't lose any streaming benefit here.
+  const [htmlBuffer, rscBuffer] = await Promise.all([
+    response.arrayBuffer(),
+    capturedRscDataPromise,
+  ]);
+
+  const combined = new Uint8Array(htmlBuffer.byteLength + rscBuffer.byteLength);
+  combined.set(new Uint8Array(htmlBuffer), 0);
+  combined.set(new Uint8Array(rscBuffer), htmlBuffer.byteLength);
+
+  const headers = new Headers(response.headers);
+  headers.set("x-vinext-rsc-byte-length", String(rscBuffer.byteLength));
+  // The combined body's content-length must reflect the real buffer size or
+  // any downstream `Content-Length` validation will reject the response.
+  headers.set("content-length", String(combined.byteLength));
+
+  return new Response(combined, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
 export async function renderAppPageLifecycle(
   options: RenderAppPageLifecycleOptions,
 ): Promise<Response> {
@@ -306,7 +349,16 @@ export async function renderAppPageLifecycle(
     (options.isProduction || options.isPrerender === true) &&
     (revalidateSeconds === null || (revalidateSeconds > 0 && revalidateSeconds !== Infinity)) &&
     !options.isForceDynamic;
-  const rscCapture = teeAppPageRscStreamForCapture(rscStream, shouldCaptureRscForCacheMetadata);
+  // In prerender mode the side-channel always carries the captured RSC bytes
+  // back to the prerender driver, so the tee must run unconditionally for any
+  // route that could plausibly emit a `.rsc` (force-dynamic and revalidate=0
+  // routes are filtered out by the driver before this handler runs, but we
+  // re-check defensively). This covers `revalidate: Infinity` static-forever
+  // routes which the cache-metadata predicate excludes.
+  const shouldCaptureRscForPrerender =
+    options.isPrerender === true && !options.isForceDynamic && revalidateSeconds !== 0;
+  const shouldCaptureRsc = shouldCaptureRscForCacheMetadata || shouldCaptureRscForPrerender;
+  const rscCapture = teeAppPageRscStreamForCapture(rscStream, shouldCaptureRsc);
   const rscForResponse = rscCapture.ssrStream;
 
   // When the fused tee (#981) is active, the sideStream carries both the embed
@@ -522,6 +574,30 @@ export async function renderAppPageLifecycle(
     !options.scriptNonce &&
     !dynamicUsedDuringRender;
 
+  // Prerender mode handles HTML responses uniformly, regardless of whether
+  // the route would write to the runtime ISR cache (force-static / null
+  // revalidate / positive revalidate / Infinity all land here). We append the
+  // captured raw RSC bytes so the driver recovers both halves from a single
+  // render. Runtime cache writeback (finalizeAppPageHtmlCacheResponse) does
+  // not apply during prerender — the prerender driver writes its own files.
+  if (options.isPrerender === true) {
+    const prerenderResponse = buildAppPageHtmlResponse(safeHtmlStream, {
+      draftCookie,
+      fontLinkHeader,
+      middlewareContext: options.middlewareContext,
+      policy: htmlResponsePolicy,
+      timing: htmlResponseTiming,
+    });
+    // The capture is mandatory: force-dynamic and revalidate=0 routes are
+    // skipped by the driver before invocation, and shouldCaptureRscForPrerender
+    // covers all remaining cases. A null value is an invariant violation —
+    // surface it loudly rather than silently double-rendering.
+    if (!capturedRscDataRef.value) {
+      throw new Error("[vinext] Invariant: prerender HTML render produced no captured RSC bytes");
+    }
+    return await appendCapturedRscToHtmlResponse(prerenderResponse, capturedRscDataRef.value);
+  }
+
   if (htmlResponsePolicy.shouldWriteToCache || shouldSpeculativelyWriteCache) {
     const isrResponse = buildAppPageHtmlResponse(safeHtmlStream, {
       draftCookie,
@@ -530,10 +606,6 @@ export async function renderAppPageLifecycle(
       policy: htmlResponsePolicy,
       timing: htmlResponseTiming,
     });
-
-    if (options.isPrerender === true) {
-      return isrResponse;
-    }
 
     return finalizeAppPageHtmlCacheResponse(isrResponse, {
       capturedRscDataPromise: capturedRscDataRef.value,

--- a/tests/app-page-render.test.ts
+++ b/tests/app-page-render.test.ts
@@ -45,6 +45,29 @@ function createDeferred<T = void>() {
   return { promise, reject, resolve };
 }
 
+/**
+ * Read a prerender HTML response and split the body into its HTML and RSC
+ * halves using the `x-vinext-rsc-byte-length` header. The prerender driver
+ * does the same — every render emits a single buffer of [HTML][raw RSC bytes].
+ */
+async function readPrerenderBundle(response: Response): Promise<{
+  html: string;
+  rsc: string;
+}> {
+  const rscByteLengthHeader = response.headers.get("x-vinext-rsc-byte-length");
+  if (rscByteLengthHeader === null) {
+    throw new Error("Expected x-vinext-rsc-byte-length header on prerender response");
+  }
+  const rscByteLength = Number(rscByteLengthHeader);
+  const buffer = new Uint8Array(await response.arrayBuffer());
+  const splitAt = buffer.byteLength - rscByteLength;
+  const decoder = new TextDecoder();
+  return {
+    html: decoder.decode(buffer.subarray(0, splitAt)),
+    rsc: decoder.decode(buffer.subarray(splitAt)),
+  };
+}
+
 function createCommonOptions() {
   const waitUntilPromises: Promise<void>[] = [];
   const renderToReadableStream = vi.fn(() => createStream(["flight-data"]));
@@ -530,7 +553,9 @@ describe("app page render lifecycle", () => {
 
     expect(response.headers.get("cache-control")).toBe("s-maxage=1, stale-while-revalidate=2");
     expect(response.headers.get("x-vinext-cache")).toBeNull();
-    await expect(response.text()).resolves.toBe("<html>page</html>");
+    const { html, rsc } = await readPrerenderBundle(response);
+    expect(html).toBe("<html>page</html>");
+    expect(rsc).toBe("flight-data");
     expect(common.waitUntilPromises).toHaveLength(0);
     expect(common.isrSet).not.toHaveBeenCalled();
   });
@@ -566,7 +591,9 @@ describe("app page render lifecycle", () => {
     });
 
     expect(response.headers.get("cache-control")).toBe("s-maxage=1, stale-while-revalidate=2");
-    await expect(response.text()).resolves.toBe("<html>page</html>");
+    const { html, rsc } = await readPrerenderBundle(response);
+    expect(html).toBe("<html>page</html>");
+    expect(rsc).toBe("flight-data");
     expect(common.isrSet).not.toHaveBeenCalled();
   });
 
@@ -605,7 +632,9 @@ describe("app page render lifecycle", () => {
     });
 
     expect(response.headers.get("cache-control")).toBe("s-maxage=1");
-    await expect(response.text()).resolves.toBe("<html>page</html>");
+    const { html, rsc } = await readPrerenderBundle(response);
+    expect(html).toBe("<html>page</html>");
+    expect(rsc).toBe("flight-data");
     expect(consumeRequestCacheLife()).toEqual({ revalidate: 1, expire: 1 });
   });
 
@@ -641,7 +670,9 @@ describe("app page render lifecycle", () => {
 
     expect(response.headers.get("cache-control")).toBe("s-maxage=1, stale-while-revalidate=2");
     expect(response.headers.get("x-vinext-cache")).toBe("MISS");
-    await expect(response.text()).resolves.toBe("<html>page</html>");
+    const { html, rsc } = await readPrerenderBundle(response);
+    expect(html).toBe("<html>page</html>");
+    expect(rsc).toBe("flight-data");
     expect(common.waitUntilPromises).toHaveLength(0);
     expect(common.isrSet).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## What this changes

App Router prerender renders each route once instead of twice. The HTML render already accumulates the raw Flight bytes through `getRawBuffer()` (used today for ISR cache metadata). This surfaces those bytes back to the prerender driver via a response side-channel — mirroring Next.js's `metadata.flightData` pattern — instead of re-invoking the handler with `RSC: 1`.

Alternative to #1097, which solves the same problem by parsing the embedded `<script>` chunks back out of the HTML response. Comparison below.

## How

- **Server side** ([app-page-render.ts](https://github.com/cloudflare/vinext/blob/alt/prerender-rsc-sidechannel/packages/vinext/src/server/app-page-render.ts)): when in prerender mode, append the captured raw RSC bytes to the HTML response body and set `x-vinext-rsc-byte-length`. Capture is mandatory in prerender mode for any route that reaches the renderer — `shouldCaptureRscForPrerender = isPrerender && !isForceDynamic && revalidateSeconds !== 0` covers `revalidate: Infinity` and force-static, which the existing cache-metadata predicate excluded.
- **Driver side** ([prerender.ts](https://github.com/cloudflare/vinext/blob/alt/prerender-rsc-sidechannel/packages/vinext/src/build/prerender.ts)): read the response as one `ArrayBuffer`, split at `total - x-vinext-rsc-byte-length`. No second invocation, no fallback path. A missing header throws — surfaces regressions loudly instead of silently double-rendering.

## Comparison vs #1097

| | #1097 (HTML scrape) | this PR (side-channel) |
|---|---|---|
| Lines changed | +447 / −9 | +141 / −21 |
| Render passes | 1 | 1 |
| HTML parsing | regex `<script>` walker + JSON-string tokenizer | none |
| RSC bytes source | embedded `<script>` chunks → `JSON.parse` → join | `getRawBuffer()` direct |
| `.rsc` content | `fixFlightHints`-rewritten Flight (`,"stylesheet"` → `,"style"` in HL hints) | **raw React Flight bytes — matches Next.js's `metadata.flightData`** |
| New protocols | inline-script chunk format with `__VINEXT_RSC_DONE__` sentinel | one response header |
| Coupling | reader tightly coupled to embed-emitter format | reuses existing `capturedRscDataRef` plumbing |
| Aligns with Next.js architecture | no — scrape after the fact | yes — single render, capture-as-side-channel |

Note: #1097's claim that "the RSC entry applies the same fix at the source, so extracted and separately requested .rsc output stay equivalent" is incorrect — `fixFlightHints` exists only in `app-ssr-stream.ts:createRscEmbedTransform` and is applied only to the HTML embed chunks. Adopting #1097 would change vinext's `.rsc` output relative to today.

## Validation

- `vp check` clean on all 3 changed files (formatting, lint, types)
- `vp test run tests/app-page-render.test.ts tests/app-page-cache.test.ts tests/app-page-execution.test.ts tests/app-ssr-stream.test.ts tests/prerender.test.ts` — **120 passed | 10 skipped** (only failure is the pre-existing CF Workers build setup error in `tests/prerender.test.ts > Cloudflare Workers hybrid build`, identical on `main`)
- The 4 prerender lifecycle tests in `tests/app-page-render.test.ts` were updated to assert the new `[HTML][RSC]` body shape via a `readPrerenderBundle` helper that mirrors the driver's split logic. They caught the contract change with the right diff at the right layer.

## Risks / follow-ups

- **`.rsc` output changes** (raw Flight, no `fixFlightHints` rewrite). This is alignment with Next.js, but if anything downstream relied on the rewritten form (CDN integrity hashes, snapshot tests of `.rsc` content), update those.
- **Memory**: HTML is buffered in memory in prerender mode. Same as today's `response.text()` and #1097's HTML scrape — no regression, but documents the constraint.
- **CF Workers prerender path** (`rscHandler` is a `fetch(...)` to a worker isolate): the wire goes over plain HTTP, headers and body work the same way. Not yet end-to-end-verified because the existing `Cloudflare Workers hybrid build` integration test fails at the build setup step on both main and this branch (rolldown/cloudflare-plugin issue, unrelated). Worth a manual run before flipping out of draft.
- **Header naming**: `x-vinext-rsc-byte-length` is on the actual HTTP response. The prerender prod-server is bound to `127.0.0.1` and gated by `x-vinext-prerender-secret`, so it shouldn't leak. Could prefix `x-vinext-internal-` to make it explicit — bikeshed.
- **Helper testability**: `appendCapturedRscToHtmlResponse` and the driver-side split are file-local. Worth extracting to a shared `prerender-bundle.ts` with named exports + dedicated unit tests for the encode/decode contract (round-trip, malformed header, RSC length > body length, multi-byte UTF-8 boundary in HTML).
- **TODO removal**: today's `// TODO: Extract RSC payload from the first response instead of invoking the handler twice.` is now obsolete — replaced with the side-channel comment.

## Test plan

- [x] Unit: `vp test run tests/app-page-render.test.ts` (22 passed, including 4 prerender lifecycle tests asserting new bundle shape)
- [x] Cache writeback: `vp test run tests/app-page-cache.test.ts` (28 passed — confirms runtime ISR cache path unaffected)
- [x] Capture mechanism: `vp test run tests/app-ssr-stream.test.ts tests/app-page-execution.test.ts` (raw bytes, fused tee, fixFlightHints non-application all verified)
- [x] Integration: `vp test run tests/prerender.test.ts` (49 passed for app-basic prerender; CF Workers integration unverified due to pre-existing setup issue)
- [ ] Manual end-to-end CF Workers prerender (`vinext build` on a real Workers project)
- [ ] Confirm no public client breakage from the `.rsc` content change (raw vs rewritten Flight)

Refs #563