### PR TITLE
test(link-navigation): sequence link.js and importActual to fix flake

### DIFF
--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -317,10 +317,17 @@ describe("Link App Router navigation scheduling", () => {
       scrollTo: vi.fn(),
     });
 
-    const [{ default: IsolatedLink }, React] = await Promise.all([
-      import("../packages/vinext/src/shims/link.js"),
-      vi.importActual<typeof import("react")>("react"),
-    ]);
+    // Load link.js BEFORE importActual("react"). Earlier these two imports ran
+    // in parallel via Promise.all, but that race made the mock occasionally not
+    // intercept link.tsx's transitive `import React from "react"` — when
+    // importActual won the race, "react" landed in the module cache as the
+    // actual module first, and link.tsx's import then resolved to that cached
+    // entry instead of the doMock factory. That caused React.startTransition
+    // inside Link to be the real implementation rather than the spy, so the
+    // assertion on `toHaveBeenCalledTimes(1)` would flake to 0.
+    // Sequencing the imports guarantees the doMock factory runs first.
+    const { default: IsolatedLink } = await import("../packages/vinext/src/shims/link.js");
+    const React = await vi.importActual<typeof import("react")>("react");
 
     ReactDOMServer.renderToString(
       React.createElement(IsolatedLink, { href: "/target", prefetch: false }, "target"),


### PR DESCRIPTION
## Summary

Fixes the intermittent unit-test failure observed on PR #1213's CI run ([job 76052351860](https://github.com/cloudflare/vinext/actions/runs/25878626751/job/76052351860)):

```
AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times
 ❯ tests/link-navigation.test.ts:345:29
```

PR #1213 only touches deploy-suite scripts, so this failure is unrelated to that change — it's a pre-existing flake in `tests/link-navigation.test.ts`.

## Root cause

The "clicking an RSC Link starts app-router navigation inside a React transition" test set up `vi.doMock("react", ...)` to replace `React.startTransition` with a spy, then ran two imports concurrently via `Promise.all`:

```ts
const [{ default: IsolatedLink }, React] = await Promise.all([
  import("../packages/vinext/src/shims/link.js"),
  vi.importActual<typeof import("react")>("react"),
]);
```

When `vi.importActual("react")` won the race, the actual `react` module was cached first. `link.tsx`'s transitive `import React from "react"` then resolved to that cached entry rather than running through the `doMock` factory, so `React.startTransition` inside `Link` was the real implementation instead of the spy. The spy stayed at 0 calls and the `toHaveBeenCalledTimes(1)` assertion failed.

The reason `clickEvent.defaultPrevented` (line 344) still passed is that `e.preventDefault()` runs before the `React.startTransition` call inside the click handler, so the click handler did execute — it just called the real `startTransition` instead of the spy.

## Fix

Sequence the imports: load `link.js` first (so the `doMock` factory runs while resolving its transitive `react` import), then grab `React` via `importActual` for use in the test's own `React.createElement` call.

This is the minimal change that removes the race. The mocked helper and spy contract are unchanged.

## Verification

- `vp test run tests/link-navigation.test.ts` — passes, all 17 tests
- Ran the failing test 30 times locally — 30/30 pass
- `vp test run --project unit` — 3980/3980 pass
- `vp check tests/link-navigation.test.ts` — clean