### PR TITLE
fix(app-router): honor route group error boundaries

### DIFF
--- a/packages/vinext/src/entries/app-rsc-manifest.ts
+++ b/packages/vinext/src/entries/app-rsc-manifest.ts
@@ -61,6 +61,11 @@ function registerRouteModules(routes: AppRoute[], imports: ImportAllocator): voi
         if (ep) imports.getImportVar(ep);
       }
     }
+    if (route.errorPaths) {
+      for (const ep of route.errorPaths) {
+        imports.getImportVar(ep);
+      }
+    }
     if (route.notFoundPath) imports.getImportVar(route.notFoundPath);
     if (route.notFoundPaths) {
       for (const nfp of route.notFoundPaths) {
@@ -138,6 +143,7 @@ ${interceptEntries.join(",\n")}
     const layoutErrorVars = (route.layoutErrorPaths || []).map((ep) =>
       ep ? imports.getImportVar(ep) : "null",
     );
+    const errorVars = (route.errorPaths ?? []).map((ep) => imports.getImportVar(ep));
     return `  {
     __buildTimeClassifications: __VINEXT_CLASS(${routeIdx}), // evaluated once at module load
     __buildTimeReasons: __classDebug ? __VINEXT_CLASS_REASONS(${routeIdx}) : null,
@@ -155,6 +161,8 @@ ${interceptEntries.join(",\n")}
     layoutTreePositions: ${JSON.stringify(route.layoutTreePositions)},
     templates: [${templateVars.join(", ")}],
     errors: [${layoutErrorVars.join(", ")}],
+    errorPaths: [${errorVars.join(", ")}],
+    errorTreePositions: ${JSON.stringify(route.errorTreePositions ?? null)},
     slots: {
 ${slotEntries.join(",\n")}
     },

--- a/packages/vinext/src/routing/app-route-graph.ts
+++ b/packages/vinext/src/routing/app-route-graph.ts
@@ -101,10 +101,12 @@ export type AppRoute = {
    * Per-layout error boundary paths, aligned with the layouts array.
    * Each entry is the error.tsx at the same directory level as the
    * corresponding layout (or null if that level has no error.tsx).
-   * Used to interleave ErrorBoundary components with layouts so that
-   * ancestor error boundaries catch errors from descendant segments.
    */
   layoutErrorPaths: (string | null)[];
+  /** Per-segment error boundary paths, aligned with errorTreePositions. */
+  errorPaths?: string[];
+  /** Tree position (directory depth from app/ root) for each error boundary. */
+  errorTreePositions?: number[];
   /** Not-found component path (nearest, walking up from page dir) */
   notFoundPath: string | null;
   /**
@@ -1021,10 +1023,14 @@ function directoryToAppRoute(
   // Compute the tree position (directory depth) for each layout.
   const layoutTreePositions = computeLayoutTreePositions(appDir, layouts);
 
-  // Discover per-layout error boundaries (aligned with layouts array).
+  // Discover per-segment error boundaries. Next.js loader trees carry an
+  // error convention for a segment even when that segment has no layout.
   // In Next.js, each segment independently wraps its children with an ErrorBoundary.
   // This array enables interleaving error boundaries with layouts in the rendering.
   const layoutErrorPaths = discoverLayoutAlignedErrors(segments, appDir, matcher);
+  const errorEntries = discoverSegmentErrors(segments, appDir, matcher);
+  const errorPaths = errorEntries.map((entry) => entry.path);
+  const errorTreePositions = errorEntries.map((entry) => entry.treePosition);
 
   // Discover loading, error in the route's directory
   const routeDir = dir === "." ? appDir : path.join(appDir, dir);
@@ -1067,6 +1073,8 @@ function directoryToAppRoute(
     loadingPath,
     errorPath,
     layoutErrorPaths,
+    errorPaths,
+    errorTreePositions,
     notFoundPath,
     notFoundPaths,
     forbiddenPaths,
@@ -1223,15 +1231,46 @@ function discoverTemplates(
 }
 
 /**
- * Discover error.tsx files aligned with the layouts array.
- * Walks the same directory levels as discoverLayouts and, for each level
- * that contributes a layout entry, checks whether error.tsx also exists.
- * Returns an array of the same length as discoverLayouts() would return,
- * with the error path (or null) at each corresponding layout level.
+ * Discover error.tsx files by segment tree position.
  *
- * This enables interleaving ErrorBoundary components with layouts in the
- * rendering tree, matching Next.js behavior where each segment independently
- * wraps its children with an error boundary.
+ * Next.js stores conventions on every loader-tree segment; a route-group
+ * directory with error.tsx but no sibling layout.tsx must still wrap its
+ * descendants. Keeping positions explicit avoids conflating segment boundaries
+ * with layout component ownership.
+ */
+function discoverSegmentErrors(
+  segments: string[],
+  appDir: string,
+  matcher: ValidFileMatcher,
+): { path: string; treePosition: number }[] {
+  const errors: { path: string; treePosition: number }[] = [];
+
+  const rootError = findFile(appDir, "error", matcher);
+  if (rootError) {
+    errors.push({ path: rootError, treePosition: 0 });
+  }
+
+  // Check each directory level
+  let currentDir = appDir;
+  for (let index = 0; index < segments.length; index++) {
+    const segment = segments[index];
+    currentDir = path.join(currentDir, segment);
+    const error = findFile(currentDir, "error", matcher);
+    if (error) {
+      errors.push({ path: error, treePosition: index + 1 });
+    }
+  }
+
+  return errors;
+}
+
+/**
+ * Discover error.tsx files aligned with the layouts array.
+ *
+ * Route manifests still model layout-owned boundary facts by layout index.
+ * Keep this layout-aligned compatibility shape separate from segment-owned
+ * error boundaries so route-group errors without layouts do not get attributed
+ * to unrelated layouts.
  */
 function discoverLayoutAlignedErrors(
   segments: string[],
@@ -1240,13 +1279,11 @@ function discoverLayoutAlignedErrors(
 ): (string | null)[] {
   const errors: (string | null)[] = [];
 
-  // Root level (only if root has a layout — matching discoverLayouts logic)
   const rootLayout = findFile(appDir, "layout", matcher);
   if (rootLayout) {
     errors.push(findFile(appDir, "error", matcher));
   }
 
-  // Check each directory level
   let currentDir = appDir;
   for (const segment of segments) {
     currentDir = path.join(currentDir, segment);

--- a/packages/vinext/src/server/app-page-boundary-render.ts
+++ b/packages/vinext/src/server/app-page-boundary-render.ts
@@ -41,6 +41,7 @@ type AppPageBoundaryRscPayloadOptions<TModule extends AppPageModule = AppPageMod
 
 export type AppPageBoundaryRoute<TModule extends AppPageModule = AppPageModule> = {
   error?: TModule | null;
+  errorPaths?: readonly TModule[] | null;
   errors?: readonly (TModule | null | undefined)[] | null;
   forbidden?: TModule | null;
   layoutTreePositions?: readonly number[] | null;
@@ -342,6 +343,7 @@ export async function renderAppPageErrorBoundary<TModule extends AppPageModule>(
 ): Promise<Response | null> {
   const errorBoundary = resolveAppPageErrorBoundary({
     getDefaultExport,
+    errorModules: options.route?.errorPaths,
     globalErrorModule: options.globalErrorModule,
     layoutErrorModules: options.route?.errors,
     pageErrorModule: options.route?.error,

--- a/packages/vinext/src/server/app-page-boundary.ts
+++ b/packages/vinext/src/server/app-page-boundary.ts
@@ -29,6 +29,7 @@ type ResolveAppPageParentHttpAccessBoundaryModuleOptions<TModule> = {
 type ResolveAppPageErrorBoundaryOptions<TModule, TComponent> = {
   getDefaultExport: (module: TModule | null | undefined) => TComponent | null | undefined;
   globalErrorModule?: TModule | null;
+  errorModules?: readonly (TModule | null | undefined)[] | null;
   layoutErrorModules?: readonly (TModule | null | undefined)[] | null;
   pageErrorModule?: TModule | null;
 };
@@ -143,12 +144,13 @@ export function resolveAppPageErrorBoundary<TModule, TComponent>(
     };
   }
 
-  if (options.layoutErrorModules) {
-    for (let index = options.layoutErrorModules.length - 1; index >= 0; index--) {
-      const layoutErrorComponent = options.getDefaultExport(options.layoutErrorModules[index]);
-      if (layoutErrorComponent) {
+  const segmentErrorModules = options.errorModules ?? options.layoutErrorModules;
+  if (segmentErrorModules) {
+    for (let index = segmentErrorModules.length - 1; index >= 0; index--) {
+      const segmentErrorComponent = options.getDefaultExport(segmentErrorModules[index]);
+      if (segmentErrorComponent) {
         return {
-          component: layoutErrorComponent,
+          component: segmentErrorComponent,
           isGlobalError: false,
         };
       }

--- a/packages/vinext/src/server/app-page-route-wiring.tsx
+++ b/packages/vinext/src/server/app-page-route-wiring.tsx
@@ -69,7 +69,9 @@ export type AppPageRouteWiringRoute<
 > = {
   ids?: AppRouteSemanticIds | null;
   error?: TErrorModule | null;
+  errorPaths?: readonly TErrorModule[] | null;
   errors?: readonly (TErrorModule | null | undefined)[] | null;
+  errorTreePositions?: readonly number[] | null;
   layoutTreePositions?: readonly number[] | null;
   layouts: readonly (TModule | null | undefined)[];
   loading?: TModule | null;
@@ -148,6 +150,11 @@ type AppPageTemplateEntry<TModule extends AppPageModule = AppPageModule> = {
   treePosition: number;
 };
 
+type AppPageErrorEntry<TErrorModule extends AppPageErrorModule = AppPageErrorModule> = {
+  errorModule?: TErrorModule | null | undefined;
+  treePosition: number;
+};
+
 function getDefaultExport<TModule extends AppPageModule>(
   module: TModule | null | undefined,
 ): AppPageComponent | null {
@@ -177,7 +184,12 @@ export function createAppPageLayoutEntries<
 >(
   route: Pick<
     AppPageRouteWiringRoute<TModule, TErrorModule>,
-    "errors" | "layoutTreePositions" | "layouts" | "notFounds" | "routeSegments"
+    | "errors"
+    | "errorTreePositions"
+    | "layoutTreePositions"
+    | "layouts"
+    | "notFounds"
+    | "routeSegments"
   > & {
     forbiddens?: readonly (TModule | null | undefined)[] | null;
     unauthorizeds?: readonly (TModule | null | undefined)[] | null;
@@ -187,7 +199,7 @@ export function createAppPageLayoutEntries<
     const treePosition = route.layoutTreePositions?.[index] ?? 0;
     const treePath = createAppPageTreePath(route.routeSegments, treePosition);
     return {
-      errorModule: route.errors?.[index] ?? null,
+      errorModule: route.errorTreePositions ? null : (route.errors?.[index] ?? null),
       forbiddenModule: route.forbiddens?.[index] ?? null,
       id: AppElementsWire.encodeLayoutId(treePath),
       layoutModule,
@@ -214,6 +226,20 @@ function createAppPageTemplateEntries<TModule extends AppPageModule>(
       treePath,
       treePosition,
     };
+  });
+}
+
+function createAppPageErrorEntries<TErrorModule extends AppPageErrorModule>(
+  route: Pick<
+    AppPageRouteWiringRoute<AppPageModule, TErrorModule>,
+    "errorPaths" | "errors" | "errorTreePositions"
+  >,
+): AppPageErrorEntry<TErrorModule>[] {
+  return (route.errorPaths ?? route.errors ?? []).flatMap((errorModule, index) => {
+    if (!errorModule) return [];
+    const treePosition = route.errorTreePositions?.[index];
+    if (treePosition === undefined) return [];
+    return [{ errorModule, treePosition }];
   });
 }
 
@@ -339,13 +365,18 @@ export function buildAppPageElements<
   const pageId = AppElementsWire.encodePageId(options.routePath, interceptionContext);
   const layoutEntries = createAppPageLayoutEntries(options.route);
   const templateEntries = createAppPageTemplateEntries(options.route);
+  const errorEntries = createAppPageErrorEntries(options.route);
   const layoutEntriesByTreePosition = new Map<number, AppPageLayoutEntry<TModule, TErrorModule>>();
   const templateEntriesByTreePosition = new Map<number, AppPageTemplateEntry<TModule>>();
+  const errorEntriesByTreePosition = new Map<number, AppPageErrorEntry<TErrorModule>>();
   for (const layoutEntry of layoutEntries) {
     layoutEntriesByTreePosition.set(layoutEntry.treePosition, layoutEntry);
   }
   for (const templateEntry of templateEntries) {
     templateEntriesByTreePosition.set(templateEntry.treePosition, templateEntry);
+  }
+  for (const errorEntry of errorEntries) {
+    errorEntriesByTreePosition.set(errorEntry.treePosition, errorEntry);
   }
   const layoutIndicesByTreePosition = new Map<number, number>();
   for (let index = 0; index < layoutEntries.length; index++) {
@@ -374,6 +405,7 @@ export function buildAppPageElements<
     new Set<number>([
       ...layoutEntries.map((entry) => entry.treePosition),
       ...templateEntries.map((entry) => entry.treePosition),
+      ...errorEntries.map((entry) => entry.treePosition),
     ]),
   ).sort((left, right) => left - right);
   const resolveSlotOverride = (slotKey: string, slotName: string) => {
@@ -584,9 +616,7 @@ export function buildAppPageElements<
   }
 
   const lastLayoutErrorModule =
-    options.route.errors && options.route.errors.length > 0
-      ? options.route.errors[options.route.errors.length - 1]
-      : null;
+    errorEntries.length > 0 ? errorEntries[errorEntries.length - 1].errorModule : null;
   // Next.js nesting (outer to inner): Error > Unauthorized > Forbidden > NotFound > children.
   // Building bottom-up means NotFoundBoundary must wrap first, then Forbidden, Unauthorized, Error.
   const notFoundComponent =
@@ -629,6 +659,7 @@ export function buildAppPageElements<
     let segmentChildren: ReactNode = routeChildren;
     const layoutEntry = layoutEntriesByTreePosition.get(treePosition);
     const templateEntry = templateEntriesByTreePosition.get(treePosition);
+    const errorEntry = errorEntriesByTreePosition.get(treePosition);
 
     // Next.js nesting per segment (outer to inner): Layout > Template > Error > Unauthorized > Forbidden > NotFound > children.
     // Building bottom-up means NotFoundBoundary must wrap the leaf subtree first,
@@ -663,13 +694,15 @@ export function buildAppPageElements<
           </UnauthorizedBoundary>
         );
       }
+    }
 
-      const layoutErrorComponent = getErrorBoundaryExport(layoutEntry.errorModule);
-      if (layoutErrorComponent) {
-        segmentChildren = (
-          <ErrorBoundary fallback={layoutErrorComponent}>{segmentChildren}</ErrorBoundary>
-        );
-      }
+    const segmentErrorComponent = getErrorBoundaryExport(
+      errorEntry?.errorModule ?? layoutEntry?.errorModule,
+    );
+    if (segmentErrorComponent) {
+      segmentChildren = (
+        <ErrorBoundary fallback={segmentErrorComponent}>{segmentChildren}</ErrorBoundary>
+      );
     }
 
     if (templateEntry && getDefaultExport(templateEntry.templateModule)) {

--- a/tests/app-route-graph.test.ts
+++ b/tests/app-route-graph.test.ts
@@ -266,6 +266,26 @@ describe("App Router route graph builder", () => {
     });
   });
 
+  it("discovers error boundaries in route groups without sibling layouts", async () => {
+    await withTempApp(async (appDir) => {
+      await writeAppFile(appDir, "layout.tsx", EMPTY_LAYOUT);
+      await writeAppFile(
+        appDir,
+        "docs/(group)/error.tsx",
+        "export default function Error() { return null; }\n",
+      );
+      await writeAppFile(appDir, "docs/(group)/child/page.tsx", EMPTY_PAGE);
+
+      const graph = await buildAppRouteGraph(appDir, createValidFileMatcher(["tsx"]));
+      const route = findRoute(graph.routes, "/docs/child");
+
+      expect(route.layoutTreePositions).toEqual([0]);
+      expect(route.layoutErrorPaths).toEqual([null]);
+      expect(route.errorPaths).toEqual([path.join(appDir, "docs/(group)/error.tsx")]);
+      expect(route.errorTreePositions).toEqual([2]);
+    });
+  });
+
   it("mints semantic ids for routes, entries, layouts, templates, and slots", async () => {
     await withTempApp(async (appDir) => {
       await createSemanticIdsFixture(appDir);

--- a/tests/fixtures/app-basic/app/nextjs-compat/route-group-error/(group)/child/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/route-group-error/(group)/child/page.tsx
@@ -1,0 +1,3 @@
+export default function RouteGroupErrorChildPage() {
+  throw new Error("route group child boom");
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/route-group-error/(group)/error.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/route-group-error/(group)/error.tsx
@@ -1,0 +1,5 @@
+"use client";
+
+export default function RouteGroupErrorBoundary() {
+  return <p id="route-group-error-boundary">Route group error boundary</p>;
+}

--- a/tests/nextjs-compat/global-error.test.ts
+++ b/tests/nextjs-compat/global-error.test.ts
@@ -65,6 +65,16 @@ describe("Next.js compat: global-error", () => {
     expect(html).not.toContain("outer-error-boundary");
   });
 
+  it("route group error.tsx without sibling layout catches descendant server errors", async () => {
+    // Next.js loader trees attach error conventions to the segment even when
+    // that segment has no layout:
+    // https://github.com/vercel/next.js/blob/canary/packages/next/src/build/webpack/loaders/next-app-loader/index.ts
+    const { res, html } = await fetchHtml(baseUrl, "/nextjs-compat/route-group-error/child");
+    expect(res.status).toBe(200);
+    expect(html).toContain("Route group error boundary");
+    expect(html).not.toContain("global-error");
+  });
+
   // ── Server component error (RSC throw -> global-error) ─────
   // Next.js: it('should render global error for error in server components', ...)
   // Source: https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/global-error/basic/index.test.ts#L29-L49

--- a/tests/routing.test.ts
+++ b/tests/routing.test.ts
@@ -46,6 +46,8 @@ function makeTestAppRoute(
     loadingPath: null,
     errorPath: null,
     layoutErrorPaths: [],
+    errorPaths: [],
+    errorTreePositions: [],
     notFoundPath: null,
     notFoundPaths: [],
     forbiddenPaths: [],


### PR DESCRIPTION
## Summary

Fixes App Router error boundary discovery for route groups that define `error.tsx` without a sibling `layout.tsx`. Vinext previously aligned segment error boundaries to discovered layouts, so an ancestor route-group boundary like `app/foo/(group)/error.tsx` was dropped for `app/foo/(group)/child/page.tsx` unless `(group)/layout.tsx` also existed.

This keeps `layoutErrorPaths` layout-aligned for route manifest facts, and adds explicit segment-owned `errorPaths` + `errorTreePositions` for runtime rendering and server fallback boundary selection. That matches the useful part of Next.js loader-tree modeling without forcing fake layout entries into vinext.

## Next.js references

- Next.js creates loader tree props from each segment path and resolves conventions independently of layout presence: [next-app-loader `createSubtreePropsFromSegmentPath`](https://github.com/vercel/next.js/blob/canary/packages/next/src/build/webpack/loaders/next-app-loader/index.ts).
- Next.js `useSelectedLayoutSegments()` returns the selected layout segment path from router context, and its compat test intentionally includes route groups in the returned segment array: [navigation hook](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/navigation.ts#L255-L281), [hooks test](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/hooks/hooks.test.ts#L142-L165). I preserved vinext’s existing route-group segment behavior because filtering `(group)` out would diverge from Next.js.

## Tests

- `vp test run tests/app-route-graph.test.ts tests/entry-templates.test.ts tests/nextjs-compat/global-error.test.ts tests/nextjs-compat/layout-segments.test.ts`
- `vp check` (passes with existing warning: `packages/vinext/src/server/request-pipeline.ts:604` has `unknown | undefined`)

## Risk

The runtime now uses explicit segment error positions while keeping layout-aligned manifest facts unchanged. The main risk covered here is server fallback rendering after RSC errors, which now also selects from segment-owned error modules before falling back to global-error.