### PR TITLE
fix(shims): treat draftMode() as non-dynamic; mark dynamic only on enable/disable

### DIFF
--- a/packages/vinext/src/shims/headers.ts
+++ b/packages/vinext/src/shims/headers.ts
@@ -841,7 +841,11 @@ export async function draftMode(): Promise<DraftModeResult> {
   if (state.headersContext?.accessError) {
     throw state.headersContext.accessError;
   }
-  markDynamicUsage();
+  // Reading `draftMode()` itself is not dynamic — `isEnabled` is a plain
+  // getter and merely calling `draftMode()` does not require bailing out
+  // of static prerendering. Only `enable()`/`disable()` mutate state and
+  // must be tracked as dynamic, mirroring Next.js's `trackDynamicDraftMode`
+  // (see .nextjs-ref/packages/next/src/server/request/draft-mode.ts:152-165).
   const secret = getDraftSecret();
 
   return {
@@ -851,6 +855,7 @@ export async function draftMode(): Promise<DraftModeResult> {
         : false;
     },
     enable(): void {
+      markDynamicUsage();
       if (state.headersContext?.accessError) {
         throw state.headersContext.accessError;
       }
@@ -860,6 +865,7 @@ export async function draftMode(): Promise<DraftModeResult> {
       state.draftModeCookieHeader = `${DRAFT_MODE_COOKIE}=${secret}; ${draftModeCookieAttributes()}`;
     },
     disable(): void {
+      markDynamicUsage();
       if (state.headersContext?.accessError) {
         throw state.headersContext.accessError;
       }

--- a/tests/nextjs-compat/draft-mode.test.ts
+++ b/tests/nextjs-compat/draft-mode.test.ts
@@ -158,11 +158,17 @@ describe("Next.js compat: draft-mode", () => {
     expect(bypassCookie).not.toMatch(/;\s*Secure/i);
   });
 
-  // ── draftMode() marks dynamic usage ──────────────────────────
-  // draftMode() reads from a request cookie, so it must opt out of
-  // static/ISR caching — same as headers() and cookies().
+  // ── draftMode() dynamic tracking ─────────────────────────────
+  // Calling `draftMode()` itself is NOT dynamic — `isEnabled` is a plain
+  // getter and merely awaiting `draftMode()` does not require bailing out
+  // of static prerendering. Only `enable()` / `disable()` mutate state and
+  // must be tracked as dynamic.
+  //
+  // Ported from Next.js: test/e2e/app-dir/draft-mode/draft-mode.test.ts
+  // ("should not generate rand when draft mode disabled during next start").
+  // Source: .nextjs-ref/packages/next/src/server/request/draft-mode.ts (trackDynamicDraftMode).
 
-  it("draftMode() marks dynamic usage so the render is uncacheable", async () => {
+  it("draftMode() does NOT mark dynamic usage on its own (allows static prerender)", async () => {
     const {
       draftMode: draftModeFn,
       consumeDynamicUsage,
@@ -172,10 +178,47 @@ describe("Next.js compat: draft-mode", () => {
 
     const ctx = headersContextFromRequest(new Request("http://localhost/test"));
     await runWithHeadersContext(ctx, async () => {
-      // Reset any prior dynamic usage
       consumeDynamicUsage();
+      const dm = await draftModeFn();
+      // Reading isEnabled is also non-dynamic.
+      // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+      dm.isEnabled;
+      expect(consumeDynamicUsage()).toBe(false);
+    });
+  });
 
-      await draftModeFn();
+  it("draftMode().enable() marks dynamic usage", async () => {
+    const {
+      draftMode: draftModeFn,
+      consumeDynamicUsage,
+      runWithHeadersContext,
+      headersContextFromRequest,
+    } = await import("../../packages/vinext/src/shims/headers.js");
+
+    const ctx = headersContextFromRequest(new Request("http://localhost/test"));
+    await runWithHeadersContext(ctx, async () => {
+      consumeDynamicUsage();
+      const dm = await draftModeFn();
+      expect(consumeDynamicUsage()).toBe(false);
+      dm.enable();
+      expect(consumeDynamicUsage()).toBe(true);
+    });
+  });
+
+  it("draftMode().disable() marks dynamic usage", async () => {
+    const {
+      draftMode: draftModeFn,
+      consumeDynamicUsage,
+      runWithHeadersContext,
+      headersContextFromRequest,
+    } = await import("../../packages/vinext/src/shims/headers.js");
+
+    const ctx = headersContextFromRequest(new Request("http://localhost/test"));
+    await runWithHeadersContext(ctx, async () => {
+      consumeDynamicUsage();
+      const dm = await draftModeFn();
+      expect(consumeDynamicUsage()).toBe(false);
+      dm.disable();
       expect(consumeDynamicUsage()).toBe(true);
     });
   });


### PR DESCRIPTION
## What

Move the `markDynamicUsage()` call out of the body of `draftMode()` and into the `enable()` / `disable()` methods of the returned object.

## Why

Reading `draftMode()` and accessing `isEnabled` are plain reads — they cannot change response output beyond what was already determined at prerender time, so they should not bail the route out of static generation. Only `enable()` and `disable()` (called from route handlers) mutate state and need to be tracked as dynamic.

This matches Next.js's own `trackDynamicDraftMode` placement at [.nextjs-ref/packages/next/src/server/request/draft-mode.ts:152-165](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/request/draft-mode.ts#L152-L165):

```ts
get isEnabled() {              // plain getter — not tracked
  if (this._provider !== null) return this._provider.isEnabled
  return false
}
public enable() {
  trackDynamicDraftMode('draftMode().enable()', this.enable)  // tracked
  ...
}
public disable() {
  trackDynamicDraftMode('draftMode().disable()', this.disable)  // tracked
  ...
}
```

## Failure this fixes

Found via the Next.js Deploy Suite. The Next.js fixture `test/e2e/app-dir/draft-mode/draft-mode.test.ts` has a test:

> should not generate rand when draft mode disabled during next start

The fixture page calls `draftMode()` and renders `Math.random()`. Next.js prerenders this page (no dynamic API was actually used), so the random value is stable across requests. vinext was returning a fresh random on every request because:

1. **Build-time speculative prerender skipped it.** `classifyAppRoute('/')` returned `unknown`, a speculative render ran, the page called `draftMode()` which immediately called `markDynamicUsage()`, the prerender loop saw `Cache-Control: no-store` and bailed (status: 'skipped', reason: 'dynamic'). No HTML/RSC was seeded.
2. **Request-time ISR write was also skipped.** `consumeDynamicUsage()` returned true after rendering, so the cache write was bailed out.

Net effect: every page that ever calls `draftMode()` — even just to read `isEnabled` — opts out of caching across the board.

## Tests

- Updates the existing `tests/nextjs-compat/draft-mode.test.ts` assertion ("draftMode() marks dynamic usage so the render is uncacheable") to match the corrected behavior (no dynamic tracking on `draftMode()` itself or `isEnabled`).
- Adds dedicated assertions that `enable()` and `disable()` each mark dynamic usage.
- All existing prerender / ISR / cache-proof / shim tests continue to pass (977 + 129 = 1106 tests in adjacent suites).

## Follow-ups (out of scope)

- vinext's `cache-proof.ts` tracks `draftMode` as a request API for cache-proof analysis (`packages/vinext/src/server/cache-proof.ts:1023-1026`). That tracker should probably also be split into draftMode-read vs draftMode-mutate to mirror Next.js, but it is observation-only and does not affect cache decisions today. Filed as a follow-up.
