### PR TITLE
fix(image): preserve fill positioning for remote images

### DIFF
--- a/packages/vinext/src/shims/image.tsx
+++ b/packages/vinext/src/shims/image.tsx
@@ -221,6 +221,21 @@ function isRemoteUrl(src: string): boolean {
   return src.startsWith("http://") || src.startsWith("https://") || src.startsWith("//");
 }
 
+function getFillStyle(
+  style?: React.CSSProperties,
+  backgroundStyle?: React.CSSProperties,
+): React.CSSProperties {
+  return {
+    position: "absolute",
+    inset: 0,
+    width: "100%",
+    height: "100%",
+    objectFit: "cover",
+    ...backgroundStyle,
+    ...style,
+  };
+}
+
 /**
  * Resolve src, width, height, blurDataURL from Image props (string or StaticImageData).
  * Shared by the Image component and getImageProps to keep behavior in sync.
@@ -421,24 +436,15 @@ const Image = forwardRef<HTMLImageElement, ImageProps>(function Image(
         className={className}
         onLoad={handleLoad}
         onError={handleError}
-        style={
-          fill
-            ? {
-                position: "absolute",
-                inset: 0,
-                width: "100%",
-                height: "100%",
-                objectFit: "cover",
-                ...style,
-              }
-            : style
-        }
+        style={fill ? getFillStyle(style) : style}
         {...rest}
       />
     );
   }
 
-  // For remote URLs, validate against remotePatterns then use @unpic/react
+  // For remote URLs, validate against remotePatterns. Non-fill images use
+  // @unpic/react for CDN URL transforms; fill uses a plain img so the DOM
+  // element keeps Next.js's absolute-positioned fill contract.
   if (isRemoteUrl(src)) {
     const validation = validateRemoteUrl(src);
     if (!validation.allowed) {
@@ -453,26 +459,33 @@ const Image = forwardRef<HTMLImageElement, ImageProps>(function Image(
     }
 
     const sanitizedBlur = imgBlurDataURL ? sanitizeBlurDataURL(imgBlurDataURL) : undefined;
+    const blurStyle =
+      placeholder === "blur" && sanitizedBlur
+        ? {
+            backgroundImage: `url(${sanitizedBlur})`,
+            backgroundSize: "cover",
+            backgroundRepeat: "no-repeat",
+            backgroundPosition: "center",
+          }
+        : undefined;
     const bg = placeholder === "blur" && sanitizedBlur ? `url(${sanitizedBlur})` : undefined;
 
     if (fill) {
       return (
-        <UnpicImage
+        <img
+          ref={mergedRef}
           src={src}
           alt={alt}
-          layout="fullWidth"
-          // `priority` is a Next.js concept — translate it to HTML attributes so
-          // it is never forwarded to the DOM as a non-boolean attribute, which
-          // would trigger React's "Received `true` for a non-boolean attribute"
-          // warning.
           loading={priority ? "eager" : (loading ?? "lazy")}
           fetchPriority={priority ? "high" : undefined}
-          sizes={sizes}
+          decoding="async"
+          sizes={sizes ?? "100vw"}
           className={className}
-          background={bg}
+          data-nimg="fill"
           onLoad={handleLoad}
           onError={handleError}
-          ref={mergedRef}
+          style={getFillStyle(style, blurStyle)}
+          {...rest}
         />
       );
     }
@@ -561,19 +574,7 @@ const Image = forwardRef<HTMLImageElement, ImageProps>(function Image(
       data-nimg={fill ? "fill" : "1"}
       onLoad={handleLoad}
       onError={handleError}
-      style={
-        fill
-          ? {
-              position: "absolute",
-              inset: 0,
-              width: "100%",
-              height: "100%",
-              objectFit: "cover",
-              ...blurStyle,
-              ...style,
-            }
-          : { ...blurStyle, ...style }
-      }
+      style={fill ? getFillStyle(style, blurStyle) : { ...blurStyle, ...style }}
       {...rest}
     />
   );
@@ -684,17 +685,7 @@ export function getImageProps(props: ImageProps): {
       sizes: sizes ?? (fill ? "100vw" : undefined),
       className,
       "data-nimg": fill ? "fill" : "1",
-      style: fill
-        ? {
-            position: "absolute" as const,
-            inset: 0,
-            width: "100%",
-            height: "100%",
-            objectFit: "cover" as const,
-            ...blurStyle,
-            ...style,
-          }
-        : { ...blurStyle, ...style },
+      style: fill ? getFillStyle(style, blurStyle) : { ...blurStyle, ...style },
       ...rest,
     } as React.ImgHTMLAttributes<HTMLImageElement>,
   };

--- a/tests/image-component.test.ts
+++ b/tests/image-component.test.ts
@@ -79,6 +79,27 @@ describe("Image SSR rendering", () => {
     expect(html).toContain('sizes="100vw"');
   });
 
+  it("renders remote fill mode with absolute positioning", () => {
+    // Ported from Next.js: test/unit/next-image-get-img-props.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/unit/next-image-get-img-props.test.ts
+    const html = ReactDOMServer.renderToString(
+      React.createElement(Image, {
+        alt: "remote fill image",
+        src: "https://images.unsplash.com/photo-fill",
+        fill: true,
+      }),
+    );
+    // Remote fill must preserve the same layout contract as local fill:
+    // the DOM img is absolutely positioned and marked as data-nimg="fill".
+    expect(html).not.toMatch(/width="\d+"/);
+    expect(html).not.toMatch(/height="\d+"/);
+    expect(html).toContain("position:absolute");
+    expect(html).toContain("width:100%");
+    expect(html).toContain("height:100%");
+    expect(html).toContain('data-nimg="fill"');
+    expect(html).toContain('sizes="100vw"');
+  });
+
   it("renders with custom sizes prop", () => {
     const html = ReactDOMServer.renderToString(
       React.createElement(Image, {


### PR DESCRIPTION
## Overview

| Field | Detail |
| --- | --- |
| Goal | Preserve Next.js `fill` layout semantics for remote `next/image` sources. |
| Core change | Remote `fill` now renders a plain `<img>` with the same fill style and `data-nimg="fill"` contract used by local images and `getImageProps()`. |
| Main boundary | DOM output from the `Image` component SSR path. |
| Primary files | `packages/vinext/src/shims/image.tsx`, `tests/image-component.test.ts` |
| Expected impact | Remote fill images no longer flow as standard block/full-width images when callers expect parent-filling absolute positioning. |

## Why

For `next/image`, `fill` is a layout contract on the rendered `<img>`, not a remote-source optimization mode. Next.js applies absolute positioning and `data-nimg="fill"` regardless of whether the source is local or remote, and its docs tell users to position the parent because the image itself is absolute.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| Remote `Image` rendering | `fill` means the DOM image fills its parent. | Removes the remote-only `layout="fullWidth"` branch for `fill` and emits the same absolute-positioned `<img>` shape as local fill. |
| Shared fill styling | Local, loader, remote, and `getImageProps()` should not drift. | Centralizes fill style construction in `getFillStyle()`. |
| Regression coverage | The public DOM output is the compatibility boundary. | Adds SSR coverage for remote `fill` asserting no width/height attrs, absolute positioning, default `sizes="100vw"`, and `data-nimg="fill"`. |

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| `<Image src="https://..." fill />` | Rendered through Unpic `layout="fullWidth"`, producing `style="object-fit:cover;width:100%"` without absolute positioning or `data-nimg="fill"`. | Renders a plain `<img>` with `position:absolute`, `inset:0`, `width:100%`, `height:100%`, `sizes="100vw"`, and `data-nimg="fill"`. |
| Local `fill`, loader `fill`, `getImageProps({ fill: true })` | Each built fill style separately. | They share `getFillStyle()` to keep the invariant in one place. |

<details>
<summary>Maintainer review path</summary>

1. `packages/vinext/src/shims/image.tsx`
   - Review `getFillStyle()` first.
   - Then review the remote URL `fill` branch and compare it with the local fill branch and `getImageProps()`.
2. `tests/image-component.test.ts`
   - Review the new SSR regression next to the existing local fill test.

</details>

<details>
<summary>Validation</summary>

- `vp test run tests/image-component.test.ts -t "renders remote fill mode with absolute positioning"`
  - Verified red before the fix and green after it.
- `vp test run tests/image-component.test.ts`
  - 53 tests passed.
- `vp test run tests/image-component.test.ts tests/image-imports.test.ts tests/image-optimization-parity.test.ts`
  - 75 tests passed.
- `vp check`
  - Formatting, lint, and type checks passed.

</details>

<details>
<summary>Risk / compatibility</summary>

- Public API: no prop API changes.
- Runtime behavior: remote `fill` uses the same plain `<img>` shape as local fill and `getImageProps()` instead of Unpic `fullWidth` transformation.
- Compatibility: this aligns the fill layout contract with Next.js. Remote non-fill images still use Unpic for CDN URL transforms.
- Existing-app risk: low. Apps relying on remote `fill` flowing in document layout were relying on behavior that conflicts with Next.js and the `fill` docs.

</details>

<details>
<summary>Non-goals</summary>

- This does not change remote non-fill image optimization.
- This does not add broader Next.js validation for conflicting `fill` styles such as overriding `position`, `width`, or `height`.
- This does not change custom-loader fill sizing behavior beyond sharing the fill style object.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| [Next.js `get-img-props` fill style](https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/get-img-props.ts#L683-L699) | Shows Next.js constructs absolute-positioned fill styles independently of source type. |
| [Next.js image component `data-nimg`](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/image-component.tsx#L277-L289) | Shows `data-nimg="fill"` is attached to the actual `<img>`. |
| [Next.js unit test for `fill`](https://github.com/vercel/next.js/blob/canary/test/unit/next-image-get-img-props.test.ts#L426-L463) | Captures the expected fill props shape. |
| [Next.js image docs for `fill`](https://github.com/vercel/next.js/blob/canary/docs/01-app/03-api-reference/02-components/image.mdx) | Documents that `fill` expands to the parent and the image itself uses absolute positioning by default. |
