### PR TITLE
wip(metadata): scaffold streaming metadata path (RSC->SSR Suspense unresolved)

### DIFF
--- a/packages/vinext/src/server/app-page-element-builder.ts
+++ b/packages/vinext/src/server/app-page-element-builder.ts
@@ -204,18 +204,24 @@ export async function buildPageElements<
     viewport: resolvedViewport,
   } = headSettled;
 
-  // Defer the metadata promise across a microtask so React sees it as pending
-  // when reaching the Suspense boundary. Without this, an already-resolved
-  // promise gets inlined and React 19 Float hoists the `<title>` etc. to
-  // `<head>` — defeating the purpose of streaming. The microtask deferral
-  // also matches Next.js's behavior where the metadata resolves AFTER the
-  // initial shell flushes.
-  // NOTE (WIP): synchronously-resolved promise is not enough — see
-  // `metadata-streaming.ts` for the open question about Suspense streaming
-  // through the RSC->SSR pipeline. Even with a setTimeout-deferred promise
-  // (tried up to 200ms), React still hoists the streamed <title> to <head>
-  // because the RSC payload may already have the resolved chunk by the time
-  // SSR begins consuming. Left here as scaffolding for the next iteration.
+  // NOTE (WIP): this scaffolding does not yet stream metadata to <body>.
+  //
+  // The fundamental issue: `resolveAppPageHead` is awaited above BEFORE the
+  // element tree is constructed. By the time we hand the promise to the
+  // RSC-side `<Suspense>` boundary it is already settled, so the RSC
+  // payload serializes the resolved tree synchronously and SSR sees no
+  // pending Suspense to stream through. Even a microtask- or 200ms-deferred
+  // promise didn't help — confirmed by experiment.
+  //
+  // Path forward (next iteration):
+  //   1. Thread the metadata promise through `handleSsr` (alongside
+  //      navigationContext) so the Suspense lives in the SSR tree, not
+  //      the RSC tree.
+  //   2. Render the Suspense + `<div hidden>` wrapper inside
+  //      `app-ssr-entry.ts` where React's `renderToReadableStream` can
+  //      observe a pending promise and emit a `<template>` placeholder.
+  //   3. The RSC payload either omits metadata or uses a sentinel; the
+  //      SSR layer is solely responsible for emitting the resolved tags.
   const streamingMetadata: Promise<{ metadata: Metadata | null }> | null = useStreamingMetadata
     ? Promise.resolve({ metadata: resolvedMetadata })
     : null;

--- a/packages/vinext/src/server/app-page-element-builder.ts
+++ b/packages/vinext/src/server/app-page-element-builder.ts
@@ -17,6 +17,8 @@ import { normalizePathnameForRouteMatch } from "../routing/utils.js";
 import type { MetadataFileRoute } from "./metadata-routes.js";
 import { APP_RSC_RENDER_MODE_NAVIGATION, type AppRscRenderMode } from "./app-rsc-render-mode.js";
 import { isInterceptionMatchedUrlPath, normalizePath } from "./normalize-path.js";
+import { hasDynamicMetadataModules, shouldStreamMetadata } from "./metadata-streaming.js";
+import type { Metadata } from "vinext/shims/metadata";
 
 export type { AppPageErrorModule, AppPageRouteWiringRoute } from "./app-page-route-wiring.js";
 
@@ -151,12 +153,26 @@ export async function buildPageElements<
     };
   }
 
-  const {
-    hasSearchParams,
-    metadata: resolvedMetadata,
-    pageSearchParams,
-    viewport: resolvedViewport,
-  } = await resolveAppPageHead({
+  // Decide whether to stream metadata into <body> (Next.js 15+ behavior) or
+  // block on resolution and emit it into <head>. Streaming is only enabled
+  // when the route has a `generateMetadata`/`generateViewport` somewhere AND
+  // the request is not an HTML-only bot AND not an RSC navigation. The RSC
+  // payload still needs fully-resolved metadata so the client router can put
+  // it in the right place; streaming only applies to the initial document
+  // SSR.
+  const metadataModules: Array<Record<string, unknown> | null | undefined> = [
+    ...route.layouts,
+    route.page ?? null,
+  ];
+  const hasDynamic = hasDynamicMetadataModules(metadataModules);
+  const userAgent = pageRequest.request.headers.get("user-agent");
+  const useStreamingMetadata = shouldStreamMetadata({
+    hasDynamic,
+    userAgent,
+    isRscRequest,
+  });
+
+  const headResolution = resolveAppPageHead({
     layoutModules: route.layouts,
     layoutTreePositions: route.layoutTreePositions,
     metadataRoutes,
@@ -175,6 +191,34 @@ export async function buildPageElements<
     routeSegments: route.routeSegments ?? null,
     searchParams,
   });
+
+  // Always await once to get search-params info (needed for page props) and
+  // the resolved viewport (needed for the static head emission even in the
+  // streaming path). When streaming, we forward the same promise into the
+  // tree so React can stream the metadata tags into <body> via Suspense.
+  const headSettled = await headResolution;
+  const {
+    hasSearchParams,
+    metadata: resolvedMetadata,
+    pageSearchParams,
+    viewport: resolvedViewport,
+  } = headSettled;
+
+  // Defer the metadata promise across a microtask so React sees it as pending
+  // when reaching the Suspense boundary. Without this, an already-resolved
+  // promise gets inlined and React 19 Float hoists the `<title>` etc. to
+  // `<head>` — defeating the purpose of streaming. The microtask deferral
+  // also matches Next.js's behavior where the metadata resolves AFTER the
+  // initial shell flushes.
+  // NOTE (WIP): synchronously-resolved promise is not enough — see
+  // `metadata-streaming.ts` for the open question about Suspense streaming
+  // through the RSC->SSR pipeline. Even with a setTimeout-deferred promise
+  // (tried up to 200ms), React still hoists the streamed <title> to <head>
+  // because the RSC payload may already have the resolved chunk by the time
+  // SSR begins consuming. Left here as scaffolding for the next iteration.
+  const streamingMetadata: Promise<{ metadata: Metadata | null }> | null = useStreamingMetadata
+    ? Promise.resolve({ metadata: resolvedMetadata })
+    : null;
 
   const pageProps: Record<string, unknown> = { params: makeThenableParams(params) };
   if (searchParams) {
@@ -196,8 +240,12 @@ export async function buildPageElements<
     mountedSlotIds,
     makeThenableParams,
     matchedParams: params,
-    resolvedMetadata,
+    // In streaming mode, suppress the resolvedMetadata from the synchronous
+    // head emission so the static head only contains charset + viewport.
+    // The same metadata will arrive via the streamingMetadata promise.
+    resolvedMetadata: useStreamingMetadata ? null : resolvedMetadata,
     resolvedViewport,
+    streamingMetadata,
     interceptionContext: opts?.interceptionContext ?? null,
     interception,
     routePath,

--- a/packages/vinext/src/server/app-page-route-wiring.tsx
+++ b/packages/vinext/src/server/app-page-route-wiring.tsx
@@ -145,6 +145,21 @@ type BuildAppPageRouteElementOptions<
   matchedParams: AppPageParams;
   resolvedMetadata: Metadata | null;
   resolvedViewport: Viewport;
+  /**
+   * When set, dynamic metadata is rendered as a Suspense-wrapped async element
+   * placed after the route tree so the streamed `<title>` / `<meta>` / `<link>`
+   * tags appear inside `<body>` in the initial SSR HTML. React 19 Float hoists
+   * them to `<head>` during hydration on the client.
+   *
+   * The promise should resolve to the same shape `resolveAppPageHead` returns,
+   * but the caller is responsible for ensuring the static portion (charset,
+   * viewport) is already encoded in `resolvedViewport`/`resolvedMetadata` so
+   * the initial shell can flush without waiting for the promise.
+   *
+   * Ported from Next.js's MetadataBoundary pattern:
+   *   https://github.com/vercel/next.js/blob/canary/packages/next/src/lib/metadata/metadata.tsx
+   */
+  streamingMetadata?: Promise<{ metadata: Metadata | null }> | null;
   rootForbiddenModule?: TModule | null;
   rootNotFoundModule?: TModule | null;
   rootUnauthorizedModule?: TModule | null;
@@ -354,6 +369,53 @@ function createAppPageRouteHead(metadata: Metadata | null, viewport: Viewport): 
       {metadata ? <MetadataHead metadata={metadata} /> : null}
       <ViewportHead viewport={viewport} />
     </>
+  );
+}
+
+/**
+ * Static portion of the head that always flushes synchronously: charset and
+ * viewport. Used by the streaming path so the initial shell can include
+ * device-width viewport and utf-8 charset without waiting for `generateMetadata`.
+ */
+function createAppPageStaticHead(viewport: Viewport): ReactNode {
+  return (
+    <>
+      <meta charSet="utf-8" />
+      <ViewportHead viewport={viewport} />
+    </>
+  );
+}
+
+/**
+ * Async component that awaits the metadata promise and renders the resolved
+ * `<title>`, `<meta>`, and `<link>` tags. Wrapped in `<Suspense>` and
+ * `<div hidden>` so React streams the tags into the document body after the
+ * initial flush. React 19 Float hoists them to `<head>` during hydration.
+ */
+async function StreamingMetadataTags({
+  metadataPromise,
+}: {
+  metadataPromise: Promise<{ metadata: Metadata | null }>;
+}) {
+  const { metadata } = await metadataPromise;
+  if (!metadata) return null;
+  return <MetadataHead metadata={metadata} />;
+}
+
+function createAppPageStreamingMetadata(
+  metadataPromise: Promise<{ metadata: Metadata | null }>,
+): ReactNode {
+  // The <div hidden> wrapper holds the Suspense placeholder so the streamed
+  // metadata tags land inside <body> in the SSR HTML (the initial shell only
+  // contains the placeholder; the tags arrive in a later <template> chunk).
+  // We mark the wrapper with a data attribute for debugging and so the
+  // client-side icon-reinsertion script can target it if needed.
+  return (
+    <div hidden data-vinext-streaming-metadata>
+      <Suspense fallback={null}>
+        <StreamingMetadataTags metadataPromise={metadataPromise} />
+      </Suspense>
+    </div>
   );
 }
 
@@ -835,12 +897,26 @@ export function buildAppPageElements<
     routeChildren = <ErrorBoundary fallback={globalErrorComponent}>{routeChildren}</ErrorBoundary>;
   }
 
-  elements[routeId] = (
-    <>
-      {createAppPageRouteHead(options.resolvedMetadata, options.resolvedViewport)}
-      {routeChildren}
-    </>
-  );
+  // Streaming metadata path: render static charset+viewport into <head>,
+  // emit the route tree, then append a hidden <Suspense> wrapper whose
+  // streamed content lands inside <body>. The client-side React 19 Float
+  // runtime hoists the resolved <title>/<meta>/<link> tags to <head>.
+  if (options.streamingMetadata) {
+    elements[routeId] = (
+      <>
+        {createAppPageStaticHead(options.resolvedViewport)}
+        {routeChildren}
+        {createAppPageStreamingMetadata(options.streamingMetadata)}
+      </>
+    );
+  } else {
+    elements[routeId] = (
+      <>
+        {createAppPageRouteHead(options.resolvedMetadata, options.resolvedViewport)}
+        {routeChildren}
+      </>
+    );
+  }
 
   return elements;
 }

--- a/packages/vinext/src/server/app-page-route-wiring.tsx
+++ b/packages/vinext/src/server/app-page-route-wiring.tsx
@@ -376,6 +376,13 @@ function createAppPageRouteHead(metadata: Metadata | null, viewport: Viewport): 
  * Static portion of the head that always flushes synchronously: charset and
  * viewport. Used by the streaming path so the initial shell can include
  * device-width viewport and utf-8 charset without waiting for `generateMetadata`.
+ *
+ * TODO(#1305): once the streaming metadata path is fully wired, the dynamic
+ * `<MetadataHead>` may also include a charset/viewport tag from user-supplied
+ * metadata. We'll need to deduplicate so the initial shell and the streamed
+ * tags don't both emit conflicting `<meta charset>` or `<meta name="viewport">`.
+ * For now this is harmless because streaming is gated behind a path that
+ * never actually streams (see app-page-element-builder.ts WIP note).
  */
 function createAppPageStaticHead(viewport: Viewport): ReactNode {
   return (

--- a/packages/vinext/src/server/metadata-streaming.ts
+++ b/packages/vinext/src/server/metadata-streaming.ts
@@ -27,6 +27,11 @@
 // Known HTML-only bots that don't execute JavaScript. These get a blocking
 // response with metadata in <head>. Matches Next.js's HTML_LIMITED_BOT_UA_RE.
 //
+// Note: `Googlebot` is intentionally excluded — modern Googlebot renders JS
+// (Chromium-based crawler), so it can run the React Float hoist on the
+// client and see the streamed metadata after hydration. Only crawlers that
+// scrape raw HTML need the blocking path.
+//
 // Source: https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/router/utils/is-bot.ts
 const HTML_LIMITED_BOT_UA_RE =
   /Mediapartners-Google|Slurp|DuckDuckBot|baiduspider|yandex|sogou|bitlybot|tumblr|vkShare|quora link preview|redditbot|ia_archiver|Bingbot|BingPreview|applebot|facebookexternalhit|facebookcatalog|Twitterbot|LinkedInBot|Slackbot|Discordbot|WhatsApp|SkypeUriPreview|Chrome-Lighthouse/i;

--- a/packages/vinext/src/server/metadata-streaming.ts
+++ b/packages/vinext/src/server/metadata-streaming.ts
@@ -35,7 +35,7 @@ const HTML_LIMITED_BOT_UA_RE =
  * Whether the user-agent is a known HTML-only bot that needs metadata in
  * <head> in the initial response (rather than streamed into <body>).
  */
-export function isHtmlLimitedBotRequest(userAgent: string | null | undefined): boolean {
+function isHtmlLimitedBotRequest(userAgent: string | null | undefined): boolean {
   if (!userAgent) return false;
   return HTML_LIMITED_BOT_UA_RE.test(userAgent);
 }

--- a/packages/vinext/src/server/metadata-streaming.ts
+++ b/packages/vinext/src/server/metadata-streaming.ts
@@ -1,0 +1,80 @@
+/**
+ * Metadata streaming helpers.
+ *
+ * Next.js 15+ streams non-blocking metadata into <body> after the initial
+ * flush, then hoists it to <head> client-side. The mechanism:
+ *
+ *   1. The route resolves static metadata (charset, viewport) synchronously
+ *      and emits it into <head> at the initial shell flush.
+ *   2. Dynamic metadata (from generateMetadata or generateViewport) is rendered
+ *      inside a <Suspense> wrapped in <div hidden>, appended to the route tree
+ *      AFTER the <html> element. React streams the resolved <title>/<meta>
+ *      tags in via <template> blocks placed inside <body>, so the SSR HTML
+ *      shows them inside <body> instead of <head>.
+ *   3. On the client, React 19 Float hoists <title>/<meta>/<link> to <head>
+ *      during hydration. The icon-reinsertion script (a SAFETY NET for Chromium
+ *      and Safari) re-runs after streaming to ensure icons end up in <head>.
+ *
+ * HTML-only bots (Twitterbot, Lighthouse, etc.) don't run client JS and need
+ * the metadata in <head> in the initial response. For these UAs we fall back
+ * to the blocking path: resolve metadata fully, then emit into <head>.
+ *
+ * Ported from Next.js:
+ *   - https://github.com/vercel/next.js/blob/canary/packages/next/src/server/web/spec-extension/user-agent.ts
+ *   - https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/metadata/is-bot.ts
+ */
+
+// Known HTML-only bots that don't execute JavaScript. These get a blocking
+// response with metadata in <head>. Matches Next.js's HTML_LIMITED_BOT_UA_RE.
+//
+// Source: https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/router/utils/is-bot.ts
+const HTML_LIMITED_BOT_UA_RE =
+  /Mediapartners-Google|Slurp|DuckDuckBot|baiduspider|yandex|sogou|bitlybot|tumblr|vkShare|quora link preview|redditbot|ia_archiver|Bingbot|BingPreview|applebot|facebookexternalhit|facebookcatalog|Twitterbot|LinkedInBot|Slackbot|Discordbot|WhatsApp|SkypeUriPreview|Chrome-Lighthouse/i;
+
+/**
+ * Whether the user-agent is a known HTML-only bot that needs metadata in
+ * <head> in the initial response (rather than streamed into <body>).
+ */
+export function isHtmlLimitedBotRequest(userAgent: string | null | undefined): boolean {
+  if (!userAgent) return false;
+  return HTML_LIMITED_BOT_UA_RE.test(userAgent);
+}
+
+/**
+ * Whether any module in the route tree has dynamic metadata or viewport
+ * resolution (i.e., exports a `generateMetadata` or `generateViewport`
+ * function). When false, we can resolve metadata fully synchronously and
+ * keep the historical behavior of emitting it into <head>.
+ */
+export function hasDynamicMetadataModules(
+  modules: ReadonlyArray<Record<string, unknown> | null | undefined>,
+): boolean {
+  for (const mod of modules) {
+    if (!mod) continue;
+    if (typeof mod.generateMetadata === "function") return true;
+    if (typeof mod.generateViewport === "function") return true;
+  }
+  return false;
+}
+
+/**
+ * Whether the request should use the streaming metadata path. A request
+ * streams metadata when:
+ *
+ *  - At least one module in the route tree has dynamic metadata, AND
+ *  - The user-agent is not a known HTML-only bot.
+ *
+ * RSC requests (client-side navigation) follow the blocking path because the
+ * RSC payload is consumed by the existing client router which expects fully
+ * resolved metadata in the flight stream.
+ */
+export function shouldStreamMetadata(options: {
+  hasDynamic: boolean;
+  userAgent: string | null | undefined;
+  isRscRequest: boolean;
+}): boolean {
+  if (!options.hasDynamic) return false;
+  if (options.isRscRequest) return false;
+  if (isHtmlLimitedBotRequest(options.userAgent)) return false;
+  return true;
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/metadata-streaming-test/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/metadata-streaming-test/page.tsx
@@ -1,0 +1,14 @@
+// Ported from Next.js: test/e2e/app-dir/metadata-streaming/app/page.tsx
+// https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/metadata-streaming/app/page.tsx
+export default function Page() {
+  return <p>index page</p>;
+}
+
+export async function generateMetadata() {
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  return {
+    title: "metadata streaming index page",
+  };
+}
+
+export const dynamic = "force-dynamic";

--- a/tests/fixtures/app-basic/app/nextjs-compat/metadata-streaming-test/slow/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/metadata-streaming-test/slow/page.tsx
@@ -1,0 +1,23 @@
+// Ported from Next.js: test/e2e/app-dir/metadata-streaming/app/slow/page.tsx
+// https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/metadata-streaming/app/slow/page.tsx
+export default function Page() {
+  return <p>slow</p>;
+}
+
+export async function generateMetadata() {
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  return {
+    title: "slow streaming page",
+    description: "slow page description",
+    generator: "vinext",
+    applicationName: "test",
+    referrer: "origin-when-cross-origin",
+    keywords: ["next.js", "react", "javascript"],
+    authors: [{ name: "huozhi" }],
+    creator: "huozhi",
+    publisher: "vercel",
+    robots: "index, follow",
+  };
+}
+
+export const dynamic = "force-dynamic";

--- a/tests/fixtures/app-basic/app/nextjs-compat/metadata-streaming-test/static-partial/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/metadata-streaming-test/static-partial/page.tsx
@@ -1,0 +1,18 @@
+// Ported from Next.js: test/e2e/app-dir/metadata-streaming/app/static/partial/page.tsx
+// https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/metadata-streaming/app/static/partial/page.tsx
+//
+// A "partial static" page: the page body renders quickly, but generateMetadata
+// resolves asynchronously. Even though the rest of the page is static, the
+// metadata is dynamic and so should stream into <body>, not be emitted directly
+// into <head>.
+export default function Page() {
+  return <div>inner static page</div>;
+}
+
+export async function generateMetadata() {
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  return {
+    title: "partial static page",
+    description: "partial static page description",
+  };
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/metadata-streaming-test/static-partial/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/metadata-streaming-test/static-partial/page.tsx
@@ -1,10 +1,18 @@
-// Ported from Next.js: test/e2e/app-dir/metadata-streaming/app/static/partial/page.tsx
+// Ported from upstream `test/e2e/app-dir/metadata-streaming/app/static/partial/page.tsx`;
+// vinext flattens to `static-partial/` because the shared `app-basic` fixture
+// keeps nextjs-compat tests at a single nesting level instead of the upstream
+// `static/<variant>/` hierarchy.
 // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/metadata-streaming/app/static/partial/page.tsx
 //
 // A "partial static" page: the page body renders quickly, but generateMetadata
 // resolves asynchronously. Even though the rest of the page is static, the
 // metadata is dynamic and so should stream into <body>, not be emitted directly
 // into <head>.
+//
+// Intentionally omits `export const dynamic = "force-dynamic"` (unlike the
+// sibling slow/ and index fixtures). The point is to exercise the partial-
+// static case where the page itself is statically renderable but metadata
+// streams in late.
 export default function Page() {
   return <div>inner static page</div>;
 }

--- a/tests/nextjs-compat/metadata-streaming.test.ts
+++ b/tests/nextjs-compat/metadata-streaming.test.ts
@@ -25,6 +25,21 @@ import {
 
 let ctx: TestServerResult;
 
+/**
+ * Split an HTML response at `</head>` so callers can independently assert on
+ * the head and body slices. Hard-fails (rather than returning -1) when the
+ * boundary is missing so a malformed response surfaces as a clear test
+ * failure instead of misleading "expected contains" diffs.
+ */
+function splitAtHeadClose(html: string): { headSlice: string; bodySlice: string } {
+  expect(html).toContain("</head>");
+  const boundary = html.indexOf("</head>");
+  return {
+    headSlice: html.slice(0, boundary),
+    bodySlice: html.slice(boundary),
+  };
+}
+
 // All "should-be-streamed" assertions are currently `it.todo` because vinext
 // does not yet stream dynamic metadata to <body>. Tracking PR: see metadata
 // streaming follow-up. The bot/HTML-only assertions are live since the
@@ -42,11 +57,10 @@ describe("Next.js compat: metadata-streaming", () => {
   //   "should delay the metadata render to body"
   it.todo("should delay metadata render to body for pages with generateMetadata", async () => {
     const { html } = await fetchHtml(ctx.baseUrl, "/nextjs-compat/metadata-streaming-test");
+    const { headSlice, bodySlice } = splitAtHeadClose(html);
     // The streamed metadata must NOT be in <head>.
-    const headSlice = html.slice(0, html.indexOf("</head>"));
     expect(headSlice).not.toContain("<title>metadata streaming index page</title>");
     // It must appear somewhere in the document body.
-    const bodySlice = html.slice(html.indexOf("</head>"));
     expect(bodySlice).toContain("<title>metadata streaming index page</title>");
   });
 
@@ -54,7 +68,7 @@ describe("Next.js compat: metadata-streaming", () => {
   //   "should still load viewport meta tags even if metadata is delayed"
   it("should still emit viewport meta tags in <head> while metadata is streaming", async () => {
     const { html } = await fetchHtml(ctx.baseUrl, "/nextjs-compat/metadata-streaming-test/slow");
-    const headSlice = html.slice(0, html.indexOf("</head>"));
+    const { headSlice } = splitAtHeadClose(html);
     expect(headSlice).toMatch(/<meta[^>]+name="viewport"[^>]+content="[^"]*width=device-width/);
     expect(headSlice).toMatch(/<meta[^>]*charSet="utf-8"|<meta[^>]*charset="utf-8"/i);
   });
@@ -66,8 +80,7 @@ describe("Next.js compat: metadata-streaming", () => {
       ctx.baseUrl,
       "/nextjs-compat/metadata-streaming-test/static-partial",
     );
-    const headSlice = html.slice(0, html.indexOf("</head>"));
-    const bodySlice = html.slice(html.indexOf("</head>"));
+    const { headSlice, bodySlice } = splitAtHeadClose(html);
     expect(headSlice).not.toContain("<title>partial static page</title>");
     expect(bodySlice).toContain("<title>partial static page</title>");
   });
@@ -79,7 +92,7 @@ describe("Next.js compat: metadata-streaming", () => {
       headers: { "user-agent": "Twitterbot/1.0" },
     });
     const html = await res.text();
-    const headSlice = html.slice(0, html.indexOf("</head>"));
+    const { headSlice } = splitAtHeadClose(html);
     expect(headSlice).toContain("<title>partial static page</title>");
   });
 
@@ -90,7 +103,7 @@ describe("Next.js compat: metadata-streaming", () => {
       headers: { "user-agent": "Twitterbot/1.0" },
     });
     const html = await res.text();
-    const headSlice = html.slice(0, html.indexOf("</head>"));
+    const { headSlice } = splitAtHeadClose(html);
     expect(headSlice).toContain("<title>metadata streaming index page</title>");
   });
 });

--- a/tests/nextjs-compat/metadata-streaming.test.ts
+++ b/tests/nextjs-compat/metadata-streaming.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Next.js compat: metadata-streaming
+ *
+ * Ported from: https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/metadata-streaming/metadata-streaming.test.ts
+ *
+ * Next.js 15+ streams non-blocking metadata into <body> after the initial
+ * flush, then hoists it to <head> client-side. When a route has
+ * generateMetadata() (or any async metadata resolution), the resolved <title>
+ * / <meta> / <link> tags should NOT appear inside <head> in the initial HTML
+ * response — they should appear inside <body> instead, so the page shell can
+ * flush early without waiting for slow metadata.
+ *
+ * Bots that don't run client JS still need the metadata in <head>. For known
+ * HTML-only bots (e.g. Twitterbot), the server falls back to blocking the
+ * shell on metadata resolution and writing the tags into <head>.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vite-plus/test";
+import {
+  startFixtureServer,
+  APP_FIXTURE_DIR,
+  fetchHtml,
+  type TestServerResult,
+} from "../helpers.js";
+
+let ctx: TestServerResult;
+
+// All "should-be-streamed" assertions are currently `it.todo` because vinext
+// does not yet stream dynamic metadata to <body>. Tracking PR: see metadata
+// streaming follow-up. The bot/HTML-only assertions are live since the
+// blocking path already produces correct HTML.
+describe("Next.js compat: metadata-streaming", () => {
+  beforeAll(async () => {
+    ctx = await startFixtureServer(APP_FIXTURE_DIR, { appRouter: true });
+  });
+
+  afterAll(async () => {
+    await ctx.server.close();
+  });
+
+  // Equivalent of:
+  //   "should delay the metadata render to body"
+  it.todo("should delay metadata render to body for pages with generateMetadata", async () => {
+    const { html } = await fetchHtml(ctx.baseUrl, "/nextjs-compat/metadata-streaming-test");
+    // The streamed metadata must NOT be in <head>.
+    const headSlice = html.slice(0, html.indexOf("</head>"));
+    expect(headSlice).not.toContain("<title>metadata streaming index page</title>");
+    // It must appear somewhere in the document body.
+    const bodySlice = html.slice(html.indexOf("</head>"));
+    expect(bodySlice).toContain("<title>metadata streaming index page</title>");
+  });
+
+  // Equivalent of:
+  //   "should still load viewport meta tags even if metadata is delayed"
+  it("should still emit viewport meta tags in <head> while metadata is streaming", async () => {
+    const { html } = await fetchHtml(ctx.baseUrl, "/nextjs-compat/metadata-streaming-test/slow");
+    const headSlice = html.slice(0, html.indexOf("</head>"));
+    expect(headSlice).toMatch(/<meta[^>]+name="viewport"[^>]+content="[^"]*width=device-width/);
+    expect(headSlice).toMatch(/<meta[^>]*charSet="utf-8"|<meta[^>]*charset="utf-8"/i);
+  });
+
+  // Equivalent of:
+  //   "should determine dynamic metadata in build and render in the body"
+  it.todo("should stream metadata to body even when most of the page is static", async () => {
+    const { html } = await fetchHtml(
+      ctx.baseUrl,
+      "/nextjs-compat/metadata-streaming-test/static-partial",
+    );
+    const headSlice = html.slice(0, html.indexOf("</head>"));
+    const bodySlice = html.slice(html.indexOf("</head>"));
+    expect(headSlice).not.toContain("<title>partial static page</title>");
+    expect(bodySlice).toContain("<title>partial static page</title>");
+  });
+
+  // Equivalent of:
+  //   "should still render dynamic metadata in the head for html bots"
+  it("should render dynamic metadata in <head> for html-only bots (Twitterbot)", async () => {
+    const res = await fetch(`${ctx.baseUrl}/nextjs-compat/metadata-streaming-test/static-partial`, {
+      headers: { "user-agent": "Twitterbot/1.0" },
+    });
+    const html = await res.text();
+    const headSlice = html.slice(0, html.indexOf("</head>"));
+    expect(headSlice).toContain("<title>partial static page</title>");
+  });
+
+  // Equivalent of:
+  //   "should send the blocking response for html limited bots"
+  it("should block on metadata for html-only bots on index", async () => {
+    const res = await fetch(`${ctx.baseUrl}/nextjs-compat/metadata-streaming-test`, {
+      headers: { "user-agent": "Twitterbot/1.0" },
+    });
+    const html = await res.text();
+    const headSlice = html.slice(0, html.indexOf("</head>"));
+    expect(headSlice).toContain("<title>metadata streaming index page</title>");
+  });
+});


### PR DESCRIPTION
## Status: WIP / research-only

Next.js 15+ streams non-blocking metadata into `<body>` after the initial flush, then hoists it to `<head>` client-side via React 19 Float. vinext currently always blocks on `generateMetadata` and emits the resolved `<title>`/`<meta>`/`<link>` tags into `<head>`.

This PR lays down scaffolding (policy, bot detection, fixture, tests, and an opt-in streaming path in the route element builder) but **does not yet make the streaming case work**. The body-streaming assertions in the new test file are `it.todo` and the upstream fixture remains at **12/19** (no delta from main yet).

Marking as draft so the next agent can pick up the open question below.

## What works
- New module `server/metadata-streaming.ts` with:
  - HTML-only bot UA regex (Twitterbot, Lighthouse, etc.) ported from Next.js `HTML_LIMITED_BOT_UA_RE`
  - `hasDynamicMetadataModules` helper detecting `generateMetadata`/`generateViewport`
  - `shouldStreamMetadata` policy: stream when dynamic AND not a bot AND not an RSC navigation
- `buildAppPageElements` accepts an optional `streamingMetadata` promise. When set, the route element emits static `<head>` (charset + viewport only) and appends `<div hidden><Suspense><AsyncMeta /></Suspense></div>` after the route tree.
- New fixtures + tests under `tests/nextjs-compat/metadata-streaming.test.ts` matching upstream shape. Bot/HTML-only assertions are live and pass on the existing blocking path.
- `vp check` clean. All 48 existing metadata tests still pass.

## What's broken (the actual bug)
With the scaffolding above, dynamic `<title>` still lands in `<head>` rather than `<body>`.

A standalone POC using `react-dom/server.edge` directly (no RSC) **does** put the streamed title in `<body>` as expected. So React Float in isolation works.

Inside vinext's RSC->SSR pipeline, something is either:
1. Resolving the Suspense boundary in the RSC payload before SSR begins consuming, so SSR sees an inline element and React hoists it.
2. Buffering until all Suspense boundaries complete.

Tried but did not change the outcome:
- `Promise.resolve({ metadata })` (synchronously resolved)
- `new Promise(r => setTimeout(r, 0))` (microtask deferred)
- `new Promise(r => setTimeout(r, 200))` (clearly pending at flush time)

## Next steps
1. Audit the RSC renderer path: does `@vitejs/plugin-rsc` flush pending Suspense chunks as separate flight rows, or does it buffer? Compare with Next.js feeding their `<Metadata>` boundary through `createFullTreeFlightDataForNavigation` / `walkTreeWithFlightRouterState`.
2. Verify whether `createFromReadableStream` in the SSR environment exposes Suspense fallback states or eagerly awaits.
3. **Alternative path**: if RSC streaming through plugin-rsc cannot hold a pending Suspense across the boundary, render the metadata Suspense in the SSR layer directly (in `app-ssr-entry.ts`) rather than in the RSC tree. The metadata promise could be threaded through `handleSsr` alongside the existing nav context.
4. Once body streaming works, add the icon-reinsertion script from Next.js's `create-server-inserted-metadata.tsx` (Chromium/Safari pick up icons from `<head>` only).
5. Flip `it.todo` -> `it` and rerun the upstream fixture. Target 19/19.

## Files
- `packages/vinext/src/server/metadata-streaming.ts` (new) - policy + bot detection
- `packages/vinext/src/server/app-page-element-builder.ts` - wires streaming policy
- `packages/vinext/src/server/app-page-route-wiring.tsx` - emits Suspense wrapper
- `tests/nextjs-compat/metadata-streaming.test.ts` (new) - test (2 todo, 3 live)
- `tests/fixtures/app-basic/app/nextjs-compat/metadata-streaming-test/**` (new)

## Related
- Next.js source: `packages/next/src/lib/metadata/metadata.tsx` (`MetadataBoundary` + `<div hidden>` pattern)
- Next.js fixture: `test/e2e/app-dir/metadata-streaming/metadata-streaming.test.ts`
- Category B2 of the deploy-suite parity audit.