### PR TITLE
docs(vinext): clarify middleware.ts deprecation warning is non-fatal

### DIFF
--- a/packages/vinext/src/server/middleware.ts
+++ b/packages/vinext/src/server/middleware.ts
@@ -70,6 +70,18 @@ const MIDDLEWARE_LOCATIONS = ["", "src/"];
  * Find the proxy or middleware file in the project root.
  * Checks for proxy.ts (Next.js 16) first, then falls back to middleware.ts.
  * If middleware.ts is found, logs a deprecation warning.
+ *
+ * Note on log noise: this function is called from Vite's `config` hook, which
+ * fires once per build environment (RSC, SSR, client, …). That means a project
+ * still using `middleware.ts` will see this warning emitted 2–3 times per
+ * build. The warning is benign — it does not abort the build. Next.js itself
+ * emits the same message via `Log.warnOnce`; matching that parity would
+ * require either a per-root deduplication map or hoisting the warning out of
+ * this function (e.g. into the plugin's `configResolved` hook). Tracked as a
+ * follow-up; see the deploy-suite investigation in run 25870737355.
+ *
+ * @see https://github.com/vercel/next.js/blob/canary/packages/next/src/build/index.ts
+ *   (search for "MIDDLEWARE_FILENAME" + "file convention is deprecated")
  */
 export function findMiddlewareFile(root: string, fileMatcher: ValidFileMatcher): string | null {
   // Check proxy.ts first (Next.js 16 replacement for middleware.ts)
@@ -82,7 +94,9 @@ export function findMiddlewareFile(root: string, fileMatcher: ValidFileMatcher):
     }
   }
 
-  // Fall back to middleware.ts (deprecated in Next.js 16)
+  // Fall back to middleware.ts (deprecated in Next.js 16).
+  // This is a warning, not an error: middleware.ts is still fully supported
+  // by both Next.js 16 and vinext. Do not change to `throw` or `process.exit`.
   for (const dir of MIDDLEWARE_LOCATIONS) {
     for (const ext of fileMatcher.dottedExtensions) {
       const fullPath = path.join(root, dir, `middleware${ext}`);


### PR DESCRIPTION
## Status

**Documentation-only / investigation finding. No behaviour change.**

This PR responds to the `middleware-deprecation` deploy-suite failure cluster from run [25870737355](https://github.com/cloudflare/vinext/actions/runs/25870737355). After investigation, the cluster's premise is incorrect: the `[vinext] middleware.ts is deprecated…` message is **not** what's causing any of the 26 build failures it appears in. It is a `console.warn` (not a `throw` / `process.exit`), and `middleware.ts` is still fully supported by both Next.js 16 and vinext.

The actual root causes of the failing builds in this cluster belong to other deploy-suite clusters and will be addressed there. This PR only updates the JSDoc in `findMiddlewareFile` so the next person investigating doesn't waste time chasing this red herring.

## What the evidence actually shows

`/tmp/opencode/deploy-fix-shared/by-cluster/middleware-deprecation.json` has 10 build-log excerpts. Every single one shows the deprecation warning printed 1–3 times, followed by a build that fails for an entirely different reason:

| Shard | Real failure (after the deprecation warning) |
|---|---|
| 0 (×2) | `[UNLOADABLE_DEPENDENCY] Could not load src/add.wasm?module` — WASM imports unsupported. Belongs to a `wasm-import` cluster. |
| 2 | `ERR_MODULE_NOT_FOUND: Cannot find module .../dist/server/ssr/style.css` — CSS asset resolution. |
| 4 | `'server-only' cannot be imported in client build ('ssr' environment)` — RSC plugin import validation when middleware imports `server-only`. |
| 6 | Build appears to complete; failure is elsewhere in the suite (not visible in tail-80). |
| 7, 9 (×2) | `TypeError: URLPattern is not a constructor` — Node `URLPattern` not available. |
| 8 (×2) | `TypeError: Cannot read properties of undefined (reading 'slug')` at `buildUrlFromParams` in prerender.js. |

In other words: the deprecation warning is benign log noise that happens to show up in a lot of build logs (because many Next.js fixtures still use `middleware.ts`), and a regex that matched on it accidentally grouped a bunch of unrelated failures under one cluster.

## What the vinext source actually does

`packages/vinext/src/server/middleware.ts:74-99` (`findMiddlewareFile`):

```ts
// Fall back to middleware.ts (deprecated in Next.js 16)
for (const dir of MIDDLEWARE_LOCATIONS) {
  for (const ext of fileMatcher.dottedExtensions) {
    const fullPath = path.join(root, dir, `middleware${ext}`);
    if (fs.existsSync(fullPath)) {
      console.warn(
        "[vinext] middleware.ts is deprecated in Next.js 16. " +
          "Rename to proxy.ts and export a default or named proxy function.",
      );
      return fullPath;
    }
  }
}
```

This is already a `console.warn`. The deprecation warning does **not** throw, does **not** `process.exit`, and does **not** prevent the file from being loaded — the function returns the resolved `middleware.ts` path and the build continues normally. There is no other handling of the deprecation in `scripts/` or elsewhere in the vinext source.

`rg "is deprecated|throw.*middleware|process\.exit" packages/vinext/src/` confirms this: the only occurrence of the string is on line 91 of `middleware.ts`, inside a `console.warn(...)`.

## Why the warning appears 2–3× per build

`findMiddlewareFile` is called from the Vite `config` hook (`packages/vinext/src/index.ts:931`), which fires **once per build environment** (RSC, SSR, client, …). Each invocation re-scans for `middleware.ts` and re-emits the warning. Next.js itself emits the same string but via `Log.warnOnce`, so it only appears once per build:

- `.nextjs-ref/packages/next/src/build/index.ts:1284`:
  ```ts
  Log.warnOnce(
    `The "${MIDDLEWARE_FILENAME}" file convention is deprecated. Please use "${PROXY_FILENAME}" instead.\n\n` + …
  )
  ```

Matching that parity in vinext would require either a per-root deduplication map or hoisting the warning out of `findMiddlewareFile` into `configResolved` (which fires once). I considered making that change in this PR but decided against it because:

1. It's not what the cluster's failures need fixed.
2. It would require updating `tests/shims.test.ts` (the existing test calls `findMiddlewareFile` against the same fixture in two places; a per-root dedup map would suppress the warning on the second call and break the `toHaveBeenCalledOnce` assertion).
3. Per the agent brief: \"If the fix is bigger, STOP. Open a draft PR that documents the finding.\"

I'm filing the warn-once parity tweak as a separate follow-up.

## Affected suites

The 26 build failures in this cluster span at least these test fixtures (sampled from log excerpts and the underlying `last 80 lines of .vinext-deploy-build.log` blocks):

- `test/e2e/middleware-*` (multiple — they ship `middleware.ts` so they hit the warning, but their failures are URLPattern / prerender bugs)
- `test/e2e/proxy-*` (some use `middleware.ts` as a baseline)
- `test/e2e/app-dir/*` (apps that include a `middleware.ts` and trip on RSC `server-only` validation, e.g. shard 4)
- `test/e2e/wasm` (shard 0 — the warning is incidental; the real failure is the `.wasm` import)
- `test/e2e/edge-runtime-*` (shards 7, 9 — failures are `URLPattern is not a constructor`)

**None of these are fixed by changing the deprecation warning, and none of them require it to change.** They will be addressed by the relevant clusters (`wasm-import`, `urlpattern-not-a-constructor`, `server-only-in-ssr`, `prerender-undefined-slug`, …).

## What this PR changes

`packages/vinext/src/server/middleware.ts`: extends the `findMiddlewareFile` JSDoc to:

- Explain why the warning may appear 2–3× per build (Vite calls the plugin config hook once per environment).
- Note that Next.js itself emits the same message via `Log.warnOnce`, with a code reference.
- Add an inline comment warning future readers not to change the `console.warn` to a `throw` / `process.exit`.

That is the entire diff. Behaviour is unchanged.

## Verification

- `bash -n scripts/*.sh` — clean (no script changes).
- `vp run fmt:check` — passes.
- `vp check packages/vinext/src/server/middleware.ts` — passes.
- `vp test run tests/shims.test.ts -t \"findMiddlewareFile\"` — 6 passed (all middleware-runner tests, including the existing warning-emission assertion).

## Recommendation

- **Merge this docs-only PR** so future investigators don't get sent down this dead end again.
- **Open a separate small PR** to make the deprecation warn-once (per-root dedup or hoist to `configResolved`), to match Next.js's `Log.warnOnce`. That will reduce log noise in CI without changing behaviour.
- **Pursue the real cluster causes** under their actual root-cause clusters (wasm imports, URLPattern, server-only in SSR, prerender slug bug, etc.).

Refs: run [25870737355](https://github.com/cloudflare/vinext/actions/runs/25870737355).