### PR TITLE
fix(app-router): error truncated progressive RSC streams

### DIFF
--- a/packages/vinext/src/server/app-browser-stream.ts
+++ b/packages/vinext/src/server/app-browser-stream.ts
@@ -21,6 +21,12 @@ export function getVinextBrowserGlobal(): typeof globalThis & VinextBrowserGloba
   return globalThis as typeof globalThis & VinextBrowserGlobals;
 }
 
+function createUnexpectedRscStreamCloseError(): Error {
+  return new Error(
+    "The connection to the page was unexpectedly closed, possibly due to the stop button being clicked, loss of Wi-Fi, or an unstable internet connection.",
+  );
+}
+
 /**
  * Convert embedded text chunks back to a ReadableStream of Uint8Array chunks.
  */
@@ -61,10 +67,24 @@ export function createProgressiveRscStream(): ReadableStream<Uint8Array> {
       }
 
       let closed = false;
+      let cancelDocumentCompletionCheck: (() => void) | undefined;
+      const cancelPendingDocumentCompletionCheck = () => {
+        const cancel = cancelDocumentCompletionCheck;
+        cancelDocumentCompletionCheck = undefined;
+        cancel?.();
+      };
       const closeOnce = () => {
         if (!closed) {
           closed = true;
+          cancelPendingDocumentCompletionCheck();
           controller.close();
+        }
+      };
+      const errorOnce = () => {
+        if (!closed) {
+          closed = true;
+          cancelPendingDocumentCompletionCheck();
+          controller.error(createUnexpectedRscStreamCloseError());
         }
       };
 
@@ -87,9 +107,12 @@ export function createProgressiveRscStream(): ReadableStream<Uint8Array> {
 
       if (typeof document !== "undefined") {
         if (document.readyState === "loading") {
-          document.addEventListener("DOMContentLoaded", closeOnce);
+          document.addEventListener("DOMContentLoaded", errorOnce);
+          cancelDocumentCompletionCheck = () =>
+            document.removeEventListener("DOMContentLoaded", errorOnce);
         } else {
-          closeOnce();
+          const timeoutId = setTimeout(errorOnce);
+          cancelDocumentCompletionCheck = () => clearTimeout(timeoutId);
         }
       }
     },

--- a/tests/app-browser-stream.test.ts
+++ b/tests/app-browser-stream.test.ts
@@ -47,6 +47,7 @@ describe("App browser stream helpers", () => {
   afterEach(() => {
     resetBrowserGlobals();
     setGlobalDocument(originalDocument);
+    vi.useRealTimers();
   });
 
   it("turns embedded chunks into a readable byte stream", async () => {
@@ -64,6 +65,7 @@ describe("App browser stream helpers", () => {
       addEventListener: vi.fn((event: string, callback: EventListenerOrEventListenerObject) => {
         listeners.set(event, callback as () => void);
       }),
+      removeEventListener: vi.fn(),
     } as unknown as Document);
 
     vinext.__VINEXT_RSC_CHUNKS__ = ["shell"];
@@ -88,6 +90,7 @@ describe("App browser stream helpers", () => {
     setGlobalDocument({
       readyState: "loading",
       addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
     } as unknown as Document);
 
     vinext.__VINEXT_RSC_CHUNKS__ = [];
@@ -105,7 +108,7 @@ describe("App browser stream helpers", () => {
     expect(await readText(reader)).toEqual({ done: true, text: undefined });
   });
 
-  it("closes truncated streams on DOMContentLoaded", async () => {
+  it("errors truncated streams on DOMContentLoaded before the done marker", async () => {
     let onDomContentLoaded: (() => void) | undefined;
     setGlobalDocument({
       readyState: "loading",
@@ -114,6 +117,7 @@ describe("App browser stream helpers", () => {
           onDomContentLoaded = callback as () => void;
         }
       }),
+      removeEventListener: vi.fn(),
     } as unknown as Document);
 
     vinext.__VINEXT_RSC_CHUNKS__ = [];
@@ -125,6 +129,28 @@ describe("App browser stream helpers", () => {
     expect(onDomContentLoaded).toBeTypeOf("function");
     onDomContentLoaded!();
 
-    expect(await pendingRead).toEqual({ done: true, text: undefined });
+    await expect(pendingRead).rejects.toThrow("The connection to the page was unexpectedly closed");
+  });
+
+  it("defers already-loaded document errors so the done marker can close cleanly", async () => {
+    vi.useFakeTimers();
+    setGlobalDocument({
+      readyState: "complete",
+    } as unknown as Document);
+
+    vinext.__VINEXT_RSC_CHUNKS__ = [];
+    vinext.__VINEXT_RSC_DONE__ = false;
+
+    const reader = createProgressiveRscStream().getReader();
+    const pendingRead = readText(reader);
+
+    vinext.__VINEXT_RSC_DONE__ = true;
+    vinext.__VINEXT_RSC_CHUNKS__!.push("final");
+
+    expect(await pendingRead).toEqual({ done: false, text: "final" });
+    expect(await readText(reader)).toEqual({ done: true, text: undefined });
+
+    vi.runAllTimers();
+    expect(await readText(reader)).toEqual({ done: true, text: undefined });
   });
 });


### PR DESCRIPTION
## Summary

- error the browser-side progressive RSC stream when document loading finishes before vinext emits `__VINEXT_RSC_DONE__`
- keep clean completion tied to the explicit done marker, including the late-bootstrap case where the document is already loaded but the done marker arrives in the next macrotask
- clean up the pending document-completion listener/timer once the stream reaches a terminal state

## Root Cause

`createProgressiveRscStream()` treated `DOMContentLoaded` without `__VINEXT_RSC_DONE__` as a clean stream close. That makes an interrupted or truncated inline Flight payload indistinguishable from a valid completed payload, so React sees EOF instead of a useful stream error.

Next.js handles this class of initial Flight failure by checking stream controller state and surfacing a clear unexpected-connection-closed error instead of silently completing the stream:

- [Next.js `isStreamErrorOrUnfinished` and error path](https://github.com/vercel/next.js/blob/56d95137/packages/next/src/client/app-index.tsx#L112-L147)
- [Next.js already-loaded document macrotask deferral](https://github.com/vercel/next.js/blob/56d95137/packages/next/src/client/app-index.tsx#L166-L171)

## PR Shape

This should be one PR, not split: the production change and tests are one observable behavior at a single runtime boundary. Splitting would leave either an untested behavior change or a failing test-only PR.

## Tests

- `vp test run tests/app-browser-stream.test.ts` red before the fix: truncated stream resolved as clean EOF
- `vp test run tests/app-browser-stream.test.ts tests/app-ssr-stream.test.ts tests/rsc-streaming.test.ts`
- `vp check packages/vinext/src/server/app-browser-stream.ts tests/app-browser-stream.test.ts`
- `vp check`

## Review

After the first green implementation, I ran separate review/simplifier passes. The valid feedback was to clean up the pending `DOMContentLoaded` listener/timer after terminal stream state and to match Next.js' macrotask deferral for already-loaded documents; both are included here.
