### PR TITLE
fix(app): preserve middleware headers on cached pages

### DIFF
--- a/packages/vinext/src/server/app-page-cache.ts
+++ b/packages/vinext/src/server/app-page-cache.ts
@@ -33,6 +33,7 @@ type BuildAppPageCachedResponseOptions = {
   expireSeconds?: number;
   isRscRequest: boolean;
   middlewareHeaders?: Headers | null;
+  middlewareStatus?: number | null;
   mountedSlotsHeader?: string | null;
   revalidateSeconds: number;
 };
@@ -47,6 +48,7 @@ type ReadAppPageCacheResponseOptions = {
   isrRscKey: (pathname: string, mountedSlotsHeader?: string | null) => string;
   isrSet: AppPageCacheSetter;
   middlewareHeaders?: Headers | null;
+  middlewareStatus?: number | null;
   mountedSlotsHeader?: string | null;
   expireSeconds?: number;
   revalidateSeconds: number;
@@ -177,7 +179,7 @@ export function buildAppPageCachedResponse(
 ): Response | null {
   // Preserve the legacy fallback semantics from the generated entry: invalid
   // falsy statuses still fall back to 200 rather than being forwarded through.
-  const status = cachedValue.status || 200;
+  const status = options.middlewareStatus ?? (cachedValue.status || 200);
   const revalidateSeconds = options.cacheControl?.revalidate ?? options.revalidateSeconds;
   const expireSeconds =
     options.cacheControl === undefined
@@ -242,6 +244,7 @@ export async function readAppPageCacheResponse(
         expireSeconds: options.expireSeconds,
         isRscRequest: options.isRscRequest,
         middlewareHeaders: options.middlewareHeaders,
+        middlewareStatus: options.middlewareStatus,
         mountedSlotsHeader: options.mountedSlotsHeader,
         revalidateSeconds: options.revalidateSeconds,
       });
@@ -307,6 +310,7 @@ export async function readAppPageCacheResponse(
         expireSeconds: options.expireSeconds,
         isRscRequest: options.isRscRequest,
         middlewareHeaders: options.middlewareHeaders,
+        middlewareStatus: options.middlewareStatus,
         mountedSlotsHeader: options.mountedSlotsHeader,
         revalidateSeconds: options.revalidateSeconds,
       });

--- a/packages/vinext/src/server/app-page-cache.ts
+++ b/packages/vinext/src/server/app-page-cache.ts
@@ -2,6 +2,7 @@ import type { CachedAppPageValue, CacheControlMetadata } from "vinext/shims/cach
 import { VINEXT_RSC_VARY_HEADER } from "./app-rsc-cache-busting.js";
 import { buildCachedRevalidateCacheControl } from "./cache-control.js";
 import { buildAppPageCacheValue, type ISRCacheEntry } from "./isr-cache.js";
+import { mergeMiddlewareResponseHeaders } from "./middleware-response-headers.js";
 import { readStreamAsText } from "../utils/text-stream.js";
 
 type AppPageDebugLogger = (event: string, detail: string) => void;
@@ -31,6 +32,7 @@ type BuildAppPageCachedResponseOptions = {
   cacheState: "HIT" | "STALE";
   expireSeconds?: number;
   isRscRequest: boolean;
+  middlewareHeaders?: Headers | null;
   mountedSlotsHeader?: string | null;
   revalidateSeconds: number;
 };
@@ -44,6 +46,7 @@ type ReadAppPageCacheResponseOptions = {
   isrHtmlKey: (pathname: string) => string;
   isrRscKey: (pathname: string, mountedSlotsHeader?: string | null) => string;
   isrSet: AppPageCacheSetter;
+  middlewareHeaders?: Headers | null;
   mountedSlotsHeader?: string | null;
   expireSeconds?: number;
   revalidateSeconds: number;
@@ -116,6 +119,28 @@ function buildAppPageCacheControl(
   return buildCachedRevalidateCacheControl(cacheState, revalidateSeconds, expireSeconds);
 }
 
+function buildAppPageCachedHeaders(options: {
+  cacheControl: string;
+  cacheState: BuildAppPageCachedResponseOptions["cacheState"];
+  contentType: string;
+  middlewareHeaders?: Headers | null;
+  mountedSlotsHeader?: string | null;
+}): Headers {
+  const headers = new Headers({
+    "Cache-Control": options.cacheControl,
+    "Content-Type": options.contentType,
+    Vary: VINEXT_RSC_VARY_HEADER,
+    "X-Vinext-Cache": options.cacheState,
+  });
+
+  if (options.mountedSlotsHeader) {
+    headers.set("X-Vinext-Mounted-Slots", options.mountedSlotsHeader);
+  }
+
+  mergeMiddlewareResponseHeaders(headers, options.middlewareHeaders ?? null);
+  return headers;
+}
+
 function getCachedAppPageValue(entry: ISRCacheEntry | null): CachedAppPageValue | null {
   return entry?.value.value && entry.value.value.kind === "APP_PAGE" ? entry.value.value : null;
 }
@@ -158,24 +183,23 @@ export function buildAppPageCachedResponse(
     options.cacheControl === undefined
       ? undefined
       : (options.cacheControl.expire ?? options.expireSeconds);
-  const headers = {
-    "Cache-Control": buildAppPageCacheControl(options.cacheState, revalidateSeconds, expireSeconds),
-    Vary: VINEXT_RSC_VARY_HEADER,
-    "X-Vinext-Cache": options.cacheState,
-  };
-
+  const cacheControl = buildAppPageCacheControl(
+    options.cacheState,
+    revalidateSeconds,
+    expireSeconds,
+  );
   if (options.isRscRequest) {
     if (!cachedValue.rscData) {
       return null;
     }
 
-    const rscHeaders: Record<string, string> = {
-      "Content-Type": "text/x-component; charset=utf-8",
-      ...headers,
-    };
-    if (options.mountedSlotsHeader) {
-      rscHeaders["X-Vinext-Mounted-Slots"] = options.mountedSlotsHeader;
-    }
+    const rscHeaders = buildAppPageCachedHeaders({
+      cacheControl,
+      cacheState: options.cacheState,
+      contentType: "text/x-component; charset=utf-8",
+      middlewareHeaders: options.middlewareHeaders,
+      mountedSlotsHeader: options.mountedSlotsHeader,
+    });
 
     return new Response(cachedValue.rscData, {
       status,
@@ -187,12 +211,16 @@ export function buildAppPageCachedResponse(
     return null;
   }
 
+  const htmlHeaders = buildAppPageCachedHeaders({
+    cacheControl,
+    cacheState: options.cacheState,
+    contentType: "text/html; charset=utf-8",
+    middlewareHeaders: options.middlewareHeaders,
+  });
+
   return new Response(cachedValue.html, {
     status,
-    headers: {
-      "Content-Type": "text/html; charset=utf-8",
-      ...headers,
-    },
+    headers: htmlHeaders,
   });
 }
 
@@ -213,6 +241,7 @@ export async function readAppPageCacheResponse(
         cacheControl: cached?.value.cacheControl,
         expireSeconds: options.expireSeconds,
         isRscRequest: options.isRscRequest,
+        middlewareHeaders: options.middlewareHeaders,
         mountedSlotsHeader: options.mountedSlotsHeader,
         revalidateSeconds: options.revalidateSeconds,
       });
@@ -277,6 +306,7 @@ export async function readAppPageCacheResponse(
         cacheControl: cached.value.cacheControl,
         expireSeconds: options.expireSeconds,
         isRscRequest: options.isRscRequest,
+        middlewareHeaders: options.middlewareHeaders,
         mountedSlotsHeader: options.mountedSlotsHeader,
         revalidateSeconds: options.revalidateSeconds,
       });

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -349,6 +349,7 @@ export async function dispatchAppPage<TRoute extends AppPageDispatchRoute>(
       isrHtmlKey: options.isrHtmlKey,
       isrRscKey: options.isrRscKey,
       isrSet: options.isrSet,
+      middlewareHeaders: options.middlewareContext.headers,
       mountedSlotsHeader: options.mountedSlotsHeader,
       expireSeconds: options.expireSeconds,
       // cacheLife-only routes discover their actual revalidate during the

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -350,6 +350,7 @@ export async function dispatchAppPage<TRoute extends AppPageDispatchRoute>(
       isrRscKey: options.isrRscKey,
       isrSet: options.isrSet,
       middlewareHeaders: options.middlewareContext.headers,
+      middlewareStatus: options.middlewareContext.status,
       mountedSlotsHeader: options.mountedSlotsHeader,
       expireSeconds: options.expireSeconds,
       // cacheLife-only routes discover their actual revalidate during the

--- a/tests/app-page-cache.test.ts
+++ b/tests/app-page-cache.test.ts
@@ -192,6 +192,20 @@ describe("app page cache helpers", () => {
     expect(response?.status).toBe(200);
   });
 
+  it("uses middleware status for cached responses when middleware continues", () => {
+    const response = buildAppPageCachedResponse(
+      buildCachedAppPageValue("<h1>cached</h1>", undefined, 201),
+      {
+        cacheState: "HIT",
+        isRscRequest: false,
+        middlewareStatus: 202,
+        revalidateSeconds: 60,
+      },
+    );
+
+    expect(response?.status).toBe(202);
+  });
+
   it("returns null when a cached entry lacks the requested HTML or RSC payload", () => {
     const htmlOnly = buildCachedAppPageValue("<h1>cached</h1>");
     const rscOnly = buildCachedAppPageValue("", new TextEncoder().encode("flight").buffer);
@@ -233,6 +247,7 @@ describe("app page cache helpers", () => {
       },
       async isrSet() {},
       middlewareHeaders,
+      middlewareStatus: 203,
       revalidateSeconds: 60,
       async renderFreshPageForCache() {
         throw new Error("should not render");
@@ -244,6 +259,7 @@ describe("app page cache helpers", () => {
 
     expect(response?.headers.get("x-vinext-cache")).toBe("HIT");
     expect(response?.headers.get("x-from-middleware")).toBe("hit");
+    expect(response?.status).toBe(203);
     await expect(response?.text()).resolves.toBe("<h1>cached</h1>");
     expect(didClearRequestContext).toBe(true);
   });

--- a/tests/app-page-cache.test.ts
+++ b/tests/app-page-cache.test.ts
@@ -8,6 +8,7 @@ import {
   scheduleAppPageRscCacheWrite,
 } from "../packages/vinext/src/server/app-page-cache.js";
 import type { ISRCacheEntry } from "../packages/vinext/src/server/isr-cache.js";
+import { VINEXT_RSC_VARY_HEADER } from "../packages/vinext/src/server/app-rsc-cache-busting.js";
 import type { CachedAppPageValue } from "../packages/vinext/src/shims/cache.js";
 
 function buildISRCacheEntry(
@@ -78,6 +79,50 @@ describe("app page cache helpers", () => {
     expect(rscResponse?.headers.get("content-type")).toBe("text/x-component; charset=utf-8");
     expect(rscResponse?.headers.get("cache-control")).toBe("s-maxage=0, stale-while-revalidate");
     expect(await rscResponse?.arrayBuffer()).toEqual(rscData);
+  });
+
+  it("merges middleware response headers into cached HTML responses", async () => {
+    const middlewareHeaders = new Headers({
+      "Cache-Control": "private, no-store",
+      "Content-Security-Policy": "frame-ancestors 'none'",
+      Vary: "Accept-Encoding",
+      "X-Frame-Options": "DENY",
+    });
+    middlewareHeaders.append("Set-Cookie", "session=abc; Path=/; HttpOnly");
+
+    const response = buildAppPageCachedResponse(buildCachedAppPageValue("<h1>cached</h1>"), {
+      cacheState: "HIT",
+      isRscRequest: false,
+      middlewareHeaders,
+      revalidateSeconds: 60,
+    });
+
+    expect(response?.headers.get("Cache-Control")).toBe("private, no-store");
+    expect(response?.headers.get("Content-Security-Policy")).toBe("frame-ancestors 'none'");
+    expect(response?.headers.get("Set-Cookie")).toBe("session=abc; Path=/; HttpOnly");
+    expect(response?.headers.get("Vary")).toBe(`${VINEXT_RSC_VARY_HEADER}, Accept-Encoding`);
+    expect(response?.headers.get("X-Frame-Options")).toBe("DENY");
+    expect(response?.headers.get("X-Vinext-Cache")).toBe("HIT");
+  });
+
+  it("merges middleware response headers into cached RSC responses", async () => {
+    const rscData = new TextEncoder().encode("flight").buffer;
+    const middlewareHeaders = new Headers({
+      "Access-Control-Allow-Origin": "https://example.com",
+      Vary: "Origin",
+    });
+
+    const response = buildAppPageCachedResponse(buildCachedAppPageValue("", rscData), {
+      cacheState: "STALE",
+      isRscRequest: true,
+      middlewareHeaders,
+      revalidateSeconds: 60,
+    });
+
+    expect(response?.headers.get("Access-Control-Allow-Origin")).toBe("https://example.com");
+    expect(response?.headers.get("Vary")).toBe(`${VINEXT_RSC_VARY_HEADER}, Origin`);
+    expect(response?.headers.get("X-Vinext-Cache")).toBe("STALE");
+    await expect(response?.arrayBuffer()).resolves.toEqual(rscData);
   });
 
   it("uses stored cache-control metadata instead of global config for cached HIT responses", async () => {
@@ -169,6 +214,7 @@ describe("app page cache helpers", () => {
 
   it("returns cached HIT responses and clears request state", async () => {
     let didClearRequestContext = false;
+    const middlewareHeaders = new Headers({ "X-From-Middleware": "hit" });
 
     const response = await readAppPageCacheResponse({
       cleanPathname: "/cached",
@@ -186,6 +232,7 @@ describe("app page cache helpers", () => {
         return "rsc:" + pathname;
       },
       async isrSet() {},
+      middlewareHeaders,
       revalidateSeconds: 60,
       async renderFreshPageForCache() {
         throw new Error("should not render");
@@ -196,6 +243,7 @@ describe("app page cache helpers", () => {
     });
 
     expect(response?.headers.get("x-vinext-cache")).toBe("HIT");
+    expect(response?.headers.get("x-from-middleware")).toBe("hit");
     await expect(response?.text()).resolves.toBe("<h1>cached</h1>");
     expect(didClearRequestContext).toBe(true);
   });


### PR DESCRIPTION
## Summary

Fix App Router ISR cache HIT/STALE responses so they preserve middleware response headers, matching the fresh render path. Cached HTML and RSC responses now build their normal cache/content headers, then run the same `mergeMiddlewareResponseHeaders` helper used by fresh app-page responses.

## Root cause

Fresh app-page responses merge `middlewareContext.headers`, but the ISR cache path built a bare `Response` from cached HTML/RSC payloads and never received the middleware context. That meant middleware-owned response headers such as CSP, `X-Frame-Options`, CORS, `Set-Cookie`, `Vary`, and custom headers could appear on MISS and silently disappear on HIT/STALE.

## Next.js reference

Next.js keeps middleware response headers on the outbound response before the matched route body is sent:

- Middleware response headers are converted and copied into routing response headers in [`resolve-routes.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/router-utils/resolve-routes.ts#L683-L707).
- Those routing response headers are applied to the Node response before body handling in [`router-server.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/router-server.ts#L474-L478).
- Later response sending does not overwrite already-present singular headers, while additive headers such as `set-cookie` and `vary` are appended in [`send-response.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/send-response.ts#L43-L64).
- Render payload cache headers also avoid overriding a user/middleware-owned `Cache-Control` in [`send-payload.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/send-payload.ts#L58-L61).

vinext does not have the same Node `resHeaders` layering in the App Router cache helper, so this PR threads `middlewareContext.headers` into `readAppPageCacheResponse` and centralizes cached response header construction around the existing merge helper.

## Tests

- `vp test run tests/app-page-cache.test.ts tests/app-page-response.test.ts`
- `vp check packages/vinext/src/server/app-page-cache.ts packages/vinext/src/server/app-page-dispatch.ts tests/app-page-cache.test.ts`
