### PR TITLE
fix(app-router): serve bundles through assetPrefix path

### DIFF
--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -130,6 +130,8 @@ export type NextConfig = {
   env?: Record<string, string>;
   /** Base URL path prefix */
   basePath?: string;
+  /** Prefix for generated static asset URLs */
+  assetPrefix?: string;
   /** Whether to add trailing slashes */
   trailingSlash?: boolean;
   /** Internationalization routing config */
@@ -244,6 +246,7 @@ export type NextConfigInput = NextConfig | NextConfigFactory;
 export type ResolvedNextConfig = {
   env: Record<string, string>;
   basePath: string;
+  assetPrefix: string;
   trailingSlash: boolean;
   output: "" | "export" | "standalone";
   pageExtensions: string[];
@@ -839,6 +842,7 @@ export async function resolveNextConfig(
     const resolved: ResolvedNextConfig = {
       env: {},
       basePath: "",
+      assetPrefix: "",
       trailingSlash: false,
       output: "",
       pageExtensions: normalizePageExtensions(),
@@ -1022,6 +1026,7 @@ export async function resolveNextConfig(
   const resolved: ResolvedNextConfig = {
     env: config.env ?? {},
     basePath: config.basePath ?? "",
+    assetPrefix: config.assetPrefix ?? "",
     trailingSlash: config.trailingSlash ?? false,
     output: output === "export" || output === "standalone" ? output : "",
     pageExtensions,

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -93,6 +93,8 @@ type AppRouterConfig = {
     fallback: NextRewrite[];
   };
   headers?: NextHeader[];
+  /** Configured next.config assetPrefix. Used for emitted bundle URLs and static asset aliases. */
+  assetPrefix?: string;
   /** Extra origins allowed for server action CSRF checks (from experimental.serverActions.allowedOrigins). */
   allowedOrigins?: string[];
   /** Extra origins allowed for dev server access (from allowedDevOrigins). */
@@ -148,6 +150,7 @@ export function generateRscEntry(
   const redirects = config?.redirects ?? [];
   const rewrites = config?.rewrites ?? { beforeFiles: [], afterFiles: [], fallback: [] };
   const headers = config?.headers ?? [];
+  const assetPrefix = config?.assetPrefix ?? "";
   const allowedOrigins = config?.allowedOrigins ?? [];
   const bodySizeLimit = config?.bodySizeLimit ?? 1 * 1024 * 1024;
   const expireTime = config?.expireTime ?? DEFAULT_EXPIRE_TIME;
@@ -352,6 +355,12 @@ ${metaRouteEntries.join(",\n")}
 // Hoisted ahead of __fallbackRenderer / buildPageElements so both can thread
 // the configured basePath through file-based metadata href emission.
 const __basePath = ${JSON.stringify(bp)};
+const __assetPrefix = ${JSON.stringify(assetPrefix)};
+
+export const vinextConfig = {
+  assetPrefix: __assetPrefix,
+  basePath: __basePath,
+};
 
 const rootNotFoundModule = ${rootNotFoundVar ? rootNotFoundVar : "null"};
 const rootForbiddenModule = ${rootForbiddenVar ? rootForbiddenVar : "null"};
@@ -466,6 +475,7 @@ ${routes
 };
 
 export default __createAppRscHandler({
+  assetPrefix: __assetPrefix,
   basePath: __basePath,
   clearRequestContext() {
     __clearRequestContext();

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -40,6 +40,7 @@ import {
   type NextRewrite,
   type NextHeader,
 } from "./config/next-config.js";
+import { normalizeAssetPrefix } from "./utils/asset-prefix.js";
 
 import { findMiddlewareFile, runMiddleware } from "./server/middleware.js";
 import {
@@ -1036,6 +1037,9 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         }
         // Expose basePath to client-side code
         defines["process.env.__NEXT_ROUTER_BASEPATH"] = JSON.stringify(nextConfig.basePath);
+        defines["process.env.__NEXT_ASSET_PREFIX"] = JSON.stringify(
+          normalizeAssetPrefix(nextConfig.assetPrefix),
+        );
         // Expose trailingSlash to client-side code so <Link> can render hrefs
         // in the canonical form and avoid an unnecessary 308 redirect bounce.
         defines["process.env.__VINEXT_TRAILING_SLASH"] = JSON.stringify(
@@ -2076,6 +2080,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
               redirects: nextConfig?.redirects,
               rewrites: nextConfig?.rewrites,
               headers: nextConfig?.headers,
+              assetPrefix: nextConfig?.assetPrefix,
               allowedOrigins: nextConfig?.serverActionsAllowedOrigins,
               allowedDevOrigins: nextConfig?.allowedDevOrigins,
               bodySizeLimit: nextConfig?.serverActionsBodySizeLimit,

--- a/packages/vinext/src/server/app-router-entry.ts
+++ b/packages/vinext/src/server/app-router-entry.ts
@@ -14,9 +14,10 @@
 
 import "./server-globals.js";
 // @ts-expect-error — virtual module resolved by vinext
-import rscHandler from "virtual:vinext-rsc-entry";
+import rscHandler, { vinextConfig } from "virtual:vinext-rsc-entry";
 import { runWithExecutionContext, type ExecutionContextLike } from "vinext/shims/request-context";
 import { resolveStaticAssetSignal } from "./worker-utils.js";
+import { stripAssetPrefixPathname } from "../utils/asset-prefix.js";
 import {
   cloneRequestWithHeaders,
   filterInternalHeaders,
@@ -78,6 +79,11 @@ async function handleRequest(
   // decodeURIComponent + normalizePath on the incoming URL. Decoding here
   // AND in the handler would double-decode, causing inconsistent path
   // matching between middleware and routing.
+
+  const assetLookupPath = stripAssetPrefixPathname(url.pathname, vinextConfig.assetPrefix);
+  if (assetLookupPath.startsWith("/assets/") && env?.ASSETS) {
+    return env.ASSETS.fetch(new Request(new URL(assetLookupPath, request.url)));
+  }
 
   // Delegate to RSC handler (which decodes + normalizes the pathname itself),
   // wrapping in the ExecutionContext ALS scope so downstream code can reach

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -39,6 +39,7 @@ import {
   stripRscSuffix,
 } from "./app-rsc-cache-busting.js";
 import { finalizeAppRscResponse } from "./app-rsc-response-finalizer.js";
+import { stripAssetPrefixPathname } from "../utils/asset-prefix.js";
 import { normalizeRscRequest } from "./app-rsc-request-normalization.js";
 import { notFoundResponse } from "./http-error-responses.js";
 import { getScriptNonceFromHeaderSources } from "./csp.js";
@@ -52,6 +53,7 @@ import {
   cloneRequestWithHeaders,
   filterInternalHeaders,
   applyConfigHeadersToResponse,
+  createStaticFileSignal,
   normalizeTrailingSlash,
   resolvePublicFileRoute,
   validateImageUrl,
@@ -165,6 +167,7 @@ type NavigationContextValue = {
 };
 
 type CreateAppRscHandlerOptions<TRoute extends AppRscHandlerRoute> = {
+  assetPrefix: string;
   basePath: string;
   clearRequestContext: () => void;
   configHeaders: NextHeader[];
@@ -305,6 +308,11 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
     staticParamsMap: options.staticParamsMap,
   });
   if (prerenderEndpointResponse) return prerenderEndpointResponse;
+
+  const assetPrefixPathname = stripAssetPrefixPathname(pathname, options.assetPrefix);
+  if (assetPrefixPathname.startsWith("/assets/")) {
+    return createStaticFileSignal(assetPrefixPathname, { headers: null, status: null });
+  }
 
   const trailingSlashRedirect = normalizeTrailingSlash(
     pathname,

--- a/packages/vinext/src/server/app-ssr-entry.ts
+++ b/packages/vinext/src/server/app-ssr-entry.ts
@@ -34,6 +34,7 @@ import { ElementsContext, Slot } from "vinext/shims/slot";
 import { AppRouterContext } from "vinext/shims/internal/app-router-context";
 import { createClientReferencePreloader } from "./app-client-reference-preloader.js";
 import { RSC_FORM_STATE_GLOBAL } from "./app-browser-hydration.js";
+import { applyAssetPrefix } from "../utils/asset-prefix.js";
 
 export type FontPreload = {
   href: string;
@@ -109,6 +110,15 @@ function renderFontHtml(fontData?: FontData, nonce?: string): string {
   }
 
   return fontHTML;
+}
+
+const assetPrefix = process.env.__NEXT_ASSET_PREFIX ?? "";
+
+function prefixBootstrapScriptAssets(bootstrapScriptContent: string): string {
+  return bootstrapScriptContent.replaceAll(/import\("([^"]+)"\)/g, (match, pathname) => {
+    if (!pathname.startsWith("/assets/")) return match;
+    return `import("${applyAssetPrefix(pathname, assetPrefix)}")`;
+  });
 }
 
 function extractModulePreloadHtml(bootstrapScriptContent?: string, nonce?: string): string {
@@ -244,7 +254,9 @@ export async function handleSsr(
         : root;
       const ssrRoot = withScriptNonce(ssrTree, options?.scriptNonce);
 
-      const bootstrapScriptContent = await import.meta.viteRsc.loadBootstrapScriptContent("index");
+      const bootstrapScriptContent = prefixBootstrapScriptAssets(
+        await import.meta.viteRsc.loadBootstrapScriptContent("index"),
+      );
       const errorMetaRenderer = createSsrErrorMetaRenderer({
         basePath: options?.basePath,
       });

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -52,6 +52,7 @@ import {
 } from "./request-pipeline.js";
 import { notFoundResponse } from "./http-error-responses.js";
 import { hasBasePath, stripBasePath, removeTrailingSlash } from "../utils/base-path.js";
+import { stripAssetPrefixPathname } from "../utils/asset-prefix.js";
 import { computeLazyChunks } from "../utils/lazy-chunks.js";
 import { manifestFileWithBase } from "../utils/manifest-paths.js";
 import { normalizePathnameForRouteMatchStrict } from "../routing/utils.js";
@@ -965,6 +966,13 @@ async function startAppRouterServer(options: AppRouterServerOptions) {
   const rscMtime = fs.statSync(rscEntryPath).mtimeMs;
   const rscModule = await import(`${pathToFileURL(rscEntryPath).href}?t=${rscMtime}`);
   const rscHandler = resolveAppRouterHandler(rscModule.default);
+  const appAssetPrefix =
+    typeof rscModule.vinextConfig === "object" &&
+    rscModule.vinextConfig !== null &&
+    "assetPrefix" in rscModule.vinextConfig &&
+    typeof rscModule.vinextConfig.assetPrefix === "string"
+      ? rscModule.vinextConfig.assetPrefix
+      : "";
 
   // Seed the memory cache with pre-rendered routes so the first request to
   // any pre-rendered page is a cache HIT instead of a full re-render.
@@ -1031,9 +1039,10 @@ async function startAppRouterServer(options: AppRouterServerOptions) {
     // Serve hashed build assets (Vite output in /assets/) directly.
     // Public directory files fall through to the RSC handler, which runs
     // middleware before serving them.
+    const assetLookupPath = stripAssetPrefixPathname(pathname, appAssetPrefix);
     if (
-      pathname.startsWith("/assets/") &&
-      (await tryServeStatic(req, res, clientDir, pathname, compress, staticCache))
+      assetLookupPath.startsWith("/assets/") &&
+      (await tryServeStatic(req, res, clientDir, assetLookupPath, compress, staticCache))
     ) {
       return;
     }

--- a/packages/vinext/src/utils/asset-prefix.ts
+++ b/packages/vinext/src/utils/asset-prefix.ts
@@ -1,0 +1,47 @@
+import { hasBasePath, stripBasePath } from "./base-path.js";
+
+export function normalizeAssetPrefix(assetPrefix: string | undefined): string {
+  const raw = assetPrefix?.trim();
+  if (!raw) return "";
+
+  if (URL.canParse(raw)) {
+    const url = new URL(raw);
+    url.pathname = url.pathname.replace(/\/+$/, "");
+    url.search = "";
+    url.hash = "";
+    return url.href.replace(/\/$/, "");
+  }
+
+  const pathPrefix = raw.replace(/^\/+|\/+$/g, "");
+  return pathPrefix ? `/${pathPrefix}` : "";
+}
+
+export function assetPrefixPathname(assetPrefix: string | undefined): string {
+  const normalized = normalizeAssetPrefix(assetPrefix);
+  if (!normalized) return "";
+
+  if (URL.canParse(normalized)) {
+    const pathname = new URL(normalized).pathname;
+    return pathname === "/" ? "" : pathname.replace(/\/+$/, "");
+  }
+
+  return normalized;
+}
+
+export function stripAssetPrefixPathname(
+  pathname: string,
+  assetPrefix: string | undefined,
+): string {
+  const prefixPathname = assetPrefixPathname(assetPrefix);
+  if (!prefixPathname || !hasBasePath(pathname, prefixPathname)) {
+    return pathname;
+  }
+
+  return stripBasePath(pathname, prefixPathname);
+}
+
+export function applyAssetPrefix(pathname: string, assetPrefix: string | undefined): string {
+  const normalized = normalizeAssetPrefix(assetPrefix);
+  if (!normalized || !pathname.startsWith("/")) return pathname;
+  return `${normalized}${pathname}`;
+}

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -2297,6 +2297,77 @@ describe("App Router Production server (startProdServer)", () => {
     expect(res.headers.get("cache-control")).toContain("immutable");
   });
 
+  it("serves App Router bundles through an absolute assetPrefix pathname", async () => {
+    // Ported from Next.js: test/e2e/app-dir/asset-prefix-absolute/asset-prefix-absolute.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/asset-prefix-absolute/asset-prefix-absolute.test.ts
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-app-asset-prefix-"));
+    const fixtureRoot = path.join(tmpDir, "fixture");
+    let assetPrefixServer: import("node:http").Server | undefined;
+
+    try {
+      fs.cpSync(APP_FIXTURE_DIR, fixtureRoot, { recursive: true });
+      const fixtureNodeModules = path.join(fixtureRoot, "node_modules");
+      if (!fs.existsSync(fixtureNodeModules)) {
+        fs.symlinkSync(
+          path.resolve(__dirname, "..", "node_modules"),
+          fixtureNodeModules,
+          "junction",
+        );
+      }
+
+      const builder = await createBuilder({
+        root: fixtureRoot,
+        configFile: false,
+        plugins: [
+          vinext({
+            appDir: fixtureRoot,
+            nextConfig: {
+              assetPrefix: "https://example.vercel.sh/custom-asset-prefix",
+            },
+          }),
+        ],
+        logLevel: "silent",
+      });
+      await builder.buildApp();
+      const assetOutDir = path.join(fixtureRoot, "dist");
+      fs.symlinkSync(
+        path.resolve(__dirname, "..", "node_modules"),
+        path.join(assetOutDir, "node_modules"),
+      );
+
+      const { startProdServer } = await import("../packages/vinext/src/server/prod-server.js");
+      ({ server: assetPrefixServer } = await startProdServer({
+        port: 0,
+        outDir: assetOutDir,
+        noCompression: true,
+      }));
+      const addr = assetPrefixServer.address();
+      const assetPrefixBaseUrl =
+        addr && typeof addr === "object" ? `http://localhost:${addr.port}` : null;
+      expect(assetPrefixBaseUrl).not.toBeNull();
+
+      const htmlRes = await fetch(`${assetPrefixBaseUrl}/`);
+      expect(htmlRes.status).toBe(200);
+      const html = await htmlRes.text();
+      const bundlePaths = [
+        ...html.matchAll(
+          /https:\/\/example\.vercel\.sh\/custom-asset-prefix\/assets\/[^"')]+\.js/g,
+        ),
+      ].map((match) => new URL(match[0]).pathname);
+
+      expect(bundlePaths.length).toBeGreaterThan(0);
+
+      for (const bundlePath of bundlePaths) {
+        const res = await fetch(`${assetPrefixBaseUrl}${bundlePath}`);
+        expect(res.status).toBe(200);
+        expect(res.headers.get("content-type")).toContain("javascript");
+      }
+    } finally {
+      assetPrefixServer?.close();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it("serves public files from the build output", async () => {
     // Ported from Next.js: test/production/export/index.test.ts
     // https://github.com/vercel/next.js/blob/canary/test/production/export/index.test.ts

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -33,6 +33,7 @@ function createHandler(overrides: Partial<HandlerOptions> = {}) {
   const route = createPageRoute();
 
   return createAppRscHandler<TestRoute>({
+    assetPrefix: "",
     basePath: "/docs",
     clearRequestContext: overrides.clearRequestContext ?? (() => {}),
     configHeaders: overrides.configHeaders ?? [

--- a/tests/asset-prefix.test.ts
+++ b/tests/asset-prefix.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyAssetPrefix,
+  assetPrefixPathname,
+  normalizeAssetPrefix,
+  stripAssetPrefixPathname,
+} from "../packages/vinext/src/utils/asset-prefix.js";
+
+describe("assetPrefix helpers", () => {
+  it("normalizes path and absolute URL prefixes for emitted asset URLs", () => {
+    expect(normalizeAssetPrefix(undefined)).toBe("");
+    expect(normalizeAssetPrefix("/")).toBe("");
+    expect(normalizeAssetPrefix("/custom-asset-prefix/")).toBe("/custom-asset-prefix");
+    expect(normalizeAssetPrefix("custom-asset-prefix")).toBe("/custom-asset-prefix");
+    expect(normalizeAssetPrefix("https://example.vercel.sh/")).toBe("https://example.vercel.sh");
+    expect(normalizeAssetPrefix("https://example.vercel.sh/custom-asset-prefix/")).toBe(
+      "https://example.vercel.sh/custom-asset-prefix",
+    );
+    expect(normalizeAssetPrefix("https://example.vercel.sh/custom?debug#hash")).toBe(
+      "https://example.vercel.sh/custom",
+    );
+  });
+
+  it("uses only the pathname from absolute URL prefixes for local serving aliases", () => {
+    expect(assetPrefixPathname("https://example.vercel.sh/")).toBe("");
+    expect(assetPrefixPathname("https://example.vercel.sh/custom-asset-prefix")).toBe(
+      "/custom-asset-prefix",
+    );
+    expect(assetPrefixPathname("/custom-asset-prefix")).toBe("/custom-asset-prefix");
+  });
+
+  it("strips assetPrefix pathnames on segment boundaries only", () => {
+    expect(
+      stripAssetPrefixPathname("/custom-asset-prefix/assets/app.js", "/custom-asset-prefix"),
+    ).toBe("/assets/app.js");
+    expect(
+      stripAssetPrefixPathname("/custom-asset-prefixes/assets/app.js", "/custom-asset-prefix"),
+    ).toBe("/custom-asset-prefixes/assets/app.js");
+    expect(
+      stripAssetPrefixPathname(
+        "/custom-asset-prefix/assets/app.js",
+        "https://example.vercel.sh/custom-asset-prefix",
+      ),
+    ).toBe("/assets/app.js");
+  });
+
+  it("applies assetPrefix only to root-relative asset paths", () => {
+    expect(applyAssetPrefix("/assets/app.js", "https://example.vercel.sh/custom")).toBe(
+      "https://example.vercel.sh/custom/assets/app.js",
+    );
+    expect(applyAssetPrefix("assets/app.js", "https://example.vercel.sh/custom")).toBe(
+      "assets/app.js",
+    );
+    expect(applyAssetPrefix("/assets/app.js", undefined)).toBe("/assets/app.js");
+  });
+});

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -857,6 +857,7 @@ describe("detectNextIntlConfig", () => {
     return {
       env: {},
       basePath: "",
+      assetPrefix: "",
       trailingSlash: false,
       output: "",
       pageExtensions: ["tsx", "ts", "jsx", "js"],


### PR DESCRIPTION
## Review Dashboard

| Area | Summary |
| --- | --- |
| Bug | App Router production HTML did not emit bundle URLs under an absolute `assetPrefix` pathname, and production asset serving only recognized direct `/assets/*` requests. |
| Fix | Thread `assetPrefix` through resolved config and generated App Router runtime config, prefix bootstrap bundle imports, and map the local assetPrefix pathname back to `/assets/*` at Node, Worker, and RSC static-file-signal boundaries. |
| Tests | Added a production App Router regression ported from Next.js plus focused helper coverage for normalization and segment-boundary stripping. |
| Scope | One PR: URL emission and served-path aliasing are one observable contract. Splitting would leave either prefixed URLs that 404 or serving aliases with no emitted callers. |

## Why

Next.js supports an absolute `assetPrefix` whose URL has a pathname. Its App Router e2e test renders a page, finds scripts under the configured absolute prefix, and expects those bundle URLs to return 200 when fetched.

vinext had no resolved `assetPrefix` config and no App Router runtime config carrying it into generated entries. As a result, App Router production bundles stayed root-relative, and even a prefixed bundle request would miss the direct `/assets/*` static serving path.

## What Changed

| Contract Piece | Change |
| --- | --- |
| Config | Added `assetPrefix` to `NextConfig` and `ResolvedNextConfig`. |
| Emission | Exposed normalized `process.env.__NEXT_ASSET_PREFIX` and prefixed App Router bootstrap `import("/assets/...")` URLs. |
| Serving | Added a typed assetPrefix helper and stripped the local pathname alias before static asset lookup in Node prod, Worker entry, and RSC static-file signal paths. |
| Tests | Added helper unit tests and an App Router production regression that builds a fixture with `https://example.vercel.sh/custom-asset-prefix`, asserts prefixed bundle URLs are emitted, and verifies each served prefixed bundle returns 200 JavaScript. |

## Next.js References

- [Next.js App Router absolute assetPrefix e2e test](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/asset-prefix-absolute/asset-prefix-absolute.test.ts)
- [Next.js custom route loader adds assetPrefix pathname rewrites](https://github.com/vercel/next.js/blob/canary/packages/next/src/lib/load-custom-routes.ts#L604-L626)
- [Next.js assetPrefix rewrite unit coverage](https://github.com/vercel/next.js/blob/canary/packages/next/src/lib/load-custom-routes.test.ts#L78-L176)

## Validation

- `vp test run tests/asset-prefix.test.ts`
- `vp test run tests/app-router.test.ts -t "serves App Router bundles through an absolute assetPrefix pathname"`
- `vp check`
- `vp run vinext#build`

`vp run vinext#build` completed successfully with the existing package-build unresolved virtual module warnings for externalized virtual entrypoints.
