### PR TITLE
feat(app-router): plan root-boundary navigation decisions

### DIFF
--- a/packages/vinext/src/server/app-browser-navigation-controller.ts
+++ b/packages/vinext/src/server/app-browser-navigation-controller.ts
@@ -490,6 +490,7 @@ export function createAppBrowserNavigationController(
         currentState: getBrowserRouterState(),
         pending,
         startedNavigationId: options.navId,
+        targetHref: options.targetHref,
       });
 
       if (approval.decision.disposition === "no-commit") {
@@ -563,6 +564,7 @@ export function createAppBrowserNavigationController(
       renderId: allocateRenderId(),
       operationLane: "server-action",
       startedNavigationId,
+      targetHref: window.location.href,
       type: "navigate",
     });
 
@@ -582,6 +584,7 @@ export function createAppBrowserNavigationController(
         currentState: getBrowserRouterState(),
         pending,
         startedNavigationId,
+        targetHref: window.location.href,
       });
 
       if (latestApproval.decision.disposition === "hard-navigate") {

--- a/packages/vinext/src/server/app-browser-state.ts
+++ b/packages/vinext/src/server/app-browser-state.ts
@@ -8,10 +8,18 @@ import {
 import { createRscRequestHeaders } from "./app-rsc-cache-busting.js";
 import {
   NavigationTraceReasonCodes,
+  createNavigationLifecycleTraceFields,
   createNavigationTrace,
   type NavigationTrace,
-  type NavigationTraceReasonCode,
+  type NavigationTraceFields,
 } from "./navigation-trace.js";
+import {
+  navigationPlanner,
+  type NavigationDecisionV0,
+  type OperationLane,
+  type OperationToken,
+  type RouteSnapshotV0,
+} from "./navigation-planner.js";
 import type { ClientNavigationRenderSnapshot } from "vinext/shims/navigation";
 
 const VINEXT_PREVIOUS_NEXT_URL_HISTORY_STATE_KEY = "__vinext_previousNextUrl";
@@ -20,7 +28,7 @@ type HistoryStateRecord = {
   [key: string]: unknown;
 };
 
-export type OperationLane = "navigation" | "refresh" | "traverse" | "server-action" | "hmr";
+export type { OperationLane } from "./navigation-planner.js";
 
 type OperationRecordBase = {
   id: number;
@@ -184,87 +192,164 @@ export function shouldHardNavigate(
   currentRootLayoutTreePath: string | null,
   nextRootLayoutTreePath: string | null,
 ): boolean {
-  // `null` means the payload could not identify an enclosing root layout
-  // boundary. Treat that as soft-navigation compatible so fallback payloads
-  // do not force a hard reload purely because metadata is absent.
   return (
-    currentRootLayoutTreePath !== null &&
-    nextRootLayoutTreePath !== null &&
-    currentRootLayoutTreePath !== nextRootLayoutTreePath
+    navigationPlanner.classifyRootBoundaryTransition(
+      currentRootLayoutTreePath,
+      nextRootLayoutTreePath,
+    ) === "rootBoundaryChanged"
   );
 }
 
 export function resolvePendingNavigationCommitDisposition(options: {
   activeNavigationId: number;
-  currentVisibleCommitVersion: number;
-  currentRootLayoutTreePath: string | null;
-  nextRootLayoutTreePath: string | null;
+  currentState: AppRouterState;
+  pending: PendingNavigationCommit;
   startedNavigationId: number;
-  startedVisibleCommitVersion: number;
 }): PendingNavigationCommitDisposition {
-  if (options.startedNavigationId !== options.activeNavigationId) {
-    return "skip";
-  }
-
-  if (options.startedVisibleCommitVersion !== options.currentVisibleCommitVersion) {
-    return "skip";
-  }
-
-  if (shouldHardNavigate(options.currentRootLayoutTreePath, options.nextRootLayoutTreePath)) {
-    return "hard-navigate";
-  }
-
-  return "dispatch";
+  return resolvePendingNavigationCommitDispositionDecision(options).disposition;
 }
 
 export function resolvePendingNavigationCommitDispositionDecision(options: {
   activeNavigationId: number;
-  currentVisibleCommitVersion: number;
-  currentRootLayoutTreePath: string | null;
-  nextRootLayoutTreePath: string | null;
+  currentState: AppRouterState;
+  pending: PendingNavigationCommit;
   startedNavigationId: number;
-  startedVisibleCommitVersion: number;
+  targetHref?: string;
 }): PendingNavigationCommitDispositionDecision {
-  const disposition = resolvePendingNavigationCommitDisposition(options);
-  const traceFields = {
-    activeNavigationId: options.activeNavigationId,
-    currentRootLayoutTreePath: options.currentRootLayoutTreePath,
-    currentVisibleCommitVersion: options.currentVisibleCommitVersion,
-    nextRootLayoutTreePath: options.nextRootLayoutTreePath,
-    startedNavigationId: options.startedNavigationId,
-    startedVisibleCommitVersion: options.startedVisibleCommitVersion,
-  };
+  if (
+    options.startedNavigationId !== options.activeNavigationId ||
+    options.pending.action.operation.startedVisibleCommitVersion !==
+      options.currentState.visibleCommitVersion
+  ) {
+    return {
+      disposition: "skip",
+      trace: createNavigationTrace(
+        NavigationTraceReasonCodes.staleOperation,
+        createPendingNavigationTraceFields(options),
+      ),
+    };
+  }
 
-  return {
-    disposition,
-    trace: createNavigationTrace(
-      getPendingNavigationCommitDispositionTraceCode({
-        currentRootLayoutTreePath: options.currentRootLayoutTreePath,
-        disposition,
-        nextRootLayoutTreePath: options.nextRootLayoutTreePath,
-      }),
+  const traceFields = createPendingNavigationTraceFields(options);
+
+  return mapNavigationDecisionToPendingDisposition(
+    planPendingRootBoundaryFlightResponse({
+      currentState: options.currentState,
+      pending: options.pending,
+      targetHref: options.targetHref,
       traceFields,
-    ),
+    }),
+  );
+}
+
+function createPendingNavigationTraceFields(options: {
+  activeNavigationId: number;
+  currentState: AppRouterState;
+  pending: PendingNavigationCommit;
+  startedNavigationId: number;
+}): NavigationTraceFields {
+  return createNavigationLifecycleTraceFields({
+    activeNavigationId: options.activeNavigationId,
+    currentRootLayoutTreePath: options.currentState.rootLayoutTreePath,
+    currentVisibleCommitVersion: options.currentState.visibleCommitVersion,
+    nextRootLayoutTreePath: options.pending.rootLayoutTreePath,
+    startedNavigationId: options.startedNavigationId,
+    startedVisibleCommitVersion: options.pending.action.operation.startedVisibleCommitVersion,
+  });
+}
+
+function createNavigationSnapshotUrl(snapshot: ClientNavigationRenderSnapshot): string {
+  const query = snapshot.searchParams.toString();
+  return query === "" ? snapshot.pathname : `${snapshot.pathname}?${query}`;
+}
+
+function createVisibleRouteSnapshot(state: AppRouterState): RouteSnapshotV0 {
+  const displayUrl = createNavigationSnapshotUrl(state.navigationSnapshot);
+  return {
+    displayUrl,
+    matchedUrl: state.navigationSnapshot.pathname,
+    rootBoundaryId: state.rootLayoutTreePath,
+    routeId: state.routeId,
   };
 }
 
-function getPendingNavigationCommitDispositionTraceCode(options: {
-  currentRootLayoutTreePath: string | null;
-  disposition: PendingNavigationCommitDisposition;
-  nextRootLayoutTreePath: string | null;
-}): NavigationTraceReasonCode {
-  switch (options.disposition) {
-    case "skip":
-      return NavigationTraceReasonCodes.staleOperation;
-    case "hard-navigate":
-      return NavigationTraceReasonCodes.rootBoundaryChanged;
-    case "dispatch":
-      return options.currentRootLayoutTreePath === null || options.nextRootLayoutTreePath === null
-        ? NavigationTraceReasonCodes.rootBoundaryUnknown
-        : NavigationTraceReasonCodes.commitCurrent;
+function createPendingRouteSnapshot(pending: PendingNavigationCommit): RouteSnapshotV0 {
+  const displayUrl = createNavigationSnapshotUrl(pending.action.navigationSnapshot);
+  return {
+    displayUrl,
+    matchedUrl: pending.action.navigationSnapshot.pathname,
+    rootBoundaryId: pending.rootLayoutTreePath,
+    routeId: pending.routeId,
+  };
+}
+
+function createPendingNavigationOperationToken(options: {
+  pending: PendingNavigationCommit;
+  targetSnapshot: RouteSnapshotV0;
+}): OperationToken {
+  return {
+    baseVisibleCommitVersion: options.pending.action.operation.startedVisibleCommitVersion,
+    deploymentVersion: null,
+    graphVersion: null,
+    lane: options.pending.action.operation.lane,
+    operationId: options.pending.action.operation.id,
+    targetSnapshotFingerprint: `${options.targetSnapshot.routeId}|root:${
+      options.targetSnapshot.rootBoundaryId ?? "unknown"
+    }`,
+  };
+}
+
+function planPendingRootBoundaryFlightResponse(options: {
+  currentState: AppRouterState;
+  pending: PendingNavigationCommit;
+  targetHref?: string;
+  traceFields: NavigationTraceFields;
+}): NavigationDecisionV0 {
+  const targetSnapshot = createPendingRouteSnapshot(options.pending);
+  const token = createPendingNavigationOperationToken({
+    pending: options.pending,
+    targetSnapshot,
+  });
+
+  // #726-CORE-07/08 keeps the browser state layer as the lifecycle gate and
+  // only translates committed AppElements metadata into planner snapshots.
+  // The planner owns the root-boundary decision; later #726 route-graph work
+  // should replace these client-visible snapshots with the read model called
+  // out in routing/app-router.ts instead of adding more local topology checks.
+  return navigationPlanner.plan({
+    routeManifest: null,
+    state: {
+      nextOperationToken: token,
+      traceFields: options.traceFields,
+      visibleCommitVersion: options.currentState.visibleCommitVersion,
+      visibleSnapshot: createVisibleRouteSnapshot(options.currentState),
+    },
+    event: {
+      kind: "flightResponseArrived",
+      result: {
+        href: options.targetHref ?? targetSnapshot.displayUrl,
+        targetSnapshot,
+      },
+      token,
+    },
+  });
+}
+
+function mapNavigationDecisionToPendingDisposition(
+  decision: NavigationDecisionV0,
+): PendingNavigationCommitDispositionDecision {
+  switch (decision.kind) {
+    case "proposeCommit":
+      return { disposition: "dispatch", trace: decision.trace };
+    case "hardNavigate":
+      return { disposition: "hard-navigate", trace: decision.trace };
+    case "noCommit":
+      return { disposition: "skip", trace: decision.trace };
+    case "requestWork":
+      throw new Error("[vinext] Root-boundary commit planning returned requestWork");
     default: {
-      const _exhaustive: never = options.disposition;
-      throw new Error("[vinext] Unknown navigation commit disposition: " + String(_exhaustive));
+      const _exhaustive: never = decision;
+      throw new Error("[vinext] Unknown navigation decision: " + String(_exhaustive));
     }
   }
 }

--- a/packages/vinext/src/server/app-browser-state.ts
+++ b/packages/vinext/src/server/app-browser-state.ts
@@ -346,7 +346,9 @@ function mapNavigationDecisionToPendingDisposition(
     case "noCommit":
       return { disposition: "skip", trace: decision.trace };
     case "requestWork":
-      throw new Error("[vinext] Root-boundary commit planning returned requestWork");
+      throw new Error(
+        "[vinext] Root-boundary commit planning returned requestWork; flightResponseArrived should never request work",
+      );
     default: {
       const _exhaustive: never = decision;
       throw new Error("[vinext] Unknown navigation decision: " + String(_exhaustive));

--- a/packages/vinext/src/server/app-browser-state.ts
+++ b/packages/vinext/src/server/app-browser-state.ts
@@ -244,15 +244,19 @@ function createPendingNavigationTraceFields(options: {
   currentState: AppRouterState;
   pending: PendingNavigationCommit;
   startedNavigationId: number;
+  targetHref?: string;
 }): NavigationTraceFields {
-  return createNavigationLifecycleTraceFields({
-    activeNavigationId: options.activeNavigationId,
-    currentRootLayoutTreePath: options.currentState.rootLayoutTreePath,
-    currentVisibleCommitVersion: options.currentState.visibleCommitVersion,
-    nextRootLayoutTreePath: options.pending.rootLayoutTreePath,
-    startedNavigationId: options.startedNavigationId,
-    startedVisibleCommitVersion: options.pending.action.operation.startedVisibleCommitVersion,
-  });
+  return {
+    ...createNavigationLifecycleTraceFields({
+      activeNavigationId: options.activeNavigationId,
+      currentRootLayoutTreePath: options.currentState.rootLayoutTreePath,
+      currentVisibleCommitVersion: options.currentState.visibleCommitVersion,
+      nextRootLayoutTreePath: options.pending.rootLayoutTreePath,
+      startedNavigationId: options.startedNavigationId,
+      startedVisibleCommitVersion: options.pending.action.operation.startedVisibleCommitVersion,
+    }),
+    ...(options.targetHref !== undefined ? { targetHref: options.targetHref } : {}),
+  };
 }
 
 function createNavigationSnapshotUrl(snapshot: ClientNavigationRenderSnapshot): string {
@@ -264,6 +268,9 @@ function createVisibleRouteSnapshot(state: AppRouterState): RouteSnapshotV0 {
   const displayUrl = createNavigationSnapshotUrl(state.navigationSnapshot);
   return {
     displayUrl,
+    // `displayUrl` preserves the browser-visible query string for decisions and
+    // traces. `matchedUrl` stays path-only because route matching has already
+    // consumed query params before AppElements metadata reaches this boundary.
     matchedUrl: state.navigationSnapshot.pathname,
     rootBoundaryId: state.rootLayoutTreePath,
     routeId: state.routeId,
@@ -274,6 +281,8 @@ function createPendingRouteSnapshot(pending: PendingNavigationCommit): RouteSnap
   const displayUrl = createNavigationSnapshotUrl(pending.action.navigationSnapshot);
   return {
     displayUrl,
+    // See createVisibleRouteSnapshot: matchedUrl intentionally models the route
+    // identity, not the address bar URL.
     matchedUrl: pending.action.navigationSnapshot.pathname,
     rootBoundaryId: pending.rootLayoutTreePath,
     routeId: pending.routeId,
@@ -326,6 +335,10 @@ function planPendingRootBoundaryFlightResponse(options: {
     event: {
       kind: "flightResponseArrived",
       result: {
+        // Approval call sites must pass the executor's targetHref so the
+        // planner trace and future hard-nav executor agree with the browser
+        // URL. The fallback remains for lower-level tests and direct disposition
+        // callers that exercise only snapshot-derived planner semantics.
         href: options.targetHref ?? targetSnapshot.displayUrl,
         targetSnapshot,
       },

--- a/packages/vinext/src/server/app-browser-state.ts
+++ b/packages/vinext/src/server/app-browser-state.ts
@@ -216,6 +216,8 @@ export function resolvePendingNavigationCommitDispositionDecision(options: {
   startedNavigationId: number;
   targetHref?: string;
 }): PendingNavigationCommitDispositionDecision {
+  const traceFields = createPendingNavigationTraceFields(options);
+
   if (
     options.startedNavigationId !== options.activeNavigationId ||
     options.pending.action.operation.startedVisibleCommitVersion !==
@@ -223,14 +225,9 @@ export function resolvePendingNavigationCommitDispositionDecision(options: {
   ) {
     return {
       disposition: "skip",
-      trace: createNavigationTrace(
-        NavigationTraceReasonCodes.staleOperation,
-        createPendingNavigationTraceFields(options),
-      ),
+      trace: createNavigationTrace(NavigationTraceReasonCodes.staleOperation, traceFields),
     };
   }
-
-  const traceFields = createPendingNavigationTraceFields(options);
 
   return mapNavigationDecisionToPendingDisposition(
     planPendingRootBoundaryFlightResponse({
@@ -293,10 +290,12 @@ function createPendingNavigationOperationToken(options: {
     graphVersion: null,
     lane: options.pending.action.operation.lane,
     operationId: options.pending.action.operation.id,
-    targetSnapshotFingerprint: `${options.targetSnapshot.routeId}|root:${
-      options.targetSnapshot.rootBoundaryId ?? "unknown"
-    }`,
+    targetSnapshotFingerprint: createRootBoundarySnapshotFingerprint(options.targetSnapshot),
   };
+}
+
+function createRootBoundarySnapshotFingerprint(snapshot: RouteSnapshotV0): string {
+  return `${snapshot.routeId}|root:${snapshot.rootBoundaryId ?? "unknown"}`;
 }
 
 function planPendingRootBoundaryFlightResponse(options: {
@@ -347,7 +346,7 @@ function mapNavigationDecisionToPendingDisposition(
       return { disposition: "skip", trace: decision.trace };
     case "requestWork":
       throw new Error(
-        "[vinext] Root-boundary commit planning returned requestWork; flightResponseArrived should never request work",
+        `[vinext] Root-boundary commit planning returned requestWork (${decision.work.kind}); flightResponseArrived should never request work`,
       );
     default: {
       const _exhaustive: never = decision;

--- a/packages/vinext/src/server/app-browser-visible-commit.ts
+++ b/packages/vinext/src/server/app-browser-visible-commit.ts
@@ -147,11 +147,9 @@ function reduceApprovedVisibleCommitState(
 
 function resolvePendingNavigationCommitDecision(options: {
   activeNavigationId: number;
-  currentVisibleCommitVersion: number;
-  currentRootLayoutTreePath: string | null;
-  nextRootLayoutTreePath: string | null;
+  currentState: AppRouterState;
+  pending: PendingNavigationCommit;
   startedNavigationId: number;
-  startedVisibleCommitVersion: number;
 }): CommitDecision {
   const { disposition, trace } = resolvePendingNavigationCommitDispositionDecision(options);
 
@@ -273,11 +271,9 @@ export function approvePendingNavigationCommit(options: {
   const decision = addCommitTransactionTrace(
     resolvePendingNavigationCommitDecision({
       activeNavigationId: options.activeNavigationId,
-      currentVisibleCommitVersion: options.currentState.visibleCommitVersion,
-      currentRootLayoutTreePath: options.currentState.rootLayoutTreePath,
-      nextRootLayoutTreePath: options.pending.rootLayoutTreePath,
+      currentState: options.currentState,
+      pending: options.pending,
       startedNavigationId: options.startedNavigationId,
-      startedVisibleCommitVersion: options.pending.action.operation.startedVisibleCommitVersion,
     }),
     options.pending,
   );

--- a/packages/vinext/src/server/app-browser-visible-commit.ts
+++ b/packages/vinext/src/server/app-browser-visible-commit.ts
@@ -150,6 +150,7 @@ function resolvePendingNavigationCommitDecision(options: {
   currentState: AppRouterState;
   pending: PendingNavigationCommit;
   startedNavigationId: number;
+  targetHref: string;
 }): CommitDecision {
   const { disposition, trace } = resolvePendingNavigationCommitDispositionDecision(options);
 
@@ -267,6 +268,7 @@ export function approvePendingNavigationCommit(options: {
   currentState: AppRouterState;
   pending: PendingNavigationCommit;
   startedNavigationId: number;
+  targetHref: string;
 }): CommitApproval {
   const decision = addCommitTransactionTrace(
     resolvePendingNavigationCommitDecision({
@@ -274,6 +276,7 @@ export function approvePendingNavigationCommit(options: {
       currentState: options.currentState,
       pending: options.pending,
       startedNavigationId: options.startedNavigationId,
+      targetHref: options.targetHref,
     }),
     options.pending,
   );
@@ -313,6 +316,7 @@ export async function resolveAndClassifyNavigationCommit(options: {
   previousNextUrl?: string | null;
   renderId: number;
   startedNavigationId: number;
+  targetHref: string;
   type: "navigate" | "replace" | "traverse";
 }): Promise<ClassifiedPendingNavigationCommit> {
   const pending = await createPendingNavigationCommit({
@@ -331,6 +335,7 @@ export async function resolveAndClassifyNavigationCommit(options: {
     currentState: approvalState,
     pending,
     startedNavigationId: options.startedNavigationId,
+    targetHref: options.targetHref,
   });
 
   return {

--- a/packages/vinext/src/server/navigation-planner.ts
+++ b/packages/vinext/src/server/navigation-planner.ts
@@ -1,0 +1,280 @@
+import type { RouteManifest } from "../routing/app-route-graph.js";
+import {
+  NavigationTraceReasonCodes,
+  createNavigationLifecycleTraceFields,
+  createNavigationTrace,
+  type NavigationTrace,
+  type NavigationTraceFields,
+} from "./navigation-trace.js";
+
+export type OperationLane =
+  | "hmr"
+  | "navigation"
+  | "prefetch"
+  | "refresh"
+  | "server-action"
+  | "traverse";
+
+export type OperationToken = {
+  operationId: number;
+  lane: OperationLane;
+  baseVisibleCommitVersion: number;
+  graphVersion: string | null;
+  deploymentVersion: string | null;
+  targetSnapshotFingerprint: string;
+  cacheVariantFingerprint?: string;
+};
+
+export type RouteSnapshotV0 = {
+  routeId: string;
+  rootBoundaryId: string | null;
+  displayUrl: string;
+  matchedUrl: string;
+};
+
+export type NavigationPlannerStateV0 = {
+  nextOperationToken: OperationToken;
+  // Callers that have lifecycle authority should pass the complete trace
+  // context. When absent, the planner emits the stable root-boundary facts it
+  // can derive from the event and visible snapshot.
+  traceFields?: NavigationTraceFields;
+  visibleCommitVersion: number;
+  visibleSnapshot: RouteSnapshotV0;
+};
+
+export type RefreshScope = "visible";
+
+export type NavigationEvent =
+  | { kind: "navigate"; href: string; mode: "push" | "replace" }
+  | { kind: "refresh"; scope: RefreshScope }
+  | { kind: "traverse"; direction: "back" | "forward"; historyState: unknown }
+  | { kind: "prefetch"; href: string }
+  | { kind: "flightResponseArrived"; token: OperationToken; result: FlightResultV0 };
+
+export type RequestedWork =
+  | { kind: "flight"; href: string; mode: "push" | "replace" | "refresh" }
+  | { direction: "back" | "forward"; historyState: unknown; kind: "traverseFlight" }
+  | { kind: "prefetch"; href: string };
+
+export type CommitProposal = {
+  reason: "currentRootBoundary" | "rootBoundaryUnknownFallback";
+  targetSnapshot: RouteSnapshotV0;
+};
+
+export type NoCommitReason = "prefetchOnly";
+export type HardNavigationReason = "rootBoundaryChanged";
+export type RootBoundaryTransition =
+  | "currentRootBoundary"
+  | "rootBoundaryChanged"
+  | "rootBoundaryUnknownFallback";
+
+export type NavigationDecisionV0 =
+  | {
+      kind: "requestWork";
+      token: OperationToken;
+      work: RequestedWork;
+      trace: NavigationTrace;
+    }
+  | {
+      kind: "proposeCommit";
+      token: OperationToken;
+      proposal: CommitProposal;
+      trace: NavigationTrace;
+    }
+  | {
+      kind: "noCommit";
+      token: OperationToken;
+      reason: NoCommitReason;
+      trace: NavigationTrace;
+    }
+  | {
+      kind: "hardNavigate";
+      token: OperationToken;
+      url: string;
+      reason: HardNavigationReason;
+      trace: NavigationTrace;
+    };
+
+export type FlightResultV0 = {
+  href: string;
+  targetSnapshot: RouteSnapshotV0;
+};
+
+export type NavigationPlannerInput = {
+  routeManifest: RouteManifest | null;
+  state: NavigationPlannerStateV0;
+  event: NavigationEvent;
+};
+
+function createRequestWorkDecision(options: {
+  eventKind: NavigationEvent["kind"];
+  state: NavigationPlannerStateV0;
+  work: RequestedWork;
+}): NavigationDecisionV0 {
+  return {
+    kind: "requestWork",
+    token: options.state.nextOperationToken,
+    work: options.work,
+    trace: createNavigationTrace(NavigationTraceReasonCodes.requestWork, {
+      eventKind: options.eventKind,
+      targetHref: getRequestedWorkTargetHref(options.work),
+    }),
+  };
+}
+
+function getRequestedWorkTargetHref(work: RequestedWork): string | null {
+  switch (work.kind) {
+    case "flight":
+    case "prefetch":
+      return work.href;
+    case "traverseFlight":
+      return null;
+    default: {
+      const _exhaustive: never = work;
+      throw new Error("[vinext] Unknown requested navigation work: " + String(_exhaustive));
+    }
+  }
+}
+
+function createRootBoundaryTraceFields(options: {
+  event: Extract<NavigationEvent, { kind: "flightResponseArrived" }>;
+  state: NavigationPlannerStateV0;
+}): NavigationTraceFields {
+  return (
+    options.state.traceFields ??
+    createNavigationLifecycleTraceFields({
+      currentRootLayoutTreePath: options.state.visibleSnapshot.rootBoundaryId,
+      currentVisibleCommitVersion: options.state.visibleCommitVersion,
+      nextRootLayoutTreePath: options.event.result.targetSnapshot.rootBoundaryId,
+      startedVisibleCommitVersion: options.event.token.baseVisibleCommitVersion,
+    })
+  );
+}
+
+function classifyRootBoundaryTransition(
+  currentRootBoundaryId: string | null,
+  nextRootBoundaryId: string | null,
+): RootBoundaryTransition {
+  if (currentRootBoundaryId === null || nextRootBoundaryId === null) {
+    return "rootBoundaryUnknownFallback";
+  }
+
+  return currentRootBoundaryId === nextRootBoundaryId
+    ? "currentRootBoundary"
+    : "rootBoundaryChanged";
+}
+
+function planFlightResponseArrived(options: {
+  event: Extract<NavigationEvent, { kind: "flightResponseArrived" }>;
+  state: NavigationPlannerStateV0;
+}): NavigationDecisionV0 {
+  const traceFields = createRootBoundaryTraceFields(options);
+
+  if (options.event.token.lane === "prefetch") {
+    return {
+      kind: "noCommit",
+      reason: "prefetchOnly",
+      token: options.event.token,
+      trace: createNavigationTrace(NavigationTraceReasonCodes.prefetchOnly, traceFields),
+    };
+  }
+
+  const transition = classifyRootBoundaryTransition(
+    options.state.visibleSnapshot.rootBoundaryId,
+    options.event.result.targetSnapshot.rootBoundaryId,
+  );
+
+  if (transition === "rootBoundaryChanged") {
+    return {
+      kind: "hardNavigate",
+      reason: "rootBoundaryChanged",
+      token: options.event.token,
+      trace: createNavigationTrace(NavigationTraceReasonCodes.rootBoundaryChanged, traceFields),
+      url: options.event.result.href,
+    };
+  }
+
+  if (transition === "rootBoundaryUnknownFallback") {
+    // Unknown root identity is an uncertainty fallback, not evidence that
+    // reuse is safe. #726-CORE-09 can delete the legacy soft-commit writer
+    // once every promoted caller supplies graph-owned root boundary IDs from
+    // the route graph read model documented in routing/app-router.ts.
+    return {
+      kind: "proposeCommit",
+      proposal: {
+        reason: "rootBoundaryUnknownFallback",
+        targetSnapshot: options.event.result.targetSnapshot,
+      },
+      token: options.event.token,
+      trace: createNavigationTrace(NavigationTraceReasonCodes.rootBoundaryUnknown, traceFields),
+    };
+  }
+
+  return {
+    kind: "proposeCommit",
+    proposal: {
+      reason: "currentRootBoundary",
+      targetSnapshot: options.event.result.targetSnapshot,
+    },
+    token: options.event.token,
+    trace: createNavigationTrace(NavigationTraceReasonCodes.commitCurrent, traceFields),
+  };
+}
+
+function planNavigation(input: NavigationPlannerInput): NavigationDecisionV0 {
+  switch (input.event.kind) {
+    case "navigate":
+      return createRequestWorkDecision({
+        eventKind: input.event.kind,
+        state: input.state,
+        work: {
+          href: input.event.href,
+          kind: "flight",
+          mode: input.event.mode,
+        },
+      });
+    case "refresh":
+      return createRequestWorkDecision({
+        eventKind: input.event.kind,
+        state: input.state,
+        work: {
+          href: input.state.visibleSnapshot.displayUrl,
+          kind: "flight",
+          mode: "refresh",
+        },
+      });
+    case "traverse":
+      return createRequestWorkDecision({
+        eventKind: input.event.kind,
+        state: input.state,
+        work: {
+          direction: input.event.direction,
+          historyState: input.event.historyState,
+          kind: "traverseFlight",
+        },
+      });
+    case "prefetch":
+      return createRequestWorkDecision({
+        eventKind: input.event.kind,
+        state: input.state,
+        work: {
+          href: input.event.href,
+          kind: "prefetch",
+        },
+      });
+    case "flightResponseArrived":
+      return planFlightResponseArrived({
+        event: input.event,
+        state: input.state,
+      });
+    default: {
+      const _exhaustive: never = input.event;
+      throw new Error("[vinext] Unknown navigation event: " + String(_exhaustive));
+    }
+  }
+}
+
+export const navigationPlanner = {
+  classifyRootBoundaryTransition,
+  plan: planNavigation,
+};

--- a/packages/vinext/src/server/navigation-planner.ts
+++ b/packages/vinext/src/server/navigation-planner.ts
@@ -33,6 +33,10 @@ export type RouteSnapshotV0 = {
 };
 
 export type NavigationPlannerStateV0 = {
+  // V0 keeps a single state shape so intent events and result events can move
+  // through one planner surface. flightResponseArrived uses event.token; later
+  // #726 slices can split this by event kind once more result paths are routed
+  // through the planner.
   nextOperationToken: OperationToken;
   // Callers that have lifecycle authority should pass the complete trace
   // context. When absent, the planner emits the stable root-boundary facts it
@@ -140,6 +144,9 @@ function createRootBoundaryTraceFields(options: {
   event: Extract<NavigationEvent, { kind: "flightResponseArrived" }>;
   state: NavigationPlannerStateV0;
 }): NavigationTraceFields {
+  // Browser commit approval supplies lifecycle trace context before calling
+  // the planner. This fallback exists for pure planner callers and tests; it
+  // intentionally cannot invent lifecycle-only fields such as active nav id.
   return (
     options.state.traceFields ??
     createNavigationLifecycleTraceFields({

--- a/packages/vinext/src/server/navigation-planner.ts
+++ b/packages/vinext/src/server/navigation-planner.ts
@@ -163,6 +163,10 @@ function classifyRootBoundaryTransition(
   nextRootBoundaryId: string | null,
 ): RootBoundaryTransition {
   if (currentRootBoundaryId === null || nextRootBoundaryId === null) {
+    // Both null directions intentionally share the v0 fallback because this
+    // slice only knows boundary identity from the current flight payload.
+    // #726-CORE-09 can split "unknown current" from "unknown target" once the
+    // planner consumes graph-owned root boundary facts for both sides.
     return "rootBoundaryUnknownFallback";
   }
 

--- a/packages/vinext/src/server/navigation-planner.ts
+++ b/packages/vinext/src/server/navigation-planner.ts
@@ -105,6 +105,9 @@ export type FlightResultV0 = {
 };
 
 export type NavigationPlannerInput = {
+  // Reserved for #726-CORE-09 route-graph-aware planning. CORE-07/08 only
+  // routes the existing root-boundary decision through the planner, so browser
+  // callers pass null until route topology becomes part of the decision input.
   routeManifest: RouteManifest | null;
   state: NavigationPlannerStateV0;
   event: NavigationEvent;

--- a/packages/vinext/src/server/navigation-trace.ts
+++ b/packages/vinext/src/server/navigation-trace.ts
@@ -4,11 +4,15 @@ export type NavigationTraceSchemaVersion = 0;
 
 export const NavigationTraceReasonCodes = {
   commitCurrent: "NC_COMMIT",
+  prefetchOnly: "NC_PREFETCH_ONLY",
+  requestWork: "NC_REQUEST",
   rootBoundaryChanged: "NC_ROOT",
   rootBoundaryUnknown: "NC_ROOT_UNKNOWN",
   staleOperation: "NC_STALE",
 } satisfies Readonly<{
   commitCurrent: "NC_COMMIT";
+  prefetchOnly: "NC_PREFETCH_ONLY";
+  requestWork: "NC_REQUEST";
   rootBoundaryChanged: "NC_ROOT";
   rootBoundaryUnknown: "NC_ROOT_UNKNOWN";
   staleOperation: "NC_STALE";
@@ -35,11 +39,14 @@ export type NavigationTraceCode = NavigationTraceReasonCode | NavigationTraceTra
 export type NavigationTraceFieldName =
   | "activeNavigationId"
   | "currentRootLayoutTreePath"
+  | "currentVisibleCommitVersion"
   | "nextRootLayoutTreePath"
+  | "eventKind"
   | "operationLane"
   | "pendingOperationId"
   | "startedVisibleCommitVersion"
-  | "startedNavigationId";
+  | "startedNavigationId"
+  | "targetHref";
 
 export type NavigationTraceFieldValue = string | number | boolean | null;
 
@@ -56,6 +63,28 @@ export type NavigationTrace = Readonly<{
   schemaVersion: NavigationTraceSchemaVersion;
   entries: readonly NavigationTraceEntry[];
 }>;
+
+export function createNavigationLifecycleTraceFields(options: {
+  activeNavigationId?: number;
+  currentRootLayoutTreePath: string | null;
+  currentVisibleCommitVersion: number;
+  nextRootLayoutTreePath: string | null;
+  startedNavigationId?: number;
+  startedVisibleCommitVersion: number;
+}): NavigationTraceFields {
+  return {
+    ...(options.activeNavigationId !== undefined
+      ? { activeNavigationId: options.activeNavigationId }
+      : {}),
+    currentRootLayoutTreePath: options.currentRootLayoutTreePath,
+    currentVisibleCommitVersion: options.currentVisibleCommitVersion,
+    nextRootLayoutTreePath: options.nextRootLayoutTreePath,
+    ...(options.startedNavigationId !== undefined
+      ? { startedNavigationId: options.startedNavigationId }
+      : {}),
+    startedVisibleCommitVersion: options.startedVisibleCommitVersion,
+  };
+}
 
 function createNavigationTraceEntry(
   code: NavigationTraceCode,

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -76,6 +76,7 @@ type TestPendingDispositionOptions = {
   currentRootLayoutTreePath: string | null;
   currentVisibleCommitVersion: number;
   nextRootLayoutTreePath: string | null;
+  renderId?: number;
   startedNavigationId: number;
   startedVisibleCommitVersion: number;
 };
@@ -98,7 +99,7 @@ async function resolveTestPendingNavigationCommitDispositionDecision(
     ),
     navigationSnapshot: createClientNavigationRenderSnapshot("https://example.com/dashboard", {}),
     operationLane: "navigation",
-    renderId: options.startedNavigationId,
+    renderId: options.renderId ?? options.startedNavigationId,
     type: "navigate",
   });
 

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -648,14 +648,45 @@ describe("app browser entry state helpers", () => {
     const decision = await resolveTestPendingNavigationCommitDispositionDecision({
       activeNavigationId: 2,
       currentVisibleCommitVersion: 1,
-      currentRootLayoutTreePath: "/(marketing)",
-      nextRootLayoutTreePath: "/(dashboard)",
+      currentRootLayoutTreePath: "/",
+      nextRootLayoutTreePath: "/",
       startedNavigationId: 2,
       startedVisibleCommitVersion: 0,
     });
 
     expect(decision.disposition).toBe("skip");
     expect(decision.trace.entries[0]?.code).toBe(NavigationTraceReasonCodes.staleOperation);
+  });
+
+  it("treats stale state as authoritative even when the root boundary changed", async () => {
+    const decision = await resolveTestPendingNavigationCommitDispositionDecision({
+      activeNavigationId: 2,
+      currentVisibleCommitVersion: 1,
+      currentRootLayoutTreePath: "/(marketing)",
+      nextRootLayoutTreePath: "/(dashboard)",
+      startedNavigationId: 2,
+      startedVisibleCommitVersion: 0,
+    });
+
+    expect(decision).toEqual({
+      disposition: "skip",
+      trace: {
+        schemaVersion: NAVIGATION_TRACE_SCHEMA_VERSION,
+        entries: [
+          {
+            code: NavigationTraceReasonCodes.staleOperation,
+            fields: {
+              activeNavigationId: 2,
+              currentRootLayoutTreePath: "/(marketing)",
+              currentVisibleCommitVersion: 1,
+              nextRootLayoutTreePath: "/(dashboard)",
+              startedNavigationId: 2,
+              startedVisibleCommitVersion: 0,
+            },
+          },
+        ],
+      },
+    });
   });
 
   it("traces root-boundary hard navigation decisions", async () => {

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -71,6 +71,45 @@ function createState(overrides: Partial<AppRouterState> = {}): AppRouterState {
   };
 }
 
+type TestPendingDispositionOptions = {
+  activeNavigationId: number;
+  currentRootLayoutTreePath: string | null;
+  currentVisibleCommitVersion: number;
+  nextRootLayoutTreePath: string | null;
+  startedNavigationId: number;
+  startedVisibleCommitVersion: number;
+};
+
+async function resolveTestPendingNavigationCommitDispositionDecision(
+  options: TestPendingDispositionOptions,
+) {
+  const startState = createState({
+    rootLayoutTreePath: options.currentRootLayoutTreePath,
+    visibleCommitVersion: options.startedVisibleCommitVersion,
+  });
+  const currentState = createState({
+    rootLayoutTreePath: options.currentRootLayoutTreePath,
+    visibleCommitVersion: options.currentVisibleCommitVersion,
+  });
+  const pending = await createPendingNavigationCommit({
+    currentState: startState,
+    nextElements: Promise.resolve(
+      createResolvedElements("route:/dashboard", options.nextRootLayoutTreePath),
+    ),
+    navigationSnapshot: createClientNavigationRenderSnapshot("https://example.com/dashboard", {}),
+    operationLane: "navigation",
+    renderId: options.startedNavigationId,
+    type: "navigate",
+  });
+
+  return resolvePendingNavigationCommitDispositionDecision({
+    activeNavigationId: options.activeNavigationId,
+    currentState,
+    pending,
+    startedNavigationId: options.startedNavigationId,
+  });
+}
+
 function createControllerHarness(initialState: AppRouterState = createState()) {
   const controller = createAppBrowserNavigationController();
   const stateRef: { current: AppRouterState } = { current: initialState };
@@ -373,11 +412,9 @@ describe("app browser entry state helpers", () => {
     expect(
       resolvePendingNavigationCommitDisposition({
         activeNavigationId: 3,
-        currentVisibleCommitVersion: currentState.visibleCommitVersion,
-        currentRootLayoutTreePath: currentState.rootLayoutTreePath,
-        nextRootLayoutTreePath: pending.rootLayoutTreePath,
+        currentState,
+        pending,
         startedNavigationId: 3,
-        startedVisibleCommitVersion: pending.action.operation.startedVisibleCommitVersion,
       }),
     ).toBe("hard-navigate");
   });
@@ -476,11 +513,9 @@ describe("app browser entry state helpers", () => {
     expect(
       resolvePendingNavigationCommitDisposition({
         activeNavigationId: 5,
-        currentVisibleCommitVersion: currentState.visibleCommitVersion,
-        currentRootLayoutTreePath: currentState.rootLayoutTreePath,
-        nextRootLayoutTreePath: pending.rootLayoutTreePath,
+        currentState,
+        pending,
         startedNavigationId: 4,
-        startedVisibleCommitVersion: pending.action.operation.startedVisibleCommitVersion,
       }),
     ).toBe("skip");
   });
@@ -580,8 +615,8 @@ describe("app browser entry state helpers", () => {
     expect(approval.approvedCommit).toBeNull();
   });
 
-  it("traces stale pending commits with compact reason codes and structured fields", () => {
-    const decision = resolvePendingNavigationCommitDispositionDecision({
+  it("traces stale pending commits with compact reason codes and structured fields", async () => {
+    const decision = await resolveTestPendingNavigationCommitDispositionDecision({
       activeNavigationId: 5,
       currentVisibleCommitVersion: 0,
       currentRootLayoutTreePath: "/",
@@ -609,8 +644,8 @@ describe("app browser entry state helpers", () => {
     });
   });
 
-  it("treats a visible commit version mismatch as stale before root-boundary decisions", () => {
-    const decision = resolvePendingNavigationCommitDispositionDecision({
+  it("treats a visible commit version mismatch as stale before root-boundary decisions", async () => {
+    const decision = await resolveTestPendingNavigationCommitDispositionDecision({
       activeNavigationId: 2,
       currentVisibleCommitVersion: 1,
       currentRootLayoutTreePath: "/(marketing)",
@@ -623,8 +658,8 @@ describe("app browser entry state helpers", () => {
     expect(decision.trace.entries[0]?.code).toBe(NavigationTraceReasonCodes.staleOperation);
   });
 
-  it("traces root-boundary hard navigation decisions", () => {
-    const decision = resolvePendingNavigationCommitDispositionDecision({
+  it("traces root-boundary hard navigation decisions", async () => {
+    const decision = await resolveTestPendingNavigationCommitDispositionDecision({
       activeNavigationId: 2,
       currentVisibleCommitVersion: 0,
       currentRootLayoutTreePath: "/(marketing)",
@@ -649,8 +684,8 @@ describe("app browser entry state helpers", () => {
     ]);
   });
 
-  it("traces unknown root-layout identity as a legacy soft-commit fallback", () => {
-    const decision = resolvePendingNavigationCommitDispositionDecision({
+  it("traces unknown root-layout identity as a legacy soft-commit fallback", async () => {
+    const decision = await resolveTestPendingNavigationCommitDispositionDecision({
       activeNavigationId: 2,
       currentVisibleCommitVersion: 0,
       currentRootLayoutTreePath: "/",
@@ -663,8 +698,8 @@ describe("app browser entry state helpers", () => {
     expect(decision.trace.entries[0]?.code).toBe(NavigationTraceReasonCodes.rootBoundaryUnknown);
   });
 
-  it("traces matching root-layout dispatches as current commits", () => {
-    const decision = resolvePendingNavigationCommitDispositionDecision({
+  it("traces matching root-layout dispatches as current commits", async () => {
+    const decision = await resolveTestPendingNavigationCommitDispositionDecision({
       activeNavigationId: 2,
       currentVisibleCommitVersion: 0,
       currentRootLayoutTreePath: "/",

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -140,6 +140,7 @@ type ApprovedTestCommitOptions = {
   rootLayoutTreePath: string | null;
   routeId: string;
   startedNavigationId?: number;
+  targetHref?: string;
   type?: "navigate" | "replace" | "traverse";
 };
 
@@ -172,6 +173,7 @@ async function applyApprovedTestCommit(
     currentState: state,
     pending,
     startedNavigationId: options.startedNavigationId ?? activeNavigationId,
+    targetHref: options.targetHref ?? "https://example.com/initial",
   });
 
   if (approval.approvedCommit === null) {
@@ -305,6 +307,7 @@ describe("app browser entry state helpers", () => {
       currentState: state,
       pending,
       startedNavigationId: 1,
+      targetHref: "https://example.com/next",
     });
     if (approval.approvedCommit === null) {
       throw new Error("Expected approved visible commit");
@@ -483,6 +486,7 @@ describe("app browser entry state helpers", () => {
       currentState,
       pending,
       startedNavigationId: 1,
+      targetHref: "https://example.com/dashboard",
     });
     if (approval.approvedCommit === null) {
       throw new Error("Expected approved visible commit");
@@ -540,6 +544,7 @@ describe("app browser entry state helpers", () => {
       currentState: latestState,
       pending,
       startedNavigationId: 7,
+      targetHref: "https://example.com/dashboard",
     });
 
     expect(approval.decision.disposition).toBe("no-commit");
@@ -561,6 +566,7 @@ describe("app browser entry state helpers", () => {
           nextRootLayoutTreePath: "/",
           startedNavigationId: 7,
           startedVisibleCommitVersion: 4,
+          targetHref: "https://example.com/dashboard",
         },
       },
     ]);
@@ -588,6 +594,7 @@ describe("app browser entry state helpers", () => {
       currentState: latestState,
       pending,
       startedNavigationId: 8,
+      targetHref: "https://example.com/previous",
     });
 
     expect(approval.decision.disposition).toBe("no-commit");
@@ -609,6 +616,7 @@ describe("app browser entry state helpers", () => {
           nextRootLayoutTreePath: "/",
           startedNavigationId: 8,
           startedVisibleCommitVersion: 2,
+          targetHref: "https://example.com/previous",
         },
       },
     ]);
@@ -792,6 +800,7 @@ describe("app browser entry state helpers", () => {
       currentState,
       pending,
       startedNavigationId: 4,
+      targetHref: "https://example.com/dashboard",
     });
 
     expect(approval.decision.disposition).toBe("commit");
@@ -819,6 +828,7 @@ describe("app browser entry state helpers", () => {
           nextRootLayoutTreePath: "/",
           startedNavigationId: 4,
           startedVisibleCommitVersion: 0,
+          targetHref: "https://example.com/dashboard",
         },
       },
     ]);
@@ -851,6 +861,7 @@ describe("app browser entry state helpers", () => {
       currentState,
       pending,
       startedNavigationId: 6,
+      targetHref: "https://example.com/legacy-payload",
     });
 
     expect(approval.decision.disposition).toBe("commit");
@@ -936,6 +947,7 @@ describe("app browser entry state helpers", () => {
       currentState,
       pending,
       startedNavigationId: 4,
+      targetHref: "https://example.com/next",
     });
 
     if (approval.approvedCommit === null) {
@@ -973,6 +985,7 @@ describe("app browser entry state helpers", () => {
       currentState,
       pending,
       startedNavigationId: 4,
+      targetHref: "https://example.com/feed",
     });
 
     if (approval.approvedCommit === null) {
@@ -1007,6 +1020,7 @@ describe("app browser entry state helpers", () => {
       currentState,
       pending,
       startedNavigationId: 7,
+      targetHref: "https://example.com/dashboard",
     });
     expect(staleApproval.decision.disposition).toBe("no-commit");
     expect(staleApproval.decision.trace.entries[0]?.code).toBe(
@@ -1022,6 +1036,7 @@ describe("app browser entry state helpers", () => {
       currentState,
       pending,
       startedNavigationId: 8,
+      targetHref: "https://example.com/dashboard?from=planner",
     });
     expect(hardNavigateApproval.decision.disposition).toBe("hard-navigate");
     expect(hardNavigateApproval.decision.trace.entries[0]?.code).toBe(
@@ -1029,6 +1044,9 @@ describe("app browser entry state helpers", () => {
     );
     expect(hardNavigateApproval.decision.trace.entries[1]?.code).toBe(
       NavigationTraceReasonCodes.rootBoundaryChanged,
+    );
+    expect(hardNavigateApproval.decision.trace.entries[1]?.fields.targetHref).toBe(
+      "https://example.com/dashboard?from=planner",
     );
     expect(hardNavigateApproval.approvedCommit).toBeNull();
   });
@@ -1857,6 +1875,7 @@ describe("app browser navigation lifecycle settlement", () => {
       operationLane: "navigation",
       renderId: 3,
       startedNavigationId: 5,
+      targetHref: "https://example.com/dashboard",
       type: "navigate",
     });
 
@@ -1881,6 +1900,7 @@ describe("app browser navigation lifecycle settlement", () => {
       operationLane: "server-action",
       renderId: 24,
       startedNavigationId: 5,
+      targetHref: "https://example.com/dashboard",
       type: "navigate",
     });
 
@@ -1908,6 +1928,7 @@ describe("app browser navigation lifecycle settlement", () => {
           nextRootLayoutTreePath: "/",
           startedNavigationId: 5,
           startedVisibleCommitVersion: 0,
+          targetHref: "https://example.com/dashboard",
         },
       },
     ]);
@@ -1930,6 +1951,7 @@ describe("app browser navigation lifecycle settlement", () => {
       operationLane: "server-action",
       renderId: 25,
       startedNavigationId: 8,
+      targetHref: "https://example.com/dashboard",
       type: "navigate",
     });
 
@@ -1960,6 +1982,7 @@ describe("app browser navigation lifecycle settlement", () => {
           nextRootLayoutTreePath: "/",
           startedNavigationId: 8,
           startedVisibleCommitVersion: 0,
+          targetHref: "https://example.com/dashboard",
         },
       },
     ]);
@@ -2272,6 +2295,7 @@ describe("app browser entry previousNextUrl helpers", () => {
       operationLane: "server-action",
       renderId: 3,
       startedNavigationId: 7,
+      targetHref: "https://example.com/dashboard?action=same-url",
       type: "navigate",
     });
 
@@ -2280,6 +2304,9 @@ describe("app browser entry previousNextUrl helpers", () => {
     expect(result.pending.action.renderId).toBe(3);
     expect(result.trace.entries[0]?.code).toBe(NavigationTraceTransactionCodes.hardNavigate);
     expect(result.trace.entries[1]?.code).toBe(NavigationTraceReasonCodes.rootBoundaryChanged);
+    expect(result.trace.entries[1]?.fields.targetHref).toBe(
+      "https://example.com/dashboard?action=same-url",
+    );
   });
 
   it("creates navigation trace entries without retaining field ownership", () => {

--- a/tests/navigation-planner.test.ts
+++ b/tests/navigation-planner.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  NAVIGATION_TRACE_SCHEMA_VERSION,
+  NavigationTraceReasonCodes,
+} from "../packages/vinext/src/server/navigation-trace.js";
+import {
+  navigationPlanner,
+  type FlightResultV0,
+  type NavigationDecisionV0,
+  type NavigationEvent,
+  type NavigationPlannerInput,
+  type NavigationPlannerStateV0,
+  type OperationToken,
+  type RefreshScope,
+  type RouteSnapshotV0,
+  type RootBoundaryTransition,
+} from "../packages/vinext/src/server/navigation-planner.js";
+
+function createRouteSnapshot(rootBoundaryId: string | null): RouteSnapshotV0 {
+  return {
+    displayUrl: "https://example.com/dashboard",
+    matchedUrl: "/dashboard",
+    rootBoundaryId,
+    routeId: "route:/dashboard",
+  };
+}
+
+function createOperationToken(overrides: Partial<OperationToken> = {}): OperationToken {
+  return {
+    baseVisibleCommitVersion: 2,
+    deploymentVersion: null,
+    graphVersion: null,
+    lane: "navigation",
+    operationId: 7,
+    targetSnapshotFingerprint: "route:/dashboard|root:/",
+    ...overrides,
+  };
+}
+
+function planFlightResponse(rootBoundaryId: string | null): NavigationDecisionV0 {
+  const token = createOperationToken({
+    targetSnapshotFingerprint: `route:/dashboard|root:${rootBoundaryId ?? "unknown"}`,
+  });
+  const result: FlightResultV0 = {
+    href: "https://example.com/dashboard",
+    targetSnapshot: createRouteSnapshot(rootBoundaryId),
+  };
+  const state: NavigationPlannerStateV0 = {
+    nextOperationToken: token,
+    traceFields: {
+      currentRootLayoutTreePath: "/",
+      currentVisibleCommitVersion: 2,
+      nextRootLayoutTreePath: rootBoundaryId,
+      startedVisibleCommitVersion: 2,
+    },
+    visibleCommitVersion: 2,
+    visibleSnapshot: createRouteSnapshot("/"),
+  };
+  const event: NavigationEvent = {
+    kind: "flightResponseArrived",
+    result,
+    token,
+  };
+  const input: NavigationPlannerInput = {
+    event,
+    routeManifest: null,
+    state,
+  };
+
+  return navigationPlanner.plan(input);
+}
+
+describe("navigationPlanner root-boundary decisions", () => {
+  // Root-layout MPA semantics match Next.js coverage:
+  // .nextjs-ref/test/e2e/app-dir/root-layout/root-layout.test.ts
+  // .nextjs-ref/test/e2e/app-dir/segment-cache/mpa-navigations/mpa-navigations.test.ts
+  it("proposes a visible commit for same-root flight responses", () => {
+    const decision = planFlightResponse("/");
+
+    expect(decision.kind).toBe("proposeCommit");
+    if (decision.kind !== "proposeCommit") {
+      throw new Error("Expected proposeCommit decision");
+    }
+    expect(decision.proposal.targetSnapshot.rootBoundaryId).toBe("/");
+    expect(decision.trace).toEqual({
+      schemaVersion: NAVIGATION_TRACE_SCHEMA_VERSION,
+      entries: [
+        {
+          code: NavigationTraceReasonCodes.commitCurrent,
+          fields: {
+            currentRootLayoutTreePath: "/",
+            currentVisibleCommitVersion: 2,
+            nextRootLayoutTreePath: "/",
+            startedVisibleCommitVersion: 2,
+          },
+        },
+      ],
+    });
+  });
+
+  it("hard-navigates cross-root flight responses", () => {
+    const transition: RootBoundaryTransition = navigationPlanner.classifyRootBoundaryTransition(
+      "/",
+      "/(dashboard)",
+    );
+    const decision = planFlightResponse("/(dashboard)");
+
+    expect(transition).toBe("rootBoundaryChanged");
+    expect(decision.kind).toBe("hardNavigate");
+    if (decision.kind !== "hardNavigate") {
+      throw new Error("Expected hardNavigate decision");
+    }
+    expect(decision.reason).toBe("rootBoundaryChanged");
+    expect(decision.url).toBe("https://example.com/dashboard");
+    expect(decision.trace.entries).toEqual([
+      {
+        code: NavigationTraceReasonCodes.rootBoundaryChanged,
+        fields: {
+          currentRootLayoutTreePath: "/",
+          currentVisibleCommitVersion: 2,
+          nextRootLayoutTreePath: "/(dashboard)",
+          startedVisibleCommitVersion: 2,
+        },
+      },
+    ]);
+  });
+
+  it("uses the current soft fallback when the target root identity is unknown", () => {
+    const decision = planFlightResponse(null);
+
+    expect(decision.kind).toBe("proposeCommit");
+    if (decision.kind !== "proposeCommit") {
+      throw new Error("Expected proposeCommit decision");
+    }
+    expect(decision.proposal.reason).toBe("rootBoundaryUnknownFallback");
+    expect(decision.trace.entries[0]?.code).toBe(NavigationTraceReasonCodes.rootBoundaryUnknown);
+  });
+
+  it("never hard-navigates prefetch flight responses", () => {
+    const token = createOperationToken({
+      lane: "prefetch",
+      targetSnapshotFingerprint: "route:/dashboard|root:/(dashboard)",
+    });
+    const decision = navigationPlanner.plan({
+      routeManifest: null,
+      state: {
+        nextOperationToken: token,
+        traceFields: {
+          currentRootLayoutTreePath: "/",
+          currentVisibleCommitVersion: 2,
+          nextRootLayoutTreePath: "/(dashboard)",
+          startedVisibleCommitVersion: 2,
+        },
+        visibleCommitVersion: 2,
+        visibleSnapshot: createRouteSnapshot("/"),
+      },
+      event: {
+        kind: "flightResponseArrived",
+        result: {
+          href: "https://example.com/dashboard",
+          targetSnapshot: createRouteSnapshot("/(dashboard)"),
+        },
+        token,
+      },
+    });
+
+    expect(decision.kind).toBe("noCommit");
+    if (decision.kind !== "noCommit") {
+      throw new Error("Expected noCommit decision");
+    }
+    expect(decision.reason).toBe("prefetchOnly");
+    expect(decision.trace.entries[0]?.code).toBe(NavigationTraceReasonCodes.prefetchOnly);
+  });
+
+  it("returns requestWork for initial navigation intent events", () => {
+    const token = createOperationToken();
+    const input: NavigationPlannerInput = {
+      routeManifest: null,
+      state: {
+        nextOperationToken: token,
+        visibleCommitVersion: 2,
+        visibleSnapshot: createRouteSnapshot("/"),
+      },
+      event: {
+        href: "https://example.com/dashboard",
+        kind: "navigate",
+        mode: "push",
+      },
+    };
+    const decision = navigationPlanner.plan(input);
+
+    expect(decision.kind).toBe("requestWork");
+    if (decision.kind !== "requestWork") {
+      throw new Error("Expected requestWork decision");
+    }
+    expect(decision.token).toBe(token);
+    expect(decision.work).toEqual({
+      href: "https://example.com/dashboard",
+      kind: "flight",
+      mode: "push",
+    });
+  });
+
+  it("returns requestWork for refresh intent events", () => {
+    const token = createOperationToken({
+      targetSnapshotFingerprint: "route:/dashboard|root:/|refresh",
+    });
+    const scope: RefreshScope = "visible";
+    const event: NavigationEvent = { kind: "refresh", scope };
+    const decision = navigationPlanner.plan({
+      event,
+      routeManifest: null,
+      state: {
+        nextOperationToken: token,
+        visibleCommitVersion: 2,
+        visibleSnapshot: createRouteSnapshot("/"),
+      },
+    });
+
+    expect(decision.kind).toBe("requestWork");
+    if (decision.kind !== "requestWork") {
+      throw new Error("Expected requestWork decision");
+    }
+    expect(decision.work).toEqual({
+      href: "https://example.com/dashboard",
+      kind: "flight",
+      mode: "refresh",
+    });
+  });
+
+  it("does not invent a target href for traverse intent events", () => {
+    const token = createOperationToken();
+    const historyState = { key: "previous-entry" };
+    const decision = navigationPlanner.plan({
+      routeManifest: null,
+      state: {
+        nextOperationToken: token,
+        visibleCommitVersion: 2,
+        visibleSnapshot: createRouteSnapshot("/"),
+      },
+      event: {
+        direction: "back",
+        historyState,
+        kind: "traverse",
+      },
+    });
+
+    expect(decision.kind).toBe("requestWork");
+    if (decision.kind !== "requestWork") {
+      throw new Error("Expected requestWork decision");
+    }
+    expect(decision.work).toEqual({
+      direction: "back",
+      historyState,
+      kind: "traverseFlight",
+    });
+    expect(decision.trace.entries[0]?.fields.targetHref).toBeNull();
+  });
+});

--- a/tests/navigation-planner.test.ts
+++ b/tests/navigation-planner.test.ts
@@ -70,6 +70,38 @@ function planFlightResponse(rootBoundaryId: string | null): NavigationDecisionV0
   return navigationPlanner.plan(input);
 }
 
+function planFlightResponseFromRootBoundaries(options: {
+  currentRootBoundaryId: string | null;
+  nextRootBoundaryId: string | null;
+}): NavigationDecisionV0 {
+  const token = createOperationToken({
+    targetSnapshotFingerprint: `route:/dashboard|root:${options.nextRootBoundaryId ?? "unknown"}`,
+  });
+
+  return navigationPlanner.plan({
+    event: {
+      kind: "flightResponseArrived",
+      result: {
+        href: "https://example.com/dashboard",
+        targetSnapshot: createRouteSnapshot(options.nextRootBoundaryId),
+      },
+      token,
+    },
+    routeManifest: null,
+    state: {
+      nextOperationToken: token,
+      traceFields: {
+        currentRootLayoutTreePath: options.currentRootBoundaryId,
+        currentVisibleCommitVersion: 2,
+        nextRootLayoutTreePath: options.nextRootBoundaryId,
+        startedVisibleCommitVersion: 2,
+      },
+      visibleCommitVersion: 2,
+      visibleSnapshot: createRouteSnapshot(options.currentRootBoundaryId),
+    },
+  });
+}
+
 describe("navigationPlanner root-boundary decisions", () => {
   // Root-layout MPA semantics match Next.js coverage:
   // .nextjs-ref/test/e2e/app-dir/root-layout/root-layout.test.ts
@@ -128,6 +160,22 @@ describe("navigationPlanner root-boundary decisions", () => {
   it("uses the current soft fallback when the target root identity is unknown", () => {
     const decision = planFlightResponse(null);
 
+    expect(decision.kind).toBe("proposeCommit");
+    if (decision.kind !== "proposeCommit") {
+      throw new Error("Expected proposeCommit decision");
+    }
+    expect(decision.proposal.reason).toBe("rootBoundaryUnknownFallback");
+    expect(decision.trace.entries[0]?.code).toBe(NavigationTraceReasonCodes.rootBoundaryUnknown);
+  });
+
+  it("uses the current soft fallback when the visible root identity is unknown", () => {
+    const transition = navigationPlanner.classifyRootBoundaryTransition(null, "/");
+    const decision = planFlightResponseFromRootBoundaries({
+      currentRootBoundaryId: null,
+      nextRootBoundaryId: "/",
+    });
+
+    expect(transition).toBe("rootBoundaryUnknownFallback");
     expect(decision.kind).toBe("proposeCommit");
     if (decision.kind !== "proposeCommit") {
       throw new Error("Expected proposeCommit decision");


### PR DESCRIPTION
## What this changes

Implements `#726-CORE-07/08` from issue #726 by adding a small `navigationPlanner` spine with `NavigationEvent`, `NavigationDecisionV0`, `OperationToken`, and `RouteSnapshotV0` contracts, then routing the current root-boundary hard-navigation decision through that planner.

Bonk: please read issue #726 before reviewing this PR so the bigger navigation planner / lifecycle gate / executor architecture is in view. This PR is intentionally a narrow CORE-07/08 slice, not the full planner migration.

## Behavior preserved

The current browser navigation behavior is kept intact:

- same root boundary -> proposed visible commit (`NC_COMMIT`)
- changed root boundary -> hard navigation (`NC_ROOT`)
- unknown root boundary -> legacy soft-commit fallback (`NC_ROOT_UNKNOWN`)
- stale lifecycle authority -> lifecycle gate still skips before planner decisions (`NC_STALE`)
- prefetch flight responses -> no visible commit / no hard navigation (`NC_PREFETCH_ONLY`)

The browser state layer remains the lifecycle gate. It now translates current/pending App Router state into planner snapshots, while the planner owns the semantic root-boundary decision. I left targeted comments at that boundary and the unknown-root fallback to make the future #726 route-graph/planner slices clear for follow-up PRs.

## Why

Issue #726 is moving vinext from local navigation checks toward a semantic planner that proposes decisions, with lifecycle approval and execution kept separate. Root-boundary hard navigation is the smallest current behavior that can prove that spine without turning the planner into a broad reducer too early.

## Next.js reference

Checked the local Next.js oracle for root-layout MPA behavior:

- `.nextjs-ref/test/e2e/app-dir/root-layout/root-layout.test.ts`
- `.nextjs-ref/test/e2e/app-dir/segment-cache/mpa-navigations/mpa-navigations.test.ts`

The added vinext tests preserve the same high-level contract: crossing root layout boundaries is hard navigation; same-root navigation remains soft.

## Validation

- `vp test run tests/navigation-planner.test.ts tests/app-browser-entry.test.ts` — 83 tests passed
- `vp check packages/vinext/src/server/navigation-planner.ts packages/vinext/src/server/app-browser-state.ts packages/vinext/src/server/app-browser-visible-commit.ts packages/vinext/src/server/navigation-trace.ts tests/navigation-planner.test.ts tests/app-browser-entry.test.ts`
- `vp run knip --no-progress`
- `git diff --check`
- `vp run vinext#build`

`vp run vinext#build` still emits the repo's expected unresolved virtual/private import warnings for generated entry placeholders.

## Review loop

Ran high-effort correctness and architecture review passes, then a simplifier loop. The main simplifier finding was that the first version fabricated sentinel planner inputs for root-boundary checks; this version removes that shape and passes real pending/current state-derived snapshots through the planner path.
