### PR TITLE
fix(router): preserve filesystem routes before afterFiles rewrites

### DIFF
--- a/examples/pages-router-cloudflare/next.config.mjs
+++ b/examples/pages-router-cloudflare/next.config.mjs
@@ -22,4 +22,12 @@ export default {
       },
     ];
   },
+
+  async rewrites() {
+    return {
+      beforeFiles: [],
+      afterFiles: [{ source: "/nav-test", destination: "/about" }],
+      fallback: [],
+    };
+  },
 };

--- a/examples/pages-router-cloudflare/pages/nav-test.tsx
+++ b/examples/pages-router-cloudflare/pages/nav-test.tsx
@@ -1,0 +1,11 @@
+import Link from "next/link";
+
+export default function NavTest() {
+  return (
+    <>
+      <h1>Navigation Test</h1>
+      <p>Filesystem route wins before afterFiles.</p>
+      <Link href="/">Home</Link>
+    </>
+  );
+}

--- a/examples/pages-router-cloudflare/worker/index.ts
+++ b/examples/pages-router-cloudflare/worker/index.ts
@@ -6,6 +6,7 @@
  * - handleApiRoute(request, url) -> Response
  * - runMiddleware(request) -> middleware result
  * - vinextConfig -> embedded next.config.js settings
+ * - matchPageRoute(url, request) -> route match metadata
  *
  * Both use Web-standard Request/Response APIs, making them
  * directly usable in a Worker fetch handler.
@@ -22,7 +23,7 @@ import {
 import { mergeHeaders } from "vinext/server/worker-utils";
 
 // @ts-expect-error -- virtual module resolved by vinext at build time
-import { renderPage, handleApiRoute, runMiddleware, vinextConfig } from "virtual:vinext-server-entry";
+import { renderPage, handleApiRoute, runMiddleware, vinextConfig, matchPageRoute } from "virtual:vinext-server-entry";
 
 // Extract config values (embedded at build time in the server entry)
 const basePath: string = vinextConfig?.basePath ?? "";
@@ -204,8 +205,11 @@ export default {
         return mergeHeaders(response, middlewareHeaders, middlewareRewriteStatus);
       }
 
+      const pageMatch =
+        typeof matchPageRoute === "function" ? matchPageRoute(resolvedPathname, request) : null;
+
       // Apply afterFiles rewrites
-      if (configRewrites.afterFiles?.length) {
+      if ((!pageMatch || pageMatch.route.isDynamic) && configRewrites.afterFiles?.length) {
         const rewritten = matchRewrite(resolvedPathname, configRewrites.afterFiles, postMwReqCtx);
         if (rewritten) {
           if (isExternalUrl(rewritten)) {

--- a/examples/realworld-api-rest/worker/index.ts
+++ b/examples/realworld-api-rest/worker/index.ts
@@ -6,6 +6,7 @@
  * - handleApiRoute(request, url) -> Response
  * - runMiddleware(request) -> middleware result
  * - vinextConfig -> embedded next.config.js settings
+ * - matchPageRoute(url, request) -> route match metadata
  *
  * Both use Web-standard Request/Response APIs, making them
  * directly usable in a Worker fetch handler.
@@ -21,7 +22,7 @@ import {
 import { mergeHeaders } from "vinext/server/worker-utils";
 
 // @ts-expect-error -- virtual module resolved by vinext at build time
-import { renderPage, handleApiRoute, runMiddleware, vinextConfig } from "virtual:vinext-server-entry";
+import { renderPage, handleApiRoute, runMiddleware, vinextConfig, matchPageRoute } from "virtual:vinext-server-entry";
 
 // Extract config values (embedded at build time in the server entry)
 const basePath: string = vinextConfig?.basePath ?? "";
@@ -200,8 +201,11 @@ export default {
         return mergeHeaders(response, middlewareHeaders, middlewareRewriteStatus);
       }
 
+      const pageMatch =
+        typeof matchPageRoute === "function" ? matchPageRoute(resolvedPathname, request) : null;
+
       // Apply afterFiles rewrites
-      if (configRewrites.afterFiles?.length) {
+      if ((!pageMatch || pageMatch.route.isDynamic) && configRewrites.afterFiles?.length) {
         const rewritten = matchRewrite(resolvedPathname, configRewrites.afterFiles, reqCtx);
         if (rewritten) {
           if (isExternalUrl(rewritten)) {
@@ -240,4 +244,3 @@ export default {
     }
   },
 };
-

--- a/packages/vinext/src/deploy.ts
+++ b/packages/vinext/src/deploy.ts
@@ -536,7 +536,7 @@ import {
 } from "vinext/server/request-pipeline";
 
 // @ts-expect-error -- virtual module resolved by vinext at build time
-import { renderPage, handleApiRoute, runMiddleware, vinextConfig } from "virtual:vinext-server-entry";
+import { renderPage, handleApiRoute, runMiddleware, vinextConfig, matchPageRoute } from "virtual:vinext-server-entry";
 
 interface Env {
   ASSETS: Fetcher;
@@ -801,8 +801,12 @@ export default {
         return mergeHeaders(response, middlewareHeaders, middlewareRewriteStatus);
       }
 
+      const pageMatch =
+        typeof matchPageRoute === "function" ? matchPageRoute(resolvedPathname, request) : null;
+
       // ── 8. Apply afterFiles rewrites from next.config.js ──────────
-      if (configRewrites.afterFiles?.length) {
+      // These run after non-dynamic page routes but before dynamic routes.
+      if ((!pageMatch || pageMatch.route.isDynamic) && configRewrites.afterFiles?.length) {
         const rewritten = matchRewrite(resolvedPathname, configRewrites.afterFiles, postMwReqCtx);
         if (rewritten) {
           if (isExternalUrl(rewritten)) {

--- a/packages/vinext/src/entries/pages-server-entry.ts
+++ b/packages/vinext/src/entries/pages-server-entry.ts
@@ -275,6 +275,20 @@ function matchRoute(url, routes) {
   return _trieMatch(trie, urlParts);
 }
 
+export function matchPageRoute(url, request) {
+  const routeUrl = i18nConfig && request
+    ? resolvePagesI18nRequest(
+        url,
+        i18nConfig,
+        request.headers,
+        new URL(request.url).hostname,
+        vinextConfig.basePath,
+        vinextConfig.trailingSlash,
+      ).url
+    : url;
+  return matchRoute(routeUrl, pageRoutes);
+}
+
 function parseQuery(url) {
   const qs = url.split("?")[1];
   if (!qs) return {};

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -2717,17 +2717,20 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
 
               const routes = await pagesRouter(pagesDir, nextConfig?.pageExtensions, fileMatcher);
 
-              // Apply afterFiles rewrites — these run after initial route matching
-              // If beforeFiles already rewrote the URL, afterFiles still run on the
-              // *resolved* pathname. Next.js applies these when route matching succeeds
-              // but allows overriding with rewrites.
-              if (nextConfig?.rewrites.afterFiles.length) {
+              let match = matchRoute(resolvedUrl.split("?")[0], routes);
+
+              // Apply afterFiles rewrites after non-dynamic page routes have had a
+              // chance to win, but before dynamic route matching.
+              if ((!match || match.route.isDynamic) && nextConfig?.rewrites.afterFiles.length) {
                 const afterRewrite = applyRewrites(
                   resolvedUrl.split("?")[0],
                   nextConfig.rewrites.afterFiles,
                   reqCtx,
                 );
-                if (afterRewrite) resolvedUrl = afterRewrite;
+                if (afterRewrite) {
+                  resolvedUrl = afterRewrite;
+                  match = matchRoute(resolvedUrl.split("?")[0], routes);
+                }
               }
 
               // External rewrite from afterFiles — proxy to external URL
@@ -2751,7 +2754,6 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
               const mwStatus = req.__vinextMiddlewareStatus;
 
               // Try rendering the resolved URL
-              const match = matchRoute(resolvedUrl.split("?")[0], routes);
               if (match) {
                 applyDeferredMwHeaders();
                 if (middlewareRequestHeaders) {

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -60,6 +60,7 @@ type RootParamNamesMap = Parameters<
 type AppRscMiddlewareContext = AppMiddlewareContext;
 
 type AppRscHandlerRoute = {
+  isDynamic: boolean;
   page?: unknown;
   pattern: string;
   rootParamNames?: readonly string[];
@@ -378,19 +379,24 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
   });
   if (serverActionResponse) return serverActionResponse;
 
-  const afterFilesRewrite = await applyRewrite(
-    {
-      clearRequestContext: options.clearRequestContext,
-      request,
-      requestContext: postMiddlewareRequestContext,
-      rewrites: options.configRewrites.afterFiles,
-    },
-    cleanPathname,
-  );
-  if (afterFilesRewrite instanceof Response) return afterFilesRewrite;
-  if (afterFilesRewrite) cleanPathname = afterFilesRewrite;
-
   let match = options.matchRoute(cleanPathname);
+  if (!match || match.route.isDynamic) {
+    const afterFilesRewrite = await applyRewrite(
+      {
+        clearRequestContext: options.clearRequestContext,
+        request,
+        requestContext: postMiddlewareRequestContext,
+        rewrites: options.configRewrites.afterFiles,
+      },
+      cleanPathname,
+    );
+    if (afterFilesRewrite instanceof Response) return afterFilesRewrite;
+    if (afterFilesRewrite) {
+      cleanPathname = afterFilesRewrite;
+      match = options.matchRoute(cleanPathname);
+    }
+  }
+
   if (!match) {
     const fallbackRewrite = await applyRewrite(
       {

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -1171,6 +1171,28 @@ type PagesRouterServerOptions = {
   purpose?: ProdServerOptions["purpose"];
 };
 
+type PagesServerEntryPageRoute = {
+  pattern: string;
+  module?: {
+    getStaticPaths?: (opts: { locales: string[]; defaultLocale: string }) => Promise<unknown>;
+  };
+};
+
+function isPagesServerEntryPageRoute(value: unknown): value is PagesServerEntryPageRoute {
+  if (!value || typeof value !== "object" || !("pattern" in value)) return false;
+  if (typeof value.pattern !== "string") return false;
+
+  if (!("module" in value) || value.module === undefined) return true;
+  const pageModule = value.module;
+  if (!pageModule || typeof pageModule !== "object") return false;
+
+  return !("getStaticPaths" in pageModule) || typeof pageModule.getStaticPaths === "function";
+}
+
+function readPagesServerEntryPageRoutes(value: unknown): PagesServerEntryPageRoute[] | undefined {
+  return Array.isArray(value) && value.every(isPagesServerEntryPageRoute) ? value : undefined;
+}
+
 /**
  * Start the Pages Router production server.
  *
@@ -1191,14 +1213,7 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
   const { renderPage, handleApiRoute: handleApi, runMiddleware, vinextConfig } = serverEntry;
   const matchPageRoute =
     typeof serverEntry.matchPageRoute === "function" ? serverEntry.matchPageRoute : undefined;
-  const pageRoutes = serverEntry.pageRoutes as
-    | Array<{
-        pattern: string;
-        module?: {
-          getStaticPaths?: (opts: { locales: string[]; defaultLocale: string }) => Promise<unknown>;
-        };
-      }>
-    | undefined;
+  const pageRoutes = readPagesServerEntryPageRoutes(serverEntry.pageRoutes);
 
   // Load prerender secret written at build time by vinext:server-manifest plugin.
   // Used to authenticate internal /__vinext/prerender/* HTTP endpoints.

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -1189,6 +1189,16 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
   const serverMtime = fs.statSync(serverEntryPath).mtimeMs;
   const serverEntry = await import(`${pathToFileURL(serverEntryPath).href}?t=${serverMtime}`);
   const { renderPage, handleApiRoute: handleApi, runMiddleware, vinextConfig } = serverEntry;
+  const matchPageRoute =
+    typeof serverEntry.matchPageRoute === "function" ? serverEntry.matchPageRoute : undefined;
+  const pageRoutes = serverEntry.pageRoutes as
+    | Array<{
+        pattern: string;
+        module?: {
+          getStaticPaths?: (opts: { locales: string[]; defaultLocale: string }) => Promise<unknown>;
+        };
+      }>
+    | undefined;
 
   // Load prerender secret written at build time by vinext:server-manifest plugin.
   // Used to authenticate internal /__vinext/prerender/* HTTP endpoints.
@@ -1292,17 +1302,6 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
       const localesRaw = parsedUrl.searchParams.get("locales");
       const locales: string[] = localesRaw ? JSON.parse(localesRaw) : [];
       const defaultLocale = parsedUrl.searchParams.get("defaultLocale") ?? "";
-      const pageRoutes = serverEntry.pageRoutes as
-        | Array<{
-            pattern: string;
-            module?: {
-              getStaticPaths?: (opts: {
-                locales: string[];
-                defaultLocale: string;
-              }) => Promise<unknown>;
-            };
-          }>
-        | undefined;
       const route = pageRoutes?.find((r) => r.pattern === pattern);
       const fn = route?.module?.getStaticPaths;
       if (typeof fn !== "function") {
@@ -1655,8 +1654,11 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
         return;
       }
 
+      const pageMatch = matchPageRoute ? matchPageRoute(resolvedPathname, webRequest) : null;
+
       // ── 9. Apply afterFiles rewrites from next.config.js ──────────
-      if (configRewrites.afterFiles?.length) {
+      // These run after non-dynamic page routes but before dynamic routes.
+      if ((!pageMatch || pageMatch.route.isDynamic) && configRewrites.afterFiles?.length) {
         const rewritten = matchRewrite(resolvedPathname, configRewrites.afterFiles, postMwReqCtx);
         if (rewritten) {
           if (isExternalUrl(rewritten)) {

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -8,6 +8,7 @@ import { createAppRscHandler } from "../packages/vinext/src/server/app-rsc-handl
 import { makeThenableParams } from "../packages/vinext/src/shims/thenable-params.js";
 
 type TestRoute = {
+  isDynamic: boolean;
   page?: { default?: unknown } | null;
   pattern: string;
   rootParamNames?: readonly string[];
@@ -19,6 +20,7 @@ type HandlerOptions = Parameters<typeof createAppRscHandler<TestRoute>>[0];
 
 function createPageRoute(overrides: Partial<TestRoute> = {}): TestRoute {
   return {
+    isDynamic: false,
     page: { default() {} },
     pattern: "/about",
     routeSegments: ["about"],
@@ -221,6 +223,78 @@ describe("createAppRscHandler", () => {
     expect(matchRoute).toHaveBeenLastCalledWith("/about");
     expect(dispatchMatchedPage).toHaveBeenCalledWith(
       expect.objectContaining({ cleanPathname: "/about" }),
+    );
+  });
+
+  it("does not let afterFiles rewrites override non-dynamic app routes", async () => {
+    const routes = {
+      "/about": createPageRoute({ pattern: "/about", routeSegments: ["about"] }),
+      "/nav": createPageRoute({ pattern: "/nav", routeSegments: ["nav"] }),
+    };
+    const dispatchMatchedPage = vi.fn(
+      async ({ route }) => new Response(`page:${route.pattern}`, { status: 200 }),
+    );
+    const handler = createHandler({
+      configHeaders: [],
+      configRewrites: {
+        beforeFiles: [],
+        afterFiles: [{ source: "/nav", destination: "/about" }],
+        fallback: [],
+      },
+      dispatchMatchedPage,
+      matchRoute: (pathname: string) => {
+        const route = routes[pathname as keyof typeof routes];
+        return route ? { params: {}, route } : null;
+      },
+    });
+
+    const response = await handler(new Request("https://example.test/docs/nav"), null);
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("page:/nav");
+    expect(dispatchMatchedPage).toHaveBeenCalledWith(
+      expect.objectContaining({ cleanPathname: "/nav", route: routes["/nav"] }),
+    );
+  });
+
+  it("runs afterFiles rewrites before dynamic app route matching", async () => {
+    const routes = {
+      "/about": createPageRoute({ pattern: "/about", routeSegments: ["about"] }),
+      dynamicBlog: createPageRoute({
+        isDynamic: true,
+        pattern: "/blog/:slug",
+        routeSegments: ["blog", "[slug]"],
+      }),
+    };
+    const dispatchMatchedPage = vi.fn(
+      async ({ route }) => new Response(`page:${route.pattern}`, { status: 200 }),
+    );
+    const emptyParams: Record<string, string | string[]> = {};
+    const legacyParams: Record<string, string | string[]> = { slug: "legacy" };
+    const matchRoute: HandlerOptions["matchRoute"] = (pathname) => {
+      if (pathname === "/about") return { params: emptyParams, route: routes["/about"] };
+      if (pathname === "/blog/legacy") {
+        return { params: legacyParams, route: routes.dynamicBlog };
+      }
+      return null;
+    };
+    const handler = createHandler({
+      configHeaders: [],
+      configRewrites: {
+        beforeFiles: [],
+        afterFiles: [{ source: "/blog/legacy", destination: "/about" }],
+        fallback: [],
+      },
+      dispatchMatchedPage,
+      matchRoute,
+    });
+
+    const response = await handler(new Request("https://example.test/docs/blog/legacy"), null);
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("page:/about");
+    expect(dispatchMatchedPage).toHaveBeenCalledWith(
+      expect.objectContaining({ cleanPathname: "/about", route: routes["/about"] }),
     );
   });
 

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -243,8 +243,9 @@ describe("createAppRscHandler", () => {
       },
       dispatchMatchedPage,
       matchRoute: (pathname: string) => {
-        const route = routes[pathname as keyof typeof routes];
-        return route ? { params: {}, route } : null;
+        if (pathname === "/about") return { params: {}, route: routes["/about"] };
+        if (pathname === "/nav") return { params: {}, route: routes["/nav"] };
+        return null;
       },
     });
 

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -593,6 +593,8 @@ describe("generatePagesRouterWorkerEntry", () => {
     expect(content).toContain("configRewrites.afterFiles");
     expect(content).toContain("configRewrites.fallback");
     expect(content).toContain("matchRewrite(resolvedPathname");
+    expect(content).toContain("matchPageRoute");
+    expect(content).toContain("matchPageRoute(resolvedPathname, request)");
   });
 
   it("applies next.config.js custom headers", () => {

--- a/tests/e2e/cloudflare-pages-router/navigation.spec.ts
+++ b/tests/e2e/cloudflare-pages-router/navigation.spec.ts
@@ -29,6 +29,12 @@ test.describe("Pages Router navigation on Cloudflare Workers", () => {
     await expect(page.locator("h1")).toHaveText("Hello from Pages Router on Workers!");
   });
 
+  test("concrete page wins before afterFiles rewrites in the built Worker", async ({ page }) => {
+    await page.goto(BASE + "/nav-test");
+    await expect(page.locator("h1")).toHaveText("Navigation Test");
+    await expect(page.locator("body")).not.toContainText("This is the about page");
+  });
+
   test("each page has correct __NEXT_DATA__.page value", async ({ page }) => {
     // Home
     let res = await page.goto(BASE + "/");

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -4770,12 +4770,15 @@ describe("chained middleware → config rewrites", () => {
     const rootNodeModules = path.resolve(import.meta.dirname, "../node_modules");
     await fsp.symlink(rootNodeModules, path.join(chainTmpDir, "node_modules"), "junction");
 
-    // Config with afterFiles rewrite: /intermediate → /final
+    // Config with afterFiles rewrites:
+    // - /rewrite-source has no page file, so afterFiles may rewrite it to /final.
+    // - /intermediate has a page file, so it must win before afterFiles.
     await fsp.writeFile(
       path.join(chainTmpDir, "next.config.mjs"),
       `export default {
   async rewrites() {
     return [
+      { source: "/rewrite-source", destination: "/final" },
       { source: "/intermediate", destination: "/final" },
     ];
   },
@@ -4784,14 +4787,14 @@ describe("chained middleware → config rewrites", () => {
 
     await fsp.mkdir(path.join(chainTmpDir, "pages"), { recursive: true });
 
-    // Middleware: rewrites /original → /intermediate
+    // Middleware: rewrites /original → /rewrite-source
     await fsp.writeFile(
       path.join(chainTmpDir, "middleware.ts"),
       `import { NextResponse } from "next/server";
 export function middleware(request) {
   const url = new URL(request.url);
   if (url.pathname === "/original") {
-    return NextResponse.rewrite(new URL("/intermediate", request.url));
+    return NextResponse.rewrite(new URL("/rewrite-source", request.url));
   }
   return NextResponse.next();
 }`,
@@ -4803,7 +4806,7 @@ export function middleware(request) {
       `export default function Original() { return <h1>ORIGINAL PAGE</h1>; }`,
     );
 
-    // /intermediate — middleware rewrites to here, then config rewrites to /final
+    // /intermediate — concrete page files win before afterFiles rewrites.
     await fsp.writeFile(
       path.join(chainTmpDir, "pages", "intermediate.tsx"),
       `export default function Intermediate() { return <h1>INTERMEDIATE PAGE</h1>; }`,
@@ -4815,7 +4818,6 @@ export function middleware(request) {
       `export default function Final() { return <h1>FINAL PAGE</h1>; }`,
     );
 
-    // /direct-intermediate — tests that config rewrite works independently
     await fsp.writeFile(
       path.join(chainTmpDir, "pages", "index.tsx"),
       `export default function Home() { return <h1>Home</h1>; }`,
@@ -4852,23 +4854,29 @@ export function middleware(request) {
     await fsp.rm(chainTmpDir, { recursive: true, force: true }).catch(() => {});
   }, 15000);
 
-  it("middleware rewrite alone works: /original renders /intermediate content", async () => {
-    // Middleware rewrites /original → /intermediate
-    // Without chaining, we'd see INTERMEDIATE PAGE content
+  it("chains middleware rewrites into afterFiles rewrites when no page file wins", async () => {
+    // Middleware rewrites /original to /rewrite-source. There is no page file at
+    // /rewrite-source, so the afterFiles rewrite can continue to /final.
     const res = await fetch(`${chainBaseUrl}/original`);
     const html = await res.text();
-    // The middleware first rewrites to /intermediate, then the config rewrite
-    // rewrites /intermediate → /final. So we expect FINAL PAGE.
     expect(html).toContain("FINAL PAGE");
+    expect(html).not.toContain("ORIGINAL PAGE");
   });
 
-  it("config rewrite alone works: /intermediate renders /final content", async () => {
-    const res = await fetch(`${chainBaseUrl}/intermediate`);
+  it("applies afterFiles rewrites for paths with no page file", async () => {
+    const res = await fetch(`${chainBaseUrl}/rewrite-source`);
     const html = await res.text();
     expect(html).toContain("FINAL PAGE");
   });
 
-  it("chained: /original → middleware → /intermediate → config → /final", async () => {
+  it("does not let afterFiles rewrites override concrete page files", async () => {
+    const res = await fetch(`${chainBaseUrl}/intermediate`);
+    const html = await res.text();
+    expect(html).toContain("INTERMEDIATE PAGE");
+    expect(html).not.toContain("FINAL PAGE");
+  });
+
+  it("chained: /original → middleware → /rewrite-source → config → /final", async () => {
     const res = await fetch(`${chainBaseUrl}/original`);
     expect(res.status).toBe(200);
     const html = await res.text();

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -4771,8 +4771,8 @@ describe("chained middleware → config rewrites", () => {
     await fsp.symlink(rootNodeModules, path.join(chainTmpDir, "node_modules"), "junction");
 
     // Config with afterFiles rewrites:
-    // - /rewrite-source has no page file, so afterFiles may rewrite it to /final.
-    // - /intermediate has a page file, so it must win before afterFiles.
+    // - /rewrite-source lacks a page file, so afterFiles can rewrite it to /final.
+    // - /intermediate owns a page file, so it wins before afterFiles.
     await fsp.writeFile(
       path.join(chainTmpDir, "next.config.mjs"),
       `export default {

--- a/tests/fixtures/pages-basic/next.config.mjs
+++ b/tests/fixtures/pages-basic/next.config.mjs
@@ -54,6 +54,10 @@ const nextConfig = {
           source: "/after-rewrite",
           destination: "/about",
         },
+        {
+          source: "/nav-test",
+          destination: "/about",
+        },
         // Used by Vitest: pages-router.test.ts — afterFiles rewrite gated on
         // a cookie injected by middleware. Middleware injects mw-user=1 via
         // x-middleware-request-cookie when ?mw-auth is present. The afterFiles

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -720,6 +720,14 @@ describe("Pages Router integration", () => {
     expect(html).toContain("About");
   });
 
+  it("does not let afterFiles rewrites override static page routes in dev", async () => {
+    const res = await fetch(`${baseUrl}/nav-test`);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("Navigation Test");
+    expect(html).not.toContain("This is the about page.");
+  });
+
   it("applies fallback rewrites from next.config.js", async () => {
     const res = await fetch(`${baseUrl}/fallback-rewrite`);
     expect(res.status).toBe(200);
@@ -3266,6 +3274,14 @@ describe("Production server next.config.js features (Pages Router)", () => {
     expect(res.status).toBe(200);
     const html = await res.text();
     expect(html).toContain("About");
+  });
+
+  it("does not let afterFiles rewrites override static page routes in production", async () => {
+    const res = await fetch(`${prodUrl}/nav-test`);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("Navigation Test");
+    expect(html).not.toContain("This is the about page.");
   });
 
   it("applies custom headers from next.config.js on /api routes", async () => {


### PR DESCRIPTION
## Overview

| Item | Detail |
| --- | --- |
| Goal | Preserve Next.js rewrite ordering for `afterFiles` rewrites. |
| Core change | Check non-dynamic filesystem routes before `afterFiles`, while still letting `afterFiles` run before dynamic routes. |
| Primary surfaces | App Router RSC handler, Pages Router dev server, Pages production server, generated Pages Worker entry. |
| Impact | Existing static pages are no longer accidentally shadowed by `afterFiles` rewrites. |

## Why

Next.js treats `afterFiles` as a middle phase: it runs after public/static/non-dynamic page matches, but before dynamic route matching. Vinext was applying `afterFiles` before route matching in the App RSC handler and Pages runtime paths, so a config rewrite could override a concrete page file.

| Area | Invariant | What this PR changes |
| --- | --- | --- |
| App Router | Non-dynamic app routes win before `afterFiles`; dynamic app routes still allow `afterFiles` first. | `createAppRscHandler` now checks the route match before applying `afterFiles`. |
| Pages dev/prod | Static page routes win before `afterFiles`; dynamic pages remain after `afterFiles`. | Dev and production request pipelines gate `afterFiles` on the current page match. |
| Pages Worker | Generated Workers should not duplicate route matching logic. | The generated Pages server entry exports `matchPageRoute`; the Worker entry uses that matcher rather than scanning `pageRoutes` itself. |

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| `/nav-test` static page with `afterFiles: /nav-test -> /about` | Rendered `/about`. | Renders `/nav-test`. |
| Dynamic route with matching `afterFiles` rewrite | Could work incidentally because rewrites ran first. | Still rewrites before dynamic route rendering by design. |
| Worker routing | No filesystem route gate before `afterFiles`. | Uses the generated page matcher, including i18n normalization when request context is available. |

## Validation

- `vp check`
- `vp test run tests/app-rsc-handler.test.ts tests/pages-router.test.ts tests/deploy.test.ts`
- `vp test run tests/app-router.test.ts -t "afterFiles"`
- `vp run knip --no-progress`

## References

| Reference | Why it matters |
| --- | --- |
| [Next.js rewrites docs](https://github.com/vercel/next.js/blob/canary/docs/01-app/03-api-reference/05-config/01-next-config-js/rewrites.mdx#L87-L97) | Documents that non-dynamic pages are checked before `afterFiles`, while dynamic routes are checked after. |
| [Next.js server route order](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/router-utils/resolve-routes.ts#L95-L114) | Shows `check_fs` before `afterFiles`, then dynamic route checking. |
| [Next.js filesystem check](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/router-utils/resolve-routes.ts#L491-L512) | Shows exact filesystem outputs can terminate before afterFiles rewrites. |
| [Next.js client rewrite resolver](https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/router/utils/resolve-rewrites.ts#L120-L147) | Mirrors the same page-before-afterFiles and dynamic-before-fallback sequence on the client. |
| [Next.js custom routes regression](https://github.com/vercel/next.js/blob/canary/test/e2e/custom-routes/custom-routes.test.ts#L634-L637) | Confirms rewrites should not override an existing page file. |
