### PR TITLE
fix(image): preserve inline styles on remote images

### DIFF
--- a/packages/vinext/src/shims/image.tsx
+++ b/packages/vinext/src/shims/image.tsx
@@ -18,6 +18,16 @@ import { Image as UnpicImage } from "@unpic/react";
 import { hasRemoteMatch, isPrivateIp, type RemotePattern } from "./image-config.js";
 import { useMergedRef } from "./use-merged-ref.js";
 
+type StyleableUnpicImageProps = React.ComponentPropsWithoutRef<typeof UnpicImage> & {
+  style?: React.CSSProperties;
+};
+
+// @unpic/react's runtime forwards incoming `style` through transformProps and
+// merges it with generated layout styles, but its public React type omits it.
+const StyleableUnpicImage = UnpicImage as React.ForwardRefExoticComponent<
+  StyleableUnpicImageProps & React.RefAttributes<HTMLImageElement>
+>;
+
 export type StaticImageData = {
   src: string;
   height: number;
@@ -562,7 +572,7 @@ const Image = forwardRef<HTMLImageElement, ImageProps>(function Image(
         fetchPriority: priorityFetchPriority,
       });
       return (
-        <UnpicImage
+        <StyleableUnpicImage
           src={src}
           alt={alt}
           width={imgWidth}
@@ -573,6 +583,7 @@ const Image = forwardRef<HTMLImageElement, ImageProps>(function Image(
           fetchPriority={priorityFetchPriority}
           sizes={sizes}
           className={className}
+          style={style}
           background={bg}
           onLoad={handleLoad}
           onError={handleError}

--- a/packages/vinext/src/shims/image.tsx
+++ b/packages/vinext/src/shims/image.tsx
@@ -18,16 +18,6 @@ import { Image as UnpicImage } from "@unpic/react";
 import { hasRemoteMatch, isPrivateIp, type RemotePattern } from "./image-config.js";
 import { useMergedRef } from "./use-merged-ref.js";
 
-type StyleableUnpicImageProps = React.ComponentPropsWithoutRef<typeof UnpicImage> & {
-  style?: React.CSSProperties;
-};
-
-// @unpic/react's runtime forwards incoming `style` through transformProps and
-// merges it with generated layout styles, but its public React type omits it.
-const StyleableUnpicImage = UnpicImage as React.ForwardRefExoticComponent<
-  StyleableUnpicImageProps & React.RefAttributes<HTMLImageElement>
->;
-
 export type StaticImageData = {
   src: string;
   height: number;
@@ -565,6 +555,10 @@ const Image = forwardRef<HTMLImageElement, ImageProps>(function Image(
     }
     // constrained layout requires width+height or aspectRatio
     if (imgWidth && imgHeight) {
+      // @unpic/react forwards additional image props through transformProps and
+      // merges `style` with generated layout styles at runtime, but its public
+      // React type omits `style`.
+      const unpicRuntimeStyleProps: { style?: React.CSSProperties } = { style };
       preloadImageResource({
         shouldPreload,
         src,
@@ -572,7 +566,7 @@ const Image = forwardRef<HTMLImageElement, ImageProps>(function Image(
         fetchPriority: priorityFetchPriority,
       });
       return (
-        <StyleableUnpicImage
+        <UnpicImage
           src={src}
           alt={alt}
           width={imgWidth}
@@ -583,7 +577,7 @@ const Image = forwardRef<HTMLImageElement, ImageProps>(function Image(
           fetchPriority={priorityFetchPriority}
           sizes={sizes}
           className={className}
-          style={style}
+          {...unpicRuntimeStyleProps}
           background={bg}
           onLoad={handleLoad}
           onError={handleError}

--- a/tests/image-component.test.ts
+++ b/tests/image-component.test.ts
@@ -205,6 +205,30 @@ describe("Image SSR rendering", () => {
     expect(html).toContain('class="hero-img"');
     expect(html).toContain("border-radius:8px");
   });
+
+  it("preserves custom style for remote images with width and height", () => {
+    // Next.js computes a single imgAttributes.style object in getImgProps and
+    // passes it through to the rendered <img>.
+    // https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/get-img-props.ts
+    // https://github.com/vercel/next.js/blob/canary/packages/next/src/client/image-component.tsx
+    const html = ReactDOMServer.renderToString(
+      React.createElement(Image, {
+        alt: "remote styled",
+        src: "https://images.unsplash.com/photo-style",
+        width: 400,
+        height: 300,
+        style: {
+          borderRadius: "12px",
+          objectPosition: "left center",
+          transform: "scale(0.9)",
+        },
+      }),
+    );
+
+    expect(html).toContain("border-radius:12px");
+    expect(html).toContain("object-position:left center");
+    expect(html).toContain("transform:scale(0.9)");
+  });
 });
 
 // ─── srcSet generation ──────────────────────────────────────────────────


### PR DESCRIPTION
## Overview

| Field | Details |
| --- | --- |
| Goal | Preserve user-provided `style` props on remote `next/image` renders with explicit `width` and `height`. |
| Core change | Pass the image shim's `style` prop through the remote constrained `UnpicImage` branch. |
| Main boundary | Keep vinext's remote CDN transform path composable without changing local image, fill image, preload, or validation behavior. |
| Primary files | `packages/vinext/src/shims/image.tsx`, `tests/image-component.test.ts` |
| Expected impact | Remote images can now use inline styling such as `borderRadius`, `objectPosition`, and `transform`. |

## Why

`next/image` should preserve ordinary image props consistently across render paths. vinext already preserves `style` for local images, custom-loader images, and remote fill images. The remote constrained branch was the outlier because it delegated to `@unpic/react` without passing the destructured `style` prop.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| Remote constrained image rendering | A user `style` prop remains part of the rendered image contract. | Passes `style` into the existing `@unpic/react` runtime boundary. |
| Type boundary | Keep the dependency graph unchanged and avoid production assertions. | Uses a small typed spread object because `@unpic/react` forwards `style` at runtime but its public component type omits the direct JSX prop. |
| Compatibility | Follow Next.js's final-image style pass-through model. | Adds an SSR regression test against the rendered output. |

## What Changed

| Scenario | Before | After |
| --- | --- | --- |
| Remote image with `width` and `height` plus `style` | Rendered through `UnpicImage` and dropped user inline styles. | Renders through `UnpicImage` with user inline styles preserved. |
| Local, custom loader, and fill images | Already preserved styles. | Unchanged. |
| Dependencies | Existing `@unpic/react` dependency. | Unchanged. |

<details>
<summary>Maintainer review path</summary>

1. `tests/image-component.test.ts` adds the behavior regression first. It renders a remote image with explicit dimensions and asserts the final SSR markup includes `border-radius`, `object-position`, and `transform`.
2. `packages/vinext/src/shims/image.tsx` contains the one behavior change in the remote constrained branch. The typed spread object documents the `@unpic/react` type/runtime mismatch without adding dependencies or introducing a production assertion.

</details>

<details>
<summary>Validation</summary>

- Verified on `main` before fixing with a minimal SSR render check: local image styles were present while remote constrained image styles were missing.
- Added the focused regression test and observed it fail before the implementation.
- `vp test run tests/image-component.test.ts -t "preserves custom style for remote images with width and height"`
- `vp test run tests/image-component.test.ts`
- `vp check packages/vinext/src/shims/image.tsx tests/image-component.test.ts`
- Commit hook also ran formatting, lint/type checks for checked files, and `knip`.

</details>

<details>
<summary>Risk / Compatibility</summary>

- Public API: no new props. This restores support for an existing `next/image` prop on one render branch.
- Runtime: limited to remote URL images with explicit `width` and `height` that use the constrained Unpic path.
- Dependencies: no new direct dependencies and no package/catalog changes.
- Build output: no route, cache, RSC, Workers, or optimizer behavior changes.
- Compatibility: user styles can override generated Unpic layout styles, matching normal React `style` precedence and Next.js's style merge model.

</details>

<details>
<summary>Non-goals</summary>

- Does not change image optimization URL generation.
- Does not change remote image validation.
- Does not change fill-image layout behavior.
- Does not expand `getImageProps` behavior, which already returns style for remote images.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| [Next.js `getImgProps` builds `imgStyle` from fill defaults, transparent color, and user `style`](https://github.com/vercel/next.js/blob/ec0279c7a9416cd2b8182167d4e526d2688ae21a/packages/next/src/shared/lib/get-img-props.ts#L683-L699) | Shows user style participates in the final image style object. |
| [Next.js returns `style: { ...imgStyle, ...placeholderStyle }`](https://github.com/vercel/next.js/blob/ec0279c7a9416cd2b8182167d4e526d2688ae21a/packages/next/src/shared/lib/get-img-props.ts#L769-L780) | Shows the style object is part of the image props contract. |
| [Next.js `ImageElement` passes `style` to the DOM `<img>`](https://github.com/vercel/next.js/blob/ec0279c7a9416cd2b8182167d4e526d2688ae21a/packages/next/src/client/image-component.tsx#L277-L299) | Confirms the final component preserves the computed style on render. |
| [Next.js unit coverage for style in `getImageProps`](https://github.com/vercel/next.js/blob/ec0279c7a9416cd2b8182167d4e526d2688ae21a/test/unit/next-image-get-img-props.test.ts#L462-L485) | Existing upstream test coverage for preserving user style in image props. |