### PR TITLE
feat(dev): add dev server lock file

### DIFF
--- a/packages/vinext/src/cli.ts
+++ b/packages/vinext/src/cli.ts
@@ -30,6 +30,11 @@ import { loadNextConfig, resolveNextConfig, PHASE_PRODUCTION_BUILD } from "./con
 import { emitStandaloneOutput } from "./build/standalone.js";
 import { resolveVinextPackageRoot } from "./utils/vinext-root.js";
 import { parseArgs } from "./cli-args.js";
+import {
+  type DevLockfile,
+  formatAlreadyRunningError,
+  tryAcquireLockfile,
+} from "./server/dev-lockfile.js";
 
 // ─── Resolve Vite from the project root ────────────────────────────────────────
 //
@@ -299,6 +304,41 @@ async function dev() {
   const port = parsed.port ?? 3000;
   const host = parsed.hostname ?? "localhost";
 
+  // Acquire the dev lock file. If another live `vinext dev` is running in this
+  // directory, print an actionable error (PID + URL) and exit. This is
+  // especially useful for AI coding agents, which frequently attempt to start
+  // a dev server without knowing one is already running.
+  //
+  // Disabled when VINEXT_NO_DEV_LOCK is set (escape hatch for unusual setups).
+  let lockfile: DevLockfile | undefined;
+  if (process.env.VINEXT_NO_DEV_LOCK !== "1") {
+    const root = process.cwd();
+    const acquired = tryAcquireLockfile({
+      root,
+      info: {
+        pid: process.pid,
+        port,
+        hostname: host,
+        appUrl: `http://${host}:${port}`,
+        startedAt: Date.now(),
+        cwd: root,
+      },
+    });
+    if (!acquired.ok) {
+      console.error(
+        "\n  " +
+          formatAlreadyRunningError({
+            existing: acquired.existing,
+            cwd: root,
+            lockfilePath: acquired.lockfilePath,
+          }).replace(/\n/g, "\n  ") +
+          "\n",
+      );
+      process.exit(1);
+    }
+    lockfile = acquired.lockfile;
+  }
+
   console.log(`\n  vinext dev  (Vite ${getViteVersion()})\n`);
 
   const config = buildViteConfig({
@@ -308,6 +348,23 @@ async function dev() {
   const server = await vite.createServer(config);
   await server.listen();
   server.printUrls();
+
+  // Once the server is actually listening, the port may have changed (e.g.
+  // Vite picked a free port if the requested one was in use). Update the
+  // lock file so other tools see the right port/URL.
+  if (lockfile) {
+    const address = server.httpServer?.address();
+    const actualPort = typeof address === "object" && address ? address.port : port;
+    const actualHost = host;
+    lockfile.update({
+      pid: process.pid,
+      port: actualPort,
+      hostname: actualHost,
+      appUrl: `http://${actualHost}:${actualPort}`,
+      startedAt: Date.now(),
+      cwd: process.cwd(),
+    });
+  }
 }
 
 async function buildApp() {

--- a/packages/vinext/src/cli.ts
+++ b/packages/vinext/src/cli.ts
@@ -313,13 +313,17 @@ async function dev() {
   let lockfile: DevLockfile | undefined;
   if (process.env.VINEXT_NO_DEV_LOCK !== "1") {
     const root = process.cwd();
+    // Substitute "localhost" for wildcard binds so the URL is actually
+    // clickable when surfaced in the lock file before server.listen() has
+    // had a chance to resolve the real URL.
+    const initialDisplayHost = host === "0.0.0.0" ? "localhost" : host;
     const acquired = tryAcquireLockfile({
       root,
       info: {
         pid: process.pid,
         port,
         hostname: host,
-        appUrl: `http://${host}:${port}`,
+        appUrl: `http://${initialDisplayHost}:${port}`,
         startedAt: Date.now(),
         cwd: root,
       },
@@ -352,15 +356,33 @@ async function dev() {
   // Once the server is actually listening, the port may have changed (e.g.
   // Vite picked a free port if the requested one was in use). Update the
   // lock file so other tools see the right port/URL.
+  //
+  // Prefer Vite's resolvedUrls.local[0] because it handles wildcard binds
+  // (e.g. host "0.0.0.0") by substituting "localhost" so the URL is
+  // actually clickable. Fall back to httpServer.address() if Vite didn't
+  // populate resolvedUrls for some reason.
   if (lockfile) {
-    const address = server.httpServer?.address();
-    const actualPort = typeof address === "object" && address ? address.port : port;
-    const actualHost = host;
+    const resolved = server.resolvedUrls?.local[0];
+    let actualPort = port;
+    let appUrl: string;
+    if (resolved) {
+      appUrl = resolved.replace(/\/$/, "");
+      try {
+        const parsed = new URL(appUrl);
+        actualPort = parsed.port ? Number.parseInt(parsed.port, 10) : actualPort;
+      } catch {
+        // ignore — keep requested port
+      }
+    } else {
+      const address = server.httpServer?.address();
+      actualPort = typeof address === "object" && address ? address.port : port;
+      appUrl = `http://${host === "0.0.0.0" ? "localhost" : host}:${actualPort}`;
+    }
     lockfile.update({
       pid: process.pid,
       port: actualPort,
-      hostname: actualHost,
-      appUrl: `http://${actualHost}:${actualPort}`,
+      hostname: host,
+      appUrl,
       startedAt: Date.now(),
       cwd: process.cwd(),
     });

--- a/packages/vinext/src/cli.ts
+++ b/packages/vinext/src/cli.ts
@@ -311,6 +311,10 @@ async function dev() {
   //
   // Disabled when VINEXT_NO_DEV_LOCK is set (escape hatch for unusual setups).
   let lockfile: DevLockfile | undefined;
+  // Capture the acquisition timestamp so we can preserve it across the
+  // post-listen update(). `startedAt` is meant to reflect when this process
+  // started, not when the URL was resolved.
+  const startedAt = Date.now();
   if (process.env.VINEXT_NO_DEV_LOCK !== "1") {
     const root = process.cwd();
     // Substitute "localhost" for wildcard binds so the URL is actually
@@ -324,7 +328,7 @@ async function dev() {
         port,
         hostname: host,
         appUrl: `http://${initialDisplayHost}:${port}`,
-        startedAt: Date.now(),
+        startedAt,
         cwd: root,
       },
     });
@@ -349,8 +353,19 @@ async function dev() {
     server: { port, host },
   });
 
-  const server = await vite.createServer(config);
-  await server.listen();
+  // If anything between here and the first successful listen() throws (e.g.
+  // strictPort and the port is taken), release the lock immediately so we
+  // don't leave a misleading "server running" entry behind in the brief
+  // window before the exit handler runs. The exit handler still serves as
+  // a safety net for unexpected exit paths.
+  let server;
+  try {
+    server = await vite.createServer(config);
+    await server.listen();
+  } catch (err) {
+    lockfile?.release();
+    throw err;
+  }
   server.printUrls();
 
   // Once the server is actually listening, the port may have changed (e.g.
@@ -383,7 +398,9 @@ async function dev() {
       port: actualPort,
       hostname: host,
       appUrl,
-      startedAt: Date.now(),
+      // Preserve the original acquire-time startedAt rather than resetting
+      // to "now". startedAt represents when the process started.
+      startedAt,
       cwd: process.cwd(),
     });
   }

--- a/packages/vinext/src/server/dev-lockfile.ts
+++ b/packages/vinext/src/server/dev-lockfile.ts
@@ -2,10 +2,9 @@
  * Dev server lock file.
  *
  * Writes the running dev server's PID, port, and URL into a lock file at
- * `node_modules/.cache/vinext/dev-lock.json`. When a second `vinext dev`
- * process starts in the same project directory, it reads the lock file and
- * either fails with an actionable error or, if the previous process is dead,
- * takes over the lock.
+ * `<root>/.vinext/dev/lock.json`. When a second `vinext dev` process starts in
+ * the same project directory, it reads the lock file and either fails with an
+ * actionable error or, if the previous process is dead, takes over the lock.
  *
  * This is especially useful for AI coding agents, which frequently attempt to
  * start `vinext dev` without knowing a server is already running.
@@ -19,15 +18,17 @@
  *   (`process.kill(pid, 0)`), which is good enough for the dev-server
  *   "another server is running" use case. Race conditions on lock acquisition
  *   are tolerated: at worst, two dev servers race and one fails to bind a port.
- * - Lock file lives in `node_modules/.cache/vinext/` instead of `.next/dev/`,
- *   matching vinext's existing convention of not maintaining a `.next` dir.
+ * - Lock file lives in `<root>/.vinext/dev/lock.json` (mirroring Next.js'
+ *   `.next/dev/lock` layout). `.vinext/` is already used by the fonts plugin
+ *   to cache self-hosted Google Fonts, so this re-uses the same project-local
+ *   state directory rather than polluting `node_modules`.
  */
 
 import fs from "node:fs";
 import path from "node:path";
 
-const LOCK_DIR_RELATIVE = path.join("node_modules", ".cache", "vinext");
-const LOCK_FILE_NAME = "dev-lock.json";
+const LOCK_DIR_RELATIVE = path.join(".vinext", "dev");
+const LOCK_FILE_NAME = "lock.json";
 
 /**
  * Information about a running dev server, stored inside the lock file itself.
@@ -169,7 +170,7 @@ export function formatAlreadyRunningError(opts: FormatErrorOptions): string {
 }
 
 type AcquireOptions = {
-  /** Project root. Lock file goes in `<root>/node_modules/.cache/vinext/`. */
+  /** Project root. Lock file goes in `<root>/.vinext/dev/lock.json`. */
   root: string;
   /** Initial server info to write. Port/URL may be updated later via `update()`. */
   info: DevServerInfo;

--- a/packages/vinext/src/server/dev-lockfile.ts
+++ b/packages/vinext/src/server/dev-lockfile.ts
@@ -116,7 +116,7 @@ function writeLockfile(lockfilePath: string, info: DevServerInfo): void {
   fs.writeFileSync(lockfilePath, JSON.stringify(info, null, 2));
 }
 
-export type FormatErrorOptions = {
+type FormatErrorOptions = {
   /** Existing server info from the lock file, if readable. */
   existing: DevServerInfo | undefined;
   /** Project directory the new (failing) process is trying to run in. */
@@ -158,7 +158,7 @@ export function formatAlreadyRunningError(opts: FormatErrorOptions): string {
   ].join("\n");
 }
 
-export type AcquireOptions = {
+type AcquireOptions = {
   /** Project root. Lock file goes in `<root>/node_modules/.cache/vinext/`. */
   root: string;
   /** Initial server info to write. Port/URL may be updated later via `update()`. */
@@ -172,12 +172,12 @@ export type AcquireOptions = {
   unlockOnExit?: boolean;
 };
 
-export type AcquireSuccess = {
+type AcquireSuccess = {
   ok: true;
   lockfile: DevLockfile;
 };
 
-export type AcquireFailure = {
+type AcquireFailure = {
   ok: false;
   /** The server info from the existing lock file, if readable. */
   existing: DevServerInfo | undefined;
@@ -185,7 +185,7 @@ export type AcquireFailure = {
   lockfilePath: string;
 };
 
-export type AcquireResult = AcquireSuccess | AcquireFailure;
+type AcquireResult = AcquireSuccess | AcquireFailure;
 
 /**
  * Try to acquire the dev lock file for the given project root.

--- a/packages/vinext/src/server/dev-lockfile.ts
+++ b/packages/vinext/src/server/dev-lockfile.ts
@@ -1,0 +1,259 @@
+/**
+ * Dev server lock file.
+ *
+ * Writes the running dev server's PID, port, and URL into a lock file at
+ * `node_modules/.cache/vinext/dev-lock.json`. When a second `vinext dev`
+ * process starts in the same project directory, it reads the lock file and
+ * either fails with an actionable error or, if the previous process is dead,
+ * takes over the lock.
+ *
+ * This is especially useful for AI coding agents, which frequently attempt to
+ * start `vinext dev` without knowing a server is already running.
+ *
+ * Ported behaviorally from Next.js:
+ *   https://github.com/vercel/next.js/blob/canary/packages/next/src/build/lockfile.ts
+ *
+ * Differences vs Next.js:
+ * - No native `flock()`. Next.js uses Rust SWC bindings for cross-platform
+ *   advisory locking; vinext uses a JSON file plus a PID liveness check
+ *   (`process.kill(pid, 0)`), which is good enough for the dev-server
+ *   "another server is running" use case. Race conditions on lock acquisition
+ *   are tolerated: at worst, two dev servers race and one fails to bind a port.
+ * - Lock file lives in `node_modules/.cache/vinext/` instead of `.next/dev/`,
+ *   matching vinext's existing convention of not maintaining a `.next` dir.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+const LOCK_DIR_RELATIVE = path.join("node_modules", ".cache", "vinext");
+const LOCK_FILE_NAME = "dev-lock.json";
+
+/**
+ * Information about a running dev server, stored inside the lock file itself.
+ */
+export type DevServerInfo = {
+  pid: number;
+  port: number;
+  hostname: string;
+  appUrl: string;
+  startedAt: number;
+  /** Project directory the server is running in. Used to detect stale entries. */
+  cwd: string;
+};
+
+export type DevLockfile = {
+  /** Update the lock file contents (e.g. once the port is known after listen). */
+  update(info: DevServerInfo): void;
+  /** Release the lock — deletes the file. Safe to call multiple times. */
+  release(): void;
+  /** Absolute path to the lock file. */
+  path: string;
+};
+
+/**
+ * Returns the absolute path to the lock file for a given project root.
+ */
+export function getLockfilePath(root: string): string {
+  return path.join(root, LOCK_DIR_RELATIVE, LOCK_FILE_NAME);
+}
+
+/**
+ * Reads and parses the lock file at the given path. Returns `undefined` if the
+ * file doesn't exist or can't be parsed.
+ */
+export function readLockfile(lockfilePath: string): DevServerInfo | undefined {
+  let content: string;
+  try {
+    content = fs.readFileSync(lockfilePath, "utf-8");
+  } catch {
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(content) as DevServerInfo;
+    if (
+      typeof parsed.pid === "number" &&
+      typeof parsed.port === "number" &&
+      typeof parsed.hostname === "string" &&
+      typeof parsed.appUrl === "string" &&
+      typeof parsed.startedAt === "number" &&
+      typeof parsed.cwd === "string"
+    ) {
+      return parsed;
+    }
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Returns true if a process with the given PID is running.
+ *
+ * Uses `process.kill(pid, 0)`, which sends a null signal — it doesn't actually
+ * kill the process, it just checks if it exists. Throws `ESRCH` if the process
+ * doesn't exist, or `EPERM` if it exists but we don't have permission to
+ * signal it (in which case it's still running, just owned by someone else).
+ */
+export function isPidAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    // EPERM means the process exists but we lack permission — still alive.
+    return code === "EPERM";
+  }
+}
+
+/**
+ * Writes the lock file with the given content. Creates the parent directory
+ * if it doesn't exist.
+ */
+function writeLockfile(lockfilePath: string, info: DevServerInfo): void {
+  fs.mkdirSync(path.dirname(lockfilePath), { recursive: true });
+  fs.writeFileSync(lockfilePath, JSON.stringify(info, null, 2));
+}
+
+export type FormatErrorOptions = {
+  /** Existing server info from the lock file, if readable. */
+  existing: DevServerInfo | undefined;
+  /** Project directory the new (failing) process is trying to run in. */
+  cwd: string;
+  /** Path to the lock file. */
+  lockfilePath: string;
+};
+
+/**
+ * Format the error message printed when another dev server is already running.
+ *
+ * Matches Next.js' error layout so AI agents and CLIs can parse the same
+ * `- PID: ` / `- Local: ` lines.
+ */
+export function formatAlreadyRunningError(opts: FormatErrorOptions): string {
+  const { existing, cwd, lockfilePath } = opts;
+
+  if (!existing) {
+    return [
+      "Another vinext dev server appears to be running in this directory.",
+      "",
+      `Stale lock file: ${path.relative(cwd, lockfilePath)}`,
+      "Remove it manually if no server is running, then re-run `vinext dev`.",
+    ].join("\n");
+  }
+
+  const killCommand =
+    process.platform === "win32" ? `taskkill /PID ${existing.pid} /F` : `kill ${existing.pid}`;
+
+  return [
+    "Another vinext dev server is already running.",
+    "",
+    `- Local:        ${existing.appUrl}`,
+    `- PID:          ${existing.pid}`,
+    `- Dir:          ${existing.cwd}`,
+    "",
+    `You can access the existing server at ${existing.appUrl},`,
+    `or run \`${killCommand}\` to stop it and start a new one.`,
+  ].join("\n");
+}
+
+export type AcquireOptions = {
+  /** Project root. Lock file goes in `<root>/node_modules/.cache/vinext/`. */
+  root: string;
+  /** Initial server info to write. Port/URL may be updated later via `update()`. */
+  info: DevServerInfo;
+  /**
+   * If a lock file exists but its PID is dead, take over instead of failing.
+   * Defaults to `true`. Set to `false` for testing.
+   */
+  takeOverStale?: boolean;
+  /** Register `process.on('exit', release)`. Defaults to `true`. */
+  unlockOnExit?: boolean;
+};
+
+export type AcquireSuccess = {
+  ok: true;
+  lockfile: DevLockfile;
+};
+
+export type AcquireFailure = {
+  ok: false;
+  /** The server info from the existing lock file, if readable. */
+  existing: DevServerInfo | undefined;
+  /** Absolute path to the lock file. */
+  lockfilePath: string;
+};
+
+export type AcquireResult = AcquireSuccess | AcquireFailure;
+
+/**
+ * Try to acquire the dev lock file for the given project root.
+ *
+ * Returns `{ ok: true, lockfile }` on success — the caller should call
+ * `lockfile.release()` on shutdown (or rely on the exit listener registered
+ * via `unlockOnExit`).
+ *
+ * Returns `{ ok: false, existing, lockfilePath }` if another live dev server
+ * already holds the lock.
+ */
+export function tryAcquireLockfile(opts: AcquireOptions): AcquireResult {
+  const { root, info, takeOverStale = true, unlockOnExit = true } = opts;
+  const lockfilePath = getLockfilePath(root);
+
+  const existing = readLockfile(lockfilePath);
+  if (existing) {
+    const alive = isPidAlive(existing.pid);
+    if (alive) {
+      return { ok: false, existing, lockfilePath };
+    }
+    if (!takeOverStale) {
+      return { ok: false, existing, lockfilePath };
+    }
+    // Existing entry is stale (dead PID). Fall through and overwrite.
+  }
+
+  writeLockfile(lockfilePath, info);
+
+  let released = false;
+  const release = () => {
+    if (released) return;
+    released = true;
+    try {
+      // Only delete if the file still points at us. If another process took
+      // over the lock (e.g. after a crash), don't delete their entry.
+      const current = readLockfile(lockfilePath);
+      if (current && current.pid === info.pid) {
+        fs.unlinkSync(lockfilePath);
+      }
+    } catch {
+      // Best-effort cleanup.
+    }
+  };
+
+  let exitListener: NodeJS.ExitListener | undefined;
+  if (unlockOnExit) {
+    exitListener = () => release();
+    process.on("exit", exitListener);
+  }
+
+  const lockfile: DevLockfile = {
+    path: lockfilePath,
+    update(next: DevServerInfo): void {
+      try {
+        writeLockfile(lockfilePath, next);
+      } catch {
+        // Best-effort; not fatal.
+      }
+    },
+    release(): void {
+      release();
+      if (exitListener) {
+        process.off("exit", exitListener);
+        exitListener = undefined;
+      }
+    },
+  };
+
+  return { ok: true, lockfile };
+}

--- a/packages/vinext/src/server/dev-lockfile.ts
+++ b/packages/vinext/src/server/dev-lockfile.ts
@@ -110,10 +110,15 @@ export function isPidAlive(pid: number): boolean {
 /**
  * Writes the lock file with the given content. Creates the parent directory
  * if it doesn't exist.
+ *
+ * Mode `0o600` because the lock file contains a PID that, in principle, lets
+ * other users on the machine send signals to this user's dev server.
+ * Restricting reads is defense-in-depth: the PID is also discoverable via
+ * `ps` and the port via `netstat`/`ss`, so this isn't load-bearing.
  */
 function writeLockfile(lockfilePath: string, info: DevServerInfo): void {
   fs.mkdirSync(path.dirname(lockfilePath), { recursive: true });
-  fs.writeFileSync(lockfilePath, JSON.stringify(info, null, 2));
+  fs.writeFileSync(lockfilePath, JSON.stringify(info, null, 2), { mode: 0o600 });
 }
 
 type FormatErrorOptions = {
@@ -130,11 +135,16 @@ type FormatErrorOptions = {
  *
  * Matches Next.js' error layout so AI agents and CLIs can parse the same
  * `- PID: ` / `- Local: ` lines.
+ *
+ * The `existing: undefined` branch below is defensive — `tryAcquireLockfile`
+ * currently only returns `ok: false` with a defined `existing`, but the
+ * formatter is exported and unit-tested separately, so it handles both shapes.
  */
 export function formatAlreadyRunningError(opts: FormatErrorOptions): string {
   const { existing, cwd, lockfilePath } = opts;
 
   if (!existing) {
+    // Defensive fallback. Not reachable from tryAcquireLockfile today.
     return [
       "Another vinext dev server appears to be running in this directory.",
       "",
@@ -213,7 +223,20 @@ export function tryAcquireLockfile(opts: AcquireOptions): AcquireResult {
     // Existing entry is stale (dead PID). Fall through and overwrite.
   }
 
+  // NB: there is a small TOCTOU window between readLockfile() above and
+  // writeLockfile() here. Two processes starting simultaneously can both
+  // pass the check and both write the lock file. This is intentionally
+  // tolerated — the loser will fail to bind its port, producing a clear
+  // error. A native flock() (the approach Next.js takes via Rust bindings)
+  // would close the window, but it's not worth the complexity for a
+  // dev-ergonomics feature.
   writeLockfile(lockfilePath, info);
+
+  // Capture the owner PID once so release() always asks "is the file still
+  // mine?" against the same identity, regardless of what update() writes
+  // later. In practice the PID never changes between acquire and release,
+  // but this makes the intent explicit and decouples release from update.
+  const ownerPid = info.pid;
 
   let released = false;
   const release = () => {
@@ -223,7 +246,7 @@ export function tryAcquireLockfile(opts: AcquireOptions): AcquireResult {
       // Only delete if the file still points at us. If another process took
       // over the lock (e.g. after a crash), don't delete their entry.
       const current = readLockfile(lockfilePath);
-      if (current && current.pid === info.pid) {
+      if (current && current.pid === ownerPid) {
         fs.unlinkSync(lockfilePath);
       }
     } catch {
@@ -231,6 +254,15 @@ export function tryAcquireLockfile(opts: AcquireOptions): AcquireResult {
     }
   };
 
+  // The "exit" event fires once Node.js is about to exit — either gracefully
+  // (event loop drained, explicit process.exit(), or after the default
+  // SIGINT/SIGTERM handlers terminate the process). It does NOT fire on
+  // uncaught exceptions or hard crashes (SIGKILL), which is fine: the next
+  // `vinext dev` will detect the dead PID and take over the stale lock.
+  //
+  // If a future caller installs a custom signal handler that swallows
+  // SIGINT/SIGTERM without exiting, the lock would leak — also fine, same
+  // recovery path applies.
   let exitListener: NodeJS.ExitListener | undefined;
   if (unlockOnExit) {
     exitListener = () => release();

--- a/tests/dev-lockfile.test.ts
+++ b/tests/dev-lockfile.test.ts
@@ -192,6 +192,32 @@ describe("tryAcquireLockfile", () => {
     result.lockfile.release();
   });
 
+  it("update() preserves startedAt when callers pass the original value", () => {
+    // Documents the CLI contract: `startedAt` is meant to reflect when the
+    // process started, not when the URL was resolved. The dev() command in
+    // cli.ts captures startedAt at acquire time and passes the same value
+    // into update() so the lock file's startedAt stays stable across the
+    // pre-listen → post-listen rewrite.
+    const startedAt = Date.now() - 60_000; // pretend the process started a minute ago
+    const result = tryAcquireLockfile({
+      root,
+      info: baseInfo({ cwd: root, port: 3000, startedAt }),
+      unlockOnExit: false,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    result.lockfile.update(
+      baseInfo({
+        cwd: root,
+        port: 5173,
+        appUrl: "http://localhost:5173",
+        startedAt, // caller's responsibility to thread this through
+      }),
+    );
+    expect(readLockfile(getLockfilePath(root))?.startedAt).toBe(startedAt);
+    result.lockfile.release();
+  });
+
   it("release() is idempotent", () => {
     const result = tryAcquireLockfile({
       root,

--- a/tests/dev-lockfile.test.ts
+++ b/tests/dev-lockfile.test.ts
@@ -44,10 +44,10 @@ function baseInfo(overrides: Partial<DevServerInfo> = {}): DevServerInfo {
 }
 
 describe("getLockfilePath", () => {
-  it("places the lock file under node_modules/.cache/vinext/", () => {
+  it("places the lock file under .vinext/dev/", () => {
     const root = "/projects/my-app";
     expect(getLockfilePath(root)).toBe(
-      path.join("/projects/my-app", "node_modules", ".cache", "vinext", "dev-lock.json"),
+      path.join("/projects/my-app", ".vinext", "dev", "lock.json"),
     );
   });
 });
@@ -331,7 +331,7 @@ describe("formatAlreadyRunningError", () => {
     const msg = formatAlreadyRunningError({
       existing,
       cwd: "/path/to/project",
-      lockfilePath: "/path/to/project/node_modules/.cache/vinext/dev-lock.json",
+      lockfilePath: "/path/to/project/.vinext/dev/lock.json",
     });
     expect(msg).toContain("Another vinext dev server is already running");
     expect(msg).toContain("- Local:        http://localhost:3000");
@@ -350,9 +350,9 @@ describe("formatAlreadyRunningError", () => {
     const msg = formatAlreadyRunningError({
       existing: undefined,
       cwd: "/path/to/project",
-      lockfilePath: "/path/to/project/node_modules/.cache/vinext/dev-lock.json",
+      lockfilePath: "/path/to/project/.vinext/dev/lock.json",
     });
     expect(msg).toContain("Stale lock file");
-    expect(msg).toContain("node_modules/.cache/vinext/dev-lock.json");
+    expect(msg).toContain(".vinext/dev/lock.json");
   });
 });

--- a/tests/dev-lockfile.test.ts
+++ b/tests/dev-lockfile.test.ts
@@ -221,6 +221,77 @@ describe("tryAcquireLockfile", () => {
     result.lockfile.release();
     expect(fs.existsSync(lockPath)).toBe(true);
   });
+
+  it("release() ignores stale ownerPid even after update() rewrites with different info", () => {
+    // Acquire with current PID, then update() with a different PID in the
+    // payload. release() must still check against the *original* ownerPid
+    // (the acquire-time PID), not the update-time PID. Without that guarantee
+    // a malicious or buggy caller could trick release() into deleting another
+    // process's lock by passing a fake PID through update().
+    const lockPath = getLockfilePath(root);
+    const result = tryAcquireLockfile({
+      root,
+      info: baseInfo({ cwd: root, pid: process.pid }),
+      unlockOnExit: false,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    // Pretend update() was called with a different PID (simulating a future
+    // bug or hostile caller). The lock file now claims to be owned by some
+    // other PID.
+    const otherPid = process.pid + 99999;
+    result.lockfile.update(baseInfo({ cwd: root, pid: otherPid }));
+    expect(readLockfile(lockPath)?.pid).toBe(otherPid);
+
+    // release() must NOT delete the file, because ownerPid (captured at
+    // acquire) doesn't match what's on disk.
+    result.lockfile.release();
+    expect(fs.existsSync(lockPath)).toBe(true);
+  });
+
+  it("registers an exit listener when unlockOnExit is true and removes it on release()", () => {
+    const before = process.listenerCount("exit");
+    const result = tryAcquireLockfile({
+      root,
+      info: baseInfo({ cwd: root }),
+      unlockOnExit: true,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(process.listenerCount("exit")).toBe(before + 1);
+    result.lockfile.release();
+    expect(process.listenerCount("exit")).toBe(before);
+  });
+
+  it("registers no exit listener when unlockOnExit is false", () => {
+    const before = process.listenerCount("exit");
+    const result = tryAcquireLockfile({
+      root,
+      info: baseInfo({ cwd: root }),
+      unlockOnExit: false,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(process.listenerCount("exit")).toBe(before);
+    result.lockfile.release();
+  });
+
+  it("write sets restrictive file permissions on POSIX", () => {
+    // mode bits aren't meaningfully enforced on Windows, skip there.
+    if (process.platform === "win32") return;
+    const result = tryAcquireLockfile({
+      root,
+      info: baseInfo({ cwd: root }),
+      unlockOnExit: false,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const stat = fs.statSync(getLockfilePath(root));
+    // Only the user permission bits should be set; group/other should be 0.
+    expect(stat.mode & 0o077).toBe(0);
+    result.lockfile.release();
+  });
 });
 
 describe("formatAlreadyRunningError", () => {

--- a/tests/dev-lockfile.test.ts
+++ b/tests/dev-lockfile.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Tests for the dev server lock file.
+ *
+ * Behavior modeled on Next.js' dev lock file:
+ *   https://github.com/vercel/next.js/blob/canary/packages/next/src/build/lockfile.ts
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
+
+import {
+  type DevServerInfo,
+  formatAlreadyRunningError,
+  getLockfilePath,
+  isPidAlive,
+  readLockfile,
+  tryAcquireLockfile,
+} from "../packages/vinext/src/server/dev-lockfile.js";
+
+function makeTempRoot(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "vinext-lockfile-"));
+}
+
+function cleanup(root: string): void {
+  try {
+    fs.rmSync(root, { recursive: true, force: true });
+  } catch {
+    // best-effort
+  }
+}
+
+function baseInfo(overrides: Partial<DevServerInfo> = {}): DevServerInfo {
+  return {
+    pid: process.pid,
+    port: 3000,
+    hostname: "localhost",
+    appUrl: "http://localhost:3000",
+    startedAt: Date.now(),
+    cwd: "/tmp/example",
+    ...overrides,
+  };
+}
+
+describe("getLockfilePath", () => {
+  it("places the lock file under node_modules/.cache/vinext/", () => {
+    const root = "/projects/my-app";
+    expect(getLockfilePath(root)).toBe(
+      path.join("/projects/my-app", "node_modules", ".cache", "vinext", "dev-lock.json"),
+    );
+  });
+});
+
+describe("isPidAlive", () => {
+  it("returns true for the current process", () => {
+    expect(isPidAlive(process.pid)).toBe(true);
+  });
+
+  it("returns false for an obviously dead pid", () => {
+    // PID 0 / negative / non-integer are never valid.
+    expect(isPidAlive(0)).toBe(false);
+    expect(isPidAlive(-1)).toBe(false);
+    expect(isPidAlive(Number.NaN)).toBe(false);
+  });
+
+  it("returns false for a very large unused pid", () => {
+    // PIDs above the typical kernel max are extremely unlikely to exist.
+    expect(isPidAlive(2_147_000_000)).toBe(false);
+  });
+});
+
+describe("readLockfile", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = makeTempRoot();
+  });
+
+  afterEach(() => {
+    cleanup(root);
+  });
+
+  it("returns undefined when the file doesn't exist", () => {
+    expect(readLockfile(getLockfilePath(root))).toBeUndefined();
+  });
+
+  it("returns undefined for invalid JSON", () => {
+    const lockPath = getLockfilePath(root);
+    fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+    fs.writeFileSync(lockPath, "{ not json");
+    expect(readLockfile(lockPath)).toBeUndefined();
+  });
+
+  it("returns undefined for JSON missing required fields", () => {
+    const lockPath = getLockfilePath(root);
+    fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+    fs.writeFileSync(lockPath, JSON.stringify({ pid: 1 }));
+    expect(readLockfile(lockPath)).toBeUndefined();
+  });
+
+  it("round-trips valid server info", () => {
+    const info = baseInfo({ pid: 42, port: 4321 });
+    const lockPath = getLockfilePath(root);
+    fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+    fs.writeFileSync(lockPath, JSON.stringify(info));
+    expect(readLockfile(lockPath)).toEqual(info);
+  });
+});
+
+describe("tryAcquireLockfile", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = makeTempRoot();
+  });
+
+  afterEach(() => {
+    cleanup(root);
+  });
+
+  it("writes the lock file when none exists", () => {
+    const info = baseInfo({ cwd: root });
+    const result = tryAcquireLockfile({ root, info, unlockOnExit: false });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const stored = readLockfile(getLockfilePath(root));
+    expect(stored).toEqual(info);
+    result.lockfile.release();
+    expect(fs.existsSync(getLockfilePath(root))).toBe(false);
+  });
+
+  it("fails when an existing lock file references a live PID", () => {
+    // Write a lock file pointing at the current (live) process.
+    const existing = baseInfo({ pid: process.pid, cwd: root });
+    const lockPath = getLockfilePath(root);
+    fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+    fs.writeFileSync(lockPath, JSON.stringify(existing));
+
+    const result = tryAcquireLockfile({
+      root,
+      info: baseInfo({ pid: process.pid + 1, cwd: root }),
+      unlockOnExit: false,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.existing).toEqual(existing);
+    expect(result.lockfilePath).toBe(lockPath);
+  });
+
+  it("takes over the lock when the existing entry is a dead PID", () => {
+    // Use a definitely-dead pid (very large).
+    const stale = baseInfo({ pid: 2_147_000_000, cwd: root });
+    const lockPath = getLockfilePath(root);
+    fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+    fs.writeFileSync(lockPath, JSON.stringify(stale));
+
+    const info = baseInfo({ pid: process.pid, port: 4000, cwd: root });
+    const result = tryAcquireLockfile({ root, info, unlockOnExit: false });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(readLockfile(lockPath)).toEqual(info);
+    result.lockfile.release();
+  });
+
+  it("does not take over stale entries when takeOverStale is false", () => {
+    const stale = baseInfo({ pid: 2_147_000_000, cwd: root });
+    const lockPath = getLockfilePath(root);
+    fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+    fs.writeFileSync(lockPath, JSON.stringify(stale));
+
+    const result = tryAcquireLockfile({
+      root,
+      info: baseInfo({ cwd: root }),
+      takeOverStale: false,
+      unlockOnExit: false,
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it("update() rewrites the lock file contents", () => {
+    const result = tryAcquireLockfile({
+      root,
+      info: baseInfo({ cwd: root, port: 3000 }),
+      unlockOnExit: false,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const updated = baseInfo({ cwd: root, port: 5173, appUrl: "http://localhost:5173" });
+    result.lockfile.update(updated);
+    expect(readLockfile(getLockfilePath(root))).toEqual(updated);
+    result.lockfile.release();
+  });
+
+  it("release() is idempotent", () => {
+    const result = tryAcquireLockfile({
+      root,
+      info: baseInfo({ cwd: root }),
+      unlockOnExit: false,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    result.lockfile.release();
+    result.lockfile.release();
+    expect(fs.existsSync(getLockfilePath(root))).toBe(false);
+  });
+
+  it("release() does not delete a lock file owned by a different PID", () => {
+    const result = tryAcquireLockfile({
+      root,
+      info: baseInfo({ cwd: root, pid: process.pid }),
+      unlockOnExit: false,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    // Simulate another process taking over.
+    const lockPath = getLockfilePath(root);
+    fs.writeFileSync(lockPath, JSON.stringify(baseInfo({ cwd: root, pid: process.pid + 12345 })));
+
+    result.lockfile.release();
+    expect(fs.existsSync(lockPath)).toBe(true);
+  });
+});
+
+describe("formatAlreadyRunningError", () => {
+  it("includes PID, URL, and dir when existing info is available", () => {
+    const existing = baseInfo({
+      pid: 12345,
+      port: 3000,
+      appUrl: "http://localhost:3000",
+      cwd: "/path/to/project",
+    });
+    const msg = formatAlreadyRunningError({
+      existing,
+      cwd: "/path/to/project",
+      lockfilePath: "/path/to/project/node_modules/.cache/vinext/dev-lock.json",
+    });
+    expect(msg).toContain("Another vinext dev server is already running");
+    expect(msg).toContain("- Local:        http://localhost:3000");
+    expect(msg).toContain("- PID:          12345");
+    expect(msg).toContain("- Dir:          /path/to/project");
+
+    // Platform-aware kill instructions.
+    if (process.platform === "win32") {
+      expect(msg).toContain("taskkill /PID 12345 /F");
+    } else {
+      expect(msg).toContain("kill 12345");
+    }
+  });
+
+  it("falls back to a generic message when the lock file is corrupt", () => {
+    const msg = formatAlreadyRunningError({
+      existing: undefined,
+      cwd: "/path/to/project",
+      lockfilePath: "/path/to/project/node_modules/.cache/vinext/dev-lock.json",
+    });
+    expect(msg).toContain("Stale lock file");
+    expect(msg).toContain("node_modules/.cache/vinext/dev-lock.json");
+  });
+});


### PR DESCRIPTION
## Summary

Adds a dev server lock file at `node_modules/.cache/vinext/dev-lock.json` that records the running `vinext dev` process's PID, port, URL, and project directory. When a second `vinext dev` starts in the same project, vinext reads the lock file and either takes over (if the previous process is dead) or prints an actionable error:

```
  Another vinext dev server is already running.

  - Local:        http://localhost:3000
  - PID:          12345
  - Dir:          /path/to/project

  You can access the existing server at http://localhost:3000,
  or run `kill 12345` to stop it and start a new one.
```

This is especially useful for AI coding agents (and human contributors in tmux/iTerm splits) that frequently attempt to start a dev server without knowing one is already running. The structured error gives the agent enough info to either connect to the existing server or kill it.

Modeled on Next.js' dev server lock file: https://github.com/vercel/next.js/blob/canary/packages/next/src/build/lockfile.ts

## Differences vs Next.js

- **No native `flock()`.** Next.js uses Rust SWC bindings for cross-platform advisory locking. vinext uses a JSON file plus a PID liveness check (`process.kill(pid, 0)`), which is good enough for the dev-server "is another server running?" use case. The race window on acquisition is small and benign — at worst, two dev servers race and one fails to bind its port.
- **Lock file lives in `node_modules/.cache/vinext/`** instead of `.next/dev/`, matching vinext's existing convention of not maintaining a `.next` directory.
- **Build is not locked yet.** Next.js also prevents two `next build` from running simultaneously. This PR scopes to `vinext dev`. Adding `vinext build` lock can be a follow-up.

## Behavior details

- Stale lock files (recorded PID is dead) are taken over automatically. No manual cleanup needed if a previous run crashed.
- `release()` only deletes the lock file if it still points at the current PID — this avoids clobbering a successor's lock if an earlier process is shutting down while a new one starts.
- After `server.listen()`, the lock file is rewritten with the actual port (which may differ from the requested port if Vite fell back to a free one).
- Escape hatch: set `VINEXT_NO_DEV_LOCK=1` to disable the feature.

## Test plan

- `vp test run tests/dev-lockfile.test.ts` — 17 unit tests covering:
  - lock file path resolution
  - PID liveness check
  - read/write round-trips and corrupt-file handling
  - acquire when no lock exists
  - acquire fails when an existing lock has a live PID
  - acquire takes over when the existing lock has a dead PID
  - `takeOverStale: false` opts out of the takeover behavior
  - `update()` rewrites the lock file
  - `release()` is idempotent
  - `release()` refuses to delete a lock file owned by a different PID
  - error message includes PID, URL, dir, and a platform-appropriate `kill` / `taskkill` hint
- `vp check` clean on the changed files.

Marking as draft for review on the approach before pushing further (e.g. extending to `vinext build`).