### PR TITLE
fix(app-router): preserve config headers on middleware redirects

### DIFF
--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -43,6 +43,7 @@ import { buildPostMwRequestContext } from "./app-post-middleware-context.js";
 import {
   cloneRequestWithHeaders,
   filterInternalHeaders,
+  applyConfigHeadersToResponse,
   normalizeTrailingSlash,
   resolvePublicFileRoute,
   validateImageUrl,
@@ -217,6 +218,39 @@ async function applyRewrite(
   return rewritten;
 }
 
+function applyConfigHeadersToMiddlewareRedirect(
+  response: Response,
+  options: {
+    configHeaders: NextHeader[];
+    pathname: string;
+    requestContext: RequestContext;
+  },
+): Response {
+  // Non-redirect middleware responses still pass through finalization, where
+  // config headers are applied once. Redirects skip finalization to avoid
+  // mutating immutable redirect headers, so they need the earlier header layer here.
+  if (response.status < 300 || response.status >= 400) return response;
+  if (!options.configHeaders.length) return response;
+
+  const headers = new Headers();
+  applyConfigHeadersToResponse(headers, {
+    configHeaders: options.configHeaders,
+    pathname: options.pathname,
+    requestContext: options.requestContext,
+  });
+
+  if (!headers.entries().next().done) {
+    mergeMiddlewareResponseHeaders(headers, response.headers);
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    });
+  }
+
+  return response;
+}
+
 async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
   options: CreateAppRscHandlerOptions<TRoute>,
   request: Request,
@@ -296,7 +330,13 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
       module: options.middlewareModule,
       request,
     });
-    if (middlewareResult.kind === "response") return middlewareResult.response;
+    if (middlewareResult.kind === "response") {
+      return applyConfigHeadersToMiddlewareRedirect(middlewareResult.response, {
+        configHeaders: options.configHeaders,
+        pathname: cleanPathname,
+        requestContext: preMiddlewareRequestContext,
+      });
+    }
 
     cleanPathname = middlewareResult.cleanPathname;
     if (middlewareResult.search !== null) {

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -108,6 +108,81 @@ describe("createAppRscHandler", () => {
     expect(dispatchMatchedPage).not.toHaveBeenCalled();
   });
 
+  it("lets middleware redirect headers override earlier matching config headers", async () => {
+    // Next.js route order reference:
+    // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/router-utils/resolve-routes.ts
+    const dispatchMatchedPage = vi.fn(async () => new Response("page", { status: 200 }));
+    const handler = createHandler({
+      dispatchMatchedPage,
+      middlewareModule: {
+        default: () =>
+          new Response(null, {
+            status: 307,
+            headers: {
+              Location: "/login",
+              "x-test-header": "middleware",
+            },
+          }),
+      },
+    });
+
+    const response = await handler(new Request("https://example.test/docs/about"), null);
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe("/login");
+    expect(response.headers.get("x-test-header")).toBe("middleware");
+    expect(dispatchMatchedPage).not.toHaveBeenCalled();
+  });
+
+  it("carries config headers on middleware redirects when middleware does not override them", async () => {
+    // Next.js route order reference:
+    // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/router-utils/resolve-routes.ts
+    const dispatchMatchedPage = vi.fn(async () => new Response("page", { status: 200 }));
+    const handler = createHandler({
+      dispatchMatchedPage,
+      middlewareModule: {
+        default: () =>
+          new Response(null, {
+            status: 307,
+            headers: { Location: "/login" },
+          }),
+      },
+    });
+
+    const response = await handler(new Request("https://example.test/docs/about"), null);
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe("/login");
+    expect(response.headers.get("x-test-header")).toBe("applied");
+    expect(dispatchMatchedPage).not.toHaveBeenCalled();
+  });
+
+  it("does not duplicate additive config headers on non-redirect middleware responses", async () => {
+    const handler = createHandler({
+      configHeaders: [
+        {
+          source: "/about",
+          headers: [{ key: "Vary", value: "X-Config" }],
+        },
+      ],
+      middlewareModule: {
+        default: () =>
+          new Response("blocked", {
+            status: 401,
+            headers: { Vary: "User-Agent" },
+          }),
+      },
+    });
+
+    const response = await handler(new Request("https://example.test/docs/about"), null);
+    const varyTokens = (response.headers.get("vary") ?? "").split(",").map((token) => token.trim());
+
+    expect(response.status).toBe(401);
+    expect(varyTokens).toContain("User-Agent");
+    expect(varyTokens).toContain("X-Config");
+    expect(varyTokens.filter((token) => token === "X-Config")).toHaveLength(1);
+  });
+
   it("canonicalizes config redirect locations for RSC requests", async () => {
     const headers = createRscRequestHeaders({ mountedSlotsHeader: "slot:modal:/" });
     const expectedHash = await computeRscCacheBustingSearchParam(headers);


### PR DESCRIPTION
## Overview

| Area | Detail |
| --- | --- |
| Goal | Match Next.js header ordering for App Router middleware redirects. |
| Core change | Apply matching `next.config.js headers()` to middleware redirect responses before returning them from the App Router request path. |
| Boundary | Config redirects still skip config response headers. Non-redirect middleware responses still get config headers through normal finalization. |
| Primary files | `packages/vinext/src/server/app-rsc-handler.ts`, `tests/app-rsc-handler.test.ts` |
| Expected impact | Middleware redirects now carry config security/custom headers unless middleware overrides the same key. |

## Why

Next.js evaluates custom headers before redirects and middleware. App Router middleware redirects are therefore downstream of the header route and should retain matched config headers, while middleware response headers keep precedence for duplicate keys.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| Route ordering | `headers()` runs before middleware. | Middleware redirects receive the already-matched config header layer. |
| Precedence | Middleware/custom response headers win over earlier config headers. | The redirect response headers are merged over matched config headers. |
| Finalization | App Router redirects skip final response mutation. | Only middleware redirects get this early config-header application. |

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| Middleware redirect, config header matches | Config header was missing because redirect finalization is skipped. | Config header is present. |
| Middleware redirect sets same header | Middleware header still wins. | Middleware header still wins. |
| Non-redirect middleware response with additive config headers | Could have been duplicated if handled early and finalized again. | Covered by a regression test and left to normal finalization. |
| Config redirect | Config response headers are not applied. | Unchanged. |

<details>
<summary>Maintainer review path</summary>

1. `tests/app-rsc-handler.test.ts`  
   Review the three new behavior tests for the route-order contract, middleware precedence, and additive-header non-duplication.

2. `packages/vinext/src/server/app-rsc-handler.ts`  
   Review `applyConfigHeadersToMiddlewareRedirect()` and its call site in the middleware short-circuit branch.

</details>

<details>
<summary>Validation</summary>

Added failing coverage first:

- `vp test run tests/app-rsc-handler.test.ts` failed before the fix with `expected null to be "applied"` for a middleware redirect.

Ran after the fix and review feedback:

- `vp test run tests/app-rsc-handler.test.ts tests/app-rsc-response-finalizer.test.ts tests/request-pipeline.test.ts`
- `vp check packages/vinext/src/server/app-rsc-handler.ts tests/app-rsc-handler.test.ts`
- `vp test run tests/app-rsc-handler.test.ts tests/app-rsc-response-finalizer.test.ts tests/request-pipeline.test.ts tests/app-router.test.ts`
- `vp check`

The commit hook also ran formatting, lint/type checks, and knip successfully.

</details>

<details>
<summary>Risk / compatibility</summary>

- Public API impact: none.
- Runtime impact: App Router middleware redirects now include matched config headers, matching Next.js ordering.
- Precedence: middleware redirect headers are merged over config headers for duplicate keys.
- Duplicate additive headers: non-redirect middleware responses are not handled by the early redirect helper and continue through finalization once.
- Pages Router impact: none in this PR.

</details>

<details>
<summary>Non-goals</summary>

- This does not reorder the entire App Router request pipeline.
- This does not change config redirect behavior.
- This does not change Pages Router production/dev paths.

This should be one PR rather than split: the bug, observable contract, source change, and regression tests all sit on the App Router middleware redirect boundary. Splitting would separate the fix from the proof without reducing review risk.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| [Next.js resolve-routes order](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/router-utils/resolve-routes.ts#L85-L95) | Shows custom headers are evaluated before redirects and middleware. |
| [Next.js custom header application](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/router-utils/resolve-routes.ts#L829-L848) | Shows matched header routes populate the response header layer. |
| [Next.js middleware header merge](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/router-utils/resolve-routes.ts#L699-L724) | Shows middleware response headers are merged after config headers and can override them. |
| [Next.js middleware redirect return](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/router-utils/resolve-routes.ts#L753-L773) | Shows middleware redirects return the accumulated response header layer. |
| [Next.js custom routes header tests](https://github.com/vercel/next.js/blob/canary/test/e2e/custom-routes/custom-routes.test.ts#L1330-L1342) | Existing upstream coverage for config header matching conditions. |
