### PR TITLE
refactor: extract internal HTTP header names into shared constants

### DIFF
--- a/packages/vinext/src/build/prerender.ts
+++ b/packages/vinext/src/build/prerender.ts
@@ -32,6 +32,7 @@ import {
 } from "vinext/shims/cache";
 import { runWithHeadersContext, headersContextFromRequest } from "vinext/shims/headers";
 import { createValidFileMatcher, findFileWithExtensions } from "../routing/file-matcher.js";
+import { VINEXT_PRERENDER_SECRET_HEADER } from "../server/headers.js";
 import { startProdServer } from "../server/prod-server.js";
 import { readPrerenderSecret } from "./server-manifest.js";
 export { readPrerenderSecret } from "./server-manifest.js";
@@ -503,7 +504,7 @@ export async function prerenderPages({
 
     const baseUrl = `http://127.0.0.1:${prodServer.port}`;
     const secretHeaders: Record<string, string> = prerenderSecret
-      ? { "x-vinext-prerender-secret": prerenderSecret }
+      ? { [VINEXT_PRERENDER_SECRET_HEADER]: prerenderSecret }
       : {};
 
     type BundleRoute = {
@@ -837,7 +838,7 @@ export async function prerenderApp({
 
     const baseUrl = `http://127.0.0.1:${prodServer.port}`;
     const secretHeaders: Record<string, string> = prerenderSecret
-      ? { "x-vinext-prerender-secret": prerenderSecret }
+      ? { [VINEXT_PRERENDER_SECRET_HEADER]: prerenderSecret }
       : {};
 
     rscHandler = (req: Request) => {

--- a/packages/vinext/src/cloudflare/tpr.ts
+++ b/packages/vinext/src/cloudflare/tpr.ts
@@ -23,6 +23,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { spawn, type ChildProcess } from "node:child_process";
+import { VINEXT_REVALIDATE_HEADER } from "../server/headers.js";
 import { isrCacheKey } from "../server/isr-cache.js";
 import { ENTRY_PREFIX } from "./kv-cache-handler.js";
 
@@ -565,7 +566,7 @@ async function prerenderRoutes(
               if (
                 key === "content-type" ||
                 key === "cache-control" ||
-                key === "x-vinext-revalidate" ||
+                key === VINEXT_REVALIDATE_HEADER ||
                 key === "location"
               ) {
                 headers[key] = value;
@@ -683,7 +684,7 @@ export function buildTprKVPairs(
   const pairs: Array<{ key: string; value: string; expiration_ttl: number }> = [];
 
   for (const [routePath, result] of entries) {
-    const revalidateHeader = result.headers["x-vinext-revalidate"];
+    const revalidateHeader = result.headers[VINEXT_REVALIDATE_HEADER];
     const revalidateSeconds =
       revalidateHeader && !isNaN(Number(revalidateHeader))
         ? Number(revalidateHeader)

--- a/packages/vinext/src/config/config-matchers.ts
+++ b/packages/vinext/src/config/config-matchers.ts
@@ -6,6 +6,11 @@
  */
 
 import type { NextRedirect, NextRewrite, NextHeader, HasCondition } from "./next-config.js";
+import {
+  MIDDLEWARE_HEADER_PREFIX,
+  VINEXT_MW_CTX_HEADER,
+  VINEXT_PRERENDER_SECRET_HEADER,
+} from "../server/headers.js";
 import { buildRequestHeadersFromMiddlewareResponse } from "../server/middleware-request-headers.js";
 
 /**
@@ -511,7 +516,7 @@ export function applyMiddlewareRequestHeaders(
   );
 
   for (const key of Object.keys(middlewareHeaders)) {
-    if (key.startsWith("x-middleware-")) {
+    if (key.startsWith(MIDDLEWARE_HEADER_PREFIX)) {
       delete middlewareHeaders[key];
     }
   }
@@ -1079,7 +1084,7 @@ export async function proxyExternalRequest(
   stripHopByHopRequestHeaders(headers);
   const keysToDelete: string[] = [];
   for (const key of headers.keys()) {
-    if (key.startsWith("x-middleware-")) {
+    if (key.startsWith(MIDDLEWARE_HEADER_PREFIX)) {
       keysToDelete.push(key);
     }
   }
@@ -1089,9 +1094,9 @@ export async function proxyExternalRequest(
   // Internal prerender authentication header must never be forwarded to
   // external rewrite destinations. It authorizes hidden production endpoints
   // used only by vinext's own prerender pipeline.
-  headers.delete("x-vinext-prerender-secret");
+  headers.delete(VINEXT_PRERENDER_SECRET_HEADER);
   // Internal App Router dev middleware context must never leave the dev server.
-  headers.delete("x-vinext-mw-ctx");
+  headers.delete(VINEXT_MW_CTX_HEADER);
 
   const method = request.method;
   const hasBody = method !== "GET" && method !== "HEAD";

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -42,6 +42,13 @@ import {
 } from "./config/next-config.js";
 
 import { findMiddlewareFile, runMiddleware } from "./server/middleware.js";
+import {
+  MIDDLEWARE_HEADER_PREFIX,
+  MIDDLEWARE_NEXT_HEADER,
+  MIDDLEWARE_REWRITE_HEADER,
+  VINEXT_MW_CTX_HEADER,
+  VINEXT_TIMING_HEADER,
+} from "./server/headers.js";
 import { logRequest, now } from "./server/request-log.js";
 import { normalizePath } from "./server/normalize-path.js";
 import {
@@ -2196,7 +2203,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
 
               const _origSetHeader = res.setHeader.bind(res);
               res.setHeader = function (name, value) {
-                if (name.toLowerCase() === "x-vinext-timing") {
+                if (name.toLowerCase() === VINEXT_TIMING_HEADER) {
                   _parseTiming(value);
                   return res; // drop the header — don't forward to client
                 }
@@ -2218,7 +2225,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                 // Pull timing out of the headers object when present.
                 if (headers && typeof headers === "object" && !Array.isArray(headers)) {
                   const timingKey = Object.keys(headers).find(
-                    (k) => k.toLowerCase() === "x-vinext-timing",
+                    (k) => k.toLowerCase() === VINEXT_TIMING_HEADER,
                   );
                   if (timingKey) {
                     _parseTiming(headers[timingKey]);
@@ -2500,7 +2507,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                 if (middlewareRequestHeaders) {
                   applyRequestHeadersToNodeRequest(middlewareRequestHeaders);
                 } else {
-                  delete req.headers["x-vinext-mw-ctx"];
+                  delete req.headers[VINEXT_MW_CTX_HEADER];
                 }
               };
 
@@ -2601,13 +2608,13 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                     // entry (via x-vinext-mw-ctx) for App Router routes.
                     deferredMwResponseHeaders = [];
                     for (const [key, value] of result.responseHeaders) {
-                      if (!key.startsWith("x-middleware-")) {
+                      if (!key.startsWith(MIDDLEWARE_HEADER_PREFIX)) {
                         deferredMwResponseHeaders.push([key, value]);
                       }
                     }
                   } else {
                     for (const [key, value] of result.responseHeaders) {
-                      if (!key.startsWith("x-middleware-")) {
+                      if (!key.startsWith(MIDDLEWARE_HEADER_PREFIX)) {
                         res.appendHeader(key, value);
                       }
                     }
@@ -2641,12 +2648,12 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                     for (const [key, value] of result.responseHeaders) {
                       // Exclude control headers that runMiddleware already
                       // consumed — matches the RSC entry's inline filtering.
-                      if (key !== "x-middleware-next" && key !== "x-middleware-rewrite") {
+                      if (key !== MIDDLEWARE_NEXT_HEADER && key !== MIDDLEWARE_REWRITE_HEADER) {
                         mwCtxEntries.push([key, value]);
                       }
                     }
                   }
-                  req.headers["x-vinext-mw-ctx"] = JSON.stringify({
+                  req.headers[VINEXT_MW_CTX_HEADER] = JSON.stringify({
                     h: mwCtxEntries,
                     s: middlewareStatus ?? null,
                     r: result.rewriteUrl ?? null,

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -89,9 +89,14 @@ import {
   stripRscCacheBustingSearchParam,
   stripRscSuffix,
   VINEXT_RSC_CONTENT_TYPE,
-  VINEXT_RSC_MOUNTED_SLOTS_HEADER,
 } from "./app-rsc-cache-busting.js";
 import { APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI } from "./app-rsc-render-mode.js";
+import {
+  ACTION_REDIRECT_HEADER,
+  ACTION_REDIRECT_TYPE_HEADER,
+  VINEXT_MOUNTED_SLOTS_HEADER,
+  VINEXT_PARAMS_HEADER,
+} from "./headers.js";
 
 type SearchParamInput = ConstructorParameters<typeof URLSearchParams>[0];
 
@@ -761,7 +766,7 @@ async function readInitialRscStream(): Promise<ReadableStream<Uint8Array> | null
   // Ignore malformed param headers and continue with hydration. The original
   // try/catch also swallowed errors from applyClientParams; preserve that.
   const parsedParams = parseEncodedJsonHeader<Record<string, string | string[]>>(
-    rscResponse.headers.get("X-Vinext-Params"),
+    rscResponse.headers.get(VINEXT_PARAMS_HEADER),
   );
   const params: Record<string, string | string[]> = parsedParams ?? {};
   if (parsedParams) {
@@ -808,7 +813,7 @@ function registerServerActionCallback(): void {
       throw new Error(getServerActionNotFoundClientMessage(id));
     }
 
-    const actionRedirect = fetchResponse.headers.get("x-action-redirect");
+    const actionRedirect = fetchResponse.headers.get(ACTION_REDIRECT_HEADER);
     if (actionRedirect) {
       if (isDangerousScheme(actionRedirect)) {
         console.error(DANGEROUS_URL_BLOCK_MESSAGE);
@@ -831,7 +836,7 @@ function registerServerActionCallback(): void {
       // requires a valid RSC payload. This is a known parity gap with Next.js,
       // which pre-renders the redirect target's RSC payload.
       clearClientNavigationCaches();
-      const redirectType = fetchResponse.headers.get("x-action-redirect-type") ?? "replace";
+      const redirectType = fetchResponse.headers.get(ACTION_REDIRECT_TYPE_HEADER) ?? "replace";
       if (redirectType === "push") {
         window.location.assign(actionRedirect);
       } else {
@@ -997,7 +1002,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
             navigationKind === "refresh" ? APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI : undefined,
         });
         if (mountedSlotsHeader) {
-          requestHeaders.set(VINEXT_RSC_MOUNTED_SLOTS_HEADER, mountedSlotsHeader);
+          requestHeaders.set(VINEXT_MOUNTED_SLOTS_HEADER, mountedSlotsHeader);
         }
         const rscUrl = await createRscRequestUrl(url.pathname + url.search, requestHeaders);
         const cachedRoute = getVisitedResponse(
@@ -1147,7 +1152,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
         // navParams falls back to {} on a missing or malformed header.
         const navParams: Record<string, string | string[]> =
           parseEncodedJsonHeader<Record<string, string | string[]>>(
-            navResponse.headers.get("X-Vinext-Params"),
+            navResponse.headers.get(VINEXT_PARAMS_HEADER),
           ) ?? {};
         // Build snapshot from local params, not latestClientParams
         const navigationSnapshot = createClientNavigationRenderSnapshot(currentHref, navParams);

--- a/packages/vinext/src/server/app-browser-state.ts
+++ b/packages/vinext/src/server/app-browser-state.ts
@@ -7,6 +7,11 @@ import {
 } from "./app-elements.js";
 import { createRscRequestHeaders } from "./app-rsc-cache-busting.js";
 import {
+  RSC_ACTION_HEADER,
+  VINEXT_INTERCEPTION_CONTEXT_HEADER,
+  VINEXT_MOUNTED_SLOTS_HEADER,
+} from "./headers.js";
+import {
   NavigationTraceReasonCodes,
   createNavigationLifecycleTraceFields,
   createNavigationTrace,
@@ -173,19 +178,19 @@ export function resolveServerActionRequestState(
   options: ResolveServerActionRequestStateOptions,
 ): ResolveServerActionRequestStateResult {
   const headers = createRscRequestHeaders();
-  headers.set("x-rsc-action", options.actionId);
+  headers.set(RSC_ACTION_HEADER, options.actionId);
 
   const interceptionContext = resolveInterceptionContextFromPreviousNextUrl(
     options.previousNextUrl,
     options.basePath,
   );
   if (interceptionContext !== null) {
-    headers.set("X-Vinext-Interception-Context", interceptionContext);
+    headers.set(VINEXT_INTERCEPTION_CONTEXT_HEADER, interceptionContext);
   }
 
   const mountedSlotsHeader = getMountedSlotIdsHeader(options.elements);
   if (mountedSlotsHeader !== null) {
-    headers.set("X-Vinext-Mounted-Slots", mountedSlotsHeader);
+    headers.set(VINEXT_MOUNTED_SLOTS_HEADER, mountedSlotsHeader);
   }
 
   return { headers };

--- a/packages/vinext/src/server/app-middleware.ts
+++ b/packages/vinext/src/server/app-middleware.ts
@@ -2,6 +2,7 @@ import type { NextI18nConfig } from "../config/next-config.js";
 import { isExternalUrl, proxyExternalRequest } from "../config/config-matchers.js";
 import { applyMiddlewareRequestHeaders, setHeadersContext } from "vinext/shims/headers";
 import { setNavigationContext } from "vinext/shims/navigation";
+import { FLIGHT_HEADERS, VINEXT_MW_CTX_HEADER } from "./headers.js";
 import { buildRequestHeadersFromMiddlewareResponse } from "./middleware-request-headers.js";
 import { mergeMiddlewareResponseHeaders } from "./middleware-response-headers.js";
 import { executeMiddleware, type MiddlewareModule } from "./middleware-runtime.js";
@@ -41,13 +42,8 @@ type ForwardedMiddlewareContext = {
   s?: unknown;
 };
 
-export const FLIGHT_HEADERS: readonly string[] = [
-  "rsc",
-  "next-router-state-tree",
-  "next-router-prefetch",
-  "next-hmr-refresh",
-  "next-router-segment-prefetch",
-];
+// Re-exported from headers.ts for backward compatibility.
+export { FLIGHT_HEADERS } from "./headers.js";
 
 const FLIGHT_HEADER_SET = new Set(FLIGHT_HEADERS);
 
@@ -169,7 +165,7 @@ function applyForwardedMiddlewareContext(
     return { applied: false };
   }
 
-  const header = request.headers.get("x-vinext-mw-ctx");
+  const header = request.headers.get(VINEXT_MW_CTX_HEADER);
   if (!header) return { applied: false };
 
   try {

--- a/packages/vinext/src/server/app-page-cache.ts
+++ b/packages/vinext/src/server/app-page-cache.ts
@@ -1,6 +1,7 @@
 import type { CachedAppPageValue, CacheControlMetadata } from "vinext/shims/cache";
 import { VINEXT_RSC_VARY_HEADER } from "./app-rsc-cache-busting.js";
 import { buildCachedRevalidateCacheControl } from "./cache-control.js";
+import { VINEXT_CACHE_HEADER, VINEXT_MOUNTED_SLOTS_HEADER } from "./headers.js";
 import { buildAppPageCacheValue, type ISRCacheEntry } from "./isr-cache.js";
 import { mergeMiddlewareResponseHeaders } from "./middleware-response-headers.js";
 import { readStreamAsText } from "../utils/text-stream.js";
@@ -151,11 +152,11 @@ function buildAppPageCachedHeaders(options: {
     "Cache-Control": options.cacheControl,
     "Content-Type": options.contentType,
     Vary: VINEXT_RSC_VARY_HEADER,
-    "X-Vinext-Cache": options.cacheState,
+    [VINEXT_CACHE_HEADER]: options.cacheState,
   });
 
   if (options.mountedSlotsHeader) {
-    headers.set("X-Vinext-Mounted-Slots", options.mountedSlotsHeader);
+    headers.set(VINEXT_MOUNTED_SLOTS_HEADER, options.mountedSlotsHeader);
   }
 
   mergeMiddlewareResponseHeaders(headers, options.middlewareHeaders ?? null);
@@ -377,7 +378,7 @@ export function finalizeAppPageHtmlCacheResponse(
     // consumed. Until that late dynamic check finishes, downstream shared caches
     // must not cache a response whose ISR policy was known before streaming.
     clientHeaders.set("Cache-Control", NO_STORE_CACHE_CONTROL);
-    clientHeaders.set("X-Vinext-Cache", "MISS");
+    clientHeaders.set(VINEXT_CACHE_HEADER, "MISS");
   }
 
   const cachePromise = (async () => {
@@ -461,7 +462,7 @@ export function finalizeAppPageRscCacheResponse(
   // late request API was used, the client-facing MISS response must not enter a
   // shared cache when the ISR policy was known before streaming.
   clientHeaders.set("Cache-Control", NO_STORE_CACHE_CONTROL);
-  clientHeaders.set("X-Vinext-Cache", "MISS");
+  clientHeaders.set(VINEXT_CACHE_HEADER, "MISS");
 
   return new Response(response.body, {
     status: response.status,

--- a/packages/vinext/src/server/app-page-response.ts
+++ b/packages/vinext/src/server/app-page-response.ts
@@ -3,6 +3,12 @@ import {
   NO_STORE_CACHE_CONTROL,
   STATIC_CACHE_CONTROL,
 } from "./cache-control.js";
+import {
+  VINEXT_CACHE_HEADER,
+  VINEXT_MOUNTED_SLOTS_HEADER,
+  VINEXT_PARAMS_HEADER,
+  VINEXT_TIMING_HEADER,
+} from "./headers.js";
 import { mergeMiddlewareResponseHeaders } from "./middleware-response-headers.js";
 import { VINEXT_RSC_VARY_HEADER } from "./app-rsc-cache-busting.js";
 
@@ -78,7 +84,7 @@ function applyTimingHeader(headers: Headers, timing?: AppPageResponseTiming): vo
       ? Math.round(timing.renderEnd - timing.compileEnd)
       : -1;
 
-  headers.set("x-vinext-timing", `${handlerStart},${compileMs},${renderMs}`);
+  headers.set(VINEXT_TIMING_HEADER, `${handlerStart},${compileMs},${renderMs}`);
 }
 
 export function resolveAppPageRscResponsePolicy(
@@ -218,16 +224,16 @@ export function buildAppPageRscResponse(
   if (options.params && Object.keys(options.params).length > 0) {
     // encodeURIComponent so non-ASCII params (e.g. Korean slugs) survive the
     // HTTP ByteString constraint — Headers.set() rejects chars above U+00FF.
-    headers.set("X-Vinext-Params", encodeURIComponent(JSON.stringify(options.params)));
+    headers.set(VINEXT_PARAMS_HEADER, encodeURIComponent(JSON.stringify(options.params)));
   }
   if (options.mountedSlotsHeader) {
-    headers.set("X-Vinext-Mounted-Slots", options.mountedSlotsHeader);
+    headers.set(VINEXT_MOUNTED_SLOTS_HEADER, options.mountedSlotsHeader);
   }
   if (options.policy.cacheControl) {
     headers.set("Cache-Control", options.policy.cacheControl);
   }
   if (options.policy.cacheState) {
-    headers.set("X-Vinext-Cache", options.policy.cacheState);
+    headers.set(VINEXT_CACHE_HEADER, options.policy.cacheState);
   }
 
   mergeMiddlewareResponseHeaders(headers, options.middlewareContext.headers);
@@ -253,7 +259,7 @@ export function buildAppPageHtmlResponse(
     headers.set("Cache-Control", options.policy.cacheControl);
   }
   if (options.policy.cacheState) {
-    headers.set("X-Vinext-Cache", options.policy.cacheState);
+    headers.set(VINEXT_CACHE_HEADER, options.policy.cacheState);
   }
   if (options.draftCookie) {
     headers.append("Set-Cookie", options.draftCookie);

--- a/packages/vinext/src/server/app-route-handler-policy.ts
+++ b/packages/vinext/src/server/app-route-handler-policy.ts
@@ -4,6 +4,7 @@ import {
   type RouteHandlerHttpMethod,
   type RouteHandlerModule,
 } from "./app-route-handler-runtime.js";
+import { NEXT_ACTION_HEADER, RSC_ACTION_HEADER } from "./headers.js";
 import { parseNextHttpErrorDigest, parseNextRedirectDigest } from "./next-error-digest.js";
 
 export type AppRouteHandlerModule = {
@@ -63,8 +64,8 @@ export function isPossibleAppRouteActionRequest(
 
   const contentType = request.headers.get("content-type");
   return (
-    request.headers.has("x-rsc-action") ||
-    request.headers.has("next-action") ||
+    request.headers.has(RSC_ACTION_HEADER) ||
+    request.headers.has(NEXT_ACTION_HEADER) ||
     // Next.js uses strict equality here, so charset variants intentionally do
     // not classify as action requests even though they are valid form posts.
     contentType === "application/x-www-form-urlencoded" ||

--- a/packages/vinext/src/server/app-route-handler-response.ts
+++ b/packages/vinext/src/server/app-route-handler-response.ts
@@ -4,6 +4,12 @@ import {
   NEVER_CACHE_CONTROL,
   STATIC_CACHE_CONTROL,
 } from "./cache-control.js";
+import {
+  MIDDLEWARE_HEADER_PREFIX,
+  MIDDLEWARE_NEXT_HEADER,
+  MIDDLEWARE_REWRITE_HEADER,
+  VINEXT_CACHE_HEADER,
+} from "./headers.js";
 import { mergeMiddlewareResponseHeaders } from "./middleware-response-headers.js";
 import { processMiddlewareHeaders } from "./request-pipeline.js";
 
@@ -33,7 +39,7 @@ const APP_ROUTE_NEXT_ERROR =
 
 function hasMiddlewareHeader(headers: Headers): boolean {
   for (const key of headers.keys()) {
-    if (key.startsWith("x-middleware-")) return true;
+    if (key.startsWith(MIDDLEWARE_HEADER_PREFIX)) return true;
   }
   return false;
 }
@@ -81,11 +87,11 @@ export function applyRouteHandlerMiddlewareContext(
 export function assertSupportedAppRouteHandlerResponse(response: Response): void {
   // NextResponse.next() and rewrite() are middleware control-flow signals.
   // Once an App Route handler has returned, Next.js rejects those responses.
-  if (response.headers.has("x-middleware-rewrite")) {
+  if (response.headers.has(MIDDLEWARE_REWRITE_HEADER)) {
     throw new Error(APP_ROUTE_REWRITE_ERROR);
   }
 
-  if (response.headers.get("x-middleware-next") === "1") {
+  if (response.headers.get(MIDDLEWARE_NEXT_HEADER) === "1") {
     throw new Error(APP_ROUTE_NEXT_ERROR);
   }
 }
@@ -104,7 +110,7 @@ export function buildRouteHandlerCachedResponse(
       headers.set(key, value);
     }
   }
-  headers.set("X-Vinext-Cache", options.cacheState);
+  headers.set(VINEXT_CACHE_HEADER, options.cacheState);
   const revalidateSeconds = options.cacheControl?.revalidate ?? options.revalidateSeconds;
   const expireSeconds =
     options.cacheControl === undefined
@@ -133,7 +139,7 @@ export function applyRouteHandlerRevalidateHeader(
 }
 
 export function markRouteHandlerCacheMiss(response: Response): void {
-  response.headers.set("X-Vinext-Cache", "MISS");
+  response.headers.set(VINEXT_CACHE_HEADER, "MISS");
 }
 
 function getSetCookieName(cookie: string): string | null {
@@ -191,9 +197,9 @@ export async function buildAppRouteCacheValue(response: Response): Promise<Cache
   response.headers.forEach((value, key) => {
     if (
       key === "set-cookie" ||
-      key === "x-vinext-cache" ||
+      key === VINEXT_CACHE_HEADER.toLowerCase() ||
       key === "cache-control" ||
-      key.startsWith("x-middleware-")
+      key.startsWith(MIDDLEWARE_HEADER_PREFIX)
     ) {
       return;
     }

--- a/packages/vinext/src/server/app-rsc-cache-busting.ts
+++ b/packages/vinext/src/server/app-rsc-cache-busting.ts
@@ -4,6 +4,16 @@ import {
   parseAppRscRenderMode,
   type AppRscRenderMode,
 } from "./app-rsc-render-mode.js";
+import {
+  NEXT_ROUTER_PREFETCH_HEADER,
+  NEXT_ROUTER_SEGMENT_PREFETCH_HEADER,
+  NEXT_ROUTER_STATE_TREE_HEADER,
+  NEXT_URL_HEADER,
+  RSC_HEADER,
+  VINEXT_INTERCEPTION_CONTEXT_HEADER,
+  VINEXT_MOUNTED_SLOTS_HEADER,
+  VINEXT_RSC_RENDER_MODE_HEADER,
+} from "./headers.js";
 
 /**
  * RSC cache-busting hashes cover the headers that make a `.rsc` payload vary.
@@ -13,25 +23,22 @@ import {
  */
 export const VINEXT_RSC_CACHE_BUSTING_SEARCH_PARAM = "_rsc";
 export const VINEXT_RSC_CONTENT_TYPE = "text/x-component";
-export const VINEXT_RSC_MOUNTED_SLOTS_HEADER = "X-Vinext-Mounted-Slots";
-export const VINEXT_RSC_RENDER_MODE_HEADER = "X-Vinext-Rsc-Render-Mode";
 
-const VINEXT_RSC_HEADER = "RSC";
-const VINEXT_RSC_INTERCEPTION_CONTEXT_HEADER = "X-Vinext-Interception-Context";
-const NEXT_ROUTER_STATE_TREE_HEADER = "Next-Router-State-Tree";
-const NEXT_ROUTER_PREFETCH_HEADER = "Next-Router-Prefetch";
-const NEXT_ROUTER_SEGMENT_PREFETCH_HEADER = "Next-Router-Segment-Prefetch";
-const NEXT_URL_HEADER = "Next-Url";
+/** @deprecated Import {@link VINEXT_MOUNTED_SLOTS_HEADER} from `./headers.js` instead. */
+export const VINEXT_RSC_MOUNTED_SLOTS_HEADER = VINEXT_MOUNTED_SLOTS_HEADER;
+
+// Re-export so existing consumers that import from this module keep working.
+export { VINEXT_RSC_RENDER_MODE_HEADER } from "./headers.js";
 
 export const VINEXT_RSC_VARY_HEADER = [
-  VINEXT_RSC_HEADER,
+  RSC_HEADER,
   "Accept",
   NEXT_ROUTER_STATE_TREE_HEADER,
   NEXT_ROUTER_PREFETCH_HEADER,
   NEXT_ROUTER_SEGMENT_PREFETCH_HEADER,
   NEXT_URL_HEADER,
-  VINEXT_RSC_INTERCEPTION_CONTEXT_HEADER,
-  VINEXT_RSC_MOUNTED_SLOTS_HEADER,
+  VINEXT_INTERCEPTION_CONTEXT_HEADER,
+  VINEXT_MOUNTED_SLOTS_HEADER,
   VINEXT_RSC_RENDER_MODE_HEADER,
 ].join(", ");
 
@@ -82,8 +89,8 @@ function createCacheBustingInput(
     headers.get(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER),
     headers.get(NEXT_ROUTER_STATE_TREE_HEADER),
     headers.get(NEXT_URL_HEADER),
-    headers.get(VINEXT_RSC_INTERCEPTION_CONTEXT_HEADER),
-    headers.get(VINEXT_RSC_MOUNTED_SLOTS_HEADER),
+    headers.get(VINEXT_INTERCEPTION_CONTEXT_HEADER),
+    headers.get(VINEXT_MOUNTED_SLOTS_HEADER),
     ...(options.includeRenderModeHeader === false
       ? []
       : [normalizeRenderModeHeaderValue(headers.get(VINEXT_RSC_RENDER_MODE_HEADER))]),
@@ -176,15 +183,15 @@ export function stripRscSuffix(pathname: string): string {
 export function createRscRequestHeaders(options: CreateRscRequestHeadersOptions = {}): Headers {
   const headers = new Headers({
     Accept: VINEXT_RSC_CONTENT_TYPE,
-    [VINEXT_RSC_HEADER]: "1",
+    [RSC_HEADER]: "1",
   });
 
   if (options.interceptionContext !== undefined && options.interceptionContext !== null) {
-    headers.set(VINEXT_RSC_INTERCEPTION_CONTEXT_HEADER, options.interceptionContext);
+    headers.set(VINEXT_INTERCEPTION_CONTEXT_HEADER, options.interceptionContext);
   }
 
   if (options.mountedSlotsHeader !== undefined && options.mountedSlotsHeader !== null) {
-    headers.set(VINEXT_RSC_MOUNTED_SLOTS_HEADER, options.mountedSlotsHeader);
+    headers.set(VINEXT_MOUNTED_SLOTS_HEADER, options.mountedSlotsHeader);
   }
 
   const renderMode = options.renderMode ?? APP_RSC_RENDER_MODE_NAVIGATION;

--- a/packages/vinext/src/server/app-rsc-cache-busting.ts
+++ b/packages/vinext/src/server/app-rsc-cache-busting.ts
@@ -24,9 +24,6 @@ import {
 export const VINEXT_RSC_CACHE_BUSTING_SEARCH_PARAM = "_rsc";
 export const VINEXT_RSC_CONTENT_TYPE = "text/x-component";
 
-/** @deprecated Import {@link VINEXT_MOUNTED_SLOTS_HEADER} from `./headers.js` instead. */
-export const VINEXT_RSC_MOUNTED_SLOTS_HEADER = VINEXT_MOUNTED_SLOTS_HEADER;
-
 // Re-export so existing consumers that import from this module keep working.
 export { VINEXT_RSC_RENDER_MODE_HEADER } from "./headers.js";
 

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -13,6 +13,12 @@ import {
   sanitizeDestination,
 } from "../config/config-matchers.js";
 import { headersContextFromRequest } from "vinext/shims/headers";
+import {
+  NEXT_ACTION_HEADER,
+  RSC_ACTION_HEADER,
+  RSC_HEADER,
+  VINEXT_MW_CTX_HEADER,
+} from "./headers.js";
 import { ensureFetchPatch, setCurrentFetchSoftTags } from "vinext/shims/fetch-cache";
 import type { ReactFormState } from "react-dom/client";
 import {
@@ -305,7 +311,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
       redirectDestinationWithBasePath(redirect.destination, options.basePath),
     );
     const location =
-      isRscRequest && request.headers.get("RSC") === "1"
+      isRscRequest && request.headers.get(RSC_HEADER) === "1"
         ? await createRscRedirectLocation(destination, request)
         : destination;
     return new Response(null, {
@@ -400,7 +406,8 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
     params: {},
   });
 
-  const actionId = request.headers.get("x-rsc-action") ?? request.headers.get("next-action");
+  const actionId =
+    request.headers.get(RSC_ACTION_HEADER) ?? request.headers.get(NEXT_ACTION_HEADER);
   const contentType = request.headers.get("content-type") || "";
 
   const progressiveActionResult = await options.handleProgressiveActionRequest({
@@ -547,10 +554,10 @@ export function createAppRscHandler<TRoute extends AppRscHandlerRoute>(
     // x-vinext-mw-ctx to req.headers after the Request is built, so it is
     // visible to .get() but lost when filterInternalHeaders iterates. Read it
     // BEFORE iterating so applyForwardedMiddlewareContext can skip middleware.
-    const mwCtx = rawRequest.headers.get("x-vinext-mw-ctx");
+    const mwCtx = rawRequest.headers.get(VINEXT_MW_CTX_HEADER);
     const filteredHeaders = filterInternalHeaders(rawRequest.headers);
     if (mwCtx !== null) {
-      filteredHeaders.set("x-vinext-mw-ctx", mwCtx);
+      filteredHeaders.set(VINEXT_MW_CTX_HEADER, mwCtx);
     }
     const request = cloneRequestWithHeaders(rawRequest, filteredHeaders);
 

--- a/packages/vinext/src/server/app-rsc-request-normalization.ts
+++ b/packages/vinext/src/server/app-rsc-request-normalization.ts
@@ -2,6 +2,7 @@ import { normalizePath } from "./normalize-path.js";
 import { normalizePathnameForRouteMatchStrict } from "../routing/utils.js";
 import { guardProtocolRelativeUrl } from "./request-pipeline.js";
 import { hasBasePath, stripBasePath } from "../utils/base-path.js";
+import { VINEXT_INTERCEPTION_CONTEXT_HEADER, VINEXT_MOUNTED_SLOTS_HEADER } from "./headers.js";
 import { normalizeMountedSlotsHeader } from "./app-mounted-slots-header.js";
 import { stripRscSuffix, VINEXT_RSC_RENDER_MODE_HEADER } from "./app-rsc-cache-busting.js";
 import {
@@ -101,11 +102,11 @@ export function normalizeRscRequest(
   // Step 8: Sanitize X-Vinext-Interception-Context.
   // Null bytes in header values can be used for injection in some HTTP stacks.
   const interceptionContextHeader =
-    request.headers.get("X-Vinext-Interception-Context")?.replaceAll("\0", "") || null;
+    request.headers.get(VINEXT_INTERCEPTION_CONTEXT_HEADER)?.replaceAll("\0", "") || null;
 
   // Step 9: Normalize mounted-slots header for canonical cache keying.
   const mountedSlotsHeader = normalizeMountedSlotsHeader(
-    request.headers.get("x-vinext-mounted-slots"),
+    request.headers.get(VINEXT_MOUNTED_SLOTS_HEADER),
   );
   const renderMode = isRscRequest
     ? parseAppRscRenderMode(request.headers.get(VINEXT_RSC_RENDER_MODE_HEADER))

--- a/packages/vinext/src/server/app-rsc-request-normalization.ts
+++ b/packages/vinext/src/server/app-rsc-request-normalization.ts
@@ -2,9 +2,13 @@ import { normalizePath } from "./normalize-path.js";
 import { normalizePathnameForRouteMatchStrict } from "../routing/utils.js";
 import { guardProtocolRelativeUrl } from "./request-pipeline.js";
 import { hasBasePath, stripBasePath } from "../utils/base-path.js";
-import { VINEXT_INTERCEPTION_CONTEXT_HEADER, VINEXT_MOUNTED_SLOTS_HEADER } from "./headers.js";
+import {
+  VINEXT_INTERCEPTION_CONTEXT_HEADER,
+  VINEXT_MOUNTED_SLOTS_HEADER,
+  VINEXT_RSC_RENDER_MODE_HEADER,
+} from "./headers.js";
 import { normalizeMountedSlotsHeader } from "./app-mounted-slots-header.js";
-import { stripRscSuffix, VINEXT_RSC_RENDER_MODE_HEADER } from "./app-rsc-cache-busting.js";
+import { stripRscSuffix } from "./app-rsc-cache-busting.js";
 import {
   APP_RSC_RENDER_MODE_NAVIGATION,
   parseAppRscRenderMode,

--- a/packages/vinext/src/server/app-rsc-response-finalizer.ts
+++ b/packages/vinext/src/server/app-rsc-response-finalizer.ts
@@ -1,5 +1,6 @@
 import type { NextHeader } from "../config/next-config.js";
 import type { RequestContext } from "../config/config-matchers.js";
+import { VINEXT_STATIC_FILE_HEADER } from "./headers.js";
 import { applyConfigHeadersToResponse } from "./request-pipeline.js";
 import { VINEXT_RSC_VARY_HEADER } from "./app-rsc-cache-busting.js";
 import { mergeVaryHeader } from "./middleware-response-headers.js";
@@ -42,7 +43,7 @@ export function finalizeAppRscResponse(
     return response;
   }
 
-  if (!response.headers.has("x-vinext-static-file")) {
+  if (!response.headers.has(VINEXT_STATIC_FILE_HEADER)) {
     mergeVaryHeader(response.headers, VINEXT_RSC_VARY_HEADER);
   }
 

--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -2,6 +2,12 @@ import { getAndClearActionRevalidationKind, type ActionRevalidationKind } from "
 import type { HeadersAccessPhase } from "vinext/shims/headers";
 import { type FetchCacheMode, setCurrentFetchCacheMode } from "vinext/shims/fetch-cache";
 import type { ReactFormState } from "react-dom/client";
+import {
+  ACTION_REDIRECT_HEADER,
+  ACTION_REDIRECT_STATUS_HEADER,
+  ACTION_REDIRECT_TYPE_HEADER,
+  ACTION_REVALIDATED_HEADER,
+} from "./headers.js";
 import { VINEXT_RSC_VARY_HEADER } from "./app-rsc-cache-busting.js";
 import { resolveAppPageActionRerenderTarget } from "./app-page-request.js";
 import { mergeMiddlewareResponseHeaders } from "./middleware-response-headers.js";
@@ -208,7 +214,7 @@ const ACTION_DID_REVALIDATE_STATIC_AND_DYNAMIC = 1 satisfies ActionRevalidationK
 
 function setActionRevalidatedHeader(headers: Headers, kind: ActionRevalidationKind): void {
   if (kind === ACTION_DID_NOT_REVALIDATE) return;
-  headers.set("x-action-revalidated", JSON.stringify(kind));
+  headers.set(ACTION_REVALIDATED_HEADER, JSON.stringify(kind));
 }
 
 function resolveActionRevalidationKind(hasModifiedCookies: boolean): ActionRevalidationKind {
@@ -626,9 +632,9 @@ export async function handleServerActionRscRequest<
         Vary: VINEXT_RSC_VARY_HEADER,
       });
       mergeMiddlewareResponseHeaders(redirectHeaders, options.middlewareHeaders);
-      redirectHeaders.set("x-action-redirect", actionRedirect.url);
-      redirectHeaders.set("x-action-redirect-type", actionRedirect.type);
-      redirectHeaders.set("x-action-redirect-status", String(actionRedirect.status));
+      redirectHeaders.set(ACTION_REDIRECT_HEADER, actionRedirect.url);
+      redirectHeaders.set(ACTION_REDIRECT_TYPE_HEADER, actionRedirect.type);
+      redirectHeaders.set(ACTION_REDIRECT_STATUS_HEADER, String(actionRedirect.status));
       for (const cookie of actionPendingCookies) {
         redirectHeaders.append("Set-Cookie", cookie);
       }

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -5,6 +5,7 @@ import { matchRoute, patternToNextFormat } from "../routing/pages-router.js";
 import type { ModuleImporter } from "./instrumentation.js";
 import { importModule, reportRequestError } from "./instrumentation.js";
 import type { NextI18nConfig } from "../config/next-config.js";
+import { VINEXT_CACHE_HEADER } from "./headers.js";
 import {
   isrGet,
   isrSet,
@@ -563,7 +564,7 @@ export function createSSRHandler(
             const revalidateSecs = getRevalidateDuration(cacheKey) ?? 60;
             const hitHeaders: Record<string, string> = {
               "Content-Type": "text/html",
-              "X-Vinext-Cache": "HIT",
+              [VINEXT_CACHE_HEADER]: "HIT",
               "Cache-Control": `s-maxage=${revalidateSecs}, stale-while-revalidate`,
             };
             if (earlyFontLinkHeader) hitHeaders["Link"] = earlyFontLinkHeader;
@@ -710,7 +711,7 @@ export function createSSRHandler(
             const revalidateSecs = getRevalidateDuration(cacheKey) ?? 60;
             const staleHeaders: Record<string, string> = {
               "Content-Type": "text/html",
-              "X-Vinext-Cache": "STALE",
+              [VINEXT_CACHE_HEADER]: "STALE",
               "Cache-Control": `s-maxage=${revalidateSecs}, stale-while-revalidate`,
             };
             if (earlyFontLinkHeader) staleHeaders["Link"] = earlyFontLinkHeader;
@@ -954,7 +955,7 @@ hydrate();
           } else {
             extraHeaders["Cache-Control"] =
               `s-maxage=${isrRevalidateSeconds}, stale-while-revalidate`;
-            extraHeaders["X-Vinext-Cache"] = "MISS";
+            extraHeaders[VINEXT_CACHE_HEADER] = "MISS";
           }
         }
 

--- a/packages/vinext/src/server/headers.ts
+++ b/packages/vinext/src/server/headers.ts
@@ -102,10 +102,10 @@ export const MIDDLEWARE_NEXT_HEADER = "x-middleware-next";
 export const MIDDLEWARE_REWRITE_HEADER = "x-middleware-rewrite";
 
 /** Redirect URL set by middleware. */
-export const MIDDLEWARE_REDIRECT_HEADER = "x-middleware-redirect";
+const MIDDLEWARE_REDIRECT_HEADER = "x-middleware-redirect";
 
 /** Skip-middleware signal. */
-export const MIDDLEWARE_SKIP_HEADER = "x-middleware-skip";
+const MIDDLEWARE_SKIP_HEADER = "x-middleware-skip";
 
 /** Generic prefix for all middleware internal headers. */
 export const MIDDLEWARE_HEADER_PREFIX = "x-middleware-";
@@ -132,10 +132,10 @@ export const FLIGHT_HEADERS: readonly string[] = [
 // Vercel / Now.sh legacy internal headers (stripped from inbound requests)
 // ---------------------------------------------------------------------------
 
-export const NOW_ROUTE_MATCHES_HEADER = "x-now-route-matches";
-export const MATCHED_PATH_HEADER = "x-matched-path";
-export const NEXTJS_DATA_HEADER = "x-nextjs-data";
-export const NEXT_RESUME_STATE_LENGTH_HEADER = "x-next-resume-state-length";
+const NOW_ROUTE_MATCHES_HEADER = "x-now-route-matches";
+const MATCHED_PATH_HEADER = "x-matched-path";
+const NEXTJS_DATA_HEADER = "x-nextjs-data";
+const NEXT_RESUME_STATE_LENGTH_HEADER = "x-next-resume-state-length";
 
 // ---------------------------------------------------------------------------
 // Internal headers blocklist — stripped from inbound requests for security

--- a/packages/vinext/src/server/headers.ts
+++ b/packages/vinext/src/server/headers.ts
@@ -1,0 +1,163 @@
+/**
+ * Internal HTTP header name constants used throughout vinext.
+ *
+ * Centralizes all custom header names so they are defined once and referenced
+ * everywhere via imports. Keeping them in one module prevents typos, makes
+ * rename-refactors trivial, and lets grep find every consumer instantly.
+ *
+ * Standard HTTP headers (Content-Type, Cache-Control, etc.) are intentionally
+ * omitted — only vinext-internal and Next.js-protocol headers belong here.
+ */
+
+// ---------------------------------------------------------------------------
+// Vinext-proprietary headers (`x-vinext-*` / `X-Vinext-*`)
+// ---------------------------------------------------------------------------
+
+/** ISR / page cache state indicator: "HIT" | "MISS" | "STALE" | "STATIC". */
+export const VINEXT_CACHE_HEADER = "X-Vinext-Cache";
+
+/** Static file signal — value is URL-encoded pathname. */
+export const VINEXT_STATIC_FILE_HEADER = "x-vinext-static-file";
+
+/** Serialized middleware context (JSON) forwarded from dev server to RSC entry. */
+export const VINEXT_MW_CTX_HEADER = "x-vinext-mw-ctx";
+
+/** Timing metrics: `handlerStart,compileMs,renderMs`. */
+export const VINEXT_TIMING_HEADER = "x-vinext-timing";
+
+/** Build-time prerender authentication secret. */
+export const VINEXT_PRERENDER_SECRET_HEADER = "x-vinext-prerender-secret";
+
+/** TPR (Tailored Per-Request) revalidation interval in seconds. */
+export const VINEXT_REVALIDATE_HEADER = "x-vinext-revalidate";
+
+/** Marker on cached ISR entries indicating RSC payload (value "1"). */
+export const VINEXT_RSC_MARKER_HEADER = "x-vinext-rsc";
+
+/** URL-encoded JSON route params carried on RSC responses. */
+export const VINEXT_PARAMS_HEADER = "X-Vinext-Params";
+
+/** Deduplicated, sorted list of mounted layout slots for cache keying. */
+export const VINEXT_MOUNTED_SLOTS_HEADER = "X-Vinext-Mounted-Slots";
+
+/** Route interception context for parallel/intercepting routes. */
+export const VINEXT_INTERCEPTION_CONTEXT_HEADER = "X-Vinext-Interception-Context";
+
+/** RSC render mode (e.g. "navigation", "prefetch"). */
+export const VINEXT_RSC_RENDER_MODE_HEADER = "X-Vinext-Rsc-Render-Mode";
+
+// ---------------------------------------------------------------------------
+// RSC protocol headers
+// ---------------------------------------------------------------------------
+
+/** Standard RSC header — value "1" indicates an RSC payload request. */
+export const RSC_HEADER = "RSC";
+
+/** Server Action invocation header (vinext/vite-rsc protocol). */
+export const RSC_ACTION_HEADER = "x-rsc-action";
+
+// ---------------------------------------------------------------------------
+// Next.js compatibility headers
+// ---------------------------------------------------------------------------
+
+/** Next.js Server Action invocation header (fallback for x-rsc-action). */
+export const NEXT_ACTION_HEADER = "next-action";
+
+/** Next.js action-not-found indicator (value "1"). */
+export const NEXTJS_ACTION_NOT_FOUND_HEADER = "x-nextjs-action-not-found";
+
+// ---------------------------------------------------------------------------
+// Server Action response headers (`x-action-*`)
+// ---------------------------------------------------------------------------
+
+/** Indicates revalidation occurred — value is JSON kind (1 = path/tag, 2 = dynamic-only). */
+export const ACTION_REVALIDATED_HEADER = "x-action-revalidated";
+
+/** Redirect URL from a Server Action. */
+export const ACTION_REDIRECT_HEADER = "x-action-redirect";
+
+/** Redirect type from a Server Action ("push" | "replace"). */
+export const ACTION_REDIRECT_TYPE_HEADER = "x-action-redirect-type";
+
+/** HTTP status for a Server Action redirect (e.g. "308"). */
+export const ACTION_REDIRECT_STATUS_HEADER = "x-action-redirect-status";
+
+// ---------------------------------------------------------------------------
+// Middleware protocol headers (`x-middleware-*`)
+// ---------------------------------------------------------------------------
+
+/** Prefix for forwarded request headers (e.g. `x-middleware-request-cookie`). */
+export const MIDDLEWARE_REQUEST_HEADER_PREFIX = "x-middleware-request-";
+
+/** Comma-separated list of header names that middleware wants to override. */
+export const MIDDLEWARE_OVERRIDE_HEADERS = "x-middleware-override-headers";
+
+/** Carries cookies set by middleware for same-render reads. */
+export const MIDDLEWARE_SET_COOKIE_HEADER = "x-middleware-set-cookie";
+
+/** Signal from `NextResponse.next()` — value "1" means "continue to next handler". */
+export const MIDDLEWARE_NEXT_HEADER = "x-middleware-next";
+
+/** Rewrite destination URL set by `NextResponse.rewrite()`. */
+export const MIDDLEWARE_REWRITE_HEADER = "x-middleware-rewrite";
+
+/** Redirect URL set by middleware. */
+export const MIDDLEWARE_REDIRECT_HEADER = "x-middleware-redirect";
+
+/** Skip-middleware signal. */
+export const MIDDLEWARE_SKIP_HEADER = "x-middleware-skip";
+
+/** Generic prefix for all middleware internal headers. */
+export const MIDDLEWARE_HEADER_PREFIX = "x-middleware-";
+
+// ---------------------------------------------------------------------------
+// Next.js / RSC flight headers (forwarded through middleware)
+// ---------------------------------------------------------------------------
+
+export const NEXT_ROUTER_STATE_TREE_HEADER = "Next-Router-State-Tree";
+export const NEXT_ROUTER_PREFETCH_HEADER = "Next-Router-Prefetch";
+export const NEXT_ROUTER_SEGMENT_PREFETCH_HEADER = "Next-Router-Segment-Prefetch";
+export const NEXT_URL_HEADER = "Next-Url";
+
+/** Lowercase flight header variants used in middleware forwarding. */
+export const FLIGHT_HEADERS: readonly string[] = [
+  "rsc",
+  "next-router-state-tree",
+  "next-router-prefetch",
+  "next-hmr-refresh",
+  "next-router-segment-prefetch",
+];
+
+// ---------------------------------------------------------------------------
+// Vercel / Now.sh legacy internal headers (stripped from inbound requests)
+// ---------------------------------------------------------------------------
+
+export const NOW_ROUTE_MATCHES_HEADER = "x-now-route-matches";
+export const MATCHED_PATH_HEADER = "x-matched-path";
+export const NEXTJS_DATA_HEADER = "x-nextjs-data";
+export const NEXT_RESUME_STATE_LENGTH_HEADER = "x-next-resume-state-length";
+
+// ---------------------------------------------------------------------------
+// Internal headers blocklist — stripped from inbound requests for security
+// ---------------------------------------------------------------------------
+
+/**
+ * Headers that must be stripped from external requests before any handler
+ * processes them. An attacker could forge these to influence routing or
+ * impersonate internal data fetches.
+ *
+ * Ported from Next.js `INTERNAL_HEADERS`:
+ * https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/server-ipc/utils.ts
+ */
+export const INTERNAL_HEADERS = [
+  MIDDLEWARE_REWRITE_HEADER,
+  MIDDLEWARE_REDIRECT_HEADER,
+  MIDDLEWARE_SET_COOKIE_HEADER,
+  MIDDLEWARE_SKIP_HEADER,
+  MIDDLEWARE_OVERRIDE_HEADERS,
+  MIDDLEWARE_NEXT_HEADER,
+  NOW_ROUTE_MATCHES_HEADER,
+  MATCHED_PATH_HEADER,
+  NEXTJS_DATA_HEADER,
+  NEXT_RESUME_STATE_LENGTH_HEADER,
+];

--- a/packages/vinext/src/server/middleware-request-headers.ts
+++ b/packages/vinext/src/server/middleware-request-headers.ts
@@ -1,6 +1,8 @@
-const MIDDLEWARE_REQUEST_HEADER_PREFIX = "x-middleware-request-";
-const MIDDLEWARE_OVERRIDE_HEADERS = "x-middleware-override-headers";
-const MIDDLEWARE_SET_COOKIE_HEADER = "x-middleware-set-cookie";
+import {
+  MIDDLEWARE_OVERRIDE_HEADERS,
+  MIDDLEWARE_REQUEST_HEADER_PREFIX,
+  MIDDLEWARE_SET_COOKIE_HEADER,
+} from "./headers.js";
 const CREDENTIAL_REQUEST_HEADERS = ["authorization", "cookie"] as const;
 
 type MiddlewareHeaderValue = string | string[];

--- a/packages/vinext/src/server/middleware-runtime.ts
+++ b/packages/vinext/src/server/middleware-runtime.ts
@@ -7,6 +7,11 @@ import {
 } from "vinext/shims/request-context";
 import { NextFetchEvent, NextRequest } from "vinext/shims/server";
 import { normalizePath } from "./normalize-path.js";
+import {
+  MIDDLEWARE_HEADER_PREFIX,
+  MIDDLEWARE_NEXT_HEADER,
+  MIDDLEWARE_REWRITE_HEADER,
+} from "./headers.js";
 import { MatcherConfig, matchesMiddleware } from "./middleware-matcher.js";
 import { shouldKeepMiddlewareHeader } from "./middleware-request-headers.js";
 import { processMiddlewareHeaders } from "./request-pipeline.js";
@@ -100,7 +105,7 @@ function stripMiddlewareHeadersFromResponse(response: Response): Response {
 function collectMiddlewareHeaders(response: Response): Headers {
   const responseHeaders = new Headers();
   for (const [key, value] of response.headers) {
-    if (!key.startsWith("x-middleware-") || shouldKeepMiddlewareHeader(key)) {
+    if (!key.startsWith(MIDDLEWARE_HEADER_PREFIX) || shouldKeepMiddlewareHeader(key)) {
       responseHeaders.append(key, value);
     }
   }
@@ -208,7 +213,7 @@ export async function executeMiddleware(
     return { continue: true, waitUntilPromises };
   }
 
-  if (response.headers.get("x-middleware-next") === "1") {
+  if (response.headers.get(MIDDLEWARE_NEXT_HEADER) === "1") {
     return {
       continue: true,
       responseHeaders: collectMiddlewareHeaders(response),
@@ -222,7 +227,7 @@ export async function executeMiddleware(
     if (location) {
       const responseHeaders = new Headers();
       for (const [key, value] of response.headers) {
-        if (!key.startsWith("x-middleware-") && key.toLowerCase() !== "location") {
+        if (!key.startsWith(MIDDLEWARE_HEADER_PREFIX) && key.toLowerCase() !== "location") {
           responseHeaders.append(key, value);
         }
       }
@@ -237,7 +242,7 @@ export async function executeMiddleware(
     }
   }
 
-  const rewriteUrl = response.headers.get("x-middleware-rewrite");
+  const rewriteUrl = response.headers.get(MIDDLEWARE_REWRITE_HEADER);
   if (rewriteUrl) {
     let rewritePath: string;
     try {

--- a/packages/vinext/src/server/pages-page-data.ts
+++ b/packages/vinext/src/server/pages-page-data.ts
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import type { Route } from "../routing/pages-router.js";
 import type { CachedPagesValue, CacheControlMetadata } from "vinext/shims/cache";
 import { buildCachedRevalidateCacheControl } from "./cache-control.js";
+import { VINEXT_CACHE_HEADER } from "./headers.js";
 import { buildPagesCacheValue, type ISRCacheEntry } from "./isr-cache.js";
 import {
   buildPagesNextDataScript,
@@ -172,7 +173,7 @@ function buildPagesCacheResponse(
     cacheControl === undefined ? undefined : (cacheControl.expire ?? expireSeconds);
   const headers: Record<string, string> = {
     "Content-Type": "text/html",
-    "X-Vinext-Cache": cacheState,
+    [VINEXT_CACHE_HEADER]: cacheState,
     "Cache-Control": buildCachedRevalidateCacheControl(
       cacheState,
       effectiveRevalidateSeconds,

--- a/packages/vinext/src/server/pages-page-response.ts
+++ b/packages/vinext/src/server/pages-page-response.ts
@@ -3,6 +3,7 @@ import type { CachedPagesValue } from "vinext/shims/cache";
 import { withScriptNonce } from "vinext/shims/script-nonce-context";
 import { getRequestExecutionContext } from "vinext/shims/request-context";
 import { buildRevalidateCacheControl } from "./cache-control.js";
+import { VINEXT_CACHE_HEADER } from "./headers.js";
 import { createInlineScriptTag, createNonceAttribute, escapeHtmlAttr } from "./html.js";
 import { reportRequestError } from "./instrumentation.js";
 import { readStreamAsText } from "../utils/text-stream.js";
@@ -366,7 +367,7 @@ export async function renderPagesPageResponse(
       "Cache-Control",
       buildRevalidateCacheControl(options.isrRevalidateSeconds, options.expireSeconds),
     );
-    responseHeaders.set("X-Vinext-Cache", "MISS");
+    responseHeaders.set(VINEXT_CACHE_HEADER, "MISS");
   }
   if (options.fontLinkHeader) {
     responseHeaders.set("Link", options.fontLinkHeader);

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -57,6 +57,7 @@ import { manifestFileWithBase } from "../utils/manifest-paths.js";
 import { normalizePathnameForRouteMatchStrict } from "../routing/utils.js";
 import type { ExecutionContextLike } from "vinext/shims/request-context";
 import { readPrerenderSecret } from "../build/server-manifest.js";
+import { VINEXT_PRERENDER_SECRET_HEADER, VINEXT_STATIC_FILE_HEADER } from "./headers.js";
 import { seedMemoryCacheFromPrerender } from "./seed-cache.js";
 import { installSocketErrorBackstop } from "./socket-error-backstop.js";
 
@@ -1015,7 +1016,7 @@ async function startAppRouterServer(options: AppRouterServerOptions) {
       pathname === "/__vinext/prerender/static-params" ||
       pathname === "/__vinext/prerender/pages-static-paths"
     ) {
-      const secret = req.headers["x-vinext-prerender-secret"];
+      const secret = req.headers[VINEXT_PRERENDER_SECRET_HEADER];
       if (!prerenderSecret || secret !== prerenderSecret) {
         res.writeHead(403);
         res.end("Forbidden");
@@ -1094,7 +1095,7 @@ async function startAppRouterServer(options: AppRouterServerOptions) {
       const request = nodeToWebRequest(req, normalizedUrl);
       const response = await rscHandler(request);
 
-      const staticFileSignal = response.headers.get("x-vinext-static-file");
+      const staticFileSignal = response.headers.get(VINEXT_STATIC_FILE_HEADER);
       if (staticFileSignal) {
         let staticFilePath = "/";
         try {
@@ -1105,7 +1106,7 @@ async function startAppRouterServer(options: AppRouterServerOptions) {
 
         const staticResponseHeaders = omitHeadersCaseInsensitive(
           mergeResponseHeaders({}, response),
-          ["x-vinext-static-file", "content-encoding", "content-length", "content-type"],
+          [VINEXT_STATIC_FILE_HEADER, "content-encoding", "content-length", "content-type"],
         );
 
         const served = await tryServeStatic(
@@ -1307,7 +1308,7 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
     // Internal prerender endpoint — only reachable with the correct build-time secret.
     // Used by the prerender phase to fetch getStaticPaths results via HTTP.
     if (pathname === "/__vinext/prerender/pages-static-paths") {
-      const secret = req.headers["x-vinext-prerender-secret"];
+      const secret = req.headers[VINEXT_PRERENDER_SECRET_HEADER];
       if (!prerenderSecret || secret !== prerenderSecret) {
         res.writeHead(403);
         res.end("Forbidden");

--- a/packages/vinext/src/server/request-pipeline.ts
+++ b/packages/vinext/src/server/request-pipeline.ts
@@ -2,6 +2,11 @@ import { hasBasePath, stripBasePath, removeTrailingSlash } from "../utils/base-p
 import type { NextHeader } from "../config/next-config.js";
 import type { RequestContext } from "../config/config-matchers.js";
 import { matchHeaders } from "../config/config-matchers.js";
+import {
+  INTERNAL_HEADERS as INTERNAL_HEADERS_CONSTANTS,
+  MIDDLEWARE_HEADER_PREFIX,
+  VINEXT_STATIC_FILE_HEADER,
+} from "./headers.js";
 import { forbiddenResponse, notFoundResponse } from "./http-error-responses.js";
 
 /**
@@ -208,7 +213,7 @@ export function createStaticFileSignal(
   context: StaticFileSignalContext,
 ): Response {
   const headers = new Headers({
-    "x-vinext-static-file": encodeURIComponent(pathname),
+    [VINEXT_STATIC_FILE_HEADER]: encodeURIComponent(pathname),
   });
   if (context.headers) {
     for (const [key, value] of context.headers) {
@@ -540,7 +545,7 @@ export function processMiddlewareHeaders(headers: Headers): void {
   const keysToDelete: string[] = [];
 
   for (const key of headers.keys()) {
-    if (key.startsWith("x-middleware-")) {
+    if (key.startsWith(MIDDLEWARE_HEADER_PREFIX)) {
       keysToDelete.push(key);
     }
   }
@@ -555,25 +560,9 @@ export function processMiddlewareHeaders(headers: Headers): void {
  * from external requests. An attacker could forge these to influence routing
  * or impersonate internal data fetches.
  *
- * Ported from Next.js `INTERNAL_HEADERS`:
- * https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/server-ipc/utils.ts
- *
- * Next.js strips these via `filterInternalHeaders()` at the router-server
- * entry point before any handler sees the request:
- * https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/router-server.ts
+ * @see {@link INTERNAL_HEADERS_CONSTANTS} in `./headers.ts` for the canonical definition.
  */
-export const INTERNAL_HEADERS = [
-  "x-middleware-rewrite",
-  "x-middleware-redirect",
-  "x-middleware-set-cookie",
-  "x-middleware-skip",
-  "x-middleware-override-headers",
-  "x-middleware-next",
-  "x-now-route-matches",
-  "x-matched-path",
-  "x-nextjs-data",
-  "x-next-resume-state-length",
-];
+export const INTERNAL_HEADERS = INTERNAL_HEADERS_CONSTANTS;
 
 type RequestInitWithCf = RequestInit & { cf?: unknown };
 

--- a/packages/vinext/src/server/request-pipeline.ts
+++ b/packages/vinext/src/server/request-pipeline.ts
@@ -3,7 +3,7 @@ import type { NextHeader } from "../config/next-config.js";
 import type { RequestContext } from "../config/config-matchers.js";
 import { matchHeaders } from "../config/config-matchers.js";
 import {
-  INTERNAL_HEADERS as INTERNAL_HEADERS_CONSTANTS,
+  INTERNAL_HEADERS,
   MIDDLEWARE_HEADER_PREFIX,
   VINEXT_STATIC_FILE_HEADER,
 } from "./headers.js";
@@ -560,9 +560,9 @@ export function processMiddlewareHeaders(headers: Headers): void {
  * from external requests. An attacker could forge these to influence routing
  * or impersonate internal data fetches.
  *
- * @see {@link INTERNAL_HEADERS_CONSTANTS} in `./headers.ts` for the canonical definition.
+ * @see `./headers.ts` for the canonical definition.
  */
-export const INTERNAL_HEADERS = INTERNAL_HEADERS_CONSTANTS;
+export { INTERNAL_HEADERS } from "./headers.js";
 
 type RequestInitWithCf = RequestInit & { cf?: unknown };
 

--- a/packages/vinext/src/server/server-action-not-found.ts
+++ b/packages/vinext/src/server/server-action-not-found.ts
@@ -1,7 +1,9 @@
+import { NEXTJS_ACTION_NOT_FOUND_HEADER } from "./headers.js";
+
 const SERVER_ACTION_NOT_FOUND_DOCS =
   "https://nextjs.org/docs/messages/failed-to-find-server-action";
 
-const SERVER_ACTION_NOT_FOUND_HEADER = "x-nextjs-action-not-found";
+const SERVER_ACTION_NOT_FOUND_HEADER = NEXTJS_ACTION_NOT_FOUND_HEADER;
 const SERVER_ACTION_NOT_FOUND_BODY = "Server action not found.";
 
 function getServerActionNotFoundPrefix(actionId: string | null): string {

--- a/packages/vinext/src/server/server-action-not-found.ts
+++ b/packages/vinext/src/server/server-action-not-found.ts
@@ -1,9 +1,7 @@
-import { NEXTJS_ACTION_NOT_FOUND_HEADER } from "./headers.js";
+import { NEXTJS_ACTION_NOT_FOUND_HEADER as SERVER_ACTION_NOT_FOUND_HEADER } from "./headers.js";
 
 const SERVER_ACTION_NOT_FOUND_DOCS =
   "https://nextjs.org/docs/messages/failed-to-find-server-action";
-
-const SERVER_ACTION_NOT_FOUND_HEADER = NEXTJS_ACTION_NOT_FOUND_HEADER;
 const SERVER_ACTION_NOT_FOUND_BODY = "Server action not found.";
 
 function getServerActionNotFoundPrefix(actionId: string | null): string {

--- a/packages/vinext/src/server/worker-utils.ts
+++ b/packages/vinext/src/server/worker-utils.ts
@@ -5,6 +5,7 @@
  * "vinext/server/worker-utils". The generated worker entry (deploy.ts)
  * inlines these functions in its template string.
  */
+import { VINEXT_STATIC_FILE_HEADER } from "./headers.js";
 
 /**
  * Merge middleware/config headers into a response.
@@ -115,7 +116,7 @@ export async function resolveStaticAssetSignal(
     fetchAsset(path: string): Promise<Response>;
   },
 ): Promise<Response | null> {
-  const signal = signalResponse.headers.get("x-vinext-static-file");
+  const signal = signalResponse.headers.get(VINEXT_STATIC_FILE_HEADER);
   if (!signal) return null;
 
   let assetPath = "/";
@@ -126,7 +127,7 @@ export async function resolveStaticAssetSignal(
   }
 
   const extraHeaders = buildHeaderRecord(signalResponse, [
-    "x-vinext-static-file",
+    VINEXT_STATIC_FILE_HEADER,
     "content-encoding",
     "content-length",
     "content-type",

--- a/packages/vinext/src/shims/cache-runtime.ts
+++ b/packages/vinext/src/shims/cache-runtime.ts
@@ -36,6 +36,7 @@ import {
   type CacheControlMetadata,
   type CacheLifeConfig,
 } from "./cache.js";
+import { VINEXT_RSC_MARKER_HEADER } from "../server/headers.js";
 import { getOrCreateAls } from "./internal/als-registry.js";
 import {
   isInsideUnifiedScope,
@@ -409,7 +410,7 @@ export function registerCachedFunction<T extends (...args: any[]) => Promise<any
     const existing = await handler.get(cacheKey, { kind: "FETCH" });
     if (existing?.value && existing.value.kind === "FETCH" && existing.cacheState !== "stale") {
       try {
-        if (rsc && existing.value.data.headers["x-vinext-rsc"] === "1") {
+        if (rsc && existing.value.data.headers[VINEXT_RSC_MARKER_HEADER] === "1") {
           // RSC-serialized entry: base64 → bytes → stream → deserialize
           const bytes = base64ToUint8(existing.value.data.body);
           const stream = uint8ToStream(bytes);
@@ -454,7 +455,7 @@ export function registerCachedFunction<T extends (...args: any[]) => Promise<any
         const stream = rsc.renderToReadableStream(result);
         const bytes = await collectStream(stream);
         body = uint8ToBase64(bytes);
-        headers["x-vinext-rsc"] = "1";
+        headers[VINEXT_RSC_MARKER_HEADER] = "1";
       } else {
         // JSON fallback
         body = JSON.stringify(result);

--- a/packages/vinext/src/shims/headers.ts
+++ b/packages/vinext/src/shims/headers.ts
@@ -9,6 +9,7 @@
  */
 
 import type { AsyncLocalStorage } from "node:async_hooks";
+import { MIDDLEWARE_SET_COOKIE_HEADER } from "../server/headers.js";
 import { buildRequestHeadersFromMiddlewareResponse } from "../server/middleware-request-headers.js";
 import { getOrCreateAls } from "./internal/als-registry.js";
 import {
@@ -69,7 +70,6 @@ const _fallbackState = (_g[_FALLBACK_KEY] ??= {
   phase: "render",
 } satisfies VinextHeadersShimState) as VinextHeadersShimState;
 const EXPIRED_COOKIE_DATE = new Date(0).toUTCString();
-const MIDDLEWARE_SET_COOKIE_HEADER = "x-middleware-set-cookie";
 
 function splitMiddlewareSetCookieHeader(value: string): string[] {
   const cookies: string[] = [];

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -28,11 +28,8 @@ import {
   prefetchRscResponse,
 } from "./navigation.js";
 import { AppElementsWire } from "../server/app-elements.js";
-import {
-  createRscRequestHeaders,
-  createRscRequestUrl,
-  VINEXT_RSC_MOUNTED_SLOTS_HEADER,
-} from "../server/app-rsc-cache-busting.js";
+import { createRscRequestHeaders, createRscRequestUrl } from "../server/app-rsc-cache-busting.js";
+import { VINEXT_MOUNTED_SLOTS_HEADER } from "../server/headers.js";
 import { isDangerousScheme } from "./url-safety.js";
 import {
   resolveRelativeHref,
@@ -140,7 +137,7 @@ function prefetchUrl(href: string): void {
         const mountedSlotsHeader = getMountedSlotsHeader();
         const headers = createRscRequestHeaders({ interceptionContext });
         if (mountedSlotsHeader) {
-          headers.set(VINEXT_RSC_MOUNTED_SLOTS_HEADER, mountedSlotsHeader);
+          headers.set(VINEXT_MOUNTED_SLOTS_HEADER, mountedSlotsHeader);
         }
         // Distinguish the same visible URL when it is prefetched from different
         // request contexts such as /feed vs /gallery or different mounted slots.

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -13,11 +13,8 @@
 import * as React from "react";
 import { notifyAppRouterTransitionStart } from "../client/instrumentation-client-state.js";
 import { AppElementsWire } from "../server/app-elements.js";
-import {
-  createRscRequestHeaders,
-  createRscRequestUrl,
-  VINEXT_RSC_MOUNTED_SLOTS_HEADER,
-} from "../server/app-rsc-cache-busting.js";
+import { createRscRequestHeaders, createRscRequestUrl } from "../server/app-rsc-cache-busting.js";
+import { VINEXT_MOUNTED_SLOTS_HEADER, VINEXT_PARAMS_HEADER } from "../server/headers.js";
 import {
   isHashOnlyBrowserUrlChange,
   toBrowserNavigationHref,
@@ -415,8 +412,8 @@ export async function snapshotRscResponse(response: Response): Promise<CachedRsc
   return {
     buffer,
     contentType: response.headers.get("content-type") ?? "text/x-component",
-    mountedSlotsHeader: response.headers.get("X-Vinext-Mounted-Slots"),
-    paramsHeader: response.headers.get("X-Vinext-Params"),
+    mountedSlotsHeader: response.headers.get(VINEXT_MOUNTED_SLOTS_HEADER),
+    paramsHeader: response.headers.get(VINEXT_PARAMS_HEADER),
     url: response.url,
   };
 }
@@ -439,10 +436,10 @@ export async function snapshotRscResponse(response: Response): Promise<CachedRsc
 export function restoreRscResponse(cached: CachedRscResponse, copy = true): Response {
   const headers = new Headers({ "content-type": cached.contentType });
   if (cached.mountedSlotsHeader != null) {
-    headers.set("X-Vinext-Mounted-Slots", cached.mountedSlotsHeader);
+    headers.set(VINEXT_MOUNTED_SLOTS_HEADER, cached.mountedSlotsHeader);
   }
   if (cached.paramsHeader != null) {
-    headers.set("X-Vinext-Params", cached.paramsHeader);
+    headers.set(VINEXT_PARAMS_HEADER, cached.paramsHeader);
   }
 
   return new Response(copy ? cached.buffer.slice(0) : cached.buffer, {
@@ -1293,7 +1290,7 @@ const _appRouter = {
       const mountedSlotsHeader = getMountedSlotsHeader();
       const headers = createRscRequestHeaders({ interceptionContext });
       if (mountedSlotsHeader) {
-        headers.set(VINEXT_RSC_MOUNTED_SLOTS_HEADER, mountedSlotsHeader);
+        headers.set(VINEXT_MOUNTED_SLOTS_HEADER, mountedSlotsHeader);
       }
       const rscUrl = await createRscRequestUrl(fullHref, headers);
       const cacheKey = AppElementsWire.encodeCacheKey(rscUrl, interceptionContext);

--- a/packages/vinext/src/shims/server.ts
+++ b/packages/vinext/src/shims/server.ts
@@ -9,6 +9,11 @@
  * rather than bug-for-bug parity with Next.js internals.
  */
 
+import {
+  MIDDLEWARE_NEXT_HEADER,
+  MIDDLEWARE_REWRITE_HEADER,
+  MIDDLEWARE_SET_COOKIE_HEADER,
+} from "../server/headers.js";
 import { encodeMiddlewareRequestHeaders } from "../server/middleware-request-headers.js";
 import { serializeSetCookie, validateCookieName } from "./internal/cookie-serialize.js";
 import { parseCookieHeader } from "./internal/parse-cookie-header.js";
@@ -248,7 +253,7 @@ export class NextResponse<_Body = unknown> extends Response {
    */
   static rewrite(destination: string | URL, init?: MiddlewareResponseInit): NextResponse {
     const headers = new Headers(init?.headers);
-    headers.set("x-middleware-rewrite", validateURL(destination));
+    headers.set(MIDDLEWARE_REWRITE_HEADER, validateURL(destination));
     if (init?.request?.headers) {
       encodeMiddlewareRequestHeaders(headers, init.request.headers);
     }
@@ -261,7 +266,7 @@ export class NextResponse<_Body = unknown> extends Response {
    */
   static next(init?: MiddlewareResponseInit): NextResponse {
     const headers = new Headers(init?.headers);
-    headers.set("x-middleware-next", "1");
+    headers.set(MIDDLEWARE_NEXT_HEADER, "1");
     if (init?.request?.headers) {
       encodeMiddlewareRequestHeaders(headers, init.request.headers);
     }
@@ -760,11 +765,11 @@ class MiddlewareResponseCookies extends ResponseCookies {
   private _syncMiddlewareCookieHeader(): void {
     const cookies = this._responseHeaders.getSetCookie();
     if (cookies.length === 0) {
-      this._responseHeaders.delete("x-middleware-set-cookie");
+      this._responseHeaders.delete(MIDDLEWARE_SET_COOKIE_HEADER);
       return;
     }
 
-    this._responseHeaders.set("x-middleware-set-cookie", cookies.join(","));
+    this._responseHeaders.set(MIDDLEWARE_SET_COOKIE_HEADER, cookies.join(","));
   }
 }
 


### PR DESCRIPTION
## Summary

- Adds `packages/vinext/src/server/headers.ts` as the single source of truth for all ~40 internal HTTP header name constants
- Updates 29 consumer files across `server/`, `shims/`, `config/`, `cloudflare/`, `build/`, and `index.ts` to import from the shared module instead of using string literals
- Preserves backward-compatible re-exports from `app-rsc-cache-busting.ts`, `app-middleware.ts`, and `request-pipeline.ts`

## Motivation

Internal header strings like `x-vinext-cache`, `x-middleware-next`, `x-action-redirect`, etc. were duplicated across ~30 files as raw string literals. This made typos possible, renames difficult, and it was hard to grep for all consumers of a given header.

## Details

The new `headers.ts` module organizes constants into categories:

| Category | Examples |
|---|---|
| Vinext-proprietary (`x-vinext-*`) | `VINEXT_CACHE_HEADER`, `VINEXT_STATIC_FILE_HEADER`, `VINEXT_MW_CTX_HEADER` |
| RSC protocol | `RSC_HEADER`, `RSC_ACTION_HEADER` |
| Next.js compatibility | `NEXT_ACTION_HEADER`, `NEXTJS_ACTION_NOT_FOUND_HEADER` |
| Server Action response (`x-action-*`) | `ACTION_REDIRECT_HEADER`, `ACTION_REVALIDATED_HEADER` |
| Middleware protocol (`x-middleware-*`) | `MIDDLEWARE_NEXT_HEADER`, `MIDDLEWARE_REWRITE_HEADER` |
| Flight headers | `FLIGHT_HEADERS`, `NEXT_ROUTER_STATE_TREE_HEADER` |
| Security blocklist | `INTERNAL_HEADERS` (composed from the constants above) |

Standard HTTP headers (Content-Type, Cache-Control, etc.) are intentionally omitted.

## Testing

- `vp check` passes (formatting, linting, type checking)
- 1,682 tests pass across shims, routing, app-router, ISR cache, and features test suites