### PR TITLE
fix(app-router): propagate generateStaticParams validation errors

### DIFF
--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -437,9 +437,6 @@ export async function dispatchAppPage<TRoute extends AppPageDispatchRoute>(
     enforceStaticParamsOnly: options.dynamicParamsConfig === false,
     generateStaticParams: options.generateStaticParams,
     isDynamicRoute: route.isDynamic,
-    logGenerateStaticParamsError(error) {
-      console.error("[vinext] generateStaticParams error:", error);
-    },
     params: options.params,
   });
   if (dynamicParamsResponse) {

--- a/packages/vinext/src/server/app-page-request.ts
+++ b/packages/vinext/src/server/app-page-request.ts
@@ -23,7 +23,6 @@ export type ValidateAppPageDynamicParamsOptions = {
     | readonly (GenerateStaticParams | GenerateStaticParamsSource | null | undefined)[]
     | null;
   isDynamicRoute: boolean;
-  logGenerateStaticParamsError?: (error: unknown) => void;
   params: AppPageParams;
 };
 
@@ -259,16 +258,12 @@ export async function validateAppPageDynamicParams(
   }
 
   for (const source of generateStaticParamsSources) {
-    try {
-      const staticParams = await source.generateStaticParams({
-        params: pickRouteParams(options.params, source.parentParamNames),
-      });
-      if (Array.isArray(staticParams) && !areStaticParamsAllowed(options.params, staticParams)) {
-        options.clearRequestContext();
-        return notFoundResponse();
-      }
-    } catch (error) {
-      options.logGenerateStaticParamsError?.(error);
+    const staticParams = await source.generateStaticParams({
+      params: pickRouteParams(options.params, source.parentParamNames),
+    });
+    if (Array.isArray(staticParams) && !areStaticParamsAllowed(options.params, staticParams)) {
+      options.clearRequestContext();
+      return notFoundResponse();
     }
   }
 

--- a/tests/app-page-request.test.ts
+++ b/tests/app-page-request.test.ts
@@ -109,47 +109,79 @@ describe("app page request helpers", () => {
     expect(itemGenerateStaticParams).toHaveBeenCalledWith({ params: { category: "docs" } });
   });
 
-  it("logs and falls through when generateStaticParams throws", async () => {
-    const logGenerateStaticParamsError = vi.fn();
+  // Ported from Next.js: packages/next/src/build/static-paths/app.test.ts
+  // https://github.com/vercel/next.js/blob/canary/packages/next/src/build/static-paths/app.test.ts
+  it("throws when generateStaticParams throws", async () => {
+    const error = new Error("boom");
 
-    const response = await validateAppPageDynamicParams({
-      clearRequestContext() {},
-      enforceStaticParamsOnly: true,
-      async generateStaticParams() {
-        throw new Error("boom");
-      },
-      isDynamicRoute: true,
-      logGenerateStaticParamsError,
-      params: { slug: "post" },
-    });
-
-    expect(response).toBeNull();
-    expect(logGenerateStaticParamsError).toHaveBeenCalledTimes(1);
+    await expect(
+      validateAppPageDynamicParams({
+        clearRequestContext() {},
+        enforceStaticParamsOnly: true,
+        async generateStaticParams() {
+          throw error;
+        },
+        isDynamicRoute: true,
+        params: { slug: "post" },
+      }),
+    ).rejects.toThrow(error);
   });
 
-  it("checks remaining sources when an earlier generateStaticParams source throws", async () => {
+  // Ported from Next.js: packages/next/src/build/static-paths/app.test.ts
+  // https://github.com/vercel/next.js/blob/canary/packages/next/src/build/static-paths/app.test.ts
+  it("throws when generateStaticParams rejects", async () => {
+    const error = new Error("async boom");
+
+    await expect(
+      validateAppPageDynamicParams({
+        clearRequestContext() {},
+        enforceStaticParamsOnly: true,
+        async generateStaticParams() {
+          return Promise.reject(error);
+        },
+        isDynamicRoute: true,
+        params: { slug: "post" },
+      }),
+    ).rejects.toThrow(error);
+  });
+
+  // Ported from Next.js: packages/next/src/build/static-paths/app.test.ts
+  // https://github.com/vercel/next.js/blob/canary/packages/next/src/build/static-paths/app.test.ts
+  it("does not check remaining sources when an earlier generateStaticParams source throws", async () => {
     const clearRequestContext = vi.fn();
-    const logGenerateStaticParamsError = vi.fn();
     const throwsSource = vi.fn(() => {
       throw new Error("source 1 failed");
     });
     const rejectsSource = vi.fn(async () => [{ slug: "other" }]);
 
+    await expect(
+      validateAppPageDynamicParams({
+        clearRequestContext,
+        enforceStaticParamsOnly: true,
+        generateStaticParams: [throwsSource, rejectsSource],
+        isDynamicRoute: true,
+        params: { slug: "target" },
+      }),
+    ).rejects.toThrow("source 1 failed");
+
+    expect(clearRequestContext).not.toHaveBeenCalled();
+    expect(throwsSource).toHaveBeenCalledTimes(1);
+    expect(rejectsSource).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when generateStaticParams excludes the requested params", async () => {
+    const clearRequestContext = vi.fn();
+
     const response = await validateAppPageDynamicParams({
       clearRequestContext,
       enforceStaticParamsOnly: true,
-      generateStaticParams: [throwsSource, rejectsSource],
+      generateStaticParams: async () => [{ slug: "other" }],
       isDynamicRoute: true,
-      logGenerateStaticParamsError,
       params: { slug: "target" },
     });
 
-    // First source threw → logged, then second source checked → rejected → 404.
     expect(response?.status).toBe(404);
     expect(clearRequestContext).toHaveBeenCalledTimes(1);
-    expect(logGenerateStaticParamsError).toHaveBeenCalledTimes(1);
-    expect(throwsSource).toHaveBeenCalledTimes(1);
-    expect(rejectsSource).toHaveBeenCalledTimes(1);
   });
 
   it("renders intercepted source routes on RSC navigations", async () => {


### PR DESCRIPTION
## What this changes

`dynamicParams = false` validation now propagates thrown or rejected `generateStaticParams` errors instead of logging and continuing.

## Why

The previous request-time validator caught `generateStaticParams` failures, optionally logged them, and then fell through to later validation. That could turn a real application error into a successful render or a misleading 404, depending on the remaining sources.

Next.js treats these failures as fatal to static params generation:

- Source: [`generateRouteStaticParams` awaits `callGenerateStaticParams` without swallowing errors](https://github.com/vercel/next.js/blob/04294cb47a6d67adf73c8b6f196ed6a2ddcb2b0e/packages/next/src/build/static-paths/app.ts#L697-L723)
- Tests: [`generateStaticParams` thrown, rejected, and partial failures reject](https://github.com/vercel/next.js/blob/04294cb47a6d67adf73c8b6f196ed6a2ddcb2b0e/packages/next/src/build/static-paths/app.test.ts#L1299-L1356)

## Approach

The validation helper now lets `generateStaticParams` errors reject naturally. The dispatch caller no longer passes a logging callback whose only recovery path was to continue after the error.

Known excluded params still return the existing 404 response and clear request context. Missing `generateStaticParams` sources still return 404 under `dynamicParams = false`.

## Validation

- `vp test run tests/app-page-request.test.ts`
- `vp test run tests/app-page-dispatch.test.ts`
- `vp test run tests/app-page-request.test.ts tests/app-page-dispatch.test.ts`
- `vp test run tests/app-router.test.ts -t "dynamicParams"`
- `vp check tests/app-page-request.test.ts packages/vinext/src/server/app-page-request.ts packages/vinext/src/server/app-page-dispatch.ts`
- `vp check` completed with no errors and one existing warning outside this diff: `packages/vinext/src/server/request-pipeline.ts:604` has `unknown | undefined`.

## Risks / follow-ups

This intentionally changes only the App Router request-time `dynamicParams = false` validation path. The prerender endpoint already returns a 500 JSON error response for `generateStaticParams` failures so the prerender caller can treat it as a build failure.
