### PR TITLE
feat(router): expose RouteManifest default and segment boundary facts

### DIFF
--- a/packages/vinext/src/routing/app-route-graph.ts
+++ b/packages/vinext/src/routing/app-route-graph.ts
@@ -234,8 +234,17 @@ export type RouteManifestSlot = {
   ownerTreePath: string;
   ownerLayoutId: string | null;
   rootBoundaryId: RootBoundaryId | null;
+  defaultId: string | null;
   hasDefault: boolean;
   hasPage: boolean;
+};
+
+export type RouteManifestDefault = {
+  id: string;
+  slotId: string;
+  ownerTreePath: string;
+  ownerLayoutId: string | null;
+  rootBoundaryId: RootBoundaryId | null;
 };
 
 export type RouteManifestSlotBindingState = "active" | "default" | "unmatched";
@@ -246,6 +255,7 @@ export type RouteManifestSlotBinding = {
   slotId: string;
   ownerLayoutId: string | null;
   state: RouteManifestSlotBindingState;
+  defaultId: string | null;
   routeSegments: readonly string[] | null;
   slotPatternParts?: readonly string[];
   slotParamNames?: readonly string[];
@@ -274,6 +284,7 @@ export type StaticSegmentGraph = {
   layouts: ReadonlyMap<string, RouteManifestLayout>;
   templates: ReadonlyMap<string, RouteManifestTemplate>;
   slots: ReadonlyMap<string, RouteManifestSlot>;
+  defaults: ReadonlyMap<string, RouteManifestDefault>;
   slotBindings: ReadonlyMap<string, RouteManifestSlotBinding>;
   boundaries: ReadonlyMap<string, RouteManifestBoundary>;
   rootBoundaries: ReadonlyMap<RootBoundaryId, RouteManifestRootBoundary>;
@@ -308,6 +319,10 @@ function createAppRouteGraphSlotId(slotName: string, ownerTreePath: string): str
   return `slot:${slotName}:${ownerTreePath}`;
 }
 
+function createAppRouteGraphDefaultId(slotId: string): string {
+  return `default:${slotId}`;
+}
+
 function createAppRouteGraphRootBoundaryId(treePath: string): RootBoundaryId {
   return `root-boundary:${treePath}`;
 }
@@ -340,6 +355,7 @@ function createStaticSegmentGraph(routes: readonly AppRouteGraphRoute[]): Static
   const layouts = new Map<string, RouteManifestLayout>();
   const templates = new Map<string, RouteManifestTemplate>();
   const slots = new Map<string, RouteManifestSlot>();
+  const defaults = new Map<string, RouteManifestDefault>();
   const slotBindings = new Map<string, RouteManifestSlotBinding>();
   const boundaries = new Map<string, RouteManifestBoundary>();
   const rootBoundaries = new Map<RootBoundaryId, RouteManifestRootBoundary>();
@@ -408,6 +424,8 @@ function createStaticSegmentGraph(routes: readonly AppRouteGraphRoute[]): Static
       }
     }
 
+    addRouteManifestSegmentErrorBoundaryFacts({ boundaries, route });
+
     for (const [index, templateId] of route.ids.templates.entries()) {
       const treePosition = route.templateTreePositions?.[index];
       assertRouteManifestTreePosition("template", route, templateId, treePosition);
@@ -436,6 +454,7 @@ function createStaticSegmentGraph(routes: readonly AppRouteGraphRoute[]): Static
 
     for (const slot of route.parallelSlots) {
       const ownerLayoutId = findSlotOwnerLayoutId(route, slot);
+      const defaultId = slot.defaultPath ? createAppRouteGraphDefaultId(slot.id) : null;
       slots.set(slot.id, {
         id: slot.id,
         key: slot.key,
@@ -443,10 +462,20 @@ function createStaticSegmentGraph(routes: readonly AppRouteGraphRoute[]): Static
         ownerTreePath: slot.ownerTreePath,
         ownerLayoutId,
         rootBoundaryId: ownerLayoutId ? route.ids.rootBoundary : null,
+        defaultId,
         hasDefault: slot.defaultPath !== null,
         hasPage: slot.hasPage,
       });
-      const binding = createRouteManifestSlotBinding(route, slot, ownerLayoutId);
+      if (defaultId) {
+        defaults.set(defaultId, {
+          id: defaultId,
+          slotId: slot.id,
+          ownerTreePath: slot.ownerTreePath,
+          ownerLayoutId,
+          rootBoundaryId: ownerLayoutId ? route.ids.rootBoundary : null,
+        });
+      }
+      const binding = createRouteManifestSlotBinding(route, slot, ownerLayoutId, defaultId);
       slotBindings.set(binding.id, binding);
     }
   }
@@ -458,6 +487,7 @@ function createStaticSegmentGraph(routes: readonly AppRouteGraphRoute[]): Static
     layouts,
     templates,
     slots,
+    defaults,
     slotBindings,
     boundaries,
     rootBoundaries,
@@ -484,13 +514,16 @@ function createRouteManifestSlotBinding(
   route: AppRouteGraphRoute,
   slot: AppRouteGraphParallelSlot,
   ownerLayoutId: string | null,
+  defaultId: string | null,
 ): RouteManifestSlotBinding {
+  const state = getRouteManifestSlotBindingState(slot);
   const binding: RouteManifestSlotBinding = {
     id: `${route.ids.route}::${slot.id}`,
     routeId: route.ids.route,
     slotId: slot.id,
     ownerLayoutId,
-    state: getRouteManifestSlotBindingState(slot),
+    state,
+    defaultId: state === "default" ? defaultId : null,
     routeSegments: slot.routeSegments ? [...slot.routeSegments] : null,
   };
 
@@ -529,11 +562,32 @@ function addRouteManifestBoundaryFacts(input: {
   );
 }
 
+function addRouteManifestSegmentErrorBoundaryFacts(input: {
+  boundaries: Map<string, RouteManifestBoundary>;
+  route: AppRouteGraphRoute;
+}): void {
+  for (const [index, boundaryPath] of (input.route.errorPaths ?? []).entries()) {
+    const treePosition = input.route.errorTreePositions?.[index];
+    assertRouteManifestBoundaryTreePosition(input.route, boundaryPath, treePosition);
+    const treePath = createAppRouteGraphTreePath(input.route.routeSegments, treePosition);
+    addRouteManifestBoundaryFact(
+      {
+        boundaries: input.boundaries,
+        route: input.route,
+        layoutId: findRouteManifestOwnerLayoutId(input.route, treePosition),
+        treePath,
+      },
+      "error",
+      boundaryPath,
+    );
+  }
+}
+
 function addRouteManifestBoundaryFact(
   input: {
     boundaries: Map<string, RouteManifestBoundary>;
     route: AppRouteGraphRoute;
-    layoutId: string;
+    layoutId: string | null;
     treePath: string;
   },
   outcome: RouteManifestBoundaryOutcome,
@@ -564,6 +618,18 @@ function assertRouteManifestTreePosition(
   );
 }
 
+function assertRouteManifestBoundaryTreePosition(
+  route: AppRouteGraphRoute,
+  boundaryPath: string,
+  treePosition: number | undefined,
+): asserts treePosition is number {
+  if (treePosition !== undefined) return;
+
+  throw new Error(
+    `[vinext] App route graph invariant violated: missing boundary tree position for ${boundaryPath} on ${route.pattern}`,
+  );
+}
+
 function assertRouteManifestRootBoundary(
   kind: "layout" | "template",
   route: AppRouteGraphRoute,
@@ -588,6 +654,7 @@ function createRouteManifestGraphVersion(segmentGraph: StaticSegmentGraph): Grap
     layouts: sortedMapValues(segmentGraph.layouts),
     templates: sortedMapValues(segmentGraph.templates),
     slots: sortedMapValues(segmentGraph.slots),
+    defaults: sortedMapValues(segmentGraph.defaults),
     slotBindings: sortedMapValues(segmentGraph.slotBindings),
     boundaries: sortedMapValues(segmentGraph.boundaries),
     rootBoundaries: sortedMapValues(segmentGraph.rootBoundaries),

--- a/packages/vinext/src/routing/app-route-graph.ts
+++ b/packages/vinext/src/routing/app-route-graph.ts
@@ -569,12 +569,15 @@ function addRouteManifestSegmentErrorBoundaryFacts(input: {
   for (const [index, boundaryPath] of (input.route.errorPaths ?? []).entries()) {
     const treePosition = input.route.errorTreePositions?.[index];
     assertRouteManifestBoundaryTreePosition(input.route, boundaryPath, treePosition);
+    const ownerLayoutId = findRouteManifestOwnerLayoutId(input.route, treePosition);
+    if (ownerLayoutId !== null) continue;
+
     const treePath = createAppRouteGraphTreePath(input.route.routeSegments, treePosition);
     addRouteManifestBoundaryFact(
       {
         boundaries: input.boundaries,
         route: input.route,
-        layoutId: findRouteManifestOwnerLayoutId(input.route, treePosition),
+        layoutId: ownerLayoutId,
         treePath,
       },
       "error",

--- a/tests/app-route-graph.test.ts
+++ b/tests/app-route-graph.test.ts
@@ -48,6 +48,7 @@ function snapshotRouteManifest(manifest: RouteManifest) {
     routeHandlers: Array.from(manifest.segmentGraph.routeHandlers.entries()),
     templates: Array.from(manifest.segmentGraph.templates.entries()),
     slots: Array.from(manifest.segmentGraph.slots.entries()),
+    defaults: Array.from(manifest.segmentGraph.defaults.entries()),
     slotBindings: Array.from(manifest.segmentGraph.slotBindings.entries()),
     boundaries: Array.from(manifest.segmentGraph.boundaries.entries()),
     rootBoundaries: Array.from(manifest.segmentGraph.rootBoundaries.entries()),
@@ -383,8 +384,16 @@ describe("App Router route graph builder", () => {
         ownerTreePath: "/(marketing)/blog/[slug]",
         ownerLayoutId: "layout:/(marketing)/blog/[slug]",
         rootBoundaryId: "root-boundary:/",
+        defaultId: "default:slot:modal:/(marketing)/blog/[slug]",
         hasDefault: true,
         hasPage: false,
+      });
+      expect(segmentGraph.defaults.get("default:slot:modal:/(marketing)/blog/[slug]")).toEqual({
+        id: "default:slot:modal:/(marketing)/blog/[slug]",
+        slotId: "slot:modal:/(marketing)/blog/[slug]",
+        ownerLayoutId: "layout:/(marketing)/blog/[slug]",
+        ownerTreePath: "/(marketing)/blog/[slug]",
+        rootBoundaryId: "root-boundary:/",
       });
       expect(segmentGraph.rootBoundaries.get("root-boundary:/")).toEqual({
         id: "root-boundary:/",
@@ -464,6 +473,7 @@ describe("App Router route graph builder", () => {
         ownerTreePath: "/(marketing)/dashboard",
         ownerLayoutId: "layout:/(marketing)/dashboard",
         rootBoundaryId: "root-boundary:/(marketing)",
+        defaultId: "default:slot:analytics:/(marketing)/dashboard",
         hasDefault: true,
         hasPage: false,
       });
@@ -471,8 +481,16 @@ describe("App Router route graph builder", () => {
         ownerTreePath: "/(marketing)/dashboard",
         ownerLayoutId: "layout:/(marketing)/dashboard",
         rootBoundaryId: "root-boundary:/(marketing)",
+        defaultId: "default:slot:modal:/(marketing)/dashboard",
         hasDefault: true,
         hasPage: true,
+      });
+      expect(segmentGraph.defaults.get("default:slot:analytics:/(marketing)/dashboard")).toEqual({
+        id: "default:slot:analytics:/(marketing)/dashboard",
+        slotId: "slot:analytics:/(marketing)/dashboard",
+        ownerLayoutId: "layout:/(marketing)/dashboard",
+        ownerTreePath: "/(marketing)/dashboard",
+        rootBoundaryId: "root-boundary:/(marketing)",
       });
 
       expect(
@@ -483,6 +501,7 @@ describe("App Router route graph builder", () => {
         slotId: "slot:analytics:/(marketing)/dashboard",
         ownerLayoutId: "layout:/(marketing)/dashboard",
         state: "default",
+        defaultId: "default:slot:analytics:/(marketing)/dashboard",
         routeSegments: null,
       });
       expect(
@@ -493,6 +512,7 @@ describe("App Router route graph builder", () => {
         slotId: "slot:modal:/(marketing)/dashboard",
         ownerLayoutId: "layout:/(marketing)/dashboard",
         state: "active",
+        defaultId: null,
         routeSegments: [],
       });
       expect(
@@ -505,6 +525,7 @@ describe("App Router route graph builder", () => {
         slotId: "slot:modal:/(marketing)/dashboard",
         ownerLayoutId: "layout:/(marketing)/dashboard",
         state: "active",
+        defaultId: null,
         routeSegments: ["settings"],
       });
 
@@ -556,6 +577,27 @@ describe("App Router route graph builder", () => {
         treePath: "/(marketing)/dashboard",
         ownerLayoutId: "layout:/(marketing)/dashboard",
         rootBoundaryId: "root-boundary:/(marketing)",
+      });
+    });
+  });
+
+  it("exposes segment error boundary facts even when the segment has no sibling layout", async () => {
+    await withTempApp(async (appDir) => {
+      await writeAppFile(appDir, "layout.tsx", EMPTY_LAYOUT);
+      await writeAppFile(appDir, "docs/(group)/error.tsx", EMPTY_PAGE);
+      await writeAppFile(appDir, "docs/(group)/child/page.tsx", EMPTY_PAGE);
+
+      const graph = await buildAppRouteGraph(appDir, createValidFileMatcher());
+      const boundary = graph.routeManifest.segmentGraph.boundaries.get(
+        "boundary:error:/docs/(group)",
+      );
+
+      expect(boundary).toEqual({
+        id: "boundary:error:/docs/(group)",
+        outcome: "error",
+        treePath: "/docs/(group)",
+        ownerLayoutId: null,
+        rootBoundaryId: "root-boundary:/",
       });
     });
   });

--- a/tests/app-route-graph.test.ts
+++ b/tests/app-route-graph.test.ts
@@ -599,6 +599,7 @@ describe("App Router route graph builder", () => {
         ownerLayoutId: null,
         rootBoundaryId: "root-boundary:/",
       });
+      expect(graph.routeManifest.segmentGraph.boundaries.has("boundary:error:/docs")).toBe(false);
     });
   });
 


### PR DESCRIPTION
## What this changes

Implements the remaining RouteManifest facts for task `#726-GRAPH-04/06` from issue #726.

- Adds graph-owned `RouteManifestDefault` entries keyed from semantic slot IDs.
- Threads `defaultId` through slot declarations and default-rendering slot bindings so later planner work can prove when a slot default is the visible fallback.
- Exposes segment-level error boundary facts even when a route-group segment has no sibling layout.
- Includes defaults and the newly exposed boundaries in the RouteManifest `graphVersion` canonical shape.

## Why

Issue #726 is moving App Router meaning out of flat wire-key absence and into explicit graph facts. The previous RouteManifest slice exposed slot ownership, template reset, and layout-aligned boundary facts, but two meanings were still implicit:

- slot defaults were mostly represented by `hasDefault` booleans, with no graph-owned default entry to reference from planner decisions;
- error boundaries discovered for route-group segments without layouts existed on `AppRouteGraphRoute`, but were not materialized into `StaticSegmentGraph.boundaries`.

Both gaps matter for future slot/default and boundary semantic promotion. A planner should be able to prove these facts from the manifest, not infer them from file payload shape or missing wire entries.

## Approach

- Keep this as a RouteManifest facts-only PR. It does not promote planner behavior, slot preservation, template reset behavior, or cache decisions.
- Use stable constructors derived from existing semantic IDs, for example `default:${slotId}`.
- Preserve the existing boundary fact shape and allow `ownerLayoutId: null` for layoutless segment boundaries.
- Keep graphVersion deterministic by adding the defaults map to the canonical manifest hash input.

Bonk: please read issue #726 to see the big picture before reviewing this PR. This is the `#726-GRAPH-04/06` facts slice, not a planner promotion PR.

## Validation

- `vp test run tests/app-route-graph.test.ts`
- `vp test run tests/app-route-graph.test.ts tests/routing.test.ts`
- `vp check packages/vinext/src/routing/app-route-graph.ts tests/app-route-graph.test.ts`
- `vp run vinext#build`

Also ran full `vp check`; it exited 0 and reported one existing warning in `packages/vinext/src/server/request-pipeline.ts` for `unknown | undefined`, unrelated to this diff.

## Risks / follow-ups

- This changes the exported `RouteManifest` read model and graphVersion for apps with slot defaults or segment error boundaries.
- Runtime rendering behavior is intentionally unchanged.
- Planner ownership of slot/default/template/boundary behavior remains a later #726 layer.
