### PR TITLE
fix(deploy-suite): inject jiti when test app uses TypeScript config files

### DIFF
--- a/scripts/e2e-deploy.sh
+++ b/scripts/e2e-deploy.sh
@@ -442,6 +442,47 @@ function bumpSassDep(name, minSpec) {
 bumpSassDep('sass', '^1.70.0')
 bumpSassDep('sass-embedded', '^1.70.0')
 
+// Detect TypeScript config files. Vite's PostCSS/Tailwind/etc. config loaders
+// require either `jiti` or `tsx` to load `*.config.{ts,mts,cts}` (and dotfile
+// `.postcssrc.ts` variants). Next.js used to auto-install one of these into
+// the test app at build time; once vinext takes over, the test app's
+// package.json no longer lists either, so the build fails with:
+//
+//   'tsx' or 'jiti' is required for the TypeScript configuration files.
+//   Make sure it is installed
+//   Cannot find package 'jiti' imported from .../vite/dist/node/chunks/node.js
+//
+// jiti is the lighter of the two (no native deps) and matches what Vite's
+// internal config loader prefers, so inject jiti when any TS-flavoured config
+// file is present at the test app root.
+const tsConfigFilePatterns = [
+  /^next\.config\.(?:ts|mts|cts)$/,
+  /^postcss\.config\.(?:ts|mts|cts)$/,
+  /^tailwind\.config\.(?:ts|mts|cts)$/,
+  /^vite\.config\.(?:ts|mts|cts)$/,
+  /^\.postcssrc\.(?:ts|mts|cts)$/,
+]
+let hasTsConfig = false
+try {
+  const entries = fs.readdirSync(process.cwd(), { withFileTypes: true })
+  for (const entry of entries) {
+    if (!entry.isFile()) continue
+    if (tsConfigFilePatterns.some((rx) => rx.test(entry.name))) {
+      hasTsConfig = true
+      break
+    }
+  }
+} catch {
+  // ignore — fall back to not injecting jiti
+}
+
+if (hasTsConfig && !pkg.devDependencies.jiti && !pkg.dependencies?.jiti) {
+  // Pin matches the version already resolved transitively in the vinext
+  // workspace (via @tailwindcss/node). postcss-load-config and Vite both
+  // require jiti >=1.21.0; ^2.6.1 satisfies that.
+  pkg.devDependencies.jiti = '^2.6.1'
+}
+
 fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n')
 console.log('Injected vinext harness dependencies into package.json')
 EOF


### PR DESCRIPTION
## Summary

Test apps using `next.config.ts` (or `.mts`/`.cts`), `postcss.config.{ts,mts,cts}`, or `.postcssrc.ts` fail at `vinext build` time with:

```
Failed to load PostCSS config: 'tsx' or 'jiti' is required for the TypeScript
configuration files. Make sure it is installed
Cannot find package 'jiti' imported from .../vite/dist/node/chunks/node.js
```

Next.js auto-installs `jiti`/`tsx` as part of its own build pipeline when it detects a TypeScript config file. Once vinext replaces Next.js as the deploy target, the test app's `package.json` no longer lists either, so Vite's bundled PostCSS / Tailwind / etc. config loaders fail to load `*.config.ts` files.

## Root cause

This is **not** in vinext source — it's a fixture-deps gap in the deploy harness. The PostCSS config loader bundled with Vite (`postcss-load-config`) requires either `jiti` or `tsx` to be installed in the **app's** `node_modules` to load TS config files. Both packages are listed as optional peer dependencies of Vite (see `pnpm-lock.yaml` line 3692: `jiti: '>=1.21.0'`, line 3700: `tsx: ^4.8.1`).

In the Next.js test fixtures, the apps don't list either dependency because Next.js handles the auto-install. Once vinext takes over via `scripts/e2e-deploy.sh`, neither is in the resolved tree, and PostCSS config loading throws.

## Fix

Extend the harness-deps injector in `scripts/e2e-deploy.sh` (the embedded Node block, lines ~277-409) to:

1. Scan the test app root for `*.config.{ts,mts,cts}` files (and the dotfile `.postcssrc.ts` variants)
2. Inject `jiti` into `devDependencies` when present

Pinned to `^2.6.1` to match the version already resolved transitively in this workspace via `@tailwindcss/node` (`pnpm-lock.yaml` line 7535). Both `postcss-load-config` and Vite require `jiti >=1.21.0`; `^2.6.1` satisfies that. `jiti` is the lighter of the two options (no native deps) and matches what Vite's internal loader prefers.

## Affected suites (~20 build-time failures in run 25870737355)

- `test/e2e/app-dir/next-config-ts/*` — 13 fixture variants
- `test/e2e/app-dir/next-config-ts-native-mts/*` — 13 fixture variants
- `test/e2e/app-dir/next-config-ts-native-ts/*` — 13 fixture variants
- `test/e2e/postcss-config-ts/` — 4 fixture variants (postcss-config, postcss-config-cts, postcss-config-mts, postcssrc)

## How I verified locally

- `bash -n scripts/*.sh` passes
- Manually exercised the embedded Node block against synthetic test apps with:
  - `next.config.ts` (positive) → `jiti: ^2.6.1` injected
  - `postcss.config.mts` (positive) → injected
  - `.postcssrc.ts` (positive) → injected
  - `next.config.js` only (negative) → not injected
- Confirmed `jiti@2.6.1` already resolves in the workspace tree (via `@tailwindcss/node`), so no new transitive dep is added at the vinext side.

## Out of scope

- Real-test assertions for the affected suites (they were all blocked by the build-time failure, so the actual test pass/fail status is unknown until this lands and CI re-runs them).
- The `tsx` alternative — `jiti` covers every fixture in the cluster, and tooling prefers it.

Refs: https://github.com/cloudflare/vinext/actions/runs/25870737355