### PR TITLE
fix(deploy-suite): apply tsconfig compilerOptions.paths when loading next.config.ts

### DIFF
--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -12,6 +12,7 @@ import { randomUUID } from "node:crypto";
 import { PHASE_DEVELOPMENT_SERVER } from "vinext/shims/constants";
 import { normalizePageExtensions } from "../routing/file-matcher.js";
 import { isExternalUrl } from "./config-matchers.js";
+import { loadTsconfigPathAliasesForRoot } from "./tsconfig-paths.js";
 
 /**
  * Parse a body size limit value (string or number) into bytes.
@@ -413,6 +414,13 @@ export async function loadNextConfig(
 
   const filename = path.basename(configPath);
 
+  // Mirror Next.js: read `compilerOptions.paths` from the project's
+  // tsconfig.json so aliased imports inside next.config.ts (e.g.
+  // `import { foo } from '@/foo'`) resolve at config-load time. Next.js
+  // passes these to SWC; we pass them to Vite's resolver as `resolve.alias`.
+  // See packages/next/src/build/next-config-ts/transpile-config.ts.
+  const tsconfigAliases = loadTsconfigPathAliasesForRoot(root);
+
   try {
     // Load config via Vite's module runner (TS + extensionless import support)
     const { runnerImport } = await import("vite");
@@ -420,6 +428,9 @@ export async function loadNextConfig(
       root,
       logLevel: "error",
       clearScreen: false,
+      resolve: {
+        alias: tsconfigAliases,
+      },
     });
     return await unwrapConfig(mod, phase);
   } catch (e) {

--- a/packages/vinext/src/config/tsconfig-paths.ts
+++ b/packages/vinext/src/config/tsconfig-paths.ts
@@ -1,0 +1,154 @@
+/**
+ * tsconfig.json `compilerOptions.paths` loader.
+ *
+ * Used to make tsconfig path aliases (e.g. `@/foo` mapping to `./src/foo`)
+ * available when vinext loads `next.config.ts` through Vite's `runnerImport`.
+ *
+ * Next.js's own `next.config.ts` loader (packages/next/src/build/next-config-ts/
+ * transpile-config.ts) reads `compilerOptions.paths` from the project's
+ * `tsconfig.json` and passes them to SWC so that imports like
+ * `import { foo } from '@/foo'` resolve at config load time. We do the same
+ * here, but as Vite `resolve.alias` entries.
+ *
+ * The implementation is intentionally minimal:
+ *   - Static JSON-style parse of tsconfig.json (handles trailing commas /
+ *     comments via the shared `parseStaticObjectLiteral` helper)
+ *   - `extends` is followed up to a small recursion depth, with cycle
+ *     detection — matches the subset Next.js supports
+ *   - Only the common `"@/*": ["./src/*"]` / `"@/*": ["src/*"]` pattern is
+ *     supported; non-wildcard paths and exact aliases also work
+ *   - Returned alias values are always absolute paths so they work with
+ *     `runnerImport`'s inline environment (which has its own root).
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { createRequire } from "node:module";
+import { parseStaticObjectLiteral } from "../plugins/fonts.js";
+
+const TSCONFIG_FILES = ["tsconfig.json", "jsconfig.json"];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function resolveTsconfigPathCandidate(candidate: string): string | null {
+  const candidates = candidate.endsWith(".json")
+    ? [candidate]
+    : [candidate, `${candidate}.json`, path.join(candidate, "tsconfig.json")];
+
+  for (const item of candidates) {
+    if (fs.existsSync(item) && fs.statSync(item).isFile()) {
+      return item;
+    }
+  }
+
+  return null;
+}
+
+function resolveTsconfigExtends(configPath: string, specifier: string): string | null {
+  const fromDir = path.dirname(configPath);
+  if (specifier.startsWith(".") || specifier.startsWith("/") || specifier.startsWith("\\")) {
+    return resolveTsconfigPathCandidate(path.resolve(fromDir, specifier));
+  }
+
+  const requireFromConfig = createRequire(configPath);
+  const candidates = [specifier, `${specifier}.json`, path.join(specifier, "tsconfig.json")];
+
+  for (const item of candidates) {
+    try {
+      return requireFromConfig.resolve(item);
+    } catch {}
+  }
+
+  return null;
+}
+
+function materializeAliases(
+  pathsConfig: Record<string, unknown>,
+  baseUrl: string,
+): Record<string, string> {
+  const aliases: Record<string, string> = {};
+
+  for (const [find, rawTargets] of Object.entries(pathsConfig)) {
+    const target = Array.isArray(rawTargets)
+      ? rawTargets.find((value): value is string => typeof value === "string")
+      : typeof rawTargets === "string"
+        ? rawTargets
+        : null;
+    if (!target) continue;
+
+    if (find.includes("*") || target.includes("*")) {
+      // Only support trailing wildcard (the common `"@/*": ["./src/*"]` form).
+      if (!find.endsWith("/*") || !target.endsWith("/*")) continue;
+      if (find.indexOf("*") !== find.length - 1 || target.indexOf("*") !== target.length - 1) {
+        continue;
+      }
+
+      const aliasKey = find.slice(0, -2);
+      const targetDir = target.slice(0, -2);
+      if (!aliasKey || !targetDir) continue;
+
+      aliases[aliasKey] = path.resolve(baseUrl, targetDir);
+      continue;
+    }
+
+    aliases[find] = path.resolve(baseUrl, target);
+  }
+
+  return aliases;
+}
+
+function loadAliasesFromTsconfigFile(
+  configPath: string,
+  seen: Set<string>,
+): Record<string, string> {
+  if (seen.has(configPath)) return {};
+  seen.add(configPath);
+
+  let parsed: Record<string, unknown> | null = null;
+  try {
+    parsed = parseStaticObjectLiteral(fs.readFileSync(configPath, "utf-8"));
+  } catch {
+    return {};
+  }
+  if (!parsed) return {};
+
+  let aliases: Record<string, string> = {};
+  if (typeof parsed.extends === "string") {
+    const extendedPath = resolveTsconfigExtends(configPath, parsed.extends);
+    if (extendedPath) {
+      aliases = loadAliasesFromTsconfigFile(extendedPath, seen);
+    }
+  }
+
+  const compilerOptions = isRecord(parsed.compilerOptions) ? parsed.compilerOptions : null;
+  const pathsConfig =
+    compilerOptions && isRecord(compilerOptions.paths) ? compilerOptions.paths : null;
+  if (!pathsConfig) return aliases;
+
+  const baseUrl =
+    compilerOptions && typeof compilerOptions.baseUrl === "string" ? compilerOptions.baseUrl : ".";
+  const resolvedBaseUrl = path.resolve(path.dirname(configPath), baseUrl);
+
+  return {
+    ...aliases,
+    ...materializeAliases(pathsConfig, resolvedBaseUrl),
+  };
+}
+
+/**
+ * Read the project's tsconfig.json (or jsconfig.json) and return its
+ * `compilerOptions.paths` as absolute-path Vite `resolve.alias` entries.
+ *
+ * Returns an empty object if no config is found or no paths are configured.
+ * Errors during parsing are swallowed — this is a best-effort helper that
+ * must not break config loading.
+ */
+export function loadTsconfigPathAliasesForRoot(projectRoot: string): Record<string, string> {
+  for (const name of TSCONFIG_FILES) {
+    const candidate = path.join(projectRoot, name);
+    if (!fs.existsSync(candidate)) continue;
+    return loadAliasesFromTsconfigFile(candidate, new Set());
+  }
+  return {};
+}

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -87,6 +87,114 @@ describe("loadNextConfig phase argument", () => {
   });
 });
 
+describe("loadNextConfig with tsconfig path aliases", () => {
+  // Ported from Next.js: test/e2e/app-dir/next-config-ts/import-alias-paths-only/
+  //   https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/next-config-ts/import-alias-paths-only/
+  // and import-alias-paths-with-baseurl/.
+  // Next.js's transpile-config.ts reads compilerOptions.paths from tsconfig.json
+  // and passes them to SWC so that next.config.ts can import via tsconfig
+  // aliases. vinext mirrors this by passing tsconfig paths to Vite as
+  // resolve.alias when calling runnerImport.
+
+  let tmpDir: string;
+
+  afterEach(() => {
+    if (tmpDir) {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("resolves '@/*' imports in next.config.ts from tsconfig paths (no baseUrl)", async () => {
+    tmpDir = makeTempDir();
+
+    fs.mkdirSync(path.join(tmpDir, "src"), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, "src", "foo.ts"), `export const foo = "foo";\n`);
+    fs.writeFileSync(
+      path.join(tmpDir, "tsconfig.json"),
+      JSON.stringify({
+        compilerOptions: {
+          paths: {
+            "@/*": ["./src/*"],
+          },
+        },
+      }),
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "next.config.ts"),
+      `import { foo } from "@/foo";\nexport default { env: { FOO: foo } };\n`,
+    );
+
+    const config = await loadNextConfig(tmpDir);
+    expect(config?.env?.FOO).toBe("foo");
+  });
+
+  it("resolves '@/*' imports when baseUrl is set", async () => {
+    tmpDir = makeTempDir();
+
+    fs.mkdirSync(path.join(tmpDir, "src"), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, "src", "bar.ts"), `export const bar = "bar";\n`);
+    fs.writeFileSync(
+      path.join(tmpDir, "tsconfig.json"),
+      JSON.stringify({
+        compilerOptions: {
+          baseUrl: ".",
+          paths: {
+            "@/*": ["src/*"],
+          },
+        },
+      }),
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "next.config.ts"),
+      `import { bar } from "@/bar";\nexport default { env: { BAR: bar } };\n`,
+    );
+
+    const config = await loadNextConfig(tmpDir);
+    expect(config?.env?.BAR).toBe("bar");
+  });
+
+  it("follows tsconfig 'extends' when resolving paths", async () => {
+    tmpDir = makeTempDir();
+
+    fs.mkdirSync(path.join(tmpDir, "src"), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, "src", "baz.ts"), `export const baz = "baz";\n`);
+    fs.writeFileSync(
+      path.join(tmpDir, "tsconfig.base.json"),
+      JSON.stringify({
+        compilerOptions: {
+          paths: {
+            "@/*": ["./src/*"],
+          },
+        },
+      }),
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "tsconfig.json"),
+      JSON.stringify({
+        extends: "./tsconfig.base.json",
+      }),
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "next.config.ts"),
+      `import { baz } from "@/baz";\nexport default { env: { BAZ: baz } };\n`,
+    );
+
+    const config = await loadNextConfig(tmpDir);
+    expect(config?.env?.BAZ).toBe("baz");
+  });
+
+  it("loads config without tsconfig.json (no aliases needed)", async () => {
+    tmpDir = makeTempDir();
+    fs.writeFileSync(
+      path.join(tmpDir, "next.config.ts"),
+      `export default { env: { PLAIN: "yes" } };\n`,
+    );
+
+    const config = await loadNextConfig(tmpDir);
+    expect(config?.env?.PLAIN).toBe("yes");
+  });
+});
+
 describe("resolveNextConfig alias extraction", () => {
   let tmpDir: string;
 

--- a/tests/tsconfig-paths-config-loader.test.ts
+++ b/tests/tsconfig-paths-config-loader.test.ts
@@ -1,0 +1,148 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import { loadTsconfigPathAliasesForRoot } from "../packages/vinext/src/config/tsconfig-paths.js";
+
+function makeTempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "vinext-tsconfig-paths-test-"));
+}
+
+describe("loadTsconfigPathAliasesForRoot", () => {
+  let tmpDir: string;
+
+  afterEach(() => {
+    if (tmpDir) {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns absolute alias paths for wildcard mapping without baseUrl", () => {
+    tmpDir = makeTempDir();
+    fs.writeFileSync(
+      path.join(tmpDir, "tsconfig.json"),
+      JSON.stringify({
+        compilerOptions: {
+          paths: {
+            "@/*": ["./src/*"],
+          },
+        },
+      }),
+    );
+
+    const aliases = loadTsconfigPathAliasesForRoot(tmpDir);
+    expect(aliases["@"]).toBe(path.join(tmpDir, "src"));
+  });
+
+  it("supports baseUrl with relative path values", () => {
+    tmpDir = makeTempDir();
+    fs.writeFileSync(
+      path.join(tmpDir, "tsconfig.json"),
+      JSON.stringify({
+        compilerOptions: {
+          baseUrl: ".",
+          paths: {
+            "@/*": ["src/*"],
+          },
+        },
+      }),
+    );
+
+    const aliases = loadTsconfigPathAliasesForRoot(tmpDir);
+    expect(aliases["@"]).toBe(path.join(tmpDir, "src"));
+  });
+
+  it("follows 'extends' for inherited paths", () => {
+    tmpDir = makeTempDir();
+    fs.writeFileSync(
+      path.join(tmpDir, "tsconfig.base.json"),
+      JSON.stringify({
+        compilerOptions: { paths: { "@/*": ["./lib/*"] } },
+      }),
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "tsconfig.json"),
+      JSON.stringify({ extends: "./tsconfig.base.json" }),
+    );
+
+    const aliases = loadTsconfigPathAliasesForRoot(tmpDir);
+    expect(aliases["@"]).toBe(path.join(tmpDir, "lib"));
+  });
+
+  it("child paths override extended paths", () => {
+    tmpDir = makeTempDir();
+    fs.writeFileSync(
+      path.join(tmpDir, "tsconfig.base.json"),
+      JSON.stringify({
+        compilerOptions: { paths: { "@/*": ["./lib/*"] } },
+      }),
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "tsconfig.json"),
+      JSON.stringify({
+        extends: "./tsconfig.base.json",
+        compilerOptions: { paths: { "@/*": ["./src/*"] } },
+      }),
+    );
+
+    const aliases = loadTsconfigPathAliasesForRoot(tmpDir);
+    expect(aliases["@"]).toBe(path.join(tmpDir, "src"));
+  });
+
+  it("supports non-wildcard exact alias", () => {
+    tmpDir = makeTempDir();
+    fs.writeFileSync(
+      path.join(tmpDir, "tsconfig.json"),
+      JSON.stringify({
+        compilerOptions: {
+          paths: {
+            "@app": ["./src/app.ts"],
+          },
+        },
+      }),
+    );
+
+    const aliases = loadTsconfigPathAliasesForRoot(tmpDir);
+    expect(aliases["@app"]).toBe(path.join(tmpDir, "src", "app.ts"));
+  });
+
+  it("returns empty object when tsconfig.json is missing", () => {
+    tmpDir = makeTempDir();
+    expect(loadTsconfigPathAliasesForRoot(tmpDir)).toEqual({});
+  });
+
+  it("falls back to jsconfig.json when tsconfig.json is absent", () => {
+    tmpDir = makeTempDir();
+    fs.writeFileSync(
+      path.join(tmpDir, "jsconfig.json"),
+      JSON.stringify({
+        compilerOptions: {
+          paths: { "@/*": ["./src/*"] },
+        },
+      }),
+    );
+
+    const aliases = loadTsconfigPathAliasesForRoot(tmpDir);
+    expect(aliases["@"]).toBe(path.join(tmpDir, "src"));
+  });
+
+  it("ignores malformed wildcard patterns", () => {
+    tmpDir = makeTempDir();
+    fs.writeFileSync(
+      path.join(tmpDir, "tsconfig.json"),
+      JSON.stringify({
+        compilerOptions: {
+          // Invalid: wildcard not at end
+          paths: { "@*x/*": ["./src/*"] },
+        },
+      }),
+    );
+    expect(loadTsconfigPathAliasesForRoot(tmpDir)).toEqual({});
+  });
+
+  it("returns empty object on unparseable tsconfig.json", () => {
+    tmpDir = makeTempDir();
+    fs.writeFileSync(path.join(tmpDir, "tsconfig.json"), "not valid json{{{");
+    expect(loadTsconfigPathAliasesForRoot(tmpDir)).toEqual({});
+  });
+});


### PR DESCRIPTION
## Summary

Next.js's own `next.config.ts` loader (`packages/next/src/build/next-config-ts/transpile-config.ts`) reads `compilerOptions.paths` + `baseUrl` from `tsconfig.json` and passes them to SWC so users can write:

```ts
// next.config.ts
import { foo } from '@/foo'
export default { env: { foo } }
```

vinext's `loadNextConfig()` calls Vite's `runnerImport()`, but did not configure any `resolve.alias` entries, so the deploy harness fails with:

```
[vinext] Failed to load next.config.ts:
  Cannot find module '@/foo' imported from '<dir>/next.config.ts'
```

This is a **parity gap in vinext source** (not a harness issue), surfaced by the Next.js deploy test suite. The brief flagged it as the correct long-term fix, and the fix is small and self-contained, so it lives in vinext source.

## Root cause

`packages/vinext/src/config/next-config.ts::loadNextConfig` calls `runnerImport(configPath, { root, logLevel, clearScreen })` — but Vite's module-runner environment created by `runnerImport` only knows about Node resolution by default. tsconfig path aliases need to be passed in explicitly via `resolve.alias`.

`packages/vinext/src/index.ts` already has tsconfig-aware logic for the application bundle (via `vite-tsconfig-paths` on Vite 7 and `resolve.tsconfigPaths` on Vite 8) — but `loadNextConfig` runs *before* Vite's plugin pipeline starts, with its own `runnerImport` environment that does not inherit any of that.

## Fix

1. Extracted a small standalone helper `packages/vinext/src/config/tsconfig-paths.ts` that reads `compilerOptions.paths`/`baseUrl` from the project's `tsconfig.json` (or `jsconfig.json`), follows `extends` with cycle detection, and returns absolute-path Vite `resolve.alias` entries. Mirrors the subset Next.js supports.

2. Updated `loadNextConfig` to compute those aliases and pass them as `inlineConfig.resolve.alias` to `runnerImport`.

The helper deliberately duplicates a small amount of logic that already exists in `index.ts` (`loadTsconfigPathAliases` / `resolveTsconfigAliases`) rather than refactoring `index.ts`. Keeping the new code self-contained minimizes risk to the application-bundle path. A future cleanup could unify the two.

## Affected suites (from run [25870737355](https://github.com/cloudflare/vinext/actions/runs/25870737355))

- `e2e/app-dir/next-config-ts/import-alias-paths-only/`
- `e2e/app-dir/next-config-ts/import-alias-paths-with-baseurl/`
- `e2e/app-dir/next-config-ts/import-js-extensions-cjs/`
- `e2e/app-dir/next-config-ts/import-js-extensions-esm/`
- `e2e/app-dir/next-config-ts-native-ts/dynamic-import-esm/`
- `e2e/app-dir/next-config-ts-native-mts/import-from-node-modules/`

## Verification

- **9 new unit tests** in `tests/tsconfig-paths-config-loader.test.ts` covering: wildcard mapping, `baseUrl` handling, `extends` (including override), exact non-wildcard aliases, missing config, `jsconfig.json` fallback, malformed patterns, unparseable JSON.
- **4 new integration tests** in `tests/next-config.test.ts > loadNextConfig with tsconfig path aliases` — ported from Next.js's `test/e2e/app-dir/next-config-ts/import-alias-paths-only` and `import-alias-paths-with-baseurl` fixtures.
- **Real-world repro**: copied `.nextjs-ref/test/e2e/app-dir/next-config-ts/import-alias-paths-only/` (which uses `import { foo } from '@/foo'` in `next.config.ts` and has a JSON-with-comments tsconfig), promoted `tsconfig.test.json` → `tsconfig.json` (matching what the Next.js harness does), and confirmed `loadNextConfig` now returns `{ env: { foo: "foo" } }` instead of throwing.
- `vp check` (fmt + lint + types) clean.
- `bash -n scripts/*.sh` clean.
- Existing `tsconfig-paths-vite8.test.ts` and `tsconfig-path-alias-build.test.ts` still pass — no regression in the application-bundle path.

Refs: run [25870737355](https://github.com/cloudflare/vinext/actions/runs/25870737355).