### PR TITLE
fix(shims): add placeholder useRouter bfcacheId

### DIFF
--- a/packages/vinext/src/shims/internal/app-router-context.ts
+++ b/packages/vinext/src/shims/internal/app-router-context.ts
@@ -18,6 +18,7 @@ export type PrefetchOptions = {
 };
 
 export type AppRouterInstance = {
+  bfcacheId: string;
   back(): void;
   forward(): void;
   refresh(): void;

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -1235,6 +1235,7 @@ export async function navigateClientSide(
 // ---------------------------------------------------------------------------
 
 const _appRouter = {
+  bfcacheId: "0",
   push(href: string, options?: { scroll?: boolean }): void {
     assertSafeNavigationUrl(href);
     if (isServer) return;

--- a/packages/vinext/src/shims/next-shims.d.ts
+++ b/packages/vinext/src/shims/next-shims.d.ts
@@ -124,6 +124,7 @@ declare module "next/link" {
 
 declare module "next/navigation" {
   export function useRouter(): {
+    bfcacheId: string;
     push(href: string, options?: { scroll?: boolean }): void;
     replace(href: string, options?: { scroll?: boolean }): void;
     back(): void;

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -49,6 +49,15 @@ describe("next/navigation shim", () => {
     expect(typeof router.prefetch).toBe("function");
   });
 
+  it("useRouter() exposes the stable bfcacheId placeholder", async () => {
+    const { useRouter } = await import("../packages/vinext/src/shims/navigation.js");
+    const first = useRouter();
+    const second = useRouter();
+    expect(typeof first.bfcacheId).toBe("string");
+    expect(first.bfcacheId).toBe("0");
+    expect(second.bfcacheId).toBe(first.bfcacheId);
+  });
+
   // Next.js parity: refresh-reducer.ts invalidates the entire segment cache.
   // Our equivalent is clearClientNavigationCaches(), which router.refresh()
   // must call before re-fetching, or stale cached RSC payloads for sibling


### PR DESCRIPTION
## Summary

Closes #1182.

This PR adds API-surface compatibility for Next.js' new `useRouter().bfcacheId` field from `next/navigation`.

For now, vinext returns the stable `"0"` placeholder. This matches the upstream default / adapter fallback behavior and keeps typed consumers or libraries that destructure `bfcacheId` from breaking.

## Changes

- Add `bfcacheId: "0"` to the App Router singleton returned by `useRouter()`.
- Add `bfcacheId: string` to the `next/navigation` shim type declaration.
- Add `bfcacheId: string` to the internal `AppRouterInstance` compatibility type.
- Add a focused shim test covering the stable placeholder value.

## Notes

This intentionally does not implement full segment-scoped `bfcacheId` semantics yet.

Full parity would require vinext to model Next.js' CacheNode / segment-cache behavior, including:

- minting per-segment ids
- changing ids on fresh `push` / `replace`
- restoring ids on browser back / forward
- preserving ids across `router.refresh()`, search-param-only, and hash-only navigations

That should remain a follow-up tied to a future segment-cache implementation.

Upstream reference:
https://github.com/vercel/next.js/commit/56d95137fd6d84f4bc1e5ef2bb31e0136d5fad9c

## Testing

- `CI=true pnpm test tests/shims.test.ts -t "useRouter"`
- `pnpm exec vp check packages/vinext/src/shims/navigation.ts packages/vinext/src/shims/next-shims.d.ts packages/vinext/src/shims/internal/app-router-context.ts tests/shims.test.ts`
