### PR TITLE
fix(app-router): isolate middleware request bodies

### DIFF
--- a/packages/vinext/src/server/middleware-runtime.ts
+++ b/packages/vinext/src/server/middleware-runtime.ts
@@ -135,11 +135,13 @@ function createNextRequest(
   basePath?: string,
 ): NextRequest {
   const url = new URL(request.url);
-  let mwRequest = request;
+  // Middleware gets an isolated body branch; downstream routing keeps owning
+  // the original request body.
+  let mwRequest = request.body && !request.bodyUsed ? request.clone() : request;
   if (normalizedPathname !== url.pathname) {
     const mwUrl = new URL(url);
     mwUrl.pathname = normalizedPathname;
-    mwRequest = new Request(mwUrl, request);
+    mwRequest = new Request(mwUrl, mwRequest);
   }
 
   const nextConfig =

--- a/packages/vinext/src/shims/server.ts
+++ b/packages/vinext/src/shims/server.ts
@@ -95,18 +95,12 @@ export class NextRequest extends Request {
     // Strip nextConfig before passing to super() — it's vinext-internal,
     // not a valid RequestInit property.
     const { nextConfig: _nextConfig, ...requestInit } = init ?? {};
-    // Handle the case where input is a Request object - we need to extract URL and init
-    // to avoid Node.js undici issues with passing Request objects directly to super()
     if (input instanceof Request) {
-      const req = input;
-      super(req.url, {
-        method: req.method,
-        headers: req.headers,
-        body: req.body,
-        // @ts-expect-error - duplex is not in RequestInit type but needed for streams
-        duplex: req.body ? "half" : undefined,
-        ...requestInit,
-      });
+      // Keep caller-owned request bodies readable after wrapping. Middleware and
+      // route-handler plumbing may need the source Request after this wrapper runs.
+      const requestInput =
+        requestInit.body === undefined && input.body && !input.bodyUsed ? input.clone() : input;
+      super(requestInput, requestInit);
     } else {
       super(input, requestInit);
     }

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -1459,6 +1459,21 @@ describe("next/server shim", () => {
     expect(req.cookies.has("missing")).toBe(false);
   });
 
+  it("NextRequest copies a Request body without disturbing the source request", async () => {
+    const { NextRequest } = await import("../packages/vinext/src/shims/server.js");
+    const source = new Request("https://example.com/api/echo", {
+      body: JSON.stringify({ ok: true }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+
+    const req = new NextRequest(source);
+
+    await expect(req.json()).resolves.toEqual({ ok: true });
+    expect(source.bodyUsed).toBe(false);
+    await expect(source.json()).resolves.toEqual({ ok: true });
+  });
+
   it("NextResponse.json() creates a JSON response", async () => {
     const { NextResponse } = await import("../packages/vinext/src/shims/server.js");
     const res = NextResponse.json({ message: "hello" }, { status: 201 });
@@ -3914,6 +3929,37 @@ describe("double-encoded path handling in middleware", () => {
     expect(result.kind).toBe("continue");
     expect(request.body?.locked).toBe(false);
     expect(await request.text()).toBe("action-payload");
+  });
+
+  it("App Router middleware can read the body without consuming the downstream request", async () => {
+    const { applyAppMiddleware } = await import("../packages/vinext/src/server/app-middleware.js");
+    const request = new Request("http://localhost:3000/api/echo", {
+      body: JSON.stringify({ message: "hello" }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+    let middlewareBody: unknown;
+    const module = {
+      default: async (req: Request) => {
+        middlewareBody = await req.json();
+        return new Response(null, {
+          headers: { "x-middleware-next": "1" },
+        });
+      },
+    };
+
+    const result = await applyAppMiddleware({
+      cleanPathname: "/api/echo",
+      context: { headers: null, requestHeaders: null, status: null },
+      isProxy: false,
+      module,
+      request,
+    });
+
+    expect(result.kind).toBe("continue");
+    expect(middlewareBody).toEqual({ message: "hello" });
+    expect(request.bodyUsed).toBe(false);
+    await expect(request.json()).resolves.toEqual({ message: "hello" });
   });
 
   it("external middleware rewrite proxy strips upstream x-middleware headers without middleware context", async () => {


### PR DESCRIPTION
## What this changes

Isolates middleware request bodies from the downstream App Router request. Middleware can now call `await request.json()`, `text()`, or another body reader and still allow the matched route handler or server action pipeline to read the original request body afterward.

## Why

`NextRequest` rebuilt wrapped `Request` inputs with `body: req.body`, and App Router middleware constructed its request from the same caller-owned `Request` that downstream routing later reused. Because `ReadableStream` bodies are single-consumer, middleware that inspected a POST body disturbed the downstream request body and caused route handlers to fail when reading it.

This matters for auth, validation, logging, and action middleware that needs to inspect request payloads before continuing.

## Approach

- `NextRequest` now wraps a cloned body branch when the caller passes a readable `Request`, preserving the source request for framework plumbing that still owns it.
- App Router middleware now receives an isolated request branch before optional decoded-path normalization, so `new Request(mwUrl, ...)` cannot disturb the original body either.
- Added regression coverage for both the constructor behavior and the full `applyAppMiddleware` boundary where middleware reads JSON and downstream still reads the same payload.

Next.js reference points:

- [`NextRequest` delegates `Request` inputs to the platform `Request` constructor](https://github.com/vercel/next.js/blob/04294cb47a6d67adf73c8b6f196ed6a2ddcb2b0e/packages/next/src/server/web/spec-extension/request.ts#L22-L39).
- [Next.js adapters pass request bodies into `NextRequest` from internal Node/Web request wrappers](https://github.com/vercel/next.js/blob/04294cb47a6d67adf73c8b6f196ed6a2ddcb2b0e/packages/next/src/server/web/spec-extension/adapters/next-request.ts#L80-L145).
- [Next.js has middleware coverage where middleware reads a POST body before continuing](https://github.com/vercel/next.js/blob/04294cb47a6d67adf73c8b6f196ed6a2ddcb2b0e/test/e2e/app-dir/actions/middleware-node.js#L10-L19).

vinext improves on the direct platform copy approach at its middleware boundary because the original `Request` remains framework-owned and is reused downstream after middleware completes.

## Validation

- `vp test run tests/shims.test.ts -t "App Router middleware can read the body without consuming the downstream request"` failed before the fix with `request.bodyUsed === true`.
- `vp test run tests/shims.test.ts -t "App Router middleware can read the body without consuming the downstream request"`
- `vp test run tests/shims.test.ts -t "NextRequest copies a Request body without disturbing the source request"`
- `vp test run tests/shims.test.ts tests/app-route-handler-runtime.test.ts tests/request-pipeline.test.ts`
- `vp check` exits 0. It reports the existing warning in `packages/vinext/src/server/request-pipeline.ts` about `unknown | undefined`, which is outside this diff.

## Risks / follow-ups

The change intentionally prefers preserving caller-owned request bodies over plain `new Request(input)` disturbance semantics when constructing vinext `NextRequest` wrappers. The new tests lock that in because middleware and route-handler plumbing can both need access to the same logical payload.
