### PR TITLE
fix(pages-router): guard navigation shim against SSR

### DIFF
--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -823,6 +823,25 @@ function updateHistory(mode: "push" | "replace", url: string): void {
 }
 
 /**
+ * Throw the canonical "no router instance" error used when a Pages Router
+ * navigation method (push/replace/back/reload/prefetch/beforePopState) is
+ * invoked during SSR or prerendering.
+ *
+ * Mirrors Next.js's `ServerRouter.push`/`replace`/etc. which all call
+ * `noRouter()` in `packages/next/src/server/render.tsx`. The error message
+ * matches Next.js verbatim so userland error handling and docs links work
+ * unchanged.
+ *
+ * Ported from Next.js: packages/next/src/server/render.tsx
+ * https://github.com/vercel/next.js/blob/canary/packages/next/src/server/render.tsx
+ */
+function throwNoRouterInstance(): never {
+  throw new Error(
+    'No router instance found. you should only use "next/router" inside the client side of your app. https://nextjs.org/docs/messages/no-router-instance',
+  );
+}
+
+/**
  * Shared client-side navigation flow used by both `useRouter()` and the
  * `Router` singleton. The only differences between push/replace are the
  * history method (`pushState` vs `replaceState`), the external-URL fallback
@@ -840,6 +859,17 @@ async function performNavigation(
   mode: "push" | "replace",
   onStateUpdate?: () => void,
 ): Promise<boolean> {
+  // SSR / prerender guard. Calling Router.push or Router.replace from a
+  // Pages Router component during server rendering would otherwise crash
+  // with `ReferenceError: window is not defined` (window.location is
+  // accessed unconditionally below). Match Next.js's `ServerRouter.push`
+  // behaviour and throw the documented "no router instance" error so the
+  // failure surfaces as a normal render error instead of a ReferenceError
+  // that takes down the request pipeline.
+  if (typeof window === "undefined") {
+    throwNoRouterInstance();
+  }
+
   const navigationLocale = resolveTransitionLocale(options?.locale);
   let resolved = resolveNavigationTarget(url, as, navigationLocale);
 
@@ -1113,16 +1143,38 @@ export function withRouter<P extends WithRouterProps>(
 // Note: `withRouter` is exposed only as a named export from `next/router`.
 // The default export of that module is the Router singleton declared below.
 
-// Also export a default Router singleton for `import Router from 'next/router'`
+// Also export a default Router singleton for `import Router from 'next/router'`.
+//
+// Every navigation method is guarded against SSR/prerender execution. Matches
+// Next.js's `ServerRouter` (packages/next/src/server/render.tsx) which throws
+// `noRouter()` from push/replace/back/reload/prefetch/beforePopState so that
+// invoking them during server rendering surfaces as a documented render error
+// rather than a `ReferenceError: window is not defined`. The throws are
+// synchronous (not via the returned Promise) so render-time callers see the
+// error inline — matching Next.js behaviour and avoiding unhandled rejections.
 const Router = {
-  push: (url: string | UrlObject, as?: string, options?: TransitionOptions) =>
-    performNavigation(url, as, options, "push"),
-  replace: (url: string | UrlObject, as?: string, options?: TransitionOptions) =>
-    performNavigation(url, as, options, "replace"),
-  back: () => window.history.back(),
-  reload: () => window.location.reload(),
-  prefetch: prefetchUrl,
+  push: (url: string | UrlObject, as?: string, options?: TransitionOptions) => {
+    if (typeof window === "undefined") throwNoRouterInstance();
+    return performNavigation(url, as, options, "push");
+  },
+  replace: (url: string | UrlObject, as?: string, options?: TransitionOptions) => {
+    if (typeof window === "undefined") throwNoRouterInstance();
+    return performNavigation(url, as, options, "replace");
+  },
+  back: () => {
+    if (typeof window === "undefined") throwNoRouterInstance();
+    window.history.back();
+  },
+  reload: () => {
+    if (typeof window === "undefined") throwNoRouterInstance();
+    window.location.reload();
+  },
+  prefetch: (url: string) => {
+    if (typeof window === "undefined") throwNoRouterInstance();
+    return prefetchUrl(url);
+  },
   beforePopState: (cb: BeforePopStateCallback) => {
+    if (typeof window === "undefined") throwNoRouterInstance();
     _beforePopStateCb = cb;
   },
   events: routerEvents,

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -15848,3 +15848,99 @@ describe("next/offline shim", () => {
     expect(offline.useOffline()).toBe(false);
   });
 });
+
+// Regression for cloudflare/vinext#1353. The Pages Router navigation shim
+// referenced `window` unconditionally inside `performNavigation()`, so any
+// component calling `router.push()` during SSR or prerendering
+// (VINEXT_PRERENDER=1) crashed the render pipeline with
+// `ReferenceError: window is not defined`. Next.js's `ServerRouter`
+// (packages/next/src/server/render.tsx) instead throws a documented
+// "No router instance found" error from every navigation method. We mirror
+// that here so the failure mode is a recoverable render error rather than
+// a global ReferenceError.
+//
+// Ported from Next.js: test/e2e/with-router/pages/router-method-ssr.js +
+// test/e2e/with-router/index.test.ts (the "router-method-ssr" SSR case).
+describe("next/router SSR guard (issue #1353)", () => {
+  let previousWindow: unknown;
+
+  beforeEach(() => {
+    previousWindow = (globalThis as any).window;
+    delete (globalThis as any).window;
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    if (previousWindow === undefined) {
+      delete (globalThis as any).window;
+    } else {
+      (globalThis as any).window = previousWindow;
+    }
+    vi.resetModules();
+  });
+
+  it("Router.push throws the documented 'no router instance' error during SSR (no ReferenceError)", async () => {
+    const Router = (await import("../packages/vinext/src/shims/router.js")).default;
+    expect(() => Router.push("/a")).toThrow(/No router instance found/);
+  });
+
+  it("Router.replace throws the documented 'no router instance' error during SSR", async () => {
+    const Router = (await import("../packages/vinext/src/shims/router.js")).default;
+    expect(() => Router.replace("/a")).toThrow(/No router instance found/);
+  });
+
+  it("Router.back throws during SSR instead of touching window.history", async () => {
+    const Router = (await import("../packages/vinext/src/shims/router.js")).default;
+    expect(() => Router.back()).toThrow(/No router instance found/);
+  });
+
+  it("Router.reload throws during SSR instead of touching window.location", async () => {
+    const Router = (await import("../packages/vinext/src/shims/router.js")).default;
+    expect(() => Router.reload()).toThrow(/No router instance found/);
+  });
+
+  it("Router.prefetch throws during SSR instead of touching document", async () => {
+    const Router = (await import("../packages/vinext/src/shims/router.js")).default;
+    expect(() => Router.prefetch("/a")).toThrow(/No router instance found/);
+  });
+
+  it("Router.beforePopState throws during SSR", async () => {
+    const Router = (await import("../packages/vinext/src/shims/router.js")).default;
+    expect(() => Router.beforePopState(() => true)).toThrow(/No router instance found/);
+  });
+
+  // Render a `withRouter`-wrapped page that calls `router.push()` during SSR
+  // (the exact pattern from Next.js's `router-method-ssr.js` fixture).
+  // Before the fix this crashed with `ReferenceError: window is not defined`
+  // from `performNavigation`. After the fix the render throws the documented
+  // "No router instance found" error, which is what Next.js does too.
+  it("withRouter component that calls router.push() during SSR throws a render error, not a ReferenceError", async () => {
+    const { withRouter, wrapWithRouterContext } =
+      await import("../packages/vinext/src/shims/router.js");
+    const React = await import("react");
+    const { renderToStaticMarkup } = await import("react-dom/server");
+
+    const RouterMethodSSR = ({ router }: { router: NextRouter }) => {
+      // Mirrors Next.js's `router-method-ssr.js` fixture, which calls
+      // `router.push('/a')` synchronously during SSR. The push must throw
+      // synchronously for the test to observe the error; we ignore the
+      // returned Promise type via `void` to satisfy the lint rule (the
+      // Promise is never produced because the sync throw happens first).
+      void router.push("/a");
+      return React.createElement("p", null, "Navigating...");
+    };
+    const Wrapped = withRouter(RouterMethodSSR as React.ComponentType<{ router: NextRouter }>);
+
+    let caught: unknown = null;
+    try {
+      renderToStaticMarkup(wrapWithRouterContext(React.createElement(Wrapped)));
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toMatch(/No router instance found/);
+    expect((caught as Error).message).not.toMatch(/window is not defined/);
+    expect(caught as Error).not.toBeInstanceOf(ReferenceError);
+  });
+});


### PR DESCRIPTION
## Summary

`performNavigation()` and the `Router` singleton's `back`/`reload`/`prefetch`/`beforePopState` methods referenced `window`/`document` unconditionally. Invoking `router.push()` from a Pages Router component during SSR or prerender (`VINEXT_PRERENDER=1`) crashed the request pipeline with:

```
ReferenceError: window is not defined
    at performNavigation (.../dist/server/entry.js:1288:76)
    at Object.push (.../dist/server/entry.js:1407:30)
    at RouterMethodSSR (.../dist/server/entry.js:5257:44)
```

Cleanup then surfaced as a downstream `TypeError: Cannot read properties of undefined (reading 'destroy')` in `afterAll` because the prerender process never reached its normal teardown path.

This change mirrors Next.js's `ServerRouter` (`packages/next/src/server/render.tsx`) — every navigation method synchronously throws the documented `No router instance found. you should only use "next/router" inside the client side of your app.` error. The throw happens before any browser global is accessed, so the failure surfaces as a normal render error with the canonical docs link instead of a `ReferenceError` that takes down the worker.

Reproduces the Next.js `test/e2e/with-router/pages/router-method-ssr.js` fixture, which is the exact pattern the failing E2E tests use.

## Test plan

- [x] Added unit tests in `tests/shims.test.ts` covering every guarded path: `Router.push`/`replace`/`back`/`reload`/`prefetch`/`beforePopState` during SSR, plus a `withRouter`-wrapped component that calls `router.push()` during `renderToStaticMarkup`. Confirmed each test fails on `main` (7 failures, all surfacing `ReferenceError: window is not defined`) and passes on this branch.
- [x] `pnpm test tests/shims.test.ts` — 936 passed.
- [x] `pnpm test tests/pages-router.test.ts tests/router-javascript-urls.test.ts` — 220 passed.
- [x] `vp check` — formatting, lint, and types clean.
- [ ] CI green.

Closes #1353