### PR TITLE
feat(server): add waitForAllReady forkpoint for prerender/ISR parity (#1011)

### DIFF
--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -434,6 +434,7 @@ export async function renderAppPageLifecycle(
         scriptNonce: options.scriptNonce,
         sideStream: rscCapture.sideStream,
         ssrHandler,
+        waitForAllReady: options.isPrerender,
       });
     },
     renderSpecialErrorResponse(specialError) {

--- a/packages/vinext/src/server/app-page-stream.ts
+++ b/packages/vinext/src/server/app-page-stream.ts
@@ -23,6 +23,8 @@ export type AppPageSsrHandler = {
       scriptNonce?: string;
       sideStream?: ReadableStream<Uint8Array>;
       capturedRscDataRef?: { value: Promise<ArrayBuffer> | null };
+      /** When true, wait for the full React tree before emitting bytes. */
+      waitForAllReady?: boolean;
     },
   ) => Promise<ReadableStream<Uint8Array>>;
 };
@@ -38,6 +40,8 @@ type RenderAppPageHtmlStreamOptions = {
   sideStream?: ReadableStream<Uint8Array>;
   /** Out-parameter filled with accumulated raw RSC bytes after stream consumption. */
   capturedRscDataRef?: { value: Promise<ArrayBuffer> | null };
+  /** When true, wait for the full React tree before emitting bytes. */
+  waitForAllReady?: boolean;
 };
 
 type RenderAppPageHtmlResponseOptions = {
@@ -92,6 +96,7 @@ export async function renderAppPageHtmlStream(
     scriptNonce: options.scriptNonce,
     sideStream: options.sideStream,
     capturedRscDataRef: options.capturedRscDataRef,
+    waitForAllReady: options.waitForAllReady,
   };
 
   return options.ssrHandler.handleSsr(

--- a/packages/vinext/src/server/app-ssr-entry.ts
+++ b/packages/vinext/src/server/app-ssr-entry.ts
@@ -155,6 +155,10 @@ export async function handleSsr(
     sideStream?: ReadableStream<Uint8Array>;
     /** Out-parameter: filled with accumulated raw RSC bytes when sideStream is consumed. */
     capturedRscDataRef?: { value: Promise<ArrayBuffer> | null };
+    /** When true, wait for the full React tree (including Suspense boundaries)
+     *  to resolve before returning the HTML stream. Used for static prerender
+     *  and ISR cache writes to avoid caching fallback content. */
+    waitForAllReady?: boolean;
   },
 ): Promise<ReadableStream<Uint8Array>> {
   return runWithNavigationContext(async () => {
@@ -235,6 +239,14 @@ export async function handleSsr(
           return undefined;
         },
       });
+
+      // When producing static output (prerender / ISR cache writes), wait for
+      // the full React tree to resolve before emitting bytes. This prevents
+      // Suspense fallback content from being serialized to the cache.
+      // Matches Next.js waitForAllReady forkpoint in renderToNodeFizzStream.
+      if (options?.waitForAllReady === true) {
+        await htmlStream.allReady;
+      }
 
       const fontHTML = renderFontHtml(fontData, options?.scriptNonce);
       let didInjectHeadHTML = false;

--- a/tests/app-page-stream.test.ts
+++ b/tests/app-page-stream.test.ts
@@ -81,13 +81,12 @@ describe("app page stream helpers", () => {
 
     await expect(new Response(htmlStream).text()).resolves.toBe("<html>all-ready</html>");
     expect(ssrHandler).toHaveBeenCalledTimes(1);
-    const callArgs = ssrHandler.mock.calls[0] as unknown as [
-      unknown,
-      unknown,
-      unknown,
-      { waitForAllReady?: boolean },
-    ];
-    expect(callArgs[3]).toMatchObject({ waitForAllReady: true });
+    expect(ssrHandler).toHaveBeenCalledWith(
+      expect.anything(),
+      null,
+      expect.anything(),
+      expect.objectContaining({ waitForAllReady: true }),
+    );
   });
 
   it("defers clearRequestContext until the HTML stream body is fully consumed", async () => {

--- a/tests/app-page-stream.test.ts
+++ b/tests/app-page-stream.test.ts
@@ -64,6 +64,32 @@ describe("app page stream helpers", () => {
     await expect(new Response(htmlStream).text()).resolves.toBe("<html>ok</html>");
   });
 
+  it("forwards waitForAllReady to the SSR handler", async () => {
+    const ssrHandler = vi.fn(async () => createStream(["<html>all-ready</html>"]));
+
+    const htmlStream = await renderAppPageHtmlStream({
+      fontData: createAppPageFontData({
+        getLinks: () => [],
+        getPreloads: () => [],
+        getStyles: () => [],
+      }),
+      navigationContext: null,
+      rscStream: createStream(["flight"]),
+      waitForAllReady: true,
+      ssrHandler: { handleSsr: ssrHandler },
+    });
+
+    await expect(new Response(htmlStream).text()).resolves.toBe("<html>all-ready</html>");
+    expect(ssrHandler).toHaveBeenCalledTimes(1);
+    const callArgs = ssrHandler.mock.calls[0] as unknown as [
+      unknown,
+      unknown,
+      unknown,
+      { waitForAllReady?: boolean },
+    ];
+    expect(callArgs[3]).toMatchObject({ waitForAllReady: true });
+  });
+
   it("defers clearRequestContext until the HTML stream body is fully consumed", async () => {
     // Regression test for issue #660: clearRequestContext() must not race the
     // lazy RSC/SSR stream pipeline. It should be called only after the HTTP


### PR DESCRIPTION
Mirrors Next.js PR #93376: adds a `waitForAllReady` option that defers emitting the HTML stream until React's `onAllReady` fires, ensuring the full tree (including resolved Suspense boundaries) is present before serialization.

### Changes
- `app-ssr-entry.ts`: accept `waitForAllReady` and await `stream.allReady`
- `app-page-stream.ts`: thread `waitForAllReady` through the pipeline
- `app-page-render.ts`: pass `waitForAllReady: isPrerender` to the HTML render
- `tests/app-page-stream.test.ts`: add unit test verifying option forwarding

### Verification
- `pnpm test tests/app-page-stream.test.ts tests/app-page-render.test.ts` — 34 passing
- `pnpm test tests/app-page-cache.test.ts tests/isr-cache.test.ts` — 79 additional passing
- Formatting auto-fixed via `pnpm run fmt`

Closes #1011