### PR TITLE
fix(deploy-suite): extract CJS->ESM converter to standalone script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,6 @@ jobs:
         run: vp run build
       - run: vp run check
       - run: vp run knip
-      # Catch bash syntax errors in CI-critical shell scripts. The deploy-suite
-      # harness (scripts/e2e-deploy.sh) once shipped with a syntax error that
-      # caused 2480 deploy-suite failures before anyone noticed — see #1189.
       - name: Bash syntax check
         run: |
           for f in scripts/*.sh; do

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,14 @@ jobs:
         run: vp run build
       - run: vp run check
       - run: vp run knip
+      # Catch bash syntax errors in CI-critical shell scripts. The deploy-suite
+      # harness (scripts/e2e-deploy.sh) once shipped with a syntax error that
+      # caused 2480 deploy-suite failures before anyone noticed — see #1189.
+      - name: Bash syntax check
+        run: |
+          for f in scripts/*.sh; do
+            bash -n "$f" || { echo "Syntax error in $f"; exit 1; }
+          done
 
   test-unit:
     name: Vitest (unit)

--- a/scripts/cjs-to-esm-config.mjs
+++ b/scripts/cjs-to-esm-config.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+// Convert a CommonJS Next.js config file (next.config.{js,ts}) to ESM in-place.
+//
+// Used by scripts/e2e-deploy.sh after `vinext init` adds "type": "module" to
+// the test app's package.json — at that point Node treats .js as ESM, but
+// Next.js doesn't accept .cjs for its config file, so we have to rewrite the
+// CJS syntax to ESM equivalents.
+//
+// This was previously inlined into e2e-deploy.sh via `node -e '…'`, but the
+// JS body contained the `'"'"'` quote-escape pattern enough times that
+// rebalancing got broken (one unquoted `(` in a comment was enough to make
+// bash fail to parse the whole script). Extracting to a standalone module
+// removes the quoting hazard entirely — see #1189.
+//
+// The converter handles:
+//   module.exports = X              → export default X
+//   const X = require('mod')        → import X from 'mod'
+//   const X = require('mod')(args)  → import _X from 'mod'; const X = _X(args)
+//   const { a, b } = require('mod') → import { a, b } from 'mod'
+//   require('mod') in expressions   → (await import('mod')).default
+//
+// Limitations: doesn't handle dynamic require with variables, require.resolve,
+// or conditional require. Covers the common next.config.js patterns in the
+// deploy suite.
+
+import fs from "node:fs";
+
+const file = process.argv[2];
+if (!file) {
+  console.error("Usage: cjs-to-esm-config.mjs <file>");
+  process.exit(1);
+}
+
+let code = fs.readFileSync(file, "utf8");
+
+if (!/\bmodule\.exports\b/.test(code) && !/\brequire\s*\(/.test(code)) {
+  // Nothing to convert.
+  process.exit(0);
+}
+
+const imports = [];
+let counter = 0;
+
+// 1. const X = require("mod")(args) → import + const X = _mod(args)
+code = code.replace(
+  /\b(const|let|var)\s+(\w+)\s*=\s*require\s*\(\s*(["'][^"']+["'])\s*\)\s*(\([^)]*\))/g,
+  (_, decl, name, mod, call) => {
+    const alias = `_cjsImport${counter++}`;
+    imports.push(`import ${alias} from ${mod};`);
+    return `${decl} ${name} = ${alias}${call}`;
+  },
+);
+
+// 2. const X = require("mod") → import X from "mod"
+code = code.replace(
+  /\b(const|let|var)\s+(\w+)\s*=\s*require\s*\(\s*(["'][^"']+["'])\s*\)/g,
+  (_, _decl, name, mod) => {
+    imports.push(`import ${name} from ${mod};`);
+    return "";
+  },
+);
+
+// 2b. const { a, b } = require("mod") → import { a, b } from "mod"
+code = code.replace(
+  /\b(const|let|var)\s+(\{[^}]+\})\s*=\s*require\s*\(\s*(["'][^"']+["'])\s*\)/g,
+  (_, _decl, destructured, mod) => {
+    imports.push(`import ${destructured} from ${mod};`);
+    return "";
+  },
+);
+
+// 3. Remaining require("mod") in expressions → (await import("mod")).default
+code = code.replace(
+  /\brequire\s*\(\s*(["'][^"']+["'])\s*\)/g,
+  (_, mod) => `(await import(${mod})).default`,
+);
+
+// 4. module.exports = → export default
+code = code.replace(/\bmodule\.exports\s*=\s*/, "export default ");
+
+// Prepend collected imports
+if (imports.length > 0) {
+  code = imports.join("\n") + "\n" + code;
+}
+
+// Clean up empty lines from removed const declarations
+code = code.replace(/\n{3,}/g, "\n\n");
+
+fs.writeFileSync(file, code);
+console.log(`Converted ${file} from CJS to ESM`);

--- a/scripts/e2e-deploy.sh
+++ b/scripts/e2e-deploy.sh
@@ -442,73 +442,13 @@ run_pnpm exec vinext init --skip-check --force >> "${BUILD_LOG}" 2>&1
 # doesn't support it), so convert CJS syntax to ESM in-place. vinext init
 # handles other config files (postcss, tailwind, etc.) by renaming to .cjs.
 #
-# The converter handles:
-#   module.exports = X              → export default X
-#   const X = require('mod')        → import X from 'mod'
-#   const X = require('mod')(args)  → import _X from 'mod'; const X = _X(args)
-#   require('mod') in expressions   → (await import('mod')).default
+# The converter lives in scripts/cjs-to-esm-config.mjs. It used to be inlined
+# here via `node -e '…'`, but the JS body contained enough `'"'"'`-style
+# quote-escape sequences that a single unquoted `(` in a comment caused bash
+# to fail to parse the whole script.
 for config_file in next.config.js next.config.ts; do
   if [ -f "${config_file}" ]; then
-    node -e '
-      const fs = require("node:fs");
-      const f = process.argv[1];
-      let c = fs.readFileSync(f, "utf8");
-      if (!/\bmodule\.exports\b/.test(c) && !/\brequire\s*\(/.test(c)) process.exit(0);
-
-      const imports = [];
-      let counter = 0;
-
-      // 1. const X = require("mod")(args) → import + const X = _mod(args)
-      c = c.replace(
-        /\b(const|let|var)\s+(\w+)\s*=\s*require\s*\(\s*(["'"'"'][^"'"'"']+["'"'"'])\s*\)\s*(\([^)]*\))/g,
-        (_, decl, name, mod, call) => {
-          const alias = `_cjsImport${counter++}`;
-          imports.push(`import ${alias} from ${mod};`);
-          return `${decl} ${name} = ${alias}${call}`;
-        }
-      );
-
-      // 2. const X = require("mod") → import X from "mod"
-      c = c.replace(
-        /\b(const|let|var)\s+(\w+)\s*=\s*require\s*\(\s*(["'"'"'][^"'"'"']+["'"'"'])\s*\)/g,
-        (_, _decl, name, mod) => {
-          imports.push(`import ${name} from ${mod};`);
-          return "";
-        }
-      );
-
-      // 2b. const { a, b } = require("mod") → import { a, b } from "mod"
-      c = c.replace(
-        /\b(const|let|var)\s+(\{[^}]+\})\s*=\s*require\s*\(\s*(["'"'"'][^"'"'"']+["'"'"'])\s*\)/g,
-        (_, _decl, destructured, mod) => {
-          imports.push(`import ${destructured} from ${mod};`);
-          return "";
-        }
-      );
-
-      // 3. Remaining require("mod") in expressions → (await import("mod")).default
-      // TODO: This doesn't perfectly handle all CJS patterns (e.g. dynamic
-      // require with variables, require.resolve, conditional require). For the
-      // deploy suite this covers the common next.config.js patterns.
-      c = c.replace(
-        /\brequire\s*\(\s*(["'"'"'][^"'"'"']+["'"'"'])\s*\)/g,
-        (_, mod) => `(await import(${mod})).default`
-      );
-
-      // 4. module.exports = → export default
-      c = c.replace(/\bmodule\.exports\s*=\s*/, "export default ");
-
-      // Prepend collected imports
-      if (imports.length > 0) {
-        c = imports.join("\n") + "\n" + c;
-      }
-
-      // Clean up empty lines from removed const declarations
-      c = c.replace(/\n{3,}/g, "\n\n");
-
-      fs.writeFileSync(f, c);
-      console.log("Converted " + f + " from CJS to ESM");
-    ' "${config_file}" >> "${BUILD_LOG}" 2>&1
+    node "${VINEXT_DIR}/scripts/cjs-to-esm-config.mjs" "${config_file}" >> "${BUILD_LOG}" 2>&1
   fi
 done
 


### PR DESCRIPTION
## Summary

- Move the `next.config.{js,ts}` CJS→ESM converter out of an inlined `node -e '…'` blob in `scripts/e2e-deploy.sh` and into a standalone `scripts/cjs-to-esm-config.mjs`. Same regex pipeline, no behavioural change.
- Add a `bash -n scripts/*.sh` gate to the **Check** job so this class of regression can't ship green.

## Why

The deploy-suite run [25869359604](https://github.com/cloudflare/vinext/actions/runs/25869359604) reported `329 passed, 2480 failed, 653 skipped` — a 9.5% pass rate. Investigating, **every single failure** was byte-identical:

```
Error: Custom deploy script failed:  undefined (2)
  at NextDeployInstance.deployUsingCustomScript (next.js/test/lib/next-modes/next-deploy.ts:70:13)
```

…and the runner logs showed the real cause:

```
scripts/e2e-deploy.sh: line 490: syntax error near unexpected token `('
scripts/e2e-deploy.sh: line 490: `      // TODO: This doesn't perfectly handle all CJS patterns (e.g. dynamic'
```

`bash -n scripts/e2e-deploy.sh` reproduces the error locally on `843df83`.

### Root cause

The CJS→ESM converter (added in #1189) was passed to `node -e` as a single-quoted bash argument. The JS body used the `'\"'\"'` quote-escape trick repeatedly inside regex literals. The net effect rebalanced quoting such that some later lines — notably the comment `// TODO: … (e.g. dynamic …` on line 490 — sat **outside** a single-quoted bash region. Bash then saw `(e.g. dynamic …)` as shell syntax and refused to parse the whole script.

The deploy step exited with status 2 before doing any work, so **every deploy-suite test failed at `createNext()` setup** before any vinext code was exercised. The 329 "passes" were almost entirely `should skip next deploy` placeholders, not real assertions — effective real-test pass rate this run was 0%.

### What the fix does

- `scripts/cjs-to-esm-config.mjs`: new standalone Node script with the identical regex pipeline (handles `module.exports = X`, `const X = require('mod')`, `const X = require('mod')(args)`, `const { a, b } = require('mod')`, and bare `require('mod')` in expressions). Lives in a `.mjs` file so its source is never re-parsed by bash.
- `scripts/e2e-deploy.sh`: the old 60-line `node -e '…'` blob is replaced by `node "${VINEXT_DIR}/scripts/cjs-to-esm-config.mjs" "${config_file}"`. Net `-65 / +13` lines in the bash script.
- `.github/workflows/ci.yml`: new step in the **Check** job runs `bash -n` on every `scripts/*.sh`. If anyone reintroduces a syntax error in a deploy-critical shell script, the Check gate fails on the PR.

## Verification

Locally:

```
$ bash -n scripts/e2e-deploy.sh && echo OK
OK
$ for f in scripts/*.sh; do bash -n "$f" || echo FAIL $f; done
(all clean)
```

Smoke-tested the converter against a representative `next.config.js`:

```js
// input
const path = require('path')
const withPWA = require('next-pwa')({ dest: 'public' })
const { withSentryConfig } = require('@sentry/nextjs')

module.exports = withPWA({
  reactStrictMode: true,
  basePath: '/myapp',
})
```

```js
// output (validated with `node --check --input-type=module`)
import _cjsImport0 from 'next-pwa';
import path from 'path';
import { withSentryConfig } from '@sentry/nextjs';

const withPWA = _cjsImport0({ dest: 'public' })

export default withPWA({
  reactStrictMode: true,
  basePath: '/myapp',
})
```

The regex pipeline is byte-for-byte the one that was inlined; only the wrapping changed.

## Follow-up (not in this PR)

The harness reported `undefined` for stderr in every failure (`Custom deploy script failed: undefined (2)`), which made the root cause invisible in the test report — you have to dig into raw runner logs to find the bash syntax error. The `deploy-debug-N` artifacts also only contain `context.txt` and `package.json`, no stdout/stderr capture from the deploy script itself. Worth a separate PR to fix the harness so future failures of this class are visible in the test report.

After this lands, re-run the deploy suite to get the first real parity signal. With the harness fixed, the run will surface actual vinext bugs and parity gaps instead of one repeated harness error.