### PR TITLE
chore(lint): enable stricter promise and error rules

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -2255,7 +2255,11 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             });
           }
 
-          server.middlewares.use(async (req, res, next) => {
+          const handlePagesMiddleware = async (
+            req: import("node:http").IncomingMessage,
+            res: import("node:http").ServerResponse,
+            next: (err?: unknown) => void,
+          ): Promise<void> => {
             try {
               let url: string = req.url ?? "/";
 
@@ -2793,6 +2797,10 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             } catch (e) {
               next(e);
             }
+          };
+
+          server.middlewares.use((req, res, next) => {
+            void handlePagesMiddleware(req, res, next);
           });
         };
       },

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -1212,7 +1212,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
   });
 
   if (import.meta.hot) {
-    import.meta.hot.on("rsc:update", async () => {
+    const handleRscUpdate = async (): Promise<void> => {
       try {
         // If BrowserRoot has been mounted before but isn't now, a render
         // error tore down the tree (e.g. a server route threw). HMR can't
@@ -1270,6 +1270,10 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
       } catch (error) {
         console.error("[vinext] RSC HMR error:", error);
       }
+    };
+
+    import.meta.hot.on("rsc:update", () => {
+      void handleRscUpdate();
     });
   }
 }

--- a/packages/vinext/src/server/app-route-handler-dispatch.ts
+++ b/packages/vinext/src/server/app-route-handler-dispatch.ts
@@ -255,7 +255,9 @@ export async function dispatchAppRouteHandler(
       middlewareContext: options.middlewareContext,
       middlewareRequestHeaders: options.middlewareRequestHeaders,
       params: makeThenableParams(options.params),
-      reportRequestError,
+      reportRequestError(error, request, context) {
+        void reportRequestError(error, request, context);
+      },
       request: options.request,
       expireSeconds: options.expireSeconds,
       revalidateSeconds,

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -979,7 +979,7 @@ async function startAppRouterServer(options: AppRouterServerOptions) {
   // .br/.gz/.zst variants (generated at build time) are detected automatically.
   const staticCache = await StaticFileCache.create(clientDir);
 
-  const server = createServer(async (req, res) => {
+  const handleRequest = async (req: IncomingMessage, res: ServerResponse): Promise<void> => {
     const rawUrl = req.url ?? "/";
     const rawPathname = rawUrl.split("?")[0];
 
@@ -1140,6 +1140,10 @@ async function startAppRouterServer(options: AppRouterServerOptions) {
         res.end("Internal Server Error");
       }
     }
+  };
+
+  const server = createServer((req, res) => {
+    void handleRequest(req, res);
   });
 
   await new Promise<void>((resolve) => {
@@ -1243,7 +1247,7 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
   // Build the static file metadata cache at startup (same as App Router).
   const staticCache = await StaticFileCache.create(clientDir);
 
-  const server = createServer(async (req, res) => {
+  const handleRequest = async (req: IncomingMessage, res: ServerResponse): Promise<void> => {
     const rawUrl = req.url ?? "/";
     const rawPagesPathnameBeforeNormalize = rawUrl.split("?")[0];
 
@@ -1738,6 +1742,10 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
         res.end("Internal Server Error");
       }
     }
+  };
+
+  const server = createServer((req, res) => {
+    void handleRequest(req, res);
   });
 
   await new Promise<void>((resolve) => {

--- a/packages/vinext/src/server/request-pipeline.ts
+++ b/packages/vinext/src/server/request-pipeline.ts
@@ -462,6 +462,7 @@ function matchWildcardDomain(domain: string, pattern: string): boolean {
   while (patternParts.length) {
     const patternPart = patternParts.pop();
     const domainPart = domainParts.pop();
+    if (patternPart === undefined) return false;
 
     switch (patternPart) {
       case "":
@@ -601,7 +602,7 @@ export function filterInternalHeaders(headers: Headers): Headers {
   return filtered;
 }
 
-function getRequestCf(request: Request): unknown | undefined {
+function getRequestCf(request: Request): unknown {
   const cf = Reflect.get(request, "cf");
   return cf === undefined ? undefined : cf;
 }

--- a/packages/vinext/src/shims/form.tsx
+++ b/packages/vinext/src/shims/form.tsx
@@ -244,7 +244,16 @@ const Form = forwardRef(function Form(props: FormProps, ref: ForwardedRef<HTMLFo
     }
   }
 
-  return <form ref={ref} action={action} onSubmit={handleSubmit} {...rest} />;
+  return (
+    <form
+      ref={ref}
+      action={action}
+      onSubmit={(event) => {
+        void handleSubmit(event);
+      }}
+      {...rest}
+    />
+  );
 });
 
 export default Form;

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -476,7 +476,14 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
 
   return (
     <LinkStatusContext.Provider value={linkStatusValue}>
-      <a ref={setRefs} href={fullHref} onClick={handleClick} {...anchorProps}>
+      <a
+        ref={setRefs}
+        href={fullHref}
+        onClick={(event) => {
+          void handleClick(event);
+        }}
+        {...anchorProps}
+      >
         {children}
       </a>
     </LinkStatusContext.Provider>

--- a/tests/ecosystem.test.ts
+++ b/tests/ecosystem.test.ts
@@ -83,7 +83,9 @@ async function startFixture(
         cleanup();
         resolve();
       } catch {
-        setTimeout(checkReady, READY_POLL_INTERVAL_MS);
+        setTimeout(() => {
+          void checkReady();
+        }, READY_POLL_INTERVAL_MS);
       }
     };
 

--- a/tests/error-boundary.test.ts
+++ b/tests/error-boundary.test.ts
@@ -131,31 +131,34 @@ describe("ErrorBoundary digest classification (actual class)", () => {
   });
 
   it("rethrows NEXT_NOT_FOUND", () => {
-    const e = Object.assign(new Error(), { digest: "NEXT_NOT_FOUND" });
+    const e = createErrorWithDigest("NEXT_NOT_FOUND", "NEXT_NOT_FOUND");
     expect(ErrorBoundaryInnerClass).not.toBeNull();
     expect(() => ErrorBoundaryInnerClass?.getDerivedStateFromError(e)).toThrow(e);
   });
 
   it("rethrows NEXT_HTTP_ERROR_FALLBACK;404", () => {
-    const e = Object.assign(new Error(), { digest: "NEXT_HTTP_ERROR_FALLBACK;404" });
+    const e = createErrorWithDigest("NEXT_HTTP_ERROR_FALLBACK;404", "NEXT_HTTP_ERROR_FALLBACK;404");
     expect(ErrorBoundaryInnerClass).not.toBeNull();
     expect(() => ErrorBoundaryInnerClass?.getDerivedStateFromError(e)).toThrow(e);
   });
 
   it("rethrows NEXT_HTTP_ERROR_FALLBACK;403", () => {
-    const e = Object.assign(new Error(), { digest: "NEXT_HTTP_ERROR_FALLBACK;403" });
+    const e = createErrorWithDigest("NEXT_HTTP_ERROR_FALLBACK;403", "NEXT_HTTP_ERROR_FALLBACK;403");
     expect(ErrorBoundaryInnerClass).not.toBeNull();
     expect(() => ErrorBoundaryInnerClass?.getDerivedStateFromError(e)).toThrow(e);
   });
 
   it("rethrows NEXT_HTTP_ERROR_FALLBACK;401", () => {
-    const e = Object.assign(new Error(), { digest: "NEXT_HTTP_ERROR_FALLBACK;401" });
+    const e = createErrorWithDigest("NEXT_HTTP_ERROR_FALLBACK;401", "NEXT_HTTP_ERROR_FALLBACK;401");
     expect(ErrorBoundaryInnerClass).not.toBeNull();
     expect(() => ErrorBoundaryInnerClass?.getDerivedStateFromError(e)).toThrow(e);
   });
 
   it("rethrows NEXT_REDIRECT", () => {
-    const e = Object.assign(new Error(), { digest: "NEXT_REDIRECT;replace;/login;307;" });
+    const e = createErrorWithDigest(
+      "NEXT_REDIRECT;replace;/login;307;",
+      "NEXT_REDIRECT;replace;/login;307;",
+    );
     expect(ErrorBoundaryInnerClass).not.toBeNull();
     expect(() => ErrorBoundaryInnerClass?.getDerivedStateFromError(e)).toThrow(e);
   });
@@ -168,14 +171,14 @@ describe("ErrorBoundary digest classification (actual class)", () => {
   });
 
   it("catches errors with unknown digest", () => {
-    const e = Object.assign(new Error(), { digest: "CUSTOM_ERROR" });
+    const e = createErrorWithDigest("CUSTOM_ERROR", "CUSTOM_ERROR");
     expect(ErrorBoundaryInnerClass).not.toBeNull();
     const state = ErrorBoundaryInnerClass?.getDerivedStateFromError(e);
     expect(state).toEqual({ error: { thrownValue: e } });
   });
 
   it("catches errors with empty digest", () => {
-    const e = Object.assign(new Error(), { digest: "" });
+    const e = createErrorWithDigest("Empty digest", "");
     expect(ErrorBoundaryInnerClass).not.toBeNull();
     const state = ErrorBoundaryInnerClass?.getDerivedStateFromError(e);
     expect(state).toEqual({ error: { thrownValue: e } });
@@ -270,26 +273,29 @@ describe("ForbiddenBoundary digest classification", () => {
   });
 
   it("catches NEXT_HTTP_ERROR_FALLBACK;403", () => {
-    const e = Object.assign(new Error(), { digest: "NEXT_HTTP_ERROR_FALLBACK;403" });
+    const e = createErrorWithDigest("NEXT_HTTP_ERROR_FALLBACK;403", "NEXT_HTTP_ERROR_FALLBACK;403");
     expect(ForbiddenBoundaryInnerClass).not.toBeNull();
     const state = ForbiddenBoundaryInnerClass?.getDerivedStateFromError(e);
     expect(state).toMatchObject({ forbidden: true });
   });
 
   it("re-throws NEXT_HTTP_ERROR_FALLBACK;404 (notFound domain)", () => {
-    const e = Object.assign(new Error(), { digest: "NEXT_HTTP_ERROR_FALLBACK;404" });
+    const e = createErrorWithDigest("NEXT_HTTP_ERROR_FALLBACK;404", "NEXT_HTTP_ERROR_FALLBACK;404");
     expect(ForbiddenBoundaryInnerClass).not.toBeNull();
     expect(() => ForbiddenBoundaryInnerClass?.getDerivedStateFromError(e)).toThrow(e);
   });
 
   it("re-throws NEXT_HTTP_ERROR_FALLBACK;401 (unauthorized domain)", () => {
-    const e = Object.assign(new Error(), { digest: "NEXT_HTTP_ERROR_FALLBACK;401" });
+    const e = createErrorWithDigest("NEXT_HTTP_ERROR_FALLBACK;401", "NEXT_HTTP_ERROR_FALLBACK;401");
     expect(ForbiddenBoundaryInnerClass).not.toBeNull();
     expect(() => ForbiddenBoundaryInnerClass?.getDerivedStateFromError(e)).toThrow(e);
   });
 
   it("re-throws NEXT_HTTP_ERROR_FALLBACK;4030 (defensive: exact match, startsWith would be wrong)", () => {
-    const e = Object.assign(new Error(), { digest: "NEXT_HTTP_ERROR_FALLBACK;4030" });
+    const e = createErrorWithDigest(
+      "NEXT_HTTP_ERROR_FALLBACK;4030",
+      "NEXT_HTTP_ERROR_FALLBACK;4030",
+    );
     expect(ForbiddenBoundaryInnerClass).not.toBeNull();
     expect(() => ForbiddenBoundaryInnerClass?.getDerivedStateFromError(e)).toThrow(e);
   });
@@ -314,26 +320,29 @@ describe("UnauthorizedBoundary digest classification", () => {
   });
 
   it("catches NEXT_HTTP_ERROR_FALLBACK;401", () => {
-    const e = Object.assign(new Error(), { digest: "NEXT_HTTP_ERROR_FALLBACK;401" });
+    const e = createErrorWithDigest("NEXT_HTTP_ERROR_FALLBACK;401", "NEXT_HTTP_ERROR_FALLBACK;401");
     expect(UnauthorizedBoundaryInnerClass).not.toBeNull();
     const state = UnauthorizedBoundaryInnerClass?.getDerivedStateFromError(e);
     expect(state).toMatchObject({ unauthorized: true });
   });
 
   it("re-throws NEXT_HTTP_ERROR_FALLBACK;404 (notFound domain)", () => {
-    const e = Object.assign(new Error(), { digest: "NEXT_HTTP_ERROR_FALLBACK;404" });
+    const e = createErrorWithDigest("NEXT_HTTP_ERROR_FALLBACK;404", "NEXT_HTTP_ERROR_FALLBACK;404");
     expect(UnauthorizedBoundaryInnerClass).not.toBeNull();
     expect(() => UnauthorizedBoundaryInnerClass?.getDerivedStateFromError(e)).toThrow(e);
   });
 
   it("re-throws NEXT_HTTP_ERROR_FALLBACK;403 (forbidden domain)", () => {
-    const e = Object.assign(new Error(), { digest: "NEXT_HTTP_ERROR_FALLBACK;403" });
+    const e = createErrorWithDigest("NEXT_HTTP_ERROR_FALLBACK;403", "NEXT_HTTP_ERROR_FALLBACK;403");
     expect(UnauthorizedBoundaryInnerClass).not.toBeNull();
     expect(() => UnauthorizedBoundaryInnerClass?.getDerivedStateFromError(e)).toThrow(e);
   });
 
   it("re-throws NEXT_HTTP_ERROR_FALLBACK;4010 (defensive: exact match, startsWith would be wrong)", () => {
-    const e = Object.assign(new Error(), { digest: "NEXT_HTTP_ERROR_FALLBACK;4010" });
+    const e = createErrorWithDigest(
+      "NEXT_HTTP_ERROR_FALLBACK;4010",
+      "NEXT_HTTP_ERROR_FALLBACK;4010",
+    );
     expect(UnauthorizedBoundaryInnerClass).not.toBeNull();
     expect(() => UnauthorizedBoundaryInnerClass?.getDerivedStateFromError(e)).toThrow(e);
   });

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -163,7 +163,7 @@ async function captureStreamedResponse(
         decoder.on("error", reject);
       }
 
-      res.on("end", async () => {
+      const finishResponse = async () => {
         try {
           if (decoder) {
             decoder.end();
@@ -187,6 +187,10 @@ async function captureStreamedResponse(
         } catch (error) {
           reject(error);
         }
+      };
+
+      res.on("end", () => {
+        void finishResponse();
       });
     });
 
@@ -1198,6 +1202,7 @@ describe("Pages Router allowedDevOrigins config", () => {
     const res = await fetch(`${baseUrl}/`, {
       headers: { Origin: "http://allowed.example.com" },
     });
+    await res.body?.cancel();
     expect(res.status).toBe(200);
   });
 
@@ -1205,6 +1210,7 @@ describe("Pages Router allowedDevOrigins config", () => {
     const res = await fetch(`${baseUrl}/`, {
       headers: { Origin: "http://actions.example.com" },
     });
+    await res.body?.cancel();
     expect(res.status).toBe(403);
   });
 });
@@ -2218,42 +2224,46 @@ export default function CounterPage() {
     // The server entry uses Web-standard Request/Response, so we bridge
     // from Node.js HTTP objects.
     const { createServer: createHttpServer } = await import("node:http");
-    const httpServer = createHttpServer(async (req, res) => {
-      const url = req.url ?? "/";
-      const pathname = url.split("?")[0];
+    const httpServer = createHttpServer((req, res) => {
+      void (async () => {
+        const url = req.url ?? "/";
+        const pathname = url.split("?")[0];
 
-      // Convert Node.js req to Web Request
-      const headers = new Headers();
-      for (const [k, v] of Object.entries(req.headers)) {
-        if (v) headers.set(k, Array.isArray(v) ? v.join(", ") : v);
-      }
-      const host = req.headers.host ?? "localhost";
-      const method = req.method ?? "GET";
-      const init: RequestInit & { duplex?: "half" } = {
-        method,
-        headers,
-      };
-      if (method !== "GET" && method !== "HEAD") {
-        init.body = Readable.toWeb(req) as ReadableStream;
-        init.duplex = "half";
-      }
-      const webRequest = new Request(`http://${host}${url}`, init);
+        // Convert Node.js req to Web Request
+        const headers = new Headers();
+        for (const [k, v] of Object.entries(req.headers)) {
+          if (v) headers.set(k, Array.isArray(v) ? v.join(", ") : v);
+        }
+        const host = req.headers.host ?? "localhost";
+        const method = req.method ?? "GET";
+        const init: RequestInit & { duplex?: "half" } = {
+          method,
+          headers,
+        };
+        if (method !== "GET" && method !== "HEAD") {
+          init.body = Readable.toWeb(req) as ReadableStream;
+          init.duplex = "half";
+        }
+        const webRequest = new Request(`http://${host}${url}`, init);
 
-      let response: Response;
-      if (pathname.startsWith("/api/") || pathname === "/api") {
-        response = await serverEntry.handleApiRoute(webRequest, url);
-      } else {
-        response = await serverEntry.renderPage(webRequest, url, manifest);
-      }
+        let response: Response;
+        if (pathname.startsWith("/api/") || pathname === "/api") {
+          response = await serverEntry.handleApiRoute(webRequest, url);
+        } else {
+          response = await serverEntry.renderPage(webRequest, url, manifest);
+        }
 
-      // Pipe Web Response back to Node.js res
-      const body = await response.text();
-      const resHeaders: Record<string, string> = {};
-      response.headers.forEach((v: string, k: string) => {
-        resHeaders[k] = v;
+        // Pipe Web Response back to Node.js res
+        const body = await response.text();
+        const resHeaders: Record<string, string> = {};
+        response.headers.forEach((v: string, k: string) => {
+          resHeaders[k] = v;
+        });
+        res.writeHead(response.status, response.statusText || undefined, resHeaders);
+        res.end(body);
+      })().catch((error: unknown) => {
+        res.destroy(error instanceof Error ? error : new Error(String(error)));
       });
-      res.writeHead(response.status, response.statusText || undefined, resHeaders);
-      res.end(body);
     });
 
     // Start on a random port

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -101,6 +101,8 @@ function createResponseDecoder(
 ): zlib.BrotliDecompress | zlib.Gunzip | zlib.Inflate | null {
   const encoding = Array.isArray(contentEncoding) ? contentEncoding[0] : contentEncoding;
   switch (encoding) {
+    case undefined:
+      return null;
     case "br":
       return zlib.createBrotliDecompress();
     case "gzip":
@@ -1194,7 +1196,18 @@ describe("Pages Router allowedDevOrigins config", () => {
   }, 30000);
 
   afterAll(async () => {
-    await server?.close();
+    try {
+      (
+        server?.httpServer as
+          | {
+              closeAllConnections?: () => void;
+            }
+          | undefined
+      )?.closeAllConnections?.();
+      await Promise.race([server?.close(), new Promise((resolve) => setTimeout(resolve, 5000))]);
+    } catch {
+      // Best-effort cleanup: the temp directory removal below is the durable assertion.
+    }
     await fsp.rm(tmpDir, { recursive: true, force: true });
   }, 30000);
 
@@ -1202,7 +1215,7 @@ describe("Pages Router allowedDevOrigins config", () => {
     const res = await fetch(`${baseUrl}/`, {
       headers: { Origin: "http://allowed.example.com" },
     });
-    await res.body?.cancel();
+    await res.text();
     expect(res.status).toBe(200);
   });
 
@@ -1210,7 +1223,7 @@ describe("Pages Router allowedDevOrigins config", () => {
     const res = await fetch(`${baseUrl}/`, {
       headers: { Origin: "http://actions.example.com" },
     });
-    await res.body?.cancel();
+    await res.text();
     expect(res.status).toBe(403);
   });
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -59,6 +59,21 @@ export default defineConfig({
         rules: {
           "@typescript-eslint/no-explicit-any": "off",
           "@typescript-eslint/no-unsafe-function-type": "off",
+          "typescript/no-misused-promises": "error",
+          "import/no-self-import": "error",
+          "unicorn/throw-new-error": "error",
+          "unicorn/error-message": "error",
+        },
+      },
+      {
+        files: ["packages/vinext/src/**/*.{ts,tsx}"],
+        rules: {
+          "typescript/no-misused-promises": "error",
+          "typescript/switch-exhaustiveness-check": "error",
+          "typescript/restrict-template-expressions": "error",
+          "import/no-self-import": "error",
+          "unicorn/throw-new-error": "error",
+          "unicorn/error-message": "error",
         },
       },
       {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -60,6 +60,7 @@ export default defineConfig({
           "@typescript-eslint/no-explicit-any": "off",
           "@typescript-eslint/no-unsafe-function-type": "off",
           "typescript/no-misused-promises": "error",
+          "typescript/switch-exhaustiveness-check": "error",
           "import/no-self-import": "error",
           "unicorn/throw-new-error": "error",
           "unicorn/error-message": "error",


### PR DESCRIPTION
## What this changes
Enables the requested Oxlint rules for vinext source files and applies the useful test subset. Fixes the resulting callback boundaries, error fixtures, exhaustive switches, and the existing redundant unknown union warning.

## Enabled rules
Source files:
- `typescript/no-misused-promises`: `error`
- `typescript/switch-exhaustiveness-check`: `error`
- `typescript/restrict-template-expressions`: `error`
- `import/no-self-import`: `error`
- `unicorn/throw-new-error`: `error`
- `unicorn/error-message`: `error`

Test files:
- `typescript/no-misused-promises`: `error`
- `typescript/switch-exhaustiveness-check`: `error`
- `import/no-self-import`: `error`
- `unicorn/throw-new-error`: `error`
- `unicorn/error-message`: `error`

## Validation
- `vp check`
- `vp test run tests/pages-router.test.ts`
- `vp test run tests/error-boundary.test.ts tests/link.test.ts tests/shims.test.ts tests/ecosystem.test.ts`
- `vp test run tests/app-router.test.ts`

## Follow-ups
`typescript/no-unnecessary-type-assertion` and `typescript/no-unsafe-type-assertion` should be handled in future PRs.