### PR TITLE
feat(compat): support declared artifact compatibility sets

### DIFF
--- a/packages/vinext/src/server/artifact-compatibility.ts
+++ b/packages/vinext/src/server/artifact-compatibility.ts
@@ -25,6 +25,19 @@ type ArtifactCompatibilityEnvelopeInput = Readonly<{
   renderEpoch?: string | null;
 }>;
 
+type ArtifactCompatibilitySet = readonly [string, string, ...string[]];
+
+type ArtifactCompatibilityMap = Readonly<{
+  graphVersions?: readonly ArtifactCompatibilitySet[];
+  deploymentVersions?: readonly ArtifactCompatibilitySet[];
+  rootBoundaryIds?: readonly ArtifactCompatibilitySet[];
+  renderEpochs?: readonly ArtifactCompatibilitySet[];
+}>;
+
+type ArtifactCompatibilityEvaluationOptions = Readonly<{
+  compatibilityMap?: ArtifactCompatibilityMap;
+}>;
+
 type ArtifactCompatibilityFallback = "renderFresh";
 
 type ArtifactCompatibilityUnknownReason =
@@ -35,9 +48,13 @@ type ArtifactCompatibilityUnknownReason =
 
 type ArtifactCompatibilityIncompatibleReason =
   | "appElementsSchemaVersionMismatch"
+  | "deploymentVersionNotDeclaredCompatible"
   | "deploymentVersionMismatch"
+  | "graphVersionNotDeclaredCompatible"
   | "graphVersionMismatch"
+  | "renderEpochNotDeclaredCompatible"
   | "renderEpochMismatch"
+  | "rootBoundaryIdNotDeclaredCompatible"
   | "rootBoundaryIdMismatch"
   | "rscPayloadSchemaVersionMismatch"
   | "schemaVersionMismatch";
@@ -140,22 +157,43 @@ function compareKnownField(
   candidateValue: string | null,
   unknownReason: ArtifactCompatibilityUnknownReason,
   mismatchReason: ArtifactCompatibilityIncompatibleReason,
+  notDeclaredCompatibleReason: ArtifactCompatibilityIncompatibleReason,
+  compatibilitySets: readonly ArtifactCompatibilitySet[] | undefined,
 ): ArtifactCompatibilityDecision | null {
   if (currentValue === null || candidateValue === null) {
     return unknown(unknownReason);
   }
-  if (currentValue !== candidateValue) {
+  if (currentValue === candidateValue) {
+    return null;
+  }
+  if (compatibilitySets === undefined) {
     return incompatible(mismatchReason);
   }
-  return null;
+  return isDeclaredCompatible(currentValue, candidateValue, compatibilitySets)
+    ? null
+    : incompatible(notDeclaredCompatibleReason);
+}
+
+function isDeclaredCompatible(
+  currentValue: string,
+  candidateValue: string,
+  compatibilitySets: readonly ArtifactCompatibilitySet[],
+): boolean {
+  // Compatibility is intentionally scoped to one declared set. Overlapping
+  // pair sets like [a,b] and [b,c] must not silently make a compatible with c.
+  return compatibilitySets.some(
+    (compatibilitySet) =>
+      compatibilitySet.includes(currentValue) && compatibilitySet.includes(candidateValue),
+  );
 }
 
 export function evaluateArtifactCompatibility(
   current: ArtifactCompatibilityEnvelope,
   candidate: ArtifactCompatibilityEnvelope,
+  options: ArtifactCompatibilityEvaluationOptions = {},
 ): ArtifactCompatibilityDecision {
-  // Pre-positioned for #726-COMPAT-04/05, where cache and visited-response
-  // reuse paths will compare the current render proof with a candidate payload.
+  // This remains a proof evaluator: mismatched fields are compatible only when
+  // the current build's compatibility map explicitly declares that relationship.
   if (current.schemaVersion !== candidate.schemaVersion) {
     return incompatible("schemaVersionMismatch");
   }
@@ -171,6 +209,8 @@ export function evaluateArtifactCompatibility(
     candidate.graphVersion,
     "graphVersionUnknown",
     "graphVersionMismatch",
+    "graphVersionNotDeclaredCompatible",
+    options.compatibilityMap?.graphVersions,
   );
   if (graphDecision) return graphDecision;
 
@@ -179,6 +219,8 @@ export function evaluateArtifactCompatibility(
     candidate.deploymentVersion,
     "deploymentVersionUnknown",
     "deploymentVersionMismatch",
+    "deploymentVersionNotDeclaredCompatible",
+    options.compatibilityMap?.deploymentVersions,
   );
   if (deploymentDecision) return deploymentDecision;
 
@@ -187,6 +229,8 @@ export function evaluateArtifactCompatibility(
     candidate.rootBoundaryId,
     "rootBoundaryIdUnknown",
     "rootBoundaryIdMismatch",
+    "rootBoundaryIdNotDeclaredCompatible",
+    options.compatibilityMap?.rootBoundaryIds,
   );
   if (rootBoundaryDecision) return rootBoundaryDecision;
 
@@ -195,6 +239,8 @@ export function evaluateArtifactCompatibility(
     candidate.renderEpoch,
     "renderEpochUnknown",
     "renderEpochMismatch",
+    "renderEpochNotDeclaredCompatible",
+    options.compatibilityMap?.renderEpochs,
   );
   if (renderEpochDecision) return renderEpochDecision;
 

--- a/tests/app-elements.test.ts
+++ b/tests/app-elements.test.ts
@@ -771,6 +771,112 @@ describe("artifact compatibility proof evaluation", () => {
     });
   });
 
+  it("accepts rolling deploy payloads when compatibility is explicitly declared", () => {
+    const current = createArtifactCompatibilityEnvelope({
+      graphVersion: "graph-next",
+      deploymentVersion: "deploy-canary",
+      rootBoundaryId: "root-next",
+      renderEpoch: "epoch-next",
+    });
+    const candidate = createArtifactCompatibilityEnvelope({
+      graphVersion: "graph-current",
+      deploymentVersion: "deploy-stable",
+      rootBoundaryId: "root-current",
+      renderEpoch: "epoch-current",
+    });
+
+    expect(
+      evaluateArtifactCompatibility(current, candidate, {
+        compatibilityMap: {
+          graphVersions: [["graph-current", "graph-next"]],
+          deploymentVersions: [["deploy-stable", "deploy-canary"]],
+          rootBoundaryIds: [["root-current", "root-next"]],
+          renderEpochs: [["epoch-current", "epoch-next"]],
+        },
+      }),
+    ).toEqual({ kind: "compatible" });
+  });
+
+  it("supports canary and rollback only when they share a declared compatibility set", () => {
+    const rollback = createArtifactCompatibilityEnvelope({
+      graphVersion: "graph-a",
+      deploymentVersion: "deploy-rollback",
+      rootBoundaryId: "root-a",
+      renderEpoch: "epoch-a",
+    });
+    const canary = createArtifactCompatibilityEnvelope({
+      graphVersion: "graph-a",
+      deploymentVersion: "deploy-canary",
+      rootBoundaryId: "root-a",
+      renderEpoch: "epoch-a",
+    });
+
+    expect(
+      evaluateArtifactCompatibility(rollback, canary, {
+        compatibilityMap: {
+          deploymentVersions: [["deploy-stable", "deploy-canary", "deploy-rollback"]],
+        },
+      }),
+    ).toEqual({ kind: "compatible" });
+  });
+
+  it("does not infer transitive deployment compatibility across overlapping pairs", () => {
+    const current = createArtifactCompatibilityEnvelope({
+      graphVersion: "graph-a",
+      deploymentVersion: "deploy-c",
+      rootBoundaryId: "root-a",
+      renderEpoch: "epoch-a",
+    });
+    const candidate = createArtifactCompatibilityEnvelope({
+      graphVersion: "graph-a",
+      deploymentVersion: "deploy-a",
+      rootBoundaryId: "root-a",
+      renderEpoch: "epoch-a",
+    });
+
+    expect(
+      evaluateArtifactCompatibility(current, candidate, {
+        compatibilityMap: {
+          deploymentVersions: [
+            ["deploy-a", "deploy-b"],
+            ["deploy-b", "deploy-c"],
+          ],
+        },
+      }),
+    ).toEqual({
+      kind: "incompatible",
+      fallback: "renderFresh",
+      reason: "deploymentVersionNotDeclaredCompatible",
+    });
+  });
+
+  it("falls back to fresh render when a stale compatibility map lacks the rollback deploy", () => {
+    const rollback = createArtifactCompatibilityEnvelope({
+      graphVersion: "graph-a",
+      deploymentVersion: "deploy-rollback",
+      rootBoundaryId: "root-a",
+      renderEpoch: "epoch-a",
+    });
+    const staleCanary = createArtifactCompatibilityEnvelope({
+      graphVersion: "graph-a",
+      deploymentVersion: "deploy-canary",
+      rootBoundaryId: "root-a",
+      renderEpoch: "epoch-a",
+    });
+
+    expect(
+      evaluateArtifactCompatibility(rollback, staleCanary, {
+        compatibilityMap: {
+          deploymentVersions: [["deploy-stable", "deploy-canary"]],
+        },
+      }),
+    ).toEqual({
+      kind: "incompatible",
+      fallback: "renderFresh",
+      reason: "deploymentVersionNotDeclaredCompatible",
+    });
+  });
+
   it("treats old-client/new-server future compatibility metadata as unknown proof", () => {
     const current = createArtifactCompatibilityEnvelope({
       graphVersion: "graph-current",
@@ -791,6 +897,29 @@ describe("artifact compatibility proof evaluation", () => {
         rootBoundaryId: "root-next",
         renderEpoch: "epoch-next",
       },
+    } satisfies Readonly<Record<string, unknown>>;
+
+    const metadata = AppElementsWire.readMetadata(payload);
+
+    expect(metadata.artifactCompatibility).toEqual(createArtifactCompatibilityEnvelope());
+    expect(evaluateArtifactCompatibility(current, metadata.artifactCompatibility)).toEqual({
+      kind: "unknown",
+      fallback: "renderFresh",
+      reason: "graphVersionUnknown",
+    });
+  });
+
+  it("treats new-client/old-server legacy payload metadata as unknown proof", () => {
+    const current = createArtifactCompatibilityEnvelope({
+      graphVersion: "graph-current",
+      deploymentVersion: "deploy-current",
+      rootBoundaryId: "root-current",
+      renderEpoch: "epoch-current",
+    });
+    const payload = {
+      [APP_ROUTE_KEY]: "route:/dashboard",
+      [APP_INTERCEPTION_CONTEXT_KEY]: null,
+      [APP_ROOT_LAYOUT_KEY]: "/",
     } satisfies Readonly<Record<string, unknown>>;
 
     const metadata = AppElementsWire.readMetadata(payload);


### PR DESCRIPTION
## Overview

| Field | Detail |
| --- | --- |
| Task | Implements `#726-COMPAT-06/08` from the #726 practical roadmap. |
| Goal | Add rolling deploy and old/new client fallback coverage without enabling cache reuse or skip transport. |
| Core change | `evaluateArtifactCompatibility` can now accept explicit compatibility sets for graph, deployment, root boundary, and render epoch proof fields. |
| Main boundary | Unknown proof and undeclared mismatches still fall back to `renderFresh`; compatibility is proof, not optimism. |
| Review focus | `packages/vinext/src/server/artifact-compatibility.ts`, then `tests/app-elements.test.ts`. |

Bonk: please read issue #726 before reviewing this PR so the architectural big picture is clear. This slice is deliberately narrow and should be reviewed against the compatibility outcome protocol described there.

## Why

Issue #726 says deployment compatibility must be algebra, not strict equality everywhere. The invariant for this slice is: a mismatch may be treated as compatible only when the current compatibility map explicitly proves that relationship. Otherwise the safe outcome is still `renderFresh`, not reuse, skip, or hard-navigation looping.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| Rolling deploys | Declared compatibility can bridge old and new deploy metadata. | Adds compatibility sets to the artifact proof evaluator. |
| Canary and rollback | Compatibility is transitive only inside an explicitly declared set. | Tests same-set canary/rollback and rejects overlapping pair transitivity. |
| Old/new clients | Future or legacy metadata is not proof. | Adds coverage for old-client/new-server and new-client/old-server fallback to unknown proof. |
| Stale maps | Missing declarations are unsafe. | Adds a stale compatibility-map fixture that falls back to fresh render. |

## What Changed

| Scenario | Before | After |
| --- | --- | --- |
| Known version mismatch | Always incompatible with `renderFresh`. | Still incompatible unless a compatibility map explicitly declares the mismatch compatible. |
| Rolling deploy window | No typed proof path for compatible old/new deploy metadata. | Declared graph/deploy/root/epoch sets can produce `compatible`. |
| Overlapping compatibility pairs | Not modeled. | `[a,b]` plus `[b,c]` does not imply `a` and `c` compatibility. |
| Future or legacy metadata | Existing unknown fallback was present but not covered as the old/new matrix. | Covered directly for old-client/new-server and new-client/old-server. |

<details>
<summary>Maintainer Review Path</summary>

1. `packages/vinext/src/server/artifact-compatibility.ts`
   - Check the `ArtifactCompatibilityMap` shape.
   - Check `compareKnownField` keeps nulls as unknown and equal values as strict compatible.
   - Check `isDeclaredCompatible` only accepts membership inside one declared set.

2. `tests/app-elements.test.ts`
   - Review the new rolling deploy, canary/rollback, transitivity, stale map, and old/new client fallback tests.
   - Confirm the tests assert outcomes rather than implementation details.

</details>

<details>
<summary>Validation</summary>

- `vp test run tests/app-elements.test.ts tests/app-browser-entry.test.ts`
  - 2 files passed, 146 tests passed.
- `vp check packages/vinext/src/server/artifact-compatibility.ts tests/app-elements.test.ts`
  - format, lint, and type checks passed for both changed files.
- Commit hook
  - format completed, lint/type passed for 551 files, `knip` passed.
- `vp run vinext#build`
  - build completed. The build emitted the existing virtual-module externalization warnings for `private-next-instrumentation-client`, `virtual:vinext-rsc-entry`, and `virtual:vite-rsc/client-references`.

</details>

<details>
<summary>Risk / Compatibility</summary>

- Runtime impact: low. This changes a pure evaluator and its focused tests.
- Cache/skip impact: no cache reuse or skip transport is enabled here.
- Safety fallback: unknown, future, legacy, and stale compatibility information still resolves to `renderFresh`.
- Public API impact: none intended. The compatibility-map types remain module-local to avoid exporting unused API surface.
- Next.js oracle: local Next.js source shows deployment IDs are attached to client RSC and server-action requests, and older/newer deployment action failures are treated as deployment skew rather than proof of reuse.

</details>

<details>
<summary>Non-goals</summary>

- Does not implement skip transport.
- Does not prevent reload loops for skip transport. That remains `#726-COMPAT-09` per the roadmap.
- Does not enable cache authority or artifact reuse.
- Does not introduce runtime profile IO or compatibility-map generation.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| Refs #726 | Parent architecture issue and compatibility outcome protocol. |
| `#726-COMPAT-06/08` | Specific roadmap slice implemented by this PR. |
| Next.js `fetch-server-response.ts` and `server-action-reducer.ts` in `.nextjs-ref` | Confirms deployment IDs are part of navigation/action requests. |
| Next.js `no-server-actions` compatibility tests in `.nextjs-ref` | Confirms older/newer deployment failures are a first-class compatibility scenario. |
