### PR TITLE
fix: stream Suspense fallbacks during draft mode in App Router

### DIFF
--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -326,7 +326,7 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
     return methodResponse;
   }
 
-  if (isForceStatic || isDynamicError) {
+  if ((isForceStatic || isDynamicError) && !isDraftMode) {
     setHeadersContext(
       createStaticGenerationHeadersContext({
         dynamicConfig,

--- a/tests/fixtures/app-basic/app/nextjs-compat/draftmode/streaming/layout.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/draftmode/streaming/layout.tsx
@@ -1,0 +1,13 @@
+import type { ReactNode } from "react";
+import { draftMode } from "next/headers";
+
+export default async function Layout({ children }: { children: ReactNode }) {
+  const { isEnabled } = await draftMode();
+
+  return (
+    <>
+      <div id="draft-mode">{String(isEnabled)}</div>
+      {children}
+    </>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/draftmode/streaming/loading.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/draftmode/streaming/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <div id="delayed-runtime-fallback">Loading draft content...</div>;
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/draftmode/streaming/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/draftmode/streaming/page.tsx
@@ -1,0 +1,5 @@
+export default async function Page() {
+  await new Promise((resolve) => setTimeout(resolve, 100));
+
+  return <div id="delayed-runtime-content">Draft runtime content</div>;
+}

--- a/tests/nextjs-compat/draft-mode.test.ts
+++ b/tests/nextjs-compat/draft-mode.test.ts
@@ -17,7 +17,7 @@
 
 import { describe, it, expect, beforeAll, afterAll } from "vite-plus/test";
 import type { ViteDevServer } from "vite-plus";
-import { APP_FIXTURE_DIR, startFixtureServer, fetchJson } from "../helpers.js";
+import { APP_FIXTURE_DIR, startFixtureServer, fetchJson, fetchHtml } from "../helpers.js";
 
 describe("Next.js compat: draft-mode", () => {
   let server: ViteDevServer;
@@ -207,5 +207,26 @@ describe("Next.js compat: draft-mode", () => {
       /Page with `dynamic = (?:&quot;|\\")error(?:&quot;|\\")` used a dynamic API/,
     );
     expect(res.headers.getSetCookie()).toEqual([]);
+  });
+
+  // ── Draft mode streams Suspense fallbacks ────────────────────
+  // Ported from Next.js: test/e2e/app-dir/cache-components/cache-components.draft-mode.test.ts
+  // https://github.com/vercel/next.js/pull/93417
+
+  it("should stream Suspense fallbacks when draft mode is enabled", async () => {
+    // Enable draft mode and extract the bypass cookie
+    const draftRes = await fetch(`${baseUrl}/nextjs-compat/api/draft-enable`);
+    const setCookies = draftRes.headers.getSetCookie();
+    const bypassCookie = setCookies.find((c) => c.includes("__prerender_bypass"));
+    expect(bypassCookie).toBeDefined();
+    const rawCookie = bypassCookie!.split(";")[0];
+
+    // Request the streaming page with the draft cookie
+    const { html } = await fetchHtml(baseUrl, "/nextjs-compat/draftmode/streaming", {
+      headers: { Cookie: rawCookie },
+    });
+
+    expect(html).toContain('id="draft-mode">true');
+    expect(html).toContain("Loading draft content...");
   });
 });


### PR DESCRIPTION
Fixes #1009

## Summary
- Skip static generation context setup for draft mode requests in `app-page-dispatch.ts`, matching Next.js behavior where draft mode opts into dynamic HTML rendering.
- Port test fixture and streaming test from Next.js PR #93417 to verify draft-mode pages stream their `loading.tsx` / Suspense fallbacks.

## Test plan
- Added streaming test to `tests/nextjs-compat/draft-mode.test.ts`
- Added fixture pages at `tests/fixtures/app-basic/app/nextjs-compat/draftmode/streaming/`
- Verified draft-mode requests show Suspense fallback text in HTML response
