### PR TITLE
fix(app-router): append RSC vary headers in finalizer

### DIFF
--- a/packages/vinext/src/server/app-rsc-response-finalizer.ts
+++ b/packages/vinext/src/server/app-rsc-response-finalizer.ts
@@ -1,6 +1,8 @@
 import type { NextHeader } from "../config/next-config.js";
 import type { RequestContext } from "../config/config-matchers.js";
 import { applyConfigHeadersToResponse } from "./request-pipeline.js";
+import { VINEXT_RSC_VARY_HEADER } from "./app-rsc-cache-busting.js";
+import { mergeVaryHeader } from "./middleware-response-headers.js";
 import { stripBasePath } from "../utils/base-path.js";
 import { normalizePath } from "./normalize-path.js";
 import { normalizePathnameForRouteMatch } from "../routing/utils.js";
@@ -18,7 +20,8 @@ type FinalizeAppRscResponseOptions = {
 };
 
 /**
- * Apply next.config.js response headers to an App Router response.
+ * Apply App Router response finalization that must happen outside individual
+ * route dispatchers.
  *
  * Called once per request in the outer handler() wrapper, after all route
  * handling, so that every response path (page, route handler, server action,
@@ -37,6 +40,10 @@ export function finalizeAppRscResponse(
   // and Next.js deliberately excludes config headers from redirect responses.
   if (response.status >= 300 && response.status < 400) {
     return response;
+  }
+
+  if (!response.headers.has("x-vinext-static-file")) {
+    mergeVaryHeader(response.headers, VINEXT_RSC_VARY_HEADER);
   }
 
   if (!options.configHeaders.length) {

--- a/packages/vinext/src/server/middleware-response-headers.ts
+++ b/packages/vinext/src/server/middleware-response-headers.ts
@@ -1,6 +1,6 @@
 const ADDITIVE_RESPONSE_HEADER_NAMES = new Set(["set-cookie", "vary"]);
 
-function mergeVaryHeader(target: Headers, value: string): void {
+export function mergeVaryHeader(target: Headers, value: string): void {
   const existing = target.get("Vary");
   const tokens = (existing ? `${existing}, ${value}` : value)
     .split(",")

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -3,6 +3,7 @@ import {
   computeRscCacheBustingSearchParam,
   createRscRequestHeaders,
   createRscRequestUrl,
+  VINEXT_RSC_VARY_HEADER,
 } from "../packages/vinext/src/server/app-rsc-cache-busting.js";
 import { createAppRscHandler } from "../packages/vinext/src/server/app-rsc-handler.js";
 import { makeThenableParams } from "../packages/vinext/src/shims/thenable-params.js";
@@ -87,6 +88,7 @@ describe("createAppRscHandler", () => {
     expect(dispatchMatchedPage).toHaveBeenCalledTimes(1);
     expect(response.status).toBe(200);
     expect(response.headers.get("x-test-header")).toBe("applied");
+    expect(response.headers.get("vary")).toBe(VINEXT_RSC_VARY_HEADER);
   });
 
   it("returns config redirects before route dispatch and skips finalization", async () => {
@@ -238,6 +240,7 @@ describe("createAppRscHandler", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("x-vinext-static-file")).toBe("%2Flogo.svg");
+    expect(response.headers.get("vary")).toBeNull();
     expect(clearRequestContext).toHaveBeenCalledTimes(1);
     expect(matchRoute).not.toHaveBeenCalled();
   });
@@ -322,6 +325,34 @@ describe("createAppRscHandler", () => {
         route,
       }),
     );
+  });
+
+  it("appends App Router RSC vary values to route handler responses", async () => {
+    const route = createPageRoute({
+      page: null,
+      pattern: "/api/:id",
+      routeHandler: { GET: () => new Response("route") },
+      routeSegments: ["api", "[id]"],
+    });
+    const dispatchMatchedRouteHandler = vi.fn(
+      async () => new Response("route", { status: 200, headers: { Vary: "User-Agent" } }),
+    );
+    const handler = createHandler({
+      configHeaders: [],
+      dispatchMatchedRouteHandler,
+      matchRoute: (pathname: string) =>
+        pathname === "/api/123"
+          ? {
+              params: { id: "123" },
+              route,
+            }
+          : null,
+    });
+
+    const response = await handler(new Request("https://example.test/docs/api/123"), null);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("vary")).toBe(`User-Agent, ${VINEXT_RSC_VARY_HEADER}`);
   });
 
   it("clears request context before returning the plain 404 fallback", async () => {

--- a/tests/app-rsc-response-finalizer.test.ts
+++ b/tests/app-rsc-response-finalizer.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vite-plus/test";
+import { VINEXT_RSC_VARY_HEADER } from "../packages/vinext/src/server/app-rsc-cache-busting.js";
 import { finalizeAppRscResponse } from "../packages/vinext/src/server/app-rsc-response-finalizer.js";
 import type { RequestContext } from "../packages/vinext/src/config/config-matchers.js";
 
@@ -29,9 +30,12 @@ describe("finalizeAppRscResponse — config header application", () => {
     expect(response.headers.get("x-added")).toBe("config");
   });
 
-  it("does not apply config headers when none are configured", () => {
-    // Behavior: empty configHeaders list → response returned as-is with no mutation.
-    // Regression: unexpected header appears, or function throws.
+  it("adds the App Router RSC vary header when no config headers are configured", () => {
+    // Behavior: App Router responses always carry the RSC vary key, even when
+    // no next.config.js headers match. This covers app route handlers that
+    // return their own Response object instead of using app page helpers.
+    // Ported from Next.js:
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/vary-header/test/index.test.ts
     const response = new Response("body", { status: 200, headers: { "x-existing": "keep" } });
     const request = new Request("http://example.com/about");
 
@@ -43,6 +47,7 @@ describe("finalizeAppRscResponse — config header application", () => {
 
     expect(result).toBe(response);
     expect(result.headers.get("x-existing")).toBe("keep");
+    expect(result.headers.get("vary")).toBe(VINEXT_RSC_VARY_HEADER);
   });
 
   it("does not apply config headers when source pattern does not match", () => {
@@ -58,6 +63,52 @@ describe("finalizeAppRscResponse — config header application", () => {
     });
 
     expect(response.headers.get("x-added")).toBeNull();
+  });
+});
+
+// ── App Router RSC vary header ──────────────────────────────────────────
+
+describe("finalizeAppRscResponse — App Router RSC vary header", () => {
+  it("preserves custom Vary values while appending the internal RSC vary key", () => {
+    const response = new Response("body", { status: 200, headers: { Vary: "User-Agent" } });
+    const request = new Request("http://example.com/normal");
+
+    finalizeAppRscResponse(response, request, {
+      basePath: "",
+      configHeaders: [],
+      requestContext: makeRequestContext(),
+    });
+
+    expect(response.headers.get("vary")).toBe(`User-Agent, ${VINEXT_RSC_VARY_HEADER}`);
+  });
+
+  it("does not duplicate RSC vary tokens already set by app page helpers", () => {
+    const response = new Response("body", {
+      status: 200,
+      headers: { Vary: VINEXT_RSC_VARY_HEADER },
+    });
+    const request = new Request("http://example.com/about");
+
+    finalizeAppRscResponse(response, request, {
+      basePath: "",
+      configHeaders: [],
+      requestContext: makeRequestContext(),
+    });
+
+    expect(response.headers.get("vary")).toBe(VINEXT_RSC_VARY_HEADER);
+  });
+
+  it("preserves wildcard Vary semantics", () => {
+    const response = new Response("body", { status: 200, headers: { Vary: "*" } });
+    const request = new Request("http://example.com/about");
+
+    finalizeAppRscResponse(response, request, {
+      basePath: "",
+      configHeaders: [],
+      requestContext: makeRequestContext(),
+    });
+
+    expect(response.headers.get("vary")).toBe("*");
   });
 });
 


### PR DESCRIPTION
## Overview

| Field | Details |
| --- | --- |
| Goal | Ensure App Router responses expose the RSC response variant key to HTTP caches. |
| Core change | `finalizeAppRscResponse` now merges `VINEXT_RSC_VARY_HEADER` for non-redirect, non-static-file App Router responses. |
| Primary files | `packages/vinext/src/server/app-rsc-response-finalizer.ts`, `packages/vinext/src/server/middleware-response-headers.ts` |
| Expected impact | App route handler and other custom App Router `Response`s preserve user `Vary` values while also varying on RSC navigation headers. |

## Why

App Router responses are selected by request headers such as `RSC`, `Next-Router-State-Tree`, `Next-Router-Prefetch`, and `Next-Router-Segment-Prefetch`. If the final response omits those fields from `Vary`, shared caches can reuse an HTML/navigation/route-handler variant for a request that needed a different variant.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| App Router response finalization | The cache variant key belongs at the outer App Router boundary, not only page helpers. | The finalizer appends the shared vinext RSC vary header for non-redirect App Router responses. |
| User response headers | User and middleware `Vary` values must be preserved. | Reuses the existing deduping `Vary` merge helper rather than replacing the header. |
| Static assets | Public file signals should not gain RSC cache fragmentation. | Leaves `x-vinext-static-file` signal responses alone. |

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| App route handler returns `Vary: User-Agent` | Final response only varied on `User-Agent`. | Final response varies on `User-Agent` plus vinext RSC headers. |
| App page helper already sets RSC `Vary` | It could be set by the page helper only. | Finalizer dedupes and keeps the same value. |
| Public file signal | No RSC `Vary`. | Still no RSC `Vary`. |

<details>
<summary>Validation</summary>

- `vp test run tests/app-rsc-response-finalizer.test.ts tests/app-rsc-handler.test.ts tests/app-page-response.test.ts tests/app-route-handler-response.test.ts`
- `vp check`

</details>

<details>
<summary>Risk / compatibility</summary>

- No public API change.
- Redirect responses still bypass finalization to avoid immutable header mutation.
- Public static file signals still avoid the RSC `Vary` value to preserve asset cache efficiency.
- Existing app page responses that already set the shared `Vary` value are deduped.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| [Next.js `BaseServer.setVaryHeader`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/base-server.ts#L2000-L2025) | Shows the App Router base `Vary` set. |
| [Next.js app page route module `getVaryHeader`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/route-modules/app-page/module.ts#L184-L200) | Shows the same base vary construction for the app page module. |
| [Next.js vary-header e2e test](https://github.com/vercel/next.js/blob/canary/test/e2e/vary-header/test/index.test.ts#L16-L31) | Confirms app route handlers preserve custom `Vary` values and append internal RSC headers. |