### PR TITLE
Prefer Pages Router route params over same-key query params

### DIFF
--- a/packages/vinext/src/entries/pages-server-entry.ts
+++ b/packages/vinext/src/entries/pages-server-entry.ts
@@ -290,6 +290,10 @@ function parseQuery(url) {
   return q;
 }
 
+function mergeRouteParamsIntoQuery(query, params) {
+  return Object.assign(query, params);
+}
+
 function patternToNextFormat(pattern) {
   // Match any non-/ param name. Non-greedy with lookahead prevents
   // the +/* suffix being consumed into the param name when the name
@@ -450,10 +454,11 @@ async function _renderPage(request, url, manifest, middlewareHeaders) {
     ensureFetchPatch();
     try {
       const routePattern = patternToNextFormat(route.pattern);
+      const query = mergeRouteParamsIntoQuery(parseQuery(routeUrl), params);
       if (typeof setSSRContext === "function") {
         setSSRContext({
           pathname: routePattern,
-          query: { ...params, ...parseQuery(routeUrl) },
+          query,
           asPath: routeUrl,
           locale: locale,
           locales: i18nConfig ? i18nConfig.locales : undefined,
@@ -490,13 +495,12 @@ async function _renderPage(request, url, manifest, middlewareHeaders) {
           _fontLinkHeader = _allFp.map(function(p) { return "<" + p.href + ">; rel=preload; as=font; type=" + p.type + "; crossorigin"; }).join(", ");
         }
       } catch (e) { /* font preloads not available */ }
-      const query = parseQuery(routeUrl);
       const pageDataResult = await __resolvePagesPageData({
         applyRequestContexts() {
           if (typeof setSSRContext === "function") {
             setSSRContext({
               pathname: routePattern,
-              query: { ...params, ...query },
+              query,
               asPath: routeUrl,
               locale: locale,
               locales: i18nConfig ? i18nConfig.locales : undefined,

--- a/packages/vinext/src/server/api-handler.ts
+++ b/packages/vinext/src/server/api-handler.ts
@@ -11,7 +11,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { decode as decodeQueryString } from "node:querystring";
 import { type Route, matchRoute } from "../routing/pages-router.js";
 import { reportRequestError, importModule, type ModuleImporter } from "./instrumentation.js";
-import { addQueryParam } from "../utils/query.js";
+import { mergeRouteParamsIntoQuery, parseQueryString } from "../utils/query.js";
 import { PagesBodyParseError, getMediaType, isJsonMediaType } from "./pages-media-type.js";
 
 /**
@@ -197,15 +197,9 @@ export async function handleApiRoute(
       return true;
     }
 
-    // Parse query from URL + route params
-    const query: Record<string, string | string[]> = { ...params };
-    const queryString = url.split("?")[1];
-    if (queryString) {
-      const searchParams = new URLSearchParams(queryString);
-      for (const [key, value] of searchParams) {
-        addQueryParam(query, key, value);
-      }
-    }
+    // Parse query from URL + route params. Path params win over same-key search
+    // params so a query string cannot change the dynamic route value.
+    const query = mergeRouteParamsIntoQuery(parseQueryString(url), params);
 
     // Parse body
     const body = await parseBody(req);

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -27,7 +27,7 @@ import { runWithServerInsertedHTMLState } from "vinext/shims/navigation-state";
 import { withScriptNonce } from "vinext/shims/script-nonce-context";
 import { createInlineScriptTag, createNonceAttribute, safeJsonStringify } from "./html.js";
 import { getScriptNonceFromNodeHeaderSources } from "./csp.js";
-import { parseQueryString as parseQuery } from "../utils/query.js";
+import { mergeRouteParamsIntoQuery, parseQueryString as parseQuery } from "../utils/query.js";
 import path from "node:path";
 import React from "react";
 import { renderToReadableStream } from "react-dom/server.edge";
@@ -330,6 +330,7 @@ export function createSSRHandler(
     }
 
     const { route, params } = match;
+    const query = mergeRouteParamsIntoQuery(parseQuery(url), params);
 
     // Wrap the entire request in a single unified AsyncLocalStorage scope.
     const requestContext = createRequestContext();
@@ -344,7 +345,7 @@ export function createSSRHandler(
         if (typeof routerShim.setSSRContext === "function") {
           routerShim.setSSRContext({
             pathname: patternToNextFormat(route.pattern),
-            query: { ...params, ...parseQuery(url) },
+            query,
             asPath: url,
             locale: locale ?? currentDefaultLocale,
             locales: i18nConfig?.locales,
@@ -451,7 +452,7 @@ export function createSSRHandler(
             params,
             req,
             res,
-            query: parseQuery(url),
+            query,
             resolvedUrl: localeStrippedUrl,
             locale: locale ?? currentDefaultLocale,
             locales: i18nConfig?.locales,
@@ -605,7 +606,7 @@ export function createSSRHandler(
                       if (typeof routerShim.setSSRContext === "function") {
                         routerShim.setSSRContext({
                           pathname: patternToNextFormat(route.pattern),
-                          query: { ...params, ...parseQuery(url) },
+                          query,
                           asPath: url,
                           locale: locale ?? currentDefaultLocale,
                           locales: i18nConfig?.locales,

--- a/packages/vinext/src/server/pages-api-route.ts
+++ b/packages/vinext/src/server/pages-api-route.ts
@@ -1,5 +1,5 @@
 import type { Route } from "../routing/pages-router.js";
-import { addQueryParam } from "../utils/query.js";
+import { mergeRouteParamsIntoQuery, parseQueryString } from "../utils/query.js";
 import {
   createPagesReqRes,
   parsePagesApiBody,
@@ -29,17 +29,7 @@ type HandlePagesApiRouteOptions = {
 };
 
 function buildPagesApiQuery(url: string, params: PagesRequestQuery): PagesRequestQuery {
-  const query: PagesRequestQuery = { ...params };
-  const search = url.split("?")[1];
-  if (!search) {
-    return query;
-  }
-
-  for (const [key, value] of new URLSearchParams(search)) {
-    addQueryParam(query, key, value);
-  }
-
-  return query;
+  return mergeRouteParamsIntoQuery(parseQueryString(url), params);
 }
 
 export async function handlePagesApiRoute(options: HandlePagesApiRouteOptions): Promise<Response> {

--- a/packages/vinext/src/utils/query.ts
+++ b/packages/vinext/src/utils/query.ts
@@ -37,6 +37,23 @@ export function addQueryParam(
 }
 
 /**
+ * Merge pathname-derived dynamic route params into a query object.
+ *
+ * Route params must win over same-name URL search params so `/posts/123?id=456`
+ * still exposes `id: "123"` to Pages Router APIs.
+ */
+export function mergeRouteParamsIntoQuery(
+  query: Record<string, string | string[]>,
+  params: Record<string, string | string[]>,
+): Record<string, string | string[]> {
+  const merged: Record<string, string | string[]> = { ...query };
+  for (const [key, value] of Object.entries(params)) {
+    setOwnQueryValue(merged, key, Array.isArray(value) ? [...value] : value);
+  }
+  return merged;
+}
+
+/**
  * Parse a URL's query string into a Record, with multi-value keys promoted to arrays.
  */
 export function parseQueryString(url: string): Record<string, string | string[]> {

--- a/tests/pages-api-route.test.ts
+++ b/tests/pages-api-route.test.ts
@@ -39,6 +39,25 @@ describe("pages api route", () => {
     });
   });
 
+  it("keeps dynamic params ahead of same-key query-string values", async () => {
+    const response = await handlePagesApiRoute({
+      match: createMatch(
+        (req, res) => {
+          res.json(req.query);
+        },
+        { id: "123" },
+      ),
+      request: new Request("https://example.com/api/users/123?id=evil&tag=a"),
+      url: "/api/users/123?id=evil&tag=a",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      id: "123",
+      tag: "a",
+    });
+  });
+
   it("returns 400 with an Invalid JSON statusText for malformed JSON bodies", async () => {
     const response = await handlePagesApiRoute({
       match: createMatch((req, res) => {

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -345,6 +345,16 @@ describe("Pages Router integration", () => {
     expect(html).toMatch(/Query ID:\s*(<!--\s*-->)?\s*42/);
   });
 
+  it("keeps dynamic route params ahead of same-key search params during SSR", async () => {
+    const res = await fetch(`${baseUrl}/posts/42?id=evil`);
+    expect(res.status).toBe(200);
+
+    const html = await res.text();
+    expect(html).toMatch(/Post:\s*(<!--\s*-->)?\s*42/);
+    expect(html).toMatch(/Query ID:\s*(<!--\s*-->)?\s*42/);
+    expect(html).not.toMatch(/Query ID:\s*(<!--\s*-->)?\s*evil/);
+  });
+
   it("next/compat/router: useRouter returns router object in Pages Router context", async () => {
     const res = await fetch(`${baseUrl}/compat-router-test`);
     expect(res.status).toBe(200);
@@ -470,6 +480,14 @@ describe("Pages Router integration", () => {
 
   it("handles dynamic API routes with query params", async () => {
     const res = await fetch(`${baseUrl}/api/users/123`);
+    expect(res.status).toBe(200);
+
+    const data = await res.json();
+    expect(data).toEqual({ user: { id: "123", name: "User 123" } });
+  });
+
+  it("keeps dynamic API route params ahead of same-key query params", async () => {
+    const res = await fetch(`${baseUrl}/api/users/123?id=evil`);
     expect(res.status).toBe(200);
 
     const data = await res.json();


### PR DESCRIPTION
## Summary

- Keep pathname-derived Pages Router params authoritative when search params use the same key
- Apply the same merge order in dev SSR, the generated production Pages entry, and Pages API route handlers
- Add regression coverage for SSR router state and Pages API query objects

## Test

- `vp test run tests/pages-api-route.test.ts`
- `vp test run tests/pages-router.test.ts -t "dynamic route params ahead|dynamic API route params ahead"`
- `vp test run tests/entry-templates.test.ts`
- `vp check packages/vinext/src/utils/query.ts packages/vinext/src/server/api-handler.ts packages/vinext/src/server/pages-api-route.ts packages/vinext/src/server/dev-server.ts packages/vinext/src/entries/pages-server-entry.ts tests/pages-api-route.test.ts tests/pages-router.test.ts`