### PR TITLE
fix(middleware): expose URLPattern global to middleware runtime

### DIFF
--- a/packages/vinext/package.json
+++ b/packages/vinext/package.json
@@ -69,6 +69,7 @@
     "image-size": "catalog:",
     "ipaddr.js": "catalog:",
     "magic-string": "catalog:",
+    "urlpattern-polyfill": "catalog:",
     "vite-plugin-commonjs": "catalog:",
     "vite-tsconfig-paths": "catalog:",
     "web-vitals": "catalog:"

--- a/packages/vinext/src/shims/server.ts
+++ b/packages/vinext/src/shims/server.ts
@@ -9,6 +9,7 @@
  * rather than bug-for-bug parity with Next.js internals.
  */
 
+import { URLPattern as URLPatternPolyfill } from "urlpattern-polyfill/urlpattern";
 import {
   MIDDLEWARE_NEXT_HEADER,
   MIDDLEWARE_REWRITE_HEADER,
@@ -932,14 +933,32 @@ export async function connection(): Promise<void> {
 
 /**
  * URLPattern re-export — used in middleware for route matching.
- * Available natively in Node 20+, Cloudflare Workers, Deno.
- * Falls back to urlpattern-polyfill if the global is not available.
+ *
+ * Available natively in Cloudflare Workers, Deno, modern browsers, and Node 24+.
+ * Node 22 (vinext's minimum supported version) does NOT expose URLPattern
+ * globally yet — it ships under `--experimental-url-pattern` only — so we fall
+ * back to `urlpattern-polyfill`'s implementation for the Node-based dev server
+ * and the production server (`vinext start`).
+ *
+ * We also install the polyfilled class onto `globalThis.URLPattern` so user
+ * middleware that references the bare `URLPattern` global (e.g. Next.js's
+ * middleware-general / middleware-trailing-slash test fixtures, which import
+ * `URLPattern` from `next/server` and then call `new URLPattern(...)`) works
+ * without each call site re-importing the shim.
+ *
+ * Next.js's own `next/server` re-export does not polyfill — it relies on the
+ * edge runtime providing URLPattern. vinext runs middleware on the host
+ * JS runtime (Node or Workers), so we have to polyfill ourselves when the
+ * host lacks it.
+ *
+ * @see https://github.com/vercel/next.js/blob/canary/packages/next/src/server/web/spec-extension/url-pattern.ts
  */
-export const URLPattern: typeof globalThis.URLPattern =
-  globalThis.URLPattern ??
-  (() => {
-    throw new Error(
-      "URLPattern is not available in this runtime. " +
-        "Install the `urlpattern-polyfill` package or upgrade to Node 20+.",
-    );
-  });
+type URLPatternConstructor = typeof globalThis.URLPattern;
+const _globalForURLPattern = globalThis as unknown as { URLPattern?: URLPatternConstructor };
+
+export const URLPattern: URLPatternConstructor =
+  _globalForURLPattern.URLPattern ?? (URLPatternPolyfill as unknown as URLPatternConstructor);
+
+if (typeof _globalForURLPattern.URLPattern === "undefined") {
+  _globalForURLPattern.URLPattern = URLPattern;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,6 +201,9 @@ catalogs:
     typescript:
       specifier: ^5.7.0
       version: 5.9.3
+    urlpattern-polyfill:
+      specifier: ^10.1.0
+      version: 10.1.0
     use-count-up:
       specifier: 3.0.1
       version: 3.0.1
@@ -902,6 +905,9 @@ importers:
       magic-string:
         specifier: 'catalog:'
         version: 0.30.21
+      urlpattern-polyfill:
+        specifier: 'catalog:'
+        version: 10.1.0
       vite:
         specifier: npm:@voidzero-dev/vite-plus-core@0.1.21
         version: '@voidzero-dev/vite-plus-core@0.1.21(@types/node@25.2.3)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.8.3)'
@@ -6337,6 +6343,9 @@ packages:
     peerDependencies:
       browserslist: '>= 4.21.0'
 
+  urlpattern-polyfill@10.1.0:
+    resolution: {integrity: sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw==}
+
   use-callback-ref@1.3.3:
     resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
     engines: {node: '>=10'}
@@ -11040,6 +11049,8 @@ snapshots:
       browserslist: 4.28.2
       escalade: 3.2.0
       picocolors: 1.1.1
+
+  urlpattern-polyfill@10.1.0: {}
 
   use-callback-ref@1.3.3(@types/react@19.2.14)(react@19.2.6):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -77,6 +77,7 @@ catalog:
   tailwind-merge: ^3.3.0
   tailwindcss: 4.1.4
   typescript: ^5.7.0
+  urlpattern-polyfill: ^10.1.0
   use-count-up: 3.0.1
   validator: ^13.15.26
   vite: npm:@voidzero-dev/vite-plus-core@0.1.21

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -1979,6 +1979,94 @@ export const config = { matcher: ["/protected"] };
     }
   });
 
+  // Reproduces the failure mode from the Next.js deploy suite, where the
+  // middleware-general / middleware-trailing-slash fixtures import URLPattern
+  // from `next/server` and call `new URLPattern(...)` at module scope. On Node
+  // 22 (which CI uses for the deploy suite), `globalThis.URLPattern` is
+  // undefined, so the shim must fall back to a constructible polyfill rather
+  // than a plain arrow function that throws "URLPattern is not a constructor".
+  //
+  // Ported from Next.js:
+  //   test/e2e/middleware-general/app/middleware.js
+  //   test/e2e/middleware-trailing-slash/app/middleware.js
+  it("middleware that constructs URLPattern at module scope builds and runs", async () => {
+    const tmpRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "vinext-mw-urlpattern-"));
+    const rootNodeModules = path.resolve(import.meta.dirname, "../node_modules");
+    const fixtureOutDir = path.join(tmpRoot, "dist");
+
+    try {
+      await fsp.symlink(rootNodeModules, path.join(tmpRoot, "node_modules"), "junction");
+      await fsp.mkdir(path.join(tmpRoot, "pages"), { recursive: true });
+
+      await fsp.writeFile(
+        path.join(tmpRoot, "pages", "index.tsx"),
+        "export default function Page() { return <div>ok</div>; }\n",
+      );
+
+      await fsp.writeFile(
+        path.join(tmpRoot, "middleware.js"),
+        `import { NextResponse, URLPattern } from "next/server";
+
+const PATTERNS = [
+  [
+    new URLPattern({ pathname: "/:locale/:id" }),
+    ({ pathname }) => ({ pathname: "/:locale/:id", params: pathname.groups }),
+  ],
+  [
+    new URLPattern({ pathname: "/:id" }),
+    ({ pathname }) => ({ pathname: "/:id", params: pathname.groups }),
+  ],
+];
+
+function params(url) {
+  for (const [pattern, handler] of PATTERNS) {
+    const match = pattern.exec(url);
+    if (match) return handler(match);
+  }
+  return { pathname: null, params: {} };
+}
+
+export function middleware(request) {
+  const result = params(request.url);
+  const response = NextResponse.next();
+  response.headers.set("x-matched-pattern", result.pathname ?? "none");
+  response.headers.set("x-matched-id", result.params.id ?? "");
+  return response;
+}
+`,
+      );
+
+      await build({
+        root: tmpRoot,
+        configFile: false,
+        plugins: [vinext()],
+        logLevel: "silent",
+        build: {
+          outDir: path.join(fixtureOutDir, "server"),
+          ssr: "virtual:vinext-server-entry",
+          rollupOptions: {
+            output: {
+              entryFileNames: "entry.js",
+            },
+          },
+        },
+      });
+
+      const entryPath = path.join(fixtureOutDir, "server", "entry.js");
+      // Importing the built entry evaluates the middleware module, which
+      // constructs URLPattern at the top level. Before the fix, this threw
+      // synchronously with "URLPattern is not a constructor" on Node 22.
+      const entryModule = await import(pathToFileURL(entryPath).href);
+      const result = await entryModule.runMiddleware(new Request("http://localhost/en/42"));
+
+      expect(result.continue).toBe(true);
+      expect(result.responseHeaders?.get("x-matched-pattern")).toBe("/:locale/:id");
+      expect(result.responseHeaders?.get("x-matched-id")).toBe("42");
+    } finally {
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
   it("produces client bundle with page chunks and SSR manifest", async () => {
     // Build the client bundle
     await build({

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -2711,19 +2711,18 @@ describe("next/server shim", () => {
     await expect(result).resolves.toBeUndefined();
   });
 
-  it("URLPattern is exported and available in Node 20+", async () => {
+  it("URLPattern is exported as a constructible class", async () => {
     const { URLPattern } = await import("../packages/vinext/src/shims/server.js");
-    // Node 22+ has URLPattern globally; if available, test it works
-    if (globalThis.URLPattern) {
-      expect(URLPattern).toBe(globalThis.URLPattern);
-      const pattern = new URLPattern({ pathname: "/blog/:slug" });
-      const match = pattern.exec({ pathname: "/blog/hello-world" });
-      expect(match).toBeTruthy();
-      expect(match!.pathname.groups.slug).toBe("hello-world");
-    } else {
-      // URLPattern not available — our export should be a fallback that throws
-      expect(typeof URLPattern).toBe("function");
-    }
+    expect(typeof URLPattern).toBe("function");
+
+    // Must be constructible — Next.js middleware fixtures (e.g. middleware-general,
+    // middleware-trailing-slash) call `new URLPattern(...)` directly at module
+    // scope, so a plain arrow-function fallback would throw
+    // "URLPattern is not a constructor" on Node 22 where the global is absent.
+    const pattern = new URLPattern({ pathname: "/blog/:slug" });
+    const match = pattern.exec({ pathname: "/blog/hello-world" });
+    expect(match).toBeTruthy();
+    expect(match!.pathname.groups.slug).toBe("hello-world");
   });
 });
 


### PR DESCRIPTION
## Summary

Next.js middleware fixtures that import `URLPattern` from `next/server` and call `new URLPattern(...)` at module scope fail to start under the Next.js deploy suite on Node 22 with:

```
TypeError: URLPattern is not a constructor
   at <tmp>/.next/server/middleware.js
```

Node 22 (vinext's minimum supported version) does not expose `URLPattern` globally — the global only appeared as `--experimental-url-pattern` in Node 24+. The previous shim in `packages/vinext/src/shims/server.ts` fell through to a plain arrow function, which is not constructible.

## Fix

- Add `urlpattern-polyfill` (^10.1.0) as a runtime dependency of `vinext`.
- The `next/server` shim now resolves `URLPattern` to the polyfilled class when the host runtime lacks the global, and installs it on `globalThis.URLPattern` so user code referencing the bare global keeps working.
- Cloudflare Workers and Node 24+ continue to use the platform implementation (the polyfill is only used as a fallback).

Next.js's own re-export does **not** polyfill — its middleware runs inside the edge runtime that already provides `URLPattern`:

https://github.com/vercel/next.js/blob/canary/packages/next/src/server/web/spec-extension/url-pattern.ts

vinext runs middleware on the host JS runtime (Node or Workers), so it has to polyfill itself when the host lacks it.

## Affected upstream tests

- [`test/e2e/middleware-general/app/middleware.js`](https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-general/app/middleware.js) — imports `URLPattern` from `next/server` and constructs it at module top-level.
- [`test/e2e/middleware-trailing-slash/app/middleware.js`](https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-trailing-slash/app/middleware.js) — same pattern.

## Reference

- Failing CI run: https://github.com/cloudflare/vinext/actions/runs/25951111875

## Test plan

- [x] Added `tests/pages-router.test.ts > middleware that constructs URLPattern at module scope builds and runs` which writes a middleware identical in shape to the Next.js fixtures, runs `vinext build`, imports the bundled entry, and asserts the middleware executes.
- [x] Updated `tests/shims.test.ts` URLPattern test to assert the shim is always constructible (regression on Node 22 would have been silent because the global is available on Node 24 where the CI test machine runs).
- [x] `pnpm test tests/shims.test.ts tests/pages-router.test.ts` — 1111 passed.
- [x] `pnpm test tests/deploy.test.ts tests/prod-server-logs.test.ts tests/app-post-middleware-context.test.ts` — 228 passed.
- [x] `pnpm run check` — format/lint/types clean.
- [ ] Re-run the Next.js Deploy Suite against the middleware-general / middleware-trailing-slash suites once this branch is available.