### PR TITLE
fix(pages-api): execute edge API routes with Fetch Request

### DIFF
--- a/packages/vinext/src/server/api-handler.ts
+++ b/packages/vinext/src/server/api-handler.ts
@@ -171,6 +171,53 @@ async function createEdgeApiRequest(req: IncomingMessage, url: string): Promise<
   });
 }
 
+function waitForWritableDrain(res: ServerResponse): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      res.off("drain", onDrain);
+      res.off("error", onError);
+    };
+    const onDrain = () => {
+      cleanup();
+      resolve();
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    res.once("drain", onDrain);
+    res.once("error", onError);
+  });
+}
+
+async function writeEdgeApiResponseBody(
+  res: ServerResponse,
+  body: ReadableStream<Uint8Array> | null,
+): Promise<void> {
+  if (!body) {
+    res.end();
+    return;
+  }
+
+  const reader = body.getReader();
+  try {
+    while (true) {
+      const result = await reader.read();
+      if (result.done) break;
+      if (result.value.byteLength === 0) continue;
+      if (!res.write(Buffer.from(result.value))) {
+        await waitForWritableDrain(res);
+      }
+    }
+    res.end();
+  } catch (error) {
+    res.destroy(error instanceof Error ? error : new Error(String(error)));
+    throw error;
+  } finally {
+    reader.releaseLock();
+  }
+}
+
 /**
  * Enhance a Node.js req/res pair with Next.js API route helpers.
  */
@@ -273,7 +320,7 @@ export async function handleApiRoute(
       if (setCookieHeaders.length) {
         res.setHeader("set-cookie", setCookieHeaders);
       }
-      res.end(Buffer.from(await response.arrayBuffer()));
+      await writeEdgeApiResponseBody(res, response.body);
       return true;
     }
 

--- a/packages/vinext/src/server/api-handler.ts
+++ b/packages/vinext/src/server/api-handler.ts
@@ -152,7 +152,8 @@ function createEdgeApiRequest(req: IncomingMessage, url: string): Request {
     }
   }
 
-  const forwardedProto = headers.get("x-forwarded-proto")?.split(",")[0]?.trim() ?? "http";
+  const rawProto = headers.get("x-forwarded-proto")?.split(",")[0]?.trim();
+  const forwardedProto = rawProto === "https" || rawProto === "http" ? rawProto : "http";
   const host = headers.get("host") ?? "localhost";
   const requestUrl = new URL(url, `${forwardedProto}://${host}`);
   const body = readEdgeRequestBody(req);
@@ -302,15 +303,6 @@ export async function handleApiRoute(
   try {
     // Load the API route module through the ModuleRunner
     const apiModule = await importModule(runner, route.filePath);
-    const handler = apiModule.default;
-
-    if (typeof handler !== "function") {
-      console.error(`[vinext] API route ${route.filePath} does not export a default function`);
-      res.statusCode = 500;
-      res.end("API route does not export a default function");
-      return true;
-    }
-
     if (isEdgeApiRouteModule(apiModule)) {
       const response = await apiModule.default(createEdgeApiRequest(req, url));
       if (!(response instanceof Response)) {
@@ -327,6 +319,14 @@ export async function handleApiRoute(
         res.setHeader("set-cookie", setCookieHeaders);
       }
       await writeEdgeApiResponseBody(res, response.body);
+      return true;
+    }
+
+    const handler = apiModule.default;
+    if (typeof handler !== "function") {
+      console.error(`[vinext] API route ${route.filePath} does not export a default function`);
+      res.statusCode = 500;
+      res.end("API route does not export a default function");
       return true;
     }
 

--- a/packages/vinext/src/server/api-handler.ts
+++ b/packages/vinext/src/server/api-handler.ts
@@ -176,6 +176,7 @@ function waitForWritableDrain(res: ServerResponse): Promise<void> {
     const cleanup = () => {
       res.off("drain", onDrain);
       res.off("error", onError);
+      res.off("close", onClose);
     };
     const onDrain = () => {
       cleanup();
@@ -185,8 +186,13 @@ function waitForWritableDrain(res: ServerResponse): Promise<void> {
       cleanup();
       reject(error);
     };
+    const onClose = () => {
+      cleanup();
+      reject(new Error("Response closed before writable drain"));
+    };
     res.once("drain", onDrain);
     res.once("error", onError);
+    res.once("close", onClose);
   });
 }
 

--- a/packages/vinext/src/server/api-handler.ts
+++ b/packages/vinext/src/server/api-handler.ts
@@ -15,6 +15,7 @@ import { type Route, matchRoute } from "../routing/pages-router.js";
 import { reportRequestError, importModule, type ModuleImporter } from "./instrumentation.js";
 import { mergeRouteParamsIntoQuery, parseQueryString } from "../utils/query.js";
 import { PagesBodyParseError, getMediaType, isJsonMediaType } from "./pages-media-type.js";
+import { isEdgeApiRuntime } from "./edge-api-runtime.js";
 
 /**
  * Extend the Node.js request with Next.js-style helpers.
@@ -119,10 +120,6 @@ function parseCookies(req: IncomingMessage): Record<string, string> {
   return cookies;
 }
 
-function isEdgeApiRuntime(runtime: string | undefined): boolean {
-  return runtime === "edge" || runtime === "experimental-edge";
-}
-
 function isEdgeApiRouteModule(module: Record<string, unknown>): module is EdgeApiRouteModule {
   const config = module.config;
   if (!config || typeof config !== "object") return false;
@@ -132,24 +129,20 @@ function isEdgeApiRouteModule(module: Record<string, unknown>): module is EdgeAp
   );
 }
 
-async function readEdgeRequestBody(req: IncomingMessage): Promise<Blob | undefined> {
+function readEdgeRequestBody(req: IncomingMessage): ReadableStream<Uint8Array> | undefined {
   if (req.method === "GET" || req.method === "HEAD") return undefined;
-
-  const chunks: Uint8Array[] = [];
-  for await (const chunk of req) {
-    if (typeof chunk === "string") {
-      chunks.push(Buffer.from(chunk));
-    } else if (chunk instanceof Uint8Array) {
-      chunks.push(chunk);
-    } else {
-      chunks.push(Buffer.from(String(chunk)));
-    }
-  }
-
-  return new Blob([Buffer.concat(chunks)]);
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      req.on("data", (chunk: Buffer | string) => {
+        controller.enqueue(typeof chunk === "string" ? Buffer.from(chunk) : new Uint8Array(chunk));
+      });
+      req.on("end", () => controller.close());
+      req.on("error", (error) => controller.error(error));
+    },
+  });
 }
 
-async function createEdgeApiRequest(req: IncomingMessage, url: string): Promise<Request> {
+function createEdgeApiRequest(req: IncomingMessage, url: string): Request {
   const headers = new Headers();
   for (const [name, value] of Object.entries(req.headers)) {
     if (Array.isArray(value)) {
@@ -159,16 +152,22 @@ async function createEdgeApiRequest(req: IncomingMessage, url: string): Promise<
     }
   }
 
-  const forwardedProto = headers.get("x-forwarded-proto") ?? "http";
+  const forwardedProto = headers.get("x-forwarded-proto")?.split(",")[0]?.trim() ?? "http";
   const host = headers.get("host") ?? "localhost";
   const requestUrl = new URL(url, `${forwardedProto}://${host}`);
-  const body = await readEdgeRequestBody(req);
+  const body = readEdgeRequestBody(req);
 
-  return new Request(requestUrl, {
-    body,
+  const init: RequestInit & { duplex?: "half" } = {
     headers,
     method: req.method,
-  });
+  };
+
+  if (body) {
+    init.body = body;
+    init.duplex = "half";
+  }
+
+  return new Request(requestUrl, init);
 }
 
 function waitForWritableDrain(res: ServerResponse): Promise<void> {
@@ -233,52 +232,53 @@ function enhanceApiObjects(
   query: Record<string, string | string[]>,
   body: unknown,
 ): { apiReq: NextApiRequest; apiRes: NextApiResponse } {
-  const apiReq = req as NextApiRequest;
-  apiReq.query = query;
-  apiReq.body = body;
-  apiReq.cookies = parseCookies(req);
+  const apiReq: NextApiRequest = Object.assign(req, {
+    body,
+    cookies: parseCookies(req),
+    query,
+  });
 
-  const apiRes = res as NextApiResponse;
+  const apiRes: NextApiResponse = Object.assign(res, {
+    status(this: NextApiResponse, code: number) {
+      this.statusCode = code;
+      return this;
+    },
 
-  apiRes.status = function (code: number) {
-    this.statusCode = code;
-    return this;
-  };
-
-  apiRes.json = function (data: unknown) {
-    this.setHeader("Content-Type", "application/json");
-    this.end(JSON.stringify(data));
-  };
-
-  apiRes.send = function (data: unknown) {
-    if (Buffer.isBuffer(data)) {
-      if (!this.getHeader("Content-Type")) {
-        this.setHeader("Content-Type", "application/octet-stream");
-      }
-      this.setHeader("Content-Length", String(data.length));
-      this.end(data);
-      return;
-    }
-
-    if (typeof data === "object" && data !== null) {
+    json(this: NextApiResponse, data: unknown) {
       this.setHeader("Content-Type", "application/json");
       this.end(JSON.stringify(data));
-    } else {
-      if (!this.getHeader("Content-Type")) {
-        this.setHeader("Content-Type", "text/plain");
-      }
-      this.end(String(data));
-    }
-  };
+    },
 
-  apiRes.redirect = function (statusOrUrl: number | string, url?: string) {
-    if (typeof statusOrUrl === "string") {
-      this.writeHead(307, { Location: statusOrUrl });
-    } else {
-      this.writeHead(statusOrUrl, { Location: url! });
-    }
-    this.end();
-  };
+    send(this: NextApiResponse, data: unknown) {
+      if (Buffer.isBuffer(data)) {
+        if (!this.getHeader("Content-Type")) {
+          this.setHeader("Content-Type", "application/octet-stream");
+        }
+        this.setHeader("Content-Length", String(data.length));
+        this.end(data);
+        return;
+      }
+
+      if (typeof data === "object" && data !== null) {
+        this.setHeader("Content-Type", "application/json");
+        this.end(JSON.stringify(data));
+      } else {
+        if (!this.getHeader("Content-Type")) {
+          this.setHeader("Content-Type", "text/plain");
+        }
+        this.end(String(data));
+      }
+    },
+
+    redirect(this: NextApiResponse, statusOrUrl: number | string, url?: string) {
+      if (typeof statusOrUrl === "string") {
+        this.writeHead(307, { Location: statusOrUrl });
+      } else {
+        this.writeHead(statusOrUrl, { Location: url ?? "" });
+      }
+      this.end();
+    },
+  });
 
   return { apiReq, apiRes };
 }
@@ -312,7 +312,7 @@ export async function handleApiRoute(
     }
 
     if (isEdgeApiRouteModule(apiModule)) {
-      const response = await apiModule.default(await createEdgeApiRequest(req, url));
+      const response = await apiModule.default(createEdgeApiRequest(req, url));
       if (!(response instanceof Response)) {
         throw new Error("Edge API route did not return a Response");
       }

--- a/packages/vinext/src/server/api-handler.ts
+++ b/packages/vinext/src/server/api-handler.ts
@@ -7,8 +7,10 @@
  * The req/res objects are Node.js IncomingMessage/ServerResponse with
  * Next.js extensions: req.query, req.body, res.json(), res.status(), etc.
  */
+import "./server-globals.js";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { decode as decodeQueryString } from "node:querystring";
+import { Buffer } from "node:buffer";
 import { type Route, matchRoute } from "../routing/pages-router.js";
 import { reportRequestError, importModule, type ModuleImporter } from "./instrumentation.js";
 import { mergeRouteParamsIntoQuery, parseQueryString } from "../utils/query.js";
@@ -32,6 +34,13 @@ type NextApiResponse = {
   send(data: unknown): void;
   redirect(statusOrUrl: number | string, url?: string): void;
 } & ServerResponse;
+
+type EdgeApiRouteModule = {
+  config?: {
+    runtime?: string;
+  };
+  default: (request: Request) => Response | Promise<Response>;
+};
 
 /**
  * Maximum request body size (1 MB). Matches Next.js default bodyParser sizeLimit.
@@ -108,6 +117,58 @@ function parseCookies(req: IncomingMessage): Record<string, string> {
     }
   }
   return cookies;
+}
+
+function isEdgeApiRuntime(runtime: string | undefined): boolean {
+  return runtime === "edge" || runtime === "experimental-edge";
+}
+
+function isEdgeApiRouteModule(module: Record<string, unknown>): module is EdgeApiRouteModule {
+  const config = module.config;
+  if (!config || typeof config !== "object") return false;
+  const runtime = "runtime" in config ? config.runtime : undefined;
+  return (
+    typeof module.default === "function" && typeof runtime === "string" && isEdgeApiRuntime(runtime)
+  );
+}
+
+async function readEdgeRequestBody(req: IncomingMessage): Promise<Blob | undefined> {
+  if (req.method === "GET" || req.method === "HEAD") return undefined;
+
+  const chunks: Uint8Array[] = [];
+  for await (const chunk of req) {
+    if (typeof chunk === "string") {
+      chunks.push(Buffer.from(chunk));
+    } else if (chunk instanceof Uint8Array) {
+      chunks.push(chunk);
+    } else {
+      chunks.push(Buffer.from(String(chunk)));
+    }
+  }
+
+  return new Blob([Buffer.concat(chunks)]);
+}
+
+async function createEdgeApiRequest(req: IncomingMessage, url: string): Promise<Request> {
+  const headers = new Headers();
+  for (const [name, value] of Object.entries(req.headers)) {
+    if (Array.isArray(value)) {
+      for (const item of value) headers.append(name, item);
+    } else if (value !== undefined) {
+      headers.set(name, value);
+    }
+  }
+
+  const forwardedProto = headers.get("x-forwarded-proto") ?? "http";
+  const host = headers.get("host") ?? "localhost";
+  const requestUrl = new URL(url, `${forwardedProto}://${host}`);
+  const body = await readEdgeRequestBody(req);
+
+  return new Request(requestUrl, {
+    body,
+    headers,
+    method: req.method,
+  });
 }
 
 /**
@@ -194,6 +255,25 @@ export async function handleApiRoute(
       console.error(`[vinext] API route ${route.filePath} does not export a default function`);
       res.statusCode = 500;
       res.end("API route does not export a default function");
+      return true;
+    }
+
+    if (isEdgeApiRouteModule(apiModule)) {
+      const response = await apiModule.default(await createEdgeApiRequest(req, url));
+      if (!(response instanceof Response)) {
+        throw new Error("Edge API route did not return a Response");
+      }
+
+      res.statusCode = response.status;
+      res.statusMessage = response.statusText;
+      const setCookieHeaders = response.headers.getSetCookie();
+      response.headers.forEach((value, name) => {
+        if (name !== "set-cookie") res.setHeader(name, value);
+      });
+      if (setCookieHeaders.length) {
+        res.setHeader("set-cookie", setCookieHeaders);
+      }
+      res.end(Buffer.from(await response.arrayBuffer()));
       return true;
     }
 

--- a/packages/vinext/src/server/edge-api-runtime.ts
+++ b/packages/vinext/src/server/edge-api-runtime.ts
@@ -1,0 +1,3 @@
+export function isEdgeApiRuntime(runtime: string | undefined): boolean {
+  return runtime === "edge" || runtime === "experimental-edge";
+}

--- a/packages/vinext/src/server/pages-api-route.ts
+++ b/packages/vinext/src/server/pages-api-route.ts
@@ -75,6 +75,8 @@ export async function handlePagesApiRoute(options: HandlePagesApiRouteOptions): 
       throw new Error("Edge API route did not return a Response");
     }
 
+    // This is redundant at runtime after the edge branch for function exports, but it
+    // keeps the Node handler ABI narrowed without a production type assertion.
     if (!isNodeApiRouteModule(route.module)) {
       return new Response("API route does not export a default function", { status: 500 });
     }

--- a/packages/vinext/src/server/pages-api-route.ts
+++ b/packages/vinext/src/server/pages-api-route.ts
@@ -11,8 +11,20 @@ import {
 } from "./pages-node-compat.js";
 import { internalServerErrorResponse } from "./http-error-responses.js";
 
+type PagesApiRouteConfig = {
+  runtime?: string;
+};
+
+type PagesNodeApiRouteHandler = (
+  req: PagesReqResRequest,
+  res: PagesReqResResponse,
+) => void | Promise<void>;
+
+type PagesEdgeApiRouteHandler = (request: Request) => Response | Promise<Response>;
+
 type PagesApiRouteModule = {
-  default?: (req: PagesReqResRequest, res: PagesReqResResponse) => void | Promise<void>;
+  config?: PagesApiRouteConfig;
+  default?: PagesNodeApiRouteHandler | PagesEdgeApiRouteHandler;
 };
 
 export type PagesApiRouteMatch = {
@@ -33,6 +45,24 @@ function buildPagesApiQuery(url: string, params: PagesRequestQuery): PagesReques
   return mergeRouteParamsIntoQuery(parseQueryString(url), params);
 }
 
+function isEdgeApiRuntime(runtime: string | undefined): boolean {
+  return runtime === "edge" || runtime === "experimental-edge";
+}
+
+function isEdgeApiRouteHandler(
+  handler: PagesApiRouteModule["default"],
+  module: PagesApiRouteModule,
+): handler is PagesEdgeApiRouteHandler {
+  return typeof handler === "function" && isEdgeApiRuntime(module.config?.runtime);
+}
+
+function isNodeApiRouteHandler(
+  handler: PagesApiRouteModule["default"],
+  module: PagesApiRouteModule,
+): handler is PagesNodeApiRouteHandler {
+  return typeof handler === "function" && !isEdgeApiRuntime(module.config?.runtime);
+}
+
 export async function handlePagesApiRoute(options: HandlePagesApiRouteOptions): Promise<Response> {
   if (!options.match) {
     return new Response("404 - API route not found", { status: 404 });
@@ -45,6 +75,19 @@ export async function handlePagesApiRoute(options: HandlePagesApiRouteOptions): 
   }
 
   try {
+    if (isEdgeApiRouteHandler(handler, route.module)) {
+      const response = await handler(options.request);
+      if (response instanceof Response) {
+        return response;
+      }
+
+      throw new Error("Edge API route did not return a Response");
+    }
+
+    if (!isNodeApiRouteHandler(handler, route.module)) {
+      throw new Error("Unsupported API route runtime");
+    }
+
     const query = buildPagesApiQuery(options.url, params);
     const body = await parsePagesApiBody(options.request);
     const { req, res, responsePromise } = createPagesReqRes({

--- a/packages/vinext/src/server/pages-api-route.ts
+++ b/packages/vinext/src/server/pages-api-route.ts
@@ -10,6 +10,7 @@ import {
   PagesApiBodyParseError,
 } from "./pages-node-compat.js";
 import { internalServerErrorResponse } from "./http-error-responses.js";
+import { isEdgeApiRuntime } from "./edge-api-runtime.js";
 
 type PagesApiRouteConfig = {
   runtime?: string;
@@ -45,22 +46,16 @@ function buildPagesApiQuery(url: string, params: PagesRequestQuery): PagesReques
   return mergeRouteParamsIntoQuery(parseQueryString(url), params);
 }
 
-function isEdgeApiRuntime(runtime: string | undefined): boolean {
-  return runtime === "edge" || runtime === "experimental-edge";
+function isEdgeApiRouteModule(
+  module: PagesApiRouteModule,
+): module is PagesApiRouteModule & { default: PagesEdgeApiRouteHandler } {
+  return typeof module.default === "function" && isEdgeApiRuntime(module.config?.runtime);
 }
 
-function isEdgeApiRouteHandler(
-  handler: PagesApiRouteModule["default"],
+function isNodeApiRouteModule(
   module: PagesApiRouteModule,
-): handler is PagesEdgeApiRouteHandler {
-  return typeof handler === "function" && isEdgeApiRuntime(module.config?.runtime);
-}
-
-function isNodeApiRouteHandler(
-  handler: PagesApiRouteModule["default"],
-  module: PagesApiRouteModule,
-): handler is PagesNodeApiRouteHandler {
-  return typeof handler === "function" && !isEdgeApiRuntime(module.config?.runtime);
+): module is PagesApiRouteModule & { default: PagesNodeApiRouteHandler } {
+  return typeof module.default === "function" && !isEdgeApiRuntime(module.config?.runtime);
 }
 
 export async function handlePagesApiRoute(options: HandlePagesApiRouteOptions): Promise<Response> {
@@ -69,14 +64,10 @@ export async function handlePagesApiRoute(options: HandlePagesApiRouteOptions): 
   }
 
   const { route, params } = options.match;
-  const handler = route.module.default;
-  if (typeof handler !== "function") {
-    return new Response("API route does not export a default function", { status: 500 });
-  }
 
   try {
-    if (isEdgeApiRouteHandler(handler, route.module)) {
-      const response = await handler(options.request);
+    if (isEdgeApiRouteModule(route.module)) {
+      const response = await route.module.default(options.request);
       if (response instanceof Response) {
         return response;
       }
@@ -84,8 +75,8 @@ export async function handlePagesApiRoute(options: HandlePagesApiRouteOptions): 
       throw new Error("Edge API route did not return a Response");
     }
 
-    if (!isNodeApiRouteHandler(handler, route.module)) {
-      throw new Error("Unsupported API route runtime");
+    if (!isNodeApiRouteModule(route.module)) {
+      return new Response("API route does not export a default function", { status: 500 });
     }
 
     const query = buildPagesApiQuery(options.url, params);
@@ -97,7 +88,7 @@ export async function handlePagesApiRoute(options: HandlePagesApiRouteOptions): 
       url: options.url,
     });
 
-    await handler(req, res);
+    await route.module.default(req, res);
     res.end();
     return await responsePromise;
   } catch (error) {

--- a/tests/api-handler-globals.test.ts
+++ b/tests/api-handler-globals.test.ts
@@ -21,6 +21,7 @@ type MockResponse = http.ServerResponse & {
   _body: string | Buffer;
   _headers: Record<string, string | string[]>;
   _statusCode: number;
+  _writes: Buffer[];
 };
 
 const originalAsyncLocalStorage = Object.getOwnPropertyDescriptor(globalThis, "AsyncLocalStorage");
@@ -74,14 +75,39 @@ function mockRes(): MockResponse {
     _body: "",
     _headers: headers,
     _statusCode: 200,
+    _writes: [] as Buffer[],
     headersSent: false,
     writableEnded: false,
     setHeader(name: string, value: string | string[]) {
       headers[name.toLowerCase()] = value;
     },
+    write(data: string | Buffer | Uint8Array) {
+      const chunk =
+        typeof data === "string"
+          ? Buffer.from(data)
+          : Buffer.isBuffer(data)
+            ? data
+            : Buffer.from(data);
+      res._writes.push(chunk);
+      res._body = Buffer.isBuffer(res._body)
+        ? Buffer.concat([res._body, chunk])
+        : res._body
+          ? Buffer.concat([Buffer.from(res._body), chunk])
+          : chunk;
+      return true;
+    },
     end(data?: string | Buffer) {
-      if (data !== undefined) res._body = data;
+      if (data !== undefined) {
+        if (res._writes.length) {
+          res.write(data);
+        } else {
+          res._body = data;
+        }
+      }
       res._statusCode = res.statusCode;
+    },
+    destroy() {
+      return res;
     },
   } as unknown as MockResponse;
   return res;

--- a/tests/api-handler-globals.test.ts
+++ b/tests/api-handler-globals.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { PassThrough } from "node:stream";
+import type http from "node:http";
+import type { Route } from "../packages/vinext/src/routing/pages-router.js";
+import type { ModuleImporter } from "../packages/vinext/src/server/instrumentation.js";
+
+vi.mock("../packages/vinext/src/server/instrumentation.js", () => ({
+  reportRequestError: vi.fn(() => Promise.resolve()),
+  importModule: (runner: { import(id: string): Promise<unknown> }, id: string) =>
+    runner.import(id) as Promise<Record<string, unknown>>,
+}));
+
+type GlobalWithAsyncLocalStorage = typeof globalThis & {
+  AsyncLocalStorage?: new <Store>() => {
+    getStore(): Store | undefined;
+    run<T>(store: Store, callback: () => T): T;
+  };
+};
+
+type MockResponse = http.ServerResponse & {
+  _body: string | Buffer;
+  _headers: Record<string, string | string[]>;
+  _statusCode: number;
+};
+
+const originalAsyncLocalStorage = Object.getOwnPropertyDescriptor(globalThis, "AsyncLocalStorage");
+
+afterEach(() => {
+  if (originalAsyncLocalStorage) {
+    Object.defineProperty(globalThis, "AsyncLocalStorage", originalAsyncLocalStorage);
+  } else {
+    Reflect.deleteProperty(globalThis, "AsyncLocalStorage");
+  }
+});
+
+function route(pattern: string, filePath = "/fake/api/handler.ts"): Route {
+  const isDynamic = pattern.includes(":");
+  const params = isDynamic ? [...pattern.matchAll(/:(\w+)/g)].map((m) => m[1]) : [];
+  return { pattern, patternParts: pattern.split("/").filter(Boolean), filePath, isDynamic, params };
+}
+
+function mockReq(
+  method: string,
+  url: string,
+  headers: Record<string, string> = {},
+): http.IncomingMessage {
+  const stream = new PassThrough();
+  const req = Object.assign(stream, {
+    method,
+    url,
+    headers,
+    httpVersion: "1.1",
+    httpVersionMajor: 1,
+    httpVersionMinor: 1,
+    complete: false,
+    connection: null,
+    socket: null,
+    aborted: false,
+    rawHeaders: [] as string[],
+    trailers: {} as Record<string, string | undefined>,
+    rawTrailers: [] as string[],
+    statusCode: undefined,
+    statusMessage: undefined,
+  }) as unknown as http.IncomingMessage;
+
+  queueMicrotask(() => stream.push(null));
+  return req;
+}
+
+function mockRes(): MockResponse {
+  const headers: Record<string, string | string[]> = {};
+  const res = {
+    statusCode: 200,
+    _body: "",
+    _headers: headers,
+    _statusCode: 200,
+    headersSent: false,
+    writableEnded: false,
+    setHeader(name: string, value: string | string[]) {
+      headers[name.toLowerCase()] = value;
+    },
+    end(data?: string | Buffer) {
+      if (data !== undefined) res._body = data;
+      res._statusCode = res.statusCode;
+    },
+  } as unknown as MockResponse;
+  return res;
+}
+
+describe("handleApiRoute edge runtime globals", () => {
+  it("installs global AsyncLocalStorage before importing edge API modules", async () => {
+    Reflect.deleteProperty(globalThis, "AsyncLocalStorage");
+
+    vi.resetModules();
+    const { handleApiRoute } = await import("../packages/vinext/src/server/api-handler.js");
+    const server: ModuleImporter = {
+      import: vi.fn().mockImplementation(async () => {
+        const AsyncLocalStorage = (globalThis as GlobalWithAsyncLocalStorage).AsyncLocalStorage;
+        if (typeof AsyncLocalStorage !== "function") {
+          throw new Error("AsyncLocalStorage global missing during user module import");
+        }
+
+        const storage = new AsyncLocalStorage<{ id: string }>();
+        return {
+          config: { runtime: "edge" },
+          default: (request: Request) => {
+            const id = request.headers.get("req-id") ?? "";
+            return storage.run({ id }, () => Response.json(storage.getStore()));
+          },
+        };
+      }),
+    };
+    const req = mockReq("GET", "/api/users", {
+      host: "example.com",
+      "req-id": "req-42",
+    });
+    const res = mockRes();
+
+    await handleApiRoute(server, req, res, "/api/users", [route("/api/users")]);
+
+    expect(res._statusCode).toBe(200);
+    expect(res._body.toString()).toBe(JSON.stringify({ id: "req-42" }));
+  });
+});

--- a/tests/api-handler.test.ts
+++ b/tests/api-handler.test.ts
@@ -845,6 +845,27 @@ describe("handleApiRoute", () => {
       expect(capturedUrl).toBe("https://example.com/api/users?name=alice");
     });
 
+    it("falls back to http for unsupported x-forwarded-proto values", async () => {
+      let capturedUrl = "";
+      const handler = vi.fn((request: Request) => {
+        capturedUrl = request.url;
+        return Response.json({ ok: true });
+      });
+      const server = mockServer({
+        config: { runtime: "edge" },
+        default: handler,
+      });
+      const req = mockReq("GET", "/api/users", undefined, {
+        host: "example.com",
+        "x-forwarded-proto": "ftp, https",
+      });
+      const res = mockRes();
+
+      await handleApiRoute(server, req, res, "/api/users", [route("/api/users")]);
+
+      expect(capturedUrl).toBe("http://example.com/api/users");
+    });
+
     it("preserves multiple Set-Cookie headers from edge API responses", async () => {
       const handler = vi.fn(() => {
         const headers = new Headers();

--- a/tests/api-handler.test.ts
+++ b/tests/api-handler.test.ts
@@ -14,6 +14,7 @@ import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import { AsyncLocalStorage } from "node:async_hooks";
 import { PassThrough } from "node:stream";
 import http from "node:http";
+import type { AddressInfo } from "node:net";
 import { handleApiRoute } from "../packages/vinext/src/server/api-handler.js";
 import {
   reportRequestError,
@@ -84,6 +85,7 @@ function mockRes(): http.ServerResponse & {
   _headers: Record<string, string | string[]>;
   _statusCode: number;
   _ended: boolean;
+  _writes: Buffer[];
 } {
   const headers: Record<string, string | string[]> = {};
   const res = {
@@ -92,6 +94,7 @@ function mockRes(): http.ServerResponse & {
     _headers: headers,
     _statusCode: 200,
     _ended: false,
+    _writes: [] as Buffer[],
     setHeader(name: string, value: string | string[]) {
       headers[name.toLowerCase()] = value;
     },
@@ -107,9 +110,28 @@ function mockRes(): http.ServerResponse & {
         }
       }
     },
+    write(data: string | Buffer | Uint8Array) {
+      const chunk =
+        typeof data === "string"
+          ? Buffer.from(data)
+          : Buffer.isBuffer(data)
+            ? data
+            : Buffer.from(data);
+      res._writes.push(chunk);
+      res._body = Buffer.isBuffer(res._body)
+        ? Buffer.concat([res._body, chunk])
+        : res._body
+          ? Buffer.concat([Buffer.from(res._body), chunk])
+          : chunk;
+      return true;
+    },
     end(data?: string | Buffer) {
       if (data !== undefined) {
-        res._body = data;
+        if (res._writes.length) {
+          res.write(data);
+        } else {
+          res._body = data;
+        }
       }
       res._ended = true;
       res._statusCode = res.statusCode;
@@ -119,6 +141,7 @@ function mockRes(): http.ServerResponse & {
     _headers: Record<string, string | string[]>;
     _statusCode: number;
     _ended: boolean;
+    _writes: Buffer[];
   };
   return res;
 }
@@ -822,6 +845,57 @@ describe("handleApiRoute", () => {
       expect(res._statusCode).toBe(200);
       expect(res._headers["set-cookie"]).toEqual(["one=1; Path=/", "two=2; Path=/"]);
       expect(res._body.toString()).toBe("ok");
+    });
+
+    it("streams edge API response bodies through the dev bridge", async () => {
+      let releaseSecondChunk!: () => void;
+      const secondChunkReady = new Promise<void>((resolve) => {
+        releaseSecondChunk = resolve;
+      });
+      const encoder = new TextEncoder();
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(encoder.encode("first"));
+          void secondChunkReady.then(() => {
+            controller.enqueue(encoder.encode("-second"));
+            controller.close();
+          });
+        },
+      });
+      const handler = vi.fn(() => new Response(body));
+      const server = mockServer({
+        config: { runtime: "edge" },
+        default: handler,
+      });
+      const nodeServer = http.createServer((req, res) => {
+        void handleApiRoute(server, req, res, req.url ?? "/", [route("/api/users")]);
+      });
+
+      try {
+        await new Promise<void>((resolve) => nodeServer.listen(0, resolve));
+        const address = nodeServer.address() as AddressInfo;
+        const response = await fetch(`http://127.0.0.1:${address.port}/api/users`);
+        const reader = response.body?.getReader();
+        expect(reader).toBeDefined();
+        if (!reader) return;
+
+        const first = await reader.read();
+        expect(first.done).toBe(false);
+        expect(new TextDecoder().decode(first.value)).toBe("first");
+
+        releaseSecondChunk();
+        const second = await reader.read();
+        const done = await reader.read();
+
+        expect(second.done).toBe(false);
+        expect(new TextDecoder().decode(second.value)).toBe("-second");
+        expect(done.done).toBe(true);
+      } finally {
+        nodeServer.closeAllConnections();
+        await new Promise<void>((resolve, reject) => {
+          nodeServer.close((error) => (error ? reject(error) : resolve()));
+        });
+      }
     });
   });
 

--- a/tests/api-handler.test.ts
+++ b/tests/api-handler.test.ts
@@ -11,6 +11,7 @@
  * ViteDevServer.
  */
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { AsyncLocalStorage } from "node:async_hooks";
 import { PassThrough } from "node:stream";
 import http from "node:http";
 import { handleApiRoute } from "../packages/vinext/src/server/api-handler.js";
@@ -80,18 +81,18 @@ function mockReq(
  */
 function mockRes(): http.ServerResponse & {
   _body: string | Buffer;
-  _headers: Record<string, string>;
+  _headers: Record<string, string | string[]>;
   _statusCode: number;
   _ended: boolean;
 } {
-  const headers: Record<string, string> = {};
+  const headers: Record<string, string | string[]> = {};
   const res = {
     statusCode: 200,
     _body: "",
     _headers: headers,
     _statusCode: 200,
     _ended: false,
-    setHeader(name: string, value: string) {
+    setHeader(name: string, value: string | string[]) {
       headers[name.toLowerCase()] = value;
     },
     getHeader(name: string) {
@@ -115,7 +116,7 @@ function mockRes(): http.ServerResponse & {
     },
   } as unknown as http.ServerResponse & {
     _body: string | Buffer;
-    _headers: Record<string, string>;
+    _headers: Record<string, string | string[]>;
     _statusCode: number;
     _ended: boolean;
   };
@@ -764,6 +765,63 @@ describe("handleApiRoute", () => {
       await handleApiRoute(server, req, res, "/api/users", [route("/api/users")]);
 
       expect(capturedQuery).toEqual({});
+    });
+  });
+
+  // ── Edge runtime ───────────────────────────────────────────────────
+
+  describe("edge runtime", () => {
+    it("calls edge API route handlers with a Fetch Request and writes their Response", async () => {
+      // Ported from Next.js: test/e2e/edge-async-local-storage/index.test.ts
+      // https://github.com/vercel/next.js/blob/canary/test/e2e/edge-async-local-storage/index.test.ts
+      const storage = new AsyncLocalStorage<{ id: string }>();
+      const handler = vi.fn((request: Request) => {
+        const id = request.headers.get("req-id") ?? "";
+        return storage.run({ id }, async () => {
+          await Promise.resolve();
+          return Response.json(storage.getStore());
+        });
+      });
+      const server = mockServer({
+        config: { runtime: "edge" },
+        default: handler,
+      });
+      const req = mockReq("GET", "/api/users", undefined, {
+        host: "example.com",
+        "req-id": "req-42",
+      });
+      const res = mockRes();
+
+      const handled = await handleApiRoute(server, req, res, "/api/users", [route("/api/users")]);
+
+      expect(handled).toBe(true);
+      expect(handler).toHaveBeenCalledOnce();
+      expect(res._statusCode).toBe(200);
+      expect(res._headers["content-type"]).toBe("application/json");
+      expect(res._body.toString()).toBe(JSON.stringify({ id: "req-42" }));
+    });
+
+    it("preserves multiple Set-Cookie headers from edge API responses", async () => {
+      const handler = vi.fn(() => {
+        const headers = new Headers();
+        headers.append("set-cookie", "one=1; Path=/");
+        headers.append("set-cookie", "two=2; Path=/");
+        return new Response("ok", { headers });
+      });
+      const server = mockServer({
+        config: { runtime: "edge" },
+        default: handler,
+      });
+      const req = mockReq("GET", "/api/users", undefined, {
+        host: "example.com",
+      });
+      const res = mockRes();
+
+      await handleApiRoute(server, req, res, "/api/users", [route("/api/users")]);
+
+      expect(res._statusCode).toBe(200);
+      expect(res._headers["set-cookie"]).toEqual(["one=1; Path=/", "two=2; Path=/"]);
+      expect(res._body.toString()).toBe("ok");
     });
   });
 

--- a/tests/api-handler.test.ts
+++ b/tests/api-handler.test.ts
@@ -824,6 +824,27 @@ describe("handleApiRoute", () => {
       expect(res._body.toString()).toBe(JSON.stringify({ id: "req-42" }));
     });
 
+    it("uses the first x-forwarded-proto value for edge API request URLs", async () => {
+      let capturedUrl = "";
+      const handler = vi.fn((request: Request) => {
+        capturedUrl = request.url;
+        return Response.json({ ok: true });
+      });
+      const server = mockServer({
+        config: { runtime: "edge" },
+        default: handler,
+      });
+      const req = mockReq("GET", "/api/users", undefined, {
+        host: "example.com",
+        "x-forwarded-proto": "https, http",
+      });
+      const res = mockRes();
+
+      await handleApiRoute(server, req, res, "/api/users?name=alice", [route("/api/users")]);
+
+      expect(capturedUrl).toBe("https://example.com/api/users?name=alice");
+    });
+
     it("preserves multiple Set-Cookie headers from edge API responses", async () => {
       const handler = vi.fn(() => {
         const headers = new Headers();
@@ -868,7 +889,14 @@ describe("handleApiRoute", () => {
         default: handler,
       });
       const nodeServer = http.createServer((req, res) => {
-        void handleApiRoute(server, req, res, req.url ?? "/", [route("/api/users")]);
+        handleApiRoute(server, req, res, req.url ?? "/", [route("/api/users")]).catch((error) => {
+          if (!res.headersSent) {
+            res.writeHead(500);
+            res.end(error instanceof Error ? error.message : String(error));
+            return;
+          }
+          res.destroy(error instanceof Error ? error : new Error(String(error)));
+        });
       });
 
       try {
@@ -890,6 +918,74 @@ describe("handleApiRoute", () => {
         expect(second.done).toBe(false);
         expect(new TextDecoder().decode(second.value)).toBe("-second");
         expect(done.done).toBe(true);
+      } finally {
+        nodeServer.closeAllConnections();
+        await new Promise<void>((resolve, reject) => {
+          nodeServer.close((error) => (error ? reject(error) : resolve()));
+        });
+      }
+    });
+
+    it("streams edge API request bodies into the handler before the client finishes sending", async () => {
+      const decoder = new TextDecoder();
+      const handler = vi.fn(async (request: Request) => {
+        const reader = request.body?.getReader();
+        if (!reader) return new Response("missing body", { status: 400 });
+        const first = await reader.read();
+        return new Response(first.done ? "done" : decoder.decode(first.value));
+      });
+      const server = mockServer({
+        config: { runtime: "edge" },
+        default: handler,
+      });
+      const nodeServer = http.createServer((req, res) => {
+        handleApiRoute(server, req, res, req.url ?? "/", [route("/api/users")]).catch((error) => {
+          if (!res.headersSent) {
+            res.writeHead(500);
+            res.end(error instanceof Error ? error.message : String(error));
+            return;
+          }
+          res.destroy(error instanceof Error ? error : new Error(String(error)));
+        });
+      });
+
+      try {
+        await new Promise<void>((resolve) => nodeServer.listen(0, resolve));
+        const address = nodeServer.address() as AddressInfo;
+        const req = http.request({
+          headers: { "content-type": "text/plain", "transfer-encoding": "chunked" },
+          host: "127.0.0.1",
+          method: "POST",
+          path: "/api/users",
+          port: address.port,
+        });
+
+        const responseBody = await new Promise<string>((resolve, reject) => {
+          const timeout = setTimeout(
+            () => reject(new Error("Timed out waiting for streamed request body response")),
+            1000,
+          );
+          req.on("error", (error) => {
+            clearTimeout(timeout);
+            reject(error);
+          });
+          req.on("response", (response) => {
+            const chunks: Buffer[] = [];
+            response.on("data", (chunk: Buffer) => chunks.push(chunk));
+            response.on("error", (error) => {
+              clearTimeout(timeout);
+              reject(error);
+            });
+            response.on("end", () => {
+              clearTimeout(timeout);
+              resolve(Buffer.concat(chunks).toString("utf-8"));
+            });
+          });
+          req.write("first");
+        });
+
+        req.end("-second");
+        expect(responseBody).toBe("first");
       } finally {
         nodeServer.closeAllConnections();
         await new Promise<void>((resolve, reject) => {

--- a/tests/pages-api-route.test.ts
+++ b/tests/pages-api-route.test.ts
@@ -1,18 +1,23 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import { describe, expect, it, vi } from "vite-plus/test";
 import {
   handlePagesApiRoute,
   type PagesApiRouteMatch,
 } from "../packages/vinext/src/server/pages-api-route.js";
 
+type PagesApiRouteModule = PagesApiRouteMatch["route"]["module"];
+
 function createMatch(
-  handler: PagesApiRouteMatch["route"]["module"]["default"],
+  handler: PagesApiRouteModule["default"],
   params: Record<string, string | string[]> = {},
+  moduleConfig?: PagesApiRouteModule["config"],
 ): PagesApiRouteMatch {
   return {
     params,
     route: {
       pattern: "/api/test",
       module: {
+        config: moduleConfig,
         default: handler,
       },
     },
@@ -253,5 +258,70 @@ describe("pages api route", () => {
     // Only one set-cookie header — the replacement
     const cookies = response.headers.getSetCookie();
     expect(cookies).toEqual(["session=xyz"]);
+  });
+
+  it("calls edge API route handlers with a Fetch Request and returns their Response", async () => {
+    // Ported from Next.js: test/e2e/edge-async-local-storage/index.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/edge-async-local-storage/index.test.ts
+    const response = await handlePagesApiRoute({
+      match: createMatch(
+        (request: Request) => {
+          const id = request.headers.get("req-id");
+          return Response.json({ id });
+        },
+        {},
+        { runtime: "edge" },
+      ),
+      request: new Request("https://example.com/api/test", {
+        headers: { "req-id": "req-42" },
+      }),
+      url: "/api/test",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ id: "req-42" });
+  });
+
+  it("preserves nested AsyncLocalStorage state across concurrent edge API requests", async () => {
+    // Ported from Next.js: test/e2e/edge-async-local-storage/index.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/edge-async-local-storage/index.test.ts
+    const topStorage = new AsyncLocalStorage<{ id: string }>();
+    const ids = Array.from({ length: 100 }, (_, i) => `req-${i}`);
+
+    const responses = await Promise.all(
+      ids.map((id) =>
+        handlePagesApiRoute({
+          match: createMatch(
+            (request: Request) => {
+              const requestId = request.headers.get("req-id") ?? "";
+              return topStorage.run({ id: requestId }, async () => {
+                const nestedStorage = new AsyncLocalStorage<string>();
+                const nested = await nestedStorage.run(`nested-${requestId}`, async () => {
+                  await Promise.resolve();
+                  return { nestedId: nestedStorage.getStore() };
+                });
+
+                await Promise.resolve();
+                return Response.json({ ...nested, ...topStorage.getStore() });
+              });
+            },
+            {},
+            { runtime: "experimental-edge" },
+          ),
+          request: new Request("https://example.com/api/test", {
+            headers: { "req-id": id },
+          }),
+          url: "/api/test",
+        }),
+      ),
+    );
+
+    for (const [index, response] of responses.entries()) {
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({
+        id: ids[index],
+        nestedId: `nested-${ids[index]}`,
+      });
+    }
   });
 });


### PR DESCRIPTION
## Overview

| Field | Detail |
| --- | --- |
| Goal | Match Next.js Pages Edge API route execution for handlers that use `config.runtime` and return a Fetch `Response`. |
| Core change | Route `edge` and `experimental-edge` Pages API modules through Fetch `Request`/`Response` semantics before Node API body parsing. |
| Boundary | Keeps Node-style Pages API routes on the existing `req`/`res` adapter while adding the Edge API branch at the route execution boundary. |
| Primary files | `packages/vinext/src/server/pages-api-route.ts`, `packages/vinext/src/server/api-handler.ts`, `packages/vinext/src/server/edge-api-runtime.ts`, `tests/pages-api-route.test.ts`, `tests/api-handler.test.ts`, `tests/api-handler-globals.test.ts` |
| Expected impact | Valid Edge API handlers can use global `AsyncLocalStorage`, `request.headers.get()`, return `Response.json()`, stream request and response bodies in dev, and preserve user storage state across concurrent requests. |

## Why

Pages API route runtime selection changes the handler contract. A Node API route receives `req`/`res`; an Edge API route receives a Fetch `Request` and returns a Fetch `Response`. The bug was that vinext installed the Edge runtime global in the generated/Web helper but still executed `config.runtime = "edge"` Pages API modules through the Node adapter in dev, so a real Next-style module using unqualified global `AsyncLocalStorage` during module evaluation could fail before API execution.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| Edge API routes | Runtime config owns the handler ABI. | Detects `edge` and `experimental-edge` before Node body parsing and calls the handler with the Fetch `Request`. |
| Node API routes | Existing `pages/api` `req`/`res` behavior must stay intact. | Leaves non-edge modules on the existing query/body/cookie adapter. |
| Dev/prod parity | Request handling branches should not diverge between server paths. | Mirrors the Edge API branch in both the generated Web Request helper and the dev Node bridge. |
| Edge globals | User modules may construct `new AsyncLocalStorage()` at module scope. | Installs `server-globals` before the dev bridge imports the user API module. |
| Streaming | Dev Edge API request and response bodies should flow through Web/Node streams instead of being fully buffered first. | Creates streaming Fetch `Request` bodies with `duplex: "half"` and pipes Web `Response.body` chunks into `ServerResponse.write()` with drain/close/error handling. |

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| `export const config = { runtime: "edge" }` in `pages/api/*` | Handler received Node-style `req`, so `request.headers.get()` failed and vinext returned 500. | Handler receives a Fetch `Request`; its returned `Response` is sent to the caller. |
| `runtime: "experimental-edge"` | Treated as Node API route execution. | Treated as the Edge API route alias Next.js still accepts. |
| Unqualified global `AsyncLocalStorage` in dev Edge API modules | The dev bridge could import the user module before installing the global. | `api-handler.ts` installs `server-globals` before `importModule()` evaluates the user module. |
| Concurrent user `AsyncLocalStorage` in Edge API handlers | Not reachable because the handler ABI was wrong. | Covered with 100 concurrent calls and nested storage instances. |
| Multiple `Set-Cookie` headers from dev Edge API `Response` | Intended by the bridge but previously unasserted. | Covered with a direct dev bridge regression using `Headers.getSetCookie()`. |
| Streaming Edge API responses in dev | The bridge buffered with `await response.arrayBuffer()` before `res.end()`. | The bridge reads chunks from `response.body` and writes them to the real Node response as they arrive. |
| Streaming Edge API requests in dev | The bridge buffered the full Node request body before constructing the Fetch `Request`. | The bridge exposes the incoming body as a Web `ReadableStream`, so handlers can consume request chunks before the client finishes sending. |
| `x-forwarded-proto` with multiple proxy values | The dev bridge used the raw comma-separated value as the URL scheme. | The bridge uses the first trimmed value, matching the prod server path. |

<details>
<summary>Maintainer review path</summary>

1. `packages/vinext/src/server/pages-api-route.ts`: shared Web Request route helper. Review the runtime split before `parsePagesApiBody()` and the unchanged Node branch after it.
2. `packages/vinext/src/server/api-handler.ts`: dev Node bridge. Review the `server-globals` import, `createEdgeApiRequest()`, Edge response header forwarding, `Set-Cookie` preservation, streamed request body construction, and streamed response body writer.
3. `packages/vinext/src/server/edge-api-runtime.ts`: shared runtime discriminator for `edge` and `experimental-edge`.
4. `tests/pages-api-route.test.ts`: Next.js contract port for Fetch Request execution and concurrent nested `AsyncLocalStorage` isolation.
5. `tests/api-handler.test.ts`: dev bridge coverage proving the Node-side server path uses the same Edge API ABI, preserves multiple `Set-Cookie` headers, handles comma-separated `x-forwarded-proto`, streams a delayed Web response body through a real `http.ServerResponse`, and streams request chunks into the handler before the client finishes sending.
6. `tests/api-handler-globals.test.ts`: dev bridge regression for the exact module-evaluation failure mode: delete the global, dynamically import `api-handler`, then mock user module import constructing `new AsyncLocalStorage()` at module scope.

</details>

<details>
<summary>Validation</summary>

- `vp test run tests/pages-api-route.test.ts -t "edge API route"` initially failed with `expected 500 to be 200`, confirming the candidate.
- `vp test run tests/api-handler-globals.test.ts` initially failed before the `server-globals` dev bridge import with `AsyncLocalStorage global missing during user module import`, confirming the reviewer feedback.
- `vp test run tests/api-handler.test.ts -t "edge runtime"`
- `vp check packages/vinext/src/server/api-handler.ts packages/vinext/src/server/pages-api-route.ts packages/vinext/src/server/edge-api-runtime.ts tests/api-handler.test.ts`
- `vp test run tests/api-handler-globals.test.ts tests/api-handler.test.ts tests/pages-api-route.test.ts tests/edge-globals.test.ts`
- `vp check`
- Commit hook also ran formatting, type/lint checks, `knip`, and rebuilt `packages/vinext/dist` where applicable.

</details>

<details>
<summary>Risk / compatibility</summary>

- Public API: no new public API surface.
- Runtime behavior: only modules whose exported config runtime is `edge` or `experimental-edge` change execution mode.
- Node Pages API compatibility: non-edge modules still use the existing body parsing and `req`/`res` helpers.
- Headers: the dev bridge forwards Edge `Response` headers and preserves multiple `Set-Cookie` values.
- Request bodies: the dev bridge now exposes Edge request bodies as Web streams instead of pre-buffering them into memory.
- Response bodies: the dev bridge now streams Edge `Response.body` chunks through Node's `ServerResponse`, including drain backpressure and close/error handling.
- Scope: this does not implement a full Edge sandbox. vinext already exposes the `AsyncLocalStorage` global through `server-globals`; this PR makes the dev bridge install it before user API module evaluation and fixes the API route ABI needed by the Next.js test candidate.

</details>

<details>
<summary>Non-goals</summary>

- No changes to App Router route handlers.
- No broader Edge runtime module restriction or sandbox parity work.
- No changes to non-edge Pages API body parser behavior.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| [Next.js edge async local storage e2e](https://github.com/vercel/next.js/blob/canary/test/e2e/edge-async-local-storage/index.test.ts) | Source of the reported candidate and the concurrent ALS contract ported here. |
| [Next.js single Edge API fixture](https://github.com/vercel/next.js/blob/canary/test/e2e/edge-async-local-storage/pages/api/single.js) | Shows module-level `AsyncLocalStorage`, `request.headers.get()`, and `Response.json()`. |
| [Next.js multiple Edge API fixture](https://github.com/vercel/next.js/blob/canary/test/e2e/edge-async-local-storage/pages/api/multiple.js) | Shows nested per-request storage instances under concurrency. |
| [Next.js pages-edge-api template](https://github.com/vercel/next.js/blob/canary/packages/next/src/build/templates/pages-edge-api.ts) | Shows Edge Pages API routes wrapped as Fetch `Request` to `Response` handlers. |
| [Next.js edge sandbox global ALS](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/web/sandbox/context.ts) | Confirms `AsyncLocalStorage` is installed globally in the Edge sandbox. |
