### PR TITLE
feat(config): implement assetPrefix

### DIFF
--- a/packages/vinext/src/build/precompress.ts
+++ b/packages/vinext/src/build/precompress.ts
@@ -71,17 +71,30 @@ async function* walkFiles(dir: string, base: string = dir): AsyncGenerator<strin
 }
 
 /**
- * Precompress all compressible hashed assets under `clientDir/assets/`.
+ * Precompress all compressible hashed assets under `clientDir/<assetsDir>/`.
  *
  * Writes `.br`, `.gz`, and `.zst` files alongside each original.
  * Safe to re-run — overwrites existing compressed variants with identical
  * output, and never compresses `.br`, `.gz`, or `.zst` files themselves.
+ *
+ * `assetsDir` defaults to `"assets"` (Vite's historical default). When
+ * `assetPrefix` is configured the build writes assets to a different
+ * directory (e.g. `"cdn/_next/static"` for a path prefix, or `"_next/static"`
+ * for an absolute URL prefix); callers should resolve that with
+ * `resolveAssetsDir(assetPrefix)` and thread it through. Without this,
+ * `assetPrefix` builds would walk an empty `assets/` directory and emit
+ * zero compressed variants.
  */
 export async function precompressAssets(
   clientDir: string,
-  onProgress?: (completed: number, total: number, file: string) => void,
+  options: {
+    /** Subdirectory under `clientDir` containing hashed assets. Defaults to `"assets"`. */
+    assetsDir?: string;
+    onProgress?: (completed: number, total: number, file: string) => void;
+  } = {},
 ): Promise<PrecompressResult> {
-  const assetsDir = path.join(clientDir, "assets");
+  const { assetsDir: assetsSubdir = "assets", onProgress } = options;
+  const assetsDir = path.join(clientDir, assetsSubdir);
   const result: PrecompressResult = {
     filesCompressed: 0,
     totalOriginalBytes: 0,

--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -838,7 +838,10 @@ export function normalizeAssetPrefix(value: unknown): string {
     );
   }
 
-  const trimmed = value.trim().replace(/\/+$/, "");
+  // Avoid `replace(/\/+$/, "")` — CodeQL flags it as polynomial backtracking
+  // on uncontrolled input. An explicit loop has the same effect with linear time.
+  let trimmed = value.trim();
+  while (trimmed.endsWith("/")) trimmed = trimmed.slice(0, -1);
   if (trimmed === "") return "";
 
   // Absolute URL — keep origin verbatim, validate parseability so a typo

--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -130,6 +130,14 @@ export type NextConfig = {
   env?: Record<string, string>;
   /** Base URL path prefix */
   basePath?: string;
+  /**
+   * Prefix applied to every emitted JS/CSS/image/static asset URL.
+   * Accepts a path prefix (e.g. `/custom-asset-prefix`) or an absolute
+   * URL (e.g. `https://cdn.example.com`). Distinct from `basePath`:
+   * `basePath` affects route URLs; `assetPrefix` only affects asset URLs.
+   * @see https://nextjs.org/docs/app/api-reference/config/next-config-js/assetPrefix
+   */
+  assetPrefix?: string;
   /** Whether to add trailing slashes */
   trailingSlash?: boolean;
   /** Internationalization routing config */
@@ -244,6 +252,20 @@ export type NextConfigInput = NextConfig | NextConfigFactory;
 export type ResolvedNextConfig = {
   env: Record<string, string>;
   basePath: string;
+  /**
+   * Resolved `assetPrefix` from next.config.
+   *
+   * Empty string when unset. Trailing slashes are trimmed. May be either:
+   *  - a path prefix beginning with `/` (e.g. `"/custom-asset-prefix"`), or
+   *  - an absolute URL with `http(s)://` origin (e.g. `"https://cdn.example.com"`
+   *    or `"https://cdn.example.com/sub"`).
+   *
+   * Mirrors Next.js semantics — `assetPrefix` controls emitted asset URLs
+   * only; route URLs continue to live under `basePath`.
+   *
+   * @see https://nextjs.org/docs/app/api-reference/config/next-config-js/assetPrefix
+   */
+  assetPrefix: string;
   trailingSlash: boolean;
   output: "" | "export" | "standalone";
   pageExtensions: string[];
@@ -791,6 +813,47 @@ async function resolveBuildId(
   return trimmed;
 }
 
+/**
+ * Normalize the `assetPrefix` option from next.config.
+ *
+ * Accepts both absolute URLs (`https://cdn.example.com[/subpath]`) and
+ * path prefixes (`/custom-asset-prefix`). Trailing slashes are trimmed.
+ * Empty/whitespace-only strings are treated as unset and return `""`.
+ *
+ * Path prefixes that omit the leading slash get one added so they always
+ * begin with `/` — this matches how Next.js routes match against them.
+ *
+ * Non-string values are rejected to surface config mistakes early.
+ *
+ * @see https://nextjs.org/docs/app/api-reference/config/next-config-js/assetPrefix
+ */
+export function normalizeAssetPrefix(value: unknown): string {
+  if (value === undefined || value === null || value === "") return "";
+
+  if (typeof value !== "string") {
+    throw new Error(
+      `Invalid \`assetPrefix\` configuration: must be a string, got ${typeof value}. ` +
+        `Accepts a path prefix ("/custom-asset-prefix") or an absolute URL ` +
+        `("https://cdn.example.com").`,
+    );
+  }
+
+  const trimmed = value.trim().replace(/\/+$/, "");
+  if (trimmed === "") return "";
+
+  // Absolute URL — keep origin verbatim, validate parseability so a typo
+  // surfaces at config-load time instead of as a confusing build error.
+  if (/^https?:\/\//i.test(trimmed)) {
+    if (!URL.canParse(trimmed)) {
+      throw new Error(`Invalid \`assetPrefix\` configuration: "${value}" is not a parseable URL.`);
+    }
+    return trimmed;
+  }
+
+  // Path prefix — always begin with "/", consistent with basePath.
+  return trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+}
+
 function resolveDeploymentId(configDeploymentId: unknown): string | undefined {
   const deploymentId =
     configDeploymentId !== undefined ? configDeploymentId : process.env.NEXT_DEPLOYMENT_ID;
@@ -839,6 +902,7 @@ export async function resolveNextConfig(
     const resolved: ResolvedNextConfig = {
       env: {},
       basePath: "",
+      assetPrefix: "",
       trailingSlash: false,
       output: "",
       pageExtensions: normalizePageExtensions(),
@@ -1022,6 +1086,7 @@ export async function resolveNextConfig(
   const resolved: ResolvedNextConfig = {
     env: config.env ?? {},
     basePath: config.basePath ?? "",
+    assetPrefix: normalizeAssetPrefix(config.assetPrefix),
     trailingSlash: config.trailingSlash ?? false,
     output: output === "export" || output === "standalone" ? output : "",
     pageExtensions,

--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -1123,6 +1123,24 @@ export async function resolveNextConfig(
   // webpack/turbopack already in `aliases` take precedence)
   detectNextIntlConfig(root, resolved);
 
+  // Parity with Next.js: when `basePath` is configured but `assetPrefix` is
+  // not, fall back to using `basePath` as the asset prefix. Without this, an
+  // app deployed under a basePath would serve its routes correctly but emit
+  // its assets from `<basePath>/assets/...` (Vite's default `base + assetsDir`
+  // composition) rather than from the Next.js-canonical
+  // `<basePath>/_next/static/...`.
+  //
+  // Mirrors Next.js: packages/next/src/server/config.ts:509-532
+  // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/config.ts
+  // Conditions copied verbatim:
+  //   - `basePath !== ""` (skips when basePath is unset)
+  //   - `basePath !== "/"` (Next.js rejects this earlier, but we mirror the
+  //     guard so we don't silently produce `assetPrefix === "/"`)
+  //   - `assetPrefix === ""` (user did not explicitly opt out by setting it)
+  if (resolved.basePath !== "" && resolved.basePath !== "/" && resolved.assetPrefix === "") {
+    resolved.assetPrefix = resolved.basePath;
+  }
+
   return resolved;
 }
 

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -99,6 +99,15 @@ type AppRouterConfig = {
   allowedDevOrigins?: string[];
   /** Body size limit for server actions in bytes (from experimental.serverActions.bodySizeLimit). */
   bodySizeLimit?: number;
+  /**
+   * Resolved `assetPrefix` from next.config. Empty string when unset.
+   * Embedded in the generated entry so the App Router prod-server reads
+   * it from the imported module instead of a sidecar JSON file —
+   * matches how the Pages Router entry exposes `vinextConfig.assetPrefix`.
+   *
+   * @see https://nextjs.org/docs/app/api-reference/config/next-config-js/assetPrefix
+   */
+  assetPrefix?: string;
   /** Route-level expire fallback in seconds for ISR entries with numeric revalidate. */
   expireTime?: number;
   /** Internationalization routing config for middleware matcher locale handling. */
@@ -150,6 +159,7 @@ export function generateRscEntry(
   const headers = config?.headers ?? [];
   const allowedOrigins = config?.allowedOrigins ?? [];
   const bodySizeLimit = config?.bodySizeLimit ?? 1 * 1024 * 1024;
+  const assetPrefix = config?.assetPrefix ?? "";
   const expireTime = config?.expireTime ?? DEFAULT_EXPIRE_TIME;
   const i18nConfig = config?.i18n ?? null;
   const hasPagesDir = config?.hasPagesDir ?? false;
@@ -435,6 +445,10 @@ const __configHeaders = ${JSON.stringify(headers)};
 const __publicFiles = new Set(${JSON.stringify(publicFiles)});
 const __allowedOrigins = ${JSON.stringify(allowedOrigins)};
 const __expireTime = ${JSON.stringify(expireTime)};
+// Re-exported for the App Router prod-server to consume at startup —
+// mirrors the embedded \`__basePath\` pattern (and Pages Router's
+// \`vinextConfig\` export). Empty string when unset.
+export const __assetPrefix = ${JSON.stringify(assetPrefix)};
 
 ${generateDevOriginCheckCode(config?.allowedDevOrigins)}
 

--- a/packages/vinext/src/entries/pages-server-entry.ts
+++ b/packages/vinext/src/entries/pages-server-entry.ts
@@ -104,6 +104,7 @@ export async function generateServerEntry(
   // so prod-server.ts can apply them without loading next.config.js at runtime.
   const vinextConfigJson = JSON.stringify({
     basePath: nextConfig?.basePath ?? "",
+    assetPrefix: nextConfig?.assetPrefix ?? "",
     trailingSlash: nextConfig?.trailingSlash ?? false,
     redirects: nextConfig?.redirects ?? [],
     rewrites: nextConfig?.rewrites ?? { beforeFiles: [], afterFiles: [], fallback: [] },

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -3955,11 +3955,19 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             const workerEntry = path.join(workerOutDir, "index.js");
             if (!fs.existsSync(workerEntry)) return;
 
-            // Fallback: scan dist/client/assets/ for the client entry chunk.
-            // Pages Router uses "vinext-client-entry", App Router uses
-            // "vinext-app-browser-entry".
+            // Fallback: scan the on-disk assets directory for the client entry
+            // chunk when the SSR manifest lookup didn't surface one. Pages Router
+            // uses "vinext-client-entry", App Router uses "vinext-app-browser-entry".
+            //
+            // When `assetPrefix` is configured, chunks live under
+            // `<prefix>/_next/static/` (path-prefix) or `_next/static/`
+            // (absolute-URL prefix) — NOT `assets/`. Resolve the actual
+            // subdirectory from the same helper that drives `build.assetsDir`
+            // and the prod-server lookup path, so this fallback works for every
+            // layout supported by the rest of the pipeline.
             if (!clientEntryFile) {
-              const assetsDir = path.join(clientDir, "assets");
+              const assetsSubdir = resolveAssetsDir(nextConfig?.assetPrefix);
+              const assetsDir = path.join(clientDir, assetsSubdir);
               if (fs.existsSync(assetsDir)) {
                 const files = fs.readdirSync(assetsDir);
                 const entry = files.find(
@@ -3967,7 +3975,8 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                     (f.includes("vinext-client-entry") || f.includes("vinext-app-browser-entry")) &&
                     f.endsWith(".js"),
                 );
-                if (entry) clientEntryFile = manifestFileWithBase("assets/" + entry, clientBase);
+                if (entry)
+                  clientEntryFile = manifestFileWithBase(`${assetsSubdir}/${entry}`, clientBase);
               }
             }
 

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -79,6 +79,11 @@ import { buildRequestHeadersFromMiddlewareResponse } from "./server/middleware-r
 import { detectPackageManager } from "./utils/project.js";
 import { manifestFileWithBase, manifestFilesWithBase } from "./utils/manifest-paths.js";
 import { hasBasePath, removeTrailingSlash } from "./utils/base-path.js";
+import {
+  ASSET_PREFIX_URL_DIR,
+  resolveAssetUrlPrefix,
+  resolveAssetsDir,
+} from "./utils/asset-prefix.js";
 import { asyncHooksStubPlugin } from "./plugins/async-hooks-stub.js";
 import { clientReferenceDedupPlugin } from "./plugins/client-reference-dedup.js";
 import { createRscClientReferenceLoadersPlugin } from "./plugins/rsc-client-reference-loaders.js";
@@ -1363,6 +1368,19 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             // test/e2e/app-dir/css-media-query/css-media-query.test.ts which
             // asserts `cssText` preserves `max-width: 768px`.
             cssTarget: ["chrome111", "edge111", "firefox114", "safari15"],
+            // Direct Vite to write build output under `<assetPrefix>/_next/static/`
+            // (path-prefix form) or `_next/static/` (absolute-URL form) when
+            // `assetPrefix` is configured. Keeps the default of `assets/`
+            // when no prefix is set so existing on-disk layouts are stable
+            // for projects that haven't opted in.
+            //
+            // Pair with `experimental.renderBuiltUrl` above: the on-disk
+            // layout matches the URL path so the Cloudflare ASSETS binding
+            // and any static file server can resolve `<assetPrefix>/_next/static/...`
+            // requests without a runtime rewrite.
+            ...(nextConfig.assetPrefix
+              ? { assetsDir: resolveAssetsDir(nextConfig.assetPrefix) }
+              : {}),
             ...withBuildBundlerOptions(viteMajorVersion, {
               // Suppress "Module level directives cause errors when bundled"
               // warnings for "use client" / "use server" directives. Our shims
@@ -1519,8 +1537,51 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             : { esbuild: { jsx: "automatic" } }),
           // Define env vars for client bundle
           define: defines,
-          // Set base path if configured
+          // Set base path if configured.
+          //
+          // `base` controls both the dev server URL prefix and the default
+          // asset URL prefix in production. Routes live under `basePath`,
+          // so we anchor `base` there. Asset URLs are then re-prefixed with
+          // `assetPrefix` (when configured) via `experimental.renderBuiltUrl`
+          // below — that keeps `basePath` and `assetPrefix` independent, as
+          // they are in Next.js.
           ...(nextConfig.basePath ? { base: nextConfig.basePath + "/" } : {}),
+          // When `assetPrefix` is configured, override Vite's default
+          // `assetsURL = base + url` behaviour so emitted JS/CSS/asset URLs
+          // start with the configured asset prefix and use Next.js's
+          // canonical `_next/static/` directory convention. We also write
+          // assets to disk under that same path layout (via `build.assetsDir`
+          // below) so the Cloudflare ASSETS binding and any static file
+          // server can serve them without runtime rewrites.
+          //
+          // See packages/vinext/src/utils/asset-prefix.ts for the helpers
+          // and Next.js docs for the contract:
+          // https://nextjs.org/docs/app/api-reference/config/next-config-js/assetPrefix
+          ...(nextConfig.assetPrefix
+            ? {
+                experimental: {
+                  renderBuiltUrl: (filename: string) => {
+                    // `filename` is the bundler-relative output path,
+                    // e.g. `_next/static/chunk-abc.js` or
+                    // `<assetPrefix-pathname>/_next/static/chunk-abc.js`
+                    // when assetPrefix is a path prefix. Re-anchor it under
+                    // the configured asset URL prefix.
+                    const urlPrefix = resolveAssetUrlPrefix(nextConfig.assetPrefix);
+                    // Strip any leading on-disk `assetsDir` segment so we
+                    // don't double-prefix when the on-disk layout already
+                    // mirrors the URL path.
+                    const onDiskDir = resolveAssetsDir(nextConfig.assetPrefix);
+                    const dirPrefix = onDiskDir + "/";
+                    const stripped = filename.startsWith(dirPrefix)
+                      ? filename.slice(dirPrefix.length)
+                      : filename.startsWith(`${ASSET_PREFIX_URL_DIR}/`)
+                        ? filename.slice(ASSET_PREFIX_URL_DIR.length + 1)
+                        : filename;
+                    return urlPrefix + stripped;
+                  },
+                },
+              }
+            : {}),
           // Inject resolved PostCSS plugins (when found) and any
           // sassOptions translated from next.config. Both end up on
           // `css.*`, so we merge them into a single `css` object rather
@@ -3532,6 +3593,20 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           };
 
           fs.writeFileSync(path.join(outDir, "image-config.json"), JSON.stringify(imageConfig));
+
+          // Persist a small subset of next.config values that the App Router
+          // prod-server needs at startup but which are not embedded in the
+          // RSC entry (the RSC entry only embeds `__basePath`). Keep this
+          // file narrowly scoped — anything that affects request handling
+          // outside of the RSC handler should live here so dev/prod parity
+          // is easy to audit.
+          const runtimeConfig = {
+            assetPrefix: nextConfig?.assetPrefix ?? "",
+          };
+          fs.writeFileSync(
+            path.join(outDir, "vinext-runtime-config.json"),
+            JSON.stringify(runtimeConfig),
+          );
         },
       },
     },

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -3791,7 +3791,11 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
 
             // Only precompress hashed assets — public directory files use
             // on-the-fly compression since they may change between deploys.
-            const assetsDir = path.join(outDir, "assets");
+            // When `assetPrefix` is configured the assets live under a
+            // different subdirectory (e.g. `cdn/_next/static/`); resolve from
+            // the config so we walk the actual on-disk layout.
+            const assetsSubdir = resolveAssetsDir(nextConfig.assetPrefix);
+            const assetsDir = path.join(outDir, assetsSubdir);
             if (!fs.existsSync(assetsDir)) return;
 
             const isTTY = process.stderr.isTTY;
@@ -3803,16 +3807,19 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             // the full precompression cost on the critical path of step 4/5.
             pendingPrecompressError = null;
             pendingPrecompress = (async () => {
-              const result = await precompressAssets(outDir, (completed, total, file) => {
-                if (!isTTY) return;
-                const pct = total > 0 ? Math.floor((completed / total) * 100) : 0;
-                const bar = `[${"█".repeat(Math.floor(pct / 5))}${" ".repeat(20 - Math.floor(pct / 5))}]`;
-                const maxFile = 30;
-                const fileLabel = file.length > maxFile ? "…" + file.slice(-(maxFile - 1)) : file;
-                const line = `Compressing assets... ${bar} ${String(completed).padStart(String(total).length)}/${total} ${fileLabel}`;
-                const padded = line.padEnd(lastLineLen);
-                lastLineLen = line.length;
-                process.stderr.write(`\r${padded}`);
+              const result = await precompressAssets(outDir, {
+                assetsDir: assetsSubdir,
+                onProgress: (completed, total, file) => {
+                  if (!isTTY) return;
+                  const pct = total > 0 ? Math.floor((completed / total) * 100) : 0;
+                  const bar = `[${"█".repeat(Math.floor(pct / 5))}${" ".repeat(20 - Math.floor(pct / 5))}]`;
+                  const maxFile = 30;
+                  const fileLabel = file.length > maxFile ? "…" + file.slice(-(maxFile - 1)) : file;
+                  const line = `Compressing assets... ${bar} ${String(completed).padStart(String(total).length)}/${total} ${fileLabel}`;
+                  const padded = line.padEnd(lastLineLen);
+                  lastLineLen = line.length;
+                  process.stderr.write(`\r${padded}`);
+                },
               });
               if (isTTY) {
                 process.stderr.write(`\r${" ".repeat(lastLineLen)}\r`);

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -2140,6 +2140,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
               allowedOrigins: nextConfig?.serverActionsAllowedOrigins,
               allowedDevOrigins: nextConfig?.allowedDevOrigins,
               bodySizeLimit: nextConfig?.serverActionsBodySizeLimit,
+              assetPrefix: nextConfig?.assetPrefix,
               expireTime: nextConfig?.expireTime,
               i18n: nextConfig?.i18n,
               hasPagesDir,
@@ -3593,20 +3594,6 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           };
 
           fs.writeFileSync(path.join(outDir, "image-config.json"), JSON.stringify(imageConfig));
-
-          // Persist a small subset of next.config values that the App Router
-          // prod-server needs at startup but which are not embedded in the
-          // RSC entry (the RSC entry only embeds `__basePath`). Keep this
-          // file narrowly scoped — anything that affects request handling
-          // outside of the RSC handler should live here so dev/prod parity
-          // is easy to audit.
-          const runtimeConfig = {
-            assetPrefix: nextConfig?.assetPrefix ?? "",
-          };
-          fs.writeFileSync(
-            path.join(outDir, "vinext-runtime-config.json"),
-            JSON.stringify(runtimeConfig),
-          );
         },
       },
     },

--- a/packages/vinext/src/server/app-ssr-entry.ts
+++ b/packages/vinext/src/server/app-ssr-entry.ts
@@ -128,7 +128,10 @@ function renderFontHtml(fontData?: FontData, nonce?: string): string {
  */
 function extractBootstrapModuleUrl(bootstrapScriptContent?: string): string | undefined {
   if (!bootstrapScriptContent) return undefined;
-  const match = bootstrapScriptContent.match(/import\("([^"]+)"\)/);
+  // Accept either quote style — plugin-rsc currently emits double quotes
+  // (`import("…")`) but a future version could switch to single quotes,
+  // and there's no public contract documenting which is used.
+  const match = bootstrapScriptContent.match(/import\(["']([^"']+)["']\)/);
   return match?.[1] ?? undefined;
 }
 

--- a/packages/vinext/src/server/app-ssr-entry.ts
+++ b/packages/vinext/src/server/app-ssr-entry.ts
@@ -111,18 +111,35 @@ function renderFontHtml(fontData?: FontData, nonce?: string): string {
   return fontHTML;
 }
 
-function extractModulePreloadHtml(bootstrapScriptContent?: string, nonce?: string): string {
-  if (!bootstrapScriptContent) return "";
-
+/**
+ * Extract the bootstrap module URL from the `import("...")` string that
+ * `import.meta.viteRsc.loadBootstrapScriptContent("index")` returns.
+ *
+ * The plugin-rsc helper returns the bootstrap as an inline call so we can
+ * inject it via `bootstrapScriptContent`. We instead pass the URL to
+ * React's `bootstrapModules` option so a real
+ * `<script type="module" src="…">` tag ends up in the streamed HTML —
+ * this exposes the URL to anything that reads `script.attribs.src` (e.g.
+ * the Next.js asset-prefix fixture test). The same URL also feeds the
+ * `<link rel="modulepreload">` we emit ahead of the bootstrap.
+ *
+ * Returns `undefined` when the helper produced no URL (older plugin-rsc
+ * versions, or a custom client entry that disables bootstrap content).
+ */
+function extractBootstrapModuleUrl(bootstrapScriptContent?: string): string | undefined {
+  if (!bootstrapScriptContent) return undefined;
   const match = bootstrapScriptContent.match(/import\("([^"]+)"\)/);
-  if (!match?.[1]) return "";
+  return match?.[1] ?? undefined;
+}
 
-  return `<link rel="modulepreload"${createNonceAttribute(nonce)} href="${escapeHtmlAttr(match[1])}" />\n`;
+function buildModulePreloadHtml(bootstrapModuleUrl?: string, nonce?: string): string {
+  if (!bootstrapModuleUrl) return "";
+  return `<link rel="modulepreload"${createNonceAttribute(nonce)} href="${escapeHtmlAttr(bootstrapModuleUrl)}" />\n`;
 }
 
 function buildHeadInjectionHtml(
   navContext: NavigationContext | null,
-  bootstrapScriptContent: string | undefined,
+  bootstrapModuleUrl: string | undefined,
   formState: ReactFormState | null,
   insertedHTML: string,
   fontHTML: string,
@@ -152,7 +169,7 @@ function buildHeadInjectionHtml(
     paramsScript +
     navScript +
     formStateScript +
-    extractModulePreloadHtml(bootstrapScriptContent, scriptNonce) +
+    buildModulePreloadHtml(bootstrapModuleUrl, scriptNonce) +
     insertedHTML +
     fontHTML
   );
@@ -244,13 +261,34 @@ export async function handleSsr(
         : root;
       const ssrRoot = withScriptNonce(ssrTree, options?.scriptNonce);
 
+      // plugin-rsc returns the bootstrap as `import("<url>")` so callers can
+      // inject it via `bootstrapScriptContent`. We hand the URL to React's
+      // `bootstrapModules` option instead so the streamed HTML contains a
+      // real `<script type="module" src="<url>">` tag — exposing the URL
+      // to anything that inspects `script.attribs.src` (e.g. the Next.js
+      // asset-prefix fixture test "bundles should return 200 on served
+      // assetPrefix"). Mirrors Next.js's app-render path which passes
+      // `bootstrapScripts: [{ src }]` for the same reason; we use
+      // `bootstrapModules` because vinext's chunks are native ES modules
+      // (Vite output) so a `type="module"` tag is the correct loader.
+      //
+      // In dev, `<url>` is a Vite dev URL like
+      // `/@id/__x00__virtual:vinext-app-browser-entry`; the browser fetches
+      // it as a module from the dev server. In prod it's the hashed bundle
+      // URL (e.g. `/_next/static/index-abc123.js`, optionally prefixed by
+      // `assetPrefix`). Both are valid `<script type="module" src=…>` targets.
       const bootstrapScriptContent = await import.meta.viteRsc.loadBootstrapScriptContent("index");
+      const bootstrapModuleUrl = extractBootstrapModuleUrl(bootstrapScriptContent);
       const errorMetaRenderer = createSsrErrorMetaRenderer({
         basePath: options?.basePath,
       });
 
       const htmlStream = await renderToReadableStream(ssrRoot, {
-        bootstrapScriptContent,
+        // `bootstrapScriptContent` was previously how vinext injected the
+        // dynamic-import call. `bootstrapModules` performs the same work
+        // natively (and exposes the URL in the DOM), so passing both would
+        // load the bootstrap module twice.
+        bootstrapModules: bootstrapModuleUrl ? [bootstrapModuleUrl] : undefined,
         formState: options?.formState ?? null,
         nonce: options?.scriptNonce,
         onError(error) {
@@ -288,7 +326,7 @@ export async function handleSsr(
         didInjectHeadHTML = true;
         return buildHeadInjectionHtml(
           navContext,
-          bootstrapScriptContent,
+          bootstrapModuleUrl,
           options?.formState ?? null,
           insertedHTML + errorMetaHTML,
           fontHTML,

--- a/packages/vinext/src/server/app-ssr-entry.ts
+++ b/packages/vinext/src/server/app-ssr-entry.ts
@@ -291,6 +291,17 @@ export async function handleSsr(
         // dynamic-import call. `bootstrapModules` performs the same work
         // natively (and exposes the URL in the DOM), so passing both would
         // load the bootstrap module twice.
+        //
+        // CSP implications of using `bootstrapModules` instead of inline
+        // `bootstrapScriptContent`:
+        //  - Apps no longer need `script-src 'unsafe-inline'` to load the
+        //    bootstrap (improvement — inline imports required `'unsafe-inline'`).
+        //  - Apps that restrict script sources need `'self'` for the
+        //    common case, or the CDN origin when `assetPrefix` is an
+        //    absolute URL like `https://cdn.example.com`.
+        //  - React still applies `nonce` to the emitted
+        //    `<script type="module" src=…>` tag, so nonce-based CSP
+        //    (`script-src 'nonce-…' 'strict-dynamic'`) keeps working.
         bootstrapModules: bootstrapModuleUrl ? [bootstrapModuleUrl] : undefined,
         formState: options?.formState ?? null,
         nonce: options?.scriptNonce,

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -52,6 +52,11 @@ import {
 } from "./request-pipeline.js";
 import { notFoundResponse } from "./http-error-responses.js";
 import { hasBasePath, stripBasePath, removeTrailingSlash } from "../utils/base-path.js";
+import {
+  ASSET_PREFIX_URL_DIR,
+  assetPrefixPathname,
+  isAbsoluteAssetPrefix,
+} from "../utils/asset-prefix.js";
 import { computeLazyChunks } from "../utils/lazy-chunks.js";
 import { manifestFileWithBase } from "../utils/manifest-paths.js";
 import { normalizePathnameForRouteMatchStrict } from "../routing/utils.js";
@@ -525,7 +530,11 @@ async function tryServeStatic(
 
   const ext = path.extname(resolved.path);
   const ct = CONTENT_TYPES[ext] ?? "application/octet-stream";
-  const isHashed = pathname.startsWith("/assets/");
+  // Mirror the StaticFileCache's `isHashed` rule: assets under Vite's
+  // `assetsDir` carry a content hash regardless of whether they sit under
+  // `/assets/` (historical default) or `/<prefix>?/_next/static/`
+  // (assetPrefix-enabled builds). Both forms get immutable cache headers.
+  const isHashed = pathname.startsWith("/assets/") || pathname.includes("/_next/static/");
   const cacheControl = isHashed ? "public, max-age=31536000, immutable" : "public, max-age=3600";
   // Use a filename-hash ETag for hashed assets (matches the fast-path cache
   // behaviour and survives deploys). Use resolved.path (not pathname) so that
@@ -923,6 +932,70 @@ function resolveAppRouterHandler(entry: unknown): (request: Request) => Promise<
 }
 
 /**
+ * Resolve a request pathname to a static-asset lookup path inside `clientDir`.
+ *
+ * Returns `null` when the request is not for a built asset, in which case
+ * the caller should let the request fall through to the RSC handler.
+ *
+ * Three URL shapes are recognised:
+ *
+ *  - `/assets/...` — the historical Vite default, used when `assetPrefix` is
+ *    unset. Returns the pathname verbatim.
+ *  - `<assetPathPrefix>/_next/static/...` — when `assetPrefix` is a path
+ *    prefix (e.g. `/custom-asset-prefix`). The on-disk layout is
+ *    `dist/client/<prefix>/_next/static/...`, so the pathname maps 1:1.
+ *  - `/_next/static/...` — when `assetPrefix` is an absolute URL with no
+ *    path component (e.g. `https://cdn.example.com`). Files land on disk
+ *    at `dist/client/_next/static/...`. This branch is mostly a fallback
+ *    for setups that don't actually route asset requests to the CDN.
+ *
+ * When `assetPrefix` is an absolute URL with a non-empty pathname
+ * (e.g. `https://cdn.example.com/sub`), files are written to
+ * `dist/client/_next/static/...` but emitted URLs prepend the full URL
+ * (`https://cdn.example.com/sub/_next/static/...`). Requests for those
+ * URLs do not normally arrive at this server — they go to the CDN. We
+ * still accept `<pathname>/_next/static/...` so a same-origin reverse
+ * proxy can route through.
+ */
+export function resolveAppRouterAssetPath(
+  pathname: string,
+  assetPathPrefix: string,
+  assetPrefix: string,
+): string | null {
+  // Historical layout — always supported for projects without assetPrefix.
+  if (pathname.startsWith("/assets/")) return pathname;
+
+  if (!assetPrefix) return null;
+
+  const nextStaticDir = `/${ASSET_PREFIX_URL_DIR}/`;
+
+  if (assetPathPrefix) {
+    // Path prefix (or absolute URL with a path component). Strip the prefix
+    // and verify the rest lives under `_next/static/`.
+    if (pathname === assetPathPrefix || pathname.startsWith(assetPathPrefix + "/")) {
+      const rest = pathname.slice(assetPathPrefix.length) || "/";
+      if (rest.startsWith(nextStaticDir)) {
+        // For path-prefix assetPrefix: on-disk path mirrors the URL, so the
+        // request path is already the lookup path.
+        if (!isAbsoluteAssetPrefix(assetPrefix)) {
+          return pathname;
+        }
+        // For absolute-URL assetPrefix with a path component: on-disk path
+        // is just `_next/static/...` (no extra prefix dir on disk).
+        return rest;
+      }
+    }
+    return null;
+  }
+
+  // Absolute-URL assetPrefix with no path component — files on disk at
+  // `dist/client/_next/static/...`. Accept incoming `/_next/static/...`.
+  if (pathname.startsWith(nextStaticDir)) return pathname;
+
+  return null;
+}
+
+/**
  * Start the App Router production server.
  *
  * The App Router entry (dist/server/index.js) can export either:
@@ -953,6 +1026,29 @@ async function startAppRouterServer(options: AppRouterServerOptions) {
       /* ignore parse errors */
     }
   }
+
+  // Load runtime config written by the same plugin. Contains values the App
+  // Router prod-server needs at startup but which are not embedded in the
+  // RSC entry — currently `assetPrefix`. Defaults to an empty assetPrefix
+  // when the file is missing (older builds) so behaviour is unchanged for
+  // projects that haven't opted in.
+  let appRouterAssetPrefix = "";
+  const runtimeConfigPath = path.join(path.dirname(rscEntryPath), "vinext-runtime-config.json");
+  if (fs.existsSync(runtimeConfigPath)) {
+    try {
+      const runtimeConfig = JSON.parse(fs.readFileSync(runtimeConfigPath, "utf-8"));
+      if (typeof runtimeConfig?.assetPrefix === "string") {
+        appRouterAssetPrefix = runtimeConfig.assetPrefix;
+      }
+    } catch {
+      /* ignore parse errors */
+    }
+  }
+  // Path portion of the assetPrefix to match incoming asset requests against
+  // (empty when the prefix is an absolute URL with no path component, or when
+  // no prefix is configured). The URL prefix the prod-server needs to strip
+  // before locating files on disk includes this path plus `_next/static/`.
+  const appAssetPathPrefix = assetPrefixPathname(appRouterAssetPrefix);
 
   // Load prerender secret written at build time by vinext:server-manifest plugin.
   // Used to authenticate internal /__vinext/prerender/* HTTP endpoints.
@@ -1031,11 +1127,27 @@ async function startAppRouterServer(options: AppRouterServerOptions) {
     // Serve hashed build assets (Vite output in /assets/) directly.
     // Public directory files fall through to the RSC handler, which runs
     // middleware before serving them.
-    if (
-      pathname.startsWith("/assets/") &&
-      (await tryServeStatic(req, res, clientDir, pathname, compress, staticCache))
-    ) {
-      return;
+    //
+    // When `assetPrefix` is configured the on-disk layout under
+    // `dist/client` mirrors `<prefix>/_next/static/...` (path-prefix form)
+    // or `_next/static/...` (absolute-URL form). Either way, requests for
+    // `<prefix>/_next/static/...` arrive at this server in production
+    // (Cloudflare's ASSETS binding serves these directly in Workers; this
+    // branch is the Node fallback) and we look them up on disk. The base
+    // `/assets/` prefix continues to work too — projects without
+    // `assetPrefix` keep the historical layout.
+    {
+      const assetLookupPath = resolveAppRouterAssetPath(
+        pathname,
+        appAssetPathPrefix,
+        appRouterAssetPrefix,
+      );
+      if (
+        assetLookupPath &&
+        (await tryServeStatic(req, res, clientDir, assetLookupPath, compress, staticCache))
+      ) {
+        return;
+      }
     }
 
     // Image optimization passthrough (Node.js prod server has no Images binding;
@@ -1222,6 +1334,11 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
 
   // Extract config values (embedded at build time in the server entry)
   const basePath: string = vinextConfig?.basePath ?? "";
+  const assetPrefix: string = vinextConfig?.assetPrefix ?? "";
+  // Path component of `assetPrefix` against which incoming requests are
+  // matched (empty when absent or when the prefix is an absolute URL with
+  // no path component).
+  const pagesAssetPathPrefix = assetPrefixPathname(assetPrefix);
   const assetBase = basePath ? `${basePath}/` : "/";
   const trailingSlash: boolean = vinextConfig?.trailingSlash ?? false;
   const configRedirects = vinextConfig?.redirects ?? [];
@@ -1342,10 +1459,22 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
     // middleware. These are always public and don't need protection.
     // Public directory files (e.g. /favicon.ico, /robots.txt) are served
     // after middleware (step 5b) so middleware can intercept them.
+    //
+    // When `assetPrefix` is configured, also accept asset requests under
+    // `<prefix>/_next/static/...` (or `/_next/static/...` for an absolute
+    // URL prefix). On disk the layout under `dist/client` mirrors the URL
+    // (see `resolveAppRouterAssetPath` for the full table), so the same
+    // helper handles both routers.
     const staticLookupPath = stripBasePath(pathname, basePath);
+    const pagesAssetLookup =
+      resolveAppRouterAssetPath(staticLookupPath, pagesAssetPathPrefix, assetPrefix) ??
+      // Fall back to the unstripped path for the assetPrefix branch — when
+      // `basePath` is not set, `stripBasePath` is a no-op and the helper
+      // result above already covers it.
+      null;
     if (
-      staticLookupPath.startsWith("/assets/") &&
-      (await tryServeStatic(req, res, clientDir, staticLookupPath, compress, staticCache))
+      pagesAssetLookup &&
+      (await tryServeStatic(req, res, clientDir, pagesAssetLookup, compress, staticCache))
     ) {
       return;
     }

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -1030,29 +1030,6 @@ async function startAppRouterServer(options: AppRouterServerOptions) {
     }
   }
 
-  // Load runtime config written by the same plugin. Contains values the App
-  // Router prod-server needs at startup but which are not embedded in the
-  // RSC entry — currently `assetPrefix`. Defaults to an empty assetPrefix
-  // when the file is missing (older builds) so behaviour is unchanged for
-  // projects that haven't opted in.
-  let appRouterAssetPrefix = "";
-  const runtimeConfigPath = path.join(path.dirname(rscEntryPath), "vinext-runtime-config.json");
-  if (fs.existsSync(runtimeConfigPath)) {
-    try {
-      const runtimeConfig = JSON.parse(fs.readFileSync(runtimeConfigPath, "utf-8"));
-      if (typeof runtimeConfig?.assetPrefix === "string") {
-        appRouterAssetPrefix = runtimeConfig.assetPrefix;
-      }
-    } catch {
-      /* ignore parse errors */
-    }
-  }
-  // Path portion of the assetPrefix to match incoming asset requests against
-  // (empty when the prefix is an absolute URL with no path component, or when
-  // no prefix is configured). The URL prefix the prod-server needs to strip
-  // before locating files on disk includes this path plus `_next/static/`.
-  const appAssetPathPrefix = assetPrefixPathname(appRouterAssetPrefix);
-
   // Load prerender secret written at build time by vinext:server-manifest plugin.
   // Used to authenticate internal /__vinext/prerender/* HTTP endpoints.
   const prerenderSecret = readPrerenderSecret(path.dirname(rscEntryPath));
@@ -1064,6 +1041,20 @@ async function startAppRouterServer(options: AppRouterServerOptions) {
   const rscMtime = fs.statSync(rscEntryPath).mtimeMs;
   const rscModule = await import(`${pathToFileURL(rscEntryPath).href}?t=${rscMtime}`);
   const rscHandler = resolveAppRouterHandler(rscModule.default);
+
+  // `assetPrefix` is embedded as a compile-time constant in the generated
+  // RSC entry (see `entries/app-rsc-entry.ts`'s `export const __assetPrefix`),
+  // mirroring how `__basePath` is inlined there and how the Pages Router
+  // entry exposes `vinextConfig.assetPrefix`. Default to "" so older builds
+  // (and the rare case where the entry doesn't re-export this constant)
+  // continue to work with the historical asset layout.
+  const appRouterAssetPrefix: string =
+    typeof rscModule.__assetPrefix === "string" ? rscModule.__assetPrefix : "";
+  // Path portion of the assetPrefix to match incoming asset requests against
+  // (empty when the prefix is an absolute URL with no path component, or when
+  // no prefix is configured). The URL prefix the prod-server needs to strip
+  // before locating files on disk includes this path plus `_next/static/`.
+  const appAssetPathPrefix = assetPrefixPathname(appRouterAssetPrefix);
 
   // Seed the memory cache with pre-rendered routes so the first request to
   // any pre-rendered page is a cache HIT instead of a full re-render.

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -534,13 +534,10 @@ async function tryServeStatic(
   // `assetsDir` carry a content hash regardless of whether they sit under
   // `/assets/` (historical default) or `/<prefix>?/_next/static/`
   // (assetPrefix-enabled builds). Both forms get immutable cache headers.
-  // Prefer prefix checks for the well-known layouts; only fall through to a
-  // substring check when an `assetPrefix` could shift `/_next/static/` away
-  // from the URL root (e.g. `/cdn/_next/static/...`).
-  const isHashed =
-    pathname.startsWith("/assets/") ||
-    pathname.startsWith("/_next/static/") ||
-    pathname.includes("/_next/static/");
+  // `pathname` always has a leading `/`, so a single `includes` covers both
+  // the root-level `/_next/static/...` case and any `/<prefix>/_next/static/...`
+  // assetPrefix layout.
+  const isHashed = pathname.startsWith("/assets/") || pathname.includes("/_next/static/");
   const cacheControl = isHashed ? "public, max-age=31536000, immutable" : "public, max-age=3600";
   // Use a filename-hash ETag for hashed assets (matches the fast-path cache
   // behaviour and survives deploys). Use resolved.path (not pathname) so that

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -534,7 +534,13 @@ async function tryServeStatic(
   // `assetsDir` carry a content hash regardless of whether they sit under
   // `/assets/` (historical default) or `/<prefix>?/_next/static/`
   // (assetPrefix-enabled builds). Both forms get immutable cache headers.
-  const isHashed = pathname.startsWith("/assets/") || pathname.includes("/_next/static/");
+  // Prefer prefix checks for the well-known layouts; only fall through to a
+  // substring check when an `assetPrefix` could shift `/_next/static/` away
+  // from the URL root (e.g. `/cdn/_next/static/...`).
+  const isHashed =
+    pathname.startsWith("/assets/") ||
+    pathname.startsWith("/_next/static/") ||
+    pathname.includes("/_next/static/");
   const cacheControl = isHashed ? "public, max-age=31536000, immutable" : "public, max-age=3600";
   // Use a filename-hash ETag for hashed assets (matches the fast-path cache
   // behaviour and survives deploys). Use resolved.path (not pathname) so that
@@ -1466,12 +1472,11 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
     // (see `resolveAppRouterAssetPath` for the full table), so the same
     // helper handles both routers.
     const staticLookupPath = stripBasePath(pathname, basePath);
-    const pagesAssetLookup =
-      resolveAppRouterAssetPath(staticLookupPath, pagesAssetPathPrefix, assetPrefix) ??
-      // Fall back to the unstripped path for the assetPrefix branch — when
-      // `basePath` is not set, `stripBasePath` is a no-op and the helper
-      // result above already covers it.
-      null;
+    const pagesAssetLookup = resolveAppRouterAssetPath(
+      staticLookupPath,
+      pagesAssetPathPrefix,
+      assetPrefix,
+    );
     if (
       pagesAssetLookup &&
       (await tryServeStatic(req, res, clientDir, pagesAssetLookup, compress, staticCache))

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -1459,12 +1459,17 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
     // URL prefix). On disk the layout under `dist/client` mirrors the URL
     // (see `resolveAppRouterAssetPath` for the full table), so the same
     // helper handles both routers.
+    //
+    // Match the App Router's behaviour (above) and use the UN-stripped
+    // `pathname` here, not `staticLookupPath`. Emitted asset URLs already
+    // carry the assetPrefix verbatim (which equals `basePath` when the
+    // Next.js parity fallback fires — packages/next/src/server/config.ts:528-531),
+    // so stripping `basePath` first would make `resolveAppRouterAssetPath`'s
+    // path-prefix branch miss the match and return null → 404.
+    // `staticLookupPath` is still computed because non-asset paths below
+    // (image-optimization, SSR routing) match against the basePath-stripped form.
     const staticLookupPath = stripBasePath(pathname, basePath);
-    const pagesAssetLookup = resolveAppRouterAssetPath(
-      staticLookupPath,
-      pagesAssetPathPrefix,
-      assetPrefix,
-    );
+    const pagesAssetLookup = resolveAppRouterAssetPath(pathname, pagesAssetPathPrefix, assetPrefix);
     if (
       pagesAssetLookup &&
       (await tryServeStatic(req, res, clientDir, pagesAssetLookup, compress, staticCache))

--- a/packages/vinext/src/server/static-file-cache.ts
+++ b/packages/vinext/src/server/static-file-cache.ts
@@ -117,7 +117,13 @@ export class StaticFileCache {
 
       const ext = path.extname(relativePath);
       const contentType = CONTENT_TYPES[ext] ?? "application/octet-stream";
-      const isHashed = relativePath.startsWith("assets/");
+      // Files under Vite's `assetsDir` are content-hashed. The historical
+      // default is `assets/`; when `assetPrefix` is configured the layout
+      // becomes `<prefix>/_next/static/...` (path-prefix) or `_next/static/...`
+      // (absolute-URL prefix). All three forms get long-lived `immutable`
+      // cache headers — the hash in the filename invalidates safely.
+      const isHashed =
+        relativePath.startsWith("assets/") || relativePath.includes("/_next/static/");
       const cacheControl = isHashed
         ? "public, max-age=31536000, immutable"
         : "public, max-age=3600";

--- a/packages/vinext/src/server/static-file-cache.ts
+++ b/packages/vinext/src/server/static-file-cache.ts
@@ -122,8 +122,14 @@ export class StaticFileCache {
       // becomes `<prefix>/_next/static/...` (path-prefix) or `_next/static/...`
       // (absolute-URL prefix). All three forms get long-lived `immutable`
       // cache headers — the hash in the filename invalidates safely.
+      // Prefer prefix checks when the path is known to be root-relative without
+      // a leading slash (the default case). Fall back to a substring check only
+      // for the path-prefixed `assetPrefix` layout where `_next/static/` lives
+      // under an arbitrary prefix directory (e.g. `cdn/_next/static/...`).
       const isHashed =
-        relativePath.startsWith("assets/") || relativePath.includes("/_next/static/");
+        relativePath.startsWith("assets/") ||
+        relativePath.startsWith("_next/static/") ||
+        relativePath.includes("/_next/static/");
       const cacheControl = isHashed
         ? "public, max-age=31536000, immutable"
         : "public, max-age=3600";

--- a/packages/vinext/src/server/static-file-cache.ts
+++ b/packages/vinext/src/server/static-file-cache.ts
@@ -122,10 +122,12 @@ export class StaticFileCache {
       // becomes `<prefix>/_next/static/...` (path-prefix) or `_next/static/...`
       // (absolute-URL prefix). All three forms get long-lived `immutable`
       // cache headers — the hash in the filename invalidates safely.
-      // Prefer prefix checks when the path is known to be root-relative without
-      // a leading slash (the default case). Fall back to a substring check only
-      // for the path-prefixed `assetPrefix` layout where `_next/static/` lives
-      // under an arbitrary prefix directory (e.g. `cdn/_next/static/...`).
+      //
+      // `relativePath` is the path relative to `clientDir`, with no leading
+      // slash. Because of that, `startsWith("_next/static/")` and
+      // `includes("/_next/static/")` are NOT equivalent — the former covers
+      // the absolute-URL prefix layout (no parent directory), the latter
+      // covers the path-prefix layout (under an arbitrary parent like `cdn/`).
       const isHashed =
         relativePath.startsWith("assets/") ||
         relativePath.startsWith("_next/static/") ||

--- a/packages/vinext/src/utils/asset-prefix.ts
+++ b/packages/vinext/src/utils/asset-prefix.ts
@@ -53,7 +53,10 @@ export function resolveAssetsDir(assetPrefix: string): string {
     return ASSET_PREFIX_URL_DIR;
   }
   // Path prefix — strip leading slash so the path joins cleanly with outDir.
-  const stripped = assetPrefix.replace(/^\/+/, "");
+  // Use an explicit loop instead of `replace(/^\/+/, "")` so CodeQL doesn't
+  // flag the regex as polynomial-time on uncontrolled input.
+  let stripped = assetPrefix;
+  while (stripped.startsWith("/")) stripped = stripped.slice(1);
   return `${stripped}/${ASSET_PREFIX_URL_DIR}`;
 }
 
@@ -87,7 +90,8 @@ export function assetPrefixPathname(assetPrefix: string): string {
   if (!assetPrefix) return "";
   if (!isAbsoluteAssetPrefix(assetPrefix)) return assetPrefix;
   try {
-    const pathname = new URL(assetPrefix).pathname.replace(/\/+$/, "");
+    let pathname = new URL(assetPrefix).pathname;
+    while (pathname.endsWith("/")) pathname = pathname.slice(0, -1);
     return pathname === "" ? "" : pathname;
   } catch {
     return "";

--- a/packages/vinext/src/utils/asset-prefix.ts
+++ b/packages/vinext/src/utils/asset-prefix.ts
@@ -1,0 +1,95 @@
+/**
+ * Shared helpers for next.config `assetPrefix`.
+ *
+ * Mirrors Next.js semantics: `assetPrefix` is prepended to every JS/CSS/image/
+ * static asset URL emitted in the page. It is distinct from `basePath`, which
+ * affects route URLs.
+ *
+ *  - A `assetPrefix` of `""` (empty) means "no prefix" — behaviour matches the
+ *    historical default.
+ *  - A path prefix like `"/custom-asset-prefix"` is applied as a URL prefix
+ *    relative to the deployment origin. The prod server must also serve assets
+ *    under that prefix.
+ *  - An absolute URL like `"https://cdn.example.com"` makes asset URLs fully
+ *    qualified. Runtime serving on the deployment origin is a no-op — the CDN
+ *    serves the assets directly.
+ *
+ * The path component of the asset URL after the prefix is always
+ * `/_next/static/<filename>` to match Next.js's convention. This is the
+ * convention upstream test suites assert against.
+ *
+ * @see https://nextjs.org/docs/app/api-reference/config/next-config-js/assetPrefix
+ */
+
+/**
+ * Suffix appended to the assetPrefix (or used standalone when no prefix is
+ * configured) to form the leading portion of every emitted asset URL.
+ * Matches Next.js: assets always live under `/_next/static/`.
+ */
+export const ASSET_PREFIX_URL_DIR = "_next/static";
+
+/** Whether `assetPrefix` is an absolute URL (vs a path prefix). */
+export function isAbsoluteAssetPrefix(assetPrefix: string): boolean {
+  return /^https?:\/\//i.test(assetPrefix);
+}
+
+/**
+ * Compute the on-disk `build.assetsDir` for the given `assetPrefix`.
+ *
+ *  - Path prefix (`/cdn`): write to `cdn/_next/static/` so the on-disk layout
+ *    matches the URL — the Cloudflare ASSETS binding (and any static file
+ *    server) serves them directly without a runtime rewrite.
+ *  - Absolute URL (with or without path component): write to `_next/static/`.
+ *    Runtime serving is best-effort — the CDN is expected to serve these.
+ *  - Empty: keep the historical default of `assets/`, preserving disk layout
+ *    for projects that haven't opted into `assetPrefix`.
+ */
+export function resolveAssetsDir(assetPrefix: string): string {
+  if (!assetPrefix) return "assets";
+  if (isAbsoluteAssetPrefix(assetPrefix)) {
+    // Files on disk land at `_next/static/...`. The absolute URL is applied
+    // at URL-rendering time via renderBuiltUrl; on-disk path is irrelevant
+    // to the CDN.
+    return ASSET_PREFIX_URL_DIR;
+  }
+  // Path prefix — strip leading slash so the path joins cleanly with outDir.
+  const stripped = assetPrefix.replace(/^\/+/, "");
+  return `${stripped}/${ASSET_PREFIX_URL_DIR}`;
+}
+
+/**
+ * Build the URL prefix to apply to emitted asset URLs. Returns the full URL
+ * prefix including the `_next/static/` directory, with a trailing slash.
+ *
+ * Examples:
+ *  - `""` → `"/_next/static/"`
+ *  - `"/cdn"` → `"/cdn/_next/static/"`
+ *  - `"https://cdn.example.com"` → `"https://cdn.example.com/_next/static/"`
+ *  - `"https://cdn.example.com/sub"` → `"https://cdn.example.com/sub/_next/static/"`
+ */
+export function resolveAssetUrlPrefix(assetPrefix: string): string {
+  if (!assetPrefix) return `/${ASSET_PREFIX_URL_DIR}/`;
+  return `${assetPrefix}/${ASSET_PREFIX_URL_DIR}/`;
+}
+
+/**
+ * Extract the path portion of `assetPrefix` for use in runtime URL matching.
+ *
+ *  - For a path prefix: returns it verbatim (e.g. `/custom-asset-prefix`).
+ *  - For an absolute URL: returns its pathname stripped of trailing slashes
+ *    (e.g. `"https://cdn.example.com/sub"` → `/sub`, plain origin → `""`).
+ *  - For empty input: returns `""`.
+ *
+ * Used by the prod server and Cloudflare worker entry to recognise asset
+ * requests that arrive at the deployment origin under the configured prefix.
+ */
+export function assetPrefixPathname(assetPrefix: string): string {
+  if (!assetPrefix) return "";
+  if (!isAbsoluteAssetPrefix(assetPrefix)) return assetPrefix;
+  try {
+    const pathname = new URL(assetPrefix).pathname.replace(/\/+$/, "");
+    return pathname === "" ? "" : pathname;
+  } catch {
+    return "";
+  }
+}

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -2119,8 +2119,9 @@ describe("App Router Production build", () => {
       const homeHtml = await homeRes.text();
       expect(homeHtml).toContain("Welcome to App Router");
       expect(homeHtml).toContain("<script");
-      // Production bootstrap should reference hashed assets
-      expect(homeHtml).toMatch(/import\("\/assets\/[^"]+\.js"\)/);
+      // Production bootstrap is emitted as a real <script type="module" src=…>
+      // tag (via React's bootstrapModules option) referencing hashed assets.
+      expect(homeHtml).toMatch(/<script[^>]+type="module"[^>]+src="\/assets\/[^"]+\.js"/);
 
       // Dynamic route works
       const blogRes = await fetch(`${previewUrl}/blog/test-post`);

--- a/tests/asset-prefix.test.ts
+++ b/tests/asset-prefix.test.ts
@@ -208,13 +208,23 @@ describe("resolveAppRouterAssetPath", () => {
  * The fixture is copied so tests can mutate next.config.ts independently
  * without polluting each other or the shared on-disk fixture. node_modules
  * is symlinked to the workspace root to avoid a real install.
+ *
+ * `registerCleanup` is invoked synchronously right after `mkdtempSync` so
+ * the tmp dir is always tracked, even if `createBuilder` or `buildApp`
+ * throws before this function returns.
  */
-async function buildFixtureWithConfig(extraConfigJson: string): Promise<{
+async function buildFixtureWithConfig(
+  extraConfigJson: string,
+  registerCleanup: (cleanup: () => void) => void,
+): Promise<{
   fixtureRoot: string;
   outDir: string;
-  cleanup: () => void;
 }> {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-asset-prefix-"));
+  // Register the cleanup BEFORE any work that can throw. If the copy/symlink/
+  // build step fails, the afterAll hook still removes the tmp dir.
+  registerCleanup(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
   const fixtureRoot = path.join(tmpDir, "fixture");
   fs.cpSync(APP_FIXTURE_DIR, fixtureRoot, { recursive: true });
   // Symlink the workspace node_modules so the fixture can resolve React,
@@ -244,23 +254,22 @@ async function buildFixtureWithConfig(extraConfigJson: string): Promise<{
   });
   await builder.buildApp();
 
-  return {
-    fixtureRoot,
-    outDir,
-    cleanup: () => fs.rmSync(tmpDir, { recursive: true, force: true }),
-  };
+  return { fixtureRoot, outDir };
 }
 
 describe("assetPrefix end-to-end build", () => {
-  // Track tmp dirs so we can clean up if a test throws before its own cleanup.
+  // Track tmp dirs so we can clean up even if a build throws. `cleanups` is
+  // populated by `buildFixtureWithConfig` synchronously right after the tmp
+  // dir is created, so a thrown `createBuilder`/`buildApp` still leaves the
+  // tmp dir registered for the afterAll teardown.
   const cleanups: Array<() => void> = [];
   afterAll(() => {
     for (const c of cleanups) c();
   });
+  const register = (cleanup: () => void) => cleanups.push(cleanup);
 
   it("path-prefix: emits assets under <prefix>/_next/static/ on disk and in HTML", async () => {
-    const built = await buildFixtureWithConfig(`assetPrefix: "/custom-asset-prefix",`);
-    cleanups.push(built.cleanup);
+    const built = await buildFixtureWithConfig(`assetPrefix: "/custom-asset-prefix",`, register);
 
     // Files land on disk where the URLs say they should — Cloudflare's
     // ASSETS binding (and any static file server) can serve them directly
@@ -329,8 +338,7 @@ describe("assetPrefix end-to-end build", () => {
   }, 180_000);
 
   it("absolute URL: emits fully-qualified asset URLs and never includes /assets/", async () => {
-    const built = await buildFixtureWithConfig(`assetPrefix: "https://cdn.example.com",`);
-    cleanups.push(built.cleanup);
+    const built = await buildFixtureWithConfig(`assetPrefix: "https://cdn.example.com",`, register);
 
     // Disk layout is just _next/static/ — the CDN owns the URL prefix.
     const onDiskStatic = path.join(built.outDir, "client", "_next", "static");
@@ -364,8 +372,10 @@ describe("assetPrefix end-to-end build", () => {
   }, 180_000);
 
   it("basePath + assetPrefix: routes under basePath, assets under assetPrefix", async () => {
-    const built = await buildFixtureWithConfig(`basePath: "/app",\n  assetPrefix: "/cdn-prefix",`);
-    cleanups.push(built.cleanup);
+    const built = await buildFixtureWithConfig(
+      `basePath: "/app",\n  assetPrefix: "/cdn-prefix",`,
+      register,
+    );
 
     // On-disk path mirrors the assetPrefix path — independent of basePath.
     const onDiskStatic = path.join(built.outDir, "client", "cdn-prefix", "_next", "static");
@@ -404,8 +414,7 @@ describe("assetPrefix end-to-end build", () => {
   it("unset: continues to emit URLs under /assets/ (backward compatibility)", async () => {
     // Smoke-check the baseline — no assetPrefix is set, so behaviour must
     // be unchanged from before this feature landed.
-    const built = await buildFixtureWithConfig(`// no assetPrefix`);
-    cleanups.push(built.cleanup);
+    const built = await buildFixtureWithConfig(`// no assetPrefix`, register);
 
     // Historical layout preserved.
     const onDiskAssets = path.join(built.outDir, "client", "assets");

--- a/tests/asset-prefix.test.ts
+++ b/tests/asset-prefix.test.ts
@@ -304,21 +304,23 @@ describe("assetPrefix end-to-end build", () => {
       // Helpful when this test starts to drift — uncomment to inspect HTML.
       // console.log("--- HTML ---\n" + html + "\n--- /HTML ---");
 
-      // Bootstrap script URL must be prefixed AND live under _next/static.
-      // Mirrors the Next.js fixture assertion:
+      // Bootstrap is emitted as `<script type="module" src="…">` via React's
+      // `bootstrapModules` option (see app-ssr-entry.ts). Mirrors the Next.js
+      // fixture assertion:
       //   src?.includes('/custom-asset-prefix/_next/static') ||
       //   src?.includes('/custom-asset-prefix/_next/static/immutable')
-      const bootstrapMatch = html.match(/import\("([^"]+\.js)"\)/);
+      const bootstrapSrcRe = /<script[^>]+type="module"[^>]+src="([^"]+\.js)"/;
+      const bootstrapMatch = html.match(bootstrapSrcRe);
       expect(
         bootstrapMatch,
-        "expected a bootstrap `import(...)` script in the HTML",
+        'expected a `<script type="module" src="…">` bootstrap in the HTML',
       ).not.toBeNull();
       expect(bootstrapMatch![1]).toMatch(/^\/custom-asset-prefix\/_next\/static\//);
 
-      // Any `<script src="...">` tag with a non-inline src must also be
-      // under the configured prefix. Vite/RSC may inject modulepreload
-      // links too — we don't strictly require them here, but they must
-      // not leak the old /assets/ default.
+      // Every `<script src="...">` tag (bootstrap + any preload-related
+      // injected tags) must live under the configured prefix. Vite/RSC may
+      // inject modulepreload links too — we don't strictly require them
+      // here, but they must not leak the old /assets/ default.
       const scriptSrcRe = /<script[^>]+src="([^"]+)"/g;
       const scriptSrcs: string[] = [];
       for (const m of html.matchAll(scriptSrcRe)) {
@@ -359,7 +361,7 @@ describe("assetPrefix end-to-end build", () => {
       expect(homeRes.status).toBe(200);
       const html = await homeRes.text();
 
-      const bootstrapMatch = html.match(/import\("([^"]+\.js)"\)/);
+      const bootstrapMatch = html.match(/<script[^>]+type="module"[^>]+src="([^"]+\.js)"/);
       expect(bootstrapMatch).not.toBeNull();
       // Fully qualified — no protocol-relative or path-only URLs.
       expect(bootstrapMatch![1]).toMatch(/^https:\/\/cdn\.example\.com\/_next\/static\//);
@@ -397,7 +399,7 @@ describe("assetPrefix end-to-end build", () => {
       expect(homeRes.status).toBe(200);
       const html = await homeRes.text();
 
-      const bootstrapMatch = html.match(/import\("([^"]+\.js)"\)/);
+      const bootstrapMatch = html.match(/<script[^>]+type="module"[^>]+src="([^"]+\.js)"/);
       expect(bootstrapMatch).not.toBeNull();
       // Asset URLs must NOT be under basePath — they are under assetPrefix only.
       expect(bootstrapMatch![1]).toMatch(/^\/cdn-prefix\/_next\/static\//);
@@ -438,7 +440,7 @@ describe("assetPrefix end-to-end build", () => {
       expect(homeRes.status).toBe(200);
       const html = await homeRes.text();
 
-      const bootstrapMatch = html.match(/import\("([^"]+\.js)"\)/);
+      const bootstrapMatch = html.match(/<script[^>]+type="module"[^>]+src="([^"]+\.js)"/);
       expect(bootstrapMatch).not.toBeNull();
       expect(bootstrapMatch![1]).toMatch(/^\/assets\//);
       const bundleRes = await fetch(`${baseUrl}${bootstrapMatch![1]}`);

--- a/tests/asset-prefix.test.ts
+++ b/tests/asset-prefix.test.ts
@@ -413,6 +413,57 @@ describe("assetPrefix end-to-end build", () => {
     }
   }, 180_000);
 
+  // Ported from Next.js: packages/next/src/server/config.ts:528-531
+  // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/config.ts
+  it("basePath alone: falls back to using basePath as assetPrefix", async () => {
+    // Next.js parity — `basePath: "/app"` with no `assetPrefix` should serve
+    // assets from `/app/_next/static/...` (NOT `/assets/...` and NOT
+    // `/app/assets/...`). The fallback in resolveNextConfig() rewrites
+    // `assetPrefix = basePath`, which feeds the rest of the pipeline.
+    const built = await buildFixtureWithConfig(`basePath: "/app",`, register);
+
+    // On-disk layout mirrors the asset URL: <basePath>/_next/static/...
+    const onDiskStatic = path.join(built.outDir, "client", "app", "_next", "static");
+    expect(fs.existsSync(onDiskStatic), `expected on-disk layout under ${onDiskStatic}`).toBe(true);
+    // Legacy `<basePath>/assets/` directory should NOT exist — the fallback
+    // moves assets to the Next.js-canonical location.
+    const onDiskAssets = path.join(built.outDir, "client", "app", "assets");
+    expect(fs.existsSync(onDiskAssets)).toBe(false);
+
+    const { startProdServer } = await import("../packages/vinext/src/server/prod-server.js");
+    const { server } = await startProdServer({
+      port: 0,
+      outDir: built.outDir,
+      noCompression: true,
+    });
+    try {
+      const addr = server.address();
+      const port = typeof addr === "object" && addr ? addr.port : 0;
+      const baseUrl = `http://localhost:${port}`;
+
+      const homeRes = await fetch(`${baseUrl}/app/`);
+      expect(homeRes.status).toBe(200);
+      const html = await homeRes.text();
+
+      const bootstrapMatch = html.match(/<script[^>]+type="module"[^>]+src="([^"]+\.js)"/);
+      expect(bootstrapMatch).not.toBeNull();
+      // Asset URL lives under basePath at Next.js's `_next/static/` path.
+      expect(bootstrapMatch![1]).toMatch(/^\/app\/_next\/static\//);
+      // Critically, the asset URL must NOT include `/assets/` (the old
+      // Vite default) anywhere — the fallback should have completely
+      // replaced that layout.
+      expect(bootstrapMatch![1]).not.toContain("/assets/");
+
+      // The prod-server resolves the URL against the on-disk path and
+      // returns the JS bundle.
+      const bundleRes = await fetch(`${baseUrl}${bootstrapMatch![1]}`);
+      expect(bundleRes.status).toBe(200);
+      expect(bundleRes.headers.get("content-type")).toContain("javascript");
+    } finally {
+      server.close();
+    }
+  }, 180_000);
+
   it("unset: continues to emit URLs under /assets/ (backward compatibility)", async () => {
     // Smoke-check the baseline — no assetPrefix is set, so behaviour must
     // be unchanged from before this feature landed.

--- a/tests/asset-prefix.test.ts
+++ b/tests/asset-prefix.test.ts
@@ -23,7 +23,7 @@ import { describe, it, expect, afterAll } from "vite-plus/test";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { createBuilder } from "vite";
+import { build, createBuilder } from "vite";
 import vinext from "../packages/vinext/src/index.js";
 import {
   isAbsoluteAssetPrefix,
@@ -496,6 +496,115 @@ describe("assetPrefix end-to-end build", () => {
       expect(bootstrapMatch![1]).toMatch(/^\/assets\//);
       const bundleRes = await fetch(`${baseUrl}${bootstrapMatch![1]}`);
       expect(bundleRes.status).toBe(200);
+    } finally {
+      server.close();
+    }
+  }, 180_000);
+
+  // Regression test for round-5 review feedback on #1311. Mirrors the App
+  // Router "basePath alone" test above, but for the Pages Router. The bug:
+  // the Pages Router prod-server stripped basePath from the request path
+  // BEFORE matching against assetPrefix's path-prefix branch, so when the
+  // Next.js parity fallback set `assetPrefix = basePath`, every asset 404'd.
+  //
+  // Critically: this test FETCHES the asset URLs (not just inspecting HTML),
+  // which is what the existing pages-router basePath test missed.
+  it("Pages Router with basePath alone serves assets under <basePath>/_next/static/", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-pages-asset-prefix-"));
+    register(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+    // Spin up a minimal Pages Router fixture inline rather than copy
+    // tests/fixtures/pages-basic — that fixture pulls in a large config
+    // object (redirects/rewrites/headers) we don't need here.
+    fs.symlinkSync(ROOT_NODE_MODULES, path.join(tmpDir, "node_modules"), "junction");
+    fs.writeFileSync(path.join(tmpDir, "package.json"), JSON.stringify({ type: "module" }));
+    fs.writeFileSync(
+      path.join(tmpDir, "next.config.mjs"),
+      `export default { basePath: "/docs" };\n`,
+    );
+    fs.mkdirSync(path.join(tmpDir, "pages"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, "pages", "index.tsx"),
+      `import { useState } from "react";
+export default function HomePage() {
+  const [count, setCount] = useState(0);
+  return (
+    <button data-testid="increment" onClick={() => setCount((c) => c + 1)}>
+      Count: {count}
+    </button>
+  );
+}
+`,
+    );
+
+    const outDir = path.join(tmpDir, "dist");
+
+    // Pages Router build pipeline — server then client. Matches the pattern
+    // in tests/pages-router.test.ts for the SSR-manifest basePath test.
+    await build({
+      root: tmpDir,
+      configFile: false,
+      plugins: [vinext({ disableAppRouter: true })],
+      logLevel: "silent",
+      build: {
+        outDir: path.join(outDir, "server"),
+        ssr: "virtual:vinext-server-entry",
+        rollupOptions: { output: { entryFileNames: "entry.js" } },
+      },
+    });
+    await build({
+      root: tmpDir,
+      configFile: false,
+      plugins: [vinext({ disableAppRouter: true })],
+      logLevel: "silent",
+      build: {
+        outDir: path.join(outDir, "client"),
+        manifest: true,
+        ssrManifest: true,
+        rollupOptions: { input: "virtual:vinext-client-entry" },
+      },
+    });
+
+    const { startProdServer } = await import("../packages/vinext/src/server/prod-server.js");
+    const { server } = await startProdServer({
+      port: 0,
+      host: "127.0.0.1",
+      outDir,
+      noCompression: true,
+    });
+    try {
+      const addr = server.address();
+      const port = typeof addr === "object" && addr ? addr.port : 0;
+      const baseUrl = `http://127.0.0.1:${port}`;
+
+      const homeRes = await fetch(`${baseUrl}/docs/`);
+      expect(homeRes.status).toBe(200);
+      const html = await homeRes.text();
+
+      // Collect every emitted asset URL (script srcs + stylesheet hrefs).
+      // The parity fallback (`assetPrefix = basePath`) puts them all under
+      // `<basePath>/_next/static/`, which is the Next.js-canonical layout.
+      const assetUrls = new Set<string>();
+      for (const m of html.matchAll(
+        /<(?:script|link)[^>]+(?:src|href)="(\/docs\/_next\/[^"]+)"/g,
+      )) {
+        assetUrls.add(m[1]);
+      }
+      expect(assetUrls.size, "expected at least one asset URL in the SSR HTML").toBeGreaterThan(0);
+
+      // Critically: fetch each asset URL and assert 200. Before the
+      // round-5 fix, the Pages Router lookup stripped basePath from the
+      // request path before matching assetPrefix's path-prefix branch,
+      // which made the helper return null → 404 here. Inspecting HTML
+      // alone (as the pre-existing pages-router basePath test did) was
+      // not enough to catch the regression.
+      for (const url of assetUrls) {
+        const assetRes = await fetch(`${baseUrl}${url}`);
+        expect(assetRes.status, `expected 200 for ${url}`).toBe(200);
+        if (url.endsWith(".js")) {
+          expect(assetRes.headers.get("content-type")).toContain("javascript");
+        }
+      }
     } finally {
       server.close();
     }

--- a/tests/asset-prefix.test.ts
+++ b/tests/asset-prefix.test.ts
@@ -1,0 +1,441 @@
+/**
+ * `assetPrefix` integration tests.
+ *
+ * Mirrors Next.js's `assetPrefix` behaviour:
+ *  - Path prefix (e.g. `/custom-asset-prefix`): every emitted script/CSS URL
+ *    starts with that prefix and lives under `_next/static/` to match
+ *    Next.js's URL convention. Fetching those URLs from the prod server
+ *    must succeed.
+ *  - Absolute URL (e.g. `https://cdn.example.com`): emitted URLs are fully
+ *    qualified — runtime serving on the deployment origin is a no-op.
+ *  - Combined with `basePath`: routes stay under `basePath`, assets under
+ *    `assetPrefix`. They are independent.
+ *  - Unset (default): URLs continue to live under `/assets/` for backward
+ *    compatibility.
+ *
+ * Ported from Next.js: test/e2e/app-dir/asset-prefix/asset-prefix.test.ts
+ * https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/asset-prefix/asset-prefix.test.ts
+ *
+ * @see https://nextjs.org/docs/app/api-reference/config/next-config-js/assetPrefix
+ */
+
+import { describe, it, expect, afterAll } from "vite-plus/test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createBuilder } from "vite";
+import vinext from "../packages/vinext/src/index.js";
+import {
+  isAbsoluteAssetPrefix,
+  resolveAssetUrlPrefix,
+  resolveAssetsDir,
+  assetPrefixPathname,
+  ASSET_PREFIX_URL_DIR,
+} from "../packages/vinext/src/utils/asset-prefix.js";
+import { resolveAppRouterAssetPath } from "../packages/vinext/src/server/prod-server.js";
+import { normalizeAssetPrefix } from "../packages/vinext/src/config/next-config.js";
+
+const APP_FIXTURE_DIR = path.resolve(import.meta.dirname, "./fixtures/app-basic");
+const ROOT_NODE_MODULES = path.resolve(import.meta.dirname, "../node_modules");
+
+// ── Unit tests on the asset-prefix helpers ────────────────────────────────────
+
+describe("normalizeAssetPrefix", () => {
+  it("returns an empty string when unset, null, or empty", () => {
+    expect(normalizeAssetPrefix(undefined)).toBe("");
+    expect(normalizeAssetPrefix(null)).toBe("");
+    expect(normalizeAssetPrefix("")).toBe("");
+    expect(normalizeAssetPrefix("   ")).toBe("");
+  });
+
+  it("trims trailing slashes and preserves a path prefix", () => {
+    expect(normalizeAssetPrefix("/cdn")).toBe("/cdn");
+    expect(normalizeAssetPrefix("/cdn/")).toBe("/cdn");
+    expect(normalizeAssetPrefix("/cdn//")).toBe("/cdn");
+    expect(normalizeAssetPrefix("/custom-asset-prefix")).toBe("/custom-asset-prefix");
+  });
+
+  it("adds a leading slash to bare path prefixes", () => {
+    // Next.js accepts both `cdn` and `/cdn`; normalize to the leading-slash form.
+    expect(normalizeAssetPrefix("cdn")).toBe("/cdn");
+  });
+
+  it("preserves absolute URLs verbatim (sans trailing slash)", () => {
+    expect(normalizeAssetPrefix("https://cdn.example.com")).toBe("https://cdn.example.com");
+    expect(normalizeAssetPrefix("https://cdn.example.com/")).toBe("https://cdn.example.com");
+    expect(normalizeAssetPrefix("https://cdn.example.com/sub")).toBe("https://cdn.example.com/sub");
+    expect(normalizeAssetPrefix("HTTP://cdn.example.com")).toBe("HTTP://cdn.example.com");
+  });
+
+  it("throws on non-string values to surface config typos early", () => {
+    expect(() => normalizeAssetPrefix(42 as unknown as string)).toThrow(/must be a string/);
+    expect(() => normalizeAssetPrefix({} as unknown as string)).toThrow(/must be a string/);
+  });
+
+  it("throws on unparseable absolute URLs", () => {
+    // A URL that begins with the http(s) scheme but cannot be parsed —
+    // the colon-only host triggers `URL.canParse` to return false.
+    expect(() => normalizeAssetPrefix("https://:::")).toThrow(/parseable URL/);
+  });
+});
+
+describe("isAbsoluteAssetPrefix", () => {
+  it("is true for http/https URLs and false for path prefixes or empty", () => {
+    expect(isAbsoluteAssetPrefix("https://cdn.example.com")).toBe(true);
+    expect(isAbsoluteAssetPrefix("http://cdn.example.com")).toBe(true);
+    expect(isAbsoluteAssetPrefix("HTTPS://cdn.example.com")).toBe(true);
+    expect(isAbsoluteAssetPrefix("/custom-asset-prefix")).toBe(false);
+    expect(isAbsoluteAssetPrefix("")).toBe(false);
+  });
+});
+
+describe("resolveAssetsDir", () => {
+  it("keeps the historical `assets/` default when no prefix is configured", () => {
+    expect(resolveAssetsDir("")).toBe("assets");
+  });
+
+  it("returns `<prefix>/_next/static` for path prefixes so disk and URL align", () => {
+    expect(resolveAssetsDir("/custom-asset-prefix")).toBe("custom-asset-prefix/_next/static");
+    expect(resolveAssetsDir("/cdn")).toBe(`cdn/${ASSET_PREFIX_URL_DIR}`);
+  });
+
+  it("returns `_next/static` for absolute-URL prefixes — the CDN owns the URL prefix", () => {
+    expect(resolveAssetsDir("https://cdn.example.com")).toBe(ASSET_PREFIX_URL_DIR);
+    expect(resolveAssetsDir("https://cdn.example.com/sub")).toBe(ASSET_PREFIX_URL_DIR);
+  });
+});
+
+describe("resolveAssetUrlPrefix", () => {
+  it("returns `/_next/static/` when no prefix is configured", () => {
+    expect(resolveAssetUrlPrefix("")).toBe("/_next/static/");
+  });
+
+  it("concatenates the prefix with the static dir for path prefixes", () => {
+    expect(resolveAssetUrlPrefix("/cdn")).toBe("/cdn/_next/static/");
+    expect(resolveAssetUrlPrefix("/custom-asset-prefix")).toBe(
+      "/custom-asset-prefix/_next/static/",
+    );
+  });
+
+  it("preserves the full URL for absolute-URL prefixes", () => {
+    expect(resolveAssetUrlPrefix("https://cdn.example.com")).toBe(
+      "https://cdn.example.com/_next/static/",
+    );
+    expect(resolveAssetUrlPrefix("https://cdn.example.com/sub")).toBe(
+      "https://cdn.example.com/sub/_next/static/",
+    );
+  });
+});
+
+describe("assetPrefixPathname", () => {
+  it("returns empty for unset prefix and absolute URLs without a path component", () => {
+    expect(assetPrefixPathname("")).toBe("");
+    expect(assetPrefixPathname("https://cdn.example.com")).toBe("");
+    expect(assetPrefixPathname("https://cdn.example.com/")).toBe("");
+  });
+
+  it("returns the path component for path-prefix and pathful URL prefixes", () => {
+    expect(assetPrefixPathname("/custom-asset-prefix")).toBe("/custom-asset-prefix");
+    expect(assetPrefixPathname("https://cdn.example.com/sub")).toBe("/sub");
+  });
+});
+
+describe("resolveAppRouterAssetPath", () => {
+  it("falls back to /assets/ when no prefix is configured", () => {
+    expect(resolveAppRouterAssetPath("/assets/foo-abc.js", "", "")).toBe("/assets/foo-abc.js");
+    expect(resolveAppRouterAssetPath("/about", "", "")).toBeNull();
+  });
+
+  it("recognises `<prefix>/_next/static/<file>` for path-prefix configs", () => {
+    expect(
+      resolveAppRouterAssetPath(
+        "/custom-asset-prefix/_next/static/foo-abc.js",
+        "/custom-asset-prefix",
+        "/custom-asset-prefix",
+      ),
+    ).toBe("/custom-asset-prefix/_next/static/foo-abc.js");
+  });
+
+  it("strips the path component for absolute-URL prefixes with a path", () => {
+    // Disk layout for absolute-URL prefixes is `_next/static/...` (no
+    // extra prefix dir on disk), so a same-origin proxy that forwards the
+    // full URL path lands on the right file once the URL prefix is stripped.
+    expect(
+      resolveAppRouterAssetPath(
+        "/sub/_next/static/foo-abc.js",
+        "/sub",
+        "https://cdn.example.com/sub",
+      ),
+    ).toBe("/_next/static/foo-abc.js");
+  });
+
+  it("accepts `/_next/static/<file>` for absolute-URL prefixes without a path", () => {
+    expect(
+      resolveAppRouterAssetPath("/_next/static/foo-abc.js", "", "https://cdn.example.com"),
+    ).toBe("/_next/static/foo-abc.js");
+  });
+
+  it("returns null for unrelated paths when a prefix is configured", () => {
+    expect(
+      resolveAppRouterAssetPath(
+        "/some-other-path/foo.js",
+        "/custom-asset-prefix",
+        "/custom-asset-prefix",
+      ),
+    ).toBeNull();
+  });
+
+  it("keeps the historical /assets/ branch working alongside an asset prefix", () => {
+    // Backward compatibility: a project that turns on assetPrefix and still
+    // has plugins emitting under /assets/ (e.g. legacy outputs) should keep
+    // working in the same server process.
+    expect(
+      resolveAppRouterAssetPath(
+        "/assets/foo-abc.js",
+        "/custom-asset-prefix",
+        "/custom-asset-prefix",
+      ),
+    ).toBe("/assets/foo-abc.js");
+  });
+});
+
+// ── End-to-end build tests ────────────────────────────────────────────────────
+
+/**
+ * Build the app-basic fixture into an isolated tmp dir, optionally patching
+ * `next.config.ts` with extra config keys.
+ *
+ * The fixture is copied so tests can mutate next.config.ts independently
+ * without polluting each other or the shared on-disk fixture. node_modules
+ * is symlinked to the workspace root to avoid a real install.
+ */
+async function buildFixtureWithConfig(extraConfigJson: string): Promise<{
+  fixtureRoot: string;
+  outDir: string;
+  cleanup: () => void;
+}> {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-asset-prefix-"));
+  const fixtureRoot = path.join(tmpDir, "fixture");
+  fs.cpSync(APP_FIXTURE_DIR, fixtureRoot, { recursive: true });
+  // Symlink the workspace node_modules so the fixture can resolve React,
+  // vinext, and @vitejs/plugin-rsc.
+  const fixtureNodeModules = path.join(fixtureRoot, "node_modules");
+  if (!fs.existsSync(fixtureNodeModules)) {
+    fs.symlinkSync(ROOT_NODE_MODULES, fixtureNodeModules, "junction");
+  }
+
+  // Patch next.config.ts to add the extra keys. We splice them in right after
+  // the opening `{` to avoid clobbering the existing async functions.
+  const nextConfigPath = path.join(fixtureRoot, "next.config.ts");
+  const original = fs.readFileSync(nextConfigPath, "utf-8");
+  const patched = original.replace(
+    "const nextConfig: NextConfig = {",
+    `const nextConfig: NextConfig = {\n  ${extraConfigJson}`,
+  );
+  fs.writeFileSync(nextConfigPath, patched);
+
+  const outDir = path.join(fixtureRoot, "dist");
+
+  const builder = await createBuilder({
+    root: fixtureRoot,
+    configFile: false,
+    plugins: [vinext({ appDir: fixtureRoot })],
+    logLevel: "silent",
+  });
+  await builder.buildApp();
+
+  return {
+    fixtureRoot,
+    outDir,
+    cleanup: () => fs.rmSync(tmpDir, { recursive: true, force: true }),
+  };
+}
+
+describe("assetPrefix end-to-end build", () => {
+  // Track tmp dirs so we can clean up if a test throws before its own cleanup.
+  const cleanups: Array<() => void> = [];
+  afterAll(() => {
+    for (const c of cleanups) c();
+  });
+
+  it("path-prefix: emits assets under <prefix>/_next/static/ on disk and in HTML", async () => {
+    const built = await buildFixtureWithConfig(`assetPrefix: "/custom-asset-prefix",`);
+    cleanups.push(built.cleanup);
+
+    // Files land on disk where the URLs say they should — Cloudflare's
+    // ASSETS binding (and any static file server) can serve them directly
+    // without a runtime rewrite.
+    const onDiskStatic = path.join(
+      built.outDir,
+      "client",
+      "custom-asset-prefix",
+      "_next",
+      "static",
+    );
+    expect(fs.existsSync(onDiskStatic), `expected on-disk layout under ${onDiskStatic}`).toBe(true);
+    const entries = fs.readdirSync(onDiskStatic);
+    expect(entries.some((f) => f.endsWith(".js"))).toBe(true);
+
+    // Serve the build via startProdServer and verify SSR HTML references
+    // the assetPrefix-anchored URLs, and that those URLs return 200.
+    const { startProdServer } = await import("../packages/vinext/src/server/prod-server.js");
+    const { server } = await startProdServer({
+      port: 0,
+      outDir: built.outDir,
+      noCompression: true,
+    });
+    try {
+      const addr = server.address();
+      const port = typeof addr === "object" && addr ? addr.port : 0;
+      const baseUrl = `http://localhost:${port}`;
+
+      const homeRes = await fetch(`${baseUrl}/`);
+      expect(homeRes.status).toBe(200);
+      const html = await homeRes.text();
+      // Helpful when this test starts to drift — uncomment to inspect HTML.
+      // console.log("--- HTML ---\n" + html + "\n--- /HTML ---");
+
+      // Bootstrap script URL must be prefixed AND live under _next/static.
+      // Mirrors the Next.js fixture assertion:
+      //   src?.includes('/custom-asset-prefix/_next/static') ||
+      //   src?.includes('/custom-asset-prefix/_next/static/immutable')
+      const bootstrapMatch = html.match(/import\("([^"]+\.js)"\)/);
+      expect(
+        bootstrapMatch,
+        "expected a bootstrap `import(...)` script in the HTML",
+      ).not.toBeNull();
+      expect(bootstrapMatch![1]).toMatch(/^\/custom-asset-prefix\/_next\/static\//);
+
+      // Any `<script src="...">` tag with a non-inline src must also be
+      // under the configured prefix. Vite/RSC may inject modulepreload
+      // links too — we don't strictly require them here, but they must
+      // not leak the old /assets/ default.
+      const scriptSrcRe = /<script[^>]+src="([^"]+)"/g;
+      const scriptSrcs: string[] = [];
+      for (const m of html.matchAll(scriptSrcRe)) {
+        scriptSrcs.push(m[1]);
+      }
+      for (const src of scriptSrcs) {
+        expect(src.startsWith("/custom-asset-prefix/_next/static/")).toBe(true);
+      }
+
+      // Fetching the bootstrap URL must return 200 with the JS body.
+      const bundleRes = await fetch(`${baseUrl}${bootstrapMatch![1]}`);
+      expect(bundleRes.status).toBe(200);
+      expect(bundleRes.headers.get("content-type")).toContain("javascript");
+    } finally {
+      server.close();
+    }
+  }, 180_000);
+
+  it("absolute URL: emits fully-qualified asset URLs and never includes /assets/", async () => {
+    const built = await buildFixtureWithConfig(`assetPrefix: "https://cdn.example.com",`);
+    cleanups.push(built.cleanup);
+
+    // Disk layout is just _next/static/ — the CDN owns the URL prefix.
+    const onDiskStatic = path.join(built.outDir, "client", "_next", "static");
+    expect(fs.existsSync(onDiskStatic), `expected on-disk layout under ${onDiskStatic}`).toBe(true);
+
+    const { startProdServer } = await import("../packages/vinext/src/server/prod-server.js");
+    const { server } = await startProdServer({
+      port: 0,
+      outDir: built.outDir,
+      noCompression: true,
+    });
+    try {
+      const addr = server.address();
+      const port = typeof addr === "object" && addr ? addr.port : 0;
+      const baseUrl = `http://localhost:${port}`;
+
+      const homeRes = await fetch(`${baseUrl}/`);
+      expect(homeRes.status).toBe(200);
+      const html = await homeRes.text();
+
+      const bootstrapMatch = html.match(/import\("([^"]+\.js)"\)/);
+      expect(bootstrapMatch).not.toBeNull();
+      // Fully qualified — no protocol-relative or path-only URLs.
+      expect(bootstrapMatch![1]).toMatch(/^https:\/\/cdn\.example\.com\/_next\/static\//);
+
+      // No emitted asset URL should leak the historical /assets/ default.
+      expect(html).not.toMatch(/<script[^>]+src="\/assets\//);
+    } finally {
+      server.close();
+    }
+  }, 180_000);
+
+  it("basePath + assetPrefix: routes under basePath, assets under assetPrefix", async () => {
+    const built = await buildFixtureWithConfig(`basePath: "/app",\n  assetPrefix: "/cdn-prefix",`);
+    cleanups.push(built.cleanup);
+
+    // On-disk path mirrors the assetPrefix path — independent of basePath.
+    const onDiskStatic = path.join(built.outDir, "client", "cdn-prefix", "_next", "static");
+    expect(fs.existsSync(onDiskStatic), `expected on-disk layout under ${onDiskStatic}`).toBe(true);
+
+    const { startProdServer } = await import("../packages/vinext/src/server/prod-server.js");
+    const { server } = await startProdServer({
+      port: 0,
+      outDir: built.outDir,
+      noCompression: true,
+    });
+    try {
+      const addr = server.address();
+      const port = typeof addr === "object" && addr ? addr.port : 0;
+      const baseUrl = `http://localhost:${port}`;
+
+      // Routes live under basePath only.
+      const homeRes = await fetch(`${baseUrl}/app/`);
+      expect(homeRes.status).toBe(200);
+      const html = await homeRes.text();
+
+      const bootstrapMatch = html.match(/import\("([^"]+\.js)"\)/);
+      expect(bootstrapMatch).not.toBeNull();
+      // Asset URLs must NOT be under basePath — they are under assetPrefix only.
+      expect(bootstrapMatch![1]).toMatch(/^\/cdn-prefix\/_next\/static\//);
+      expect(bootstrapMatch![1].startsWith("/app/")).toBe(false);
+
+      // Fetching the asset URL succeeds (no basePath redirect).
+      const bundleRes = await fetch(`${baseUrl}${bootstrapMatch![1]}`);
+      expect(bundleRes.status).toBe(200);
+    } finally {
+      server.close();
+    }
+  }, 180_000);
+
+  it("unset: continues to emit URLs under /assets/ (backward compatibility)", async () => {
+    // Smoke-check the baseline — no assetPrefix is set, so behaviour must
+    // be unchanged from before this feature landed.
+    const built = await buildFixtureWithConfig(`// no assetPrefix`);
+    cleanups.push(built.cleanup);
+
+    // Historical layout preserved.
+    const onDiskAssets = path.join(built.outDir, "client", "assets");
+    expect(
+      fs.existsSync(onDiskAssets),
+      `expected historical on-disk layout under ${onDiskAssets}`,
+    ).toBe(true);
+
+    const { startProdServer } = await import("../packages/vinext/src/server/prod-server.js");
+    const { server } = await startProdServer({
+      port: 0,
+      outDir: built.outDir,
+      noCompression: true,
+    });
+    try {
+      const addr = server.address();
+      const port = typeof addr === "object" && addr ? addr.port : 0;
+      const baseUrl = `http://localhost:${port}`;
+
+      const homeRes = await fetch(`${baseUrl}/`);
+      expect(homeRes.status).toBe(200);
+      const html = await homeRes.text();
+
+      const bootstrapMatch = html.match(/import\("([^"]+\.js)"\)/);
+      expect(bootstrapMatch).not.toBeNull();
+      expect(bootstrapMatch![1]).toMatch(/^\/assets\//);
+      const bundleRes = await fetch(`${baseUrl}${bootstrapMatch![1]}`);
+      expect(bundleRes.status).toBe(200);
+    } finally {
+      server.close();
+    }
+  }, 180_000);
+});

--- a/tests/e2e/cloudflare-workers/navigation.spec.ts
+++ b/tests/e2e/cloudflare-workers/navigation.spec.ts
@@ -48,8 +48,9 @@ test.describe("Cloudflare Workers Navigation", () => {
   test("static assets are served (client JS bundle)", async ({ request }) => {
     // First get the home page to find the JS bundle URL
     const html = await (await request.get(`${BASE}/`)).text();
-    // The bundle is referenced as import("/assets/index-XXXX.js")
-    const match = html.match(/import\("(\/assets\/[^"]+)"\)/);
+    // The bundle is referenced as <script type="module" src="/assets/index-XXXX.js">
+    // (emitted via React's bootstrapModules option from app-ssr-entry.ts).
+    const match = html.match(/<script[^>]+type="module"[^>]+src="(\/assets\/[^"]+)"/);
     expect(match).toBeTruthy();
 
     const jsUrl = match![1];

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -856,6 +856,7 @@ describe("detectNextIntlConfig", () => {
   function makeResolved(overrides: Partial<ResolvedNextConfig> = {}): ResolvedNextConfig {
     return {
       env: {},
+      assetPrefix: "",
       basePath: "",
       trailingSlash: false,
       output: "",

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -844,6 +844,49 @@ describe("resolveNextConfig expireTime", () => {
   });
 });
 
+// Ported from Next.js: packages/next/src/server/config.ts:528-531
+// https://github.com/vercel/next.js/blob/canary/packages/next/src/server/config.ts
+describe("resolveNextConfig basePath → assetPrefix parity fallback", () => {
+  it("falls back to basePath when assetPrefix is empty", async () => {
+    const resolved = await resolveNextConfig({ basePath: "/app" });
+    expect(resolved.basePath).toBe("/app");
+    expect(resolved.assetPrefix).toBe("/app");
+  });
+
+  it("does not override an explicitly set assetPrefix", async () => {
+    const resolved = await resolveNextConfig({
+      basePath: "/app",
+      assetPrefix: "/cdn",
+    });
+    expect(resolved.basePath).toBe("/app");
+    expect(resolved.assetPrefix).toBe("/cdn");
+  });
+
+  it("preserves absolute-URL assetPrefix even when basePath is also set", async () => {
+    const resolved = await resolveNextConfig({
+      basePath: "/app",
+      assetPrefix: "https://cdn.example.com",
+    });
+    expect(resolved.assetPrefix).toBe("https://cdn.example.com");
+  });
+
+  it("leaves assetPrefix empty when basePath is also empty", async () => {
+    const resolved = await resolveNextConfig({});
+    expect(resolved.basePath).toBe("");
+    expect(resolved.assetPrefix).toBe("");
+  });
+
+  it("does not fall back when basePath is literal `/` (parity with Next.js)", async () => {
+    // Next.js rejects basePath === "/" earlier in its config pipeline;
+    // vinext passes the value through but the fallback explicitly skips
+    // it to avoid producing assetPrefix === "/" (which would collide
+    // with the root URL).
+    const resolved = await resolveNextConfig({ basePath: "/" });
+    expect(resolved.basePath).toBe("/");
+    expect(resolved.assetPrefix).toBe("");
+  });
+});
+
 describe("detectNextIntlConfig", () => {
   let tmpDir: string;
 

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -2155,6 +2155,18 @@ export default function CounterPage() {
         ([key]) => key.endsWith("/pages/counter.tsx") || key === "pages/counter.tsx",
       );
       expect(counterManifestEntry).toBeDefined();
+      // Next.js parity: when `basePath` is set and `assetPrefix` is unset,
+      // `assetPrefix` falls back to `basePath`. The on-disk layout therefore
+      // mirrors `<basePath>/_next/static/...` rather than the legacy
+      // `<basePath>/assets/...` Vite default.
+      // See packages/next/src/server/config.ts:528-531.
+      //
+      // Every entry should be anchored under basePath. With the parity
+      // fallback in effect, entries land under `<basePath>/_next/static/`
+      // (Vite's raw SSR manifest may produce duplicate-prefixed entries
+      // alongside the backfilled ones — both forms start with `docs/` so
+      // the prod-server's URL→file lookup is unaffected. The
+      // user-visible HTML asserts below are the source of truth).
       expect(counterManifestEntry?.[1].every((file: string) => file.startsWith("docs/"))).toBe(
         true,
       );
@@ -2173,8 +2185,11 @@ export default function CounterPage() {
         const res = await fetch(`http://127.0.0.1:${addr.port}/docs/counter`);
         expect(res.status).toBe(200);
         const html = await res.text();
-        expect(html).toContain('href="/docs/assets/');
-        expect(html).toContain('src="/docs/assets/');
+        // Asset URLs land under `<basePath>/_next/static/` per Next.js
+        // parity (basePath→assetPrefix fallback). Stylesheets and scripts
+        // both share the same prefix.
+        expect(html).toContain('href="/docs/_next/static/');
+        expect(html).toContain('src="/docs/_next/static/');
       } finally {
         await new Promise<void>((resolve) => prodServer.close(() => resolve()));
       }

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -2182,7 +2182,8 @@ export default function CounterPage() {
 
       try {
         const addr = prodServer.address() as { port: number };
-        const res = await fetch(`http://127.0.0.1:${addr.port}/docs/counter`);
+        const baseUrl = `http://127.0.0.1:${addr.port}`;
+        const res = await fetch(`${baseUrl}/docs/counter`);
         expect(res.status).toBe(200);
         const html = await res.text();
         // Asset URLs land under `<basePath>/_next/static/` per Next.js
@@ -2190,6 +2191,25 @@ export default function CounterPage() {
         // both share the same prefix.
         expect(html).toContain('href="/docs/_next/static/');
         expect(html).toContain('src="/docs/_next/static/');
+
+        // Every emitted asset URL must actually resolve to 200 from the
+        // prod server. The previous version of this test only asserted
+        // the URLs APPEAR in HTML, not that they were served correctly.
+        // The Pages Router asset lookup was stripping basePath BEFORE
+        // matching against the assetPrefix, so requests for
+        // `/docs/_next/static/...` were 404ing when assetPrefix fell
+        // back to basePath (round-5 review feedback on #1311).
+        const assetUrls = new Set<string>();
+        for (const m of html.matchAll(
+          /<(?:script|link)[^>]+(?:src|href)="(\/docs\/_next\/[^"]+)"/g,
+        )) {
+          assetUrls.add(m[1]);
+        }
+        expect(assetUrls.size).toBeGreaterThan(0);
+        for (const url of assetUrls) {
+          const assetRes = await fetch(`${baseUrl}${url}`);
+          expect(assetRes.status, `expected 200 for ${url}`).toBe(200);
+        }
       } finally {
         await new Promise<void>((resolve) => prodServer.close(() => resolve()));
       }

--- a/tests/precompress.test.ts
+++ b/tests/precompress.test.ts
@@ -181,6 +181,38 @@ describe("precompressAssets", () => {
     expect(decompressed).toBe(jsContent);
   });
 
+  it("compresses assets under a custom assetsDir (assetPrefix layout)", async () => {
+    // With `assetPrefix: "/cdn"` the build emits hashed assets under
+    // `<clientDir>/cdn/_next/static/...` instead of the default `assets/`.
+    // Caller threads the resolved subdir in via options.assetsDir.
+    const jsContent = "const x = 1;\n".repeat(200);
+    await writeAsset(clientDir, "cdn/_next/static/main-abc123.js", jsContent);
+    // A file at the legacy `assets/` location must NOT be picked up when a
+    // custom assetsDir is in effect — otherwise both layouts would be walked.
+    await writeAsset(clientDir, "assets/legacy-def456.js", jsContent);
+
+    const result = await precompressAssets(clientDir, { assetsDir: "cdn/_next/static" });
+
+    expect(result.filesCompressed).toBe(1);
+    expect(fs.existsSync(path.join(clientDir, "cdn/_next/static/main-abc123.js.br"))).toBe(true);
+    expect(fs.existsSync(path.join(clientDir, "cdn/_next/static/main-abc123.js.gz"))).toBe(true);
+    // Legacy location is untouched
+    expect(fs.existsSync(path.join(clientDir, "assets/legacy-def456.js.br"))).toBe(false);
+  });
+
+  it("compresses assets under _next/static for absolute-URL assetPrefix", async () => {
+    // With an absolute-URL `assetPrefix` (e.g. `https://cdn.example.com`)
+    // assets are written to `_next/static/` on disk; the URL prefix is
+    // applied at render time, not on the filesystem.
+    const jsContent = "function f() { return 1; }\n".repeat(200);
+    await writeAsset(clientDir, "_next/static/chunk-xyz999.js", jsContent);
+
+    const result = await precompressAssets(clientDir, { assetsDir: "_next/static" });
+
+    expect(result.filesCompressed).toBe(1);
+    expect(fs.existsSync(path.join(clientDir, "_next/static/chunk-xyz999.js.br"))).toBe(true);
+  });
+
   it("reports total original and compressed byte sizes", async () => {
     const jsContent = "const x = 1;\n".repeat(500);
     await writeAsset(clientDir, "assets/big-fff666.js", jsContent);


### PR DESCRIPTION
## What

Implements the Next.js `assetPrefix` config option in vinext. `assetPrefix` prepends a URL (CDN origin or path prefix) to every emitted JS/CSS/image/static asset URL while leaving routing under `basePath` untouched.

Closes the gap noted in the diagnostic: prior to this PR the config loader silently dropped `assetPrefix`, Vite's `base` was derived from `basePath` only, and the Pages/App prod servers had no way to recognise the prefixed URLs.

Reference: https://nextjs.org/docs/app/api-reference/config/next-config-js/assetPrefix
Next.js source: `packages/next/src/lib/load-custom-routes.ts` (`assetPrefix` handling + the automatic `/<prefix>/_next/:path+` rewrite).

## How

Layered approach split across three commits — config + build, runtime serving, tests:

1. **Config (`packages/vinext/src/config/next-config.ts`)** — adds `assetPrefix` to `NextConfig` and `ResolvedNextConfig`. A new exported `normalizeAssetPrefix(value)` helper trims trailing slashes, accepts path prefixes (`/cdn`) and absolute URLs (`https://cdn.example.com[/sub]`), validates parseability, and rejects non-string values.

2. **Asset-prefix helpers (`packages/vinext/src/utils/asset-prefix.ts`)** — new module collects the shared logic so the build plugin and runtime servers stay aligned:
   - `resolveAssetsDir(prefix)` → on-disk layout under `outDir`.
   - `resolveAssetUrlPrefix(prefix)` → emitted URL prefix (always ends with `_next/static/`, matching Next.js's URL convention).
   - `assetPrefixPathname(prefix)` → path portion used for runtime URL matching.
   - `isAbsoluteAssetPrefix(prefix)` → helper for branching.

3. **Vite plugin (`packages/vinext/src/index.ts`)** — when `assetPrefix` is configured:
   - `build.assetsDir` → `<prefix>/_next/static` for path prefixes, `_next/static` for absolute URLs. Disk layout matches the URL so the Cloudflare ASSETS binding and any static file server serve the assets without a runtime rewrite.
   - `experimental.renderBuiltUrl` → overrides Vite's default `assetsURL = base + url` emission so `assetPrefix` URLs are emitted directly. This keeps `basePath` and `assetPrefix` independent — routes anchor at `base = basePath + '/'` as today, asset URLs anchor at the configured asset prefix.

4. **Runtime serving (`packages/vinext/src/server/prod-server.ts`)** — both routers share a new `resolveAppRouterAssetPath(pathname, assetPathPrefix, assetPrefix)` helper that translates request URLs into on-disk lookup paths. Three URL shapes are recognised: historical `/assets/`, `<assetPathPrefix>/_next/static/...` for path prefixes / pathful absolute URLs, and `/_next/static/...` for plain absolute-URL prefixes. The App Router loads `assetPrefix` from a new `vinext-runtime-config.json` sibling (the RSC entry only embeds `__basePath`); the Pages Router reads it from the embedded `vinextConfig`.

5. **Cache headers (`packages/vinext/src/server/static-file-cache.ts`)** — files under `_next/static/` join `assets/` as "content-hashed" for the long-lived `immutable` Cache-Control. Same change in the slow-path branch of `tryServeStatic`.

## Tests

- **`tests/asset-prefix.test.ts`** (new — 25 cases) covers:
  - Unit tests for every helper (`normalizeAssetPrefix`, `isAbsoluteAssetPrefix`, `resolveAssetsDir`, `resolveAssetUrlPrefix`, `assetPrefixPathname`, `resolveAppRouterAssetPath`).
  - End-to-end `vinext build` + `startProdServer` tests for each `assetPrefix` shape:
    - Path prefix (`/custom-asset-prefix`) → SSR HTML references `/custom-asset-prefix/_next/static/...`, on-disk layout matches, fetching the bootstrap URL returns 200.
    - Absolute URL (`https://cdn.example.com`) → emitted asset URLs are fully qualified, no `/assets/` leaks.
    - Combined `basePath: '/app'` + `assetPrefix: '/cdn-prefix'` → routes stay under `/app/`, asset URLs under `/cdn-prefix/` (proves independence).
    - Unset (default) → historical `/assets/` layout preserved.
  - Result: ✅ 25/25 passing.

- **Regression sweep** — re-ran:
  - `tests/build-optimization.test.ts` (78 ✓)
  - `tests/ssr-css-assets.test.ts` (incl.)
  - `tests/next-config.test.ts` (108 ✓)
  - `tests/pages-router.test.ts` (209 ✓)
  - `tests/app-router.test.ts` (317 ✓)
  - `tests/deploy.test.ts` (220 ✓)
  - `tests/shims.test.ts` (915 ✓)
  - `tests/font-google-build.test.ts` (1 ✓)
  - `tests/nextjs-compat/` (288 ✓)
  - Misc build tests
  - No regressions.

- **Next.js fixture parity** — ran `VINEXT_BUILD=1 ./scripts/run-nextjs-deploy-suite.sh .nextjs-ref test/e2e/app-dir/asset-prefix/asset-prefix.test.ts`. Of the 7 cases in that suite, **4 now pass** that did not before:
  - ✅ `should redirect route when requesting it directly`
  - ✅ `should render link`
  - ✅ `rewrites that do not start with assetPrefix should still work`
  - ✅ `should respect rewrites that start with assetPrefix`
  - ❌ `should redirect route when requesting it directly by browser` — Playwright not installed locally (env issue, unrelated)
  - ❌ `should redirect route when clicking link` — same Playwright env issue
  - ❌ `bundles should return 200 on served assetPrefix` — see "Deliberate divergences" below

## Deliberate divergences from Next.js

* **`<script src="...">` vs `<script>import("...")</script>`** — the upstream `bundles should return 200 on served assetPrefix` test iterates over `$('script').toArray()` and reads `script.attribs.src`. Vinext uses `@vitejs/plugin-rsc`'s bootstrap which emits inline `<script>import("X")</script>` instead of `<script src="X" type="module">`, so the upstream selector returns 0 matches. The asset prefix logic itself is functionally correct — emitted URLs are prefixed, on-disk layout matches, and fetching the URLs returns 200 (verified in our own tests via the same regex extraction). This is a pre-existing architectural divergence in how vinext emits the bootstrap script and was not changed here.

## Open questions / follow-ups

* **Dev server parity** — Vite's `base` is still derived from `basePath` only; dev URLs aren't yet `assetPrefix`-aware. The production code path is what the documented use case targets, but a follow-up could thread `assetPrefix` through Vite's connect middleware too.
* **`<script src>` bootstrap emission** — emitting `<script src=...>` tags (perhaps via React's `bootstrapScripts` array instead of `bootstrapScriptContent`) would unlock the upstream `bundles should return 200` test directly. Out of scope here.
* **Automatic `/<prefix>/_next/:path+` rewrite** — Next.js auto-injects a rewrite from `/<assetPrefix>/_next/...` to `/_next/...` when `basePath === assetPrefix`. Vinext's prod server already serves the assets directly from disk so this rewrite isn't required for correctness, but parity for user-defined rewrites against the asset prefix path could be tightened up.


## Notes — updates since the original description

The original "Deliberate divergences" and "Open questions" sections were written against the very first round of this PR. Several items have since been resolved:

- **`<script src>` bootstrap is now emitted** (round 3, commit `3a2c886`). The App Router SSR pipeline passes `bootstrapModules: [url]` to React's `renderToReadableStream` instead of inline `bootstrapScriptContent`, so the streamed HTML contains a real `<script type="module" src="…">` tag. The Next.js `bundles should return 200 on served assetPrefix` fixture test now finds the bundle URLs via `$('script').toArray()`.

- **`vinext-runtime-config.json` sidecar removed** (round 4, commit `1218a81`). `assetPrefix` is now embedded as `export const __assetPrefix` in the generated RSC entry, matching the existing `__basePath` embed pattern and the Pages Router's `vinextConfig` export.

- **`basePath → assetPrefix` parity fallback added** (round 4, commit `bac8425`). When `basePath` is set and `assetPrefix` is left empty, vinext now mirrors Next.js's behaviour (`packages/next/src/server/config.ts:528-531`) and treats `assetPrefix = basePath`. This shifts the default asset URL layout for `basePath`-only apps from `/app/assets/…` to `/app/_next/static/…` — matching Next.js's expected layout.

### CSP behavioural change

The switch from inline `bootstrapScriptContent` to `bootstrapModules` (above) has CSP implications worth calling out:

- Apps no longer need `script-src 'unsafe-inline'` for the App Router bootstrap (improvement — inline imports previously required it).
- Apps that restrict script sources need `'self'` for the common case, or the CDN origin when `assetPrefix` is an absolute URL like `https://cdn.example.com`.
- React still threads the request nonce through to the emitted `<script type="module" src=…>` tag, so nonce-based CSP (`script-src 'nonce-…' 'strict-dynamic'`) keeps working unchanged.

See the comment at `packages/vinext/src/server/app-ssr-entry.ts` near the `bootstrapModules` call for the same notes inline.
