### PR TITLE
fix(app-router): emit streamed redirect and not-found meta tags

### DIFF
--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -435,12 +435,15 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
                 styles: options.getFontStyles(),
                 preloads: options.getFontPreloads(),
               },
-              revalidatedRscCapture.sideStream
-                ? {
-                    sideStream: revalidatedRscCapture.sideStream,
-                    capturedRscDataRef: revalidatedCapturedRscRef,
-                  }
-                : undefined,
+              {
+                basePath: options.basePath,
+                ...(revalidatedRscCapture.sideStream
+                  ? {
+                      sideStream: revalidatedRscCapture.sideStream,
+                      capturedRscDataRef: revalidatedCapturedRscRef,
+                    }
+                  : {}),
+              },
             );
             const html = await readStreamAsText(revalidatedHtmlStream);
             const rscData = await getCapturedRscDataPromise(revalidatedCapturedRscRef.value);
@@ -603,6 +606,7 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
   }
 
   return renderAppPageLifecycle({
+    basePath: options.basePath,
     cleanPathname: options.cleanPathname,
     clearRequestContext: options.clearRequestContext,
     consumeDynamicUsage,

--- a/packages/vinext/src/server/app-page-execution.ts
+++ b/packages/vinext/src/server/app-page-execution.ts
@@ -3,7 +3,7 @@ import type { ClassificationReason } from "../build/layout-classification-types.
 import { createRscRedirectLocation } from "./app-rsc-cache-busting.js";
 import { mergeMiddlewareResponseHeaders } from "./middleware-response-headers.js";
 import { parseNextHttpErrorDigest, parseNextRedirectDigest } from "./next-error-digest.js";
-import { hasBasePath } from "../utils/base-path.js";
+import { addBasePathToPathname } from "../utils/base-path.js";
 
 export type { LayoutFlags };
 export type { ClassificationReason };
@@ -175,10 +175,7 @@ function applyAppPageRedirectBasePath(
   if (!basePath || resolved.origin !== requestOrigin) {
     return resolved.toString();
   }
-  if (hasBasePath(resolved.pathname, basePath)) {
-    return resolved.toString();
-  }
-  resolved.pathname = resolved.pathname === "/" ? basePath : `${basePath}${resolved.pathname}`;
+  resolved.pathname = addBasePathToPathname(resolved.pathname, basePath);
   return resolved.toString();
 }
 

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -68,6 +68,7 @@ type AppPageRequestCacheLife = {
 };
 
 type RenderAppPageLifecycleOptions = {
+  basePath?: string;
   cleanPathname: string;
   clearRequestContext: () => void;
   consumeDynamicUsage: () => boolean;
@@ -492,6 +493,7 @@ export async function renderAppPageLifecycle(
         capturedRscDataRef,
         fontData,
         navigationContext: options.getNavigationContext(),
+        basePath: options.basePath,
         formState: options.formState ?? null,
         rscStream: rscForResponse,
         scriptNonce: options.scriptNonce,

--- a/packages/vinext/src/server/app-page-stream.ts
+++ b/packages/vinext/src/server/app-page-stream.ts
@@ -23,6 +23,7 @@ export type AppPageSsrHandler = {
     options?: {
       formState?: ReactFormState | null;
       scriptNonce?: string;
+      basePath?: string;
       sideStream?: ReadableStream<Uint8Array>;
       capturedRscDataRef?: { value: Promise<ArrayBuffer> | null };
       /** When true, wait for the full React tree before emitting bytes. */
@@ -37,6 +38,7 @@ type RenderAppPageHtmlStreamOptions = {
   navigationContext: unknown;
   rscStream: ReadableStream<Uint8Array>;
   scriptNonce?: string;
+  basePath?: string;
   ssrHandler: AppPageSsrHandler;
   /** Pre-split side stream for fused embed+capture (#981). When set,
    *  handleSsr skips its internal tee and accumulates raw RSC bytes. */
@@ -98,6 +100,7 @@ export async function renderAppPageHtmlStream(
   const ssrOptions = {
     formState: options.formState ?? null,
     scriptNonce: options.scriptNonce,
+    basePath: options.basePath,
     sideStream: options.sideStream,
     capturedRscDataRef: options.capturedRscDataRef,
     waitForAllReady: options.waitForAllReady,

--- a/packages/vinext/src/server/app-ssr-entry.ts
+++ b/packages/vinext/src/server/app-ssr-entry.ts
@@ -27,6 +27,7 @@ import {
 } from "./html.js";
 import { createRscEmbedTransform, createTickBufferedTransform } from "./app-ssr-stream.js";
 import { deferUntilStreamConsumed } from "./app-page-stream.js";
+import { createSsrErrorMetaRenderer } from "./app-ssr-error-meta.js";
 import { AppElementsWire, type AppWireElements } from "./app-elements.js";
 import { ElementsContext, Slot } from "vinext/shims/slot";
 import { AppRouterContext } from "vinext/shims/internal/app-router-context";
@@ -169,6 +170,7 @@ export async function handleSsr(
     /** Out-parameter: filled with accumulated raw RSC bytes when sideStream is consumed. */
     capturedRscDataRef?: { value: Promise<ArrayBuffer> | null };
     formState?: ReactFormState | null;
+    basePath?: string;
     /** When true, wait for the full React tree (including Suspense boundaries)
      *  to resolve before returning the HTML stream. Used for static prerender
      *  and ISR cache writes to avoid caching fallback content. */
@@ -242,12 +244,17 @@ export async function handleSsr(
       const ssrRoot = withScriptNonce(ssrTree, options?.scriptNonce);
 
       const bootstrapScriptContent = await import.meta.viteRsc.loadBootstrapScriptContent("index");
+      const errorMetaRenderer = createSsrErrorMetaRenderer({
+        basePath: options?.basePath,
+      });
 
       const htmlStream = await renderToReadableStream(ssrRoot, {
         bootstrapScriptContent,
         formState: options?.formState ?? null,
         nonce: options?.scriptNonce,
         onError(error) {
+          errorMetaRenderer.capture(error);
+
           if (error && typeof error === "object" && "digest" in error) {
             return String(error.digest);
           }
@@ -274,14 +281,15 @@ export async function handleSsr(
       let didInjectHeadHTML = false;
       const getInsertedHTML = (): string => {
         const insertedHTML = renderInsertedHtml(renderServerInsertedHTML());
-        if (didInjectHeadHTML) return insertedHTML;
+        const errorMetaHTML = errorMetaRenderer.flush();
+        if (didInjectHeadHTML) return insertedHTML + errorMetaHTML;
 
         didInjectHeadHTML = true;
         return buildHeadInjectionHtml(
           navContext,
           bootstrapScriptContent,
           options?.formState ?? null,
-          insertedHTML,
+          insertedHTML + errorMetaHTML,
           fontHTML,
           options?.scriptNonce,
         );

--- a/packages/vinext/src/server/app-ssr-error-meta.ts
+++ b/packages/vinext/src/server/app-ssr-error-meta.ts
@@ -1,0 +1,87 @@
+import { hasBasePath } from "../utils/base-path.js";
+import { escapeHtmlAttr } from "./html.js";
+import {
+  getNextErrorDigest,
+  parseNextHttpErrorDigest,
+  parseNextRedirectDigest,
+} from "./next-error-digest.js";
+
+type SsrErrorMetaRenderOptions = {
+  basePath?: string;
+  nodeEnv?: string;
+};
+
+type SsrErrorMetaRenderer = {
+  capture: (error: unknown) => void;
+  flush: () => string;
+};
+
+const PERMANENT_REDIRECT_STATUS = 308;
+
+function prefixRedirectLocation(location: string, basePath?: string): string {
+  if (!basePath || !location.startsWith("/") || hasBasePath(location, basePath)) {
+    return location;
+  }
+
+  return `${basePath}${location}`;
+}
+
+function renderSsrErrorMetaTag(error: unknown, options: SsrErrorMetaRenderOptions): string {
+  const digest = getNextErrorDigest(error);
+  if (!digest) return "";
+
+  const httpError = parseNextHttpErrorDigest(digest);
+  if (httpError) {
+    let html = '<meta name="robots" content="noindex" />';
+    if ((options.nodeEnv ?? process.env.NODE_ENV) === "development") {
+      html += '<meta name="next-error" content="not-found" />';
+    }
+    return html;
+  }
+
+  const redirect = parseNextRedirectDigest(digest);
+  if (!redirect) return "";
+
+  const delay = redirect.status === PERMANENT_REDIRECT_STATUS ? 0 : 1;
+  const location = prefixRedirectLocation(redirect.url, options.basePath);
+  return (
+    '<meta id="__next-page-redirect" http-equiv="refresh" content="' +
+    delay +
+    ";url=" +
+    escapeHtmlAttr(location) +
+    '" />'
+  );
+}
+
+export function renderSsrErrorMetaTags(
+  errors: readonly unknown[],
+  options: SsrErrorMetaRenderOptions = {},
+): string {
+  let html = "";
+
+  for (const error of errors) {
+    html += renderSsrErrorMetaTag(error, options);
+  }
+
+  return html;
+}
+
+export function createSsrErrorMetaRenderer(
+  options: SsrErrorMetaRenderOptions = {},
+): SsrErrorMetaRenderer {
+  const capturedErrors: unknown[] = [];
+  let flushedUntil = 0;
+
+  return {
+    capture(error) {
+      capturedErrors.push(error);
+    },
+    flush() {
+      if (flushedUntil >= capturedErrors.length) return "";
+
+      const html = renderSsrErrorMetaTags(capturedErrors.slice(flushedUntil), options);
+      flushedUntil = capturedErrors.length;
+      return html;
+    },
+  };
+}

--- a/packages/vinext/src/server/app-ssr-error-meta.ts
+++ b/packages/vinext/src/server/app-ssr-error-meta.ts
@@ -1,4 +1,4 @@
-import { hasBasePath } from "../utils/base-path.js";
+import { addBasePathToPathname } from "../utils/base-path.js";
 import { escapeHtmlAttr } from "./html.js";
 import {
   getNextErrorDigest,
@@ -19,11 +19,23 @@ type SsrErrorMetaRenderer = {
 const PERMANENT_REDIRECT_STATUS = 308;
 
 function prefixRedirectLocation(location: string, basePath?: string): string {
-  if (!basePath || !location.startsWith("/") || hasBasePath(location, basePath)) {
+  if (!basePath || !location.startsWith("/")) {
     return location;
   }
 
-  return `${basePath}${location}`;
+  const hashIndex = location.indexOf("#");
+  const queryIndex = location.indexOf("?");
+  const pathnameEnd =
+    queryIndex === -1
+      ? hashIndex === -1
+        ? location.length
+        : hashIndex
+      : hashIndex === -1
+        ? queryIndex
+        : Math.min(queryIndex, hashIndex);
+  const pathname = location.slice(0, pathnameEnd);
+
+  return addBasePathToPathname(pathname, basePath) + location.slice(pathnameEnd);
 }
 
 function renderSsrErrorMetaTag(error: unknown, options: SsrErrorMetaRenderOptions): string {

--- a/packages/vinext/src/server/html.ts
+++ b/packages/vinext/src/server/html.ts
@@ -28,7 +28,11 @@ export function safeJsonStringify(data: unknown): string {
 }
 
 export function escapeHtmlAttr(value: string): string {
-  return value.replace(/&/g, "&amp;").replace(/"/g, "&quot;");
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
 }
 
 export function createNonceAttribute(nonce?: string): string {

--- a/packages/vinext/src/utils/base-path.ts
+++ b/packages/vinext/src/utils/base-path.ts
@@ -24,6 +24,16 @@ export function stripBasePath(pathname: string, basePath: string): string {
 }
 
 /**
+ * Add the configured basePath to a pathname unless it is already inside that
+ * basePath. Query strings and hashes must be handled by callers before calling
+ * this pathname-only helper.
+ */
+export function addBasePathToPathname(pathname: string, basePath: string | undefined): string {
+  if (!basePath || hasBasePath(pathname, basePath)) return pathname;
+  return pathname === "/" ? basePath : `${basePath}${pathname}`;
+}
+
+/**
  * Remove trailing slashes from a pathname while preserving the root "/".
  * Collapses any number of trailing slashes ("/a//" → "/a"). Used by the
  * trailing-slash redirect path and route pattern normalization.

--- a/tests/app-page-execution.test.ts
+++ b/tests/app-page-execution.test.ts
@@ -164,6 +164,38 @@ describe("app page execution helpers", () => {
 
     expect(alreadyPrefixed.headers.get("location")).toBe("https://example.com/blog/about");
 
+    const alreadyPrefixedRootWithQuery = await buildAppPageSpecialErrorResponse({
+      basePath: "/blog",
+      clearRequestContext,
+      isRscRequest: false,
+      request: new Request("https://example.com/blog/protected"),
+      specialError: {
+        kind: "redirect",
+        location: "/blog?from=checkout",
+        statusCode: 307,
+      },
+    });
+
+    expect(alreadyPrefixedRootWithQuery.headers.get("location")).toBe(
+      "https://example.com/blog?from=checkout",
+    );
+
+    const alreadyPrefixedRootWithHash = await buildAppPageSpecialErrorResponse({
+      basePath: "/blog",
+      clearRequestContext,
+      isRscRequest: false,
+      request: new Request("https://example.com/blog/protected"),
+      specialError: {
+        kind: "redirect",
+        location: "/blog#top",
+        statusCode: 307,
+      },
+    });
+
+    expect(alreadyPrefixedRootWithHash.headers.get("location")).toBe(
+      "https://example.com/blog#top",
+    );
+
     // No basePath configured → behavior unchanged (resolves against the
     // request URL as before).
     const unconfigured = await buildAppPageSpecialErrorResponse({

--- a/tests/app-page-stream.test.ts
+++ b/tests/app-page-stream.test.ts
@@ -114,6 +114,30 @@ describe("app page stream helpers", () => {
     );
   });
 
+  it("forwards basePath to the SSR handler", async () => {
+    const ssrHandler = vi.fn(async () => createStream(["<html>base-path</html>"]));
+
+    const htmlStream = await renderAppPageHtmlStream({
+      basePath: "/docs",
+      fontData: createAppPageFontData({
+        getLinks: () => [],
+        getPreloads: () => [],
+        getStyles: () => [],
+      }),
+      navigationContext: null,
+      rscStream: createStream(["flight"]),
+      ssrHandler: { handleSsr: ssrHandler },
+    });
+
+    await expect(new Response(htmlStream).text()).resolves.toBe("<html>base-path</html>");
+    expect(ssrHandler).toHaveBeenCalledWith(
+      expect.anything(),
+      null,
+      expect.anything(),
+      expect.objectContaining({ basePath: "/docs" }),
+    );
+  });
+
   it("defers clearRequestContext until the HTML stream body is fully consumed", async () => {
     // Regression test for issue #660: clearRequestContext() must not race the
     // lazy RSC/SSR stream pipeline. It should be called only after the HTTP

--- a/tests/app-ssr-error-meta.test.ts
+++ b/tests/app-ssr-error-meta.test.ts
@@ -53,6 +53,20 @@ describe("App SSR error meta tags", () => {
     ).toBe(
       '<meta id="__next-page-redirect" http-equiv="refresh" content="1;url=https://example.com" />',
     );
+
+    expect(
+      renderSsrErrorMetaTags([digestError("NEXT_REDIRECT;replace;/docs%3Ffrom%3Dcheckout;307")], {
+        basePath: "/docs",
+      }),
+    ).toBe(
+      '<meta id="__next-page-redirect" http-equiv="refresh" content="1;url=/docs?from=checkout" />',
+    );
+
+    expect(
+      renderSsrErrorMetaTags([digestError("NEXT_REDIRECT;replace;/docs%23top;307")], {
+        basePath: "/docs",
+      }),
+    ).toBe('<meta id="__next-page-redirect" http-equiv="refresh" content="1;url=/docs#top" />');
   });
 
   it("escapes redirect meta URLs before inserting them into HTML", () => {

--- a/tests/app-ssr-error-meta.test.ts
+++ b/tests/app-ssr-error-meta.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  createSsrErrorMetaRenderer,
+  renderSsrErrorMetaTags,
+} from "../packages/vinext/src/server/app-ssr-error-meta.js";
+
+function digestError(digest: string): Error & { digest: string } {
+  return Object.assign(new Error(digest), { digest });
+}
+
+describe("App SSR error meta tags", () => {
+  it("renders noindex meta tags for streamed notFound and HTTP access fallback errors", () => {
+    expect(renderSsrErrorMetaTags([digestError("NEXT_NOT_FOUND")])).toBe(
+      '<meta name="robots" content="noindex" />',
+    );
+
+    expect(renderSsrErrorMetaTags([digestError("NEXT_HTTP_ERROR_FALLBACK;403")])).toBe(
+      '<meta name="robots" content="noindex" />',
+    );
+  });
+
+  it("renders development next-error metadata for streamed notFound errors", () => {
+    expect(
+      renderSsrErrorMetaTags([digestError("NEXT_NOT_FOUND")], { nodeEnv: "development" }),
+    ).toBe(
+      '<meta name="robots" content="noindex" />' + '<meta name="next-error" content="not-found" />',
+    );
+  });
+
+  it("renders refresh meta tags for streamed temporary and permanent redirects", () => {
+    expect(renderSsrErrorMetaTags([digestError("NEXT_REDIRECT;replace;/target;307")])).toBe(
+      '<meta id="__next-page-redirect" http-equiv="refresh" content="1;url=/target" />',
+    );
+
+    expect(renderSsrErrorMetaTags([digestError("NEXT_REDIRECT;replace;/target;308")])).toBe(
+      '<meta id="__next-page-redirect" http-equiv="refresh" content="0;url=/target" />',
+    );
+  });
+
+  it("prefixes app-internal redirect meta URLs with the configured basePath", () => {
+    expect(
+      renderSsrErrorMetaTags([digestError("NEXT_REDIRECT;replace;/target?ok=1#done;307")], {
+        basePath: "/docs",
+      }),
+    ).toBe(
+      '<meta id="__next-page-redirect" http-equiv="refresh" content="1;url=/docs/target?ok=1#done" />',
+    );
+
+    expect(
+      renderSsrErrorMetaTags([digestError("NEXT_REDIRECT;replace;https%3A%2F%2Fexample.com;307")], {
+        basePath: "/docs",
+      }),
+    ).toBe(
+      '<meta id="__next-page-redirect" http-equiv="refresh" content="1;url=https://example.com" />',
+    );
+  });
+
+  it("escapes redirect meta URLs before inserting them into HTML", () => {
+    expect(
+      renderSsrErrorMetaTags([
+        digestError("NEXT_REDIRECT;replace;/target%3Fnext%3D%26%22%3Cscript%3E;307"),
+      ]),
+    ).toBe(
+      '<meta id="__next-page-redirect" http-equiv="refresh" content="1;url=/target?next=&amp;&quot;&lt;script&gt;" />',
+    );
+  });
+
+  it("flushes each captured SSR error meta tag once", () => {
+    const renderer = createSsrErrorMetaRenderer({ nodeEnv: "production" });
+
+    renderer.capture(digestError("NEXT_NOT_FOUND"));
+    expect(renderer.flush()).toBe('<meta name="robots" content="noindex" />');
+    expect(renderer.flush()).toBe("");
+
+    renderer.capture(digestError("NEXT_REDIRECT;replace;/target;307"));
+    expect(renderer.flush()).toBe(
+      '<meta id="__next-page-redirect" http-equiv="refresh" content="1;url=/target" />',
+    );
+    expect(renderer.flush()).toBe("");
+  });
+});

--- a/tests/rsc-streaming.test.ts
+++ b/tests/rsc-streaming.test.ts
@@ -16,6 +16,7 @@ import {
   createRscEmbedTransform,
   createTickBufferedTransform,
 } from "../packages/vinext/src/server/app-ssr-stream.js";
+import { createSsrErrorMetaRenderer } from "../packages/vinext/src/server/app-ssr-error-meta.js";
 
 /**
  * Create a ReadableStream from an array of string chunks, with optional
@@ -415,6 +416,45 @@ describe("Tick-buffered RSC streaming (behavioral)", () => {
     expect(shellStylePos).toBeGreaterThan(-1);
     expect(trailingStylePos).toBeGreaterThan(shellStylePos);
     expect(trailingStylePos).toBeLessThan(donePos);
+  });
+
+  it("emits SSR-captured redirect meta tags after the shell has already flushed", async () => {
+    // Ported from Next.js: test/e2e/app-dir/navigation/navigation.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/navigation/navigation.test.ts
+    const rsc = createMockRscStream();
+    rsc.close();
+
+    const rscEmbed = createRscEmbedTransform(rsc.stream);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    const errorMetaRenderer = createSsrErrorMetaRenderer();
+    const encoder = new TextEncoder();
+    const htmlStream = new ReadableStream<Uint8Array>({
+      async start(controller) {
+        controller.enqueue(encoder.encode("<html><head></head><body><main>shell</main>"));
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        errorMetaRenderer.capture(
+          Object.assign(new Error("NEXT_REDIRECT"), {
+            digest: "NEXT_REDIRECT;replace;/redirect/result;307",
+          }),
+        );
+        controller.enqueue(encoder.encode("<template>resolved boundary</template></body></html>"));
+        controller.close();
+      },
+    });
+
+    const transform = createTickBufferedTransform(rscEmbed, () => errorMetaRenderer.flush());
+    const output = await collectStream(htmlStream.pipeThrough(transform));
+
+    const shellPos = output.indexOf("<main>shell</main>");
+    const redirectMetaPos = output.indexOf(
+      '<meta id="__next-page-redirect" http-equiv="refresh" content="1;url=/redirect/result" />',
+    );
+    const boundaryPos = output.indexOf("<template>resolved boundary</template>");
+
+    expect(shellPos).toBeGreaterThan(-1);
+    expect(redirectMetaPos).toBeGreaterThan(shellPos);
+    expect(redirectMetaPos).toBeLessThan(boundaryPos);
   });
 
   it("still injects head content even without </head> in stream", async () => {


### PR DESCRIPTION
## Overview

| Field | Details |
| --- | --- |
| Goal | Match Next.js streamed App Router handling for `redirect()` and `notFound()` after the SSR shell has committed. |
| Core change | Capture SSR render errors in `handleSsr` and flush browser-visible meta tags through the existing server-inserted HTML path. |
| Main boundary | Streaming HTML cannot change the HTTP status once bytes are committed, so navigation signals must be communicated in streamed HTML. |
| Primary files | `server/app-ssr-error-meta.ts`, `server/app-ssr-entry.ts`, `server/app-page-stream.ts`, `tests/rsc-streaming.test.ts` |
| Expected impact | Late streamed redirects get a refresh meta tag; late streamed notFound/http access fallback errors get a noindex meta tag. |

## Why

Once the App Router HTML shell streams, a later `redirect()` or `notFound()` cannot turn the response into a 307 or 404. Next.js treats the streamed HTML as the browser-visible recovery boundary: it records SSR render errors and injects `<meta http-equiv="refresh">` or `<meta name="robots" content="noindex">` so browsers and crawlers react before hydration catches up.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| SSR streaming | Post-shell navigation signals must still be visible in HTML. | `handleSsr` captures errors from React's HTML `onError` and flushes meta tags on each insertion pass. |
| Routing compatibility | `basePath` handling for streamed redirects should match early redirect responses. | Threads `basePath` into the SSR handler and applies it to app-internal refresh URLs. |
| HTML safety | Dynamic redirect URLs must not break attribute context. | Uses the shared HTML attribute escaper, extended to escape `<` and `>`. |

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| `redirect()` after the shell has streamed | 200 HTML response with the digest only in RSC data until hydration. | 200 HTML response includes a refresh meta tag for the redirect target. |
| `permanentRedirect()` after the shell has streamed | Same as above. | Refresh meta tag uses `0` delay for 308. |
| `notFound()` / HTTP access fallback after the shell has streamed | 200 HTML response lacked the noindex fallback meta. | Stream includes `<meta name="robots" content="noindex">`. |

<details>
<summary>Maintainer review path</summary>

1. `packages/vinext/src/server/app-ssr-error-meta.ts`: focused helper for mapping captured digest errors to meta tags and flushing each captured error once.
2. `packages/vinext/src/server/app-ssr-entry.ts`: React HTML `onError` capture and insertion into the existing streamed server-inserted HTML path.
3. `packages/vinext/src/server/app-page-stream.ts`, `app-page-render.ts`, `app-page-dispatch.ts`: `basePath` plumbing into the SSR handler, including ISR regeneration.
4. `tests/app-ssr-error-meta.test.ts` and `tests/rsc-streaming.test.ts`: direct semantics plus the post-shell streaming timing regression.

</details>

<details>
<summary>Validation</summary>

- `vp test run tests/app-ssr-error-meta.test.ts tests/app-page-stream.test.ts tests/rsc-streaming.test.ts tests/app-page-render.test.ts tests/app-page-dispatch.test.ts tests/app-ssr-stream.test.ts`
- `vp check`
- Pre-commit hook also reran formatting, lint, type checks, and `knip`.

</details>

<details>
<summary>Risk / compatibility</summary>

- Runtime impact is limited to App Router HTML SSR streaming.
- The helper only emits tags for recognized Next.js control-flow digests. Ordinary SSR errors keep the existing digest behavior.
- `basePath` prefixing avoids double-prefixing already-prefixed app-internal URLs to stay consistent with vinext's existing redirect response path.
- No public API changes.

</details>

<details>
<summary>Non-goals</summary>

- This does not change early redirect or notFound response status handling.
- This does not alter RSC-only navigation responses or server action redirect handling.
- This does not attempt to re-render streamed fallback pages after bytes have committed.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| [Next.js `makeGetServerInsertedHTML`](https://github.com/vercel/next.js/blob/ec0279c7a9416cd2b8182167d4e526d2688ae21a/packages/next/src/server/app-render/make-get-server-inserted-html.tsx#L15-L75) | Shows the streamed error meta tag injection path for HTTP access fallback and redirect errors. |
| [Next.js HTML error handler](https://github.com/vercel/next.js/blob/ec0279c7a9416cd2b8182167d4e526d2688ae21a/packages/next/src/server/app-render/create-error-handler.tsx#L153-L166) | Records every SSR render error into `allCapturedErrors`. |
| [Next.js app render wiring](https://github.com/vercel/next.js/blob/ec0279c7a9416cd2b8182167d4e526d2688ae21a/packages/next/src/server/app-render/app-render.tsx#L3439-L3445) | Creates `allCapturedErrors` and passes it to the HTML error handler. |
| [Next.js streaming SEO E2E tests](https://github.com/vercel/next.js/blob/ec0279c7a9416cd2b8182167d4e526d2688ae21a/test/e2e/app-dir/navigation/navigation.test.ts#L733-L762) | Asserts noindex and refresh meta tags for streamed notFound and redirects. |
| [Next.js `redirect` docs](https://github.com/vercel/next.js/blob/canary/docs/01-app/03-api-reference/04-functions/redirect.mdx) | Documents meta tag redirect behavior in streaming contexts. |
| [Next.js streaming status code docs](https://github.com/vercel/next.js/blob/canary/docs/01-app/03-api-reference/03-file-conventions/loading.mdx#status-codes) | Documents why streaming returns 200 and communicates noindex in HTML for late 404s. |