### PR TITLE
fix(actions): cap decoded server action arguments

### DIFF
--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -176,6 +176,12 @@ type ActionControlResponse =
       statusCode: number;
     };
 
+/**
+ * Matches Next.js' server action argument cap to prevent stack overflow in
+ * Function.prototype.apply when decoding hostile action payloads.
+ */
+const SERVER_ACTION_ARGS_LIMIT = 1000;
+
 function isRequestBodyTooLarge(error: unknown): boolean {
   return error instanceof Error && error.message === "Request body too large";
 }
@@ -190,6 +196,14 @@ function normalizeError(error: unknown): Error {
 
 function getServerActionFailureMessage(error: unknown): string {
   return error instanceof Error && error.message ? error.message : String(error);
+}
+
+function validateServerActionArgs(args: readonly unknown[]): void {
+  if (args.length > SERVER_ACTION_ARGS_LIMIT) {
+    throw new Error(
+      `Server Action arguments list is too long (${args.length}). Maximum allowed is ${SERVER_ACTION_ARGS_LIMIT}.`,
+    );
+  }
 }
 
 export async function readActionBodyWithLimit(request: Request, maxBytes: number): Promise<string> {
@@ -527,6 +541,7 @@ export async function handleServerActionRscRequest<
     const previousHeadersPhase = options.setHeadersAccessPhase("action");
     try {
       try {
+        validateServerActionArgs(args);
         const data = await action.apply(null, args);
         returnValue = { ok: true, data };
       } catch (error) {

--- a/tests/app-server-action-execution.test.ts
+++ b/tests/app-server-action-execution.test.ts
@@ -601,6 +601,47 @@ describe("app server action execution helpers", () => {
     expect(navigationContexts).toEqual([{ params: {}, pathname: "/dashboard" }]);
   });
 
+  // Ported from Next.js: test/e2e/app-dir/actions/app-action.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/actions/app-action.test.ts
+  it("rejects fetch actions with too many decoded arguments before invoking the action", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const action = vi.fn();
+      let renderedModel: TestActionModel | null = null;
+
+      const response = await handleServerActionRscRequest(
+        createRscOptions({
+          decodeReply() {
+            return Array.from({ length: 1001 }, (_, index) => index);
+          },
+          loadServerAction() {
+            return Promise.resolve(action);
+          },
+          renderToReadableStream(model) {
+            renderedModel = model;
+            return new Response("too-many-args-flight").body;
+          },
+          sanitizeErrorForClient(error) {
+            return error instanceof Error ? error.message : String(error);
+          },
+        }),
+      );
+
+      expect(response?.status).toBe(200);
+      expect(await response?.text()).toBe("too-many-args-flight");
+      expect(action).not.toHaveBeenCalled();
+      expect(renderedModel).toEqual({
+        root: "dashboard:{}:none",
+        returnValue: {
+          ok: false,
+          data: "Server Action arguments list is too long (1001). Maximum allowed is 1000.",
+        },
+      });
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
   it("rejects malformed fetch-action payloads before decodeReply", async () => {
     const decodeReply = vi.fn();
 


### PR DESCRIPTION
## What this changes

Adds a Next.js-compatible 1000-argument cap for decoded fetch server action payloads before vinext invokes the action with `Function.prototype.apply`.

## Why

The fetch action path treated `decodeReply()` output as trusted and passed the decoded array directly to `action.apply(null, args)`. A hostile payload could force an oversized argument list and hit the same stack-overflow failure class guarded by Next.js.

Relevant Next.js references:

- [Next.js `SERVER_ACTION_ARGS_LIMIT` and pre-`apply` guard](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/action-handler.ts#L1282-L1311)
- [Next.js too-many-args e2e coverage](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/actions/app-action.test.ts#L195-L216)

## Approach

- Define the same `SERVER_ACTION_ARGS_LIMIT = 1000` boundary used by Next.js.
- Validate decoded fetch action args after entering the action header phase and immediately before `apply`, so the existing phase cleanup and RSC action error packaging continue to work.
- Add a focused regression test proving a 1001-argument decoded payload never invokes the action and returns the sanitized action error through the existing RSC payload path.

## Validation

- `vp test run tests/app-server-action-execution.test.ts`
- `vp check packages/vinext/src/server/app-server-action-execution.ts tests/app-server-action-execution.test.ts`

## Risks / follow-ups

