### PR TITLE
fix: pass params: null (not {}) for non-dynamic routes

### DIFF
--- a/packages/vinext/src/server/app-route-handler-cache.ts
+++ b/packages/vinext/src/server/app-route-handler-cache.ts
@@ -41,7 +41,8 @@ type ReadAppRouteHandlerCacheOptions = {
   isrSet: RouteHandlerCacheSetter;
   markDynamicUsage: MarkAppRouteDynamicUsageFn;
   middlewareContext: RouteHandlerMiddlewareContext;
-  params: AppRouteParams;
+  /** `null` for non-dynamic routes. See `AppRouteHandlerFunction` for details. */
+  params: AppRouteParams | null;
   requestUrl: string;
   revalidateSearchParams: URLSearchParams;
   expireSeconds?: number;
@@ -58,6 +59,12 @@ type ReadAppRouteHandlerCacheOptions = {
     } | null,
   ) => void;
 };
+
+// Navigation context expects a plain object (used for `useParams()` etc),
+// not `null`. For non-dynamic routes there are no params to expose, so we
+// pass an empty object — only the user-visible handler context surfaces
+// `null` for non-dynamic routes.
+const EMPTY_PARAMS: AppRouteParams = Object.freeze({}) as AppRouteParams;
 
 function getCachedAppRouteValue(entry: ISRCacheEntry | null) {
   return entry?.value.value && entry.value.value.kind === "APP_ROUTE" ? entry.value.value : null;
@@ -96,7 +103,7 @@ export async function readAppRouteHandlerCacheResponse(
           options.setNavigationContext({
             pathname: options.cleanPathname,
             searchParams: revalidateSearchParams,
-            params: options.params,
+            params: options.params ?? EMPTY_PARAMS,
           });
 
           const { dynamicUsedInHandler, response } = await runAppRouteHandler({
@@ -106,7 +113,7 @@ export async function readAppRouteHandlerCacheResponse(
             handlerFn: options.handlerFn,
             i18n: options.i18n,
             markDynamicUsage: options.markDynamicUsage,
-            params: makeThenableParams(options.params),
+            params: options.params === null ? null : makeThenableParams(options.params),
             request: new Request(options.requestUrl, { method: "GET" }),
             routePattern: options.routePattern,
             setHeadersAccessPhase: options.setHeadersAccessPhase,

--- a/packages/vinext/src/server/app-route-handler-dispatch.ts
+++ b/packages/vinext/src/server/app-route-handler-dispatch.ts
@@ -72,7 +72,12 @@ type DispatchAppRouteHandlerOptions = {
   isrSet: RouteHandlerCacheSetter;
   middlewareContext: RouteHandlerMiddlewareContext;
   middlewareRequestHeaders?: Headers | null;
-  params: AppRouteParams;
+  /**
+   * `null` for non-dynamic routes, matching Next.js semantics. The dispatch
+   * layer threads this through to the handler context unchanged so user code
+   * (`params ? await params : null`) resolves to `null`.
+   */
+  params: AppRouteParams | null;
   request: Request;
   route: AppRouteHandlerDispatchRoute;
   scheduleBackgroundRegeneration: RouteHandlerBackgroundRegenerator;
@@ -254,7 +259,7 @@ export async function dispatchAppRouteHandler(
       method,
       middlewareContext: options.middlewareContext,
       middlewareRequestHeaders: options.middlewareRequestHeaders,
-      params: makeThenableParams(options.params),
+      params: options.params === null ? null : makeThenableParams(options.params),
       reportRequestError(error, request, context) {
         void reportRequestError(error, request, context);
       },

--- a/packages/vinext/src/server/app-route-handler-execution.ts
+++ b/packages/vinext/src/server/app-route-handler-execution.ts
@@ -31,9 +31,20 @@ import {
 export type AppRouteParams = Record<string, string | string[]>;
 export type AppRouteDynamicUsageFn = () => boolean;
 export type MarkAppRouteDynamicUsageFn = () => void;
+/**
+ * Route handler context.
+ *
+ * `params` is `null` for non-dynamic routes (no `[param]` segments) so that
+ * user code like `params ? await params : null` resolves to `null`, matching
+ * Next.js behavior. For dynamic routes it's a thenable that resolves to the
+ * matched params object.
+ *
+ * See: test/e2e/app-dir/app-routes/app-custom-routes.test.ts in Next.js for
+ * the authoritative assertion (`expect(meta.params).toEqual(null)`).
+ */
 export type AppRouteHandlerFunction = (
   request: NextRequest,
-  context: { params: AppRouteParams },
+  context: { params: AppRouteParams | null },
 ) => Response | Promise<Response>;
 export type RouteHandlerCacheSetter = (
   key: string,
@@ -57,7 +68,11 @@ type RunAppRouteHandlerOptions = {
   i18n?: NextI18nConfig | null;
   markDynamicUsage: MarkAppRouteDynamicUsageFn;
   middlewareRequestHeaders?: Headers | null;
-  params: AppRouteParams;
+  /**
+   * `null` for non-dynamic routes. Passed through to the handler context
+   * unchanged — callers are expected to compute this from `route.isDynamic`.
+   */
+  params: AppRouteParams | null;
   request: Request;
   routePattern?: string;
   setHeadersAccessPhase?: (phase: HeadersAccessPhase) => HeadersAccessPhase;

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -105,7 +105,13 @@ type DispatchMatchedPageOptions<TRoute> = {
 type DispatchMatchedRouteHandlerOptions<TRoute> = {
   cleanPathname: string;
   middlewareContext: AppRscMiddlewareContext;
-  params: AppPageParams;
+  /**
+   * `null` for non-dynamic routes. Mirrors Next.js' route handler context
+   * shape: user code that does `params ? await params : null` resolves to
+   * `null` for routes without dynamic segments. Dynamic routes receive the
+   * matched params object.
+   */
+  params: AppPageParams | null;
   request: Request;
   route: TRoute;
   searchParams: URLSearchParams;
@@ -533,7 +539,11 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
     return options.dispatchMatchedRouteHandler({
       cleanPathname,
       middlewareContext,
-      params,
+      // Non-dynamic routes report params as `null` to match Next.js. Internal
+      // bookkeeping above (navigation context, root params) keeps the matched
+      // object (always `{}` for non-dynamic) so `useParams()` etc. still see
+      // an object shape; only the user-facing handler context surfaces null.
+      params: route.isDynamic ? params : null,
       request,
       route,
       searchParams: url.searchParams,

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -332,6 +332,13 @@ export function createSSRHandler(
     }
 
     const { route, params } = match;
+    // Next.js exposes `params: null` to data-fetching contexts (gSSP, gSP) on
+    // non-dynamic routes — see render.tsx's `...(pageIsDynamic ? { params } : undefined)`.
+    // Internal use (query merging, _app router context) keeps the matched
+    // object since those expect a record shape, not null.
+    const userFacingParams: Record<string, string | string[]> | null = route.isDynamic
+      ? params
+      : null;
     const query = mergeRouteParamsIntoQuery(parseQuery(url), params);
 
     // Wrap the entire request in a single unified AsyncLocalStorage scope.
@@ -463,7 +470,7 @@ export function createSSRHandler(
           const headersBeforeGSSP = new Set(Object.keys(res.getHeaders()));
 
           const context = {
-            params,
+            params: userFacingParams,
             req,
             res,
             query,
@@ -606,7 +613,7 @@ export function createSSRHandler(
                 return runWithRequestContext(regenContext, async () => {
                   ensureFetchPatch();
                   const freshResult = await pageModule.getStaticProps({
-                    params,
+                    params: userFacingParams,
                     locale: locale ?? currentDefaultLocale,
                     locales: i18nConfig?.locales,
                     defaultLocale: currentDefaultLocale,
@@ -735,7 +742,7 @@ export function createSSRHandler(
 
           // Cache miss — call getStaticProps normally
           const context = {
-            params,
+            params: userFacingParams,
             locale: locale ?? currentDefaultLocale,
             locales: i18nConfig?.locales,
             defaultLocale: currentDefaultLocale,

--- a/packages/vinext/src/server/pages-page-data.ts
+++ b/packages/vinext/src/server/pages-page-data.ts
@@ -54,8 +54,19 @@ export type PagesPageModule = {
     locales: string[];
     defaultLocale: string;
   }) => Promise<PagesStaticPathsResult> | PagesStaticPathsResult;
+  /**
+   * Pages Router data-fetching context.
+   *
+   * `params` is `null` for non-dynamic routes (no `[param]` segments) to
+   * match Next.js. User code typically falls back via `params || null`, so
+   * passing `null` (rather than `{}`) is required for the value to be
+   * observable as `null` once the data flows through to the page props.
+   *
+   * See: test/e2e/edge-pages-support/index.test.ts in Next.js for the
+   * authoritative assertion (`expect(props.params).toBe(null)`).
+   */
   getServerSideProps?: (context: {
-    params: Record<string, unknown>;
+    params: Record<string, unknown> | null;
     req: unknown;
     res: PagesMutableGsspResponse;
     query: Record<string, unknown>;
@@ -65,7 +76,7 @@ export type PagesPageModule = {
     defaultLocale?: string;
   }) => Promise<PagesPagePropsResult> | PagesPagePropsResult;
   getStaticProps?: (context: {
-    params: Record<string, unknown>;
+    params: Record<string, unknown> | null;
     locale?: string;
     locales?: string[];
     defaultLocale?: string;
@@ -272,6 +283,15 @@ export async function renderPagesIsrHtml(options: RenderPagesIsrHtmlOptions): Pr
 export async function resolvePagesPageData(
   options: ResolvePagesPageDataOptions,
 ): Promise<ResolvePagesPageDataResult> {
+  // Next.js passes `params: null` (effectively) to gSSP/gSP context for
+  // non-dynamic routes — see render.tsx's `...(pageIsDynamic ? { params } : undefined)`.
+  // Internal bookkeeping (route param hydration, ISR HTML, getStaticPaths
+  // validation) still uses the matched-but-empty object — only user-facing
+  // data-fetching contexts surface `null`.
+  const userFacingParams: Record<string, unknown> | null = options.route.isDynamic
+    ? options.params
+    : null;
+
   if (typeof options.pageModule.getStaticPaths === "function" && options.route.isDynamic) {
     const pathsResult = await options.pageModule.getStaticPaths({
       locales: options.i18n.locales ?? [],
@@ -300,7 +320,7 @@ export async function resolvePagesPageData(
   if (typeof options.pageModule.getServerSideProps === "function") {
     const { req, res, responsePromise } = options.createGsspReqRes();
     const result = await options.pageModule.getServerSideProps({
-      params: options.params,
+      params: userFacingParams,
       req,
       res,
       query: options.query,
@@ -369,7 +389,7 @@ export async function resolvePagesPageData(
         async function () {
           return options.runInFreshUnifiedContext(async () => {
             const freshResult = await options.pageModule.getStaticProps?.({
-              params: options.params,
+              params: userFacingParams,
               locale: options.i18n.locale,
               locales: options.i18n.locales,
               defaultLocale: options.i18n.defaultLocale,
@@ -424,7 +444,7 @@ export async function resolvePagesPageData(
     }
 
     const result = await options.pageModule.getStaticProps({
-      params: options.params,
+      params: userFacingParams,
       locale: options.i18n.locale,
       locales: options.i18n.locales,
       defaultLocale: options.i18n.defaultLocale,

--- a/tests/app-route-handler-dispatch.test.ts
+++ b/tests/app-route-handler-dispatch.test.ts
@@ -213,6 +213,50 @@ describe("app route handler dispatch", () => {
     expect(didClearRequestContext).toBe(true);
   });
 
+  // Matches Next.js behavior: route handlers on non-dynamic routes receive
+  // `context.params` as null (not `{}`). User code typically does
+  // `const resolved = params ? await params : null`, and the resolved value
+  // is observable through tests like `expect(meta.params).toEqual(null)`.
+  // Ported from Next.js: test/e2e/app-dir/app-routes/app-custom-routes.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/app-routes/app-custom-routes.test.ts#L424-L431
+  it("passes params: null to route handlers on non-dynamic routes", async () => {
+    let receivedParams: unknown = "untouched";
+    const route = {
+      pattern: "/api/static",
+      routeHandler: {
+        GET(_request: Request, context: { params: unknown }) {
+          receivedParams = context.params;
+          return new Response("ok");
+        },
+      },
+      routeSegments: ["api", "static"],
+    };
+
+    await dispatchAppRouteHandler({
+      cleanPathname: "/api/static",
+      clearRequestContext() {},
+      i18n: null,
+      isDevelopment: false,
+      isProduction: true,
+      async isrGet() {
+        return null;
+      },
+      isrRouteKey(pathname) {
+        return "route:" + pathname;
+      },
+      async isrSet() {},
+      middlewareContext: { headers: null, status: null },
+      middlewareRequestHeaders: null,
+      params: null,
+      request: new Request("https://example.com/api/static"),
+      route,
+      scheduleBackgroundRegeneration() {},
+      searchParams: new URLSearchParams(),
+    });
+
+    expect(receivedParams).toBeNull();
+  });
+
   it("attaches App Router route context when stale route handler cache schedules regeneration", async () => {
     const handlerSpy = vi.fn(() => new Response("regenerated"));
     let scheduledContext:

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -474,6 +474,7 @@ describe("createAppRscHandler", () => {
 
   it("dispatches route handlers with matched params", async () => {
     const route = createPageRoute({
+      isDynamic: true,
       page: null,
       pattern: "/api/:id",
       routeHandler: { GET: () => new Response("route") },
@@ -504,8 +505,44 @@ describe("createAppRscHandler", () => {
     );
   });
 
+  // Matches Next.js behavior: non-dynamic route handlers receive params=null.
+  // See test/e2e/app-dir/app-routes/app-custom-routes.test.ts in next.js.
+  it("dispatches non-dynamic route handlers with params: null", async () => {
+    const route = createPageRoute({
+      isDynamic: false,
+      page: null,
+      pattern: "/api/static",
+      routeHandler: { GET: () => new Response("route") },
+      routeSegments: ["api", "static"],
+    });
+    const dispatchMatchedRouteHandler = vi.fn(async () => new Response("route", { status: 200 }));
+    const handler = createHandler({
+      configHeaders: [],
+      dispatchMatchedRouteHandler,
+      matchRoute: (pathname: string) =>
+        pathname === "/api/static"
+          ? {
+              params: {},
+              route,
+            }
+          : null,
+    });
+
+    const response = await handler(new Request("https://example.test/docs/api/static"), null);
+
+    expect(response.status).toBe(200);
+    expect(dispatchMatchedRouteHandler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cleanPathname: "/api/static",
+        params: null,
+        route,
+      }),
+    );
+  });
+
   it("appends App Router RSC vary values to route handler responses", async () => {
     const route = createPageRoute({
+      isDynamic: true,
       page: null,
       pattern: "/api/:id",
       routeHandler: { GET: () => new Response("route") },

--- a/tests/fixtures/app-basic/app/nextjs-compat/api/params-null/route.ts
+++ b/tests/fixtures/app-basic/app/nextjs-compat/api/params-null/route.ts
@@ -1,0 +1,14 @@
+// Non-dynamic route handler: `context.params` should be null (not `{}`)
+// in Next.js. User code typically does `params ? await params : null`,
+// and the result must be observable as `null`.
+//
+// See Next.js test:
+// test/e2e/app-dir/app-routes/app-custom-routes.test.ts
+// - "does not provide params to routes without dynamic parameters"
+type ParamsContext = { params?: Promise<Record<string, string | string[]>> };
+
+export async function GET(_request: Request, context: ParamsContext) {
+  const params = context.params;
+  const resolved = params ? await params : null;
+  return Response.json({ params: resolved });
+}

--- a/tests/nextjs-compat/app-routes.test.ts
+++ b/tests/nextjs-compat/app-routes.test.ts
@@ -389,6 +389,15 @@ describe("Next.js compat: app-routes", () => {
   // Next.js: 'provides params to routes with dynamic parameters'
   // Source: https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/app-routes/app-custom-routes.test.ts#L84-L92
 
+  // Next.js: 'does not provide params to routes without dynamic parameters'
+  // Source: https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/app-routes/app-custom-routes.test.ts#L424-L431
+  it("does not provide params to routes without dynamic parameters", async () => {
+    const res = await fetch(`${baseUrl}/nextjs-compat/api/params-null`);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.params).toBeNull();
+  });
+
   it("catch-all route handler supports await params (Next.js 15 async params)", async () => {
     const res = await fetch(`${baseUrl}/api/catch-all/a/b/c`);
     expect(res.status).toBe(200);

--- a/tests/pages-page-data.test.ts
+++ b/tests/pages-page-data.test.ts
@@ -297,4 +297,73 @@ describe("pages page data", () => {
       pageProps: { title: "hello" },
     });
   });
+
+  // Matches Next.js behavior: for non-dynamic routes, `params` in
+  // getServerSideProps context is null (not `{}`).
+  // Ported from Next.js: test/e2e/edge-pages-support/index.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/edge-pages-support/index.test.ts#L67-L77
+  it("passes params: null to getServerSideProps on non-dynamic routes", async () => {
+    let received: unknown = "untouched";
+    await resolvePagesPageData(
+      createOptions({
+        pageModule: {
+          async getServerSideProps(context) {
+            received = context.params;
+            return { props: {} };
+          },
+        },
+        params: {},
+        query: {},
+        route: { isDynamic: false },
+        routePattern: "/",
+        routeUrl: "/",
+      }),
+    );
+
+    expect(received).toBeNull();
+  });
+
+  it("passes the matched params object to getServerSideProps on dynamic routes", async () => {
+    let received: unknown = null;
+    await resolvePagesPageData(
+      createOptions({
+        pageModule: {
+          async getServerSideProps(context) {
+            received = context.params;
+            return { props: {} };
+          },
+        },
+        params: { id: "123" },
+        query: { id: "123" },
+        route: { isDynamic: true },
+        routePattern: "/[id]",
+        routeUrl: "/123",
+      }),
+    );
+
+    expect(received).toEqual({ id: "123" });
+  });
+
+  // Matches Next.js behavior: for non-dynamic routes, `params` in
+  // getStaticProps context is null (not `{}`).
+  it("passes params: null to getStaticProps on non-dynamic routes", async () => {
+    let received: unknown = "untouched";
+    await resolvePagesPageData(
+      createOptions({
+        pageModule: {
+          async getStaticProps(context) {
+            received = context.params;
+            return { props: {} };
+          },
+        },
+        params: {},
+        query: {},
+        route: { isDynamic: false },
+        routePattern: "/",
+        routeUrl: "/",
+      }),
+    );
+
+    expect(received).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary

Closes #1350.

Next.js exposes `params` as `null` (effectively — see below) to route handlers and `getServerSideProps`/`getStaticProps` for routes with no dynamic segments. vinext was passing an empty object, which is truthy and breaks user code that branches on `params` (e.g. `params ? await params : null` or `params || null`).

The fix computes a user-facing params value at each dispatch boundary:
- **App Router route handler dispatch** — `src/server/app-rsc-handler.ts` passes `route.isDynamic ? params : null` to `dispatchMatchedRouteHandler`, which threads it through to the handler context unchanged. `app-route-handler-cache.ts` and `app-route-handler-dispatch.ts` accept `AppRouteParams | null` and skip the `makeThenableParams` wrap when the value is `null`.
- **Pages Router prod path** — `src/server/pages-page-data.ts` computes `userFacingParams` once at the top of `resolvePagesPageData` and uses it for `getServerSideProps` and `getStaticProps` contexts (including the stale-regen path).
- **Pages Router dev path** — `src/server/dev-server.ts` computes the same `userFacingParams` and uses it for `getServerSideProps`, the stale-regen `getStaticProps`, and the cache-miss `getStaticProps`.

Internal bookkeeping — navigation context, query merging for SSR, `useParams()` source, root params extraction, `getStaticPaths` validation, ISR HTML hydration — keeps the matched-but-empty-object shape, since those consumers expect a record.

## References

Authoritative Next.js test assertions:
- [test/e2e/app-dir/app-routes/app-custom-routes.test.ts#L424-L431](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/app-routes/app-custom-routes.test.ts#L424-L431) — `expect(meta.params).toEqual(null)` for non-dynamic route handlers
- [test/e2e/edge-pages-support/index.test.ts#L67-L77](https://github.com/vercel/next.js/blob/canary/test/e2e/edge-pages-support/index.test.ts#L67-L77) — `expect(props.params).toBe(null)` for non-dynamic `getServerSideProps`

Next.js source:
- [`packages/next/src/server/render.tsx`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/render.tsx#L1106-L1113) — Pages Router spreads `...(pageIsDynamic ? { params } : undefined)` into the gSSP/gSP context.
- [`packages/next/src/server/route-modules/app-route/module.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/route-modules/app-route/module.ts#L353-L357) — App Router handler context sets `params: context.params ? createServerParamsForRoute(...) : undefined`.

## Test plan

- [x] Unit tests added at the dispatch and execution layers
  - `tests/app-rsc-handler.test.ts` — non-dynamic route handler dispatch surfaces `params: null`
  - `tests/app-route-handler-dispatch.test.ts` — dispatch boundary passes `null` straight to the handler context
  - `tests/pages-page-data.test.ts` — `resolvePagesPageData` passes `null` to gSSP/gSP for non-dynamic routes, dynamic routes still receive the matched object
- [x] Integration test added in the nextjs-compat suite
  - `tests/nextjs-compat/app-routes.test.ts` — "does not provide params to routes without dynamic parameters" against a fresh fixture
- [x] `pnpm run check` (format + lint + type-check) passes
- [x] All targeted suites pass locally: `tests/app-route-handler-*.test.ts`, `tests/app-rsc-handler.test.ts`, `tests/app-router.test.ts`, `tests/features.test.ts`, `tests/pages-*.test.ts`, `tests/nextjs-compat/`
- [ ] CI green