### PR TITLE
fix(actions): return HTTP fallback status for RSC action notFound

### DIFF
--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -288,9 +288,14 @@ function getActionRedirect(error: unknown): AppServerActionRedirect | null {
   };
 }
 
-function isActionHttpFallback(error: unknown): boolean {
+function getActionHttpFallbackStatus(error: unknown): number | null {
   const digest = getNextErrorDigest(error);
-  return digest !== null && parseNextHttpErrorDigest(digest) !== null;
+  if (!digest) return null;
+
+  const httpError = parseNextHttpErrorDigest(digest);
+  if (!httpError || !Number.isInteger(httpError.status)) return null;
+
+  return httpError.status;
 }
 
 function createServerActionErrorResponse(
@@ -538,6 +543,7 @@ export async function handleServerActionRscRequest<
     const args = await options.decodeReply(body, { temporaryReferences });
     let returnValue: AppServerActionReturnValue;
     let actionRedirect: AppServerActionRedirect | null = null;
+    let actionStatus = 200;
     const previousHeadersPhase = options.setHeadersAccessPhase("action");
     try {
       try {
@@ -548,11 +554,15 @@ export async function handleServerActionRscRequest<
         actionRedirect = getActionRedirect(error);
         if (actionRedirect) {
           returnValue = { ok: true, data: undefined };
-        } else if (isActionHttpFallback(error)) {
-          returnValue = { ok: false, data: error };
         } else {
-          console.error("[vinext] Server action error:", error);
-          returnValue = { ok: false, data: options.sanitizeErrorForClient(error) };
+          const httpFallbackStatus = getActionHttpFallbackStatus(error);
+          if (httpFallbackStatus !== null) {
+            actionStatus = httpFallbackStatus;
+            returnValue = { ok: false, data: error };
+          } else {
+            console.error("[vinext] Server action error:", error);
+            returnValue = { ok: false, data: options.sanitizeErrorForClient(error) };
+          }
         }
       }
     } finally {
@@ -637,7 +647,7 @@ export async function handleServerActionRscRequest<
     });
     mergeMiddlewareResponseHeaders(actionHeaders, options.middlewareHeaders);
     const actionResponse = new Response(rscStream, {
-      status: options.middlewareStatus ?? 200,
+      status: options.middlewareStatus ?? actionStatus,
       headers: actionHeaders,
     });
     if (actionPendingCookies.length > 0 || actionDraftCookie) {

--- a/tests/app-server-action-execution.test.ts
+++ b/tests/app-server-action-execution.test.ts
@@ -761,29 +761,37 @@ describe("app server action execution helpers", () => {
     expect(renderToReadableStream).not.toHaveBeenCalled();
   });
 
-  it("packages access fallback digests into the action return payload", async () => {
-    let renderedModel: TestActionModel | null = null;
-    const notFoundError = { digest: "NEXT_NOT_FOUND" };
+  // Ported from Next.js: packages/next/src/server/app-render/action-handler.ts
+  // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/action-handler.ts
+  it("sets the HTTP fallback status while packaging fallback digests into fetch-action Flight", async () => {
+    for (const [digest, statusCode] of [
+      ["NEXT_NOT_FOUND", 404],
+      ["NEXT_HTTP_ERROR_FALLBACK;404", 404],
+      ["NEXT_HTTP_ERROR_FALLBACK;403", 403],
+    ]) {
+      let renderedModel: TestActionModel | null = null;
+      const fallbackError = { digest };
 
-    const response = await handleServerActionRscRequest(
-      createRscOptions({
-        loadServerAction() {
-          return Promise.resolve(() => {
-            throw notFoundError;
-          });
-        },
-        renderToReadableStream(model) {
-          renderedModel = model;
-          return new Response("fallback-flight").body;
-        },
-      }),
-    );
+      const response = await handleServerActionRscRequest(
+        createRscOptions({
+          loadServerAction() {
+            return Promise.resolve(() => {
+              throw fallbackError;
+            });
+          },
+          renderToReadableStream(model) {
+            renderedModel = model;
+            return new Response("fallback-flight").body;
+          },
+        }),
+      );
 
-    expect(response?.status).toBe(200);
-    expect(await response?.text()).toBe("fallback-flight");
-    expect(renderedModel).toEqual({
-      root: "dashboard:{}:none",
-      returnValue: { ok: false, data: notFoundError },
-    });
+      expect(response?.status).toBe(statusCode);
+      expect(await response?.text()).toBe("fallback-flight");
+      expect(renderedModel).toEqual({
+        root: "dashboard:{}:none",
+        returnValue: { ok: false, data: fallbackError },
+      });
+    }
   });
 });


### PR DESCRIPTION
## What this changes
RSC server actions that throw `notFound()` or another HTTP access fallback now return the matching HTTP status while still sending the Flight payload expected by the client.

## Why
Progressive form actions already mapped control-flow fallbacks to explicit response statuses, but fetch/RSC actions kept falling through to the generic Flight response status of 200. That left `notFound()` action responses with the right payload shape but the wrong HTTP status.

Next.js handles this by detecting HTTP access fallback errors in the action handler, setting `res.statusCode = getAccessFallbackHTTPStatus(err)`, and then generating Flight for fetch actions. Reference: https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/action-handler.ts#L1210-L1231

## Approach
Extract the HTTP fallback status from the server action error digest at the action boundary. Preserve the thrown fallback error in the action return payload so the client-side Flight semantics stay unchanged, but carry the extracted status into the final RSC action `Response`.

Redirects remain on the existing action redirect header path, and ordinary action errors still use sanitized Flight error payloads.

## Validation
- `vp test run tests/app-server-action-execution.test.ts`
- `vp check packages/vinext/src/server/app-server-action-execution.ts tests/app-server-action-execution.test.ts`
- `vp fmt packages/vinext/src/server/app-server-action-execution.ts tests/app-server-action-execution.test.ts --check`
- `git diff --check`

## Risks / follow-ups
The change is scoped to fetch/RSC server action HTTP access fallback statuses. It does not add the broader MPA successful form-state render path that vinext already documents as incomplete.