### PR TITLE
fix(app-router): hydrate initial root in transition

### DIFF
--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -1,6 +1,6 @@
 /// <reference types="vite/client" />
 
-import { createElement, use, useLayoutEffect, useRef, useState } from "react";
+import { createElement, startTransition, use, useLayoutEffect, useRef, useState } from "react";
 import {
   createFromFetch,
   createFromReadableStream,
@@ -55,6 +55,7 @@ import {
 import {
   consumeInitialFormState,
   createVinextHydrateRootOptions,
+  hydrateRootInTransition,
 } from "./app-browser-hydration.js";
 import {
   AppElementsWire,
@@ -957,14 +958,16 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
         formState,
         onUncaughtError,
       });
-  window.__VINEXT_RSC_ROOT__ = hydrateRoot(
-    document,
-    createElement(BrowserRoot, {
+  window.__VINEXT_RSC_ROOT__ = hydrateRootInTransition({
+    children: createElement(BrowserRoot, {
       initialElements: root,
       initialNavigationSnapshot,
     }),
-    hydrateRootOptions,
-  );
+    container: document,
+    hydrateRoot,
+    options: hydrateRootOptions,
+    startTransition,
+  });
   window.__VINEXT_HYDRATED_AT = performance.now();
 
   // Exposed so the navigation shim's `router.refresh()` can invalidate the

--- a/packages/vinext/src/server/app-browser-hydration.ts
+++ b/packages/vinext/src/server/app-browser-hydration.ts
@@ -1,8 +1,13 @@
 import type { hydrateRoot, ReactFormState } from "react-dom/client";
 
 type HydrateRootOptions = NonNullable<Parameters<typeof hydrateRoot>[2]>;
+type HydrateRoot = typeof hydrateRoot;
+type HydrateRootContainer = Parameters<HydrateRoot>[0];
+type HydrateRootChildren = Parameters<HydrateRoot>[1];
+type HydrateRootReturn = ReturnType<HydrateRoot>;
 type HydrateRootCaughtErrorHandler = NonNullable<HydrateRootOptions["onCaughtError"]>;
 type HydrateRootUncaughtErrorHandler = NonNullable<HydrateRootOptions["onUncaughtError"]>;
+type StartTransition = (action: () => void) => void;
 
 export const RSC_FORM_STATE_GLOBAL = "__VINEXT_RSC_FORM_STATE__";
 
@@ -34,4 +39,24 @@ export function createVinextHydrateRootOptions(options: {
   }
 
   return hydrateOptions;
+}
+
+export function hydrateRootInTransition(options: {
+  children: HydrateRootChildren;
+  container: HydrateRootContainer;
+  hydrateRoot: HydrateRoot;
+  options: HydrateRootOptions;
+  startTransition: StartTransition;
+}): HydrateRootReturn {
+  let root: HydrateRootReturn | undefined;
+
+  options.startTransition(() => {
+    root = options.hydrateRoot(options.container, options.children, options.options);
+  });
+
+  if (root === undefined) {
+    throw new Error("[vinext] React.startTransition did not synchronously start hydration");
+  }
+
+  return root;
 }

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -6,6 +6,7 @@ import {
   RSC_FORM_STATE_GLOBAL,
   consumeInitialFormState,
   createVinextHydrateRootOptions,
+  hydrateRootInTransition,
 } from "../packages/vinext/src/server/app-browser-hydration.js";
 import { createAppBrowserNavigationController } from "../packages/vinext/src/server/app-browser-navigation-controller.js";
 import {
@@ -2843,6 +2844,34 @@ describe("createOnUncaughtError (hydrateRoot uncaught handler)", () => {
 });
 
 describe("app browser form-state hydration", () => {
+  it("schedules App Router hydrateRoot inside a transition", () => {
+    const container = { nodeType: 1 } as Element;
+    const root = { render: vi.fn(), unmount: vi.fn() };
+    const callOrder: string[] = [];
+    const hydrateRoot = vi.fn(() => {
+      callOrder.push("hydrateRoot");
+      return root;
+    });
+    const startTransition = vi.fn((action: () => void) => {
+      callOrder.push("transition:start");
+      action();
+      callOrder.push("transition:end");
+    });
+
+    const result = hydrateRootInTransition({
+      children: "root",
+      container,
+      hydrateRoot,
+      options: {},
+      startTransition,
+    });
+
+    expect(result).toBe(root);
+    expect(startTransition).toHaveBeenCalledTimes(1);
+    expect(hydrateRoot).toHaveBeenCalledWith(container, "root", {});
+    expect(callOrder).toEqual(["transition:start", "hydrateRoot", "transition:end"]);
+  });
+
   it("passes the one-shot form-state bootstrap payload to hydrateRoot options", () => {
     const formState = ["action-result", "key-path", "reference-id", 1] as never;
     const global = { [RSC_FORM_STATE_GLOBAL]: formState };


### PR DESCRIPTION
## Overview

| Field | Details |
| --- | --- |
| Goal | Match Next.js App Router hydration scheduling for the initial browser root. |
| Core change | Wrap the App Router `hydrateRoot` call in `React.startTransition` through a small typed helper. |
| Review focus | `packages/vinext/src/server/app-browser-hydration.ts`, then the call site in `app-browser-entry.ts`. |
| Expected impact | Initial App Router hydration is scheduled as non-urgent transition work, letting React prioritize urgent input during hydration. |

## Why

For App Router startup, vinext should follow the same scheduling contract as Next.js: the initial hydration tree is transition work, while urgent browser input remains urgent. vinext was calling `hydrateRoot` directly in the App Router browser entry, so the initial hydration path diverged from Next.js and ran outside the transition boundary.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| App Router hydration | Match Next.js browser-entry semantics where they are observable and practical. | Calls `hydrateRoot` from inside `startTransition`. |
| Pages Router parity | Do not generalize across routers when Next.js treats them differently. | Leaves Pages Router hydration unchanged. |
| Testability | Scheduler wiring should be proved without timing-sensitive browser benchmarks. | Adds a focused helper test that verifies call order. |

## What changed

| Surface | Before | After |
| --- | --- | --- |
| App Router initial hydration | Direct `hydrateRoot(document, ...)` call. | `hydrateRoot` runs inside the `startTransition` action and still returns the root synchronously. |
| Hydration helper | Form-state option construction only. | Adds a typed `hydrateRootInTransition` helper. |
| Regression coverage | No assertion that initial App Router hydration was scheduled as a transition. | `tests/app-browser-entry.test.ts` verifies `hydrateRoot` is invoked inside the transition callback. |

<details>
<summary>Validation</summary>

- `vp test run tests/app-browser-entry.test.ts`: 92 tests passed.
- `vp check`: formatting, lint, and type checks passed.
- Commit hook also ran checked-file formatting, lint/type checks, and `knip` successfully.

</details>

<details>
<summary>Risk and compatibility</summary>

- Public API: none.
- Config: none.
- Pages Router: intentionally unchanged because Next.js Pages Router does not wrap the initial `hydrateRoot` call in the same entry path.
- Runtime: App Router initial hydration now follows Next.js App Router transition scheduling. The helper preserves the existing synchronous root assignment contract for `window.__VINEXT_RSC_ROOT__`.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| [Next.js App Router wraps initial `hydrateRoot` in `React.startTransition`](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/app-index.tsx#L420-L424) | Source of the intended App Router startup behavior. |
| [Next.js Pages Router initial hydrate remains direct](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/index.tsx#L573-L582) | Confirms this should not be blindly applied to Pages Router hydration. |
| [React `startTransition` docs](https://react.dev/reference/react/startTransition) | Documents transition updates as non-blocking work. |
| [React `hydrateRoot` docs](https://react.dev/reference/react-dom/client/hydrateRoot) | Documents the startup hydration API being scheduled here. |