### PR TITLE
refactor(prerender): extract shared static-paths normalization

### DIFF
--- a/packages/vinext/src/build/prerender.ts
+++ b/packages/vinext/src/build/prerender.ts
@@ -32,7 +32,7 @@ import {
 } from "vinext/shims/cache";
 import { runWithHeadersContext, headersContextFromRequest } from "vinext/shims/headers";
 import { createValidFileMatcher, findFileWithExtensions } from "../routing/file-matcher.js";
-import { matchRoutePattern } from "../routing/route-pattern.js";
+import { normalizeStaticPathsEntry, type StaticPathsEntry } from "../routing/route-pattern.js";
 import { VINEXT_PRERENDER_SECRET_HEADER } from "../server/headers.js";
 import { startProdServer } from "../server/prod-server.js";
 import { readPrerenderSecret } from "./server-manifest.js";
@@ -342,57 +342,6 @@ function buildUrlFromParams(
 }
 
 /**
- * Convert a Pages-Router `getStaticPaths` entry into a params object.
- *
- * Next.js accepts either a string path or `{ params, locale? }`. See:
- *   .nextjs-ref/packages/next/src/build/static-paths/pages.ts (lines 86-129)
- *   https://nextjs.org/docs/pages/api-reference/functions/get-static-paths
- *
- * For a string entry, match it against the route pattern to extract params,
- * mirroring `_routeMatcher(cleanedEntry)` in the Next.js source. If the string
- * doesn't match the pattern, Next.js throws — we return `null` and let the
- * caller record a per-route error result instead of crashing the build.
- */
-function normalizeStaticPathsItem(
-  pattern: string,
-  item: string | { params?: Record<string, string | string[]>; locale?: string } | null | undefined,
-): { params: Record<string, string | string[]> } | { error: string } {
-  if (item === null || item === undefined) {
-    return { error: `getStaticPaths returned a ${item === null ? "null" : "undefined"} entry` };
-  }
-
-  if (typeof item === "string") {
-    // Strip query string and trailing slash (mirrors Next.js removeTrailingSlash).
-    const pathOnly = item.split("?")[0];
-    const trimmed = pathOnly === "/" ? "/" : pathOnly.replace(/\/$/, "");
-    const urlParts = trimmed.split("/").filter(Boolean);
-    const patternParts = pattern.split("/").filter(Boolean);
-    const matched = matchRoutePattern(urlParts, patternParts);
-    if (!matched) {
-      return {
-        error: `The provided path \`${item}\` from getStaticPaths does not match the route pattern \`${pattern}\`.`,
-      };
-    }
-    return { params: matched };
-  }
-
-  if (typeof item !== "object") {
-    return { error: `getStaticPaths entry must be a string or an object, got ${typeof item}` };
-  }
-
-  const { params } = item;
-  if (params === undefined || params === null) {
-    return {
-      error:
-        `getStaticPaths entry is missing the \`params\` key for pattern \`${pattern}\`. ` +
-        `Return either a string path or { params: { ... } }.`,
-    };
-  }
-
-  return { params };
-}
-
-/**
  * Determine the HTML output file path for a URL.
  * Respects trailingSlash config.
  */
@@ -576,17 +525,16 @@ export async function prerenderPages({
       : {};
 
     // Next.js allows `paths` to be either a list of strings or a list of
-    // { params, locale? } objects. See
-    //   .nextjs-ref/packages/next/src/build/static-paths/pages.ts
-    //   https://nextjs.org/docs/pages/api-reference/functions/get-static-paths
-    type StaticPathsItem = string | { params?: Record<string, string | string[]>; locale?: string };
+    // { params, locale? } objects. The `StaticPathsEntry` type and the
+    // `normalizeStaticPathsEntry` helper live in `../routing/route-pattern.ts`
+    // — see that file's doc comments for the Next.js references.
     type BundleRoute = {
       pattern: string;
       isDynamic: boolean;
       params: Record<string, string>;
       module: {
         getStaticPaths?: (opts: { locales: string[]; defaultLocale: string }) => Promise<{
-          paths: Array<StaticPathsItem>;
+          paths: Array<StaticPathsEntry>;
           fallback: unknown;
         }>;
         getStaticProps?: unknown;
@@ -625,7 +573,7 @@ export async function prerenderPages({
               }
               if (text === "null") return { paths: [], fallback: false };
               return JSON.parse(text) as {
-                paths: Array<StaticPathsItem>;
+                paths: Array<StaticPathsEntry>;
                 fallback: unknown;
               };
             }
@@ -706,14 +654,14 @@ export async function prerenderPages({
           continue;
         }
 
-        // `paths` may be `Array<string | { params, locale? }>` — see the
-        // Next.js implementation referenced on StaticPathsItem above. Normalize
-        // each entry into a params object, surfacing any per-entry problem as
-        // a per-route error result instead of crashing the whole prerender.
-        const paths: Array<StaticPathsItem> = pathsResult?.paths ?? [];
+        // `paths` may be `Array<string | { params, locale? }>` — normalize
+        // each entry into a params object via the shared helper, surfacing any
+        // per-entry problem as a per-route error result instead of crashing
+        // the whole prerender.
+        const paths: Array<StaticPathsEntry> = pathsResult?.paths ?? [];
         let entryError: string | null = null;
         for (const item of paths) {
-          const normalized = normalizeStaticPathsItem(route.pattern, item);
+          const normalized = normalizeStaticPathsEntry(item, route.pattern);
           if ("error" in normalized) {
             entryError = normalized.error;
             break;

--- a/packages/vinext/src/routing/route-pattern.ts
+++ b/packages/vinext/src/routing/route-pattern.ts
@@ -165,7 +165,7 @@ export type StaticPathsEntry =
  * Result of {@link normalizeStaticPathsEntry}: either a params object, or a
  * descriptive error string the caller can surface as a per-route error result.
  */
-export type NormalizedStaticPathsEntry = { params: RoutePatternParams } | { error: string };
+type NormalizedStaticPathsEntry = { params: RoutePatternParams } | { error: string };
 
 /**
  * Strip query string and a single trailing slash from a pathname.

--- a/packages/vinext/src/routing/route-pattern.ts
+++ b/packages/vinext/src/routing/route-pattern.ts
@@ -141,3 +141,100 @@ export function matchRoutePattern(
   decodeMatchedParams(params);
   return params;
 }
+
+/**
+ * A single entry from `getStaticPaths().paths`.
+ *
+ * Next.js allows both shapes:
+ *   - a raw string path, e.g. `"/blog/hello"`
+ *   - an object `{ params, locale? }`
+ *
+ * See:
+ *   https://nextjs.org/docs/pages/api-reference/functions/get-static-paths
+ *   .nextjs-ref/packages/next/src/build/static-paths/pages.ts (the
+ *     `typeof entry === 'string'` branch around line 89, and the object
+ *     branch around line 132)
+ */
+export type StaticPathsEntry =
+  | string
+  | { params?: RoutePatternParams; locale?: string }
+  | null
+  | undefined;
+
+/**
+ * Result of {@link normalizeStaticPathsEntry}: either a params object, or a
+ * descriptive error string the caller can surface as a per-route error result.
+ */
+export type NormalizedStaticPathsEntry = { params: RoutePatternParams } | { error: string };
+
+/**
+ * Strip query string and a single trailing slash from a pathname.
+ *
+ * Mirrors the Next.js `removeTrailingSlash` helper used in
+ * `.nextjs-ref/packages/next/src/build/static-paths/pages.ts`. Kept here so
+ * both the build-time prerender and the request-time matchers normalize the
+ * same way.
+ */
+export function normalizeStaticPathname(pathname: string): string {
+  const noQuery = pathname.split("?")[0];
+  return noQuery === "/" ? "/" : noQuery.replace(/\/$/, "");
+}
+
+/**
+ * Normalize a single `getStaticPaths` entry into a `{ params }` object.
+ *
+ * Handles both Next.js-supported shapes:
+ *   - For a string entry, match it against `routePattern` to extract params,
+ *     mirroring `_routeMatcher(cleanedEntry)` in
+ *     `.nextjs-ref/packages/next/src/build/static-paths/pages.ts`. If the
+ *     string does not match the pattern, Next.js throws; we return an
+ *     `{ error }` result so the caller can record a per-route error instead
+ *     of crashing the build.
+ *   - For an object entry, require a `params` key (Next.js raises
+ *     "A required parameter (X) was not provided..." otherwise).
+ *
+ * Note: this intentionally does NOT strip a locale prefix. The build pipeline
+ * currently passes empty `locales` to `getStaticPaths`, so locale-prefixed
+ * string entries are not produced. If/when i18n is wired through prerender,
+ * locale handling should be added here, not duplicated at call sites.
+ */
+export function normalizeStaticPathsEntry(
+  entry: StaticPathsEntry,
+  routePattern: string,
+): NormalizedStaticPathsEntry {
+  if (entry === null || entry === undefined) {
+    return {
+      error: `getStaticPaths returned a ${entry === null ? "null" : "undefined"} entry`,
+    };
+  }
+
+  if (typeof entry === "string") {
+    const trimmed = normalizeStaticPathname(entry);
+    const urlParts = trimmed.split("/").filter(Boolean);
+    const patternParts = routePattern.split("/").filter(Boolean);
+    const matched = matchRoutePattern(urlParts, patternParts);
+    if (!matched) {
+      return {
+        error: `The provided path \`${entry}\` from getStaticPaths does not match the route pattern \`${routePattern}\`.`,
+      };
+    }
+    return { params: matched };
+  }
+
+  if (typeof entry !== "object") {
+    return {
+      error: `getStaticPaths entry must be a string or an object, got ${typeof entry}`,
+    };
+  }
+
+  const { params } = entry;
+  if (params === undefined || params === null) {
+    return {
+      error:
+        `getStaticPaths entry is missing the \`params\` key for pattern \`${routePattern}\`. ` +
+        `Return either a string path or { params: { ... } }.`,
+    };
+  }
+
+  return { params };
+}

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -2,6 +2,7 @@ import type { ViteDevServer } from "vite";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { Route } from "../routing/pages-router.js";
 import { matchRoute, patternToNextFormat } from "../routing/pages-router.js";
+import { normalizeStaticPathname, type StaticPathsEntry } from "../routing/route-pattern.js";
 import type { ModuleImporter } from "./instrumentation.js";
 import { importModule, reportRequestError } from "./instrumentation.js";
 import type { NextI18nConfig } from "../config/next-config.js";
@@ -404,22 +405,17 @@ export function createSSRHandler(
           const fallback = pathsResult?.fallback ?? false;
 
           if (fallback === false) {
-            // Only allow paths explicitly listed in getStaticPaths.
-            // Next.js accepts `paths` as Array<string | { params, locale? }>:
-            //   https://nextjs.org/docs/pages/api-reference/functions/get-static-paths
-            //   .nextjs-ref/packages/next/src/build/static-paths/pages.ts
-            type StaticPathsItem =
-              | string
-              | { params?: Record<string, string | string[]>; locale?: string };
-            const paths: Array<StaticPathsItem> = pathsResult?.paths ?? [];
-            const normalizePathname = (p: string): string => {
-              const noQuery = p.split("?")[0];
-              return noQuery === "/" ? "/" : noQuery.replace(/\/$/, "");
-            };
-            const currentPathname = normalizePathname(url);
-            const isValidPath = paths.some((p: StaticPathsItem) => {
+            // Only allow paths explicitly listed in getStaticPaths. Next.js
+            // accepts `paths` as Array<string | { params, locale? }>; the
+            // shared `StaticPathsEntry` type and `normalizeStaticPathname`
+            // helper in `../routing/route-pattern.ts` reference the upstream
+            // implementation.
+            type DevStaticPathsEntry = Exclude<StaticPathsEntry, null | undefined>;
+            const paths: Array<DevStaticPathsEntry> = pathsResult?.paths ?? [];
+            const currentPathname = normalizeStaticPathname(url);
+            const isValidPath = paths.some((p) => {
               if (typeof p === "string") {
-                return normalizePathname(p) === currentPathname;
+                return normalizeStaticPathname(p) === currentPathname;
               }
               const entryParams = p.params;
               if (entryParams === undefined || entryParams === null) {

--- a/packages/vinext/src/server/pages-page-data.ts
+++ b/packages/vinext/src/server/pages-page-data.ts
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import type { Route } from "../routing/pages-router.js";
+import { normalizeStaticPathname } from "../routing/route-pattern.js";
 import type { CachedPagesValue, CacheControlMetadata } from "vinext/shims/cache";
 import { buildCachedRevalidateCacheControl } from "./cache-control.js";
 import { VINEXT_CACHE_HEADER } from "./headers.js";
@@ -17,9 +18,12 @@ type PagesRedirectResult = {
 };
 
 // Next.js allows `paths` entries to be either an object with a `params` key
-// or a raw string path. See:
-//   https://nextjs.org/docs/pages/api-reference/functions/get-static-paths
-//   .nextjs-ref/packages/next/src/build/static-paths/pages.ts (`typeof entry === 'string'` branch)
+// or a raw string path. We keep a local variant of `StaticPathsEntry` here
+// because at request time we compare against the actual request `params`
+// (whose value type is `unknown` from the route matcher) rather than the
+// `string | string[]` shape used at build time. The shared
+// `normalizeStaticPathname` helper from `../routing/route-pattern.js` is used
+// to canonicalize the string-entry comparison.
 type PagesStaticPathsEntry = string | { params?: Record<string, unknown>; locale?: string };
 
 type PagesStaticPathsResult = {
@@ -153,11 +157,13 @@ function resolvePagesRedirectStatus(redirect: PagesRedirectResult): number {
  *   - { params: { ... } }
  *   - "string-path"
  *
- * For a string entry, compare the entry (with the route pattern's prefix
- * already stripped by the caller via `routeUrl`) against the actual URL by
- * checking that the entry path equals the current `routeUrl`. We strip query
- * string and trailing slash to mirror the Next.js logic in
- *   .nextjs-ref/packages/next/src/build/static-paths/pages.ts
+ * For a string entry, compare the entry against the current request URL using
+ * the shared `normalizeStaticPathname` helper from
+ * `../routing/route-pattern.ts` (which mirrors the Next.js
+ * `removeTrailingSlash` behaviour in
+ * `.nextjs-ref/packages/next/src/build/static-paths/pages.ts`). For an object
+ * entry with a missing `params` key, return false rather than throwing — the
+ * caller will respond with a 404 just like Next.js does for unlisted paths.
  */
 function matchesPagesStaticPath(
   pathEntry: PagesStaticPathsEntry,
@@ -165,11 +171,7 @@ function matchesPagesStaticPath(
   routeUrl: string,
 ): boolean {
   if (typeof pathEntry === "string") {
-    const normalize = (p: string): string => {
-      const noQuery = p.split("?")[0];
-      return noQuery === "/" ? "/" : noQuery.replace(/\/$/, "");
-    };
-    return normalize(pathEntry) === normalize(routeUrl);
+    return normalizeStaticPathname(pathEntry) === normalizeStaticPathname(routeUrl);
   }
   const entryParams = pathEntry.params;
   if (entryParams === undefined || entryParams === null) {

--- a/tests/route-pattern.test.ts
+++ b/tests/route-pattern.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vite-plus/test";
 import {
   fillRoutePatternSegments,
   matchRoutePattern,
+  normalizeStaticPathname,
+  normalizeStaticPathsEntry,
   routePattern,
   routePatternParts,
 } from "../packages/vinext/src/routing/route-pattern.js";
@@ -93,5 +95,105 @@ describe("matchRoutePattern param decoding", () => {
 
   it("applies exactly one decodeURIComponent pass (double-encoded stays single-encoded)", () => {
     expect(matchRoutePattern(["files", "a%252Fb"], ["files", ":name"])).toEqual({ name: "a%2Fb" });
+  });
+});
+
+// Helper extracted from packages/vinext/src/build/prerender.ts,
+// packages/vinext/src/server/pages-page-data.ts, and
+// packages/vinext/src/server/dev-server.ts (originally added in PR #1227).
+// Mirrors .nextjs-ref/packages/next/src/build/static-paths/pages.ts.
+describe("normalizeStaticPathname", () => {
+  it("strips query string", () => {
+    expect(normalizeStaticPathname("/blog/hello?utm=x")).toBe("/blog/hello");
+  });
+
+  it("strips a single trailing slash on non-root paths", () => {
+    expect(normalizeStaticPathname("/blog/hello/")).toBe("/blog/hello");
+  });
+
+  it("preserves the root path", () => {
+    expect(normalizeStaticPathname("/")).toBe("/");
+  });
+
+  it("leaves a path without a trailing slash unchanged", () => {
+    expect(normalizeStaticPathname("/blog/hello")).toBe("/blog/hello");
+  });
+});
+
+describe("normalizeStaticPathsEntry", () => {
+  it("matches a string entry against a single-segment dynamic pattern", () => {
+    expect(normalizeStaticPathsEntry("/blog/hello", "/blog/:slug")).toEqual({
+      params: { slug: "hello" },
+    });
+  });
+
+  it("strips query string and trailing slash from a string entry", () => {
+    expect(normalizeStaticPathsEntry("/blog/hello/?ref=x", "/blog/:slug")).toEqual({
+      params: { slug: "hello" },
+    });
+  });
+
+  it("matches a string entry against a required catch-all pattern", () => {
+    expect(normalizeStaticPathsEntry("/docs/a/b/c", "/docs/:slug+")).toEqual({
+      params: { slug: ["a", "b", "c"] },
+    });
+  });
+
+  it("matches a string entry against an optional catch-all pattern", () => {
+    expect(normalizeStaticPathsEntry("/docs", "/docs/:slug*")).toEqual({
+      params: {},
+    });
+    expect(normalizeStaticPathsEntry("/docs/a/b", "/docs/:slug*")).toEqual({
+      params: { slug: ["a", "b"] },
+    });
+  });
+
+  it("returns an error when a string entry does not match the route pattern", () => {
+    const result = normalizeStaticPathsEntry("/posts/hello", "/blog/:slug");
+    expect(result).toMatchObject({ error: expect.stringMatching(/does not match/) });
+  });
+
+  it("passes an object entry's params through unchanged", () => {
+    const params = { slug: "hello" };
+    expect(normalizeStaticPathsEntry({ params }, "/blog/:slug")).toEqual({ params });
+  });
+
+  it("passes a catch-all array params object through unchanged", () => {
+    const params = { slug: ["a", "b"] };
+    expect(normalizeStaticPathsEntry({ params }, "/docs/:slug+")).toEqual({ params });
+  });
+
+  it("returns an error when an object entry has no params key", () => {
+    const result = normalizeStaticPathsEntry({}, "/blog/:slug");
+    expect(result).toMatchObject({ error: expect.stringMatching(/missing the `params` key/) });
+  });
+
+  it("returns an error when an object entry has explicit null params", () => {
+    const result = normalizeStaticPathsEntry(
+      { params: null } as unknown as { params?: Record<string, string | string[]> },
+      "/blog/:slug",
+    );
+    expect(result).toMatchObject({ error: expect.stringMatching(/missing the `params` key/) });
+  });
+
+  it("returns an error when the entry is null or undefined", () => {
+    expect(normalizeStaticPathsEntry(null, "/blog/:slug")).toMatchObject({
+      error: expect.stringMatching(/null entry/),
+    });
+    expect(normalizeStaticPathsEntry(undefined, "/blog/:slug")).toMatchObject({
+      error: expect.stringMatching(/undefined entry/),
+    });
+  });
+
+  it("returns an error for a non-string, non-object entry", () => {
+    const result = normalizeStaticPathsEntry(42 as unknown as string, "/blog/:slug");
+    expect(result).toMatchObject({ error: expect.stringMatching(/must be a string or an object/) });
+  });
+
+  it("decodes percent-encoded segments when matching a string entry", () => {
+    // Mirrors matchRoutePattern's decodeURIComponent pass (see "matchRoutePattern param decoding" suite above).
+    expect(normalizeStaticPathsEntry("/files/a%2Fb", "/files/:name")).toEqual({
+      params: { name: "a/b" },
+    });
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #1227, which added the same `getStaticPaths`-entry normalization logic to three files. This PR hoists that duplication into a single shared helper next to the existing `matchRoutePattern` utility so future call sites don't drift.

## Files now sharing the helper

- `packages/vinext/src/build/prerender.ts` — build-time prerender (Pages Router)
- `packages/vinext/src/server/pages-page-data.ts` — production Pages Router request handling (`matchesPagesStaticPath`)
- `packages/vinext/src/server/dev-server.ts` — dev-server Pages Router request handling

## New helper API

Added to `packages/vinext/src/routing/route-pattern.ts`:

```ts
export type StaticPathsEntry =
  | string
  | { params?: RoutePatternParams; locale?: string }
  | null
  | undefined;

export type NormalizedStaticPathsEntry =
  | { params: RoutePatternParams }
  | { error: string };

/** Strip query string and a single trailing slash (mirrors Next.js removeTrailingSlash). */
export function normalizeStaticPathname(pathname: string): string;

/** Normalize a getStaticPaths entry into { params } or { error }. */
export function normalizeStaticPathsEntry(
  entry: StaticPathsEntry,
  routePattern: string,
): NormalizedStaticPathsEntry;
```

The build-time prerender uses `normalizeStaticPathsEntry` directly. The two server-side matchers (which compare against the actual request `params`, not just extract them from the string) share `normalizeStaticPathname` and the `StaticPathsEntry` type while keeping their existing match-against-request-params logic intact.

## Behaviour

Pure refactor. No behaviour changes:

- String paths still get parsed correctly at build time.
- Missing-`params` items still surface as per-route build errors.
- The clearer error message added to `buildUrlFromParams` in #1227 stays in place.
- `matchesPagesStaticPath` (prod) and the dev-server matching path produce the same 404/match results they did before #1227's merge.

## Tests

The safety net from #1227 (`tests/prerender.test.ts`'s `string-paths` and `missing-params` cases) continues to pass. Targeted unit tests for the new helper added in `tests/route-pattern.test.ts` (next to the existing `routePattern` / `matchRoutePattern` tests) cover:

- string entries against single-segment, required catch-all, and optional catch-all patterns
- query string and trailing-slash stripping
- object entries with valid params (single key + catch-all array)
- object entries with missing / explicit-null `params`
- non-string-non-object entries
- null and undefined entries
- percent-encoded segments decoding through `matchRoutePattern`

Verified locally:

- `vp test run tests/route-pattern.test.ts` — 25 passed
- `vp test run tests/prerender.test.ts tests/run-prerender-concurrency.test.ts tests/app-prerender-endpoints.test.ts tests/pages-router.test.ts` — 285 passed
- `vp check` on every touched file — clean (the pre-existing `tests/e2e/fixtures.ts:33` lint error on `main` is unchanged)