### PR TITLE
fix(app-router): guard popstate scroll restore on stale navigation

### DIFF
--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -75,6 +75,7 @@ import {
   type AppRouterState,
   type OperationLane,
 } from "./app-browser-state.js";
+import { createPopstateRestoreHandler } from "./app-browser-popstate.js";
 import { DevRecoveryBoundary, RedirectBoundary } from "vinext/shims/error-boundary";
 import { AppRouterContext } from "vinext/shims/internal/app-router-context";
 import { ElementsContext, Slot } from "vinext/shims/slot";
@@ -652,44 +653,6 @@ function scrollToHashTarget(hash: string): void {
 
     document.getElementsByName(fragment)[0]?.scrollIntoView({ behavior: "auto" });
   });
-}
-
-type PopstateRestoreHandlerDependencies = {
-  getActiveNavigationId: () => number;
-  getNavigate: () =>
-    | ((href: string, redirectDepth: number, navigationKind: NavigationKind) => Promise<void>)
-    | null
-    | undefined;
-  getPendingNavigation: () => Promise<void> | null;
-  isCurrentNavigation: (navId: number) => boolean;
-  restorePopstateScrollPosition: (state: unknown) => void;
-  setPendingNavigation: (pendingNavigation: Promise<void> | null) => void;
-};
-
-export function createPopstateRestoreHandler({
-  getActiveNavigationId,
-  getNavigate,
-  getPendingNavigation,
-  isCurrentNavigation,
-  restorePopstateScrollPosition: restore,
-  setPendingNavigation,
-}: PopstateRestoreHandlerDependencies): (event: PopStateEvent) => void {
-  return (event) => {
-    notifyAppRouterTransitionStart(window.location.href, "traverse");
-    const navigateRsc = getNavigate();
-    const pendingNavigation =
-      navigateRsc?.(window.location.href, 0, "traverse") ?? Promise.resolve();
-    const popstateNavId = navigateRsc ? getActiveNavigationId() : null;
-    setPendingNavigation(pendingNavigation);
-    void pendingNavigation.finally(() => {
-      if (popstateNavId === null || isCurrentNavigation(popstateNavId)) {
-        restore(event.state);
-      }
-      if (getPendingNavigation() === pendingNavigation) {
-        setPendingNavigation(null);
-      }
-    });
-  };
 }
 
 function restorePopstateScrollPosition(state: unknown): void {
@@ -1372,9 +1335,10 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
     createPopstateRestoreHandler({
       getActiveNavigationId: () => browserNavigationController.getActiveNavigationId(),
       getNavigate: () => window.__VINEXT_RSC_NAVIGATE__,
-      getPendingNavigation: () => window.__VINEXT_RSC_PENDING__ as Promise<void> | null,
+      getPendingNavigation: () => window.__VINEXT_RSC_PENDING__ ?? null,
       isCurrentNavigation: (navId: number) =>
         browserNavigationController.isCurrentNavigation(navId),
+      notifyAppRouterTransitionStart: (href) => notifyAppRouterTransitionStart(href, "traverse"),
       restorePopstateScrollPosition,
       setPendingNavigation: (navigation) => {
         window.__VINEXT_RSC_PENDING__ = navigation;

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -654,6 +654,45 @@ function scrollToHashTarget(hash: string): void {
   });
 }
 
+type PopstateRestoreHandlerDependencies = {
+  getActiveNavigationId: () => number;
+  getNavigate: () =>
+    | ((href: string, redirectDepth: number, navigationKind: NavigationKind) => Promise<void>)
+    | null
+    | undefined;
+  getPendingNavigation: () => Promise<void> | null;
+  isCurrentNavigation: (navId: number) => boolean;
+  restorePopstateScrollPosition: (state: unknown) => void;
+  setPendingNavigation: (pendingNavigation: Promise<void> | null) => void;
+};
+
+export function createPopstateRestoreHandler({
+  getActiveNavigationId,
+  getNavigate,
+  getPendingNavigation,
+  isCurrentNavigation,
+  restorePopstateScrollPosition: restore,
+  setPendingNavigation,
+}: PopstateRestoreHandlerDependencies): (event: PopStateEvent) => void {
+  return (event) => {
+    notifyAppRouterTransitionStart(window.location.href, "traverse");
+    const navigateRsc = getNavigate();
+    const pendingNavigation =
+      navigateRsc?.(window.location.href, 0, "traverse") ?? Promise.resolve();
+    const popstateNavId = navigateRsc ? getActiveNavigationId() : null;
+    setPendingNavigation(pendingNavigation);
+    void pendingNavigation.finally(() => {
+      if (popstateNavId !== null && !isCurrentNavigation(popstateNavId)) {
+        return;
+      }
+      restore(event.state);
+      if (getPendingNavigation() === pendingNavigation) {
+        setPendingNavigation(null);
+      }
+    });
+  };
+}
+
 function restorePopstateScrollPosition(state: unknown): void {
   if (!(state && typeof state === "object" && "__vinext_scrollY" in state)) {
     if (window.location.hash) {
@@ -1329,26 +1368,20 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
   // Pages Router scroll restoration is handled in shims/navigation.ts:1289 with
   // microtask-based deferral for compatibility with non-RSC navigation.
   // See: https://github.com/vercel/next.js/discussions/41934#discussioncomment-4602607
-  window.addEventListener("popstate", (event) => {
-    notifyAppRouterTransitionStart(window.location.href, "traverse");
-    const navigateRsc = window.__VINEXT_RSC_NAVIGATE__;
-    const pendingNavigation =
-      navigateRsc?.(window.location.href, 0, "traverse") ?? Promise.resolve();
-    const popstateNavId = navigateRsc ? browserNavigationController.getActiveNavigationId() : null;
-    window.__VINEXT_RSC_PENDING__ = pendingNavigation;
-    void pendingNavigation.finally(() => {
-      if (
-        popstateNavId !== null &&
-        !browserNavigationController.isCurrentNavigation(popstateNavId)
-      ) {
-        return;
-      }
-      restorePopstateScrollPosition(event.state);
-      if (window.__VINEXT_RSC_PENDING__ === pendingNavigation) {
-        window.__VINEXT_RSC_PENDING__ = null;
-      }
-    });
-  });
+  window.addEventListener(
+    "popstate",
+    createPopstateRestoreHandler({
+      getActiveNavigationId: () => browserNavigationController.getActiveNavigationId(),
+      getNavigate: () => window.__VINEXT_RSC_NAVIGATE__,
+      getPendingNavigation: () => window.__VINEXT_RSC_PENDING__ as Promise<void> | null,
+      isCurrentNavigation: (navId: number) =>
+        browserNavigationController.isCurrentNavigation(navId),
+      restorePopstateScrollPosition,
+      setPendingNavigation: (navigation) => {
+        window.__VINEXT_RSC_PENDING__ = navigation;
+      },
+    }),
+  );
 
   if (import.meta.hot) {
     const handleRscUpdate = async (): Promise<void> => {

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -682,10 +682,9 @@ export function createPopstateRestoreHandler({
     const popstateNavId = navigateRsc ? getActiveNavigationId() : null;
     setPendingNavigation(pendingNavigation);
     void pendingNavigation.finally(() => {
-      if (popstateNavId !== null && !isCurrentNavigation(popstateNavId)) {
-        return;
+      if (popstateNavId === null || isCurrentNavigation(popstateNavId)) {
+        restore(event.state);
       }
-      restore(event.state);
       if (getPendingNavigation() === pendingNavigation) {
         setPendingNavigation(null);
       }

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -1331,10 +1331,18 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
   // See: https://github.com/vercel/next.js/discussions/41934#discussioncomment-4602607
   window.addEventListener("popstate", (event) => {
     notifyAppRouterTransitionStart(window.location.href, "traverse");
+    const navigateRsc = window.__VINEXT_RSC_NAVIGATE__;
     const pendingNavigation =
-      window.__VINEXT_RSC_NAVIGATE__?.(window.location.href, 0, "traverse") ?? Promise.resolve();
+      navigateRsc?.(window.location.href, 0, "traverse") ?? Promise.resolve();
+    const popstateNavId = navigateRsc ? browserNavigationController.getActiveNavigationId() : null;
     window.__VINEXT_RSC_PENDING__ = pendingNavigation;
     void pendingNavigation.finally(() => {
+      if (
+        popstateNavId !== null &&
+        !browserNavigationController.isCurrentNavigation(popstateNavId)
+      ) {
+        return;
+      }
       restorePopstateScrollPosition(event.state);
       if (window.__VINEXT_RSC_PENDING__ === pendingNavigation) {
         window.__VINEXT_RSC_PENDING__ = null;

--- a/packages/vinext/src/server/app-browser-popstate.ts
+++ b/packages/vinext/src/server/app-browser-popstate.ts
@@ -1,0 +1,39 @@
+type PopstateRestoreHandlerDependencies = {
+  getActiveNavigationId: () => number;
+  getNavigate: () =>
+    | ((href: string, redirectDepth: number, navigationKind: "traverse") => Promise<void>)
+    | null
+    | undefined;
+  getPendingNavigation: () => Promise<void> | null;
+  isCurrentNavigation: (navId: number) => boolean;
+  notifyAppRouterTransitionStart: (href: string) => void;
+  restorePopstateScrollPosition: (state: unknown) => void;
+  setPendingNavigation: (pendingNavigation: Promise<void> | null) => void;
+};
+
+export function createPopstateRestoreHandler({
+  getActiveNavigationId,
+  getNavigate,
+  getPendingNavigation,
+  isCurrentNavigation,
+  notifyAppRouterTransitionStart,
+  restorePopstateScrollPosition: restore,
+  setPendingNavigation,
+}: PopstateRestoreHandlerDependencies): (event: PopStateEvent) => void {
+  return (event) => {
+    notifyAppRouterTransitionStart(window.location.href);
+    const navigateRsc = getNavigate();
+    const pendingNavigation =
+      navigateRsc?.(window.location.href, 0, "traverse") ?? Promise.resolve();
+    const popstateNavId = navigateRsc ? getActiveNavigationId() : null;
+    setPendingNavigation(pendingNavigation);
+    void pendingNavigation.finally(() => {
+      if (popstateNavId === null || isCurrentNavigation(popstateNavId)) {
+        restore(event.state);
+      }
+      if (getPendingNavigation() === pendingNavigation) {
+        setPendingNavigation(null);
+      }
+    });
+  };
+}

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -1,7 +1,7 @@
 import React from "react";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import { createOnUncaughtError } from "../packages/vinext/src/server/app-browser-error.js";
-import { createPopstateRestoreHandler } from "../packages/vinext/src/server/app-browser-entry.js";
+import { createPopstateRestoreHandler } from "../packages/vinext/src/server/app-browser-popstate.js";
 import {
   createDiscardedServerActionRefreshScheduler,
   createServerActionInitiationSnapshot,
@@ -275,7 +275,7 @@ describe("createPopstateRestoreHandler", () => {
         return null;
       }
       navigationIndex += 1;
-      return async () => deferreds[index].promise;
+      return () => deferreds[index].promise;
     };
     let activeNavId = 0;
 
@@ -288,10 +288,11 @@ describe("createPopstateRestoreHandler", () => {
         if (navigation === null || navigation === undefined) return null;
 
         activeNavId += 1;
-        return async () => navigation();
+        return () => navigation();
       },
-      getPendingNavigation: () => window.__VINEXT_RSC_PENDING__ as Promise<void> | null,
+      getPendingNavigation: () => window.__VINEXT_RSC_PENDING__ ?? null,
       isCurrentNavigation: (navId) => navId === activeNavId,
+      notifyAppRouterTransitionStart: () => {},
       restorePopstateScrollPosition: (state) => {
         restoredStates.push(state);
       },
@@ -330,13 +331,12 @@ describe("createPopstateRestoreHandler", () => {
       getNavigate: () => {
         if (navigationCalls > 0) return null;
         navigationCalls += 1;
-        return async () => {
-          activeNavId += 1;
-          return first.promise;
-        };
+        activeNavId += 1;
+        return () => first.promise;
       },
-      getPendingNavigation: () => window.__VINEXT_RSC_PENDING__ as Promise<void> | null,
+      getPendingNavigation: () => window.__VINEXT_RSC_PENDING__ ?? null,
       isCurrentNavigation: (navId) => navId === activeNavId,
+      notifyAppRouterTransitionStart: () => {},
       restorePopstateScrollPosition: () => {
         restoreCalls += 1;
       },

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -1,6 +1,7 @@
 import React from "react";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import { createOnUncaughtError } from "../packages/vinext/src/server/app-browser-error.js";
+import { createPopstateRestoreHandler } from "../packages/vinext/src/server/app-browser-entry.js";
 import {
   createDiscardedServerActionRefreshScheduler,
   createServerActionInitiationSnapshot,
@@ -250,6 +251,71 @@ function stubWindow(href: string) {
 
   return { assign, replace, storage };
 }
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+describe("createPopstateRestoreHandler", () => {
+  it("restores scroll only for the latest popstate navigation", async () => {
+    stubWindow("https://example.com/page");
+    const restoredStates: unknown[] = [];
+    const first = createDeferred<void>();
+    const second = createDeferred<void>();
+    const deferreds = [first, second];
+    let navigationIndex = 0;
+
+    const getNavigate = () => {
+      const index = navigationIndex;
+      if (index >= deferreds.length) {
+        return null;
+      }
+      navigationIndex += 1;
+      return async () => deferreds[index].promise;
+    };
+    let activeNavId = 0;
+
+    window.__VINEXT_RSC_PENDING__ = null;
+
+    const handler = createPopstateRestoreHandler({
+      getActiveNavigationId: () => activeNavId,
+      getNavigate: () => {
+        const navigation = getNavigate();
+        if (navigation === null || navigation === undefined) return null;
+
+        activeNavId += 1;
+        return async () => navigation();
+      },
+      getPendingNavigation: () => window.__VINEXT_RSC_PENDING__ as Promise<void> | null,
+      isCurrentNavigation: (navId) => navId === activeNavId,
+      restorePopstateScrollPosition: (state) => {
+        restoredStates.push(state);
+      },
+      setPendingNavigation: (pending) => {
+        window.__VINEXT_RSC_PENDING__ = pending;
+      },
+    });
+
+    handler({ state: { __vinext_scrollY: 10 } } as PopStateEvent);
+    handler({ state: { __vinext_scrollY: 20 } } as PopStateEvent);
+
+    // Resolve the newest popstate nav first; it should restore its state.
+    second.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(restoredStates).toEqual([{ __vinext_scrollY: 20 }]);
+
+    first.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(restoredStates).toEqual([{ __vinext_scrollY: 20 }]);
+    expect(window.__VINEXT_RSC_PENDING__).toBeNull();
+  });
+});
 
 afterEach(() => {
   vi.restoreAllMocks();

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -315,6 +315,50 @@ describe("createPopstateRestoreHandler", () => {
     expect(restoredStates).toEqual([{ __vinext_scrollY: 20 }]);
     expect(window.__VINEXT_RSC_PENDING__).toBeNull();
   });
+
+  it("clears pending popstate navigation state when an older popstate navigation becomes stale", async () => {
+    stubWindow("https://example.com/page");
+    const first = createDeferred<void>();
+    let activeNavId = 0;
+    let navigationCalls = 0;
+    let restoreCalls = 0;
+
+    window.__VINEXT_RSC_PENDING__ = null;
+
+    const handler = createPopstateRestoreHandler({
+      getActiveNavigationId: () => activeNavId,
+      getNavigate: () => {
+        if (navigationCalls > 0) return null;
+        navigationCalls += 1;
+        return async () => {
+          activeNavId += 1;
+          return first.promise;
+        };
+      },
+      getPendingNavigation: () => window.__VINEXT_RSC_PENDING__ as Promise<void> | null,
+      isCurrentNavigation: (navId) => navId === activeNavId,
+      restorePopstateScrollPosition: () => {
+        restoreCalls += 1;
+      },
+      setPendingNavigation: (pending) => {
+        window.__VINEXT_RSC_PENDING__ = pending;
+      },
+    });
+
+    handler({ state: { __vinext_scrollY: 10 } } as PopStateEvent);
+    expect(window.__VINEXT_RSC_PENDING__).toBe(first.promise);
+
+    // Simulate a superseding programmatic navigation that does not set a pending
+    // popstate marker.
+    activeNavId += 1;
+
+    first.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(restoreCalls).toBe(0);
+    expect(window.__VINEXT_RSC_PENDING__).toBeNull();
+  });
 });
 
 afterEach(() => {


### PR DESCRIPTION
## Summary
Prevents stale App Router popstate completions from restoring an old history scroll position after rapid back/forward races.

## Problem
`window.__VINEXT_RSC_NAVIGATE__` is invoked for every `popstate`, and we currently run `restorePopstateScrollPosition(event.state)` in `.finally` unconditionally. If multiple back/forward traversals run concurrently, an older navigation can resolve after a newer one and incorrectly restore scroll for the stale history entry.

This manifests as jumpy/incorrect scroll when users navigate quickly or under network jitter.

## Why this change is meaningful
This is not speculative UI behavior tuning; it is a concrete race-condition fix affecting user-visible navigation state:

- it changes externally observable behavior (scroll restoration correctness)
- it closes a stale async completion window
- it aligns with existing vinext nav lifecycle semantics (`activeNavigationId` / `isCurrentNavigation`) and with Next.js intent to drop superseded traversals

## Implementation
In `packages/vinext/src/server/app-browser-entry.ts`:

- capture the `navigate` session id (`navId`) for each popstate-triggered RSC navigation via `browserNavigationController.getActiveNavigationId()`
- skip scroll restoration in the `.finally` handler unless that `navId` is still current
- keep the existing `__VINEXT_RSC_PENDING__` identity guard for clearing only the current pending marker

Net effect: only the winner traversal may restore scroll, and superseded traversals settle quietly.

## Next.js parity / reference
- Next.js App Router uses an action queue where `ACTION_NAVIGATE`/`ACTION_RESTORE` supersede pending work by marking it `discarded`:
  https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/app-router-instance.ts#L173-L206
- App Router popstate dispatches restore actions through this queue:
  https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/app-router.tsx#L375-L399
- Next.js Pages Router cancellation path for superseded async navigation also uses explicit cancellation handlers:
  https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/router/router.ts#L670-L696

## Validation
- Implemented as a focused diff in the App Router popstate finalizer in the browser entry.
- Commit hash: `0abbf083`

