### PR TITLE
feat(app-router): promote segment reset semantics

### DIFF
--- a/packages/vinext/src/server/app-page-route-wiring.tsx
+++ b/packages/vinext/src/server/app-page-route-wiring.tsx
@@ -24,6 +24,13 @@ import {
   shouldSuppressLoadingBoundaries,
   type AppRscRenderMode,
 } from "./app-rsc-render-mode.js";
+import {
+  resolveAppPageChildSegments,
+  resolveAppPageLeafSegmentStateKey,
+  resolveAppPageSegmentStateKey,
+} from "./app-page-segment-state.js";
+
+export { resolveAppPageChildSegments } from "./app-page-segment-state.js";
 
 type AppPageComponentProps = {
   children?: ReactNode;
@@ -250,75 +257,6 @@ function createAppPageErrorEntries<TErrorModule extends AppPageErrorModule>(
   });
 }
 
-export function resolveAppPageChildSegments(
-  routeSegments: readonly string[],
-  treePosition: number,
-  params: AppPageParams,
-): string[] {
-  const rawSegments = routeSegments.slice(treePosition);
-  const resolvedSegments: string[] = [];
-
-  for (const segment of rawSegments) {
-    if (
-      segment.startsWith("[[...") &&
-      segment.endsWith("]]") &&
-      segment.length > "[[...x]]".length - 1
-    ) {
-      const paramName = segment.slice(5, -2);
-      const paramValue = params[paramName];
-      if (Array.isArray(paramValue) && paramValue.length === 0) {
-        continue;
-      }
-      if (paramValue === undefined) {
-        continue;
-      }
-      resolvedSegments.push(Array.isArray(paramValue) ? paramValue.join("/") : paramValue);
-      continue;
-    }
-
-    if (segment.startsWith("[...") && segment.endsWith("]")) {
-      const paramName = segment.slice(4, -1);
-      const paramValue = params[paramName];
-      if (Array.isArray(paramValue)) {
-        resolvedSegments.push(paramValue.join("/"));
-        continue;
-      }
-      resolvedSegments.push(paramValue ?? segment);
-      continue;
-    }
-
-    if (segment.startsWith("[") && segment.endsWith("]") && !segment.includes(".")) {
-      const paramName = segment.slice(1, -1);
-      const paramValue = params[paramName];
-      resolvedSegments.push(
-        Array.isArray(paramValue) ? paramValue.join("/") : (paramValue ?? segment),
-      );
-      continue;
-    }
-
-    resolvedSegments.push(segment);
-  }
-
-  return resolvedSegments;
-}
-
-function resolveAppPageVisibleSegments(
-  routeSegments: readonly string[],
-  params: AppPageParams,
-): string[] {
-  const resolvedSegments = resolveAppPageChildSegments(routeSegments, 0, params);
-  return resolvedSegments.filter((segment) => !(segment.startsWith("(") && segment.endsWith(")")));
-}
-
-function resolveAppPageTemplateKey(
-  routeSegments: readonly string[],
-  treePosition: number,
-  params: AppPageParams,
-): string {
-  const visibleSegments = resolveAppPageVisibleSegments(routeSegments.slice(treePosition), params);
-  return visibleSegments[0] ?? "";
-}
-
 function createAppPageParallelSlotEntries<
   TModule extends AppPageModule,
   TErrorModule extends AppPageErrorModule,
@@ -368,6 +306,8 @@ export function buildAppPageElements<
   TErrorModule extends AppPageErrorModule,
 >(options: BuildAppPageElementsOptions<TModule, TErrorModule>): AppElements {
   const interceptionContext = options.interceptionContext ?? null;
+  const routeSegments = options.route.routeSegments ?? [];
+  const routeResetKey = resolveAppPageLeafSegmentStateKey(routeSegments, options.matchedParams);
   const routeId = AppElementsWire.encodeRouteId(options.routePath, interceptionContext);
   const pageId = AppElementsWire.encodePageId(options.routePath, interceptionContext);
   const layoutEntries = createAppPageLayoutEntries(options.route);
@@ -537,6 +477,8 @@ export function buildAppPageElements<
     const slotId = AppElementsWire.encodeSlotId(slotName, treePath);
     const slotOverride = resolveSlotOverride(slotKey, slotName);
     const slotParams = getEffectiveSlotParams(slotKey, slotName);
+    const slotRouteSegments = slot.routeSegments ?? [];
+    const slotResetKey = resolveAppPageLeafSegmentStateKey(slotRouteSegments, slotParams);
     const overrideOrPageComponent =
       getDefaultExport(slotOverride?.pageModule) ?? getDefaultExport(slot.page);
     const defaultComponent = getDefaultExport(slot.default);
@@ -600,12 +542,20 @@ export function buildAppPageElements<
       !shouldSuppressLoadingBoundaries(options.renderMode ?? APP_RSC_RENDER_MODE_NAVIGATION)
     ) {
       const SlotLoadingComponent = slotLoadingComponent;
-      slotElement = <Suspense fallback={<SlotLoadingComponent />}>{slotElement}</Suspense>;
+      slotElement = (
+        <Suspense key={slotResetKey} fallback={<SlotLoadingComponent />}>
+          {slotElement}
+        </Suspense>
+      );
     }
 
     const slotErrorComponent = getErrorBoundaryExport(slot.error);
     if (slotErrorComponent) {
-      slotElement = <ErrorBoundary fallback={slotErrorComponent}>{slotElement}</ErrorBoundary>;
+      slotElement = (
+        <ErrorBoundary resetKey={slotResetKey} fallback={slotErrorComponent}>
+          {slotElement}
+        </ErrorBoundary>
+      );
     }
 
     elements[slotId] = renderAfterAppDependencies(
@@ -646,15 +596,10 @@ export function buildAppPageElements<
     !shouldSuppressLoadingBoundaries(options.renderMode ?? APP_RSC_RENDER_MODE_NAVIGATION)
   ) {
     const RouteLoadingComponent = routeLoadingComponent;
-    // Key the Suspense by pageId so cross-route navigations produce a fresh
-    // Suspense identity. Without this, React's transition behavior matches
-    // the old and new route's Suspense by position and keeps showing the
-    // old UI while the new page's data fetches — the loading.tsx fallback
-    // never paints. Same route renders (refresh, search-param changes)
-    // share the pageId, so the existing Suspense is preserved and fallback
-    // doesn't flash unnecessarily.
+    // Next.js keys loading.tsx to the active segment state key. Dynamic param
+    // changes reset the pending boundary, while search-only changes preserve it.
     routeChildren = (
-      <Suspense key={pageId} fallback={<RouteLoadingComponent />}>
+      <Suspense key={routeResetKey} fallback={<RouteLoadingComponent />}>
         {routeChildren}
       </Suspense>
     );
@@ -669,7 +614,9 @@ export function buildAppPageElements<
   if (notFoundComponent) {
     const NotFoundComponent = notFoundComponent;
     routeChildren = (
-      <NotFoundBoundary fallback={<NotFoundComponent />}>{routeChildren}</NotFoundBoundary>
+      <NotFoundBoundary resetKey={routeResetKey} fallback={<NotFoundComponent />}>
+        {routeChildren}
+      </NotFoundBoundary>
     );
   }
 
@@ -678,7 +625,9 @@ export function buildAppPageElements<
   if (forbiddenComponent) {
     const ForbiddenComponent = forbiddenComponent;
     routeChildren = (
-      <ForbiddenBoundary fallback={<ForbiddenComponent />}>{routeChildren}</ForbiddenBoundary>
+      <ForbiddenBoundary resetKey={routeResetKey} fallback={<ForbiddenComponent />}>
+        {routeChildren}
+      </ForbiddenBoundary>
     );
   }
 
@@ -688,7 +637,7 @@ export function buildAppPageElements<
   if (unauthorizedComponent) {
     const UnauthorizedComponent = unauthorizedComponent;
     routeChildren = (
-      <UnauthorizedBoundary fallback={<UnauthorizedComponent />}>
+      <UnauthorizedBoundary resetKey={routeResetKey} fallback={<UnauthorizedComponent />}>
         {routeChildren}
       </UnauthorizedBoundary>
     );
@@ -696,11 +645,20 @@ export function buildAppPageElements<
 
   const pageErrorComponent = getErrorBoundaryExport(options.route.error);
   if (pageErrorComponent && options.route.error !== lastLayoutErrorModule) {
-    routeChildren = <ErrorBoundary fallback={pageErrorComponent}>{routeChildren}</ErrorBoundary>;
+    routeChildren = (
+      <ErrorBoundary resetKey={routeResetKey} fallback={pageErrorComponent}>
+        {routeChildren}
+      </ErrorBoundary>
+    );
   }
 
   for (let index = orderedTreePositions.length - 1; index >= 0; index--) {
     const treePosition = orderedTreePositions[index];
+    const segmentResetKey = resolveAppPageSegmentStateKey(
+      routeSegments,
+      treePosition,
+      options.matchedParams,
+    );
     let segmentChildren: ReactNode = routeChildren;
     const layoutEntry = layoutEntriesByTreePosition.get(treePosition);
     const templateEntry = templateEntriesByTreePosition.get(treePosition);
@@ -714,7 +672,7 @@ export function buildAppPageElements<
       if (layoutNotFoundComponent) {
         const LayoutNotFoundComponent = layoutNotFoundComponent;
         segmentChildren = (
-          <NotFoundBoundary fallback={<LayoutNotFoundComponent />}>
+          <NotFoundBoundary resetKey={segmentResetKey} fallback={<LayoutNotFoundComponent />}>
             {segmentChildren}
           </NotFoundBoundary>
         );
@@ -724,7 +682,7 @@ export function buildAppPageElements<
       if (layoutForbiddenComponent) {
         const LayoutForbiddenComponent = layoutForbiddenComponent;
         segmentChildren = (
-          <ForbiddenBoundary fallback={<LayoutForbiddenComponent />}>
+          <ForbiddenBoundary resetKey={segmentResetKey} fallback={<LayoutForbiddenComponent />}>
             {segmentChildren}
           </ForbiddenBoundary>
         );
@@ -734,7 +692,10 @@ export function buildAppPageElements<
       if (layoutUnauthorizedComponent) {
         const LayoutUnauthorizedComponent = layoutUnauthorizedComponent;
         segmentChildren = (
-          <UnauthorizedBoundary fallback={<LayoutUnauthorizedComponent />}>
+          <UnauthorizedBoundary
+            resetKey={segmentResetKey}
+            fallback={<LayoutUnauthorizedComponent />}
+          >
             {segmentChildren}
           </UnauthorizedBoundary>
         );
@@ -746,20 +707,15 @@ export function buildAppPageElements<
     );
     if (segmentErrorComponent) {
       segmentChildren = (
-        <ErrorBoundary fallback={segmentErrorComponent}>{segmentChildren}</ErrorBoundary>
+        <ErrorBoundary resetKey={segmentResetKey} fallback={segmentErrorComponent}>
+          {segmentChildren}
+        </ErrorBoundary>
       );
     }
 
     if (templateEntry && getDefaultExport(templateEntry.templateModule)) {
       segmentChildren = (
-        <Slot
-          id={templateEntry.id}
-          key={resolveAppPageTemplateKey(
-            options.route.routeSegments ?? [],
-            templateEntry.treePosition,
-            options.matchedParams,
-          )}
-        >
+        <Slot id={templateEntry.id} key={segmentResetKey}>
           {segmentChildren}
         </Slot>
       );
@@ -773,7 +729,7 @@ export function buildAppPageElements<
     const layoutIndex = layoutIndicesByTreePosition.get(treePosition) ?? -1;
     const segmentMap: { children: string[] } & Record<string, string[]> = {
       children: resolveAppPageChildSegments(
-        options.route.routeSegments ?? [],
+        routeSegments,
         layoutEntry.treePosition,
         options.matchedParams,
       ),

--- a/packages/vinext/src/server/app-page-route-wiring.tsx
+++ b/packages/vinext/src/server/app-page-route-wiring.tsx
@@ -26,7 +26,7 @@ import {
 } from "./app-rsc-render-mode.js";
 import {
   resolveAppPageChildSegments,
-  resolveAppPageLeafSegmentStateKey,
+  resolveAppPageRouteStateKey,
   resolveAppPageSegmentStateKey,
 } from "./app-page-segment-state.js";
 
@@ -307,7 +307,7 @@ export function buildAppPageElements<
 >(options: BuildAppPageElementsOptions<TModule, TErrorModule>): AppElements {
   const interceptionContext = options.interceptionContext ?? null;
   const routeSegments = options.route.routeSegments ?? [];
-  const routeResetKey = resolveAppPageLeafSegmentStateKey(routeSegments, options.matchedParams);
+  const routeResetKey = resolveAppPageRouteStateKey(routeSegments, options.matchedParams);
   const routeId = AppElementsWire.encodeRouteId(options.routePath, interceptionContext);
   const pageId = AppElementsWire.encodePageId(options.routePath, interceptionContext);
   const layoutEntries = createAppPageLayoutEntries(options.route);
@@ -478,7 +478,7 @@ export function buildAppPageElements<
     const slotOverride = resolveSlotOverride(slotKey, slotName);
     const slotParams = getEffectiveSlotParams(slotKey, slotName);
     const slotRouteSegments = slot.routeSegments ?? [];
-    const slotResetKey = resolveAppPageLeafSegmentStateKey(slotRouteSegments, slotParams);
+    const slotResetKey = resolveAppPageRouteStateKey(slotRouteSegments, slotParams);
     const overrideOrPageComponent =
       getDefaultExport(slotOverride?.pageModule) ?? getDefaultExport(slot.page);
     const defaultComponent = getDefaultExport(slot.default);
@@ -596,8 +596,10 @@ export function buildAppPageElements<
     !shouldSuppressLoadingBoundaries(options.renderMode ?? APP_RSC_RENDER_MODE_NAVIGATION)
   ) {
     const RouteLoadingComponent = routeLoadingComponent;
-    // Next.js keys loading.tsx to the active segment state key. Dynamic param
-    // changes reset the pending boundary, while search-only changes preserve it.
+    // Route-level wrappers cover the full page branch in vinext's flat element
+    // transport, so their reset key includes the visible segment-state path.
+    // Dynamic param changes reset the pending boundary, while search-only changes
+    // preserve it.
     routeChildren = (
       <Suspense key={routeResetKey} fallback={<RouteLoadingComponent />}>
         {routeChildren}

--- a/packages/vinext/src/server/app-page-segment-state.ts
+++ b/packages/vinext/src/server/app-page-segment-state.ts
@@ -16,11 +16,69 @@ function isRouteGroupSegment(segment: string): boolean {
   return segment.startsWith("(") && segment.endsWith(")");
 }
 
+type AppPageSegmentParamType = "d" | "c" | "oc";
+
+type AppPageSegmentParam = {
+  name: string;
+  type: AppPageSegmentParamType;
+};
+
 function formatParamSegmentValue(value: string | string[] | undefined): string | undefined {
   if (Array.isArray(value)) {
     return value.join("/");
   }
   return value;
+}
+
+function readSegmentParam(segment: string): AppPageSegmentParam | null {
+  if (isOptionalCatchAllSegment(segment)) {
+    return {
+      name: segment.slice(5, -2),
+      type: "oc",
+    };
+  }
+
+  if (isCatchAllSegment(segment)) {
+    return {
+      name: segment.slice(4, -1),
+      type: "c",
+    };
+  }
+
+  if (isDynamicSegment(segment)) {
+    return {
+      name: segment.slice(1, -1),
+      type: "d",
+    };
+  }
+
+  return null;
+}
+
+function formatSegmentStateParamValue(
+  param: AppPageSegmentParam,
+  params: AppPageParams,
+  fallbackSegment: string,
+): string {
+  const value = params[param.name];
+
+  if (
+    param.type === "oc" &&
+    (value === undefined || (Array.isArray(value) && value.length === 0))
+  ) {
+    return "";
+  }
+
+  return formatParamSegmentValue(value) ?? fallbackSegment;
+}
+
+function resolveSingleSegmentStateKey(segment: string, params: AppPageParams): string {
+  const param = readSegmentParam(segment);
+  if (!param) {
+    return segment;
+  }
+
+  return `${param.name}|${formatSegmentStateParamValue(param, params, segment)}|${param.type}`;
 }
 
 export function resolveAppPageChildSegments(
@@ -68,12 +126,27 @@ export function resolveAppPageSegmentStateKey(
   treePosition: number,
   params: AppPageParams,
 ): string {
-  for (const segment of resolveAppPageChildSegments(routeSegments, treePosition, params)) {
+  for (const segment of routeSegments.slice(treePosition)) {
     if (!isRouteGroupSegment(segment)) {
-      return segment;
+      return resolveSingleSegmentStateKey(segment, params);
     }
   }
   return "";
+}
+
+export function resolveAppPageRouteStateKey(
+  routeSegments: readonly string[],
+  params: AppPageParams,
+): string {
+  const statePath: string[] = [];
+
+  for (const segment of routeSegments) {
+    if (!isRouteGroupSegment(segment)) {
+      statePath.push(resolveSingleSegmentStateKey(segment, params));
+    }
+  }
+
+  return statePath.length > 0 ? JSON.stringify(statePath) : "";
 }
 
 export function resolveAppPageLeafSegmentStateKey(

--- a/packages/vinext/src/server/app-page-segment-state.ts
+++ b/packages/vinext/src/server/app-page-segment-state.ts
@@ -1,0 +1,90 @@
+import type { AppPageParams } from "./app-page-boundary.js";
+
+function isOptionalCatchAllSegment(segment: string): boolean {
+  return segment.startsWith("[[...") && segment.endsWith("]]") && segment.length > 7;
+}
+
+function isCatchAllSegment(segment: string): boolean {
+  return segment.startsWith("[...") && segment.endsWith("]") && segment.length > 5;
+}
+
+function isDynamicSegment(segment: string): boolean {
+  return segment.startsWith("[") && segment.endsWith("]") && !segment.includes(".");
+}
+
+function isRouteGroupSegment(segment: string): boolean {
+  return segment.startsWith("(") && segment.endsWith(")");
+}
+
+function formatParamSegmentValue(value: string | string[] | undefined): string | undefined {
+  if (Array.isArray(value)) {
+    return value.join("/");
+  }
+  return value;
+}
+
+export function resolveAppPageChildSegments(
+  routeSegments: readonly string[],
+  treePosition: number,
+  params: AppPageParams,
+): string[] {
+  const rawSegments = routeSegments.slice(treePosition);
+  const resolvedSegments: string[] = [];
+
+  for (const segment of rawSegments) {
+    if (isOptionalCatchAllSegment(segment)) {
+      const paramName = segment.slice(5, -2);
+      const paramValue = params[paramName];
+      if (Array.isArray(paramValue) && paramValue.length === 0) {
+        continue;
+      }
+      const resolvedValue = formatParamSegmentValue(paramValue);
+      if (resolvedValue !== undefined) {
+        resolvedSegments.push(resolvedValue);
+      }
+      continue;
+    }
+
+    if (isCatchAllSegment(segment)) {
+      const paramName = segment.slice(4, -1);
+      resolvedSegments.push(formatParamSegmentValue(params[paramName]) ?? segment);
+      continue;
+    }
+
+    if (isDynamicSegment(segment)) {
+      const paramName = segment.slice(1, -1);
+      resolvedSegments.push(formatParamSegmentValue(params[paramName]) ?? segment);
+      continue;
+    }
+
+    resolvedSegments.push(segment);
+  }
+
+  return resolvedSegments;
+}
+
+export function resolveAppPageSegmentStateKey(
+  routeSegments: readonly string[],
+  treePosition: number,
+  params: AppPageParams,
+): string {
+  for (const segment of resolveAppPageChildSegments(routeSegments, treePosition, params)) {
+    if (!isRouteGroupSegment(segment)) {
+      return segment;
+    }
+  }
+  return "";
+}
+
+export function resolveAppPageLeafSegmentStateKey(
+  routeSegments: readonly string[],
+  params: AppPageParams,
+): string {
+  for (let treePosition = routeSegments.length - 1; treePosition >= 0; treePosition--) {
+    const segmentStateKey = resolveAppPageSegmentStateKey(routeSegments, treePosition, params);
+    if (segmentStateKey) {
+      return segmentStateKey;
+    }
+  }
+  return "";
+}

--- a/packages/vinext/src/shims/error-boundary.tsx
+++ b/packages/vinext/src/shims/error-boundary.tsx
@@ -9,6 +9,7 @@ import { getErrorDigest, isNavigationSignalError } from "../utils/navigation-sig
 export type ErrorBoundaryProps = {
   fallback: React.ComponentType<{ error: unknown; reset: () => void }>;
   children: React.ReactNode;
+  resetKey?: string | null;
 };
 
 type CapturedError = {
@@ -32,7 +33,36 @@ type ErrorBoundaryInnerProps = {
 export type ErrorBoundaryState = {
   error: CapturedError | null;
   previousPathname: string;
+  previousResetKey: string | null;
 };
+
+type BoundaryResetProps = {
+  pathname: string;
+  resetKey?: string | null;
+};
+
+type BoundaryResetState = {
+  previousPathname: string;
+  previousResetKey: string | null;
+};
+
+function readBoundaryResetState(props: BoundaryResetProps): BoundaryResetState {
+  return {
+    previousPathname: props.pathname,
+    previousResetKey: props.resetKey ?? null,
+  };
+}
+
+function shouldResetBoundary(
+  nextResetState: BoundaryResetState,
+  previousResetState: BoundaryResetState,
+): boolean {
+  if (nextResetState.previousResetKey !== null || previousResetState.previousResetKey !== null) {
+    return nextResetState.previousResetKey !== previousResetState.previousResetKey;
+  }
+
+  return nextResetState.previousPathname !== previousResetState.previousPathname;
+}
 
 function isRedirectError(error: unknown): error is RedirectError {
   return getErrorDigest(error)?.startsWith("NEXT_REDIRECT;") ?? false;
@@ -164,17 +194,18 @@ export class ErrorBoundaryInner extends React.Component<
 > {
   constructor(props: ErrorBoundaryInnerProps) {
     super(props);
-    this.state = { error: null, previousPathname: props.pathname };
+    this.state = { error: null, ...readBoundaryResetState(props) };
   }
 
   static getDerivedStateFromProps(
     props: ErrorBoundaryInnerProps,
     state: ErrorBoundaryState,
   ): ErrorBoundaryState | null {
-    if (props.pathname !== state.previousPathname && state.error) {
-      return { error: null, previousPathname: props.pathname };
+    const nextResetState = readBoundaryResetState(props);
+    if (state.error && shouldResetBoundary(nextResetState, state)) {
+      return { error: null, ...nextResetState };
     }
-    return { error: state.error, previousPathname: props.pathname };
+    return { error: state.error, ...nextResetState };
   }
 
   static getDerivedStateFromError(error: unknown): Partial<ErrorBoundaryState> {
@@ -200,10 +231,10 @@ export class ErrorBoundaryInner extends React.Component<
   }
 }
 
-export function ErrorBoundary({ fallback, children }: ErrorBoundaryProps) {
+export function ErrorBoundary({ fallback, children, resetKey }: ErrorBoundaryProps) {
   const pathname = usePathname();
   return (
-    <ErrorBoundaryInner pathname={pathname} fallback={fallback}>
+    <ErrorBoundaryInner pathname={pathname} resetKey={resetKey} fallback={fallback}>
       {children}
     </ErrorBoundaryInner>
   );
@@ -216,6 +247,7 @@ export function ErrorBoundary({ fallback, children }: ErrorBoundaryProps) {
 type NotFoundBoundaryProps = {
   fallback: React.ReactNode;
   children: React.ReactNode;
+  resetKey?: string | null;
 };
 
 type NotFoundBoundaryInnerProps = {
@@ -225,12 +257,13 @@ type NotFoundBoundaryInnerProps = {
 type NotFoundBoundaryState = {
   notFound: boolean;
   previousPathname: string;
+  previousResetKey: string | null;
 };
 
 /**
  * Inner class component that catches notFound() errors and renders the
- * not-found.tsx fallback. Resets when the pathname changes (client navigation)
- * so a previous notFound() doesn't permanently stick.
+ * not-found.tsx fallback. Resets on the caller's segment reset key when one is
+ * provided, otherwise falls back to pathname changes for legacy callers.
  *
  * The ErrorBoundary above re-throws notFound errors so they propagate up to this
  * boundary. This must be placed above the ErrorBoundary in the component tree.
@@ -241,19 +274,18 @@ class NotFoundBoundaryInner extends React.Component<
 > {
   constructor(props: NotFoundBoundaryInnerProps) {
     super(props);
-    this.state = { notFound: false, previousPathname: props.pathname };
+    this.state = { notFound: false, ...readBoundaryResetState(props) };
   }
 
   static getDerivedStateFromProps(
     props: NotFoundBoundaryInnerProps,
     state: NotFoundBoundaryState,
   ): NotFoundBoundaryState | null {
-    // Reset the boundary when the route changes so a previous notFound()
-    // doesn't permanently stick after client-side navigation.
-    if (props.pathname !== state.previousPathname && state.notFound) {
-      return { notFound: false, previousPathname: props.pathname };
+    const nextResetState = readBoundaryResetState(props);
+    if (state.notFound && shouldResetBoundary(nextResetState, state)) {
+      return { notFound: false, ...nextResetState };
     }
-    return { notFound: state.notFound, previousPathname: props.pathname };
+    return { notFound: state.notFound, ...nextResetState };
   }
 
   static getDerivedStateFromError(error: unknown): Partial<NotFoundBoundaryState> {
@@ -277,12 +309,12 @@ class NotFoundBoundaryInner extends React.Component<
 
 /**
  * Wrapper that reads the current pathname and passes it to the inner class
- * component. This enables automatic reset on client-side navigation.
+ * component. Segment reset keys own App Router remount semantics when present.
  */
-export function NotFoundBoundary({ fallback, children }: NotFoundBoundaryProps) {
+export function NotFoundBoundary({ fallback, children, resetKey }: NotFoundBoundaryProps) {
   const pathname = usePathname();
   return (
-    <NotFoundBoundaryInner pathname={pathname} fallback={fallback}>
+    <NotFoundBoundaryInner pathname={pathname} resetKey={resetKey} fallback={fallback}>
       {children}
     </NotFoundBoundaryInner>
   );
@@ -295,6 +327,7 @@ export function NotFoundBoundary({ fallback, children }: NotFoundBoundaryProps) 
 type ForbiddenBoundaryProps = {
   fallback: React.ReactNode;
   children: React.ReactNode;
+  resetKey?: string | null;
 };
 
 type ForbiddenBoundaryInnerProps = {
@@ -304,6 +337,7 @@ type ForbiddenBoundaryInnerProps = {
 type ForbiddenBoundaryState = {
   forbidden: boolean;
   previousPathname: string;
+  previousResetKey: string | null;
 };
 
 export class ForbiddenBoundaryInner extends React.Component<
@@ -312,17 +346,18 @@ export class ForbiddenBoundaryInner extends React.Component<
 > {
   constructor(props: ForbiddenBoundaryInnerProps) {
     super(props);
-    this.state = { forbidden: false, previousPathname: props.pathname };
+    this.state = { forbidden: false, ...readBoundaryResetState(props) };
   }
 
   static getDerivedStateFromProps(
     props: ForbiddenBoundaryInnerProps,
     state: ForbiddenBoundaryState,
   ): ForbiddenBoundaryState | null {
-    if (props.pathname !== state.previousPathname && state.forbidden) {
-      return { forbidden: false, previousPathname: props.pathname };
+    const nextResetState = readBoundaryResetState(props);
+    if (state.forbidden && shouldResetBoundary(nextResetState, state)) {
+      return { forbidden: false, ...nextResetState };
     }
-    return { forbidden: state.forbidden, previousPathname: props.pathname };
+    return { forbidden: state.forbidden, ...nextResetState };
   }
 
   static getDerivedStateFromError(error: unknown): Partial<ForbiddenBoundaryState> {
@@ -343,10 +378,10 @@ export class ForbiddenBoundaryInner extends React.Component<
   }
 }
 
-export function ForbiddenBoundary({ fallback, children }: ForbiddenBoundaryProps) {
+export function ForbiddenBoundary({ fallback, children, resetKey }: ForbiddenBoundaryProps) {
   const pathname = usePathname();
   return (
-    <ForbiddenBoundaryInner pathname={pathname} fallback={fallback}>
+    <ForbiddenBoundaryInner pathname={pathname} resetKey={resetKey} fallback={fallback}>
       {children}
     </ForbiddenBoundaryInner>
   );
@@ -359,6 +394,7 @@ export function ForbiddenBoundary({ fallback, children }: ForbiddenBoundaryProps
 type UnauthorizedBoundaryProps = {
   fallback: React.ReactNode;
   children: React.ReactNode;
+  resetKey?: string | null;
 };
 
 type UnauthorizedBoundaryInnerProps = {
@@ -368,6 +404,7 @@ type UnauthorizedBoundaryInnerProps = {
 type UnauthorizedBoundaryState = {
   unauthorized: boolean;
   previousPathname: string;
+  previousResetKey: string | null;
 };
 
 export class UnauthorizedBoundaryInner extends React.Component<
@@ -376,17 +413,18 @@ export class UnauthorizedBoundaryInner extends React.Component<
 > {
   constructor(props: UnauthorizedBoundaryInnerProps) {
     super(props);
-    this.state = { unauthorized: false, previousPathname: props.pathname };
+    this.state = { unauthorized: false, ...readBoundaryResetState(props) };
   }
 
   static getDerivedStateFromProps(
     props: UnauthorizedBoundaryInnerProps,
     state: UnauthorizedBoundaryState,
   ): UnauthorizedBoundaryState | null {
-    if (props.pathname !== state.previousPathname && state.unauthorized) {
-      return { unauthorized: false, previousPathname: props.pathname };
+    const nextResetState = readBoundaryResetState(props);
+    if (state.unauthorized && shouldResetBoundary(nextResetState, state)) {
+      return { unauthorized: false, ...nextResetState };
     }
-    return { unauthorized: state.unauthorized, previousPathname: props.pathname };
+    return { unauthorized: state.unauthorized, ...nextResetState };
   }
 
   static getDerivedStateFromError(error: unknown): Partial<UnauthorizedBoundaryState> {
@@ -407,10 +445,10 @@ export class UnauthorizedBoundaryInner extends React.Component<
   }
 }
 
-export function UnauthorizedBoundary({ fallback, children }: UnauthorizedBoundaryProps) {
+export function UnauthorizedBoundary({ fallback, children, resetKey }: UnauthorizedBoundaryProps) {
   const pathname = usePathname();
   return (
-    <UnauthorizedBoundaryInner pathname={pathname} fallback={fallback}>
+    <UnauthorizedBoundaryInner pathname={pathname} resetKey={resetKey} fallback={fallback}>
       {children}
     </UnauthorizedBoundaryInner>
   );

--- a/packages/vinext/src/shims/error-boundary.tsx
+++ b/packages/vinext/src/shims/error-boundary.tsx
@@ -46,10 +46,14 @@ type BoundaryResetState = {
   previousResetKey: string | null;
 };
 
+function normalizeBoundaryResetKey(resetKey: string | null | undefined): string | null {
+  return resetKey === undefined || resetKey === null || resetKey === "" ? null : resetKey;
+}
+
 function readBoundaryResetState(props: BoundaryResetProps): BoundaryResetState {
   return {
     previousPathname: props.pathname,
-    previousResetKey: props.resetKey ?? null,
+    previousResetKey: normalizeBoundaryResetKey(props.resetKey),
   };
 }
 
@@ -57,8 +61,11 @@ function shouldResetBoundary(
   nextResetState: BoundaryResetState,
   previousResetState: BoundaryResetState,
 ): boolean {
-  if (nextResetState.previousResetKey !== null || previousResetState.previousResetKey !== null) {
-    return nextResetState.previousResetKey !== previousResetState.previousResetKey;
+  const nextResetKey = normalizeBoundaryResetKey(nextResetState.previousResetKey);
+  const previousResetKey = normalizeBoundaryResetKey(previousResetState.previousResetKey);
+
+  if (nextResetKey !== null || previousResetKey !== null) {
+    return nextResetKey !== previousResetKey;
   }
 
   return nextResetState.previousPathname !== previousResetState.previousPathname;

--- a/tests/app-page-route-wiring.test.ts
+++ b/tests/app-page-route-wiring.test.ts
@@ -1089,10 +1089,10 @@ describe("app page route wiring helpers", () => {
     const templateSlot = findSlotById(elements["route:/docs/launch"], "template:/docs");
 
     expect(templateSlot).not.toBeNull();
-    expect(templateSlot?.key).toBe("launch");
+    expect(templateSlot?.key).toBe("slug|launch|d");
   });
 
-  it("threads segment reset keys into loading, error, and not-found boundaries", () => {
+  it("threads route state reset keys into loading, error, and not-found boundaries", () => {
     function RouteLoading() {
       return createElement("p", null, "Loading");
     }
@@ -1135,9 +1135,122 @@ describe("app page route wiring helpers", () => {
     const errorBoundary = findElementByTypeName(routeEntry, "ErrorBoundary");
     const notFoundBoundary = findElementByTypeName(routeEntry, "NotFoundBoundary");
 
-    expect(loadingBoundary?.key).toBe("alpha");
-    expect(errorBoundary?.props.resetKey).toBe("alpha");
-    expect(notFoundBoundary?.props.resetKey).toBe("alpha");
+    expect(loadingBoundary?.key).toBe(JSON.stringify(["products", "id|alpha|d"]));
+    expect(errorBoundary?.props.resetKey).toBe(JSON.stringify(["products", "id|alpha|d"]));
+    expect(notFoundBoundary?.props.resetKey).toBe(JSON.stringify(["products", "id|alpha|d"]));
+  });
+
+  it("does not collide route reset keys across branches with the same dynamic leaf value", () => {
+    function RouteLoading() {
+      return createElement("p", null, "Loading");
+    }
+
+    function RouteError() {
+      return createElement("p", null, "Error");
+    }
+
+    function RouteNotFound() {
+      return createElement("p", null, "Not Found");
+    }
+
+    function buildBranchElements(branch: "posts" | "photos") {
+      return buildAppPageElements({
+        element: createElement(PageProbe),
+        makeThenableParams(params) {
+          return Promise.resolve(params);
+        },
+        matchedParams: { id: "123" },
+        resolvedMetadata: null,
+        resolvedViewport: {},
+        route: {
+          error: { default: RouteError },
+          errors: [null],
+          layoutTreePositions: [0],
+          layouts: [{ default: RootLayout }],
+          loading: { default: RouteLoading },
+          notFound: { default: RouteNotFound },
+          notFounds: [null],
+          routeSegments: ["reset-collision", branch, "[id]"],
+          slots: {},
+          templateTreePositions: [],
+          templates: [],
+        },
+        routePath: `/reset-collision/${branch}/123`,
+        rootNotFoundModule: null,
+      })[`route:/reset-collision/${branch}/123`];
+    }
+
+    const postsRoute = buildBranchElements("posts");
+    const photosRoute = buildBranchElements("photos");
+    const postsLoadingBoundary = findSuspenseWithFallback(postsRoute, "RouteLoading");
+    const photosLoadingBoundary = findSuspenseWithFallback(photosRoute, "RouteLoading");
+    const postsErrorBoundary = findElementByTypeName(postsRoute, "ErrorBoundary");
+    const photosErrorBoundary = findElementByTypeName(photosRoute, "ErrorBoundary");
+    const postsNotFoundBoundary = findElementByTypeName(postsRoute, "NotFoundBoundary");
+    const photosNotFoundBoundary = findElementByTypeName(photosRoute, "NotFoundBoundary");
+
+    expect(postsLoadingBoundary?.key).toBe(
+      JSON.stringify(["reset-collision", "posts", "id|123|d"]),
+    );
+    expect(photosLoadingBoundary?.key).toBe(
+      JSON.stringify(["reset-collision", "photos", "id|123|d"]),
+    );
+    expect(postsLoadingBoundary?.key).not.toBe(photosLoadingBoundary?.key);
+    expect(postsErrorBoundary?.props.resetKey).not.toBe(photosErrorBoundary?.props.resetKey);
+    expect(postsNotFoundBoundary?.props.resetKey).not.toBe(photosNotFoundBoundary?.props.resetKey);
+  });
+
+  it("does not collide route reset keys across static branches with the same leaf segment", () => {
+    function RouteLoading() {
+      return createElement("p", null, "Loading");
+    }
+
+    function RouteError() {
+      return createElement("p", null, "Error");
+    }
+
+    function buildStaticBranchElements(branch: "account" | "admin") {
+      return buildAppPageElements({
+        element: createElement(PageProbe),
+        makeThenableParams(params) {
+          return Promise.resolve(params);
+        },
+        matchedParams: {},
+        resolvedMetadata: null,
+        resolvedViewport: {},
+        route: {
+          error: { default: RouteError },
+          errors: [null],
+          layoutTreePositions: [0],
+          layouts: [{ default: RootLayout }],
+          loading: { default: RouteLoading },
+          notFound: null,
+          notFounds: [null],
+          routeSegments: ["reset-collision", branch, "settings"],
+          slots: {},
+          templateTreePositions: [],
+          templates: [],
+        },
+        routePath: `/reset-collision/${branch}/settings`,
+        rootNotFoundModule: null,
+      })[`route:/reset-collision/${branch}/settings`];
+    }
+
+    const accountRoute = buildStaticBranchElements("account");
+    const adminRoute = buildStaticBranchElements("admin");
+    const accountLoadingBoundary = findSuspenseWithFallback(accountRoute, "RouteLoading");
+    const adminLoadingBoundary = findSuspenseWithFallback(adminRoute, "RouteLoading");
+    const accountErrorBoundary = findElementByTypeName(accountRoute, "ErrorBoundary");
+    const adminErrorBoundary = findElementByTypeName(adminRoute, "ErrorBoundary");
+
+    expect(accountLoadingBoundary?.key).toBe(
+      JSON.stringify(["reset-collision", "account", "settings"]),
+    );
+    expect(adminLoadingBoundary?.key).toBe(
+      JSON.stringify(["reset-collision", "admin", "settings"]),
+    );
+    expect(accountLoadingBoundary?.key).not.toBe(adminLoadingBoundary?.key);
+    expect(accountErrorBoundary?.props.resetKey).not.toBe(adminErrorBoundary?.props.resetKey);
   });
 
   it("threads segment reset keys into boundaries even without template.tsx", () => {
@@ -1174,7 +1287,7 @@ describe("app page route wiring helpers", () => {
 
     const errorBoundary = findElementByTypeName(elements["route:/docs/intro"], "ErrorBoundary");
 
-    expect(errorBoundary?.props.resetKey).toBe("intro");
+    expect(errorBoundary?.props.resetKey).toBe("slug|intro|d");
   });
 
   it("interleaves templates with their corresponding layouts", async () => {

--- a/tests/app-page-route-wiring.test.ts
+++ b/tests/app-page-route-wiring.test.ts
@@ -1,4 +1,4 @@
-import { Fragment, createElement, isValidElement, type ReactNode } from "react";
+import { Fragment, createElement, isValidElement, type ReactElement, type ReactNode } from "react";
 import { describe, expect, it } from "vite-plus/test";
 import { useSelectedLayoutSegments } from "../packages/vinext/src/shims/navigation.js";
 import type { AppElements } from "../packages/vinext/src/server/app-elements.js";
@@ -52,6 +52,83 @@ function containsElementType(node: unknown, type: unknown): boolean {
     containsElementType(node.props.children, type) ||
     containsElementType(node.props.fallback, type)
   );
+}
+
+function getElementTypeName(type: unknown): string {
+  if (typeof type === "string") return type;
+  if (typeof type === "function") {
+    return (
+      (type as { displayName?: string; name?: string }).displayName ??
+      (type as { name?: string }).name ??
+      ""
+    );
+  }
+  return String(type);
+}
+
+type InspectableElementProps = Record<string, unknown> & {
+  children?: unknown;
+  fallback?: unknown;
+  id?: unknown;
+};
+
+function findElement(
+  node: unknown,
+  predicate: (element: ReactElement<InspectableElementProps>) => boolean,
+): ReactElement<InspectableElementProps> | null {
+  if (Array.isArray(node)) {
+    for (const child of node) {
+      const match = findElement(child, predicate);
+      if (match) return match;
+    }
+    return null;
+  }
+
+  if (!isValidElement<InspectableElementProps>(node)) {
+    return null;
+  }
+
+  if (predicate(node)) return node;
+
+  for (const value of Object.values(node.props)) {
+    const match = findElement(value, predicate);
+    if (match) return match;
+  }
+
+  return null;
+}
+
+function findElementByTypeName(
+  node: unknown,
+  typeName: string,
+): ReactElement<Record<string, unknown>> | null {
+  const match = findElement(node, (element) => getElementTypeName(element.type) === typeName);
+  return match as ReactElement<Record<string, unknown>> | null;
+}
+
+function findSlotById(node: unknown, id: string): ReactElement<Record<string, unknown>> | null {
+  const match = findElement(
+    node,
+    (element) =>
+      getElementTypeName(element.type) === "Slot" &&
+      typeof element.props.id === "string" &&
+      element.props.id === id,
+  );
+  return match as ReactElement<Record<string, unknown>> | null;
+}
+
+function findSuspenseWithFallback(
+  node: unknown,
+  fallbackTypeName: string,
+): ReactElement<Record<string, unknown>> | null {
+  const match = findElement(node, (element) => {
+    if (getElementTypeName(element.type) !== "Symbol(react.suspense)") {
+      return false;
+    }
+    const fallback = element.props.fallback;
+    return isValidElement(fallback) && getElementTypeName(fallback.type) === fallbackTypeName;
+  });
+  return match as ReactElement<Record<string, unknown>> | null;
 }
 
 async function readStream(stream: ReadableStream<Uint8Array>): Promise<string> {
@@ -977,6 +1054,127 @@ describe("app page route wiring helpers", () => {
     expect(templateDepth).toBeDefined();
     expect(notFoundDepth).toBeDefined();
     expect(templateDepth).toBeLessThan(notFoundDepth!);
+  });
+
+  it("keys template slots with the semantic segment state key", () => {
+    function LeafTemplate(props: { children?: ReactNode }) {
+      return createElement("section", { "data-template": "leaf" }, readChildren(props.children));
+    }
+
+    const elements = buildAppPageElements({
+      element: createElement(PageProbe),
+      makeThenableParams(params) {
+        return Promise.resolve(params);
+      },
+      matchedParams: { slug: "launch" },
+      resolvedMetadata: null,
+      resolvedViewport: {},
+      route: {
+        error: null,
+        errors: [null, null],
+        layoutTreePositions: [0, 1],
+        layouts: [{ default: RootLayout }, { default: GroupLayout }],
+        loading: null,
+        notFound: null,
+        notFounds: [null, null],
+        routeSegments: ["docs", "[slug]"],
+        slots: {},
+        templateTreePositions: [1],
+        templates: [{ default: LeafTemplate }],
+      },
+      routePath: "/docs/launch",
+      rootNotFoundModule: null,
+    });
+
+    const templateSlot = findSlotById(elements["route:/docs/launch"], "template:/docs");
+
+    expect(templateSlot).not.toBeNull();
+    expect(templateSlot?.key).toBe("launch");
+  });
+
+  it("threads segment reset keys into loading, error, and not-found boundaries", () => {
+    function RouteLoading() {
+      return createElement("p", null, "Loading");
+    }
+
+    function RouteError() {
+      return createElement("p", null, "Error");
+    }
+
+    function RouteNotFound() {
+      return createElement("p", null, "Not Found");
+    }
+
+    const elements = buildAppPageElements({
+      element: createElement(PageProbe),
+      makeThenableParams(params) {
+        return Promise.resolve(params);
+      },
+      matchedParams: { id: "alpha" },
+      resolvedMetadata: null,
+      resolvedViewport: {},
+      route: {
+        error: { default: RouteError },
+        errors: [null],
+        layoutTreePositions: [0],
+        layouts: [{ default: RootLayout }],
+        loading: { default: RouteLoading },
+        notFound: { default: RouteNotFound },
+        notFounds: [null],
+        routeSegments: ["products", "[id]"],
+        slots: {},
+        templateTreePositions: [],
+        templates: [],
+      },
+      routePath: "/products/alpha",
+      rootNotFoundModule: null,
+    });
+
+    const routeEntry = elements["route:/products/alpha"];
+    const loadingBoundary = findSuspenseWithFallback(routeEntry, "RouteLoading");
+    const errorBoundary = findElementByTypeName(routeEntry, "ErrorBoundary");
+    const notFoundBoundary = findElementByTypeName(routeEntry, "NotFoundBoundary");
+
+    expect(loadingBoundary?.key).toBe("alpha");
+    expect(errorBoundary?.props.resetKey).toBe("alpha");
+    expect(notFoundBoundary?.props.resetKey).toBe("alpha");
+  });
+
+  it("threads segment reset keys into boundaries even without template.tsx", () => {
+    function SegmentError() {
+      return createElement("p", null, "Segment Error");
+    }
+
+    const elements = buildAppPageElements({
+      element: createElement(PageProbe),
+      makeThenableParams(params) {
+        return Promise.resolve(params);
+      },
+      matchedParams: { slug: "intro" },
+      resolvedMetadata: null,
+      resolvedViewport: {},
+      route: {
+        error: null,
+        errorPaths: [{ default: SegmentError }],
+        errors: [null],
+        errorTreePositions: [1],
+        layoutTreePositions: [0],
+        layouts: [{ default: RootLayout }],
+        loading: null,
+        notFound: null,
+        notFounds: [null],
+        routeSegments: ["docs", "[slug]"],
+        slots: {},
+        templateTreePositions: [],
+        templates: [],
+      },
+      routePath: "/docs/intro",
+      rootNotFoundModule: null,
+    });
+
+    const errorBoundary = findElementByTypeName(elements["route:/docs/intro"], "ErrorBoundary");
+
+    expect(errorBoundary?.props.resetKey).toBe("intro");
   });
 
   it("interleaves templates with their corresponding layouts", async () => {

--- a/tests/app-page-segment-state.test.ts
+++ b/tests/app-page-segment-state.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  resolveAppPageLeafSegmentStateKey,
+  resolveAppPageSegmentStateKey,
+} from "../packages/vinext/src/server/app-page-segment-state.js";
+
+describe("app page segment state keys", () => {
+  // Mirrors Next.js createRouterCacheKey(..., true): the React state key is
+  // the active segment identity without search params, so search-only changes
+  // do not reset templates or boundaries.
+  it("resolves dynamic params into segment state keys without search params", () => {
+    expect(
+      resolveAppPageSegmentStateKey(["dashboard", "[team]", "settings"], 1, {
+        team: "alpha",
+      }),
+    ).toBe("alpha");
+  });
+
+  it("skips route groups when selecting the state key below a tree position", () => {
+    expect(
+      resolveAppPageSegmentStateKey(["(marketing)", "blog", "[slug]"], 0, {
+        slug: "launch",
+      }),
+    ).toBe("blog");
+    expect(
+      resolveAppPageSegmentStateKey(["(marketing)", "blog", "[slug]"], 1, {
+        slug: "launch",
+      }),
+    ).toBe("blog");
+    expect(
+      resolveAppPageSegmentStateKey(["(marketing)", "blog", "[slug]"], 2, {
+        slug: "launch",
+      }),
+    ).toBe("launch");
+  });
+
+  it("uses the final visible segment for route-level loading and boundary reset", () => {
+    expect(
+      resolveAppPageLeafSegmentStateKey(["(marketing)", "blog", "[slug]"], {
+        slug: "launch",
+      }),
+    ).toBe("launch");
+    expect(resolveAppPageLeafSegmentStateKey(["(marketing)"], {})).toBe("");
+  });
+
+  it("keeps catch-all segment keys canonical", () => {
+    expect(
+      resolveAppPageSegmentStateKey(["docs", "[...parts]"], 1, {
+        parts: ["guides", "routing"],
+      }),
+    ).toBe("guides/routing");
+    expect(
+      resolveAppPageSegmentStateKey(["docs", "[[...parts]]"], 1, {
+        parts: [],
+      }),
+    ).toBe("");
+  });
+});

--- a/tests/app-page-segment-state.test.ts
+++ b/tests/app-page-segment-state.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vite-plus/test";
 import {
   resolveAppPageLeafSegmentStateKey,
+  resolveAppPageRouteStateKey,
   resolveAppPageSegmentStateKey,
 } from "../packages/vinext/src/server/app-page-segment-state.js";
 
@@ -13,7 +14,7 @@ describe("app page segment state keys", () => {
       resolveAppPageSegmentStateKey(["dashboard", "[team]", "settings"], 1, {
         team: "alpha",
       }),
-    ).toBe("alpha");
+    ).toBe("team|alpha|d");
   });
 
   it("skips route groups when selecting the state key below a tree position", () => {
@@ -31,16 +32,38 @@ describe("app page segment state keys", () => {
       resolveAppPageSegmentStateKey(["(marketing)", "blog", "[slug]"], 2, {
         slug: "launch",
       }),
-    ).toBe("launch");
+    ).toBe("slug|launch|d");
   });
 
-  it("uses the final visible segment for route-level loading and boundary reset", () => {
+  it("keeps the leaf segment helper scoped to the active local segment", () => {
     expect(
       resolveAppPageLeafSegmentStateKey(["(marketing)", "blog", "[slug]"], {
         slug: "launch",
       }),
-    ).toBe("launch");
+    ).toBe("slug|launch|d");
     expect(resolveAppPageLeafSegmentStateKey(["(marketing)"], {})).toBe("");
+  });
+
+  it("uses the full visible segment-state path for route-wide reset keys", () => {
+    expect(
+      resolveAppPageRouteStateKey(["(marketing)", "blog", "[slug]"], {
+        slug: "launch",
+      }),
+    ).toBe(JSON.stringify(["blog", "slug|launch|d"]));
+
+    expect(
+      resolveAppPageRouteStateKey(["posts", "[id]"], {
+        id: "123",
+      }),
+    ).not.toBe(
+      resolveAppPageRouteStateKey(["photos", "[id]"], {
+        id: "123",
+      }),
+    );
+
+    expect(resolveAppPageRouteStateKey(["account", "settings"], {})).not.toBe(
+      resolveAppPageRouteStateKey(["admin", "settings"], {}),
+    );
   });
 
   it("keeps catch-all segment keys canonical", () => {
@@ -48,11 +71,11 @@ describe("app page segment state keys", () => {
       resolveAppPageSegmentStateKey(["docs", "[...parts]"], 1, {
         parts: ["guides", "routing"],
       }),
-    ).toBe("guides/routing");
+    ).toBe("parts|guides/routing|c");
     expect(
       resolveAppPageSegmentStateKey(["docs", "[[...parts]]"], 1, {
         parts: [],
       }),
-    ).toBe("");
+    ).toBe("parts||oc");
   });
 });

--- a/tests/e2e/app-router/reset-key-collisions.spec.ts
+++ b/tests/e2e/app-router/reset-key-collisions.spec.ts
@@ -1,0 +1,45 @@
+import { expect, test } from "@playwright/test";
+import { disableDevErrorOverlay } from "../helpers";
+
+const BASE = "http://localhost:4174";
+
+async function triggerPostsError(page: import("@playwright/test").Page) {
+  await disableDevErrorOverlay(page);
+
+  await expect(page.getByTestId("posts-error-trigger")).toBeVisible({
+    timeout: 10_000,
+  });
+
+  await expect(async () => {
+    await page.getByTestId("posts-error-trigger").click({ noWaitAfter: true });
+    await expect(page.getByTestId("posts-error-boundary")).toBeVisible({
+      timeout: 10_000,
+    });
+  }).toPass({ timeout: 20_000 });
+}
+
+test.describe("route reset key collisions", () => {
+  test("dynamic branches with the same leaf param value clear captured route errors", async ({
+    page,
+  }) => {
+    await page.goto(`${BASE}/reset-collision/posts/123`);
+    await expect(page.getByTestId("posts-page")).toHaveText("Posts 123");
+
+    await triggerPostsError(page);
+
+    await page.getByTestId("to-photos-123").click();
+
+    await expect(page.getByTestId("photos-page")).toHaveText("Photos 123");
+    await expect(page.getByTestId("posts-error-boundary")).not.toBeAttached();
+  });
+
+  test("static branches with the same leaf segment remount route loading", async ({ page }) => {
+    await page.goto(`${BASE}/reset-collision/account/settings`);
+    await expect(page.getByTestId("account-settings-page")).toHaveText("Account settings");
+
+    await page.getByTestId("to-admin-settings").click();
+
+    await expect(page.getByTestId("admin-settings-loading")).toBeVisible();
+    await expect(page.getByTestId("admin-settings-page")).toHaveText("Admin settings");
+  });
+});

--- a/tests/error-boundary.test.ts
+++ b/tests/error-boundary.test.ts
@@ -4,7 +4,7 @@
  * Tests the ErrorBoundary, NotFoundBoundary, ForbiddenBoundary, and
  * UnauthorizedBoundary components that handle error.tsx, not-found.tsx,
  * forbidden.tsx, and unauthorized.tsx rendering in the App Router.
- * Verifies correct digest handling, error propagation, and pathname reset.
+ * Verifies correct digest handling, error propagation, and reset behavior.
  *
  * Ported from Next.js: test/e2e/app-dir/error-boundary/error-boundary.test.ts
  * https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/error-boundary/error-boundary.test.ts
@@ -23,9 +23,9 @@ vi.mock("next/navigation", () => ({
 // - packages/next/src/client/components/error-boundary.tsx
 // - packages/next/src/client/components/navigation.ts
 //
-// Next.js resets segment error boundaries on pathname changes using a
-// previousPathname field, and usePathname() is pathname-only rather than
-// query-aware. These tests lock our shim to that behavior.
+// Next.js keeps pathname reset fallback in the boundary implementation, while
+// segment remounts provide the App Router's preferred reset owner. These tests
+// lock both paths.
 
 type ErrorBoundaryInnerConstructor = {
   getDerivedStateFromError(error: unknown): Partial<{
@@ -37,14 +37,17 @@ type ErrorBoundaryInnerConstructor = {
       children: React.ReactNode;
       fallback: React.ComponentType<{ error: unknown; reset: () => void }>;
       pathname: string;
+      resetKey?: string | null;
     },
     state: {
       error: { thrownValue: unknown } | null;
       previousPathname: string;
+      previousResetKey?: string | null;
     },
   ): {
     error: { thrownValue: unknown } | null;
     previousPathname: string;
+    previousResetKey?: string | null;
   } | null;
 };
 
@@ -215,12 +218,78 @@ describe("ErrorBoundary digest classification (actual class)", () => {
       {
         error: { thrownValue: new Error("stuck") },
         previousPathname: "/previous",
+        previousResetKey: null,
       },
     );
 
     expect(state).toEqual({
       error: null,
       previousPathname: "/next",
+      previousResetKey: null,
+    });
+  });
+
+  it("resets caught errors when the semantic reset key changes on the same pathname", () => {
+    expect(ErrorBoundaryInner).not.toBeNull();
+    if (!ErrorBoundaryInner) {
+      throw new Error("Expected ErrorBoundaryInner export");
+    }
+
+    function Fallback() {
+      return null;
+    }
+
+    const state = ErrorBoundaryInner.getDerivedStateFromProps(
+      {
+        children: null,
+        fallback: Fallback,
+        pathname: "/products/[id]",
+        resetKey: "product-b",
+      },
+      {
+        error: { thrownValue: new Error("stuck") },
+        previousPathname: "/products/[id]",
+        previousResetKey: "product-a",
+      },
+    );
+
+    expect(state).toEqual({
+      error: null,
+      previousPathname: "/products/[id]",
+      previousResetKey: "product-b",
+    });
+  });
+
+  it("keeps caught errors when the semantic reset key is unchanged", () => {
+    expect(ErrorBoundaryInner).not.toBeNull();
+    if (!ErrorBoundaryInner) {
+      throw new Error("Expected ErrorBoundaryInner export");
+    }
+
+    const error = new Error("stuck");
+
+    function Fallback() {
+      return null;
+    }
+
+    const state = ErrorBoundaryInner.getDerivedStateFromProps(
+      {
+        children: null,
+        fallback: Fallback,
+        pathname: "/products/next",
+        resetKey: "product-a",
+      },
+      {
+        error: { thrownValue: error },
+        previousPathname: "/products/previous",
+        previousResetKey: "product-a",
+      },
+    );
+
+    expect(state).toEqual({
+      error: { thrownValue: error },
+      previousPathname: "/products/next",
+      previousResetKey: "product-a",
     });
   });
 
@@ -234,6 +303,7 @@ describe("ErrorBoundary digest classification (actual class)", () => {
     const baseState = {
       error: null,
       previousPathname: "/error-test",
+      previousResetKey: null,
     };
     const stateAfterError = {
       ...baseState,
@@ -256,6 +326,7 @@ describe("ErrorBoundary digest classification (actual class)", () => {
     expect(stateAfterProps).toEqual({
       error: { thrownValue: error },
       previousPathname: "/error-test",
+      previousResetKey: null,
     });
   });
 });

--- a/tests/error-boundary.test.ts
+++ b/tests/error-boundary.test.ts
@@ -260,6 +260,37 @@ describe("ErrorBoundary digest classification (actual class)", () => {
     });
   });
 
+  it("treats an empty semantic reset key as absent for pathname fallback", () => {
+    expect(ErrorBoundaryInner).not.toBeNull();
+    if (!ErrorBoundaryInner) {
+      throw new Error("Expected ErrorBoundaryInner export");
+    }
+
+    function Fallback() {
+      return null;
+    }
+
+    const state = ErrorBoundaryInner.getDerivedStateFromProps(
+      {
+        children: null,
+        fallback: Fallback,
+        pathname: "/next",
+        resetKey: "",
+      },
+      {
+        error: { thrownValue: new Error("stuck") },
+        previousPathname: "/previous",
+        previousResetKey: "",
+      },
+    );
+
+    expect(state).toEqual({
+      error: null,
+      previousPathname: "/next",
+      previousResetKey: null,
+    });
+  });
+
   it("keeps caught errors when the semantic reset key is unchanged", () => {
     expect(ErrorBoundaryInner).not.toBeNull();
     if (!ErrorBoundaryInner) {

--- a/tests/fixtures/app-basic/app/reset-collision/account/settings/page.tsx
+++ b/tests/fixtures/app-basic/app/reset-collision/account/settings/page.tsx
@@ -1,0 +1,12 @@
+import Link from "next/link";
+
+export default function AccountSettingsCollisionPage() {
+  return (
+    <main>
+      <h1 data-testid="account-settings-page">Account settings</h1>
+      <Link data-testid="to-admin-settings" href="/reset-collision/admin/settings">
+        Go to admin settings
+      </Link>
+    </main>
+  );
+}

--- a/tests/fixtures/app-basic/app/reset-collision/admin/settings/loading.tsx
+++ b/tests/fixtures/app-basic/app/reset-collision/admin/settings/loading.tsx
@@ -1,0 +1,3 @@
+export default function AdminSettingsLoading() {
+  return <p data-testid="admin-settings-loading">Loading admin settings</p>;
+}

--- a/tests/fixtures/app-basic/app/reset-collision/admin/settings/page.tsx
+++ b/tests/fixtures/app-basic/app/reset-collision/admin/settings/page.tsx
@@ -1,0 +1,13 @@
+async function waitForAdminSettings() {
+  await new Promise((resolve) => setTimeout(resolve, 1_000));
+}
+
+export default async function AdminSettingsCollisionPage() {
+  await waitForAdminSettings();
+
+  return (
+    <main>
+      <h1 data-testid="admin-settings-page">Admin settings</h1>
+    </main>
+  );
+}

--- a/tests/fixtures/app-basic/app/reset-collision/error-trigger.tsx
+++ b/tests/fixtures/app-basic/app/reset-collision/error-trigger.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { useState } from "react";
+
+export function ErrorTrigger({ label }: { label: string }) {
+  const [shouldThrow, setShouldThrow] = useState(false);
+
+  if (shouldThrow) {
+    throw new Error(`${label} reset collision error`);
+  }
+
+  return (
+    <button data-testid={`${label}-error-trigger`} onClick={() => setShouldThrow(true)}>
+      Trigger {label} error
+    </button>
+  );
+}

--- a/tests/fixtures/app-basic/app/reset-collision/photos/[id]/page.tsx
+++ b/tests/fixtures/app-basic/app/reset-collision/photos/[id]/page.tsx
@@ -1,0 +1,9 @@
+export default async function PhotosCollisionPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+
+  return (
+    <main>
+      <h1 data-testid="photos-page">Photos {id}</h1>
+    </main>
+  );
+}

--- a/tests/fixtures/app-basic/app/reset-collision/posts/[id]/error.tsx
+++ b/tests/fixtures/app-basic/app/reset-collision/posts/[id]/error.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import Link from "next/link";
+
+export default function PostsCollisionError({ error }: { error: Error; reset: () => void }) {
+  return (
+    <section data-testid="posts-error-boundary">
+      <h1>Posts error boundary</h1>
+      <p>{error.message}</p>
+      <Link data-testid="to-photos-123" href="/reset-collision/photos/123">
+        Go to photos 123
+      </Link>
+    </section>
+  );
+}

--- a/tests/fixtures/app-basic/app/reset-collision/posts/[id]/page.tsx
+++ b/tests/fixtures/app-basic/app/reset-collision/posts/[id]/page.tsx
@@ -1,0 +1,12 @@
+import { ErrorTrigger } from "../../error-trigger";
+
+export default async function PostsCollisionPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+
+  return (
+    <main>
+      <h1 data-testid="posts-page">Posts {id}</h1>
+      <ErrorTrigger label="posts" />
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary

Implements `#726-CORE-11/12` from issue #726.

This promotes template reset and loading/error/not-found reset semantics to explicit App Router segment state keys. The important architectural point is that reset ownership now lives in typed routing/runtime helpers and boundary props, not as an accidental consequence of pathname-only state or the flat AppElements wire shape.

Bonk: please read issue #726 before reviewing this PR. It has the architectural big picture for why these reset semantics need a clear owner and why this PR deliberately avoids turning the AppElements transport into router brain.

## What changed

- Added a typed `app-page-segment-state` helper for semantic segment reset keys, including dynamic params, catch-all params, optional catch-all params, and route-group handling.
- Wired App Router template slots, loading boundaries, error boundaries, and HTTP access boundaries to reset from semantic segment identity.
- Kept legacy pathname fallback behavior for boundary callers that do not pass a reset key.
- Added focused tests for segment key derivation, template slot keys, route/per-segment boundary reset props, and boundary reset precedence.

## Validation

- `vp test run tests/app-page-segment-state.test.ts tests/error-boundary.test.ts tests/app-page-route-wiring.test.ts`
- `vp test run tests/navigation-planner.test.ts tests/app-browser-entry.test.ts tests/app-elements.test.ts tests/app-page-boundary-render.test.ts`
- `vp test run tests/slot.test.ts tests/app-router.test.ts tests/nextjs-compat/navigation.test.ts`
- `vp check`
- `vp run vinext#build`
- `PLAYWRIGHT_PROJECT=app-router vp run test:e2e tests/e2e/app-router/layout-persistence.spec.ts tests/e2e/app-router/loading.spec.ts tests/e2e/app-router/error-interactive.spec.ts`
