### PR TITLE
fix(link): preserve native download clicks

### DIFF
--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -442,6 +442,11 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
     if (onClick) onClick(e);
     if (e.defaultPrevented) return;
 
+    // Native download links must keep the browser's default behavior.
+    if (e.currentTarget.hasAttribute("download")) {
+      return;
+    }
+
     // Only intercept left clicks without modifiers (standard link behavior)
     if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) {
       return;

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -15,7 +15,7 @@ type CapturedClickEvent = {
   altKey?: boolean;
   button: number;
   ctrlKey?: boolean;
-  currentTarget: { target: string };
+  currentTarget: { hasAttribute(name: string): boolean; target: string };
   defaultPrevented: boolean;
   metaKey?: boolean;
   preventDefault(): void;
@@ -335,7 +335,7 @@ describe("Link App Router navigation scheduling", () => {
 
     const clickEvent = {
       button: 0,
-      currentTarget: { target: "" },
+      currentTarget: { hasAttribute: () => false, target: "" },
       defaultPrevented: false,
       preventDefault() {
         this.defaultPrevented = true;
@@ -352,6 +352,77 @@ describe("Link App Router navigation scheduling", () => {
     expect(startTransition).toHaveBeenCalledTimes(1);
     expect(navigate).toHaveBeenCalledWith("/target", 0, "navigate", "push", undefined, true);
     expect(transitionStates).toEqual([true]);
+  });
+
+  it("lets the browser handle download links without app-router navigation", async () => {
+    vi.resetModules();
+
+    let capturedAnchorProps: CapturedAnchorProps | undefined;
+    const startTransition = vi.fn((callback: () => void) => {
+      callback();
+    });
+
+    const captureAnchor = (type: unknown, props: unknown) => {
+      if (type === "a" && props !== null && typeof props === "object") {
+        capturedAnchorProps = props;
+      }
+    };
+
+    mockReactAnchorCaptureForLinkOnly_DO_NOT_REUSE({ captureAnchor, startTransition });
+
+    const navigate = vi.fn(async () => {});
+    vi.stubGlobal("window", {
+      __VINEXT_RSC_NAVIGATE__: navigate,
+      addEventListener: vi.fn(),
+      history: {
+        pushState: vi.fn(),
+        replaceState: vi.fn(),
+      },
+      location: {
+        href: "https://example.com/current",
+        origin: "https://example.com",
+      },
+      scrollTo: vi.fn(),
+    });
+
+    const { default: IsolatedLink } = await import("../packages/vinext/src/shims/link.js");
+    const React = await vi.importActual<typeof import("react")>("react");
+    const onClick = vi.fn();
+    const onNavigate = vi.fn();
+
+    // Ported from Next.js: test/e2e/link-on-navigate-prop/index.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/link-on-navigate-prop/index.test.ts
+    ReactDOMServer.renderToString(
+      React.createElement(
+        IsolatedLink,
+        { download: true, href: "/file.pdf", onClick, onNavigate, prefetch: false },
+        "download",
+      ),
+    );
+
+    const clickEvent = {
+      button: 0,
+      currentTarget: {
+        hasAttribute: (name: string) => name === "download",
+        target: "",
+      },
+      defaultPrevented: false,
+      preventDefault() {
+        this.defaultPrevented = true;
+      },
+    };
+    const linkOnClick = capturedAnchorProps?.onClick;
+    expect(linkOnClick).toBeTypeOf("function");
+    if (linkOnClick === undefined) {
+      throw new Error("Expected rendered Link anchor to expose an onClick handler");
+    }
+    await linkOnClick(clickEvent);
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(clickEvent.defaultPrevented).toBe(false);
+    expect(onNavigate).not.toHaveBeenCalled();
+    expect(startTransition).not.toHaveBeenCalled();
+    expect(navigate).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Overview

| Field | Details |
| --- | --- |
| Goal | Match Next.js `<Link download>` click semantics. |
| Core change | Return from the Link click handler before `preventDefault()` when the rendered anchor has the `download` attribute. |
| Primary files | `packages/vinext/src/shims/link.tsx`, `tests/link-navigation.test.ts` |
| Impact | Native file downloads keep browser behavior instead of being intercepted as vinext SPA navigation. |

## Why

`next/link` extends an anchor, but an anchor with `download` is not a client-side route transition. Next.js treats that click as browser-owned behavior: user `onClick` can run, but `onNavigate` and router navigation must not.

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| `<Link href="/file.pdf" download>` | Vinext called `preventDefault()` and entered SPA navigation. | Vinext leaves the browser default download behavior intact. |
| `onClick` on a download Link | Ran before vinext navigation. | Still runs. |
| `onNavigate` on a download Link | Could run because the click was treated as client navigation. | Does not run. |

## Validation

- `vp test run tests/link-navigation.test.ts -t "download links"` failed before the production guard, then passed after it.
- `vp test run tests/link-navigation.test.ts`
- `vp check`
- Commit hook reran formatting, lint, type checks, and `knip`.

## References

| Reference | Why it matters |
| --- | --- |
| [Next.js App Router Link download guard](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/app-dir/link.tsx#L241-L274) | App Router returns before SPA navigation when the anchor has `download`. |
| [Next.js Pages Router Link download guard](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/link.tsx#L204-L239) | Pages Router uses the same native-browser download rule. |
| [Next.js onNavigate download test](https://github.com/vercel/next.js/blob/canary/test/e2e/link-on-navigate-prop/index.test.ts#L128-L150) | Verifies download links update `onClick` state but not `onNavigate` state. |
| [Next.js Link docs for onNavigate](https://github.com/vercel/next.js/blob/canary/docs/01-app/03-api-reference/02-components/link.mdx#L497-L501) | Documents that download links work with `onClick` but not `onNavigate`. |

## Risk

Low. The new guard only applies when the actual clicked anchor has the HTML `download` attribute, and it executes after user `onClick` so `preventDefault()` from user code still wins. It runs before router-specific App or Pages logic, so both routers share the same compatibility fix.
