### PR TITLE
fix(pages-router): avoid getServerSideProps identifier collision in build

### DIFF
--- a/packages/vinext/src/plugins/strip-server-exports.ts
+++ b/packages/vinext/src/plugins/strip-server-exports.ts
@@ -53,22 +53,32 @@ export function stripServerExports(code: string): string | null {
     }
 
     // Case 3: export { getServerSideProps } or export { getServerSideProps as gSSP }
+    //
+    // We must NOT emit `export const getServerSideProps = undefined` here:
+    // the user typically has a local `const getServerSideProps = ...` (or
+    // `function getServerSideProps() {}`) binding in the same scope that the
+    // specifier re-exports. Re-declaring the binding with `const` would
+    // produce a `Identifier ... has already been declared` parse error under
+    // OXC/Rolldown, which is stricter than the legacy webpack/esbuild
+    // pipeline. Instead, drop the specifier entirely and let the now-unused
+    // local declaration be tree-shaken.
+    //
+    // This matches Next.js's `next-ssg-transform` behavior, which removes
+    // server-export specifiers without emitting a stub.
     if (node.specifiers && node.specifiers.length > 0 && !node.source) {
       const kept: Extract<ASTNode, { type: "ExportSpecifier" }>[] = [];
-      const stripped: string[] = [];
+      let strippedAny = false;
       for (const spec of node.specifiers) {
         // spec.local.name is the binding name, spec.exported.name is the export name
         // oxlint-disable-next-line typescript/no-explicit-any
         const exportedName = (spec.exported as any)?.name ?? (spec.exported as any)?.value;
         if (SERVER_EXPORTS.has(exportedName)) {
-          stripped.push(exportedName);
+          strippedAny = true;
         } else {
           kept.push(spec);
         }
       }
-      if (stripped.length > 0) {
-        // Build replacement: keep non-server specifiers, add stubs for stripped ones
-        const parts: string[] = [];
+      if (strippedAny) {
         if (kept.length > 0) {
           const keptStr = kept
             // oxlint-disable-next-line typescript/no-explicit-any
@@ -78,12 +88,11 @@ export function stripServerExports(code: string): string | null {
               return local === exported ? local : `${local} as ${exported}`;
             })
             .join(", ");
-          parts.push(`export { ${keptStr} };`);
+          s.overwrite(node.start, node.end, `export { ${keptStr} };`);
+        } else {
+          // Drop the entire `export { ... }` statement.
+          s.overwrite(node.start, node.end, "");
         }
-        for (const name of stripped) {
-          parts.push(`export const ${name} = undefined;`);
-        }
-        s.overwrite(node.start, node.end, parts.join("\n"));
         changed = true;
       }
     }

--- a/tests/build-optimization.test.ts
+++ b/tests/build-optimization.test.ts
@@ -9,6 +9,7 @@ import fsp from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, it, expect, beforeEach, afterEach } from "vite-plus/test";
+import { parseAst } from "vite";
 import { augmentSsrManifestFromBundle as _augmentSsrManifestFromBundle } from "../packages/vinext/src/build/ssr-manifest.js";
 import { stripServerExports as _stripServerExports } from "../packages/vinext/src/plugins/strip-server-exports.js";
 import {
@@ -1851,6 +1852,11 @@ export const getServerSideProps = async function fetchData() {
 
   it("handles export { name } re-export syntax", () => {
     // This pattern was completely unhandled by the old regex approach.
+    //
+    // Regression test for #1354: emitting `export const getServerSideProps =
+    // undefined;` here collides with the existing local `const
+    // getServerSideProps` binding and triggers a parse error under
+    // OXC/Rolldown. We must drop the specifier without adding a stub.
     const code = `
 const getServerSideProps = async () => {
   return { props: { data: 'secret' } };
@@ -1864,9 +1870,16 @@ export { getServerSideProps };
 `;
     const result = _stripServerExports(code);
     expect(result).not.toBeNull();
-    expect(result).toContain("export const getServerSideProps = undefined;");
-    // The original local declaration remains (dead code, tree-shaken later)
+    // The `export { getServerSideProps }` statement must be removed entirely
+    // — no stub declaration is added.
     expect(result).not.toContain("export { getServerSideProps }");
+    expect(result).not.toContain("export const getServerSideProps");
+    // The unused local declaration becomes dead code and is tree-shaken
+    // later. It must not be duplicated by the transform.
+    const constMatches = result!.match(/const getServerSideProps\b/g) ?? [];
+    expect(constMatches).toHaveLength(1);
+    // The transformed code must be valid JS (no redeclaration).
+    expect(() => parseAst(result!)).not.toThrow();
   });
 
   it("handles export { name } with other specifiers", () => {
@@ -1884,9 +1897,84 @@ export { getServerSideProps, config };
 `;
     const result = _stripServerExports(code);
     expect(result).not.toBeNull();
-    // config should be preserved
+    // config should be preserved, getServerSideProps specifier dropped.
     expect(result).toContain("export { config }");
-    expect(result).toContain("export const getServerSideProps = undefined;");
+    expect(result).not.toContain("export { getServerSideProps");
+    expect(result).not.toContain("export const getServerSideProps");
+    expect(() => parseAst(result!)).not.toThrow();
+  });
+
+  // Regression test for #1354: every supported declaration form must
+  // produce parseable output when combined with `export { name }`.
+  it("does not redeclare identifiers for function-declaration + named export", () => {
+    const code = `
+async function getServerSideProps() {
+  return { props: {} };
+}
+
+export default function Page() {
+  return null;
+}
+
+export { getServerSideProps };
+`;
+    const result = _stripServerExports(code);
+    expect(result).not.toBeNull();
+    expect(result).not.toContain("export const getServerSideProps");
+    expect(() => parseAst(result!)).not.toThrow();
+  });
+
+  it("does not redeclare identifiers when both getServerSideProps and getStaticProps use named export", () => {
+    const code = `
+const getServerSideProps = async () => ({ props: {} });
+const getStaticProps = async () => ({ props: {} });
+
+export default function Page() {
+  return null;
+}
+
+export { getServerSideProps, getStaticProps };
+`;
+    const result = _stripServerExports(code);
+    expect(result).not.toBeNull();
+    expect(result).not.toContain("export const getServerSideProps");
+    expect(result).not.toContain("export const getStaticProps");
+    expect(result).not.toContain("export {");
+    expect(() => parseAst(result!)).not.toThrow();
+  });
+
+  it("does not redeclare identifiers when local `let` binding is re-exported", () => {
+    const code = `
+let getStaticPaths = async () => ({ paths: [], fallback: false });
+
+export default function Page() {
+  return null;
+}
+
+export { getStaticPaths };
+`;
+    const result = _stripServerExports(code);
+    expect(result).not.toBeNull();
+    expect(result).not.toContain("export const getStaticPaths");
+    // Must not introduce a `const getStaticPaths` next to the `let`.
+    expect(result).not.toMatch(/const\s+getStaticPaths/);
+    expect(() => parseAst(result!)).not.toThrow();
+  });
+
+  it("handles aliased named export (export { local as getServerSideProps })", () => {
+    const code = `
+const fetchData = async () => ({ props: {} });
+
+export default function Page() {
+  return null;
+}
+
+export { fetchData as getServerSideProps };
+`;
+    const result = _stripServerExports(code);
+    expect(result).not.toBeNull();
+    expect(result).not.toContain("getServerSideProps");
+    expect(() => parseAst(result!)).not.toThrow();
   });
 
   it("handles strings containing braces", () => {

--- a/tests/fixtures/pages-basic/pages/gssp-named-export.tsx
+++ b/tests/fixtures/pages-basic/pages/gssp-named-export.tsx
@@ -1,0 +1,30 @@
+// Regression fixture for #1354: pages may declare `getServerSideProps` as a
+// local `const` and re-export it via `export { getServerSideProps }`. The
+// build pipeline must not redeclare the identifier when stripping server
+// exports from the client bundle.
+//
+// Ported from Next.js: test/e2e/getserversideprops/app/pages/refresh.js
+// https://github.com/vercel/next.js/blob/canary/test/e2e/getserversideprops/app/pages/refresh.js
+interface Props {
+  message: string;
+}
+
+const getServerSideProps = async () => {
+  return {
+    props: {
+      message: "Hello from named-export gSSP",
+    },
+  };
+};
+
+function GsspNamedExportPage({ message }: Props) {
+  return (
+    <div>
+      <h1>gSSP via named export</h1>
+      <p data-testid="message">{message}</p>
+    </div>
+  );
+}
+
+export default GsspNamedExportPage;
+export { getServerSideProps };

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -304,6 +304,19 @@ describe("Pages Router integration", () => {
     expect(html).toContain("Rendered at:");
   });
 
+  // Regression test for #1354: when a page declares `getServerSideProps` as
+  // a local `const` and exports it via `export { getServerSideProps }`, the
+  // client-bundle transform must strip the export specifier without
+  // redeclaring the identifier. Prior to the fix, the build failed with
+  // `Identifier 'getServerSideProps' has already been declared` under OXC.
+  it("renders a page that exports gSSP via `export { ... }` named re-export", async () => {
+    const res = await fetch(`${baseUrl}/gssp-named-export`);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("gSSP via named export");
+    expect(html).toContain("Hello from named-export gSSP");
+  });
+
   it("getServerSideProps headers and status are applied to the response", async () => {
     const res = await fetch(`${baseUrl}/ssr-headers`);
     // gSSP sets statusCode = 201
@@ -2463,6 +2476,18 @@ export default function CounterPage() {
       expect(ssrRes.status).toBe(200);
       const ssrHtml = await ssrRes.text();
       expect(ssrHtml).toContain("Server-Side Rendered");
+
+      // Regression test for #1354: a page that exports `getServerSideProps`
+      // via a separate `export { getServerSideProps }` re-export must build
+      // and render in production. Previously, the client bundle transform
+      // emitted a stub `export const getServerSideProps = undefined;` that
+      // collided with the user's local `const getServerSideProps = ...`
+      // binding and broke the Rolldown/OXC parse step.
+      const gsspNamedRes = await fetch(`${prodUrl}/gssp-named-export`);
+      expect(gsspNamedRes.status).toBe(200);
+      const gsspNamedHtml = await gsspNamedRes.text();
+      expect(gsspNamedHtml).toContain("gSSP via named export");
+      expect(gsspNamedHtml).toContain("Hello from named-export gSSP");
 
       // Test: API route
       const apiRes = await fetch(`${prodUrl}/api/hello`);


### PR DESCRIPTION
## Summary

When a Pages Router page declared `getServerSideProps` (or `getStaticProps` / `getStaticPaths`) as a local binding and re-exported it via the `export { ... }` form, vinext's `stripServerExports` transform overwrote the export statement with `export const getServerSideProps = undefined;`, leaving the user's local `const getServerSideProps = ...` in place. The result was two declarations of the same identifier in module scope, which Rolldown/OXC rejects with `Identifier \`getServerSideProps\` has already been declared`. A single such page broke the entire production build (cascading to 48 failures in Next.js's `test/e2e/getserversideprops` suite).

The fix drops the export specifier without emitting a stub declaration, matching Next.js's [`next-ssg-transform`](https://github.com/vercel/next.js/blob/canary/packages/next/src/build/babel/plugins/next-ssg-transform.ts#L248-L268) behaviour. The now-unused local declaration becomes dead code and is tree-shaken later.

### Failing input

```js
const getServerSideProps = async () => {
  return { props: {} };
};

export default function Page() { return null; }
export { getServerSideProps };
```

### Before (broken transform output)

```js
const getServerSideProps = async () => { /* original */ };
export default function Page() { return null; }
export const getServerSideProps = undefined; // ← redeclaration error
```

### After (fixed transform output)

```js
const getServerSideProps = async () => { /* original, now unreferenced; tree-shaken */ };
export default function Page() { return null; }
// `export { getServerSideProps }` removed entirely
```

## Test plan

- [x] New unit tests in `tests/build-optimization.test.ts` cover every supported declaration form combined with `export { ... }`: `const` arrow, `let`, `async function` declaration, multi-export specifiers, and aliased (`export { local as getServerSideProps }`) syntax. Each asserts the output contains no duplicate declarations.
- [x] New fixture page `tests/fixtures/pages-basic/pages/gssp-named-export.tsx` ports the failing pattern from [Next.js `test/e2e/getserversideprops/app/pages/refresh.js`](https://github.com/vercel/next.js/blob/canary/test/e2e/getserversideprops/app/pages/refresh.js).
- [x] New `pages-router` dev test renders the fixture and asserts the response body.
- [x] Extended the existing "serves pages from production build end-to-end" test to fetch `/gssp-named-export` from the built worker — this is the direct regression test for the production-only OXC parse error.
- [x] Verified the production-build test reproduces the exact error on `main` and passes with the fix applied.
- [x] `pnpm test tests/build-optimization.test.ts` — 79 passed.
- [x] `pnpm test tests/pages-router.test.ts` — 210 passed.
- [x] `pnpm test tests/deploy.test.ts` — 220 passed.
- [x] `pnpm run check` — clean.

Closes #1354