### PR TITLE
fix(router): normalize trailing slash parity

### DIFF
--- a/packages/vinext/src/deploy.ts
+++ b/packages/vinext/src/deploy.ts
@@ -543,6 +543,8 @@ import {
   applyConfigHeadersToHeaderRecord,
   cloneRequestWithHeaders,
   filterInternalHeaders,
+  isOpenRedirectShaped,
+  normalizeTrailingSlash,
 } from "vinext/server/request-pipeline";
 
 // @ts-expect-error -- virtual module resolved by vinext at build time
@@ -585,20 +587,6 @@ function hasBasePath(pathname: string, basePath: string): boolean {
 function stripBasePath(pathname: string, basePath: string): string {
   if (!hasBasePath(pathname, basePath)) return pathname;
   return pathname.slice(basePath.length) || "/";
-}
-
-// Mirror of isOpenRedirectShaped in server/request-pipeline.ts. Inlined here
-// because this worker runs in the Cloudflare Workers environment and can't
-// import from our local source at build time. Keep in sync.
-function isOpenRedirectShaped(rawPathname: string): boolean {
-  if (!rawPathname.startsWith("/")) return false;
-  const afterSlash = rawPathname.slice(1);
-  if (afterSlash.startsWith("/") || afterSlash.startsWith("\\")) return true;
-  if (afterSlash.length >= 3 && afterSlash[0] === "%") {
-    const encoded = afterSlash.slice(0, 3).toLowerCase();
-    if (encoded === "%5c" || encoded === "%2f") return true;
-  }
-  return false;
 }
 
 export default {
@@ -649,18 +637,15 @@ export default {
       }
 
       // ── 2. Trailing slash normalization ────────────────────────────
-      if (pathname !== "/" && pathname !== "/api" && !pathname.startsWith("/api/")) {
-        const hasTrailing = pathname.endsWith("/");
-        if (trailingSlash && !hasTrailing) {
-          return new Response(null, {
-            status: 308,
-            headers: { Location: basePath + pathname + "/" + url.search },
-          });
-        } else if (!trailingSlash && hasTrailing) {
-          return new Response(null, {
-            status: 308,
-            headers: { Location: basePath + pathname.replace(/\\/+$/, "") + url.search },
-          });
+      {
+        const trailingSlashRedirect = normalizeTrailingSlash(
+          pathname,
+          basePath,
+          trailingSlash,
+          url.search,
+        );
+        if (trailingSlashRedirect) {
+          return trailingSlashRedirect;
         }
       }
 

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -55,6 +55,7 @@ import {
   filterInternalHeaders,
   INTERNAL_HEADERS,
   isOpenRedirectShaped,
+  normalizeTrailingSlash,
 } from "./server/request-pipeline.js";
 import {
   findInstrumentationClientFile,
@@ -78,7 +79,7 @@ import { scanMetadataFiles } from "./server/metadata-routes.js";
 import { buildRequestHeadersFromMiddlewareResponse } from "./server/middleware-request-headers.js";
 import { detectPackageManager } from "./utils/project.js";
 import { manifestFileWithBase, manifestFilesWithBase } from "./utils/manifest-paths.js";
-import { hasBasePath, removeTrailingSlash } from "./utils/base-path.js";
+import { hasBasePath } from "./utils/base-path.js";
 import {
   ASSET_PREFIX_URL_DIR,
   resolveAssetUrlPrefix,
@@ -2739,11 +2740,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                 url = url.replace(/\.html(?=\?|$)/, "");
               }
 
-              // Skip requests for files with extensions (static assets)
               let pathname = url.split("?")[0];
-              if (pathname.includes(".") && !pathname.endsWith(".html")) {
-                return next();
-              }
 
               // Guard against protocol-relative URL open redirects.
               // Check the RAW pathname before decode/normalize so both literal
@@ -2786,30 +2783,30 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                 pathname = stripped;
               }
 
-              // Normalize trailing slash based on next.config.js trailingSlash setting.
-              // Redirect to the canonical form if needed.
-              if (
-                nextConfig &&
-                pathname !== "/" &&
-                pathname !== "/api" &&
-                !pathname.startsWith("/api/")
-              ) {
-                const hasTrailing = pathname.endsWith("/");
-                if (nextConfig.trailingSlash && !hasTrailing) {
-                  // trailingSlash: true — redirect /about → /about/
-                  const qs = url.includes("?") ? url.slice(url.indexOf("?")) : "";
-                  const dest = bp + pathname + "/" + qs;
-                  res.writeHead(308, { Location: dest });
-                  res.end();
-                  return;
-                } else if (!nextConfig.trailingSlash && hasTrailing) {
-                  // trailingSlash: false (default) — redirect /about/ → /about
-                  const qs = url.includes("?") ? url.slice(url.indexOf("?")) : "";
-                  const dest = bp + removeTrailingSlash(pathname) + qs;
-                  res.writeHead(308, { Location: dest });
+              if (nextConfig) {
+                const qs = url.includes("?") ? url.slice(url.indexOf("?")) : "";
+                const trailingSlashRedirect = normalizeTrailingSlash(
+                  pathname,
+                  bp,
+                  nextConfig.trailingSlash,
+                  qs,
+                );
+                if (trailingSlashRedirect) {
+                  const location = trailingSlashRedirect.headers.get("Location");
+                  res.writeHead(
+                    trailingSlashRedirect.status,
+                    location ? { Location: location } : undefined,
+                  );
                   res.end();
                   return;
                 }
+              }
+
+              // Skip requests for files with extensions (static assets) after
+              // trailing-slash canonicalization so file-looking dynamic routes
+              // like /catch-all/hello.world/ still get the Next.js redirect.
+              if (pathname.includes(".") && !pathname.endsWith(".html")) {
+                return next();
               }
 
               // When @cloudflare/vite-plugin is present, delegate the entire

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -49,9 +49,10 @@ import {
   applyConfigHeadersToHeaderRecord,
   filterInternalHeaders,
   isOpenRedirectShaped,
+  normalizeTrailingSlash,
 } from "./request-pipeline.js";
 import { notFoundResponse } from "./http-error-responses.js";
-import { hasBasePath, stripBasePath, removeTrailingSlash } from "../utils/base-path.js";
+import { hasBasePath, stripBasePath } from "../utils/base-path.js";
 import {
   ASSET_PREFIX_URL_DIR,
   assetPrefixPathname,
@@ -1532,16 +1533,15 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
       }
 
       // ── 3. Trailing slash normalization ───────────────────────────
-      if (pathname !== "/" && pathname !== "/api" && !pathname.startsWith("/api/")) {
-        const hasTrailing = pathname.endsWith("/");
-        if (trailingSlash && !hasTrailing) {
-          const qs = url.includes("?") ? url.slice(url.indexOf("?")) : "";
-          res.writeHead(308, { Location: basePath + pathname + "/" + qs });
-          res.end();
-          return;
-        } else if (!trailingSlash && hasTrailing) {
-          const qs = url.includes("?") ? url.slice(url.indexOf("?")) : "";
-          res.writeHead(308, { Location: basePath + removeTrailingSlash(pathname) + qs });
+      {
+        const qs = url.includes("?") ? url.slice(url.indexOf("?")) : "";
+        const trailingSlashRedirect = normalizeTrailingSlash(pathname, basePath, trailingSlash, qs);
+        if (trailingSlashRedirect) {
+          const location = trailingSlashRedirect.headers.get("Location");
+          res.writeHead(
+            trailingSlashRedirect.status,
+            location ? { Location: location } : undefined,
+          );
           res.end();
           return;
         }

--- a/packages/vinext/src/server/request-pipeline.ts
+++ b/packages/vinext/src/server/request-pipeline.ts
@@ -130,6 +130,12 @@ type ResolvePublicFileRouteOptions = {
   request: Request;
 };
 
+const FILE_LIKE_PATHNAME_RE = /\.[^/]+\/?$/;
+
+function isWellKnownPathname(pathname: string): boolean {
+  return pathname === "/.well-known" || pathname.startsWith("/.well-known/");
+}
+
 function findHeaderRecordKey(headers: HeaderRecord, lowerName: string): string | undefined {
   for (const key of Object.keys(headers)) {
     if (key.toLowerCase() === lowerName) return key;
@@ -240,6 +246,33 @@ export function resolvePublicFileRoute(options: ResolvePublicFileRouteOptions): 
   return createStaticFileSignal(options.cleanPathname, options.middlewareContext);
 }
 
+export function normalizeTrailingSlashPathname(
+  pathname: string,
+  trailingSlash: boolean,
+): string | null {
+  if (pathname === "/" || pathname === "/api" || pathname.startsWith("/api/")) {
+    return null;
+  }
+
+  const hasTrailing = pathname.endsWith("/");
+
+  if (trailingSlash) {
+    // Next.js emits two internal redirect rules for trailingSlash:true:
+    // file-looking paths lose a trailing slash, non-file paths gain one, and
+    // /.well-known stays untouched for RFC-defined discovery URLs.
+    if (isWellKnownPathname(pathname)) return null;
+    if (FILE_LIKE_PATHNAME_RE.test(pathname)) {
+      const normalized = removeTrailingSlash(pathname);
+      return normalized === pathname ? null : normalized;
+    }
+    if (!hasTrailing && !pathname.endsWith(".rsc")) return `${pathname}/`;
+    return null;
+  }
+
+  if (hasTrailing) return removeTrailingSlash(pathname);
+  return null;
+}
+
 /**
  * Check if the pathname needs a trailing slash redirect, and return the
  * redirect Response if so.
@@ -248,6 +281,8 @@ export function resolvePublicFileRoute(options: ResolvePublicFileRouteOptions): 
  * - `/api` routes are never redirected
  * - The root path `/` is never redirected
  * - If `trailingSlash` is true, redirect `/about` → `/about/`
+ * - If `trailingSlash` is true, redirect file-looking `/file.ext/` → `/file.ext`
+ * - If `trailingSlash` is true, do not redirect `/.well-known/*`
  * - If `trailingSlash` is false (default), redirect `/about/` → `/about`
  *
  * @param pathname - The basePath-stripped pathname
@@ -272,22 +307,12 @@ export function normalizeTrailingSlash(
   if (isOpenRedirectShaped(pathname)) {
     return notFoundResponse();
   }
-  const hasTrailing = pathname.endsWith("/");
-  // RSC (client-side navigation) requests arrive as /path.rsc — don't
-  // redirect those to /path.rsc/ when trailingSlash is enabled.
-  if (trailingSlash && !hasTrailing && !pathname.endsWith(".rsc")) {
-    return new Response(null, {
-      status: 308,
-      headers: { Location: basePath + pathname + "/" + search },
-    });
-  }
-  if (!trailingSlash && hasTrailing) {
-    return new Response(null, {
-      status: 308,
-      headers: { Location: basePath + removeTrailingSlash(pathname) + search },
-    });
-  }
-  return null;
+  const normalizedPathname = normalizeTrailingSlashPathname(pathname, trailingSlash);
+  if (normalizedPathname === null) return null;
+  return new Response(null, {
+    status: 308,
+    headers: { Location: basePath + normalizedPathname + search },
+  });
 }
 
 /**

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -22,6 +22,7 @@ import { installWindowNext, type PagesRouterPublicInstance } from "../client/win
 import {
   isAbsoluteOrProtocolRelativeUrl,
   isHashOnlyBrowserUrlChange,
+  normalizePathTrailingSlash,
   toBrowserNavigationHref,
   toSameOriginAppPath,
 } from "./url-utils.js";
@@ -39,6 +40,8 @@ import { setPagesRouterPopStateHandler } from "./pages-router-runtime.js";
 
 /** basePath from next.config.js, injected by the plugin at build time */
 const __basePath: string = process.env.__NEXT_ROUTER_BASEPATH ?? "";
+/** trailingSlash from next.config.js, injected by the plugin at build time */
+const __trailingSlash: boolean = process.env.__VINEXT_TRAILING_SLASH === "true";
 
 type BeforePopStateCallback = (state: {
   url: string;
@@ -796,7 +799,11 @@ async function performNavigation(
     resolved = localPath;
   }
 
-  const full = toBrowserNavigationHref(resolved, window.location.href, __basePath);
+  resolved = normalizePathTrailingSlash(resolved, __trailingSlash);
+  const full = normalizePathTrailingSlash(
+    toBrowserNavigationHref(resolved, window.location.href, __basePath),
+    __trailingSlash,
+  );
   const shallow = options?.shallow ?? false;
   const doScroll = options?.scroll !== false;
 

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -620,7 +620,8 @@ describe("generatePagesRouterWorkerEntry", () => {
   it("handles trailing slash normalization", () => {
     const content = generatePagesRouterWorkerEntry();
     expect(content).toContain("trailingSlash");
-    expect(content).toContain("hasTrailing");
+    expect(content).toContain("normalizeTrailingSlash");
+    expect(content).toContain('from "vinext/server/request-pipeline"');
   });
 
   it("routes /api/ to handleApiRoute using resolved URL", () => {
@@ -650,12 +651,8 @@ describe("generatePagesRouterWorkerEntry", () => {
 
   it("includes an open-redirect guard that rejects encoded backslash and slash", () => {
     const content = generatePagesRouterWorkerEntry();
-    // The generated worker inlines isOpenRedirectShaped. Regression for
-    // VULN-126915 — the guard must handle both literal (\\, //) and
-    // percent-encoded (%5C, %2F) variants in the leading segment.
-    expect(content).toContain("function isOpenRedirectShaped");
-    expect(content).toContain('"%5c"');
-    expect(content).toContain('"%2f"');
+    expect(content).toContain("isOpenRedirectShaped");
+    expect(content).toContain('from "vinext/server/request-pipeline"');
     expect(content).toContain("isOpenRedirectShaped(pathname)");
   });
 

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -2066,6 +2066,14 @@ describe("basePath + trailingSlash interaction", () => {
 }`,
     );
 
+    await fsp.mkdir(path.join(tmpDir, "pages", "catch-all"), { recursive: true });
+    await fsp.writeFile(
+      path.join(tmpDir, "pages", "catch-all", "[...slug].tsx"),
+      `export default function CatchAll() {
+  return <h1>TrailingSlash CatchAll</h1>;
+}`,
+    );
+
     const plugins: any[] = [vinext()];
     tsServer = await createServer({
       root: tmpDir,
@@ -2105,6 +2113,14 @@ describe("basePath + trailingSlash interaction", () => {
     expect(res.status).toBe(200);
     const html = await res.text();
     expect(html).toContain("TrailingSlash About");
+  });
+
+  it("GET /app/catch-all/hello.world/ redirects to the file-looking canonical path", async () => {
+    const res = await fetch(`${tsBaseUrl}/app/catch-all/hello.world/`, {
+      redirect: "manual",
+    });
+    expect(res.status).toBe(308);
+    expect(res.headers.get("location")).toBe("/app/catch-all/hello.world");
   });
 });
 

--- a/tests/request-pipeline.test.ts
+++ b/tests/request-pipeline.test.ts
@@ -338,6 +338,28 @@ describe("normalizeTrailingSlash", () => {
     expect(res!.headers.get("Location")).toBe("/about/?foo=1");
   });
 
+  it("strips the trailing slash from file-looking paths when trailingSlash is true", () => {
+    const res = normalizeTrailingSlash("/catch-all/hello.world/", "", true, "");
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(308);
+    expect(res!.headers.get("Location")).toBe("/catch-all/hello.world");
+  });
+
+  it("preserves query string when stripping file-looking paths with trailingSlash true", () => {
+    const res = normalizeTrailingSlash("/catch-all/hello.world/", "", true, "?hello=world");
+    expect(res).not.toBeNull();
+    expect(res!.headers.get("Location")).toBe("/catch-all/hello.world?hello=world");
+  });
+
+  it("does not add a slash to already-canonical file-looking paths with trailingSlash true", () => {
+    expect(normalizeTrailingSlash("/catch-all/hello.world", "", true, "")).toBeNull();
+  });
+
+  it("does not redirect .well-known paths when trailingSlash is true", () => {
+    expect(normalizeTrailingSlash("/.well-known/acme-challenge", "", true, "")).toBeNull();
+    expect(normalizeTrailingSlash("/.well-known/acme-challenge/", "", true, "")).toBeNull();
+  });
+
   it("prepends basePath to redirect Location", () => {
     const res = normalizeTrailingSlash("/about", "/docs", true, "");
     expect(res!.headers.get("Location")).toBe("/docs/about/");

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -11247,6 +11247,70 @@ describe("Pages Router concurrent navigation", () => {
     return assignments;
   }
 
+  async function expectPagesRouterPushTrailingSlashNormalization({
+    target,
+    expectedBrowserUrl,
+  }: {
+    target: string;
+    expectedBrowserUrl: string;
+  }): Promise<void> {
+    const previousWindow = (globalThis as any).window;
+    const previousTrailingSlash = process.env.__VINEXT_TRAILING_SLASH;
+    const originalFetch = globalThis.fetch;
+    const { win } = createNavWindow();
+    (globalThis as any).window = win;
+    process.env.__VINEXT_TRAILING_SLASH = "true";
+    vi.resetModules();
+
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error("shallow trailing-slash normalization test must not fetch page HTML");
+    });
+
+    try {
+      const routerModule = await import("../packages/vinext/src/shims/router.js");
+      const Router = routerModule.default;
+
+      const result = await Router.push(target, undefined, { shallow: true });
+
+      expect(result).toBe(true);
+      expect(win.history.pushState).toHaveBeenCalledWith({}, "", expectedBrowserUrl);
+    } finally {
+      if (previousTrailingSlash === undefined) {
+        delete process.env.__VINEXT_TRAILING_SLASH;
+      } else {
+        process.env.__VINEXT_TRAILING_SLASH = previousTrailingSlash;
+      }
+      vi.resetModules();
+      if (previousWindow === undefined) {
+        delete (globalThis as any).window;
+      } else {
+        (globalThis as any).window = previousWindow;
+      }
+      globalThis.fetch = originalFetch;
+    }
+  }
+
+  it("Pages Router push normalizes query-bearing paths when trailingSlash is true", async () => {
+    await expectPagesRouterPushTrailingSlashNormalization({
+      target: "/about?hello=world",
+      expectedBrowserUrl: "/about/?hello=world",
+    });
+  });
+
+  it("Pages Router push preserves canonical query-bearing paths when trailingSlash is true", async () => {
+    await expectPagesRouterPushTrailingSlashNormalization({
+      target: "/about/?hello=world",
+      expectedBrowserUrl: "/about/?hello=world",
+    });
+  });
+
+  it("Pages Router push strips file-looking path slashes when trailingSlash is true", async () => {
+    await expectPagesRouterPushTrailingSlashNormalization({
+      target: "/catch-all/hello.world/",
+      expectedBrowserUrl: "/catch-all/hello.world",
+    });
+  });
+
   it("last push() wins when two overlap — superseded navigation does not render", async () => {
     const previousWindow = (globalThis as any).window;
     const originalFetch = globalThis.fetch;


### PR DESCRIPTION
## Overview

| Item | Detail |
| --- | --- |
| Goal | Match Next.js trailing-slash behavior for file-looking catch-all routes and Pages Router imperative navigation. |
| Core change | Share the server redirect decision across Pages Router dev, prod, App Router, and generated Worker paths, and apply client trailing-slash normalization in `Router.push` / `Router.replace`. |
| Main boundary | `trailingSlash:true` should add slashes to route-like paths, strip slashes from file-looking paths, preserve query/hash, and leave `/.well-known/*` server redirects alone. |
| Primary files | `packages/vinext/src/server/request-pipeline.ts`, `packages/vinext/src/shims/router.ts`, Pages Router runtime wiring in `index.ts`, `prod-server.ts`, and `deploy.ts`. |
| Expected impact | Fixes Next.js trailing-slash parity failures without changing public API shape. |

## Why

Trailing-slash canonicalization is part of the routing contract, not a rendering detail. Next.js applies that contract in both places users observe it: server redirects and client URL preparation. Vinext already normalized `<Link>` hrefs, but Pages Router imperative navigation bypassed that helper, and server redirects treated catch-all dot segments as directories instead of file-looking paths.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| Server redirects | The canonical `Location` must follow Next.js route-manifest redirect rules. | File-looking paths such as `/catch-all/hello.world/` now redirect to `/catch-all/hello.world` under `trailingSlash:true`; non-file paths still gain a slash; queries are preserved. |
| Client navigation | `Router.push` and `Router.replace` should prepare hrefs through the same trailing-slash normalization used by link resolution. | Pages Router imperative navigation now normalizes the resolved local URL before writing browser history. |
| Runtime parity | Pages Router dev, prod, App Router, and generated Worker paths should not drift on request pipeline behavior. | Node runtimes and generated Worker code now call the shared `normalizeTrailingSlash` request-pipeline helper instead of carrying separate redirect decisions. |

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| `trailingSlash:true` request to `/catch-all/hello.world/` | No redirect, or incorrect directory-style canonicalization depending on path. | `308 Location: /catch-all/hello.world`. |
| `trailingSlash:true` request to `/file.ext/?q=1` | File-looking path kept the trailing slash. | `308 Location: /file.ext?q=1`. |
| `trailingSlash:true` request to `/.well-known/acme-challenge` | Could be normalized like an app route. | No trailing-slash redirect, matching Next.js generated redirect exclusion. |
| `Router.push('/about?hello=world')` | History wrote `/about?hello=world`. | History writes `/about/?hello=world`. |
| `Router.push('/catch-all/hello.world/')` | History kept `/catch-all/hello.world/`. | History writes `/catch-all/hello.world`. |

<details>
<summary>Maintainer review path</summary>

1. `packages/vinext/src/server/request-pipeline.ts`
   - Review the shared `normalizeTrailingSlashPathname` decision and the open-redirect guard ordering.
2. `packages/vinext/src/index.ts`, `packages/vinext/src/server/prod-server.ts`, and `packages/vinext/src/deploy.ts`
   - Confirm Pages Router runtimes delegate to `normalizeTrailingSlash` instead of owning redirect rules locally.
3. `packages/vinext/src/shims/router.ts`
   - Confirm `Router.push` / `Router.replace` run local URLs through the same client helper used by link normalization.
4. `tests/request-pipeline.test.ts`, `tests/shims.test.ts`, and `tests/deploy.test.ts`
   - Review the observable redirect, browser-history, and generated Worker wiring regressions.

</details>

<details>
<summary>Validation</summary>

- `vp test run tests/request-pipeline.test.ts tests/shims.test.ts -t "trailingSlash|Pages Router push normalizes|Pages Router push preserves|Pages Router push strips"`
- `vp test run tests/request-pipeline.test.ts tests/shims.test.ts tests/link.test.ts`
- `vp test run tests/deploy.test.ts`
- `vp check`
- `vp run vinext#build`
- Generated Worker sanity check: `normalizeTrailingSlashPathname` is not inlined; generated Worker imports and calls `normalizeTrailingSlash` from `vinext/server/request-pipeline`.
- Commit hook: formatting, lint/typecheck, knip, and the project-local rebuild hook completed successfully.

</details>

<details>
<summary>Risk / compatibility</summary>

- Public API: no new API surface.
- Routing behavior: intentionally changes `trailingSlash:true` canonical URLs to match Next.js for file-looking paths and Pages Router imperative navigation.
- Query preservation: covered in server redirect and router push regressions.
- Workers: generated Pages Router Worker imports the shared request-pipeline helper instead of duplicating trailing-slash semantics in the template.
- RSC: existing `.rsc` no-redirect behavior is preserved by the file-looking path rule.

</details>

<details>
<summary>Non-goals</summary>

- This PR does not rewrite the existing `<Link>` normalization path, which already used the Next-style client helper.
- This PR does not port the full upstream trailing-slashes e2e fixture into vinext. It adds focused lower-boundary regressions for the failing behavior instead.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| [Next.js `load-custom-routes.ts` trailing-slash redirects](https://github.com/vercel/next.js/blob/canary/packages/next/src/lib/load-custom-routes.ts#L795-L821) | Shows the generated redirect rules for `trailingSlash:true`, including file-looking path stripping and `/.well-known` exclusion. |
| [Next.js `normalize-trailing-slash.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/normalize-trailing-slash.ts#L8-L25) | Shows client-side file-looking path normalization while preserving query/hash. |
| [Next.js `resolve-href.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/resolve-href.ts#L99-L102) | Shows href resolution applying `normalizePathTrailingSlash` to the final pathname. |
| [Next.js Pages Router `prepareUrlAs`](https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/router/router.ts#L132-L150) | Shows `router.push` / `router.replace` flowing through href preparation. |
