### PR TITLE
fix(app-router): track hash-only traversal metadata

### DIFF
--- a/packages/vinext/src/global.d.ts
+++ b/packages/vinext/src/global.d.ts
@@ -127,7 +127,7 @@ declare global {
      * history metadata/index allocator as approved RSC commits.
      */
     __VINEXT_RSC_COMMIT_HASH_NAVIGATION__:
-      | ((href: string, historyUpdateMode: "push" | "replace") => void)
+      | ((href: string, historyUpdateMode: "push" | "replace", scroll: boolean) => void)
       | undefined;
 
     /**

--- a/packages/vinext/src/global.d.ts
+++ b/packages/vinext/src/global.d.ts
@@ -121,6 +121,16 @@ declare global {
     __VINEXT_CLEAR_NAV_CACHES__: (() => void) | undefined;
 
     /**
+     * Commits an App Router hash-only navigation without fetching RSC data.
+     * Installed by the browser RSC entry so `next/navigation` and `next/link`
+     * can route app-owned hash-only history writes through the same vinext
+     * history metadata/index allocator as approved RSC commits.
+     */
+    __VINEXT_RSC_COMMIT_HASH_NAVIGATION__:
+      | ((href: string, historyUpdateMode: "push" | "replace") => void)
+      | undefined;
+
+    /**
      * A Promise that resolves when the current in-flight popstate RSC navigation
      * finishes rendering.
      * Set by the popstate handler in the browser RSC entry; read by

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -226,6 +226,35 @@ function commitHistoryTraversalIndex(index: number | null): void {
   }
 }
 
+function commitHashOnlyNavigation(
+  href: string,
+  historyUpdateMode: Exclude<HistoryUpdateMode, undefined>,
+): void {
+  const preserveExistingState = historyUpdateMode === "replace";
+  const navigationHistoryIndex = allocateNavigationHistoryTraversalIndex(historyUpdateMode);
+  const previousNextUrl = hasBrowserRouterState()
+    ? getBrowserRouterState().previousNextUrl
+    : readHistoryStatePreviousNextUrl(window.history.state);
+  const historyState = createHistoryStateWithNavigationMetadata(
+    preserveExistingState ? window.history.state : null,
+    {
+      previousNextUrl,
+      traversalIndex: navigationHistoryIndex,
+    },
+  );
+
+  if (historyUpdateMode === "replace") {
+    replaceHistoryStateWithoutNotify(historyState, "", href);
+  } else {
+    pushHistoryStateWithoutNotify(historyState, "", href);
+  }
+  commitHistoryTraversalIndex(navigationHistoryIndex);
+}
+
+function commitTraversalIndexFromHistoryState(historyState: unknown): void {
+  commitHistoryTraversalIndex(readHistoryStateTraversalIndex(historyState));
+}
+
 function getBrowserRouterState(): AppRouterState {
   return browserNavigationController.getBrowserRouterState();
 }
@@ -1113,6 +1142,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
   // header comment: "the segment cache contains the actual RSC data which
   // needs to be re-fetched."
   window.__VINEXT_CLEAR_NAV_CACHES__ = clearClientNavigationCaches;
+  window.__VINEXT_RSC_COMMIT_HASH_NAVIGATION__ = commitHashOnlyNavigation;
 
   window.__VINEXT_RSC_NAVIGATE__ = async function navigateRsc(
     href: string,
@@ -1475,6 +1505,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
     const href = window.location.href;
     if (isSameAppRoutePopstateTarget(href)) {
       notifyAppRouterTransitionStart(href, "traverse");
+      commitTraversalIndexFromHistoryState(event.state);
       restorePopstateScrollPosition(event.state);
       return;
     }

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -229,14 +229,14 @@ function commitHistoryTraversalIndex(index: number | null): void {
 function commitHashOnlyNavigation(
   href: string,
   historyUpdateMode: Exclude<HistoryUpdateMode, undefined>,
+  scroll: boolean,
 ): void {
-  const preserveExistingState = historyUpdateMode === "replace";
   const navigationHistoryIndex = allocateNavigationHistoryTraversalIndex(historyUpdateMode);
   const previousNextUrl = hasBrowserRouterState()
     ? getBrowserRouterState().previousNextUrl
     : readHistoryStatePreviousNextUrl(window.history.state);
   const historyState = createHistoryStateWithNavigationMetadata(
-    preserveExistingState ? window.history.state : null,
+    createHashOnlyNavigationBaseHistoryState(historyUpdateMode, scroll),
     {
       previousNextUrl,
       traversalIndex: navigationHistoryIndex,
@@ -249,6 +249,32 @@ function commitHashOnlyNavigation(
     pushHistoryStateWithoutNotify(historyState, "", href);
   }
   commitHistoryTraversalIndex(navigationHistoryIndex);
+}
+
+function createHashOnlyNavigationBaseHistoryState(
+  historyUpdateMode: Exclude<HistoryUpdateMode, undefined>,
+  scroll: boolean,
+): unknown {
+  if (historyUpdateMode !== "replace") {
+    return null;
+  }
+  return scroll ? stripVinextScrollState(window.history.state) : window.history.state;
+}
+
+function stripVinextScrollState(state: unknown): unknown {
+  if (!state || typeof state !== "object") {
+    return state;
+  }
+
+  const nextState: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(state)) {
+    if (key === "__vinext_scrollX" || key === "__vinext_scrollY") {
+      continue;
+    }
+    nextState[key] = value;
+  }
+
+  return Object.keys(nextState).length > 0 ? nextState : null;
 }
 
 function commitTraversalIndexFromHistoryState(historyState: unknown): void {

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -1214,6 +1214,20 @@ function saveScrollPosition(): void {
   );
 }
 
+function commitHashOnlyHistoryState(href: string, mode: "push" | "replace"): void {
+  const commitAppRouterHashNavigation = window.__VINEXT_RSC_COMMIT_HASH_NAVIGATION__;
+  if (commitAppRouterHashNavigation) {
+    commitAppRouterHashNavigation(href, mode);
+    return;
+  }
+
+  if (mode === "replace") {
+    replaceHistoryStateWithoutNotify(null, "", href);
+  } else {
+    pushHistoryStateWithoutNotify(null, "", href);
+  }
+}
+
 /**
  * Restore scroll position from a history state object (used on popstate).
  *
@@ -1297,11 +1311,7 @@ export async function navigateClientSide(
   // Hash-only change: update URL and scroll to target, skip RSC fetch
   if (isHashOnlyChange(fullHref)) {
     const hash = fullHref.includes("#") ? fullHref.slice(fullHref.indexOf("#")) : "";
-    if (mode === "replace") {
-      replaceHistoryStateWithoutNotify(null, "", fullHref);
-    } else {
-      pushHistoryStateWithoutNotify(null, "", fullHref);
-    }
+    commitHashOnlyHistoryState(fullHref, mode);
     commitClientNavigationState();
     if (scroll) {
       scrollToHashTarget(hash);

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -1214,10 +1214,10 @@ function saveScrollPosition(): void {
   );
 }
 
-function commitHashOnlyHistoryState(href: string, mode: "push" | "replace"): void {
+function commitHashOnlyHistoryState(href: string, mode: "push" | "replace", scroll: boolean): void {
   const commitAppRouterHashNavigation = window.__VINEXT_RSC_COMMIT_HASH_NAVIGATION__;
   if (commitAppRouterHashNavigation) {
-    commitAppRouterHashNavigation(href, mode);
+    commitAppRouterHashNavigation(href, mode, scroll);
     return;
   }
 
@@ -1311,7 +1311,7 @@ export async function navigateClientSide(
   // Hash-only change: update URL and scroll to target, skip RSC fetch
   if (isHashOnlyChange(fullHref)) {
     const hash = fullHref.includes("#") ? fullHref.slice(fullHref.indexOf("#")) : "";
-    commitHashOnlyHistoryState(fullHref, mode);
+    commitHashOnlyHistoryState(fullHref, mode, scroll);
     commitClientNavigationState();
     if (scroll) {
       scrollToHashTarget(hash);

--- a/tests/e2e/app-router/nextjs-compat/hash-popstate-scroll.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/hash-popstate-scroll.spec.ts
@@ -104,6 +104,37 @@ test.describe("Next.js compat: hash popstate scroll", () => {
     expect(await readVinextHistoryIndex(page)).toBe(0);
   });
 
+  test("hash-only replace after back restores scroll for the replaced hash target", async ({
+    page,
+  }) => {
+    await page.goto(`${BASE}/nextjs-compat/hash-popstate-scroll`);
+    await waitForAppRouterHydration(page);
+
+    await page.click("#hash-link");
+    await expect(page).toHaveURL(`${BASE}/nextjs-compat/hash-popstate-scroll#content`);
+    expect(await readVinextHistoryIndex(page)).toBe(1);
+
+    await page.goBack();
+    await expect(page).toHaveURL(`${BASE}/nextjs-compat/hash-popstate-scroll`);
+    await expectScrollY(page, 0);
+    expect(await readVinextHistoryIndex(page)).toBe(0);
+
+    await page.click("#replace-content");
+    await expect(page).toHaveURL(`${BASE}/nextjs-compat/hash-popstate-scroll#content`);
+    await expect(page.locator("#content")).toBeInViewport();
+    expect(await readVinextHistoryIndex(page)).toBe(0);
+
+    await page.goForward();
+    await expect(page).toHaveURL(`${BASE}/nextjs-compat/hash-popstate-scroll#content`);
+    await expect(page.locator("#content")).toBeInViewport();
+    expect(await readVinextHistoryIndex(page)).toBe(1);
+
+    await page.goBack();
+    await expect(page).toHaveURL(`${BASE}/nextjs-compat/hash-popstate-scroll#content`);
+    await expect(page.locator("#content")).toBeInViewport();
+    expect(await readVinextHistoryIndex(page)).toBe(0);
+  });
+
   // Next.js App Router handles popstate with ACTION_RESTORE and classifies
   // same-path/search fragment changes as onlyHashChange in segment-cache
   // navigation, avoiding a new RSC payload for hash-only traversal.

--- a/tests/e2e/app-router/nextjs-compat/hash-popstate-scroll.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/hash-popstate-scroll.spec.ts
@@ -5,6 +5,16 @@ import { waitForAppRouterHydration } from "../../helpers";
 const BASE = "http://localhost:4174";
 
 test.describe("Next.js compat: hash popstate scroll", () => {
+  async function readVinextHistoryIndex(page: Page) {
+    return page.evaluate(() => {
+      const state = window.history.state;
+      if (!state || typeof state !== "object") return null;
+
+      const value = (state as Record<string, unknown>).__vinext_historyIndex;
+      return typeof value === "number" ? value : null;
+    });
+  }
+
   async function expectScrollY(page: Page, expected: number) {
     await expect(async () => {
       const scrollY = await page.evaluate(() => window.scrollY);
@@ -56,6 +66,42 @@ test.describe("Next.js compat: hash popstate scroll", () => {
     await page.goForward();
     await expect(page).toHaveURL(`${BASE}/nextjs-compat/hash-popstate-scroll#content`);
     await expect(page.locator("#content")).toBeInViewport();
+  });
+
+  test("hash-only Link entries carry vinext traversal metadata", async ({ page }) => {
+    await page.goto(`${BASE}/nextjs-compat/hash-popstate-scroll`);
+    await waitForAppRouterHydration(page);
+    await expect(page.locator("h1")).toHaveText("Hash Popstate Scroll");
+    expect(await readVinextHistoryIndex(page)).toBe(0);
+
+    await page.click("#hash-link");
+    await expect(page).toHaveURL(`${BASE}/nextjs-compat/hash-popstate-scroll#content`);
+    expect(await readVinextHistoryIndex(page)).toBe(1);
+
+    await page.goBack();
+    await expect(page).toHaveURL(`${BASE}/nextjs-compat/hash-popstate-scroll`);
+    expect(await readVinextHistoryIndex(page)).toBe(0);
+
+    await page.goForward();
+    await expect(page).toHaveURL(`${BASE}/nextjs-compat/hash-popstate-scroll#content`);
+    expect(await readVinextHistoryIndex(page)).toBe(1);
+  });
+
+  test("hash-only replace after back keeps the current traversal index", async ({ page }) => {
+    await page.goto(`${BASE}/nextjs-compat/hash-popstate-scroll`);
+    await waitForAppRouterHydration(page);
+
+    await page.click("#hash-link");
+    await expect(page).toHaveURL(`${BASE}/nextjs-compat/hash-popstate-scroll#content`);
+    expect(await readVinextHistoryIndex(page)).toBe(1);
+
+    await page.goBack();
+    await expect(page).toHaveURL(`${BASE}/nextjs-compat/hash-popstate-scroll`);
+    expect(await readVinextHistoryIndex(page)).toBe(0);
+
+    await page.click("#replace-top");
+    await expect(page).toHaveURL(`${BASE}/nextjs-compat/hash-popstate-scroll#top`);
+    expect(await readVinextHistoryIndex(page)).toBe(0);
   });
 
   // Next.js App Router handles popstate with ACTION_RESTORE and classifies

--- a/tests/fixtures/app-basic/app/nextjs-compat/hash-popstate-scroll/hash-actions.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/hash-popstate-scroll/hash-actions.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+export function HashActions() {
+  const router = useRouter();
+
+  return (
+    <button id="replace-top" onClick={() => router.replace("#top")} type="button">
+      Replace top
+    </button>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/hash-popstate-scroll/hash-actions.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/hash-popstate-scroll/hash-actions.tsx
@@ -6,8 +6,13 @@ export function HashActions() {
   const router = useRouter();
 
   return (
-    <button id="replace-top" onClick={() => router.replace("#top")} type="button">
-      Replace top
-    </button>
+    <>
+      <button id="replace-top" onClick={() => router.replace("#top")} type="button">
+        Replace top
+      </button>
+      <button id="replace-content" onClick={() => router.replace("#content")} type="button">
+        Replace content
+      </button>
+    </>
   );
 }

--- a/tests/fixtures/app-basic/app/nextjs-compat/hash-popstate-scroll/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/hash-popstate-scroll/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { HashActions } from "./hash-actions";
 
 export default function HashPopstateScrollPage() {
   return (
@@ -17,6 +18,7 @@ export default function HashPopstateScrollPage() {
         <Link href="#top" id="top-link">
           Go to top
         </Link>
+        <HashActions />
       </nav>
       <div style={{ height: 1200 }} />
       <section id="content" style={{ minHeight: 400 }}>


### PR DESCRIPTION
## Overview

| Field | Details |
| --- | --- |
| Goal | Close #1252 by giving App Router-owned hash-only history entries an explicit traversal metadata contract. |
| Core change | Hash-only Link/router writes now commit through the browser entry's vinext history metadata/index allocator instead of writing null history state. |
| Boundary | Hash-only navigation still skips RSC work. The browser entry owns traversal index mutation; next/navigation only delegates the history write when App Router is active. |
| Scroll fix | Default-scroll hash-only `replace` strips stale vinext scroll restoration keys before writing the new hash URL, while `scroll: false` preserves existing scroll state. |
| Primary files | `app-browser-entry.ts`, `navigation.ts`, `hash-popstate-scroll.spec.ts` |
| Expected impact | Future traversal-direction work can treat hash-only App Router entries as app-owned metadata-bearing entries rather than intentional unknowns. |

## Why

App Router-owned visible history entries should carry vinext traversal metadata before traversal direction becomes semantic. Hash-only navigation is a visible commit, but it has no RSC payload to approve, so the correct boundary is to let the browser entry commit the history metadata while keeping the RSC fetch path out of the flow.

Hash-only `replace` also has a scroll-state trap: if the new URL points at `#content` but the replaced history state still has `__vinext_scrollY: 0`, later traversal restores scroll `0` instead of scrolling the hash target. This PR avoids that contradiction for default-scroll replaces by stripping only vinext scroll restoration keys before metadata is written.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| Hash-only navigation | App-owned history entries should preserve vinext metadata. | Hash-only push/replace delegates to a browser-entry-owned commit hook. |
| Traversal indexing | The module that owns `currentHistoryTraversalIndex` should mutate it. | Index allocation and commits stay in `app-browser-entry.ts`. |
| Popstate | Same-path/search hash traversal should not fetch RSC, but it must update local traversal state. | The same-route popstate fast path commits the target history index before restoring scroll. |
| Scroll restoration | A history entry should not carry a hash URL and stale scroll coordinates that disagree. | Default-scroll hash replaces drop old vinext scroll keys; explicit `scroll: false` keeps them. |

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| `Link href="#..."` in App Router | `navigateClientSide()` pushed `null` state. | The pushed entry carries `__vinext_historyIndex` and existing `previousNextUrl` metadata. |
| `router.replace("#...")` after back from a hash entry | The internal current traversal index could remain stale. | Same-route popstate updates the current index from the target history state, so replace keeps the current entry index. |
| `router.replace("#content")` after back to the base entry | The replaced entry could keep old `__vinext_scrollY: 0`, then later restore top-of-page scroll for a `#content` URL. | The replaced entry keeps traversal metadata but drops stale vinext scroll keys, so later traversal scrolls the hash target. |
| Hash-only back/forward | Skipped RSC and restored scroll. | Still skips RSC and restores scroll, with metadata preserved. |

<details>
<summary>Maintainer review path</summary>

1. `packages/vinext/src/server/app-browser-entry.ts`: owns the hash-only commit hook, traversal index allocation, same-route popstate index update, and scroll-key stripping for default-scroll hash replaces.
2. `packages/vinext/src/shims/navigation.ts`: delegates hash-only history writes to App Router when the browser entry hook is installed, passing the effective `scroll` option, with the old null-state fallback for non-App-Router paths.
3. `packages/vinext/src/global.d.ts`: documents the internal window hook contract.
4. `tests/e2e/app-router/nextjs-compat/hash-popstate-scroll.spec.ts`: covers metadata-bearing hash entries, replace-after-back index correctness, and replace-after-back scroll restoration for `#content`.
5. `tests/fixtures/app-basic/app/nextjs-compat/hash-popstate-scroll/hash-actions.tsx`: adds client fixture buttons for `router.replace("#top")` and `router.replace("#content")`.

</details>

<details>
<summary>Validation</summary>

- Red check before initial implementation: the new hash metadata tests failed with `Expected: 1 Received: null`.
- Red check for review feedback: `hash-only replace after back restores scroll for the replaced hash target` failed on the final `goBack()` because `#content` was out of viewport.
- `vp check packages/vinext/src/global.d.ts packages/vinext/src/server/app-browser-entry.ts packages/vinext/src/shims/navigation.ts tests/e2e/app-router/nextjs-compat/hash-popstate-scroll.spec.ts tests/fixtures/app-basic/app/nextjs-compat/hash-popstate-scroll/page.tsx tests/fixtures/app-basic/app/nextjs-compat/hash-popstate-scroll/hash-actions.tsx`
- `vp run vinext#build`
- `PLAYWRIGHT_PROJECT=app-router pnpm run test:e2e -- tests/e2e/app-router/nextjs-compat/hash-popstate-scroll.spec.ts`
- `vp test run tests/app-browser-entry.test.ts`
- `git diff --check`
- Commit hooks: formatting, lint/type checks, and `knip`

</details>

<details>
<summary>Risk / compatibility</summary>

- Runtime impact is limited to App Router browser-side hash-only navigation and same-route hash popstate.
- Hash-only navigation still skips RSC fetches and does not route unapproved RSC work into browser-visible state.
- Pages Router and pre-App-Router fallback behavior keep the previous null-state hash write path.
- The new global remains internal and intentionally `void`; `navigation.ts` does not infer or branch on browser-entry commit outcomes.
- Default-scroll hash replaces strip only vinext scroll restoration keys. Other caller or framework history state fields are preserved.
- Explicit `scroll: false` hash replaces preserve existing scroll restoration state.
- Existing scroll restoration behavior is covered by the hash-popstate tests and remains green.

</details>

<details>
<summary>Non-goals</summary>

- This does not make traversal direction semantic in the planner.
- This does not change query-only or full route navigation behavior.
- This does not try to repair metadata-less external browser history entries.
- This does not change Pages Router hash-only fallback state behavior.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| Closes #1252 | Tracks the hash-only App Router traversal metadata gap. |
| #1248 | Introduced the traversal metadata/index model this PR extends to hash-only entries. |
| #726 | Parent App Router navigation lifecycle work. |
| https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/navigation/navigation.test.ts | Next.js coverage for App Router navigation and hash behavior. |
| https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/segment-cache/navigation.ts | Reference point for keeping hash-only navigation outside the RSC fetch path. |
