### PR TITLE
fix(config): handle ssr.external: true in App Router (closes #1103)

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -1193,16 +1193,25 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           //   Any user-provided `ssr.noExternal` is intentionally superseded
           //   by this setting; only `ssr.external` entries escape Vite's transform.
           // Skip when targeting bundled runtimes (Cloudflare/Nitro bundle everything).
+          // Also skip `noExternal: true` when the user opted into
+          // `ssr.external: true` — they've explicitly asked for everything
+          // external, and forcing `noExternal: true` here leaks down into
+          // `environments.ssr.resolve.noExternal` (Vite uses top-level
+          // `ssr.*` as the default for the per-env resolve config), which
+          // makes Vite bundle React despite the user's intent and produces
+          // the duplicate-React crashes documented in #1103.
           // This also resolves extensionless-import issues in packages like
           // `validator` (see #189) by routing them through Vite's resolver.
           ...(hasCloudflarePlugin || hasNitroPlugin
             ? {}
-            : {
-                ssr: {
-                  external: ["react", "react-dom", "react-dom/server"],
-                  noExternal: true,
-                },
-              }),
+            : config.ssr?.external === true
+              ? { ssr: { external: true as const } }
+              : {
+                  ssr: {
+                    external: ["react", "react-dom", "react-dom/server"],
+                    noExternal: true,
+                  },
+                }),
           resolve: {
             // Materialize simple tsconfig/jsconfig path aliases into resolve.alias
             // so Vite can transform import.meta.glob("@/...") and import(`@/...`).
@@ -1519,6 +1528,37 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
       },
 
       configResolved(config) {
+        // When the user sets `ssr.external: true`, strip React entries from
+        // `environments.ssr.resolve.noExternal`. @vitejs/plugin-rsc populates
+        // this list via crawlFrameworkPkgs, but `noExternal` overrides
+        // `external: true` for the listed packages. The result is that React
+        // gets bundled by Vite's transform pipeline despite the user opting
+        // for full externalization, producing a second React module record
+        // alongside the Node-loaded one used by externalized callers (vinext's
+        // runtime). 'use client' modules SSR'd through the bundled-React env
+        // then crash with `Invalid hook call` / `useContext null`. Stripping
+        // these entries forces the SSR env to load React via Node externals,
+        // matching the renderer's React. See #1103.
+        if (hasAppDir) {
+          const ssrEnv = config.environments?.ssr;
+          if (ssrEnv?.resolve?.external === true && Array.isArray(ssrEnv.resolve.noExternal)) {
+            // Strip React entries that @vitejs/plugin-rsc auto-adds to
+            // `environments.ssr.resolve.noExternal` via crawlFrameworkPkgs.
+            // With `ssr.external: true`, the SSR env loads React via Node's
+            // resolver, but `noExternal: ["react", ...]` overrides that for
+            // the listed packages — Vite bundles React anyway, producing a
+            // second module record alongside the Node-loaded one used by
+            // externalized callers (vinext's runtime). 'use client' modules
+            // SSR'd through that env then crash with `useContext null` /
+            // `Invalid hook call`. Stripping these entries forces the SSR
+            // env to load React via Node externals so the renderer and the
+            // runtime share a single React. See #1103.
+            ssrEnv.resolve.noExternal = ssrEnv.resolve.noExternal.filter(
+              (entry) => typeof entry !== "string" || !SSR_EXTERNAL_REACT_ENTRIES.includes(entry),
+            );
+          }
+        }
+
         // Detect double React plugin registration. When vinext auto-injects
         // @vitejs/plugin-react AND the user also registers it manually, the
         // React transform / refresh pipeline runs twice.

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -79,6 +79,7 @@ import { createOptimizeImportsPlugin } from "./plugins/optimize-imports.js";
 import { createOgInlineFetchAssetsPlugin, ogAssetsPlugin } from "./plugins/og-assets.js";
 import {
   mergeOptimizeDepsExclude,
+  SSR_EXTERNAL_REACT_ENTRIES,
   VINEXT_OPTIMIZE_DEPS_EXCLUDE,
 } from "./plugins/rsc-client-shim-excludes.js";
 import { createServerExternalsManifestPlugin } from "./plugins/server-externals-manifest.js";
@@ -651,7 +652,9 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         });
       })
       .catch((cause) => {
-        throw new Error("vinext: Failed to load @vitejs/plugin-rsc.", { cause });
+        throw new Error("vinext: Failed to load @vitejs/plugin-rsc.", {
+          cause,
+        });
       });
   }
 
@@ -671,7 +674,9 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
     reactPluginPromise = reactImport
       .then((mod) => (mod as VitePluginReactModule).default(reactOptions))
       .catch((cause) => {
-        throw new Error("vinext: Failed to load @vitejs/plugin-react.", { cause });
+        throw new Error("vinext: Failed to load @vitejs/plugin-react.", {
+          cause,
+        });
       });
   }
 
@@ -1150,7 +1155,9 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
               // moduleSideEffects: 'no-external' could drop server packages
               // that rely on module-level side effects.
               ...(!isSSR && !isMultiEnv
-                ? { treeshake: getClientTreeshakeConfigForVite(viteMajorVersion) }
+                ? {
+                    treeshake: getClientTreeshakeConfigForVite(viteMajorVersion),
+                  }
                 : {}),
               // Code-split client bundles: separate framework (React/ReactDOM),
               // vinext runtime (shims), and vendor packages into their own
@@ -1199,7 +1206,11 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           resolve: {
             // Materialize simple tsconfig/jsconfig path aliases into resolve.alias
             // so Vite can transform import.meta.glob("@/...") and import(`@/...`).
-            alias: { ...tsconfigPathAliases, ...nextConfig.aliases, ...nextShimMap },
+            alias: {
+              ...tsconfigPathAliases,
+              ...nextConfig.aliases,
+              ...nextShimMap,
+            },
             // Dedupe React packages to prevent dual-instance errors.
             // When vinext is linked (npm link / bun link) or any dependency
             // brings its own React copy, multiple React instances can load,
@@ -1357,7 +1368,17 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                     },
                   }),
               optimizeDeps: {
-                exclude: mergeOptimizeDepsExclude(incomingExclude, VINEXT_OPTIMIZE_DEPS_EXCLUDE),
+                // When userSsrExternal === true, exclude React from the SSR
+                // optimizer so plugin-rsc's crawlFrameworkPkgs doesn't pre-bundle
+                // a duplicate React copy into deps_ssr/. The SSR env loads React
+                // via Node's resolver instead, sharing one instance with the
+                // renderer and any 'use client' module SSR'd through it. See
+                // https://github.com/cloudflare/vinext/issues/1103.
+                exclude: mergeOptimizeDepsExclude(
+                  incomingExclude,
+                  VINEXT_OPTIMIZE_DEPS_EXCLUDE,
+                  userSsrExternal === true ? SSR_EXTERNAL_REACT_ENTRIES : [],
+                ),
                 entries: optimizeEntries,
               },
               build: {
@@ -2384,7 +2405,9 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
               const requestOrigin = `http://${req.headers.host || "localhost"}`;
               const preMiddlewareReqUrl = new URL(url, requestOrigin);
               const preMiddlewareReqCtx: RequestContext = requestContextFromRequest(
-                new Request(preMiddlewareReqUrl, { headers: nodeRequestHeaders }),
+                new Request(preMiddlewareReqUrl, {
+                  headers: nodeRequestHeaders,
+                }),
               );
 
               // Config redirects run before middleware, but still match against
@@ -3237,7 +3260,9 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           }
         },
       },
-    } as Plugin & { nitro: { setup: (nitro: NitroSetupContext) => Promise<void> } }, // Nitro plugin extension convention: https://nitro.build/guide/plugins
+    } as Plugin & {
+      nitro: { setup: (nitro: NitroSetupContext) => Promise<void> };
+    }, // Nitro plugin extension convention: https://nitro.build/guide/plugins
     // Vite can emit empty SSR manifest entries for modules that Rollup inlines
     // into another chunk. Pages Router looks up assets by page module path at
     // runtime, so rebuild those mappings from the emitted client bundle.

--- a/packages/vinext/src/plugins/rsc-client-shim-excludes.ts
+++ b/packages/vinext/src/plugins/rsc-client-shim-excludes.ts
@@ -21,6 +21,25 @@ export const VINEXT_OPTIMIZE_DEPS_EXCLUDE = Object.freeze([
   ...RSC_CLIENT_SHIM_OPTIMIZE_DEPS_EXCLUDE,
 ]);
 
+// React entries that @vitejs/plugin-rsc adds to environments.ssr.optimizeDeps.include
+// via crawlFrameworkPkgs. When the user sets ssr.external: true, the SSR env loads
+// everything via Node's resolver (including React from /node_modules/react). If Vite
+// also pre-bundles React into deps_ssr/, two distinct React module records coexist:
+// react-dom-server.edge sets the dispatcher on its bundled React, but externalized
+// callers (vinext's runtime, and 'use client' modules going through the SSR transform)
+// see a different React → React.H is null → useContext / useSyncExternalStore crash.
+// Adding these to optimizeDeps.exclude keeps deps_ssr/ React-free so the runtime and
+// the renderer share a single Node-loaded React copy.
+export const SSR_EXTERNAL_REACT_ENTRIES = Object.freeze([
+  "react",
+  "react-dom",
+  "react-dom/server.edge",
+  "react-dom/static.edge",
+  "react/jsx-runtime",
+  "react/jsx-dev-runtime",
+  "react-server-dom-webpack/client.edge",
+]);
+
 export function mergeOptimizeDepsExclude(
   ...excludeGroups: readonly (readonly string[])[]
 ): string[] {

--- a/tests/build-optimization.test.ts
+++ b/tests/build-optimization.test.ts
@@ -348,6 +348,12 @@ describe("optimizeDeps.exclude for vinext", () => {
       const rscExclude = result.environments.rsc.optimizeDeps?.exclude ?? [];
       expect(rscExclude).not.toContain("react");
       expect(rscExclude).not.toContain("react-dom");
+      // Top-level ssr.noExternal: true also needs to be skipped — Vite
+      // applies top-level ssr.* as defaults for environments.ssr.*, so
+      // setting noExternal: true here would force-bundle React despite
+      // external: true and recreate the duplicate-React bug.
+      expect(result.ssr?.noExternal).toBeUndefined();
+      expect(result.ssr?.external).toBe(true);
     } finally {
       await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
     }

--- a/tests/build-optimization.test.ts
+++ b/tests/build-optimization.test.ts
@@ -146,7 +146,9 @@ describe("optimizeDeps.exclude for vinext", () => {
         plugins: [],
         optimizeDeps: { exclude: ["@lingui/macro"] },
       };
-      const result = await (mainPlugin as any).config(mockConfig, { command: "build" });
+      const result = await (mainPlugin as any).config(mockConfig, {
+        command: "build",
+      });
 
       expect(result.optimizeDeps?.exclude).toContain("vinext");
       expect(result.optimizeDeps?.exclude).toContain("@vercel/og");
@@ -201,7 +203,9 @@ describe("optimizeDeps.exclude for vinext", () => {
           include: ["some-lib"],
         },
       };
-      const result = await (mainPlugin as any).config(mockConfig, { command: "build" });
+      const result = await (mainPlugin as any).config(mockConfig, {
+        command: "build",
+      });
 
       // All environments should contain the incoming excludes
       for (const envName of ["rsc", "ssr", "client"]) {
@@ -260,7 +264,9 @@ describe("optimizeDeps.exclude for vinext", () => {
 
     try {
       const mockConfig = { root: tmpDir, build: {}, plugins: [] };
-      const result = await (mainPlugin as any).config(mockConfig, { command: "build" });
+      const result = await (mainPlugin as any).config(mockConfig, {
+        command: "build",
+      });
 
       // Top-level
       expect(result.optimizeDeps?.exclude).toContain("vinext");
@@ -273,6 +279,168 @@ describe("optimizeDeps.exclude for vinext", () => {
         expect(result.environments.rsc.optimizeDeps?.exclude).toContain(shimExclude);
         expect(result.environments.ssr.optimizeDeps?.exclude).toContain(shimExclude);
         expect(result.environments.client.optimizeDeps?.exclude).toContain(shimExclude);
+      }
+    } finally {
+      await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }, 15000);
+
+  // Regression for #1103: when the user sets `ssr.external: true`, plugin-rsc's
+  // crawlFrameworkPkgs adds React to environments.ssr.optimizeDeps.include and
+  // Vite pre-bundles a second React copy into deps_ssr/. Externalized callers
+  // (vinext's runtime) and SSR-transformed 'use client' modules then end up
+  // with two distinct React module records, leaving React.H null and crashing
+  // every useContext / useSyncExternalStore call. The fix excludes React from
+  // the SSR optimizer so deps_ssr/ stays React-free.
+  const ssrExternalReactEntries = [
+    "react",
+    "react-dom",
+    "react-dom/server.edge",
+    "react-dom/static.edge",
+    "react/jsx-runtime",
+    "react/jsx-dev-runtime",
+    "react-server-dom-webpack/client.edge",
+  ];
+
+  it("excludes React from ssr optimizeDeps when ssr.external: true (App Router)", async () => {
+    const vinext = (await import("../packages/vinext/src/index.js")).default;
+    const plugins = vinext();
+    const mainPlugin = plugins.find(
+      (p: any) => p.name === "vinext:config" && typeof p.config === "function",
+    );
+    expect(mainPlugin).toBeDefined();
+
+    const os = await import("node:os");
+    const fsp = await import("node:fs/promises");
+    const path = await import("node:path");
+
+    const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "vinext-ts-test-optdeps-react-true-"));
+    const rootNodeModules = path.resolve(import.meta.dirname, "../node_modules");
+    await fsp.symlink(rootNodeModules, path.join(tmpDir, "node_modules"), "junction");
+    await fsp.mkdir(path.join(tmpDir, "app"), { recursive: true });
+    await fsp.writeFile(
+      path.join(tmpDir, "app", "layout.tsx"),
+      `export default function RootLayout({ children }: { children: React.ReactNode }) { return <html><body>{children}</body></html>; }`,
+    );
+    await fsp.writeFile(
+      path.join(tmpDir, "app", "page.tsx"),
+      `export default function Home() { return <h1>Home</h1>; }`,
+    );
+    await fsp.writeFile(path.join(tmpDir, "next.config.mjs"), `export default {};`);
+
+    try {
+      const mockConfig = {
+        root: tmpDir,
+        build: {},
+        plugins: [],
+        ssr: { external: true },
+      };
+      const result = await (mainPlugin as any).config(mockConfig, {
+        command: "serve",
+      });
+
+      const ssrExclude = result.environments.ssr.optimizeDeps?.exclude ?? [];
+      for (const entry of ssrExternalReactEntries) {
+        expect(ssrExclude, `ssr exclude should contain ${entry}`).toContain(entry);
+      }
+      // RSC env still needs the react-server condition pre-bundled, so React
+      // must NOT be excluded there.
+      const rscExclude = result.environments.rsc.optimizeDeps?.exclude ?? [];
+      expect(rscExclude).not.toContain("react");
+      expect(rscExclude).not.toContain("react-dom");
+    } finally {
+      await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }, 15000);
+
+  it("does NOT exclude React from ssr optimizeDeps when ssr.external is unset", async () => {
+    // Default mode (vinext sets noExternal: true on ssr) still pre-bundles
+    // React into deps_ssr — that's the path that already works because
+    // everything is bundled with one React copy.
+    const vinext = (await import("../packages/vinext/src/index.js")).default;
+    const plugins = vinext();
+    const mainPlugin = plugins.find(
+      (p: any) => p.name === "vinext:config" && typeof p.config === "function",
+    );
+    expect(mainPlugin).toBeDefined();
+
+    const os = await import("node:os");
+    const fsp = await import("node:fs/promises");
+    const path = await import("node:path");
+
+    const tmpDir = await fsp.mkdtemp(
+      path.join(os.tmpdir(), "vinext-ts-test-optdeps-react-default-"),
+    );
+    const rootNodeModules = path.resolve(import.meta.dirname, "../node_modules");
+    await fsp.symlink(rootNodeModules, path.join(tmpDir, "node_modules"), "junction");
+    await fsp.mkdir(path.join(tmpDir, "app"), { recursive: true });
+    await fsp.writeFile(
+      path.join(tmpDir, "app", "layout.tsx"),
+      `export default function RootLayout({ children }: { children: React.ReactNode }) { return <html><body>{children}</body></html>; }`,
+    );
+    await fsp.writeFile(
+      path.join(tmpDir, "app", "page.tsx"),
+      `export default function Home() { return <h1>Home</h1>; }`,
+    );
+    await fsp.writeFile(path.join(tmpDir, "next.config.mjs"), `export default {};`);
+
+    try {
+      const mockConfig = { root: tmpDir, build: {}, plugins: [] };
+      const result = await (mainPlugin as any).config(mockConfig, {
+        command: "serve",
+      });
+
+      const ssrExclude = result.environments.ssr.optimizeDeps?.exclude ?? [];
+      for (const entry of ssrExternalReactEntries) {
+        expect(ssrExclude, `ssr exclude should NOT contain ${entry}`).not.toContain(entry);
+      }
+    } finally {
+      await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }, 15000);
+
+  it("does NOT exclude React from ssr optimizeDeps when ssr.external is a string array", async () => {
+    // Array form of ssr.external (e.g. ['pg']) should not trigger the
+    // React strip — only the blanket `true` form does.
+    const vinext = (await import("../packages/vinext/src/index.js")).default;
+    const plugins = vinext();
+    const mainPlugin = plugins.find(
+      (p: any) => p.name === "vinext:config" && typeof p.config === "function",
+    );
+    expect(mainPlugin).toBeDefined();
+
+    const os = await import("node:os");
+    const fsp = await import("node:fs/promises");
+    const path = await import("node:path");
+
+    const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "vinext-ts-test-optdeps-react-array-"));
+    const rootNodeModules = path.resolve(import.meta.dirname, "../node_modules");
+    await fsp.symlink(rootNodeModules, path.join(tmpDir, "node_modules"), "junction");
+    await fsp.mkdir(path.join(tmpDir, "app"), { recursive: true });
+    await fsp.writeFile(
+      path.join(tmpDir, "app", "layout.tsx"),
+      `export default function RootLayout({ children }: { children: React.ReactNode }) { return <html><body>{children}</body></html>; }`,
+    );
+    await fsp.writeFile(
+      path.join(tmpDir, "app", "page.tsx"),
+      `export default function Home() { return <h1>Home</h1>; }`,
+    );
+    await fsp.writeFile(path.join(tmpDir, "next.config.mjs"), `export default {};`);
+
+    try {
+      const mockConfig = {
+        root: tmpDir,
+        build: {},
+        plugins: [],
+        ssr: { external: ["pg"] },
+      };
+      const result = await (mainPlugin as any).config(mockConfig, {
+        command: "serve",
+      });
+
+      const ssrExclude = result.environments.ssr.optimizeDeps?.exclude ?? [];
+      for (const entry of ssrExternalReactEntries) {
+        expect(ssrExclude, `ssr exclude should NOT contain ${entry}`).not.toContain(entry);
       }
     } finally {
       await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
@@ -316,7 +484,10 @@ describe("process.env.NODE_ENV define", () => {
     const { mainPlugin, tmpDir, fsp } = await setupTmpProject();
     try {
       const mockConfig = { root: tmpDir, build: {}, plugins: [] };
-      const result = await mainPlugin.config(mockConfig, { command: "build", mode: "production" });
+      const result = await mainPlugin.config(mockConfig, {
+        command: "build",
+        mode: "production",
+      });
 
       expect(result.define?.["process.env.NODE_ENV"]).toBe(JSON.stringify("production"));
     } finally {
@@ -343,7 +514,10 @@ describe("process.env.NODE_ENV define", () => {
     const { mainPlugin, tmpDir, fsp } = await setupTmpProject();
     try {
       const mockConfig = { root: tmpDir, build: {}, plugins: [] };
-      const result = await mainPlugin.config(mockConfig, { command: "serve", mode: "development" });
+      const result = await mainPlugin.config(mockConfig, {
+        command: "serve",
+        mode: "development",
+      });
 
       expect(result.define?.["process.env.NODE_ENV"]).toBe(JSON.stringify("development"));
     } finally {
@@ -360,7 +534,10 @@ describe("process.env.NODE_ENV define", () => {
         plugins: [],
         define: { "process.env.NODE_ENV": JSON.stringify("staging") },
       };
-      const result = await mainPlugin.config(mockConfig, { command: "build", mode: "production" });
+      const result = await mainPlugin.config(mockConfig, {
+        command: "build",
+        mode: "production",
+      });
 
       // Should NOT override the user's explicit define
       expect(result.define?.["process.env.NODE_ENV"]).toBeUndefined();
@@ -405,7 +582,9 @@ describe("treeshake config integration", () => {
         build: {},
         plugins: [],
       };
-      const result = await (mainPlugin as any).config(mockConfig, { command: "build" });
+      const result = await (mainPlugin as any).config(mockConfig, {
+        command: "build",
+      });
 
       // treeshake should be set on bundler options for non-SSR builds
       expect(getBuildBundlerOptions(result).treeshake).toEqual({
@@ -446,7 +625,9 @@ describe("treeshake config integration", () => {
         build: { ssr: "virtual:vinext-server-entry" },
         plugins: [],
       };
-      const result = await (mainPlugin as any).config(mockConfig, { command: "build" });
+      const result = await (mainPlugin as any).config(mockConfig, {
+        command: "build",
+      });
 
       // treeshake should NOT be set for SSR builds
       expect(getBuildBundlerOptions(result).treeshake).toBeUndefined();
@@ -493,7 +674,9 @@ describe("treeshake config integration", () => {
         build: {},
         plugins: [],
       };
-      const result = await (mainPlugin as any).config(mockConfig, { command: "build" });
+      const result = await (mainPlugin as any).config(mockConfig, {
+        command: "build",
+      });
 
       // Global bundler options should NOT have treeshake (would leak into RSC/SSR)
       expect(getBuildBundlerOptions(result).treeshake).toBeUndefined();
@@ -541,7 +724,9 @@ describe("treeshake config integration", () => {
         build: {},
         plugins: [],
       };
-      const result = await (mainPlugin as any).config(mockConfig, { command: "build" });
+      const result = await (mainPlugin as any).config(mockConfig, {
+        command: "build",
+      });
 
       // For standalone client builds (non-SSR, non-multi-env),
       // output config should include the min chunk size setting.
@@ -600,7 +785,9 @@ describe("treeshake config integration", () => {
         build: {},
         plugins: [fakeCloudflarePlugin],
       };
-      const result = await (mainPlugin as any).config(mockConfig, { command: "build" });
+      const result = await (mainPlugin as any).config(mockConfig, {
+        command: "build",
+      });
 
       // Client environment should have manifest: true for lazy chunk detection
       expect(result.environments).toBeDefined();
@@ -1302,7 +1489,9 @@ describe("vinext:async-hooks-stub", () => {
   // mock context to control which environment is being simulated.
   function resolveId(id: string, environmentName: string | undefined): string | undefined {
     const handler = (
-      _asyncHooksStubPlugin.resolveId as { handler: (id: string) => string | undefined }
+      _asyncHooksStubPlugin.resolveId as {
+        handler: (id: string) => string | undefined;
+      }
     ).handler;
     return handler.call(
       { environment: environmentName ? { name: environmentName } : undefined },
@@ -1311,8 +1500,11 @@ describe("vinext:async-hooks-stub", () => {
   }
 
   function load(id: string): string | undefined {
-    const handler = (_asyncHooksStubPlugin.load as { handler: (id: string) => string | undefined })
-      .handler;
+    const handler = (
+      _asyncHooksStubPlugin.load as {
+        handler: (id: string) => string | undefined;
+      }
+    ).handler;
     return handler.call({}, id);
   }
 


### PR DESCRIPTION
Closes #1103.

## What

When the user sets `ssr.external: true` in their `vite.config.ts`, ensure no React copy gets bundled into the SSR env. Two changes:

1. Strip React entries from `environments.ssr.optimizeDeps.exclude` so `@vitejs/plugin-rsc`'s `crawlFrameworkPkgs` cannot pre-bundle a duplicate React into `deps_ssr/`.
2. When `config.ssr.external === true`, vinext only sets `ssr: { external: true }` at the top level — no `noExternal: true` to leak into the per-env config (Vite uses top-level `ssr.*` as defaults for `environments.ssr.*`). Plus a defensive `configResolved` hook that strips React from `environments.ssr.resolve.noExternal` if anything re-added it.

## Why

With `ssr.external: true`, the SSR env loads everything via Node's resolver — including React from `/node_modules/react`. But `optimizeDeps.include` overrides `external: true`, and `noExternal: ['react', ...]` defeats `external` for those entries. The result is two distinct React module records:

- vinext's runtime (loaded via Node externals) → `/node_modules/react/index.js`
- 'use client' modules SSR'd through the bundled-React env → Vite-resolved React

`react-dom-server.edge` sets the dispatcher on its bundled React; externalized callers see a different React → `React.H` is null → every hook call from a `'use client'` module crashes with `Cannot read properties of null (reading 'useContext')` / `Invalid hook call`.

The default mode (`noExternal: true`) is unaffected because everything bundled in one pass = one React. Build is unaffected for the same reason.

## How

```ts
// SSR env's optimizeDeps.exclude — strip React when external is fully external:
optimizeDeps: {
  exclude: mergeOptimizeDepsExclude(
    incomingExclude,
    VINEXT_OPTIMIZE_DEPS_EXCLUDE,
    userSsrExternal === true ? SSR_EXTERNAL_REACT_ENTRIES : [],
  ),
  entries: optimizeEntries,
},

// Top-level ssr block — gate on user's external: true so noExternal: true
// doesn't leak into environments.ssr.resolve.noExternal as a default:
...(hasCloudflarePlugin || hasNitroPlugin
  ? {}
  : config.ssr?.external === true
    ? { ssr: { external: true as const } }
    : { ssr: { external: ['react', 'react-dom', 'react-dom/server'], noExternal: true } }),

// configResolved — defensive strip if anything re-added React:
if (hasAppDir) {
  const ssrEnv = config.environments?.ssr;
  if (ssrEnv?.resolve?.external === true && Array.isArray(ssrEnv.resolve.noExternal)) {
    ssrEnv.resolve.noExternal = ssrEnv.resolve.noExternal.filter(
      (entry) => typeof entry !== 'string' || !SSR_EXTERNAL_REACT_ENTRIES.includes(entry),
    );
  }
}
```

The RSC env is left alone (it still pre-bundles React with the `react-server` condition).

## Tests

Three new cases in `tests/build-optimization.test.ts`:

1. `excludes React from ssr optimizeDeps when ssr.external: true (App Router)` — verifies the strip applies, that RSC env still pre-bundles React, and that top-level `ssr.noExternal` is undefined.
2. `does NOT exclude React from ssr optimizeDeps when ssr.external is unset` — default mode unchanged.
3. `does NOT exclude React from ssr optimizeDeps when ssr.external is a string array` — only the blanket `true` form triggers the strip.

`pnpm test --project unit` ⇒ 131/131 files, 3,736 tests pass.
`pnpm run check` ⇒ clean (1 unrelated pre-existing warning).

## Manual verification

Applied locally to a real-world App Router app (~80 deps including nuqs, next-themes, launchdarkly-react, blocknote, opentelemetry, pg, protobufjs, keyv, etc.) configured with `ssr.external: true`. Before the fix: every `'use client'` route crashed with `useContext null` in dev. After the fix: routes render correctly, hooks fire as expected.