### PR TITLE
feat(router): add manifest-backed interception topology

### DIFF
--- a/packages/vinext/src/entries/app-browser-entry.ts
+++ b/packages/vinext/src/entries/app-browser-entry.ts
@@ -48,6 +48,7 @@ function buildRouteManifestExpression(routeManifest: RouteManifest | null): stri
     defaults: ${buildMapExpression(graph.defaults)},
     slotBindings: ${buildMapExpression(graph.slotBindings)},
     interceptions: ${buildMapExpression(graph.interceptions)},
+    interceptionsBySlotId: ${buildMapExpression(graph.interceptionsBySlotId)},
     boundaries: ${buildMapExpression(graph.boundaries)},
     rootBoundaries: ${buildMapExpression(graph.rootBoundaries)}
   }

--- a/packages/vinext/src/entries/app-browser-entry.ts
+++ b/packages/vinext/src/entries/app-browser-entry.ts
@@ -47,6 +47,7 @@ function buildRouteManifestExpression(routeManifest: RouteManifest | null): stri
     slots: ${buildMapExpression(graph.slots)},
     defaults: ${buildMapExpression(graph.defaults)},
     slotBindings: ${buildMapExpression(graph.slotBindings)},
+    interceptions: ${buildMapExpression(graph.interceptions)},
     boundaries: ${buildMapExpression(graph.boundaries)},
     rootBoundaries: ${buildMapExpression(graph.rootBoundaries)}
   }

--- a/packages/vinext/src/routing/app-route-graph.ts
+++ b/packages/vinext/src/routing/app-route-graph.ts
@@ -277,6 +277,18 @@ export type RouteManifestSlotBinding = {
   slotParamNames?: readonly string[];
 };
 
+export type RouteManifestInterception = {
+  id: string;
+  sourcePattern: string;
+  sourcePatternParts: readonly string[];
+  targetPattern: string;
+  targetPatternParts: readonly string[];
+  slotId: string;
+  ownerLayoutId: string | null;
+  interceptingRouteId: string | null;
+  targetRouteId: string | null;
+};
+
 export type RouteManifestBoundaryOutcome = "error" | "forbidden" | "notFound" | "unauthorized";
 
 export type RouteManifestBoundary = {
@@ -302,6 +314,7 @@ export type StaticSegmentGraph = {
   slots: ReadonlyMap<string, RouteManifestSlot>;
   defaults: ReadonlyMap<string, RouteManifestDefault>;
   slotBindings: ReadonlyMap<string, RouteManifestSlotBinding>;
+  interceptions: ReadonlyMap<string, RouteManifestInterception>;
   boundaries: ReadonlyMap<string, RouteManifestBoundary>;
   rootBoundaries: ReadonlyMap<RootBoundaryId, RouteManifestRootBoundary>;
 };
@@ -339,6 +352,14 @@ function createAppRouteGraphDefaultId(slotId: string): string {
   return `default:${slotId}`;
 }
 
+function createAppRouteGraphInterceptionId(
+  slotId: string,
+  sourcePattern: string,
+  targetPattern: string,
+): string {
+  return `interception:${slotId}:${sourcePattern}->${targetPattern}`;
+}
+
 function createAppRouteGraphRootBoundaryId(treePath: string): RootBoundaryId {
   return `root-boundary:${treePath}`;
 }
@@ -373,8 +394,10 @@ function createStaticSegmentGraph(routes: readonly AppRouteGraphRoute[]): Static
   const slots = new Map<string, RouteManifestSlot>();
   const defaults = new Map<string, RouteManifestDefault>();
   const slotBindings = new Map<string, RouteManifestSlotBinding>();
+  const interceptions = new Map<string, RouteManifestInterception>();
   const boundaries = new Map<string, RouteManifestBoundary>();
   const rootBoundaries = new Map<RootBoundaryId, RouteManifestRootBoundary>();
+  const routeIdByPattern = createRouteManifestRouteIdByPattern(routes);
 
   for (const route of routes) {
     routeEntries.set(route.ids.route, {
@@ -493,6 +516,13 @@ function createStaticSegmentGraph(routes: readonly AppRouteGraphRoute[]): Static
       }
       const binding = createRouteManifestSlotBinding(route, slot, ownerLayoutId, defaultId);
       slotBindings.set(binding.id, binding);
+      addRouteManifestInterceptionFacts({
+        interceptions,
+        ownerLayoutId,
+        route,
+        routeIdByPattern,
+        slot,
+      });
     }
   }
 
@@ -505,9 +535,16 @@ function createStaticSegmentGraph(routes: readonly AppRouteGraphRoute[]): Static
     slots,
     defaults,
     slotBindings,
+    interceptions,
     boundaries,
     rootBoundaries,
   };
+}
+
+function createRouteManifestRouteIdByPattern(
+  routes: readonly AppRouteGraphRoute[],
+): ReadonlyMap<string, string> {
+  return new Map(routes.map((route) => [route.pattern, route.ids.route]));
 }
 
 function findRouteManifestOwnerLayoutId(
@@ -551,6 +588,37 @@ function createRouteManifestSlotBinding(
   }
 
   return binding;
+}
+
+function addRouteManifestInterceptionFacts(input: {
+  interceptions: Map<string, RouteManifestInterception>;
+  ownerLayoutId: string | null;
+  route: AppRouteGraphRoute;
+  routeIdByPattern: ReadonlyMap<string, string>;
+  slot: AppRouteGraphParallelSlot;
+}): void {
+  for (const interception of input.slot.interceptingRoutes) {
+    const id = createAppRouteGraphInterceptionId(
+      input.slot.id,
+      interception.sourceMatchPattern,
+      interception.targetPattern,
+    );
+    input.interceptions.set(id, {
+      id,
+      sourcePattern: interception.sourceMatchPattern,
+      sourcePatternParts: splitRouteManifestPatternParts(interception.sourceMatchPattern),
+      targetPattern: interception.targetPattern,
+      targetPatternParts: splitRouteManifestPatternParts(interception.targetPattern),
+      slotId: input.slot.id,
+      ownerLayoutId: input.ownerLayoutId,
+      interceptingRouteId: input.routeIdByPattern.get(interception.sourceMatchPattern) ?? null,
+      targetRouteId: input.routeIdByPattern.get(interception.targetPattern) ?? null,
+    });
+  }
+}
+
+function splitRouteManifestPatternParts(pattern: string): string[] {
+  return pattern.split("/").filter((part) => part.length > 0);
 }
 
 function getRouteManifestSlotBindingState(
@@ -675,6 +743,7 @@ function createRouteManifestGraphVersion(segmentGraph: StaticSegmentGraph): Grap
     slots: sortedMapValues(segmentGraph.slots),
     defaults: sortedMapValues(segmentGraph.defaults),
     slotBindings: sortedMapValues(segmentGraph.slotBindings),
+    interceptions: sortedMapValues(segmentGraph.interceptions),
     boundaries: sortedMapValues(segmentGraph.boundaries),
     rootBoundaries: sortedMapValues(segmentGraph.rootBoundaries),
   };

--- a/packages/vinext/src/routing/app-route-graph.ts
+++ b/packages/vinext/src/routing/app-route-graph.ts
@@ -315,6 +315,7 @@ export type StaticSegmentGraph = {
   defaults: ReadonlyMap<string, RouteManifestDefault>;
   slotBindings: ReadonlyMap<string, RouteManifestSlotBinding>;
   interceptions: ReadonlyMap<string, RouteManifestInterception>;
+  interceptionsBySlotId: ReadonlyMap<string, readonly RouteManifestInterception[]>;
   boundaries: ReadonlyMap<string, RouteManifestBoundary>;
   rootBoundaries: ReadonlyMap<RootBoundaryId, RouteManifestRootBoundary>;
 };
@@ -526,6 +527,8 @@ function createStaticSegmentGraph(routes: readonly AppRouteGraphRoute[]): Static
     }
   }
 
+  const interceptionsBySlotId = createRouteManifestInterceptionsBySlotId(interceptions);
+
   return {
     routes: routeEntries,
     pages,
@@ -536,6 +539,7 @@ function createStaticSegmentGraph(routes: readonly AppRouteGraphRoute[]): Static
     defaults,
     slotBindings,
     interceptions,
+    interceptionsBySlotId,
     boundaries,
     rootBoundaries,
   };
@@ -615,6 +619,30 @@ function addRouteManifestInterceptionFacts(input: {
       targetRouteId: input.routeIdByPattern.get(interception.targetPattern) ?? null,
     });
   }
+}
+
+function createRouteManifestInterceptionsBySlotId(
+  interceptions: ReadonlyMap<string, RouteManifestInterception>,
+): ReadonlyMap<string, readonly RouteManifestInterception[]> {
+  const interceptionsBySlotId = new Map<string, RouteManifestInterception[]>();
+  for (const interception of interceptions.values()) {
+    const existing = interceptionsBySlotId.get(interception.slotId);
+    if (existing) {
+      existing.push(interception);
+    } else {
+      interceptionsBySlotId.set(interception.slotId, [interception]);
+    }
+  }
+
+  for (const slotInterceptions of interceptionsBySlotId.values()) {
+    slotInterceptions.sort((left, right) => compareStableStrings(left.id, right.id));
+  }
+
+  return new Map(
+    Array.from(interceptionsBySlotId.entries()).sort(([left], [right]) =>
+      compareStableStrings(left, right),
+    ),
+  );
 }
 
 function splitRouteManifestPatternParts(pattern: string): string[] {
@@ -744,6 +772,7 @@ function createRouteManifestGraphVersion(segmentGraph: StaticSegmentGraph): Grap
     defaults: sortedMapValues(segmentGraph.defaults),
     slotBindings: sortedMapValues(segmentGraph.slotBindings),
     interceptions: sortedMapValues(segmentGraph.interceptions),
+    interceptionsBySlotId: sortedMapValues(segmentGraph.interceptionsBySlotId),
     boundaries: sortedMapValues(segmentGraph.boundaries),
     rootBoundaries: sortedMapValues(segmentGraph.rootBoundaries),
   };

--- a/packages/vinext/src/routing/route-pattern.ts
+++ b/packages/vinext/src/routing/route-pattern.ts
@@ -142,6 +142,33 @@ export function matchRoutePattern(
   return params;
 }
 
+export function matchRoutePatternPrefix(
+  pathParts: readonly string[],
+  patternParts: readonly string[],
+): boolean {
+  let pathIndex = 0;
+  for (let patternIndex = 0; patternIndex < patternParts.length; patternIndex++) {
+    const patternPart = patternParts[patternIndex];
+    const isTerminal = patternIndex === patternParts.length - 1;
+
+    if (patternPart.startsWith(":") && patternPart.endsWith("+")) {
+      return isTerminal && pathParts.length - pathIndex >= 1;
+    }
+    if (patternPart.startsWith(":") && patternPart.endsWith("*")) {
+      return isTerminal;
+    }
+    if (pathIndex >= pathParts.length) return false;
+    if (patternPart.startsWith(":")) {
+      pathIndex++;
+      continue;
+    }
+    if (pathParts[pathIndex] !== patternPart) return false;
+    pathIndex++;
+  }
+
+  return true;
+}
+
 /**
  * A single entry from `getStaticPaths().paths`.
  *

--- a/packages/vinext/src/server/app-rsc-route-matching.ts
+++ b/packages/vinext/src/server/app-rsc-route-matching.ts
@@ -1,5 +1,9 @@
 import { buildRouteTrie, trieMatch } from "../routing/route-trie.js";
-import { matchRoutePattern, type RoutePatternParams } from "../routing/route-pattern.js";
+import {
+  matchRoutePattern,
+  matchRoutePatternPrefix,
+  type RoutePatternParams,
+} from "../routing/route-pattern.js";
 import { normalizePathnameForRouteMatch } from "../routing/utils.js";
 
 type AppRscRouteParams = RoutePatternParams;
@@ -142,47 +146,7 @@ function matchInterceptSource(sourceParts: string[], entry: AppRscInterceptLooku
   if (!patternParts) return true;
   // Root pattern (`/`) matches any source.
   if (patternParts.length === 0) return true;
-  return matchPathPrefix(sourceParts, patternParts);
-}
-
-/**
- * True when `pathParts` matches `patternParts` from index 0 and all pattern
- * segments are satisfied. Trailing path segments beyond the pattern are
- * allowed (to mirror Next.js' `(?:/.*)?` tail on intercepting-route headers).
- *
- * Supports the same segment syntax as the route trie:
- *   - `:name`   — dynamic, exactly one segment
- *   - `:name+`  — catch-all, 1+ segments (must be terminal in the pattern)
- *   - `:name*`  — optional catch-all, 0+ segments (must be terminal)
- *   - anything else — literal segment
- */
-function matchPathPrefix(pathParts: string[], patternParts: string[]): boolean {
-  let pi = 0;
-  for (let i = 0; i < patternParts.length; i++) {
-    const part = patternParts[i];
-    const isTerminal = i === patternParts.length - 1;
-
-    if (part.startsWith(":") && part.endsWith("+")) {
-      if (!isTerminal) return false;
-      // Catch-all must consume at least one remaining segment.
-      return pathParts.length - pi >= 1;
-    }
-    if (part.startsWith(":") && part.endsWith("*")) {
-      if (!isTerminal) return false;
-      // Optional catch-all accepts any tail (including empty).
-      return true;
-    }
-    if (pi >= pathParts.length) return false;
-    if (part.startsWith(":")) {
-      // Dynamic single-segment — any non-empty value matches.
-      pi++;
-      continue;
-    }
-    if (pathParts[pi] !== part) return false;
-    pi++;
-  }
-  // Pattern fully consumed; any extra path segments are descendants and OK.
-  return true;
+  return matchRoutePatternPrefix(sourceParts, patternParts);
 }
 
 function createInterceptLookup<Route extends AppRscRouteForMatching>(

--- a/packages/vinext/src/server/navigation-planner.ts
+++ b/packages/vinext/src/server/navigation-planner.ts
@@ -1,6 +1,10 @@
-import { matchRoutePattern } from "../routing/route-pattern.js";
+import { matchRoutePattern, matchRoutePatternPrefix } from "../routing/route-pattern.js";
 import { normalizePathnameForRouteMatch } from "../routing/utils.js";
-import type { RouteManifest, RouteManifestRoute } from "../routing/app-route-graph.js";
+import type {
+  RouteManifest,
+  RouteManifestInterception,
+  RouteManifestRoute,
+} from "../routing/app-route-graph.js";
 import { compareAppElementsSlotIds, type AppElementsSlotBinding } from "./app-elements.js";
 import {
   NavigationTraceReasonCodes,
@@ -330,6 +334,35 @@ function resolveRouteTopologySnapshot(options: {
   };
 }
 
+function findRouteManifestInterceptionForProof(
+  routeManifest: RouteManifest,
+  proof: InterceptionSnapshotV0,
+): RouteManifestInterception | null {
+  const sourceParts = splitMatchedUrlIntoRouteParts(proof.sourceMatchedUrl);
+  const targetParts = splitMatchedUrlIntoRouteParts(proof.targetMatchedUrl);
+  const targetRoute = findRouteManifestRouteByIdOrMatchedUrl({
+    matchedUrl: proof.targetMatchedUrl,
+    routeId: proof.targetRouteId,
+    routeManifest,
+  });
+  const interceptions = routeManifest.segmentGraph.interceptions;
+  if (!interceptions) return null;
+
+  for (const interception of interceptions.values()) {
+    if (interception.slotId !== proof.slotId) continue;
+    if (!matchRoutePatternPrefix(sourceParts, interception.sourcePatternParts)) {
+      continue;
+    }
+    if (matchRoutePattern(targetParts, interception.targetPatternParts) === null) continue;
+    if (interception.targetRouteId !== null && targetRoute?.id !== interception.targetRouteId) {
+      continue;
+    }
+    return interception;
+  }
+
+  return null;
+}
+
 function createRootBoundaryTraceFields(options: {
   currentRootLayoutTreePath: string | null;
   event: Extract<NavigationEvent, { kind: "flightResponseArrived" }>;
@@ -568,6 +601,7 @@ function createInterceptionProofRejectedDecision(options: {
 function validateInterceptedPreservation(options: {
   currentSnapshot: RouteSnapshotV0;
   currentTopology: RouteTopologySnapshot;
+  routeManifest: RouteManifest | null;
   targetSnapshot: RouteSnapshotV0;
   targetTopology: RouteTopologySnapshot;
 }): InterceptedPreservationValidation {
@@ -597,6 +631,17 @@ function validateInterceptedPreservation(options: {
     };
   }
 
+  const declaredInterception =
+    options.routeManifest === null
+      ? null
+      : findRouteManifestInterceptionForProof(options.routeManifest, proof);
+  if (options.routeManifest !== null && declaredInterception === null) {
+    return {
+      kind: "rejected",
+      reasonCode: NavigationTraceReasonCodes.interceptedRejectedUndeclaredTopology,
+    };
+  }
+
   const preservedLayoutIds = resolveSameLayoutAncestorPersistenceForTopologies(
     options.currentTopology,
     options.targetTopology,
@@ -621,6 +666,15 @@ function validateInterceptedPreservation(options: {
     return {
       kind: "rejected",
       reasonCode: NavigationTraceReasonCodes.interceptedRejectedMissingSlotProof,
+    };
+  }
+  if (
+    declaredInterception !== null &&
+    targetSlotBinding.ownerLayoutId !== declaredInterception.ownerLayoutId
+  ) {
+    return {
+      kind: "rejected",
+      reasonCode: NavigationTraceReasonCodes.interceptedRejectedUndeclaredTopology,
     };
   }
 
@@ -677,6 +731,7 @@ function planFlightResponseArrived(options: {
     const validation = validateInterceptedPreservation({
       currentSnapshot: options.state.visibleSnapshot,
       currentTopology,
+      routeManifest: options.routeManifest,
       targetSnapshot,
       targetTopology,
     });

--- a/packages/vinext/src/server/navigation-planner.ts
+++ b/packages/vinext/src/server/navigation-planner.ts
@@ -345,11 +345,10 @@ function findRouteManifestInterceptionForProof(
     routeId: proof.targetRouteId,
     routeManifest,
   });
-  const interceptions = routeManifest.segmentGraph.interceptions;
-  if (!interceptions) return null;
+  const candidateInterceptions =
+    routeManifest.segmentGraph.interceptionsBySlotId.get(proof.slotId) ?? [];
 
-  for (const interception of interceptions.values()) {
-    if (interception.slotId !== proof.slotId) continue;
+  for (const interception of candidateInterceptions) {
     if (!matchRoutePatternPrefix(sourceParts, interception.sourcePatternParts)) {
       continue;
     }

--- a/packages/vinext/src/server/navigation-trace.ts
+++ b/packages/vinext/src/server/navigation-trace.ts
@@ -9,6 +9,7 @@ export const NavigationTraceReasonCodes = {
   interceptedRejectedMissingProof: "NC_INTERCEPT_REJECT_MISSING_PROOF",
   interceptedRejectedMissingSlotProof: "NC_INTERCEPT_REJECT_SLOT",
   interceptedRejectedTargetMismatch: "NC_INTERCEPT_REJECT_TARGET",
+  interceptedRejectedUndeclaredTopology: "NC_INTERCEPT_REJECT_GRAPH",
   interceptedRejectedUnknownSource: "NC_INTERCEPT_REJECT_SOURCE",
   prefetchOnly: "NC_PREFETCH_ONLY",
   requestWork: "NC_REQUEST",
@@ -22,6 +23,7 @@ export const NavigationTraceReasonCodes = {
   interceptedRejectedMissingProof: "NC_INTERCEPT_REJECT_MISSING_PROOF";
   interceptedRejectedMissingSlotProof: "NC_INTERCEPT_REJECT_SLOT";
   interceptedRejectedTargetMismatch: "NC_INTERCEPT_REJECT_TARGET";
+  interceptedRejectedUndeclaredTopology: "NC_INTERCEPT_REJECT_GRAPH";
   interceptedRejectedUnknownSource: "NC_INTERCEPT_REJECT_SOURCE";
   prefetchOnly: "NC_PREFETCH_ONLY";
   requestWork: "NC_REQUEST";

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -182,6 +182,7 @@ function createTestRouteManifest(routes: readonly TestRouteManifestRoute[]): Rou
     boundaries: new Map(),
     defaults: new Map(),
     interceptions: new Map(),
+    interceptionsBySlotId: new Map(),
     layouts: new Map(),
     pages: new Map(),
     rootBoundaries,

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -181,6 +181,7 @@ function createTestRouteManifest(routes: readonly TestRouteManifestRoute[]): Rou
   const segmentGraph: StaticSegmentGraph = {
     boundaries: new Map(),
     defaults: new Map(),
+    interceptions: new Map(),
     layouts: new Map(),
     pages: new Map(),
     rootBoundaries,

--- a/tests/app-route-graph.test.ts
+++ b/tests/app-route-graph.test.ts
@@ -51,6 +51,7 @@ function snapshotRouteManifest(manifest: RouteManifest) {
     defaults: Array.from(manifest.segmentGraph.defaults.entries()),
     slotBindings: Array.from(manifest.segmentGraph.slotBindings.entries()),
     interceptions: Array.from(manifest.segmentGraph.interceptions.entries()),
+    interceptionsBySlotId: Array.from(manifest.segmentGraph.interceptionsBySlotId.entries()),
     boundaries: Array.from(manifest.segmentGraph.boundaries.entries()),
     rootBoundaries: Array.from(manifest.segmentGraph.rootBoundaries.entries()),
   };
@@ -991,6 +992,9 @@ describe("App Router route graph builder", () => {
 
         const graph = await buildAppRouteGraph(appDir, createValidFileMatcher());
         const interceptions = Array.from(graph.routeManifest.segmentGraph.interceptions.values());
+        const interceptionsBySlotId = Array.from(
+          graph.routeManifest.segmentGraph.interceptionsBySlotId.entries(),
+        );
 
         expect(interceptions).toEqual([
           {
@@ -1005,6 +1009,7 @@ describe("App Router route graph builder", () => {
             targetRouteId: "route:/:locale/photos/:id",
           },
         ]);
+        expect(interceptionsBySlotId).toEqual([["slot:modal:/[locale]/feed", interceptions]]);
       });
     });
   });

--- a/tests/app-route-graph.test.ts
+++ b/tests/app-route-graph.test.ts
@@ -50,6 +50,7 @@ function snapshotRouteManifest(manifest: RouteManifest) {
     slots: Array.from(manifest.segmentGraph.slots.entries()),
     defaults: Array.from(manifest.segmentGraph.defaults.entries()),
     slotBindings: Array.from(manifest.segmentGraph.slotBindings.entries()),
+    interceptions: Array.from(manifest.segmentGraph.interceptions.entries()),
     boundaries: Array.from(manifest.segmentGraph.boundaries.entries()),
     rootBoundaries: Array.from(manifest.segmentGraph.rootBoundaries.entries()),
   };
@@ -975,6 +976,35 @@ describe("App Router route graph builder", () => {
             convention: "../..",
           }),
         );
+      });
+    });
+
+    it("promotes dynamic interception topology into RouteManifest facts", async () => {
+      await withTempApp(async (appDir) => {
+        await writeAppFile(appDir, "layout.tsx", EMPTY_LAYOUT);
+        await writeAppFile(appDir, "[locale]/layout.tsx", EMPTY_LAYOUT);
+        await writeAppFile(appDir, "[locale]/feed/layout.tsx", EMPTY_LAYOUT);
+        await writeAppFile(appDir, "[locale]/feed/page.tsx", EMPTY_PAGE);
+        await writeAppFile(appDir, "[locale]/photos/[id]/page.tsx", EMPTY_PAGE);
+        await writeAppFile(appDir, "[locale]/feed/@modal/default.tsx", EMPTY_PAGE);
+        await writeAppFile(appDir, "[locale]/feed/@modal/(..)photos/[id]/page.tsx", EMPTY_PAGE);
+
+        const graph = await buildAppRouteGraph(appDir, createValidFileMatcher());
+        const interceptions = Array.from(graph.routeManifest.segmentGraph.interceptions.values());
+
+        expect(interceptions).toEqual([
+          {
+            id: "interception:slot:modal:/[locale]/feed:/:locale/feed->/:locale/photos/:id",
+            sourcePattern: "/:locale/feed",
+            sourcePatternParts: [":locale", "feed"],
+            targetPattern: "/:locale/photos/:id",
+            targetPatternParts: [":locale", "photos", ":id"],
+            slotId: "slot:modal:/[locale]/feed",
+            ownerLayoutId: "layout:/[locale]/feed",
+            interceptingRouteId: "route:/:locale/feed",
+            targetRouteId: "route:/:locale/photos/:id",
+          },
+        ]);
       });
     });
   });

--- a/tests/navigation-planner.test.ts
+++ b/tests/navigation-planner.test.ts
@@ -90,6 +90,7 @@ function createTestRouteManifest(routes: readonly TestManifestRoute[]): RouteMan
   const manifestRoutes = new Map<string, RouteManifestRoute>();
   const slotBindings = new Map<string, RouteManifestSlotBinding>();
   const interceptions = new Map<string, RouteManifestInterception>();
+  const interceptionsBySlotId = new Map<string, RouteManifestInterception[]>();
   const rootBoundaries = new Map<RootBoundaryId, RouteManifestRootBoundary>();
   const routeIdByPattern = new Map(
     routes.map((route) => [route.pattern, route.id ?? `route:${route.pattern}`]),
@@ -137,7 +138,7 @@ function createTestRouteManifest(routes: readonly TestManifestRoute[]): RouteMan
         .split("/")
         .filter((segment) => segment.length > 0);
       const id = `interception:${interception.slotId}:${interception.sourcePattern}->${interception.targetPattern}`;
-      interceptions.set(id, {
+      const manifestInterception = {
         id,
         interceptingRouteId: routeIdByPattern.get(interception.sourcePattern) ?? null,
         ownerLayoutId: interception.ownerLayoutId,
@@ -149,7 +150,14 @@ function createTestRouteManifest(routes: readonly TestManifestRoute[]): RouteMan
         targetPattern: interception.targetPattern,
         targetPatternParts,
         targetRouteId: routeIdByPattern.get(interception.targetPattern) ?? null,
-      });
+      };
+      interceptions.set(id, manifestInterception);
+      const slotInterceptions = interceptionsBySlotId.get(interception.slotId);
+      if (slotInterceptions) {
+        slotInterceptions.push(manifestInterception);
+      } else {
+        interceptionsBySlotId.set(interception.slotId, [manifestInterception]);
+      }
     }
 
     const rootLayoutId = route.layoutIds[0];
@@ -166,6 +174,7 @@ function createTestRouteManifest(routes: readonly TestManifestRoute[]): RouteMan
     boundaries: new Map(),
     defaults: new Map(),
     interceptions,
+    interceptionsBySlotId,
     layouts: new Map(),
     pages: new Map(),
     rootBoundaries,

--- a/tests/navigation-planner.test.ts
+++ b/tests/navigation-planner.test.ts
@@ -986,7 +986,7 @@ describe("navigationPlanner root-boundary decisions", () => {
     expect(decision.proposal.preserveElementIds).toEqual(["layout:/", "layout:/feed"]);
   });
 
-  it("approves manifest-declared dynamic interception topology", () => {
+  it("approves manifest-declared dynamic interception topology with concrete wire route ids", () => {
     const routeManifest = createTestRouteManifest([
       {
         layoutIds: ["layout:/", "layout:/[locale]", "layout:/[locale]/feed"],
@@ -1010,7 +1010,7 @@ describe("navigationPlanner root-boundary decisions", () => {
     const currentSnapshot: RouteSnapshotV0 = {
       ...createRouteSnapshot(null, []),
       matchedUrl: "/en/feed",
-      routeId: "route:/:locale/feed",
+      routeId: "route:/en/feed",
     };
     const targetSnapshot: RouteSnapshotV0 = {
       ...createRouteSnapshot(
@@ -1022,14 +1022,14 @@ describe("navigationPlanner root-boundary decisions", () => {
       displayUrl: "https://example.com/en/photos/42",
       interception: createInterceptionSnapshot({
         sourceMatchedUrl: "/en/feed",
-        sourceRouteId: "route:/:locale/feed",
+        sourceRouteId: "route:/en/feed",
         slotId: "slot:modal:/[locale]/feed",
         targetMatchedUrl: "/en/photos/42",
-        targetRouteId: "route:/:locale/photos/:id",
+        targetRouteId: "route:/en/photos/42",
       }),
       interceptionContext: "/en/feed",
       matchedUrl: "/en/photos/42",
-      routeId: "route:/:locale/photos/:id\u0000/en/feed",
+      routeId: "route:/en/photos/42\u0000/en/feed",
     };
 
     const decision = planFlightResponseFromSnapshots({

--- a/tests/navigation-planner.test.ts
+++ b/tests/navigation-planner.test.ts
@@ -22,6 +22,7 @@ import type {
   GraphVersion,
   RootBoundaryId,
   RouteManifest,
+  RouteManifestInterception,
   RouteManifestRoute,
   RouteManifestRootBoundary,
   RouteManifestSlotBinding,
@@ -35,6 +36,14 @@ type TestManifestRoute = {
   patternParts?: readonly string[];
   rootBoundaryId: string | null;
   slotBindings?: readonly ParallelSlotBindingSnapshotV0[];
+  interceptions?: readonly TestManifestInterception[];
+};
+
+type TestManifestInterception = {
+  sourcePattern: string;
+  targetPattern: string;
+  slotId: string;
+  ownerLayoutId: string | null;
 };
 
 function createRouteSnapshot(
@@ -80,10 +89,14 @@ function createSlotBinding(
 function createTestRouteManifest(routes: readonly TestManifestRoute[]): RouteManifest {
   const manifestRoutes = new Map<string, RouteManifestRoute>();
   const slotBindings = new Map<string, RouteManifestSlotBinding>();
+  const interceptions = new Map<string, RouteManifestInterception>();
   const rootBoundaries = new Map<RootBoundaryId, RouteManifestRootBoundary>();
+  const routeIdByPattern = new Map(
+    routes.map((route) => [route.pattern, route.id ?? `route:${route.pattern}`]),
+  );
 
   for (const route of routes) {
-    const routeId = route.id ?? `route:${route.pattern}`;
+    const routeId = routeIdByPattern.get(route.pattern) ?? `route:${route.pattern}`;
     const rootBoundaryId =
       route.rootBoundaryId === null ? null : (route.rootBoundaryId as RootBoundaryId);
     const routeSlotBindings = route.slotBindings ?? [];
@@ -119,6 +132,26 @@ function createTestRouteManifest(routes: readonly TestManifestRoute[]): RouteMan
       });
     }
 
+    for (const interception of route.interceptions ?? []) {
+      const targetPatternParts = interception.targetPattern
+        .split("/")
+        .filter((segment) => segment.length > 0);
+      const id = `interception:${interception.slotId}:${interception.sourcePattern}->${interception.targetPattern}`;
+      interceptions.set(id, {
+        id,
+        interceptingRouteId: routeIdByPattern.get(interception.sourcePattern) ?? null,
+        ownerLayoutId: interception.ownerLayoutId,
+        slotId: interception.slotId,
+        sourcePattern: interception.sourcePattern,
+        sourcePatternParts: interception.sourcePattern
+          .split("/")
+          .filter((segment) => segment.length > 0),
+        targetPattern: interception.targetPattern,
+        targetPatternParts,
+        targetRouteId: routeIdByPattern.get(interception.targetPattern) ?? null,
+      });
+    }
+
     const rootLayoutId = route.layoutIds[0];
     if (rootBoundaryId !== null && rootLayoutId !== undefined) {
       rootBoundaries.set(rootBoundaryId, {
@@ -132,6 +165,7 @@ function createTestRouteManifest(routes: readonly TestManifestRoute[]): RouteMan
   const segmentGraph: StaticSegmentGraph = {
     boundaries: new Map(),
     defaults: new Map(),
+    interceptions,
     layouts: new Map(),
     pages: new Map(),
     rootBoundaries,
@@ -904,6 +938,14 @@ describe("navigationPlanner root-boundary decisions", () => {
         layoutIds: ["layout:/", "layout:/feed"],
         pattern: "/feed",
         rootBoundaryId: "root-boundary:/",
+        interceptions: [
+          {
+            ownerLayoutId: "layout:/feed",
+            slotId: "slot:modal:/feed",
+            sourcePattern: "/feed",
+            targetPattern: "/photos/:id",
+          },
+        ],
       },
       {
         layoutIds: ["layout:/photos", "layout:/photos/photo"],
@@ -942,6 +984,174 @@ describe("navigationPlanner root-boundary decisions", () => {
     }
     expect(decision.proposal.reason).toBe("interceptedCurrentRootBoundary");
     expect(decision.proposal.preserveElementIds).toEqual(["layout:/", "layout:/feed"]);
+  });
+
+  it("approves manifest-declared dynamic interception topology", () => {
+    const routeManifest = createTestRouteManifest([
+      {
+        layoutIds: ["layout:/", "layout:/[locale]", "layout:/[locale]/feed"],
+        pattern: "/:locale/feed",
+        rootBoundaryId: "root-boundary:/",
+        interceptions: [
+          {
+            ownerLayoutId: "layout:/[locale]/feed",
+            slotId: "slot:modal:/[locale]/feed",
+            sourcePattern: "/:locale/feed",
+            targetPattern: "/:locale/photos/:id",
+          },
+        ],
+      },
+      {
+        layoutIds: ["layout:/", "layout:/[locale]", "layout:/[locale]/photos"],
+        pattern: "/:locale/photos/:id",
+        rootBoundaryId: "root-boundary:/",
+      },
+    ]);
+    const currentSnapshot: RouteSnapshotV0 = {
+      ...createRouteSnapshot(null, []),
+      matchedUrl: "/en/feed",
+      routeId: "route:/:locale/feed",
+    };
+    const targetSnapshot: RouteSnapshotV0 = {
+      ...createRouteSnapshot(
+        null,
+        [],
+        [],
+        [createSlotBinding("slot:modal:/[locale]/feed", "layout:/[locale]/feed", "active")],
+      ),
+      displayUrl: "https://example.com/en/photos/42",
+      interception: createInterceptionSnapshot({
+        sourceMatchedUrl: "/en/feed",
+        sourceRouteId: "route:/:locale/feed",
+        slotId: "slot:modal:/[locale]/feed",
+        targetMatchedUrl: "/en/photos/42",
+        targetRouteId: "route:/:locale/photos/:id",
+      }),
+      interceptionContext: "/en/feed",
+      matchedUrl: "/en/photos/42",
+      routeId: "route:/:locale/photos/:id\u0000/en/feed",
+    };
+
+    const decision = planFlightResponseFromSnapshots({
+      currentSnapshot,
+      routeManifest,
+      targetSnapshot,
+    });
+
+    expect(decision.kind).toBe("proposeCommit");
+    if (decision.kind !== "proposeCommit") {
+      throw new Error("Expected proposeCommit decision");
+    }
+    expect(decision.proposal.reason).toBe("interceptedCurrentRootBoundary");
+    expect(decision.proposal.preserveElementIds).toEqual([
+      "layout:/",
+      "layout:/[locale]",
+      "layout:/[locale]/feed",
+    ]);
+  });
+
+  it("rejects intercepted preservation when RouteManifest does not declare the topology", () => {
+    const routeManifest = createTestRouteManifest([
+      {
+        layoutIds: ["layout:/", "layout:/feed"],
+        pattern: "/feed",
+        rootBoundaryId: "root-boundary:/",
+      },
+      {
+        layoutIds: ["layout:/", "layout:/photos"],
+        pattern: "/photos/:id",
+        rootBoundaryId: "root-boundary:/",
+      },
+    ]);
+    const currentSnapshot: RouteSnapshotV0 = {
+      ...createRouteSnapshot(null, []),
+      matchedUrl: "/feed",
+      routeId: "route:/feed",
+    };
+    const targetSnapshot: RouteSnapshotV0 = {
+      ...createRouteSnapshot(
+        null,
+        [],
+        [],
+        [createSlotBinding("slot:modal:/feed", "layout:/feed", "active")],
+      ),
+      displayUrl: "https://example.com/photos/42",
+      interception: createInterceptionSnapshot(),
+      interceptionContext: "/feed",
+      matchedUrl: "/photos/42",
+      routeId: "route:/photos/42\u0000/feed",
+    };
+
+    const decision = planFlightResponseFromSnapshots({
+      currentSnapshot,
+      routeManifest,
+      targetSnapshot,
+    });
+
+    expect(decision.kind).toBe("hardNavigate");
+    if (decision.kind !== "hardNavigate") {
+      throw new Error("Expected hardNavigate decision");
+    }
+    expect(decision.reason).toBe("interceptionProofRejected");
+    expect(decision.trace.entries[0]?.code).toBe(
+      NavigationTraceReasonCodes.interceptedRejectedUndeclaredTopology,
+    );
+  });
+
+  it("rejects intercepted preservation when RouteManifest declares a different slot owner", () => {
+    const routeManifest = createTestRouteManifest([
+      {
+        layoutIds: ["layout:/", "layout:/feed", "layout:/other"],
+        pattern: "/feed",
+        rootBoundaryId: "root-boundary:/",
+        interceptions: [
+          {
+            ownerLayoutId: "layout:/feed",
+            slotId: "slot:modal:/feed",
+            sourcePattern: "/feed",
+            targetPattern: "/photos/:id",
+          },
+        ],
+      },
+      {
+        layoutIds: ["layout:/", "layout:/photos"],
+        pattern: "/photos/:id",
+        rootBoundaryId: "root-boundary:/",
+      },
+    ]);
+    const currentSnapshot: RouteSnapshotV0 = {
+      ...createRouteSnapshot(null, []),
+      matchedUrl: "/feed",
+      routeId: "route:/feed",
+    };
+    const targetSnapshot: RouteSnapshotV0 = {
+      ...createRouteSnapshot(
+        null,
+        [],
+        [],
+        [createSlotBinding("slot:modal:/feed", "layout:/other", "active")],
+      ),
+      displayUrl: "https://example.com/photos/42",
+      interception: createInterceptionSnapshot(),
+      interceptionContext: "/feed",
+      matchedUrl: "/photos/42",
+      routeId: "route:/photos/42\u0000/feed",
+    };
+
+    const decision = planFlightResponseFromSnapshots({
+      currentSnapshot,
+      routeManifest,
+      targetSnapshot,
+    });
+
+    expect(decision.kind).toBe("hardNavigate");
+    if (decision.kind !== "hardNavigate") {
+      throw new Error("Expected hardNavigate decision");
+    }
+    expect(decision.reason).toBe("interceptionProofRejected");
+    expect(decision.trace.entries[0]?.code).toBe(
+      NavigationTraceReasonCodes.interceptedRejectedUndeclaredTopology,
+    );
   });
 
   it("approves intercepted preservation only from explicit source and slot proof", () => {


### PR DESCRIPTION
## Summary

Implements the requested `feat(router): add manifest-backed interception topology` slice from #726.

- Promotes scanner-discovered interception routes into `RouteManifestInterception` facts owned by `RouteManifest`.
- Records source/target patterns, split pattern parts for dynamic matching, owning slot id, owner layout id, and source/target route ids when the graph can resolve them.
- Serializes the new manifest facts into the browser route manifest and includes them in the graph version hash.
- Adds a manifest-owned `interceptionsBySlotId` index so planner validation checks only the declared candidates for the proof slot while keeping `interceptions` as the canonical fact map.
- Validates `__interception` proof against manifest-declared topology before preserving intercepted navigation state; undeclared graph edges now hard-navigate with `NC_INTERCEPT_REJECT_GRAPH`.
- Shares the descendant prefix matcher between RSC route interception matching and planner validation so proof validation tracks the same Next-URL-style source matching topology.

## Architecture Context

This is the Route Manifest ownership step described in #726: scanner/runtime metadata already found interception topology, but the manifest did not expose it as durable graph facts for Navigation Planner validation.

Next.js reference points used for this slice:

- `extractInterceptionRouteInformation` in `packages/next/src/shared/lib/router/utils/interception-routes.ts`
- generated interception rewrites gated by `Next-URL` in `packages/next/src/lib/generate-interception-routes-rewrites.ts`

Bonk: please read #726 before reviewing. This PR is a semantic-promotion slice of the larger Route Manifest / NavigationPlanner architecture, so the issue has the architectural big picture behind the smaller diff.

## Tests

- `vp test run tests/app-route-graph.test.ts`
- `vp test run tests/navigation-planner.test.ts`
- `vp test run tests/app-rsc-route-matching.test.ts`
- `vp test run tests/entry-templates.test.ts`
- `vp test run tests/app-browser-entry.test.ts`
- `vp test run tests/app-rsc-route-matching.test.ts tests/app-route-graph.test.ts tests/entry-templates.test.ts tests/app-browser-entry.test.ts`
- `git diff --check`
- `vp check`
- `vp run vinext#build`
