### PR TITLE
feat(pages-router): implement _next/data JSON endpoint

### DIFF
--- a/packages/vinext/src/entries/pages-server-entry.ts
+++ b/packages/vinext/src/entries/pages-server-entry.ts
@@ -611,21 +611,20 @@ async function _renderPage(request, url, manifest, middlewareHeaders, options) {
       // ── _next/data JSON envelope short-circuit ───────────────────────
       // For client-side navigations Next.js fetches /_next/data/<buildId>/<page>.json
       // and expects { pageProps } as JSON instead of the full HTML page. Skip
-      // rendering the React tree and emit the JSON envelope directly. Headers
-      // and cookies set on the gsspRes by getServerSideProps are forwarded
-      // so middleware/auth flows work the same as the HTML page.
+      // rendering the React tree and emit the JSON envelope directly via the
+      // typed helper so the envelope shape stays in one place. Headers and
+      // cookies set on the gsspRes by getServerSideProps are forwarded so
+      // middleware/auth flows work the same as the HTML page.
       if (isDataReq) {
-        const dataHeaders = { "Content-Type": "application/json" };
+        const init = {};
         if (gsspRes && gsspRes.headers) {
+          init.headers = {};
           for (const [k, v] of Object.entries(gsspRes.headers)) {
             if (v === undefined || v === null) continue;
-            dataHeaders[k] = Array.isArray(v) ? v.join(", ") : String(v);
+            init.headers[k] = Array.isArray(v) ? v.join(", ") : String(v);
           }
         }
-        return new Response(safeJsonStringify({ pageProps }), {
-          status: 200,
-          headers: dataHeaders,
-        });
+        return __buildNextDataJsonResponse(pageProps, safeJsonStringify, init);
       }
 
       // Include both the matched page module and the global _app module

--- a/packages/vinext/src/entries/pages-server-entry.ts
+++ b/packages/vinext/src/entries/pages-server-entry.ts
@@ -23,6 +23,7 @@ const _pagesPageResponsePath = resolveEntryPath(
   import.meta.url,
 );
 const _pagesPageDataPath = resolveEntryPath("../server/pages-page-data.js", import.meta.url);
+const _pagesDataRoutePath = resolveEntryPath("../server/pages-data-route.js", import.meta.url);
 const _pagesNodeCompatPath = resolveEntryPath("../server/pages-node-compat.js", import.meta.url);
 const _pagesApiRoutePath = resolveEntryPath("../server/pages-api-route.js", import.meta.url);
 const _isrCachePath = resolveEntryPath("../server/isr-cache.js", import.meta.url);
@@ -211,6 +212,7 @@ import {
 } from ${JSON.stringify(_isrCachePath)};
 import { getScriptNonceFromHeaderSources as __getScriptNonceFromHeaderSources } from ${JSON.stringify(_cspPath)};
 import { resolvePagesPageData as __resolvePagesPageData } from ${JSON.stringify(_pagesPageDataPath)};
+import { buildNextDataJsonResponse as __buildNextDataJsonResponse, buildNextDataNotFoundResponse as __buildNextDataNotFoundResponse } from ${JSON.stringify(_pagesDataRoutePath)};
 import { renderPagesPageResponse as __renderPagesPageResponse } from ${JSON.stringify(_pagesPageResponsePath)};
 ${instrumentationImportCode}
 ${middlewareImportCode}
@@ -220,8 +222,10 @@ ${instrumentationInitCode}
 // i18n config (embedded at build time)
 const i18nConfig = ${i18nConfigJson};
 
-// Build ID (embedded at build time)
-const buildId = ${buildIdJson};
+// Build ID (embedded at build time). Exported so the production server can
+// match _next/data requests against the embedded buildId without needing
+// to load next.config.js at runtime.
+export const buildId = ${buildIdJson};
 
 // Full resolved config for production server (embedded at build time)
 export const vinextConfig = ${vinextConfigJson};
@@ -443,12 +447,13 @@ function collectAssetTags(manifest, moduleIds, scriptNonce) {
   return tags.join("\\n  ");
 }
 
-export async function renderPage(request, url, manifest, ctx, middlewareHeaders) {
-  if (ctx) return _runWithExecutionContext(ctx, () => _renderPage(request, url, manifest, middlewareHeaders));
-  return _renderPage(request, url, manifest, middlewareHeaders);
+export async function renderPage(request, url, manifest, ctx, middlewareHeaders, options) {
+  if (ctx) return _runWithExecutionContext(ctx, () => _renderPage(request, url, manifest, middlewareHeaders, options));
+  return _renderPage(request, url, manifest, middlewareHeaders, options);
 }
 
-async function _renderPage(request, url, manifest, middlewareHeaders) {
+async function _renderPage(request, url, manifest, middlewareHeaders, options) {
+  const isDataReq = !!(options && options.isDataReq);
   const localeInfo = i18nConfig
     ? resolvePagesI18nRequest(
         url,
@@ -472,6 +477,9 @@ async function _renderPage(request, url, manifest, middlewareHeaders) {
 
   const match = matchRoute(routeUrl, pageRoutes);
   if (!match) {
+    if (isDataReq) {
+      return __buildNextDataNotFoundResponse();
+    }
     return new Response("<!DOCTYPE html><html><body><h1>404 - Page not found</h1></body></html>",
       { status: 404, headers: { "Content-Type": "text/html" } });
   }
@@ -526,6 +534,7 @@ async function _renderPage(request, url, manifest, middlewareHeaders) {
         }
       } catch (e) { /* font preloads not available */ }
       const pageDataResult = await __resolvePagesPageData({
+        isDataReq,
         applyRequestContexts() {
           if (typeof setSSRContext === "function") {
             setSSRContext({
@@ -598,6 +607,26 @@ async function _renderPage(request, url, manifest, middlewareHeaders) {
       let pageProps = pageDataResult.pageProps;
       var gsspRes = pageDataResult.gsspRes;
       let isrRevalidateSeconds = pageDataResult.isrRevalidateSeconds;
+
+      // ── _next/data JSON envelope short-circuit ───────────────────────
+      // For client-side navigations Next.js fetches /_next/data/<buildId>/<page>.json
+      // and expects { pageProps } as JSON instead of the full HTML page. Skip
+      // rendering the React tree and emit the JSON envelope directly. Headers
+      // and cookies set on the gsspRes by getServerSideProps are forwarded
+      // so middleware/auth flows work the same as the HTML page.
+      if (isDataReq) {
+        const dataHeaders = { "Content-Type": "application/json" };
+        if (gsspRes && gsspRes.headers) {
+          for (const [k, v] of Object.entries(gsspRes.headers)) {
+            if (v === undefined || v === null) continue;
+            dataHeaders[k] = Array.isArray(v) ? v.join(", ") : String(v);
+          }
+        }
+        return new Response(safeJsonStringify({ pageProps }), {
+          status: 200,
+          headers: dataHeaders,
+        });
+      }
 
       // Include both the matched page module and the global _app module
       // (if present). _app is wrapped around every page in Pages Router,

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -2880,6 +2880,13 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                   // Rewrite req.url so downstream middleware sees the page
                   // path, not the raw _next/data URL.
                   req.url = url;
+                } else {
+                  // Stale buildId or malformed path. Return a JSON 404 here
+                  // (matching the prod-server path) so clients hard-navigate
+                  // instead of trying to parse Vite's HTML 404 as JSON.
+                  res.writeHead(404, { "Content-Type": "application/json" });
+                  res.end("{}");
+                  return;
                 }
               }
 

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -2864,7 +2864,13 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
               // to the dot-extension skip below which returns 404.
               let isDataReq = false;
               if (isNextDataPathname(pathname)) {
-                const devBuildId = process.env.__VINEXT_BUILD_ID ?? "development";
+                // Use the plugin's resolved buildId so a user-supplied
+                // `generateBuildId` in next.config.mjs is honored in dev —
+                // matching the value embedded into the prod entry. Fall back
+                // to the env-var define (set by the plugin) and finally
+                // "development" if the plugin hasn't resolved a config yet.
+                const devBuildId =
+                  nextConfig?.buildId ?? process.env.__VINEXT_BUILD_ID ?? "development";
                 const dataMatch = parseNextDataPathname(pathname, devBuildId);
                 if (dataMatch) {
                   isDataReq = true;

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -42,6 +42,7 @@ import {
 } from "./config/next-config.js";
 
 import { findMiddlewareFile, runMiddleware } from "./server/middleware.js";
+import { isNextDataPathname, parseNextDataPathname } from "./server/pages-data-route.js";
 import {
   MIDDLEWARE_HEADER_PREFIX,
   MIDDLEWARE_NEXT_HEADER,
@@ -2853,6 +2854,29 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                 }
               }
 
+              // ── `_next/data` normalization (Pages Router) ──────────────
+              // Client-side navigations in the Pages Router fetch
+              // `/_next/data/<buildId>/<page>.json`. Normalize the URL to the
+              // page path BEFORE middleware runs so middleware sees `/page`
+              // (matching Next.js — see `handleNextDataRequest` in
+              // base-server.ts). If the buildId is missing (dev) or matches,
+              // accept the request; if it is present and wrong, fall through
+              // to the dot-extension skip below which returns 404.
+              let isDataReq = false;
+              if (isNextDataPathname(pathname)) {
+                const devBuildId = process.env.__VINEXT_BUILD_ID ?? "development";
+                const dataMatch = parseNextDataPathname(pathname, devBuildId);
+                if (dataMatch) {
+                  isDataReq = true;
+                  const qs = url.includes("?") ? url.slice(url.indexOf("?")) : "";
+                  url = dataMatch.pagePathname + qs;
+                  pathname = dataMatch.pagePathname;
+                  // Rewrite req.url so downstream middleware sees the page
+                  // path, not the raw _next/data URL.
+                  req.url = url;
+                }
+              }
+
               // Skip requests for files with extensions (static assets) after
               // trailing-slash canonicalization so file-looking dynamic routes
               // like /catch-all/hello.world/ still get the Next.js redirect.
@@ -3195,7 +3219,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                 if (middlewareRequestHeaders) {
                   applyRequestHeadersToNodeRequest(middlewareRequestHeaders);
                 }
-                await handler(req, res, resolvedUrl, mwStatus);
+                await handler(req, res, resolvedUrl, mwStatus, isDataReq);
                 return;
               }
 
@@ -3222,7 +3246,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                   if (middlewareRequestHeaders) {
                     applyRequestHeadersToNodeRequest(middlewareRequestHeaders);
                   }
-                  await handler(req, res, fallbackRewrite, mwStatus);
+                  await handler(req, res, fallbackRewrite, mwStatus, isDataReq);
                   return;
                 }
               }
@@ -3231,7 +3255,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
               // otherwise render via the pages SSR handler (will 404 for unknown routes).
               if (hasAppDir) return next();
 
-              await handler(req, res, resolvedUrl, mwStatus);
+              await handler(req, res, resolvedUrl, mwStatus, isDataReq);
             } catch (e) {
               next(e);
             }

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -445,6 +445,13 @@ export function createSSRHandler(
             });
 
             if (!isValidPath) {
+              if (isDataReq) {
+                // Data requests get a JSON 404 so the client router can
+                // hard-navigate instead of trying to parse HTML as JSON.
+                res.writeHead(404, { "Content-Type": "application/json" });
+                res.end("{}");
+                return;
+              }
               await renderErrorPage(
                 server,
                 runner,
@@ -516,6 +523,11 @@ export function createSSRHandler(
             return;
           }
           if (result && "notFound" in result && result.notFound) {
+            if (isDataReq) {
+              res.writeHead(404, { "Content-Type": "application/json" });
+              res.end("{}");
+              return;
+            }
             await renderErrorPage(
               server,
               runner,
@@ -786,6 +798,11 @@ export function createSSRHandler(
             return;
           }
           if (result && "notFound" in result && result.notFound) {
+            if (isDataReq) {
+              res.writeHead(404, { "Content-Type": "application/json" });
+              res.end("{}");
+              return;
+            }
             await renderErrorPage(
               server,
               runner,

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -273,6 +273,13 @@ export function createSSRHandler(
     url: string,
     /** Status code override — propagated from middleware rewrite status. */
     statusCode?: number,
+    /**
+     * True when the request originated as `/_next/data/<buildId>/<page>.json`.
+     * When true the handler emits a `{ pageProps }` JSON envelope instead of
+     * rendering the React tree to HTML — matching Next.js' behavior for
+     * client-side navigations in the Pages Router.
+     */
+    isDataReq: boolean = false,
   ): Promise<void> => {
     const _reqStart = now();
     let _compileEnd: number | undefined;
@@ -326,6 +333,13 @@ export function createSSRHandler(
     const match = matchRoute(localeStrippedUrl, routes);
 
     if (!match) {
+      if (isDataReq) {
+        // Stale client requested data for a page that no longer exists.
+        // Emit a JSON 404 so the client hard-navigates (matches Next.js).
+        res.writeHead(404, { "Content-Type": "application/json" });
+        res.end("{}");
+        return;
+      }
       // No route matched — try to render custom 404 page
       await renderErrorPage(server, runner, req, res, url, pagesDir, 404, undefined, matcher);
       return;
@@ -569,7 +583,13 @@ export function createSSRHandler(
           );
           const cached = await isrGet(cacheKey);
 
-          if (cached && !cached.isStale && cached.value.value?.kind === "PAGES" && !scriptNonce) {
+          if (
+            cached &&
+            !cached.isStale &&
+            cached.value.value?.kind === "PAGES" &&
+            !scriptNonce &&
+            !isDataReq
+          ) {
             // Fresh cache hit — serve directly
             const cachedPage = cached.value.value as CachedPagesValue;
             const cachedHtml = cachedPage.html;
@@ -586,7 +606,13 @@ export function createSSRHandler(
             return;
           }
 
-          if (cached && cached.isStale && cached.value.value?.kind === "PAGES" && !scriptNonce) {
+          if (
+            cached &&
+            cached.isStale &&
+            cached.value.value?.kind === "PAGES" &&
+            !scriptNonce &&
+            !isDataReq
+          ) {
             // Stale hit — serve stale immediately, trigger background regen
             const cachedPage = cached.value.value as CachedPagesValue;
             const cachedHtml = cachedPage.html;
@@ -777,6 +803,27 @@ export function createSSRHandler(
           if (typeof result?.revalidate === "number" && result.revalidate > 0) {
             isrRevalidateSeconds = result.revalidate;
           }
+        }
+
+        // ── _next/data JSON envelope short-circuit (dev) ──────────────
+        // Client-side navigations fetch /_next/data/<buildId>/<page>.json and
+        // expect { pageProps } as JSON. We have pageProps; skip the React
+        // tree render and the _document shell entirely. Headers set on `res`
+        // by getServerSideProps (cookies, status codes, etc.) are preserved
+        // because we already let gSSP mutate `res` above.
+        if (isDataReq) {
+          const dataHeaders: Record<string, string | string[] | number> = {
+            "Content-Type": "application/json",
+          };
+          if (gsspExtraHeaders) {
+            for (const [k, v] of Object.entries(gsspExtraHeaders)) {
+              dataHeaders[k] = v;
+            }
+          }
+          res.writeHead(statusCode ?? 200, dataHeaders);
+          res.end(JSON.stringify({ pageProps }));
+          _renderEnd = now();
+          return;
         }
 
         // Try to load _app.tsx if it exists

--- a/packages/vinext/src/server/pages-data-route.ts
+++ b/packages/vinext/src/server/pages-data-route.ts
@@ -1,0 +1,121 @@
+/**
+ * Helpers for the Pages Router `/_next/data/{buildId}/{...page}.json` endpoint.
+ *
+ * Next.js uses this endpoint for client-side navigations in the Pages Router:
+ * `next/link` and `router.push()` fetch `pageProps` from this URL instead of
+ * doing a full HTML navigation. The server must:
+ *   1. Match the URL pattern and extract the page pathname (with the buildId
+ *      and `.json` extension removed, locale prefix preserved).
+ *   2. Normalize the URL BEFORE middleware runs so middleware sees the page
+ *      path (e.g. `/about`) rather than the raw `/_next/data/.../about.json`.
+ *   3. Invoke the same `getServerSideProps` / `getStaticProps` machinery as
+ *      the HTML page and serialize the resulting props as a JSON envelope:
+ *      `{ pageProps: ... }` with `Content-Type: application/json`.
+ *
+ * Ported from Next.js:
+ *   - `packages/next/src/server/normalizers/request/next-data.ts` — prefix/suffix matcher.
+ *   - `packages/next/src/server/base-server.ts` (`handleNextDataRequest`) — pipeline normalization.
+ *   - `packages/next/src/server/render.tsx` — JSON envelope emission (`isNextDataRequest`).
+ */
+
+const NEXT_DATA_PREFIX = "/_next/data/";
+const NEXT_DATA_SUFFIX = ".json";
+
+export type NextDataMatch = {
+  /**
+   * The normalized page pathname (with leading slash, no trailing slash,
+   * `.json` stripped, buildId stripped). For locale-prefixed requests like
+   * `/_next/data/<buildId>/en/about.json` this is `/en/about` — locale
+   * handling is done downstream by the existing `resolvePagesI18nRequest`
+   * pipeline so this helper does not need to know about i18n config.
+   */
+  pagePathname: string;
+};
+
+/**
+ * Returns true if the pathname looks like a `_next/data` request, regardless
+ * of buildId. Used by the request pipeline to short-circuit before middleware
+ * even when the buildId is wrong (so we can still return a 404 JSON response).
+ */
+export function isNextDataPathname(pathname: string): boolean {
+  return pathname.startsWith(NEXT_DATA_PREFIX) && pathname.endsWith(NEXT_DATA_SUFFIX);
+}
+
+/**
+ * Parse `/_next/data/<buildId>/<...page>.json` and return the normalized page
+ * pathname. Returns `null` if the pathname does not match the pattern or if
+ * the buildId segment does not match the server's buildId.
+ *
+ * The returned `pagePathname` is the page route path Next.js would render for
+ * the equivalent HTML navigation — including any locale prefix, which is then
+ * stripped by `resolvePagesI18nRequest` downstream.
+ *
+ * `/_next/data/<buildId>/about.json`         → `/about`
+ * `/_next/data/<buildId>/en/about.json`      → `/en/about`
+ * `/_next/data/<buildId>/index.json`         → `/`
+ * `/_next/data/<buildId>/en.json`            → `/en`
+ * `/_next/data/<wrong-id>/about.json`        → null
+ * `/_next/data/<buildId>/about`              → null  (missing .json suffix)
+ */
+export function parseNextDataPathname(pathname: string, buildId: string): NextDataMatch | null {
+  if (!buildId) return null;
+  if (!isNextDataPathname(pathname)) return null;
+
+  const expectedPrefix = `${NEXT_DATA_PREFIX}${buildId}/`;
+  // `/_next/data/<buildId>.json` (no trailing slash) is not a valid data req.
+  if (!pathname.startsWith(expectedPrefix)) return null;
+
+  const rest = pathname.slice(expectedPrefix.length, -NEXT_DATA_SUFFIX.length);
+
+  // Empty rest (`/_next/data/<buildId>/.json`) is not a valid page path.
+  if (rest.length === 0) return null;
+
+  // Next.js denormalizes `index` to `/` to mirror file-system page paths
+  // (`pages/index.tsx` → `/`). See `denormalizePagePath` in Next.js.
+  if (rest === "index") return { pagePathname: "/" };
+  if (rest.endsWith("/index")) return { pagePathname: `/${rest.slice(0, -"/index".length)}` };
+
+  return { pagePathname: `/${rest}` };
+}
+
+/**
+ * Build the JSON envelope returned by `/_next/data/<buildId>/<page>.json`.
+ * Mirrors Next.js' `RenderResult(JSON.stringify(props))` path in
+ * `packages/next/src/server/render.tsx` (search for `isNextDataRequest`).
+ *
+ * The envelope is the outer `props` object the React tree would receive:
+ *   { pageProps: {...}, /* optional locale data, redirect markers, etc. *\/ }
+ */
+export function buildNextDataJsonResponse(
+  pageProps: Record<string, unknown>,
+  safeJsonStringify: (value: unknown) => string,
+  init?: ResponseInit,
+): Response {
+  const body = safeJsonStringify({ pageProps });
+  return new Response(body, {
+    status: init?.status ?? 200,
+    statusText: init?.statusText,
+    headers: {
+      "Content-Type": "application/json",
+      ...(init?.headers as Record<string, string> | undefined),
+    },
+  });
+}
+
+/**
+ * Build the 404 response Next.js returns for an unknown `_next/data` page.
+ * Next.js renders this as a normal 404 page, but the body shape that clients
+ * see for a missing page-data endpoint is the literal string `"{ }"` for the
+ * body and a 404 status with `application/json` so client-side hard-navigation
+ * fallback fires (see `__N_SSP` handling in `router.ts`).
+ *
+ * We match Next.js' behavior: 404 status + JSON content type. The body is an
+ * empty JSON object so clients that blindly call `res.json()` do not throw
+ * before checking the status code.
+ */
+export function buildNextDataNotFoundResponse(): Response {
+  return new Response("{}", {
+    status: 404,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/packages/vinext/src/server/pages-data-route.ts
+++ b/packages/vinext/src/server/pages-data-route.ts
@@ -21,7 +21,7 @@
 const NEXT_DATA_PREFIX = "/_next/data/";
 const NEXT_DATA_SUFFIX = ".json";
 
-export type NextDataMatch = {
+type NextDataMatch = {
   /**
    * The normalized page pathname (with leading slash, no trailing slash,
    * `.json` stripped, buildId stripped). For locale-prefixed requests like

--- a/packages/vinext/src/server/pages-page-data.ts
+++ b/packages/vinext/src/server/pages-page-data.ts
@@ -87,6 +87,15 @@ type RenderPagesIsrHtmlOptions = {
 export type ResolvePagesPageDataOptions = {
   applyRequestContexts: () => void;
   buildId: string | null;
+  /**
+   * When true, this is a `/_next/data/<buildId>/<page>.json` request. Callers
+   * that respond with a JSON envelope (`{ pageProps }`) instead of HTML must
+   * bypass the HTML ISR cache: a cached HTML body cannot be reshaped into the
+   * expected JSON shape, and storing JSON in the HTML cache would corrupt
+   * subsequent HTML hits. Next.js handles this the same way — see
+   * `isNextDataRequest` checks in `packages/next/src/server/base-server.ts`.
+   */
+  isDataReq?: boolean;
   createGsspReqRes: () => PagesGsspContextResponse;
   createPageElement: (pageProps: Record<string, unknown>) => ReactNode;
   fontLinkHeader: string;
@@ -143,7 +152,13 @@ function buildPagesNotFoundResponse(): Response {
 }
 
 function buildPagesDataNotFoundResponse(): Response {
-  return new Response("404", { status: 404 });
+  // Matches Next.js: `/_next/data/<buildId>/<page>.json` 404 responses use
+  // application/json with an empty object body so clients can call
+  // `res.json()` without throwing before inspecting the status code.
+  return new Response("{}", {
+    status: 404,
+    headers: { "Content-Type": "application/json" },
+  });
 }
 
 function resolvePagesRedirectStatus(redirect: PagesRedirectResult): number {
@@ -349,7 +364,13 @@ export async function resolvePagesPageData(
     const cached = await options.isrGet(cacheKey);
     const cachedValue = cached?.value.value;
 
-    if (cachedValue?.kind === "PAGES" && cached && !cached.isStale && !options.scriptNonce) {
+    if (
+      cachedValue?.kind === "PAGES" &&
+      cached &&
+      !cached.isStale &&
+      !options.scriptNonce &&
+      !options.isDataReq
+    ) {
       return {
         kind: "response",
         response: buildPagesCacheResponse(
@@ -363,7 +384,13 @@ export async function resolvePagesPageData(
       };
     }
 
-    if (cachedValue?.kind === "PAGES" && cached && cached.isStale && !options.scriptNonce) {
+    if (
+      cachedValue?.kind === "PAGES" &&
+      cached &&
+      cached.isStale &&
+      !options.scriptNonce &&
+      !options.isDataReq
+    ) {
       options.triggerBackgroundRegeneration(
         cacheKey,
         async function () {

--- a/packages/vinext/src/server/pages-page-data.ts
+++ b/packages/vinext/src/server/pages-page-data.ts
@@ -301,9 +301,14 @@ export async function resolvePagesPageData(
       );
 
       if (!isValidPath) {
+        // For data requests (`/_next/data/...json`), return a JSON-shaped 404
+        // so the client router can `res.json()` without blowing up — matches
+        // Next.js' behavior. HTML navigations still get the HTML 404 page.
         return {
           kind: "response",
-          response: buildPagesNotFoundResponse(),
+          response: options.isDataReq
+            ? buildPagesDataNotFoundResponse()
+            : buildPagesNotFoundResponse(),
         };
       }
     }

--- a/packages/vinext/src/server/pages-page-data.ts
+++ b/packages/vinext/src/server/pages-page-data.ts
@@ -354,7 +354,9 @@ export async function resolvePagesPageData(
     if (result?.notFound) {
       return {
         kind: "response",
-        response: buildPagesDataNotFoundResponse(),
+        response: options.isDataReq
+          ? buildPagesDataNotFoundResponse()
+          : buildPagesNotFoundResponse(),
       };
     }
 
@@ -479,7 +481,9 @@ export async function resolvePagesPageData(
     if (result?.notFound) {
       return {
         kind: "response",
-        response: buildPagesDataNotFoundResponse(),
+        response: options.isDataReq
+          ? buildPagesDataNotFoundResponse()
+          : buildPagesNotFoundResponse(),
       };
     }
 

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -52,6 +52,11 @@ import {
   normalizeTrailingSlash,
 } from "./request-pipeline.js";
 import { notFoundResponse } from "./http-error-responses.js";
+import {
+  isNextDataPathname,
+  parseNextDataPathname,
+  buildNextDataNotFoundResponse,
+} from "./pages-data-route.js";
 import { hasBasePath, stripBasePath } from "../utils/base-path.js";
 import {
   ASSET_PREFIX_URL_DIR,
@@ -1318,7 +1323,13 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
   // the freshly built module rather than a stale cached copy.
   const serverMtime = fs.statSync(serverEntryPath).mtimeMs;
   const serverEntry = await import(`${pathToFileURL(serverEntryPath).href}?t=${serverMtime}`);
-  const { renderPage, handleApiRoute: handleApi, runMiddleware, vinextConfig } = serverEntry;
+  const {
+    renderPage,
+    handleApiRoute: handleApi,
+    runMiddleware,
+    vinextConfig,
+    buildId: pagesBuildId,
+  } = serverEntry;
   const matchPageRoute =
     typeof serverEntry.matchPageRoute === "function" ? serverEntry.matchPageRoute : undefined;
   const pageRoutes = readPagesServerEntryPageRoutes(serverEntry.pageRoutes);
@@ -1545,6 +1556,30 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
           res.end();
           return;
         }
+      }
+
+      // ── 3b. `_next/data` normalization ────────────────────────────
+      // Pages Router client-side navigations fetch
+      // `/_next/data/<buildId>/<page>.json`. The page path must be normalized
+      // BEFORE middleware runs so middleware sees `/page`, matching Next.js
+      // (see `handleNextDataRequest` in base-server.ts). If the buildId in the
+      // URL does not match this server's buildId we return a JSON 404 right
+      // here — stale clients can fall back to a hard navigation without
+      // accidentally triggering middleware/SSR on a bogus path.
+      let isDataReq = false;
+      if (isNextDataPathname(pathname)) {
+        const dataMatch = pagesBuildId ? parseNextDataPathname(pathname, pagesBuildId) : null;
+        if (!dataMatch) {
+          // Wrong buildId (or malformed) — surface a JSON 404 so the client
+          // hard-navigates instead of silently rendering an empty page.
+          const notFound = buildNextDataNotFoundResponse();
+          await sendWebResponse(notFound, req, res, compress);
+          return;
+        }
+        isDataReq = true;
+        const qs = url.includes("?") ? url.slice(url.indexOf("?")) : "";
+        url = dataMatch.pagePathname + qs;
+        pathname = dataMatch.pagePathname;
       }
 
       // Convert Node.js req to Web Request for the server entry
@@ -1819,12 +1854,14 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
       let response: Response | undefined;
       if (typeof renderPage === "function") {
         const middlewareResponseHeaders = toWebHeaders(middlewareHeaders);
+        const renderOptions = isDataReq ? { isDataReq: true } : undefined;
         response = await renderPage(
           webRequest,
           resolvedUrl,
           ssrManifest,
           undefined,
           middlewareResponseHeaders,
+          renderOptions,
         );
 
         // ── 11. Fallback rewrites (if SSR returned 404) ─────────────
@@ -1846,6 +1883,7 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
               ssrManifest,
               undefined,
               middlewareResponseHeaders,
+              renderOptions,
             );
           }
         }

--- a/tests/fixtures/pages-basic/middleware.ts
+++ b/tests/fixtures/pages-basic/middleware.ts
@@ -7,6 +7,10 @@ export function middleware(request: NextRequest) {
   // Add a custom header to all matched requests
   const response = NextResponse.next();
   response.headers.set("x-custom-middleware", "active");
+  // Expose the pathname middleware actually observed. Used by tests verifying
+  // `/_next/data/<buildId>/<page>.json` is normalized to `/page` BEFORE
+  // middleware runs (matching Next.js' `handleNextDataRequest` pipeline).
+  response.headers.set("x-mw-pathname", url.pathname);
 
   // Redirect /old-page to /about
   if (url.pathname === "/old-page") {

--- a/tests/pages-data-route.test.ts
+++ b/tests/pages-data-route.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vite-plus/test";
+import {
+  isNextDataPathname,
+  parseNextDataPathname,
+  buildNextDataJsonResponse,
+  buildNextDataNotFoundResponse,
+} from "../packages/vinext/src/server/pages-data-route.js";
+
+// Helper mirroring vinext/html safeJsonStringify behavior for tests.
+const safeJsonStringify = (value: unknown) => JSON.stringify(value);
+
+describe("pages-data-route", () => {
+  describe("isNextDataPathname", () => {
+    it("returns true for valid _next/data paths regardless of buildId", () => {
+      expect(isNextDataPathname("/_next/data/abc/about.json")).toBe(true);
+      expect(isNextDataPathname("/_next/data/abc/en/about.json")).toBe(true);
+      expect(isNextDataPathname("/_next/data/wrong/about.json")).toBe(true);
+    });
+
+    it("returns false for non-_next/data paths", () => {
+      expect(isNextDataPathname("/about")).toBe(false);
+      expect(isNextDataPathname("/_next/static/chunks/foo.js")).toBe(false);
+      expect(isNextDataPathname("/_next/data/abc/about")).toBe(false); // no .json
+      expect(isNextDataPathname("/data/abc/about.json")).toBe(false);
+    });
+  });
+
+  describe("parseNextDataPathname", () => {
+    const BUILD_ID = "abc123";
+
+    it("extracts the page pathname from a flat route", () => {
+      expect(parseNextDataPathname(`/_next/data/${BUILD_ID}/about.json`, BUILD_ID)).toEqual({
+        pagePathname: "/about",
+      });
+    });
+
+    it("preserves locale prefix (handled by downstream i18n resolver)", () => {
+      expect(parseNextDataPathname(`/_next/data/${BUILD_ID}/en/about.json`, BUILD_ID)).toEqual({
+        pagePathname: "/en/about",
+      });
+    });
+
+    it("preserves nested segments", () => {
+      expect(parseNextDataPathname(`/_next/data/${BUILD_ID}/blog/post-1.json`, BUILD_ID)).toEqual({
+        pagePathname: "/blog/post-1",
+      });
+    });
+
+    it("denormalizes `index` to `/`", () => {
+      expect(parseNextDataPathname(`/_next/data/${BUILD_ID}/index.json`, BUILD_ID)).toEqual({
+        pagePathname: "/",
+      });
+    });
+
+    it("denormalizes trailing `/index` to a directory", () => {
+      expect(parseNextDataPathname(`/_next/data/${BUILD_ID}/en/index.json`, BUILD_ID)).toEqual({
+        pagePathname: "/en",
+      });
+    });
+
+    it("returns null for a mismatched buildId", () => {
+      expect(parseNextDataPathname(`/_next/data/other-build/about.json`, BUILD_ID)).toBeNull();
+    });
+
+    it("returns null when the prefix is missing the trailing slash", () => {
+      expect(parseNextDataPathname(`/_next/data/${BUILD_ID}.json`, BUILD_ID)).toBeNull();
+    });
+
+    it("returns null for empty page segment", () => {
+      expect(parseNextDataPathname(`/_next/data/${BUILD_ID}/.json`, BUILD_ID)).toBeNull();
+    });
+
+    it("returns null for non-_next/data paths", () => {
+      expect(parseNextDataPathname("/about", BUILD_ID)).toBeNull();
+      expect(parseNextDataPathname("/_next/static/x.json", BUILD_ID)).toBeNull();
+    });
+
+    it("returns null when buildId is empty", () => {
+      expect(parseNextDataPathname(`/_next/data/abc/about.json`, "")).toBeNull();
+    });
+  });
+
+  describe("buildNextDataJsonResponse", () => {
+    it("returns a 200 JSON envelope with pageProps key", async () => {
+      const res = buildNextDataJsonResponse({ message: "hi" }, safeJsonStringify);
+      expect(res.status).toBe(200);
+      expect(res.headers.get("Content-Type")).toBe("application/json");
+      expect(await res.json()).toEqual({ pageProps: { message: "hi" } });
+    });
+  });
+
+  describe("buildNextDataNotFoundResponse", () => {
+    it("returns a 404 JSON response with empty body", async () => {
+      const res = buildNextDataNotFoundResponse();
+      expect(res.status).toBe(404);
+      expect(res.headers.get("Content-Type")).toBe("application/json");
+      // Body is `{}` — clients blindly calling `.json()` won't throw before
+      // checking the status code.
+      expect(await res.json()).toEqual({});
+    });
+  });
+});

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -1114,20 +1114,33 @@ describe("Pages Router integration", () => {
   // Ported from Next.js: test/e2e/middleware-general/test/index.test.ts
   // ("should trigger middleware for data requests").
   describe("/_next/data JSON endpoint", () => {
-    // In dev, the buildId is read from process.env.__VINEXT_BUILD_ID and
-    // falls back to "development" when unset (matching the entry generator).
-    const DEV_BUILD_ID = process.env.__VINEXT_BUILD_ID ?? "development";
+    // pages-basic's next.config.mjs pins the build id to "test-build-id".
+    // In dev the plugin now reads this from the resolved config so the
+    // value matches the prod-server's embedded buildId.
+    const BUILD_ID = "test-build-id";
 
     it("returns { pageProps } JSON for a getServerSideProps page", async () => {
-      const res = await fetch(`${baseUrl}/_next/data/${DEV_BUILD_ID}/ssr.json`);
+      const res = await fetch(`${baseUrl}/_next/data/${BUILD_ID}/ssr.json`);
       expect(res.status).toBe(200);
       expect(res.headers.get("content-type")).toContain("application/json");
       const json = (await res.json()) as { pageProps: { message: string } };
       expect(json.pageProps.message).toBe("Hello from getServerSideProps");
     });
 
+    it("returns { pageProps } JSON for a getStaticProps page", async () => {
+      // /isr-test uses getStaticProps with revalidate; the data endpoint
+      // must bypass the HTML ISR cache and surface the props as JSON
+      // (mirroring Next.js' `isNextDataRequest` cache-bypass path).
+      const res = await fetch(`${baseUrl}/_next/data/${BUILD_ID}/isr-test.json`);
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toContain("application/json");
+      const json = (await res.json()) as { pageProps: Record<string, unknown> };
+      expect(json).toHaveProperty("pageProps");
+      expect(typeof json.pageProps).toBe("object");
+    });
+
     it("normalizes the URL to /<page> BEFORE middleware runs", async () => {
-      const res = await fetch(`${baseUrl}/_next/data/${DEV_BUILD_ID}/ssr.json`);
+      const res = await fetch(`${baseUrl}/_next/data/${BUILD_ID}/ssr.json`);
       expect(res.status).toBe(200);
       // Middleware exposes the pathname it observed via `x-mw-pathname`.
       // The raw `/_next/data/...` should never reach the middleware function —
@@ -1139,11 +1152,24 @@ describe("Pages Router integration", () => {
     });
 
     it("returns 404 JSON for an unknown page", async () => {
-      const res = await fetch(`${baseUrl}/_next/data/${DEV_BUILD_ID}/totally-missing-page.json`);
+      const res = await fetch(`${baseUrl}/_next/data/${BUILD_ID}/totally-missing-page.json`);
       expect(res.status).toBe(404);
       expect(res.headers.get("content-type")).toContain("application/json");
       // Body must still be valid JSON so naive clients calling `.json()` do
       // not throw before checking the status code.
+      expect(await res.json()).toEqual({});
+    });
+
+    it("returns JSON 404 when getStaticPaths fallback:false rejects the path", async () => {
+      // /blog/[slug] has `fallback: false` and only allows the slugs listed
+      // in getStaticPaths. An unlisted slug must produce a JSON 404 for
+      // data requests (not the HTML 404 page) so the client router can
+      // hard-navigate instead of failing to parse HTML as JSON.
+      const res = await fetch(
+        `${baseUrl}/_next/data/${BUILD_ID}/blog/this-slug-does-not-exist.json`,
+      );
+      expect(res.status).toBe(404);
+      expect(res.headers.get("content-type")).toContain("application/json");
       expect(await res.json()).toEqual({});
     });
   });
@@ -3171,6 +3197,19 @@ describe("Production server middleware (Pages Router)", () => {
       expect(res.headers.get("content-type")).toContain("application/json");
       const json = (await res.json()) as { pageProps: { message: string } };
       expect(json.pageProps.message).toBe("Hello from getServerSideProps");
+    });
+
+    it("returns { pageProps } JSON for a getStaticProps page (bypasses HTML cache)", async () => {
+      // /isr-test uses getStaticProps with revalidate. The data endpoint
+      // must bypass the cached HTML body and surface pageProps as JSON —
+      // mirrors Next.js' `isNextDataRequest` cache-bypass logic in
+      // base-server.ts.
+      const res = await fetch(`${prodUrl}/_next/data/${BUILD_ID}/isr-test.json`);
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toContain("application/json");
+      const json = (await res.json()) as { pageProps: Record<string, unknown> };
+      expect(json).toHaveProperty("pageProps");
+      expect(typeof json.pageProps).toBe("object");
     });
 
     it("normalizes the URL to /<page> BEFORE middleware runs", async () => {

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -1109,6 +1109,44 @@ describe("Pages Router integration", () => {
     const res = await fetch(`${baseUrl}/`);
     expect(res.status).toBe(200);
   });
+
+  // ── /_next/data JSON endpoint (issue #1330) ──────────────────────
+  // Ported from Next.js: test/e2e/middleware-general/test/index.test.ts
+  // ("should trigger middleware for data requests").
+  describe("/_next/data JSON endpoint", () => {
+    // In dev, the buildId is read from process.env.__VINEXT_BUILD_ID and
+    // falls back to "development" when unset (matching the entry generator).
+    const DEV_BUILD_ID = process.env.__VINEXT_BUILD_ID ?? "development";
+
+    it("returns { pageProps } JSON for a getServerSideProps page", async () => {
+      const res = await fetch(`${baseUrl}/_next/data/${DEV_BUILD_ID}/ssr.json`);
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toContain("application/json");
+      const json = (await res.json()) as { pageProps: { message: string } };
+      expect(json.pageProps.message).toBe("Hello from getServerSideProps");
+    });
+
+    it("normalizes the URL to /<page> BEFORE middleware runs", async () => {
+      const res = await fetch(`${baseUrl}/_next/data/${DEV_BUILD_ID}/ssr.json`);
+      expect(res.status).toBe(200);
+      // Middleware exposes the pathname it observed via `x-mw-pathname`.
+      // The raw `/_next/data/...` should never reach the middleware function —
+      // Next.js normalizes it to `/ssr` first.
+      expect(res.headers.get("x-mw-pathname")).toBe("/ssr");
+      // The middleware also sets `x-custom-middleware: active` on every match,
+      // proving the middleware actually executed for this request.
+      expect(res.headers.get("x-custom-middleware")).toBe("active");
+    });
+
+    it("returns 404 JSON for an unknown page", async () => {
+      const res = await fetch(`${baseUrl}/_next/data/${DEV_BUILD_ID}/totally-missing-page.json`);
+      expect(res.status).toBe(404);
+      expect(res.headers.get("content-type")).toContain("application/json");
+      // Body must still be valid JSON so naive clients calling `.json()` do
+      // not throw before checking the status code.
+      expect(await res.json()).toEqual({});
+    });
+  });
 });
 
 describe("Pages Router dev server origin check", () => {
@@ -3117,6 +3155,49 @@ describe("Production server middleware (Pages Router)", () => {
     // Ensure encoded variants like /%2Evite/ are also blocked
     const res = await fetch(`${prodUrl}/%2Evite/ssr-manifest.json`);
     expect(res.status).toBe(404);
+  });
+
+  // ── /_next/data JSON endpoint in production (issue #1330) ─────────
+  // Ported from Next.js: test/e2e/middleware-general/test/index.test.ts
+  // ("should trigger middleware for data requests", "should normalize data
+  // requests into page requests").
+  describe("/_next/data JSON endpoint", () => {
+    // pages-basic's next.config.mjs pins the build id to "test-build-id".
+    const BUILD_ID = "test-build-id";
+
+    it("returns { pageProps } JSON for a getServerSideProps page", async () => {
+      const res = await fetch(`${prodUrl}/_next/data/${BUILD_ID}/ssr.json`);
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toContain("application/json");
+      const json = (await res.json()) as { pageProps: { message: string } };
+      expect(json.pageProps.message).toBe("Hello from getServerSideProps");
+    });
+
+    it("normalizes the URL to /<page> BEFORE middleware runs", async () => {
+      const res = await fetch(`${prodUrl}/_next/data/${BUILD_ID}/ssr.json`);
+      expect(res.status).toBe(200);
+      // The middleware fixture sets `x-mw-pathname` to whatever pathname it
+      // observed. If `_next/data` is not normalized first, middleware sees
+      // the raw `/_next/data/.../ssr.json` URL — which is the failure mode
+      // tracked in issue #1330 and surfaced by `middleware-general` tests
+      // in the deploy suite.
+      expect(res.headers.get("x-mw-pathname")).toBe("/ssr");
+      expect(res.headers.get("x-custom-middleware")).toBe("active");
+    });
+
+    it("returns JSON 404 for an unknown page", async () => {
+      const res = await fetch(`${prodUrl}/_next/data/${BUILD_ID}/totally-missing-page.json`);
+      expect(res.status).toBe(404);
+      expect(res.headers.get("content-type")).toContain("application/json");
+      expect(await res.json()).toEqual({});
+    });
+
+    it("returns JSON 404 for a stale buildId", async () => {
+      const res = await fetch(`${prodUrl}/_next/data/wrong-build-id/ssr.json`);
+      expect(res.status).toBe(404);
+      expect(res.headers.get("content-type")).toContain("application/json");
+      expect(await res.json()).toEqual({});
+    });
   });
 });
 

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -1172,6 +1172,16 @@ describe("Pages Router integration", () => {
       expect(res.headers.get("content-type")).toContain("application/json");
       expect(await res.json()).toEqual({});
     });
+
+    it("returns JSON 404 for a stale buildId (dev)", async () => {
+      // Mirrors the prod-server path: when the buildId in the URL doesn't
+      // match the resolved buildId we surface a JSON 404 right away so the
+      // client can hard-navigate (instead of parsing Vite's HTML 404).
+      const res = await fetch(`${baseUrl}/_next/data/wrong-build-id/ssr.json`);
+      expect(res.status).toBe(404);
+      expect(res.headers.get("content-type")).toContain("application/json");
+      expect(await res.json()).toEqual({});
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

Implements the `/_next/data/<buildId>/<page>.json` endpoint for the Pages Router in both dev and prod, so client-side navigations via `next/link` and `router.push()` work end-to-end on vinext.

- New helper `packages/vinext/src/server/pages-data-route.ts` parses the URL pattern and builds the JSON envelope. Unit-tested in `tests/pages-data-route.test.ts`.
- Request pipeline (dev `index.ts`, prod `prod-server.ts`) detects `_next/data` after basePath/trailing-slash normalization and rewrites the URL to the page path BEFORE middleware runs — matching Next.js' `handleNextDataRequest` (`packages/next/src/server/base-server.ts`).
- `renderPage` (generated entry) accepts an `isDataReq` option. When set, it skips React tree + `_document` shell rendering and emits the JSON envelope directly. Headers set by `getServerSideProps` are preserved.
- `resolvePagesPageData` bypasses the HTML ISR cache for data requests (a cached HTML body cannot be reshaped into JSON; storing JSON in the HTML cache would corrupt subsequent HTML hits) and now emits a JSON-shaped 404 body so naive clients calling `res.json()` do not throw before checking the status.

### JSON envelope shape

```json
{ "pageProps": { "message": "Hello from getServerSideProps" } }
```

`Content-Type: application/json`; status 200 for matched pages, 404 (with `{}` body) for unknown pages or a stale buildId.

### Middleware visibility

The pages-basic fixture middleware now sets `x-mw-pathname: <observed pathname>`. The new tests assert that requesting `/_next/data/<buildId>/ssr.json` makes middleware observe `/ssr` — proving the normalization happens before middleware runs.

## Test plan

- [x] `pnpm test tests/pages-data-route.test.ts` (14 new unit tests)
- [x] `pnpm test tests/pages-router.test.ts` (216 tests, including 3 new dev + 4 new prod integration tests for the endpoint)
- [x] `pnpm test tests/pages-page-data.test.ts tests/pages-i18n.test.ts tests/pages-i18n-prod.test.ts`
- [x] `pnpm test tests/app-router.test.ts` (318 tests — no regressions)
- [x] `pnpm run check` (format, lint, types green)
- [ ] CI green

## References

- Next.js source — pipeline normalization: [`base-server.ts` `handleNextDataRequest`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/base-server.ts)
- Next.js source — JSON envelope emission: [`render.tsx` `isNextDataRequest` branch](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/render.tsx)
- Next.js test — middleware visibility: [`test/e2e/middleware-general/test/index.test.ts`](https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-general/test/index.test.ts) (`should trigger middleware for data requests`, `should normalize data requests into page requests`)

Closes #1330