### PR TITLE
fix(app-router): match Next.js RSC Content-Type and 404 plain-text body

### DIFF
--- a/packages/vinext/src/deploy.ts
+++ b/packages/vinext/src/deploy.ts
@@ -605,7 +605,7 @@ export default {
       // Location headers, so an encoded backslash in a downstream 308 redirect
       // would also navigate to the attacker's origin.
       if (isOpenRedirectShaped(pathname)) {
-        return new Response("404 Not Found", { status: 404 });
+        return new Response("This page could not be found", { status: 404 });
       }
 
       // Strip internal headers from inbound requests so they cannot be
@@ -836,7 +836,7 @@ export default {
       }
 
       if (!response) {
-        return new Response("404 - Not found", { status: 404 });
+        return new Response("This page could not be found", { status: 404 });
       }
 
       return mergeHeaders(response, middlewareHeaders, middlewareRewriteStatus);

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -2498,7 +2498,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
               // and would otherwise reach trailing-slash redirect emitters.
               if (isOpenRedirectShaped(pathname)) {
                 res.writeHead(404);
-                res.end("404 Not Found");
+                res.end("This page could not be found");
                 return;
               }
               pathname = pathname.replaceAll("\\", "/");

--- a/packages/vinext/src/server/app-page-boundary.ts
+++ b/packages/vinext/src/server/app-page-boundary.ts
@@ -1,6 +1,10 @@
 import { runWithFetchDedupe } from "vinext/shims/fetch-cache";
 import { mergeMiddlewareResponseHeaders } from "./middleware-response-headers.js";
-import { VINEXT_RSC_VARY_HEADER, applyRscCompatibilityIdHeader } from "./app-rsc-cache-busting.js";
+import {
+  VINEXT_RSC_CONTENT_TYPE,
+  VINEXT_RSC_VARY_HEADER,
+  applyRscCompatibilityIdHeader,
+} from "./app-rsc-cache-busting.js";
 import { resolveAppPageSegmentParams } from "./app-page-params.js";
 
 export type AppPageParams = Record<string, string | string[]>;
@@ -235,7 +239,7 @@ export async function renderAppPageBoundaryResponse<TElement>(
     // by the client, so headers()/cookies() and async server components still need
     // their ALS-backed state while the stream is being read.
     const headers = new Headers({
-      "Content-Type": "text/x-component; charset=utf-8",
+      "Content-Type": VINEXT_RSC_CONTENT_TYPE,
       Vary: VINEXT_RSC_VARY_HEADER,
     });
     mergeMiddlewareResponseHeaders(headers, options.middlewareHeaders ?? null);

--- a/packages/vinext/src/server/app-page-cache.ts
+++ b/packages/vinext/src/server/app-page-cache.ts
@@ -1,5 +1,9 @@
 import type { CachedAppPageValue, CacheControlMetadata } from "vinext/shims/cache";
-import { VINEXT_RSC_VARY_HEADER, applyRscCompatibilityIdHeader } from "./app-rsc-cache-busting.js";
+import {
+  VINEXT_RSC_CONTENT_TYPE,
+  VINEXT_RSC_VARY_HEADER,
+  applyRscCompatibilityIdHeader,
+} from "./app-rsc-cache-busting.js";
 import { buildCachedRevalidateCacheControl } from "./cache-control.js";
 import { VINEXT_CACHE_HEADER, VINEXT_MOUNTED_SLOTS_HEADER } from "./headers.js";
 import { buildAppPageCacheValue, type ISRCacheEntry } from "./isr-cache.js";
@@ -235,7 +239,7 @@ export function buildAppPageCachedResponse(
     const rscHeaders = buildAppPageCachedHeaders({
       cacheControl,
       cacheState: options.cacheState,
-      contentType: "text/x-component; charset=utf-8",
+      contentType: VINEXT_RSC_CONTENT_TYPE,
       middlewareHeaders: options.middlewareHeaders,
       mountedSlotsHeader: options.mountedSlotsHeader,
     });

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -58,7 +58,11 @@ import {
   mergeMiddlewareResponseHeaders,
   type AppPageMiddlewareContext,
 } from "./app-page-response.js";
-import { VINEXT_RSC_VARY_HEADER, applyRscCompatibilityIdHeader } from "./app-rsc-cache-busting.js";
+import {
+  VINEXT_RSC_CONTENT_TYPE,
+  VINEXT_RSC_VARY_HEADER,
+  applyRscCompatibilityIdHeader,
+} from "./app-rsc-cache-busting.js";
 import {
   APP_RSC_RENDER_MODE_NAVIGATION,
   shouldSuppressLoadingBoundaries,
@@ -557,7 +561,7 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
         onError: interceptOnError,
       });
       const interceptHeaders = new Headers({
-        "Content-Type": "text/x-component; charset=utf-8",
+        "Content-Type": VINEXT_RSC_CONTENT_TYPE,
         Vary: VINEXT_RSC_VARY_HEADER,
       });
       mergeMiddlewareResponseHeaders(interceptHeaders, options.middlewareContext.headers);

--- a/packages/vinext/src/server/app-page-response.ts
+++ b/packages/vinext/src/server/app-page-response.ts
@@ -10,7 +10,11 @@ import {
   VINEXT_TIMING_HEADER,
 } from "./headers.js";
 import { mergeMiddlewareResponseHeaders } from "./middleware-response-headers.js";
-import { VINEXT_RSC_VARY_HEADER, applyRscCompatibilityIdHeader } from "./app-rsc-cache-busting.js";
+import {
+  VINEXT_RSC_CONTENT_TYPE,
+  VINEXT_RSC_VARY_HEADER,
+  applyRscCompatibilityIdHeader,
+} from "./app-rsc-cache-busting.js";
 
 export type AppPageMiddlewareContext = {
   headers: Headers | null;
@@ -217,7 +221,7 @@ export function buildAppPageRscResponse(
   options: BuildAppPageRscResponseOptions,
 ): Response {
   const headers = new Headers({
-    "Content-Type": "text/x-component; charset=utf-8",
+    "Content-Type": VINEXT_RSC_CONTENT_TYPE,
     Vary: VINEXT_RSC_VARY_HEADER,
   });
 

--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -8,7 +8,11 @@ import {
   ACTION_REDIRECT_TYPE_HEADER,
   ACTION_REVALIDATED_HEADER,
 } from "./headers.js";
-import { VINEXT_RSC_VARY_HEADER, applyRscCompatibilityIdHeader } from "./app-rsc-cache-busting.js";
+import {
+  VINEXT_RSC_CONTENT_TYPE,
+  VINEXT_RSC_VARY_HEADER,
+  applyRscCompatibilityIdHeader,
+} from "./app-rsc-cache-busting.js";
 import { resolveAppPageActionRerenderTarget } from "./app-page-request.js";
 import { mergeMiddlewareResponseHeaders } from "./middleware-response-headers.js";
 import {
@@ -628,7 +632,7 @@ export async function handleServerActionRscRequest<
       );
       options.clearRequestContext();
       const redirectHeaders = new Headers({
-        "Content-Type": "text/x-component; charset=utf-8",
+        "Content-Type": VINEXT_RSC_CONTENT_TYPE,
         Vary: VINEXT_RSC_VARY_HEADER,
       });
       mergeMiddlewareResponseHeaders(redirectHeaders, options.middlewareHeaders);
@@ -665,7 +669,7 @@ export async function handleServerActionRscRequest<
       options.clearRequestContext();
 
       const actionHeaders = new Headers({
-        "Content-Type": "text/x-component; charset=utf-8",
+        "Content-Type": VINEXT_RSC_CONTENT_TYPE,
         Vary: VINEXT_RSC_VARY_HEADER,
       });
       mergeMiddlewareResponseHeaders(actionHeaders, options.middlewareHeaders);
@@ -729,7 +733,7 @@ export async function handleServerActionRscRequest<
     );
 
     const actionHeaders = new Headers({
-      "Content-Type": "text/x-component; charset=utf-8",
+      "Content-Type": VINEXT_RSC_CONTENT_TYPE,
       Vary: VINEXT_RSC_VARY_HEADER,
     });
     mergeMiddlewareResponseHeaders(actionHeaders, options.middlewareHeaders);

--- a/packages/vinext/src/server/http-error-responses.ts
+++ b/packages/vinext/src/server/http-error-responses.ts
@@ -42,12 +42,25 @@ export function forbiddenResponse(): Response {
 /**
  * Build a 404 Not Found plain-text response.
  *
+ * The body matches Next.js's plain-text 404 response exactly. Next.js writes
+ * `res.end('This page could not be found')` (no trailing period) for the
+ * fallback 404 path; see in `.nextjs-ref`:
+ *   - packages/next/src/server/route-modules/pages/pages-handler.ts L121, L535
+ *   - packages/next/src/build/templates/app-route.ts L170, L349
+ *   - packages/next/src/build/templates/app-page.ts L701, L1043
+ * (The React-rendered not-found component in `packages/next/src/client/components/builtin/not-found.tsx`
+ * uses the same text with a trailing period — that variant is rendered as HTML,
+ * not returned as the plain-text body.)
+ *
  * The `headers` option lets call sites merge middleware response headers into
  * the 404, matching the pattern used by `app-rsc-handler` after a route match
  * fails but middleware has already contributed headers.
  */
 export function notFoundResponse(init?: ErrorResponseInit): Response {
-  return new Response("Not Found", { status: 404, headers: init?.headers });
+  return new Response("This page could not be found", {
+    status: 404,
+    headers: init?.headers,
+  });
 }
 
 /**

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -990,7 +990,7 @@ async function startAppRouterServer(options: AppRouterServerOptions) {
     // below and would otherwise reach the trailing-slash redirect emitter.
     if (isOpenRedirectShaped(rawPathname)) {
       res.writeHead(404);
-      res.end("404 Not Found");
+      res.end("This page could not be found");
       return;
     }
 
@@ -1284,7 +1284,7 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
     // below and would otherwise reach the trailing-slash redirect emitter.
     if (isOpenRedirectShaped(rawPagesPathnameBeforeNormalize)) {
       res.writeHead(404);
-      res.end("404 Not Found");
+      res.end("This page could not be found");
       return;
     }
 
@@ -1726,7 +1726,7 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
 
       if (!response) {
         res.writeHead(404);
-        res.end("404 - Not found");
+        res.end("This page could not be found");
         return;
       }
 

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -294,7 +294,7 @@ describe("app browser entry navigation scheduling", () => {
     const snapshot = navigationShim.createCachedRscResponseSnapshot(
       new Response("unused", {
         headers: {
-          "content-type": "text/x-component; charset=utf-8",
+          "content-type": "text/x-component",
           [VINEXT_MOUNTED_SLOTS_HEADER]: "children",
           [VINEXT_PARAMS_HEADER]: "%7B%22slug%22%3A%22target%22%7D",
           [VINEXT_RSC_COMPATIBILITY_ID_HEADER]: "compat-a",

--- a/tests/app-page-boundary-render.test.ts
+++ b/tests/app-page-boundary-render.test.ts
@@ -306,7 +306,7 @@ describe("app page boundary render helpers", () => {
     });
 
     expect(response?.status).toBe(404);
-    expect(response?.headers.get("Content-Type")).toBe("text/x-component; charset=utf-8");
+    expect(response?.headers.get("Content-Type")).toBe("text/x-component");
 
     const payload = JSON.parse((await response?.text()) ?? "{}") as Record<string, unknown>;
     expect(payload.__route).toBe("route:/posts/missing");
@@ -548,7 +548,7 @@ describe("app page boundary render helpers", () => {
     });
 
     expect(response?.status).toBe(200);
-    expect(response?.headers.get("Content-Type")).toBe("text/x-component; charset=utf-8");
+    expect(response?.headers.get("Content-Type")).toBe("text/x-component");
 
     const payload = JSON.parse((await response?.text()) ?? "{}") as Record<string, unknown>;
     expect(payload.__route).toBe("route:/posts/missing");

--- a/tests/app-page-boundary.test.ts
+++ b/tests/app-page-boundary.test.ts
@@ -202,7 +202,7 @@ describe("app page boundary helpers", () => {
     });
 
     expect(response.status).toBe(404);
-    expect(response.headers.get("Content-Type")).toBe("text/x-component; charset=utf-8");
+    expect(response.headers.get("Content-Type")).toBe("text/x-component");
     expect(createHtmlResponse).not.toHaveBeenCalled();
     await expect(response.text()).resolves.toBe("RSC boundary");
   });

--- a/tests/app-page-cache.test.ts
+++ b/tests/app-page-cache.test.ts
@@ -82,7 +82,7 @@ describe("app page cache helpers", () => {
         revalidateSeconds: 60,
       }),
     );
-    expect(rscResponse?.headers.get("content-type")).toBe("text/x-component; charset=utf-8");
+    expect(rscResponse?.headers.get("content-type")).toBe("text/x-component");
     expect(rscResponse?.headers.get("cache-control")).toBe("s-maxage=0, stale-while-revalidate");
     expect(rscResponse?.headers.get(VINEXT_RSC_COMPATIBILITY_ID_HEADER)).toBe("compat-a");
     expect(await rscResponse?.arrayBuffer()).toEqual(rscData);
@@ -810,7 +810,7 @@ describe("app page cache helpers", () => {
     const response = finalizeAppPageRscCacheResponse(
       new Response("flight", {
         headers: {
-          "Content-Type": "text/x-component; charset=utf-8",
+          "Content-Type": "text/x-component",
           "Cache-Control": "s-maxage=60, stale-while-revalidate",
           "X-Vinext-Cache": "MISS",
         },

--- a/tests/app-page-dispatch.test.ts
+++ b/tests/app-page-dispatch.test.ts
@@ -347,7 +347,7 @@ describe("app page dispatch", () => {
     });
 
     expect(response.status).toBe(404);
-    await expect(response.text()).resolves.toBe("Not Found");
+    await expect(response.text()).resolves.toBe("This page could not be found");
   });
 
   it("serves intercepted RSC source-route payloads with middleware response state", async () => {
@@ -389,7 +389,7 @@ describe("app page dispatch", () => {
     });
 
     expect(response.status).toBe(202);
-    expect(response.headers.get("content-type")).toBe("text/x-component; charset=utf-8");
+    expect(response.headers.get("content-type")).toBe("text/x-component");
     expect(response.headers.get("x-from-middleware")).toBe("yes");
     await expect(response.text()).resolves.toBe("/feed:{}:modal@app/feed/@modal");
   });

--- a/tests/app-page-render.test.ts
+++ b/tests/app-page-render.test.ts
@@ -333,7 +333,7 @@ describe("app page render lifecycle", () => {
     });
 
     expect(response.status).toBe(200);
-    expect(response.headers.get("content-type")).toBe("text/x-component; charset=utf-8");
+    expect(response.headers.get("content-type")).toBe("text/x-component");
     expect(response.headers.get("cache-control")).toBe("no-store, must-revalidate");
     expect(response.headers.get("x-vinext-cache")).toBe("MISS");
     await expect(response.text()).resolves.toBe("flight-data");

--- a/tests/app-page-request.test.ts
+++ b/tests/app-page-request.test.ts
@@ -24,7 +24,7 @@ describe("app page request helpers", () => {
     });
 
     expect(response?.status).toBe(404);
-    await expect(response?.text()).resolves.toBe("Not Found");
+    await expect(response?.text()).resolves.toBe("This page could not be found");
     expect(clearRequestContext).toHaveBeenCalledTimes(1);
   });
 
@@ -40,7 +40,7 @@ describe("app page request helpers", () => {
     });
 
     expect(response?.status).toBe(404);
-    await expect(response?.text()).resolves.toBe("Not Found");
+    await expect(response?.text()).resolves.toBe("This page could not be found");
     expect(clearRequestContext).toHaveBeenCalledTimes(1);
   });
 

--- a/tests/app-page-response.test.ts
+++ b/tests/app-page-response.test.ts
@@ -378,7 +378,7 @@ describe("app page response helpers", () => {
     });
 
     expect(response.status).toBe(202);
-    expect(response.headers.get("content-type")).toBe("text/x-component; charset=utf-8");
+    expect(response.headers.get("content-type")).toBe("text/x-component");
     expect(response.headers.get("x-vinext-params")).toBe(encodeURIComponent('{"slug":"test"}'));
     expect(response.headers.get("cache-control")).toBe("private, max-age=5");
     expect(response.headers.get("x-vinext-cache")).toBe("MISS");

--- a/tests/app-prerender-endpoints.test.ts
+++ b/tests/app-prerender-endpoints.test.ts
@@ -33,7 +33,7 @@ describe("App prerender endpoint helpers", () => {
     );
 
     expect(response?.status).toBe(404);
-    await expect(response?.text()).resolves.toBe("Not Found");
+    await expect(response?.text()).resolves.toBe("This page could not be found");
   });
 
   it("calls generateStaticParams with object parent params and serializes the result", async () => {

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -212,6 +212,21 @@ describe("App Router integration", () => {
     expect(res.status).toBe(404);
   });
 
+  // Next.js sets the RSC response Content-Type to exactly "text/x-component"
+  // (no charset). Several Next.js tests use strict equality:
+  //   .nextjs-ref/test/e2e/app-dir/app/index.test.ts L362, L371
+  //   .nextjs-ref/test/e2e/app-dir/segment-cache/deployment-skew/deployment-skew.test.ts L80
+  // Source constant:
+  //   .nextjs-ref/packages/next/src/client/components/app-router-headers.ts L17
+  //   export const RSC_CONTENT_TYPE_HEADER = 'text/x-component' as const
+  it("uses text/x-component for the RSC Content-Type with no charset suffix", async () => {
+    const res = await fetch(`${baseUrl}/about.rsc`, {
+      headers: { Accept: "text/x-component", RSC: "1" },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("text/x-component");
+  });
+
   // Dual-router coexistence: the app-basic fixture has both app/ and pages/
   // (pages/old-school.tsx activates hasPagesDir). This verifies the Pages Router
   // still renders its own pages correctly when both routers are active — the

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -544,7 +544,7 @@ describe("createAppRscHandler", () => {
     const response = await handler(new Request("https://example.test/docs/missing"), null);
 
     expect(response.status).toBe(404);
-    expect(await response.text()).toBe("Not Found");
+    expect(await response.text()).toBe("This page could not be found");
     expect(clearRequestContext).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/app-server-action-execution.test.ts
+++ b/tests/app-server-action-execution.test.ts
@@ -629,7 +629,7 @@ describe("app server action execution helpers", () => {
     );
 
     expect(response?.status).toBe(200);
-    expect(response?.headers.get("content-type")).toBe("text/x-component; charset=utf-8");
+    expect(response?.headers.get("content-type")).toBe("text/x-component");
     expect(response?.headers.get("vary")).toBe(VINEXT_RSC_VARY_HEADER);
     expect(response?.headers.get("x-middleware")).toBe("present");
     expect(response?.headers.getSetCookie()).toEqual(["action=1; Path=/", "draft=1; Path=/"]);
@@ -660,7 +660,7 @@ describe("app server action execution helpers", () => {
       );
 
       expect(response?.status).toBe(200);
-      expect(response?.headers.get("content-type")).toBe("text/x-component; charset=utf-8");
+      expect(response?.headers.get("content-type")).toBe("text/x-component");
       expect(response?.headers.get(VINEXT_RSC_COMPATIBILITY_ID_HEADER)).toBe("compat-action");
       expect(response?.headers.get("x-action-revalidated")).toBeNull();
       expect(buildPageElement).not.toHaveBeenCalled();

--- a/tests/http-error-responses.test.ts
+++ b/tests/http-error-responses.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Tests for the shared HTTP error response helpers.
+ *
+ * The 404 body assertion verifies parity with Next.js, which writes
+ * "This page could not be found" (no trailing period) as the plain-text
+ * 404 body. Sources in .nextjs-ref:
+ *   - packages/next/src/server/route-modules/pages/pages-handler.ts L121, L535
+ *   - packages/next/src/build/templates/app-route.ts L170, L349
+ *   - packages/next/src/build/templates/app-page.ts L701, L1043
+ *   - packages/next/src/pages/_error.tsx L7  (`404: 'This page could not be found'`)
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  notFoundResponse,
+  badRequestResponse,
+  forbiddenResponse,
+  methodNotAllowedResponse,
+  internalServerErrorResponse,
+  payloadTooLargeResponse,
+} from "../packages/vinext/src/server/http-error-responses.js";
+
+describe("notFoundResponse", () => {
+  it("uses the Next.js-compatible plain-text body 'This page could not be found'", async () => {
+    const response = notFoundResponse();
+    expect(response.status).toBe(404);
+    expect(await response.text()).toBe("This page could not be found");
+  });
+
+  it("preserves caller-supplied headers", async () => {
+    const response = notFoundResponse({
+      headers: { "x-mw": "1" },
+    });
+    expect(response.headers.get("x-mw")).toBe("1");
+  });
+});
+
+describe("other error response helpers (regression sanity)", () => {
+  it("badRequestResponse returns 400 with 'Bad Request' body", async () => {
+    const response = badRequestResponse();
+    expect(response.status).toBe(400);
+    expect(await response.text()).toBe("Bad Request");
+  });
+
+  it("forbiddenResponse returns 403 with 'Forbidden' body", async () => {
+    const response = forbiddenResponse();
+    expect(response.status).toBe(403);
+    expect(await response.text()).toBe("Forbidden");
+  });
+
+  it("methodNotAllowedResponse returns 405 with Allow header", async () => {
+    const response = methodNotAllowedResponse("GET, HEAD");
+    expect(response.status).toBe(405);
+    expect(response.headers.get("Allow")).toBe("GET, HEAD");
+    expect(await response.text()).toBe("Method Not Allowed");
+  });
+
+  it("payloadTooLargeResponse returns 413", async () => {
+    const response = payloadTooLargeResponse();
+    expect(response.status).toBe(413);
+    expect(await response.text()).toBe("Payload Too Large");
+  });
+
+  it("internalServerErrorResponse returns 500 with canonical body by default", async () => {
+    const response = internalServerErrorResponse();
+    expect(response.status).toBe(500);
+    expect(await response.text()).toBe("Internal Server Error");
+  });
+});

--- a/tests/prefetch-cache.test.ts
+++ b/tests/prefetch-cache.test.ts
@@ -186,7 +186,7 @@ describe("prefetch cache eviction", () => {
   it("preserves RSC metadata when replaying cached responses", async () => {
     const response = new Response("flight", {
       headers: {
-        "content-type": "text/x-component; charset=utf-8",
+        "content-type": "text/x-component",
         [VINEXT_RSC_COMPATIBILITY_ID_HEADER]: "compat-a",
         "x-vinext-params": encodeURIComponent('{"id":"2"}'),
       },
@@ -195,7 +195,7 @@ describe("prefetch cache eviction", () => {
     const snapshot = await snapshotRscResponse(response);
     const restored = restoreRscResponse(snapshot);
 
-    expect(restored.headers.get("content-type")).toBe("text/x-component; charset=utf-8");
+    expect(restored.headers.get("content-type")).toBe("text/x-component");
     expect(restored.headers.get(VINEXT_RSC_COMPATIBILITY_ID_HEADER)).toBe("compat-a");
     expect(restored.headers.get("x-vinext-params")).toBe(encodeURIComponent('{"id":"2"}'));
     await expect(restored.text()).resolves.toBe("flight");


### PR DESCRIPTION
Two small Next.js-parity fixes for the App Router. Both align with explicit Next.js test assertions that vinext currently fails.

## LHF-6: RSC Content-Type drops the `charset=utf-8` suffix

Next.js sets the RSC (React Server Components / "flight") response `Content-Type` to **exactly** `text/x-component`. vinext was sending `text/x-component; charset=utf-8`.

The suffix breaks:

- Next.js segment-cache deduplication checks that key off the unsuffixed string (see `action-handler.ts` which does `contentType.startsWith(RSC_CONTENT_TYPE_HEADER)` against `'text/x-component'`).
- Next.js e2e tests that assert strict equality via `.toBe('text/x-component')`.

### Next.js source citations

- [`packages/next/src/client/components/app-router-headers.ts:17`](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/app-router-headers.ts#L17) — `export const RSC_CONTENT_TYPE_HEADER = 'text/x-component' as const`
- [`packages/next/src/server/app-render/flight-render-result.ts:15`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/flight-render-result.ts#L15) — uses the constant as the `contentType`.

### Next.js test citations (strict equality)

- [`test/e2e/app-dir/app/index.test.ts:362,371`](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/app/index.test.ts#L362) — `should use text/x-component for flight` (also edge runtime variant).
- [`test/e2e/app-dir/segment-cache/deployment-skew/deployment-skew.test.ts:80`](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/segment-cache/deployment-skew/deployment-skew.test.ts#L80) — `expect(...).toBe('text/x-component')`.

## LHF-7: 404 plain-text body becomes `This page could not be found`

Next.js's plain-text 404 response body in production is exactly `This page could not be found` (no trailing period in the response body — the React-rendered not-found component uses the same text with a period). vinext was returning `Not Found` / `404 Not Found` / `404 - Not found`.

### Next.js source citations

- [`packages/next/src/server/route-modules/pages/pages-handler.ts:121,535`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/route-modules/pages/pages-handler.ts#L121) — `res.end('This page could not be found')`.
- [`packages/next/src/build/templates/app-route.ts:170,349`](https://github.com/vercel/next.js/blob/canary/packages/next/src/build/templates/app-route.ts#L170) — same.
- [`packages/next/src/build/templates/app-page.ts:701,1043`](https://github.com/vercel/next.js/blob/canary/packages/next/src/build/templates/app-page.ts#L701) — same.
- [`packages/next/src/pages/_error.tsx:7`](https://github.com/vercel/next.js/blob/canary/packages/next/src/pages/_error.tsx#L7) — `404: 'This page could not be found'`.
- [`packages/next/src/client/components/builtin/not-found.tsx:7`](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/builtin/not-found.tsx#L7) — `message="This page could not be found."` (HTML variant, with period — vinext already matches this in `shims/error.tsx`).

### Next.js test citations

- `test/e2e/app-dir/app/index.test.ts` — `should not serve when layout is provided but no folder index`, `should not serve .server.js as a path`, `should not serve .client.js as a path`, `should handle required segments root as not found`.
- [`test/e2e/app-dir/parallel-route-not-found/parallel-route-not-found.test.ts:52`](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/parallel-route-not-found/parallel-route-not-found.test.ts#L52).
- [`test/e2e/app-dir/prefetching-not-found/prefetching-not-found.test.ts:16`](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/prefetching-not-found/prefetching-not-found.test.ts#L16) — the HTML-rendered variant with trailing period.

## Impact

Unblocks ~16 deploy-suite tests across the two clusters in run https://github.com/cloudflare/vinext/actions/runs/25897889733.

## Files changed

### LHF-6 (RSC Content-Type)

- `packages/vinext/src/server/app-page-response.ts` — replaces the literal at the main RSC response site.
- `packages/vinext/src/server/app-page-cache.ts` — replaces it for cached RSC responses (both fresh and stored).
- `packages/vinext/src/server/app-page-dispatch.ts` — replaces it for intercepted-route RSC responses.
- `packages/vinext/src/server/app-page-boundary.ts` — replaces it for 404/forbidden/unauthorized boundary responses.
- `packages/vinext/src/server/app-server-action-execution.ts` — replaces three occurrences (action redirect, action response, action rerender).
- Each file now imports the existing `VINEXT_RSC_CONTENT_TYPE` constant from `app-rsc-cache-busting.ts` (added in an earlier PR) instead of duplicating the string literal.
- Tests asserting the old strict-equality string were updated to match the new value.

### LHF-7 (404 body)

- `packages/vinext/src/server/http-error-responses.ts` — the shared `notFoundResponse()` helper now emits the Next.js-canonical body. Includes Next.js source citations in the JSDoc.
- `packages/vinext/src/server/prod-server.ts` — two inline 404 sites (open-redirect guard in both App Router and Pages Router branches; Pages Router SSR-fallback 404).
- `packages/vinext/src/index.ts` — the dev-server open-redirect 404 site.
- `packages/vinext/src/deploy.ts` — two inline 404 sites in the Cloudflare Workers entry (open-redirect guard; SSR-fallback 404).
- HTTP status reason phrase `Not Found` is unchanged everywhere (that's the standard HTTP/1.1 reason phrase, not a response body).
- Route-specific bodies like `404 - API route not found` are intentionally retained — they live behind explicit `if (resolvedPathname.startsWith('/api/'))` guards.
- Unit tests asserting the old `Not Found` body were updated to match the new value.

## New tests

- `tests/http-error-responses.test.ts` (new file) — covers `notFoundResponse()` and the sibling helpers with the new canonical body assertions, plus the LHF-7 source citations.
- `tests/app-router.test.ts > uses text/x-component for the RSC Content-Type with no charset suffix` — integration-level RSC content-type strict-equality test against the dev server, mirroring the failing Next.js assertions.

## Verification

- `vp check` — clean.
- `vp run knip` — clean.
- `vp test run tests/http-error-responses.test.ts tests/app-router.test.ts tests/pages-router.test.ts tests/prerender.test.ts tests/app-page-cache.test.ts tests/app-page-boundary.test.ts tests/app-page-boundary-render.test.ts tests/app-page-response.test.ts tests/app-server-action-execution.test.ts tests/app-page-render.test.ts tests/prefetch-cache.test.ts tests/app-rsc-handler.test.ts tests/app-page-dispatch.test.ts tests/app-page-request.test.ts tests/app-prerender-endpoints.test.ts tests/app-browser-entry.test.ts tests/deploy.test.ts tests/nextjs-compat/` — all green.

## Notes

- The original task description listed four sites for LHF-6 (`app-page-response.ts`, `app-page-dispatch.ts`, `app-page-boundary.ts`, `app-page-cache.ts`). There are three additional occurrences in `app-server-action-execution.ts` (action redirect / action response / action rerender) that share the same Next.js parity requirement; they are included in this PR.
- The original task description listed three sites for LHF-7 (`http-error-responses.ts`, `prod-server.ts:993`, `prod-server.ts:1287`). There are two additional inline 404 sites in `prod-server.ts:1729` (Pages Router SSR-fallback) and `deploy.ts:608,839` (Cloudflare Workers entry) that share the same Next.js parity requirement; they are included in this PR. The `index.ts:2489` dev-server open-redirect site is also included.
- A constant `VINEXT_RSC_CONTENT_TYPE` already existed in `app-rsc-cache-busting.ts` — this PR consolidates the seven duplicated literals onto it rather than introducing a new module.