### PR TITLE
fix(link): keep auto prefetch from fetching dynamic app routes

### DIFF
--- a/packages/vinext/src/client/vinext-next-data.ts
+++ b/packages/vinext/src/client/vinext-next-data.ts
@@ -7,6 +7,11 @@
  */
 import type { NEXT_DATA } from "vinext/shims/internal/utils";
 
+export type VinextLinkPrefetchRoute = {
+  patternParts: string[];
+  isDynamic: boolean;
+};
+
 export type VinextNextData = {
   /** vinext-specific additions (not part of Next.js upstream). */
   __vinext?: {

--- a/packages/vinext/src/entries/app-browser-entry.ts
+++ b/packages/vinext/src/entries/app-browser-entry.ts
@@ -1,4 +1,6 @@
 import { resolveRuntimeEntryModule } from "./runtime-entry-module.js";
+import type { VinextLinkPrefetchRoute } from "../client/vinext-next-data.js";
+import type { AppRoute } from "../routing/app-router.js";
 
 /**
  * Generate the virtual browser entry module.
@@ -7,7 +9,20 @@ import { resolveRuntimeEntryModule } from "./runtime-entry-module.js";
  * embedded RSC payload and handles client-side navigation by re-fetching
  * RSC streams.
  */
-export function generateBrowserEntry(): string {
+export function generateBrowserEntry(routes: readonly AppRoute[] = []): string {
   const entryPath = resolveRuntimeEntryModule("app-browser-entry");
-  return `import ${JSON.stringify(entryPath)};`;
+  const prefetchRoutes: VinextLinkPrefetchRoute[] = routes
+    .filter((route) => isLinkPrefetchRoute(route))
+    .map((route) => ({
+      patternParts: [...route.patternParts],
+      isDynamic: route.isDynamic,
+    }));
+
+  return `window.__VINEXT_LINK_PREFETCH_ROUTES__ = ${JSON.stringify(prefetchRoutes)};
+import ${JSON.stringify(entryPath)};`;
+}
+
+function isLinkPrefetchRoute(route: AppRoute): boolean {
+  if (route.pagePath !== null) return true;
+  return route.routePath === null && route.layouts.length > 0;
 }

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -1785,7 +1785,8 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           return generateSsrEntry(hasPagesDir);
         }
         if (id === RESOLVED_APP_BROWSER_ENTRY && hasAppDir) {
-          return generateBrowserEntry();
+          const routes = await appRouter(appDir, nextConfig?.pageExtensions, fileMatcher);
+          return generateBrowserEntry(routes);
         }
         if (id.startsWith(RESOLVED_VIRTUAL_GOOGLE_FONTS + "?")) {
           return generateGoogleFontsVirtualModule(id, _fontGoogleShimPath);

--- a/packages/vinext/src/shims/link-prefetch.ts
+++ b/packages/vinext/src/shims/link-prefetch.ts
@@ -14,7 +14,7 @@ export type LinkPrefetchDecision =
 
 export function canLinkPrefetch(input: {
   nodeEnv: string | undefined;
-  prefetch: boolean | null | undefined;
+  prefetch: boolean | "auto" | null | undefined;
   isDangerous: boolean;
 }): boolean {
   return input.nodeEnv === "production" && input.prefetch !== false && !input.isDangerous;
@@ -22,7 +22,7 @@ export function canLinkPrefetch(input: {
 
 export function getLinkPrefetchDecision(input: {
   nodeEnv: string | undefined;
-  prefetch: boolean | null | undefined;
+  prefetch: boolean | "auto" | null | undefined;
   isDangerous: boolean;
   intent: LinkPrefetchIntent;
 }): LinkPrefetchDecision {

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -42,7 +42,9 @@ import {
 import { appendSearchParamsToUrl, type UrlQuery, urlQueryToSearchParams } from "../utils/query.js";
 import { addLocalePrefix, getDomainLocaleUrl, type DomainLocale } from "../utils/domain-locale.js";
 import { getI18nContext } from "./i18n-context.js";
-import type { VinextNextData } from "../client/vinext-next-data.js";
+import type { VinextLinkPrefetchRoute, VinextNextData } from "../client/vinext-next-data.js";
+import { createRouteTrieCache, matchRouteWithTrie } from "../routing/route-matching.js";
+import { stripBasePath } from "../utils/base-path.js";
 
 type NavigateEvent = {
   url: URL;
@@ -58,8 +60,8 @@ type LinkProps = {
   as?: string;
   /** Replace the current history entry instead of pushing */
   replace?: boolean;
-  /** Prefetch the page in the background (default: true, uses IntersectionObserver) */
-  prefetch?: boolean;
+  /** Prefetch the page in the background (App Router default: auto, Pages Router default: true) */
+  prefetch?: boolean | "auto" | null;
   /** Whether to pass the href to the child element */
   passHref?: boolean;
   /** Scroll to top on navigation (default: true) */
@@ -70,6 +72,17 @@ type LinkProps = {
   onNavigate?: (event: NavigateEvent) => void;
   children?: React.ReactNode;
 } & Omit<AnchorHTMLAttributes<HTMLAnchorElement>, "href">;
+
+type LinkPrefetchMode = "disabled" | "auto" | "full";
+
+declare global {
+  // Window is an ambient interface from lib.dom; interface merging is required
+  // for this global browser hook.
+  // oxlint-disable-next-line typescript-eslint/consistent-type-definitions
+  interface Window {
+    __VINEXT_LINK_PREFETCH_ROUTES__?: VinextLinkPrefetchRoute[];
+  }
+}
 
 // ---------------------------------------------------------------------------
 // useLinkStatus — reports the pending state of a parent <Link> navigation
@@ -92,6 +105,7 @@ export function useLinkStatus(): LinkStatusContextValue {
 
 /** basePath from next.config.js, injected by the plugin at build time */
 const __basePath: string = process.env.__NEXT_ROUTER_BASEPATH ?? "";
+const linkPrefetchRouteTrieCache = createRouteTrieCache<VinextLinkPrefetchRoute>();
 
 function resolveHref(href: LinkProps["href"]): string {
   if (typeof href === "string") return href;
@@ -101,6 +115,45 @@ function resolveHref(href: LinkProps["href"]): string {
     url = appendSearchParamsToUrl(url, params);
   }
   return url;
+}
+
+export function resolveLinkPrefetchMode(
+  prefetchProp: LinkProps["prefetch"],
+  isDangerous: boolean,
+): LinkPrefetchMode {
+  if (isDangerous || prefetchProp === false) return "disabled";
+  if (prefetchProp === true) return "full";
+  return "auto";
+}
+
+function toSameOriginRouteHref(href: string): string | null {
+  if (typeof window === "undefined") return null;
+
+  let url: URL;
+  try {
+    url = new URL(href, window.location.href);
+  } catch {
+    return null;
+  }
+
+  if (url.origin !== window.location.origin) return null;
+
+  return `${stripBasePath(url.pathname, __basePath)}${url.search}`;
+}
+
+export function canAutoPrefetchFullAppRoute(href: string): boolean {
+  if (typeof window === "undefined") return false;
+
+  const routes = window.__VINEXT_LINK_PREFETCH_ROUTES__;
+  if (!routes) return false;
+
+  const routeHref = toSameOriginRouteHref(href);
+  if (routeHref === null) return false;
+
+  const match = matchRouteWithTrie(routeHref, routes, linkPrefetchRouteTrieCache);
+  if (!match) return false;
+
+  return !match.route.isDynamic;
 }
 
 // ---------------------------------------------------------------------------
@@ -117,7 +170,7 @@ function resolveHref(href: LinkProps["href"]): string {
  * Uses `requestIdleCallback` (or `setTimeout` fallback) to avoid blocking
  * the main thread during initial page load.
  */
-function prefetchUrl(href: string, priority: "low" | "high" = "low"): void {
+function prefetchUrl(href: string, mode: LinkPrefetchMode, priority: "low" | "high" = "low"): void {
   if (typeof window === "undefined") return;
 
   const prefetchHref = getLinkPrefetchHref({
@@ -134,6 +187,13 @@ function prefetchUrl(href: string, priority: "low" | "high" = "low"): void {
   schedule(() => {
     void (async () => {
       if (typeof window.__VINEXT_RSC_NAVIGATE__ === "function") {
+        // `auto`/`null`/undefined should not behave like `prefetch={true}` for
+        // App Router dynamic routes. Next.js may prefetch a loading-boundary
+        // shell for dynamic routes, but vinext's current client cache stores
+        // complete RSC responses only; keep automatic full prefetch to route
+        // shapes that are statically known safe until segment prefetch exists.
+        if (mode === "auto" && !canAutoPrefetchFullAppRoute(prefetchHref)) return;
+
         const interceptionContext = getCurrentInterceptionContext();
         const mountedSlotsHeader = getMountedSlotsHeader();
         const headers = createRscRequestHeaders({ interceptionContext });
@@ -313,8 +373,10 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
   }, []);
 
   // Prefetching: observe the element when it enters the viewport.
-  // prefetch={false} disables, prefetch={true} or undefined/null (default) enables.
+  // In App Router, null/undefined/"auto" is automatic prefetch and true opts
+  // into a full RSC prefetch, matching Next.js's public prefetch contract.
   const internalRef = useRef<HTMLAnchorElement | null>(null);
+  const prefetchMode = resolveLinkPrefetchMode(prefetchProp, isDangerous);
   const shouldPrefetch = canLinkPrefetch({
     nodeEnv: process.env.NODE_ENV,
     prefetch: prefetchProp,
@@ -346,19 +408,19 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
     const observer = getSharedObserver();
     if (!observer) return;
 
-    observerCallbacks.set(node, () => prefetchUrl(hrefToPrefetch, "low"));
+    observerCallbacks.set(node, () => prefetchUrl(hrefToPrefetch, prefetchMode, "low"));
     observer.observe(node);
 
     return () => {
       observer.unobserve(node);
       observerCallbacks.delete(node);
     };
-  }, [shouldPrefetch, localizedHref]);
+  }, [shouldPrefetch, prefetchMode, localizedHref]);
 
   const prefetchOnIntent = useCallback(() => {
     if (!shouldPrefetch) return;
-    prefetchUrl(localizedHref, "high");
-  }, [shouldPrefetch, localizedHref]);
+    prefetchUrl(localizedHref, prefetchMode, "high");
+  }, [shouldPrefetch, prefetchMode, localizedHref]);
 
   const handleMouseEnter = useCallback(
     (e: MouseEvent<HTMLAnchorElement>) => {

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -8,6 +8,7 @@ import path from "node:path";
 import fs from "node:fs";
 import os from "node:os";
 import { describe, it, expect } from "vite-plus/test";
+import { generateBrowserEntry } from "../packages/vinext/src/entries/app-browser-entry.js";
 import { buildAppRscManifestCode } from "../packages/vinext/src/entries/app-rsc-manifest.js";
 import { generateRscEntry } from "../packages/vinext/src/entries/app-rsc-entry.js";
 import { buildAppRouteGraph } from "../packages/vinext/src/routing/app-route-graph.js";
@@ -115,6 +116,64 @@ const minimalAppRoutes: AppRoute[] = [
 // ── App Router manifest construction ─────────────────────────────────
 
 describe("App Router generated manifest construction", () => {
+  it("embeds the Link auto-prefetch route manifest in the browser entry", () => {
+    const code = generateBrowserEntry([
+      ...minimalAppRoutes,
+      {
+        pattern: "/modal-host",
+        patternParts: ["modal-host"],
+        pagePath: null,
+        routePath: null,
+        layouts: ["/tmp/test/app/layout.tsx", "/tmp/test/app/modal-host/layout.tsx"],
+        templates: [],
+        parallelSlots: [],
+        loadingPath: null,
+        errorPath: null,
+        layoutErrorPaths: [null, null],
+        notFoundPath: null,
+        notFoundPaths: [null, null],
+        forbiddenPaths: [null, null],
+        forbiddenPath: null,
+        unauthorizedPaths: [null, null],
+        unauthorizedPath: null,
+        routeSegments: ["modal-host"],
+        templateTreePositions: [],
+        layoutTreePositions: [0, 1],
+        isDynamic: false,
+        params: [],
+      },
+      {
+        pattern: "/api",
+        patternParts: ["api"],
+        pagePath: null,
+        routePath: "/tmp/test/app/api/route.ts",
+        layouts: [],
+        templates: [],
+        parallelSlots: [],
+        loadingPath: null,
+        errorPath: null,
+        layoutErrorPaths: [],
+        notFoundPath: null,
+        notFoundPaths: [],
+        forbiddenPaths: [],
+        forbiddenPath: null,
+        unauthorizedPaths: [],
+        unauthorizedPath: null,
+        routeSegments: ["api"],
+        templateTreePositions: [],
+        layoutTreePositions: [],
+        isDynamic: false,
+        params: [],
+      },
+    ]);
+
+    expect(code).toContain("window.__VINEXT_LINK_PREFETCH_ROUTES__ = ");
+    expect(code).toContain('{"patternParts":["about"],"isDynamic":false}');
+    expect(code).toContain('{"patternParts":["blog",":slug"],"isDynamic":true}');
+    expect(code).toContain('{"patternParts":["modal-host"],"isDynamic":false}');
+    expect(code).not.toContain('{"patternParts":["api"],"isDynamic":false}');
+  });
+
   it("constructs route module imports and route entries from the scanned app shape", () => {
     const routes = [
       {

--- a/tests/fixtures/app-basic/app/feed/page.tsx
+++ b/tests/fixtures/app-basic/app/feed/page.tsx
@@ -17,7 +17,7 @@ export default async function FeedPage() {
           <Link href="/photos/3">Photo 3</Link>
         </li>
         <li>
-          <Link href="/photos/42" id="feed-photo-42-link">
+          <Link href="/photos/42" id="feed-photo-42-link" prefetch={true}>
             Photo 42
           </Link>
         </li>

--- a/tests/fixtures/app-basic/app/gallery/page.tsx
+++ b/tests/fixtures/app-basic/app/gallery/page.tsx
@@ -6,7 +6,7 @@ export default function GalleryPage() {
       <h1>Photo Gallery</h1>
       <ul>
         <li>
-          <Link href="/photos/42" id="gallery-photo-42-link">
+          <Link href="/photos/42" id="gallery-photo-42-link" prefetch={true}>
             Photo 42
           </Link>
         </li>

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -7,6 +7,7 @@ import {
   type LinkPrefetchIntent,
   type LinkPrefetchDecision,
 } from "../packages/vinext/src/shims/link-prefetch.js";
+import type { VinextLinkPrefetchRoute } from "../packages/vinext/src/client/vinext-next-data.js";
 
 type CapturedEffect = () => void | (() => void);
 
@@ -29,6 +30,14 @@ type CapturedAnchorProps = {
   onTouchStart?: (event: CapturedIntentEvent) => void;
   ref?: (node: HTMLAnchorElement | null) => void;
 };
+
+const linkPrefetchRoutes = [
+  { patternParts: ["viewport-prefetch-target"], isDynamic: false },
+  { patternParts: ["intent-prefetch-target"], isDynamic: false },
+  { patternParts: ["touch-prefetch-target"], isDynamic: false },
+  { patternParts: ["same-origin-intent-prefetch-target"], isDynamic: false },
+  { patternParts: ["blog", ":slug"], isDynamic: true },
+] satisfies VinextLinkPrefetchRoute[];
 
 type MockReactAnchorCaptureOptions = {
   captureAnchor(type: unknown, props: unknown): void;
@@ -390,6 +399,7 @@ async function renderIsolatedLink(options: {
       replaceState: vi.fn(),
     },
     location,
+    __VINEXT_LINK_PREFETCH_ROUTES__: linkPrefetchRoutes,
     requestIdleCallback: vi.fn((callback: () => void) => {
       callback();
       return 1;
@@ -434,7 +444,7 @@ async function renderIsolatedLink(options: {
 }
 
 describe("Link App Router prefetch scheduling", () => {
-  it("prefetches visible links in production with low priority", async () => {
+  function stubIntersectionObserver() {
     let intersectionCallback: IntersectionObserverCallback | undefined;
     const observe = vi.fn();
     const unobserve = vi.fn();
@@ -454,44 +464,102 @@ describe("Link App Router prefetch scheduling", () => {
     }
     vi.stubGlobal("IntersectionObserver", FakeIntersectionObserver);
 
+    return {
+      observe,
+      unobserve,
+      dispatchIntersectingEntry(anchor: HTMLAnchorElement) {
+        const rect = {
+          bottom: 0,
+          height: 0,
+          left: 0,
+          right: 0,
+          top: 0,
+          width: 0,
+          x: 0,
+          y: 0,
+          toJSON: () => ({}),
+        };
+        intersectionCallback?.(
+          [
+            {
+              boundingClientRect: rect,
+              intersectionRatio: 1,
+              intersectionRect: rect,
+              isIntersecting: true,
+              rootBounds: null,
+              target: anchor,
+              time: 0,
+            },
+          ],
+          {} as IntersectionObserver,
+        );
+      },
+    };
+  }
+
+  it("prefetches visible links in production with low priority", async () => {
+    const observer = stubIntersectionObserver();
+
     const result = await renderIsolatedLink({
       href: "/viewport-prefetch-target",
       nodeEnv: "production",
     });
 
     try {
-      expect(observe).toHaveBeenCalledWith(result.anchor);
-      expect(intersectionCallback).toBeTypeOf("function");
-      const rect = {
-        bottom: 0,
-        height: 0,
-        left: 0,
-        right: 0,
-        top: 0,
-        width: 0,
-        x: 0,
-        y: 0,
-        toJSON: () => ({}),
-      };
-      intersectionCallback?.(
-        [
-          {
-            boundingClientRect: rect,
-            intersectionRatio: 1,
-            intersectionRect: rect,
-            isIntersecting: true,
-            rootBounds: null,
-            target: result.anchor,
-            time: 0,
-          },
-        ],
-        {} as IntersectionObserver,
-      );
+      expect(observer.observe).toHaveBeenCalledWith(result.anchor);
+      observer.dispatchIntersectingEntry(result.anchor);
       await flushPrefetchTasks();
 
-      expect(unobserve).toHaveBeenCalledWith(result.anchor);
+      expect(observer.unobserve).toHaveBeenCalledWith(result.anchor);
       expect(result.fetch).toHaveBeenCalledWith(
         expect.stringContaining("/viewport-prefetch-target.rsc"),
+        expect.objectContaining({
+          credentials: "include",
+          priority: "low",
+        }),
+      );
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
+  it("does not full-prefetch visible dynamic links in automatic production mode", async () => {
+    const observer = stubIntersectionObserver();
+
+    const result = await renderIsolatedLink({
+      href: "/blog/hello",
+      nodeEnv: "production",
+    });
+
+    try {
+      expect(observer.observe).toHaveBeenCalledWith(result.anchor);
+      observer.dispatchIntersectingEntry(result.anchor);
+      await flushPrefetchTasks();
+
+      expect(observer.unobserve).toHaveBeenCalledWith(result.anchor);
+      expect(result.fetch).not.toHaveBeenCalled();
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
+  it("full-prefetches visible dynamic links when prefetch is explicitly true", async () => {
+    const observer = stubIntersectionObserver();
+
+    const result = await renderIsolatedLink({
+      href: "/blog/hello",
+      nodeEnv: "production",
+      props: { prefetch: true },
+    });
+
+    try {
+      expect(observer.observe).toHaveBeenCalledWith(result.anchor);
+      observer.dispatchIntersectingEntry(result.anchor);
+      await flushPrefetchTasks();
+
+      expect(observer.unobserve).toHaveBeenCalledWith(result.anchor);
+      expect(result.fetch).toHaveBeenCalledWith(
+        expect.stringContaining("/blog/hello.rsc"),
         expect.objectContaining({
           credentials: "include",
           priority: "low",

--- a/tests/link.test.ts
+++ b/tests/link.test.ts
@@ -15,7 +15,11 @@ import ReactDOMServer from "react-dom/server";
 
 // We test the Link component and its internal helpers.
 // Link is a "use client" component but renderToString still works for SSR output.
-import Link, { useLinkStatus } from "../packages/vinext/src/shims/link.js";
+import Link, {
+  canAutoPrefetchFullAppRoute,
+  resolveLinkPrefetchMode,
+  useLinkStatus,
+} from "../packages/vinext/src/shims/link.js";
 
 // Internal helpers re-exported or accessible via the router shim
 import { isExternalUrl, isHashOnlyChange } from "../packages/vinext/src/shims/router.js";
@@ -130,6 +134,45 @@ describe("useLinkStatus", () => {
     }
     ReactDOMServer.renderToString(React.createElement(TestComponent));
     expect(status).toEqual({ pending: false });
+  });
+});
+
+describe("Link App Router prefetch mode", () => {
+  it("distinguishes automatic prefetch from explicit full prefetch", () => {
+    expect(resolveLinkPrefetchMode(undefined, false)).toBe("auto");
+    expect(resolveLinkPrefetchMode(null, false)).toBe("auto");
+    expect(resolveLinkPrefetchMode("auto", false)).toBe("auto");
+    expect(resolveLinkPrefetchMode(true, false)).toBe("full");
+    expect(resolveLinkPrefetchMode(false, false)).toBe("disabled");
+    expect(resolveLinkPrefetchMode(true, true)).toBe("disabled");
+  });
+
+  it("allows automatic full RSC prefetch only for known static App Router routes", () => {
+    const originalWindow = globalThis.window;
+    (globalThis as any).window = {
+      location: {
+        href: "http://localhost/blog",
+        origin: "http://localhost",
+      },
+      __VINEXT_LINK_PREFETCH_ROUTES__: [
+        { patternParts: ["about"], isDynamic: false },
+        { patternParts: ["blog", ":slug"], isDynamic: true },
+        { patternParts: ["docs", ":slug+"], isDynamic: true },
+      ],
+    };
+
+    try {
+      expect(canAutoPrefetchFullAppRoute("/about")).toBe(true);
+      expect(canAutoPrefetchFullAppRoute("/blog/hello-world")).toBe(false);
+      expect(canAutoPrefetchFullAppRoute("/docs/a/b")).toBe(false);
+      expect(canAutoPrefetchFullAppRoute("/missing")).toBe(false);
+    } finally {
+      if (originalWindow === undefined) {
+        delete (globalThis as any).window;
+      } else {
+        (globalThis as any).window = originalWindow;
+      }
+    }
   });
 });
 


### PR DESCRIPTION
## Overview

| Field | Detail |
| --- | --- |
| Goal | Stop App Router `<Link prefetch={null}>`, omitted `prefetch`, and `prefetch=\"auto\"` from behaving like `prefetch={true}` for dynamic routes. |
| Core change | Split Link prefetch into `disabled`, `auto`, and `full`, then gate automatic full RSC prefetches through a generated static route manifest. |
| Main boundary | `prefetch={true}` still opts into full RSC prefetch. `null`/`undefined`/`\"auto\"` no longer trigger full dynamic route payload fetches. |
| Primary files | `packages/vinext/src/shims/link.tsx`, `packages/vinext/src/entries/app-browser-entry.ts`, `packages/vinext/src/index.ts` |
| Expected impact | Less background work for dynamic App Router links that use default/auto prefetch semantics. |

## Why

The Link prefetch prop is not a boolean in the App Router contract. Next.js treats `null`, `undefined`, and `\"auto\"` as automatic prefetch, while `true` is the explicit full-prefetch mode. Vinext collapsed those states into “enabled”, which meant default links to dynamic routes could fetch full RSC payloads as soon as they entered the viewport.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| Link API | Public prop values must preserve the Next.js distinction between auto and full. | Adds a typed prefetch mode resolver instead of using `prefetch !== false`. |
| App Router RSC prefetch | Automatic full prefetch should only happen when vinext can prove it is a static route shape. | Emits a small browser route manifest and matches hrefs against it before full auto prefetch. |
| Explicit opt-in | `prefetch={true}` is still allowed to fetch the full route and data. | Keeps explicit full prefetch behavior unchanged. |

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| `<Link href=\"/about\" />` for a static app route | Full RSC prefetch | Full RSC prefetch |
| `<Link href=\"/blog/hello-world\" />` for a dynamic app route | Full RSC prefetch | No full auto RSC prefetch |
| `<Link href=\"/blog/hello-world\" prefetch={true} />` | Full RSC prefetch | Full RSC prefetch |
| Dangerous URL schemes | Disabled | Disabled |

<details>
<summary>Maintainer review path</summary>

1. `packages/vinext/src/shims/link.tsx`: mode resolution, static route matching, and the auto-prefetch gate.
2. `packages/vinext/src/entries/app-browser-entry.ts`: browser route manifest generation.
3. `packages/vinext/src/index.ts`: passes scanned App Router routes into the browser entry generator.
4. `tests/link.test.ts` and `tests/entry-templates.test.ts`: focused behavior and codegen coverage.

</details>

<details>
<summary>Validation</summary>

- `vp test run tests/link.test.ts tests/entry-templates.test.ts`
- `vp check tests/link.test.ts tests/entry-templates.test.ts packages/vinext/src/shims/link.tsx packages/vinext/src/entries/app-browser-entry.ts packages/vinext/src/client/vinext-next-data.ts packages/vinext/src/index.ts`
- `git diff --check`

</details>

<details>
<summary>Risk / compatibility</summary>

- Public API: widens the shim type to accept `prefetch=\"auto\" | null`, matching App Router Link.
- Runtime: static App Router links still auto-prefetch full RSC payloads. Dynamic App Router links require `prefetch={true}` for full prefetch.
- Build output: app browser entry now includes a compact route-shape manifest for page routes.
- Intentional scope: Next.js can prefetch loading-boundary shells for some dynamic routes. Vinext currently caches complete RSC responses, not partial segment prefetches, so this PR avoids pretending `auto` can safely do that work.

</details>

<details>
<summary>Non-goals</summary>

- Implement Next.js segment-cache or loading-boundary partial prefetches.
- Include generated static param values in the browser prefetch manifest.
- Change `router.prefetch()`, which is already an explicit imperative prefetch API.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| [Next.js App Router Link prefetch prop](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/app-dir/link.tsx) | Documents `\"auto\"`, `null`, and `undefined` as automatic App Router prefetch, distinct from `true`. |
| [Next.js prefetch mode mapping](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/app-dir/link.tsx#L781-L800) | Maps `true` to full prefetch and `null`/`\"auto\"` to automatic/PPR behavior. |
| [Next.js PrefetchKind docs](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/router-reducer/router-reducer-types.ts#L131-L139) | States that auto prefetches static pages fully and dynamic pages partially. |
| [Next.js `prefetch=\"auto\"` test](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/segment-cache/prefetch-auto/prefetch-auto.test.ts) | Confirms `\"auto\"` is an alias for the default automatic behavior. |