### PR TITLE
fix(app-router): prerender layout static params

### DIFF
--- a/packages/vinext/src/build/prerender.ts
+++ b/packages/vinext/src/build/prerender.ts
@@ -425,6 +425,8 @@ export async function resolveParentParams(
 
     for (const parentParams of currentParams) {
       const results = await generateStaticParams({ params: parentParams });
+      // `null` is the CF Workers Proxy sentinel: the proxy has no
+      // generateStaticParams for this pattern. Skip and let later providers run.
       if (results === null) continue;
       if (!Array.isArray(results)) return [];
 

--- a/packages/vinext/src/build/prerender.ts
+++ b/packages/vinext/src/build/prerender.ts
@@ -369,11 +369,7 @@ export function getOutputPath(urlPath: string, trailingSlash: boolean): string {
 /** Map of route patterns to generateStaticParams functions (or null/undefined). */
 export type StaticParamsMap = Record<
   string,
-  | ((opts: {
-      params: Record<string, string | string[]>;
-    }) => Promise<Record<string, string | string[]>[]>)
-  | null
-  | undefined
+  ((opts: { params: Record<string, string | string[]> }) => Promise<unknown>) | null | undefined
 >;
 
 /**
@@ -385,7 +381,6 @@ export type StaticParamsMap = Record<
  */
 export async function resolveParentParams(
   childRoute: AppRoute,
-  routeIndex: ReadonlyMap<string, AppRoute>,
   staticParamsMap: StaticParamsMap,
 ): Promise<Record<string, string | string[]>[]> {
   const { patternParts } = childRoute;
@@ -403,7 +398,7 @@ export async function resolveParentParams(
 
   type GenerateStaticParamsFn = (opts: {
     params: Record<string, string | string[]>;
-  }) => Promise<Record<string, string | string[]>[]>;
+  }) => Promise<unknown>;
 
   const parentSegments: GenerateStaticParamsFn[] = [];
 
@@ -413,38 +408,39 @@ export async function resolveParentParams(
     prefixPattern += "/" + part;
     if (!part.startsWith(":")) continue;
 
-    const parentRoute = routeIndex.get(prefixPattern);
-    // TODO: layout-level generateStaticParams — a layout segment can define
-    // generateStaticParams without a corresponding page file, so parentRoute
-    // may be undefined here even though the layout exports generateStaticParams.
-    // resolveParentParams currently only looks up routes that have a pagePath
-    // (i.e. leaf pages), missing layout-level providers. Fix requires scanning
-    // layout files in addition to page files during route collection.
-    if (parentRoute?.pagePath) {
-      const fn = staticParamsMap[prefixPattern];
-      if (typeof fn === "function") {
-        parentSegments.push(fn);
-      }
+    const fn = staticParamsMap[prefixPattern];
+    if (typeof fn === "function") {
+      parentSegments.push(fn);
     }
   }
 
   if (parentSegments.length === 0) return [];
 
   let currentParams: Record<string, string | string[]>[] = [{}];
+  let resolvedAnyParent = false;
+
   for (const generateStaticParams of parentSegments) {
     const nextParams: Record<string, string | string[]>[] = [];
+    let resolvedThisParent = false;
+
     for (const parentParams of currentParams) {
       const results = await generateStaticParams({ params: parentParams });
-      if (Array.isArray(results)) {
-        for (const result of results) {
-          nextParams.push({ ...parentParams, ...result });
-        }
+      if (results === null) continue;
+      if (!Array.isArray(results)) return [];
+
+      resolvedThisParent = true;
+      resolvedAnyParent = true;
+      for (const result of results) {
+        nextParams.push({ ...parentParams, ...result });
       }
     }
-    currentParams = nextParams;
+
+    if (resolvedThisParent) {
+      currentParams = nextParams;
+    }
   }
 
-  return currentParams;
+  return resolvedAnyParent ? currentParams : [];
 }
 
 // ─── Pages Router Prerender ───────────────────────────────────────────────────
@@ -962,8 +958,6 @@ export async function prerenderApp({
       },
     });
 
-    const routeIndex = new Map(routes.map((r) => [r.pattern, r]));
-
     // ── Collect URLs to render ────────────────────────────────────────────────
     type UrlToRender = {
       urlPath: string;
@@ -1048,7 +1042,7 @@ export async function prerenderApp({
             continue;
           }
 
-          const parentParamSets = await resolveParentParams(route, routeIndex, staticParamsMap);
+          const parentParamSets = await resolveParentParams(route, staticParamsMap);
           let paramSets: Record<string, string | string[]>[] | null;
 
           if (parentParamSets.length > 0) {
@@ -1067,10 +1061,14 @@ export async function prerenderApp({
                     ...childParams,
                   });
                 }
+              } else {
+                paramSets = [];
+                break;
               }
             }
           } else {
-            paramSets = await generateStaticParamsFn({ params: {} });
+            const results = await generateStaticParamsFn({ params: {} });
+            paramSets = Array.isArray(results) || results === null ? results : [];
           }
 
           // null: route has no generateStaticParams (CF Workers Proxy returned null)

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -75,6 +75,10 @@ const appRscErrorHandlerPath = resolveEntryPath(
   import.meta.url,
 );
 const appRequestContextPath = resolveEntryPath("../server/app-request-context.js", import.meta.url);
+const appPrerenderStaticParamsPath = resolveEntryPath(
+  "../server/app-prerender-static-params.js",
+  import.meta.url,
+);
 const appHookWarningSuppressionPath = resolveEntryPath(
   "../server/app-hook-warning-suppression.js",
   import.meta.url,
@@ -165,6 +169,7 @@ export function generateRscEntry(
     routeEntries,
     metaRouteEntries,
     generateStaticParamsEntries,
+    rootParamNameEntries,
     rootNotFoundVar,
     rootForbiddenVar,
     rootUnauthorizedVar,
@@ -276,6 +281,7 @@ ${hasPagesDir ? `// Pages Router routes are loaded lazily from the SSR environme
 // so per-route dispatch can opt into suppression via .run(true, ...).
 import { suppressHookWarningAls } from ${JSON.stringify(appHookWarningSuppressionPath)};
 import { clearAppRequestContext as __clearRequestContext, setAppNavigationContext as setNavigationContext } from ${JSON.stringify(appRequestContextPath)};
+import { createAppPrerenderStaticParamsResolver as __createAppPrerenderStaticParamsResolver } from ${JSON.stringify(appPrerenderStaticParamsPath)};
 
 // Note: cache entries are written with \`headers: undefined\`. Next.js stores
 // response headers (e.g. set-cookie from cookies().set() during render) in the
@@ -451,18 +457,10 @@ var __MAX_ACTION_BODY_SIZE = ${JSON.stringify(bodySizeLimit)};
 // Used by the prerender phase to enumerate dynamic route URLs without
 // loading route modules via the dev server.
 export const generateStaticParamsMap = {
-// TODO: layout-level generateStaticParams — this map only includes routes that
-// have a pagePath (leaf pages). Layout segments can also export generateStaticParams
-// to provide parent params for nested dynamic routes, but they don't have a pagePath
-// so they are excluded here. Supporting layout-level generateStaticParams requires
-// scanning layout.tsx files separately and including them in this map.
 ${generateStaticParamsEntries.join("\n")}
 };${loadPrerenderPagesRoutesCode}
 const rootParamNamesMap = {
-${routes
-  .filter((r) => r.isDynamic && r.pagePath && r.rootParamNames && r.rootParamNames.length > 0)
-  .map((r) => `  ${JSON.stringify(r.pattern)}: ${JSON.stringify(r.rootParamNames)},`)
-  .join("\n")}
+${rootParamNameEntries.join("\n")}
 };
 
 export default __createAppRscHandler({

--- a/packages/vinext/src/entries/app-rsc-manifest.ts
+++ b/packages/vinext/src/entries/app-rsc-manifest.ts
@@ -1,4 +1,4 @@
-import type { AppRoute } from "../routing/app-router.js";
+import { convertSegmentsToRouteParts, type AppRoute } from "../routing/app-router.js";
 import { createMetadataRouteEntriesSource } from "../server/metadata-route-build-data.js";
 import type { MetadataFileRoute } from "../server/metadata-routes.js";
 import { normalizePathSeparators } from "./runtime-entry-module.js";
@@ -8,6 +8,7 @@ type AppRscManifestCode = {
   routeEntries: string[];
   metaRouteEntries: string[];
   generateStaticParamsEntries: string[];
+  rootParamNameEntries: string[];
   rootNotFoundVar: string | null;
   rootForbiddenVar: string | null;
   rootUnauthorizedVar: string | null;
@@ -188,15 +189,100 @@ ${slotEntries.join(",\n")}
   });
 }
 
+type RoutePatternPrefix = {
+  pattern: string;
+  paramNames: string[];
+};
+
+function createRoutePatternPrefix(
+  routeSegments: readonly string[],
+  treePosition: number,
+): RoutePatternPrefix | null {
+  const limit = Math.max(0, Math.min(treePosition, routeSegments.length));
+  const converted = convertSegmentsToRouteParts(routeSegments.slice(0, limit));
+  if (!converted) return null;
+
+  return {
+    pattern: converted.urlSegments.length === 0 ? "/" : `/${converted.urlSegments.join("/")}`,
+    paramNames: converted.params,
+  };
+}
+
+function appendStaticParamSource(
+  sourcesByPattern: Map<string, string[]>,
+  pattern: string | null,
+  sourceVar: string,
+): void {
+  if (!pattern || pattern === "/" || !pattern.includes(":")) return;
+  const sources = sourcesByPattern.get(pattern) ?? [];
+  // ImportAllocator is path-stable, so the generated member expression is a
+  // deterministic key for deduping the same module across inherited routes.
+  if (!sources.includes(sourceVar)) sources.push(sourceVar);
+  sourcesByPattern.set(pattern, sources);
+}
+
 function buildGenerateStaticParamsEntries(routes: AppRoute[], imports: ImportAllocator): string[] {
-  const entries: string[] = [];
+  const sourcesByPattern = new Map<string, string[]>();
+
   for (const route of routes) {
-    if (!route.isDynamic || !route.pagePath) continue;
-    entries.push(
-      `  ${JSON.stringify(route.pattern)}: ${imports.getImportVar(route.pagePath)}?.generateStaticParams ?? null,`,
-    );
+    if (!route.isDynamic) continue;
+
+    for (const [index, layoutPath] of route.layouts.entries()) {
+      appendStaticParamSource(
+        sourcesByPattern,
+        createRoutePatternPrefix(route.routeSegments, route.layoutTreePositions[index] ?? 0)
+          ?.pattern ?? null,
+        `${imports.getImportVar(layoutPath)}?.generateStaticParams`,
+      );
+    }
+
+    if (route.pagePath) {
+      appendStaticParamSource(
+        sourcesByPattern,
+        route.pattern,
+        `${imports.getImportVar(route.pagePath)}?.generateStaticParams`,
+      );
+    }
   }
-  return entries;
+
+  return Array.from(sourcesByPattern.entries()).map(
+    ([pattern, sources]) =>
+      `  ${JSON.stringify(pattern)}: __createAppPrerenderStaticParamsResolver([${sources.join(", ")}]),`,
+  );
+}
+
+function buildRootParamNameEntries(routes: AppRoute[]): string[] {
+  const namesByPattern = new Map<string, string[]>();
+
+  function append(
+    pattern: string | null,
+    rootParamNames: readonly string[] | undefined,
+    paramNames: readonly string[],
+  ): void {
+    if (!pattern || pattern === "/" || !pattern.includes(":")) return;
+    const patternParams = new Set(paramNames);
+    const names = (rootParamNames ?? []).filter((name) => patternParams.has(name));
+    if (names.length === 0) return;
+
+    const existing = namesByPattern.get(pattern) ?? [];
+    for (const name of names) {
+      if (!existing.includes(name)) existing.push(name);
+    }
+    namesByPattern.set(pattern, existing);
+  }
+
+  for (const route of routes) {
+    if (!route.isDynamic) continue;
+    append(route.pattern, route.rootParamNames, route.params);
+    for (const treePosition of route.layoutTreePositions) {
+      const prefix = createRoutePatternPrefix(route.routeSegments, treePosition);
+      append(prefix?.pattern ?? null, route.rootParamNames, prefix?.paramNames ?? []);
+    }
+  }
+
+  return Array.from(namesByPattern.entries()).map(
+    ([pattern, names]) => `  ${JSON.stringify(pattern)}: ${JSON.stringify(names)},`,
+  );
 }
 
 export function buildAppRscManifestCode(
@@ -236,6 +322,7 @@ export function buildAppRscManifestCode(
     routeEntries,
     metaRouteEntries: createMetadataRouteEntriesSource(metadataRoutes, imports.importMap),
     generateStaticParamsEntries: buildGenerateStaticParamsEntries(options.routes, imports),
+    rootParamNameEntries: buildRootParamNameEntries(options.routes),
     rootNotFoundVar,
     rootForbiddenVar,
     rootUnauthorizedVar,

--- a/packages/vinext/src/entries/app-rsc-manifest.ts
+++ b/packages/vinext/src/entries/app-rsc-manifest.ts
@@ -198,7 +198,8 @@ function createRoutePatternPrefix(
   routeSegments: readonly string[],
   treePosition: number,
 ): RoutePatternPrefix | null {
-  const limit = Math.max(0, Math.min(treePosition, routeSegments.length));
+  // treePosition is always non-negative (represents tree depth).
+  const limit = Math.min(treePosition, routeSegments.length);
   const converted = convertSegmentsToRouteParts(routeSegments.slice(0, limit));
   if (!converted) return null;
 

--- a/packages/vinext/src/routing/app-route-graph.ts
+++ b/packages/vinext/src/routing/app-route-graph.ts
@@ -2072,8 +2072,8 @@ function findFile(dir: string, name: string, matcher: ValidFileMatcher): string 
  * (route groups, @slots, ".") and converting dynamic segment syntax to Express-style
  * patterns (e.g. "[id]" → ":id", "[...slug]" → ":slug+").
  */
-function convertSegmentsToRouteParts(
-  segments: string[],
+export function convertSegmentsToRouteParts(
+  segments: readonly string[],
 ): { urlSegments: string[]; params: string[]; isDynamic: boolean } | null {
   const urlSegments: string[] = [];
   const params: string[] = [];
@@ -2125,7 +2125,7 @@ function convertSegmentsToRouteParts(
   return { urlSegments, params, isDynamic };
 }
 
-function hasRemainingVisibleSegments(segments: string[], startIndex: number): boolean {
+function hasRemainingVisibleSegments(segments: readonly string[], startIndex: number): boolean {
   for (let i = startIndex; i < segments.length; i++) {
     if (!isInvisibleSegment(segments[i])) return true;
   }

--- a/packages/vinext/src/routing/app-router.ts
+++ b/packages/vinext/src/routing/app-router.ts
@@ -22,7 +22,7 @@ import {
   type RouteManifest,
 } from "./app-route-graph.js";
 export type { AppRoute } from "./app-route-graph.js";
-export { computeRootParamNames } from "./app-route-graph.js";
+export { computeRootParamNames, convertSegmentsToRouteParts } from "./app-route-graph.js";
 
 type AppRouteGraph = {
   routes: AppRouteGraphRoute[];

--- a/packages/vinext/src/server/app-prerender-static-params.ts
+++ b/packages/vinext/src/server/app-prerender-static-params.ts
@@ -2,6 +2,44 @@ import { pickRootParams, setRootParams, type RootParams } from "vinext/shims/roo
 
 type GenerateStaticParamsFunction = (input: { params: RootParams }) => unknown;
 
+function isGenerateStaticParamsFunction(value: unknown): value is GenerateStaticParamsFunction {
+  return typeof value === "function";
+}
+
+function isRootParams(value: unknown): value is RootParams {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+export function createAppPrerenderStaticParamsResolver(
+  sources: readonly unknown[],
+): GenerateStaticParamsFunction | null {
+  const generateStaticParamsFns = sources.filter(isGenerateStaticParamsFunction);
+  if (generateStaticParamsFns.length === 0) return null;
+  if (generateStaticParamsFns.length === 1) return generateStaticParamsFns[0];
+
+  return async ({ params }) => {
+    let paramSets: RootParams[] = [params];
+
+    for (const generateStaticParams of generateStaticParamsFns) {
+      const nextParamSets: RootParams[] = [];
+
+      for (const parentParams of paramSets) {
+        const result = await generateStaticParams({ params: parentParams });
+        if (!Array.isArray(result)) return [];
+
+        for (const item of result) {
+          if (!isRootParams(item)) return [];
+          nextParamSets.push({ ...parentParams, ...item });
+        }
+      }
+
+      paramSets = nextParamSets;
+    }
+
+    return paramSets;
+  };
+}
+
 type CallAppPrerenderStaticParamsOptions = {
   fn: GenerateStaticParamsFunction;
   params: RootParams;

--- a/packages/vinext/src/server/app-prerender-static-params.ts
+++ b/packages/vinext/src/server/app-prerender-static-params.ts
@@ -15,7 +15,20 @@ export function createAppPrerenderStaticParamsResolver(
 ): GenerateStaticParamsFunction | null {
   const generateStaticParamsFns = sources.filter(isGenerateStaticParamsFunction);
   if (generateStaticParamsFns.length === 0) return null;
-  if (generateStaticParamsFns.length === 1) return generateStaticParamsFns[0];
+  if (generateStaticParamsFns.length === 1) {
+    const single = generateStaticParamsFns[0];
+    // Wrap the single source in the same non-array/non-object guards as the
+    // multi-source composition path so the contract is uniform regardless of
+    // how many sources were composed.
+    return async (input) => {
+      const result = await single(input);
+      if (!Array.isArray(result)) return [];
+      for (const item of result) {
+        if (!isRootParams(item)) return [];
+      }
+      return result;
+    };
+  }
 
   return async ({ params }) => {
     let paramSets: RootParams[] = [params];

--- a/tests/app-prerender-endpoints.test.ts
+++ b/tests/app-prerender-endpoints.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vite-plus/test";
 import { handleAppPrerenderEndpoint } from "../packages/vinext/src/server/app-prerender-endpoints.js";
+import { createAppPrerenderStaticParamsResolver } from "../packages/vinext/src/server/app-prerender-static-params.js";
 import { getRootParam } from "../packages/vinext/src/shims/root-params.js";
 
 type TestPageRoute = {
@@ -10,6 +11,43 @@ type TestPageRoute = {
 };
 
 describe("App prerender endpoint helpers", () => {
+  it("composes layout and page generateStaticParams sources top-down", async () => {
+    // Ported from Next.js: test/e2e/app-dir/app-root-params-getters/generate-static-params.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/app-root-params-getters/generate-static-params.test.ts
+    const layoutGenerateStaticParams = vi.fn(() => [
+      { lang: "en", locale: "us" },
+      { lang: "es", locale: "es" },
+    ]);
+    const pageGenerateStaticParams = vi.fn(({ params }) => [{ slug: `${params.lang}-post` }]);
+    const resolveStaticParams = createAppPrerenderStaticParamsResolver([
+      layoutGenerateStaticParams,
+      pageGenerateStaticParams,
+    ]);
+
+    await expect(resolveStaticParams?.({ params: {} })).resolves.toEqual([
+      { lang: "en", locale: "us", slug: "en-post" },
+      { lang: "es", locale: "es", slug: "es-post" },
+    ]);
+    expect(pageGenerateStaticParams).toHaveBeenCalledWith({
+      params: { lang: "en", locale: "us" },
+    });
+    expect(pageGenerateStaticParams).toHaveBeenCalledWith({
+      params: { lang: "es", locale: "es" },
+    });
+  });
+
+  it("bails out of composed generateStaticParams when a source returns a non-array", async () => {
+    const malformedLayoutGenerateStaticParams = vi.fn(() => undefined);
+    const pageGenerateStaticParams = vi.fn(() => [{ slug: "unused" }]);
+    const resolveStaticParams = createAppPrerenderStaticParamsResolver([
+      malformedLayoutGenerateStaticParams,
+      pageGenerateStaticParams,
+    ]);
+
+    await expect(resolveStaticParams?.({ params: {} })).resolves.toEqual([]);
+    expect(pageGenerateStaticParams).not.toHaveBeenCalled();
+  });
+
   it("falls through for non-prerender requests", async () => {
     const response = await handleAppPrerenderEndpoint(new Request("http://localhost/blog/post"), {
       isPrerenderEnabled: () => true,

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -325,7 +325,97 @@ describe("App Router generated manifest construction", () => {
     expect(dynamicRouteEntry).toContain("page: mod_17");
     expect(dynamicRouteEntry).toContain('params: ["photoId"]');
     expect(manifest.generateStaticParamsEntries).toEqual([
-      '  "/dashboard/:id": mod_5?.generateStaticParams ?? null,',
+      '  "/dashboard/:id": __createAppPrerenderStaticParamsResolver([mod_5?.generateStaticParams]),',
+    ]);
+  });
+
+  it("exposes layout-level generateStaticParams to App Router prerender", () => {
+    // Ported from Next.js: test/e2e/app-dir/app-root-params-getters/generate-static-params.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/app-root-params-getters/generate-static-params.test.ts
+    const routes = [
+      {
+        pattern: "/:lang/:locale/other/:slug",
+        patternParts: [":lang", ":locale", "other", ":slug"],
+        pagePath: "/tmp/test/app/[lang]/[locale]/other/[slug]/page.tsx",
+        routePath: null,
+        layouts: ["/tmp/test/app/[lang]/[locale]/layout.tsx"],
+        templates: [],
+        parallelSlots: [],
+        loadingPath: null,
+        errorPath: null,
+        layoutErrorPaths: [null],
+        notFoundPath: null,
+        notFoundPaths: [null],
+        forbiddenPath: null,
+        forbiddenPaths: [null],
+        unauthorizedPath: null,
+        unauthorizedPaths: [null],
+        routeSegments: ["[lang]", "[locale]", "other", "[slug]"],
+        templateTreePositions: [],
+        layoutTreePositions: [2],
+        isDynamic: true,
+        params: ["lang", "locale", "slug"],
+        rootParamNames: ["lang", "locale"],
+      },
+    ] satisfies AppRoute[];
+
+    const manifest = buildAppRscManifestCode({
+      routes,
+      metadataRoutes: [],
+      globalErrorPath: null,
+    });
+
+    expect(manifest.generateStaticParamsEntries).toEqual([
+      '  "/:lang/:locale": __createAppPrerenderStaticParamsResolver([mod_1?.generateStaticParams]),',
+      '  "/:lang/:locale/other/:slug": __createAppPrerenderStaticParamsResolver([mod_0?.generateStaticParams]),',
+    ]);
+    expect(manifest.rootParamNameEntries).toEqual([
+      '  "/:lang/:locale/other/:slug": ["lang","locale"],',
+      '  "/:lang/:locale": ["lang","locale"],',
+    ]);
+  });
+
+  it("keys layout generateStaticParams with canonical decoded route patterns", () => {
+    const routes = [
+      {
+        pattern: "/:lang/docs v2/:section/:slug",
+        patternParts: [":lang", "docs v2", ":section", ":slug"],
+        pagePath: "/tmp/test/app/[lang]/docs%20v2/[section]/[slug]/page.tsx",
+        routePath: null,
+        layouts: ["/tmp/test/app/[lang]/docs%20v2/[section]/layout.tsx"],
+        templates: [],
+        parallelSlots: [],
+        loadingPath: null,
+        errorPath: null,
+        layoutErrorPaths: [null],
+        notFoundPath: null,
+        notFoundPaths: [null],
+        forbiddenPath: null,
+        forbiddenPaths: [null],
+        unauthorizedPath: null,
+        unauthorizedPaths: [null],
+        routeSegments: ["[lang]", "docs%20v2", "[section]", "[slug]"],
+        templateTreePositions: [],
+        layoutTreePositions: [3],
+        isDynamic: true,
+        params: ["lang", "section", "slug"],
+        rootParamNames: ["lang", "section"],
+      },
+    ] satisfies AppRoute[];
+
+    const manifest = buildAppRscManifestCode({
+      routes,
+      metadataRoutes: [],
+      globalErrorPath: null,
+    });
+
+    expect(manifest.generateStaticParamsEntries).toEqual([
+      '  "/:lang/docs v2/:section": __createAppPrerenderStaticParamsResolver([mod_1?.generateStaticParams]),',
+      '  "/:lang/docs v2/:section/:slug": __createAppPrerenderStaticParamsResolver([mod_0?.generateStaticParams]),',
+    ]);
+    expect(manifest.rootParamNameEntries).toEqual([
+      '  "/:lang/docs v2/:section/:slug": ["lang","section"],',
+      '  "/:lang/docs v2/:section": ["lang","section"],',
     ]);
   });
 

--- a/tests/prerender.test.ts
+++ b/tests/prerender.test.ts
@@ -1208,53 +1208,86 @@ function mockRoute(pattern: string, opts: { pagePath?: string | null } = {}): Ap
   };
 }
 
-function routeIndexFrom(routes: AppRoute[]): ReadonlyMap<string, AppRoute> {
-  return new Map(routes.map((r) => [r.pattern, r]));
-}
-
 describe("resolveParentParams", () => {
   it("returns empty array when route has no parent dynamic segments", async () => {
     const route = mockRoute("/blog/:slug");
-    const result = await resolveParentParams(route, routeIndexFrom([route]), {});
+    const result = await resolveParentParams(route, {});
     expect(result).toEqual([]);
   });
 
-  it("returns empty array when parent route has no pagePath", async () => {
-    const parent = mockRoute("/shop/:category", { pagePath: null });
+  it("returns empty array when no parent generateStaticParams is registered", async () => {
     const child = mockRoute("/shop/:category/:item");
-    const result = await resolveParentParams(child, routeIndexFrom([parent, child]), {});
+    const result = await resolveParentParams(child, {});
     expect(result).toEqual([]);
+  });
+
+  it("resolves layout-level parent generateStaticParams without requiring a parent page", async () => {
+    // Ported from Next.js: test/e2e/app-dir/app-root-params-getters/generate-static-params.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/app-root-params-getters/generate-static-params.test.ts
+    const child = mockRoute("/:lang/:locale/other/:slug");
+    const staticParamsMap: StaticParamsMap = {
+      "/:lang/:locale": async () => [
+        { lang: "en", locale: "us" },
+        { lang: "es", locale: "es" },
+      ],
+    };
+
+    const result = await resolveParentParams(child, staticParamsMap);
+
+    expect(result).toEqual([
+      { lang: "en", locale: "us" },
+      { lang: "es", locale: "es" },
+    ]);
   });
 
   it("returns empty array when parent has no generateStaticParams", async () => {
-    const parent = mockRoute("/shop/:category");
     const child = mockRoute("/shop/:category/:item");
     const staticParamsMap: StaticParamsMap = {};
-    const result = await resolveParentParams(
-      child,
-      routeIndexFrom([parent, child]),
-      staticParamsMap,
-    );
+    const result = await resolveParentParams(child, staticParamsMap);
     expect(result).toEqual([]);
   });
 
+  it("skips missing parent providers but bails on malformed non-array results", async () => {
+    const child = mockRoute("/shop/:category/:item/:slug");
+    const calls: Record<string, string | string[]>[] = [];
+    const itemGenerateStaticParams = async ({
+      params,
+    }: {
+      params: Record<string, string | string[]>;
+    }) => {
+      calls.push(params);
+      return [{ item: "shoes" }];
+    };
+    const staticParamsMap: StaticParamsMap = {
+      "/shop/:category": async () => null,
+      "/shop/:category/:item": itemGenerateStaticParams,
+    };
+
+    const missingProviderResult = await resolveParentParams(child, staticParamsMap);
+
+    expect(missingProviderResult).toEqual([{ item: "shoes" }]);
+    expect(calls).toEqual([{}]);
+
+    calls.length = 0;
+    const malformedProviderResult = await resolveParentParams(child, {
+      "/shop/:category": async () => undefined,
+      "/shop/:category/:item": itemGenerateStaticParams,
+    });
+
+    expect(malformedProviderResult).toEqual([]);
+    expect(calls).toEqual([]);
+  });
+
   it("resolves single parent dynamic segment", async () => {
-    const parent = mockRoute("/shop/:category");
     const child = mockRoute("/shop/:category/:item");
     const staticParamsMap: StaticParamsMap = {
       "/shop/:category": async () => [{ category: "electronics" }, { category: "clothing" }],
     };
-    const result = await resolveParentParams(
-      child,
-      routeIndexFrom([parent, child]),
-      staticParamsMap,
-    );
+    const result = await resolveParentParams(child, staticParamsMap);
     expect(result).toEqual([{ category: "electronics" }, { category: "clothing" }]);
   });
 
   it("resolves two levels of parent dynamic segments", async () => {
-    const grandparent = mockRoute("/a/:b");
-    const parent = mockRoute("/a/:b/c/:d");
     const child = mockRoute("/a/:b/c/:d/:e");
     const staticParamsMap: StaticParamsMap = {
       "/a/:b": async () => [{ b: "1" }, { b: "2" }],
@@ -1263,11 +1296,7 @@ describe("resolveParentParams", () => {
         return [{ d: "y" }, { d: "z" }];
       },
     };
-    const result = await resolveParentParams(
-      child,
-      routeIndexFrom([grandparent, parent, child]),
-      staticParamsMap,
-    );
+    const result = await resolveParentParams(child, staticParamsMap);
     expect(result).toEqual([
       { b: "1", d: "x" },
       { b: "2", d: "y" },
@@ -1276,42 +1305,32 @@ describe("resolveParentParams", () => {
   });
 
   it("skips static segments between dynamic parents", async () => {
-    const parent = mockRoute("/shop/:category");
     const child = mockRoute("/shop/:category/details/:item");
     const staticParamsMap: StaticParamsMap = {
       "/shop/:category": async () => [{ category: "shoes" }],
     };
-    const result = await resolveParentParams(
-      child,
-      routeIndexFrom([parent, child]),
-      staticParamsMap,
-    );
+    const result = await resolveParentParams(child, staticParamsMap);
     expect(result).toEqual([{ category: "shoes" }]);
   });
 
   it("returns empty array for a fully static route", async () => {
     const route = mockRoute("/about/contact");
-    const result = await resolveParentParams(route, routeIndexFrom([route]), {});
+    const result = await resolveParentParams(route, {});
     expect(result).toEqual([]);
   });
 
   it("returns empty array for a single-segment dynamic route", async () => {
     const route = mockRoute("/:id");
-    const result = await resolveParentParams(route, routeIndexFrom([route]), {});
+    const result = await resolveParentParams(route, {});
     expect(result).toEqual([]);
   });
 
   it("resolves parent with catch-all child segment", async () => {
-    const parent = mockRoute("/shop/:category");
     const child = mockRoute("/shop/:category/:rest+");
     const staticParamsMap: StaticParamsMap = {
       "/shop/:category": async () => [{ category: "electronics" }],
     };
-    const result = await resolveParentParams(
-      child,
-      routeIndexFrom([parent, child]),
-      staticParamsMap,
-    );
+    const result = await resolveParentParams(child, staticParamsMap);
     expect(result).toEqual([{ category: "electronics" }]);
   });
 });


### PR DESCRIPTION
## Dashboard

| Area | Summary |
| --- | --- |
| Contract | App Router prerender must see layout-level `generateStaticParams` providers and pass parent root params into nested `generateStaticParams`. |
| Next.js refs | [`generate-static-params.test.ts`](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/app-root-params-getters/generate-static-params.test.ts), [`static-paths/app.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/build/static-paths/app.ts), [`root-params.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/request/root-params.ts) |
| Fix shape | Generated RSC entries now expose layout/page static-param providers by route pattern and compose same-pattern providers in a typed helper. Prerender parent resolution now queries the provider map directly instead of requiring a parent page route. |
| Tests | `vp test run tests/entry-templates.test.ts tests/app-prerender-endpoints.test.ts tests/prerender.test.ts`; `vp test run tests/app-router.test.ts`; `vp check`; `vp run vinext#build` |

## Why

Next.js walks `generateStaticParams` top-down. During each call it makes root params available from parent-generated params, so a nested segment can call `lang()` after a parent layout generated `{ lang, locale }`.

vinext already seeded root params for prerender endpoint calls, but the generated provider map only pointed at leaf page modules and `resolveParentParams()` only looked through page-backed parent routes. That skipped the fixture shape from Next.js where `app/[lang]/[locale]/layout.tsx` owns the root params.

## Changed

| Before | After |
| --- | --- |
| `generateStaticParamsMap` used only `route.page?.generateStaticParams`. | Layout and page providers are registered by URL pattern. |
| Parent params required a page-backed parent route. | Parent params resolve from any provider registered for a dynamic prefix, including layout-only prefixes. |
| Same-pattern layout/page providers had no shared composition point. | `createAppPrerenderStaticParamsResolver()` composes providers top-down while preserving single-provider behavior. |

## Out of scope

Next.js also throws when a root-param getter is read inside the `generateStaticParams` that defines that same root param. This PR only fixes the valid static-prerender path from the failing test; stricter error parity can be handled separately.
