### PR TITLE
fix(middleware): redirect protocol — relative Location and x-nextjs-redirect

### DIFF
--- a/packages/vinext/src/deploy.ts
+++ b/packages/vinext/src/deploy.ts
@@ -606,6 +606,11 @@ export default {
         return new Response("This page could not be found", { status: 404 });
       }
 
+      // Capture x-nextjs-data before filterInternalHeaders strips it -- the
+      // middleware redirect protocol needs to know whether the inbound request
+      // was a _next/data fetch to emit x-nextjs-redirect instead of a 3xx.
+      const isDataRequest = request.headers.get("x-nextjs-data") === "1";
+
       // Strip internal headers from inbound requests so they cannot be
       // forged to influence routing or impersonate internal state.
       // Request.headers is immutable in Workers, so build a clean copy.
@@ -691,7 +696,7 @@ export default {
       const middlewareHeaders: Record<string, string | string[]> = {};
       let middlewareRewriteStatus: number | undefined;
       if (typeof runMiddleware === "function") {
-        const result = await runMiddleware(request, ctx);
+        const result = await runMiddleware(request, ctx, { isDataRequest });
 
         // Bubble up waitUntil promises (e.g. Clerk telemetry/session sync)
         if (result.waitUntilPromises?.length) {

--- a/packages/vinext/src/entries/pages-server-entry.ts
+++ b/packages/vinext/src/entries/pages-server-entry.ts
@@ -159,11 +159,12 @@ if (typeof _instrumentation.onRequestError === "function") {
   // TypeScript modules so dev/prod paths cannot drift.
   const middlewareExportCode = middlewarePath
     ? `
-export async function runMiddleware(request, ctx) {
+export async function runMiddleware(request, ctx, options) {
   return __runGeneratedMiddleware({
     basePath: vinextConfig.basePath,
     ctx,
     i18nConfig,
+    isDataRequest: options?.isDataRequest === true,
     isProxy: ${JSON.stringify(isProxyFile(middlewarePath))},
     module: middlewareModule,
     request,

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -2878,6 +2878,11 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                     .map(([k, v]) => [k, Array.isArray(v) ? v.join(", ") : String(v)]),
                 ),
               );
+              // Capture `x-nextjs-data` before filterInternalHeaders strips it
+              // — the middleware redirect protocol needs to know whether the
+              // inbound request was a `_next/data` fetch to emit
+              // `x-nextjs-redirect` instead of a 3xx.
+              const isDataRequest = rawHeaders.get("x-nextjs-data") === "1";
               // Strip internal headers from inbound requests so they cannot be
               // forged to influence routing or impersonate internal state.
               // Both the middleware Request (built below) and the SSR handler
@@ -2958,6 +2963,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                   middlewareRequest,
                   nextConfig?.i18n,
                   nextConfig?.basePath,
+                  isDataRequest,
                 );
 
                 // Settle waitUntil promises — no ctx.waitUntil() in dev, but

--- a/packages/vinext/src/server/app-middleware.ts
+++ b/packages/vinext/src/server/app-middleware.ts
@@ -20,6 +20,12 @@ export type ApplyAppMiddlewareOptions = {
   cleanPathname: string;
   context: AppMiddlewareContext;
   i18nConfig?: NextI18nConfig | null;
+  /**
+   * Whether the inbound request was a `_next/data` fetch. Captured from the
+   * raw incoming headers by the caller, because `x-nextjs-data` is in
+   * INTERNAL_HEADERS and is stripped before this function runs.
+   */
+  isDataRequest?: boolean;
   isProxy: boolean;
   module: MiddlewareModule;
   request: Request;
@@ -224,6 +230,7 @@ export async function applyAppMiddleware(
     const result = await executeMiddleware({
       basePath: options.basePath,
       i18nConfig: options.i18nConfig,
+      isDataRequest: options.isDataRequest,
       isProxy: options.isProxy,
       module: options.module,
       normalizedPathname: cleanPathname,

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -281,6 +281,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
   options: CreateAppRscHandlerOptions<TRoute>,
   request: Request,
   preMiddlewareRequestContext: RequestContext,
+  isDataRequest: boolean,
 ): Promise<Response> {
   const handlerStart = process.env.NODE_ENV !== "production" ? performance.now() : 0;
 
@@ -353,6 +354,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
       cleanPathname,
       context: middlewareContext,
       i18nConfig: options.i18nConfig,
+      isDataRequest,
       isProxy: options.isMiddlewareProxy,
       module: options.middlewareModule,
       request,
@@ -580,6 +582,10 @@ export function createAppRscHandler<TRoute extends AppRscHandlerRoute>(
     // visible to .get() but lost when filterInternalHeaders iterates. Read it
     // BEFORE iterating so applyForwardedMiddlewareContext can skip middleware.
     const mwCtx = rawRequest.headers.get(VINEXT_MW_CTX_HEADER);
+    // Capture `x-nextjs-data` before filtering — the middleware redirect
+    // protocol needs to know whether the inbound request was a `_next/data`
+    // fetch to emit `x-nextjs-redirect` instead of an HTTP redirect.
+    const isDataRequest = rawRequest.headers.get("x-nextjs-data") === "1";
     const filteredHeaders = filterInternalHeaders(rawRequest.headers);
     if (mwCtx !== null) {
       filteredHeaders.set(VINEXT_MW_CTX_HEADER, mwCtx);
@@ -604,7 +610,12 @@ export function createAppRscHandler<TRoute extends AppRscHandlerRoute>(
           let response: Response;
 
           try {
-            response = await handleAppRscRequest(options, request, preMiddlewareRequestContext);
+            response = await handleAppRscRequest(
+              options,
+              request,
+              preMiddlewareRequestContext,
+              isDataRequest,
+            );
           } catch (error) {
             if (process.env.NODE_ENV !== "production") {
               flattenErrorCauses(error);

--- a/packages/vinext/src/server/middleware-runtime.ts
+++ b/packages/vinext/src/server/middleware-runtime.ts
@@ -103,6 +103,47 @@ function stripMiddlewareHeadersFromResponse(response: Response): Response {
   });
 }
 
+/**
+ * Make a same-host URL relative to the request origin. Cross-origin URLs are
+ * returned unchanged. Mirrors Next.js's `getRelativeURL` behaviour:
+ * https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/router/utils/relativize-url.ts
+ */
+function relativizeLocation(location: string, requestUrl: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(location, requestUrl);
+  } catch {
+    return location;
+  }
+  const base = new URL(requestUrl);
+  if (parsed.origin !== base.origin) return parsed.toString();
+  return parsed.pathname + parsed.search + parsed.hash;
+}
+
+/**
+ * Translate a middleware redirect Response into the soft-redirect protocol
+ * used by Next.js for `_next/data` requests: a 200 OK with the redirect target
+ * carried in the `x-nextjs-redirect` header. The client router consumes this
+ * header to perform the navigation, avoiding CORS issues that would arise from
+ * an actual cross-origin HTTP redirect on a data fetch.
+ *
+ * Reference: packages/next/src/server/web/adapter.ts
+ * https://github.com/vercel/next.js/blob/canary/packages/next/src/server/web/adapter.ts
+ */
+function dataRedirectResponse(target: string, originalResponse: Response): Response {
+  const headers = new Headers(originalResponse.headers);
+  processMiddlewareHeaders(headers);
+  headers.delete("Location");
+  headers.delete("location");
+  headers.set("x-nextjs-redirect", target);
+  return new Response(null, { status: 200, headers });
+}
+
+/** True when the request was issued by Next.js's data-fetch client. */
+function isNextDataRequest(request: Request): boolean {
+  return request.headers.get("x-nextjs-data") === "1";
+}
+
 function collectMiddlewareHeaders(response: Response): Headers {
   const responseHeaders = new Headers();
   for (const [key, value] of response.headers) {
@@ -226,17 +267,43 @@ export async function executeMiddleware(
   if (response.status >= 300 && response.status < 400) {
     const location = response.headers.get("Location") ?? response.headers.get("location");
     if (location) {
+      // Make same-host Location relative for parity with Next.js, which only
+      // emits absolute URLs for cross-origin redirects:
+      // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/web/adapter.ts
+      const relativeLocation = relativizeLocation(location, options.request.url);
+
+      // For `_next/data` requests, translate the HTTP redirect into the
+      // `x-nextjs-redirect` soft-redirect protocol so the client router can
+      // perform the navigation without tripping CORS on cross-origin targets.
+      if (isNextDataRequest(options.request)) {
+        return {
+          continue: false,
+          response: dataRedirectResponse(relativeLocation, response),
+          waitUntilPromises,
+        };
+      }
+
       const responseHeaders = new Headers();
       for (const [key, value] of response.headers) {
         if (!key.startsWith(MIDDLEWARE_HEADER_PREFIX) && key.toLowerCase() !== "location") {
           responseHeaders.append(key, value);
         }
       }
+      // Rebuild the response with the relativized Location so consumers that
+      // forward `result.response` (rather than `result.redirectUrl`) also send
+      // the correct header.
+      const relativizedResponseHeaders = new Headers(response.headers);
+      relativizedResponseHeaders.set("Location", relativeLocation);
+      const relativizedResponse = new Response(response.body, {
+        status: response.status,
+        statusText: response.statusText,
+        headers: relativizedResponseHeaders,
+      });
       return {
         continue: false,
-        redirectUrl: location,
+        redirectUrl: relativeLocation,
         redirectStatus: response.status,
-        response: stripMiddlewareHeadersFromResponse(response),
+        response: stripMiddlewareHeadersFromResponse(relativizedResponse),
         responseHeaders,
         waitUntilPromises,
       };

--- a/packages/vinext/src/server/middleware-runtime.ts
+++ b/packages/vinext/src/server/middleware-runtime.ts
@@ -46,6 +46,13 @@ type ExecuteMiddlewareOptions = {
   filePath?: string;
   i18nConfig?: NextI18nConfig | null;
   includeErrorDetails?: boolean;
+  /**
+   * Whether the incoming request was a Next.js `_next/data` fetch (carried
+   * `x-nextjs-data: 1`). The header itself is stripped by `filterInternalHeaders`
+   * before the middleware request is constructed, so callers must capture this
+   * flag from the raw incoming headers and forward it explicitly.
+   */
+  isDataRequest?: boolean;
   isProxy: boolean;
   module: MiddlewareModule;
   normalizedPathname?: string;
@@ -133,15 +140,11 @@ function relativizeLocation(location: string, requestUrl: string): string {
 function dataRedirectResponse(target: string, originalResponse: Response): Response {
   const headers = new Headers(originalResponse.headers);
   processMiddlewareHeaders(headers);
+  // Headers.delete is case-insensitive per the Fetch spec, so a single call
+  // covers `Location` / `location` / `LOCATION`.
   headers.delete("Location");
-  headers.delete("location");
   headers.set("x-nextjs-redirect", target);
   return new Response(null, { status: 200, headers });
-}
-
-/** True when the request was issued by Next.js's data-fetch client. */
-function isNextDataRequest(request: Request): boolean {
-  return request.headers.get("x-nextjs-data") === "1";
 }
 
 function collectMiddlewareHeaders(response: Response): Headers {
@@ -275,7 +278,10 @@ export async function executeMiddleware(
       // For `_next/data` requests, translate the HTTP redirect into the
       // `x-nextjs-redirect` soft-redirect protocol so the client router can
       // perform the navigation without tripping CORS on cross-origin targets.
-      if (isNextDataRequest(options.request)) {
+      // `x-nextjs-data` lives in INTERNAL_HEADERS and is stripped before the
+      // middleware request is constructed, so the flag is threaded in from the
+      // caller (which sees the raw incoming headers).
+      if (options.isDataRequest) {
         return {
           continue: false,
           response: dataRedirectResponse(relativeLocation, response),

--- a/packages/vinext/src/server/middleware.ts
+++ b/packages/vinext/src/server/middleware.ts
@@ -134,6 +134,7 @@ export async function runMiddleware(
   request: Request,
   i18nConfig?: NextI18nConfig | null,
   basePath?: string,
+  isDataRequest?: boolean,
 ): Promise<MiddlewareResult> {
   // Load the middleware module via the direct-call ModuleRunner.
   // This bypasses the hot channel entirely and is safe with all Vite plugin
@@ -148,6 +149,7 @@ export async function runMiddleware(
     filePath: middlewarePath,
     i18nConfig,
     includeErrorDetails: process.env.NODE_ENV !== "production",
+    isDataRequest,
     isProxy: isProxyFile(middlewarePath),
     module: mod,
     request,

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -1557,6 +1557,10 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
         if (v) h.set(k, Array.isArray(v) ? v.join(", ") : v);
         return h;
       }, new Headers());
+      // Capture `x-nextjs-data` before filterInternalHeaders strips it — the
+      // middleware redirect protocol needs to know whether the inbound request
+      // was a `_next/data` fetch to emit `x-nextjs-redirect` instead of a 3xx.
+      const isDataRequest = rawReqHeaders.get("x-nextjs-data") === "1";
       // Strip internal headers from inbound requests before any handler or
       // middleware sees them.
       const reqHeaders = filterInternalHeaders(rawReqHeaders);
@@ -1603,7 +1607,7 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
       const middlewareHeaders: Record<string, string | string[]> = {};
       let middlewareStatus: number | undefined;
       if (typeof runMiddleware === "function") {
-        const result = await runMiddleware(webRequest, undefined);
+        const result = await runMiddleware(webRequest, undefined, { isDataRequest });
 
         // Settle waitUntil promises immediately — in Node.js there's no ctx.waitUntil().
         // Must run BEFORE the !result.continue check so promises survive redirect/response paths

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -521,7 +521,7 @@ describe("generatePagesRouterWorkerEntry", () => {
   it("runs middleware before routing", () => {
     const content = generatePagesRouterWorkerEntry();
     // Middleware should appear before API route check
-    const middlewarePos = content.indexOf("runMiddleware(request, ctx)");
+    const middlewarePos = content.indexOf("runMiddleware(request, ctx, { isDataRequest })");
     const apiRoutePos = content.indexOf('resolvedPathname.startsWith("/api/")');
     expect(middlewarePos).toBeGreaterThan(-1);
     expect(apiRoutePos).toBeGreaterThan(-1);
@@ -531,7 +531,7 @@ describe("generatePagesRouterWorkerEntry", () => {
   it("applies next.config.js redirects before middleware", () => {
     const content = generatePagesRouterWorkerEntry();
     const redirectPos = content.indexOf("matchRedirect(pathname, configRedirects, reqCtx)");
-    const middlewarePos = content.indexOf("runMiddleware(request, ctx)");
+    const middlewarePos = content.indexOf("runMiddleware(request, ctx, { isDataRequest })");
     expect(redirectPos).toBeGreaterThan(-1);
     expect(middlewarePos).toBeGreaterThan(-1);
     expect(redirectPos).toBeLessThan(middlewarePos);
@@ -881,7 +881,7 @@ describe("generatePagesRouterWorkerEntry", () => {
   it("builds reqCtx before middleware runs", () => {
     const content = generatePagesRouterWorkerEntry();
     const reqCtxPos = content.indexOf("requestContextFromRequest(request)");
-    const middlewarePos = content.indexOf("runMiddleware(request, ctx)");
+    const middlewarePos = content.indexOf("runMiddleware(request, ctx, { isDataRequest })");
     expect(reqCtxPos).toBeGreaterThan(-1);
     expect(middlewarePos).toBeGreaterThan(-1);
     expect(reqCtxPos).toBeLessThan(middlewarePos);

--- a/tests/middleware-runtime.test.ts
+++ b/tests/middleware-runtime.test.ts
@@ -88,9 +88,8 @@ describe("middleware redirect protocol", () => {
     const result = await executeMiddleware({
       isProxy: false,
       module,
-      request: new Request("http://localhost:3000/old-home", {
-        headers: { "x-nextjs-data": "1" },
-      }),
+      isDataRequest: true,
+      request: new Request("http://localhost:3000/old-home"),
     });
 
     // The protocol: 200 response, no Location, x-nextjs-redirect header set.
@@ -110,11 +109,10 @@ describe("middleware redirect protocol", () => {
     };
 
     const result = await executeMiddleware({
+      isDataRequest: true,
       isProxy: false,
       module,
-      request: new Request("http://localhost:3000/old-home?override=external", {
-        headers: { "x-nextjs-data": "1" },
-      }),
+      request: new Request("http://localhost:3000/old-home?override=external"),
     });
 
     expect(result.continue).toBe(false);
@@ -122,6 +120,29 @@ describe("middleware redirect protocol", () => {
     expect(result.response?.headers.get("x-nextjs-redirect")).toBe("https://example.vercel.sh/");
     expect(result.response?.headers.get("Location")).toBeNull();
     expect(result.redirectUrl).toBeUndefined();
+  });
+
+  it("ignores a forged x-nextjs-data header when the caller did not opt in", async () => {
+    // `x-nextjs-data` is in INTERNAL_HEADERS and gets stripped by the caller
+    // before this function runs. The soft-redirect protocol is gated on the
+    // explicit `isDataRequest` flag rather than the header on the request, so
+    // forged headers can never reach the redirect translator.
+    const module = {
+      default: (req: Request) => Response.redirect(new URL("/new-home", req.url).toString(), 307),
+    };
+
+    const result = await executeMiddleware({
+      isProxy: false,
+      module,
+      // The flag is intentionally NOT set — only the (forged) header is.
+      request: new Request("http://localhost:3000/old-home", {
+        headers: { "x-nextjs-data": "1" },
+      }),
+    });
+
+    expect(result.redirectUrl).toBe("/new-home");
+    expect(result.response?.status).toBe(307);
+    expect(result.response?.headers.get("x-nextjs-redirect")).toBeNull();
   });
 
   it("does not translate redirects to x-nextjs-redirect when x-nextjs-data is absent", async () => {

--- a/tests/middleware-runtime.test.ts
+++ b/tests/middleware-runtime.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vite-plus/test";
+import { executeMiddleware } from "../packages/vinext/src/server/middleware-runtime.js";
+
+// Tests for the redirect protocol implemented in `executeMiddleware`. These
+// fixtures mirror the behaviour Next.js's edge adapter applies after a
+// middleware returns a redirect Response:
+//   - Same-host Location headers are made relative.
+//   - When the original request carries `x-nextjs-data: 1`, the redirect is
+//     translated into a 200 response with `x-nextjs-redirect`.
+// Reference: packages/next/src/server/web/adapter.ts (canary)
+// https://github.com/vercel/next.js/blob/canary/packages/next/src/server/web/adapter.ts
+
+describe("middleware redirect protocol", () => {
+  it("relativizes the Location header for same-host redirects", async () => {
+    const module = {
+      default: (req: Request) => {
+        const target = new URL("/another", req.url);
+        return Response.redirect(target.toString(), 302);
+      },
+    };
+
+    const result = await executeMiddleware({
+      isProxy: false,
+      module,
+      request: new Request("http://127.0.0.1:39063/to?pathname=/another"),
+    });
+
+    expect(result.continue).toBe(false);
+    expect(result.redirectUrl).toBe("/another");
+    expect(result.redirectStatus).toBe(302);
+    expect(result.response?.headers.get("Location")).toBe("/another");
+  });
+
+  it("preserves the search string when relativizing the Location header", async () => {
+    const module = {
+      default: (req: Request) => {
+        const target = new URL("/another?foo=bar", req.url);
+        return Response.redirect(target.toString(), 307);
+      },
+    };
+
+    const result = await executeMiddleware({
+      isProxy: false,
+      module,
+      request: new Request("http://localhost:3000/start"),
+    });
+
+    expect(result.redirectUrl).toBe("/another?foo=bar");
+    expect(result.response?.headers.get("Location")).toBe("/another?foo=bar");
+  });
+
+  it("preserves the hash fragment when relativizing the Location header", async () => {
+    const module = {
+      default: (req: Request) =>
+        Response.redirect(new URL("/new-home#fragment", req.url).toString(), 307),
+    };
+
+    const result = await executeMiddleware({
+      isProxy: false,
+      module,
+      request: new Request("http://localhost:3000/with-fragment"),
+    });
+
+    expect(result.redirectUrl).toBe("/new-home#fragment");
+  });
+
+  it("leaves cross-origin Location headers absolute", async () => {
+    const module = {
+      default: () => Response.redirect("https://example.vercel.sh/", 307),
+    };
+
+    const result = await executeMiddleware({
+      isProxy: false,
+      module,
+      request: new Request("http://127.0.0.1:39063/old-home?override=external"),
+    });
+
+    expect(result.continue).toBe(false);
+    expect(result.redirectUrl).toBe("https://example.vercel.sh/");
+    expect(result.response?.headers.get("Location")).toBe("https://example.vercel.sh/");
+  });
+
+  it("translates same-host redirects to x-nextjs-redirect for data requests", async () => {
+    const module = {
+      default: (req: Request) => Response.redirect(new URL("/new-home", req.url).toString(), 307),
+    };
+
+    const result = await executeMiddleware({
+      isProxy: false,
+      module,
+      request: new Request("http://localhost:3000/old-home", {
+        headers: { "x-nextjs-data": "1" },
+      }),
+    });
+
+    // The protocol: 200 response, no Location, x-nextjs-redirect header set.
+    expect(result.continue).toBe(false);
+    expect(result.response).toBeDefined();
+    expect(result.response?.status).toBe(200);
+    expect(result.response?.headers.get("x-nextjs-redirect")).toBe("/new-home");
+    expect(result.response?.headers.get("Location")).toBeNull();
+    // No HTTP redirect should be surfaced to upstream callers.
+    expect(result.redirectUrl).toBeUndefined();
+    expect(result.redirectStatus).toBeUndefined();
+  });
+
+  it("translates external redirects to x-nextjs-redirect for data requests", async () => {
+    const module = {
+      default: () => Response.redirect("https://example.vercel.sh/", 307),
+    };
+
+    const result = await executeMiddleware({
+      isProxy: false,
+      module,
+      request: new Request("http://localhost:3000/old-home?override=external", {
+        headers: { "x-nextjs-data": "1" },
+      }),
+    });
+
+    expect(result.continue).toBe(false);
+    expect(result.response?.status).toBe(200);
+    expect(result.response?.headers.get("x-nextjs-redirect")).toBe("https://example.vercel.sh/");
+    expect(result.response?.headers.get("Location")).toBeNull();
+    expect(result.redirectUrl).toBeUndefined();
+  });
+
+  it("does not translate redirects to x-nextjs-redirect when x-nextjs-data is absent", async () => {
+    const module = {
+      default: (req: Request) => Response.redirect(new URL("/new-home", req.url).toString(), 307),
+    };
+
+    const result = await executeMiddleware({
+      isProxy: false,
+      module,
+      request: new Request("http://localhost:3000/old-home"),
+    });
+
+    expect(result.continue).toBe(false);
+    expect(result.redirectUrl).toBe("/new-home");
+    expect(result.response?.status).toBe(307);
+    expect(result.response?.headers.get("x-nextjs-redirect")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Brings vinext's middleware redirect responses in line with Next.js's edge adapter:

- **Relativize same-host `Location` headers.** Next.js emits `Location: /another`; vinext was emitting `Location: http://127.0.0.1:39063/another`. Now matches Next.js — only cross-origin targets stay absolute.
- **`x-nextjs-redirect` soft-redirect protocol.** When the incoming request carries `x-nextjs-data: 1` (a `_next/data` fetch), translate the HTTP 3xx into a 200 OK with `x-nextjs-redirect: <target>`. The client router consumes this header to perform the navigation without tripping CORS on cross-origin data fetches.

Both fixes live in `executeMiddleware` (`packages/vinext/src/server/middleware-runtime.ts`), so all four call sites — prod server, dev plugin, deploy worker, app-middleware — inherit the corrected protocol. Dev/prod parity is preserved.

Reference: [`packages/next/src/server/web/adapter.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/web/adapter.ts) (lines 446–487) and [`relativize-url.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/router/utils/relativize-url.ts).

## Test plan

- [x] New unit tests in `tests/middleware-runtime.test.ts` (7 cases):
  - Same-host Location is relativized; status code is preserved.
  - Search string and hash fragment survive relativization.
  - Cross-origin Location stays absolute.
  - `x-nextjs-data: 1` triggers translation to 200 + `x-nextjs-redirect` for both same-host and external targets.
  - Without `x-nextjs-data`, behaviour remains a normal HTTP redirect.
- [x] `pnpm test tests/middleware-runtime.test.ts` — all 7 pass.
- [x] `pnpm test tests/shims.test.ts tests/app-post-middleware-context.test.ts tests/request-pipeline.test.ts tests/app-rsc-handler.test.ts tests/deploy.test.ts` — all 1265 existing tests still pass.
- [x] `pnpm run check` — lint, format, type-check clean.

## Follow-up

Issue 1334 also lists an i18n + API redirect hang (`/fr/api/ok` 60 s timeout). That is a distinct routing problem in the locale-prefix stripping for API routes and is not addressed here; tracked as remaining work on the parent issue.

Refs #1334