### PR TITLE
fix(i18n): honor locale: false on rewrites/redirects + default-locale redirect

### DIFF
--- a/packages/vinext/src/config/config-matchers.ts
+++ b/packages/vinext/src/config/config-matchers.ts
@@ -5,7 +5,13 @@
  * (prod-server.ts) so both apply next.config.js rules identically.
  */
 
-import type { NextRedirect, NextRewrite, NextHeader, HasCondition } from "./next-config.js";
+import type {
+  NextI18nConfig,
+  NextRedirect,
+  NextRewrite,
+  NextHeader,
+  HasCondition,
+} from "./next-config.js";
 import {
   MIDDLEWARE_HEADER_PREFIX,
   VINEXT_MW_CTX_HEADER,
@@ -691,11 +697,23 @@ export function matchConfigPattern(
   // The last condition catches simple params with literal suffixes (e.g. "/:slug.md")
   // where the param name is followed by a dot — the simple matcher would treat
   // "slug.md" as the param name and match any single segment regardless of suffix.
+  // Enter the full regex branch when:
+  //   - the pattern uses explicit regex groups or escapes,
+  //   - a catch-all (`:foo*` / `:foo+`) is followed by a literal suffix that
+  //     the simple catch-all branch cannot express,
+  //   - a named param is followed by a dot (the simple branch would treat
+  //     "slug.md" as the whole param name),
+  //   - the pattern has multiple named params and any of them is a catch-all
+  //     (e.g. `/:locale/files/:path*`). The simple catch-all branch only
+  //     handles trailing-catch-all-with-static-prefix; mixed cases need regex.
+  const catchAllAnchor = /:[\w-]+[*+]/.test(pattern);
+  const namedParamCount = (pattern.match(/:[\w-]+/g) || []).length;
   if (
     pattern.includes("(") ||
     pattern.includes("\\") ||
     /:[\w-]+[*+][^/]/.test(pattern) ||
-    /:[\w-]+\./.test(pattern)
+    /:[\w-]+\./.test(pattern) ||
+    (catchAllAnchor && namedParamCount > 1)
   ) {
     try {
       // Look up the compiled regex in the module-level cache. Patterns come
@@ -1184,4 +1202,106 @@ export function matchHeaders(
     }
   }
   return result;
+}
+
+/**
+ * Escape a string for inclusion in a regex character class / alternation.
+ * Mirrors `escape-string-regexp` semantics used by Next.js's processRoutes.
+ */
+function _escapeRegexString(value: string): string {
+  return value.replace(/[|\\{}()[\]^$+*?.]/g, "\\$&");
+}
+
+/**
+ * Apply Next.js i18n locale-prefix transformation to a set of redirect or
+ * rewrite rules. Mirrors the relevant slice of Next.js's `processRoutes`
+ * (load-custom-routes.ts) with one deliberate divergence noted below.
+ *
+ * For each rule:
+ *   - If `locale === false` or no i18n is configured, the rule is emitted
+ *     untouched. This is the core of issue #1336 item 1: with `locale: false`
+ *     the user-supplied source is matched against the raw locale-prefixed
+ *     URL so a `:locale` segment in the source captures the prefix itself.
+ *   - Otherwise an internal locale-capture variant is produced whose source
+ *     starts with `/:nextInternalLocale(en|sv|nl)` so that locale-prefixed
+ *     URLs match. For redirects only, a second variant prefixed with
+ *     `/${defaultLocale}` is also emitted, matching Next.js exactly.
+ *   - **Vinext divergence**: we ALSO retain the original (unprefixed) source
+ *     so that requests for the default locale that arrive without a prefix
+ *     still match. Next.js solves this upstream by path-normalising every
+ *     incoming default-locale request to include the prefix
+ *     (`resolve-routes.ts` lines ~251-263); vinext currently does that
+ *     normalisation only inside the pages-server-entry route matcher, so
+ *     the rewrite/redirect matcher would otherwise miss unprefixed paths.
+ *     Keeping the unprefixed variant gives functionally identical behaviour
+ *     without requiring a server-wide path normalisation pass. The original
+ *     source is appended LAST so the locale-aware variants win when both
+ *     forms could match.
+ *
+ * Destinations that are local (start with `/`) are similarly rewritten with
+ * `/:nextInternalLocale` for the locale-capture variant so the locale
+ * survives the rewrite/redirect target.
+ *
+ * Mirrors the Next.js reference in
+ * packages/next/src/lib/load-custom-routes.ts — see `processRoutes`.
+ */
+export function applyLocaleToRoutes<T extends NextRedirect | NextRewrite>(
+  routes: T[],
+  i18n: NextI18nConfig | null | undefined,
+  type: "redirect" | "rewrite",
+): T[] {
+  if (!i18n || routes.length === 0) return routes;
+
+  const localesAlternation = i18n.locales.map(_escapeRegexString).join("|");
+  const internalLocale = `/:nextInternalLocale(${localesAlternation})`;
+
+  // For redirects, Next.js emits a per-default-locale literal variant
+  // (so that `/${defaultLocale}/old` redirects to the unprefixed destination
+  // and the default locale is implicitly stripped). For rewrites Next.js
+  // emits only the `:nextInternalLocale` form. We mirror that distinction.
+  const defaultLocales: string[] = type === "redirect" ? [...new Set([i18n.defaultLocale])] : [];
+
+  const out: T[] = [];
+  for (const r of routes) {
+    if (r.locale === false) {
+      out.push(r);
+      continue;
+    }
+
+    // Destinations may be absolute URLs (external) — Next.js skips the
+    // locale-prefix injection on external destinations.
+    const isExternal = !!r.destination && !r.destination.startsWith("/");
+
+    // For each default locale, emit a literal `/${locale}/...` variant
+    // whose destination does NOT carry a locale prefix (Next.js parity).
+    if (!isExternal) {
+      for (const locale of defaultLocales) {
+        const localizedSource = `/${locale}${r.source === "/" ? "" : r.source}`;
+        out.push({
+          ...r,
+          source: localizedSource,
+        });
+      }
+    }
+
+    // Emit the `:nextInternalLocale` variant that matches all locales.
+    const internalSource = `${internalLocale}${r.source === "/" ? "" : r.source}`;
+    let internalDestination = r.destination;
+    if (internalDestination && internalDestination.startsWith("/") && !isExternal) {
+      internalDestination = `/:nextInternalLocale${
+        internalDestination === "/" ? "" : internalDestination
+      }`;
+    }
+    out.push({
+      ...r,
+      source: internalSource,
+      destination: internalDestination,
+    });
+
+    // Retain the original unprefixed source as a fallback so default-locale
+    // requests that arrive without a prefix (e.g. `/old`) still match.
+    // See the docblock above for why this differs from upstream Next.js.
+    out.push(r);
+  }
+  return out;
 }

--- a/packages/vinext/src/config/config-matchers.ts
+++ b/packages/vinext/src/config/config-matchers.ts
@@ -123,14 +123,26 @@ function getCachedRegex<K, V>(cache: Map<K, V | null>, key: K, compile: () => V 
  * in the array are still checked first.
  */
 
-/** Matches `/:param(alternation)?/static/suffix` — the locale-static pattern. */
-const _LOCALE_STATIC_RE = /^\/:[\w-]+\(([^)]+)\)\?\/([a-zA-Z0-9_~.%@!$&'*+,;=:/-]+)$/;
+/**
+ * Matches `/:param(alternation)?/static/suffix` — the locale-static pattern.
+ *
+ * The `?` after the capture group is itself optional so that both forms are
+ * detected:
+ *   - `/:locale(en|fr)?/foo` (locale segment optional — user-written rules)
+ *   - `/:nextInternalLocale(en|fr)/foo` (locale segment mandatory — emitted
+ *      by `applyLocaleToRoutes` for the locale-capture variant)
+ * Both forms benefit from O(1) suffix lookup; the optionality is recorded
+ * on the entry so we know whether to try the no-locale-prefix bucket.
+ */
+const _LOCALE_STATIC_RE = /^\/:[\w-]+\(([^)]+)\)(\??)\/([a-zA-Z0-9_~.%@!$&'*+,;=:/-]+)$/;
 
 type LocaleStaticEntry = {
   /** The param name extracted from the source (e.g. "locale"). */
   paramName: string;
   /** The compiled regex matching just the alternation, used at match time. */
   altRe: RegExp;
+  /** Whether the locale segment is optional (the source had `?` after the group). */
+  optional: boolean;
   /** The original redirect rule. */
   redirect: NextRedirect;
   /** Position of this rule in the original redirects array. */
@@ -169,7 +181,8 @@ function _getRedirectIndex(redirects: NextRedirect[]): RedirectIndex {
     if (m) {
       const paramName = redirect.source.slice(2, redirect.source.indexOf("("));
       const alternation = m[1];
-      const suffix = "/" + m[2]; // e.g. "/security"
+      const optional = m[2] === "?";
+      const suffix = "/" + m[3]; // e.g. "/security"
       // Build a small regex to validate the captured locale value against the
       // alternation. Using anchored match to avoid partial matches.
       // The alternation comes from user config; run it through safeRegExp to
@@ -180,7 +193,13 @@ function _getRedirectIndex(redirects: NextRedirect[]): RedirectIndex {
         linear.push([i, redirect]);
         continue;
       }
-      const entry: LocaleStaticEntry = { paramName, altRe, redirect, originalIndex: i };
+      const entry: LocaleStaticEntry = {
+        paramName,
+        altRe,
+        optional,
+        redirect,
+        originalIndex: i,
+      };
       const bucket = localeStatic.get(suffix);
       if (bucket) {
         bucket.push(entry);
@@ -874,9 +893,14 @@ export function matchRedirect(
 
   if (index.localeStatic.size > 0) {
     // Case 1: no locale prefix — pathname IS the suffix.
+    // Only valid for entries whose source had `?` after the alternation
+    // (the locale segment was optional). Mandatory-locale entries — emitted
+    // by `applyLocaleToRoutes` as `/:nextInternalLocale(en|fr)/foo` — must
+    // not match here because they require the locale segment to be present.
     const noLocaleBucket = index.localeStatic.get(pathname);
     if (noLocaleBucket) {
       for (const entry of noLocaleBucket) {
+        if (!entry.optional) continue; // mandatory-locale rule — skip
         if (entry.originalIndex >= localeMatchIndex) continue; // already have a better match
         const redirect = entry.redirect;
         const conditionParams =
@@ -1249,17 +1273,30 @@ export function applyLocaleToRoutes<T extends NextRedirect | NextRewrite>(
   routes: T[],
   i18n: NextI18nConfig | null | undefined,
   type: "redirect" | "rewrite",
+  options: { trailingSlash?: boolean } = {},
 ): T[] {
   if (!i18n || routes.length === 0) return routes;
 
+  const trailingSlash = options.trailingSlash ?? false;
   const localesAlternation = i18n.locales.map(_escapeRegexString).join("|");
   const internalLocale = `/:nextInternalLocale(${localesAlternation})`;
+
+  // Mirrors Next.js: the root source `"/"` is collapsed to `""` only when
+  // `trailingSlash` is unset. With `trailingSlash: true` the source is
+  // preserved so the emitted variant is `/:nextInternalLocale(en|fr)/`
+  // rather than `/:nextInternalLocale(en|fr)`.
+  const suffixFor = (source: string): string => (source === "/" && !trailingSlash ? "" : source);
 
   // For redirects, Next.js emits a per-default-locale literal variant
   // (so that `/${defaultLocale}/old` redirects to the unprefixed destination
   // and the default locale is implicitly stripped). For rewrites Next.js
   // emits only the `:nextInternalLocale` form. We mirror that distinction.
-  const defaultLocales: string[] = type === "redirect" ? [...new Set([i18n.defaultLocale])] : [];
+  //
+  // The list is a single-element array today; domain-locale support (which
+  // Next.js wires up alongside `i18n.domains`) will append each domain's
+  // `defaultLocale` here once vinext mirrors that branch — tracked as part
+  // of #1336's follow-ups.
+  const defaultLocales: string[] = type === "redirect" ? [i18n.defaultLocale] : [];
 
   const out: T[] = [];
   for (const r of routes) {
@@ -1276,7 +1313,7 @@ export function applyLocaleToRoutes<T extends NextRedirect | NextRewrite>(
     // whose destination does NOT carry a locale prefix (Next.js parity).
     if (!isExternal) {
       for (const locale of defaultLocales) {
-        const localizedSource = `/${locale}${r.source === "/" ? "" : r.source}`;
+        const localizedSource = `/${locale}${suffixFor(r.source)}`;
         out.push({
           ...r,
           source: localizedSource,
@@ -1285,11 +1322,11 @@ export function applyLocaleToRoutes<T extends NextRedirect | NextRewrite>(
     }
 
     // Emit the `:nextInternalLocale` variant that matches all locales.
-    const internalSource = `${internalLocale}${r.source === "/" ? "" : r.source}`;
+    const internalSource = `${internalLocale}${suffixFor(r.source)}`;
     let internalDestination = r.destination;
     if (internalDestination && internalDestination.startsWith("/") && !isExternal) {
       internalDestination = `/:nextInternalLocale${
-        internalDestination === "/" ? "" : internalDestination
+        internalDestination === "/" && !trailingSlash ? "" : internalDestination
       }`;
     }
     out.push({

--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -77,6 +77,21 @@ export type NextRedirect = {
   permanent: boolean;
   has?: HasCondition[];
   missing?: HasCondition[];
+  /**
+   * When true (the default with i18n configured), Next.js prepends an internal
+   * locale alternation to the source so the rule matches locale-prefixed paths.
+   * When `false`, the source is left untouched and matches the raw path,
+   * letting user-supplied `:locale` segments capture the prefix themselves.
+   * See https://nextjs.org/docs/app/api-reference/config/next-config-js/redirects#locale
+   */
+  locale?: false;
+  /**
+   * When `false`, Next.js does not prepend `basePath` to the rule's source.
+   * Currently parsed for forward compatibility but not yet applied — vinext
+   * strips basePath before matching, so all rules behave as if `basePath:false`
+   * is implicit. Tracking parity in a follow-up.
+   */
+  basePath?: false;
 };
 
 export type NextRewrite = {
@@ -84,6 +99,10 @@ export type NextRewrite = {
   destination: string;
   has?: HasCondition[];
   missing?: HasCondition[];
+  /** See {@link NextRedirect.locale}. */
+  locale?: false;
+  /** See {@link NextRedirect.basePath}. */
+  basePath?: false;
 };
 
 export type NextHeader = {
@@ -1085,6 +1104,22 @@ export async function resolveNextConfig(
   // Resolve cacheMaxMemorySize
   const cacheMaxMemorySize: number | undefined =
     typeof config.cacheMaxMemorySize === "number" ? config.cacheMaxMemorySize : undefined;
+
+  // Apply Next.js i18n locale-prefix transformation to redirects/rewrites.
+  // When i18n is configured and a rule does NOT carry `locale: false`, the
+  // source is rewritten to match locale-prefixed URLs. Rules with
+  // `locale: false` are left untouched so user-supplied `:locale` segments
+  // can capture the prefix themselves. Mirrors processRoutes() in
+  // packages/next/src/lib/load-custom-routes.ts.
+  if (i18n) {
+    const { applyLocaleToRoutes } = await import("./config-matchers.js");
+    redirects = applyLocaleToRoutes(redirects, i18n, "redirect");
+    rewrites = {
+      beforeFiles: applyLocaleToRoutes(rewrites.beforeFiles, i18n, "rewrite"),
+      afterFiles: applyLocaleToRoutes(rewrites.afterFiles, i18n, "rewrite"),
+      fallback: applyLocaleToRoutes(rewrites.fallback, i18n, "rewrite"),
+    };
+  }
 
   const resolved: ResolvedNextConfig = {
     env: config.env ?? {},

--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -12,7 +12,7 @@ import { randomUUID } from "node:crypto";
 import commonjs from "vite-plugin-commonjs";
 import { PHASE_DEVELOPMENT_SERVER } from "vinext/shims/constants";
 import { normalizePageExtensions } from "../routing/file-matcher.js";
-import { isExternalUrl } from "./config-matchers.js";
+import { applyLocaleToRoutes, isExternalUrl } from "./config-matchers.js";
 import { loadTsconfigPathAliasesForRoot } from "./tsconfig-paths.js";
 
 /**
@@ -1112,12 +1112,12 @@ export async function resolveNextConfig(
   // can capture the prefix themselves. Mirrors processRoutes() in
   // packages/next/src/lib/load-custom-routes.ts.
   if (i18n) {
-    const { applyLocaleToRoutes } = await import("./config-matchers.js");
-    redirects = applyLocaleToRoutes(redirects, i18n, "redirect");
+    const opts = { trailingSlash: config.trailingSlash ?? false };
+    redirects = applyLocaleToRoutes(redirects, i18n, "redirect", opts);
     rewrites = {
-      beforeFiles: applyLocaleToRoutes(rewrites.beforeFiles, i18n, "rewrite"),
-      afterFiles: applyLocaleToRoutes(rewrites.afterFiles, i18n, "rewrite"),
-      fallback: applyLocaleToRoutes(rewrites.fallback, i18n, "rewrite"),
+      beforeFiles: applyLocaleToRoutes(rewrites.beforeFiles, i18n, "rewrite", opts),
+      afterFiles: applyLocaleToRoutes(rewrites.afterFiles, i18n, "rewrite", opts),
+      fallback: applyLocaleToRoutes(rewrites.fallback, i18n, "rewrite", opts),
     };
   }
 

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -16077,6 +16077,62 @@ describe("locale: false on rewrites/redirects (issue #1336)", () => {
     expect(matchRewrite("/old", rules, emptyCtx)).toBe("/new");
   });
 
+  it("matchRedirect uses the locale-static fast path for nextInternalLocale variants", async () => {
+    // The `_LOCALE_STATIC_RE` detection regex must accept both
+    //   `/:locale(en|fr)?/foo` (optional, user-written)
+    // and
+    //   `/:nextInternalLocale(en|fr)/foo` (mandatory, emitted by
+    //                                       applyLocaleToRoutes)
+    // — otherwise the locale-capture variants emitted by this PR would fall
+    // into the linear scan, regressing the O(1) lookup performance of i18n
+    // apps with many redirects.
+    const { matchRedirect, applyLocaleToRoutes } =
+      await import("../packages/vinext/src/config/config-matchers.js");
+    const i18n = { locales: ["en", "sv", "nl"], defaultLocale: "en" };
+    const rules = applyLocaleToRoutes(
+      [{ source: "/security", destination: "/security-dest", permanent: false as const }],
+      i18n,
+      "redirect",
+    );
+    // Locale-capture (mandatory) variant must hit the fast path AND substitute
+    // the captured locale into the destination.
+    expect(matchRedirect("/sv/security", rules, emptyCtx)?.destination).toBe("/sv/security-dest");
+    // Default-locale-literal variant strips the prefix.
+    expect(matchRedirect("/en/security", rules, emptyCtx)?.destination).toBe("/security-dest");
+    // No-locale-prefix path must not be matched by the mandatory variant —
+    // the original (unprefixed) source matches and produces the unprefixed
+    // destination.
+    expect(matchRedirect("/security", rules, emptyCtx)?.destination).toBe("/security-dest");
+  });
+
+  it("applyLocaleToRoutes preserves trailing slash when trailingSlash is true", async () => {
+    const { applyLocaleToRoutes } =
+      await import("../packages/vinext/src/config/config-matchers.js");
+    const i18n = { locales: ["en", "fr"], defaultLocale: "en" };
+
+    // trailingSlash: false (default) — root source collapses to "".
+    const noTrailing = applyLocaleToRoutes(
+      [{ source: "/", destination: "/home" }],
+      i18n,
+      "rewrite",
+      { trailingSlash: false },
+    );
+    const internalNoTrailing = noTrailing.find((r) => r.source.startsWith("/:nextInternalLocale("));
+    expect(internalNoTrailing?.source).toBe("/:nextInternalLocale(en|fr)");
+
+    // trailingSlash: true — root source is preserved.
+    const withTrailing = applyLocaleToRoutes(
+      [{ source: "/", destination: "/home" }],
+      i18n,
+      "rewrite",
+      { trailingSlash: true },
+    );
+    const internalWithTrailing = withTrailing.find((r) =>
+      r.source.startsWith("/:nextInternalLocale("),
+    );
+    expect(internalWithTrailing?.source).toBe("/:nextInternalLocale(en|fr)/");
+  });
+
   it("matchRedirect emits both default-locale-literal and locale-capture variants", async () => {
     // For redirects, Next.js emits two source variants per rule:
     //   1. `/${defaultLocale}/old` with destination `/new` (no locale prefix

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -15961,3 +15961,141 @@ describe("next/router SSR guard (issue #1353)", () => {
     expect(caught as Error).not.toBeInstanceOf(ReferenceError);
   });
 });
+
+// ---------------------------------------------------------------------------
+// i18n `locale: false` on rewrites/redirects (issue #1336, item 1).
+// Ported from Next.js: test/e2e/i18n-ignore-rewrite-source-locale/rewrites.test.ts
+// https://github.com/vercel/next.js/blob/canary/test/e2e/i18n-ignore-rewrite-source-locale/rewrites.test.ts
+//
+// When a rewrite/redirect source carries `locale: false`, Next.js leaves the
+// source pattern untouched (no internal locale prefix is prepended). So a
+// source like `/:locale/rewrite-files/:path*` matches the raw locale-prefixed
+// path with `:locale` capturing the actual locale segment.
+//
+// Without `locale: false`, Next.js prepends `/:nextInternalLocale(en|sv|nl)?`
+// to the source so that the rule matches both prefixed and unprefixed paths
+// (and the user-supplied source pattern matches against the de-localised
+// remainder).
+
+describe("locale: false on rewrites/redirects (issue #1336)", () => {
+  const emptyCtx = {
+    headers: new Headers(),
+    cookies: {},
+    query: new URLSearchParams(),
+    host: "localhost",
+  };
+
+  it("matches multi-param source with trailing catch-all (regression)", async () => {
+    // Even before the locale: false logic, the underlying matcher must handle
+    // a source like `/:locale/rewrite-files/:path*` where there is another
+    // named param before the trailing catch-all. Previously this fell into
+    // the simple catch-all branch which only handled the trailing param.
+    const { matchConfigPattern } = await import("../packages/vinext/src/config/config-matchers.js");
+    const pattern = "/:locale/rewrite-files/:path*";
+    const result = matchConfigPattern("/en/rewrite-files/file.txt", pattern);
+    expect(result).toEqual({ locale: "en", path: "file.txt" });
+
+    const nested = matchConfigPattern("/sv/rewrite-files/sub/dir/file.txt", pattern);
+    expect(nested).toEqual({ locale: "sv", path: "sub/dir/file.txt" });
+  });
+
+  it("processRoutes: with locale:false leaves source untouched", async () => {
+    const { applyLocaleToRoutes } =
+      await import("../packages/vinext/src/config/config-matchers.js");
+    const i18n = { locales: ["en", "sv", "nl"], defaultLocale: "en" };
+    const rules = [
+      {
+        source: "/:locale/rewrite-files/:path*",
+        destination: "/:path*",
+        locale: false as const,
+      },
+    ];
+    const out = applyLocaleToRoutes(rules, i18n, "rewrite");
+    expect(out).toHaveLength(1);
+    // locale:false → no internal locale prefix is injected.
+    expect(out[0].source).toBe("/:locale/rewrite-files/:path*");
+    expect(out[0].destination).toBe("/:path*");
+  });
+
+  it("processRoutes: without locale:false prepends the locale alternation", async () => {
+    const { applyLocaleToRoutes } =
+      await import("../packages/vinext/src/config/config-matchers.js");
+    const i18n = { locales: ["en", "sv", "nl"], defaultLocale: "en" };
+    const rules = [{ source: "/old", destination: "/new", permanent: true as const }];
+    const out = applyLocaleToRoutes(rules, i18n, "redirect");
+    // Next.js produces two source-variants per default-locale (and per domain
+    // default locale for redirects): one default-prefixed and one with the
+    // internal locale capture group. We only require that one of the produced
+    // rules captures the locale alternation so the original source matches
+    // localised URLs.
+    const hasInternalLocaleVariant = out.some((r) => r.source.startsWith("/:nextInternalLocale("));
+    expect(hasInternalLocaleVariant).toBe(true);
+  });
+
+  it("matchRewrite honours locale:false against locale-prefixed paths", async () => {
+    const { matchRewrite, applyLocaleToRoutes } =
+      await import("../packages/vinext/src/config/config-matchers.js");
+    const i18n = { locales: ["en", "sv", "nl"], defaultLocale: "en" };
+    const rules = applyLocaleToRoutes(
+      [
+        {
+          source: "/:locale/rewrite-files/:path*",
+          destination: "/:path*",
+          locale: false as const,
+        },
+        {
+          source: "/:locale/rewrite-api/:path*",
+          destination: "/api/:path*",
+          locale: false as const,
+        },
+      ],
+      i18n,
+      "rewrite",
+    );
+
+    expect(matchRewrite("/en/rewrite-files/file.txt", rules, emptyCtx)).toBe("/file.txt");
+    expect(matchRewrite("/sv/rewrite-files/file.txt", rules, emptyCtx)).toBe("/file.txt");
+    expect(matchRewrite("/nl/rewrite-files/file.txt", rules, emptyCtx)).toBe("/file.txt");
+    expect(matchRewrite("/en/rewrite-api/hello", rules, emptyCtx)).toBe("/api/hello");
+  });
+
+  it("matchRewrite without locale:false matches all locale-prefixed forms", async () => {
+    // When the user writes a plain source like `/old` and i18n is configured,
+    // vinext emits a `/:nextInternalLocale(en|sv|nl)` variant so the rule
+    // matches any locale-prefixed URL while retaining the original `/old`
+    // source for default-locale requests that arrive without a prefix.
+    const { matchRewrite, applyLocaleToRoutes } =
+      await import("../packages/vinext/src/config/config-matchers.js");
+    const i18n = { locales: ["en", "sv", "nl"], defaultLocale: "en" };
+    const rules = applyLocaleToRoutes([{ source: "/old", destination: "/new" }], i18n, "rewrite");
+
+    // Locale-prefixed paths match and the destination is also locale-prefixed.
+    expect(matchRewrite("/en/old", rules, emptyCtx)).toBe("/en/new");
+    expect(matchRewrite("/sv/old", rules, emptyCtx)).toBe("/sv/new");
+    expect(matchRewrite("/nl/old", rules, emptyCtx)).toBe("/nl/new");
+    // Unprefixed default-locale paths still match the original source.
+    expect(matchRewrite("/old", rules, emptyCtx)).toBe("/new");
+  });
+
+  it("matchRedirect emits both default-locale-literal and locale-capture variants", async () => {
+    // For redirects, Next.js emits two source variants per rule:
+    //   1. `/${defaultLocale}/old` with destination `/new` (no locale prefix
+    //      in destination — the default-locale variant strips the prefix).
+    //   2. `/:nextInternalLocale(en|sv|nl)/old` with destination
+    //      `/:nextInternalLocale/new` so non-default locales keep their prefix.
+    // This matches packages/next/src/lib/load-custom-routes.ts processRoutes.
+    const { matchRedirect, applyLocaleToRoutes } =
+      await import("../packages/vinext/src/config/config-matchers.js");
+    const i18n = { locales: ["en", "sv", "nl"], defaultLocale: "en" };
+    const rules = applyLocaleToRoutes(
+      [{ source: "/old", destination: "/new", permanent: false as const }],
+      i18n,
+      "redirect",
+    );
+    // `/en/old` matches the default-locale-literal variant first → strips the prefix.
+    expect(matchRedirect("/en/old", rules, emptyCtx)?.destination).toBe("/new");
+    // Non-default locales match the `:nextInternalLocale` variant.
+    expect(matchRedirect("/sv/old", rules, emptyCtx)?.destination).toBe("/sv/new");
+    expect(matchRedirect("/nl/old", rules, emptyCtx)?.destination).toBe("/nl/new");
+  });
+});


### PR DESCRIPTION
## Summary

Sub-issue #1336 item 1 (the highest-impact slice) — wire up the `locale: false` flag on Next.js rewrite/redirect sources, and fix the underlying matcher bug that made the flag's intended use case (`source: '/:locale/rewrite-files/:path*'`) fail outright.

Concretely:

- **Type surface.** Add `locale?: false` and `basePath?: false` to `NextRedirect` / `NextRewrite` so user configs that set the flag are no longer silently stripped during config load.
- **Matcher fix.** `matchConfigPattern` now uses the full regex branch whenever a pattern combines multiple named params with a catch-all (e.g. `/:locale/rewrite-files/:path*`). The simple catch-all branch only handled trailing-catch-all-with-static-prefix and treated `:locale` literally.
- **`applyLocaleToRoutes`.** New helper that mirrors Next.js's `processRoutes` (`packages/next/src/lib/load-custom-routes.ts`): when i18n is configured and a rule does not carry `locale: false`, emit a `/:nextInternalLocale(en|sv|nl)/...` variant plus (for redirects only) a per-default-locale literal variant. Rules flagged `locale: false` are emitted untouched.
- **Path-normalisation parity.** Next.js normalises every default-locale request to include the prefix before matching. Vinext doesn't (yet) — see item 4 below — so we deliberately retain the original unprefixed source as a fallback. This is documented in the helper's docblock.

## Out of scope (follow-ups)

Per the parent issue, items 2-4 stay open after this PR:

- **Item 2 — Locale not sticky on client navigations.** Belongs in `next/link` / navigation runtime; orthogonal to the config matcher.
- **Item 3 — Locale prefix not stripped for API routes.** `/fr/api/ok` → 404. Needs API-route resolution to participate in i18n stripping; separate change.
- **Item 4 — Default-locale prefix stripping.** The issue text claims `/en/page` should issue a 308 to `/page`, but Next.js does not do that — it normalises the path internally and serves the same content. The closest behavioural gap (server-side default-locale path normalisation before route matching) is large enough to merit its own PR; for now the `applyLocaleToRoutes` `defaultLocales` variant produces the right destination for redirect rules under the default locale.

## Test plan

- [x] `pnpm test tests/shims.test.ts` — 935 tests pass, including 6 new tests in the `locale: false on rewrites/redirects (issue #1336)` block:
  - multi-param + catch-all matcher regression
  - `applyLocaleToRoutes` leaves `locale: false` sources untouched
  - `applyLocaleToRoutes` emits an `:nextInternalLocale` variant otherwise
  - `matchRewrite` honours `locale: false` against all locale-prefixed paths (`/en|sv|nl/rewrite-files/file.txt`)
  - `matchRewrite` without `locale: false` matches every locale-prefixed form
  - `matchRedirect` emits both default-locale-literal and locale-capture variants
- [x] `pnpm test tests/deploy.test.ts tests/pages-i18n.test.ts tests/pages-i18n-prod.test.ts` — 239 tests pass
- [x] `pnpm test tests/routing.test.ts tests/pages-router.test.ts tests/app-router.test.ts` — 637 tests pass
- [x] `pnpm check` — formatter + linter + type-check green
- [ ] CI green (waiting)
- [ ] `/bigbonk review` feedback addressed

## References

- Ported from Next.js: [`test/e2e/i18n-ignore-rewrite-source-locale/rewrites.test.ts`](https://github.com/vercel/next.js/blob/canary/test/e2e/i18n-ignore-rewrite-source-locale/rewrites.test.ts)
- Implementation reference: [`packages/next/src/lib/load-custom-routes.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/lib/load-custom-routes.ts) — `processRoutes`

Refs #1336