### PR TITLE
fix(app-router): emit action revalidation headers

### DIFF
--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -685,6 +685,7 @@ export async function handleServerActionRscRequest<
     }
     return actionResponse;
   } catch (error) {
+    getAndClearActionRevalidationKind();
     return createServerActionErrorResponse(error, {
       cleanPathname: options.cleanPathname,
       clearRequestContext: options.clearRequestContext,

--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -192,6 +192,11 @@ function setActionRevalidatedHeader(headers: Headers, kind: ActionRevalidationKi
 
 function resolveActionRevalidationKind(hasModifiedCookies: boolean): ActionRevalidationKind {
   const revalidationKind = getAndClearActionRevalidationKind();
+  // Cookie mutations are a hard override to STATIC_AND_DYNAMIC: any cookie
+  // change can invalidate downstream cached payloads regardless of what
+  // (if anything) the action explicitly revalidated, so we always emit the
+  // strongest kind. STATIC_AND_DYNAMIC is also the lowest numeric value, so
+  // this matches the max-precedence semantics in markActionRevalidation.
   if (hasModifiedCookies) return ACTION_DID_REVALIDATE_STATIC_AND_DYNAMIC;
   return revalidationKind;
 }

--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -466,6 +466,7 @@ export async function handleProgressiveServerActionRequest(
       });
     }
 
+    getAndClearActionRevalidationKind();
     options.getAndClearPendingCookies();
     // Next.js rethrows generic MPA action errors into its page render path.
     // vinext does not yet implement that form-state render path, so unexpected

--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -1,3 +1,4 @@
+import { getAndClearActionRevalidationKind, type ActionRevalidationKind } from "vinext/shims/cache";
 import type { HeadersAccessPhase } from "vinext/shims/headers";
 import { type FetchCacheMode, setCurrentFetchCacheMode } from "vinext/shims/fetch-cache";
 import { VINEXT_RSC_VARY_HEADER } from "./app-rsc-cache-busting.js";
@@ -181,6 +182,19 @@ type ActionControlResponse =
  * Function.prototype.apply when decoding hostile action payloads.
  */
 const SERVER_ACTION_ARGS_LIMIT = 1000;
+const ACTION_DID_NOT_REVALIDATE = 0 satisfies ActionRevalidationKind;
+const ACTION_DID_REVALIDATE_STATIC_AND_DYNAMIC = 1 satisfies ActionRevalidationKind;
+
+function setActionRevalidatedHeader(headers: Headers, kind: ActionRevalidationKind): void {
+  if (kind === ACTION_DID_NOT_REVALIDATE) return;
+  headers.set("x-action-revalidated", JSON.stringify(kind));
+}
+
+function resolveActionRevalidationKind(hasModifiedCookies: boolean): ActionRevalidationKind {
+  const revalidationKind = getAndClearActionRevalidationKind();
+  if (hasModifiedCookies) return ACTION_DID_REVALIDATE_STATIC_AND_DYNAMIC;
+  return revalidationKind;
+}
 
 function isRequestBodyTooLarge(error: unknown): boolean {
   return error instanceof Error && error.message === "Request body too large";
@@ -416,11 +430,15 @@ export async function handleProgressiveServerActionRequest(
       // Next.js decodes form state and re-renders after a successful MPA action.
       // vinext currently supports the redirect/error status cases; successful
       // non-redirect actions intentionally fall through to the page render.
+      getAndClearActionRevalidationKind();
       return null;
     }
 
     const actionPendingCookies = options.getAndClearPendingCookies();
     const actionDraftCookie = options.getDraftModeCookieHeader();
+    const actionRevalidationKind = resolveActionRevalidationKind(
+      actionPendingCookies.length > 0 || Boolean(actionDraftCookie),
+    );
     options.clearRequestContext();
 
     const headers = new Headers();
@@ -434,6 +452,7 @@ export async function handleProgressiveServerActionRequest(
     if (actionDraftCookie) {
       headers.append("Set-Cookie", actionDraftCookie);
     }
+    setActionRevalidatedHeader(headers, actionRevalidationKind);
 
     return new Response(null, {
       status: actionControlResponse.kind === "redirect" ? 303 : actionControlResponse.statusCode,
@@ -572,6 +591,9 @@ export async function handleServerActionRscRequest<
     if (actionRedirect) {
       const actionPendingCookies = options.getAndClearPendingCookies();
       const actionDraftCookie = options.getDraftModeCookieHeader();
+      const actionRevalidationKind = resolveActionRevalidationKind(
+        actionPendingCookies.length > 0 || Boolean(actionDraftCookie),
+      );
       options.clearRequestContext();
       const redirectHeaders = new Headers({
         "Content-Type": "text/x-component; charset=utf-8",
@@ -585,6 +607,7 @@ export async function handleServerActionRscRequest<
         redirectHeaders.append("Set-Cookie", cookie);
       }
       if (actionDraftCookie) redirectHeaders.append("Set-Cookie", actionDraftCookie);
+      setActionRevalidatedHeader(redirectHeaders, actionRevalidationKind);
       return new Response("", { status: 200, headers: redirectHeaders });
     }
 
@@ -640,12 +663,16 @@ export async function handleServerActionRscRequest<
 
     const actionPendingCookies = options.getAndClearPendingCookies();
     const actionDraftCookie = options.getDraftModeCookieHeader();
+    const actionRevalidationKind = resolveActionRevalidationKind(
+      actionPendingCookies.length > 0 || Boolean(actionDraftCookie),
+    );
 
     const actionHeaders = new Headers({
       "Content-Type": "text/x-component; charset=utf-8",
       Vary: VINEXT_RSC_VARY_HEADER,
     });
     mergeMiddlewareResponseHeaders(actionHeaders, options.middlewareHeaders);
+    setActionRevalidatedHeader(actionHeaders, actionRevalidationKind);
     const actionResponse = new Response(rscStream, {
       status: options.middlewareStatus ?? actionStatus,
       headers: actionHeaders,

--- a/packages/vinext/src/shims/cache.ts
+++ b/packages/vinext/src/shims/cache.ts
@@ -378,7 +378,9 @@ export async function revalidateTag(
   tag: string,
   profile?: string | { expire?: number },
 ): Promise<void> {
-  markActionRevalidation(ACTION_DID_REVALIDATE_STATIC_AND_DYNAMIC);
+  if (!profile) {
+    markActionRevalidation(ACTION_DID_REVALIDATE_STATIC_AND_DYNAMIC);
+  }
   // Resolve the profile to durations for the handler
   let durations: { expire?: number } | undefined;
   if (typeof profile === "string") {
@@ -591,14 +593,17 @@ export function _runWithCacheState<T>(fn: () => T | Promise<T>): T | Promise<T> 
  * @internal
  */
 export function _initRequestScopedCacheState(): void {
-  _getCacheState().actionRevalidationKind = ACTION_DID_NOT_REVALIDATE;
-  _getCacheState().requestScopedCacheLife = null;
+  const state = _getCacheState();
+  state.actionRevalidationKind = ACTION_DID_NOT_REVALIDATE;
+  state.requestScopedCacheLife = null;
 }
 
 function markActionRevalidation(kind: ActionRevalidationKind): void {
   if (getHeadersAccessPhase() !== "action") return;
 
   const state = _getCacheState();
+  // Static/data invalidation includes the dynamic refresh case, so never
+  // downgrade from kind 1 to kind 2 if both APIs run in one action.
   state.actionRevalidationKind =
     state.actionRevalidationKind === ACTION_DID_REVALIDATE_STATIC_AND_DYNAMIC
       ? ACTION_DID_REVALIDATE_STATIC_AND_DYNAMIC

--- a/packages/vinext/src/shims/cache.ts
+++ b/packages/vinext/src/shims/cache.ts
@@ -17,7 +17,7 @@
  *   setCacheHandler(new MyCacheHandler());
  */
 
-import { markDynamicUsage as _markDynamic } from "./headers.js";
+import { getHeadersAccessPhase, markDynamicUsage as _markDynamic } from "./headers.js";
 import { getOrCreateAls } from "./internal/als-registry.js";
 import { fnv1a64 } from "../utils/hash.js";
 import {
@@ -378,6 +378,7 @@ export async function revalidateTag(
   tag: string,
   profile?: string | { expire?: number },
 ): Promise<void> {
+  markActionRevalidation(ACTION_DID_REVALIDATE_STATIC_AND_DYNAMIC);
   // Resolve the profile to durations for the handler
   let durations: { expire?: number } | undefined;
   if (typeof profile === "string") {
@@ -407,6 +408,7 @@ export async function revalidateTag(
  * layout/page hierarchy tags, so only no-type invalidation applies there.
  */
 export async function revalidatePath(path: string, type?: "page" | "layout"): Promise<void> {
+  markActionRevalidation(ACTION_DID_REVALIDATE_STATIC_AND_DYNAMIC);
   // Strip trailing slash so root "/" becomes "" — avoids double-slash in _N_T_//layout
   const stem = path.endsWith("/") ? path.slice(0, -1) : path;
   const tag = type ? `_N_T_${stem}/${type}` : `_N_T_${stem || "/"}`;
@@ -418,10 +420,12 @@ export async function revalidatePath(path: string, type?: "page" | "layout"): Pr
  *
  * In Next.js, calling `refresh()` inside a Server Action triggers a
  * client-side router refresh so the user immediately sees updated data.
- * vinext does not yet implement the Server Actions refresh protocol,
- * so this function has no effect.
+ * vinext reports the dynamic-only invalidation through the Server Action
+ * response header that the client router already understands.
  */
-export function refresh(): void {}
+export function refresh(): void {
+  markActionRevalidation(ACTION_DID_REVALIDATE_DYNAMIC_ONLY);
+}
 
 /**
  * Expire a cache tag immediately (Next.js 16).
@@ -431,6 +435,7 @@ export function refresh(): void {}
  * `updateTag` invalidates synchronously within the same request context.
  */
 export async function updateTag(tag: string): Promise<void> {
+  markActionRevalidation(ACTION_DID_REVALIDATE_STATIC_AND_DYNAMIC);
   // Expire the tag immediately (same as revalidateTag without SWR)
   await _getActiveHandler().revalidateTag(tag);
 }
@@ -527,8 +532,10 @@ export function unstable_io(): Promise<void> {
 // Uses AsyncLocalStorage for request isolation on concurrent workers.
 // ---------------------------------------------------------------------------
 export type UnstableCacheRevalidationMode = "foreground" | "background";
+export type ActionRevalidationKind = 0 | 1 | 2;
 
 export type CacheState = {
+  actionRevalidationKind: ActionRevalidationKind;
   requestScopedCacheLife: CacheLifeConfig | null;
   unstableCacheRevalidation: UnstableCacheRevalidationMode;
 };
@@ -538,9 +545,14 @@ const _g = globalThis as unknown as Record<PropertyKey, unknown>;
 const _cacheAls = getOrCreateAls<CacheState>("vinext.cache.als");
 
 const _cacheFallbackState = (_g[_FALLBACK_KEY] ??= {
+  actionRevalidationKind: 0,
   requestScopedCacheLife: null,
   unstableCacheRevalidation: "foreground",
 } satisfies CacheState) as CacheState;
+
+const ACTION_DID_NOT_REVALIDATE = 0 satisfies ActionRevalidationKind;
+const ACTION_DID_REVALIDATE_STATIC_AND_DYNAMIC = 1 satisfies ActionRevalidationKind;
+const ACTION_DID_REVALIDATE_DYNAMIC_ONLY = 2 satisfies ActionRevalidationKind;
 
 function _getCacheState(): CacheState {
   if (isInsideUnifiedScope()) {
@@ -560,11 +572,13 @@ export function _runWithCacheState<T>(fn: () => T | Promise<T>): T | Promise<T>;
 export function _runWithCacheState<T>(fn: () => T | Promise<T>): T | Promise<T> {
   if (isInsideUnifiedScope()) {
     return runWithUnifiedStateMutation((uCtx) => {
+      uCtx.actionRevalidationKind = ACTION_DID_NOT_REVALIDATE;
       uCtx.requestScopedCacheLife = null;
       uCtx.unstableCacheRevalidation = "foreground";
     }, fn);
   }
   const state: CacheState = {
+    actionRevalidationKind: ACTION_DID_NOT_REVALIDATE,
     requestScopedCacheLife: null,
     unstableCacheRevalidation: "foreground",
   };
@@ -577,7 +591,25 @@ export function _runWithCacheState<T>(fn: () => T | Promise<T>): T | Promise<T> 
  * @internal
  */
 export function _initRequestScopedCacheState(): void {
+  _getCacheState().actionRevalidationKind = ACTION_DID_NOT_REVALIDATE;
   _getCacheState().requestScopedCacheLife = null;
+}
+
+function markActionRevalidation(kind: ActionRevalidationKind): void {
+  if (getHeadersAccessPhase() !== "action") return;
+
+  const state = _getCacheState();
+  state.actionRevalidationKind =
+    state.actionRevalidationKind === ACTION_DID_REVALIDATE_STATIC_AND_DYNAMIC
+      ? ACTION_DID_REVALIDATE_STATIC_AND_DYNAMIC
+      : kind;
+}
+
+export function getAndClearActionRevalidationKind(): ActionRevalidationKind {
+  const state = _getCacheState();
+  const kind = state.actionRevalidationKind;
+  state.actionRevalidationKind = ACTION_DID_NOT_REVALIDATE;
+  return kind;
 }
 
 /**

--- a/packages/vinext/src/shims/cache.ts
+++ b/packages/vinext/src/shims/cache.ts
@@ -388,7 +388,11 @@ export async function revalidateTag(
   } else if (profile && typeof profile === "object") {
     durations = profile;
   }
-  if (!profile || durations?.expire === 0) {
+  // Notify the client router whenever the server-side cache is fully
+  // invalidated (no SWR window). An unknown profile name resolves to no
+  // durations, in which case the handler treats it as a full invalidation —
+  // so we mark here too, matching what actually happens server-side.
+  if (!profile || !durations || durations.expire === 0) {
     markActionRevalidation(ACTION_DID_REVALIDATE_STATIC_AND_DYNAMIC);
   }
   await _getActiveHandler().revalidateTag(tag, durations);

--- a/packages/vinext/src/shims/cache.ts
+++ b/packages/vinext/src/shims/cache.ts
@@ -378,9 +378,6 @@ export async function revalidateTag(
   tag: string,
   profile?: string | { expire?: number },
 ): Promise<void> {
-  if (!profile) {
-    markActionRevalidation(ACTION_DID_REVALIDATE_STATIC_AND_DYNAMIC);
-  }
   // Resolve the profile to durations for the handler
   let durations: { expire?: number } | undefined;
   if (typeof profile === "string") {
@@ -390,6 +387,9 @@ export async function revalidateTag(
     }
   } else if (profile && typeof profile === "object") {
     durations = profile;
+  }
+  if (!profile || durations?.expire === 0) {
+    markActionRevalidation(ACTION_DID_REVALIDATE_STATIC_AND_DYNAMIC);
   }
   await _getActiveHandler().revalidateTag(tag, durations);
 }

--- a/packages/vinext/src/shims/headers.ts
+++ b/packages/vinext/src/shims/headers.ts
@@ -288,6 +288,10 @@ export function setHeadersAccessPhase(phase: HeadersAccessPhase): HeadersAccessP
   return _setStatePhase(_getState(), phase);
 }
 
+export function getHeadersAccessPhase(): HeadersAccessPhase {
+  return _getState().phase;
+}
+
 /**
  * Set the headers/cookies context for the current RSC render.
  * Called by the framework's RSC entry before rendering each request.

--- a/packages/vinext/src/shims/unified-request-context.ts
+++ b/packages/vinext/src/shims/unified-request-context.ts
@@ -85,6 +85,7 @@ function _getInheritedExecutionContext(): ExecutionContextLike | null {
 export function createRequestContext(opts?: Partial<UnifiedRequestContext>): UnifiedRequestContext {
   return {
     headersContext: null,
+    actionRevalidationKind: 0,
     dynamicUsageDetected: false,
     invalidDynamicUsageError: null,
     pendingSetCookies: [],

--- a/tests/app-server-action-execution.test.ts
+++ b/tests/app-server-action-execution.test.ts
@@ -618,6 +618,22 @@ describe("app server action execution helpers", () => {
     expect(response?.headers.get("x-action-revalidated")).toBe("1");
   });
 
+  it("does not emit x-action-revalidated when a fetch action revalidates a tag with a profile", async () => {
+    const response = await handleServerActionRscRequest(
+      createRscOptions({
+        loadServerAction() {
+          return Promise.resolve(async () => {
+            await revalidateTag("dashboard", "hours");
+            return "revalidated";
+          });
+        },
+      }),
+    );
+
+    expect(response?.status).toBe(200);
+    expect(response?.headers.get("x-action-revalidated")).toBeNull();
+  });
+
   it("emits dynamic-only x-action-revalidated when a fetch action refreshes", async () => {
     const response = await handleServerActionRscRequest(
       createRscOptions({

--- a/tests/app-server-action-execution.test.ts
+++ b/tests/app-server-action-execution.test.ts
@@ -634,6 +634,22 @@ describe("app server action execution helpers", () => {
     expect(response?.headers.get("x-action-revalidated")).toBeNull();
   });
 
+  it("emits x-action-revalidated when a fetch action revalidates a tag with expire zero", async () => {
+    const response = await handleServerActionRscRequest(
+      createRscOptions({
+        loadServerAction() {
+          return Promise.resolve(async () => {
+            await revalidateTag("dashboard", { expire: 0 });
+            return "revalidated";
+          });
+        },
+      }),
+    );
+
+    expect(response?.status).toBe(200);
+    expect(response?.headers.get("x-action-revalidated")).toBe("1");
+  });
+
   it("emits dynamic-only x-action-revalidated when a fetch action refreshes", async () => {
     const response = await handleServerActionRscRequest(
       createRscOptions({

--- a/tests/app-server-action-execution.test.ts
+++ b/tests/app-server-action-execution.test.ts
@@ -9,6 +9,8 @@ import {
   type HandleProgressiveServerActionRequestOptions,
 } from "../packages/vinext/src/server/app-server-action-execution.js";
 import { VINEXT_RSC_VARY_HEADER } from "../packages/vinext/src/server/app-rsc-cache-busting.js";
+import { refresh, revalidatePath, revalidateTag } from "../packages/vinext/src/shims/cache.js";
+import { setHeadersAccessPhase } from "../packages/vinext/src/shims/headers.js";
 
 type TestRoute = {
   id: string;
@@ -101,9 +103,7 @@ function createOptions(
     },
     reportRequestError() {},
     request: createMultipartRequest(),
-    setHeadersAccessPhase() {
-      return "render";
-    },
+    setHeadersAccessPhase,
     ...overrides,
   };
 }
@@ -210,9 +210,7 @@ function createRscOptions(
       return error;
     },
     searchParams: new URLSearchParams("tab=activity"),
-    setHeadersAccessPhase() {
-      return "render";
-    },
+    setHeadersAccessPhase,
     setNavigationContext() {},
     toInterceptOpts(intercept) {
       return { slot: intercept.slotKey };
@@ -601,6 +599,41 @@ describe("app server action execution helpers", () => {
     expect(navigationContexts).toEqual([{ params: {}, pathname: "/dashboard" }]);
   });
 
+  // Mirrors Next.js' action revalidation header contract:
+  // packages/next/src/server/app-render/action-handler.ts addRevalidationHeader()
+  // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/action-handler.ts
+  it("emits x-action-revalidated when a fetch action revalidates a path", async () => {
+    const response = await handleServerActionRscRequest(
+      createRscOptions({
+        loadServerAction() {
+          return Promise.resolve(async () => {
+            await revalidatePath("/dashboard");
+            return "revalidated";
+          });
+        },
+      }),
+    );
+
+    expect(response?.status).toBe(200);
+    expect(response?.headers.get("x-action-revalidated")).toBe("1");
+  });
+
+  it("emits dynamic-only x-action-revalidated when a fetch action refreshes", async () => {
+    const response = await handleServerActionRscRequest(
+      createRscOptions({
+        loadServerAction() {
+          return Promise.resolve(() => {
+            refresh();
+            return "refreshed";
+          });
+        },
+      }),
+    );
+
+    expect(response?.status).toBe(200);
+    expect(response?.headers.get("x-action-revalidated")).toBe("2");
+  });
+
   // Ported from Next.js: test/e2e/app-dir/actions/app-action.test.ts
   // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/actions/app-action.test.ts
   it("rejects fetch actions with too many decoded arguments before invoking the action", async () => {
@@ -759,6 +792,23 @@ describe("app server action execution helpers", () => {
     expect(await response?.text()).toBe("");
     expect(clearContext).toHaveBeenCalledTimes(1);
     expect(renderToReadableStream).not.toHaveBeenCalled();
+  });
+
+  it("emits x-action-revalidated when a redirecting fetch action revalidates a tag", async () => {
+    const response = await handleServerActionRscRequest(
+      createRscOptions({
+        loadServerAction() {
+          return Promise.resolve(async () => {
+            await revalidateTag("dashboard");
+            throw { digest: "NEXT_REDIRECT;;%2Ftarget;307" };
+          });
+        },
+      }),
+    );
+
+    expect(response?.status).toBe(200);
+    expect(response?.headers.get("x-action-revalidated")).toBe("1");
+    expect(response?.headers.get("x-action-redirect")).toBe("/target");
   });
 
   // Ported from Next.js: packages/next/src/server/app-render/action-handler.ts


### PR DESCRIPTION
## What this changes
Server Action responses now emit `x-action-revalidated` when an action invalidates cached client router data. Path and tag revalidation, `updateTag`, cookie mutation, and `refresh()` now surface the same numeric header contract the Next.js client reducer expects.

## Why
vinext already invalidated the server-side cache when actions called `revalidatePath()` or `revalidateTag()`, but the action response did not tell the client router that its cached RSC payloads were stale. After an action completed, the browser could keep using stale router cache entries until another navigation forced fresh data.

Next.js reference points:

- [`addRevalidationHeader()` in `action-handler.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/action-handler.ts#L146-L198)
- [`x-action-revalidated` client parsing in `server-action-reducer.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts#L199-L206)
- [`ActionRevalidationKind` constants](https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/action-revalidation-kind.ts#L1-L5)
- [`refresh()` dynamic-only revalidation marker](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/web/spec-extension/revalidate.ts#L83-L88)
- [`revalidatePath()` static-and-dynamic marker](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/web/spec-extension/revalidate.ts#L240-L245)

## Approach
Add a small action-scoped revalidation marker to the existing cache shim request state. `revalidatePath()`, `revalidateTag()`, `updateTag()`, and `refresh()` only record action revalidation while the headers shim is in the `action` phase, so normal route/page revalidation calls do not accidentally produce action response headers.

The action executor consumes and clears that marker while constructing progressive action responses, action redirects, and normal RSC action responses. Cookie mutations are treated as static-and-dynamic invalidations, matching Next.js behavior, while `refresh()` emits the dynamic-only value.

## Validation
- `vp test run tests/app-server-action-execution.test.ts`
- `vp test run tests/app-browser-entry.test.ts -t "server action"`
- `vp check tests/app-server-action-execution.test.ts packages/vinext/src/server/app-server-action-execution.ts packages/vinext/src/shims/cache.ts packages/vinext/src/shims/headers.ts packages/vinext/src/shims/unified-request-context.ts`

## Risks / follow-ups
This intentionally preserves Next.js current coarse invalidation model: the header only communicates the invalidation kind, not the exact path or tag set. More granular path/tag client invalidation would be a separate compatibility project.