### PR TITLE
fix(app-router): preserve history metadata for external state updates

### DIFF
--- a/packages/vinext/src/server/app-browser-state.ts
+++ b/packages/vinext/src/server/app-browser-state.ts
@@ -29,12 +29,10 @@ import {
   type RouteSnapshotV0,
 } from "./navigation-planner.js";
 import type { ClientNavigationRenderSnapshot } from "vinext/shims/navigation";
-
-const VINEXT_PREVIOUS_NEXT_URL_HISTORY_STATE_KEY = "__vinext_previousNextUrl";
-
-type HistoryStateRecord = {
-  [key: string]: unknown;
-};
+export {
+  createHistoryStateWithPreviousNextUrl,
+  readHistoryStatePreviousNextUrl,
+} from "./app-history-state.js";
 
 export type { OperationLane } from "./navigation-planner.js";
 
@@ -109,38 +107,6 @@ type NonDispatchPendingNavigationCommitDispositionDecision = {
 type PendingNavigationCommitDispositionDecision =
   | DispatchPendingNavigationCommitDispositionDecision
   | NonDispatchPendingNavigationCommitDispositionDecision;
-
-function cloneHistoryState(state: unknown): HistoryStateRecord {
-  if (!state || typeof state !== "object") {
-    return {};
-  }
-
-  const nextState: HistoryStateRecord = {};
-  for (const [key, value] of Object.entries(state)) {
-    nextState[key] = value;
-  }
-  return nextState;
-}
-
-export function createHistoryStateWithPreviousNextUrl(
-  state: unknown,
-  previousNextUrl: string | null,
-): HistoryStateRecord | null {
-  const nextState = cloneHistoryState(state);
-
-  if (previousNextUrl === null) {
-    delete nextState[VINEXT_PREVIOUS_NEXT_URL_HISTORY_STATE_KEY];
-  } else {
-    nextState[VINEXT_PREVIOUS_NEXT_URL_HISTORY_STATE_KEY] = previousNextUrl;
-  }
-
-  return Object.keys(nextState).length > 0 ? nextState : null;
-}
-
-export function readHistoryStatePreviousNextUrl(state: unknown): string | null {
-  const value = cloneHistoryState(state)[VINEXT_PREVIOUS_NEXT_URL_HISTORY_STATE_KEY];
-  return typeof value === "string" ? value : null;
-}
 
 function createOperationRecord(options: {
   id: number;

--- a/packages/vinext/src/server/app-history-state.ts
+++ b/packages/vinext/src/server/app-history-state.ts
@@ -1,0 +1,49 @@
+const VINEXT_PREVIOUS_NEXT_URL_HISTORY_STATE_KEY = "__vinext_previousNextUrl";
+
+type HistoryStateRecord = {
+  [key: string]: unknown;
+};
+
+function cloneHistoryState(state: unknown): HistoryStateRecord {
+  if (!state || typeof state !== "object") {
+    return {};
+  }
+
+  const nextState: HistoryStateRecord = {};
+  for (const [key, value] of Object.entries(state)) {
+    nextState[key] = value;
+  }
+  return nextState;
+}
+
+export function createHistoryStateWithPreviousNextUrl(
+  state: unknown,
+  previousNextUrl: string | null,
+): HistoryStateRecord | null {
+  const nextState = cloneHistoryState(state);
+
+  if (previousNextUrl === null) {
+    delete nextState[VINEXT_PREVIOUS_NEXT_URL_HISTORY_STATE_KEY];
+  } else {
+    nextState[VINEXT_PREVIOUS_NEXT_URL_HISTORY_STATE_KEY] = previousNextUrl;
+  }
+
+  return Object.keys(nextState).length > 0 ? nextState : null;
+}
+
+export function createExternalHistoryStatePreservingMetadata(
+  callerState: unknown,
+  currentHistoryState: unknown,
+): unknown {
+  const previousNextUrl = readHistoryStatePreviousNextUrl(currentHistoryState);
+  if (previousNextUrl === null) {
+    return callerState;
+  }
+
+  return createHistoryStateWithPreviousNextUrl(callerState, previousNextUrl);
+}
+
+export function readHistoryStatePreviousNextUrl(state: unknown): string | null {
+  const value = cloneHistoryState(state)[VINEXT_PREVIOUS_NEXT_URL_HISTORY_STATE_KEY];
+  return typeof value === "string" ? value : null;
+}

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -13,6 +13,7 @@
 import * as React from "react";
 import { notifyAppRouterTransitionStart } from "../client/instrumentation-client-state.js";
 import { AppElementsWire } from "../server/app-elements.js";
+import { createExternalHistoryStatePreservingMetadata } from "../server/app-history-state.js";
 import {
   createRscRequestHeaders,
   createRscRequestUrl,
@@ -2049,7 +2050,12 @@ if (!isServer) {
       unused: string,
       url?: string | URL | null,
     ): void {
-      state.originalPushState.call(window.history, data, unused, url);
+      state.originalPushState.call(
+        window.history,
+        createExternalHistoryStatePreservingMetadata(data, window.history.state),
+        unused,
+        url,
+      );
       if (state.suppressUrlNotifyCount === 0) {
         commitClientNavigationState();
       }
@@ -2060,7 +2066,12 @@ if (!isServer) {
       unused: string,
       url?: string | URL | null,
     ): void {
-      state.originalReplaceState.call(window.history, data, unused, url);
+      state.originalReplaceState.call(
+        window.history,
+        createExternalHistoryStatePreservingMetadata(data, window.history.state),
+        unused,
+        url,
+      );
       if (state.suppressUrlNotifyCount === 0) {
         commitClientNavigationState();
       }

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -225,6 +225,80 @@ describe("next/navigation shim", () => {
     }
   });
 
+  it("preserves App Router history metadata when external history calls provide caller state", async () => {
+    // Matches Next.js' external History API wrapper behavior:
+    // https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/app-router.tsx#L114-L127
+    // Covered by Next.js shallow-routing tests for object, null, and undefined state:
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/shallow-routing/shallow-routing.test.ts
+    const previousWindow = (globalThis as any).window;
+    const historyMetadataKey = "__vinext_previousNextUrl";
+    const win = {
+      location: {
+        pathname: "/photo/1",
+        search: "",
+        hash: "",
+        href: "http://localhost/photo/1",
+        origin: "http://localhost",
+      },
+      history: {
+        state: { [historyMetadataKey]: "/feed" } as unknown,
+        pushState(data: unknown, _unused: string, url?: string | URL | null) {
+          this.state = data;
+          if (!url) return;
+          const parsed = new URL(url, win.location.href);
+          win.location.pathname = parsed.pathname;
+          win.location.search = parsed.search;
+          win.location.hash = parsed.hash;
+          win.location.href = parsed.href;
+        },
+        replaceState(data: unknown, _unused: string, url?: string | URL | null) {
+          this.state = data;
+          if (!url) return;
+          const parsed = new URL(url, win.location.href);
+          win.location.pathname = parsed.pathname;
+          win.location.search = parsed.search;
+          win.location.hash = parsed.hash;
+          win.location.href = parsed.href;
+        },
+      },
+      addEventListener: vi.fn(),
+    };
+    (globalThis as any).window = win;
+
+    try {
+      vi.resetModules();
+      await import("../packages/vinext/src/shims/navigation.js");
+
+      win.history.pushState({ myData: { foo: "bar" } }, "", "/photo/1?filter=active");
+      expect(win.history.state).toEqual({
+        myData: { foo: "bar" },
+        [historyMetadataKey]: "/feed",
+      });
+
+      win.history.pushState(null, "", "/photo/1?filter=pending");
+      expect(win.history.state).toEqual({
+        [historyMetadataKey]: "/feed",
+      });
+
+      win.history.replaceState(null, "", "/photo/1?filter=archived");
+      expect(win.history.state).toEqual({
+        [historyMetadataKey]: "/feed",
+      });
+
+      win.history.replaceState(undefined, "", "/photo/1?filter=all");
+      expect(win.history.state).toEqual({
+        [historyMetadataKey]: "/feed",
+      });
+    } finally {
+      vi.resetModules();
+      if (previousWindow === undefined) {
+        delete (globalThis as any).window;
+      } else {
+        (globalThis as any).window = previousWindow;
+      }
+    }
+  });
+
   it("exports redirect, notFound, permanentRedirect", async () => {
     const nav = await import("../packages/vinext/src/shims/navigation.js");
     expect(typeof nav.redirect).toBe("function");


### PR DESCRIPTION
## Overview

| Field | Details |
| --- | --- |
| Goal | Preserve App Router interception metadata when app code calls `window.history.pushState` or `window.history.replaceState` directly. |
| Core change | Copy the current vinext `previousNextUrl` history marker onto caller-provided history state before delegating to the browser History API. |
| Main boundary | Public History API wrappers in the `next/navigation` shim. |
| Primary files | `packages/vinext/src/shims/navigation.ts`, `packages/vinext/src/server/app-history-state.ts`, `tests/shims.test.ts` |
| Expected impact | External shallow URL updates no longer drop the interception source needed by later App Router traversal and refresh paths. |

## Why

App Router history entries need to carry enough internal state for later traversal to reconstruct the same router context. Vinext stores the intercepted-route source URL in `history.state.__vinext_previousNextUrl`; if an external shallow `pushState` or `replaceState` replaces that state with caller data, later App Router work can lose the interception context.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| History API wrappers | External URL updates should update public URL hooks without erasing App Router internals. | The wrappers now preserve vinext history metadata before calling the original browser method. |
| Intercepting routes | `previousNextUrl` is the client-side source for deriving interception context during traversal. | The marker survives external object, `null`, and `undefined` caller state. |
| Next.js parity | Next.js copies internal App Router state before external `pushState` and `replaceState`. | Vinext now follows that same contract for its equivalent metadata. |

## What Changed

| Scenario | Before | After |
| --- | --- | --- |
| `history.pushState({ myData }, '', url)` while current history state has `__vinext_previousNextUrl` | Stored only `{ myData }`, dropping the vinext marker. | Stores caller data plus `__vinext_previousNextUrl`. |
| `history.pushState(null, '', url)` in the same state | Stored `null`. | Stores the current vinext marker. |
| `history.replaceState(null/undefined, '', url)` in the same state | Replaced the entry with `null` or `undefined`. | Replaces it with the current vinext marker. |

<details>
<summary>Maintainer review path</summary>

1. `packages/vinext/src/server/app-history-state.ts` extracts the existing previousNextUrl history helpers and adds the external-copy helper.
2. `packages/vinext/src/shims/navigation.ts` uses that helper in the patched public `pushState` and `replaceState` paths.
3. `packages/vinext/src/server/app-browser-state.ts` re-exports the extracted helpers so existing App Router imports keep the same boundary.
4. `tests/shims.test.ts` covers the public wrapper behavior with object, `null`, and `undefined` caller state.

</details>

<details>
<summary>Validation</summary>

- `vp test run tests/shims.test.ts -t "preserves App Router history metadata"`
- `vp test run tests/shims.test.ts`
- `vp test run tests/app-browser-entry.test.ts -t "previousNextUrl"`
- `vp test run tests/app-browser-entry.test.ts`
- `vp check`
- Commit hook also ran formatting, lint/type checks, and `knip`.

</details>

<details>
<summary>Risk / compatibility</summary>

- Public API: no new public API surface.
- Runtime: only affects patched browser History API calls when the current entry already contains vinext App Router metadata.
- Compatibility: aligns with the Next.js App Router wrapper behavior for direct History API usage.
- Existing app risk: low. Caller state is still preserved when present, with the internal vinext marker copied alongside it.

</details>

<details>
<summary>Non-goals</summary>

- This does not change Pages Router history behavior.
- This does not redesign scroll restoration state.
- This does not add e2e coverage for a full intercepted-route modal flow because the failing contract is at the public History API wrapper boundary.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| [Next.js `copyNextJsInternalHistoryState`](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/app-router.tsx#L114-L127) | Shows Next.js copies internal App Router history state into external caller state. |
| [Next.js external `pushState` and `replaceState` wrappers](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/app-router.tsx#L327-L371) | Confirms this is intentional wrapper behavior, not incidental state shape. |
| [Next.js shallow-routing tests](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/shallow-routing/shallow-routing.test.ts) | Covers direct History API usage with object, `null`, and `undefined` state inputs. |
| [Next.js segment-cache nextUrl regression context](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/segment-cache/optimistic-route-cache-keying-regression/optimistic-route-cache-keying-regression.test.ts#L18-L41) | Documents why the referring `nextUrl` dimension matters for interception-aware routing and caching. |
