### PR TITLE
fix(navigation): support prefetch invalidation callbacks

### DIFF
--- a/packages/vinext/src/client/window-next.ts
+++ b/packages/vinext/src/client/window-next.ts
@@ -51,7 +51,7 @@ type AppRouterPublicInstance = {
   back: () => void;
   forward: () => void;
   refresh: () => void;
-  prefetch: (href: string) => void;
+  prefetch: (href: string, options?: { onInvalidate?: () => void }) => void;
   /** Default placeholder, matches Next.js. */
   bfcacheId?: string;
 };

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -21,8 +21,7 @@ import {
   getCurrentNextUrl,
   getCurrentInterceptionContext,
   getClientNavigationRenderContext,
-  getPrefetchCache,
-  getPrefetchedUrls,
+  invalidatePrefetchCache,
   pushHistoryStateWithoutNotify,
   replaceClientParamsWithoutNotify,
   replaceHistoryStateWithoutNotify,
@@ -215,8 +214,7 @@ function clearVisitedResponseCache(): void {
 }
 
 function clearPrefetchState(): void {
-  getPrefetchCache().clear();
-  getPrefetchedUrls().clear();
+  invalidatePrefetchCache();
 }
 
 function clearClientNavigationCaches(): void {

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -296,7 +296,14 @@ export type CachedRscResponse = {
   url: string;
 };
 
+export type PrefetchOptions = {
+  kind?: unknown;
+  onInvalidate?: () => void;
+};
+
 export type PrefetchCacheEntry = {
+  invalidationTimer?: ReturnType<typeof setTimeout>;
+  onInvalidateCallbacks?: Set<() => void>;
   outcome: "pending" | "cache-seeded";
   snapshot?: CachedRscResponse;
   pending?: Promise<void>;
@@ -353,20 +360,118 @@ function evictPrefetchCacheIfNeeded(): void {
 
   for (const [key, entry] of cache) {
     if (now - entry.timestamp >= PREFETCH_CACHE_TTL) {
-      cache.delete(key);
-      prefetched.delete(key);
+      deletePrefetchCacheEntry(cache, prefetched, key, entry, true);
     }
   }
 
   while (cache.size >= MAX_PREFETCH_CACHE_SIZE) {
     const oldest = cache.keys().next().value;
     if (oldest !== undefined) {
-      cache.delete(oldest);
-      prefetched.delete(oldest);
+      const entry = cache.get(oldest);
+      if (entry) {
+        deletePrefetchCacheEntry(cache, prefetched, oldest, entry, true);
+      } else {
+        cache.delete(oldest);
+        prefetched.delete(oldest);
+      }
     } else {
       break;
     }
   }
+}
+
+function clearPrefetchInvalidation(entry: PrefetchCacheEntry): void {
+  if (entry.invalidationTimer !== undefined) {
+    clearTimeout(entry.invalidationTimer);
+    entry.invalidationTimer = undefined;
+  }
+}
+
+function notifyPrefetchInvalidated(entry: PrefetchCacheEntry): void {
+  clearPrefetchInvalidation(entry);
+  const callbacks = entry.onInvalidateCallbacks;
+  entry.onInvalidateCallbacks = undefined;
+  if (callbacks === undefined) return;
+
+  for (const onInvalidate of callbacks) {
+    try {
+      onInvalidate();
+    } catch (error) {
+      if (typeof reportError === "function") {
+        reportError(error);
+      } else {
+        console.error(error);
+      }
+    }
+  }
+}
+
+function deletePrefetchCacheEntry(
+  cache: Map<string, PrefetchCacheEntry>,
+  prefetched: Set<string>,
+  cacheKey: string,
+  entry: PrefetchCacheEntry,
+  notify: boolean,
+): void {
+  cache.delete(cacheKey);
+  prefetched.delete(cacheKey);
+  if (notify) {
+    notifyPrefetchInvalidated(entry);
+  } else {
+    clearPrefetchInvalidation(entry);
+    entry.onInvalidateCallbacks = undefined;
+  }
+}
+
+function invalidatePrefetchCacheEntry(cacheKey: string): void {
+  const cache = getPrefetchCache();
+  const entry = cache.get(cacheKey);
+  if (!entry) return;
+  deletePrefetchCacheEntry(cache, getPrefetchedUrls(), cacheKey, entry, true);
+}
+
+function schedulePrefetchInvalidation(cacheKey: string, entry: PrefetchCacheEntry): void {
+  if (entry.onInvalidateCallbacks === undefined || entry.onInvalidateCallbacks.size === 0) return;
+
+  clearPrefetchInvalidation(entry);
+  const elapsed = Date.now() - entry.timestamp;
+  const delay = Math.max(0, PREFETCH_CACHE_TTL - elapsed);
+  entry.invalidationTimer = setTimeout(() => {
+    invalidatePrefetchCacheEntry(cacheKey);
+  }, delay);
+}
+
+function addPrefetchInvalidationCallback(
+  entry: PrefetchCacheEntry,
+  onInvalidate: (() => void) | undefined,
+): void {
+  if (onInvalidate === undefined) return;
+  if (entry.onInvalidateCallbacks === undefined) {
+    entry.onInvalidateCallbacks = new Set();
+  }
+  entry.onInvalidateCallbacks.add(onInvalidate);
+}
+
+function attachPrefetchInvalidationCallback(
+  cacheKey: string,
+  onInvalidate: (() => void) | undefined,
+): void {
+  if (onInvalidate === undefined) return;
+  const entry = getPrefetchCache().get(cacheKey);
+  if (!entry) return;
+  addPrefetchInvalidationCallback(entry, onInvalidate);
+  if (entry.outcome === "cache-seeded") {
+    schedulePrefetchInvalidation(cacheKey, entry);
+  }
+}
+
+export function invalidatePrefetchCache(): void {
+  const cache = getPrefetchCache();
+  const prefetched = getPrefetchedUrls();
+  for (const [cacheKey, entry] of cache) {
+    deletePrefetchCacheEntry(cache, prefetched, cacheKey, entry, true);
+  }
+  prefetched.clear();
 }
 
 /**
@@ -389,21 +494,27 @@ export function storePrefetchResponse(
   rscUrl: string,
   response: Response,
   interceptionContext: string | null = null,
+  options?: PrefetchOptions,
 ): void {
   const cacheKey = AppElementsWire.encodeCacheKey(rscUrl, interceptionContext);
   evictPrefetchCacheIfNeeded();
-  const entry: PrefetchCacheEntry = { outcome: "pending", timestamp: Date.now() };
+  const entry: PrefetchCacheEntry = {
+    outcome: "pending",
+    timestamp: Date.now(),
+  };
+  addPrefetchInvalidationCallback(entry, options?.onInvalidate);
   entry.pending = snapshotRscResponse(response)
     .then((snapshot) => {
       entry.snapshot = snapshot;
     })
     .catch(() => {
-      getPrefetchCache().delete(cacheKey);
+      deletePrefetchCacheEntry(getPrefetchCache(), getPrefetchedUrls(), cacheKey, entry, false);
     })
     .finally(() => {
       entry.pending = undefined;
       if (entry.snapshot) {
         entry.outcome = "cache-seeded";
+        schedulePrefetchInvalidation(cacheKey, entry);
       }
     });
   getPrefetchCache().set(cacheKey, entry);
@@ -477,13 +588,18 @@ export function prefetchRscResponse(
   fetchPromise: Promise<Response>,
   interceptionContext: string | null = null,
   mountedSlotsHeader: string | null = null,
+  options?: PrefetchOptions,
 ): void {
   const cacheKey = AppElementsWire.encodeCacheKey(rscUrl, interceptionContext);
   const cache = getPrefetchCache();
   const prefetched = getPrefetchedUrls();
   const now = Date.now();
 
-  const entry: PrefetchCacheEntry = { outcome: "pending", timestamp: now };
+  const entry: PrefetchCacheEntry = {
+    outcome: "pending",
+    timestamp: now,
+  };
+  addPrefetchInvalidationCallback(entry, options?.onInvalidate);
 
   entry.pending = fetchPromise
     .then(async (response) => {
@@ -495,18 +611,17 @@ export function prefetchRscResponse(
           mountedSlotsHeader,
         };
       } else {
-        prefetched.delete(cacheKey);
-        cache.delete(cacheKey);
+        deletePrefetchCacheEntry(cache, prefetched, cacheKey, entry, false);
       }
     })
     .catch(() => {
-      prefetched.delete(cacheKey);
-      cache.delete(cacheKey);
+      deletePrefetchCacheEntry(cache, prefetched, cacheKey, entry, false);
     })
     .finally(() => {
       entry.pending = undefined;
       if (entry.snapshot) {
         entry.outcome = "cache-seeded";
+        schedulePrefetchInvalidation(cacheKey, entry);
       }
     });
 
@@ -536,8 +651,7 @@ export function consumePrefetchResponse(
   // without a successful transition to a cache-seeded entry.
   if (entry.pending || entry.outcome !== "cache-seeded") return null;
 
-  cache.delete(cacheKey);
-  getPrefetchedUrls().delete(cacheKey);
+  deletePrefetchCacheEntry(cache, getPrefetchedUrls(), cacheKey, entry, false);
 
   if (entry.snapshot) {
     if ((entry.snapshot.mountedSlotsHeader ?? null) !== mountedSlotsHeader) {
@@ -1305,7 +1419,7 @@ const _appRouter = {
       React.startTransition(navigate);
     }
   },
-  prefetch(href: string): void {
+  prefetch(href: string, options?: PrefetchOptions): void {
     assertSafeNavigationUrl(href);
     if (isServer) return;
     void (async () => {
@@ -1332,7 +1446,10 @@ const _appRouter = {
       const rscUrl = await createRscRequestUrl(fullHref, headers);
       const cacheKey = AppElementsWire.encodeCacheKey(rscUrl, interceptionContext);
       const prefetched = getPrefetchedUrls();
-      if (prefetched.has(cacheKey)) return;
+      if (prefetched.has(cacheKey)) {
+        attachPrefetchInvalidationCallback(cacheKey, options?.onInvalidate);
+        return;
+      }
       prefetched.add(cacheKey);
       prefetchRscResponse(
         rscUrl,
@@ -1343,6 +1460,7 @@ const _appRouter = {
         }),
         interceptionContext,
         mountedSlotsHeader,
+        options,
       );
     })().catch((error) => {
       console.error("[vinext] RSC prefetch setup error:", error);

--- a/packages/vinext/src/shims/next-shims.d.ts
+++ b/packages/vinext/src/shims/next-shims.d.ts
@@ -136,7 +136,7 @@ declare module "next/navigation" {
     back(): void;
     forward(): void;
     refresh(): void;
-    prefetch(href: string): void;
+    prefetch(href: string, options?: { onInvalidate?: () => void }): void;
   };
   export function usePathname(): string;
   export class ReadonlyURLSearchParams extends URLSearchParams {
@@ -202,6 +202,8 @@ declare module "next/navigation" {
     url: string;
   };
   export type PrefetchCacheEntry = {
+    invalidationTimer?: ReturnType<typeof setTimeout>;
+    onInvalidateCallbacks?: Set<() => void>;
     outcome: "pending" | "cache-seeded";
     snapshot?: CachedRscResponse;
     pending?: Promise<void>;
@@ -211,10 +213,12 @@ declare module "next/navigation" {
   export const PREFETCH_CACHE_TTL: number;
   export function getPrefetchCache(): Map<string, PrefetchCacheEntry>;
   export function getPrefetchedUrls(): Set<string>;
+  export function invalidatePrefetchCache(): void;
   export function storePrefetchResponse(
     rscUrl: string,
     response: Response,
     interceptionContext?: string | null,
+    options?: { onInvalidate?: () => void },
   ): void;
   export function snapshotRscResponse(response: Response): Promise<CachedRscResponse>;
   export function restoreRscResponse(cached: CachedRscResponse, copy?: boolean): Response;

--- a/tests/prefetch-cache.test.ts
+++ b/tests/prefetch-cache.test.ts
@@ -23,6 +23,7 @@ let MAX_PREFETCH_CACHE_SIZE: Navigation["MAX_PREFETCH_CACHE_SIZE"];
 let PREFETCH_CACHE_TTL: Navigation["PREFETCH_CACHE_TTL"];
 let snapshotRscResponse: Navigation["snapshotRscResponse"];
 let restoreRscResponse: Navigation["restoreRscResponse"];
+let invalidatePrefetchCache: Navigation["invalidatePrefetchCache"];
 let useRouter: Navigation["useRouter"];
 
 beforeEach(async () => {
@@ -52,6 +53,7 @@ beforeEach(async () => {
   PREFETCH_CACHE_TTL = nav.PREFETCH_CACHE_TTL;
   snapshotRscResponse = nav.snapshotRscResponse;
   restoreRscResponse = nav.restoreRscResponse;
+  invalidatePrefetchCache = nav.invalidatePrefetchCache;
   useRouter = nav.useRouter;
 });
 
@@ -121,6 +123,55 @@ describe("prefetch cache eviction", () => {
     expect(getPrefetchedUrls().has(AppElementsWire.encodeCacheKey(String(fetchedUrl), "/"))).toBe(
       true,
     );
+  });
+
+  it("router.prefetch calls onInvalidate once when the prefetched response is invalidated", async () => {
+    let fetchedUrl: unknown;
+    const fetch = vi.fn(async (input: RequestInfo | URL) => {
+      fetchedUrl = input;
+      return new Response("flight", { headers: { "content-type": "text/x-component" } });
+    });
+    const onInvalidate = vi.fn();
+    (globalThis as any).fetch = fetch;
+
+    useRouter().prefetch("/dashboard", { onInvalidate });
+    await waitForPrefetchSetup(() => getPrefetchCache().size > 0);
+
+    const cacheKey = AppElementsWire.encodeCacheKey(String(fetchedUrl), "/");
+    expect(getPrefetchedUrls().has(cacheKey)).toBe(true);
+
+    invalidatePrefetchCache();
+
+    expect(onInvalidate).toHaveBeenCalledTimes(1);
+    expect(getPrefetchedUrls().has(cacheKey)).toBe(false);
+    expect(getPrefetchCache().has(cacheKey)).toBe(false);
+
+    invalidatePrefetchCache();
+    expect(onInvalidate).toHaveBeenCalledTimes(1);
+  });
+
+  it("router.prefetch preserves onInvalidate callbacks attached to an already-prefetched URL", async () => {
+    const fetch = vi.fn(
+      async () => new Response("flight", { headers: { "content-type": "text/x-component" } }),
+    );
+    const firstInvalidate = vi.fn();
+    const secondInvalidate = vi.fn();
+    (globalThis as any).fetch = fetch;
+
+    useRouter().prefetch("/dashboard", { onInvalidate: firstInvalidate });
+    await waitForPrefetchSetup(() => getPrefetchCache().size > 0);
+    useRouter().prefetch("/dashboard", { onInvalidate: secondInvalidate });
+    await waitForPrefetchSetup(() => {
+      const entry = getPrefetchCache().values().next().value;
+      return entry?.onInvalidateCallbacks?.size === 2;
+    });
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+
+    invalidatePrefetchCache();
+
+    expect(firstInvalidate).toHaveBeenCalledTimes(1);
+    expect(secondInvalidate).toHaveBeenCalledTimes(1);
   });
 
   it("reuses a prefetched response only when mounted-slot context matches", () => {


### PR DESCRIPTION
## Overview

| Field | Detail |
| --- | --- |
| Goal | Match Next.js `router.prefetch(href, { onInvalidate })` compatibility for App Router callers. |
| Core change | Store invalidation callbacks on vinext RSC prefetch cache entries and notify them once when entries are invalidated or expire. |
| Main boundary | `next/navigation` public router surface and the in-memory App Router prefetch cache. |
| Primary files | `packages/vinext/src/shims/navigation.ts`, `packages/vinext/src/server/app-browser-entry.ts`, `tests/prefetch-cache.test.ts` |
| Expected impact | Custom prefetch polling patterns can compile and observe stale prefetch invalidation without extra network prefetches. |

## Why

The App Router prefetch API must preserve the caller's stale-data notification callback through the same cache lifecycle that owns the prefetched RSC payload. Vinext accepted only `href`, so `onInvalidate` was both rejected by the public shim type and ignored by the runtime.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| Public API | `next/navigation` should accept documented App Router prefetch options. | Adds the optional `onInvalidate` parameter to the public router types and `window.next.router` surface. |
| Cache lifecycle | The owner that invalidates a prefetched entry owns its notification and cleanup. | Routes refresh/cache clear, TTL expiry, and capacity eviction through one invalidating removal path. |
| Duplicate prefetches | Deduping the fetch must not drop listener intent. | Deduped prefetch calls attach additional callbacks to the existing cache entry without firing another request. |

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| `router.prefetch('/x', { onInvalidate })` | Type surface only accepted `href`; runtime ignored the callback. | Callback is accepted, stored, and invoked once when the prefetched entry is invalidated or expires. |
| Multiple callers prefetch the same URL | Second call deduped and had no observable callback path. | Second call attaches its listener to the existing cache entry. |
| `router.refresh()` clears prefetch state | Cache entries were cleared silently. | Prefetch invalidation callbacks are notified through the same cache clear. |
| Navigation consumes a prefetched response | Entry was removed. | Entry is still removed silently, because consuming fresh prefetched data is not stale invalidation. |

<details>
<summary>Maintainer review path</summary>

1. `packages/vinext/src/shims/navigation.ts` for the cache-entry listener model, invalidation cleanup, and router prefetch option plumbing.
2. `packages/vinext/src/server/app-browser-entry.ts` for the browser cache-clear path now using `invalidatePrefetchCache()`.
3. `tests/prefetch-cache.test.ts` for focused coverage of callback notification and deduped listener attachment.
4. `packages/vinext/src/shims/next-shims.d.ts` and `packages/vinext/src/client/window-next.ts` for public type-surface parity.

</details>

<details>
<summary>Validation</summary>

- `vp test run tests/prefetch-cache.test.ts tests/shims.test.ts`
- `vp check`
- Commit hook also ran formatting, lint/type checks, and `knip`.

</details>

<details>
<summary>Risk / compatibility</summary>

- Public API impact: additive support for the documented optional prefetch callback.
- Runtime impact: at most one timer per prefetched entry that has listeners, bounded by the existing max prefetch cache size.
- Existing-app risk: normal prefetch and navigation consumption paths keep working; failed prefetches still clear silently rather than reporting false stale-data invalidation.
- Intentional limitation: `kind` is accepted by the internal `PrefetchOptions` shape for compatibility, but vinext does not implement Next's segment-cache fetch strategies yet.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| [Next.js `AppRouterInstance.prefetch` type](https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/app-router-context.shared-runtime.ts#L28-L64) | Shows the App Router instance accepts `PrefetchOptions`. |
| [Next.js public app router instance](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/app-router-instance.ts#L399-L437) | Shows `router.prefetch` forwards `options?.onInvalidate`. |
| [Next.js segment-cache invalidation listener](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/segment-cache/cache.ts#L392-L424) | Shows callback notification is at-most-once and user callbacks are error-isolated. |
| [Next.js manual prefetch revalidation E2E](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/segment-cache/revalidation/segment-cache-revalidation.test.ts#L173-L231) | Demonstrates the custom polling pattern using `router.prefetch(..., { onInvalidate })`. |
| [Next.js useRouter docs](https://github.com/vercel/next.js/blob/canary/docs/01-app/03-api-reference/04-functions/use-router.mdx#L47-L57) | Documents the public `onInvalidate` behavior and at-most-once callback semantics. |