### PR TITLE
Align React RSC init floor with 19.2.6

### DIFF
--- a/packages/vinext/src/cli.ts
+++ b/packages/vinext/src/cli.ts
@@ -363,7 +363,7 @@ async function buildApp() {
     : createBuildLogger(vite);
 
   // For App Router: upgrade React if needed for react-server-dom-webpack compatibility.
-  // Without this, builds with react<19.2.5 produce a Worker that crashes at
+  // Without this, builds with older React versions can produce a Worker that crashes at
   // runtime with "Cannot read properties of undefined (reading 'moduleMap')".
   if (isApp) {
     const reactUpgrade = getReactUpgradeDeps(process.cwd());

--- a/packages/vinext/src/init.ts
+++ b/packages/vinext/src/init.ts
@@ -150,7 +150,7 @@ export function isDepInstalled(root: string, dep: string): boolean {
  * Check if react/react-dom need upgrading for react-server-dom-webpack compatibility.
  *
  * react-server-dom-webpack versions are pinned to match their React version
- * (e.g. rsdw@19.2.5 requires react@^19.2.5). When a project has an older
+ * (e.g. rsdw@19.2.6 requires react@^19.2.6). When a project has an older
  * React (e.g. create-next-app ships react@19.2.3), we need to upgrade
  * react/react-dom BEFORE installing rsdw to avoid peer-dep conflicts.
  *
@@ -169,12 +169,12 @@ export function getReactUpgradeDeps(root: string): string[] {
     const resolved = req.resolve("react");
     const version = findPackageVersion(resolved, "react");
     if (!version) return [];
-    // react-server-dom-webpack@latest currently requires react@^19.2.5
+    // react-server-dom-webpack@latest currently requires react@^19.2.6
     const parts = version.split(".");
     const major = parseInt(parts[0], 10);
     const minor = parseInt(parts[1], 10);
     const patch = parseInt(parts[2], 10);
-    if (major < 19 || (major === 19 && minor < 2) || (major === 19 && minor === 2 && patch < 5)) {
+    if (major < 19 || (major === 19 && minor < 2) || (major === 19 && minor === 2 && patch < 6)) {
       return ["react@latest", "react-dom@latest"];
     }
     return [];
@@ -293,7 +293,7 @@ export async function init(options: InitOptions): Promise<InitResult> {
   const missingDeps = neededDeps.filter((dep) => !isDepInstalled(root, dep));
 
   // For App Router: react-server-dom-webpack requires react/react-dom versions
-  // to match exactly (e.g. rsdw@19.2.5 needs react@^19.2.5). If the installed
+  // to match exactly (e.g. rsdw@19.2.6 needs react@^19.2.6). If the installed
   // React is too old (common with create-next-app), upgrade it first as a
   // regular dependency to avoid ERESOLVE peer-dep conflicts.
   if (isApp && missingDeps.includes("react-server-dom-webpack")) {

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -314,7 +314,7 @@ function setupFakeReact(dir: string, version: string): void {
 describe("getReactUpgradeDeps", () => {
   it("returns react@latest + react-dom@latest when React is below the RSDW security floor", () => {
     setupProject(tmpDir, { router: "app" });
-    setupFakeReact(tmpDir, "19.2.4");
+    setupFakeReact(tmpDir, "19.2.5");
 
     const deps = getReactUpgradeDeps(tmpDir);
     expect(deps).toEqual(["react@latest", "react-dom@latest"]);


### PR DESCRIPTION
## Summary

- align the init/build React upgrade guard with `react-server-dom-webpack@19.2.6`
- treat React 19.2.5 as below the App Router RSC floor so projects upgrade before installing RSDW
- update init coverage for the new boundary

## Context

React published GHSA-rv78-f8rc-xrxh for `react-server-dom-*` packages. The workspace catalog and lockfile already resolve to 19.2.6 on main; this PR keeps vinext's App Router init path aligned with that patched release.

https://github.com/facebook/react/security/advisories/GHSA-rv78-f8rc-xrxh

## Validation

- `./node_modules/.bin/vp test tests/init.test.ts`
- `./node_modules/.bin/vp check tests/init.test.ts`
- `git diff --check origin/main...HEAD`