### PR TITLE
fix(link): align visible and intent prefetching

### DIFF
--- a/packages/vinext/src/global.d.ts
+++ b/packages/vinext/src/global.d.ts
@@ -137,6 +137,14 @@ declare global {
      */
     __VINEXT_RSC_PREFETCHED_URLS__: Set<string> | undefined;
 
+    /**
+     * Re-prefetches currently visible App Router links after cache invalidation
+     * or router-state changes. Installed by `next/link` when Link is loaded on
+     * the client; called opportunistically by navigation/cache owners without a
+     * direct import to avoid a circular dependency.
+     */
+    __VINEXT_PING_VISIBLE_LINKS__: (() => void) | undefined;
+
     // ── Next.js conventional globals ────────────────────────────────────────
     //
     // `__NEXT_DATA__` is already declared by `next/dist/client/index.d.ts` as

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -546,6 +546,7 @@ function BrowserRoot({
 
   useLayoutEffect(() => {
     setMountedSlotsHeader(getMountedSlotIdsHeader(stateRef.current.elements));
+    window.__VINEXT_PING_VISIBLE_LINKS__?.();
   }, [treeState.elements]);
 
   useLayoutEffect(() => {

--- a/packages/vinext/src/shims/link-prefetch.ts
+++ b/packages/vinext/src/shims/link-prefetch.ts
@@ -2,6 +2,7 @@ import { hasBasePath, stripBasePath } from "../utils/base-path.js";
 
 export type LinkPrefetchIntent = "viewport" | "intent";
 export type LinkPrefetchPriority = "low" | "high";
+export type LinkPrefetchRouterMode = "app" | "pages";
 
 export type LinkPrefetchDecision =
   | {
@@ -20,13 +21,31 @@ export function canLinkPrefetch(input: {
   return input.nodeEnv === "production" && input.prefetch !== false && !input.isDangerous;
 }
 
+export function canLinkIntentPrefetch(input: {
+  nodeEnv: string | undefined;
+  prefetch: boolean | "auto" | null | undefined;
+  isDangerous: boolean;
+  routerMode: LinkPrefetchRouterMode;
+}): boolean {
+  if (input.nodeEnv !== "production" || input.isDangerous) return false;
+  return input.routerMode === "pages" || input.prefetch !== false;
+}
+
 export function getLinkPrefetchDecision(input: {
   nodeEnv: string | undefined;
   prefetch: boolean | "auto" | null | undefined;
   isDangerous: boolean;
   intent: LinkPrefetchIntent;
+  routerMode?: LinkPrefetchRouterMode;
 }): LinkPrefetchDecision {
-  if (!canLinkPrefetch(input)) return { shouldPrefetch: false };
+  const shouldPrefetch =
+    input.intent === "intent"
+      ? canLinkIntentPrefetch({
+          ...input,
+          routerMode: input.routerMode ?? "app",
+        })
+      : canLinkPrefetch(input);
+  if (!shouldPrefetch) return { shouldPrefetch: false };
 
   return {
     shouldPrefetch: true,

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -62,6 +62,11 @@ type LinkProps = {
   replace?: boolean;
   /** Prefetch the page in the background (App Router default: auto, Pages Router default: true) */
   prefetch?: boolean | "auto" | null;
+  /**
+   * Unstable App Router option matching Next.js canary: an automatic prefetch
+   * is upgraded to a full prefetch when the user shows navigation intent.
+   */
+  unstable_dynamicOnHover?: boolean;
   /** Whether to pass the href to the child element */
   passHref?: boolean;
   /** Scroll to top on navigation (default: true) */
@@ -241,7 +246,37 @@ function prefetchUrl(href: string, mode: LinkPrefetchMode, priority: "low" | "hi
  * All Link elements use the same observer to minimize resource usage.
  */
 let sharedObserver: IntersectionObserver | null = null;
-const observerCallbacks = new WeakMap<Element, () => void>();
+type LinkPrefetchInstance = {
+  href: string;
+  mode: LinkPrefetchMode;
+  isVisible: boolean;
+};
+
+const observedLinkPrefetches = new WeakMap<Element, LinkPrefetchInstance>();
+const visibleLinkPrefetches = new Set<LinkPrefetchInstance>();
+
+function setVisibleLinkPrefetch(instance: LinkPrefetchInstance, isVisible: boolean): void {
+  instance.isVisible = isVisible;
+  if (isVisible) {
+    visibleLinkPrefetches.add(instance);
+    prefetchUrl(instance.href, instance.mode, "low");
+  } else {
+    visibleLinkPrefetches.delete(instance);
+  }
+}
+
+function registerVisibleLinkPing(): void {
+  if (typeof window === "undefined") return;
+  window.__VINEXT_PING_VISIBLE_LINKS__ = pingVisibleLinkPrefetches;
+}
+
+function pingVisibleLinkPrefetches(): void {
+  for (const instance of visibleLinkPrefetches) {
+    if (instance.isVisible) {
+      prefetchUrl(instance.href, instance.mode, "low");
+    }
+  }
+}
 
 function getSharedObserver(): IntersectionObserver | null {
   if (typeof window === "undefined" || typeof IntersectionObserver === "undefined") return null;
@@ -250,15 +285,9 @@ function getSharedObserver(): IntersectionObserver | null {
   sharedObserver = new IntersectionObserver(
     (entries) => {
       for (const entry of entries) {
-        if (entry.isIntersecting) {
-          const callback = observerCallbacks.get(entry.target);
-          if (callback) {
-            callback();
-            // Unobserve after prefetching — only prefetch once
-            sharedObserver?.unobserve(entry.target);
-            observerCallbacks.delete(entry.target);
-          }
-        }
+        const instance = observedLinkPrefetches.get(entry.target);
+        if (!instance) continue;
+        setVisibleLinkPrefetch(instance, entry.isIntersecting || entry.intersectionRatio > 0);
       }
     },
     {
@@ -343,6 +372,7 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
     onMouseEnter,
     onTouchStart,
     onNavigate,
+    unstable_dynamicOnHover = false,
     ...rest
   },
   forwardedRef,
@@ -408,19 +438,33 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
     const observer = getSharedObserver();
     if (!observer) return;
 
-    observerCallbacks.set(node, () => prefetchUrl(hrefToPrefetch, prefetchMode, "low"));
+    registerVisibleLinkPing();
+    const instance: LinkPrefetchInstance = {
+      href: hrefToPrefetch,
+      mode: prefetchMode,
+      isVisible: false,
+    };
+    observedLinkPrefetches.set(node, instance);
     observer.observe(node);
 
     return () => {
       observer.unobserve(node);
-      observerCallbacks.delete(node);
+      observedLinkPrefetches.delete(node);
+      visibleLinkPrefetches.delete(instance);
     };
   }, [shouldPrefetch, prefetchMode, localizedHref]);
 
   const prefetchOnIntent = useCallback(() => {
     if (!shouldPrefetch) return;
-    prefetchUrl(localizedHref, prefetchMode, "high");
-  }, [shouldPrefetch, prefetchMode, localizedHref]);
+    const intentMode = unstable_dynamicOnHover ? "full" : prefetchMode;
+    if (unstable_dynamicOnHover && internalRef.current) {
+      const instance = observedLinkPrefetches.get(internalRef.current);
+      if (instance) {
+        instance.mode = "full";
+      }
+    }
+    prefetchUrl(localizedHref, intentMode, "high");
+  }, [shouldPrefetch, prefetchMode, localizedHref, unstable_dynamicOnHover]);
 
   const handleMouseEnter = useCallback(
     (e: MouseEvent<HTMLAnchorElement>) => {

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -32,7 +32,12 @@ import { AppElementsWire } from "../server/app-elements.js";
 import { createRscRequestHeaders, createRscRequestUrl } from "../server/app-rsc-cache-busting.js";
 import { VINEXT_MOUNTED_SLOTS_HEADER } from "../server/headers.js";
 import { isDangerousScheme } from "./url-safety.js";
-import { canLinkPrefetch, getLinkPrefetchHref } from "./link-prefetch.js";
+import {
+  canLinkIntentPrefetch,
+  canLinkPrefetch,
+  getLinkPrefetchHref,
+  type LinkPrefetchRouterMode,
+} from "./link-prefetch.js";
 import {
   resolveRelativeHref,
   toBrowserNavigationHref,
@@ -146,6 +151,12 @@ function toSameOriginRouteHref(href: string): string | null {
   return `${stripBasePath(url.pathname, __basePath)}${url.search}`;
 }
 
+function getLinkPrefetchRouterMode(): LinkPrefetchRouterMode {
+  return typeof window !== "undefined" && typeof window.__VINEXT_RSC_NAVIGATE__ === "function"
+    ? "app"
+    : "pages";
+}
+
 export function canAutoPrefetchFullAppRoute(href: string): boolean {
   if (typeof window === "undefined") return false;
 
@@ -248,8 +259,10 @@ function prefetchUrl(href: string, mode: LinkPrefetchMode, priority: "low" | "hi
 let sharedObserver: IntersectionObserver | null = null;
 type LinkPrefetchInstance = {
   href: string;
-  mode: LinkPrefetchMode;
   isVisible: boolean;
+  mode: LinkPrefetchMode;
+  routerMode: LinkPrefetchRouterMode;
+  viewportPrefetched: boolean;
 };
 
 const observedLinkPrefetches = new WeakMap<Element, LinkPrefetchInstance>();
@@ -259,7 +272,9 @@ function setVisibleLinkPrefetch(instance: LinkPrefetchInstance, isVisible: boole
   instance.isVisible = isVisible;
   if (isVisible) {
     visibleLinkPrefetches.add(instance);
+    if (instance.routerMode === "pages" && instance.viewportPrefetched) return;
     prefetchUrl(instance.href, instance.mode, "low");
+    instance.viewportPrefetched = true;
   } else {
     visibleLinkPrefetches.delete(instance);
   }
@@ -272,7 +287,7 @@ function registerVisibleLinkPing(): void {
 
 function pingVisibleLinkPrefetches(): void {
   for (const instance of visibleLinkPrefetches) {
-    if (instance.isVisible) {
+    if (instance.isVisible && instance.routerMode === "app") {
       prefetchUrl(instance.href, instance.mode, "low");
     }
   }
@@ -407,7 +422,7 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
   // into a full RSC prefetch, matching Next.js's public prefetch contract.
   const internalRef = useRef<HTMLAnchorElement | null>(null);
   const prefetchMode = resolveLinkPrefetchMode(prefetchProp, isDangerous);
-  const shouldPrefetch = canLinkPrefetch({
+  const shouldViewportPrefetch = canLinkPrefetch({
     nodeEnv: process.env.NODE_ENV,
     prefetch: prefetchProp,
     isDangerous,
@@ -424,7 +439,7 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
   );
 
   useEffect(() => {
-    if (!shouldPrefetch || typeof window === "undefined") return;
+    if (!shouldViewportPrefetch || typeof window === "undefined") return;
     const node = internalRef.current;
     if (!node) return;
 
@@ -441,8 +456,10 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
     registerVisibleLinkPing();
     const instance: LinkPrefetchInstance = {
       href: hrefToPrefetch,
-      mode: prefetchMode,
       isVisible: false,
+      mode: prefetchMode,
+      routerMode: getLinkPrefetchRouterMode(),
+      viewportPrefetched: false,
     };
     observedLinkPrefetches.set(node, instance);
     observer.observe(node);
@@ -452,10 +469,19 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
       observedLinkPrefetches.delete(node);
       visibleLinkPrefetches.delete(instance);
     };
-  }, [shouldPrefetch, prefetchMode, localizedHref]);
+  }, [shouldViewportPrefetch, prefetchMode, localizedHref]);
 
   const prefetchOnIntent = useCallback(() => {
-    if (!shouldPrefetch) return;
+    if (
+      !canLinkIntentPrefetch({
+        nodeEnv: process.env.NODE_ENV,
+        prefetch: prefetchProp,
+        isDangerous,
+        routerMode: getLinkPrefetchRouterMode(),
+      })
+    ) {
+      return;
+    }
     const intentMode = unstable_dynamicOnHover ? "full" : prefetchMode;
     if (unstable_dynamicOnHover && internalRef.current) {
       const instance = observedLinkPrefetches.get(internalRef.current);
@@ -464,7 +490,7 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
       }
     }
     prefetchUrl(localizedHref, intentMode, "high");
-  }, [shouldPrefetch, prefetchMode, localizedHref, unstable_dynamicOnHover]);
+  }, [prefetchProp, isDangerous, prefetchMode, localizedHref, unstable_dynamicOnHover]);
 
   const handleMouseEnter = useCallback(
     (e: MouseEvent<HTMLAnchorElement>) => {

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -473,6 +473,9 @@ export function invalidatePrefetchCache(): void {
     deletePrefetchCacheEntry(cache, prefetched, cacheKey, entry, true);
   }
   prefetched.clear();
+  if (!isServer) {
+    window.__VINEXT_PING_VISIBLE_LINKS__?.();
+  }
 }
 
 /**
@@ -1182,6 +1185,7 @@ export function commitClientNavigationState(
 
   if (shouldNotify) {
     notifyNavigationListeners();
+    window.__VINEXT_PING_VISIBLE_LINKS__?.();
   }
 }
 

--- a/packages/vinext/src/shims/next-shims.d.ts
+++ b/packages/vinext/src/shims/next-shims.d.ts
@@ -117,7 +117,8 @@ declare module "next/link" {
     href: string | { pathname?: string; query?: UrlQuery };
     as?: string;
     replace?: boolean;
-    prefetch?: boolean;
+    prefetch?: boolean | "auto" | null;
+    unstable_dynamicOnHover?: boolean;
     passHref?: boolean;
     scroll?: boolean;
     locale?: string | false;

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -512,8 +512,38 @@ describe("Link App Router prefetch scheduling", () => {
       observer.dispatchIntersectingEntry(result.anchor);
       await flushPrefetchTasks();
 
-      expect(observer.unobserve).toHaveBeenCalledWith(result.anchor);
+      expect(observer.unobserve).not.toHaveBeenCalledWith(result.anchor);
       expect(result.fetch).toHaveBeenCalledWith(
+        expect.stringContaining("/viewport-prefetch-target.rsc"),
+        expect.objectContaining({
+          credentials: "include",
+          priority: "low",
+        }),
+      );
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
+  it("re-prefetches visible links after the prefetch cache is invalidated", async () => {
+    const observer = stubIntersectionObserver();
+
+    const result = await renderIsolatedLink({
+      href: "/viewport-prefetch-target",
+      nodeEnv: "production",
+    });
+    const { invalidatePrefetchCache } = await import("../packages/vinext/src/shims/navigation.js");
+
+    try {
+      observer.dispatchIntersectingEntry(result.anchor);
+      await flushPrefetchTasks();
+      expect(result.fetch).toHaveBeenCalledTimes(1);
+
+      invalidatePrefetchCache();
+      await flushPrefetchTasks();
+
+      expect(result.fetch).toHaveBeenCalledTimes(2);
+      expect(result.fetch).toHaveBeenLastCalledWith(
         expect.stringContaining("/viewport-prefetch-target.rsc"),
         expect.objectContaining({
           credentials: "include",
@@ -538,7 +568,7 @@ describe("Link App Router prefetch scheduling", () => {
       observer.dispatchIntersectingEntry(result.anchor);
       await flushPrefetchTasks();
 
-      expect(observer.unobserve).toHaveBeenCalledWith(result.anchor);
+      expect(observer.unobserve).not.toHaveBeenCalledWith(result.anchor);
       expect(result.fetch).not.toHaveBeenCalled();
     } finally {
       result.restoreNodeEnv();
@@ -559,7 +589,7 @@ describe("Link App Router prefetch scheduling", () => {
       observer.dispatchIntersectingEntry(result.anchor);
       await flushPrefetchTasks();
 
-      expect(observer.unobserve).toHaveBeenCalledWith(result.anchor);
+      expect(observer.unobserve).not.toHaveBeenCalledWith(result.anchor);
       expect(result.fetch).toHaveBeenCalledWith(
         expect.stringContaining("/blog/hello.rsc"),
         expect.objectContaining({
@@ -655,6 +685,47 @@ describe("Link App Router prefetch scheduling", () => {
         expect.objectContaining({
           credentials: "include",
           priority: "high",
+        }),
+      );
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
+  it("upgrades automatic dynamic links to full prefetch on unstable_dynamicOnHover intent", async () => {
+    const observer = stubIntersectionObserver();
+    const result = await renderIsolatedLink({
+      href: "/blog/hello",
+      nodeEnv: "production",
+      props: { unstable_dynamicOnHover: true },
+    });
+    const { invalidatePrefetchCache } = await import("../packages/vinext/src/shims/navigation.js");
+
+    try {
+      observer.dispatchIntersectingEntry(result.anchor);
+      await flushPrefetchTasks();
+      expect(result.fetch).not.toHaveBeenCalled();
+
+      result.capturedAnchorProps.onMouseEnter?.({ currentTarget: result.anchor });
+      await flushPrefetchTasks();
+
+      expect(result.fetch).toHaveBeenCalledWith(
+        expect.stringContaining("/blog/hello.rsc"),
+        expect.objectContaining({
+          credentials: "include",
+          priority: "high",
+        }),
+      );
+
+      invalidatePrefetchCache();
+      await flushPrefetchTasks();
+
+      expect(result.fetch).toHaveBeenCalledTimes(2);
+      expect(result.fetch).toHaveBeenLastCalledWith(
+        expect.stringContaining("/blog/hello.rsc"),
+        expect.objectContaining({
+          credentials: "include",
+          priority: "low",
         }),
       );
     } finally {

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -6,6 +6,7 @@ import {
   getLinkPrefetchHref,
   type LinkPrefetchIntent,
   type LinkPrefetchDecision,
+  type LinkPrefetchRouterMode,
 } from "../packages/vinext/src/shims/link-prefetch.js";
 import type { VinextLinkPrefetchRoute } from "../packages/vinext/src/client/vinext-next-data.js";
 
@@ -29,6 +30,12 @@ type CapturedAnchorProps = {
   onMouseEnter?: (event: CapturedIntentEvent) => void;
   onTouchStart?: (event: CapturedIntentEvent) => void;
   ref?: (node: HTMLAnchorElement | null) => void;
+};
+
+type CapturedPrefetchLinkElement = {
+  as?: string;
+  href?: string;
+  rel?: string;
 };
 
 const linkPrefetchRoutes = [
@@ -177,9 +184,20 @@ describe("Link prefetch pure decisions", () => {
         expected: { shouldPrefetch: true, priority: "high" },
       },
       {
-        name: "prod + prefetch=false",
+        name: "prod + app intent + prefetch=false",
         input: { nodeEnv: "production", prefetch: false, isDangerous: false, intent: "intent" },
         expected: { shouldPrefetch: false },
+      },
+      {
+        name: "prod + pages intent + prefetch=false",
+        input: {
+          nodeEnv: "production",
+          prefetch: false,
+          isDangerous: false,
+          intent: "intent",
+          routerMode: "pages",
+        },
+        expected: { shouldPrefetch: true, priority: "high" },
       },
       {
         name: "prod + dangerous",
@@ -193,6 +211,7 @@ describe("Link prefetch pure decisions", () => {
         prefetch: boolean | undefined;
         isDangerous: boolean;
         intent: LinkPrefetchIntent;
+        routerMode?: LinkPrefetchRouterMode;
       };
       expected: LinkPrefetchDecision;
     }>;
@@ -386,12 +405,21 @@ async function renderIsolatedLink(options: {
   });
 
   const fetch = vi.fn(() => Promise.resolve(new Response("")));
+  const pagePrefetchLinks: CapturedPrefetchLinkElement[] = [];
   const location = {
     href: "https://example.com/current",
     origin: "https://example.com",
   };
 
   vi.stubGlobal("fetch", fetch);
+  vi.stubGlobal("document", {
+    createElement: vi.fn(() => ({})),
+    head: {
+      appendChild: vi.fn((node: CapturedPrefetchLinkElement) => {
+        pagePrefetchLinks.push(node);
+      }),
+    },
+  });
   vi.stubGlobal("window", {
     __VINEXT_RSC_NAVIGATE__: vi.fn(),
     addEventListener: vi.fn(),
@@ -437,6 +465,7 @@ async function renderIsolatedLink(options: {
       anchor,
       capturedAnchorProps,
       fetch,
+      pagePrefetchLinks,
       restoreNodeEnv,
     };
   } catch (error) {
@@ -445,7 +474,7 @@ async function renderIsolatedLink(options: {
   }
 }
 
-describe("Link App Router prefetch scheduling", () => {
+describe("Link prefetch scheduling", () => {
   function stubIntersectionObserver() {
     let intersectionCallback: IntersectionObserverCallback | undefined;
     const observe = vi.fn();
@@ -469,7 +498,7 @@ describe("Link App Router prefetch scheduling", () => {
     return {
       observe,
       unobserve,
-      dispatchIntersectingEntry(anchor: HTMLAnchorElement) {
+      dispatchIntersectingEntry(anchor: HTMLAnchorElement, isIntersecting = true) {
         const rect = {
           bottom: 0,
           height: 0,
@@ -485,9 +514,9 @@ describe("Link App Router prefetch scheduling", () => {
           [
             {
               boundingClientRect: rect,
-              intersectionRatio: 1,
+              intersectionRatio: isIntersecting ? 1 : 0,
               intersectionRect: rect,
-              isIntersecting: true,
+              isIntersecting,
               rootBounds: null,
               target: anchor,
               time: 0,
@@ -820,7 +849,7 @@ describe("Link App Router prefetch scheduling", () => {
     }
   });
 
-  it("does not prefetch on intent when prefetch is false", async () => {
+  it("does not App Router prefetch on intent when prefetch is false", async () => {
     const userOnMouseEnter = vi.fn();
     const result = await renderIsolatedLink({
       href: "/disabled-intent-prefetch-target",
@@ -834,6 +863,112 @@ describe("Link App Router prefetch scheduling", () => {
 
       expect(userOnMouseEnter).toHaveBeenCalledTimes(1);
       expect(result.fetch).not.toHaveBeenCalled();
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
+  it("prefetches Pages Router links on mouse intent when prefetch is false", async () => {
+    const userOnMouseEnter = vi.fn();
+    const result = await renderIsolatedLink({
+      href: "/pages-disabled-mouse-intent-prefetch-target",
+      nodeEnv: "production",
+      props: { onMouseEnter: userOnMouseEnter, prefetch: false },
+      windowOverrides: {
+        __VINEXT_RSC_NAVIGATE__: undefined,
+        __NEXT_DATA__: {
+          __vinext: {
+            pageModuleUrl: "/_next/static/chunks/pages/current.js",
+          },
+        },
+      },
+    });
+
+    try {
+      result.capturedAnchorProps.onMouseEnter?.({ currentTarget: result.anchor });
+      await flushPrefetchTasks();
+
+      expect(userOnMouseEnter).toHaveBeenCalledTimes(1);
+      expect(result.fetch).not.toHaveBeenCalled();
+      expect(result.pagePrefetchLinks).toEqual([
+        {
+          as: "document",
+          href: "/pages-disabled-mouse-intent-prefetch-target",
+          rel: "prefetch",
+        },
+      ]);
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
+  it("prefetches Pages Router links on touch intent when prefetch is false", async () => {
+    const userOnTouchStart = vi.fn();
+    const result = await renderIsolatedLink({
+      href: "/pages-disabled-touch-intent-prefetch-target",
+      nodeEnv: "production",
+      props: { onTouchStart: userOnTouchStart, prefetch: false },
+      windowOverrides: {
+        __VINEXT_RSC_NAVIGATE__: undefined,
+        __NEXT_DATA__: {
+          __vinext: {
+            pageModuleUrl: "/_next/static/chunks/pages/current.js",
+          },
+        },
+      },
+    });
+
+    try {
+      result.capturedAnchorProps.onTouchStart?.({ currentTarget: result.anchor });
+      await flushPrefetchTasks();
+
+      expect(userOnTouchStart).toHaveBeenCalledTimes(1);
+      expect(result.fetch).not.toHaveBeenCalled();
+      expect(result.pagePrefetchLinks).toEqual([
+        {
+          as: "document",
+          href: "/pages-disabled-touch-intent-prefetch-target",
+          rel: "prefetch",
+        },
+      ]);
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
+  it("does not duplicate Pages Router viewport prefetch after visibility changes", async () => {
+    const observer = stubIntersectionObserver();
+    const result = await renderIsolatedLink({
+      href: "/pages-viewport-prefetch-target",
+      nodeEnv: "production",
+      windowOverrides: {
+        __VINEXT_RSC_NAVIGATE__: undefined,
+        __NEXT_DATA__: {
+          __vinext: {
+            pageModuleUrl: "/_next/static/chunks/pages/current.js",
+          },
+        },
+      },
+    });
+
+    try {
+      observer.dispatchIntersectingEntry(result.anchor, true);
+      await flushPrefetchTasks();
+      observer.dispatchIntersectingEntry(result.anchor, false);
+      await flushPrefetchTasks();
+      observer.dispatchIntersectingEntry(result.anchor, true);
+      await flushPrefetchTasks();
+      window.__VINEXT_PING_VISIBLE_LINKS__?.();
+      await flushPrefetchTasks();
+
+      expect(result.fetch).not.toHaveBeenCalled();
+      expect(result.pagePrefetchLinks).toEqual([
+        {
+          as: "document",
+          href: "/pages-viewport-prefetch-target",
+          rel: "prefetch",
+        },
+      ]);
     } finally {
       result.restoreNodeEnv();
     }


### PR DESCRIPTION
## Overview

| Item | Detail |
| --- | --- |
| Goal | Bring vinext Link prefetch scheduling closer to Next.js App and Pages Router behavior. |
| Core change | Track mounted and visible App Router Link prefetch instances, and split intent eligibility by router mode. |
| Boundary | Link owns DOM visibility and intent strategy. Navigation/cache owners only ping visible App Router links through an internal browser hook. |
| Primary files | `packages/vinext/src/shims/link.tsx`, `packages/vinext/src/shims/link-prefetch.ts`, `packages/vinext/src/shims/navigation.ts`, `tests/link-navigation.test.ts` |
| Expected impact | App Router visible links can re-prefetch after cache/router changes, dynamic links can upgrade on hover, and Pages Router `prefetch={false}` still prefetches on hover/touch intent. |

## Why

Correct Link prefetching depends on two separate contracts. App Router prefetching needs mounted Link state to survive beyond the first viewport hit so visible links can be rescheduled when cache or router inputs change. Pages Router has a different `prefetch={false}` contract: it disables viewport prefetch, but hover and touch intent still prefetch.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| Visibility | A visible App Router Link remains a scheduling participant until it leaves the viewport or unmounts. | Keeps observed instances in a WeakMap and visible App Router instances in a Set. |
| Cache invalidation | Clearing App Router prefetch data should give currently visible links a chance to refill it. | `invalidatePrefetchCache()` pings visible App Router links after clearing the cache. |
| Router context | Mounted slot/router-state changes may affect App Router prefetch compatibility. | Browser router commits ping visible links after mounted slot state is refreshed. |
| App Router intent | `prefetch={false}` disables both viewport and hover/touch prefetch. | Intent eligibility preserves the stricter App Router gate. |
| Pages Router intent | `prefetch={false}` disables viewport prefetch only. | Pages Router hover/touch intent still creates a high-priority document prefetch. |
| Dynamic hover | Hover can raise priority and, for `unstable_dynamicOnHover`, upgrade strategy. | Hover updates the visible instance to full prefetch before issuing the high-priority request. |

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| App Router static visible Link | Prefetched once, then unobserved. | Prefetches on first visibility and remains tracked for future App Router pings. |
| App Router cache invalidation | Visible Link prefetch cache stayed empty until another user action. | Visible links re-prefetch after invalidation. |
| App Router dynamic auto Link | Viewport auto prefetch correctly skipped full RSC fetch, but hover could not opt into full prefetch. | `unstable_dynamicOnHover` upgrades hover to full prefetch and persists that strategy for later pings. |
| Pages Router `prefetch={false}` viewport | Disabled. | Still disabled. |
| Pages Router `prefetch={false}` hover/touch | Incorrectly disabled by the shared gate. | Intent prefetch now runs, matching Next.js Pages Router. |
| Pages Router viewport re-entry | Persistent observation could duplicate document prefetch links. | Pages viewport prefetch is one-shot per mounted link and skipped by visible-link pings. |
| Link typings | Local shim accepted narrower `prefetch` type. | Typing now accepts `boolean | "auto" | null` and the unstable hover prop. |

<details>
<summary>Maintainer review path</summary>

1. `packages/vinext/src/shims/link.tsx`: registry shape, router-mode detection, visibility transitions, intent strategy upshift, Pages one-shot viewport behavior, cleanup.
2. `packages/vinext/src/shims/link-prefetch.ts`: trigger/router-mode eligibility split.
3. `packages/vinext/src/shims/navigation.ts`: cache invalidation and committed URL/router-state ping points.
4. `packages/vinext/src/server/app-browser-entry.ts`: mounted slot header update before visible-link ping.
5. `tests/link-navigation.test.ts`: regression coverage for persistent observation, invalidation refill, dynamic hover upgrade, App Router `prefetch={false}` intent suppression, Pages Router `prefetch={false}` hover/touch intent, and Pages viewport re-entry dedupe.

</details>

<details>
<summary>Validation</summary>

- `vp test run tests/link-navigation.test.ts tests/link.test.ts`: 84 tests passed.
- `vp check`: formatting, lint, and type checks passed.
- Commit hooks also ran `vp check --fix` and `knip --no-progress` successfully.

</details>

<details>
<summary>Risk / compatibility</summary>

- Public API: aligns local `next/link` shim typing with supported runtime values. `unstable_dynamicOnHover` remains explicitly unstable.
- Runtime: the visible-link ping hook is optional and browser-only. Navigation/cache code does not import Link, avoiding a circular dependency.
- RSC cache: App Router pings still go through the existing RSC cache key and dedupe path, so duplicate visible pings should not duplicate in-flight or cached RSC fetches.
- Pages Router: intent prefetch now matches Next.js Pages Router semantics for `prefetch={false}`. Pages viewport prefetch stays one-shot to avoid duplicate `<link rel="prefetch">` nodes under the persistent observer.

</details>

<details>
<summary>Non-goals</summary>

- This does not implement Next.js segment-cache or PPR partial prefetching.
- This does not add a full Next.js scheduler with task cancellation and priority queues.
- This does not change the current App Router dynamic-route auto-prefetch policy, which still avoids full automatic RSC prefetch unless explicitly requested or upgraded by hover intent.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| [Next.js App Router Link instance and visible registry](https://github.com/vercel/next.js/blob/d698d658d4af84f67814189cc76488917b9bdf4a/packages/next/src/client/components/links.ts#L97-L108) | Next tracks mounted prefetchable elements separately from the visible set. |
| [Next.js App Router visibility and intent rescheduling](https://github.com/vercel/next.js/blob/d698d658d4af84f67814189cc76488917b9bdf4a/packages/next/src/client/components/links.ts#L246-L285) | Visibility and hover both call into the same rescheduling path, with hover able to switch to full prefetch. |
| [Next.js App Router pingVisibleLinks](https://github.com/vercel/next.js/blob/d698d658d4af84f67814189cc76488917b9bdf4a/packages/next/src/client/components/links.ts#L341-L370) | Visible links are rescheduled after cache/router inputs change. |
| [Next.js unstable_dynamicOnHover prop](https://github.com/vercel/next.js/blob/d698d658d4af84f67814189cc76488917b9bdf4a/packages/next/src/client/app-dir/link.tsx#L159-L163) | Documents the hidden prop as a hover-time full-prefetch upgrade. |
| [Next.js App Router `prefetch={false}` intent gate](https://github.com/vercel/next.js/blob/d698d658d4af84f67814189cc76488917b9bdf4a/packages/next/src/client/app-dir/link.tsx#L695-L731) | App Router disables hover/touch intent when prefetching is disabled. |
| [Next.js Pages Router viewport gate](https://github.com/vercel/next.js/blob/d698d658d4af84f67814189cc76488917b9bdf4a/packages/next/src/client/link.tsx#L574-L584) | Pages Router applies `prefetchEnabled` to viewport prefetch. |
| [Next.js Pages Router hover/touch intent path](https://github.com/vercel/next.js/blob/d698d658d4af84f67814189cc76488917b9bdf4a/packages/next/src/client/link.tsx#L635-L683) | Pages Router hover/touch still prefetch without checking `prefetchEnabled`. |
| [Next.js dynamic-on-hover test](https://github.com/vercel/next.js/blob/d698d658d4af84f67814189cc76488917b9bdf4a/test/e2e/app-dir/segment-cache/dynamic-on-hover/dynamic-on-hover.test.ts#L14-L62) | Confirms hover should prefetch dynamic data and avoid additional requests on navigation. |
