### PR TITLE
fix(navigation): populate useParams/useSearchParams under Pages Router

### DIFF
--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -254,6 +254,49 @@ export function _registerStateAccessors(accessors: _StateAccessors): void {
   _clearInsertedHTMLCallbacks = accessors.clearInsertedHTMLCallbacks;
 }
 
+// ---------------------------------------------------------------------------
+// Pages Router compat source.
+//
+// `next/navigation` is the App Router API surface, but Next.js exposes the
+// same hook names to Pages Router pages as a compat shim. In Next.js this is
+// done by wrapping pages with SearchParamsContext / PathParamsContext /
+// PathnameContext providers populated from the Pages Router's state — see:
+// .nextjs-ref/packages/next/src/server/render.tsx
+// .nextjs-ref/packages/next/src/client/index.tsx
+// .nextjs-ref/packages/next/src/shared/lib/router/adapters.tsx
+//
+// vinext drives these hooks from a module-level navigation context instead of
+// React Context, so we fall back to a Pages Router accessor when no App
+// Router context is set. The accessor is published by next/router via a
+// global Symbol.for handle (see packages/vinext/src/shims/router.ts); we do
+// NOT import router.ts here because doing so would force navigation.ts to be
+// loaded for every consumer of next/router, triggering window.history
+// patches in unit tests that only want the router shim.
+// ---------------------------------------------------------------------------
+
+type PagesNavigationContext = {
+  pathname: string;
+  searchParams: URLSearchParams;
+  params: Record<string, string | string[]>;
+};
+
+const PAGES_NAVIGATION_ACCESSOR_KEY = Symbol.for(
+  "vinext.navigation.pagesNavigationContextAccessor",
+);
+type _GlobalWithPagesAccessor = typeof globalThis & {
+  [PAGES_NAVIGATION_ACCESSOR_KEY]?: () => PagesNavigationContext | null;
+};
+
+function _getPagesNavigationContext(): PagesNavigationContext | null {
+  const accessor = (globalThis as _GlobalWithPagesAccessor)[PAGES_NAVIGATION_ACCESSOR_KEY];
+  if (!accessor) return null;
+  try {
+    return accessor();
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Get the navigation context for the current SSR/RSC render.
  * Reads from AsyncLocalStorage when available (concurrent-safe),
@@ -822,7 +865,13 @@ function getServerSearchParamsSnapshot(): ReadonlyURLSearchParams {
   const ctx = _getServerContext() as NavigationContextWithReadonlyCache | null;
 
   if (!ctx) {
-    // No server context available - return cached empty instance
+    // No App Router server context - try Pages Router compat shim.
+    // See `adaptForSearchParams` in Next.js's adapters:
+    // .nextjs-ref/packages/next/src/shared/lib/router/adapters.tsx
+    const pagesCtx = _getPagesNavigationContext();
+    if (pagesCtx) {
+      return new ReadonlyURLSearchParams(pagesCtx.searchParams);
+    }
     if (_cachedEmptyServerSearchParams === null) {
       _cachedEmptyServerSearchParams = new ReadonlyURLSearchParams();
     }
@@ -998,11 +1047,25 @@ export function clearPendingPathname(navId: number): void {
 }
 
 function getClientParamsSnapshot(): Record<string, string | string[]> {
-  return getClientNavigationState()?.clientParams ?? _EMPTY_PARAMS;
+  const state = getClientNavigationState();
+  if (state && Object.keys(state.clientParams).length > 0) {
+    return state.clientParams;
+  }
+  // Fall back to the Pages Router compat shim if nothing has populated the
+  // App Router client params (Pages Router pages never call setClientParams).
+  const pagesCtx = _getPagesNavigationContext();
+  if (pagesCtx) return pagesCtx.params;
+  return state?.clientParams ?? _EMPTY_PARAMS;
 }
 
 function getServerParamsSnapshot(): Record<string, string | string[]> {
-  return _getServerContext()?.params ?? _EMPTY_PARAMS;
+  const ctx = _getServerContext();
+  if (ctx) return ctx.params;
+  // No App Router navigation context — fall back to Pages Router state.
+  // See `adaptForPathParams` in Next.js's pages-router adapter:
+  // .nextjs-ref/packages/next/src/shared/lib/router/adapters.tsx
+  const pagesCtx = _getPagesNavigationContext();
+  return pagesCtx?.params ?? _EMPTY_PARAMS;
 }
 
 function subscribeToNavigation(cb: () => void): () => void {
@@ -1024,14 +1087,17 @@ export function usePathname(): string {
   if (isServer) {
     // During SSR of "use client" components, the navigation context may not be set.
     // Return a safe fallback — the client will hydrate with the real value.
-    return _getServerContext()?.pathname ?? "/";
+    const ctx = _getServerContext();
+    if (ctx) return ctx.pathname;
+    // Pages Router compat shim: derive pathname from the Pages Router state.
+    return _getPagesNavigationContext()?.pathname ?? "/";
   }
   const renderSnapshot = useClientNavigationRenderSnapshot();
   // Client-side: use the hook system for reactivity
   const pathname = React.useSyncExternalStore(
     subscribeToNavigation,
     getPathnameSnapshot,
-    () => _getServerContext()?.pathname ?? "/",
+    () => _getServerContext()?.pathname ?? _getPagesNavigationContext()?.pathname ?? "/",
   );
   // Prefer the render snapshot during an active navigation transition so
   // hooks return the pending URL, not the stale committed one. After commit,
@@ -1051,7 +1117,7 @@ export function usePathname(): string {
 export function useSearchParams(): ReadonlyURLSearchParams {
   if (isServer) {
     // During SSR for "use client" components, the navigation context may not be set.
-    // Return a safe fallback — the client will hydrate with the real value.
+    // getServerSearchParamsSnapshot also covers the Pages Router compat shim.
     return getServerSearchParamsSnapshot();
   }
   const renderSnapshot = useClientNavigationRenderSnapshot();
@@ -1076,7 +1142,8 @@ export function useParams<
 >(): T {
   if (isServer) {
     // During SSR for "use client" components, the navigation context may not be set.
-    return (_getServerContext()?.params ?? _EMPTY_PARAMS) as T;
+    // getServerParamsSnapshot covers both App Router and Pages Router compat.
+    return getServerParamsSnapshot() as T;
   }
   const renderSnapshot = useClientNavigationRenderSnapshot();
   const params = React.useSyncExternalStore(

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -271,6 +271,86 @@ export function setSSRContext(ctx: SSRContext | null): void {
   _setSSRContextImpl(ctx);
 }
 
+type PagesNavigationContextShape = {
+  pathname: string;
+  searchParams: URLSearchParams;
+  params: Record<string, string | string[]>;
+};
+
+// Client-only cache for snapshot stability. useSyncExternalStore compares
+// snapshots with Object.is, so returning a fresh object on every render would
+// trigger re-render loops. We use a module-level cache keyed by URL inputs;
+// this is safe in the browser because there is exactly one request at a time
+// but it must NOT be used on the server (concurrent ALS-scoped requests).
+let _cachedClientPagesNavCtx: PagesNavigationContextShape | null = null;
+let _cachedClientPagesNavCtxKey: string | null = null;
+
+function _buildClientPagesNavigationContext(
+  routePattern: string,
+  resolvedPath: string,
+  searchString: string,
+): PagesNavigationContextShape {
+  const cacheKey = `${routePattern}|${resolvedPath}|${searchString}`;
+  if (_cachedClientPagesNavCtxKey === cacheKey && _cachedClientPagesNavCtx) {
+    return _cachedClientPagesNavCtx;
+  }
+  const searchParams = new URLSearchParams(searchString);
+  const params = routePattern ? (extractRouteParamsFromPath(routePattern, resolvedPath) ?? {}) : {};
+  const ctx: PagesNavigationContextShape = { pathname: resolvedPath, searchParams, params };
+  _cachedClientPagesNavCtx = ctx;
+  _cachedClientPagesNavCtxKey = cacheKey;
+  return ctx;
+}
+
+/**
+ * Cross-router compat shim source for `next/navigation` hooks.
+ *
+ * Returns the current Pages Router state shaped as a navigation context so
+ * the App Router hooks (useParams/useSearchParams/usePathname) can act as
+ * compat shims when invoked inside a Pages Router render. Mirrors Next.js's
+ * `adaptForPathParams` and `adaptForSearchParams` in
+ * .nextjs-ref/packages/next/src/shared/lib/router/adapters.tsx, which Next.js
+ * uses to populate SearchParamsContext / PathParamsContext for the Pages
+ * Router (see packages/next/src/server/render.tsx and
+ * packages/next/src/client/index.tsx).
+ *
+ * Returns `null` when there is no Pages Router state available — e.g. App
+ * Router pages, RSC-only renders, or pre-router renders. Callers should
+ * treat null as "App Router context, use normal app-router state".
+ */
+export function getPagesNavigationContext(): PagesNavigationContextShape | null {
+  if (typeof window === "undefined") {
+    const ssrCtx = _getSSRContext();
+    if (!ssrCtx) return null;
+    // ssrCtx.pathname is the route pattern (e.g. "/blog/[slug]").
+    // ssrCtx.asPath is the resolved URL with query string. For useSearchParams
+    // we want only the URL search string; for useParams we want only the
+    // dynamic route params. Build a fresh object each call — server scope is
+    // request-isolated via ALS but module state must not be cached across
+    // concurrent requests.
+    let searchParams: URLSearchParams;
+    let resolvedPath: string;
+    try {
+      const url = new URL(ssrCtx.asPath, "http://_");
+      searchParams = url.searchParams;
+      resolvedPath = url.pathname;
+    } catch {
+      searchParams = new URLSearchParams();
+      resolvedPath = ssrCtx.pathname;
+    }
+    const params = extractRouteParamsFromPath(ssrCtx.pathname, resolvedPath) ?? {};
+    return { pathname: resolvedPath, searchParams, params };
+  }
+
+  // Client: derive from window.location + __NEXT_DATA__. __NEXT_DATA__.page
+  // is the route pattern that was matched; navigateClient() keeps it in sync
+  // with the visible URL on every client-side navigation. Cached so
+  // useSyncExternalStore sees a stable snapshot between renders.
+  const resolvedPath = stripBasePath(window.location.pathname, __basePath);
+  const pattern = window.__NEXT_DATA__?.page ?? "";
+  return _buildClientPagesNavigationContext(pattern, resolvedPath, window.location.search);
+}
+
 /**
  * Extract param names from a Next.js route pattern.
  * E.g., "/posts/[id]" → ["id"], "/docs/[...slug]" → ["slug"],
@@ -1001,5 +1081,20 @@ if (typeof window !== "undefined") {
   // and treat the surface as opaque.
   installWindowNext({ router: Router as unknown as PagesRouterPublicInstance });
 }
+
+// Register the Pages Router compat shim source for `next/navigation` hooks
+// (useParams / useSearchParams / usePathname). The accessor is exposed
+// through a well-known Symbol.for so navigation.ts can read it without
+// importing this module — that avoids triggering navigation.ts's
+// `window.history.pushState` patch in tests that only need next/router.
+//
+// Mirrors Next.js's behavior where the pages-router server (render.tsx) and
+// client (client/index.tsx) wrap pages with SearchParamsContext /
+// PathParamsContext / PathnameContext providers populated from the router.
+const _PAGES_NAVIGATION_ACCESSOR_KEY = Symbol.for(
+  "vinext.navigation.pagesNavigationContextAccessor",
+);
+(globalThis as Record<PropertyKey, unknown>)[_PAGES_NAVIGATION_ACCESSOR_KEY] =
+  getPagesNavigationContext;
 
 export default Router;

--- a/tests/fixtures/pages-basic/pages/nav-compat/[slug].tsx
+++ b/tests/fixtures/pages-basic/pages/nav-compat/[slug].tsx
@@ -1,0 +1,24 @@
+// Pages Router fixture that uses `next/navigation` hooks.
+// Mirrors the Next.js test in:
+// .nextjs-ref/test/e2e/app-dir/params-hooks-compat/shared/params-component.js
+//
+// Under Pages Router, useParams() must return ONLY the dynamic route params
+// (no query-string keys) and useSearchParams() must return ONLY the query
+// string (no route param keys). See `adaptForSearchParams` and
+// `adaptForPathParams` in Next.js:
+// https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/router/adapters.tsx
+import { useParams, useSearchParams } from "next/navigation";
+
+export default function PagesNavCompat() {
+  const params = useParams();
+  const searchParams = useSearchParams();
+  const searchObject = Object.fromEntries(searchParams ? searchParams.entries() : []);
+  return (
+    <div>
+      <h2>useParams()</h2>
+      <pre id="use-params">{JSON.stringify(params)}</pre>
+      <h2>useSearchParams()</h2>
+      <pre id="use-search-params">{JSON.stringify(searchObject)}</pre>
+    </div>
+  );
+}

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -374,6 +374,32 @@ describe("Pages Router integration", () => {
     expect(html).toContain("/compat-router-test");
   });
 
+  // Ported from Next.js: test/e2e/app-dir/params-hooks-compat/index.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/params-hooks-compat/index.test.ts
+  // Under Pages Router, hooks from `next/navigation` must work as compat shims
+  // populated from the Pages Router (next/router) state — useParams returns
+  // ONLY dynamic route params (no query keys), useSearchParams returns ONLY
+  // the URL search string (no route params).
+  it("next/navigation useParams returns only dynamic route params under Pages Router", async () => {
+    const res = await fetch(`${baseUrl}/nav-compat/foobar?a=pages`);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    const paramsMatch = html.match(/<pre id="use-params">([^<]*)<\/pre>/);
+    expect(paramsMatch).not.toBeNull();
+    const params = JSON.parse(paramsMatch![1].replaceAll("&quot;", '"'));
+    expect(params).toEqual({ slug: "foobar" });
+  });
+
+  it("next/navigation useSearchParams returns only query string under Pages Router", async () => {
+    const res = await fetch(`${baseUrl}/nav-compat/foobar?q=pages`);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    const searchMatch = html.match(/<pre id="use-search-params">([^<]*)<\/pre>/);
+    expect(searchMatch).not.toBeNull();
+    const search = JSON.parse(searchMatch![1].replaceAll("&quot;", '"'));
+    expect(search).toEqual({ q: "pages" });
+  });
+
   it("does not collapse encoded slashes onto nested routes in dev", async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-pages-encoded-dev-"));
     writeEncodedSlashPagesFixture(tmpDir);


### PR DESCRIPTION
## Summary

Under the Pages Router, hooks from `next/navigation` returned empty objects:

```
expect(pagesParamsJSON).toEqual({ slug: 'foobar' })       // got {}
expect(pagesSearchparamsJSON).toEqual({ q: 'pages' })     // got {}
```

This blocks the Next.js deploy-suite tests:
- `test/e2e/app-dir/params-hooks-compat/index.test.ts`
- `test/e2e/app-dir/use-params/use-params.test.ts` ("should work on pages router")
- `test/e2e/app-dir/app-root-params-getters/simple.test.ts`

## Root cause

Next.js treats `next/navigation` as a cross-router compat shim. The Pages
Router server ([`server/render.tsx`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/render.tsx))
and client ([`client/index.tsx`](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/index.tsx))
wrap each page with `SearchParamsContext` / `PathParamsContext` /
`PathnameContext` providers populated from the router via
`adaptForSearchParams` and `adaptForPathParams` in
[`shared/lib/router/adapters.tsx`](https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/router/adapters.tsx).

vinext drives those hooks from a module-level navigation context that is
only set for App Router renders. For Pages Router renders the context is
null, so `useParams` / `useSearchParams` / `usePathname` fell through to
empty fallbacks.

## Fix

A Pages Router compat source is published by `next/router` through a
`Symbol.for` global handle. `next/navigation` reads that handle when
the App Router context is null and derives:

- `pathname` from `window.location` / SSR `asPath`
- `searchParams` from the URL query string only (not merged route
  params, matching `adaptForSearchParams`)
- `params` from the route pattern matched against the resolved path
  (matching `adaptForPathParams`)

The publisher is exposed via `globalThis[Symbol.for(...)]` rather than a
direct module import so `navigation.ts` does not become a transitive
dependency of every `next/router` consumer. (Importing `navigation.ts`
runs its `window.history.pushState` patch at module load time, which
breaks unit tests that only need `next/router`.)

## Testing

New vitest cases at `tests/pages-router.test.ts`:
- `next/navigation useParams returns only dynamic route params under Pages Router`
- `next/navigation useSearchParams returns only query string under Pages Router`

backed by a new fixture page at
`tests/fixtures/pages-basic/pages/nav-compat/[slug].tsx` that mirrors
[`params-hooks-compat/shared/params-component.js`](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/params-hooks-compat/shared/params-component.js).

Verified:
- `vp test run tests/pages-router.test.ts tests/shims.test.ts tests/nextjs-compat/` — **1387 passed / 2 skipped**
- `vp test run tests/app-router.test.ts tests/features.test.ts` — **610 passed**
- `vp check` — clean (format, lint, types)

## Notes

- App Router behaviour is unchanged. The fallback only runs when
  `_getServerContext()` returns null, which never happens during an
  App Router render.
- Pages dev (`server/dev-server.ts`) and prod (`server/prod-server.ts` →
  `entries/pages-server-entry.ts`) both go through `setSSRContext` on
  `next/router`, so the compat shim is populated for both modes.
- The client-side pages context is cached by URL inputs so
  `useSyncExternalStore` consumers see a stable snapshot reference
  across renders.