### PR TITLE
fix(shims): add withRouter HOC to next/router

### DIFF
--- a/packages/vinext/src/shims/next-shims.d.ts
+++ b/packages/vinext/src/shims/next-shims.d.ts
@@ -22,8 +22,14 @@ declare module "next" {
 }
 
 declare module "next/router" {
+  import { ComponentType } from "react";
   export function useRouter(): any;
   export function setSSRContext(ctx: any): void;
+  export type WithRouterProps = { router: any };
+  export type ExcludeRouterProps<P> = Pick<P, Exclude<keyof P, keyof WithRouterProps>>;
+  export function withRouter<P extends WithRouterProps>(
+    ComposedComponent: ComponentType<P>,
+  ): ComponentType<ExcludeRouterProps<P>>;
   const Router: {
     push(url: string | object): Promise<boolean>;
     replace(url: string | object): Promise<boolean>;

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -948,10 +948,17 @@ export function withRouter<P extends WithRouterProps>(
 ): ComponentType<ExcludeRouterProps<P>> {
   function WithRouterWrapper(props: ExcludeRouterProps<P>): ReactElement {
     const router = useRouter();
-    return createElement(ComposedComponent, {
-      ...(props as unknown as P),
-      router,
-    });
+    // Match Next.js spread order:
+    // `<ComposedComponent router={useRouter()} {...props} />`
+    // The injected `router` is placed first, and `{...props}` is spread
+    // after, so a user-passed `router` prop overrides the HOC-injected
+    // one (last-spread wins). Mirrors
+    // packages/next/src/client/with-router.tsx. At the type level
+    // `props: ExcludeRouterProps<P>` has no `router` key, but TS still
+    // sees `P` as `WithRouterProps`-extending when checking the literal,
+    // so we widen to a `Record` for the final prop bag.
+    const merged: Record<string, unknown> = { router, ...(props as Record<string, unknown>) };
+    return createElement(ComposedComponent, merged as unknown as P);
   }
 
   // Forward getInitialProps so class-component pages that define it keep

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -5,7 +5,15 @@
  * Backed by the browser History API. Supports client-side navigation
  * by fetching new page data and re-rendering the React root.
  */
-import { useState, useEffect, useCallback, useMemo, createElement, type ReactElement } from "react";
+import {
+  useState,
+  useEffect,
+  useCallback,
+  useMemo,
+  createElement,
+  type ReactElement,
+  type ComponentType,
+} from "react";
 import { RouterContext } from "./internal/router-context.js";
 import type { VinextNextData } from "../client/vinext-next-data.js";
 import { isValidModulePath } from "../client/validate-module-path.js";
@@ -897,6 +905,76 @@ export function wrapWithRouterContext(element: ReactElement): ReactElement {
 
   return createElement(RouterContext.Provider, { value: routerValue }, element) as ReactElement;
 }
+
+/**
+ * Props injected by `withRouter` into the wrapped component.
+ *
+ * Ported from Next.js: packages/next/src/client/with-router.tsx
+ * https://github.com/vercel/next.js/blob/canary/packages/next/src/client/with-router.tsx
+ */
+export type WithRouterProps = {
+  router: NextRouter;
+};
+
+/**
+ * Pick<P, Exclude<keyof P, keyof WithRouterProps>> — the props of the
+ * composed component minus the `router` prop that `withRouter` injects.
+ *
+ * Ported from Next.js: packages/next/src/client/with-router.tsx
+ */
+export type ExcludeRouterProps<P> = Pick<P, Exclude<keyof P, keyof WithRouterProps>>;
+
+/**
+ * Higher-order component that injects the Pages Router `router` instance as
+ * a `router` prop into a wrapped component. Primarily used by class
+ * components (which cannot call hooks) to access the router. The wrapped
+ * component receives the same props as the original, minus `router`, which
+ * is filled in by the HOC.
+ *
+ * Ported from Next.js: packages/next/src/client/with-router.tsx
+ * https://github.com/vercel/next.js/blob/canary/packages/next/src/client/with-router.tsx
+ *
+ * Differences from Next.js:
+ * - We type the composed component as `ComponentType<P>` instead of
+ *   `NextComponentType<C, any, P>` because vinext does not expose
+ *   `NextComponentType` from this shim. The runtime shape (and the props
+ *   the wrapper forwards) is identical.
+ * - We forward `getInitialProps` and `origGetInitialProps` from the
+ *   composed component so `_app` parity holds for class components that
+ *   define `getInitialProps`.
+ */
+export function withRouter<P extends WithRouterProps>(
+  ComposedComponent: ComponentType<P>,
+): ComponentType<ExcludeRouterProps<P>> {
+  function WithRouterWrapper(props: ExcludeRouterProps<P>): ReactElement {
+    const router = useRouter();
+    return createElement(ComposedComponent, {
+      ...(props as unknown as P),
+      router,
+    });
+  }
+
+  // Forward getInitialProps so class-component pages that define it keep
+  // working when wrapped. Mirrors Next.js's with-router.tsx.
+  const composed = ComposedComponent as ComponentType<P> & {
+    getInitialProps?: unknown;
+    origGetInitialProps?: unknown;
+  };
+  (WithRouterWrapper as unknown as { getInitialProps?: unknown }).getInitialProps =
+    composed.getInitialProps;
+  (WithRouterWrapper as unknown as { origGetInitialProps?: unknown }).origGetInitialProps =
+    composed.origGetInitialProps;
+
+  if (process.env.NODE_ENV !== "production") {
+    const name = composed.displayName || composed.name || "Unknown";
+    WithRouterWrapper.displayName = `withRouter(${name})`;
+  }
+
+  return WithRouterWrapper;
+}
+
+// Note: `withRouter` is exposed only as a named export from `next/router`.
+// The default export of that module is the Router singleton declared below.
 
 // Also export a default Router singleton for `import Router from 'next/router'`
 const Router = {

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -818,6 +818,143 @@ describe("window.next debug global", () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// next/router withRouter HOC
+//
+// withRouter is a higher-order component that injects the Pages Router
+// `router` instance as a prop into class components (which cannot call
+// hooks). Real Next.js apps and the Next.js deploy test suite depend on
+// this export — without it, bundlers fail with
+// `[MISSING_EXPORT] "withRouter" is not exported by ".../shims/router.js"`.
+//
+// Ported from Next.js: packages/next/src/client/with-router.tsx
+// https://github.com/vercel/next.js/blob/canary/packages/next/src/client/with-router.tsx
+//
+// Reference Next.js e2e fixture (class component using withRouter):
+// .nextjs-ref/test/e2e/with-router/pages/a.js
+// ---------------------------------------------------------------------------
+describe("next/router withRouter HOC", () => {
+  it("exports withRouter as a named function", async () => {
+    const previousWindow = (globalThis as any).window;
+    const win: any = {
+      location: { pathname: "/", search: "", hash: "", href: "http://localhost/" },
+      history: { state: null, pushState() {}, replaceState() {} },
+      addEventListener() {},
+    };
+    (globalThis as any).window = win;
+
+    try {
+      vi.resetModules();
+      const { withRouter } = await import("../packages/vinext/src/shims/router.js");
+      expect(typeof withRouter).toBe("function");
+    } finally {
+      (globalThis as any).window = previousWindow;
+      vi.resetModules();
+    }
+  });
+
+  it("withRouter wraps a component and forwards static props", async () => {
+    const previousWindow = (globalThis as any).window;
+    const win: any = {
+      location: { pathname: "/", search: "", hash: "", href: "http://localhost/" },
+      history: { state: null, pushState() {}, replaceState() {} },
+      addEventListener() {},
+    };
+    (globalThis as any).window = win;
+
+    try {
+      vi.resetModules();
+      const { withRouter } = await import("../packages/vinext/src/shims/router.js");
+      const React = await import("react");
+
+      const Inner: React.ComponentType<{ router: any; label: string }> = ({ label }) =>
+        React.createElement("span", null, label);
+
+      const Wrapped = withRouter(Inner);
+      expect(typeof Wrapped).toBe("function");
+      // displayName is set in dev to `withRouter(<Inner>)`.
+      if (process.env.NODE_ENV !== "production") {
+        expect(Wrapped.displayName).toContain("withRouter");
+      }
+    } finally {
+      (globalThis as any).window = previousWindow;
+      vi.resetModules();
+    }
+  });
+
+  it("withRouter injects a router prop into the wrapped component", async () => {
+    const previousWindow = (globalThis as any).window;
+    const win: any = {
+      location: { pathname: "/", search: "", hash: "", href: "http://localhost/" },
+      history: { state: null, pushState() {}, replaceState() {} },
+      addEventListener() {},
+    };
+    (globalThis as any).window = win;
+
+    try {
+      vi.resetModules();
+      const { withRouter } = await import("../packages/vinext/src/shims/router.js");
+      const React = await import("react");
+      const { renderToStaticMarkup } = await import("react-dom/server");
+
+      let receivedRouter: any = null;
+      let receivedLabel: string | undefined;
+      const Inner: React.ComponentType<{ router: any; label: string }> = (props) => {
+        receivedRouter = props.router;
+        receivedLabel = props.label;
+        return React.createElement("span", null, "ok");
+      };
+
+      const Wrapped = withRouter(Inner);
+      const html = renderToStaticMarkup(React.createElement(Wrapped as any, { label: "hi" }));
+      expect(html).toBe("<span>ok</span>");
+      expect(receivedLabel).toBe("hi");
+      // router must be the NextRouter shape (push/replace/back/...).
+      expect(receivedRouter).toBeTruthy();
+      expect(typeof receivedRouter.push).toBe("function");
+      expect(typeof receivedRouter.replace).toBe("function");
+      expect(typeof receivedRouter.back).toBe("function");
+      expect(typeof receivedRouter.reload).toBe("function");
+      expect(typeof receivedRouter.prefetch).toBe("function");
+      expect(receivedRouter.events).toBeDefined();
+    } finally {
+      (globalThis as any).window = previousWindow;
+      vi.resetModules();
+    }
+  });
+
+  it("withRouter forwards getInitialProps from the composed component", async () => {
+    const previousWindow = (globalThis as any).window;
+    const win: any = {
+      location: { pathname: "/", search: "", hash: "", href: "http://localhost/" },
+      history: { state: null, pushState() {}, replaceState() {} },
+      addEventListener() {},
+    };
+    (globalThis as any).window = win;
+
+    try {
+      vi.resetModules();
+      const { withRouter } = await import("../packages/vinext/src/shims/router.js");
+
+      type InnerType = ((props: { router: any }) => null) & {
+        getInitialProps?: () => unknown;
+        origGetInitialProps?: () => unknown;
+      };
+      const Inner: InnerType = (() => null) as InnerType;
+      const gip = () => ({ foo: "bar" });
+      Inner.getInitialProps = gip;
+      Inner.origGetInitialProps = gip;
+
+      const Wrapped = withRouter(Inner) as typeof Inner;
+      expect(Wrapped.getInitialProps).toBe(gip);
+      expect(Wrapped.origGetInitialProps).toBe(gip);
+    } finally {
+      (globalThis as any).window = previousWindow;
+      vi.resetModules();
+    }
+  });
+});
+
 describe("next/headers shim", () => {
   it("exports cookies, headers, draftMode", async () => {
     const mod = await import("../packages/vinext/src/shims/headers.js");

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -834,124 +834,109 @@ describe("window.next debug global", () => {
 // .nextjs-ref/test/e2e/with-router/pages/a.js
 // ---------------------------------------------------------------------------
 describe("next/router withRouter HOC", () => {
-  it("exports withRouter as a named function", async () => {
-    const previousWindow = (globalThis as any).window;
-    const win: any = {
+  let previousWindow: unknown;
+
+  beforeEach(() => {
+    previousWindow = (globalThis as any).window;
+    (globalThis as any).window = {
       location: { pathname: "/", search: "", hash: "", href: "http://localhost/" },
       history: { state: null, pushState() {}, replaceState() {} },
       addEventListener() {},
     };
-    (globalThis as any).window = win;
+    vi.resetModules();
+  });
 
-    try {
-      vi.resetModules();
-      const { withRouter } = await import("../packages/vinext/src/shims/router.js");
-      expect(typeof withRouter).toBe("function");
-    } finally {
-      (globalThis as any).window = previousWindow;
-      vi.resetModules();
-    }
+  afterEach(() => {
+    (globalThis as any).window = previousWindow;
+    vi.resetModules();
+  });
+
+  it("exports withRouter as a named function", async () => {
+    const { withRouter } = await import("../packages/vinext/src/shims/router.js");
+    expect(typeof withRouter).toBe("function");
   });
 
   it("withRouter wraps a component and forwards static props", async () => {
-    const previousWindow = (globalThis as any).window;
-    const win: any = {
-      location: { pathname: "/", search: "", hash: "", href: "http://localhost/" },
-      history: { state: null, pushState() {}, replaceState() {} },
-      addEventListener() {},
-    };
-    (globalThis as any).window = win;
+    const { withRouter } = await import("../packages/vinext/src/shims/router.js");
+    const React = await import("react");
 
-    try {
-      vi.resetModules();
-      const { withRouter } = await import("../packages/vinext/src/shims/router.js");
-      const React = await import("react");
+    const Inner: React.ComponentType<{ router: any; label: string }> = ({ label }) =>
+      React.createElement("span", null, label);
 
-      const Inner: React.ComponentType<{ router: any; label: string }> = ({ label }) =>
-        React.createElement("span", null, label);
-
-      const Wrapped = withRouter(Inner);
-      expect(typeof Wrapped).toBe("function");
-      // displayName is set in dev to `withRouter(<Inner>)`.
-      if (process.env.NODE_ENV !== "production") {
-        expect(Wrapped.displayName).toContain("withRouter");
-      }
-    } finally {
-      (globalThis as any).window = previousWindow;
-      vi.resetModules();
+    const Wrapped = withRouter(Inner);
+    expect(typeof Wrapped).toBe("function");
+    // displayName is set in dev to `withRouter(<Inner>)`.
+    if (process.env.NODE_ENV !== "production") {
+      expect(Wrapped.displayName).toContain("withRouter");
     }
   });
 
   it("withRouter injects a router prop into the wrapped component", async () => {
-    const previousWindow = (globalThis as any).window;
-    const win: any = {
-      location: { pathname: "/", search: "", hash: "", href: "http://localhost/" },
-      history: { state: null, pushState() {}, replaceState() {} },
-      addEventListener() {},
+    const { withRouter } = await import("../packages/vinext/src/shims/router.js");
+    const React = await import("react");
+    const { renderToStaticMarkup } = await import("react-dom/server");
+
+    let receivedRouter: any = null;
+    let receivedLabel: string | undefined;
+    const Inner: React.ComponentType<{ router: any; label: string }> = (props) => {
+      receivedRouter = props.router;
+      receivedLabel = props.label;
+      return React.createElement("span", null, "ok");
     };
-    (globalThis as any).window = win;
 
-    try {
-      vi.resetModules();
-      const { withRouter } = await import("../packages/vinext/src/shims/router.js");
-      const React = await import("react");
-      const { renderToStaticMarkup } = await import("react-dom/server");
+    const Wrapped = withRouter(Inner);
+    const html = renderToStaticMarkup(React.createElement(Wrapped as any, { label: "hi" }));
+    expect(html).toBe("<span>ok</span>");
+    expect(receivedLabel).toBe("hi");
+    // router must be the NextRouter shape (push/replace/back/...).
+    expect(receivedRouter).toBeTruthy();
+    expect(typeof receivedRouter.push).toBe("function");
+    expect(typeof receivedRouter.replace).toBe("function");
+    expect(typeof receivedRouter.back).toBe("function");
+    expect(typeof receivedRouter.reload).toBe("function");
+    expect(typeof receivedRouter.prefetch).toBe("function");
+    expect(receivedRouter.events).toBeDefined();
+  });
 
-      let receivedRouter: any = null;
-      let receivedLabel: string | undefined;
-      const Inner: React.ComponentType<{ router: any; label: string }> = (props) => {
-        receivedRouter = props.router;
-        receivedLabel = props.label;
-        return React.createElement("span", null, "ok");
-      };
+  // Regression guard for Next.js spread order:
+  // packages/next/src/client/with-router.tsx renders
+  //   `<ComposedComponent router={useRouter()} {...props} />`
+  // — the injected `router` is placed FIRST and `{...props}` spread after,
+  // so a user-passed `router` prop overrides the HOC-injected one. If the
+  // spread order is ever inverted in the shim, this test fails.
+  it("user-passed router prop overrides the HOC-injected router (Next.js spread order)", async () => {
+    const { withRouter } = await import("../packages/vinext/src/shims/router.js");
+    const React = await import("react");
+    const { renderToStaticMarkup } = await import("react-dom/server");
 
-      const Wrapped = withRouter(Inner);
-      const html = renderToStaticMarkup(React.createElement(Wrapped as any, { label: "hi" }));
-      expect(html).toBe("<span>ok</span>");
-      expect(receivedLabel).toBe("hi");
-      // router must be the NextRouter shape (push/replace/back/...).
-      expect(receivedRouter).toBeTruthy();
-      expect(typeof receivedRouter.push).toBe("function");
-      expect(typeof receivedRouter.replace).toBe("function");
-      expect(typeof receivedRouter.back).toBe("function");
-      expect(typeof receivedRouter.reload).toBe("function");
-      expect(typeof receivedRouter.prefetch).toBe("function");
-      expect(receivedRouter.events).toBeDefined();
-    } finally {
-      (globalThis as any).window = previousWindow;
-      vi.resetModules();
-    }
+    let receivedRouter: any = null;
+    const Inner: React.ComponentType<{ router: any }> = (props) => {
+      receivedRouter = props.router;
+      return React.createElement("span", null, "ok");
+    };
+
+    const Wrapped = withRouter(Inner);
+    const userRouter = { sentinel: "user-provided" };
+    renderToStaticMarkup(React.createElement(Wrapped as any, { router: userRouter }));
+    // Last spread wins: the user-passed router survives.
+    expect(receivedRouter).toBe(userRouter);
   });
 
   it("withRouter forwards getInitialProps from the composed component", async () => {
-    const previousWindow = (globalThis as any).window;
-    const win: any = {
-      location: { pathname: "/", search: "", hash: "", href: "http://localhost/" },
-      history: { state: null, pushState() {}, replaceState() {} },
-      addEventListener() {},
+    const { withRouter } = await import("../packages/vinext/src/shims/router.js");
+
+    type InnerType = ((props: { router: any }) => null) & {
+      getInitialProps?: () => unknown;
+      origGetInitialProps?: () => unknown;
     };
-    (globalThis as any).window = win;
+    const Inner: InnerType = (() => null) as InnerType;
+    const gip = () => ({ foo: "bar" });
+    Inner.getInitialProps = gip;
+    Inner.origGetInitialProps = gip;
 
-    try {
-      vi.resetModules();
-      const { withRouter } = await import("../packages/vinext/src/shims/router.js");
-
-      type InnerType = ((props: { router: any }) => null) & {
-        getInitialProps?: () => unknown;
-        origGetInitialProps?: () => unknown;
-      };
-      const Inner: InnerType = (() => null) as InnerType;
-      const gip = () => ({ foo: "bar" });
-      Inner.getInitialProps = gip;
-      Inner.origGetInitialProps = gip;
-
-      const Wrapped = withRouter(Inner) as typeof Inner;
-      expect(Wrapped.getInitialProps).toBe(gip);
-      expect(Wrapped.origGetInitialProps).toBe(gip);
-    } finally {
-      (globalThis as any).window = previousWindow;
-      vi.resetModules();
-    }
+    const Wrapped = withRouter(Inner) as typeof Inner;
+    expect(Wrapped.getInitialProps).toBe(gip);
+    expect(Wrapped.origGetInitialProps).toBe(gip);
   });
 });
 


### PR DESCRIPTION
## Summary

- Add `withRouter` higher-order component to `packages/vinext/src/shims/router.ts`, ported from [`packages/next/src/client/with-router.tsx`](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/with-router.tsx) in Next.js.
- Also export `WithRouterProps` and `ExcludeRouterProps` types (commonly imported by typed Pages Router apps) and add matching `declare module "next/router"` entries in `next-shims.d.ts`.

## Why

The Next.js deploy test suite currently has **9 build failures** of the form:

```
[MISSING_EXPORT] "withRouter" is not exported by "node_modules/.../vinext/dist/shims/router.js"
```

`withRouter` is primarily used by class components (which cannot call hooks) to receive the Pages Router `router` instance as a prop. Real-world Next.js apps and the e2e fixtures (e.g. [`test/e2e/with-router/pages/a.js`](https://github.com/vercel/next.js/blob/canary/test/e2e/with-router/pages/a.js)) import it directly from `next/router`. Without this export, those bundles fail to build.

## Implementation

The implementation mirrors Next.js's HOC behaviour:

1. Calls `useRouter()` and forwards the result as a `router` prop.
2. Forwards `getInitialProps` and `origGetInitialProps` from the composed component (parity with `_app` Pages Router behaviour for class components that define `getInitialProps`).
3. Sets a `withRouter(<Name>)` `displayName` outside `production`.

Source: [`packages/next/src/client/with-router.tsx`](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/with-router.tsx)

## Type signature differences vs Next.js

Next.js types the composed component as `NextComponentType<C, any, P>`. vinext does not currently expose `NextComponentType` from this shim, so the port uses `ComponentType<P>` instead. The runtime shape is identical; the only difference is that vinext's HOC cannot recover the legacy `NextComponentType.context` type. No existing call sites in the Next.js test fixtures depend on that — they all use plain class components that read `this.props.router`.

## Tests

Added a `next/router withRouter HOC` describe block in `tests/shims.test.ts` (4 tests):

1. `withRouter` is exported as a function.
2. Wrapping a component returns a function and sets a `withRouter(...)` `displayName` in dev.
3. The wrapped component renders correctly and receives `router` as a prop with the expected `NextRouter` surface (`push`, `replace`, `back`, `reload`, `prefetch`, `events`).
4. `getInitialProps` and `origGetInitialProps` are forwarded from the composed component.

Local results:
- `vp test run tests/shims.test.ts` — **870 passed** (4 new).
- `vp check` — pass (format, lint, type checks).

## Uncertainty / follow-ups

- The simplified type signature (`ComponentType<P>` instead of `NextComponentType<C, any, P>`) is a deliberate narrowing because vinext does not expose `NextComponentType`. If a user's TypeScript code depends on the richer Next.js signature, they may see a type-only regression. The runtime behaviour is identical and matches Next.js exactly.
- `WithRouterProps.router` in `next-shims.d.ts` is typed as `any` rather than the full `NextRouter` interface; the ambient declaration file already uses `any` for `useRouter`'s return value, so this keeps the d.ts file consistent. The actual implementation (in `router.ts`) uses the full `NextRouter` type.