### PR TITLE
test(router): add navigation trace invariant debugger

### DIFF
--- a/packages/vinext/src/server/navigation-trace-debugger.ts
+++ b/packages/vinext/src/server/navigation-trace-debugger.ts
@@ -1,0 +1,797 @@
+import {
+  NAVIGATION_TRACE_SCHEMA_VERSION,
+  NavigationTraceReasonCodes,
+  NavigationTraceTransactionCodes,
+  type NavigationTraceFieldName,
+  type NavigationTraceFieldValue,
+} from "./navigation-trace.js";
+import type { NavigationDecisionV0, NavigationEvent, OperationLane } from "./navigation-planner.js";
+
+type NavigationTraceDebuggerRuntime = "development" | "production" | "test";
+type NavigationTraceDebuggerOptions = Readonly<{
+  runtime?: NavigationTraceDebuggerRuntime;
+}>;
+
+type NavigationTraceDebugSubject = "commitApproval" | "plannerDecision";
+type NavigationTraceDebugSource = "commitTransaction" | "lifecycleGate" | "planner";
+type NavigationTraceDebugOutcome =
+  | "hardNavigate"
+  | "noCommit"
+  | "requestWork"
+  | "stale"
+  | "visibleCommit";
+
+type NavigationTraceInvariantIssueCode =
+  | "approval-mismatch"
+  | "empty-trace"
+  | "invalid-field"
+  | "invalid-schema"
+  | "missing-field"
+  | "missing-transaction"
+  | "unexpected-code"
+  | "unknown-code"
+  | "unknown-field";
+
+type NavigationTraceInvariantIssue = Readonly<{
+  code: NavigationTraceInvariantIssueCode;
+  entryIndex?: number;
+  field?: NavigationTraceFieldName;
+  message: string;
+  source: NavigationTraceDebugSource;
+}>;
+
+type NavigationTraceDebugExplanation = Readonly<{
+  reasonCode: string | null;
+  traceCodes: readonly string[];
+  transactionCode: string | null;
+}>;
+
+type NavigationTraceDebugReport = Readonly<{
+  explanation: NavigationTraceDebugExplanation;
+  issues: readonly NavigationTraceInvariantIssue[];
+  ok: boolean;
+  outcome: NavigationTraceDebugOutcome;
+  source: NavigationTraceDebugSource;
+  subject: NavigationTraceDebugSubject;
+}>;
+
+type NavigationTraceDebugTrace = Readonly<{
+  entries: readonly NavigationTraceDebugEntry[];
+  schemaVersion: number;
+}>;
+
+type NavigationTraceDebugEntry = Readonly<{
+  code: string;
+  fields: Readonly<Record<string, unknown>>;
+}>;
+
+export type NavigationTraceCommitApprovalDebugInput = Readonly<{
+  approvedCommit: object | null | undefined;
+  decision: Readonly<{
+    disposition: "commit" | "hard-navigate" | "no-commit";
+    trace: NavigationTraceDebugTrace;
+  }>;
+}>;
+
+type NavigationTraceDebugSpec = Readonly<{
+  expectedReasonCodes: readonly string[];
+  expectedTransactionCode: string | null;
+  outcome: NavigationTraceDebugOutcome;
+  source: NavigationTraceDebugSource;
+  subject: NavigationTraceDebugSubject;
+}>;
+
+const reasonTraceCodes: ReadonlySet<string> = new Set(Object.values(NavigationTraceReasonCodes));
+const transactionTraceCodes: ReadonlySet<string> = new Set(
+  Object.values(NavigationTraceTransactionCodes),
+);
+const knownTraceCodes: ReadonlySet<string> = new Set([
+  ...reasonTraceCodes,
+  ...transactionTraceCodes,
+]);
+
+const navigationTraceFieldRegistry = {
+  activeNavigationId: true,
+  currentRootLayoutTreePath: true,
+  currentVisibleCommitVersion: true,
+  eventKind: true,
+  nextRootLayoutTreePath: true,
+  operationLane: true,
+  pendingOperationId: true,
+  startedNavigationId: true,
+  startedVisibleCommitVersion: true,
+  targetHref: true,
+} satisfies Readonly<Record<NavigationTraceFieldName, true>>;
+
+type NavigationEventKind = NavigationEvent["kind"];
+const navigationEventKindRegistry = {
+  flightResponseArrived: true,
+  navigate: true,
+  prefetch: true,
+  refresh: true,
+  traverse: true,
+} satisfies Readonly<Record<NavigationEventKind, true>>;
+
+const operationLaneRegistry = {
+  hmr: true,
+  navigation: true,
+  prefetch: true,
+  refresh: true,
+  "server-action": true,
+  traverse: true,
+} satisfies Readonly<Record<OperationLane, true>>;
+
+const knownFieldNames: ReadonlySet<string> = new Set(Object.keys(navigationTraceFieldRegistry));
+const navigationEventKinds: ReadonlySet<string> = new Set(Object.keys(navigationEventKindRegistry));
+const operationLanes: ReadonlySet<string> = new Set(Object.keys(operationLaneRegistry));
+
+const requestWorkFields = ["eventKind", "targetHref"] satisfies readonly NavigationTraceFieldName[];
+const rootBoundaryFields = [
+  "currentRootLayoutTreePath",
+  "currentVisibleCommitVersion",
+  "nextRootLayoutTreePath",
+  "startedVisibleCommitVersion",
+] satisfies readonly NavigationTraceFieldName[];
+const staleLifecycleFields = [
+  "activeNavigationId",
+  "currentRootLayoutTreePath",
+  "currentVisibleCommitVersion",
+  "nextRootLayoutTreePath",
+  "startedNavigationId",
+  "startedVisibleCommitVersion",
+] satisfies readonly NavigationTraceFieldName[];
+const transactionFields = [
+  "operationLane",
+  "pendingOperationId",
+  "startedVisibleCommitVersion",
+] satisfies readonly NavigationTraceFieldName[];
+
+export function inspectNavigationDecisionTrace(
+  decision: NavigationDecisionV0,
+  options: NavigationTraceDebuggerOptions = {},
+): NavigationTraceDebugReport {
+  assertDebuggerRuntime(options);
+
+  const spec = createDecisionDebugSpec(decision);
+  return inspectTraceAgainstSpec(decision.trace, spec);
+}
+
+export function assertValidNavigationDecisionTrace(
+  decision: NavigationDecisionV0,
+  options: NavigationTraceDebuggerOptions = {},
+): void {
+  const report = inspectNavigationDecisionTrace(decision, options);
+  assertReportHasNoIssues(report);
+}
+
+export function inspectNavigationCommitApprovalTrace(
+  approval: NavigationTraceCommitApprovalDebugInput,
+  options: NavigationTraceDebuggerOptions = {},
+): NavigationTraceDebugReport {
+  assertDebuggerRuntime(options);
+
+  const spec = createCommitApprovalDebugSpec(approval);
+  const report = inspectTraceAgainstSpec(approval.decision.trace, spec);
+  const issues = [...report.issues];
+
+  addApprovalShapeIssues(approval, issues);
+  return createReport({
+    ...report,
+    issues,
+  });
+}
+
+export function assertValidNavigationCommitApprovalTrace(
+  approval: NavigationTraceCommitApprovalDebugInput,
+  options: NavigationTraceDebuggerOptions = {},
+): void {
+  const report = inspectNavigationCommitApprovalTrace(approval, options);
+  assertReportHasNoIssues(report);
+}
+
+function formatNavigationTraceDebugReport(report: NavigationTraceDebugReport): string {
+  const header =
+    `NavigationTrace invariant failed ` +
+    `[subject=${report.subject} outcome=${report.outcome} source=${report.source}]`;
+  const traceCodes = report.explanation.traceCodes.join(" > ") || "<empty>";
+  const issueLines = report.issues.map((issue) => `- [${issue.source}] ${issue.message}`);
+  return [header, `trace=${traceCodes}`, ...issueLines].join("\n");
+}
+
+function assertReportHasNoIssues(report: NavigationTraceDebugReport): void {
+  if (!report.ok) {
+    throw new Error(formatNavigationTraceDebugReport(report));
+  }
+}
+
+function createDecisionDebugSpec(decision: NavigationDecisionV0): NavigationTraceDebugSpec {
+  switch (decision.kind) {
+    case "requestWork":
+      return {
+        expectedReasonCodes: [NavigationTraceReasonCodes.requestWork],
+        expectedTransactionCode: null,
+        outcome: "requestWork",
+        source: "planner",
+        subject: "plannerDecision",
+      };
+    case "proposeCommit":
+      return {
+        expectedReasonCodes: [
+          decision.proposal.reason === "rootBoundaryUnknownFallback"
+            ? NavigationTraceReasonCodes.rootBoundaryUnknown
+            : NavigationTraceReasonCodes.commitCurrent,
+        ],
+        expectedTransactionCode: null,
+        outcome: "visibleCommit",
+        source: "planner",
+        subject: "plannerDecision",
+      };
+    case "noCommit":
+      return {
+        expectedReasonCodes: [NavigationTraceReasonCodes.prefetchOnly],
+        expectedTransactionCode: null,
+        outcome: "noCommit",
+        source: "planner",
+        subject: "plannerDecision",
+      };
+    case "hardNavigate":
+      return {
+        expectedReasonCodes: [NavigationTraceReasonCodes.rootBoundaryChanged],
+        expectedTransactionCode: null,
+        outcome: "hardNavigate",
+        source: "planner",
+        subject: "plannerDecision",
+      };
+    default: {
+      const _exhaustive: never = decision;
+      throw new Error("[vinext] Unknown navigation decision: " + String(_exhaustive));
+    }
+  }
+}
+
+function createCommitApprovalDebugSpec(
+  approval: NavigationTraceCommitApprovalDebugInput,
+): NavigationTraceDebugSpec {
+  switch (approval.decision.disposition) {
+    case "commit":
+      return {
+        expectedReasonCodes: [
+          NavigationTraceReasonCodes.commitCurrent,
+          NavigationTraceReasonCodes.rootBoundaryUnknown,
+        ],
+        expectedTransactionCode: NavigationTraceTransactionCodes.visibleCommit,
+        outcome: "visibleCommit",
+        source: "commitTransaction",
+        subject: "commitApproval",
+      };
+    case "hard-navigate":
+      return {
+        expectedReasonCodes: [NavigationTraceReasonCodes.rootBoundaryChanged],
+        expectedTransactionCode: NavigationTraceTransactionCodes.hardNavigate,
+        outcome: "hardNavigate",
+        source: "commitTransaction",
+        subject: "commitApproval",
+      };
+    case "no-commit": {
+      const reasonCode = findFirstReasonCode(approval.decision.trace);
+      return {
+        expectedReasonCodes: [
+          NavigationTraceReasonCodes.prefetchOnly,
+          NavigationTraceReasonCodes.staleOperation,
+        ],
+        expectedTransactionCode: NavigationTraceTransactionCodes.noCommit,
+        outcome: reasonCode === NavigationTraceReasonCodes.staleOperation ? "stale" : "noCommit",
+        source:
+          reasonCode === NavigationTraceReasonCodes.staleOperation ? "lifecycleGate" : "planner",
+        subject: "commitApproval",
+      };
+    }
+    default: {
+      const _exhaustive: never = approval.decision.disposition;
+      throw new Error("[vinext] Unknown commit approval disposition: " + String(_exhaustive));
+    }
+  }
+}
+
+function inspectTraceAgainstSpec(
+  trace: NavigationTraceDebugTrace,
+  spec: NavigationTraceDebugSpec,
+): NavigationTraceDebugReport {
+  const issues: NavigationTraceInvariantIssue[] = [];
+
+  addTraceShapeIssues(trace, spec.source, issues);
+  addTraceCompositionIssues(trace, spec, issues);
+  addExpectedTransactionIssues(trace, spec, issues);
+  addExpectedReasonIssues(trace, spec, issues);
+  addRequiredFieldIssues(trace, spec, issues);
+
+  return createReport({
+    explanation: createExplanation(trace),
+    issues,
+    outcome: spec.outcome,
+    source: spec.source,
+    subject: spec.subject,
+  });
+}
+
+function createReport(options: {
+  explanation: NavigationTraceDebugExplanation;
+  issues: readonly NavigationTraceInvariantIssue[];
+  outcome: NavigationTraceDebugOutcome;
+  source: NavigationTraceDebugSource;
+  subject: NavigationTraceDebugSubject;
+}): NavigationTraceDebugReport {
+  return {
+    explanation: options.explanation,
+    issues: [...options.issues],
+    ok: options.issues.length === 0,
+    outcome: options.outcome,
+    source: options.source,
+    subject: options.subject,
+  };
+}
+
+function addTraceShapeIssues(
+  trace: NavigationTraceDebugTrace,
+  source: NavigationTraceDebugSource,
+  issues: NavigationTraceInvariantIssue[],
+): void {
+  if (trace.schemaVersion !== NAVIGATION_TRACE_SCHEMA_VERSION) {
+    issues.push({
+      code: "invalid-schema",
+      message: `NavigationTrace schemaVersion must be ${NAVIGATION_TRACE_SCHEMA_VERSION}`,
+      source,
+    });
+  }
+
+  if (trace.entries.length === 0) {
+    issues.push({
+      code: "empty-trace",
+      message: "NavigationTrace must include at least one entry",
+      source,
+    });
+    return;
+  }
+
+  trace.entries.forEach((entry, entryIndex) => {
+    if (!knownTraceCodes.has(entry.code)) {
+      issues.push({
+        code: "unknown-code",
+        entryIndex,
+        message: `unknown NavigationTrace code ${entry.code}`,
+        source,
+      });
+    }
+
+    addFieldShapeIssues(entry, entryIndex, source, issues);
+  });
+}
+
+function addTraceCompositionIssues(
+  trace: NavigationTraceDebugTrace,
+  spec: NavigationTraceDebugSpec,
+  issues: NavigationTraceInvariantIssue[],
+): void {
+  const transactionEntries = trace.entries
+    .map((entry, index) => ({ entry, index }))
+    .filter(({ entry }) => transactionTraceCodes.has(entry.code));
+  const reasonEntries = trace.entries
+    .map((entry, index) => ({ entry, index }))
+    .filter(({ entry }) => reasonTraceCodes.has(entry.code));
+
+  if (spec.expectedTransactionCode === null) {
+    for (const transactionEntry of transactionEntries) {
+      issues.push({
+        code: "unexpected-code",
+        entryIndex: transactionEntry.index,
+        message: `planner decision trace must not include transaction code ${transactionEntry.entry.code}`,
+        source: "planner",
+      });
+    }
+  } else if (transactionEntries.length > 1) {
+    for (const transactionEntry of transactionEntries.slice(1)) {
+      issues.push({
+        code: "unexpected-code",
+        entryIndex: transactionEntry.index,
+        message: "commit approval trace must include exactly one transaction code",
+        source: "commitTransaction",
+      });
+    }
+  }
+
+  if (reasonEntries.length > 1) {
+    for (const reasonEntry of reasonEntries.slice(1)) {
+      issues.push({
+        code: "unexpected-code",
+        entryIndex: reasonEntry.index,
+        message: `${formatSubject(spec.subject)} trace must include exactly one reason code`,
+        source: expectedReasonSource(spec),
+      });
+    }
+  }
+}
+
+function formatSubject(subject: NavigationTraceDebugSubject): string {
+  switch (subject) {
+    case "commitApproval":
+      return "commit approval";
+    case "plannerDecision":
+      return "planner decision";
+    default: {
+      const _exhaustive: never = subject;
+      throw new Error("[vinext] Unknown navigation trace debug subject: " + String(_exhaustive));
+    }
+  }
+}
+
+function addFieldShapeIssues(
+  entry: NavigationTraceDebugEntry,
+  entryIndex: number,
+  source: NavigationTraceDebugSource,
+  issues: NavigationTraceInvariantIssue[],
+): void {
+  for (const [field, value] of Object.entries(entry.fields)) {
+    if (!knownFieldNames.has(field)) {
+      issues.push({
+        code: "unknown-field",
+        entryIndex,
+        message: `${entry.code} includes unknown field ${field}`,
+        source,
+      });
+      continue;
+    }
+
+    addFieldValueIssue(entry, entryIndex, field, value, source, issues);
+  }
+}
+
+function addFieldValueIssue(
+  entry: NavigationTraceDebugEntry,
+  entryIndex: number,
+  field: string,
+  value: unknown,
+  source: NavigationTraceDebugSource,
+  issues: NavigationTraceInvariantIssue[],
+): void {
+  if (!isStructuredTraceFieldValue(value)) {
+    issues.push({
+      code: "invalid-field",
+      entryIndex,
+      message: `${entry.code} field ${field} must be string, number, boolean, or null`,
+      source,
+    });
+    return;
+  }
+
+  switch (field) {
+    case "activeNavigationId":
+    case "currentVisibleCommitVersion":
+    case "pendingOperationId":
+    case "startedNavigationId":
+    case "startedVisibleCommitVersion":
+      if (typeof value !== "number") {
+        issues.push(createInvalidFieldIssue(entry, entryIndex, field, "number", source));
+      }
+      return;
+    case "currentRootLayoutTreePath":
+    case "nextRootLayoutTreePath":
+    case "targetHref":
+      if (typeof value !== "string" && value !== null) {
+        issues.push(createInvalidFieldIssue(entry, entryIndex, field, "string or null", source));
+      }
+      return;
+    case "eventKind":
+      if (typeof value !== "string" || !navigationEventKinds.has(value)) {
+        issues.push(
+          createInvalidFieldIssue(entry, entryIndex, field, "navigation event kind", source),
+        );
+      }
+      return;
+    case "operationLane":
+      if (typeof value !== "string" || !operationLanes.has(value)) {
+        issues.push(createInvalidFieldIssue(entry, entryIndex, field, "operation lane", source));
+      }
+      return;
+    default:
+      return;
+  }
+}
+
+function createInvalidFieldIssue(
+  entry: NavigationTraceDebugEntry,
+  entryIndex: number,
+  field: string,
+  expected: string,
+  source: NavigationTraceDebugSource,
+): NavigationTraceInvariantIssue {
+  return {
+    code: "invalid-field",
+    entryIndex,
+    message: `${entry.code} field ${field} must be ${expected}`,
+    source,
+  };
+}
+
+function isStructuredTraceFieldValue(value: unknown): value is NavigationTraceFieldValue {
+  return (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  );
+}
+
+function addExpectedTransactionIssues(
+  trace: NavigationTraceDebugTrace,
+  spec: NavigationTraceDebugSpec,
+  issues: NavigationTraceInvariantIssue[],
+): void {
+  if (spec.expectedTransactionCode === null) {
+    return;
+  }
+
+  const firstEntry = trace.entries[0];
+  if (firstEntry?.code !== spec.expectedTransactionCode) {
+    issues.push({
+      code: "missing-transaction",
+      entryIndex: 0,
+      message: `commit approval expected first trace code ${spec.expectedTransactionCode}`,
+      source: "commitTransaction",
+    });
+  }
+}
+
+function addExpectedReasonIssues(
+  trace: NavigationTraceDebugTrace,
+  spec: NavigationTraceDebugSpec,
+  issues: NavigationTraceInvariantIssue[],
+): void {
+  const reasonEntry = findFirstReasonEntry(trace);
+  if (reasonEntry === null) {
+    issues.push({
+      code: "unexpected-code",
+      message: `NavigationTrace expected one of ${spec.expectedReasonCodes.join(", ")}`,
+      source: expectedReasonSource(spec),
+    });
+    return;
+  }
+
+  if (!spec.expectedReasonCodes.includes(reasonEntry.entry.code)) {
+    issues.push({
+      code: "unexpected-code",
+      entryIndex: reasonEntry.index,
+      message:
+        `NavigationTrace expected one of ${spec.expectedReasonCodes.join(", ")} ` +
+        `but found ${reasonEntry.entry.code}`,
+      source: reasonEntrySource(reasonEntry.entry.code, spec),
+    });
+  }
+}
+
+function addRequiredFieldIssues(
+  trace: NavigationTraceDebugTrace,
+  spec: NavigationTraceDebugSpec,
+  issues: NavigationTraceInvariantIssue[],
+): void {
+  const transactionEntry = findExpectedTransactionEntry(trace, spec.expectedTransactionCode);
+  if (transactionEntry !== null) {
+    requireFields({
+      entry: transactionEntry.entry,
+      entryIndex: transactionEntry.index,
+      fields: transactionFields,
+      issues,
+      source: "commitTransaction",
+    });
+  }
+
+  const reasonEntry = findFirstReasonEntry(trace);
+  if (reasonEntry === null) {
+    return;
+  }
+
+  if (isHmrVisibleCommitTrace(spec, transactionEntry)) {
+    return;
+  }
+
+  const fields = getRequiredReasonFields(reasonEntry.entry.code);
+  requireFields({
+    entry: reasonEntry.entry,
+    entryIndex: reasonEntry.index,
+    fields,
+    issues,
+    source: reasonEntrySource(reasonEntry.entry.code, spec),
+  });
+  addReasonInvariantIssues(reasonEntry.entry, reasonEntry.index, spec, issues);
+}
+
+function requireFields(options: {
+  entry: NavigationTraceDebugEntry;
+  entryIndex: number;
+  fields: readonly NavigationTraceFieldName[];
+  issues: NavigationTraceInvariantIssue[];
+  source: NavigationTraceDebugSource;
+}): void {
+  for (const field of options.fields) {
+    if (!(field in options.entry.fields)) {
+      options.issues.push({
+        code: "missing-field",
+        entryIndex: options.entryIndex,
+        field,
+        message: `${options.entry.code} is missing required field ${field}`,
+        source: options.source,
+      });
+    }
+  }
+}
+
+function getRequiredReasonFields(code: string): readonly NavigationTraceFieldName[] {
+  switch (code) {
+    case NavigationTraceReasonCodes.requestWork:
+      return requestWorkFields;
+    case NavigationTraceReasonCodes.staleOperation:
+      return staleLifecycleFields;
+    case NavigationTraceReasonCodes.commitCurrent:
+    case NavigationTraceReasonCodes.prefetchOnly:
+    case NavigationTraceReasonCodes.rootBoundaryChanged:
+    case NavigationTraceReasonCodes.rootBoundaryUnknown:
+      return rootBoundaryFields;
+    default:
+      return [];
+  }
+}
+
+function addApprovalShapeIssues(
+  approval: NavigationTraceCommitApprovalDebugInput,
+  issues: NavigationTraceInvariantIssue[],
+): void {
+  if (
+    approval.decision.disposition === "commit" &&
+    (approval.approvedCommit === null || approval.approvedCommit === undefined)
+  ) {
+    issues.push({
+      code: "approval-mismatch",
+      message: "commit approval has commit disposition but no approved visible commit",
+      source: "commitTransaction",
+    });
+  }
+
+  if (approval.decision.disposition !== "commit" && approval.approvedCommit !== null) {
+    issues.push({
+      code: "approval-mismatch",
+      message: `${approval.decision.disposition} approval must not carry an approved visible commit`,
+      source: "commitTransaction",
+    });
+  }
+}
+
+function addReasonInvariantIssues(
+  entry: NavigationTraceDebugEntry,
+  entryIndex: number,
+  spec: NavigationTraceDebugSpec,
+  issues: NavigationTraceInvariantIssue[],
+): void {
+  if (entry.code !== NavigationTraceReasonCodes.staleOperation) {
+    return;
+  }
+
+  const fields = entry.fields;
+  const navigationIdChanged = fields.activeNavigationId !== fields.startedNavigationId;
+  const visibleCommitVersionChanged =
+    fields.currentVisibleCommitVersion !== fields.startedVisibleCommitVersion;
+
+  if (!navigationIdChanged && !visibleCommitVersionChanged) {
+    issues.push({
+      code: "invalid-field",
+      entryIndex,
+      message:
+        "NC_STALE requires activeNavigationId/startNavigationId or visibleCommitVersion mismatch",
+      source: reasonEntrySource(entry.code, spec),
+    });
+  }
+}
+
+function createExplanation(trace: NavigationTraceDebugTrace): NavigationTraceDebugExplanation {
+  return {
+    reasonCode: findFirstReasonCode(trace),
+    traceCodes: trace.entries.map((entry) => entry.code),
+    transactionCode: findFirstTransactionCode(trace),
+  };
+}
+
+function findExpectedTransactionEntry(
+  trace: NavigationTraceDebugTrace,
+  expectedTransactionCode: string | null,
+): { entry: NavigationTraceDebugEntry; index: number } | null {
+  if (expectedTransactionCode === null) {
+    return null;
+  }
+
+  const firstEntry = trace.entries[0];
+  if (firstEntry?.code !== expectedTransactionCode) {
+    return null;
+  }
+
+  return { entry: firstEntry, index: 0 };
+}
+
+function findFirstReasonEntry(
+  trace: NavigationTraceDebugTrace,
+): { entry: NavigationTraceDebugEntry; index: number } | null {
+  for (const [index, entry] of trace.entries.entries()) {
+    if (reasonTraceCodes.has(entry.code)) {
+      return { entry, index };
+    }
+  }
+
+  return null;
+}
+
+function findFirstReasonCode(trace: NavigationTraceDebugTrace): string | null {
+  return findFirstReasonEntry(trace)?.entry.code ?? null;
+}
+
+function findFirstTransactionCode(trace: NavigationTraceDebugTrace): string | null {
+  for (const entry of trace.entries) {
+    if (transactionTraceCodes.has(entry.code)) {
+      return entry.code;
+    }
+  }
+
+  return null;
+}
+
+function reasonEntrySource(
+  code: string,
+  spec: NavigationTraceDebugSpec,
+): NavigationTraceDebugSource {
+  if (code === NavigationTraceReasonCodes.staleOperation) {
+    return "lifecycleGate";
+  }
+
+  return expectedReasonSource(spec);
+}
+
+function expectedReasonSource(spec: NavigationTraceDebugSpec): NavigationTraceDebugSource {
+  if (spec.outcome === "stale") {
+    return "lifecycleGate";
+  }
+
+  return "planner";
+}
+
+function isHmrVisibleCommitTrace(
+  spec: NavigationTraceDebugSpec,
+  transactionEntry: { entry: NavigationTraceDebugEntry; index: number } | null,
+): boolean {
+  return (
+    spec.subject === "commitApproval" &&
+    spec.outcome === "visibleCommit" &&
+    transactionEntry?.entry.fields.operationLane === "hmr"
+  );
+}
+
+function assertDebuggerRuntime(options: NavigationTraceDebuggerOptions): void {
+  if (resolveDebuggerRuntime(options) === "production") {
+    throw new Error("[vinext] NavigationTrace invariant debugger is dev/test-only");
+  }
+}
+
+function resolveDebuggerRuntime(
+  options: NavigationTraceDebuggerOptions,
+): NavigationTraceDebuggerRuntime {
+  if (options.runtime !== undefined) {
+    return options.runtime;
+  }
+
+  if (typeof process !== "undefined") {
+    if (process.env.VITEST === "true" || process.env.NODE_ENV === "test") {
+      return "test";
+    }
+
+    if (process.env.NODE_ENV === "development") {
+      return "development";
+    }
+  }
+
+  return "production";
+}

--- a/packages/vinext/src/server/navigation-trace-debugger.ts
+++ b/packages/vinext/src/server/navigation-trace-debugger.ts
@@ -2,8 +2,10 @@ import {
   NAVIGATION_TRACE_SCHEMA_VERSION,
   NavigationTraceReasonCodes,
   NavigationTraceTransactionCodes,
+  type NavigationTraceReasonCode,
   type NavigationTraceFieldName,
   type NavigationTraceFieldValue,
+  type NavigationTraceTransactionCode,
 } from "./navigation-trace.js";
 import type { NavigationDecisionV0, NavigationEvent, OperationLane } from "./navigation-planner.js";
 
@@ -76,19 +78,30 @@ export type NavigationTraceCommitApprovalDebugInput = Readonly<{
 type NavigationTraceDebugSpec = Readonly<{
   expectedReasonCodes: readonly string[];
   expectedTransactionCode: string | null;
+  disposition: NavigationTraceCommitApprovalDebugInput["decision"]["disposition"] | null;
   outcome: NavigationTraceDebugOutcome;
   source: NavigationTraceDebugSource;
   subject: NavigationTraceDebugSubject;
 }>;
 
-const reasonTraceCodes: ReadonlySet<string> = new Set(Object.values(NavigationTraceReasonCodes));
-const transactionTraceCodes: ReadonlySet<string> = new Set(
-  Object.values(NavigationTraceTransactionCodes),
-);
-const knownTraceCodes: ReadonlySet<string> = new Set([
-  ...reasonTraceCodes,
-  ...transactionTraceCodes,
-]);
+type NavigationTraceReasonInvariant = "staleMismatch";
+type NavigationTraceReasonThinTraceRule = Readonly<{
+  lane: OperationLane;
+  outcome: NavigationTraceDebugOutcome;
+  requiredFields: readonly NavigationTraceFieldName[];
+  subject: NavigationTraceDebugSubject;
+}>;
+type NavigationTraceReasonSpec = Readonly<{
+  invariant?: NavigationTraceReasonInvariant;
+  owner: NavigationTraceDebugSource;
+  requiredFields: readonly NavigationTraceFieldName[];
+  thinTraceWhen?: readonly NavigationTraceReasonThinTraceRule[];
+}>;
+type NavigationTraceTransactionSpec = Readonly<{
+  allowedDispositions: readonly NavigationTraceCommitApprovalDebugInput["decision"]["disposition"][];
+  owner: "commitTransaction";
+  requiredFields: readonly NavigationTraceFieldName[];
+}>;
 
 const navigationTraceFieldRegistry = {
   activeNavigationId: true,
@@ -145,6 +158,73 @@ const transactionFields = [
   "pendingOperationId",
   "startedVisibleCommitVersion",
 ] satisfies readonly NavigationTraceFieldName[];
+
+const reasonSpecs = {
+  [NavigationTraceReasonCodes.requestWork]: {
+    owner: "planner",
+    requiredFields: requestWorkFields,
+  },
+  [NavigationTraceReasonCodes.commitCurrent]: {
+    owner: "planner",
+    requiredFields: rootBoundaryFields,
+    thinTraceWhen: [
+      {
+        lane: "hmr",
+        outcome: "visibleCommit",
+        requiredFields: [],
+        subject: "commitApproval",
+      },
+    ],
+  },
+  [NavigationTraceReasonCodes.rootBoundaryChanged]: {
+    owner: "planner",
+    requiredFields: rootBoundaryFields,
+  },
+  [NavigationTraceReasonCodes.rootBoundaryUnknown]: {
+    owner: "planner",
+    requiredFields: rootBoundaryFields,
+  },
+  [NavigationTraceReasonCodes.prefetchOnly]: {
+    owner: "planner",
+    requiredFields: rootBoundaryFields,
+  },
+  [NavigationTraceReasonCodes.staleOperation]: {
+    invariant: "staleMismatch",
+    owner: "lifecycleGate",
+    requiredFields: staleLifecycleFields,
+  },
+} satisfies Readonly<Record<NavigationTraceReasonCode, NavigationTraceReasonSpec>>;
+
+const transactionSpecs = {
+  [NavigationTraceTransactionCodes.visibleCommit]: {
+    allowedDispositions: ["commit"],
+    owner: "commitTransaction",
+    requiredFields: transactionFields,
+  },
+  [NavigationTraceTransactionCodes.noCommit]: {
+    allowedDispositions: ["no-commit"],
+    owner: "commitTransaction",
+    requiredFields: transactionFields,
+  },
+  [NavigationTraceTransactionCodes.hardNavigate]: {
+    allowedDispositions: ["hard-navigate"],
+    owner: "commitTransaction",
+    requiredFields: transactionFields,
+  },
+} satisfies Readonly<Record<NavigationTraceTransactionCode, NavigationTraceTransactionSpec>>;
+
+const reasonSpecsByCode: ReadonlyMap<string, NavigationTraceReasonSpec> = new Map(
+  Object.entries(reasonSpecs),
+);
+const transactionSpecsByCode: ReadonlyMap<string, NavigationTraceTransactionSpec> = new Map(
+  Object.entries(transactionSpecs),
+);
+const reasonTraceCodes: ReadonlySet<string> = new Set(reasonSpecsByCode.keys());
+const transactionTraceCodes: ReadonlySet<string> = new Set(transactionSpecsByCode.keys());
+const knownTraceCodes: ReadonlySet<string> = new Set([
+  ...reasonTraceCodes,
+  ...transactionTraceCodes,
+]);
 
 export function inspectNavigationDecisionTrace(
   decision: NavigationDecisionV0,
@@ -208,6 +288,7 @@ function createDecisionDebugSpec(decision: NavigationDecisionV0): NavigationTrac
   switch (decision.kind) {
     case "requestWork":
       return {
+        disposition: null,
         expectedReasonCodes: [NavigationTraceReasonCodes.requestWork],
         expectedTransactionCode: null,
         outcome: "requestWork",
@@ -216,6 +297,7 @@ function createDecisionDebugSpec(decision: NavigationDecisionV0): NavigationTrac
       };
     case "proposeCommit":
       return {
+        disposition: null,
         expectedReasonCodes: [
           decision.proposal.reason === "rootBoundaryUnknownFallback"
             ? NavigationTraceReasonCodes.rootBoundaryUnknown
@@ -228,6 +310,7 @@ function createDecisionDebugSpec(decision: NavigationDecisionV0): NavigationTrac
       };
     case "noCommit":
       return {
+        disposition: null,
         expectedReasonCodes: [NavigationTraceReasonCodes.prefetchOnly],
         expectedTransactionCode: null,
         outcome: "noCommit",
@@ -236,6 +319,7 @@ function createDecisionDebugSpec(decision: NavigationDecisionV0): NavigationTrac
       };
     case "hardNavigate":
       return {
+        disposition: null,
         expectedReasonCodes: [NavigationTraceReasonCodes.rootBoundaryChanged],
         expectedTransactionCode: null,
         outcome: "hardNavigate",
@@ -255,6 +339,7 @@ function createCommitApprovalDebugSpec(
   switch (approval.decision.disposition) {
     case "commit":
       return {
+        disposition: "commit",
         expectedReasonCodes: [
           NavigationTraceReasonCodes.commitCurrent,
           NavigationTraceReasonCodes.rootBoundaryUnknown,
@@ -266,6 +351,7 @@ function createCommitApprovalDebugSpec(
       };
     case "hard-navigate":
       return {
+        disposition: "hard-navigate",
         expectedReasonCodes: [NavigationTraceReasonCodes.rootBoundaryChanged],
         expectedTransactionCode: NavigationTraceTransactionCodes.hardNavigate,
         outcome: "hardNavigate",
@@ -275,6 +361,7 @@ function createCommitApprovalDebugSpec(
     case "no-commit": {
       const reasonCode = findFirstReasonCode(approval.decision.trace);
       return {
+        disposition: "no-commit",
         expectedReasonCodes: [
           NavigationTraceReasonCodes.prefetchOnly,
           NavigationTraceReasonCodes.staleOperation,
@@ -538,6 +625,21 @@ function addExpectedTransactionIssues(
       message: `commit approval expected first trace code ${spec.expectedTransactionCode}`,
       source: "commitTransaction",
     });
+    return;
+  }
+
+  const transactionSpec = getTransactionSpec(firstEntry.code);
+  if (
+    spec.disposition !== null &&
+    transactionSpec !== null &&
+    !allowsTransactionDisposition(transactionSpec, spec.disposition)
+  ) {
+    issues.push({
+      code: "unexpected-code",
+      entryIndex: 0,
+      message: `${firstEntry.code} is not allowed for ${spec.disposition} approval`,
+      source: transactionSpec.owner,
+    });
   }
 }
 
@@ -575,13 +677,16 @@ function addRequiredFieldIssues(
 ): void {
   const transactionEntry = findExpectedTransactionEntry(trace, spec.expectedTransactionCode);
   if (transactionEntry !== null) {
-    requireFields({
-      entry: transactionEntry.entry,
-      entryIndex: transactionEntry.index,
-      fields: transactionFields,
-      issues,
-      source: "commitTransaction",
-    });
+    const transactionSpec = getTransactionSpec(transactionEntry.entry.code);
+    if (transactionSpec !== null) {
+      requireFields({
+        entry: transactionEntry.entry,
+        entryIndex: transactionEntry.index,
+        fields: transactionSpec.requiredFields,
+        issues,
+        source: transactionSpec.owner,
+      });
+    }
   }
 
   const reasonEntry = findFirstReasonEntry(trace);
@@ -589,19 +694,20 @@ function addRequiredFieldIssues(
     return;
   }
 
-  if (isHmrVisibleCommitTrace(spec, transactionEntry)) {
+  const reasonSpec = getReasonSpec(reasonEntry.entry.code);
+  if (reasonSpec === null) {
     return;
   }
 
-  const fields = getRequiredReasonFields(reasonEntry.entry.code);
+  const fields = resolveReasonRequiredFields(reasonSpec, spec, transactionEntry);
   requireFields({
     entry: reasonEntry.entry,
     entryIndex: reasonEntry.index,
     fields,
     issues,
-    source: reasonEntrySource(reasonEntry.entry.code, spec),
+    source: reasonSpec.owner,
   });
-  addReasonInvariantIssues(reasonEntry.entry, reasonEntry.index, spec, issues);
+  addReasonInvariantIssues(reasonEntry.entry, reasonEntry.index, reasonSpec, issues);
 }
 
 function requireFields(options: {
@@ -624,20 +730,30 @@ function requireFields(options: {
   }
 }
 
-function getRequiredReasonFields(code: string): readonly NavigationTraceFieldName[] {
-  switch (code) {
-    case NavigationTraceReasonCodes.requestWork:
-      return requestWorkFields;
-    case NavigationTraceReasonCodes.staleOperation:
-      return staleLifecycleFields;
-    case NavigationTraceReasonCodes.commitCurrent:
-    case NavigationTraceReasonCodes.prefetchOnly:
-    case NavigationTraceReasonCodes.rootBoundaryChanged:
-    case NavigationTraceReasonCodes.rootBoundaryUnknown:
-      return rootBoundaryFields;
-    default:
-      return [];
+function resolveReasonRequiredFields(
+  reasonSpec: NavigationTraceReasonSpec,
+  spec: NavigationTraceDebugSpec,
+  transactionEntry: { entry: NavigationTraceDebugEntry; index: number } | null,
+): readonly NavigationTraceFieldName[] {
+  for (const rule of reasonSpec.thinTraceWhen ?? []) {
+    if (matchesReasonThinTraceRule(rule, spec, transactionEntry)) {
+      return rule.requiredFields;
+    }
   }
+
+  return reasonSpec.requiredFields;
+}
+
+function matchesReasonThinTraceRule(
+  rule: NavigationTraceReasonThinTraceRule,
+  spec: NavigationTraceDebugSpec,
+  transactionEntry: { entry: NavigationTraceDebugEntry; index: number } | null,
+): boolean {
+  return (
+    spec.subject === rule.subject &&
+    spec.outcome === rule.outcome &&
+    transactionEntry?.entry.fields.operationLane === rule.lane
+  );
 }
 
 function addApprovalShapeIssues(
@@ -664,11 +780,18 @@ function addApprovalShapeIssues(
 function addReasonInvariantIssues(
   entry: NavigationTraceDebugEntry,
   entryIndex: number,
-  spec: NavigationTraceDebugSpec,
+  reasonSpec: NavigationTraceReasonSpec,
   issues: NavigationTraceInvariantIssue[],
 ): void {
-  if (entry.code !== NavigationTraceReasonCodes.staleOperation) {
-    return;
+  switch (reasonSpec.invariant) {
+    case undefined:
+      return;
+    case "staleMismatch":
+      break;
+    default: {
+      const _exhaustive: never = reasonSpec.invariant;
+      throw new Error("[vinext] Unknown NavigationTrace reason invariant: " + String(_exhaustive));
+    }
   }
 
   const fields = entry.fields;
@@ -682,7 +805,7 @@ function addReasonInvariantIssues(
       entryIndex,
       message:
         "NC_STALE requires activeNavigationId/startNavigationId or visibleCommitVersion mismatch",
-      source: reasonEntrySource(entry.code, spec),
+      source: reasonSpec.owner,
     });
   }
 }
@@ -741,8 +864,9 @@ function reasonEntrySource(
   code: string,
   spec: NavigationTraceDebugSpec,
 ): NavigationTraceDebugSource {
-  if (code === NavigationTraceReasonCodes.staleOperation) {
-    return "lifecycleGate";
+  const reasonSpec = getReasonSpec(code);
+  if (reasonSpec !== null) {
+    return reasonSpec.owner;
   }
 
   return expectedReasonSource(spec);
@@ -756,15 +880,19 @@ function expectedReasonSource(spec: NavigationTraceDebugSpec): NavigationTraceDe
   return "planner";
 }
 
-function isHmrVisibleCommitTrace(
-  spec: NavigationTraceDebugSpec,
-  transactionEntry: { entry: NavigationTraceDebugEntry; index: number } | null,
+function getReasonSpec(code: string): NavigationTraceReasonSpec | null {
+  return reasonSpecsByCode.get(code) ?? null;
+}
+
+function getTransactionSpec(code: string): NavigationTraceTransactionSpec | null {
+  return transactionSpecsByCode.get(code) ?? null;
+}
+
+function allowsTransactionDisposition(
+  transactionSpec: NavigationTraceTransactionSpec,
+  disposition: NavigationTraceCommitApprovalDebugInput["decision"]["disposition"],
 ): boolean {
-  return (
-    spec.subject === "commitApproval" &&
-    spec.outcome === "visibleCommit" &&
-    transactionEntry?.entry.fields.operationLane === "hmr"
-  );
+  return transactionSpec.allowedDispositions.some((allowed) => allowed === disposition);
 }
 
 function assertDebuggerRuntime(options: NavigationTraceDebuggerOptions): void {

--- a/packages/vinext/src/server/navigation-trace-debugger.ts
+++ b/packages/vinext/src/server/navigation-trace-debugger.ts
@@ -66,7 +66,7 @@ type NavigationTraceDebugEntry = Readonly<{
 }>;
 
 export type NavigationTraceCommitApprovalDebugInput = Readonly<{
-  approvedCommit: object | null | undefined;
+  approvedCommit: object | null;
   decision: Readonly<{
     disposition: "commit" | "hard-navigate" | "no-commit";
     trace: NavigationTraceDebugTrace;
@@ -644,10 +644,7 @@ function addApprovalShapeIssues(
   approval: NavigationTraceCommitApprovalDebugInput,
   issues: NavigationTraceInvariantIssue[],
 ): void {
-  if (
-    approval.decision.disposition === "commit" &&
-    (approval.approvedCommit === null || approval.approvedCommit === undefined)
-  ) {
+  if (approval.decision.disposition === "commit" && approval.approvedCommit === null) {
     issues.push({
       code: "approval-mismatch",
       message: "commit approval has commit disposition but no approved visible commit",

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -40,6 +40,7 @@ import {
   NavigationTraceTransactionCodes,
   createNavigationTrace,
 } from "../packages/vinext/src/server/navigation-trace.js";
+import { assertValidNavigationCommitApprovalTrace } from "../packages/vinext/src/server/navigation-trace-debugger.js";
 
 function createResolvedElements(
   routeId: string,
@@ -547,6 +548,7 @@ describe("app browser entry state helpers", () => {
       startedNavigationId: 7,
       targetHref: "https://example.com/dashboard",
     });
+    assertValidNavigationCommitApprovalTrace(approval);
 
     expect(approval.decision.disposition).toBe("no-commit");
     expect(approval.decision.trace.entries).toEqual([
@@ -597,6 +599,7 @@ describe("app browser entry state helpers", () => {
       startedNavigationId: 8,
       targetHref: "https://example.com/previous",
     });
+    assertValidNavigationCommitApprovalTrace(approval);
 
     expect(approval.decision.disposition).toBe("no-commit");
     expect(approval.decision.trace.entries).toEqual([
@@ -803,6 +806,7 @@ describe("app browser entry state helpers", () => {
       startedNavigationId: 4,
       targetHref: "https://example.com/dashboard",
     });
+    assertValidNavigationCommitApprovalTrace(approval);
 
     expect(approval.decision.disposition).toBe("commit");
     if (approval.decision.disposition !== "commit") {
@@ -864,6 +868,7 @@ describe("app browser entry state helpers", () => {
       startedNavigationId: 6,
       targetHref: "https://example.com/legacy-payload",
     });
+    assertValidNavigationCommitApprovalTrace(approval);
 
     expect(approval.decision.disposition).toBe("commit");
     expect(approval.decision.trace.entries[0]?.code).toBe(
@@ -891,6 +896,10 @@ describe("app browser entry state helpers", () => {
     });
 
     const approvedCommit = approveHmrVisibleCommit(pending);
+    assertValidNavigationCommitApprovalTrace({
+      approvedCommit,
+      decision: approvedCommit.decision,
+    });
     expect(approvedCommit.decision.trace.entries[0]).toEqual({
       code: NavigationTraceTransactionCodes.visibleCommit,
       fields: {
@@ -1023,6 +1032,7 @@ describe("app browser entry state helpers", () => {
       startedNavigationId: 7,
       targetHref: "https://example.com/dashboard",
     });
+    assertValidNavigationCommitApprovalTrace(staleApproval);
     expect(staleApproval.decision.disposition).toBe("no-commit");
     expect(staleApproval.decision.trace.entries[0]?.code).toBe(
       NavigationTraceTransactionCodes.noCommit,
@@ -1039,6 +1049,7 @@ describe("app browser entry state helpers", () => {
       startedNavigationId: 8,
       targetHref: "https://example.com/dashboard?from=planner",
     });
+    assertValidNavigationCommitApprovalTrace(hardNavigateApproval);
     expect(hardNavigateApproval.decision.disposition).toBe("hard-navigate");
     expect(hardNavigateApproval.decision.trace.entries[0]?.code).toBe(
       NavigationTraceTransactionCodes.hardNavigate,
@@ -2298,6 +2309,10 @@ describe("app browser entry previousNextUrl helpers", () => {
       startedNavigationId: 7,
       targetHref: "https://example.com/dashboard?action=same-url",
       type: "navigate",
+    });
+    assertValidNavigationCommitApprovalTrace({
+      approvedCommit: result.approvedCommit,
+      decision: result.decision,
     });
 
     expect(result.decision.disposition).toBe("hard-navigate");

--- a/tests/navigation-planner.test.ts
+++ b/tests/navigation-planner.test.ts
@@ -15,6 +15,7 @@ import {
   type RouteSnapshotV0,
   type RootBoundaryTransition,
 } from "../packages/vinext/src/server/navigation-planner.js";
+import { assertValidNavigationDecisionTrace } from "../packages/vinext/src/server/navigation-trace-debugger.js";
 
 function createRouteSnapshot(rootBoundaryId: string | null): RouteSnapshotV0 {
   return {
@@ -108,6 +109,7 @@ describe("navigationPlanner root-boundary decisions", () => {
   // .nextjs-ref/test/e2e/app-dir/segment-cache/mpa-navigations/mpa-navigations.test.ts
   it("proposes a visible commit for same-root flight responses", () => {
     const decision = planFlightResponse("/");
+    assertValidNavigationDecisionTrace(decision);
 
     expect(decision.kind).toBe("proposeCommit");
     if (decision.kind !== "proposeCommit") {
@@ -136,6 +138,7 @@ describe("navigationPlanner root-boundary decisions", () => {
       "/(dashboard)",
     );
     const decision = planFlightResponse("/(dashboard)");
+    assertValidNavigationDecisionTrace(decision);
 
     expect(transition).toBe("rootBoundaryChanged");
     expect(decision.kind).toBe("hardNavigate");
@@ -159,6 +162,7 @@ describe("navigationPlanner root-boundary decisions", () => {
 
   it("uses the current soft fallback when the target root identity is unknown", () => {
     const decision = planFlightResponse(null);
+    assertValidNavigationDecisionTrace(decision);
 
     expect(decision.kind).toBe("proposeCommit");
     if (decision.kind !== "proposeCommit") {
@@ -174,6 +178,7 @@ describe("navigationPlanner root-boundary decisions", () => {
       currentRootBoundaryId: null,
       nextRootBoundaryId: "/",
     });
+    assertValidNavigationDecisionTrace(decision);
 
     expect(transition).toBe("rootBoundaryUnknownFallback");
     expect(decision.kind).toBe("proposeCommit");
@@ -211,6 +216,7 @@ describe("navigationPlanner root-boundary decisions", () => {
         token,
       },
     });
+    assertValidNavigationDecisionTrace(decision);
 
     expect(decision.kind).toBe("noCommit");
     if (decision.kind !== "noCommit") {
@@ -236,6 +242,7 @@ describe("navigationPlanner root-boundary decisions", () => {
       },
     };
     const decision = navigationPlanner.plan(input);
+    assertValidNavigationDecisionTrace(decision);
 
     expect(decision.kind).toBe("requestWork");
     if (decision.kind !== "requestWork") {
@@ -264,6 +271,7 @@ describe("navigationPlanner root-boundary decisions", () => {
         visibleSnapshot: createRouteSnapshot("/"),
       },
     });
+    assertValidNavigationDecisionTrace(decision);
 
     expect(decision.kind).toBe("requestWork");
     if (decision.kind !== "requestWork") {
@@ -292,6 +300,7 @@ describe("navigationPlanner root-boundary decisions", () => {
         kind: "traverse",
       },
     });
+    assertValidNavigationDecisionTrace(decision);
 
     expect(decision.kind).toBe("requestWork");
     if (decision.kind !== "requestWork") {

--- a/tests/navigation-trace-debugger.test.ts
+++ b/tests/navigation-trace-debugger.test.ts
@@ -1,0 +1,612 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  NavigationTraceReasonCodes,
+  NavigationTraceTransactionCodes,
+  createNavigationTrace,
+} from "../packages/vinext/src/server/navigation-trace.js";
+import {
+  navigationPlanner,
+  type NavigationDecisionV0,
+  type OperationToken,
+  type RouteSnapshotV0,
+} from "../packages/vinext/src/server/navigation-planner.js";
+import {
+  assertValidNavigationCommitApprovalTrace,
+  assertValidNavigationDecisionTrace,
+  inspectNavigationCommitApprovalTrace,
+  inspectNavigationDecisionTrace,
+  type NavigationTraceCommitApprovalDebugInput,
+} from "../packages/vinext/src/server/navigation-trace-debugger.js";
+
+function createOperationToken(overrides: Partial<OperationToken> = {}): OperationToken {
+  return {
+    baseVisibleCommitVersion: 0,
+    deploymentVersion: null,
+    graphVersion: null,
+    lane: "navigation",
+    operationId: 11,
+    targetSnapshotFingerprint: "route:/dashboard|root:/",
+    ...overrides,
+  };
+}
+
+function createRouteSnapshot(rootBoundaryId: string | null): RouteSnapshotV0 {
+  return {
+    displayUrl: "https://example.com/dashboard",
+    matchedUrl: "/dashboard",
+    rootBoundaryId,
+    routeId: "route:/dashboard",
+  };
+}
+
+function planSameRootNavigation(): NavigationDecisionV0 {
+  const token = createOperationToken();
+
+  return navigationPlanner.plan({
+    event: {
+      kind: "flightResponseArrived",
+      result: {
+        href: "https://example.com/dashboard",
+        targetSnapshot: createRouteSnapshot("/"),
+      },
+      token,
+    },
+    routeManifest: null,
+    state: {
+      nextOperationToken: token,
+      traceFields: {
+        activeNavigationId: 4,
+        currentRootLayoutTreePath: "/",
+        currentVisibleCommitVersion: 0,
+        nextRootLayoutTreePath: "/",
+        startedNavigationId: 4,
+        startedVisibleCommitVersion: 0,
+        targetHref: "https://example.com/dashboard",
+      },
+      visibleCommitVersion: 0,
+      visibleSnapshot: createRouteSnapshot("/"),
+    },
+  });
+}
+
+describe("NavigationTrace invariant debugger", () => {
+  it("explains valid planner visible-commit proposals without approving state", () => {
+    const report = inspectNavigationDecisionTrace(planSameRootNavigation(), { runtime: "test" });
+
+    expect(report).toMatchObject({
+      ok: true,
+      outcome: "visibleCommit",
+      source: "planner",
+      subject: "plannerDecision",
+    });
+    expect(report.explanation).toEqual({
+      reasonCode: NavigationTraceReasonCodes.commitCurrent,
+      transactionCode: null,
+      traceCodes: [NavigationTraceReasonCodes.commitCurrent],
+    });
+  });
+
+  it("points malformed planner decision traces at the planner owner", () => {
+    const token = createOperationToken();
+    const decision: NavigationDecisionV0 = {
+      kind: "requestWork",
+      token,
+      trace: createNavigationTrace(NavigationTraceReasonCodes.requestWork, {
+        eventKind: "navigate",
+      }),
+      work: {
+        href: "https://example.com/dashboard",
+        kind: "flight",
+        mode: "push",
+      },
+    };
+
+    const report = inspectNavigationDecisionTrace(decision, { runtime: "test" });
+
+    expect(report.ok).toBe(false);
+    expect(report.issues).toEqual([
+      {
+        code: "missing-field",
+        entryIndex: 0,
+        field: "targetHref",
+        message: "NC_REQUEST is missing required field targetHref",
+        source: "planner",
+      },
+    ]);
+    expect(() => assertValidNavigationDecisionTrace(decision, { runtime: "test" })).toThrow(
+      "NavigationTrace invariant failed [subject=plannerDecision outcome=requestWork source=planner]",
+    );
+  });
+
+  it("validates commit approval transaction traces and visible outcome explanations", () => {
+    const approval = {
+      approvedCommit: {},
+      decision: {
+        disposition: "commit",
+        trace: {
+          schemaVersion: 0,
+          entries: [
+            {
+              code: NavigationTraceTransactionCodes.visibleCommit,
+              fields: {
+                operationLane: "navigation",
+                pendingOperationId: 11,
+                startedVisibleCommitVersion: 0,
+              },
+            },
+            {
+              code: NavigationTraceReasonCodes.commitCurrent,
+              fields: {
+                activeNavigationId: 4,
+                currentRootLayoutTreePath: "/",
+                currentVisibleCommitVersion: 0,
+                nextRootLayoutTreePath: "/",
+                startedNavigationId: 4,
+                startedVisibleCommitVersion: 0,
+                targetHref: "https://example.com/dashboard",
+              },
+            },
+          ],
+        },
+      },
+    } satisfies NavigationTraceCommitApprovalDebugInput;
+
+    const report = inspectNavigationCommitApprovalTrace(approval, { runtime: "test" });
+
+    expect(report).toMatchObject({
+      ok: true,
+      outcome: "visibleCommit",
+      source: "commitTransaction",
+      subject: "commitApproval",
+    });
+    expect(report.explanation).toEqual({
+      reasonCode: NavigationTraceReasonCodes.commitCurrent,
+      transactionCode: NavigationTraceTransactionCodes.visibleCommit,
+      traceCodes: [
+        NavigationTraceTransactionCodes.visibleCommit,
+        NavigationTraceReasonCodes.commitCurrent,
+      ],
+    });
+    expect(() =>
+      assertValidNavigationCommitApprovalTrace(approval, { runtime: "test" }),
+    ).not.toThrow();
+  });
+
+  it("explains valid planner no-commit prefetch outcomes", () => {
+    const token = createOperationToken({ lane: "prefetch" });
+    const decision = navigationPlanner.plan({
+      event: {
+        kind: "flightResponseArrived",
+        result: {
+          href: "https://example.com/dashboard",
+          targetSnapshot: createRouteSnapshot("/"),
+        },
+        token,
+      },
+      routeManifest: null,
+      state: {
+        nextOperationToken: token,
+        traceFields: {
+          currentRootLayoutTreePath: "/",
+          currentVisibleCommitVersion: 0,
+          nextRootLayoutTreePath: "/",
+          startedVisibleCommitVersion: 0,
+        },
+        visibleCommitVersion: 0,
+        visibleSnapshot: createRouteSnapshot("/"),
+      },
+    });
+
+    const report = inspectNavigationDecisionTrace(decision, { runtime: "test" });
+
+    expect(report).toMatchObject({
+      ok: true,
+      outcome: "noCommit",
+      source: "planner",
+      subject: "plannerDecision",
+    });
+    expect(report.explanation).toEqual({
+      reasonCode: NavigationTraceReasonCodes.prefetchOnly,
+      transactionCode: null,
+      traceCodes: [NavigationTraceReasonCodes.prefetchOnly],
+    });
+  });
+
+  it("explains valid stale lifecycle no-commit approvals", () => {
+    const approval = {
+      approvedCommit: null,
+      decision: {
+        disposition: "no-commit",
+        trace: {
+          schemaVersion: 0,
+          entries: [
+            {
+              code: NavigationTraceTransactionCodes.noCommit,
+              fields: {
+                operationLane: "refresh",
+                pendingOperationId: 22,
+                startedVisibleCommitVersion: 4,
+              },
+            },
+            {
+              code: NavigationTraceReasonCodes.staleOperation,
+              fields: {
+                activeNavigationId: 7,
+                currentRootLayoutTreePath: "/",
+                currentVisibleCommitVersion: 5,
+                nextRootLayoutTreePath: "/",
+                startedNavigationId: 7,
+                startedVisibleCommitVersion: 4,
+              },
+            },
+          ],
+        },
+      },
+    } satisfies NavigationTraceCommitApprovalDebugInput;
+
+    const report = inspectNavigationCommitApprovalTrace(approval, { runtime: "test" });
+
+    expect(report).toMatchObject({
+      ok: true,
+      outcome: "stale",
+      source: "lifecycleGate",
+      subject: "commitApproval",
+    });
+    expect(report.explanation).toEqual({
+      reasonCode: NavigationTraceReasonCodes.staleOperation,
+      transactionCode: NavigationTraceTransactionCodes.noCommit,
+      traceCodes: [
+        NavigationTraceTransactionCodes.noCommit,
+        NavigationTraceReasonCodes.staleOperation,
+      ],
+    });
+  });
+
+  it("explains valid hard-navigation commit approvals", () => {
+    const approval = {
+      approvedCommit: null,
+      decision: {
+        disposition: "hard-navigate",
+        trace: {
+          schemaVersion: 0,
+          entries: [
+            {
+              code: NavigationTraceTransactionCodes.hardNavigate,
+              fields: {
+                operationLane: "navigation",
+                pendingOperationId: 13,
+                startedVisibleCommitVersion: 0,
+              },
+            },
+            {
+              code: NavigationTraceReasonCodes.rootBoundaryChanged,
+              fields: {
+                activeNavigationId: 4,
+                currentRootLayoutTreePath: "/(marketing)",
+                currentVisibleCommitVersion: 0,
+                nextRootLayoutTreePath: "/(dashboard)",
+                startedNavigationId: 4,
+                startedVisibleCommitVersion: 0,
+                targetHref: "https://example.com/dashboard",
+              },
+            },
+          ],
+        },
+      },
+    } satisfies NavigationTraceCommitApprovalDebugInput;
+
+    const report = inspectNavigationCommitApprovalTrace(approval, { runtime: "test" });
+
+    expect(report).toMatchObject({
+      ok: true,
+      outcome: "hardNavigate",
+      source: "commitTransaction",
+      subject: "commitApproval",
+    });
+    expect(report.explanation).toEqual({
+      reasonCode: NavigationTraceReasonCodes.rootBoundaryChanged,
+      transactionCode: NavigationTraceTransactionCodes.hardNavigate,
+      traceCodes: [
+        NavigationTraceTransactionCodes.hardNavigate,
+        NavigationTraceReasonCodes.rootBoundaryChanged,
+      ],
+    });
+  });
+
+  it("points stale no-commit trace field failures at the lifecycle gate", () => {
+    const approval = {
+      approvedCommit: null,
+      decision: {
+        disposition: "no-commit",
+        trace: {
+          schemaVersion: 0,
+          entries: [
+            {
+              code: NavigationTraceTransactionCodes.noCommit,
+              fields: {
+                operationLane: "refresh",
+                pendingOperationId: 22,
+                startedVisibleCommitVersion: 4,
+              },
+            },
+            {
+              code: NavigationTraceReasonCodes.staleOperation,
+              fields: {
+                currentRootLayoutTreePath: "/",
+                currentVisibleCommitVersion: 5,
+                nextRootLayoutTreePath: "/",
+                startedVisibleCommitVersion: 4,
+              },
+            },
+          ],
+        },
+      },
+    } satisfies NavigationTraceCommitApprovalDebugInput;
+
+    const report = inspectNavigationCommitApprovalTrace(approval, { runtime: "test" });
+
+    expect(report.ok).toBe(false);
+    expect(report.issues).toEqual([
+      {
+        code: "missing-field",
+        entryIndex: 1,
+        field: "activeNavigationId",
+        message: "NC_STALE is missing required field activeNavigationId",
+        source: "lifecycleGate",
+      },
+      {
+        code: "missing-field",
+        entryIndex: 1,
+        field: "startedNavigationId",
+        message: "NC_STALE is missing required field startedNavigationId",
+        source: "lifecycleGate",
+      },
+    ]);
+  });
+
+  it("rejects stale traces without a stale lifecycle mismatch", () => {
+    const approval = {
+      approvedCommit: null,
+      decision: {
+        disposition: "no-commit",
+        trace: {
+          schemaVersion: 0,
+          entries: [
+            {
+              code: NavigationTraceTransactionCodes.noCommit,
+              fields: {
+                operationLane: "navigation",
+                pendingOperationId: 17,
+                startedVisibleCommitVersion: 3,
+              },
+            },
+            {
+              code: NavigationTraceReasonCodes.staleOperation,
+              fields: {
+                activeNavigationId: 4,
+                currentRootLayoutTreePath: "/",
+                currentVisibleCommitVersion: 3,
+                nextRootLayoutTreePath: "/",
+                startedNavigationId: 4,
+                startedVisibleCommitVersion: 3,
+              },
+            },
+          ],
+        },
+      },
+    } satisfies NavigationTraceCommitApprovalDebugInput;
+
+    const report = inspectNavigationCommitApprovalTrace(approval, { runtime: "test" });
+
+    expect(report.ok).toBe(false);
+    expect(report.issues[0]).toEqual({
+      code: "invalid-field",
+      entryIndex: 1,
+      message:
+        "NC_STALE requires activeNavigationId/startNavigationId or visibleCommitVersion mismatch",
+      source: "lifecycleGate",
+    });
+  });
+
+  it("rejects commit approvals without an approved visible commit", () => {
+    const approval = {
+      approvedCommit: undefined,
+      decision: {
+        disposition: "commit",
+        trace: {
+          schemaVersion: 0,
+          entries: [
+            {
+              code: NavigationTraceTransactionCodes.visibleCommit,
+              fields: {
+                operationLane: "navigation",
+                pendingOperationId: 11,
+                startedVisibleCommitVersion: 0,
+              },
+            },
+            {
+              code: NavigationTraceReasonCodes.commitCurrent,
+              fields: {
+                currentRootLayoutTreePath: "/",
+                currentVisibleCommitVersion: 0,
+                nextRootLayoutTreePath: "/",
+                startedVisibleCommitVersion: 0,
+              },
+            },
+          ],
+        },
+      },
+    } satisfies NavigationTraceCommitApprovalDebugInput;
+
+    const report = inspectNavigationCommitApprovalTrace(approval, { runtime: "test" });
+
+    expect(report.ok).toBe(false);
+    expect(report.issues[0]).toEqual({
+      code: "approval-mismatch",
+      message: "commit approval has commit disposition but no approved visible commit",
+      source: "commitTransaction",
+    });
+  });
+
+  it("rejects non-visible approvals that carry an approved visible commit", () => {
+    const approval = {
+      approvedCommit: {},
+      decision: {
+        disposition: "hard-navigate",
+        trace: {
+          schemaVersion: 0,
+          entries: [
+            {
+              code: NavigationTraceTransactionCodes.hardNavigate,
+              fields: {
+                operationLane: "navigation",
+                pendingOperationId: 13,
+                startedVisibleCommitVersion: 0,
+              },
+            },
+            {
+              code: NavigationTraceReasonCodes.rootBoundaryChanged,
+              fields: {
+                currentRootLayoutTreePath: "/(marketing)",
+                currentVisibleCommitVersion: 0,
+                nextRootLayoutTreePath: "/(dashboard)",
+                startedVisibleCommitVersion: 0,
+              },
+            },
+          ],
+        },
+      },
+    } satisfies NavigationTraceCommitApprovalDebugInput;
+
+    const report = inspectNavigationCommitApprovalTrace(approval, { runtime: "test" });
+
+    expect(report.ok).toBe(false);
+    expect(report.issues[0]).toEqual({
+      code: "approval-mismatch",
+      message: "hard-navigate approval must not carry an approved visible commit",
+      source: "commitTransaction",
+    });
+  });
+
+  it("points missing transaction wrappers at the commit transaction owner", () => {
+    const approval = {
+      approvedCommit: {},
+      decision: {
+        disposition: "commit",
+        trace: createNavigationTrace(NavigationTraceReasonCodes.commitCurrent, {
+          activeNavigationId: 4,
+          currentRootLayoutTreePath: "/",
+          currentVisibleCommitVersion: 0,
+          nextRootLayoutTreePath: "/",
+          startedNavigationId: 4,
+          startedVisibleCommitVersion: 0,
+          targetHref: "https://example.com/dashboard",
+        }),
+      },
+    } satisfies NavigationTraceCommitApprovalDebugInput;
+
+    const report = inspectNavigationCommitApprovalTrace(approval, { runtime: "test" });
+
+    expect(report.ok).toBe(false);
+    expect(report.issues[0]).toEqual({
+      code: "missing-transaction",
+      entryIndex: 0,
+      message: "commit approval expected first trace code NT_VISIBLE_COMMIT",
+      source: "commitTransaction",
+    });
+  });
+
+  it("rejects extra transaction entries on planner decision traces", () => {
+    const decision: NavigationDecisionV0 = {
+      ...planSameRootNavigation(),
+      trace: {
+        schemaVersion: 0,
+        entries: [
+          {
+            code: NavigationTraceReasonCodes.commitCurrent,
+            fields: {
+              currentRootLayoutTreePath: "/",
+              currentVisibleCommitVersion: 0,
+              nextRootLayoutTreePath: "/",
+              startedVisibleCommitVersion: 0,
+            },
+          },
+          {
+            code: NavigationTraceTransactionCodes.visibleCommit,
+            fields: {
+              operationLane: "navigation",
+              pendingOperationId: 11,
+              startedVisibleCommitVersion: 0,
+            },
+          },
+        ],
+      },
+    };
+
+    const report = inspectNavigationDecisionTrace(decision, { runtime: "test" });
+
+    expect(report.ok).toBe(false);
+    expect(report.issues[0]).toEqual({
+      code: "unexpected-code",
+      entryIndex: 1,
+      message: "planner decision trace must not include transaction code NT_VISIBLE_COMMIT",
+      source: "planner",
+    });
+  });
+
+  it("rejects multiple reason entries on commit approval traces", () => {
+    const approval = {
+      approvedCommit: {},
+      decision: {
+        disposition: "commit",
+        trace: {
+          schemaVersion: 0,
+          entries: [
+            {
+              code: NavigationTraceTransactionCodes.visibleCommit,
+              fields: {
+                operationLane: "navigation",
+                pendingOperationId: 11,
+                startedVisibleCommitVersion: 0,
+              },
+            },
+            {
+              code: NavigationTraceReasonCodes.commitCurrent,
+              fields: {
+                currentRootLayoutTreePath: "/",
+                currentVisibleCommitVersion: 0,
+                nextRootLayoutTreePath: "/",
+                startedVisibleCommitVersion: 0,
+              },
+            },
+            {
+              code: NavigationTraceReasonCodes.rootBoundaryUnknown,
+              fields: {
+                currentRootLayoutTreePath: "/",
+                currentVisibleCommitVersion: 0,
+                nextRootLayoutTreePath: null,
+                startedVisibleCommitVersion: 0,
+              },
+            },
+          ],
+        },
+      },
+    } satisfies NavigationTraceCommitApprovalDebugInput;
+
+    const report = inspectNavigationCommitApprovalTrace(approval, { runtime: "test" });
+
+    expect(report.ok).toBe(false);
+    expect(report.issues[0]).toEqual({
+      code: "unexpected-code",
+      entryIndex: 2,
+      message: "commit approval trace must include exactly one reason code",
+      source: "planner",
+    });
+  });
+
+  it("keeps the debugger off production runtime surfaces", () => {
+    expect(() =>
+      inspectNavigationDecisionTrace(planSameRootNavigation(), { runtime: "production" }),
+    ).toThrow("[vinext] NavigationTrace invariant debugger is dev/test-only");
+  });
+});

--- a/tests/navigation-trace-debugger.test.ts
+++ b/tests/navigation-trace-debugger.test.ts
@@ -526,6 +526,7 @@ describe("NavigationTrace invariant debugger", () => {
     const invalidShapeCases = [
       {
         expectedCode: "invalid-schema",
+        expectedMessage: "NavigationTrace schemaVersion must be 0",
         trace: {
           ...validCommitTrace,
           schemaVersion: 999,
@@ -533,6 +534,7 @@ describe("NavigationTrace invariant debugger", () => {
       },
       {
         expectedCode: "empty-trace",
+        expectedMessage: "NavigationTrace must include at least one entry",
         trace: {
           schemaVersion: 0,
           entries: [],
@@ -540,6 +542,7 @@ describe("NavigationTrace invariant debugger", () => {
       },
       {
         expectedCode: "unknown-code",
+        expectedMessage: "unknown NavigationTrace code NC_UNKNOWN",
         trace: {
           ...validCommitTrace,
           entries: [
@@ -553,6 +556,7 @@ describe("NavigationTrace invariant debugger", () => {
       },
       {
         expectedCode: "unknown-field",
+        expectedMessage: "NC_COMMIT includes unknown field unexpectedField",
         trace: {
           ...validCommitTrace,
           entries: [
@@ -569,6 +573,41 @@ describe("NavigationTrace invariant debugger", () => {
       },
       {
         expectedCode: "invalid-field",
+        expectedMessage: "NC_COMMIT field targetHref must be string, number, boolean, or null",
+        trace: {
+          ...validCommitTrace,
+          entries: [
+            validCommitTrace.entries[0],
+            {
+              ...validCommitTrace.entries[1],
+              fields: {
+                ...validCommitTrace.entries[1].fields,
+                targetHref: { href: "https://example.com/dashboard" },
+              },
+            },
+          ],
+        },
+      },
+      {
+        expectedCode: "invalid-field",
+        expectedMessage: "NC_COMMIT field eventKind must be navigation event kind",
+        trace: {
+          ...validCommitTrace,
+          entries: [
+            validCommitTrace.entries[0],
+            {
+              ...validCommitTrace.entries[1],
+              fields: {
+                ...validCommitTrace.entries[1].fields,
+                eventKind: "replaceState",
+              },
+            },
+          ],
+        },
+      },
+      {
+        expectedCode: "invalid-field",
+        expectedMessage: "NT_VISIBLE_COMMIT field operationLane must be operation lane",
         trace: {
           ...validCommitTrace,
           entries: [
@@ -576,7 +615,7 @@ describe("NavigationTrace invariant debugger", () => {
               ...validCommitTrace.entries[0],
               fields: {
                 ...validCommitTrace.entries[0].fields,
-                pendingOperationId: "11",
+                operationLane: "background",
               },
             },
             validCommitTrace.entries[1],
@@ -585,6 +624,7 @@ describe("NavigationTrace invariant debugger", () => {
       },
     ] satisfies readonly {
       expectedCode: string;
+      expectedMessage: string;
       trace: NavigationTraceCommitApprovalDebugInput["decision"]["trace"];
     }[];
 
@@ -597,6 +637,7 @@ describe("NavigationTrace invariant debugger", () => {
       expect(report.issues).toContainEqual(
         expect.objectContaining({
           code: testCase.expectedCode,
+          message: testCase.expectedMessage,
         }),
       );
     }

--- a/tests/navigation-trace-debugger.test.ts
+++ b/tests/navigation-trace-debugger.test.ts
@@ -69,6 +69,18 @@ function planSameRootNavigation(): NavigationDecisionV0 {
   });
 }
 
+function createCommitApprovalDebugInput(
+  trace: NavigationTraceCommitApprovalDebugInput["decision"]["trace"],
+): NavigationTraceCommitApprovalDebugInput {
+  return {
+    approvedCommit: {},
+    decision: {
+      disposition: "commit",
+      trace,
+    },
+  };
+}
+
 describe("NavigationTrace invariant debugger", () => {
   it("explains valid planner visible-commit proposals without approving state", () => {
     const report = inspectNavigationDecisionTrace(planSameRootNavigation(), { runtime: "test" });
@@ -410,7 +422,7 @@ describe("NavigationTrace invariant debugger", () => {
 
   it("rejects commit approvals without an approved visible commit", () => {
     const approval = {
-      approvedCommit: undefined,
+      approvedCommit: null,
       decision: {
         disposition: "commit",
         trace: {
@@ -486,6 +498,108 @@ describe("NavigationTrace invariant debugger", () => {
       message: "hard-navigate approval must not carry an approved visible commit",
       source: "commitTransaction",
     });
+  });
+
+  it("reports compact trace shape validation failures", () => {
+    const validCommitTrace = {
+      schemaVersion: 0,
+      entries: [
+        {
+          code: NavigationTraceTransactionCodes.visibleCommit,
+          fields: {
+            operationLane: "navigation",
+            pendingOperationId: 11,
+            startedVisibleCommitVersion: 0,
+          },
+        },
+        {
+          code: NavigationTraceReasonCodes.commitCurrent,
+          fields: {
+            currentRootLayoutTreePath: "/",
+            currentVisibleCommitVersion: 0,
+            nextRootLayoutTreePath: "/",
+            startedVisibleCommitVersion: 0,
+          },
+        },
+      ],
+    } satisfies NavigationTraceCommitApprovalDebugInput["decision"]["trace"];
+    const invalidShapeCases = [
+      {
+        expectedCode: "invalid-schema",
+        trace: {
+          ...validCommitTrace,
+          schemaVersion: 999,
+        },
+      },
+      {
+        expectedCode: "empty-trace",
+        trace: {
+          schemaVersion: 0,
+          entries: [],
+        },
+      },
+      {
+        expectedCode: "unknown-code",
+        trace: {
+          ...validCommitTrace,
+          entries: [
+            ...validCommitTrace.entries,
+            {
+              code: "NC_UNKNOWN",
+              fields: {},
+            },
+          ],
+        },
+      },
+      {
+        expectedCode: "unknown-field",
+        trace: {
+          ...validCommitTrace,
+          entries: [
+            validCommitTrace.entries[0],
+            {
+              ...validCommitTrace.entries[1],
+              fields: {
+                ...validCommitTrace.entries[1].fields,
+                unexpectedField: true,
+              },
+            },
+          ],
+        },
+      },
+      {
+        expectedCode: "invalid-field",
+        trace: {
+          ...validCommitTrace,
+          entries: [
+            {
+              ...validCommitTrace.entries[0],
+              fields: {
+                ...validCommitTrace.entries[0].fields,
+                pendingOperationId: "11",
+              },
+            },
+            validCommitTrace.entries[1],
+          ],
+        },
+      },
+    ] satisfies readonly {
+      expectedCode: string;
+      trace: NavigationTraceCommitApprovalDebugInput["decision"]["trace"];
+    }[];
+
+    for (const testCase of invalidShapeCases) {
+      const report = inspectNavigationCommitApprovalTrace(
+        createCommitApprovalDebugInput(testCase.trace),
+        { runtime: "test" },
+      );
+
+      expect(report.issues).toContainEqual(
+        expect.objectContaining({
+          code: testCase.expectedCode,
+        }),
+      );
+    }
   });
 
   it("points missing transaction wrappers at the commit transaction owner", () => {


### PR DESCRIPTION
Refs #726. Implements #726-DEBUG-01.

## Overview

| Item | Detail |
| --- | --- |
| Goal | Implement #726-DEBUG-01 for issue #726. |
| Core change | Add a dev/test-only NavigationTrace invariant debugger for planner and lifecycle tests. |
| Boundary | Consumes NavigationDecisionV0, commit approvals, traces, and lifecycle fields only. It does not add route or planner semantics. |
| Primary files | packages/vinext/src/server/navigation-trace-debugger.ts, tests/navigation-trace-debugger.test.ts, tests/navigation-planner.test.ts, tests/app-browser-entry.test.ts |
| Expected impact | Better failure localization for planner, lifecycle gate, and commit transaction trace regressions. |

## Why

For #726, NavigationTrace is useful only if compact trace codes and structured fields remain owned by the right boundary. #726-DEBUG-01 adds the minimal invariant debugger needed by planner and lifecycle tests so bad traces fail with the responsible owner rather than becoming broad router failures.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| Planner | Planner emits decision reasons, not commit transaction approval. | Planner traces are rejected if they contain transaction codes or conflicting reason entries. |
| Lifecycle gate | Stale means the operation was superseded by navigation id or visible commit version. | Stale traces must carry lifecycle fields and show a real stale mismatch. |
| Commit transaction | Visible state mutation requires an approved commit transaction. | Commit approvals must prepend the expected transaction code and match approvedCommit shape. |

## What changed

| Surface | Before | After |
| --- | --- | --- |
| Planner tests | Asserted trace snapshots but not reusable invariants. | Assert planner traces via `assertValidNavigationDecisionTrace`. |
| Lifecycle tests | Trace failures did not identify owner. | Commit approval traces classify failures as planner, lifecycleGate, or commitTransaction. |
| Debug surface | No focused helper for #726 trace invariants. | Internal dev/test-only helper validates trace shape, required fields, stale invariants, and approval shape. |

<details>
<summary>Maintainer review path</summary>

1. `packages/vinext/src/server/navigation-trace-debugger.ts`: verify it consumes existing decisions and traces only and does not own route semantics.
2. `tests/navigation-trace-debugger.test.ts`: review valid explanations plus hostile malformed trace cases.
3. `tests/navigation-planner.test.ts`: verify planner decisions now assert debugger invariants.
4. `tests/app-browser-entry.test.ts`: verify lifecycle and commit approval paths use the debugger.

</details>

<details>
<summary>Validation</summary>

- `vp test run tests/navigation-trace-debugger.test.ts tests/navigation-planner.test.ts tests/app-browser-entry.test.ts`
  - 3 files passed, 102 tests passed
- `vp check packages/vinext/src/server/navigation-trace-debugger.ts tests/navigation-trace-debugger.test.ts tests/navigation-planner.test.ts tests/app-browser-entry.test.ts`
  - formatted, no warnings, lint errors, or type errors
- commit hook
  - formatting, lint/type checks across 531 files, knip clean
- `vp run vinext#build`
  - package build passed; existing virtual-module warnings only
- Subagent review
  - Ran three GPT-5.5 high review agents for architecture ownership, testing rigor, and TypeScript/runtime boundary. Valid findings were addressed before this PR was opened.

</details>

<details>
<summary>Risk / compatibility</summary>

- Public API: none. The helper is internal and not added to package exports.
- Runtime: fail-closed outside explicit dev/test contexts.
- Router behavior: none. This PR does not change navigation decisions or commit behavior.
- Build output: package build emits the internal helper because vinext packs source entries by glob.

</details>

<details>
<summary>Non-goals</summary>

- No production metrics.
- No cache, skip, or runtime counters.
- No external observability integration.
- No route or planner semantic promotion.
- No duplicate planner or root-boundary decision logic.

</details>

## Bonk

Bonk, please read issue #726 before reviewing this PR. The architectural big picture matters here: this PR is only the #726-DEBUG-01 diagnostic slice, and it should stay a consumer of planner/lifecycle traces rather than becoming a second planner.

## References

| Reference | Why it matters |
| --- | --- |
| #726 | Original NavigationPlanner and lifecycle architecture. |
| #726-DEBUG-01 | Roadmap task implemented by this PR. |
