### PR TITLE
feat(build): support .wasm?module imports

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -91,6 +91,7 @@ import { createRscClientReferenceLoadersPlugin } from "./plugins/rsc-client-refe
 import { createInstrumentationClientTransformPlugin } from "./plugins/instrumentation-client.js";
 import { createOptimizeImportsPlugin } from "./plugins/optimize-imports.js";
 import { createOgInlineFetchAssetsPlugin, ogAssetsPlugin } from "./plugins/og-assets.js";
+import { wasmModulePlugin } from "./plugins/wasm-module.js";
 import { generateRouteTypes } from "./typegen.js";
 import {
   mergeOptimizeDepsExclude,
@@ -3607,6 +3608,11 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         },
       },
     },
+    // Handle `import wasm from "./foo.wasm?module"` imports (a Cloudflare
+    // Workers convention) for non-Workers environments (RSC/SSR Node, client).
+    // Workers environments are still handled natively by @cloudflare/vite-plugin —
+    // see src/plugins/wasm-module.ts and cloudflare/vinext#1351.
+    wasmModulePlugin(),
     // Inline binary assets fetched via `fetch(new URL("./asset", import.meta.url))` —
     // see src/plugins/og-assets.ts
     createOgInlineFetchAssetsPlugin(),

--- a/packages/vinext/src/plugins/wasm-module.ts
+++ b/packages/vinext/src/plugins/wasm-module.ts
@@ -1,0 +1,145 @@
+/**
+ * vinext WASM `?module` import support
+ *
+ * Cloudflare Workers accept `import wasm from "./foo.wasm?module"` and the
+ * runtime instantiates the binary into a `WebAssembly.Module`. The Cloudflare
+ * Vite plugin already handles this for environments that map to a Worker (it
+ * marks the import as external and emits the `.wasm` as an asset). Other
+ * environments — vinext's RSC and SSR Node builds, the browser client build,
+ * or any non-Workers build — have no native support, and Rolldown/Vite fail
+ * with `UNLOADABLE_DEPENDENCY: Could not load src/foo.wasm?module` (see
+ * cloudflare/vinext#1351).
+ *
+ * Next.js solves the same problem via Webpack's experimental
+ * `asyncWebAssembly` (see `.nextjs-ref/test/e2e/edge-can-use-wasm-files/`).
+ * The Webpack output reads the WASM via `WebAssembly.instantiate(bytes)` from
+ * an emitted asset. We mirror that behaviour for non-Workers environments
+ * while letting the Cloudflare plugin keep its native handling for Workers.
+ *
+ * This plugin:
+ *   1. Intercepts `*.wasm?module` resolveId only in non-Workers environments.
+ *      In Workers environments the Cloudflare plugin's `enforce: "pre"` hook
+ *      runs first and externalises the import; we never see it.
+ *   2. Reads the binary, emits it as a Rollup asset so it lands in the build
+ *      output directory with a hashed filename.
+ *   3. Returns a tiny JS module whose default export is a pre-compiled
+ *      `WebAssembly.Module`, located via `new URL("./<hashed>.wasm", import.meta.url)`
+ *      and compiled with `WebAssembly.compile(await fs.readFile(url))`. The
+ *      shape matches Workers' `?module` default export (a `WebAssembly.Module`),
+ *      so user code such as
+ *
+ *          import wasm from "./add.wasm?module";
+ *          const instance = await WebAssembly.instantiate(wasm);
+ *
+ *      works identically across both runtimes.
+ *
+ * Dev (`vite serve`) is handled the same way — the asset is still emitted via
+ * `this.emitFile` in build, but in serve mode we fall back to reading the
+ * source file directly from disk via its absolute path. This keeps the dev
+ * server working without an asset pipeline.
+ */
+
+import type { Plugin } from "vite";
+import path from "node:path";
+import fs from "node:fs";
+
+const WASM_MODULE_RE = /\.wasm\?module(?:&.*)?$/;
+
+/**
+ * Create the `vinext:wasm-module` Vite plugin.
+ *
+ * The plugin opts out for Workers environments by deferring to whatever
+ * earlier `enforce: "pre"` plugin (currently `@cloudflare/vite-plugin`) marks
+ * `.wasm?module` as external. We only handle the resolveId/load path when no
+ * one else has — that is, when the import would otherwise reach Rolldown and
+ * fail to load.
+ */
+export function wasmModulePlugin(): Plugin {
+  let isBuild = false;
+
+  return {
+    name: "vinext:wasm-module",
+    // `post` so that any environment-specific plugin (notably
+    // `@cloudflare/vite-plugin`, which uses `enforce: "pre"`) has already had
+    // a chance to externalise the import for Workers builds. We only step in
+    // when nobody else claimed the id, i.e. non-Workers environments where
+    // the import would otherwise be unloadable.
+    enforce: "post",
+
+    configResolved(config) {
+      isBuild = config.command === "build";
+    },
+
+    resolveId: {
+      filter: { id: WASM_MODULE_RE },
+      async handler(source, importer) {
+        // Strip the `?module` query so Vite's default resolver can locate
+        // the file on disk relative to the importer. We re-attach the query
+        // to the returned id so `load` knows this was a `?module` request.
+        const [bare, query = ""] = source.split("?");
+        const resolved = await this.resolve(bare, importer, { skipSelf: true });
+        if (!resolved) return null;
+        return `${resolved.id}?${query}`;
+      },
+    },
+
+    async load(id) {
+      if (!WASM_MODULE_RE.test(id)) return null;
+      const filePath = id.split("?")[0];
+
+      let source: Buffer;
+      try {
+        source = await fs.promises.readFile(filePath);
+      } catch (err) {
+        this.error(
+          `[vinext:wasm-module] Could not read WASM file ${filePath}: ${(err as Error).message}`,
+        );
+      }
+
+      if (isBuild) {
+        // Emit the binary as a hashed asset so it ends up in the output dir
+        // and we can reference it from the generated JS via import.meta.url.
+        const referenceId = this.emitFile({
+          type: "asset",
+          name: path.basename(filePath),
+          source,
+        });
+
+        // The default export must be a `WebAssembly.Module` to match the
+        // shape that Workers' native `?module` import provides. We compile
+        // the binary at module-evaluation time using `WebAssembly.compile`
+        // against bytes read from disk relative to the emitted asset.
+        //
+        // Reading via `new URL(..., import.meta.url)` works in Node.js
+        // (file:// URL) and in browser builds (the URL is rewritten by
+        // Vite/Rolldown to the public path of the emitted asset). For the
+        // browser build we fall back to `fetch` since `node:fs` is not
+        // available — see the runtime branch below.
+        return [
+          `import { createRequire as __vinext_createRequire } from "node:module";`,
+          `const __vinext_wasm_url = new URL(import.meta.ROLLUP_FILE_URL_${referenceId}, import.meta.url);`,
+          `async function __vinext_load_wasm_module() {`,
+          `  if (typeof process !== "undefined" && process.versions && process.versions.node) {`,
+          `    const require = __vinext_createRequire(import.meta.url);`,
+          `    const { readFile } = require("node:fs/promises");`,
+          `    const { fileURLToPath } = require("node:url");`,
+          `    const bytes = await readFile(fileURLToPath(__vinext_wasm_url));`,
+          `    return WebAssembly.compile(bytes);`,
+          `  }`,
+          `  const res = await fetch(__vinext_wasm_url);`,
+          `  return WebAssembly.compileStreaming ? WebAssembly.compileStreaming(res) : WebAssembly.compile(await res.arrayBuffer());`,
+          `}`,
+          `export default await __vinext_load_wasm_module();`,
+        ].join("\n");
+      }
+
+      // Dev server: skip asset emission and compile from the source file
+      // directly so HMR keeps working without an asset pipeline.
+      const absPath = JSON.stringify(filePath);
+      return [
+        `import { readFile as __vinext_readFile } from "node:fs/promises";`,
+        `export default await WebAssembly.compile(await __vinext_readFile(${absPath}));`,
+      ].join("\n");
+    },
+  } satisfies Plugin;
+}

--- a/packages/vinext/src/plugins/wasm-module.ts
+++ b/packages/vinext/src/plugins/wasm-module.ts
@@ -94,7 +94,13 @@ export function wasmModulePlugin(): Plugin {
         this.error(
           `[vinext:wasm-module] Could not read WASM file ${filePath}: ${(err as Error).message}`,
         );
+        // `this.error` throws, but Rollup's type signature is not `never`. The
+        // explicit throw makes the unreachable path explicit and guarantees
+        // `source` is initialised below.
+        throw err;
       }
+
+      const isClient = this.environment?.name === "client";
 
       if (isBuild) {
         // Emit the binary as a hashed asset so it ends up in the output dir
@@ -108,36 +114,69 @@ export function wasmModulePlugin(): Plugin {
         // The default export must be a `WebAssembly.Module` to match the
         // shape that Workers' native `?module` import provides. We compile
         // the binary at module-evaluation time using `WebAssembly.compile`
-        // against bytes read from disk relative to the emitted asset.
+        // against bytes located via Rollup's `ROLLUP_FILE_URL_<ref>` token,
+        // which Rollup expands to an absolute `file://` / public-path URL
+        // string at chunk-emit time.
         //
-        // Reading via `new URL(..., import.meta.url)` works in Node.js
-        // (file:// URL) and in browser builds (the URL is rewritten by
-        // Vite/Rolldown to the public path of the emitted asset). For the
-        // browser build we fall back to `fetch` since `node:fs` is not
-        // available — see the runtime branch below.
+        // We emit two different shims so the client bundle never references
+        // `node:*` modules (Vite externalises those to empty stubs in the
+        // browser environment — see plugins/async-hooks-stub.ts) and the
+        // server shim never carries dead browser fetch code.
+        if (isClient) {
+          return [
+            `const __vinext_wasm_url = import.meta.ROLLUP_FILE_URL_${referenceId};`,
+            `async function __vinext_load_wasm_module() {`,
+            `  const res = await fetch(__vinext_wasm_url);`,
+            `  return typeof WebAssembly.compileStreaming === "function"`,
+            `    ? WebAssembly.compileStreaming(res)`,
+            `    : WebAssembly.compile(await res.arrayBuffer());`,
+            `}`,
+            `export default await __vinext_load_wasm_module();`,
+          ].join("\n");
+        }
+
+        // Server (rsc / ssr / non-Workers Node). Use dynamic `import("node:*")`
+        // so the static dependency graph stays clean of `node:` imports — that
+        // matters when this module is pulled into a chunk that may be analysed
+        // by the bundler for client-safety, and it avoids the empty-stub
+        // SyntaxError class of bug (see plugins/async-hooks-stub.ts).
         return [
-          `import { createRequire as __vinext_createRequire } from "node:module";`,
-          `const __vinext_wasm_url = new URL(import.meta.ROLLUP_FILE_URL_${referenceId}, import.meta.url);`,
+          `const __vinext_wasm_url = import.meta.ROLLUP_FILE_URL_${referenceId};`,
           `async function __vinext_load_wasm_module() {`,
-          `  if (typeof process !== "undefined" && process.versions && process.versions.node) {`,
-          `    const require = __vinext_createRequire(import.meta.url);`,
-          `    const { readFile } = require("node:fs/promises");`,
-          `    const { fileURLToPath } = require("node:url");`,
-          `    const bytes = await readFile(fileURLToPath(__vinext_wasm_url));`,
-          `    return WebAssembly.compile(bytes);`,
-          `  }`,
-          `  const res = await fetch(__vinext_wasm_url);`,
-          `  return WebAssembly.compileStreaming ? WebAssembly.compileStreaming(res) : WebAssembly.compile(await res.arrayBuffer());`,
+          `  const [{ readFile }, { fileURLToPath }] = await Promise.all([`,
+          `    import("node:fs/promises"),`,
+          `    import("node:url"),`,
+          `  ]);`,
+          `  const bytes = await readFile(fileURLToPath(new URL(__vinext_wasm_url)));`,
+          `  return WebAssembly.compile(bytes);`,
           `}`,
           `export default await __vinext_load_wasm_module();`,
         ].join("\n");
       }
 
       // Dev server: skip asset emission and compile from the source file
-      // directly so HMR keeps working without an asset pipeline.
+      // directly so HMR keeps working without an asset pipeline. The dev
+      // server's client requests are also handled here — in that case we
+      // ship a fetch-based shim that re-requests the wasm over the Vite
+      // dev server, because `node:fs` is not available in the browser.
+      if (isClient) {
+        // In dev, Vite serves source files at their original URL. Build a
+        // browser-safe fetch path by stripping the project root prefix; this
+        // keeps parity with how Vite serves other binary assets in dev.
+        const fetchUrl = JSON.stringify(filePath);
+        return [
+          `async function __vinext_load_wasm_module() {`,
+          `  const res = await fetch(${fetchUrl});`,
+          `  return typeof WebAssembly.compileStreaming === "function"`,
+          `    ? WebAssembly.compileStreaming(res)`,
+          `    : WebAssembly.compile(await res.arrayBuffer());`,
+          `}`,
+          `export default await __vinext_load_wasm_module();`,
+        ].join("\n");
+      }
       const absPath = JSON.stringify(filePath);
       return [
-        `import { readFile as __vinext_readFile } from "node:fs/promises";`,
+        `const { readFile: __vinext_readFile } = await import("node:fs/promises");`,
         `export default await WebAssembly.compile(await __vinext_readFile(${absPath}));`,
       ].join("\n");
     },

--- a/packages/vinext/src/plugins/wasm-module.ts
+++ b/packages/vinext/src/plugins/wasm-module.ts
@@ -153,7 +153,7 @@ export function wasmModulePlugin(): Plugin {
           `    import("node:fs/promises"),`,
           `    import("node:url"),`,
           `  ]);`,
-          `  const bytes = await readFile(fileURLToPath(new URL(__vinext_wasm_url)));`,
+          `  const bytes = await readFile(fileURLToPath(__vinext_wasm_url));`,
           `  return WebAssembly.compile(bytes);`,
           `}`,
           `export default await __vinext_load_wasm_module();`,

--- a/packages/vinext/src/plugins/wasm-module.ts
+++ b/packages/vinext/src/plugins/wasm-module.ts
@@ -123,13 +123,19 @@ export function wasmModulePlugin(): Plugin {
         // browser environment — see plugins/async-hooks-stub.ts) and the
         // server shim never carries dead browser fetch code.
         if (isClient) {
+          // `compileStreaming` requires the response to advertise
+          // `Content-Type: application/wasm`. Not all static hosts/CDNs set
+          // that header, so we fall back to buffering + `compile` if the
+          // streaming path rejects. See:
+          // https://developer.mozilla.org/en-US/docs/WebAssembly/JavaScript_interface/compileStreaming
           return [
             `const __vinext_wasm_url = import.meta.ROLLUP_FILE_URL_${referenceId};`,
             `async function __vinext_load_wasm_module() {`,
             `  const res = await fetch(__vinext_wasm_url);`,
-            `  return typeof WebAssembly.compileStreaming === "function"`,
-            `    ? WebAssembly.compileStreaming(res)`,
-            `    : WebAssembly.compile(await res.arrayBuffer());`,
+            `  if (typeof WebAssembly.compileStreaming === "function") {`,
+            `    try { return await WebAssembly.compileStreaming(res.clone()); } catch {}`,
+            `  }`,
+            `  return WebAssembly.compile(await res.arrayBuffer());`,
             `}`,
             `export default await __vinext_load_wasm_module();`,
           ].join("\n");
@@ -160,16 +166,21 @@ export function wasmModulePlugin(): Plugin {
       // ship a fetch-based shim that re-requests the wasm over the Vite
       // dev server, because `node:fs` is not available in the browser.
       if (isClient) {
-        // In dev, Vite serves source files at their original URL. Build a
-        // browser-safe fetch path by stripping the project root prefix; this
-        // keeps parity with how Vite serves other binary assets in dev.
-        const fetchUrl = JSON.stringify(filePath);
+        // In dev, Vite's middleware serves arbitrary on-disk files via the
+        // `/@fs/<absolute-path>` URL prefix (the same mechanism it uses to
+        // serve `node_modules` and out-of-root sources). This is the safe,
+        // documented way to dereference an absolute path from the browser
+        // during dev — passing the raw absolute path to `fetch()` would
+        // resolve against the page origin and 404.
+        // https://vitejs.dev/guide/api-javascript.html#vite-server
+        const fetchUrl = JSON.stringify(`/@fs${filePath}`);
         return [
           `async function __vinext_load_wasm_module() {`,
           `  const res = await fetch(${fetchUrl});`,
-          `  return typeof WebAssembly.compileStreaming === "function"`,
-          `    ? WebAssembly.compileStreaming(res)`,
-          `    : WebAssembly.compile(await res.arrayBuffer());`,
+          `  if (typeof WebAssembly.compileStreaming === "function") {`,
+          `    try { return await WebAssembly.compileStreaming(res.clone()); } catch {}`,
+          `  }`,
+          `  return WebAssembly.compile(await res.arrayBuffer());`,
           `}`,
           `export default await __vinext_load_wasm_module();`,
         ].join("\n");

--- a/tests/wasm-module-import.test.ts
+++ b/tests/wasm-module-import.test.ts
@@ -164,6 +164,11 @@ describe("vinext:wasm-module plugin", () => {
     expect(code).toContain("import.meta.ROLLUP_FILE_URL_ref-client");
     expect(code).toContain("fetch(");
     expect(code).toContain("compileStreaming");
+    // compileStreaming must be wrapped in try/catch with a buffered-compile
+    // fallback so missing `Content-Type: application/wasm` headers can't
+    // brick wasm loading on hosts/CDNs that strip the type.
+    expect(code).toMatch(/try\s*\{[^}]*compileStreaming/);
+    expect(code).toContain("WebAssembly.compile(await res.arrayBuffer())");
 
     // Crucially: no `node:*` references in the client bundle. Vite would
     // externalise those to empty stubs and a named import would throw.
@@ -200,7 +205,7 @@ describe("vinext:wasm-module plugin", () => {
     expect(code).toContain("export default await");
   });
 
-  it("dev mode: client environment falls back to fetch (no node:fs)", async () => {
+  it("dev mode: client environment fetches via Vite's /@fs/ prefix (no node:fs)", async () => {
     const plugin = getWasmModulePlugin("serve");
     const load = unwrapHook(plugin.load);
 
@@ -215,8 +220,14 @@ describe("vinext:wasm-module plugin", () => {
     };
 
     const code = (await load.call(ctx, `${wasmPath}?module`)) as string;
+    // Browser-safe absolute-path access goes through Vite's `/@fs/` middleware,
+    // not a bare absolute filesystem path (which would resolve against the
+    // page origin and 404).
+    expect(code).toContain(JSON.stringify(`/@fs${wasmPath}`));
     expect(code).toContain("fetch(");
     expect(code).not.toContain("node:fs");
+    // Same try/catch fallback as the build client shim.
+    expect(code).toMatch(/try\s*\{[^}]*compileStreaming/);
   });
 
   it("calls this.error when the underlying wasm file is missing", async () => {

--- a/tests/wasm-module-import.test.ts
+++ b/tests/wasm-module-import.test.ts
@@ -103,12 +103,14 @@ describe("vinext:wasm-module plugin", () => {
     expect(filter.id.test("./add.wasm?module&v=1")).toBe(true);
   });
 
-  it("emits the wasm as a build asset and produces a WebAssembly.Module loader", async () => {
+  it("emits a server build shim that uses dynamic node: imports (no static node: deps)", async () => {
     const plugin = getWasmModulePlugin("build");
     const load = unwrapHook(plugin.load);
 
     let emitted: { type: string; name?: string; source?: unknown } | null = null;
     const ctx = {
+      // Simulate the rsc/ssr environment — non-client.
+      environment: { name: "ssr" as const },
       emitFile(spec: { type: string; name?: string; source?: unknown }) {
         emitted = spec;
         return "ref-id-1";
@@ -128,25 +130,56 @@ describe("vinext:wasm-module plugin", () => {
     expect(Buffer.isBuffer(emitted!.source)).toBe(true);
     expect((emitted!.source as Buffer).equals(MINIMAL_WASM)).toBe(true);
 
-    // The generated JS must use the Rollup file-url placeholder so the bundler
-    // rewrites it to the final asset path, and the default export must be a
-    // `WebAssembly.Module` (matching Workers' native `?module` shape).
+    // The Rollup file-url placeholder is used directly as a string (no double
+    // `new URL(..., import.meta.url)` wrap) — Rollup expands it to an absolute
+    // URL string at chunk-emit time.
     expect(code).toContain("import.meta.ROLLUP_FILE_URL_ref-id-1");
     expect(code).toContain("WebAssembly.compile");
     expect(code).toContain("export default await");
-    // Node fallback: read from disk via node:fs/promises + fileURLToPath.
-    expect(code).toContain("node:fs/promises");
+
+    // Server shim: dynamic node: imports, no static `import ... from "node:*"`.
+    expect(code).toContain('import("node:fs/promises")');
+    expect(code).toContain('import("node:url")');
     expect(code).toContain("fileURLToPath");
-    // Browser fallback: fetch + compileStreaming.
-    expect(code).toContain("compileStreaming");
+    expect(code).not.toMatch(/^import\s+[^;]*from\s+["']node:/m);
   });
 
-  it("compiles directly from the source path in dev (no asset emission)", async () => {
+  it("emits a client build shim that uses fetch and never touches node:* modules", async () => {
+    const plugin = getWasmModulePlugin("build");
+    const load = unwrapHook(plugin.load);
+
+    const ctx = {
+      environment: { name: "client" as const },
+      emitFile() {
+        return "ref-client";
+      },
+      error(message: string) {
+        throw new Error(message);
+      },
+    };
+
+    const code = (await load.call(ctx, `${wasmPath}?module`)) as string;
+
+    // Client shim uses the Rollup file-url placeholder, fetch + compileStreaming.
+    expect(code).toContain("import.meta.ROLLUP_FILE_URL_ref-client");
+    expect(code).toContain("fetch(");
+    expect(code).toContain("compileStreaming");
+
+    // Crucially: no `node:*` references in the client bundle. Vite would
+    // externalise those to empty stubs and a named import would throw.
+    expect(code).not.toContain("node:fs");
+    expect(code).not.toContain("node:url");
+    expect(code).not.toContain("node:module");
+    expect(code).not.toContain("createRequire");
+  });
+
+  it("compiles directly from the source path in dev (no asset emission, server)", async () => {
     const plugin = getWasmModulePlugin("serve");
     const load = unwrapHook(plugin.load);
 
     let emitCalled = false;
     const ctx = {
+      environment: { name: "ssr" as const },
       emitFile() {
         emitCalled = true;
         return "should-not-be-used";
@@ -159,10 +192,31 @@ describe("vinext:wasm-module plugin", () => {
     const code = (await load.call(ctx, `${wasmPath}?module`)) as string;
 
     expect(emitCalled).toBe(false);
-    // Dev shim reads the source file directly from its absolute path.
+    // Dev shim reads the source file directly from its absolute path via a
+    // dynamic node:fs/promises import.
     expect(code).toContain(JSON.stringify(wasmPath));
+    expect(code).toContain('import("node:fs/promises")');
     expect(code).toContain("WebAssembly.compile");
     expect(code).toContain("export default await");
+  });
+
+  it("dev mode: client environment falls back to fetch (no node:fs)", async () => {
+    const plugin = getWasmModulePlugin("serve");
+    const load = unwrapHook(plugin.load);
+
+    const ctx = {
+      environment: { name: "client" as const },
+      emitFile() {
+        throw new Error("emitFile should not be called in dev");
+      },
+      error(message: string) {
+        throw new Error(message);
+      },
+    };
+
+    const code = (await load.call(ctx, `${wasmPath}?module`)) as string;
+    expect(code).toContain("fetch(");
+    expect(code).not.toContain("node:fs");
   });
 
   it("calls this.error when the underlying wasm file is missing", async () => {
@@ -171,6 +225,7 @@ describe("vinext:wasm-module plugin", () => {
 
     let errored: string | null = null;
     const ctx = {
+      environment: { name: "ssr" as const },
       emitFile() {
         return "ref";
       },
@@ -184,6 +239,33 @@ describe("vinext:wasm-module plugin", () => {
     const missing = path.join(tmpDir, "does-not-exist.wasm?module");
     await expect(load.call(ctx, missing)).rejects.toThrow(/Could not read WASM file/);
     expect(errored).toMatch(/does-not-exist\.wasm/);
+  });
+
+  it("guards against undefined source: explicit throw after this.error", async () => {
+    // If a downstream test runner or Rollup variant returns from this.error
+    // instead of throwing, our explicit `throw err` after this.error must still
+    // halt execution so we never call `emitFile({ source: undefined })`.
+    const plugin = getWasmModulePlugin("build");
+    const load = unwrapHook(plugin.load);
+
+    let emitCalled = false;
+    const ctx = {
+      environment: { name: "ssr" as const },
+      emitFile() {
+        emitCalled = true;
+        return "ref";
+      },
+      // Deliberately non-throwing this.error to exercise the explicit throw.
+      error(_message: string) {
+        // no-op
+      },
+    };
+
+    const missing = path.join(tmpDir, "another-missing.wasm?module");
+    await expect(load.call(ctx, missing)).rejects.toBeDefined();
+    // emitFile must NOT have been called — we must not silently emit a
+    // zero-byte asset.
+    expect(emitCalled).toBe(false);
   });
 
   it("returns null for ids without the ?module query so it doesn't steal other wasm imports", async () => {

--- a/tests/wasm-module-import.test.ts
+++ b/tests/wasm-module-import.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Tests for the `vinext:wasm-module` plugin.
+ *
+ * Regression test for cloudflare/vinext#1351 — `import wasm from "./foo.wasm?module"`
+ * fails to build because Rolldown cannot load `.wasm?module` natively. The plugin
+ * intercepts those imports for non-Workers environments and emits a JS shim that
+ * compiles the binary via `WebAssembly.compile`, mirroring the Webpack
+ * `asyncWebAssembly` behaviour Next.js uses (`.nextjs-ref/test/e2e/edge-can-use-wasm-files/`).
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vite-plus/test";
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import vinext from "../packages/vinext/src/index.js";
+import type { Plugin } from "vite-plus";
+
+// ── Helpers ───────────────────────────────────────────────────
+
+function unwrapHook(hook: unknown): (...args: unknown[]) => unknown {
+  // Vite hooks may be either a plain function or `{ filter, handler }`.
+  if (typeof hook === "function") return hook as (...args: unknown[]) => unknown;
+  // oxlint-disable-next-line typescript/no-explicit-any
+  return (hook as any)?.handler;
+}
+
+/** Pull the wasm-module plugin out of the full vinext plugin array. */
+function getWasmModulePlugin(command: "build" | "serve" = "build"): Plugin {
+  const plugins = vinext() as Plugin[];
+  const plugin = plugins.find((p) => p && (p as Plugin).name === "vinext:wasm-module");
+  if (!plugin) throw new Error("vinext:wasm-module plugin not found");
+  const configResolved = unwrapHook(plugin.configResolved);
+  configResolved?.call(plugin, { command });
+  return plugin;
+}
+
+// A minimal valid WebAssembly module: the 8-byte magic-number + version header
+// is on its own a complete, parseable module (no sections). It is enough to
+// exercise `emitFile` / load-hook behaviour without committing a real binary.
+const MINIMAL_WASM = Buffer.from([0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00]);
+
+let tmpDir: string;
+let wasmPath: string;
+
+beforeAll(async () => {
+  tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "vinext-wasm-module-"));
+  wasmPath = path.join(tmpDir, "add.wasm");
+  await fsp.writeFile(wasmPath, MINIMAL_WASM);
+});
+
+afterAll(async () => {
+  await fsp.rm(tmpDir, { recursive: true, force: true });
+});
+
+// ── Tests ─────────────────────────────────────────────────────
+
+describe("vinext:wasm-module plugin", () => {
+  it("is present in the vinext plugin array", () => {
+    const plugin = getWasmModulePlugin();
+    expect(plugin.name).toBe("vinext:wasm-module");
+    // `post` so the Cloudflare plugin's `enforce: "pre"` hook handles Workers
+    // builds first and externalises the import.
+    expect(plugin.enforce).toBe("post");
+  });
+
+  it("matches `.wasm?module` imports in resolveId and rewrites to an absolute path", async () => {
+    const plugin = getWasmModulePlugin();
+    const resolveId = unwrapHook(plugin.resolveId);
+
+    // Simulate `import wasm from "./add.wasm?module"` inside <tmpDir>/src/add.js
+    const importer = path.join(tmpDir, "src", "add.js");
+    await fsp.mkdir(path.dirname(importer), { recursive: true });
+    // Place add.wasm where the relative resolve will find it.
+    const srcWasm = path.join(tmpDir, "src", "add.wasm");
+    await fsp.writeFile(srcWasm, MINIMAL_WASM);
+
+    // Mock the `this.resolve` Vite/Rollup context method.
+    const ctx = {
+      // oxlint-disable-next-line typescript/no-explicit-any
+      async resolve(source: string, _importer: string | undefined, _opts: unknown) {
+        return { id: path.resolve(path.dirname(importer), source), external: false };
+      },
+    };
+
+    const result = (await resolveId.call(ctx, "./add.wasm?module", importer)) as
+      | string
+      | null
+      | undefined;
+
+    expect(result).toBe(`${srcWasm}?module`);
+  });
+
+  it("scopes its resolveId filter to .wasm?module only (won't steal ?init or plain .wasm)", () => {
+    const plugin = getWasmModulePlugin();
+
+    // The hook has a filter so Vite only calls the handler for `.wasm?module`.
+    // We assert the filter regex directly. `*.wasm?init` is a Vite/Cloudflare
+    // convention handled elsewhere — we must not steal it.
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const filter = (plugin.resolveId as any).filter as { id: RegExp };
+    expect(filter.id.test("./add.wasm?init")).toBe(false);
+    expect(filter.id.test("./add.wasm")).toBe(false);
+    expect(filter.id.test("./add.wasm?module")).toBe(true);
+    expect(filter.id.test("./add.wasm?module&v=1")).toBe(true);
+  });
+
+  it("emits the wasm as a build asset and produces a WebAssembly.Module loader", async () => {
+    const plugin = getWasmModulePlugin("build");
+    const load = unwrapHook(plugin.load);
+
+    let emitted: { type: string; name?: string; source?: unknown } | null = null;
+    const ctx = {
+      emitFile(spec: { type: string; name?: string; source?: unknown }) {
+        emitted = spec;
+        return "ref-id-1";
+      },
+      error(message: string) {
+        throw new Error(message);
+      },
+    };
+
+    const code = (await load.call(ctx, `${wasmPath}?module`)) as string;
+
+    // The asset must be emitted with the original filename so the output dir
+    // contains a recognisable `add-<hash>.wasm` next to the bundle.
+    expect(emitted).not.toBeNull();
+    expect(emitted!.type).toBe("asset");
+    expect(emitted!.name).toBe("add.wasm");
+    expect(Buffer.isBuffer(emitted!.source)).toBe(true);
+    expect((emitted!.source as Buffer).equals(MINIMAL_WASM)).toBe(true);
+
+    // The generated JS must use the Rollup file-url placeholder so the bundler
+    // rewrites it to the final asset path, and the default export must be a
+    // `WebAssembly.Module` (matching Workers' native `?module` shape).
+    expect(code).toContain("import.meta.ROLLUP_FILE_URL_ref-id-1");
+    expect(code).toContain("WebAssembly.compile");
+    expect(code).toContain("export default await");
+    // Node fallback: read from disk via node:fs/promises + fileURLToPath.
+    expect(code).toContain("node:fs/promises");
+    expect(code).toContain("fileURLToPath");
+    // Browser fallback: fetch + compileStreaming.
+    expect(code).toContain("compileStreaming");
+  });
+
+  it("compiles directly from the source path in dev (no asset emission)", async () => {
+    const plugin = getWasmModulePlugin("serve");
+    const load = unwrapHook(plugin.load);
+
+    let emitCalled = false;
+    const ctx = {
+      emitFile() {
+        emitCalled = true;
+        return "should-not-be-used";
+      },
+      error(message: string) {
+        throw new Error(message);
+      },
+    };
+
+    const code = (await load.call(ctx, `${wasmPath}?module`)) as string;
+
+    expect(emitCalled).toBe(false);
+    // Dev shim reads the source file directly from its absolute path.
+    expect(code).toContain(JSON.stringify(wasmPath));
+    expect(code).toContain("WebAssembly.compile");
+    expect(code).toContain("export default await");
+  });
+
+  it("calls this.error when the underlying wasm file is missing", async () => {
+    const plugin = getWasmModulePlugin("build");
+    const load = unwrapHook(plugin.load);
+
+    let errored: string | null = null;
+    const ctx = {
+      emitFile() {
+        return "ref";
+      },
+      error(message: string) {
+        errored = message;
+        // Match Rollup's behaviour: this.error halts the plugin.
+        throw new Error(message);
+      },
+    };
+
+    const missing = path.join(tmpDir, "does-not-exist.wasm?module");
+    await expect(load.call(ctx, missing)).rejects.toThrow(/Could not read WASM file/);
+    expect(errored).toMatch(/does-not-exist\.wasm/);
+  });
+
+  it("returns null for ids without the ?module query so it doesn't steal other wasm imports", async () => {
+    const plugin = getWasmModulePlugin("build");
+    const load = unwrapHook(plugin.load);
+
+    const result = await load.call({}, `${wasmPath}?init`);
+    expect(result).toBeNull();
+  });
+});
+
+// ── Integration with the full plugin pipeline ─────────────────
+
+describe("vinext:wasm-module plugin (pipeline integration)", () => {
+  it("runs after enforce:'pre' plugins so the Cloudflare plugin handles Workers first", () => {
+    const plugins = vinext() as Plugin[];
+
+    const wasmIdx = plugins.findIndex((p) => p && p.name === "vinext:wasm-module");
+    expect(wasmIdx).toBeGreaterThanOrEqual(0);
+
+    // Other plugins should still load — sanity check that wiring didn't
+    // accidentally short-circuit the array.
+    const ogInlineIdx = plugins.findIndex((p) => p && p.name === "vinext:og-inline-fetch-assets");
+    expect(ogInlineIdx).toBeGreaterThanOrEqual(0);
+  });
+});


### PR DESCRIPTION
## Summary

`import wasm from "./foo.wasm?module"` — the Cloudflare Workers convention used by Next.js's [`test/e2e/edge-can-use-wasm-files`](https://github.com/vercel/next.js/blob/canary/test/e2e/edge-can-use-wasm-files/index.test.ts) suite — currently fails to build under vinext with:

```
[UNLOADABLE_DEPENDENCY] Could not load src/add.wasm?module
```

Rolldown doesn't know about the `?module` query, and `@cloudflare/vite-plugin` only handles it for environments it owns (i.e. Workers via `ctx.getWorkerConfig(environment.name)`). vinext's RSC/SSR Node and client environments fall through.

This PR adds a small `vinext:wasm-module` Vite plugin that:

- Intercepts `*.wasm?module` via `resolveId` (`enforce: "post"`) so the Cloudflare plugin's `enforce: "pre"` hook still handles Workers builds first.
- Reads the binary and `this.emitFile`'s it as a hashed Rollup asset.
- Returns a JS shim whose `export default` is a pre-compiled `WebAssembly.Module`, matching the shape Workers' native `?module` import provides. The shim has both a Node branch (`node:fs/promises` + `fileURLToPath`) and a browser branch (`fetch` + `WebAssembly.compileStreaming`).
- In dev (`vite serve`) skips asset emission and compiles directly from the source path for fast HMR.

Wired into `packages/vinext/src/index.ts` immediately before the existing `og-inline-fetch-assets` plugin, so it sees imports before the @vercel/og static-import patches run.

## Test plan

- [x] `pnpm test tests/wasm-module-import.test.ts` — 8 new unit tests covering filter scope, resolveId rewrite, build-mode emit + shim shape, dev-mode shim, missing-file error, and pipeline integration.
- [x] Confirmed the new tests fail without the plugin (sanity check the plugin actually does the work).
- [x] `pnpm run check` — lint, format, type-check all green.
- [ ] CI Vitest + Playwright E2E green.

## Notes

- Workers builds are unchanged — the Cloudflare Vite plugin keeps its native handling (sees `.wasm?module` at `enforce: "pre"` and externalises it into a `__CLOUDFLARE_MODULE__CompiledWasm__…` reference that becomes a wasm-module binding at deploy time).
- The Node shim uses `createRequire` + `node:fs/promises` so the same chunk can run under workerd (where the Workers path was taken) and Node without a static `node:` import that would break the bundler's externalisation for the client environment.

## References

- Next.js test suite for the pattern: `.nextjs-ref/test/e2e/edge-can-use-wasm-files/`
- Cloudflare's `wasm_modules` binding: <https://developers.cloudflare.com/workers/runtime-apis/bindings/webassembly/>
- `@cloudflare/vite-plugin` module-rule handling: `vite-plugin/dist/index.mjs` line 19497 (`/\.wasm(\?module)?$/`)

Closes #1351