### PR TITLE
feat: implement next web vitals hook

### DIFF
--- a/packages/vinext/package.json
+++ b/packages/vinext/package.json
@@ -69,7 +69,8 @@
     "image-size": "catalog:",
     "magic-string": "catalog:",
     "vite-plugin-commonjs": "catalog:",
-    "vite-tsconfig-paths": "catalog:"
+    "vite-tsconfig-paths": "catalog:",
+    "web-vitals": "catalog:"
   },
   "devDependencies": {
     "@types/node": "catalog:",

--- a/packages/vinext/src/shims/next-shims.d.ts
+++ b/packages/vinext/src/shims/next-shims.d.ts
@@ -550,15 +550,10 @@ declare module "next/form" {
 }
 
 declare module "next/web-vitals" {
-  type WebVitalsMetric = {
-    id: string;
-    name: string;
-    value: number;
-    rating?: "good" | "needs-improvement" | "poor";
-    delta: number;
-    navigationType?: "navigate" | "reload" | "back-forward" | "prerender";
-  };
-  type ReportWebVitalsCallback = (metric: WebVitalsMetric) => void;
+  import type { MetricType } from "web-vitals";
+
+  export type WebVitalsMetric = MetricType;
+  export type ReportWebVitalsCallback = (metric: WebVitalsMetric) => void;
   export function useReportWebVitals(callback: ReportWebVitalsCallback): void;
 }
 

--- a/packages/vinext/src/shims/web-vitals.ts
+++ b/packages/vinext/src/shims/web-vitals.ts
@@ -1,30 +1,28 @@
-/**
- * next/web-vitals shim
- *
- * Provides useReportWebVitals() — a no-op hook for compatibility.
- * In real Next.js, this sends Core Web Vitals to an analytics endpoint.
- * Apps can use the web-vitals library directly instead.
- */
+import { useEffect, useRef } from "react";
+import { onCLS, onFID, onLCP, onINP, onFCP, onTTFB, type MetricType } from "web-vitals";
 
-type WebVitalsMetric = {
-  id: string;
-  name: string;
-  value: number;
-  rating?: "good" | "needs-improvement" | "poor";
-  delta: number;
-  navigationType?: "navigate" | "reload" | "back-forward" | "prerender";
-};
-
+type WebVitalsMetric = MetricType;
 type ReportWebVitalsCallback = (metric: WebVitalsMetric) => void;
 
-/**
- * Register a callback to receive Core Web Vitals metrics.
- * No-op in our implementation — use the `web-vitals` library directly
- * for production metrics collection.
- */
-export function useReportWebVitals(_callback: ReportWebVitalsCallback): void {
-  // No-op — apps should use the web-vitals library directly
-  // or their own analytics integration.
+export function useReportWebVitals(callback: ReportWebVitalsCallback): void {
+  const callbackRef = useRef(callback);
+
+  useEffect(() => {
+    callbackRef.current = callback;
+  }, [callback]);
+
+  useEffect(() => {
+    const reportWebVitals = (metric: WebVitalsMetric) => {
+      callbackRef.current(metric);
+    };
+
+    onCLS(reportWebVitals);
+    onFID(reportWebVitals);
+    onLCP(reportWebVitals);
+    onINP(reportWebVitals);
+    onFCP(reportWebVitals);
+    onTTFB(reportWebVitals);
+  }, []);
 }
 
 export type { WebVitalsMetric, ReportWebVitalsCallback };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,6 +195,9 @@ catalogs:
     vite-tsconfig-paths:
       specifier: ^6.1.1
       version: 6.1.1
+    web-vitals:
+      specifier: ^4.2.4
+      version: 4.2.4
     wrangler:
       specifier: ^4.80.0
       version: 4.80.0
@@ -800,6 +803,9 @@ importers:
       vite-tsconfig-paths:
         specifier: 'catalog:'
         version: 6.1.1(@voidzero-dev/vite-plus-core@0.1.17(@types/node@25.2.3)(esbuild@0.27.3)(jiti@2.6.1)(typescript@5.9.3)(yaml@2.8.3))(typescript@5.9.3)
+      web-vitals:
+        specifier: 'catalog:'
+        version: 4.2.4
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -5862,6 +5868,9 @@ packages:
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
+  web-vitals@4.2.4:
+    resolution: {integrity: sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==}
+
   webpack-sources@3.3.4:
     resolution: {integrity: sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q==}
     engines: {node: '>=10.13.0'}
@@ -10337,6 +10346,8 @@ snapshots:
   walk-up-path@4.0.0: {}
 
   web-namespaces@2.0.1: {}
+
+  web-vitals@4.2.4: {}
 
   webpack-sources@3.3.4: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -79,6 +79,7 @@ catalog:
   vite-plus: 0.1.17
   vite-tsconfig-paths: ^6.1.1
   vitest: npm:@voidzero-dev/vite-plus-test@0.1.17
+  web-vitals: ^4.2.4
   wrangler: ^4.80.0
   zod: 3.24.3
   knip: ^6.6.2

--- a/tests/e2e/app-router/nextjs-compat/web-vitals.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/web-vitals.spec.ts
@@ -1,0 +1,48 @@
+/**
+ * Ported from Next.js: test/e2e/app-dir/app/useReportWebVitals.test.ts
+ * https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/app/useReportWebVitals.test.ts
+ */
+
+import { expect, test } from "@playwright/test";
+import { waitForAppRouterHydration } from "../../helpers";
+
+const BASE = "http://localhost:4174";
+const expectedMetricNames = ["CLS", "FCP", "FID", "INP", "LCP", "TTFB"];
+const expectedMetricNamesKey = expectedMetricNames.join(",");
+
+test.describe("Next.js compat: useReportWebVitals", () => {
+  test("reports browser web vitals from next/web-vitals", async ({ page }) => {
+    const reportedMetricNames: string[] = [];
+
+    await page.route("https://example.vercel.sh/vitals", async (route) => {
+      const body = route.request().postData();
+      if (body) {
+        const name = new URLSearchParams(body).get("name");
+        if (name) {
+          reportedMetricNames.push(name);
+        }
+      }
+      await route.fulfill({ status: 204, body: "" });
+    });
+
+    await page.goto(`${BASE}/nextjs-compat/report-web-vitals`);
+    await expect(page.locator("h1")).toHaveText("Report Web Vitals");
+    await waitForAppRouterHydration(page);
+    await expect.poll(() => reportedMetricNames.length, { timeout: 10_000 }).toBeGreaterThan(0);
+
+    await page.reload();
+    await waitForAppRouterHydration(page);
+    await page.locator("#web-vitals-interaction").click();
+
+    await expect
+      .poll(() => reportedMetricNames.includes("FID") || reportedMetricNames.includes("INP"), {
+        timeout: 10_000,
+      })
+      .toBe(true);
+    await page.goto("about:blank");
+
+    await expect
+      .poll(() => [...new Set(reportedMetricNames)].sort().join(","), { timeout: 10_000 })
+      .toBe(expectedMetricNamesKey);
+  });
+});

--- a/tests/fixtures/app-basic/app/nextjs-compat/report-web-vitals/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/report-web-vitals/page.tsx
@@ -1,0 +1,13 @@
+import Reporter from "./reporter";
+
+export default function ReportWebVitalsPage() {
+  return (
+    <main>
+      <h1>Report Web Vitals</h1>
+      <button id="web-vitals-interaction" type="button">
+        Trigger interaction
+      </button>
+      <Reporter />
+    </main>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/report-web-vitals/reporter.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/report-web-vitals/reporter.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { useReportWebVitals, type WebVitalsMetric } from "next/web-vitals";
+
+const vitalsUrl = "https://example.vercel.sh/vitals";
+
+export default function Reporter() {
+  useReportWebVitals((metric: WebVitalsMetric) => {
+    fetch(vitalsUrl, {
+      body: new URLSearchParams({ name: metric.name, value: String(metric.value) }),
+      credentials: "omit",
+      keepalive: true,
+      method: "POST",
+    });
+  });
+
+  return null;
+}

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -8887,11 +8887,9 @@ describe("extractMdxOptions", () => {
 });
 
 describe("next/web-vitals shim", () => {
-  it("exports useReportWebVitals as a no-op function", async () => {
+  it("exports useReportWebVitals as a hook function", async () => {
     const { useReportWebVitals } = await import("../packages/vinext/src/shims/web-vitals.js");
     expect(typeof useReportWebVitals).toBe("function");
-    // Should run without throwing
-    expect(() => useReportWebVitals(() => {})).not.toThrow();
   });
 });
 


### PR DESCRIPTION
## Summary

- Implements `next/web-vitals` so `useReportWebVitals` reports the six metrics Next.js subscribes to: CLS, FID, LCP, INP, FCP, and TTFB.
- Adds `web-vitals@4.2.4` as a vinext dependency because v4 still exposes `onFID`, matching Next 16's current six-metric behavior.
- Adds a real App Router browser compat test that intercepts the reporter endpoint and verifies the actual fixture reports all six metric names.

## Verification

The bug is valid. vinext's previous shim was an explicit no-op, so apps importing `next/web-vitals` never received metric callbacks.

Relevant Next.js references from the local `.nextjs-ref` canary checkout (`554b7fe3b028ec40f4cd0df877049c018f78e2ce`):

- [Next.js `useReportWebVitals` source](https://github.com/vercel/next.js/blob/554b7fe3b028ec40f4cd0df877049c018f78e2ce/packages/next/src/client/web-vitals.ts)
- [Next.js App Router e2e test](https://github.com/vercel/next.js/blob/554b7fe3b028ec40f4cd0df877049c018f78e2ce/test/e2e/app-dir/app/useReportWebVitals.test.ts)
- [Next.js reporter fixture](https://github.com/vercel/next.js/blob/554b7fe3b028ec40f4cd0df877049c018f78e2ce/test/e2e/app-dir/app/app/report-web-vitals/reporter.js)

This should be one PR rather than split: the runtime shim, dependency, ambient type, and compat fixture/test are one behavior change. Splitting would either leave an unused dependency/test fixture or land the hook without the browser proof.

One reviewer flagged the raw Next.js `useEffect(..., [callback])` shape as potentially resubscribing long-lived `web-vitals` observers on component re-render. I verified that against the `web-vitals` package guidance and kept vinext's implementation slightly safer by subscribing once per mount and forwarding through the latest callback ref.

## Tests

- `vp test run tests/shims.test.ts -t "next/web-vitals"`
- `vp run vinext#build`
- `PLAYWRIGHT_PROJECT=app-router vp run test:e2e tests/e2e/app-router/nextjs-compat/web-vitals.spec.ts`
- `vp check`
