### PR TITLE
fix(middleware): allow server-only imports

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -89,6 +89,7 @@ import { asyncHooksStubPlugin } from "./plugins/async-hooks-stub.js";
 import { clientReferenceDedupPlugin } from "./plugins/client-reference-dedup.js";
 import { createRscClientReferenceLoadersPlugin } from "./plugins/rsc-client-reference-loaders.js";
 import { createInstrumentationClientTransformPlugin } from "./plugins/instrumentation-client.js";
+import { createMiddlewareServerOnlyPlugin } from "./plugins/middleware-server-only.js";
 import { createOptimizeImportsPlugin } from "./plugins/optimize-imports.js";
 import { createOgInlineFetchAssetsPlugin, ogAssetsPlugin } from "./plugins/og-assets.js";
 import { generateRouteTypes } from "./typegen.js";
@@ -934,6 +935,18 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           } satisfies Plugin,
         ]
       : []),
+    // Allow `import 'server-only'` from middleware (and any module reachable
+    // from it) in non-RSC environments. Registered before `vinext:config` so
+    // its `enforce: "pre"` resolveId runs ahead of @vitejs/plugin-rsc's
+    // `rsc:validate-imports` (which rejects bare `server-only` outside RSC).
+    // See packages/vinext/src/plugins/middleware-server-only.ts for the
+    // import-chain taint design.
+    createMiddlewareServerOnlyPlugin({
+      getMiddlewarePath: () => middlewarePath,
+      getCanonicalMiddlewarePath: () =>
+        middlewarePath ? (tryRealpathSync(middlewarePath) ?? middlewarePath) : null,
+      serverOnlyShimPath: resolveShimModulePath(shimsDir, "server-only"),
+    }),
     {
       name: "vinext:config",
       enforce: "pre",

--- a/packages/vinext/src/plugins/middleware-server-only.ts
+++ b/packages/vinext/src/plugins/middleware-server-only.ts
@@ -1,0 +1,134 @@
+import type { Plugin } from "vite";
+
+/**
+ * Allow `import 'server-only'` from middleware (and any module reachable
+ * from middleware) in the SSR environment.
+ *
+ * Background: middleware runs server-side, so importing `server-only` is
+ * semantically correct. However, vinext bundles middleware into the SSR
+ * environment (via `virtual:vinext-server-entry`), and @vitejs/plugin-rsc's
+ * `rsc:validate-imports` plugin treats any non-RSC environment as a "client"
+ * build, rejecting `server-only` imports with:
+ *
+ *   'server-only' cannot be imported in client build ('ssr' environment)
+ *
+ * Next.js solves this with webpack `issuerLayer` rules: middleware (and
+ * `instrumentation`) sit in the `neutralTarget` layer where `server-only`
+ * is aliased to a no-op while `client-only` still errors. See
+ *   packages/next/src/build/webpack-config.ts ("Alias server-only and
+ *   client-only to proper exports based on bundling layers")
+ *
+ * Vite has no per-layer aliasing within a single environment, so we mirror
+ * the behavior with import-chain taint tracking:
+ *
+ *   1. Seed a `tainted` set with the middleware entry path (and its
+ *      canonical realpath).
+ *   2. For every resolveId call from a tainted importer, resolve the import
+ *      via `this.resolve(..., { skipSelf: true })` and add the resolved id
+ *      to the tainted set. This propagates the taint along the import graph
+ *      synchronously, before plugin-rsc's `order: "pre"` validate-imports
+ *      handler sees the next `server-only` request.
+ *   3. When a tainted module imports `server-only` in a non-RSC environment,
+ *      short-circuit to the no-op shim path so plugin-rsc's filter (which
+ *      matches the bare `^server-only$` specifier) never fires for that
+ *      import.
+ *
+ * The taint set is scoped to the middleware chain only — `server-only`
+ * imports from anywhere else (including client component code traversing
+ * through the SSR environment for `react-dom/server.edge` rendering) still
+ * hit the rsc:validate-imports rejection, preserving the original safety
+ * net for accidental client-side `server-only` leakage.
+ *
+ * Ported from Next.js handling of `WEBPACK_LAYERS.middleware` /
+ * `WEBPACK_LAYERS.GROUP.neutralTarget`:
+ * https://github.com/vercel/next.js/blob/canary/packages/next/src/build/webpack-config.ts
+ */
+export function createMiddlewareServerOnlyPlugin(options: {
+  getMiddlewarePath: () => string | null;
+  getCanonicalMiddlewarePath: () => string | null;
+  serverOnlyShimPath: string;
+}): Plugin {
+  // Tracks module IDs reachable from the middleware entry. The set is
+  // populated lazily as resolveId fires with tainted importers — we cannot
+  // pre-walk the graph because middleware's imports aren't known until
+  // Rolldown starts processing the entry.
+  //
+  // Rolldown canonicalizes IDs via fs.realpathSync.native, so we store
+  // both the original and canonical paths when known. Comparisons are
+  // done by checking the importer string verbatim (which is whatever
+  // Rolldown handed us).
+  const tainted = new Set<string>();
+
+  function isTainted(id: string | undefined): boolean {
+    if (!id) return false;
+    if (tainted.has(id)) return true;
+    // Strip query string suffix (e.g. ?v=hash, ?rsc, ?used). Rolldown stores
+    // module IDs with the query in `importer` strings for HMR / dep optimizer
+    // round-trips; the canonical id we tracked doesn't carry one.
+    const queryIndex = id.indexOf("?");
+    if (queryIndex !== -1) {
+      return tainted.has(id.slice(0, queryIndex));
+    }
+    return false;
+  }
+
+  function addTainted(id: string): void {
+    const queryIndex = id.indexOf("?");
+    tainted.add(queryIndex === -1 ? id : id.slice(0, queryIndex));
+  }
+
+  return {
+    name: "vinext:middleware-server-only",
+    // `enforce: "pre"` so this plugin's resolveId hook fires before
+    // @vitejs/plugin-rsc's `rsc:validate-imports` (which is a normal-priority
+    // plugin with an `order: "pre"` hook). Vite groups by enforce first,
+    // then by hook order — pre-enforce hooks always beat normal-enforce ones
+    // regardless of hook-level order.
+    enforce: "pre",
+
+    buildStart() {
+      // Reseed at the start of every build so consecutive `vite build`
+      // invocations on the same plugin instance (used by the test suite)
+      // don't carry over stale taint from a previous run.
+      tainted.clear();
+      const middlewarePath = options.getMiddlewarePath();
+      if (middlewarePath) addTainted(middlewarePath);
+      const canonical = options.getCanonicalMiddlewarePath();
+      if (canonical) addTainted(canonical);
+    },
+
+    resolveId: {
+      // No filter on the id — we need to observe every resolution whose
+      // importer is tainted in order to propagate taint along the graph.
+      // The hot path (importer not tainted, id !== "server-only") falls
+      // through to `return undefined` immediately.
+      order: "pre",
+      async handler(id, importer, opts) {
+        // Only relevant outside the RSC environment. Inside `rsc`, the
+        // react-server export condition already makes `server-only` a no-op,
+        // and plugin-rsc's validator allows it there.
+        if (this.environment?.name === "rsc") return;
+        if (!importer) return;
+        if (!isTainted(importer)) return;
+
+        // server-only from a tainted importer → swap in the no-op shim
+        // path before plugin-rsc's pre-resolveId can claim it as the
+        // bare specifier.
+        if (id === "server-only") {
+          return { id: options.serverOnlyShimPath, moduleSideEffects: false };
+        }
+
+        // Propagate taint: resolve the import ourselves (skipSelf so we
+        // don't recurse) and add the resolved id to the tainted set. We
+        // don't return the resolved id — letting other plugins handle the
+        // actual resolution keeps this plugin a pure tracker for any
+        // import that isn't `server-only`.
+        const resolved = await this.resolve(id, importer, { ...opts, skipSelf: true });
+        if (resolved && !resolved.external) {
+          addTainted(resolved.id);
+        }
+        return;
+      },
+    },
+  };
+}

--- a/tests/middleware-server-only.test.ts
+++ b/tests/middleware-server-only.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Build-time integration test: middleware (and any module reachable from it)
+ * must be allowed to `import 'server-only'`, even though vinext bundles
+ * middleware into the SSR environment.
+ *
+ * Ported from Next.js: test/e2e/module-layer/module-layer.test.ts
+ *   https://github.com/vercel/next.js/blob/canary/test/e2e/module-layer/module-layer.test.ts
+ *   The fixture's `middleware.js` contains a top-level `import 'server-only'`
+ *   plus a `react` import — Next.js's module-layer rules let `server-only`
+ *   through for middleware (`WEBPACK_LAYERS.neutralTarget`) while still
+ *   blocking it from client code.
+ *
+ * Before this fix, `@vitejs/plugin-rsc`'s `rsc:validate-imports` rejected
+ * the import with:
+ *
+ *   'server-only' cannot be imported in client build ('ssr' environment):
+ *     imported by middleware.js
+ *       imported by virtual:vinext-server-entry
+ *
+ * That single build failure cascaded into 13 failures in the
+ * `module-layer.test.ts` deploy suite, which is the failure pattern that
+ * the upstream issue (#1344) tracks.
+ */
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vite-plus/test";
+
+const FIXTURE_PREFIX = "vinext-mw-server-only-";
+
+async function writeFile(file: string, source: string): Promise<void> {
+  await fsp.mkdir(path.dirname(file), { recursive: true });
+  await fsp.writeFile(file, source, "utf8");
+}
+
+async function buildFixture(): Promise<{ tmpDir: string }> {
+  const workspaceRoot = path.resolve(import.meta.dirname, "..");
+  const workspaceNodeModules = path.join(workspaceRoot, "node_modules");
+
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), FIXTURE_PREFIX));
+
+  // Hybrid App + Pages Router fixture. The Next.js module-layer test has
+  // both directories, and that combination is what makes the SSR entry
+  // (which contains the bare \`import 'server-only'\` statement coming from
+  // middleware) reachable from \`virtual:vinext-app-ssr-entry\` — see the
+  // hybrid re-export branch in src/entries/app-ssr-entry.ts. With only
+  // app/, the App Router SSR environment never imports the Pages Router
+  // virtual server entry, so plugin-rsc's validate-imports buildEnd pass
+  // never sees the \`server-only\` chain. The hybrid fixture mirrors what
+  // the deploy suite actually builds.
+  await writeFile(
+    path.join(tmpDir, "app", "layout.tsx"),
+    `export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return <html lang="en"><body>{children}</body></html>;
+}
+`,
+  );
+  await writeFile(
+    path.join(tmpDir, "app", "page.tsx"),
+    `export default function Home() { return <div>home</div>; }\n`,
+  );
+  // Pages Router companion route — its mere presence flips
+  // \`hasPagesDir\` and triggers the SSR-entry → server-entry re-export.
+  await writeFile(
+    path.join(tmpDir, "pages", "pages-ssr.tsx"),
+    `export default function PagesSsr() { return <div>pages-ssr</div>; }\n`,
+  );
+
+  // A helper that the middleware imports. Mirrors the Next.js fixture's
+  // `lib/mixed-lib`-style transitive case: `server-only` must remain a
+  // no-op when reached two hops away from the middleware entry.
+  //
+  // Marked side-effectful via an exported sentinel so Rolldown does NOT
+  // tree-shake the module and its `import 'server-only'` out of the bundle.
+  // The Next.js fixture has the same property by virtue of `react` being
+  // an actual runtime dependency of the middleware; we keep ours minimal.
+  await writeFile(
+    path.join(tmpDir, "lib", "auth.ts"),
+    `import "server-only";
+
+// Side-effectful top-level export to anchor the module against tree-shaking.
+export const __AUTH_TAG = "vinext-test-tag-" + Date.now().toString(36);
+export function getUserId(): string {
+  return __AUTH_TAG;
+}
+`,
+  );
+
+  // Middleware with a direct \`import 'server-only'\` (the failure surface
+  // reported in the issue) and a transitive one through ./lib/auth.
+  //
+  // Mirrors the Next.js module-layer fixture's middleware.js, which also
+  // imports \`import * as React from 'react'\` — React is what anchors the
+  // server-side module so DCE cannot drop the server-only chain. We keep
+  // the React assertion to match the upstream fixture's intent: even though
+  // React is bundled, its client-side hooks (\`useState\`) must NOT appear
+  // in the server-layer copy.
+  await writeFile(
+    path.join(tmpDir, "middleware.ts"),
+    `import "server-only";
+import * as React from "react";
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { getUserId } from "./lib/auth";
+
+export function middleware(request: NextRequest) {
+  // Match the Next.js fixture's React-in-server-layer assertion so the
+  // \`react\` import is genuinely live and Rolldown cannot tree-shake it.
+  const ReactObject = Object(React);
+  if (ReactObject.useState) {
+    throw new Error("React.useState should not be defined in server layer");
+  }
+  // Use the helper's result in a header so Rolldown's DCE pass cannot drop
+  // either the helper module or its top-level \`import 'server-only'\`.
+  const response = NextResponse.next();
+  response.headers.set("x-vinext-test-user", getUserId());
+  response.headers.set("x-vinext-test-react-keys", Object.keys(ReactObject).length.toString());
+  return response;
+}
+
+export const config = { matcher: ["/"] };
+`,
+  );
+
+  // Symlink workspace node_modules so vinext, react, react-dom resolve.
+  await fsp.symlink(workspaceNodeModules, path.join(tmpDir, "node_modules"), "junction");
+
+  const { default: vinext } = await import(
+    pathToFileURL(path.join(workspaceRoot, "packages/vinext/src/index.ts")).href
+  );
+  const { createBuilder } = await import("vite");
+  const rscOutDir = path.join(tmpDir, "dist", "server");
+  const ssrOutDir = path.join(tmpDir, "dist", "server", "ssr");
+  const clientOutDir = path.join(tmpDir, "dist", "client");
+
+  const builder = await createBuilder({
+    root: tmpDir,
+    configFile: false,
+    plugins: [vinext({ appDir: tmpDir, rscOutDir, ssrOutDir, clientOutDir })],
+    logLevel: "error",
+  });
+
+  await builder.buildApp();
+  return { tmpDir };
+}
+
+describe("middleware can import server-only", () => {
+  let tmpDir: string;
+
+  beforeAll(async () => {
+    const built = await buildFixture();
+    tmpDir = built.tmpDir;
+  }, 120_000);
+
+  afterAll(() => {
+    // tmpdirs are left for post-mortem debugging; the test harness cleans
+    // os.tmpdir() periodically. Matching the pattern used by other build
+    // integration tests (build-time-classification-integration.test.ts).
+  });
+
+  async function collectServerJsFiles(): Promise<string[]> {
+    // App Router default output layout:
+    //   dist/server/index.{js,mjs}      ← RSC entry
+    //   dist/server/ssr/*.{js,mjs}      ← SSR pass for client components
+    //   dist/client/assets/*.js         ← browser bundle
+    const serverDir = path.join(tmpDir, "dist", "server");
+    const stack: string[] = [serverDir];
+    const seen: string[] = [];
+    while (stack.length) {
+      const current = stack.pop()!;
+      const entries = await fsp.readdir(current, { withFileTypes: true });
+      for (const entry of entries) {
+        const full = path.join(current, entry.name);
+        if (entry.isDirectory()) stack.push(full);
+        else if (/\.(m?js)$/.test(entry.name)) seen.push(full);
+      }
+    }
+    return seen;
+  }
+
+  it("emits server bundles without an invalid-server-only stub", async () => {
+    // The validate-imports plugin replaces an invalid bare `server-only`
+    // specifier with a virtual module body of:
+    //   throw new Error("invalid import of 'server-only'")
+    // If our taint-tracking plugin works, that string must not appear in any
+    // server-side artifact (it would appear in the SSR pass if middleware's
+    // chain were rejected). We check both the RSC entry and the SSR dir to
+    // catch regressions in either environment.
+    const files = await collectServerJsFiles();
+    expect(
+      files.length,
+      `expected JS artifacts under dist/server (got: ${files.length})`,
+    ).toBeGreaterThan(0);
+    for (const file of files) {
+      const source = await fsp.readFile(file, "utf8");
+      expect(
+        source.includes("invalid import of 'server-only'"),
+        `${path.relative(tmpDir, file)} contains the rsc:validate-imports throw stub`,
+      ).toBe(false);
+    }
+  });
+
+  it("keeps the middleware (and its server-only chain) in the bundle", async () => {
+    // Sanity check: prove the fixture isn't trivially passing because Rolldown
+    // tree-shook the middleware out before validate-imports could see it. If
+    // \`getUserId\`'s body (the \`__AUTH_TAG\` constant) is reachable in the
+    // emitted artifacts, the middleware → lib/auth.ts → server-only chain
+    // really did survive into the build that validate-imports inspects.
+    const files = await collectServerJsFiles();
+    const found = await Promise.all(
+      files.map(async (f) => (await fsp.readFile(f, "utf8")).includes("vinext-test-tag-")),
+    );
+    expect(
+      found.some(Boolean),
+      "expected lib/auth's __AUTH_TAG sentinel to appear in at least one server artifact",
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1344.

Middleware runs server-side, so `import 'server-only'` is semantically correct. However, vinext bundles middleware into the SSR environment (via `virtual:vinext-server-entry`), and `@vitejs/plugin-rsc`'s `rsc:validate-imports` rejects the bare specifier with:

```
[plugin rsc:validate-imports] middleware.js
Error: 'server-only' cannot be imported in client build ('ssr' environment):
 imported by middleware.js
   imported by virtual:vinext-server-entry
    imported by virtual:vinext-app-ssr-entry
```

This single build failure cascaded into 13 test failures in the Next.js deploy suite's `test/e2e/module-layer/module-layer.test.ts`.

## Approach

Next.js solves this with webpack `issuerLayer` rules: middleware (and instrumentation) sit in the `neutralTarget` layer where `server-only` is aliased to a no-op while `client-only` still errors. See `packages/next/src/build/webpack-config.ts` (search for "Alias server-only and client-only to proper exports based on bundling layers").

[Reference — Next.js webpack-config.ts module-layer rules](https://github.com/vercel/next.js/blob/canary/packages/next/src/build/webpack-config.ts).

Vite has no per-layer aliasing within an environment, so we mirror the behavior with import-chain taint tracking in a new `vinext:middleware-server-only` plugin:

1. Seed a `Set<string>` with the middleware entry path (and its canonical realpath).
2. For every `resolveId` call with a tainted importer, resolve the import via `this.resolve(..., { skipSelf: true })` and add the resolved id to the tainted set. This propagates taint synchronously along the import graph.
3. When a tainted module imports `server-only` in a non-RSC environment, short-circuit to the existing no-op shim path (`packages/vinext/src/shims/server-only.ts`) so plugin-rsc's `^server-only$` filter never matches.

The plugin uses `enforce: "pre"`, so its hook beats `rsc:validate-imports`' `order: "pre"` resolveId on the bare specifier. Taint is scoped to the middleware chain — `server-only` from anywhere else (client component code traversing the SSR pass, for example) still hits the rsc:validate-imports rejection, preserving the existing safety net.

Reference — the failing fixture this fix mirrors: [Next.js `test/e2e/module-layer/module-layer.test.ts`](https://github.com/vercel/next.js/blob/canary/test/e2e/module-layer/module-layer.test.ts). Its `middleware.js` imports `server-only` plus `react`, which is the exact shape that broke in deploy-suite run [26163751905](https://github.com/cloudflare/vinext/actions/runs/26163751905).

## Test plan

- [x] `pnpm test tests/middleware-server-only.test.ts` — new integration test builds a hybrid App+Pages Router fixture (matching the Next.js module-layer fixture's shape) whose middleware imports `server-only` directly **and** transitively via a `lib/auth.ts` helper. Two assertions: (a) no `invalid import of 'server-only'` stub appears in any server-side artifact, and (b) the middleware-reachable `lib/auth.ts` sentinel survives into the bundle (guards against a trivially passing test that just tree-shook the chain out).
- [x] Reproduced the failure on `main` by temporarily disabling the plugin — same error as CI, same import chain (`middleware.ts → virtual:vinext-server-entry → virtual:vinext-app-ssr-entry`).
- [x] `pnpm run check` — format, lint, type-check all green.
- [x] `pnpm test tests/app-post-middleware-context.test.ts tests/build-optimization.test.ts tests/build-time-classification-integration.test.ts tests/check.test.ts tests/shims.test.ts` — sibling test suites still pass.
- [ ] CI deploy suite — confirm the 13 `module-layer.test.ts` failures clear.