### PR TITLE
fix(rsc): allow JSX in .js client modules inside node_modules

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -423,6 +423,61 @@ function isValidExportIdentifier(name: string): boolean {
   return /^[$A-Z_a-z][$\w]*$/.test(name);
 }
 
+/**
+ * Returns true when `code` starts with a React `"use client"` or `"use server"`
+ * directive (after stripping leading comments, hashbang, and whitespace).
+ *
+ * Used by `vinext:jsx-in-js` to opt `.js` files inside `node_modules` into the
+ * JSX transform. We mirror `@vitejs/plugin-rsc`'s detection by looking at the
+ * directive prologue rather than scanning the whole file — `code.includes`
+ * alone would match incidental occurrences in template literals or comments.
+ */
+function hasReactDirective(code: string): boolean {
+  let i = 0;
+  const len = code.length;
+  // Strip BOM.
+  if (code.charCodeAt(0) === 0xfeff) i = 1;
+  // Strip hashbang.
+  if (code[i] === "#" && code[i + 1] === "!") {
+    const nl = code.indexOf("\n", i);
+    if (nl === -1) return false;
+    i = nl + 1;
+  }
+  while (i < len) {
+    // Skip whitespace.
+    while (i < len && /\s/.test(code[i] ?? "")) i++;
+    if (i >= len) return false;
+    // Skip line comments.
+    if (code[i] === "/" && code[i + 1] === "/") {
+      const nl = code.indexOf("\n", i + 2);
+      if (nl === -1) return false;
+      i = nl + 1;
+      continue;
+    }
+    // Skip block comments.
+    if (code[i] === "/" && code[i + 1] === "*") {
+      const end = code.indexOf("*/", i + 2);
+      if (end === -1) return false;
+      i = end + 2;
+      continue;
+    }
+    // At first non-comment, non-whitespace token. Must be a string literal
+    // directive to qualify (per ECMA-262 Directive Prologue grammar).
+    const quote = code[i];
+    if (quote !== '"' && quote !== "'") return false;
+    const closing = code.indexOf(quote, i + 1);
+    if (closing === -1) return false;
+    const directive = code.slice(i + 1, closing);
+    if (directive === "use client" || directive === "use server") return true;
+    // Other directives (e.g., "use strict") may precede the React directive.
+    // Continue scanning past the statement-terminating `;` or newline.
+    i = closing + 1;
+    while (i < len && (code[i] === ";" || code[i] === " " || code[i] === "\t")) i++;
+    if (code[i] === "\n") i++;
+  }
+  return false;
+}
+
 function generateRootParamsModule(rootParamNames: Iterable<string>): string {
   const names = Array.from(new Set(rootParamNames)).filter(isValidExportIdentifier).sort();
   if (names.length === 0) return "export {};\n";
@@ -812,17 +867,43 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
     // `vite:oxc`. We transform `.js` files with `lang: "jsx"` using Vite's
     // exported `transformWithOxc`. When `vite:oxc` later processes the
     // output, the JSX has already been compiled to createElement calls.
+    //
+    // For files inside `node_modules`, we only re-transform `.js`/`.mjs`
+    // modules that begin with a React `"use client"` or `"use server"`
+    // directive. Third-party Next.js client libraries routinely ship plain
+    // `.js` files containing `"use client"` + JSX (Next.js's SWC pipeline
+    // compiles JSX in `.js` transparently). Without this, `@vitejs/plugin-rsc`'s
+    // `rsc:use-client` analysis pass parses those files via rolldown/oxc with
+    // `lang: "js"` and fails with `RolldownError: Unexpected JSX expression`.
+    //
+    // We limit the node_modules transform to directive-bearing files to:
+    //   1. avoid re-parsing every `.js` in `node_modules` (build perf), and
+    //   2. avoid forcibly applying `lang: "jsx"` to library code that may use
+    //      syntax incompatible with the JSX-enabled OXC parser.
     ...(viteMajorVersion >= 8
       ? [
           {
             name: "vinext:jsx-in-js",
             enforce: "pre" as const,
             async transform(code: string, id: string) {
-              // Only handle .js/.mjs files outside node_modules.
+              // Only handle .js/.mjs files.
               // TypeScript (.ts/.tsx/.jsx) files are handled by vite:oxc.
               const cleanId = id.split("?")[0];
               if (!/\.(m?js)$/.test(cleanId)) return;
-              if (cleanId.includes("/node_modules/")) return;
+
+              // Inside node_modules, restrict the JSX transform to files that
+              // carry a React directive. `@vitejs/plugin-rsc` only parses
+              // such modules (and only those failures have been observed in
+              // the wild). The cheap `includes` check avoids any work for the
+              // vast majority of `.js` files in `node_modules`.
+              if (cleanId.includes("/node_modules/")) {
+                if (!code.includes("use client") && !code.includes("use server")) {
+                  return;
+                }
+                if (!hasReactDirective(code)) {
+                  return;
+                }
+              }
 
               const result = await transformWithOxc(code, id, {
                 lang: "jsx",

--- a/tests/jsx-in-js-node-modules.test.ts
+++ b/tests/jsx-in-js-node-modules.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Test: JSX in plain `.js` files inside `node_modules`.
+ *
+ * Many third-party Next.js client libraries ship `.js` files containing
+ * `"use client"` + JSX (Next.js's SWC pipeline transparently compiles JSX in
+ * plain `.js`, even inside `node_modules`). vinext's pre-existing
+ * `vinext:jsx-in-js` plugin only handles user source (`outside node_modules`),
+ * so when `@vitejs/plugin-rsc`'s `use-client` analysis pass tries to parse a
+ * library file like:
+ *
+ *   'use client'
+ *   export function Hello() {
+ *     return <p>hello world</p>
+ *   }
+ *
+ * rolldown/oxc fails with:
+ *
+ *   RolldownError: Parse failed with 1 error:
+ *   Unexpected JSX expression
+ *
+ * Ported from Next.js:
+ *   test/e2e/app-dir/next-dist-client-esm-import/
+ *   https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/next-dist-client-esm-import/
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, rm } from "node:fs/promises";
+import { createBuilder } from "vite";
+import { describe, expect, it } from "vite-plus/test";
+import vinext from "../packages/vinext/src/index.js";
+
+async function withTempDir<T>(prefix: string, run: (tmpDir: string) => Promise<T>): Promise<T> {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), prefix));
+  try {
+    return await run(tmpDir);
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+}
+
+function writeFixtureFile(root: string, filePath: string, content: string) {
+  const absPath = path.join(root, filePath);
+  fs.mkdirSync(path.dirname(absPath), { recursive: true });
+  fs.writeFileSync(absPath, content);
+}
+
+async function buildApp(root: string) {
+  const rscOutDir = path.join(root, "dist", "server");
+  const ssrOutDir = path.join(root, "dist", "server", "ssr");
+  const clientOutDir = path.join(root, "dist", "client");
+  const builder = await createBuilder({
+    root,
+    configFile: false,
+    plugins: [vinext({ appDir: root, rscOutDir, ssrOutDir, clientOutDir })],
+    logLevel: "silent",
+  });
+  await builder.buildApp();
+}
+
+describe("App Router: client modules with JSX in .js files inside node_modules", () => {
+  it("builds a 'use client' .js module with JSX shipped from a node_modules dependency", async () => {
+    await withTempDir("vinext-jsx-node-modules-", async (root) => {
+      // Link top-level node_modules (react, react-dom, etc.) so vinext can resolve them.
+      fs.symlinkSync(
+        path.resolve(import.meta.dirname, "../node_modules"),
+        path.join(root, "node_modules"),
+        "junction",
+      );
+
+      // App-level files.
+      writeFixtureFile(
+        root,
+        "package.json",
+        JSON.stringify({ name: "vinext-jsx-node-modules", private: true, type: "module" }, null, 2),
+      );
+      writeFixtureFile(
+        root,
+        "tsconfig.json",
+        JSON.stringify(
+          {
+            compilerOptions: {
+              target: "ES2022",
+              module: "ESNext",
+              moduleResolution: "bundler",
+              jsx: "react-jsx",
+              strict: true,
+              skipLibCheck: true,
+              types: ["vite/client", "@vitejs/plugin-rsc/types"],
+            },
+            include: ["app", "*.ts", "*.tsx"],
+          },
+          null,
+          2,
+        ),
+      );
+      writeFixtureFile(
+        root,
+        "app/layout.tsx",
+        `import type { ReactNode } from "react";
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}
+`,
+      );
+      writeFixtureFile(
+        root,
+        "app/page.tsx",
+        `import { Hello } from "@monorepo/adapter-next";
+
+export default function Page() {
+  return <Hello />;
+}
+`,
+      );
+
+      // A fake third-party package (ESM `type: "module"`) inside node_modules
+      // whose entry is a plain `.js` file containing `"use client"` + JSX.
+      // This mirrors the Next.js test fixture verbatim.
+      const pkgDir = path.join(root, "node_modules", "@monorepo", "adapter-next");
+      writeFixtureFile(
+        pkgDir,
+        "package.json",
+        JSON.stringify(
+          {
+            name: "@monorepo/adapter-next",
+            type: "module",
+            exports: {
+              ".": {
+                default: "./dist/client/index.js",
+              },
+            },
+          },
+          null,
+          2,
+        ),
+      );
+      writeFixtureFile(
+        pkgDir,
+        "dist/client/index.js",
+        `'use client'
+
+export function Hello() {
+  return <p>hello world</p>
+}
+`,
+      );
+
+      // Build. The bug manifests as a RolldownError "Unexpected JSX expression"
+      // thrown by rolldown/oxc when @vitejs/plugin-rsc analyses the .js file.
+      await expect(buildApp(root)).resolves.not.toThrow();
+
+      // Ensure the build actually produced server + client output.
+      expect(fs.existsSync(path.join(root, "dist", "server", "index.js"))).toBe(true);
+      expect(fs.existsSync(path.join(root, "dist", "client"))).toBe(true);
+    });
+  }, 90_000);
+});


### PR DESCRIPTION
## Summary

Many third-party Next.js client libraries ship plain `.js` files containing `'use client'` (or `'use server'`) plus JSX. Next.js's SWC pipeline compiles JSX in `.js` transparently, but vinext's `vinext:jsx-in-js` plugin (added in #1199) explicitly skipped `node_modules`, so `@vitejs/plugin-rsc`'s `rsc:use-client` analysis pass would feed the raw source straight to rolldown/oxc with `lang: 'js'` and crash the production build.

## Original error

```
[plugin rsc:use-client] /tmp/.../node_modules/.pnpm/@monorepo+adapter-next@.../client/index.js
RolldownError: Parse failed with 1 error:
Unexpected JSX expression
4:   return <p>hello world</p>
            ^
```

## Affected Next.js fixtures

- [`test/e2e/app-dir/next-dist-client-esm-import`](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/next-dist-client-esm-import/) — ships `@monorepo/adapter-next/dist/client/index.js` as a plain `.js` ESM module that exports `'use client'` JSX.
- [`test/e2e/app-dir/client-module-with-package-type`](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/client-module-with-package-type/) — similar pattern across ESM/CJS sub-packages (the JSX-bearing one is the failure mode this PR addresses).

These are part of category **A1** in the deploy-suite failure analysis.

## Root cause

`packages/vinext/src/index.ts` configures `vinext:jsx-in-js` with:

```ts
if (cleanId.includes("/node_modules/")) return;
```

so any third-party `.js` file containing JSX bypasses the JSX transform. `@vitejs/plugin-rsc` then parses that file with rolldown/oxc using `lang: 'js'` (extension-inferred), which has no JSX support and throws `RolldownError: Unexpected JSX expression`.

## Fix

Extend `vinext:jsx-in-js` so it also transforms `.js`/`.mjs` files inside `node_modules` **when** they begin with a React directive (`'use client'` or `'use server'`). A small `hasReactDirective()` helper walks the directive prologue (skipping BOM, hashbang, line/block comments, and earlier directives like `'use strict'`) so we only opt into the transform when there is a real directive — `code.includes('use client')` alone would match incidental occurrences in template literals or comments.

Scoping the change this way:

1. Solves the failure (the only files `rsc:use-client` parses are directive-bearing modules).
2. Keeps build performance unchanged for the vast majority of `node_modules` `.js` files, which exit the plugin after a cheap `String#includes` check.
3. Avoids forcing `lang: 'jsx'` on arbitrary library code that may use syntax the JSX-enabled OXC parser does not accept.

## Validation

```
vp check                                       # format / lint / type — clean
vp test run tests/jsx-in-js-node-modules.test.ts
vp test run tests/jsx-in-js.test.ts tests/jsx-in-js-node-modules.test.ts \
            tests/intercepting-routes-build.test.ts tests/build-optimization.test.ts
vp test run tests/nextjs-compat/ tests/font-google-build.test.ts \
            tests/build-time-classification-integration.test.ts \
            tests/tsconfig-path-alias-build.test.ts                # 281 passing, 2 skipped, 0 regressions
vp run vinext#build                                                # clean
```

`tests/jsx-in-js-node-modules.test.ts` reproduces the exact error from the deploy-suite log on `main` (fixture mirrors `@monorepo/adapter-next` byte-for-byte) and passes with the fix applied.