### PR TITLE
fix(rsc): preserve binary inlined Flight chunks

### DIFF
--- a/packages/vinext/src/build/prerender.ts
+++ b/packages/vinext/src/build/prerender.ts
@@ -25,6 +25,12 @@ import type { AppRoute } from "../routing/app-router.js";
 import type { ResolvedNextConfig } from "../config/next-config.js";
 import { classifyPagesRoute, classifyAppRoute, getAppRouteRenderEntryPath } from "./report.js";
 import {
+  concatUint8Arrays,
+  decodeRscEmbeddedChunk,
+  RSC_EMBEDDED_BINARY_CHUNK,
+  type RscEmbeddedChunk,
+} from "../server/app-rsc-embedded-chunks.js";
+import {
   NoOpCacheHandler,
   setCacheHandler,
   getCacheHandler,
@@ -202,9 +208,9 @@ const RSC_CHUNK_FULL_PREFIX = `${RSC_CHUNK_SCRIPT_PREFIX}self.__VINEXT_RSC_CHUNK
  * Safe regex usage: safeJsonStringify (used by createRscEmbedTransform) escapes
  * all '<' and '>' in the embedded JSON, preventing false </script> matches.
  */
-export function extractRscPayloadFromPrerenderedHtml(html: string): string | null {
+export function extractRscPayloadFromPrerenderedHtml(html: string): Uint8Array | null {
   const scriptPattern = /<script(?:\s[^>]*)?>([\s\S]*?)<\/script>/gi;
-  const chunks: string[] = [];
+  const chunks: Uint8Array[] = [];
   let sawDone = false;
   let match: RegExpExecArray | null;
 
@@ -217,7 +223,7 @@ export function extractRscPayloadFromPrerenderedHtml(html: string): string | nul
     }
 
     if (script.startsWith(RSC_CHUNK_SCRIPT_PREFIX)) {
-      chunks.push(parseRscChunkPushArgument(script));
+      chunks.push(decodeRscEmbeddedChunk(parseRscChunkPushArgument(script)));
     }
   }
 
@@ -235,17 +241,17 @@ export function extractRscPayloadFromPrerenderedHtml(html: string): string | nul
     throw new Error("[vinext] Malformed prerender RSC embed: missing __VINEXT_RSC_DONE__ marker");
   }
 
-  return chunks.join("");
+  return concatUint8Arrays(chunks);
 }
 
 /**
- * Parse the JSON-string argument of a single chunk-push script. The script
+ * Parse the JSON argument of a single chunk-push script. The script
  * shape is exactly `<prefix>(<safeJsonStringify(chunk)>)` because the writer
  * concatenates those literals — so the body always starts with the full
  * prefix and ends with `)`. JSON.parse on the slice catches any tampering or
  * trailing code.
  */
-function parseRscChunkPushArgument(script: string): string {
+function parseRscChunkPushArgument(script: string): RscEmbeddedChunk {
   if (!script.startsWith(RSC_CHUNK_FULL_PREFIX) || !script.endsWith(")")) {
     throw new Error("[vinext] Malformed prerender RSC embed: unexpected chunk script shape");
   }
@@ -256,10 +262,18 @@ function parseRscChunkPushArgument(script: string): string {
   } catch {
     throw new Error("[vinext] Malformed prerender RSC embed: invalid chunk JSON");
   }
-  if (typeof parsed !== "string") {
-    throw new Error("[vinext] Malformed prerender RSC embed: chunk payload is not a string");
+  if (typeof parsed === "string") {
+    return parsed;
   }
-  return parsed;
+  if (
+    Array.isArray(parsed) &&
+    parsed.length === 2 &&
+    parsed[0] === RSC_EMBEDDED_BINARY_CHUNK &&
+    typeof parsed[1] === "string"
+  ) {
+    return [parsed[0], parsed[1]];
+  }
+  throw new Error("[vinext] Malformed prerender RSC embed: unsupported chunk payload");
 }
 
 /**
@@ -1235,7 +1249,7 @@ export async function prerenderApp({
               `[vinext] prerenderApp: RSC fallback returned ${rscRes.status} for ${urlPath}`,
             );
           }
-          rscData = await rscRes.text();
+          rscData = new Uint8Array(await rscRes.arrayBuffer());
         }
 
         const outputFiles: string[] = [];
@@ -1251,7 +1265,7 @@ export async function prerenderApp({
         const rscOutputPath = getRscOutputPath(urlPath);
         const rscFullPath = path.join(outDir, rscOutputPath);
         fs.mkdirSync(path.dirname(rscFullPath), { recursive: true });
-        fs.writeFileSync(rscFullPath, rscData, "utf-8");
+        fs.writeFileSync(rscFullPath, rscData);
         outputFiles.push(rscOutputPath);
 
         const renderedCacheControl = resolveRenderedCacheControl(

--- a/packages/vinext/src/global.d.ts
+++ b/packages/vinext/src/global.d.ts
@@ -155,14 +155,16 @@ declare global {
   // compatibility with Web Workers (where `window` is undefined).
 
   /**
-   * Array of RSC Flight protocol text chunks streamed progressively by the
-   * server via inline `<script>` tags.
+   * Array of RSC Flight protocol chunks streamed progressively by the server
+   * via inline `<script>` tags. Text chunks are stored directly; non-UTF-8
+   * chunks are stored as `[3, base64]` binary chunks, matching Next.js'
+   * inlined Flight payload kind.
    * Each `<script>` calls `self.__VINEXT_RSC_CHUNKS__.push(chunk)`.
    * The browser RSC entry monkey-patches this array's `push` method to feed a
    * `ReadableStream` that is consumed by `react-server-dom-webpack`.
    */
   // oxlint-disable-next-line no-var
-  var __VINEXT_RSC_CHUNKS__: string[] | undefined;
+  var __VINEXT_RSC_CHUNKS__: (string | [3, string])[] | undefined;
 
   /**
    * Set to `true` by a final inline `<script>` when the server has finished
@@ -202,7 +204,9 @@ declare global {
    *   `__VINEXT_RSC_PARAMS__` instead.
    */
   // oxlint-disable-next-line no-var
-  var __VINEXT_RSC__: { rsc: string[]; params: Record<string, string | string[]> } | undefined;
+  var __VINEXT_RSC__:
+    | { rsc: (string | [3, string])[]; params: Record<string, string | string[]> }
+    | undefined;
 
   // ── globalThis globals — server-side / Cloudflare Workers ─────────────────
   //

--- a/packages/vinext/src/server/app-browser-stream.ts
+++ b/packages/vinext/src/server/app-browser-stream.ts
@@ -1,5 +1,6 @@
 import type { ReactFormState } from "react-dom/client";
 import { RSC_FORM_STATE_GLOBAL } from "./app-browser-hydration.js";
+import { decodeRscEmbeddedChunk, type RscEmbeddedChunk } from "./app-rsc-embedded-chunks.js";
 
 type NavigationSnapshot = {
   pathname: string;
@@ -7,14 +8,14 @@ type NavigationSnapshot = {
 };
 
 type LegacyRscEmbedData = {
-  rsc: string[];
+  rsc: RscEmbeddedChunk[];
   params?: Record<string, string | string[]>;
   nav?: NavigationSnapshot;
 };
 
 type VinextBrowserGlobals = {
   __VINEXT_RSC__?: LegacyRscEmbedData;
-  __VINEXT_RSC_CHUNKS__?: string[];
+  __VINEXT_RSC_CHUNKS__?: RscEmbeddedChunk[];
   __VINEXT_RSC_DONE__?: boolean;
   [RSC_FORM_STATE_GLOBAL]?: ReactFormState;
   __VINEXT_RSC_PARAMS__?: Record<string, string | string[]>;
@@ -32,14 +33,15 @@ function createUnexpectedRscStreamCloseError(): Error {
 }
 
 /**
- * Convert embedded text chunks back to a ReadableStream of Uint8Array chunks.
+ * Convert embedded chunks back to a ReadableStream of Uint8Array chunks.
  */
-export function chunksToReadableStream(chunks: readonly string[]): ReadableStream<Uint8Array> {
-  const encoder = new TextEncoder();
+export function chunksToReadableStream(
+  chunks: readonly RscEmbeddedChunk[],
+): ReadableStream<Uint8Array> {
   return new ReadableStream<Uint8Array>({
     start(controller) {
       for (const chunk of chunks) {
-        controller.enqueue(encoder.encode(chunk));
+        controller.enqueue(decodeRscEmbeddedChunk(chunk));
       }
       controller.close();
     },
@@ -54,15 +56,13 @@ export function chunksToReadableStream(chunks: readonly string[]): ReadableStrea
  * instead of polling with setTimeout.
  */
 export function createProgressiveRscStream(): ReadableStream<Uint8Array> {
-  const encoder = new TextEncoder();
-
   return new ReadableStream<Uint8Array>({
     start(controller) {
       const vinext = getVinextBrowserGlobal();
       const initialChunks = vinext.__VINEXT_RSC_CHUNKS__ ?? [];
 
       for (const chunk of initialChunks) {
-        controller.enqueue(encoder.encode(chunk));
+        controller.enqueue(decodeRscEmbeddedChunk(chunk));
       }
 
       if (vinext.__VINEXT_RSC_DONE__) {
@@ -93,13 +93,13 @@ export function createProgressiveRscStream(): ReadableStream<Uint8Array> {
       };
 
       const arr = (vinext.__VINEXT_RSC_CHUNKS__ ??= []);
-      arr.push = function (...chunks: string[]): number {
+      arr.push = function (...chunks: RscEmbeddedChunk[]): number {
         const length = Array.prototype.push.apply(this, chunks);
 
         if (closed) return length;
 
         for (const chunk of chunks) {
-          controller.enqueue(encoder.encode(chunk));
+          controller.enqueue(decodeRscEmbeddedChunk(chunk));
         }
 
         if (vinext.__VINEXT_RSC_DONE__) {

--- a/packages/vinext/src/server/app-rsc-embedded-chunks.ts
+++ b/packages/vinext/src/server/app-rsc-embedded-chunks.ts
@@ -1,0 +1,44 @@
+export const RSC_EMBEDDED_BINARY_CHUNK = 3;
+
+export type RscEmbeddedChunk = string | [typeof RSC_EMBEDDED_BINARY_CHUNK, string];
+
+const BASE64_CHUNK_SIZE = 0x8000;
+const textEncoder = new TextEncoder();
+
+export function bytesToBase64(bytes: Uint8Array): string {
+  let binary = "";
+  for (let offset = 0; offset < bytes.byteLength; offset += BASE64_CHUNK_SIZE) {
+    binary += String.fromCharCode(...bytes.subarray(offset, offset + BASE64_CHUNK_SIZE));
+  }
+  return btoa(binary);
+}
+
+function base64ToBytes(base64: string): Uint8Array {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index++) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return bytes;
+}
+
+export function decodeRscEmbeddedChunk(chunk: RscEmbeddedChunk): Uint8Array {
+  if (typeof chunk === "string") {
+    return textEncoder.encode(chunk);
+  }
+  return base64ToBytes(chunk[1]);
+}
+
+export function concatUint8Arrays(chunks: readonly Uint8Array[]): Uint8Array<ArrayBuffer> {
+  let totalLength = 0;
+  for (const chunk of chunks) {
+    totalLength += chunk.byteLength;
+  }
+  const result = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const chunk of chunks) {
+    result.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return result;
+}

--- a/packages/vinext/src/server/app-ssr-stream.ts
+++ b/packages/vinext/src/server/app-ssr-stream.ts
@@ -1,4 +1,10 @@
 import { createInlineScriptTag, safeJsonStringify } from "./html.js";
+import {
+  bytesToBase64,
+  concatUint8Arrays,
+  RSC_EMBEDDED_BINARY_CHUNK,
+  type RscEmbeddedChunk,
+} from "./app-rsc-embedded-chunks.js";
 
 type RscEmbedTransform = {
   flush(): string;
@@ -20,15 +26,14 @@ export function fixFlightHints(text: string): string {
 
 /**
  * Create a helper that progressively embeds RSC chunks as inline <script> tags.
- * The browser entry turns the embedded text chunks back into Uint8Array data.
+ * The browser entry turns the embedded chunks back into Uint8Array data.
  */
 export function createRscEmbedTransform(
   embedStream: ReadableStream<Uint8Array>,
   scriptNonce?: string,
 ): RscEmbedTransform {
   const reader = embedStream.getReader();
-  const decoder = new TextDecoder();
-  let pendingChunks: string[] = [];
+  let pendingChunks: RscEmbeddedChunk[] = [];
   const rawChunks: Uint8Array[] = [];
   let reading = false;
 
@@ -42,11 +47,16 @@ export function createRscEmbedTransform(
         // Accumulate raw bytes BEFORE fixFlightHints so the cache stores
         // unmodified RSC data. The embed script path below applies fixes.
         rawChunks.push(result.value);
-        const text = decoder.decode(result.value, { stream: true });
-        // The RSC entry already fixes HL hints at the source. Keep this second
-        // pass as defense in depth for any embed stream that bypasses that
-        // wrapper; the rewrite is idempotent, so double-application is safe.
-        pendingChunks.push(fixFlightHints(text));
+        try {
+          const decoder = new TextDecoder("utf-8", { fatal: true });
+          const text = decoder.decode(result.value);
+          // The RSC entry already fixes HL hints at the source. Keep this second
+          // pass as defense in depth for any embed stream that bypasses that
+          // wrapper; the rewrite is idempotent, so double-application is safe.
+          pendingChunks.push(fixFlightHints(text));
+        } catch {
+          pendingChunks.push([RSC_EMBEDDED_BINARY_CHUNK, bytesToBase64(result.value)]);
+        }
       }
     } catch (error) {
       if (process.env.NODE_ENV !== "production") {
@@ -88,16 +98,7 @@ export function createRscEmbedTransform(
 
     async getRawBuffer(): Promise<ArrayBuffer> {
       await pumpPromise;
-      let totalLength = 0;
-      for (const chunk of rawChunks) {
-        totalLength += chunk.byteLength;
-      }
-      const buffer = new Uint8Array(totalLength);
-      let offset = 0;
-      for (const chunk of rawChunks) {
-        buffer.set(chunk, offset);
-        offset += chunk.byteLength;
-      }
+      const buffer = concatUint8Arrays(rawChunks);
       rawChunks.length = 0;
       return buffer.buffer;
     },

--- a/tests/app-browser-stream.test.ts
+++ b/tests/app-browser-stream.test.ts
@@ -39,6 +39,16 @@ async function readText(
   };
 }
 
+async function readBytes(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+): Promise<{ done: boolean; bytes?: number[] }> {
+  const result = await reader.read();
+  return {
+    done: result.done,
+    bytes: result.value ? Array.from(result.value) : undefined,
+  };
+}
+
 describe("App browser stream helpers", () => {
   beforeEach(() => {
     resetBrowserGlobals();
@@ -56,6 +66,16 @@ describe("App browser stream helpers", () => {
     expect(await readText(reader)).toEqual({ done: false, text: "alpha" });
     expect(await readText(reader)).toEqual({ done: false, text: "beta" });
     expect(await readText(reader)).toEqual({ done: true, text: undefined });
+  });
+
+  it("turns embedded binary chunks into exact readable bytes", async () => {
+    // Ported from Next.js: test/e2e/app-dir/binary/rsc-binary.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/binary/rsc-binary.test.ts
+    const reader = chunksToReadableStream(["text", [3, "/wABAgM="]]).getReader();
+
+    expect(await readText(reader)).toEqual({ done: false, text: "text" });
+    expect(await readBytes(reader)).toEqual({ done: false, bytes: [255, 0, 1, 2, 3] });
+    expect(await readBytes(reader)).toEqual({ done: true, bytes: undefined });
   });
 
   it("replays existing chunks and streams future pushes immediately", async () => {
@@ -106,6 +126,29 @@ describe("App browser stream helpers", () => {
     vinext.__VINEXT_RSC_CHUNKS__!.push("omega");
     expect(await readText(reader)).toEqual({ done: false, text: "omega" });
     expect(await readText(reader)).toEqual({ done: true, text: undefined });
+  });
+
+  it("streams progressive binary chunks without UTF-8 replacement", async () => {
+    // Ported from Next.js: test/e2e/app-dir/binary/rsc-binary.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/binary/rsc-binary.test.ts
+    setGlobalDocument({
+      readyState: "loading",
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    } as unknown as Document);
+
+    vinext.__VINEXT_RSC_CHUNKS__ = [];
+    vinext.__VINEXT_RSC_DONE__ = false;
+
+    const reader = createProgressiveRscStream().getReader();
+
+    vinext.__VINEXT_RSC_CHUNKS__!.push([3, "/wABAgM="]);
+    expect(await readBytes(reader)).toEqual({ done: false, bytes: [255, 0, 1, 2, 3] });
+
+    vinext.__VINEXT_RSC_DONE__ = true;
+    vinext.__VINEXT_RSC_CHUNKS__!.push("final");
+    expect(await readText(reader)).toEqual({ done: false, text: "final" });
+    expect(await readBytes(reader)).toEqual({ done: true, bytes: undefined });
   });
 
   it("errors truncated streams on DOMContentLoaded before the done marker", async () => {

--- a/tests/app-ssr-stream.test.ts
+++ b/tests/app-ssr-stream.test.ts
@@ -84,6 +84,17 @@ function createTextStream(chunks: string[]): ReadableStream<Uint8Array> {
   });
 }
 
+function createByteStream(chunks: Uint8Array[]): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(chunk);
+      }
+      controller.close();
+    },
+  });
+}
+
 describe("createRscEmbedTransform raw buffer (#981)", () => {
   it("accumulates raw bytes while producing embed scripts", async () => {
     const sideStream = createTextStream(["chunk1", "chunk2"]);
@@ -128,5 +139,28 @@ describe("createRscEmbedTransform raw buffer (#981)", () => {
     // fixFlightHints turns "stylesheet" → "style" before the chunk is script-wrapped.
     expect(finalScripts).not.toContain("stylesheet");
     expect(finalScripts).toContain("__VINEXT_RSC_DONE__");
+  });
+
+  it("embeds non-UTF-8 RSC chunks as base64 binary chunks", async () => {
+    // Ported from Next.js: test/e2e/app-dir/binary/rsc-binary.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/binary/rsc-binary.test.ts
+    const transform = createRscEmbedTransform(
+      createByteStream([new Uint8Array([0xff, 0, 1, 2, 3])]),
+    );
+
+    const finalScripts = await transform.finalize();
+
+    expect(finalScripts).toContain('self.__VINEXT_RSC_CHUNKS__.push([3,"/wABAgM="])');
+  });
+
+  it("does not lose incomplete UTF-8 bytes before a binary chunk", async () => {
+    const transform = createRscEmbedTransform(
+      createByteStream([new Uint8Array([0x41, 0xc3]), new Uint8Array([0xff])]),
+    );
+
+    const finalScripts = await transform.finalize();
+
+    expect(finalScripts).toContain('self.__VINEXT_RSC_CHUNKS__.push([3,"QcM="])');
+    expect(finalScripts).toContain('self.__VINEXT_RSC_CHUNKS__.push([3,"/w=="])');
   });
 });

--- a/tests/prerender.test.ts
+++ b/tests/prerender.test.ts
@@ -66,6 +66,11 @@ function closeServer(server: Server): Promise<void> {
 // ─── App Router RSC payload extraction ───────────────────────────────────────
 
 describe("extractRscPayloadFromPrerenderedHtml", () => {
+  function decodeExtractedPayload(html: string): string | null {
+    const payload = extractRscPayloadFromPrerenderedHtml(html);
+    return payload === null ? null : new TextDecoder().decode(payload);
+  }
+
   it("reconstructs streamed RSC chunks from inline bootstrap scripts", () => {
     const chunks = [
       '0:D{"name":"layout"}\n',
@@ -84,7 +89,24 @@ describe("extractRscPayloadFromPrerenderedHtml", () => {
       "<script>self.__VINEXT_RSC_DONE__=true</script>" +
       "</body></html>";
 
-    expect(extractRscPayloadFromPrerenderedHtml(html)).toBe(chunks.join(""));
+    expect(decodeExtractedPayload(html)).toBe(chunks.join(""));
+  });
+
+  it("reconstructs binary RSC chunks from inline bootstrap scripts", () => {
+    // Ported from Next.js: test/e2e/app-dir/binary/rsc-binary.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/binary/rsc-binary.test.ts
+    const html =
+      "<html><body>" +
+      `<script>self.__VINEXT_RSC_CHUNKS__=self.__VINEXT_RSC_CHUNKS__||[];self.__VINEXT_RSC_CHUNKS__.push(${safeJsonStringify("0:text\n")})</script>` +
+      '<script>self.__VINEXT_RSC_CHUNKS__=self.__VINEXT_RSC_CHUNKS__||[];self.__VINEXT_RSC_CHUNKS__.push([3,"/wABAgM="])</script>' +
+      "<script>self.__VINEXT_RSC_DONE__=true</script>" +
+      "</body></html>";
+
+    const payload = extractRscPayloadFromPrerenderedHtml(html);
+
+    expect(payload).toEqual(
+      new Uint8Array([...new TextEncoder().encode("0:text\n"), 255, 0, 1, 2, 3]),
+    );
   });
 
   it("throws when the done marker is missing", () => {


### PR DESCRIPTION
## Overview

| Field | Details |
| --- | --- |
| Goal | Preserve arbitrary binary RSC Flight bytes when App Router payloads are inlined into HTML. |
| Core change | Encode non-UTF-8 embedded RSC chunks as `[3, base64]` records and decode them back to `Uint8Array` before React consumes the stream. |
| Boundary | SSR HTML embedding, browser hydration stream reconstruction, and prerender `.rsc` extraction. |
| Primary files | `app-ssr-stream.ts`, `app-browser-stream.ts`, `app-rsc-embedded-chunks.ts`, `prerender.ts`. |
| Expected impact | Client components can receive binary values from server components without hydration stream corruption. |

## Why

The inlined Flight transport must be byte preserving. React Flight can serialize binary values, and Next.js treats inlined non-UTF-8 chunks as binary payloads rather than forcing them through UTF-8 text. vinext currently decodes every embedded chunk as text, which turns arbitrary bytes such as `0xff` into replacement characters before the browser reconstructs the stream.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| SSR embed | Inlined Flight chunks must preserve the original byte sequence. | Falls back to base64 binary records when a chunk is not valid UTF-8. |
| Browser hydration | React must receive the same bytes the server emitted. | Decodes binary records directly to `Uint8Array` instead of `TextEncoder` output. |
| Prerender output | Static `.rsc` files are byte payloads, not UTF-8 text files. | Reconstructs extracted and fallback RSC payloads as bytes and writes them without an encoding. |

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| Valid UTF-8 Flight chunk | Embedded as a string chunk. | Same behavior. |
| Non-UTF-8 Flight chunk | Decoded to text with replacement characters and re-encoded incorrectly. | Embedded as `[3, base64]` and decoded back to exact bytes. |
| Prerendered App Router `.rsc` payload | Extracted and written through UTF-8 strings. | Extracted and written as `Uint8Array` bytes. |

<details>
<summary>Maintainer review path</summary>

1. `packages/vinext/src/server/app-rsc-embedded-chunks.ts` defines the shared embedded chunk shape and base64 conversion.
2. `packages/vinext/src/server/app-ssr-stream.ts` decides whether each streamed RSC chunk can be embedded as UTF-8 text or must be encoded as binary.
3. `packages/vinext/src/server/app-browser-stream.ts` reconstructs embedded text and binary chunks into the `ReadableStream<Uint8Array>` consumed by React.
4. `packages/vinext/src/build/prerender.ts` keeps prerendered `.rsc` output byte preserving when extracting from HTML or falling back to an RSC request.
5. The three test files cover the server embed, browser decode, and prerender extraction boundaries.

</details>

<details>
<summary>Validation</summary>

- `vp test run tests/app-browser-stream.test.ts tests/app-ssr-stream.test.ts tests/prerender.test.ts`
- `vp check`
- Commit hook: `vp check --fix` plus `knip --no-progress`

</details>

<details>
<summary>Risk / compatibility</summary>

- Existing text chunk payloads stay valid and use the same string representation.
- The new `[3, base64]` record mirrors Next.js' inlined Flight binary payload kind.
- The legacy `__VINEXT_RSC__` shape is widened to accept binary records but remains compatible with existing `string[]` payloads.
- This does not change direct `text/x-component` fetch responses, only the HTML-inlined hydration and prerender extraction path.

</details>

<details>
<summary>Non-goals</summary>

- This does not add a full browser e2e fixture for binary client props. The regression is covered at the lower stream transport boundaries that caused the corruption.
- This does not change the existing Flight hint rewrite behavior for valid text chunks.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| [Next.js client inline Flight decoder](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/app-index.tsx#L50-L104) | Shows the `[3, base64]` binary segment shape and browser-side `Uint8Array` reconstruction. |
| [Next.js server inline Flight writer](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/use-flight-response.tsx#L175-L271) | Shows the server deciding between UTF-8 text chunks and base64 binary chunks. |
| [Next.js Node inline Flight writer](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/stream-ops.node.ts#L950-L1022) | Shows the same binary payload kind in the Node stream path. |
| [Next.js binary RSC e2e test](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/binary/rsc-binary.test.ts) | Confirms binary values should survive RSC serialization and hydration. |
