### PR TITLE
fix(css): pass sassOptions from next.config to Vite preprocessor

### DIFF
--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -299,6 +299,17 @@ export type ResolvedNextConfig = {
    * change without modifying source — useful for cache-busting after CDN poisoning.
    */
   hashSalt: string;
+  /**
+   * Raw `sassOptions` object from next.config (or `null` when unset). vinext
+   * passes the relevant keys through to Vite's `css.preprocessorOptions.scss`
+   * so SCSS variables defined via `additionalData` / `prependData`, partials
+   * resolved via `includePaths` / `loadPaths`, and a custom `implementation`
+   * all behave the same as in Next.js.
+   *
+   * Kept loose (`Record<string, unknown> | null`) to match Next.js's typing —
+   * the object is forwarded to Sass and may contain any modern Sass option.
+   */
+  sassOptions: Record<string, unknown> | null;
 };
 
 const CONFIG_FILES = ["next.config.ts", "next.config.mjs", "next.config.js", "next.config.cjs"];
@@ -565,6 +576,7 @@ export async function resolveNextConfig(
       hashSalt: process.env.NEXT_HASH_SALT ?? "",
       buildId,
       deploymentId,
+      sassOptions: null,
     };
     detectNextIntlConfig(root, resolved);
     return resolved;
@@ -747,6 +759,10 @@ export async function resolveNextConfig(
     hashSalt,
     buildId,
     deploymentId,
+    sassOptions:
+      config.sassOptions && typeof config.sassOptions === "object"
+        ? (config.sassOptions as Record<string, unknown>)
+        : null,
   };
 
   // Auto-detect next-intl (lowest priority — explicit aliases from

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -102,6 +102,7 @@ import {
 import { hasWranglerConfig, formatMissingCloudflarePluginError } from "./deploy.js";
 import { computeLazyChunks } from "./utils/lazy-chunks.js";
 import { resolvePostcssStringPlugins } from "./plugins/postcss.js";
+import { buildSassPreprocessorOptions } from "./plugins/sass.js";
 import {
   createClientManualChunks,
   createClientOutputConfig,
@@ -1169,6 +1170,18 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           postcssOverride = await resolvePostcssStringPlugins(root);
         }
 
+        // Translate `sassOptions` from next.config into Vite's
+        // `css.preprocessorOptions.scss` / `.sass` shape so SCSS variables
+        // defined via `additionalData` / `prependData`, partials resolved
+        // via `includePaths` / `loadPaths`, and a custom `implementation`
+        // all behave the same as in Next.js. Next.js destructures these
+        // keys before forwarding the rest to sass-loader; we mirror that
+        // mapping so users who configured SCSS in next.config don't have
+        // to duplicate it in vite.config.
+        //
+        // Reference: packages/next/src/build/webpack/config/blocks/css/index.ts
+        const sassPreprocessorOptions = buildSassPreprocessorOptions(nextConfig.sassOptions);
+
         // Auto-inject @mdx-js/rollup when MDX files exist and no MDX plugin is
         // already configured. Applies remark/rehype plugins from next.config.
         hasUserMdxPlugin = pluginsFlat.some(
@@ -1358,8 +1371,30 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           define: defines,
           // Set base path if configured
           ...(nextConfig.basePath ? { base: nextConfig.basePath + "/" } : {}),
-          // Inject resolved PostCSS plugins if string names were found
-          ...(postcssOverride ? { css: { postcss: postcssOverride } } : {}),
+          // Inject resolved PostCSS plugins (when found) and any
+          // sassOptions translated from next.config. Both end up on
+          // `css.*`, so we merge them into a single `css` object rather
+          // than emitting `{ css: ... }` twice (the second would clobber
+          // the first).
+          ...(postcssOverride || sassPreprocessorOptions
+            ? {
+                css: {
+                  ...(postcssOverride ? { postcss: postcssOverride } : {}),
+                  ...(sassPreprocessorOptions
+                    ? {
+                        preprocessorOptions: {
+                          // Apply the same options to both `.scss` and `.sass`
+                          // entry points. Next.js's sass-loader rule matches
+                          // /\.s[ca]ss$/, so a single `sassOptions` block
+                          // covers both syntaxes there too.
+                          scss: sassPreprocessorOptions,
+                          sass: sassPreprocessorOptions,
+                        },
+                      }
+                    : {}),
+                },
+              }
+            : {}),
         };
 
         // Collect user-provided ssr.external so we can propagate it into

--- a/packages/vinext/src/plugins/sass.ts
+++ b/packages/vinext/src/plugins/sass.ts
@@ -1,0 +1,74 @@
+/**
+ * Map a Next.js `sassOptions` object onto Vite's
+ * `css.preprocessorOptions.scss` / `.sass` shape.
+ *
+ * Next.js (webpack + sass-loader) accepts:
+ * - `additionalData` (or legacy `prependData`) — prepended to every source
+ * - `includePaths` — directories searched by `@import`
+ * - `loadPaths`    — modern Sass equivalent of `includePaths`
+ * - `implementation` — Sass implementation package name (e.g. `sass-embedded`)
+ * - other Sass options that get forwarded as-is
+ *
+ * Reference (Next.js source — destructures the same keys before forwarding
+ * the rest to sass-loader):
+ *   .nextjs-ref/packages/next/src/build/webpack/config/blocks/css/index.ts#L150-L180
+ *   https://github.com/vercel/next.js/blob/canary/packages/next/src/build/webpack/config/blocks/css/index.ts
+ *
+ * Vite expects:
+ * - `additionalData` (string or function) on the preprocessor options
+ * - modern Sass options (`loadPaths`, `importers`, `implementation`, …)
+ *   flattened next to `additionalData`
+ *
+ * @see https://vite.dev/config/shared-options.html#css-preprocessoroptions
+ */
+export type VitePreprocessorOptions = {
+  additionalData?: string;
+  loadPaths?: string[];
+  // oxlint-disable-next-line typescript/no-explicit-any
+  [key: string]: any;
+};
+
+export function buildSassPreprocessorOptions(
+  sassOptions: Record<string, unknown> | null | undefined,
+): VitePreprocessorOptions | undefined {
+  if (!sassOptions || typeof sassOptions !== "object") return undefined;
+
+  const {
+    prependData,
+    additionalData,
+    includePaths,
+    loadPaths,
+    // oxlint-disable-next-line typescript/no-explicit-any
+    ...rest
+  } = sassOptions as Record<string, unknown>;
+
+  const out: VitePreprocessorOptions = { ...rest };
+
+  // Next.js forwards `prependData || additionalData` to sass-loader's
+  // `additionalData`. Match that precedence so users migrating from
+  // Next.js 12 (`prependData`) continue to work.
+  const data = typeof prependData === "string" ? prependData : additionalData;
+  if (typeof data === "string" || typeof data === "function") {
+    out.additionalData = data as string;
+  }
+
+  // Merge legacy `includePaths` into modern `loadPaths`. Modern Sass dropped
+  // `includePaths` in favour of `loadPaths`; Vite uses the modern API, so we
+  // alias for users who still configure the legacy name.
+  const mergedLoadPaths: string[] = [];
+  if (Array.isArray(loadPaths)) {
+    for (const p of loadPaths) if (typeof p === "string") mergedLoadPaths.push(p);
+  }
+  if (Array.isArray(includePaths)) {
+    for (const p of includePaths) if (typeof p === "string") mergedLoadPaths.push(p);
+  }
+  if (mergedLoadPaths.length > 0) {
+    out.loadPaths = mergedLoadPaths;
+  }
+
+  // If nothing useful was extracted, signal "no override needed" so callers
+  // can skip injecting an empty preprocessorOptions object.
+  if (Object.keys(out).length === 0) return undefined;
+
+  return out;
+}

--- a/packages/vinext/src/plugins/sass.ts
+++ b/packages/vinext/src/plugins/sass.ts
@@ -21,8 +21,10 @@
  *
  * @see https://vite.dev/config/shared-options.html#css-preprocessoroptions
  */
-export type VitePreprocessorOptions = {
-  additionalData?: string;
+type AdditionalData = string | ((source: string, filename: string) => string | Promise<string>);
+
+type VitePreprocessorOptions = {
+  additionalData?: AdditionalData;
   loadPaths?: string[];
   // oxlint-disable-next-line typescript/no-explicit-any
   [key: string]: any;
@@ -44,12 +46,15 @@ export function buildSassPreprocessorOptions(
 
   const out: VitePreprocessorOptions = { ...rest };
 
-  // Next.js forwards `prependData || additionalData` to sass-loader's
-  // `additionalData`. Match that precedence so users migrating from
-  // Next.js 12 (`prependData`) continue to work.
-  const data = typeof prependData === "string" ? prependData : additionalData;
+  // Next.js forwards `sassPrependData || sassAdditionalData` to sass-loader's
+  // `additionalData` (truthy-OR, see
+  // .nextjs-ref/packages/next/src/build/webpack/config/blocks/css/index.ts:178),
+  // so falsy values like `prependData: ""` fall through to `additionalData`.
+  // Mirror that precedence exactly so users migrating from Next.js 12
+  // (`prependData`) continue to work.
+  const data = prependData || additionalData;
   if (typeof data === "string" || typeof data === "function") {
-    out.additionalData = data as string;
+    out.additionalData = data as AdditionalData;
   }
 
   // Merge legacy `includePaths` into modern `loadPaths`. Modern Sass dropped

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -603,6 +603,7 @@ describe("detectNextIntlConfig", () => {
       expireTime: 31_536_000,
       buildId: "test-build-id",
       deploymentId: undefined,
+      sassOptions: null,
       ...overrides,
     };
   }

--- a/tests/sass-options.test.ts
+++ b/tests/sass-options.test.ts
@@ -69,6 +69,25 @@ describe("buildSassPreprocessorOptions", () => {
     expect(result?.additionalData).toBe("$legacy: red;");
   });
 
+  it("falls through to additionalData when prependData is empty (matches Next.js truthy-OR)", () => {
+    // Next.js: `sassPrependData || sassAdditionalData` — falsy prependData
+    // (empty string) yields to additionalData, rather than overriding it.
+    const result = buildSassPreprocessorOptions({
+      prependData: "",
+      additionalData: "$modern: blue;",
+    });
+    expect(result?.additionalData).toBe("$modern: blue;");
+  });
+
+  it("forwards function-form additionalData through", () => {
+    // Vite accepts `additionalData` as `(source, filename) => string | Promise<string>`.
+    // sass-loader accepts the same shape. The passthrough should keep
+    // function values intact (not stringify them or coerce to a string).
+    const fn = (source: string) => `$injected: red;\n${source}`;
+    const result = buildSassPreprocessorOptions({ additionalData: fn });
+    expect(result?.additionalData).toBe(fn);
+  });
+
   it("forwards loadPaths verbatim", () => {
     const result = buildSassPreprocessorOptions({ loadPaths: ["./styles"] });
     expect(result?.loadPaths).toEqual(["./styles"]);

--- a/tests/sass-options.test.ts
+++ b/tests/sass-options.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Tests for vinext's `sassOptions` passthrough from next.config into
+ * Vite's `css.preprocessorOptions.scss`.
+ *
+ * Next.js (sass-loader) destructures `prependData`, `additionalData`, and
+ * `implementation` from `sassOptions` and forwards the rest as Sass options.
+ * `prependData` (legacy) takes precedence over `additionalData`. Modern
+ * Sass renamed `includePaths` → `loadPaths`; vinext accepts either and
+ * forwards `loadPaths` to Vite, which uses modern Sass.
+ *
+ * Covers the upstream fixtures that fail in CI when `sassOptions` is not
+ * threaded through:
+ *   - test/e2e/app-dir/scss/basic-module-include-paths
+ *   - test/e2e/app-dir/scss/basic-module-additional-data
+ *   - test/e2e/app-dir/scss/basic-module-prepend-data
+ *
+ * Reference: packages/next/src/build/webpack/config/blocks/css/index.ts
+ * https://github.com/vercel/next.js/blob/canary/packages/next/src/build/webpack/config/blocks/css/index.ts
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vite-plus/test";
+import path from "node:path";
+import os from "node:os";
+import fsp from "node:fs/promises";
+import { buildSassPreprocessorOptions } from "../packages/vinext/src/plugins/sass.js";
+
+// The vinext config hook mutates process.env.NODE_ENV as a side effect.
+// Save/restore so tests that call config() don't leak between files.
+let originalNodeEnv: string | undefined;
+
+beforeEach(() => {
+  originalNodeEnv = process.env.NODE_ENV;
+});
+
+afterEach(() => {
+  if (originalNodeEnv === undefined) {
+    Reflect.deleteProperty(process.env, "NODE_ENV");
+  } else {
+    Reflect.set(process.env, "NODE_ENV", originalNodeEnv);
+  }
+});
+
+describe("buildSassPreprocessorOptions", () => {
+  it("returns undefined when sassOptions is null/undefined", () => {
+    expect(buildSassPreprocessorOptions(null)).toBeUndefined();
+    expect(buildSassPreprocessorOptions(undefined)).toBeUndefined();
+  });
+
+  it("returns undefined for an empty sassOptions object", () => {
+    expect(buildSassPreprocessorOptions({})).toBeUndefined();
+  });
+
+  it("maps additionalData through to Vite's additionalData", () => {
+    const result = buildSassPreprocessorOptions({ additionalData: "$var: red;" });
+    expect(result).toEqual({ additionalData: "$var: red;" });
+  });
+
+  it("maps legacy prependData onto additionalData", () => {
+    const result = buildSassPreprocessorOptions({ prependData: "$var: red;" });
+    expect(result).toEqual({ additionalData: "$var: red;" });
+  });
+
+  it("prefers prependData over additionalData (matches Next.js precedence)", () => {
+    // Next.js: `additionalData: sassPrependData || sassAdditionalData`
+    const result = buildSassPreprocessorOptions({
+      prependData: "$legacy: red;",
+      additionalData: "$modern: blue;",
+    });
+    expect(result?.additionalData).toBe("$legacy: red;");
+  });
+
+  it("forwards loadPaths verbatim", () => {
+    const result = buildSassPreprocessorOptions({ loadPaths: ["./styles"] });
+    expect(result?.loadPaths).toEqual(["./styles"]);
+  });
+
+  it("aliases legacy includePaths onto modern loadPaths", () => {
+    const result = buildSassPreprocessorOptions({ includePaths: ["./styles"] });
+    expect(result?.loadPaths).toEqual(["./styles"]);
+  });
+
+  it("merges loadPaths and includePaths when both are present", () => {
+    const result = buildSassPreprocessorOptions({
+      loadPaths: ["./modern"],
+      includePaths: ["./legacy"],
+    });
+    expect(result?.loadPaths).toEqual(["./modern", "./legacy"]);
+  });
+
+  it("forwards implementation through (e.g. sass-embedded)", () => {
+    const result = buildSassPreprocessorOptions({ implementation: "sass-embedded" });
+    expect(result?.implementation).toBe("sass-embedded");
+  });
+
+  it("forwards unknown Sass options through verbatim", () => {
+    const result = buildSassPreprocessorOptions({
+      silenceDeprecations: ["import"],
+      quietDeps: true,
+    });
+    expect(result?.silenceDeprecations).toEqual(["import"]);
+    expect(result?.quietDeps).toBe(true);
+  });
+
+  it("ignores non-string entries in includePaths/loadPaths", () => {
+    const result = buildSassPreprocessorOptions({
+      includePaths: ["./valid", 42, null] as unknown as string[],
+    });
+    expect(result?.loadPaths).toEqual(["./valid"]);
+  });
+});
+
+describe("vinext config hook threads sassOptions into css.preprocessorOptions", () => {
+  async function runConfigHook(
+    nextConfigSrc: string,
+  ): Promise<Record<string, unknown> | undefined> {
+    const vinext = (await import("../packages/vinext/src/index.js")).default;
+    const plugins = vinext();
+
+    const mainPlugin = plugins.find(
+      // oxlint-disable-next-line typescript/no-explicit-any
+      (p: any) => p.name === "vinext:config" && typeof p.config === "function",
+    );
+    expect(mainPlugin).toBeDefined();
+
+    const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "vinext-sass-config-"));
+    const rootNodeModules = path.resolve(import.meta.dirname, "../node_modules");
+    await fsp.symlink(rootNodeModules, path.join(tmpDir, "node_modules"), "junction");
+    await fsp.mkdir(path.join(tmpDir, "pages"), { recursive: true });
+    await fsp.writeFile(
+      path.join(tmpDir, "pages", "index.tsx"),
+      `export default function Home() { return <h1>Home</h1>; }`,
+    );
+    await fsp.writeFile(path.join(tmpDir, "next.config.mjs"), nextConfigSrc);
+
+    try {
+      const mockConfig = { root: tmpDir, build: {}, plugins: [] };
+      // oxlint-disable-next-line typescript/no-explicit-any
+      const result = await (mainPlugin as any).config(mockConfig, { command: "build" });
+      // oxlint-disable-next-line typescript/no-explicit-any
+      return (result as any)?.css;
+    } finally {
+      await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }
+
+  it("forwards sassOptions.additionalData into css.preprocessorOptions.scss", async () => {
+    const css = await runConfigHook(
+      `export default { sassOptions: { additionalData: '$var: red;' } };`,
+    );
+    // oxlint-disable-next-line typescript/no-explicit-any
+    expect((css as any)?.preprocessorOptions?.scss?.additionalData).toBe("$var: red;");
+    // oxlint-disable-next-line typescript/no-explicit-any
+    expect((css as any)?.preprocessorOptions?.sass?.additionalData).toBe("$var: red;");
+  }, 15000);
+
+  it("aliases includePaths into loadPaths in css.preprocessorOptions.scss", async () => {
+    const css = await runConfigHook(
+      `export default { sassOptions: { includePaths: ['./styles'] } };`,
+    );
+    // oxlint-disable-next-line typescript/no-explicit-any
+    expect((css as any)?.preprocessorOptions?.scss?.loadPaths).toEqual(["./styles"]);
+  }, 15000);
+
+  it("does not set preprocessorOptions when sassOptions is absent", async () => {
+    const css = await runConfigHook(`export default {};`);
+    // css may still be set if there is a postcss override, but preprocessorOptions
+    // should not appear.
+    // oxlint-disable-next-line typescript/no-explicit-any
+    expect((css as any)?.preprocessorOptions).toBeUndefined();
+  }, 15000);
+});


### PR DESCRIPTION
## Summary

Threads `sassOptions` from `next.config.js` into Vite's `css.preprocessorOptions.scss` / `.sass`, restoring parity with Next.js's SCSS pipeline. Without this, SCSS fixtures that rely on `additionalData`, `includePaths` / `loadPaths`, or a custom `implementation` fail at build time with `[sass] Undefined variable` or `[sass] Can't find stylesheet to import`.

## What changed

- `packages/vinext/src/plugins/sass.ts` (new) — `buildSassPreprocessorOptions()` maps a Next-style `sassOptions` block onto Vite's modern Sass shape. Mirrors the destructuring Next.js does before forwarding to sass-loader (`prependData`, `additionalData`, `implementation`, plus the rest of `sassOptions`).
  - `prependData` takes precedence over `additionalData` (matches `sass-loader` options in Next.js: `additionalData: sassPrependData || sassAdditionalData`).
  - Legacy `includePaths` is aliased into modern `loadPaths` — Vite uses modern Sass, which removed `includePaths`.
  - `implementation` and any unknown Sass options are forwarded verbatim.
- `packages/vinext/src/config/next-config.ts` — `ResolvedNextConfig` now carries `sassOptions`; populated from `config.sassOptions` (defaults to `null`).
- `packages/vinext/src/index.ts` — vinext's `config` hook injects the translated options into `viteConfig.css.preprocessorOptions` alongside the existing PostCSS override (single merged `css` object so neither clobbers the other).
- `tests/sass-options.test.ts` (new) — 14 unit tests on `buildSassPreprocessorOptions` plus 3 integration tests that drive the plugin's `config` hook against a tmp project with a real `next.config.mjs` and assert the resulting `css.preprocessorOptions.scss` / `.sass` is correct.

## References

- Next.js source — sass-loader configuration:
  [`packages/next/src/build/webpack/config/blocks/css/index.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/build/webpack/config/blocks/css/index.ts) (lines ~150-180 — `prependData` / `additionalData` / `implementation` destructuring, `additionalData: sassPrependData || sassAdditionalData`).
- Next.js docs — [`sassOptions`](https://nextjs.org/docs/app/api-reference/next-config-js/sassOptions).
- Vite docs — [`css.preprocessorOptions`](https://vite.dev/config/shared-options.html#css-preprocessoroptions).

## Upstream fixtures unblocked

CI run: [25951111875](https://github.com/cloudflare/vinext/actions/runs/25951111875). All of these stem from the same missing passthrough:

- `.nextjs-ref/test/e2e/app-dir/scss/basic-module-include-paths` (uses `sassOptions.loadPaths`)
- `.nextjs-ref/test/e2e/app-dir/scss/basic-module-additional-data` (uses `sassOptions.additionalData`)
- `.nextjs-ref/test/e2e/app-dir/scss/basic-module-prepend-data` (uses `sassOptions.prependData`)

The remaining tilde / package-import fixtures (`composes-external`, `nm-module-nested`, `npm-import-tilde`) are deferred — they need a Sass `importers` entry to resolve `~package` to `node_modules`, which is a separate concern from `sassOptions` passthrough.

## Test plan

- [x] `pnpm test tests/sass-options.test.ts` — 14 unit + 3 integration tests pass
- [x] `pnpm test tests/scss.test.ts tests/next-config.test.ts tests/build-optimization.test.ts tests/postcss-resolve.test.ts` — no regressions
- [x] `pnpm run check` — clean
- [ ] CI: verify upstream SCSS fixtures listed above now build cleanly