### PR TITLE
feat(cache): gate planner commits on explicit reuse proof

### DIFF
--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -79,6 +79,7 @@ import {
   createHistoryStateWithPreviousNextUrl,
   readHistoryStatePreviousNextUrl,
   readHistoryStateTraversalIndex,
+  isCacheRestorableAppPayloadMetadata,
   resolveHistoryTraversalIntent,
   resolveInterceptionContextFromPreviousNextUrl,
   resolveServerActionRequestState,
@@ -1488,6 +1489,10 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
         // never actually rendered successfully.
         const resolvedElements = await rscPayload;
         const metadata = AppElementsWire.readMetadata(resolvedElements);
+        if (!isCacheRestorableAppPayloadMetadata(metadata)) {
+          void cacheBufferPromise.catch(() => {});
+          return;
+        }
         const cacheBuffer = await cacheBufferPromise;
         storeVisitedResponseSnapshot(
           rscUrl,

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -75,6 +75,8 @@ import {
   type AppWireElements,
 } from "./app-elements.js";
 import {
+  FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
+  VISITED_CACHE_APP_NAVIGATION_PAYLOAD_ORIGIN,
   createHistoryStateWithNavigationMetadata,
   createHistoryStateWithPreviousNextUrl,
   readHistoryStatePreviousNextUrl,
@@ -83,6 +85,7 @@ import {
   resolveHistoryTraversalIntent,
   resolveInterceptionContextFromPreviousNextUrl,
   resolveServerActionRequestState,
+  type AppNavigationPayloadOrigin,
   type AppRouterState,
   type HistoryTraversalIntent,
   type OperationLane,
@@ -444,10 +447,10 @@ async function renderNavigationPayload(
   params: Record<string, string | string[]>,
   previousNextUrl: string | null,
   pendingRouterState: PendingBrowserRouterState | null,
+  payloadOrigin: AppNavigationPayloadOrigin,
   actionType: "navigate" | "replace" | "traverse" = "navigate",
   operationLane: OperationLane = "navigation",
   traversalIntent: HistoryTraversalIntent | null = null,
-  requireCacheEntryReuseProof: boolean = false,
 ): Promise<NavigationPayloadOutcome> {
   try {
     return await browserNavigationController.renderNavigationPayload({
@@ -460,10 +463,10 @@ async function renderNavigationPayload(
       navigationSnapshot,
       nextElements: payload,
       operationLane,
+      payloadOrigin,
       params,
       pendingRouterState,
       previousNextUrl,
-      requireCacheEntryReuseProof,
       targetHistoryIndex: traversalIntent === null ? undefined : traversalIntent.targetHistoryIndex,
       targetHref,
       navId,
@@ -1318,10 +1321,10 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
             cachedParams,
             requestPreviousNextUrl,
             pendingRouterState,
+            VISITED_CACHE_APP_NAVIGATION_PAYLOAD_ORIGIN,
             toActionType(navigationKind),
             toOperationLane(navigationKind),
             activeTraversalIntent,
-            true,
           );
           return;
         }
@@ -1475,6 +1478,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
           navParams,
           requestPreviousNextUrl,
           pendingRouterState,
+          FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
           toActionType(navigationKind),
           toOperationLane(navigationKind),
           activeTraversalIntent,

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -446,6 +446,7 @@ async function renderNavigationPayload(
   actionType: "navigate" | "replace" | "traverse" = "navigate",
   operationLane: OperationLane = "navigation",
   traversalIntent: HistoryTraversalIntent | null = null,
+  requireCacheEntryReuseProof: boolean = false,
 ): Promise<NavigationPayloadOutcome> {
   try {
     return await browserNavigationController.renderNavigationPayload({
@@ -461,6 +462,7 @@ async function renderNavigationPayload(
       params,
       pendingRouterState,
       previousNextUrl,
+      requireCacheEntryReuseProof,
       targetHistoryIndex: traversalIntent === null ? undefined : traversalIntent.targetHistoryIndex,
       targetHref,
       navId,
@@ -1318,6 +1320,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
             toActionType(navigationKind),
             toOperationLane(navigationKind),
             activeTraversalIntent,
+            true,
           );
           return;
         }

--- a/packages/vinext/src/server/app-browser-navigation-controller.ts
+++ b/packages/vinext/src/server/app-browser-navigation-controller.ts
@@ -7,7 +7,9 @@ import {
 import type { ClientNavigationRenderSnapshot } from "vinext/shims/navigation";
 import type { RouteManifest } from "../routing/app-route-graph.js";
 import {
+  FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
   createPendingNavigationCommit,
+  type AppNavigationPayloadOrigin,
   type AppRouterState,
   type OperationLane,
 } from "./app-browser-state.js";
@@ -81,10 +83,10 @@ type BrowserNavigationController = {
     navigationSnapshot: ClientNavigationRenderSnapshot;
     nextElements: Promise<AppElements>;
     operationLane: OperationLane;
+    payloadOrigin: AppNavigationPayloadOrigin;
     params: Record<string, string | string[]>;
     pendingRouterState: PendingBrowserRouterState | null;
     previousNextUrl: string | null;
-    requireCacheEntryReuseProof?: boolean;
     targetHistoryIndex?: number | null;
     targetHref: string;
     navId: number;
@@ -412,6 +414,7 @@ export function createAppBrowserNavigationController(
       nextElements,
       navigationSnapshot,
       operationLane: "hmr",
+      payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
       renderId,
       type: "replace",
     });
@@ -493,10 +496,10 @@ export function createAppBrowserNavigationController(
     navigationSnapshot: ClientNavigationRenderSnapshot;
     nextElements: Promise<AppElements>;
     operationLane: OperationLane;
+    payloadOrigin: AppNavigationPayloadOrigin;
     params: Record<string, string | string[]>;
     pendingRouterState: PendingBrowserRouterState | null;
     previousNextUrl: string | null;
-    requireCacheEntryReuseProof?: boolean;
     targetHistoryIndex?: number | null;
     targetHref: string;
     navId: number;
@@ -516,9 +519,9 @@ export function createAppBrowserNavigationController(
         nextElements: options.nextElements,
         navigationSnapshot: options.navigationSnapshot,
         operationLane: options.operationLane,
+        payloadOrigin: options.payloadOrigin,
         previousNextUrl: options.previousNextUrl,
         renderId,
-        requireCacheEntryReuseProof: options.requireCacheEntryReuseProof,
         type: options.actionType,
       });
 
@@ -604,6 +607,7 @@ export function createAppBrowserNavigationController(
       nextElements,
       renderId: allocateRenderId(),
       operationLane: "server-action",
+      payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
       startedNavigationId,
       routeManifest: getRouteManifest(),
       targetHref,

--- a/packages/vinext/src/server/app-browser-navigation-controller.ts
+++ b/packages/vinext/src/server/app-browser-navigation-controller.ts
@@ -84,6 +84,7 @@ type BrowserNavigationController = {
     params: Record<string, string | string[]>;
     pendingRouterState: PendingBrowserRouterState | null;
     previousNextUrl: string | null;
+    requireCacheEntryReuseProof?: boolean;
     targetHistoryIndex?: number | null;
     targetHref: string;
     navId: number;
@@ -495,6 +496,7 @@ export function createAppBrowserNavigationController(
     params: Record<string, string | string[]>;
     pendingRouterState: PendingBrowserRouterState | null;
     previousNextUrl: string | null;
+    requireCacheEntryReuseProof?: boolean;
     targetHistoryIndex?: number | null;
     targetHref: string;
     navId: number;
@@ -516,6 +518,7 @@ export function createAppBrowserNavigationController(
         operationLane: options.operationLane,
         previousNextUrl: options.previousNextUrl,
         renderId,
+        requireCacheEntryReuseProof: options.requireCacheEntryReuseProof,
         type: options.actionType,
       });
 

--- a/packages/vinext/src/server/app-browser-state.ts
+++ b/packages/vinext/src/server/app-browser-state.ts
@@ -150,7 +150,7 @@ function createOperationRecord(options: {
 
 export function isCacheRestorableAppPayloadMetadata(
   metadata: CacheRestorableAppPayloadMetadata,
-): boolean {
+): metadata is Required<CacheRestorableAppPayloadMetadata> {
   return metadata.cacheEntryReuseProof !== undefined;
 }
 

--- a/packages/vinext/src/server/app-browser-state.ts
+++ b/packages/vinext/src/server/app-browser-state.ts
@@ -105,6 +105,17 @@ export type PendingNavigationCommit = {
   routeId: string;
 };
 
+export type AppNavigationPayloadOrigin = Readonly<
+  { origin: "fresh" } | { origin: "visited-cache" }
+>;
+
+export const FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN: AppNavigationPayloadOrigin = {
+  origin: "fresh",
+};
+export const VISITED_CACHE_APP_NAVIGATION_PAYLOAD_ORIGIN: AppNavigationPayloadOrigin = {
+  origin: "visited-cache",
+};
+
 type PendingNavigationCommitDisposition = "dispatch" | "hard-navigate" | "skip";
 type CacheRestorableAppPayloadMetadata = Readonly<{
   cacheEntryReuseProof?: CacheEntryReuseProof;
@@ -141,6 +152,19 @@ export function isCacheRestorableAppPayloadMetadata(
   metadata: CacheRestorableAppPayloadMetadata,
 ): boolean {
   return metadata.cacheEntryReuseProof !== undefined;
+}
+
+function requiresCacheEntryReuseProof(origin: AppNavigationPayloadOrigin): boolean {
+  switch (origin.origin) {
+    case "fresh":
+      return false;
+    case "visited-cache":
+      return true;
+    default: {
+      const _exhaustive: never = origin;
+      throw new Error("[vinext] Unknown App Router payload origin: " + String(_exhaustive));
+    }
+  }
 }
 
 function normalizeNavigationSnapshotMatchedUrl(pathname: string): string {
@@ -433,18 +457,20 @@ export async function createPendingNavigationCommit(options: {
   nextElements: Promise<AppElements>;
   navigationSnapshot: ClientNavigationRenderSnapshot;
   operationLane: OperationLane;
+  payloadOrigin: AppNavigationPayloadOrigin;
   // Advisory: non-intercepted responses clear this even when callers pass the
   // current visible previousNextUrl.
   previousNextUrl?: string | null;
   renderId: number;
-  requireCacheEntryReuseProof?: boolean;
   type: "navigate" | "replace" | "traverse";
 }): Promise<PendingNavigationCommit> {
   const elements = await options.nextElements;
   const metadata = AppElementsWire.readMetadata(elements);
   const cacheEntryReuseProof =
     metadata.cacheEntryReuseProof ??
-    (options.requireCacheEntryReuseProof ? createCacheEntryReuseProof(null) : undefined);
+    (requiresCacheEntryReuseProof(options.payloadOrigin)
+      ? createCacheEntryReuseProof(null)
+      : undefined);
   const requestedPreviousNextUrl =
     options.previousNextUrl !== undefined
       ? options.previousNextUrl

--- a/packages/vinext/src/server/app-browser-state.ts
+++ b/packages/vinext/src/server/app-browser-state.ts
@@ -150,7 +150,7 @@ function createOperationRecord(options: {
 
 export function isCacheRestorableAppPayloadMetadata(
   metadata: CacheRestorableAppPayloadMetadata,
-): metadata is Required<CacheRestorableAppPayloadMetadata> {
+): metadata is CacheRestorableAppPayloadMetadata & { cacheEntryReuseProof: CacheEntryReuseProof } {
   return metadata.cacheEntryReuseProof !== undefined;
 }
 
@@ -394,8 +394,7 @@ function planPendingRootBoundaryFlightResponse(options: {
     routeManifest: options.routeManifest,
     targetSnapshot,
   });
-  const cacheEntryReuseProof =
-    options.pending.cacheEntryReuseProof ?? options.pending.action.cacheEntryReuseProof;
+  const cacheEntryReuseProof = options.pending.cacheEntryReuseProof;
 
   // #726-CORE-07/08 keeps the browser state layer as the lifecycle gate and
   // only translates committed AppElements metadata into planner snapshots.

--- a/packages/vinext/src/server/app-browser-state.ts
+++ b/packages/vinext/src/server/app-browser-state.ts
@@ -106,6 +106,9 @@ export type PendingNavigationCommit = {
 };
 
 type PendingNavigationCommitDisposition = "dispatch" | "hard-navigate" | "skip";
+type CacheRestorableAppPayloadMetadata = Readonly<{
+  cacheEntryReuseProof?: CacheEntryReuseProof;
+}>;
 type DispatchPendingNavigationCommitDispositionDecision = {
   disposition: "dispatch";
   preserveAbsentSlots: boolean;
@@ -132,6 +135,12 @@ function createOperationRecord(options: {
     startedVisibleCommitVersion: options.startedVisibleCommitVersion,
     state: "pending",
   };
+}
+
+export function isCacheRestorableAppPayloadMetadata(
+  metadata: CacheRestorableAppPayloadMetadata,
+): boolean {
+  return metadata.cacheEntryReuseProof !== undefined;
 }
 
 function normalizeNavigationSnapshotMatchedUrl(pathname: string): string {

--- a/packages/vinext/src/server/app-browser-state.ts
+++ b/packages/vinext/src/server/app-browser-state.ts
@@ -22,6 +22,7 @@ import {
   type NavigationTrace,
   type NavigationTraceFields,
 } from "./navigation-trace.js";
+import { createCacheEntryReuseProof, type CacheEntryReuseProof } from "./cache-proof.js";
 import {
   navigationPlanner,
   type MountedParallelSlotSnapshotV0,
@@ -78,6 +79,7 @@ export type AppRouterState = {
 };
 
 export type AppRouterAction = {
+  cacheEntryReuseProof?: CacheEntryReuseProof;
   elements: AppElements;
   interception: AppElementsInterception | null;
   interceptionContext: string | null;
@@ -95,6 +97,7 @@ export type AppRouterAction = {
 
 export type PendingNavigationCommit = {
   action: AppRouterAction;
+  cacheEntryReuseProof?: CacheEntryReuseProof;
   interception: AppElementsInterception | null;
   interceptionContext: string | null;
   previousNextUrl: string | null;
@@ -358,6 +361,8 @@ function planPendingRootBoundaryFlightResponse(options: {
     routeManifest: options.routeManifest,
     targetSnapshot,
   });
+  const cacheEntryReuseProof =
+    options.pending.cacheEntryReuseProof ?? options.pending.action.cacheEntryReuseProof;
 
   // #726-CORE-07/08 keeps the browser state layer as the lifecycle gate and
   // only translates committed AppElements metadata into planner snapshots.
@@ -374,6 +379,7 @@ function planPendingRootBoundaryFlightResponse(options: {
     event: {
       kind: "flightResponseArrived",
       result: {
+        ...(cacheEntryReuseProof ? { cacheEntryReuseProof } : {}),
         // Approval call sites must pass the executor's targetHref so the
         // planner trace and future hard-nav executor agree with the browser
         // URL. The fallback remains for lower-level tests and direct disposition
@@ -422,10 +428,14 @@ export async function createPendingNavigationCommit(options: {
   // current visible previousNextUrl.
   previousNextUrl?: string | null;
   renderId: number;
+  requireCacheEntryReuseProof?: boolean;
   type: "navigate" | "replace" | "traverse";
 }): Promise<PendingNavigationCommit> {
   const elements = await options.nextElements;
   const metadata = AppElementsWire.readMetadata(elements);
+  const cacheEntryReuseProof =
+    metadata.cacheEntryReuseProof ??
+    (options.requireCacheEntryReuseProof ? createCacheEntryReuseProof(null) : undefined);
   const requestedPreviousNextUrl =
     options.previousNextUrl !== undefined
       ? options.previousNextUrl
@@ -434,6 +444,7 @@ export async function createPendingNavigationCommit(options: {
 
   return {
     action: {
+      ...(cacheEntryReuseProof ? { cacheEntryReuseProof } : {}),
       elements,
       interception: metadata.interception,
       interceptionContext: metadata.interceptionContext,
@@ -452,7 +463,8 @@ export async function createPendingNavigationCommit(options: {
       routeId: metadata.routeId,
       type: options.type,
     },
-    // Convenience aliases — always equal action.interceptionContext / action.rootLayoutTreePath / action.routeId.
+    // Convenience aliases — always equal their action.* counterparts.
+    ...(cacheEntryReuseProof ? { cacheEntryReuseProof } : {}),
     interception: metadata.interception,
     interceptionContext: metadata.interceptionContext,
     previousNextUrl,

--- a/packages/vinext/src/server/app-browser-visible-commit.ts
+++ b/packages/vinext/src/server/app-browser-visible-commit.ts
@@ -9,6 +9,7 @@ import {
 import {
   createPendingNavigationCommit,
   resolvePendingNavigationCommitDispositionDecision,
+  type AppNavigationPayloadOrigin,
   type AppRouterAction,
   type AppRouterState,
   type CommittedOperationRecord,
@@ -405,6 +406,7 @@ export async function resolveAndClassifyNavigationCommit(options: {
   navigationSnapshot: ClientNavigationRenderSnapshot;
   nextElements: Promise<AppElements>;
   operationLane: OperationLane;
+  payloadOrigin: AppNavigationPayloadOrigin;
   previousNextUrl?: string | null;
   renderId: number;
   routeManifest?: RouteManifest | null;
@@ -417,6 +419,7 @@ export async function resolveAndClassifyNavigationCommit(options: {
     nextElements: options.nextElements,
     navigationSnapshot: options.navigationSnapshot,
     operationLane: options.operationLane,
+    payloadOrigin: options.payloadOrigin,
     previousNextUrl: options.previousNextUrl,
     renderId: options.renderId,
     type: options.type,

--- a/packages/vinext/src/server/app-elements-wire.ts
+++ b/packages/vinext/src/server/app-elements-wire.ts
@@ -677,6 +677,9 @@ function parseCacheEntryReuseProofMetadata(value: unknown): CacheEntryReuseProof
     decision.kind === "reuse" &&
     decision.canReuse === true &&
     decision.code === "CP_STATIC_LAYOUT_REUSE_PROVEN" &&
+    // Static layout proofs are the only runtime cache-entry reuse class today.
+    // Extend this parser alongside any new reuse class before it can restore
+    // visited cache entries as commit-capable payloads.
     decision.reuseClass === "static-layout"
   ) {
     return {

--- a/packages/vinext/src/server/app-elements-wire.ts
+++ b/packages/vinext/src/server/app-elements-wire.ts
@@ -4,12 +4,19 @@ import {
   parseArtifactCompatibilityEnvelope,
   type ArtifactCompatibilityEnvelope,
 } from "./artifact-compatibility.js";
-import type { RenderObservation } from "./cache-proof.js";
+import type {
+  CacheEntryReuseProof,
+  CacheProofBreakerFallbackMode,
+  CacheProofFallbackScope,
+  CacheProofRejectionCode,
+  RenderObservation,
+} from "./cache-proof.js";
 import { isInterceptionMatchedUrlPath } from "./normalize-path.js";
 
 const APP_INTERCEPTION_SEPARATOR = "\0";
 
 export const APP_ARTIFACT_COMPATIBILITY_KEY = "__artifactCompatibility";
+export const APP_CACHE_ENTRY_REUSE_PROOF_KEY = "__cacheEntryReuseProof";
 export const APP_INTERCEPTION_KEY = "__interception";
 export const APP_INTERCEPTION_CONTEXT_KEY = "__interceptionContext";
 export const APP_LAYOUT_IDS_KEY = "__layoutIds";
@@ -21,6 +28,38 @@ export const APP_SLOT_BINDINGS_KEY = "__slotBindings";
 export const APP_UNMATCHED_SLOT_WIRE_VALUE = "__VINEXT_UNMATCHED_SLOT__";
 
 export const UNMATCHED_SLOT = Symbol.for("vinext.unmatchedSlot");
+
+const CACHE_PROOF_REJECTION_CODES: ReadonlySet<string> = new Set([
+  "CP_CACHE_ENTRY_PROOF_MISSING",
+  "CP_MODEL_DISABLED",
+  "CP_ARTIFACT_COMPATIBILITY_INCOMPATIBLE",
+  "CP_ARTIFACT_COMPATIBILITY_UNKNOWN",
+  "CP_DIMENSION_COUNT_EXCEEDED",
+  "CP_DIMENSION_NAME_MISSING",
+  "CP_DIMENSION_NAME_TOO_LONG",
+  "CP_DIMENSION_VALUE_COUNT_EXCEEDED",
+  "CP_DIMENSION_VALUE_TOO_LONG",
+  "CP_DIMENSION_VALUES_MISSING",
+  "CP_ENCODED_VARIANT_TOO_LONG",
+  "CP_INVALID_VARIANT_BUDGET",
+  "CP_ROUTE_VARIANT_BUDGET_ROUTE_MISMATCH",
+  "CP_ROUTE_VARIANT_CEILING_EXCEEDED",
+  "CP_UNSAFE_PUBLIC_DIMENSION",
+  "CP_BOUNDARY_OUTCOME_MISMATCH",
+  "CP_BOUNDARY_OUTCOME_UNKNOWN",
+  "CP_PRIVATE_DYNAMIC_DOWNGRADE",
+  "CP_STATIC_LAYOUT_CANDIDATE_OUTPUT_KIND",
+  "CP_STATIC_LAYOUT_CURRENT_OUTPUT_KIND",
+  "CP_STATIC_LAYOUT_ID_MISMATCH",
+  "CP_STATIC_LAYOUT_OBSERVATION_OUTPUT_KIND",
+  "CP_STATIC_LAYOUT_OBSERVATION_OUTPUT_MISMATCH",
+  "CP_STATIC_LAYOUT_PRIVATE_DYNAMIC_DOWNGRADE",
+  "CP_STATIC_LAYOUT_REQUEST_API_OBSERVED",
+  "CP_STATIC_LAYOUT_REQUEST_API_UNKNOWN",
+  "CP_STATIC_LAYOUT_ROOT_BOUNDARY_MISMATCH",
+  "CP_STATIC_LAYOUT_ROOT_BOUNDARY_UNKNOWN",
+  "CP_STATIC_LAYOUT_VARIANT_DIMENSION_UNPROVEN",
+] satisfies readonly CacheProofRejectionCode[]);
 
 export type AppElementsSlotBindingState = "active" | "default" | "unmatched";
 
@@ -88,6 +127,7 @@ export type AppElementValue =
   | null
   | LayoutFlags
   | ArtifactCompatibilityEnvelope
+  | CacheEntryReuseProof
   | AppElementsInterception
   | readonly AppElementsSlotBinding[];
 type AppWireElementValue =
@@ -96,6 +136,7 @@ type AppWireElementValue =
   | null
   | LayoutFlags
   | ArtifactCompatibilityEnvelope
+  | CacheEntryReuseProof
   | AppElementsInterception
   | readonly AppElementsSlotBinding[];
 
@@ -123,6 +164,7 @@ export type LayoutFlags = Readonly<Record<string, "s" | "d">>;
 
 type AppElementsMetadata = {
   artifactCompatibility: ArtifactCompatibilityEnvelope;
+  cacheEntryReuseProof?: CacheEntryReuseProof;
   interception: AppElementsInterception | null;
   interceptionContext: string | null;
   layoutIds: readonly string[];
@@ -169,6 +211,7 @@ export type AppOutgoingElements = Readonly<
     | ReactNode
     | LayoutFlags
     | ArtifactCompatibilityEnvelope
+    | CacheEntryReuseProof
     | AppElementsInterception
     | RenderObservation
     | readonly AppElementsSlotBinding[]
@@ -177,6 +220,7 @@ export type AppOutgoingElements = Readonly<
 
 type AppElementsWireKeys = {
   readonly artifactCompatibility: typeof APP_ARTIFACT_COMPATIBILITY_KEY;
+  readonly cacheEntryReuseProof: typeof APP_CACHE_ENTRY_REUSE_PROOF_KEY;
   readonly interception: typeof APP_INTERCEPTION_KEY;
   readonly interceptionContext: typeof APP_INTERCEPTION_CONTEXT_KEY;
   readonly layoutIds: typeof APP_LAYOUT_IDS_KEY;
@@ -201,6 +245,7 @@ type AppElementsWireCodec = {
           Record<string, ReactNode | AppElementsInterception | readonly AppElementsSlotBinding[]>
         >;
     artifactCompatibility?: ArtifactCompatibilityEnvelope;
+    cacheEntryReuseProof?: CacheEntryReuseProof;
     layoutFlags: LayoutFlags;
     renderObservation?: RenderObservation;
   }): ReactNode | AppOutgoingElements;
@@ -545,6 +590,7 @@ export function buildOutgoingAppPayload(input: {
         Record<string, ReactNode | AppElementsInterception | readonly AppElementsSlotBinding[]>
       >;
   artifactCompatibility?: ArtifactCompatibilityEnvelope;
+  cacheEntryReuseProof?: CacheEntryReuseProof;
   layoutFlags: LayoutFlags;
   renderObservation?: RenderObservation;
 }): ReactNode | AppOutgoingElements {
@@ -556,6 +602,7 @@ export function buildOutgoingAppPayload(input: {
     | ReactNode
     | LayoutFlags
     | ArtifactCompatibilityEnvelope
+    | CacheEntryReuseProof
     | AppElementsInterception
     | RenderObservation
     | readonly AppElementsSlotBinding[]
@@ -565,6 +612,9 @@ export function buildOutgoingAppPayload(input: {
     [APP_ARTIFACT_COMPATIBILITY_KEY]:
       input.artifactCompatibility ?? createArtifactCompatibilityEnvelope(),
   };
+  if (input.cacheEntryReuseProof) {
+    payload[APP_CACHE_ENTRY_REUSE_PROOF_KEY] = input.cacheEntryReuseProof;
+  }
   if (input.renderObservation) {
     payload[APP_RENDER_OBSERVATION_KEY] = input.renderObservation;
   }
@@ -580,6 +630,74 @@ function readArtifactCompatibilityMetadata(value: unknown): ArtifactCompatibilit
   // emitted as scaffolding, so bad or future-version values degrade like
   // missing __layoutFlags instead of crashing render paths that do not read it.
   return artifactCompatibility ?? createArtifactCompatibilityEnvelope();
+}
+
+function createMissingCacheEntryReuseProof(): CacheEntryReuseProof {
+  return {
+    kind: "runtime-cache-entry",
+    decision: null,
+  };
+}
+
+function isCacheProofRejectionCode(value: unknown): value is CacheProofRejectionCode {
+  return typeof value === "string" && CACHE_PROOF_REJECTION_CODES.has(value);
+}
+
+function isCacheProofFallbackMode(value: unknown): value is CacheProofBreakerFallbackMode {
+  return value === "renderFresh" || value === "privateUncacheable";
+}
+
+function isCacheProofFallbackScope(value: unknown): value is CacheProofFallbackScope {
+  return value === "affectedOutput" || value === "route";
+}
+
+function parseCacheEntryReuseProofMetadata(value: unknown): CacheEntryReuseProof | null {
+  if (value === undefined) return null;
+  if (!isRecord(value) || value.kind !== "runtime-cache-entry") {
+    return createMissingCacheEntryReuseProof();
+  }
+
+  const decision = value.decision;
+  if (decision === null) return createMissingCacheEntryReuseProof();
+  if (!isRecord(decision)) return createMissingCacheEntryReuseProof();
+
+  if (
+    decision.kind === "reuse" &&
+    decision.canReuse === true &&
+    decision.code === "CP_STATIC_LAYOUT_REUSE_PROVEN" &&
+    decision.reuseClass === "static-layout"
+  ) {
+    return {
+      kind: "runtime-cache-entry",
+      decision: {
+        canReuse: true,
+        code: decision.code,
+        kind: "reuse",
+        reuseClass: decision.reuseClass,
+      },
+    };
+  }
+
+  if (
+    decision.kind === "reject" &&
+    decision.canReuse === false &&
+    isCacheProofRejectionCode(decision.code) &&
+    isCacheProofFallbackMode(decision.mode) &&
+    isCacheProofFallbackScope(decision.scope)
+  ) {
+    return {
+      kind: "runtime-cache-entry",
+      decision: {
+        canReuse: false,
+        code: decision.code,
+        kind: "reject",
+        mode: decision.mode,
+        scope: decision.scope,
+      },
+    };
+  }
+
+  return createMissingCacheEntryReuseProof();
 }
 
 export function readAppElementsMetadata(
@@ -614,9 +732,13 @@ export function readAppElementsMetadata(
   const artifactCompatibility = readArtifactCompatibilityMetadata(
     elements[APP_ARTIFACT_COMPATIBILITY_KEY],
   );
+  const cacheEntryReuseProof = parseCacheEntryReuseProofMetadata(
+    elements[APP_CACHE_ENTRY_REUSE_PROOF_KEY],
+  );
 
   return {
     artifactCompatibility,
+    ...(cacheEntryReuseProof ? { cacheEntryReuseProof } : {}),
     interception,
     interceptionContext: interceptionContext ?? null,
     layoutIds,
@@ -632,6 +754,7 @@ export const AppElementsWire: AppElementsWireCodec = {
   // behind the codec boundary.
   keys: {
     artifactCompatibility: APP_ARTIFACT_COMPATIBILITY_KEY,
+    cacheEntryReuseProof: APP_CACHE_ENTRY_REUSE_PROOF_KEY,
     interception: APP_INTERCEPTION_KEY,
     interceptionContext: APP_INTERCEPTION_CONTEXT_KEY,
     layoutIds: APP_LAYOUT_IDS_KEY,

--- a/packages/vinext/src/server/app-elements-wire.ts
+++ b/packages/vinext/src/server/app-elements-wire.ts
@@ -663,6 +663,10 @@ function isCacheProofFallbackScope(value: unknown): value is CacheProofFallbackS
   return value === "affectedOutput" || value === "route";
 }
 
+// Three-way wire semantics are intentional:
+// - null means the proof field was absent and no cache authority was claimed.
+// - { decision: null } means a present proof was malformed or unusable.
+// - { decision: ... } means the proof parsed into an explicit reuse decision.
 function parseCacheEntryReuseProofMetadata(value: unknown): CacheEntryReuseProof | null {
   if (value === undefined) return null;
   if (!isRecord(value) || value.kind !== "runtime-cache-entry") {

--- a/packages/vinext/src/server/app-elements-wire.ts
+++ b/packages/vinext/src/server/app-elements-wire.ts
@@ -29,7 +29,19 @@ export const APP_UNMATCHED_SLOT_WIRE_VALUE = "__VINEXT_UNMATCHED_SLOT__";
 
 export const UNMATCHED_SLOT = Symbol.for("vinext.unmatchedSlot");
 
-const CACHE_PROOF_REJECTION_CODES: ReadonlySet<string> = new Set([
+function createCacheProofRejectionCodeSet<const T extends readonly CacheProofRejectionCode[]>(
+  codes: T &
+    ([CacheProofRejectionCode] extends [T[number]]
+      ? unknown
+      : readonly [
+          "Missing cache proof rejection codes",
+          Exclude<CacheProofRejectionCode, T[number]>,
+        ]),
+): ReadonlySet<string> {
+  return new Set(codes);
+}
+
+const CACHE_PROOF_REJECTION_CODES = createCacheProofRejectionCodeSet([
   "CP_CACHE_ENTRY_PROOF_MISSING",
   "CP_MODEL_DISABLED",
   "CP_ARTIFACT_COMPATIBILITY_INCOMPATIBLE",
@@ -59,7 +71,7 @@ const CACHE_PROOF_REJECTION_CODES: ReadonlySet<string> = new Set([
   "CP_STATIC_LAYOUT_ROOT_BOUNDARY_MISMATCH",
   "CP_STATIC_LAYOUT_ROOT_BOUNDARY_UNKNOWN",
   "CP_STATIC_LAYOUT_VARIANT_DIMENSION_UNPROVEN",
-] satisfies readonly CacheProofRejectionCode[]);
+]);
 
 export type AppElementsSlotBindingState = "active" | "default" | "unmatched";
 

--- a/packages/vinext/src/server/app-elements.ts
+++ b/packages/vinext/src/server/app-elements.ts
@@ -4,6 +4,7 @@ import { AppElementsWire, UNMATCHED_SLOT, type AppElements } from "./app-element
 export {
   AppElementsWire,
   APP_ARTIFACT_COMPATIBILITY_KEY,
+  APP_CACHE_ENTRY_REUSE_PROOF_KEY,
   APP_INTERCEPTION_KEY,
   APP_INTERCEPTION_CONTEXT_KEY,
   APP_LAYOUT_IDS_KEY,

--- a/packages/vinext/src/server/cache-proof.ts
+++ b/packages/vinext/src/server/cache-proof.ts
@@ -11,6 +11,7 @@ export const CACHE_PROOF_MODEL_SCHEMA_VERSION = 1;
 export type CacheProofModelSchemaVersion = 1;
 
 export type CacheProofRejectionCode =
+  | "CP_CACHE_ENTRY_PROOF_MISSING"
   | "CP_MODEL_DISABLED"
   | "CP_ARTIFACT_COMPATIBILITY_INCOMPATIBLE"
   | "CP_ARTIFACT_COMPATIBILITY_UNKNOWN"
@@ -395,6 +396,26 @@ export type StaticLayoutArtifactReuseDecision =
       kind: "fallback";
       metric: CacheProofHotPathMetric;
     }>;
+
+export type CacheEntryReuseDecision =
+  | Readonly<{
+      canReuse: true;
+      code: CacheProofAcceptanceCode;
+      kind: "reuse";
+      reuseClass: StaticLayoutReuseProof["reuseClass"];
+    }>
+  | Readonly<{
+      canReuse: false;
+      code: CacheProofRejectionCode;
+      kind: "reject";
+      mode: CacheProofBreakerFallbackMode;
+      scope: CacheProofFallbackScope;
+    }>;
+
+export type CacheEntryReuseProof = Readonly<{
+  decision: CacheEntryReuseDecision | null;
+  kind: "runtime-cache-entry";
+}>;
 
 export type CreateStaticLayoutArtifactReuseDecisionInput = Readonly<{
   candidateArtifactCompatibility: ArtifactCompatibilityEnvelope;
@@ -1531,6 +1552,43 @@ export function createStaticLayoutArtifactReuseDecision(
     proof: proof.proof,
     metric: createCacheProofHotPathMetric("reuse", proof.proof.code, proof.proof.fields),
   };
+}
+
+export function createCacheEntryReuseProof(
+  decision: StaticLayoutArtifactReuseDecision | null,
+): CacheEntryReuseProof {
+  if (decision === null) {
+    return {
+      kind: "runtime-cache-entry",
+      decision: null,
+    };
+  }
+
+  switch (decision.kind) {
+    case "reuse":
+      return {
+        kind: "runtime-cache-entry",
+        decision: {
+          canReuse: true,
+          code: decision.proof.code,
+          kind: "reuse",
+          reuseClass: decision.proof.reuseClass,
+        },
+      };
+    case "fallback":
+      return {
+        kind: "runtime-cache-entry",
+        decision: {
+          canReuse: false,
+          code: decision.fallback.code,
+          kind: "reject",
+          mode: decision.fallback.mode,
+          scope: decision.fallback.scope,
+        },
+      };
+    default:
+      return assertNever(decision);
+  }
 }
 
 export function createDisabledCacheProofDecision(

--- a/packages/vinext/src/server/navigation-planner.ts
+++ b/packages/vinext/src/server/navigation-planner.ts
@@ -6,6 +6,11 @@ import type {
   RouteManifestRoute,
 } from "../routing/app-route-graph.js";
 import { compareAppElementsSlotIds, type AppElementsSlotBinding } from "./app-elements.js";
+import type {
+  CacheEntryReuseDecision,
+  CacheEntryReuseProof,
+  CacheProofRejectionCode,
+} from "./cache-proof.js";
 import {
   NavigationTraceReasonCodes,
   createNavigationLifecycleTraceFields,
@@ -96,6 +101,7 @@ export type RequestedWork =
   | { kind: "prefetch"; href: string };
 
 export type CommitProposal = {
+  cacheEntryReuseDecision?: AcceptedCacheEntryReuseDecision;
   preserveAbsentSlots: boolean;
   preserveElementIds: readonly string[];
   preservePreviousSlotIds: readonly string[];
@@ -104,7 +110,10 @@ export type CommitProposal = {
 };
 
 export type NoCommitReason = "prefetchOnly";
-export type HardNavigationReason = "interceptionProofRejected" | "rootBoundaryChanged";
+export type HardNavigationReason =
+  | "cacheProofRejected"
+  | "interceptionProofRejected"
+  | "rootBoundaryChanged";
 export type RootBoundaryTransition =
   | "currentRootBoundary"
   | "rootBoundaryChanged"
@@ -138,6 +147,7 @@ export type NavigationDecisionV0 =
     };
 
 export type FlightResultV0 = {
+  cacheEntryReuseProof?: CacheEntryReuseProof;
   href: string;
   targetSnapshot: RouteSnapshotV0;
 };
@@ -168,8 +178,21 @@ type RouteTopologyResolution =
     };
 
 type RouteTopologySlotBindingSource = "snapshot" | "manifestTarget";
+type AcceptedCacheEntryReuseDecision = Extract<CacheEntryReuseDecision, { canReuse: true }>;
+type RejectedCacheEntryReuseDecision = Extract<CacheEntryReuseDecision, { canReuse: false }>;
+type CacheEntryProofEvaluation =
+  | Readonly<{
+      decision: AcceptedCacheEntryReuseDecision | null;
+      kind: "accepted";
+    }>
+  | Readonly<{
+      decision: RejectedCacheEntryReuseDecision | null;
+      kind: "rejected";
+    }>;
 
 const ROUTE_INTERCEPTION_CONTEXT_SEPARATOR = "\0";
+const CACHE_ENTRY_PROOF_MISSING_CODE =
+  "CP_CACHE_ENTRY_PROOF_MISSING" satisfies CacheProofRejectionCode;
 
 function createRequestWorkDecision(options: {
   eventKind: NavigationEvent["kind"];
@@ -604,6 +627,93 @@ function createInterceptionProofRejectedDecision(options: {
   };
 }
 
+function evaluateCacheEntryReuseProof(
+  proof: CacheEntryReuseProof | undefined,
+): CacheEntryProofEvaluation {
+  if (proof === undefined) {
+    return {
+      kind: "accepted",
+      decision: null,
+    };
+  }
+
+  if (proof.decision === null) {
+    return {
+      kind: "rejected",
+      decision: null,
+    };
+  }
+
+  if (proof.decision.canReuse) {
+    return {
+      kind: "accepted",
+      decision: proof.decision,
+    };
+  }
+
+  return {
+    kind: "rejected",
+    decision: proof.decision,
+  };
+}
+
+function createCacheProofRejectedTraceFields(
+  traceFields: NavigationTraceFields,
+  decision: RejectedCacheEntryReuseDecision | null,
+): NavigationTraceFields {
+  if (decision === null) {
+    return {
+      ...traceFields,
+      cacheProofCode: CACHE_ENTRY_PROOF_MISSING_CODE,
+    };
+  }
+
+  return {
+    ...traceFields,
+    cacheProofCode: decision.code,
+    cacheProofMode: decision.mode,
+    cacheProofScope: decision.scope,
+  };
+}
+
+function createCacheProofRejectedDecision(options: {
+  event: Extract<NavigationEvent, { kind: "flightResponseArrived" }>;
+  rejection: Extract<CacheEntryProofEvaluation, { kind: "rejected" }>;
+  traceFields: NavigationTraceFields;
+}): NavigationDecisionV0 {
+  return {
+    kind: "hardNavigate",
+    reason: "cacheProofRejected",
+    token: options.event.token,
+    trace: createNavigationTrace(
+      NavigationTraceReasonCodes.cacheProofRejected,
+      createCacheProofRejectedTraceFields(options.traceFields, options.rejection.decision),
+    ),
+    url: options.event.result.href,
+  };
+}
+
+function createAcceptedCacheProofTraceFields(
+  traceFields: NavigationTraceFields,
+  decision: AcceptedCacheEntryReuseDecision | null,
+): NavigationTraceFields {
+  if (decision === null) return traceFields;
+  return {
+    ...traceFields,
+    cacheProofCode: decision.code,
+    cacheProofReuseClass: decision.reuseClass,
+  };
+}
+
+function createCacheEntryProposalFields(
+  decision: AcceptedCacheEntryReuseDecision | null,
+): Pick<CommitProposal, "cacheEntryReuseDecision"> {
+  if (decision === null) return {};
+  return {
+    cacheEntryReuseDecision: decision,
+  };
+}
+
 function validateInterceptedPreservation(options: {
   currentSnapshot: RouteSnapshotV0;
   currentTopology: RouteTopologySnapshot;
@@ -731,6 +841,23 @@ function planFlightResponseArrived(options: {
     };
   }
 
+  const cacheEntryProofEvaluation = evaluateCacheEntryReuseProof(
+    options.event.result.cacheEntryReuseProof,
+  );
+  if (cacheEntryProofEvaluation.kind === "rejected") {
+    return createCacheProofRejectedDecision({
+      event: options.event,
+      rejection: cacheEntryProofEvaluation,
+      traceFields,
+    });
+  }
+  const acceptedCacheEntryDecision = cacheEntryProofEvaluation.decision;
+  const commitTraceFields = createAcceptedCacheProofTraceFields(
+    traceFields,
+    acceptedCacheEntryDecision,
+  );
+  const cacheEntryProposalFields = createCacheEntryProposalFields(acceptedCacheEntryDecision);
+
   // interceptionContext is transport evidence, not authority. Normal payloads
   // can carry it when a request was sent from an intercepted visible world, so
   // only explicit __interception proof enters the preservation branch.
@@ -762,6 +889,7 @@ function planFlightResponseArrived(options: {
     return {
       kind: "proposeCommit",
       proposal: {
+        ...cacheEntryProposalFields,
         preserveAbsentSlots: false,
         preserveElementIds: validation.preserveElementIds,
         preservePreviousSlotIds: validation.preservePreviousSlotIds,
@@ -771,7 +899,7 @@ function planFlightResponseArrived(options: {
       token: options.event.token,
       trace: createNavigationTrace(
         NavigationTraceReasonCodes.interceptedCommitCurrent,
-        traceFields,
+        commitTraceFields,
       ),
     };
   }
@@ -801,6 +929,7 @@ function planFlightResponseArrived(options: {
     return {
       kind: "proposeCommit",
       proposal: {
+        ...cacheEntryProposalFields,
         preserveAbsentSlots: false,
         preserveElementIds: [],
         preservePreviousSlotIds: [],
@@ -808,7 +937,10 @@ function planFlightResponseArrived(options: {
         targetSnapshot,
       },
       token: options.event.token,
-      trace: createNavigationTrace(NavigationTraceReasonCodes.rootBoundaryUnknown, traceFields),
+      trace: createNavigationTrace(
+        NavigationTraceReasonCodes.rootBoundaryUnknown,
+        commitTraceFields,
+      ),
     };
   }
 
@@ -819,6 +951,7 @@ function planFlightResponseArrived(options: {
   return {
     kind: "proposeCommit",
     proposal: {
+      ...cacheEntryProposalFields,
       preserveAbsentSlots: false,
       preserveElementIds: resolveCurrentRootBoundaryCommitElementPersistence({
         currentTopology: currentTopology.topology,
@@ -834,7 +967,7 @@ function planFlightResponseArrived(options: {
       targetSnapshot,
     },
     token: options.event.token,
-    trace: createNavigationTrace(NavigationTraceReasonCodes.commitCurrent, traceFields),
+    trace: createNavigationTrace(NavigationTraceReasonCodes.commitCurrent, commitTraceFields),
   };
 }
 

--- a/packages/vinext/src/server/navigation-planner.ts
+++ b/packages/vinext/src/server/navigation-planner.ts
@@ -867,7 +867,7 @@ function planFlightResponseArrived(options: {
       return createInterceptionProofRejectedDecision({
         event: options.event,
         reasonCode: NavigationTraceReasonCodes.interceptedRejectedUndeclaredTopology,
-        traceFields,
+        traceFields: commitTraceFields,
       });
     }
 
@@ -882,7 +882,7 @@ function planFlightResponseArrived(options: {
       return createInterceptionProofRejectedDecision({
         event: options.event,
         reasonCode: validation.reasonCode,
-        traceFields,
+        traceFields: commitTraceFields,
       });
     }
 
@@ -917,7 +917,10 @@ function planFlightResponseArrived(options: {
       kind: "hardNavigate",
       reason: "rootBoundaryChanged",
       token: options.event.token,
-      trace: createNavigationTrace(NavigationTraceReasonCodes.rootBoundaryChanged, traceFields),
+      trace: createNavigationTrace(
+        NavigationTraceReasonCodes.rootBoundaryChanged,
+        commitTraceFields,
+      ),
       url: options.event.result.href,
     };
   }

--- a/packages/vinext/src/server/navigation-trace.ts
+++ b/packages/vinext/src/server/navigation-trace.ts
@@ -3,6 +3,7 @@ export const NAVIGATION_TRACE_SCHEMA_VERSION = 0;
 export type NavigationTraceSchemaVersion = 0;
 
 export const NavigationTraceReasonCodes = {
+  cacheProofRejected: "NC_CACHE_REJECT",
   commitCurrent: "NC_COMMIT",
   interceptedCommitCurrent: "NC_INTERCEPT_COMMIT",
   interceptedRejectedIncompatibleRoot: "NC_INTERCEPT_REJECT_ROOT",
@@ -17,6 +18,7 @@ export const NavigationTraceReasonCodes = {
   rootBoundaryUnknown: "NC_ROOT_UNKNOWN",
   staleOperation: "NC_STALE",
 } satisfies Readonly<{
+  cacheProofRejected: "NC_CACHE_REJECT";
   commitCurrent: "NC_COMMIT";
   interceptedCommitCurrent: "NC_INTERCEPT_COMMIT";
   interceptedRejectedIncompatibleRoot: "NC_INTERCEPT_REJECT_ROOT";
@@ -52,6 +54,10 @@ export type NavigationTraceCode = NavigationTraceReasonCode | NavigationTraceTra
 
 export type NavigationTraceFieldName =
   | "activeNavigationId"
+  | "cacheProofCode"
+  | "cacheProofMode"
+  | "cacheProofReuseClass"
+  | "cacheProofScope"
   | "currentRootLayoutTreePath"
   | "currentVisibleCommitVersion"
   | "nextRootLayoutTreePath"

--- a/packages/vinext/src/shims/slot.tsx
+++ b/packages/vinext/src/shims/slot.tsx
@@ -11,6 +11,7 @@ import {
   type LayoutFlags,
 } from "../server/app-elements.js";
 import type { ArtifactCompatibilityEnvelope } from "../server/artifact-compatibility.js";
+import type { CacheEntryReuseProof } from "../server/cache-proof.js";
 import { notFound } from "./navigation.js";
 
 const EMPTY_ELEMENTS: AppElements = Object.freeze({});
@@ -88,16 +89,23 @@ function isInterceptionMetadataValue(value: unknown): value is AppElementsInterc
   );
 }
 
+function isCacheEntryReuseProofValue(value: unknown): value is CacheEntryReuseProof {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  return "kind" in value && value.kind === "runtime-cache-entry" && "decision" in value;
+}
+
 function isTransportMetadataValue(
   value: AppElementValue | undefined,
 ): value is
   | LayoutFlags
   | ArtifactCompatibilityEnvelope
+  | CacheEntryReuseProof
   | AppElementsInterception
   | readonly AppElementsSlotBinding[] {
   return (
     isLayoutFlagsValue(value) ||
     isArtifactCompatibilityEnvelopeValue(value) ||
+    isCacheEntryReuseProofValue(value) ||
     isInterceptionMetadataValue(value) ||
     isSlotBindingListValue(value)
   );

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -43,6 +43,7 @@ import {
   createHistoryStateWithNavigationMetadata,
   createHistoryStateWithPreviousNextUrl,
   createPendingNavigationCommit,
+  isCacheRestorableAppPayloadMetadata,
   readHistoryStatePreviousNextUrl,
   readHistoryStateTraversalIndex,
   resolveInterceptionContextFromPreviousNextUrl,
@@ -1303,6 +1304,14 @@ describe("app browser entry state helpers", () => {
         },
       },
     ]);
+  });
+
+  it("does not classify unproofed payload metadata as cache-restorable", () => {
+    const elements = createResolvedElements("route:/dashboard/settings", "/", null, {
+      "page:/dashboard/settings": React.createElement("main", null, "settings"),
+    });
+
+    expect(isCacheRestorableAppPayloadMetadata(AppElementsWire.readMetadata(elements))).toBe(false);
   });
 
   it("traces unknown root-layout identity without preserving absent slots", async () => {

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -42,6 +42,8 @@ import * as navigationShim from "../packages/vinext/src/shims/navigation.js";
 import {
   createHistoryStateWithNavigationMetadata,
   createHistoryStateWithPreviousNextUrl,
+  FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
+  VISITED_CACHE_APP_NAVIGATION_PAYLOAD_ORIGIN,
   createPendingNavigationCommit,
   isCacheRestorableAppPayloadMetadata,
   readHistoryStatePreviousNextUrl,
@@ -393,6 +395,7 @@ async function resolveTestPendingNavigationCommitDispositionDecision(
     visibleCommitVersion: options.currentVisibleCommitVersion,
   });
   const pending = await createPendingNavigationCommit({
+    payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
     currentState: startState,
     nextElements: Promise.resolve(
       createResolvedElements("route:/dashboard", options.nextRootLayoutTreePath),
@@ -457,6 +460,7 @@ async function applyApprovedTestCommit(
   options: ApprovedTestCommitOptions,
 ): Promise<AppRouterState> {
   const pending = await createPendingNavigationCommit({
+    payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
     currentState: state,
     nextElements: Promise.resolve(
       createResolvedElements(
@@ -736,6 +740,7 @@ describe("app browser entry navigation scheduling", () => {
         navigationSnapshot: createClientNavigationRenderSnapshot("https://example.com/initial", {}),
         nextElements: Promise.resolve(createResolvedElements("route:/dashboard", "/")),
         operationLane: "navigation",
+        payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
         params: {},
         pendingRouterState: null,
         previousNextUrl: null,
@@ -754,6 +759,7 @@ describe("app browser entry state helpers", () => {
   it("requires renderId when creating pending commits", () => {
     // @ts-expect-error renderId is required to avoid duplicate commit ids.
     void createPendingNavigationCommit({
+      payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
       currentState: createState(),
       nextElements: Promise.resolve(createResolvedElements("route:/dashboard", "/")),
       navigationSnapshot: createState().navigationSnapshot,
@@ -803,6 +809,7 @@ describe("app browser entry state helpers", () => {
 
     const state = createState();
     const pending = await createPendingNavigationCommit({
+      payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
       currentState: state,
       nextElements: Promise.resolve(nextElements),
       navigationSnapshot: state.navigationSnapshot,
@@ -863,6 +870,7 @@ describe("app browser entry state helpers", () => {
 
   it("carries interception context through pending navigation commits", async () => {
     const pending = await createPendingNavigationCommit({
+      payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
       currentState: createState(),
       nextElements: Promise.resolve(
         createResolvedElements(
@@ -905,6 +913,7 @@ describe("app browser entry state helpers", () => {
     });
 
     const pending = await createPendingNavigationCommit({
+      payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
       currentState: interceptedState,
       nextElements: Promise.resolve(createResolvedElements("route:/feed", "/")),
       navigationSnapshot: createState().navigationSnapshot,
@@ -923,6 +932,7 @@ describe("app browser entry state helpers", () => {
       rootLayoutTreePath: "/(marketing)",
     });
     const pending = await createPendingNavigationCommit({
+      payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
       currentState,
       nextElements: Promise.resolve(createResolvedElements("route:/dashboard", "/(dashboard)")),
       navigationSnapshot: currentState.navigationSnapshot,
@@ -949,6 +959,7 @@ describe("app browser entry state helpers", () => {
     });
     let resolved = false;
     const pending = createPendingNavigationCommit({
+      payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
       currentState: createState(),
       nextElements,
       navigationSnapshot: createState().navigationSnapshot,
@@ -986,6 +997,7 @@ describe("app browser entry state helpers", () => {
     });
 
     const pending = await createPendingNavigationCommit({
+      payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
       currentState,
       nextElements: Promise.resolve(createResolvedElements("route:/dashboard", "/")),
       navigationSnapshot: currentState.navigationSnapshot,
@@ -1027,6 +1039,7 @@ describe("app browser entry state helpers", () => {
   it("skips a pending commit when a newer navigation has become active", async () => {
     const currentState = createState();
     const pending = await createPendingNavigationCommit({
+      payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
       currentState,
       nextElements: Promise.resolve(createResolvedElements("route:/dashboard", "/")),
       navigationSnapshot: currentState.navigationSnapshot,
@@ -1053,6 +1066,7 @@ describe("app browser entry state helpers", () => {
       visibleCommitVersion: 5,
     });
     const pending = await createPendingNavigationCommit({
+      payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
       currentState: refreshStartState,
       nextElements: Promise.resolve(createResolvedElements("route:/dashboard", "/")),
       navigationSnapshot: refreshStartState.navigationSnapshot,
@@ -1103,6 +1117,7 @@ describe("app browser entry state helpers", () => {
       visibleCommitVersion: 3,
     });
     const pending = await createPendingNavigationCommit({
+      payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
       currentState: traverseStartState,
       nextElements: Promise.resolve(createResolvedElements("route:/previous", "/")),
       navigationSnapshot: traverseStartState.navigationSnapshot,
@@ -1275,7 +1290,7 @@ describe("app browser entry state helpers", () => {
       ),
       operationLane: "navigation",
       renderId: 2,
-      requireCacheEntryReuseProof: true,
+      payloadOrigin: VISITED_CACHE_APP_NAVIGATION_PAYLOAD_ORIGIN,
       type: "navigate",
     });
 
@@ -1370,6 +1385,7 @@ describe("app browser entry state helpers", () => {
       ],
     });
     const pending = await createPendingNavigationCommit({
+      payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
       currentState,
       nextElements: Promise.resolve(
         createResolvedElements(
@@ -1423,6 +1439,7 @@ describe("app browser entry state helpers", () => {
 
   it("builds a merge commit for refresh and server-action payloads", async () => {
     const refreshCommit = await createPendingNavigationCommit({
+      payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
       currentState: createState(),
       nextElements: Promise.resolve(createResolvedElements("route:/dashboard", "/")),
       navigationSnapshot: createState().navigationSnapshot,
@@ -1450,6 +1467,7 @@ describe("app browser entry state helpers", () => {
     });
 
     const pending = await createPendingNavigationCommit({
+      payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
       currentState,
       nextElements: Promise.resolve(
         createResolvedElements(
@@ -1504,6 +1522,7 @@ describe("app browser entry state helpers", () => {
     expect(contextOnlyState.routeId).toBe(AppElementsWire.encodeRouteId("/feed", "/feed"));
 
     const interceptedPending = await createPendingNavigationCommit({
+      payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
       currentState: contextOnlyState,
       nextElements: Promise.resolve(
         createResolvedElements(
@@ -1558,6 +1577,7 @@ describe("app browser entry state helpers", () => {
   it("creates an approved visible commit only after the current operation decision allows mutation", async () => {
     const currentState = createState();
     const pending = await createPendingNavigationCommit({
+      payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
       currentState,
       nextElements: Promise.resolve(
         createResolvedElements("route:/dashboard", "/", null, {
@@ -1625,6 +1645,7 @@ describe("app browser entry state helpers", () => {
   it("traces unknown root-layout approval as an unproven payload commit", async () => {
     const currentState = createState();
     const pending = await createPendingNavigationCommit({
+      payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
       currentState,
       nextElements: Promise.resolve(createResolvedElements("route:/legacy-payload", null)),
       navigationSnapshot: currentState.navigationSnapshot,
@@ -1659,6 +1680,7 @@ describe("app browser entry state helpers", () => {
   it("approves HMR visible commits through a named trusted recovery path", async () => {
     const currentState = createState();
     const pending = await createPendingNavigationCommit({
+      payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
       currentState,
       nextElements: Promise.resolve(
         createResolvedElements("route:/hmr", "/", null, {
@@ -1693,6 +1715,7 @@ describe("app browser entry state helpers", () => {
   it("rejects non-HMR commits on the HMR approval path", async () => {
     const currentState = createState();
     const pending = await createPendingNavigationCommit({
+      payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
       currentState,
       nextElements: Promise.resolve(createResolvedElements("route:/dashboard", "/")),
       navigationSnapshot: currentState.navigationSnapshot,
@@ -1716,6 +1739,7 @@ describe("app browser entry state helpers", () => {
       "page:/next": React.createElement("main", null, "next"),
     });
     const pending = await createPendingNavigationCommit({
+      payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
       currentState,
       nextElements: Promise.resolve(nextElements),
       navigationSnapshot: currentState.navigationSnapshot,
@@ -1754,6 +1778,7 @@ describe("app browser entry state helpers", () => {
       }),
     });
     const pending = await createPendingNavigationCommit({
+      payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
       currentState,
       nextElements: Promise.resolve(createResolvedElements("route:/feed", "/")),
       navigationSnapshot: currentState.navigationSnapshot,
@@ -1791,6 +1816,7 @@ describe("app browser entry state helpers", () => {
       rootLayoutTreePath: "/(marketing)",
     });
     const pending = await createPendingNavigationCommit({
+      payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
       currentState,
       nextElements: Promise.resolve(createResolvedElements("route:/dashboard", "/(dashboard)")),
       navigationSnapshot: currentState.navigationSnapshot,
@@ -1942,6 +1968,7 @@ describe("app browser navigation controller", () => {
       );
 
       void controller.renderNavigationPayload({
+        payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
         actionType: "navigate",
         createNavigationCommitEffect: () => vi.fn(),
         historyUpdateMode: "push",
@@ -1994,6 +2021,7 @@ describe("app browser navigation controller", () => {
       });
 
       const result = controller.renderNavigationPayload({
+        payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
         actionType: "navigate",
         createNavigationCommitEffect: () => vi.fn(),
         historyUpdateMode: "push",
@@ -2068,6 +2096,7 @@ describe("app browser navigation controller", () => {
 
     try {
       void controller.renderNavigationPayload({
+        payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
         actionType: "navigate",
         createNavigationCommitEffect,
         historyUpdateMode: "push",
@@ -2137,10 +2166,10 @@ describe("app browser navigation controller", () => {
           }),
         ),
         operationLane: "navigation",
+        payloadOrigin: VISITED_CACHE_APP_NAVIGATION_PAYLOAD_ORIGIN,
         params: {},
         pendingRouterState: null,
         previousNextUrl: null,
-        requireCacheEntryReuseProof: true,
         targetHref: "https://example.com/dashboard/settings",
         navId: controller.beginNavigation(),
       });
@@ -2166,6 +2195,7 @@ describe("app browser navigation controller", () => {
     try {
       const navId = controller.beginNavigation();
       const renderPromise = controller.renderNavigationPayload({
+        payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
         actionType: "navigate",
         createNavigationCommitEffect,
         historyUpdateMode: "push",
@@ -2210,6 +2240,7 @@ describe("app browser navigation controller", () => {
     try {
       const navId = controller.beginNavigation();
       const renderPromise = controller.renderNavigationPayload({
+        payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
         actionType: "navigate",
         createNavigationCommitEffect: () => commitEffect,
         historyUpdateMode: "push",
@@ -2680,6 +2711,7 @@ describe("app browser navigation lifecycle settlement", () => {
       // Start three navigations. Only C is the current (winning) one.
       const navA = controller.beginNavigation();
       void controller.renderNavigationPayload({
+        payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
         actionType: "navigate",
         createNavigationCommitEffect: () => {
           effectsRun.push("A");
@@ -2698,6 +2730,7 @@ describe("app browser navigation lifecycle settlement", () => {
 
       const navB = controller.beginNavigation();
       void controller.renderNavigationPayload({
+        payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
         actionType: "navigate",
         createNavigationCommitEffect: () => {
           effectsRun.push("B");
@@ -2716,6 +2749,7 @@ describe("app browser navigation lifecycle settlement", () => {
 
       const navC = controller.beginNavigation();
       void controller.renderNavigationPayload({
+        payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
         actionType: "navigate",
         createNavigationCommitEffect: () => {
           effectsRun.push("C");
@@ -2790,6 +2824,7 @@ describe("app browser navigation lifecycle settlement", () => {
       // Start cross-root navigation A (deferred, /(marketing) → /(dashboard)).
       const navA = controller.beginNavigation();
       void controller.renderNavigationPayload({
+        payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
         actionType: "navigate",
         createNavigationCommitEffect: () => () => {},
         historyUpdateMode: "push",
@@ -2806,6 +2841,7 @@ describe("app browser navigation lifecycle settlement", () => {
       // Start new navigation B (same root). B advances activeNavigationId past A.
       const navB = controller.beginNavigation();
       void controller.renderNavigationPayload({
+        payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
         actionType: "navigate",
         createNavigationCommitEffect: () => () => {},
         historyUpdateMode: "push",
@@ -2859,6 +2895,7 @@ describe("app browser navigation lifecycle settlement", () => {
     try {
       const refreshNav = controller.beginNavigation();
       void controller.renderNavigationPayload({
+        payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
         actionType: "navigate",
         createNavigationCommitEffect: () => () => {},
         historyUpdateMode: undefined,
@@ -2912,6 +2949,7 @@ describe("app browser navigation lifecycle settlement", () => {
       const traversePendingState = controller.beginPendingBrowserRouterState();
       const traverseNav = controller.beginNavigation();
       void controller.renderNavigationPayload({
+        payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
         actionType: "traverse",
         createNavigationCommitEffect: () => () => {},
         historyUpdateMode: undefined,
@@ -2957,6 +2995,7 @@ describe("app browser navigation lifecycle settlement", () => {
 
   it("resolveAndClassifyNavigationCommit classifies skip when IDs have diverged", async () => {
     const result = await resolveAndClassifyNavigationCommit({
+      payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
       activeNavigationId: 9,
       currentState: createState(),
       navigationSnapshot: createState().navigationSnapshot,
@@ -2981,6 +3020,7 @@ describe("app browser navigation lifecycle settlement", () => {
     });
 
     const resultPromise = resolveAndClassifyNavigationCommit({
+      payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
       activeNavigationId,
       currentState,
       getActiveNavigationId: () => activeNavigationId,
@@ -3032,6 +3072,7 @@ describe("app browser navigation lifecycle settlement", () => {
     });
 
     const resultPromise = resolveAndClassifyNavigationCommit({
+      payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
       activeNavigationId: 8,
       currentState: startedState,
       getCurrentStateForApproval: () => approvalState,
@@ -3085,6 +3126,7 @@ describe("app browser navigation lifecycle settlement", () => {
     try {
       const navId = controller.beginNavigation();
       const renderPromise = controller.renderNavigationPayload({
+        payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
         actionType: "navigate",
         createNavigationCommitEffect: () => () => {},
         historyUpdateMode: "push",
@@ -3122,6 +3164,7 @@ describe("app browser root-layout hard navigation", () => {
     try {
       const navId = controller.beginNavigation();
       const renderPromise = controller.renderNavigationPayload({
+        payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
         actionType: "navigate",
         createNavigationCommitEffect,
         historyUpdateMode: "push",
@@ -3165,6 +3208,7 @@ describe("app browser root-layout hard navigation", () => {
     try {
       const navId = controller.beginNavigation();
       void controller.renderNavigationPayload({
+        payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
         actionType: "navigate",
         createNavigationCommitEffect: () => () => {},
         historyUpdateMode: "push",
@@ -3208,6 +3252,7 @@ describe("app browser root-layout hard navigation", () => {
       const firstNavId = controller.beginNavigation();
       await expect(
         controller.renderNavigationPayload({
+          payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
           actionType: "navigate",
           createNavigationCommitEffect: () => () => {},
           historyUpdateMode: "push",
@@ -3236,6 +3281,7 @@ describe("app browser root-layout hard navigation", () => {
       const secondNavId = controller.beginNavigation();
       await expect(
         controller.renderNavigationPayload({
+          payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
           actionType: "navigate",
           createNavigationCommitEffect: () => () => {},
           historyUpdateMode: "push",
@@ -3274,6 +3320,7 @@ describe("app browser root-layout hard navigation", () => {
       const firstNavId = controller.beginNavigation();
       await expect(
         controller.renderNavigationPayload({
+          payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
           actionType: "navigate",
           createNavigationCommitEffect: () => () => {},
           historyUpdateMode: "push",
@@ -3301,6 +3348,7 @@ describe("app browser root-layout hard navigation", () => {
       const secondNavId = controller.beginNavigation();
       await expect(
         controller.renderNavigationPayload({
+          payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
           actionType: "navigate",
           createNavigationCommitEffect: () => () => {},
           historyUpdateMode: "push",
@@ -3435,6 +3483,7 @@ describe("app browser entry previousNextUrl helpers", () => {
     });
 
     const result = await resolveAndClassifyNavigationCommit({
+      payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
       activeNavigationId: 7,
       currentState,
       navigationSnapshot: currentState.navigationSnapshot,
@@ -3588,6 +3637,7 @@ describe("app browser entry previousNextUrl helpers", () => {
       slotBindings: [modalSlotBinding],
     });
     const pending = await createPendingNavigationCommit({
+      payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
       currentState: state,
       nextElements: Promise.resolve(
         createResolvedElements(

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -1247,6 +1247,64 @@ describe("app browser entry state helpers", () => {
     ]);
   });
 
+  it("rejects cache-restored pending commits when cache-entry proof metadata is absent", async () => {
+    const currentState = createState({
+      navigationSnapshot: createClientNavigationRenderSnapshot(
+        "https://example.com/dashboard/profile",
+        {},
+      ),
+      routeId: "route:/dashboard/profile",
+    });
+    const pending = await createPendingNavigationCommit({
+      currentState,
+      nextElements: Promise.resolve(
+        createResolvedElements(
+          "route:/dashboard/settings",
+          "/",
+          null,
+          {
+            "page:/dashboard/settings": React.createElement("main", null, "settings"),
+          },
+          ["layout:/"],
+        ),
+      ),
+      navigationSnapshot: createClientNavigationRenderSnapshot(
+        "https://example.com/dashboard/settings",
+        {},
+      ),
+      operationLane: "navigation",
+      renderId: 2,
+      requireCacheEntryReuseProof: true,
+      type: "navigate",
+    });
+
+    const decision = resolvePendingNavigationCommitDispositionDecision({
+      activeNavigationId: 2,
+      currentState,
+      pending,
+      routeManifest: createRouteManifestForPendingCommit(currentState, pending),
+      startedNavigationId: 2,
+      targetHref: "https://example.com/dashboard/settings",
+    });
+
+    expect(decision.disposition).toBe("hard-navigate");
+    expect(decision.trace.entries).toEqual([
+      {
+        code: NavigationTraceReasonCodes.cacheProofRejected,
+        fields: {
+          activeNavigationId: 2,
+          cacheProofCode: "CP_CACHE_ENTRY_PROOF_MISSING",
+          currentRootLayoutTreePath: "/",
+          currentVisibleCommitVersion: 0,
+          nextRootLayoutTreePath: "/",
+          startedNavigationId: 2,
+          startedVisibleCommitVersion: 0,
+          targetHref: "https://example.com/dashboard/settings",
+        },
+      },
+    ]);
+  });
+
   it("traces unknown root-layout identity without preserving absent slots", async () => {
     const decision = await resolveTestPendingNavigationCommitDispositionDecision({
       activeNavigationId: 2,
@@ -2021,6 +2079,67 @@ describe("app browser navigation controller", () => {
       expect(createNavigationCommitEffect).toHaveBeenCalledTimes(1);
       expect(commitEffect).not.toHaveBeenCalled();
       expect(setBrowserRouterState).toHaveBeenCalledTimes(1);
+    } finally {
+      detach();
+    }
+  });
+
+  it("hard-navigates cache-restored payloads missing cache-entry proof metadata", async () => {
+    const performHardNavigation = vi.fn(() => true);
+    const createNavigationCommitEffect = vi.fn(() => vi.fn());
+    const currentState = createState({
+      navigationSnapshot: createClientNavigationRenderSnapshot(
+        "https://example.com/dashboard/profile",
+        {},
+      ),
+      routeId: "route:/dashboard/profile",
+    });
+    const routeManifest = createTestRouteManifest([
+      {
+        id: "route:/dashboard/profile",
+        layoutIds: currentState.layoutIds,
+        pattern: "/dashboard/profile",
+        rootBoundaryId: "root-boundary:/",
+      },
+      {
+        id: "route:/dashboard/settings",
+        layoutIds: [AppElementsWire.encodeLayoutId("/")],
+        pattern: "/dashboard/settings",
+        rootBoundaryId: "root-boundary:/",
+      },
+    ]);
+    const { controller, detach, stateRef } = createControllerHarness(currentState, {
+      getRouteManifest: () => routeManifest,
+      performHardNavigation,
+    });
+
+    try {
+      const result = await controller.renderNavigationPayload({
+        actionType: "navigate",
+        createNavigationCommitEffect,
+        historyUpdateMode: "push",
+        navigationSnapshot: createClientNavigationRenderSnapshot(
+          "https://example.com/dashboard/settings",
+          {},
+        ),
+        nextElements: Promise.resolve(
+          createResolvedElements("route:/dashboard/settings", "/", null, {
+            "page:/dashboard/settings": React.createElement("main", null, "settings"),
+          }),
+        ),
+        operationLane: "navigation",
+        params: {},
+        pendingRouterState: null,
+        previousNextUrl: null,
+        requireCacheEntryReuseProof: true,
+        targetHref: "https://example.com/dashboard/settings",
+        navId: controller.beginNavigation(),
+      });
+
+      expect(result).toBe("hard-navigate");
+      expect(performHardNavigation).toHaveBeenCalledWith("https://example.com/dashboard/settings");
+      expect(createNavigationCommitEffect).not.toHaveBeenCalled();
+      expect(stateRef.current.routeId).toBe("route:/dashboard/profile");
     } finally {
       detach();
     }

--- a/tests/app-elements.test.ts
+++ b/tests/app-elements.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vite-plus/test";
 import { UNMATCHED_SLOT } from "../packages/vinext/src/shims/slot.js";
 import {
   APP_ARTIFACT_COMPATIBILITY_KEY,
+  APP_CACHE_ENTRY_REUSE_PROOF_KEY,
   AppElementsWire,
   APP_INTERCEPTION_KEY,
   APP_INTERCEPTION_CONTEXT_KEY,
@@ -29,7 +30,10 @@ import {
   evaluateArtifactCompatibility,
   RSC_PAYLOAD_SCHEMA_VERSION,
 } from "../packages/vinext/src/server/artifact-compatibility.js";
-import { buildRenderObservation } from "../packages/vinext/src/server/cache-proof.js";
+import {
+  buildRenderObservation,
+  createCacheEntryReuseProof,
+} from "../packages/vinext/src/server/cache-proof.js";
 
 describe("AppElementsWire", () => {
   it("encodes outgoing record payloads without mutating caller-owned records", () => {
@@ -838,6 +842,27 @@ describe("buildOutgoingAppPayload", () => {
         rootBoundaryId: "root-a",
         renderEpoch: null,
       });
+    }
+  });
+
+  it("carries planner-visible cache entry reuse proof as metadata only", () => {
+    const cacheEntryReuseProof = createCacheEntryReuseProof(null);
+    const result = buildOutgoingAppPayload({
+      element: {
+        [APP_ROUTE_KEY]: "route:/dashboard",
+        [APP_ROOT_LAYOUT_KEY]: "/",
+        "page:/dashboard": "dashboard-page",
+      },
+      cacheEntryReuseProof,
+      layoutFlags: { "layout:/": "s" },
+    });
+
+    expect(isAppElementsRecord(result)).toBe(true);
+    if (isAppElementsRecord(result)) {
+      expect(result[APP_CACHE_ENTRY_REUSE_PROOF_KEY]).toEqual(cacheEntryReuseProof);
+      expect(AppElementsWire.readMetadata(result).cacheEntryReuseProof).toEqual(
+        cacheEntryReuseProof,
+      );
     }
   });
 

--- a/tests/cache-proof.test.ts
+++ b/tests/cache-proof.test.ts
@@ -10,6 +10,7 @@ import {
   classifyCacheVariantDimensionDowngrade,
   classifyRenderObservationDowngrade,
   createAppRouteCacheProofGraphScope,
+  createCacheEntryReuseProof,
   createDisabledCacheProofDecision,
   createStaticLayoutArtifactReuseDecision,
   DEFAULT_CACHE_VARIANT_BUDGET,
@@ -902,6 +903,64 @@ describe("disabled cache proof model", () => {
           rootBoundaryId: "layout:/",
         },
       },
+    });
+  });
+
+  it("projects static layout artifact decisions into planner-visible cache entry proof", () => {
+    const currentOutput = createLayoutOutput({
+      routeId: "route:/dashboard/profile",
+    });
+    const candidateOutput = createLayoutOutput({
+      routeId: "route:/dashboard/settings",
+    });
+    const compatibleArtifact = createArtifactCompatibilityEnvelope({
+      deploymentVersion: "deploy-a",
+      graphVersion: "graph-a",
+      rootBoundaryId: "layout:/",
+      renderEpoch: "epoch-a",
+    });
+    const reuseDecision = createStaticLayoutArtifactReuseDecision({
+      currentArtifactCompatibility: compatibleArtifact,
+      candidateArtifactCompatibility: compatibleArtifact,
+      candidateObservation: buildLayoutObservation({ output: candidateOutput }),
+      candidateVariant: buildLayoutVariantAdmission({ output: candidateOutput }),
+      currentOutput,
+    });
+    const rejectedDecision = createStaticLayoutArtifactReuseDecision({
+      currentArtifactCompatibility: compatibleArtifact,
+      candidateArtifactCompatibility: createArtifactCompatibilityEnvelope({
+        deploymentVersion: "deploy-b",
+        graphVersion: "graph-a",
+        rootBoundaryId: "layout:/",
+        renderEpoch: "epoch-a",
+      }),
+      candidateObservation: buildLayoutObservation({ output: candidateOutput }),
+      candidateVariant: buildLayoutVariantAdmission({ output: candidateOutput }),
+      currentOutput,
+    });
+
+    expect(createCacheEntryReuseProof(reuseDecision)).toEqual({
+      kind: "runtime-cache-entry",
+      decision: {
+        canReuse: true,
+        code: "CP_STATIC_LAYOUT_REUSE_PROVEN",
+        kind: "reuse",
+        reuseClass: "static-layout",
+      },
+    });
+    expect(createCacheEntryReuseProof(rejectedDecision)).toEqual({
+      kind: "runtime-cache-entry",
+      decision: {
+        canReuse: false,
+        code: "CP_ARTIFACT_COMPATIBILITY_INCOMPATIBLE",
+        kind: "reject",
+        mode: "renderFresh",
+        scope: "affectedOutput",
+      },
+    });
+    expect(createCacheEntryReuseProof(null)).toEqual({
+      kind: "runtime-cache-entry",
+      decision: null,
     });
   });
 

--- a/tests/e2e/app-router/build-id-navigation.spec.ts
+++ b/tests/e2e/app-router/build-id-navigation.spec.ts
@@ -71,7 +71,7 @@ async function waitForLastRscNavigation(page: Page): Promise<void> {
 }
 
 test.describe("App Router RSC compatibility navigation", () => {
-  test("replays same-build visited RSC payloads instead of refetching or reloading", async ({
+  test("refetches unproofed same-build visited RSC payloads instead of reloading", async ({
     page,
   }) => {
     const aboutRscRequests: string[] = [];
@@ -89,7 +89,7 @@ test.describe("App Router RSC compatibility navigation", () => {
     await pushAppRoute(page, "/about");
     await expect(page.locator("h1")).toHaveText("About");
     // router.push commits visible UI before the RSC navigation promise has
-    // finished seeding the visited-response cache this test asserts on.
+    // finished its post-commit cache-store eligibility check.
     await waitForLastRscNavigation(page);
     expect(aboutRscRequests).toHaveLength(1);
 
@@ -107,9 +107,12 @@ test.describe("App Router RSC compatibility navigation", () => {
     await pushAppRoute(page, "/about");
     await expect(page.locator("h1")).toHaveText("About");
 
+    // Until a real cache proof producer exists, unproofed responses must not be
+    // restored as commit-capable visited-cache entries. The marker proves this
+    // stayed a soft navigation rather than degrading to an MPA reload.
     await expect(
       page.evaluate((marker) => Reflect.get(window, marker), VISITED_CACHE_MARKER),
     ).resolves.toBe(true);
-    expect(aboutRscRequests).toHaveLength(1);
+    expect(aboutRscRequests).toHaveLength(2);
   });
 });

--- a/tests/navigation-planner.test.ts
+++ b/tests/navigation-planner.test.ts
@@ -28,6 +28,10 @@ import type {
   RouteManifestSlotBinding,
   StaticSegmentGraph,
 } from "../packages/vinext/src/routing/app-route-graph.js";
+import {
+  createCacheEntryReuseProof,
+  type CacheEntryReuseProof,
+} from "../packages/vinext/src/server/cache-proof.js";
 
 type TestManifestRoute = {
   id?: string;
@@ -278,6 +282,21 @@ function createOperationToken(overrides: Partial<OperationToken> = {}): Operatio
   };
 }
 
+function createRejectedCacheEntryReuseProof(
+  code: "CP_ARTIFACT_COMPATIBILITY_INCOMPATIBLE" | "CP_ROUTE_VARIANT_CEILING_EXCEEDED",
+): CacheEntryReuseProof {
+  return {
+    kind: "runtime-cache-entry",
+    decision: {
+      canReuse: false,
+      code,
+      kind: "reject",
+      mode: code === "CP_ROUTE_VARIANT_CEILING_EXCEEDED" ? "privateUncacheable" : "renderFresh",
+      scope: code === "CP_ROUTE_VARIANT_CEILING_EXCEEDED" ? "route" : "affectedOutput",
+    },
+  };
+}
+
 function planFlightResponse(rootBoundaryId: string | null): NavigationDecisionV0 {
   const token = createOperationToken({
     targetSnapshotFingerprint: `route:/dashboard|root:${rootBoundaryId ?? "unknown"}`,
@@ -393,6 +412,7 @@ function planFlightResponseFromRootBoundaries(options: {
 }
 
 function planFlightResponseFromSnapshots(options: {
+  cacheEntryReuseProof?: CacheEntryReuseProof;
   currentSnapshot: RouteSnapshotV0;
   lane?: OperationToken["lane"];
   routeManifest?: RouteManifest | null;
@@ -410,6 +430,9 @@ function planFlightResponseFromSnapshots(options: {
     event: {
       kind: "flightResponseArrived",
       result: {
+        ...(options.cacheEntryReuseProof
+          ? { cacheEntryReuseProof: options.cacheEntryReuseProof }
+          : {}),
         href: options.targetSnapshot.displayUrl,
         targetSnapshot: options.targetSnapshot,
       },
@@ -456,6 +479,134 @@ describe("navigationPlanner root-boundary decisions", () => {
           },
         },
       ],
+    });
+  });
+
+  it("rejects runtime cache entries when the cache proof is missing", () => {
+    const currentSnapshot: RouteSnapshotV0 = {
+      ...createRouteSnapshot("/"),
+      displayUrl: "https://example.com/dashboard/profile",
+      matchedUrl: "/dashboard/profile",
+      routeId: "route:/dashboard/profile",
+    };
+    const targetSnapshot: RouteSnapshotV0 = {
+      ...createRouteSnapshot("/"),
+      displayUrl: "https://example.com/dashboard/settings",
+      matchedUrl: "/dashboard/settings",
+      routeId: "route:/dashboard/settings",
+    };
+
+    const decision = planFlightResponseFromSnapshots({
+      cacheEntryReuseProof: createCacheEntryReuseProof(null),
+      currentSnapshot,
+      targetSnapshot,
+    });
+
+    expect(decision.kind).toBe("hardNavigate");
+    if (decision.kind !== "hardNavigate") {
+      throw new Error("Expected cache proof rejection to hard navigate");
+    }
+    expect(decision.reason).toBe("cacheProofRejected");
+    expect(decision.url).toBe("https://example.com/dashboard/settings");
+    expect(decision.trace.entries).toEqual([
+      {
+        code: NavigationTraceReasonCodes.cacheProofRejected,
+        fields: {
+          cacheProofCode: "CP_CACHE_ENTRY_PROOF_MISSING",
+          currentRootLayoutTreePath: "/",
+          currentVisibleCommitVersion: 2,
+          nextRootLayoutTreePath: "/",
+          startedVisibleCommitVersion: 2,
+        },
+      },
+    ]);
+  });
+
+  it("rejects incompatible runtime cache entries before route-topology commit approval", () => {
+    const currentSnapshot: RouteSnapshotV0 = {
+      ...createRouteSnapshot("/"),
+      displayUrl: "https://example.com/dashboard/profile",
+      matchedUrl: "/dashboard/profile",
+      routeId: "route:/dashboard/profile",
+    };
+    const targetSnapshot: RouteSnapshotV0 = {
+      ...createRouteSnapshot("/"),
+      displayUrl: "https://example.com/dashboard/settings",
+      matchedUrl: "/dashboard/settings",
+      routeId: "route:/dashboard/settings",
+    };
+
+    const decision = planFlightResponseFromSnapshots({
+      cacheEntryReuseProof: createRejectedCacheEntryReuseProof(
+        "CP_ARTIFACT_COMPATIBILITY_INCOMPATIBLE",
+      ),
+      currentSnapshot,
+      targetSnapshot,
+    });
+
+    expect(decision.kind).toBe("hardNavigate");
+    if (decision.kind !== "hardNavigate") {
+      throw new Error("Expected incompatible cache entry to hard navigate");
+    }
+    expect(decision.reason).toBe("cacheProofRejected");
+    expect(decision.trace.entries[0]).toEqual({
+      code: NavigationTraceReasonCodes.cacheProofRejected,
+      fields: {
+        cacheProofCode: "CP_ARTIFACT_COMPATIBILITY_INCOMPATIBLE",
+        cacheProofMode: "renderFresh",
+        cacheProofScope: "affectedOutput",
+        currentRootLayoutTreePath: "/",
+        currentVisibleCommitVersion: 2,
+        nextRootLayoutTreePath: "/",
+        startedVisibleCommitVersion: 2,
+      },
+    });
+  });
+
+  it("keeps accepted runtime cache proof visible on the commit proposal", () => {
+    const currentSnapshot: RouteSnapshotV0 = {
+      ...createRouteSnapshot("/"),
+      displayUrl: "https://example.com/dashboard/profile",
+      matchedUrl: "/dashboard/profile",
+      routeId: "route:/dashboard/profile",
+    };
+    const targetSnapshot: RouteSnapshotV0 = {
+      ...createRouteSnapshot("/"),
+      displayUrl: "https://example.com/dashboard/settings",
+      matchedUrl: "/dashboard/settings",
+      routeId: "route:/dashboard/settings",
+    };
+    const cacheEntryReuseProof: CacheEntryReuseProof = {
+      kind: "runtime-cache-entry",
+      decision: {
+        canReuse: true,
+        code: "CP_STATIC_LAYOUT_REUSE_PROVEN",
+        kind: "reuse",
+        reuseClass: "static-layout",
+      },
+    };
+
+    const decision = planFlightResponseFromSnapshots({
+      cacheEntryReuseProof,
+      currentSnapshot,
+      targetSnapshot,
+    });
+
+    expect(decision.kind).toBe("proposeCommit");
+    if (decision.kind !== "proposeCommit") {
+      throw new Error("Expected proven cache entry to remain committable");
+    }
+    expect(decision.proposal.cacheEntryReuseDecision).toEqual(cacheEntryReuseProof.decision);
+    expect(decision.trace.entries[0]).toEqual({
+      code: NavigationTraceReasonCodes.commitCurrent,
+      fields: {
+        cacheProofCode: "CP_STATIC_LAYOUT_REUSE_PROVEN",
+        cacheProofReuseClass: "static-layout",
+        currentRootLayoutTreePath: "/",
+        currentVisibleCommitVersion: 2,
+        nextRootLayoutTreePath: "/",
+        startedVisibleCommitVersion: 2,
+      },
     });
   });
 

--- a/tests/navigation-planner.test.ts
+++ b/tests/navigation-planner.test.ts
@@ -82,6 +82,18 @@ function createInterceptionSnapshot(
   };
 }
 
+function createAcceptedStaticLayoutCacheEntryReuseProof(): CacheEntryReuseProof {
+  return {
+    kind: "runtime-cache-entry",
+    decision: {
+      canReuse: true,
+      code: "CP_STATIC_LAYOUT_REUSE_PROVEN",
+      kind: "reuse",
+      reuseClass: "static-layout",
+    },
+  };
+}
+
 function createSlotBinding(
   slotId: string,
   ownerLayoutId: string,
@@ -576,15 +588,7 @@ describe("navigationPlanner root-boundary decisions", () => {
       matchedUrl: "/dashboard/settings",
       routeId: "route:/dashboard/settings",
     };
-    const cacheEntryReuseProof: CacheEntryReuseProof = {
-      kind: "runtime-cache-entry",
-      decision: {
-        canReuse: true,
-        code: "CP_STATIC_LAYOUT_REUSE_PROVEN",
-        kind: "reuse",
-        reuseClass: "static-layout",
-      },
-    };
+    const cacheEntryReuseProof = createAcceptedStaticLayoutCacheEntryReuseProof();
 
     const decision = planFlightResponseFromSnapshots({
       cacheEntryReuseProof,
@@ -635,6 +639,44 @@ describe("navigationPlanner root-boundary decisions", () => {
         },
       },
     ]);
+  });
+
+  it("keeps accepted runtime cache proof fields on later root-boundary rejections", () => {
+    const currentSnapshot: RouteSnapshotV0 = {
+      ...createRouteSnapshot("/"),
+      displayUrl: "https://example.com/current",
+      matchedUrl: "/current",
+      routeId: "route:/current",
+    };
+    const targetSnapshot: RouteSnapshotV0 = {
+      ...createRouteSnapshot("/(dashboard)"),
+      displayUrl: "https://example.com/dashboard",
+      matchedUrl: "/dashboard",
+      routeId: "route:/dashboard",
+    };
+
+    const decision = planFlightResponseFromSnapshots({
+      cacheEntryReuseProof: createAcceptedStaticLayoutCacheEntryReuseProof(),
+      currentSnapshot,
+      targetSnapshot,
+    });
+
+    expect(decision.kind).toBe("hardNavigate");
+    if (decision.kind !== "hardNavigate") {
+      throw new Error("Expected hardNavigate decision");
+    }
+    expect(decision.reason).toBe("rootBoundaryChanged");
+    expect(decision.trace.entries[0]).toEqual({
+      code: NavigationTraceReasonCodes.rootBoundaryChanged,
+      fields: {
+        cacheProofCode: "CP_STATIC_LAYOUT_REUSE_PROVEN",
+        cacheProofReuseClass: "static-layout",
+        currentRootLayoutTreePath: "/",
+        currentVisibleCommitVersion: 2,
+        nextRootLayoutTreePath: "/(dashboard)",
+        startedVisibleCommitVersion: 2,
+      },
+    });
   });
 
   it("uses an unproven payload fallback when the target root identity is unknown", () => {
@@ -1387,6 +1429,7 @@ describe("navigationPlanner root-boundary decisions", () => {
     };
 
     const decision = planFlightResponseFromSnapshots({
+      cacheEntryReuseProof: createAcceptedStaticLayoutCacheEntryReuseProof(),
       currentSnapshot,
       routeManifest,
       targetSnapshot,
@@ -1400,6 +1443,10 @@ describe("navigationPlanner root-boundary decisions", () => {
     expect(decision.trace.entries[0]?.code).toBe(
       NavigationTraceReasonCodes.interceptedRejectedUndeclaredTopology,
     );
+    expect(decision.trace.entries[0]?.fields).toMatchObject({
+      cacheProofCode: "CP_STATIC_LAYOUT_REUSE_PROVEN",
+      cacheProofReuseClass: "static-layout",
+    });
   });
 
   it("rejects intercepted preservation when RouteManifest declares a different slot owner", () => {


### PR DESCRIPTION
## Overview

Bonk: please read #726 before reviewing this slice so the cache proof and planner lifecycle changes are evaluated against the architectural big picture.

| Item | Detail |
| --- | --- |
| Goal | Implement #726-CACHE-13/14 for planner-visible cache proof and lifecycle rejection of incompatible runtime cache entries. |
| Core change | Runtime cache entries can carry compact cache-entry reuse proof into App Router commit planning. |
| Main boundary | Fresh RSC payloads may omit cache proof. Cache-restored payloads must present proof, and unproofed real payloads are not stored as visited-response restore candidates yet. |
| Primary files | `cache-proof.ts`, `navigation-planner.ts`, `app-elements-wire.ts`, `app-browser-state.ts`, `app-browser-entry.ts` |
| Expected impact | Prevents cache hits from being treated as semantic reuse authority without explicit proof. |

## Why

The #726 invariant is that runtime reuse must be authorized by proof, not by the fact that response bytes exist. This PR keeps that decision at the lifecycle/planner boundary: cache proof is serialized as metadata, decoded into the pending commit, then evaluated before normal route-topology commit approval.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| Cache proof | No proof, no cache reuse authority. | Adds a planner-visible `CacheEntryReuseProof` projection from static layout artifact decisions. |
| Browser lifecycle | Cache origin matters. | Cache-restored payloads require proof, while fresh payloads keep the existing omission-tolerant path. |
| Real producer gap | Do not turn unproofed production payloads into commit-capable cache entries. | Until the real proof producer exists, decoded payload metadata must contain proof before the visited-response cache stores the snapshot. |
| Planner | A cache hit is not semantic proof. | Rejected or missing cache proof hard-navigates before route-topology commit approval. Accepted proof is attached to the commit proposal and trace. |
| Traceability | Rejections need compact proof reason fields. | Adds `NC_CACHE_REJECT` plus cache proof code, mode, scope, and reuse-class fields. |

## What changed

| Scenario / surface | Before | After |
| --- | --- | --- |
| Accepted static-layout cache proof | Not visible to the planner commit decision. | `cacheEntryReuseDecision` appears on the commit proposal and trace. |
| Incompatible runtime cache entry | Could continue through ordinary payload planning unless another lifecycle guard stopped it. | Planner returns `hardNavigate` with `cacheProofRejected`. |
| Cache-restored payload missing proof metadata | Could look like an ordinary fresh payload. | Required-proof restore path synthesizes a missing-proof rejection. |
| Real App Router payload without proof | Could be stored as a visited-response restore candidate, then fail the new restore gate on replay. | It is not stored as a commit-capable visited-response cache entry. The next navigation refetches and remains SPA-soft. |
| Fresh payload missing proof metadata | Existing behavior was omission-tolerant. | Still omission-tolerant, because it is not a runtime cache-entry reuse claim. |
| Parser rejection-code list | Listed values were type-valid but not type-exhaustive. | The allowlist is checked exhaustively against `CacheProofRejectionCode`. |

<details>
<summary>Maintainer review path</summary>

1. `packages/vinext/src/server/cache-proof.ts`  
   Review the compact `CacheEntryReuseProof` shape and projection from `StaticLayoutArtifactReuseDecision`.

2. `packages/vinext/src/server/app-elements-wire.ts`  
   Review wire key addition, metadata parsing, malformed proof degradation into missing-proof rejection, and exhaustive rejection-code allowlist.

3. `packages/vinext/src/server/app-browser-state.ts` and `packages/vinext/src/server/app-browser-entry.ts`  
   Review how cache-restored payloads require proof while fresh payloads do not, plus the interim visited-cache storage gate for unproofed real payloads.

4. `packages/vinext/src/server/navigation-planner.ts` and `packages/vinext/src/server/navigation-trace.ts`  
   Review rejection ordering, trace fields, and accepted-proof visibility on commit proposals.

5. `packages/vinext/src/shims/slot.tsx`  
   Review the metadata guard for cache proof values.

</details>

<details>
<summary>Validation</summary>

- `vp check packages/vinext/src/server/app-elements-wire.ts packages/vinext/src/server/app-browser-entry.ts packages/vinext/src/server/app-browser-state.ts tests/app-browser-entry.test.ts tests/e2e/app-router/build-id-navigation.spec.ts`
  - Formatting, lint, and type checks passed for 5 files.
- `vp test run tests/app-browser-entry.test.ts tests/cache-proof.test.ts tests/navigation-planner.test.ts tests/app-elements.test.ts`
  - 4 files passed.
  - 262 tests passed.
- `vp run vinext#build`
  - Build completed successfully. It emitted the existing expected unresolved external or virtual module warnings for packaged entry placeholders.
- `PLAYWRIGHT_PROJECT=app-router pnpm run test:e2e tests/e2e/app-router/build-id-navigation.spec.ts`
  - 1 test passed.
- `PLAYWRIGHT_PROJECT=app-router pnpm run test:e2e tests/e2e/app-router/navigation-flows.spec.ts tests/e2e/app-router/layout-persistence.spec.ts tests/e2e/app-router/navigation-regressions.spec.ts`
  - Command completed with exit 0.
  - 30 passed, 2 flaky tests passed on retry. The first-attempt flakes were dev overlay pointer interception in existing error-overlay coverage, not the cache proof path.
- Isolated reruns passed:
  - `PLAYWRIGHT_PROJECT=app-router pnpm run test:e2e tests/e2e/app-router/navigation-regressions.spec.ts -g "cross-route then same-route navigation works"`
  - `PLAYWRIGHT_PROJECT=app-router pnpm run test:e2e tests/e2e/app-router/layout-persistence.spec.ts -g "navigating away from error and back clears the error"`
- Commit hook passed formatting, lint/type checks across 609 files, and `knip`.
- Review subagent after the follow-up fix reported: no blocking findings.

</details>

<details>
<summary>Risk / compatibility</summary>

- Public API impact: none intended.
- Browser runtime impact: proofed cache-restored App Router payloads can commit through the planner gate. Unproofed real payloads refetch instead of restoring from the visited-response cache until the real proof producer is wired.
- Fresh RSC payload impact: omission of cache proof remains compatible.
- Cache/router impact: this is a planner/lifecycle proof gate plus an interim visited-cache storage gate. It does not implement the ClientReuseManifest or a broader cache coordinator.
- Existing-app risk: older cached client payloads without proof are not trusted as semantic reuse authority.

</details>

<details>
<summary>Non-goals</summary>

- Does not implement ClientReuseManifest.
- Does not wire the final real proof producer into `renderAppPageToReadableStream` yet.
- Does not redesign ISR or visited-response cache storage beyond the required interim eligibility gate.
- Does not make runtime cache proof a semantic substitute for route topology, interception, or root-boundary checks.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| #726 | Architectural umbrella for the planner and proof model. |
| #726-CACHE-13/14 | Specific task implemented by this PR. |
| `.nextjs-ref/test/e2e/app-dir/use-cache` and segment-cache coverage | Searched for related Next.js cache behavior. This PR is an internal vinext lifecycle invariant rather than a direct public Next.js API parity port. |
