### PR TITLE
fix(app-router): forward searchParams correctly in probePage()

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -50,7 +50,7 @@ const appPageRouteWiringPath = resolveEntryPath(
   "../server/app-page-route-wiring.js",
   import.meta.url,
 );
-const appPageHeadPath = resolveEntryPath("../server/app-page-head.js", import.meta.url);
+const appPageProbePath = resolveEntryPath("../server/app-page-probe.js", import.meta.url);
 const appPageParamsPath = resolveEntryPath("../server/app-page-params.js", import.meta.url);
 const appPageDispatchPath = resolveEntryPath("../server/app-page-dispatch.js", import.meta.url);
 const appPageRequestPath = resolveEntryPath("../server/app-page-request.js", import.meta.url);
@@ -221,9 +221,7 @@ import { buildPageElements as __buildPageElements } from ${JSON.stringify(appPag
 import {
   resolveAppPageSegmentParams as __resolveAppPageSegmentParams,
 } from ${JSON.stringify(appPageParamsPath)};
-import {
-  collectAppPageSearchParams as __collectAppPageSearchParams,
-} from ${JSON.stringify(appPageHeadPath)};
+import { probeAppPage as __probeAppPage } from ${JSON.stringify(appPageProbePath)};
 import {
   dispatchAppPage as __dispatchAppPage,
 } from ${JSON.stringify(appPageDispatchPath)};
@@ -542,11 +540,11 @@ export default __createAppRscHandler({
         });
       },
       probePage() {
-        if (!PageComponent) return null;
-        const _asyncSearchParams = makeThenableParams(
-          __collectAppPageSearchParams(searchParams).searchParamsObject,
-        );
-        return PageComponent({ params: _asyncRouteParams, searchParams: _asyncSearchParams });
+        return __probeAppPage({
+          pageComponent: PageComponent,
+          asyncRouteParams: _asyncRouteParams,
+          searchParams,
+        });
       },
       renderErrorBoundaryPage(renderErr) {
         return __fallbackRenderer.renderErrorBoundary(route, renderErr, isRscRequest, request, params, scriptNonce, middlewareContext);

--- a/packages/vinext/src/server/app-page-probe.ts
+++ b/packages/vinext/src/server/app-page-probe.ts
@@ -1,3 +1,5 @@
+import { makeThenableParams } from "vinext/shims/thenable-params";
+import { collectAppPageSearchParams } from "./app-page-head.js";
 import {
   probeAppPageComponent,
   probeAppPageLayouts,
@@ -5,6 +7,40 @@ import {
   type LayoutClassificationOptions,
   type LayoutFlags,
 } from "./app-page-execution.js";
+
+/**
+ * Build a probePage() invocation for the App Router request lifecycle.
+ *
+ * The generated RSC entry calls this once per request after route matching to
+ * eagerly invoke the page component. Surfacing redirect()/notFound() throws
+ * here lets the probe lifecycle turn them into proper HTTP responses before
+ * RSC streaming begins (see `probeAppPageBeforeRender`).
+ *
+ * The helper exists to keep the generated entry thin (a single delegation
+ * call) and to make the search-params wiring directly unit-testable. A bug
+ * here previously slipped through because the entry hand-rolled the call and
+ * read a non-existent key off `collectAppPageSearchParams`'s return value
+ * (see https://github.com/cloudflare/vinext/issues/1235).
+ *
+ * Returns `null` when the route has no page component (eg. interception-only
+ * routes), matching the caller contract on `probePage`.
+ */
+export function probeAppPage(options: {
+  pageComponent: unknown;
+  asyncRouteParams: unknown;
+  searchParams: URLSearchParams | null | undefined;
+}): unknown {
+  const { pageComponent, asyncRouteParams, searchParams } = options;
+  if (typeof pageComponent !== "function") {
+    return null;
+  }
+  const { pageSearchParams } = collectAppPageSearchParams(searchParams);
+  const asyncSearchParams = makeThenableParams(pageSearchParams);
+  return (pageComponent as (props: Record<string, unknown>) => unknown)({
+    params: asyncRouteParams,
+    searchParams: asyncSearchParams,
+  });
+}
 
 type ProbeAppPageBeforeRenderResult = {
   response: Response | null;

--- a/tests/app-page-probe.test.ts
+++ b/tests/app-page-probe.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from "vite-plus/test";
-import { probeAppPageBeforeRender } from "../packages/vinext/src/server/app-page-probe.js";
+import {
+  probeAppPage,
+  probeAppPageBeforeRender,
+} from "../packages/vinext/src/server/app-page-probe.js";
 
 // Mirrors makeThenableParams() from app-rsc-entry.ts — the function that
 // converts raw null-prototype params into objects that work with both
@@ -387,5 +390,90 @@ describe("app page probe helpers", () => {
     expect(probePage).not.toHaveBeenCalled();
     expect(renderPageSpecialError).not.toHaveBeenCalled();
     expect(result.response).toBeNull();
+  });
+});
+
+// Regression coverage for https://github.com/cloudflare/vinext/issues/1235.
+//
+// The generated RSC entry originally hand-rolled the probePage() body and read
+// a non-existent key off collectAppPageSearchParams's return value, so the
+// page component received `undefined` for searchParams and any
+// `await searchParams` threw TypeError during probing. probeAppPage()
+// encapsulates that wiring so the entry can delegate to a single typed call
+// and the behaviour is unit-testable in isolation.
+describe("probeAppPage", () => {
+  it("invokes the page with thenable params and resolved searchParams", async () => {
+    const calls: { params: unknown; searchParams: unknown }[] = [];
+    function Page(props: {
+      params: Promise<Record<string, string>>;
+      searchParams: Promise<Record<string, string | string[]>>;
+    }) {
+      calls.push({ params: props.params, searchParams: props.searchParams });
+      return "rendered";
+    }
+
+    const asyncRouteParams = makeThenableParams({ slug: "intro" });
+    const result = probeAppPage({
+      pageComponent: Page,
+      asyncRouteParams,
+      searchParams: new URLSearchParams("id=abc&tag=hello&tag=world"),
+    });
+
+    expect(result).toBe("rendered");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.params).toBe(asyncRouteParams);
+
+    const sp = (await calls[0]?.searchParams) as Record<string, string | string[]>;
+    expect(sp.id).toBe("abc");
+    expect(sp.tag).toEqual(["hello", "world"]);
+  });
+
+  it("returns null when the page has no default export to render", () => {
+    expect(
+      probeAppPage({
+        pageComponent: undefined,
+        asyncRouteParams: makeThenableParams({}),
+        searchParams: new URLSearchParams("id=abc"),
+      }),
+    ).toBeNull();
+    expect(
+      probeAppPage({
+        pageComponent: null,
+        asyncRouteParams: makeThenableParams({}),
+        searchParams: null,
+      }),
+    ).toBeNull();
+  });
+
+  it("passes an empty searchParams object when the request has no query string", async () => {
+    let received: Record<string, unknown> | undefined;
+    async function Page(props: { searchParams: Promise<Record<string, unknown>> }) {
+      received = await props.searchParams;
+    }
+
+    await probeAppPage({
+      pageComponent: Page,
+      asyncRouteParams: makeThenableParams({}),
+      searchParams: null,
+    });
+
+    expect(received).toBeDefined();
+    expect(Object.keys(received ?? {})).toEqual([]);
+  });
+
+  it("lets redirect()/notFound() throws propagate so the probe lifecycle can catch them", async () => {
+    const REDIRECT = new Error("NEXT_REDIRECT");
+    async function Page(props: { searchParams: Promise<{ dest?: string }> }) {
+      const { dest } = await props.searchParams;
+      if (dest) throw REDIRECT;
+    }
+
+    const result = probeAppPage({
+      pageComponent: Page,
+      asyncRouteParams: makeThenableParams({}),
+      searchParams: new URLSearchParams("dest=/about"),
+    }) as Promise<unknown>;
+
+    await expect(result).rejects.toBe(REDIRECT);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #1235.

The generated RSC entry's `probePage()` body read a non-existent key off `collectAppPageSearchParams`'s return value, so the page component received `undefined` for `searchParams` during the probe phase. Any page that did `await searchParams` during probing threw `TypeError`, the probe swallowed it as a non-special error, and `redirect()`/`notFound()` calls were dropped from the probe path — they only surfaced later via the RSC render path, by luck of error-boundary handling.

The visible render path was unaffected because `app-page-element-builder.ts` reads the correct key (`pageSearchParams`) from `resolveAppPageHead` independently. So the bug was latent for HTML responses but real: it defeated the entire point of `probePage()`, which is to surface `redirect()`/`notFound()` as clean HTTP responses before RSC streaming begins.

## Approach

Per the codebase's [AGENTS.md guidance](https://github.com/cloudflare/vinext/blob/main/AGENTS.md#generated-entry-modules-should-stay-thin), the generated RSC entry should stay thin and delegate real runtime behaviour to typed helpers under `server/*`. The original `probePage()` hand-rolled the `collectAppPageSearchParams(...).x` call inside a giant template literal, which is exactly the kind of place this class of bug hides.

This PR:

1. **Extracts the wiring into a typed helper** — `probeAppPage()` in `packages/vinext/src/server/app-page-probe.ts` — which takes the page component, the already-thenable params, and the raw `URLSearchParams`, and invokes the page component with the resolved props.
2. **Updates the generated entry** to delegate to that helper in a single call. The entry no longer imports `collectAppPageSearchParams` or constructs the props inline.
3. **Adds unit tests** in `tests/app-page-probe.test.ts` covering:
   - Page receives the original thenable params and a `searchParams` thenable that resolves to the parsed query
   - `null` is returned when the route has no page default export
   - Empty `URLSearchParams` / `null` produces an empty `searchParams` object (not `undefined`)
   - Thrown redirects propagate so `probeAppPageBeforeRender` can catch them

I confirmed the new tests fail against the original buggy key and pass with the fix.

## Verification

- `vp test run tests/app-page-probe.test.ts` — 13 passed (4 new + 9 existing)
- `vp test run tests/app-page-probe.test.ts tests/app-page-head.test.ts tests/entry-templates.test.ts tests/app-router.test.ts` — 348 passed across 4 files
- `vp check` on the touched files — pass

CI will run the full suite.