### PR TITLE
fix(app-router): promote mounted parallel slot preservation

### DIFF
--- a/packages/vinext/src/server/app-browser-state.ts
+++ b/packages/vinext/src/server/app-browser-state.ts
@@ -1,6 +1,7 @@
 import { stripBasePath } from "../utils/base-path.js";
 import {
   AppElementsWire,
+  getMountedSlotIds,
   getMountedSlotIdsHeader,
   type AppElements,
   type LayoutFlags,
@@ -20,6 +21,7 @@ import {
 } from "./navigation-trace.js";
 import {
   navigationPlanner,
+  type MountedParallelSlotSnapshotV0,
   type NavigationDecisionV0,
   type OperationLane,
   type OperationToken,
@@ -89,11 +91,20 @@ export type PendingNavigationCommit = {
 };
 
 type PendingNavigationCommitDisposition = "dispatch" | "hard-navigate" | "skip";
-type PendingNavigationCommitDispositionDecision = {
-  disposition: PendingNavigationCommitDisposition;
+type DispatchPendingNavigationCommitDispositionDecision = {
+  disposition: "dispatch";
+  preserveAbsentSlots: boolean;
   preserveElementIds: readonly string[];
   trace: NavigationTrace;
 };
+type NonDispatchPendingNavigationCommitDispositionDecision = {
+  disposition: Exclude<PendingNavigationCommitDisposition, "dispatch">;
+  preserveElementIds: readonly [];
+  trace: NavigationTrace;
+};
+type PendingNavigationCommitDispositionDecision =
+  | DispatchPendingNavigationCommitDispositionDecision
+  | NonDispatchPendingNavigationCommitDispositionDecision;
 
 function cloneHistoryState(state: unknown): HistoryStateRecord {
   if (!state || typeof state !== "object") {
@@ -252,6 +263,21 @@ function createNavigationSnapshotUrl(snapshot: ClientNavigationRenderSnapshot): 
   return query === "" ? snapshot.pathname : `${snapshot.pathname}?${query}`;
 }
 
+function createMountedParallelSlotSnapshots(
+  elements: AppElements,
+): readonly MountedParallelSlotSnapshotV0[] {
+  const snapshots: MountedParallelSlotSnapshotV0[] = [];
+  for (const slotId of getMountedSlotIds(elements)) {
+    const parsed = AppElementsWire.parseElementKey(slotId);
+    if (parsed?.kind !== "slot") continue;
+    snapshots.push({
+      ownerLayoutId: AppElementsWire.encodeLayoutId(parsed.treePath),
+      slotId,
+    });
+  }
+  return snapshots;
+}
+
 function createVisibleRouteSnapshot(state: AppRouterState): RouteSnapshotV0 {
   const displayUrl = createNavigationSnapshotUrl(state.navigationSnapshot);
   return {
@@ -261,6 +287,7 @@ function createVisibleRouteSnapshot(state: AppRouterState): RouteSnapshotV0 {
     // traces. `matchedUrl` stays path-only because route matching has already
     // consumed query params before AppElements metadata reaches this boundary.
     matchedUrl: state.navigationSnapshot.pathname,
+    mountedParallelSlots: createMountedParallelSlotSnapshots(state.elements),
     rootBoundaryId: state.rootLayoutTreePath,
     routeId: state.routeId,
   };
@@ -274,6 +301,7 @@ function createPendingRouteSnapshot(pending: PendingNavigationCommit): RouteSnap
     // See createVisibleRouteSnapshot: matchedUrl intentionally models the route
     // identity, not the address bar URL.
     matchedUrl: pending.action.navigationSnapshot.pathname,
+    mountedParallelSlots: createMountedParallelSlotSnapshots(pending.action.elements),
     rootBoundaryId: pending.rootLayoutTreePath,
     routeId: pending.routeId,
   };
@@ -344,6 +372,7 @@ function mapNavigationDecisionToPendingDisposition(
     case "proposeCommit":
       return {
         disposition: "dispatch",
+        preserveAbsentSlots: decision.proposal.preserveAbsentSlots,
         preserveElementIds: decision.proposal.preserveElementIds,
         trace: decision.trace,
       };

--- a/packages/vinext/src/server/app-browser-visible-commit.ts
+++ b/packages/vinext/src/server/app-browser-visible-commit.ts
@@ -23,6 +23,7 @@ import {
 
 type VisibleCommitDecision = {
   disposition: "commit";
+  preserveAbsentSlots: boolean;
   preserveElementIds: readonly string[];
   trace: NavigationTrace;
 };
@@ -116,6 +117,7 @@ function reduceApprovedVisibleCommitState(
         {
           elements: mergeElements(state.elements, action.elements, {
             clearAbsentSlots: action.type === "traverse",
+            preserveAbsentSlots: commit.decision.preserveAbsentSlots,
             preserveElementIds: commit.decision.preserveElementIds,
           }),
           interceptionContext: action.interceptionContext,
@@ -163,18 +165,21 @@ function resolvePendingNavigationCommitDecision(options: {
   startedNavigationId: number;
   targetHref: string;
 }): CommitDecision {
-  const { disposition, preserveElementIds, trace } =
-    resolvePendingNavigationCommitDispositionDecision(options);
+  const decision = resolvePendingNavigationCommitDispositionDecision(options);
 
-  switch (disposition) {
+  switch (decision.disposition) {
     case "skip":
-      return { disposition: "no-commit", trace };
+      return { disposition: "no-commit", trace: decision.trace };
     case "hard-navigate":
-      return { disposition: "hard-navigate", trace };
+      return { disposition: "hard-navigate", trace: decision.trace };
     case "dispatch":
-      return createVisibleCommitDecision(trace, preserveElementIds);
+      return createVisibleCommitDecision(
+        decision.trace,
+        decision.preserveElementIds,
+        decision.preserveAbsentSlots,
+      );
     default: {
-      const _exhaustive: never = disposition;
+      const _exhaustive: never = decision;
       throw new Error("[vinext] Unknown navigation commit disposition: " + String(_exhaustive));
     }
   }
@@ -183,8 +188,14 @@ function resolvePendingNavigationCommitDecision(options: {
 function createVisibleCommitDecision(
   trace: NavigationTrace = createNavigationTrace(NavigationTraceReasonCodes.commitCurrent),
   preserveElementIds: readonly string[] = [],
+  preserveAbsentSlots: boolean = false,
 ): VisibleCommitDecision {
-  return { disposition: "commit", preserveElementIds: [...preserveElementIds], trace };
+  return {
+    disposition: "commit",
+    preserveAbsentSlots,
+    preserveElementIds: [...preserveElementIds],
+    trace,
+  };
 }
 
 function mergeLayoutFlags(

--- a/packages/vinext/src/server/navigation-planner.ts
+++ b/packages/vinext/src/server/navigation-planner.ts
@@ -216,16 +216,22 @@ function resolveMountedParallelSlotPersistence(
   currentSnapshot: RouteSnapshotV0,
   targetSnapshot: RouteSnapshotV0,
 ): readonly string[] {
-  const preservedLayoutIds = new Set(
-    resolveSameLayoutAncestorPersistence(currentSnapshot, targetSnapshot),
-  );
-  if (preservedLayoutIds.size === 0) return [];
+  const preservedLayoutIds = resolveSameLayoutAncestorPersistence(currentSnapshot, targetSnapshot);
+  return resolveMountedParallelSlotPersistenceForLayouts(currentSnapshot, preservedLayoutIds);
+}
+
+function resolveMountedParallelSlotPersistenceForLayouts(
+  currentSnapshot: RouteSnapshotV0,
+  preservedLayoutIds: readonly string[],
+): readonly string[] {
+  if (preservedLayoutIds.length === 0) return [];
+  const preservedLayoutIdSet = new Set(preservedLayoutIds);
 
   const preservedSlotIds: string[] = [];
   const seenSlotIds = new Set<string>();
   for (const slot of currentSnapshot.mountedParallelSlots) {
     if (slot.ownerLayoutId === null) continue;
-    if (!preservedLayoutIds.has(slot.ownerLayoutId)) continue;
+    if (!preservedLayoutIdSet.has(slot.ownerLayoutId)) continue;
     if (seenSlotIds.has(slot.slotId)) continue;
 
     preservedSlotIds.push(slot.slotId);
@@ -238,9 +244,30 @@ function resolveCurrentRootBoundaryElementPersistence(
   currentSnapshot: RouteSnapshotV0,
   targetSnapshot: RouteSnapshotV0,
 ): readonly string[] {
+  const preservedLayoutIds = resolveSameLayoutAncestorPersistence(currentSnapshot, targetSnapshot);
   return [
-    ...resolveSameLayoutAncestorPersistence(currentSnapshot, targetSnapshot),
-    ...resolveMountedParallelSlotPersistence(currentSnapshot, targetSnapshot),
+    ...preservedLayoutIds,
+    ...resolveMountedParallelSlotPersistenceForLayouts(currentSnapshot, preservedLayoutIds),
+  ];
+}
+
+function resolveCurrentRootBoundaryCommitElementPersistence(options: {
+  currentSnapshot: RouteSnapshotV0;
+  lane: OperationLane;
+  targetSnapshot: RouteSnapshotV0;
+}): readonly string[] {
+  const preservedLayoutIds = resolveSameLayoutAncestorPersistence(
+    options.currentSnapshot,
+    options.targetSnapshot,
+  );
+
+  if (options.lane === "traverse") {
+    return preservedLayoutIds;
+  }
+
+  return [
+    ...preservedLayoutIds,
+    ...resolveMountedParallelSlotPersistenceForLayouts(options.currentSnapshot, preservedLayoutIds),
   ];
 }
 
@@ -296,10 +323,11 @@ function planFlightResponseArrived(options: {
     kind: "proposeCommit",
     proposal: {
       preserveAbsentSlots: false,
-      preserveElementIds: resolveCurrentRootBoundaryElementPersistence(
-        options.state.visibleSnapshot,
-        options.event.result.targetSnapshot,
-      ),
+      preserveElementIds: resolveCurrentRootBoundaryCommitElementPersistence({
+        currentSnapshot: options.state.visibleSnapshot,
+        lane: options.event.token.lane,
+        targetSnapshot: options.event.result.targetSnapshot,
+      }),
       reason: "currentRootBoundary",
       targetSnapshot: options.event.result.targetSnapshot,
     },

--- a/packages/vinext/src/server/navigation-planner.ts
+++ b/packages/vinext/src/server/navigation-planner.ts
@@ -30,9 +30,15 @@ export type RouteSnapshotV0 = {
   // Ordered ancestor-first, with the root layout at index 0. Same-layout
   // persistence uses prefix comparison, so callers must preserve this order.
   layoutIds: readonly string[];
+  mountedParallelSlots: readonly MountedParallelSlotSnapshotV0[];
   rootBoundaryId: string | null;
   displayUrl: string;
   matchedUrl: string;
+};
+
+export type MountedParallelSlotSnapshotV0 = {
+  slotId: string;
+  ownerLayoutId: string | null;
 };
 
 export type NavigationPlannerStateV0 = {
@@ -64,6 +70,7 @@ export type RequestedWork =
   | { kind: "prefetch"; href: string };
 
 export type CommitProposal = {
+  preserveAbsentSlots: boolean;
   preserveElementIds: readonly string[];
   reason: "currentRootBoundary" | "rootBoundaryUnknownFallback";
   targetSnapshot: RouteSnapshotV0;
@@ -205,6 +212,38 @@ function resolveSameLayoutAncestorPersistence(
   return commonLayoutIds;
 }
 
+function resolveMountedParallelSlotPersistence(
+  currentSnapshot: RouteSnapshotV0,
+  targetSnapshot: RouteSnapshotV0,
+): readonly string[] {
+  const preservedLayoutIds = new Set(
+    resolveSameLayoutAncestorPersistence(currentSnapshot, targetSnapshot),
+  );
+  if (preservedLayoutIds.size === 0) return [];
+
+  const preservedSlotIds: string[] = [];
+  const seenSlotIds = new Set<string>();
+  for (const slot of currentSnapshot.mountedParallelSlots) {
+    if (slot.ownerLayoutId === null) continue;
+    if (!preservedLayoutIds.has(slot.ownerLayoutId)) continue;
+    if (seenSlotIds.has(slot.slotId)) continue;
+
+    preservedSlotIds.push(slot.slotId);
+    seenSlotIds.add(slot.slotId);
+  }
+  return preservedSlotIds;
+}
+
+function resolveCurrentRootBoundaryElementPersistence(
+  currentSnapshot: RouteSnapshotV0,
+  targetSnapshot: RouteSnapshotV0,
+): readonly string[] {
+  return [
+    ...resolveSameLayoutAncestorPersistence(currentSnapshot, targetSnapshot),
+    ...resolveMountedParallelSlotPersistence(currentSnapshot, targetSnapshot),
+  ];
+}
+
 function planFlightResponseArrived(options: {
   event: Extract<NavigationEvent, { kind: "flightResponseArrived" }>;
   state: NavigationPlannerStateV0;
@@ -243,6 +282,7 @@ function planFlightResponseArrived(options: {
     return {
       kind: "proposeCommit",
       proposal: {
+        preserveAbsentSlots: true,
         preserveElementIds: [],
         reason: "rootBoundaryUnknownFallback",
         targetSnapshot: options.event.result.targetSnapshot,
@@ -255,7 +295,8 @@ function planFlightResponseArrived(options: {
   return {
     kind: "proposeCommit",
     proposal: {
-      preserveElementIds: resolveSameLayoutAncestorPersistence(
+      preserveAbsentSlots: false,
+      preserveElementIds: resolveCurrentRootBoundaryElementPersistence(
         options.state.visibleSnapshot,
         options.event.result.targetSnapshot,
       ),
@@ -323,5 +364,7 @@ function planNavigation(input: NavigationPlannerInput): NavigationDecisionV0 {
 export const navigationPlanner = {
   classifyRootBoundaryTransition,
   plan: planNavigation,
+  resolveCurrentRootBoundaryElementPersistence,
+  resolveMountedParallelSlotPersistence,
   resolveSameLayoutAncestorPersistence,
 };

--- a/packages/vinext/src/shims/slot.tsx
+++ b/packages/vinext/src/shims/slot.tsx
@@ -29,6 +29,7 @@ export const ParallelSlotsContext = React.createContext<Readonly<
 
 type MergeElementsOptions = {
   clearAbsentSlots?: boolean;
+  preserveAbsentSlots?: boolean;
   preserveElementIds?: readonly string[];
 };
 
@@ -39,6 +40,8 @@ export function mergeElements(
 ): AppElements {
   const clearAbsentSlots =
     typeof options === "boolean" ? options : (options.clearAbsentSlots ?? false);
+  const preserveAbsentSlots =
+    typeof options === "boolean" ? !options : (options.preserveAbsentSlots ?? true);
   const preserveElementIds = typeof options === "boolean" ? [] : (options.preserveElementIds ?? []);
   const merged: Record<string, AppElementValue> = { ...next };
 
@@ -63,16 +66,16 @@ export function mergeElements(
   }
   // On traversal (browser back/forward), the server renders the full destination
   // route tree. A slot absent from next means the destination route tree does not
-  // include it, so clear it rather than keeping the stale prev value. This only
-  // runs for traversals because soft forward navigations may omit parent layout
-  // slots that should be preserved.
+  // include it, so clear it rather than keeping the stale prev value. The legacy
+  // absent-slot path stays opt-in for unpromoted fallbacks; promoted navigation
+  // commits preserve mounted slots through planner-approved preserveElementIds.
   if (clearAbsentSlots) {
     for (const key of slotKeys) {
       if (!Object.hasOwn(next, key)) {
         delete merged[key];
       }
     }
-  } else {
+  } else if (preserveAbsentSlots) {
     for (const key of slotKeys) {
       if (!Object.hasOwn(merged, key) && Object.hasOwn(prev, key)) {
         const value = prev[key];

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -2455,6 +2455,70 @@ describe("app browser entry previousNextUrl helpers", () => {
     expect(Object.hasOwn(nextState.elements, "slot:modal:/feed")).toBe(false);
   });
 
+  it("clears planner-approved mounted parallel slots on approved traverse commits", async () => {
+    const feedLayout = React.createElement("div", null, "feed layout");
+    const mountedSlot = React.createElement("div", null, "modal");
+    const state = createState({
+      elements: createResolvedElements(
+        "route:/feed",
+        "/",
+        null,
+        {
+          "layout:/": React.createElement("div", null, "root layout"),
+          "layout:/feed": feedLayout,
+          "slot:modal:/feed": mountedSlot,
+        },
+        ["layout:/", "layout:/feed"],
+      ),
+      layoutIds: ["layout:/", "layout:/feed"],
+      navigationSnapshot: createClientNavigationRenderSnapshot("https://example.com/feed", {}),
+      routeId: "route:/feed",
+    });
+    const pending = await createPendingNavigationCommit({
+      currentState: state,
+      nextElements: Promise.resolve(
+        createResolvedElements(
+          "route:/feed/comments",
+          "/",
+          null,
+          {
+            "page:/feed/comments": React.createElement("main", null, "comments"),
+          },
+          ["layout:/", "layout:/feed", "layout:/feed/comments"],
+        ),
+      ),
+      navigationSnapshot: createClientNavigationRenderSnapshot(
+        "https://example.com/feed/comments",
+        {},
+      ),
+      operationLane: "traverse",
+      previousNextUrl: null,
+      renderId: 1,
+      type: "traverse",
+    });
+
+    const approval = approvePendingNavigationCommit({
+      activeNavigationId: 1,
+      currentState: state,
+      pending,
+      startedNavigationId: 1,
+      targetHref: "https://example.com/feed/comments",
+    });
+
+    expect(approval.decision.disposition).toBe("commit");
+    if (approval.decision.disposition !== "commit") {
+      throw new Error("Expected visible commit approval");
+    }
+    expect(approval.decision.preserveElementIds).toContain("slot:modal:/feed");
+    if (approval.approvedCommit === null) {
+      throw new Error("Expected approved visible commit");
+    }
+
+    const nextState = applyApprovedVisibleCommit(state, approval.approvedCommit);
+    expect(nextState.elements["layout:/feed"]).toBe(feedLayout);
+    expect(Object.hasOwn(nextState.elements, "slot:modal:/feed")).toBe(false);
+  });
+
   it("preserves planner-approved mounted parallel slots on approved navigate commits", async () => {
     const mountedSlot = React.createElement("div", null, "modal");
     const state = createState({

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -844,6 +844,7 @@ describe("app browser entry state helpers", () => {
     if (approval.decision.disposition !== "commit") {
       throw new Error("Expected visible commit approval");
     }
+    expect(approval.decision.preserveAbsentSlots).toBe(false);
     if (approval.approvedCommit === null) {
       throw new Error("Expected approved visible commit");
     }
@@ -902,6 +903,10 @@ describe("app browser entry state helpers", () => {
     });
 
     expect(approval.decision.disposition).toBe("commit");
+    if (approval.decision.disposition !== "commit") {
+      throw new Error("Expected visible commit approval");
+    }
+    expect(approval.decision.preserveAbsentSlots).toBe(true);
     expect(approval.decision.trace.entries[0]?.code).toBe(
       NavigationTraceTransactionCodes.visibleCommit,
     );
@@ -2450,19 +2455,62 @@ describe("app browser entry previousNextUrl helpers", () => {
     expect(Object.hasOwn(nextState.elements, "slot:modal:/feed")).toBe(false);
   });
 
-  it("preserves absent parallel slots on approved navigate commits", async () => {
+  it("preserves planner-approved mounted parallel slots on approved navigate commits", async () => {
+    const mountedSlot = React.createElement("div", null, "modal");
     const state = createState({
-      elements: createResolvedElements("route:/feed", "/", null, {
-        "slot:modal:/feed": React.createElement("div", null, "modal"),
-      }),
+      elements: createResolvedElements(
+        "route:/feed",
+        "/",
+        null,
+        {
+          "layout:/": React.createElement("div", null, "root layout"),
+          "layout:/feed": React.createElement("div", null, "feed layout"),
+          "slot:modal:/feed": mountedSlot,
+        },
+        ["layout:/", "layout:/feed"],
+      ),
+      layoutIds: ["layout:/", "layout:/feed"],
     });
 
     const nextState = await applyApprovedTestCommit(state, {
+      extraEntries: {
+        "page:/feed/comments": React.createElement("main", null, "comments"),
+      },
+      layoutIds: ["layout:/", "layout:/feed", "layout:/feed/comments"],
       rootLayoutTreePath: "/",
       routeId: "route:/feed/comments",
     });
 
     expect(Object.hasOwn(nextState.elements, "slot:modal:/feed")).toBe(true);
+    expect(nextState.elements["slot:modal:/feed"]).toBe(mountedSlot);
+  });
+
+  it("does not preserve absent parallel slots when their owner layout is not approved", async () => {
+    const state = createState({
+      elements: createResolvedElements(
+        "route:/feed",
+        "/",
+        null,
+        {
+          "layout:/": React.createElement("div", null, "root layout"),
+          "layout:/feed": React.createElement("div", null, "feed layout"),
+          "slot:modal:/feed": React.createElement("div", null, "modal"),
+        },
+        ["layout:/", "layout:/feed"],
+      ),
+      layoutIds: ["layout:/", "layout:/feed"],
+    });
+
+    const nextState = await applyApprovedTestCommit(state, {
+      extraEntries: {
+        "page:/settings": React.createElement("main", null, "settings"),
+      },
+      layoutIds: ["layout:/", "layout:/settings"],
+      rootLayoutTreePath: "/",
+      routeId: "route:/settings",
+    });
+
+    expect(Object.hasOwn(nextState.elements, "slot:modal:/feed")).toBe(false);
   });
 });
 

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -2455,7 +2455,7 @@ describe("app browser entry previousNextUrl helpers", () => {
     expect(Object.hasOwn(nextState.elements, "slot:modal:/feed")).toBe(false);
   });
 
-  it("clears planner-approved mounted parallel slots on approved traverse commits", async () => {
+  it("does not approve mounted parallel slots on approved traverse commits", async () => {
     const feedLayout = React.createElement("div", null, "feed layout");
     const mountedSlot = React.createElement("div", null, "modal");
     const state = createState({
@@ -2509,7 +2509,7 @@ describe("app browser entry previousNextUrl helpers", () => {
     if (approval.decision.disposition !== "commit") {
       throw new Error("Expected visible commit approval");
     }
-    expect(approval.decision.preserveElementIds).toContain("slot:modal:/feed");
+    expect(approval.decision.preserveElementIds).toEqual(["layout:/", "layout:/feed"]);
     if (approval.approvedCommit === null) {
       throw new Error("Expected approved visible commit");
     }

--- a/tests/navigation-planner.test.ts
+++ b/tests/navigation-planner.test.ts
@@ -261,6 +261,59 @@ describe("navigationPlanner root-boundary decisions", () => {
     ).toEqual(["layout:/"]);
   });
 
+  it("does not approve mounted parallel slot preservation for traverse commits", () => {
+    const currentSnapshot: RouteSnapshotV0 = {
+      ...createRouteSnapshot(
+        "/",
+        ["layout:/", "layout:/feed"],
+        [{ ownerLayoutId: "layout:/feed", slotId: "slot:modal:/feed" }],
+      ),
+      displayUrl: "https://example.com/feed",
+      matchedUrl: "/feed",
+      routeId: "route:/feed",
+    };
+    const targetSnapshot: RouteSnapshotV0 = {
+      ...createRouteSnapshot("/", ["layout:/", "layout:/feed", "layout:/feed/comments"]),
+      displayUrl: "https://example.com/feed/comments",
+      matchedUrl: "/feed/comments",
+      routeId: "route:/feed/comments",
+    };
+    const token = createOperationToken({
+      lane: "traverse",
+      targetSnapshotFingerprint: "route:/feed/comments|root:/",
+    });
+
+    const decision = navigationPlanner.plan({
+      event: {
+        kind: "flightResponseArrived",
+        result: {
+          href: "https://example.com/feed/comments",
+          targetSnapshot,
+        },
+        token,
+      },
+      routeManifest: null,
+      state: {
+        nextOperationToken: token,
+        traceFields: {
+          currentRootLayoutTreePath: "/",
+          currentVisibleCommitVersion: 2,
+          nextRootLayoutTreePath: "/",
+          startedVisibleCommitVersion: 2,
+        },
+        visibleCommitVersion: 2,
+        visibleSnapshot: currentSnapshot,
+      },
+    });
+
+    expect(decision.kind).toBe("proposeCommit");
+    if (decision.kind !== "proposeCommit") {
+      throw new Error("Expected proposeCommit decision");
+    }
+    expect(decision.proposal.preserveAbsentSlots).toBe(false);
+    expect(decision.proposal.preserveElementIds).toEqual(["layout:/", "layout:/feed"]);
+  });
+
   it("does not preserve layouts across root-boundary uncertainty", () => {
     const currentSnapshot = createRouteSnapshot("/", ["layout:/"]);
     const targetSnapshot = createRouteSnapshot(null, ["layout:/"]);

--- a/tests/navigation-planner.test.ts
+++ b/tests/navigation-planner.test.ts
@@ -6,6 +6,7 @@ import {
 import {
   navigationPlanner,
   type FlightResultV0,
+  type MountedParallelSlotSnapshotV0,
   type NavigationDecisionV0,
   type NavigationEvent,
   type NavigationPlannerInput,
@@ -19,11 +20,13 @@ import {
 function createRouteSnapshot(
   rootBoundaryId: string | null,
   layoutIds: readonly string[] = rootBoundaryId === null ? [] : [`layout:${rootBoundaryId}`],
+  mountedParallelSlots: readonly MountedParallelSlotSnapshotV0[] = [],
 ): RouteSnapshotV0 {
   return {
     displayUrl: "https://example.com/dashboard",
     layoutIds,
     matchedUrl: "/dashboard",
+    mountedParallelSlots,
     rootBoundaryId,
     routeId: "route:/dashboard",
   };
@@ -117,6 +120,7 @@ describe("navigationPlanner root-boundary decisions", () => {
     if (decision.kind !== "proposeCommit") {
       throw new Error("Expected proposeCommit decision");
     }
+    expect(decision.proposal.preserveAbsentSlots).toBe(false);
     expect(decision.proposal.targetSnapshot.rootBoundaryId).toBe("/");
     expect(decision.proposal.preserveElementIds).toEqual(["layout:/"]);
     expect(decision.trace).toEqual({
@@ -170,6 +174,7 @@ describe("navigationPlanner root-boundary decisions", () => {
       throw new Error("Expected proposeCommit decision");
     }
     expect(decision.proposal.reason).toBe("rootBoundaryUnknownFallback");
+    expect(decision.proposal.preserveAbsentSlots).toBe(true);
     expect(decision.proposal.preserveElementIds).toEqual([]);
     expect(decision.trace.entries[0]?.code).toBe(NavigationTraceReasonCodes.rootBoundaryUnknown);
   });
@@ -187,6 +192,7 @@ describe("navigationPlanner root-boundary decisions", () => {
       throw new Error("Expected proposeCommit decision");
     }
     expect(decision.proposal.reason).toBe("rootBoundaryUnknownFallback");
+    expect(decision.proposal.preserveAbsentSlots).toBe(true);
     expect(decision.proposal.preserveElementIds).toEqual([]);
     expect(decision.trace.entries[0]?.code).toBe(NavigationTraceReasonCodes.rootBoundaryUnknown);
   });
@@ -206,6 +212,53 @@ describe("navigationPlanner root-boundary decisions", () => {
     expect(
       navigationPlanner.resolveSameLayoutAncestorPersistence(currentSnapshot, targetSnapshot),
     ).toEqual(["layout:/", "layout:/dashboard"]);
+  });
+
+  it("preserves mounted parallel slots owned by approved same-layout ancestors", () => {
+    // Mirrors Next.js mounted parallel route preservation covered by:
+    // .nextjs-ref/test/e2e/app-dir/parallel-routes-and-interception-catchall/parallel-routes-and-interception-catchall.test.ts
+    const currentSnapshot = createRouteSnapshot(
+      "/",
+      ["layout:/", "layout:/feed"],
+      [
+        { ownerLayoutId: "layout:/feed", slotId: "slot:modal:/feed" },
+        { ownerLayoutId: "layout:/other", slotId: "slot:stale:/other" },
+      ],
+    );
+    const targetSnapshot = createRouteSnapshot("/", [
+      "layout:/",
+      "layout:/feed",
+      "layout:/feed/comments",
+    ]);
+
+    expect(
+      navigationPlanner.resolveMountedParallelSlotPersistence(currentSnapshot, targetSnapshot),
+    ).toEqual(["slot:modal:/feed"]);
+    expect(
+      navigationPlanner.resolveCurrentRootBoundaryElementPersistence(
+        currentSnapshot,
+        targetSnapshot,
+      ),
+    ).toEqual(["layout:/", "layout:/feed", "slot:modal:/feed"]);
+  });
+
+  it("does not preserve mounted parallel slots when their owner layout is not retained", () => {
+    const currentSnapshot = createRouteSnapshot(
+      "/",
+      ["layout:/", "layout:/feed"],
+      [{ ownerLayoutId: "layout:/feed", slotId: "slot:modal:/feed" }],
+    );
+    const targetSnapshot = createRouteSnapshot("/", ["layout:/", "layout:/settings"]);
+
+    expect(
+      navigationPlanner.resolveMountedParallelSlotPersistence(currentSnapshot, targetSnapshot),
+    ).toEqual([]);
+    expect(
+      navigationPlanner.resolveCurrentRootBoundaryElementPersistence(
+        currentSnapshot,
+        targetSnapshot,
+      ),
+    ).toEqual(["layout:/"]);
   });
 
   it("does not preserve layouts across root-boundary uncertainty", () => {

--- a/tests/slot.test.ts
+++ b/tests/slot.test.ts
@@ -361,6 +361,47 @@ describe("slot primitives", () => {
     expect(Object.hasOwn(merged, "slot:team:/dashboard")).toBe(true);
   });
 
+  it("mergeElements drops absent slots when legacy absent-slot preservation is fenced", async () => {
+    const { mergeElements } = await import("../packages/vinext/src/shims/slot.js");
+
+    const merged = mergeElements(
+      {
+        "layout:/": React.createElement("div", null, "layout"),
+        "page:/dashboard": React.createElement("div", null, "dashboard"),
+        "slot:team:/dashboard": React.createElement("div", null, "team panel"),
+      },
+      {
+        "page:/dashboard/settings": React.createElement("div", null, "settings"),
+      },
+      { preserveAbsentSlots: false },
+    );
+
+    expect(Object.hasOwn(merged, "slot:team:/dashboard")).toBe(false);
+  });
+
+  it("mergeElements preserves explicitly approved mounted slots without wire absence semantics", async () => {
+    const { mergeElements } = await import("../packages/vinext/src/shims/slot.js");
+
+    const mountedSlot = React.createElement("div", null, "team panel");
+    const merged = mergeElements(
+      {
+        "layout:/": React.createElement("div", null, "layout"),
+        "layout:/dashboard": React.createElement("div", null, "dashboard layout"),
+        "page:/dashboard": React.createElement("div", null, "dashboard"),
+        "slot:team:/dashboard": mountedSlot,
+      },
+      {
+        "page:/dashboard/settings": React.createElement("div", null, "settings"),
+      },
+      {
+        preserveAbsentSlots: false,
+        preserveElementIds: ["layout:/", "layout:/dashboard", "slot:team:/dashboard"],
+      },
+    );
+
+    expect(merged["slot:team:/dashboard"]).toBe(mountedSlot);
+  });
+
   it("Slot renders element from resolved context", async () => {
     const mod = await import("../packages/vinext/src/shims/slot.js");
 


### PR DESCRIPTION
## Overview

| Field | Details |
| --- | --- |
| Goal | Implement `#726-CORE-13` from #726 by moving mounted parallel slot preservation through the planner and visible commit path. |
| Core change | Route snapshots now carry mounted parallel slot ownership, and current-root commit proposals preserve slots only when their owner layout is in the approved same-layout prefix. |
| Main boundary | AppElements wire-key absence is no longer the proof for promoted same-root commits. The legacy absent-slot path is fenced behind unknown-root fallback only. |
| Primary files | `navigation-planner.ts`, `app-browser-state.ts`, `app-browser-visible-commit.ts`, `slot.tsx` |
| Expected impact | Same mounted-slot soft-navigation behaviour, with explicit planner proof. No default/unmatched slot semantic promotion and no interception promotion in this PR. |

## Why

Mounted slot preservation is only correct when the router can prove the slot is currently mounted and the layout that owns that slot is retained by the candidate commit. The architecture in #726 requires that proof to live in the planner/lifecycle path, not in missing flat payload entries.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| Planner ownership | Route meaning belongs to `NavigationPlanner`, not AppElements wire absence. | Adds mounted parallel slot facts to `RouteSnapshotV0` and includes approved slot ids in the commit proposal. |
| Commit authority | Visible state mutates only through an approved visible commit. | Carries `preserveAbsentSlots` and `preserveElementIds` from planner proposal to the approved commit reducer. |
| Legacy fallback | Unknown root identity is fallback/uncertainty, not proof. | Keeps the old absent-slot merge path only for unknown-root fallback, while current-root promoted commits require explicit ids. |

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| Same-root soft navigation with mounted slot under retained owner layout | Browser preserved because the slot key was absent from the next payload. | Planner preserves the mounted slot id because its owner layout is in the approved common layout prefix. |
| Same-root navigation where slot owner layout is not retained | Browser could preserve stale absent slots via wire absence. | Approved current-root commits drop absent slots unless the planner explicitly approved the slot id. |
| Unknown-root fallback | Used the legacy soft merge behaviour. | Still uses the legacy absent-slot path, explicitly fenced as fallback. |
| Traversal | Clears stale absent slots. | Unchanged. |

<details>
<summary>Maintainer review path</summary>

1. `packages/vinext/src/server/navigation-planner.ts`: mounted slot ownership joins the planner snapshot, and current-root proposals now compute layout and slot preservation together.
2. `packages/vinext/src/server/app-browser-state.ts`: browser state converts mounted AppElements slot ids into owner-layout facts at the codec boundary before calling the planner.
3. `packages/vinext/src/server/app-browser-visible-commit.ts`: approved commits carry the planner's absent-slot fallback decision into `mergeElements`.
4. `packages/vinext/src/shims/slot.tsx`: `mergeElements` keeps the old absent-slot behaviour opt-in and preserves explicitly approved ids independently.
5. Tests: planner, merge, and browser-state tests cover the promoted path and the fenced legacy path.

</details>

<details>
<summary>Validation</summary>

- `vp test run tests/navigation-planner.test.ts tests/slot.test.ts tests/app-browser-entry.test.ts tests/app-page-route-wiring.test.ts` 142 tests passed.
- `vp check` completed with 0 errors. It reported two existing warnings in `tests/head.test.ts` for `dangerouslySetInnerHTML` plus `children`, unrelated to this PR.
- `git diff --check` passed.

</details>

<details>
<summary>Risk / compatibility</summary>

- Public API: no new public API surface.
- App Router runtime: promoted same-root commits now require explicit planner-approved slot ids rather than broad absent-slot preservation.
- Fallback compatibility: unknown-root fallback intentionally keeps legacy absent-slot preservation.
- Non-goals: default/unmatched slot semantics, intercepted route preservation, cache reuse, and skip transport remain outside this slice.

</details>

## Bonk

Bonk, please read issue #726 to understand the architectural big picture before reviewing this slice.

## References

| Reference | Why it matters |
| --- | --- |
| #726 | Original architecture issue and invariant source. |
| `#726-CORE-13` | Roadmap task implemented here: promote mounted parallel slot preservation. |
| Next.js `test/e2e/app-dir/parallel-routes-and-interception-catchall/parallel-routes-and-interception-catchall.test.ts` | Source behaviour for preserving other mounted slots during intercepted parallel-route navigation. |