### PR TITLE
ci: pin pnpm in cna-test to vinext's package.json version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,10 @@ jobs:
         # match the store layout from create-next-app. Tracks any future
         # bump in vinext's root package.json automatically.
         run: |
-          PKG_MGR=$(node -p "require('${{ github.workspace }}/package.json').packageManager")
+          # cd into the workspace to read package.json via a relative path —
+          # ${{ github.workspace }} contains backslashes on Windows that get
+          # eaten by the JS string literal parser when interpolated inline.
+          PKG_MGR=$(cd "${{ github.workspace }}" && node -p "require('./package.json').packageManager")
           node -e "
             const fs = require('fs');
             const pkg = JSON.parse(fs.readFileSync('package.json', 'utf-8'));

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,26 @@ jobs:
       - name: Scaffold a fresh create-next-app project
         run: vp dlx create-next-app@16.2.5 "${{ runner.temp }}/cna-test" --yes
 
+      - name: Pin pnpm in scaffolded project to vinext's version
+        working-directory: ${{ runner.temp }}/cna-test
+        shell: bash
+        # create-next-app's bundled pnpm links node_modules to a major-version
+        # store (e.g. v10). vp's bundled pnpm can drift to a newer major (v11),
+        # which then refuses to operate on the existing node_modules with
+        # ERR_PNPM_UNEXPECTED_STORE. vp respects the project's packageManager
+        # field, so writing the same one vinext itself uses makes vp's pnpm
+        # match the store layout from create-next-app. Tracks any future
+        # bump in vinext's root package.json automatically.
+        run: |
+          PKG_MGR=$(node -p "require('${{ github.workspace }}/package.json').packageManager")
+          node -e "
+            const fs = require('fs');
+            const pkg = JSON.parse(fs.readFileSync('package.json', 'utf-8'));
+            pkg.packageManager = '$PKG_MGR';
+            fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
+          echo "Pinned packageManager to $PKG_MGR"
+
       - name: Install vinext from local tarball
         working-directory: ${{ runner.temp }}/cna-test
         shell: bash


### PR DESCRIPTION
## What

The `create-next-app` CI job started failing on main with `ERR_PNPM_UNEXPECTED_STORE` (e.g. [run 25490165807](https://github.com/cloudflare/vinext/actions/runs/25490165807/job/74800715042)).

```
The dependencies at "/home/runner/work/_temp/cna-test/node_modules" are
currently linked from the store at "/home/runner/.local/share/pnpm/store/v10".
pnpm now wants to use the store at "/home/runner/.local/share/pnpm/store/v11"
to link dependencies.
```

## Root cause

The job has two pnpm-using steps:

1. `vp dlx create-next-app@16.2.5` — uses create-next-app's bundled pnpm (currently 10.32.1). Links `node_modules` to the v10 store layout.
2. `vp add ...vinext-*.tgz` — uses vp's bundled pnpm. That major version recently bumped from 10 → 11. v11 sees the v10-linked `node_modules` and refuses to operate on it.

Both steps ran with the same SHA before and after the failure — comparing the [last passing run](https://github.com/cloudflare/vinext/actions/runs/25484260801) to the failing one, the only thing that changed was vp's bundled pnpm version (the action installs vp via `setup-vp` with `version: latest`).

## Fix

Add a step between the scaffold and the `vp add` that writes vinext's own pinned pnpm version (read from root `package.json`'s `packageManager` field — `pnpm@10.32.1` today) onto the scaffolded `cna-test/package.json`. vp respects `packageManager`, so `vp add` then runs through pnpm 10.x and the store layout matches.

`vp add` is unchanged. Stays in sync with future pnpm bumps in vinext's root automatically — no further CI edits required.

## Validation

- [ ] CI run on this PR passes the `create-next-app (ubuntu-latest)` and `create-next-app (windows-latest)` jobs.

## Alternative considered

Pinning `setup-vp` to a specific vp version (so vp's pnpm doesn't drift) would also fix this. That trades one drift for another — every pnpm bump in vinext would also need a vp version bump in CI to test against the same store layout. Pinning at the project level (this PR) is more localized and self-tracking.