### PR TITLE
fix(fetch-cache): dedupe identical render fetches

### DIFF
--- a/packages/vinext/src/server/app-page-boundary.ts
+++ b/packages/vinext/src/server/app-page-boundary.ts
@@ -1,3 +1,4 @@
+import { runWithFetchDedupe } from "vinext/shims/fetch-cache";
 import { mergeMiddlewareResponseHeaders } from "./middleware-response-headers.js";
 import { VINEXT_RSC_VARY_HEADER } from "./app-rsc-cache-busting.js";
 import { resolveAppPageSegmentParams } from "./app-page-params.js";
@@ -219,9 +220,11 @@ export function wrapAppPageBoundaryElement<
 export async function renderAppPageBoundaryResponse<TElement>(
   options: RenderAppPageBoundaryResponseOptions<TElement>,
 ): Promise<Response> {
-  const rscStream = options.renderToReadableStream(options.element, {
-    onError: options.createRscOnErrorHandler(),
-  });
+  const rscStream = runWithFetchDedupe(() =>
+    options.renderToReadableStream(options.element, {
+      onError: options.createRscOnErrorHandler(),
+    }),
+  );
 
   if (options.isRscRequest) {
     // Do NOT clear request-scoped context here. RSC responses are consumed lazily

--- a/packages/vinext/src/server/app-page-boundary.ts
+++ b/packages/vinext/src/server/app-page-boundary.ts
@@ -220,6 +220,10 @@ export function wrapAppPageBoundaryElement<
 export async function renderAppPageBoundaryResponse<TElement>(
   options: RenderAppPageBoundaryResponseOptions<TElement>,
 ): Promise<Response> {
+  // Defensive wrap for standalone callers; idempotent under dispatchAppPage.
+  // The async stream consumption that follows relies on the surrounding
+  // runWithRequestContext to keep ALS state alive after this synchronous call
+  // returns. See app-page-render.ts for the same pattern.
   const rscStream = runWithFetchDedupe(() =>
     options.renderToReadableStream(options.element, {
       onError: options.createRscOnErrorHandler(),

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -291,10 +291,10 @@ function toInterceptOptions(
 export async function dispatchAppPage<TRoute extends AppPageDispatchRoute>(
   options: DispatchAppPageOptions<TRoute>,
 ): Promise<Response> {
-  return await runWithFetchDedupe(() => dispatchAppPageWithDedupe(options));
+  return await runWithFetchDedupe(() => dispatchAppPageInner(options));
 }
 
-async function dispatchAppPageWithDedupe<TRoute extends AppPageDispatchRoute>(
+async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
   options: DispatchAppPageOptions<TRoute>,
 ): Promise<Response> {
   const route = options.route;
@@ -387,6 +387,8 @@ async function dispatchAppPageWithDedupe<TRoute extends AppPageDispatchRoute>(
               options.cleanPathname,
               route.pattern,
             );
+            // No inner runWithFetchDedupe here: this renderFn is already
+            // wrapped in runWithFetchDedupe by runAppPageRevalidationContext.
             const revalidatedRscStream = options.renderToReadableStream(revalidatedElement, {
               onError: revalidatedOnError,
             });
@@ -486,6 +488,8 @@ async function dispatchAppPageWithDedupe<TRoute extends AppPageDispatchRoute>(
         options.cleanPathname,
         sourceRoute.pattern,
       );
+      // No inner runWithFetchDedupe here: dispatchAppPage already activated
+      // dedupe at line 294, and this callback runs inside dispatchAppPageInner.
       const interceptStream = options.renderToReadableStream(interceptElement, {
         onError: interceptOnError,
       });

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -20,6 +20,7 @@ import {
   ensureFetchPatch,
   type FetchCacheMode,
   getCollectedFetchTags,
+  runWithFetchDedupe,
   setCurrentFetchCacheMode,
   setCurrentFetchSoftTags,
 } from "vinext/shims/fetch-cache";
@@ -258,7 +259,7 @@ async function runAppPageRevalidationContext(
       searchParams: new URLSearchParams(),
       params: options.params,
     });
-    return renderFn();
+    return await runWithFetchDedupe(renderFn);
   });
 }
 
@@ -288,6 +289,12 @@ function toInterceptOptions(
 }
 
 export async function dispatchAppPage<TRoute extends AppPageDispatchRoute>(
+  options: DispatchAppPageOptions<TRoute>,
+): Promise<Response> {
+  return await runWithFetchDedupe(() => dispatchAppPageWithDedupe(options));
+}
+
+async function dispatchAppPageWithDedupe<TRoute extends AppPageDispatchRoute>(
   options: DispatchAppPageOptions<TRoute>,
 ): Promise<Response> {
   const route = options.route;
@@ -380,9 +387,11 @@ export async function dispatchAppPage<TRoute extends AppPageDispatchRoute>(
               options.cleanPathname,
               route.pattern,
             );
-            const revalidatedRscStream = options.renderToReadableStream(revalidatedElement, {
-              onError: revalidatedOnError,
-            });
+            const revalidatedRscStream = runWithFetchDedupe(() =>
+              options.renderToReadableStream(revalidatedElement, {
+                onError: revalidatedOnError,
+              }),
+            );
             const revalidatedRscCapture = teeAppPageRscStreamForCapture(revalidatedRscStream, true);
             const revalidatedSsrEntry = await options.loadSsrHandler();
             const revalidatedCapturedRscRef: { value: Promise<ArrayBuffer> | null } = {
@@ -479,9 +488,11 @@ export async function dispatchAppPage<TRoute extends AppPageDispatchRoute>(
         options.cleanPathname,
         sourceRoute.pattern,
       );
-      const interceptStream = options.renderToReadableStream(interceptElement, {
-        onError: interceptOnError,
-      });
+      const interceptStream = runWithFetchDedupe(() =>
+        options.renderToReadableStream(interceptElement, {
+          onError: interceptOnError,
+        }),
+      );
       const interceptHeaders = new Headers({
         "Content-Type": "text/x-component; charset=utf-8",
         Vary: VINEXT_RSC_VARY_HEADER,

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -387,11 +387,9 @@ async function dispatchAppPageWithDedupe<TRoute extends AppPageDispatchRoute>(
               options.cleanPathname,
               route.pattern,
             );
-            const revalidatedRscStream = runWithFetchDedupe(() =>
-              options.renderToReadableStream(revalidatedElement, {
-                onError: revalidatedOnError,
-              }),
-            );
+            const revalidatedRscStream = options.renderToReadableStream(revalidatedElement, {
+              onError: revalidatedOnError,
+            });
             const revalidatedRscCapture = teeAppPageRscStreamForCapture(revalidatedRscStream, true);
             const revalidatedSsrEntry = await options.loadSsrHandler();
             const revalidatedCapturedRscRef: { value: Promise<ArrayBuffer> | null } = {
@@ -488,11 +486,9 @@ async function dispatchAppPageWithDedupe<TRoute extends AppPageDispatchRoute>(
         options.cleanPathname,
         sourceRoute.pattern,
       );
-      const interceptStream = runWithFetchDedupe(() =>
-        options.renderToReadableStream(interceptElement, {
-          onError: interceptOnError,
-        }),
-      );
+      const interceptStream = options.renderToReadableStream(interceptElement, {
+        onError: interceptOnError,
+      });
       const interceptHeaders = new Headers({
         "Content-Type": "text/x-component; charset=utf-8",
         Vary: VINEXT_RSC_VARY_HEADER,

--- a/packages/vinext/src/server/app-page-head.ts
+++ b/packages/vinext/src/server/app-page-head.ts
@@ -8,6 +8,7 @@ import {
   type MetadataMergeEntry,
   type Viewport,
 } from "vinext/shims/metadata";
+import { runWithFetchDedupe } from "vinext/shims/fetch-cache";
 import { applyFileBasedMetadata } from "./file-based-metadata.js";
 import type { AppPageParams } from "./app-page-boundary.js";
 import { resolveAppPageSegmentParams } from "./app-page-params.js";
@@ -299,6 +300,12 @@ async function resolveParallelRouteHead<TModule extends AppPageHeadModule>(
 }
 
 export async function resolveAppPageHead<TModule extends AppPageHeadModule>(
+  options: ResolveAppPageHeadOptions<TModule>,
+): Promise<ResolveAppPageHeadResult> {
+  return await runWithFetchDedupe(() => resolveAppPageHeadInner(options));
+}
+
+async function resolveAppPageHeadInner<TModule extends AppPageHeadModule>(
   options: ResolveAppPageHeadOptions<TModule>,
 ): Promise<ResolveAppPageHeadResult> {
   const routeSegments = options.routeSegments ?? [];

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import type { CachedAppPageValue } from "vinext/shims/cache";
+import { runWithFetchDedupe } from "vinext/shims/fetch-cache";
 import { AppElementsWire, isAppElementsRecord, type AppOutgoingElements } from "./app-elements.js";
 import {
   finalizeAppPageHtmlCacheResponse,
@@ -297,9 +298,11 @@ export async function renderAppPageLifecycle(
   const compileEnd = options.isProduction ? undefined : performance.now();
   const baseOnError = options.createRscOnErrorHandler(options.cleanPathname, options.routePattern);
   const rscErrorTracker = createAppPageRscErrorTracker(baseOnError);
-  const rscStream = options.renderToReadableStream(outgoingElement, {
-    onError: rscErrorTracker.onRenderError,
-  });
+  const rscStream = runWithFetchDedupe(() =>
+    options.renderToReadableStream(outgoingElement, {
+      onError: rscErrorTracker.onRenderError,
+    }),
+  );
 
   let revalidateSeconds = options.revalidateSeconds;
   let expireSeconds = options.expireSeconds;

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -298,6 +298,13 @@ export async function renderAppPageLifecycle(
   const compileEnd = options.isProduction ? undefined : performance.now();
   const baseOnError = options.createRscOnErrorHandler(options.cleanPathname, options.routePattern);
   const rscErrorTracker = createAppPageRscErrorTracker(baseOnError);
+  // Defensive wrap for standalone callers. In the normal dispatch path this is
+  // a no-op since dispatchAppPage already activated dedupe. Note that
+  // renderToReadableStream returns synchronously — the actual fetch calls
+  // happen later during async stream consumption — so the dedupe map a
+  // standalone call would establish here is only effective if the caller has
+  // an outer runWithRequestContext / runWithFetchDedupe scope keeping the ALS
+  // store alive across that consumption.
   const rscStream = runWithFetchDedupe(() =>
     options.renderToReadableStream(outgoingElement, {
       onError: rscErrorTracker.onRenderError,

--- a/packages/vinext/src/server/app-page-request.ts
+++ b/packages/vinext/src/server/app-page-request.ts
@@ -1,4 +1,5 @@
 import type { AppPageSpecialError } from "./app-page-execution.js";
+import { runWithFetchDedupe } from "vinext/shims/fetch-cache";
 import { getAppPageSegmentParamName } from "./app-page-params.js";
 import { notFoundResponse } from "./http-error-responses.js";
 
@@ -258,9 +259,11 @@ export async function validateAppPageDynamicParams(
   }
 
   for (const source of generateStaticParamsSources) {
-    const staticParams = await source.generateStaticParams({
-      params: pickRouteParams(options.params, source.parentParamNames),
-    });
+    const staticParams = await runWithFetchDedupe(() =>
+      source.generateStaticParams({
+        params: pickRouteParams(options.params, source.parentParamNames),
+      }),
+    );
     if (Array.isArray(staticParams) && !areStaticParamsAllowed(options.params, staticParams)) {
       options.clearRequestContext();
       return notFoundResponse();

--- a/packages/vinext/src/shims/fetch-cache.ts
+++ b/packages/vinext/src/shims/fetch-cache.ts
@@ -1139,6 +1139,13 @@ export async function runWithFetchCache<T>(fn: () => Promise<T>): Promise<T> {
  * Activate per-render fetch memoization without resetting request fetch tags.
  * Next.js request memoization is scoped to React render work, not the whole
  * request pipeline, so route handlers and middleware stay observable.
+ *
+ * ALS scope lifetime: when `fn` returns synchronously (e.g. wrapping a
+ * `renderToReadableStream` call), the ALS scope established here only covers
+ * the synchronous portion. Any fetch work that happens later during async
+ * stream consumption falls back to the parent ALS store, which is fine when
+ * the parent already activated dedupe (the common dispatch case) but means
+ * standalone callers must keep the dedupe scope alive across consumption.
  */
 export function runWithFetchDedupe<T>(fn: () => T): T;
 export function runWithFetchDedupe<T>(fn: () => Promise<T>): Promise<T>;

--- a/packages/vinext/src/shims/fetch-cache.ts
+++ b/packages/vinext/src/shims/fetch-cache.ts
@@ -692,14 +692,17 @@ function cloneDedupeResponse(response: Response): [Response, Response] {
   }
 
   const [body1, body2] = response.body.tee();
-  const responseInit = {
+
+  const cloned1 = new Response(body1, {
     status: response.status,
     statusText: response.statusText,
-    headers: response.headers,
-  };
-
-  const cloned1 = new Response(body1, responseInit);
-  const cloned2 = new Response(body2, responseInit);
+    headers: new Headers(response.headers),
+  });
+  const cloned2 = new Response(body2, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: new Headers(response.headers),
+  });
 
   for (const cloned of [cloned1, cloned2]) {
     Object.defineProperty(cloned, "url", {

--- a/packages/vinext/src/shims/fetch-cache.ts
+++ b/packages/vinext/src/shims/fetch-cache.ts
@@ -759,15 +759,26 @@ function dedupeFetch(
   };
   entries.push(entry);
 
-  return promise.then((response) => {
-    // entry.response holds an unconsumed tee'd branch for the duration of the
-    // render scope. The dedupe map is owned by the per-render context and is
-    // dropped when runWithFetchDedupe exits, at which point the
-    // FinalizationRegistry cancels any still-unconsumed branch.
-    const [responseForCaller, responseForFutureCaller] = cloneDedupeResponse(response);
-    entry.response = responseForFutureCaller;
-    return responseForCaller;
-  });
+  return promise.then(
+    (response) => {
+      // entry.response holds an unconsumed tee'd branch for the duration of the
+      // render scope. The dedupe map is owned by the per-render context and is
+      // dropped when runWithFetchDedupe exits, at which point the
+      // FinalizationRegistry cancels any still-unconsumed branch.
+      const [responseForCaller, responseForFutureCaller] = cloneDedupeResponse(response);
+      entry.response = responseForFutureCaller;
+      return responseForCaller;
+    },
+    (err) => {
+      // Drop the failed entry so a later fetch to the same URL within this
+      // render scope can retry instead of chaining on the rejected promise.
+      // Mirrors React.cache() retry-on-error semantics in Next.js, where a
+      // new call site naturally creates a fresh cache entry.
+      const idx = entries.indexOf(entry);
+      if (idx !== -1) entries.splice(idx, 1);
+      throw err;
+    },
+  );
 }
 
 /**

--- a/packages/vinext/src/shims/fetch-cache.ts
+++ b/packages/vinext/src/shims/fetch-cache.ts
@@ -683,41 +683,38 @@ function createFetchDedupeCandidate(
   };
 }
 
+function buildDedupeClone(body: ReadableStream<Uint8Array> | null, source: Response): Response {
+  const cloned = new Response(body, {
+    status: source.status,
+    statusText: source.statusText,
+    headers: new Headers(source.headers),
+  });
+  Object.defineProperty(cloned, "url", {
+    value: source.url,
+    configurable: true,
+    enumerable: true,
+    writable: false,
+  });
+  if (_responseBodyRegistry && cloned.body) {
+    _responseBodyRegistry.register(cloned, new WeakRef(cloned.body));
+  }
+  return cloned;
+}
+
 function cloneDedupeResponse(response: Response): [Response, Response] {
   // Mirrors Next.js' cloneResponse helper. Native Response.clone() has had
   // undici stream-lifetime bugs in Node, so tee explicitly and register the
   // branches for cleanup if the caller drops a body without consuming it.
+  // Always construct fresh Response objects (even for bodyless responses) so
+  // the dedupe entry's stored response and the caller's response are distinct
+  // — mirrors Next.js, and avoids any "disturbed response" surprise if a
+  // runtime tracks consumption state on shared references.
   if (!response.body) {
-    return [response, response];
+    return [buildDedupeClone(null, response), buildDedupeClone(null, response)];
   }
 
   const [body1, body2] = response.body.tee();
-
-  const cloned1 = new Response(body1, {
-    status: response.status,
-    statusText: response.statusText,
-    headers: new Headers(response.headers),
-  });
-  const cloned2 = new Response(body2, {
-    status: response.status,
-    statusText: response.statusText,
-    headers: new Headers(response.headers),
-  });
-
-  for (const cloned of [cloned1, cloned2]) {
-    Object.defineProperty(cloned, "url", {
-      value: response.url,
-      configurable: true,
-      enumerable: true,
-      writable: false,
-    });
-
-    if (_responseBodyRegistry && cloned.body) {
-      _responseBodyRegistry.register(cloned, new WeakRef(cloned.body));
-    }
-  }
-
-  return [cloned1, cloned2];
+  return [buildDedupeClone(body1, response), buildDedupeClone(body2, response)];
 }
 
 function dedupeFetch(
@@ -763,6 +760,10 @@ function dedupeFetch(
   entries.push(entry);
 
   return promise.then((response) => {
+    // entry.response holds an unconsumed tee'd branch for the duration of the
+    // render scope. The dedupe map is owned by the per-render context and is
+    // dropped when runWithFetchDedupe exits, at which point the
+    // FinalizationRegistry cancels any still-unconsumed branch.
     const [responseForCaller, responseForFutureCaller] = cloneDedupeResponse(response);
     entry.response = responseForFutureCaller;
     return responseForCaller;

--- a/packages/vinext/src/shims/fetch-cache.ts
+++ b/packages/vinext/src/shims/fetch-cache.ts
@@ -419,6 +419,12 @@ type NextFetchOptions = {
   tags?: string[];
 };
 
+type FetchDedupeEntry = {
+  key: string;
+  promise: Promise<Response>;
+  response: Response | null;
+};
+
 // Extend the standard RequestInit to include `next`
 declare global {
   // oxlint-disable-next-line typescript/consistent-type-definitions
@@ -470,6 +476,8 @@ export type FetchCacheState = {
   currentRequestTags: string[];
   currentFetchSoftTags: string[];
   currentFetchCacheMode: FetchCacheMode | null;
+  isFetchDedupeActive: boolean;
+  currentFetchDedupeEntries: Map<string, FetchDedupeEntry[]>;
 };
 
 export type FetchCacheMode =
@@ -484,11 +492,25 @@ export type FetchCacheMode =
 const _FALLBACK_KEY = Symbol.for("vinext.fetchCache.fallback");
 const _g = globalThis as unknown as Record<PropertyKey, unknown>;
 const _als = getOrCreateAls<FetchCacheState>("vinext.fetchCache.als");
+const _noop = (): void => {};
+
+let _responseBodyRegistry: FinalizationRegistry<WeakRef<ReadableStream<Uint8Array>>> | undefined;
+
+if (globalThis.FinalizationRegistry) {
+  _responseBodyRegistry = new FinalizationRegistry((weakRef) => {
+    const stream = weakRef.deref();
+    if (stream && !stream.locked) {
+      void stream.cancel("Response object has been garbage collected").then(_noop, _noop);
+    }
+  });
+}
 
 const _fallbackState = (_g[_FALLBACK_KEY] ??= {
   currentRequestTags: [],
   currentFetchSoftTags: [],
   currentFetchCacheMode: null,
+  isFetchDedupeActive: false,
+  currentFetchDedupeEntries: new Map(),
 } satisfies FetchCacheState) as FetchCacheState;
 
 function _getState(): FetchCacheState {
@@ -502,10 +524,12 @@ function _getState(): FetchCacheState {
  * Reset the fallback state for a new request.  Used by `withFetchCache()`
  * in single-threaded contexts where ALS.run() isn't used.
  */
-function _resetFallbackState(): void {
+function _resetFallbackState(isFetchDedupeActive: boolean): void {
   _fallbackState.currentRequestTags = [];
   _fallbackState.currentFetchSoftTags = [];
   _fallbackState.currentFetchCacheMode = null;
+  _fallbackState.isFetchDedupeActive = isFetchDedupeActive;
+  _fallbackState.currentFetchDedupeEntries = new Map();
 }
 
 /**
@@ -612,6 +636,136 @@ function getFetchCacheDirective(
   return input.cache;
 }
 
+function buildFetchDedupeKey(request: Request): string {
+  const filteredHeaders = Array.from(request.headers.entries()).filter(
+    ([key]) => !HEADER_BLOCKLIST.includes(key.toLowerCase()),
+  );
+
+  return JSON.stringify([
+    request.method,
+    filteredHeaders,
+    request.mode,
+    request.redirect,
+    request.credentials,
+    request.referrer,
+    request.referrerPolicy,
+    request.integrity,
+  ]);
+}
+
+function createFetchDedupeCandidate(
+  input: string | URL | Request,
+  init: RequestInit | undefined,
+): { url: string; key: string } | null {
+  if (init?.signal) {
+    return null;
+  }
+
+  const method = init?.method?.toUpperCase();
+  if (method && method !== "GET" && method !== "HEAD") {
+    return null;
+  }
+
+  if (init?.keepalive) {
+    return null;
+  }
+
+  const request =
+    typeof input === "string" || input instanceof URL ? new Request(input, init) : input;
+
+  if ((request.method !== "GET" && request.method !== "HEAD") || request.keepalive) {
+    return null;
+  }
+
+  return {
+    url: request.url,
+    key: buildFetchDedupeKey(request),
+  };
+}
+
+function cloneDedupeResponse(response: Response): [Response, Response] {
+  // Mirrors Next.js' cloneResponse helper. Native Response.clone() has had
+  // undici stream-lifetime bugs in Node, so tee explicitly and register the
+  // branches for cleanup if the caller drops a body without consuming it.
+  if (!response.body) {
+    return [response, response];
+  }
+
+  const [body1, body2] = response.body.tee();
+  const responseInit = {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  };
+
+  const cloned1 = new Response(body1, responseInit);
+  const cloned2 = new Response(body2, responseInit);
+
+  for (const cloned of [cloned1, cloned2]) {
+    Object.defineProperty(cloned, "url", {
+      value: response.url,
+      configurable: true,
+      enumerable: true,
+      writable: false,
+    });
+
+    if (_responseBodyRegistry && cloned.body) {
+      _responseBodyRegistry.register(cloned, new WeakRef(cloned.body));
+    }
+  }
+
+  return [cloned1, cloned2];
+}
+
+function dedupeFetch(
+  input: string | URL | Request,
+  init: RequestInit | undefined,
+): Promise<Response> {
+  const state = _getState();
+  if (!state.isFetchDedupeActive) {
+    return originalFetch(input, init);
+  }
+
+  const candidate = createFetchDedupeCandidate(input, init);
+  if (!candidate) {
+    return originalFetch(input, init);
+  }
+
+  const entriesByUrl = state.currentFetchDedupeEntries;
+  let entries = entriesByUrl.get(candidate.url);
+  if (!entries) {
+    entries = [];
+    entriesByUrl.set(candidate.url, entries);
+  }
+
+  for (const entry of entries) {
+    if (entry.key !== candidate.key) continue;
+
+    return entry.promise.then(() => {
+      if (!entry.response) {
+        throw new Error("[vinext] Missing deduped fetch response");
+      }
+      const [responseForCaller, responseForFutureCaller] = cloneDedupeResponse(entry.response);
+      entry.response = responseForFutureCaller;
+      return responseForCaller;
+    });
+  }
+
+  const promise = originalFetch(input, init);
+  const entry: FetchDedupeEntry = {
+    key: candidate.key,
+    promise,
+    response: null,
+  };
+  entries.push(entry);
+
+  return promise.then((response) => {
+    const [responseForCaller, responseForFutureCaller] = cloneDedupeResponse(response);
+    entry.response = responseForFutureCaller;
+    return responseForCaller;
+  });
+}
+
 /**
  * Create a patched fetch function with Next.js caching semantics.
  *
@@ -646,7 +800,7 @@ function createPatchedFetch(): typeof globalThis.fetch {
 
     // If no caching options at all, just pass through to original fetch
     if (!nextOpts && !cacheDirective) {
-      return originalFetch(input, init);
+      return dedupeFetch(input, init);
     }
 
     // Explicit no-store or no-cache — bypass cache entirely
@@ -658,7 +812,7 @@ function createPatchedFetch(): typeof globalThis.fetch {
     ) {
       // Strip the `next` property before passing to real fetch
       const cleanInit = stripNextFromInit(init, cacheDirective);
-      return originalFetch(input, cleanInit);
+      return dedupeFetch(input, cleanInit);
     }
 
     // Safety: when per-user auth headers are present and the developer hasn't
@@ -671,7 +825,7 @@ function createPatchedFetch(): typeof globalThis.fetch {
       (typeof nextOpts?.revalidate === "number" && nextOpts.revalidate > 0);
     if (!hasExplicitCacheOpt && hasAuthHeaders(input, init)) {
       const cleanInit = stripNextFromInit(init, cacheDirective);
-      return originalFetch(input, cleanInit);
+      return dedupeFetch(input, cleanInit);
     }
 
     // Determine revalidation period
@@ -693,7 +847,7 @@ function createPatchedFetch(): typeof globalThis.fetch {
       } else {
         // next: {} with no revalidate or tags — pass through
         const cleanInit = stripNextFromInit(init, cacheDirective);
-        return originalFetch(input, cleanInit);
+        return dedupeFetch(input, cleanInit);
       }
     }
 
@@ -712,7 +866,7 @@ function createPatchedFetch(): typeof globalThis.fetch {
         err instanceof SkipCacheKeyGenerationError
       ) {
         fetchInit = stripNextFromInit(fetchInit, cacheDirective);
-        return originalFetch(input, fetchInit);
+        return dedupeFetch(input, fetchInit);
       }
       throw err;
     }
@@ -831,7 +985,7 @@ function createPatchedFetch(): typeof globalThis.fetch {
     }
 
     // Cache miss — fetch from network
-    const response = await originalFetch(input, fetchInit);
+    const response = await dedupeFetch(input, fetchInit);
 
     // Only cache 200 responses
     if (response.status === 200) {
@@ -932,10 +1086,10 @@ function _ensurePatchInstalled(): void {
  */
 export function withFetchCache(): () => void {
   _ensurePatchInstalled();
-  _resetFallbackState();
+  _resetFallbackState(true);
 
   return () => {
-    _resetFallbackState();
+    _resetFallbackState(false);
   };
 }
 
@@ -950,10 +1104,49 @@ export async function runWithFetchCache<T>(fn: () => Promise<T>): Promise<T> {
     return await runWithUnifiedStateMutation((uCtx) => {
       uCtx.currentRequestTags = [];
       uCtx.currentFetchSoftTags = [];
+      uCtx.isFetchDedupeActive = true;
+      uCtx.currentFetchDedupeEntries = new Map();
     }, fn);
   }
   return _als.run(
-    { currentRequestTags: [], currentFetchSoftTags: [], currentFetchCacheMode: null },
+    {
+      currentRequestTags: [],
+      currentFetchSoftTags: [],
+      currentFetchCacheMode: null,
+      isFetchDedupeActive: true,
+      currentFetchDedupeEntries: new Map(),
+    },
+    fn,
+  );
+}
+
+/**
+ * Activate per-render fetch memoization without resetting request fetch tags.
+ * Next.js request memoization is scoped to React render work, not the whole
+ * request pipeline, so route handlers and middleware stay observable.
+ */
+export function runWithFetchDedupe<T>(fn: () => T): T;
+export function runWithFetchDedupe<T>(fn: () => Promise<T>): Promise<T>;
+export function runWithFetchDedupe<T>(fn: () => T | Promise<T>): T | Promise<T> {
+  _ensurePatchInstalled();
+  const state = _getState();
+  if (state.isFetchDedupeActive) {
+    return fn();
+  }
+
+  if (isInsideUnifiedScope()) {
+    return runWithUnifiedStateMutation((uCtx) => {
+      uCtx.isFetchDedupeActive = true;
+      uCtx.currentFetchDedupeEntries = new Map();
+    }, fn);
+  }
+
+  return _als.run(
+    {
+      ...state,
+      isFetchDedupeActive: true,
+      currentFetchDedupeEntries: new Map(),
+    },
     fn,
   );
 }

--- a/packages/vinext/src/shims/unified-request-context.ts
+++ b/packages/vinext/src/shims/unified-request-context.ts
@@ -99,6 +99,8 @@ export function createRequestContext(opts?: Partial<UnifiedRequestContext>): Uni
     currentRequestTags: [],
     currentFetchSoftTags: [],
     currentFetchCacheMode: null,
+    isFetchDedupeActive: false,
+    currentFetchDedupeEntries: new Map(),
     executionContext: _getInheritedExecutionContext(), // inherits from standalone ALS if present
     requestCache: new WeakMap(),
     ssrContext: null,

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -2436,9 +2436,21 @@ describe("App Router Production server (startProdServer)", () => {
           intervalMs: 100,
           timeoutMs: 3000,
         });
-        await new Promise((resolve) => setTimeout(resolve, 200));
+        // Poll for count stabilization rather than assuming a fixed window —
+        // a stray third fetch would betray dedupe leaking across the
+        // metadata + page boundary in background regeneration.
+        let stableCount = getRequestCount();
+        let stableSince = Date.now();
+        while (Date.now() - stableSince < 500) {
+          await new Promise((resolve) => setTimeout(resolve, 50));
+          const current = getRequestCount();
+          if (current !== stableCount) {
+            stableCount = current;
+            stableSince = Date.now();
+          }
+        }
 
-        expect(getRequestCount()).toBe(2);
+        expect(stableCount).toBe(2);
       } finally {
         delete process.env.TEST_FETCH_DEDUPE_TARGET;
       }

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import http from "node:http";
 import os from "node:os";
 import path from "node:path";
 import zlib from "node:zlib";
@@ -40,6 +41,56 @@ function textContentByTestId(html: string, testId: string): string {
   }
 
   return decodeHtmlText(html.slice(contentStart + 1, contentEnd));
+}
+
+async function withCountingFetchTarget<T>(
+  fn: (targetUrl: string, getRequestCount: () => number) => Promise<T>,
+): Promise<T> {
+  let requestCount = 0;
+  const upstream = http.createServer((_req, res) => {
+    requestCount += 1;
+    res.setHeader("content-type", "application/json");
+    res.end(JSON.stringify({ count: requestCount }));
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    upstream.once("error", reject);
+    upstream.listen(0, "127.0.0.1", () => {
+      upstream.off("error", reject);
+      resolve();
+    });
+  });
+
+  const address = upstream.address();
+  if (!address || typeof address === "string") {
+    await new Promise<void>((resolve, reject) => {
+      upstream.close((error) => (error ? reject(error) : resolve()));
+    });
+    throw new Error("Counting fetch target did not bind to a TCP port");
+  }
+
+  try {
+    return await fn(`http://127.0.0.1:${address.port}/tick`, () => requestCount);
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      upstream.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function waitForCondition(
+  condition: () => boolean,
+  options?: { intervalMs?: number; timeoutMs?: number },
+): Promise<void> {
+  const intervalMs = options?.intervalMs ?? 100;
+  const deadline = Date.now() + (options?.timeoutMs ?? 3000);
+
+  while (!condition()) {
+    if (Date.now() >= deadline) {
+      throw new Error("Timed out waiting for condition");
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
 }
 
 describe("App Router integration", () => {
@@ -236,6 +287,63 @@ describe("App Router integration", () => {
     // If broken, useContext returns null and we see "NOT_FOUND".
     expect(html).toContain("dark-test-theme");
     expect(html).not.toContain("NOT_FOUND");
+  });
+
+  it("does not dedupe identical fetches in app route handlers", async () => {
+    await withCountingFetchTarget(async (targetUrl, getRequestCount) => {
+      process.env.TEST_FETCH_DEDUPE_TARGET = targetUrl;
+      try {
+        const res = await fetch(`${baseUrl}/api/fetch-dedupe`);
+        expect(res.status).toBe(200);
+        expect(await res.json()).toEqual({ counts: [1, 2] });
+        expect(getRequestCount()).toBe(2);
+      } finally {
+        delete process.env.TEST_FETCH_DEDUPE_TARGET;
+      }
+    });
+  });
+
+  it("does not dedupe identical fetches in middleware", async () => {
+    await withCountingFetchTarget(async (targetUrl, getRequestCount) => {
+      process.env.TEST_FETCH_DEDUPE_TARGET = targetUrl;
+      try {
+        const res = await fetch(`${baseUrl}/middleware-fetch-dedupe`);
+        expect(res.status).toBe(200);
+        expect(await res.json()).toEqual({ counts: [1, 2] });
+        expect(getRequestCount()).toBe(2);
+      } finally {
+        delete process.env.TEST_FETCH_DEDUPE_TARGET;
+      }
+    });
+  });
+
+  it("dedupes identical fetches during app page server component render", async () => {
+    await withCountingFetchTarget(async (targetUrl, getRequestCount) => {
+      process.env.TEST_FETCH_DEDUPE_TARGET = targetUrl;
+      try {
+        const { res, html } = await fetchHtml(baseUrl, "/fetch-dedupe-render");
+        expect(res.status).toBe(200);
+        expect(textContentByTestId(html, "fetch-dedupe-counts")).toBe("[1,1]");
+        expect(getRequestCount()).toBe(1);
+      } finally {
+        delete process.env.TEST_FETCH_DEDUPE_TARGET;
+      }
+    });
+  });
+
+  it("dedupes identical no-store fetches across generateMetadata and page render", async () => {
+    await withCountingFetchTarget(async (targetUrl, getRequestCount) => {
+      process.env.TEST_FETCH_DEDUPE_TARGET = targetUrl;
+      try {
+        const { res, html } = await fetchHtml(baseUrl, "/fetch-dedupe-metadata");
+        expect(res.status).toBe(200);
+        expect(html).toContain("<title>Product 1</title>");
+        expect(textContentByTestId(html, "fetch-dedupe-metadata-count")).toBe("1");
+        expect(getRequestCount()).toBe(1);
+      } finally {
+        delete process.env.TEST_FETCH_DEDUPE_TARGET;
+      }
+    });
   });
 
   it("SSR renders 'use client' components that use usePathname/useSearchParams", async () => {
@@ -2307,6 +2415,34 @@ describe("App Router Production server (startProdServer)", () => {
     expect(reqId3).toBeTruthy();
     expect(reqId3).not.toBe(reqId1);
     expect(res3.headers.get("x-vinext-cache")).toBe("MISS");
+  });
+
+  it("dedupes identical no-store fetches across metadata and page render during ISR background regeneration", async () => {
+    await withCountingFetchTarget(async (targetUrl, getRequestCount) => {
+      process.env.TEST_FETCH_DEDUPE_TARGET = targetUrl;
+      try {
+        const warmRes = await fetch(`${baseUrl}/fetch-dedupe-isr-metadata`);
+        expect(warmRes.status).toBe(200);
+        expect(await warmRes.text()).toContain("<title>ISR Product 1</title>");
+        expect(getRequestCount()).toBe(1);
+
+        await new Promise((resolve) => setTimeout(resolve, 1500));
+
+        const staleRes = await fetch(`${baseUrl}/fetch-dedupe-isr-metadata`);
+        expect(staleRes.status).toBe(200);
+        await staleRes.arrayBuffer();
+
+        await waitForCondition(() => getRequestCount() > 1, {
+          intervalMs: 100,
+          timeoutMs: 3000,
+        });
+        await new Promise((resolve) => setTimeout(resolve, 200));
+
+        expect(getRequestCount()).toBe(2);
+      } finally {
+        delete process.env.TEST_FETCH_DEDUPE_TARGET;
+      }
+    });
   });
 
   it("page ISR + searchParams: RSC requests stay dynamic instead of serving cached query data", async () => {

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -2867,11 +2867,11 @@ describe("fetch cache (extended fetch with next options)", () => {
     expect(typeof mod.getCollectedFetchTags).toBe("function");
   });
 
-  it("passes through fetch without next options unchanged", async () => {
+  it("passes through fetch without next options to persistent cache but dedupes within a render", async () => {
     const { withFetchCache } = await import("../packages/vinext/src/shims/fetch-cache.js");
 
     fetchCallCount = 0;
-    const cleanup = withFetchCache();
+    let cleanup = withFetchCache();
     try {
       const resp1 = await fetch(`${mockServerUrl}/plain`);
       const data1 = await resp1.json();
@@ -2879,7 +2879,13 @@ describe("fetch cache (extended fetch with next options)", () => {
 
       const resp2 = await fetch(`${mockServerUrl}/plain`);
       const data2 = await resp2.json();
-      expect(data2.count).toBe(2); // NOT cached — no next options
+      expect(data2.count).toBe(1); // Same render fetch is deduped
+
+      cleanup();
+      cleanup = withFetchCache();
+      const resp3 = await fetch(`${mockServerUrl}/plain`);
+      const data3 = await resp3.json();
+      expect(data3.count).toBe(2); // New render still bypasses persistent cache
     } finally {
       cleanup();
     }
@@ -3005,7 +3011,7 @@ describe("fetch cache (extended fetch with next options)", () => {
     }
   });
 
-  it("cache: 'no-store' bypasses cache", async () => {
+  it("cache: 'no-store' bypasses persistent cache but dedupes within a render", async () => {
     const { withFetchCache } = await import("../packages/vinext/src/shims/fetch-cache.js");
     const { setCacheHandler, MemoryCacheHandler } =
       await import("../packages/vinext/src/shims/cache.js");
@@ -3013,7 +3019,7 @@ describe("fetch cache (extended fetch with next options)", () => {
     setCacheHandler(new MemoryCacheHandler());
     fetchCallCount = 0;
 
-    const cleanup = withFetchCache();
+    let cleanup = withFetchCache();
     try {
       const resp1 = await fetch(`${mockServerUrl}/no-store`, {
         cache: "no-store",
@@ -3025,14 +3031,22 @@ describe("fetch cache (extended fetch with next options)", () => {
         cache: "no-store",
       });
       const data2 = await resp2.json();
-      expect(data2.count).toBe(2); // NOT cached
+      expect(data2.count).toBe(1); // Same render fetch is deduped
+
+      cleanup();
+      cleanup = withFetchCache();
+      const resp3 = await fetch(`${mockServerUrl}/no-store`, {
+        cache: "no-store",
+      });
+      const data3 = await resp3.json();
+      expect(data3.count).toBe(2); // New render still bypasses persistent cache
     } finally {
       cleanup();
       setCacheHandler(new MemoryCacheHandler());
     }
   });
 
-  it("next.revalidate: false bypasses cache", async () => {
+  it("next.revalidate: false bypasses persistent cache but dedupes within a render", async () => {
     const { withFetchCache } = await import("../packages/vinext/src/shims/fetch-cache.js");
     const { setCacheHandler, MemoryCacheHandler } =
       await import("../packages/vinext/src/shims/cache.js");
@@ -3040,18 +3054,23 @@ describe("fetch cache (extended fetch with next options)", () => {
     setCacheHandler(new MemoryCacheHandler());
     fetchCallCount = 0;
 
-    const cleanup = withFetchCache();
+    let cleanup = withFetchCache();
     try {
       await fetch(`${mockServerUrl}/no-rev`, { next: { revalidate: false } });
       await fetch(`${mockServerUrl}/no-rev`, { next: { revalidate: false } });
-      expect(fetchCallCount).toBe(2); // Both hit the network
+      expect(fetchCallCount).toBe(1);
+
+      cleanup();
+      cleanup = withFetchCache();
+      await fetch(`${mockServerUrl}/no-rev`, { next: { revalidate: false } });
+      expect(fetchCallCount).toBe(2);
     } finally {
       cleanup();
       setCacheHandler(new MemoryCacheHandler());
     }
   });
 
-  it("next.revalidate: 0 bypasses cache", async () => {
+  it("next.revalidate: 0 bypasses persistent cache but dedupes within a render", async () => {
     const { withFetchCache } = await import("../packages/vinext/src/shims/fetch-cache.js");
     const { setCacheHandler, MemoryCacheHandler } =
       await import("../packages/vinext/src/shims/cache.js");
@@ -3059,9 +3078,14 @@ describe("fetch cache (extended fetch with next options)", () => {
     setCacheHandler(new MemoryCacheHandler());
     fetchCallCount = 0;
 
-    const cleanup = withFetchCache();
+    let cleanup = withFetchCache();
     try {
       await fetch(`${mockServerUrl}/zero`, { next: { revalidate: 0 } });
+      await fetch(`${mockServerUrl}/zero`, { next: { revalidate: 0 } });
+      expect(fetchCallCount).toBe(1);
+
+      cleanup();
+      cleanup = withFetchCache();
       await fetch(`${mockServerUrl}/zero`, { next: { revalidate: 0 } });
       expect(fetchCallCount).toBe(2);
     } finally {
@@ -3078,7 +3102,7 @@ describe("fetch cache (extended fetch with next options)", () => {
     setCacheHandler(new MemoryCacheHandler());
     fetchCallCount = 0;
 
-    const cleanup = withFetchCache();
+    let cleanup = withFetchCache();
     try {
       // First fetch — cache miss, hits network
       const resp1 = await fetch(`${mockServerUrl}/tagged`, {
@@ -3099,7 +3123,10 @@ describe("fetch cache (extended fetch with next options)", () => {
       // Invalidate the tag
       await revalidateTag("posts");
 
-      // Third fetch — cache miss after tag invalidation
+      cleanup();
+      cleanup = withFetchCache();
+
+      // Third fetch — cache miss after tag invalidation in a later render
       const resp3 = await fetch(`${mockServerUrl}/tagged`, {
         next: { revalidate: 3600, tags: ["posts"] },
       });

--- a/tests/fetch-cache.test.ts
+++ b/tests/fetch-cache.test.ts
@@ -408,6 +408,36 @@ describe("fetch cache shim", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
+  it("dedupes identical Request object inputs as the dedupe key source", async () => {
+    const [res1, res2] = await Promise.all([
+      fetch(new Request("https://api.example.com/req-input-dedupe")),
+      fetch(new Request("https://api.example.com/req-input-dedupe")),
+    ]);
+
+    expect((await res1.json()).count).toBe(1);
+    expect((await res2.json()).count).toBe(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not dedupe Request inputs that differ in non-trace headers", async () => {
+    const [res1, res2] = await Promise.all([
+      fetch(
+        new Request("https://api.example.com/req-input-headers", {
+          headers: { "x-variant": "a" },
+        }),
+      ),
+      fetch(
+        new Request("https://api.example.com/req-input-headers", {
+          headers: { "x-variant": "b" },
+        }),
+      ),
+    ]);
+
+    expect((await res1.json()).count).toBe(1);
+    expect((await res2.json()).count).toBe(2);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
   // ── Tag-based invalidation ──────────────────────────────────────────
 
   it("next.tags caches and revalidateTag invalidates", async () => {

--- a/tests/fetch-cache.test.ts
+++ b/tests/fetch-cache.test.ts
@@ -419,6 +419,23 @@ describe("fetch cache shim", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it("removes failed dedupe entries so a later fetch in the same scope can retry", async () => {
+    fetchMock.mockReset();
+    fetchMock
+      .mockImplementationOnce(async () => {
+        throw new Error("network down");
+      })
+      .mockImplementation(defaultFetchMockImplementation);
+
+    await expect(fetch("https://api.example.com/retry-after-failure")).rejects.toThrow(
+      "network down",
+    );
+
+    const res = await fetch("https://api.example.com/retry-after-failure");
+    expect((await res.json()).url).toBe("https://api.example.com/retry-after-failure");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
   it("does not dedupe Request inputs that differ in non-trace headers", async () => {
     const [res1, res2] = await Promise.all([
       fetch(

--- a/tests/fetch-cache.test.ts
+++ b/tests/fetch-cache.test.ts
@@ -51,6 +51,11 @@ const { createRequestContext, runWithRequestContext } =
 describe("fetch cache shim", () => {
   let cleanup: (() => void) | null = null;
 
+  function startNewFetchCacheScope(): void {
+    cleanup?.();
+    cleanup = withFetchCache();
+  }
+
   beforeEach(() => {
     // Reset state
     requestCount = 0;
@@ -158,8 +163,8 @@ describe("fetch cache shim", () => {
       cache: "no-store",
     });
     const data2 = await res2.json();
-    expect(data2.count).toBe(2);
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(data2.count).toBe(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it("segment fetchCache default-no-store bypasses cache with metadata-only next options", async () => {
@@ -175,8 +180,8 @@ describe("fetch cache shim", () => {
       next: { tags: ["segment-default-no-store-tags"] },
     });
     const data2 = await res2.json();
-    expect(data2.count).toBe(2);
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(data2.count).toBe(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it("segment fetchCache force-no-store overrides explicit force-cache", async () => {
@@ -192,8 +197,8 @@ describe("fetch cache shim", () => {
       cache: "force-cache",
     });
     const data2 = await res2.json();
-    expect(data2.count).toBe(2);
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(data2.count).toBe(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it("segment fetchCache force-no-store forwards no-store to the real fetch", async () => {
@@ -253,8 +258,10 @@ describe("fetch cache shim", () => {
   });
 
   // ── No caching (no-store, revalidate: 0, revalidate: false) ─────────
+  // Ported from Next.js: test coverage for packages/next/src/server/lib/dedupe-fetch.test.ts
+  // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/dedupe-fetch.test.ts
 
-  it("cache: 'no-store' bypasses cache entirely", async () => {
+  it("cache: 'no-store' bypasses persistent cache but dedupes identical render fetches", async () => {
     const res1 = await fetch("https://api.example.com/nostore", {
       cache: "no-store",
     });
@@ -265,11 +272,11 @@ describe("fetch cache shim", () => {
       cache: "no-store",
     });
     const data2 = await res2.json();
-    expect(data2.count).toBe(2); // Fresh fetch each time
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(data2.count).toBe(1); // Same render fetch is deduped
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
-  it("next.revalidate: 0 skips caching", async () => {
+  it("next.revalidate: 0 bypasses persistent cache but dedupes identical render fetches", async () => {
     const res1 = await fetch("https://api.example.com/rev0", {
       next: { revalidate: 0 },
     });
@@ -280,11 +287,11 @@ describe("fetch cache shim", () => {
       next: { revalidate: 0 },
     });
     const data2 = await res2.json();
-    expect(data2.count).toBe(2); // Not cached
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(data2.count).toBe(1); // Same render fetch is deduped
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
-  it("next.revalidate: false skips caching", async () => {
+  it("next.revalidate: false bypasses persistent cache but dedupes identical render fetches", async () => {
     const res1 = await fetch("https://api.example.com/revfalse", {
       next: { revalidate: false },
     });
@@ -295,18 +302,109 @@ describe("fetch cache shim", () => {
       next: { revalidate: false },
     });
     const data2 = await res2.json();
-    expect(data2.count).toBe(2); // Not cached
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(data2.count).toBe(1); // Same render fetch is deduped
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
-  it("no cache or next options passes through without caching", async () => {
+  it("no cache or next options bypasses persistent cache but dedupes identical render fetches", async () => {
     const res1 = await fetch("https://api.example.com/passthrough");
     const data1 = await res1.json();
     expect(data1.count).toBe(1);
 
     const res2 = await fetch("https://api.example.com/passthrough");
     const data2 = await res2.json();
-    expect(data2.count).toBe(2); // Pass-through, no caching
+    expect(data2.count).toBe(1); // Same render fetch is deduped
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("no cache or next options do not dedupe across request scopes", async () => {
+    cleanup?.();
+    cleanup = null;
+
+    const data1 = await runWithFetchCache(async () => {
+      const res = await fetch("https://api.example.com/request-scoped-dedupe");
+      return await res.json();
+    });
+    const data2 = await runWithFetchCache(async () => {
+      const res = await fetch("https://api.example.com/request-scoped-dedupe");
+      return await res.json();
+    });
+
+    expect(data1.count).toBe(1);
+    expect(data2.count).toBe(2);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    cleanup = withFetchCache();
+  });
+
+  it("does not dedupe ordinary fetches outside a fetch-cache scope", async () => {
+    cleanup?.();
+    cleanup = null;
+
+    await fetch("https://api.example.com/outside-scope");
+    await fetch("https://api.example.com/outside-scope");
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    cleanup = withFetchCache();
+  });
+
+  it("dedupes identical uncached responses with independent response bodies", async () => {
+    const [res1, res2] = await Promise.all([
+      fetch("https://api.example.com/body-dedupe"),
+      fetch("https://api.example.com/body-dedupe"),
+    ]);
+
+    expect(await res1.json()).toEqual({
+      url: "https://api.example.com/body-dedupe",
+      count: 1,
+    });
+    expect(await res2.json()).toEqual({
+      url: "https://api.example.com/body-dedupe",
+      count: 1,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not dedupe uncached fetches with abort signals", async () => {
+    const controller = new AbortController();
+
+    await fetch("https://api.example.com/signal-dedupe", { signal: controller.signal });
+    await fetch("https://api.example.com/signal-dedupe", { signal: controller.signal });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not dedupe uncached fetches with side-effecting methods", async () => {
+    await fetch("https://api.example.com/post-dedupe", { method: "POST", body: "one" });
+    await fetch("https://api.example.com/post-dedupe", { method: "POST", body: "one" });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("dedupes uncached fetches across trace header differences only", async () => {
+    const [res1, res2] = await Promise.all([
+      fetch("https://api.example.com/trace-dedupe", {
+        headers: {
+          traceparent: "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01",
+          tracestate: "vendor=a",
+        },
+      }),
+      fetch("https://api.example.com/trace-dedupe", {
+        headers: {
+          traceparent: "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-cccccccccccccccc-01",
+          tracestate: "vendor=b",
+        },
+      }),
+    ]);
+
+    expect((await res1.json()).count).toBe(1);
+    expect((await res2.json()).count).toBe(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await fetch("https://api.example.com/trace-dedupe", {
+      headers: { "x-custom": "different" },
+    });
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
@@ -329,6 +427,7 @@ describe("fetch cache shim", () => {
 
     // Invalidate via tag
     await revalidateTag("posts");
+    startNewFetchCacheScope();
 
     // Should re-fetch after tag invalidation
     const res3 = await fetch("https://api.example.com/posts", {
@@ -351,6 +450,7 @@ describe("fetch cache shim", () => {
 
     // Invalidate only "posts"
     await revalidateTag("posts");
+    startNewFetchCacheScope();
 
     // Posts should re-fetch
     const postRes = await fetch("https://api.example.com/posts-tag", {
@@ -383,6 +483,7 @@ describe("fetch cache shim", () => {
     for (const [, entry] of store) {
       entry.revalidateAt = Date.now() - 1000; // Expired 1 second ago
     }
+    startNewFetchCacheScope();
 
     // Should return stale data immediately
     const res2 = await fetch("https://api.example.com/stale-test", {
@@ -427,6 +528,7 @@ describe("fetch cache shim", () => {
     for (const [, entry] of store) {
       entry.revalidateAt = Date.now() - 1000;
     }
+    startNewFetchCacheScope();
 
     const res2 = await fetch(makeRequest(), { next: { revalidate: 1 } });
     const data2 = await res2.json();
@@ -455,6 +557,7 @@ describe("fetch cache shim", () => {
       for (const [, entry] of store) {
         entry.revalidateAt = Date.now() - 1000;
       }
+      startNewFetchCacheScope();
 
       // Trigger stale hit — should fire background refetch via waitUntil
       const res2 = await fetch("https://api.example.com/waituntil-test", {
@@ -488,6 +591,7 @@ describe("fetch cache shim", () => {
         for (const [, entry] of store) {
           entry.revalidateAt = Date.now() - 1000;
         }
+        startNewFetchCacheScope();
 
         const res2 = await fetch("https://api.example.com/unified-waituntil-test", {
           next: { revalidate: 1 },
@@ -535,6 +639,7 @@ describe("fetch cache shim", () => {
     for (const [, entry] of store) {
       entry.revalidateAt = Date.now() - 1000;
     }
+    startNewFetchCacheScope();
 
     // Fire 5 concurrent stale hits — should all return stale data
     // but only trigger ONE background refetch
@@ -573,6 +678,7 @@ describe("fetch cache shim", () => {
     for (const [, entry] of store) {
       entry.revalidateAt = Date.now() - 1000;
     }
+    startNewFetchCacheScope();
 
     // First stale hit — triggers background refetch
     await fetch("https://api.example.com/dedup-cycle", {
@@ -585,6 +691,7 @@ describe("fetch cache shim", () => {
     for (const [, entry] of store) {
       entry.revalidateAt = Date.now() - 1000;
     }
+    startNewFetchCacheScope();
 
     // Second stale hit — should trigger a NEW background refetch
     // (the previous one completed and cleaned up)
@@ -613,6 +720,7 @@ describe("fetch cache shim", () => {
     for (const [, entry] of store) {
       entry.revalidateAt = Date.now() - 1000;
     }
+    startNewFetchCacheScope();
 
     // Stale hit — background refetch will fail
     const res = await fetch("https://api.example.com/dedup-error", {
@@ -629,6 +737,7 @@ describe("fetch cache shim", () => {
     for (const [, entry] of store) {
       entry.revalidateAt = Date.now() - 1000;
     }
+    startNewFetchCacheScope();
 
     // A new stale hit should trigger a fresh refetch (dedup entry was cleaned up)
     await fetch("https://api.example.com/dedup-error", {
@@ -710,6 +819,7 @@ describe("fetch cache shim", () => {
       for (const [, entry] of store) {
         entry.revalidateAt = Date.now() - 1000;
       }
+      startNewFetchCacheScope();
 
       // Stale hit — background refetch hangs
       await fetch("https://api.example.com/dedup-hang", {
@@ -721,6 +831,7 @@ describe("fetch cache shim", () => {
       for (const [, entry] of store) {
         entry.revalidateAt = Date.now() - 1000;
       }
+      startNewFetchCacheScope();
       await fetch("https://api.example.com/dedup-hang", {
         next: { revalidate: 1 },
       });
@@ -734,6 +845,7 @@ describe("fetch cache shim", () => {
       for (const [, entry] of store) {
         entry.revalidateAt = Date.now() - 1000;
       }
+      startNewFetchCacheScope();
 
       // New stale hit should trigger a fresh refetch
       await fetch("https://api.example.com/dedup-hang", {
@@ -773,6 +885,7 @@ describe("fetch cache shim", () => {
       for (const [, entry] of store) {
         entry.revalidateAt = Date.now() - 1000;
       }
+      startNewFetchCacheScope();
       await fetch("https://api.example.com/dedup-race", {
         next: { revalidate: 1 },
       });
@@ -788,6 +901,7 @@ describe("fetch cache shim", () => {
       for (const [, entry] of store) {
         entry.revalidateAt = Date.now() - 1000;
       }
+      startNewFetchCacheScope();
       await fetch("https://api.example.com/dedup-race", {
         next: { revalidate: 1 },
       });
@@ -813,6 +927,7 @@ describe("fetch cache shim", () => {
       for (const [, entry] of store) {
         entry.revalidateAt = Date.now() - 1000;
       }
+      startNewFetchCacheScope();
       await fetch("https://api.example.com/dedup-race", {
         next: { revalidate: 1 },
       });
@@ -934,6 +1049,8 @@ describe("fetch cache shim", () => {
     expect(data1.count).toBe(1);
 
     await revalidatePath("/posts/hello");
+    startNewFetchCacheScope();
+    setCurrentFetchSoftTags(["_N_T_/posts/hello"]);
 
     const res2 = await fetch("https://api.example.com/path-soft-tag", {
       next: { revalidate: 3600 },
@@ -959,6 +1076,7 @@ describe("fetch cache shim", () => {
     expect(res1.status).toBe(404);
 
     // Should re-fetch since 404 wasn't cached
+    startNewFetchCacheScope();
     const res2 = await fetch("https://api.example.com/missing-page", {
       next: { revalidate: 60 },
     });
@@ -1183,6 +1301,7 @@ describe("fetch cache shim", () => {
     for (const [, entry] of store) {
       entry.revalidateAt = Date.now() - 1000;
     }
+    startNewFetchCacheScope();
 
     // Should return stale
     const res3 = await fetch("https://api.example.com/force-ttl", {
@@ -1225,15 +1344,15 @@ describe("fetch cache shim", () => {
 
   // ── next: {} empty passes through ───────────────────────────────────
 
-  it("next: {} with no revalidate or tags passes through", async () => {
+  it("next: {} with no revalidate or tags bypasses persistent cache but dedupes render fetches", async () => {
     const res1 = await fetch("https://api.example.com/empty-next", { next: {} });
     const data1 = await res1.json();
     expect(data1.count).toBe(1);
 
     const res2 = await fetch("https://api.example.com/empty-next", { next: {} });
     const data2 = await res2.json();
-    expect(data2.count).toBe(2); // Not cached
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(data2.count).toBe(1); // Same render fetch is deduped
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   // ── Concurrent request isolation via ALS ─────────────────────────────
@@ -1364,8 +1483,8 @@ describe("fetch cache shim", () => {
         next: { tags: ["user-data"] },
       });
       const data2 = await res2.json();
-      expect(data2.count).toBe(2); // Not cached — safety bypass
-      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(data2.count).toBe(1); // Same render fetch is deduped
+      expect(fetchMock).toHaveBeenCalledTimes(1);
     });
 
     it("X-API-Key header is included in cache key", async () => {
@@ -1416,8 +1535,8 @@ describe("fetch cache shim", () => {
       cache: "no-cache" as RequestCache,
     });
     const data2 = await res2.json();
-    expect(data2.count).toBe(2); // Fresh fetch each time
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(data2.count).toBe(1); // Same render fetch is deduped
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it("cache: 'no-store' with auth headers bypasses cache", async () => {
@@ -1433,8 +1552,8 @@ describe("fetch cache shim", () => {
       headers: { Authorization: "Bearer token" },
     });
     const data2 = await res2.json();
-    expect(data2.count).toBe(2); // Always fresh
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(data2.count).toBe(1); // Same render fetch is deduped
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it("cache: 'no-cache' with auth headers bypasses cache", async () => {

--- a/tests/fixtures/app-basic/app/api/fetch-dedupe/route.ts
+++ b/tests/fixtures/app-basic/app/api/fetch-dedupe/route.ts
@@ -1,0 +1,13 @@
+export async function GET() {
+  const target = process.env.TEST_FETCH_DEDUPE_TARGET;
+  if (!target) {
+    return Response.json({ error: "missing TEST_FETCH_DEDUPE_TARGET" }, { status: 500 });
+  }
+
+  const first = await fetch(target, { cache: "no-store" });
+  const second = await fetch(target, { cache: "no-store" });
+  const firstBody = (await first.json()) as { count: number };
+  const secondBody = (await second.json()) as { count: number };
+
+  return Response.json({ counts: [firstBody.count, secondBody.count] });
+}

--- a/tests/fixtures/app-basic/app/fetch-dedupe-isr-metadata/loading.tsx
+++ b/tests/fixtures/app-basic/app/fetch-dedupe-isr-metadata/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <p>Loading ISR metadata fetch dedupe test...</p>;
+}

--- a/tests/fixtures/app-basic/app/fetch-dedupe-isr-metadata/page.tsx
+++ b/tests/fixtures/app-basic/app/fetch-dedupe-isr-metadata/page.tsx
@@ -1,0 +1,47 @@
+import type { Metadata } from "next";
+
+export const revalidate = 1;
+
+type CountBody = {
+  count: number;
+};
+
+function assertCountBody(value: unknown): CountBody {
+  if (
+    typeof value === "object" &&
+    value !== null &&
+    "count" in value &&
+    typeof value.count === "number"
+  ) {
+    return value;
+  }
+  throw new Error("Expected fetch target to return { count: number }");
+}
+
+async function fetchProduct(): Promise<CountBody> {
+  const target = process.env.TEST_FETCH_DEDUPE_TARGET;
+  if (!target) {
+    throw new Error("missing TEST_FETCH_DEDUPE_TARGET");
+  }
+
+  const response = await fetch(target, { cache: "no-store" });
+  return assertCountBody(await response.json());
+}
+
+export async function generateMetadata(): Promise<Metadata> {
+  const product = await fetchProduct();
+  return {
+    title: `ISR Product ${product.count}`,
+  };
+}
+
+export default async function FetchDedupeIsrMetadataPage() {
+  const product = await fetchProduct();
+
+  return (
+    <main>
+      <h1>Fetch Dedupe ISR Metadata</h1>
+      <p data-testid="fetch-dedupe-isr-metadata-count">{product.count}</p>
+    </main>
+  );
+}

--- a/tests/fixtures/app-basic/app/fetch-dedupe-metadata/loading.tsx
+++ b/tests/fixtures/app-basic/app/fetch-dedupe-metadata/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <p>Loading metadata fetch dedupe test...</p>;
+}

--- a/tests/fixtures/app-basic/app/fetch-dedupe-metadata/page.tsx
+++ b/tests/fixtures/app-basic/app/fetch-dedupe-metadata/page.tsx
@@ -1,0 +1,33 @@
+import type { Metadata } from "next";
+
+type CountBody = {
+  count: number;
+};
+
+async function fetchProduct(): Promise<CountBody> {
+  const target = process.env.TEST_FETCH_DEDUPE_TARGET;
+  if (!target) {
+    throw new Error("missing TEST_FETCH_DEDUPE_TARGET");
+  }
+
+  const response = await fetch(target, { cache: "no-store" });
+  return (await response.json()) as CountBody;
+}
+
+export async function generateMetadata(): Promise<Metadata> {
+  const product = await fetchProduct();
+  return {
+    title: `Product ${product.count}`,
+  };
+}
+
+export default async function FetchDedupeMetadataPage() {
+  const product = await fetchProduct();
+
+  return (
+    <main>
+      <h1>Fetch Dedupe Metadata</h1>
+      <p data-testid="fetch-dedupe-metadata-count">{product.count}</p>
+    </main>
+  );
+}

--- a/tests/fixtures/app-basic/app/fetch-dedupe-metadata/page.tsx
+++ b/tests/fixtures/app-basic/app/fetch-dedupe-metadata/page.tsx
@@ -4,6 +4,18 @@ type CountBody = {
   count: number;
 };
 
+function assertCountBody(value: unknown): CountBody {
+  if (
+    typeof value === "object" &&
+    value !== null &&
+    "count" in value &&
+    typeof value.count === "number"
+  ) {
+    return value;
+  }
+  throw new Error("Expected fetch target to return { count: number }");
+}
+
 async function fetchProduct(): Promise<CountBody> {
   const target = process.env.TEST_FETCH_DEDUPE_TARGET;
   if (!target) {
@@ -11,7 +23,7 @@ async function fetchProduct(): Promise<CountBody> {
   }
 
   const response = await fetch(target, { cache: "no-store" });
-  return (await response.json()) as CountBody;
+  return assertCountBody(await response.json());
 }
 
 export async function generateMetadata(): Promise<Metadata> {

--- a/tests/fixtures/app-basic/app/fetch-dedupe-render/loading.tsx
+++ b/tests/fixtures/app-basic/app/fetch-dedupe-render/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <p>Loading fetch dedupe test...</p>;
+}

--- a/tests/fixtures/app-basic/app/fetch-dedupe-render/page.tsx
+++ b/tests/fixtures/app-basic/app/fetch-dedupe-render/page.tsx
@@ -1,0 +1,18 @@
+export default async function FetchDedupeRenderPage() {
+  const target = process.env.TEST_FETCH_DEDUPE_TARGET;
+  if (!target) {
+    throw new Error("missing TEST_FETCH_DEDUPE_TARGET");
+  }
+
+  const first = await fetch(target, { cache: "no-store" });
+  const second = await fetch(target, { cache: "no-store" });
+  const firstBody = (await first.json()) as { count: number };
+  const secondBody = (await second.json()) as { count: number };
+
+  return (
+    <main>
+      <h1>Fetch Dedupe Render</h1>
+      <p data-testid="fetch-dedupe-counts">{JSON.stringify([firstBody.count, secondBody.count])}</p>
+    </main>
+  );
+}

--- a/tests/fixtures/app-basic/middleware.ts
+++ b/tests/fixtures/app-basic/middleware.ts
@@ -116,6 +116,19 @@ export async function middleware(request: NextRequest, event: NextFetchEvent) {
     return new Response("Event OK", { status: 200 });
   }
 
+  if (pathname === "/middleware-fetch-dedupe") {
+    const target = process.env.TEST_FETCH_DEDUPE_TARGET;
+    if (!target) {
+      return Response.json({ error: "missing TEST_FETCH_DEDUPE_TARGET" }, { status: 500 });
+    }
+
+    const first = await fetch(target, { cache: "no-store" });
+    const second = await fetch(target, { cache: "no-store" });
+    const firstBody = (await first.json()) as { count: number };
+    const secondBody = (await second.json()) as { count: number };
+    return Response.json({ counts: [firstBody.count, secondBody.count] });
+  }
+
   // Inject mw-before-user=1 cookie for beforeFiles rewrite gating test.
   // In App Router order, beforeFiles rewrites run after middleware, so they
   // should see this cookie. The /mw-gated-before rule in next.config.ts has:
@@ -274,6 +287,7 @@ export const config = {
     "/middleware-blocked",
     "/middleware-throw",
     "/middleware-event",
+    "/middleware-fetch-dedupe",
     "/search-query",
     "/headers/override-from-middleware",
     "/header-override-delete",


### PR DESCRIPTION
## What this changes

Adds render-scoped fetch deduplication beneath vinext's persistent fetch cache shim. Identical GET and HEAD fetches in React render scopes now share one upstream response, including uncached `no-store`, `no-cache`, and persistent-cache-miss fetches.

The important boundary is intentional: the generic App Router request context starts with fetch dedupe disabled. Dedupe is activated around the App Page render transaction, so `generateStaticParams` runtime validation, metadata resolution, element building, layouts/pages, and RSC render share one memoization map. Middleware, App Route Handlers, proxy/rewrite handling, static file handling, and the general request pipeline keep calling through normally unless persistent fetch caching itself applies.

## Why

vinext previously sent cache-bypass fetches straight to the captured original `fetch`, so repeated `fetch("/api/data")` calls from sibling Server Components could produce N identical upstream requests during one render. That diverges from Next.js request memoization.

Next.js also documents the inverse boundary: request memoization applies to the React Component tree and related render work such as `generateMetadata`, but does not apply to Route Handlers because Route Handlers are not part of that tree.

## Next.js references

- [`createDedupeFetch()` stores per-render entries through `React.cache()`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/dedupe-fetch.ts#L44-L126)
- [`patchFetch()` wraps `globalThis.fetch` with `createDedupeFetch()` before creating the patched fetcher](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/patch-fetch.ts#L1309-L1314)
- [`cloneResponse()` tees response bodies and registers stream cleanup instead of using native `Response.clone()`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/clone-response.ts#L26-L76)
- [Next.js caching docs: request memoization applies to the React Component tree, not Route Handlers](https://nextjs.org/docs/app/deep-dive/caching#request-memoization)
- [Next.js `generateMetadata` docs: `fetch` requests are automatically memoized across `generateMetadata`, `generateStaticParams`, Layouts, Pages, and Server Components](https://nextjs.org/docs/app/api-reference/functions/generate-metadata#good-to-know)
- [Next.js dedupe-fetch unit coverage for GET/HEAD, trace headers, signals, methods, Request and URL inputs, errors, and cloned response bodies](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/dedupe-fetch.test.ts)

## Approach

The dedupe key follows Next.js semantics: URL plus method, headers with `traceparent` and `tracestate` excluded, mode, redirect, credentials, referrer, referrerPolicy, and integrity. It deliberately opts out for caller-provided abort signals, `keepalive`, and side-effecting methods.

The implementation separates request context from render memoization:

- `createRequestContext()` defaults `isFetchDedupeActive` to `false`.
- `runWithFetchDedupe()` creates a fresh dedupe map only when no dedupe scope is already active; nested calls reuse the current render transaction map.
- `dispatchAppPage()` activates the render transaction around dynamic-param validation, intercept resolution, page element building, metadata resolution, and RSC render.
- `runAppPageRevalidationContext()` activates the same render transaction scope for stale background ISR regeneration, so metadata, page render, and nested helper calls share one dedupe map there too.
- Boundary-only render helpers still opt in directly for special error/not-found/forbidden/unauthorized rendering paths that do not pass through normal page dispatch.

The response cloning path now mirrors Next's `cloneResponse()` helper instead of native `Response.clone()`, which is safer for Node/undici stream cleanup while still working in Workers.

## Validation

- `vp check packages/vinext/src/server/app-page-dispatch.ts tests/app-router.test.ts tests/fixtures/app-basic/app/fetch-dedupe-isr-metadata/page.tsx tests/fixtures/app-basic/app/fetch-dedupe-isr-metadata/loading.tsx`
- `vp test run tests/app-router.test.ts -t "ISR background regeneration"`
- `vp test run tests/app-router.test.ts -t "fetches"`
- `vp test run tests/fetch-cache.test.ts`
- `vp test run tests/app-router.test.ts`
- commit hook: `vp check --fix`, `knip --no-progress`, package rebuild via `vp pack`

## Regression coverage

- App Route Handler: two identical `no-store` fetches make two upstream requests.
- Middleware: two identical `no-store` fetches make two upstream requests.
- App Page Server Component render: two identical `no-store` fetches make one upstream request and both consumers receive cloned bodies.
- `generateMetadata` plus App Page render: identical `no-store` fetches make one upstream request across both phases.
- Background ISR regeneration: stale regeneration dedupes identical `no-store` fetches across metadata and page render.
