### PR TITLE
fix(script): honor async false for client scripts

### DIFF
--- a/packages/vinext/src/shims/script.tsx
+++ b/packages/vinext/src/shims/script.tsx
@@ -99,11 +99,41 @@ function buildBeforeInteractiveScriptProps(options: {
   return scriptProps;
 }
 
+function setBooleanScriptAttribute(el: HTMLScriptElement, attr: string, value: unknown): boolean {
+  const enabled = value !== false && value !== "false" && Boolean(value);
+
+  switch (attr) {
+    case "async":
+      el.async = enabled;
+      break;
+    case "defer":
+      el.defer = enabled;
+      break;
+    case "noModule":
+    case "nomodule":
+      el.noModule = enabled;
+      break;
+    default:
+      return false;
+  }
+
+  if (!enabled) {
+    // Dynamic script elements start in the browser's force-async state.
+    // Setting and removing the attribute mirrors Next.js and clears that state.
+    el.setAttribute(attr, "");
+    el.removeAttribute(attr);
+  }
+
+  return true;
+}
+
 function setScriptAttributes(el: HTMLScriptElement, rest: Record<string, unknown>): void {
   for (const [attr, value] of Object.entries(rest)) {
     if (attr === "dangerouslySetInnerHTML") continue;
-    if (attr === "className") {
-      el.setAttribute("class", String(value));
+    if (value === undefined) continue;
+    if (setBooleanScriptAttribute(el, attr, value)) continue;
+    if (attr === "className" && typeof value === "string") {
+      el.setAttribute("class", value);
     } else if (typeof value === "string") {
       el.setAttribute(attr, value);
     } else if (typeof value === "boolean" && value) {

--- a/tests/script.test.ts
+++ b/tests/script.test.ts
@@ -198,4 +198,58 @@ describe("Script SSR rendering", () => {
     expect(appendedScripts).toHaveLength(1);
     expect(appendedScripts[0]!.attrs.nonce).toBe("property-nonce");
   });
+
+  it("clears forced async execution when async is explicitly false", () => {
+    type MockScript = {
+      async: boolean;
+      attrs: Record<string, string>;
+      src: string;
+      setAttribute(name: string, value: string): void;
+      removeAttribute(name: string): void;
+      getAttribute(name: string): string | null;
+      addEventListener(): void;
+    };
+
+    const appendedScripts: MockScript[] = [];
+    class MockHTMLElement {}
+
+    const createdScript: MockScript = {
+      async: true,
+      attrs: {},
+      src: "",
+      setAttribute(name: string, value: string) {
+        this.attrs[name] = value;
+      },
+      removeAttribute(name: string) {
+        Reflect.deleteProperty(this.attrs, name);
+      },
+      getAttribute(name: string): string | null {
+        return this.attrs[name] ?? null;
+      },
+      addEventListener() {},
+    };
+
+    setGlobalValue("HTMLElement", MockHTMLElement);
+    setGlobalValue("window", {});
+    setGlobalValue("document", {
+      querySelector() {
+        return null;
+      },
+      createElement(tagName: string) {
+        expect(tagName).toBe("script");
+        return createdScript;
+      },
+      body: {
+        appendChild(element: unknown) {
+          appendedScripts.push(element as typeof createdScript);
+        },
+      },
+    });
+
+    handleClientScriptLoad({ src: "/ordered-script.js", async: false });
+
+    expect(appendedScripts).toHaveLength(1);
+    expect(appendedScripts[0]!.async).toBe(false);
+    expect(appendedScripts[0]!.attrs).not.toHaveProperty("async");
+  });
 });


### PR DESCRIPTION
## Overview

| Field | Detail |
| --- | --- |
| Goal | Preserve ordered execution for client-inserted `next/script` elements when callers pass `async={false}`. |
| Core change | Set script boolean attributes through DOM properties before appending the script. |
| Boundary | `handleClientScriptLoad` and the client-side `<Script>` insertion path. |
| Primary files | `packages/vinext/src/shims/script.tsx`, `tests/script.test.ts` |
| Expected impact | Dependent third-party scripts can opt out of the browser's forced async behavior. |

## Why

Dynamically-created script elements start in the browser's force-async state. A `next/script` shim must treat `async={false}` as an execution-order instruction, not as a false boolean prop to skip.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| Client script insertion | Explicit `async={false}` must clear force async before append. | `async`, `defer`, and `noModule` are assigned through `HTMLScriptElement` properties. |
| Next.js compatibility | Match the public `next/script` behavior where it is browser-observable. | Mirrors Next.js's boolean script attribute handling, including set/remove for disabled attributes. |
| Attribute boundary | Unknown passthrough props should stay contained at the DOM insertion edge. | Keeps boolean script attribute handling in one helper and leaves other attributes on the existing path. |

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| `handleClientScriptLoad({ src, async: false })` | The false prop was skipped and `el.async` stayed true. | The DOM property is set to false and the `async` attribute is absent. |
| Disabled script boolean attributes | False values were ignored by the attribute loop. | Disabled values explicitly clear the reflected attribute state. |

<details>
<summary>Maintainer review path</summary>

1. `packages/vinext/src/shims/script.tsx`: review `setBooleanScriptAttribute` and its call from `setScriptAttributes`.
2. `tests/script.test.ts`: review the focused client insertion regression that starts from a forced-async script element.

</details>

<details>
<summary>Validation</summary>

- Reproduced on `main` with a mocked DOM script element: `handleClientScriptLoad({ async: false })` left `async` as `true`.
- Confirmed the new regression failed before the implementation and passed after it.
- `vp test run tests/script.test.ts`
- `vp check packages/vinext/src/shims/script.tsx tests/script.test.ts`
- `vp run vinext#build` completed successfully. The build still reports the existing unresolved virtual or external import warnings for generated entry points.

</details>

<details>
<summary>Risk / compatibility</summary>

- Public API: no new API surface.
- Runtime: changes only client-side dynamic script insertion for script boolean attributes.
- Compatibility: intentionally follows Next.js's force-async handling for script boolean attributes.
- Existing app risk: low. `async={true}` remains enabled, omitted `async` remains untouched, and `async={false}` now does what callers requested.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| [Next.js `setAttributesFromProps`](https://github.com/vercel/next.js/blob/ec0279c7a9416cd2b8182167d4e526d2688ae21a/packages/next/src/client/set-attributes-from-props.ts#L21-L58) | Next.js handles `async`, `defer`, and `noModule` through script DOM properties and clears disabled attributes to override force async. |
| [Next.js PR 20748](https://github.com/vercel/next.js/pull/20748) | Original compatibility fix for boolean script attributes and force async behavior. |
| [HTML spec: script force async](https://html.spec.whatwg.org/multipage/scripting.html#script-force-async) | Defines the browser behavior that makes `async={false}` require explicit DOM state changes. |
