### PR TITLE
fix(app-router): prevent repeated hard-navigation loops

### DIFF
--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -42,6 +42,7 @@ import {
 } from "./app-browser-stream.js";
 import {
   createAppBrowserNavigationController,
+  clearHardNavigationLoopGuard,
   type HistoryUpdateMode,
   type NavigationPayloadOutcome,
   type PendingBrowserRouterState,
@@ -694,6 +695,7 @@ async function readInitialRscStream(): Promise<ReadableStream<Uint8Array> | null
     // the page — any prior reload flag for this path is stale and must be
     // cleared so a future failure gets its own fresh recovery attempt.
     clearReloadFlag();
+    clearHardNavigationLoopGuard();
 
     if (vinext.__VINEXT_RSC__) {
       const embedData = vinext.__VINEXT_RSC__;
@@ -757,6 +759,7 @@ async function readInitialRscStream(): Promise<ReadableStream<Uint8Array> | null
   // Successful RSC response clears the guard so a subsequent reload of the
   // same path after a transient failure still gets one recovery attempt.
   clearReloadFlag();
+  clearHardNavigationLoopGuard();
 
   // Ignore malformed param headers and continue with hydration. The original
   // try/catch also swallowed errors from applyClientParams; preserve that.

--- a/packages/vinext/src/server/app-browser-navigation-controller.ts
+++ b/packages/vinext/src/server/app-browser-navigation-controller.ts
@@ -27,6 +27,7 @@ export type PendingBrowserRouterState = {
   settled: boolean;
 };
 export type NavigationPayloadOutcome = "committed" | "no-commit" | "hard-navigate";
+type HardNavigationMode = "assign" | "replace";
 
 type BrowserNavigationCommitEffectFactory = (options: {
   href: string;
@@ -42,6 +43,7 @@ type BrowserRouterStateRef = {
 
 type BrowserNavigationControllerDeps = {
   commitClientNavigationState?: typeof commitClientNavigationState;
+  performHardNavigation?: (href: string, mode?: HardNavigationMode) => boolean;
 };
 
 type BrowserNavigationController = {
@@ -101,11 +103,78 @@ type BrowserNavigationController = {
   ): ReactNode;
 };
 
+const HARD_NAVIGATION_LOOP_GUARD_KEY = "__vinext_hard_navigation_target__";
+
+function normalizeBrowserHref(href: string): string {
+  try {
+    return new URL(href, window.location.href).href;
+  } catch {
+    return href;
+  }
+}
+
+function readHardNavigationLoopGuard(): string | null {
+  try {
+    return window.sessionStorage.getItem(HARD_NAVIGATION_LOOP_GUARD_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function writeHardNavigationLoopGuard(targetHref: string): boolean {
+  try {
+    window.sessionStorage.setItem(HARD_NAVIGATION_LOOP_GUARD_KEY, targetHref);
+    return window.sessionStorage.getItem(HARD_NAVIGATION_LOOP_GUARD_KEY) === targetHref;
+  } catch {
+    return false;
+  }
+}
+
+export function clearHardNavigationLoopGuard(): void {
+  try {
+    window.sessionStorage.removeItem(HARD_NAVIGATION_LOOP_GUARD_KEY);
+  } catch {}
+}
+
+function performHardNavigationWithLoopGuard(
+  href: string,
+  mode: HardNavigationMode = "assign",
+): boolean {
+  const targetHref = normalizeBrowserHref(href);
+  const currentHref = normalizeBrowserHref(window.location.href);
+
+  if (readHardNavigationLoopGuard() === targetHref && currentHref === targetHref) {
+    clearHardNavigationLoopGuard();
+    console.error(
+      `[vinext] Prevented repeated hard navigation to ${targetHref}; ` +
+        "leaving the current document in place to avoid a reload loop.",
+    );
+    return false;
+  }
+
+  const guardPersisted = writeHardNavigationLoopGuard(targetHref);
+  if (!guardPersisted && currentHref === targetHref) {
+    console.error(
+      `[vinext] Hard navigation to ${targetHref} requires a reload-loop guard, ` +
+        "but sessionStorage is unavailable; leaving the current document in place.",
+    );
+    return false;
+  }
+
+  if (mode === "replace") {
+    window.location.replace(href);
+  } else {
+    window.location.assign(href);
+  }
+  return true;
+}
+
 export function createAppBrowserNavigationController(
   deps: BrowserNavigationControllerDeps = {},
 ): BrowserNavigationController {
   const commitClientNavigationStateImpl =
     deps.commitClientNavigationState ?? commitClientNavigationState;
+  const performHardNavigation = deps.performHardNavigation ?? performHardNavigationWithLoopGuard;
 
   // These are plain module-level variables (inside the controller closure),
   // unlike ClientNavigationState which uses Symbol.for to survive multiple
@@ -434,8 +503,7 @@ export function createAppBrowserNavigationController(
       if (approval.decision.disposition === "hard-navigate") {
         settlePendingBrowserRouterState(options.pendingRouterState);
         pendingNavigationCommits.delete(renderId);
-        window.location.assign(options.targetHref);
-        return "hard-navigate";
+        return performHardNavigation(options.targetHref) ? "hard-navigate" : "no-commit";
       }
 
       const approvedCommit = approval.approvedCommit;
@@ -504,7 +572,7 @@ export function createAppBrowserNavigationController(
     });
 
     if (decision.disposition === "hard-navigate") {
-      window.location.assign(window.location.href);
+      performHardNavigation(window.location.href);
       return undefined;
     }
 
@@ -519,7 +587,7 @@ export function createAppBrowserNavigationController(
       });
 
       if (latestApproval.decision.disposition === "hard-navigate") {
-        window.location.assign(window.location.href);
+        performHardNavigation(window.location.href);
         return undefined;
       }
 

--- a/packages/vinext/src/server/app-browser-navigation-controller.ts
+++ b/packages/vinext/src/server/app-browser-navigation-controller.ts
@@ -160,6 +160,9 @@ function performHardNavigationWithLoopGuard(
     );
     return false;
   }
+  // If storage is unavailable but the target is a different URL, the browser
+  // can still make forward progress. Only same-target reloads need a persisted
+  // guard because they can re-enter this exact recovery path indefinitely.
 
   if (mode === "replace") {
     window.location.replace(href);
@@ -572,6 +575,9 @@ export function createAppBrowserNavigationController(
     });
 
     if (decision.disposition === "hard-navigate") {
+      // Same-URL action hard navigations do not expose a navigation outcome to
+      // callers. If the loop guard blocks, the degraded state is still the
+      // existing return contract: no visible commit and no action value.
       performHardNavigation(window.location.href);
       return undefined;
     }
@@ -587,6 +593,8 @@ export function createAppBrowserNavigationController(
       });
 
       if (latestApproval.decision.disposition === "hard-navigate") {
+        // See the same-URL hard-navigation note above. The guard result is
+        // deliberately not surfaced through the server-action return channel.
         performHardNavigation(window.location.href);
         return undefined;
       }

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -144,6 +144,8 @@ async function applyApprovedTestCommit(
 
 function stubWindow(href: string) {
   const assign = vi.fn();
+  const replace = vi.fn();
+  const storage = new Map<string, string>();
 
   vi.stubGlobal("window", {
     history: { state: null },
@@ -151,10 +153,22 @@ function stubWindow(href: string) {
       assign,
       href,
       origin: new URL(href).origin,
+      replace,
+    },
+    sessionStorage: {
+      getItem(key: string) {
+        return storage.get(key) ?? null;
+      },
+      removeItem(key: string) {
+        storage.delete(key);
+      },
+      setItem(key: string, value: string) {
+        storage.set(key, value);
+      },
     },
   });
 
-  return { assign };
+  return { assign, replace, storage };
 }
 
 afterEach(() => {
@@ -469,7 +483,8 @@ describe("app browser entry state helpers", () => {
     });
 
     expect(approval.decision.disposition).toBe("no-commit");
-    expect(approval.decision.trace.entries[0]).toEqual({
+    expect(approval.decision.trace.entries[0]?.code).toBe(NavigationTraceTransactionCodes.noCommit);
+    expect(approval.decision.trace.entries[1]).toEqual({
       code: NavigationTraceReasonCodes.staleOperation,
       fields: {
         activeNavigationId: 7,
@@ -507,7 +522,8 @@ describe("app browser entry state helpers", () => {
     });
 
     expect(approval.decision.disposition).toBe("no-commit");
-    expect(approval.decision.trace.entries[0]).toEqual({
+    expect(approval.decision.trace.entries[0]?.code).toBe(NavigationTraceTransactionCodes.noCommit);
+    expect(approval.decision.trace.entries[1]).toEqual({
       code: NavigationTraceReasonCodes.staleOperation,
       fields: {
         activeNavigationId: 8,
@@ -1776,7 +1792,8 @@ describe("app browser navigation lifecycle settlement", () => {
     const result = await resultPromise;
     expect(result.decision.disposition).toBe("no-commit");
     expect(result.approvedCommit).toBeNull();
-    expect(result.trace.entries[0]).toEqual({
+    expect(result.trace.entries[0]?.code).toBe(NavigationTraceTransactionCodes.noCommit);
+    expect(result.trace.entries[1]).toEqual({
       code: NavigationTraceReasonCodes.staleOperation,
       fields: {
         activeNavigationId: 9,
@@ -1818,7 +1835,8 @@ describe("app browser navigation lifecycle settlement", () => {
     const result = await resultPromise;
     expect(result.decision.disposition).toBe("no-commit");
     expect(result.approvedCommit).toBeNull();
-    expect(result.trace.entries[0]).toEqual({
+    expect(result.trace.entries[0]?.code).toBe(NavigationTraceTransactionCodes.noCommit);
+    expect(result.trace.entries[1]).toEqual({
       code: NavigationTraceReasonCodes.staleOperation,
       fields: {
         activeNavigationId: 8,
@@ -1947,6 +1965,73 @@ describe("app browser root-layout hard navigation", () => {
 
       expect(assign).toHaveBeenCalledTimes(1);
       await expect(pendingRouterState.promise).resolves.toBeDefined();
+    } finally {
+      detach();
+    }
+  });
+
+  it("blocks a repeated same-target root-boundary hard navigation to prevent reload loops", async () => {
+    const { controller, detach } = createControllerHarness(
+      createState({ rootLayoutTreePath: "/(marketing)" }),
+    );
+    const { assign, storage } = stubWindow("https://example.com/marketing");
+
+    try {
+      const firstNavId = controller.beginNavigation();
+      await expect(
+        controller.renderNavigationPayload({
+          actionType: "navigate",
+          createNavigationCommitEffect: () => () => {},
+          historyUpdateMode: "push",
+          navigationSnapshot: createClientNavigationRenderSnapshot(
+            "https://example.com/marketing",
+            {},
+          ),
+          nextElements: Promise.resolve(
+            createResolvedElements("route:/dashboard", "/(dashboard)", null, {
+              "page:/dashboard": React.createElement("main", null, "dashboard"),
+            }),
+          ),
+          operationLane: "navigation",
+          params: {},
+          pendingRouterState: null,
+          previousNextUrl: null,
+          targetHref: "https://example.com/dashboard",
+          navId: firstNavId,
+          useTransition: false,
+        }),
+      ).resolves.toBe("hard-navigate");
+      expect(assign).toHaveBeenCalledTimes(1);
+      expect(storage.size).toBe(1);
+
+      assign.mockClear();
+      window.location.href = "https://example.com/dashboard";
+      const secondNavId = controller.beginNavigation();
+      await expect(
+        controller.renderNavigationPayload({
+          actionType: "navigate",
+          createNavigationCommitEffect: () => () => {},
+          historyUpdateMode: "push",
+          navigationSnapshot: createClientNavigationRenderSnapshot(
+            "https://example.com/dashboard",
+            {},
+          ),
+          nextElements: Promise.resolve(
+            createResolvedElements("route:/dashboard", "/(dashboard)", null, {
+              "page:/dashboard": React.createElement("main", null, "dashboard"),
+            }),
+          ),
+          operationLane: "navigation",
+          params: {},
+          pendingRouterState: null,
+          previousNextUrl: null,
+          targetHref: "https://example.com/dashboard",
+          navId: secondNavId,
+          useTransition: false,
+        }),
+      ).resolves.toBe("no-commit");
+      expect(assign).not.toHaveBeenCalled();
+      expect(storage.size).toBe(0);
     } finally {
       detach();
     }

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -2036,6 +2036,72 @@ describe("app browser root-layout hard navigation", () => {
       detach();
     }
   });
+
+  it("allows cross-page hard navigation when the stored guard target is not the current URL", async () => {
+    const { controller, detach } = createControllerHarness(
+      createState({ rootLayoutTreePath: "/(marketing)" }),
+    );
+    const { assign } = stubWindow("https://example.com/marketing");
+
+    try {
+      const firstNavId = controller.beginNavigation();
+      await expect(
+        controller.renderNavigationPayload({
+          actionType: "navigate",
+          createNavigationCommitEffect: () => () => {},
+          historyUpdateMode: "push",
+          navigationSnapshot: createClientNavigationRenderSnapshot(
+            "https://example.com/marketing",
+            {},
+          ),
+          nextElements: Promise.resolve(
+            createResolvedElements("route:/dashboard", "/(dashboard)", null, {
+              "page:/dashboard": React.createElement("main", null, "dashboard"),
+            }),
+          ),
+          operationLane: "navigation",
+          params: {},
+          pendingRouterState: null,
+          previousNextUrl: null,
+          targetHref: "https://example.com/dashboard",
+          navId: firstNavId,
+          useTransition: false,
+        }),
+      ).resolves.toBe("hard-navigate");
+      expect(assign).toHaveBeenCalledTimes(1);
+
+      assign.mockClear();
+      window.location.href = "https://example.com/settings";
+      const secondNavId = controller.beginNavigation();
+      await expect(
+        controller.renderNavigationPayload({
+          actionType: "navigate",
+          createNavigationCommitEffect: () => () => {},
+          historyUpdateMode: "push",
+          navigationSnapshot: createClientNavigationRenderSnapshot(
+            "https://example.com/settings",
+            {},
+          ),
+          nextElements: Promise.resolve(
+            createResolvedElements("route:/dashboard", "/(dashboard)", null, {
+              "page:/dashboard": React.createElement("main", null, "dashboard"),
+            }),
+          ),
+          operationLane: "navigation",
+          params: {},
+          pendingRouterState: null,
+          previousNextUrl: null,
+          targetHref: "https://example.com/dashboard",
+          navId: secondNavId,
+          useTransition: false,
+        }),
+      ).resolves.toBe("hard-navigate");
+      expect(assign).toHaveBeenCalledTimes(1);
+      expect(assign).toHaveBeenCalledWith("https://example.com/dashboard");
+    } finally {
+      detach();
+    }
+  });
 });
 
 describe("app browser entry previousNextUrl helpers", () => {

--- a/tests/app-elements.test.ts
+++ b/tests/app-elements.test.ts
@@ -722,4 +722,36 @@ describe("artifact compatibility proof evaluation", () => {
       reason: "deploymentVersionMismatch",
     });
   });
+
+  it("treats old-client/new-server future compatibility metadata as unknown proof", () => {
+    const current = createArtifactCompatibilityEnvelope({
+      graphVersion: "graph-current",
+      deploymentVersion: "deploy-current",
+      rootBoundaryId: "root-current",
+      renderEpoch: "epoch-current",
+    });
+    const payload = {
+      [APP_ROUTE_KEY]: "route:/dashboard",
+      [APP_INTERCEPTION_CONTEXT_KEY]: null,
+      [APP_ROOT_LAYOUT_KEY]: "/",
+      [APP_ARTIFACT_COMPATIBILITY_KEY]: {
+        schemaVersion: ARTIFACT_COMPATIBILITY_SCHEMA_VERSION + 1,
+        graphVersion: "graph-next",
+        deploymentVersion: "deploy-next",
+        appElementsSchemaVersion: APP_ELEMENTS_SCHEMA_VERSION,
+        rscPayloadSchemaVersion: RSC_PAYLOAD_SCHEMA_VERSION,
+        rootBoundaryId: "root-next",
+        renderEpoch: "epoch-next",
+      },
+    } satisfies Readonly<Record<string, unknown>>;
+
+    const metadata = AppElementsWire.readMetadata(payload);
+
+    expect(metadata.artifactCompatibility).toEqual(createArtifactCompatibilityEnvelope());
+    expect(evaluateArtifactCompatibility(current, metadata.artifactCompatibility)).toEqual({
+      kind: "unknown",
+      fallback: "renderFresh",
+      reason: "graphVersionUnknown",
+    });
+  });
 });


### PR DESCRIPTION
## What this changes

Implements `#726-COMPAT-04/05` from #726.

This adds a browser-side hard-navigation loop guard for App Router root-boundary hard navigation. When a hard navigation has already been attempted for a target and the browser is already on that target URL, vinext now blocks the repeated attempt, logs the recovery decision, clears the guard, and leaves the current document in place instead of reloading forever.

It also adds explicit old-client/new-server coverage for future compatibility metadata. A payload with a future artifact compatibility schema still degrades to unknown compatibility and `renderFresh`; it does not become positive reuse proof.

Bonk: please read issue #726 for the big-picture architecture before reviewing this slice.

## Why

Issue #726 calls out deployment compatibility as algebra rather than strict equality everywhere. From first principles, a router should only reuse or visibly commit work when it has proof that the work belongs to the same semantic world: compatible graph, compatible deployment, compatible root boundary, compatible payload schema, and a still-current lifecycle token. When that proof is missing, the fallback can be a hard navigation, but the fallback itself also needs a bounded safety contract.

A hard navigation is a recovery effect, not semantic proof. If the same client/server skew keeps producing the same hard-navigation decision for the same URL, repeating the effect no longer moves the system toward a safer state. It just burns the current document and starts over. The correct invariant is: try the hard navigation once for the target, then stop if the freshly loaded document reaches the same decision again for that same target.

For example, an old client on `/dashboard` can request RSC from a new server whose root-boundary metadata is incompatible with the visible tree. The client correctly chooses a hard navigation to `/dashboard`. If the loaded document still has the old client bundle and receives the same incompatible payload again, an unguarded `window.location.assign('/dashboard')` loops forever. With this guard, the first hard navigation is allowed, the repeated same-target hard navigation is blocked, and the server-rendered document remains visible.

The existing root-boundary path had a direct `window.location.assign(...)` side effect with no persisted memory of the attempted target. That preserved current root-boundary behavior, but it did not bound the recovery path if the same client/server skew kept producing the same hard-navigation decision for the same URL.

## Approach

- Route App Router hard-navigation effects through a small loop-guard helper in the browser navigation controller.
- Persist the last attempted hard-navigation target in `sessionStorage`.
- Block only when the stored target matches and the browser is already on that same target URL, so ordinary cross-root navigations to the same destination from a different page still work.
- Clear the guard after successful initial RSC bootstrap, matching the existing one-shot initial RSC reload guard lifecycle.
- Keep compatibility fallback conservative: future or malformed compatibility metadata remains unknown proof and falls back to fresh render.
- Document the intentionally ignored same-URL server-action guard result and the storage-unavailable cross-URL asymmetry.

Non-goals for this PR match `#726-COMPAT-04/05`: no full rolling deploy protocol, no skip transport, and no cache/reuse authority changes.

## Validation

Next.js reference checked: `test/e2e/app-dir/segment-cache/deployment-skew/deployment-skew.test.ts` in the local Next.js canary clone, which covers deployment skew hard-navigation behavior.

- `vp test run tests/app-browser-entry.test.ts tests/app-elements.test.ts` passed: 126 tests.
- `vp check tests/app-browser-entry.test.ts packages/vinext/src/server/app-browser-navigation-controller.ts` passed with no warnings after the Bonk follow-up.
- `vp check tests/app-browser-entry.test.ts tests/app-elements.test.ts packages/vinext/src/server/app-browser-navigation-controller.ts packages/vinext/src/server/app-browser-entry.ts` passed with no warnings before the Bonk follow-up.
- `vp check` exited successfully. It reported one existing warning outside this PR in `packages/vinext/src/server/request-pipeline.ts` for `unknown | undefined`.
