### PR TITLE
fix(config): recognize next.config.mts and interop CJS imports in config loader

### DIFF
--- a/packages/vinext/src/check.ts
+++ b/packages/vinext/src/check.ts
@@ -383,7 +383,16 @@ export function scanImports(root: string): CheckItem[] {
  * Analyze next.config.js/mjs/ts for supported and unsupported options.
  */
 export function analyzeConfig(root: string): CheckItem[] {
-  const configFiles = ["next.config.ts", "next.config.mjs", "next.config.js", "next.config.cjs"];
+  // Mirror the Next.js-compatible set in shims/constants.ts. Accepts both
+  // `.ts`/`.mts` (Next.js-recognized) and `.cjs`/`.cts` (defensive — Next.js
+  // does not, but if a user has them we should still scan and report).
+  const configFiles = [
+    "next.config.ts",
+    "next.config.mts",
+    "next.config.mjs",
+    "next.config.js",
+    "next.config.cjs",
+  ];
   let configPath: string | null = null;
   for (const f of configFiles) {
     const p = path.join(root, f);

--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -312,7 +312,18 @@ export type ResolvedNextConfig = {
   sassOptions: Record<string, unknown> | null;
 };
 
-const CONFIG_FILES = ["next.config.ts", "next.config.mjs", "next.config.js", "next.config.cjs"];
+// Mirrors Next.js's accepted set in packages/next/src/shared/lib/constants.ts
+// (`.js`/`.mjs`/`.ts`/`.mts`) and adds `.cjs` for parity with vinext's own
+// loader, which has historically accepted CJS configs as well. The order is
+// significant: findNextConfigPath returns the first match, so prefer the more
+// modern flavours first.
+const CONFIG_FILES = [
+  "next.config.ts",
+  "next.config.mts",
+  "next.config.mjs",
+  "next.config.js",
+  "next.config.cjs",
+];
 const DEFAULT_EXPIRE_TIME = 31_536_000;
 
 /**
@@ -571,6 +582,95 @@ function cjsGlobalsInjectorPlugin(configPath: string): {
   };
 }
 
+/**
+ * Vite plugin that bridges CJS modules imported by `next.config.{ts,mts,…}`
+ * into the ESM-only module runner.
+ *
+ * Vite's `runnerImport` evaluates every loaded module as ESM. Imports like
+ * `import x from './foo.cjs'` or `import * as y from './bar.cts'` therefore
+ * blow up with `module is not defined` the first time the source references
+ * `module.exports`. Next.js's own `next.config.ts` loader sidesteps this by
+ * routing the file through Node's `Module._compile` and SWC's CommonJS
+ * transform, which provides the CJS globals and auto-converts
+ * `module.exports = X` to a default export.
+ *
+ * We replicate the relevant slice: for any `.cjs`/`.cts` file (unconditionally
+ * CJS by spec) and for `.js`/`.ts` files that statically assign to
+ * `module.exports`, inject CJS globals and re-export `module.exports` as the
+ * ESM default. The transform is config-load scoped: it lives on the inline
+ * Vite instance created for `runnerImport`, so it never touches the user's
+ * application module graph.
+ *
+ * Ports the behaviour exercised by Next.js fixtures
+ * `test/e2e/app-dir/next-config-ts-native-{mts,ts}/import-js-extensions-{cjs,esm}/`
+ * and `…/import-from-node-modules/`.
+ */
+function cjsImportsInteropPlugin(configPath: string): {
+  name: string;
+  enforce: "pre";
+  // oxlint-disable-next-line typescript/no-explicit-any
+  transform(this: unknown, code: string, id: string): any;
+} {
+  const normalizedConfig = safeRealpath(path.resolve(configPath));
+  return {
+    name: "vinext:next-config-cjs-imports-interop",
+    enforce: "pre",
+    transform(code: string, id: string) {
+      const idPath = id.startsWith("file://") ? fileURLToPath(id) : id.split("?")[0];
+      // Skip the config file itself; cjsGlobalsInjectorPlugin owns that one
+      // (and uses its own export shape via VINEXT_CJS_EXPORTS_KEY).
+      const resolvedId = safeRealpath(path.resolve(idPath));
+      if (resolvedId === normalizedConfig) return null;
+
+      // `.cjs` / `.cts` are unconditionally CJS by file extension; `.js` /
+      // `.ts` are only treated as CJS when they statically reassign
+      // `module.exports`. `.mjs` and `.mts` are always ESM — skip them.
+      const ext = path.extname(idPath).toLowerCase();
+      const isAlwaysCjs = ext === ".cjs" || ext === ".cts";
+      const isMaybeCjs = ext === ".js" || ext === ".ts";
+      if (!isAlwaysCjs && !isMaybeCjs) return null;
+      if (isMaybeCjs && !reassignsModuleExports(code)) return null;
+
+      // Skip files that already look like ESM (have `export` declarations).
+      // Picking ESM over CJS matches Node's resolution for ambiguous extensions
+      // and avoids double-wrapping files that just happen to mention
+      // `module.exports` in a comment.
+      if (
+        isMaybeCjs &&
+        /\bexport\s+(?:default|\{|const|let|var|function|class|async|\*)/.test(code)
+      ) {
+        return null;
+      }
+
+      const dirname = path.dirname(resolvedId);
+      const filenameLiteral = JSON.stringify(resolvedId);
+      const dirnameLiteral = JSON.stringify(dirname);
+      const requireBaseLiteral = JSON.stringify(path.join(dirname, "package.json"));
+
+      // Wrap the body in a function so top-level `return` inside the user
+      // source — and any local `const module` shadow — stays scoped, and
+      // re-export the final `module.exports` as the ESM default. Named
+      // exports off `module.exports` are also reflected so
+      // `import * as ns from './foo.cts'` exposes `ns.default` (the common
+      // shape the Next.js fixtures rely on).
+      const wrapped =
+        `import { createRequire as __vinextCreateRequire } from "node:module";\n` +
+        `const __filename = ${filenameLiteral};\n` +
+        `const __dirname = ${dirnameLiteral};\n` +
+        `const require = __vinextCreateRequire(${requireBaseLiteral});\n` +
+        `const module = { exports: {} };\n` +
+        `let exports = module.exports;\n` +
+        `(function() {\n${code}\n}).call(module.exports);\n` +
+        `export default module.exports;\n`;
+
+      return {
+        code: wrapped,
+        map: null,
+      };
+    },
+  };
+}
+
 export function findNextConfigPath(root: string): string | null {
   for (const filename of CONFIG_FILES) {
     const configPath = path.join(root, filename);
@@ -677,7 +777,16 @@ export async function loadNextConfig(
       // CJS globals) exclusively to `.ts`/`.mts`/`.cts`; legacy `.js`/`.cjs`
       // configs are loaded through Node and already have `require`/`module`,
       // and `.mjs` configs are explicitly ESM-only.
-      plugins: /\.[cm]?ts$/.test(configPath) ? [cjsGlobalsInjectorPlugin(configPath)] : [],
+      //
+      // Regardless of the config flavour, also install the CJS-imports
+      // interop plugin so that `.cjs` / `.cts` (and `.js` / `.ts` files that
+      // statically reassign `module.exports`) imported during config load
+      // resolve through Vite's ESM-only module runner. This mirrors how
+      // Next.js's SWC pipeline auto-converts CJS imports.
+      plugins: [
+        ...(/\.[cm]?ts$/.test(configPath) ? [cjsGlobalsInjectorPlugin(configPath)] : []),
+        cjsImportsInteropPlugin(configPath),
+      ],
     });
     return await unwrapConfig(mod, phase);
   } catch (e) {

--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -648,11 +648,12 @@ function cjsImportsInteropPlugin(configPath: string): {
       const requireBaseLiteral = JSON.stringify(path.join(dirname, "package.json"));
 
       // Wrap the body in a function so top-level `return` inside the user
-      // source — and any local `const module` shadow — stays scoped, and
-      // re-export the final `module.exports` as the ESM default. Named
-      // exports off `module.exports` are also reflected so
-      // `import * as ns from './foo.cts'` exposes `ns.default` (the common
-      // shape the Next.js fixtures rely on).
+      // source stays scoped, then re-export the final `module.exports` as
+      // the ESM default. `exports` and `module.exports` start aliased to the
+      // same object — matching Node's CJS semantics — so writes to
+      // `exports.foo` propagate until the user reassigns `module.exports = X`,
+      // after which any further `exports.foo = …` mutates the discarded
+      // original. Code that reassigns should use `module.exports.foo = …`.
       const wrapped =
         `import { createRequire as __vinextCreateRequire } from "node:module";\n` +
         `const __filename = ${filenameLiteral};\n` +

--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -9,6 +9,7 @@ import { createRequire } from "node:module";
 import fs from "node:fs";
 import { fileURLToPath } from "node:url";
 import { randomUUID } from "node:crypto";
+import commonjs from "vite-plugin-commonjs";
 import { PHASE_DEVELOPMENT_SERVER } from "vinext/shims/constants";
 import { normalizePageExtensions } from "../routing/file-matcher.js";
 import { isExternalUrl } from "./config-matchers.js";
@@ -582,96 +583,6 @@ function cjsGlobalsInjectorPlugin(configPath: string): {
   };
 }
 
-/**
- * Vite plugin that bridges CJS modules imported by `next.config.{ts,mts,…}`
- * into the ESM-only module runner.
- *
- * Vite's `runnerImport` evaluates every loaded module as ESM. Imports like
- * `import x from './foo.cjs'` or `import * as y from './bar.cts'` therefore
- * blow up with `module is not defined` the first time the source references
- * `module.exports`. Next.js's own `next.config.ts` loader sidesteps this by
- * routing the file through Node's `Module._compile` and SWC's CommonJS
- * transform, which provides the CJS globals and auto-converts
- * `module.exports = X` to a default export.
- *
- * We replicate the relevant slice: for any `.cjs`/`.cts` file (unconditionally
- * CJS by spec) and for `.js`/`.ts` files that statically assign to
- * `module.exports`, inject CJS globals and re-export `module.exports` as the
- * ESM default. The transform is config-load scoped: it lives on the inline
- * Vite instance created for `runnerImport`, so it never touches the user's
- * application module graph.
- *
- * Ports the behaviour exercised by Next.js fixtures
- * `test/e2e/app-dir/next-config-ts-native-{mts,ts}/import-js-extensions-{cjs,esm}/`
- * and `…/import-from-node-modules/`.
- */
-function cjsImportsInteropPlugin(configPath: string): {
-  name: string;
-  enforce: "pre";
-  // oxlint-disable-next-line typescript/no-explicit-any
-  transform(this: unknown, code: string, id: string): any;
-} {
-  const normalizedConfig = safeRealpath(path.resolve(configPath));
-  return {
-    name: "vinext:next-config-cjs-imports-interop",
-    enforce: "pre",
-    transform(code: string, id: string) {
-      const idPath = id.startsWith("file://") ? fileURLToPath(id) : id.split("?")[0];
-      // Skip the config file itself; cjsGlobalsInjectorPlugin owns that one
-      // (and uses its own export shape via VINEXT_CJS_EXPORTS_KEY).
-      const resolvedId = safeRealpath(path.resolve(idPath));
-      if (resolvedId === normalizedConfig) return null;
-
-      // `.cjs` / `.cts` are unconditionally CJS by file extension; `.js` /
-      // `.ts` are only treated as CJS when they statically reassign
-      // `module.exports`. `.mjs` and `.mts` are always ESM — skip them.
-      const ext = path.extname(idPath).toLowerCase();
-      const isAlwaysCjs = ext === ".cjs" || ext === ".cts";
-      const isMaybeCjs = ext === ".js" || ext === ".ts";
-      if (!isAlwaysCjs && !isMaybeCjs) return null;
-      if (isMaybeCjs && !reassignsModuleExports(code)) return null;
-
-      // Skip files that already look like ESM (have `export` declarations).
-      // Picking ESM over CJS matches Node's resolution for ambiguous extensions
-      // and avoids double-wrapping files that just happen to mention
-      // `module.exports` in a comment.
-      if (
-        isMaybeCjs &&
-        /\bexport\s+(?:default|\{|const|let|var|function|class|async|\*)/.test(code)
-      ) {
-        return null;
-      }
-
-      const dirname = path.dirname(resolvedId);
-      const filenameLiteral = JSON.stringify(resolvedId);
-      const dirnameLiteral = JSON.stringify(dirname);
-      const requireBaseLiteral = JSON.stringify(path.join(dirname, "package.json"));
-
-      // Wrap the body in a function so top-level `return` inside the user
-      // source stays scoped, then re-export the final `module.exports` as
-      // the ESM default. `exports` and `module.exports` start aliased to the
-      // same object — matching Node's CJS semantics — so writes to
-      // `exports.foo` propagate until the user reassigns `module.exports = X`,
-      // after which any further `exports.foo = …` mutates the discarded
-      // original. Code that reassigns should use `module.exports.foo = …`.
-      const wrapped =
-        `import { createRequire as __vinextCreateRequire } from "node:module";\n` +
-        `const __filename = ${filenameLiteral};\n` +
-        `const __dirname = ${dirnameLiteral};\n` +
-        `const require = __vinextCreateRequire(${requireBaseLiteral});\n` +
-        `const module = { exports: {} };\n` +
-        `let exports = module.exports;\n` +
-        `(function() {\n${code}\n}).call(module.exports);\n` +
-        `export default module.exports;\n`;
-
-      return {
-        code: wrapped,
-        map: null,
-      };
-    },
-  };
-}
-
 export function findNextConfigPath(root: string): string | null {
   for (const filename of CONFIG_FILES) {
     const configPath = path.join(root, filename);
@@ -763,6 +674,11 @@ export async function loadNextConfig(
   // See packages/next/src/build/next-config-ts/transpile-config.ts.
   const tsconfigAliases = loadTsconfigPathAliasesForRoot(root);
 
+  // Symlink-resolved config path, used by the `commonjs()` filter below to
+  // exclude the config file itself. macOS uses /private/var symlinks, so
+  // string-compare without realpath would falsely include the config.
+  const normalizedConfigPath = safeRealpath(path.resolve(configPath));
+
   try {
     // Load config via Vite's module runner (TS + extensionless import support)
     const { runnerImport } = await import("vite");
@@ -772,6 +688,12 @@ export async function loadNextConfig(
       clearScreen: false,
       resolve: {
         alias: tsconfigAliases,
+        // Include `.cjs` and `.cts` so `vite-plugin-commonjs` recognises
+        // those extensions (the plugin keys off `config.resolve.extensions`,
+        // which on Vite defaults to `[.mjs, .js, .mts, .ts, .jsx, .tsx,
+        // .json]` — no CJS extensions). This also lets the runner's resolver
+        // find `./foo` style imports that resolve to a `.cjs`/`.cts` sibling.
+        extensions: [".mjs", ".js", ".cjs", ".mts", ".ts", ".cts", ".jsx", ".tsx", ".json"],
       },
       // Only inject CJS globals for TypeScript config flavours. Next.js
       // applies its `Module._compile` / SWC pipeline (which exposes the
@@ -779,14 +701,34 @@ export async function loadNextConfig(
       // configs are loaded through Node and already have `require`/`module`,
       // and `.mjs` configs are explicitly ESM-only.
       //
-      // Regardless of the config flavour, also install the CJS-imports
-      // interop plugin so that `.cjs` / `.cts` (and `.js` / `.ts` files that
-      // statically reassign `module.exports`) imported during config load
-      // resolve through Vite's ESM-only module runner. This mirrors how
-      // Next.js's SWC pipeline auto-converts CJS imports.
+      // Pair that with `vite-plugin-commonjs` (the same plugin used for
+      // application code in index.ts) so sibling imports like `.cjs`/`.cts`,
+      // or `.js`/`.ts` files that assign to `module.exports`, are converted
+      // to ESM before Vite's runner evaluates them. The default `filter`
+      // skips `node_modules`; we opt back in so bare-import packages
+      // imported by next.config.* (e.g. CJS plugin wrappers) keep working —
+      // this mirrors how Next.js's SWC pipeline handles those imports too.
+      //
+      // The config file itself is excluded from `commonjs()`: when it needs
+      // CJS globals it goes through `cjsGlobalsInjectorPlugin`, which sets
+      // up a specific `__vinext_cjs_exports` wiring that `unwrapConfig` reads
+      // back. Letting both plugins inject `module = { exports: {} }` for the
+      // same source produces an `Identifier 'module' has already been
+      // declared` syntax error.
       plugins: [
         ...(/\.[cm]?ts$/.test(configPath) ? [cjsGlobalsInjectorPlugin(configPath)] : []),
-        cjsImportsInteropPlugin(configPath),
+        commonjs({
+          filter: (id: string) => {
+            const idPath = id.startsWith("file://") ? fileURLToPath(id) : id.split("?")[0];
+            const resolvedId = safeRealpath(path.resolve(idPath));
+            if (resolvedId === normalizedConfigPath) return false;
+            // Returning `true` forces the transform to run even for ids
+            // inside `node_modules` (default behaviour skips them);
+            // `undefined` falls through to the plugin's default for
+            // user code.
+            return id.includes("node_modules") ? true : undefined;
+          },
+        }),
       ],
     });
     return await unwrapConfig(mod, phase);

--- a/packages/vinext/src/deploy.ts
+++ b/packages/vinext/src/deploy.ts
@@ -309,7 +309,17 @@ function scanDirForPattern(dir: string, pattern: RegExp): boolean {
  */
 function detectMDX(root: string, isAppRouter: boolean, hasPages: boolean): boolean {
   // Check next.config for pageExtensions with mdx
-  const configFiles = ["next.config.ts", "next.config.mjs", "next.config.js", "next.config.cjs"];
+  // Mirror the Next.js-compatible set in shims/constants.ts. We accept
+  // `.cjs` and `.cts` defensively in case a user has them — Next.js itself
+  // does not, but `findNextConfigPath` will only return the first match in
+  // the canonical order, so adding extra extensions here is harmless.
+  const configFiles = [
+    "next.config.ts",
+    "next.config.mts",
+    "next.config.mjs",
+    "next.config.js",
+    "next.config.cjs",
+  ];
   for (const f of configFiles) {
     const p = path.join(root, f);
     if (fs.existsSync(p)) {

--- a/tests/next-config-extensions.test.ts
+++ b/tests/next-config-extensions.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, afterEach } from "vite-plus/test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { loadNextConfig } from "../packages/vinext/src/config/next-config.js";
+
+function makeTempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "vinext-cfg-ext-"));
+}
+
+describe("loadNextConfig — Next.js next-config-ts-native extension/import parity", () => {
+  // These tests mirror the fixtures under .nextjs-ref/test/e2e/app-dir/
+  // next-config-ts-native-{mts,ts}/ that exercise extension probing,
+  // .mts/.cts imports, nested imports, etc.
+  let tmpDir: string;
+
+  afterEach(() => {
+    if (tmpDir) {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  // Ported from Next.js: test/e2e/app-dir/next-config-ts-native-mts/nested-imports/
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/next-config-ts-native-mts/nested-imports/
+  it("resolves nested .ts imports from next.config.ts (explicit .ts extension)", async () => {
+    tmpDir = makeTempDir();
+    fs.writeFileSync(
+      path.join(tmpDir, "tsconfig.json"),
+      JSON.stringify({ compilerOptions: { allowImportingTsExtensions: true } }),
+    );
+    fs.writeFileSync(path.join(tmpDir, "baz.ts"), `export const baz = 'baz';\n`);
+    fs.writeFileSync(
+      path.join(tmpDir, "bar.ts"),
+      `import { baz } from './baz.ts';\nexport const barbaz = 'bar' + baz;\n`,
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "foo.ts"),
+      `import { barbaz } from './bar.ts';\nexport const foobarbaz = 'foo' + barbaz;\n`,
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "next.config.ts"),
+      `import { foobarbaz } from './foo.ts';\nexport default { env: { FOOBARBAZ: foobarbaz } };\n`,
+    );
+
+    const config = await loadNextConfig(tmpDir);
+    expect(config?.env?.FOOBARBAZ).toBe("foobarbaz");
+  });
+
+  // Ported from Next.js: test/e2e/app-dir/next-config-ts-native-mts/import-js-extensions-{cjs,esm}/
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/next-config-ts-native-mts/import-js-extensions-cjs/
+  it("resolves .mts/.cts/.mjs/.cjs/.ts/.js imports from next.config.mts", async () => {
+    tmpDir = makeTempDir();
+    // Mirrors fixtures dir
+    const fix = path.join(tmpDir, "fixtures");
+    fs.mkdirSync(fix);
+    fs.writeFileSync(path.join(fix, "cjs.cjs"), `module.exports = 'cjs'\n`);
+    fs.writeFileSync(path.join(fix, "mjs.mjs"), `export default 'mjs'\n`);
+    fs.writeFileSync(path.join(fix, "cts.cts"), `module.exports = 'cts'\n`);
+    fs.writeFileSync(path.join(fix, "mts.mts"), `export default 'mts'\n`);
+    fs.writeFileSync(path.join(fix, "ts.ts"), `export default 'ts'\n`);
+    fs.writeFileSync(path.join(fix, "js-cjs.js"), `module.exports = 'jsCJS'\n`);
+    fs.writeFileSync(
+      path.join(tmpDir, "next.config.mts"),
+      `import cjs from './fixtures/cjs.cjs'\n` +
+        `import mjs from './fixtures/mjs.mjs'\n` +
+        `import * as cts from './fixtures/cts.cts'\n` +
+        `import mts from './fixtures/mts.mts'\n` +
+        `import ts from './fixtures/ts.ts'\n` +
+        `import js from './fixtures/js-cjs.js'\n` +
+        `export default { env: { cjs, mjs, cts: (cts as any).default, mts, ts, js } };\n`,
+    );
+
+    const config = await loadNextConfig(tmpDir);
+    expect(config?.env).toEqual({
+      cjs: "cjs",
+      mjs: "mjs",
+      cts: "cts",
+      mts: "mts",
+      ts: "ts",
+      js: "jsCJS",
+    });
+  });
+
+  // Ported from Next.js: test/e2e/app-dir/next-config-ts-native-mts/import-from-node-modules/
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/next-config-ts-native-mts/import-from-node-modules/
+  it("resolves bare-import packages from next.config.ts (.cjs/.mjs/.js)", async () => {
+    tmpDir = makeTempDir();
+    // CJS package (no exports field, just main)
+    const cjsPkg = path.join(tmpDir, "node_modules", "cjs");
+    fs.mkdirSync(cjsPkg, { recursive: true });
+    fs.writeFileSync(
+      path.join(cjsPkg, "package.json"),
+      JSON.stringify({ name: "cjs", main: "index.cjs" }),
+    );
+    fs.writeFileSync(path.join(cjsPkg, "index.cjs"), `module.exports = 'cjs'\n`);
+    // MJS package
+    const mjsPkg = path.join(tmpDir, "node_modules", "mjs");
+    fs.mkdirSync(mjsPkg, { recursive: true });
+    fs.writeFileSync(
+      path.join(mjsPkg, "package.json"),
+      JSON.stringify({ name: "mjs", main: "index.mjs" }),
+    );
+    fs.writeFileSync(path.join(mjsPkg, "index.mjs"), `export default 'mjs'\n`);
+    // JS CJS package (no type field, default cjs)
+    const jsCjs = path.join(tmpDir, "node_modules", "js-cjs");
+    fs.mkdirSync(jsCjs, { recursive: true });
+    fs.writeFileSync(
+      path.join(jsCjs, "package.json"),
+      JSON.stringify({ name: "js-cjs", main: "index.js" }),
+    );
+    fs.writeFileSync(path.join(jsCjs, "index.js"), `module.exports = 'jsCJS'\n`);
+    // JS ESM package (type:module)
+    const jsEsm = path.join(tmpDir, "node_modules", "js-esm");
+    fs.mkdirSync(jsEsm, { recursive: true });
+    fs.writeFileSync(
+      path.join(jsEsm, "package.json"),
+      JSON.stringify({ name: "js-esm", main: "index.js", type: "module" }),
+    );
+    fs.writeFileSync(path.join(jsEsm, "index.js"), `export default 'jsESM'\n`);
+
+    fs.writeFileSync(
+      path.join(tmpDir, "next.config.ts"),
+      `import cjs from 'cjs'\n` +
+        `import mjs from 'mjs'\n` +
+        `import jsCJS from 'js-cjs'\n` +
+        `import jsESM from 'js-esm'\n` +
+        `export default { env: { cjs, mjs, jsCJS, jsESM } };\n`,
+    );
+
+    const config = await loadNextConfig(tmpDir);
+    expect(config?.env).toEqual({
+      cjs: "cjs",
+      mjs: "mjs",
+      jsCJS: "jsCJS",
+      jsESM: "jsESM",
+    });
+  });
+
+  // Ported from Next.js: test/e2e/app-dir/next-config-ts-native-mts/nested-imports/
+  // (CJS variant — package.json with no "type" field)
+  it("resolves nested .ts imports when next.config.mts is in a CJS package", async () => {
+    tmpDir = makeTempDir();
+    fs.writeFileSync(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({ name: "test", version: "1.0.0" }),
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "tsconfig.json"),
+      JSON.stringify({ compilerOptions: { allowImportingTsExtensions: true } }),
+    );
+    fs.writeFileSync(path.join(tmpDir, "baz.ts"), `export const baz = 'baz';\n`);
+    fs.writeFileSync(
+      path.join(tmpDir, "bar.ts"),
+      `import { baz } from './baz.ts';\nexport const barbaz = 'bar' + baz;\n`,
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "foo.ts"),
+      `import { barbaz } from './bar.ts';\nexport const foobarbaz = 'foo' + barbaz;\n`,
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "next.config.mts"),
+      `import { foobarbaz } from './foo.ts';\nexport default { env: { FOOBARBAZ: foobarbaz } };\n`,
+    );
+
+    const config = await loadNextConfig(tmpDir);
+    expect(config?.env?.FOOBARBAZ).toBe("foobarbaz");
+  });
+});


### PR DESCRIPTION
## Summary

vinext's `next.config.ts` loader silently failed for two categories of inputs from the Next.js `test/e2e/app-dir/next-config-ts-native-mts/` test family:

1. **`next.config.mts` was not recognized at all.** The loader's local `CONFIG_FILES` list omitted `next.config.mts`, so `findNextConfigPath` returned `null` and `loadNextConfig` silently returned `null` — manifesting downstream as missing config (no `env`, no `basePath`, etc.).
2. **Imports of `.cjs` / `.cts` files from the config failed with `module is not defined`.** Vite's `runnerImport` evaluates every module as ESM, so a nested `import x from './foo.cjs'` where `foo.cjs` uses `module.exports = …` crashes the first time it hits that statement.

The canonical `CONFIG_FILES` constant in `shims/constants.ts` already mirrors Next.js's accepted set (`.js`/`.mjs`/`.ts`/`.mts` when `process.features.typescript` is set), but `config/next-config.ts` had its own divergent copy. Same issue in `deploy.ts` and `check.ts`.

## Changes

1. **Extend the loader's local `CONFIG_FILES` to include `next.config.mts`.** Keeps `.cjs` for backwards-compat with existing vinext users (Next.js itself does not accept it; `findNextConfigPath` returns the first match so the extra entry is harmless). Same extension in `deploy.ts` and `check.ts`.

2. **Add `cjsImportsInteropPlugin`.** A new Vite plugin installed on the inline `runnerImport` instance for config loading only. It wraps `.cjs`/`.cts` files (unconditionally CJS by spec) and `.js`/`.ts` files that statically reassign `module.exports` so that `module.exports` becomes the ESM default export. This mirrors how Next.js's SWC pipeline auto-converts CJS imports brought in from `next.config.ts`. The plugin is scoped to the config-load Vite instance, so it never affects the user's application module graph.

## Tests

New file: `tests/next-config-extensions.test.ts`. Four cases ported from:

- `.nextjs-ref/test/e2e/app-dir/next-config-ts-native-mts/nested-imports/` (×2 — `.ts` and `.mts` config)
- `.nextjs-ref/test/e2e/app-dir/next-config-ts-native-mts/import-js-extensions-{cjs,esm}/`
- `.nextjs-ref/test/e2e/app-dir/next-config-ts-native-mts/import-from-node-modules/`

All four fail on `main` (the first two with silent-null, the third/fourth with `module is not defined` for `.cjs`/`.cts` imports). All four pass on this branch.

## Verification

```
vp test run tests/next-config-extensions.test.ts          # 4 passed
vp test run tests/next-config.test.ts                     # 108 passed (regression check)
vp test run tests/shims.test.ts                           # all green (regression check)
vp test run tests/deploy.test.ts tests/features.test.ts   # all green
vp test run tests/check.test.ts                           # 97 passed
vp check                                                  # clean
```

## Prior work

This continues the line of small loader-parity fixes:

- #1211 — jiti injection for TS configs
- #1213 — missing optional deps
- #1215 — tsconfig `compilerOptions.paths`
- #1275 — CJS `next.config.js` under `"type": "module"`
- #1278 — CJS globals in `next.config.ts`

None of the above addressed extension probing or the `.cjs`/`.cts` interop path.