### PR TITLE
fix(app-router): preserve omitted redirect type context

### DIFF
--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -302,7 +302,7 @@ function getActionRedirect(error: unknown): AppServerActionRedirect | null {
 
   return {
     status: redirect.status,
-    type: redirect.type,
+    type: redirect.type ?? "push",
     url: redirect.url,
   };
 }

--- a/packages/vinext/src/server/next-error-digest.ts
+++ b/packages/vinext/src/server/next-error-digest.ts
@@ -15,7 +15,7 @@
 
 type NextRedirectDigest = {
   status: number;
-  type: string;
+  type: string | null;
   url: string;
 };
 
@@ -39,7 +39,8 @@ export function getNextErrorDigest(error: unknown): string | null {
  * Parses a `NEXT_REDIRECT;<type>;<encodedUrl>;<status>` digest. Returns null
  * when the digest is not a redirect digest or the encoded URL segment is
  * missing. The `url` is decoded with `decodeURIComponent`; the `status`
- * defaults to 307 when omitted; the `type` defaults to "push".
+ * defaults to 307 when omitted; an omitted `type` is left as null so the
+ * caller can apply the correct context-sensitive default.
  */
 export function parseNextRedirectDigest(digest: string): NextRedirectDigest | null {
   if (!digest.startsWith("NEXT_REDIRECT;")) {
@@ -52,9 +53,11 @@ export function parseNextRedirectDigest(digest: string): NextRedirectDigest | nu
     return null;
   }
 
+  const type = parts[1];
+
   return {
     status: parts[3] ? parseInt(parts[3], 10) : 307,
-    type: parts[1] || "push",
+    type: type || null,
     url: decodeURIComponent(encodedUrl),
   };
 }

--- a/tests/next-error-digest.test.ts
+++ b/tests/next-error-digest.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vite-plus/test";
+import { parseNextRedirectDigest } from "../packages/vinext/src/server/next-error-digest.js";
+
+describe("next error digest parsing", () => {
+  // Mirrors Next.js redirect type semantics from:
+  // https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/redirect.ts
+  it("preserves an omitted redirect type so callers can apply context-sensitive defaults", () => {
+    expect(parseNextRedirectDigest("NEXT_REDIRECT;;%2Fdashboard;307")).toEqual({
+      status: 307,
+      type: null,
+      url: "/dashboard",
+    });
+  });
+
+  it("preserves explicit redirect types", () => {
+    expect(parseNextRedirectDigest("NEXT_REDIRECT;replace;%2Flogin;308")).toEqual({
+      status: 308,
+      type: "replace",
+      url: "/login",
+    });
+
+    expect(parseNextRedirectDigest("NEXT_REDIRECT;push;%2Fprofile;307")).toEqual({
+      status: 307,
+      type: "push",
+      url: "/profile",
+    });
+  });
+
+  it("preserves non-empty redirect type segments as raw digest data", () => {
+    expect(parseNextRedirectDigest("NEXT_REDIRECT;custom;%2Fprofile;307")).toEqual({
+      status: 307,
+      type: "custom",
+      url: "/profile",
+    });
+  });
+});


### PR DESCRIPTION
## Overview

| Field | Detail |
| --- | --- |
| Goal | Match Next.js redirect history behavior when `redirect()` omits `type` |
| Core change | Preserve the empty redirect type sentinel at digest parsing, then default it to `push` only in the Server Action path |
| Boundary | `parseNextRedirectDigest()` parses raw digest data; action handling applies the action-specific default |
| Primary files | `packages/vinext/src/server/next-error-digest.ts`, `packages/vinext/src/server/app-server-action-execution.ts`, `tests/next-error-digest.test.ts` |
| Expected impact | Non-action redirects no longer inherit the Server Action `push` default from the shared parser |

## Why

`redirect()` has a context-sensitive default: Server Actions default to `push`, while SSR and other server render contexts default to `replace`. Vinext already carries an empty type sentinel when `redirect()` omits the argument, but the shared parser resolved that sentinel to `push` before non-action callers could apply their own context.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| Digest parsing | Parse raw control-flow data without choosing caller policy | Empty type now parses as `null` instead of `push` |
| Server Actions | Server Action redirect defaults remain `push` | Action packaging resolves `null` to `push` locally |
| Compatibility | Preserve existing non-empty digest type data | Non-empty type segments still pass through unchanged |

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| `NEXT_REDIRECT;;/target;307` parsed by shared helper | `type: "push"` | `type: null` |
| Fetch Server Action redirect with omitted type | Header still sends `push` | Header still sends `push` |
| Non-empty explicit type segment | Preserved | Preserved |

<details>
<summary>Maintainer review path</summary>

1. `packages/vinext/src/server/next-error-digest.ts`: confirm the parser preserves omitted redirect type as `null` and keeps non-empty type segments raw.
2. `packages/vinext/src/server/app-server-action-execution.ts`: confirm Server Actions are the only place that applies the omitted-type `push` default.
3. `tests/next-error-digest.test.ts`: confirm the regression covers omitted, explicit, and non-empty raw type segments.

</details>

<details>
<summary>Validation</summary>

- `vp test run tests/next-error-digest.test.ts` failed before the fix with `type: "push"` for an omitted type sentinel.
- `vp test run tests/next-error-digest.test.ts tests/app-server-action-execution.test.ts tests/app-route-handler-policy.test.ts tests/app-page-execution.test.ts tests/app-route-handler-execution.test.ts tests/app-page-request.test.ts`
- `vp check packages/vinext/src/server/next-error-digest.ts packages/vinext/src/server/app-server-action-execution.ts tests/next-error-digest.test.ts`
- Commit hook also ran formatting, lint/type checks across 531 files, and knip.

</details>

<details>
<summary>Risk / compatibility</summary>

- Public API: no signature changes.
- Runtime: scoped to parsing `NEXT_REDIRECT` digests and packaging action redirect headers.
- Compatibility: preserves old behavior for non-empty type segments, including malformed custom values, except the intentional omitted-type fix.
- Non-goal: this does not implement full Next.js `actionAsyncStorage` inside the navigation shim. Vinext keeps the existing sentinel-based architecture and resolves context at catch sites.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| [Next.js `redirect()` default selection](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/redirect.ts#L38-L45) | Shows `push` for Server Actions and `replace` elsewhere |
| [Next.js action redirect handling](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/action-handler.ts#L1179-L1197) | Shows Server Actions consuming the redirect type from the redirect error |
| [Next.js client action redirect parsing](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts#L181-L193) | Shows action redirect type is interpreted as `push`, `replace`, or undefined |