### PR TITLE
refactor(router): quarantine navigation runtime topology

### DIFF
--- a/packages/vinext/src/build/prerender.ts
+++ b/packages/vinext/src/build/prerender.ts
@@ -234,12 +234,6 @@ export function extractRscPayloadFromPrerenderedHtml(html: string): Uint8Array |
       );
       continue;
     }
-    if (script.startsWith(RSC_RUNTIME_BOOTSTRAP_EXPRESSION)) {
-      chunks.push(
-        decodeRscEmbeddedChunk(parseRscChunkPushArgument(script, RSC_RUNTIME_CHUNK_FULL_PREFIX)),
-      );
-      continue;
-    }
 
     if (script.startsWith(RSC_LEGACY_CHUNK_SCRIPT_PREFIX)) {
       chunks.push(

--- a/packages/vinext/src/build/prerender.ts
+++ b/packages/vinext/src/build/prerender.ts
@@ -41,6 +41,7 @@ import { runWithHeadersContext, headersContextFromRequest } from "vinext/shims/h
 import { createValidFileMatcher, findFileWithExtensions } from "../routing/file-matcher.js";
 import { normalizeStaticPathsEntry, type StaticPathsEntry } from "../routing/route-pattern.js";
 import { VINEXT_PRERENDER_SECRET_HEADER } from "../server/headers.js";
+import { safeJsonStringify } from "../server/html.js";
 import { startProdServer } from "../server/prod-server.js";
 import { readPrerenderSecret } from "./server-manifest.js";
 export { readPrerenderSecret } from "./server-manifest.js";
@@ -193,7 +194,7 @@ const RSC_LEGACY_DONE_SCRIPT = "self.__VINEXT_RSC_DONE__=true";
 // safeJsonStringify(chunk) argument. Keep these in sync with the writer in
 // packages/vinext/src/server/app-ssr-stream.ts.
 const RSC_LEGACY_CHUNK_FULL_PREFIX = `${RSC_LEGACY_CHUNK_SCRIPT_PREFIX}self.__VINEXT_RSC_CHUNKS__.push(`;
-const RSC_RUNTIME_BOOTSTRAP_EXPRESSION = `((self[Symbol.for(${JSON.stringify(
+const RSC_RUNTIME_BOOTSTRAP_EXPRESSION = `((self[Symbol.for(${safeJsonStringify(
   NAVIGATION_RUNTIME_SYMBOL_DESCRIPTION,
 )})]??={bootstrap:{routeManifest:null},functions:{}}).bootstrap.rsc??={rsc:[]})`;
 const RSC_RUNTIME_CHUNK_FULL_PREFIX = `${RSC_RUNTIME_BOOTSTRAP_EXPRESSION}.rsc.push(`;

--- a/packages/vinext/src/build/prerender.ts
+++ b/packages/vinext/src/build/prerender.ts
@@ -30,7 +30,6 @@ import {
   RSC_EMBEDDED_BINARY_CHUNK,
   type RscEmbeddedChunk,
 } from "../server/app-rsc-embedded-chunks.js";
-import { NAVIGATION_RUNTIME_SYMBOL_DESCRIPTION } from "../client/navigation-runtime.js";
 import {
   NoOpCacheHandler,
   setCacheHandler,
@@ -40,8 +39,8 @@ import {
 import { runWithHeadersContext, headersContextFromRequest } from "vinext/shims/headers";
 import { createValidFileMatcher, findFileWithExtensions } from "../routing/file-matcher.js";
 import { normalizeStaticPathsEntry, type StaticPathsEntry } from "../routing/route-pattern.js";
+import { navigationRuntimeRscBootstrapExpression } from "../server/app-ssr-stream.js";
 import { VINEXT_PRERENDER_SECRET_HEADER } from "../server/headers.js";
-import { safeJsonStringify } from "../server/html.js";
 import { startProdServer } from "../server/prod-server.js";
 import { readPrerenderSecret } from "./server-manifest.js";
 export { readPrerenderSecret } from "./server-manifest.js";
@@ -190,13 +189,10 @@ const DEFAULT_CONCURRENCY = Math.min(os.availableParallelism(), 8);
 
 const RSC_LEGACY_CHUNK_SCRIPT_PREFIX = "self.__VINEXT_RSC_CHUNKS__=self.__VINEXT_RSC_CHUNKS__||[];";
 const RSC_LEGACY_DONE_SCRIPT = "self.__VINEXT_RSC_DONE__=true";
-// Full literals that createRscEmbedTransform concatenates before the
-// safeJsonStringify(chunk) argument. Keep these in sync with the writer in
-// packages/vinext/src/server/app-ssr-stream.ts.
+// Full literals that createRscEmbedTransform concatenates before the chunk
+// argument in packages/vinext/src/server/app-ssr-stream.ts.
 const RSC_LEGACY_CHUNK_FULL_PREFIX = `${RSC_LEGACY_CHUNK_SCRIPT_PREFIX}self.__VINEXT_RSC_CHUNKS__.push(`;
-const RSC_RUNTIME_BOOTSTRAP_EXPRESSION = `((self[Symbol.for(${safeJsonStringify(
-  NAVIGATION_RUNTIME_SYMBOL_DESCRIPTION,
-)})]??={bootstrap:{routeManifest:null},functions:{}}).bootstrap.rsc??={rsc:[]})`;
+const RSC_RUNTIME_BOOTSTRAP_EXPRESSION = navigationRuntimeRscBootstrapExpression();
 const RSC_RUNTIME_CHUNK_FULL_PREFIX = `${RSC_RUNTIME_BOOTSTRAP_EXPRESSION}.rsc.push(`;
 const RSC_RUNTIME_DONE_SCRIPT = `${RSC_RUNTIME_BOOTSTRAP_EXPRESSION}.done=true`;
 

--- a/packages/vinext/src/build/prerender.ts
+++ b/packages/vinext/src/build/prerender.ts
@@ -30,6 +30,7 @@ import {
   RSC_EMBEDDED_BINARY_CHUNK,
   type RscEmbeddedChunk,
 } from "../server/app-rsc-embedded-chunks.js";
+import { NAVIGATION_RUNTIME_SYMBOL_DESCRIPTION } from "../client/navigation-runtime.js";
 import {
   NoOpCacheHandler,
   setCacheHandler,
@@ -186,12 +187,17 @@ const NOT_FOUND_SENTINEL_PATH = "/__vinext_nonexistent_for_404__";
 
 const DEFAULT_CONCURRENCY = Math.min(os.availableParallelism(), 8);
 
-const RSC_CHUNK_SCRIPT_PREFIX = "self.__VINEXT_RSC_CHUNKS__=self.__VINEXT_RSC_CHUNKS__||[];";
-const RSC_DONE_MARKER = "__VINEXT_RSC_DONE__=true";
-// Full literal that createRscEmbedTransform concatenates before the
-// safeJsonStringify(chunk) argument. Keep this in sync with the writer at
-// packages/vinext/src/server/app-ssr-stream.ts:73.
-const RSC_CHUNK_FULL_PREFIX = `${RSC_CHUNK_SCRIPT_PREFIX}self.__VINEXT_RSC_CHUNKS__.push(`;
+const RSC_LEGACY_CHUNK_SCRIPT_PREFIX = "self.__VINEXT_RSC_CHUNKS__=self.__VINEXT_RSC_CHUNKS__||[];";
+const RSC_LEGACY_DONE_SCRIPT = "self.__VINEXT_RSC_DONE__=true";
+// Full literals that createRscEmbedTransform concatenates before the
+// safeJsonStringify(chunk) argument. Keep these in sync with the writer in
+// packages/vinext/src/server/app-ssr-stream.ts.
+const RSC_LEGACY_CHUNK_FULL_PREFIX = `${RSC_LEGACY_CHUNK_SCRIPT_PREFIX}self.__VINEXT_RSC_CHUNKS__.push(`;
+const RSC_RUNTIME_BOOTSTRAP_EXPRESSION = `((self[Symbol.for(${JSON.stringify(
+  NAVIGATION_RUNTIME_SYMBOL_DESCRIPTION,
+)})]??={bootstrap:{routeManifest:null},functions:{}}).bootstrap.rsc??={rsc:[]})`;
+const RSC_RUNTIME_CHUNK_FULL_PREFIX = `${RSC_RUNTIME_BOOTSTRAP_EXPRESSION}.rsc.push(`;
+const RSC_RUNTIME_DONE_SCRIPT = `${RSC_RUNTIME_BOOTSTRAP_EXPRESSION}.done=true`;
 
 /**
  * Reconstruct the RSC payload from a prerender HTML response by parsing the
@@ -217,13 +223,28 @@ export function extractRscPayloadFromPrerenderedHtml(html: string): Uint8Array |
   while ((match = scriptPattern.exec(html)) !== null) {
     const script = (match[1] ?? "").trim().replace(/;$/, "");
 
-    if (script === `self.${RSC_DONE_MARKER}`) {
+    if (script === RSC_RUNTIME_DONE_SCRIPT || script === RSC_LEGACY_DONE_SCRIPT) {
       sawDone = true;
       continue;
     }
 
-    if (script.startsWith(RSC_CHUNK_SCRIPT_PREFIX)) {
-      chunks.push(decodeRscEmbeddedChunk(parseRscChunkPushArgument(script)));
+    if (script.startsWith(RSC_RUNTIME_CHUNK_FULL_PREFIX)) {
+      chunks.push(
+        decodeRscEmbeddedChunk(parseRscChunkPushArgument(script, RSC_RUNTIME_CHUNK_FULL_PREFIX)),
+      );
+      continue;
+    }
+    if (script.startsWith(RSC_RUNTIME_BOOTSTRAP_EXPRESSION)) {
+      chunks.push(
+        decodeRscEmbeddedChunk(parseRscChunkPushArgument(script, RSC_RUNTIME_CHUNK_FULL_PREFIX)),
+      );
+      continue;
+    }
+
+    if (script.startsWith(RSC_LEGACY_CHUNK_SCRIPT_PREFIX)) {
+      chunks.push(
+        decodeRscEmbeddedChunk(parseRscChunkPushArgument(script, RSC_LEGACY_CHUNK_FULL_PREFIX)),
+      );
     }
   }
 
@@ -238,7 +259,7 @@ export function extractRscPayloadFromPrerenderedHtml(html: string): Uint8Array |
     );
   }
   if (!sawDone) {
-    throw new Error("[vinext] Malformed prerender RSC embed: missing __VINEXT_RSC_DONE__ marker");
+    throw new Error("[vinext] Malformed prerender RSC embed: missing RSC done marker");
   }
 
   return concatUint8Arrays(chunks);
@@ -251,11 +272,11 @@ export function extractRscPayloadFromPrerenderedHtml(html: string): Uint8Array |
  * prefix and ends with `)`. JSON.parse on the slice catches any tampering or
  * trailing code.
  */
-function parseRscChunkPushArgument(script: string): RscEmbeddedChunk {
-  if (!script.startsWith(RSC_CHUNK_FULL_PREFIX) || !script.endsWith(")")) {
+function parseRscChunkPushArgument(script: string, chunkPrefix: string): RscEmbeddedChunk {
+  if (!script.startsWith(chunkPrefix) || !script.endsWith(")")) {
     throw new Error("[vinext] Malformed prerender RSC embed: unexpected chunk script shape");
   }
-  const jsonSource = script.slice(RSC_CHUNK_FULL_PREFIX.length, -1);
+  const jsonSource = script.slice(chunkPrefix.length, -1);
   let parsed: unknown;
   try {
     parsed = JSON.parse(jsonSource);

--- a/packages/vinext/src/client/navigation-runtime.ts
+++ b/packages/vinext/src/client/navigation-runtime.ts
@@ -138,8 +138,9 @@ function isNavigationRuntimeRscBootstrap(value: unknown): value is NavigationRun
   const nav = Reflect.get(value, "nav");
   const params = Reflect.get(value, "params");
   const rsc = Reflect.get(value, "rsc");
-  // RSC chunks are trusted inline-script payloads, but the public runtime seam
-  // still rejects malformed ambient state before hydration consumes it.
+  // getNavigationRuntime() runs at bootstrap/read boundaries, not per chunk.
+  // Keep full validation here so malformed ambient state is rejected before
+  // hydration consumes it instead of caching a stale validation result.
   return (
     (done === undefined || typeof done === "boolean") &&
     (nav === undefined || isNavigationRuntimeSnapshot(nav)) &&
@@ -233,6 +234,11 @@ export function getNavigationRuntime(): NavigationRuntime | null {
   return isNavigationRuntime(runtime) ? runtime : null;
 }
 
+/**
+ * Returns the registered browser runtime, creating it when a window exists.
+ * Without a window, callers receive a detached runtime and must retain the
+ * returned reference themselves; server calls are intentionally not global.
+ */
 function ensureNavigationRuntime(): NavigationRuntime {
   const runtimeWindow = readRuntimeWindow();
   if (runtimeWindow === null) {

--- a/packages/vinext/src/client/navigation-runtime.ts
+++ b/packages/vinext/src/client/navigation-runtime.ts
@@ -1,0 +1,145 @@
+import type { RouteManifest } from "../routing/app-route-graph.js";
+
+export type NavigationRuntimeSnapshot = {
+  pathname: string;
+  searchParams: [string, string][];
+};
+
+export type NavigationRuntimeRscChunk = string | [3, string];
+
+export type NavigationRuntimeRscBootstrap = {
+  nav?: NavigationRuntimeSnapshot;
+  params?: Record<string, string | string[]>;
+  rsc: NavigationRuntimeRscChunk[];
+};
+
+export type NavigationRuntimeKind = "navigate" | "traverse" | "refresh";
+
+export type NavigationRuntimeHistoryUpdateMode = "push" | "replace";
+
+export type NavigationRuntimeTraversalIntent = {
+  direction: "back" | "forward" | "unknown";
+  historyState: unknown;
+  targetHistoryIndex: number | null;
+};
+
+export type NavigationRuntimeNavigate = (
+  href: string,
+  redirectDepth?: number,
+  navigationKind?: NavigationRuntimeKind,
+  historyUpdateMode?: NavigationRuntimeHistoryUpdateMode,
+  previousNextUrlOverride?: string | null,
+  programmaticTransition?: boolean,
+  traversalIntent?: NavigationRuntimeTraversalIntent,
+) => Promise<void>;
+
+export type NavigationRuntimeFunctions = {
+  clearNavigationCaches?: () => void;
+  commitHashNavigation?: (
+    href: string,
+    historyUpdateMode: NavigationRuntimeHistoryUpdateMode,
+    scroll: boolean,
+  ) => void;
+  navigate?: NavigationRuntimeNavigate;
+  pingVisibleLinks?: () => void;
+};
+
+export type NavigationRuntimeBootstrap = {
+  routeManifest: RouteManifest | null;
+  rsc: NavigationRuntimeRscBootstrap | undefined;
+};
+
+export type NavigationRuntime = {
+  bootstrap: NavigationRuntimeBootstrap;
+  functions: NavigationRuntimeFunctions;
+};
+
+export const NAVIGATION_RUNTIME_KEY = Symbol.for("vinext.navigationRuntime");
+
+function createNavigationRuntime(): NavigationRuntime {
+  return {
+    bootstrap: {
+      routeManifest: null,
+      rsc: undefined,
+    },
+    functions: {},
+  };
+}
+
+function readRuntimeWindow(): Window | null {
+  if (typeof window === "undefined") return null;
+  return window;
+}
+
+function isNavigationRuntimeFunctions(value: unknown): value is NavigationRuntimeFunctions {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  return (
+    isOptionalRuntimeFunction(Reflect.get(value, "clearNavigationCaches")) &&
+    isOptionalRuntimeFunction(Reflect.get(value, "commitHashNavigation")) &&
+    isOptionalRuntimeFunction(Reflect.get(value, "navigate")) &&
+    isOptionalRuntimeFunction(Reflect.get(value, "pingVisibleLinks"))
+  );
+}
+
+function isNavigationRuntimeBootstrap(value: unknown): value is NavigationRuntimeBootstrap {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNavigationRuntime(value: unknown): value is NavigationRuntime {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  if (!("bootstrap" in value) || !("functions" in value)) return false;
+  const { bootstrap, functions } = value;
+  return isNavigationRuntimeBootstrap(bootstrap) && isNavigationRuntimeFunctions(functions);
+}
+
+function isOptionalRuntimeFunction(value: unknown): boolean {
+  return value === undefined || typeof value === "function";
+}
+
+export function getNavigationRuntime(): NavigationRuntime | null {
+  const runtimeWindow = readRuntimeWindow();
+  if (runtimeWindow === null) return null;
+
+  const runtime: unknown = Reflect.get(runtimeWindow, NAVIGATION_RUNTIME_KEY);
+  return isNavigationRuntime(runtime) ? runtime : null;
+}
+
+function ensureNavigationRuntime(): NavigationRuntime {
+  const runtimeWindow = readRuntimeWindow();
+  if (runtimeWindow === null) {
+    return createNavigationRuntime();
+  }
+
+  const existingRuntime: unknown = Reflect.get(runtimeWindow, NAVIGATION_RUNTIME_KEY);
+  const runtime = isNavigationRuntime(existingRuntime)
+    ? existingRuntime
+    : createNavigationRuntime();
+  Reflect.set(runtimeWindow, NAVIGATION_RUNTIME_KEY, runtime);
+  return runtime;
+}
+
+export function registerNavigationRuntimeBootstrap(
+  bootstrap: Partial<NavigationRuntimeBootstrap>,
+): NavigationRuntime {
+  const runtime = ensureNavigationRuntime();
+  runtime.bootstrap = {
+    ...runtime.bootstrap,
+    ...bootstrap,
+  };
+  return runtime;
+}
+
+export function registerNavigationRuntimeFunctions(
+  functions: Partial<NavigationRuntimeFunctions>,
+): NavigationRuntime {
+  const runtime = ensureNavigationRuntime();
+  runtime.functions = {
+    ...runtime.functions,
+    ...functions,
+  };
+  return runtime;
+}
+
+export function hasAppNavigationRuntime(): boolean {
+  return typeof getNavigationRuntime()?.functions.navigate === "function";
+}

--- a/packages/vinext/src/client/navigation-runtime.ts
+++ b/packages/vinext/src/client/navigation-runtime.ts
@@ -138,6 +138,8 @@ function isNavigationRuntimeRscBootstrap(value: unknown): value is NavigationRun
   const nav = Reflect.get(value, "nav");
   const params = Reflect.get(value, "params");
   const rsc = Reflect.get(value, "rsc");
+  // RSC chunks are trusted inline-script payloads, but the public runtime seam
+  // still rejects malformed ambient state before hydration consumes it.
   return (
     (done === undefined || typeof done === "boolean") &&
     (nav === undefined || isNavigationRuntimeSnapshot(nav)) &&
@@ -183,15 +185,23 @@ function isNavigationRuntimeRouteManifest(value: unknown): value is RouteManifes
   if (typeof graphVersion !== "string" || !isUnknownRecord(segmentGraph)) return false;
   const interceptions = Reflect.get(segmentGraph, "interceptions");
   const interceptionsBySlotId = Reflect.get(segmentGraph, "interceptionsBySlotId");
-  return (
-    ROUTE_MANIFEST_SEGMENT_GRAPH_MAP_KEYS.every(
+  if (
+    !ROUTE_MANIFEST_SEGMENT_GRAPH_MAP_KEYS.every(
       (key) => Reflect.get(segmentGraph, key) instanceof Map,
-    ) &&
-    interceptions instanceof Map &&
-    Array.from(interceptions.values()).every(isNavigationRuntimeInterception) &&
-    interceptionsBySlotId instanceof Map &&
-    Array.from(interceptionsBySlotId.values()).every(isNavigationRuntimeInterceptionArray)
-  );
+    ) ||
+    !(interceptions instanceof Map) ||
+    !(interceptionsBySlotId instanceof Map)
+  ) {
+    return false;
+  }
+
+  for (const interception of interceptions.values()) {
+    if (!isNavigationRuntimeInterception(interception)) return false;
+  }
+  for (const slotInterceptions of interceptionsBySlotId.values()) {
+    if (!isNavigationRuntimeInterceptionArray(slotInterceptions)) return false;
+  }
+  return true;
 }
 
 function isNavigationRuntimeBootstrap(value: unknown): value is NavigationRuntimeBootstrap {

--- a/packages/vinext/src/client/navigation-runtime.ts
+++ b/packages/vinext/src/client/navigation-runtime.ts
@@ -1,4 +1,5 @@
-import type { RouteManifest } from "../routing/app-route-graph.js";
+import type { RouteManifest, RouteManifestInterception } from "../routing/app-route-graph.js";
+import { isUnknownRecord } from "../utils/record.js";
 
 export type NavigationRuntimeSnapshot = {
   pathname: string;
@@ -8,6 +9,7 @@ export type NavigationRuntimeSnapshot = {
 export type NavigationRuntimeRscChunk = string | [3, string];
 
 export type NavigationRuntimeRscBootstrap = {
+  done?: boolean;
   nav?: NavigationRuntimeSnapshot;
   params?: Record<string, string | string[]>;
   rsc: NavigationRuntimeRscChunk[];
@@ -54,7 +56,23 @@ export type NavigationRuntime = {
   functions: NavigationRuntimeFunctions;
 };
 
-export const NAVIGATION_RUNTIME_KEY = Symbol.for("vinext.navigationRuntime");
+export const NAVIGATION_RUNTIME_SYMBOL_DESCRIPTION = "vinext.navigationRuntime";
+export const NAVIGATION_RUNTIME_KEY = Symbol.for(NAVIGATION_RUNTIME_SYMBOL_DESCRIPTION);
+
+const ROUTE_MANIFEST_SEGMENT_GRAPH_MAP_KEYS: readonly string[] = [
+  "boundaries",
+  "defaults",
+  "interceptions",
+  "interceptionsBySlotId",
+  "layouts",
+  "pages",
+  "rootBoundaries",
+  "routeHandlers",
+  "routes",
+  "slotBindings",
+  "slots",
+  "templates",
+];
 
 function createNavigationRuntime(): NavigationRuntime {
   return {
@@ -72,7 +90,7 @@ function readRuntimeWindow(): Window | null {
 }
 
 function isNavigationRuntimeFunctions(value: unknown): value is NavigationRuntimeFunctions {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  if (!isUnknownRecord(value)) return false;
   return (
     isOptionalRuntimeFunction(Reflect.get(value, "clearNavigationCaches")) &&
     isOptionalRuntimeFunction(Reflect.get(value, "commitHashNavigation")) &&
@@ -81,12 +99,113 @@ function isNavigationRuntimeFunctions(value: unknown): value is NavigationRuntim
   );
 }
 
+function isNavigationRuntimeRscChunk(value: unknown): value is NavigationRuntimeRscChunk {
+  if (typeof value === "string") return true;
+  return (
+    Array.isArray(value) && value.length === 2 && value[0] === 3 && typeof value[1] === "string"
+  );
+}
+
+function isNavigationRuntimeSnapshot(value: unknown): value is NavigationRuntimeSnapshot {
+  if (!isUnknownRecord(value)) return false;
+  const pathname = Reflect.get(value, "pathname");
+  const searchParams = Reflect.get(value, "searchParams");
+  return (
+    typeof pathname === "string" &&
+    Array.isArray(searchParams) &&
+    searchParams.every(
+      (entry): entry is [string, string] =>
+        Array.isArray(entry) &&
+        entry.length === 2 &&
+        typeof entry[0] === "string" &&
+        typeof entry[1] === "string",
+    )
+  );
+}
+
+function isNavigationRuntimeParams(value: unknown): value is Record<string, string | string[]> {
+  if (!isUnknownRecord(value)) return false;
+  return Object.values(value).every(
+    (entry) =>
+      typeof entry === "string" ||
+      (Array.isArray(entry) && entry.every((part) => typeof part === "string")),
+  );
+}
+
+function isNavigationRuntimeRscBootstrap(value: unknown): value is NavigationRuntimeRscBootstrap {
+  if (!isUnknownRecord(value)) return false;
+  const done = Reflect.get(value, "done");
+  const nav = Reflect.get(value, "nav");
+  const params = Reflect.get(value, "params");
+  const rsc = Reflect.get(value, "rsc");
+  return (
+    (done === undefined || typeof done === "boolean") &&
+    (nav === undefined || isNavigationRuntimeSnapshot(nav)) &&
+    (params === undefined || isNavigationRuntimeParams(params)) &&
+    Array.isArray(rsc) &&
+    rsc.every(isNavigationRuntimeRscChunk)
+  );
+}
+
+function isReadonlyStringArray(value: unknown): value is readonly string[] {
+  return Array.isArray(value) && value.every((entry) => typeof entry === "string");
+}
+
+function isNullableString(value: unknown): value is string | null {
+  return value === null || typeof value === "string";
+}
+
+function isNavigationRuntimeInterception(value: unknown): value is RouteManifestInterception {
+  if (!isUnknownRecord(value)) return false;
+  return (
+    typeof value.id === "string" &&
+    typeof value.sourcePattern === "string" &&
+    isReadonlyStringArray(value.sourcePatternParts) &&
+    typeof value.targetPattern === "string" &&
+    isReadonlyStringArray(value.targetPatternParts) &&
+    typeof value.slotId === "string" &&
+    isNullableString(value.ownerLayoutId) &&
+    isNullableString(value.interceptingRouteId) &&
+    isNullableString(value.targetRouteId)
+  );
+}
+
+function isNavigationRuntimeInterceptionArray(
+  value: unknown,
+): value is readonly RouteManifestInterception[] {
+  return Array.isArray(value) && value.every(isNavigationRuntimeInterception);
+}
+
+function isNavigationRuntimeRouteManifest(value: unknown): value is RouteManifest {
+  if (!isUnknownRecord(value)) return false;
+  const graphVersion = Reflect.get(value, "graphVersion");
+  const segmentGraph = Reflect.get(value, "segmentGraph");
+  if (typeof graphVersion !== "string" || !isUnknownRecord(segmentGraph)) return false;
+  const interceptions = Reflect.get(segmentGraph, "interceptions");
+  const interceptionsBySlotId = Reflect.get(segmentGraph, "interceptionsBySlotId");
+  return (
+    ROUTE_MANIFEST_SEGMENT_GRAPH_MAP_KEYS.every(
+      (key) => Reflect.get(segmentGraph, key) instanceof Map,
+    ) &&
+    interceptions instanceof Map &&
+    Array.from(interceptions.values()).every(isNavigationRuntimeInterception) &&
+    interceptionsBySlotId instanceof Map &&
+    Array.from(interceptionsBySlotId.values()).every(isNavigationRuntimeInterceptionArray)
+  );
+}
+
 function isNavigationRuntimeBootstrap(value: unknown): value is NavigationRuntimeBootstrap {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
+  if (!isUnknownRecord(value)) return false;
+  const routeManifest = Reflect.get(value, "routeManifest");
+  const rsc = Reflect.get(value, "rsc");
+  return (
+    (routeManifest === null || isNavigationRuntimeRouteManifest(routeManifest)) &&
+    (rsc === undefined || isNavigationRuntimeRscBootstrap(rsc))
+  );
 }
 
 function isNavigationRuntime(value: unknown): value is NavigationRuntime {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  if (!isUnknownRecord(value)) return false;
   if (!("bootstrap" in value) || !("functions" in value)) return false;
   const { bootstrap, functions } = value;
   return isNavigationRuntimeBootstrap(bootstrap) && isNavigationRuntimeFunctions(functions);
@@ -137,6 +256,32 @@ export function registerNavigationRuntimeFunctions(
     ...runtime.functions,
     ...functions,
   };
+  return runtime;
+}
+
+export function ensureNavigationRuntimeRscBootstrap(): NavigationRuntimeRscBootstrap {
+  const runtime = ensureNavigationRuntime();
+  return ensureNavigationRuntimeRscBootstrapForRuntime(runtime);
+}
+
+function ensureNavigationRuntimeRscBootstrapForRuntime(
+  runtime: NavigationRuntime,
+): NavigationRuntimeRscBootstrap {
+  const rscBootstrap = runtime.bootstrap.rsc;
+  if (rscBootstrap === undefined) {
+    const nextRscBootstrap: NavigationRuntimeRscBootstrap = { rsc: [] };
+    runtime.bootstrap.rsc = nextRscBootstrap;
+    return nextRscBootstrap;
+  }
+
+  return rscBootstrap;
+}
+
+export function subscribeNavigationRuntimeRscChunk(
+  chunk: NavigationRuntimeRscChunk,
+): NavigationRuntime {
+  const runtime = ensureNavigationRuntime();
+  ensureNavigationRuntimeRscBootstrapForRuntime(runtime).rsc.push(chunk);
   return runtime;
 }
 

--- a/packages/vinext/src/entries/app-browser-entry.ts
+++ b/packages/vinext/src/entries/app-browser-entry.ts
@@ -1,4 +1,4 @@
-import { resolveRuntimeEntryModule } from "./runtime-entry-module.js";
+import { resolveClientRuntimeModule, resolveRuntimeEntryModule } from "./runtime-entry-module.js";
 import type { VinextLinkPrefetchRoute } from "../client/vinext-next-data.js";
 import type { AppRoute } from "../routing/app-router.js";
 import type { RouteManifest } from "../routing/app-route-graph.js";
@@ -15,6 +15,7 @@ export function generateBrowserEntry(
   routeManifest: RouteManifest | null = null,
 ): string {
   const entryPath = resolveRuntimeEntryModule("app-browser-entry");
+  const navigationRuntimePath = resolveClientRuntimeModule("navigation-runtime");
   const prefetchRoutes: VinextLinkPrefetchRoute[] = routes
     .filter((route) => isLinkPrefetchRoute(route))
     .map((route) => ({
@@ -22,8 +23,12 @@ export function generateBrowserEntry(
       isDynamic: route.isDynamic,
     }));
 
-  return `window.__VINEXT_LINK_PREFETCH_ROUTES__ = ${JSON.stringify(prefetchRoutes)};
-window.__VINEXT_ROUTE_MANIFEST__ = ${buildRouteManifestExpression(routeManifest)};
+  return `import { registerNavigationRuntimeBootstrap } from ${JSON.stringify(navigationRuntimePath)};
+
+window.__VINEXT_LINK_PREFETCH_ROUTES__ = ${JSON.stringify(prefetchRoutes)};
+registerNavigationRuntimeBootstrap({
+    routeManifest: ${buildRouteManifestExpression(routeManifest)}
+});
 import ${JSON.stringify(entryPath)};`;
 }
 

--- a/packages/vinext/src/entries/runtime-entry-module.ts
+++ b/packages/vinext/src/entries/runtime-entry-module.ts
@@ -37,12 +37,20 @@ export function resolveEntryPath(rel: string, base: string): string {
  * published packages.
  */
 export function resolveRuntimeEntryModule(name: string): string {
+  return resolveRuntimeModulePath("server", name);
+}
+
+export function resolveClientRuntimeModule(name: string): string {
+  return resolveRuntimeModulePath("client", name);
+}
+
+function resolveRuntimeModulePath(directory: "client" | "server", name: string): string {
   for (const ext of [".ts", ".js", ".mts", ".mjs"]) {
-    const filePath = resolveEntryPath(`../server/${name}${ext}`, import.meta.url);
+    const filePath = resolveEntryPath(`../${directory}/${name}${ext}`, import.meta.url);
     if (fs.existsSync(filePath)) {
       return filePath;
     }
   }
 
-  return resolveEntryPath(`../server/${name}.js`, import.meta.url);
+  return resolveEntryPath(`../${directory}/${name}.js`, import.meta.url);
 }

--- a/packages/vinext/src/global.d.ts
+++ b/packages/vinext/src/global.d.ts
@@ -18,7 +18,6 @@
 
 import type { Root } from "react-dom/client";
 import type { OnRequestErrorHandler } from "./server/instrumentation";
-import type { RouteManifest } from "./routing/app-route-graph";
 import type { CachedRscResponse, PrefetchCacheEntry } from "vinext/shims/navigation";
 
 // `window.next` is declared inline in `./client/window-next.ts` (mirroring
@@ -85,60 +84,6 @@ declare global {
     __VINEXT_RSC_ROOT__: Root | undefined;
 
     /**
-     * The client-side RSC navigation function for App Router.
-     * Registered by the browser RSC entry on `window` so that the navigation
-     * shim, Link, and Form can trigger RSC re-fetches without a direct import.
-     *
-     * @param href - The destination URL (may be absolute or relative).
-     * @param redirectDepth - Internal parameter used to detect redirect loops.
-     * @param navigationKind - Internal hint for traversal vs regular navigation.
-     * @param historyUpdateMode - Internal hint for when history should publish.
-     * @param traversalIntent - Internal popstate direction/history metadata.
-     */
-    __VINEXT_RSC_NAVIGATE__:
-      | ((
-          href: string,
-          redirectDepth?: number,
-          navigationKind?: "navigate" | "traverse" | "refresh",
-          historyUpdateMode?: "push" | "replace",
-          previousNextUrlOverride?: string | null,
-          programmaticTransition?: boolean,
-          traversalIntent?: {
-            direction: "back" | "forward" | "unknown";
-            historyState: unknown;
-            targetHistoryIndex: number | null;
-          },
-        ) => Promise<void>)
-      | undefined;
-
-    /**
-     * Invalidates the client-side RSC navigation caches (visited-response +
-     * prefetch). Installed by the browser RSC entry so that `router.refresh()`
-     * in the navigation shim can drop stale RSC payloads for routes other
-     * than the current one — required for Next.js parity, since refresh is
-     * specified to invalidate the entire segment cache (see
-     * Next.js refresh-reducer.ts).
-     */
-    __VINEXT_CLEAR_NAV_CACHES__: (() => void) | undefined;
-
-    /**
-     * Static App Router route graph read model embedded by the generated
-     * browser entry. Navigation planning uses it as the semantic authority
-     * for root-boundary, layout, and target parallel-slot facts.
-     */
-    __VINEXT_ROUTE_MANIFEST__: RouteManifest | null | undefined;
-
-    /**
-     * Commits an App Router hash-only navigation without fetching RSC data.
-     * Installed by the browser RSC entry so `next/navigation` and `next/link`
-     * can route app-owned hash-only history writes through the same vinext
-     * history metadata/index allocator as approved RSC commits.
-     */
-    __VINEXT_RSC_COMMIT_HASH_NAVIGATION__:
-      | ((href: string, historyUpdateMode: "push" | "replace", scroll: boolean) => void)
-      | undefined;
-
-    /**
      * A Promise that resolves when the current in-flight popstate RSC navigation
      * finishes rendering.
      * Set by the popstate handler in the browser RSC entry; read by
@@ -160,14 +105,6 @@ declare global {
      * Prevents duplicate prefetch requests for the same URL.
      */
     __VINEXT_RSC_PREFETCHED_URLS__: Set<string> | undefined;
-
-    /**
-     * Re-prefetches currently visible App Router links after cache invalidation
-     * or router-state changes. Installed by `next/link` when Link is loaded on
-     * the client; called opportunistically by navigation/cache owners without a
-     * direct import to avoid a circular dependency.
-     */
-    __VINEXT_PING_VISIBLE_LINKS__: (() => void) | undefined;
 
     // ── Next.js conventional globals ────────────────────────────────────────
     //
@@ -225,21 +162,6 @@ declare global {
    */
   // oxlint-disable-next-line no-var
   var __VINEXT_RSC_NAV__: { pathname: string; searchParams: [string, string][] } | undefined;
-
-  /**
-   * Legacy RSC embed format (pre-progressive-streaming).
-   * A single object containing all RSC chunks and the route params, embedded
-   * in a single `<script>` block.
-   * Still read by the browser entry for backwards compatibility with older
-   * cached HTML responses.
-   *
-   * @deprecated Use `__VINEXT_RSC_CHUNKS__` / `__VINEXT_RSC_DONE__` /
-   *   `__VINEXT_RSC_PARAMS__` instead.
-   */
-  // oxlint-disable-next-line no-var
-  var __VINEXT_RSC__:
-    | { rsc: (string | [3, string])[]; params: Record<string, string | string[]> }
-    | undefined;
 
   // ── globalThis globals — server-side / Cloudflare Workers ─────────────────
   //

--- a/packages/vinext/src/routing/utils.ts
+++ b/packages/vinext/src/routing/utils.ts
@@ -123,6 +123,10 @@ export function normalizePathnameForRouteMatch(pathname: string): string {
     .join("/");
 }
 
+export function splitPathnameForRouteMatch(pathname: string): string[] {
+  return normalizePathnameForRouteMatch(pathname).split("/").filter(Boolean);
+}
+
 /**
  * Strict pathname normalization for live request handling.
  * Throws on malformed percent-encoding so callers can return 400.

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -933,6 +933,8 @@ async function readInitialRscStream(): Promise<ReadableStream<Uint8Array> | null
         registerNavigationRuntimeBootstrap({ rsc: undefined });
         return chunksToReadableStream(runtimeRsc.rsc);
       }
+      // The progressive stream must capture this bootstrap object before any
+      // cleanup clears it from the runtime.
       return createProgressiveRscStream();
     }
 

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -36,6 +36,7 @@ import {
   registerNavigationRuntimeBootstrap,
   registerNavigationRuntimeFunctions,
   type NavigationRuntimeNavigate,
+  type NavigationRuntimeRscBootstrap,
 } from "../client/navigation-runtime.js";
 import { scrollToHashTargetOnNextFrame } from "vinext/shims/hash-scroll";
 import { installWindowNext } from "../client/window-next.js";
@@ -51,6 +52,7 @@ import {
   type NavigationPayloadOutcome,
   type PendingBrowserRouterState,
 } from "./app-browser-navigation-controller.js";
+import { resolveManifestNavigationInterceptionContext } from "./app-browser-interception-context.js";
 import {
   createDiscardedServerActionRefreshScheduler,
   createServerActionInitiationSnapshot,
@@ -573,6 +575,7 @@ type NavigationRequestState = {
 
 function getRequestState(
   navigationKind: NavigationKind,
+  targetPathname: string,
   previousNextUrlOverride?: string | null,
   traverseHistoryState?: unknown,
 ): NavigationRequestState {
@@ -586,12 +589,12 @@ function getRequestState(
     };
   }
 
-  // Two branches for "navigate":
+  // Three branches for "navigate":
   // 1. previousNextUrl !== null → a committed intercepted navigation set this
   //    in browser state (requires proof). This is the proven interception path.
-  // 2. previousNextUrl === null → send no interception context. This fires for
-  //    non-intercepted navigations (direct loads, normal client navs) where no
-  //    proven interception state exists.
+  // 2. route manifest declares current URL can intercept target URL → ask the
+  //    server for an intercepted payload using manifest route facts only.
+  // 3. otherwise, send no interception context.
   switch (navigationKind) {
     case "navigate": {
       const currentPreviousNextUrl = getBrowserRouterState().previousNextUrl;
@@ -602,6 +605,18 @@ function getRequestState(
             __basePath,
           ),
           previousNextUrl: currentPreviousNextUrl,
+        };
+      }
+      const manifestInterceptionContext = resolveManifestNavigationInterceptionContext({
+        basePath: __basePath,
+        currentPathname: window.location.pathname,
+        routeManifest: getBrowserRouteManifest(),
+        targetPathname,
+      });
+      if (manifestInterceptionContext !== null) {
+        return {
+          interceptionContext: manifestInterceptionContext,
+          previousNextUrl: window.location.pathname + window.location.search,
         };
       }
       return {
@@ -903,31 +918,22 @@ function recoverFromBadInitialRscResponse(reason: string): null {
 
 async function readInitialRscStream(): Promise<ReadableStream<Uint8Array> | null> {
   const vinext = getVinextBrowserGlobal();
-  const embeddedRsc = getNavigationRuntime()?.bootstrap.rsc;
+  const runtimeRsc = getNavigationRuntime()?.bootstrap.rsc;
 
-  if (embeddedRsc || vinext.__VINEXT_RSC_CHUNKS__ || vinext.__VINEXT_RSC_DONE__) {
+  if (runtimeRsc || vinext.__VINEXT_RSC_CHUNKS__ || vinext.__VINEXT_RSC_DONE__) {
     // Reaching the embedded-RSC branch means the server successfully rendered
     // the page — any prior reload flag for this path is stale and must be
     // cleared so a future failure gets its own fresh recovery attempt.
     clearReloadFlag();
     clearHardNavigationLoopGuard();
 
-    if (embeddedRsc) {
-      registerNavigationRuntimeBootstrap({ rsc: undefined });
-
-      const params = embeddedRsc.params ?? {};
-      if (embeddedRsc.params) {
-        applyClientParams(embeddedRsc.params);
+    if (runtimeRsc) {
+      applyRuntimeRscBootstrap(runtimeRsc);
+      if (runtimeRsc.done) {
+        registerNavigationRuntimeBootstrap({ rsc: undefined });
+        return chunksToReadableStream(runtimeRsc.rsc);
       }
-      if (embeddedRsc.nav) {
-        restoreHydrationNavigationContext(
-          embeddedRsc.nav.pathname,
-          embeddedRsc.nav.searchParams,
-          params,
-        );
-      }
-
-      return chunksToReadableStream(embeddedRsc.rsc);
+      return createProgressiveRscStream();
     }
 
     const params = vinext.__VINEXT_RSC_PARAMS__ ?? {};
@@ -992,6 +998,16 @@ async function readInitialRscStream(): Promise<ReadableStream<Uint8Array> | null
   restoreHydrationNavigationContext(window.location.pathname, window.location.search, params);
 
   return rscResponse.body;
+}
+
+function applyRuntimeRscBootstrap(rsc: NavigationRuntimeRscBootstrap): void {
+  const params = rsc.params ?? {};
+  if (rsc.params) {
+    applyClientParams(rsc.params);
+  }
+  if (rsc.nav) {
+    restoreHydrationNavigationContext(rsc.nav.pathname, rsc.nav.searchParams, params);
+  }
 }
 
 function registerServerActionCallback(): void {
@@ -1222,6 +1238,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
         const url = new URL(currentHref, window.location.origin);
         const requestState = getRequestState(
           navigationKind,
+          url.pathname,
           currentPrevNextUrl,
           activeTraversalIntent?.historyState,
         );

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -18,8 +18,6 @@ import {
   consumePrefetchResponse,
   createCachedRscResponseSnapshot,
   createClientNavigationRenderSnapshot,
-  getCurrentNextUrl,
-  getCurrentInterceptionContext,
   getClientNavigationRenderContext,
   invalidatePrefetchCache,
   pushHistoryStateWithoutNotify,
@@ -33,6 +31,12 @@ import {
   type CachedRscResponse,
   type ClientNavigationRenderSnapshot,
 } from "vinext/shims/navigation";
+import {
+  getNavigationRuntime,
+  registerNavigationRuntimeBootstrap,
+  registerNavigationRuntimeFunctions,
+  type NavigationRuntimeNavigate,
+} from "../client/navigation-runtime.js";
 import { scrollToHashTargetOnNextFrame } from "vinext/shims/hash-scroll";
 import { installWindowNext } from "../client/window-next.js";
 import {
@@ -152,7 +156,7 @@ const VISITED_RESPONSE_CACHE_TTL = 5 * 60_000;
 const MAX_TRAVERSAL_CACHE_TTL = 30 * 60_000;
 const CLIENT_RSC_COMPATIBILITY_ID = getVinextRscCompatibilityId();
 function getBrowserRouteManifest(): RouteManifest | null {
-  return window.__VINEXT_ROUTE_MANIFEST__ ?? null;
+  return getNavigationRuntime()?.bootstrap.routeManifest ?? null;
 }
 
 const browserNavigationController = createAppBrowserNavigationController({
@@ -162,10 +166,14 @@ const browserNavigationController = createAppBrowserNavigationController({
 const discardedServerActionRefreshScheduler = createDiscardedServerActionRefreshScheduler({
   runRefresh() {
     clearClientNavigationCaches();
-    const rscNavigate = window.__VINEXT_RSC_NAVIGATE__;
-    if (typeof rscNavigate !== "function") return;
-
-    void rscNavigate(window.location.href, 0, "refresh", undefined, undefined, true);
+    void getNavigationRuntime()?.functions.navigate?.(
+      window.location.href,
+      0,
+      "refresh",
+      undefined,
+      undefined,
+      true,
+    );
   },
 });
 const NavigationCommitSignal = browserNavigationController.NavigationCommitSignal;
@@ -581,10 +589,9 @@ function getRequestState(
   // Two branches for "navigate":
   // 1. previousNextUrl !== null → a committed intercepted navigation set this
   //    in browser state (requires proof). This is the proven interception path.
-  // 2. previousNextUrl === null → fall through to legacy DOM-derived context.
-  //    This fires for non-intercepted navigations (direct loads, normal client
-  //    navs) where no proven interception state exists. The legacy path returns
-  //    whatever the current DOM/history context reflects.
+  // 2. previousNextUrl === null → send no interception context. This fires for
+  //    non-intercepted navigations (direct loads, normal client navs) where no
+  //    proven interception state exists.
   switch (navigationKind) {
     case "navigate": {
       const currentPreviousNextUrl = getBrowserRouterState().previousNextUrl;
@@ -598,8 +605,8 @@ function getRequestState(
         };
       }
       return {
-        interceptionContext: getCurrentInterceptionContext(),
-        previousNextUrl: getCurrentNextUrl(),
+        interceptionContext: null,
+        previousNextUrl: null,
       };
     }
     case "traverse": {
@@ -688,7 +695,7 @@ function BrowserRoot({
 
   // Publish the stable ref object and dispatch during layout commit. This keeps
   // the module-level escape hatches aligned with React's committed tree without
-  // performing module writes during render. __VINEXT_RSC_NAVIGATE__ is assigned
+  // performing module writes during render. The navigation runtime is registered
   // after hydrateRoot() returns; by then this layout effect has already run for
   // the hydration commit, so getBrowserRouterState() never observes a null ref.
   useLayoutEffect(() => {
@@ -710,7 +717,7 @@ function BrowserRoot({
 
   useLayoutEffect(() => {
     setMountedSlotsHeader(getMountedSlotIdsHeader(stateRef.current.elements));
-    window.__VINEXT_PING_VISIBLE_LINKS__?.();
+    getNavigationRuntime()?.functions.pingVisibleLinks?.();
   }, [treeState.elements]);
 
   useLayoutEffect(() => {
@@ -858,7 +865,7 @@ function clearReloadFlag(): void {
 // reload once so the server has a chance to render the correct error page
 // as HTML. On the second attempt (detected via the sessionStorage flag), the
 // endpoint is persistently broken. Returns null so main() aborts the
-// hydration bootstrap without registering `__VINEXT_RSC_*` globals —
+// hydration bootstrap without registering RSC navigation globals —
 // including during the brief window between reload() firing and the page
 // actually unloading — so external probes never see a half-hydrated page.
 function recoverFromBadInitialRscResponse(reason: string): null {
@@ -896,31 +903,31 @@ function recoverFromBadInitialRscResponse(reason: string): null {
 
 async function readInitialRscStream(): Promise<ReadableStream<Uint8Array> | null> {
   const vinext = getVinextBrowserGlobal();
+  const embeddedRsc = getNavigationRuntime()?.bootstrap.rsc;
 
-  if (vinext.__VINEXT_RSC__ || vinext.__VINEXT_RSC_CHUNKS__ || vinext.__VINEXT_RSC_DONE__) {
+  if (embeddedRsc || vinext.__VINEXT_RSC_CHUNKS__ || vinext.__VINEXT_RSC_DONE__) {
     // Reaching the embedded-RSC branch means the server successfully rendered
     // the page — any prior reload flag for this path is stale and must be
     // cleared so a future failure gets its own fresh recovery attempt.
     clearReloadFlag();
     clearHardNavigationLoopGuard();
 
-    if (vinext.__VINEXT_RSC__) {
-      const embedData = vinext.__VINEXT_RSC__;
-      delete vinext.__VINEXT_RSC__;
+    if (embeddedRsc) {
+      registerNavigationRuntimeBootstrap({ rsc: undefined });
 
-      const params = embedData.params ?? {};
-      if (embedData.params) {
-        applyClientParams(embedData.params);
+      const params = embeddedRsc.params ?? {};
+      if (embeddedRsc.params) {
+        applyClientParams(embeddedRsc.params);
       }
-      if (embedData.nav) {
+      if (embeddedRsc.nav) {
         restoreHydrationNavigationContext(
-          embedData.nav.pathname,
-          embedData.nav.searchParams,
+          embeddedRsc.nav.pathname,
+          embeddedRsc.nav.searchParams,
           params,
         );
       }
 
-      return chunksToReadableStream(embedData.rsc);
+      return chunksToReadableStream(embeddedRsc.rsc);
     }
 
     const params = vinext.__VINEXT_RSC_PARAMS__ ?? {};
@@ -1114,7 +1121,7 @@ async function main(): Promise<void> {
   // null signals that readInitialRscStream aborted hydration — either because
   // a reload is in flight (first-attempt recovery) or the endpoint is
   // persistently broken (post-reload). Bootstrap is a separate synchronous
-  // helper so the null-branch structurally cannot reach any __VINEXT_RSC_*
+  // helper so the null-branch structurally cannot reach any RSC bootstrap
   // global assignment, even if a future refactor interposes async work here.
   if (rscStream === null) return;
   bootstrapHydration(rscStream);
@@ -1168,15 +1175,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
     startTransition,
   });
 
-  // Exposed so the navigation shim's `router.refresh()` can invalidate the
-  // entire client navigation cache (visited-response + prefetch) before
-  // re-fetching, matching Next.js refresh semantics — see refresh-reducer.ts
-  // header comment: "the segment cache contains the actual RSC data which
-  // needs to be re-fetched."
-  window.__VINEXT_CLEAR_NAV_CACHES__ = clearClientNavigationCaches;
-  window.__VINEXT_RSC_COMMIT_HASH_NAVIGATION__ = commitHashOnlyNavigation;
-
-  window.__VINEXT_RSC_NAVIGATE__ = async function navigateRsc(
+  const navigateRsc: NavigationRuntimeNavigate = async function navigateRsc(
     href: string,
     redirectDepth = 0,
     navigationKind: NavigationKind = "navigate",
@@ -1500,6 +1499,14 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
     }
   };
 
+  // Exposed through one typed runtime seam so next/navigation, Link, Form, and
+  // the browser entry share a single App Router capability contract.
+  registerNavigationRuntimeFunctions({
+    clearNavigationCaches: clearClientNavigationCaches,
+    commitHashNavigation: commitHashOnlyNavigation,
+    navigate: navigateRsc,
+  });
+
   if ("scrollRestoration" in history) {
     history.scrollRestoration = "manual";
   }
@@ -1514,7 +1521,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
       browserNavigationController,
     ),
     getPendingNavigation: () => window.__VINEXT_RSC_PENDING__,
-    getNavigate: () => window.__VINEXT_RSC_NAVIGATE__,
+    getNavigate: () => getNavigationRuntime()?.functions.navigate,
     isCurrentNavigation: browserNavigationController.isCurrentNavigation.bind(
       browserNavigationController,
     ),

--- a/packages/vinext/src/server/app-browser-interception-context.ts
+++ b/packages/vinext/src/server/app-browser-interception-context.ts
@@ -1,0 +1,38 @@
+import type { RouteManifest } from "../routing/app-route-graph.js";
+import { matchRoutePattern, matchRoutePatternPrefix } from "../routing/route-pattern.js";
+import { splitPathnameForRouteMatch } from "../routing/utils.js";
+import { stripBasePath } from "../utils/base-path.js";
+
+type ResolveManifestNavigationInterceptionContextOptions = {
+  basePath: string;
+  currentPathname: string;
+  routeManifest: RouteManifest | null;
+  targetPathname: string;
+};
+
+/**
+ * Resolve the first-hop interception context from declared route topology.
+ *
+ * This is intentionally manifest-only: it lets a normal browser navigation
+ * ask the server for an intercepted payload when the current URL is a declared
+ * interception source for the target URL, without reintroducing snapshot
+ * topology as route/layout/slot authority.
+ */
+export function resolveManifestNavigationInterceptionContext(
+  options: ResolveManifestNavigationInterceptionContextOptions,
+): string | null {
+  if (options.routeManifest === null) return null;
+
+  const currentPathname = stripBasePath(options.currentPathname, options.basePath);
+  const targetPathname = stripBasePath(options.targetPathname, options.basePath);
+  const sourceParts = splitPathnameForRouteMatch(currentPathname);
+  const targetParts = splitPathnameForRouteMatch(targetPathname);
+
+  for (const interception of options.routeManifest.segmentGraph.interceptions.values()) {
+    if (!matchRoutePatternPrefix(sourceParts, interception.sourcePatternParts)) continue;
+    if (matchRoutePattern(targetParts, interception.targetPatternParts) === null) continue;
+    return currentPathname;
+  }
+
+  return null;
+}

--- a/packages/vinext/src/server/app-browser-interception-context.ts
+++ b/packages/vinext/src/server/app-browser-interception-context.ts
@@ -17,6 +17,9 @@ type ResolveManifestNavigationInterceptionContextOptions = {
  * ask the server for an intercepted payload when the current URL is a declared
  * interception source for the target URL, without reintroducing snapshot
  * topology as route/layout/slot authority.
+ *
+ * When multiple manifest interceptions match, the first one wins. That order
+ * is owned by the deterministic route graph builder.
  */
 export function resolveManifestNavigationInterceptionContext(
   options: ResolveManifestNavigationInterceptionContextOptions,

--- a/packages/vinext/src/server/app-browser-stream.ts
+++ b/packages/vinext/src/server/app-browser-stream.ts
@@ -94,8 +94,9 @@ export function createProgressiveRscStream(): ReadableStream<Uint8Array> {
       const liveRuntimeRsc =
         getNavigationRuntime() === null ? null : ensureNavigationRuntimeRscBootstrap();
       const arr = liveRuntimeRsc?.rsc ?? (vinext.__VINEXT_RSC_CHUNKS__ ??= []);
-      // Keep a stable reference to the bootstrap object that inline done
-      // scripts mutate. The runtime clears it only after done closes this stream.
+      // Capture the bootstrap object before it can be cleared. Inline done
+      // scripts mutate this same object, and clearing happens only after the
+      // stream has already been consumed or closed.
       arr.push = function (...chunks: RscEmbeddedChunk[]): number {
         const length = Array.prototype.push.apply(this, chunks);
 

--- a/packages/vinext/src/server/app-browser-stream.ts
+++ b/packages/vinext/src/server/app-browser-stream.ts
@@ -94,6 +94,8 @@ export function createProgressiveRscStream(): ReadableStream<Uint8Array> {
       const liveRuntimeRsc =
         getNavigationRuntime() === null ? null : ensureNavigationRuntimeRscBootstrap();
       const arr = liveRuntimeRsc?.rsc ?? (vinext.__VINEXT_RSC_CHUNKS__ ??= []);
+      // Keep a stable reference to the bootstrap object that inline done
+      // scripts mutate. The runtime clears it only after done closes this stream.
       arr.push = function (...chunks: RscEmbeddedChunk[]): number {
         const length = Array.prototype.push.apply(this, chunks);
 

--- a/packages/vinext/src/server/app-browser-stream.ts
+++ b/packages/vinext/src/server/app-browser-stream.ts
@@ -1,5 +1,10 @@
 import type { ReactFormState } from "react-dom/client";
-import type { NavigationRuntimeSnapshot } from "../client/navigation-runtime.js";
+import {
+  ensureNavigationRuntimeRscBootstrap,
+  getNavigationRuntime,
+  type NavigationRuntimeRscBootstrap,
+  type NavigationRuntimeSnapshot,
+} from "../client/navigation-runtime.js";
 import { RSC_FORM_STATE_GLOBAL } from "./app-browser-hydration.js";
 import { decodeRscEmbeddedChunk, type RscEmbeddedChunk } from "./app-rsc-embedded-chunks.js";
 
@@ -37,24 +42,29 @@ export function chunksToReadableStream(
   });
 }
 
+function getNavigationRuntimeRscBootstrap(): NavigationRuntimeRscBootstrap | null {
+  return getNavigationRuntime()?.bootstrap.rsc ?? null;
+}
+
 /**
  * Create a ReadableStream from progressively-embedded RSC chunks.
  *
- * The server pushes chunks into `__VINEXT_RSC_CHUNKS__` via inline <script>
- * tags. We monkey-patch `push()` so new chunks stream to React immediately
- * instead of polling with setTimeout.
+ * The server pushes chunks into the typed navigation runtime via inline
+ * <script> tags. We monkey-patch `push()` so new chunks stream to React
+ * immediately instead of polling with setTimeout.
  */
 export function createProgressiveRscStream(): ReadableStream<Uint8Array> {
   return new ReadableStream<Uint8Array>({
     start(controller) {
       const vinext = getVinextBrowserGlobal();
-      const initialChunks = vinext.__VINEXT_RSC_CHUNKS__ ?? [];
+      const runtimeRsc = getNavigationRuntimeRscBootstrap();
+      const initialChunks = runtimeRsc?.rsc ?? vinext.__VINEXT_RSC_CHUNKS__ ?? [];
 
       for (const chunk of initialChunks) {
         controller.enqueue(decodeRscEmbeddedChunk(chunk));
       }
 
-      if (vinext.__VINEXT_RSC_DONE__) {
+      if (runtimeRsc?.done || vinext.__VINEXT_RSC_DONE__) {
         controller.close();
         return;
       }
@@ -81,7 +91,9 @@ export function createProgressiveRscStream(): ReadableStream<Uint8Array> {
         }
       };
 
-      const arr = (vinext.__VINEXT_RSC_CHUNKS__ ??= []);
+      const liveRuntimeRsc =
+        getNavigationRuntime() === null ? null : ensureNavigationRuntimeRscBootstrap();
+      const arr = liveRuntimeRsc?.rsc ?? (vinext.__VINEXT_RSC_CHUNKS__ ??= []);
       arr.push = function (...chunks: RscEmbeddedChunk[]): number {
         const length = Array.prototype.push.apply(this, chunks);
 
@@ -91,7 +103,7 @@ export function createProgressiveRscStream(): ReadableStream<Uint8Array> {
           controller.enqueue(decodeRscEmbeddedChunk(chunk));
         }
 
-        if (vinext.__VINEXT_RSC_DONE__) {
+        if (liveRuntimeRsc?.done || vinext.__VINEXT_RSC_DONE__) {
           closeOnce();
         }
 

--- a/packages/vinext/src/server/app-browser-stream.ts
+++ b/packages/vinext/src/server/app-browser-stream.ts
@@ -1,25 +1,14 @@
 import type { ReactFormState } from "react-dom/client";
+import type { NavigationRuntimeSnapshot } from "../client/navigation-runtime.js";
 import { RSC_FORM_STATE_GLOBAL } from "./app-browser-hydration.js";
 import { decodeRscEmbeddedChunk, type RscEmbeddedChunk } from "./app-rsc-embedded-chunks.js";
 
-type NavigationSnapshot = {
-  pathname: string;
-  searchParams: [string, string][];
-};
-
-type LegacyRscEmbedData = {
-  rsc: RscEmbeddedChunk[];
-  params?: Record<string, string | string[]>;
-  nav?: NavigationSnapshot;
-};
-
 type VinextBrowserGlobals = {
-  __VINEXT_RSC__?: LegacyRscEmbedData;
   __VINEXT_RSC_CHUNKS__?: RscEmbeddedChunk[];
   __VINEXT_RSC_DONE__?: boolean;
   [RSC_FORM_STATE_GLOBAL]?: ReactFormState;
   __VINEXT_RSC_PARAMS__?: Record<string, string | string[]>;
-  __VINEXT_RSC_NAV__?: NavigationSnapshot;
+  __VINEXT_RSC_NAV__?: NavigationRuntimeSnapshot;
 };
 
 export function getVinextBrowserGlobal(): typeof globalThis & VinextBrowserGlobals {

--- a/packages/vinext/src/server/app-rsc-route-matching.ts
+++ b/packages/vinext/src/server/app-rsc-route-matching.ts
@@ -4,7 +4,7 @@ import {
   matchRoutePatternPrefix,
   type RoutePatternParams,
 } from "../routing/route-pattern.js";
-import { normalizePathnameForRouteMatch } from "../routing/utils.js";
+import { splitPathnameForRouteMatch } from "../routing/utils.js";
 
 type AppRscRouteParams = RoutePatternParams;
 
@@ -68,7 +68,7 @@ function createRouteParams(): AppRscRouteParams {
 function appRscPathnameParts(pathname: string): string[] {
   const pathOnly = pathname.split("?")[0];
   const normalized = pathOnly === "/" ? "/" : pathOnly.replace(/\/$/, "");
-  return normalizePathnameForRouteMatch(normalized).split("/").filter(Boolean);
+  return splitPathnameForRouteMatch(normalized);
 }
 
 export function createAppRscRouteMatcher<Route extends AppRscRouteForMatching>(

--- a/packages/vinext/src/server/app-ssr-entry.ts
+++ b/packages/vinext/src/server/app-ssr-entry.ts
@@ -26,7 +26,11 @@ import {
   escapeHtmlAttr,
   safeJsonStringify,
 } from "./html.js";
-import { createRscEmbedTransform, createTickBufferedTransform } from "./app-ssr-stream.js";
+import {
+  createNavigationRuntimeRscMetadataScript,
+  createRscEmbedTransform,
+  createTickBufferedTransform,
+} from "./app-ssr-stream.js";
 import { deferUntilStreamConsumed } from "./app-page-stream.js";
 import { createSsrErrorMetaRenderer } from "./app-ssr-error-meta.js";
 import { AppElementsWire, type AppWireElements } from "./app-elements.js";
@@ -148,16 +152,12 @@ function buildHeadInjectionHtml(
   fontHTML: string,
   scriptNonce?: string,
 ): string {
-  const paramsScript = createInlineScriptTag(
-    "self.__VINEXT_RSC_PARAMS__=" + safeJsonStringify(navContext?.params ?? {}),
-    scriptNonce,
-  );
   const navPayload = {
     pathname: navContext?.pathname ?? "/",
     searchParams: navContext?.searchParams ? [...navContext.searchParams.entries()] : [],
   };
-  const navScript = createInlineScriptTag(
-    "self.__VINEXT_RSC_NAV__=" + safeJsonStringify(navPayload),
+  const rscMetadataScript = createInlineScriptTag(
+    createNavigationRuntimeRscMetadataScript(navContext?.params ?? {}, navPayload),
     scriptNonce,
   );
   const formStateScript =
@@ -169,8 +169,7 @@ function buildHeadInjectionHtml(
         );
 
   return (
-    paramsScript +
-    navScript +
+    rscMetadataScript +
     formStateScript +
     buildModulePreloadHtml(bootstrapModuleUrl, scriptNonce) +
     insertedHTML +

--- a/packages/vinext/src/server/app-ssr-stream.ts
+++ b/packages/vinext/src/server/app-ssr-stream.ts
@@ -5,6 +5,7 @@ import {
   RSC_EMBEDDED_BINARY_CHUNK,
   type RscEmbeddedChunk,
 } from "./app-rsc-embedded-chunks.js";
+import { NAVIGATION_RUNTIME_SYMBOL_DESCRIPTION } from "../client/navigation-runtime.js";
 
 type RscEmbedTransform = {
   flush(): string;
@@ -14,6 +15,37 @@ type RscEmbedTransform = {
 };
 
 type HtmlInsertion = string | (() => string);
+
+const NAVIGATION_RUNTIME_REFERENCE = `self[Symbol.for(${safeJsonStringify(
+  NAVIGATION_RUNTIME_SYMBOL_DESCRIPTION,
+)})]`;
+
+function navigationRuntimeRscBootstrapExpression(): string {
+  return `((${NAVIGATION_RUNTIME_REFERENCE}??={bootstrap:{routeManifest:null},functions:{}}).bootstrap.rsc??={rsc:[]})`;
+}
+
+export function createNavigationRuntimeRscMetadataScript(
+  params: Record<string, string | string[]>,
+  nav: { pathname: string; searchParams: [string, string][] },
+): string {
+  return (
+    "Object.assign(" +
+    navigationRuntimeRscBootstrapExpression() +
+    ",{params:" +
+    safeJsonStringify(params) +
+    ",nav:" +
+    safeJsonStringify(nav) +
+    "})"
+  );
+}
+
+function createNavigationRuntimeRscChunkScript(chunk: RscEmbeddedChunk): string {
+  return navigationRuntimeRscBootstrapExpression() + ".rsc.push(" + safeJsonStringify(chunk) + ")";
+}
+
+function createNavigationRuntimeRscDoneScript(): string {
+  return navigationRuntimeRscBootstrapExpression() + ".done=true";
+}
 
 /**
  * Fix invalid preload "as" values in RSC Flight hint lines before they reach
@@ -79,12 +111,7 @@ export function createRscEmbedTransform(
 
       let scripts = "";
       for (const chunk of chunks) {
-        scripts += createInlineScriptTag(
-          "self.__VINEXT_RSC_CHUNKS__=self.__VINEXT_RSC_CHUNKS__||[];self.__VINEXT_RSC_CHUNKS__.push(" +
-            safeJsonStringify(chunk) +
-            ")",
-          scriptNonce,
-        );
+        scripts += createInlineScriptTag(createNavigationRuntimeRscChunkScript(chunk), scriptNonce);
       }
       return scripts;
     },
@@ -92,7 +119,7 @@ export function createRscEmbedTransform(
     async finalize(): Promise<string> {
       await pumpPromise;
       let scripts = this.flush();
-      scripts += createInlineScriptTag("self.__VINEXT_RSC_DONE__=true", scriptNonce);
+      scripts += createInlineScriptTag(createNavigationRuntimeRscDoneScript(), scriptNonce);
       return scripts;
     },
 

--- a/packages/vinext/src/server/app-ssr-stream.ts
+++ b/packages/vinext/src/server/app-ssr-stream.ts
@@ -20,7 +20,7 @@ const NAVIGATION_RUNTIME_REFERENCE = `self[Symbol.for(${safeJsonStringify(
   NAVIGATION_RUNTIME_SYMBOL_DESCRIPTION,
 )})]`;
 
-function navigationRuntimeRscBootstrapExpression(): string {
+export function navigationRuntimeRscBootstrapExpression(): string {
   return `((${NAVIGATION_RUNTIME_REFERENCE}??={bootstrap:{routeManifest:null},functions:{}}).bootstrap.rsc??={rsc:[]})`;
 }
 

--- a/packages/vinext/src/server/navigation-planner.ts
+++ b/packages/vinext/src/server/navigation-planner.ts
@@ -99,7 +99,7 @@ export type CommitProposal = {
   preserveAbsentSlots: boolean;
   preserveElementIds: readonly string[];
   preservePreviousSlotIds: readonly string[];
-  reason: "currentRootBoundary" | "interceptedCurrentRootBoundary" | "rootBoundaryUnknownFallback";
+  reason: "currentRootBoundary" | "interceptedCurrentRootBoundary" | "unprovenTopologyFallback";
   targetSnapshot: RouteSnapshotV0;
 };
 
@@ -108,7 +108,7 @@ export type HardNavigationReason = "interceptionProofRejected" | "rootBoundaryCh
 export type RootBoundaryTransition =
   | "currentRootBoundary"
   | "rootBoundaryChanged"
-  | "rootBoundaryUnknownFallback";
+  | "rootBoundaryUnknown";
 
 export type NavigationDecisionV0 =
   | {
@@ -157,6 +157,15 @@ type RouteTopologySnapshot = {
   rootLayoutTreePath: string | null;
   slotBindings: readonly ParallelSlotBindingSnapshotV0[];
 };
+
+type RouteTopologyResolution =
+  | {
+      kind: "known";
+      topology: RouteTopologySnapshot;
+    }
+  | {
+      kind: "unknown";
+    };
 
 type RouteTopologySlotBindingSource = "snapshot" | "manifestTarget";
 
@@ -310,13 +319,13 @@ function resolveRouteTopologySnapshot(options: {
   routeManifest: RouteManifest | null;
   slotBindingSource: RouteTopologySlotBindingSource;
   snapshot: RouteSnapshotV0;
-}): RouteTopologySnapshot {
+}): RouteTopologyResolution {
   const route =
     options.routeManifest === null
       ? null
       : findRouteManifestRouteForSnapshot(options.routeManifest, options.snapshot);
   if (route === null || options.routeManifest === null) {
-    return createSnapshotRouteTopology(options.snapshot);
+    return { kind: "unknown" };
   }
 
   // Intercepted targets carry the source route's tree topology, not the direct
@@ -325,12 +334,15 @@ function resolveRouteTopologySnapshot(options: {
     options.slotBindingSource === "manifestTarget" && options.snapshot.interception === null;
 
   return {
-    layoutIds: route.layoutIds,
-    rootBoundaryId: route.rootBoundaryId,
-    rootLayoutTreePath: resolveRouteManifestRootLayoutTreePath(options.routeManifest, route),
-    slotBindings: shouldUseManifestSlotBindings
-      ? resolveRouteManifestSlotBindings(options.routeManifest, route)
-      : options.snapshot.slotBindings,
+    kind: "known",
+    topology: {
+      layoutIds: route.layoutIds,
+      rootBoundaryId: route.rootBoundaryId,
+      rootLayoutTreePath: resolveRouteManifestRootLayoutTreePath(options.routeManifest, route),
+      slotBindings: shouldUseManifestSlotBindings
+        ? resolveRouteManifestSlotBindings(options.routeManifest, route)
+        : options.snapshot.slotBindings,
+    },
   };
 }
 
@@ -392,10 +404,7 @@ function classifyRootBoundaryTransition(
   nextRootBoundaryId: string | null,
 ): RootBoundaryTransition {
   if (currentRootBoundaryId === null || nextRootBoundaryId === null) {
-    // Both null directions intentionally share the fallback because unresolved
-    // routes or legacy callers cannot prove either same-root reuse or root
-    // changes from semantic topology.
-    return "rootBoundaryUnknownFallback";
+    return "rootBoundaryUnknown";
   }
 
   return currentRootBoundaryId === nextRootBoundaryId
@@ -707,9 +716,11 @@ function planFlightResponseArrived(options: {
     snapshot: targetSnapshot,
   });
   const traceFields = createRootBoundaryTraceFields({
-    currentRootLayoutTreePath: currentTopology.rootLayoutTreePath,
+    currentRootLayoutTreePath:
+      currentTopology.kind === "known" ? currentTopology.topology.rootLayoutTreePath : null,
     event: options.event,
-    nextRootLayoutTreePath: targetTopology.rootLayoutTreePath,
+    nextRootLayoutTreePath:
+      targetTopology.kind === "known" ? targetTopology.topology.rootLayoutTreePath : null,
     state: options.state,
   });
 
@@ -727,12 +738,20 @@ function planFlightResponseArrived(options: {
   // only explicit __interception proof enters the preservation branch.
   const hasInterceptedPayload = targetSnapshot.interception !== null;
   if (hasInterceptedPayload) {
+    if (currentTopology.kind === "unknown" || targetTopology.kind === "unknown") {
+      return createInterceptionProofRejectedDecision({
+        event: options.event,
+        reasonCode: NavigationTraceReasonCodes.interceptedRejectedUndeclaredTopology,
+        traceFields,
+      });
+    }
+
     const validation = validateInterceptedPreservation({
       currentSnapshot: options.state.visibleSnapshot,
-      currentTopology,
+      currentTopology: currentTopology.topology,
       routeManifest: options.routeManifest,
       targetSnapshot,
-      targetTopology,
+      targetTopology: targetTopology.topology,
     });
     if (validation.kind === "rejected") {
       return createInterceptionProofRejectedDecision({
@@ -759,10 +778,13 @@ function planFlightResponseArrived(options: {
     };
   }
 
-  const transition = classifyRootBoundaryTransition(
-    currentTopology.rootBoundaryId,
-    targetTopology.rootBoundaryId,
-  );
+  const transition =
+    currentTopology.kind === "unknown" || targetTopology.kind === "unknown"
+      ? "rootBoundaryUnknown"
+      : classifyRootBoundaryTransition(
+          currentTopology.topology.rootBoundaryId,
+          targetTopology.topology.rootBoundaryId,
+        );
 
   if (transition === "rootBoundaryChanged") {
     return {
@@ -774,17 +796,17 @@ function planFlightResponseArrived(options: {
     };
   }
 
-  if (transition === "rootBoundaryUnknownFallback") {
-    // Unknown root identity is an uncertainty fallback, not evidence that
-    // reuse is safe. It remains only for callers without a manifest or routes
-    // that cannot be matched back to RouteManifest topology.
+  if (transition === "rootBoundaryUnknown") {
+    // Unknown topology is not semantic proof. The event may still commit its
+    // fully supplied payload, but it must not preserve absent slots, layouts,
+    // or previous slot content from snapshot-derived route shape.
     return {
       kind: "proposeCommit",
       proposal: {
-        preserveAbsentSlots: true,
+        preserveAbsentSlots: false,
         preserveElementIds: [],
         preservePreviousSlotIds: [],
-        reason: "rootBoundaryUnknownFallback",
+        reason: "unprovenTopologyFallback",
         targetSnapshot,
       },
       token: options.event.token,
@@ -792,19 +814,23 @@ function planFlightResponseArrived(options: {
     };
   }
 
+  if (currentTopology.kind !== "known" || targetTopology.kind !== "known") {
+    throw new Error("[vinext] Current-root navigation planning requires manifest topology");
+  }
+
   return {
     kind: "proposeCommit",
     proposal: {
       preserveAbsentSlots: false,
       preserveElementIds: resolveCurrentRootBoundaryCommitElementPersistence({
-        currentTopology,
+        currentTopology: currentTopology.topology,
         lane: options.event.token.lane,
-        targetTopology,
+        targetTopology: targetTopology.topology,
       }),
       preservePreviousSlotIds: resolveCurrentRootBoundaryCommitSlotPersistence({
-        currentTopology,
+        currentTopology: currentTopology.topology,
         lane: options.event.token.lane,
-        targetTopology,
+        targetTopology: targetTopology.topology,
       }),
       reason: "currentRootBoundary",
       targetSnapshot,

--- a/packages/vinext/src/server/navigation-planner.ts
+++ b/packages/vinext/src/server/navigation-planner.ts
@@ -1,5 +1,5 @@
 import { matchRoutePattern, matchRoutePatternPrefix } from "../routing/route-pattern.js";
-import { normalizePathnameForRouteMatch } from "../routing/utils.js";
+import { splitPathnameForRouteMatch } from "../routing/utils.js";
 import type {
   RouteManifest,
   RouteManifestInterception,
@@ -229,9 +229,7 @@ function getMatchedUrlPathname(matchedUrl: string): string {
 }
 
 function splitMatchedUrlIntoRouteParts(matchedUrl: string): string[] {
-  return normalizePathnameForRouteMatch(getMatchedUrlPathname(matchedUrl))
-    .split("/")
-    .filter((part) => part.length > 0);
+  return splitPathnameForRouteMatch(getMatchedUrlPathname(matchedUrl));
 }
 
 function findRouteManifestRouteByMatchedUrl(

--- a/packages/vinext/src/shims/form.tsx
+++ b/packages/vinext/src/shims/form.tsx
@@ -19,6 +19,7 @@
  */
 
 import { forwardRef, useActionState, type FormHTMLAttributes, type ForwardedRef } from "react";
+import { hasAppNavigationRuntime } from "../client/navigation-runtime.js";
 import { navigateClientSide } from "./navigation.js";
 import { isDangerousScheme } from "./url-safety.js";
 import { toSameOriginPath } from "./url-utils.js";
@@ -223,7 +224,7 @@ const Form = forwardRef(function Form(props: FormProps, ref: ForwardedRef<HTMLFo
     const url = createFormSubmitDestinationUrl(effectiveAction, e.currentTarget, submitter);
 
     // Navigate client-side
-    if (typeof window.__VINEXT_RSC_NAVIGATE__ === "function") {
+    if (hasAppNavigationRuntime()) {
       // App Router: use the shared navigator so URL/history publish stays
       // aligned with the committed RSC tree.
       await navigateClientSide(url, replace ? "replace" : "push", scroll);
@@ -239,7 +240,7 @@ const Form = forwardRef(function Form(props: FormProps, ref: ForwardedRef<HTMLFo
 
     // App Router: scroll is handled inside navigateClientSide (called above).
     // Pages Router: scroll manually since pushState/popstate doesn't auto-scroll.
-    if (typeof window.__VINEXT_RSC_NAVIGATE__ !== "function" && scroll) {
+    if (!hasAppNavigationRuntime() && scroll) {
       window.scrollTo(0, 0);
     }
   }

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -19,6 +19,11 @@ import React, {
   type MouseEvent,
   type TouchEvent,
 } from "react";
+import {
+  getNavigationRuntime,
+  hasAppNavigationRuntime,
+  registerNavigationRuntimeFunctions,
+} from "../client/navigation-runtime.js";
 // Import shared RSC prefetch utilities from navigation shim (relative path
 // so this resolves both via the Vite plugin and in direct vitest imports)
 import {
@@ -156,9 +161,7 @@ function toSameOriginRouteHref(href: string): string | null {
 }
 
 function getLinkPrefetchRouterMode(): LinkPrefetchRouterMode {
-  return typeof window !== "undefined" && typeof window.__VINEXT_RSC_NAVIGATE__ === "function"
-    ? "app"
-    : "pages";
+  return hasAppNavigationRuntime() ? "app" : "pages";
 }
 
 export function canAutoPrefetchFullAppRoute(href: string): boolean {
@@ -206,7 +209,7 @@ function prefetchUrl(href: string, mode: LinkPrefetchMode, priority: "low" | "hi
 
   schedule(() => {
     void (async () => {
-      if (typeof window.__VINEXT_RSC_NAVIGATE__ === "function") {
+      if (hasAppNavigationRuntime()) {
         // `auto`/`null`/undefined should not behave like `prefetch={true}` for
         // App Router dynamic routes. Next.js may prefetch a loading-boundary
         // shell for dynamic routes, but vinext's current client cache stores
@@ -286,7 +289,7 @@ function setVisibleLinkPrefetch(instance: LinkPrefetchInstance, isVisible: boole
 
 function registerVisibleLinkPing(): void {
   if (typeof window === "undefined") return;
-  window.__VINEXT_PING_VISIBLE_LINKS__ = pingVisibleLinkPrefetches;
+  registerNavigationRuntimeFunctions({ pingVisibleLinks: pingVisibleLinkPrefetches });
 }
 
 function pingVisibleLinkPrefetches(): void {
@@ -591,7 +594,7 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
 
     // App Router: delegate to navigateClientSide which handles scroll save,
     // hash-only changes, RSC fetch, and two-phase URL commit.
-    if (typeof window.__VINEXT_RSC_NAVIGATE__ === "function") {
+    if (getNavigationRuntime()?.functions.navigate) {
       setPending(true);
       React.startTransition(() => {
         void navigateClientSide(navigateHref, replace ? "replace" : "push", scroll, true).finally(

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -11,6 +11,7 @@
 // would throw at link time for missing bindings. With `import * as React`, the
 // bindings are just `undefined` on the namespace object and we can guard at runtime.
 import * as React from "react";
+import { getNavigationRuntime, hasAppNavigationRuntime } from "../client/navigation-runtime.js";
 import { notifyAppRouterTransitionStart } from "../client/instrumentation-client-state.js";
 import { AppElementsWire } from "../server/app-elements.js";
 import { createExternalHistoryStatePreservingMetadata } from "../server/app-history-state.js";
@@ -520,7 +521,7 @@ export function invalidatePrefetchCache(): void {
   }
   prefetched.clear();
   if (!isServer) {
-    window.__VINEXT_PING_VISIBLE_LINKS__?.();
+    getNavigationRuntime()?.functions.pingVisibleLinks?.();
   }
 }
 
@@ -1240,7 +1241,7 @@ export function commitClientNavigationState(
 
   if (shouldNotify) {
     notifyNavigationListeners();
-    window.__VINEXT_PING_VISIBLE_LINKS__?.();
+    getNavigationRuntime()?.functions.pingVisibleLinks?.();
   }
 }
 
@@ -1282,7 +1283,7 @@ function saveScrollPosition(): void {
 }
 
 function commitHashOnlyHistoryState(href: string, mode: "push" | "replace", scroll: boolean): void {
-  const commitAppRouterHashNavigation = window.__VINEXT_RSC_COMMIT_HASH_NAVIGATION__;
+  const commitAppRouterHashNavigation = getNavigationRuntime()?.functions.commitHashNavigation;
   if (commitAppRouterHashNavigation) {
     commitAppRouterHashNavigation(href, mode, scroll);
     return;
@@ -1299,8 +1300,8 @@ function commitHashOnlyHistoryState(href: string, mode: "push" | "replace", scro
  * Restore scroll position from a history state object (used on popstate).
  *
  * When an RSC navigation is in flight (back/forward triggers both this
- * handler and the browser entry's popstate handler which calls
- * __VINEXT_RSC_NAVIGATE__), we must wait for the new content to render
+ * handler and the browser entry's popstate handler which calls the registered
+ * navigation runtime), we must wait for the new content to render
  * before scrolling. Otherwise the user sees old content flash at the
  * restored scroll position.
  *
@@ -1398,15 +1399,9 @@ export async function navigateClientSide(
   // navigateRsc owns the push/replace exclusively. This avoids a fragile
   // double-push and ensures window.location still reflects the *current* URL
   // when navigateRsc publishes the committed URL.
-  if (typeof window.__VINEXT_RSC_NAVIGATE__ === "function") {
-    await window.__VINEXT_RSC_NAVIGATE__(
-      fullHref,
-      0,
-      "navigate",
-      mode,
-      undefined,
-      programmaticTransition,
-    );
+  const appNavigate = getNavigationRuntime()?.functions.navigate;
+  if (appNavigate) {
+    await appNavigate(fullHref, 0, "navigate", mode, undefined, programmaticTransition);
   } else {
     if (mode === "replace") {
       replaceHistoryStateWithoutNotify(null, "", fullHref);
@@ -1476,13 +1471,10 @@ const _appRouter = {
     // without this, a stale cached payload for a sibling route (e.g. a page
     // gated by a session that has since been cleared) would still satisfy a
     // subsequent client navigation and bypass the server's redirect logic.
-    const clearCaches = window.__VINEXT_CLEAR_NAV_CACHES__;
-    if (typeof clearCaches === "function") {
-      clearCaches();
-    }
+    getNavigationRuntime()?.functions.clearNavigationCaches?.();
     // Re-fetch the current page's RSC stream
-    const rscNavigate = window.__VINEXT_RSC_NAVIGATE__;
-    if (typeof rscNavigate === "function") {
+    const rscNavigate = getNavigationRuntime()?.functions.navigate;
+    if (rscNavigate) {
       const navigate = () => {
         void rscNavigate(window.location.href, 0, "refresh", undefined, undefined, true);
       };
@@ -2073,12 +2065,12 @@ if (!isServer) {
     state.patchInstalled = true;
 
     // Listen for popstate on the client.
-    // Note: This handler runs for Pages Router only (when __VINEXT_RSC_NAVIGATE__
-    // is not available). It restores scroll position with microtask-based deferral.
+    // Note: This handler runs for Pages Router only (when App Router navigation
+    // runtime is not available). It restores scroll position with microtask-based deferral.
     // App Router scroll restoration is handled in server/app-browser-entry.ts:697
     // with RSC navigation coordination (waits for pending navigation to settle).
     window.addEventListener("popstate", (event) => {
-      if (typeof window.__VINEXT_RSC_NAVIGATE__ !== "function") {
+      if (!hasAppNavigationRuntime()) {
         commitClientNavigationState();
         restoreScrollPosition(event.state);
       }

--- a/packages/vinext/src/utils/cache-control-metadata.ts
+++ b/packages/vinext/src/utils/cache-control-metadata.ts
@@ -1,6 +1,5 @@
-export function isUnknownRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
-}
+import { isUnknownRecord } from "./record.js";
+export { isUnknownRecord } from "./record.js";
 
 function readRecordField(
   ctx: Record<string, unknown> | undefined,

--- a/packages/vinext/src/utils/record.ts
+++ b/packages/vinext/src/utils/record.ts
@@ -1,0 +1,3 @@
+export function isUnknownRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -74,15 +74,27 @@ import type {
   GraphVersion,
   RootBoundaryId,
   RouteManifest,
+  RouteManifestInterception,
   RouteManifestRootBoundary,
   RouteManifestRoute,
+  RouteManifestSlotBinding,
   StaticSegmentGraph,
 } from "../packages/vinext/src/routing/app-route-graph.js";
 
 type TestRouteManifestRoute = {
+  id?: string;
+  interceptions?: readonly TestRouteManifestInterception[];
   layoutIds: readonly string[];
   pattern: string;
   rootBoundaryId: string | null;
+  slotBindings?: readonly AppElementsSlotBinding[];
+};
+
+type TestRouteManifestInterception = {
+  ownerLayoutId: string | null;
+  slotId: string;
+  sourcePattern: string;
+  targetPattern: string;
 };
 
 function createResolvedElements(
@@ -144,12 +156,20 @@ function createInterceptionProof(
 
 function createTestRouteManifest(routes: readonly TestRouteManifestRoute[]): RouteManifest {
   const manifestRoutes = new Map<string, RouteManifestRoute>();
+  const slotBindings = new Map<string, RouteManifestSlotBinding>();
+  const interceptions = new Map<string, RouteManifestInterception>();
+  const interceptionsBySlotId = new Map<string, RouteManifestInterception[]>();
   const rootBoundaries = new Map<RootBoundaryId, RouteManifestRootBoundary>();
+  const routeIdByPattern = new Map(
+    routes.map((route) => [route.pattern, route.id ?? `route:${route.pattern}`]),
+  );
 
   for (const route of routes) {
-    const routeId = `route:${route.pattern}`;
+    const routeId = route.id ?? `route:${route.pattern}`;
     const rootBoundaryId =
       route.rootBoundaryId === null ? null : (route.rootBoundaryId as RootBoundaryId);
+    const routeSlotBindings = route.slotBindings ?? [];
+    const slotIds = routeSlotBindings.map((binding) => binding.slotId).sort();
     const patternParts = route.pattern.split("/").filter((segment) => segment.length > 0);
     manifestRoutes.set(routeId, {
       id: routeId,
@@ -164,9 +184,48 @@ function createTestRouteManifest(routes: readonly TestRouteManifestRoute[]): Rou
       rootBoundaryId,
       rootParamNames: [],
       routeHandlerId: null,
-      slotIds: [],
+      slotIds,
       templateIds: [],
     });
+
+    for (const binding of routeSlotBindings) {
+      slotBindings.set(`${routeId}::${binding.slotId}`, {
+        defaultId: binding.state === "default" ? `default:${binding.slotId}` : null,
+        id: `${routeId}::${binding.slotId}`,
+        ownerLayoutId: binding.ownerLayoutId,
+        routeId,
+        routeSegments: null,
+        slotId: binding.slotId,
+        state: binding.state,
+      });
+    }
+
+    for (const interception of route.interceptions ?? []) {
+      const targetPatternParts = interception.targetPattern
+        .split("/")
+        .filter((segment) => segment.length > 0);
+      const id = `interception:${interception.slotId}:${interception.sourcePattern}->${interception.targetPattern}`;
+      const manifestInterception = {
+        id,
+        interceptingRouteId: routeIdByPattern.get(interception.sourcePattern) ?? null,
+        ownerLayoutId: interception.ownerLayoutId,
+        slotId: interception.slotId,
+        sourcePattern: interception.sourcePattern,
+        sourcePatternParts: interception.sourcePattern
+          .split("/")
+          .filter((segment) => segment.length > 0),
+        targetPattern: interception.targetPattern,
+        targetPatternParts,
+        targetRouteId: routeIdByPattern.get(interception.targetPattern) ?? null,
+      };
+      interceptions.set(id, manifestInterception);
+      const slotInterceptions = interceptionsBySlotId.get(interception.slotId);
+      if (slotInterceptions) {
+        slotInterceptions.push(manifestInterception);
+      } else {
+        interceptionsBySlotId.set(interception.slotId, [manifestInterception]);
+      }
+    }
 
     const rootLayoutId = route.layoutIds[0];
     if (rootBoundaryId !== null && rootLayoutId !== undefined) {
@@ -181,14 +240,14 @@ function createTestRouteManifest(routes: readonly TestRouteManifestRoute[]): Rou
   const segmentGraph: StaticSegmentGraph = {
     boundaries: new Map(),
     defaults: new Map(),
-    interceptions: new Map(),
-    interceptionsBySlotId: new Map(),
+    interceptions,
+    interceptionsBySlotId,
     layouts: new Map(),
     pages: new Map(),
     rootBoundaries,
     routeHandlers: new Map(),
     routes: manifestRoutes,
-    slotBindings: new Map(),
+    slotBindings,
     slots: new Map(),
     templates: new Map(),
   };
@@ -197,6 +256,118 @@ function createTestRouteManifest(routes: readonly TestRouteManifestRoute[]): Rou
     graphVersion: "graph:test" as GraphVersion,
     segmentGraph,
   };
+}
+
+function rootBoundaryIdFromTreePath(rootLayoutTreePath: string | null): string | null {
+  return rootLayoutTreePath === null ? null : `root-boundary:${rootLayoutTreePath}`;
+}
+
+function normalizeTestRoutePattern(pathname: string): string {
+  try {
+    return decodeURI(pathname);
+  } catch {
+    return pathname;
+  }
+}
+
+function routeIdWithoutInterceptionContext(routeId: string): string {
+  const parsed = AppElementsWire.parseElementKey(routeId);
+  if (parsed?.kind !== "route") return routeId;
+  return AppElementsWire.encodeRouteId(parsed.path, null);
+}
+
+function createRouteManifestForPendingCommit(
+  currentState: AppRouterState,
+  pending: Awaited<ReturnType<typeof createPendingNavigationCommit>>,
+): RouteManifest {
+  const currentPattern =
+    currentState.interception?.sourceMatchedUrl ??
+    normalizeTestRoutePattern(currentState.navigationSnapshot.pathname);
+  const currentRouteId =
+    currentState.interception?.sourceRouteId ??
+    routeIdWithoutInterceptionContext(currentState.routeId);
+  const currentRoute = {
+    id: currentRouteId,
+    layoutIds: currentState.layoutIds,
+    pattern: currentPattern,
+    rootBoundaryId: rootBoundaryIdFromTreePath(currentState.rootLayoutTreePath),
+    slotBindings: currentState.slotBindings,
+  };
+  const pendingInterception = pending.action.interception;
+
+  if (pendingInterception !== null) {
+    const currentMatchesSource =
+      currentRouteId === pendingInterception.sourceRouteId &&
+      currentPattern === pendingInterception.sourceMatchedUrl;
+    const sourceLayoutIds = currentMatchesSource
+      ? currentState.layoutIds
+      : pending.action.layoutIds;
+    const sourceRootLayoutTreePath = currentMatchesSource
+      ? currentState.rootLayoutTreePath
+      : pending.rootLayoutTreePath;
+    return createTestRouteManifest([
+      currentRoute,
+      {
+        id: pendingInterception.sourceRouteId,
+        interceptions: [
+          {
+            ownerLayoutId:
+              pending.action.slotBindings.find(
+                (binding) => binding.slotId === pendingInterception.slotId,
+              )?.ownerLayoutId ?? null,
+            slotId: pendingInterception.slotId,
+            sourcePattern: pendingInterception.sourceMatchedUrl,
+            targetPattern: pendingInterception.targetMatchedUrl,
+          },
+        ],
+        layoutIds: sourceLayoutIds,
+        pattern: pendingInterception.sourceMatchedUrl,
+        rootBoundaryId: rootBoundaryIdFromTreePath(sourceRootLayoutTreePath),
+        slotBindings: pending.action.slotBindings,
+      },
+      {
+        id: pendingInterception.targetRouteId,
+        layoutIds: pending.action.layoutIds,
+        pattern: pendingInterception.targetMatchedUrl,
+        rootBoundaryId: rootBoundaryIdFromTreePath(pending.rootLayoutTreePath),
+      },
+    ]);
+  }
+
+  return createTestRouteManifest([
+    currentRoute,
+    {
+      id: routeIdWithoutInterceptionContext(pending.routeId),
+      layoutIds: pending.action.layoutIds,
+      pattern: normalizeTestRoutePattern(pending.action.navigationSnapshot.pathname),
+      rootBoundaryId: rootBoundaryIdFromTreePath(pending.rootLayoutTreePath),
+      slotBindings: pending.action.slotBindings,
+    },
+  ]);
+}
+
+function createRootChangeRouteManifest(
+  options: {
+    currentPattern?: string;
+    currentRouteId?: string;
+    targetPattern?: string;
+    targetRouteId?: string;
+  } = {},
+): RouteManifest {
+  return createTestRouteManifest([
+    {
+      id: options.currentRouteId ?? "route:/initial",
+      layoutIds: [AppElementsWire.encodeLayoutId("/(marketing)")],
+      pattern: options.currentPattern ?? "/initial",
+      rootBoundaryId: "root-boundary:/(marketing)",
+    },
+    {
+      id: options.targetRouteId ?? "route:/dashboard",
+      layoutIds: [AppElementsWire.encodeLayoutId("/(dashboard)")],
+      pattern: options.targetPattern ?? "/dashboard",
+      rootBoundaryId: "root-boundary:/(dashboard)",
+    },
+  ]);
 }
 
 type TestPendingDispositionOptions = {
@@ -235,6 +406,7 @@ async function resolveTestPendingNavigationCommitDispositionDecision(
     activeNavigationId: options.activeNavigationId,
     currentState,
     pending,
+    routeManifest: createRouteManifestForPendingCommit(currentState, pending),
     startedNavigationId: options.startedNavigationId,
   });
 }
@@ -310,6 +482,7 @@ async function applyApprovedTestCommit(
     activeNavigationId,
     currentState: state,
     pending,
+    routeManifest: createRouteManifestForPendingCommit(state, pending),
     startedNavigationId: options.startedNavigationId ?? activeNavigationId,
     targetHref: options.targetHref ?? "https://example.com/initial",
   });
@@ -640,6 +813,7 @@ describe("app browser entry state helpers", () => {
       activeNavigationId: 1,
       currentState: state,
       pending,
+      routeManifest: createRouteManifestForPendingCommit(state, pending),
       startedNavigationId: 1,
       targetHref: "https://example.com/next",
     });
@@ -761,6 +935,7 @@ describe("app browser entry state helpers", () => {
         activeNavigationId: 3,
         currentState,
         pending,
+        routeManifest: createRouteManifestForPendingCommit(currentState, pending),
         startedNavigationId: 3,
       }).disposition,
     ).toBe("hard-navigate");
@@ -829,6 +1004,7 @@ describe("app browser entry state helpers", () => {
       activeNavigationId: 1,
       currentState,
       pending,
+      routeManifest: createRouteManifestForPendingCommit(currentState, pending),
       startedNavigationId: 1,
       targetHref: "https://example.com/dashboard",
     });
@@ -863,6 +1039,7 @@ describe("app browser entry state helpers", () => {
         activeNavigationId: 5,
         currentState,
         pending,
+        routeManifest: createRouteManifestForPendingCommit(currentState, pending),
         startedNavigationId: 4,
       }).disposition,
     ).toBe("skip");
@@ -887,6 +1064,7 @@ describe("app browser entry state helpers", () => {
       activeNavigationId: 7,
       currentState: latestState,
       pending,
+      routeManifest: createRouteManifestForPendingCommit(latestState, pending),
       startedNavigationId: 7,
       targetHref: "https://example.com/dashboard",
     });
@@ -937,6 +1115,7 @@ describe("app browser entry state helpers", () => {
       activeNavigationId: 8,
       currentState: latestState,
       pending,
+      routeManifest: createRouteManifestForPendingCommit(latestState, pending),
       startedNavigationId: 8,
       targetHref: "https://example.com/previous",
     });
@@ -1068,7 +1247,7 @@ describe("app browser entry state helpers", () => {
     ]);
   });
 
-  it("traces unknown root-layout identity as a legacy soft-commit fallback", async () => {
+  it("traces unknown root-layout identity without preserving absent slots", async () => {
     const decision = await resolveTestPendingNavigationCommitDispositionDecision({
       activeNavigationId: 2,
       currentVisibleCommitVersion: 0,
@@ -1158,6 +1337,7 @@ describe("app browser entry state helpers", () => {
       activeNavigationId: 1,
       currentState,
       pending,
+      routeManifest: createRouteManifestForPendingCommit(currentState, pending),
       startedNavigationId: 1,
     });
 
@@ -1230,6 +1410,7 @@ describe("app browser entry state helpers", () => {
       activeNavigationId: 1,
       currentState,
       pending,
+      routeManifest: createRouteManifestForPendingCommit(currentState, pending),
       startedNavigationId: 1,
     });
 
@@ -1243,6 +1424,7 @@ describe("app browser entry state helpers", () => {
       activeNavigationId: 1,
       currentState,
       pending,
+      routeManifest: createRouteManifestForPendingCommit(currentState, pending),
       startedNavigationId: 1,
       targetHref: "https://example.com/feed",
     });
@@ -1295,6 +1477,7 @@ describe("app browser entry state helpers", () => {
       activeNavigationId: 2,
       currentState: contextOnlyState,
       pending: interceptedPending,
+      routeManifest: createRouteManifestForPendingCommit(contextOnlyState, interceptedPending),
       startedNavigationId: 2,
       targetHref: "https://example.com/photos/42",
     });
@@ -1324,6 +1507,7 @@ describe("app browser entry state helpers", () => {
       activeNavigationId: 4,
       currentState,
       pending,
+      routeManifest: createRouteManifestForPendingCommit(currentState, pending),
       startedNavigationId: 4,
       targetHref: "https://example.com/dashboard",
     });
@@ -1371,7 +1555,7 @@ describe("app browser entry state helpers", () => {
     });
   });
 
-  it("traces unknown root-layout approval as a visible commit with an uncertainty reason", async () => {
+  it("traces unknown root-layout approval as an unproven payload commit", async () => {
     const currentState = createState();
     const pending = await createPendingNavigationCommit({
       currentState,
@@ -1386,6 +1570,7 @@ describe("app browser entry state helpers", () => {
       activeNavigationId: 6,
       currentState,
       pending,
+      routeManifest: createRouteManifestForPendingCommit(currentState, pending),
       startedNavigationId: 6,
       targetHref: "https://example.com/legacy-payload",
     });
@@ -1394,7 +1579,7 @@ describe("app browser entry state helpers", () => {
     if (approval.decision.disposition !== "commit") {
       throw new Error("Expected visible commit approval");
     }
-    expect(approval.decision.preserveAbsentSlots).toBe(true);
+    expect(approval.decision.preserveAbsentSlots).toBe(false);
     expect(approval.decision.trace.entries[0]?.code).toBe(
       NavigationTraceTransactionCodes.visibleCommit,
     );
@@ -1476,6 +1661,7 @@ describe("app browser entry state helpers", () => {
       activeNavigationId: 4,
       currentState,
       pending,
+      routeManifest: createRouteManifestForPendingCommit(currentState, pending),
       startedNavigationId: 4,
       targetHref: "https://example.com/next",
     });
@@ -1514,6 +1700,7 @@ describe("app browser entry state helpers", () => {
       activeNavigationId: 4,
       currentState,
       pending,
+      routeManifest: createRouteManifestForPendingCommit(currentState, pending),
       startedNavigationId: 4,
       targetHref: "https://example.com/feed",
     });
@@ -1549,6 +1736,7 @@ describe("app browser entry state helpers", () => {
       activeNavigationId: 8,
       currentState,
       pending,
+      routeManifest: createRouteManifestForPendingCommit(currentState, pending),
       startedNavigationId: 7,
       targetHref: "https://example.com/dashboard",
     });
@@ -1565,6 +1753,7 @@ describe("app browser entry state helpers", () => {
       activeNavigationId: 8,
       currentState,
       pending,
+      routeManifest: createRouteManifestForPendingCommit(currentState, pending),
       startedNavigationId: 8,
       targetHref: "https://example.com/dashboard?from=planner",
     });
@@ -2304,7 +2493,7 @@ describe("app browser navigation controller", () => {
     }
   });
 
-  it("hard-navigates same-URL server action payloads when the root layout changes", async () => {
+  it("does not hard-navigate same-URL server action payloads from snapshot root topology alone", async () => {
     const actionTargetHref = "https://example.com/marketing?from=action";
     const initialState = createState({
       rootLayoutTreePath: "/(marketing)",
@@ -2331,9 +2520,8 @@ describe("app browser navigation controller", () => {
       );
 
       expect(result).toBeUndefined();
-      expect(assign).toHaveBeenCalledTimes(1);
-      expect(assign).toHaveBeenCalledWith(actionTargetHref);
-      expect(stateRef.current.routeId).toBe("route:/marketing");
+      expect(assign).not.toHaveBeenCalled();
+      expect(stateRef.current.routeId).toBe("route:/dashboard");
     } finally {
       detach();
     }
@@ -2798,6 +2986,7 @@ describe("app browser root-layout hard navigation", () => {
   it("renderNavigationPayload calls window.location.assign when root layout changes", async () => {
     const { controller, detach } = createControllerHarness(
       createState({ rootLayoutTreePath: "/(marketing)" }),
+      { getRouteManifest: () => createRootChangeRouteManifest() },
     );
     const { assign } = stubWindow("https://example.com/marketing");
     const createNavigationCommitEffect = vi.fn();
@@ -2809,7 +2998,7 @@ describe("app browser root-layout hard navigation", () => {
         createNavigationCommitEffect,
         historyUpdateMode: "push",
         navigationSnapshot: createClientNavigationRenderSnapshot(
-          "https://example.com/marketing",
+          "https://example.com/dashboard",
           {},
         ),
         nextElements: Promise.resolve(
@@ -2837,6 +3026,7 @@ describe("app browser root-layout hard navigation", () => {
   it("hard-navigate settles the pending router state before navigating away", async () => {
     const { controller, detach } = createControllerHarness(
       createState({ rootLayoutTreePath: "/(marketing)" }),
+      { getRouteManifest: () => createRootChangeRouteManifest() },
     );
     const { assign } = stubWindow("https://example.com/marketing");
     const pendingRouterState = controller.beginPendingBrowserRouterState();
@@ -2851,7 +3041,7 @@ describe("app browser root-layout hard navigation", () => {
         createNavigationCommitEffect: () => () => {},
         historyUpdateMode: "push",
         navigationSnapshot: createClientNavigationRenderSnapshot(
-          "https://example.com/marketing",
+          "https://example.com/dashboard",
           {},
         ),
         nextElements: Promise.resolve(
@@ -2882,6 +3072,7 @@ describe("app browser root-layout hard navigation", () => {
   it("blocks a repeated same-target root-boundary hard navigation to prevent reload loops", async () => {
     const { controller, detach } = createControllerHarness(
       createState({ rootLayoutTreePath: "/(marketing)" }),
+      { getRouteManifest: () => createRootChangeRouteManifest() },
     );
     const { assign, storage } = stubWindow("https://example.com/marketing");
 
@@ -2893,7 +3084,7 @@ describe("app browser root-layout hard navigation", () => {
           createNavigationCommitEffect: () => () => {},
           historyUpdateMode: "push",
           navigationSnapshot: createClientNavigationRenderSnapshot(
-            "https://example.com/marketing",
+            "https://example.com/dashboard",
             {},
           ),
           nextElements: Promise.resolve(
@@ -2947,6 +3138,7 @@ describe("app browser root-layout hard navigation", () => {
   it("allows cross-page hard navigation when the stored guard target is not the current URL", async () => {
     const { controller, detach } = createControllerHarness(
       createState({ rootLayoutTreePath: "/(marketing)" }),
+      { getRouteManifest: () => createRootChangeRouteManifest() },
     );
     const { assign } = stubWindow("https://example.com/marketing");
 
@@ -2958,7 +3150,7 @@ describe("app browser root-layout hard navigation", () => {
           createNavigationCommitEffect: () => () => {},
           historyUpdateMode: "push",
           navigationSnapshot: createClientNavigationRenderSnapshot(
-            "https://example.com/marketing",
+            "https://example.com/dashboard",
             {},
           ),
           nextElements: Promise.resolve(
@@ -2985,7 +3177,7 @@ describe("app browser root-layout hard navigation", () => {
           createNavigationCommitEffect: () => () => {},
           historyUpdateMode: "push",
           navigationSnapshot: createClientNavigationRenderSnapshot(
-            "https://example.com/settings",
+            "https://example.com/dashboard",
             {},
           ),
           nextElements: Promise.resolve(
@@ -3109,7 +3301,7 @@ describe("app browser entry previousNextUrl helpers", () => {
     });
   });
 
-  it("classifies pending commits in one step for same-url payloads", async () => {
+  it("classifies same-url payloads without treating snapshot root topology as authority", async () => {
     const currentState = createState({
       rootLayoutTreePath: "/(marketing)",
     });
@@ -3126,11 +3318,11 @@ describe("app browser entry previousNextUrl helpers", () => {
       type: "navigate",
     });
 
-    expect(result.decision.disposition).toBe("hard-navigate");
+    expect(result.decision.disposition).toBe("commit");
     expect(result.pending.routeId).toBe("route:/dashboard");
     expect(result.pending.action.renderId).toBe(3);
-    expect(result.trace.entries[0]?.code).toBe(NavigationTraceTransactionCodes.hardNavigate);
-    expect(result.trace.entries[1]?.code).toBe(NavigationTraceReasonCodes.rootBoundaryChanged);
+    expect(result.trace.entries[0]?.code).toBe(NavigationTraceTransactionCodes.visibleCommit);
+    expect(result.trace.entries[1]?.code).toBe(NavigationTraceReasonCodes.rootBoundaryUnknown);
     expect(result.trace.entries[1]?.fields.targetHref).toBe(
       "https://example.com/dashboard?action=same-url",
     );
@@ -3301,6 +3493,7 @@ describe("app browser entry previousNextUrl helpers", () => {
       activeNavigationId: 1,
       currentState: state,
       pending,
+      routeManifest: createRouteManifestForPendingCommit(state, pending),
       startedNavigationId: 1,
       targetHref: "https://example.com/feed/comments",
     });

--- a/tests/app-browser-interception-context.test.ts
+++ b/tests/app-browser-interception-context.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vite-plus/test";
+import { resolveManifestNavigationInterceptionContext } from "../packages/vinext/src/server/app-browser-interception-context.js";
+import type {
+  RouteManifest,
+  RouteManifestInterception,
+} from "../packages/vinext/src/routing/app-route-graph.js";
+
+function createRouteManifest(interceptions: readonly RouteManifestInterception[]): RouteManifest {
+  return {
+    graphVersion: "test",
+    segmentGraph: {
+      boundaries: new Map(),
+      defaults: new Map(),
+      interceptions: new Map(interceptions.map((interception) => [interception.id, interception])),
+      interceptionsBySlotId: new Map(),
+      layouts: new Map(),
+      pages: new Map(),
+      rootBoundaries: new Map(),
+      routeHandlers: new Map(),
+      routes: new Map(),
+      slotBindings: new Map(),
+      slots: new Map(),
+      templates: new Map(),
+    },
+  };
+}
+
+const feedPhotoInterception: RouteManifestInterception = {
+  id: "interception:slot:modal:/feed->/photos/:id",
+  interceptingRouteId: "route:/feed",
+  ownerLayoutId: "layout:/feed",
+  slotId: "slot:modal:/feed",
+  sourcePattern: "/feed",
+  sourcePatternParts: ["feed"],
+  targetPattern: "/photos/:id",
+  targetPatternParts: ["photos", ":id"],
+  targetRouteId: "route:/photos/:id",
+};
+
+describe("resolveManifestNavigationInterceptionContext", () => {
+  it("uses manifest-declared interception rules for first-hop browser navigations", () => {
+    expect(
+      resolveManifestNavigationInterceptionContext({
+        basePath: "",
+        currentPathname: "/feed",
+        routeManifest: createRouteManifest([feedPhotoInterception]),
+        targetPathname: "/photos/42",
+      }),
+    ).toBe("/feed");
+  });
+
+  it("strips basePath before matching and returning the interception context", () => {
+    expect(
+      resolveManifestNavigationInterceptionContext({
+        basePath: "/app",
+        currentPathname: "/app/feed",
+        routeManifest: createRouteManifest([feedPhotoInterception]),
+        targetPathname: "/app/photos/42",
+      }),
+    ).toBe("/feed");
+  });
+
+  it("does not infer interception context without a matching manifest rule", () => {
+    expect(
+      resolveManifestNavigationInterceptionContext({
+        basePath: "",
+        currentPathname: "/about",
+        routeManifest: createRouteManifest([feedPhotoInterception]),
+        targetPathname: "/photos/42",
+      }),
+    ).toBeNull();
+
+    expect(
+      resolveManifestNavigationInterceptionContext({
+        basePath: "",
+        currentPathname: "/feed",
+        routeManifest: createRouteManifest([feedPhotoInterception]),
+        targetPathname: "/about",
+      }),
+    ).toBeNull();
+  });
+});

--- a/tests/app-browser-stream.test.ts
+++ b/tests/app-browser-stream.test.ts
@@ -9,7 +9,6 @@ const originalDocument = globalThis.document;
 const vinext = getVinextBrowserGlobal();
 
 function resetBrowserGlobals(): void {
-  delete vinext.__VINEXT_RSC__;
   delete vinext.__VINEXT_RSC_CHUNKS__;
   delete vinext.__VINEXT_RSC_DONE__;
   delete vinext.__VINEXT_RSC_PARAMS__;

--- a/tests/app-browser-stream.test.ts
+++ b/tests/app-browser-stream.test.ts
@@ -4,6 +4,11 @@ import {
   createProgressiveRscStream,
   getVinextBrowserGlobal,
 } from "../packages/vinext/src/server/app-browser-stream.js";
+import {
+  NAVIGATION_RUNTIME_KEY,
+  getNavigationRuntime,
+  registerNavigationRuntimeBootstrap,
+} from "../packages/vinext/src/client/navigation-runtime.js";
 
 const originalDocument = globalThis.document;
 const vinext = getVinextBrowserGlobal();
@@ -13,6 +18,7 @@ function resetBrowserGlobals(): void {
   delete vinext.__VINEXT_RSC_DONE__;
   delete vinext.__VINEXT_RSC_PARAMS__;
   delete vinext.__VINEXT_RSC_NAV__;
+  Reflect.deleteProperty(globalThis, "window");
 }
 
 function setGlobalDocument(value: Document | undefined): void {
@@ -103,6 +109,37 @@ describe("App browser stream helpers", () => {
     expect(await readText(reader)).toEqual({ done: true, text: undefined });
 
     expect(listeners.has("DOMContentLoaded")).toBe(true);
+  });
+
+  it("streams progressive chunks from the typed navigation runtime", async () => {
+    const runtimeWindow = {};
+    Reflect.set(globalThis, "window", runtimeWindow);
+    setGlobalDocument({
+      readyState: "loading",
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    } as unknown as Document);
+
+    registerNavigationRuntimeBootstrap({ rsc: { rsc: ["shell"], done: false } });
+
+    const reader = createProgressiveRscStream().getReader();
+
+    expect(await readText(reader)).toEqual({ done: false, text: "shell" });
+
+    const runtimeRsc = getNavigationRuntime()?.bootstrap.rsc;
+    if (runtimeRsc === undefined) {
+      throw new Error("Expected navigation runtime RSC bootstrap");
+    }
+
+    runtimeRsc.rsc.push("delta");
+    expect(await readText(reader)).toEqual({ done: false, text: "delta" });
+
+    runtimeRsc.done = true;
+    runtimeRsc.rsc.push("final");
+    expect(await readText(reader)).toEqual({ done: false, text: "final" });
+    expect(await readText(reader)).toEqual({ done: true, text: undefined });
+
+    expect(Reflect.has(runtimeWindow, NAVIGATION_RUNTIME_KEY)).toBe(true);
   });
 
   it("streams every chunk when push receives multiple arguments", async () => {

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -2204,7 +2204,9 @@ describe("App Router Production server (startProdServer)", () => {
       "script-src 'nonce-first' 'strict-dynamic';",
     );
     const firstHtml = await firstRes.text();
-    expect(firstHtml).toContain('<script nonce="first">self.__VINEXT_RSC_PARAMS__={}</script>');
+    expect(firstHtml).toContain(
+      '<script nonce="first">Object.assign(((self[Symbol.for("vinext.navigationRuntime")]',
+    );
 
     const secondRes = await fetch(`${baseUrl}/revalidate-test?csp-nonce=second`);
     expect(secondRes.status).toBe(200);
@@ -2213,7 +2215,9 @@ describe("App Router Production server (startProdServer)", () => {
       "script-src 'nonce-second' 'strict-dynamic';",
     );
     const secondHtml = await secondRes.text();
-    expect(secondHtml).toContain('<script nonce="second">self.__VINEXT_RSC_PARAMS__={}</script>');
+    expect(secondHtml).toContain(
+      '<script nonce="second">Object.assign(((self[Symbol.for("vinext.navigationRuntime")]',
+    );
     expect(secondHtml).not.toContain('nonce="first"');
   });
 

--- a/tests/app-ssr-stream.test.ts
+++ b/tests/app-ssr-stream.test.ts
@@ -107,8 +107,10 @@ describe("createRscEmbedTransform raw buffer (#981)", () => {
 
     // Embed scripts still work
     const finalScripts = await transform.finalize();
-    expect(finalScripts).toContain("__VINEXT_RSC_DONE__");
-    expect(finalScripts).toContain("__VINEXT_RSC_CHUNKS__");
+    expect(finalScripts).toContain('Symbol.for("vinext.navigationRuntime")');
+    expect(finalScripts).toContain(".done=true");
+    expect(finalScripts).toContain('.rsc.push("chunk1")');
+    expect(finalScripts).toContain('.rsc.push("chunk2")');
   });
 
   it("rejects getRawBuffer when the stream errors (#1002)", async () => {
@@ -138,7 +140,7 @@ describe("createRscEmbedTransform raw buffer (#981)", () => {
     // The fixed text "as=\"style\"" appears in the embed script after JSON escaping.
     // fixFlightHints turns "stylesheet" → "style" before the chunk is script-wrapped.
     expect(finalScripts).not.toContain("stylesheet");
-    expect(finalScripts).toContain("__VINEXT_RSC_DONE__");
+    expect(finalScripts).toContain(".done=true");
   });
 
   it("embeds non-UTF-8 RSC chunks as base64 binary chunks", async () => {
@@ -150,7 +152,7 @@ describe("createRscEmbedTransform raw buffer (#981)", () => {
 
     const finalScripts = await transform.finalize();
 
-    expect(finalScripts).toContain('self.__VINEXT_RSC_CHUNKS__.push([3,"/wABAgM="])');
+    expect(finalScripts).toContain('.rsc.push([3,"/wABAgM="])');
   });
 
   it("does not lose incomplete UTF-8 bytes before a binary chunk", async () => {
@@ -160,7 +162,7 @@ describe("createRscEmbedTransform raw buffer (#981)", () => {
 
     const finalScripts = await transform.finalize();
 
-    expect(finalScripts).toContain('self.__VINEXT_RSC_CHUNKS__.push([3,"QcM="])');
-    expect(finalScripts).toContain('self.__VINEXT_RSC_CHUNKS__.push([3,"/w=="])');
+    expect(finalScripts).toContain('.rsc.push([3,"QcM="])');
+    expect(finalScripts).toContain('.rsc.push([3,"/w=="])');
   });
 });

--- a/tests/e2e/app-router/advanced.spec.ts
+++ b/tests/e2e/app-router/advanced.spec.ts
@@ -197,7 +197,17 @@ test.describe("Intercepting Routes", () => {
       .toBe("/feed");
 
     await page.evaluate(async () => {
-      const navigate = Reflect.get(window, "__VINEXT_RSC_NAVIGATE__");
+      const runtime = Reflect.get(window, Symbol.for("vinext.navigationRuntime"));
+      const navigate =
+        typeof runtime === "object" &&
+        runtime !== null &&
+        "functions" in runtime &&
+        typeof runtime.functions === "object" &&
+        runtime.functions !== null &&
+        "navigate" in runtime.functions &&
+        typeof runtime.functions.navigate === "function"
+          ? runtime.functions.navigate
+          : null;
       if (typeof navigate !== "function") {
         throw new Error("Expected Vinext RSC navigation executor to be installed");
       }

--- a/tests/e2e/app-router/build-id-navigation.spec.ts
+++ b/tests/e2e/app-router/build-id-navigation.spec.ts
@@ -17,12 +17,23 @@ async function pushAppRoute(page: Page, pathname: string): Promise<void> {
 
 async function captureRscNavigationPromises(page: Page): Promise<void> {
   await page.evaluate((marker) => {
-    const navigate = window.__VINEXT_RSC_NAVIGATE__;
+    type TestNavigate = (
+      href: string,
+      redirectDepth?: number,
+      navigationKind?: "navigate" | "refresh" | "prefetch",
+      historyUpdateMode?: "push" | "replace",
+      previousNextUrlOverride?: string | null,
+      programmaticTransition?: boolean,
+    ) => Promise<unknown>;
+    const runtime = Reflect.get(window, Symbol.for("vinext.navigationRuntime")) as
+      | { functions?: { navigate?: TestNavigate } }
+      | undefined;
+    const navigate = runtime?.functions?.navigate ?? null;
     if (typeof navigate !== "function") {
-      throw new Error("window.__VINEXT_RSC_NAVIGATE__ is not installed");
+      throw new Error("App Router navigation runtime is not installed");
     }
 
-    const wrappedNavigate: typeof navigate = (
+    const wrappedNavigate: TestNavigate = (
       href,
       redirectDepth,
       navigationKind,
@@ -42,7 +53,10 @@ async function captureRscNavigationPromises(page: Page): Promise<void> {
       return pendingNavigation;
     };
 
-    window.__VINEXT_RSC_NAVIGATE__ = wrappedNavigate;
+    if (!runtime?.functions) {
+      throw new Error("App Router navigation runtime functions are not installed");
+    }
+    runtime.functions.navigate = wrappedNavigate;
   }, RSC_NAVIGATION_PROMISE_MARKER);
 }
 

--- a/tests/e2e/app-router/dev-error-overlay.spec.ts
+++ b/tests/e2e/app-router/dev-error-overlay.spec.ts
@@ -135,9 +135,18 @@ test.describe("Dev error overlay", () => {
     // Wait for the Link's onClick handler to attach so the click drives a soft
     // RSC navigation (with historyUpdateMode = "push") instead of a full reload.
     await page.waitForFunction(
-      () =>
-        typeof (window as unknown as { __VINEXT_RSC_NAVIGATE__?: unknown })
-          .__VINEXT_RSC_NAVIGATE__ === "function",
+      () => {
+        const runtime = Reflect.get(window, Symbol.for("vinext.navigationRuntime"));
+        return (
+          typeof runtime === "object" &&
+          runtime !== null &&
+          "functions" in runtime &&
+          typeof runtime.functions === "object" &&
+          runtime.functions !== null &&
+          "navigate" in runtime.functions &&
+          typeof runtime.functions.navigate === "function"
+        );
+      },
       undefined,
       { timeout: 10_000 },
     );
@@ -192,13 +201,22 @@ test.describe("Dev error overlay", () => {
 
     // The boundary itself rendered null, so any in-page link inside the route
     // tree is gone. Drive a soft RSC navigation programmatically through the
-    // global hook the framework installs — the dispatched tree bumps
+    // navigation runtime the framework installs — the dispatched tree bumps
     // renderId, the boundary resets, and the home page renders without a
     // document reload.
     await page.evaluate(() => {
-      const navigate = (window as unknown as { __VINEXT_RSC_NAVIGATE__?: (href: string) => void })
-        .__VINEXT_RSC_NAVIGATE__;
-      if (!navigate) throw new Error("__VINEXT_RSC_NAVIGATE__ is not installed");
+      const runtime = Reflect.get(window, Symbol.for("vinext.navigationRuntime"));
+      const navigate =
+        typeof runtime === "object" &&
+        runtime !== null &&
+        "functions" in runtime &&
+        typeof runtime.functions === "object" &&
+        runtime.functions !== null &&
+        "navigate" in runtime.functions &&
+        typeof runtime.functions.navigate === "function"
+          ? runtime.functions.navigate
+          : null;
+      if (!navigate) throw new Error("App Router navigation runtime is not installed");
       navigate("/");
     });
     await expect(page.locator("h1")).toHaveText("Welcome to App Router");

--- a/tests/e2e/app-router/nextjs-compat/hash-popstate-scroll.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/hash-popstate-scroll.spec.ts
@@ -149,12 +149,26 @@ test.describe("Next.js compat: hash popstate scroll", () => {
     await expect(page).toHaveURL(`${BASE}/nextjs-compat/hash-popstate-scroll#content`);
 
     await page.evaluate(() => {
+      type TestNavigate = (
+        href: string,
+        redirectDepth?: number,
+        navigationKind?: "navigate" | "refresh" | "prefetch",
+        historyUpdateMode?: "push" | "replace",
+        previousNextUrlOverride?: string | null,
+        programmaticTransition?: boolean,
+      ) => Promise<unknown>;
       const testWindow = window as Window & { __vinextHashPopstateRscCalls?: number };
-      const originalNavigate = window.__VINEXT_RSC_NAVIGATE__;
+      const runtime = Reflect.get(window, Symbol.for("vinext.navigationRuntime")) as
+        | { functions?: { navigate?: TestNavigate } }
+        | undefined;
+      const originalNavigate = runtime?.functions?.navigate ?? null;
       if (typeof originalNavigate !== "function") {
-        throw new Error("__VINEXT_RSC_NAVIGATE__ is not installed");
+        throw new Error("App Router navigation runtime is not installed");
       }
-      window.__VINEXT_RSC_NAVIGATE__ = async (...args) => {
+      if (!runtime?.functions) {
+        throw new Error("App Router navigation runtime functions are not installed");
+      }
+      runtime.functions.navigate = async (...args: Parameters<TestNavigate>) => {
         testWindow.__vinextHashPopstateRscCalls =
           (testWindow.__vinextHashPopstateRscCalls ?? 0) + 1;
         return originalNavigate(...args);

--- a/tests/e2e/app-router/rsc-fetch-errors.spec.ts
+++ b/tests/e2e/app-router/rsc-fetch-errors.spec.ts
@@ -113,7 +113,19 @@ test.describe("RSC fetch non-ok response handling", () => {
 
     const navigationPromise = page.waitForURL(`${BASE}${targetPath}`, { timeout: 10_000 });
     await page.evaluate(() => {
-      void (window as any).__VINEXT_RSC_NAVIGATE__("/rsc-fetch-error-target");
+      const runtime = Reflect.get(window, Symbol.for("vinext.navigationRuntime"));
+      const navigate =
+        typeof runtime === "object" &&
+        runtime !== null &&
+        "functions" in runtime &&
+        typeof runtime.functions === "object" &&
+        runtime.functions !== null &&
+        "navigate" in runtime.functions &&
+        typeof runtime.functions.navigate === "function"
+          ? runtime.functions.navigate
+          : null;
+      if (!navigate) throw new Error("App Router navigation runtime is not installed");
+      void navigate("/rsc-fetch-error-target");
     });
     await navigationPromise;
 

--- a/tests/e2e/app-with-src/dev-overlay-recovery.spec.ts
+++ b/tests/e2e/app-with-src/dev-overlay-recovery.spec.ts
@@ -14,9 +14,18 @@ test.describe("Dev recovery boundary (no global-error.tsx)", () => {
     await page.goto(`${BASE}/`);
     await expect(page.locator("#app-with-src-home")).toBeVisible();
     await page.waitForFunction(
-      () =>
-        typeof (window as unknown as { __VINEXT_RSC_NAVIGATE__?: unknown })
-          .__VINEXT_RSC_NAVIGATE__ === "function",
+      () => {
+        const runtime = Reflect.get(window, Symbol.for("vinext.navigationRuntime"));
+        return (
+          typeof runtime === "object" &&
+          runtime !== null &&
+          "functions" in runtime &&
+          typeof runtime.functions === "object" &&
+          runtime.functions !== null &&
+          "navigate" in runtime.functions &&
+          typeof runtime.functions.navigate === "function"
+        );
+      },
       undefined,
       { timeout: 10_000 },
     );

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -18,12 +18,22 @@ export async function waitForHydration(page: Page): Promise<void> {
  */
 export async function waitForAppRouterHydration(page: Page): Promise<void> {
   await expect(async () => {
-    const ready = await page.evaluate(
-      () =>
+    const ready = await page.evaluate(() => {
+      const runtime = Reflect.get(window, Symbol.for("vinext.navigationRuntime"));
+      const hasNavigate =
+        typeof runtime === "object" &&
+        runtime !== null &&
+        "functions" in runtime &&
+        typeof runtime.functions === "object" &&
+        runtime.functions !== null &&
+        "navigate" in runtime.functions &&
+        typeof runtime.functions.navigate === "function";
+      return (
         Boolean(window.__VINEXT_RSC_ROOT__) &&
-        typeof window.__VINEXT_RSC_NAVIGATE__ === "function" &&
-        typeof window.__VINEXT_HYDRATED_AT === "number",
-    );
+        hasNavigate &&
+        typeof window.__VINEXT_HYDRATED_AT === "number"
+      );
+    });
     expect(ready).toBe(true);
   }).toPass({ timeout: 10_000 });
   await page.evaluate(

--- a/tests/ecosystem.test.ts
+++ b/tests/ecosystem.test.ts
@@ -159,7 +159,7 @@ describe("nuqs", () => {
 
     const optimizedAdapter = readFileSync(path.join(depsDir, optimizedAdapterFile!), "utf8");
 
-    expect(optimizedAdapter).toContain("__VINEXT_RSC_NAVIGATE__");
+    expect(optimizedAdapter).toContain("vinext.navigationRuntime");
     expect(optimizedAdapter).toContain("vinext.navigation.readonlySearchParams");
     expect(optimizedAdapter).not.toContain("node_modules/.pnpm/next@");
   });

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -169,8 +169,10 @@ describe("App Router generated manifest construction", () => {
       },
     ]);
 
+    expect(code).toContain("import { registerNavigationRuntimeBootstrap } from ");
     expect(code).toContain("window.__VINEXT_LINK_PREFETCH_ROUTES__ = ");
-    expect(code).toContain("window.__VINEXT_ROUTE_MANIFEST__ = null;");
+    expect(code).toContain("registerNavigationRuntimeBootstrap({");
+    expect(code).toContain("routeManifest: null");
     expect(code).toContain('{"patternParts":["about"],"isDynamic":false}');
     expect(code).toContain('{"patternParts":["blog",":slug"],"isDynamic":true}');
     expect(code).toContain('{"patternParts":["modal-host"],"isDynamic":false}');
@@ -192,7 +194,7 @@ describe("App Router generated manifest construction", () => {
       const graph = await buildAppRouteGraph(appDir, createValidFileMatcher());
       const code = generateBrowserEntry(graph.routes, graph.routeManifest);
 
-      expect(code).toContain("window.__VINEXT_ROUTE_MANIFEST__ = {");
+      expect(code).toContain("registerNavigationRuntimeBootstrap({");
       expect(code).toContain("graphVersion:");
       expect(code).toContain("routes: new Map(");
       expect(code).toContain("rootBoundaries: new Map(");

--- a/tests/form.test.ts
+++ b/tests/form.test.ts
@@ -105,7 +105,15 @@ function createWindowStub() {
     replaceState,
     scrollTo,
     window: {
-      __VINEXT_RSC_NAVIGATE__: navigate,
+      [Symbol.for("vinext.navigationRuntime")]: {
+        bootstrap: {
+          routeManifest: null,
+          rsc: undefined,
+        },
+        functions: {
+          navigate,
+        },
+      },
       history: {
         pushState,
         replaceState,
@@ -262,7 +270,7 @@ describe("Form client GET interception", () => {
       '<Form> received an `action` that contains search params: "/search?lang=en". This is not supported, and they will be ignored. If you need to pass in additional search params, use an `<input type="hidden" />` instead.',
     );
     expect(event.preventDefault).toHaveBeenCalledOnce();
-    // navigateClientSide delegates URL push to __VINEXT_RSC_NAVIGATE__ (two-phase commit)
+    // navigateClientSide delegates URL push to the App Router navigation runtime.
     expect(navigate).toHaveBeenCalledWith(
       "/search?q=react",
       0,

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -46,6 +46,31 @@ const linkPrefetchRoutes = [
   { patternParts: ["blog", ":slug"], isDynamic: true },
 ] satisfies VinextLinkPrefetchRoute[];
 
+function createTestNavigationRuntime(navigate: unknown) {
+  return {
+    bootstrap: {
+      routeManifest: null,
+      rsc: undefined,
+    },
+    functions: {
+      navigate,
+    },
+  };
+}
+
+function pingVisibleLinksFromRuntime(): void {
+  const runtime: unknown = Reflect.get(window, Symbol.for("vinext.navigationRuntime"));
+  if (typeof runtime !== "object" || runtime === null || !("functions" in runtime)) return;
+  const { functions } = runtime;
+  if (typeof functions !== "object" || functions === null || !("pingVisibleLinks" in functions)) {
+    return;
+  }
+  const { pingVisibleLinks } = functions;
+  if (typeof pingVisibleLinks === "function") {
+    pingVisibleLinks();
+  }
+}
+
 type MockReactAnchorCaptureOptions = {
   captureAnchor(type: unknown, props: unknown): void;
   captureEffect?: (effect: CapturedEffect) => void;
@@ -342,7 +367,15 @@ describe("Link App Router navigation scheduling", () => {
       transitionStates.push(transitionActive);
     });
     vi.stubGlobal("window", {
-      __VINEXT_RSC_NAVIGATE__: navigate,
+      [Symbol.for("vinext.navigationRuntime")]: {
+        bootstrap: {
+          routeManifest: null,
+          rsc: undefined,
+        },
+        functions: {
+          navigate,
+        },
+      },
       addEventListener: vi.fn(),
       history: {
         pushState: vi.fn(),
@@ -448,7 +481,15 @@ describe("Link App Router navigation scheduling", () => {
 
     const navigate = vi.fn(async () => {});
     vi.stubGlobal("window", {
-      __VINEXT_RSC_NAVIGATE__: navigate,
+      [Symbol.for("vinext.navigationRuntime")]: {
+        bootstrap: {
+          routeManifest: null,
+          rsc: undefined,
+        },
+        functions: {
+          navigate,
+        },
+      },
       addEventListener: vi.fn(),
       history: {
         pushState: vi.fn(),
@@ -503,6 +544,7 @@ describe("Link App Router navigation scheduling", () => {
 });
 
 async function renderIsolatedLink(options: {
+  appNavigation?: boolean;
   href: string;
   nodeEnv: string;
   props?: Record<string, unknown>;
@@ -539,6 +581,8 @@ async function renderIsolatedLink(options: {
     href: "https://example.com/current",
     origin: "https://example.com",
   };
+  const navigationRuntime =
+    options.appNavigation === false ? undefined : createTestNavigationRuntime(navigate);
 
   vi.stubGlobal("fetch", fetch);
   vi.stubGlobal("document", {
@@ -550,7 +594,9 @@ async function renderIsolatedLink(options: {
     },
   });
   vi.stubGlobal("window", {
-    __VINEXT_RSC_NAVIGATE__: navigate,
+    ...(navigationRuntime === undefined
+      ? {}
+      : { [Symbol.for("vinext.navigationRuntime")]: navigationRuntime }),
     addEventListener: vi.fn(),
     dispatchEvent: vi.fn(),
     history: {
@@ -1017,11 +1063,11 @@ describe("Link prefetch scheduling", () => {
   it("prefetches Pages Router links on mouse intent when prefetch is false", async () => {
     const userOnMouseEnter = vi.fn();
     const result = await renderIsolatedLink({
+      appNavigation: false,
       href: "/pages-disabled-mouse-intent-prefetch-target",
       nodeEnv: "production",
       props: { onMouseEnter: userOnMouseEnter, prefetch: false },
       windowOverrides: {
-        __VINEXT_RSC_NAVIGATE__: undefined,
         __NEXT_DATA__: {
           __vinext: {
             pageModuleUrl: "/_next/static/chunks/pages/current.js",
@@ -1051,11 +1097,11 @@ describe("Link prefetch scheduling", () => {
   it("prefetches Pages Router links on touch intent when prefetch is false", async () => {
     const userOnTouchStart = vi.fn();
     const result = await renderIsolatedLink({
+      appNavigation: false,
       href: "/pages-disabled-touch-intent-prefetch-target",
       nodeEnv: "production",
       props: { onTouchStart: userOnTouchStart, prefetch: false },
       windowOverrides: {
-        __VINEXT_RSC_NAVIGATE__: undefined,
         __NEXT_DATA__: {
           __vinext: {
             pageModuleUrl: "/_next/static/chunks/pages/current.js",
@@ -1085,10 +1131,10 @@ describe("Link prefetch scheduling", () => {
   it("does not duplicate Pages Router viewport prefetch after visibility changes", async () => {
     const observer = stubIntersectionObserver();
     const result = await renderIsolatedLink({
+      appNavigation: false,
       href: "/pages-viewport-prefetch-target",
       nodeEnv: "production",
       windowOverrides: {
-        __VINEXT_RSC_NAVIGATE__: undefined,
         __NEXT_DATA__: {
           __vinext: {
             pageModuleUrl: "/_next/static/chunks/pages/current.js",
@@ -1104,7 +1150,7 @@ describe("Link prefetch scheduling", () => {
       await flushPrefetchTasks();
       observer.dispatchIntersectingEntry(result.anchor, true);
       await flushPrefetchTasks();
-      window.__VINEXT_PING_VISIBLE_LINKS__?.();
+      pingVisibleLinksFromRuntime();
       await flushPrefetchTasks();
 
       expect(result.fetch).not.toHaveBeenCalled();

--- a/tests/navigation-planner.test.ts
+++ b/tests/navigation-planner.test.ts
@@ -191,6 +191,81 @@ function createTestRouteManifest(routes: readonly TestManifestRoute[]): RouteMan
   };
 }
 
+function rootBoundaryIdForManifest(rootBoundaryId: string | null): string | null {
+  return rootBoundaryId === null ? null : `root-boundary:${rootBoundaryId}`;
+}
+
+function createRouteManifestForSnapshots(
+  currentSnapshot: RouteSnapshotV0,
+  targetSnapshot: RouteSnapshotV0,
+): RouteManifest {
+  if (targetSnapshot.interception !== null) {
+    const proof = targetSnapshot.interception;
+    const routes: TestManifestRoute[] = [
+      {
+        id: currentSnapshot.routeId,
+        layoutIds: currentSnapshot.layoutIds,
+        pattern: currentSnapshot.matchedUrl,
+        rootBoundaryId: rootBoundaryIdForManifest(currentSnapshot.rootBoundaryId),
+      },
+    ];
+    if (
+      proof.sourceRouteId !== currentSnapshot.routeId ||
+      proof.sourceMatchedUrl !== currentSnapshot.matchedUrl
+    ) {
+      routes.push({
+        id: proof.sourceRouteId,
+        layoutIds: targetSnapshot.layoutIds,
+        pattern: proof.sourceMatchedUrl,
+        rootBoundaryId: rootBoundaryIdForManifest(targetSnapshot.rootBoundaryId),
+      });
+    }
+    routes.push(
+      {
+        id: proof.sourceRouteId,
+        interceptions: [
+          {
+            ownerLayoutId:
+              targetSnapshot.slotBindings.find((binding) => binding.slotId === proof.slotId)
+                ?.ownerLayoutId ?? null,
+            slotId: proof.slotId,
+            sourcePattern: proof.sourceMatchedUrl,
+            targetPattern: proof.targetMatchedUrl,
+          },
+        ],
+        layoutIds: currentSnapshot.layoutIds,
+        pattern: proof.sourceMatchedUrl,
+        rootBoundaryId: rootBoundaryIdForManifest(currentSnapshot.rootBoundaryId),
+        slotBindings: targetSnapshot.slotBindings,
+      },
+      {
+        id: proof.targetRouteId,
+        layoutIds: targetSnapshot.layoutIds,
+        pattern: proof.targetMatchedUrl,
+        rootBoundaryId: rootBoundaryIdForManifest(targetSnapshot.rootBoundaryId),
+      },
+    );
+    return createTestRouteManifest(routes);
+  }
+
+  return createTestRouteManifest([
+    {
+      id: currentSnapshot.routeId,
+      layoutIds: currentSnapshot.layoutIds,
+      pattern: currentSnapshot.matchedUrl,
+      rootBoundaryId: rootBoundaryIdForManifest(currentSnapshot.rootBoundaryId),
+      slotBindings: currentSnapshot.slotBindings,
+    },
+    {
+      id: targetSnapshot.routeId,
+      layoutIds: targetSnapshot.layoutIds,
+      pattern: targetSnapshot.matchedUrl,
+      rootBoundaryId: rootBoundaryIdForManifest(targetSnapshot.rootBoundaryId),
+      slotBindings: targetSnapshot.slotBindings,
+    },
+  ]);
+}
+
 function createOperationToken(overrides: Partial<OperationToken> = {}): OperationToken {
   return {
     baseVisibleCommitVersion: 2,
@@ -207,9 +282,25 @@ function planFlightResponse(rootBoundaryId: string | null): NavigationDecisionV0
   const token = createOperationToken({
     targetSnapshotFingerprint: `route:/dashboard|root:${rootBoundaryId ?? "unknown"}`,
   });
+  const routeManifest = createTestRouteManifest([
+    {
+      layoutIds: ["layout:/"],
+      pattern: "/current",
+      rootBoundaryId: "root-boundary:/",
+    },
+    {
+      layoutIds: rootBoundaryId === null ? [] : [`layout:${rootBoundaryId}`],
+      pattern: "/dashboard",
+      rootBoundaryId: rootBoundaryId === null ? null : `root-boundary:${rootBoundaryId}`,
+    },
+  ]);
   const result: FlightResultV0 = {
     href: "https://example.com/dashboard",
-    targetSnapshot: createRouteSnapshot(rootBoundaryId),
+    targetSnapshot: {
+      ...createRouteSnapshot(rootBoundaryId),
+      matchedUrl: "/dashboard",
+      routeId: "route:/dashboard",
+    },
   };
   const state: NavigationPlannerStateV0 = {
     nextOperationToken: token,
@@ -220,7 +311,12 @@ function planFlightResponse(rootBoundaryId: string | null): NavigationDecisionV0
       startedVisibleCommitVersion: 2,
     },
     visibleCommitVersion: 2,
-    visibleSnapshot: createRouteSnapshot("/"),
+    visibleSnapshot: {
+      ...createRouteSnapshot("/"),
+      displayUrl: "https://example.com/current",
+      matchedUrl: "/current",
+      routeId: "route:/current",
+    },
   };
   const event: NavigationEvent = {
     kind: "flightResponseArrived",
@@ -229,7 +325,7 @@ function planFlightResponse(rootBoundaryId: string | null): NavigationDecisionV0
   };
   const input: NavigationPlannerInput = {
     event,
-    routeManifest: null,
+    routeManifest,
     state,
   };
 
@@ -244,16 +340,39 @@ function planFlightResponseFromRootBoundaries(options: {
     targetSnapshotFingerprint: `route:/dashboard|root:${options.nextRootBoundaryId ?? "unknown"}`,
   });
 
+  const routeManifest = createTestRouteManifest([
+    {
+      layoutIds:
+        options.currentRootBoundaryId === null ? [] : [`layout:${options.currentRootBoundaryId}`],
+      pattern: "/current",
+      rootBoundaryId:
+        options.currentRootBoundaryId === null
+          ? null
+          : `root-boundary:${options.currentRootBoundaryId}`,
+    },
+    {
+      layoutIds:
+        options.nextRootBoundaryId === null ? [] : [`layout:${options.nextRootBoundaryId}`],
+      pattern: "/dashboard",
+      rootBoundaryId:
+        options.nextRootBoundaryId === null ? null : `root-boundary:${options.nextRootBoundaryId}`,
+    },
+  ]);
+
   return navigationPlanner.plan({
     event: {
       kind: "flightResponseArrived",
       result: {
         href: "https://example.com/dashboard",
-        targetSnapshot: createRouteSnapshot(options.nextRootBoundaryId),
+        targetSnapshot: {
+          ...createRouteSnapshot(options.nextRootBoundaryId),
+          matchedUrl: "/dashboard",
+          routeId: "route:/dashboard",
+        },
       },
       token,
     },
-    routeManifest: null,
+    routeManifest,
     state: {
       nextOperationToken: token,
       traceFields: {
@@ -263,7 +382,12 @@ function planFlightResponseFromRootBoundaries(options: {
         startedVisibleCommitVersion: 2,
       },
       visibleCommitVersion: 2,
-      visibleSnapshot: createRouteSnapshot(options.currentRootBoundaryId),
+      visibleSnapshot: {
+        ...createRouteSnapshot(options.currentRootBoundaryId),
+        displayUrl: "https://example.com/current",
+        matchedUrl: "/current",
+        routeId: "route:/current",
+      },
     },
   });
 }
@@ -291,7 +415,10 @@ function planFlightResponseFromSnapshots(options: {
       },
       token,
     },
-    routeManifest: options.routeManifest ?? null,
+    routeManifest:
+      options.routeManifest === undefined
+        ? createRouteManifestForSnapshots(options.currentSnapshot, options.targetSnapshot)
+        : options.routeManifest,
     state: {
       nextOperationToken: token,
       traceFields: options.traceFields,
@@ -359,34 +486,34 @@ describe("navigationPlanner root-boundary decisions", () => {
     ]);
   });
 
-  it("uses the current soft fallback when the target root identity is unknown", () => {
+  it("uses an unproven payload fallback when the target root identity is unknown", () => {
     const decision = planFlightResponse(null);
 
     expect(decision.kind).toBe("proposeCommit");
     if (decision.kind !== "proposeCommit") {
       throw new Error("Expected proposeCommit decision");
     }
-    expect(decision.proposal.reason).toBe("rootBoundaryUnknownFallback");
-    expect(decision.proposal.preserveAbsentSlots).toBe(true);
+    expect(decision.proposal.reason).toBe("unprovenTopologyFallback");
+    expect(decision.proposal.preserveAbsentSlots).toBe(false);
     expect(decision.proposal.preserveElementIds).toEqual([]);
     expect(decision.proposal.preservePreviousSlotIds).toEqual([]);
     expect(decision.trace.entries[0]?.code).toBe(NavigationTraceReasonCodes.rootBoundaryUnknown);
   });
 
-  it("uses the current soft fallback when the visible root identity is unknown", () => {
+  it("uses an unproven payload fallback when the visible root identity is unknown", () => {
     const transition = navigationPlanner.classifyRootBoundaryTransition(null, "/");
     const decision = planFlightResponseFromRootBoundaries({
       currentRootBoundaryId: null,
       nextRootBoundaryId: "/",
     });
 
-    expect(transition).toBe("rootBoundaryUnknownFallback");
+    expect(transition).toBe("rootBoundaryUnknown");
     expect(decision.kind).toBe("proposeCommit");
     if (decision.kind !== "proposeCommit") {
       throw new Error("Expected proposeCommit decision");
     }
-    expect(decision.proposal.reason).toBe("rootBoundaryUnknownFallback");
-    expect(decision.proposal.preserveAbsentSlots).toBe(true);
+    expect(decision.proposal.reason).toBe("unprovenTopologyFallback");
+    expect(decision.proposal.preserveAbsentSlots).toBe(false);
     expect(decision.proposal.preserveElementIds).toEqual([]);
     expect(decision.proposal.preservePreviousSlotIds).toEqual([]);
     expect(decision.trace.entries[0]?.code).toBe(NavigationTraceReasonCodes.rootBoundaryUnknown);
@@ -487,7 +614,7 @@ describe("navigationPlanner root-boundary decisions", () => {
         },
         token,
       },
-      routeManifest: null,
+      routeManifest: createRouteManifestForSnapshots(currentSnapshot, targetSnapshot),
       state: {
         nextOperationToken: token,
         traceFields: {
@@ -533,6 +660,12 @@ describe("navigationPlanner root-boundary decisions", () => {
         createSlotBinding("slot:reports:/dashboard", "layout:/dashboard", "active"),
       ],
     );
+    const targetSettingsSnapshot: RouteSnapshotV0 = {
+      ...targetSnapshot,
+      displayUrl: "https://example.com/dashboard/settings",
+      matchedUrl: "/dashboard/settings",
+      routeId: "route:/dashboard/settings",
+    };
     const token = createOperationToken({
       targetSnapshotFingerprint: "route:/dashboard/settings|root:/",
     });
@@ -542,11 +675,11 @@ describe("navigationPlanner root-boundary decisions", () => {
         kind: "flightResponseArrived",
         result: {
           href: "https://example.com/dashboard/settings",
-          targetSnapshot,
+          targetSnapshot: targetSettingsSnapshot,
         },
         token,
       },
-      routeManifest: null,
+      routeManifest: createRouteManifestForSnapshots(currentSnapshot, targetSettingsSnapshot),
       state: {
         nextOperationToken: token,
         traceFields: {
@@ -587,6 +720,12 @@ describe("navigationPlanner root-boundary decisions", () => {
         createSlotBinding("slot:analytics:/dashboard", "layout:/dashboard", "unmatched"),
       ],
     );
+    const targetSettingsSnapshot: RouteSnapshotV0 = {
+      ...targetSnapshot,
+      displayUrl: "https://example.com/dashboard/settings",
+      matchedUrl: "/dashboard/settings",
+      routeId: "route:/dashboard/settings",
+    };
     const token = createOperationToken({
       targetSnapshotFingerprint: "route:/dashboard/settings|root:/",
     });
@@ -596,11 +735,11 @@ describe("navigationPlanner root-boundary decisions", () => {
         kind: "flightResponseArrived",
         result: {
           href: "https://example.com/dashboard/settings",
-          targetSnapshot,
+          targetSnapshot: targetSettingsSnapshot,
         },
         token,
       },
-      routeManifest: null,
+      routeManifest: createRouteManifestForSnapshots(currentSnapshot, targetSettingsSnapshot),
       state: {
         nextOperationToken: token,
         visibleCommitVersion: 2,
@@ -616,12 +755,17 @@ describe("navigationPlanner root-boundary decisions", () => {
   });
 
   it("does not preserve default target slots when their owner layout is not retained", () => {
-    const currentSnapshot = createRouteSnapshot(
-      "/",
-      ["layout:/", "layout:/feed"],
-      [],
-      [createSlotBinding("slot:modal:/dashboard", "layout:/dashboard", "active")],
-    );
+    const currentSnapshot: RouteSnapshotV0 = {
+      ...createRouteSnapshot(
+        "/",
+        ["layout:/", "layout:/feed"],
+        [],
+        [createSlotBinding("slot:modal:/dashboard", "layout:/dashboard", "active")],
+      ),
+      displayUrl: "https://example.com/feed",
+      matchedUrl: "/feed",
+      routeId: "route:/feed",
+    };
     const targetSnapshot = createRouteSnapshot(
       "/",
       ["layout:/", "layout:/dashboard"],
@@ -1303,7 +1447,7 @@ describe("navigationPlanner root-boundary decisions", () => {
     );
   });
 
-  it("rejects intercepted preservation when source and target share no layout root", () => {
+  it("does not use intercepted snapshot root topology as preservation authority", () => {
     const currentSnapshot: RouteSnapshotV0 = {
       ...createRouteSnapshot("/", ["layout:/", "layout:/feed"]),
       matchedUrl: "/feed",
@@ -1331,7 +1475,7 @@ describe("navigationPlanner root-boundary decisions", () => {
     }
     expect(decision.reason).toBe("interceptionProofRejected");
     expect(decision.trace.entries[0]?.code).toBe(
-      NavigationTraceReasonCodes.interceptedRejectedIncompatibleRoot,
+      NavigationTraceReasonCodes.interceptedRejectedMissingSlotProof,
     );
   });
 

--- a/tests/navigation-runtime.test.ts
+++ b/tests/navigation-runtime.test.ts
@@ -2,7 +2,9 @@ import { afterEach, describe, expect, it } from "vite-plus/test";
 import {
   NAVIGATION_RUNTIME_KEY,
   getNavigationRuntime,
+  hasAppNavigationRuntime,
   registerNavigationRuntimeBootstrap,
+  registerNavigationRuntimeFunctions,
   subscribeNavigationRuntimeRscChunk,
   type NavigationRuntime,
   type NavigationRuntimeBootstrap,
@@ -46,6 +48,27 @@ describe("navigation runtime contract", () => {
     subscribeNavigationRuntimeRscChunk("chunk");
 
     expect(getNavigationRuntime()?.bootstrap.rsc?.rsc).toEqual(["chunk"]);
+  });
+
+  it("reports app navigation availability from the registered navigate slot", () => {
+    Reflect.set(globalThis, "window", {});
+
+    expect(hasAppNavigationRuntime()).toBe(false);
+
+    registerNavigationRuntimeFunctions({
+      navigate: () => Promise.resolve(),
+    });
+
+    expect(hasAppNavigationRuntime()).toBe(true);
+  });
+
+  it("keeps server-side runtime creation detached from the window contract", () => {
+    Reflect.deleteProperty(globalThis, "window");
+
+    const runtime = subscribeNavigationRuntimeRscChunk("server-chunk");
+
+    expect(runtime.bootstrap.rsc?.rsc).toEqual(["server-chunk"]);
+    expect(getNavigationRuntime()).toBeNull();
   });
 
   it("rejects runtime objects with non-function capability slots", () => {

--- a/tests/navigation-runtime.test.ts
+++ b/tests/navigation-runtime.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import {
+  NAVIGATION_RUNTIME_KEY,
+  getNavigationRuntime,
+  registerNavigationRuntimeBootstrap,
+  type NavigationRuntime,
+  type NavigationRuntimeBootstrap,
+  type NavigationRuntimeFunctions,
+  type NavigationRuntimeRscBootstrap,
+  type NavigationRuntimeRscChunk,
+} from "../packages/vinext/src/client/navigation-runtime.js";
+
+const originalWindow = Reflect.get(globalThis, "window");
+const hadWindow = Reflect.has(globalThis, "window");
+
+afterEach(() => {
+  if (hadWindow) {
+    Reflect.set(globalThis, "window", originalWindow);
+    return;
+  }
+  Reflect.deleteProperty(globalThis, "window");
+});
+
+describe("navigation runtime contract", () => {
+  it("merges bootstrap data without clobbering independently registered RSC payloads", () => {
+    Reflect.set(globalThis, "window", {});
+
+    const chunk: NavigationRuntimeRscChunk = "flight";
+    const rscBootstrap: NavigationRuntimeRscBootstrap = {
+      params: { id: "123" },
+      rsc: [chunk],
+    };
+    const bootstrap: Partial<NavigationRuntimeBootstrap> = { rsc: rscBootstrap };
+
+    registerNavigationRuntimeBootstrap(bootstrap);
+    registerNavigationRuntimeBootstrap({ routeManifest: null });
+
+    expect(getNavigationRuntime()?.bootstrap.rsc?.params?.id).toBe("123");
+    expect(getNavigationRuntime()?.bootstrap.routeManifest).toBeNull();
+  });
+
+  it("rejects runtime objects with non-function capability slots", () => {
+    const runtimeWindow = {};
+    const functions: NavigationRuntimeFunctions = {};
+    const runtime: NavigationRuntime = {
+      bootstrap: {
+        routeManifest: null,
+        rsc: undefined,
+      },
+      functions,
+    };
+    Reflect.set(globalThis, "window", runtimeWindow);
+    Reflect.set(runtimeWindow, NAVIGATION_RUNTIME_KEY, runtime);
+    Reflect.set(runtimeWindow, NAVIGATION_RUNTIME_KEY, {
+      bootstrap: {
+        routeManifest: null,
+        rsc: undefined,
+      },
+      functions: {
+        navigate: "not callable",
+      },
+    });
+
+    expect(getNavigationRuntime()).toBeNull();
+  });
+});

--- a/tests/navigation-runtime.test.ts
+++ b/tests/navigation-runtime.test.ts
@@ -3,6 +3,7 @@ import {
   NAVIGATION_RUNTIME_KEY,
   getNavigationRuntime,
   registerNavigationRuntimeBootstrap,
+  subscribeNavigationRuntimeRscChunk,
   type NavigationRuntime,
   type NavigationRuntimeBootstrap,
   type NavigationRuntimeFunctions,
@@ -39,6 +40,14 @@ describe("navigation runtime contract", () => {
     expect(getNavigationRuntime()?.bootstrap.routeManifest).toBeNull();
   });
 
+  it("creates the RSC bootstrap buffer when subscribing the first chunk", () => {
+    Reflect.set(globalThis, "window", {});
+
+    subscribeNavigationRuntimeRscChunk("chunk");
+
+    expect(getNavigationRuntime()?.bootstrap.rsc?.rsc).toEqual(["chunk"]);
+  });
+
   it("rejects runtime objects with non-function capability slots", () => {
     const runtimeWindow = {};
     const functions: NavigationRuntimeFunctions = {};
@@ -59,6 +68,58 @@ describe("navigation runtime contract", () => {
       functions: {
         navigate: "not callable",
       },
+    });
+
+    expect(getNavigationRuntime()).toBeNull();
+  });
+
+  it("rejects route manifests without the map-backed segment graph contract", () => {
+    const runtimeWindow = {};
+    Reflect.set(globalThis, "window", runtimeWindow);
+    Reflect.set(runtimeWindow, NAVIGATION_RUNTIME_KEY, {
+      bootstrap: {
+        routeManifest: {
+          graphVersion: "test",
+          segmentGraph: {
+            interceptions: {
+              values: () => [],
+            },
+          },
+        },
+        rsc: undefined,
+      },
+      functions: {},
+    });
+
+    expect(getNavigationRuntime()).toBeNull();
+  });
+
+  it("rejects route manifests with malformed interception entries", () => {
+    const runtimeWindow = {};
+    const segmentGraphMaps = {
+      boundaries: new Map(),
+      defaults: new Map(),
+      interceptions: new Map([["bad", {}]]),
+      interceptionsBySlotId: new Map(),
+      layouts: new Map(),
+      pages: new Map(),
+      rootBoundaries: new Map(),
+      routeHandlers: new Map(),
+      routes: new Map(),
+      slotBindings: new Map(),
+      slots: new Map(),
+      templates: new Map(),
+    };
+    Reflect.set(globalThis, "window", runtimeWindow);
+    Reflect.set(runtimeWindow, NAVIGATION_RUNTIME_KEY, {
+      bootstrap: {
+        routeManifest: {
+          graphVersion: "test",
+          segmentGraph: segmentGraphMaps,
+        },
+        rsc: undefined,
+      },
+      functions: {},
     });
 
     expect(getNavigationRuntime()).toBeNull();

--- a/tests/navigation-runtime.test.ts
+++ b/tests/navigation-runtime.test.ts
@@ -62,6 +62,18 @@ describe("navigation runtime contract", () => {
     expect(hasAppNavigationRuntime()).toBe(true);
   });
 
+  it("merges registered function slots without clobbering existing capabilities", () => {
+    Reflect.set(globalThis, "window", {});
+    const navigate = () => Promise.resolve();
+    const pingVisibleLinks = () => {};
+
+    registerNavigationRuntimeFunctions({ navigate });
+    registerNavigationRuntimeFunctions({ pingVisibleLinks });
+
+    expect(getNavigationRuntime()?.functions.navigate).toBe(navigate);
+    expect(getNavigationRuntime()?.functions.pingVisibleLinks).toBe(pingVisibleLinks);
+  });
+
   it("keeps server-side runtime creation detached from the window contract", () => {
     Reflect.deleteProperty(globalThis, "window");
 

--- a/tests/nextjs-compat/rsc-context-lazy-stream.test.ts
+++ b/tests/nextjs-compat/rsc-context-lazy-stream.test.ts
@@ -196,46 +196,59 @@ describe("RSC lazy stream: headers() context survives until stream is consumed",
 //   [id]/page.tsx  — dynamic-segment variant
 
 const NAV_ROUTE = "/nextjs-compat/nav-context-hydration";
+const RSC_BOOTSTRAP_PREFIX =
+  'Object.assign(((self[Symbol.for("vinext.navigationRuntime")]??={bootstrap:{routeManifest:null},functions:{}}).bootstrap.rsc??={rsc:[]}),{params:';
 
-describe("__VINEXT_RSC_NAV__: nav context embedded for hydration snapshot consistency", () => {
+function extractRscBootstrap(html: string): {
+  nav: { pathname: string; searchParams: [string, string][] };
+  params: Record<string, string | string[]>;
+} {
+  const start = html.indexOf(RSC_BOOTSTRAP_PREFIX);
+  expect(start, "navigation runtime RSC bootstrap script not found").toBeGreaterThan(-1);
+  const paramsStart = start + RSC_BOOTSTRAP_PREFIX.length;
+  const navSeparator = html.indexOf(",nav:", paramsStart);
+  expect(navSeparator, "navigation runtime nav payload not found").toBeGreaterThan(-1);
+  const end = html.indexOf("})</script>", navSeparator);
+  expect(end, "navigation runtime RSC bootstrap script was not closed").toBeGreaterThan(-1);
+  return {
+    params: JSON.parse(html.slice(paramsStart, navSeparator)),
+    nav: JSON.parse(html.slice(navSeparator + ",nav:".length, end)),
+  };
+}
+
+describe("navigation runtime RSC bootstrap: nav context embedded for hydration snapshot consistency", () => {
   // ── 1. Script tag is present ──────────────────────────────────────────────
 
-  it("HTML contains a __VINEXT_RSC_NAV__ script tag", async () => {
+  it("HTML contains a navigation runtime nav bootstrap payload", async () => {
     const res = await fetch(`${_baseUrl}${NAV_ROUTE}`);
     expect(res.status).toBe(200);
     const html = await res.text();
 
-    // generateSsrEntry() emits:
-    //   <script>self.__VINEXT_RSC_NAV__={"pathname":...,"searchParams":...}</script>
-    expect(html).toContain("__VINEXT_RSC_NAV__");
+    expect(html).toContain(RSC_BOOTSTRAP_PREFIX);
+    expect(html).toContain(",nav:");
   });
 
-  it("HTML contains a __VINEXT_RSC_PARAMS__ script tag", async () => {
+  it("HTML contains a navigation runtime params bootstrap payload", async () => {
     const res = await fetch(`${_baseUrl}${NAV_ROUTE}`);
     expect(res.status).toBe(200);
     const html = await res.text();
 
-    // generateSsrEntry() emits:
-    //   <script>self.__VINEXT_RSC_PARAMS__={...}</script>
-    expect(html).toContain("__VINEXT_RSC_PARAMS__");
+    expect(html).toContain(RSC_BOOTSTRAP_PREFIX);
+    expect(html).toContain("{params:");
   });
 
   // ── 2. Pathname is correct ────────────────────────────────────────────────
 
-  it("__VINEXT_RSC_NAV__ pathname matches the request pathname", async () => {
+  it("navigation runtime pathname matches the request pathname", async () => {
     const res = await fetch(`${_baseUrl}${NAV_ROUTE}`);
     const html = await res.text();
 
-    // Extract the JSON payload from the script tag.
-    // The server emits: self.__VINEXT_RSC_NAV__=<json>;
-    const match = html.match(/self\.__VINEXT_RSC_NAV__=(\{[^<]+\})/);
-    expect(match, "__VINEXT_RSC_NAV__ script tag not found").toBeTruthy();
-    const nav = JSON.parse(match![1]);
+    const { nav } = extractRscBootstrap(html);
 
     expect(nav.pathname).toBe(NAV_ROUTE);
   });
 
-  it("__VINEXT_RSC_NAV__ pathname agrees with SSR-rendered usePathname() output", async () => {
+  it("navigation runtime pathname agrees with SSR-rendered usePathname() output", async () => {
     const res = await fetch(`${_baseUrl}${NAV_ROUTE}`);
     const html = await res.text();
 
@@ -246,22 +259,18 @@ describe("__VINEXT_RSC_NAV__: nav context embedded for hydration snapshot consis
     // a mismatch.
     expect(html).toContain(`<span id="nav-pathname">${NAV_ROUTE}</span>`);
 
-    const match = html.match(/self\.__VINEXT_RSC_NAV__=(\{[^<]+\})/);
-    expect(match).toBeTruthy();
-    const nav = JSON.parse(match![1]);
+    const { nav } = extractRscBootstrap(html);
 
     expect(nav.pathname).toBe(NAV_ROUTE);
   });
 
   // ── 3. searchParams are correct (no query string) ─────────────────────────
 
-  it("__VINEXT_RSC_NAV__ searchParams is empty array when no query string", async () => {
+  it("navigation runtime searchParams is empty array when no query string", async () => {
     const res = await fetch(`${_baseUrl}${NAV_ROUTE}`);
     const html = await res.text();
 
-    const match = html.match(/self\.__VINEXT_RSC_NAV__=(\{[^<]+\})/);
-    expect(match).toBeTruthy();
-    const nav = JSON.parse(match![1]);
+    const { nav } = extractRscBootstrap(html);
 
     // searchParams is serialised as [...urlSearchParams.entries()] — an array of
     // [key, value] pairs — to preserve duplicate keys (e.g. ?tag=a&tag=b).
@@ -292,13 +301,11 @@ describe("__VINEXT_RSC_NAV__: nav context embedded for hydration snapshot consis
   //   - getServerSnapshot returns: "hello"
   //   → React sees "hello" = "hello" → no mismatch
 
-  it("__VINEXT_RSC_NAV__ searchParams carries query params from request URL", async () => {
+  it("navigation runtime searchParams carries query params from request URL", async () => {
     const res = await fetch(`${_baseUrl}${NAV_ROUTE}?q=hello&page=3`);
     const html = await res.text();
 
-    const match = html.match(/self\.__VINEXT_RSC_NAV__=(\{[^<]+\})/);
-    expect(match).toBeTruthy();
-    const nav = JSON.parse(match![1]);
+    const { nav } = extractRscBootstrap(html);
 
     // Serialised as array of [key, value] pairs to preserve duplicates.
     expect(nav.searchParams).toEqual([
@@ -307,7 +314,7 @@ describe("__VINEXT_RSC_NAV__: nav context embedded for hydration snapshot consis
     ]);
   });
 
-  it("__VINEXT_RSC_NAV__ searchParams agrees with SSR-rendered useSearchParams() output", async () => {
+  it("navigation runtime searchParams agrees with SSR-rendered useSearchParams() output", async () => {
     const res = await fetch(`${_baseUrl}${NAV_ROUTE}?q=hello&page=3`);
     const html = await res.text();
 
@@ -316,9 +323,7 @@ describe("__VINEXT_RSC_NAV__: nav context embedded for hydration snapshot consis
     expect(html).toContain('<span id="nav-search-page">3</span>');
 
     // Embedded payload must match
-    const match = html.match(/self\.__VINEXT_RSC_NAV__=(\{[^<]+\})/);
-    expect(match).toBeTruthy();
-    const nav = JSON.parse(match![1]);
+    const { nav } = extractRscBootstrap(html);
 
     // new URLSearchParams(nav.searchParams) reconstructs the same params
     const sp = new URLSearchParams(nav.searchParams);
@@ -342,7 +347,7 @@ describe("__VINEXT_RSC_NAV__: nav context embedded for hydration snapshot consis
 
   // ── 5. Special characters in searchParams are safely serialised ───────────
 
-  it("__VINEXT_RSC_NAV__ searchParams handles special characters without XSS", async () => {
+  it("navigation runtime searchParams handles special characters without XSS", async () => {
     // Ensure the JSON serialisation (safeJsonStringify) encodes characters
     // that could break out of a <script> tag if embedded raw.
     // The server uses safeJsonStringify which encodes < > & / to unicode escapes.
@@ -357,9 +362,7 @@ describe("__VINEXT_RSC_NAV__: nav context embedded for hydration snapshot consis
     expect(html).not.toContain(`"q":"${specialQ}"`);
 
     // But when we parse the embedded JSON, the value round-trips correctly.
-    const match = html.match(/self\.__VINEXT_RSC_NAV__=(\{[^<]+\})/);
-    expect(match).toBeTruthy();
-    const nav = JSON.parse(match![1]);
+    const { nav } = extractRscBootstrap(html);
     const sp = new URLSearchParams(nav.searchParams);
     expect(sp.get("q")).toBe(specialQ);
   });
@@ -372,31 +375,27 @@ describe("__VINEXT_RSC_NAV__: nav context embedded for hydration snapshot consis
   // params: to setNavigationContext(), so useParams() returns the right value
   // during client hydration.
 
-  it("__VINEXT_RSC_PARAMS__ contains dynamic segment value for [id] route", async () => {
+  it("navigation runtime params contains dynamic segment value for [id] route", async () => {
     const res = await fetch(`${_baseUrl}${NAV_ROUTE}/hello`);
     expect(res.status).toBe(200);
     const html = await res.text();
 
-    const match = html.match(/self\.__VINEXT_RSC_PARAMS__=(\{[^<]*\})/);
-    expect(match, "__VINEXT_RSC_PARAMS__ script tag not found").toBeTruthy();
-    const params = JSON.parse(match![1]);
+    const { params } = extractRscBootstrap(html);
 
     expect(params.id).toBe("hello");
   });
 
-  it("__VINEXT_RSC_NAV__ pathname is correct for dynamic segment route", async () => {
+  it("navigation runtime pathname is correct for dynamic segment route", async () => {
     const dynamicPath = `${NAV_ROUTE}/hello`;
     const res = await fetch(`${_baseUrl}${dynamicPath}`);
     const html = await res.text();
 
-    const match = html.match(/self\.__VINEXT_RSC_NAV__=(\{[^<]+\})/);
-    expect(match).toBeTruthy();
-    const nav = JSON.parse(match![1]);
+    const { nav } = extractRscBootstrap(html);
 
     expect(nav.pathname).toBe(dynamicPath);
   });
 
-  it("__VINEXT_RSC_NAV__ pathname agrees with SSR-rendered usePathname() for dynamic route", async () => {
+  it("navigation runtime pathname agrees with SSR-rendered usePathname() for dynamic route", async () => {
     const dynamicPath = `${NAV_ROUTE}/hello`;
     const res = await fetch(`${_baseUrl}${dynamicPath}`);
     const html = await res.text();
@@ -405,9 +404,7 @@ describe("__VINEXT_RSC_NAV__: nav context embedded for hydration snapshot consis
     // Its usePathname() output must match __VINEXT_RSC_NAV__.pathname.
     expect(html).toContain(`<span id="nav-pathname">${dynamicPath}</span>`);
 
-    const match = html.match(/self\.__VINEXT_RSC_NAV__=(\{[^<]+\})/);
-    expect(match).toBeTruthy();
-    const nav = JSON.parse(match![1]);
+    const { nav } = extractRscBootstrap(html);
     expect(nav.pathname).toBe(dynamicPath);
   });
 
@@ -419,22 +416,17 @@ describe("__VINEXT_RSC_NAV__: nav context embedded for hydration snapshot consis
   // If they were injected into the body stream they could arrive after
   // hydrateRoot() is called, making the hydration snapshot stale.
 
-  it("__VINEXT_RSC_NAV__ and __VINEXT_RSC_PARAMS__ are injected before </head>", async () => {
+  it("navigation runtime nav and params are injected before </head>", async () => {
     const res = await fetch(`${_baseUrl}${NAV_ROUTE}?q=timing`);
     const html = await res.text();
 
     const headEnd = html.indexOf("</head>");
     expect(headEnd).toBeGreaterThan(-1);
 
-    const navIdx = html.indexOf("__VINEXT_RSC_NAV__");
-    const paramsIdx = html.indexOf("__VINEXT_RSC_PARAMS__");
+    const bootstrapIdx = html.indexOf(RSC_BOOTSTRAP_PREFIX);
+    expect(bootstrapIdx).toBeGreaterThan(-1);
 
-    expect(navIdx).toBeGreaterThan(-1);
-    expect(paramsIdx).toBeGreaterThan(-1);
-
-    // Both script tags must appear before </head>
-    expect(navIdx).toBeLessThan(headEnd);
-    expect(paramsIdx).toBeLessThan(headEnd);
+    expect(bootstrapIdx).toBeLessThan(headEnd);
   });
 
   // ── 8. pathname uses the clean path, not the raw URL ─────────────────────
@@ -443,13 +435,11 @@ describe("__VINEXT_RSC_NAV__: nav context embedded for hydration snapshot consis
   // the trailing slash normalised). This must be the value embedded in
   // __VINEXT_RSC_NAV__, not the raw URL including query string.
 
-  it("__VINEXT_RSC_NAV__ pathname does not include query string", async () => {
+  it("navigation runtime pathname does not include query string", async () => {
     const res = await fetch(`${_baseUrl}${NAV_ROUTE}?q=shouldnotbehere`);
     const html = await res.text();
 
-    const match = html.match(/self\.__VINEXT_RSC_NAV__=(\{[^<]+\})/);
-    expect(match).toBeTruthy();
-    const nav = JSON.parse(match![1]);
+    const { nav } = extractRscBootstrap(html);
 
     // pathname must be just the path, not "…?q=shouldnotbehere"
     expect(nav.pathname).not.toContain("?");

--- a/tests/nextjs-compat/use-client-page-pathname.test.ts
+++ b/tests/nextjs-compat/use-client-page-pathname.test.ts
@@ -26,6 +26,25 @@ let _server: ViteDevServer;
 let _baseUrl: string;
 
 const ROUTE = "/use-client-page-pathname";
+const RSC_BOOTSTRAP_PREFIX =
+  'Object.assign(((self[Symbol.for("vinext.navigationRuntime")]??={bootstrap:{routeManifest:null},functions:{}}).bootstrap.rsc??={rsc:[]}),{params:';
+
+function extractRscBootstrap(html: string): {
+  nav: { pathname: string; searchParams: [string, string][] };
+  params: Record<string, string | string[]>;
+} {
+  const start = html.indexOf(RSC_BOOTSTRAP_PREFIX);
+  expect(start, "navigation runtime RSC bootstrap script not found").toBeGreaterThan(-1);
+  const paramsStart = start + RSC_BOOTSTRAP_PREFIX.length;
+  const navSeparator = html.indexOf(",nav:", paramsStart);
+  expect(navSeparator, "navigation runtime nav payload not found").toBeGreaterThan(-1);
+  const end = html.indexOf("})</script>", navSeparator);
+  expect(end, "navigation runtime RSC bootstrap script was not closed").toBeGreaterThan(-1);
+  return {
+    params: JSON.parse(html.slice(paramsStart, navSeparator)),
+    nav: JSON.parse(html.slice(navSeparator + ",nav:".length, end)),
+  };
+}
 
 beforeAll(async () => {
   ({ server: _server, baseUrl: _baseUrl } = await startFixtureServer(APP_FIXTURE_DIR, {
@@ -54,13 +73,11 @@ describe('"use client" page component: usePathname() SSR (issue #688)', () => {
     expect(html).toContain(`<span id="client-page-pathname">${ROUTE}</span>`);
   });
 
-  it("__VINEXT_RSC_NAV__ pathname matches SSR-rendered usePathname()", async () => {
+  it("navigation runtime pathname matches SSR-rendered usePathname()", async () => {
     const res = await fetch(`${_baseUrl}${ROUTE}`);
     const html = await res.text();
 
-    const match = html.match(/self\.__VINEXT_RSC_NAV__=(\{[^<]+\})/);
-    expect(match, "__VINEXT_RSC_NAV__ script tag not found").toBeTruthy();
-    const nav = JSON.parse(match![1]);
+    const { nav } = extractRscBootstrap(html);
 
     expect(nav.pathname).toBe(ROUTE);
   });
@@ -73,13 +90,11 @@ describe('"use client" page component: usePathname() SSR (issue #688)', () => {
     expect(html).toContain('<span id="client-page-search-string">q=hello&amp;page=2</span>');
   });
 
-  it("__VINEXT_RSC_NAV__ searchParams matches query string", async () => {
+  it("navigation runtime searchParams matches query string", async () => {
     const res = await fetch(`${_baseUrl}${ROUTE}?q=test`);
     const html = await res.text();
 
-    const match = html.match(/self\.__VINEXT_RSC_NAV__=(\{[^<]+\})/);
-    expect(match).toBeTruthy();
-    const nav = JSON.parse(match![1]);
+    const { nav } = extractRscBootstrap(html);
     const sp = new URLSearchParams(nav.searchParams);
 
     expect(sp.get("q")).toBe("test");
@@ -95,18 +110,12 @@ describe('"use client" page component: usePathname() SSR (issue #688)', () => {
 
     const html = await res.text();
 
+    expect(html).toContain(`<script nonce="vinext-test-nonce">${RSC_BOOTSTRAP_PREFIX}`);
     expect(html).toContain(
-      '<script nonce="vinext-test-nonce">self.__VINEXT_RSC_PARAMS__={}</script>',
+      '<script nonce="vinext-test-nonce">((self[Symbol.for("vinext.navigationRuntime")]',
     );
-    expect(html).toContain(
-      `<script nonce="vinext-test-nonce">self.__VINEXT_RSC_NAV__={"pathname":"${ROUTE}","searchParams":[["csp-nonce","1"]]}</script>`,
-    );
-    expect(html).toContain(
-      '<script nonce="vinext-test-nonce">self.__VINEXT_RSC_CHUNKS__=self.__VINEXT_RSC_CHUNKS__||[];self.__VINEXT_RSC_CHUNKS__.push(',
-    );
-    expect(html).toContain(
-      '<script nonce="vinext-test-nonce">self.__VINEXT_RSC_DONE__=true</script>',
-    );
+    expect(html).toContain(".rsc.push(");
+    expect(html).toContain(".done=true");
     expect(html).toMatch(/<link rel="modulepreload" nonce="vinext-test-nonce" href="[^"]+"/);
 
     const scriptTags = [...html.matchAll(/<script\b[^>]*>/g)].map((match) => match[0]);
@@ -134,7 +143,7 @@ describe('"use client" page component: usePathname() SSR (issue #688)', () => {
     });
     const html = await res.text();
 
-    expect(html).toContain('<script nonce="request-header">self.__VINEXT_RSC_PARAMS__={}</script>');
+    expect(html).toContain(`<script nonce="request-header">${RSC_BOOTSTRAP_PREFIX}`);
   });
 
   it("returns 500 when the nonce contains HTML escape characters", async () => {
@@ -168,24 +177,20 @@ describe('"use client" dynamic page: usePathname() + useParams() SSR', () => {
     expect(html).toContain('<span id="client-page-dynamic-slug">my-slug</span>');
   });
 
-  it("__VINEXT_RSC_PARAMS__ contains slug for dynamic route", async () => {
+  it("navigation runtime params contains slug for dynamic route", async () => {
     const res = await fetch(`${_baseUrl}${dynamicPath}`);
     const html = await res.text();
 
-    const match = html.match(/self\.__VINEXT_RSC_PARAMS__=(\{[^<]*\})/);
-    expect(match, "__VINEXT_RSC_PARAMS__ script tag not found").toBeTruthy();
-    const params = JSON.parse(match![1]);
+    const { params } = extractRscBootstrap(html);
 
     expect(params.slug).toBe("my-slug");
   });
 
-  it("__VINEXT_RSC_NAV__ pathname is correct for dynamic route", async () => {
+  it("navigation runtime pathname is correct for dynamic route", async () => {
     const res = await fetch(`${_baseUrl}${dynamicPath}`);
     const html = await res.text();
 
-    const match = html.match(/self\.__VINEXT_RSC_NAV__=(\{[^<]+\})/);
-    expect(match).toBeTruthy();
-    const nav = JSON.parse(match![1]);
+    const { nav } = extractRscBootstrap(html);
 
     expect(nav.pathname).toBe(dynamicPath);
   });

--- a/tests/prefetch-cache.test.ts
+++ b/tests/prefetch-cache.test.ts
@@ -264,7 +264,15 @@ describe("prefetch cache eviction", () => {
     });
     const navigate = vi.fn();
     (globalThis as any).fetch = fetch;
-    (globalThis as any).window.__VINEXT_RSC_NAVIGATE__ = navigate;
+    (globalThis as any).window[Symbol.for("vinext.navigationRuntime")] = {
+      bootstrap: {
+        routeManifest: null,
+        rsc: undefined,
+      },
+      functions: {
+        navigate,
+      },
+    };
 
     appRouterInstance.prefetch("/dashboard");
     await waitForPrefetchSetup(() => fetch.mock.calls.length > 0);

--- a/tests/prerender.test.ts
+++ b/tests/prerender.test.ts
@@ -149,6 +149,17 @@ describe("extractRscPayloadFromPrerenderedHtml", () => {
     expect(() => extractRscPayloadFromPrerenderedHtml(html)).toThrow(/missing RSC done marker/);
   });
 
+  it("ignores non-chunk runtime scripts that start with the bootstrap expression", () => {
+    const html =
+      "<html><body>" +
+      `<script>${RSC_RUNTIME_BOOTSTRAP_EXPRESSION}.metadata={}</script>` +
+      runtimeRscChunkScript("0:[]\n") +
+      runtimeRscDoneScript() +
+      "</body></html>";
+
+    expect(decodeExtractedPayload(html)).toBe("0:[]\n");
+  });
+
   it("rejects chunk scripts with trailing code after the payload push", () => {
     const html =
       "<html><body>" +

--- a/tests/prerender.test.ts
+++ b/tests/prerender.test.ts
@@ -63,6 +63,28 @@ function closeServer(server: Server): Promise<void> {
   });
 }
 
+const RSC_RUNTIME_BOOTSTRAP_EXPRESSION =
+  '((self[Symbol.for("vinext.navigationRuntime")]??={bootstrap:{routeManifest:null},functions:{}}).bootstrap.rsc??={rsc:[]})';
+
+function runtimeRscChunkScript(chunk: string | [3, string]): string {
+  return `<script>${RSC_RUNTIME_BOOTSTRAP_EXPRESSION}.rsc.push(${safeJsonStringify(chunk)})</script>`;
+}
+
+function runtimeRscDoneScript(): string {
+  return `<script>${RSC_RUNTIME_BOOTSTRAP_EXPRESSION}.done=true</script>`;
+}
+
+function legacyRscChunkScript(chunk: string | [3, string]): string {
+  return (
+    "<script>self.__VINEXT_RSC_CHUNKS__=self.__VINEXT_RSC_CHUNKS__||[];" +
+    `self.__VINEXT_RSC_CHUNKS__.push(${safeJsonStringify(chunk)})</script>`
+  );
+}
+
+function legacyRscDoneScript(): string {
+  return "<script>self.__VINEXT_RSC_DONE__=true</script>";
+}
+
 // ─── App Router RSC payload extraction ───────────────────────────────────────
 
 describe("extractRscPayloadFromPrerenderedHtml", () => {
@@ -79,14 +101,19 @@ describe("extractRscPayloadFromPrerenderedHtml", () => {
     ];
     const html =
       "<html><body>" +
-      chunks
-        .map(
-          (chunk) =>
-            "<script>self.__VINEXT_RSC_CHUNKS__=self.__VINEXT_RSC_CHUNKS__||[];" +
-            `self.__VINEXT_RSC_CHUNKS__.push(${safeJsonStringify(chunk)})</script>`,
-        )
-        .join("") +
-      "<script>self.__VINEXT_RSC_DONE__=true</script>" +
+      chunks.map((chunk) => runtimeRscChunkScript(chunk)).join("") +
+      runtimeRscDoneScript() +
+      "</body></html>";
+
+    expect(decodeExtractedPayload(html)).toBe(chunks.join(""));
+  });
+
+  it("keeps parsing legacy streamed RSC chunk scripts", () => {
+    const chunks = ['0:D{"name":"layout"}\n', '1:["$","div",null,{"children":"legacy"}]\n'];
+    const html =
+      "<html><body>" +
+      chunks.map((chunk) => legacyRscChunkScript(chunk)).join("") +
+      legacyRscDoneScript() +
       "</body></html>";
 
     expect(decodeExtractedPayload(html)).toBe(chunks.join(""));
@@ -97,9 +124,9 @@ describe("extractRscPayloadFromPrerenderedHtml", () => {
     // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/binary/rsc-binary.test.ts
     const html =
       "<html><body>" +
-      `<script>self.__VINEXT_RSC_CHUNKS__=self.__VINEXT_RSC_CHUNKS__||[];self.__VINEXT_RSC_CHUNKS__.push(${safeJsonStringify("0:text\n")})</script>` +
-      '<script>self.__VINEXT_RSC_CHUNKS__=self.__VINEXT_RSC_CHUNKS__||[];self.__VINEXT_RSC_CHUNKS__.push([3,"/wABAgM="])</script>' +
-      "<script>self.__VINEXT_RSC_DONE__=true</script>" +
+      runtimeRscChunkScript("0:text\n") +
+      runtimeRscChunkScript([3, "/wABAgM="]) +
+      runtimeRscDoneScript() +
       "</body></html>";
 
     const payload = extractRscPayloadFromPrerenderedHtml(html);
@@ -110,28 +137,23 @@ describe("extractRscPayloadFromPrerenderedHtml", () => {
   });
 
   it("throws when the done marker is missing", () => {
-    const html =
-      "<html><body>" +
-      `<script>self.__VINEXT_RSC_CHUNKS__=self.__VINEXT_RSC_CHUNKS__||[];self.__VINEXT_RSC_CHUNKS__.push(${safeJsonStringify("0:[]\n")})</script>` +
-      "</body></html>";
+    const html = "<html><body>" + runtimeRscChunkScript("0:[]\n") + "</body></html>";
 
-    expect(() => extractRscPayloadFromPrerenderedHtml(html)).toThrow(/missing __VINEXT_RSC_DONE__/);
+    expect(() => extractRscPayloadFromPrerenderedHtml(html)).toThrow(/missing RSC done marker/);
   });
 
   it("does not treat marker-looking RSC payload text as the done control script", () => {
     const html =
-      "<html><body>" +
-      `<script>self.__VINEXT_RSC_CHUNKS__=self.__VINEXT_RSC_CHUNKS__||[];self.__VINEXT_RSC_CHUNKS__.push(${safeJsonStringify('0:["__VINEXT_RSC_DONE__=true"]\n')})</script>` +
-      "</body></html>";
+      "<html><body>" + runtimeRscChunkScript('0:["__VINEXT_RSC_DONE__=true"]\n') + "</body></html>";
 
-    expect(() => extractRscPayloadFromPrerenderedHtml(html)).toThrow(/missing __VINEXT_RSC_DONE__/);
+    expect(() => extractRscPayloadFromPrerenderedHtml(html)).toThrow(/missing RSC done marker/);
   });
 
   it("rejects chunk scripts with trailing code after the payload push", () => {
     const html =
       "<html><body>" +
-      `<script>self.__VINEXT_RSC_CHUNKS__=self.__VINEXT_RSC_CHUNKS__||[];self.__VINEXT_RSC_CHUNKS__.push(${safeJsonStringify("0:[]\n")})alert(1)</script>` +
-      "<script>self.__VINEXT_RSC_DONE__=true</script>" +
+      `<script>${RSC_RUNTIME_BOOTSTRAP_EXPRESSION}.rsc.push(${safeJsonStringify("0:[]\n")})alert(1)</script>` +
+      runtimeRscDoneScript() +
       "</body></html>";
 
     // JSON.parse rejects the slice (which includes the `)` and `alert(1` after
@@ -145,8 +167,8 @@ describe("extractRscPayloadFromPrerenderedHtml", () => {
   it("rejects chunk scripts with invalid JSON", () => {
     const html =
       "<html><body>" +
-      '<script>self.__VINEXT_RSC_CHUNKS__=self.__VINEXT_RSC_CHUNKS__||[];self.__VINEXT_RSC_CHUNKS__.push("\\uZZZZ")</script>' +
-      "<script>self.__VINEXT_RSC_DONE__=true</script>" +
+      `<script>${RSC_RUNTIME_BOOTSTRAP_EXPRESSION}.rsc.push("\\uZZZZ")</script>` +
+      runtimeRscDoneScript() +
       "</body></html>";
 
     expect(() => extractRscPayloadFromPrerenderedHtml(html)).toThrow(
@@ -164,7 +186,7 @@ describe("extractRscPayloadFromPrerenderedHtml", () => {
   it("throws when only the done marker is present without any chunks", () => {
     // Half-emitted embed (done marker but no chunks) is a real bug — partial
     // emission shouldn't fall back silently.
-    const html = "<html><body><script>self.__VINEXT_RSC_DONE__=true</script></body></html>";
+    const html = `<html><body>${runtimeRscDoneScript()}</body></html>`;
 
     expect(() => extractRscPayloadFromPrerenderedHtml(html)).toThrow(
       "[vinext] Malformed prerender RSC embed: done marker present without chunk scripts",
@@ -203,8 +225,8 @@ describe("prerenderApp — RSC extraction", () => {
       res.setHeader("content-type", "text/html");
       res.end(
         "<html><body>" +
-          `<script>self.__VINEXT_RSC_CHUNKS__=self.__VINEXT_RSC_CHUNKS__||[];self.__VINEXT_RSC_CHUNKS__.push(${safeJsonStringify(rscPayload)})</script>` +
-          "<script>self.__VINEXT_RSC_DONE__=true</script>" +
+          runtimeRscChunkScript(rscPayload) +
+          runtimeRscDoneScript() +
           "</body></html>",
       );
     });

--- a/tests/rsc-streaming.test.ts
+++ b/tests/rsc-streaming.test.ts
@@ -7,7 +7,7 @@
  *
  * 1. RSC scripts are interleaved between HTML flush cycles
  * 2. No RSC scripts are injected mid-HTML-chunk (DOM corruption case)
- * 3. The __VINEXT_RSC_DONE__ signal appears after all content
+ * 3. The navigation runtime RSC done signal appears after all content
  * 4. Head injection happens correctly
  * 5. Multiple HTML chunks in the same macrotask are batched correctly
  */
@@ -101,6 +101,10 @@ async function collectStreamChunks(stream: ReadableStream<Uint8Array>): Promise<
   return chunks;
 }
 
+const RSC_RUNTIME_KEY = 'Symbol.for("vinext.navigationRuntime")';
+const RSC_RUNTIME_PUSH = ".rsc.push(";
+const RSC_RUNTIME_DONE = ".done=true";
+
 // ─── Tests ──────────────────────────────────────────────────────────────────
 
 describe("Tick-buffered RSC streaming (behavioral)", () => {
@@ -130,9 +134,9 @@ describe("Tick-buffered RSC streaming (behavioral)", () => {
     const output = await collectStream(htmlStream.pipeThrough(transform));
 
     // RSC scripts should be present in output
-    expect(output).toContain("__VINEXT_RSC_CHUNKS__");
+    expect(output).toContain(RSC_RUNTIME_PUSH);
     // Done signal should be present
-    expect(output).toContain("__VINEXT_RSC_DONE__=true");
+    expect(output).toContain(RSC_RUNTIME_DONE);
     // HTML content should be intact
     expect(output).toContain("<div id='root'>");
     expect(output).toContain("<div>Suspense resolved</div>");
@@ -151,10 +155,9 @@ describe("Tick-buffered RSC streaming (behavioral)", () => {
     const transform = createTickBufferedTransform(rscEmbed);
     const output = await collectStream(htmlStream.pipeThrough(transform));
 
-    expect(output).toContain('<script nonce="vinext-test-nonce">self.__VINEXT_RSC_CHUNKS__=');
-    expect(output).toContain(
-      '<script nonce="vinext-test-nonce">self.__VINEXT_RSC_DONE__=true</script>',
-    );
+    expect(output).toContain(`<script nonce="vinext-test-nonce">((self[${RSC_RUNTIME_KEY}]`);
+    expect(output).toContain(`<script nonce="vinext-test-nonce">((self[${RSC_RUNTIME_KEY}]`);
+    expect(output).toContain(RSC_RUNTIME_DONE);
   });
 
   it("does not inject scripts mid-HTML-chunk (DOM corruption prevention)", async () => {
@@ -188,7 +191,7 @@ describe("Tick-buffered RSC streaming (behavioral)", () => {
     expect(output).toContain("<svg><linearGradient id='g1'></linearGradient></svg>");
 
     // RSC scripts should still be present (after the HTML, not mid-element)
-    expect(output).toContain("__VINEXT_RSC_CHUNKS__");
+    expect(output).toContain(RSC_RUNTIME_PUSH);
 
     // Verify no <script> tag appears between the split HTML fragments
     // by checking that the linearGradient element is contiguous
@@ -221,7 +224,7 @@ describe("Tick-buffered RSC streaming (behavioral)", () => {
 
     // RSC scripts should appear AFTER all the HTML chunks
     const htmlEnd = output.indexOf("<div>chunk2</div>") + "<div>chunk2</div>".length;
-    const scriptStart = output.indexOf("__VINEXT_RSC_CHUNKS__");
+    const scriptStart = output.indexOf(RSC_RUNTIME_PUSH);
     expect(scriptStart).toBeGreaterThan(htmlEnd);
   });
 
@@ -272,14 +275,14 @@ describe("Tick-buffered RSC streaming (behavioral)", () => {
     expect(output).toContain("<div>Boundary 2</div>");
 
     // RSC scripts should be present for all chunks
-    expect(output).toContain("__VINEXT_RSC_CHUNKS__");
+    expect(output).toContain(RSC_RUNTIME_PUSH);
 
     // Done signal at the end
-    expect(output).toContain("__VINEXT_RSC_DONE__=true");
+    expect(output).toContain(RSC_RUNTIME_DONE);
 
     // The done signal should come AFTER all HTML content
     const lastHtmlPos = output.indexOf("</html>");
-    const donePos = output.indexOf("__VINEXT_RSC_DONE__=true");
+    const donePos = output.indexOf(RSC_RUNTIME_DONE);
     expect(donePos).toBeGreaterThan(lastHtmlPos);
   });
 
@@ -412,7 +415,7 @@ describe("Tick-buffered RSC streaming (behavioral)", () => {
 
     const shellStylePos = output.indexOf('data-styled="shell"');
     const trailingStylePos = output.indexOf('data-styled="trailing"');
-    const donePos = output.indexOf("__VINEXT_RSC_DONE__=true");
+    const donePos = output.indexOf(RSC_RUNTIME_DONE);
     expect(shellStylePos).toBeGreaterThan(-1);
     expect(trailingStylePos).toBeGreaterThan(shellStylePos);
     expect(trailingStylePos).toBeLessThan(donePos);
@@ -476,7 +479,7 @@ describe("Tick-buffered RSC streaming (behavioral)", () => {
     expect(output).toContain('name="fallback"');
   });
 
-  it("emits __VINEXT_RSC_DONE__ signal even with empty RSC stream", async () => {
+  it("emits navigation runtime RSC done signal even with empty RSC stream", async () => {
     const rsc = createMockRscStream();
     rsc.close(); // Close immediately — no RSC chunks
 
@@ -489,9 +492,9 @@ describe("Tick-buffered RSC streaming (behavioral)", () => {
     const output = await collectStream(htmlStream.pipeThrough(transform));
 
     // Done signal must always be present so the browser knows streaming is complete
-    expect(output).toContain("__VINEXT_RSC_DONE__=true");
+    expect(output).toContain(RSC_RUNTIME_DONE);
     // No RSC chunks should be present
-    expect(output).not.toContain("__VINEXT_RSC_CHUNKS__");
+    expect(output).not.toContain(RSC_RUNTIME_PUSH);
   });
 
   it("handles RSC chunks arriving after HTML stream closes", async () => {
@@ -516,9 +519,9 @@ describe("Tick-buffered RSC streaming (behavioral)", () => {
     // HTML should be present
     expect(output).toContain("Shell");
     // The late RSC chunk should still be emitted (finalize waits for RSC stream)
-    expect(output).toContain("__VINEXT_RSC_CHUNKS__");
+    expect(output).toContain(RSC_RUNTIME_PUSH);
     // Done signal must be present
-    expect(output).toContain("__VINEXT_RSC_DONE__=true");
+    expect(output).toContain(RSC_RUNTIME_DONE);
   });
 
   it("preserves RSC chunk ordering", async () => {
@@ -540,7 +543,7 @@ describe("Tick-buffered RSC streaming (behavioral)", () => {
     const output = await collectStream(htmlStream.pipeThrough(transform));
 
     // Extract RSC script contents to verify ordering
-    const scriptRegex = /__VINEXT_RSC_CHUNKS__\.push\(([^)]+)\)/g;
+    const scriptRegex = /\.rsc\.push\(([^)]+)\)/g;
     const matches: string[] = [];
     let match;
     while ((match = scriptRegex.exec(output)) !== null) {
@@ -599,17 +602,16 @@ describe("Tick-buffered RSC streaming (behavioral)", () => {
     }
 
     // All RSC chunks should be present (initial + 5 boundaries = 6 total)
-    // Count .push() calls, not raw occurrences of __VINEXT_RSC_CHUNKS__
-    // (each script tag contains __VINEXT_RSC_CHUNKS__ multiple times in the init pattern)
-    const scriptCount = (output.match(/__VINEXT_RSC_CHUNKS__\.push\(/g) || []).length;
+    // Count RSC chunk push calls, not runtime initialization occurrences.
+    const scriptCount = (output.match(/\.rsc\.push\(/g) || []).length;
     expect(scriptCount).toBe(6);
 
     // Done signal at the end
-    expect(output).toContain("__VINEXT_RSC_DONE__=true");
+    expect(output).toContain(RSC_RUNTIME_DONE);
 
     // Done signal should be the last script
-    const lastChunksPos = output.lastIndexOf("__VINEXT_RSC_CHUNKS__");
-    const donePos = output.indexOf("__VINEXT_RSC_DONE__");
+    const lastChunksPos = output.lastIndexOf(RSC_RUNTIME_PUSH);
+    const donePos = output.indexOf(RSC_RUNTIME_DONE);
     expect(donePos).toBeGreaterThan(lastChunksPos);
   });
 
@@ -631,7 +633,7 @@ describe("Tick-buffered RSC streaming (behavioral)", () => {
     const output = await collectStream(htmlStream.pipeThrough(transform));
 
     // The output should contain the RSC chunk
-    expect(output).toContain("__VINEXT_RSC_CHUNKS__");
+    expect(output).toContain(RSC_RUNTIME_PUSH);
 
     // RSC data is now stored as a JSON text string. safeJsonStringify escapes
     // <, >, and & characters so that </script> in the RSC data cannot break

--- a/tests/safe-json.test.ts
+++ b/tests/safe-json.test.ts
@@ -349,13 +349,16 @@ describe("safeJsonStringify", () => {
       expect(closeTags).toHaveLength(1);
     });
 
-    it("produces safe output for RSC embed data", () => {
+    it("produces safe output for navigation runtime RSC bootstrap data", () => {
       const embedData = {
         rsc: ["chunk with </script> in it", "<script>alert(1)</script>"],
         params: { id: "123" },
       };
 
-      const scriptContent = `<script>self.__VINEXT_RSC__=${safeJsonStringify(embedData)}</script>`;
+      const scriptContent =
+        `<script>self[Symbol.for("vinext.navigationRuntime")]={bootstrap:{routeManifest:null,rsc:` +
+        safeJsonStringify(embedData) +
+        "},functions:{}}</script>";
 
       // lgtm[js/bad-tag-filter] — counting tags to verify XSS protection, not filtering HTML
       const openTags = scriptContent.match(/<script>/g);

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -112,11 +112,19 @@ describe("next/navigation shim", () => {
         replaceState: () => {},
       },
       addEventListener: () => {},
-      __VINEXT_CLEAR_NAV_CACHES__: () => {
-        calls.push("clear");
-      },
-      __VINEXT_RSC_NAVIGATE__: async (_href: string, _depth: number, kind: string) => {
-        calls.push(`navigate:${kind}`);
+      [Symbol.for("vinext.navigationRuntime")]: {
+        bootstrap: {
+          routeManifest: null,
+          rsc: undefined,
+        },
+        functions: {
+          clearNavigationCaches: () => {
+            calls.push("clear");
+          },
+          navigate: async (_href: string, _depth: number, kind: string) => {
+            calls.push(`navigate:${kind}`);
+          },
+        },
       },
     };
     (globalThis as any).window = win;


### PR DESCRIPTION
## Overview

| Field | Detail |
| --- | --- |
| Goal | Quarantine snapshot topology fallback and type the browser navigation runtime contract. |
| Core change | Browser navigation topology now comes from the route manifest or explicit runtime proof, not from reused app snapshots. |
| Main boundary | Snapshots carry runtime proof only: visible slot content, mounted slots, and explicit interception payload proof. They do not decide route, root, layout, or slot topology. |
| Primary files | `navigation-planner.ts`, `app-browser-entry.ts`, `navigation-runtime.ts`, `app-ssr-stream.ts`, `app-browser-stream.ts`, `prerender.ts` |
| Expected impact | App Router browser navigation uses a single typed symbol-backed runtime seam and no longer preserves absent topology from stale snapshots. |

## Why

For App Router navigation to be correct, route topology must come from the manifest authority chain. A runtime snapshot can prove what is mounted or visible, but it cannot infer that omitted route-change topology means previous layout or slot topology is still valid. This PR follows that boundary and keeps first-hop interception working by resolving it from declared manifest interception rules instead of from snapshot topology.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| Navigation planner | Omitted topology is not proof of persistence. | Removes the snapshot topology fallback that produced preservation for route-change payloads without manifest topology. |
| Browser interception | First-hop intercepted navigation is route topology, not snapshot memory. | Resolves first-hop interception context from `segmentGraph.interceptions` only. |
| Runtime globals | The browser entry and shims need one typed runtime contract. | Moves navigation functions and bootstrap data behind `window[Symbol.for("vinext.navigationRuntime")]`. |
| RSC bootstrap | SSR chunk scripts and prerender extraction must share the same runtime shape. | Streams params/nav/chunks/done through the symbol-backed runtime and teaches prerender extraction that script shape. |

## What changed

| Surface | Before | After |
| --- | --- | --- |
| Route-change payload without topology | Could preserve previous layout or absent slot state from snapshot topology. | Commits supplied shell without absent-slot or previous-topology preservation. |
| `getCurrentInterceptionContext()` browser fallback | Snapshot/history state could seed interception context. | Removed. Only proven `previousNextUrl` or manifest-declared first-hop interception can set context. |
| Navigation globals | Informal `window.__VINEXT_*` slots acted as the seam. | Runtime contract is a single symbol-keyed object split into `bootstrap` and `functions`. |
| RSC bootstrap scripts | SSR emitted legacy globals for params/nav/chunks/done. | SSR emits symbol-runtime metadata, chunk, and done scripts. |
| Prerender RSC extraction | Parsed only legacy `__VINEXT_RSC_CHUNKS__` scripts. | Parses the symbol-runtime chunk shape and keeps legacy parsing for older embedded HTML compatibility. |

## Maintainer review path

<details>
<summary>Suggested order</summary>

1. `packages/vinext/src/server/navigation-planner.ts` for the topology authority change.
2. `packages/vinext/src/server/app-browser-entry.ts` and `packages/vinext/src/server/app-browser-interception-context.ts` for manifest-backed first-hop interception.
3. `packages/vinext/src/client/navigation-runtime.ts` for the typed symbol-backed runtime contract and runtime guards.
4. `packages/vinext/src/server/app-ssr-stream.ts`, `packages/vinext/src/server/app-browser-stream.ts`, and `packages/vinext/src/build/prerender.ts` for RSC bootstrap script production and extraction.
5. Tests in `tests/navigation-planner.test.ts`, `tests/app-browser-interception-context.test.ts`, `tests/navigation-runtime.test.ts`, and `tests/prerender.test.ts` for the contract coverage.

</details>

## Validation

<details>
<summary>Commands run</summary>

- `vp check`
- `vp test run tests/navigation-runtime.test.ts tests/prerender.test.ts`
- `vp test run tests/navigation-runtime.test.ts tests/app-browser-stream.test.ts tests/app-ssr-stream.test.ts tests/app-browser-interception-context.test.ts tests/app-browser-entry.test.ts tests/navigation-planner.test.ts tests/prerender.test.ts`
- `vp test run tests/rsc-streaming.test.ts tests/app-router.test.ts tests/nextjs-compat/use-client-page-pathname.test.ts tests/nextjs-compat/rsc-context-lazy-stream.test.ts tests/safe-json.test.ts tests/entry-templates.test.ts`
- `vp run vinext#build`
- `PLAYWRIGHT_PROJECT=app-router npx playwright test --project=app-router tests/e2e/app-router/advanced.spec.ts -g "Intercepting Routes"`
- Commit hook: checked-file formatting, lint/typecheck, and `knip`

Notes: `vp run vinext#build` still reports the expected unresolved virtual/private import warnings for build-time externals. The app-router intercepted-routes E2E slice passed 15/15 after the rebuild.

</details>

## Risk / compatibility

<details>
<summary>Runtime surfaces</summary>

- App Router navigation semantics change only where prior behavior depended on unproven snapshot topology fallback.
- First-hop intercepted navigation remains supported, but now only through manifest-declared interception rules.
- Legacy prerender chunk parsing remains intentionally supported so older embedded HTML shape is not silently treated as malformed.
- No production `as` or `any` assertions were added.
- Existing record validation is centralized in `utils/record.ts` and reused instead of adding another local object-record helper.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| Refs #726 | Original architecture issue for separating runtime proof from route topology authority. |

Bonk: please read issue #726 for the architectural big picture before reviewing this refactor.
