### PR TITLE
ci(nextjs-deploy): add test-path filter input

### DIFF
--- a/.github/workflows/nextjs-deploy-suite.yml
+++ b/.github/workflows/nextjs-deploy-suite.yml
@@ -25,6 +25,11 @@ on:
           - app
           - pages
           - all
+      test-path:
+        description: Optional path filter — comma-separated, e.g. `test/e2e/edge-async-local-storage`. Empty = all.
+        required: false
+        default: ""
+        type: string
       test-concurrency:
         description: Per-shard Next.js test concurrency
         required: false
@@ -35,7 +40,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: nextjs-deploy-suite-${{ inputs.vinext-ref || github.ref }}-${{ inputs.next-ref || 'v16.2.6' }}-${{ inputs.suite-filter || 'all' }}
+  group: nextjs-deploy-suite-${{ inputs.vinext-ref || github.ref }}-${{ inputs.next-ref || 'v16.2.6' }}-${{ inputs.suite-filter || 'all' }}-${{ inputs.test-path || 'all' }}
   cancel-in-progress: false
 
 jobs:
@@ -75,11 +80,18 @@ jobs:
           NEXTJS_PREPARE_ONLY: "1"
 
       - name: Generate deploy manifest
-        run: >-
-          node scripts/nextjs-deploy-manifest.mjs
-          "$GITHUB_WORKSPACE/next.js"
-          "$GITHUB_WORKSPACE/nextjs-deploy-manifest.json"
-          --filter ${{ inputs.suite-filter || 'all' }}
+        env:
+          TEST_PATH: ${{ inputs.test-path }}
+        run: |
+          args=(
+            "$GITHUB_WORKSPACE/next.js"
+            "$GITHUB_WORKSPACE/nextjs-deploy-manifest.json"
+            --filter "${{ inputs.suite-filter || 'all' }}"
+          )
+          if [ -n "${TEST_PATH:-}" ]; then
+            args+=(--match "${TEST_PATH}")
+          fi
+          node scripts/nextjs-deploy-manifest.mjs "${args[@]}"
 
       - name: Save build artifacts
         uses: actions/cache/save@v5
@@ -409,9 +421,10 @@ jobs:
       # No-op if the secret or ingest URL aren't configured.
       #
       # Guardrails:
-      #   - Only the full suite (suite-filter=all). Filtered runs (just `app`
-      #     or just `pages`) would publish a misleading partial snapshot that
-      #     drags the historical pass-rate trend off-course.
+      #   - Only the full suite (suite-filter=all, no test-path). Filtered
+      #     runs (`app`/`pages` only, or a path-narrowed run) would publish a
+      #     misleading partial snapshot that drags the historical pass-rate
+      #     trend off-course.
       #   - Only when running against main. Scheduled runs always test main
       #     (github.ref == refs/heads/main). For manual workflow_dispatch we
       #     check that `inputs.vinext-ref` resolves to main (its default).
@@ -421,6 +434,7 @@ jobs:
         if: |
           always()
           && (inputs.suite-filter == 'all' || inputs.suite-filter == '' || github.event_name == 'schedule')
+          && (inputs.test-path == '' || github.event_name == 'schedule')
           && (
             (github.event_name == 'schedule' && github.ref == 'refs/heads/main')
             || (github.event_name == 'workflow_dispatch' && (inputs.vinext-ref == 'main' || inputs.vinext-ref == ''))

--- a/scripts/nextjs-deploy-manifest.mjs
+++ b/scripts/nextjs-deploy-manifest.mjs
@@ -4,12 +4,19 @@
  * Generates a filtered deploy-tests manifest from the Next.js repo.
  *
  * Usage:
- *   node scripts/nextjs-deploy-manifest.mjs <nextjs-dir> <output-json-path> [--filter pages|app|all]
+ *   node scripts/nextjs-deploy-manifest.mjs <nextjs-dir> <output-json-path> \
+ *     [--filter pages|app|all] [--match <path>]...
  *
  * Filters:
  *   pages  — exclude test/e2e/app-dir/** (Pages Router only)
  *   app    — include only test/e2e/app-dir/** (App Router only)
  *   all    — pass through the full manifest unfiltered (default)
+ *
+ * --match narrows further to specific suites by path prefix. Repeatable, or
+ * comma-separated. A directory prefix like `test/e2e/edge-async-local-storage`
+ * keeps every suite under it; a full test file path keeps just that file.
+ * Applied AFTER --filter, so `--filter app --match test/e2e/app-dir/foo`
+ * works as expected.
  */
 
 import fs from "node:fs/promises";
@@ -17,8 +24,27 @@ import path from "node:path";
 
 function printUsage() {
   console.error(
-    "Usage: node scripts/nextjs-deploy-manifest.mjs <nextjs-dir> <output-json-path> [--filter pages|app|all]",
+    "Usage: node scripts/nextjs-deploy-manifest.mjs <nextjs-dir> <output-json-path> [--filter pages|app|all] [--match <path>]...",
   );
+}
+
+const TEST_FILE_RE = /\.test\.(t|j)sx?$/;
+
+function matchToInclude(match) {
+  // Already a test file path: include verbatim.
+  if (TEST_FILE_RE.test(match)) return match;
+  // Directory prefix: glob every test file underneath.
+  const trimmed = match.replace(/\/+$/, "");
+  return `${trimmed}/**/*.test.{t,j}s{,x}`;
+}
+
+function suiteMatchesAny(suite, matches) {
+  for (const m of matches) {
+    const trimmed = m.replace(/\/+$/, "");
+    if (suite === trimmed) return true;
+    if (suite.startsWith(`${trimmed}/`)) return true;
+  }
+  return false;
 }
 
 function isAppDirSuite(suite) {
@@ -35,12 +61,18 @@ const APP_ROUTER_NON_APP_DIR_SUITES = ["test/e2e/next-form/default/next-form-pre
 async function main() {
   const positionals = [];
   let filter = "all";
+  const matches = [];
 
-  // Simple arg parsing: positionals + optional --filter
+  // Simple arg parsing: positionals + optional --filter / --match
   for (let i = 2; i < process.argv.length; i++) {
     const arg = process.argv[i];
     if (arg === "--filter" && i + 1 < process.argv.length) {
       filter = process.argv[++i];
+    } else if (arg === "--match" && i + 1 < process.argv.length) {
+      for (const part of process.argv[++i].split(",")) {
+        const trimmed = part.trim();
+        if (trimmed) matches.push(trimmed);
+      }
     } else if (!arg.startsWith("-")) {
       positionals.push(arg);
     }
@@ -79,15 +111,26 @@ async function main() {
     suites = Object.fromEntries(Object.entries(suites).filter(([suite]) => isAppDirSuite(suite)));
   }
 
+  let include = source.rules?.include?.length
+    ? source.rules.include
+    : ["test/e2e/**/*.test.{t,j}s{,x}"];
+
+  if (matches.length > 0) {
+    suites = Object.fromEntries(
+      Object.entries(suites).filter(([suite]) => suiteMatchesAny(suite, matches)),
+    );
+    // Narrow include to just the matched paths so the runner doesn't scan
+    // the rest of test/e2e/. Excludes from --filter still apply.
+    include = matches.map(matchToInclude);
+  }
+
   const exclude = Array.from(new Set([...(source.rules?.exclude ?? []), ...extraExcludes]));
 
   const manifest = {
     version: 2,
     suites,
     rules: {
-      include: source.rules?.include?.length
-        ? source.rules.include
-        : ["test/e2e/**/*.test.{t,j}s{,x}"],
+      include,
       exclude,
     },
   };
@@ -105,6 +148,7 @@ async function main() {
       {
         source: sourcePath,
         filter,
+        matches,
         totalSuites,
         outputSuites,
         appDirSuites,


### PR DESCRIPTION
## Summary
- New optional \`test-path\` \`workflow_dispatch\` input on the Next.js Deploy Suite — comma-separated path prefixes (e.g. \`test/e2e/edge-async-local-storage\`) or full test-file paths. Lets a manual run target one suite instead of the full ~16-shard sweep.
- \`scripts/nextjs-deploy-manifest.mjs\` gains a repeatable/comma-separated \`--match <path>\` flag. Narrows both the manifest \`suites\` map and \`rules.include\` so the Next.js runner doesn't walk the rest of \`test/e2e/\`. Composes with the existing \`--filter app|pages|all\`.
- Compat-ingest step is gated off when \`test-path\` is set, since a path-narrowed run would otherwise publish a misleading partial snapshot to \`/compatibility\`. The concurrency group also includes \`test-path\` so filtered + unfiltered runs don't cancel each other.

## Test plan
- [ ] Run the workflow via \`workflow_dispatch\` with \`test-path = test/e2e/edge-async-local-storage\` and confirm only that suite executes across the 16 shards (most shards no-op).
- [ ] Run with \`test-path\` empty and confirm behavior is unchanged from before this PR (full suite, ingest still fires on \`main\`).
- [ ] Combine \`suite-filter = app\` with \`test-path = test/e2e/app-dir/<something>\` and confirm the intersection runs.
- [ ] Verify the compat-ingest step is skipped on the path-filtered run.