### PR TITLE
fix(image): support images.dangerouslyAllowLocalIP for private-IP rejections

### DIFF
--- a/packages/vinext/package.json
+++ b/packages/vinext/package.json
@@ -67,6 +67,7 @@
     "@unpic/react": "catalog:",
     "@vercel/og": "catalog:",
     "image-size": "catalog:",
+    "ipaddr.js": "catalog:",
     "magic-string": "catalog:",
     "vite-plugin-commonjs": "catalog:",
     "vite-tsconfig-paths": "catalog:"

--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -169,6 +169,8 @@ export type NextConfig = {
     imageSizes?: number[];
     /** Allow SVG images through the image optimization endpoint. SVG can contain scripts, so only enable if you trust all image sources. */
     dangerouslyAllowSVG?: boolean;
+    /** Allow image optimization for hostnames that resolve to private IP addresses. This is a security risk (SSRF) — only enable for private networks when you understand the risk. */
+    dangerouslyAllowLocalIP?: boolean;
     /** Content-Disposition header for image responses. Defaults to "inline". */
     contentDispositionType?: "inline" | "attachment";
     /** Content-Security-Policy header for image responses. Defaults to "script-src 'none'; frame-src 'none'; sandbox;" */

--- a/packages/vinext/src/deploy.ts
+++ b/packages/vinext/src/deploy.ts
@@ -562,6 +562,7 @@ const configRewrites = vinextConfig?.rewrites ?? { beforeFiles: [], afterFiles: 
 const configHeaders = vinextConfig?.headers ?? [];
 const imageConfig: ImageConfig | undefined = vinextConfig?.images ? {
   dangerouslyAllowSVG: vinextConfig.images.dangerouslyAllowSVG,
+  dangerouslyAllowLocalIP: vinextConfig.images.dangerouslyAllowLocalIP,
   contentDispositionType: vinextConfig.images.contentDispositionType,
   contentSecurityPolicy: vinextConfig.images.contentSecurityPolicy,
 } : undefined;

--- a/packages/vinext/src/entries/pages-server-entry.ts
+++ b/packages/vinext/src/entries/pages-server-entry.ts
@@ -106,6 +106,7 @@ export async function generateServerEntry(
       deviceSizes: nextConfig?.images?.deviceSizes,
       imageSizes: nextConfig?.images?.imageSizes,
       dangerouslyAllowSVG: nextConfig?.images?.dangerouslyAllowSVG,
+      dangerouslyAllowLocalIP: nextConfig?.images?.dangerouslyAllowLocalIP,
       contentDispositionType: nextConfig?.images?.contentDispositionType,
       contentSecurityPolicy: nextConfig?.images?.contentSecurityPolicy,
     },

--- a/packages/vinext/src/global.d.ts
+++ b/packages/vinext/src/global.d.ts
@@ -362,6 +362,12 @@ declare global {
        * image optimizer (`next.config.js` → `images.dangerouslyAllowSVG`).
        */
       __VINEXT_IMAGE_DANGEROUSLY_ALLOW_SVG?: string;
+
+      /**
+       * `"true"` or `"false"` — whether hostnames resolving to private IPs
+       * are allowed (`next.config.js` → `images.dangerouslyAllowLocalIP`).
+       */
+      __VINEXT_IMAGE_DANGEROUSLY_ALLOW_LOCAL_IP?: string;
     }
   }
 }

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -1218,7 +1218,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
               ? { ssr: { external: true as const } }
               : {
                   ssr: {
-                    external: ["react", "react-dom", "react-dom/server"],
+                    external: ["react", "react-dom", "react-dom/server", "ipaddr.js"],
                     noExternal: true,
                   },
                 }),
@@ -1377,7 +1377,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                 ? {}
                 : {
                     resolve: {
-                      external: userSsrExternal === true ? true : [...userSsrExternal],
+                      external: userSsrExternal === true ? true : [...userSsrExternal, "ipaddr.js"],
                       // Force all node_modules through Vite's transform pipeline
                       // so non-JS imports (CSS, images) don't hit Node's native
                       // ESM loader. Matches Next.js behavior of bundling everything.
@@ -1511,7 +1511,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             },
             ssr: {
               resolve: {
-                external: ["react", "react-dom", "react-dom/server"],
+                external: ["react", "react-dom", "react-dom/server", "ipaddr.js"],
                 noExternal: true as const,
               },
               build: {

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -898,6 +898,11 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         defines["process.env.__VINEXT_IMAGE_DANGEROUSLY_ALLOW_SVG"] = JSON.stringify(
           String(nextConfig.images?.dangerouslyAllowSVG ?? false),
         );
+        // Expose dangerouslyAllowLocalIP flag for the image shim's private-IP guard.
+        // When false (default), remote image URLs with literal private-IP hostnames are blocked.
+        defines["process.env.__VINEXT_IMAGE_DANGEROUSLY_ALLOW_LOCAL_IP"] = JSON.stringify(
+          String(nextConfig.images?.dangerouslyAllowLocalIP ?? false),
+        );
         // Draft mode secret — generated once at build time so the
         // __prerender_bypass cookie is consistent across all server
         // instances (e.g. multiple Cloudflare Workers isolates).

--- a/packages/vinext/src/server/image-optimization.ts
+++ b/packages/vinext/src/server/image-optimization.ts
@@ -29,7 +29,15 @@ export const IMAGE_OPTIMIZATION_PATH = "/_vinext/image";
 export type ImageConfig = {
   /** Allow SVG through the image optimization endpoint. Default: false. */
   dangerouslyAllowSVG?: boolean;
-  /** Allow image optimization for hostnames that resolve to private IP addresses. Default: false. */
+  /**
+   * Allow image optimization for hostnames that resolve to private IP addresses.
+   * Default: false.
+   *
+   * Note: This field is currently reserved for future server-side remote-image
+   * fetching. vinext's image optimization endpoint only serves local files, so
+   * there is no active server-side SSRF vector — the flag is consumed client-side
+   * via the image shim instead.
+   */
   dangerouslyAllowLocalIP?: boolean;
   /** Content-Disposition header value. Default: "inline". */
   contentDispositionType?: "inline" | "attachment";

--- a/packages/vinext/src/server/image-optimization.ts
+++ b/packages/vinext/src/server/image-optimization.ts
@@ -29,6 +29,8 @@ export const IMAGE_OPTIMIZATION_PATH = "/_vinext/image";
 export type ImageConfig = {
   /** Allow SVG through the image optimization endpoint. Default: false. */
   dangerouslyAllowSVG?: boolean;
+  /** Allow image optimization for hostnames that resolve to private IP addresses. Default: false. */
+  dangerouslyAllowLocalIP?: boolean;
   /** Content-Disposition header value. Default: "inline". */
   contentDispositionType?: "inline" | "attachment";
   /** Content-Security-Policy header value. Default: "script-src 'none'; frame-src 'none'; sandbox;" */

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -1210,6 +1210,7 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
   const pagesImageConfig: ImageConfig | undefined = vinextConfig?.images
     ? {
         dangerouslyAllowSVG: vinextConfig.images.dangerouslyAllowSVG,
+        dangerouslyAllowLocalIP: vinextConfig.images.dangerouslyAllowLocalIP,
         contentDispositionType: vinextConfig.images.contentDispositionType,
         contentSecurityPolicy: vinextConfig.images.contentSecurityPolicy,
       }

--- a/packages/vinext/src/shims/image-config.ts
+++ b/packages/vinext/src/shims/image-config.ts
@@ -111,3 +111,116 @@ export function hasRemoteMatch(
     remotePatterns.some((p) => matchRemotePattern(p, url))
   );
 }
+
+// ─── Private IP detection ───────────────────────────────────────────────
+
+/**
+ * Parse an IPv4 address string into 4 numeric octets.
+ * Supports dotted decimal, octal (leading 0), hex (0x prefix),
+ * and single-number 32-bit notation.
+ */
+function parseIPv4(ip: string): number[] | null {
+  if (ip.includes(".")) {
+    const parts = ip.split(".");
+    if (parts.length !== 4) return null;
+    const nums = parts.map((p) => {
+      if (p === "") return NaN;
+      if (p.startsWith("0x") || p.startsWith("0X")) return parseInt(p.slice(2), 16);
+      if (p.length > 1 && p.startsWith("0")) return parseInt(p, 8);
+      return parseInt(p, 10);
+    });
+    if (nums.some(isNaN)) return null;
+    if (nums.some((n) => n < 0 || n > 255)) return null;
+    return nums;
+  }
+
+  // Single-number notation (hex or decimal)
+  let num: number;
+  if (ip.startsWith("0x") || ip.startsWith("0X")) {
+    num = parseInt(ip.slice(2), 16);
+  } else {
+    num = parseInt(ip, 10);
+  }
+  if (isNaN(num) || num < 0 || num > 0xffffffff) return null;
+  return [(num >>> 24) & 0xff, (num >>> 16) & 0xff, (num >>> 8) & 0xff, num & 0xff];
+}
+
+function isPrivateIPv4(parts: number[]): boolean {
+  const [a, b] = parts;
+  if (a === 0) return true; // 0.0.0.0/8
+  if (a === 10) return true; // 10.0.0.0/8
+  if (a === 127) return true; // 127.0.0.0/8
+  if (a === 169 && b === 254) return true; // 169.254.0.0/16
+  if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12
+  if (a === 192 && b === 168) return true; // 192.168.0.0/16
+  return false;
+}
+
+function isPrivateIPv6(ip: string): boolean {
+  if (ip === "::1" || ip === "::") return true;
+
+  const lower = ip.toLowerCase();
+
+  // fc00::/7 (unique local)
+  if (lower.startsWith("fc") || lower.startsWith("fd")) return true;
+  // fe80::/10 (link-local)
+  if (
+    lower.startsWith("fe8") ||
+    lower.startsWith("fe9") ||
+    lower.startsWith("fea") ||
+    lower.startsWith("feb")
+  )
+    return true;
+  // ff00::/8 (multicast)
+  if (lower.startsWith("ff")) return true;
+  // 2001:2f::/32 (benchmarking)
+  if (lower.startsWith("2001:2f:")) return true;
+  // 2002::/16 (6to4)
+  if (lower.startsWith("2002:")) return true;
+
+  return false;
+}
+
+/**
+ * Determine whether a string is a private (non-routable) IP address.
+ * Works for IPv4 and IPv6, including bracketed and IPv4-mapped forms.
+ *
+ * Ported from Next.js: packages/next/src/server/is-private-ip.ts
+ * https://github.com/vercel/next.js/blob/canary/packages/next/src/server/is-private-ip.ts
+ */
+export function isPrivateIp(ip: string): boolean {
+  if (ip.startsWith("[") && ip.endsWith("]")) {
+    ip = ip.slice(1, -1);
+  }
+
+  // IPv4-mapped IPv6 addresses (::ffff:...)
+  const lowerIp = ip.toLowerCase();
+  if (lowerIp.startsWith("::ffff:")) {
+    const mapped = ip.slice(7);
+    if (mapped.includes(".")) {
+      const ipv4 = parseIPv4(mapped);
+      if (ipv4 && isPrivateIPv4(ipv4)) return true;
+    } else if (mapped.includes(":")) {
+      // Two hex groups like 7f00:1
+      const parts = mapped.split(":");
+      if (parts.length === 2) {
+        const hi = parseInt(parts[0], 16);
+        const lo = parseInt(parts[1], 16);
+        if (!isNaN(hi) && !isNaN(lo)) {
+          return isPrivateIPv4([(hi >>> 8) & 0xff, hi & 0xff, (lo >>> 8) & 0xff, lo & 0xff]);
+        }
+      }
+    }
+  }
+
+  if (ip.includes(":")) {
+    return isPrivateIPv6(ip);
+  }
+
+  const ipv4 = parseIPv4(ip);
+  if (ipv4) {
+    return isPrivateIPv4(ipv4);
+  }
+
+  return false;
+}

--- a/packages/vinext/src/shims/image-config.ts
+++ b/packages/vinext/src/shims/image-config.ts
@@ -1,3 +1,5 @@
+import ipaddr from "ipaddr.js";
+
 /**
  * Image remote pattern validation.
  *
@@ -115,112 +117,34 @@ export function hasRemoteMatch(
 // ─── Private IP detection ───────────────────────────────────────────────
 
 /**
- * Parse an IPv4 address string into 4 numeric octets.
- * Supports dotted decimal, octal (leading 0), hex (0x prefix),
- * and single-number 32-bit notation.
- */
-function parseIPv4(ip: string): number[] | null {
-  if (ip.includes(".")) {
-    const parts = ip.split(".");
-    if (parts.length !== 4) return null;
-    const nums = parts.map((p) => {
-      if (p === "") return NaN;
-      if (p.startsWith("0x") || p.startsWith("0X")) return parseInt(p.slice(2), 16);
-      if (p.length > 1 && p.startsWith("0")) return parseInt(p, 8);
-      return parseInt(p, 10);
-    });
-    if (nums.some(isNaN)) return null;
-    if (nums.some((n) => n < 0 || n > 255)) return null;
-    return nums;
-  }
-
-  // Single-number notation (hex or decimal)
-  let num: number;
-  if (ip.startsWith("0x") || ip.startsWith("0X")) {
-    num = parseInt(ip.slice(2), 16);
-  } else {
-    num = parseInt(ip, 10);
-  }
-  if (isNaN(num) || num < 0 || num > 0xffffffff) return null;
-  return [(num >>> 24) & 0xff, (num >>> 16) & 0xff, (num >>> 8) & 0xff, num & 0xff];
-}
-
-function isPrivateIPv4(parts: number[]): boolean {
-  const [a, b] = parts;
-  if (a === 0) return true; // 0.0.0.0/8
-  if (a === 10) return true; // 10.0.0.0/8
-  if (a === 127) return true; // 127.0.0.0/8
-  if (a === 169 && b === 254) return true; // 169.254.0.0/16
-  if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12
-  if (a === 192 && b === 168) return true; // 192.168.0.0/16
-  return false;
-}
-
-function isPrivateIPv6(ip: string): boolean {
-  if (ip === "::1" || ip === "::") return true;
-
-  const lower = ip.toLowerCase();
-
-  // fc00::/7 (unique local)
-  if (lower.startsWith("fc") || lower.startsWith("fd")) return true;
-  // fe80::/10 (link-local)
-  if (
-    lower.startsWith("fe8") ||
-    lower.startsWith("fe9") ||
-    lower.startsWith("fea") ||
-    lower.startsWith("feb")
-  )
-    return true;
-  // ff00::/8 (multicast)
-  if (lower.startsWith("ff")) return true;
-  // 2001:2f::/32 (benchmarking)
-  if (lower.startsWith("2001:2f:")) return true;
-  // 2002::/16 (6to4)
-  if (lower.startsWith("2002:")) return true;
-
-  return false;
-}
-
-/**
  * Determine whether a string is a private (non-routable) IP address.
  * Works for IPv4 and IPv6, including bracketed and IPv4-mapped forms.
  *
- * Ported from Next.js: packages/next/src/server/is-private-ip.ts
+ * Uses ipaddr.js with range() !== 'unicast' — the same approach Next.js
+ * takes (via packages/next/src/server/is-private-ip.ts). This covers all
+ * IETF non-unicast ranges (CGNAT, benchmarking, multicast, reserved,
+ * teredo, documentation, discard, NAT64, etc.) without hand-rolling CIDR
+ * prefix checks that are easy to get wrong.
+ *
  * https://github.com/vercel/next.js/blob/canary/packages/next/src/server/is-private-ip.ts
  */
 export function isPrivateIp(ip: string): boolean {
+  // Strip IPv6 brackets so ipaddr.js can parse the raw address.
   if (ip.startsWith("[") && ip.endsWith("]")) {
     ip = ip.slice(1, -1);
   }
 
-  // IPv4-mapped IPv6 addresses (::ffff:...)
-  const lowerIp = ip.toLowerCase();
-  if (lowerIp.startsWith("::ffff:")) {
-    const mapped = ip.slice(7);
-    if (mapped.includes(".")) {
-      const ipv4 = parseIPv4(mapped);
-      if (ipv4 && isPrivateIPv4(ipv4)) return true;
-    } else if (mapped.includes(":")) {
-      // Two hex groups like 7f00:1
-      const parts = mapped.split(":");
-      if (parts.length === 2) {
-        const hi = parseInt(parts[0], 16);
-        const lo = parseInt(parts[1], 16);
-        if (!isNaN(hi) && !isNaN(lo)) {
-          return isPrivateIPv4([(hi >>> 8) & 0xff, hi & 0xff, (lo >>> 8) & 0xff, lo & 0xff]);
-        }
-      }
+  try {
+    const parsed = ipaddr.parse(ip);
+    // IPv4-mapped addresses are classified as "ipv4Mapped" by ipaddr.js,
+    // not "unicast". We must look at the embedded IPv4 address to decide
+    // whether it's private (e.g., ::ffff:127.0.0.1) or public.
+    if (parsed instanceof ipaddr.IPv6 && parsed.isIPv4MappedAddress()) {
+      return parsed.toIPv4Address().range() !== "unicast";
     }
+    return parsed.range() !== "unicast";
+  } catch {
+    // Not a valid IP address (e.g., a domain name) — not private.
+    return false;
   }
-
-  if (ip.includes(":")) {
-    return isPrivateIPv6(ip);
-  }
-
-  const ipv4 = parseIPv4(ip);
-  if (ipv4) {
-    return isPrivateIPv4(ipv4);
-  }
-
-  return false;
 }

--- a/packages/vinext/src/shims/image.tsx
+++ b/packages/vinext/src/shims/image.tsx
@@ -91,6 +91,9 @@ function validateRemoteUrl(src: string): { allowed: boolean; reason?: string } {
   }
 
   if (!__dangerouslyAllowLocalIP && isPrivateIp(url.hostname)) {
+    // Best-effort guard for literal-IP hostnames only. Domain names resolving
+    // to private IPs cannot be caught without server-side DNS resolution.
+    // See: Next.js fetchExternalImage in packages/next/src/server/image-optimizer.ts
     return {
       allowed: false,
       reason: `Image URL "${src}" resolved to private IP. If this is expected and you understand SSRF risk, use images.dangerouslyAllowLocalIP = true to continue.`,

--- a/packages/vinext/src/shims/image.tsx
+++ b/packages/vinext/src/shims/image.tsx
@@ -14,7 +14,7 @@
  */
 import React, { forwardRef, useEffect, useLayoutEffect, useRef } from "react";
 import { Image as UnpicImage } from "@unpic/react";
-import { hasRemoteMatch, type RemotePattern } from "./image-config.js";
+import { hasRemoteMatch, isPrivateIp, type RemotePattern } from "./image-config.js";
 import { useMergedRef } from "./use-merged-ref.js";
 
 export type StaticImageData = {
@@ -62,6 +62,13 @@ const __imageDeviceSizes: number[] = (() => {
  */
 const __dangerouslyAllowSVG = process.env.__VINEXT_IMAGE_DANGEROUSLY_ALLOW_SVG === "true";
 /**
+ * Whether dangerouslyAllowLocalIP is enabled in next.config.js.
+ * When false (default), remote image URLs with literal private-IP hostnames
+ * are blocked to mitigate SSRF risk.
+ */
+const __dangerouslyAllowLocalIP = process.env.__VINEXT_IMAGE_DANGEROUSLY_ALLOW_LOCAL_IP === "true";
+
+/**
  * Validate that a remote URL is allowed by the configured remote patterns.
  * Returns true if the URL is allowed, false otherwise.
  *
@@ -71,18 +78,28 @@ const __dangerouslyAllowSVG = process.env.__VINEXT_IMAGE_DANGEROUSLY_ALLOW_SVG =
  * When patterns ARE configured, only matching URLs are allowed.
  * In development, non-matching URLs produce a console warning.
  * In production, non-matching URLs are blocked (src replaced with empty string).
+ *
+ * Private-IP hostnames are additionally rejected unless dangerouslyAllowLocalIP
+ * is set, mirroring Next.js's fetchExternalImage guard.
  */
 function validateRemoteUrl(src: string): { allowed: boolean; reason?: string } {
-  if (!__hasImageConfig) {
-    // No image config — allow everything (backwards-compatible)
-    return { allowed: true };
-  }
-
   let url: URL;
   try {
     url = new URL(src, "http://n");
   } catch {
     return { allowed: false, reason: `Invalid URL: ${src}` };
+  }
+
+  if (!__dangerouslyAllowLocalIP && isPrivateIp(url.hostname)) {
+    return {
+      allowed: false,
+      reason: `Image URL "${src}" resolved to private IP. If this is expected and you understand SSRF risk, use images.dangerouslyAllowLocalIP = true to continue.`,
+    };
+  }
+
+  if (!__hasImageConfig) {
+    // No image config — allow everything (backwards-compatible)
+    return { allowed: true };
   }
 
   if (hasRemoteMatch(__imageDomains, __imageRemotePatterns, url)) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,9 @@ catalogs:
     image-size:
       specifier: 2.0.2
       version: 2.0.2
+    ipaddr.js:
+      specifier: ^2.1.0
+      version: 2.4.0
     knip:
       specifier: ^6.6.2
       version: 6.6.2
@@ -788,6 +791,9 @@ importers:
       image-size:
         specifier: 'catalog:'
         version: 2.0.2
+      ipaddr.js:
+        specifier: 'catalog:'
+        version: 2.4.0
       magic-string:
         specifier: 'catalog:'
         version: 0.30.21
@@ -4543,6 +4549,10 @@ packages:
 
   intl-messageformat@11.1.2:
     resolution: {integrity: sha512-ucSrQmZGAxfiBHfBRXW/k7UC8MaGFlEj4Ry1tKiDcmgwQm1y3EDl40u+4VNHYomxJQMJi9NEI3riDRlth96jKg==}
+
+  ipaddr.js@2.4.0:
+    resolution: {integrity: sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==}
+    engines: {node: '>= 10'}
 
   is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
@@ -8652,6 +8662,8 @@ snapshots:
       '@formatjs/fast-memoize': 3.1.0
       '@formatjs/icu-messageformat-parser': 3.5.1
       tslib: 2.8.1
+
+  ipaddr.js@2.4.0: {}
 
   is-alphabetical@2.0.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -53,6 +53,7 @@ catalog:
   fumadocs-mdx: 14.2.10
   fumadocs-ui: 16.7.9
   image-size: 2.0.2
+  ipaddr.js: ^2.1.0
   lucide-react: ^0.577.0
   magic-string: ^0.30.21
   ms: 3.0.0-canary.1

--- a/tests/image-component.test.ts
+++ b/tests/image-component.test.ts
@@ -8,7 +8,7 @@
  * Tests SSR output, srcSet generation, getImageProps(), fill mode,
  * priority, custom loader, and static image data handling.
  */
-import { describe, it, expect } from "vite-plus/test";
+import { describe, it, expect, vi, afterEach } from "vite-plus/test";
 import React from "react";
 import ReactDOMServer from "react-dom/server";
 import Image, { getImageProps, type StaticImageData } from "../packages/vinext/src/shims/image.js";
@@ -776,5 +776,123 @@ describe("onLoad / onError handler attachment (SSR)", () => {
     );
     expect(html).toContain("<img");
     expect(html).toContain('alt="remote events"');
+  });
+});
+
+// ─── dangerouslyAllowLocalIP / private-IP guard ─────────────────────────
+// Ported from Next.js: test/unit/image-optimizer/fetch-external-image.test.ts
+// https://github.com/vercel/next.js/blob/canary/test/unit/image-optimizer/fetch-external-image.test.ts
+
+describe("dangerouslyAllowLocalIP private-IP guard", () => {
+  const previousNodeEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    process.env.NODE_ENV = previousNodeEnv;
+    delete process.env.__VINEXT_IMAGE_REMOTE_PATTERNS;
+    delete process.env.__VINEXT_IMAGE_DOMAINS;
+    delete process.env.__VINEXT_IMAGE_DANGEROUSLY_ALLOW_LOCAL_IP;
+  });
+
+  it("blocks private-IP remote URLs in production (Image returns null)", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.__VINEXT_IMAGE_REMOTE_PATTERNS = JSON.stringify([{ hostname: "**" }]);
+    process.env.__VINEXT_IMAGE_DANGEROUSLY_ALLOW_LOCAL_IP = "false";
+
+    vi.resetModules();
+    const { default: PrivateIpImage } = await import("../packages/vinext/src/shims/image.js");
+
+    const html = ReactDOMServer.renderToString(
+      React.createElement(PrivateIpImage, {
+        alt: "private ip",
+        src: "http://127.0.0.1/photo.jpg",
+        width: 400,
+        height: 300,
+      }),
+    );
+    // Production: blocked → no img tag rendered
+    expect(html).not.toContain("<img");
+  });
+
+  it("blocks private-IP remote URLs in production (getImageProps returns empty src)", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.__VINEXT_IMAGE_REMOTE_PATTERNS = JSON.stringify([{ hostname: "**" }]);
+    process.env.__VINEXT_IMAGE_DANGEROUSLY_ALLOW_LOCAL_IP = "false";
+
+    vi.resetModules();
+    const { getImageProps: privateIpGetImageProps } =
+      await import("../packages/vinext/src/shims/image.js");
+
+    const { props } = privateIpGetImageProps({
+      alt: "private ip",
+      src: "http://192.168.1.1/photo.jpg",
+      width: 400,
+      height: 300,
+    });
+    expect(props.src).toBe("");
+  });
+
+  it("allows private-IP remote URLs when dangerouslyAllowLocalIP = true", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.__VINEXT_IMAGE_REMOTE_PATTERNS = JSON.stringify([{ hostname: "**" }]);
+    process.env.__VINEXT_IMAGE_DANGEROUSLY_ALLOW_LOCAL_IP = "true";
+
+    vi.resetModules();
+    const { default: PrivateIpImage } = await import("../packages/vinext/src/shims/image.js");
+
+    const html = ReactDOMServer.renderToString(
+      React.createElement(PrivateIpImage, {
+        alt: "private ip allowed",
+        src: "http://10.0.0.1/photo.jpg",
+        width: 400,
+        height: 300,
+      }),
+    );
+    expect(html).toContain("<img");
+    expect(html).toContain('alt="private ip allowed"');
+  });
+
+  it("allows public-IP remote URLs regardless of dangerouslyAllowLocalIP", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.__VINEXT_IMAGE_REMOTE_PATTERNS = JSON.stringify([{ hostname: "**" }]);
+    process.env.__VINEXT_IMAGE_DANGEROUSLY_ALLOW_LOCAL_IP = "false";
+
+    vi.resetModules();
+    const { default: PrivateIpImage } = await import("../packages/vinext/src/shims/image.js");
+
+    const html = ReactDOMServer.renderToString(
+      React.createElement(PrivateIpImage, {
+        alt: "public ip",
+        src: "http://8.8.8.8/photo.jpg",
+        width: 400,
+        height: 300,
+      }),
+    );
+    expect(html).toContain("<img");
+    expect(html).toContain('alt="public ip"');
+  });
+
+  it("warns but does not block private-IP remote URLs in development", async () => {
+    process.env.NODE_ENV = "development";
+    process.env.__VINEXT_IMAGE_REMOTE_PATTERNS = JSON.stringify([{ hostname: "**" }]);
+    process.env.__VINEXT_IMAGE_DANGEROUSLY_ALLOW_LOCAL_IP = "false";
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    vi.resetModules();
+    const { default: PrivateIpImage } = await import("../packages/vinext/src/shims/image.js");
+
+    const html = ReactDOMServer.renderToString(
+      React.createElement(PrivateIpImage, {
+        alt: "private ip dev",
+        src: "http://172.16.0.1/photo.jpg",
+        width: 400,
+        height: 300,
+      }),
+    );
+    // Dev: warn but still render
+    expect(html).toContain("<img");
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("resolved to private IP"));
+
+    warnSpy.mockRestore();
   });
 });

--- a/tests/image-component.test.ts
+++ b/tests/image-component.test.ts
@@ -798,6 +798,8 @@ describe("dangerouslyAllowLocalIP private-IP guard", () => {
     process.env.__VINEXT_IMAGE_REMOTE_PATTERNS = JSON.stringify([{ hostname: "**" }]);
     process.env.__VINEXT_IMAGE_DANGEROUSLY_ALLOW_LOCAL_IP = "false";
 
+    // Module-level constants in image.tsx are evaluated at import time from
+    // process.env, so we must re-evaluate the module after changing env.
     vi.resetModules();
     const { default: PrivateIpImage } = await import("../packages/vinext/src/shims/image.js");
 
@@ -836,6 +838,8 @@ describe("dangerouslyAllowLocalIP private-IP guard", () => {
     process.env.__VINEXT_IMAGE_REMOTE_PATTERNS = JSON.stringify([{ hostname: "**" }]);
     process.env.__VINEXT_IMAGE_DANGEROUSLY_ALLOW_LOCAL_IP = "true";
 
+    // Module-level constants in image.tsx are evaluated at import time from
+    // process.env, so we must re-evaluate the module after changing env.
     vi.resetModules();
     const { default: PrivateIpImage } = await import("../packages/vinext/src/shims/image.js");
 
@@ -856,6 +860,8 @@ describe("dangerouslyAllowLocalIP private-IP guard", () => {
     process.env.__VINEXT_IMAGE_REMOTE_PATTERNS = JSON.stringify([{ hostname: "**" }]);
     process.env.__VINEXT_IMAGE_DANGEROUSLY_ALLOW_LOCAL_IP = "false";
 
+    // Module-level constants in image.tsx are evaluated at import time from
+    // process.env, so we must re-evaluate the module after changing env.
     vi.resetModules();
     const { default: PrivateIpImage } = await import("../packages/vinext/src/shims/image.js");
 
@@ -878,6 +884,8 @@ describe("dangerouslyAllowLocalIP private-IP guard", () => {
 
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
+    // Module-level constants in image.tsx are evaluated at import time from
+    // process.env, so we must re-evaluate the module after changing env.
     vi.resetModules();
     const { default: PrivateIpImage } = await import("../packages/vinext/src/shims/image.js");
 

--- a/tests/image-config.test.ts
+++ b/tests/image-config.test.ts
@@ -289,13 +289,35 @@ describe("isPrivateIp", () => {
     expect(isPrivateIp("::ffff:0.0.0.0")).toBe(true);
     expect(isPrivateIp("::ffff:127.0.0.1")).toBe(true);
     expect(isPrivateIp("::ffff:7f00:1")).toBe(true);
-    expect(isPrivateIp("2001:2f:ffff:ffff:ffff:ffff:ffff:ffff")).toBe(true);
-    expect(isPrivateIp("[2001:2f:ffff:ffff:ffff:ffff:ffff:ffff]")).toBe(true);
     expect(isPrivateIp("2002::")).toBe(true);
     expect(isPrivateIp("ff00::")).toBe(true);
     expect(isPrivateIp("fc00::")).toBe(true);
     expect(isPrivateIp("fe80::1")).toBe(true);
     expect(isPrivateIp("fd00::1")).toBe(true);
+  });
+
+  it("returns true for additional non-unicast IPv4 ranges (CGNAT, multicast, reserved, benchmarking, documentation)", () => {
+    expect(isPrivateIp("100.64.0.0")).toBe(true); // CGNAT (100.64.0.0/10)
+    expect(isPrivateIp("100.127.255.255")).toBe(true);
+    expect(isPrivateIp("198.18.0.0")).toBe(true); // benchmarking (198.18.0.0/15)
+    expect(isPrivateIp("198.19.255.255")).toBe(true);
+    expect(isPrivateIp("224.0.0.0")).toBe(true); // multicast (224.0.0.0/4)
+    expect(isPrivateIp("239.255.255.255")).toBe(true);
+    expect(isPrivateIp("240.0.0.0")).toBe(true); // reserved (240.0.0.0/4)
+    expect(isPrivateIp("255.255.255.255")).toBe(true); // broadcast
+    expect(isPrivateIp("192.0.0.0")).toBe(true); // IETF protocol (192.0.0.0/24)
+    expect(isPrivateIp("192.0.0.255")).toBe(true);
+    expect(isPrivateIp("198.51.100.0")).toBe(true); // TEST-NET-2 (198.51.100.0/24)
+    expect(isPrivateIp("203.0.113.0")).toBe(true); // TEST-NET-3 (203.0.113.0/24)
+  });
+
+  it("returns true for additional non-unicast IPv6 ranges (teredo, benchmarking, documentation, discard, NAT64)", () => {
+    expect(isPrivateIp("2001::1")).toBe(true); // teredo (2001::/32)
+    expect(isPrivateIp("2001:0:ffff:ffff:ffff:ffff:ffff:ffff")).toBe(true);
+    expect(isPrivateIp("2001:2::1")).toBe(true); // benchmarking (2001:2::/48, RFC 5180)
+    expect(isPrivateIp("2001:db8::1")).toBe(true); // documentation (2001:db8::/32)
+    expect(isPrivateIp("100::1")).toBe(true); // discard (100::/64)
+    expect(isPrivateIp("64:ff9b::1")).toBe(true); // NAT64 (64:ff9b::/96)
   });
 
   it("returns false for public IP addresses", () => {

--- a/tests/image-config.test.ts
+++ b/tests/image-config.test.ts
@@ -9,6 +9,7 @@ import { describe, it, expect } from "vite-plus/test";
 import {
   matchRemotePattern,
   hasRemoteMatch,
+  isPrivateIp,
   type RemotePattern,
 } from "../packages/vinext/src/shims/image-config.js";
 
@@ -257,5 +258,61 @@ describe("matchRemotePattern glob edge cases", () => {
     expect(matchRemotePattern(pattern, new URL("http://cdn.example.com/uploads/a.png"))).toBe(
       false,
     );
+  });
+});
+
+// ─── isPrivateIp ─────────────────────────────────────────────────────────
+// Ported from Next.js: packages/next/src/server/is-private-ip.test.ts
+// https://github.com/vercel/next.js/blob/canary/packages/next/src/server/is-private-ip.test.ts
+
+describe("isPrivateIp", () => {
+  it("returns true for private IPv4 addresses", () => {
+    expect(isPrivateIp("127.0.0.0")).toBe(true);
+    expect(isPrivateIp("127.0.0.1")).toBe(true);
+    expect(isPrivateIp("127.0.0.01")).toBe(true);
+    expect(isPrivateIp("127.0.0.001")).toBe(true);
+    expect(isPrivateIp("0.0.0.0")).toBe(true);
+    expect(isPrivateIp("10.0.0.0")).toBe(true);
+    expect(isPrivateIp("10.244.0.0")).toBe(true);
+    expect(isPrivateIp("192.168.0.0")).toBe(true);
+    expect(isPrivateIp("192.168.0.1")).toBe(true);
+    expect(isPrivateIp("192.168.0.01")).toBe(true);
+    expect(isPrivateIp("172.16.0.0")).toBe(true);
+    expect(isPrivateIp("172.16.0.1")).toBe(true);
+    expect(isPrivateIp("172.16.0.01")).toBe(true);
+    expect(isPrivateIp("169.254.169.254")).toBe(true);
+  });
+
+  it("returns true for private IPv6 addresses", () => {
+    expect(isPrivateIp("::")).toBe(true);
+    expect(isPrivateIp("::1")).toBe(true);
+    expect(isPrivateIp("::ffff:0.0.0.0")).toBe(true);
+    expect(isPrivateIp("::ffff:127.0.0.1")).toBe(true);
+    expect(isPrivateIp("::ffff:7f00:1")).toBe(true);
+    expect(isPrivateIp("2001:2f:ffff:ffff:ffff:ffff:ffff:ffff")).toBe(true);
+    expect(isPrivateIp("[2001:2f:ffff:ffff:ffff:ffff:ffff:ffff]")).toBe(true);
+    expect(isPrivateIp("2002::")).toBe(true);
+    expect(isPrivateIp("ff00::")).toBe(true);
+    expect(isPrivateIp("fc00::")).toBe(true);
+    expect(isPrivateIp("fe80::1")).toBe(true);
+    expect(isPrivateIp("fd00::1")).toBe(true);
+  });
+
+  it("returns false for public IP addresses", () => {
+    expect(isPrivateIp("76.76.21.21")).toBe(false);
+    expect(isPrivateIp("157.240.14.35")).toBe(false);
+    expect(isPrivateIp("8.8.8.8")).toBe(false);
+    expect(isPrivateIp("1.1.1.1")).toBe(false);
+    expect(isPrivateIp("::ffff:8.8.8.8")).toBe(false);
+    expect(isPrivateIp("::ffff:1.1.1.1")).toBe(false);
+    expect(isPrivateIp("2001:4860:4860::8888")).toBe(false);
+    expect(isPrivateIp("2606:4700:4700::1111")).toBe(false);
+  });
+
+  it("returns false for domain names", () => {
+    expect(isPrivateIp("vercel.com")).toBe(false);
+    expect(isPrivateIp("www.vercel.com")).toBe(false);
+    expect(isPrivateIp("nextjs.org")).toBe(false);
+    expect(isPrivateIp("docs.nextjs.org")).toBe(false);
   });
 });


### PR DESCRIPTION
Ports Next.js commit 5452439f3db2a78967178ca4180b27fb48393a19 (PR #91686) to vinext's next/image shim and server-side image config.

## Changes
- Add `isPrivateIp()` helper in `shims/image-config.ts` (IPv4 + IPv6, zero dependencies)
- Update `validateRemoteUrl` in `shims/image.tsx` to reject literal private-IP hostnames unless `dangerouslyAllowLocalIP` is true
- Wire `dangerouslyAllowLocalIP` through `next-config` type, Vite define, `global.d.ts`, and server-side `ImageConfig`
- Add unit tests for `isPrivateIp` and component-level private-IP guard

## Why
Next.js 16 added a server-side SSRF guard in `fetchExternalImage` that blocks upstream image hostnames resolving to private IPs, with an opt-out via `images.dangerouslyAllowLocalIP`. vinext needs parity for ecosystem compatibility.

Since vinext does not have a server-side `fetchExternalImage` equivalent, this implements a best-effort client-side guard for literal IP hostnames. Domain names that resolve to private IPs cannot be caught without DNS resolution.

## Testing
- `pnpm test run tests/image-config.test.ts tests/image-component.test.ts` — 103 tests pass
- `vp check` passes

Closes #1065