### PR TITLE
fix(app-router): refresh after discarded revalidating actions

### DIFF
--- a/packages/vinext/src/server/app-browser-action-result.ts
+++ b/packages/vinext/src/server/app-browser-action-result.ts
@@ -1,3 +1,5 @@
+import { ACTION_REVALIDATED_HEADER } from "./headers.js";
+
 export type AppBrowserServerActionResult<TRoot> = {
   root?: TRoot;
   returnValue?: {
@@ -5,6 +7,11 @@ export type AppBrowserServerActionResult<TRoot> = {
     data: unknown;
   };
 };
+
+export type ServerActionRevalidationKind = "dynamicOnly" | "none" | "staticAndDynamic";
+
+const ACTION_DID_REVALIDATE_STATIC_AND_DYNAMIC = 1;
+const ACTION_DID_REVALIDATE_DYNAMIC_ONLY = 2;
 
 /**
  * Structural discriminator: matches on `"returnValue"` or `"root"` keys.
@@ -20,10 +27,94 @@ export function isServerActionResult<TRoot>(
 
 export function shouldClearClientNavigationCachesForServerActionResult<TRoot>(
   result: AppBrowserServerActionResult<TRoot> | TRoot,
+  revalidation: ServerActionRevalidationKind = "none",
 ): boolean {
+  if (revalidation !== "none") {
+    return true;
+  }
+
   if (!isServerActionResult<TRoot>(result)) {
     return true;
   }
 
   return result.root !== undefined;
+}
+
+export function parseServerActionRevalidationHeader(
+  headers: Pick<Headers, "get">,
+): ServerActionRevalidationKind {
+  const value = headers.get(ACTION_REVALIDATED_HEADER);
+  if (!value) return "none";
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    return "none";
+  }
+
+  switch (parsed) {
+    case ACTION_DID_REVALIDATE_STATIC_AND_DYNAMIC:
+      return "staticAndDynamic";
+    case ACTION_DID_REVALIDATE_DYNAMIC_ONLY:
+      return "dynamicOnly";
+    default:
+      return "none";
+  }
+}
+
+export function shouldScheduleRefreshForDiscardedServerAction(
+  revalidation: ServerActionRevalidationKind,
+): boolean {
+  return revalidation !== "none";
+}
+
+type DiscardedServerActionRefreshScheduler = {
+  markNavigationSettled(): void;
+  markNavigationStart(): void;
+  schedule(): void;
+};
+
+type DiscardedServerActionRefreshSchedulerOptions = {
+  queueTask?: (callback: () => void) => void;
+  runRefresh: () => void;
+};
+
+export function createDiscardedServerActionRefreshScheduler(
+  options: DiscardedServerActionRefreshSchedulerOptions,
+): DiscardedServerActionRefreshScheduler {
+  const queueTask = options.queueTask ?? queueMicrotask;
+  let activeNavigationCount = 0;
+  let flushQueued = false;
+  let refreshPending = false;
+
+  function flush(): void {
+    flushQueued = false;
+    if (!refreshPending || activeNavigationCount > 0) return;
+
+    refreshPending = false;
+    options.runRefresh();
+  }
+
+  function queueFlush(): void {
+    if (flushQueued) return;
+    flushQueued = true;
+    queueTask(flush);
+  }
+
+  return {
+    markNavigationSettled() {
+      if (activeNavigationCount > 0) {
+        activeNavigationCount -= 1;
+      }
+      queueFlush();
+    },
+    markNavigationStart() {
+      activeNavigationCount += 1;
+    },
+    schedule() {
+      refreshPending = true;
+      queueFlush();
+    },
+  };
 }

--- a/packages/vinext/src/server/app-browser-action-result.ts
+++ b/packages/vinext/src/server/app-browser-action-result.ts
@@ -13,6 +13,13 @@ export type ServerActionRevalidationKind = "dynamicOnly" | "none" | "staticAndDy
 const ACTION_DID_REVALIDATE_STATIC_AND_DYNAMIC = 1;
 const ACTION_DID_REVALIDATE_DYNAMIC_ONLY = 2;
 
+type ServerActionInitiationSnapshot<TRouterState> = {
+  href: string;
+  navigationId: number;
+  path: string;
+  routerState: TRouterState;
+};
+
 /**
  * Structural discriminator: matches on `"returnValue"` or `"root"` keys.
  * This is safe because {@link AppWireElements} keys are prefixed (`route:`,
@@ -67,6 +74,22 @@ export function shouldScheduleRefreshForDiscardedServerAction(
   revalidation: ServerActionRevalidationKind,
 ): boolean {
   return revalidation !== "none";
+}
+
+export function createServerActionInitiationSnapshot<TRouterState>(options: {
+  href: string;
+  navigationId: number;
+  origin?: string;
+  routerState: TRouterState;
+}): ServerActionInitiationSnapshot<TRouterState> {
+  const url =
+    options.origin === undefined ? new URL(options.href) : new URL(options.href, options.origin);
+  return {
+    href: url.href,
+    navigationId: options.navigationId,
+    path: url.pathname + url.search,
+    routerState: options.routerState,
+  };
 }
 
 type DiscardedServerActionRefreshScheduler = {

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -48,8 +48,11 @@ import {
   type PendingBrowserRouterState,
 } from "./app-browser-navigation-controller.js";
 import {
+  createDiscardedServerActionRefreshScheduler,
   isServerActionResult,
+  parseServerActionRevalidationHeader,
   shouldClearClientNavigationCachesForServerActionResult,
+  type ServerActionRevalidationKind,
   type AppBrowserServerActionResult,
 } from "./app-browser-action-result.js";
 import {
@@ -143,6 +146,15 @@ const VISITED_RESPONSE_CACHE_TTL = 5 * 60_000;
 const MAX_TRAVERSAL_CACHE_TTL = 30 * 60_000;
 const CLIENT_RSC_COMPATIBILITY_ID = getVinextRscCompatibilityId();
 const browserNavigationController = createAppBrowserNavigationController();
+const discardedServerActionRefreshScheduler = createDiscardedServerActionRefreshScheduler({
+  runRefresh() {
+    clearClientNavigationCaches();
+    const rscNavigate = window.__VINEXT_RSC_NAVIGATE__;
+    if (typeof rscNavigate !== "function") return;
+
+    void rscNavigate(window.location.href, 0, "refresh", undefined, undefined, true);
+  },
+});
 const NavigationCommitSignal = browserNavigationController.NavigationCommitSignal;
 
 // Parses a URI-encoded JSON value carried in a response header (e.g.
@@ -302,6 +314,8 @@ async function commitSameUrlNavigatePayload(
   nextElements: Promise<AppElements>,
   returnValue?: ServerActionResult["returnValue"],
   actionInitiationState?: AppRouterState,
+  actionInitiationNavigationId?: number,
+  revalidation: ServerActionRevalidationKind = "none",
 ): Promise<unknown> {
   const navigationSnapshot = createClientNavigationRenderSnapshot(
     window.location.href,
@@ -312,6 +326,13 @@ async function commitSameUrlNavigatePayload(
     navigationSnapshot,
     returnValue,
     actionInitiationState,
+    {
+      onDiscardedRevalidation() {
+        discardedServerActionRefreshScheduler.schedule();
+      },
+      revalidation,
+      startedNavigationId: actionInitiationNavigationId,
+    },
   );
 }
 
@@ -796,7 +817,6 @@ async function readInitialRscStream(): Promise<ReadableStream<Uint8Array> | null
 function registerServerActionCallback(): void {
   setServerCallback(async (id, args) => {
     const temporaryReferences = createTemporaryReferenceSet();
-    const body = await encodeReply(args, { temporaryReferences });
 
     // Carry the interception context + mounted slots from the current router
     // state so the server-action re-render rebuilds the intercepted tree
@@ -804,6 +824,8 @@ function registerServerActionCallback(): void {
     // which sends `Next-URL` on action POSTs when the current tree contains
     // an interception route.
     const currentState = getBrowserRouterState();
+    const actionInitiationNavigationId = browserNavigationController.getActiveNavigationId();
+    const body = await encodeReply(args, { temporaryReferences });
     const { headers } = resolveServerActionRequestState({
       actionId: id,
       basePath: __basePath,
@@ -869,11 +891,12 @@ function registerServerActionCallback(): void {
       return undefined;
     }
 
+    const revalidation = parseServerActionRevalidationHeader(fetchResponse.headers);
     const result = await createFromFetch<ServerActionResult | AppWireElements>(
       Promise.resolve(fetchResponse),
       { temporaryReferences },
     );
-    if (shouldClearClientNavigationCachesForServerActionResult(result)) {
+    if (shouldClearClientNavigationCachesForServerActionResult(result, revalidation)) {
       clearClientNavigationCaches();
     }
 
@@ -889,6 +912,8 @@ function registerServerActionCallback(): void {
           Promise.resolve(AppElementsWire.decode(result.root)),
           result.returnValue,
           currentState,
+          actionInitiationNavigationId,
+          revalidation,
         );
       }
 
@@ -906,6 +931,8 @@ function registerServerActionCallback(): void {
       Promise.resolve(AppElementsWire.decode(result)),
       undefined,
       currentState,
+      actionInitiationNavigationId,
+      revalidation,
     );
   });
 }
@@ -985,6 +1012,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
     let pendingRouterState: PendingBrowserRouterState | null = null;
     // Hoist navId above try so the catch and finally blocks can reference it.
     const navId = browserNavigationController.beginNavigation();
+    discardedServerActionRefreshScheduler.markNavigationStart();
 
     // Loop variables for inline redirect following. On a redirect, these are
     // updated and the loop continues without returning or re-entering navigateRsc,
@@ -1275,6 +1303,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
       // checks, and error paths. The finally runs even when the catch returns.
       // settlePendingBrowserRouterState is idempotent via the settled flag.
       browserNavigationController.finalizeNavigation(navId, pendingRouterState);
+      discardedServerActionRefreshScheduler.markNavigationSettled();
     }
   };
 

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -49,6 +49,7 @@ import {
 } from "./app-browser-navigation-controller.js";
 import {
   createDiscardedServerActionRefreshScheduler,
+  createServerActionInitiationSnapshot,
   isServerActionResult,
   parseServerActionRevalidationHeader,
   shouldClearClientNavigationCachesForServerActionResult,
@@ -212,12 +213,9 @@ function applyClientParams(params: Record<string, string | string[]>): void {
 
 function stageClientParams(params: Record<string, string | string[]>): void {
   // NB: latestClientParams diverges from ClientNavigationState.clientParams
-  // between staging and commit. Server action snapshots (same-URL
-  // commitSameUrlNavigatePayload() calls inside registerServerActionCallback)
-  // read latestClientParams, so a
-  // server action fired during this window would get the pending (not yet
-  // committed) params. This is acceptable because the commit effect fires
-  // before hooks observe the new URL state, keeping the window vanishingly small.
+  // between staging and commit. Server action snapshots capture the committed
+  // browser router state at invocation time, so they do not read this mutable
+  // module-level value after their async request boundary.
   latestClientParams = params;
   replaceClientParamsWithoutNotify(params);
 }
@@ -235,6 +233,17 @@ function clearClientNavigationCaches(): void {
   clearVisitedResponseCache();
   clearPrefetchState();
 }
+
+function createActionInitiationSnapshot() {
+  const routerState = getBrowserRouterState();
+  return createServerActionInitiationSnapshot({
+    href: window.location.href,
+    navigationId: browserNavigationController.getActiveNavigationId(),
+    routerState,
+  });
+}
+
+type ActionInitiationSnapshot = ReturnType<typeof createActionInitiationSnapshot>;
 
 function createNavigationCommitEffect(options: {
   href: string;
@@ -312,26 +321,26 @@ async function renderNavigationPayload(
 
 async function commitSameUrlNavigatePayload(
   nextElements: Promise<AppElements>,
+  actionInitiation: ActionInitiationSnapshot,
   returnValue?: ServerActionResult["returnValue"],
-  actionInitiationState?: AppRouterState,
-  actionInitiationNavigationId?: number,
   revalidation: ServerActionRevalidationKind = "none",
 ): Promise<unknown> {
   const navigationSnapshot = createClientNavigationRenderSnapshot(
-    window.location.href,
-    latestClientParams,
+    actionInitiation.href,
+    actionInitiation.routerState.navigationSnapshot.params,
   );
   return browserNavigationController.commitSameUrlNavigatePayload(
     nextElements,
     navigationSnapshot,
     returnValue,
-    actionInitiationState,
+    actionInitiation.routerState,
     {
       onDiscardedRevalidation() {
         discardedServerActionRefreshScheduler.schedule();
       },
       revalidation,
-      startedNavigationId: actionInitiationNavigationId,
+      startedNavigationId: actionInitiation.navigationId,
+      targetHref: actionInitiation.href,
     },
   );
 }
@@ -823,24 +832,20 @@ function registerServerActionCallback(): void {
     // instead of replacing it with the direct page. Parity with Next.js,
     // which sends `Next-URL` on action POSTs when the current tree contains
     // an interception route.
-    const currentState = getBrowserRouterState();
-    const actionInitiationNavigationId = browserNavigationController.getActiveNavigationId();
+    const actionInitiation = createActionInitiationSnapshot();
     const body = await encodeReply(args, { temporaryReferences });
     const { headers } = resolveServerActionRequestState({
       actionId: id,
       basePath: __basePath,
-      elements: currentState.elements,
-      previousNextUrl: currentState.previousNextUrl,
+      elements: actionInitiation.routerState.elements,
+      previousNextUrl: actionInitiation.routerState.previousNextUrl,
     });
 
-    const fetchResponse = await fetch(
-      await createRscRequestUrl(window.location.pathname + window.location.search, headers),
-      {
-        method: "POST",
-        headers,
-        body,
-      },
-    );
+    const fetchResponse = await fetch(await createRscRequestUrl(actionInitiation.path, headers), {
+      method: "POST",
+      headers,
+      body,
+    });
 
     if (isServerActionNotFoundResponse(fetchResponse)) {
       throw new Error(getServerActionNotFoundClientMessage(id));
@@ -881,7 +886,7 @@ function registerServerActionCallback(): void {
     if (
       resolveRscCompatibilityNavigationDecision({
         clientCompatibilityId: CLIENT_RSC_COMPATIBILITY_ID,
-        currentHref: window.location.href,
+        currentHref: actionInitiation.href,
         origin: window.location.origin,
         responseCompatibilityId: fetchResponse.headers.get(VINEXT_RSC_COMPATIBILITY_ID_HEADER),
         responseUrl: fetchResponse.url,
@@ -910,9 +915,8 @@ function registerServerActionCallback(): void {
       if (result.root !== undefined) {
         return commitSameUrlNavigatePayload(
           Promise.resolve(AppElementsWire.decode(result.root)),
+          actionInitiation,
           result.returnValue,
-          currentState,
-          actionInitiationNavigationId,
           revalidation,
         );
       }
@@ -929,9 +933,8 @@ function registerServerActionCallback(): void {
 
     return commitSameUrlNavigatePayload(
       Promise.resolve(AppElementsWire.decode(result)),
+      actionInitiation,
       undefined,
-      currentState,
-      actionInitiationNavigationId,
       revalidation,
     );
   });

--- a/packages/vinext/src/server/app-browser-navigation-controller.ts
+++ b/packages/vinext/src/server/app-browser-navigation-controller.ts
@@ -49,6 +49,7 @@ type SameUrlServerActionLifecycleOptions = {
   onDiscardedRevalidation?: () => void;
   revalidation?: ServerActionRevalidationKind;
   startedNavigationId?: number;
+  targetHref?: string;
 };
 
 type BrowserNavigationControllerDeps = {
@@ -572,6 +573,7 @@ export function createAppBrowserNavigationController(
   ): Promise<unknown> {
     const currentState = actionInitiationState ?? getBrowserRouterState();
     const startedNavigationId = lifecycleOptions?.startedNavigationId ?? activeNavigationId;
+    const targetHref = lifecycleOptions?.targetHref ?? window.location.href;
     const {
       approvedCommit,
       decision,
@@ -590,7 +592,7 @@ export function createAppBrowserNavigationController(
       renderId: allocateRenderId(),
       operationLane: "server-action",
       startedNavigationId,
-      targetHref: window.location.href,
+      targetHref,
       type: "navigate",
     });
 
@@ -598,7 +600,7 @@ export function createAppBrowserNavigationController(
       // Same-URL action hard navigations do not expose a navigation outcome to
       // callers. If the loop guard blocks, the degraded state is still the
       // existing return contract: no visible commit and no action value.
-      performHardNavigation(window.location.href);
+      performHardNavigation(targetHref);
       return undefined;
     }
 
@@ -610,13 +612,13 @@ export function createAppBrowserNavigationController(
         currentState: getBrowserRouterState(),
         pending,
         startedNavigationId,
-        targetHref: window.location.href,
+        targetHref,
       });
 
       if (latestApproval.decision.disposition === "hard-navigate") {
         // See the same-URL hard-navigation note above. The guard result is
         // deliberately not surfaced through the server-action return channel.
-        performHardNavigation(window.location.href);
+        performHardNavigation(targetHref);
         return undefined;
       }
 

--- a/packages/vinext/src/server/app-browser-navigation-controller.ts
+++ b/packages/vinext/src/server/app-browser-navigation-controller.ts
@@ -17,6 +17,10 @@ import {
   resolveAndClassifyNavigationCommit,
   type ApprovedVisibleCommit,
 } from "./app-browser-visible-commit.js";
+import {
+  shouldScheduleRefreshForDiscardedServerAction,
+  type ServerActionRevalidationKind,
+} from "./app-browser-action-result.js";
 import type { AppElements } from "./app-elements.js";
 
 export type HistoryUpdateMode = "push" | "replace";
@@ -41,6 +45,12 @@ type BrowserRouterStateRef = {
   current: AppRouterState;
 };
 
+type SameUrlServerActionLifecycleOptions = {
+  onDiscardedRevalidation?: () => void;
+  revalidation?: ServerActionRevalidationKind;
+  startedNavigationId?: number;
+};
+
 type BrowserNavigationControllerDeps = {
   commitClientNavigationState?: typeof commitClientNavigationState;
   performHardNavigation?: (href: string, mode?: HardNavigationMode) => boolean;
@@ -48,6 +58,7 @@ type BrowserNavigationControllerDeps = {
 
 type BrowserNavigationController = {
   beginNavigation(): number;
+  getActiveNavigationId(): number;
   hasBrowserRouterState(): boolean;
   getBrowserRouterState(): AppRouterState;
   isCurrentNavigation(navId: number): boolean;
@@ -76,6 +87,7 @@ type BrowserNavigationController = {
     navigationSnapshot: ClientNavigationRenderSnapshot,
     returnValue?: { ok: boolean; data: unknown },
     actionInitiationState?: AppRouterState,
+    lifecycleOptions?: SameUrlServerActionLifecycleOptions,
   ): Promise<unknown>;
   hmrReplaceTree(
     nextElements: Promise<AppElements>,
@@ -240,6 +252,10 @@ export function createAppBrowserNavigationController(
 
   function beginNavigation(): number {
     activeNavigationId += 1;
+    return activeNavigationId;
+  }
+
+  function getActiveNavigationId(): number {
     return activeNavigationId;
   }
 
@@ -452,6 +468,15 @@ export function createAppBrowserNavigationController(
     setter(applyApprovedVisibleCommit(getBrowserRouterState(), commit));
   }
 
+  function notifyDiscardedServerActionRevalidation(
+    lifecycleOptions: SameUrlServerActionLifecycleOptions | undefined,
+  ): void {
+    const revalidation = lifecycleOptions?.revalidation ?? "none";
+    if (!shouldScheduleRefreshForDiscardedServerAction(revalidation)) return;
+
+    lifecycleOptions?.onDiscardedRevalidation?.();
+  }
+
   async function renderNavigationPayload(options: {
     actionType: "navigate" | "replace" | "traverse";
     createNavigationCommitEffect: BrowserNavigationCommitEffectFactory;
@@ -543,9 +568,10 @@ export function createAppBrowserNavigationController(
     navigationSnapshot: ClientNavigationRenderSnapshot,
     returnValue?: { ok: boolean; data: unknown },
     actionInitiationState?: AppRouterState,
+    lifecycleOptions?: SameUrlServerActionLifecycleOptions,
   ): Promise<unknown> {
     const currentState = actionInitiationState ?? getBrowserRouterState();
-    const startedNavigationId = activeNavigationId;
+    const startedNavigationId = lifecycleOptions?.startedNavigationId ?? activeNavigationId;
     const {
       approvedCommit,
       decision,
@@ -596,7 +622,11 @@ export function createAppBrowserNavigationController(
 
       if (latestApproval.approvedCommit) {
         dispatchSynchronousVisibleCommit(latestApproval.approvedCommit);
+      } else {
+        notifyDiscardedServerActionRevalidation(lifecycleOptions);
       }
+    } else if (decision.disposition === "no-commit") {
+      notifyDiscardedServerActionRevalidation(lifecycleOptions);
     }
 
     // Same-URL server actions still return their action value even if the UI
@@ -634,6 +664,7 @@ export function createAppBrowserNavigationController(
 
   return {
     beginNavigation,
+    getActiveNavigationId,
     hasBrowserRouterState,
     getBrowserRouterState,
     isCurrentNavigation,

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import { createOnUncaughtError } from "../packages/vinext/src/server/app-browser-error.js";
 import {
   createDiscardedServerActionRefreshScheduler,
+  createServerActionInitiationSnapshot,
   parseServerActionRevalidationHeader,
   shouldClearClientNavigationCachesForServerActionResult,
   shouldScheduleRefreshForDiscardedServerAction,
@@ -345,6 +346,26 @@ describe("app browser entry navigation scheduling", () => {
     expect(
       parseServerActionRevalidationHeader(new Headers({ [ACTION_REVALIDATED_HEADER]: "not-json" })),
     ).toBe("none");
+  });
+
+  it("captures server action initiation URL state without a hash in the request path", () => {
+    const routerState = createState({
+      navigationSnapshot: createClientNavigationRenderSnapshot("https://example.com/a?tab=1", {
+        slug: "a",
+      }),
+      routeId: "route:/a",
+    });
+
+    const snapshot = createServerActionInitiationSnapshot({
+      href: "https://example.com/a?tab=1#section",
+      navigationId: 42,
+      routerState,
+    });
+
+    expect(snapshot.href).toBe("https://example.com/a?tab=1#section");
+    expect(snapshot.navigationId).toBe(42);
+    expect(snapshot.path).toBe("/a?tab=1");
+    expect(snapshot.routerState).toBe(routerState);
   });
 
   it("keeps client navigation caches for no-root server action results", () => {
@@ -1851,13 +1872,14 @@ describe("app browser navigation controller", () => {
   });
 
   it("hard-navigates same-URL server action payloads when the root layout changes", async () => {
+    const actionTargetHref = "https://example.com/marketing?from=action";
     const initialState = createState({
       rootLayoutTreePath: "/(marketing)",
       routeId: "route:/marketing",
-      navigationSnapshot: createClientNavigationRenderSnapshot("https://example.com/marketing", {}),
+      navigationSnapshot: createClientNavigationRenderSnapshot(actionTargetHref, {}),
     });
     const { controller, detach, stateRef } = createControllerHarness(initialState);
-    const { assign } = stubWindow("https://example.com/marketing");
+    const { assign } = stubWindow("https://example.com/current");
     const nextElements = Promise.resolve(
       createResolvedElements("route:/dashboard", "/(dashboard)", null, {
         "page:/dashboard": React.createElement("main", null, "dashboard"),
@@ -1868,11 +1890,16 @@ describe("app browser navigation controller", () => {
       const result = await controller.commitSameUrlNavigatePayload(
         nextElements,
         stateRef.current.navigationSnapshot,
+        undefined,
+        undefined,
+        {
+          targetHref: actionTargetHref,
+        },
       );
 
       expect(result).toBeUndefined();
       expect(assign).toHaveBeenCalledTimes(1);
-      expect(assign).toHaveBeenCalledWith("https://example.com/marketing");
+      expect(assign).toHaveBeenCalledWith(actionTargetHref);
       expect(stateRef.current.routeId).toBe("route:/marketing");
     } finally {
       detach();

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -1,7 +1,12 @@
 import React from "react";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import { createOnUncaughtError } from "../packages/vinext/src/server/app-browser-error.js";
-import { shouldClearClientNavigationCachesForServerActionResult } from "../packages/vinext/src/server/app-browser-action-result.js";
+import {
+  createDiscardedServerActionRefreshScheduler,
+  parseServerActionRevalidationHeader,
+  shouldClearClientNavigationCachesForServerActionResult,
+  shouldScheduleRefreshForDiscardedServerAction,
+} from "../packages/vinext/src/server/app-browser-action-result.js";
 import {
   RSC_FORM_STATE_GLOBAL,
   consumeInitialFormState,
@@ -54,6 +59,7 @@ import {
   createNavigationTrace,
 } from "../packages/vinext/src/server/navigation-trace.js";
 import {
+  ACTION_REVALIDATED_HEADER,
   VINEXT_MOUNTED_SLOTS_HEADER,
   VINEXT_PARAMS_HEADER,
 } from "../packages/vinext/src/server/headers.js";
@@ -323,6 +329,24 @@ describe("app browser entry navigation scheduling", () => {
     expect(await replayed.text()).toBe("flight");
   });
 
+  it("parses action revalidation headers into explicit client effects", () => {
+    expect(parseServerActionRevalidationHeader(new Headers())).toBe("none");
+    expect(
+      parseServerActionRevalidationHeader(new Headers({ [ACTION_REVALIDATED_HEADER]: "1" })),
+    ).toBe("staticAndDynamic");
+    expect(
+      parseServerActionRevalidationHeader(new Headers({ [ACTION_REVALIDATED_HEADER]: "2" })),
+    ).toBe("dynamicOnly");
+    expect(
+      parseServerActionRevalidationHeader(
+        new Headers({ [ACTION_REVALIDATED_HEADER]: JSON.stringify("1") }),
+      ),
+    ).toBe("none");
+    expect(
+      parseServerActionRevalidationHeader(new Headers({ [ACTION_REVALIDATED_HEADER]: "not-json" })),
+    ).toBe("none");
+  });
+
   it("keeps client navigation caches for no-root server action results", () => {
     expect(
       shouldClearClientNavigationCachesForServerActionResult({
@@ -340,6 +364,55 @@ describe("app browser entry navigation scheduling", () => {
         createResolvedElements("route:/settings", "/"),
       ),
     ).toBe(true);
+    expect(
+      shouldClearClientNavigationCachesForServerActionResult(
+        {
+          returnValue: { ok: true, data: "action-result" },
+        },
+        "staticAndDynamic",
+      ),
+    ).toBe(true);
+    expect(
+      shouldClearClientNavigationCachesForServerActionResult(
+        {
+          returnValue: { ok: true, data: "action-result" },
+        },
+        "dynamicOnly",
+      ),
+    ).toBe(true);
+  });
+
+  it("schedules discarded action refreshes only for revalidated actions", () => {
+    expect(shouldScheduleRefreshForDiscardedServerAction("none")).toBe(false);
+    expect(shouldScheduleRefreshForDiscardedServerAction("dynamicOnly")).toBe(true);
+    expect(shouldScheduleRefreshForDiscardedServerAction("staticAndDynamic")).toBe(true);
+  });
+
+  it("coalesces discarded action refreshes until active navigation settles", () => {
+    const queued: Array<() => void> = [];
+    const runRefresh = vi.fn();
+    const scheduler = createDiscardedServerActionRefreshScheduler({
+      queueTask(callback) {
+        queued.push(callback);
+      },
+      runRefresh,
+    });
+
+    scheduler.markNavigationStart();
+    scheduler.schedule();
+    scheduler.schedule();
+    expect(runRefresh).not.toHaveBeenCalled();
+
+    queued.shift()?.();
+    expect(runRefresh).not.toHaveBeenCalled();
+
+    scheduler.markNavigationSettled();
+    queued.shift()?.();
+    expect(runRefresh).toHaveBeenCalledTimes(1);
+
+    scheduler.schedule();
+    queued.shift()?.();
+    expect(runRefresh).toHaveBeenCalledTimes(2);
   });
 
   it("does not expose a per-navigation transition override at the controller boundary", () => {
@@ -1541,6 +1614,117 @@ describe("app browser navigation controller", () => {
         state: "committed",
         visibleCommitVersion: 1,
       });
+    } finally {
+      detach();
+    }
+  });
+
+  it("reports discarded revalidating server action payloads for current-state refresh", async () => {
+    const initialState = createState({
+      rootLayoutTreePath: "/",
+      routeId: "route:/settings",
+      navigationSnapshot: createClientNavigationRenderSnapshot("https://example.com/settings", {
+        tab: "profile",
+      }),
+    });
+    const { controller, detach, stateRef } = createControllerHarness(initialState);
+    const { assign } = stubWindow("https://example.com/settings");
+    const onDiscardedRevalidation = vi.fn();
+    let resolveOlderPayload!: (elements: AppElements) => void;
+    const olderPayload = new Promise<AppElements>((resolve) => {
+      resolveOlderPayload = resolve;
+    });
+
+    try {
+      const olderResult = controller.commitSameUrlNavigatePayload(
+        olderPayload,
+        stateRef.current.navigationSnapshot,
+        {
+          data: "older-action-result",
+          ok: true,
+        },
+        undefined,
+        {
+          onDiscardedRevalidation,
+          revalidation: "staticAndDynamic",
+        },
+      );
+
+      await controller.commitSameUrlNavigatePayload(
+        Promise.resolve(
+          createResolvedElements("route:/settings/newer", "/", null, {
+            "page:/settings/newer": React.createElement("main", null, "newer"),
+          }),
+        ),
+        stateRef.current.navigationSnapshot,
+        {
+          data: "newer-action-result",
+          ok: true,
+        },
+      );
+
+      resolveOlderPayload(
+        createResolvedElements("route:/settings/older", "/", null, {
+          "page:/settings/older": React.createElement("main", null, "older"),
+        }),
+      );
+
+      await expect(olderResult).resolves.toBe("older-action-result");
+      expect(assign).not.toHaveBeenCalled();
+      expect(stateRef.current.routeId).toBe("route:/settings/newer");
+      expect(stateRef.current.visibleCommitVersion).toBe(1);
+      expect(onDiscardedRevalidation).toHaveBeenCalledTimes(1);
+    } finally {
+      detach();
+    }
+  });
+
+  it("discards revalidating server actions that started before an in-flight navigation", async () => {
+    const initialState = createState({
+      rootLayoutTreePath: "/",
+      routeId: "route:/settings",
+      navigationSnapshot: createClientNavigationRenderSnapshot("https://example.com/settings", {
+        tab: "profile",
+      }),
+    });
+    const { controller, detach, stateRef } = createControllerHarness(initialState);
+    const { assign } = stubWindow("https://example.com/settings");
+    const onDiscardedRevalidation = vi.fn();
+    const actionInitiationNavigationId = controller.getActiveNavigationId();
+    const actionInitiationState = stateRef.current;
+    let resolvePayload!: (elements: AppElements) => void;
+    const payload = new Promise<AppElements>((resolve) => {
+      resolvePayload = resolve;
+    });
+
+    try {
+      const result = controller.commitSameUrlNavigatePayload(
+        payload,
+        actionInitiationState.navigationSnapshot,
+        {
+          data: "action-result",
+          ok: true,
+        },
+        actionInitiationState,
+        {
+          onDiscardedRevalidation,
+          revalidation: "dynamicOnly",
+          startedNavigationId: actionInitiationNavigationId,
+        },
+      );
+
+      controller.beginNavigation();
+      resolvePayload(
+        createResolvedElements("route:/settings/action", "/", null, {
+          "page:/settings/action": React.createElement("main", null, "action"),
+        }),
+      );
+
+      await expect(result).resolves.toBe("action-result");
+      expect(assign).not.toHaveBeenCalled();
+      expect(stateRef.current.routeId).toBe("route:/settings");
+      expect(stateRef.current.visibleCommitVersion).toBe(0);
+      expect(onDiscardedRevalidation).toHaveBeenCalledTimes(1);
     } finally {
       detach();
     }

--- a/tests/e2e/app-router/nextjs-compat/actions-revalidate.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/actions-revalidate.spec.ts
@@ -15,6 +15,14 @@ import { waitForAppRouterHydration } from "../../helpers";
 const BASE = "http://localhost:4174";
 
 test.describe("Next.js compat: actions-revalidate (browser)", () => {
+  function waitForActionDiscardingResponse(page: Page) {
+    return page.waitForResponse(
+      (response) =>
+        response.request().method() === "POST" &&
+        response.url().includes("/nextjs-compat/action-discarding.rsc"),
+    );
+  }
+
   async function expectActionRefreshPreservesLoading(page: Page, buttonSelector: string) {
     const loadingLogs: string[] = [];
     page.on("console", (message) => {
@@ -49,6 +57,52 @@ test.describe("Next.js compat: actions-revalidate (browser)", () => {
 
   test("refresh() inside server action does not mount route loading", async ({ page }) => {
     await expectActionRefreshPreservesLoading(page, "#action-refresh-from-server");
+  });
+
+  // Ported from Next.js: test/e2e/app-dir/actions/app-action.test.ts
+  // "action discarding" coverage. Vinext uses a local counter instead of a
+  // remote fetch cache so the assertion is deterministic.
+  test("discarded server action without revalidation does not refresh current route", async ({
+    page,
+  }) => {
+    await page.goto(`${BASE}/nextjs-compat/action-discarding`);
+    await waitForAppRouterHydration(page);
+
+    const initialValue = await page.locator("#discarded-action-value").textContent();
+    if (!initialValue) {
+      throw new Error("Expected initial discarded action value");
+    }
+
+    const actionResponse = waitForActionDiscardingResponse(page);
+    await page.click("#slow-action");
+    await page.click("#navigate-discard-destination");
+    await expect(page.locator("#discard-destination")).toBeVisible();
+    await actionResponse;
+
+    await expect(page.locator("#discarded-action-value")).toHaveText(initialValue);
+  });
+
+  // Ported from Next.js: test/e2e/app-dir/actions/app-action.test.ts
+  // "should trigger a refresh for a server action that gets discarded due to
+  // a navigation (with revalidation)".
+  test("discarded server action with revalidation refreshes current route", async ({ page }) => {
+    await page.goto(`${BASE}/nextjs-compat/action-discarding`);
+    await waitForAppRouterHydration(page);
+
+    const initialValue = await page.locator("#discarded-action-value").textContent();
+    if (!initialValue) {
+      throw new Error("Expected initial discarded action value");
+    }
+
+    const actionResponse = waitForActionDiscardingResponse(page);
+    await page.click("#slow-action-refresh");
+    await page.click("#navigate-discard-destination");
+    await expect(page.locator("#discard-destination")).toBeVisible();
+    await actionResponse;
+
+    await expect(page.locator("#discarded-action-value")).not.toHaveText(initialValue, {
+      timeout: 10_000,
+    });
   });
 
   // Next.js: 'should not remount the page + loading component when revalidating'

--- a/tests/fixtures/app-basic/app/nextjs-compat/action-discarding/actions.ts
+++ b/tests/fixtures/app-basic/app/nextjs-compat/action-discarding/actions.ts
@@ -1,0 +1,20 @@
+"use server";
+
+import { refresh } from "next/cache";
+import { incrementValue } from "./state";
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function slowAction(): Promise<number> {
+  await wait(800);
+  return incrementValue();
+}
+
+export async function slowActionWithRefresh(): Promise<number> {
+  await wait(800);
+  const value = incrementValue();
+  refresh();
+  return value;
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/action-discarding/client.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/action-discarding/client.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { slowAction, slowActionWithRefresh } from "./actions";
+
+export function ActionDiscardingClient() {
+  return (
+    <main>
+      <h1>Action Discarding</h1>
+      <button
+        id="slow-action"
+        onClick={async () => {
+          await slowAction();
+        }}
+      >
+        Slow action
+      </button>
+      <button
+        id="slow-action-refresh"
+        onClick={async () => {
+          await slowActionWithRefresh();
+        }}
+      >
+        Slow action refresh
+      </button>
+    </main>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/action-discarding/destination/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/action-discarding/destination/page.tsx
@@ -1,0 +1,7 @@
+export default function DestinationPage() {
+  return (
+    <main>
+      <h1 id="discard-destination">Discard destination</h1>
+    </main>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/action-discarding/layout.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/action-discarding/layout.tsx
@@ -1,0 +1,19 @@
+import Link from "next/link";
+import type { ReactNode } from "react";
+import { getValue } from "./state";
+
+export const dynamic = "force-dynamic";
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return (
+    <section>
+      <p>
+        Discarded action value: <span id="discarded-action-value">{getValue()}</span>
+      </p>
+      <Link id="navigate-discard-destination" href="/nextjs-compat/action-discarding/destination">
+        Navigate to destination
+      </Link>
+      {children}
+    </section>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/action-discarding/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/action-discarding/page.tsx
@@ -1,0 +1,5 @@
+import { ActionDiscardingClient } from "./client";
+
+export default function Page() {
+  return <ActionDiscardingClient />;
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/action-discarding/state.ts
+++ b/tests/fixtures/app-basic/app/nextjs-compat/action-discarding/state.ts
@@ -1,0 +1,17 @@
+type ActionDiscardingGlobal = typeof globalThis & {
+  __vinextActionDiscardingState?: {
+    value: number;
+  };
+};
+
+const actionDiscardingGlobal: ActionDiscardingGlobal = globalThis;
+const state = (actionDiscardingGlobal.__vinextActionDiscardingState ??= { value: 0 });
+
+export function getValue(): number {
+  return state.value;
+}
+
+export function incrementValue(): number {
+  state.value += 1;
+  return state.value;
+}


### PR DESCRIPTION
Bonk: pls read #726 before reviewing
## Overview

| Field | Detail |
| --- | --- |
| Goal | Match the Core16-17 server action discard contract from #726. |
| Core change | Treat server-action revalidation as a client effect separate from visible payload commit authority. |
| Runtime boundary | Older action payloads cannot overwrite newer navigation state, but revalidated discarded actions still invalidate caches and refresh the current route. |
| Primary files | `app-browser-action-result.ts`, `app-browser-navigation-controller.ts`, `app-browser-entry.ts` |
| Impact | App Router server actions preserve newer visible state while still reflecting revalidated data after navigation settles. |

## Why

A same-URL server action has two independent effects: the action return value belongs to the caller, while the RSC payload can update visible route state only if its navigation authority is still current. Revalidation is a third effect. It must not give a stale payload commit authority, but it must still make the currently visible route observe invalidated data.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| Visible state | Older action responses cannot overwrite a newer navigation. | Captures the action initiation navigation id and uses it for same-URL action commit approval. |
| Cache state | Revalidation invalidates client navigation data even when the payload is discarded. | Parses `x-action-revalidated` into explicit client effects and clears caches for any revalidated action. |
| Refresh lane | A discarded revalidating action should trigger one current-route refresh after active navigation settles. | Adds a coalescing refresh scheduler around the RSC navigation lifecycle. |

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| Discarded action without revalidation | The older payload was discarded. | Still discarded, and no refresh is scheduled. |
| Discarded action with `refresh()` or cache revalidation | The older payload was discarded, but the current route could stay stale. | The older payload stays discarded, caches clear, and one refresh runs after active navigation settles. |
| Action response racing `encodeReply()` and navigation | The commit gate could use response-time navigation authority. | The action carries the initiation navigation id through the async request path. |

<details>
<summary>Maintainer review path</summary>

1. `packages/vinext/src/server/app-browser-action-result.ts`: header parsing, cache-clear decision, and the discarded-action refresh scheduler.
2. `packages/vinext/src/server/app-browser-navigation-controller.ts`: same-URL server action commit authority and discarded revalidation callback.
3. `packages/vinext/src/server/app-browser-entry.ts`: action initiation state capture, revalidation propagation, and RSC navigation lifecycle hooks.
4. `tests/app-browser-entry.test.ts`: focused unit coverage for the new contracts.
5. `tests/e2e/app-router/nextjs-compat/actions-revalidate.spec.ts` plus the new fixture: browser-level parity coverage for discarded server actions.

</details>

<details>
<summary>Validation</summary>

- `vp check`
- Commit hook: format, lint/typecheck, knip
- `vp test run tests/app-browser-entry.test.ts tests/app-server-action-execution.test.ts`
- `vp run vinext#build`
- `PLAYWRIGHT_PROJECT=app-router pnpm run test:e2e -- tests/e2e/app-router/nextjs-compat/actions-revalidate.spec.ts`
- `git diff --check`
- `git diff --cached --check`

</details>

<details>
<summary>Risk / compatibility</summary>

- Public API: no public API changes.
- Runtime: refresh scheduling is client-only and coalesced, and it waits for active RSC navigations to settle before refetching the current URL.
- Cache/router: revalidation now clears client navigation caches even when the server action result does not include a committed root payload.
- Compatibility: mirrors Next.js discarded server-action behavior for revalidated and non-revalidated actions. Action redirects remain on the existing hard-redirect path.

</details>

<details>
<summary>Non-goals</summary>

- This does not change the existing hard-navigation behavior for server action redirects.
- This does not implement the broader Core-18 or later route-action result model work from #726.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| Refs #726 | Tracks the Core16-17 roadmap item. |
| [Next.js action discarding tests](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/actions/app-action.test.ts) | Source parity for discarded server action refresh behavior. |
| [Next.js app router instance](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/app-router-instance.ts) | Shows discarded revalidating actions marking `needsRefresh`. |
| [Next.js server action reducer](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts) | Source parity for interpreting action revalidation as cache invalidation. |