### PR TITLE
ci(deploy-suite): default to all suites and disable test retries

### DIFF
--- a/.github/workflows/nextjs-deploy-suite.yml
+++ b/.github/workflows/nextjs-deploy-suite.yml
@@ -261,11 +261,20 @@ jobs:
             }
 
             const total = passed.length + failed.length + skipped.length;
+            const passRate = total > 0 ? ((passed.length / total) * 100).toFixed(1) : '0.0';
+            const statsLine = `${passed.length} passed, ${failed.length} failed, ${skipped.length} skipped (${total} total, ${passRate}% pass rate)`;
+
+            // Top-level annotation visible on the workflow run page
+            if (failed.length > 0) {
+              core.warning(`Next.js Deploy Suite: ${statsLine}`, { title: 'Next.js Deploy Suite results' });
+            } else {
+              core.notice(`Next.js Deploy Suite: ${statsLine}`, { title: 'Next.js Deploy Suite results' });
+            }
 
             // Job summary
             core.summary.addHeading('Next.js Deploy Suite', 2);
             core.summary.addRaw(
-              `**${passed.length}** passed, **${failed.length}** failed, **${skipped.length}** skipped (${total} total)\n\n`
+              `**${passed.length}** passed, **${failed.length}** failed, **${skipped.length}** skipped (${total} total, ${passRate}% pass rate)\n\n`
             );
 
             if (failed.length > 0) {

--- a/.github/workflows/nextjs-deploy-suite.yml
+++ b/.github/workflows/nextjs-deploy-suite.yml
@@ -19,7 +19,7 @@ on:
       suite-filter:
         description: Which suites to run (pages, app, or all)
         required: false
-        default: app
+        default: all
         type: choice
         options:
           - app
@@ -35,7 +35,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: nextjs-deploy-suite-${{ inputs.vinext-ref || github.ref }}-${{ inputs.next-ref || 'v16.2.6' }}-${{ inputs.suite-filter || 'app' }}
+  group: nextjs-deploy-suite-${{ inputs.vinext-ref || github.ref }}-${{ inputs.next-ref || 'v16.2.6' }}-${{ inputs.suite-filter || 'all' }}
   cancel-in-progress: false
 
 jobs:
@@ -79,7 +79,7 @@ jobs:
           node scripts/nextjs-deploy-manifest.mjs
           "$GITHUB_WORKSPACE/next.js"
           "$GITHUB_WORKSPACE/nextjs-deploy-manifest.json"
-          --filter ${{ inputs.suite-filter || 'app' }}
+          --filter ${{ inputs.suite-filter || 'all' }}
 
       - name: Save build artifacts
         uses: actions/cache/save@v5
@@ -165,7 +165,7 @@ jobs:
           NEXT_TEST_DEPLOY_SCRIPT_PATH: ${{ github.workspace }}/scripts/e2e-deploy.sh
           NEXT_TEST_DEPLOY_LOGS_SCRIPT_PATH: ${{ github.workspace }}/scripts/e2e-logs.sh
           NEXT_TEST_CLEANUP_SCRIPT_PATH: ${{ github.workspace }}/scripts/e2e-cleanup.sh
-        run: node run-tests.js --timings -g ${{ matrix.group }} -c ${{ inputs.test-concurrency || '2' }} --type e2e
+        run: node run-tests.js --timings --retries 0 -g ${{ matrix.group }} -c ${{ inputs.test-concurrency || '2' }} --type e2e
 
       - name: Upload test results
         if: always()
@@ -301,7 +301,7 @@ jobs:
               timestamp: new Date().toISOString(),
               vinextRef: '${{ inputs.vinext-ref || github.ref }}',
               nextRef: '${{ inputs.next-ref || 'v16.2.6' }}',
-              suiteFilter: '${{ inputs.suite-filter || 'app' }}',
+              suiteFilter: '${{ inputs.suite-filter || 'all' }}',
               summary: { total, passed: passed.length, failed: failed.length, skipped: skipped.length },
               failed: failed.map(f => ({ suite: f.suite, test: f.test })),
               passed: passed.map(p => ({ suite: p.suite, test: p.test })),


### PR DESCRIPTION
## Summary

- Change the Next.js deploy suite default `suite-filter` from `app` to `all` so nightly runs cover both app router and pages router tests.
- Pass `--retries 0` to `node run-tests.js` to disable Next.js's built-in retry behavior. The Next.js test runner defaults to `DEFAULT_NUM_RETRIES = 2` (3 total attempts), which masks real flakes and slows down failing shards.

## Notes

With the filter now defaulting to `all`, per-shard work increases. The matrix is currently 16 shards with a 60-minute job timeout — keep an eye on shard runtimes; if any approach the limit we may want to bump the shard count.