### PR TITLE
refactor(router): dedupe push/replace logic in next/router shim

### DIFF
--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -634,6 +634,106 @@ function buildRouterValue(
   };
 }
 
+/** Extract the hash fragment from a URL, including the leading `#`. */
+function extractHash(url: string): string {
+  const i = url.indexOf("#");
+  return i === -1 ? "" : url.slice(i);
+}
+
+/** Notify in-page listeners (e.g. useRouter hooks) that navigation occurred. */
+function dispatchNavigateEvent(): void {
+  window.dispatchEvent(new CustomEvent("vinext:navigate"));
+}
+
+/**
+ * Update history with the new URL and refresh the hash-only-detection tracker.
+ * Centralises the `pushState`/`replaceState` branch so callers don't repeat it.
+ */
+function updateHistory(mode: "push" | "replace", url: string): void {
+  if (mode === "push") window.history.pushState({}, "", url);
+  else window.history.replaceState({}, "", url);
+  _lastPathnameAndSearch = window.location.pathname + window.location.search;
+}
+
+/**
+ * Shared client-side navigation flow used by both `useRouter()` and the
+ * `Router` singleton. The only differences between push/replace are the
+ * history method (`pushState` vs `replaceState`), the external-URL fallback
+ * (`assign` vs `replace`), and the fact that push saves scroll position for
+ * back/forward restoration while replace does not.
+ *
+ * `onStateUpdate` lets the hook trigger a `setState` re-render at the same
+ * point that hashChangeComplete/routeChangeComplete fires; the singleton
+ * passes no callback.
+ */
+async function performNavigation(
+  url: string | UrlObject,
+  as: string | undefined,
+  options: TransitionOptions | undefined,
+  mode: "push" | "replace",
+  onStateUpdate?: () => void,
+): Promise<boolean> {
+  let resolved = resolveNavigationTarget(url, as, options?.locale);
+
+  // External URLs — delegate to browser (unless same-origin)
+  if (isExternalUrl(resolved)) {
+    const localPath = toSameOriginAppPath(resolved, __basePath);
+    if (localPath == null) {
+      if (mode === "push") window.location.assign(resolved);
+      else window.location.replace(resolved);
+      return true;
+    }
+    resolved = localPath;
+  }
+
+  const full = toBrowserNavigationHref(resolved, window.location.href, __basePath);
+  const shallow = options?.shallow ?? false;
+  const doScroll = options?.scroll !== false;
+
+  // Hash-only change — no page fetch needed
+  if (isHashOnlyChange(full)) {
+    const eventUrl = resolveHashUrl(full);
+    routerEvents.emit("hashChangeStart", eventUrl, { shallow });
+    updateHistory(mode, resolved.startsWith("#") ? resolved : full);
+    if (doScroll) scrollToHashTarget(extractHash(resolved));
+    onStateUpdate?.();
+    routerEvents.emit("hashChangeComplete", eventUrl, { shallow });
+    dispatchNavigateEvent();
+    return true;
+  }
+
+  if (mode === "push") saveScrollPosition();
+  routerEvents.emit("routeChangeStart", resolved, { shallow });
+  routerEvents.emit("beforeHistoryChange", resolved, { shallow });
+  updateHistory(mode, full);
+  if (!shallow) {
+    const result = await runNavigateClient(full, resolved);
+    if (result === "cancelled") return true;
+    if (result === "failed") return false;
+  }
+  onStateUpdate?.();
+  routerEvents.emit("routeChangeComplete", resolved, { shallow });
+
+  const hash = extractHash(resolved);
+  if (doScroll) {
+    if (hash) scrollToHashTarget(hash);
+    else window.scrollTo(0, 0);
+  }
+  dispatchNavigateEvent();
+  return true;
+}
+
+/** Inject a `<link rel="prefetch">` for the target page. */
+async function prefetchUrl(url: string): Promise<void> {
+  if (typeof document !== "undefined") {
+    const link = document.createElement("link");
+    link.rel = "prefetch";
+    link.href = url;
+    link.as = "document";
+    document.head.appendChild(link);
+  }
+}
+
 /**
  * useRouter hook - Pages Router compatible.
  */
@@ -651,129 +751,14 @@ export function useRouter(): NextRouter {
   }, []);
 
   const push = useCallback(
-    async (url: string | UrlObject, as?: string, options?: TransitionOptions): Promise<boolean> => {
-      let resolved = resolveNavigationTarget(url, as, options?.locale);
-
-      // External URLs — delegate to browser (unless same-origin)
-      if (isExternalUrl(resolved)) {
-        const localPath = toSameOriginAppPath(resolved, __basePath);
-        if (localPath == null) {
-          window.location.assign(resolved);
-          return true;
-        }
-        resolved = localPath;
-      }
-
-      const full = toBrowserNavigationHref(resolved, window.location.href, __basePath);
-
-      // Hash-only change — no page fetch needed
-      if (isHashOnlyChange(full)) {
-        const eventUrl = resolveHashUrl(full);
-        routerEvents.emit("hashChangeStart", eventUrl, {
-          shallow: options?.shallow ?? false,
-        });
-        const hash = resolved.includes("#") ? resolved.slice(resolved.indexOf("#")) : "";
-        window.history.pushState({}, "", resolved.startsWith("#") ? resolved : full);
-        _lastPathnameAndSearch = window.location.pathname + window.location.search;
-        if (options?.scroll !== false) {
-          scrollToHashTarget(hash);
-        }
-        setState(getPathnameAndQuery());
-        routerEvents.emit("hashChangeComplete", eventUrl, {
-          shallow: options?.shallow ?? false,
-        });
-        window.dispatchEvent(new CustomEvent("vinext:navigate"));
-        return true;
-      }
-
-      saveScrollPosition();
-      routerEvents.emit("routeChangeStart", resolved, { shallow: options?.shallow ?? false });
-      routerEvents.emit("beforeHistoryChange", resolved, { shallow: options?.shallow ?? false });
-      window.history.pushState({}, "", full);
-      _lastPathnameAndSearch = window.location.pathname + window.location.search;
-      if (!options?.shallow) {
-        const result = await runNavigateClient(full, resolved);
-        if (result === "cancelled") return true;
-        if (result === "failed") return false;
-      }
-      setState(getPathnameAndQuery());
-      routerEvents.emit("routeChangeComplete", resolved, { shallow: options?.shallow ?? false });
-
-      // Scroll: handle hash target, else scroll to top unless scroll:false
-      const hash = resolved.includes("#") ? resolved.slice(resolved.indexOf("#")) : "";
-      if (options?.scroll !== false) {
-        if (hash) {
-          scrollToHashTarget(hash);
-        } else {
-          window.scrollTo(0, 0);
-        }
-      }
-      window.dispatchEvent(new CustomEvent("vinext:navigate"));
-      return true;
-    },
+    (url: string | UrlObject, as?: string, options?: TransitionOptions): Promise<boolean> =>
+      performNavigation(url, as, options, "push", () => setState(getPathnameAndQuery())),
     [],
   );
 
   const replace = useCallback(
-    async (url: string | UrlObject, as?: string, options?: TransitionOptions): Promise<boolean> => {
-      let resolved = resolveNavigationTarget(url, as, options?.locale);
-
-      // External URLs — delegate to browser (unless same-origin)
-      if (isExternalUrl(resolved)) {
-        const localPath = toSameOriginAppPath(resolved, __basePath);
-        if (localPath == null) {
-          window.location.replace(resolved);
-          return true;
-        }
-        resolved = localPath;
-      }
-
-      const full = toBrowserNavigationHref(resolved, window.location.href, __basePath);
-
-      // Hash-only change — no page fetch needed
-      if (isHashOnlyChange(full)) {
-        const eventUrl = resolveHashUrl(full);
-        routerEvents.emit("hashChangeStart", eventUrl, {
-          shallow: options?.shallow ?? false,
-        });
-        const hash = resolved.includes("#") ? resolved.slice(resolved.indexOf("#")) : "";
-        window.history.replaceState({}, "", resolved.startsWith("#") ? resolved : full);
-        _lastPathnameAndSearch = window.location.pathname + window.location.search;
-        if (options?.scroll !== false) {
-          scrollToHashTarget(hash);
-        }
-        setState(getPathnameAndQuery());
-        routerEvents.emit("hashChangeComplete", eventUrl, {
-          shallow: options?.shallow ?? false,
-        });
-        window.dispatchEvent(new CustomEvent("vinext:navigate"));
-        return true;
-      }
-
-      routerEvents.emit("routeChangeStart", resolved, { shallow: options?.shallow ?? false });
-      routerEvents.emit("beforeHistoryChange", resolved, { shallow: options?.shallow ?? false });
-      window.history.replaceState({}, "", full);
-      _lastPathnameAndSearch = window.location.pathname + window.location.search;
-      if (!options?.shallow) {
-        const result = await runNavigateClient(full, resolved);
-        if (result === "cancelled") return true;
-        if (result === "failed") return false;
-      }
-      setState(getPathnameAndQuery());
-      routerEvents.emit("routeChangeComplete", resolved, { shallow: options?.shallow ?? false });
-
-      // Scroll: handle hash target, else scroll to top unless scroll:false
-      const hash = resolved.includes("#") ? resolved.slice(resolved.indexOf("#")) : "";
-      if (options?.scroll !== false) {
-        if (hash) {
-          scrollToHashTarget(hash);
-        } else {
-          window.scrollTo(0, 0);
-        }
-      }
-      window.dispatchEvent(new CustomEvent("vinext:navigate"));
-      return true;
-    },
+    (url: string | UrlObject, as?: string, options?: TransitionOptions): Promise<boolean> =>
+      performNavigation(url, as, options, "replace", () => setState(getPathnameAndQuery())),
     [],
   );
 
@@ -785,16 +770,7 @@ export function useRouter(): NextRouter {
     window.location.reload();
   }, []);
 
-  const prefetch = useCallback(async (url: string): Promise<void> => {
-    // Inject a <link rel="prefetch"> for the target page
-    if (typeof document !== "undefined") {
-      const link = document.createElement("link");
-      link.rel = "prefetch";
-      link.href = url;
-      link.as = "document";
-      document.head.appendChild(link);
-    }
-  }, []);
+  const prefetch = useCallback(prefetchUrl, []);
 
   const router = useMemo(
     (): NextRouter =>
@@ -856,7 +832,7 @@ if (typeof window !== "undefined") {
       routerEvents.emit("hashChangeStart", hashUrl, { shallow: false });
       scrollToHashTarget(window.location.hash);
       routerEvents.emit("hashChangeComplete", hashUrl, { shallow: false });
-      window.dispatchEvent(new CustomEvent("vinext:navigate"));
+      dispatchNavigateEvent();
       return;
     }
 
@@ -873,7 +849,7 @@ if (typeof window !== "undefined") {
       if (result === "completed") {
         routerEvents.emit("routeChangeComplete", fullAppUrl, { shallow: false });
         restoreScrollPosition(e.state);
-        window.dispatchEvent(new CustomEvent("vinext:navigate"));
+        dispatchNavigateEvent();
       }
       // "cancelled": superseded by a newer navigation, so this popstate no longer wins.
       // "failed": runNavigateClient already scheduled the hard-navigation fallback.
@@ -984,130 +960,13 @@ export function withRouter<P extends WithRouterProps>(
 
 // Also export a default Router singleton for `import Router from 'next/router'`
 const Router = {
-  push: async (url: string | UrlObject, as?: string, options?: TransitionOptions) => {
-    let resolved = resolveNavigationTarget(url, as, options?.locale);
-
-    // External URLs (unless same-origin)
-    if (isExternalUrl(resolved)) {
-      const localPath = toSameOriginAppPath(resolved, __basePath);
-      if (localPath == null) {
-        window.location.assign(resolved);
-        return true;
-      }
-      resolved = localPath;
-    }
-
-    const full = toBrowserNavigationHref(resolved, window.location.href, __basePath);
-
-    // Hash-only change
-    if (isHashOnlyChange(full)) {
-      const eventUrl = resolveHashUrl(full);
-      routerEvents.emit("hashChangeStart", eventUrl, {
-        shallow: options?.shallow ?? false,
-      });
-      const hash = resolved.includes("#") ? resolved.slice(resolved.indexOf("#")) : "";
-      window.history.pushState({}, "", resolved.startsWith("#") ? resolved : full);
-      _lastPathnameAndSearch = window.location.pathname + window.location.search;
-      if (options?.scroll !== false) {
-        scrollToHashTarget(hash);
-      }
-      routerEvents.emit("hashChangeComplete", eventUrl, {
-        shallow: options?.shallow ?? false,
-      });
-      window.dispatchEvent(new CustomEvent("vinext:navigate"));
-      return true;
-    }
-
-    saveScrollPosition();
-    routerEvents.emit("routeChangeStart", resolved, { shallow: options?.shallow ?? false });
-    routerEvents.emit("beforeHistoryChange", resolved, { shallow: options?.shallow ?? false });
-    window.history.pushState({}, "", full);
-    _lastPathnameAndSearch = window.location.pathname + window.location.search;
-    if (!options?.shallow) {
-      const result = await runNavigateClient(full, resolved);
-      if (result === "cancelled") return true;
-      if (result === "failed") return false;
-    }
-    routerEvents.emit("routeChangeComplete", resolved, { shallow: options?.shallow ?? false });
-
-    const hash = resolved.includes("#") ? resolved.slice(resolved.indexOf("#")) : "";
-    if (options?.scroll !== false) {
-      if (hash) {
-        scrollToHashTarget(hash);
-      } else {
-        window.scrollTo(0, 0);
-      }
-    }
-    window.dispatchEvent(new CustomEvent("vinext:navigate"));
-    return true;
-  },
-  replace: async (url: string | UrlObject, as?: string, options?: TransitionOptions) => {
-    let resolved = resolveNavigationTarget(url, as, options?.locale);
-
-    // External URLs (unless same-origin)
-    if (isExternalUrl(resolved)) {
-      const localPath = toSameOriginAppPath(resolved, __basePath);
-      if (localPath == null) {
-        window.location.replace(resolved);
-        return true;
-      }
-      resolved = localPath;
-    }
-
-    const full = toBrowserNavigationHref(resolved, window.location.href, __basePath);
-
-    // Hash-only change
-    if (isHashOnlyChange(full)) {
-      const eventUrl = resolveHashUrl(full);
-      routerEvents.emit("hashChangeStart", eventUrl, {
-        shallow: options?.shallow ?? false,
-      });
-      const hash = resolved.includes("#") ? resolved.slice(resolved.indexOf("#")) : "";
-      window.history.replaceState({}, "", resolved.startsWith("#") ? resolved : full);
-      _lastPathnameAndSearch = window.location.pathname + window.location.search;
-      if (options?.scroll !== false) {
-        scrollToHashTarget(hash);
-      }
-      routerEvents.emit("hashChangeComplete", eventUrl, {
-        shallow: options?.shallow ?? false,
-      });
-      window.dispatchEvent(new CustomEvent("vinext:navigate"));
-      return true;
-    }
-
-    routerEvents.emit("routeChangeStart", resolved, { shallow: options?.shallow ?? false });
-    routerEvents.emit("beforeHistoryChange", resolved, { shallow: options?.shallow ?? false });
-    window.history.replaceState({}, "", full);
-    _lastPathnameAndSearch = window.location.pathname + window.location.search;
-    if (!options?.shallow) {
-      const result = await runNavigateClient(full, resolved);
-      if (result === "cancelled") return true;
-      if (result === "failed") return false;
-    }
-    routerEvents.emit("routeChangeComplete", resolved, { shallow: options?.shallow ?? false });
-
-    const hash = resolved.includes("#") ? resolved.slice(resolved.indexOf("#")) : "";
-    if (options?.scroll !== false) {
-      if (hash) {
-        scrollToHashTarget(hash);
-      } else {
-        window.scrollTo(0, 0);
-      }
-    }
-    window.dispatchEvent(new CustomEvent("vinext:navigate"));
-    return true;
-  },
+  push: (url: string | UrlObject, as?: string, options?: TransitionOptions) =>
+    performNavigation(url, as, options, "push"),
+  replace: (url: string | UrlObject, as?: string, options?: TransitionOptions) =>
+    performNavigation(url, as, options, "replace"),
   back: () => window.history.back(),
   reload: () => window.location.reload(),
-  prefetch: async (url: string) => {
-    if (typeof document !== "undefined") {
-      const link = document.createElement("link");
-      link.rel = "prefetch";
-      link.href = url;
-      link.as = "document";
-      document.head.appendChild(link);
-    }
-  },
+  prefetch: prefetchUrl,
   beforePopState: (cb: BeforePopStateCallback) => {
     _beforePopStateCb = cb;
   },


### PR DESCRIPTION
## Summary
- `useRouter()`'s `push`/`replace` and the `Router` singleton's `push`/`replace` each carried near-identical ~60-line bodies. Extracted a shared `performNavigation(url, as, options, mode, onStateUpdate?)` that branches on `mode` only where push and replace truly differ (`pushState` vs `replaceState`, `location.assign` vs `location.replace`, push-only `saveScrollPosition()`).
- Small dedup helpers along for the ride: `updateHistory(mode, url)` (history call + `_lastPathnameAndSearch` tracker), `dispatchNavigateEvent()` (5 call sites), `extractHash(url)` (4 call sites), `prefetchUrl(url)` (shared by hook + singleton).
- Net diff: 112 insertions / 253 deletions on `packages/vinext/src/shims/router.ts`.

Behaviour preservation:
- Event ordering inside the hash-only branch kept identical (`hashChangeStart` → history → scroll → state update → `hashChangeComplete` → dispatch).
- Singleton's `back`/`reload` kept as `() => window.history.back()` etc., hook's kept as `useCallback` wrappers (stable refs needed for the `useMemo` dep array).

## Test plan
- [x] `pnpm check` (format + lint + types) passes
- [ ] `pnpm test:unit` — router-touching tests pass (`tests/pages-router.test.ts`, `tests/shims.test.ts`, `tests/link.test.ts`)
- [ ] manual: client-side push, replace, hash-only push, external URL fallback, browser back/forward