### PR TITLE
fix(build): avoid __dirname shim conflicts and cover node_modules

### DIFF
--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -582,6 +582,65 @@ export function reassignsModuleExports(source: string): boolean {
 }
 
 /**
+ * Detect which of the CJS-style identifiers (`__filename`, `__dirname`) the
+ * user already declares themselves with `const`, `let`, or `var`. Used by the
+ * injector to skip duplicate declarations that would otherwise fail with
+ * "Identifier `__dirname` has already been declared" under OXC/Rolldown.
+ *
+ * Skips identifiers that appear inside strings, template literals, and
+ * comments so a docstring like `/* sets __dirname *\/` doesn't suppress the
+ * shim. Recognizes plain bindings (`const __dirname = ...`), comma-continued
+ * declarators (`const x = 1, __dirname = ...`), and identifier destructuring
+ * (`const { __dirname } = ...` / `const { foo: __dirname } = ...`). Bare
+ * declarations without initializer (`let __dirname;`) are also caught — they
+ * still create a binding that collides with the injected `const`.
+ *
+ * False negatives are the safe failure mode: if we fail to detect a
+ * declaration, the existing collision error surfaces (no silent miscompile).
+ * False positives would skip the shim and turn an injected `const` into a
+ * ReferenceError, so the regex deliberately requires a binding keyword and
+ * skips string/template/comment contexts.
+ */
+export function findUserDeclaredCjsGlobals(source: string): {
+  __dirname: boolean;
+  __filename: boolean;
+} {
+  const declared = { __dirname: false, __filename: false };
+
+  // First pass: blank out comments / strings / template literals so
+  // identifiers inside them aren't matched. Replace each masked span with
+  // an equal number of spaces so indices stay aligned with the original
+  // source — useful if this function later returns positions.
+  const masked = source.replace(
+    /\/\*[\s\S]*?\*\/|\/\/[^\n]*|`(?:[^`\\$]|\\.|\$(?!\{))*`|"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'/g,
+    (m) => " ".repeat(m.length),
+  );
+
+  // Second pass: for each `const|let|var` declarator statement, look at
+  // the head of the statement (up to the next `;` or top-level statement
+  // boundary) for `__dirname`/`__filename` appearing in a binding position.
+  //
+  // Binding position = preceded (after whitespace) by the declarator
+  // keyword itself, a comma, an opening brace, or a colon (object-pattern
+  // alias). Anything preceded by `=` is the initializer side and ignored,
+  // so `const x = __dirname;` does NOT count as declaring `__dirname`.
+  const declStmt = /\b(const|let|var)\b([^;]*)/g;
+  let stmt: RegExpExecArray | null;
+  while ((stmt = declStmt.exec(masked)) !== null) {
+    const body = stmt[2];
+    const bindingRegex = /(?:^|[,{:]|\b(?:const|let|var)\b)\s*(__dirname|__filename)\b/g;
+    let bind: RegExpExecArray | null;
+    while ((bind = bindingRegex.exec(body)) !== null) {
+      const name = bind[1];
+      if (name === "__dirname") declared.__dirname = true;
+      else if (name === "__filename") declared.__filename = true;
+    }
+    if (declared.__dirname && declared.__filename) break;
+  }
+  return declared;
+}
+
+/**
  * Vite plugin that prepends CJS-style globals (`__filename`, `__dirname`,
  * `module`, `exports`, `require`) to the next.config.* source before
  * Vite's module runner evaluates it.
@@ -648,12 +707,27 @@ function cjsGlobalsInjectorPlugin(configPath: string): {
           `export const ${VINEXT_CJS_INITIAL_KEY} = __vinextInitialExports;\n`
         : "";
 
+      // Skip injecting `__dirname` / `__filename` shims when the user has
+      // already declared the same identifier with `const` / `let` / `var`.
+      // OXC/Rolldown reject a duplicate `const` declaration with
+      // "Identifier `__dirname` has already been declared", which is a real
+      // pattern in next.config.ts files written for Next.js v16 (Next.js
+      // sometimes ships configs containing `const __dirname =
+      // fileURLToPath(import.meta.url)` to polyfill the ESM module scope).
+      // The user's own declaration carries the same value semantics we'd
+      // inject, so dropping our line is correct, not a behavioural change.
+      const userDeclared = findUserDeclaredCjsGlobals(code);
+
       // Preamble runs after ESM imports are hoisted; the const bindings shadow
       // any global lookups the source would otherwise perform.
+      const filenameLine = userDeclared.__filename
+        ? ""
+        : `const __filename = ${filenameLiteral};\n`;
+      const dirnameLine = userDeclared.__dirname ? "" : `const __dirname = ${dirnameLiteral};\n`;
       const preamble =
         `import { createRequire as __vinextCreateRequire } from "node:module";\n` +
-        `const __filename = ${filenameLiteral};\n` +
-        `const __dirname = ${dirnameLiteral};\n` +
+        filenameLine +
+        dirnameLine +
         `const require = __vinextCreateRequire(${requireBaseLiteral});\n` +
         moduleLines;
 

--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -16,6 +16,7 @@ import { getHtmlLimitedBotRegex } from "../utils/html-limited-bots.js";
 import { isUnknownRecord } from "../utils/record.js";
 import { applyLocaleToRoutes, isExternalUrl } from "./config-matchers.js";
 import { loadTsconfigPathAliasesForRoot } from "./tsconfig-paths.js";
+import { maskStringsAndComments } from "../utils/mask-source.js";
 
 /**
  * Parse a body size limit value (string or number) into bytes.
@@ -608,13 +609,10 @@ export function findUserDeclaredCjsGlobals(source: string): {
   const declared = { __dirname: false, __filename: false };
 
   // First pass: blank out comments / strings / template literals so
-  // identifiers inside them aren't matched. Replace each masked span with
-  // an equal number of spaces so indices stay aligned with the original
-  // source — useful if this function later returns positions.
-  const masked = source.replace(
-    /\/\*[\s\S]*?\*\/|\/\/[^\n]*|`(?:[^`\\$]|\\.|\$(?!\{))*`|"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'/g,
-    (m) => " ".repeat(m.length),
-  );
+  // identifiers inside them aren't matched. Indices stay aligned with the
+  // original source so the second-pass statement extraction can rely on
+  // positions when needed.
+  const masked = maskStringsAndComments(source);
 
   // Second pass: for each `const|let|var` declarator statement, look at
   // the head of the statement (up to the next `;` or top-level statement
@@ -624,11 +622,17 @@ export function findUserDeclaredCjsGlobals(source: string): {
   // keyword itself, a comma, an opening brace, or a colon (object-pattern
   // alias). Anything preceded by `=` is the initializer side and ignored,
   // so `const x = __dirname;` does NOT count as declaring `__dirname`.
+  //
+  // The trailing negative lookahead `(?!\s*:)` ensures we do not treat the
+  // *property key* of an object-pattern alias as a binding. In
+  // `const { __dirname: localAlias } = ...`, the actual bound identifier
+  // is `localAlias`; the literal text `__dirname` is the source-side key,
+  // not a top-level declaration that would collide with the injector.
   const declStmt = /\b(const|let|var)\b([^;]*)/g;
   let stmt: RegExpExecArray | null;
   while ((stmt = declStmt.exec(masked)) !== null) {
     const body = stmt[2];
-    const bindingRegex = /(?:^|[,{:]|\b(?:const|let|var)\b)\s*(__dirname|__filename)\b/g;
+    const bindingRegex = /(?:^|[,{:]|\b(?:const|let|var)\b)\s*(__dirname|__filename)\b(?!\s*:)/g;
     let bind: RegExpExecArray | null;
     while ((bind = bindingRegex.exec(body)) !== null) {
       const name = bind[1];

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -137,6 +137,7 @@ import {
 } from "./build/ssr-manifest.js";
 import { stripServerExports } from "./plugins/strip-server-exports.js";
 import { removeConsoleCalls } from "./plugins/remove-console.js";
+import { cjsGlobalsShimPlugin } from "./plugins/cjs-globals-shim.js";
 import { hasMdxFiles } from "./utils/mdx-scan.js";
 import { scanPublicFileRoutes } from "./utils/public-routes.js";
 import tsconfigPaths from "vite-tsconfig-paths";
@@ -2344,6 +2345,10 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
     },
     // Stub node:async_hooks in client builds — see src/plugins/async-hooks-stub.ts
     asyncHooksStubPlugin,
+    // Inject __dirname / __filename shims into bundled node_modules code that
+    // touches the CJS globals in ESM server output —
+    // see src/plugins/cjs-globals-shim.ts
+    cjsGlobalsShimPlugin,
     createInstrumentationClientTransformPlugin(() => instrumentationClientPath),
     {
       name: "vinext:instrumentation-client-inject",

--- a/packages/vinext/src/plugins/cjs-globals-shim.ts
+++ b/packages/vinext/src/plugins/cjs-globals-shim.ts
@@ -1,0 +1,152 @@
+import type { Plugin } from "vite";
+
+/**
+ * Detect whether the source contains a bare reference to `__dirname` or
+ * `__filename` outside of strings, template literals, and comments. Mirrors
+ * the conservative "skip masked spans first" strategy used by
+ * {@link findUserDeclaredCjsGlobals} so a docstring like
+ * `/* uses __dirname *\/` doesn't force the shim into modules that don't
+ * actually need it.
+ *
+ * The return value reports each identifier independently so the injected
+ * preamble can hoist only the bindings actually used by the module — keeping
+ * the per-module patch size minimal and avoiding spurious imports.
+ */
+export function detectCjsGlobalReferences(source: string): {
+  __dirname: boolean;
+  __filename: boolean;
+} {
+  // Quick reject: the strict masked scan below is comparatively expensive on
+  // hot paths (every node_modules .js/.mjs/.cjs goes through the transform
+  // pipeline), so first verify the source contains the identifier at all.
+  if (!/__dirname|__filename/.test(source)) {
+    return { __dirname: false, __filename: false };
+  }
+
+  const masked = source.replace(
+    /\/\*[\s\S]*?\*\/|\/\/[^\n]*|`(?:[^`\\$]|\\.|\$(?!\{))*`|"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'/g,
+    (m) => " ".repeat(m.length),
+  );
+
+  return {
+    __dirname: /\b__dirname\b/.test(masked),
+    __filename: /\b__filename\b/.test(masked),
+  };
+}
+
+/**
+ * Per-module preamble that defines `__dirname` / `__filename` for ESM-bundled
+ * CommonJS code. Used as the body of the {@link cjsGlobalsShimPlugin}
+ * transform output.
+ *
+ * The bindings are scoped to the transformed module (Vite's `transform`
+ * runs before bundling, so each module's source is patched independently).
+ * After Rolldown concatenates modules, the bindings become unique top-level
+ * `const`s in the bundle thanks to the bundler's identifier renaming.
+ *
+ * `import.meta.url` resolves to the *bundle's* output URL at runtime, not
+ * the original `node_modules` location. That is intentional: the goal of
+ * this shim is to prevent `ReferenceError: __dirname is not defined` for
+ * libraries that touch these identifiers defensively (e.g. `typeof
+ * __dirname === "string"`, log paths, debug strings). Libraries that load
+ * sibling assets through `__dirname` need to be externalized instead — a
+ * shim cannot recreate the original on-disk layout post-bundle.
+ *
+ * The helper imports are aliased so they cannot collide with user-declared
+ * names like `dirname` or `fileURLToPath` already imported by the module.
+ */
+export function buildCjsGlobalsShimPreamble(needs: {
+  __dirname: boolean;
+  __filename: boolean;
+}): string {
+  if (!needs.__dirname && !needs.__filename) return "";
+
+  const lines: string[] = [`import { fileURLToPath as __vinext_fileURLToPath } from "node:url";`];
+  if (needs.__dirname) {
+    lines.push(`import { dirname as __vinext_dirname } from "node:path";`);
+  }
+  if (needs.__filename) {
+    lines.push(`const __filename = __vinext_fileURLToPath(import.meta.url);`);
+  }
+  if (needs.__dirname) {
+    // Reuse the local __filename when we already declared it, otherwise
+    // compute it inline. Avoids declaring an unused __filename binding.
+    if (needs.__filename) {
+      lines.push(`const __dirname = __vinext_dirname(__filename);`);
+    } else {
+      lines.push(`const __dirname = __vinext_dirname(__vinext_fileURLToPath(import.meta.url));`);
+    }
+  }
+  return lines.join("\n") + "\n";
+}
+
+/**
+ * Vite plugin that injects local `__dirname` / `__filename` shims into
+ * third-party `node_modules` code that references those CJS globals but is
+ * bundled into an ESM server output (`"type": "module"`).
+ *
+ * Why: vinext's production server build emits ESM (`output.format: "esm"`,
+ * `package.json#type === "module"`). The Node ESM module scope does not
+ * expose the CJS-style `__dirname` / `__filename` globals, so any
+ * `node_modules` dependency that touches them — even defensively, like
+ * `typeof __dirname === "string"` or for log messages — crashes the bundled
+ * worker with `ReferenceError: __dirname is not defined in ES module scope`.
+ *
+ * vinext already injects these shims into the user's `next.config.ts`
+ * (see `config/next-config.ts`), but that transform is keyed to the config
+ * file path. Third-party packages bundled into the server entry need the
+ * same treatment, scoped per-module so user code declaring its own
+ * `__dirname` is unaffected.
+ *
+ * Scope:
+ *   - Only `node_modules` files (user code stays untouched — user-source
+ *     `__dirname` is a real bug we want to surface, not silently shim).
+ *   - Only `.js` / `.mjs` / `.cjs` extensions (TypeScript files inside
+ *     `node_modules` are unusual and typically pass through their own
+ *     compiler first).
+ *   - Only server-side environments (`ssr`, `rsc`). The browser environment
+ *     doesn't ship CJS globals at all and clients almost never reference
+ *     them — adding a shim there would inject `node:url` imports that the
+ *     browser-target build would have to externalize.
+ *
+ * Limitation: `import.meta.url` after bundling points at the *bundle*, not
+ * the original module location. Libraries that load sibling files through
+ * `__dirname` (native `.node` addons, embedded `.wasm`, etc.) should be
+ * externalized via `next.config.serverExternalPackages` instead. This shim
+ * only prevents the `ReferenceError`; it does not preserve filesystem
+ * semantics.
+ */
+export const cjsGlobalsShimPlugin: Plugin = {
+  name: "vinext:cjs-globals-shim",
+  enforce: "pre",
+
+  transform: {
+    filter: { id: /\/node_modules\/.+\.(?:m?js|cjs)(?:\?.*)?$/ },
+    handler(code, id) {
+      // Server-only: see plugin docstring. The Vite environment API exposes
+      // the current environment name to plugin handlers via `this.environment`.
+      const envName = this.environment?.name;
+      if (envName !== "ssr" && envName !== "rsc") return null;
+
+      // Strip any query suffix before the filter recheck. Vite passes ids
+      // with `?v=…` cache busters that the filter regex already allows
+      // through, but downstream logic only cares about the source text.
+      void id;
+
+      const needs = detectCjsGlobalReferences(code);
+      if (!needs.__dirname && !needs.__filename) return null;
+
+      const preamble = buildCjsGlobalsShimPreamble(needs);
+      return {
+        code: preamble + code,
+        // Source map is intentionally null: the preamble is prepended without
+        // line offsets in the original source map. A precise map would
+        // require MagicString plumbing; the trade-off here favours zero
+        // overhead in the hot transform path. Stack traces still resolve to
+        // the original source via the bundler's combined sourcemap once the
+        // module is concatenated.
+        map: null,
+      };
+    },
+  },
+};

--- a/packages/vinext/src/plugins/cjs-globals-shim.ts
+++ b/packages/vinext/src/plugins/cjs-globals-shim.ts
@@ -1,4 +1,5 @@
 import type { Plugin } from "vite";
+import { maskStringsAndComments } from "../utils/mask-source.js";
 
 /**
  * Detect whether the source contains a bare reference to `__dirname` or
@@ -23,10 +24,7 @@ export function detectCjsGlobalReferences(source: string): {
     return { __dirname: false, __filename: false };
   }
 
-  const masked = source.replace(
-    /\/\*[\s\S]*?\*\/|\/\/[^\n]*|`(?:[^`\\$]|\\.|\$(?!\{))*`|"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'/g,
-    (m) => " ".repeat(m.length),
-  );
+  const masked = maskStringsAndComments(source);
 
   return {
     __dirname: /\b__dirname\b/.test(masked),
@@ -128,9 +126,9 @@ export const cjsGlobalsShimPlugin: Plugin = {
       const envName = this.environment?.name;
       if (envName !== "ssr" && envName !== "rsc") return null;
 
-      // Strip any query suffix before the filter recheck. Vite passes ids
-      // with `?v=…` cache busters that the filter regex already allows
-      // through, but downstream logic only cares about the source text.
+      // `id` is consumed by the Vite filter (the regex above admits ids
+      // with optional `?…` cache busters) and is not used inside the
+      // handler body — the transform only operates on the source text.
       void id;
 
       const needs = detectCjsGlobalReferences(code);

--- a/packages/vinext/src/utils/mask-source.ts
+++ b/packages/vinext/src/utils/mask-source.ts
@@ -1,0 +1,39 @@
+/**
+ * Source-masking helpers shared by the CJS-global shim plugins.
+ *
+ * Both the `next.config.ts` injector (`config/next-config.ts`) and the
+ * `node_modules` shim (`plugins/cjs-globals-shim.ts`) need to scan source
+ * code for bare identifier references / declarations *without* matching
+ * tokens that happen to appear inside string literals, template literals,
+ * or comments. They originally inlined the same regex; this module owns
+ * the canonical version so the two callers cannot drift apart.
+ */
+
+/**
+ * Single alternation that captures (and consumes) each kind of span we
+ * want to ignore. Order matters: the block-comment branch must come
+ * before the line-comment branch so `/* ... *\/` containing `//` is
+ * matched as one block, and string-literal branches must consume the
+ * full literal so embedded `*\/` or `//` don't terminate the wrong span.
+ *
+ * Template literals are matched segment-by-segment, stopping before
+ * `${` so the interpolation contents themselves remain visible to the
+ * scan (`__dirname` inside `${__dirname}/views` is a real reference).
+ */
+const MASK_REGEX =
+  /\/\*[\s\S]*?\*\/|\/\/[^\n]*|`(?:[^`\\$]|\\.|\$(?!\{))*`|"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'/g;
+
+/**
+ * Replace strings, template literals, and comments in `source` with an
+ * equal-length run of spaces. Preserves byte/character offsets so the
+ * returned string can be scanned with regexes whose match indices line up
+ * with positions in the original source — useful when callers later need
+ * to extract surrounding context (e.g. statement boundaries).
+ *
+ * Template-literal *expressions* (`${...}`) remain visible after masking
+ * because the regex stops before `${`. Identifiers used inside an
+ * interpolation are real references and must not be hidden.
+ */
+export function maskStringsAndComments(source: string): string {
+  return source.replace(MASK_REGEX, (m) => " ".repeat(m.length));
+}

--- a/tests/cjs-globals-shim.test.ts
+++ b/tests/cjs-globals-shim.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect } from "vite-plus/test";
+import {
+  buildCjsGlobalsShimPreamble,
+  cjsGlobalsShimPlugin,
+  detectCjsGlobalReferences,
+} from "../packages/vinext/src/plugins/cjs-globals-shim.js";
+
+// The transform handler may live inside an object-style hook
+// (`{ filter, handler }`) on Vite 8+. Resolve either shape to the
+// underlying function so the tests can invoke it directly with a fake
+// plugin `this` context.
+function getTransformHandler(): (
+  this: { environment?: { name: string } },
+  code: string,
+  id: string,
+) => { code: string; map: null } | null | undefined {
+  const transform = cjsGlobalsShimPlugin.transform;
+  if (!transform) throw new Error("cjsGlobalsShimPlugin has no transform hook");
+  if (typeof transform === "function") {
+    return transform as unknown as (
+      this: { environment?: { name: string } },
+      code: string,
+      id: string,
+    ) => { code: string; map: null } | null | undefined;
+  }
+  return transform.handler as unknown as (
+    this: { environment?: { name: string } },
+    code: string,
+    id: string,
+  ) => { code: string; map: null } | null | undefined;
+}
+
+describe("detectCjsGlobalReferences", () => {
+  it("returns both false when neither identifier appears", () => {
+    expect(detectCjsGlobalReferences(`export const x = 1;`)).toEqual({
+      __dirname: false,
+      __filename: false,
+    });
+  });
+
+  it("detects bare __dirname reference", () => {
+    expect(detectCjsGlobalReferences(`console.log(__dirname);`)).toEqual({
+      __dirname: true,
+      __filename: false,
+    });
+  });
+
+  it("detects bare __filename reference", () => {
+    expect(detectCjsGlobalReferences(`const f = typeof __filename;`)).toEqual({
+      __dirname: false,
+      __filename: true,
+    });
+  });
+
+  it("does not match inside strings", () => {
+    expect(detectCjsGlobalReferences(`const s = "hello __dirname world";`)).toEqual({
+      __dirname: false,
+      __filename: false,
+    });
+  });
+
+  it("does not match inside template literals (outside ${})", () => {
+    expect(detectCjsGlobalReferences("const t = `text __filename inline`;")).toEqual({
+      __dirname: false,
+      __filename: false,
+    });
+  });
+
+  it("does match inside template ${} interpolations", () => {
+    // Inside `${...}` is code, not literal text — references there are real.
+    expect(detectCjsGlobalReferences("const t = `pre ${__dirname} post`;")).toEqual({
+      __dirname: true,
+      __filename: false,
+    });
+  });
+
+  it("does not match inside comments", () => {
+    expect(detectCjsGlobalReferences(`// uses __dirname inside\nexport const x = 1;`)).toEqual({
+      __dirname: false,
+      __filename: false,
+    });
+    expect(detectCjsGlobalReferences(`/* __filename hint */ const x = 1;`)).toEqual({
+      __dirname: false,
+      __filename: false,
+    });
+  });
+
+  it("detects identifiers used as object keys when bare", () => {
+    expect(detectCjsGlobalReferences(`const x = { __dirname };`)).toEqual({
+      __dirname: true,
+      __filename: false,
+    });
+  });
+});
+
+describe("buildCjsGlobalsShimPreamble", () => {
+  it("returns empty string when nothing is needed", () => {
+    expect(buildCjsGlobalsShimPreamble({ __dirname: false, __filename: false })).toBe("");
+  });
+
+  it("emits __filename only when only __filename is needed", () => {
+    const out = buildCjsGlobalsShimPreamble({ __dirname: false, __filename: true });
+    expect(out).toContain(`import { fileURLToPath as __vinext_fileURLToPath } from "node:url"`);
+    expect(out).toContain(`const __filename = __vinext_fileURLToPath(import.meta.url);`);
+    expect(out).not.toContain("__dirname");
+    expect(out).not.toContain("node:path");
+  });
+
+  it("emits __dirname only when only __dirname is needed", () => {
+    const out = buildCjsGlobalsShimPreamble({ __dirname: true, __filename: false });
+    expect(out).toContain(`import { dirname as __vinext_dirname } from "node:path"`);
+    expect(out).toContain("const __dirname = __vinext_dirname(__vinext_fileURLToPath");
+    // Should not redeclare __filename when not needed.
+    expect(out).not.toMatch(/const __filename =/);
+  });
+
+  it("emits both bindings and reuses __filename for __dirname when both are needed", () => {
+    const out = buildCjsGlobalsShimPreamble({ __dirname: true, __filename: true });
+    expect(out).toContain(`const __filename = __vinext_fileURLToPath(import.meta.url);`);
+    expect(out).toContain(`const __dirname = __vinext_dirname(__filename);`);
+  });
+});
+
+describe("cjsGlobalsShimPlugin.transform", () => {
+  it("skips files outside node_modules via the filter", () => {
+    // Filter is enforced by Vite; when present the handler isn't invoked for
+    // non-matching ids. Verify the filter shape statically.
+    const transform = cjsGlobalsShimPlugin.transform;
+    expect(transform).toBeTruthy();
+    if (transform && typeof transform === "object") {
+      expect(transform.filter?.id).toBeInstanceOf(RegExp);
+      const re = transform.filter?.id as RegExp;
+      expect(re.test("/repo/src/index.js")).toBe(false);
+      expect(re.test("/repo/node_modules/foo/index.js")).toBe(true);
+      expect(re.test("/repo/node_modules/foo/index.mjs")).toBe(true);
+      expect(re.test("/repo/node_modules/foo/index.cjs")).toBe(true);
+      expect(re.test("/repo/node_modules/foo/index.ts")).toBe(false);
+      // Query suffix tolerated
+      expect(re.test("/repo/node_modules/foo/index.js?v=abc")).toBe(true);
+    }
+  });
+
+  it("returns null when called in a non-server environment", () => {
+    const handler = getTransformHandler();
+    const ret = handler.call(
+      { environment: { name: "client" } },
+      `console.log(__dirname);`,
+      "/repo/node_modules/foo/index.js",
+    );
+    expect(ret).toBeNull();
+  });
+
+  it("returns null when source does not reference the globals", () => {
+    const handler = getTransformHandler();
+    const ret = handler.call(
+      { environment: { name: "ssr" } },
+      `export const x = 1;`,
+      "/repo/node_modules/foo/index.js",
+    );
+    expect(ret).toBeNull();
+  });
+
+  it("prepends the shim for ssr environment", () => {
+    const handler = getTransformHandler();
+    const ret = handler.call(
+      { environment: { name: "ssr" } },
+      `console.log(__dirname, __filename);`,
+      "/repo/node_modules/foo/index.js",
+    );
+    expect(ret).not.toBeNull();
+    expect(ret?.code).toContain(`const __filename = __vinext_fileURLToPath(import.meta.url);`);
+    expect(ret?.code).toContain(`const __dirname = __vinext_dirname(__filename);`);
+    expect(ret?.code.endsWith(`console.log(__dirname, __filename);`)).toBe(true);
+  });
+
+  it("prepends the shim for rsc environment", () => {
+    const handler = getTransformHandler();
+    const ret = handler.call(
+      { environment: { name: "rsc" } },
+      `if (typeof __dirname === "string") {}`,
+      "/repo/node_modules/lib/runtime.mjs",
+    );
+    expect(ret).not.toBeNull();
+    expect(ret?.code).toContain(`const __dirname =`);
+  });
+
+  it("only injects what is needed (single binding)", () => {
+    const handler = getTransformHandler();
+    const ret = handler.call(
+      { environment: { name: "ssr" } },
+      `console.log(__filename);`,
+      "/repo/node_modules/foo/index.js",
+    );
+    expect(ret?.code).toContain(`const __filename = __vinext_fileURLToPath(import.meta.url);`);
+    // __dirname was not referenced, so it must not be declared.
+    expect(ret?.code).not.toMatch(/const __dirname/);
+    // And node:path should not be imported.
+    expect(ret?.code).not.toContain(`node:path`);
+  });
+});

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import {
   detectNextIntlConfig,
+  findUserDeclaredCjsGlobals,
   loadNextConfig,
   parseBodySizeLimit,
   reassignsModuleExports,
@@ -228,6 +229,47 @@ describe("loadNextConfig with CJS globals in next.config.ts", () => {
     expect(config?.env?.VIA).toBe("module.exports");
   });
 
+  it("does not redeclare __dirname when user already declares it", async () => {
+    // Regression for https://github.com/cloudflare/vinext/issues/1345.
+    // Some next.config.ts files written for the Next.js v16 deploy suite
+    // declare their own ESM-style `__dirname` polyfill. vinext must skip
+    // injecting `const __dirname = ...` for those configs to avoid a
+    // "Identifier `__dirname` has already been declared" parse error.
+    tmpDir = makeTempDir();
+    fs.writeFileSync(
+      path.join(tmpDir, "next.config.ts"),
+      `import { fileURLToPath } from "node:url";\n` +
+        `import { dirname } from "node:path";\n` +
+        `const __filename = fileURLToPath(import.meta.url);\n` +
+        `const __dirname = dirname(__filename);\n` +
+        `export default { env: { OWN_DIR: __dirname, OWN_FILE: __filename } };\n`,
+    );
+
+    const config = await loadNextConfig(tmpDir);
+    const ownFile = config?.env?.OWN_FILE as string | undefined;
+    expect(typeof config?.env?.OWN_DIR).toBe("string");
+    expect(ownFile?.endsWith("next.config.ts")).toBe(true);
+  });
+
+  it("does not redeclare __dirname when only __dirname is user-declared", async () => {
+    // Mixed case: user declares only __dirname themselves, but still
+    // references __filename. The injector must skip the user-declared
+    // identifier and still provide the other.
+    tmpDir = makeTempDir();
+    fs.writeFileSync(
+      path.join(tmpDir, "next.config.ts"),
+      `import { fileURLToPath } from "node:url";\n` +
+        `import { dirname } from "node:path";\n` +
+        `const __dirname = dirname(fileURLToPath(import.meta.url));\n` +
+        `export default { env: { OWN_DIR: __dirname, FNAME: __filename } };\n`,
+    );
+
+    const config = await loadNextConfig(tmpDir);
+    const fname = config?.env?.FNAME as string | undefined;
+    expect(typeof config?.env?.OWN_DIR).toBe("string");
+    expect(fname?.endsWith("next.config.ts")).toBe(true);
+  });
+
   it("loads a pure-ESM next.config.ts without injecting CJS shims", async () => {
     // No __filename / __dirname / require / module / exports references —
     // the injector transform should short-circuit. We only assert
@@ -277,6 +319,92 @@ describe("referencesCjsGlobals", () => {
     // worst case, never a correctness bug.
     expect(referencesCjsGlobals(`// __dirname is shimmed`)).toBe(true);
     expect(referencesCjsGlobals(`const s = "module.exports = 1";`)).toBe(true);
+  });
+});
+
+describe("findUserDeclaredCjsGlobals", () => {
+  it("returns both false for pure ESM source", () => {
+    expect(findUserDeclaredCjsGlobals(`export default { env: { FOO: "bar" } };\n`)).toEqual({
+      __dirname: false,
+      __filename: false,
+    });
+  });
+
+  it("detects const __dirname declarations", () => {
+    expect(findUserDeclaredCjsGlobals(`const __dirname = fileURLToPath(import.meta.url);`)).toEqual(
+      { __dirname: true, __filename: false },
+    );
+  });
+
+  it("detects const __filename declarations", () => {
+    expect(findUserDeclaredCjsGlobals(`const __filename = "/tmp/foo";`)).toEqual({
+      __dirname: false,
+      __filename: true,
+    });
+  });
+
+  it("detects let / var declarations too", () => {
+    expect(findUserDeclaredCjsGlobals(`let __dirname = "/x";`)).toEqual({
+      __dirname: true,
+      __filename: false,
+    });
+    expect(findUserDeclaredCjsGlobals(`var __filename = "/x";`)).toEqual({
+      __dirname: false,
+      __filename: true,
+    });
+  });
+
+  it("detects bare declarations without initializer", () => {
+    expect(findUserDeclaredCjsGlobals(`let __dirname;`)).toEqual({
+      __dirname: true,
+      __filename: false,
+    });
+  });
+
+  it("detects comma-continued declarators", () => {
+    expect(findUserDeclaredCjsGlobals(`const x = 1, __dirname = "/x";`)).toEqual({
+      __dirname: true,
+      __filename: false,
+    });
+  });
+
+  it("detects object-destructure patterns", () => {
+    expect(findUserDeclaredCjsGlobals(`const { __dirname } = somewhere;`)).toEqual({
+      __dirname: true,
+      __filename: false,
+    });
+  });
+
+  it("does not match inside strings or comments", () => {
+    expect(findUserDeclaredCjsGlobals(`const s = "const __dirname = 1";`)).toEqual({
+      __dirname: false,
+      __filename: false,
+    });
+    expect(findUserDeclaredCjsGlobals(`// const __dirname = "/x";`)).toEqual({
+      __dirname: false,
+      __filename: false,
+    });
+    expect(findUserDeclaredCjsGlobals(`/* const __filename = "x" */`)).toEqual({
+      __dirname: false,
+      __filename: false,
+    });
+  });
+
+  it("does not match bare references", () => {
+    // References to __dirname (without a binding keyword) should not be
+    // treated as user-owned declarations — those still need the shim.
+    expect(findUserDeclaredCjsGlobals(`const x = __dirname;`)).toEqual({
+      __dirname: false,
+      __filename: false,
+    });
+  });
+
+  it("detects both when both are declared", () => {
+    expect(
+      findUserDeclaredCjsGlobals(
+        `const __filename = fileURLToPath(import.meta.url);\nconst __dirname = dirname(__filename);\n`,
+      ),
+    ).toEqual({ __dirname: true, __filename: true });
   });
 });
 

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -406,6 +406,28 @@ describe("findUserDeclaredCjsGlobals", () => {
       ),
     ).toEqual({ __dirname: true, __filename: true });
   });
+
+  it("does not treat object-key __dirname as a declaration", () => {
+    // `__dirname` here is the *key* of an object literal initializer, not
+    // a top-level declaration. The actual binding is `cfg`. Skipping the
+    // shim because of this match would turn the user's intended runtime
+    // reference into a ReferenceError.
+    expect(findUserDeclaredCjsGlobals(`const cfg = { __dirname: 1 };`)).toEqual({
+      __dirname: false,
+      __filename: false,
+    });
+  });
+
+  it("does not treat object-pattern alias key as a declaration", () => {
+    // In `const { __dirname: alias } = src`, the literal `__dirname` is
+    // the source-side key and `alias` is what binds. The injected shim's
+    // top-level `const __dirname = ...` does not collide with `alias`,
+    // so no skip is warranted.
+    expect(findUserDeclaredCjsGlobals(`const { __dirname: alias } = src;`)).toEqual({
+      __dirname: false,
+      __filename: false,
+    });
+  });
 });
 
 describe("reassignsModuleExports", () => {


### PR DESCRIPTION
## Summary

Two related fixes to vinext's CommonJS-global shim injection that surfaced on the Next.js v16 deploy suite:

- **next.config.ts.** When the user's config already declared `const __dirname = fileURLToPath(import.meta.url)` (a real pattern in Next.js v16-style configs), the injector still emitted its own `const __dirname = ...` and OXC rejected the duplicate `const`. New `findUserDeclaredCjsGlobals` helper masks strings/comments and detects existing `const/let/var __dirname` / `__filename` bindings (plain, comma-continued, or object-destructure); the injector skips those names.
- **node_modules ReferenceError.** Bundled third-party packages reference `__dirname` / `__filename`, but the server entry is emitted as ESM (`type: module`) where those CJS globals do not exist. New `vinext:cjs-globals-shim` plugin runs in the `ssr` / `rsc` environments only, targets `node_modules` `.js/.mjs/.cjs` files containing bare references, and prepends a per-module preamble that declares both bindings via `import.meta.url` + `fileURLToPath` + `dirname` (helpers imported under `__vinext_*` aliases to avoid colliding with user imports).

The shim only prevents the `ReferenceError`. Libraries that load sibling on-disk assets through `__dirname` (native addons, embedded wasm) still need to be externalized via `serverExternalPackages` — `import.meta.url` after bundling points at the bundle, not the original module location.

## Test plan

- [x] `pnpm test tests/next-config.test.ts` (125 tests pass, including new regressions for user-declared `__dirname` / `__filename` and helper-level coverage of `findUserDeclaredCjsGlobals`)
- [x] `pnpm test tests/cjs-globals-shim.test.ts` (18 new tests covering `detectCjsGlobalReferences`, `buildCjsGlobalsShimPreamble`, plugin filter, environment gating, and full transform output)
- [x] `pnpm test tests/build-optimization.test.ts tests/deploy.test.ts tests/standalone-build.test.ts` (304 pass, no regressions)
- [x] `pnpm run check` clean (format + lint + types)

Closes #1345