### PR TITLE
fix(middleware): preserve query params on rewrite

### DIFF
--- a/packages/vinext/package.json
+++ b/packages/vinext/package.json
@@ -56,6 +56,10 @@
     "./server/worker-utils": {
       "types": "./dist/server/worker-utils.d.ts",
       "import": "./dist/server/worker-utils.js"
+    },
+    "./utils/query": {
+      "types": "./dist/utils/query.d.ts",
+      "import": "./dist/utils/query.js"
     }
   },
   "scripts": {

--- a/packages/vinext/src/deploy.ts
+++ b/packages/vinext/src/deploy.ts
@@ -546,6 +546,7 @@ import {
   isOpenRedirectShaped,
   normalizeTrailingSlash,
 } from "vinext/server/request-pipeline";
+import { mergeRewriteQuery } from "vinext/utils/query";
 
 // @ts-expect-error -- virtual module resolved by vinext at build time
 import { renderPage, handleApiRoute, runMiddleware, vinextConfig, matchPageRoute } from "virtual:vinext-server-entry";
@@ -784,8 +785,9 @@ export default {
           if (isExternalUrl(rewritten)) {
             return proxyExternalRequest(request, rewritten);
           }
-          resolvedUrl = rewritten;
-          resolvedPathname = rewritten.split("?")[0];
+          // Preserve original query params across rewrites (Next.js parity).
+          resolvedUrl = mergeRewriteQuery(resolvedUrl, rewritten);
+          resolvedPathname = resolvedUrl.split("?")[0];
         }
       }
 
@@ -808,8 +810,8 @@ export default {
           if (isExternalUrl(rewritten)) {
             return proxyExternalRequest(request, rewritten);
           }
-          resolvedUrl = rewritten;
-          resolvedPathname = rewritten.split("?")[0];
+          resolvedUrl = mergeRewriteQuery(resolvedUrl, rewritten);
+          resolvedPathname = resolvedUrl.split("?")[0];
         }
       }
 
@@ -825,7 +827,12 @@ export default {
             if (isExternalUrl(fallbackRewrite)) {
               return proxyExternalRequest(request, fallbackRewrite);
             }
-            response = await renderPage(request, fallbackRewrite, null, ctx);
+            response = await renderPage(
+              request,
+              mergeRewriteQuery(resolvedUrl, fallbackRewrite),
+              null,
+              ctx,
+            );
           }
         }
       }

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -80,6 +80,7 @@ import { buildRequestHeadersFromMiddlewareResponse } from "./server/middleware-r
 import { detectPackageManager } from "./utils/project.js";
 import { manifestFileWithBase, manifestFilesWithBase } from "./utils/manifest-paths.js";
 import { hasBasePath } from "./utils/base-path.js";
+import { mergeRewriteQuery } from "./utils/query.js";
 import {
   ASSET_PREFIX_URL_DIR,
   resolveAssetUrlPrefix,
@@ -3106,8 +3107,12 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
               // Apply rewrites from next.config.js (beforeFiles)
               let resolvedUrl = url;
               if (nextConfig?.rewrites.beforeFiles.length) {
-                resolvedUrl =
-                  applyRewrites(pathname, nextConfig.rewrites.beforeFiles, reqCtx) ?? url;
+                const rewritten = applyRewrites(pathname, nextConfig.rewrites.beforeFiles, reqCtx);
+                if (rewritten) {
+                  // Preserve original query params across the rewrite — Next.js
+                  // semantics: `Object.assign(parsedUrl.query, rewriteQuery)`.
+                  resolvedUrl = mergeRewriteQuery(url, rewritten);
+                }
               }
 
               // External rewrite from beforeFiles — proxy to external URL
@@ -3164,7 +3169,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                   reqCtx,
                 );
                 if (afterRewrite) {
-                  resolvedUrl = afterRewrite;
+                  resolvedUrl = mergeRewriteQuery(resolvedUrl, afterRewrite);
                   match = matchRoute(resolvedUrl.split("?")[0], routes);
                 }
               }

--- a/packages/vinext/src/server/middleware-runtime.ts
+++ b/packages/vinext/src/server/middleware-runtime.ts
@@ -17,6 +17,7 @@ import { MatcherConfig, matchesMiddleware } from "./middleware-matcher.js";
 import { shouldKeepMiddlewareHeader } from "./middleware-request-headers.js";
 import { processMiddlewareHeaders } from "./request-pipeline.js";
 import { badRequestResponse, internalServerErrorResponse } from "./http-error-responses.js";
+import { mergeRewriteQuery } from "../utils/query.js";
 
 export type MiddlewareModule = Record<string, unknown>;
 
@@ -249,10 +250,19 @@ export async function executeMiddleware(
     try {
       const rewriteParsed = new URL(rewriteUrl, options.request.url);
       const requestOrigin = new URL(options.request.url).origin;
-      rewritePath =
-        rewriteParsed.origin === requestOrigin
-          ? rewriteParsed.pathname + rewriteParsed.search
-          : rewriteParsed.href;
+      if (rewriteParsed.origin === requestOrigin) {
+        // Preserve the original request's query params on internal rewrites.
+        // Next.js merges via `Object.assign(parsedUrl.query, rewrittenParsedUrl.query)`
+        // — original query first, rewrite-target overrides on key conflicts.
+        rewritePath = mergeRewriteQuery(
+          options.request.url,
+          rewriteParsed.pathname + rewriteParsed.search,
+        );
+      } else {
+        // External rewrites are proxied as-is; don't smuggle local query params
+        // into the upstream URL.
+        rewritePath = rewriteParsed.href;
+      }
     } catch {
       rewritePath = rewriteUrl;
     }

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -53,6 +53,7 @@ import {
 } from "./request-pipeline.js";
 import { notFoundResponse } from "./http-error-responses.js";
 import { hasBasePath, stripBasePath } from "../utils/base-path.js";
+import { mergeRewriteQuery } from "../utils/query.js";
 import {
   ASSET_PREFIX_URL_DIR,
   assetPrefixPathname,
@@ -1756,8 +1757,10 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
             await sendWebResponse(proxyResponse, req, res, compress);
             return;
           }
-          resolvedUrl = rewritten;
-          resolvedPathname = rewritten.split("?")[0];
+          // Preserve the original request's query params across the config
+          // rewrite. Matches Next.js `Object.assign(parsedUrl.query, ...)`.
+          resolvedUrl = mergeRewriteQuery(resolvedUrl, rewritten);
+          resolvedPathname = resolvedUrl.split("?")[0];
         }
       }
 
@@ -1810,8 +1813,8 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
             await sendWebResponse(proxyResponse, req, res, compress);
             return;
           }
-          resolvedUrl = rewritten;
-          resolvedPathname = rewritten.split("?")[0];
+          resolvedUrl = mergeRewriteQuery(resolvedUrl, rewritten);
+          resolvedPathname = resolvedUrl.split("?")[0];
         }
       }
 
@@ -1842,7 +1845,7 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
             }
             response = await renderPage(
               webRequest,
-              fallbackRewrite,
+              mergeRewriteQuery(resolvedUrl, fallbackRewrite),
               ssrManifest,
               undefined,
               middlewareResponseHeaders,

--- a/packages/vinext/src/utils/query.ts
+++ b/packages/vinext/src/utils/query.ts
@@ -102,6 +102,52 @@ export function urlQueryToSearchParams(query: UrlQuery): URLSearchParams {
 }
 
 /**
+ * Merge the original request URL's query parameters into a rewrite-target URL.
+ *
+ * Matches Next.js behavior: original query params are preserved on rewrites,
+ * but the rewrite-target URL wins on key conflicts. Ported from Next.js
+ * `Object.assign(parsedUrl.query, rewrittenParsedUrl.query)` in
+ * route-modules/route-module.ts.
+ *
+ * https://github.com/vercel/next.js/blob/canary/packages/next/src/server/route-modules/route-module.ts
+ *
+ * The fragment from `rewriteUrl` is preserved (origin/pathname always come
+ * from the rewrite target). Absolute rewrite URLs are returned unchanged when
+ * the origin differs from the original — external rewrites are proxied
+ * elsewhere and shouldn't have local query params smuggled in.
+ */
+export function mergeRewriteQuery(originalUrl: string, rewriteUrl: string): string {
+  const originalSearchIndex = originalUrl.indexOf("?");
+  if (originalSearchIndex === -1) return rewriteUrl;
+
+  const originalQuery = originalUrl.slice(originalSearchIndex + 1).split("#")[0] ?? "";
+  if (!originalQuery) return rewriteUrl;
+
+  // Find the rewrite URL's pathname/search/hash boundaries without needing
+  // to fully parse it (it may be relative like `/foo?bar=1`).
+  const hashIndex = rewriteUrl.indexOf("#");
+  const beforeHash = hashIndex === -1 ? rewriteUrl : rewriteUrl.slice(0, hashIndex);
+  const hash = hashIndex === -1 ? "" : rewriteUrl.slice(hashIndex);
+  const queryIndex = beforeHash.indexOf("?");
+  const base = queryIndex === -1 ? beforeHash : beforeHash.slice(0, queryIndex);
+  const rewriteQuery = queryIndex === -1 ? "" : beforeHash.slice(queryIndex + 1);
+
+  // Build merged params: original first, rewrite-target overrides on conflict.
+  // We delete keys present in the rewrite query before appending the originals
+  // for those keys; this matches Object.assign(orig, rewrite) semantics while
+  // preserving array values from the original.
+  const merged = new URLSearchParams(originalQuery);
+  const rewriteParams = new URLSearchParams(rewriteQuery);
+  const rewriteKeys = new Set<string>();
+  for (const key of rewriteParams.keys()) rewriteKeys.add(key);
+  for (const key of rewriteKeys) merged.delete(key);
+  for (const [key, value] of rewriteParams) merged.append(key, value);
+
+  const search = merged.toString();
+  return `${base}${search ? `?${search}` : ""}${hash}`;
+}
+
+/**
  * Append query parameters to a URL while preserving any existing query string
  * and fragment identifier.
  */

--- a/packages/vinext/src/utils/query.ts
+++ b/packages/vinext/src/utils/query.ts
@@ -120,7 +120,7 @@ export function mergeRewriteQuery(originalUrl: string, rewriteUrl: string): stri
   const originalSearchIndex = originalUrl.indexOf("?");
   if (originalSearchIndex === -1) return rewriteUrl;
 
-  const originalQuery = originalUrl.slice(originalSearchIndex + 1).split("#")[0] ?? "";
+  const originalQuery = originalUrl.slice(originalSearchIndex + 1).split("#")[0];
   if (!originalQuery) return rewriteUrl;
 
   // Find the rewrite URL's pathname/search/hash boundaries without needing

--- a/tests/fixtures/pages-basic/middleware.ts
+++ b/tests/fixtures/pages-basic/middleware.ts
@@ -26,6 +26,26 @@ export function middleware(request: NextRequest) {
     return NextResponse.rewrite(new URL("/ssr", request.url));
   }
 
+  // Rewrite /mw-rewrite-query to /ssr-query — preserves the original
+  // request's query params on the rewrite target so getServerSideProps
+  // sees them. Mirrors Next.js: test/e2e/edge-pages-support.
+  if (url.pathname === "/mw-rewrite-query") {
+    return NextResponse.rewrite(new URL("/ssr-query", request.url));
+  }
+
+  // Rewrite /mw-rewrite-dynamic-query to /posts/first — the rewrite
+  // target is dynamic, so the resulting query should contain both the
+  // dynamic param (id=first) and the original query (?hello=world).
+  if (url.pathname === "/mw-rewrite-dynamic-query") {
+    return NextResponse.rewrite(new URL("/posts/first", request.url));
+  }
+
+  // Rewrite target carries its own query — rewrite-target params should
+  // win over original request params on key conflicts.
+  if (url.pathname === "/mw-rewrite-merge-query") {
+    return NextResponse.rewrite(new URL("/ssr-query?hello=from-rewrite", request.url));
+  }
+
   if (url.pathname === "/rewrite-with-cookie") {
     const res = NextResponse.rewrite(new URL("/ssr", request.url));
     res.cookies.set("rewrite-cookie", "visible", { path: "/" });

--- a/tests/fixtures/pages-basic/pages/posts/[id].tsx
+++ b/tests/fixtures/pages-basic/pages/posts/[id].tsx
@@ -2,9 +2,10 @@ import { useRouter } from "next/router";
 
 interface PostProps {
   id: string;
+  query: Record<string, string | string[] | undefined>;
 }
 
-export default function Post({ id }: PostProps) {
+export default function Post({ id, query }: PostProps) {
   const router = useRouter();
 
   return (
@@ -13,14 +14,22 @@ export default function Post({ id }: PostProps) {
       <p data-testid="pathname">Pathname: {router.pathname}</p>
       <p data-testid="as-path">As Path: {router.asPath}</p>
       <p data-testid="query">Query ID: {router.query.id}</p>
+      <p data-testid="gssp-query">{JSON.stringify(query)}</p>
     </div>
   );
 }
 
-export async function getServerSideProps({ params }: { params: { id: string } }) {
+export async function getServerSideProps({
+  params,
+  query,
+}: {
+  params: { id: string };
+  query: Record<string, string | string[] | undefined>;
+}) {
   return {
     props: {
       id: params.id,
+      query,
     },
   };
 }

--- a/tests/fixtures/pages-basic/pages/ssr-query.tsx
+++ b/tests/fixtures/pages-basic/pages/ssr-query.tsx
@@ -1,0 +1,26 @@
+interface SsrQueryProps {
+  query: Record<string, string | string[] | undefined>;
+  resolvedUrl: string;
+}
+
+export default function SsrQueryPage({ query, resolvedUrl }: SsrQueryProps) {
+  return (
+    <div>
+      <h1>SSR Query</h1>
+      <p data-testid="query">{JSON.stringify(query)}</p>
+      <p data-testid="resolved-url">{resolvedUrl}</p>
+    </div>
+  );
+}
+
+export async function getServerSideProps(context: {
+  query: Record<string, string | string[] | undefined>;
+  resolvedUrl: string;
+}) {
+  return {
+    props: {
+      query: context.query,
+      resolvedUrl: context.resolvedUrl,
+    },
+  };
+}

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -888,6 +888,60 @@ describe("Pages Router integration", () => {
     expect(html).toContain("Server-Side Rendered");
   });
 
+  // Ported from Next.js: test/e2e/edge-pages-support/index.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/edge-pages-support/index.test.ts
+  // Closes cloudflare/vinext#1342: original query params must survive a
+  // middleware rewrite. Next.js merges via
+  // Object.assign(parsedUrl.query, rewrittenParsedUrl.query) — original first,
+  // rewrite-target overrides on key conflicts.
+  it("middleware rewrite preserves original query params to getServerSideProps", async () => {
+    const res = await fetch(`${baseUrl}/mw-rewrite-query?hello=world`);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("SSR Query");
+    const nextDataMatch = html.match(/<script>window\.__NEXT_DATA__\s*=\s*({.*?})<\/script>/);
+    expect(nextDataMatch).toBeTruthy();
+    const nextData = JSON.parse(nextDataMatch![1]!);
+    expect(nextData.props.pageProps.query).toMatchObject({ hello: "world" });
+  });
+
+  it("middleware rewrite to a dynamic route merges original query with route params", async () => {
+    const res = await fetch(`${baseUrl}/mw-rewrite-dynamic-query?hello=world`);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toMatch(/Post:\s*(<!--\s*-->)?\s*first/);
+    const nextDataMatch = html.match(/<script>window\.__NEXT_DATA__\s*=\s*({.*?})<\/script>/);
+    expect(nextDataMatch).toBeTruthy();
+    const nextData = JSON.parse(nextDataMatch![1]!);
+    expect(nextData.props.pageProps.query).toMatchObject({ id: "first", hello: "world" });
+  });
+
+  it("middleware rewrite with target-side query lets rewrite-target win on key conflicts", async () => {
+    // Original ?hello=world, rewrite target is /ssr-query?hello=from-rewrite —
+    // rewrite-target query should win, matching Next.js Object.assign semantics.
+    const res = await fetch(`${baseUrl}/mw-rewrite-merge-query?hello=world&other=keep`);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    const nextDataMatch = html.match(/<script>window\.__NEXT_DATA__\s*=\s*({.*?})<\/script>/);
+    expect(nextDataMatch).toBeTruthy();
+    const nextData = JSON.parse(nextDataMatch![1]!);
+    expect(nextData.props.pageProps.query).toMatchObject({
+      hello: "from-rewrite",
+      other: "keep",
+    });
+  });
+
+  it("middleware rewrite without any original query still renders correctly", async () => {
+    const res = await fetch(`${baseUrl}/mw-rewrite-query`);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("SSR Query");
+    const nextDataMatch = html.match(/<script>window\.__NEXT_DATA__\s*=\s*({.*?})<\/script>/);
+    expect(nextDataMatch).toBeTruthy();
+    const nextData = JSON.parse(nextDataMatch![1]!);
+    expect(nextData.props.pageProps.query).toEqual({});
+  });
+
   it("middleware blocks /blocked with 403", async () => {
     const res = await fetch(`${baseUrl}/blocked`);
     expect(res.status).toBe(403);

--- a/tests/query.test.ts
+++ b/tests/query.test.ts
@@ -57,6 +57,17 @@ describe("mergeRewriteQuery", () => {
     const params = new URLSearchParams(result.slice(result.indexOf("?") + 1));
     expect(params.getAll("tag")).toEqual(["rw1", "rw2"]);
   });
+
+  it("normalizes URL-encoded space (%20) to + via URLSearchParams", () => {
+    // URLSearchParams.toString() emits `+` for spaces. Downstream consumers all
+    // re-parse via URLSearchParams or new URL(), so this normalization is safe
+    // and lossless. This test documents the intentional behavior.
+    const result = mergeRewriteQuery("http://localhost/path?foo=hello%20world", "/target");
+    expect(result).toBe("/target?foo=hello+world");
+    expect(new URLSearchParams(result.slice(result.indexOf("?") + 1)).get("foo")).toBe(
+      "hello world",
+    );
+  });
 });
 
 describe("appendSearchParamsToUrl", () => {

--- a/tests/query.test.ts
+++ b/tests/query.test.ts
@@ -1,6 +1,63 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { appendSearchParamsToUrl } from "../packages/vinext/src/utils/query.js";
+import { appendSearchParamsToUrl, mergeRewriteQuery } from "../packages/vinext/src/utils/query.js";
+
+describe("mergeRewriteQuery", () => {
+  it("preserves original query params when the rewrite target has none", () => {
+    const result = mergeRewriteQuery("http://localhost/rewrite-me?hello=world", "/");
+    expect(result).toBe("/?hello=world");
+  });
+
+  it("returns the rewrite URL unchanged when the original has no query", () => {
+    const result = mergeRewriteQuery("http://localhost/rewrite-me", "/target?foo=bar");
+    expect(result).toBe("/target?foo=bar");
+  });
+
+  it("merges original params with rewrite-target params (rewrite wins on conflicts)", () => {
+    const result = mergeRewriteQuery(
+      "http://localhost/path?hello=original&keep=this",
+      "/target?hello=from-rewrite",
+    );
+    expect(result).toContain("hello=from-rewrite");
+    expect(result).toContain("keep=this");
+    expect(result).not.toContain("hello=original");
+  });
+
+  it("preserves the rewrite URL's pathname and hash", () => {
+    const result = mergeRewriteQuery("http://localhost/path?foo=1", "/target?bar=2#section");
+    expect(result).toBe("/target?foo=1&bar=2#section");
+  });
+
+  it("supports absolute rewrite URLs (preserves origin)", () => {
+    const result = mergeRewriteQuery(
+      "http://localhost/path?foo=1",
+      "http://localhost/target?bar=2",
+    );
+    expect(result).toBe("http://localhost/target?foo=1&bar=2");
+  });
+
+  it("ignores empty query string after the question mark in original", () => {
+    const result = mergeRewriteQuery("http://localhost/path?", "/target");
+    expect(result).toBe("/target");
+  });
+
+  it("preserves multi-value keys from the original query", () => {
+    const result = mergeRewriteQuery("http://localhost/path?tag=a&tag=b", "/target?other=1");
+    expect(result).toContain("tag=a");
+    expect(result).toContain("tag=b");
+    expect(result).toContain("other=1");
+  });
+
+  it("uses rewrite-target multi-values when the same key appears in both", () => {
+    const result = mergeRewriteQuery(
+      "http://localhost/path?tag=orig1&tag=orig2",
+      "/target?tag=rw1&tag=rw2",
+    );
+    // Original tags are removed; rewrite-target tags survive.
+    const params = new URLSearchParams(result.slice(result.indexOf("?") + 1));
+    expect(params.getAll("tag")).toEqual(["rw1", "rw2"]);
+  });
+});
 
 describe("appendSearchParamsToUrl", () => {
   it("adds query params to a path with no existing query", () => {


### PR DESCRIPTION
## Summary

When middleware calls `NextResponse.rewrite(new URL('/somewhere', req.url))`, or when a `next.config.js` rewrite redirects to a new target, vinext was throwing away the original request's query string. `getServerSideProps` / Pages route handlers saw an empty `query` (or just the dynamic-route params), breaking any rewrite where downstream code needs the URL's query.

Next.js merges the original parsed URL query with the rewrite-target's query via [`Object.assign(parsedUrl.query, rewrittenParsedUrl.query)`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/route-modules/route-module.ts) — original first, rewrite-target wins on key conflicts. This PR makes vinext do the same.

### Example

```ts
// middleware.ts
export function middleware(req: NextRequest) {
  if (req.nextUrl.pathname === "/rewrite-me") {
    return NextResponse.rewrite(new URL("/", req.url));
  }
}
```

**Before** — `GET /rewrite-me?hello=world` → `getServerSideProps` sees `query = {}`

**After** — `GET /rewrite-me?hello=world` → `getServerSideProps` sees `query = { hello: "world" }`

For a dynamic rewrite target the dynamic params remain (and now the original query joins them):

```
GET /mw-rewrite-dynamic-query?hello=world → /posts/[id]
  query before: { id: "first" }
  query after:  { id: "first", hello: "world" }
```

Where original and rewrite both set the same key, the rewrite wins (matches Next.js `Object.assign` semantics):

```
GET /rewrite-merge?hello=world → /target?hello=from-rewrite
  query: { hello: "from-rewrite" }
```

## Touched code paths

- `packages/vinext/src/server/middleware-runtime.ts` — internal middleware rewrites
- `packages/vinext/src/server/prod-server.ts` — Pages Router prod (beforeFiles / afterFiles / fallback)
- `packages/vinext/src/index.ts` — Pages Router dev (beforeFiles / afterFiles)
- `packages/vinext/src/deploy.ts` — Cloudflare Worker entry template

App Router consumes the merged query through `app-middleware.ts` (it already pulls `search` from the rewrite URL set by `middleware-runtime.ts`), so it inherits the fix.

New shared helper `mergeRewriteQuery(originalUrl, rewriteUrl)` in `packages/vinext/src/utils/query.ts`.

## Test plan

- [x] `pnpm test tests/query.test.ts` — unit tests for the merge helper (`mergeRewriteQuery`)
- [x] `pnpm test tests/pages-router.test.ts` — 4 new integration tests covering rewrite-preserves-query / rewrite-to-dynamic / rewrite-wins-on-conflict / no-original-query
- [x] `pnpm test tests/features.test.ts tests/request-pipeline.test.ts` — regression check
- [x] `pnpm test tests/app-router.test.ts tests/app-post-middleware-context.test.ts` — regression check
- [x] `pnpm test tests/deploy.test.ts`
- [x] `vp check` (format + lint + types)

## References

- Next.js source (canonical merge): https://github.com/vercel/next.js/blob/canary/packages/next/src/server/route-modules/route-module.ts (search for `Object.assign(parsedUrl.query, rewrittenParsedUrl.query)`)
- Next.js test (expectations ported): https://github.com/vercel/next.js/blob/canary/test/e2e/edge-pages-support/index.test.ts (`should have correct query/params on rewrite` / `…on dynamic rewrite`)

Closes #1342