### PR TITLE
fix(shims/script): preload <script> sources during SSR via ReactDOM.preload

### DIFF
--- a/packages/vinext/src/shims/script.tsx
+++ b/packages/vinext/src/shims/script.tsx
@@ -13,6 +13,7 @@
  *   - "worker": sets type="text/partytown" (requires Partytown setup)
  */
 import React, { useEffect, useRef } from "react";
+import * as ReactDOM from "react-dom";
 import { escapeInlineContent } from "./head.js";
 import { useScriptNonce } from "./script-nonce-context.js";
 
@@ -345,6 +346,37 @@ function Script(props: ScriptProps): React.ReactElement | null {
 
   // SSR path: only "beforeInteractive" renders a <script> tag server-side
   if (typeof window === "undefined") {
+    // React Float preload — emits <link rel="preload" as="script" /> in <head>
+    // so the script is fetched while HTML streams. Mirrors Next.js's App Router
+    // behavior at .nextjs-ref/packages/next/src/client/script.tsx:298-376:
+    //   - afterInteractive with src: preload only (no <script> tag in SSR)
+    //   - beforeInteractive with src: preload + <script> tag
+    //   - inline scripts (no src): no preload
+    // Calling ReactDOM.preload during SSR is safe in both routers; React only
+    // hoists the link when it has a real <head> to hoist into.
+    if (
+      src &&
+      typeof ReactDOM.preload === "function" &&
+      (strategy === "afterInteractive" || strategy === "beforeInteractive")
+    ) {
+      const integrity = typeof rest.integrity === "string" ? rest.integrity : undefined;
+      const crossOrigin =
+        rest.crossOrigin === "anonymous" || rest.crossOrigin === "use-credentials"
+          ? rest.crossOrigin
+          : undefined;
+      const preloadOptions: ReactDOM.PreloadOptions = {
+        as: "script",
+        crossOrigin,
+      };
+      if (resolvedNonce !== undefined) {
+        preloadOptions.nonce = resolvedNonce;
+      }
+      if (integrity !== undefined) {
+        preloadOptions.integrity = integrity;
+      }
+      ReactDOM.preload(src, preloadOptions);
+    }
+
     if (strategy === "beforeInteractive") {
       return React.createElement(
         "script",

--- a/tests/nextjs-compat/script-preload.test.ts
+++ b/tests/nextjs-compat/script-preload.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Next.js Compatibility Tests: next/script preload behavior
+ *
+ * Ported from Next.js: test/e2e/app-dir/app-esm-js/index.test.ts
+ * https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/app-esm-js/index.test.ts
+ *
+ * Verifies App Router SSR emits `<link rel="preload" as="script">` for every
+ * `<Script>` with a `src` and `strategy="afterInteractive"` (the default) or
+ * `strategy="beforeInteractive"`. This is React Float behavior driven by
+ * `ReactDOM.preload()` and matches Next.js's implementation at
+ * .nextjs-ref/packages/next/src/client/script.tsx:298-376.
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vite-plus/test";
+import type { ViteDevServer } from "vite-plus";
+import { APP_FIXTURE_DIR, fetchHtml, startFixtureServer } from "../helpers.js";
+
+describe("Next.js compat: next/script preload (React Float)", () => {
+  let server: ViteDevServer;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    ({ server, baseUrl } = await startFixtureServer(APP_FIXTURE_DIR, {
+      appRouter: true,
+    }));
+    await fetch(`${baseUrl}/`).catch(() => {});
+  }, 60_000);
+
+  afterAll(async () => {
+    await server?.close();
+  });
+
+  it("App Router emits preload <link> for afterInteractive scripts", async () => {
+    const { html } = await fetchHtml(baseUrl, "/script-nonce");
+
+    // /test1.js uses afterInteractive — should preload, no <script src=>.
+    expect(html).toMatch(/<link\b[^>]*rel="preload"[^>]*href="\/test1\.js"/);
+    expect(html).toMatch(/<link\b[^>]*href="\/test1\.js"[^>]*as="script"/);
+    expect(html).not.toMatch(/<script\b[^>]*src="\/test1\.js"/);
+  });
+
+  it("App Router emits preload <link> AND <script> tag for beforeInteractive scripts", async () => {
+    const { html } = await fetchHtml(baseUrl, "/script-nonce");
+
+    // /test2.js uses beforeInteractive — should preload AND emit the <script> tag.
+    expect(html).toMatch(/<link\b[^>]*rel="preload"[^>]*href="\/test2\.js"/);
+    expect(html).toMatch(/<script\b[^>]*src="\/test2\.js"/);
+  });
+
+  it("does not emit preload for inline (no-src) scripts", async () => {
+    const { html } = await fetchHtml(baseUrl, "/script-nonce");
+
+    // id="3" is an inline beforeInteractive script with no src — no preload link.
+    // The <script id="3"> tag itself still renders.
+    expect(html).toMatch(/<script\b[^>]*id="3"/);
+    const preloads = [...html.matchAll(/<link\b[^>]*rel="preload"[^>]*>/g)].map((m) => m[0]);
+    for (const link of preloads) {
+      // No preload link should have an "id" attribute matching the inline script.
+      expect(link).not.toMatch(/id="3"/);
+    }
+  });
+});

--- a/tests/script.test.ts
+++ b/tests/script.test.ts
@@ -52,14 +52,20 @@ describe("Script SSR rendering", () => {
     expect(html).toContain('src="/analytics.js"');
   });
 
-  it("renders nothing for afterInteractive strategy on SSR", () => {
+  it("emits a preload link for afterInteractive strategy on SSR (no <script> tag)", () => {
     const html = ReactDOMServer.renderToString(
       React.createElement(Script, {
         src: "/tracking.js",
         strategy: "afterInteractive",
       } as ScriptProps),
     );
-    expect(html).toBe("");
+    // React Float hoists the ReactDOM.preload call into <link rel="preload"> in <head>.
+    // The Script component itself never returns a <script> tag for afterInteractive.
+    // Mirrors .nextjs-ref/packages/next/src/client/script.tsx:361-376.
+    expect(html).toContain('<link rel="preload"');
+    expect(html).toContain('href="/tracking.js"');
+    expect(html).toContain('as="script"');
+    expect(html).not.toContain("<script");
   });
 
   it("renders nothing for lazyOnload strategy on SSR", () => {
@@ -82,13 +88,67 @@ describe("Script SSR rendering", () => {
     expect(html).toBe("");
   });
 
-  it("defaults to afterInteractive (renders nothing on SSR)", () => {
+  it("defaults to afterInteractive (emits preload link on SSR)", () => {
     const html = ReactDOMServer.renderToString(
       React.createElement(Script, {
         src: "/default.js",
       } as ScriptProps),
     );
+    expect(html).toContain('<link rel="preload"');
+    expect(html).toContain('href="/default.js"');
+    expect(html).toContain('as="script"');
+  });
+
+  it("preserves crossOrigin and integrity on the preload link", () => {
+    const html = ReactDOMServer.renderToString(
+      React.createElement(Script, {
+        src: "/secure-after.js",
+        strategy: "afterInteractive",
+        crossOrigin: "anonymous",
+        integrity: "sha384-abc123",
+      } as ScriptProps),
+    );
+    expect(html).toContain('<link rel="preload"');
+    expect(html).toContain('href="/secure-after.js"');
+    // React normalises `crossOrigin="anonymous"` to `crossorigin=""` in HTML —
+    // both forms are equivalent per the HTML spec (an empty value selects
+    // the "anonymous" state). Accept either.
+    expect(html).toMatch(/crossorigin=("anonymous"|"")/);
+    expect(html).toContain('integrity="sha384-abc123"');
+  });
+
+  it("does not emit a preload link for inline (no-src) afterInteractive scripts", () => {
+    const html = ReactDOMServer.renderToString(
+      React.createElement(Script, {
+        strategy: "afterInteractive",
+        children: 'console.log("inline")',
+      } as ScriptProps),
+    );
     expect(html).toBe("");
+  });
+
+  it("does not emit a preload link for lazyOnload scripts on SSR", () => {
+    const html = ReactDOMServer.renderToString(
+      React.createElement(Script, {
+        src: "/lazy-preload.js",
+        strategy: "lazyOnload",
+      } as ScriptProps),
+    );
+    expect(html).not.toContain('rel="preload"');
+  });
+
+  it("emits both preload link and <script> tag for beforeInteractive with src", () => {
+    const html = ReactDOMServer.renderToString(
+      React.createElement(Script, {
+        src: "/before.js",
+        strategy: "beforeInteractive",
+      } as ScriptProps),
+    );
+    expect(html).toContain('<link rel="preload"');
+    expect(html).toContain('href="/before.js"');
+    expect(html).toContain('as="script"');
+    expect(html).toContain("<script");
+    expect(html).toContain('src="/before.js"');
   });
 
   it("renders beforeInteractive with id attribute", () => {

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -13652,7 +13652,7 @@ describe("next/script SSR rendering", () => {
     expect(html).toContain('id="analytics"');
   });
 
-  it("afterInteractive returns null in SSR", async () => {
+  it("afterInteractive emits a preload <link> (no <script> tag) in SSR", async () => {
     const React = await import("react");
     const { renderToStaticMarkup } = await import("react-dom/server");
     const Script = (await import("../packages/vinext/src/shims/script.js")).default;
@@ -13663,11 +13663,16 @@ describe("next/script SSR rendering", () => {
         strategy: "afterInteractive",
       }),
     );
-    // afterInteractive should not render anything server-side
-    expect(html).toBe("");
+    // afterInteractive does not render a <script> tag during SSR,
+    // but it does emit <link rel="preload" as="script"> via React Float
+    // so the script is fetched while HTML streams.
+    expect(html).toContain('<link rel="preload"');
+    expect(html).toContain('href="https://example.com/chat.js"');
+    expect(html).toContain('as="script"');
+    expect(html).not.toContain("<script");
   });
 
-  it("lazyOnload returns null in SSR", async () => {
+  it("lazyOnload returns null (no preload) in SSR", async () => {
     const React = await import("react");
     const { renderToStaticMarkup } = await import("react-dom/server");
     const Script = (await import("../packages/vinext/src/shims/script.js")).default;
@@ -13681,7 +13686,7 @@ describe("next/script SSR rendering", () => {
     expect(html).toBe("");
   });
 
-  it("default strategy (no strategy prop) returns null in SSR", async () => {
+  it("default strategy (no strategy prop) emits a preload <link> in SSR", async () => {
     const React = await import("react");
     const { renderToStaticMarkup } = await import("react-dom/server");
     const Script = (await import("../packages/vinext/src/shims/script.js")).default;
@@ -13691,8 +13696,11 @@ describe("next/script SSR rendering", () => {
         src: "https://example.com/default.js",
       }),
     );
-    // Default is afterInteractive → null in SSR
-    expect(html).toBe("");
+    // Default is afterInteractive → preload link only, no <script> tag.
+    expect(html).toContain('<link rel="preload"');
+    expect(html).toContain('href="https://example.com/default.js"');
+    expect(html).toContain('as="script"');
+    expect(html).not.toContain("<script");
   });
 
   it("beforeInteractive with dangerouslySetInnerHTML renders inline script", async () => {


### PR DESCRIPTION
## What

Make the `next/script` shim call `ReactDOM.preload(src, { as: 'script', ... })` during SSR for `<Script>` components with a `src` and `strategy="afterInteractive"` (the default) or `strategy="beforeInteractive"`. React Float then hoists `<link rel="preload" as="script" href={src} />` into `<head>` so the script is fetched in parallel with the streamed HTML.

## Why

This matches Next.js's App Router behavior at [.nextjs-ref/packages/next/src/client/script.tsx:298-376](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/script.tsx#L298-L376):

```tsx
if (appDir) {
  // ...
  if (strategy === 'beforeInteractive') {
    // ReactDOM.preload(src, { as: 'script', nonce, crossOrigin })
    // + render the <script> tag
  } else if (strategy === 'afterInteractive') {
    if (src) {
      ReactDOM.preload(src, { as: 'script', nonce, crossOrigin })
    }
  }
}
return null
```

Before this change, vinext's Script shim only emitted a `<script>` tag for `beforeInteractive` and returned `null` for every other strategy, with no preload call.

The existing Image shim already uses this exact React Float pattern at [`packages/vinext/src/shims/image.tsx:285-286`](../blob/main/packages/vinext/src/shims/image.tsx#L285-L286), so the SSR pipeline already supports Float hoisting end-to-end.

## Failure this fixes

Found via the Next.js Deploy Suite. The Next.js fixture `test/e2e/app-dir/app-esm-js/index.test.ts` ("should be able to render nextjs api in app router") asserts:

```ts
expect($('head link[href="/test-ext.js"]').length).toBe(1)
expect($('head link[href="/test.js"]').length).toBe(1)
```

The fixture renders `<Script src="/test.js" />` and `<Script src="/test-ext.js" />` (both default afterInteractive). Today vinext emits zero `<link>` tags for those scripts, so the assertion fails with `expected: 1, received: 0`.

## Tests

- Updated two existing Script SSR tests in `tests/script.test.ts` and `tests/shims.test.ts` that asserted `afterInteractive` / default rendered empty — they now assert the preload `<link>` is emitted and no `<script>` tag is rendered, matching Next.js.
- Added `tests/nextjs-compat/script-preload.test.ts` that ports the app-esm-js fixture's preload assertions against the existing `app-basic` `/script-nonce` fixture (which already exercises afterInteractive and beforeInteractive).
- 1151 tests pass across shims / script / pages-router / document / nonce suites.

## Notes

- `crossOrigin` handling matches React's type contract (`"anonymous" | "use-credentials" | undefined`). React normalises `"anonymous"` to `crossorigin=""` in HTML; the new tests accept both forms.
- `lazyOnload` and `worker` strategies continue to render nothing during SSR (no preload), matching Next.js.
- Inline scripts (no `src`) continue to skip preload.
