### PR TITLE
feat(app-router): support app/global-not-found.tsx (Next.js 16 parity)

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -103,6 +103,15 @@ type AppRouterConfig = {
   /** Internationalization routing config for middleware matcher locale handling. */
   i18n?: NextI18nConfig | null;
   /**
+   * Absolute path to `app/global-not-found.{tsx,ts,js,jsx}` when present.
+   * When provided, route-miss 404s render this module standalone (it owns its
+   * own `<html>` and `<body>`) instead of wrapping the regular `not-found.tsx`
+   * boundary inside the root layout. Mirrors Next.js 16's
+   * `experimental.globalNotFound` behavior.
+   * @see https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/global-not-found
+   */
+  globalNotFoundPath?: string | null;
+  /**
    * When true, the project has a `pages/` directory alongside the App Router.
    * The generated RSC entry exposes `/__vinext/prerender/pages-static-paths`
    * so `prerenderPages` can call `getStaticPaths` via `wrangler unstable_startWorker`
@@ -144,7 +153,12 @@ export function generateRscEntry(
   const i18nConfig = config?.i18n ?? null;
   const hasPagesDir = config?.hasPagesDir ?? false;
   const publicFiles = config?.publicFiles ?? [];
-  const manifestCode = buildAppRscManifestCode({ routes, metadataRoutes, globalErrorPath });
+  const manifestCode = buildAppRscManifestCode({
+    routes,
+    metadataRoutes,
+    globalErrorPath,
+    globalNotFoundPath: config?.globalNotFoundPath ?? null,
+  });
   const {
     imports,
     routeEntries,
@@ -155,6 +169,7 @@ export function generateRscEntry(
     rootUnauthorizedVar,
     rootLayoutVars,
     globalErrorVar,
+    globalNotFoundVar,
   } = manifestCode;
   const loadPrerenderPagesRoutesCode = hasPagesDir
     ? `
@@ -336,6 +351,12 @@ const rootNotFoundModule = ${rootNotFoundVar ? rootNotFoundVar : "null"};
 const rootForbiddenModule = ${rootForbiddenVar ? rootForbiddenVar : "null"};
 const rootUnauthorizedModule = ${rootUnauthorizedVar ? rootUnauthorizedVar : "null"};
 const rootLayouts = [${rootLayoutVars.join(", ")}];
+// Root-level app/global-not-found module. When present, route-miss 404s render
+// this module standalone (it provides its own html/body) instead of wrapping
+// the not-found.tsx boundary inside the root layout. Page-triggered notFound()
+// calls still use the regular not-found.tsx boundary inside the layouts.
+// See https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/app-render.tsx#L495-L520
+const globalNotFoundModule = ${globalNotFoundVar ? globalNotFoundVar : "null"};
 
 const createRscOnErrorHandler = (request, pathname, routePath) =>
   createAppRscOnErrorHandler(_reportRequestError, request, pathname, routePath);
@@ -348,6 +369,7 @@ const __fallbackRenderer = __createAppFallbackRenderer({
     rootUnauthorizedModule,
   },
   globalErrorModule: ${globalErrorVar ? globalErrorVar : "null"},
+  globalNotFoundModule,
   metadataRoutes,
   ssrLoader() {
     return import.meta.viteRsc.loadModule("ssr", "index");

--- a/packages/vinext/src/entries/app-rsc-manifest.ts
+++ b/packages/vinext/src/entries/app-rsc-manifest.ts
@@ -13,12 +13,21 @@ type AppRscManifestCode = {
   rootUnauthorizedVar: string | null;
   rootLayoutVars: string[];
   globalErrorVar: string | null;
+  globalNotFoundVar: string | null;
 };
 
 type BuildAppRscManifestCodeOptions = {
   routes: AppRoute[];
   metadataRoutes?: MetadataFileRoute[];
   globalErrorPath?: string | null;
+  /**
+   * Optional `app/global-not-found.tsx` path. When present, route-miss 404s
+   * render this module standalone (it provides its own <html>/<body>) instead
+   * of wrapping the regular not-found boundary inside the root layout.
+   * Mirrors Next.js 16's `experimental.globalNotFound` behavior.
+   * @see https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/app-render.tsx
+   */
+  globalNotFoundPath?: string | null;
 };
 
 type ImportAllocator = {
@@ -212,6 +221,9 @@ export function buildAppRscManifestCode(
   const globalErrorVar = options.globalErrorPath
     ? imports.getImportVar(options.globalErrorPath)
     : null;
+  const globalNotFoundVar = options.globalNotFoundPath
+    ? imports.getImportVar(options.globalNotFoundPath)
+    : null;
 
   const dynamicMetadataRoutes = metadataRoutes.filter((r) => r.isDynamic);
   for (const route of dynamicMetadataRoutes) {
@@ -228,5 +240,6 @@ export function buildAppRscManifestCode(
     rootUnauthorizedVar,
     rootLayoutVars,
     globalErrorVar,
+    globalNotFoundVar,
   };
 }

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -1905,6 +1905,12 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           const metaRoutes = scanMetadataFiles(appDir);
           // Check for global-error.tsx at app root
           const globalErrorPath = findFileWithExts(appDir, "global-error", fileMatcher);
+          // Check for global-not-found.tsx at app root (Next.js 16+ feature)
+          // When present, this file replaces the root layout when serving a
+          // route-miss 404. The file is responsible for emitting its own
+          // <html> and <body> tags (similar to global-error.tsx).
+          // See https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/global-not-found
+          const globalNotFoundPath = findFileWithExts(appDir, "global-not-found", fileMatcher);
           // Collect Layer 1 (segment config) classifications for all layouts.
           // Layer 2 (module graph) runs later in generateBundle once Rollup's
           // module info is available.
@@ -1932,6 +1938,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
               i18n: nextConfig?.i18n,
               hasPagesDir,
               publicFiles: scanPublicFileRoutes(root),
+              globalNotFoundPath,
             },
             instrumentationPath,
           );

--- a/packages/vinext/src/server/app-fallback-renderer.ts
+++ b/packages/vinext/src/server/app-fallback-renderer.ts
@@ -46,6 +46,14 @@ type AppFallbackRendererOptions<TModule extends AppPageModule = AppPageModule> =
   fontProviders: AppFallbackRendererFontProviders;
   getNavigationContext: () => unknown;
   globalErrorModule?: TModule | null;
+  /**
+   * Optional `app/global-not-found.tsx` module. When provided, route-miss 404s
+   * render this module as a standalone document (skipping the root layout)
+   * because it ships its own `<html>` and `<body>`. Page-triggered `notFound()`
+   * calls continue to use the regular `not-found.tsx` boundary inside layouts.
+   * @see https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/app-render.tsx
+   */
+  globalNotFoundModule?: TModule | null;
   makeThenableParams: (params: AppPageParams) => unknown;
   metadataRoutes: MetadataFileRoute[];
   resolveChildSegments: (
@@ -106,6 +114,7 @@ export function createAppFallbackRenderer<TModule extends AppPageModule>(
     fontProviders,
     getNavigationContext,
     globalErrorModule,
+    globalNotFoundModule,
     makeThenableParams,
     metadataRoutes,
     resolveChildSegments,
@@ -128,6 +137,54 @@ export function createAppFallbackRenderer<TModule extends AppPageModule>(
       scriptNonce,
       middlewareContext,
     ) {
+      // global-not-found.tsx replaces the root layout for route-miss 404s.
+      // Only applies when:
+      //   - The user defined app/global-not-found.tsx
+      //   - The 404 originates from a route miss (no matched route)
+      //   - The caller did not already pick a specific boundary component
+      // Page-triggered notFound() calls (route is non-null) keep using the
+      // regular not-found.tsx boundary inside the route's layouts.
+      // See https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/app-render.tsx#L495-L520
+      const useGlobalNotFound =
+        statusCode === 404 && !!globalNotFoundModule && !route && !opts?.boundaryComponent;
+
+      if (useGlobalNotFound) {
+        const globalNotFoundComponent = globalNotFoundModule?.default ?? null;
+        if (globalNotFoundComponent) {
+          return renderAppPageHttpAccessFallback({
+            boundaryComponent: globalNotFoundComponent,
+            buildFontLinkHeader: fontProviders.buildFontLinkHeader,
+            clearRequestContext,
+            createRscOnErrorHandler(pathname, routePath) {
+              return buildRscOnErrorHandler(request, pathname, routePath);
+            },
+            getFontLinks: fontProviders.getFontLinks,
+            getFontPreloads: fontProviders.getFontPreloads,
+            getFontStyles: fontProviders.getFontStyles,
+            getNavigationContext,
+            globalErrorModule,
+            isRscRequest,
+            layoutModules: [],
+            loadSsrHandler: ssrLoader,
+            makeThenableParams,
+            matchedParams: opts?.matchedParams ?? {},
+            middlewareContext: middlewareContext ?? EMPTY_MW_CTX,
+            metadataRoutes,
+            requestUrl: request.url,
+            resolveChildSegments,
+            rootForbiddenModule: null,
+            rootLayouts: [],
+            rootNotFoundModule: null,
+            rootUnauthorizedModule: null,
+            route: null,
+            renderToReadableStream: rscRenderer,
+            scriptNonce,
+            skipLayoutWrapping: true,
+            statusCode,
+          });
+        }
+      }
+
       return renderAppPageHttpAccessFallback({
         boundaryComponent: opts?.boundaryComponent ?? null,
         buildFontLinkHeader: fontProviders.buildFontLinkHeader,

--- a/packages/vinext/src/server/app-page-boundary-render.ts
+++ b/packages/vinext/src/server/app-page-boundary-render.ts
@@ -95,6 +95,14 @@ type RenderAppPageHttpAccessFallbackOptions<TModule extends AppPageModule = AppP
   rootNotFoundModule?: TModule | null;
   rootUnauthorizedModule?: TModule | null;
   route?: AppPageBoundaryRoute<TModule> | null;
+  /**
+   * When true, the resolved boundary is rendered without wrapping it in the
+   * route's layouts. Used by `global-not-found.tsx`, which provides its own
+   * `<html>`/`<body>` and intentionally replaces the root layout.
+   * Mirrors Next.js's `createNotFoundLoaderTree` behavior for `hasGlobalNotFound`.
+   * @see https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/app-render.tsx#L495-L520
+   */
+  skipLayoutWrapping?: boolean;
   statusCode: number;
 } & AppPageBoundaryRenderCommonOptions<TModule>;
 
@@ -317,6 +325,7 @@ export async function renderAppPageHttpAccessFallback<TModule extends AppPageMod
   }
   headElements.push(createElement(ViewportHead, { key: "viewport", viewport }));
 
+  const skipLayoutWrapping = options.skipLayoutWrapping ?? false;
   const element = wrapRenderedBoundaryElement({
     element: createElement(Fragment, null, ...headElements, createElement(boundaryComponent)),
     globalErrorModule: options.globalErrorModule,
@@ -328,13 +337,17 @@ export async function renderAppPageHttpAccessFallback<TModule extends AppPageMod
     matchedParams: options.matchedParams,
     resolveChildSegments: options.resolveChildSegments,
     routeSegments: options.route?.routeSegments,
+    skipLayoutWrapping,
   });
 
   return renderAppPageBoundaryElementResponse({
     ...options,
+    // When global-not-found owns the document, no layouts should contribute to
+    // the RSC payload's layout entries either — otherwise the SSR pipeline
+    // would expect a root-layout tree path that doesn't exist in the markup.
     element,
-    layoutModules,
-    route: options.route,
+    layoutModules: skipLayoutWrapping ? [] : layoutModules,
+    route: skipLayoutWrapping ? null : options.route,
     routePattern: options.route?.pattern,
     status: options.statusCode,
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1291,6 +1291,31 @@ importers:
         specifier: 'catalog:'
         version: 0.1.21(@opentelemetry/api@1.9.1)(@types/node@25.2.3)(@vitest/coverage-istanbul@4.1.5)(@voidzero-dev/vite-plus-core@0.1.21(@types/node@25.2.3)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.8.3))(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.8.3)
 
+  tests/fixtures/global-not-found-basic:
+    dependencies:
+      '@vitejs/plugin-rsc':
+        specifier: 'catalog:'
+        version: 0.5.26(@voidzero-dev/vite-plus-core@0.1.21(@types/node@25.2.3)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.8.3))(react-dom@19.2.6(react@19.2.6))(react-server-dom-webpack@19.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.6
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.6(react@19.2.6)
+      react-server-dom-webpack:
+        specifier: 'catalog:'
+        version: 19.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      vinext:
+        specifier: workspace:*
+        version: link:../../../packages/vinext
+      vite:
+        specifier: npm:@voidzero-dev/vite-plus-core@0.1.21
+        version: '@voidzero-dev/vite-plus-core@0.1.21(@types/node@25.2.3)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.8.3)'
+    devDependencies:
+      vite-plus:
+        specifier: 'catalog:'
+        version: 0.1.21(@opentelemetry/api@1.9.1)(@types/node@25.2.3)(@vitest/coverage-istanbul@4.1.5)(@voidzero-dev/vite-plus-core@0.1.21(@types/node@25.2.3)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.8.3))(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.8.3)
+
   tests/fixtures/pages-basic:
     dependencies:
       react:

--- a/tests/app-fallback-renderer.test.ts
+++ b/tests/app-fallback-renderer.test.ts
@@ -34,6 +34,9 @@ function createRenderer(overrides?: {
     routePath: string,
   ) => (error: unknown, requestInfo: unknown, errorContext: unknown) => unknown;
   sanitizeErrorForClient?: (error: Error) => Error;
+  globalNotFoundModule?: { default: React.ComponentType<any> } | null;
+  rootLayoutModules?: readonly ({ default: React.ComponentType<any> } | null | undefined)[];
+  rootNotFoundModule?: { default: React.ComponentType<any> } | null;
 }) {
   const clearRequestContext = vi.fn();
   const ssrLoader = vi.fn(async () => ({
@@ -68,6 +71,7 @@ function createRenderer(overrides?: {
         return { pathname: "/posts/missing" };
       },
       globalErrorModule: null,
+      globalNotFoundModule: overrides?.globalNotFoundModule ?? null,
       makeThenableParams<T>(params: T) {
         return params;
       },
@@ -77,8 +81,8 @@ function createRenderer(overrides?: {
       },
       rootBoundaries: {
         rootForbiddenModule: null,
-        rootLayouts: [],
-        rootNotFoundModule: null,
+        rootLayouts: overrides?.rootLayoutModules ?? [],
+        rootNotFoundModule: overrides?.rootNotFoundModule ?? null,
         rootUnauthorizedModule: null,
       },
       rscRenderer: renderElementToStream,
@@ -317,5 +321,147 @@ describe("app fallback renderer factory", () => {
     expect(html).toContain('data-layout="override"');
     expect(html).not.toContain("data-params-slug");
     expect(html).toContain('data-boundary="not-found"');
+  });
+});
+
+// Mirrors Next.js 16 experimental.globalNotFound behavior.
+// Ported from Next.js: test/e2e/app-dir/global-not-found/{basic,both-present,not-present}.
+// Source: https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/global-not-found
+// In Next.js, `app/global-not-found.tsx` replaces the root layout for
+// route-miss 404s — see createNotFoundLoaderTree in
+// https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/app-render.tsx#L495-L520
+describe("app fallback renderer with globalNotFoundModule", () => {
+  function RootLayout({ children }: { children: React.ReactNode }) {
+    return React.createElement("html", { lang: "en" }, React.createElement("body", null, children));
+  }
+  const rootLayoutModule = { default: RootLayout } satisfies TestModule;
+
+  function GlobalNotFound() {
+    return React.createElement(
+      "html",
+      { "data-global-not-found": "true" },
+      React.createElement(
+        "body",
+        null,
+        React.createElement("h1", { id: "global-error-title" }, "global-not-found"),
+      ),
+    );
+  }
+  const globalNotFoundModule = { default: GlobalNotFound } satisfies TestModule;
+
+  it("renders global-not-found for route-miss 404 without root layout wrapping", async () => {
+    // Mirrors test/e2e/app-dir/global-not-found/basic:
+    //   visiting /does-not-exist should produce global-not-found's own
+    //   <html data-global-not-found="true"> document, not the root layout's.
+    const { renderer } = createRenderer({
+      globalNotFoundModule,
+      rootLayoutModules: [rootLayoutModule],
+    });
+    const request = new Request("https://example.com/does-not-exist");
+
+    // route = null mirrors the route-miss path in app-rsc-handler.ts:504.
+    const response = await renderer.renderNotFound(null, false, request, undefined, undefined, {
+      headers: null,
+      status: null,
+    });
+
+    expect(response?.status).toBe(404);
+    const html = await response?.text();
+    expect(html).toContain('data-global-not-found="true"');
+    expect(html).toContain('id="global-error-title"');
+    expect(html).toContain("global-not-found");
+    // Root layout was NOT applied — it would have rendered <html lang="en">.
+    expect(html).not.toContain('lang="en"');
+  });
+
+  it("uses the route's not-found.tsx boundary when notFound() is called from a page", async () => {
+    // Mirrors test/e2e/app-dir/global-not-found/basic, /call-not-found case:
+    //   when notFound() is called inside a matched page, the regular
+    //   not-found.tsx boundary should render inside the root layout, NOT the
+    //   global-not-found.tsx document.
+    const { renderer } = createRenderer({
+      globalNotFoundModule,
+      rootLayoutModules: [rootLayoutModule],
+      rootNotFoundModule: notFoundModule,
+    });
+    const request = new Request("https://example.com/call-not-found");
+
+    // route is non-null: simulates a matched page that called notFound().
+    const response = await renderer.renderNotFound(
+      {
+        layouts: [rootLayoutModule],
+        notFound: notFoundModule,
+        params: {},
+        pattern: "/call-not-found",
+      },
+      false,
+      request,
+      undefined,
+      undefined,
+      { headers: null, status: null },
+    );
+
+    expect(response?.status).toBe(404);
+    const html = await response?.text();
+    // Should render the regular not-found boundary inside the root layout.
+    expect(html).toContain('data-boundary="not-found"');
+    expect(html).toContain('lang="en"');
+    // Should NOT render the global-not-found document.
+    expect(html).not.toContain('data-global-not-found="true"');
+  });
+
+  it("falls back to default not-found when global-not-found is absent and route is null", async () => {
+    // Mirrors test/e2e/app-dir/global-not-found/not-present: when the user
+    // opted into experimental.globalNotFound but never created the file,
+    // route-miss 404s should still serve the default 404 response. With no
+    // root notFoundModule either, the renderer returns null and the caller
+    // falls back to the framework's 404 Response.
+    const { renderer } = createRenderer({
+      globalNotFoundModule: null,
+      rootLayoutModules: [rootLayoutModule],
+    });
+    const request = new Request("https://example.com/does-not-exist");
+
+    const response = await renderer.renderNotFound(null, false, request, undefined, undefined, {
+      headers: null,
+      status: null,
+    });
+
+    // No boundary component to render -> renderer returns null.
+    expect(response).toBeNull();
+  });
+
+  it("does not use global-not-found for non-404 access fallbacks (403, 401)", async () => {
+    // global-not-found only applies to 404. Other HTTP access fallbacks
+    // (forbidden / unauthorized) keep their normal behavior.
+    function ForbiddenBoundary() {
+      return React.createElement("p", { "data-boundary": "forbidden" }, "Forbidden");
+    }
+    const forbiddenModule = { default: ForbiddenBoundary } satisfies TestModule;
+
+    const { renderer } = createRenderer({
+      globalNotFoundModule,
+      rootLayoutModules: [rootLayoutModule],
+    });
+    const request = new Request("https://example.com/admin");
+
+    // statusCode 403 with route = null. Should NOT trigger global-not-found.
+    // With no boundary configured, the renderer returns null.
+    const response = await renderer.renderHttpAccessFallback(
+      null,
+      403,
+      false,
+      request,
+      { boundaryComponent: forbiddenModule.default },
+      undefined,
+      { headers: null, status: null },
+    );
+
+    expect(response?.status).toBe(403);
+    const html = await response?.text();
+    expect(html).toContain('data-boundary="forbidden"');
+    // 403 wraps in the root layout (not global-not-found).
+    expect(html).toContain('lang="en"');
+    expect(html).not.toContain('data-global-not-found="true"');
   });
 });

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -299,6 +299,35 @@ describe("App Router generated manifest construction", () => {
     ]);
   });
 
+  it("imports the global-not-found module and exposes its var when provided", () => {
+    // Mirrors how vinext scans `app/global-not-found.tsx` in
+    // packages/vinext/src/index.ts and threads it into the manifest so the
+    // generated RSC entry can hand it to createAppFallbackRenderer.
+    // See https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/global-not-found
+    const manifest = buildAppRscManifestCode({
+      routes: minimalAppRoutes,
+      metadataRoutes: [],
+      globalErrorPath: null,
+      globalNotFoundPath: "/tmp/test/app/global-not-found.tsx",
+    });
+
+    const imports = manifest.imports.join("\n");
+    expect(imports).toContain('from "/tmp/test/app/global-not-found.tsx"');
+    expect(manifest.globalNotFoundVar).toBeTruthy();
+  });
+
+  it("does not import a global-not-found module when the path is absent", () => {
+    const manifest = buildAppRscManifestCode({
+      routes: minimalAppRoutes,
+      metadataRoutes: [],
+      globalErrorPath: null,
+      globalNotFoundPath: null,
+    });
+
+    expect(manifest.imports.join("\n")).not.toContain("global-not-found");
+    expect(manifest.globalNotFoundVar).toBeNull();
+  });
+
   it("serializes graph-minted ids without leaking the filesystem root", async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-app-rsc-manifest-"));
     const appDir = path.join(tmpDir, "app");
@@ -513,6 +542,29 @@ describe("App Router entry templates", () => {
     expect(code).toContain("app-rsc-handler.js");
     expect(code).toContain("export default __createAppRscHandler({");
     expect(code).not.toContain("computeRscCacheBustingSearchParam(");
+  });
+
+  it("generateRscEntry threads globalNotFoundPath from config into the fallback renderer", () => {
+    // The generated entry's createAppFallbackRenderer call must receive a
+    // globalNotFoundModule binding so route-miss 404s can render
+    // app/global-not-found.tsx standalone.
+    // See packages/vinext/src/entries/app-rsc-entry.ts and
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/global-not-found
+    const code = generateRscEntry("/tmp/test/app", minimalAppRoutes, null, [], null, "", false, {
+      globalNotFoundPath: "/tmp/test/app/global-not-found.tsx",
+    });
+
+    expect(code).toContain('from "/tmp/test/app/global-not-found.tsx"');
+    // The renderer is wired with the module binding (not just `null`).
+    expect(code).toContain("globalNotFoundModule,");
+    expect(code).not.toContain("const globalNotFoundModule = null;");
+  });
+
+  it("generateRscEntry emits a null globalNotFoundModule when no path is provided", () => {
+    const code = generateRscEntry("/tmp/test/app", minimalAppRoutes, null, [], null, "", false);
+
+    expect(code).toContain("const globalNotFoundModule = null;");
+    expect(code).not.toContain("global-not-found.tsx");
   });
 
   it("generateRscEntry delegates React Flight preload hint normalization", () => {

--- a/tests/fixtures/global-not-found-basic/app/call-not-found/page.tsx
+++ b/tests/fixtures/global-not-found-basic/app/call-not-found/page.tsx
@@ -1,0 +1,12 @@
+import { notFound } from "next/navigation";
+
+// Mirrors Next.js fixture:
+// https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/global-not-found/basic/app/call-not-found/page.tsx
+//
+// When a page calls notFound(), the regular not-found.tsx boundary (or the
+// framework default) is rendered INSIDE the root layout — not the
+// global-not-found document.
+
+export default function Page() {
+  notFound();
+}

--- a/tests/fixtures/global-not-found-basic/app/global-not-found.tsx
+++ b/tests/fixtures/global-not-found-basic/app/global-not-found.tsx
@@ -1,0 +1,18 @@
+// Mirrors Next.js fixture:
+// https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/global-not-found/basic/app/global-not-found.tsx
+//
+// `global-not-found.tsx` owns its own <html>/<body>. When present, vinext
+// renders this module standalone for route-miss 404s, replacing the root
+// layout (see createAppFallbackRenderer in app-fallback-renderer.ts).
+
+export default function GlobalNotFound() {
+  return (
+    // html tag is intentionally distinct from the root layout's so tests
+    // can assert which document was rendered.
+    <html data-global-not-found="true">
+      <body>
+        <h1 id="global-error-title">global-not-found</h1>
+      </body>
+    </html>
+  );
+}

--- a/tests/fixtures/global-not-found-basic/app/layout.tsx
+++ b/tests/fixtures/global-not-found-basic/app/layout.tsx
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/tests/fixtures/global-not-found-basic/app/page.tsx
+++ b/tests/fixtures/global-not-found-basic/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>;
+}

--- a/tests/fixtures/global-not-found-basic/package.json
+++ b/tests/fixtures/global-not-found-basic/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "global-not-found-basic-fixture",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@vitejs/plugin-rsc": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "react-server-dom-webpack": "catalog:",
+    "vinext": "workspace:*",
+    "vite": "catalog:"
+  },
+  "devDependencies": {
+    "vite-plus": "catalog:"
+  }
+}

--- a/tests/fixtures/global-not-found-basic/tsconfig.json
+++ b/tests/fixtures/global-not-found-basic/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "preserve",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "allowJs": true,
+    "noEmit": true
+  }
+}

--- a/tests/fixtures/global-not-found-basic/vite.config.ts
+++ b/tests/fixtures/global-not-found-basic/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from "vite";
+import vinext from "vinext";
+
+export default defineConfig({
+  plugins: [vinext({ appDir: import.meta.dirname })],
+});

--- a/tests/nextjs-compat/global-not-found.test.ts
+++ b/tests/nextjs-compat/global-not-found.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Next.js Compatibility Tests: global-not-found (basic)
+ *
+ * Ported from: https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/global-not-found/basic/global-not-found-basic.test.ts
+ *
+ * `app/global-not-found.tsx` is a Next.js 16 feature (originally behind
+ * `experimental.globalNotFound`). When present at the app root:
+ *
+ *   - Route-miss 404s (no matched route) render this module standalone.
+ *     The module provides its own `<html>` and `<body>`, replacing the root
+ *     layout — see `createNotFoundLoaderTree` in Next.js:
+ *     https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/app-render.tsx#L495-L520
+ *
+ *   - Page-triggered `notFound()` calls still render the regular `not-found.tsx`
+ *     boundary inside the root layout (or the framework default if absent).
+ *
+ * Fixture: `tests/fixtures/global-not-found-basic/` — minimal app with a root
+ * layout, a homepage, a `/call-not-found` page, and `global-not-found.tsx`.
+ */
+
+import path from "node:path";
+import { describe, it, expect, beforeAll, afterAll } from "vite-plus/test";
+import type { ViteDevServer } from "vite-plus";
+import { startFixtureServer, fetchHtml } from "../helpers.js";
+
+const FIXTURE_DIR = path.resolve(import.meta.dirname, "../fixtures/global-not-found-basic");
+
+describe("Next.js compat: global-not-found (basic)", () => {
+  let server: ViteDevServer;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    ({ server, baseUrl } = await startFixtureServer(FIXTURE_DIR, { appRouter: true }));
+    // Warm up
+    await fetch(`${baseUrl}/`).catch(() => {});
+  }, 60_000);
+
+  afterAll(async () => {
+    await server?.close();
+  });
+
+  it("renders the homepage with the normal root layout", async () => {
+    // Sanity check — the root layout should still wrap matched routes.
+    const { res, html } = await fetchHtml(baseUrl, "/");
+    expect(res.status).toBe(200);
+    expect(html).toContain('lang="en"');
+    expect(html).toContain("hello world");
+    expect(html).not.toContain('data-global-not-found="true"');
+  });
+
+  // Ported from Next.js: test/e2e/app-dir/global-not-found/basic/global-not-found-basic.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/global-not-found/basic/global-not-found-basic.test.ts
+  it("renders global-not-found for route-miss 404 (no root layout)", async () => {
+    const { res, html } = await fetchHtml(baseUrl, "/does-not-exist");
+    expect(res.status).toBe(404);
+    // global-not-found.tsx ships its own <html data-global-not-found="true">.
+    expect(html).toContain('data-global-not-found="true"');
+    expect(html).toContain('id="global-error-title"');
+    expect(html).toContain("global-not-found");
+    // The root layout's html tag (`lang="en"`) must NOT be present — global-
+    // not-found.tsx is supposed to replace it for the 404 document.
+    expect(html).not.toMatch(/<html[^>]*\blang="en"/);
+  });
+
+  it("produces exactly one <html> and one <body> for the global-not-found document", async () => {
+    // Structural integrity check: when global-not-found.tsx renders standalone
+    // the root layout's <html>/<body> must NOT also appear in the markup.
+    const { html } = await fetchHtml(baseUrl, "/does-not-exist");
+    const htmlTags = (html.match(/<html/gi) ?? []).length;
+    const bodyTags = (html.match(/<body/gi) ?? []).length;
+    expect(htmlTags, `expected 1 <html> tag, got ${htmlTags}`).toBe(1);
+    expect(bodyTags, `expected 1 <body> tag, got ${bodyTags}`).toBe(1);
+  });
+
+  // Ported from Next.js: test/e2e/app-dir/global-not-found/basic/global-not-found-basic.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/global-not-found/basic/global-not-found-basic.test.ts
+  it("does not use the global-not-found document when notFound() is called from a page", async () => {
+    // /call-not-found is a matched page that calls notFound(). The page-call
+    // path must NOT trigger the global-not-found document — that document is
+    // reserved for route-miss 404s.
+    //
+    // NOTE: Next.js parity goes further — it renders the default `404 / This
+    // page could not be found.` inside the root layout (so `<html lang="en">`
+    // is present). Vinext currently returns a plain "Not Found" body for
+    // page-call 404s when no `not-found.tsx` boundary is configured; that
+    // pre-existing parity gap is tracked separately and is out of scope for
+    // this PR. The assertion below covers only the global-not-found
+    // protection that this PR introduces.
+    const { res, html } = await fetchHtml(baseUrl, "/call-not-found");
+    expect(res.status).toBe(404);
+    // global-not-found document must NOT be used for page-call notFound().
+    expect(html).not.toContain('data-global-not-found="true"');
+    expect(html).not.toContain('id="global-error-title"');
+  });
+});


### PR DESCRIPTION
## Summary

Implements parity for Next.js 16's `experimental.globalNotFound` feature. When a user defines `app/global-not-found.tsx`, route-miss 404s render that module standalone — it provides its own `<html>`/`<body>` and replaces the root layout. Page-triggered `notFound()` calls keep using the regular `not-found.tsx` boundary inside layouts.

Next.js sources:
- Test fixtures: https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/global-not-found
- Implementation: `createNotFoundLoaderTree` in https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/app-render.tsx#L495-L520

## Triage context (B7 grab-bag)

This is one of the smaller, contained bugs in the B7 category from the deploy suite analysis. I picked it because:

1. **No open PR** covers `global-not-found` (`feat/asset-prefix` #474 is the only related PR and only touches `assetPrefix`).
2. **Multiple Next.js fixture variants** are blocked by the same root gap (vinext literally had zero references to `global-not-found` in `packages/vinext/src/` before this PR): `basic`, `both-present`, `not-present`, `metadata`, `css`, `cache-components`, `no-root-layout` — seven fixtures under `.nextjs-ref/test/e2e/app-dir/global-not-found/`.
3. **The fix is contained**: codegen + fallback renderer, no changes to request lifecycle or routing.

## Implementation

- **Discovery** (`src/index.ts`): scan for `app/global-not-found.{tsx,ts,jsx,js}` alongside the existing `global-error` scan.
- **Codegen** (`entries/app-rsc-entry.ts`, `entries/app-rsc-manifest.ts`): thread `globalNotFoundPath` through `AppRouterConfig` and the manifest builder so the generated RSC entry imports the module and binds it to `createAppFallbackRenderer` as `globalNotFoundModule`.
- **Render path** (`server/app-fallback-renderer.ts`): `renderHttpAccessFallback` switches to the global-not-found document when `statusCode === 404`, the route is `null` (route-miss), and no boundary override was supplied. Page-triggered `notFound()` calls (route is non-null) keep the existing behavior.
- **Standalone rendering** (`server/app-page-boundary-render.ts`): new `skipLayoutWrapping` option causes the boundary to render without root-layout wrapping, and zeroes out the RSC payload's layout entries so the SSR side does not expect a layout tree path the markup doesn't contain.

## Tests

- **Unit (4 new in `app-fallback-renderer.test.ts`)** — covers route-miss with global-not-found, page-call with global-not-found, absent global-not-found, and 403/401 unaffected.
- **Codegen (4 new in `entry-templates.test.ts`)** — verifies manifest import and generated-entry wiring in both directions.
- **Integration (4 in new `nextjs-compat/global-not-found.test.ts`)** — ports the Next.js `basic` fixture against a dev server: route-miss renders global-not-found standalone, exactly one `<html>`/`<body>`, page-call `notFound()` does not use the global-not-found document.

All 423 tests in the targeted suite pass. `vp check` passes.

## Known scope notes

- The new fixture is dev-server-driven (matches the pattern of other `nextjs-compat` tests). Production preview parity would be an easy follow-up.
- Page-call `notFound()` without a `not-found.tsx` boundary currently returns a plain `Not Found` body in vinext, whereas Next.js renders the default `404 / This page could not be found.` inside the root layout. That pre-existing parity gap is **out of scope for this PR**; the integration test documents it and asserts only the global-not-found protection.

## Out of scope (follow-up candidates in B7)

See the report attached to this task — `react-version` pinning, `server-actions-relative-redirect`, `global-error` rendering edge cases, middleware-redirects parity, etc.