### PR TITLE
fix: warn on blocked javascript: URL navigation

### DIFF
--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -36,7 +36,7 @@ import {
 import { AppElementsWire } from "../server/app-elements.js";
 import { createRscRequestHeaders, createRscRequestUrl } from "../server/app-rsc-cache-busting.js";
 import { VINEXT_MOUNTED_SLOTS_HEADER } from "../server/headers.js";
-import { isDangerousScheme } from "./url-safety.js";
+import { isDangerousScheme, reportBlockedDangerousNavigation } from "./url-safety.js";
 import {
   canLinkIntentPrefetch,
   canLinkPrefetch,
@@ -646,11 +646,20 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
     if (process.env.NODE_ENV !== "production") {
       console.warn(`<Link> blocked dangerous href: ${resolvedHref}`);
     }
+    // Match Next.js parity: when a user clicks a Link whose href has a
+    // dangerous scheme, emit the same `console.error` that Next.js surfaces
+    // via React's event-handler runtime when `router.push` throws.
+    // Ported from Next.js: test/e2e/app-dir/javascript-urls/javascript-urls.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/javascript-urls/javascript-urls.test.ts
+    const handleDangerousClick = (event: MouseEvent<HTMLAnchorElement>) => {
+      if (onClick) onClick(event);
+      reportBlockedDangerousNavigation();
+    };
     return (
       <LinkStatusContext.Provider value={linkStatusValue}>
         <a
           ref={setRefs}
-          onClick={onClick}
+          onClick={handleDangerousClick}
           onMouseEnter={handleMouseEnter}
           onTouchStart={handleTouchStart}
           {...anchorProps}

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -47,6 +47,7 @@ import {
 import { matchRoutePattern, routePatternParts } from "../routing/route-pattern.js";
 import { scrollToHashTarget } from "./hash-scroll.js";
 import { setPagesRouterPopStateHandler } from "./pages-router-runtime.js";
+import { assertSafeNavigationUrl } from "./url-safety.js";
 
 /** basePath from next.config.js, injected by the plugin at build time */
 const __basePath: string = process.env.__NEXT_ROUTER_BASEPATH ?? "";
@@ -840,6 +841,19 @@ async function performNavigation(
   mode: "push" | "replace",
   onStateUpdate?: () => void,
 ): Promise<boolean> {
+  // Block dangerous URI schemes (javascript:, data:, vbscript:) before any
+  // navigation work happens. Mirrors Next.js's Pages Router guard at
+  // packages/next/src/shared/lib/router/router.ts:1020-1028,1052-1060, which
+  // throws and (via React's event-handler runtime) surfaces a console.error
+  // that the `test/e2e/app-dir/javascript-urls/javascript-urls.test.ts` suite
+  // asserts on. `assertSafeNavigationUrl` emits the matching console.error
+  // before throwing so the same observable behaviour holds when the throw is
+  // swallowed by an async event handler (e.g. Link's click delegation).
+  assertSafeNavigationUrl(resolveUrl(url));
+  if (as !== undefined) {
+    assertSafeNavigationUrl(String(as));
+  }
+
   const navigationLocale = resolveTransitionLocale(options?.locale);
   let resolved = resolveNavigationTarget(url, as, navigationLocale);
 

--- a/packages/vinext/src/shims/url-safety.ts
+++ b/packages/vinext/src/shims/url-safety.ts
@@ -42,8 +42,34 @@ export function isDangerousScheme(url: string): boolean {
   return DANGEROUS_SCHEME_RES.some((re) => re.test(str));
 }
 
+/**
+ * Emit a `console.error` matching Next.js's blocked-navigation message.
+ *
+ * Next.js's `router.push` / `router.replace` / `router.prefetch` (and the
+ * Pages Router equivalents) throw an `Error` when the URL has a dangerous
+ * scheme. In the browser, React's event-handler runtime catches that throw
+ * and reports it through `console.error`, which is what the Next.js E2E
+ * `test/e2e/app-dir/javascript-urls` suite asserts on.
+ *
+ * Vinext's navigation guards run synchronously inside async event handlers
+ * (e.g. Link's `void handleClick(event)`), so a raw throw is dropped on the
+ * floor instead of bubbling up to React. Emitting the same `console.error`
+ * explicitly keeps observable behaviour aligned with Next.js — the test
+ * matcher uses `.includes("has blocked a javascript: URL as a security
+ * precaution.")` so any message containing that phrase satisfies it.
+ *
+ * Source reference (Next.js):
+ *   packages/next/src/client/components/segment-cache/navigation.ts:537
+ *   packages/next/src/client/components/app-router-instance.ts:345,402,442,460
+ *   packages/next/src/shared/lib/router/router.ts:1025,1057
+ */
+export function reportBlockedDangerousNavigation(): void {
+  console.error(DANGEROUS_URL_BLOCK_MESSAGE);
+}
+
 export function assertSafeNavigationUrl(url: string): void {
   if (isDangerousScheme(url)) {
+    reportBlockedDangerousNavigation();
     throw new Error(DANGEROUS_URL_BLOCK_MESSAGE);
   }
 }

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -1215,4 +1215,58 @@ describe("Link prefetch scheduling", () => {
       result.restoreNodeEnv();
     }
   });
+
+  // Ported from Next.js: test/e2e/app-dir/javascript-urls/javascript-urls.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/javascript-urls/javascript-urls.test.ts
+  // The Next.js test asserts a console.error log appears whose message
+  // includes "has blocked a javascript: URL as a security precaution.".
+  it("emits a console.error matching Next.js when a dangerous Link is clicked", async () => {
+    const userOnClick = vi.fn();
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const result = await renderIsolatedLink({
+      href: "javascript:alert(1)",
+      nodeEnv: "development",
+      props: {
+        onClick: userOnClick,
+      },
+      requireRef: false,
+    });
+
+    try {
+      const onClick = result.capturedAnchorProps.onClick;
+      expect(onClick).toBeTypeOf("function");
+      const clickEvent = {
+        button: 0,
+        currentTarget: { hasAttribute: () => false, target: "" },
+        defaultPrevented: false,
+        preventDefault() {
+          this.defaultPrevented = true;
+        },
+      } satisfies CapturedClickEvent;
+
+      await onClick?.(clickEvent);
+
+      // User onClick still fires so callers can run analytics/preventDefault.
+      expect(userOnClick).toHaveBeenCalledWith(clickEvent);
+      // Navigation never happens.
+      expect(result.navigate).not.toHaveBeenCalled();
+      expect(result.fetch).not.toHaveBeenCalled();
+      // Next.js parity: a console.error is emitted that includes the block
+      // message — the E2E suite asserts on `.includes(...)` against this text.
+      expect(
+        consoleError.mock.calls.some((call) =>
+          call.some(
+            (arg) =>
+              typeof arg === "string" &&
+              arg.includes("has blocked a javascript: URL as a security precaution."),
+          ),
+        ),
+      ).toBe(true);
+    } finally {
+      consoleError.mockRestore();
+      consoleWarn.mockRestore();
+      result.restoreNodeEnv();
+    }
+  });
 });

--- a/tests/router-javascript-urls.test.ts
+++ b/tests/router-javascript-urls.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vite-plus/test";
+import { afterEach, describe, it, expect, vi } from "vite-plus/test";
 
 // Ported from Next.js: test/e2e/app-dir/javascript-urls/javascript-urls.test.ts
 // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/javascript-urls/javascript-urls.test.ts
@@ -6,6 +6,16 @@ import { describe, it, expect } from "vite-plus/test";
 // Next.js blocks dangerous URI schemes in router.push/replace/prefetch with a
 // thrown Error: "Next.js has blocked a javascript: URL as a security precaution."
 // See: packages/next/src/client/components/app-router-instance.ts:343,400,440,458
+//
+// The Next.js E2E test asserts the blocked navigation surfaces as a
+// `console.error` whose message matches
+//   "has blocked a javascript: URL as a security precaution."
+// In Next.js, the thrown Error is caught by React's event-handler runtime and
+// reported via `console.error`. Vinext's Link/router shims do not always
+// propagate through React (e.g. Link click handlers are async, and async
+// throws are not reported to React). To match the observable Next.js
+// behaviour, vinext emits a `console.error` with the same message before the
+// throw, so the assertion fires in both unit-test and browser contexts.
 //
 // Vinext mirrors that behavior. The guard runs before any programmatic
 // navigation kicks off, at the top of push/replace/prefetch. Even server-side
@@ -80,5 +90,180 @@ describe("App Router appRouterInstance blocks dangerous URI schemes", () => {
   it("router.prefetch does not throw on a normal pathname", async () => {
     const { appRouterInstance } = await import("../packages/vinext/src/shims/navigation.js");
     expect(() => appRouterInstance.prefetch("/safe")).not.toThrow();
+  });
+});
+
+describe("App Router appRouterInstance emits console.error on dangerous URI schemes", () => {
+  it("router.push logs to console.error before throwing", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const { appRouterInstance } = await import("../packages/vinext/src/shims/navigation.js");
+      expect(() => appRouterInstance.push("javascript:alert(1)")).toThrow(BLOCK_MESSAGE);
+      expect(consoleError).toHaveBeenCalledWith(BLOCK_MESSAGE);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it("router.replace logs to console.error before throwing", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const { appRouterInstance } = await import("../packages/vinext/src/shims/navigation.js");
+      expect(() => appRouterInstance.replace("javascript:alert(1)")).toThrow(BLOCK_MESSAGE);
+      expect(consoleError).toHaveBeenCalledWith(BLOCK_MESSAGE);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it("router.prefetch logs to console.error before throwing", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const { appRouterInstance } = await import("../packages/vinext/src/shims/navigation.js");
+      expect(() => appRouterInstance.prefetch("javascript:alert(1)")).toThrow(BLOCK_MESSAGE);
+      expect(consoleError).toHaveBeenCalledWith(BLOCK_MESSAGE);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it("does not log when the URL is safe", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const { appRouterInstance } = await import("../packages/vinext/src/shims/navigation.js");
+      appRouterInstance.push("/safe");
+      expect(consoleError).not.toHaveBeenCalledWith(BLOCK_MESSAGE);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+});
+
+// Pages Router parity: next/router push/replace must also block dangerous
+// URI schemes with both a throw and a matching console.error. Mirrors
+// Next.js's `packages/next/src/shared/lib/router/router.ts:1020,1052`, where
+// push/replace throw the same error message.
+describe("Pages Router next/router blocks dangerous URI schemes", () => {
+  // Minimal fake window/document so importing shims/router.ts (which touches
+  // window at module load to attach popstate) does not crash. Installed by
+  // the helper below; restored in `afterEach`.
+  function installFakeBrowserGlobals() {
+    const previousWindow = (globalThis as { window?: unknown }).window;
+    const previousDocument = (globalThis as { document?: unknown }).document;
+    (globalThis as { window?: unknown }).window = {
+      location: {
+        pathname: "/",
+        search: "",
+        hash: "",
+        href: "http://localhost/",
+        origin: "http://localhost",
+      },
+      history: { state: null, pushState() {}, replaceState() {} },
+      addEventListener() {},
+      dispatchEvent() {},
+    };
+    (globalThis as { document?: unknown }).document = {
+      addEventListener() {},
+    };
+    return () => {
+      (globalThis as { window?: unknown }).window = previousWindow as never;
+      (globalThis as { document?: unknown }).document = previousDocument as never;
+    };
+  }
+
+  afterEach(() => {
+    vi.resetModules();
+  });
+
+  it("Router.push rejects on javascript: URL", async () => {
+    const restoreBrowserGlobals = installFakeBrowserGlobals();
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      vi.resetModules();
+      const routerModule = await import("../packages/vinext/src/shims/router.js");
+      const Router = routerModule.default;
+      await expect(Router.push("javascript:alert(1)")).rejects.toThrow(BLOCK_MESSAGE);
+      expect(consoleError).toHaveBeenCalledWith(BLOCK_MESSAGE);
+    } finally {
+      consoleError.mockRestore();
+      restoreBrowserGlobals();
+    }
+  });
+
+  it("Router.replace rejects on javascript: URL", async () => {
+    const restoreBrowserGlobals = installFakeBrowserGlobals();
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      vi.resetModules();
+      const routerModule = await import("../packages/vinext/src/shims/router.js");
+      const Router = routerModule.default;
+      await expect(Router.replace("javascript:alert(1)")).rejects.toThrow(BLOCK_MESSAGE);
+      expect(consoleError).toHaveBeenCalledWith(BLOCK_MESSAGE);
+    } finally {
+      consoleError.mockRestore();
+      restoreBrowserGlobals();
+    }
+  });
+
+  it("Router.push rejects when only `as` is a javascript: URL", async () => {
+    const restoreBrowserGlobals = installFakeBrowserGlobals();
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      vi.resetModules();
+      const routerModule = await import("../packages/vinext/src/shims/router.js");
+      const Router = routerModule.default;
+      await expect(Router.push("/safe", "javascript:alert(1)")).rejects.toThrow(BLOCK_MESSAGE);
+      expect(consoleError).toHaveBeenCalledWith(BLOCK_MESSAGE);
+    } finally {
+      consoleError.mockRestore();
+      restoreBrowserGlobals();
+    }
+  });
+
+  it("Router.replace rejects when only `as` is a javascript: URL", async () => {
+    const restoreBrowserGlobals = installFakeBrowserGlobals();
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      vi.resetModules();
+      const routerModule = await import("../packages/vinext/src/shims/router.js");
+      const Router = routerModule.default;
+      await expect(Router.replace("/safe", "javascript:alert(1)")).rejects.toThrow(BLOCK_MESSAGE);
+      expect(consoleError).toHaveBeenCalledWith(BLOCK_MESSAGE);
+    } finally {
+      consoleError.mockRestore();
+      restoreBrowserGlobals();
+    }
+  });
+
+  it("Router.push rejects on uppercase JAVASCRIPT: URL", async () => {
+    const restoreBrowserGlobals = installFakeBrowserGlobals();
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      vi.resetModules();
+      const routerModule = await import("../packages/vinext/src/shims/router.js");
+      const Router = routerModule.default;
+      await expect(Router.push("JAVASCRIPT:alert(1)")).rejects.toThrow(BLOCK_MESSAGE);
+      expect(consoleError).toHaveBeenCalledWith(BLOCK_MESSAGE);
+    } finally {
+      consoleError.mockRestore();
+      restoreBrowserGlobals();
+    }
+  });
+
+  it("Router.push rejects on data: URL", async () => {
+    const restoreBrowserGlobals = installFakeBrowserGlobals();
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      vi.resetModules();
+      const routerModule = await import("../packages/vinext/src/shims/router.js");
+      const Router = routerModule.default;
+      await expect(Router.push("data:text/html,<script>alert(1)</script>")).rejects.toThrow(
+        BLOCK_MESSAGE,
+      );
+      expect(consoleError).toHaveBeenCalledWith(BLOCK_MESSAGE);
+    } finally {
+      consoleError.mockRestore();
+      restoreBrowserGlobals();
+    }
   });
 });


### PR DESCRIPTION
## Summary

Match Next.js's observable behaviour when a `<Link>` click, `router.push`, `router.replace`, or `router.prefetch` blocks a `javascript:` (or `data:` / `vbscript:`) URL.

Vinext already prevented the dangerous navigation, but the `console.error` that the Next.js E2E suite asserts on (`test/e2e/app-dir/javascript-urls`) was missing because:

- App Router `router.push` / `replace` / `prefetch` threw synchronously inside `React.startTransition` callbacks — that throw never reached React's event-handler error reporter that would normally log it.
- `<Link>` rendered an inert anchor with no `href`. Clicking did nothing — no throw, no log.
- Pages Router `next/router` had no `javascript:` guard at all and would fall through to `window.location.assign(...)` for `javascript:` URLs (caught and turned into a generic XHR failure in tests).

The fix centralises the matching console message in `shims/url-safety.ts` via a new `reportBlockedDangerousNavigation()` helper:

- `assertSafeNavigationUrl` now `console.error`s with the exact Next.js message before throwing, so any caller that throws also surfaces the matching log.
- `<Link>`'s dangerous-click branch installs an `onClick` that calls `reportBlockedDangerousNavigation()` (the rendered inert anchor still has no `href`, so navigation is still prevented).
- Pages Router `performNavigation` now calls `assertSafeNavigationUrl` for both `url` and `as` at the top of every push/replace, mirroring Next.js's `packages/next/src/shared/lib/router/router.ts:1020-1028,1052-1060`.

The block on `javascript:` remains; only the warning was added alongside it.

### Next.js reference for the exact wording

`"Next.js has blocked a javascript: URL as a security precaution."` — the same message string used throughout Next.js:

- App Router router instance: [`packages/next/src/client/components/app-router-instance.ts:345,402,442,460`](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/app-router-instance.ts#L345)
- Segment cache navigation (literal `console.error`): [`packages/next/src/client/components/segment-cache/navigation.ts:537`](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/segment-cache/navigation.ts#L537)
- Pages Router push/replace: [`packages/next/src/shared/lib/router/router.ts:1025,1057`](https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/router/router.ts#L1025)

The Next.js E2E test asserts on `.includes("has blocked a javascript: URL as a security precaution.")` so the same message satisfies both the "Next.js has blocked..." and "React has blocked..." (synthetic-event React-side) variants.

## Test plan

- [x] `pnpm test tests/router-javascript-urls.test.ts` — App Router + Pages Router `router.push/replace/prefetch` block dangerous schemes with both throw + matching `console.error`. Safe URLs do not log.
- [x] `pnpm test tests/link-navigation.test.ts` — clicking a `<Link href="javascript:...">` emits the matching `console.error` while still preventing navigation and preserving user `onClick`.
- [x] `pnpm test tests/link.test.ts tests/shims.test.ts tests/url-safety.test.ts tests/navigation-runtime.test.ts tests/features.test.ts tests/app-browser-entry.test.ts` — no regressions.
- [x] `pnpm run check` — formatting/lint/types clean.
- [ ] CI green on `Check`, `Vitest`, `Playwright E2E`.

Closes #1349