### PR TITLE
fix(deploy-suite): handle missing optional deps in test fixture configs

### DIFF
--- a/scripts/cjs-to-esm-config.mjs
+++ b/scripts/cjs-to-esm-config.mjs
@@ -15,13 +15,20 @@
 // The converter handles:
 //   module.exports = X              → export default X
 //   const X = require('mod')        → import X from 'mod'
-//   const X = require('mod')(args)  → import _X from 'mod'; const X = _X(args)
+//   const X = require('mod')(args)  → const X = (await import('mod')).default(args)
 //   const { a, b } = require('mod') → import { a, b } from 'mod'
 //   require('mod') in expressions   → (await import('mod')).default
 //
+// `require('mod')(args)` is rewritten to an *inline* dynamic import (rather
+// than a hoisted static import) so that conditionally-gated requires keep
+// their CJS lazy semantics. Several Next.js deploy fixtures wrap optional
+// plugins in `if (process.env.ANALYZE) { const x = require('@next/bundle-analyzer')({...}) }`
+// — hoisting the import to the top of the module would unconditionally try
+// to resolve the package and fail the build, even when ANALYZE is unset.
+//
 // Limitations: doesn't handle dynamic require with variables, require.resolve,
-// or conditional require. Covers the common next.config.js patterns in the
-// deploy suite.
+// or `require('mod').foo()`-style member access. Covers the common
+// next.config.js patterns in the deploy suite.
 
 import fs from "node:fs";
 
@@ -39,16 +46,17 @@ if (!/\bmodule\.exports\b/.test(code) && !/\brequire\s*\(/.test(code)) {
 }
 
 const imports = [];
-let counter = 0;
 
-// 1. const X = require("mod")(args) → import + const X = _mod(args)
+// 1. const X = require("mod")(args) → const X = (await import("mod")).default(args)
+//
+// Inline dynamic import preserves CJS lazy semantics. The previous static-
+// import variant unconditionally resolved the module at the top of
+// next.config.js, which broke fixtures like
+// test/e2e/app-dir/metadata-font/next.config.js (gates @next/bundle-analyzer
+// on `if (process.env.ANALYZE)`).
 code = code.replace(
   /\b(const|let|var)\s+(\w+)\s*=\s*require\s*\(\s*(["'][^"']+["'])\s*\)\s*(\([^)]*\))/g,
-  (_, decl, name, mod, call) => {
-    const alias = `_cjsImport${counter++}`;
-    imports.push(`import ${alias} from ${mod};`);
-    return `${decl} ${name} = ${alias}${call}`;
-  },
+  (_, decl, name, mod, call) => `${decl} ${name} = (await import(${mod})).default${call}`,
 );
 
 // 2. const X = require("mod") → import X from "mod"

--- a/scripts/e2e-deploy.sh
+++ b/scripts/e2e-deploy.sh
@@ -391,6 +391,12 @@ fs.writeFileSync(
 pkg.devDependencies = pkg.devDependencies || {}
 pkg.devDependencies.vinext = 'file:.vinext-local-package'
 
+// Catalog-tracked deps: spec sourced from vinext or workspace root package.json.
+// Includes the Vite/RSC peers that vinext consumers must install, plus runtime
+// deps of vinext that pnpm doesn't hoist into the test app's top-level
+// node_modules (vinext is installed via a `file:` symlink, so its transitive
+// deps live under `.vinext-local-package/node_modules`, which Node's ESM
+// resolver can't see from `<test-app>/dist/...`).
 for (const dep of [
   'vite',
   '@vitejs/plugin-react',
@@ -398,6 +404,7 @@ for (const dep of [
   'react-server-dom-webpack',
   '@mdx-js/rollup',
   '@mdx-js/react',
+  'ipaddr.js',
 ]) {
   if (!pkg.devDependencies[dep] && !pkg.dependencies?.[dep]) {
     pkg.devDependencies[dep] = dependencySpecFor(dep)
@@ -441,6 +448,21 @@ function bumpSassDep(name, minSpec) {
 
 bumpSassDep('sass', '^1.70.0')
 bumpSassDep('sass-embedded', '^1.70.0')
+
+// Pinned harness-only deps that aren't tracked by the vinext workspace but
+// are referenced by Next.js test fixtures. `webpack` is imported at module
+// scope by test/e2e/app-dir/next-config/next.config.js (top-level
+// `require('webpack').sources.RawSource`) — Next.js's own test harness gets
+// it transitively via `next`, but the test fixture's package.json doesn't
+// declare it, so vinext's build fails to resolve it after the CJS→ESM rewrite.
+for (const [dep, spec] of [
+  ['webpack', '^5.99.0'],
+]) {
+  if (!pkg.devDependencies[dep] && !pkg.dependencies?.[dep]) {
+    pkg.devDependencies[dep] = spec
+  }
+}
+
 
 fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n')
 console.log('Injected vinext harness dependencies into package.json')


### PR DESCRIPTION
## Summary

Fixes the `missing-deps` cluster of deploy-suite build failures (5 build-log excerpts in cluster evidence, ~5 affected suites). Three distinct missing-dep failure modes addressed:

### 1. `@next/bundle-analyzer` (3 suites)

Affected: `test/e2e/app-dir/metadata-font`, `metadata-edge`, `metadata-dynamic-routes`

These fixtures wrap the require in `if (process.env.ANALYZE) { ... }`, but `scripts/cjs-to-esm-config.mjs` was rewriting `const X = require('mod')(args)` to a hoisted static `import`, which Vite then tried to resolve unconditionally at module load and failed the build (ANALYZE is never set in our test environment).

**Fix:** rewrite the pattern to an inline `(await import('mod')).default(args)` instead of hoisting. Top-level `await` is valid in ESM (Next.js config is loaded as a module), and inlining preserves CJS lazy semantics — the import only runs when the surrounding code does.

### 2. `webpack` (1 suite)

Affected: `test/e2e/app-dir/next-config`

The fixture has a top-level `console.log(require('webpack').sources.RawSource)`. Next.js's monorepo has webpack at the workspace root, so the fixture inherits it transitively, but as an isolated test app it doesn't declare webpack in its own package.json.

**Fix:** inject `webpack@^5.99.0` into the harness-deps block in `scripts/e2e-deploy.sh`.

### 3. `ipaddr.js` (1+ suite)

Affected: `test/e2e/type-module-interop`, `test/e2e/app-dir/app-middleware` (prerender)

vinext's `packages/vinext/src/shims/image-config.ts` imports `ipaddr.js`, which is declared in vinext's `dependencies`. But vinext is installed into the test app via `file:.vinext-local-package`, so pnpm puts its transitive deps under `.vinext-local-package/node_modules`. When Node's ESM resolver tries to resolve `ipaddr.js` from `<test-app>/dist/server/...` it can't see them. (`type-module-interop` hits this because it patches `"type": "module"` into its own package.json; `app-middleware` hits it during prerender on the image chunk.)

**Fix:** inject `ipaddr.js` into the harness-deps list. Spec is sourced from the vinext workspace catalog via the existing `dependencySpecFor` helper.

## Affected suites

- `test/e2e/app-dir/metadata-font/metadata-font.test.ts`
- `test/e2e/app-dir/metadata-edge/index.test.ts`
- `test/e2e/app-dir/metadata-dynamic-routes/index.test.ts`
- `test/e2e/app-dir/next-config/index.test.ts`
- `test/e2e/type-module-interop/index.test.ts`
- `test/e2e/app-dir/app-middleware/app-middleware.test.ts` (prerender stage)

## Verification

- `bash -n scripts/*.sh` ✓
- `node --check scripts/cjs-to-esm-config.mjs` ✓
- Round-tripped each of the affected fixture `next.config.js` files through the patched converter (from a local `.nextjs-ref` clone). Output is syntactically valid in all cases.
- Loaded the converted `metadata-font/next.config.js` without `ANALYZE` set → resolves to `{}` (matching original CJS behavior).
- Loaded the same file with `ANALYZE=1` → fails with `ERR_MODULE_NOT_FOUND: Cannot find package '@next/bundle-analyzer'` (also matching original CJS behavior).

Refs: workflow run 25870737355