### PR TITLE
fix(dynamic): accept Next.js dynamic overload forms

### DIFF
--- a/packages/vinext/src/shims/dynamic.ts
+++ b/packages/vinext/src/shims/dynamic.ts
@@ -13,7 +13,9 @@
  * - Client: React.lazy + Suspense (standard code splitting)
  *
  * Supports:
+ * - dynamic(import('./Component'))
  * - dynamic(() => import('./Component'))
+ * - dynamic({ loader })
  * - dynamic(() => import('./Component'), { loading: () => <Spinner /> })
  * - dynamic(() => import('./Component'), { ssr: false })
  */
@@ -27,12 +29,18 @@ type DynamicLoadingProps = {
   timedOut?: boolean;
 };
 
-type DynamicOptions = {
+type ComponentModule<P> = { default: ComponentType<P> };
+type LoaderComponent<P> = Promise<ComponentModule<P> | ComponentType<P>>;
+type LoaderFn<P> = () => LoaderComponent<P>;
+
+type DynamicOptions<P> = {
   loading?: ComponentType<DynamicLoadingProps>;
+  loader?: Loader<P>;
   ssr?: boolean;
 };
 
-type Loader<P> = () => Promise<{ default: ComponentType<P> } | ComponentType<P>>;
+type Loader<P> = LoaderFn<P> | LoaderComponent<P>;
+type DynamicInput<P> = DynamicOptions<P> | Loader<P>;
 
 const noopRetry = () => {};
 
@@ -49,16 +57,47 @@ function createDynamicLoadingProps(
   };
 }
 
-function createLazyComponent<P extends object>(loader: Loader<P>) {
+function hasDefaultExport<P>(
+  mod: ComponentModule<P> | ComponentType<P>,
+): mod is ComponentModule<P> {
+  return (typeof mod === "object" || typeof mod === "function") && mod !== null && "default" in mod;
+}
+
+function normalizeLoader<P extends object>(loader: Loader<P>): LoaderFn<P> {
+  if (typeof loader === "function") {
+    return loader;
+  }
+  return () => loader;
+}
+
+function normalizeDynamicOptions<P extends object>(
+  dynamicInput: DynamicInput<P>,
+  options?: DynamicOptions<P>,
+): DynamicOptions<P> {
+  let normalizedOptions: DynamicOptions<P>;
+
+  if (dynamicInput instanceof Promise || typeof dynamicInput === "function") {
+    normalizedOptions = { loader: normalizeLoader(dynamicInput) };
+  } else {
+    normalizedOptions = dynamicInput;
+  }
+
+  return {
+    ...normalizedOptions,
+    ...options,
+  };
+}
+
+function createLazyComponent<P extends object>(loader: LoaderFn<P>) {
   return React.lazy(async () => {
     const mod = await loader();
-    if ("default" in mod) return mod as { default: ComponentType<P> };
-    return { default: mod as ComponentType<P> };
+    if (hasDefaultExport(mod)) return mod;
+    return { default: mod };
   });
 }
 
 function useRetryableLazyComponent<P extends object>(
-  loader: Loader<P>,
+  loader: LoaderFn<P>,
   initialLazyComponent: ReturnType<typeof createLazyComponent<P>>,
 ) {
   const [LazyComponent, setLazyComponent] = React.useState(() => initialLazyComponent);
@@ -150,10 +189,15 @@ export function flushPreloads(): Promise<void[]> {
 }
 
 function dynamic<P extends object = object>(
-  loader: Loader<P>,
-  options?: DynamicOptions,
+  dynamicInput: DynamicInput<P>,
+  options?: DynamicOptions<P>,
 ): ComponentType<P> {
-  const { loading: LoadingComponent, ssr = true } = options ?? {};
+  const {
+    loader: dynamicLoader,
+    loading: LoadingComponent,
+    ssr = true,
+  } = normalizeDynamicOptions(dynamicInput, options);
+  const loader = dynamicLoader ? normalizeLoader(dynamicLoader) : () => Promise.resolve(() => null);
 
   // ssr: false — render nothing on the server, lazy-load on client
   if (!ssr) {

--- a/tests/dynamic.test.ts
+++ b/tests/dynamic.test.ts
@@ -9,6 +9,7 @@
 import { describe, it, expect } from "vite-plus/test";
 import React from "react";
 import ReactDOMServer from "react-dom/server";
+import { renderToReadableStream } from "react-dom/server.edge";
 import dynamic, { flushPreloads } from "../packages/vinext/src/shims/dynamic.js";
 
 // ─── Test components ────────────────────────────────────────────────────
@@ -21,6 +22,12 @@ function LoadingSpinner({ isLoading, error }: { isLoading?: boolean; error?: Err
   if (error) return React.createElement("div", null, `Error: ${error.message}`);
   if (isLoading) return React.createElement("div", null, "Loading...");
   return null;
+}
+
+async function renderDynamicToHtml(component: React.ComponentType) {
+  const stream = await renderToReadableStream(React.createElement(component));
+  await stream.allReady;
+  return new Response(stream).text();
 }
 
 // ─── SSR rendering ──────────────────────────────────────────────────────
@@ -45,6 +52,24 @@ describe("next/dynamic SSR", () => {
     // Some dynamic imports export the component directly
     const DynamicComponent = dynamic(() => Promise.resolve(Hello as any));
     expect(DynamicComponent.displayName).toBe("DynamicServer");
+  });
+
+  it("accepts a direct loader promise", async () => {
+    // Ported from Next.js: test/development/basic/next-dynamic/pages/dynamic/ssr.js
+    // https://github.com/vercel/next.js/blob/canary/test/development/basic/next-dynamic/pages/dynamic/ssr.js
+    const DynamicComponent = dynamic(Promise.resolve({ default: Hello }));
+
+    await expect(renderDynamicToHtml(DynamicComponent)).resolves.toContain("Hello from dynamic");
+  });
+
+  it("accepts an options object with loader", async () => {
+    // Ported from Next.js: test/development/basic/next-dynamic/pages/dynamic/head.js
+    // https://github.com/vercel/next.js/blob/canary/test/development/basic/next-dynamic/pages/dynamic/head.js
+    const DynamicComponent = dynamic({
+      loader: () => Promise.resolve({ default: Hello }),
+    });
+
+    await expect(renderDynamicToHtml(DynamicComponent)).resolves.toContain("Hello from dynamic");
   });
 });
 


### PR DESCRIPTION
## Overview

| Area | Summary |
| --- | --- |
| Goal | Match Next.js `next/dynamic` public loader argument shapes. |
| Core change | Normalize the first `dynamic()` argument before creating React.lazy components. |
| Primary files | `packages/vinext/src/shims/dynamic.ts`, `tests/dynamic.test.ts` |
| Expected impact | Existing apps using legacy direct import promises or `{ loader }` options objects render instead of failing at runtime. |

## Why

`next/dynamic` compatibility depends on accepting the same public call shapes before render-time lazy loading begins. Next.js keeps backward-compatible support for direct import promises and options objects with `loader`; vinext treated every first argument as a callable loader, so valid apps could fail later with `loader is not a function`.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| Public API | `next/dynamic` accepts multiple loader input forms | Adds a normalization boundary for function, Promise, and options-object inputs. |
| Rendering | React.lazy should receive a callable loader | Converts Promise inputs to zero-arg loader functions before any lazy component is built. |
| Compatibility | Preserve existing function-loader and `ssr:false` behavior | Leaves the existing server, client, retry, and loading paths unchanged after normalization. |

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| `dynamic(Promise.resolve(...))` | Render failed with `loader is not a function`. | Promise is wrapped as a loader and renders. |
| `dynamic({ loader: () => ... })` | Render failed with `loader is not a function`. | Object loader is extracted and renders. |
| `dynamic(() => import(...), options)` | Already worked. | Still follows the same path after normalization. |

<details>
<summary>Validation</summary>

- `vp test run tests/dynamic.test.ts tests/shims.test.ts`
- `vp check`
- Commit hook: formatting, lint/type checks, and Knip

</details>

<details>
<summary>Risk / compatibility</summary>

- Public API impact: expands accepted `next/dynamic` call shapes to match Next.js behavior.
- Runtime impact: normalization happens once when `dynamic()` is called, before existing SSR/client branches.
- Existing-app risk: low. Function loaders keep the same callable identity path, and the no-loader fallback preserves Next.js null-component behavior.
- Non-goal: this does not add build-time chunk metadata generation for `loadableGenerated` or webpack-specific preload behavior.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| [Next.js shared `dynamic.tsx`](https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/dynamic.tsx) | Source normalizes Promise, function, and object inputs before building the loader. |
| [Next.js react-loadable babel plugin](https://github.com/vercel/next.js/blob/canary/packages/next/src/build/babel/plugins/react-loadable-plugin.ts) | Documents the legacy `dynamic(import(...))` compatibility transform. |
| [Next.js direct-promise fixture](https://github.com/vercel/next.js/blob/canary/test/development/basic/next-dynamic/pages/dynamic/ssr.js) | Exercises `dynamic(import(...))`. |
| [Next.js options-object fixture](https://github.com/vercel/next.js/blob/canary/test/development/basic/next-dynamic/pages/dynamic/head.js) | Exercises `dynamic({ loader, ssr: false })`. |
| [Next.js lazy-loading docs](https://github.com/vercel/next.js/blob/canary/docs/01-app/02-guides/lazy-loading.mdx) | Documents the current function-loader `next/dynamic` form and related options. |