### PR TITLE
fix(app-router): strip internal headers around middleware

### DIFF
--- a/packages/vinext/src/server/app-middleware.ts
+++ b/packages/vinext/src/server/app-middleware.ts
@@ -5,7 +5,7 @@ import { setNavigationContext } from "vinext/shims/navigation";
 import { buildRequestHeadersFromMiddlewareResponse } from "./middleware-request-headers.js";
 import { mergeMiddlewareResponseHeaders } from "./middleware-response-headers.js";
 import { executeMiddleware, type MiddlewareModule } from "./middleware-runtime.js";
-import { processMiddlewareHeaders } from "./request-pipeline.js";
+import { cloneRequestWithHeaders, processMiddlewareHeaders } from "./request-pipeline.js";
 import { internalServerErrorResponse } from "./http-error-responses.js";
 
 export type AppMiddlewareContext = {
@@ -41,8 +41,35 @@ type ForwardedMiddlewareContext = {
   s?: unknown;
 };
 
+export const FLIGHT_HEADERS: readonly string[] = [
+  "rsc",
+  "next-router-state-tree",
+  "next-router-prefetch",
+  "next-hmr-refresh",
+  "next-router-segment-prefetch",
+];
+
+const FLIGHT_HEADER_SET = new Set(FLIGHT_HEADERS);
+
 function isForwardedMiddlewareContext(value: unknown): value is ForwardedMiddlewareContext {
   return !!value && typeof value === "object";
+}
+
+function requestWithoutFlightHeaders(request: Request): Request {
+  let hasFlightHeader = false;
+  const headers = new Headers();
+
+  for (const [key, value] of request.headers) {
+    if (FLIGHT_HEADER_SET.has(key.toLowerCase())) {
+      hasFlightHeader = true;
+    } else {
+      headers.append(key, value);
+    }
+  }
+
+  if (!hasFlightHeader) return request;
+  const source = request.body ? request.clone() : request;
+  return cloneRequestWithHeaders(source, headers);
 }
 
 function appendForwardedHeader(headers: Headers, value: unknown): void {
@@ -111,11 +138,19 @@ export async function proxyExternalMiddlewareRewrite(
   setNavigationContext(null);
 
   const proxyResponse = await proxyExternalRequest(proxyRequest, rewriteUrl);
-  if (!context.headers) return proxyResponse;
+  const headers = new Headers(proxyResponse.headers);
+  processMiddlewareHeaders(headers);
+
+  if (!context.headers) {
+    return new Response(proxyResponse.body, {
+      status: proxyResponse.status,
+      statusText: proxyResponse.statusText,
+      headers,
+    });
+  }
 
   const middlewareHeaders = new Headers(context.headers);
   processMiddlewareHeaders(middlewareHeaders);
-  const headers = new Headers(proxyResponse.headers);
   mergeMiddlewareResponseHeaders(headers, middlewareHeaders);
   return new Response(proxyResponse.body, {
     status: proxyResponse.status,
@@ -162,22 +197,23 @@ export async function applyAppMiddleware(
   options: ApplyAppMiddlewareOptions,
 ): Promise<ApplyAppMiddlewareResult> {
   const forwarded = applyForwardedMiddlewareContext(options.request, options.context);
+  const middlewareRequest = requestWithoutFlightHeaders(options.request);
   let cleanPathname = options.cleanPathname;
   let search: string | null = null;
 
   if (forwarded.rewriteUrl) {
     try {
-      if (isExternalMiddlewareRewrite(forwarded.rewriteUrl, options.request)) {
+      if (isExternalMiddlewareRewrite(forwarded.rewriteUrl, middlewareRequest)) {
         return {
           kind: "response",
           response: await proxyExternalMiddlewareRewrite(
-            options.request,
+            middlewareRequest,
             forwarded.rewriteUrl,
             options.context,
           ),
         };
       }
-      const rewriteParsed = new URL(forwarded.rewriteUrl, options.request.url);
+      const rewriteParsed = new URL(forwarded.rewriteUrl, middlewareRequest.url);
       cleanPathname = rewriteParsed.pathname;
       search = rewriteParsed.search;
     } catch (e) {
@@ -193,7 +229,7 @@ export async function applyAppMiddleware(
       isProxy: options.isProxy,
       module: options.module,
       normalizedPathname: cleanPathname,
-      request: options.request,
+      request: middlewareRequest,
     });
 
     if (!result.continue) {
@@ -218,13 +254,13 @@ export async function applyAppMiddleware(
         return {
           kind: "response",
           response: await proxyExternalMiddlewareRewrite(
-            options.request,
+            middlewareRequest,
             result.rewriteUrl,
             options.context,
           ),
         };
       }
-      const rewriteParsed = new URL(result.rewriteUrl, options.request.url);
+      const rewriteParsed = new URL(result.rewriteUrl, middlewareRequest.url);
       cleanPathname = rewriteParsed.pathname;
       search = rewriteParsed.search;
     }

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -3809,6 +3809,111 @@ describe("double-encoded path handling in middleware", () => {
     expect(mwPathname).not.toBe("/%2564ashboard");
   });
 
+  it("App Router middleware does not see internal Flight headers", async () => {
+    // Next.js strips FLIGHT_HEADERS before creating the middleware request:
+    // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/web/adapter.ts
+    const { applyAppMiddleware } = await import("../packages/vinext/src/server/app-middleware.js");
+    let capturedHeaders: Headers | undefined;
+    const module = {
+      default: (req: Request) => {
+        capturedHeaders = new Headers(req.headers);
+        return new Response(null, {
+          headers: { "x-middleware-next": "1" },
+        });
+      },
+    };
+
+    const result = await applyAppMiddleware({
+      cleanPathname: "/dashboard",
+      context: { headers: null, requestHeaders: null, status: null },
+      isProxy: false,
+      module,
+      request: new Request("http://localhost:3000/dashboard", {
+        headers: {
+          rsc: "1",
+          "next-router-state-tree": "%5B%5D",
+          "next-router-prefetch": "1",
+          "next-router-segment-prefetch": "/dashboard",
+          "next-hmr-refresh": "1",
+          "x-user-visible": "keep",
+        },
+      }),
+    });
+
+    expect(result.kind).toBe("continue");
+    expect(capturedHeaders?.get("rsc")).toBeNull();
+    expect(capturedHeaders?.get("next-router-state-tree")).toBeNull();
+    expect(capturedHeaders?.get("next-router-prefetch")).toBeNull();
+    expect(capturedHeaders?.get("next-router-segment-prefetch")).toBeNull();
+    expect(capturedHeaders?.get("next-hmr-refresh")).toBeNull();
+    expect(capturedHeaders?.get("x-user-visible")).toBe("keep");
+  });
+
+  it("App Router Flight header stripping does not lock the original request body", async () => {
+    const { applyAppMiddleware } = await import("../packages/vinext/src/server/app-middleware.js");
+    const request = new Request("http://localhost:3000/actions", {
+      body: "action-payload",
+      headers: {
+        rsc: "1",
+        "next-router-state-tree": "%5B%5D",
+      },
+      method: "POST",
+    });
+    const module = {
+      default: () =>
+        new Response(null, {
+          headers: { "x-middleware-next": "1" },
+        }),
+    };
+
+    const result = await applyAppMiddleware({
+      cleanPathname: "/actions",
+      context: { headers: null, requestHeaders: null, status: null },
+      isProxy: false,
+      module,
+      request,
+    });
+
+    expect(result.kind).toBe("continue");
+    expect(request.body?.locked).toBe(false);
+    expect(await request.text()).toBe("action-payload");
+  });
+
+  it("external middleware rewrite proxy strips upstream x-middleware headers without middleware context", async () => {
+    const { proxyExternalMiddlewareRewrite } =
+      await import("../packages/vinext/src/server/app-middleware.js");
+    const http = await import("node:http");
+    const server = http.createServer((_req, res) => {
+      res.writeHead(200, {
+        "content-type": "text/plain",
+        "x-middleware-rewrite": "/internal",
+        "x-middleware-next": "1",
+        "x-visible": "keep",
+      });
+      res.end("proxied");
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, resolve));
+    try {
+      const address = server.address();
+      expect(address && typeof address === "object").toBe(true);
+      const port = address && typeof address === "object" ? address.port : 0;
+      const response = await proxyExternalMiddlewareRewrite(
+        new Request("http://localhost:3000/source"),
+        `http://127.0.0.1:${port}/target`,
+        { headers: null, requestHeaders: null, status: null },
+      );
+
+      expect(response.status).toBe(200);
+      expect(await response.text()).toBe("proxied");
+      expect(response.headers.get("x-middleware-rewrite")).toBeNull();
+      expect(response.headers.get("x-middleware-next")).toBeNull();
+      expect(response.headers.get("x-visible")).toBe("keep");
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
   it("Pages Router runMiddleware passes decoded pathname to middleware function", async () => {
     const { runMiddleware } = await import("../packages/vinext/src/server/middleware.js");
     // Create a mock Vite server that returns a middleware module


### PR DESCRIPTION
## What this changes

App Router middleware now receives a request with internal Flight protocol headers stripped, matching Next.js middleware request construction. External middleware rewrite proxy responses are also sanitized before returning to the client, even when there is no middleware header context to merge.

## Why

vinext passed App Router Flight headers like `rsc`, `next-router-state-tree`, `next-router-prefetch`, `next-router-segment-prefetch`, and `next-hmr-refresh` through to user middleware. Those are internal protocol headers and should not be visible at the middleware boundary.

A second response-boundary path returned external middleware rewrite proxy responses raw when `context.headers` was null. That allowed upstream `x-middleware-*` headers to leak back to the browser instead of being treated as internal middleware control headers.

## Next.js references

- [`FLIGHT_HEADERS` definition](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/app-router-headers.ts)
- [Middleware adapter strips `FLIGHT_HEADERS` before creating `NextRequest`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/web/adapter.ts)
- [Request store strips `FLIGHT_HEADERS` before exposing `headers()`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/async-storage/request-store.ts)
- [Server helper for stripping Flight headers](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/strip-flight-headers.ts)

## Approach

- Add the Next.js Flight header set at the App Router middleware boundary.
- Clone only requests that actually contain Flight headers, using vinext’s existing `cloneRequestWithHeaders()` helper so request metadata and body handling stay consistent with the rest of the server pipeline.
- Run middleware execution and middleware-owned external rewrites against the stripped request, while leaving the original request available to the rest of App Router handling.
- Always run `processMiddlewareHeaders()` on external middleware rewrite proxy response headers before returning or merging them.

## Validation

- `vp test run tests/shims.test.ts -t "App Router middleware does not see internal Flight headers|external middleware rewrite proxy strips upstream|App Router middleware receives a Request with the decoded pathname"`
- `vp test run tests/app-router.test.ts -t "proxies external URLs returned by middleware rewrites with body and headers|strips content-encoding and content-length for Node fetch auto-decompression|forwards credential headers"`
- `vp lint packages/vinext/src/server/app-middleware.ts tests/shims.test.ts`
- `git diff --check`

## Risks / follow-ups

This intentionally scopes the Flight header strip to App Router middleware entry and middleware-owned external rewrites. Broader `headers()` parity for internal App Router protocol headers can be handled separately if needed.
