### PR TITLE
fix: usePathname returns canonical URL after middleware rewrite

### DIFF
--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -295,6 +295,13 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
   const { url, isRscRequest, interceptionContextHeader, mountedSlotsHeader, renderMode } =
     normalized;
   let { pathname, cleanPathname } = normalized;
+  // Canonical (external) pathname the user requested. Middleware rewrites and
+  // next.config.js rewrites mutate `cleanPathname` so internal route matching
+  // can find the destination page, but hooks like `usePathname()` must reflect
+  // the original URL the user sees in the address bar.
+  // Matches Next.js: test/e2e/app-dir/hooks/hooks.test.ts —
+  //   "should have the canonical url pathname on rewrite"
+  const canonicalPathname = cleanPathname;
 
   const prerenderEndpointResponse = await handleAppPrerenderEndpoint(request, {
     isPrerenderEnabled() {
@@ -416,7 +423,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
   }
 
   options.setNavigationContext({
-    pathname: cleanPathname,
+    pathname: canonicalPathname,
     searchParams: url.searchParams,
     params: {},
   });
@@ -519,7 +526,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
 
   const { route, params } = match;
   options.setNavigationContext({
-    pathname: cleanPathname,
+    pathname: canonicalPathname,
     searchParams: url.searchParams,
     params,
   });

--- a/tests/fixtures/app-basic/middleware.ts
+++ b/tests/fixtures/app-basic/middleware.ts
@@ -62,6 +62,14 @@ export async function middleware(request: NextRequest, event: NextFetchEvent) {
     return NextResponse.rewrite(new URL("/", request.url));
   }
 
+  // Used by Vitest: nextjs-compat/hooks.test.ts — verifies usePathname()
+  // returns the CANONICAL URL (the one the user sees) after a middleware
+  // rewrite, not the internal rewrite target. Mirrors the Next.js test
+  // semantics for `/rewritten-use-pathname` via a middleware rewrite.
+  if (pathname === "/middleware-rewritten-use-pathname") {
+    return NextResponse.rewrite(new URL("/nextjs-compat/hooks-search", request.url));
+  }
+
   // Ported from Next.js: test/e2e/middleware-rewrites/app/middleware.js
   // https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-rewrites/app/middleware.js
   if (pathname === "/middleware-external-rewrite") {
@@ -290,6 +298,7 @@ export const config = {
     "/about",
     "/middleware-redirect",
     "/middleware-rewrite",
+    "/middleware-rewritten-use-pathname",
     "/middleware-external-rewrite",
     "/middleware-rewrite-query",
     "/middleware-rewrite-status",

--- a/tests/fixtures/app-basic/next.config.ts
+++ b/tests/fixtures/app-basic/next.config.ts
@@ -103,6 +103,14 @@ const nextConfig: NextConfig = {
         { source: "/after-rewrite-about", destination: "/about" },
         // Used by E2E: config-redirect.spec.ts
         { source: "/config-rewrite", destination: "/" },
+        // Used by Vitest: nextjs-compat/hooks.test.ts — usePathname should
+        // return the CANONICAL URL after a config rewrite, not the internal
+        // rewrite target. Ported from Next.js test/e2e/app-dir/hooks/next.config.js
+        // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/hooks/next.config.js
+        {
+          source: "/rewritten-use-pathname",
+          destination: "/nextjs-compat/hooks-search",
+        },
       ],
       fallback: [
         // Used by Vitest: app-router.test.ts — fallback rewrite gated on a

--- a/tests/nextjs-compat/hooks.test.ts
+++ b/tests/nextjs-compat/hooks.test.ts
@@ -127,6 +127,26 @@ describe("Next.js compat: hooks", () => {
     expect(html).toContain("/nextjs-compat/hooks-search");
   });
 
+  // Next.js: 'should have the canonical url pathname on rewrite'
+  // Source: https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/hooks/hooks.test.ts
+  // After a next.config.js (afterFiles) rewrite, usePathname() must return the
+  // CANONICAL (external) URL the user requested, not the internal rewrite target
+  // used for route matching.
+  it("usePathname returns the canonical URL after a config rewrite", async () => {
+    const { html } = await fetchHtml(baseUrl, "/rewritten-use-pathname");
+    expect(html).toContain('<p id="current-pathname">/rewritten-use-pathname</p>');
+    expect(html).not.toContain('<p id="current-pathname">/nextjs-compat/hooks-search</p>');
+  });
+
+  // Same canonical-URL behavior must hold for middleware rewrites: usePathname()
+  // should reflect what the user typed in the address bar, not the rewrite
+  // destination used for internal route matching.
+  it("usePathname returns the canonical URL after a middleware rewrite", async () => {
+    const { html } = await fetchHtml(baseUrl, "/middleware-rewritten-use-pathname");
+    expect(html).toContain('<p id="current-pathname">/middleware-rewritten-use-pathname</p>');
+    expect(html).not.toContain('<p id="current-pathname">/nextjs-compat/hooks-search</p>');
+  });
+
   // ── useRouter SSR ───────────────────────────────────────────
   // Next.js: 'should have the correct hooks at /adapter-hooks/1'
   // Source: https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/hooks/hooks.test.ts


### PR DESCRIPTION
## Summary

- `usePathname()` (and the App Router navigation context behind it) was returning the internal rewrite destination instead of the canonical/external URL the user requested. After a middleware or `next.config.js` rewrite, vinext used the post-rewrite `cleanPathname` both for internal route matching AND for the navigation context.
- This change preserves the pre-rewrite pathname as `canonicalPathname` and uses it when populating the navigation context, while leaving `cleanPathname` to drive route matching. Hooks now match what the user sees in the address bar.
- Matches Next.js: [`test/e2e/app-dir/hooks/hooks.test.ts`](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/hooks/hooks.test.ts) — "should have the canonical url pathname on rewrite".

Closes #1348

## Test plan

- [x] New: `usePathname returns the canonical URL after a config rewrite` (afterFiles rewrite `/rewritten-use-pathname` → `/nextjs-compat/hooks-search`, page renders `/rewritten-use-pathname`)
- [x] New: `usePathname returns the canonical URL after a middleware rewrite` (middleware `NextResponse.rewrite` of `/middleware-rewritten-use-pathname` → `/nextjs-compat/hooks-search`, page renders `/middleware-rewritten-use-pathname`)
- [x] `pnpm test tests/nextjs-compat/hooks.test.ts` — 12 passed
- [x] `pnpm test tests/app-router.test.ts tests/shims.test.ts tests/app-rsc-handler.test.ts` — 1266 passed
- [x] `pnpm test tests/nextjs-compat/use-client-page-pathname.test.ts` — 11 passed
- [x] `pnpm run check` — clean