### PR TITLE
fix: enforce strict parameter isolation for root-params in prerendering and SSR

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -497,6 +497,7 @@ export default __createAppRscHandler({
     middlewareContext,
     mountedSlotsHeader,
     params,
+    rootParams,
     request,
     route,
     scriptNonce,
@@ -572,6 +573,7 @@ export default __createAppRscHandler({
       middlewareContext,
       mountedSlotsHeader,
       params,
+      rootParams,
       probeLayoutAt(li) {
         const LayoutComp = route.layouts[li]?.default;
         if (!LayoutComp) return null;

--- a/packages/vinext/src/entries/app-rsc-manifest.ts
+++ b/packages/vinext/src/entries/app-rsc-manifest.ts
@@ -222,37 +222,7 @@ function appendStaticParamSource(
   sourcesByPattern.set(pattern, sources);
 }
 
-function buildGenerateStaticParamsEntries(routes: AppRoute[], imports: ImportAllocator): string[] {
-  const sourcesByPattern = new Map<string, string[]>();
-
-  for (const route of routes) {
-    if (!route.isDynamic) continue;
-
-    for (const [index, layoutPath] of route.layouts.entries()) {
-      appendStaticParamSource(
-        sourcesByPattern,
-        createRoutePatternPrefix(route.routeSegments, route.layoutTreePositions[index] ?? 0)
-          ?.pattern ?? null,
-        `${imports.getImportVar(layoutPath)}?.generateStaticParams`,
-      );
-    }
-
-    if (route.pagePath) {
-      appendStaticParamSource(
-        sourcesByPattern,
-        route.pattern,
-        `${imports.getImportVar(route.pagePath)}?.generateStaticParams`,
-      );
-    }
-  }
-
-  return Array.from(sourcesByPattern.entries()).map(
-    ([pattern, sources]) =>
-      `  ${JSON.stringify(pattern)}: __createAppPrerenderStaticParamsResolver([${sources.join(", ")}]),`,
-  );
-}
-
-function buildRootParamNameEntries(routes: AppRoute[]): string[] {
+function buildRootParamNamesByPattern(routes: AppRoute[]): Map<string, string[]> {
   const namesByPattern = new Map<string, string[]>();
 
   function append(
@@ -281,6 +251,46 @@ function buildRootParamNameEntries(routes: AppRoute[]): string[] {
     }
   }
 
+  return namesByPattern;
+}
+
+function buildGenerateStaticParamsEntries(
+  routes: AppRoute[],
+  imports: ImportAllocator,
+  namesByPattern: Map<string, string[]>,
+): string[] {
+  const sourcesByPattern = new Map<string, string[]>();
+
+  for (const route of routes) {
+    if (!route.isDynamic) continue;
+
+    for (const [index, layoutPath] of route.layouts.entries()) {
+      appendStaticParamSource(
+        sourcesByPattern,
+        createRoutePatternPrefix(route.routeSegments, route.layoutTreePositions[index] ?? 0)
+          ?.pattern ?? null,
+        `${imports.getImportVar(layoutPath)}?.generateStaticParams`,
+      );
+    }
+
+    if (route.pagePath) {
+      appendStaticParamSource(
+        sourcesByPattern,
+        route.pattern,
+        `${imports.getImportVar(route.pagePath)}?.generateStaticParams`,
+      );
+    }
+  }
+
+  return Array.from(sourcesByPattern.entries()).map(([pattern, sources]) => {
+    const rootParamNames = namesByPattern.get(pattern) ?? [];
+    return `  ${JSON.stringify(pattern)}: __createAppPrerenderStaticParamsResolver([${sources.join(
+      ", ",
+    )}], ${JSON.stringify(rootParamNames)}),`;
+  });
+}
+
+function buildRootParamNameEntries(namesByPattern: Map<string, string[]>): string[] {
   return Array.from(namesByPattern.entries()).map(
     ([pattern, names]) => `  ${JSON.stringify(pattern)}: ${JSON.stringify(names)},`,
   );
@@ -318,12 +328,18 @@ export function buildAppRscManifestCode(
     imports.getImportVar(route.filePath);
   }
 
+  const namesByPattern = buildRootParamNamesByPattern(options.routes);
+
   return {
     imports: imports.imports,
     routeEntries,
     metaRouteEntries: createMetadataRouteEntriesSource(metadataRoutes, imports.importMap),
-    generateStaticParamsEntries: buildGenerateStaticParamsEntries(options.routes, imports),
-    rootParamNameEntries: buildRootParamNameEntries(options.routes),
+    generateStaticParamsEntries: buildGenerateStaticParamsEntries(
+      options.routes,
+      imports,
+      namesByPattern,
+    ),
+    rootParamNameEntries: buildRootParamNameEntries(namesByPattern),
     rootNotFoundVar,
     rootForbiddenVar,
     rootUnauthorizedVar,

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -6,6 +6,7 @@ import {
   _peekRequestScopedCacheLife,
   type CachedAppPageValue,
 } from "vinext/shims/cache";
+import type { RootParams } from "vinext/shims/root-params";
 import {
   consumeDynamicUsage,
   consumeInvalidDynamicUsageError,
@@ -189,6 +190,7 @@ type DispatchAppPageOptions<TRoute extends AppPageDispatchRoute> = {
   middlewareContext: AppPageMiddlewareContext;
   mountedSlotsHeader?: string | null;
   params: AppPageParams;
+  rootParams?: RootParams;
   probeLayoutAt: (layoutIndex: number) => unknown;
   probePage: () => unknown;
   expireSeconds?: number;
@@ -444,6 +446,7 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
               },
               {
                 basePath: options.basePath,
+                rootParams: options.rootParams,
                 ...(revalidatedRscCapture.sideStream
                   ? {
                       sideStream: revalidatedRscCapture.sideStream,
@@ -669,6 +672,7 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
     loadSsrHandler: options.loadSsrHandler,
     middlewareContext: options.middlewareContext,
     params: options.params,
+    rootParams: options.rootParams,
     peekRenderObservationState() {
       return {
         dynamicFetches: peekDynamicFetchObservations(),

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import type { ReactFormState } from "react-dom/client";
 import type { CachedAppPageValue } from "vinext/shims/cache";
+import type { RootParams } from "vinext/shims/root-params";
 import { runWithFetchDedupe } from "vinext/shims/fetch-cache";
 import { AppElementsWire, isAppElementsRecord, type AppOutgoingElements } from "./app-elements.js";
 import { hasDigest } from "./app-rsc-errors.js";
@@ -107,6 +108,7 @@ type RenderAppPageLifecycleOptions = {
   loadSsrHandler: () => Promise<AppPageSsrHandler>;
   middlewareContext: AppPageMiddlewareContext;
   params: Record<string, unknown>;
+  rootParams?: RootParams;
   peekRenderObservationState?: () => AppPageRenderObservationState;
   probeLayoutAt: (layoutIndex: number) => unknown;
   probePage: () => unknown;
@@ -505,6 +507,7 @@ export async function renderAppPageLifecycle(
         fontData,
         navigationContext: options.getNavigationContext(),
         basePath: options.basePath,
+        rootParams: options.rootParams,
         formState: options.formState ?? null,
         rscStream: rscForResponse,
         scriptNonce: options.scriptNonce,

--- a/packages/vinext/src/server/app-page-stream.ts
+++ b/packages/vinext/src/server/app-page-stream.ts
@@ -2,6 +2,7 @@ import type { AppPageFontPreload } from "./app-page-execution.js";
 import type { ReactFormState } from "react-dom/client";
 import { VINEXT_RSC_VARY_HEADER } from "./app-rsc-cache-busting.js";
 import { mergeMiddlewareResponseHeaders } from "./middleware-response-headers.js";
+import type { RootParams } from "vinext/shims/root-params";
 
 export type AppPageFontData = {
   links: string[];
@@ -24,6 +25,7 @@ export type AppPageSsrHandler = {
       formState?: ReactFormState | null;
       scriptNonce?: string;
       basePath?: string;
+      rootParams?: RootParams;
       sideStream?: ReadableStream<Uint8Array>;
       capturedRscDataRef?: { value: Promise<ArrayBuffer> | null };
       /** When true, wait for the full React tree before emitting bytes. */
@@ -39,6 +41,7 @@ type RenderAppPageHtmlStreamOptions = {
   rscStream: ReadableStream<Uint8Array>;
   scriptNonce?: string;
   basePath?: string;
+  rootParams?: RootParams;
   ssrHandler: AppPageSsrHandler;
   /** Pre-split side stream for fused embed+capture (#981). When set,
    *  handleSsr skips its internal tee and accumulates raw RSC bytes. */
@@ -101,6 +104,7 @@ export async function renderAppPageHtmlStream(
     formState: options.formState ?? null,
     scriptNonce: options.scriptNonce,
     basePath: options.basePath,
+    rootParams: options.rootParams,
     sideStream: options.sideStream,
     capturedRscDataRef: options.capturedRscDataRef,
     waitForAllReady: options.waitForAllReady,

--- a/packages/vinext/src/server/app-prerender-static-params.ts
+++ b/packages/vinext/src/server/app-prerender-static-params.ts
@@ -12,16 +12,31 @@ function isRootParams(value: unknown): value is RootParams {
 
 export function createAppPrerenderStaticParamsResolver(
   sources: readonly unknown[],
+  rootParamNames?: readonly string[],
 ): GenerateStaticParamsFunction | null {
   const generateStaticParamsFns = sources.filter(isGenerateStaticParamsFunction);
   if (generateStaticParamsFns.length === 0) return null;
+
+  const rootParamNamesSet = rootParamNames ? new Set(rootParamNames) : null;
+  const filterRootParams = (params: RootParams): RootParams => {
+    if (!rootParamNamesSet) return params;
+    const picked: RootParams = {};
+    for (const [key, value] of Object.entries(params)) {
+      if (rootParamNamesSet.has(key)) {
+        picked[key] = value;
+      }
+    }
+    return picked;
+  };
+
   if (generateStaticParamsFns.length === 1) {
     const single = generateStaticParamsFns[0];
     // Wrap the single source in the same non-array/non-object guards as the
     // multi-source composition path so the contract is uniform regardless of
     // how many sources were composed.
-    return async (input) =>
-      runWithRootParamsScope(input.params, async () => {
+    return async (input) => {
+      const picked = filterRootParams(input.params);
+      return runWithRootParamsScope(picked, async () => {
         const result = await single(input);
         if (!Array.isArray(result)) return [];
         for (const item of result) {
@@ -29,16 +44,19 @@ export function createAppPrerenderStaticParamsResolver(
         }
         return result;
       });
+    };
   }
 
   return async ({ params }) => {
-    let paramSets: RootParams[] = [params];
+    const picked = filterRootParams(params);
+    let paramSets: RootParams[] = [picked];
 
     for (const generateStaticParams of generateStaticParamsFns) {
       const nextParamSets: RootParams[] = [];
 
       for (const parentParams of paramSets) {
-        const result = await runWithRootParamsScope(parentParams, async () =>
+        const pickedParent = filterRootParams(parentParams);
+        const result = await runWithRootParamsScope(pickedParent, async () =>
           generateStaticParams({ params: parentParams }),
         );
         if (!Array.isArray(result)) return [];

--- a/packages/vinext/src/server/app-prerender-static-params.ts
+++ b/packages/vinext/src/server/app-prerender-static-params.ts
@@ -17,17 +17,8 @@ export function createAppPrerenderStaticParamsResolver(
   const generateStaticParamsFns = sources.filter(isGenerateStaticParamsFunction);
   if (generateStaticParamsFns.length === 0) return null;
 
-  const rootParamNamesSet = rootParamNames ? new Set(rootParamNames) : null;
-  const filterRootParams = (params: RootParams): RootParams => {
-    if (!rootParamNamesSet) return params;
-    const picked: RootParams = {};
-    for (const [key, value] of Object.entries(params)) {
-      if (rootParamNamesSet.has(key)) {
-        picked[key] = value;
-      }
-    }
-    return picked;
-  };
+  const filterRootParams = (params: RootParams): RootParams =>
+    pickRootParams(params, rootParamNames ?? []);
 
   if (generateStaticParamsFns.length === 1) {
     const single = generateStaticParamsFns[0];

--- a/packages/vinext/src/server/app-prerender-static-params.ts
+++ b/packages/vinext/src/server/app-prerender-static-params.ts
@@ -48,17 +48,18 @@ export function createAppPrerenderStaticParamsResolver(
   }
 
   return async ({ params }) => {
-    const picked = filterRootParams(params);
-    let paramSets: RootParams[] = [picked];
+    let paramSets: RootParams[] = [params];
 
     for (const generateStaticParams of generateStaticParamsFns) {
       const nextParamSets: RootParams[] = [];
 
       for (const parentParams of paramSets) {
-        const pickedParent = filterRootParams(parentParams);
-        const result = await runWithRootParamsScope(pickedParent, async () =>
+        const rootScope = filterRootParams(parentParams);
+
+        const result = await runWithRootParamsScope(rootScope, async () =>
           generateStaticParams({ params: parentParams }),
         );
+
         if (!Array.isArray(result)) return [];
 
         for (const item of result) {

--- a/packages/vinext/src/server/app-prerender-static-params.ts
+++ b/packages/vinext/src/server/app-prerender-static-params.ts
@@ -1,4 +1,4 @@
-import { pickRootParams, setRootParams, type RootParams } from "vinext/shims/root-params";
+import { pickRootParams, runWithRootParamsScope, type RootParams } from "vinext/shims/root-params";
 
 type GenerateStaticParamsFunction = (input: { params: RootParams }) => unknown;
 
@@ -20,14 +20,15 @@ export function createAppPrerenderStaticParamsResolver(
     // Wrap the single source in the same non-array/non-object guards as the
     // multi-source composition path so the contract is uniform regardless of
     // how many sources were composed.
-    return async (input) => {
-      const result = await single(input);
-      if (!Array.isArray(result)) return [];
-      for (const item of result) {
-        if (!isRootParams(item)) return [];
-      }
-      return result;
-    };
+    return async (input) =>
+      runWithRootParamsScope(input.params, async () => {
+        const result = await single(input);
+        if (!Array.isArray(result)) return [];
+        for (const item of result) {
+          if (!isRootParams(item)) return [];
+        }
+        return result;
+      });
   }
 
   return async ({ params }) => {
@@ -37,7 +38,9 @@ export function createAppPrerenderStaticParamsResolver(
       const nextParamSets: RootParams[] = [];
 
       for (const parentParams of paramSets) {
-        const result = await generateStaticParams({ params: parentParams });
+        const result = await runWithRootParamsScope(parentParams, async () =>
+          generateStaticParams({ params: parentParams }),
+        );
         if (!Array.isArray(result)) return [];
 
         for (const item of result) {
@@ -63,10 +66,6 @@ type CallAppPrerenderStaticParamsOptions = {
 export async function callAppPrerenderStaticParams(
   options: CallAppPrerenderStaticParamsOptions,
 ): Promise<unknown> {
-  setRootParams(pickRootParams(options.params, options.rootParamNamesByPattern[options.pattern]));
-  try {
-    return await options.fn({ params: options.params });
-  } finally {
-    setRootParams(null);
-  }
+  const picked = pickRootParams(options.params, options.rootParamNamesByPattern[options.pattern]);
+  return runWithRootParamsScope(picked, () => options.fn({ params: options.params }));
 }

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -25,7 +25,7 @@ import {
   getRequestExecutionContext,
   type ExecutionContextLike,
 } from "vinext/shims/request-context";
-import { pickRootParams, setRootParams } from "vinext/shims/root-params";
+import { pickRootParams, setRootParams, type RootParams } from "vinext/shims/root-params";
 import { createRequestContext, runWithRequestContext } from "vinext/shims/unified-request-context";
 import { flattenErrorCauses } from "../utils/error-cause.js";
 import { hasBasePath } from "../utils/base-path.js";
@@ -94,6 +94,7 @@ type DispatchMatchedPageOptions<TRoute> = {
   middlewareContext: AppRscMiddlewareContext;
   mountedSlotsHeader: string | null;
   params: AppPageParams;
+  rootParams?: RootParams;
   request: Request;
   route: TRoute;
   scriptNonce?: string;
@@ -522,7 +523,8 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
     searchParams: url.searchParams,
     params,
   });
-  setRootParams(pickRootParams(params, route.rootParamNames));
+  const rootParams = pickRootParams(params, route.rootParamNames);
+  setRootParams(rootParams);
 
   if (route.routeHandler) {
     setCurrentFetchSoftTags(
@@ -550,6 +552,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
     middlewareContext,
     mountedSlotsHeader,
     params,
+    rootParams,
     request,
     route,
     scriptNonce,

--- a/packages/vinext/src/server/app-ssr-entry.ts
+++ b/packages/vinext/src/server/app-ssr-entry.ts
@@ -214,7 +214,7 @@ export async function handleSsr(
       clearServerInsertedHTML();
     };
 
-    const rootParams = options?.rootParams ?? navContext?.params ?? {};
+    const rootParams = options?.rootParams ?? {};
     return runWithRootParamsScope(rootParams, async () => {
       try {
         // Fused tee path (#981): caller pre-split the stream. No internal tee needed.

--- a/packages/vinext/src/server/app-ssr-entry.ts
+++ b/packages/vinext/src/server/app-ssr-entry.ts
@@ -17,7 +17,7 @@ import {
   useServerInsertedHTML,
 } from "vinext/shims/navigation";
 import { runWithNavigationContext } from "vinext/shims/navigation-state";
-import { runWithRootParamsScope } from "vinext/shims/root-params";
+import { runWithRootParamsScope, type RootParams } from "vinext/shims/root-params";
 import { isOpenRedirectShaped } from "./request-pipeline.js";
 import { notFoundResponse } from "./http-error-responses.js";
 import { withScriptNonce } from "vinext/shims/script-nonce-context";
@@ -193,6 +193,7 @@ export async function handleSsr(
     capturedRscDataRef?: { value: Promise<ArrayBuffer> | null };
     formState?: ReactFormState | null;
     basePath?: string;
+    rootParams?: RootParams;
     /** When true, wait for the full React tree (including Suspense boundaries)
      *  to resolve before returning the HTML stream. Used for static prerender
      *  and ISR cache writes to avoid caching fallback content. */
@@ -213,7 +214,7 @@ export async function handleSsr(
       clearServerInsertedHTML();
     };
 
-    const rootParams = navContext?.params ?? {};
+    const rootParams = options?.rootParams ?? navContext?.params ?? {};
     return runWithRootParamsScope(rootParams, async () => {
       try {
         // Fused tee path (#981): caller pre-split the stream. No internal tee needed.

--- a/packages/vinext/src/server/app-ssr-entry.ts
+++ b/packages/vinext/src/server/app-ssr-entry.ts
@@ -17,6 +17,7 @@ import {
   useServerInsertedHTML,
 } from "vinext/shims/navigation";
 import { runWithNavigationContext } from "vinext/shims/navigation-state";
+import { runWithRootParamsScope } from "vinext/shims/root-params";
 import { isOpenRedirectShaped } from "./request-pipeline.js";
 import { notFoundResponse } from "./http-error-responses.js";
 import { withScriptNonce } from "vinext/shims/script-nonce-context";
@@ -212,150 +213,155 @@ export async function handleSsr(
       clearServerInsertedHTML();
     };
 
-    try {
-      // Fused tee path (#981): caller pre-split the stream. No internal tee needed.
-      // sideStream carries both the embed transform and raw byte accumulation.
-      // rscStream is used directly for createFromReadableStream (SSR).
-      let ssrStream: ReadableStream<Uint8Array>;
-      let rscEmbed;
+    const rootParams = navContext?.params ?? {};
+    return runWithRootParamsScope(rootParams, async () => {
+      try {
+        // Fused tee path (#981): caller pre-split the stream. No internal tee needed.
+        // sideStream carries both the embed transform and raw byte accumulation.
+        // rscStream is used directly for createFromReadableStream (SSR).
+        let ssrStream: ReadableStream<Uint8Array>;
+        let rscEmbed;
 
-      if (options?.sideStream) {
-        ssrStream = rscStream;
-        rscEmbed = createRscEmbedTransform(options.sideStream, options?.scriptNonce);
-        if (options.capturedRscDataRef) {
-          options.capturedRscDataRef.value = rscEmbed.getRawBuffer();
+        if (options?.sideStream) {
+          ssrStream = rscStream;
+          rscEmbed = createRscEmbedTransform(options.sideStream, options?.scriptNonce);
+          if (options.capturedRscDataRef) {
+            options.capturedRscDataRef.value = rscEmbed.getRawBuffer();
+          }
+        } else {
+          const [s1, s2] = rscStream.tee();
+          ssrStream = s1;
+          rscEmbed = createRscEmbedTransform(s2, options?.scriptNonce);
         }
-      } else {
-        const [s1, s2] = rscStream.tee();
-        ssrStream = s1;
-        rscEmbed = createRscEmbedTransform(s2, options?.scriptNonce);
-      }
 
-      let flightRoot: PromiseLike<AppWireElements> | null = null;
+        let flightRoot: PromiseLike<AppWireElements> | null = null;
 
-      function VinextFlightRoot(): ReactNode {
-        if (!flightRoot) {
-          flightRoot = createFromReadableStream<AppWireElements>(ssrStream);
+        function VinextFlightRoot(): ReactNode {
+          if (!flightRoot) {
+            flightRoot = createFromReadableStream<AppWireElements>(ssrStream);
+          }
+          const wireElements = use(flightRoot);
+          const elements = AppElementsWire.decode(wireElements);
+          const metadata = AppElementsWire.readMetadata(elements);
+          return createReactElement(
+            ElementsContext.Provider,
+            { value: elements },
+            createReactElement(Slot, { id: metadata.routeId }),
+          );
         }
-        const wireElements = use(flightRoot);
-        const elements = AppElementsWire.decode(wireElements);
-        const metadata = AppElementsWire.readMetadata(elements);
-        return createReactElement(
-          ElementsContext.Provider,
-          { value: elements },
-          createReactElement(Slot, { id: metadata.routeId }),
-        );
-      }
 
-      const flightRootElement = createReactElement(VinextFlightRoot);
-      const root = AppRouterContext
-        ? createReactElement(
-            AppRouterContext.Provider,
-            { value: appRouterInstance },
-            flightRootElement,
-          )
-        : flightRootElement;
-      const ssrTree = ServerInsertedHTMLContext
-        ? createReactElement(
-            ServerInsertedHTMLContext.Provider,
-            { value: useServerInsertedHTML },
-            root,
-          )
-        : root;
-      const ssrRoot = withScriptNonce(ssrTree, options?.scriptNonce);
+        const flightRootElement = createReactElement(VinextFlightRoot);
+        const root = AppRouterContext
+          ? createReactElement(
+              AppRouterContext.Provider,
+              { value: appRouterInstance },
+              flightRootElement,
+            )
+          : flightRootElement;
+        const ssrTree = ServerInsertedHTMLContext
+          ? createReactElement(
+              ServerInsertedHTMLContext.Provider,
+              { value: useServerInsertedHTML },
+              root,
+            )
+          : root;
+        const ssrRoot = withScriptNonce(ssrTree, options?.scriptNonce);
 
-      // plugin-rsc returns the bootstrap as `import("<url>")` so callers can
-      // inject it via `bootstrapScriptContent`. We hand the URL to React's
-      // `bootstrapModules` option instead so the streamed HTML contains a
-      // real `<script type="module" src="<url>">` tag — exposing the URL
-      // to anything that inspects `script.attribs.src` (e.g. the Next.js
-      // asset-prefix fixture test "bundles should return 200 on served
-      // assetPrefix"). Mirrors Next.js's app-render path which passes
-      // `bootstrapScripts: [{ src }]` for the same reason; we use
-      // `bootstrapModules` because vinext's chunks are native ES modules
-      // (Vite output) so a `type="module"` tag is the correct loader.
-      //
-      // In dev, `<url>` is a Vite dev URL like
-      // `/@id/__x00__virtual:vinext-app-browser-entry`; the browser fetches
-      // it as a module from the dev server. In prod it's the hashed bundle
-      // URL (e.g. `/_next/static/index-abc123.js`, optionally prefixed by
-      // `assetPrefix`). Both are valid `<script type="module" src=…>` targets.
-      const bootstrapScriptContent = await import.meta.viteRsc.loadBootstrapScriptContent("index");
-      const bootstrapModuleUrl = extractBootstrapModuleUrl(bootstrapScriptContent);
-      const errorMetaRenderer = createSsrErrorMetaRenderer({
-        basePath: options?.basePath,
-      });
-
-      const htmlStream = await renderToReadableStream(ssrRoot, {
-        // `bootstrapScriptContent` was previously how vinext injected the
-        // dynamic-import call. `bootstrapModules` performs the same work
-        // natively (and exposes the URL in the DOM), so passing both would
-        // load the bootstrap module twice.
+        // plugin-rsc returns the bootstrap as `import("<url>")` so callers can
+        // inject it via `bootstrapScriptContent`. We hand the URL to React's
+        // `bootstrapModules` option instead so the streamed HTML contains a
+        // real `<script type="module" src="<url>">` tag — exposing the URL
+        // to anything that inspects `script.attribs.src` (e.g. the Next.js
+        // asset-prefix fixture test "bundles should return 200 on served
+        // assetPrefix"). Mirrors Next.js's app-render path which passes
+        // `bootstrapScripts: [{ src }]` for the same reason; we use
+        // `bootstrapModules` because vinext's chunks are native ES modules
+        // (Vite output) so a `type="module"` tag is the correct loader.
         //
-        // CSP implications of using `bootstrapModules` instead of inline
-        // `bootstrapScriptContent`:
-        //  - Apps no longer need `script-src 'unsafe-inline'` to load the
-        //    bootstrap (improvement — inline imports required `'unsafe-inline'`).
-        //  - Apps that restrict script sources need `'self'` for the
-        //    common case, or the CDN origin when `assetPrefix` is an
-        //    absolute URL like `https://cdn.example.com`.
-        //  - React still applies `nonce` to the emitted
-        //    `<script type="module" src=…>` tag, so nonce-based CSP
-        //    (`script-src 'nonce-…' 'strict-dynamic'`) keeps working.
-        bootstrapModules: bootstrapModuleUrl ? [bootstrapModuleUrl] : undefined,
-        formState: options?.formState ?? null,
-        nonce: options?.scriptNonce,
-        onError(error) {
-          errorMetaRenderer.capture(error);
-
-          if (error && typeof error === "object" && "digest" in error) {
-            return String(error.digest);
-          }
-
-          if (process.env.NODE_ENV === "production" && error) {
-            const message = getErrorMessage(error);
-            const stack = error instanceof Error ? (error.stack ?? "") : "";
-            return ssrErrorDigest(message + stack);
-          }
-
-          return undefined;
-        },
-      });
-
-      // When producing static output (prerender / ISR cache writes), wait for
-      // the full React tree to resolve before emitting bytes. This prevents
-      // Suspense fallback content from being serialized to the cache.
-      // Matches Next.js waitForAllReady forkpoint in renderToNodeFizzStream.
-      if (options?.waitForAllReady === true) {
-        await htmlStream.allReady;
-      }
-
-      const fontHTML = renderFontHtml(fontData, options?.scriptNonce);
-      let didInjectHeadHTML = false;
-      const getInsertedHTML = (): string => {
-        const insertedHTML = renderInsertedHtml(renderServerInsertedHTML());
-        const errorMetaHTML = errorMetaRenderer.flush();
-        if (didInjectHeadHTML) return insertedHTML + errorMetaHTML;
-
-        didInjectHeadHTML = true;
-        return buildHeadInjectionHtml(
-          navContext,
-          bootstrapModuleUrl,
-          options?.formState ?? null,
-          insertedHTML + errorMetaHTML,
-          fontHTML,
-          options?.scriptNonce,
+        // In dev, `<url>` is a Vite dev URL like
+        // `/@id/__x00__virtual:vinext-app-browser-entry`; the browser fetches
+        // it as a module from the dev server. In prod it's the hashed bundle
+        // URL (e.g. `/_next/static/index-abc123.js`, optionally prefixed by
+        // `assetPrefix`). Both are valid `<script type="module" src=…>` targets.
+        const bootstrapScriptContent = await import.meta.viteRsc.loadBootstrapScriptContent(
+          "index",
         );
-      };
+        const bootstrapModuleUrl = extractBootstrapModuleUrl(bootstrapScriptContent);
+        const errorMetaRenderer = createSsrErrorMetaRenderer({
+          basePath: options?.basePath,
+        });
 
-      return deferUntilStreamConsumed(
-        htmlStream.pipeThrough(createTickBufferedTransform(rscEmbed, getInsertedHTML)),
-        cleanup,
-      );
-    } catch (error) {
-      cleanup();
-      throw error;
-    }
+        const htmlStream = await renderToReadableStream(ssrRoot, {
+          // `bootstrapScriptContent` was previously how vinext injected the
+          // dynamic-import call. `bootstrapModules` performs the same work
+          // natively (and exposes the URL in the DOM), so passing both would
+          // load the bootstrap module twice.
+          //
+          // CSP implications of using `bootstrapModules` instead of inline
+          // `bootstrapScriptContent`:
+          //  - Apps no longer need `script-src 'unsafe-inline'` to load the
+          //    bootstrap (improvement — inline imports required `'unsafe-inline'`).
+          //  - Apps that restrict script sources need `'self'` for the
+          //    common case, or the CDN origin when `assetPrefix` is an
+          //    absolute URL like `https://cdn.example.com`.
+          //  - React still applies `nonce` to the emitted
+          //    `<script type="module" src=…>` tag, so nonce-based CSP
+          //    (`script-src 'nonce-…' 'strict-dynamic'`) keeps working.
+          bootstrapModules: bootstrapModuleUrl ? [bootstrapModuleUrl] : undefined,
+          formState: options?.formState ?? null,
+          nonce: options?.scriptNonce,
+          onError(error) {
+            errorMetaRenderer.capture(error);
+
+            if (error && typeof error === "object" && "digest" in error) {
+              return String(error.digest);
+            }
+
+            if (process.env.NODE_ENV === "production" && error) {
+              const message = getErrorMessage(error);
+              const stack = error instanceof Error ? (error.stack ?? "") : "";
+              return ssrErrorDigest(message + stack);
+            }
+
+            return undefined;
+          },
+        });
+
+        // When producing static output (prerender / ISR cache writes), wait for
+        // the full React tree to resolve before emitting bytes. This prevents
+        // Suspense fallback content from being serialized to the cache.
+        // Matches Next.js waitForAllReady forkpoint in renderToNodeFizzStream.
+        if (options?.waitForAllReady === true) {
+          await htmlStream.allReady;
+        }
+
+        const fontHTML = renderFontHtml(fontData, options?.scriptNonce);
+        let didInjectHeadHTML = false;
+        const getInsertedHTML = (): string => {
+          const insertedHTML = renderInsertedHtml(renderServerInsertedHTML());
+          const errorMetaHTML = errorMetaRenderer.flush();
+          if (didInjectHeadHTML) return insertedHTML + errorMetaHTML;
+
+          didInjectHeadHTML = true;
+          return buildHeadInjectionHtml(
+            navContext,
+            bootstrapModuleUrl,
+            options?.formState ?? null,
+            insertedHTML + errorMetaHTML,
+            fontHTML,
+            options?.scriptNonce,
+          );
+        };
+
+        return deferUntilStreamConsumed(
+          htmlStream.pipeThrough(createTickBufferedTransform(rscEmbed, getInsertedHTML)),
+          cleanup,
+        );
+      } catch (error) {
+        cleanup();
+        throw error;
+      }
+    });
   }) as Promise<ReadableStream<Uint8Array>>;
 }
 

--- a/packages/vinext/src/shims/root-params.ts
+++ b/packages/vinext/src/shims/root-params.ts
@@ -1,4 +1,10 @@
-import { getRequestContext, isInsideUnifiedScope } from "./unified-request-context.js";
+import {
+  getRequestContext,
+  isInsideUnifiedScope,
+  createRequestContext,
+  runWithRequestContext,
+  runWithUnifiedStateMutation,
+} from "./unified-request-context.js";
 
 export type RootParams = Record<string, string | string[] | undefined>;
 
@@ -35,6 +41,24 @@ export function setRootParams(params: RootParams | null): void {
   getState().rootParams = params;
 }
 
+export function getRootParams(): RootParams | null {
+  return getState().rootParams;
+}
+
 export function getRootParam(name: string): Promise<string | string[] | undefined> {
   return Promise.resolve(getState().rootParams?.[name]);
+}
+
+export function runWithRootParamsScope<T>(
+  params: RootParams,
+  fn: () => T | Promise<T>,
+): T | Promise<T> {
+  if (isInsideUnifiedScope()) {
+    return runWithUnifiedStateMutation((ctx) => {
+      ctx.rootParams = params;
+    }, fn);
+  } else {
+    const ctx = createRequestContext({ rootParams: params });
+    return runWithRequestContext(ctx, fn);
+  }
 }

--- a/packages/vinext/src/shims/root-params.ts
+++ b/packages/vinext/src/shims/root-params.ts
@@ -41,14 +41,15 @@ export function setRootParams(params: RootParams | null): void {
   getState().rootParams = params;
 }
 
-export function getRootParams(): RootParams | null {
-  return getState().rootParams;
-}
-
 export function getRootParam(name: string): Promise<string | string[] | undefined> {
   return Promise.resolve(getState().rootParams?.[name]);
 }
 
+export function runWithRootParamsScope<T>(params: RootParams, fn: () => Promise<T>): Promise<T>;
+export function runWithRootParamsScope<T>(
+  params: RootParams,
+  fn: () => T | Promise<T>,
+): T | Promise<T>;
 export function runWithRootParamsScope<T>(
   params: RootParams,
   fn: () => T | Promise<T>,

--- a/packages/vinext/src/shims/root-params.ts
+++ b/packages/vinext/src/shims/root-params.ts
@@ -1,8 +1,7 @@
+import { getOrCreateAls } from "./internal/als-registry.js";
 import {
   getRequestContext,
   isInsideUnifiedScope,
-  createRequestContext,
-  runWithRequestContext,
   runWithUnifiedStateMutation,
 } from "./unified-request-context.js";
 
@@ -14,6 +13,7 @@ export type RootParamsState = {
 
 const _FALLBACK_KEY = Symbol.for("vinext.rootParams.fallback");
 const _g = globalThis as unknown as Record<PropertyKey, unknown>;
+const _als = getOrCreateAls<RootParamsState>("vinext.rootParams.als");
 
 const _fallbackState = (_g[_FALLBACK_KEY] ??= {
   rootParams: null,
@@ -23,7 +23,7 @@ function getState(): RootParamsState {
   if (isInsideUnifiedScope()) {
     return getRequestContext();
   }
-  return _fallbackState;
+  return _als.getStore() ?? _fallbackState;
 }
 
 export function pickRootParams(
@@ -58,7 +58,6 @@ export function runWithRootParamsScope<T>(
       ctx.rootParams = params;
     }, fn);
   } else {
-    const ctx = createRequestContext({ rootParams: params });
-    return runWithRequestContext(ctx, fn);
+    return _als.run({ rootParams: params }, fn);
   }
 }

--- a/tests/app-prerender-endpoints.test.ts
+++ b/tests/app-prerender-endpoints.test.ts
@@ -56,6 +56,23 @@ describe("App prerender endpoint helpers", () => {
     });
   });
 
+  it("preserves incoming non-root parent params in the resolver", async () => {
+    const first = vi.fn(async ({ params }) => {
+      expect(params).toEqual({ lang: "en", category: "docs" });
+      expect(await getRootParam("lang")).toBe("en");
+      expect(await getRootParam("category")).toBeUndefined();
+      return [{ slug: `${params.category}-post` }];
+    });
+
+    const second = vi.fn(({ params }) => [{ final: params.slug }]);
+
+    const resolve = createAppPrerenderStaticParamsResolver([first, second], ["lang"]);
+
+    await expect(resolve?.({ params: { lang: "en", category: "docs" } })).resolves.toEqual([
+      { lang: "en", category: "docs", slug: "docs-post", final: "docs-post" },
+    ]);
+  });
+
   it("bails out of composed generateStaticParams when a source returns a non-array", async () => {
     const malformedLayoutGenerateStaticParams = vi.fn(() => undefined);
     const pageGenerateStaticParams = vi.fn(() => [{ slug: "unused" }]);

--- a/tests/app-prerender-endpoints.test.ts
+++ b/tests/app-prerender-endpoints.test.ts
@@ -36,6 +36,26 @@ describe("App prerender endpoint helpers", () => {
     });
   });
 
+  it("filters non-root params from root param scope in resolver while preserving them in params argument", async () => {
+    const layoutGenerateStaticParams = vi.fn(() => [{ lang: "en", locale: "us" }]);
+    const pageGenerateStaticParams = vi.fn(async ({ params }) => {
+      const rootLang = await getRootParam("lang");
+      const rootLocale = await getRootParam("locale");
+      return [{ rootLang, rootLocale, slug: `${params.lang}-post` }];
+    });
+    const resolveStaticParams = createAppPrerenderStaticParamsResolver(
+      [layoutGenerateStaticParams, pageGenerateStaticParams],
+      ["lang"],
+    );
+
+    await expect(resolveStaticParams?.({ params: {} })).resolves.toEqual([
+      { lang: "en", locale: "us", rootLang: "en", rootLocale: undefined, slug: "en-post" },
+    ]);
+    expect(pageGenerateStaticParams).toHaveBeenCalledWith({
+      params: { lang: "en", locale: "us" },
+    });
+  });
+
   it("bails out of composed generateStaticParams when a source returns a non-array", async () => {
     const malformedLayoutGenerateStaticParams = vi.fn(() => undefined);
     const pageGenerateStaticParams = vi.fn(() => [{ slug: "unused" }]);

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -3939,6 +3939,8 @@ describe("App Router next.config.js features (generateRscEntry)", () => {
     expect(code).toContain("export default __createAppRscHandler({");
     expect(code).toContain("configRedirects: __configRedirects");
     expect(code).toContain("dispatchMatchedPage({");
+    expect(code).toContain("    rootParams,\n    request,");
+    expect(code).toContain("      rootParams,\n      probeLayoutAt");
     expect(code).toContain("dispatchMatchedRouteHandler({");
     expect(code).toContain("matchRoute,");
   });

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -325,7 +325,7 @@ describe("App Router generated manifest construction", () => {
     expect(dynamicRouteEntry).toContain("page: mod_17");
     expect(dynamicRouteEntry).toContain('params: ["photoId"]');
     expect(manifest.generateStaticParamsEntries).toEqual([
-      '  "/dashboard/:id": __createAppPrerenderStaticParamsResolver([mod_5?.generateStaticParams]),',
+      '  "/dashboard/:id": __createAppPrerenderStaticParamsResolver([mod_5?.generateStaticParams], ["id"]),',
     ]);
   });
 
@@ -366,8 +366,8 @@ describe("App Router generated manifest construction", () => {
     });
 
     expect(manifest.generateStaticParamsEntries).toEqual([
-      '  "/:lang/:locale": __createAppPrerenderStaticParamsResolver([mod_1?.generateStaticParams]),',
-      '  "/:lang/:locale/other/:slug": __createAppPrerenderStaticParamsResolver([mod_0?.generateStaticParams]),',
+      '  "/:lang/:locale": __createAppPrerenderStaticParamsResolver([mod_1?.generateStaticParams], ["lang","locale"]),',
+      '  "/:lang/:locale/other/:slug": __createAppPrerenderStaticParamsResolver([mod_0?.generateStaticParams], ["lang","locale"]),',
     ]);
     expect(manifest.rootParamNameEntries).toEqual([
       '  "/:lang/:locale/other/:slug": ["lang","locale"],',
@@ -410,8 +410,8 @@ describe("App Router generated manifest construction", () => {
     });
 
     expect(manifest.generateStaticParamsEntries).toEqual([
-      '  "/:lang/docs v2/:section": __createAppPrerenderStaticParamsResolver([mod_1?.generateStaticParams]),',
-      '  "/:lang/docs v2/:section/:slug": __createAppPrerenderStaticParamsResolver([mod_0?.generateStaticParams]),',
+      '  "/:lang/docs v2/:section": __createAppPrerenderStaticParamsResolver([mod_1?.generateStaticParams], ["lang","section"]),',
+      '  "/:lang/docs v2/:section/:slug": __createAppPrerenderStaticParamsResolver([mod_0?.generateStaticParams], ["lang","section"]),',
     ]);
     expect(manifest.rootParamNameEntries).toEqual([
       '  "/:lang/docs v2/:section/:slug": ["lang","section"],',

--- a/tests/root-params.test.ts
+++ b/tests/root-params.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vite-plus/test";
+import { getRootParam, runWithRootParamsScope } from "../packages/vinext/src/shims/root-params.js";
+import {
+  runWithRequestContext,
+  createRequestContext,
+} from "../packages/vinext/src/shims/unified-request-context.js";
+
+describe("next/root-params shim", () => {
+  it("resolves to undefined when called outside of root params scope", async () => {
+    const val = await getRootParam("lang");
+    expect(val).toBeUndefined();
+  });
+
+  it("resolves to the correct param within runWithRootParamsScope", async () => {
+    const result = await runWithRootParamsScope({ lang: "en", locale: "en-US" }, async () => {
+      const langVal = await getRootParam("lang");
+      const localeVal = await getRootParam("locale");
+      const missingVal = await getRootParam("missing");
+      return { langVal, localeVal, missingVal };
+    });
+
+    expect(result).toEqual({
+      langVal: "en",
+      localeVal: "en-US",
+      missingVal: undefined,
+    });
+  });
+
+  it("supports nested scopes overriding outer scopes", async () => {
+    const result = await runWithRootParamsScope({ lang: "en" }, async () => {
+      const outer = await getRootParam("lang");
+      const inner = await runWithRootParamsScope({ lang: "es" }, async () => getRootParam("lang"));
+      const outerAfter = await getRootParam("lang");
+      return { outer, inner, outerAfter };
+    });
+
+    expect(result).toEqual({
+      outer: "en",
+      inner: "es",
+      outerAfter: "en",
+    });
+  });
+
+  it("integrates correctly with unified request context", async () => {
+    const ctx = createRequestContext({ rootParams: { lang: "fr" } });
+    const result = await runWithRequestContext(ctx, async () => {
+      const langVal = await getRootParam("lang");
+
+      // Nested overriding scope inside unified context
+      const nestedVal = await runWithRootParamsScope({ lang: "de" }, async () =>
+        getRootParam("lang"),
+      );
+
+      const langValAfter = await getRootParam("lang");
+
+      return { langVal, nestedVal, langValAfter };
+    });
+
+    expect(result).toEqual({
+      langVal: "fr",
+      nestedVal: "de",
+      langValAfter: "fr",
+    });
+  });
+});

--- a/tests/root-params.test.ts
+++ b/tests/root-params.test.ts
@@ -4,6 +4,11 @@ import {
   runWithRequestContext,
   createRequestContext,
 } from "../packages/vinext/src/shims/unified-request-context.js";
+import { runWithNavigationContext } from "../packages/vinext/src/shims/navigation-state.js";
+import {
+  getNavigationContext,
+  setNavigationContext,
+} from "../packages/vinext/src/shims/navigation.js";
 
 describe("next/root-params shim", () => {
   it("resolves to undefined when called outside of root params scope", async () => {
@@ -60,6 +65,21 @@ describe("next/root-params shim", () => {
       langVal: "fr",
       nestedVal: "de",
       langValAfter: "fr",
+    });
+  });
+
+  it("proves sibling standalone state survives runWithRootParamsScope", async () => {
+    await runWithNavigationContext(async () => {
+      setNavigationContext({
+        pathname: "/blog/en",
+        searchParams: new URLSearchParams(),
+        params: { lang: "en" },
+      });
+
+      await runWithRootParamsScope({ lang: "en" }, async () => {
+        expect(getNavigationContext()?.pathname).toBe("/blog/en");
+        await expect(getRootParam("lang")).resolves.toBe("en");
+      });
     });
   });
 });


### PR DESCRIPTION
This PR fixes the issue where root parameters (such as `lang()` and `locale()`) from `next/root-params` were not correctly resolved or propagated during dynamic `generateStaticParams` static prerendering and SSR.

Specifically, it ensures strict parameter isolation to prevent non-root route parameters from leaking into the parent/root parameter context, aligning with the expected Next.js behavior.

### Implementation Details:
1. **Dedicated ALS Scoping**: Integrated `runWithRootParamsScope` in `root-params.ts` with a dedicated standalone ALS (`vinext.rootParams.als`) when executed outside of an active unified context. This prevents it from shadowing sibling scopes (such as `NavigationState`) by creating an overreaching empty `UnifiedRequestContext`.
2. **Strict Parameter Filtering**: Modified `createAppPrerenderStaticParamsResolver` in `app-prerender-static-params.ts` to filter incoming parent parameters when entering the root-parameter scope, while preserving full parameter bags (including incoming non-root parent parameters) for user-defined generator function arguments.
3. **Pipeline Threading**: Threaded `rootParams` from `dispatchMatchedPage` through `dispatchAppPage`, `renderAppPageLifecycle`, and `renderAppPageHtmlStream`.
4. **SSR Scope Integration**: Updated `handleSsr` in `app-ssr-entry.ts` to accept `rootParams` via options and default to `{}` rather than guessing or inferring from full navigation parameters, avoiding context leaks.

### Verification:
- Added a unit test in `root-params.test.ts` verifying that standalone sibling state (such as `NavigationState`) correctly survives and is not shadowed by `runWithRootParamsScope`.
- Added a unit test in `app-prerender-endpoints.test.ts` verifying parameter filtering and preservation.
- Added a regression unit test in `app-prerender-endpoints.test.ts` verifying that incoming non-root parent parameters are preserved during multi-source generator resolution.
- Ran all integration and compatibility tests (`entry-templates.test.ts`, `prerender.test.ts`, and `app-router.test.ts`) and verified they all pass.
- Verified formatting and linting Checks (`pnpm run check`).