### PR TITLE
fix(router): keep next/router import free of popstate side effects

### DIFF
--- a/packages/vinext/src/entries/pages-client-entry.ts
+++ b/packages/vinext/src/entries/pages-client-entry.ts
@@ -47,10 +47,7 @@ export async function generateClientEntry(
 import "vinext/instrumentation-client";
 import React from "react";
 import { hydrateRoot } from "react-dom/client";
-// Eagerly import the router shim so its module-level popstate listener is
-// registered.  Without this, browser back/forward buttons do nothing because
-// navigateClient() is never invoked on history changes.
-import "next/router";
+import { installPagesRouterRuntime } from "vinext/pages-router-runtime";
 
 const pageLoaders = {
 ${loaderEntries.join(",\n")}
@@ -107,6 +104,7 @@ async function hydrate() {
 
   const root = hydrateRoot(container, element);
   window.__VINEXT_ROOT__ = root;
+  installPagesRouterRuntime();
   window.__VINEXT_HYDRATED_AT = performance.now();
 }
 

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -1111,6 +1111,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             "vinext/cache-runtime": path.join(shimsDir, "cache-runtime"),
             "vinext/navigation-state": path.join(shimsDir, "navigation-state"),
             "vinext/unified-request-context": path.join(shimsDir, "unified-request-context"),
+            "vinext/pages-router-runtime": path.join(shimsDir, "pages-router-runtime"),
             "vinext/router-state": path.join(shimsDir, "router-state"),
             "vinext/head-state": path.join(shimsDir, "head-state"),
             "vinext/i18n-state": path.join(shimsDir, "i18n-state"),

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -893,6 +893,7 @@ export function createSSRHandler(
 import "vinext/instrumentation-client";
 import React from "react";
 import { hydrateRoot } from "react-dom/client";
+import { installPagesRouterRuntime } from "vinext/pages-router-runtime";
 import { wrapWithRouterContext } from "next/router";
 
 const nextData = window.__NEXT_DATA__;
@@ -917,6 +918,7 @@ async function hydrate() {
   element = wrapWithRouterContext(element);
   const root = hydrateRoot(document.getElementById("__next"), element);
   window.__VINEXT_ROOT__ = root;
+  installPagesRouterRuntime();
   window.__VINEXT_HYDRATED_AT = performance.now();
 }
 hydrate();

--- a/packages/vinext/src/shims/pages-router-runtime.ts
+++ b/packages/vinext/src/shims/pages-router-runtime.ts
@@ -1,0 +1,21 @@
+type PagesRouterPopStateHandler = (event: PopStateEvent) => void;
+
+let pagesRouterPopStateHandler: PagesRouterPopStateHandler | undefined;
+let pagesRouterRuntimeInstalled = false;
+
+export function setPagesRouterPopStateHandler(handler: PagesRouterPopStateHandler): void {
+  pagesRouterPopStateHandler = handler;
+}
+
+export function installPagesRouterRuntime(): void {
+  if (typeof window === "undefined" || pagesRouterRuntimeInstalled) {
+    return;
+  }
+
+  if (!pagesRouterPopStateHandler) {
+    throw new Error("[vinext] Pages Router runtime installed before next/router was initialized");
+  }
+
+  pagesRouterRuntimeInstalled = true;
+  window.addEventListener("popstate", pagesRouterPopStateHandler);
+}

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -832,7 +832,7 @@ function handlePagesRouterPopState(e: PopStateEvent): void {
 
   // Check beforePopState callback
   if (_beforePopStateCb !== undefined) {
-    const shouldContinue = (_beforePopStateCb as BeforePopStateCallback)({
+    const shouldContinue = _beforePopStateCb({
       url: appUrl,
       as: appUrl,
       options: { shallow: false },

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -35,6 +35,7 @@ import {
 } from "../utils/query.js";
 import { matchRoutePattern, routePatternParts } from "../routing/route-pattern.js";
 import { scrollToHashTarget } from "./hash-scroll.js";
+import { setPagesRouterPopStateHandler } from "./pages-router-runtime.js";
 
 /** basePath from next.config.js, injected by the plugin at build time */
 const __basePath: string = process.env.__NEXT_ROUTER_BASEPATH ?? "";
@@ -783,10 +784,11 @@ export function useRouter(): NextRouter {
 function PagesRouterProvider({ children }: { children: ReactNode }): ReactElement {
   const [{ pathname, query, asPath }, setState] = useState(getPathnameAndQuery);
 
-  // Popstate is handled by the module-level listener below so beforePopState()
-  // is consistently enforced regardless of hook consumers. Keep URL snapshot
-  // subscriptions at the provider boundary so many useRouter() calls share one
-  // router state and one vinext:navigate listener.
+  // Popstate is handled by the Pages Router client entry via
+  // installPagesRouterRuntime() so beforePopState() is consistently enforced
+  // regardless of hook consumers. Keep URL snapshot subscriptions at the
+  // provider boundary so many useRouter() calls share one router state and one
+  // vinext:navigate listener.
   useEffect(() => {
     const onNavigate = ((_e: CustomEvent) => {
       setState(getPathnameAndQuery());
@@ -821,62 +823,59 @@ let _beforePopStateCb: BeforePopStateCallback | undefined;
 let _lastPathnameAndSearch =
   typeof window !== "undefined" ? window.location.pathname + window.location.search : "";
 
-// Module-level popstate listener: handles browser back/forward by re-rendering
-// the React root with the page at the new URL. This runs regardless of whether
-// any component calls useRouter().
-if (typeof window !== "undefined") {
-  window.addEventListener("popstate", (e: PopStateEvent) => {
-    const browserUrl = window.location.pathname + window.location.search;
-    const appUrl = stripBasePath(window.location.pathname, __basePath) + window.location.search;
+function handlePagesRouterPopState(e: PopStateEvent): void {
+  const browserUrl = window.location.pathname + window.location.search;
+  const appUrl = stripBasePath(window.location.pathname, __basePath) + window.location.search;
 
-    // Detect hash-only back/forward: pathname+search unchanged, only hash differs.
-    const isHashOnly = browserUrl === _lastPathnameAndSearch;
+  // Detect hash-only back/forward: pathname+search unchanged, only hash differs.
+  const isHashOnly = browserUrl === _lastPathnameAndSearch;
 
-    // Check beforePopState callback
-    if (_beforePopStateCb !== undefined) {
-      const shouldContinue = (_beforePopStateCb as BeforePopStateCallback)({
-        url: appUrl,
-        as: appUrl,
-        options: { shallow: false },
-      });
-      if (!shouldContinue) return;
-    }
+  // Check beforePopState callback
+  if (_beforePopStateCb !== undefined) {
+    const shouldContinue = (_beforePopStateCb as BeforePopStateCallback)({
+      url: appUrl,
+      as: appUrl,
+      options: { shallow: false },
+    });
+    if (!shouldContinue) return;
+  }
 
-    // Update tracker only after beforePopState confirms navigation proceeds.
-    // If beforePopState cancels, the tracker must retain the previous value
-    // so the next popstate compares against the correct baseline.
-    _lastPathnameAndSearch = browserUrl;
+  // Update tracker only after beforePopState confirms navigation proceeds.
+  // If beforePopState cancels, the tracker must retain the previous value
+  // so the next popstate compares against the correct baseline.
+  _lastPathnameAndSearch = browserUrl;
 
-    if (isHashOnly) {
-      // Hash-only back/forward — no page fetch needed
-      const hashUrl = appUrl + window.location.hash;
-      routerEvents.emit("hashChangeStart", hashUrl, { shallow: false });
-      scrollToHashTarget(window.location.hash);
-      routerEvents.emit("hashChangeComplete", hashUrl, { shallow: false });
+  if (isHashOnly) {
+    // Hash-only back/forward — no page fetch needed
+    const hashUrl = appUrl + window.location.hash;
+    routerEvents.emit("hashChangeStart", hashUrl, { shallow: false });
+    scrollToHashTarget(window.location.hash);
+    routerEvents.emit("hashChangeComplete", hashUrl, { shallow: false });
+    dispatchNavigateEvent();
+    return;
+  }
+
+  const fullAppUrl = appUrl + window.location.hash;
+  routerEvents.emit("routeChangeStart", fullAppUrl, { shallow: false });
+  // Note: The browser has already updated window.location by the time popstate
+  // fires, so this is not truly "before" the URL change. In Next.js the popstate
+  // handler calls replaceState to store history metadata — beforeHistoryChange
+  // precedes that call, not the URL change itself. We emit it here for API
+  // compatibility.
+  routerEvents.emit("beforeHistoryChange", fullAppUrl, { shallow: false });
+  void (async () => {
+    const result = await runNavigateClient(browserUrl, fullAppUrl);
+    if (result === "completed") {
+      routerEvents.emit("routeChangeComplete", fullAppUrl, { shallow: false });
+      restoreScrollPosition(e.state);
       dispatchNavigateEvent();
-      return;
     }
-
-    const fullAppUrl = appUrl + window.location.hash;
-    routerEvents.emit("routeChangeStart", fullAppUrl, { shallow: false });
-    // Note: The browser has already updated window.location by the time popstate
-    // fires, so this is not truly "before" the URL change. In Next.js the popstate
-    // handler calls replaceState to store history metadata — beforeHistoryChange
-    // precedes that call, not the URL change itself. We emit it here for API
-    // compatibility.
-    routerEvents.emit("beforeHistoryChange", fullAppUrl, { shallow: false });
-    void (async () => {
-      const result = await runNavigateClient(browserUrl, fullAppUrl);
-      if (result === "completed") {
-        routerEvents.emit("routeChangeComplete", fullAppUrl, { shallow: false });
-        restoreScrollPosition(e.state);
-        dispatchNavigateEvent();
-      }
-      // "cancelled": superseded by a newer navigation, so this popstate no longer wins.
-      // "failed": runNavigateClient already scheduled the hard-navigation fallback.
-    })();
-  });
+    // "cancelled": superseded by a newer navigation, so this popstate no longer wins.
+    // "failed": runNavigateClient already scheduled the hard-navigation fallback.
+  })();
 }
+
+setPagesRouterPopStateHandler(handlePagesRouterPopState);
 
 /**
  * Wrap a React element in a RouterContext.Provider so that

--- a/tests/e2e/app-router/navigation-regressions.spec.ts
+++ b/tests/e2e/app-router/navigation-regressions.spec.ts
@@ -6,6 +6,11 @@ import { waitForAppRouterHydration } from "../helpers";
 // etc.). Port 4174 is the vite preview default for the app-basic fixture.
 const BASE = "http://localhost:4174";
 
+type RouterSideEffectWindow = Window & {
+  __APP_ROUTER_HISTORY_MARKER__?: string;
+  __NEXT_ROUTER_IMPORTED__?: boolean;
+};
+
 test.describe("Navigation regression tests (#652 Firefox hang fix)", () => {
   test("cross-route navigation completes without hanging", async ({ page }) => {
     await page.goto(`${BASE}/nav-flash/link-sync`);
@@ -69,6 +74,51 @@ test.describe("Navigation regression tests (#652 Firefox hang fix)", () => {
     await page.goForward();
     await expect(page.locator("#list-title")).toHaveText("Nav Flash List", { timeout: 10_000 });
     expect(page.url()).toBe(`${BASE}/nav-flash/list`);
+  });
+
+  test("importing next/router in an App Router client bundle does not hijack back/forward", async ({
+    page,
+  }) => {
+    const documentRequests: string[] = [];
+    page.on("request", (request) => {
+      if (request.isNavigationRequest() && request.resourceType() === "document") {
+        documentRequests.push(request.url());
+      }
+    });
+
+    await page.goto(`${BASE}/router-side-effect-leak`);
+    await waitForAppRouterHydration(page);
+    await expect(page.locator("h1")).toHaveText("Router side effect leak source");
+    await expect(page.locator("#router-shim-imported")).toHaveText("router shim imported");
+    await expect
+      .poll(() => page.evaluate(() => (window as RouterSideEffectWindow).__NEXT_ROUTER_IMPORTED__))
+      .toBe(true);
+
+    await page.evaluate(() => {
+      (window as RouterSideEffectWindow).__APP_ROUTER_HISTORY_MARKER__ = "alive";
+    });
+    documentRequests.length = 0;
+
+    await page.click("#side-effect-destination-link");
+    await expect(page.locator("h1")).toHaveText("Router side effect leak destination", {
+      timeout: 10_000,
+    });
+
+    await page.goBack();
+    await expect(page.locator("h1")).toHaveText("Router side effect leak source", {
+      timeout: 10_000,
+    });
+
+    await page.goForward();
+    await expect(page.locator("h1")).toHaveText("Router side effect leak destination", {
+      timeout: 10_000,
+    });
+
+    const marker = await page.evaluate(
+      () => (window as RouterSideEffectWindow).__APP_ROUTER_HISTORY_MARKER__,
+    );
+    expect(marker).toBe("alive");
+    expect(documentRequests).toEqual([]);
   });
 
   test("rapid same-route navigation settles correctly", async ({ page }) => {

--- a/tests/fixtures/app-basic/app/router-side-effect-leak/destination/page.tsx
+++ b/tests/fixtures/app-basic/app/router-side-effect-leak/destination/page.tsx
@@ -1,0 +1,7 @@
+export default function RouterSideEffectLeakDestinationPage() {
+  return (
+    <main>
+      <h1>Router side effect leak destination</h1>
+    </main>
+  );
+}

--- a/tests/fixtures/app-basic/app/router-side-effect-leak/page.tsx
+++ b/tests/fixtures/app-basic/app/router-side-effect-leak/page.tsx
@@ -1,0 +1,14 @@
+import Link from "next/link";
+import { RouterImporter } from "./router-importer";
+
+export default function RouterSideEffectLeakPage() {
+  return (
+    <main>
+      <h1>Router side effect leak source</h1>
+      <RouterImporter />
+      <Link id="side-effect-destination-link" href="/router-side-effect-leak/destination">
+        Destination
+      </Link>
+    </main>
+  );
+}

--- a/tests/fixtures/app-basic/app/router-side-effect-leak/router-importer.tsx
+++ b/tests/fixtures/app-basic/app/router-side-effect-leak/router-importer.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { useEffect } from "react";
+import Router from "next/router";
+
+declare global {
+  interface Window {
+    __NEXT_ROUTER_IMPORTED__?: boolean;
+  }
+}
+
+export function RouterImporter() {
+  useEffect(() => {
+    window.__NEXT_ROUTER_IMPORTED__ = typeof Router.beforePopState === "function";
+  }, []);
+
+  return <p id="router-shim-imported">router shim imported</p>;
+}

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -10751,6 +10751,54 @@ describe("Pages Router router helpers", () => {
 });
 
 describe("Pages Router concurrent navigation", () => {
+  it("does not install the Pages Router popstate runtime when next/router is imported", async () => {
+    const previousWindow = (globalThis as any).window;
+    const { win } = createNavWindow();
+    win.addEventListener = vi.fn();
+    (globalThis as any).window = win;
+
+    try {
+      vi.resetModules();
+      await import("../packages/vinext/src/shims/router.js");
+
+      expect(win.addEventListener).not.toHaveBeenCalledWith("popstate", expect.any(Function));
+    } finally {
+      vi.resetModules();
+      if (previousWindow === undefined) {
+        delete (globalThis as any).window;
+      } else {
+        (globalThis as any).window = previousWindow;
+      }
+    }
+  });
+
+  it("installPagesRouterRuntime registers the Pages Router popstate handler once", async () => {
+    const previousWindow = (globalThis as any).window;
+    const { win } = createNavWindow();
+    win.addEventListener = vi.fn();
+    (globalThis as any).window = win;
+
+    try {
+      vi.resetModules();
+      await import("../packages/vinext/src/shims/router.js");
+      const { installPagesRouterRuntime } =
+        await import("../packages/vinext/src/shims/pages-router-runtime.js");
+
+      installPagesRouterRuntime();
+      installPagesRouterRuntime();
+
+      expect(win.addEventListener).toHaveBeenCalledTimes(1);
+      expect(win.addEventListener).toHaveBeenCalledWith("popstate", expect.any(Function));
+    } finally {
+      vi.resetModules();
+      if (previousWindow === undefined) {
+        delete (globalThis as any).window;
+      } else {
+        (globalThis as any).window = previousWindow;
+      }
+    }
+  });
+
   /**
    * Helper: create a mock window suitable for non-shallow Router.push().
    * Returns an object with the window mock plus helpers for controlling
@@ -11371,6 +11419,9 @@ describe("Pages Router concurrent navigation", () => {
     try {
       vi.resetModules();
       await import("../packages/vinext/src/shims/router.js");
+      const { installPagesRouterRuntime } =
+        await import("../packages/vinext/src/shims/pages-router-runtime.js");
+      installPagesRouterRuntime();
 
       const popstateHandler = listeners.get("popstate");
       expect(popstateHandler).toBeDefined();


### PR DESCRIPTION
## Overview

| Field | Detail |
| --- | --- |
| Goal | Keep App Router browser history ownership isolated from Pages Router compatibility imports. |
| Core change | Move Pages Router popstate listener installation behind an internal `vinext/pages-router-runtime` installer called only by Pages Router entrypoints. |
| Main boundary | `next/router` remains a public compatibility shim, but global browser listeners are owned by router entrypoints. |
| Primary files | `packages/vinext/src/shims/router.ts`, `packages/vinext/src/shims/pages-router-runtime.ts`, `packages/vinext/src/entries/pages-client-entry.ts`, `packages/vinext/src/server/dev-server.ts` |
| Expected impact | App Router bundles can import `next/router` without hijacking back/forward traversal or forcing document reloads. |

## Why

A public shim import should not install a global browser lifecycle handler. That responsibility belongs to the runtime entrypoint that owns the page root and history model. The previous module-level `popstate` listener in `next/router` leaked Pages Router behavior into App Router client bundles when compatibility imports pulled in the shim.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| Public shim | Importing a compatibility API should expose API shape without taking over global browser events. | `next/router` now registers its handler with an internal installer instead of adding the listener on import. |
| Pages Router runtime | Pages Router entrypoints own Pages Router history behavior. | Pages client generation and dev hydration call `installPagesRouterRuntime()` after setting `window.__VINEXT_ROOT__`. |
| App Router runtime | App Router back/forward traversal must remain owned by the App Router runtime. | Adds a regression fixture that imports `next/router` from an App Router client component and verifies traversal stays client-side. |

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| App Router client bundle imports `next/router` | Import installed the Pages Router `popstate` listener and could schedule hard navigation fallback. | Import is side-effect-safe with respect to `popstate`. |
| Pages Router hydration | Generated entries imported `next/router` for its side effect. | Generated entries call the internal Pages runtime installer explicitly. |
| Pages Router popstate behavior | Handler lived directly in a module-level listener. | Handler logic remains in `router.ts`; listener installation is explicit and idempotent. |

<details>
<summary>Maintainer review path</summary>

1. `packages/vinext/src/shims/router.ts` checks that the Pages Router popstate decision logic is unchanged apart from listener ownership.
2. `packages/vinext/src/shims/pages-router-runtime.ts` checks the internal installer boundary and idempotency.
3. `packages/vinext/src/entries/pages-client-entry.ts` and `packages/vinext/src/server/dev-server.ts` check that Pages Router entrypoints install the runtime after root setup.
4. `tests/shims.test.ts` checks import side effects and installer idempotency at unit level.
5. `tests/e2e/app-router/navigation-regressions.spec.ts` plus `tests/fixtures/app-basic/app/router-side-effect-leak/*` checks the App Router regression end to end.

</details>

<details>
<summary>Validation</summary>

- `vp test run tests/shims.test.ts`
- `vp test run tests/entry-templates.test.ts`
- `vp check`
- `vp run vinext#build`
- `PLAYWRIGHT_PROJECT=app-router pnpm run test:e2e tests/e2e/app-router/navigation-regressions.spec.ts -g "importing next/router"`
- `PLAYWRIGHT_PROJECT=pages-router pnpm run test:e2e tests/e2e/pages-router/before-pop-state.spec.ts tests/e2e/pages-router/router-events.spec.ts tests/e2e/pages-router/navigation.spec.ts`

</details>

<details>
<summary>Risk / compatibility</summary>

- Public API: no intentional public `next/router` API change.
- Runtime: Pages Router still installs one `popstate` listener, but only from Pages Router entrypoints.
- App Router: removes accidental Pages Router listener ownership from App Router bundles.
- Build output: adds one internal shim entry exposed through the existing `vinext/*` alias map.

</details>

<details>
<summary>Non-goals</summary>

- Does not change App Router history state semantics.
- Does not change Pages Router navigation event ordering beyond listener ownership.
- Does not address unrelated bfcache blockers outside the `next/router` import side effect.

</details>
