### PR TITLE
fix(server): render progressive action not-found HTML

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -447,6 +447,8 @@ export default __createAppRscHandler({
   dispatchMatchedPage({
     cleanPathname,
     formState,
+    actionError,
+    actionFailed,
     handlerStart,
     interceptionContext,
     isProgressiveActionRender,
@@ -513,6 +515,8 @@ export default __createAppRscHandler({
       interceptionContext,
       expireSeconds: __expireTime,
       formState,
+      actionError,
+      actionFailed,
       isProgressiveActionRender,
       isProduction: process.env.NODE_ENV === "production",
       isRscRequest,

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -157,6 +157,8 @@ type DispatchAppPageOptions<TRoute extends AppPageDispatchRoute> = {
   fetchCache?: FetchCacheMode | null;
   findIntercept: (pathname: string) => AppPageDispatchIntercept | null;
   formState?: ReactFormState | null;
+  actionError?: unknown;
+  actionFailed?: boolean;
   generateStaticParams?: ValidateAppPageDynamicParamsOptions["generateStaticParams"];
   getFontLinks: () => string[];
   getFontPreloads: () => AppPageFontPreload[];
@@ -583,6 +585,9 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
 
   const pageBuildResult = await buildAppPageElement({
     buildPageElement() {
+      if (options.actionFailed) {
+        throw options.actionError;
+      }
       return options.buildPageElement(
         route,
         options.params,

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -85,6 +85,8 @@ type AppRscRouteMatch<TRoute> = {
 type DispatchMatchedPageOptions<TRoute> = {
   cleanPathname: string;
   formState: ReactFormState | null;
+  actionError?: unknown;
+  actionFailed?: boolean;
   handlerStart: number;
   interceptionContext: string | null;
   isProgressiveActionRender: boolean;
@@ -165,9 +167,16 @@ type CreateAppRscHandlerOptions<TRoute extends AppRscHandlerRoute> = {
     options: DispatchMatchedRouteHandlerOptions<TRoute>,
   ) => Promise<Response>;
   ensureInstrumentation?: () => Promise<void>;
-  handleProgressiveActionRequest: (
-    options: HandleProgressiveActionRequestOptions,
-  ) => Promise<Response | { formState: ReactFormState | null; kind: "form-state" } | null>;
+  handleProgressiveActionRequest: (options: HandleProgressiveActionRequestOptions) => Promise<
+    | Response
+    | {
+        actionError?: unknown;
+        actionFailed?: boolean;
+        formState: ReactFormState | null;
+        kind: "form-state";
+      }
+    | null
+  >;
   handleServerActionRequest: (
     options: HandleServerActionRequestOptions,
   ) => Promise<Response | null>;
@@ -420,6 +429,8 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
   if (progressiveActionResult instanceof Response) return progressiveActionResult;
   const isProgressiveActionRender = progressiveActionResult?.kind === "form-state";
   const formState = isProgressiveActionRender ? progressiveActionResult.formState : null;
+  const actionError = isProgressiveActionRender ? progressiveActionResult.actionError : undefined;
+  const actionFailed = isProgressiveActionRender && progressiveActionResult.actionFailed === true;
 
   const serverActionResponse = await options.handleServerActionRequest({
     actionId,
@@ -521,6 +532,8 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
   return options.dispatchMatchedPage({
     cleanPathname,
     formState,
+    actionError,
+    actionFailed,
     handlerStart,
     interceptionContext: interceptionContextHeader,
     isProgressiveActionRender,

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -118,6 +118,18 @@ type HandleProgressiveActionRequestOptions = {
   request: Request;
 };
 
+type ProgressiveActionFormStateResult =
+  | {
+      formState: ReactFormState | null;
+      kind: "form-state";
+    }
+  | {
+      actionError: unknown;
+      actionFailed: true;
+      formState: null;
+      kind: "form-state";
+    };
+
 type HandleServerActionRequestOptions = {
   actionId: string | null;
   cleanPathname: string;
@@ -167,16 +179,9 @@ type CreateAppRscHandlerOptions<TRoute extends AppRscHandlerRoute> = {
     options: DispatchMatchedRouteHandlerOptions<TRoute>,
   ) => Promise<Response>;
   ensureInstrumentation?: () => Promise<void>;
-  handleProgressiveActionRequest: (options: HandleProgressiveActionRequestOptions) => Promise<
-    | Response
-    | {
-        actionError?: unknown;
-        actionFailed?: boolean;
-        formState: ReactFormState | null;
-        kind: "form-state";
-      }
-    | null
-  >;
+  handleProgressiveActionRequest: (
+    options: HandleProgressiveActionRequestOptions,
+  ) => Promise<Response | ProgressiveActionFormStateResult | null>;
   handleServerActionRequest: (
     options: HandleServerActionRequestOptions,
   ) => Promise<Response | null>;
@@ -429,8 +434,12 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
   if (progressiveActionResult instanceof Response) return progressiveActionResult;
   const isProgressiveActionRender = progressiveActionResult?.kind === "form-state";
   const formState = isProgressiveActionRender ? progressiveActionResult.formState : null;
-  const actionError = isProgressiveActionRender ? progressiveActionResult.actionError : undefined;
-  const actionFailed = isProgressiveActionRender && progressiveActionResult.actionFailed === true;
+  const failedProgressiveActionResult =
+    isProgressiveActionRender && "actionFailed" in progressiveActionResult
+      ? progressiveActionResult
+      : null;
+  const actionFailed = failedProgressiveActionResult !== null;
+  const actionError = failedProgressiveActionResult?.actionError;
 
   const serverActionResponse = await options.handleServerActionRequest({
     actionId,

--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -73,12 +73,17 @@ type AppServerActionRoute = {
   pattern: string;
 };
 
-type ProgressiveServerActionResult = {
-  actionError?: unknown;
-  actionFailed?: boolean;
-  formState: ReactFormState | null;
-  kind: "form-state";
-};
+type ProgressiveServerActionResult =
+  | {
+      formState: ReactFormState | null;
+      kind: "form-state";
+    }
+  | {
+      actionError: unknown;
+      actionFailed: true;
+      formState: null;
+      kind: "form-state";
+    };
 
 type AppServerActionMatch<TRoute extends AppServerActionRoute> = {
   params: AppPageParams;

--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -74,6 +74,8 @@ type AppServerActionRoute = {
 };
 
 type ProgressiveServerActionResult = {
+  actionError?: unknown;
+  actionFailed?: boolean;
   formState: ReactFormState | null;
   kind: "form-state";
 };
@@ -198,16 +200,6 @@ export type HandleServerActionRscRequestOptions<
   toInterceptOpts: (intercept: AppServerActionIntercept<TPage>) => TInterceptOpts;
 };
 
-type ActionControlResponse =
-  | {
-      kind: "redirect";
-      url: string;
-    }
-  | {
-      kind: "status";
-      statusCode: number;
-    };
-
 /**
  * Matches Next.js' server action argument cap to prevent stack overflow in
  * Function.prototype.apply when decoding hostile action payloads.
@@ -295,33 +287,6 @@ export async function readActionFormDataWithLimit(
   return new Response(combined, {
     headers: { "Content-Type": request.headers.get("content-type") || "" },
   }).formData();
-}
-
-function getActionControlResponse(error: unknown): ActionControlResponse | null {
-  const digest = getNextErrorDigest(error);
-  if (!digest) return null;
-
-  const redirect = parseNextRedirectDigest(digest);
-  if (redirect) {
-    return {
-      kind: "redirect",
-      url: redirect.url,
-    };
-  }
-
-  const httpError = parseNextHttpErrorDigest(digest);
-  if (httpError) {
-    if (!Number.isInteger(httpError.status)) {
-      return null;
-    }
-
-    return {
-      kind: "status",
-      statusCode: httpError.status,
-    };
-  }
-
-  return null;
 }
 
 function getActionRedirect(error: unknown): AppServerActionRedirect | null {
@@ -449,22 +414,43 @@ export async function handleProgressiveServerActionRequest(
       return null;
     }
 
-    let actionControlResponse: ActionControlResponse | null = null;
+    let actionRedirect: AppServerActionRedirect | null = null;
+    let actionError: unknown = undefined;
+    let actionFailed = false;
     let actionResult: unknown;
     const previousHeadersPhase = options.setHeadersAccessPhase("action");
     try {
       actionResult = await action();
     } catch (error) {
-      actionControlResponse = getActionControlResponse(error);
-      if (!actionControlResponse) {
-        throw error;
+      actionRedirect = getActionRedirect(error);
+      if (!actionRedirect) {
+        actionError = error;
+        actionFailed = true;
+        const isControlFlow =
+          getActionHttpFallbackStatus(error) !== null || isServerActionNotFoundError(error, null);
+        if (!isControlFlow) {
+          console.error("[vinext] Server action error:", error);
+          options.reportRequestError(
+            normalizeError(error),
+            {
+              path: options.cleanPathname,
+              method: options.request.method,
+              headers: Object.fromEntries(options.request.headers.entries()),
+            },
+            { routerKind: "App Router", routePath: options.cleanPathname, routeType: "action" },
+          );
+        }
       }
     } finally {
       options.setHeadersAccessPhase(previousHeadersPhase);
     }
 
-    if (!actionControlResponse) {
+    if (!actionRedirect) {
       getAndClearActionRevalidationKind();
+      if (actionFailed) {
+        return { kind: "form-state", formState: null, actionError, actionFailed };
+      }
+
       const formState = await options.decodeFormState(actionResult, body);
       return { kind: "form-state", formState: formState ?? null };
     }
@@ -477,9 +463,7 @@ export async function handleProgressiveServerActionRequest(
     options.clearRequestContext();
 
     const headers = new Headers();
-    if (actionControlResponse.kind === "redirect") {
-      headers.set("Location", new URL(actionControlResponse.url, options.request.url).toString());
-    }
+    headers.set("Location", new URL(actionRedirect.url, options.request.url).toString());
     mergeMiddlewareResponseHeaders(headers, options.middlewareHeaders);
     for (const cookie of actionPendingCookies) {
       headers.append("Set-Cookie", cookie);
@@ -490,7 +474,7 @@ export async function handleProgressiveServerActionRequest(
     setActionRevalidatedHeader(headers, actionRevalidationKind);
 
     return new Response(null, {
-      status: actionControlResponse.kind === "redirect" ? 303 : actionControlResponse.statusCode,
+      status: 303,
       headers,
     });
   } catch (error) {
@@ -503,10 +487,7 @@ export async function handleProgressiveServerActionRequest(
 
     getAndClearActionRevalidationKind();
     options.getAndClearPendingCookies();
-    // Next.js rethrows generic MPA action errors into its page render path.
-    // vinext does not yet implement that form-state render path, so unexpected
-    // action failures remain request failures here.
-    console.error("[vinext] Server action error:", error);
+    console.error("[vinext] Server action payload parsing error:", error);
     options.reportRequestError(
       normalizeError(error),
       {
@@ -520,7 +501,7 @@ export async function handleProgressiveServerActionRequest(
     return internalServerErrorResponse(
       process.env.NODE_ENV === "production"
         ? undefined
-        : "Server action failed: " + getServerActionFailureMessage(error),
+        : "Server action parsing failed: " + getServerActionFailureMessage(error),
     );
   }
 }

--- a/tests/app-page-dispatch.test.ts
+++ b/tests/app-page-dispatch.test.ts
@@ -74,6 +74,8 @@ function createDispatchOptions(
     clearRequestContext?: DispatchOptions["clearRequestContext"];
     generateStaticParams?: DispatchOptions["generateStaticParams"];
     formState?: DispatchOptions["formState"];
+    actionError?: DispatchOptions["actionError"];
+    actionFailed?: DispatchOptions["actionFailed"];
     isProgressiveActionRender?: DispatchOptions["isProgressiveActionRender"];
     isProduction?: boolean;
     isRscRequest?: boolean;
@@ -126,6 +128,8 @@ function createDispatchOptions(
     hasPageModule: true,
     handlerStart: 10,
     formState: overrides.formState,
+    actionError: overrides.actionError,
+    actionFailed: overrides.actionFailed,
     interceptionContext: null,
     isProgressiveActionRender: overrides.isProgressiveActionRender,
     isProduction: overrides.isProduction ?? false,
@@ -270,6 +274,31 @@ describe("app page dispatch", () => {
     expect(response.headers.get("x-vinext-cache")).toBeNull();
     expect(response.headers.get("cache-control")).toBe("no-store, must-revalidate");
     await expect(response.text()).resolves.toBe("<html>page</html>");
+  });
+
+  it("renders not-found HTML when a progressive action calls notFound()", async () => {
+    const buildPageElement = vi.fn(async () => React.createElement("main", null, "page"));
+    const renderHttpAccessFallbackPage = vi.fn(
+      async () => new Response("<html>not found</html>", { status: 404 }),
+    );
+    const { options } = createDispatchOptions({
+      actionError: { digest: "NEXT_HTTP_ERROR_FALLBACK;404" },
+      actionFailed: true,
+      buildPageElement,
+      isProgressiveActionRender: true,
+    });
+    options.renderHttpAccessFallbackPage = renderHttpAccessFallbackPage;
+
+    const response = await dispatchAppPage(options);
+
+    expect(response.status).toBe(404);
+    await expect(response.text()).resolves.toBe("<html>not found</html>");
+    expect(buildPageElement).not.toHaveBeenCalled();
+    expect(renderHttpAccessFallbackPage).toHaveBeenCalledWith(
+      404,
+      { matchedParams: { slug: "hello" } },
+      null,
+    );
   });
 
   it("does not bypass cached production HTML for arbitrary draft cookie values", async () => {

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -3890,6 +3890,20 @@ describe("App Router next.config.js features (generateRscEntry)", () => {
     expect(code).toContain("matchRoute,");
   });
 
+  it("forwards progressive action failures from the generated RSC handler into page dispatch", () => {
+    const code = generateRscEntry("/tmp/test/app", minimalRoutes, null, [], null, "", false);
+
+    expect(code).toContain(`dispatchMatchedPage({
+    cleanPathname,
+    formState,
+    actionError,
+    actionFailed,`);
+    expect(code).toContain(`formState,
+      actionError,
+      actionFailed,
+      isProgressiveActionRender,`);
+  });
+
   it("describes beforeFiles rewrites in the generated app shape", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes, null, [], null, "", false, {
       rewrites: {

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -3890,20 +3890,6 @@ describe("App Router next.config.js features (generateRscEntry)", () => {
     expect(code).toContain("matchRoute,");
   });
 
-  it("forwards progressive action failures from the generated RSC handler into page dispatch", () => {
-    const code = generateRscEntry("/tmp/test/app", minimalRoutes, null, [], null, "", false);
-
-    expect(code).toContain(`dispatchMatchedPage({
-    cleanPathname,
-    formState,
-    actionError,
-    actionFailed,`);
-    expect(code).toContain(`formState,
-      actionError,
-      actionFailed,
-      isProgressiveActionRender,`);
-  });
-
   it("describes beforeFiles rewrites in the generated app shape", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes, null, [], null, "", false, {
       rewrites: {

--- a/tests/app-server-action-execution.test.ts
+++ b/tests/app-server-action-execution.test.ts
@@ -458,67 +458,95 @@ describe("app server action execution helpers", () => {
     expect((await request.formData()).get("field")).toBe("value");
   });
 
-  it("maps action HTTP fallback errors to status responses", async () => {
-    for (const [digest, statusCode] of [
-      ["NEXT_NOT_FOUND", 404],
-      ["NEXT_HTTP_ERROR_FALLBACK;403", 403],
-    ]) {
+  it("passes HTTP fallback errors as actionError to be rendered by error boundaries", async () => {
+    for (const digest of ["NEXT_NOT_FOUND", "NEXT_HTTP_ERROR_FALLBACK;403"]) {
       const clearContext = vi.fn();
       const reportedErrors: Error[] = [];
 
-      const response = requireProgressiveActionResponse(
-        await handleProgressiveServerActionRequest(
-          createOptions({
-            clearRequestContext: clearContext,
-            async decodeAction() {
-              return () => {
-                throw { digest };
-              };
-            },
-            reportRequestError(error) {
-              reportedErrors.push(error);
-            },
-          }),
-        ),
+      const result = await handleProgressiveServerActionRequest(
+        createOptions({
+          clearRequestContext: clearContext,
+          async decodeAction() {
+            return () => {
+              throw { digest };
+            };
+          },
+          reportRequestError(error) {
+            reportedErrors.push(error);
+          },
+        }),
       );
 
-      expect(response.status).toBe(statusCode);
+      expect(result).toEqual({
+        kind: "form-state",
+        formState: null,
+        actionError: { digest },
+        actionFailed: true,
+      });
       expect(reportedErrors).toEqual([]);
-      expect(clearContext).toHaveBeenCalledTimes(1);
+      expect(clearContext).not.toHaveBeenCalled(); // Let app-rsc-handler clear it after render
     }
   });
 
-  it("reports action execution failures and clears pending cookies", async () => {
+  it("passes action execution failures as actionError to be rendered by error boundaries", async () => {
     const reportedErrors: Error[] = [];
     const clearedCookies = vi.fn(() => ["session=1; Path=/"]);
     const clearContext = vi.fn();
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
-    const response = requireProgressiveActionResponse(
-      await handleProgressiveServerActionRequest(
-        createOptions({
-          cleanPathname: "/action-source",
-          clearRequestContext: clearContext,
-          async decodeAction() {
-            return () => {
-              throw new Error("boom");
-            };
-          },
-          getAndClearPendingCookies: clearedCookies,
-          reportRequestError(error) {
-            reportedErrors.push(error);
-          },
-        }),
-      ),
+    const error = new Error("boom");
+    const result = await handleProgressiveServerActionRequest(
+      createOptions({
+        cleanPathname: "/action-source",
+        clearRequestContext: clearContext,
+        async decodeAction() {
+          return () => {
+            throw error;
+          };
+        },
+        getAndClearPendingCookies: clearedCookies,
+        reportRequestError(err) {
+          reportedErrors.push(err);
+        },
+      }),
     );
 
-    expect(response.status).toBe(500);
-    expect(await response.text()).toBe("Server action failed: boom");
-    expect(reportedErrors.map((error) => error.message)).toEqual(["boom"]);
-    expect(clearedCookies).toHaveBeenCalledTimes(1);
-    expect(clearContext).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      kind: "form-state",
+      formState: null,
+      actionError: error,
+      actionFailed: true,
+    });
+    expect(reportedErrors.map((e) => e.message)).toEqual(["boom"]);
+    expect(clearedCookies).not.toHaveBeenCalled(); // Only cleared if response is rendered here
+    expect(clearContext).not.toHaveBeenCalled(); // Handled by app-rsc-handler
 
     errorSpy.mockRestore();
+  });
+
+  it("passes falsy action execution failures to the page render path", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      const result = await handleProgressiveServerActionRequest(
+        createOptions({
+          async decodeAction() {
+            return () => {
+              throw 0;
+            };
+          },
+        }),
+      );
+
+      expect(result).toEqual({
+        kind: "form-state",
+        formState: null,
+        actionError: 0,
+        actionFailed: true,
+      });
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 
   // Ported from Next.js: test/e2e/app-dir/no-server-actions/no-server-actions.test.ts


### PR DESCRIPTION
## Overview

| Field | Details |
| --- | --- |
| Goal | Match Next.js progressive multipart server action behavior when an action calls `notFound()` or another HTTP fallback. |
| Core change | Keep redirect actions as 303 responses, but route non-redirect action throws back into page rendering instead of returning an empty status response. |
| Main boundary | `handleProgressiveServerActionRequest` now hands action failures to `createAppRscHandler`, which passes them into `dispatchAppPage` for existing special-error rendering. |
| Primary files | `app-server-action-execution.ts`, `app-rsc-handler.ts`, `app-page-dispatch.ts` |
| Expected impact | No-JS `useActionState` form submissions that call `notFound()` render the app's not-found HTML instead of a blank 404 body. |

## Why

Progressive form actions are MPA-style submissions. When the action throws an HTTP fallback, the server response must be the page render for that fallback, not only the fallback status code. Next.js models this explicitly: fetch actions package the error into Flight, while MPA actions return a `not-found` action result and `app-render` renders the not-found loader tree to HTML.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| Progressive actions | MPA action responses own full HTML rendering. | HTTP fallback throws become render inputs instead of terminal empty responses. |
| Redirects | Redirect control flow remains response-level for MPA form submissions. | Redirects still return `303` with `Location` and action headers. |
| Error handoff | Thrown values may be falsy and still represent a failed action. | Uses an explicit `actionFailed` flag instead of truthiness. |

## What Changed

| Scenario | Before | After |
| --- | --- | --- |
| Progressive action calls `notFound()` | `404` response with no body. | `404` response with rendered not-found HTML. |
| Progressive action throws generic error | Immediate 500 from action execution helper. | Error is passed into page dispatch so app error handling can render it. |
| Progressive action redirects | `303` response. | Still `303` response. |

<details>
<summary>Maintainer review path</summary>

1. `packages/vinext/src/server/app-server-action-execution.ts`: action execution now distinguishes redirects from action failures and returns an action-failed form-state result for non-redirect throws.
2. `packages/vinext/src/server/app-rsc-handler.ts`: progressive action results now carry `actionError` plus explicit `actionFailed` into matched page dispatch.
3. `packages/vinext/src/server/app-page-dispatch.ts`: action failures are rethrown during element construction so existing HTTP fallback and error boundary machinery owns the response.
4. `tests/app-server-action-execution.test.ts` and `tests/app-page-dispatch.test.ts`: helper contract plus rendered HTML regression coverage.

</details>

<details>
<summary>Validation</summary>

- `vp test run tests/app-server-action-execution.test.ts tests/app-rsc-handler.test.ts tests/app-page-dispatch.test.ts`
- `vp check tests/app-server-action-execution.test.ts tests/app-rsc-handler.test.ts tests/app-page-dispatch.test.ts`
- `vp check`

</details>

<details>
<summary>Risk / compatibility</summary>

- Public API: no public API changes.
- Runtime: changes only progressive multipart action submissions without an action header.
- Compatibility: intentionally follows Next.js' MPA action semantics for HTTP fallback and generic thrown errors.
- Existing app risk: redirect behavior is preserved; successful form-state actions still decode form state normally.

</details>

<details>
<summary>Non-goals</summary>

- Does not change fetch action Flight semantics.
- Does not add browser e2e coverage for every `useActionState` fallback variant. The added coverage targets the lowest honest server boundaries for this regression.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| [Next.js `HandleActionResult` includes MPA `not-found`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/action-handler.ts#L525-L533) | Establishes the intended non-fetch action result shape. |
| [Next.js HTTP fallback handling in action handler](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/action-handler.ts#L1223-L1251) | Shows fetch actions package Flight while MPA actions request HTML fallback rendering. |
| [Next.js app-render renders not-found loader tree](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/app-render.tsx#L2997-L3034) | Confirms the body should be rendered HTML, not an empty status response. |
| [Next.js `useActionState` action calling `notFound()` fixture](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/global-not-found/cache-components/app/action/page.tsx#L1-L20) | Covers the same form-action surface. |
| [Next.js e2e assertion for rendered not-found boundary](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/global-not-found/cache-components/cache-components.test.ts#L16-L23) | Confirms the user-visible behavior expected after submission. |
