### PR TITLE
fix(dynamic): preserve noSSR initial delay state

### DIFF
--- a/packages/vinext/src/shims/dynamic.ts
+++ b/packages/vinext/src/shims/dynamic.ts
@@ -161,7 +161,7 @@ function dynamic<P extends object = object>(
       // On the server (SSR or RSC), just render the loading state or nothing
       const SSRFalse = (_props: P) =>
         LoadingComponent
-          ? React.createElement(LoadingComponent, createDynamicLoadingProps())
+          ? React.createElement(LoadingComponent, createDynamicLoadingProps({ pastDelay: false }))
           : null;
       SSRFalse.displayName = "DynamicSSRFalse";
       return SSRFalse;

--- a/tests/dynamic.test.ts
+++ b/tests/dynamic.test.ts
@@ -62,6 +62,18 @@ describe("next/dynamic ssr: false", () => {
     expect(html).not.toContain("Hello from dynamic");
   });
 
+  it("does not force loading UI when ssr: false has not passed the delay", () => {
+    const LoadingAfterDelay = ({ pastDelay }: { pastDelay?: boolean }) =>
+      pastDelay ? React.createElement("div", null, "Delayed loading") : null;
+    const DynamicNoSSR = dynamic(() => Promise.resolve({ default: Hello }), {
+      ssr: false,
+      loading: LoadingAfterDelay,
+    });
+
+    const html = ReactDOMServer.renderToString(React.createElement(DynamicNoSSR));
+    expect(html).toBe("");
+  });
+
   it("renders nothing on server when ssr: false and no loading", () => {
     const DynamicNoSSR = dynamic(() => Promise.resolve({ default: Hello }), { ssr: false });
 
@@ -78,7 +90,7 @@ describe("next/dynamic ssr: false", () => {
 // ─── Loading component ──────────────────────────────────────────────────
 
 describe("next/dynamic loading component", () => {
-  it("passes the full Next.js loading props shape to loading component on SSR", () => {
+  it("passes the Next.js noSSR loading props to loading component on SSR", () => {
     let receivedProps: any = null;
     function TrackingLoader(props: any) {
       receivedProps = props;
@@ -94,7 +106,7 @@ describe("next/dynamic loading component", () => {
 
     expect(receivedProps).toEqual({
       isLoading: true,
-      pastDelay: true,
+      pastDelay: false,
       error: null,
       timedOut: false,
       retry: expect.any(Function),

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -8332,7 +8332,7 @@ describe("next/dynamic shim", () => {
     expect(result).toEqual([]);
   });
 
-  it("loading component receives isLoading and pastDelay props", async () => {
+  it("loading component receives Next.js noSSR loading props", async () => {
     const { default: dynamic } = await import("../packages/vinext/src/shims/dynamic.js");
     const React = await import("react");
     const { renderToStaticMarkup } = await import("react-dom/server");
@@ -8352,7 +8352,7 @@ describe("next/dynamic shim", () => {
     renderToStaticMarkup(React.createElement(DynComp));
     expect(receivedProps).not.toBeNull();
     expect(receivedProps.isLoading).toBe(true);
-    expect(receivedProps.pastDelay).toBe(true);
+    expect(receivedProps.pastDelay).toBe(false);
     expect(receivedProps.error).toBeNull();
   });
 


### PR DESCRIPTION
## Overview

| Item | Detail |
| --- | --- |
| Goal | Match Next.js `dynamic(..., { ssr: false })` server loading props. |
| Core change | Pass `pastDelay: false` only from the vinext noSSR server placeholder path. |
| Review focus | Confirm SSR-enabled and client Suspense fallback paths still use their existing loading props. |
| Primary files | `packages/vinext/src/shims/dynamic.ts`, `tests/dynamic.test.ts`, `tests/shims.test.ts` |
| Expected impact | Loading components that return `null` before `pastDelay` no longer show incorrect SSR placeholder UI for `ssr:false`. |

## Why

The noSSR server placeholder is an initial loading state, not a delayed loading state. Next.js renders that path with `pastDelay={false}`, so components that intentionally suppress UI until the delay has elapsed should render nothing during SSR.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| `next/dynamic` parity | `ssr:false` server rendering should match Next.js noSSR props. | The server-only `DynamicSSRFalse` placeholder overrides `pastDelay` to `false`. |
| Fallback scope | Other fallback surfaces should not inherit noSSR-specific behavior. | SSR-enabled and client Suspense fallbacks keep the shared default loading props. |
| Regression coverage | Tests should verify behavior, not just implementation shape. | Adds a loading component that returns `null` until `pastDelay` is true. |

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| `dynamic(loader, { ssr: false, loading })` during SSR | Loading props included `pastDelay: true`. | Loading props include `pastDelay: false`, matching Next.js `noSSR()`. |
| Loading components using `!pastDelay` to suppress initial UI | Rendered their delayed loading UI during SSR. | Render nothing until the delayed state is actually reached. |

## PR shape

This should be one PR. The runtime change is one scoped parity fix and the test changes describe the same observable contract. Splitting would separate the regression proof from the behavior it protects without reducing review risk.

<details>
<summary>Maintainer review path</summary>

1. `packages/vinext/src/shims/dynamic.ts` verifies the change is scoped to the `!ssr && isServer` branch.
2. `tests/dynamic.test.ts` verifies the exact noSSR prop contract and observable delayed-loading behavior.
3. `tests/shims.test.ts` keeps the broader shim regression slice aligned with the new contract.

</details>

<details>
<summary>Validation</summary>

- `vp test run tests/dynamic.test.ts -t "noSSR loading props"` failed before the fix with received `pastDelay: true` and expected `false`.
- `vp test run tests/dynamic.test.ts`
- `vp test run tests/shims.test.ts -t "next/dynamic shim"`
- `vp test run tests/dynamic.test.ts tests/shims.test.ts`
- `vp check packages/vinext/src/shims/dynamic.ts tests/dynamic.test.ts tests/shims.test.ts`
- Commit hook ran format, lint, type checks, and `knip` successfully.

</details>

<details>
<summary>Risk / compatibility</summary>

- Public API: no type or signature changes.
- Runtime scope: only the server placeholder for `ssr:false` dynamic components changes.
- Compatibility: aligns with Next.js Pages Router `noSSR()` behavior.
- Non-goal: this does not change App Router lazy dynamic Suspense fallback behavior, where Next.js passes `pastDelay: true` to the fallback component.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| [Next.js `noSSR()` passes `pastDelay={false}`](https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/dynamic.tsx#L53-L70) | Authoritative behavior for the Pages Router noSSR server placeholder. |
| [Next.js loadable runtime initializes `pastDelay: false`](https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/loadable.shared-runtime.tsx#L184-L203) | Confirms delayed loading starts false and flips only after the configured delay. |
| [Next.js lazy dynamic fallback uses `pastDelay={true}`](https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/lazy-dynamic/loadable.tsx#L46-L49) | Confirms this PR should not globally change every loading fallback path. |
