### PR TITLE
refactor(edge-globals): consolidate into installEdgeGlobals() helper

### DIFF
--- a/packages/vinext/src/server/app-router-entry.ts
+++ b/packages/vinext/src/server/app-router-entry.ts
@@ -12,10 +12,7 @@
  *   cloudflare({ viteEnvironment: { name: "rsc", childEnvironments: ["ssr"] } })
  */
 
-// Install edge-runtime globals (e.g. AsyncLocalStorage) so user route handlers
-// and middleware can reference them without an explicit import, matching
-// Next.js behavior.
-import "./edge-globals.js";
+import { installEdgeGlobals } from "./edge-globals.js";
 // @ts-expect-error — virtual module resolved by vinext
 import rscHandler from "virtual:vinext-rsc-entry";
 import { runWithExecutionContext, type ExecutionContextLike } from "vinext/shims/request-context";
@@ -26,6 +23,10 @@ import {
   isOpenRedirectShaped,
 } from "./request-pipeline.js";
 import { badRequestResponse, notFoundResponse } from "./http-error-responses.js";
+
+// Expose edge-runtime globals (e.g. AsyncLocalStorage) so user route handlers
+// and middleware can reference them without an import, matching Next.js.
+installEdgeGlobals();
 
 type WorkerAssetEnv = {
   ASSETS?: {

--- a/packages/vinext/src/server/edge-globals.ts
+++ b/packages/vinext/src/server/edge-globals.ts
@@ -1,30 +1,29 @@
 /**
- * Globals exposed by the Next.js edge runtime that user code is allowed to
- * reference without an explicit `import`.
+ * Installs globals that Next.js's edge runtime exposes to user code, so the
+ * same code runs on vinext without explicit `import`s.
  *
  * Next.js's edge sandbox stitches a number of Node and Web APIs onto the
  * runtime's global context. vinext executes user code directly on the
- * Cloudflare Workers runtime (no separate sandbox), and Workers does not
- * expose `AsyncLocalStorage` as a global — it is only available via
- * `import { AsyncLocalStorage } from "node:async_hooks"` under the
- * `nodejs_compat` flag.
+ * Cloudflare Workers runtime (no separate sandbox), so any global that the
+ * Workers runtime does not already provide must be installed here.
  *
- * User code written for Next.js's edge runtime can do
+ * Currently installed:
  *
- *     const storage = new AsyncLocalStorage()
+ *   - `AsyncLocalStorage` — Workers exposes it only via
+ *     `import { AsyncLocalStorage } from "node:async_hooks"` under the
+ *     `nodejs_compat` flag, but Next.js's edge sandbox installs it as a
+ *     global (`packages/next/src/server/web/sandbox/context.ts`:
+ *     `context.AsyncLocalStorage = AsyncLocalStorage`). User code written
+ *     for the edge runtime does `new AsyncLocalStorage()` with no import.
  *
- * without importing it. To preserve that surface on vinext we install
- * `AsyncLocalStorage` on `globalThis` (idempotently) from any runtime entry
- * point that might evaluate user edge code: middleware, App Router route
- * handlers, and Pages API routes.
+ * Intentionally NOT installed:
  *
- * Reference (Next.js edge sandbox):
- *   packages/next/src/server/web/sandbox/context.ts
- *     context.AsyncLocalStorage = AsyncLocalStorage
+ *   - `URLPattern` — Cloudflare Workers expose it natively, and our CI
+ *     pins Node 24+ which also exposes it as a global. No polyfill needed.
  *
- * TODO(edge-globals): A `URLPattern` change is being worked on in parallel.
- * Once both land, consider consolidating these into a single
- * `installEdgeGlobals()` helper called from a shared bootstrap.
+ * This helper is idempotent and safe to call from every runtime entry point
+ * that might evaluate user edge code (middleware, App Router route handlers,
+ * Pages API routes).
  */
 import { AsyncLocalStorage } from "node:async_hooks";
 
@@ -32,8 +31,9 @@ type GlobalWithEdgeAdditions = typeof globalThis & {
   AsyncLocalStorage?: typeof AsyncLocalStorage;
 };
 
-const _g = globalThis as GlobalWithEdgeAdditions;
-
-if (typeof _g.AsyncLocalStorage === "undefined") {
-  _g.AsyncLocalStorage = AsyncLocalStorage;
+export function installEdgeGlobals(): void {
+  const g = globalThis as GlobalWithEdgeAdditions;
+  if (typeof g.AsyncLocalStorage === "undefined") {
+    g.AsyncLocalStorage = AsyncLocalStorage;
+  }
 }

--- a/packages/vinext/src/server/middleware-runtime.ts
+++ b/packages/vinext/src/server/middleware-runtime.ts
@@ -1,6 +1,4 @@
-// Install edge-runtime globals (e.g. AsyncLocalStorage) so user middleware
-// can reference them without an explicit import, matching Next.js behavior.
-import "./edge-globals.js";
+import { installEdgeGlobals } from "./edge-globals.js";
 import type { NextI18nConfig } from "../config/next-config.js";
 import { normalizePathnameForRouteMatchStrict } from "../routing/utils.js";
 import {
@@ -19,6 +17,10 @@ import { MatcherConfig, matchesMiddleware } from "./middleware-matcher.js";
 import { shouldKeepMiddlewareHeader } from "./middleware-request-headers.js";
 import { processMiddlewareHeaders } from "./request-pipeline.js";
 import { badRequestResponse, internalServerErrorResponse } from "./http-error-responses.js";
+
+// Expose edge-runtime globals (e.g. AsyncLocalStorage) so user middleware can
+// reference them without an import, matching Next.js.
+installEdgeGlobals();
 
 export type MiddlewareModule = Record<string, unknown>;
 

--- a/packages/vinext/src/server/pages-api-route.ts
+++ b/packages/vinext/src/server/pages-api-route.ts
@@ -1,7 +1,4 @@
-// Install edge-runtime globals (e.g. AsyncLocalStorage) so user API handlers
-// configured with `runtime: 'edge'` can reference them without an explicit
-// import, matching Next.js behavior.
-import "./edge-globals.js";
+import { installEdgeGlobals } from "./edge-globals.js";
 import type { Route } from "../routing/pages-router.js";
 import { mergeRouteParamsIntoQuery, parseQueryString } from "../utils/query.js";
 import {
@@ -13,6 +10,11 @@ import {
   PagesApiBodyParseError,
 } from "./pages-node-compat.js";
 import { internalServerErrorResponse } from "./http-error-responses.js";
+
+// Expose edge-runtime globals (e.g. AsyncLocalStorage) so API handlers
+// configured with `runtime: 'edge'` can reference them without an import,
+// matching Next.js behavior.
+installEdgeGlobals();
 
 type PagesApiRouteModule = {
   default?: (req: PagesReqResRequest, res: PagesReqResResponse) => void | Promise<void>;


### PR DESCRIPTION
## Summary

Follow-up to [#1276](https://github.com/cloudflare/vinext/pull/1276): addresses the `TODO(edge-globals)` left in `packages/vinext/src/server/edge-globals.ts`.

- Replaces the bare side-effect install with an exported `installEdgeGlobals()` function.
- Each runtime entry that may evaluate user edge code now calls it explicitly:
  - `server/app-router-entry.ts` (App Router worker entry — handles RSC + middleware + route handlers)
  - `server/middleware-runtime.ts` (Pages + App middleware)
  - `server/pages-api-route.ts` (Pages API routes including `runtime: 'edge'`)
- Documents that `URLPattern` is **intentionally not installed**: Workers exposes it natively, and CI pins Node 24+ ([#1283](https://github.com/cloudflare/vinext/pull/1283)) which also has the global. The TODO marker is dropped.

The helper remains idempotent (`if (typeof g.AsyncLocalStorage === "undefined")`), so calling it from multiple entry points is safe.

## Test plan

- [x] `pnpm test tests/edge-globals.test.ts tests/pages-api-route.test.ts tests/app-route-handler-runtime.test.ts tests/app-post-middleware-context.test.ts` → 34/34 pass
- [x] `pnpm run check` clean
- [x] Existing edge-globals integration test still verifies the global is exposed after importing `pages-api-route` — confirms the explicit call still wires through