### PR TITLE
fix(router): canonicalize App RSC route-match path parts

### DIFF
--- a/packages/vinext/src/server/app-rsc-route-matching.ts
+++ b/packages/vinext/src/server/app-rsc-route-matching.ts
@@ -1,5 +1,6 @@
 import { buildRouteTrie, trieMatch } from "../routing/route-trie.js";
 import { matchRoutePattern, type RoutePatternParams } from "../routing/route-pattern.js";
+import { normalizePathnameForRouteMatch } from "../routing/utils.js";
 
 type AppRscRouteParams = RoutePatternParams;
 
@@ -37,6 +38,12 @@ function createRouteParams(): AppRscRouteParams {
   return Object.create(null);
 }
 
+function appRscPathnameParts(pathname: string): string[] {
+  const pathOnly = pathname.split("?")[0];
+  const normalized = pathOnly === "/" ? "/" : pathOnly.replace(/\/$/, "");
+  return normalizePathnameForRouteMatch(normalized).split("/").filter(Boolean);
+}
+
 export function createAppRscRouteMatcher<Route extends AppRscRouteForMatching>(
   routes: Route[],
 ): {
@@ -48,22 +55,17 @@ export function createAppRscRouteMatcher<Route extends AppRscRouteForMatching>(
 
   return {
     matchRoute(url) {
-      const pathname = url.split("?")[0];
-      const normalizedUrl = pathname === "/" ? "/" : pathname.replace(/\/$/, "");
-      // The request entry point owns decoding. Matching here preserves the
-      // already-normalized segment bytes so middleware and routing stay aligned.
-      const urlParts = normalizedUrl.split("/").filter(Boolean);
-      return trieMatch(routeTrie, urlParts);
+      return trieMatch(routeTrie, appRscPathnameParts(url));
     },
     findIntercept(pathname, sourcePathname = null) {
-      const urlParts = pathname.split("/").filter(Boolean);
+      const urlParts = appRscPathnameParts(pathname);
       for (const entry of interceptLookup) {
         const params = matchAppRscRoutePattern(urlParts, entry.targetPatternParts);
         if (params !== null) {
           let sourceParams = createRouteParams();
           if (sourcePathname !== null) {
             const sourceRoute = routes[entry.sourceRouteIndex];
-            const sourceParts = sourcePathname.split("/").filter(Boolean);
+            const sourceParts = appRscPathnameParts(sourcePathname);
             const matchedSourceParams = sourceRoute
               ? matchAppRscRoutePattern(sourceParts, sourceRoute.patternParts)
               : null;

--- a/tests/app-rsc-route-matching.test.ts
+++ b/tests/app-rsc-route-matching.test.ts
@@ -59,6 +59,26 @@ describe("App RSC route matching", () => {
     });
   });
 
+  it("canonicalizes encoded URL parts before matching app routes", () => {
+    // Next.js canonicalizes URL pathname parts before deriving dynamic segment
+    // cache keys; vinext should apply the same decode-first discipline at the
+    // App RSC route-match boundary so encoded static segments and params use
+    // one normalized representation.
+    // https://github.com/vercel/next.js/blob/47bcfa0956679c2a5fea0b941b76bb2d69878d9c/packages/next/src/client/route-params.ts
+    const matcher = createAppRscRouteMatcher([
+      route("/_sites/:subdomain", ["_sites", ":subdomain"]),
+      route("/files/:name", ["files", ":name"]),
+    ]);
+
+    expect(matcher.matchRoute("/%5Fsites/demo")).toMatchObject({
+      route: { pattern: "/_sites/:subdomain" },
+      params: { subdomain: "demo" },
+    });
+    expect(matcher.matchRoute("/files/a%252Fb")).toMatchObject({
+      params: { name: "a%2Fb" },
+    });
+  });
+
   it("matches standalone route patterns for dynamic metadata routes", () => {
     expect(
       matchAppRscRoutePattern(["blog", "hello", "sitemap.xml"], ["blog", ":slug", "sitemap.xml"]),
@@ -99,6 +119,28 @@ describe("App RSC route matching", () => {
       targetPattern: "/photos/:id",
       page: "photo-page",
       matchedParams: { id: "target-id" },
+    });
+  });
+
+  it("canonicalizes encoded source path parts for interception params", () => {
+    const matcher = createAppRscRouteMatcher([
+      route("/_sites/:tenant", ["_sites", ":tenant"], {
+        modal: {
+          intercepts: [
+            {
+              targetPattern: "/photos/:id",
+              interceptLayouts: ["modal-layout"],
+              page: "photo-page",
+              params: ["id"],
+            },
+          ],
+        },
+      }),
+    ]);
+
+    expect(matcher.findIntercept("/photos/a%2Fb", "/%5Fsites/acme")).toMatchObject({
+      targetPattern: "/photos/:id",
+      matchedParams: { tenant: "acme", id: "a/b" },
     });
   });
 


### PR DESCRIPTION
## What this changes
App RSC route matching now canonicalizes URL pathname parts before splitting and matching routes. This puts direct App RSC route lookup and interception source-route lookup on the same decode-first path used elsewhere in vinext routing.

Fixes #1099.

## Why
Next.js fixed a related client-side bug where pathname parts from `URL.pathname.split("/")` were encoded again, so `%2F` became `%252F` and client-derived segment keys diverged from server-derived keys. See [vercel/next.js#93491](https://github.com/vercel/next.js/pull/93491), [commit 47bcfa0](https://github.com/vercel/next.js/commit/47bcfa0956679c2a5fea0b941b76bb2d69878d9c), and the changed [route-params.ts](https://github.com/vercel/next.js/blob/47bcfa0956679c2a5fea0b941b76bb2d69878d9c/packages/next/src/client/route-params.ts). The server-side invariant it matches is in Next.js [get-dynamic-param.ts](https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/router/utils/get-dynamic-param.ts).

Vinext does not have the same Segment Cache helper to patch. We send server-matched params to the client in RSC payload headers and hydration data. The equivalent risk in vinext is the App RSC matcher boundary still assumed callers had already normalized encoded pathname parts. That meant direct App RSC matching could miss encoded static segments such as `/%5Fsites/demo`, and interception source params could be dropped when source paths arrived encoded.

## Approach
This keeps the fix local to `createAppRscRouteMatcher`:

- reuse vinext's existing `normalizePathnameForRouteMatch` helper before splitting App RSC match paths
- apply the same helper to direct route matches, intercept target paths, and intercept source paths
- preserve the existing route-trie and `matchRoutePattern` decoding contract, so dynamic params are decoded exactly once

I did not add a Next.js-style `parseDynamicParamFromURLPart` clone because vinext does not derive App Router client segment keys that way today. Centralizing normalization at this matcher boundary is smaller and fits the current architecture better.

## Validation
- Added regression coverage in `tests/app-rsc-route-matching.test.ts` for encoded static path matching, exactly-once dynamic param decoding, and encoded interception source params.
- Verified the new tests fail before the implementation and pass after it.
- `vp test run tests/app-rsc-route-matching.test.ts tests/app-rsc-request-normalization.test.ts tests/route-pattern.test.ts tests/route-trie.test.ts tests/app-rsc-handler.test.ts tests/app-page-request.test.ts tests/app-server-action-execution.test.ts`
- `vp fmt --check packages/vinext/src/server/app-rsc-route-matching.ts tests/app-rsc-route-matching.test.ts`
- `vp lint packages/vinext/src/server/app-rsc-route-matching.ts tests/app-rsc-route-matching.test.ts`
- `git diff --check`
- `vp check` completed with no errors; it still reports the existing unrelated warning in `packages/vinext/src/server/request-pipeline.ts:604` about `unknown | undefined`.

## Risks / follow-ups
This deliberately does not change full request normalization order. Security-sensitive strict percent decoding, basePath handling, dot-segment resolution, and protocol-relative guards remain owned by `normalizeRscRequest`. This matcher only makes route lookup robust when a caller hands it encoded but otherwise valid path parts.