### PR TITLE
fix(headers): reuse request API promise identity

### DIFF
--- a/packages/vinext/src/shims/headers.ts
+++ b/packages/vinext/src/shims/headers.ts
@@ -477,6 +477,26 @@ function _decorateRequestApiPromise<T extends object>(
   });
 }
 
+// React.use() tracks thenables by identity, so request APIs must reuse the
+// same decorated promise for the same underlying request view.
+const _decoratedHeadersPromises = new WeakMap<Headers, Promise<Headers> & Headers>();
+const _decoratedCookiesPromises = new WeakMap<
+  RequestCookies,
+  Promise<RequestCookies> & RequestCookies
+>();
+
+function _getOrCreateDecoratedRequestApiPromise<T extends object>(
+  cache: WeakMap<T, Promise<T> & T>,
+  target: T,
+): Promise<T> & T {
+  const cached = cache.get(target);
+  if (cached) return cached;
+
+  const promise = _decorateRequestApiPromise(Promise.resolve(target), target);
+  cache.set(target, promise);
+  return promise;
+}
+
 function _decorateRejectedRequestApiPromise<T extends object>(error: unknown): Promise<T> & T {
   const normalizedError = error instanceof Error ? error : new Error(String(error));
   const promise = Promise.reject(normalizedError) as Promise<T>;
@@ -679,7 +699,7 @@ export function headers(): Promise<Headers> & Headers {
 
   markDynamicUsage();
   const readonlyHeaders = _getReadonlyHeaders(state.headersContext);
-  return _decorateRequestApiPromise(Promise.resolve(readonlyHeaders), readonlyHeaders);
+  return _getOrCreateDecoratedRequestApiPromise(_decoratedHeadersPromises, readonlyHeaders);
 }
 
 /**
@@ -711,7 +731,7 @@ export function cookies(): Promise<RequestCookies> & RequestCookies {
     ? _getMutableCookies(state.headersContext)
     : _getReadonlyCookies(state.headersContext);
 
-  return _decorateRequestApiPromise(Promise.resolve(cookieStore), cookieStore);
+  return _getOrCreateDecoratedRequestApiPromise(_decoratedCookiesPromises, cookieStore);
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -619,6 +619,43 @@ describe("next/headers shim", () => {
     setHeadersContext(null);
   });
 
+  it("headers() and cookies() reuse request API promise identity within a request context", async () => {
+    // Next.js caches request API promises by the underlying request object:
+    // packages/next/src/server/request/headers.ts
+    // packages/next/src/server/request/cookies.ts
+    // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/request/headers.ts
+    // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/request/cookies.ts
+    const { setHeadersAccessPhase, setHeadersContext, headers, cookies } =
+      await import("../packages/vinext/src/shims/headers.js");
+
+    setHeadersContext({
+      headers: new Headers({ "x-custom": "test-value" }),
+      cookies: new Map([["session", "abc123"]]),
+    });
+
+    try {
+      const firstHeaders = headers();
+      const secondHeaders = headers();
+      expect(secondHeaders).toBe(firstHeaders);
+      expect(await secondHeaders).toBe(await firstHeaders);
+
+      const firstReadonlyCookies = cookies();
+      const secondReadonlyCookies = cookies();
+      expect(secondReadonlyCookies).toBe(firstReadonlyCookies);
+      expect(await secondReadonlyCookies).toBe(await firstReadonlyCookies);
+
+      setHeadersAccessPhase("route-handler");
+
+      const firstMutableCookies = cookies();
+      const secondMutableCookies = cookies();
+      expect(secondMutableCookies).toBe(firstMutableCookies);
+      expect(await secondMutableCookies).toBe(await firstMutableCookies);
+      expect(firstMutableCookies).not.toBe(firstReadonlyCookies);
+    } finally {
+      setHeadersContext(null);
+    }
+  });
+
   it("headers() is read-only for both sync and awaited access", async () => {
     // Ported from Next.js:
     // packages/next/src/server/web/spec-extension/adapters/headers.test.ts
@@ -5893,8 +5930,10 @@ describe("middleware request header overrides", () => {
     await runWithHeadersContext(headersContextFromRequest(request), async () => {
       // 1. Prime the sealed snapshot — this is exactly what
       //    `clerkMiddleware()` does internally via `buildRequestLike()`.
-      const preHeaders = await headers();
-      const preCookies = await cookies();
+      const preHeadersPromise = headers();
+      const preCookiesPromise = cookies();
+      const preHeaders = await preHeadersPromise;
+      const preCookies = await preCookiesPromise;
       expect(preHeaders.get("authorization")).toBe("Bearer secret");
       expect(preHeaders.get("x-keep")).toBe("original");
       expect(preCookies.getAll()).toEqual([
@@ -5915,9 +5954,13 @@ describe("middleware request header overrides", () => {
       // 3. A subsequent `headers()` call — for example from the Server
       //    Component's render — must observe the override, not the snapshot
       //    captured in step 1.
-      const postHeaders = await headers();
-      const postCookies = await cookies();
+      const postHeadersPromise = headers();
+      const postCookiesPromise = cookies();
+      const postHeaders = await postHeadersPromise;
+      const postCookies = await postCookiesPromise;
 
+      expect(postHeadersPromise).not.toBe(preHeadersPromise);
+      expect(postCookiesPromise).not.toBe(preCookiesPromise);
       expect(postHeaders.get("authorization")).toBeNull();
       expect(postHeaders.get("cookie")).toBeNull();
       expect(postHeaders.get("x-keep")).toBe("updated");


### PR DESCRIPTION
## Overview

| Item | Detail |
| --- | --- |
| Goal | Keep `headers()` and `cookies()` thenable identity stable for repeated calls in one request context. |
| Core change | Cache decorated request API promises by the sealed `Headers` or `RequestCookies` object identity. |
| Review focus | `packages/vinext/src/shims/headers.ts`, then the new regression assertions in `tests/shims.test.ts`. |
| Expected impact | Better Next.js parity for async request APIs, especially callers that unwrap them with `React.use()`. |

## Why

`headers()` and `cookies()` are async request APIs in Next.js 15+. Because React tracks thenables by identity, the framework must not allocate a fresh thenable every time the same request API object is read. Next.js already preserves that invariant with WeakMap-backed promise caches and request-scoped async API promises. vinext cached the underlying request views, but decorated a fresh promise proxy on every call.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| Request API identity | Same request view should produce the same thenable. | Adds typed WeakMaps for decorated `headers()` and `cookies()` promises. |
| Middleware overrides | Replaced request views must not reuse stale promise identity. | Keeps existing object invalidation, so a new sealed view naturally gets a new cached promise. |
| Cookie phases | Readonly render cookies and mutable route-handler cookies are separate views. | Covers both phases and asserts they do not share the same promise identity. |

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| Repeated `headers()` in one request context | Returned a new decorated thenable each call. | Returns the same decorated thenable for the same sealed headers view. |
| Repeated `cookies()` in one request context | Returned a new decorated thenable each call. | Returns the same decorated thenable for the same cookie store view. |
| Middleware request header override after a prior read | Snapshot object invalidation already worked, but promise identity was not covered. | Regression test verifies the post-override request view gets a fresh thenable identity. |

<details>
<summary>Validation</summary>

- `vp test run tests/shims.test.ts -t "reuse request API promise identity|invalidates headers\\(\\) snapshot"`
- `vp test run tests/shims.test.ts -t "next/headers shim"`
- `vp test run tests/nextjs-compat/request-apis.test.ts tests/nextjs-compat/action-headers.test.ts`
- `vp check`

</details>

<details>
<summary>Risk and compatibility</summary>

- Public API shape is unchanged.
- The cache is keyed by the already-created request API objects, so `applyMiddlewareRequestHeaders()` keeps its current invalidation behavior by replacing `readonlyHeaders`, `readonlyCookies`, or `mutableCookies`.
- The WeakMap entries do not extend object lifetime beyond the request API objects themselves.
- This does not change rejected promise behavior for invalid contexts or cache-scope errors.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| [Next.js `headers()` WeakMap cache](https://github.com/vercel/next.js/blob/554b7fe3b028ec40f4cd0df877049c018f78e2ce/packages/next/src/server/request/headers.ts#L174-L207) | Shows upstream caching promise identity by the underlying headers object. |
| [Next.js `cookies()` WeakMap cache](https://github.com/vercel/next.js/blob/554b7fe3b028ec40f4cd0df877049c018f78e2ce/packages/next/src/server/request/cookies.ts#L167-L204) | Shows the same upstream pattern for cookies. |
| [Next.js request-store async API promises](https://github.com/vercel/next.js/blob/554b7fe3b028ec40f4cd0df877049c018f78e2ce/packages/next/src/server/app-render/work-unit-async-storage.external.ts#L98-L107) | Shows request-scoped promise slots for headers, cookies, and mutable cookies. |
| [Next.js async API promise creation](https://github.com/vercel/next.js/blob/554b7fe3b028ec40f4cd0df877049c018f78e2ce/packages/next/src/server/app-render/app-render.tsx#L5371-L5408) | Shows newer staged-rendering paths precreate stable request API promises. |
| [Next.js `headers` docs](https://nextjs.org/docs/app/api-reference/functions/headers) | Documents `headers()` as an async request-time API that can be unwrapped with `React.use()`. |
| [Next.js `cookies` docs](https://nextjs.org/docs/app/api-reference/functions/cookies) | Documents `cookies()` as an async request-time API that can be unwrapped with `React.use()`. |
| [Next.js sync dynamic API tests for cookies](https://github.com/vercel/next.js/blob/554b7fe3b028ec40f4cd0df877049c018f78e2ce/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts#L1192-L1220) | Confirms upstream treats `cookies()` as a Promise-based API with `React.use()` support. |
| [Next.js sync dynamic API tests for headers](https://github.com/vercel/next.js/blob/554b7fe3b028ec40f4cd0df877049c018f78e2ce/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts#L1526-L1554) | Confirms upstream treats `headers()` as a Promise-based API with `React.use()` support. |