### PR TITLE
fix(router): decode hash scroll targets

### DIFF
--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -33,6 +33,7 @@ import {
   type CachedRscResponse,
   type ClientNavigationRenderSnapshot,
 } from "vinext/shims/navigation";
+import { scrollToHashTargetOnNextFrame } from "vinext/shims/hash-scroll";
 import { installWindowNext } from "../client/window-next.js";
 import {
   chunksToReadableStream,
@@ -627,37 +628,10 @@ function restoreHydrationNavigationContext(
   });
 }
 
-function decodeHashFragment(fragment: string): string {
-  try {
-    return decodeURIComponent(fragment);
-  } catch {
-    return fragment;
-  }
-}
-
-function scrollToHashTarget(hash: string): void {
-  const fragment = decodeHashFragment(hash.startsWith("#") ? hash.slice(1) : hash);
-
-  requestAnimationFrame(() => {
-    if (fragment === "" || fragment === "top") {
-      window.scrollTo(0, 0);
-      return;
-    }
-
-    const idElement = document.getElementById(fragment);
-    if (idElement) {
-      idElement.scrollIntoView({ behavior: "auto" });
-      return;
-    }
-
-    document.getElementsByName(fragment)[0]?.scrollIntoView({ behavior: "auto" });
-  });
-}
-
 function restorePopstateScrollPosition(state: unknown): void {
   if (!(state && typeof state === "object" && "__vinext_scrollY" in state)) {
     if (window.location.hash) {
-      scrollToHashTarget(window.location.hash);
+      scrollToHashTargetOnNextFrame(window.location.hash);
     }
     return;
   }

--- a/packages/vinext/src/shims/hash-scroll.ts
+++ b/packages/vinext/src/shims/hash-scroll.ts
@@ -1,0 +1,32 @@
+export function decodeHashFragment(fragment: string): string {
+  try {
+    return decodeURIComponent(fragment);
+  } catch {
+    // Malformed percent escapes cannot be decoded; keep navigation alive and
+    // attempt browser-style matching against the raw fragment.
+    return fragment;
+  }
+}
+
+export function scrollToHashTarget(hash: string): void {
+  const fragment = decodeHashFragment(hash.startsWith("#") ? hash.slice(1) : hash);
+
+  if (fragment === "" || fragment === "top") {
+    window.scrollTo(0, 0);
+    return;
+  }
+
+  const idElement = document.getElementById(fragment);
+  if (idElement) {
+    idElement.scrollIntoView({ behavior: "auto" });
+    return;
+  }
+
+  document.getElementsByName(fragment)[0]?.scrollIntoView({ behavior: "auto" });
+}
+
+export function scrollToHashTargetOnNextFrame(hash: string): void {
+  requestAnimationFrame(() => {
+    scrollToHashTarget(hash);
+  });
+}

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -29,6 +29,7 @@ import { stripBasePath } from "../utils/base-path.js";
 import { ReadonlyURLSearchParams } from "./readonly-url-search-params.js";
 import { assertSafeNavigationUrl } from "./url-safety.js";
 import { AppRouterContext } from "./internal/app-router-context.js";
+import { scrollToHashTarget } from "./hash-scroll.js";
 
 // ─── Layout segment context ───────────────────────────────────────────────────
 // Stores the child segments below the current layout. Each layout wraps its
@@ -1101,21 +1102,6 @@ function isHashOnlyChange(href: string): boolean {
   return isHashOnlyBrowserUrlChange(href, window.location.href, __basePath);
 }
 
-/**
- * Scroll to a hash target element, or to the top if no hash.
- */
-function scrollToHash(hash: string): void {
-  if (!hash || hash === "#") {
-    window.scrollTo(0, 0);
-    return;
-  }
-  const id = hash.slice(1);
-  const element = document.getElementById(id);
-  if (element) {
-    element.scrollIntoView({ behavior: "auto" });
-  }
-}
-
 // ---------------------------------------------------------------------------
 // History method wrappers — suppress notifications for internal updates
 // ---------------------------------------------------------------------------
@@ -1312,7 +1298,7 @@ export async function navigateClientSide(
     }
     commitClientNavigationState();
     if (scroll) {
-      scrollToHash(hash);
+      scrollToHashTarget(hash);
     }
     return;
   }
@@ -1349,7 +1335,7 @@ export async function navigateClientSide(
 
   if (scroll) {
     if (hash) {
-      scrollToHash(hash);
+      scrollToHashTarget(hash);
     } else {
       window.scrollTo(0, 0);
     }

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -31,6 +31,7 @@ import {
   type UrlQuery,
   urlQueryToSearchParams,
 } from "../utils/query.js";
+import { scrollToHashTarget } from "./hash-scroll.js";
 
 /** basePath from next.config.js, injected by the plugin at build time */
 const __basePath: string = process.env.__NEXT_ROUTER_BASEPATH ?? "";
@@ -203,16 +204,6 @@ export function isHashOnlyChange(href: string): boolean {
   if (href.startsWith("#")) return true;
   if (typeof window === "undefined") return false;
   return isHashOnlyBrowserUrlChange(href, window.location.href, __basePath);
-}
-
-/** Scroll to hash target element, or top if no hash */
-function scrollToHash(hash: string): void {
-  if (!hash || hash === "#") {
-    window.scrollTo(0, 0);
-    return;
-  }
-  const el = document.getElementById(hash.slice(1));
-  if (el) el.scrollIntoView({ behavior: "auto" });
 }
 
 /** Save current scroll position into history state for back/forward restoration */
@@ -684,7 +675,7 @@ export function useRouter(): NextRouter {
         const hash = resolved.includes("#") ? resolved.slice(resolved.indexOf("#")) : "";
         window.history.pushState({}, "", resolved.startsWith("#") ? resolved : full);
         _lastPathnameAndSearch = window.location.pathname + window.location.search;
-        scrollToHash(hash);
+        scrollToHashTarget(hash);
         setState(getPathnameAndQuery());
         routerEvents.emit("hashChangeComplete", eventUrl, {
           shallow: options?.shallow ?? false,
@@ -709,7 +700,7 @@ export function useRouter(): NextRouter {
       // Scroll: handle hash target, else scroll to top unless scroll:false
       const hash = resolved.includes("#") ? resolved.slice(resolved.indexOf("#")) : "";
       if (hash) {
-        scrollToHash(hash);
+        scrollToHashTarget(hash);
       } else if (options?.scroll !== false) {
         window.scrollTo(0, 0);
       }
@@ -744,7 +735,7 @@ export function useRouter(): NextRouter {
         const hash = resolved.includes("#") ? resolved.slice(resolved.indexOf("#")) : "";
         window.history.replaceState({}, "", resolved.startsWith("#") ? resolved : full);
         _lastPathnameAndSearch = window.location.pathname + window.location.search;
-        scrollToHash(hash);
+        scrollToHashTarget(hash);
         setState(getPathnameAndQuery());
         routerEvents.emit("hashChangeComplete", eventUrl, {
           shallow: options?.shallow ?? false,
@@ -768,7 +759,7 @@ export function useRouter(): NextRouter {
       // Scroll: handle hash target, else scroll to top unless scroll:false
       const hash = resolved.includes("#") ? resolved.slice(resolved.indexOf("#")) : "";
       if (hash) {
-        scrollToHash(hash);
+        scrollToHashTarget(hash);
       } else if (options?.scroll !== false) {
         window.scrollTo(0, 0);
       }
@@ -855,7 +846,7 @@ if (typeof window !== "undefined") {
       // Hash-only back/forward — no page fetch needed
       const hashUrl = appUrl + window.location.hash;
       routerEvents.emit("hashChangeStart", hashUrl, { shallow: false });
-      scrollToHash(window.location.hash);
+      scrollToHashTarget(window.location.hash);
       routerEvents.emit("hashChangeComplete", hashUrl, { shallow: false });
       window.dispatchEvent(new CustomEvent("vinext:navigate"));
       return;
@@ -1009,7 +1000,7 @@ const Router = {
       const hash = resolved.includes("#") ? resolved.slice(resolved.indexOf("#")) : "";
       window.history.pushState({}, "", resolved.startsWith("#") ? resolved : full);
       _lastPathnameAndSearch = window.location.pathname + window.location.search;
-      scrollToHash(hash);
+      scrollToHashTarget(hash);
       routerEvents.emit("hashChangeComplete", eventUrl, {
         shallow: options?.shallow ?? false,
       });
@@ -1031,7 +1022,7 @@ const Router = {
 
     const hash = resolved.includes("#") ? resolved.slice(resolved.indexOf("#")) : "";
     if (hash) {
-      scrollToHash(hash);
+      scrollToHashTarget(hash);
     } else if (options?.scroll !== false) {
       window.scrollTo(0, 0);
     }
@@ -1062,7 +1053,7 @@ const Router = {
       const hash = resolved.includes("#") ? resolved.slice(resolved.indexOf("#")) : "";
       window.history.replaceState({}, "", resolved.startsWith("#") ? resolved : full);
       _lastPathnameAndSearch = window.location.pathname + window.location.search;
-      scrollToHash(hash);
+      scrollToHashTarget(hash);
       routerEvents.emit("hashChangeComplete", eventUrl, {
         shallow: options?.shallow ?? false,
       });
@@ -1083,7 +1074,7 @@ const Router = {
 
     const hash = resolved.includes("#") ? resolved.slice(resolved.indexOf("#")) : "";
     if (hash) {
-      scrollToHash(hash);
+      scrollToHashTarget(hash);
     } else if (options?.scroll !== false) {
       window.scrollTo(0, 0);
     }

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -675,7 +675,9 @@ export function useRouter(): NextRouter {
         const hash = resolved.includes("#") ? resolved.slice(resolved.indexOf("#")) : "";
         window.history.pushState({}, "", resolved.startsWith("#") ? resolved : full);
         _lastPathnameAndSearch = window.location.pathname + window.location.search;
-        scrollToHashTarget(hash);
+        if (options?.scroll !== false) {
+          scrollToHashTarget(hash);
+        }
         setState(getPathnameAndQuery());
         routerEvents.emit("hashChangeComplete", eventUrl, {
           shallow: options?.shallow ?? false,
@@ -699,10 +701,12 @@ export function useRouter(): NextRouter {
 
       // Scroll: handle hash target, else scroll to top unless scroll:false
       const hash = resolved.includes("#") ? resolved.slice(resolved.indexOf("#")) : "";
-      if (hash) {
-        scrollToHashTarget(hash);
-      } else if (options?.scroll !== false) {
-        window.scrollTo(0, 0);
+      if (options?.scroll !== false) {
+        if (hash) {
+          scrollToHashTarget(hash);
+        } else {
+          window.scrollTo(0, 0);
+        }
       }
       window.dispatchEvent(new CustomEvent("vinext:navigate"));
       return true;
@@ -735,7 +739,9 @@ export function useRouter(): NextRouter {
         const hash = resolved.includes("#") ? resolved.slice(resolved.indexOf("#")) : "";
         window.history.replaceState({}, "", resolved.startsWith("#") ? resolved : full);
         _lastPathnameAndSearch = window.location.pathname + window.location.search;
-        scrollToHashTarget(hash);
+        if (options?.scroll !== false) {
+          scrollToHashTarget(hash);
+        }
         setState(getPathnameAndQuery());
         routerEvents.emit("hashChangeComplete", eventUrl, {
           shallow: options?.shallow ?? false,
@@ -758,10 +764,12 @@ export function useRouter(): NextRouter {
 
       // Scroll: handle hash target, else scroll to top unless scroll:false
       const hash = resolved.includes("#") ? resolved.slice(resolved.indexOf("#")) : "";
-      if (hash) {
-        scrollToHashTarget(hash);
-      } else if (options?.scroll !== false) {
-        window.scrollTo(0, 0);
+      if (options?.scroll !== false) {
+        if (hash) {
+          scrollToHashTarget(hash);
+        } else {
+          window.scrollTo(0, 0);
+        }
       }
       window.dispatchEvent(new CustomEvent("vinext:navigate"));
       return true;
@@ -1000,7 +1008,9 @@ const Router = {
       const hash = resolved.includes("#") ? resolved.slice(resolved.indexOf("#")) : "";
       window.history.pushState({}, "", resolved.startsWith("#") ? resolved : full);
       _lastPathnameAndSearch = window.location.pathname + window.location.search;
-      scrollToHashTarget(hash);
+      if (options?.scroll !== false) {
+        scrollToHashTarget(hash);
+      }
       routerEvents.emit("hashChangeComplete", eventUrl, {
         shallow: options?.shallow ?? false,
       });
@@ -1021,10 +1031,12 @@ const Router = {
     routerEvents.emit("routeChangeComplete", resolved, { shallow: options?.shallow ?? false });
 
     const hash = resolved.includes("#") ? resolved.slice(resolved.indexOf("#")) : "";
-    if (hash) {
-      scrollToHashTarget(hash);
-    } else if (options?.scroll !== false) {
-      window.scrollTo(0, 0);
+    if (options?.scroll !== false) {
+      if (hash) {
+        scrollToHashTarget(hash);
+      } else {
+        window.scrollTo(0, 0);
+      }
     }
     window.dispatchEvent(new CustomEvent("vinext:navigate"));
     return true;
@@ -1053,7 +1065,9 @@ const Router = {
       const hash = resolved.includes("#") ? resolved.slice(resolved.indexOf("#")) : "";
       window.history.replaceState({}, "", resolved.startsWith("#") ? resolved : full);
       _lastPathnameAndSearch = window.location.pathname + window.location.search;
-      scrollToHashTarget(hash);
+      if (options?.scroll !== false) {
+        scrollToHashTarget(hash);
+      }
       routerEvents.emit("hashChangeComplete", eventUrl, {
         shallow: options?.shallow ?? false,
       });
@@ -1073,10 +1087,12 @@ const Router = {
     routerEvents.emit("routeChangeComplete", resolved, { shallow: options?.shallow ?? false });
 
     const hash = resolved.includes("#") ? resolved.slice(resolved.indexOf("#")) : "";
-    if (hash) {
-      scrollToHashTarget(hash);
-    } else if (options?.scroll !== false) {
-      window.scrollTo(0, 0);
+    if (options?.scroll !== false) {
+      if (hash) {
+        scrollToHashTarget(hash);
+      } else {
+        window.scrollTo(0, 0);
+      }
     }
     window.dispatchEvent(new CustomEvent("vinext:navigate"));
     return true;

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -10915,6 +10915,90 @@ describe("Pages Router concurrent navigation", () => {
     });
   });
 
+  it("scrolls hash-only pushes to URI-decoded id targets", async () => {
+    const previousWindow = (globalThis as any).window;
+    const previousDocument = (globalThis as any).document;
+    const originalFetch = globalThis.fetch;
+    const { win } = createNavWindow();
+    (globalThis as any).window = win;
+
+    const target = { scrollIntoView: vi.fn() };
+    const getElementById = vi.fn((id: string) => (id === "hello world" ? target : null));
+    const getElementsByName = vi.fn(() => []);
+    (globalThis as any).document = { getElementById, getElementsByName };
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error("hash-only navigations must not fetch page HTML");
+    });
+    vi.resetModules();
+
+    try {
+      const routerModule = await import("../packages/vinext/src/shims/router.js");
+      const Router = routerModule.default;
+
+      const result = await Router.push("#hello%20world");
+
+      expect(result).toBe(true);
+      expect(getElementById).toHaveBeenCalledWith("hello world");
+      expect(getElementsByName).not.toHaveBeenCalled();
+      expect(target.scrollIntoView).toHaveBeenCalledWith({ behavior: "auto" });
+    } finally {
+      vi.resetModules();
+      if (previousWindow === undefined) {
+        delete (globalThis as any).window;
+      } else {
+        (globalThis as any).window = previousWindow;
+      }
+      if (previousDocument === undefined) {
+        delete (globalThis as any).document;
+      } else {
+        (globalThis as any).document = previousDocument;
+      }
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("scrolls hash-only pushes to named anchors when no id matches", async () => {
+    const previousWindow = (globalThis as any).window;
+    const previousDocument = (globalThis as any).document;
+    const originalFetch = globalThis.fetch;
+    const { win } = createNavWindow();
+    (globalThis as any).window = win;
+
+    const target = { scrollIntoView: vi.fn() };
+    const getElementById = vi.fn(() => null);
+    const getElementsByName = vi.fn((name: string) => (name === "legacy-anchor" ? [target] : []));
+    (globalThis as any).document = { getElementById, getElementsByName };
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error("hash-only navigations must not fetch page HTML");
+    });
+    vi.resetModules();
+
+    try {
+      const routerModule = await import("../packages/vinext/src/shims/router.js");
+      const Router = routerModule.default;
+
+      const result = await Router.push("#legacy-anchor");
+
+      expect(result).toBe(true);
+      expect(getElementById).toHaveBeenCalledWith("legacy-anchor");
+      expect(getElementsByName).toHaveBeenCalledWith("legacy-anchor");
+      expect(target.scrollIntoView).toHaveBeenCalledWith({ behavior: "auto" });
+    } finally {
+      vi.resetModules();
+      if (previousWindow === undefined) {
+        delete (globalThis as any).window;
+      } else {
+        (globalThis as any).window = previousWindow;
+      }
+      if (previousDocument === undefined) {
+        delete (globalThis as any).document;
+      } else {
+        (globalThis as any).document = previousDocument;
+      }
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it("does not strip app-relative targets that start with the basePath segment", async () => {
     await expectBasePathHashOnlyPush({
       browserPath: "/app/app/foo",

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -10999,6 +10999,48 @@ describe("Pages Router concurrent navigation", () => {
     }
   });
 
+  it("does not scroll hash-only pushes when scroll is false", async () => {
+    const previousWindow = (globalThis as any).window;
+    const previousDocument = (globalThis as any).document;
+    const originalFetch = globalThis.fetch;
+    const { win } = createNavWindow();
+    (globalThis as any).window = win;
+
+    const target = { scrollIntoView: vi.fn() };
+    const getElementById = vi.fn(() => target);
+    const getElementsByName = vi.fn(() => []);
+    (globalThis as any).document = { getElementById, getElementsByName };
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error("hash-only navigations must not fetch page HTML");
+    });
+    vi.resetModules();
+
+    try {
+      const routerModule = await import("../packages/vinext/src/shims/router.js");
+      const Router = routerModule.default;
+
+      const result = await Router.push("#legacy-anchor", undefined, { scroll: false });
+
+      expect(result).toBe(true);
+      expect(getElementById).not.toHaveBeenCalled();
+      expect(getElementsByName).not.toHaveBeenCalled();
+      expect(target.scrollIntoView).not.toHaveBeenCalled();
+    } finally {
+      vi.resetModules();
+      if (previousWindow === undefined) {
+        delete (globalThis as any).window;
+      } else {
+        (globalThis as any).window = previousWindow;
+      }
+      if (previousDocument === undefined) {
+        delete (globalThis as any).document;
+      } else {
+        (globalThis as any).document = previousDocument;
+      }
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it("does not strip app-relative targets that start with the basePath segment", async () => {
     await expectBasePathHashOnlyPush({
       browserPath: "/app/app/foo",


### PR DESCRIPTION
## Overview

| Field | Details |
| --- | --- |
| Goal | Match Next.js hash scrolling for URI-encoded fragments and named anchors. |
| Core change | Centralize hash target resolution, then use it from `next/navigation`, `next/router`, and app browser popstate restoration. |
| Primary files | `packages/vinext/src/shims/hash-scroll.ts`, `packages/vinext/src/shims/navigation.ts`, `packages/vinext/src/shims/router.ts`, `packages/vinext/src/server/app-browser-entry.ts`, `tests/shims.test.ts` |
| Expected impact | Hash-only client navigation can now scroll to `id="hello world"` via `#hello%20world` and can fall back to legacy `name` anchors. |

## Why

Hash navigation is a browser-visible compatibility surface. Next.js resolves hash fragments by decoding the URI fragment, checking `id`, and then falling back to `name`; vinext only checked raw ids in the router shims, so encoded ids and named anchors were skipped despite the app browser popstate path already having the correct behavior.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| Hash fragment decoding | URL hash fragments are encoded transport, not DOM ids. | Decodes one `decodeURIComponent` pass before DOM lookup. |
| DOM target lookup | Browser-compatible hash scrolling checks `id` first, then `name`. | Adds the `document.getElementsByName()` fallback to router-driven hash navigation. |
| Runtime ownership | Shared browser behavior should not drift across router surfaces. | Moves the already-correct app browser logic into a small shared client helper. |

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| `Router.push("#hello%20world")` with `id="hello world"` | Looked for `hello%20world`, did not scroll. | Looks for `hello world`, scrolls the id target. |
| `Router.push("#legacy-anchor")` with `<a name="legacy-anchor">` | Never checked named anchors. | Checks `name` after id miss and scrolls the first match. |
| `#top` and empty fragment | Only the app browser popstate path handled this consistently. | Shared helper preserves browser-style top scrolling across the router shims. |
| Malformed percent escape | App browser path recovered by using the raw fragment. | Shared helper keeps that vinext recovery behavior. |

<details>
<summary>Maintainer review path</summary>

1. Review `packages/vinext/src/shims/hash-scroll.ts` for the exact target resolution order and malformed-fragment recovery.
2. Review `packages/vinext/src/shims/router.ts` and `packages/vinext/src/shims/navigation.ts` to confirm all old raw-id call sites use the shared helper.
3. Review `packages/vinext/src/server/app-browser-entry.ts` to confirm popstate restoration keeps its `requestAnimationFrame` scheduling while delegating the target decision.
4. Review `tests/shims.test.ts` for the focused red/green coverage through the public Pages Router singleton.

</details>

<details>
<summary>Validation</summary>

- Red check before implementation: `vp test run tests/shims.test.ts -t "hash-only pushes"` failed because `getElementById` received `hello%20world` and `getElementsByName` was never called.
- `vp test run tests/shims.test.ts -t "hash-only pushes"` passed after the fix.
- `vp test run tests/shims.test.ts tests/app-browser-entry.test.ts` passed, 1003 tests.
- `vp check` passed formatting, lint, and type checks.
- Commit hook also reran checked-file formatting, lint/type checks, and `knip`.

</details>

<details>
<summary>Risk / compatibility</summary>

- Public API: no new public Next.js API surface.
- Runtime: browser-only hash scrolling behavior changes to match Next.js and browser anchor behavior more closely.
- Compatibility: intentional vinext-specific recovery is preserved for malformed percent escapes by attempting raw-fragment matching instead of throwing during navigation.
- RSC/App Router: app browser popstate still defers hash scrolling to the next animation frame.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| [Next.js Pages Router `scrollToHash`](https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/router/router.ts#L2328-L2352) | Decodes the hash, handles `#top`, checks `id`, then falls back to `name`. |
| [Next.js App Router navigation hash decoding](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/segment-cache/navigation.ts#L688-L694) | Decodes the hash fragment before storing scroll intent. |
| [Next.js App Router hash DOM lookup](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/layout-router.tsx#L127-L140) | Resolves `top`, then `id`, then `name` in the scroll/focus handler. |
| [Next.js Pages Router CJK hash tests](https://github.com/vercel/next.js/blob/canary/test/development/pages-dir/client-navigation/url-hash.test.ts#L45-L80) | Confirms encoded/non-Latin hash anchors are expected to scroll. |
| [Next.js Pages Router named-anchor test](https://github.com/vercel/next.js/blob/canary/test/development/pages-dir/client-navigation/url-hash.test.ts#L98-L112) | Confirms `name` fallback is expected behavior. |
| [Next.js App Router hash navigation tests](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/navigation/navigation.test.ts#L149-L221) | Confirms App Router hash scrolling and `scroll={false}` behavior. |
