### PR TITLE
fix: enable JSX in plain .js files (Next.js compat)

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -1,5 +1,5 @@
 import type { Plugin, PluginOption, UserConfig, ViteDevServer } from "vite";
-import { loadEnv, parseAst } from "vite";
+import { loadEnv, parseAst, transformWithOxc } from "vite";
 import {
   pagesRouter,
   apiRouter,
@@ -764,6 +764,50 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
     // Transform CJS require()/module.exports to ESM before other plugins
     // analyze imports (RSC directive scanning, shim resolution, etc.)
     commonjs(),
+    // Enable JSX in plain .js files. Next.js allows JSX in .js files
+    // (Babel/SWC handle it transparently), but Vite 8's built-in `vite:oxc`
+    // plugin excludes .js files by default (`exclude: /\.js$/`) AND infers
+    // `lang: "js"` from the extension (which disables JSX parsing).
+    //
+    // We can't fix both issues via config alone:
+    //  - Setting `oxc.exclude: []` bypasses the filter, but `lang` is still
+    //    inferred as "js" from the extension, causing parse errors.
+    //  - Setting `oxc.lang: "jsx"` globally breaks TypeScript files (OXC
+    //    can't parse TS type annotations with `lang: "jsx"`).
+    //
+    // Additionally, `@vitejs/plugin-react` sets `jsxRefreshInclude` which
+    // matches `.js` files, pulling them into `vite:oxc`'s transform even
+    // when the main filter excludes them.
+    //
+    // Solution: use `enforce: "pre"` so this plugin's transform runs before
+    // `vite:oxc`. We transform `.js` files with `lang: "jsx"` using Vite's
+    // exported `transformWithOxc`. When `vite:oxc` later processes the
+    // output, the JSX has already been compiled to createElement calls.
+    ...(viteMajorVersion >= 8
+      ? [
+          {
+            name: "vinext:jsx-in-js",
+            enforce: "pre" as const,
+            async transform(code: string, id: string) {
+              // Only handle .js/.mjs files outside node_modules.
+              // TypeScript (.ts/.tsx/.jsx) files are handled by vite:oxc.
+              const cleanId = id.split("?")[0];
+              if (!/\.(m?js)$/.test(cleanId)) return;
+              if (cleanId.includes("/node_modules/")) return;
+
+              const result = await transformWithOxc(code, id, {
+                lang: "jsx",
+                jsx: { runtime: "automatic" as const },
+                sourcemap: true,
+              });
+              return {
+                code: result.code,
+                map: result.map,
+              };
+            },
+          } satisfies Plugin,
+        ]
+      : []),
     {
       name: "vinext:config",
       enforce: "pre",
@@ -1249,8 +1293,20 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           // NOTE: top-level optimizeDeps is now set below (after capturing
           // incoming values from earlier plugins) so both Pages Router and
           // App Router builds merge correctly.
-          // Enable JSX in .tsx/.jsx files
-          // Vite 7 uses `esbuild` for transforms, Vite 8+ uses `oxc`
+          // Enable JSX in .js files. Next.js allows JSX in plain .js
+          // files (Babel/SWC handle it transparently), but Vite 8's OXC
+          // transform defaults exclude .js files (both via the filter
+          // `exclude: /\.js$/` and by inferring `lang: "js"` from the
+          // extension, which disables JSX parsing).
+          //
+          // We leave the OXC filter defaults alone (letting `.js` files be
+          // excluded from `vite:oxc`) and instead handle `.js` files in a
+          // separate `vinext:jsx-in-js` plugin that runs before `vite:oxc`.
+          // That plugin transforms `.js` files with OXC using `lang: "jsx"`
+          // so JSX syntax is parsed correctly, while TypeScript files
+          // continue to use `vite:oxc`'s default `lang` inference.
+          //
+          // Vite 7 uses `esbuild` for transforms, Vite 8+ uses `oxc`.
           ...(viteMajorVersion >= 8
             ? { oxc: { jsx: { runtime: "automatic" } } }
             : { esbuild: { jsx: "automatic" } }),

--- a/tests/e2e/app-router/nextjs-compat/client-reference-runtime-map.browser.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/client-reference-runtime-map.browser.spec.ts
@@ -236,8 +236,9 @@ export default defineConfig({
   };
 }
 
+/* oxlint-disable eslint-plugin-react-hooks/rules-of-hooks -- Playwright fixture `use`, not a React hook */
 const test = base.extend<{ productionApp: ProductionApp }>({
-  // oxlint-disable-next-line eslint-plugin-react-hooks/rules-of-hooks, eslint/no-empty-pattern
+  // oxlint-disable-next-line eslint/no-empty-pattern
   productionApp: async ({}, use) => {
     const { fixtureRoot, server, app } = await buildAndServeProductionFixture();
 
@@ -249,6 +250,7 @@ const test = base.extend<{ productionApp: ProductionApp }>({
     }
   },
 });
+/* oxlint-enable eslint-plugin-react-hooks/rules-of-hooks */
 
 test.setTimeout(60_000);
 

--- a/tests/fixtures/app-basic/app/nextjs-compat/jsx-in-js/page.js
+++ b/tests/fixtures/app-basic/app/nextjs-compat/jsx-in-js/page.js
@@ -1,0 +1,10 @@
+// Test: JSX in plain .js files (not .tsx/.jsx).
+// Next.js supports this via Babel/SWC; vinext must enable OXC JSX for .js.
+export default function JsxInJsPage() {
+  return (
+    <div>
+      <h1 data-testid="jsx-in-js">Hello JSX in JS</h1>
+      <p>This page uses JSX syntax in a plain .js file</p>
+    </div>
+  );
+}

--- a/tests/jsx-in-js.test.ts
+++ b/tests/jsx-in-js.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Test: JSX in plain .js files
+ *
+ * Next.js allows JSX syntax in .js files (Babel/SWC handle it transparently).
+ * Vite 8's OXC transform defaults exclude .js files (include: /\.(m?ts|[jt]sx)$/,
+ * exclude: /\.js$/). vinext overrides these defaults to match Next.js behavior.
+ *
+ * Without the fix, .js files containing JSX would fail with:
+ *   "Unexpected JSX expression" (OXC parse error)
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vite-plus/test";
+import type { ViteDevServer } from "vite-plus";
+import { APP_FIXTURE_DIR, startFixtureServer, fetchHtml } from "./helpers.js";
+
+describe("JSX in plain .js files", () => {
+  let server: ViteDevServer;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    ({ server, baseUrl } = await startFixtureServer(APP_FIXTURE_DIR, {
+      appRouter: true,
+    }));
+    // Warm up
+    await fetch(`${baseUrl}/`).catch(() => {});
+  }, 60_000);
+
+  afterAll(async () => {
+    await server?.close();
+  });
+
+  it("should render a page component defined in a .js file with JSX", async () => {
+    const { res, html } = await fetchHtml(baseUrl, "/nextjs-compat/jsx-in-js");
+    expect(res.status).toBe(200);
+    expect(html).toContain("Hello JSX in JS");
+    expect(html).toContain("jsx-in-js");
+  });
+
+  it("should not produce 'Unexpected JSX expression' errors for .js files", async () => {
+    const { res, html } = await fetchHtml(baseUrl, "/nextjs-compat/jsx-in-js");
+    // If OXC fails to parse JSX in .js, the response would contain an error message
+    expect(html).not.toContain("Unexpected");
+    expect(html).not.toContain("PARSE_ERROR");
+    expect(res.status).toBe(200);
+  });
+});


### PR DESCRIPTION
## Summary

Next.js allows JSX syntax in plain `.js` files — Babel/SWC handle it transparently. This is a universal convention in the React/Next.js ecosystem. vinext didn't support it because Vite 8's built-in `vite:oxc` plugin excludes `.js` files by default.

## Problem

Vite 8's OXC transform has two barriers for `.js` files:
1. **Filter exclusion**: `exclude: /\.js$/` prevents `.js` files from entering the transform
2. **Language inference**: Even if the filter is bypassed, OXC infers `lang: "js"` from the extension, which disables JSX parsing. Only `lang: "jsx"` or `lang: "tsx"` enable it.

Neither can be fixed via config alone — setting `oxc.exclude: undefined` doesn't help because `lang` inference still blocks JSX parsing, and setting `oxc.lang: "jsx"` globally breaks TypeScript files.

## Solution

Add a `vinext:jsx-in-js` plugin with `enforce: "pre"` that runs before `vite:oxc`. It transforms `.js`/`.mjs` files (outside `node_modules`) using Vite's exported `transformWithOxc()` with `lang: "jsx"`, so JSX is compiled to `createElement` calls before `vite:oxc` ever sees the code.

## Testing

- New `tests/jsx-in-js.test.ts` with fixture at `tests/fixtures/app-basic/app/nextjs-compat/jsx-in-js/page.js`
- 972 tests pass (jsx-in-js + shims + routing), zero regressions
- Confirmed in the Next.js deploy suite CI: 0 `Unexpected JSX expression` errors (was ~60 test suite failures)