### PR TITLE
feat(cache): add static layout proof and variant budget guardrails

### DIFF
--- a/packages/vinext/src/server/cache-proof.ts
+++ b/packages/vinext/src/server/cache-proof.ts
@@ -14,6 +14,7 @@ export type CacheProofRejectionCode =
   | "CP_DIMENSION_VALUES_MISSING"
   | "CP_ENCODED_VARIANT_TOO_LONG"
   | "CP_INVALID_VARIANT_BUDGET"
+  | "CP_ROUTE_VARIANT_BUDGET_ROUTE_MISMATCH"
   | "CP_ROUTE_VARIANT_CEILING_EXCEEDED"
   | "CP_UNSAFE_PUBLIC_DIMENSION"
   | "CP_BOUNDARY_OUTCOME_MISMATCH"
@@ -157,13 +158,37 @@ export type CacheVariant = Readonly<{
 export type BuildCacheVariantInput = Readonly<{
   budget: CacheVariantBudget;
   dimensions: readonly CacheVariantDimensionInput[];
-  existingVariantCount: number;
   output: CacheProofOutputScope;
 }>;
 
 export type BuildCacheVariantResult =
   | Readonly<{ kind: "variant"; variant: CacheVariant }>
   | Readonly<{ kind: "breakerFallback"; fallback: CacheProofBreakerFallback }>;
+
+export type CacheVariantRouteBudget = Readonly<{
+  routeId: string;
+  variantCacheKeys: readonly string[];
+}>;
+
+export type CacheVariantRouteBudgetAdmission =
+  | Readonly<{
+      didConsumeRouteVariantBudget: boolean;
+      kind: "variant";
+      routeBudget: CacheVariantRouteBudget;
+      variant: CacheVariant;
+    }>
+  | Readonly<{
+      fallback: CacheProofBreakerFallback;
+      kind: "breakerFallback";
+      routeBudget: CacheVariantRouteBudget | null;
+    }>;
+
+export type BuildCacheVariantWithRouteBudgetInput = BuildCacheVariantInput &
+  Readonly<{
+    routeBudget: CacheVariantRouteBudget | null;
+  }>;
+
+export type BuildCacheVariantWithRouteBudgetResult = CacheVariantRouteBudgetAdmission;
 
 export type AppRouteCacheProofGraphScopeInput = Readonly<{
   ids: AppRouteSemanticIds;
@@ -654,21 +679,6 @@ export function buildCacheVariant(input: BuildCacheVariantInput): BuildCacheVari
       fallback: budgetFallback,
     };
   }
-  if (input.existingVariantCount >= input.budget.maxVariantsPerRoute) {
-    return {
-      kind: "breakerFallback",
-      fallback: buildBreakerFallback(
-        "CP_ROUTE_VARIANT_CEILING_EXCEEDED",
-        {
-          existingVariantCount: input.existingVariantCount,
-          maxVariantsPerRoute: input.budget.maxVariantsPerRoute,
-          routeId: input.output.routeId,
-        },
-        "privateUncacheable",
-        "route",
-      ),
-    };
-  }
   const dimensionInputs = mergeDimensionInputs(input.dimensions);
   if (dimensionInputs.length > input.budget.maxDimensionCount) {
     return {
@@ -723,6 +733,117 @@ export function buildCacheVariant(input: BuildCacheVariantInput): BuildCacheVari
       budget: { ...input.budget },
     },
   };
+}
+
+function normalizeRouteBudget(input: CacheVariantRouteBudget): CacheVariantRouteBudget {
+  return {
+    routeId: input.routeId,
+    variantCacheKeys: sortedUnique(input.variantCacheKeys),
+  };
+}
+
+function buildRouteVariantCeilingFallback(
+  variant: CacheVariant,
+  existingVariantCount: number,
+): CacheProofBreakerFallback {
+  return buildBreakerFallback(
+    "CP_ROUTE_VARIANT_CEILING_EXCEEDED",
+    {
+      existingVariantCount,
+      maxVariantsPerRoute: variant.budget.maxVariantsPerRoute,
+      routeId: variant.output.routeId,
+    },
+    "privateUncacheable",
+    "route",
+  );
+}
+
+export function enforceCacheVariantRouteBudget(input: {
+  routeBudget: CacheVariantRouteBudget | null;
+  variant: CacheVariant;
+}): CacheVariantRouteBudgetAdmission {
+  if (input.routeBudget && input.routeBudget.routeId !== input.variant.output.routeId) {
+    return {
+      kind: "breakerFallback",
+      routeBudget: normalizeRouteBudget(input.routeBudget),
+      fallback: buildBreakerFallback(
+        "CP_ROUTE_VARIANT_BUDGET_ROUTE_MISMATCH",
+        {
+          budgetRouteId: input.routeBudget.routeId,
+          routeId: input.variant.output.routeId,
+        },
+        "privateUncacheable",
+        "route",
+      ),
+    };
+  }
+
+  const routeBudget = normalizeRouteBudget(
+    input.routeBudget ?? {
+      routeId: input.variant.output.routeId,
+      variantCacheKeys: [],
+    },
+  );
+  const existingVariantCount = routeBudget.variantCacheKeys.length;
+  const isKnownVariant = routeBudget.variantCacheKeys.includes(input.variant.cacheKey);
+
+  if (existingVariantCount > input.variant.budget.maxVariantsPerRoute) {
+    return {
+      kind: "breakerFallback",
+      routeBudget,
+      fallback: buildRouteVariantCeilingFallback(input.variant, existingVariantCount),
+    };
+  }
+
+  if (isKnownVariant) {
+    return {
+      kind: "variant",
+      variant: input.variant,
+      routeBudget,
+      didConsumeRouteVariantBudget: false,
+    };
+  }
+
+  if (existingVariantCount >= input.variant.budget.maxVariantsPerRoute) {
+    return {
+      kind: "breakerFallback",
+      routeBudget,
+      fallback: buildRouteVariantCeilingFallback(input.variant, existingVariantCount),
+    };
+  }
+
+  return {
+    kind: "variant",
+    variant: input.variant,
+    routeBudget: {
+      routeId: routeBudget.routeId,
+      variantCacheKeys: sortedUnique([...routeBudget.variantCacheKeys, input.variant.cacheKey]),
+    },
+    didConsumeRouteVariantBudget: true,
+  };
+}
+
+export function buildCacheVariantWithRouteBudget(
+  input: BuildCacheVariantWithRouteBudgetInput,
+): BuildCacheVariantWithRouteBudgetResult {
+  const variantResult = buildCacheVariant({
+    budget: input.budget,
+    dimensions: input.dimensions,
+    output: input.output,
+  });
+
+  if (variantResult.kind === "breakerFallback") {
+    return {
+      kind: "breakerFallback",
+      routeBudget: input.routeBudget ? normalizeRouteBudget(input.routeBudget) : null,
+      fallback: variantResult.fallback,
+    };
+  }
+
+  return enforceCacheVariantRouteBudget({
+    routeBudget: input.routeBudget,
+    variant: variantResult.variant,
+  });
 }
 
 function boundaryOutcomesMatch(expected: BoundaryOutcome, candidate: BoundaryOutcome): boolean {

--- a/packages/vinext/src/server/cache-proof.ts
+++ b/packages/vinext/src/server/cache-proof.ts
@@ -1407,6 +1407,7 @@ export function buildStaticLayoutReuseProof(
     };
   }
 
+  // The loop can use the shared readonly registry; the proof stores a detached evidence copy.
   const requiredNegativeRequestApis = ALL_RENDER_REQUEST_API_KINDS;
   for (const api of requiredNegativeRequestApis) {
     const status = getRequestApiStatus(candidateObservation.requestApis, api);

--- a/packages/vinext/src/server/cache-proof.ts
+++ b/packages/vinext/src/server/cache-proof.ts
@@ -18,7 +18,22 @@ export type CacheProofRejectionCode =
   | "CP_UNSAFE_PUBLIC_DIMENSION"
   | "CP_BOUNDARY_OUTCOME_MISMATCH"
   | "CP_BOUNDARY_OUTCOME_UNKNOWN"
-  | "CP_PRIVATE_DYNAMIC_DOWNGRADE";
+  | "CP_PRIVATE_DYNAMIC_DOWNGRADE"
+  | "CP_STATIC_LAYOUT_CANDIDATE_OUTPUT_KIND"
+  | "CP_STATIC_LAYOUT_CURRENT_OUTPUT_KIND"
+  | "CP_STATIC_LAYOUT_ID_MISMATCH"
+  | "CP_STATIC_LAYOUT_OBSERVATION_OUTPUT_KIND"
+  | "CP_STATIC_LAYOUT_OBSERVATION_OUTPUT_MISMATCH"
+  | "CP_STATIC_LAYOUT_PRIVATE_DYNAMIC_DOWNGRADE"
+  | "CP_STATIC_LAYOUT_PRIVATE_VARIANT_DIMENSION"
+  | "CP_STATIC_LAYOUT_REQUEST_API_OBSERVED"
+  | "CP_STATIC_LAYOUT_REQUEST_API_UNKNOWN"
+  | "CP_STATIC_LAYOUT_ROOT_BOUNDARY_MISMATCH"
+  | "CP_STATIC_LAYOUT_ROOT_BOUNDARY_UNKNOWN";
+
+export type CacheProofAcceptanceCode = "CP_STATIC_LAYOUT_REUSE_PROVEN";
+
+export type CacheProofTraceCode = CacheProofAcceptanceCode | CacheProofRejectionCode;
 
 export type CacheProofTraceFieldValue = string | number | boolean | null | readonly string[];
 
@@ -127,6 +142,8 @@ export type CacheProofOutputScope =
       routeId: string;
       templateId: string;
     }>;
+
+export type StaticLayoutCacheProofOutputScope = Extract<CacheProofOutputScope, { kind: "layout" }>;
 
 export type CacheVariant = Readonly<{
   budget: CacheVariantBudget;
@@ -303,6 +320,28 @@ export type RenderObservation = Readonly<{
   schemaVersion: CacheProofModelSchemaVersion;
 }>;
 
+export type StaticLayoutReuseProof = Readonly<{
+  authorizesRuntimeReuse: false;
+  candidateOutput: StaticLayoutCacheProofOutputScope;
+  code: "CP_STATIC_LAYOUT_REUSE_PROVEN";
+  currentOutput: StaticLayoutCacheProofOutputScope;
+  fields: CacheProofTraceFields;
+  observation: RenderObservation;
+  requiredNegativeRequestApis: readonly RenderRequestApiKind[];
+  reuseClass: "static-layout";
+  variant: CacheVariant;
+}>;
+
+export type BuildStaticLayoutReuseProofInput = Readonly<{
+  candidateObservation: RenderObservation;
+  candidateVariant: CacheVariant;
+  currentOutput: CacheProofOutputScope;
+}>;
+
+export type BuildStaticLayoutReuseProofResult =
+  | Readonly<{ kind: "proof"; proof: StaticLayoutReuseProof }>
+  | Readonly<{ kind: "rejected"; fallback: CacheProofBreakerFallback }>;
+
 export type BuildRenderObservationInput = Readonly<{
   boundaryOutcome: BoundaryOutcome;
   cacheTags: readonly string[];
@@ -324,11 +363,13 @@ export type DisabledCacheProofDecision = Readonly<{
   fallback: CacheProofBreakerFallback;
   kind: "disabled";
   observation: RenderObservation;
+  staticLayoutProof?: StaticLayoutReuseProof;
   variant: CacheVariant;
 }>;
 
 export type CreateDisabledCacheProofDecisionInput = Readonly<{
   observation: RenderObservation;
+  staticLayoutProof?: StaticLayoutReuseProof;
   variant: CacheVariant;
 }>;
 
@@ -1066,6 +1107,205 @@ export function hasCompleteNegativeRequestApiProof(
   return true;
 }
 
+function isStaticLayoutOutputScope(
+  output: CacheProofOutputScope,
+): output is StaticLayoutCacheProofOutputScope {
+  return output.kind === "layout";
+}
+
+function rejectStaticLayoutReuseProof(
+  code: CacheProofRejectionCode,
+  fields: CacheProofTraceFields,
+  mode: CacheProofBreakerFallbackMode = "renderFresh",
+): BuildStaticLayoutReuseProofResult {
+  return {
+    kind: "rejected",
+    fallback: buildBreakerFallback(code, fields, mode),
+  };
+}
+
+function getRequestApiStatus(
+  observation: RenderObservation,
+  kind: RenderRequestApiKind,
+): RenderRequestApiStatus | "missing" {
+  for (const requestApi of observation.requestApis) {
+    if (requestApi.kind === kind) return requestApi.status;
+  }
+  return "missing";
+}
+
+function createStaticLayoutDowngradeFallback(
+  downgrade: CacheProofDowngradeClassification,
+): CacheProofBreakerFallback {
+  const mode: CacheProofBreakerFallbackMode =
+    downgrade.target === "privateUncacheable" ? "privateUncacheable" : "renderFresh";
+  return buildBreakerFallback(
+    "CP_STATIC_LAYOUT_PRIVATE_DYNAMIC_DOWNGRADE",
+    {
+      reasonCodes: downgrade.reasons.map((reason) => reason.code),
+      target: downgrade.target,
+    },
+    mode,
+  );
+}
+
+function createPrivateVariantDimensionFallback(
+  dimension: CacheVariantDimension,
+): CacheProofBreakerFallback | null {
+  const downgrade = classifyCacheVariantDimensionDowngrade({ source: dimension.source });
+  if (!downgrade && dimension.privacy !== "private") {
+    return null;
+  }
+
+  const target = downgrade?.target ?? "private";
+  const mode: CacheProofBreakerFallbackMode =
+    target === "privateUncacheable" ? "privateUncacheable" : "renderFresh";
+  return buildBreakerFallback(
+    "CP_STATIC_LAYOUT_PRIVATE_VARIANT_DIMENSION",
+    {
+      dimension: dimension.name,
+      privacy: dimension.privacy,
+      reasonCode: downgrade?.code ?? null,
+      source: dimension.source,
+      target,
+    },
+    mode,
+  );
+}
+
+function outputFieldMismatch(
+  candidate: StaticLayoutCacheProofOutputScope,
+  observation: StaticLayoutCacheProofOutputScope,
+): "layoutId" | "rootBoundaryId" | "routeId" | null {
+  if (candidate.layoutId !== observation.layoutId) return "layoutId";
+  if (candidate.rootBoundaryId !== observation.rootBoundaryId) return "rootBoundaryId";
+  if (candidate.routeId !== observation.routeId) return "routeId";
+  return null;
+}
+
+export function buildStaticLayoutReuseProof(
+  input: BuildStaticLayoutReuseProofInput,
+): BuildStaticLayoutReuseProofResult {
+  if (!isStaticLayoutOutputScope(input.currentOutput)) {
+    return rejectStaticLayoutReuseProof("CP_STATIC_LAYOUT_CURRENT_OUTPUT_KIND", {
+      currentOutputKind: input.currentOutput.kind,
+    });
+  }
+
+  if (!isStaticLayoutOutputScope(input.candidateVariant.output)) {
+    return rejectStaticLayoutReuseProof("CP_STATIC_LAYOUT_CANDIDATE_OUTPUT_KIND", {
+      candidateOutputKind: input.candidateVariant.output.kind,
+    });
+  }
+
+  if (!isStaticLayoutOutputScope(input.candidateObservation.output)) {
+    return rejectStaticLayoutReuseProof("CP_STATIC_LAYOUT_OBSERVATION_OUTPUT_KIND", {
+      observationOutputKind: input.candidateObservation.output.kind,
+    });
+  }
+
+  const currentOutput = input.currentOutput;
+  const candidateOutput = input.candidateVariant.output;
+  const observationOutput = input.candidateObservation.output;
+  const observedOutputMismatch = outputFieldMismatch(candidateOutput, observationOutput);
+  if (observedOutputMismatch) {
+    return rejectStaticLayoutReuseProof("CP_STATIC_LAYOUT_OBSERVATION_OUTPUT_MISMATCH", {
+      candidateLayoutId: candidateOutput.layoutId,
+      candidateRootBoundaryId: candidateOutput.rootBoundaryId,
+      candidateRouteId: candidateOutput.routeId,
+      field: observedOutputMismatch,
+      observationLayoutId: observationOutput.layoutId,
+      observationRootBoundaryId: observationOutput.rootBoundaryId,
+      observationRouteId: observationOutput.routeId,
+    });
+  }
+
+  if (currentOutput.layoutId !== candidateOutput.layoutId) {
+    return rejectStaticLayoutReuseProof("CP_STATIC_LAYOUT_ID_MISMATCH", {
+      candidateLayoutId: candidateOutput.layoutId,
+      currentLayoutId: currentOutput.layoutId,
+    });
+  }
+
+  if (currentOutput.rootBoundaryId === null || candidateOutput.rootBoundaryId === null) {
+    return rejectStaticLayoutReuseProof("CP_STATIC_LAYOUT_ROOT_BOUNDARY_UNKNOWN", {
+      candidateRootBoundaryId: candidateOutput.rootBoundaryId,
+      currentRootBoundaryId: currentOutput.rootBoundaryId,
+    });
+  }
+
+  if (currentOutput.rootBoundaryId !== candidateOutput.rootBoundaryId) {
+    return rejectStaticLayoutReuseProof("CP_STATIC_LAYOUT_ROOT_BOUNDARY_MISMATCH", {
+      candidateRootBoundaryId: candidateOutput.rootBoundaryId,
+      currentRootBoundaryId: currentOutput.rootBoundaryId,
+    });
+  }
+
+  const boundaryCompatibility = buildBoundaryOutcomeCompatibility({
+    candidate: input.candidateObservation.boundaryOutcome,
+    expected: { kind: "success" },
+  });
+  if (boundaryCompatibility.kind === "incompatible") {
+    return {
+      kind: "rejected",
+      fallback: boundaryCompatibility.fallback,
+    };
+  }
+
+  for (const dimension of input.candidateVariant.dimensions) {
+    const fallback = createPrivateVariantDimensionFallback(dimension);
+    if (fallback) {
+      return {
+        kind: "rejected",
+        fallback,
+      };
+    }
+  }
+
+  if (!input.candidateObservation.downgrade.isPublicCacheCandidate) {
+    return {
+      kind: "rejected",
+      fallback: createStaticLayoutDowngradeFallback(input.candidateObservation.downgrade),
+    };
+  }
+
+  const requiredNegativeRequestApis = ALL_RENDER_REQUEST_API_KINDS;
+  for (const api of requiredNegativeRequestApis) {
+    const status = getRequestApiStatus(input.candidateObservation, api);
+    if (status === "notObserved") continue;
+
+    return rejectStaticLayoutReuseProof(
+      status === "missing"
+        ? "CP_STATIC_LAYOUT_REQUEST_API_UNKNOWN"
+        : "CP_STATIC_LAYOUT_REQUEST_API_OBSERVED",
+      {
+        requestApi: api,
+        status,
+      },
+    );
+  }
+
+  return {
+    kind: "proof",
+    proof: {
+      authorizesRuntimeReuse: false,
+      candidateOutput,
+      code: "CP_STATIC_LAYOUT_REUSE_PROVEN",
+      currentOutput,
+      fields: {
+        candidateRouteId: candidateOutput.routeId,
+        currentRouteId: currentOutput.routeId,
+        layoutId: currentOutput.layoutId,
+        rootBoundaryId: currentOutput.rootBoundaryId,
+      },
+      observation: input.candidateObservation,
+      requiredNegativeRequestApis: [...requiredNegativeRequestApis],
+      reuseClass: "static-layout",
+      variant: input.candidateVariant,
+    },
+  };
+}
+
 export function createDisabledCacheProofDecision(
   input: CreateDisabledCacheProofDecisionInput,
 ): DisabledCacheProofDecision {
@@ -1074,6 +1314,7 @@ export function createDisabledCacheProofDecision(
     canReuse: false,
     variant: input.variant,
     observation: input.observation,
+    ...(input.staticLayoutProof ? { staticLayoutProof: input.staticLayoutProof } : {}),
     fallback: buildBreakerFallback("CP_MODEL_DISABLED"),
   };
 }

--- a/packages/vinext/src/server/cache-proof.ts
+++ b/packages/vinext/src/server/cache-proof.ts
@@ -1,5 +1,6 @@
 import type { AppRouteSemanticIds } from "../routing/app-route-graph.js";
 import { fnv1a64 } from "../utils/hash.js";
+import { findSortedStringPosition } from "../utils/sorted-array.js";
 
 export const CACHE_PROOF_MODEL_SCHEMA_VERSION = 1;
 export type CacheProofModelSchemaVersion = 1;
@@ -740,28 +741,6 @@ function normalizeRouteBudget(input: CacheVariantRouteBudget): CacheVariantRoute
     routeId: input.routeId,
     variantCacheKeys: sortedUnique(input.variantCacheKeys),
   };
-}
-
-function findSortedStringPosition(
-  values: readonly string[],
-  candidate: string,
-): { found: boolean; index: number } {
-  let lower = 0;
-  let upper = values.length;
-
-  while (lower < upper) {
-    const middle = lower + Math.floor((upper - lower) / 2);
-    if (values[middle] === candidate) {
-      return { found: true, index: middle };
-    }
-    if (values[middle] < candidate) {
-      lower = middle + 1;
-    } else {
-      upper = middle;
-    }
-  }
-
-  return { found: false, index: lower };
 }
 
 function buildRouteVariantCeilingFallback(

--- a/packages/vinext/src/server/cache-proof.ts
+++ b/packages/vinext/src/server/cache-proof.ts
@@ -1218,7 +1218,7 @@ export function hasCompleteNegativeRequestApiProof(
   if (observation.completeness !== "complete") return false;
 
   const statuses = new Map<RenderRequestApiKind, RenderRequestApiStatus>();
-  for (const requestApi of observation.requestApis) {
+  for (const requestApi of normalizeRequestApiObservations(observation.requestApis)) {
     statuses.set(requestApi.kind, requestApi.status);
   }
 
@@ -1246,13 +1246,19 @@ function rejectStaticLayoutReuseProof(
 }
 
 function getRequestApiStatus(
-  observation: RenderObservation,
+  observations: readonly RenderRequestApiObservation[],
   kind: RenderRequestApiKind,
 ): RenderRequestApiStatus | "missing" {
-  for (const requestApi of observation.requestApis) {
-    if (requestApi.kind === kind) return requestApi.status;
+  let status: RenderRequestApiStatus | null = null;
+
+  for (const requestApi of observations) {
+    if (requestApi.kind !== kind) continue;
+    if (status === null || requestApiStatusRank(requestApi.status) > requestApiStatusRank(status)) {
+      status = requestApi.status;
+    }
   }
-  return "missing";
+
+  return status ?? "missing";
 }
 
 function createStaticLayoutDowngradeFallback(
@@ -1328,6 +1334,17 @@ export function buildStaticLayoutReuseProof(
   const currentOutput = input.currentOutput;
   const candidateOutput = input.candidateVariant.output;
   const observationOutput = input.candidateObservation.output;
+  const requestApis = normalizeRequestApiObservations(input.candidateObservation.requestApis);
+  const candidateObservation = {
+    ...input.candidateObservation,
+    requestApis,
+    downgrade: classifyRenderObservationDowngrade({
+      cacheability: input.candidateObservation.cacheability,
+      completeness: input.candidateObservation.completeness,
+      dynamicFetches: input.candidateObservation.dynamicFetches,
+      requestApis,
+    }),
+  } satisfies RenderObservation;
   const observedOutputMismatch = outputFieldMismatch(candidateOutput, observationOutput);
   if (observedOutputMismatch) {
     return rejectStaticLayoutReuseProof("CP_STATIC_LAYOUT_OBSERVATION_OUTPUT_MISMATCH", {
@@ -1363,7 +1380,7 @@ export function buildStaticLayoutReuseProof(
   }
 
   const boundaryCompatibility = buildBoundaryOutcomeCompatibility({
-    candidate: input.candidateObservation.boundaryOutcome,
+    candidate: candidateObservation.boundaryOutcome,
     expected: { kind: "success" },
   });
   if (boundaryCompatibility.kind === "incompatible") {
@@ -1383,16 +1400,16 @@ export function buildStaticLayoutReuseProof(
     }
   }
 
-  if (!input.candidateObservation.downgrade.isPublicCacheCandidate) {
+  if (!candidateObservation.downgrade.isPublicCacheCandidate) {
     return {
       kind: "rejected",
-      fallback: createStaticLayoutDowngradeFallback(input.candidateObservation.downgrade),
+      fallback: createStaticLayoutDowngradeFallback(candidateObservation.downgrade),
     };
   }
 
   const requiredNegativeRequestApis = ALL_RENDER_REQUEST_API_KINDS;
   for (const api of requiredNegativeRequestApis) {
-    const status = getRequestApiStatus(input.candidateObservation, api);
+    const status = getRequestApiStatus(candidateObservation.requestApis, api);
     if (status === "notObserved") continue;
 
     return rejectStaticLayoutReuseProof(
@@ -1419,7 +1436,7 @@ export function buildStaticLayoutReuseProof(
         layoutId: currentOutput.layoutId,
         rootBoundaryId: currentOutput.rootBoundaryId,
       },
-      observation: input.candidateObservation,
+      observation: candidateObservation,
       requiredNegativeRequestApis: [...requiredNegativeRequestApis],
       reuseClass: "static-layout",
       variant: input.candidateVariant,

--- a/packages/vinext/src/server/cache-proof.ts
+++ b/packages/vinext/src/server/cache-proof.ts
@@ -742,6 +742,28 @@ function normalizeRouteBudget(input: CacheVariantRouteBudget): CacheVariantRoute
   };
 }
 
+function findSortedStringPosition(
+  values: readonly string[],
+  candidate: string,
+): { found: boolean; index: number } {
+  let lower = 0;
+  let upper = values.length;
+
+  while (lower < upper) {
+    const middle = lower + Math.floor((upper - lower) / 2);
+    if (values[middle] === candidate) {
+      return { found: true, index: middle };
+    }
+    if (values[middle] < candidate) {
+      lower = middle + 1;
+    } else {
+      upper = middle;
+    }
+  }
+
+  return { found: false, index: lower };
+}
+
 function buildRouteVariantCeilingFallback(
   variant: CacheVariant,
   existingVariantCount: number,
@@ -785,7 +807,10 @@ export function enforceCacheVariantRouteBudget(input: {
     },
   );
   const existingVariantCount = routeBudget.variantCacheKeys.length;
-  const isKnownVariant = routeBudget.variantCacheKeys.includes(input.variant.cacheKey);
+  const variantKeyPosition = findSortedStringPosition(
+    routeBudget.variantCacheKeys,
+    input.variant.cacheKey,
+  );
 
   if (existingVariantCount > input.variant.budget.maxVariantsPerRoute) {
     return {
@@ -795,7 +820,7 @@ export function enforceCacheVariantRouteBudget(input: {
     };
   }
 
-  if (isKnownVariant) {
+  if (variantKeyPosition.found) {
     return {
       kind: "variant",
       variant: input.variant,
@@ -817,7 +842,11 @@ export function enforceCacheVariantRouteBudget(input: {
     variant: input.variant,
     routeBudget: {
       routeId: routeBudget.routeId,
-      variantCacheKeys: sortedUnique([...routeBudget.variantCacheKeys, input.variant.cacheKey]),
+      variantCacheKeys: [
+        ...routeBudget.variantCacheKeys.slice(0, variantKeyPosition.index),
+        input.variant.cacheKey,
+        ...routeBudget.variantCacheKeys.slice(variantKeyPosition.index),
+      ],
     },
     didConsumeRouteVariantBudget: true,
   };

--- a/packages/vinext/src/utils/sorted-array.ts
+++ b/packages/vinext/src/utils/sorted-array.ts
@@ -1,0 +1,26 @@
+type SortedStringPosition = Readonly<{
+  found: boolean;
+  index: number;
+}>;
+
+export function findSortedStringPosition(
+  values: readonly string[],
+  candidate: string,
+): SortedStringPosition {
+  let lower = 0;
+  let upper = values.length;
+
+  while (lower < upper) {
+    const middle = lower + Math.floor((upper - lower) / 2);
+    if (values[middle] === candidate) {
+      return { found: true, index: middle };
+    }
+    if (values[middle] < candidate) {
+      lower = middle + 1;
+    } else {
+      upper = middle;
+    }
+  }
+
+  return { found: false, index: lower };
+}

--- a/tests/cache-proof.test.ts
+++ b/tests/cache-proof.test.ts
@@ -392,6 +392,9 @@ describe("disabled cache proof model", () => {
       throw new Error("Expected second route variant to be admitted");
     }
     expect(second.routeBudget.variantCacheKeys).toHaveLength(2);
+    expect(second.routeBudget.variantCacheKeys).toEqual(
+      [...second.routeBudget.variantCacheKeys].sort(),
+    );
     expect(second.didConsumeRouteVariantBudget).toBe(true);
 
     const overBudget = buildCacheVariantWithRouteBudget({

--- a/tests/cache-proof.test.ts
+++ b/tests/cache-proof.test.ts
@@ -3,6 +3,8 @@ import {
   buildBoundaryOutcomeCompatibility,
   buildCacheVariant,
   buildRenderObservation,
+  buildRenderRequestApiObservations,
+  buildStaticLayoutReuseProof,
   CACHE_PROOF_MODEL_SCHEMA_VERSION,
   classifyCacheVariantDimensionDowngrade,
   classifyRenderObservationDowngrade,
@@ -11,7 +13,15 @@ import {
   DEFAULT_CACHE_VARIANT_BUDGET,
   hasCompleteNegativeRequestApiProof,
   type AppRouteCacheProofGraphScopeInput,
+  type BoundaryOutcome,
   type CacheProofBreakerFallback,
+  type CacheProofOutputScope,
+  type CacheVariant,
+  type CacheVariantDimensionInput,
+  type RenderCacheability,
+  type RenderObservation,
+  type RenderObservationCompleteness,
+  type RenderRequestApiObservation,
 } from "../packages/vinext/src/server/cache-proof.js";
 
 function expectBreakerReason(
@@ -24,6 +34,70 @@ function expectBreakerReason(
   }
   expect(result.fallback.code).toBe(code);
   return result.fallback;
+}
+
+type LayoutOutputScope = Extract<CacheProofOutputScope, { kind: "layout" }>;
+
+function createLayoutOutput(
+  options: {
+    layoutId?: string;
+    rootBoundaryId?: string | null;
+    routeId?: string;
+  } = {},
+): LayoutOutputScope {
+  const rootBoundaryId =
+    "rootBoundaryId" in options && options.rootBoundaryId !== undefined
+      ? options.rootBoundaryId
+      : "layout:/";
+
+  return {
+    kind: "layout",
+    layoutId: options.layoutId ?? "layout:/dashboard",
+    rootBoundaryId,
+    routeId: options.routeId ?? "route:/dashboard/settings",
+  };
+}
+
+function buildLayoutVariant(options: {
+  dimensions?: readonly CacheVariantDimensionInput[];
+  output: LayoutOutputScope;
+}): CacheVariant {
+  const result = buildCacheVariant({
+    budget: DEFAULT_CACHE_VARIANT_BUDGET,
+    dimensions: options.dimensions ?? [],
+    existingVariantCount: 0,
+    output: options.output,
+  });
+  expect(result.kind).toBe("variant");
+  if (result.kind !== "variant") {
+    throw new Error("Expected cache variant construction to succeed");
+  }
+  return result.variant;
+}
+
+function buildLayoutObservation(options: {
+  boundaryOutcome?: BoundaryOutcome;
+  cacheability?: RenderCacheability;
+  completeness?: RenderObservationCompleteness;
+  dynamicFetches?: readonly string[];
+  output: LayoutOutputScope;
+  requestApis?: readonly RenderRequestApiObservation[];
+}): RenderObservation {
+  return buildRenderObservation({
+    boundaryOutcome: options.boundaryOutcome ?? { kind: "success" },
+    cacheability: options.cacheability ?? "public",
+    cacheTags: ["dashboard"],
+    completeness: options.completeness ?? "complete",
+    dynamicFetches: options.dynamicFetches ?? [],
+    output: options.output,
+    pathTags: ["/dashboard"],
+    requestApis:
+      options.requestApis ??
+      buildRenderRequestApiObservations({
+        completeness: options.completeness ?? "complete",
+        observed: [],
+      }),
+  });
 }
 
 describe("disabled cache proof model", () => {
@@ -527,5 +601,211 @@ describe("disabled cache proof model", () => {
       "CP_DOWNGRADE_DYNAMIC_REQUEST_API",
     ]);
     expect(JSON.stringify(observation.downgrade)).not.toContain("secret");
+  });
+
+  it("proves static layout reuse while leaving runtime cache reuse disabled", () => {
+    const currentOutput = createLayoutOutput({
+      routeId: "route:/dashboard/profile",
+    });
+    const candidateOutput = createLayoutOutput({
+      routeId: "route:/dashboard/settings",
+    });
+    const variant = buildLayoutVariant({ output: candidateOutput });
+    const observation = buildLayoutObservation({ output: candidateOutput });
+
+    const proof = buildStaticLayoutReuseProof({
+      candidateObservation: observation,
+      candidateVariant: variant,
+      currentOutput,
+    });
+
+    expect(proof.kind).toBe("proof");
+    if (proof.kind !== "proof") {
+      throw new Error("Expected same static layout identity to produce proof");
+    }
+    expect(proof.proof).toMatchObject({
+      authorizesRuntimeReuse: false,
+      code: "CP_STATIC_LAYOUT_REUSE_PROVEN",
+      reuseClass: "static-layout",
+      fields: {
+        candidateRouteId: "route:/dashboard/settings",
+        currentRouteId: "route:/dashboard/profile",
+        layoutId: "layout:/dashboard",
+        rootBoundaryId: "layout:/",
+      },
+    });
+
+    const decision = createDisabledCacheProofDecision({
+      observation,
+      staticLayoutProof: proof.proof,
+      variant,
+    });
+
+    expect(decision).toMatchObject({
+      canReuse: false,
+      kind: "disabled",
+      fallback: {
+        code: "CP_MODEL_DISABLED",
+      },
+      staticLayoutProof: {
+        code: "CP_STATIC_LAYOUT_REUSE_PROVEN",
+      },
+    });
+  });
+
+  it("rejects static layout proof when request API absence is not completely proven", () => {
+    const output = createLayoutOutput();
+    const variant = buildLayoutVariant({ output });
+    const observedParams = buildLayoutObservation({
+      output,
+      requestApis: buildRenderRequestApiObservations({
+        completeness: "complete",
+        observed: ["params"],
+      }),
+    });
+    const missingKinds = buildLayoutObservation({
+      output,
+      requestApis: [{ kind: "headers", status: "notObserved" }],
+    });
+
+    const observedProof = buildStaticLayoutReuseProof({
+      candidateObservation: observedParams,
+      candidateVariant: variant,
+      currentOutput: output,
+    });
+    const missingProof = buildStaticLayoutReuseProof({
+      candidateObservation: missingKinds,
+      candidateVariant: variant,
+      currentOutput: output,
+    });
+
+    expect(observedProof).toMatchObject({
+      kind: "rejected",
+      fallback: {
+        code: "CP_STATIC_LAYOUT_REQUEST_API_OBSERVED",
+        fields: {
+          requestApi: "params",
+          status: "observed",
+        },
+      },
+    });
+    expect(missingProof).toMatchObject({
+      kind: "rejected",
+      fallback: {
+        code: "CP_STATIC_LAYOUT_REQUEST_API_UNKNOWN",
+        fields: {
+          requestApi: "connection",
+          status: "missing",
+        },
+      },
+    });
+  });
+
+  it("rejects private and dynamic static layout observations before reuse proof", () => {
+    const output = createLayoutOutput();
+    const variant = buildLayoutVariant({ output });
+    const privateObservation = buildLayoutObservation({
+      output,
+      requestApis: buildRenderRequestApiObservations({
+        completeness: "complete",
+        observed: ["cookies"],
+      }),
+    });
+    const dynamicObservation = buildLayoutObservation({
+      dynamicFetches: ["https://api.example.test/dashboard?token=secret"],
+      output,
+    });
+
+    const privateProof = buildStaticLayoutReuseProof({
+      candidateObservation: privateObservation,
+      candidateVariant: variant,
+      currentOutput: output,
+    });
+    const dynamicProof = buildStaticLayoutReuseProof({
+      candidateObservation: dynamicObservation,
+      candidateVariant: variant,
+      currentOutput: output,
+    });
+
+    expect(privateProof).toMatchObject({
+      kind: "rejected",
+      fallback: {
+        code: "CP_STATIC_LAYOUT_PRIVATE_DYNAMIC_DOWNGRADE",
+        fields: {
+          reasonCodes: ["CP_DOWNGRADE_PRIVATE_REQUEST_API"],
+          target: "private",
+        },
+      },
+    });
+    expect(dynamicProof).toMatchObject({
+      kind: "rejected",
+      fallback: {
+        code: "CP_STATIC_LAYOUT_PRIVATE_DYNAMIC_DOWNGRADE",
+        fields: {
+          reasonCodes: ["CP_DOWNGRADE_DYNAMIC_FETCH"],
+          target: "freshRender",
+        },
+      },
+    });
+    expect(JSON.stringify(dynamicProof)).not.toContain("secret");
+  });
+
+  it("rejects private variant dimensions for static layout proof", () => {
+    const output = createLayoutOutput();
+    const variant = buildLayoutVariant({
+      dimensions: [
+        {
+          name: "session",
+          privacy: "private",
+          source: "cookie",
+          values: ["secret-session"],
+        },
+      ],
+      output,
+    });
+    const observation = buildLayoutObservation({ output });
+
+    const proof = buildStaticLayoutReuseProof({
+      candidateObservation: observation,
+      candidateVariant: variant,
+      currentOutput: output,
+    });
+
+    expect(proof).toMatchObject({
+      kind: "rejected",
+      fallback: {
+        code: "CP_STATIC_LAYOUT_PRIVATE_VARIANT_DIMENSION",
+        fields: {
+          dimension: "session",
+          reasonCode: "CP_DOWNGRADE_PRIVATE_DIMENSION",
+          source: "cookie",
+          target: "private",
+        },
+      },
+    });
+    expect(JSON.stringify(proof)).not.toContain("secret-session");
+  });
+
+  it("rejects unknown root-boundary identity instead of treating it as proof", () => {
+    const output = createLayoutOutput({ rootBoundaryId: null });
+    const variant = buildLayoutVariant({ output });
+    const observation = buildLayoutObservation({ output });
+
+    const proof = buildStaticLayoutReuseProof({
+      candidateObservation: observation,
+      candidateVariant: variant,
+      currentOutput: output,
+    });
+
+    expect(proof).toMatchObject({
+      kind: "rejected",
+      fallback: {
+        code: "CP_STATIC_LAYOUT_ROOT_BOUNDARY_UNKNOWN",
+        fields: {
+          candidateRootBoundaryId: null,
+          currentRootBoundaryId: null,
+        },
+      },
+    });
   });
 });

--- a/tests/cache-proof.test.ts
+++ b/tests/cache-proof.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vite-plus/test";
 import {
   buildBoundaryOutcomeCompatibility,
   buildCacheVariant,
+  buildCacheVariantWithRouteBudget,
   buildRenderObservation,
   buildRenderRequestApiObservations,
   buildStaticLayoutReuseProof,
@@ -24,8 +25,12 @@ import {
   type RenderRequestApiObservation,
 } from "../packages/vinext/src/server/cache-proof.js";
 
+type CacheVariantBuildResultForTest =
+  | ReturnType<typeof buildCacheVariant>
+  | ReturnType<typeof buildCacheVariantWithRouteBudget>;
+
 function expectBreakerReason(
-  result: ReturnType<typeof buildCacheVariant>,
+  result: CacheVariantBuildResultForTest,
   code: CacheProofBreakerFallback["code"],
 ): CacheProofBreakerFallback {
   expect(result.kind).toBe("breakerFallback");
@@ -65,7 +70,6 @@ function buildLayoutVariant(options: {
   const result = buildCacheVariant({
     budget: DEFAULT_CACHE_VARIANT_BUDGET,
     dimensions: options.dimensions ?? [],
-    existingVariantCount: 0,
     output: options.output,
   });
   expect(result.kind).toBe("variant");
@@ -153,7 +157,6 @@ describe("disabled cache proof model", () => {
           values: ["super-secret-token"],
         },
       ],
-      existingVariantCount: 0,
       output: {
         kind: "app-rsc",
         mountedSlotsFingerprint: "slots:main",
@@ -178,7 +181,6 @@ describe("disabled cache proof model", () => {
           values: ["asc", "desc"],
         },
       ],
-      existingVariantCount: 0,
       output: {
         kind: "app-rsc",
         mountedSlotsFingerprint: "slots:main",
@@ -211,7 +213,6 @@ describe("disabled cache proof model", () => {
     const absentEpoch = buildCacheVariant({
       budget: DEFAULT_CACHE_VARIANT_BUDGET,
       dimensions: [],
-      existingVariantCount: 0,
       output: {
         kind: "app-html",
         renderEpoch: null,
@@ -222,7 +223,6 @@ describe("disabled cache proof model", () => {
     const emptyEpoch = buildCacheVariant({
       budget: DEFAULT_CACHE_VARIANT_BUDGET,
       dimensions: [],
-      existingVariantCount: 0,
       output: {
         kind: "app-html",
         renderEpoch: "",
@@ -251,7 +251,6 @@ describe("disabled cache proof model", () => {
           values: ["abc"],
         },
       ],
-      existingVariantCount: 0,
       output: {
         kind: "layout",
         layoutId: "layout:/account",
@@ -277,7 +276,6 @@ describe("disabled cache proof model", () => {
             values: ["customer-a"],
           },
         ],
-        existingVariantCount: 0,
         output: {
           kind: "layout",
           layoutId: "layout:/[tenant]",
@@ -288,38 +286,12 @@ describe("disabled cache proof model", () => {
       "CP_DIMENSION_VALUE_TOO_LONG",
     );
 
-    expectBreakerReason(
-      buildCacheVariant({
-        budget: {
-          ...DEFAULT_CACHE_VARIANT_BUDGET,
-          maxVariantsPerRoute: 2,
-        },
-        dimensions: [
-          {
-            name: "tenant",
-            privacy: "public",
-            source: "params",
-            values: ["a"],
-          },
-        ],
-        existingVariantCount: 2,
-        output: {
-          kind: "layout",
-          layoutId: "layout:/[tenant]",
-          rootBoundaryId: "layout:/",
-          routeId: "route:/:tenant",
-        },
-      }),
-      "CP_ROUTE_VARIANT_CEILING_EXCEEDED",
-    );
-
     const invalidBudget = buildCacheVariant({
       budget: {
         ...DEFAULT_CACHE_VARIANT_BUDGET,
         maxEncodedLength: -1,
       },
       dimensions: [],
-      existingVariantCount: 0,
       output: {
         kind: "layout",
         layoutId: "layout:/[tenant]",
@@ -335,6 +307,104 @@ describe("disabled cache proof model", () => {
       code: "CP_INVALID_VARIANT_BUDGET",
       fields: { budgetField: "maxEncodedLength" },
     });
+  });
+
+  it("enforces per-route variant cardinality without charging duplicate variants", () => {
+    const budget = {
+      ...DEFAULT_CACHE_VARIANT_BUDGET,
+      maxVariantsPerRoute: 2,
+    };
+    const output = {
+      kind: "layout",
+      layoutId: "layout:/[tenant]",
+      rootBoundaryId: "layout:/",
+      routeId: "route:/:tenant",
+    } satisfies CacheProofOutputScope;
+
+    const first = buildCacheVariantWithRouteBudget({
+      budget,
+      dimensions: [
+        {
+          name: "tenant",
+          privacy: "public",
+          source: "params",
+          values: ["alpha"],
+        },
+      ],
+      routeBudget: null,
+      output,
+    });
+    expect(first.kind).toBe("variant");
+    if (first.kind !== "variant") {
+      throw new Error("Expected first route variant to be admitted");
+    }
+    expect(first.routeBudget.variantCacheKeys).toHaveLength(1);
+    expect(first.didConsumeRouteVariantBudget).toBe(true);
+
+    const duplicate = buildCacheVariantWithRouteBudget({
+      budget,
+      dimensions: [
+        {
+          name: "tenant",
+          privacy: "public",
+          source: "params",
+          values: ["alpha"],
+        },
+      ],
+      routeBudget: first.routeBudget,
+      output,
+    });
+    expect(duplicate.kind).toBe("variant");
+    if (duplicate.kind !== "variant") {
+      throw new Error("Expected duplicate route variant to be admitted");
+    }
+    expect(duplicate.routeBudget.variantCacheKeys).toEqual(first.routeBudget.variantCacheKeys);
+    expect(duplicate.didConsumeRouteVariantBudget).toBe(false);
+
+    const second = buildCacheVariantWithRouteBudget({
+      budget,
+      dimensions: [
+        {
+          name: "tenant",
+          privacy: "public",
+          source: "params",
+          values: ["bravo"],
+        },
+      ],
+      routeBudget: duplicate.routeBudget,
+      output,
+    });
+    expect(second.kind).toBe("variant");
+    if (second.kind !== "variant") {
+      throw new Error("Expected second route variant to be admitted");
+    }
+    expect(second.routeBudget.variantCacheKeys).toHaveLength(2);
+    expect(second.didConsumeRouteVariantBudget).toBe(true);
+
+    const overBudget = buildCacheVariantWithRouteBudget({
+      budget,
+      dimensions: [
+        {
+          name: "tenant",
+          privacy: "public",
+          source: "params",
+          values: ["charlie"],
+        },
+      ],
+      routeBudget: second.routeBudget,
+      output,
+    });
+    const fallback = expectBreakerReason(overBudget, "CP_ROUTE_VARIANT_CEILING_EXCEEDED");
+    expect(fallback).toMatchObject({
+      mode: "privateUncacheable",
+      scope: "route",
+      fields: {
+        existingVariantCount: 2,
+        maxVariantsPerRoute: 2,
+        routeId: "route:/:tenant",
+      },
+    });
+    expect(JSON.stringify(fallback.fields)).not.toContain("charlie");
   });
 
   it("requires complete negative request-api observations before absence is proof", () => {
@@ -411,7 +481,6 @@ describe("disabled cache proof model", () => {
     const variant = buildCacheVariant({
       budget: DEFAULT_CACHE_VARIANT_BUDGET,
       dimensions: [],
-      existingVariantCount: 0,
       output: {
         kind: "app-html",
         renderEpoch: null,

--- a/tests/cache-proof.test.ts
+++ b/tests/cache-proof.test.ts
@@ -17,6 +17,7 @@ import {
   type BoundaryOutcome,
   type CacheProofBreakerFallback,
   type CacheProofOutputScope,
+  type CacheProofRejectionCode,
   type CacheVariant,
   type CacheVariantDimensionInput,
   type RenderCacheability,
@@ -102,6 +103,18 @@ function buildLayoutObservation(options: {
         observed: [],
       }),
   });
+}
+
+function expectStaticLayoutProofRejection(
+  result: ReturnType<typeof buildStaticLayoutReuseProof>,
+  code: CacheProofRejectionCode,
+): CacheProofBreakerFallback {
+  expect(result.kind).toBe("rejected");
+  if (result.kind !== "rejected") {
+    throw new Error("Expected static layout proof to be rejected");
+  }
+  expect(result.fallback.code).toBe(code);
+  return result.fallback;
 }
 
 describe("disabled cache proof model", () => {
@@ -407,6 +420,86 @@ describe("disabled cache proof model", () => {
     expect(JSON.stringify(fallback.fields)).not.toContain("charlie");
   });
 
+  it("rejects route variant budgets owned by a different route", () => {
+    const output = {
+      kind: "layout",
+      layoutId: "layout:/[tenant]",
+      rootBoundaryId: "layout:/",
+      routeId: "route:/:tenant",
+    } satisfies CacheProofOutputScope;
+
+    const result = buildCacheVariantWithRouteBudget({
+      budget: DEFAULT_CACHE_VARIANT_BUDGET,
+      dimensions: [],
+      routeBudget: {
+        routeId: "route:/other",
+        variantCacheKeys: ["cp1:existing"],
+      },
+      output,
+    });
+
+    const fallback = expectBreakerReason(result, "CP_ROUTE_VARIANT_BUDGET_ROUTE_MISMATCH");
+    expect(fallback).toMatchObject({
+      mode: "privateUncacheable",
+      scope: "route",
+      fields: {
+        budgetRouteId: "route:/other",
+        routeId: "route:/:tenant",
+      },
+    });
+  });
+
+  it("rejects known duplicate route variants when the existing route budget is already over ceiling", () => {
+    const budget = {
+      ...DEFAULT_CACHE_VARIANT_BUDGET,
+      maxVariantsPerRoute: 1,
+    };
+    const output = {
+      kind: "layout",
+      layoutId: "layout:/[tenant]",
+      rootBoundaryId: "layout:/",
+      routeId: "route:/:tenant",
+    } satisfies CacheProofOutputScope;
+    const dimensions = [
+      {
+        name: "tenant",
+        privacy: "public",
+        source: "params",
+        values: ["alpha"],
+      },
+    ] satisfies readonly CacheVariantDimensionInput[];
+    const seed = buildCacheVariant({
+      budget,
+      dimensions,
+      output,
+    });
+    expect(seed.kind).toBe("variant");
+    if (seed.kind !== "variant") {
+      throw new Error("Expected seed route variant to be admitted");
+    }
+
+    const duplicate = buildCacheVariantWithRouteBudget({
+      budget,
+      dimensions,
+      routeBudget: {
+        routeId: output.routeId,
+        variantCacheKeys: [seed.variant.cacheKey, "cp1:other-known-variant"],
+      },
+      output,
+    });
+
+    const fallback = expectBreakerReason(duplicate, "CP_ROUTE_VARIANT_CEILING_EXCEEDED");
+    expect(fallback).toMatchObject({
+      mode: "privateUncacheable",
+      scope: "route",
+      fields: {
+        existingVariantCount: 2,
+        maxVariantsPerRoute: 1,
+        routeId: "route:/:tenant",
+      },
+    });
+  });
+
   it("requires complete negative request-api observations before absence is proof", () => {
     const complete = buildRenderObservation({
       boundaryOutcome: { kind: "success" },
@@ -441,11 +534,22 @@ describe("disabled cache proof model", () => {
       ...complete,
       requestApis: [{ kind: "cookies", status: "notObserved" }],
     });
+    const duplicateApiKind = {
+      ...complete,
+      requestApis: [
+        { kind: "headers", status: "observed" },
+        { kind: "headers", status: "notObserved" },
+        { kind: "cookies", status: "notObserved" },
+      ],
+    } satisfies RenderObservation;
 
     expect(hasCompleteNegativeRequestApiProof(complete, ["headers", "cookies"])).toBe(true);
     expect(hasCompleteNegativeRequestApiProof(partial, ["headers", "cookies"])).toBe(false);
     expect(hasCompleteNegativeRequestApiProof(observed, ["headers", "cookies"])).toBe(false);
     expect(hasCompleteNegativeRequestApiProof(missingApiKind, ["headers", "cookies"])).toBe(false);
+    expect(hasCompleteNegativeRequestApiProof(duplicateApiKind, ["headers", "cookies"])).toBe(
+      false,
+    );
     expect(complete.cacheTags).toEqual(["posts"]);
     expect(JSON.stringify(complete.dynamicFetches)).not.toContain("secret");
   });
@@ -770,6 +874,78 @@ describe("disabled cache proof model", () => {
     });
   });
 
+  it("rejects stale render-observation downgrade during static layout proof", () => {
+    const output = createLayoutOutput();
+    const variant = buildLayoutVariant({ output });
+    const staleObservation = {
+      ...buildLayoutObservation({ output }),
+      downgrade: {
+        fallback: null,
+        isPublicCacheCandidate: true,
+        reasons: [],
+        target: "public",
+      },
+      dynamicFetches: ["https://api.example.test/live?token=secret"],
+    } satisfies RenderObservation;
+
+    const proof = buildStaticLayoutReuseProof({
+      candidateObservation: staleObservation,
+      candidateVariant: variant,
+      currentOutput: output,
+    });
+
+    const fallback = expectStaticLayoutProofRejection(
+      proof,
+      "CP_STATIC_LAYOUT_PRIVATE_DYNAMIC_DOWNGRADE",
+    );
+    expect(fallback).toMatchObject({
+      fields: {
+        reasonCodes: ["CP_DOWNGRADE_DYNAMIC_FETCH"],
+        target: "freshRender",
+      },
+      mode: "renderFresh",
+    });
+    expect(JSON.stringify(fallback)).not.toContain("secret");
+  });
+
+  it("rejects duplicated request-api observations using the most restrictive status", () => {
+    const output = createLayoutOutput();
+    const variant = buildLayoutVariant({ output });
+    const duplicateRequestApiObservation = {
+      ...buildLayoutObservation({ output }),
+      downgrade: {
+        fallback: null,
+        isPublicCacheCandidate: true,
+        reasons: [],
+        target: "public",
+      },
+      requestApis: [
+        { kind: "connection", status: "notObserved" },
+        { kind: "cookies", status: "notObserved" },
+        { kind: "draftMode", status: "notObserved" },
+        { kind: "headers", status: "notObserved" },
+        { kind: "params", status: "notObserved" },
+        { kind: "params", status: "observed" },
+        { kind: "searchParams", status: "notObserved" },
+      ],
+    } satisfies RenderObservation;
+
+    const proof = buildStaticLayoutReuseProof({
+      candidateObservation: duplicateRequestApiObservation,
+      candidateVariant: variant,
+      currentOutput: output,
+    });
+
+    const fallback = expectStaticLayoutProofRejection(
+      proof,
+      "CP_STATIC_LAYOUT_REQUEST_API_OBSERVED",
+    );
+    expect(fallback.fields).toEqual({
+      requestApi: "params",
+      status: "observed",
+    });
+  });
+
   it("rejects private and dynamic static layout observations before reuse proof", () => {
     const output = createLayoutOutput();
     const variant = buildLayoutVariant({ output });
@@ -853,6 +1029,179 @@ describe("disabled cache proof model", () => {
       },
     });
     expect(JSON.stringify(proof)).not.toContain("secret-session");
+  });
+
+  it("rejects non-layout current output scope for static layout proof", () => {
+    const output = createLayoutOutput();
+    const variant = buildLayoutVariant({ output });
+    const observation = buildLayoutObservation({ output });
+
+    const proof = buildStaticLayoutReuseProof({
+      candidateObservation: observation,
+      candidateVariant: variant,
+      currentOutput: {
+        kind: "page",
+        pageId: "page:/dashboard",
+        rootBoundaryId: "layout:/",
+        routeId: output.routeId,
+      },
+    });
+
+    const fallback = expectStaticLayoutProofRejection(
+      proof,
+      "CP_STATIC_LAYOUT_CURRENT_OUTPUT_KIND",
+    );
+    expect(fallback.fields).toEqual({
+      currentOutputKind: "page",
+    });
+  });
+
+  it("rejects non-layout candidate variant output scope for static layout proof", () => {
+    const currentOutput = createLayoutOutput();
+    const observation = buildLayoutObservation({ output: currentOutput });
+    const variantResult = buildCacheVariant({
+      budget: DEFAULT_CACHE_VARIANT_BUDGET,
+      dimensions: [],
+      output: {
+        kind: "app-rsc",
+        mountedSlotsFingerprint: null,
+        renderEpoch: null,
+        rootBoundaryId: currentOutput.rootBoundaryId,
+        routeId: currentOutput.routeId,
+      },
+    });
+    expect(variantResult.kind).toBe("variant");
+    if (variantResult.kind !== "variant") {
+      throw new Error("Expected non-layout candidate variant construction to succeed");
+    }
+
+    const proof = buildStaticLayoutReuseProof({
+      candidateObservation: observation,
+      candidateVariant: variantResult.variant,
+      currentOutput,
+    });
+
+    const fallback = expectStaticLayoutProofRejection(
+      proof,
+      "CP_STATIC_LAYOUT_CANDIDATE_OUTPUT_KIND",
+    );
+    expect(fallback.fields).toEqual({
+      candidateOutputKind: "app-rsc",
+    });
+  });
+
+  it("rejects non-layout observation output scope for static layout proof", () => {
+    const output = createLayoutOutput();
+    const variant = buildLayoutVariant({ output });
+    const observation = buildRenderObservation({
+      boundaryOutcome: { kind: "success" },
+      cacheability: "public",
+      cacheTags: ["dashboard"],
+      completeness: "complete",
+      dynamicFetches: [],
+      output: {
+        kind: "app-rsc",
+        mountedSlotsFingerprint: null,
+        renderEpoch: null,
+        rootBoundaryId: output.rootBoundaryId,
+        routeId: output.routeId,
+      },
+      pathTags: ["/dashboard"],
+      requestApis: buildRenderRequestApiObservations({
+        completeness: "complete",
+        observed: [],
+      }),
+    });
+
+    const proof = buildStaticLayoutReuseProof({
+      candidateObservation: observation,
+      candidateVariant: variant,
+      currentOutput: output,
+    });
+
+    const fallback = expectStaticLayoutProofRejection(
+      proof,
+      "CP_STATIC_LAYOUT_OBSERVATION_OUTPUT_KIND",
+    );
+    expect(fallback.fields).toEqual({
+      observationOutputKind: "app-rsc",
+    });
+  });
+
+  it("rejects static layout observation output mismatch", () => {
+    const candidateOutput = createLayoutOutput({
+      routeId: "route:/dashboard/settings",
+    });
+    const observationOutput = createLayoutOutput({
+      routeId: "route:/dashboard/profile",
+    });
+    const variant = buildLayoutVariant({ output: candidateOutput });
+    const observation = buildLayoutObservation({ output: observationOutput });
+
+    const proof = buildStaticLayoutReuseProof({
+      candidateObservation: observation,
+      candidateVariant: variant,
+      currentOutput: candidateOutput,
+    });
+
+    const fallback = expectStaticLayoutProofRejection(
+      proof,
+      "CP_STATIC_LAYOUT_OBSERVATION_OUTPUT_MISMATCH",
+    );
+    expect(fallback.fields).toMatchObject({
+      candidateRouteId: "route:/dashboard/settings",
+      field: "routeId",
+      observationRouteId: "route:/dashboard/profile",
+    });
+  });
+
+  it("rejects static layout identity mismatch", () => {
+    const currentOutput = createLayoutOutput({
+      layoutId: "layout:/dashboard",
+    });
+    const candidateOutput = createLayoutOutput({
+      layoutId: "layout:/dashboard/settings",
+    });
+    const variant = buildLayoutVariant({ output: candidateOutput });
+    const observation = buildLayoutObservation({ output: candidateOutput });
+
+    const proof = buildStaticLayoutReuseProof({
+      candidateObservation: observation,
+      candidateVariant: variant,
+      currentOutput,
+    });
+
+    const fallback = expectStaticLayoutProofRejection(proof, "CP_STATIC_LAYOUT_ID_MISMATCH");
+    expect(fallback.fields).toEqual({
+      candidateLayoutId: "layout:/dashboard/settings",
+      currentLayoutId: "layout:/dashboard",
+    });
+  });
+
+  it("rejects static layout root-boundary mismatch", () => {
+    const currentOutput = createLayoutOutput({
+      rootBoundaryId: "layout:/root-a",
+    });
+    const candidateOutput = createLayoutOutput({
+      rootBoundaryId: "layout:/root-b",
+    });
+    const variant = buildLayoutVariant({ output: candidateOutput });
+    const observation = buildLayoutObservation({ output: candidateOutput });
+
+    const proof = buildStaticLayoutReuseProof({
+      candidateObservation: observation,
+      candidateVariant: variant,
+      currentOutput,
+    });
+
+    const fallback = expectStaticLayoutProofRejection(
+      proof,
+      "CP_STATIC_LAYOUT_ROOT_BOUNDARY_MISMATCH",
+    );
+    expect(fallback.fields).toEqual({
+      candidateRootBoundaryId: "layout:/root-b",
+      currentRootBoundaryId: "layout:/root-a",
+    });
   });
 
   it("rejects unknown root-boundary identity instead of treating it as proof", () => {

--- a/tests/cache-proof.test.ts
+++ b/tests/cache-proof.test.ts
@@ -998,6 +998,27 @@ describe("disabled cache proof model", () => {
     expect(JSON.stringify(dynamicProof)).not.toContain("secret");
   });
 
+  it("rejects static layout proof when boundary outcome is not successful", () => {
+    const output = createLayoutOutput();
+    const variant = buildLayoutVariant({ output });
+    const observation = buildLayoutObservation({
+      boundaryOutcome: { kind: "error", digest: "ERR_TEST" },
+      output,
+    });
+
+    const proof = buildStaticLayoutReuseProof({
+      candidateObservation: observation,
+      candidateVariant: variant,
+      currentOutput: output,
+    });
+
+    const fallback = expectStaticLayoutProofRejection(proof, "CP_BOUNDARY_OUTCOME_MISMATCH");
+    expect(fallback.fields).toEqual({
+      candidateKind: "error",
+      expectedKind: "success",
+    });
+  });
+
   it("rejects private variant dimensions for static layout proof", () => {
     const output = createLayoutOutput();
     const variant = buildLayoutVariant({

--- a/tests/sorted-array.test.ts
+++ b/tests/sorted-array.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vite-plus/test";
+import { findSortedStringPosition } from "../packages/vinext/src/utils/sorted-array.js";
+
+describe("sorted array utilities", () => {
+  it("finds existing sorted string positions", () => {
+    const values = ["alpha", "bravo", "charlie", "delta"];
+
+    expect(findSortedStringPosition(values, "alpha")).toEqual({ found: true, index: 0 });
+    expect(findSortedStringPosition(values, "charlie")).toEqual({ found: true, index: 2 });
+    expect(findSortedStringPosition(values, "delta")).toEqual({ found: true, index: 3 });
+  });
+
+  it("returns insertion positions for missing sorted strings", () => {
+    const values = ["bravo", "delta"];
+
+    expect(findSortedStringPosition([], "alpha")).toEqual({ found: false, index: 0 });
+    expect(findSortedStringPosition(values, "alpha")).toEqual({ found: false, index: 0 });
+    expect(findSortedStringPosition(values, "charlie")).toEqual({ found: false, index: 1 });
+    expect(findSortedStringPosition(values, "echo")).toEqual({ found: false, index: 2 });
+  });
+});


### PR DESCRIPTION
## Overview

| Field | Detail |
| --- | --- |
| Task | Implements `#726-CACHE-09/11` and  `#726-CACHE-10` |
| Original issue | #726 |
| Core change | Adds disabled static layout reuse proof plus route variant budget admission |
| Primary files | `packages/vinext/src/server/cache-proof.ts`, `tests/cache-proof.test.ts` |
| Expected impact | No cache serving is enabled. Future cache authority gets proof and breaker primitives with focused coverage. |

> Bonk: please read issue #726 before reviewing this PR. The architectural big picture is the cache proof law from that issue: no proof, no reuse, and safe fallbacks must stay narrow and event-specific.

## Why

Reusable cache artifacts need owned proof, not incidental cache presence. For #726, static layout reuse must be backed by positive layout/root/boundary proof and negative render-observation proof. Variant cardinality also needs an owned breaker path so public cache dimensions cannot grow without a route-scoped ceiling.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| Static layout reuse | Missing data is not proof | Adds a disabled proof evaluator that rejects unknown roots, output mismatches, private/dynamic observations, private variant dimensions, and incomplete request API absence. |
| Runtime reuse | Proof model is not cache authority yet | Static layout proof carries `authorizesRuntimeReuse: false` and can only be attached to the disabled cache proof decision. |
| Variant budget | Cardinality must have a route-owned breaker | Adds route budget admission that lets duplicate variants through without consuming budget and rejects new over-budget variants with a structured fallback. |

## What changed

| Scenario / surface | Before | After |
| --- | --- | --- |
| Static layout artifact proof | Render observations and downgrades existed, but no static layout proof boundary consumed them. | `buildStaticLayoutReuseProof()` proves or rejects static layout eligibility without enabling reuse. |
| Private or dynamic layout observations | Downgrade classification existed independently of reuse proof. | Static layout proof rejects private, draft, dynamic fetch, incomplete, observed, or missing request API evidence before proof. |
| Route variant budget | `buildCacheVariant()` used a scalar existing count, so duplicates could be charged as new variants. | `buildCacheVariantWithRouteBudget()` and `enforceCacheVariantRouteBudget()` track canonical variant keys per route. |
| Cache serving | Disabled. | Still disabled. |

<details>
<summary>Maintainer review path</summary>

1. `packages/vinext/src/server/cache-proof.ts`
   - Review the new cache proof trace codes and static layout proof result types first.
   - Then read `buildStaticLayoutReuseProof()` for the ordered rejection gates.
   - Then read `enforceCacheVariantRouteBudget()` and `buildCacheVariantWithRouteBudget()` for `#726-CACHE-10`.

2. `tests/cache-proof.test.ts`
   - Review the static layout proof acceptance test and its disabled runtime reuse assertion.
   - Review negative proof coverage for observed/missing request APIs, private/dynamic downgrades, private dimensions, and unknown root identity.
   - Review route budget admission coverage for duplicate, second distinct, and over-budget variants.

</details>

<details>
<summary>Validation</summary>

Commands run:

```bash
vp check tests/cache-proof.test.ts packages/vinext/src/server/cache-proof.ts
vp test run tests/cache-proof.test.ts tests/app-elements.test.ts tests/app-page-cache.test.ts
```

Latest results:

- `vp check`: no formatting, lint, or type errors in the touched files.
- `vp test run`: 3 files passed, 121 tests passed.
- Review response: static layout proof now recomputes downgrade and request-API authority from raw observation fields, with stale-downgrade and duplicate-request-API coverage.
- Commit hooks also ran repository checks and `knip` while creating the commits.

</details>

<details>
<summary>Risk / compatibility</summary>

- Public API impact: internal server helper surface only.
- Runtime impact: no cache read path consumes the new proof, and no cache serving behavior is enabled.
- Cache/router/RSC impact: proof data is constructed and tested only at helper boundaries.
- Existing app risk: low. `buildCacheVariant()` no longer accepts the lossy scalar route count; route ceiling enforcement moves to the explicit route budget helpers.
- Compatibility oracle: vinext internal invariant from #726, not a Next.js public API parity change. Next.js segment-cache tests informed the layout-sharing shape, but this PR intentionally keeps vinext cache authority disabled.

</details>

<details>
<summary>Non-goals</summary>

- Does not serve static layouts from cache.
- Does not enable skip transport.
- Does not add runtime profile storage, artifact store reads, or distributed coordination.
- Does not claim full Cache Components parity.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| #726 | Architectural source for cache proof, static layout reuse, variant budget, and no-proof-no-reuse invariants. |
| `#726-CACHE-09/11` | Requested static layout reuse proof and private/dynamic downgrade coverage, disabled. |
| `#726-CACHE-10` | Folded-in route variant budget and breaker fallback scope. |
| Next.js `test/e2e/app-dir/segment-cache/prefetch-layout-sharing` | Layout sharing behavior informed the reuse class, while this PR keeps serving disabled. |
| Next.js cache-components headers/cookies/private tests | Private/dynamic request API behavior informed the downgrade refusal cases. |


