### PR TITLE
fix(headers): make draft mode status live

### DIFF
--- a/packages/vinext/src/shims/headers.ts
+++ b/packages/vinext/src/shims/headers.ts
@@ -791,7 +791,7 @@ export function isDraftModeRequest(request: Request): boolean {
 }
 
 type DraftModeResult = {
-  isEnabled: boolean;
+  readonly isEnabled: boolean;
   enable(): void;
   disable(): void;
 };
@@ -819,27 +819,27 @@ export async function draftMode(): Promise<DraftModeResult> {
   }
   markDynamicUsage();
   const secret = getDraftSecret();
-  const isEnabled = state.headersContext
-    ? state.headersContext.cookies.get(DRAFT_MODE_COOKIE) === secret
-    : false;
+  const headersContext = state.headersContext;
 
   return {
-    isEnabled,
+    get isEnabled(): boolean {
+      return headersContext ? headersContext.cookies.get(DRAFT_MODE_COOKIE) === secret : false;
+    },
     enable(): void {
-      if (state.headersContext?.accessError) {
-        throw state.headersContext.accessError;
+      if (headersContext?.accessError) {
+        throw headersContext.accessError;
       }
-      if (state.headersContext) {
-        state.headersContext.cookies.set(DRAFT_MODE_COOKIE, secret);
+      if (headersContext) {
+        headersContext.cookies.set(DRAFT_MODE_COOKIE, secret);
       }
       state.draftModeCookieHeader = `${DRAFT_MODE_COOKIE}=${secret}; ${draftModeCookieAttributes()}`;
     },
     disable(): void {
-      if (state.headersContext?.accessError) {
-        throw state.headersContext.accessError;
+      if (headersContext?.accessError) {
+        throw headersContext.accessError;
       }
-      if (state.headersContext) {
-        state.headersContext.cookies.delete(DRAFT_MODE_COOKIE);
+      if (headersContext) {
+        headersContext.cookies.delete(DRAFT_MODE_COOKIE);
       }
       state.draftModeCookieHeader = `${DRAFT_MODE_COOKIE}=; ${draftModeCookieAttributes()}; Expires=${DRAFT_MODE_EXPIRED_DATE}`;
     },

--- a/packages/vinext/src/shims/headers.ts
+++ b/packages/vinext/src/shims/headers.ts
@@ -819,27 +819,28 @@ export async function draftMode(): Promise<DraftModeResult> {
   }
   markDynamicUsage();
   const secret = getDraftSecret();
-  const headersContext = state.headersContext;
 
   return {
     get isEnabled(): boolean {
-      return headersContext ? headersContext.cookies.get(DRAFT_MODE_COOKIE) === secret : false;
+      return state.headersContext
+        ? state.headersContext.cookies.get(DRAFT_MODE_COOKIE) === secret
+        : false;
     },
     enable(): void {
-      if (headersContext?.accessError) {
-        throw headersContext.accessError;
+      if (state.headersContext?.accessError) {
+        throw state.headersContext.accessError;
       }
-      if (headersContext) {
-        headersContext.cookies.set(DRAFT_MODE_COOKIE, secret);
+      if (state.headersContext) {
+        state.headersContext.cookies.set(DRAFT_MODE_COOKIE, secret);
       }
       state.draftModeCookieHeader = `${DRAFT_MODE_COOKIE}=${secret}; ${draftModeCookieAttributes()}`;
     },
     disable(): void {
-      if (headersContext?.accessError) {
-        throw headersContext.accessError;
+      if (state.headersContext?.accessError) {
+        throw state.headersContext.accessError;
       }
-      if (headersContext) {
-        headersContext.cookies.delete(DRAFT_MODE_COOKIE);
+      if (state.headersContext) {
+        state.headersContext.cookies.delete(DRAFT_MODE_COOKIE);
       }
       state.draftModeCookieHeader = `${DRAFT_MODE_COOKIE}=; ${draftModeCookieAttributes()}; Expires=${DRAFT_MODE_EXPIRED_DATE}`;
     },

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -1188,7 +1188,10 @@ describe("next/headers shim", () => {
     expect(dm.isEnabled).toBe(false);
 
     dm.enable();
-    // After enabling, the cookie should be set on the context
+    // isEnabled should reflect the change on the same object (live getter)
+    // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/request/draft-mode.ts
+    expect(dm.isEnabled).toBe(true);
+    // A fresh draftMode() call should also see the change
     const dm2 = await draftMode();
     expect(dm2.isEnabled).toBe(true);
 
@@ -1201,26 +1204,6 @@ describe("next/headers shim", () => {
       /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
     );
     expect(cookieHeader).toContain("HttpOnly");
-    setHeadersContext(null);
-  });
-
-  it("draftMode().isEnabled reflects enable() on the same draft mode object", async () => {
-    const { setHeadersContext, draftMode } =
-      await import("../packages/vinext/src/shims/headers.js");
-
-    setHeadersContext({
-      headers: new Headers(),
-      cookies: new Map(),
-    });
-
-    const dm = await draftMode();
-    expect(dm.isEnabled).toBe(false);
-
-    dm.enable();
-    // Next.js exposes DraftMode.isEnabled as a live getter backed by DraftModeProvider.
-    // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/request/draft-mode.ts
-    expect(dm.isEnabled).toBe(true);
-
     setHeadersContext(null);
   });
 
@@ -1241,33 +1224,15 @@ describe("next/headers shim", () => {
     expect(dm1.isEnabled).toBe(true);
 
     dm1.disable();
+    // isEnabled should reflect the change on the same object (live getter)
+    expect(dm1.isEnabled).toBe(false);
+    // A fresh draftMode() call should also see the change
     const dm2 = await draftMode();
     expect(dm2.isEnabled).toBe(false);
 
     const cookieHeader = getDraftModeCookieHeader();
     expect(cookieHeader).toContain("Expires=Thu, 01 Jan 1970 00:00:00 GMT");
     expect(cookieHeader).not.toContain("Max-Age=0");
-    setHeadersContext(null);
-  });
-
-  it("draftMode().isEnabled reflects disable() on the same draft mode object", async () => {
-    const { setHeadersContext, draftMode, getDraftModeCookieHeader } =
-      await import("../packages/vinext/src/shims/headers.js");
-
-    setHeadersContext({
-      headers: new Headers(),
-      cookies: new Map(),
-    });
-
-    const dm = await draftMode();
-    dm.enable();
-    getDraftModeCookieHeader();
-
-    expect(dm.isEnabled).toBe(true);
-
-    dm.disable();
-    expect(dm.isEnabled).toBe(false);
-
     setHeadersContext(null);
   });
 

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -1204,6 +1204,26 @@ describe("next/headers shim", () => {
     setHeadersContext(null);
   });
 
+  it("draftMode().isEnabled reflects enable() on the same draft mode object", async () => {
+    const { setHeadersContext, draftMode } =
+      await import("../packages/vinext/src/shims/headers.js");
+
+    setHeadersContext({
+      headers: new Headers(),
+      cookies: new Map(),
+    });
+
+    const dm = await draftMode();
+    expect(dm.isEnabled).toBe(false);
+
+    dm.enable();
+    // Next.js exposes DraftMode.isEnabled as a live getter backed by DraftModeProvider.
+    // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/request/draft-mode.ts
+    expect(dm.isEnabled).toBe(true);
+
+    setHeadersContext(null);
+  });
+
   it("draftMode().disable() clears the bypass cookie", async () => {
     const { setHeadersContext, draftMode, getDraftModeCookieHeader } =
       await import("../packages/vinext/src/shims/headers.js");
@@ -1227,6 +1247,27 @@ describe("next/headers shim", () => {
     const cookieHeader = getDraftModeCookieHeader();
     expect(cookieHeader).toContain("Expires=Thu, 01 Jan 1970 00:00:00 GMT");
     expect(cookieHeader).not.toContain("Max-Age=0");
+    setHeadersContext(null);
+  });
+
+  it("draftMode().isEnabled reflects disable() on the same draft mode object", async () => {
+    const { setHeadersContext, draftMode, getDraftModeCookieHeader } =
+      await import("../packages/vinext/src/shims/headers.js");
+
+    setHeadersContext({
+      headers: new Headers(),
+      cookies: new Map(),
+    });
+
+    const dm = await draftMode();
+    dm.enable();
+    getDraftModeCookieHeader();
+
+    expect(dm.isEnabled).toBe(true);
+
+    dm.disable();
+    expect(dm.isEnabled).toBe(false);
+
     setHeadersContext(null);
   });
 


### PR DESCRIPTION
## Overview

| Field | Detail |
| --- | --- |
| Goal | Match Next.js `draftMode().isEnabled` liveness on the same returned draft mode object. |
| Core change | Replace the captured `isEnabled` boolean with a getter that reads the request draft cookie map. |
| Main boundary | Keeps existing vinext draft-mode cookie mutation and `Set-Cookie` accumulation paths intact. |
| Primary files | `packages/vinext/src/shims/headers.ts`, `tests/shims.test.ts` |
| PR shape | One PR. This is a single shim contract bug with focused regression coverage, not a cross-module runtime change. |

## Why

`draftMode()` returns a request API object. In Next.js, `isEnabled` is not a stale snapshot on that object: it is a getter over mutable draft-mode provider state, and `enable()` / `disable()` update that provider. vinext already mutated the request cookie map on enable/disable, but the original returned object held the initial boolean, so same-object reads diverged from Next.js.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| Draft mode API | The same `draftMode()` result should reflect draft state changes made through that object. | `isEnabled` is now a getter over the captured request cookie context. |
| Request state | Existing cookie mutation should remain the source of truth. | `enable()` and `disable()` still mutate the same request cookie map and pending `Set-Cookie` state. |
| Compatibility | Follow Next.js where the behavior is clear and cheap to match. | Adds regression tests for same-object `enable()` and `disable()` reads. |

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| `const draft = await draftMode(); draft.enable(); draft.isEnabled` | `false` because `isEnabled` captured the initial value. | `true` because the getter reads the mutated request cookie map. |
| `const draft = await draftMode(); draft.enable(); draft.disable(); draft.isEnabled` | Could remain stale on the original object. | Reflects `false` after `disable()`. |
| Existing round-trip draft mode behavior | Already covered by separate calls and HTTP compat tests. | Preserved. |

<details>
<summary>Maintainer review path</summary>

1. `packages/vinext/src/shims/headers.ts`
   - Review `DraftModeResult` and `draftMode()` around the getter and the existing `enable()` / `disable()` mutation path.
2. `tests/shims.test.ts`
   - Review the two added same-object liveness tests next to the existing draft mode tests.

</details>

<details>
<summary>Validation</summary>

- `vp test run tests/shims.test.ts -t "same draft mode object"`
- `vp test run tests/shims.test.ts`
- `vp test run tests/nextjs-compat/draft-mode.test.ts`
- `vp check packages/vinext/src/shims/headers.ts tests/shims.test.ts`
- Commit hook: formatting, lint/type checks, and `knip`

</details>

<details>
<summary>Risk / compatibility</summary>

- Public API: preserves the `draftMode()` shape while making `isEnabled` match Next.js liveness.
- Runtime: limited to the `next/headers` draft mode shim.
- Cookie behavior: no new cookie names, attributes, or response header paths.
- Existing-app risk: low. Code that reads `isEnabled` immediately after `enable()` or `disable()` now receives the updated state instead of a stale value.

</details>

<details>
<summary>Non-goals</summary>

- Does not change draft mode cookie generation or attributes.
- Does not expand draft mode support in pages router or middleware.
- Does not alter cache-scope or dynamic API error behavior.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| [`DraftMode.get isEnabled`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/request/draft-mode.ts) | Next.js exposes `isEnabled` as a getter that delegates to the draft mode provider. |
| [`DraftModeProvider.enable/disable`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/async-storage/draft-mode-provider.ts) | Next.js mutates provider state to `true` / `false` when draft mode is toggled. |
| [`test/e2e/app-dir/draft-mode`](https://github.com/vercel/next.js/tree/canary/test/e2e/app-dir/draft-mode) | Existing upstream coverage for draft mode route handler behavior. |
