### PR TITLE
fix(middleware): preserve credentials for external override rewrites

### DIFF
--- a/packages/vinext/src/config/config-matchers.ts
+++ b/packages/vinext/src/config/config-matchers.ts
@@ -502,8 +502,13 @@ export function normalizeHost(hostHeader: string | null, fallbackHostname: strin
 export function applyMiddlewareRequestHeaders(
   middlewareHeaders: Record<string, string | string[]>,
   request: Request,
+  options: { preserveCredentialHeaders?: boolean } = {},
 ): { request: Request; postMwReqCtx: RequestContext } {
-  const nextHeaders = buildRequestHeadersFromMiddlewareResponse(request.headers, middlewareHeaders);
+  const nextHeaders = buildRequestHeadersFromMiddlewareResponse(
+    request.headers,
+    middlewareHeaders,
+    options,
+  );
 
   for (const key of Object.keys(middlewareHeaders)) {
     if (key.startsWith("x-middleware-")) {

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -2570,6 +2570,11 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                   middlewareRequestHeaders = buildRequestHeadersFromMiddlewareResponse(
                     currentRequestHeaders,
                     result.responseHeaders,
+                    {
+                      preserveCredentialHeaders: Boolean(
+                        result.rewriteUrl && isExternalUrl(result.rewriteUrl),
+                      ),
+                    },
                   );
 
                   if (middlewareRequestHeaders && !hasAppDir) {

--- a/packages/vinext/src/server/app-middleware.ts
+++ b/packages/vinext/src/server/app-middleware.ts
@@ -109,7 +109,9 @@ function requestWithMiddlewareRequestHeaders(
   middlewareHeaders: Headers | null,
 ): Request {
   const nextHeaders = middlewareHeaders
-    ? buildRequestHeadersFromMiddlewareResponse(request.headers, middlewareHeaders)
+    ? buildRequestHeadersFromMiddlewareResponse(request.headers, middlewareHeaders, {
+        preserveCredentialHeaders: true,
+      })
     : null;
   if (!nextHeaders) return request;
 

--- a/packages/vinext/src/server/middleware-request-headers.ts
+++ b/packages/vinext/src/server/middleware-request-headers.ts
@@ -1,9 +1,13 @@
 const MIDDLEWARE_REQUEST_HEADER_PREFIX = "x-middleware-request-";
 const MIDDLEWARE_OVERRIDE_HEADERS = "x-middleware-override-headers";
 const MIDDLEWARE_SET_COOKIE_HEADER = "x-middleware-set-cookie";
+const CREDENTIAL_REQUEST_HEADERS = ["authorization", "cookie"] as const;
 
 type MiddlewareHeaderValue = string | string[];
 type MiddlewareHeaderSource = Headers | Record<string, MiddlewareHeaderValue>;
+type BuildRequestHeadersOptions = {
+  preserveCredentialHeaders?: boolean;
+};
 
 function getMiddlewareHeaderValue(source: MiddlewareHeaderSource, key: string): string | null {
   if (source instanceof Headers) {
@@ -68,6 +72,7 @@ export function encodeMiddlewareRequestHeaders(
 export function buildRequestHeadersFromMiddlewareResponse(
   baseHeaders: Headers,
   middlewareHeaders: MiddlewareHeaderSource,
+  options: BuildRequestHeadersOptions = {},
 ): Headers | null {
   const overrideHeaderNames = getOverrideHeaderNames(middlewareHeaders);
   const forwardedHeaders = getForwardedRequestHeaders(middlewareHeaders);
@@ -83,6 +88,18 @@ export function buildRequestHeadersFromMiddlewareResponse(
       nextHeaders.set(key, value);
     }
     return nextHeaders;
+  }
+
+  if (options.preserveCredentialHeaders) {
+    const overrideHeaderNameSet = new Set(overrideHeaderNames);
+    for (const key of CREDENTIAL_REQUEST_HEADERS) {
+      if (overrideHeaderNameSet.has(key)) continue;
+
+      const value = baseHeaders.get(key);
+      if (value !== null) {
+        nextHeaders.set(key, value);
+      }
+    }
   }
 
   for (const key of overrideHeaderNames) {

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -1545,6 +1545,7 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
       const { postMwReqCtx, request: postMwReq } = applyMiddlewareRequestHeaders(
         middlewareHeaders,
         webRequest,
+        { preserveCredentialHeaders: isExternalUrl(resolvedUrl) },
       );
       webRequest = postMwReq;
 

--- a/tests/request-pipeline.test.ts
+++ b/tests/request-pipeline.test.ts
@@ -17,6 +17,7 @@ import {
   validateImageUrl,
   processMiddlewareHeaders,
 } from "../packages/vinext/src/server/request-pipeline.js";
+import { buildRequestHeadersFromMiddlewareResponse } from "../packages/vinext/src/server/middleware-request-headers.js";
 
 // ── guardProtocolRelativeUrl ────────────────────────────────────────────
 
@@ -749,6 +750,49 @@ describe("filterInternalHeaders", () => {
     const headers = new Headers();
     const result = filterInternalHeaders(headers);
     expect([...result.keys()]).toEqual([]);
+  });
+});
+
+describe("buildRequestHeadersFromMiddlewareResponse", () => {
+  it("preserves credential headers when applying partial middleware override headers", () => {
+    const baseHeaders = new Headers({
+      authorization: "Bearer token",
+      cookie: "session=abc",
+      "x-keep": "original",
+    });
+    const middlewareHeaders = new Headers({
+      "x-middleware-override-headers": "x-added",
+      "x-middleware-request-x-added": "1",
+    });
+
+    const result = buildRequestHeadersFromMiddlewareResponse(baseHeaders, middlewareHeaders, {
+      preserveCredentialHeaders: true,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.get("authorization")).toBe("Bearer token");
+    expect(result!.get("cookie")).toBe("session=abc");
+    expect(result!.get("x-added")).toBe("1");
+    expect(result!.get("x-keep")).toBeNull();
+  });
+
+  it("deletes credential headers when middleware explicitly omits their forwarded values", () => {
+    const baseHeaders = new Headers({
+      authorization: "Bearer token",
+      cookie: "session=abc",
+      "x-keep": "original",
+    });
+    const middlewareHeaders = new Headers({
+      "x-middleware-override-headers": "authorization,cookie,x-keep",
+      "x-middleware-request-x-keep": "updated",
+    });
+
+    const result = buildRequestHeadersFromMiddlewareResponse(baseHeaders, middlewareHeaders);
+
+    expect(result).not.toBeNull();
+    expect(result!.get("authorization")).toBeNull();
+    expect(result!.get("cookie")).toBeNull();
+    expect(result!.get("x-keep")).toBe("updated");
   });
 });
 

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -3951,6 +3951,51 @@ describe("double-encoded path handling in middleware", () => {
     }
   });
 
+  it("external middleware rewrite proxy preserves credentials when applying partial request overrides", async () => {
+    const { proxyExternalMiddlewareRewrite } =
+      await import("../packages/vinext/src/server/app-middleware.js");
+    const http = await import("node:http");
+    let capturedHeaders: Record<string, string | string[] | undefined> = {};
+    const server = http.createServer((req, res) => {
+      capturedHeaders = req.headers;
+      res.writeHead(200, { "content-type": "text/plain" });
+      res.end("proxied");
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, resolve));
+    try {
+      const address = server.address();
+      expect(address && typeof address === "object").toBe(true);
+      const port = address && typeof address === "object" ? address.port : 0;
+      const response = await proxyExternalMiddlewareRewrite(
+        new Request("http://localhost:3000/source", {
+          headers: {
+            authorization: "Bearer secret",
+            cookie: "session=abc",
+            "x-keep": "original",
+          },
+        }),
+        `http://127.0.0.1:${port}/target`,
+        {
+          headers: null,
+          requestHeaders: new Headers({
+            "x-middleware-override-headers": "x-added",
+            "x-middleware-request-x-added": "1",
+          }),
+          status: null,
+        },
+      );
+
+      expect(response.status).toBe(200);
+      expect(capturedHeaders.authorization).toBe("Bearer secret");
+      expect(capturedHeaders.cookie).toBe("session=abc");
+      expect(capturedHeaders["x-added"]).toBe("1");
+      expect(capturedHeaders["x-keep"]).toBeUndefined();
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
   it("Pages Router runMiddleware passes decoded pathname to middleware function", async () => {
     const { runMiddleware } = await import("../packages/vinext/src/server/middleware.js");
     // Create a mock Vite server that returns a middleware module


### PR DESCRIPTION
## What this changes

Preserves original `cookie` and `authorization` request headers when middleware request-header overrides are applied immediately before external rewrite proxying.

## Why

The shared middleware override helper correctly treats `x-middleware-override-headers` as an authoritative replacement set for normal Next.js request-context application. That mirrors Next.js' router behavior, where omitted headers are deleted from the downstream request.

However, vinext also uses the same helper at external proxy boundaries. If that boundary receives a partial override set, rebuilding from `new Headers()` drops credential headers that were present on the original request. External rewrite targets then receive the middleware-added headers but not the caller's cookie or authorization credentials.

Relevant Next.js references:

- [`NextResponse` serializes middleware request override keys into `x-middleware-request-*` and `x-middleware-override-headers`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/web/spec-extension/response.ts#L13-L27)
- [`resolve-routes` applies the override set by deleting omitted request headers and then applying forwarded values](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/router-utils/resolve-routes.ts#L640-L666)
- [`middleware-request-header-overrides` covers add, delete, and update behavior against downstream handlers](https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-request-header-overrides/test/index.test.ts)

## Approach

Keep Next.js-compatible deletion semantics as the default behavior of `buildRequestHeadersFromMiddlewareResponse()`.

Add an explicit `preserveCredentialHeaders` option for external proxy boundaries only. When enabled, original `authorization` and `cookie` headers are copied into the rebuilt request unless middleware explicitly lists those headers in the override set, which still allows intentional deletion or replacement.

Thread that option through App Router external middleware rewrites and Pages Router dev/prod external rewrite paths.

## Validation

- `vp test run tests/request-pipeline.test.ts`
- `vp test run tests/shims.test.ts -t "middleware request header overrides|external middleware rewrite proxy"`
- `vp test run tests/request-pipeline.test.ts tests/shims.test.ts -t "credential headers|middleware request header overrides|external middleware rewrite proxy"`
- `vp test run tests/pages-router.test.ts -t "external middleware rewrites|external middleware rewrite|runMiddleware preserves external middleware rewrite destinations"`
- `vp check packages/vinext/src/server/middleware-request-headers.ts packages/vinext/src/server/app-middleware.ts packages/vinext/src/config/config-matchers.ts packages/vinext/src/server/prod-server.ts packages/vinext/src/index.ts tests/request-pipeline.test.ts tests/shims.test.ts`

## Risks / follow-ups

This intentionally preserves only `cookie` and `authorization`, matching the reported credential loss. Other omitted headers still follow the authoritative override-set deletion behavior.
