### PR TITLE
fix(link): preserve unsafe href click handlers

### DIFF
--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -547,16 +547,24 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
 
   // Block dangerous URI schemes (javascript:, data:, vbscript:).
   // Render an inert <a> without href to prevent XSS while preserving
-  // styling and attributes like className, id, aria-*.
+  // styling, refs, and developer event handlers like onClick.
   // This check is placed after all hooks to satisfy the Rules of Hooks.
   if (isDangerous) {
     if (process.env.NODE_ENV !== "production") {
       console.warn(`<Link> blocked dangerous href: ${resolvedHref}`);
     }
     return (
-      <a {...anchorProps} onMouseEnter={handleMouseEnter} onTouchStart={handleTouchStart}>
-        {children}
-      </a>
+      <LinkStatusContext.Provider value={linkStatusValue}>
+        <a
+          ref={setRefs}
+          onClick={onClick}
+          onMouseEnter={handleMouseEnter}
+          onTouchStart={handleTouchStart}
+          {...anchorProps}
+        >
+          {children}
+        </a>
+      </LinkStatusContext.Provider>
     );
   }
 

--- a/tests/e2e/app-router/nextjs-compat/javascript-urls.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/javascript-urls.spec.ts
@@ -95,4 +95,21 @@ test.describe("javascript-urls", () => {
     await page.locator('a[href="/nextjs-compat/javascript-urls/safe"]').click();
     await expect(page).toHaveURL(`${BASE}/nextjs-compat/javascript-urls/safe`);
   });
+
+  // Next.js keeps user-provided Link onClick handlers on anchors whose href is
+  // later blocked by React/Next.js javascript: URL protections.
+  // Reference implementation: https://github.com/vercel/next.js/blob/canary/packages/next/src/client/link.tsx
+  test("preserves custom Link onClick handlers when blocking unsafe hrefs", async ({ page }) => {
+    await page.goto(`${BASE}/nextjs-compat/javascript-urls/link-onclick`);
+    await waitForAppRouterHydration(page);
+    const initialUrl = page.url();
+
+    const unsafeLink = page.locator("#unsafe-link");
+    await expect(unsafeLink).not.toHaveAttribute("href", /.+/);
+
+    await unsafeLink.click();
+
+    await expect(page.locator("#click-count")).toHaveText("clicks: 1");
+    expect(page.url()).toBe(initialUrl);
+  });
 });

--- a/tests/fixtures/app-basic/app/nextjs-compat/javascript-urls/link-onclick/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/javascript-urls/link-onclick/page.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { DANGEROUS_JAVASCRIPT_URL } from "../bad-url";
+
+export default function Page() {
+  const [clicks, setClicks] = useState(0);
+
+  return (
+    <>
+      <p id="click-count">clicks: {clicks}</p>
+      <Link
+        id="unsafe-link"
+        href={DANGEROUS_JAVASCRIPT_URL}
+        onClick={() => {
+          setClicks((value) => value + 1);
+        }}
+      >
+        unsafe link with custom click handler
+      </Link>
+    </>
+  );
+}


### PR DESCRIPTION
## Overview

| Area | Change |
| --- | --- |
| Goal | Keep dangerous `next/link` hrefs inert without dropping developer click handlers. |
| Core change | The unsafe Link render branch now preserves the forwarded ref, `LinkStatusContext`, and user `onClick` while still omitting `href`. |
| Primary files | `packages/vinext/src/shims/link.tsx`, `tests/e2e/app-router/nextjs-compat/javascript-urls.spec.ts` |
| Expected impact | `javascript:`, `data:`, and `vbscript:` Link hrefs remain blocked, but custom interactive handlers continue to work. |

## Why

A blocked URL should not erase unrelated anchor behavior. Next.js attaches user `onClick` to the rendered anchor before its internal navigation handling, and its JavaScript URL protections block the dangerous navigation path rather than making the anchor lose user event handlers entirely. Vinext already strips the unsafe `href`, which is stricter and useful, but the separate unsafe branch accidentally omitted `onClick`.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| Unsafe Link rendering | Dangerous hrefs must not become browser navigations. | Keeps omitting `href` for unsafe schemes. |
| Anchor behavior | Developer-provided anchor handlers should survive URL sanitization. | Passes `onClick` through on the unsafe branch. |
| Link internals | Unsafe branch should stay structurally close to normal Link rendering where safe. | Preserves the ref and `LinkStatusContext` wrapper. |

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| `<Link href="javascript:void(0)" onClick={trackEvent}>` | Renders without `href`, but the custom `onClick` is dropped. | Renders without `href`, the custom `onClick` runs, and the page URL does not change. |

<details>
<summary>Maintainer review path</summary>

1. `packages/vinext/src/shims/link.tsx`: inspect the dangerous href branch and confirm it still does not pass `href` or call normal navigation logic.
2. `tests/fixtures/app-basic/app/nextjs-compat/javascript-urls/link-onclick/page.tsx`: fixture proving a custom click handler is observable after hydration.
3. `tests/e2e/app-router/nextjs-compat/javascript-urls.spec.ts`: regression test asserting no `href`, click handler execution, and unchanged URL.

</details>

<details>
<summary>Validation</summary>

- `vp test run tests/link.test.ts`
- `vp run vinext#build`
- `PLAYWRIGHT_PROJECT=app-router npx playwright test tests/e2e/app-router/nextjs-compat/javascript-urls.spec.ts -g "preserves custom Link onClick"`
- `PLAYWRIGHT_PROJECT=app-router npx playwright test tests/e2e/app-router/nextjs-compat/javascript-urls.spec.ts`
- `vp check`
- Commit hook also ran formatting, lint/type checks, and `knip`.

</details>

<details>
<summary>Risk / compatibility</summary>

- Public API: no type or prop surface changes.
- Runtime: limited to the already-dangerous Link branch.
- Security: preserves vinext's existing stricter behavior of omitting the unsafe `href`; this PR does not make the dangerous URL reachable through Link navigation.
- Compatibility: better matches Next.js user-event semantics while keeping vinext's defense-in-depth sanitization.

</details>

<details>
<summary>Non-goals</summary>

- Does not change router `push` or `replace` JavaScript URL handling.
- Does not change vinext's intentional blocking of `data:` and `vbscript:` Link hrefs.
- Does not attempt to mimic React's exact console/redbox behavior for rendered `javascript:` anchors.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| [Next.js Link implementation](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/link.tsx) | Shows user `onClick` is attached to Link's anchor props before internal navigation handling. |
| [Next.js JavaScript URL detector](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/lib/javascript-url.ts) | Source for the URL safety semantics vinext's detector already references. |
| [Next.js JavaScript URL e2e tests](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/javascript-urls/javascript-urls.test.ts) | Confirms JavaScript URL navigation should be blocked across Link and router surfaces. |