### PR TITLE
ci(benchmarks): pin contents: read

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -10,6 +10,9 @@ concurrency:
   group: benchmarks
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   benchmark:
     name: Run Benchmarks


### PR DESCRIPTION
Adds a top-level `permissions: contents: read` block to `benchmarks.yml` — the last workflow here that wasn't declaring its scope.

The job:
- Checks out the repo + builds vinext, then runs hyperfine-based benchmarks.
- Uploads the JSON results via `actions/upload-artifact@v7` (writes only to the run's artifact store, not the repo).
- Posts results to `benchmarks.vinext.workers.dev` using `secrets.BENCHMARK_UPLOAD_TOKEN` — not the GitHub token.
- Writes a markdown summary to `$GITHUB_STEP_SUMMARY`.

None of those steps need any GitHub API writes, so `contents: read` is the correct minimum. Matches the top-level pattern already in `ci.yml`, `publish.yml`, etc.