### PR TITLE
fix(workflow): use correct workers.dev URL for compat ingest

### DIFF
--- a/.github/workflows/nextjs-deploy-suite.yml
+++ b/.github/workflows/nextjs-deploy-suite.yml
@@ -420,7 +420,7 @@ jobs:
           )
           && hashFiles('report/compat-ingest.json') != ''
         env:
-          COMPAT_INGEST_URL: ${{ vars.COMPAT_INGEST_URL || 'https://vinext-web.cloudflare.workers.dev/api/compatibility' }}
+          COMPAT_INGEST_URL: ${{ vars.COMPAT_INGEST_URL || 'https://vinext-web.vinext.workers.dev/api/compatibility' }}
           COMPAT_INGEST_SECRET: ${{ secrets.COMPAT_INGEST_SECRET }}
         run: |
           if [ -z "${COMPAT_INGEST_SECRET:-}" ]; then

--- a/.github/workflows/nextjs-deploy-suite.yml
+++ b/.github/workflows/nextjs-deploy-suite.yml
@@ -393,7 +393,14 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: deploy-suite-report
-          path: report/deploy-suite-report.json
+          # Include both files: the human-readable report and the
+          # /compatibility ingest payload. Keeping the ingest payload
+          # archived lets us manually re-POST a run if the live ingest
+          # step fails (network blip, bad URL, expired secret, etc.)
+          # without re-running the 40-minute suite.
+          path: |
+            report/deploy-suite-report.json
+            report/compat-ingest.json
           retention-days: 90
 
       # Submit per-file results to the /compatibility page's ingest endpoint.


### PR DESCRIPTION
## Summary

Two small workflow fixes for the deploy suite's `/compatibility` ingest, both shaken loose by tonight's failed nightly run.

### 1. Use the correct workers.dev URL

The default ingest URL (added in #1239) used `vinext-web.cloudflare.workers.dev`, which doesn't resolve. `*.workers.dev` URLs are namespaced under the **account** subdomain — for the `vinext` Cloudflare account that's `vinext.workers.dev` (see `scripts/smoke-test.sh` and `.github/workflows/deploy-examples.yml` which both use the correct host).

Tonight's run hit:
```
curl: (6) Could not resolve host: vinext-web.cloudflare.workers.dev
```

Now defaults to `vinext-web.vinext.workers.dev/api/compatibility`. Still overridable via the `COMPAT_INGEST_URL` repo variable for custom domains.

### 2. Archive the ingest payload alongside the report

When the live POST fails (DNS, expired secret, rotated secret, etc.) we previously had no way to recover without re-running the 40-minute suite — `compat-ingest.json` was generated but only `deploy-suite-report.json` was uploaded. Now both ship in the `deploy-suite-report` artifact, so a maintainer can download and curl it through by hand.