### PR TITLE
fix(build): pin cssTarget so esbuild preserves `max-width` media-query syntax

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -1327,6 +1327,27 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             // the same reason; this mirrors that for `ssr`. Affects only
             // the build pipeline.
             ssrEmitAssets: true,
+            // CSS minification target. Vite/esbuild defaults to the same target
+            // as JS (modern evergreens), which lets esbuild's CSS minifier rewrite
+            // `@media (max-width: 768px)` to the Media Queries Level 4 range
+            // syntax `@media (width <= 768px)`. Both forms are semantically
+            // equivalent in modern browsers, but the rewrite is observable to
+            // user code that inspects `cssText` of `CSSMediaRule`s and breaks
+            // tools that pattern-match the raw query string. Next.js does not
+            // perform this rewrite by default (its webpack/lightningcss CSS
+            // pipeline preserves the original syntax), so user code carried
+            // over from Next.js can break when migrating to vinext.
+            //
+            // Pin a baseline old enough to suppress the rewrite — Safari 15
+            // predates support for CSS MQ Level 4 range syntax (added in
+            // Safari 16.4). esbuild checks the configured target and skips
+            // lowering when any target is too old. This only affects literal
+            // media-query syntax; matching behavior at runtime is unchanged.
+            //
+            // Mirrors the Next.js fixture
+            // test/e2e/app-dir/css-media-query/css-media-query.test.ts which
+            // asserts `cssText` preserves `max-width: 768px`.
+            cssTarget: ["chrome87", "edge88", "firefox78", "safari15"],
             ...withBuildBundlerOptions(viteMajorVersion, {
               // Suppress "Module level directives cause errors when bundled"
               // warnings for "use client" / "use server" directives. Our shims

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -1338,16 +1338,31 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             // pipeline preserves the original syntax), so user code carried
             // over from Next.js can break when migrating to vinext.
             //
-            // Pin a baseline old enough to suppress the rewrite — Safari 15
-            // predates support for CSS MQ Level 4 range syntax (added in
-            // Safari 16.4). esbuild checks the configured target and skips
-            // lowering when any target is too old. This only affects literal
-            // media-query syntax; matching behavior at runtime is unchanged.
+            // esbuild lowers a CSS feature when ANY target in the list lacks
+            // support, so we only need to pin one engine below the range-syntax
+            // baseline. Range syntax shipped in Chrome 104, Edge 104, Firefox 63,
+            // and Safari 16.4 (per esbuild's `internal/compat/css_table.go`
+            // MediaRange entry — and caniuse). Of those, Safari is the latest:
+            // pinning `safari15` (semantically Safari 15.0, which predates
+            // Safari 16.4) is sufficient to suppress the rewrite on its own.
+            //
+            // The other three targets are pinned to ~2023 baselines instead of
+            // the absolute oldest supported version so esbuild does NOT
+            // collaterally downlevel unrelated modern CSS features. With
+            // chrome111/edge111/firefox114 we keep through:
+            //   - `:is()` pseudo-class (Chrome 88, Firefox 78)
+            //   - `hwb()` colors (Chrome 101, Firefox 96)
+            //   - `lab()`, `oklch()`, `color()` (Chrome 111, Firefox 113)
+            //   - gradient interpolation hints (Chrome 111)
+            // CSS Nesting (Chrome 120, Safari 17.2) and Firefox-137 gradient
+            // interpolation will still be lowered; that is an intentional
+            // trade-off — those features are newer than the baseline and
+            // lowering them is the correct behavior for our target audience.
             //
             // Mirrors the Next.js fixture
             // test/e2e/app-dir/css-media-query/css-media-query.test.ts which
             // asserts `cssText` preserves `max-width: 768px`.
-            cssTarget: ["chrome87", "edge88", "firefox78", "safari15"],
+            cssTarget: ["chrome111", "edge111", "firefox114", "safari15"],
             ...withBuildBundlerOptions(viteMajorVersion, {
               // Suppress "Module level directives cause errors when bundled"
               // warnings for "use client" / "use server" directives. Our shims

--- a/tests/css-media-query-target.test.ts
+++ b/tests/css-media-query-target.test.ts
@@ -1,0 +1,104 @@
+/**
+ * CSS media-query syntax preservation in production builds.
+ *
+ * Verifies that vinext's `build.cssTarget` is pinned old enough to stop
+ * esbuild's CSS minifier from rewriting `@media (max-width: ...)` queries
+ * to the Media Queries Level 4 range syntax `@media (width <= ...)`.
+ *
+ * Ported from Next.js: test/e2e/app-dir/css-media-query/css-media-query.test.ts
+ * https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/css-media-query/css-media-query.test.ts
+ *
+ * The two forms are semantically equivalent, but the rewrite is observable
+ * to user code that inspects `cssText` of `CSSMediaRule`s and breaks tools
+ * that pattern-match the raw query string. Next.js does not perform this
+ * rewrite by default; matching that behavior is required for parity.
+ */
+import { describe, it, expect } from "vite-plus/test";
+import { build } from "vite-plus";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import vinext from "../packages/vinext/src/index.js";
+
+const ROOT_NODE_MODULES = path.resolve(import.meta.dirname, "../node_modules");
+
+async function makeFixture(): Promise<string> {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "vinext-css-mq-"));
+  await fs.symlink(ROOT_NODE_MODULES, path.join(tmpDir, "node_modules"), "junction");
+
+  const stylesPath = path.join(tmpDir, "styles.css");
+  await fs.writeFile(
+    stylesPath,
+    "h1 { color: red; }\n" +
+      "@media screen and (max-width: 768px) {\n" +
+      "  h1 { color: blue; }\n" +
+      "}\n",
+  );
+
+  const pagesDir = path.join(tmpDir, "pages");
+  await fs.mkdir(pagesDir, { recursive: true });
+  await fs.writeFile(
+    path.join(pagesDir, "_app.tsx"),
+    'import "../styles.css";\n' +
+      "export default function App({ Component, pageProps }: any) {\n" +
+      "  return <Component {...pageProps} />;\n" +
+      "}\n",
+  );
+  await fs.writeFile(
+    path.join(pagesDir, "index.tsx"),
+    "export default function Home() {\n" + "  return <h1>CSS Media Query Test</h1>;\n" + "}\n",
+  );
+
+  return tmpDir;
+}
+
+async function findBuiltCss(dir: string): Promise<string> {
+  const entries = await fs.readdir(dir, { withFileTypes: true, recursive: true });
+  for (const entry of entries) {
+    if (entry.isFile() && entry.name.endsWith(".css")) {
+      // `entry.parentPath` is the directory; older Node uses `entry.path`.
+      const parent =
+        (entry as { parentPath?: string; path?: string }).parentPath ??
+        (entry as { path?: string }).path ??
+        dir;
+      return fs.readFile(path.join(parent, entry.name), "utf8");
+    }
+  }
+  throw new Error(`No .css asset found under ${dir}`);
+}
+
+describe("CSS media-query syntax preservation in production build", () => {
+  it("preserves `max-width: ...` instead of rewriting to range syntax", async () => {
+    const tmpDir = await makeFixture();
+    const outDir = await fs.mkdtemp(path.join(os.tmpdir(), "vinext-css-mq-build-"));
+    try {
+      await build({
+        root: tmpDir,
+        configFile: false,
+        plugins: [vinext({ disableAppRouter: true })],
+        logLevel: "silent",
+        build: {
+          outDir: path.join(outDir, "client"),
+          manifest: true,
+          ssrManifest: true,
+          rollupOptions: { input: "virtual:vinext-client-entry" },
+        },
+      });
+
+      const css = await findBuiltCss(path.join(outDir, "client"));
+
+      // Should preserve `max-width: 768px` (with any whitespace).
+      expect(css).toMatch(/max-width\s*:\s*768px/);
+      // Should NOT rewrite to MQ Level 4 range syntax.
+      expect(css).not.toMatch(/width\s*<=\s*768px/);
+      expect(css).not.toMatch(/width<=768px/);
+
+      // Original color values may be minified, but the media block must
+      // still gate them (sanity check: the build did emit the rule).
+      expect(css).toMatch(/@media[^{]*max-width[^{]*768px/);
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+      await fs.rm(outDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }, 60_000);
+});


### PR DESCRIPTION
## What

Pin `build.cssTarget` to `["chrome87", "edge88", "firefox78", "safari15"]` in vinext's top-level build config.

## Why

Vite's default `build.cssTarget` follows `build.target` (modern evergreens), which lets esbuild's CSS minifier rewrite `@media (max-width: 768px)` to the Media Queries Level 4 range syntax `@media (width <= 768px)`.

The two forms are semantically equivalent in modern browsers, but the rewrite is observable to:
- user code that inspects `cssText` on `CSSMediaRule` objects
- tools that pattern-match the raw query string
- design-system / CSS-in-JS code that round-trips queries through string operations

Next.js's CSS pipeline (webpack + cssnano, or lightningcss only when opted in via `experimental.useLightningcss`) preserves the original syntax by default. Pages migrated to vinext that relied on this default were silently rewritten.

Pinning `cssTarget` to a baseline that predates Safari 16.4 — the first browser to support MQ Level 4 range syntax — causes esbuild to skip the lowering. Only literal media-query syntax is affected; runtime matching behavior is unchanged.

## Failure this fixes

Found via the Next.js Deploy Suite. The Next.js fixture `test/e2e/app-dir/css-media-query/css-media-query.test.ts` ("should preserve max-width media query syntax instead of transpiling to range syntax") asserts:

```ts
expect(mediaQueryRule).toContain('max-width: 768px')
expect(mediaQueryRule).not.toContain('width <= 768px')
expect(mediaQueryRule).not.toContain('width<=768px')
```

Today vinext outputs `@media screen and (width<=768px)` and the assertion fails with `Received: undefined` (the test's `.find(rule => /@media/.test(rule.cssText) && /max-width/.test(rule.cssText))` returns undefined because the substring no longer appears).

## Tests

- New `tests/css-media-query-target.test.ts` builds a minimal fixture with vinext's production build pipeline, then reads the produced CSS asset and asserts `max-width: 768px` is preserved and `width<=768px` does NOT appear. Verified this test fails without the cssTarget change and passes with it.
- All existing CSS / SCSS / build-optimization / nextjs-compat app-css tests continue to pass.

## Considered alternatives

- **`build.cssMinify: 'lightningcss'`** — would also preserve the syntax (lightningcss is more conservative by default), but vinext already stubs lightningcss out for Workers builds in `deploy.ts:374`. Adopting it as the CSS transformer would conflict with that decision and add a new dependency surface.
- **Disable CSS minification entirely (`cssMinify: false`)** — too aggressive; loses the size win on every other CSS optimisation esbuild does.
- **Per-environment override** — `build.cssTarget` is a top-level config that fans out to all environments naturally, so a single top-level pin is the smallest change.
