### PR TITLE
fix(deploy-suite): bump pinned sass below ^1.70.0 for Vite 8

### DIFF
--- a/scripts/e2e-deploy.sh
+++ b/scripts/e2e-deploy.sh
@@ -404,6 +404,44 @@ for (const dep of [
   }
 }
 
+// Some Next.js scss test fixtures pin sass to an old version (e.g. 1.54.0)
+// that predates `sass.initAsyncCompiler`. Vite 8's built-in vite:css preprocessor
+// calls that API and declares `sass@^1.70.0` / `sass-embedded@^1.70.0` as peers.
+// If the test app pins a sass/sass-embedded version below the Vite 8 peer range,
+// bump it so the SCSS preprocessor can initialise. This is the minimum bump that
+// keeps the test app's intent (use sass) while making Vite happy. Without it,
+// every test/e2e/app-dir/scss/* and test/e2e/app-dir/scss-modules/* suite fails
+// at build time with: TypeError: [sass] sass.initAsyncCompiler is not a function.
+//
+// Parses the leading `major.minor` out of pinned specs like "1.54.0", "^1.70.0",
+// "~1.75.0", ">=1.70.0". Falls through (no rewrite) for git/file/workspace/tag
+// specs, which never come from the Next.js test fixtures we're patching here.
+function parseMajorMinor(spec) {
+  const match = /^[\^~>=<\s]*(\d+)\.(\d+)/.exec(spec)
+  if (!match) return null
+  return { major: Number(match[1]), minor: Number(match[2]) }
+}
+
+function bumpSassDep(name, minSpec) {
+  for (const bucket of ['dependencies', 'devDependencies', 'peerDependencies']) {
+    const deps = pkg[bucket]
+    if (!deps || !deps[name]) continue
+    const current = deps[name]
+    const version = parseMajorMinor(current)
+    if (!version) continue
+    if (version.major > 1 || (version.major === 1 && version.minor >= 70)) {
+      continue
+    }
+    deps[name] = minSpec
+    console.log(
+      `Bumped ${bucket}.${name} from ${current} to ${minSpec} for Vite 8 compatibility`,
+    )
+  }
+}
+
+bumpSassDep('sass', '^1.70.0')
+bumpSassDep('sass-embedded', '^1.70.0')
+
 fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n')
 console.log('Injected vinext harness dependencies into package.json')
 EOF


### PR DESCRIPTION
## Summary

Next.js's `test/e2e/app-dir/scss/*` fixtures pin `sass: '1.54.0'` via
`createNextDescribe`'s `dependencies` option. Vite 8's built-in
`vite:css` preprocessor calls `sass.initAsyncCompiler()`, an API added
in dart-sass 1.70.0 (Feb 2024). When the deploy harness installs the
test app, that old pin wins over Vite 8's optional `sass@^1.70.0` peer
range, and every SCSS test suite fails at build time with:

```
TypeError: [sass] sass.initAsyncCompiler is not a function
```

This cluster accounted for ~31 deploy-script failures in [run
25870737355](https://github.com/cloudflare/vinext/actions/runs/25870737355).

## Root cause

- Vite 8 (`packages/vite/package.json`): `peerDependencies.sass = "^1.70.0"`, `peerDependencies["sass-embedded"] = "^1.70.0"` (optional).
- Vite 8 SSR build (`vite/dist/node/chunks/node.js`): `compilerPromise ??= sass.initAsyncCompiler()`.
- Next.js fixtures, e.g. `.nextjs-ref/test/e2e/app-dir/scss/multi-page/multi-page.test.ts`:
  ```ts
  nextTestSetup({ dependencies: { sass: '1.54.0' }, ... })
  ```
- pnpm resolves the fixture's exact pin (`1.54.0`) and ignores the peer warning, so Vite picks up a sass that has no `initAsyncCompiler`.

## Fix

In the deploy harness's existing dependency-injection step (the Node
heredoc in `scripts/e2e-deploy.sh` that rewrites the test app's
`package.json`), after Vite + RSC plugins are added, scan
`dependencies` / `devDependencies` / `peerDependencies` for `sass` or
`sass-embedded`. If the spec's leading `major.minor` is below `1.70`,
rewrite it to `^1.70.0`. Non-version specs (`workspace:`, `file:`,
`git+`, tag specs) are left untouched. No-op when sass isn't a
dependency.

This keeps the test app's intent (use the sass preprocessor) while
making the resolved version compatible with Vite 8.

## Affected suites (top 10 of 25)

From `by-cluster/sass.json` + `shard-logs/*.log`:

1. `test/e2e/app-dir/scss/3rd-party-module/3rd-party-module.test.ts`
2. `test/e2e/app-dir/scss/basic-module/basic-module.test.ts`
3. `test/e2e/app-dir/scss/basic-module-include-paths/basic-module-include-paths.test.ts`
4. `test/e2e/app-dir/scss/basic-module-prepend-data/basic-module-prepend-data.test.ts`
5. `test/e2e/app-dir/scss/catch-all-module/catch-all-module.test.ts`
6. `test/e2e/app-dir/scss/composes-basic/composes-basic.test.ts`
7. `test/e2e/app-dir/scss/composes-external/composes-external.test.ts`
8. `test/e2e/app-dir/scss/data-url/data-url.test.ts`
9. `test/e2e/app-dir/scss/dev-module/dev-module.test.ts`
10. `test/e2e/app-dir/scss/multi-page/multi-page.test.ts`

(Plus `dynamic-route-module`, `external-url`, `loader-order`, `multi-global`,
`multi-global-reversed`, `nested-global`, `nm-module`, `nm-module-nested`,
`npm-import`, `npm-import-nested`, `npm-import-tilde`, `single-global-src`,
`url-global`, `url-global-partial`, `with-styled-jsx`.)

## Verification

- `bash -n scripts/*.sh` passes.
- Unit-checked the `major.minor` parser against 13 spec strings (semver,
  caret/tilde, range operators, workspace/file/git/tag specs) — all
  expected.
- Reproduced locally against the `multi-page` scss fixture:
  - Before: `node_modules/.pnpm/vite@8.0.12_..._sass@1.54.0_...` →
    `TypeError: [sass] sass.initAsyncCompiler is not a function`.
  - After (with this patch): `node_modules/.pnpm/vite@8.0.12_..._sass@1.99.0_...`,
    build advances past the SCSS preprocessor. (Separate JSX-in-Pages-Router
    error then trips it; that's a different cluster, tracked separately.)

Reference: <https://github.com/cloudflare/vinext/actions/runs/25870737355>.