### PR TITLE
fix(app-router): model RSC redirect and traversal lifecycle

### DIFF
--- a/packages/vinext/src/global.d.ts
+++ b/packages/vinext/src/global.d.ts
@@ -92,6 +92,7 @@ declare global {
      * @param redirectDepth - Internal parameter used to detect redirect loops.
      * @param navigationKind - Internal hint for traversal vs regular navigation.
      * @param historyUpdateMode - Internal hint for when history should publish.
+     * @param traversalIntent - Internal popstate direction/history metadata.
      */
     __VINEXT_RSC_NAVIGATE__:
       | ((
@@ -101,6 +102,11 @@ declare global {
           historyUpdateMode?: "push" | "replace",
           previousNextUrlOverride?: string | null,
           programmaticTransition?: boolean,
+          traversalIntent?: {
+            direction: "back" | "forward" | "unknown";
+            historyState: unknown;
+            targetHistoryIndex: number | null;
+          },
         ) => Promise<void>)
       | undefined;
 

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -69,11 +69,15 @@ import {
   type AppWireElements,
 } from "./app-elements.js";
 import {
+  createHistoryStateWithNavigationMetadata,
   createHistoryStateWithPreviousNextUrl,
   readHistoryStatePreviousNextUrl,
+  readHistoryStateTraversalIndex,
+  resolveHistoryTraversalIntent,
   resolveInterceptionContextFromPreviousNextUrl,
   resolveServerActionRequestState,
   type AppRouterState,
+  type HistoryTraversalIntent,
   type OperationLane,
 } from "./app-browser-state.js";
 import { createPopstateRestoreHandler } from "./app-browser-popstate.js";
@@ -96,12 +100,11 @@ import {
   getVinextRscCompatibilityId,
   resolveHardNavigationTargetFromRscResponse,
   resolveRscCompatibilityNavigationDecision,
-  stripRscCacheBustingSearchParam,
-  stripRscSuffix,
   VINEXT_RSC_COMPATIBILITY_ID_HEADER,
   VINEXT_RSC_CONTENT_TYPE,
 } from "./app-rsc-cache-busting.js";
 import { APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI } from "./app-rsc-render-mode.js";
+import { resolveRscRedirectLifecycleHop } from "./app-browser-rsc-redirect.js";
 import {
   ACTION_REDIRECT_HEADER,
   ACTION_REDIRECT_TYPE_HEADER,
@@ -192,6 +195,36 @@ let browserRouterStateHasEverCommitted = false;
 // of stranding them on the previous URL with a blank page. Cleared once the
 // commit effect runs (URL update succeeded) or the navigation is superseded.
 let pendingNavigationRecoveryHref: string | null = null;
+let currentHistoryTraversalIndex: number | null =
+  readHistoryStateTraversalIndex(window.history.state) ?? 0;
+let nextHistoryTraversalIndex: number = currentHistoryTraversalIndex;
+
+function allocateNavigationHistoryTraversalIndex(
+  historyUpdateMode: HistoryUpdateMode | undefined,
+): number | null {
+  switch (historyUpdateMode) {
+    case "push":
+      return nextHistoryTraversalIndex + 1;
+    case "replace":
+      return currentHistoryTraversalIndex;
+    case undefined:
+      return null;
+    default: {
+      const _exhaustive: never = historyUpdateMode;
+      throw new Error("[vinext] Unknown history update mode: " + String(_exhaustive));
+    }
+  }
+}
+
+function commitHistoryTraversalIndex(index: number | null): void {
+  currentHistoryTraversalIndex = index;
+  if (index !== null) {
+    // Keep allocation anchored to the highest app-owned entry we know about.
+    // Traversing to metadata-less entries makes the current index unknown, but
+    // the next app-owned push should still continue from known app history.
+    nextHistoryTraversalIndex = Math.max(nextHistoryTraversalIndex, index);
+  }
+}
 
 function getBrowserRouterState(): AppRouterState {
   return browserNavigationController.getBrowserRouterState();
@@ -275,8 +308,9 @@ function createNavigationCommitEffect(options: {
   navId: number;
   params: Record<string, string | string[]>;
   previousNextUrl: string | null;
+  targetHistoryIndex?: number | null;
 }): () => void {
-  const { href, historyUpdateMode, navId, params, previousNextUrl } = options;
+  const { href, historyUpdateMode, navId, params, previousNextUrl, targetHistoryIndex } = options;
 
   return () => {
     // Only update URL if this is still the active navigation.
@@ -290,9 +324,16 @@ function createNavigationCommitEffect(options: {
 
     const targetHref = new URL(href, window.location.origin).href;
     const preserveExistingState = historyUpdateMode === "replace";
-    const historyState = createHistoryStateWithPreviousNextUrl(
+    const navigationHistoryIndex =
+      targetHistoryIndex !== undefined
+        ? targetHistoryIndex
+        : allocateNavigationHistoryTraversalIndex(historyUpdateMode);
+    const historyState = createHistoryStateWithNavigationMetadata(
       preserveExistingState ? window.history.state : null,
-      previousNextUrl,
+      {
+        previousNextUrl,
+        traversalIndex: navigationHistoryIndex,
+      },
     );
 
     let wroteHistoryState = false;
@@ -300,15 +341,20 @@ function createNavigationCommitEffect(options: {
       stageClientParams(params);
       replaceHistoryStateWithoutNotify(historyState, "", href);
       wroteHistoryState = true;
+      commitHistoryTraversalIndex(navigationHistoryIndex);
     } else if (historyUpdateMode === "push" && window.location.href !== targetHref) {
       stageClientParams(params);
       pushHistoryStateWithoutNotify(historyState, "", href);
       wroteHistoryState = true;
+      commitHistoryTraversalIndex(navigationHistoryIndex);
     }
 
     if (!wroteHistoryState) {
       syncCurrentHistoryStatePreviousNextUrl(previousNextUrl);
       stageClientParams(params);
+      if (targetHistoryIndex !== undefined) {
+        commitHistoryTraversalIndex(targetHistoryIndex);
+      }
     }
 
     // URL has been updated; the recovery hard-nav target is no longer needed.
@@ -328,6 +374,7 @@ async function renderNavigationPayload(
   pendingRouterState: PendingBrowserRouterState | null,
   actionType: "navigate" | "replace" | "traverse" = "navigate",
   operationLane: OperationLane = "navigation",
+  traversalIntent: HistoryTraversalIntent | null = null,
 ): Promise<NavigationPayloadOutcome> {
   try {
     return await browserNavigationController.renderNavigationPayload({
@@ -343,6 +390,7 @@ async function renderNavigationPayload(
       params,
       pendingRouterState,
       previousNextUrl,
+      targetHistoryIndex: traversalIntent === null ? undefined : traversalIntent.targetHistoryIndex,
       targetHref,
       navId,
     });
@@ -457,6 +505,7 @@ type NavigationRequestState = {
 function getRequestState(
   navigationKind: NavigationKind,
   previousNextUrlOverride?: string | null,
+  traverseHistoryState?: unknown,
 ): NavigationRequestState {
   if (previousNextUrlOverride !== undefined) {
     return {
@@ -493,7 +542,9 @@ function getRequestState(
       };
     }
     case "traverse": {
-      const previousNextUrl = readHistoryStatePreviousNextUrl(window.history.state);
+      const previousNextUrl = readHistoryStatePreviousNextUrl(
+        traverseHistoryState ?? window.history.state,
+      );
       return {
         interceptionContext: resolveInterceptionContextFromPreviousNextUrl(
           previousNextUrl,
@@ -607,7 +658,10 @@ function BrowserRoot({
     }
 
     replaceHistoryStateWithoutNotify(
-      createHistoryStateWithPreviousNextUrl(window.history.state, treeState.previousNextUrl),
+      createHistoryStateWithNavigationMetadata(window.history.state, {
+        previousNextUrl: treeState.previousNextUrl,
+        traversalIndex: currentHistoryTraversalIndex,
+      }),
       "",
       window.location.href,
     );
@@ -1016,7 +1070,10 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
     latestClientParams,
   );
   replaceHistoryStateWithoutNotify(
-    createHistoryStateWithPreviousNextUrl(window.history.state, null),
+    createHistoryStateWithNavigationMetadata(window.history.state, {
+      previousNextUrl: null,
+      traversalIndex: currentHistoryTraversalIndex,
+    }),
     "",
     window.location.href,
   );
@@ -1064,6 +1121,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
     historyUpdateMode?: HistoryUpdateMode,
     previousNextUrlOverride?: string | null,
     programmaticTransition = false,
+    traversalIntent?: HistoryTraversalIntent,
   ): Promise<void> {
     let pendingRouterState: PendingBrowserRouterState | null = null;
     // Hoist navId above try so the catch and finally blocks can reference it.
@@ -1077,6 +1135,14 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
     let currentHistoryMode = historyUpdateMode;
     let currentPrevNextUrl = previousNextUrlOverride;
     let redirectCount = redirectDepth;
+    const activeTraversalIntent =
+      navigationKind === "traverse"
+        ? (traversalIntent ??
+          resolveHistoryTraversalIntent({
+            currentHistoryIndex: currentHistoryTraversalIndex,
+            historyState: window.history.state,
+          }))
+        : null;
 
     try {
       const shouldUsePendingRouterState = programmaticTransition;
@@ -1092,16 +1158,12 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
       }
 
       while (true) {
-        if (redirectCount > 10) {
-          console.error(
-            "[vinext] Too many RSC redirects — aborting navigation to prevent infinite loop.",
-          );
-          window.location.href = currentHref;
-          return;
-        }
-
         const url = new URL(currentHref, window.location.origin);
-        const requestState = getRequestState(navigationKind, currentPrevNextUrl);
+        const requestState = getRequestState(
+          navigationKind,
+          currentPrevNextUrl,
+          activeTraversalIntent?.historyState,
+        );
         const requestInterceptionContext = requestState.interceptionContext;
         const requestPreviousNextUrl = requestState.previousNextUrl;
         if (navigationKind === "refresh") {
@@ -1175,6 +1237,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
             pendingRouterState,
             toActionType(navigationKind),
             toOperationLane(navigationKind),
+            activeTraversalIntent,
           );
           return;
         }
@@ -1248,26 +1311,34 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
           return;
         }
 
-        const finalUrl = new URL(navResponseUrl ?? navResponse.url, window.location.origin);
-        stripRscCacheBustingSearchParam(finalUrl);
-        const requestedUrl = new URL(rscUrl, window.location.origin);
+        const redirectDecision = resolveRscRedirectLifecycleHop({
+          currentHref,
+          historyUpdateMode: currentHistoryMode ?? "replace",
+          origin: window.location.origin,
+          redirectDepth: redirectCount,
+          requestPreviousNextUrl,
+          responseUrl: navResponseUrl ?? navResponse.url,
+        });
 
-        if (finalUrl.pathname !== requestedUrl.pathname) {
-          // Server-side redirect: update the URL in history and loop to fetch
-          // the destination without settling pendingRouterState. This keeps
-          // isPending true across all redirect hops instead of flashing false.
-          const destinationPath = stripRscSuffix(finalUrl.pathname) + finalUrl.search;
-          replaceHistoryStateWithoutNotify(
-            createHistoryStateWithPreviousNextUrl(null, requestPreviousNextUrl),
-            "",
-            destinationPath,
-          );
+        if (redirectDecision.kind === "terminal-hard-navigation") {
+          if (redirectDecision.reason === "maxRedirectsExceeded") {
+            console.error(
+              "[vinext] Too many RSC redirects — aborting navigation to prevent infinite loop.",
+            );
+          }
+          window.location.href = redirectDecision.href;
+          return;
+        }
 
-          currentHref = destinationPath;
-          // URL already written above; the commit effect must not push/replace again.
-          currentHistoryMode = undefined;
-          currentPrevNextUrl = requestPreviousNextUrl;
-          redirectCount += 1;
+        if (redirectDecision.kind === "follow") {
+          // Server-side redirect: keep the redirect chain inside this operation
+          // and defer URL/history mutation to the eventual approved commit.
+          // This keeps isPending true across all hops and avoids publishing a
+          // destination URL before its RSC payload is lifecycle-approved.
+          currentHref = redirectDecision.href;
+          currentHistoryMode = redirectDecision.historyUpdateMode;
+          currentPrevNextUrl = redirectDecision.previousNextUrl;
+          redirectCount = redirectDecision.redirectDepth;
           continue;
         }
 
@@ -1322,6 +1393,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
           pendingRouterState,
           toActionType(navigationKind),
           toOperationLane(navigationKind),
+          activeTraversalIntent,
         );
         if (renderOutcome !== "committed") return;
         // Don't cache the response if this navigation was superseded during

--- a/packages/vinext/src/server/app-browser-navigation-controller.ts
+++ b/packages/vinext/src/server/app-browser-navigation-controller.ts
@@ -39,6 +39,7 @@ type BrowserNavigationCommitEffectFactory = (options: {
   navId: number;
   params: Record<string, string | string[]>;
   previousNextUrl: string | null;
+  targetHistoryIndex?: number | null;
 }) => () => void;
 
 type BrowserRouterStateRef = {
@@ -81,6 +82,7 @@ type BrowserNavigationController = {
     params: Record<string, string | string[]>;
     pendingRouterState: PendingBrowserRouterState | null;
     previousNextUrl: string | null;
+    targetHistoryIndex?: number | null;
     targetHref: string;
     navId: number;
   }): Promise<NavigationPayloadOutcome>;
@@ -490,6 +492,7 @@ export function createAppBrowserNavigationController(
     params: Record<string, string | string[]>;
     pendingRouterState: PendingBrowserRouterState | null;
     previousNextUrl: string | null;
+    targetHistoryIndex?: number | null;
     targetHref: string;
     navId: number;
   }): Promise<NavigationPayloadOutcome> {
@@ -547,6 +550,7 @@ export function createAppBrowserNavigationController(
           navId: options.navId,
           params: options.params,
           previousNextUrl: approvedCommit.previousNextUrl,
+          targetHistoryIndex: options.targetHistoryIndex,
         }),
       );
       activateNavigationSnapshot();

--- a/packages/vinext/src/server/app-browser-rsc-redirect.ts
+++ b/packages/vinext/src/server/app-browser-rsc-redirect.ts
@@ -1,0 +1,79 @@
+import {
+  resolveHardNavigationTargetFromRscResponse,
+  stripRscCacheBustingSearchParam,
+  stripRscSuffix,
+} from "./app-rsc-cache-busting.js";
+
+const MAX_RSC_REDIRECT_DEPTH = 10;
+
+type RscRedirectHistoryUpdateMode = "push" | "replace" | undefined;
+
+type RscRedirectLifecycleDecision =
+  | { kind: "no-redirect" }
+  | {
+      href: string;
+      historyUpdateMode: RscRedirectHistoryUpdateMode;
+      kind: "follow";
+      previousNextUrl: string | null;
+      redirectDepth: number;
+    }
+  | {
+      href: string;
+      kind: "terminal-hard-navigation";
+      reason: "externalRedirect" | "maxRedirectsExceeded";
+      redirectDepth: number;
+    };
+
+function toVisibleAppHref(href: string, origin: string): string {
+  const url = new URL(href, origin);
+  stripRscCacheBustingSearchParam(url);
+  return `${stripRscSuffix(url.pathname)}${url.search}${url.hash}`;
+}
+
+export function resolveRscRedirectLifecycleHop(options: {
+  currentHref: string;
+  historyUpdateMode: RscRedirectHistoryUpdateMode;
+  maxRedirectDepth?: number;
+  origin: string;
+  redirectDepth: number;
+  requestPreviousNextUrl: string | null;
+  responseUrl: string;
+}): RscRedirectLifecycleDecision {
+  const responseUrl = new URL(options.responseUrl, options.origin);
+
+  if (responseUrl.origin !== options.origin) {
+    return {
+      href: responseUrl.href,
+      kind: "terminal-hard-navigation",
+      reason: "externalRedirect",
+      redirectDepth: options.redirectDepth,
+    };
+  }
+
+  const redirectedHref = resolveHardNavigationTargetFromRscResponse(
+    responseUrl.href,
+    options.currentHref,
+    options.origin,
+  );
+  if (redirectedHref === toVisibleAppHref(options.currentHref, options.origin)) {
+    return { kind: "no-redirect" };
+  }
+
+  const maxRedirectDepth = options.maxRedirectDepth ?? MAX_RSC_REDIRECT_DEPTH;
+  if (options.redirectDepth >= maxRedirectDepth) {
+    return {
+      href: redirectedHref,
+      kind: "terminal-hard-navigation",
+      reason: "maxRedirectsExceeded",
+      redirectDepth: options.redirectDepth,
+    };
+  }
+
+  return {
+    href: redirectedHref,
+    historyUpdateMode: options.historyUpdateMode,
+    kind: "follow",
+    previousNextUrl: options.requestPreviousNextUrl,
+    redirectDepth: options.redirectDepth + 1,
+  };
+}

--- a/packages/vinext/src/server/app-browser-state.ts
+++ b/packages/vinext/src/server/app-browser-state.ts
@@ -33,8 +33,12 @@ import type { ClientNavigationRenderSnapshot } from "vinext/shims/navigation";
 import { normalizePathnameForRouteMatch } from "../routing/utils.js";
 import { normalizePath } from "./normalize-path.js";
 export {
+  createHistoryStateWithNavigationMetadata,
   createHistoryStateWithPreviousNextUrl,
   readHistoryStatePreviousNextUrl,
+  readHistoryStateTraversalIndex,
+  resolveHistoryTraversalIntent,
+  type HistoryTraversalIntent,
 } from "./app-history-state.js";
 
 export type { OperationLane } from "./navigation-planner.js";
@@ -113,7 +117,6 @@ type NonDispatchPendingNavigationCommitDispositionDecision = {
 type PendingNavigationCommitDispositionDecision =
   | DispatchPendingNavigationCommitDispositionDecision
   | NonDispatchPendingNavigationCommitDispositionDecision;
-
 function createOperationRecord(options: {
   id: number;
   lane: OperationLane;

--- a/packages/vinext/src/server/app-history-state.ts
+++ b/packages/vinext/src/server/app-history-state.ts
@@ -1,7 +1,16 @@
+import type { TraverseDirection } from "./navigation-planner.js";
+
 const VINEXT_PREVIOUS_NEXT_URL_HISTORY_STATE_KEY = "__vinext_previousNextUrl";
+const VINEXT_HISTORY_INDEX_HISTORY_STATE_KEY = "__vinext_historyIndex";
 
 type HistoryStateRecord = {
   [key: string]: unknown;
+};
+
+export type HistoryTraversalIntent = {
+  direction: TraverseDirection;
+  historyState: unknown;
+  targetHistoryIndex: number | null;
 };
 
 function cloneHistoryState(state: unknown): HistoryStateRecord {
@@ -20,12 +29,30 @@ export function createHistoryStateWithPreviousNextUrl(
   state: unknown,
   previousNextUrl: string | null,
 ): HistoryStateRecord | null {
+  return createHistoryStateWithNavigationMetadata(state, { previousNextUrl });
+}
+
+export function createHistoryStateWithNavigationMetadata(
+  state: unknown,
+  metadata: {
+    previousNextUrl: string | null;
+    traversalIndex?: number | null;
+  },
+): HistoryStateRecord | null {
   const nextState = cloneHistoryState(state);
 
-  if (previousNextUrl === null) {
+  if (metadata.previousNextUrl === null) {
     delete nextState[VINEXT_PREVIOUS_NEXT_URL_HISTORY_STATE_KEY];
   } else {
-    nextState[VINEXT_PREVIOUS_NEXT_URL_HISTORY_STATE_KEY] = previousNextUrl;
+    nextState[VINEXT_PREVIOUS_NEXT_URL_HISTORY_STATE_KEY] = metadata.previousNextUrl;
+  }
+
+  if (metadata.traversalIndex !== undefined) {
+    if (isValidHistoryTraversalIndex(metadata.traversalIndex)) {
+      nextState[VINEXT_HISTORY_INDEX_HISTORY_STATE_KEY] = metadata.traversalIndex;
+    } else {
+      delete nextState[VINEXT_HISTORY_INDEX_HISTORY_STATE_KEY];
+    }
   }
 
   return Object.keys(nextState).length > 0 ? nextState : null;
@@ -46,4 +73,35 @@ export function createExternalHistoryStatePreservingMetadata(
 export function readHistoryStatePreviousNextUrl(state: unknown): string | null {
   const value = cloneHistoryState(state)[VINEXT_PREVIOUS_NEXT_URL_HISTORY_STATE_KEY];
   return typeof value === "string" ? value : null;
+}
+
+function isValidHistoryTraversalIndex(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+}
+
+export function readHistoryStateTraversalIndex(state: unknown): number | null {
+  const value = cloneHistoryState(state)[VINEXT_HISTORY_INDEX_HISTORY_STATE_KEY];
+  return isValidHistoryTraversalIndex(value) ? value : null;
+}
+
+export function resolveHistoryTraversalIntent(options: {
+  currentHistoryIndex: number | null;
+  historyState: unknown;
+}): HistoryTraversalIntent {
+  const targetHistoryIndex = readHistoryStateTraversalIndex(options.historyState);
+  let direction: TraverseDirection = "unknown";
+
+  if (options.currentHistoryIndex !== null && targetHistoryIndex !== null) {
+    if (targetHistoryIndex < options.currentHistoryIndex) {
+      direction = "back";
+    } else if (targetHistoryIndex > options.currentHistoryIndex) {
+      direction = "forward";
+    }
+  }
+
+  return {
+    direction,
+    historyState: options.historyState,
+    targetHistoryIndex,
+  };
 }

--- a/packages/vinext/src/server/navigation-planner.ts
+++ b/packages/vinext/src/server/navigation-planner.ts
@@ -75,17 +75,18 @@ export type NavigationPlannerStateV0 = {
 };
 
 export type RefreshScope = "visible";
+export type TraverseDirection = "back" | "forward" | "unknown";
 
 export type NavigationEvent =
   | { kind: "navigate"; href: string; mode: "push" | "replace" }
   | { kind: "refresh"; scope: RefreshScope }
-  | { kind: "traverse"; direction: "back" | "forward"; historyState: unknown }
+  | { kind: "traverse"; direction: TraverseDirection; historyState: unknown }
   | { kind: "prefetch"; href: string }
   | { kind: "flightResponseArrived"; token: OperationToken; result: FlightResultV0 };
 
 export type RequestedWork =
   | { kind: "flight"; href: string; mode: "push" | "replace" | "refresh" }
-  | { direction: "back" | "forward"; historyState: unknown; kind: "traverseFlight" }
+  | { direction: TraverseDirection; historyState: unknown; kind: "traverseFlight" }
   | { kind: "prefetch"; href: string };
 
 export type CommitProposal = {
@@ -149,6 +150,8 @@ function createRequestWorkDecision(options: {
   state: NavigationPlannerStateV0;
   work: RequestedWork;
 }): NavigationDecisionV0 {
+  const traverseFields =
+    options.work.kind === "traverseFlight" ? { traverseDirection: options.work.direction } : {};
   return {
     kind: "requestWork",
     token: options.state.nextOperationToken,
@@ -156,6 +159,7 @@ function createRequestWorkDecision(options: {
     trace: createNavigationTrace(NavigationTraceReasonCodes.requestWork, {
       eventKind: options.eventKind,
       targetHref: getRequestedWorkTargetHref(options.work),
+      ...traverseFields,
     }),
   };
 }

--- a/packages/vinext/src/server/navigation-trace.ts
+++ b/packages/vinext/src/server/navigation-trace.ts
@@ -58,7 +58,8 @@ export type NavigationTraceFieldName =
   | "pendingOperationId"
   | "startedVisibleCommitVersion"
   | "startedNavigationId"
-  | "targetHref";
+  | "targetHref"
+  | "traverseDirection";
 
 export type NavigationTraceFieldValue = string | number | boolean | null;
 

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -40,15 +40,19 @@ import {
 import { createClientNavigationRenderSnapshot } from "../packages/vinext/src/shims/navigation.js";
 import * as navigationShim from "../packages/vinext/src/shims/navigation.js";
 import {
+  createHistoryStateWithNavigationMetadata,
   createHistoryStateWithPreviousNextUrl,
   createPendingNavigationCommit,
   readHistoryStatePreviousNextUrl,
+  readHistoryStateTraversalIndex,
   resolveInterceptionContextFromPreviousNextUrl,
+  resolveHistoryTraversalIntent,
   resolveServerActionRequestState,
   resolvePendingNavigationCommitDispositionDecision,
   type AppRouterState,
   type OperationLane,
 } from "../packages/vinext/src/server/app-browser-state.js";
+import { resolveRscRedirectLifecycleHop } from "../packages/vinext/src/server/app-browser-rsc-redirect.js";
 import {
   applyApprovedVisibleCommit,
   approveHmrVisibleCommit,
@@ -2916,6 +2920,60 @@ describe("app browser entry previousNextUrl helpers", () => {
     expect(resolveInterceptionContextFromPreviousNextUrl(null)).toBeNull();
   });
 
+  it("stores traversal index alongside existing history state", () => {
+    const state = createHistoryStateWithNavigationMetadata(
+      {
+        __vinext_scrollY: 120,
+      },
+      {
+        previousNextUrl: "/feed?tab=latest",
+        traversalIndex: 4,
+      },
+    );
+
+    expect(state).toEqual({
+      __vinext_historyIndex: 4,
+      __vinext_previousNextUrl: "/feed?tab=latest",
+      __vinext_scrollY: 120,
+    });
+    expect(readHistoryStateTraversalIndex(state)).toBe(4);
+  });
+
+  it("resolves back, forward, and unknown traversal intent from history state", () => {
+    expect(
+      resolveHistoryTraversalIntent({
+        currentHistoryIndex: 5,
+        historyState: { __vinext_historyIndex: 3 },
+      }).direction,
+    ).toBe("back");
+    expect(
+      resolveHistoryTraversalIntent({
+        currentHistoryIndex: 5,
+        historyState: { __vinext_historyIndex: 7 },
+      }).direction,
+    ).toBe("forward");
+    expect(
+      resolveHistoryTraversalIntent({
+        currentHistoryIndex: 5,
+        historyState: {},
+      }),
+    ).toEqual({
+      direction: "unknown",
+      historyState: {},
+      targetHistoryIndex: null,
+    });
+    expect(
+      resolveHistoryTraversalIntent({
+        currentHistoryIndex: null,
+        historyState: { __vinext_historyIndex: 7 },
+      }),
+    ).toEqual({
+      direction: "unknown",
+      historyState: { __vinext_historyIndex: 7 },
+      targetHistoryIndex: 7,
+    });
+  });
+
   it("classifies pending commits in one step for same-url payloads", async () => {
     const currentState = createState({
       rootLayoutTreePath: "/(marketing)",
@@ -3370,6 +3428,99 @@ describe("createPopstateRestoreHandler", () => {
 
     expect(restoreCalls).toEqual([]);
     expect(window.__VINEXT_RSC_PENDING__).toBeNull();
+  });
+});
+
+describe("app browser RSC redirect lifecycle", () => {
+  it("keeps RSC redirect hops in the initiating lifecycle and preserves push history intent", () => {
+    const decision = resolveRscRedirectLifecycleHop({
+      currentHref: "https://example.com/start",
+      historyUpdateMode: "push",
+      origin: "https://example.com",
+      redirectDepth: 0,
+      requestPreviousNextUrl: "/feed",
+      responseUrl: "https://example.com/target.rsc?tab=1&_rsc=abc",
+    });
+
+    expect(decision).toEqual({
+      href: "/target?tab=1",
+      historyUpdateMode: "push",
+      kind: "follow",
+      previousNextUrl: "/feed",
+      redirectDepth: 1,
+    });
+  });
+
+  it("treats same-path search changes as RSC redirects", () => {
+    const decision = resolveRscRedirectLifecycleHop({
+      currentHref: "https://example.com/items?sort=old",
+      historyUpdateMode: "replace",
+      origin: "https://example.com",
+      redirectDepth: 2,
+      requestPreviousNextUrl: null,
+      responseUrl: "https://example.com/items.rsc?sort=new&_rsc=abc",
+    });
+
+    expect(decision).toMatchObject({
+      href: "/items?sort=new",
+      historyUpdateMode: "replace",
+      kind: "follow",
+      redirectDepth: 3,
+    });
+  });
+
+  it("allows callers to model terminal traverse/refresh redirects as replace commits", () => {
+    const decision = resolveRscRedirectLifecycleHop({
+      currentHref: "https://example.com/old",
+      historyUpdateMode: "replace",
+      origin: "https://example.com",
+      redirectDepth: 0,
+      requestPreviousNextUrl: null,
+      responseUrl: "https://example.com/new.rsc?_rsc=abc",
+    });
+
+    expect(decision).toMatchObject({
+      href: "/new",
+      historyUpdateMode: "replace",
+      kind: "follow",
+    });
+  });
+
+  it("turns external RSC redirects into terminal hard navigations", () => {
+    const decision = resolveRscRedirectLifecycleHop({
+      currentHref: "https://example.com/account",
+      historyUpdateMode: "push",
+      origin: "https://example.com",
+      redirectDepth: 0,
+      requestPreviousNextUrl: null,
+      responseUrl: "https://idp.example/login",
+    });
+
+    expect(decision).toEqual({
+      href: "https://idp.example/login",
+      kind: "terminal-hard-navigation",
+      reason: "externalRedirect",
+      redirectDepth: 0,
+    });
+  });
+
+  it("turns an over-budget redirect chain into a terminal hard navigation", () => {
+    const decision = resolveRscRedirectLifecycleHop({
+      currentHref: "https://example.com/a",
+      historyUpdateMode: "push",
+      maxRedirectDepth: 2,
+      origin: "https://example.com",
+      redirectDepth: 2,
+      requestPreviousNextUrl: null,
+      responseUrl: "https://example.com/b.rsc?_rsc=abc",
+    });
+
+    expect(decision).toEqual({
+      href: "/b",
+      kind: "terminal-hard-navigation",
+      reason: "maxRedirectsExceeded",
+      redirectDepth: 2,
+    });
   });
 });
 

--- a/tests/e2e/app-router/nextjs-compat/router-push-pending.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/router-push-pending.spec.ts
@@ -162,4 +162,32 @@ test.describe("Next.js compat: router pending state (browser)", () => {
       timeout: 10_000,
     });
   });
+
+  /**
+   * Redirected RSC responses should stay inside the initiating router.push()
+   * lifecycle. The final destination is the committed history entry; vinext
+   * must not replace the source entry before the redirected payload is approved.
+   *
+   * Next.js source reference:
+   * .nextjs-ref/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+   * uses the post-redirect canonical URL while preserving the navigation type.
+   */
+  test("back after router.push to a server-redirecting page returns to the source entry", async ({
+    page,
+  }) => {
+    await page.goto(`${BASE}/nextjs-compat/router-push-pending`);
+    await waitForAppRouterHydration(page);
+
+    await page.click("#push-redirect");
+    await expect(page.locator("#redirect-destination")).toBeVisible({
+      timeout: 10_000,
+    });
+    expect(new URL(page.url()).pathname).toBe("/nextjs-compat/router-push-pending-destination");
+
+    await page.goBack();
+    await expect(page.locator("#router-push-pending-title")).toBeVisible({
+      timeout: 10_000,
+    });
+    expect(new URL(page.url()).pathname).toBe("/nextjs-compat/router-push-pending");
+  });
 });

--- a/tests/navigation-planner.test.ts
+++ b/tests/navigation-planner.test.ts
@@ -925,5 +925,35 @@ describe("navigationPlanner root-boundary decisions", () => {
       kind: "traverseFlight",
     });
     expect(decision.trace.entries[0]?.fields.targetHref).toBeNull();
+    expect(decision.trace.entries[0]?.fields.traverseDirection).toBe("back");
+  });
+
+  it("keeps unknown traversal direction explicit instead of guessing", () => {
+    const token = createOperationToken();
+    const historyState = { key: "external-entry" };
+    const decision = navigationPlanner.plan({
+      routeManifest: null,
+      state: {
+        nextOperationToken: token,
+        visibleCommitVersion: 2,
+        visibleSnapshot: createRouteSnapshot("/"),
+      },
+      event: {
+        direction: "unknown",
+        historyState,
+        kind: "traverse",
+      },
+    });
+
+    expect(decision.kind).toBe("requestWork");
+    if (decision.kind !== "requestWork") {
+      throw new Error("Expected requestWork decision");
+    }
+    expect(decision.work).toEqual({
+      direction: "unknown",
+      historyState,
+      kind: "traverseFlight",
+    });
+    expect(decision.trace.entries[0]?.fields.traverseDirection).toBe("unknown");
   });
 });


### PR DESCRIPTION
## Overview

| Field | Details |
| --- | --- |
| Task | `#726-CORE-18/19`: Model RSC redirect lifecycle and back/forward traversal intent |
| Parent issue | Refs https://github.com/cloudflare/vinext/issues/726 |
| Core change | RSC redirects now stay inside the initiating navigation lifecycle until an approved visible commit publishes URL/history state. |
| Traversal model | App Router RSC commits carry vinext traversal metadata. Metadata-less entries, including hash-only entries in this slice, are modeled as `unknown` rather than guessed. |
| Follow-up | Hash-only App Router traversal metadata is tracked in https://github.com/cloudflare/vinext/issues/1252. |
| Primary review files | `app-browser-entry.ts`, `app-browser-rsc-redirect.ts`, `app-browser-state.ts`, `navigation-planner.ts` |

Bonk: please read issue #726 before reviewing this PR. The redirect and traversal changes are part of the broader navigation lifecycle architecture, not an isolated redirect patch.

## Why

For App Router navigation to be correct, visible browser state must only change after the lifecycle controller approves a commit. The previous RSC redirect path followed server redirects by writing history before the final RSC payload was approved, which could collapse the source entry for `router.push()` and leave back/forward traversal without a durable intent model.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| RSC redirects | One user navigation should keep one pending operation where possible. | Redirect hops are followed inline and only publish history on the eventual approved commit. |
| Terminal redirects | Redirect escape paths must be explicit. | External redirects and redirect-budget exhaustion return terminal hard-navigation decisions. |
| Traversal intent | Missing history metadata must not be guessed. | `back`, `forward`, and `unknown` are modeled explicitly, and unknown traversal targets keep the local index unknown. |
| Planner | The planner should remain small and pure. | It only carries the traversal direction through requested work and trace fields. |

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| `router.push()` to an RSC server redirect | The redirect hop could replace history before the final payload committed. | The redirected destination is pushed as the final approved commit, preserving Back to the source entry. |
| Same-path redirect with changed query | Redirect detection only compared pathnames. | Redirect lifecycle decision compares visible app hrefs, so query-only redirects are followed. |
| External RSC redirect | Mixed into redirect-following control flow. | Returns an explicit terminal hard navigation. |
| Browser back/forward | Traversal direction was not represented in planner work. | Traversal work and traces carry `back`, `forward`, or `unknown`. |
| Metadata-less history entry | Could be classified against stale local index state. | Unknown target index stays unknown and does not synthesize traversal metadata on replace commits. |

<details>
<summary>Maintainer review path</summary>

1. `packages/vinext/src/server/app-browser-rsc-redirect.ts`: pure redirect lifecycle decision helper.
2. `packages/vinext/src/server/app-browser-entry.ts`: inline redirect following, approved-commit history publishing, popstate traversal intent capture.
3. `packages/vinext/src/server/app-browser-state.ts`: history metadata read/write helpers and traversal intent resolution.
4. `packages/vinext/src/server/navigation-planner.ts` and `navigation-trace.ts`: small planner surface for traversal direction and traces.
5. `tests/app-browser-entry.test.ts`, `tests/navigation-planner.test.ts`, and the Playwright spec for coverage.

</details>

<details>
<summary>Validation</summary>

- `vp test run tests/app-browser-entry.test.ts tests/navigation-planner.test.ts`
- `PLAYWRIGHT_PROJECT=app-router pnpm run test:e2e -- tests/e2e/app-router/nextjs-compat/router-push-pending.spec.ts`
- `vp check`
- Commit hook also ran formatting, lint/type checks, and `knip`.
- Ran local elegance review, then a GPT-5.5 high-effort review subagent. Addressed its findings on metadata-less traversal state and exact pathname assertions.

</details>

<details>
<summary>Risk and compatibility</summary>

- Runtime impact is limited to App Router browser RSC navigation.
- Public API impact is limited to the internal `window.__VINEXT_RSC_NAVIGATE__` signature.
- Traversal metadata uses vinext-owned history-state keys and preserves existing history state fields.
- Unknown browser history entries remain unknown instead of being repaired speculatively.
- Hash-only App Router entries still bypass the RSC commit metadata writer in this slice and remain intentionally metadata-less/unknown. The follow-up is #1252.
- This does not model streaming chunk lifecycle. That remains outside `#726-CORE-18/19`.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| https://github.com/cloudflare/vinext/issues/726 | Parent architecture issue and roadmap context. |
| `#726-CORE-18/19` | Specific task slice implemented here. |
| https://github.com/cloudflare/vinext/issues/1252 | Follow-up for hash-only App Router entries in the traversal metadata model. |
| `.nextjs-ref/packages/next/src/client/components/router-reducer/fetch-server-response.ts` | Next.js preserves navigation type while using the post-redirect canonical URL. |
| `.nextjs-ref/packages/next/src/client/components/app-router.tsx` | Next.js popstate handling context for traversal intent. |
