### PR TITLE
fix(dynamic): pass complete loading props

### DIFF
--- a/packages/vinext/src/shims/dynamic.ts
+++ b/packages/vinext/src/shims/dynamic.ts
@@ -19,12 +19,68 @@
  */
 import React, { type ComponentType } from "react";
 
+type DynamicLoadingProps = {
+  error?: Error | null;
+  isLoading?: boolean;
+  pastDelay?: boolean;
+  retry?: () => void;
+  timedOut?: boolean;
+};
+
 type DynamicOptions = {
-  loading?: ComponentType<{ error?: Error | null; isLoading?: boolean; pastDelay?: boolean }>;
+  loading?: ComponentType<DynamicLoadingProps>;
   ssr?: boolean;
 };
 
 type Loader<P> = () => Promise<{ default: ComponentType<P> } | ComponentType<P>>;
+
+const noopRetry = () => {};
+
+function createDynamicLoadingProps(
+  overrides: Partial<DynamicLoadingProps> = {},
+): DynamicLoadingProps {
+  return {
+    error: null,
+    isLoading: true,
+    pastDelay: true,
+    retry: noopRetry,
+    timedOut: false,
+    ...overrides,
+  };
+}
+
+function createLazyComponent<P extends object>(loader: Loader<P>) {
+  return React.lazy(async () => {
+    const mod = await loader();
+    if ("default" in mod) return mod as { default: ComponentType<P> };
+    return { default: mod as ComponentType<P> };
+  });
+}
+
+function useRetryableLazyComponent<P extends object>(
+  loader: Loader<P>,
+  initialLazyComponent: ReturnType<typeof createLazyComponent<P>>,
+) {
+  const [LazyComponent, setLazyComponent] = React.useState(() => initialLazyComponent);
+  const [retryKey, setRetryKey] = React.useState(0);
+  const retry = React.useCallback(() => {
+    setLazyComponent(() => createLazyComponent(loader));
+    setRetryKey((key) => key + 1);
+  }, [loader]);
+  return { LazyComponent, retry, retryKey };
+}
+
+type DynamicErrorBoundaryProps = {
+  fallback: ComponentType<DynamicLoadingProps>;
+  retry: () => void;
+  resetKey: number;
+  children?: React.ReactNode;
+};
+
+type DynamicErrorBoundaryState = {
+  error: Error | null;
+  resetKey: number;
+};
 
 /**
  * Lightweight error boundary that renders the loading component with the error
@@ -35,35 +91,39 @@ type Loader<P> = () => Promise<{ default: ComponentType<P> } | ComponentType<P>>
  * Lazily created because React.Component is not available in the RSC environment
  * (server components use a slimmed-down React that doesn't include class components).
  */
-// oxlint-disable-next-line typescript/no-explicit-any
-let DynamicErrorBoundary: any;
+let DynamicErrorBoundary: ComponentType<DynamicErrorBoundaryProps> | null | undefined;
 function getDynamicErrorBoundary() {
   if (DynamicErrorBoundary) return DynamicErrorBoundary;
   if (!React.Component) return null;
   DynamicErrorBoundary = class extends (
-    React.Component<
-      {
-        fallback: ComponentType<{ error?: Error | null; isLoading?: boolean; pastDelay?: boolean }>;
-        children: React.ReactNode;
-      },
-      { error: Error | null }
-    >
+    React.Component<DynamicErrorBoundaryProps, DynamicErrorBoundaryState>
   ) {
-    // oxlint-disable-next-line typescript/no-explicit-any
-    constructor(props: any) {
+    constructor(props: DynamicErrorBoundaryProps) {
       super(props);
-      this.state = { error: null };
+      this.state = { error: null, resetKey: props.resetKey };
+    }
+    static getDerivedStateFromProps(
+      props: DynamicErrorBoundaryProps,
+      state: DynamicErrorBoundaryState,
+    ) {
+      if (props.resetKey !== state.resetKey) {
+        return { error: null, resetKey: props.resetKey };
+      }
+      return null;
     }
     static getDerivedStateFromError(error: unknown) {
       return { error: error instanceof Error ? error : new Error(String(error)) };
     }
     render() {
       if (this.state.error) {
-        return React.createElement(this.props.fallback, {
-          isLoading: false,
-          pastDelay: true,
-          error: this.state.error,
-        });
+        return React.createElement(
+          this.props.fallback,
+          createDynamicLoadingProps({
+            isLoading: false,
+            error: this.state.error,
+            retry: this.props.retry,
+          }),
+        );
       }
       return this.props.children;
     }
@@ -101,37 +161,44 @@ function dynamic<P extends object = object>(
       // On the server (SSR or RSC), just render the loading state or nothing
       const SSRFalse = (_props: P) =>
         LoadingComponent
-          ? React.createElement(LoadingComponent, { isLoading: true, pastDelay: true, error: null })
+          ? React.createElement(LoadingComponent, createDynamicLoadingProps())
           : null;
       SSRFalse.displayName = "DynamicSSRFalse";
       return SSRFalse;
     }
 
-    // Client: use lazy with Suspense
-    const LazyComponent = React.lazy(async () => {
-      const mod = await loader();
-      if ("default" in mod) return mod as { default: ComponentType<P> };
-      return { default: mod as ComponentType<P> };
-    });
+    const InitialLazyComponent = createLazyComponent(loader);
 
     const ClientSSRFalse = (props: P) => {
       const [mounted, setMounted] = React.useState(false);
+      const { LazyComponent, retry, retryKey } = useRetryableLazyComponent(
+        loader,
+        InitialLazyComponent,
+      );
       React.useEffect(() => setMounted(true), []);
 
       if (!mounted) {
         return LoadingComponent
-          ? React.createElement(LoadingComponent, { isLoading: true, pastDelay: true, error: null })
+          ? React.createElement(LoadingComponent, createDynamicLoadingProps({ retry }))
           : null;
       }
 
       const fallback = LoadingComponent
-        ? React.createElement(LoadingComponent, { isLoading: true, pastDelay: true, error: null })
+        ? React.createElement(LoadingComponent, createDynamicLoadingProps({ retry }))
         : null;
-      return React.createElement(
-        React.Suspense,
-        { fallback },
-        React.createElement(LazyComponent, props),
-      );
+      const lazyElement = React.createElement(LazyComponent, props);
+      let content: React.ReactNode = lazyElement;
+      if (LoadingComponent) {
+        const ErrorBoundary = getDynamicErrorBoundary();
+        if (ErrorBoundary) {
+          content = React.createElement(
+            ErrorBoundary,
+            { fallback: LoadingComponent, retry, resetKey: retryKey },
+            lazyElement,
+          );
+        }
+      }
+      return React.createElement(React.Suspense, { fallback }, content);
     };
 
     ClientSSRFalse.displayName = "DynamicClientSSRFalse";
@@ -165,23 +232,26 @@ function dynamic<P extends object = object>(
 
     // SSR path: Use React.lazy so that renderToReadableStream can suspend
     // until the dynamically-imported component is available.
-    const LazyServer = React.lazy(async () => {
-      const mod = await loader();
-      if ("default" in mod) return mod as { default: ComponentType<P> };
-      return { default: mod as ComponentType<P> };
-    });
+    const LazyServer = createLazyComponent(loader);
 
     const ServerDynamic = (props: P) => {
       const fallback = LoadingComponent
-        ? React.createElement(LoadingComponent, { isLoading: true, pastDelay: true, error: null })
+        ? React.createElement(LoadingComponent, createDynamicLoadingProps())
         : null;
       const lazyElement = React.createElement(LazyServer, props);
       // Wrap with error boundary so loader rejections render the loading
       // component with the error instead of propagating uncaught.
-      const ErrorBoundary = LoadingComponent ? getDynamicErrorBoundary() : null;
-      const content = ErrorBoundary
-        ? React.createElement(ErrorBoundary, { fallback: LoadingComponent }, lazyElement)
-        : lazyElement;
+      let content: React.ReactNode = lazyElement;
+      if (LoadingComponent) {
+        const ErrorBoundary = getDynamicErrorBoundary();
+        if (ErrorBoundary) {
+          content = React.createElement(
+            ErrorBoundary,
+            { fallback: LoadingComponent, retry: noopRetry, resetKey: 0 },
+            lazyElement,
+          );
+        }
+      }
       return React.createElement(React.Suspense, { fallback }, content);
     };
 
@@ -189,22 +259,29 @@ function dynamic<P extends object = object>(
     return ServerDynamic;
   }
 
-  // Client path: standard React.lazy with Suspense
-  const LazyComponent = React.lazy(async () => {
-    const mod = await loader();
-    if ("default" in mod) return mod as { default: ComponentType<P> };
-    return { default: mod as ComponentType<P> };
-  });
+  const InitialLazyComponent = createLazyComponent(loader);
 
   const ClientDynamic = (props: P) => {
-    const fallback = LoadingComponent
-      ? React.createElement(LoadingComponent, { isLoading: true, pastDelay: true, error: null })
-      : null;
-    return React.createElement(
-      React.Suspense,
-      { fallback },
-      React.createElement(LazyComponent, props),
+    const { LazyComponent, retry, retryKey } = useRetryableLazyComponent(
+      loader,
+      InitialLazyComponent,
     );
+    const fallback = LoadingComponent
+      ? React.createElement(LoadingComponent, createDynamicLoadingProps({ retry }))
+      : null;
+    const lazyElement = React.createElement(LazyComponent, props);
+    let content: React.ReactNode = lazyElement;
+    if (LoadingComponent) {
+      const ErrorBoundary = getDynamicErrorBoundary();
+      if (ErrorBoundary) {
+        content = React.createElement(
+          ErrorBoundary,
+          { fallback: LoadingComponent, retry, resetKey: retryKey },
+          lazyElement,
+        );
+      }
+    }
+    return React.createElement(React.Suspense, { fallback }, content);
   };
 
   ClientDynamic.displayName = "DynamicClient";

--- a/packages/vinext/src/shims/next-shims.d.ts
+++ b/packages/vinext/src/shims/next-shims.d.ts
@@ -30,9 +30,16 @@ declare module "next/head" {
 
 declare module "next/dynamic" {
   import { ComponentType } from "react";
+  type DynamicOptionsLoadingProps = {
+    error?: Error | null;
+    isLoading?: boolean;
+    pastDelay?: boolean;
+    retry?: () => void;
+    timedOut?: boolean;
+  };
   function dynamic<P extends object = object>(
     loader: () => Promise<{ default: ComponentType<P> } | ComponentType<P>>,
-    options?: { loading?: ComponentType<any>; ssr?: boolean },
+    options?: { loading?: ComponentType<DynamicOptionsLoadingProps>; ssr?: boolean },
   ): ComponentType<P>;
   export default dynamic;
   export function flushPreloads(): Promise<void[]>;

--- a/tests/dynamic.test.ts
+++ b/tests/dynamic.test.ts
@@ -78,7 +78,7 @@ describe("next/dynamic ssr: false", () => {
 // ─── Loading component ──────────────────────────────────────────────────
 
 describe("next/dynamic loading component", () => {
-  it("passes isLoading and pastDelay to loading component on SSR", () => {
+  it("passes the full Next.js loading props shape to loading component on SSR", () => {
     let receivedProps: any = null;
     function TrackingLoader(props: any) {
       receivedProps = props;
@@ -96,6 +96,8 @@ describe("next/dynamic loading component", () => {
       isLoading: true,
       pastDelay: true,
       error: null,
+      timedOut: false,
+      retry: expect.any(Function),
     });
   });
 });

--- a/tests/fixtures/pages-basic/next-shims.d.ts
+++ b/tests/fixtures/pages-basic/next-shims.d.ts
@@ -93,8 +93,15 @@ declare module "next/image" {
 
 declare module "next/dynamic" {
   import { ComponentType } from "react";
+  type DynamicOptionsLoadingProps = {
+    error?: Error | null;
+    isLoading?: boolean;
+    pastDelay?: boolean;
+    retry?: () => void;
+    timedOut?: boolean;
+  };
   interface DynamicOptions {
-    loading?: ComponentType<{ error?: Error | null; isLoading?: boolean; pastDelay?: boolean }>;
+    loading?: ComponentType<DynamicOptionsLoadingProps>;
     ssr?: boolean;
   }
   function dynamic<P extends object = object>(


### PR DESCRIPTION
## Overview

| Field | Detail |
|---|---|
| Goal | Match the Next.js `next/dynamic` loading prop contract. |
| Core change | Pass `error`, `isLoading`, `pastDelay`, `retry`, and `timedOut` everywhere vinext renders a dynamic loading component. |
| Primary files | `packages/vinext/src/shims/dynamic.ts`, `tests/dynamic.test.ts`, `packages/vinext/src/shims/next-shims.d.ts` |
| Expected impact | Loading components that destructure `retry` or `timedOut` no longer observe an incompatible prop shape. |

## Why

A `next/dynamic` loading component receives a public props object, so compatibility depends on the complete key shape, not only the fields vinext currently uses. Next.js defines `retry` and `timedOut` in the public loading props type and passes them from the Pages loadable runtime.

## What changed

| Surface | Before | After |
|---|---|---|
| Loading props | `isLoading`, `pastDelay`, and `error` | Adds `retry` and `timedOut` with stable defaults |
| Client loader errors | Loading UI saw `error` but no retry callback | Loading UI receives a retry callback that replaces the lazy component and resets the shim error boundary |
| Types | Ambient declarations omitted the full loading prop shape | Shim declarations include the Next.js parity fields |

<details>
<summary>Validation</summary>

- `vp test run tests/dynamic.test.ts tests/nextjs-compat/dynamic.test.ts`
- `vp check`
- `vp run vinext#build`
- Commit hook also ran formatting, lint/type checks, and `knip`.

</details>

<details>
<summary>Risk / compatibility</summary>

- Keeps vinext's existing `pastDelay: true` default to avoid mixing this compatibility fix with delay semantics changes.
- Server-side `retry` is a no-op because there is no client reload loop during SSR. Client paths get an active retry callback.
- No config, routing, cache, or Worker behavior changes.

</details>

## References

| Reference | Why it matters |
|---|---|
| [Next.js `DynamicOptionsLoadingProps`](https://github.com/vercel/next.js/blob/554b7fe3b028ec40f4cd0df877049c018f78e2ce/packages/next/src/shared/lib/dynamic.tsx#L23-L29) | Public type includes `retry` and `timedOut`. |
| [Next.js Pages loadable runtime](https://github.com/vercel/next.js/blob/554b7fe3b028ec40f4cd0df877049c018f78e2ce/packages/next/src/shared/lib/loadable.shared-runtime.tsx#L139-L147) | Runtime passes `timedOut` and `retry` to the loading component. |
| [Next.js lazy dynamic types](https://github.com/vercel/next.js/blob/554b7fe3b028ec40f4cd0df877049c018f78e2ce/packages/next/src/shared/lib/lazy-dynamic/types.ts#L13-L18) | App dynamic type surface carries the same loading prop shape. |
| [Next.js `next/dynamic` docs](https://nextjs.org/docs/app/building-your-application/optimizing/lazy-loading#nextdynamic) | Documents the public API this shim is matching. |
