### PR TITLE
fix(navigation): throw when app router context is missing

### DIFF
--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -72,6 +72,7 @@ import {
   type OperationLane,
 } from "./app-browser-state.js";
 import { DevRecoveryBoundary, RedirectBoundary } from "vinext/shims/error-boundary";
+import { AppRouterContext } from "vinext/shims/internal/app-router-context";
 import { ElementsContext, Slot } from "vinext/shims/slot";
 import { createOnUncaughtError } from "./app-browser-error.js";
 import {
@@ -524,7 +525,7 @@ function BrowserRoot({
     );
   }, [treeState.previousNextUrl, treeState.renderId]);
 
-  const innerTree = createElement(
+  const routeTree = createElement(
     RedirectBoundary,
     null,
     createElement(
@@ -537,6 +538,9 @@ function BrowserRoot({
       ),
     ),
   );
+  const innerTree = AppRouterContext
+    ? createElement(AppRouterContext.Provider, { value: appRouterInstance }, routeTree)
+    : routeTree;
 
   // In dev, wrap the route tree in a top-level recovery boundary. A render
   // error (e.g. a slot's RSC reference rejects) is caught here instead of

--- a/packages/vinext/src/server/app-ssr-entry.ts
+++ b/packages/vinext/src/server/app-ssr-entry.ts
@@ -9,6 +9,7 @@ import clientReferences from "virtual:vite-rsc/client-references";
 import type { NavigationContext } from "vinext/shims/navigation";
 import {
   ServerInsertedHTMLContext,
+  appRouterInstance,
   clearServerInsertedHTML,
   renderServerInsertedHTML,
   setNavigationContext,
@@ -28,6 +29,7 @@ import { createRscEmbedTransform, createTickBufferedTransform } from "./app-ssr-
 import { deferUntilStreamConsumed } from "./app-page-stream.js";
 import { AppElementsWire, type AppWireElements } from "./app-elements.js";
 import { ElementsContext, Slot } from "vinext/shims/slot";
+import { AppRouterContext } from "vinext/shims/internal/app-router-context";
 import { createClientReferencePreloader } from "./app-client-reference-preloader.js";
 import { RSC_FORM_STATE_GLOBAL } from "./app-browser-hydration.js";
 
@@ -222,7 +224,14 @@ export async function handleSsr(
         );
       }
 
-      const root = createReactElement(VinextFlightRoot);
+      const flightRootElement = createReactElement(VinextFlightRoot);
+      const root = AppRouterContext
+        ? createReactElement(
+            AppRouterContext.Provider,
+            { value: appRouterInstance },
+            flightRootElement,
+          )
+        : flightRootElement;
       const ssrTree = ServerInsertedHTMLContext
         ? createReactElement(
             ServerInsertedHTMLContext.Provider,

--- a/packages/vinext/src/shims/internal/app-router-context.ts
+++ b/packages/vinext/src/shims/internal/app-router-context.ts
@@ -6,7 +6,7 @@
  *
  * We export the types and minimal context objects so these libraries resolve.
  */
-import { createContext } from "react";
+import * as React from "react";
 
 export type NavigateOptions = {
   scroll?: boolean;
@@ -27,8 +27,49 @@ export type AppRouterInstance = {
   prefetch(href: string, options?: PrefetchOptions): void;
 };
 
-export const AppRouterContext = createContext<AppRouterInstance | null>(null);
-export const GlobalLayoutRouterContext = createContext<unknown>(null);
-export const LayoutRouterContext = createContext<unknown>(null);
-export const MissingSlotContext = createContext<Set<string>>(new Set());
-export const TemplateContext = createContext<unknown>(null);
+const APP_ROUTER_CONTEXT_KEY = Symbol.for("vinext.appRouterContext");
+const GLOBAL_LAYOUT_ROUTER_CONTEXT_KEY = Symbol.for("vinext.globalLayoutRouterContext");
+const LAYOUT_ROUTER_CONTEXT_KEY = Symbol.for("vinext.layoutRouterContext");
+const MISSING_SLOT_CONTEXT_KEY = Symbol.for("vinext.missingSlotContext");
+const TEMPLATE_CONTEXT_KEY = Symbol.for("vinext.templateContext");
+
+type AppRouterContextGlobal = typeof globalThis & {
+  [APP_ROUTER_CONTEXT_KEY]?: React.Context<AppRouterInstance | null> | null;
+  [GLOBAL_LAYOUT_ROUTER_CONTEXT_KEY]?: React.Context<unknown> | null;
+  [LAYOUT_ROUTER_CONTEXT_KEY]?: React.Context<unknown> | null;
+  [MISSING_SLOT_CONTEXT_KEY]?: React.Context<Set<string>> | null;
+  [TEMPLATE_CONTEXT_KEY]?: React.Context<unknown> | null;
+};
+
+function getOrCreateContext<T>(key: symbol, defaultValue: T): React.Context<T> | null {
+  if (typeof React.createContext !== "function") return null;
+
+  // Boundary assertion: symbol-keyed global storage preserves context identity
+  // across duplicate module instances while keeping the public exports typed.
+  const globalState = globalThis as AppRouterContextGlobal & {
+    [key]?: React.Context<T> | null;
+  };
+  if (!globalState[key]) {
+    globalState[key] = React.createContext(defaultValue);
+  }
+  return globalState[key] ?? null;
+}
+
+export const AppRouterContext: React.Context<AppRouterInstance | null> | null =
+  getOrCreateContext<AppRouterInstance | null>(APP_ROUTER_CONTEXT_KEY, null);
+export const GlobalLayoutRouterContext: React.Context<unknown> | null = getOrCreateContext<unknown>(
+  GLOBAL_LAYOUT_ROUTER_CONTEXT_KEY,
+  null,
+);
+export const LayoutRouterContext: React.Context<unknown> | null = getOrCreateContext<unknown>(
+  LAYOUT_ROUTER_CONTEXT_KEY,
+  null,
+);
+export const MissingSlotContext: React.Context<Set<string>> | null = getOrCreateContext(
+  MISSING_SLOT_CONTEXT_KEY,
+  new Set(),
+);
+export const TemplateContext: React.Context<unknown> | null = getOrCreateContext<unknown>(
+  TEMPLATE_CONTEXT_KEY,
+  null,
+);

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -28,6 +28,7 @@ import {
 import { stripBasePath } from "../utils/base-path.js";
 import { ReadonlyURLSearchParams } from "./readonly-url-search-params.js";
 import { assertSafeNavigationUrl } from "./url-safety.js";
+import { AppRouterContext } from "./internal/app-router-context.js";
 
 // ─── Layout segment context ───────────────────────────────────────────────────
 // Stores the child segments below the current layout. Each layout wraps its
@@ -1368,7 +1369,14 @@ export const appRouterInstance = _appRouter;
  * (e.g. useMemo / useEffect deps, React.memo) don't re-render unnecessarily.
  */
 export function useRouter() {
-  return _appRouter;
+  if (!AppRouterContext || typeof React.useContext !== "function") {
+    throw new Error("invariant expected app router to be mounted");
+  }
+  const router = React.useContext(AppRouterContext);
+  if (router === null) {
+    throw new Error("invariant expected app router to be mounted");
+  }
+  return router;
 }
 
 /**

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -373,6 +373,14 @@ describe("App Router integration", () => {
     expect(html).toContain("hello");
   });
 
+  it("SSR renders a real app route that calls useRouter()", async () => {
+    const { res, html } = await fetchHtml(baseUrl, "/nextjs-compat/hooks-router");
+    expect(res.status).toBe(200);
+    expect(html).toContain("Router Test Page");
+    expect(html).toContain("/nextjs-compat/hooks-router");
+    expect(html).not.toContain("invariant expected app router to be mounted");
+  });
+
   it("applies nested layouts (dashboard layout wraps dashboard pages)", async () => {
     const res = await fetch(`${baseUrl}/dashboard`);
     expect(res.status).toBe(200);

--- a/tests/prefetch-cache.test.ts
+++ b/tests/prefetch-cache.test.ts
@@ -23,7 +23,7 @@ let MAX_PREFETCH_CACHE_SIZE: Navigation["MAX_PREFETCH_CACHE_SIZE"];
 let PREFETCH_CACHE_TTL: Navigation["PREFETCH_CACHE_TTL"];
 let snapshotRscResponse: Navigation["snapshotRscResponse"];
 let restoreRscResponse: Navigation["restoreRscResponse"];
-let useRouter: Navigation["useRouter"];
+let appRouterInstance: Navigation["appRouterInstance"];
 
 beforeEach(async () => {
   // Set window BEFORE importing so isServer evaluates to false
@@ -52,7 +52,7 @@ beforeEach(async () => {
   PREFETCH_CACHE_TTL = nav.PREFETCH_CACHE_TTL;
   snapshotRscResponse = nav.snapshotRscResponse;
   restoreRscResponse = nav.restoreRscResponse;
-  useRouter = nav.useRouter;
+  appRouterInstance = nav.appRouterInstance;
 });
 
 afterEach(() => {
@@ -98,7 +98,7 @@ describe("prefetch cache eviction", () => {
     const fetch = vi.fn();
     (globalThis as any).fetch = fetch;
 
-    useRouter().prefetch("https://external.example/dashboard");
+    appRouterInstance.prefetch("https://external.example/dashboard");
     await waitForPrefetchSetup();
 
     expect(fetch).not.toHaveBeenCalled();
@@ -113,7 +113,7 @@ describe("prefetch cache eviction", () => {
     });
     (globalThis as any).fetch = fetch;
 
-    useRouter().prefetch("http://localhost/dashboard?tab=1");
+    appRouterInstance.prefetch("http://localhost/dashboard?tab=1");
     await waitForPrefetchSetup(() => fetch.mock.calls.length > 0);
 
     expect(fetch).toHaveBeenCalledTimes(1);
@@ -215,7 +215,7 @@ describe("prefetch cache eviction", () => {
     (globalThis as any).fetch = fetch;
     (globalThis as any).window.__VINEXT_RSC_NAVIGATE__ = navigate;
 
-    useRouter().prefetch("/dashboard");
+    appRouterInstance.prefetch("/dashboard");
     await waitForPrefetchSetup(() => fetch.mock.calls.length > 0);
 
     if (fetchedUrl === undefined) {

--- a/tests/router-javascript-urls.test.ts
+++ b/tests/router-javascript-urls.test.ts
@@ -23,71 +23,62 @@ import { describe, it, expect } from "vite-plus/test";
 
 const BLOCK_MESSAGE = "Next.js has blocked a javascript: URL as a security precaution.";
 
-describe("App Router useRouter() blocks dangerous URI schemes", () => {
+describe("App Router appRouterInstance blocks dangerous URI schemes", () => {
   it("router.push throws on javascript: URL", async () => {
-    const { useRouter } = await import("../packages/vinext/src/shims/navigation.js");
-    const router = useRouter();
-    expect(() => router.push("javascript:alert(1)")).toThrow(BLOCK_MESSAGE);
+    const { appRouterInstance } = await import("../packages/vinext/src/shims/navigation.js");
+    expect(() => appRouterInstance.push("javascript:alert(1)")).toThrow(BLOCK_MESSAGE);
   });
 
   it("router.replace throws on javascript: URL", async () => {
-    const { useRouter } = await import("../packages/vinext/src/shims/navigation.js");
-    const router = useRouter();
-    expect(() => router.replace("javascript:alert(1)")).toThrow(BLOCK_MESSAGE);
+    const { appRouterInstance } = await import("../packages/vinext/src/shims/navigation.js");
+    expect(() => appRouterInstance.replace("javascript:alert(1)")).toThrow(BLOCK_MESSAGE);
   });
 
   it("router.prefetch throws on javascript: URL", async () => {
-    const { useRouter } = await import("../packages/vinext/src/shims/navigation.js");
-    const router = useRouter();
-    expect(() => router.prefetch("javascript:alert(1)")).toThrow(BLOCK_MESSAGE);
+    const { appRouterInstance } = await import("../packages/vinext/src/shims/navigation.js");
+    expect(() => appRouterInstance.prefetch("javascript:alert(1)")).toThrow(BLOCK_MESSAGE);
   });
 
   it("router.push throws on data: URL", async () => {
-    const { useRouter } = await import("../packages/vinext/src/shims/navigation.js");
-    const router = useRouter();
-    expect(() => router.push("data:text/html,<script>alert(1)</script>")).toThrow(BLOCK_MESSAGE);
+    const { appRouterInstance } = await import("../packages/vinext/src/shims/navigation.js");
+    expect(() => appRouterInstance.push("data:text/html,<script>alert(1)</script>")).toThrow(
+      BLOCK_MESSAGE,
+    );
   });
 
   it("router.push throws on vbscript: URL", async () => {
-    const { useRouter } = await import("../packages/vinext/src/shims/navigation.js");
-    const router = useRouter();
-    expect(() => router.push("vbscript:MsgBox(1)")).toThrow(BLOCK_MESSAGE);
+    const { appRouterInstance } = await import("../packages/vinext/src/shims/navigation.js");
+    expect(() => appRouterInstance.push("vbscript:MsgBox(1)")).toThrow(BLOCK_MESSAGE);
   });
 
   it("router.push throws on obfuscated javascript: URL with embedded tabs", async () => {
-    const { useRouter } = await import("../packages/vinext/src/shims/navigation.js");
-    const router = useRouter();
-    expect(() => router.push("java\tscript:alert(1)")).toThrow(BLOCK_MESSAGE);
+    const { appRouterInstance } = await import("../packages/vinext/src/shims/navigation.js");
+    expect(() => appRouterInstance.push("java\tscript:alert(1)")).toThrow(BLOCK_MESSAGE);
   });
 
   it("router.push throws on uppercase JAVASCRIPT: URL", async () => {
-    const { useRouter } = await import("../packages/vinext/src/shims/navigation.js");
-    const router = useRouter();
-    expect(() => router.push("JAVASCRIPT:alert(1)")).toThrow(BLOCK_MESSAGE);
+    const { appRouterInstance } = await import("../packages/vinext/src/shims/navigation.js");
+    expect(() => appRouterInstance.push("JAVASCRIPT:alert(1)")).toThrow(BLOCK_MESSAGE);
   });
 
   it("router.push throws on leading-whitespace javascript: URL", async () => {
-    const { useRouter } = await import("../packages/vinext/src/shims/navigation.js");
-    const router = useRouter();
-    expect(() => router.push("   javascript:alert(1)")).toThrow(BLOCK_MESSAGE);
+    const { appRouterInstance } = await import("../packages/vinext/src/shims/navigation.js");
+    expect(() => appRouterInstance.push("   javascript:alert(1)")).toThrow(BLOCK_MESSAGE);
   });
 
   // Safe URLs must not throw — guard must not over-block.
   it("router.push does not throw on a normal pathname", async () => {
-    const { useRouter } = await import("../packages/vinext/src/shims/navigation.js");
-    const router = useRouter();
-    expect(() => router.push("/safe")).not.toThrow();
+    const { appRouterInstance } = await import("../packages/vinext/src/shims/navigation.js");
+    expect(() => appRouterInstance.push("/safe")).not.toThrow();
   });
 
   it("router.replace does not throw on absolute https URL", async () => {
-    const { useRouter } = await import("../packages/vinext/src/shims/navigation.js");
-    const router = useRouter();
-    expect(() => router.replace("https://example.com/path")).not.toThrow();
+    const { appRouterInstance } = await import("../packages/vinext/src/shims/navigation.js");
+    expect(() => appRouterInstance.replace("https://example.com/path")).not.toThrow();
   });
 
   it("router.prefetch does not throw on a normal pathname", async () => {
-    const { useRouter } = await import("../packages/vinext/src/shims/navigation.js");
-    const router = useRouter();
-    expect(() => router.prefetch("/safe")).not.toThrow();
+    const { appRouterInstance } = await import("../packages/vinext/src/shims/navigation.js");
+    expect(() => appRouterInstance.prefetch("/safe")).not.toThrow();
   });
 });

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -23,24 +23,62 @@ describe("next/navigation shim", () => {
     expect(typeof nav.useRouter).toBe("function");
   });
 
-  // Regression test: useRouter() must return a stable singleton.
-  // Next.js returns the same router object reference on every call.
-  // Components using the router in useMemo/useEffect dependency arrays or
-  // wrapped in React.memo would re-render unnecessarily if each call
-  // returned a new object.
-  // Ported from: https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/hooks/hooks.test.ts
-  it("useRouter() returns the same object reference on every call (stable singleton)", async () => {
+  // Next.js parity: next/navigation's useRouter reads AppRouterContext and
+  // throws when it is rendered outside the App Router provider.
+  // Ported from Next.js:
+  // https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/navigation.ts
+  it("useRouter() throws when AppRouterContext is not mounted", async () => {
+    const React = await import("react");
+    const { renderToStaticMarkup } = await import("react-dom/server");
     const { useRouter } = await import("../packages/vinext/src/shims/navigation.js");
-    const first = useRouter();
-    const second = useRouter();
-    const third = useRouter();
-    expect(first).toBe(second);
-    expect(second).toBe(third);
+
+    function Probe() {
+      useRouter();
+      return React.createElement("span", null, "unreachable");
+    }
+
+    expect(() => renderToStaticMarkup(React.createElement(Probe))).toThrow(
+      "invariant expected app router to be mounted",
+    );
   });
 
-  it("useRouter() singleton exposes the expected navigation methods", async () => {
-    const { useRouter } = await import("../packages/vinext/src/shims/navigation.js");
-    const router = useRouter();
+  // Regression test: within the App Router provider, useRouter() must return
+  // the mounted router instance. Next.js returns a stable router reference from
+  // context, so components using the router in dependency arrays do not
+  // re-render unnecessarily.
+  // Ported from: https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/hooks/hooks.test.ts
+  it("useRouter() returns the mounted AppRouterContext router", async () => {
+    const React = await import("react");
+    const { renderToStaticMarkup } = await import("react-dom/server");
+    const { useRouter, appRouterInstance } =
+      await import("../packages/vinext/src/shims/navigation.js");
+    const { AppRouterContext } =
+      await import("../packages/vinext/src/shims/internal/app-router-context.js");
+    const captured: unknown[] = [];
+
+    function Probe() {
+      captured.push(useRouter(), useRouter());
+      return React.createElement("span", null, "ok");
+    }
+
+    if (!AppRouterContext) {
+      throw new Error("Expected AppRouterContext to be available in the test renderer");
+    }
+
+    renderToStaticMarkup(
+      React.createElement(
+        AppRouterContext.Provider,
+        { value: appRouterInstance },
+        React.createElement(Probe),
+      ),
+    );
+
+    expect(captured).toEqual([appRouterInstance, appRouterInstance]);
+  });
+
+  it("appRouterInstance singleton exposes the expected navigation methods", async () => {
+    const { appRouterInstance: router } =
+      await import("../packages/vinext/src/shims/navigation.js");
     expect(typeof router.push).toBe("function");
     expect(typeof router.replace).toBe("function");
     expect(typeof router.back).toBe("function");
@@ -49,13 +87,10 @@ describe("next/navigation shim", () => {
     expect(typeof router.prefetch).toBe("function");
   });
 
-  it("useRouter() exposes the stable bfcacheId placeholder", async () => {
-    const { useRouter } = await import("../packages/vinext/src/shims/navigation.js");
-    const first = useRouter();
-    const second = useRouter();
-    expect(typeof first.bfcacheId).toBe("string");
-    expect(first.bfcacheId).toBe("0");
-    expect(second.bfcacheId).toBe(first.bfcacheId);
+  it("appRouterInstance exposes the stable bfcacheId placeholder", async () => {
+    const { appRouterInstance } = await import("../packages/vinext/src/shims/navigation.js");
+    expect(typeof appRouterInstance.bfcacheId).toBe("string");
+    expect(appRouterInstance.bfcacheId).toBe("0");
   });
 
   // Next.js parity: refresh-reducer.ts invalidates the entire segment cache.
@@ -87,8 +122,8 @@ describe("next/navigation shim", () => {
 
     try {
       vi.resetModules();
-      const { useRouter } = await import("../packages/vinext/src/shims/navigation.js");
-      useRouter().refresh();
+      const { appRouterInstance } = await import("../packages/vinext/src/shims/navigation.js");
+      appRouterInstance.refresh();
       // refresh() schedules the rscNavigate inside React.startTransition, so
       // the navigate call lands after the synchronous clear but is dispatched
       // in the same tick — yield once to let it flush.
@@ -13093,6 +13128,23 @@ describe("next/dist/* internal import shims", () => {
     expect(mod.LayoutRouterContext).toBeDefined();
     expect(mod.MissingSlotContext).toBeDefined();
     expect(mod.TemplateContext).toBeDefined();
+  });
+
+  it("app-router-context imports when React.createContext is unavailable", async () => {
+    vi.resetModules();
+    vi.doMock("react", () => ({ createContext: undefined }));
+
+    try {
+      const mod = await import("../packages/vinext/src/shims/internal/app-router-context.js");
+      expect(mod.AppRouterContext).toBeNull();
+      expect(mod.GlobalLayoutRouterContext).toBeNull();
+      expect(mod.LayoutRouterContext).toBeNull();
+      expect(mod.MissingSlotContext).toBeNull();
+      expect(mod.TemplateContext).toBeNull();
+    } finally {
+      vi.doUnmock("react");
+      vi.resetModules();
+    }
   });
 
   it("utils exports NEXT_DATA type helpers", async () => {


### PR DESCRIPTION
## Overview

| Field | Details |
| --- | --- |
| Goal | Match Next.js `next/navigation` `useRouter()` semantics when no App Router provider is mounted. |
| Core change | `useRouter()` now reads `AppRouterContext` and throws the Next.js invariant when absent. |
| Boundary | `appRouterInstance` remains the public singleton for `window.next.router` and direct runtime helpers. |
| Primary files | `packages/vinext/src/shims/navigation.ts`, `packages/vinext/src/server/app-browser-entry.ts`, `packages/vinext/src/server/app-ssr-entry.ts`, `tests/shims.test.ts` |
| Expected impact | Components rendered outside the App Router boundary fail loudly instead of silently receiving a usable router. |

## Why

`next/navigation` hooks are only valid inside the App Router tree. Next.js enforces that by reading `AppRouterContext` and throwing `invariant expected app router to be mounted` when the provider is absent. Vinext returned its module-level singleton unconditionally, which made invalid usage look valid and hid integration bugs.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| App Router hook contract | `useRouter()` depends on a mounted App Router context. | Reads `AppRouterContext` and throws when it is `null`. |
| Browser App Router root | Legitimate client renders need the public router instance in context. | Wraps `BrowserRoot` route content in `AppRouterContext.Provider`. |
| SSR App Router root | Client components rendered during SSR should see the same mounted router context. | Wraps the SSR flight root in `AppRouterContext.Provider`. |
| Direct singleton consumers | `window.next.router` and low-level router tests are not hooks. | Keeps `appRouterInstance` exported and updates direct tests to use it directly. |

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| `useRouter()` outside `AppRouterContext` | Returned a usable no-context router singleton. | Throws `invariant expected app router to be mounted`. |
| `useRouter()` under vinext App Router browser root | Returned the singleton by bypassing context. | Returns the router instance provided by context. |
| `useRouter()` during App Router SSR | Returned the singleton by bypassing context. | Returns the router instance provided by context. |
| Direct navigation helper tests | Called a hook outside React to reach router methods. | Use `appRouterInstance` for non-hook method-level coverage. |

<details>
<summary>Maintainer review path</summary>

1. `packages/vinext/src/shims/navigation.ts` confirms the hook now follows the Next.js context invariant.
2. `packages/vinext/src/server/app-browser-entry.ts` confirms the client App Router tree provides the existing public router singleton.
3. `packages/vinext/src/server/app-ssr-entry.ts` confirms SSR of client components sees the same provider.
4. `tests/shims.test.ts` contains the focused regression coverage for missing and mounted context behavior.
5. `tests/prefetch-cache.test.ts` and `tests/router-javascript-urls.test.ts` show method-level tests no longer call a React hook outside React.

</details>

<details>
<summary>Validation</summary>

- `vp test run tests/shims.test.ts -t "useRouter\(\) throws when AppRouterContext is not mounted"` failed before the implementation because vinext did not throw.
- `vp test run tests/shims.test.ts -t "useRouter\(\) throws when AppRouterContext is not mounted|useRouter\(\) returns the mounted AppRouterContext router|router.refresh\(\) clears nav caches"`
- `vp test run tests/prefetch-cache.test.ts`
- `vp test run tests/router-javascript-urls.test.ts`
- `vp test run tests/shims.test.ts tests/prefetch-cache.test.ts tests/router-javascript-urls.test.ts`
- `vp check`
- `vp run vinext#build`

</details>

<details>
<summary>Risk / compatibility</summary>

- Public API: `useRouter()` now matches Next.js by throwing when used outside the App Router provider. This can expose previously hidden invalid usage.
- Runtime: browser and SSR App Router roots now mount `AppRouterContext.Provider` with the existing `appRouterInstance`.
- Compatibility: `appRouterInstance` remains exported for `window.next.router` and internal method-level tests.
- Build output: package build succeeds with the existing virtual-module externalization warnings.

</details>

<details>
<summary>Non-goals</summary>

- This does not implement Next.js contextual `bfcacheId` behavior from `LayoutRouterContext`. Vinext keeps the existing stable placeholder behavior.
- This does not change Pages Router `next/router` or `next/compat/router` semantics.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| [Next.js `useRouter()` source](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/navigation.ts) | Shows the `AppRouterContext` read and missing-provider invariant. |
| [Next.js App Router provider](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/app-router.tsx) | Shows `AppRouterContext.Provider` mounting the public app router instance around the route tree. |
| [Next.js app router context type](https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/app-router-context.shared-runtime.ts) | Defines the public App Router context shape used by `useRouter()`. |
| [Next.js hook behavior tests](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/hooks/hooks.test.ts) | Existing upstream coverage for normal `useRouter()` access and identity expectations. |
