### PR TITLE
test: regression tests for issue #1196 (catch-all route params with basePath + rewrites + middleware)

### DIFF
--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -3886,6 +3886,76 @@ describe("router __NEXT_DATA__ correctness (Pages Router)", () => {
     expect(nextData.page).toBe("/shallow-test");
     expect(nextData.props.pageProps.gsspCallId).toBeGreaterThan(0);
   });
+
+  // Ported from Next.js: test/e2e/middleware-dynamic-basepath-matcher-rewrites
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-dynamic-basepath-matcher-rewrites
+  // Regression test for GitHub issue #1196 — catch-all + basePath + rewrites + middleware.
+  it("catch-all route params are preserved with basePath + rewrites + middleware", async () => {
+    const tmpRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "vinext-pages-catchall-basepath-"));
+    const rootNodeModules = path.resolve(import.meta.dirname, "../node_modules");
+
+    try {
+      await fsp.symlink(rootNodeModules, path.join(tmpRoot, "node_modules"), "junction");
+      await fsp.mkdir(path.join(tmpRoot, "pages"), { recursive: true });
+
+      await fsp.writeFile(path.join(tmpRoot, "package.json"), JSON.stringify({ type: "module" }));
+      await fsp.writeFile(
+        path.join(tmpRoot, "next.config.mjs"),
+        `export default {
+          basePath: "/docs",
+          async rewrites() {
+            return {
+              beforeFiles: [
+                { source: "/before-rewrite", destination: "/about" },
+              ],
+            };
+          },
+        };\n`,
+      );
+      await fsp.writeFile(
+        path.join(tmpRoot, "middleware.ts"),
+        `import { NextResponse } from "next/server";
+export const config = { matcher: "/:path*" };
+export default function middleware() {
+  return NextResponse.next();
+}
+`,
+      );
+      await fsp.writeFile(
+        path.join(tmpRoot, "pages", "[...path].tsx"),
+        `export default function CatchAllPage({ path }: { path: string[] }) {
+          return (
+            <div>
+              <h1 data-testid="page-title">CatchAll</h1>
+              <p data-testid="query-path">{JSON.stringify(path)}</p>
+            </div>
+          );
+        }
+
+        export async function getServerSideProps({ params }: { params: { path: string[] } }) {
+          return { props: { path: params.path } };
+        }
+`,
+      );
+
+      const { server, baseUrl } = await startFixtureServer(tmpRoot, { appRouter: false });
+      try {
+        const res = await fetch(`${baseUrl}/docs/first`);
+        expect(res.status).toBe(200);
+        const html = await res.text();
+        const match = html.match(/<script>window\.__NEXT_DATA__\s*=\s*({[\s\S]*?})<\/script>/);
+        expect(match).toBeTruthy();
+        const nextData = JSON.parse(match![1]);
+        expect(nextData.page).toBe("/[...path]");
+        expect(nextData.query).toEqual({ path: ["first"] });
+        expect(html).toContain("CatchAll");
+      } finally {
+        await server.close();
+      }
+    } finally {
+      await fsp.rm(tmpRoot, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("Pages Router dev ISR regeneration", () => {

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -3938,12 +3938,12 @@ export default function middleware() {
 `,
       );
 
-      const { server, baseUrl } = await startFixtureServer(tmpRoot, { appRouter: false });
+      const { server, baseUrl } = await startFixtureServer(tmpRoot);
       try {
         const res = await fetch(`${baseUrl}/docs/first`);
         expect(res.status).toBe(200);
         const html = await res.text();
-        const match = html.match(/<script>window\.__NEXT_DATA__\s*=\s*({[\s\S]*?})<\/script>/);
+        const match = html.match(/<script>window\.__NEXT_DATA__\s*=\s*({.*?})<\/script>/);
         expect(match).toBeTruthy();
         const nextData = JSON.parse(match![1]);
         expect(nextData.page).toBe("/[...path]");

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -11652,7 +11652,7 @@ describe("Pages Router concurrent navigation", () => {
   // Ported from Next.js: test/e2e/middleware-dynamic-basepath-matcher-rewrites
   // https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-dynamic-basepath-matcher-rewrites
   // Issue #1196 — catch-all router.query must not be corrupted by basePath + rewrites + middleware.
-  it("preserves catch-all router.query after client navigation with basePath", async () => {
+  it("initializes catch-all router.query from __NEXT_DATA__ with basePath", async () => {
     const previousWindow = (globalThis as any).window;
     const previousBasePath = process.env.__NEXT_ROUTER_BASEPATH;
     const { win } = createNavWindow();
@@ -11696,12 +11696,12 @@ describe("Pages Router concurrent navigation", () => {
       } else {
         process.env.__NEXT_ROUTER_BASEPATH = previousBasePath;
       }
-      vi.resetModules();
       if (previousWindow === undefined) {
         delete (globalThis as any).window;
       } else {
         (globalThis as any).window = previousWindow;
       }
+      vi.resetModules();
     }
   });
 });

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -11704,6 +11704,107 @@ describe("Pages Router concurrent navigation", () => {
       vi.resetModules();
     }
   });
+
+  // Ported from Next.js: test/e2e/middleware-dynamic-basepath-matcher-rewrites
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-dynamic-basepath-matcher-rewrites
+  // Issue #1196 — during a client-side <Link>/Router.push() navigation on a
+  // catch-all route under basePath, router.query.<catchAll> must reflect the
+  // destination URL segments and not be corrupted by intermediate data-URL
+  // handling. In Next.js the corruption originated in getMiddlewareData where
+  // basePath wasn't stripped from the _next/data/... URL before the catch-all
+  // route regex matched against it. vinext's navigateClient reads __NEXT_DATA__
+  // directly from the response HTML rather than constructing _next/data URLs,
+  // so it doesn't have that architectural pattern, but the route-param
+  // extraction path that ultimately produces router.query must still strip
+  // basePath from the resolved pathname before matching the catch-all pattern.
+  // This test exercises Router.push() through performNavigation → pushState
+  // and verifies that router.query.path reflects the destination segments.
+  it("preserves catch-all router.query after client navigation with basePath", async () => {
+    const previousWindow = (globalThis as any).window;
+    const previousBasePath = process.env.__NEXT_ROUTER_BASEPATH;
+    const originalFetch = globalThis.fetch;
+    const { win } = createNavWindow();
+
+    // Simulate being on a catch-all page under basePath when navigation starts.
+    process.env.__NEXT_ROUTER_BASEPATH = "/docs";
+    win.location.pathname = "/docs/first";
+    win.location.href = "http://localhost/docs/first";
+    win.__NEXT_DATA__ = {
+      page: "/[...path]",
+      query: { path: ["first"] },
+      isFallback: false,
+      props: { pageProps: {} },
+      // The catch-all module file is referenced through a Vite-style path that
+      // passes isValidModulePath() (no ".." directory-traversal segments).
+      __vinext: { pageModuleUrl: "/@fs/pages/catchall.js" },
+    };
+
+    (globalThis as any).window = win;
+    vi.resetModules();
+
+    // Capture router state mid-navigation, after pushState has updated
+    // window.location but before navigateClient's dynamic import runs (which
+    // would fail in this test env). useRouter() reads from window.location
+    // and window.__NEXT_DATA__ at provider-mount time, so rendering a Probe
+    // inside the mocked fetch handler observes the post-pushState state —
+    // exactly the code path that #1196 corrupts in Next.js.
+    const React = await import("react");
+    const { renderToStaticMarkup } = await import("react-dom/server");
+    const routerModule = await import("../packages/vinext/src/shims/router.js");
+
+    let capturedRouter: any;
+    function Probe() {
+      capturedRouter = routerModule.useRouter();
+      return React.createElement("span", null, "ok");
+    }
+
+    globalThis.fetch = async (_url: any, _init: any) => {
+      renderToStaticMarkup(routerModule.wrapWithRouterContext(React.createElement(Probe)));
+      // Return HTML containing the destination's __NEXT_DATA__. The dynamic
+      // import of the page module fails in this test env, which is fine — the
+      // assertion above has already captured router.query.
+      return new Response(
+        buildNavHtml("/[...path]", "/@fs/pages/catchall.js", { path: ["second"] }),
+      );
+    };
+
+    // Silence the expected routeChangeError from the page-module import failure.
+    const onRouteChangeError = vi.fn();
+
+    try {
+      const Router = routerModule.default;
+      Router.events.on("routeChangeError", onRouteChangeError);
+
+      // Router.push() takes an app-relative path; basePath is added internally
+      // by performNavigation → toBrowserNavigationHref before pushState.
+      await Router.push("/second");
+
+      // pushState has fired, so location.pathname is "/docs/second".
+      // stripBasePath() removes "/docs", and the catch-all pattern
+      // "/[...path]" from __NEXT_DATA__.page extracts { path: ["second"] }.
+      expect(capturedRouter.pathname).toBe("/[...path]");
+      expect(capturedRouter.asPath).toBe("/second");
+      expect(capturedRouter.query.path).toEqual(["second"]);
+      // Negative assertion mirroring #1196: query.path must NOT contain
+      // _next/data segments.
+      expect(capturedRouter.query.path).not.toContain("_next");
+      expect(capturedRouter.query.path).not.toContain("data");
+    } finally {
+      routerModule.default.events.off("routeChangeError", onRouteChangeError);
+      globalThis.fetch = originalFetch;
+      if (previousBasePath === undefined) {
+        delete process.env.__NEXT_ROUTER_BASEPATH;
+      } else {
+        process.env.__NEXT_ROUTER_BASEPATH = previousBasePath;
+      }
+      if (previousWindow === undefined) {
+        delete (globalThis as any).window;
+      } else {
+        (globalThis as any).window = previousWindow;
+      }
+      vi.resetModules();
+    }
+  });
 });
 
 describe("next/server enhancements", () => {

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -10833,10 +10833,14 @@ describe("Pages Router concurrent navigation", () => {
    * Build a minimal HTML response that navigateClient can parse.
    * Includes __NEXT_DATA__ with a pageModuleUrl pointing to the given path.
    */
-  function buildNavHtml(page: string, pageModuleUrl: string): string {
+  function buildNavHtml(
+    page: string,
+    pageModuleUrl: string,
+    query: Record<string, unknown> = {},
+  ): string {
     const nextData = JSON.stringify({
       page,
-      query: {},
+      query,
       isFallback: false,
       props: { pageProps: { page } },
       __vinext: { pageModuleUrl },
@@ -11642,6 +11646,62 @@ describe("Pages Router concurrent navigation", () => {
         (globalThis as any).window = previousWindow;
       }
       globalThis.fetch = originalFetch;
+    }
+  });
+
+  // Ported from Next.js: test/e2e/middleware-dynamic-basepath-matcher-rewrites
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-dynamic-basepath-matcher-rewrites
+  // Issue #1196 — catch-all router.query must not be corrupted by basePath + rewrites + middleware.
+  it("preserves catch-all router.query after client navigation with basePath", async () => {
+    const previousWindow = (globalThis as any).window;
+    const previousBasePath = process.env.__NEXT_ROUTER_BASEPATH;
+    const { win } = createNavWindow();
+
+    // Simulate being on a catch-all page under basePath
+    process.env.__NEXT_ROUTER_BASEPATH = "/docs";
+    win.location.pathname = "/docs/first";
+    win.location.href = "http://localhost/docs/first";
+
+    // Server-rendered __NEXT_DATA__ for the catch-all page
+    win.__NEXT_DATA__ = {
+      page: "/[...path]",
+      query: { path: ["first"] },
+      isFallback: false,
+      props: { pageProps: {} },
+      __vinext: { pageModuleUrl: "/@fs/pages/[...path].js" },
+    };
+
+    (globalThis as any).window = win;
+    vi.resetModules();
+
+    const React = await import("react");
+    const { renderToStaticMarkup } = await import("react-dom/server");
+    const routerModule = await import("../packages/vinext/src/shims/router.js");
+
+    let capturedRouter: any;
+    function Probe() {
+      capturedRouter = routerModule.useRouter();
+      return React.createElement("span", null, "ok");
+    }
+
+    try {
+      renderToStaticMarkup(routerModule.wrapWithRouterContext(React.createElement(Probe)));
+
+      expect(capturedRouter.query.path).toEqual(["first"]);
+      expect(capturedRouter.pathname).toBe("/[...path]");
+      expect(capturedRouter.asPath).toBe("/first");
+    } finally {
+      if (previousBasePath === undefined) {
+        delete process.env.__NEXT_ROUTER_BASEPATH;
+      } else {
+        process.env.__NEXT_ROUTER_BASEPATH = previousBasePath;
+      }
+      vi.resetModules();
+      if (previousWindow === undefined) {
+        delete (globalThis as any).window;
+      } else {
+        (globalThis as any).window = previousWindow;
+      }
     }
   });
 });


### PR DESCRIPTION
Adds integration and unit tests to verify that catch-all route params are preserved when `basePath`, `rewrites`, and `middleware` are combined.

**Changes:**
- `tests/pages-router.test.ts`: Integration test checks server-rendered `__NEXT_DATA__` contains correct `page` and `query` for a catch-all route.
- `tests/shims.test.ts`: Unit test verifies client-side `router.query` stays intact for a catch-all page under `basePath`.

Both tests are ported from the Next.js test suite and target the regression described in GitHub issue #1196.

Simplify fixes applied:
- Use `[\s\S]*?` in the `__NEXT_DATA__` regex for multiline safety.
- Use `await fsp.rm` instead of `fs.rmSync` for consistent async cleanup.

Closes #1196