### PR TITLE
feat(image): add images.dangerouslyAllowLocalIP config parity

### DIFF
--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -169,6 +169,8 @@ export type NextConfig = {
     imageSizes?: number[];
     /** Allow SVG images through the image optimization endpoint. SVG can contain scripts, so only enable if you trust all image sources. */
     dangerouslyAllowSVG?: boolean;
+    /** Allow fetching upstream images that resolve to private/local IPs. Use only when hosting in a VPC with split-horizon DNS. Defaults to false. */
+    dangerouslyAllowLocalIP?: boolean;
     /** Content-Disposition header for image responses. Defaults to "inline". */
     contentDispositionType?: "inline" | "attachment";
     /** Content-Security-Policy header for image responses. Defaults to "script-src 'none'; frame-src 'none'; sandbox;" */

--- a/packages/vinext/src/deploy.ts
+++ b/packages/vinext/src/deploy.ts
@@ -463,6 +463,8 @@ import { handleImageOptimization, DEFAULT_DEVICE_SIZES, DEFAULT_IMAGE_SIZES } fr
 import type { ImageConfig } from "vinext/server/image-optimization";
 import handler from "vinext/server/app-router-entry";
 ${isrImports}
+// @ts-expect-error -- virtual module resolved by vinext at build time
+import { vinextConfig } from "virtual:vinext-server-entry";
 interface Env {
   ASSETS: Fetcher;${isrEnvField}
   IMAGES: {
@@ -479,11 +481,13 @@ interface ExecutionContext {
   passThroughOnException(): void;
 }
 
-// Image security config. SVG sources with .svg extension auto-skip the
-// optimization endpoint on the client side (served directly, no proxy).
-// To route SVGs through the optimizer (with security headers), set
-// dangerouslyAllowSVG: true in next.config.js and uncomment below:
-// const imageConfig: ImageConfig = { dangerouslyAllowSVG: true };
+// Extract config values (embedded at build time in the server entry)
+const imageConfig: ImageConfig | undefined = vinextConfig?.images ? {
+  dangerouslyAllowSVG: vinextConfig.images.dangerouslyAllowSVG,
+  dangerouslyAllowLocalIP: vinextConfig.images.dangerouslyAllowLocalIP,
+  contentDispositionType: vinextConfig.images.contentDispositionType,
+  contentSecurityPolicy: vinextConfig.images.contentSecurityPolicy,
+} : undefined;
 
 export default {
   async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
@@ -500,7 +504,7 @@ ${isrSetup}    const url = new URL(request.url);
           const result = await env.IMAGES.input(body).transform(width > 0 ? { width } : {}).output({ format, quality });
           return result.response();
         },
-      }, allowedWidths);
+      }, allowedWidths, imageConfig);
     }
 
     // Delegate everything else to vinext, forwarding ctx so that
@@ -562,6 +566,7 @@ const configRewrites = vinextConfig?.rewrites ?? { beforeFiles: [], afterFiles: 
 const configHeaders = vinextConfig?.headers ?? [];
 const imageConfig: ImageConfig | undefined = vinextConfig?.images ? {
   dangerouslyAllowSVG: vinextConfig.images.dangerouslyAllowSVG,
+  dangerouslyAllowLocalIP: vinextConfig.images.dangerouslyAllowLocalIP,
   contentDispositionType: vinextConfig.images.contentDispositionType,
   contentSecurityPolicy: vinextConfig.images.contentSecurityPolicy,
 } : undefined;

--- a/packages/vinext/src/entries/pages-server-entry.ts
+++ b/packages/vinext/src/entries/pages-server-entry.ts
@@ -106,6 +106,7 @@ export async function generateServerEntry(
       deviceSizes: nextConfig?.images?.deviceSizes,
       imageSizes: nextConfig?.images?.imageSizes,
       dangerouslyAllowSVG: nextConfig?.images?.dangerouslyAllowSVG,
+      dangerouslyAllowLocalIP: nextConfig?.images?.dangerouslyAllowLocalIP,
       contentDispositionType: nextConfig?.images?.contentDispositionType,
       contentSecurityPolicy: nextConfig?.images?.contentSecurityPolicy,
     },

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -3191,6 +3191,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
 
           const imageConfig = {
             dangerouslyAllowSVG: nextConfig?.images?.dangerouslyAllowSVG,
+            dangerouslyAllowLocalIP: nextConfig?.images?.dangerouslyAllowLocalIP,
             contentDispositionType: nextConfig?.images?.contentDispositionType,
             contentSecurityPolicy: nextConfig?.images?.contentSecurityPolicy,
           };

--- a/packages/vinext/src/server/image-optimization.ts
+++ b/packages/vinext/src/server/image-optimization.ts
@@ -29,6 +29,8 @@ export const IMAGE_OPTIMIZATION_PATH = "/_vinext/image";
 export type ImageConfig = {
   /** Allow SVG through the image optimization endpoint. Default: false. */
   dangerouslyAllowSVG?: boolean;
+  /** Allow fetching upstream images that resolve to private/local IPs. Default: false. */
+  dangerouslyAllowLocalIP?: boolean;
   /** Content-Disposition header value. Default: "inline". */
   contentDispositionType?: "inline" | "attachment";
   /** Content-Security-Policy header value. Default: "script-src 'none'; frame-src 'none'; sandbox;" */

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -480,6 +480,14 @@ describe("generateAppRouterWorkerEntry", () => {
     expect(content).toContain("env.IMAGES");
   });
 
+  it("includes dangerouslyAllowLocalIP in imageConfig extraction", () => {
+    const content = generateAppRouterWorkerEntry();
+    const imageConfigStart = content.indexOf("const imageConfig: ImageConfig | undefined");
+    const imageConfigEnd = content.indexOf("};", imageConfigStart);
+    const imageConfigBlock = content.slice(imageConfigStart, imageConfigEnd);
+    expect(imageConfigBlock).toContain("dangerouslyAllowLocalIP");
+  });
+
   it("does not include KV wiring when hasISR is false", () => {
     const content = generateAppRouterWorkerEntry(false);
     expect(content).not.toContain("KVCacheHandler");
@@ -663,6 +671,14 @@ describe("generatePagesRouterWorkerEntry", () => {
     expect(content).toContain("transformImage:");
     expect(content).toContain("env.ASSETS.fetch");
     expect(content).toContain("env.IMAGES");
+  });
+
+  it("includes dangerouslyAllowLocalIP in imageConfig extraction", () => {
+    const content = generatePagesRouterWorkerEntry();
+    const imageConfigStart = content.indexOf("const imageConfig: ImageConfig");
+    const imageConfigEnd = content.indexOf("};", imageConfigStart);
+    const imageConfigBlock = content.slice(imageConfigStart, imageConfigEnd);
+    expect(imageConfigBlock).toContain("dangerouslyAllowLocalIP");
   });
 
   it("merges middleware and config headers into responses with correct precedence", () => {
@@ -1137,7 +1153,7 @@ describe("getFilesToGenerate", () => {
     const workerFile = files.find((f) => f.description === "worker/index.ts");
     expect(workerFile).toBeDefined();
     expect(workerFile!.content).toContain("vinext/server/app-router-entry");
-    expect(workerFile!.content).not.toContain("virtual:vinext-server-entry");
+    expect(workerFile!.content).toContain("virtual:vinext-server-entry");
   });
 
   it("generates Pages Router worker entry for Pages Router project", () => {

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -677,6 +677,16 @@ describe("generateBuildId", () => {
     expect(config.buildId.length).toBeGreaterThan(0);
   });
 
+  it("preserves dangerouslyAllowLocalIP from images config", async () => {
+    const config = await resolveNextConfig({ images: { dangerouslyAllowLocalIP: true } });
+    expect(config.images?.dangerouslyAllowLocalIP).toBe(true);
+  });
+
+  it("preserves dangerouslyAllowLocalIP as false", async () => {
+    const config = await resolveNextConfig({ images: { dangerouslyAllowLocalIP: false } });
+    expect(config.images?.dangerouslyAllowLocalIP).toBe(false);
+  });
+
   it("uses the string returned by generateBuildId", async () => {
     const config = await resolveNextConfig({ generateBuildId: () => "my-custom-build-id" });
     expect(config.buildId).toBe("my-custom-build-id");


### PR DESCRIPTION
Next.js PR #91686 added `images.dangerouslyAllowLocalIP` (default false) and a server-side SSRF guard in `fetchExternalImage` that rejects hostnames resolving to private IPs.

vinext does not fetch external images server-side (`parseImageParams` already blocks absolute URLs), so we do not need a DNS-resolution-based guard. This change adds config-level parity so that Next.js configs using `dangerouslyAllowLocalIP` do not silently drop the field.

## Changes
- Add `dangerouslyAllowLocalIP` to `ImageConfig` type
- Add `dangerouslyAllowLocalIP` to next-config schema
- Serialize `dangerouslyAllowLocalIP` into `image-config.json` at build time
- Include `dangerouslyAllowLocalIP` in pages-server-entry runtime config
- Include `dangerouslyAllowLocalIP` in App/Pages worker entry templates
- Pass `imageConfig` through to `handleImageOptimization` in deploy templates
- Add tests for config resolution and deploy template extraction

Closes #1065
Ported-from: vercel/next.js#91686

Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.github.com>