### PR TITLE
chore: build vinext on postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "lint": "vp lint",
     "test:e2e": "playwright test",
     "knip": "knip",
-    "prepare": "vp config"
+    "prepare": "vp config",
+    "postinstall": "vp run vinext#build"
   },
   "dependencies": {
     "@mdx-js/react": "catalog:",


### PR DESCRIPTION
## Summary
- Add a `postinstall` script at the monorepo root that runs `vp run vinext#build`, so the main `vinext` package's `dist/` is built automatically after `pnpm install`.

## Test plan
- [ ] `pnpm install` from a clean checkout produces `packages/vinext/dist/` without a separate `pnpm build` step.