### PR TITLE
fix(app-page-render): surface invalid dynamic usage errors via flight in dev

### DIFF
--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -3,6 +3,7 @@ import type { ReactFormState } from "react-dom/client";
 import type { CachedAppPageValue } from "vinext/shims/cache";
 import { runWithFetchDedupe } from "vinext/shims/fetch-cache";
 import { AppElementsWire, isAppElementsRecord, type AppOutgoingElements } from "./app-elements.js";
+import { hasDigest } from "./app-rsc-errors.js";
 import {
   finalizeAppPageHtmlCacheResponse,
   finalizeAppPageRscCacheResponse,
@@ -215,7 +216,15 @@ function createAppPageArtifactCompatibility(
  * "use cache" may be caught by user try/catch and silently swallowed — this
  * wrapper waits for the stream to drain and surfaces any recorded error to the
  * terminal (and, via HMR, the browser dev overlay).
- * Ported from Next.js: https://github.com/vercel/next.js/commit/f5e54c06726b571a042fce67417e40a29f6b8689
+ *
+ * Dedups against React's Flight error chunk: if the recorded error already
+ * carries a `digest`, React's serverComponentsErrorHandler has already stamped
+ * it and emitted it into the RSC stream. Skipping `console.error` prevents
+ * double-logging. Caught cases (no digest) still surface here.
+ *
+ * Ported from Next.js:
+ *   https://github.com/vercel/next.js/commit/f5e54c06726b571a042fce67417e40a29f6b8689
+ *   https://github.com/vercel/next.js/pull/93706
  */
 function wrapRscResponseForDevErrorReporting(
   response: Response,
@@ -229,7 +238,9 @@ function wrapRscResponseForDevErrorReporting(
     if (consumed) return;
     consumed = true;
     const error = consumeInvalidDynamicUsageError();
-    if (error) {
+    if (!error) return;
+    // Dedup: React already emitted this error as a Flight error chunk.
+    if (!hasDigest(error)) {
       console.error("[vinext] Invalid dynamic usage:", error);
     }
   };

--- a/packages/vinext/src/server/app-rsc-errors.ts
+++ b/packages/vinext/src/server/app-rsc-errors.ts
@@ -27,7 +27,7 @@ type CreateRscOnErrorHandlerOptions = {
   requestInfo: RscRequestInfo | null;
 };
 
-function hasDigest(error: unknown): error is { digest: unknown } {
+export function hasDigest(error: unknown): error is { digest: unknown } {
   return Boolean(error && typeof error === "object" && "digest" in error);
 }
 

--- a/tests/app-page-render.test.ts
+++ b/tests/app-page-render.test.ts
@@ -1011,3 +1011,199 @@ describe("layoutFlags injection into RSC payload", () => {
     }
   });
 });
+
+describe("dev error reporting for invalid dynamic usage — issue #1195", () => {
+  it("does not double-log an uncaught error that React already stamped with a digest", async () => {
+    const common = createCommonOptions();
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const errorWithDigest = Object.assign(new Error("cookies() inside use cache"), {
+      digest: "DYNAMIC_SERVER_USAGE",
+    });
+    let consumedError: unknown = null;
+    const consumeInvalidDynamicUsageError = vi.fn(() => {
+      if (consumedError !== null) return null;
+      consumedError = errorWithDigest;
+      return errorWithDigest;
+    });
+
+    const response = await renderAppPageLifecycle({
+      ...common.options,
+      consumeInvalidDynamicUsageError,
+      isRscRequest: true,
+    });
+
+    expect(response.status).toBe(200);
+    await response.text();
+    expect(consumeInvalidDynamicUsageError).toHaveBeenCalled();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("logs a caught error that has no digest (React never saw it)", async () => {
+    const common = createCommonOptions();
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const errorWithoutDigest = new Error("cookies() inside use cache");
+    let consumedError: unknown = null;
+    const consumeInvalidDynamicUsageError = vi.fn(() => {
+      if (consumedError !== null) return null;
+      consumedError = errorWithoutDigest;
+      return errorWithoutDigest;
+    });
+
+    const response = await renderAppPageLifecycle({
+      ...common.options,
+      consumeInvalidDynamicUsageError,
+      isRscRequest: true,
+    });
+
+    expect(response.status).toBe(200);
+    await response.text();
+    expect(consumeInvalidDynamicUsageError).toHaveBeenCalled();
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "[vinext] Invalid dynamic usage:",
+      errorWithoutDigest,
+    );
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("does not log when no invalid dynamic usage error was recorded", async () => {
+    const common = createCommonOptions();
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const consumeInvalidDynamicUsageError = vi.fn(() => null);
+
+    const response = await renderAppPageLifecycle({
+      ...common.options,
+      consumeInvalidDynamicUsageError,
+      isRscRequest: true,
+    });
+
+    expect(response.status).toBe(200);
+    await response.text();
+    expect(consumeInvalidDynamicUsageError).toHaveBeenCalled();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("still dedups when the stream is cancelled before full consumption", async () => {
+    const common = createCommonOptions();
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const errorWithDigest = Object.assign(new Error("cookies() inside use cache"), {
+      digest: "DYNAMIC_SERVER_USAGE",
+    });
+    let consumedError: unknown = null;
+    const consumeInvalidDynamicUsageError = vi.fn(() => {
+      if (consumedError !== null) return null;
+      consumedError = errorWithDigest;
+      return errorWithDigest;
+    });
+
+    const response = await renderAppPageLifecycle({
+      ...common.options,
+      consumeInvalidDynamicUsageError,
+      isRscRequest: true,
+    });
+
+    // Cancel the stream before consuming any bytes
+    if (response.body) {
+      await response.body.cancel("client disconnect");
+    }
+    expect(consumeInvalidDynamicUsageError).toHaveBeenCalled();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("still dedups when the stream errors during pull", async () => {
+    const common = createCommonOptions();
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const errorWithDigest = Object.assign(new Error("cookies() inside use cache"), {
+      digest: "DYNAMIC_SERVER_USAGE",
+    });
+    let consumedError: unknown = null;
+    const consumeInvalidDynamicUsageError = vi.fn(() => {
+      if (consumedError !== null) return null;
+      consumedError = errorWithDigest;
+      return errorWithDigest;
+    });
+
+    const renderToReadableStream = vi.fn(
+      () =>
+        new ReadableStream<Uint8Array>({
+          pull() {
+            throw new Error("stream blowup");
+          },
+        }),
+    );
+
+    const response = await renderAppPageLifecycle({
+      ...common.options,
+      consumeInvalidDynamicUsageError,
+      isRscRequest: true,
+      renderToReadableStream,
+    });
+
+    // Attempting to consume the stream will trigger the error
+    try {
+      await response.text();
+    } catch {
+      // Expected
+    }
+    expect(consumeInvalidDynamicUsageError).toHaveBeenCalled();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("does not apply the wrapper in production mode", async () => {
+    const common = createCommonOptions();
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const errorWithoutDigest = new Error("cookies() inside use cache");
+    const consumeInvalidDynamicUsageError = vi.fn(() => errorWithoutDigest);
+
+    const response = await renderAppPageLifecycle({
+      ...common.options,
+      consumeInvalidDynamicUsageError,
+      isProduction: true,
+      isRscRequest: true,
+    });
+
+    expect(response.status).toBe(200);
+    await response.text();
+    // In production the wrapper is skipped entirely
+    expect(consumeInvalidDynamicUsageError).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("does not apply the wrapper for HTML (non-RSC) requests", async () => {
+    const common = createCommonOptions();
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const errorWithoutDigest = new Error("cookies() inside use cache");
+    const consumeInvalidDynamicUsageError = vi.fn(() => errorWithoutDigest);
+
+    const response = await renderAppPageLifecycle({
+      ...common.options,
+      consumeInvalidDynamicUsageError,
+      isRscRequest: false,
+    });
+
+    await response.text();
+    // HTML path intentionally defers dev error reporting
+    expect(consumeInvalidDynamicUsageError).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+
+    consoleErrorSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
Wraps the RSC response body in dev mode to check for invalid dynamic usage errors (e.g. `cookies()`/`headers()` inside "use cache") after the stream is fully consumed. This mirrors Next.js behavior where `workStore.invalidDynamicUsageError` is surfaced via the Flight pipeline so errors caught by user try/catch don't silently disappear.

- Dedups against React's Flight error chunk using digest presence
- Only applies to RSC responses (client-side navigations) in dev
- HTML path intentionally deferred; error still flows through `rscErrorTracker`
- Ported from Next.js: https://github.com/vercel/next.js/commit/f5e54c06726b571a042fce67417e40a29f6b8689

Closes #1195