### PR TITLE
fix: await top-level await module imports

### DIFF
--- a/packages/vinext/src/shims/document.tsx
+++ b/packages/vinext/src/shims/document.tsx
@@ -50,6 +50,42 @@ export function NextScript() {
 }
 
 /**
+ * Loose stand-ins for Next.js's `DocumentContext` / `DocumentInitialProps`.
+ * The shim doesn't currently invoke `getInitialProps` on user `_document.tsx`
+ * files (separate gap), but the signatures here match Next.js's so subclasses
+ * that delegate via `await Document.getInitialProps(ctx)` typecheck against
+ * the same shape they'd see under real Next.js.
+ *
+ * @see https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/utils.ts
+ */
+export type DocumentContext = {
+  // The full `DocumentContext` includes `renderPage`, `defaultGetInitialProps`,
+  // and the inherited `NextPageContext` (`pathname`, `query`, `req`, `res`,
+  // `err`, `asPath`, ...). They're declared as optional here because vinext
+  // does not yet plumb them through; widening to optional avoids forcing user
+  // code to assert their presence.
+  renderPage?: (options?: {
+    enhanceApp?: (App: React.ComponentType<{ children?: React.ReactNode }>) => unknown;
+    enhanceComponent?: (Comp: React.ComponentType<unknown>) => unknown;
+  }) => { html: string; head?: ReadonlyArray<React.ReactElement> };
+  defaultGetInitialProps?: (
+    ctx: DocumentContext,
+    options?: { nonce?: string },
+  ) => Promise<DocumentInitialProps>;
+  pathname?: string;
+  query?: Record<string, string | string[] | undefined>;
+  asPath?: string;
+  // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+  err?: any;
+};
+
+export type DocumentInitialProps = {
+  html: string;
+  head?: ReadonlyArray<React.ReactElement>;
+  styles?: React.ReactElement[] | Iterable<React.ReactNode> | React.ReactElement;
+};
+
+/**
  * Default Document component — also the base class user `_document.tsx` files
  * `extend`. Must be a class (not a function) to match Next.js's `next/document`
  * default export so `class MyDocument extends Document` produces a constructible
@@ -61,18 +97,20 @@ export function NextScript() {
  * @see https://github.com/vercel/next.js/blob/canary/packages/next/src/pages/_document.tsx
  * Ported behavior: Next.js's default `Document` is a `class Document extends
  * React.Component`. Custom documents extend it and override `getInitialProps`
- * and `render`.
+ * and `render`. Generic default matches Next.js (`P = {}`).
  */
-export default class Document<P = unknown> extends React.Component<
-  P & { children?: React.ReactNode }
-> {
+// oxlint-disable-next-line @typescript-eslint/no-empty-object-type
+export default class Document<P = {}> extends React.Component<P & { children?: React.ReactNode }> {
   /**
    * `getInitialProps` is invoked by the SSR pipeline. The default implementation
-   * is a no-op: subclasses replace it. Returning an empty object keeps the
-   * runtime contract compatible with consumers that always call it.
+   * is a stub: vinext does not yet plumb the Pages Router `renderPage` /
+   * `defaultGetInitialProps` chain into the SSR entry, so subclasses that
+   * delegate via `await Document.getInitialProps(ctx)` receive an empty shell
+   * (`html: ""`). This matches the runtime contract user code expects without
+   * pretending the chain is wired up.
    */
-  static async getInitialProps(_ctx: unknown): Promise<Record<string, unknown>> {
-    return {};
+  static async getInitialProps(_ctx: DocumentContext): Promise<DocumentInitialProps> {
+    return { html: "" };
   }
 
   render(): React.ReactNode {

--- a/packages/vinext/src/shims/document.tsx
+++ b/packages/vinext/src/shims/document.tsx
@@ -50,16 +50,40 @@ export function NextScript() {
 }
 
 /**
- * Default Document component - used when no custom _document.tsx exists.
+ * Default Document component — also the base class user `_document.tsx` files
+ * `extend`. Must be a class (not a function) to match Next.js's `next/document`
+ * default export so `class MyDocument extends Document` produces a constructible
+ * class that React can instantiate during SSR. Returning a function here breaks
+ * any user `_document.tsx` that uses the class-based form because `extends`
+ * against a non-constructor produces a class that can only be called without
+ * `new`, which React refuses to do.
+ *
+ * @see https://github.com/vercel/next.js/blob/canary/packages/next/src/pages/_document.tsx
+ * Ported behavior: Next.js's default `Document` is a `class Document extends
+ * React.Component`. Custom documents extend it and override `getInitialProps`
+ * and `render`.
  */
-export default function Document() {
-  return (
-    <Html>
-      <Head />
-      <body>
-        <Main />
-        <NextScript />
-      </body>
-    </Html>
-  );
+export default class Document<P = unknown> extends React.Component<
+  P & { children?: React.ReactNode }
+> {
+  /**
+   * `getInitialProps` is invoked by the SSR pipeline. The default implementation
+   * is a no-op: subclasses replace it. Returning an empty object keeps the
+   * runtime contract compatible with consumers that always call it.
+   */
+  static async getInitialProps(_ctx: unknown): Promise<Record<string, unknown>> {
+    return {};
+  }
+
+  render(): React.ReactNode {
+    return (
+      <Html>
+        <Head />
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    );
+  }
 }

--- a/packages/vinext/src/shims/next-shims.d.ts
+++ b/packages/vinext/src/shims/next-shims.d.ts
@@ -55,11 +55,36 @@ declare module "next/head" {
 }
 
 declare module "next/document" {
-  import { ComponentType, ReactNode } from "react";
+  import { Component, ComponentType, ReactElement, ReactNode } from "react";
   export const Html: ComponentType<{ lang?: string; children?: ReactNode; [key: string]: unknown }>;
   export const Head: ComponentType<{ children?: ReactNode }>;
   export const Main: ComponentType;
   export const NextScript: ComponentType;
+  export type DocumentInitialProps = {
+    html: string;
+    head?: ReadonlyArray<ReactElement>;
+    styles?: ReactElement[] | Iterable<ReactNode> | ReactElement;
+  };
+  export type DocumentContext = {
+    renderPage?: (options?: {
+      enhanceApp?: (App: ComponentType<{ children?: ReactNode }>) => unknown;
+      enhanceComponent?: (Comp: ComponentType<unknown>) => unknown;
+    }) => { html: string; head?: ReadonlyArray<ReactElement> };
+    defaultGetInitialProps?: (
+      ctx: DocumentContext,
+      options?: { nonce?: string },
+    ) => Promise<DocumentInitialProps>;
+    pathname?: string;
+    query?: Record<string, string | string[] | undefined>;
+    asPath?: string;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    err?: any;
+  };
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+  export default class Document<P = {}> extends Component<P & { children?: ReactNode }> {
+    static getInitialProps(ctx: DocumentContext): Promise<DocumentInitialProps>;
+    render(): ReactNode;
+  }
 }
 
 declare module "next/dynamic" {

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -123,6 +123,17 @@ describe("App Router integration", () => {
     expect(html).toContain("This is the about page.");
   });
 
+  // Ported from Next.js: test/e2e/async-modules/index.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/async-modules/index.test.ts
+  it("renders pages that use top-level await (async modules)", async () => {
+    const res = await fetch(`${baseUrl}/async-modules-test`);
+    expect(res.status).toBe(200);
+
+    const html = await res.text();
+    expect(html).toContain('<div id="app-value">hello</div>');
+    expect(html).toContain('<div id="page-value">42</div>');
+  });
+
   // Ported from Next.js: test/e2e/prerender.test.ts
   // https://github.com/vercel/next.js/blob/canary/test/e2e/prerender.test.ts
   it("returns Method Not Allowed for non-action mutation requests to App Router pages", async () => {

--- a/tests/document.test.ts
+++ b/tests/document.test.ts
@@ -90,3 +90,48 @@ describe("Html", () => {
     expect(html).toMatch(/^<html/);
   });
 });
+
+// Regression test for the contract motivating PR #1381 (issue #1361):
+// user `pages/_document.tsx` files commonly use the class form
+// `class MyDocument extends Document`. If the shim's default export is a
+// function, the extends chain produces a class React refuses to construct
+// (`Class constructor cannot be invoked without 'new'`), which 500s SSR and
+// surfaces as empty pages in deploy-suite e2e tests.
+//
+// Ported from Next.js: test/e2e/async-modules/pages/_document.jsx
+// https://github.com/vercel/next.js/blob/canary/test/e2e/async-modules/pages/_document.jsx
+describe("Document base class", () => {
+  it("can be extended by a user class that React can construct", () => {
+    class MyDocument extends Document {
+      render() {
+        return React.createElement(
+          Html,
+          { lang: "ja" },
+          React.createElement(Head),
+          React.createElement(
+            "body",
+            null,
+            React.createElement("div", { id: "doc-marker" }, "ok"),
+            React.createElement(Main),
+            React.createElement(NextScript),
+          ),
+        );
+      }
+    }
+    const html = render(React.createElement(MyDocument));
+    expect(html).toMatch(/<html[^>]*lang="ja"/);
+    expect(html).toContain('id="doc-marker"');
+    expect(html).toContain("__NEXT_MAIN__");
+    expect(html).toContain("__NEXT_SCRIPTS__");
+  });
+
+  it("exposes a static getInitialProps that resolves to a DocumentInitialProps-shaped value", async () => {
+    // The runtime contract: subclasses commonly delegate via
+    // `await Document.getInitialProps(ctx)` and destructure `html` from the
+    // result. The stub returns an empty html shell — the test pins the shape
+    // so wiring up the full Pages Router renderPage flow later doesn't
+    // silently regress consumers that destructure `html`.
+    const result = await Document.getInitialProps({});
+    expect(typeof result.html).toBe("string");
+  });
+});

--- a/tests/fixtures/app-basic/app/async-modules-test/page.tsx
+++ b/tests/fixtures/app-basic/app/async-modules-test/page.tsx
@@ -1,0 +1,16 @@
+// Top-level await (async module) test fixture.
+// Verifies that pages using TLA render their resolved data instead of empty.
+// Ported from Next.js: test/e2e/async-modules/pages/index.jsx
+// https://github.com/vercel/next.js/blob/canary/test/e2e/async-modules/pages/index.jsx
+
+const value = await Promise.resolve(42);
+const text = await Promise.resolve("hello");
+
+export default function AsyncModulesTestPage() {
+  return (
+    <main>
+      <div id="app-value">{text}</div>
+      <div id="page-value">{value}</div>
+    </main>
+  );
+}

--- a/tests/fixtures/app-basic/app/async-modules-test/page.tsx
+++ b/tests/fixtures/app-basic/app/async-modules-test/page.tsx
@@ -1,6 +1,8 @@
-// Top-level await (async module) test fixture.
+// Top-level await (async module) test fixture for the App Router.
 // Verifies that pages using TLA render their resolved data instead of empty.
-// Ported from Next.js: test/e2e/async-modules/pages/index.jsx
+// Based on Next.js: test/e2e/async-modules/pages/index.jsx (adapted for App
+// Router — the upstream async-modules suite is Pages-Router-only; this is the
+// same TLA pattern wrapped in an App Router server component).
 // https://github.com/vercel/next.js/blob/canary/test/e2e/async-modules/pages/index.jsx
 
 const value = await Promise.resolve(42);

--- a/tests/fixtures/pages-basic/pages/async-modules-test.tsx
+++ b/tests/fixtures/pages-basic/pages/async-modules-test.tsx
@@ -1,0 +1,16 @@
+// Top-level await (async module) test fixture.
+// Verifies that pages using TLA render their resolved data instead of empty.
+// Ported from Next.js: test/e2e/async-modules/pages/index.jsx
+// https://github.com/vercel/next.js/blob/canary/test/e2e/async-modules/pages/index.jsx
+
+const value = await Promise.resolve(42);
+const text = await Promise.resolve("hello");
+
+export default function AsyncModulesTestPage() {
+  return (
+    <main>
+      <div id="app-value">{text}</div>
+      <div id="page-value">{value}</div>
+    </main>
+  );
+}

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -264,6 +264,17 @@ describe("Pages Router integration", () => {
     expect(html).toContain("This is the about page.");
   });
 
+  // Ported from Next.js: test/e2e/async-modules/index.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/async-modules/index.test.ts
+  it("renders pages that use top-level await (async modules)", async () => {
+    const res = await fetch(`${baseUrl}/async-modules-test`);
+    expect(res.status).toBe(200);
+
+    const html = await res.text();
+    expect(html).toContain('<div id="app-value">hello</div>');
+    expect(html).toContain('<div id="page-value">42</div>');
+  });
+
   it("adds middleware CSP nonces to Pages Router next data", async () => {
     const res = await fetch(`${baseUrl}/dynamic-page?mw-csp-nonce=pages-response`);
     expect(res.status).toBe(200);
@@ -2506,6 +2517,15 @@ export default function CounterPage() {
       // Test: 404 for unknown route
       const notFoundRes = await fetch(`${prodUrl}/nonexistent`);
       expect(notFoundRes.status).toBe(404);
+
+      // Test: page using top-level await (async module).
+      // Ported from Next.js: test/e2e/async-modules/index.test.ts
+      // https://github.com/vercel/next.js/blob/canary/test/e2e/async-modules/index.test.ts
+      const asyncModRes = await fetch(`${prodUrl}/async-modules-test`);
+      expect(asyncModRes.status).toBe(200);
+      const asyncModHtml = await asyncModRes.text();
+      expect(asyncModHtml).toContain('<div id="app-value">hello</div>');
+      expect(asyncModHtml).toContain('<div id="page-value">42</div>');
     } finally {
       httpServer.close();
     }
@@ -3878,6 +3898,174 @@ export function middleware(request) {
       expect(await res.text()).toBe("");
     });
   }
+});
+
+// Ported from Next.js: test/e2e/async-modules/index.test.ts
+// https://github.com/vercel/next.js/blob/canary/test/e2e/async-modules/index.test.ts
+//
+// Verifies that page modules using top-level await (async modules) render
+// their resolved data, not empty content. This covers the Pages Router
+// production build path where `_app.tsx` and the page module each contain
+// `await` at the module top level. Vite/Rolldown must propagate TLA through
+// the generated SSR entry's static imports so the entry awaits these modules
+// before reading their default exports.
+describe("Pages Router top-level await (async modules) in production", () => {
+  let tmpRoot: string;
+  let outDir: string;
+  let prodServer: import("node:http").Server;
+  let prodUrl: string;
+
+  beforeAll(async () => {
+    tmpRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "vinext-pages-async-modules-"));
+    outDir = path.join(tmpRoot, "dist");
+    await fsp.symlink(
+      path.resolve(import.meta.dirname, "../node_modules"),
+      path.join(tmpRoot, "node_modules"),
+      "junction",
+    );
+    await fsp.writeFile(path.join(tmpRoot, "package.json"), JSON.stringify({ type: "module" }));
+    await fsp.mkdir(path.join(tmpRoot, "pages", "api"), { recursive: true });
+
+    await fsp.writeFile(
+      path.join(tmpRoot, "pages", "_app.tsx"),
+      `const appValue = await Promise.resolve("hello");
+export default function MyApp({ Component, pageProps }: any) {
+  return <Component {...pageProps} appValue={appValue} />;
+}
+`,
+    );
+
+    await fsp.writeFile(
+      path.join(tmpRoot, "pages", "index.tsx"),
+      `const value = await Promise.resolve(42);
+export default function Index({ appValue }: any) {
+  return (
+    <main>
+      <div id="app-value">{appValue}</div>
+      <div id="page-value">{value}</div>
+    </main>
+  );
+}
+`,
+    );
+
+    await fsp.writeFile(
+      path.join(tmpRoot, "pages", "gssp.tsx"),
+      `const gsspValue = await Promise.resolve(42);
+export async function getServerSideProps() {
+  return { props: { gsspValue } };
+}
+export default function Page({ gsspValue }: any) {
+  return <div id="gssp-value">{gsspValue}</div>;
+}
+`,
+    );
+
+    await fsp.writeFile(
+      path.join(tmpRoot, "pages", "gsp.tsx"),
+      `const gspValue = await Promise.resolve(42);
+export async function getStaticProps() {
+  return { props: { gspValue } };
+}
+export default function Page({ gspValue }: any) {
+  return <div id="gsp-value">{gspValue}</div>;
+}
+`,
+    );
+
+    await fsp.writeFile(
+      path.join(tmpRoot, "pages", "api", "hello.ts"),
+      `const value = await Promise.resolve(42);
+export default function handler(_req: any, res: any) {
+  res.status(200).json({ value });
+}
+`,
+    );
+
+    // Class-based Document. Mirrors the original Next.js async-modules
+    // fixture (pages/_document.jsx) which uses `class MyDocument extends
+    // Document`. This requires the `next/document` default export to be a
+    // class, not a function — otherwise React refuses to construct
+    // MyDocument and throws "Class constructor cannot be invoked without
+    // 'new'", which surfaces in e2e as an empty/500 SSR response.
+    await fsp.writeFile(
+      path.join(tmpRoot, "pages", "_document.tsx"),
+      `import Document, { Html, Head, Main, NextScript } from "next/document";
+const docValue = await Promise.resolve("doc value");
+export default class MyDocument extends Document {
+  render() {
+    return (
+      <Html>
+        <Head />
+        <body>
+          <div id="doc-value">{docValue}</div>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    );
+  }
+}
+`,
+    );
+
+    await buildPagesFixtureToOutDir(tmpRoot, outDir);
+
+    const { startProdServer } = await import("../packages/vinext/src/server/prod-server.js");
+    prodServer = unwrapStartedProdServer(
+      await startProdServer({
+        port: 0,
+        host: "127.0.0.1",
+        outDir,
+      }),
+    );
+    const addr = prodServer.address() as { port: number };
+    prodUrl = `http://127.0.0.1:${addr.port}`;
+  }, 120000);
+
+  afterAll(async () => {
+    if (prodServer) {
+      await new Promise<void>((resolve) => prodServer.close(() => resolve()));
+    }
+    if (tmpRoot) {
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("renders an index page whose _app and page both use top-level await", async () => {
+    const res = await fetch(`${prodUrl}/`);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain('<div id="app-value">hello</div>');
+    expect(html).toContain('<div id="page-value">42</div>');
+  });
+
+  it("renders a page whose module-level await runs before getServerSideProps", async () => {
+    const res = await fetch(`${prodUrl}/gssp`);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain('<div id="gssp-value">42</div>');
+  });
+
+  it("renders a page whose module-level await runs before getStaticProps", async () => {
+    const res = await fetch(`${prodUrl}/gsp`);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain('<div id="gsp-value">42</div>');
+  });
+
+  it("serves an API route whose module uses top-level await", async () => {
+    const res = await fetch(`${prodUrl}/api/hello`);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ value: 42 });
+  });
+
+  it("renders an async class-based _document.tsx with resolved TLA values", async () => {
+    const res = await fetch(`${prodUrl}/`);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain('<div id="doc-value">doc value</div>');
+  });
 });
 
 describe("router __NEXT_DATA__ correctness (Pages Router)", () => {


### PR DESCRIPTION
## Summary

Issue #1361 reports that pages using top-level `await` (async modules) render empty content in deployed Next.js compatibility tests (`test/e2e/async-modules`). After reproducing locally with the Next.js fixture, the **actual** root cause is not TLA propagation — it is the `next/document` shim default export being a function instead of a class.

The original Next.js fixture's `pages/_document.jsx` uses the standard class form:

```jsx
import Document from 'next/document'
class MyDocument extends Document { ... }
```

Next.js's `Document` default export is `class Document extends React.Component`. vinext's shim exported a function. `class MyDocument extends <function>` is constructible at the JS level, but when React tries to render `<MyDocument />` it goes through the class-component path, hits the `extends` chain via the original `function Document()`, and ends up calling the constructor without `new` — throwing `TypeError: Class constructor MyDocument cannot be invoked without 'new'`. SSR 500s, the page body is empty, and every async-modules e2e expectation against `#app-value`, `#page-value`, `#gssp-value`, `#gsp-value`, `#content-404` etc. fails simultaneously. Top-level `await` itself propagates correctly through Rolldown's static-import graph already — Vinext's own pages, `_app.tsx`, `getStaticProps`, `getServerSideProps`, and API-route paths all render with TLA fine once `_document` no longer crashes.

This PR:

- Converts `packages/vinext/src/shims/document.tsx` default export to a class matching Next.js's signature (static `getInitialProps`, instance `render()`).
- Adds Pages Router production-build coverage that mirrors the Next.js `test/e2e/async-modules` fixture: index page + `_app.tsx` + `gssp.tsx` + `gsp.tsx` + `api/hello.ts` + class-based `_document.tsx`, all using module-level `await`.
- Adds dev-server smoke tests for both Pages and App Router (`tests/fixtures/{pages-basic,app-basic}/.../async-modules-test`) so future regressions in TLA propagation surface in the targeted test files.

Closes #1361

## Files changed

- `packages/vinext/src/shims/document.tsx` — class-based default export
- `tests/pages-router.test.ts` — new "Pages Router top-level await (async modules) in production" describe block (5 tests) + dev integration test
- `tests/app-router.test.ts` — dev integration test for app-router TLA
- `tests/fixtures/pages-basic/pages/async-modules-test.tsx` — Pages Router TLA fixture
- `tests/fixtures/app-basic/app/async-modules-test/page.tsx` — App Router TLA fixture

## Test plan

- [x] `pnpm test tests/pages-router.test.ts` — all 215 pass (5 new TLA tests)
- [x] `pnpm test tests/app-router.test.ts` — all pass (1 new TLA test)
- [x] `pnpm test tests/shims.test.ts` — all pass (Document class change doesn't break existing shim consumers)
- [x] `pnpm test tests/features.test.ts` — 303 pass
- [x] `pnpm run check` — clean (format + lint + types)
- [ ] CI green
- [ ] `/bigbonk review`

## Notes / caveats

- Calling user `_document.getInitialProps()` during SSR is **not** wired up in vinext yet (separate gap, separate issue). The class-based shim restores the constructor contract so user `_document.tsx` files render at all, but values produced by `getInitialProps` won't reach `this.props` until that pipeline lands. The `csr async page modules` case from the Next.js test (`#doc-value: "doc value"`) depends on that follow-up. The TLA value itself is captured at module load.
- Next.js source reference: [`packages/next/src/pages/_document.tsx`](https://github.com/vercel/next.js/blob/canary/packages/next/src/pages/_document.tsx) — default export is `class Document<P> extends React.Component<DocumentProps & P>` with a static `getInitialProps(ctx)` that delegates to `ctx.defaultGetInitialProps`.
- Ported test reference: [`test/e2e/async-modules/index.test.ts`](https://github.com/vercel/next.js/blob/canary/test/e2e/async-modules/index.test.ts).