### PR TITLE
fix(app-router): keep ISR app cache regeneration variant-safe

### DIFF
--- a/packages/vinext/src/server/app-page-cache.ts
+++ b/packages/vinext/src/server/app-page-cache.ts
@@ -52,6 +52,7 @@ type ReadAppPageCacheResponseOptions = {
 };
 
 type FinalizeAppPageHtmlCacheResponseOptions = {
+  capturedDynamicUsageBeforeContextCleanup?: () => boolean;
   capturedRscDataPromise: Promise<ArrayBuffer> | null;
   cleanPathname: string;
   consumeDynamicUsage: () => boolean;
@@ -229,13 +230,14 @@ export async function readAppPageCacheResponse(
     }
 
     if (cached?.isStale && cachedValue) {
+      const regenerationKey = options.isRscRequest
+        ? options.isrRscKey(options.cleanPathname, options.mountedSlotsHeader)
+        : options.isrHtmlKey(options.cleanPathname);
+
       // Preserve the legacy behavior from the inline generator: stale entries
       // still trigger background regeneration even if this request cannot use
       // the stale payload and will fall through to a fresh render.
-      // Dedup key is pathname-only: if multiple slot variants are stale
-      // concurrently, only one regen runs. Other variants refresh on
-      // their next STALE read.
-      options.scheduleBackgroundRegeneration(options.cleanPathname, async () => {
+      options.scheduleBackgroundRegeneration(regenerationKey, async () => {
         const revalidatedPage = await options.renderFreshPageForCache();
         const revalidateSeconds =
           revalidatedPage.cacheControl?.revalidate ?? options.revalidateSeconds;
@@ -325,7 +327,10 @@ export function finalizeAppPageHtmlCacheResponse(
     try {
       const cachedHtml = await readStreamAsText(streamForCache);
 
-      if (options.consumeDynamicUsage()) {
+      if (
+        options.capturedDynamicUsageBeforeContextCleanup?.() === true ||
+        options.consumeDynamicUsage()
+      ) {
         options.isrDebug?.("HTML cache write skipped (dynamic usage during render)", htmlKey);
         return;
       }

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -484,6 +484,7 @@ export async function renderAppPageLifecycle(
   }
   const draftCookie = options.getDraftModeCookieHeader();
   const dynamicUsedDuringRender = options.consumeDynamicUsage();
+  let dynamicUsedBeforeContextCleanup = dynamicUsedDuringRender;
 
   // Defer clearRequestContext() until the HTML stream is fully consumed by the
   // HTTP layer. The RSC/SSR pipeline is lazy — Server Components execute while
@@ -492,6 +493,8 @@ export async function renderAppPageLifecycle(
   // headers()/cookies() to see a null context on warm (module-cached) requests.
   // See: https://github.com/cloudflare/vinext/issues/660
   const safeHtmlStream = deferUntilStreamConsumed(htmlStream, () => {
+    dynamicUsedBeforeContextCleanup =
+      dynamicUsedBeforeContextCleanup || options.consumeDynamicUsage();
     options.clearRequestContext();
   });
 
@@ -536,6 +539,9 @@ export async function renderAppPageLifecycle(
     }
 
     return finalizeAppPageHtmlCacheResponse(isrResponse, {
+      capturedDynamicUsageBeforeContextCleanup() {
+        return dynamicUsedBeforeContextCleanup;
+      },
       capturedRscDataPromise: capturedRscDataRef.value,
       cleanPathname: options.cleanPathname,
       consumeDynamicUsage: options.consumeDynamicUsage,

--- a/tests/app-page-cache.test.ts
+++ b/tests/app-page-cache.test.ts
@@ -299,6 +299,41 @@ describe("app page cache helpers", () => {
     ]);
   });
 
+  it("dedups stale RSC regeneration by the slot-specific cache key", async () => {
+    const scheduledKeys: string[] = [];
+    const rscData = new TextEncoder().encode("stale-flight").buffer;
+
+    await readAppPageCacheResponse({
+      cleanPathname: "/parallel",
+      clearRequestContext() {},
+      isRscRequest: true,
+      async isrGet() {
+        return buildISRCacheEntry(buildCachedAppPageValue("", rscData), true);
+      },
+      isrHtmlKey(pathname) {
+        return "html:" + pathname;
+      },
+      isrRscKey(pathname, mountedSlotsHeader) {
+        return `rsc:${pathname}:${mountedSlotsHeader ?? "none"}`;
+      },
+      async isrSet() {},
+      mountedSlotsHeader: "slot:auth:/",
+      revalidateSeconds: 60,
+      async renderFreshPageForCache() {
+        return {
+          html: "<h1>fresh</h1>",
+          rscData,
+          tags: ["/parallel", "_N_T_/parallel"],
+        };
+      },
+      scheduleBackgroundRegeneration(key) {
+        scheduledKeys.push(key);
+      },
+    });
+
+    expect(scheduledKeys).toEqual(["rsc:/parallel:slot:auth:/"]);
+  });
+
   it("serves stale HTML entries and regenerates HTML plus canonical RSC cache keys", async () => {
     const scheduledRegenerations: Array<() => Promise<void>> = [];
     const isrSetCalls: Array<{
@@ -561,6 +596,60 @@ describe("app page cache helpers", () => {
     expect(isrSet).not.toHaveBeenCalled();
     expect(debugCalls).toEqual([
       ["HTML cache write skipped (dynamic usage during render)", "html:/dynamic-html"],
+    ]);
+  });
+
+  it("skips HTML and RSC cache writes when dynamic usage was captured before context cleanup", async () => {
+    const pendingCacheWrites: Promise<void>[] = [];
+    const debugCalls: Array<[string, string]> = [];
+    const isrSet = vi.fn();
+
+    const response = finalizeAppPageHtmlCacheResponse(
+      new Response("<h1>personalized</h1>", {
+        headers: {
+          "Content-Type": "text/html; charset=utf-8",
+          "Cache-Control": "s-maxage=60, stale-while-revalidate",
+          Vary: "RSC, Accept",
+          "X-Vinext-Cache": "MISS",
+        },
+      }),
+      {
+        capturedDynamicUsageBeforeContextCleanup() {
+          return true;
+        },
+        capturedRscDataPromise: Promise.resolve(new TextEncoder().encode("flight").buffer),
+        cleanPathname: "/dynamic-html-cleanup",
+        consumeDynamicUsage() {
+          return false;
+        },
+        getPageTags() {
+          return ["/dynamic-html-cleanup", "_N_T_/dynamic-html-cleanup"];
+        },
+        isrDebug(event, detail) {
+          debugCalls.push([event, detail]);
+        },
+        isrHtmlKey(pathname) {
+          return "html:" + pathname;
+        },
+        isrRscKey(pathname) {
+          return "rsc:" + pathname;
+        },
+        isrSet,
+        revalidateSeconds: 60,
+        waitUntil(promise) {
+          pendingCacheWrites.push(promise);
+        },
+      },
+    );
+
+    await expect(response.text()).resolves.toBe("<h1>personalized</h1>");
+    expect(pendingCacheWrites).toHaveLength(1);
+
+    await pendingCacheWrites[0];
+
+    expect(isrSet).not.toHaveBeenCalled();
+    expect(debugCalls).toEqual([
+      ["HTML cache write skipped (dynamic usage during render)", "html:/dynamic-html-cleanup"],
     ]);
   });
 


### PR DESCRIPTION
## What this changes
App Router ISR stale regeneration now dedups on the actual cache key for the requested payload. HTML stale entries use the HTML key, and RSC stale entries use the slot-aware RSC key, so parallel stale mounted-slot variants for one pathname can regenerate independently.

HTML cache writes also honor dynamic usage captured immediately before request context cleanup. If dynamic APIs are discovered while the HTML stream is drained, the later cache branch can still skip both HTML and paired canonical RSC writes even if the client branch cleared request state first.

## Why
The previous stale app-page path scheduled background regeneration with only `cleanPathname`, while RSC ISR storage keys include the mounted slot variant. Two stale RSC variants for one pathname could collapse into one pending regeneration, leaving the other variant stale until a later request escaped the pending-regeneration window.

The HTML cache writer read `consumeDynamicUsage()` after teeing the response stream. If the client branch reached `clearRequestContext()` before the cache branch performed that read, late dynamic usage could become invisible and personalized output could be persisted.

## Next.js reference
Next.js batches response-cache work by the cache key it is reading and revalidating:

- https://github.com/vercel/next.js/blob/04294cb47a6d67adf73c8b6f196ed6a2ddcb2b0e/packages/next/src/server/response-cache/index.ts#L273-L296
- https://github.com/vercel/next.js/blob/04294cb47a6d67adf73c8b6f196ed6a2ddcb2b0e/packages/next/src/server/response-cache/index.ts#L357-L368
- https://github.com/vercel/next.js/blob/04294cb47a6d67adf73c8b6f196ed6a2ddcb2b0e/packages/next/src/server/response-cache/index.ts#L412-L430

Next.js also keeps App Router stream creation and teeing inside `workUnitAsyncStorage.run(...)`, which is the reference point for preserving dynamic usage visibility around streaming:

- https://github.com/vercel/next.js/blob/04294cb47a6d67adf73c8b6f196ed6a2ddcb2b0e/packages/next/src/server/app-render/app-render.tsx#L1043-L1062
- https://github.com/vercel/next.js/blob/04294cb47a6d67adf73c8b6f196ed6a2ddcb2b0e/packages/next/src/server/app-render/app-render.tsx#L3882-L3900

## Approach
- Use `isrHtmlKey(cleanPathname)` or `isrRscKey(cleanPathname, mountedSlotsHeader)` as the background regeneration dedup key instead of `cleanPathname`.
- Snapshot `consumeDynamicUsage()` in the `deferUntilStreamConsumed()` cleanup path before calling `clearRequestContext()`.
- Let `finalizeAppPageHtmlCacheResponse()` consult that snapshot before falling back to its normal cache-branch dynamic check.

## Validation
- Added a regression test proving stale RSC regeneration is scheduled with the slot-specific cache key.
- Added a regression test proving pre-cleanup dynamic usage skips HTML and paired RSC cache writes even when the later cache-branch `consumeDynamicUsage()` call returns false.
- `vp test run tests/app-page-cache.test.ts tests/app-page-render.test.ts tests/app-page-dispatch.test.ts tests/app-rsc-cache-busting.test.ts`
- `vp check` completed with 0 errors and 1 existing warning in `packages/vinext/src/server/request-pipeline.ts:604` (`unknown | undefined`).

## Risks / follow-ups
The fix is intentionally scoped to App Router app-page ISR. Route-handler ISR already dedups on its route cache key and does not share the HTML stream cleanup race shape.