### PR TITLE
fix(edge): expose AsyncLocalStorage as a global in edge runtime

### DIFF
--- a/packages/vinext/src/server/app-router-entry.ts
+++ b/packages/vinext/src/server/app-router-entry.ts
@@ -12,6 +12,10 @@
  *   cloudflare({ viteEnvironment: { name: "rsc", childEnvironments: ["ssr"] } })
  */
 
+// Install edge-runtime globals (e.g. AsyncLocalStorage) so user route handlers
+// and middleware can reference them without an explicit import, matching
+// Next.js behavior.
+import "./edge-globals.js";
 // @ts-expect-error — virtual module resolved by vinext
 import rscHandler from "virtual:vinext-rsc-entry";
 import { runWithExecutionContext, type ExecutionContextLike } from "vinext/shims/request-context";

--- a/packages/vinext/src/server/edge-globals.ts
+++ b/packages/vinext/src/server/edge-globals.ts
@@ -1,0 +1,39 @@
+/**
+ * Globals exposed by the Next.js edge runtime that user code is allowed to
+ * reference without an explicit `import`.
+ *
+ * Next.js's edge sandbox stitches a number of Node and Web APIs onto the
+ * runtime's global context. vinext executes user code directly on the
+ * Cloudflare Workers runtime (no separate sandbox), and Workers does not
+ * expose `AsyncLocalStorage` as a global — it is only available via
+ * `import { AsyncLocalStorage } from "node:async_hooks"` under the
+ * `nodejs_compat` flag.
+ *
+ * User code written for Next.js's edge runtime can do
+ *
+ *     const storage = new AsyncLocalStorage()
+ *
+ * without importing it. To preserve that surface on vinext we install
+ * `AsyncLocalStorage` on `globalThis` (idempotently) from any runtime entry
+ * point that might evaluate user edge code: middleware, App Router route
+ * handlers, and Pages API routes.
+ *
+ * Reference (Next.js edge sandbox):
+ *   packages/next/src/server/web/sandbox/context.ts
+ *     context.AsyncLocalStorage = AsyncLocalStorage
+ *
+ * TODO(edge-globals): A `URLPattern` change is being worked on in parallel.
+ * Once both land, consider consolidating these into a single
+ * `installEdgeGlobals()` helper called from a shared bootstrap.
+ */
+import { AsyncLocalStorage } from "node:async_hooks";
+
+type GlobalWithEdgeAdditions = typeof globalThis & {
+  AsyncLocalStorage?: typeof AsyncLocalStorage;
+};
+
+const _g = globalThis as GlobalWithEdgeAdditions;
+
+if (typeof _g.AsyncLocalStorage === "undefined") {
+  _g.AsyncLocalStorage = AsyncLocalStorage;
+}

--- a/packages/vinext/src/server/middleware-runtime.ts
+++ b/packages/vinext/src/server/middleware-runtime.ts
@@ -1,3 +1,6 @@
+// Install edge-runtime globals (e.g. AsyncLocalStorage) so user middleware
+// can reference them without an explicit import, matching Next.js behavior.
+import "./edge-globals.js";
 import type { NextI18nConfig } from "../config/next-config.js";
 import { normalizePathnameForRouteMatchStrict } from "../routing/utils.js";
 import {

--- a/packages/vinext/src/server/pages-api-route.ts
+++ b/packages/vinext/src/server/pages-api-route.ts
@@ -1,3 +1,7 @@
+// Install edge-runtime globals (e.g. AsyncLocalStorage) so user API handlers
+// configured with `runtime: 'edge'` can reference them without an explicit
+// import, matching Next.js behavior.
+import "./edge-globals.js";
 import type { Route } from "../routing/pages-router.js";
 import { mergeRouteParamsIntoQuery, parseQueryString } from "../utils/query.js";
 import {

--- a/tests/edge-globals.test.ts
+++ b/tests/edge-globals.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Tests that edge-runtime globals are exposed on `globalThis` for user code
+ * that does not explicitly import them.
+ *
+ * Next.js's edge sandbox installs `AsyncLocalStorage` on the global context
+ * (see `packages/next/src/server/web/sandbox/context.ts`). vinext executes
+ * user code directly on the Cloudflare Workers runtime, which only exposes
+ * `AsyncLocalStorage` via `import { AsyncLocalStorage } from "node:async_hooks"`.
+ * Without this shim, fixtures like `.nextjs-ref/test/e2e/edge-async-local-storage/`
+ * that do `new AsyncLocalStorage()` without an import fail with
+ *   ReferenceError: AsyncLocalStorage is not defined.
+ */
+import { describe, expect, it } from "vite-plus/test";
+import { AsyncLocalStorage as NodeAsyncLocalStorage } from "node:async_hooks";
+
+import { handlePagesApiRoute } from "../packages/vinext/src/server/pages-api-route.js";
+
+type GlobalWithAls = typeof globalThis & {
+  AsyncLocalStorage?: typeof NodeAsyncLocalStorage;
+};
+
+describe("edge runtime globals", () => {
+  it("exposes AsyncLocalStorage on globalThis after loading the pages api route entry", () => {
+    // Importing pages-api-route should have side-effect-installed the global
+    // (via the edge-globals module). Reference handlePagesApiRoute so the
+    // import is not tree-shaken in case the test runner gets clever.
+    expect(typeof handlePagesApiRoute).toBe("function");
+
+    const g = globalThis as GlobalWithAls;
+    expect(g.AsyncLocalStorage).toBeDefined();
+    expect(g.AsyncLocalStorage).toBe(NodeAsyncLocalStorage);
+  });
+
+  it("lets a Pages API handler use AsyncLocalStorage as a global, like Next.js edge runtime", async () => {
+    // This mirrors `.nextjs-ref/test/e2e/edge-async-local-storage/` —
+    // user code that does `new AsyncLocalStorage()` with no import.
+    const storage = new (globalThis as GlobalWithAls).AsyncLocalStorage!<{ id: string }>();
+
+    const response = await handlePagesApiRoute({
+      match: {
+        params: {},
+        route: {
+          pattern: "/api/async",
+          module: {
+            default: async (req, res) => {
+              const id = String(req.headers["req-id"] ?? "");
+              await storage.run({ id }, async () => {
+                await Promise.resolve();
+                res.json(storage.getStore());
+              });
+            },
+          },
+        },
+      },
+      request: new Request("https://example.com/api/async", {
+        headers: { "req-id": "req-42" },
+      }),
+      url: "/api/async",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ id: "req-42" });
+  });
+
+  it("preserves per-request isolation across many concurrent invocations", async () => {
+    const storage = new (globalThis as GlobalWithAls).AsyncLocalStorage!<{ id: string }>();
+
+    const handler = async (
+      req: { headers: Record<string, string | string[] | undefined> },
+      res: { json(data: unknown): void },
+    ): Promise<void> => {
+      const id = String(req.headers["req-id"] ?? "");
+      await storage.run({ id }, async () => {
+        // Yield to the event loop to expose any context leakage between requests.
+        await Promise.resolve();
+        await Promise.resolve();
+        res.json(storage.getStore());
+      });
+    };
+
+    const ids = Array.from({ length: 25 }, (_, i) => `req-${i}`);
+    const responses = await Promise.all(
+      ids.map((id) =>
+        handlePagesApiRoute({
+          match: {
+            params: {},
+            route: {
+              pattern: "/api/async",
+              module: { default: handler },
+            },
+          },
+          request: new Request("https://example.com/api/async", {
+            headers: { "req-id": id },
+          }),
+          url: "/api/async",
+        }),
+      ),
+    );
+
+    for (const [i, response] of responses.entries()) {
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({ id: ids[i] });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Edge fixtures like [`.nextjs-ref/test/e2e/edge-async-local-storage/`](https://github.com/vercel/next.js/blob/canary/test/e2e/edge-async-local-storage/index.test.ts) do `new AsyncLocalStorage()` without an explicit `import`, relying on the global that Next.js's edge sandbox installs:

```ts
// packages/next/src/server/web/sandbox/context.ts
context.AsyncLocalStorage = AsyncLocalStorage
```

vinext executes user code directly on the Cloudflare Workers runtime, which only exposes `AsyncLocalStorage` via `import { AsyncLocalStorage } from "node:async_hooks"` under the `nodejs_compat` flag, not as a global. As a result the `edge-async-local-storage` fixture failed in CI run [25951111875](https://github.com/cloudflare/vinext/actions/runs/25951111875) with:

```
ReferenceError: AsyncLocalStorage is not defined
```

This change adds a small `server/edge-globals.ts` module that idempotently installs `AsyncLocalStorage` on `globalThis`, and imports it for its side effect from each entry point that may evaluate user edge code:

- `server/app-router-entry.ts` — App Router worker entry (route handlers + middleware loaded via the RSC handler)
- `server/middleware-runtime.ts` — Pages and App middleware
- `server/pages-api-route.ts` — Pages API routes (including `runtime: 'edge'`)

A `TODO(edge-globals)` notes that a parallel PR is adding `URLPattern`, and once both land these can be consolidated into a single `installEdgeGlobals()` helper.

## Test plan

- [x] New unit test `tests/edge-globals.test.ts` verifies the global is exposed after loading `pages-api-route`, runs a handler that does `new AsyncLocalStorage()` like the upstream fixture, and exercises per-request isolation across 25 concurrent invocations.
- [x] Confirmed the new test fails (`TypeError: globalThis.AsyncLocalStorage is not a constructor`) when the `edge-globals.js` side-effect import is removed — i.e. it's a genuine regression test for this bug.
- [x] `pnpm test tests/edge-globals.test.ts tests/pages-api-route.test.ts tests/api-handler.test.ts tests/app-post-middleware-context.test.ts tests/app-route-handler-runtime.test.ts` — 74 tests pass.
- [x] `pnpm run check` — formatting, lint, and type checks all pass.