### PR TITLE
fix(metadata): match Next dynamic route semantics

### DIFF
--- a/packages/vinext/src/server/app-page-boundary-render.ts
+++ b/packages/vinext/src/server/app-page-boundary-render.ts
@@ -305,6 +305,7 @@ export async function renderAppPageHttpAccessFallback<TModule extends AppPageMod
   }
 
   const layoutModules = options.layoutModules ?? options.route?.layouts ?? options.rootLayouts;
+  const pathname = new URL(options.requestUrl).pathname;
   const routeSegments = resolveHttpAccessFallbackHeadRouteSegments(options.route, layoutModules);
   const { metadata, viewport } = await resolveAppPageHead({
     basePath: options.basePath ?? "",
@@ -315,7 +316,7 @@ export async function renderAppPageHttpAccessFallback<TModule extends AppPageMod
     ),
     metadataRoutes: options.metadataRoutes,
     params: options.matchedParams,
-    routePath: options.route?.pattern ?? new URL(options.requestUrl).pathname,
+    routePath: options.route?.pattern ?? pathname,
     routeSegments,
   });
 
@@ -324,7 +325,7 @@ export async function renderAppPageHttpAccessFallback<TModule extends AppPageMod
     createElement("meta", { content: "noindex", key: "robots", name: "robots" }),
   ];
   if (metadata) {
-    headElements.push(createElement(MetadataHead, { key: "metadata", metadata }));
+    headElements.push(createElement(MetadataHead, { key: "metadata", metadata, pathname }));
   }
   headElements.push(createElement(ViewportHead, { key: "viewport", viewport }));
 
@@ -392,7 +393,7 @@ export async function renderAppPageErrorBoundary<TModule extends AppPageModule>(
         routeSegments: options.route?.routeSegments,
       });
       if (metadata) {
-        headElements.push(createElement(MetadataHead, { key: "metadata", metadata }));
+        headElements.push(createElement(MetadataHead, { key: "metadata", metadata, pathname }));
       }
       headElements.push(createElement(ViewportHead, { key: "viewport", viewport }));
     } catch (error) {

--- a/packages/vinext/src/server/app-page-element-builder.ts
+++ b/packages/vinext/src/server/app-page-element-builder.ts
@@ -203,6 +203,7 @@ export async function buildPageElements<
     makeThenableParams,
     matchedParams: params,
     resolvedMetadata,
+    resolvedMetadataPathname: routePath,
     resolvedViewport,
     interceptionContext: opts?.interceptionContext ?? null,
     interception,

--- a/packages/vinext/src/server/app-page-route-wiring.tsx
+++ b/packages/vinext/src/server/app-page-route-wiring.tsx
@@ -144,6 +144,7 @@ type BuildAppPageRouteElementOptions<
   makeThenableParams: (params: AppPageParams) => unknown;
   matchedParams: AppPageParams;
   resolvedMetadata: Metadata | null;
+  resolvedMetadataPathname?: string;
   resolvedViewport: Viewport;
   rootForbiddenModule?: TModule | null;
   rootNotFoundModule?: TModule | null;
@@ -347,11 +348,15 @@ function createAppPageSlotBindings<
   });
 }
 
-function createAppPageRouteHead(metadata: Metadata | null, viewport: Viewport): ReactNode {
+function createAppPageRouteHead(
+  metadata: Metadata | null,
+  viewport: Viewport,
+  pathname: string,
+): ReactNode {
   return (
     <>
       <meta charSet="utf-8" />
-      {metadata ? <MetadataHead metadata={metadata} /> : null}
+      {metadata ? <MetadataHead metadata={metadata} pathname={pathname} /> : null}
       <ViewportHead viewport={viewport} />
     </>
   );
@@ -837,7 +842,11 @@ export function buildAppPageElements<
 
   elements[routeId] = (
     <>
-      {createAppPageRouteHead(options.resolvedMetadata, options.resolvedViewport)}
+      {createAppPageRouteHead(
+        options.resolvedMetadata,
+        options.resolvedViewport,
+        options.resolvedMetadataPathname ?? options.routePath,
+      )}
       {routeChildren}
     </>
   );

--- a/packages/vinext/src/server/file-based-metadata.ts
+++ b/packages/vinext/src/server/file-based-metadata.ts
@@ -31,6 +31,7 @@ type SocialImageEntry = {
   height?: number;
   alt?: string;
   type?: string;
+  metadataRoute?: true;
 };
 
 type DynamicImageSize = {
@@ -335,6 +336,15 @@ function normalizeAppleEntry(value: string | URL | AppleIconEntry): AppleIconEnt
   return { ...value };
 }
 
+function markMetadataRouteSocialImage(entry: SocialImageEntry): SocialImageEntry {
+  Object.defineProperty(entry, "metadataRoute", {
+    configurable: true,
+    enumerable: false,
+    value: true,
+  });
+  return entry;
+}
+
 function buildSocialEntry(headData: MetadataRouteHeadData): SocialImageEntry | null {
   if (headData.kind !== "openGraph" && headData.kind !== "twitter") {
     return null;
@@ -355,7 +365,7 @@ function buildSocialEntry(headData: MetadataRouteHeadData): SocialImageEntry | n
   if (headData.type) {
     socialEntry.type = headData.type;
   }
-  return socialEntry;
+  return markMetadataRouteSocialImage(socialEntry);
 }
 
 function normalizeMetadataImageId(route: MetadataFileRoute, id: string | number): string | null {

--- a/packages/vinext/src/server/metadata-route-response.ts
+++ b/packages/vinext/src/server/metadata-route-response.ts
@@ -38,6 +38,10 @@ type MetadataRouteFunctions = {
 };
 
 const routeFunctionCache = new WeakMap<MetadataRuntimeRoute, MetadataRouteFunctions>();
+const CACHE_HEADERS = {
+  noCache: "no-cache, no-store",
+  revalidate: "public, max-age=0, must-revalidate",
+} as const;
 
 function isObject(value: unknown): value is object {
   return typeof value === "object" && value !== null;
@@ -76,6 +80,25 @@ function isImageMetadataRoute(route: MetadataRuntimeRoute): boolean {
     route.type === "opengraph-image" ||
     route.type === "twitter-image"
   );
+}
+
+function metadataRouteCacheHeader(route: MetadataRuntimeRoute): string {
+  if (isImageMetadataRoute(route) && process.env.NODE_ENV === "development") {
+    return CACHE_HEADERS.noCache;
+  }
+  return CACHE_HEADERS.revalidate;
+}
+
+function withMetadataRouteCacheHeader(response: Response, route: MetadataRuntimeRoute): Response {
+  const headers = new Headers(response.headers);
+  if (!headers.has("Cache-Control")) {
+    headers.set("Cache-Control", metadataRouteCacheHeader(route));
+  }
+  return new Response(response.body, {
+    headers,
+    status: response.status,
+    statusText: response.statusText,
+  });
 }
 
 function getMetadataRouteFunctions(route: MetadataRuntimeRoute): MetadataRouteFunctions {
@@ -194,7 +217,7 @@ async function handleGeneratedSitemap(
     id: makeThenableMetadataRouteId(matchedId),
   });
   if (result instanceof Response) {
-    return result;
+    return withMetadataRouteCacheHeader(result, route);
   }
   if (!isSitemapEntries(result)) {
     throw new TypeError("Metadata sitemap routes must return an array.");
@@ -202,7 +225,7 @@ async function handleGeneratedSitemap(
   return new Response(sitemapToXml(result), {
     headers: {
       "Content-Type": route.contentType,
-      "Cache-Control": "public, max-age=0, must-revalidate",
+      "Cache-Control": metadataRouteCacheHeader(route),
     },
   });
 }
@@ -276,7 +299,7 @@ async function callDynamicMetadataRoute(
   }
 
   if (result instanceof Response) {
-    return result;
+    return withMetadataRouteCacheHeader(result, route);
   }
 
   let body: string;
@@ -306,7 +329,7 @@ async function callDynamicMetadataRoute(
   return new Response(body, {
     headers: {
       "Content-Type": route.contentType,
-      "Cache-Control": "public, max-age=0, must-revalidate",
+      "Cache-Control": metadataRouteCacheHeader(route),
     },
   });
 }
@@ -327,7 +350,7 @@ function serveStaticMetadataRoute(route: MetadataRuntimeRoute): Response {
     return new Response(bytes, {
       headers: {
         "Content-Type": route.contentType,
-        "Cache-Control": "public, max-age=0, must-revalidate",
+        "Cache-Control": metadataRouteCacheHeader(route),
       },
     });
   } catch (error) {

--- a/packages/vinext/src/server/metadata-route-response.ts
+++ b/packages/vinext/src/server/metadata-route-response.ts
@@ -83,7 +83,7 @@ function isImageMetadataRoute(route: MetadataRuntimeRoute): boolean {
 }
 
 function metadataRouteCacheHeader(route: MetadataRuntimeRoute): string {
-  if (isImageMetadataRoute(route) && process.env.NODE_ENV === "development") {
+  if (route.isDynamic && isImageMetadataRoute(route) && process.env.NODE_ENV === "development") {
     return CACHE_HEADERS.noCache;
   }
   return CACHE_HEADERS.revalidate;

--- a/packages/vinext/src/server/metadata-routes.ts
+++ b/packages/vinext/src/server/metadata-routes.ts
@@ -114,7 +114,7 @@ export const METADATA_FILE_MAP: Record<
     contentType: "application/xml",
     canBeDynamic: true,
     staticExtensions: [".xml"],
-    dynamicExtensions: [".ts", ".js"],
+    dynamicExtensions: [".tsx", ".ts", ".jsx", ".js"],
     nestable: true,
   },
   robots: {
@@ -122,7 +122,7 @@ export const METADATA_FILE_MAP: Record<
     contentType: "text/plain",
     canBeDynamic: true,
     staticExtensions: [".txt"],
-    dynamicExtensions: [".ts", ".js"],
+    dynamicExtensions: [".tsx", ".ts", ".jsx", ".js"],
     nestable: false,
   },
   manifest: {
@@ -130,7 +130,7 @@ export const METADATA_FILE_MAP: Record<
     contentType: "application/manifest+json",
     canBeDynamic: true,
     staticExtensions: [".json", ".webmanifest"],
-    dynamicExtensions: [".ts", ".js"],
+    dynamicExtensions: [".tsx", ".ts", ".jsx", ".js"],
     nestable: false,
   },
   favicon: {
@@ -146,7 +146,7 @@ export const METADATA_FILE_MAP: Record<
     contentType: "image/png",
     canBeDynamic: true,
     staticExtensions: [".ico", ".jpg", ".jpeg", ".png", ".svg"],
-    dynamicExtensions: [".ts", ".tsx", ".js"],
+    dynamicExtensions: [".tsx", ".ts", ".jsx", ".js"],
     nestable: true,
   },
   "opengraph-image": {
@@ -154,7 +154,7 @@ export const METADATA_FILE_MAP: Record<
     contentType: "image/png",
     canBeDynamic: true,
     staticExtensions: [".jpg", ".jpeg", ".png", ".gif"],
-    dynamicExtensions: [".ts", ".tsx", ".js"],
+    dynamicExtensions: [".tsx", ".ts", ".jsx", ".js"],
     nestable: true,
   },
   "twitter-image": {
@@ -162,7 +162,7 @@ export const METADATA_FILE_MAP: Record<
     contentType: "image/png",
     canBeDynamic: true,
     staticExtensions: [".jpg", ".jpeg", ".png", ".gif"],
-    dynamicExtensions: [".ts", ".tsx", ".js"],
+    dynamicExtensions: [".tsx", ".ts", ".jsx", ".js"],
     nestable: true,
   },
   "apple-icon": {
@@ -170,7 +170,7 @@ export const METADATA_FILE_MAP: Record<
     contentType: "image/png",
     canBeDynamic: true,
     staticExtensions: [".jpg", ".jpeg", ".png"],
-    dynamicExtensions: [".ts", ".tsx", ".js"],
+    dynamicExtensions: [".tsx", ".ts", ".jsx", ".js"],
     nestable: true,
   },
 };
@@ -327,15 +327,15 @@ export function robotsToText(config: RobotsConfig): string {
     lines.push("");
   }
 
+  if (config.host) {
+    lines.push(`Host: ${config.host}`);
+  }
+
   if (config.sitemap) {
     const sitemaps = Array.isArray(config.sitemap) ? config.sitemap : [config.sitemap];
     for (const sitemap of sitemaps) {
       lines.push(`Sitemap: ${sitemap}`);
     }
-  }
-
-  if (config.host) {
-    lines.push(`Host: ${config.host}`);
   }
 
   return lines.join("\n").trim() + "\n";

--- a/packages/vinext/src/shims/metadata.tsx
+++ b/packages/vinext/src/shims/metadata.tsx
@@ -6,6 +6,7 @@
  */
 import React from "react";
 import { makeThenableParams } from "./thenable-params.js";
+import { isAbsoluteOrProtocolRelativeUrl } from "./url-utils.js";
 
 // ---------------------------------------------------------------------------
 // Viewport types and resolution
@@ -139,15 +140,7 @@ export type Metadata = {
     description?: string;
     url?: string | URL;
     siteName?: string;
-    images?:
-      | string
-      | URL
-      | { url: string | URL; width?: number; height?: number; alt?: string; type?: string }
-      | Array<
-          | string
-          | URL
-          | { url: string | URL; width?: number; height?: number; alt?: string; type?: string }
-        >;
+    images?: string | URL | SocialImageDescriptor | Array<string | URL | SocialImageDescriptor>;
     videos?: Array<{ url: string | URL; width?: number; height?: number }>;
     audio?: Array<{ url: string | URL }>;
     locale?: string;
@@ -162,15 +155,7 @@ export type Metadata = {
     siteId?: string;
     title?: string;
     description?: string;
-    images?:
-      | string
-      | URL
-      | { url: string | URL; alt?: string; width?: number; height?: number; type?: string }
-      | Array<
-          | string
-          | URL
-          | { url: string | URL; alt?: string; width?: number; height?: number; type?: string }
-        >;
+    images?: string | URL | SocialImageDescriptor | Array<string | URL | SocialImageDescriptor>;
     creator?: string;
     creatorId?: string;
     players?: TwitterPlayerDescriptor | TwitterPlayerDescriptor[];
@@ -264,6 +249,14 @@ type TwitterAppDescriptor = {
     googleplay?: string | URL;
   };
   name?: string;
+};
+
+type SocialImageDescriptor = {
+  url: string | URL;
+  alt?: string;
+  width?: number;
+  height?: number;
+  type?: string;
 };
 
 type IconDescriptor = {
@@ -601,7 +594,132 @@ function normalizeUrlDescriptorEntries<T extends { url: string | URL }>(
   return [normalizeUrlDescriptor(value, createDescriptor)];
 }
 
-export function MetadataHead({ metadata }: { metadata: Metadata }) {
+function stringifyUrl(url: string | URL): string {
+  return typeof url === "string" ? url : url.toString();
+}
+
+function createLocalMetadataBase(): URL {
+  const protocol = process.env.__NEXT_EXPERIMENTAL_HTTPS ? "https" : "http";
+  return new URL(`${protocol}://localhost:${process.env.PORT || 3000}`);
+}
+
+function getPreviewDeploymentUrl(): URL | null {
+  const origin = process.env.VERCEL_BRANCH_URL || process.env.VERCEL_URL;
+  return origin ? new URL(`https://${origin}`) : null;
+}
+
+function getProductionDeploymentUrl(): URL | null {
+  const origin = process.env.VERCEL_PROJECT_PRODUCTION_URL;
+  return origin ? new URL(`https://${origin}`) : null;
+}
+
+function getSocialImageMetadataBaseFallback(metadataBase: URL | null | undefined): URL {
+  const defaultMetadataBase = createLocalMetadataBase();
+  const previewDeploymentUrl = getPreviewDeploymentUrl();
+  const productionDeploymentUrl = getProductionDeploymentUrl();
+
+  if (process.env.NODE_ENV === "development") {
+    return defaultMetadataBase;
+  }
+
+  if (previewDeploymentUrl) {
+    return previewDeploymentUrl;
+  }
+
+  return metadataBase || productionDeploymentUrl || defaultMetadataBase;
+}
+
+function trimSlashes(value: string): string {
+  return value.replace(/^\/+|\/+$/g, "");
+}
+
+function joinMetadataPath(basePathname: string, pathname: string): string {
+  if (!basePathname || basePathname === "/") {
+    return pathname;
+  }
+
+  const base = trimSlashes(basePathname);
+  const path = trimSlashes(pathname);
+  return path ? `/${base}/${path}` : `/${base}`;
+}
+
+function resolveRelativeMetadataUrl(url: string, pathname: string): string {
+  if (url === "." || url === "./") {
+    return pathname || "/";
+  }
+  if (!url.startsWith("./")) {
+    return url;
+  }
+
+  const base = pathname === "/" ? "" : pathname.replace(/\/+$/g, "");
+  return `${base}/${url.slice(2)}`;
+}
+
+function formatResolvedMetadataUrl(url: URL): string {
+  if (url.pathname === "/" && url.search === "" && url.hash === "") {
+    return url.origin;
+  }
+  return url.href;
+}
+
+function resolveMetadataUrl(url: string | URL, metadataBase: URL | null | undefined): string {
+  const value = stringifyUrl(url);
+  if (isAbsoluteOrProtocolRelativeUrl(value) || !metadataBase) {
+    return value;
+  }
+
+  try {
+    return formatResolvedMetadataUrl(
+      new URL(joinMetadataPath(metadataBase.pathname, value), metadataBase),
+    );
+  } catch {
+    return value;
+  }
+}
+
+function resolveCanonicalUrl(
+  url: string | URL,
+  metadataBase: URL | null | undefined,
+  pathname: string,
+): string {
+  if (url instanceof URL) {
+    return resolveMetadataUrl(url, metadataBase);
+  }
+  return resolveMetadataUrl(resolveRelativeMetadataUrl(url, pathname), metadataBase);
+}
+
+function isSocialImageDescriptor(
+  value: string | URL | SocialImageDescriptor,
+): value is SocialImageDescriptor {
+  return typeof value === "object" && !(value instanceof URL);
+}
+
+function isMetadataRouteSocialImage(value: SocialImageDescriptor): boolean {
+  return Reflect.get(value, "metadataRoute") === true;
+}
+
+function resolveSocialImageUrl(
+  image: string | URL | SocialImageDescriptor,
+  metadataBase: URL | null | undefined,
+): string {
+  const imageUrl = isSocialImageDescriptor(image) ? image.url : image;
+  const metadataRoute = isSocialImageDescriptor(image) && isMetadataRouteSocialImage(image);
+  if (
+    typeof imageUrl === "string" &&
+    !isAbsoluteOrProtocolRelativeUrl(imageUrl) &&
+    (!metadataBase || metadataRoute)
+  ) {
+    return resolveMetadataUrl(imageUrl, getSocialImageMetadataBaseFallback(metadataBase));
+  }
+  return resolveMetadataUrl(imageUrl, metadataBase);
+}
+
+type MetadataHeadProps = {
+  metadata: Metadata;
+  pathname?: string;
+};
+
+export function MetadataHead({ metadata, pathname = "/" }: MetadataHeadProps) {
   const elements: React.ReactElement[] = [];
   let key = 0;
 
@@ -611,15 +729,7 @@ export function MetadataHead({ metadata }: { metadata: Metadata }) {
   function resolveUrl(url: string | URL | undefined): string | undefined;
   function resolveUrl(url: string | URL | undefined): string | undefined {
     if (!url) return undefined;
-    // Coerce URL objects to strings (Next.js metadata allows string | URL)
-    const s = typeof url === "string" ? url : url instanceof URL ? url.toString() : String(url);
-    if (!base) return s;
-    if (s.startsWith("http://") || s.startsWith("https://") || s.startsWith("//")) return s;
-    try {
-      return new URL(s, base).toString();
-    } catch {
-      return s;
-    }
+    return resolveMetadataUrl(url, base);
   }
 
   // Title
@@ -764,8 +874,9 @@ export function MetadataHead({ metadata }: { metadata: Metadata }) {
             ? og.images
             : [og.images];
       for (const img of imgList) {
-        const imgUrl = typeof img === "string" || img instanceof URL ? img : img.url;
-        elements.push(<meta key={key++} property="og:image" content={resolveUrl(imgUrl)} />);
+        elements.push(
+          <meta key={key++} property="og:image" content={resolveSocialImageUrl(img, base)} />,
+        );
         if (typeof img !== "string" && !(img instanceof URL)) {
           if (img.width)
             elements.push(
@@ -822,8 +933,9 @@ export function MetadataHead({ metadata }: { metadata: Metadata }) {
             ? tw.images
             : [tw.images];
       for (const img of imgList) {
-        const imgUrl = typeof img === "string" || img instanceof URL ? img : img.url;
-        elements.push(<meta key={key++} name="twitter:image" content={resolveUrl(imgUrl)} />);
+        elements.push(
+          <meta key={key++} name="twitter:image" content={resolveSocialImageUrl(img, base)} />,
+        );
         if (typeof img !== "string" && !(img instanceof URL)) {
           if (img.type) {
             elements.push(<meta key={key++} name="twitter:image:type" content={img.type} />);
@@ -954,14 +1066,20 @@ export function MetadataHead({ metadata }: { metadata: Metadata }) {
 
   // Manifest
   if (metadata.manifest) {
-    elements.push(<link key={key++} rel="manifest" href={resolveUrl(metadata.manifest)} />);
+    elements.push(<link key={key++} rel="manifest" href={stringifyUrl(metadata.manifest)} />);
   }
 
   // Alternates
   if (metadata.alternates) {
     const alt = metadata.alternates;
     if (alt.canonical) {
-      elements.push(<link key={key++} rel="canonical" href={resolveUrl(alt.canonical)} />);
+      elements.push(
+        <link
+          key={key++}
+          rel="canonical"
+          href={resolveCanonicalUrl(alt.canonical, base, pathname)}
+        />,
+      );
     }
     if (alt.languages) {
       for (const [lang, href] of Object.entries(alt.languages)) {

--- a/packages/vinext/src/shims/metadata.tsx
+++ b/packages/vinext/src/shims/metadata.tsx
@@ -622,7 +622,11 @@ function getSocialImageMetadataBaseFallback(metadataBase: URL | null | undefined
     return defaultMetadataBase;
   }
 
-  if (previewDeploymentUrl) {
+  if (
+    process.env.NODE_ENV === "production" &&
+    process.env.VERCEL_ENV === "preview" &&
+    previewDeploymentUrl
+  ) {
     return previewDeploymentUrl;
   }
 

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -3297,6 +3297,14 @@ describe("metadata routes integration (App Router)", () => {
     expect(data.display).toBe("standalone");
   });
 
+  it("serves sitemap routes that import but do not render client references", async () => {
+    // Ported from Next.js: test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
+    const res = await fetch(`${baseUrl}/client-ref-dependency/sitemap.xml`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("application/xml");
+  });
+
   // Note: serving /icon from dynamic icon.tsx requires the RSC environment
   // to have access to Satori + Resvg Node APIs. This works when the RSC env
   // has proper Node externals configured. The discovery/routing is tested below.

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -2492,6 +2492,28 @@ describe("MetadataHead rendering", () => {
     renderToStaticMarkup = (await import("react-dom/server")).renderToStaticMarkup;
   });
 
+  function metadataRouteImage(url: string): { url: string } {
+    const image = { url };
+    Object.defineProperty(image, "metadataRoute", { value: true });
+    return image;
+  }
+
+  function renderStaticSocialImagesMetadata(metadataBase: URL | null): string {
+    return renderToStaticMarkup(
+      React.createElement(MetadataHead, {
+        metadata: {
+          metadataBase,
+          openGraph: {
+            images: [metadataRouteImage("/metadata-base/unset/opengraph-image2/100")],
+          },
+          twitter: {
+            images: metadataRouteImage("/metadata-base/unset/twitter-image.png"),
+          },
+        },
+      }),
+    );
+  }
+
   it("renders generator meta tag", () => {
     const html = renderToStaticMarkup(
       React.createElement(MetadataHead, { metadata: { generator: "Next.js" } }),
@@ -2715,24 +2737,7 @@ describe("MetadataHead rendering", () => {
     withEnvVar("NODE_ENV", "production", () => {
       withEnvVar("PORT", "4567", () => {
         withEnvVar("VERCEL_PROJECT_PRODUCTION_URL", undefined, () => {
-          const openGraphImage = { url: "/metadata-base/unset/opengraph-image2/100" };
-          const twitterImage = { url: "/metadata-base/unset/twitter-image.png" };
-          Object.defineProperty(openGraphImage, "metadataRoute", { value: true });
-          Object.defineProperty(twitterImage, "metadataRoute", { value: true });
-
-          const html = renderToStaticMarkup(
-            React.createElement(MetadataHead, {
-              metadata: {
-                metadataBase: null,
-                openGraph: {
-                  images: [openGraphImage],
-                },
-                twitter: {
-                  images: twitterImage,
-                },
-              },
-            }),
-          );
+          const html = renderStaticSocialImagesMetadata(null);
 
           expect(html).toContain(
             'content="http://localhost:4567/metadata-base/unset/opengraph-image2/100"',
@@ -2740,6 +2745,68 @@ describe("MetadataHead rendering", () => {
           expect(html).toContain(
             'content="http://localhost:4567/metadata-base/unset/twitter-image.png"',
           );
+        });
+      });
+    });
+  });
+
+  it("lets configured metadataBase win over non-preview deployment urls for static metadata route images", () => {
+    withEnvVar("NODE_ENV", "production", () => {
+      withEnvVar("VERCEL_URL", "my-deployment.vercel.app", () => {
+        withEnvVar("VERCEL_ENV", "production", () => {
+          const html = renderStaticSocialImagesMetadata(new URL("https://mydomain.com"));
+
+          expect(html).toContain(
+            'content="https://mydomain.com/metadata-base/unset/opengraph-image2/100"',
+          );
+          expect(html).not.toContain("my-deployment.vercel.app");
+        });
+      });
+    });
+  });
+
+  it("lets configured metadataBase win over deployment urls when VERCEL_ENV is unset", () => {
+    withEnvVar("NODE_ENV", "production", () => {
+      withEnvVar("VERCEL_URL", "my-deployment.vercel.app", () => {
+        withEnvVar("VERCEL_ENV", undefined, () => {
+          const html = renderStaticSocialImagesMetadata(new URL("https://mydomain.com"));
+
+          expect(html).toContain(
+            'content="https://mydomain.com/metadata-base/unset/opengraph-image2/100"',
+          );
+          expect(html).not.toContain("my-deployment.vercel.app");
+        });
+      });
+    });
+  });
+
+  it("uses preview deployment urls for static metadata route images in Vercel preview", () => {
+    withEnvVar("NODE_ENV", "production", () => {
+      withEnvVar("VERCEL_BRANCH_URL", "branch-preview.vercel.app", () => {
+        withEnvVar("VERCEL_ENV", "preview", () => {
+          const html = renderStaticSocialImagesMetadata(new URL("https://mydomain.com"));
+
+          expect(html).toContain(
+            'content="https://branch-preview.vercel.app/metadata-base/unset/opengraph-image2/100"',
+          );
+          expect(html).not.toContain("https://mydomain.com/metadata-base/unset");
+        });
+      });
+    });
+  });
+
+  it("uses production deployment urls as fallback when metadataBase is unset", () => {
+    withEnvVar("NODE_ENV", "production", () => {
+      withEnvVar("VERCEL_PROJECT_PRODUCTION_URL", "project-production.vercel.app", () => {
+        withEnvVar("VERCEL_URL", "my-deployment.vercel.app", () => {
+          withEnvVar("VERCEL_ENV", "production", () => {
+            const html = renderStaticSocialImagesMetadata(null);
+
+            expect(html).toContain(
+              'content="https://project-production.vercel.app/metadata-base/unset/opengraph-image2/100"',
+            );
+            expect(html).not.toContain("my-deployment.vercel.app");
+          });
         });
       });
     });

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -23,6 +23,7 @@ import {
   requestNodeServerWithHost,
   startFixtureServer,
 } from "./helpers.js";
+import { withEnvVar } from "./env-test-helpers.js";
 import { createValidFileMatcher } from "../packages/vinext/src/routing/file-matcher.js";
 
 const FIXTURE_DIR = PAGES_FIXTURE_DIR;
@@ -2677,6 +2678,71 @@ describe("MetadataHead rendering", () => {
     );
     expect(html).toContain('href="https://acme.com/about"');
     expect(html).toContain('content="https://acme.com/og.png"');
+  });
+
+  it("normalizes root canonical metadataBase URLs without a trailing slash", () => {
+    // Ported from Next.js: test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
+    const html = renderToStaticMarkup(
+      React.createElement(MetadataHead, {
+        metadata: {
+          metadataBase: new URL("https://mydomain.com"),
+          alternates: { canonical: "./" },
+        },
+        pathname: "/",
+      }),
+    );
+
+    expect(html).toContain('rel="canonical"');
+    expect(html).toContain('href="https://mydomain.com"');
+  });
+
+  it("keeps manifest metadata routes relative when metadataBase is configured", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(MetadataHead, {
+        metadata: {
+          metadataBase: new URL("https://mydomain.com"),
+          manifest: "/manifest.webmanifest",
+        },
+      }),
+    );
+
+    expect(html).toContain('rel="manifest"');
+    expect(html).toContain('href="/manifest.webmanifest"');
+  });
+
+  it("uses social image fallback metadataBase for static metadata route images", () => {
+    withEnvVar("NODE_ENV", "production", () => {
+      withEnvVar("PORT", "4567", () => {
+        withEnvVar("VERCEL_PROJECT_PRODUCTION_URL", undefined, () => {
+          const openGraphImage = { url: "/metadata-base/unset/opengraph-image2/100" };
+          const twitterImage = { url: "/metadata-base/unset/twitter-image.png" };
+          Object.defineProperty(openGraphImage, "metadataRoute", { value: true });
+          Object.defineProperty(twitterImage, "metadataRoute", { value: true });
+
+          const html = renderToStaticMarkup(
+            React.createElement(MetadataHead, {
+              metadata: {
+                metadataBase: null,
+                openGraph: {
+                  images: [openGraphImage],
+                },
+                twitter: {
+                  images: twitterImage,
+                },
+              },
+            }),
+          );
+
+          expect(html).toContain(
+            'content="http://localhost:4567/metadata-base/unset/opengraph-image2/100"',
+          );
+          expect(html).toContain(
+            'content="http://localhost:4567/metadata-base/unset/twitter-image.png"',
+          );
+        });
+      });
+    });
   });
 
   it("accepts URL objects for canonical and openGraph.url", () => {

--- a/tests/fixtures/app-basic/app/client-ref-dependency/client-component.tsx
+++ b/tests/fixtures/app-basic/app/client-ref-dependency/client-component.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+import React from "react";
+
+function ClientComponent() {
+  const [state] = React.useState("component");
+  return <div>{`client-${state}`}</div>;
+}
+
+export const clientRef = <ClientComponent />;

--- a/tests/fixtures/app-basic/app/client-ref-dependency/sitemap.tsx
+++ b/tests/fixtures/app-basic/app/client-ref-dependency/sitemap.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { clientRef } from "./client-component";
+
+export const contentType = "image/png";
+const cachedNoop = React.cache(() => null);
+
+function noopCall(value: unknown) {
+  return value;
+}
+
+export default function sitemap() {
+  // Keep the variable from being tree-shaken, matching the upstream fixture.
+  noopCall(clientRef);
+  cachedNoop();
+  return [];
+}

--- a/tests/metadata-route-response.test.ts
+++ b/tests/metadata-route-response.test.ts
@@ -357,6 +357,33 @@ describe("handleMetadataRouteRequest", () => {
     expect(await response?.text()).toBe("image:post-small");
   });
 
+  it("sets metadata cache control on dynamic image route Response results", async () => {
+    // Ported from Next.js: test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
+    const route = {
+      type: "opengraph-image",
+      isDynamic: true,
+      filePath: "/tmp/app/opengraph-image.tsx",
+      routePrefix: "",
+      routeSegments: [],
+      servedUrl: "/opengraph-image",
+      contentType: "image/png",
+      module: {
+        default: () => new Response("image", { headers: { "Content-Type": "image/png" } }),
+      },
+    } satisfies MetadataFileRoute;
+
+    const response = await handleMetadataRouteRequest({
+      metadataRoutes: [route],
+      cleanPathname: "/opengraph-image",
+      makeThenableParams,
+    });
+
+    expect(response?.status).toBe(200);
+    expect(response?.headers.get("content-type")).toBe("image/png");
+    expect(response?.headers.get("cache-control")).toBe("public, max-age=0, must-revalidate");
+  });
+
   it("returns 404 for unknown or invalid generated image ids", async () => {
     const route = {
       type: "icon",

--- a/tests/metadata-route-response.test.ts
+++ b/tests/metadata-route-response.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vite-plus/test";
 import { handleMetadataRouteRequest } from "../packages/vinext/src/server/metadata-route-response.js";
 import type { MetadataFileRoute } from "../packages/vinext/src/server/metadata-routes.js";
+import { withEnvVar } from "./env-test-helpers.js";
 
 type MetadataRuntimeRoute = MetadataFileRoute & {
   fileDataBase64?: string;
@@ -64,6 +65,30 @@ describe("handleMetadataRouteRequest", () => {
     expect(
       Array.from(new Uint8Array((await response?.arrayBuffer()) ?? new ArrayBuffer(0))),
     ).toEqual([105, 99, 111, 110, 45, 98, 121, 116, 101, 115]);
+  });
+
+  it("keeps static image metadata route cache control stable in development", async () => {
+    await withEnvVar("NODE_ENV", "development", async () => {
+      const route = {
+        type: "apple-icon",
+        isDynamic: false,
+        filePath: "/tmp/app/apple-icon.png",
+        routePrefix: "",
+        routeSegments: [],
+        servedUrl: "/apple-icon.png",
+        contentType: "image/png",
+        fileDataBase64: btoa("icon-bytes"),
+      } satisfies MetadataRuntimeRoute;
+
+      const response = await handleMetadataRouteRequest({
+        metadataRoutes: [route],
+        cleanPathname: "/apple-icon.png",
+        makeThenableParams,
+      });
+
+      expect(response?.status).toBe(200);
+      expect(response?.headers.get("cache-control")).toBe("public, max-age=0, must-revalidate");
+    });
   });
 
   it("caches metadata route module function lookups", async () => {

--- a/tests/metadata-routes.test.ts
+++ b/tests/metadata-routes.test.ts
@@ -10,7 +10,10 @@ import { describe, it, expect, beforeEach, afterEach } from "vite-plus/test";
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
-import { resolveSitemap as nextResolveSitemap } from "next/dist/build/webpack/loaders/metadata/resolve-route-data.js";
+import {
+  resolveRobots as nextResolveRobots,
+  resolveSitemap as nextResolveSitemap,
+} from "next/dist/build/webpack/loaders/metadata/resolve-route-data.js";
 import {
   sitemapToXml,
   robotsToText,
@@ -29,6 +32,12 @@ import {
 // several edge cases are surprising but observable in Next itself.
 function expectSitemapToMatchNext(entries: SitemapEntry[]): void {
   expect(sitemapToXml(entries)).toBe(nextResolveSitemap(entries));
+}
+
+type NextRobotsConfig = Parameters<typeof nextResolveRobots>[0];
+
+function expectRobotsToMatchNext(config: RobotsConfig & NextRobotsConfig): void {
+  expect(robotsToText(config)).toBe(nextResolveRobots(config));
 }
 
 describe("matchMetadataRoutePattern", () => {
@@ -635,6 +644,33 @@ describe("robotsToText", () => {
     expect(txt).toContain("Host: example.com");
   });
 
+  it("emits Host before Sitemap like Next.js dynamic robots routes", () => {
+    // Ported from Next.js: test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
+    const config = {
+      rules: [
+        { userAgent: "Googlebot", allow: "/" },
+        { userAgent: ["Applebot", "Bingbot"], disallow: "/", crawlDelay: 2 },
+      ],
+      host: "https://example.com",
+      sitemap: "https://example.com/sitemap.xml",
+    } satisfies RobotsConfig;
+
+    expectRobotsToMatchNext(config);
+    expect(robotsToText(config)).toBe(
+      "User-Agent: Googlebot\n" +
+        "Allow: /\n" +
+        "\n" +
+        "User-Agent: Applebot\n" +
+        "User-Agent: Bingbot\n" +
+        "Disallow: /\n" +
+        "Crawl-delay: 2\n" +
+        "\n" +
+        "Host: https://example.com\n" +
+        "Sitemap: https://example.com/sitemap.xml\n",
+    );
+  });
+
   it("defaults user agent to *", () => {
     const config: RobotsConfig = {
       rules: { allow: "/" },
@@ -853,6 +889,15 @@ describe("scanMetadataFiles", () => {
     expect(icon).toBeDefined();
     expect(icon!.isDynamic).toBe(true);
     expect(icon!.servedUrl).toBe("/icon");
+  });
+
+  it("discovers dynamic sitemap.tsx routes", () => {
+    createFile("blog/sitemap.tsx");
+    const routes = scanMetadataFiles(tmpDir);
+    const sitemap = routes.find((r) => r.type === "sitemap");
+    expect(sitemap).toBeDefined();
+    expect(sitemap!.isDynamic).toBe(true);
+    expect(sitemap!.servedUrl).toBe("/blog/sitemap.xml");
   });
 
   it("discovers static icon.png at root", () => {


### PR DESCRIPTION
## Overview

| Field | Details |
| --- | --- |
| Goal | Bring App Router dynamic metadata routes closer to Next.js behavior for the failing `metadata-dynamic-routes` cases. |
| Core change | Align metadata route discovery, robots serialization, dynamic route cache headers, and rendered metadata URL resolution. |
| Main boundary | Metadata route scanning and response shaping stay in `server/*`; rendered head URL semantics stay in the metadata shim. |
| Primary files | `metadata-routes.ts`, `metadata-route-response.ts`, `metadata.tsx`, `file-based-metadata.ts`, app page head wiring. |
| Expected impact | Existing metadata routes keep working, with additional Next-compatible TSX/JSX discovery and corrected head URL output. |

## Why

Metadata routes are framework-owned routes, so vinext has to apply Next's route discovery, response headers, and rendered URL rules even when userland handlers return plain `Response` objects or file-based metadata contributes head entries.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| Route discovery | Dynamic metadata route files use configured page extensions in Next. | Accepts `.tsx`, `.ts`, `.jsx`, and `.js` for dynamic metadata routes, including `sitemap.tsx`. |
| Route responses | The metadata route loader owns default cache headers. | Adds default `Cache-Control` to handler-returned metadata `Response`s without overriding user-set headers. |
| Robots output | Serialized route data should match Next's observable text. | Emits `Host` before `Sitemap`. |
| Head URLs | Canonical, manifest, and social image URLs are not the same class of metadata URL. | Canonical root URLs drop the trailing slash, manifest route hrefs remain relative, and file-based social images use Next's fallback metadata base rules. |

## What Changed

| Scenario | Before | After |
| --- | --- | --- |
| `app/foo/sitemap.tsx` | Not discovered, so `/foo/sitemap.xml` 404ed. | Discovered and served as a dynamic sitemap route. |
| `robots.ts` with `host` and `sitemap` | `Sitemap` appeared before `Host`. | Output matches Next's `Host` then `Sitemap` ordering. |
| Dynamic image metadata route returning `Response` | Missing framework `Cache-Control` unless handler set it. | Gets Next-style metadata route cache headers by default. |
| `metadataBase: new URL("https://mydomain.com")` and canonical `./` at `/` | Rendered `https://mydomain.com/`. | Renders `https://mydomain.com`. |
| File-based social image routes with no `metadataBase` | Stayed relative. | Resolve through localhost or deployment fallback like Next. |
| Manifest metadata route with `metadataBase` | Became absolute. | Stays relative. |

## Maintainer Review Path

<details>
<summary>Suggested review order</summary>

1. `packages/vinext/src/server/metadata-routes.ts`
   - Verify extension parity and robots serialization order.
2. `packages/vinext/src/server/metadata-route-response.ts`
   - Check cache header ownership and preservation of handler-set headers.
3. `packages/vinext/src/shims/metadata.tsx`
   - Review URL class separation for canonical, generic metadata URLs, manifest, and social images.
4. `packages/vinext/src/server/file-based-metadata.ts`
   - Check the non-enumerable internal marker for file-based social image routes.
5. `packages/vinext/src/server/app-page-*.ts(x)`
   - Confirm actual request pathname is threaded into metadata head rendering.
6. Tests
   - Review the ported Next.js regression cases and focused lower-boundary assertions.

</details>

## Validation

<details>
<summary>Commands run</summary>

- `vp check`
- `vp test run tests/metadata-routes.test.ts tests/metadata-route-response.test.ts tests/file-based-metadata.test.ts tests/features.test.ts -t "Host before Sitemap|discovers dynamic sitemap.tsx routes|metadata cache control|root canonical|manifest metadata routes|social image fallback|leaf file image|leaf Twitter file image|dynamic metadata module exports|multiple generateImageMetadata"`
- `vp test run tests/app-router.test.ts -t "serves sitemap routes that import but do not render client references|serves /sitemap.xml from dynamic sitemap.ts|serves /robots.txt from dynamic robots.ts|serves /manifest.webmanifest from dynamic manifest.ts|serves dynamic opengraph-image in dynamic segment with params|serves dynamic icon routes generated by generateImageMetadata|injects dynamic metadata image routes into the head|injects multiple generateImageMetadata icon routes into the head"`
- `vp test run tests/file-based-metadata.test.ts`
- `vp test run tests/metadata-route-response.test.ts`
- `vp test run tests/metadata-routes.test.ts tests/features.test.ts tests/app-page-route-wiring.test.ts tests/app-page-element-builder.test.ts`

</details>

## Risk / Compatibility

<details>
<summary>Relevant risks</summary>

- Public API: no new public metadata field is introduced. The metadata-route social image marker is non-enumerable and read only as an internal runtime signal.
- Route discovery: accepting `.jsx` and `.tsx` broadens dynamic metadata route support to match Next's default page extensions.
- Cache headers: user-provided `Cache-Control` remains authoritative because the default is only added when absent.
- URL rendering: generic metadata URLs still use `metadataBase`; manifest and file-based social image routes now follow their separate Next semantics.

</details>

## Non-Goals

<details>
<summary>Out of scope</summary>

- Full metadata resolver parity beyond the failing dynamic metadata route cases.
- Custom `pageExtensions` configuration for metadata route discovery.
- Reworking the metadata shim into a separate resolver module.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| [Next `is-metadata-route.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/lib/metadata/is-metadata-route.ts) | Shows metadata route matching uses default/page extensions including `tsx` and `jsx`. |
| [Next `create-app-route-code.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/build/webpack/loaders/next-app-loader/create-app-route-code.ts) | Shows metadata route files are wrapped through the metadata route loader. |
| [Next `next-metadata-route-loader.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/build/webpack/loaders/next-metadata-route-loader.ts) | Owns metadata route response construction and default cache headers. |
| [Next `resolve-route-data.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/build/webpack/loaders/metadata/resolve-route-data.ts) | Defines robots and sitemap serialization behavior. |
| [Next `resolve-url.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/lib/metadata/resolvers/resolve-url.ts) | Defines metadata URL fallback behavior, including localhost/deployment fallbacks. |
| [Next `resolve-opengraph.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/lib/metadata/resolvers/resolve-opengraph.ts) | Applies social image metadataBase fallback for relative and static metadata route images. |
| [Next metadata-dynamic-routes test](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/metadata-dynamic-routes/index.test.ts) | Source of the parity regressions covered by this PR. |
