### PR TITLE
fix(app-router): read indefinite app page cache entries

### DIFF
--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -206,8 +206,7 @@ function shouldReadAppPageCache(options: {
     !options.isDraftMode &&
     !options.isForceDynamic &&
     (options.isRscRequest || !options.scriptNonce) &&
-    (options.revalidateSeconds === null ||
-      (options.revalidateSeconds > 0 && options.revalidateSeconds !== Infinity))
+    (options.revalidateSeconds === null || options.revalidateSeconds > 0)
   );
 }
 

--- a/packages/vinext/src/server/cache-control.ts
+++ b/packages/vinext/src/server/cache-control.ts
@@ -45,6 +45,10 @@ export function buildCachedRevalidateCacheControl(
   revalidateSeconds: number,
   expireSeconds?: number,
 ): string {
+  if (revalidateSeconds === Infinity) {
+    return STATIC_CACHE_CONTROL;
+  }
+
   // When expire is known, match Next.js and emit the route policy even for
   // vinext-served STALE entries. The hard-expire gate has already decided the
   // stale payload is still usable, and downstream caches should see the same

--- a/tests/app-page-cache.test.ts
+++ b/tests/app-page-cache.test.ts
@@ -106,6 +106,18 @@ describe("app page cache helpers", () => {
     expect(response?.headers.get("cache-control")).toBe("s-maxage=60, stale-while-revalidate=240");
   });
 
+  it("emits static cache-control for cached indefinite app pages", async () => {
+    const response = buildAppPageCachedResponse(buildCachedAppPageValue("<h1>cached</h1>"), {
+      cacheState: "HIT",
+      isRscRequest: false,
+      revalidateSeconds: Infinity,
+    });
+
+    expect(response?.headers.get("cache-control")).toBe(
+      "s-maxage=31536000, stale-while-revalidate",
+    );
+  });
+
   it("preserves legacy STALE headers when cached entries lack cache-control metadata", async () => {
     const cachedValue = buildCachedAppPageValue("<h1>cached</h1>");
 

--- a/tests/app-page-dispatch.test.ts
+++ b/tests/app-page-dispatch.test.ts
@@ -251,6 +251,26 @@ describe("app page dispatch", () => {
     await expect(response.text()).resolves.toBe("<html>cached</html>");
   });
 
+  it("serves cached production HTML for indefinite revalidate=false pages", async () => {
+    const { options } = createDispatchOptions({
+      async buildPageElement() {
+        throw new Error("revalidate=false cache hit should not render the page");
+      },
+      isProduction: true,
+      isrGet: vi.fn(async () =>
+        buildISRCacheEntry(buildCachedAppPageValue("<html>static cached</html>")),
+      ),
+      revalidateSeconds: Infinity,
+    });
+
+    const response = await dispatchAppPage(options);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("s-maxage=31536000, stale-while-revalidate");
+    expect(response.headers.get("x-vinext-cache")).toBe("HIT");
+    await expect(response.text()).resolves.toBe("<html>static cached</html>");
+  });
+
   it("returns method policy responses instead of rendering unsupported methods", async () => {
     const { options } = createDispatchOptions({
       async buildPageElement() {

--- a/tests/cache-control.test.ts
+++ b/tests/cache-control.test.ts
@@ -29,6 +29,12 @@ describe("cache-control helpers", () => {
     );
   });
 
+  it("uses static cache-control for cached indefinite responses", () => {
+    expect(buildCachedRevalidateCacheControl("HIT", Infinity)).toBe(
+      "s-maxage=31536000, stale-while-revalidate",
+    );
+  });
+
   it("preserves legacy STALE cached response headers when expire is unknown", () => {
     expect(buildCachedRevalidateCacheControl("STALE", 60)).toBe(
       "s-maxage=0, stale-while-revalidate",


### PR DESCRIPTION
## What this changes

App Router pages whose effective segment config resolves to `revalidate = false` now read from the app-page ISR cache in production. Cached indefinite app-page hits also normalize their `Cache-Control` header to `s-maxage=31536000, stale-while-revalidate` instead of leaking `s-maxage=Infinity`.

## Why

`resolveRevalidateSeconds()` intentionally maps `revalidate: false` to `Infinity` so vinext can distinguish “never revalidate” from an unset route policy. The app-page cache read gate then excluded `Infinity`, so prerendered static app pages could be seeded into the ISR cache but never used. Every request fell through into fresh RSC plus SSR plus HTML rendering, while the static cache header masked the wasted work.

Next.js treats this policy as cacheable and non-stale-by-time, not as “skip the response cache”:

- [`INFINITE_CACHE` represents `revalidate=false`](https://github.com/vercel/next.js/blob/canary/packages/next/src/lib/constants.ts#L41-L46)
- [app render converts collected infinite revalidate back to `cacheControl.revalidate = false`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/app-render.tsx#L3214-L3228)
- [response cache still attempts the incremental cache read before rendering](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/response-cache/index.ts#L329-L356)
- [incremental cache uses `false` as “not stale by time”](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/incremental-cache/index.ts#L221-L236), then [only marks stale when the computed revalidate timestamp is not `false`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/incremental-cache/index.ts#L602-L607)
- [`getCacheControlHeader()` emits one-year `s-maxage` for `revalidate: false`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/cache-control.ts#L17-L35)

## Approach

- Allow app-page cache reads for positive `Infinity` while keeping the existing production, force-dynamic, RSC, and script nonce guards.
- Normalize cached `Infinity` revalidate values through vinext's existing static cache-control constant.
- Keep runtime cache writes for non-finite revalidate values disabled. This preserves the current boundary where indefinite app pages are populated by prerender seeding, not by time-based ISR regeneration writes.

## Validation

- `vp test run tests/cache-control.test.ts tests/app-page-dispatch.test.ts tests/app-page-cache.test.ts tests/app-page-response.test.ts`
- `vp check tests/cache-control.test.ts tests/app-page-cache.test.ts tests/app-page-dispatch.test.ts packages/vinext/src/server/cache-control.ts packages/vinext/src/server/app-page-dispatch.ts`
- Red-green regression check: the new dispatch/cache tests failed before the fix because the app page rendered instead of hitting cache and cached headers emitted `s-maxage=Infinity`; they pass after the implementation.

## Risks / follow-ups

This intentionally does not add request-time cache writes for `revalidate=false` app pages. The fix is scoped to the seeded/read path and response normalization, matching the bug while avoiding a broader change to dynamic detection and cache write timing.
