### PR TITLE
refactor(router): share interception matched-url validation

### DIFF
--- a/packages/vinext/src/server/app-elements-wire.ts
+++ b/packages/vinext/src/server/app-elements-wire.ts
@@ -5,6 +5,7 @@ import {
   type ArtifactCompatibilityEnvelope,
 } from "./artifact-compatibility.js";
 import type { RenderObservation } from "./cache-proof.js";
+import { isInterceptionMatchedUrlPath } from "./normalize-path.js";
 
 const APP_INTERCEPTION_SEPARATOR = "\0";
 
@@ -462,13 +463,7 @@ function readRequiredInterceptionString(
 }
 
 function parseInterceptionMatchedUrl(value: string): string {
-  if (
-    !value.startsWith("/") ||
-    value.startsWith("//") ||
-    value.includes("?") ||
-    value.includes("#") ||
-    value.includes("\0")
-  ) {
+  if (!isInterceptionMatchedUrlPath(value)) {
     throw new Error("[vinext] Invalid __interception in App Router payload: expected path URLs");
   }
   return value;

--- a/packages/vinext/src/server/app-page-element-builder.ts
+++ b/packages/vinext/src/server/app-page-element-builder.ts
@@ -16,7 +16,7 @@ import { matchRoutePattern } from "../routing/route-pattern.js";
 import { normalizePathnameForRouteMatch } from "../routing/utils.js";
 import type { MetadataFileRoute } from "./metadata-routes.js";
 import { APP_RSC_RENDER_MODE_NAVIGATION, type AppRscRenderMode } from "./app-rsc-render-mode.js";
-import { normalizePath } from "./normalize-path.js";
+import { isInterceptionMatchedUrlPath, normalizePath } from "./normalize-path.js";
 
 export type { AppPageErrorModule, AppPageRouteWiringRoute } from "./app-page-route-wiring.js";
 
@@ -231,16 +231,7 @@ function createAppPageInterceptionProof<TModule extends AppPageModule>(
 }
 
 function normalizeInterceptionProofMatchedUrl(value: string | null): string | null {
-  if (
-    value === null ||
-    !value.startsWith("/") ||
-    value.startsWith("//") ||
-    value.includes("?") ||
-    value.includes("#") ||
-    value.includes("\0")
-  ) {
-    return null;
-  }
+  if (value === null || !isInterceptionMatchedUrlPath(value)) return null;
 
   return normalizePath(normalizePathnameForRouteMatch(value));
 }

--- a/packages/vinext/src/server/normalize-path.ts
+++ b/packages/vinext/src/server/normalize-path.ts
@@ -37,6 +37,16 @@ export function decodePathParams(pathname: string): string {
     .join("/");
 }
 
+export function isInterceptionMatchedUrlPath(value: string): boolean {
+  return (
+    value.startsWith("/") &&
+    !value.startsWith("//") &&
+    !value.includes("?") &&
+    !value.includes("#") &&
+    !value.includes("\0")
+  );
+}
+
 /**
  * Path normalization utility for request handling.
  *


### PR DESCRIPTION
## Overview

| Area | Detail |
| --- | --- |
| Goal | Follow up on James's review from #1249 by removing the duplicated interception matched-url path predicate. |
| Core change | Add a shared `isInterceptionMatchedUrlPath` helper for the path-only URL shape used by interception proof metadata. |
| Boundary | The helper only validates the common path shape. The builder still owns normalization and nullable proof construction, while the wire codec still owns payload rejection and error text. |
| Impact | No intended runtime behavior change. This fences validation drift between proof creation and wire parsing. |

## Why

Interception proof paths have one shared invariant: matched URLs are app-path URLs, not absolute URLs, query-bearing URLs, hash-bearing URLs, or strings with null bytes. That invariant should have one owner, while the two callers keep their different boundary behavior.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| Proof construction | Invalid proof input means no proof is emitted. | Uses the shared predicate before normalizing the accepted path. |
| AppElements wire parsing | Invalid serialized proof metadata is a malformed payload. | Uses the shared predicate before throwing the existing payload error. |
| Router maintenance | Shared semantic predicates should not drift across builder and wire boundaries. | Moves the repeated checks into `app-interception-url.ts`. |

## What changed

| Surface | Before | After |
| --- | --- | --- |
| `app-page-element-builder.ts` | Repeated the matched-url path checks inline before normalization. | Calls `isInterceptionMatchedUrlPath`, then keeps existing normalization. |
| `app-elements-wire.ts` | Repeated the same path checks inline before throwing. | Calls `isInterceptionMatchedUrlPath`, then keeps the existing throw behavior. |

<details>
<summary>Validation</summary>

- `vp test run tests/app-elements.test.ts tests/app-page-element-builder.test.ts`
- `vp check`
- Commit hook: formatting, lint/typecheck, and `knip --no-progress`

</details>

## References

| Reference | Why it matters |
| --- | --- |
| #1249 | This is a review follow-up on the merged Core-15 interception preservation PR. |
| #726 | Architectural context for keeping interception proof semantics explicit and owned. |
