### PR TITLE
test: harden ecosystem fixture startup

### DIFF
--- a/tests/ecosystem.test.ts
+++ b/tests/ecosystem.test.ts
@@ -10,130 +10,23 @@
  * Run with: npx vitest run tests/ecosystem.test.ts
  */
 import { describe, it, expect, beforeAll, afterAll } from "vite-plus/test";
-import { spawn, type ChildProcess } from "node:child_process";
+import type { ChildProcess } from "node:child_process";
 import { readFileSync } from "node:fs";
 import path from "node:path";
+import {
+  FIXTURE_HOOK_TIMEOUT_MS,
+  startFixtureDevServer,
+  stopFixtureDevServer,
+} from "./fixture-dev-server.js";
 
 const FIXTURES_DIR = path.resolve(__dirname, "fixtures", "ecosystem");
-const STARTUP_TIMEOUT_MS = process.env.CI ? 90_000 : 30_000;
-const READY_POLL_INTERVAL_MS = 250;
 
-/**
- * Start a Vite dev server as a child process and wait for it to be ready.
- */
-async function startFixture(
-  name: string,
-  port: number,
-): Promise<{
-  process: ChildProcess;
-  baseUrl: string;
-  fetchPage: (pathname: string) => Promise<{ html: string; status: number }>;
-}> {
-  const root = path.join(FIXTURES_DIR, name);
-  const baseUrl = `http://localhost:${port}`;
-
-  const proc = spawn("npx", ["vp", "dev", "--port", String(port), "--strictPort"], {
-    cwd: root,
-    stdio: ["pipe", "pipe", "pipe"],
-    env: { ...process.env },
-    detached: process.platform !== "win32",
+function startFixture(name: string, port: number) {
+  return startFixtureDevServer({
+    name,
+    port,
+    root: path.join(FIXTURES_DIR, name),
   });
-
-  let output = "";
-  const appendOutput = (data: Buffer | string) => {
-    output += data.toString();
-  };
-
-  proc.stdout?.on("data", appendOutput);
-  proc.stderr?.on("data", appendOutput);
-
-  await new Promise<void>((resolve, reject) => {
-    const deadline = Date.now() + STARTUP_TIMEOUT_MS;
-
-    const onError = (err: Error) => {
-      cleanup();
-      reject(err);
-    };
-
-    const onExit = (code: number | null) => {
-      cleanup();
-      reject(new Error(`Fixture "${name}" exited with code ${code}: ${output}`));
-    };
-
-    const cleanup = () => {
-      proc.off("error", onError);
-      proc.off("exit", onExit);
-    };
-
-    const checkReady = async () => {
-      if (Date.now() >= deadline) {
-        cleanup();
-        reject(
-          new Error(`Fixture "${name}" did not start within ${STARTUP_TIMEOUT_MS}ms: ${output}`),
-        );
-        return;
-      }
-
-      try {
-        const res = await fetch(`${baseUrl}/`, {
-          redirect: "manual",
-          signal: AbortSignal.timeout(2_000),
-        });
-        await res.body?.cancel();
-        cleanup();
-        resolve();
-      } catch {
-        setTimeout(checkReady, READY_POLL_INTERVAL_MS);
-      }
-    };
-
-    proc.on("error", onError);
-    proc.on("exit", onExit);
-    void checkReady();
-  });
-
-  // Give the server a moment to be fully ready for requests
-  await new Promise((r) => setTimeout(r, 500));
-
-  async function fetchPage(pathname: string) {
-    const res = await fetch(`${baseUrl}${pathname}`, {
-      signal: AbortSignal.timeout(10000),
-    });
-    const html = await res.text();
-    return { html, status: res.status };
-  }
-
-  return { process: proc, baseUrl, fetchPage };
-}
-
-function killProcess(proc: ChildProcess | null) {
-  if (!proc || proc.killed) {
-    return;
-  }
-
-  if (process.platform === "win32") {
-    try {
-      proc.kill("SIGTERM");
-    } catch {
-      return;
-    }
-    return;
-  }
-
-  const pid = proc.pid;
-  if (pid == null) {
-    return;
-  }
-
-  try {
-    process.kill(-pid, "SIGTERM");
-  } catch {
-    try {
-      proc.kill("SIGKILL");
-    } catch {
-      // ignore
-    }
-  }
 }
 
 // ─── next-themes ──────────────────────────────────────────────────────────────
@@ -145,9 +38,9 @@ describe("next-themes", () => {
     const fixture = await startFixture("next-themes", 4400);
     proc = fixture.process;
     fetchPage = fixture.fetchPage;
-  }, STARTUP_TIMEOUT_MS);
+  }, FIXTURE_HOOK_TIMEOUT_MS);
 
-  afterAll(() => killProcess(proc));
+  afterAll(() => stopFixtureDevServer(proc));
 
   it("renders SSR content", async () => {
     const { html, status } = await fetchPage("/");
@@ -183,9 +76,9 @@ describe("next-view-transitions", () => {
     const fixture = await startFixture("next-view-transitions", 4401);
     proc = fixture.process;
     fetchPage = fixture.fetchPage;
-  }, STARTUP_TIMEOUT_MS);
+  }, FIXTURE_HOOK_TIMEOUT_MS);
 
-  afterAll(() => killProcess(proc));
+  afterAll(() => stopFixtureDevServer(proc));
 
   it("renders home page with view transition styles", async () => {
     const { html, status } = await fetchPage("/");
@@ -224,9 +117,9 @@ describe("nuqs", () => {
     const fixture = await startFixture("nuqs", 4402);
     proc = fixture.process;
     fetchPage = fixture.fetchPage;
-  }, STARTUP_TIMEOUT_MS);
+  }, FIXTURE_HOOK_TIMEOUT_MS);
 
-  afterAll(() => killProcess(proc));
+  afterAll(() => stopFixtureDevServer(proc));
 
   it("renders SSR content", async () => {
     const { html, status } = await fetchPage("/");
@@ -281,9 +174,9 @@ describe("next-intl", () => {
     const fixture = await startFixture("next-intl", 4403);
     proc = fixture.process;
     fetchPage = fixture.fetchPage;
-  }, STARTUP_TIMEOUT_MS);
+  }, FIXTURE_HOOK_TIMEOUT_MS);
 
-  afterAll(() => killProcess(proc));
+  afterAll(() => stopFixtureDevServer(proc));
 
   it("renders English SSR content", async () => {
     const { html, status } = await fetchPage("/en");
@@ -335,9 +228,9 @@ describe("better-auth", () => {
     proc = fixture.process;
     baseUrl = fixture.baseUrl;
     fetchPage = fixture.fetchPage;
-  }, STARTUP_TIMEOUT_MS);
+  }, FIXTURE_HOOK_TIMEOUT_MS);
 
-  afterAll(() => killProcess(proc));
+  afterAll(() => stopFixtureDevServer(proc));
 
   it("renders SSR content", async () => {
     const { html, status } = await fetchPage("/");
@@ -438,9 +331,9 @@ describe("shadcn", () => {
     const fixture = await startFixture("shadcn", 4405);
     proc = fixture.process;
     fetchPage = fixture.fetchPage;
-  }, STARTUP_TIMEOUT_MS);
+  }, FIXTURE_HOOK_TIMEOUT_MS);
 
-  afterAll(() => killProcess(proc));
+  afterAll(() => stopFixtureDevServer(proc));
 
   it("renders SSR content", async () => {
     const { html, status } = await fetchPage("/");
@@ -493,9 +386,9 @@ describe("validator", () => {
     const fixture = await startFixture("validator", 4406);
     proc = fixture.process;
     fetchPage = fixture.fetchPage;
-  }, STARTUP_TIMEOUT_MS);
+  }, FIXTURE_HOOK_TIMEOUT_MS);
 
-  afterAll(() => killProcess(proc));
+  afterAll(() => stopFixtureDevServer(proc));
 
   it("can import and use validator/es/lib/isEmail.js in SSR", async () => {
     const { html, status } = await fetchPage("/");

--- a/tests/fixture-dev-server.test.ts
+++ b/tests/fixture-dev-server.test.ts
@@ -1,0 +1,47 @@
+import { once } from "node:events";
+import { describe, expect, it } from "vite-plus/test";
+import {
+  FIXTURE_HOOK_TIMEOUT_MS,
+  FIXTURE_STARTUP_TIMEOUT_MS,
+  startFixtureDevServer,
+  type FixtureDevServer,
+} from "./fixture-dev-server.js";
+
+describe("fixture dev server helper", () => {
+  it("keeps Vitest hook timeout above the internal startup timeout", () => {
+    expect(FIXTURE_HOOK_TIMEOUT_MS).toBeGreaterThan(FIXTURE_STARTUP_TIMEOUT_MS);
+  });
+
+  it("terminates the child process when startup readiness times out", async () => {
+    let fixtureProcess: FixtureDevServer["process"] | undefined;
+
+    await expect(
+      startFixtureDevServer({
+        name: "never-ready",
+        root: process.cwd(),
+        port: 49_999,
+        command: {
+          bin: process.execPath,
+          args: [
+            "-e",
+            "console.log('server booted but never listened'); setInterval(() => {}, 1000);",
+          ],
+        },
+        startupTimeoutMs: 100,
+        readinessPollIntervalMs: 10,
+        readyRequestTimeoutMs: 20,
+        serverSettleDelayMs: 0,
+        onSpawn: (proc) => {
+          fixtureProcess = proc;
+        },
+      }),
+    ).rejects.toThrow(/Fixture "never-ready" did not start within 100ms: .*never listened/s);
+
+    expect(fixtureProcess).toBeDefined();
+    if (fixtureProcess && fixtureProcess.exitCode == null && !fixtureProcess.killed) {
+      await once(fixtureProcess, "exit");
+    }
+
+    expect(fixtureProcess?.signalCode ?? fixtureProcess?.exitCode).not.toBeNull();
+  });
+});

--- a/tests/fixture-dev-server.ts
+++ b/tests/fixture-dev-server.ts
@@ -1,0 +1,186 @@
+import { spawn, type ChildProcess } from "node:child_process";
+
+export const FIXTURE_STARTUP_TIMEOUT_MS = process.env.CI ? 90_000 : 30_000;
+export const FIXTURE_HOOK_TIMEOUT_MS = FIXTURE_STARTUP_TIMEOUT_MS + 15_000;
+
+const READY_POLL_INTERVAL_MS = 250;
+const READY_REQUEST_TIMEOUT_MS = 2_000;
+const SERVER_SETTLE_DELAY_MS = 500;
+
+export type FixtureDevServer = {
+  process: ChildProcess;
+  baseUrl: string;
+  fetchPage: (pathname: string) => Promise<{ html: string; status: number }>;
+};
+
+type FixtureDevServerOptions = {
+  name: string;
+  root: string;
+  port: number;
+  command?: {
+    bin: string;
+    args: string[];
+  };
+  startupTimeoutMs?: number;
+  readinessPollIntervalMs?: number;
+  readyRequestTimeoutMs?: number;
+  serverSettleDelayMs?: number;
+  onSpawn?: (proc: ChildProcess) => void;
+};
+
+export async function startFixtureDevServer({
+  name,
+  root,
+  port,
+  command = {
+    bin: "npx",
+    args: ["vp", "dev", "--port", String(port), "--strictPort"],
+  },
+  startupTimeoutMs = FIXTURE_STARTUP_TIMEOUT_MS,
+  readinessPollIntervalMs = READY_POLL_INTERVAL_MS,
+  readyRequestTimeoutMs = READY_REQUEST_TIMEOUT_MS,
+  serverSettleDelayMs = SERVER_SETTLE_DELAY_MS,
+  onSpawn,
+}: FixtureDevServerOptions): Promise<FixtureDevServer> {
+  const baseUrl = `http://localhost:${port}`;
+  const proc = spawn(command.bin, command.args, {
+    cwd: root,
+    stdio: ["pipe", "pipe", "pipe"],
+    env: { ...process.env },
+    detached: process.platform !== "win32",
+  });
+
+  onSpawn?.(proc);
+
+  let output = "";
+  const appendOutput = (data: Buffer | string) => {
+    output += data.toString();
+  };
+
+  proc.stdout?.on("data", appendOutput);
+  proc.stderr?.on("data", appendOutput);
+
+  try {
+    await waitForFixtureReady({
+      name,
+      baseUrl,
+      proc,
+      getOutput: () => output,
+      startupTimeoutMs,
+      readinessPollIntervalMs,
+      readyRequestTimeoutMs,
+    });
+  } catch (error) {
+    stopFixtureDevServer(proc);
+    throw error;
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, serverSettleDelayMs));
+
+  async function fetchPage(pathname: string) {
+    const res = await fetch(`${baseUrl}${pathname}`, {
+      signal: AbortSignal.timeout(10_000),
+    });
+    const html = await res.text();
+    return { html, status: res.status };
+  }
+
+  return { process: proc, baseUrl, fetchPage };
+}
+
+export function stopFixtureDevServer(proc: ChildProcess | null | undefined) {
+  if (!proc || proc.killed) {
+    return;
+  }
+
+  if (process.platform === "win32") {
+    try {
+      proc.kill("SIGTERM");
+    } catch {
+      return;
+    }
+    return;
+  }
+
+  const pid = proc.pid;
+  if (pid == null) {
+    return;
+  }
+
+  try {
+    process.kill(-pid, "SIGTERM");
+  } catch {
+    try {
+      proc.kill("SIGKILL");
+    } catch {
+      // ignore
+    }
+  }
+}
+
+async function waitForFixtureReady({
+  name,
+  baseUrl,
+  proc,
+  getOutput,
+  startupTimeoutMs,
+  readinessPollIntervalMs,
+  readyRequestTimeoutMs,
+}: {
+  name: string;
+  baseUrl: string;
+  proc: ChildProcess;
+  getOutput: () => string;
+  startupTimeoutMs: number;
+  readinessPollIntervalMs: number;
+  readyRequestTimeoutMs: number;
+}) {
+  await new Promise<void>((resolve, reject) => {
+    const deadline = Date.now() + startupTimeoutMs;
+
+    const onError = (err: Error) => {
+      cleanup();
+      reject(err);
+    };
+
+    const onExit = (code: number | null) => {
+      cleanup();
+      reject(new Error(`Fixture "${name}" exited with code ${code}: ${getOutput()}`));
+    };
+
+    let pollTimer: NodeJS.Timeout | undefined;
+    const cleanup = () => {
+      if (pollTimer) {
+        clearTimeout(pollTimer);
+      }
+      proc.off("error", onError);
+      proc.off("exit", onExit);
+    };
+
+    const checkReady = async () => {
+      if (Date.now() >= deadline) {
+        cleanup();
+        reject(
+          new Error(`Fixture "${name}" did not start within ${startupTimeoutMs}ms: ${getOutput()}`),
+        );
+        return;
+      }
+
+      try {
+        const res = await fetch(`${baseUrl}/`, {
+          redirect: "manual",
+          signal: AbortSignal.timeout(readyRequestTimeoutMs),
+        });
+        await res.body?.cancel();
+        cleanup();
+        resolve();
+      } catch {
+        pollTimer = setTimeout(checkReady, readinessPollIntervalMs);
+      }
+    };
+
+    proc.on("error", onError);
+    proc.on("exit", onExit);
+    void checkReady();
+  });
+}

--- a/tests/fixtures/ecosystem/better-auth/lib/auth.ts
+++ b/tests/fixtures/ecosystem/better-auth/lib/auth.ts
@@ -5,7 +5,7 @@ import { sqlite } from "./db";
 export const auth = betterAuth({
   database: sqlite,
   secret: "vinext-test-secret-at-least-32-characters-long!!",
-  baseURL: process.env.BETTER_AUTH_URL ?? "http://localhost:4403",
+  baseURL: process.env.BETTER_AUTH_URL ?? "http://localhost:4404",
   emailAndPassword: {
     enabled: true,
   },


### PR DESCRIPTION
## Summary

Fixes #1145.

The ecosystem test harness used the same 90s deadline for both its internal fixture readiness loop and the Vitest `beforeAll` hook. When startup stalled under CI load, Vitest could kill the hook before the helper rejected with its buffered server output. Because the child process was only assigned after successful startup, the `afterAll` cleanup path could not terminate the still-running fixture server.

This PR extracts the subprocess fixture launcher into `tests/fixture-dev-server.ts` and makes startup ownership explicit:

- kill the spawned dev server when readiness fails or times out
- keep the Vitest hook timeout above the internal startup deadline so failures surface the diagnostic error
- preserve buffered stdout/stderr in startup failures
- add a focused regression test for the timeout cleanup path
- fix the `better-auth` fixture fallback `baseURL` to match its test port (`4404`)

## Verification

```sh
vp test run tests/fixture-dev-server.test.ts tests/ecosystem.test.ts
vp check
```

`vp check` passes with the existing unrelated warning in `packages/vinext/src/server/request-pipeline.ts:604`.
