### PR TITLE
fix(middleware): preserve NextResponse.next status

### DIFF
--- a/packages/vinext/src/global.d.ts
+++ b/packages/vinext/src/global.d.ts
@@ -367,12 +367,12 @@ declare global {
 declare module "node:http" {
   interface IncomingMessage {
     /**
-     * The HTTP status code set by vinext middleware for Pages Router rewrite
-     * responses (e.g. 307 for a rewrite that should surface as a redirect).
-     * Written in `index.ts` when middleware emits a `rewriteStatus`, read by
-     * the downstream Pages Router handler to decide the final response status.
+     * The HTTP status code set by vinext middleware for Pages Router continue
+     * or rewrite responses. Written in `index.ts` when middleware emits a
+     * status override, read by the downstream Pages Router handler to decide
+     * the final response status.
      */
-    __vinextRewriteStatus?: number;
+    __vinextMiddlewareStatus?: number;
   }
 }
 

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -2608,8 +2608,9 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                   // would be dispatched instead.
                   req.url = url;
                 }
-                if (result.rewriteStatus) {
-                  req.__vinextRewriteStatus = result.rewriteStatus;
+                const middlewareStatus = result.status ?? result.rewriteStatus;
+                if (middlewareStatus !== undefined) {
+                  req.__vinextMiddlewareStatus = middlewareStatus;
                 }
 
                 // Forward middleware context to the RSC entry so it can
@@ -2628,7 +2629,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                   }
                   req.headers["x-vinext-mw-ctx"] = JSON.stringify({
                     h: mwCtxEntries,
-                    s: result.rewriteStatus ?? null,
+                    s: middlewareStatus ?? null,
                     r: result.rewriteUrl ?? null,
                   });
                 }
@@ -2733,7 +2734,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                 nextConfig?.basePath ?? "",
                 nextConfig?.trailingSlash ?? false,
               );
-              const mwStatus = req.__vinextRewriteStatus;
+              const mwStatus = req.__vinextMiddlewareStatus;
 
               // Try rendering the resolved URL
               const match = matchRoute(resolvedUrl.split("?")[0], routes);

--- a/packages/vinext/src/server/app-middleware.ts
+++ b/packages/vinext/src/server/app-middleware.ts
@@ -246,6 +246,10 @@ export async function applyAppMiddleware(
       options.context.headers = new Headers(result.responseHeaders);
     }
 
+    if (result.status !== undefined) {
+      options.context.status = result.status;
+    }
+
     if (result.rewriteUrl) {
       if (result.rewriteStatus !== undefined) {
         options.context.status = result.rewriteStatus;

--- a/packages/vinext/src/server/middleware-runtime.ts
+++ b/packages/vinext/src/server/middleware-runtime.ts
@@ -20,6 +20,7 @@ export type MiddlewareResult = {
   redirectStatus?: number;
   rewriteUrl?: string;
   rewriteStatus?: number;
+  status?: number;
   responseHeaders?: Headers;
   response?: Response;
   waitUntilPromises?: Promise<unknown>[];
@@ -209,6 +210,7 @@ export async function executeMiddleware(
     return {
       continue: true,
       responseHeaders: collectMiddlewareHeaders(response),
+      status: response.status !== 200 ? response.status : undefined,
       waitUntilPromises,
     };
   }
@@ -251,6 +253,7 @@ export async function executeMiddleware(
       rewriteUrl: rewritePath,
       rewriteStatus: response.status !== 200 ? response.status : undefined,
       responseHeaders: collectMiddlewareHeaders(response),
+      status: response.status !== 200 ? response.status : undefined,
       waitUntilPromises,
     };
   }

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -1454,7 +1454,7 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
       // ── 5. Run middleware ─────────────────────────────────────────
       let resolvedUrl = url;
       const middlewareHeaders: Record<string, string | string[]> = {};
-      let middlewareRewriteStatus: number | undefined;
+      let middlewareStatus: number | undefined;
       if (typeof runMiddleware === "function") {
         const result = await runMiddleware(webRequest, undefined);
 
@@ -1532,9 +1532,10 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
           resolvedUrl = result.rewriteUrl;
         }
 
-        // Apply custom status code from middleware rewrite
-        // (e.g. NextResponse.rewrite(url, { status: 403 }))
-        middlewareRewriteStatus = result.rewriteStatus;
+        // Apply custom status code from middleware continue/rewrite responses.
+        // Examples: NextResponse.next({ status: 404 }) and
+        // NextResponse.rewrite(url, { status: 403 }).
+        middlewareStatus = result.status ?? result.rewriteStatus;
       }
 
       // Unpack x-middleware-request-* headers into the actual request and strip
@@ -1621,11 +1622,7 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
           response = new Response("404 - API route not found", { status: 404 });
         }
 
-        const mergedResponse = mergeWebResponse(
-          middlewareHeaders,
-          response,
-          middlewareRewriteStatus,
-        );
+        const mergedResponse = mergeWebResponse(middlewareHeaders, response, middlewareStatus);
 
         if (!mergedResponse.body) {
           await sendWebResponse(mergedResponse, req, res, compress);
@@ -1711,7 +1708,7 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
 
       // Capture the streaming marker before mergeWebResponse rebuilds the Response.
       const shouldStreamPagesResponse = isVinextStreamedHtmlResponse(response);
-      const mergedResponse = mergeWebResponse(middlewareHeaders, response, middlewareRewriteStatus);
+      const mergedResponse = mergeWebResponse(middlewareHeaders, response, middlewareStatus);
 
       if (shouldStreamPagesResponse || !mergedResponse.body) {
         await sendWebResponse(mergedResponse, req, res, compress);

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -4887,6 +4887,9 @@ export function middleware(request) {
   if (url.pathname === "/blocked") {
     return NextResponse.rewrite(new URL("/allowed", request.url), { status: 403 });
   }
+  if (url.pathname === "/next-status") {
+    return NextResponse.next({ status: 404 });
+  }
   return NextResponse.next();
 }`,
     );
@@ -4899,6 +4902,11 @@ export function middleware(request) {
     await fsp.writeFile(
       path.join(statusTmpDir, "pages", "index.tsx"),
       `export default function Home() { return <h1>Home</h1>; }`,
+    );
+
+    await fsp.writeFile(
+      path.join(statusTmpDir, "pages", "next-status.tsx"),
+      `export default function NextStatus() { return <h1>NEXT STATUS PAGE</h1>; }`,
     );
 
     const vinext = (await import("../packages/vinext/src/index.js")).default;
@@ -4938,6 +4946,13 @@ export function middleware(request) {
     expect(html).toContain("ALLOWED PAGE");
     // Status code should be 403 from the middleware rewrite
     expect(res.status).toBe(403);
+  });
+
+  it("middleware next with custom status returns that status code", async () => {
+    const res = await fetch(`${statusBaseUrl}/next-status`);
+    const html = await res.text();
+    expect(html).toContain("NEXT STATUS PAGE");
+    expect(res.status).toBe(404);
   });
 
   it("normal requests without rewrite status return 200", async () => {

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -2970,6 +2970,24 @@ describe("runMiddleware preserves x-middleware-request-* headers (dev mode)", ()
     expect(result.responseHeaders!.has("x-middleware-next")).toBe(false);
   });
 
+  it("preserves status from NextResponse.next()", async () => {
+    const { runMiddleware } = await import("../packages/vinext/src/server/middleware.js");
+    const { NextResponse } = await import("../packages/vinext/src/shims/server.js");
+
+    const mockRunner = {
+      import: async () => ({
+        default: () => NextResponse.next({ status: 404 }),
+        config: { matcher: "/" },
+      }),
+    };
+
+    const request = new Request("http://localhost/");
+    const result = await runMiddleware(mockRunner as any, "/fake/middleware.ts", request);
+
+    expect(result.continue).toBe(true);
+    expect(result.status).toBe(404);
+  });
+
   it("keeps x-middleware-request-* headers on rewrite", async () => {
     const { runMiddleware } = await import("../packages/vinext/src/server/middleware.js");
     const { NextResponse } = await import("../packages/vinext/src/shims/server.js");
@@ -3807,6 +3825,25 @@ describe("double-encoded path handling in middleware", () => {
     const mwPathname = new URL(capturedUrl!).pathname;
     expect(mwPathname).toBe("/%64ashboard");
     expect(mwPathname).not.toBe("/%2564ashboard");
+  });
+
+  it("App Router middleware preserves status from NextResponse.next()", async () => {
+    const { applyAppMiddleware } = await import("../packages/vinext/src/server/app-middleware.js");
+    const { NextResponse } = await import("../packages/vinext/src/shims/server.js");
+    const context = { headers: null, requestHeaders: null, status: null };
+
+    const result = await applyAppMiddleware({
+      cleanPathname: "/",
+      context,
+      isProxy: false,
+      module: {
+        default: () => NextResponse.next({ status: 404 }),
+      },
+      request: new Request("http://localhost:3000/"),
+    });
+
+    expect(result.kind).toBe("continue");
+    expect(context.status).toBe(404);
   });
 
   it("App Router middleware does not see internal Flight headers", async () => {


### PR DESCRIPTION
## What this changes
`NextResponse.next({ status })` now preserves the middleware response status when routing continues. The status flows through the shared middleware runtime into App Router middleware context and Pages Router dev/prod response merging, so a matched route can render with the middleware-selected status instead of silently falling back to the route response status.

## Why
`NextResponse.next()` builds a real `Response` from the supplied init while adding `x-middleware-next`: [Next.js response.ts#L146-L151](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/web/spec-extension/response.ts#L146-L151). Next.js then treats the middleware response status as routing metadata: it copies `middlewareRes.status` onto the server response when middleware returns, and returns it from the routing pipeline for middleware refresh responses: [resolve-routes.ts#L590-L591](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/router-utils/resolve-routes.ts#L590-L591), [resolve-routes.ts#L772-L779](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/router-utils/resolve-routes.ts#L772-L779).

Vinext already preserved custom status for middleware rewrites, but the `x-middleware-next` branch only propagated headers. That meant `NextResponse.next({ status: 404 })` continued correctly but lost the status before final response construction.

## Approach
Add a `status` field to `MiddlewareResult` for continue responses and set it from non-200 middleware `Response.status` values. App Router stores it in the existing middleware context status field. Pages Router dev and prod reuse their existing status override mechanisms, generalized from rewrite-only status to middleware continue/rewrite status.

The older `rewriteStatus` field remains populated for compatibility with existing callers while shared consumers prefer the broader `status` field.

## Validation
- `vp test run tests/shims.test.ts -t "preserves status from NextResponse.next"`
- `vp test run tests/shims.test.ts -t "NextResponse.next"`
- `vp test run tests/features.test.ts -t "middleware rewriteStatus propagation"`
- `vp test run tests/shims.test.ts`
- `vp test run tests/features.test.ts`
- `vp check packages/vinext/src/server/middleware-runtime.ts packages/vinext/src/server/app-middleware.ts packages/vinext/src/server/prod-server.ts packages/vinext/src/index.ts packages/vinext/src/global.d.ts tests/shims.test.ts tests/features.test.ts`

## Risks / follow-ups
This intentionally preserves status only when middleware returns a non-200 continue/rewrite response, matching vinext's existing status override semantics and avoiding needless response reconstruction for the default `NextResponse.next()` case.