### PR TITLE
fix(config): provide CJS globals when loading next.config.ts

### DIFF
--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -380,13 +380,23 @@ async function resolveConfigValue(
 }
 
 /**
- * Sentinel marker placed on the injected `module.exports` initial object so we
- * can detect whether a config file reassigned `module.exports = {...}` (CJS
- * style) versus only using `export default` (ESM style). See
- * `cjsGlobalsInjectorPlugin` for how the marker gets attached.
+ * Named export attached by `cjsGlobalsInjectorPlugin` when the source
+ * statically looks like it assigns to `module.exports`. Holds the wrapper
+ * `module` object so {@link unwrapConfig} can read back the user's CJS-style
+ * export. Pure-ESM configs skip the wrapper entirely and rely on the ESM
+ * `default` export instead.
  */
 const VINEXT_CJS_EXPORTS_KEY = "__vinext_cjs_exports";
-const VINEXT_CJS_INITIAL_MARKER = Symbol.for("vinext:cjs-initial");
+
+/**
+ * Companion named export pointing at the initial empty `{}` that the wrapper
+ * is constructed with. Lets {@link unwrapConfig} distinguish "user reassigned
+ * or mutated module.exports" from "module.exports is still the untouched
+ * empty wrapper" — the latter happens when {@link reassignsModuleExports}
+ * matches inside a string or comment (a harmless false positive that should
+ * still fall through to the ESM `default` export).
+ */
+const VINEXT_CJS_INITIAL_KEY = "__vinext_cjs_initial_exports";
 
 /**
  * Unwrap the config value from a loaded module namespace.
@@ -395,26 +405,29 @@ const VINEXT_CJS_INITIAL_MARKER = Symbol.for("vinext:cjs-initial");
  * otherwise falls back to `default`/the namespace itself. Mirrors Next.js's
  * behaviour, where the config is loaded through `Module._compile` and CJS
  * assignments override any ESM-style exports.
+ *
+ * The presence of the `__vinext_cjs_exports` named export is the static
+ * signal (set by `cjsGlobalsInjectorPlugin` when `reassignsModuleExports`
+ * matched) that this file might use CJS-style exports. We then disambiguate
+ * "user actually touched module.exports" from "static heuristic was a false
+ * positive" by comparing identity against the initial empty wrapper: if
+ * `module.exports` is still the original `{}`, fall back to ESM `default`.
  */
 async function unwrapConfig(
   // oxlint-disable-next-line typescript/no-explicit-any
   mod: any,
   phase: string = PHASE_DEVELOPMENT_SERVER,
 ): Promise<NextConfig> {
-  // The CJS-globals injector plugin exports the wrapper `module` object
-  // (with an `.exports` property) so that `module.exports = ...` reassignments
-  // inside the config file are observable here. The wrapper's initial
-  // `exports` value is tagged with VINEXT_CJS_INITIAL_MARKER; if that marker
-  // is still present, the file did not use CJS-style exports and we fall
-  // through to the ESM `default` export.
   const cjsModule = mod?.[VINEXT_CJS_EXPORTS_KEY];
   const cjsExports = cjsModule?.exports;
-  if (
+  const cjsInitial = mod?.[VINEXT_CJS_INITIAL_KEY];
+  const userTouchedExports =
     cjsExports !== undefined &&
     cjsExports !== null &&
-    typeof cjsExports === "object" &&
-    !(VINEXT_CJS_INITIAL_MARKER in cjsExports)
-  ) {
+    // Either reassigned outright, or mutated keys on the initial object.
+    (cjsExports !== cjsInitial ||
+      (typeof cjsExports === "object" && Object.keys(cjsExports).length > 0));
+  if (userTouchedExports) {
     return await resolveConfigValue(cjsExports, phase);
   }
   return await resolveConfigValue(mod.default ?? mod, phase);
@@ -449,6 +462,29 @@ function safeRealpath(p: string): string {
  */
 export function referencesCjsGlobals(source: string): boolean {
   return /\b(?:__filename|__dirname|require|module|exports)\b/.test(source);
+}
+
+/**
+ * Static heuristic: returns true when the source appears to assign to
+ * `module.exports` — either via `module.exports = …`, `module.exports.foo = …`,
+ * or `module.exports[…] = …`. Used to decide whether the injector plugin
+ * needs to wire up the wrapper `module` object so {@link unwrapConfig} can
+ * read back the user's CJS-style export.
+ *
+ * Pure-ESM configs skip the wrapper entirely, which means a faster transform
+ * (no extra `export const` line) and a simpler unwrap path (no need to
+ * disambiguate "initial empty object" from "user reassigned to {}").
+ *
+ * Like {@link referencesCjsGlobals}, false positives are harmless: at worst
+ * we emit an unused `__vinext_cjs_exports` named export, and `unwrapConfig`
+ * still prefers it (it points at an empty object, which then gets treated
+ * as the config — equivalent to today's sentinel logic for pure-ESM files
+ * that happen to mention `module.exports` only in a string).
+ */
+export function reassignsModuleExports(source: string): boolean {
+  // Match `module.exports` followed by `=` (not `==` / `===`), `.identifier =`,
+  // or `[...] =`. Whitespace allowed around the dot.
+  return /\bmodule\s*\.\s*exports\b\s*(?:=(?!=)|\.\s*[A-Za-z_$][\w$]*\s*=(?!=)|\[)/.test(source);
 }
 
 /**
@@ -505,6 +541,19 @@ function cjsGlobalsInjectorPlugin(configPath: string): {
       const dirnameLiteral = JSON.stringify(dirname);
       const requireBaseLiteral = JSON.stringify(path.join(dirname, "package.json"));
 
+      // Only wire up the wrapper `module` object — and the corresponding
+      // named export read by unwrapConfig — when the source statically looks
+      // like it assigns to module.exports. Pure-ESM configs avoid the extra
+      // export and the unwrap-by-wrapper code path.
+      const needsModuleWrapper = reassignsModuleExports(code);
+      const moduleLines = needsModuleWrapper
+        ? `const __vinextInitialExports = {};\n` +
+          `const module = { exports: __vinextInitialExports };\n` +
+          `const exports = module.exports;\n` +
+          `export const ${VINEXT_CJS_EXPORTS_KEY} = module;\n` +
+          `export const ${VINEXT_CJS_INITIAL_KEY} = __vinextInitialExports;\n`
+        : "";
+
       // Preamble runs after ESM imports are hoisted; the const bindings shadow
       // any global lookups the source would otherwise perform.
       const preamble =
@@ -512,14 +561,8 @@ function cjsGlobalsInjectorPlugin(configPath: string): {
         `const __filename = ${filenameLiteral};\n` +
         `const __dirname = ${dirnameLiteral};\n` +
         `const require = __vinextCreateRequire(${requireBaseLiteral});\n` +
-        `const module = { exports: {} };\n` +
-        `module.exports[Symbol.for("vinext:cjs-initial")] = true;\n` +
-        `const exports = module.exports;\n` +
-        `export const ${VINEXT_CJS_EXPORTS_KEY} = module;\n`;
+        moduleLines;
 
-      // Export the wrapper object (not `module.exports` directly) so that
-      // `module.exports = {...}` reassignments inside the user's source are
-      // visible to {@link unwrapConfig} via the wrapper's mutated `.exports`.
       return {
         code: preamble + code,
         map: null,

--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -433,6 +433,25 @@ function safeRealpath(p: string): string {
 }
 
 /**
+ * Whole-word substring check for any of the CJS-style globals that the
+ * injector plugin would shim. Used to skip the transform entirely for the
+ * common case where the config is pure ESM (no `__filename`, `__dirname`,
+ * `require`, `module`, or `exports` references).
+ *
+ * False positives are harmless: a comment, string literal, or unrelated
+ * identifier like `node:module` will trigger the transform unnecessarily,
+ * but the resulting injection is idempotent and the loaded config is
+ * unaffected. False negatives would be a correctness bug, so we err on the
+ * side of matching too eagerly.
+ *
+ * Note: `\bexports\b` does not match `export default` (different word
+ * boundaries), and `\brequire\b` does not match `requireSomething`.
+ */
+export function referencesCjsGlobals(source: string): boolean {
+  return /\b(?:__filename|__dirname|require|module|exports)\b/.test(source);
+}
+
+/**
  * Vite plugin that prepends CJS-style globals (`__filename`, `__dirname`,
  * `module`, `exports`, `require`) to the next.config.* source before
  * Vite's module runner evaluates it.
@@ -445,6 +464,10 @@ function safeRealpath(p: string): string {
  * `fs.readFileSync(path.join(__dirname, 'foo.txt'), 'utf8')`. vinext loads
  * configs through Vite's ESM-only module runner, so we inject the same
  * globals as plain `const` declarations.
+ *
+ * For configs that don't reference any CJS global (the common case — every
+ * upstream `next-config-ts` fixture except `node-api-cjs` is pure ESM) we
+ * skip the transform entirely; see {@link referencesCjsGlobals}.
  *
  * `module.exports` reassignment is preserved by exposing the injected
  * `module` object as a named export (see {@link VINEXT_CJS_EXPORTS_KEY}) and
@@ -469,6 +492,12 @@ function cjsGlobalsInjectorPlugin(configPath: string): {
       const idPath = id.startsWith("file://") ? fileURLToPath(id) : id.split("?")[0];
       const resolvedId = safeRealpath(path.resolve(idPath));
       if (resolvedId !== normalizedTarget) return null;
+
+      // Fast path: skip the transform when the source contains no bareword
+      // reference to any of the shimmed globals. The vast majority of
+      // `next.config.ts` files are pure ESM (`export default { ... }`) and
+      // pay no cost from this plugin.
+      if (!referencesCjsGlobals(code)) return null;
 
       const dirname = path.dirname(normalizedTarget);
       // JSON.stringify produces safe JS string literals for paths.

--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -380,14 +380,123 @@ async function resolveConfigValue(
 }
 
 /**
+ * Sentinel marker placed on the injected `module.exports` initial object so we
+ * can detect whether a config file reassigned `module.exports = {...}` (CJS
+ * style) versus only using `export default` (ESM style). See
+ * `cjsGlobalsInjectorPlugin` for how the marker gets attached.
+ */
+const VINEXT_CJS_EXPORTS_KEY = "__vinext_cjs_exports";
+const VINEXT_CJS_INITIAL_MARKER = Symbol.for("vinext:cjs-initial");
+
+/**
  * Unwrap the config value from a loaded module namespace.
+ *
+ * Prefers `module.exports` (CJS style) when the config file reassigned it,
+ * otherwise falls back to `default`/the namespace itself. Mirrors Next.js's
+ * behaviour, where the config is loaded through `Module._compile` and CJS
+ * assignments override any ESM-style exports.
  */
 async function unwrapConfig(
   // oxlint-disable-next-line typescript/no-explicit-any
   mod: any,
   phase: string = PHASE_DEVELOPMENT_SERVER,
 ): Promise<NextConfig> {
+  // The CJS-globals injector plugin exports the wrapper `module` object
+  // (with an `.exports` property) so that `module.exports = ...` reassignments
+  // inside the config file are observable here. The wrapper's initial
+  // `exports` value is tagged with VINEXT_CJS_INITIAL_MARKER; if that marker
+  // is still present, the file did not use CJS-style exports and we fall
+  // through to the ESM `default` export.
+  const cjsModule = mod?.[VINEXT_CJS_EXPORTS_KEY];
+  const cjsExports = cjsModule?.exports;
+  if (
+    cjsExports !== undefined &&
+    cjsExports !== null &&
+    typeof cjsExports === "object" &&
+    !(VINEXT_CJS_INITIAL_MARKER in cjsExports)
+  ) {
+    return await resolveConfigValue(cjsExports, phase);
+  }
   return await resolveConfigValue(mod.default ?? mod, phase);
+}
+
+/**
+ * Resolve a path through filesystem symlinks, falling back to the original
+ * path when the file does not exist (e.g. virtual ids, query-suffixed ids).
+ */
+function safeRealpath(p: string): string {
+  try {
+    return fs.realpathSync(p);
+  } catch {
+    return p;
+  }
+}
+
+/**
+ * Vite plugin that prepends CJS-style globals (`__filename`, `__dirname`,
+ * `module`, `exports`, `require`) to the next.config.* source before
+ * Vite's module runner evaluates it.
+ *
+ * Next.js's `next.config.ts` loader (packages/next/src/build/next-config-ts/
+ * transpile-config.ts → require-hook.ts) feeds the file through Node's
+ * `Module._compile`, which provides these CJS globals even when the source
+ * uses ESM syntax. Upstream test fixtures in `test/e2e/app-dir/next-config-ts*`
+ * rely on that, e.g. `node-api-cjs/next.config.ts` reads
+ * `fs.readFileSync(path.join(__dirname, 'foo.txt'), 'utf8')`. vinext loads
+ * configs through Vite's ESM-only module runner, so we inject the same
+ * globals as plain `const` declarations.
+ *
+ * `module.exports` reassignment is preserved by exposing the injected
+ * `module` object as a named export (see {@link VINEXT_CJS_EXPORTS_KEY}) and
+ * reading it back in {@link unwrapConfig}.
+ */
+function cjsGlobalsInjectorPlugin(configPath: string): {
+  name: string;
+  enforce: "pre";
+  // oxlint-disable-next-line typescript/no-explicit-any
+  transform(this: unknown, code: string, id: string): any;
+} {
+  // Resolve symlinks once so we can compare against the (possibly
+  // symlink-resolved) id Vite passes to `transform`. On macOS, `/var/folders`
+  // is a symlink to `/private/var/folders`, so the temp-dir path in tests
+  // would otherwise mismatch.
+  const normalizedTarget = safeRealpath(path.resolve(configPath));
+  return {
+    name: "vinext:next-config-cjs-globals",
+    enforce: "pre",
+    transform(code: string, id: string) {
+      // Vite may pass an id with a query suffix (?v=...) or as a file URL.
+      const idPath = id.startsWith("file://") ? fileURLToPath(id) : id.split("?")[0];
+      const resolvedId = safeRealpath(path.resolve(idPath));
+      if (resolvedId !== normalizedTarget) return null;
+
+      const dirname = path.dirname(normalizedTarget);
+      // JSON.stringify produces safe JS string literals for paths.
+      const filenameLiteral = JSON.stringify(normalizedTarget);
+      const dirnameLiteral = JSON.stringify(dirname);
+      const requireBaseLiteral = JSON.stringify(path.join(dirname, "package.json"));
+
+      // Preamble runs after ESM imports are hoisted; the const bindings shadow
+      // any global lookups the source would otherwise perform.
+      const preamble =
+        `import { createRequire as __vinextCreateRequire } from "node:module";\n` +
+        `const __filename = ${filenameLiteral};\n` +
+        `const __dirname = ${dirnameLiteral};\n` +
+        `const require = __vinextCreateRequire(${requireBaseLiteral});\n` +
+        `const module = { exports: {} };\n` +
+        `module.exports[Symbol.for("vinext:cjs-initial")] = true;\n` +
+        `const exports = module.exports;\n` +
+        `export const ${VINEXT_CJS_EXPORTS_KEY} = module;\n`;
+
+      // Export the wrapper object (not `module.exports` directly) so that
+      // `module.exports = {...}` reassignments inside the user's source are
+      // visible to {@link unwrapConfig} via the wrapper's mutated `.exports`.
+      return {
+        code: preamble + code,
+        map: null,
+      };
+    },
+  };
 }
 
 export function findNextConfigPath(root: string): string | null {
@@ -491,6 +600,12 @@ export async function loadNextConfig(
       resolve: {
         alias: tsconfigAliases,
       },
+      // Only inject CJS globals for TypeScript config flavours. Next.js
+      // applies its `Module._compile` / SWC pipeline (which exposes the
+      // CJS globals) exclusively to `.ts`/`.mts`/`.cts`; legacy `.js`/`.cjs`
+      // configs are loaded through Node and already have `require`/`module`,
+      // and `.mjs` configs are explicitly ESM-only.
+      plugins: /\.[cm]?ts$/.test(configPath) ? [cjsGlobalsInjectorPlugin(configPath)] : [],
     });
     return await unwrapConfig(mod, phase);
   } catch (e) {

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -6,6 +6,7 @@ import {
   detectNextIntlConfig,
   loadNextConfig,
   parseBodySizeLimit,
+  reassignsModuleExports,
   referencesCjsGlobals,
   resolveNextConfig,
   type ResolvedNextConfig,
@@ -276,6 +277,90 @@ describe("referencesCjsGlobals", () => {
     // worst case, never a correctness bug.
     expect(referencesCjsGlobals(`// __dirname is shimmed`)).toBe(true);
     expect(referencesCjsGlobals(`const s = "module.exports = 1";`)).toBe(true);
+  });
+});
+
+describe("reassignsModuleExports", () => {
+  it("returns true for direct module.exports reassignment", () => {
+    expect(reassignsModuleExports(`module.exports = { foo: 1 };`)).toBe(true);
+    expect(reassignsModuleExports(`module . exports = X;`)).toBe(true);
+  });
+
+  it("returns true for property mutation", () => {
+    expect(reassignsModuleExports(`module.exports.foo = 1;`)).toBe(true);
+    expect(reassignsModuleExports(`module.exports["foo"] = 1;`)).toBe(true);
+    expect(reassignsModuleExports(`module.exports[name] = 1;`)).toBe(true);
+  });
+
+  it("returns false for pure-ESM source", () => {
+    expect(reassignsModuleExports(`export default { foo: 1 };`)).toBe(false);
+    expect(reassignsModuleExports(`const x = module;`)).toBe(false);
+    expect(reassignsModuleExports(`import x from "node:module";`)).toBe(false);
+  });
+
+  it("does not match comparisons or reads", () => {
+    expect(reassignsModuleExports(`if (module.exports === foo) {}`)).toBe(false);
+    expect(reassignsModuleExports(`const x = module.exports;`)).toBe(false);
+    expect(reassignsModuleExports(`const x = module.exports.foo;`)).toBe(false);
+  });
+});
+
+describe("loadNextConfig CJS vs ESM unwrap", () => {
+  // Exercises the static reassignsModuleExports detection end-to-end:
+  // pure-ESM configs go through the ESM `default` path, configs that
+  // reassign module.exports get unwrapped from the injected wrapper.
+  let tmpDir: string;
+
+  afterEach(() => {
+    if (tmpDir) {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns ESM default for a pure-ESM config", async () => {
+    tmpDir = makeTempDir();
+    fs.writeFileSync(
+      path.join(tmpDir, "next.config.ts"),
+      `export default { env: { SHAPE: "esm-default" } };\n`,
+    );
+    const config = await loadNextConfig(tmpDir);
+    expect(config?.env?.SHAPE).toBe("esm-default");
+  });
+
+  it("returns module.exports = X for a config that reassigns module.exports", async () => {
+    tmpDir = makeTempDir();
+    fs.writeFileSync(
+      path.join(tmpDir, "next.config.ts"),
+      `module.exports = { env: { SHAPE: "reassigned" } };\n`,
+    );
+    const config = await loadNextConfig(tmpDir);
+    expect(config?.env?.SHAPE).toBe("reassigned");
+  });
+
+  it("accumulates module.exports.foo = ... assignments", async () => {
+    tmpDir = makeTempDir();
+    fs.writeFileSync(
+      path.join(tmpDir, "next.config.ts"),
+      `module.exports.env = { SHAPE: "mutated" };\nmodule.exports.basePath = "/m";\n`,
+    );
+    const config = await loadNextConfig(tmpDir);
+    expect(config?.env?.SHAPE).toBe("mutated");
+    expect(config?.basePath).toBe("/m");
+  });
+
+  it("falls back to ESM default when module.exports reference is only a false positive", async () => {
+    // Ports the heuristic-false-positive case: the substring matcher
+    // could see `module.exports = ` inside a string and decide to emit
+    // the wrapper. The unwrap path checks identity against the initial
+    // empty exports object and falls back to the ESM default.
+    tmpDir = makeTempDir();
+    fs.writeFileSync(
+      path.join(tmpDir, "next.config.ts"),
+      `const doc = "module.exports = legacy";\nexport default { env: { SHAPE: "fallback", DOC: doc } };\n`,
+    );
+    const config = await loadNextConfig(tmpDir);
+    expect(config?.env?.SHAPE).toBe("fallback");
+    expect(config?.env?.DOC).toBe("module.exports = legacy");
   });
 });
 

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -6,6 +6,7 @@ import {
   detectNextIntlConfig,
   loadNextConfig,
   parseBodySizeLimit,
+  referencesCjsGlobals,
   resolveNextConfig,
   type ResolvedNextConfig,
 } from "../packages/vinext/src/config/next-config.js";
@@ -224,6 +225,57 @@ describe("loadNextConfig with CJS globals in next.config.ts", () => {
 
     const config = await loadNextConfig(tmpDir);
     expect(config?.env?.VIA).toBe("module.exports");
+  });
+
+  it("loads a pure-ESM next.config.ts without injecting CJS shims", async () => {
+    // No __filename / __dirname / require / module / exports references —
+    // the injector transform should short-circuit. We only assert
+    // functional behaviour: the export const that the transform would add
+    // (__vinext_cjs_exports) is invisible to user code anyway, so the
+    // observable contract is just "ESM config loads correctly".
+    tmpDir = makeTempDir();
+    fs.writeFileSync(
+      path.join(tmpDir, "next.config.ts"),
+      `export default { env: { PURE: "esm" } };\n`,
+    );
+
+    const config = await loadNextConfig(tmpDir);
+    expect(config?.env?.PURE).toBe("esm");
+  });
+});
+
+describe("referencesCjsGlobals", () => {
+  it("returns false for pure-ESM source", () => {
+    expect(referencesCjsGlobals(`export default { env: { FOO: "bar" } };\n`)).toBe(false);
+    expect(
+      referencesCjsGlobals(
+        `import type { NextConfig } from "next";\nconst nextConfig: NextConfig = {};\nexport default nextConfig;\n`,
+      ),
+    ).toBe(false);
+    expect(referencesCjsGlobals(`export { nextConfig as default };\n`)).toBe(false);
+  });
+
+  it("returns true when any CJS global is referenced", () => {
+    expect(referencesCjsGlobals(`const x = __filename;`)).toBe(true);
+    expect(referencesCjsGlobals(`const x = __dirname;`)).toBe(true);
+    expect(referencesCjsGlobals(`const x = require("./foo");`)).toBe(true);
+    expect(referencesCjsGlobals(`module.exports = { a: 1 };`)).toBe(true);
+    expect(referencesCjsGlobals(`exports.foo = 1;`)).toBe(true);
+  });
+
+  it("does not match identifiers that merely contain a global as a substring", () => {
+    expect(referencesCjsGlobals(`const requireSomething = 1;`)).toBe(false);
+    expect(referencesCjsGlobals(`const myModule = 1;`)).toBe(false);
+    expect(referencesCjsGlobals(`const exporter = 1;`)).toBe(false);
+    // `export default` is a different word boundary from `exports`.
+    expect(referencesCjsGlobals(`export default {};`)).toBe(false);
+  });
+
+  it("matches inside strings and comments (acceptable false positive)", () => {
+    // Substring match is intentionally loose: a wasted transform is the
+    // worst case, never a correctness bug.
+    expect(referencesCjsGlobals(`// __dirname is shimmed`)).toBe(true);
+    expect(referencesCjsGlobals(`const s = "module.exports = 1";`)).toBe(true);
   });
 });
 

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -161,6 +161,72 @@ describe("loadNextConfig phase argument", () => {
   });
 });
 
+describe("loadNextConfig with CJS globals in next.config.ts", () => {
+  // Ported from Next.js: test/e2e/app-dir/next-config-ts/node-api-cjs/
+  //   https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/next-config-ts/node-api-cjs/next.config.ts
+  // and test/e2e/app-dir/next-config-ts/import-js-extensions-cjs/.
+  // Next.js's transpile-config.ts transforms next.config.ts to CommonJS via SWC
+  // and evaluates it through Node's `Module._compile`, which exposes the CJS
+  // globals (`__filename`, `__dirname`, `module`, `require`, `exports`) even
+  // when the source uses ESM syntax. vinext mirrors that behaviour so that
+  // upstream fixtures referencing these globals continue to load.
+  let tmpDir: string;
+
+  afterEach(() => {
+    if (tmpDir) {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("exposes __dirname inside next.config.ts", async () => {
+    tmpDir = makeTempDir();
+    fs.writeFileSync(path.join(tmpDir, "foo.txt"), "foo");
+    fs.writeFileSync(
+      path.join(tmpDir, "next.config.ts"),
+      `import fs from "node:fs";\nimport path from "node:path";\nconst foo = fs.readFileSync(path.join(__dirname, "foo.txt"), "utf8");\nexport default { env: { FOO: foo } };\n`,
+    );
+
+    const config = await loadNextConfig(tmpDir);
+    expect(config?.env?.FOO).toBe("foo");
+  });
+
+  it("exposes __filename inside next.config.ts", async () => {
+    tmpDir = makeTempDir();
+    fs.writeFileSync(
+      path.join(tmpDir, "next.config.ts"),
+      `export default { env: { NAME: __filename } };\n`,
+    );
+
+    const config = await loadNextConfig(tmpDir);
+    const name = config?.env?.NAME;
+    expect(typeof name).toBe("string");
+    expect((name as string).endsWith("next.config.ts")).toBe(true);
+  });
+
+  it("exposes a working require() inside next.config.ts", async () => {
+    tmpDir = makeTempDir();
+    fs.writeFileSync(path.join(tmpDir, "data.json"), `{"value":"json-data"}`);
+    fs.writeFileSync(
+      path.join(tmpDir, "next.config.ts"),
+      `const data = require("./data.json");\nexport default { env: { VAL: data.value } };\n`,
+    );
+
+    const config = await loadNextConfig(tmpDir);
+    expect(config?.env?.VAL).toBe("json-data");
+  });
+
+  it("exposes a CommonJS module/exports object inside next.config.ts", async () => {
+    tmpDir = makeTempDir();
+    fs.writeFileSync(
+      path.join(tmpDir, "next.config.ts"),
+      `module.exports = { env: { VIA: "module.exports" } };\n`,
+    );
+
+    const config = await loadNextConfig(tmpDir);
+    expect(config?.env?.VIA).toBe("module.exports");
+  });
+});
+
 describe("loadNextConfig with tsconfig path aliases", () => {
   // Ported from Next.js: test/e2e/app-dir/next-config-ts/import-alias-paths-only/
   //   https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/next-config-ts/import-alias-paths-only/


### PR DESCRIPTION
## Summary

Several upstream `next-config-ts*` fixtures fail to even build in vinext with errors like:

- `[vinext] Failed to load next.config.ts: module is not defined`
- `ReferenceError: __filename is not defined`
- `ReferenceError: __dirname is not defined`

Next.js evaluates `next.config.ts` in a context where the CJS-style globals (`__filename`, `__dirname`, `module`, `exports`, `require`) are available even though the file itself uses ESM syntax. Concretely, `packages/next/src/build/next-config-ts/transpile-config.ts` transforms the source to CommonJS via SWC ([`module.type: 'commonjs'`](https://github.com/vercel/next.js/blob/canary/packages/next/src/build/next-config-ts/transpile-config.ts#L18-L43)) and then feeds it through `requireFromString`, which calls Node's `Module._compile` ([require-hook.ts](https://github.com/vercel/next.js/blob/canary/packages/next/src/build/next-config-ts/require-hook.ts#L50-L56)) - and `Module._compile` naturally wraps the code in `(function(exports, require, module, __filename, __dirname) { ... })`.

vinext loads the config through Vite's `runnerImport`, which uses an ESM-only evaluator. Without the CJS globals, any TypeScript config that references them throws.

This PR adds a small Vite plugin scoped to the config file that prepends a preamble declaring the missing globals as local `const`s. The preamble also installs a wrapper `module = { exports: {} }` and re-exports it as a named export so that CJS-style `module.exports = { ... }` reassignments inside the config remain observable. `unwrapConfig` prefers the reassigned `module.exports` value over the ESM `default` export, mirroring Node's behaviour. An initial sentinel symbol distinguishes "did not touch CJS exports" from "reassigned to `{}`".

The plugin is intentionally narrow:
- Runs only on the resolved `next.config.{ts,mts,cts}` path (gated by extension and by symlink-resolved path comparison).
- Does not touch `next.config.{js,mjs,cjs}` - those continue to be loaded by Vite/`createRequire` as before.
- No behavioural change for ESM-only configs.

### Affected upstream test fixtures

`.nextjs-ref/test/e2e/app-dir/`:
- `next-config-ts-native-ts/import-js-extensions-cjs`
- `next-config-ts-native-mts/{node-api-cjs,import-js-extensions-cjs,nested-imports,...}`
- `next-config-ts/node-api-cjs`

CI run that surfaced these: https://github.com/cloudflare/vinext/actions/runs/25951111875

## Test plan

- [x] Added 4 unit tests in `tests/next-config.test.ts` covering `__dirname`, `__filename`, `require()`, and `module.exports = ...` inside a `next.config.ts`. All four fail on `main` and pass with this fix.
- [x] `pnpm test tests/next-config.test.ts` - 91/91 pass.
- [x] `pnpm test` - full suite, 5493 passed / 4 skipped.
- [x] `pnpm run check` - clean (formatter, lint, types).