### PR TITLE
fix(app-router): schedule link navigations as transitions

### DIFF
--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -19,7 +19,6 @@ import {
   getCurrentNextUrl,
   getCurrentInterceptionContext,
   getClientNavigationRenderContext,
-  getClientNavigationState,
   getPrefetchCache,
   getPrefetchedUrls,
   pushHistoryStateWithoutNotify,
@@ -34,7 +33,6 @@ import {
   type CachedRscResponse,
   type ClientNavigationRenderSnapshot,
 } from "vinext/shims/navigation";
-import { stripBasePath } from "../utils/base-path.js";
 import {
   chunksToReadableStream,
   createProgressiveRscStream,
@@ -262,7 +260,6 @@ async function renderNavigationPayload(
   params: Record<string, string | string[]>,
   previousNextUrl: string | null,
   pendingRouterState: PendingBrowserRouterState | null,
-  useTransition = true,
   actionType: "navigate" | "replace" | "traverse" = "navigate",
   operationLane: OperationLane = "navigation",
 ): Promise<NavigationPayloadOutcome> {
@@ -282,7 +279,6 @@ async function renderNavigationPayload(
       previousNextUrl,
       targetHref,
       navId,
-      useTransition,
     });
   } catch (error) {
     pendingNavigationRecoveryHref = null;
@@ -965,17 +961,6 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
         const requestInterceptionContext = requestState.interceptionContext;
         const requestPreviousNextUrl = requestState.previousNextUrl;
 
-        // Compare against previous pending navigation first, then committed state.
-        // This avoids isSameRoute misclassification during rapid back-to-back clicks.
-        const navState = getClientNavigationState();
-        const currentPath =
-          navState?.pendingPathname ??
-          navState?.cachedPathname ??
-          stripBasePath(window.location.pathname, __basePath);
-
-        const targetPath = stripBasePath(url.pathname, __basePath);
-        const isSameRoute = targetPath === currentPath;
-
         // Set this navigation as the pending pathname, overwriting any previous.
         // Pass navId so only this navigation (or a newer one) can clear it later.
         setPendingPathname(url.pathname, navId);
@@ -1028,7 +1013,6 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
             cachedParams,
             requestPreviousNextUrl,
             pendingRouterState,
-            isSameRoute,
             toActionType(navigationKind),
             toOperationLane(navigationKind),
           );
@@ -1161,7 +1145,6 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
           navParams,
           requestPreviousNextUrl,
           pendingRouterState,
-          isSameRoute,
           toActionType(navigationKind),
           toOperationLane(navigationKind),
         );

--- a/packages/vinext/src/server/app-browser-navigation-controller.ts
+++ b/packages/vinext/src/server/app-browser-navigation-controller.ts
@@ -70,7 +70,6 @@ type BrowserNavigationController = {
     previousNextUrl: string | null;
     targetHref: string;
     navId: number;
-    useTransition?: boolean;
   }): Promise<NavigationPayloadOutcome>;
   commitSameUrlNavigatePayload(
     nextElements: Promise<AppElements>,
@@ -398,7 +397,7 @@ export function createAppBrowserNavigationController(
     // initialized-setter error.
     if (!hasBrowserRouterState()) return;
 
-    dispatchApprovedVisibleCommit(approveHmrVisibleCommit(pending), null, false);
+    dispatchSynchronousVisibleCommit(approveHmrVisibleCommit(pending));
   }
 
   function NavigationCommitSignal(
@@ -432,27 +431,25 @@ export function createAppBrowserNavigationController(
   function dispatchApprovedVisibleCommit(
     commit: ApprovedVisibleCommit,
     pendingRouterState: PendingBrowserRouterState | null,
-    useTransitionMode: boolean,
   ): void {
     const setter = getBrowserRouterStateSetter();
 
-    const applyAction = () => {
-      if (pendingRouterState) {
-        // The programmatic navigation is already running inside React.startTransition
-        // (from router.push/replace/refresh), so resolving the deferred promise is
-        // sufficient — no additional startTransition wrapper is needed below.
-        resolvePendingBrowserRouterState(pendingRouterState, commit);
-        return;
-      }
-
-      setter(applyApprovedVisibleCommit(getBrowserRouterState(), commit));
-    };
-
-    if (useTransitionMode) {
-      startTransition(applyAction);
-    } else {
-      applyAction();
+    if (pendingRouterState) {
+      // The programmatic navigation is already running inside React.startTransition
+      // (from router.push/replace/refresh/Link), so resolving the deferred promise
+      // is sufficient.
+      resolvePendingBrowserRouterState(pendingRouterState, commit);
+      return;
     }
+
+    startTransition(() => {
+      setter(applyApprovedVisibleCommit(getBrowserRouterState(), commit));
+    });
+  }
+
+  function dispatchSynchronousVisibleCommit(commit: ApprovedVisibleCommit): void {
+    const setter = getBrowserRouterStateSetter();
+    setter(applyApprovedVisibleCommit(getBrowserRouterState(), commit));
   }
 
   async function renderNavigationPayload(options: {
@@ -467,7 +464,6 @@ export function createAppBrowserNavigationController(
     previousNextUrl: string | null;
     targetHref: string;
     navId: number;
-    useTransition?: boolean;
   }): Promise<NavigationPayloadOutcome> {
     const renderId = allocateRenderId();
     let resolveCommitted: (() => void) | undefined;
@@ -526,11 +522,7 @@ export function createAppBrowserNavigationController(
       );
       activateNavigationSnapshot();
       snapshotActivated = true;
-      dispatchApprovedVisibleCommit(
-        approvedCommit,
-        options.pendingRouterState,
-        options.useTransition ?? true,
-      );
+      dispatchApprovedVisibleCommit(approvedCommit, options.pendingRouterState);
     } catch (error) {
       pendingNavigationPrePaintEffects.delete(renderId);
       pendingNavigationCommits.delete(renderId);
@@ -600,7 +592,7 @@ export function createAppBrowserNavigationController(
       }
 
       if (latestApproval.approvedCommit) {
-        dispatchApprovedVisibleCommit(latestApproval.approvedCommit, null, false);
+        dispatchSynchronousVisibleCommit(latestApproval.approvedCommit);
       }
     }
 

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -424,11 +424,14 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
     // hash-only changes, RSC fetch, and two-phase URL commit.
     if (typeof window.__VINEXT_RSC_NAVIGATE__ === "function") {
       setPending(true);
-      try {
-        await navigateClientSide(navigateHref, replace ? "replace" : "push", scroll);
-      } finally {
-        if (mountedRef.current) setPending(false);
-      }
+      React.startTransition(() => {
+        void navigateClientSide(navigateHref, replace ? "replace" : "push", scroll, true).finally(
+          () => {
+            if (mountedRef.current) setPending(false);
+          },
+        );
+      });
+      return;
     } else {
       // Next.js only consumes onRouterTransitionStart in the App Router.
       // Pages Router still executes instrumentation-client side effects

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -968,8 +968,7 @@ function isHashOnlyChange(href: string): boolean {
   try {
     const current = new URL(window.location.href);
     const next = new URL(href, window.location.href);
-    // Strip basePath from both pathnames for consistent comparison
-    // (matches how isSameRoute handles basePath in app-browser-entry.ts)
+    // Strip basePath for consistent same-origin comparison.
     const strippedCurrentPath = stripBasePath(current.pathname, __basePath);
     const strippedNextPath = stripBasePath(next.pathname, __basePath);
     return (
@@ -1207,7 +1206,7 @@ export async function navigateClientSide(
   // History is NOT pushed here for RSC navigations — the commit effect inside
   // navigateRsc owns the push/replace exclusively. This avoids a fragile
   // double-push and ensures window.location still reflects the *current* URL
-  // when navigateRsc computes isSameRoute (cross-route vs same-route).
+  // when navigateRsc publishes the committed URL.
   if (typeof window.__VINEXT_RSC_NAVIGATE__ === "function") {
     await window.__VINEXT_RSC_NAVIGATE__(
       fullHref,

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -1,7 +1,5 @@
 import React from "react";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
-import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
 import { createOnUncaughtError } from "../packages/vinext/src/server/app-browser-error.js";
 import { createAppBrowserNavigationController } from "../packages/vinext/src/server/app-browser-navigation-controller.js";
 import { devOnCaughtError } from "../packages/vinext/src/server/dev-error-overlay.js";
@@ -179,16 +177,27 @@ afterEach(() => {
 });
 
 describe("app browser entry navigation scheduling", () => {
-  it("does not derive visible commit scheduling from same-route path equality", () => {
-    const entryPath = fileURLToPath(
-      new URL("../packages/vinext/src/server/app-browser-entry.ts", import.meta.url),
-    );
-    const source = readFileSync(entryPath, "utf8");
-
-    const renderPayloadCalls = source.matchAll(/renderNavigationPayload\(([\s\S]*?)\);/g);
-    for (const call of renderPayloadCalls) {
-      expect(call[1]).not.toContain("isSameRoute");
+  it("does not expose a per-navigation transition override at the controller boundary", () => {
+    type Controller = ReturnType<typeof createAppBrowserNavigationController>;
+    function assertNoTransitionOverride(controller: Controller) {
+      void controller.renderNavigationPayload({
+        actionType: "navigate",
+        createNavigationCommitEffect: () => () => {},
+        historyUpdateMode: "push",
+        navigationSnapshot: createClientNavigationRenderSnapshot("https://example.com/initial", {}),
+        nextElements: Promise.resolve(createResolvedElements("route:/dashboard", "/")),
+        operationLane: "navigation",
+        params: {},
+        pendingRouterState: null,
+        previousNextUrl: null,
+        targetHref: "https://example.com/dashboard",
+        navId: 1,
+        // @ts-expect-error ordinary navigations must not choose their own scheduling lane.
+        useTransition: false,
+      });
     }
+
+    expect(assertNoTransitionOverride).toBeTypeOf("function");
   });
 });
 

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -1,5 +1,7 @@
 import React from "react";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { createOnUncaughtError } from "../packages/vinext/src/server/app-browser-error.js";
 import { createAppBrowserNavigationController } from "../packages/vinext/src/server/app-browser-navigation-controller.js";
 import { devOnCaughtError } from "../packages/vinext/src/server/dev-error-overlay.js";
@@ -174,6 +176,20 @@ function stubWindow(href: string) {
 afterEach(() => {
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
+});
+
+describe("app browser entry navigation scheduling", () => {
+  it("does not derive visible commit scheduling from same-route path equality", () => {
+    const entryPath = fileURLToPath(
+      new URL("../packages/vinext/src/server/app-browser-entry.ts", import.meta.url),
+    );
+    const source = readFileSync(entryPath, "utf8");
+
+    const renderPayloadCalls = source.matchAll(/renderNavigationPayload\(([\s\S]*?)\);/g);
+    for (const call of renderPayloadCalls) {
+      expect(call[1]).not.toContain("isSameRoute");
+    }
+  });
 });
 
 describe("app browser entry state helpers", () => {
@@ -1036,7 +1052,6 @@ describe("app browser navigation controller", () => {
         previousNextUrl: null,
         targetHref: "https://example.com/dashboard",
         navId,
-        useTransition: false,
       });
 
       // Yield microticks so the async function reaches dispatch and sets state.
@@ -1099,7 +1114,6 @@ describe("app browser navigation controller", () => {
         previousNextUrl: null,
         targetHref: "https://example.com/dashboard",
         navId: controller.beginNavigation(),
-        useTransition: false,
       });
 
       await expect(pendingRouterState.promise).resolves.toMatchObject({
@@ -1137,7 +1151,6 @@ describe("app browser navigation controller", () => {
         previousNextUrl: null,
         targetHref: "https://example.com/dashboard",
         navId,
-        useTransition: false,
       });
 
       controller.beginNavigation();
@@ -1182,7 +1195,6 @@ describe("app browser navigation controller", () => {
         previousNextUrl: null,
         targetHref: "https://example.com/dashboard",
         navId,
-        useTransition: false,
       });
 
       // Yield enough microticks for the async function to reach dispatch
@@ -1500,7 +1512,6 @@ describe("app browser navigation lifecycle settlement", () => {
         previousNextUrl: null,
         targetHref: "https://example.com/a",
         navId: navA,
-        useTransition: false,
       });
 
       const navB = controller.beginNavigation();
@@ -1519,7 +1530,6 @@ describe("app browser navigation lifecycle settlement", () => {
         previousNextUrl: null,
         targetHref: "https://example.com/b",
         navId: navB,
-        useTransition: false,
       });
 
       const navC = controller.beginNavigation();
@@ -1538,14 +1548,13 @@ describe("app browser navigation lifecycle settlement", () => {
         previousNextUrl: null,
         targetHref: "https://example.com/c",
         navId: navC,
-        useTransition: false,
       });
 
       // Yield so C's async payload resolves and state is committed.
       // renderNavigationPayload returns a promise that settles only when
       // NavigationCommitSignal fires (a React component not mounted in
       // unit tests). The state mutation through dispatchApprovedVisibleCommit is
-      // synchronous when useTransition=false, so we verify via stateRef.
+      // applied during React.startTransition's action, so we verify via stateRef.
       await Promise.resolve();
       await Promise.resolve();
       await Promise.resolve();
@@ -1610,7 +1619,6 @@ describe("app browser navigation lifecycle settlement", () => {
         previousNextUrl: null,
         targetHref: "https://example.com/dashboard",
         navId: navA,
-        useTransition: false,
       });
 
       // Start new navigation B (same root). B advances activeNavigationId past A.
@@ -1631,7 +1639,6 @@ describe("app browser navigation lifecycle settlement", () => {
         previousNextUrl: null,
         targetHref: "https://example.com/marketing/settings",
         navId: navB,
-        useTransition: false,
       });
 
       // Yield so B's async payload resolves and state commits.
@@ -1681,7 +1688,6 @@ describe("app browser navigation lifecycle settlement", () => {
         previousNextUrl: null,
         targetHref: "https://example.com/initial",
         navId: refreshNav,
-        useTransition: false,
       });
 
       await controller.hmrReplaceTree(
@@ -1735,7 +1741,6 @@ describe("app browser navigation lifecycle settlement", () => {
         previousNextUrl: null,
         targetHref: "https://example.com/previous",
         navId: traverseNav,
-        useTransition: false,
       });
 
       await controller.hmrReplaceTree(
@@ -1904,7 +1909,6 @@ describe("app browser navigation lifecycle settlement", () => {
         previousNextUrl: null,
         targetHref: "https://example.com/dashboard",
         navId,
-        useTransition: false,
       });
 
       await expect(renderPromise).rejects.toThrow("RSC fetch failed");
@@ -1948,7 +1952,6 @@ describe("app browser root-layout hard navigation", () => {
         previousNextUrl: null,
         targetHref: "https://example.com/dashboard",
         navId,
-        useTransition: false,
       });
 
       await expect(renderPromise).resolves.toBe("hard-navigate");
@@ -1991,7 +1994,6 @@ describe("app browser root-layout hard navigation", () => {
         previousNextUrl: null,
         targetHref: "https://example.com/dashboard",
         navId,
-        useTransition: false,
       });
 
       // Yield so the async function runs the settle+hard-navigate path.
@@ -2034,7 +2036,6 @@ describe("app browser root-layout hard navigation", () => {
           previousNextUrl: null,
           targetHref: "https://example.com/dashboard",
           navId: firstNavId,
-          useTransition: false,
         }),
       ).resolves.toBe("hard-navigate");
       expect(assign).toHaveBeenCalledTimes(1);
@@ -2063,7 +2064,6 @@ describe("app browser root-layout hard navigation", () => {
           previousNextUrl: null,
           targetHref: "https://example.com/dashboard",
           navId: secondNavId,
-          useTransition: false,
         }),
       ).resolves.toBe("no-commit");
       expect(assign).not.toHaveBeenCalled();
@@ -2101,7 +2101,6 @@ describe("app browser root-layout hard navigation", () => {
           previousNextUrl: null,
           targetHref: "https://example.com/dashboard",
           navId: firstNavId,
-          useTransition: false,
         }),
       ).resolves.toBe("hard-navigate");
       expect(assign).toHaveBeenCalledTimes(1);
@@ -2129,7 +2128,6 @@ describe("app browser root-layout hard navigation", () => {
           previousNextUrl: null,
           targetHref: "https://example.com/dashboard",
           navId: secondNavId,
-          useTransition: false,
         }),
       ).resolves.toBe("hard-navigate");
       expect(assign).toHaveBeenCalledTimes(1);

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import ReactDOMServer from "react-dom/server";
+import type { ElementType, ReactNode } from "react";
+
+type CapturedClickEvent = {
+  altKey?: boolean;
+  button: number;
+  ctrlKey?: boolean;
+  currentTarget: { target: string };
+  defaultPrevented: boolean;
+  metaKey?: boolean;
+  preventDefault(): void;
+  shiftKey?: boolean;
+};
+
+type CapturedAnchorProps = {
+  onClick?: (event: CapturedClickEvent) => void | Promise<void>;
+};
+
+afterEach(() => {
+  vi.doUnmock("react");
+  vi.doUnmock("react/jsx-runtime");
+  vi.doUnmock("react/jsx-dev-runtime");
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("Link App Router navigation scheduling", () => {
+  it("clicking an RSC Link starts app-router navigation inside a React transition", async () => {
+    vi.resetModules();
+
+    let capturedAnchorProps: CapturedAnchorProps | undefined;
+    let transitionActive = false;
+    const transitionStates: boolean[] = [];
+    const startTransition = vi.fn((callback: () => void) => {
+      transitionActive = true;
+      try {
+        callback();
+      } finally {
+        transitionActive = false;
+      }
+    });
+
+    const captureAnchor = (type: unknown, props: unknown) => {
+      if (type === "a" && props !== null && typeof props === "object") {
+        capturedAnchorProps = props;
+      }
+    };
+
+    vi.doMock("react", async () => {
+      const actual = await vi.importActual<typeof import("react")>("react");
+      const createElement = ((
+        type: ElementType,
+        props: Record<string, unknown> | null,
+        ...children: ReactNode[]
+      ) => {
+        captureAnchor(type, props);
+        return actual.createElement(type, props, ...children);
+      }) as typeof actual.createElement;
+
+      return {
+        ...actual,
+        createElement,
+        default: { ...actual, createElement, startTransition },
+        startTransition,
+      };
+    });
+
+    vi.doMock("react/jsx-runtime", async () => {
+      const actual = await vi.importActual<typeof import("react/jsx-runtime")>("react/jsx-runtime");
+      return {
+        ...actual,
+        jsx(type: ElementType, props: Record<string, unknown>, key?: string) {
+          captureAnchor(type, props);
+          return actual.jsx(type, props, key);
+        },
+        jsxs(type: ElementType, props: Record<string, unknown>, key?: string) {
+          captureAnchor(type, props);
+          return actual.jsxs(type, props, key);
+        },
+      };
+    });
+
+    vi.doMock("react/jsx-dev-runtime", async () => {
+      const actual =
+        await vi.importActual<typeof import("react/jsx-dev-runtime")>("react/jsx-dev-runtime");
+      return {
+        ...actual,
+        jsxDEV(
+          type: ElementType,
+          props: Record<string, unknown>,
+          key?: string,
+          isStaticChildren?: boolean,
+          source?: Parameters<typeof actual.jsxDEV>[4],
+          self?: Parameters<typeof actual.jsxDEV>[5],
+        ) {
+          captureAnchor(type, props);
+          return actual.jsxDEV(type, props, key, isStaticChildren ?? false, source, self);
+        },
+      };
+    });
+
+    const navigate = vi.fn(async () => {
+      transitionStates.push(transitionActive);
+    });
+    vi.stubGlobal("window", {
+      __VINEXT_RSC_NAVIGATE__: navigate,
+      addEventListener: vi.fn(),
+      history: {
+        pushState: vi.fn(),
+        replaceState: vi.fn(),
+      },
+      location: {
+        href: "https://example.com/current",
+        origin: "https://example.com",
+      },
+      scrollTo: vi.fn(),
+    });
+
+    const [{ default: IsolatedLink }, React] = await Promise.all([
+      import("../packages/vinext/src/shims/link.js"),
+      vi.importActual<typeof import("react")>("react"),
+    ]);
+
+    ReactDOMServer.renderToString(
+      React.createElement(IsolatedLink, { href: "/target", prefetch: false }, "target"),
+    );
+
+    const clickEvent = {
+      button: 0,
+      currentTarget: { target: "" },
+      defaultPrevented: false,
+      preventDefault() {
+        this.defaultPrevented = true;
+      },
+    };
+    const onClick = capturedAnchorProps?.onClick;
+    expect(onClick).toBeTypeOf("function");
+    if (onClick === undefined) {
+      throw new Error("Expected rendered Link anchor to expose an onClick handler");
+    }
+    await onClick(clickEvent);
+
+    expect(clickEvent.defaultPrevented).toBe(true);
+    expect(startTransition).toHaveBeenCalledTimes(1);
+    expect(navigate).toHaveBeenCalledWith("/target", 0, "navigate", "push", undefined, true);
+    expect(transitionStates).toEqual([true]);
+  });
+});

--- a/tests/link.test.ts
+++ b/tests/link.test.ts
@@ -10,6 +10,8 @@
  * pure helper functions work correctly.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vite-plus/test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import React from "react";
 import ReactDOMServer from "react-dom/server";
 
@@ -116,6 +118,20 @@ describe("Link rendering", () => {
     );
     expect(html).toContain("<span>Nested child</span>");
     expect(html).toContain('href="/nested"');
+  });
+});
+
+describe("Link App Router navigation scheduling", () => {
+  it("starts RSC link navigations as React transitions", () => {
+    const linkPath = fileURLToPath(
+      new URL("../packages/vinext/src/shims/link.tsx", import.meta.url),
+    );
+    const source = readFileSync(linkPath, "utf8");
+
+    expect(source).toContain("React.startTransition");
+    expect(source).toContain(
+      'navigateClientSide(navigateHref, replace ? "replace" : "push", scroll, true)',
+    );
   });
 });
 

--- a/tests/link.test.ts
+++ b/tests/link.test.ts
@@ -10,8 +10,6 @@
  * pure helper functions work correctly.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vite-plus/test";
-import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
 import React from "react";
 import ReactDOMServer from "react-dom/server";
 
@@ -118,20 +116,6 @@ describe("Link rendering", () => {
     );
     expect(html).toContain("<span>Nested child</span>");
     expect(html).toContain('href="/nested"');
-  });
-});
-
-describe("Link App Router navigation scheduling", () => {
-  it("starts RSC link navigations as React transitions", () => {
-    const linkPath = fileURLToPath(
-      new URL("../packages/vinext/src/shims/link.tsx", import.meta.url),
-    );
-    const source = readFileSync(linkPath, "utf8");
-
-    expect(source).toContain("React.startTransition");
-    expect(source).toContain(
-      'navigateClientSide(navigateHref, replace ? "replace" : "push", scroll, true)',
-    );
   });
 });
 


### PR DESCRIPTION
## What this changes
App Router `<Link>` clicks now enter React transition scheduling before starting RSC navigation, matching the existing `useRouter().push/replace` path.

Normal browser navigation payload commits no longer accept a `useTransition` override, so cross-route commits cannot be accidentally scheduled synchronously from path equality. Synchronous visible commits remain private to HMR and same-URL server-action handling, where they have separate lifecycle rules.

## Why
vinext was computing `isSameRoute` in the app browser entry and passing it as the navigation payload transition toggle. That inverted the intended semantics for cross-route link clicks: cross-route payloads got `useTransition: false`, while same-route payloads got transition scheduling.

Next.js treats App Router navigation as transition work regardless of route equality:

- [`dispatchAction` publishes async router state with `startTransition`](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/app-router-instance.ts#L166-L170)
- [`router.replace` wraps `dispatchNavigateAction` in `startTransition`](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/app-router-instance.ts#L445-L455)
- [`router.push` wraps `dispatchNavigateAction` in `startTransition`](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/app-router-instance.ts#L463-L473)
- [`<Link>` delegates App Router clicks through `router.push/replace`](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/link.tsx#L279-L281)

## Approach
Keep vinext's lifecycle model: two-phase URL commit, stale-navigation authority, pending pathname tracking, and separate synchronous paths for HMR and same-URL server-action commits.

Change only the scheduling boundary:

- RSC `<Link>` clicks call `navigateClientSide(..., true)` inside `React.startTransition`, reusing the existing programmatic pending-router-state path.
- `renderNavigationPayload` no longer accepts or forwards a transition override for ordinary navigations.
- The app browser entry removes `isSameRoute` from payload commit scheduling entirely.

## Validation
- `vp test run tests/app-browser-entry.test.ts tests/link.test.ts`
- `vp check packages/vinext/src/server/app-browser-entry.ts packages/vinext/src/server/app-browser-navigation-controller.ts packages/vinext/src/shims/link.tsx tests/app-browser-entry.test.ts tests/link.test.ts`
- `PLAYWRIGHT_PROJECT=app-router vp run test:e2e tests/e2e/app-router/navigation-regressions.spec.ts`

## Risks / follow-ups
The change intentionally does not rewrite vinext's router to fetch inside React like Next.js does. It preserves vinext's current RSC fetch and commit pipeline, but aligns the public navigation scheduling contract with Next.js.