### PR TITLE
fix(shims): add unstable_catchError, unstable_rethrow, unstable_isUnrecognizedActionError

### DIFF
--- a/packages/vinext/src/shims/error-boundary.tsx
+++ b/packages/vinext/src/shims/error-boundary.tsx
@@ -3,8 +3,8 @@
 import React from "react";
 // Import the local shim, not the public next/navigation alias. The built
 // package may execute this file before the plugin's resolveId hook is active.
-import { usePathname, useRouter } from "./navigation.js";
-import { getErrorDigest, isNavigationSignalError } from "../utils/navigation-signal.js";
+import { isRedirectError, usePathname, useRouter } from "./navigation.js";
+import { isNavigationSignalError } from "../utils/navigation-signal.js";
 
 export type ErrorBoundaryProps = {
   fallback: React.ComponentType<{ error: unknown; reset: () => void }>;
@@ -69,10 +69,6 @@ function shouldResetBoundary(
   }
 
   return nextResetState.previousPathname !== previousResetState.previousPathname;
-}
-
-function isRedirectError(error: unknown): error is RedirectError {
-  return getErrorDigest(error)?.startsWith("NEXT_REDIRECT;") ?? false;
 }
 
 function decodeRedirectTarget(target: string): string {
@@ -144,6 +140,13 @@ export class RedirectErrorBoundary extends React.Component<
 
   static getDerivedStateFromError(error: unknown): RedirectBoundaryState {
     if (isRedirectError(error)) {
+      // The public `isRedirectError` narrows to `Error & { digest: string }`.
+      // Cast to the local `RedirectError` (which also carries the optional
+      // `handled` field) so the parity logic below compiles. The cast is
+      // safe because every error that matches the prefix predicate is — by
+      // construction — produced by vinext's `redirect()` /
+      // `permanentRedirect()` helpers, which yield `Error` instances.
+      const redirectError = error as RedirectError;
       // Next.js parity: an outer RedirectBoundary that has already started
       // handling a redirect marks the error as `handled` so that, if React
       // re-throws the same error during a retry render, an inner boundary
@@ -151,14 +154,14 @@ export class RedirectErrorBoundary extends React.Component<
       // currently emit `handled` itself (we never assign it on the error
       // object), but we keep the branch so behavior matches Next.js if a
       // host or future change ever does.
-      if (error.handled) {
+      if (redirectError.handled) {
         return {
           redirect: null,
           redirectType: null,
         };
       }
 
-      const url = getURLFromRedirectError(error);
+      const url = getURLFromRedirectError(redirectError);
       if (url === null) {
         // Malformed digest (e.g. `NEXT_REDIRECT;push;` with an empty URL
         // segment). The server-side parser at next-error-digest.ts:51 also
@@ -169,7 +172,7 @@ export class RedirectErrorBoundary extends React.Component<
 
       return {
         redirect: url,
-        redirectType: getRedirectTypeFromError(error),
+        redirectType: getRedirectTypeFromError(redirectError),
       };
     }
 

--- a/packages/vinext/src/shims/error.tsx
+++ b/packages/vinext/src/shims/error.tsx
@@ -4,8 +4,13 @@
  * Provides the default Next.js error page component.
  * Used by apps that import `import Error from 'next/error'` for
  * custom error handling in getServerSideProps or API routes.
+ *
+ * Also re-exports the unstable App Router error-boundary HOC
+ * (`unstable_catchError`) and its `ErrorInfo` type, mirroring
+ * `next/error`'s public surface.
  */
 import React from "react";
+import { isNextRouterError } from "./navigation.js";
 
 type ErrorProps = {
   statusCode: number;
@@ -73,3 +78,128 @@ function ErrorComponent({ statusCode, title }: ErrorProps): React.ReactElement {
 }
 
 export default ErrorComponent;
+
+// ---------------------------------------------------------------------------
+// unstable_catchError — App Router error-boundary HOC
+//
+// `unstable_catchError(fallback)` returns a Component that renders `children`
+// and, if the children throw, renders the user-supplied fallback with an
+// `ErrorInfo` object. Internal Next.js navigation signals (redirect /
+// notFound / forbidden / unauthorized) are rethrown so they reach the outer
+// framework boundaries.
+//
+// Ported from Next.js:
+//   https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/catch-error.tsx
+//   https://github.com/vercel/next.js/blob/canary/packages/next/src/api/error.ts
+//   https://github.com/vercel/next.js/blob/canary/packages/next/src/api/error.react-server.ts
+//
+// Differences from Next.js:
+//   - We do not implement `unstable_retry` (requires the App Router instance
+//     context, which vinext doesn't currently thread through error boundaries).
+//     It is exposed on `ErrorInfo` as a no-op that throws a clear error so
+//     misuse fails loudly rather than silently. Tracked as a follow-up.
+//   - Bot-user-agent graceful-degradation, `handleHardNavError`, and
+//     `handleISRError` are not yet supported. Errors always render the
+//     fallback in non-bot contexts.
+//   - The single implementation runs in both react-server and client
+//     conditions. In Next.js, the react-server build exports a throwing stub
+//     because the API is documented as client-only. Here we let module
+//     evaluation succeed everywhere so `import { unstable_catchError } from
+//     'next/error'` does not break SSR-only bundles; misuse in a Server
+//     Component still fails at render time because React class components
+//     are unavailable in the react-server condition for this code path.
+// ---------------------------------------------------------------------------
+
+export type ErrorInfo = {
+  error: unknown;
+  reset: () => void;
+  unstable_retry: () => void;
+};
+
+type _UserProps = Record<string, unknown>;
+
+type _CatchErrorState = { thrownValue: unknown } | null;
+
+class _CatchError<P extends _UserProps> extends React.Component<
+  {
+    fallback: (props: P, errorInfo: ErrorInfo) => React.ReactNode;
+    forwardedProps: P;
+    children?: React.ReactNode;
+  },
+  { error: _CatchErrorState }
+> {
+  // Match Next.js's DevTools label so userland tooling/snapshots align.
+  // https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/catch-error.tsx
+  static displayName = "unstable_catchError(Next.CatchError)";
+
+  state = { error: null as _CatchErrorState };
+
+  static getDerivedStateFromError(thrownValue: unknown): { error: _CatchErrorState } {
+    if (isNextRouterError(thrownValue)) {
+      // Re-throw redirect/notFound/etc. so an outer framework boundary handles
+      // them. Matches Next.js's CatchError.getDerivedStateFromError().
+      throw thrownValue;
+    }
+    return { error: { thrownValue } };
+  }
+
+  reset = (): void => {
+    this.setState({ error: null });
+  };
+
+  unstable_retry = (): void => {
+    // vinext does not yet expose a refresh handle through this boundary.
+    // Throwing a clear error is better than a silent no-op; tracked as a
+    // follow-up so users discover the gap immediately.
+    throw new Error(
+      "`unstable_retry()` is not yet implemented by vinext's `unstable_catchError`. " +
+        "Use `reset()` for now.",
+    );
+  };
+
+  render(): React.ReactNode {
+    if (this.state.error) {
+      const errorInfo: ErrorInfo = {
+        error: this.state.error.thrownValue,
+        reset: this.reset,
+        unstable_retry: this.unstable_retry,
+      };
+      return this.props.fallback(this.props.forwardedProps, errorInfo);
+    }
+    return this.props.children;
+  }
+}
+
+/**
+ * Wrap a fallback render function in a Component-level error boundary.
+ * Returns a Component that renders `children` and, on error, renders the
+ * supplied fallback with an `ErrorInfo` value.
+ *
+ * Ported from Next.js:
+ *   https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/catch-error.tsx
+ */
+export function unstable_catchError<P extends _UserProps>(
+  fallback: (props: P, errorInfo: ErrorInfo) => React.ReactNode,
+): React.ComponentType<P & { children?: React.ReactNode }> {
+  // The inner class is generic in P, but createElement loses that generic at
+  // the call site. Cast it to a non-generic constructor for the specific P
+  // we close over here so TypeScript can pick the JSX-style createElement
+  // overload without complaining about missing generic instantiation.
+  const TypedCatchError = _CatchError as unknown as React.ComponentType<{
+    fallback: (props: P, errorInfo: ErrorInfo) => React.ReactNode;
+    forwardedProps: P;
+    children?: React.ReactNode;
+  }>;
+
+  function CatchErrorBoundary(allProps: P & { children?: React.ReactNode }): React.ReactElement {
+    const { children, ...rest } = allProps;
+    const forwardedProps = rest as unknown as P;
+    return React.createElement(
+      TypedCatchError,
+      { fallback, forwardedProps },
+      children as React.ReactNode,
+    );
+  }
+  CatchErrorBoundary.displayName = `unstable_catchError(${fallback.name || "CatchErrorFallback"})`;
+  return CatchErrorBoundary;
+}

--- a/packages/vinext/src/shims/error.tsx
+++ b/packages/vinext/src/shims/error.tsx
@@ -10,7 +10,7 @@
  * `next/error`'s public surface.
  */
 import React from "react";
-import { isNextRouterError } from "./navigation.js";
+import { appRouterInstance, isNextRouterError } from "./navigation.js";
 
 type ErrorProps = {
   statusCode: number;
@@ -94,10 +94,18 @@ export default ErrorComponent;
 //   https://github.com/vercel/next.js/blob/canary/packages/next/src/api/error.react-server.ts
 //
 // Differences from Next.js:
-//   - We do not implement `unstable_retry` (requires the App Router instance
-//     context, which vinext doesn't currently thread through error boundaries).
-//     It is exposed on `ErrorInfo` as a no-op that throws a clear error so
-//     misuse fails loudly rather than silently. Tracked as a follow-up.
+//   - `unstable_retry()` matches Next.js's App Router behavior on the
+//     client — it calls `appRouterInstance.refresh()` inside a
+//     React.startTransition and then resets the boundary. On the server it
+//     throws (consistent with React class components only running on the
+//     server during SSR setup, where retry isn't meaningful). The
+//     Pages-Router-only error message Next.js throws
+//     (`unstable_retry()` can only be used in the App Router. Use
+//     `reset()` in the Pages Router.) is not currently dispatched because
+//     vinext's boundary doesn't read `PagesRouterContext`. Calling retry
+//     under Pages Router will trigger an App Router refresh, which is a
+//     no-op in that environment — the error remains visible until
+//     `reset()` is called. Tracked as a parity follow-up.
 //   - Bot-user-agent graceful-degradation, `handleHardNavError`, and
 //     `handleISRError` are not yet supported. Errors always render the
 //     fallback in non-bot contexts.
@@ -148,13 +156,26 @@ class _CatchError<P extends _UserProps> extends React.Component<
   };
 
   unstable_retry = (): void => {
-    // vinext does not yet expose a refresh handle through this boundary.
-    // Throwing a clear error is better than a silent no-op; tracked as a
-    // follow-up so users discover the gap immediately.
-    throw new Error(
-      "`unstable_retry()` is not yet implemented by vinext's `unstable_catchError`. " +
-        "Use `reset()` for now.",
-    );
+    // Matches Next.js's App Router branch in
+    // packages/next/src/client/components/catch-error.tsx — refresh the
+    // current route, then clear the error so children re-render. Wrapped in
+    // startTransition so the in-flight refresh and the reset commit
+    // together (no flash of the children rendering with stale data).
+    //
+    // On the server, refresh is meaningless and `appRouterInstance.refresh`
+    // is a no-op; throw a clear error so callers don't silently swallow a
+    // retry attempt during SSR setup. Matches the spirit of Next.js's
+    // server-side throw (which lives in error-boundary.tsx, not here).
+    if (typeof window === "undefined") {
+      throw new Error(
+        "`unstable_retry()` can only be used on the client. Call it from a user " +
+          "interaction handler inside the error fallback.",
+      );
+    }
+    React.startTransition(() => {
+      appRouterInstance.refresh();
+      this.reset();
+    });
   };
 
   render(): React.ReactNode {

--- a/packages/vinext/src/shims/navigation.react-server.ts
+++ b/packages/vinext/src/shims/navigation.react-server.ts
@@ -46,6 +46,10 @@ export {
   // where `unstable_rethrow` is also re-exported in the react-server build.
   isRedirectError,
   isNextRouterError,
+  isBailoutToCSRError,
+  isDynamicServerError,
+  BailoutToCSRError,
+  DynamicServerError,
   unstable_rethrow,
 
   // Utilities

--- a/packages/vinext/src/shims/navigation.react-server.ts
+++ b/packages/vinext/src/shims/navigation.react-server.ts
@@ -35,6 +35,19 @@ export {
   forbidden,
   unauthorized,
 
+  // Internal-error predicates and rethrow.
+  //
+  // These are environment-agnostic (no React hooks, no browser globals), so
+  // we re-export the canonical implementation from `./navigation.js` to keep
+  // a single source of truth across the react-server and client conditions.
+  //
+  // Ported from Next.js:
+  //   https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/navigation.react-server.ts
+  // where `unstable_rethrow` is also re-exported in the react-server build.
+  isRedirectError,
+  isNextRouterError,
+  unstable_rethrow,
+
   // Utilities
   ReadonlyURLSearchParams,
 } from "./navigation.js";
@@ -70,4 +83,16 @@ export function useSelectedLayoutSegments(): never {
 
 export function useServerInsertedHTML(): never {
   throwClientHookError("useServerInsertedHTML()");
+}
+
+// `unstable_isUnrecognizedActionError` is client-only: server actions cannot
+// fail with "unrecognized action" inside the React-server render path because
+// they execute synchronously against the action manifest. Calling this from a
+// Server Component is always a programming error.
+//
+// Ported from Next.js:
+//   https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/navigation.react-server.ts
+// which throws the same diagnostic message from the react-server condition.
+export function unstable_isUnrecognizedActionError(): boolean {
+  throw new Error("`unstable_isUnrecognizedActionError` can only be used on the client.");
 }

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -1588,6 +1588,139 @@ export function unauthorized(): never {
 }
 
 // ---------------------------------------------------------------------------
+// Internal-error predicates and rethrow
+//
+// `unstable_rethrow` is part of Next.js's public API. User code in try/catch
+// wrappers calls it to let Next.js's control-flow signals (redirect, notFound,
+// forbidden, unauthorized, …) propagate up to the framework instead of being
+// swallowed.
+//
+// Ported from Next.js:
+//   - packages/next/src/client/components/unstable-rethrow.ts (dispatcher)
+//   - packages/next/src/client/components/unstable-rethrow.browser.ts
+//   - packages/next/src/client/components/unstable-rethrow.server.ts
+//   - packages/next/src/client/components/is-next-router-error.ts
+//   - packages/next/src/client/components/redirect-error.ts
+//
+// vinext does not yet implement every Next.js internal-error category
+// (BailoutToCSRError, DynamicServerError, prerender postpone errors, …) so we
+// only check the ones we actually emit:
+//   - redirect / permanentRedirect → digest starts with "NEXT_REDIRECT;"
+//   - notFound / forbidden / unauthorized → covered by isHTTPAccessFallbackError
+// ---------------------------------------------------------------------------
+
+type _RedirectErrorShape = Error & { digest: string };
+
+/**
+ * Check whether an error was produced by `redirect()` or `permanentRedirect()`.
+ *
+ * vinext emits 3-part (`NEXT_REDIRECT;{type};{encoded-url}`) and 4-part
+ * (`NEXT_REDIRECT;{type};{encoded-url};308`) digests; we match permissively so
+ * either format counts. Mirrors the lenient check already used by
+ * `shims/error-boundary.tsx`.
+ *
+ * Ported from Next.js:
+ *   https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/redirect-error.ts
+ */
+export function isRedirectError(error: unknown): error is _RedirectErrorShape {
+  if (
+    !error ||
+    typeof error !== "object" ||
+    !("digest" in error) ||
+    typeof (error as { digest: unknown }).digest !== "string"
+  ) {
+    return false;
+  }
+  return (error as { digest: string }).digest.startsWith("NEXT_REDIRECT;");
+}
+
+/**
+ * Returns true if the error is a Next.js navigation signal — either a redirect
+ * or an HTTP access fallback (notFound / forbidden / unauthorized).
+ *
+ * Ported from Next.js:
+ *   https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/is-next-router-error.ts
+ */
+export function isNextRouterError(error: unknown): boolean {
+  return isRedirectError(error) || isHTTPAccessFallbackError(error);
+}
+
+/**
+ * Rethrow internal Next.js errors so they're handled by the framework.
+ *
+ * When wrapping an API that uses errors for control flow (redirect, notFound,
+ * etc.), call this inside `catch` blocks before doing your own error handling.
+ * If the error is a Next.js internal error, it's rethrown; otherwise this is a
+ * no-op (apart from recursing through `error.cause`).
+ *
+ * Fresh implementation that follows Next.js's dispatcher pattern, but
+ * specialized to the internal-error categories vinext actually emits. The
+ * single function intentionally covers both server and browser contexts —
+ * Next.js splits these into `.server.ts` / `.browser.ts` files only because
+ * the server build pulls in additional checks (`isPostpone`,
+ * `isHangingPromiseRejectionError`, …) that vinext does not yet implement.
+ *
+ * Ported from Next.js:
+ *   https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/unstable-rethrow.ts
+ *   https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/unstable-rethrow.server.ts
+ *   https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/unstable-rethrow.browser.ts
+ */
+export function unstable_rethrow(error: unknown): void {
+  if (isNextRouterError(error)) {
+    throw error;
+  }
+
+  if (error instanceof Error && "cause" in error) {
+    unstable_rethrow((error as Error & { cause: unknown }).cause);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Unrecognized server-action errors
+//
+// `unstable_isUnrecognizedActionError` lets client code detect when a server
+// action call failed because the server didn't recognize the action id — this
+// typically means the client bundle and the server are from different
+// deployments and a hard reload is required.
+//
+// Ported from Next.js:
+//   https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/unrecognized-action-error.ts
+// ---------------------------------------------------------------------------
+
+/**
+ * Error class for unrecognized server-action calls. Thrown by the App Router
+ * server-action handler when the requested action id is not present in the
+ * current build's action manifest.
+ *
+ * vinext does not yet construct this error from its server-action dispatcher
+ * — it's exposed primarily so user code can use the predicate below
+ * (`unstable_isUnrecognizedActionError`) as a stable `instanceof` check.
+ * Ported as a 1:1 alias of Next.js's class so deployments that throw it
+ * directly (or third-party action wrappers) interoperate.
+ */
+export class UnrecognizedActionError extends Error {
+  constructor(...args: ConstructorParameters<typeof Error>) {
+    super(...args);
+    this.name = "UnrecognizedActionError";
+  }
+}
+
+/**
+ * Returns true if the error came from a server action whose id was not
+ * recognized by the server. Useful inside `catch` blocks that surround
+ * `await myAction(...)` calls; reloading the page generally fixes the
+ * underlying client/server deployment mismatch.
+ *
+ * Ported from Next.js:
+ *   https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/unrecognized-action-error.ts
+ */
+export function unstable_isUnrecognizedActionError(
+  error: unknown,
+): error is UnrecognizedActionError {
+  return !!(error && typeof error === "object" && error instanceof UnrecognizedActionError);
+}
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -1614,13 +1614,31 @@ type _RedirectErrorShape = Error & { digest: string };
 /**
  * Check whether an error was produced by `redirect()` or `permanentRedirect()`.
  *
- * vinext emits 3-part (`NEXT_REDIRECT;{type};{encoded-url}`) and 4-part
- * (`NEXT_REDIRECT;{type};{encoded-url};308`) digests; we match permissively so
- * either format counts. Mirrors the lenient check already used by
- * `shims/error-boundary.tsx`.
- *
- * Ported from Next.js:
+ * **Divergence from Next.js:** Next.js's `isRedirectError` performs full
+ * 4-segment validation — it splits the digest on `;`, checks `type` ∈
+ * {push, replace}, requires a non-empty destination, and validates the
+ * status code (303, 307, 308). See:
  *   https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/redirect-error.ts
+ *
+ * vinext instead uses a simple prefix check (`startsWith("NEXT_REDIRECT;")`).
+ * Reasons:
+ *   1. vinext emits two digest shapes — 3-part for `redirect()`
+ *      (`NEXT_REDIRECT;{type};{encoded-url}`) and 4-part for
+ *      `permanentRedirect()` (`NEXT_REDIRECT;{type};{encoded-url};308`).
+ *      Strict validation would have to special-case both, and Next.js's
+ *      validator (tuned to its 5-part canary digests) rejects them.
+ *   2. The `type` field is sometimes empty in vinext's redirect digests
+ *      (context-dependent resolution; see `redirect()` above), which the
+ *      strict check disallows.
+ *
+ * **Consequence:** A malformed digest such as `"NEXT_REDIRECT;garbage"`
+ * returns `true` here, whereas Next.js would return `false`. In practice,
+ * the only callers of this predicate are vinext-internal code paths
+ * (`unstable_rethrow`, `unstable_catchError`, the redirect error boundary)
+ * that see digests vinext itself emits — so the divergence does not surface
+ * in normal use. Maintainers extending the prefix logic should keep this
+ * predicate in lockstep with the corresponding `decode*` helpers in
+ * `shims/error-boundary.tsx`.
  */
 export function isRedirectError(error: unknown): error is _RedirectErrorShape {
   if (

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -1592,8 +1592,11 @@ export function unauthorized(): never {
 //
 // `unstable_rethrow` is part of Next.js's public API. User code in try/catch
 // wrappers calls it to let Next.js's control-flow signals (redirect, notFound,
-// forbidden, unauthorized, …) propagate up to the framework instead of being
-// swallowed.
+// forbidden, unauthorized, dynamic-server-usage, bailout-to-CSR, …)
+// propagate up to the framework instead of being swallowed. The canonical
+// use case is a `fetch()` retry helper that needs to bail out the moment
+// fetch throws a framework signal — see Next.js's
+// test/e2e/app-dir/app-static/lib/fetch-retry.js.
 //
 // Ported from Next.js:
 //   - packages/next/src/client/components/unstable-rethrow.ts (dispatcher)
@@ -1601,12 +1604,21 @@ export function unauthorized(): never {
 //   - packages/next/src/client/components/unstable-rethrow.server.ts
 //   - packages/next/src/client/components/is-next-router-error.ts
 //   - packages/next/src/client/components/redirect-error.ts
+//   - packages/next/src/shared/lib/lazy-dynamic/bailout-to-csr.ts
+//   - packages/next/src/client/components/hooks-server-context.ts
 //
-// vinext does not yet implement every Next.js internal-error category
-// (BailoutToCSRError, DynamicServerError, prerender postpone errors, …) so we
-// only check the ones we actually emit:
-//   - redirect / permanentRedirect → digest starts with "NEXT_REDIRECT;"
-//   - notFound / forbidden / unauthorized → covered by isHTTPAccessFallbackError
+// Coverage of Next.js's 7 server-side categories (server build):
+//   ✓ isNextRouterError (#1) — redirect + HTTP access fallback
+//   ✓ isBailoutToCSRError (#2) — digest === "BAILOUT_TO_CLIENT_SIDE_RENDERING"
+//   ✓ isDynamicServerError (#3) — digest === "DYNAMIC_SERVER_USAGE"
+//   ✗ isDynamicPostpone (#4) — PPR-internal message check; vinext has no PPR
+//   ✗ isPostpone (#5) — React.unstable_postpone signal; vinext has no PPR
+//   ✗ isHangingPromiseRejectionError (#6) — prerender abort signal
+//   ✗ isPrerenderInterruptedError (#7) — prerender controller interrupt
+//
+// The four uncovered categories are server-only Next.js internals tied to
+// prerender-machinery vinext does not implement; user code cannot construct
+// them in normal use. They will be added if/when vinext grows PPR support.
 // ---------------------------------------------------------------------------
 
 type _RedirectErrorShape = Error & { digest: string };
@@ -1614,8 +1626,14 @@ type _RedirectErrorShape = Error & { digest: string };
 /**
  * Check whether an error was produced by `redirect()` or `permanentRedirect()`.
  *
- * **Divergence from Next.js:** Next.js's `isRedirectError` performs full
- * 4-segment validation — it splits the digest on `;`, checks `type` ∈
+ * **Note on vinext public surface:** Next.js does NOT expose `isRedirectError`
+ * from `next/navigation` — it's an internal predicate. vinext exposes it for
+ * symmetry with the already-public `isHTTPAccessFallbackError` and because
+ * `unstable_rethrow` consumers benefit from being able to narrow types.
+ * Treat it as a vinext-only extension.
+ *
+ * **Divergence from Next.js:** Next.js's internal `isRedirectError` performs
+ * full 4-segment validation — it splits the digest on `;`, checks `type` ∈
  * {push, replace}, requires a non-empty destination, and validates the
  * status code (303, 307, 308). See:
  *   https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/redirect-error.ts
@@ -1656,6 +1674,10 @@ export function isRedirectError(error: unknown): error is _RedirectErrorShape {
  * Returns true if the error is a Next.js navigation signal — either a redirect
  * or an HTTP access fallback (notFound / forbidden / unauthorized).
  *
+ * **Note on vinext public surface:** Like `isRedirectError`, Next.js does NOT
+ * expose this from `next/navigation`. vinext exposes it for symmetry — treat
+ * it as a vinext-only extension.
+ *
  * Ported from Next.js:
  *   https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/is-next-router-error.ts
  */
@@ -1663,20 +1685,137 @@ export function isNextRouterError(error: unknown): boolean {
   return isRedirectError(error) || isHTTPAccessFallbackError(error);
 }
 
+// ---------------------------------------------------------------------------
+// BailoutToCSRError — `next/dynamic` with `ssr: false` throws this during
+// server render to signal that the dynamic component must be rendered on
+// the client. Lives in shared (non-server) code so it can flow through both
+// the SSR pipeline and userland; third-party libraries that emulate
+// `next/dynamic` also construct it.
+//
+// Ported from Next.js:
+//   https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/lazy-dynamic/bailout-to-csr.ts
+// ---------------------------------------------------------------------------
+
+const _BAILOUT_TO_CSR_DIGEST = "BAILOUT_TO_CLIENT_SIDE_RENDERING";
+
+/**
+ * Error thrown to bail out of server rendering and fall back to client-side
+ * rendering. Used by `next/dynamic` with `ssr: false`.
+ *
+ * vinext does not yet emit this error itself — it's exposed so user code and
+ * third-party libraries that mimic `next/dynamic`'s bailout semantics can
+ * construct an error with the canonical digest that `unstable_rethrow`
+ * recognises.
+ *
+ * Ported 1:1 from Next.js:
+ *   https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/lazy-dynamic/bailout-to-csr.ts
+ */
+export class BailoutToCSRError extends Error {
+  public readonly digest: typeof _BAILOUT_TO_CSR_DIGEST = _BAILOUT_TO_CSR_DIGEST;
+  public readonly reason: string;
+
+  constructor(reason: string) {
+    super(`Bail out to client-side rendering: ${reason}`);
+    this.reason = reason;
+  }
+}
+
+/**
+ * Returns true if the error is a `BailoutToCSRError`. Matches Next.js's
+ * digest-based predicate, so any error from a foreign module instance of
+ * the class (or constructed manually with the canonical digest) is also
+ * detected.
+ *
+ * **Note on vinext public surface:** Next.js does NOT expose this from
+ * `next/navigation`. vinext exposes it for symmetry with `isRedirectError`
+ * — treat it as a vinext-only extension. The matching producer
+ * (`BailoutToCSRError`) is the public detection contract; Next.js exposes
+ * neither.
+ *
+ * Ported from Next.js:
+ *   https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/lazy-dynamic/bailout-to-csr.ts
+ */
+export function isBailoutToCSRError(error: unknown): error is BailoutToCSRError {
+  if (!error || typeof error !== "object" || !("digest" in error)) {
+    return false;
+  }
+  return (error as { digest: unknown }).digest === _BAILOUT_TO_CSR_DIGEST;
+}
+
+// ---------------------------------------------------------------------------
+// DynamicServerError — thrown by Next.js's internal `cookies()`/`headers()`
+// shims when called inside a static render context that cannot resolve
+// request-scoped data. vinext's own `next/headers` shim has its own throw
+// semantics, so vinext never constructs this error itself, but third-party
+// code or accidentally-bundled Next.js internals can.
+//
+// Ported from Next.js:
+//   https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/hooks-server-context.ts
+// ---------------------------------------------------------------------------
+
+const _DYNAMIC_SERVER_USAGE_DIGEST = "DYNAMIC_SERVER_USAGE";
+
+/**
+ * Error thrown when dynamic server APIs (`cookies()`, `headers()`, etc.) are
+ * used inside a static/prerender context. Carries the `DYNAMIC_SERVER_USAGE`
+ * digest so `unstable_rethrow` can recognise and propagate it.
+ *
+ * vinext does not construct this error itself — exposed for the same
+ * "stable detection contract" reason as `BailoutToCSRError` above.
+ *
+ * Ported 1:1 from Next.js:
+ *   https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/hooks-server-context.ts
+ */
+export class DynamicServerError extends Error {
+  public readonly digest: typeof _DYNAMIC_SERVER_USAGE_DIGEST = _DYNAMIC_SERVER_USAGE_DIGEST;
+  public readonly description: string;
+
+  constructor(description: string) {
+    super(`Dynamic server usage: ${description}`);
+    this.description = description;
+  }
+}
+
+/**
+ * Returns true if the error is a `DynamicServerError` (or any error with the
+ * canonical `DYNAMIC_SERVER_USAGE` digest).
+ *
+ * **Note on vinext public surface:** Next.js does NOT expose this from
+ * `next/navigation`. vinext exposes it for symmetry — treat it as a
+ * vinext-only extension.
+ *
+ * Ported from Next.js:
+ *   https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/hooks-server-context.ts
+ */
+export function isDynamicServerError(error: unknown): error is DynamicServerError {
+  if (!error || typeof error !== "object" || !("digest" in error)) {
+    return false;
+  }
+  const digest = (error as { digest: unknown }).digest;
+  return typeof digest === "string" && digest === _DYNAMIC_SERVER_USAGE_DIGEST;
+}
+
 /**
  * Rethrow internal Next.js errors so they're handled by the framework.
  *
  * When wrapping an API that uses errors for control flow (redirect, notFound,
- * etc.), call this inside `catch` blocks before doing your own error handling.
- * If the error is a Next.js internal error, it's rethrown; otherwise this is a
- * no-op (apart from recursing through `error.cause`).
+ * cookies in static render, `next/dynamic` SSR bailout, etc.), call this
+ * inside `catch` blocks before doing your own error handling. If the error
+ * is a Next.js internal error, it's rethrown; otherwise this is a no-op
+ * (apart from recursing through `error.cause`).
  *
- * Fresh implementation that follows Next.js's dispatcher pattern, but
- * specialized to the internal-error categories vinext actually emits. The
- * single function intentionally covers both server and browser contexts —
- * Next.js splits these into `.server.ts` / `.browser.ts` files only because
- * the server build pulls in additional checks (`isPostpone`,
- * `isHangingPromiseRejectionError`, …) that vinext does not yet implement.
+ * Recognises (matches Next.js's browser build + the subset of the server
+ * build that vinext can realistically encounter):
+ *   - `isNextRouterError`: redirect / notFound / forbidden / unauthorized
+ *   - `isBailoutToCSRError`: `next/dynamic` `ssr: false` bailout
+ *   - `isDynamicServerError`: dynamic API used in static render
+ *
+ * vinext does not yet recognise four additional server-only Next.js
+ * categories — `isDynamicPostpone`, `isPostpone`,
+ * `isHangingPromiseRejectionError`, `isPrerenderInterruptedError` — because
+ * they signal PPR / prerender-controller events that vinext's render
+ * pipeline does not generate. User code cannot construct these in normal
+ * use; they will be added if/when vinext grows PPR support.
  *
  * Ported from Next.js:
  *   https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/unstable-rethrow.ts
@@ -1684,7 +1823,7 @@ export function isNextRouterError(error: unknown): boolean {
  *   https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/unstable-rethrow.browser.ts
  */
 export function unstable_rethrow(error: unknown): void {
-  if (isNextRouterError(error)) {
+  if (isNextRouterError(error) || isBailoutToCSRError(error) || isDynamicServerError(error)) {
     throw error;
   }
 

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -1791,8 +1791,10 @@ export function isDynamicServerError(error: unknown): error is DynamicServerErro
   if (!error || typeof error !== "object" || !("digest" in error)) {
     return false;
   }
-  const digest = (error as { digest: unknown }).digest;
-  return typeof digest === "string" && digest === _DYNAMIC_SERVER_USAGE_DIGEST;
+  // `===` against a string literal already requires the operand to be a
+  // string, so no separate `typeof digest === "string"` check is needed.
+  // Matches `isBailoutToCSRError` above for stylistic consistency.
+  return (error as { digest: unknown }).digest === _DYNAMIC_SERVER_USAGE_DIGEST;
 }
 
 /**

--- a/packages/vinext/src/shims/next-shims.d.ts
+++ b/packages/vinext/src/shims/next-shims.d.ts
@@ -163,6 +163,18 @@ declare module "next/navigation" {
   export function getAccessFallbackHTTPStatus(error: unknown): number;
   export function isRedirectError(error: unknown): error is Error & { digest: string };
   export function isNextRouterError(error: unknown): boolean;
+  export class BailoutToCSRError extends Error {
+    readonly digest: "BAILOUT_TO_CLIENT_SIDE_RENDERING";
+    readonly reason: string;
+    constructor(reason: string);
+  }
+  export function isBailoutToCSRError(error: unknown): error is BailoutToCSRError;
+  export class DynamicServerError extends Error {
+    readonly digest: "DYNAMIC_SERVER_USAGE";
+    readonly description: string;
+    constructor(description: string);
+  }
+  export function isDynamicServerError(error: unknown): error is DynamicServerError;
   export function unstable_rethrow(error: unknown): void;
   export class UnrecognizedActionError extends Error {}
   export function unstable_isUnrecognizedActionError(

--- a/packages/vinext/src/shims/next-shims.d.ts
+++ b/packages/vinext/src/shims/next-shims.d.ts
@@ -161,6 +161,13 @@ declare module "next/navigation" {
   export const HTTP_ERROR_FALLBACK_ERROR_CODE: string;
   export function isHTTPAccessFallbackError(error: unknown): boolean;
   export function getAccessFallbackHTTPStatus(error: unknown): number;
+  export function isRedirectError(error: unknown): error is Error & { digest: string };
+  export function isNextRouterError(error: unknown): boolean;
+  export function unstable_rethrow(error: unknown): void;
+  export class UnrecognizedActionError extends Error {}
+  export function unstable_isUnrecognizedActionError(
+    error: unknown,
+  ): error is UnrecognizedActionError;
   // Context management (internal)
   export function setNavigationContext(ctx: any): void;
   export function setClientParams(params: Record<string, string | string[]>): void;
@@ -292,7 +299,7 @@ declare module "next/legacy/image" {
 }
 
 declare module "next/error" {
-  import { ComponentType } from "react";
+  import { ComponentType, ReactNode } from "react";
 
   type ErrorProps = {
     statusCode: number;
@@ -302,6 +309,16 @@ declare module "next/error" {
 
   const ErrorComponent: ComponentType<ErrorProps>;
   export default ErrorComponent;
+
+  export type ErrorInfo = {
+    error: unknown;
+    reset: () => void;
+    unstable_retry: () => void;
+  };
+
+  export function unstable_catchError<P extends Record<string, unknown>>(
+    fallback: (props: P, errorInfo: ErrorInfo) => ReactNode,
+  ): ComponentType<P & { children?: ReactNode }>;
 }
 
 declare module "next/constants" {

--- a/packages/vinext/src/utils/navigation-signal.ts
+++ b/packages/vinext/src/utils/navigation-signal.ts
@@ -10,7 +10,7 @@
 // Previously duplicated between shims/error-boundary.tsx and
 // server/dev-error-overlay.tsx; consolidated here so they cannot drift.
 
-export function getErrorDigest(error: unknown): string | null {
+function getErrorDigest(error: unknown): string | null {
   if (!error || typeof error !== "object" || !("digest" in error)) {
     return null;
   }

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -634,6 +634,324 @@ describe("next/navigation shim", () => {
 
     expect(html).toContain("[]");
   });
+
+  // -------------------------------------------------------------------------
+  // unstable_rethrow + unstable_isUnrecognizedActionError
+  //
+  // Ported from Next.js:
+  //   https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/unstable-rethrow.ts
+  //   https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/unrecognized-action-error.ts
+  // -------------------------------------------------------------------------
+  it("exports unstable_rethrow and unstable_isUnrecognizedActionError", async () => {
+    const nav = await import("../packages/vinext/src/shims/navigation.js");
+    expect(typeof nav.unstable_rethrow).toBe("function");
+    expect(typeof nav.unstable_isUnrecognizedActionError).toBe("function");
+    expect(typeof nav.isRedirectError).toBe("function");
+    expect(typeof nav.isNextRouterError).toBe("function");
+    expect(typeof nav.UnrecognizedActionError).toBe("function");
+  });
+
+  it("unstable_rethrow re-throws redirect errors", async () => {
+    const { redirect, unstable_rethrow } =
+      await import("../packages/vinext/src/shims/navigation.js");
+    let captured: unknown = null;
+    try {
+      redirect("/login");
+    } catch (e) {
+      captured = e;
+    }
+    expect(captured).not.toBeNull();
+
+    expect(() => unstable_rethrow(captured)).toThrow();
+    try {
+      unstable_rethrow(captured);
+    } catch (rethrown) {
+      // Identity-preserving rethrow — must be the same error reference
+      expect(rethrown).toBe(captured);
+    }
+  });
+
+  it("unstable_rethrow re-throws notFound/forbidden/unauthorized errors", async () => {
+    const { notFound, forbidden, unauthorized, unstable_rethrow } =
+      await import("../packages/vinext/src/shims/navigation.js");
+    for (const trigger of [notFound, forbidden, unauthorized]) {
+      let captured: unknown = null;
+      try {
+        trigger();
+      } catch (e) {
+        captured = e;
+      }
+      expect(captured).not.toBeNull();
+      expect(() => unstable_rethrow(captured)).toThrow();
+    }
+  });
+
+  it("unstable_rethrow is a no-op for unrelated errors", async () => {
+    const { unstable_rethrow } = await import("../packages/vinext/src/shims/navigation.js");
+    // Plain Error: no digest, no cause
+    expect(() => unstable_rethrow(new Error("plain"))).not.toThrow();
+    expect(() => unstable_rethrow("string error")).not.toThrow();
+    expect(() => unstable_rethrow(null)).not.toThrow();
+    expect(() => unstable_rethrow(undefined)).not.toThrow();
+    expect(() => unstable_rethrow({ digest: "not-a-next-error" })).not.toThrow();
+  });
+
+  it("unstable_rethrow recurses through error.cause to rethrow wrapped Next.js errors", async () => {
+    const { redirect, unstable_rethrow } =
+      await import("../packages/vinext/src/shims/navigation.js");
+    let inner: unknown = null;
+    try {
+      redirect("/login");
+    } catch (e) {
+      inner = e;
+    }
+    const wrapped = new Error("user wrapped this", { cause: inner });
+
+    expect(() => unstable_rethrow(wrapped)).toThrow();
+    try {
+      unstable_rethrow(wrapped);
+    } catch (rethrown) {
+      // The recursion should rethrow the original Next.js error, not the wrapper
+      expect(rethrown).toBe(inner);
+    }
+  });
+
+  it("unstable_isUnrecognizedActionError returns true for UnrecognizedActionError instances", async () => {
+    const { UnrecognizedActionError, unstable_isUnrecognizedActionError } =
+      await import("../packages/vinext/src/shims/navigation.js");
+    const err = new UnrecognizedActionError("missing action 'abc'");
+    expect(err.name).toBe("UnrecognizedActionError");
+    expect(unstable_isUnrecognizedActionError(err)).toBe(true);
+  });
+
+  it("unstable_isUnrecognizedActionError returns false for other errors", async () => {
+    const { unstable_isUnrecognizedActionError } =
+      await import("../packages/vinext/src/shims/navigation.js");
+    expect(unstable_isUnrecognizedActionError(new Error("other"))).toBe(false);
+    expect(unstable_isUnrecognizedActionError(null)).toBe(false);
+    expect(unstable_isUnrecognizedActionError(undefined)).toBe(false);
+    expect(unstable_isUnrecognizedActionError("string")).toBe(false);
+    expect(unstable_isUnrecognizedActionError({ name: "UnrecognizedActionError" })).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // react-server re-exports
+  // -------------------------------------------------------------------------
+  it("navigation.react-server re-exports unstable_rethrow and stubs unstable_isUnrecognizedActionError", async () => {
+    const rsc = await import("../packages/vinext/src/shims/navigation.react-server.js");
+    expect(typeof rsc.unstable_rethrow).toBe("function");
+    expect(typeof rsc.unstable_isUnrecognizedActionError).toBe("function");
+
+    // The RSC stub should throw a clear "client-only" error, matching Next.js.
+    expect(() => rsc.unstable_isUnrecognizedActionError()).toThrow(/client/i);
+
+    // unstable_rethrow itself is environment-agnostic — re-exported from
+    // ./navigation.js — and should behave identically to the client export.
+    const { redirect } = await import("../packages/vinext/src/shims/navigation.js");
+    let captured: unknown = null;
+    try {
+      redirect("/login");
+    } catch (e) {
+      captured = e;
+    }
+    expect(() => rsc.unstable_rethrow(captured)).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// next/error shim — unstable_catchError
+//
+// Ported from Next.js:
+//   https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/catch-error.tsx
+//   https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/catch-error/
+// ---------------------------------------------------------------------------
+describe("next/error shim — unstable_catchError", () => {
+  it("exports unstable_catchError as a function", async () => {
+    const mod = await import("../packages/vinext/src/shims/error.js");
+    expect(typeof mod.unstable_catchError).toBe("function");
+  });
+
+  it("returns a Component that renders children when no error occurs", async () => {
+    const React = (await import("react")).default;
+    const { renderToStaticMarkup } = await import("react-dom/server");
+    const { unstable_catchError } = await import("../packages/vinext/src/shims/error.js");
+
+    function Fallback(_props: { title: string }) {
+      return React.createElement("p", null, "should not render");
+    }
+
+    const Boundary = unstable_catchError<{ title: string }>(Fallback);
+    const html = renderToStaticMarkup(
+      React.createElement(
+        Boundary,
+        { title: "ignored" },
+        React.createElement("span", { id: "ok" }, "hello"),
+      ),
+    );
+
+    expect(html).toContain('id="ok"');
+    expect(html).toContain("hello");
+  });
+
+  it("class-component lifecycle catches non-router errors and renders the fallback", async () => {
+    // React 19's renderToStaticMarkup does NOT invoke error boundaries during
+    // SSR — errors propagate up by design (boundaries only run during client
+    // commit). To validate behavior without spinning up a real browser, we
+    // exercise the lifecycle hooks directly: `getDerivedStateFromError` is
+    // the canonical predicate driving the class component's behavior, and
+    // its return value is the only thing the React runtime feeds into the
+    // next render.
+    const React = (await import("react")).default;
+    const { renderToStaticMarkup } = await import("react-dom/server");
+    const { unstable_catchError } = await import("../packages/vinext/src/shims/error.js");
+
+    const seenErrors: unknown[] = [];
+    function Fallback(
+      props: { title: string },
+      info: { error: unknown; reset: () => void; unstable_retry: () => void },
+    ) {
+      seenErrors.push(info.error);
+      const message = info.error instanceof Error ? info.error.message : String(info.error);
+      return React.createElement(
+        "div",
+        null,
+        React.createElement("p", { id: "title" }, props.title),
+        React.createElement("p", { id: "msg" }, message),
+      );
+    }
+
+    const Boundary = unstable_catchError<{ title: string }>(Fallback);
+
+    // Locate the inner class component by inspecting what the HOC renders.
+    // The wrapper function returns `React.createElement(_CatchError, ...)`.
+    const wrapperResult = (
+      Boundary as unknown as (props: {
+        title: string;
+        children?: React.ReactNode;
+      }) => React.ReactElement
+    )({
+      title: "hello-title",
+      children: React.createElement("span", null, "child"),
+    });
+    const InnerCatchError = wrapperResult.type as unknown as React.ComponentClass<{
+      fallback: typeof Fallback;
+      forwardedProps: { title: string };
+      children?: React.ReactNode;
+    }>;
+
+    const props = {
+      fallback: Fallback,
+      forwardedProps: { title: "hello-title" },
+      children: React.createElement("span", null, "child"),
+    };
+    // Cast through unknown to instantiate without engaging React's renderer.
+    const instance = new (InnerCatchError as unknown as new (p: typeof props) => InstanceType<
+      typeof InnerCatchError
+    > & {
+      state: { error: { thrownValue: unknown } | null };
+      render(): React.ReactNode;
+    })(props);
+    instance.state = { error: null };
+
+    // 1. No error → renders children.
+    const childrenOutput = renderToStaticMarkup(instance.render() as React.ReactElement);
+    expect(childrenOutput).toContain("child");
+
+    // 2. After getDerivedStateFromError, renders the fallback with ErrorInfo.
+    const thrown = new Error("boom");
+    const derived = (
+      InnerCatchError as unknown as {
+        getDerivedStateFromError(e: unknown): { error: { thrownValue: unknown } | null };
+      }
+    ).getDerivedStateFromError(thrown);
+    expect(derived).toEqual({ error: { thrownValue: thrown } });
+    instance.state = derived;
+    const fallbackOutput = renderToStaticMarkup(instance.render() as React.ReactElement);
+    expect(fallbackOutput).toContain('id="msg"');
+    expect(fallbackOutput).toContain("boom");
+    expect(fallbackOutput).toContain("hello-title");
+    expect(seenErrors[seenErrors.length - 1]).toBe(thrown);
+  });
+
+  it("class-component getDerivedStateFromError re-throws Next.js router errors", async () => {
+    const { unstable_catchError } = await import("../packages/vinext/src/shims/error.js");
+    const { redirect } = await import("../packages/vinext/src/shims/navigation.js");
+
+    function Fallback() {
+      return null;
+    }
+    const Boundary = unstable_catchError(Fallback);
+
+    // Probe the inner class through the wrapper.
+    const wrapperResult = (Boundary as unknown as (p: Record<string, never>) => { type: unknown })(
+      {},
+    );
+    const InnerCatchError = wrapperResult.type as unknown as {
+      getDerivedStateFromError(e: unknown): unknown;
+    };
+
+    let captured: unknown = null;
+    try {
+      redirect("/login");
+    } catch (e) {
+      captured = e;
+    }
+    expect(() => InnerCatchError.getDerivedStateFromError(captured)).toThrow();
+    try {
+      InnerCatchError.getDerivedStateFromError(captured);
+    } catch (rethrown) {
+      // Identity-preserving rethrow.
+      expect(rethrown).toBe(captured);
+    }
+  });
+
+  it("rethrows Next.js navigation signals (redirect, notFound) instead of catching them", async () => {
+    const React = (await import("react")).default;
+    const { renderToStaticMarkup } = await import("react-dom/server");
+    const { unstable_catchError } = await import("../packages/vinext/src/shims/error.js");
+    const { redirect } = await import("../packages/vinext/src/shims/navigation.js");
+
+    function RedirectThrower(): React.ReactElement {
+      redirect("/login");
+      // Unreachable: `redirect()` throws. Annotated explicitly to satisfy
+      // the `ReactElement` return-type contract.
+      return React.createElement("span", null);
+    }
+
+    function Fallback() {
+      return React.createElement("p", null, "should not be reached");
+    }
+
+    const Boundary = unstable_catchError(Fallback);
+
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      // The boundary must let the redirect propagate up — renderToStaticMarkup
+      // should throw with the redirect digest.
+      let captured: unknown = null;
+      try {
+        renderToStaticMarkup(
+          React.createElement(Boundary, null, React.createElement(RedirectThrower)),
+        );
+      } catch (e) {
+        captured = e;
+      }
+      expect(captured).not.toBeNull();
+      expect((captured as { digest?: string }).digest).toContain("NEXT_REDIRECT");
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("exposes the displayName matching Next.js (`unstable_catchError(...)`)", async () => {
+    const { unstable_catchError } = await import("../packages/vinext/src/shims/error.js");
+    const Fallback = function MyFallback() {
+      return null;
+    };
+    const Boundary = unstable_catchError(Fallback);
+    // Wrapper component carries the user fallback name for DevTools.
+    expect(Boundary.displayName).toBe("unstable_catchError(MyFallback)");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -696,6 +696,103 @@ describe("next/navigation shim", () => {
     expect(() => unstable_rethrow({ digest: "not-a-next-error" })).not.toThrow();
   });
 
+  // -------------------------------------------------------------------------
+  // BailoutToCSRError + DynamicServerError parity
+  //
+  // Ported from Next.js:
+  //   https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/lazy-dynamic/bailout-to-csr.ts
+  //   https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/hooks-server-context.ts
+  // -------------------------------------------------------------------------
+  it("exports BailoutToCSRError + isBailoutToCSRError with the canonical digest", async () => {
+    const { BailoutToCSRError, isBailoutToCSRError } =
+      await import("../packages/vinext/src/shims/navigation.js");
+    const err = new BailoutToCSRError("test-reason");
+    expect(err.digest).toBe("BAILOUT_TO_CLIENT_SIDE_RENDERING");
+    expect(err.reason).toBe("test-reason");
+    expect(err.message).toBe("Bail out to client-side rendering: test-reason");
+    expect(isBailoutToCSRError(err)).toBe(true);
+    // Predicate matches by digest, not by instanceof — a foreign object with
+    // the canonical digest should also be detected (Next.js parity).
+    expect(isBailoutToCSRError({ digest: "BAILOUT_TO_CLIENT_SIDE_RENDERING" })).toBe(true);
+    // Negative cases.
+    expect(isBailoutToCSRError(new Error("plain"))).toBe(false);
+    expect(isBailoutToCSRError({ digest: "OTHER" })).toBe(false);
+    expect(isBailoutToCSRError(null)).toBe(false);
+    expect(isBailoutToCSRError(undefined)).toBe(false);
+  });
+
+  it("exports DynamicServerError + isDynamicServerError with the canonical digest", async () => {
+    const { DynamicServerError, isDynamicServerError } =
+      await import("../packages/vinext/src/shims/navigation.js");
+    const err = new DynamicServerError("cookies()");
+    expect(err.digest).toBe("DYNAMIC_SERVER_USAGE");
+    expect(err.description).toBe("cookies()");
+    expect(err.message).toBe("Dynamic server usage: cookies()");
+    expect(isDynamicServerError(err)).toBe(true);
+    // Predicate matches by digest — Next.js parity.
+    expect(isDynamicServerError({ digest: "DYNAMIC_SERVER_USAGE" })).toBe(true);
+    // Negative cases.
+    expect(isDynamicServerError(new Error("plain"))).toBe(false);
+    expect(isDynamicServerError({ digest: "OTHER" })).toBe(false);
+    expect(isDynamicServerError(null)).toBe(false);
+    expect(isDynamicServerError(undefined)).toBe(false);
+  });
+
+  // Mirrors the Next.js fixture
+  //   .nextjs-ref/test/e2e/app-dir/unstable-rethrow/app/dynamic-error/page.tsx
+  // where `cookies()` throws a DynamicServerError inside a try/catch and
+  // unstable_rethrow must propagate it.
+  it("unstable_rethrow re-throws BailoutToCSRError (next/dynamic ssr:false bailout)", async () => {
+    const { BailoutToCSRError, unstable_rethrow } =
+      await import("../packages/vinext/src/shims/navigation.js");
+    const err = new BailoutToCSRError("Lazy(): No ssr");
+    expect(() => unstable_rethrow(err)).toThrow();
+    try {
+      unstable_rethrow(err);
+    } catch (rethrown) {
+      expect(rethrown).toBe(err);
+    }
+  });
+
+  it("unstable_rethrow re-throws DynamicServerError (cookies()/headers() in static render)", async () => {
+    const { DynamicServerError, unstable_rethrow } =
+      await import("../packages/vinext/src/shims/navigation.js");
+    const err = new DynamicServerError("Route used cookies()");
+    expect(() => unstable_rethrow(err)).toThrow();
+    try {
+      unstable_rethrow(err);
+    } catch (rethrown) {
+      expect(rethrown).toBe(err);
+    }
+  });
+
+  it("unstable_rethrow does NOT match the four server-only categories vinext does not implement", async () => {
+    // These categories (isDynamicPostpone, isPostpone,
+    // isHangingPromiseRejectionError, isPrerenderInterruptedError) are
+    // server-only Next.js internals tied to PPR / prerender-controller
+    // machinery vinext does not implement. They are deferred as follow-ups
+    // (see the JSDoc on unstable_rethrow). This test pins that intentional
+    // gap so the omission is visible to future maintainers.
+    const { unstable_rethrow } = await import("../packages/vinext/src/shims/navigation.js");
+
+    const postpone = { $$typeof: Symbol.for("react.postpone") };
+    expect(() => unstable_rethrow(postpone)).not.toThrow();
+
+    const hanging = Object.assign(new Error("hanging"), { digest: "HANGING_PROMISE_REJECTION" });
+    expect(() => unstable_rethrow(hanging)).not.toThrow();
+
+    const interrupted = Object.assign(new Error("interrupt"), {
+      digest: "NEXT_PRERENDER_INTERRUPTED",
+    });
+    expect(() => unstable_rethrow(interrupted)).not.toThrow();
+
+    // No fixed digest — message-shape based detection. We don't try to
+    // construct a faithful payload here; just confirm an arbitrary message
+    // doesn't match.
+    const dynamicPostpone = new Error("some random message");
+    expect(() => unstable_rethrow(dynamicPostpone)).not.toThrow();
+  });
+
   it("unstable_rethrow recurses through error.cause to rethrow wrapped Next.js errors", async () => {
     const { redirect, unstable_rethrow } =
       await import("../packages/vinext/src/shims/navigation.js");
@@ -951,6 +1048,164 @@ describe("next/error shim — unstable_catchError", () => {
     const Boundary = unstable_catchError(Fallback);
     // Wrapper component carries the user fallback name for DevTools.
     expect(Boundary.displayName).toBe("unstable_catchError(MyFallback)");
+  });
+
+  // Ported from Next.js:
+  //   .nextjs-ref/test/e2e/app-dir/catch-error/catch-error.test.ts
+  //   "should render fallback when null is thrown from a Client Component"
+  //   "should render fallback when undefined is thrown from a Client Component"
+  //
+  // The boundary must accept null/undefined as `thrownValue` (not just Error
+  // instances) and route them to the fallback. Crucially, the rethrow guard
+  // (`isNextRouterError`) must not crash on null/undefined inputs.
+  it("class-component getDerivedStateFromError accepts null thrown values", async () => {
+    const React = (await import("react")).default;
+    const { unstable_catchError } = await import("../packages/vinext/src/shims/error.js");
+
+    function Fallback() {
+      return null;
+    }
+    const Boundary = unstable_catchError(Fallback);
+    const wrapperResult = (Boundary as unknown as (p: Record<string, never>) => { type: unknown })(
+      {},
+    );
+    const InnerCatchError = wrapperResult.type as unknown as {
+      getDerivedStateFromError(e: unknown): { error: { thrownValue: unknown } | null };
+    };
+
+    const derivedNull = InnerCatchError.getDerivedStateFromError(null);
+    expect(derivedNull).toEqual({ error: { thrownValue: null } });
+
+    const derivedUndefined = InnerCatchError.getDerivedStateFromError(undefined);
+    expect(derivedUndefined).toEqual({ error: { thrownValue: undefined } });
+
+    // Exhaustive non-error primitives (strings, numbers, booleans) should
+    // also flow through to the fallback without throwing.
+    void React; // keep import for module side-effects parity with other tests
+    expect(InnerCatchError.getDerivedStateFromError("string")).toEqual({
+      error: { thrownValue: "string" },
+    });
+    expect(InnerCatchError.getDerivedStateFromError(0)).toEqual({
+      error: { thrownValue: 0 },
+    });
+  });
+
+  // unstable_retry behavior parity. Next.js refreshes the App Router segment
+  // and resets the boundary. vinext does the same on the client; on the
+  // server we throw (refresh is meaningless during SSR setup).
+  it("unstable_retry throws on the server (where refresh is meaningless)", async () => {
+    const React = (await import("react")).default;
+    const { unstable_catchError } = await import("../packages/vinext/src/shims/error.js");
+
+    function Fallback(
+      _props: Record<string, never>,
+      info: { error: unknown; reset: () => void; unstable_retry: () => void },
+    ) {
+      return React.createElement("button", { onClick: info.unstable_retry }, "retry");
+    }
+    const Boundary = unstable_catchError(Fallback);
+    // Probe the inner class for its instance shape.
+    const wrapperResult = (Boundary as unknown as (p: Record<string, never>) => { type: unknown })(
+      {},
+    );
+    const InnerCatchError = wrapperResult.type as unknown as new (props: object) => {
+      state: { error: { thrownValue: unknown } | null };
+      unstable_retry: () => void;
+    };
+    const instance = new InnerCatchError({
+      fallback: Fallback,
+      forwardedProps: {},
+    });
+    instance.state = { error: { thrownValue: new Error("boom") } };
+
+    // typeof window === "undefined" in this Node test environment, so
+    // unstable_retry should throw a clear "client only" error.
+    expect(() => instance.unstable_retry()).toThrow(/client/i);
+  });
+
+  it("unstable_retry on the client calls appRouterInstance.refresh and resets the boundary", async () => {
+    // Stub `window` with the minimum surface navigation.ts needs at
+    // module-load time (location, history, addEventListener). This must be
+    // installed BEFORE re-importing the shims, otherwise navigation.ts will
+    // initialize its client navigation state against a bare `{}` and crash.
+    // Mutable view over globalThis that allows assigning/deleting `window`.
+    // We avoid `as Window & typeof globalThis` because the stub doesn't have
+    // the full DOM surface — just the bits navigation.ts touches at
+    // module-load.
+    const globalAny = globalThis as unknown as { window?: unknown };
+    const previousWindow = globalAny.window;
+    const stubWindow = {
+      location: {
+        search: "",
+        pathname: "/",
+        href: "http://localhost/",
+        origin: "http://localhost",
+      },
+      history: {
+        pushState: () => {},
+        replaceState: () => {},
+        back: () => {},
+        forward: () => {},
+        state: null,
+      },
+      addEventListener: () => {},
+      scrollTo: () => {},
+    };
+    globalAny.window = stubWindow;
+
+    try {
+      vi.resetModules();
+
+      const React = (await import("react")).default;
+      const { unstable_catchError } = await import("../packages/vinext/src/shims/error.js");
+      const navigation = await import("../packages/vinext/src/shims/navigation.js");
+
+      const refreshSpy = vi
+        .spyOn(navigation.appRouterInstance, "refresh")
+        .mockImplementation(() => {});
+
+      function Fallback() {
+        return null;
+      }
+      const Boundary = unstable_catchError(Fallback);
+      const wrapperResult = (
+        Boundary as unknown as (p: Record<string, never>) => { type: unknown }
+      )({});
+      const InnerCatchError = wrapperResult.type as unknown as new (props: object) => {
+        state: { error: { thrownValue: unknown } | null };
+        unstable_retry: () => void;
+      };
+      const instance = new InnerCatchError({
+        fallback: Fallback,
+        forwardedProps: {},
+      });
+
+      // Seed an error so reset has something to clear, and replace setState
+      // with a spy so we can confirm the boundary self-resets.
+      instance.state = { error: { thrownValue: new Error("boom") } };
+      const setStateCalls: Array<{ error: { thrownValue: unknown } | null }> = [];
+      (instance as unknown as { setState: (partial: object) => void }).setState = (partial) => {
+        setStateCalls.push(partial as { error: { thrownValue: unknown } | null });
+        instance.state = { ...instance.state, ...(partial as object) } as typeof instance.state;
+      };
+
+      // startTransition runs synchronously here because there's no
+      // concurrent renderer in the test environment.
+      void React.startTransition;
+      instance.unstable_retry();
+
+      expect(refreshSpy).toHaveBeenCalledTimes(1);
+      expect(setStateCalls).toEqual([{ error: null }]);
+
+      refreshSpy.mockRestore();
+    } finally {
+      if (previousWindow === undefined) {
+        delete globalAny.window;
+      } else {
+        globalAny.window = previousWindow;
+      }
+      vi.resetModules();
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

Adds missing `unstable_*` exports related to error handling, unblocking 18 build failures in the Next.js deploy suite. After a thorough parity audit against Next.js's full error-rethrow surface, the PR also covers `BailoutToCSRError` and `DynamicServerError` and makes `unstable_catchError.unstable_retry` functional on the client.

## Exports

| Export | Shim file | Next.js source-of-truth | Status |
|---|---|---|---|
| `unstable_catchError` | `packages/vinext/src/shims/error.tsx` | [`client/components/catch-error.tsx`](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/catch-error.tsx) + [`api/error.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/api/error.ts) | Fresh implementation (HOC wrapping a class-component error boundary). Re-throws Next.js navigation signals via `isNextRouterError`. `unstable_retry` matches Next.js's App Router branch: calls `appRouterInstance.refresh()` inside `React.startTransition` then resets the boundary. On the server, throws a clear "client-only" error. |
| `unstable_rethrow` | `packages/vinext/src/shims/navigation.ts` (+ re-exported from `navigation.react-server.ts`) | [`client/components/unstable-rethrow.{ts,server,browser}.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/unstable-rethrow.ts) | Fresh implementation. Covers Next.js's two browser-build categories (`isNextRouterError`, `isBailoutToCSRError`) plus one of the five server-build extras (`isDynamicServerError`). The remaining four server-only categories (PPR / prerender controller) are deferred — vinext can't emit them. Recurses through `error.cause`. |
| `isRedirectError` | `packages/vinext/src/shims/navigation.ts` | [`client/components/redirect-error.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/redirect-error.ts) | **vinext-only extension** — Next.js does NOT export `isRedirectError` from `next/navigation`. Permissive prefix match (vs. Next.js's strict 4-segment validation) because vinext emits 3- and 4-part digests where Next.js emits 5-part. Divergence documented in JSDoc. |
| `isNextRouterError` | `packages/vinext/src/shims/navigation.ts` | [`client/components/is-next-router-error.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/is-next-router-error.ts) | **vinext-only extension** — same caveat as `isRedirectError`. Combines `isRedirectError` + `isHTTPAccessFallbackError`. |
| `BailoutToCSRError` + `isBailoutToCSRError` | `packages/vinext/src/shims/navigation.ts` | [`shared/lib/lazy-dynamic/bailout-to-csr.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/lazy-dynamic/bailout-to-csr.ts) | 1:1 port. **vinext-only extension** on the export surface — Next.js's class is internal but the digest (`BAILOUT_TO_CLIENT_SIDE_RENDERING`) is the stable detection contract. |
| `DynamicServerError` + `isDynamicServerError` | `packages/vinext/src/shims/navigation.ts` | [`client/components/hooks-server-context.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/hooks-server-context.ts) | 1:1 port. **vinext-only extension** on the export surface — same shape as `BailoutToCSRError`. |
| `UnrecognizedActionError` | `packages/vinext/src/shims/navigation.ts` | [`client/components/unrecognized-action-error.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/unrecognized-action-error.ts) | 1:1 alias — Next.js's class verbatim. |
| `unstable_isUnrecognizedActionError` | `packages/vinext/src/shims/navigation.ts` (+ throwing stub in `navigation.react-server.ts`) | [`client/components/unrecognized-action-error.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/unrecognized-action-error.ts) + [`client/components/navigation.react-server.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/navigation.react-server.ts) | 1:1 port of the predicate. RSC stub matches Next.js's `'client only'` throw. |

## `unstable_rethrow` category coverage

Next.js's server-side build handles seven error categories; the browser build handles two. vinext now covers three, all in a single environment-agnostic implementation:

| # | Predicate | Next.js source | vinext |
|---|---|---|---|
| 1 | `isNextRouterError` (redirect + HTTP fallback) | [`is-next-router-error.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/is-next-router-error.ts) | ✅ |
| 2 | `isBailoutToCSRError` (`next/dynamic` `ssr: false`) | [`bailout-to-csr.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/lazy-dynamic/bailout-to-csr.ts) | ✅ |
| 3 | `isDynamicServerError` (dynamic API in static render) | [`hooks-server-context.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/hooks-server-context.ts) | ✅ |
| 4 | `isDynamicPostpone` (PPR message check) | [`dynamic-rendering.ts:408`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/dynamic-rendering.ts) | ❌ (vinext has no PPR) |
| 5 | `isPostpone` (React.unstable_postpone) | [`is-postpone.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/router-utils/is-postpone.ts) | ❌ (vinext has no PPR) |
| 6 | `isHangingPromiseRejectionError` (prerender abort) | [`dynamic-rendering-utils.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/dynamic-rendering-utils.ts) | ❌ (vinext has no prerender controller) |
| 7 | `isPrerenderInterruptedError` (prerender interrupt) | [`dynamic-rendering.ts:448`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/dynamic-rendering.ts) | ❌ (vinext has no prerender controller) |

The four uncovered categories are tied to Next.js's PPR / prerender-controller machinery that vinext does not implement; user code cannot construct them in normal use. A dedicated test pins this intentional omission so the gap is visible to future maintainers.

## Files touched

- `packages/vinext/src/shims/error.tsx`
- `packages/vinext/src/shims/navigation.ts`
- `packages/vinext/src/shims/navigation.react-server.ts`
- `packages/vinext/src/shims/error-boundary.tsx` (consolidate duplicate `isRedirectError` via import from `./navigation.js`)
- `packages/vinext/src/shims/next-shims.d.ts` (TS declarations for the new exports)
- `packages/vinext/src/utils/navigation-signal.ts` (drop unused `getErrorDigest` export after consolidation)
- `tests/shims.test.ts`

## Tests

22 new test cases in `tests/shims.test.ts`:

- `unstable_rethrow` rethrows redirect, notFound, forbidden, unauthorized; no-op for unrelated errors; recurses through `error.cause`.
- `BailoutToCSRError` + `DynamicServerError` constructors / predicates (canonical digests, foreign-object detection by digest, negative cases).
- `unstable_rethrow` propagates `BailoutToCSRError` and `DynamicServerError`.
- `unstable_rethrow` does NOT match the four uncovered server-only categories — pins the intentional gap.
- `unstable_isUnrecognizedActionError` predicate behavior.
- `navigation.react-server` re-exports `unstable_rethrow` and stubs `unstable_isUnrecognizedActionError`.
- `unstable_catchError` exposes a function; renders children when no error; renders the fallback with `ErrorInfo`; re-throws Next.js router errors from `getDerivedStateFromError`; carries the expected `displayName`.
- `unstable_catchError` accepts `null` / `undefined` / non-Error thrown values (ported from `test/e2e/app-dir/catch-error/throw-null` and `throw-undefined`).
- `unstable_retry` throws "client-only" on the server.
- `unstable_retry` on the client calls `appRouterInstance.refresh()` + resets the boundary state.

`vp test run tests/shims.test.ts tests/error-boundary.test.ts tests/app-router.test.ts tests/app-rsc-errors.test.ts` — 1274/1274 pass.
`vp check` — clean (format + lint + type + knip).

## Follow-ups (intentionally out of scope)

- `isPostpone` / `isDynamicPostpone` / `isHangingPromiseRejectionError` / `isPrerenderInterruptedError` — server-only Next.js internals tied to PPR / prerender machinery vinext doesn't implement. Will need them only if vinext grows PPR.
- Pages Router-specific `unstable_retry` error message (`unstable_retry() can only be used in the App Router. Use reset() in the Pages Router.`) — requires reading `PagesRouterContext` from inside the boundary, which vinext's `unstable_catchError` doesn't currently do.
- Next.js's react-server build of `unstable_catchError` throws when called. We keep a single working implementation across both environments so SSR-only bundles don't break at module load — misuse in a Server Component will fail at render time. Splitting into per-environment shims is tracked separately.
- Bot-user-agent graceful-degradation, `handleHardNavError`, `handleISRError` paths in the catch-error boundary.

## Next.js test fixtures consulted

- [`test/e2e/app-dir/catch-error/`](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/catch-error/) (unstable_catchError fixture + tests, especially `throw-null` / `throw-undefined`)
- [`test/e2e/app-dir/unstable-rethrow/`](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/unstable-rethrow/) (cause, dynamic-error, not-found-page, redirect fixtures)
- [`test/e2e/app-dir/app-static/lib/fetch-retry.js`](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/app-static/lib/fetch-retry.js) (canonical user-facing `unstable_rethrow` use case)

🤖 Generated with [Claude Code](https://claude.com/claude-code) via [opencode](https://opencode.ai)