### PR TITLE
fix: handle basePath hash-only page navigations

### DIFF
--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -18,7 +18,11 @@ import {
   createRscRequestUrl,
   VINEXT_RSC_MOUNTED_SLOTS_HEADER,
 } from "../server/app-rsc-cache-busting.js";
-import { toBrowserNavigationHref, toSameOriginAppPath } from "./url-utils.js";
+import {
+  isHashOnlyBrowserUrlChange,
+  toBrowserNavigationHref,
+  toSameOriginAppPath,
+} from "./url-utils.js";
 import { stripBasePath } from "../utils/base-path.js";
 import { ReadonlyURLSearchParams } from "./readonly-url-search-params.js";
 import { assertSafeNavigationUrl } from "./url-safety.js";
@@ -965,18 +969,7 @@ function isExternalUrl(href: string): boolean {
 function isHashOnlyChange(href: string): boolean {
   if (typeof window === "undefined") return false;
   if (href.startsWith("#")) return true;
-  try {
-    const current = new URL(window.location.href);
-    const next = new URL(href, window.location.href);
-    // Strip basePath for consistent same-origin comparison.
-    const strippedCurrentPath = stripBasePath(current.pathname, __basePath);
-    const strippedNextPath = stripBasePath(next.pathname, __basePath);
-    return (
-      strippedCurrentPath === strippedNextPath && current.search === next.search && next.hash !== ""
-    );
-  } catch {
-    return false;
-  }
+  return isHashOnlyBrowserUrlChange(href, window.location.href, __basePath);
 }
 
 /**

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -9,7 +9,11 @@ import { useState, useEffect, useCallback, useMemo, createElement, type ReactEle
 import { RouterContext } from "./internal/router-context.js";
 import type { VinextNextData } from "../client/vinext-next-data.js";
 import { isValidModulePath } from "../client/validate-module-path.js";
-import { toBrowserNavigationHref, toSameOriginAppPath } from "./url-utils.js";
+import {
+  isHashOnlyBrowserUrlChange,
+  toBrowserNavigationHref,
+  toSameOriginAppPath,
+} from "./url-utils.js";
 import { stripBasePath } from "../utils/base-path.js";
 import { addLocalePrefix, getDomainLocaleUrl, type DomainLocale } from "../utils/domain-locale.js";
 import {
@@ -189,13 +193,7 @@ function resolveHashUrl(url: string): string {
 export function isHashOnlyChange(href: string): boolean {
   if (href.startsWith("#")) return true;
   if (typeof window === "undefined") return false;
-  try {
-    const current = new URL(window.location.href);
-    const next = new URL(href, window.location.href);
-    return current.pathname === next.pathname && current.search === next.search && next.hash !== "";
-  } catch {
-    return false;
-  }
+  return isHashOnlyBrowserUrlChange(href, window.location.href, __basePath);
 }
 
 /** Scroll to hash target element, or top if no hash */
@@ -669,8 +667,8 @@ export function useRouter(): NextRouter {
       const full = toBrowserNavigationHref(resolved, window.location.href, __basePath);
 
       // Hash-only change — no page fetch needed
-      if (isHashOnlyChange(resolved)) {
-        const eventUrl = resolveHashUrl(resolved);
+      if (isHashOnlyChange(full)) {
+        const eventUrl = resolveHashUrl(full);
         routerEvents.emit("hashChangeStart", eventUrl, {
           shallow: options?.shallow ?? false,
         });
@@ -729,8 +727,8 @@ export function useRouter(): NextRouter {
       const full = toBrowserNavigationHref(resolved, window.location.href, __basePath);
 
       // Hash-only change — no page fetch needed
-      if (isHashOnlyChange(resolved)) {
-        const eventUrl = resolveHashUrl(resolved);
+      if (isHashOnlyChange(full)) {
+        const eventUrl = resolveHashUrl(full);
         routerEvents.emit("hashChangeStart", eventUrl, {
           shallow: options?.shallow ?? false,
         });
@@ -917,8 +915,8 @@ const Router = {
     const full = toBrowserNavigationHref(resolved, window.location.href, __basePath);
 
     // Hash-only change
-    if (isHashOnlyChange(resolved)) {
-      const eventUrl = resolveHashUrl(resolved);
+    if (isHashOnlyChange(full)) {
+      const eventUrl = resolveHashUrl(full);
       routerEvents.emit("hashChangeStart", eventUrl, {
         shallow: options?.shallow ?? false,
       });
@@ -970,8 +968,8 @@ const Router = {
     const full = toBrowserNavigationHref(resolved, window.location.href, __basePath);
 
     // Hash-only change
-    if (isHashOnlyChange(resolved)) {
-      const eventUrl = resolveHashUrl(resolved);
+    if (isHashOnlyChange(full)) {
+      const eventUrl = resolveHashUrl(full);
       routerEvents.emit("hashChangeStart", eventUrl, {
         shallow: options?.shallow ?? false,
       });

--- a/packages/vinext/src/shims/url-utils.ts
+++ b/packages/vinext/src/shims/url-utils.ts
@@ -115,3 +115,19 @@ export function toBrowserNavigationHref(href: string, currentUrl?: string, baseP
 
   return withBasePath(resolved, basePath);
 }
+
+export function isHashOnlyBrowserUrlChange(
+  href: string,
+  currentHref: string,
+  basePath = "",
+): boolean {
+  try {
+    const current = new URL(currentHref);
+    const next = new URL(href, currentHref);
+    const currentPathname = stripBasePath(current.pathname, basePath);
+    const nextPathname = stripBasePath(next.pathname, basePath);
+    return currentPathname === nextPathname && current.search === next.search && next.hash !== "";
+  } catch {
+    return false;
+  }
+}

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -9806,6 +9806,106 @@ describe("Pages Router concurrent navigation", () => {
     }
   });
 
+  async function expectBasePathHashOnlyPush({
+    browserPath,
+    target,
+    expectedBrowserUrl,
+    expectedEventUrl,
+  }: {
+    browserPath: string;
+    target: string;
+    expectedBrowserUrl: string;
+    expectedEventUrl: string;
+  }) {
+    const previousWindow = (globalThis as any).window;
+    const previousDocument = (globalThis as any).document;
+    const originalFetch = globalThis.fetch;
+    const previousBasePath = process.env.__NEXT_ROUTER_BASEPATH;
+    const { win } = createNavWindow();
+    win.location.pathname = browserPath;
+    win.location.href = `http://localhost${browserPath}`;
+    (globalThis as any).window = win;
+    (globalThis as any).document = {
+      getElementById: vi.fn(() => ({ scrollIntoView: vi.fn() })),
+    };
+    process.env.__NEXT_ROUTER_BASEPATH = "/app";
+    vi.resetModules();
+
+    const fetch = vi.fn(async () => {
+      throw new Error("hash-only navigations must not fetch page HTML");
+    });
+    globalThis.fetch = fetch;
+
+    const hashEvents: string[] = [];
+    const routeEvents: string[] = [];
+    const onHashChangeStart = (...args: unknown[]) => {
+      hashEvents.push(`start:${String(args[0])}`);
+    };
+    const onHashChangeComplete = (...args: unknown[]) => {
+      hashEvents.push(`complete:${String(args[0])}`);
+    };
+    const onRouteChangeStart = (...args: unknown[]) => {
+      routeEvents.push(`start:${String(args[0])}`);
+    };
+
+    try {
+      const routerModule = await import("../packages/vinext/src/shims/router.js");
+      const Router = routerModule.default;
+      Router.events.on("hashChangeStart", onHashChangeStart);
+      Router.events.on("hashChangeComplete", onHashChangeComplete);
+      Router.events.on("routeChangeStart", onRouteChangeStart);
+
+      const result = await Router.push(target);
+
+      expect(result).toBe(true);
+      expect(fetch).not.toHaveBeenCalled();
+      expect(win.history.pushState).toHaveBeenCalledWith({}, "", expectedBrowserUrl);
+      expect(hashEvents).toEqual([`start:${expectedEventUrl}`, `complete:${expectedEventUrl}`]);
+      expect(routeEvents).toEqual([]);
+    } finally {
+      const routerModule = await import("../packages/vinext/src/shims/router.js");
+      const Router = routerModule.default;
+      Router.events.off("hashChangeStart", onHashChangeStart);
+      Router.events.off("hashChangeComplete", onHashChangeComplete);
+      Router.events.off("routeChangeStart", onRouteChangeStart);
+      if (previousBasePath === undefined) {
+        delete process.env.__NEXT_ROUTER_BASEPATH;
+      } else {
+        process.env.__NEXT_ROUTER_BASEPATH = previousBasePath;
+      }
+      vi.resetModules();
+      if (previousWindow === undefined) {
+        delete (globalThis as any).window;
+      } else {
+        (globalThis as any).window = previousWindow;
+      }
+      if (previousDocument === undefined) {
+        delete (globalThis as any).document;
+      } else {
+        (globalThis as any).document = previousDocument;
+      }
+      globalThis.fetch = originalFetch;
+    }
+  }
+
+  it("treats app-relative hash navigations as hash-only when basePath is configured", async () => {
+    await expectBasePathHashOnlyPush({
+      browserPath: "/app/router-events-test",
+      target: "/router-events-test#section-1",
+      expectedBrowserUrl: "/app/router-events-test#section-1",
+      expectedEventUrl: "/router-events-test#section-1",
+    });
+  });
+
+  it("does not strip app-relative targets that start with the basePath segment", async () => {
+    await expectBasePathHashOnlyPush({
+      browserPath: "/app/app/foo",
+      target: "/app/foo#section-1",
+      expectedBrowserUrl: "/app/app/foo#section-1",
+      expectedEventUrl: "/app/foo#section-1",
+    });
+  });
+
   it("popstate known failures schedule a single hard navigation", async () => {
     const previousWindow = (globalThis as any).window;
     const originalFetch = globalThis.fetch;


### PR DESCRIPTION
## Summary

- Fix Pages Router hash-only navigation when `basePath` is configured by checking the fully resolved browser URL before deciding whether to fetch page HTML.
- Share the basePath-aware hash-only URL comparison with the App Router path so both shims use the same rule.
- Add regression coverage for normal basePath routes and routes whose app-relative path starts with the same segment as the basePath.

## Root Cause

Pages Router computed `full` with `toBrowserNavigationHref()`, but it still called `isHashOnlyChange()` with the app-relative `resolved` target. With `basePath: "/app"`, the browser URL is `/app/router-events-test` while the app-relative target is `/router-events-test#section-1`, so the old raw pathname comparison missed the same-page hash change and fell through to the HTML fetch path.

The fix mirrors the shape used by App Router: compare browser URLs after stripping the configured basePath once. Pages Router now passes the browser URL it is about to write into the hash-only check and derives hash event URLs from that same browser URL.

## Next.js Reference

- Next.js removes basePath before hash-only routing decisions: [`router.ts` cleaned `as`](https://github.com/vercel/next.js/blob/56d95137fd6d84f4bc1e5ef2bb31e0136d5fad9c/packages/next/src/shared/lib/router/router.ts#L1358-L1377)
- Next.js hash-only short-circuit: [`onlyAHashChange`](https://github.com/vercel/next.js/blob/56d95137fd6d84f4bc1e5ef2bb31e0136d5fad9c/packages/next/src/shared/lib/router/router.ts#L2301-L2321)
- Next.js basePath removal helper: [`remove-base-path.ts`](https://github.com/vercel/next.js/blob/56d95137fd6d84f4bc1e5ef2bb31e0136d5fad9c/packages/next/src/client/remove-base-path.ts#L5-L17)

## PR Scope

This should be one PR, not split: the production change, shared helper extraction, and focused regressions all cover one observable Pages Router client navigation contract. Splitting would leave either the bug fix or the shared App/Pages helper without its full safety net.

## Tests

- `vp test run tests/shims.test.ts -t "treats app-relative hash navigations as hash-only when basePath is configured"` (failed before the fix, passed after)
- `vp test run tests/shims.test.ts -t "basePath"`
- `vp test run tests/shims.test.ts tests/link-navigation.test.ts tests/link.test.ts tests/router-javascript-urls.test.ts`
- `vp check packages/vinext/src/shims/router.ts packages/vinext/src/shims/navigation.ts packages/vinext/src/shims/url-utils.ts tests/shims.test.ts`
