### PR TITLE
fix(app-router): keep refresh transitions pending

### DIFF
--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -1036,7 +1036,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
     let redirectCount = redirectDepth;
 
     try {
-      const shouldUsePendingRouterState = programmaticTransition && navigationKind !== "refresh";
+      const shouldUsePendingRouterState = programmaticTransition;
       if (shouldUsePendingRouterState && hasBrowserRouterState()) {
         pendingRouterState = beginPendingBrowserRouterState();
       } else {

--- a/tests/e2e/app-router/nextjs-compat/router-push-pending.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/router-push-pending.spec.ts
@@ -1,11 +1,13 @@
 /**
- * Next.js Compat E2E: router push pending state
+ * Next.js Compat E2E: router pending state
  *
  * Next.js references:
  * - https://github.com/vercel/next.js/blob/canary/test/e2e/use-link-status/index.test.ts
  * - https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/navigation/navigation.test.ts
  * - https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/navigation/navigation.test.ts#L482
  *   (redirect-with-loading: verifies redirect only triggers once and does not flicker)
+ * - https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/app-router-instance.ts
+ * - https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/use-action-queue.ts
  *
  * The contract we care about here is that a programmatic App Router navigation
  * started inside useTransition should flip isPending immediately and keep it
@@ -17,7 +19,7 @@ import { waitForAppRouterHydration } from "../../helpers";
 
 const BASE = "http://localhost:4174";
 
-test.describe("Next.js compat: router.push pending state (browser)", () => {
+test.describe("Next.js compat: router pending state (browser)", () => {
   test("same-route search param push keeps useTransition pending until commit", async ({
     page,
   }) => {
@@ -135,5 +137,29 @@ test.describe("Next.js compat: router.push pending state (browser)", () => {
 
     // Final state: URL is at destination
     expect(page.url()).toContain("/nextjs-compat/router-push-pending-destination");
+  });
+
+  test("router.refresh keeps useTransition pending until the refreshed route commits", async ({
+    page,
+  }) => {
+    await page.goto(`${BASE}/nextjs-compat/router-refresh-pending`);
+    await waitForAppRouterHydration(page);
+
+    await expect(page.locator("#refresh-pending-state")).toHaveText("idle");
+    const initialStamp = await page.locator("#refresh-server-stamp").textContent();
+    expect(initialStamp).toBeTruthy();
+
+    const clickPromise = page.click("#refresh-current-route", { noWaitAfter: true });
+
+    await expect(page.locator("#refresh-pending-state")).toHaveText("pending", {
+      timeout: 1_000,
+    });
+    await clickPromise;
+    await expect(page.locator("#refresh-server-stamp")).not.toHaveText(initialStamp ?? "", {
+      timeout: 10_000,
+    });
+    await expect(page.locator("#refresh-pending-state")).toHaveText("idle", {
+      timeout: 10_000,
+    });
   });
 });

--- a/tests/fixtures/app-basic/app/nextjs-compat/router-refresh-pending/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/router-refresh-pending/page.tsx
@@ -1,0 +1,19 @@
+import { RefreshPendingClient } from "./refresh-pending-client";
+
+async function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export default async function RouterRefreshPendingPage() {
+  // Keep the refresh RSC request in flight long enough for the browser test to
+  // observe the transition's pending state before the refreshed tree commits.
+  await delay(1_000);
+
+  return (
+    <div>
+      <h1 id="router-refresh-pending-title">Router refresh pending</h1>
+      <RefreshPendingClient />
+      <p id="refresh-server-stamp">server stamp: {Date.now()}</p>
+    </div>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/router-refresh-pending/refresh-pending-client.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/router-refresh-pending/refresh-pending-client.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useTransition } from "react";
+
+export function RefreshPendingClient() {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+
+  return (
+    <div>
+      <p id="refresh-pending-state">{isPending ? "pending" : "idle"}</p>
+      <button
+        id="refresh-current-route"
+        onClick={() => {
+          startTransition(() => {
+            router.refresh();
+          });
+        }}
+      >
+        Refresh current route
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Overview

| Field | Detail |
| --- | --- |
| Goal | Keep `useTransition()` pending while `router.refresh()` is fetching and committing the refreshed RSC tree. |
| Core change | Programmatic refresh navigations now create the same pending browser router state used by other programmatic App Router navigations. |
| Primary files | `packages/vinext/src/server/app-browser-entry.ts`, `tests/e2e/app-router/nextjs-compat/router-push-pending.spec.ts` |
| Expected impact | Apps that wrap `router.refresh()` in `startTransition` can show loading feedback until the refreshed route commits. |

## Why

A programmatic App Router navigation that starts inside a React transition must publish a pending router state before the async RSC work begins, then resolve it when the committed tree is ready. Next.js does this for `ACTION_REFRESH` through the same async action queue path as other router actions, so excluding refresh in vinext lets `isPending` drop to idle during the refresh request.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| Browser App Router | Programmatic navigations should keep the caller's transition pending until commit. | Removes the refresh-only exclusion from pending browser router state creation. |
| Next.js parity | `router.refresh()` is an async App Router action, not a fire-and-forget fetch from React's perspective. | Aligns refresh scheduling with Next.js' `ACTION_REFRESH` dispatch and action queue behavior. |
| Regression coverage | The observable contract is browser-visible `useTransition` state. | Adds a slow same-route refresh fixture and Playwright assertion for pending then idle. |

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| `startTransition(() => router.refresh())` | `isPending` could return to `false` while the refresh RSC request was still in flight. | `isPending` becomes `true` during the refresh and returns to `false` after the refreshed tree commits. |
| `router.push()` pending behavior | Already covered and unchanged. | Existing push pending tests still pass. |

<details>
<summary>Maintainer review path</summary>

1. `packages/vinext/src/server/app-browser-entry.ts`: confirm `navigateRsc` now treats refresh like other programmatic transitions when deciding whether to create pending browser router state.
2. `tests/fixtures/app-basic/app/nextjs-compat/router-refresh-pending/*`: inspect the minimal fixture that delays the server response outside Suspense so pending state is observable.
3. `tests/e2e/app-router/nextjs-compat/router-push-pending.spec.ts`: review the new refresh regression alongside the existing push pending coverage.

</details>

<details>
<summary>Validation</summary>

- `vp test run tests/app-browser-entry.test.ts`
- `vp run vinext#build`
- `PLAYWRIGHT_PROJECT=app-router npx playwright test tests/e2e/app-router/nextjs-compat/router-push-pending.spec.ts --project=app-router`
- `vp check`

Note: the browser regression failed when run against the pre-rebuild package dist, which still contained the refresh exclusion. After rebuilding `vinext` so the fixture served the patched runtime, it passed.

</details>

<details>
<summary>Risk / compatibility</summary>

- Public API: no API shape changes.
- Runtime: refresh now publishes a deferred router-state promise for programmatic transitions, matching the existing push/replace path.
- Loading UI: the refresh request still uses the existing refresh preserve-UI render mode, so route loading boundaries remain suppressed for refresh.
- Cache behavior: unchanged. Refresh cache invalidation still happens before dispatch in the navigation shim.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| [Next.js public app router instance](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/app-router-instance.ts) | `refresh()` dispatches `ACTION_REFRESH` inside `startTransition`. |
| [Next.js action queue](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/use-action-queue.ts) | Non-restore router actions publish a deferred state promise to React and resolve it when the action completes. |
| [Next.js `useRouter().refresh()` docs](https://github.com/vercel/next.js/blob/canary/docs/01-app/03-api-reference/04-functions/use-router.mdx) | Documents refresh as a new server request that re-renders Server Components and merges the payload. |
| [Next.js navigation pending coverage](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/navigation/navigation.test.ts) | Existing compat reference for keeping pending state across async navigations. |
