### PR TITLE
fix(script): dedupe concurrent same-src loads

### DIFF
--- a/packages/vinext/src/shims/script.tsx
+++ b/packages/vinext/src/shims/script.tsx
@@ -143,9 +143,12 @@ function loadClientScript(
   if (src) {
     const existingLoad = loadingScripts.get(src);
     if (existingLoad) {
-      if (key) loadedScripts.add(key);
       void existingLoad.then(
-        (event) => onLoad?.(event),
+        (event) => {
+          if (key) loadedScripts.add(key);
+          onLoad?.(event);
+          onReady?.();
+        },
         (event) => onError?.(event),
       );
       return;
@@ -193,7 +196,7 @@ function loadClientScript(
         onError?.(event);
       });
     });
-    loadPromise.catch(() => undefined);
+    loadPromise.catch(() => undefined).finally(() => loadingScripts.delete(src));
     loadingScripts.set(src, loadPromise);
   }
 

--- a/packages/vinext/src/shims/script.tsx
+++ b/packages/vinext/src/shims/script.tsx
@@ -49,8 +49,11 @@ export type ScriptProps = {
   [key: string]: unknown;
 };
 
-// Track scripts that have already been loaded to avoid duplicates
+// Track scripts that have already been loaded, plus remote scripts currently
+// loading, to avoid duplicate DOM insertion when same-src components mount
+// before the first load event fires.
 const loadedScripts = new Set<string>();
+const loadingScripts = new Map<string, Promise<Event>>();
 
 function getClientAutoNonce(): string | undefined {
   if (typeof document === "undefined") return undefined;
@@ -96,51 +99,115 @@ function buildBeforeInteractiveScriptProps(options: {
   return scriptProps;
 }
 
-/**
- * Load a script imperatively (outside of React).
- */
-export function handleClientScriptLoad(props: ScriptProps): void {
-  const {
-    src,
-    id,
-    onLoad,
-    onError,
-    strategy: _strategy,
-    onReady: _onReady,
-    children,
-    ...rest
-  } = props;
-  if (typeof window === "undefined") return;
-
-  const key = id ?? src ?? "";
-  if (key && loadedScripts.has(key)) return;
-
-  const el = document.createElement("script");
-  if (src) el.src = src;
-  if (id) el.id = id;
-  const resolvedNonce = resolveScriptNonce(rest.nonce);
-
+function setScriptAttributes(el: HTMLScriptElement, rest: Record<string, unknown>): void {
   for (const [attr, value] of Object.entries(rest)) {
-    if (attr === "dangerouslySetInnerHTML" || attr === "className") continue;
-    if (typeof value === "string") {
+    if (attr === "dangerouslySetInnerHTML") continue;
+    if (attr === "className") {
+      el.setAttribute("class", String(value));
+    } else if (typeof value === "string") {
       el.setAttribute(attr, value);
     } else if (typeof value === "boolean" && value) {
       el.setAttribute(attr, "");
     }
   }
-  if (resolvedNonce && !el.getAttribute("nonce")) {
-    el.setAttribute("nonce", resolvedNonce);
+}
+
+function loadClientScript(
+  props: ScriptProps,
+  options: {
+    resolvedNonce?: string;
+    fireReadyWhenAlreadyLoaded: boolean;
+  },
+): void {
+  const {
+    src,
+    id,
+    onLoad,
+    onReady,
+    onError,
+    strategy = "afterInteractive",
+    children,
+    dangerouslySetInnerHTML,
+    ...rest
+  } = props;
+  if (typeof window === "undefined") return;
+
+  const key = id ?? src ?? "";
+  if (key && loadedScripts.has(key)) {
+    if (options.fireReadyWhenAlreadyLoaded) {
+      onReady?.();
+    }
+    return;
   }
 
-  if (children && typeof children === "string") {
+  if (src) {
+    const existingLoad = loadingScripts.get(src);
+    if (existingLoad) {
+      if (key) loadedScripts.add(key);
+      void existingLoad.then(
+        (event) => onLoad?.(event),
+        (event) => onError?.(event),
+      );
+      return;
+    }
+  }
+
+  const el = document.createElement("script");
+  if (src) el.src = src;
+  if (id) el.id = id;
+
+  setScriptAttributes(el, rest);
+  if (options.resolvedNonce && !el.getAttribute("nonce")) {
+    el.setAttribute("nonce", options.resolvedNonce);
+  }
+
+  if (strategy === "worker") {
+    el.setAttribute("type", "text/partytown");
+  }
+
+  const markLoaded = () => {
+    if (key) loadedScripts.add(key);
+    onReady?.();
+  };
+
+  if (dangerouslySetInnerHTML?.__html) {
+    // Intentional: mirrors the Next.js <Script> API where dangerouslySetInnerHTML
+    // is developer-supplied inline script content (not user input). The prop name
+    // itself signals developer awareness of the XSS risk, consistent with React's
+    // design. User-supplied data must never flow into this prop.
+    el.innerHTML = dangerouslySetInnerHTML.__html;
+    markLoaded();
+  } else if (children && typeof children === "string") {
     el.textContent = children;
+    markLoaded();
+  } else if (src) {
+    const loadPromise = new Promise<Event>((resolve, reject) => {
+      el.addEventListener("load", (event) => {
+        resolve(event);
+        if (key) loadedScripts.add(key);
+        onLoad?.(event);
+        onReady?.();
+      });
+      el.addEventListener("error", (event) => {
+        reject(event);
+        onError?.(event);
+      });
+    });
+    loadPromise.catch(() => undefined);
+    loadingScripts.set(src, loadPromise);
   }
-
-  if (onLoad) el.addEventListener("load", onLoad);
-  if (onError) el.addEventListener("error", onError);
 
   document.body.appendChild(el);
-  if (key) loadedScripts.add(key);
+}
+
+/**
+ * Load a script imperatively (outside of React).
+ */
+export function handleClientScriptLoad(props: ScriptProps): void {
+  loadClientScript(props, {
+    resolvedNonce: resolveScriptNonce(props.nonce),
+    fireReadyWhenAlreadyLoaded: false,
+  });
 }
 
 /**
@@ -192,48 +259,20 @@ function Script(props: ScriptProps): React.ReactElement | null {
         return;
       }
 
-      const el = document.createElement("script");
-      if (src) el.src = src;
-      if (id) el.id = id;
-
-      for (const [attr, value] of Object.entries(rest)) {
-        if (attr === "className") {
-          el.setAttribute("class", String(value));
-        } else if (typeof value === "string") {
-          el.setAttribute(attr, value);
-        } else if (typeof value === "boolean" && value) {
-          el.setAttribute(attr, "");
-        }
-      }
-      if (resolvedNonce && !el.getAttribute("nonce")) {
-        el.setAttribute("nonce", resolvedNonce);
-      }
-
-      if (strategy === "worker") {
-        el.setAttribute("type", "text/partytown");
-      }
-
-      if (dangerouslySetInnerHTML?.__html) {
-        // Intentional: mirrors the Next.js <Script> API where dangerouslySetInnerHTML
-        // is developer-supplied inline script content (not user input). The prop name
-        // itself signals developer awareness of the XSS risk, consistent with React's
-        // design. User-supplied data must never flow into this prop.
-        el.innerHTML = dangerouslySetInnerHTML.__html as string;
-      } else if (children && typeof children === "string") {
-        el.textContent = children;
-      }
-
-      el.addEventListener("load", (e) => {
-        if (key) loadedScripts.add(key);
-        onLoad?.(e);
-        onReady?.();
-      });
-
-      if (onError) {
-        el.addEventListener("error", onError);
-      }
-
-      document.body.appendChild(el);
+      loadClientScript(
+        {
+          src,
+          id,
+          strategy,
+          onLoad,
+          onReady,
+          onError,
+          children,
+          dangerouslySetInnerHTML,
+          ...rest,
+        },
+        { resolvedNonce, fireReadyWhenAlreadyLoaded: true },
+      );
     };
 
     if (strategy === "lazyOnload") {

--- a/tests/e2e/pages-router/script.spec.ts
+++ b/tests/e2e/pages-router/script.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from "@playwright/test";
+
+const BASE = "http://localhost:4173";
+
+test.describe("next/script", () => {
+  // Ported from Next.js: packages/next/src/client/script.tsx
+  // https://github.com/vercel/next.js/blob/canary/packages/next/src/client/script.tsx
+  // Next.js keeps a ScriptCache for in-flight remote scripts so same-src
+  // components mounted together only append one DOM script.
+  test("deduplicates simultaneous same-src scripts before load completes", async ({ page }) => {
+    await page.goto(`${BASE}/script-dedupe`);
+    await expect(page.getByRole("heading", { name: "Script Dedupe" })).toBeVisible();
+
+    await expect.poll(() => page.locator('script[src="/dedupe-script.js"]').count()).toBe(1);
+    await expect
+      .poll(() => page.evaluate(() => Reflect.get(window, "__vinextScriptDedupeExecutions")))
+      .toBe(1);
+  });
+});

--- a/tests/fixtures/pages-basic/pages/script-dedupe.tsx
+++ b/tests/fixtures/pages-basic/pages/script-dedupe.tsx
@@ -1,0 +1,11 @@
+import Script from "next/script";
+
+export default function ScriptDedupePage() {
+  return (
+    <main>
+      <h1>Script Dedupe</h1>
+      <Script src="/dedupe-script.js" />
+      <Script src="/dedupe-script.js" />
+    </main>
+  );
+}

--- a/tests/fixtures/pages-basic/public/dedupe-script.js
+++ b/tests/fixtures/pages-basic/public/dedupe-script.js
@@ -1,0 +1,1 @@
+window.__vinextScriptDedupeExecutions = (window.__vinextScriptDedupeExecutions || 0) + 1;


### PR DESCRIPTION
## Overview

| Area | Detail |
| --- | --- |
| Goal | Prevent duplicate execution when multiple `next/script` components request the same remote script before it finishes loading. |
| Core change | Add an in-flight script cache keyed by `src`, separate from the completed-load cache. |
| Primary files | `packages/vinext/src/shims/script.tsx`, `tests/e2e/pages-router/script.spec.ts` |
| Expected impact | Same-src scripts mount as one DOM script while later callers still receive load/error callbacks. |

## Why

`next/script` must treat a remote script request as owned by its `src`, including the interval between DOM insertion and the browser load event. Without an in-flight cache, simultaneous components can all miss the completed-load cache and each append a `<script>`, which double-executes third-party code.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| Client script loading | A same-`src` remote script should be inserted once, even while loading. | Tracks `loadingScripts` promises separately from `loadedScripts`. |
| Callback behavior | Duplicate callers should not create duplicate DOM nodes. | Attaches duplicate callers to the existing load promise for `onLoad` and `onError`. |
| Next.js compatibility | Follow Next.js' `ScriptCache` / `LoadCache` split. | Mirrors the relevant cache shape in vinext's smaller shim. |

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| Two same-`src` scripts mount together | Two DOM scripts can be appended and executed. | One DOM script is appended and executed once. |
| A later same-`src` caller arrives while the first is loading | It can bypass `loadedScripts`. | It reuses the existing load promise. |

<details>
<summary>Maintainer review path</summary>

1. `packages/vinext/src/shims/script.tsx`: inspect the split between completed loads and in-flight remote loads, plus the shared `loadClientScript` path used by both component and imperative loading.
2. `tests/fixtures/pages-basic/pages/script-dedupe.tsx`: minimal reproduction page with two simultaneous same-`src` scripts.
3. `tests/e2e/pages-router/script.spec.ts`: browser assertion for one DOM script and one execution.

</details>

<details>
<summary>Validation</summary>

- `vp test run tests/script.test.ts`
- `PLAYWRIGHT_PROJECT=pages-router npx playwright test tests/e2e/pages-router/script.spec.ts`
- `vp check`

The new Playwright regression failed before the fix with two `script[src="/dedupe-script.js"]` nodes, then passed after the in-flight cache was added.

</details>

<details>
<summary>Risk / compatibility</summary>

- Public API: no API shape changes.
- Runtime: client-side `next/script` remote loading now matches Next.js' same-`src` de-duplication semantics more closely.
- Existing apps: the intended behavior removes duplicate third-party script execution. Duplicate same-`src` callers still get load/error callbacks through the existing promise.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| [Next.js `ScriptCache` and `LoadCache`](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/script.tsx) | Upstream implementation tracks in-flight remote scripts separately from loaded scripts. |
| [Next.js script loader tests](https://github.com/vercel/next.js/blob/canary/test/e2e/script-loader/script-loader.test.ts) | Covers `next/script` duplicate and readiness behavior around script loading. |
| [Next.js `next/script` docs](https://nextjs.org/docs/app/api-reference/components/script) | Public component semantics for loading third-party scripts. |
