### PR TITLE
fix(actions): return 404 + x-nextjs-action-not-found for missing actions

### DIFF
--- a/packages/vinext/src/server/server-action-not-found.ts
+++ b/packages/vinext/src/server/server-action-not-found.ts
@@ -33,15 +33,44 @@ export function isServerActionNotFoundError(error: unknown, actionId: string | n
     return false;
   }
 
-  if (!actionId) {
-    return message.startsWith("Failed to find Server Action");
-  }
-
-  if (message.startsWith(getServerActionNotFoundPrefix(actionId))) {
+  if (actionId && message.startsWith(getServerActionNotFoundPrefix(actionId))) {
     return true;
   }
 
-  return Boolean(actionId && message.includes(`[vite-rsc] invalid server reference '${actionId}'`));
+  if (!actionId && message.startsWith("Failed to find Server Action")) {
+    return true;
+  }
+
+  // `@vitejs/plugin-rsc` raises two different "no such server reference"
+  // errors depending on the build mode. Both mean the same thing — the
+  // referenced server action id isn't in the runtime manifest — and must
+  // surface as Next.js' 404 + action-not-found header rather than a generic
+  // 500. The progressive (no-JS) path also hits this in `decodeAction(body)`
+  // before it has any actionId in hand, so match these patterns whether or
+  // not the caller has resolved an action id from request headers.
+  //
+  //  - dev:  `[vite-rsc] invalid server reference '<id>'` (from the reference
+  //          validation virtual module loaded ahead of dynamic import)
+  //  - prod: `server reference not found '<id>'`         (from the built
+  //          `virtual:vite-rsc/server-references` lookup, including the case
+  //          where the build has no server actions at all)
+  //
+  // See: @vitejs/plugin-rsc dist/rsc.js (`server reference not found`) and
+  // dist/plugin-*.js (`[vite-rsc] invalid <type> reference`).
+  if (actionId) {
+    if (message.includes(`[vite-rsc] invalid server reference '${actionId}'`)) {
+      return true;
+    }
+    if (message.includes(`server reference not found '${actionId}'`)) {
+      return true;
+    }
+    return false;
+  }
+
+  return (
+    /\[vite-rsc] invalid server reference '/.test(message) ||
+    /server reference not found '/.test(message)
+  );
 }
 
 export function createServerActionNotFoundResponse(): Response {

--- a/tests/app-server-action-execution.test.ts
+++ b/tests/app-server-action-execution.test.ts
@@ -583,6 +583,26 @@ describe("app server action execution helpers", () => {
     expect(clearContext).toHaveBeenCalledTimes(1);
   });
 
+  // The progressive (MPA / no-JS form POST) path also needs to recognise the
+  // prod-build "server reference not found" shape thrown by
+  // `@vitejs/plugin-rsc` when the referenced action id isn't in the built
+  // manifest, including when the build has no server actions at all.
+  it("returns action-not-found when the prod build has no matching reference on a progressive action", async () => {
+    const response = requireProgressiveActionResponse(
+      await handleProgressiveServerActionRequest(
+        createOptions({
+          async decodeAction() {
+            throw new Error("server reference not found 'abc123'");
+          },
+        }),
+      ),
+    );
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get("x-nextjs-action-not-found")).toBe("1");
+    expect(await response.text()).toBe("Server action not found.");
+  });
+
   it("returns action-not-found for progressive decode misses that include an action id", async () => {
     const response = requireProgressiveActionResponse(
       await handleProgressiveServerActionRequest(
@@ -876,6 +896,40 @@ describe("app server action execution helpers", () => {
     expect(response?.headers.get("x-nextjs-action-not-found")).toBe("1");
     expect(await response?.text()).toBe("Server action not found.");
     expect(decodeReply).not.toHaveBeenCalled();
+  });
+
+  // Reproduces the prod-build error path where the @vitejs/plugin-rsc server
+  // references manifest doesn't include the requested action id. In a build
+  // with NO server actions defined at all, the action loader throws
+  // `server reference not found '<id>'` (not the dev-mode `[vite-rsc] invalid
+  // server reference '<id>'`). Both shapes have to land on the 404 +
+  // `x-nextjs-action-not-found` response that the client router recognises.
+  //
+  // Ported from Next.js: test/e2e/app-dir/no-server-actions/no-server-actions.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/no-server-actions/no-server-actions.test.ts
+  it("returns action-not-found when the prod build has no matching server reference", async () => {
+    const reportedErrors: Error[] = [];
+    const renderToReadableStream = vi.fn();
+
+    const response = await handleServerActionRscRequest(
+      createRscOptions({
+        actionId: "abc123",
+        loadServerAction() {
+          return Promise.reject(new Error("server reference not found 'abc123'"));
+        },
+        renderToReadableStream,
+        reportRequestError(error) {
+          reportedErrors.push(error);
+        },
+      }),
+    );
+
+    expect(response?.status).toBe(404);
+    expect(response?.headers.get("x-nextjs-action-not-found")).toBe("1");
+    expect(response?.headers.get("content-type")).toBe("text/plain");
+    expect(await response?.text()).toBe("Server action not found.");
+    expect(reportedErrors).toEqual([]);
+    expect(renderToReadableStream).not.toHaveBeenCalled();
   });
 
   it("keeps unrelated server action loader failures on the generic error path", async () => {


### PR DESCRIPTION
## Summary

Recognise the prod-mode error shape from `@vitejs/plugin-rsc` when a server-action
reference id is missing from the manifest, so apps return Next.js' standard
404 + `x-nextjs-action-not-found: 1` response (with `content-type: text/plain` and
body `Server action not found.`) instead of a generic 500.

`@vitejs/plugin-rsc` raises two different "no such server reference" errors
depending on the build mode, and both mean the same thing:

- dev: `[vite-rsc] invalid server reference '<id>'` (reference validation virtual)
- prod: `server reference not found '<id>'` (`virtual:vite-rsc/server-references` lookup, including the no-server-actions-at-all case)

Only the dev-mode message was matched before, so production builds (and apps
with no server actions defined at all) fell through to the generic 500 path. The
progressive (no-JS) handler hits the same code path via `decodeAction(body)`
before it has resolved an action id, so the `actionId: null` branch was widened
to recognise both error patterns too.

This addresses sub-problem #1 from #1340 (404 + `x-nextjs-action-not-found`).
Two sub-problems remain as follow-ups:

- #2 Error boundary propagation for `text/plain` / invalid-content-type action responses.
- #3 Apps that have other server actions defined but receive an unrecognized id _on the progressive path_ — this requires plumbing the actions manifest into the handler so we can short-circuit before `decodeAction`. Today vinext relies on `decodeAction` raising one of the recognised reference errors; in the worst case it returns a non-function and we render the page (no 404).

Refs #1340

## Test plan

- [x] Added unit test reproducing the prod-mode `server reference not found '<id>'` shape on the fetch-action path; confirmed it failed on `main` (500 received, 404 expected) and now passes.
- [x] Added matching unit test for the progressive (MPA) decode path with the prod error shape.
- [x] `pnpm test tests/app-server-action-execution.test.ts` — 37 passed.
- [x] `pnpm run check` — format + lint + types clean.
- [ ] CI: Check, Vitest, Playwright E2E (this PR).