### PR TITLE
feat(app-router): plan navigation from RouteManifest topology

### DIFF
--- a/packages/vinext/src/entries/app-browser-entry.ts
+++ b/packages/vinext/src/entries/app-browser-entry.ts
@@ -1,6 +1,7 @@
 import { resolveRuntimeEntryModule } from "./runtime-entry-module.js";
 import type { VinextLinkPrefetchRoute } from "../client/vinext-next-data.js";
 import type { AppRoute } from "../routing/app-router.js";
+import type { RouteManifest } from "../routing/app-route-graph.js";
 
 /**
  * Generate the virtual browser entry module.
@@ -9,7 +10,10 @@ import type { AppRoute } from "../routing/app-router.js";
  * embedded RSC payload and handles client-side navigation by re-fetching
  * RSC streams.
  */
-export function generateBrowserEntry(routes: readonly AppRoute[] = []): string {
+export function generateBrowserEntry(
+  routes: readonly AppRoute[] = [],
+  routeManifest: RouteManifest | null = null,
+): string {
   const entryPath = resolveRuntimeEntryModule("app-browser-entry");
   const prefetchRoutes: VinextLinkPrefetchRoute[] = routes
     .filter((route) => isLinkPrefetchRoute(route))
@@ -19,10 +23,36 @@ export function generateBrowserEntry(routes: readonly AppRoute[] = []): string {
     }));
 
   return `window.__VINEXT_LINK_PREFETCH_ROUTES__ = ${JSON.stringify(prefetchRoutes)};
+window.__VINEXT_ROUTE_MANIFEST__ = ${buildRouteManifestExpression(routeManifest)};
 import ${JSON.stringify(entryPath)};`;
 }
 
 function isLinkPrefetchRoute(route: AppRoute): boolean {
   if (route.pagePath !== null) return true;
   return route.routePath === null && route.layouts.length > 0;
+}
+
+function buildRouteManifestExpression(routeManifest: RouteManifest | null): string {
+  if (routeManifest === null) return "null";
+
+  const graph = routeManifest.segmentGraph;
+  return `{
+  graphVersion: ${JSON.stringify(routeManifest.graphVersion)},
+  segmentGraph: {
+    routes: ${buildMapExpression(graph.routes)},
+    pages: ${buildMapExpression(graph.pages)},
+    routeHandlers: ${buildMapExpression(graph.routeHandlers)},
+    layouts: ${buildMapExpression(graph.layouts)},
+    templates: ${buildMapExpression(graph.templates)},
+    slots: ${buildMapExpression(graph.slots)},
+    defaults: ${buildMapExpression(graph.defaults)},
+    slotBindings: ${buildMapExpression(graph.slotBindings)},
+    boundaries: ${buildMapExpression(graph.boundaries)},
+    rootBoundaries: ${buildMapExpression(graph.rootBoundaries)}
+  }
+}`;
+}
+
+function buildMapExpression<Key extends string, Value>(map: ReadonlyMap<Key, Value>): string {
+  return `new Map(${JSON.stringify(Array.from(map.entries()))})`;
 }

--- a/packages/vinext/src/global.d.ts
+++ b/packages/vinext/src/global.d.ts
@@ -18,6 +18,7 @@
 
 import type { Root } from "react-dom/client";
 import type { OnRequestErrorHandler } from "./server/instrumentation";
+import type { RouteManifest } from "./routing/app-route-graph";
 import type { CachedRscResponse, PrefetchCacheEntry } from "vinext/shims/navigation";
 
 // `window.next` is declared inline in `./client/window-next.ts` (mirroring
@@ -119,6 +120,13 @@ declare global {
      * Next.js refresh-reducer.ts).
      */
     __VINEXT_CLEAR_NAV_CACHES__: (() => void) | undefined;
+
+    /**
+     * Static App Router route graph read model embedded by the generated
+     * browser entry. Navigation planning uses it as the semantic authority
+     * for root-boundary, layout, and target parallel-slot facts.
+     */
+    __VINEXT_ROUTE_MANIFEST__: RouteManifest | null | undefined;
 
     /**
      * Commits an App Router hash-only navigation without fetching RSC data.

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -8,7 +8,7 @@ import {
 } from "./routing/pages-router.js";
 import { generateServerEntry as _generateServerEntry } from "./entries/pages-server-entry.js";
 import { generateClientEntry as _generateClientEntry } from "./entries/pages-client-entry.js";
-import { appRouter, invalidateAppRouteCache } from "./routing/app-router.js";
+import { appRouteGraph, appRouter, invalidateAppRouteCache } from "./routing/app-router.js";
 import type { NitroRouteRuleConfig } from "./build/nitro-route-rules.js";
 import { createValidFileMatcher } from "./routing/file-matcher.js";
 import { createSSRHandler } from "./server/dev-server.js";
@@ -2062,8 +2062,8 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           return generateSsrEntry(hasPagesDir);
         }
         if (id === RESOLVED_APP_BROWSER_ENTRY && hasAppDir) {
-          const routes = await appRouter(appDir, nextConfig?.pageExtensions, fileMatcher);
-          return generateBrowserEntry(routes);
+          const graph = await appRouteGraph(appDir, nextConfig?.pageExtensions, fileMatcher);
+          return generateBrowserEntry(graph.routes, graph.routeManifest);
         }
         if (id.startsWith(RESOLVED_VIRTUAL_GOOGLE_FONTS + "?")) {
           return generateGoogleFontsVirtualModule(id, _fontGoogleShimPath);

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -84,6 +84,7 @@ import { createPopstateRestoreHandler } from "./app-browser-popstate.js";
 import { DevRecoveryBoundary, RedirectBoundary } from "vinext/shims/error-boundary";
 import { AppRouterContext } from "vinext/shims/internal/app-router-context";
 import { ElementsContext, Slot } from "vinext/shims/slot";
+import type { RouteManifest } from "../routing/app-route-graph.js";
 import { stripBasePath } from "../utils/base-path.js";
 import { createOnUncaughtError } from "./app-browser-error.js";
 import {
@@ -150,7 +151,12 @@ const MAX_VISITED_RESPONSE_CACHE_SIZE = 50;
 const VISITED_RESPONSE_CACHE_TTL = 5 * 60_000;
 const MAX_TRAVERSAL_CACHE_TTL = 30 * 60_000;
 const CLIENT_RSC_COMPATIBILITY_ID = getVinextRscCompatibilityId();
+function getBrowserRouteManifest(): RouteManifest | null {
+  return window.__VINEXT_ROUTE_MANIFEST__ ?? null;
+}
+
 const browserNavigationController = createAppBrowserNavigationController({
+  routeManifest: getBrowserRouteManifest(),
   syncHistoryStatePreviousNextUrl: syncCurrentHistoryStatePreviousNextUrl,
 });
 const discardedServerActionRefreshScheduler = createDiscardedServerActionRefreshScheduler({

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -156,7 +156,7 @@ function getBrowserRouteManifest(): RouteManifest | null {
 }
 
 const browserNavigationController = createAppBrowserNavigationController({
-  routeManifest: getBrowserRouteManifest(),
+  getRouteManifest: getBrowserRouteManifest,
   syncHistoryStatePreviousNextUrl: syncCurrentHistoryStatePreviousNextUrl,
 });
 const discardedServerActionRefreshScheduler = createDiscardedServerActionRefreshScheduler({

--- a/packages/vinext/src/server/app-browser-navigation-controller.ts
+++ b/packages/vinext/src/server/app-browser-navigation-controller.ts
@@ -5,6 +5,7 @@ import {
   commitClientNavigationState,
 } from "vinext/shims/navigation";
 import type { ClientNavigationRenderSnapshot } from "vinext/shims/navigation";
+import type { RouteManifest } from "../routing/app-route-graph.js";
 import {
   createPendingNavigationCommit,
   type AppRouterState,
@@ -56,6 +57,7 @@ type SameUrlServerActionLifecycleOptions = {
 type BrowserNavigationControllerDeps = {
   commitClientNavigationState?: typeof commitClientNavigationState;
   performHardNavigation?: (href: string, mode?: HardNavigationMode) => boolean;
+  routeManifest?: RouteManifest | null;
   syncHistoryStatePreviousNextUrl?: (previousNextUrl: string | null) => void;
 };
 
@@ -193,6 +195,7 @@ export function createAppBrowserNavigationController(
   const commitClientNavigationStateImpl =
     deps.commitClientNavigationState ?? commitClientNavigationState;
   const performHardNavigation = deps.performHardNavigation ?? performHardNavigationWithLoopGuard;
+  const routeManifest = deps.routeManifest ?? null;
   const syncHistoryStatePreviousNextUrl = deps.syncHistoryStatePreviousNextUrl ?? (() => {});
 
   // These are plain module-level variables (inside the controller closure),
@@ -520,6 +523,7 @@ export function createAppBrowserNavigationController(
         activeNavigationId,
         currentState: getBrowserRouterState(),
         pending,
+        routeManifest,
         startedNavigationId: options.navId,
         targetHref: options.targetHref,
       });
@@ -598,6 +602,7 @@ export function createAppBrowserNavigationController(
       renderId: allocateRenderId(),
       operationLane: "server-action",
       startedNavigationId,
+      routeManifest,
       targetHref,
       type: "navigate",
     });
@@ -617,6 +622,7 @@ export function createAppBrowserNavigationController(
         activeNavigationId,
         currentState: getBrowserRouterState(),
         pending,
+        routeManifest,
         startedNavigationId,
         targetHref,
       });

--- a/packages/vinext/src/server/app-browser-navigation-controller.ts
+++ b/packages/vinext/src/server/app-browser-navigation-controller.ts
@@ -57,7 +57,7 @@ type SameUrlServerActionLifecycleOptions = {
 type BrowserNavigationControllerDeps = {
   commitClientNavigationState?: typeof commitClientNavigationState;
   performHardNavigation?: (href: string, mode?: HardNavigationMode) => boolean;
-  routeManifest?: RouteManifest | null;
+  getRouteManifest?: () => RouteManifest | null;
   syncHistoryStatePreviousNextUrl?: (previousNextUrl: string | null) => void;
 };
 
@@ -195,7 +195,7 @@ export function createAppBrowserNavigationController(
   const commitClientNavigationStateImpl =
     deps.commitClientNavigationState ?? commitClientNavigationState;
   const performHardNavigation = deps.performHardNavigation ?? performHardNavigationWithLoopGuard;
-  const routeManifest = deps.routeManifest ?? null;
+  const getRouteManifest = deps.getRouteManifest ?? (() => null);
   const syncHistoryStatePreviousNextUrl = deps.syncHistoryStatePreviousNextUrl ?? (() => {});
 
   // These are plain module-level variables (inside the controller closure),
@@ -523,7 +523,7 @@ export function createAppBrowserNavigationController(
         activeNavigationId,
         currentState: getBrowserRouterState(),
         pending,
-        routeManifest,
+        routeManifest: getRouteManifest(),
         startedNavigationId: options.navId,
         targetHref: options.targetHref,
       });
@@ -602,7 +602,7 @@ export function createAppBrowserNavigationController(
       renderId: allocateRenderId(),
       operationLane: "server-action",
       startedNavigationId,
-      routeManifest,
+      routeManifest: getRouteManifest(),
       targetHref,
       type: "navigate",
     });
@@ -622,7 +622,7 @@ export function createAppBrowserNavigationController(
         activeNavigationId,
         currentState: getBrowserRouterState(),
         pending,
-        routeManifest,
+        routeManifest: getRouteManifest(),
         startedNavigationId,
         targetHref,
       });

--- a/packages/vinext/src/server/app-browser-state.ts
+++ b/packages/vinext/src/server/app-browser-state.ts
@@ -1,4 +1,5 @@
 import { stripBasePath } from "../utils/base-path.js";
+import type { RouteManifest } from "../routing/app-route-graph.js";
 import {
   AppElementsWire,
   getMountedSlotIds,
@@ -210,6 +211,7 @@ export function resolvePendingNavigationCommitDispositionDecision(options: {
   activeNavigationId: number;
   currentState: AppRouterState;
   pending: PendingNavigationCommit;
+  routeManifest?: RouteManifest | null;
   startedNavigationId: number;
   targetHref?: string;
 }): PendingNavigationCommitDispositionDecision {
@@ -231,6 +233,7 @@ export function resolvePendingNavigationCommitDispositionDecision(options: {
     planPendingRootBoundaryFlightResponse({
       currentState: options.currentState,
       pending: options.pending,
+      routeManifest: options.routeManifest ?? null,
       targetHref: options.targetHref,
       traceFields,
     }),
@@ -325,12 +328,13 @@ function createPendingRouteSnapshot(pending: PendingNavigationCommit): RouteSnap
 
 function createPendingNavigationOperationToken(options: {
   pending: PendingNavigationCommit;
+  routeManifest: RouteManifest | null;
   targetSnapshot: RouteSnapshotV0;
 }): OperationToken {
   return {
     baseVisibleCommitVersion: options.pending.action.operation.startedVisibleCommitVersion,
     deploymentVersion: null,
-    graphVersion: null,
+    graphVersion: options.routeManifest?.graphVersion ?? null,
     lane: options.pending.action.operation.lane,
     operationId: options.pending.action.operation.id,
     targetSnapshotFingerprint: createRootBoundarySnapshotFingerprint(options.targetSnapshot),
@@ -344,22 +348,23 @@ function createRootBoundarySnapshotFingerprint(snapshot: RouteSnapshotV0): strin
 function planPendingRootBoundaryFlightResponse(options: {
   currentState: AppRouterState;
   pending: PendingNavigationCommit;
+  routeManifest: RouteManifest | null;
   targetHref?: string;
   traceFields: NavigationTraceFields;
 }): NavigationDecisionV0 {
   const targetSnapshot = createPendingRouteSnapshot(options.pending);
   const token = createPendingNavigationOperationToken({
     pending: options.pending,
+    routeManifest: options.routeManifest,
     targetSnapshot,
   });
 
   // #726-CORE-07/08 keeps the browser state layer as the lifecycle gate and
   // only translates committed AppElements metadata into planner snapshots.
-  // The planner owns the root-boundary decision; later #726 route-graph work
-  // should replace these client-visible snapshots with the read model called
-  // out in routing/app-router.ts instead of adding more local topology checks.
+  // RouteManifest now supplies graph-owned route topology while snapshots
+  // continue to carry runtime state such as visible slot content.
   return navigationPlanner.plan({
-    routeManifest: null,
+    routeManifest: options.routeManifest,
     state: {
       nextOperationToken: token,
       traceFields: options.traceFields,

--- a/packages/vinext/src/server/app-browser-visible-commit.ts
+++ b/packages/vinext/src/server/app-browser-visible-commit.ts
@@ -1,4 +1,5 @@
 import type { ClientNavigationRenderSnapshot } from "vinext/shims/navigation";
+import type { RouteManifest } from "../routing/app-route-graph.js";
 import { mergeElements } from "vinext/shims/slot";
 import {
   normalizeAppElementsSlotBindings,
@@ -208,6 +209,7 @@ function resolvePendingNavigationCommitDecision(options: {
   activeNavigationId: number;
   currentState: AppRouterState;
   pending: PendingNavigationCommit;
+  routeManifest?: RouteManifest | null;
   startedNavigationId: number;
   targetHref: string;
 }): CommitDecision {
@@ -355,6 +357,7 @@ export function approvePendingNavigationCommit(options: {
   activeNavigationId: number;
   currentState: AppRouterState;
   pending: PendingNavigationCommit;
+  routeManifest?: RouteManifest | null;
   startedNavigationId: number;
   targetHref: string;
 }): CommitApproval {
@@ -363,6 +366,7 @@ export function approvePendingNavigationCommit(options: {
       activeNavigationId: options.activeNavigationId,
       currentState: options.currentState,
       pending: options.pending,
+      routeManifest: options.routeManifest ?? null,
       startedNavigationId: options.startedNavigationId,
       targetHref: options.targetHref,
     }),
@@ -403,6 +407,7 @@ export async function resolveAndClassifyNavigationCommit(options: {
   operationLane: OperationLane;
   previousNextUrl?: string | null;
   renderId: number;
+  routeManifest?: RouteManifest | null;
   startedNavigationId: number;
   targetHref: string;
   type: "navigate" | "replace" | "traverse";
@@ -422,6 +427,7 @@ export async function resolveAndClassifyNavigationCommit(options: {
     activeNavigationId: options.getActiveNavigationId?.() ?? options.activeNavigationId,
     currentState: approvalState,
     pending,
+    routeManifest: options.routeManifest ?? null,
     startedNavigationId: options.startedNavigationId,
     targetHref: options.targetHref,
   });

--- a/packages/vinext/src/server/navigation-planner.ts
+++ b/packages/vinext/src/server/navigation-planner.ts
@@ -215,14 +215,21 @@ function getMatchedUrlPathname(matchedUrl: string): string {
   }
 }
 
+function splitMatchedUrlIntoRouteParts(matchedUrl: string): string[] {
+  return normalizePathnameForRouteMatch(getMatchedUrlPathname(matchedUrl))
+    .split("/")
+    .filter((part) => part.length > 0);
+}
+
 function findRouteManifestRouteByMatchedUrl(
   routeManifest: RouteManifest,
   matchedUrl: string,
 ): RouteManifestRoute | null {
-  const urlParts = normalizePathnameForRouteMatch(getMatchedUrlPathname(matchedUrl))
-    .split("/")
-    .filter((part) => part.length > 0);
+  const urlParts = splitMatchedUrlIntoRouteParts(matchedUrl);
 
+  // RouteManifest preserves buildAppRouteGraph's compareRoutes() order, so the
+  // first pattern match follows the same static/dynamic/catch-all precedence as
+  // request-time route matching instead of raw filesystem scan order.
   for (const route of routeManifest.segmentGraph.routes.values()) {
     if (matchRoutePattern(urlParts, route.patternParts) !== null) {
       return route;
@@ -233,10 +240,7 @@ function findRouteManifestRouteByMatchedUrl(
 }
 
 function routeManifestRouteMatchesUrl(route: RouteManifestRoute, matchedUrl: string): boolean {
-  const urlParts = normalizePathnameForRouteMatch(getMatchedUrlPathname(matchedUrl))
-    .split("/")
-    .filter((part) => part.length > 0);
-  return matchRoutePattern(urlParts, route.patternParts) !== null;
+  return matchRoutePattern(splitMatchedUrlIntoRouteParts(matchedUrl), route.patternParts) !== null;
 }
 
 function findRouteManifestRouteByIdOrMatchedUrl(options: {
@@ -311,6 +315,8 @@ function resolveRouteTopologySnapshot(options: {
     return createSnapshotRouteTopology(options.snapshot);
   }
 
+  // Intercepted targets carry the source route's tree topology, not the direct
+  // target route's, so direct-target manifest slot bindings do not apply.
   const shouldUseManifestSlotBindings =
     options.slotBindingSource === "manifestTarget" && options.snapshot.interception === null;
 

--- a/packages/vinext/src/server/navigation-planner.ts
+++ b/packages/vinext/src/server/navigation-planner.ts
@@ -232,16 +232,25 @@ function findRouteManifestRouteByMatchedUrl(
   return null;
 }
 
+function routeManifestRouteMatchesUrl(route: RouteManifestRoute, matchedUrl: string): boolean {
+  const urlParts = normalizePathnameForRouteMatch(getMatchedUrlPathname(matchedUrl))
+    .split("/")
+    .filter((part) => part.length > 0);
+  return matchRoutePattern(urlParts, route.patternParts) !== null;
+}
+
 function findRouteManifestRouteByIdOrMatchedUrl(options: {
   matchedUrl: string;
   routeId: string;
   routeManifest: RouteManifest;
 }): RouteManifestRoute | null {
   const routeId = stripInterceptionContextFromRouteId(options.routeId);
-  return (
-    options.routeManifest.segmentGraph.routes.get(routeId) ??
-    findRouteManifestRouteByMatchedUrl(options.routeManifest, options.matchedUrl)
-  );
+  const route = options.routeManifest.segmentGraph.routes.get(routeId);
+  if (route && routeManifestRouteMatchesUrl(route, options.matchedUrl)) {
+    return route;
+  }
+
+  return findRouteManifestRouteByMatchedUrl(options.routeManifest, options.matchedUrl);
 }
 
 function findRouteManifestRouteForSnapshot(

--- a/packages/vinext/src/server/navigation-planner.ts
+++ b/packages/vinext/src/server/navigation-planner.ts
@@ -1,4 +1,6 @@
-import type { RouteManifest } from "../routing/app-route-graph.js";
+import { matchRoutePattern } from "../routing/route-pattern.js";
+import { normalizePathnameForRouteMatch } from "../routing/utils.js";
+import type { RouteManifest, RouteManifestRoute } from "../routing/app-route-graph.js";
 import { compareAppElementsSlotIds, type AppElementsSlotBinding } from "./app-elements.js";
 import {
   NavigationTraceReasonCodes,
@@ -137,13 +139,24 @@ export type FlightResultV0 = {
 };
 
 export type NavigationPlannerInput = {
-  // Reserved for #726-CORE-09 route-graph-aware planning. CORE-07/08 only
-  // routes the existing root-boundary decision through the planner, so browser
-  // callers pass null until route topology becomes part of the decision input.
+  // Graph-owned route topology is the semantic authority for root/layout/slot
+  // decisions whenever the caller can supply it. Null keeps the legacy
+  // snapshot-only path for low-level tests and unknown route shapes.
   routeManifest: RouteManifest | null;
   state: NavigationPlannerStateV0;
   event: NavigationEvent;
 };
+
+type RouteTopologySnapshot = {
+  layoutIds: readonly string[];
+  rootBoundaryId: string | null;
+  rootLayoutTreePath: string | null;
+  slotBindings: readonly ParallelSlotBindingSnapshotV0[];
+};
+
+type RouteTopologySlotBindingSource = "snapshot" | "manifestTarget";
+
+const ROUTE_INTERCEPTION_CONTEXT_SEPARATOR = "\0";
 
 function createRequestWorkDecision(options: {
   eventKind: NavigationEvent["kind"];
@@ -178,22 +191,153 @@ function getRequestedWorkTargetHref(work: RequestedWork): string | null {
   }
 }
 
+function createSnapshotRouteTopology(snapshot: RouteSnapshotV0): RouteTopologySnapshot {
+  return {
+    layoutIds: snapshot.layoutIds,
+    rootBoundaryId: snapshot.rootBoundaryId,
+    rootLayoutTreePath: snapshot.rootBoundaryId,
+    slotBindings: snapshot.slotBindings,
+  };
+}
+
+function stripInterceptionContextFromRouteId(routeId: string): string {
+  const separatorIndex = routeId.indexOf(ROUTE_INTERCEPTION_CONTEXT_SEPARATOR);
+  return separatorIndex === -1 ? routeId : routeId.slice(0, separatorIndex);
+}
+
+function getMatchedUrlPathname(matchedUrl: string): string {
+  try {
+    return new URL(matchedUrl, "https://vinext.local").pathname;
+  } catch {
+    const [withoutHash = ""] = matchedUrl.split("#");
+    const [pathname = ""] = withoutHash.split("?");
+    return pathname === "" ? "/" : pathname;
+  }
+}
+
+function findRouteManifestRouteByMatchedUrl(
+  routeManifest: RouteManifest,
+  matchedUrl: string,
+): RouteManifestRoute | null {
+  const urlParts = normalizePathnameForRouteMatch(getMatchedUrlPathname(matchedUrl))
+    .split("/")
+    .filter((part) => part.length > 0);
+
+  for (const route of routeManifest.segmentGraph.routes.values()) {
+    if (matchRoutePattern(urlParts, route.patternParts) !== null) {
+      return route;
+    }
+  }
+
+  return null;
+}
+
+function findRouteManifestRouteByIdOrMatchedUrl(options: {
+  matchedUrl: string;
+  routeId: string;
+  routeManifest: RouteManifest;
+}): RouteManifestRoute | null {
+  const routeId = stripInterceptionContextFromRouteId(options.routeId);
+  return (
+    options.routeManifest.segmentGraph.routes.get(routeId) ??
+    findRouteManifestRouteByMatchedUrl(options.routeManifest, options.matchedUrl)
+  );
+}
+
+function findRouteManifestRouteForSnapshot(
+  routeManifest: RouteManifest,
+  snapshot: RouteSnapshotV0,
+): RouteManifestRoute | null {
+  if (snapshot.interception !== null) {
+    return findRouteManifestRouteByIdOrMatchedUrl({
+      matchedUrl: snapshot.interception.sourceMatchedUrl,
+      routeId: snapshot.interception.sourceRouteId,
+      routeManifest,
+    });
+  }
+
+  return findRouteManifestRouteByIdOrMatchedUrl({
+    matchedUrl: snapshot.matchedUrl,
+    routeId: snapshot.routeId,
+    routeManifest,
+  });
+}
+
+function resolveRouteManifestSlotBindings(
+  routeManifest: RouteManifest,
+  route: RouteManifestRoute,
+): readonly ParallelSlotBindingSnapshotV0[] {
+  const bindings: ParallelSlotBindingSnapshotV0[] = [];
+  for (const slotId of route.slotIds) {
+    const binding = routeManifest.segmentGraph.slotBindings.get(`${route.id}::${slotId}`);
+    if (!binding) continue;
+    bindings.push({
+      ownerLayoutId: binding.ownerLayoutId,
+      slotId: binding.slotId,
+      state: binding.state,
+    });
+  }
+
+  return bindings.sort((left, right) => compareAppElementsSlotIds(left.slotId, right.slotId));
+}
+
+function resolveRouteManifestRootLayoutTreePath(
+  routeManifest: RouteManifest,
+  route: RouteManifestRoute,
+): string | null {
+  if (route.rootBoundaryId === null) return null;
+  return routeManifest.segmentGraph.rootBoundaries.get(route.rootBoundaryId)?.treePath ?? null;
+}
+
+function resolveRouteTopologySnapshot(options: {
+  routeManifest: RouteManifest | null;
+  slotBindingSource: RouteTopologySlotBindingSource;
+  snapshot: RouteSnapshotV0;
+}): RouteTopologySnapshot {
+  const route =
+    options.routeManifest === null
+      ? null
+      : findRouteManifestRouteForSnapshot(options.routeManifest, options.snapshot);
+  if (route === null || options.routeManifest === null) {
+    return createSnapshotRouteTopology(options.snapshot);
+  }
+
+  const shouldUseManifestSlotBindings =
+    options.slotBindingSource === "manifestTarget" && options.snapshot.interception === null;
+
+  return {
+    layoutIds: route.layoutIds,
+    rootBoundaryId: route.rootBoundaryId,
+    rootLayoutTreePath: resolveRouteManifestRootLayoutTreePath(options.routeManifest, route),
+    slotBindings: shouldUseManifestSlotBindings
+      ? resolveRouteManifestSlotBindings(options.routeManifest, route)
+      : options.snapshot.slotBindings,
+  };
+}
+
 function createRootBoundaryTraceFields(options: {
+  currentRootLayoutTreePath: string | null;
   event: Extract<NavigationEvent, { kind: "flightResponseArrived" }>;
+  nextRootLayoutTreePath: string | null;
   state: NavigationPlannerStateV0;
 }): NavigationTraceFields {
   // Browser commit approval supplies lifecycle trace context before calling
   // the planner. This fallback exists for pure planner callers and tests; it
   // intentionally cannot invent lifecycle-only fields such as active nav id.
-  return (
-    options.state.traceFields ??
-    createNavigationLifecycleTraceFields({
-      currentRootLayoutTreePath: options.state.visibleSnapshot.rootBoundaryId,
-      currentVisibleCommitVersion: options.state.visibleCommitVersion,
-      nextRootLayoutTreePath: options.event.result.targetSnapshot.rootBoundaryId,
-      startedVisibleCommitVersion: options.event.token.baseVisibleCommitVersion,
-    })
-  );
+  if (options.state.traceFields) {
+    return {
+      ...options.state.traceFields,
+      currentRootLayoutTreePath: options.currentRootLayoutTreePath,
+      nextRootLayoutTreePath: options.nextRootLayoutTreePath,
+    };
+  }
+
+  return createNavigationLifecycleTraceFields({
+    currentRootLayoutTreePath: options.currentRootLayoutTreePath,
+    currentVisibleCommitVersion: options.state.visibleCommitVersion,
+    nextRootLayoutTreePath: options.nextRootLayoutTreePath,
+    startedVisibleCommitVersion: options.event.token.baseVisibleCommitVersion,
+  });
 }
 
 function classifyRootBoundaryTransition(
@@ -201,10 +345,9 @@ function classifyRootBoundaryTransition(
   nextRootBoundaryId: string | null,
 ): RootBoundaryTransition {
   if (currentRootBoundaryId === null || nextRootBoundaryId === null) {
-    // Both null directions intentionally share the v0 fallback because this
-    // slice only knows boundary identity from the current flight payload.
-    // #726-CORE-09 can split "unknown current" from "unknown target" once the
-    // planner consumes graph-owned root boundary facts for both sides.
+    // Both null directions intentionally share the fallback because unresolved
+    // routes or legacy callers cannot prove either same-root reuse or root
+    // changes from semantic topology.
     return "rootBoundaryUnknownFallback";
   }
 
@@ -217,20 +360,30 @@ function resolveSameLayoutAncestorPersistence(
   currentSnapshot: RouteSnapshotV0,
   targetSnapshot: RouteSnapshotV0,
 ): readonly string[] {
+  return resolveSameLayoutAncestorPersistenceForTopologies(
+    createSnapshotRouteTopology(currentSnapshot),
+    createSnapshotRouteTopology(targetSnapshot),
+  );
+}
+
+function resolveSameLayoutAncestorPersistenceForTopologies(
+  currentTopology: RouteTopologySnapshot,
+  targetTopology: RouteTopologySnapshot,
+): readonly string[] {
   if (
     classifyRootBoundaryTransition(
-      currentSnapshot.rootBoundaryId,
-      targetSnapshot.rootBoundaryId,
+      currentTopology.rootBoundaryId,
+      targetTopology.rootBoundaryId,
     ) !== "currentRootBoundary"
   ) {
     return [];
   }
 
   const commonLayoutIds: string[] = [];
-  const maxLength = Math.min(currentSnapshot.layoutIds.length, targetSnapshot.layoutIds.length);
+  const maxLength = Math.min(currentTopology.layoutIds.length, targetTopology.layoutIds.length);
   for (let index = 0; index < maxLength; index++) {
-    const layoutId = currentSnapshot.layoutIds[index];
-    if (layoutId !== targetSnapshot.layoutIds[index]) break;
+    const layoutId = currentTopology.layoutIds[index];
+    if (layoutId !== targetTopology.layoutIds[index]) break;
     commonLayoutIds.push(layoutId);
   }
   return commonLayoutIds;
@@ -279,9 +432,9 @@ function resolveCurrentRootBoundaryElementPersistence(
 }
 
 function resolveCurrentRootBoundaryCommitElementPersistence(options: {
-  currentSnapshot: RouteSnapshotV0;
+  currentTopology: RouteTopologySnapshot;
   lane: OperationLane;
-  targetSnapshot: RouteSnapshotV0;
+  targetTopology: RouteTopologySnapshot;
 }): readonly string[] {
   // Commit element persistence only keeps layout IDs. Default/unmatched slot
   // reuse is handled separately by preservePreviousSlotIds, using slot-binding
@@ -289,26 +442,29 @@ function resolveCurrentRootBoundaryCommitElementPersistence(options: {
   // resolveCurrentRootBoundaryCommitSlotPersistence recomputes this same
   // ancestor set; planner correctness relies on both calls agreeing so any
   // preserved slot's owner layout is also present in preserveElementIds.
-  return resolveSameLayoutAncestorPersistence(options.currentSnapshot, options.targetSnapshot);
+  return resolveSameLayoutAncestorPersistenceForTopologies(
+    options.currentTopology,
+    options.targetTopology,
+  );
 }
 
 function resolveCurrentRootBoundaryCommitSlotPersistence(options: {
-  currentSnapshot: RouteSnapshotV0;
+  currentTopology: RouteTopologySnapshot;
   lane: OperationLane;
-  targetSnapshot: RouteSnapshotV0;
+  targetTopology: RouteTopologySnapshot;
 }): readonly string[] {
   if (options.lane === "traverse") return [];
 
-  const preservedLayoutIds = resolveSameLayoutAncestorPersistence(
-    options.currentSnapshot,
-    options.targetSnapshot,
+  const preservedLayoutIds = resolveSameLayoutAncestorPersistenceForTopologies(
+    options.currentTopology,
+    options.targetTopology,
   );
   if (preservedLayoutIds.length === 0) return [];
 
   return resolveDefaultOrUnmatchedSlotPersistenceForLayouts({
-    currentSnapshot: options.currentSnapshot,
+    currentSlotBindings: options.currentTopology.slotBindings,
     preservedLayoutIds,
-    targetSnapshot: options.targetSnapshot,
+    targetSlotBindings: options.targetTopology.slotBindings,
   });
 }
 
@@ -323,20 +479,20 @@ function resolveCurrentRootBoundaryCommitSlotPersistence(options: {
  * Wire absence and UNMATCHED_SLOT markers are not semantic proof.
  */
 function resolveDefaultOrUnmatchedSlotPersistenceForLayouts(options: {
-  currentSnapshot: RouteSnapshotV0;
+  currentSlotBindings: readonly ParallelSlotBindingSnapshotV0[];
   preservedLayoutIds: readonly string[];
-  targetSnapshot: RouteSnapshotV0;
+  targetSlotBindings: readonly ParallelSlotBindingSnapshotV0[];
 }): readonly string[] {
   const preservedLayoutIdSet = new Set(options.preservedLayoutIds);
   const slotIdsWithContent = new Set<string>();
-  for (const binding of options.currentSnapshot.slotBindings) {
+  for (const binding of options.currentSlotBindings) {
     if (binding.state === "unmatched") continue;
     slotIdsWithContent.add(binding.slotId);
   }
 
   const preservedSlotIds: string[] = [];
   const seenSlotIds = new Set<string>();
-  for (const binding of options.targetSnapshot.slotBindings) {
+  for (const binding of options.targetSlotBindings) {
     if (binding.ownerLayoutId === null) continue;
     if (!preservedLayoutIdSet.has(binding.ownerLayoutId)) continue;
     if (binding.state === "active") continue;
@@ -396,7 +552,9 @@ function createInterceptionProofRejectedDecision(options: {
 
 function validateInterceptedPreservation(options: {
   currentSnapshot: RouteSnapshotV0;
+  currentTopology: RouteTopologySnapshot;
   targetSnapshot: RouteSnapshotV0;
+  targetTopology: RouteTopologySnapshot;
 }): InterceptedPreservationValidation {
   const proof = options.targetSnapshot.interception;
   if (!proof) {
@@ -424,9 +582,9 @@ function validateInterceptedPreservation(options: {
     };
   }
 
-  const preservedLayoutIds = resolveSameLayoutAncestorPersistence(
-    options.currentSnapshot,
-    options.targetSnapshot,
+  const preservedLayoutIds = resolveSameLayoutAncestorPersistenceForTopologies(
+    options.currentTopology,
+    options.targetTopology,
   );
   if (preservedLayoutIds.length === 0) {
     return {
@@ -436,7 +594,7 @@ function validateInterceptedPreservation(options: {
   }
 
   const preservedLayoutIdSet = new Set(preservedLayoutIds);
-  const targetSlotBinding = options.targetSnapshot.slotBindings.find(
+  const targetSlotBinding = options.targetTopology.slotBindings.find(
     (binding) => binding.slotId === proof.slotId,
   );
   if (
@@ -452,9 +610,9 @@ function validateInterceptedPreservation(options: {
   }
 
   const preservePreviousSlotIds = resolveDefaultOrUnmatchedSlotPersistenceForLayouts({
-    currentSnapshot: options.currentSnapshot,
+    currentSlotBindings: options.currentTopology.slotBindings,
     preservedLayoutIds,
-    targetSnapshot: options.targetSnapshot,
+    targetSlotBindings: options.targetTopology.slotBindings,
   }).filter((slotId) => slotId !== proof.slotId);
 
   return {
@@ -466,9 +624,26 @@ function validateInterceptedPreservation(options: {
 
 function planFlightResponseArrived(options: {
   event: Extract<NavigationEvent, { kind: "flightResponseArrived" }>;
+  routeManifest: RouteManifest | null;
   state: NavigationPlannerStateV0;
 }): NavigationDecisionV0 {
-  const traceFields = createRootBoundaryTraceFields(options);
+  const targetSnapshot = options.event.result.targetSnapshot;
+  const currentTopology = resolveRouteTopologySnapshot({
+    routeManifest: options.routeManifest,
+    slotBindingSource: "snapshot",
+    snapshot: options.state.visibleSnapshot,
+  });
+  const targetTopology = resolveRouteTopologySnapshot({
+    routeManifest: options.routeManifest,
+    slotBindingSource: "manifestTarget",
+    snapshot: targetSnapshot,
+  });
+  const traceFields = createRootBoundaryTraceFields({
+    currentRootLayoutTreePath: currentTopology.rootLayoutTreePath,
+    event: options.event,
+    nextRootLayoutTreePath: targetTopology.rootLayoutTreePath,
+    state: options.state,
+  });
 
   if (options.event.token.lane === "prefetch") {
     return {
@@ -479,7 +654,6 @@ function planFlightResponseArrived(options: {
     };
   }
 
-  const targetSnapshot = options.event.result.targetSnapshot;
   // interceptionContext is transport evidence, not authority. Normal payloads
   // can carry it when a request was sent from an intercepted visible world, so
   // only explicit __interception proof enters the preservation branch.
@@ -487,7 +661,9 @@ function planFlightResponseArrived(options: {
   if (hasInterceptedPayload) {
     const validation = validateInterceptedPreservation({
       currentSnapshot: options.state.visibleSnapshot,
+      currentTopology,
       targetSnapshot,
+      targetTopology,
     });
     if (validation.kind === "rejected") {
       return createInterceptionProofRejectedDecision({
@@ -515,8 +691,8 @@ function planFlightResponseArrived(options: {
   }
 
   const transition = classifyRootBoundaryTransition(
-    options.state.visibleSnapshot.rootBoundaryId,
-    targetSnapshot.rootBoundaryId,
+    currentTopology.rootBoundaryId,
+    targetTopology.rootBoundaryId,
   );
 
   if (transition === "rootBoundaryChanged") {
@@ -531,9 +707,8 @@ function planFlightResponseArrived(options: {
 
   if (transition === "rootBoundaryUnknownFallback") {
     // Unknown root identity is an uncertainty fallback, not evidence that
-    // reuse is safe. #726-CORE-09 can delete the legacy soft-commit writer
-    // once every promoted caller supplies graph-owned root boundary IDs from
-    // the route graph read model documented in routing/app-router.ts.
+    // reuse is safe. It remains only for callers without a manifest or routes
+    // that cannot be matched back to RouteManifest topology.
     return {
       kind: "proposeCommit",
       proposal: {
@@ -553,14 +728,14 @@ function planFlightResponseArrived(options: {
     proposal: {
       preserveAbsentSlots: false,
       preserveElementIds: resolveCurrentRootBoundaryCommitElementPersistence({
-        currentSnapshot: options.state.visibleSnapshot,
+        currentTopology,
         lane: options.event.token.lane,
-        targetSnapshot,
+        targetTopology,
       }),
       preservePreviousSlotIds: resolveCurrentRootBoundaryCommitSlotPersistence({
-        currentSnapshot: options.state.visibleSnapshot,
+        currentTopology,
         lane: options.event.token.lane,
-        targetSnapshot,
+        targetTopology,
       }),
       reason: "currentRootBoundary",
       targetSnapshot,
@@ -614,6 +789,7 @@ function planNavigation(input: NavigationPlannerInput): NavigationDecisionV0 {
     case "flightResponseArrived":
       return planFlightResponseArrived({
         event: input.event,
+        routeManifest: input.routeManifest,
         state: input.state,
       });
     default: {

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -70,6 +70,20 @@ import {
   VINEXT_MOUNTED_SLOTS_HEADER,
   VINEXT_PARAMS_HEADER,
 } from "../packages/vinext/src/server/headers.js";
+import type {
+  GraphVersion,
+  RootBoundaryId,
+  RouteManifest,
+  RouteManifestRootBoundary,
+  RouteManifestRoute,
+  StaticSegmentGraph,
+} from "../packages/vinext/src/routing/app-route-graph.js";
+
+type TestRouteManifestRoute = {
+  layoutIds: readonly string[];
+  pattern: string;
+  rootBoundaryId: string | null;
+};
 
 function createResolvedElements(
   routeId: string,
@@ -125,6 +139,61 @@ function createInterceptionProof(
     slotId,
     targetMatchedUrl,
     targetRouteId: AppElementsWire.encodeRouteId(targetMatchedUrl, null),
+  };
+}
+
+function createTestRouteManifest(routes: readonly TestRouteManifestRoute[]): RouteManifest {
+  const manifestRoutes = new Map<string, RouteManifestRoute>();
+  const rootBoundaries = new Map<RootBoundaryId, RouteManifestRootBoundary>();
+
+  for (const route of routes) {
+    const routeId = `route:${route.pattern}`;
+    const rootBoundaryId =
+      route.rootBoundaryId === null ? null : (route.rootBoundaryId as RootBoundaryId);
+    const patternParts = route.pattern.split("/").filter((segment) => segment.length > 0);
+    manifestRoutes.set(routeId, {
+      id: routeId,
+      isDynamic: patternParts.some((part) => part.startsWith(":")),
+      layoutIds: route.layoutIds,
+      pageId: null,
+      paramNames: patternParts
+        .filter((part) => part.startsWith(":"))
+        .map((part) => part.replace(/^:/, "").replace(/[+*]$/, "")),
+      pattern: route.pattern,
+      patternParts,
+      rootBoundaryId,
+      rootParamNames: [],
+      routeHandlerId: null,
+      slotIds: [],
+      templateIds: [],
+    });
+
+    const rootLayoutId = route.layoutIds[0];
+    if (rootBoundaryId !== null && rootLayoutId !== undefined) {
+      rootBoundaries.set(rootBoundaryId, {
+        id: rootBoundaryId,
+        layoutId: rootLayoutId,
+        treePath: route.rootBoundaryId?.replace(/^root-boundary:/, "") ?? "/",
+      });
+    }
+  }
+
+  const segmentGraph: StaticSegmentGraph = {
+    boundaries: new Map(),
+    defaults: new Map(),
+    layouts: new Map(),
+    pages: new Map(),
+    rootBoundaries,
+    routeHandlers: new Map(),
+    routes: manifestRoutes,
+    slotBindings: new Map(),
+    slots: new Map(),
+    templates: new Map(),
+  };
+
+  return {
+    graphVersion: "graph:test" as GraphVersion,
+    segmentGraph,
   };
 }
 
@@ -1638,6 +1707,70 @@ describe("app browser navigation controller", () => {
       expect(stateRef.current.routeId).toBe("route:/dashboard");
     } finally {
       clearSpy.mockRestore();
+      detach();
+    }
+  });
+
+  it("reads RouteManifest lazily after generated browser globals are assigned", async () => {
+    let routeManifest: RouteManifest | null = null;
+    const performHardNavigation = vi.fn(() => true);
+    const { controller, detach, stateRef } = createControllerHarness(
+      createState({
+        layoutIds: ["layout:/stale"],
+        navigationSnapshot: createClientNavigationRenderSnapshot("https://example.com/app", {}),
+        rootLayoutTreePath: "/",
+        routeId: "route:/app",
+      }),
+      {
+        getRouteManifest: () => routeManifest,
+        performHardNavigation,
+      },
+    );
+
+    try {
+      const pendingRouterState = controller.beginPendingBrowserRouterState();
+      const navId = controller.beginNavigation();
+      let resolvePayload!: (elements: AppElements) => void;
+      const nextElements = new Promise<AppElements>((resolve) => {
+        resolvePayload = resolve;
+      });
+
+      const result = controller.renderNavigationPayload({
+        actionType: "navigate",
+        createNavigationCommitEffect: () => vi.fn(),
+        historyUpdateMode: "push",
+        navigationSnapshot: createClientNavigationRenderSnapshot(
+          "https://example.com/marketing",
+          {},
+        ),
+        nextElements,
+        operationLane: "navigation",
+        params: {},
+        pendingRouterState,
+        previousNextUrl: null,
+        targetHref: "https://example.com/marketing",
+        navId,
+      });
+
+      routeManifest = createTestRouteManifest([
+        {
+          layoutIds: ["layout:/app"],
+          pattern: "/app",
+          rootBoundaryId: "root-boundary:/app",
+        },
+        {
+          layoutIds: ["layout:/marketing"],
+          pattern: "/marketing",
+          rootBoundaryId: "root-boundary:/marketing",
+        },
+      ]);
+      resolvePayload(createResolvedElements("route:/marketing", "/", null, {}, ["layout:/stale"]));
+
+      await expect(result).resolves.toBe("hard-navigate");
+      await expect(pendingRouterState.promise).resolves.toBe(stateRef.current);
+      expect(performHardNavigation).toHaveBeenCalledWith("https://example.com/marketing");
+      expect(stateRef.current.routeId).toBe("route:/app");
+    } finally {
       detach();
     }
   });

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -170,10 +170,37 @@ describe("App Router generated manifest construction", () => {
     ]);
 
     expect(code).toContain("window.__VINEXT_LINK_PREFETCH_ROUTES__ = ");
+    expect(code).toContain("window.__VINEXT_ROUTE_MANIFEST__ = null;");
     expect(code).toContain('{"patternParts":["about"],"isDynamic":false}');
     expect(code).toContain('{"patternParts":["blog",":slug"],"isDynamic":true}');
     expect(code).toContain('{"patternParts":["modal-host"],"isDynamic":false}');
     expect(code).not.toContain('{"patternParts":["api"],"isDynamic":false}');
+  });
+
+  it("embeds the RouteManifest read model in the browser entry", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-browser-route-manifest-"));
+    const appDir = path.join(tmpDir, "app");
+    try {
+      fs.mkdirSync(path.join(appDir, "dashboard"), { recursive: true });
+      fs.writeFileSync(path.join(appDir, "layout.tsx"), "export default function Layout() {}\n");
+      fs.writeFileSync(path.join(appDir, "page.tsx"), "export default function Page() {}\n");
+      fs.writeFileSync(
+        path.join(appDir, "dashboard", "page.tsx"),
+        "export default function Page() {}\n",
+      );
+
+      const graph = await buildAppRouteGraph(appDir, createValidFileMatcher());
+      const code = generateBrowserEntry(graph.routes, graph.routeManifest);
+
+      expect(code).toContain("window.__VINEXT_ROUTE_MANIFEST__ = {");
+      expect(code).toContain("graphVersion:");
+      expect(code).toContain("routes: new Map(");
+      expect(code).toContain("rootBoundaries: new Map(");
+      expect(code).toContain('"route:/dashboard"');
+      expect(code).toContain('"root-boundary:/"');
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 
   it("constructs route module imports and route entries from the scanned app shape", () => {

--- a/tests/navigation-planner.test.ts
+++ b/tests/navigation-planner.test.ts
@@ -18,6 +18,24 @@ import {
   type InterceptionSnapshotV0,
   type RootBoundaryTransition,
 } from "../packages/vinext/src/server/navigation-planner.js";
+import type {
+  GraphVersion,
+  RootBoundaryId,
+  RouteManifest,
+  RouteManifestRoute,
+  RouteManifestRootBoundary,
+  RouteManifestSlotBinding,
+  StaticSegmentGraph,
+} from "../packages/vinext/src/routing/app-route-graph.js";
+
+type TestManifestRoute = {
+  id?: string;
+  layoutIds: readonly string[];
+  pattern: string;
+  patternParts?: readonly string[];
+  rootBoundaryId: string | null;
+  slotBindings?: readonly ParallelSlotBindingSnapshotV0[];
+};
 
 function createRouteSnapshot(
   rootBoundaryId: string | null,
@@ -57,6 +75,77 @@ function createSlotBinding(
   state: ParallelSlotBindingSnapshotV0["state"] = "active",
 ): ParallelSlotBindingSnapshotV0 {
   return { ownerLayoutId, slotId, state };
+}
+
+function createTestRouteManifest(routes: readonly TestManifestRoute[]): RouteManifest {
+  const manifestRoutes = new Map<string, RouteManifestRoute>();
+  const slotBindings = new Map<string, RouteManifestSlotBinding>();
+  const rootBoundaries = new Map<RootBoundaryId, RouteManifestRootBoundary>();
+
+  for (const route of routes) {
+    const routeId = route.id ?? `route:${route.pattern}`;
+    const rootBoundaryId =
+      route.rootBoundaryId === null ? null : (route.rootBoundaryId as RootBoundaryId);
+    const routeSlotBindings = route.slotBindings ?? [];
+    const slotIds = routeSlotBindings.map((binding) => binding.slotId).sort();
+    const patternParts =
+      route.patternParts ?? route.pattern.split("/").filter((segment) => segment.length > 0);
+    manifestRoutes.set(routeId, {
+      id: routeId,
+      isDynamic: patternParts.some((part) => part.startsWith(":")),
+      layoutIds: route.layoutIds,
+      pageId: null,
+      paramNames: patternParts
+        .filter((part) => part.startsWith(":"))
+        .map((part) => part.replace(/^:/, "").replace(/[+*]$/, "")),
+      pattern: route.pattern,
+      patternParts,
+      rootBoundaryId,
+      rootParamNames: [],
+      routeHandlerId: null,
+      slotIds,
+      templateIds: [],
+    });
+
+    for (const binding of routeSlotBindings) {
+      slotBindings.set(`${routeId}::${binding.slotId}`, {
+        defaultId: binding.state === "default" ? `default:${binding.slotId}` : null,
+        id: `${routeId}::${binding.slotId}`,
+        ownerLayoutId: binding.ownerLayoutId,
+        routeId,
+        routeSegments: null,
+        slotId: binding.slotId,
+        state: binding.state,
+      });
+    }
+
+    const rootLayoutId = route.layoutIds[0];
+    if (rootBoundaryId !== null && rootLayoutId !== undefined) {
+      rootBoundaries.set(rootBoundaryId, {
+        id: rootBoundaryId,
+        layoutId: rootLayoutId,
+        treePath: route.rootBoundaryId?.replace(/^root-boundary:/, "") ?? "/",
+      });
+    }
+  }
+
+  const segmentGraph: StaticSegmentGraph = {
+    boundaries: new Map(),
+    defaults: new Map(),
+    layouts: new Map(),
+    pages: new Map(),
+    rootBoundaries,
+    routeHandlers: new Map(),
+    routes: manifestRoutes,
+    slotBindings,
+    slots: new Map(),
+    templates: new Map(),
+  };
+
+  return {
+    graphVersion: "graph:test" as GraphVersion,
+    segmentGraph,
+  };
 }
 
 function createOperationToken(overrides: Partial<OperationToken> = {}): OperationToken {
@@ -139,7 +228,9 @@ function planFlightResponseFromRootBoundaries(options: {
 function planFlightResponseFromSnapshots(options: {
   currentSnapshot: RouteSnapshotV0;
   lane?: OperationToken["lane"];
+  routeManifest?: RouteManifest | null;
   targetSnapshot: RouteSnapshotV0;
+  traceFields?: NavigationPlannerStateV0["traceFields"];
 }): NavigationDecisionV0 {
   const token = createOperationToken({
     lane: options.lane ?? "navigation",
@@ -157,9 +248,10 @@ function planFlightResponseFromSnapshots(options: {
       },
       token,
     },
-    routeManifest: null,
+    routeManifest: options.routeManifest ?? null,
     state: {
       nextOperationToken: token,
+      traceFields: options.traceFields,
       visibleCommitVersion: 2,
       visibleSnapshot: options.currentSnapshot,
     },
@@ -548,6 +640,268 @@ describe("navigationPlanner root-boundary decisions", () => {
       throw new Error("Expected proposeCommit decision");
     }
     expect(decision.proposal.preservePreviousSlotIds).toEqual([]);
+  });
+
+  it("uses RouteManifest root boundaries instead of stale snapshot roots", () => {
+    const routeManifest = createTestRouteManifest([
+      {
+        layoutIds: ["layout:/app"],
+        pattern: "/app",
+        rootBoundaryId: "root-boundary:/app",
+      },
+      {
+        layoutIds: ["layout:/marketing"],
+        pattern: "/marketing",
+        rootBoundaryId: "root-boundary:/marketing",
+      },
+    ]);
+    const currentSnapshot: RouteSnapshotV0 = {
+      ...createRouteSnapshot("/", ["layout:/stale-app"]),
+      matchedUrl: "/app",
+      routeId: "route:/app",
+    };
+    const targetSnapshot: RouteSnapshotV0 = {
+      ...createRouteSnapshot("/", ["layout:/stale-app", "layout:/stale-marketing"]),
+      displayUrl: "https://example.com/marketing",
+      matchedUrl: "/marketing",
+      routeId: "route:/marketing",
+    };
+
+    const decision = planFlightResponseFromSnapshots({
+      currentSnapshot,
+      routeManifest,
+      targetSnapshot,
+      traceFields: {
+        currentRootLayoutTreePath: "/",
+        currentVisibleCommitVersion: 2,
+        nextRootLayoutTreePath: "/",
+        startedVisibleCommitVersion: 2,
+      },
+    });
+
+    expect(decision.kind).toBe("hardNavigate");
+    if (decision.kind !== "hardNavigate") {
+      throw new Error("Expected hardNavigate decision");
+    }
+    expect(decision.reason).toBe("rootBoundaryChanged");
+    expect(decision.trace.entries[0]?.fields.currentRootLayoutTreePath).toBe("/app");
+    expect(decision.trace.entries[0]?.fields.nextRootLayoutTreePath).toBe("/marketing");
+  });
+
+  it("uses RouteManifest topology to commit when snapshot root identities are missing", () => {
+    const routeManifest = createTestRouteManifest([
+      {
+        layoutIds: ["layout:/", "layout:/dashboard"],
+        pattern: "/dashboard",
+        rootBoundaryId: "root-boundary:/",
+      },
+      {
+        layoutIds: ["layout:/", "layout:/dashboard", "layout:/dashboard/settings"],
+        pattern: "/dashboard/settings",
+        rootBoundaryId: "root-boundary:/",
+      },
+    ]);
+    const currentSnapshot: RouteSnapshotV0 = {
+      ...createRouteSnapshot(null, []),
+      matchedUrl: "/dashboard",
+      routeId: "route:/dashboard",
+    };
+    const targetSnapshot: RouteSnapshotV0 = {
+      ...createRouteSnapshot(null, []),
+      displayUrl: "https://example.com/dashboard/settings",
+      matchedUrl: "/dashboard/settings",
+      routeId: "route:/dashboard/settings",
+    };
+
+    const decision = planFlightResponseFromSnapshots({
+      currentSnapshot,
+      routeManifest,
+      targetSnapshot,
+    });
+
+    expect(decision.kind).toBe("proposeCommit");
+    if (decision.kind !== "proposeCommit") {
+      throw new Error("Expected proposeCommit decision");
+    }
+    expect(decision.proposal.reason).toBe("currentRootBoundary");
+    expect(decision.proposal.preserveAbsentSlots).toBe(false);
+    expect(decision.proposal.preserveElementIds).toEqual(["layout:/", "layout:/dashboard"]);
+  });
+
+  it("matches concrete dynamic URLs to manifest route patterns", () => {
+    const routeManifest = createTestRouteManifest([
+      {
+        layoutIds: ["layout:/", "layout:/blog"],
+        pattern: "/blog/:slug",
+        rootBoundaryId: "root-boundary:/",
+      },
+    ]);
+    const currentSnapshot: RouteSnapshotV0 = {
+      ...createRouteSnapshot(null, []),
+      displayUrl: "https://example.com/blog/hello",
+      matchedUrl: "/blog/hello",
+      routeId: "route:/blog/hello",
+    };
+    const targetSnapshot: RouteSnapshotV0 = {
+      ...createRouteSnapshot(null, []),
+      displayUrl: "https://example.com/blog/world",
+      matchedUrl: "/blog/world",
+      routeId: "route:/blog/world",
+    };
+
+    const decision = planFlightResponseFromSnapshots({
+      currentSnapshot,
+      routeManifest,
+      targetSnapshot,
+    });
+
+    expect(decision.kind).toBe("proposeCommit");
+    if (decision.kind !== "proposeCommit") {
+      throw new Error("Expected proposeCommit decision");
+    }
+    expect(decision.proposal.reason).toBe("currentRootBoundary");
+    expect(decision.proposal.preserveElementIds).toEqual(["layout:/", "layout:/blog"]);
+  });
+
+  it("uses manifest target slot bindings while keeping visible snapshot as content proof", () => {
+    const modalSlot = "slot:modal:/dashboard";
+    const staleSlot = "slot:stale:/dashboard";
+    const routeManifest = createTestRouteManifest([
+      {
+        layoutIds: ["layout:/", "layout:/dashboard"],
+        pattern: "/dashboard",
+        rootBoundaryId: "root-boundary:/",
+      },
+      {
+        layoutIds: ["layout:/", "layout:/dashboard", "layout:/dashboard/settings"],
+        pattern: "/dashboard/settings",
+        rootBoundaryId: "root-boundary:/",
+        slotBindings: [createSlotBinding(modalSlot, "layout:/dashboard", "default")],
+      },
+    ]);
+    const currentSnapshot: RouteSnapshotV0 = {
+      ...createRouteSnapshot(
+        null,
+        [],
+        [],
+        [
+          createSlotBinding(modalSlot, "layout:/dashboard", "active"),
+          createSlotBinding(staleSlot, "layout:/dashboard", "active"),
+        ],
+      ),
+      matchedUrl: "/dashboard",
+      routeId: "route:/dashboard",
+    };
+    const targetSnapshot: RouteSnapshotV0 = {
+      ...createRouteSnapshot(
+        null,
+        [],
+        [],
+        [createSlotBinding(staleSlot, "layout:/dashboard", "default")],
+      ),
+      displayUrl: "https://example.com/dashboard/settings",
+      matchedUrl: "/dashboard/settings",
+      routeId: "route:/dashboard/settings",
+    };
+
+    const decision = planFlightResponseFromSnapshots({
+      currentSnapshot,
+      routeManifest,
+      targetSnapshot,
+    });
+
+    expect(decision.kind).toBe("proposeCommit");
+    if (decision.kind !== "proposeCommit") {
+      throw new Error("Expected proposeCommit decision");
+    }
+    expect(decision.proposal.preservePreviousSlotIds).toEqual([modalSlot]);
+  });
+
+  it("does not use manifest current slots as visible content proof", () => {
+    const modalSlot = "slot:modal:/dashboard";
+    const routeManifest = createTestRouteManifest([
+      {
+        layoutIds: ["layout:/", "layout:/dashboard"],
+        pattern: "/dashboard",
+        rootBoundaryId: "root-boundary:/",
+        slotBindings: [createSlotBinding(modalSlot, "layout:/dashboard", "active")],
+      },
+      {
+        layoutIds: ["layout:/", "layout:/dashboard", "layout:/dashboard/settings"],
+        pattern: "/dashboard/settings",
+        rootBoundaryId: "root-boundary:/",
+        slotBindings: [createSlotBinding(modalSlot, "layout:/dashboard", "default")],
+      },
+    ]);
+    const currentSnapshot: RouteSnapshotV0 = {
+      ...createRouteSnapshot(null, [], [], []),
+      matchedUrl: "/dashboard",
+      routeId: "route:/dashboard",
+    };
+    const targetSnapshot: RouteSnapshotV0 = {
+      ...createRouteSnapshot(null, [], [], []),
+      displayUrl: "https://example.com/dashboard/settings",
+      matchedUrl: "/dashboard/settings",
+      routeId: "route:/dashboard/settings",
+    };
+
+    const decision = planFlightResponseFromSnapshots({
+      currentSnapshot,
+      routeManifest,
+      targetSnapshot,
+    });
+
+    expect(decision.kind).toBe("proposeCommit");
+    if (decision.kind !== "proposeCommit") {
+      throw new Error("Expected proposeCommit decision");
+    }
+    expect(decision.proposal.preservePreviousSlotIds).toEqual([]);
+  });
+
+  it("uses the manifest source route topology for intercepted payloads", () => {
+    const routeManifest = createTestRouteManifest([
+      {
+        layoutIds: ["layout:/", "layout:/feed"],
+        pattern: "/feed",
+        rootBoundaryId: "root-boundary:/",
+      },
+      {
+        layoutIds: ["layout:/photos", "layout:/photos/photo"],
+        pattern: "/photos/:id",
+        rootBoundaryId: "root-boundary:/photos",
+      },
+    ]);
+    const currentSnapshot: RouteSnapshotV0 = {
+      ...createRouteSnapshot(null, []),
+      matchedUrl: "/feed",
+      routeId: "route:/feed",
+    };
+    const targetSnapshot: RouteSnapshotV0 = {
+      ...createRouteSnapshot(
+        null,
+        [],
+        [],
+        [createSlotBinding("slot:modal:/feed", "layout:/feed", "active")],
+      ),
+      displayUrl: "https://example.com/photos/42",
+      interception: createInterceptionSnapshot(),
+      interceptionContext: "/feed",
+      matchedUrl: "/photos/42",
+      routeId: "route:/photos/42\u0000/feed",
+    };
+
+    const decision = planFlightResponseFromSnapshots({
+      currentSnapshot,
+      routeManifest,
+      targetSnapshot,
+    });
+
+    expect(decision.kind).toBe("proposeCommit");
+    if (decision.kind !== "proposeCommit") {
+      throw new Error("Expected proposeCommit decision");
+    }
+    expect(decision.proposal.reason).toBe("interceptedCurrentRootBoundary");
+    expect(decision.proposal.preserveElementIds).toEqual(["layout:/", "layout:/feed"]);
   });
 
   it("approves intercepted preservation only from explicit source and slot proof", () => {

--- a/tests/navigation-planner.test.ts
+++ b/tests/navigation-planner.test.ts
@@ -728,6 +728,46 @@ describe("navigationPlanner root-boundary decisions", () => {
     expect(decision.proposal.preserveElementIds).toEqual(["layout:/", "layout:/dashboard"]);
   });
 
+  it("does not let stale manifest route IDs override the matched URL", () => {
+    const routeManifest = createTestRouteManifest([
+      {
+        layoutIds: ["layout:/app"],
+        pattern: "/app",
+        rootBoundaryId: "root-boundary:/app",
+      },
+      {
+        layoutIds: ["layout:/marketing"],
+        pattern: "/marketing",
+        rootBoundaryId: "root-boundary:/marketing",
+      },
+    ]);
+    const currentSnapshot: RouteSnapshotV0 = {
+      ...createRouteSnapshot(null, []),
+      displayUrl: "https://example.com/app",
+      matchedUrl: "/app",
+      routeId: "route:/app",
+    };
+    const targetSnapshot: RouteSnapshotV0 = {
+      ...createRouteSnapshot(null, []),
+      displayUrl: "https://example.com/app",
+      matchedUrl: "/app",
+      routeId: "route:/marketing",
+    };
+
+    const decision = planFlightResponseFromSnapshots({
+      currentSnapshot,
+      routeManifest,
+      targetSnapshot,
+    });
+
+    expect(decision.kind).toBe("proposeCommit");
+    if (decision.kind !== "proposeCommit") {
+      throw new Error("Expected proposeCommit decision");
+    }
+    expect(decision.proposal.reason).toBe("currentRootBoundary");
+    expect(decision.proposal.preserveElementIds).toEqual(["layout:/app"]);
+  });
+
   it("matches concrete dynamic URLs to manifest route patterns", () => {
     const routeManifest = createTestRouteManifest([
       {


### PR DESCRIPTION
## Overview

| Field | Details |
| --- | --- |
| Goal | Make App Router navigation commit planning consume `RouteManifest` as the semantic source of root, layout, and target slot topology. |
| Core change | Embed the App Router route manifest into the generated browser entry and pass it through commit approval into `NavigationPlanner`. |
| Main boundary | `RouteManifest` owns static route topology. Runtime snapshots still own visible slot content proof and explicit interception proof. |
| Primary files | `server/navigation-planner.ts`, `entries/app-browser-entry.ts`, `server/app-browser-state.ts`, `server/app-browser-visible-commit.ts`, `server/app-browser-navigation-controller.ts` |
| Expected impact | More reliable same-root vs cross-root planning when payload snapshots are stale, missing, or concrete dynamic URLs rather than manifest route IDs. |

## Why

Client navigation correctness depends on separating route topology from runtime state. Next.js makes hard-navigation and segment reuse decisions from router tree semantics, not raw URL strings or one-off payload metadata. Vinext already has a `RouteManifest` read model with stable route, root-boundary, layout, and slot identities, so the navigation planner should use that as topology authority while keeping runtime-only evidence in the browser snapshot.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| Root boundaries | A cross-root transition must hard navigate even if the RSC payload carries stale root metadata. | The planner resolves current and target root boundaries through `RouteManifest` when possible. |
| Layout persistence | Preserved layout IDs must come from semantic route topology, not incidental payload arrays. | Same-layout prefix comparison now runs over resolved route topology. |
| Dynamic routes | Changing only a dynamic value should not look like an unknown route when the manifest pattern proves the same route. | Concrete matched URLs fall back to manifest pattern matching when direct route IDs do not exist. |
| Parallel slots | Target default or unmatched slot reuse should use static target slot facts, but only when current visible state proves content exists. | Target slot bindings can come from the manifest; current slot content proof remains snapshot-owned. |
| Interception | Intercepted payloads must preserve the source route tree, not the direct target page tree. | Intercepted topology resolves from the proof source route while preserving existing explicit proof checks. |

## What changed

| Scenario / surface | Before | After |
| --- | --- | --- |
| Browser entry | Only embedded Link prefetch route metadata. | Embeds `window.__VINEXT_ROUTE_MANIFEST__` with map-shaped graph data. |
| Commit approval path | Passed `routeManifest: null` to the planner. | Passes the generated manifest through navigation controller, visible commit, and browser state helpers. |
| Planner route resolution | Snapshot route IDs, root IDs, layout IDs, and slot bindings were the only authority. | Uses manifest route IDs first, then matched URL pattern matching, then falls back to snapshot topology if unresolved. |
| Trace fields | Could reflect stale snapshot root tree paths when lifecycle fields were supplied. | Planner rewrites root trace fields to the topology used for the actual decision. |

<details>
<summary>Maintainer review path</summary>

1. `packages/vinext/src/server/navigation-planner.ts`
   - Start here. Review the topology adapter, manifest route resolution, dynamic matched URL fallback, target slot binding source selection, and intercepted source route handling.
2. `packages/vinext/src/entries/app-browser-entry.ts` and `packages/vinext/src/index.ts`
   - Confirm the generated browser entry receives the graph read model and serializes the `ReadonlyMap` fields back into runtime `Map`s.
3. `packages/vinext/src/server/app-browser-state.ts`, `packages/vinext/src/server/app-browser-visible-commit.ts`, `packages/vinext/src/server/app-browser-navigation-controller.ts`, `packages/vinext/src/server/app-browser-entry.ts`
   - Check the pass-through path from generated global to commit approval and planner call.
4. `tests/navigation-planner.test.ts`
   - Review the behavioral matrix around stale roots, unknown snapshot roots, dynamic route values, target slots, current slot proof, and intercepted source topology.
5. `tests/entry-templates.test.ts`
   - Check the generated browser entry manifest coverage.

</details>

<details>
<summary>Validation</summary>

- `vp test run tests/navigation-planner.test.ts tests/entry-templates.test.ts tests/app-browser-entry.test.ts tests/app-route-graph.test.ts`
- `vp check packages/vinext/src/server/navigation-planner.ts packages/vinext/src/server/app-browser-state.ts packages/vinext/src/server/app-browser-visible-commit.ts packages/vinext/src/server/app-browser-navigation-controller.ts packages/vinext/src/server/app-browser-entry.ts packages/vinext/src/entries/app-browser-entry.ts packages/vinext/src/index.ts packages/vinext/src/global.d.ts tests/navigation-planner.test.ts tests/entry-templates.test.ts`
- `vp run vinext#build`
- Commit hook also ran entry-template tests, formatting, type-aware check, and knip before commit creation.

`vp run vinext#build` still reports the existing expected unresolved virtual/external imports for `private-next-instrumentation-client`, `virtual:vinext-rsc-entry`, and `virtual:vite-rsc/client-references`, then completes successfully.

</details>

<details>
<summary>Risk / compatibility</summary>

- Public API: no user-facing API change.
- Build output: App Router browser entry now embeds the route manifest, increasing generated bootstrap data for App Router apps.
- Runtime behavior: commit decisions prefer manifest topology when a route can be resolved. Unknown routes still fall back to the existing snapshot path.
- Interception: explicit proof requirements remain. This PR only changes the topology used after proof identity passes.
- Compatibility: follows Next.js's route-tree-driven root-layout and segment reuse model while using vinext's existing `RouteManifest` read model instead of duplicating tree reducer state.

</details>

<details>
<summary>Non-goals</summary>

- Does not replace the full App Router client state model with a Next.js-style router tree.
- Does not change RSC payload serialization beyond embedding the existing route manifest in the browser entry.
- Does not remove the legacy snapshot fallback for unresolved route shapes.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| [Next.js `is-navigating-to-new-root-layout.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/router-reducer/is-navigating-to-new-root-layout.ts) | Shows Next.js classifies root-layout changes from segment tree semantics rather than concrete URL values. |
| [Next.js `ppr-navigations.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/router-reducer/ppr-navigations.ts) | Source for same-segment reuse and default parallel route reuse behavior. |
| [Next.js root layout E2E](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/root-layout/root-layout.test.ts) | Covers SPA preservation within the same root and MPA navigation across root layouts. |
| [Next.js segment-cache MPA navigation E2E](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/segment-cache/mpa-navigations/mpa-navigations.test.ts) | Exercises cross-root MPA behavior in the newer segment cache path. |
| [Next.js intercepted routes with parallel catchall E2E](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/parallel-routes-and-interception-catchall/parallel-routes-and-interception-catchall.test.ts) | Confirms intercepted route behavior preserves the source route tree and sibling slots. |