### PR TITLE
fix(cache): encode non-ASCII characters in cache tags at construction

### DIFF
--- a/packages/vinext/src/server/app-page-cache.ts
+++ b/packages/vinext/src/server/app-page-cache.ts
@@ -4,6 +4,7 @@ import { buildCachedRevalidateCacheControl } from "./cache-control.js";
 import { buildAppPageCacheValue, type ISRCacheEntry } from "./isr-cache.js";
 import { mergeMiddlewareResponseHeaders } from "./middleware-response-headers.js";
 import { readStreamAsText } from "../utils/text-stream.js";
+import { encodeCacheTag } from "../utils/encode-cache-tag.js";
 
 type AppPageDebugLogger = (event: string, detail: string) => void;
 type AppPageCacheGetter = (key: string) => Promise<ISRCacheEntry | null>;
@@ -110,7 +111,10 @@ export function buildAppPageCacheTags(pathname: string, extraTags: readonly stri
       tags.push(tag);
     }
   }
-  return tags;
+  // Canonicalise to ASCII-safe form so path-derived tags from non-ASCII
+  // pathnames match what `revalidatePath`/`revalidateTag` produce after
+  // their own encoding pass.
+  return tags.map(encodeCacheTag);
 }
 
 function buildAppPageCacheControl(

--- a/packages/vinext/src/server/implicit-tags.ts
+++ b/packages/vinext/src/server/implicit-tags.ts
@@ -1,3 +1,5 @@
+import { encodeCacheTag } from "../utils/encode-cache-tag.js";
+
 const NEXT_CACHE_IMPLICIT_TAG_ID = "_N_T_";
 
 type AppCacheLeafKind = "page" | "route";
@@ -58,5 +60,8 @@ export function buildPageCacheTags(
     appendUnique(tags, tag);
   }
 
-  return tags;
+  // Canonicalise to ASCII-safe form so path-derived tags from non-ASCII
+  // pathnames (e.g. `/שלום`) match what `revalidatePath`/`revalidateTag`
+  // produce after their own encoding pass.
+  return tags.map(encodeCacheTag);
 }

--- a/packages/vinext/src/shims/cache.ts
+++ b/packages/vinext/src/shims/cache.ts
@@ -28,6 +28,7 @@ import {
 import { workUnitAsyncStorage } from "./internal/work-unit-async-storage.js";
 import { makeHangingPromise } from "./internal/make-hanging-promise.js";
 import { readCacheControlNumberField } from "../utils/cache-control-metadata.js";
+import { encodeCacheTag, encodeCacheTags } from "../utils/encode-cache-tag.js";
 
 // ---------------------------------------------------------------------------
 // Lazy accessor for cache context — avoids circular imports with cache-runtime.
@@ -395,7 +396,7 @@ export async function revalidateTag(
   if (!profile || !durations || durations.expire === 0) {
     markActionRevalidation(ACTION_DID_REVALIDATE_STATIC_AND_DYNAMIC);
   }
-  await _getActiveHandler().revalidateTag(tag, durations);
+  await _getActiveHandler().revalidateTag(encodeCacheTag(tag), durations);
 }
 
 /**
@@ -418,7 +419,7 @@ export async function revalidatePath(path: string, type?: "page" | "layout"): Pr
   // Strip trailing slash so root "/" becomes "" — avoids double-slash in _N_T_//layout
   const stem = path.endsWith("/") ? path.slice(0, -1) : path;
   const tag = type ? `_N_T_${stem}/${type}` : `_N_T_${stem || "/"}`;
-  await _getActiveHandler().revalidateTag(tag);
+  await _getActiveHandler().revalidateTag(encodeCacheTag(tag));
 }
 
 /**
@@ -443,7 +444,7 @@ export function refresh(): void {
 export async function updateTag(tag: string): Promise<void> {
   markActionRevalidation(ACTION_DID_REVALIDATE_STATIC_AND_DYNAMIC);
   // Expire the tag immediately (same as revalidateTag without SWR)
-  await _getActiveHandler().revalidateTag(tag);
+  await _getActiveHandler().revalidateTag(encodeCacheTag(tag));
 }
 
 /**
@@ -791,7 +792,7 @@ export function cacheTag(...tags: string[]): void {
   try {
     const ctx = _getCacheContextFn?.();
     if (ctx) {
-      ctx.tags.push(...tags);
+      ctx.tags.push(...encodeCacheTags(tags));
     }
   } catch {
     // Not in a cache context — no-op
@@ -945,7 +946,7 @@ export function unstable_cache<T extends (...args: any[]) => Promise<any>>(
   // different functions may hash to the same key, or the same function may
   // hash differently across builds. Always pass explicit keyParts in
   // production to get a stable, collision-free cache key.
-  const tags = options?.tags ?? [];
+  const tags = encodeCacheTags(options?.tags ?? []);
   const revalidateSeconds = options?.revalidate;
 
   const cachedFn = async (...args: Parameters<T>) => {

--- a/packages/vinext/src/shims/fetch-cache.ts
+++ b/packages/vinext/src/shims/fetch-cache.ts
@@ -20,6 +20,7 @@
  */
 
 import { getCacheHandler, type CachedFetchValue } from "./cache.js";
+import { encodeCacheTags } from "../utils/encode-cache-tag.js";
 import { getOrCreateAls } from "./internal/als-registry.js";
 import { getRequestExecutionContext } from "./request-context.js";
 import {
@@ -697,7 +698,7 @@ function createPatchedFetch(): typeof globalThis.fetch {
       }
     }
 
-    const tags = nextOpts?.tags ?? [];
+    const tags = encodeCacheTags(nextOpts?.tags ?? []);
     const softTags = _getState().currentFetchSoftTags;
     let fetchInit = stripNextFromInit(init, cacheDirective);
     let cacheKey: string;

--- a/packages/vinext/src/utils/encode-cache-tag.ts
+++ b/packages/vinext/src/utils/encode-cache-tag.ts
@@ -1,0 +1,38 @@
+/**
+ * Cache-tag canonicalisation.
+ *
+ * Tags can flow into HTTP headers (e.g. `x-next-cache-tags` on ISR responses,
+ * Cloudflare cache-tag headers, downstream Worker code) where Node's
+ * `validateHeaderValue` rejects any byte outside `\t\x20-\x7e` and crashes
+ * the response with `ERR_INVALID_CHAR`. Even on platforms with permissive
+ * header setters, divergence between storage form and wire form silently
+ * breaks invalidation when a `revalidateTag` call's tag does not byte-match
+ * the form that was stored.
+ *
+ * The fix is to apply this encoding at every public boundary so storage,
+ * comparison, and the wire all see the same ASCII-safe form. The fast-path
+ * returns the input unchanged for already-ASCII tags (the common case), so
+ * pre-encoded `%xx` input round-trips losslessly without `decodeURIComponent`
+ * mangling literal `%xx` characters.
+ *
+ * The replacement matches *runs* of out-of-class code units rather than each
+ * code unit individually so surrogate pairs (emoji, non-BMP characters) are
+ * handed to `encodeURIComponent` as a complete code point — a per-code-unit
+ * regex would split the pair and throw `URIError`.
+ *
+ * Mirrors Next.js's `packages/next/src/server/lib/encode-cache-tag.ts`
+ * (introduced in vercel/next.js#93601).
+ */
+
+const OUT_OF_CLASS_CHAR = /[^\t\x20-\x7e]/;
+const OUT_OF_CLASS_RUN = /[^\t\x20-\x7e]+/g;
+
+export function encodeCacheTag(tag: string): string {
+  return OUT_OF_CLASS_CHAR.test(tag)
+    ? tag.replace(OUT_OF_CLASS_RUN, (run) => encodeURIComponent(run))
+    : tag;
+}
+
+export function encodeCacheTags(tags: readonly string[]): string[] {
+  return tags.map(encodeCacheTag);
+}

--- a/tests/encode-cache-tag.test.ts
+++ b/tests/encode-cache-tag.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vite-plus/test";
+import { encodeCacheTag, encodeCacheTags } from "../packages/vinext/src/utils/encode-cache-tag.js";
+import { buildPageCacheTags } from "../packages/vinext/src/server/implicit-tags.js";
+import { buildAppPageCacheTags } from "../packages/vinext/src/server/app-page-cache.js";
+
+// Regression: cloudflare/vinext#1138 — non-ASCII cache tags must be encoded at
+// construction so storage, comparison, and any downstream HTTP header
+// (`x-next-cache-tags`, Cloudflare cache-tag) see the same ASCII-safe form.
+// Mirrors vercel/next.js#93601.
+describe("encodeCacheTag", () => {
+  it("returns ASCII tags unchanged (fast path)", () => {
+    expect(encodeCacheTag("posts")).toBe("posts");
+    expect(encodeCacheTag("_N_T_/blog/[slug]/page")).toBe("_N_T_/blog/[slug]/page");
+    expect(encodeCacheTag("")).toBe("");
+  });
+
+  it("percent-encodes non-ASCII runs", () => {
+    expect(encodeCacheTag("שלום-עולם")).toBe("%D7%A9%D7%9C%D7%95%D7%9D-%D7%A2%D7%95%D7%9C%D7%9D");
+    expect(encodeCacheTag("مرحبا")).toBe("%D9%85%D8%B1%D8%AD%D8%A8%D8%A7");
+    expect(encodeCacheTag("こんにちは")).toBe("%E3%81%93%E3%82%93%E3%81%AB%E3%81%A1%E3%81%AF");
+  });
+
+  it("handles surrogate pairs (emoji / non-BMP) without URIError", () => {
+    // 🎉 is U+1F389 — a surrogate pair in UTF-16. A naive per-code-unit
+    // regex would split the pair and `encodeURIComponent` would throw.
+    expect(() => encodeCacheTag("party-🎉")).not.toThrow();
+    expect(encodeCacheTag("party-🎉")).toBe("party-%F0%9F%8E%89");
+  });
+
+  it("preserves literal %xx sequences in already-encoded input", () => {
+    // The fast path leaves ASCII input alone, so pre-encoded tags round-trip
+    // losslessly without double-encoding the percent sign.
+    expect(encodeCacheTag("100%25-off")).toBe("100%25-off");
+    expect(encodeCacheTag("%D7%A9%D7%9C%D7%95%D7%9D")).toBe("%D7%A9%D7%9C%D7%95%D7%9D");
+  });
+
+  it("preserves tab and printable ASCII (\\x20-\\x7e)", () => {
+    const printable = "\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCXYZ[\\]^_`abcxyz{|}~";
+    expect(encodeCacheTag(printable)).toBe(printable);
+  });
+
+  it("encodes control characters that would crash header validation", () => {
+    // Node's validateHeaderValue rejects bytes outside [\t\x20-\x7e].
+    expect(encodeCacheTag("a\nb")).toBe("a%0Ab");
+    expect(encodeCacheTag("a\x7fb")).toBe("a%7Fb");
+  });
+
+  it("is idempotent on its own output", () => {
+    const once = encodeCacheTag("שלום-עולם");
+    expect(encodeCacheTag(once)).toBe(once);
+  });
+});
+
+describe("encodeCacheTags", () => {
+  it("encodes each tag in an array", () => {
+    expect(encodeCacheTags(["posts", "שלום", "🎉"])).toEqual([
+      "posts",
+      "%D7%A9%D7%9C%D7%95%D7%9D",
+      "%F0%9F%8E%89",
+    ]);
+  });
+});
+
+describe("path-derived tag construction encodes non-ASCII pathnames", () => {
+  // Without encoding, a Hebrew pathname stored at render time would never
+  // match the tag produced by `revalidatePath('/שלום')` because the latter
+  // encodes its input — so the cache would silently fail to invalidate.
+  it("buildPageCacheTags encodes non-ASCII pathnames and route segments", () => {
+    expect(buildPageCacheTags("/שלום", [], ["שלום"], "page")).toEqual([
+      "/%D7%A9%D7%9C%D7%95%D7%9D",
+      "_N_T_/%D7%A9%D7%9C%D7%95%D7%9D",
+      "_N_T_/layout",
+      "_N_T_/%D7%A9%D7%9C%D7%95%D7%9D/layout",
+      "_N_T_/%D7%A9%D7%9C%D7%95%D7%9D/page",
+    ]);
+  });
+
+  it("buildPageCacheTags encodes non-ASCII extra tags from cacheTag()", () => {
+    expect(buildPageCacheTags("/blog/hello", ["שלום"], ["blog", "[slug]"], "page")).toEqual([
+      "/blog/hello",
+      "_N_T_/blog/hello",
+      "_N_T_/layout",
+      "_N_T_/blog/layout",
+      "_N_T_/blog/[slug]/layout",
+      "_N_T_/blog/[slug]/page",
+      "%D7%A9%D7%9C%D7%95%D7%9D",
+    ]);
+  });
+
+  it("buildAppPageCacheTags encodes non-ASCII pathnames and extra tags", () => {
+    expect(buildAppPageCacheTags("/مرحبا", ["🎉"])).toEqual([
+      "/%D9%85%D8%B1%D8%AD%D8%A8%D8%A7",
+      "_N_T_/%D9%85%D8%B1%D8%AD%D8%A8%D8%A7",
+      "_N_T_/layout",
+      "_N_T_/%D9%85%D8%B1%D8%AD%D8%A8%D8%A7/layout",
+      "_N_T_/%D9%85%D8%B1%D8%AD%D8%A8%D8%A7/page",
+      "%F0%9F%8E%89",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `encodeCacheTag` / `encodeCacheTags` helper (mirrors [vercel/next.js#93601](https://github.com/vercel/next.js/pull/93601)) that percent-encodes any byte outside `\t\x20-\x7e`, fast-paths ASCII, handles surrogate pairs as whole code points, and is idempotent on `%xx` input.
- Applies it at every public cache-tag boundary so storage, comparison, and any downstream `x-next-cache-tags` / Cloudflare cache-tag header see the same canonical ASCII-safe form: `cacheTag`, `revalidateTag`, `revalidatePath`, `updateTag`, `unstable_cache` `options.tags`, `fetch(..., { next: { tags } })`, and the path-derived `_N_T_` tag builders (`buildPageCacheTags`, `buildAppPageCacheTags`).
- Adds `tests/encode-cache-tag.test.ts` covering ASCII fast-path, multi-script encoding (Hebrew/Arabic/Japanese), surrogate-pair safety, `%xx` round-trip preservation, control-char encoding, idempotence, and that the path-derived builders produce ASCII-only output for non-ASCII pathnames + extra tags.

Closes #1138.

## Test plan

- [x] `pnpm test:unit tests/encode-cache-tag.test.ts` — 11 cases pass
- [x] `pnpm test:unit tests/page-cache-tags.test.ts tests/app-page-cache.test.ts tests/fetch-cache.test.ts` — existing suites unaffected (121 pass)
- [x] `pnpm test:integration tests/kv-cache-handler.test.ts` — 56 pass