### PR TITLE
feat(cache): export stable `io` from next/cache, deprecate `unstable_io`

### DIFF
--- a/packages/vinext/src/check.ts
+++ b/packages/vinext/src/check.ts
@@ -85,7 +85,7 @@ const IMPORT_SUPPORT: Record<string, { status: Status; detail?: string }> = {
   "next/server": { status: "supported", detail: "NextRequest/NextResponse shimmed" },
   "next/cache": {
     status: "supported",
-    detail: "revalidateTag, revalidatePath, unstable_cache, unstable_io, cacheLife, cacheTag",
+    detail: "revalidateTag, revalidatePath, unstable_cache, io, cacheLife, cacheTag",
   },
   "next/dynamic": { status: "supported" },
   "next/head": { status: "supported" },

--- a/packages/vinext/src/server/prerender-work-unit-setup.ts
+++ b/packages/vinext/src/server/prerender-work-unit-setup.ts
@@ -2,7 +2,7 @@
  * Sets up the work unit async storage for prerendering.
  *
  * When VINEXT_PRERENDER=1, wraps execution in a workUnitAsyncStorage.run()
- * with a PrerenderStore so that dynamic APIs (e.g., unstable_io()) can
+ * with a PrerenderStore so that dynamic APIs (e.g., io()) can
  * detect the prerender context and return hanging promises.
  *
  * Used by: app-rsc-entry.ts handler template.

--- a/packages/vinext/src/shims/cache.ts
+++ b/packages/vinext/src/shims/cache.ts
@@ -468,6 +468,7 @@ const _resolvedIOPromise: Promise<void> = Promise.resolve(undefined);
  *
  * See: https://github.com/vercel/next.js/pull/92521
  * Guard removed: https://github.com/vercel/next.js/pull/92923
+ * Stabilized (renamed from unstable_io): https://github.com/vercel/next.js/pull/93621
  *
  * Ported from Next.js: packages/next/src/server/request/io.ts
  * https://github.com/vercel/next.js/blob/canary/packages/next/src/server/request/io.ts
@@ -484,7 +485,7 @@ const _resolvedIOPromise: Promise<void> = Promise.resolve(undefined);
  * When no work unit store is present (e.g. client-side, standalone script),
  * resolves immediately — matching the browser/client implementation.
  */
-export function unstable_io(): Promise<void> {
+export function io(): Promise<void> {
   const workUnitStore = workUnitAsyncStorage.getStore();
 
   if (workUnitStore) {
@@ -500,7 +501,7 @@ export function unstable_io(): Promise<void> {
         return makeHangingPromise(
           workUnitStore.renderSignal,
           /* route */ workUnitStore.route ?? "unknown",
-          "`unstable_io()`",
+          "`io()`",
         );
       case "cache":
       case "private-cache":
@@ -517,6 +518,23 @@ export function unstable_io(): Promise<void> {
   // No work store — outside rendering context (client, standalone script).
   return _resolvedIOPromise;
 }
+
+/**
+ * @deprecated Use `io` instead. Kept as a transitional alias since vinext
+ * shipped the unstable name longer than upstream Next.js (see #805). Will be
+ * removed in a future minor.
+ */
+export function unstable_io(): Promise<void> {
+  if (!_unstableIoWarned) {
+    _unstableIoWarned = true;
+    console.warn(
+      "[vinext] `unstable_io` is deprecated. Import `io` from 'next/cache' instead.",
+    );
+  }
+  return io();
+}
+
+let _unstableIoWarned = false;
 
 // ---------------------------------------------------------------------------
 // Request-scoped cacheLife for page-level "use cache" directives.

--- a/packages/vinext/src/shims/cache.ts
+++ b/packages/vinext/src/shims/cache.ts
@@ -527,9 +527,7 @@ export function io(): Promise<void> {
 export function unstable_io(): Promise<void> {
   if (!_unstableIoWarned) {
     _unstableIoWarned = true;
-    console.warn(
-      "[vinext] `unstable_io` is deprecated. Import `io` from 'next/cache' instead.",
-    );
+    console.warn("[vinext] `unstable_io` is deprecated. Import `io` from 'next/cache' instead.");
   }
   return io();
 }

--- a/packages/vinext/src/shims/internal/make-hanging-promise.ts
+++ b/packages/vinext/src/shims/internal/make-hanging-promise.ts
@@ -1,7 +1,7 @@
 /**
  * makeHangingPromise — returns a promise that never resolves during prerendering.
  *
- * When prerendering, `unstable_io()` must return a hanging promise to prevent
+ * When prerendering, `io()` must return a hanging promise to prevent
  * React from executing past the IO boundary. The promise never resolves—it only
  * rejects if the render signal is aborted (e.g., due to a dynamic error or
  * cache-fill completion).

--- a/packages/vinext/src/shims/internal/work-unit-async-storage.ts
+++ b/packages/vinext/src/shims/internal/work-unit-async-storage.ts
@@ -3,11 +3,11 @@
  * and next/dist/client/components/request-async-storage.external
  *
  * Tracks the current rendering context type so that dynamic APIs
- * (unstable_io, headers, cookies, etc.) can branch on whether they're
+ * (io, headers, cookies, etc.) can branch on whether they're
  * inside a request, prerender, cache scope, or other context.
  *
  * Used by: @sentry/nextjs (runtime resolve for request context injection),
- * unstable_io() for hanging-promise behavior during prerendering.
+ * io() for hanging-promise behavior during prerendering.
  */
 import { AsyncLocalStorage } from "node:async_hooks";
 

--- a/packages/vinext/src/shims/next-shims.d.ts
+++ b/packages/vinext/src/shims/next-shims.d.ts
@@ -521,6 +521,8 @@ declare module "next/cache" {
   ): T;
   export function unstable_noStore(): void;
   export function noStore(): void;
+  export function io(): Promise<void>;
+  /** @deprecated Use `io` instead. */
   export function unstable_io(): Promise<void>;
 
   // "use cache" APIs (Next.js 15+)

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -1895,31 +1895,31 @@ describe("next/cache shim", () => {
 
   // Ported from Next.js: packages/next/src/client/request/io.browser.ts
   // https://github.com/vercel/next.js/blob/canary/packages/next/src/client/request/io.browser.ts
-  it("exports unstable_io function", async () => {
+  it("exports io function", async () => {
     const mod = await import("../packages/vinext/src/shims/cache.js");
-    expect(typeof mod.unstable_io).toBe("function");
+    expect(typeof mod.io).toBe("function");
   });
 
-  it("unstable_io returns a resolved promise", async () => {
-    const { unstable_io } = await import("../packages/vinext/src/shims/cache.js");
-    const result = unstable_io();
+  it("io returns a resolved promise", async () => {
+    const { io } = await import("../packages/vinext/src/shims/cache.js");
+    const result = io();
     expect(result).toBeInstanceOf(Promise);
     expect((result as any).status).toBe("fulfilled");
     expect((result as any).value).toBeUndefined();
     await expect(result).resolves.toBeUndefined();
   });
 
-  it("unstable_io returns same instance (singleton)", async () => {
-    const { unstable_io } = await import("../packages/vinext/src/shims/cache.js");
-    const r1 = unstable_io();
-    const r2 = unstable_io();
+  it("io returns same instance (singleton)", async () => {
+    const { io } = await import("../packages/vinext/src/shims/cache.js");
+    const r1 = io();
+    const r2 = io();
     expect(r1).toBe(r2);
   });
 
   // Ported from Next.js: packages/next/src/server/request/io.ts
   // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/request/io.ts
-  it("unstable_io returns a hanging promise during prerender", async () => {
-    const { unstable_io } = await import("../packages/vinext/src/shims/cache.js");
+  it("io returns a hanging promise during prerender", async () => {
+    const { io } = await import("../packages/vinext/src/shims/cache.js");
     const { workUnitAsyncStorage } =
       await import("../packages/vinext/src/shims/internal/work-unit-async-storage.js");
 
@@ -1928,7 +1928,7 @@ describe("next/cache shim", () => {
     // run() returns whatever the callback returns — a hanging promise.
     const hanging = workUnitAsyncStorage.run(
       { type: "prerender", renderSignal: controller.signal },
-      unstable_io,
+      io,
     );
 
     // The promise should not be resolved or rejected (it's "hanging")
@@ -1945,30 +1945,30 @@ describe("next/cache shim", () => {
     controller.abort();
   });
 
-  it("unstable_io resolves immediately with request store", async () => {
-    const { unstable_io } = await import("../packages/vinext/src/shims/cache.js");
+  it("io resolves immediately with request store", async () => {
+    const { io } = await import("../packages/vinext/src/shims/cache.js");
     const { workUnitAsyncStorage } =
       await import("../packages/vinext/src/shims/internal/work-unit-async-storage.js");
 
-    const promise = workUnitAsyncStorage.run({ type: "request" }, unstable_io);
+    const promise = workUnitAsyncStorage.run({ type: "request" }, io);
 
     expect(promise).toBeInstanceOf(Promise);
     await expect(promise).resolves.toBeUndefined();
   });
 
-  it("unstable_io resolves immediately with cache store", async () => {
-    const { unstable_io } = await import("../packages/vinext/src/shims/cache.js");
+  it("io resolves immediately with cache store", async () => {
+    const { io } = await import("../packages/vinext/src/shims/cache.js");
     const { workUnitAsyncStorage } =
       await import("../packages/vinext/src/shims/internal/work-unit-async-storage.js");
 
-    const promise = workUnitAsyncStorage.run({ type: "cache" }, unstable_io);
+    const promise = workUnitAsyncStorage.run({ type: "cache" }, io);
 
     expect(promise).toBeInstanceOf(Promise);
     await expect(promise).resolves.toBeUndefined();
   });
 
-  it("unstable_io rejects hanging promise on abort when prerendering", async () => {
-    const { unstable_io } = await import("../packages/vinext/src/shims/cache.js");
+  it("io rejects hanging promise on abort when prerendering", async () => {
+    const { io } = await import("../packages/vinext/src/shims/cache.js");
     const { workUnitAsyncStorage } =
       await import("../packages/vinext/src/shims/internal/work-unit-async-storage.js");
 
@@ -1976,18 +1976,18 @@ describe("next/cache shim", () => {
 
     const hanging = workUnitAsyncStorage.run(
       { type: "prerender", renderSignal: controller.signal },
-      unstable_io,
+      io,
     );
 
     expect(hanging).toBeInstanceOf(Promise);
 
     // Abort the signal — the hanging promise should reject
     controller.abort();
-    await expect(hanging).rejects.toThrow(/unstable_io/i);
+    await expect(hanging).rejects.toThrow(/`io\(\)`/);
   });
 
-  it("unstable_io returns rejected promise when signal already aborted", async () => {
-    const { unstable_io } = await import("../packages/vinext/src/shims/cache.js");
+  it("io returns rejected promise when signal already aborted", async () => {
+    const { io } = await import("../packages/vinext/src/shims/cache.js");
     const { workUnitAsyncStorage } =
       await import("../packages/vinext/src/shims/internal/work-unit-async-storage.js");
 
@@ -1996,14 +1996,14 @@ describe("next/cache shim", () => {
 
     const promise = workUnitAsyncStorage.run(
       { type: "prerender", renderSignal: controller.signal },
-      unstable_io,
+      io,
     );
 
     await expect(promise).rejects.toThrow(/prerendering/i);
   });
 
-  it("unstable_io does not emit unhandled rejection when signal already aborted", async () => {
-    const { unstable_io } = await import("../packages/vinext/src/shims/cache.js");
+  it("io does not emit unhandled rejection when signal already aborted", async () => {
+    const { io } = await import("../packages/vinext/src/shims/cache.js");
     const { workUnitAsyncStorage } =
       await import("../packages/vinext/src/shims/internal/work-unit-async-storage.js");
 
@@ -2019,7 +2019,7 @@ describe("next/cache shim", () => {
 
       const promise = workUnitAsyncStorage.run(
         { type: "prerender", renderSignal: controller.signal, route: "/test" },
-        unstable_io,
+        io,
       );
 
       // Wait a tick for potential unhandled rejection to be detected
@@ -2035,6 +2035,25 @@ describe("next/cache shim", () => {
       expect(unhandledRejections.length).toBe(0);
     } finally {
       process.off("unhandledRejection", onUnhandledRejection);
+    }
+  });
+
+  it("unstable_io is exported as a deprecation alias for io", async () => {
+    const mod = await import("../packages/vinext/src/shims/cache.js");
+    expect(typeof mod.unstable_io).toBe("function");
+
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const result = mod.unstable_io();
+      expect(result).toBeInstanceOf(Promise);
+      await expect(result).resolves.toBeUndefined();
+      // Warning fires at most once per process; at least one call must mention deprecation.
+      const warned = warn.mock.calls.some((args) =>
+        String(args[0] ?? "").includes("unstable_io"),
+      );
+      expect(warned).toBe(true);
+    } finally {
+      warn.mockRestore();
     }
   });
 

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -2048,9 +2048,7 @@ describe("next/cache shim", () => {
       expect(result).toBeInstanceOf(Promise);
       await expect(result).resolves.toBeUndefined();
       // Warning fires at most once per process; at least one call must mention deprecation.
-      const warned = warn.mock.calls.some((args) =>
-        String(args[0] ?? "").includes("unstable_io"),
-      );
+      const warned = warn.mock.calls.some((args) => String(args[0] ?? "").includes("unstable_io"));
       expect(warned).toBe(true);
     } finally {
       warn.mockRestore();


### PR DESCRIPTION
## Summary

- Export `io` from vinext's `next/cache` shim, mirroring the upstream stabilization in [vercel/next.js#93621](https://github.com/vercel/next.js/pull/93621).
- Keep `unstable_io` as a transitional alias that emits a one-time `console.warn`. Upstream dropped the unstable name outright (it only shipped in canaries), but vinext shipped it for longer (since #805), so a soft deprecation is safer.
- Update the TypeScript declaration in `shims/next-shims.d.ts` to expose `io()` and mark `unstable_io()` as `@deprecated`.
- Rename internal doc comments referring to `unstable_io()` to `io()`.

Closes #1139.

## Test plan

- [x] `vp test run tests/shims.test.ts -t "io"` — 9 io tests pass (8 ported from `unstable_io`, plus a new test asserting `unstable_io` still works and warns).
- [x] `tsc --noEmit` clean.
- [ ] Smoke-test an example app importing `import { io } from 'next/cache'`.