### PR TITLE
feat(form): implement next/form <Form> with soft navigation

### DIFF
--- a/packages/vinext/src/shims/form.tsx
+++ b/packages/vinext/src/shims/form.tsx
@@ -22,7 +22,14 @@ import { forwardRef, useActionState, type FormHTMLAttributes, type ForwardedRef 
 import { hasAppNavigationRuntime } from "../client/navigation-runtime.js";
 import { navigateClientSide } from "./navigation.js";
 import { isDangerousScheme } from "./url-safety.js";
-import { toSameOriginPath } from "./url-utils.js";
+import { toSameOriginPath, withBasePath } from "./url-utils.js";
+
+// Mirrors `__NEXT_ROUTER_BASEPATH` exposure in `next/link` / `next/router`.
+// `addBasePath` is only applied to the form-level `action` prop. A submitter's
+// `formAction` is intentionally untouched, matching Next.js (the comment in
+// upstream `form.tsx` notes "this should not have basePath added, because we
+// can't add it before hydration").
+const __basePath: string = process.env.__NEXT_ROUTER_BASEPATH ?? "";
 
 // Re-export useActionState from React 19 to match Next.js's next/form module
 export { useActionState };
@@ -192,6 +199,12 @@ const Form = forwardRef(function Form(props: FormProps, ref: ForwardedRef<HTMLFo
     return <form ref={ref} onSubmit={onSubmit} {...rest} />;
   }
 
+  // Prefix basePath to the navigating `action` prop (matches Next.js's
+  // `addBasePath(actionProp)` in `client/form.tsx` and `client/app-dir/form.tsx`).
+  // This becomes both the rendered `action=` attribute (so JS-disabled
+  // submissions still hit the right URL) and the soft-navigation target.
+  const actionHref = withBasePath(action, __basePath);
+
   async function handleSubmit(e: React.SubmitEvent<HTMLFormElement>) {
     // Call user's onSubmit first
     if (onSubmit) {
@@ -208,7 +221,10 @@ const Form = forwardRef(function Form(props: FormProps, ref: ForwardedRef<HTMLFo
     const method = getEffectiveMethod(submitter, rest.method);
     if (method !== "GET") return;
 
-    const effectiveAction = getEffectiveAction(submitter, action as string);
+    // NOTE: a submitter's `formAction` is intentionally NOT base-path-prefixed
+    // here, matching Next.js. Upstream `form.tsx` notes: "this should not have
+    // `basePath` added, because we can't add it before hydration".
+    const effectiveAction = getEffectiveAction(submitter, actionHref);
     if (process.env.NODE_ENV !== "production" && submitter?.getAttribute("formaction") !== null) {
       checkFormActionUrl(effectiveAction, "formAction");
     }
@@ -229,26 +245,37 @@ const Form = forwardRef(function Form(props: FormProps, ref: ForwardedRef<HTMLFo
       // aligned with the committed RSC tree.
       await navigateClientSide(url, replace ? "replace" : "push", scroll);
     } else {
-      // Pages Router: use router or fallback
-      if (replace) {
-        window.history.replaceState({}, "", url);
-      } else {
-        window.history.pushState({}, "", url);
+      // Pages Router: delegate to the Router singleton so navigation flows
+      // through `performNavigation` (route events, HTML fetch, scroll
+      // handling). Mirrors what `<Link>` does at link.tsx:619-623.
+      try {
+        const routerModule = await import("./router.js");
+        const Router = routerModule.default;
+        if (replace) {
+          await Router.replace(url, undefined, { scroll });
+        } else {
+          await Router.push(url, undefined, { scroll });
+        }
+      } catch {
+        // Fallback: pushState + popstate keeps the URL in sync even if the
+        // Router singleton import fails (e.g. in test/SSR-only contexts).
+        if (replace) {
+          window.history.replaceState({}, "", url);
+        } else {
+          window.history.pushState({}, "", url);
+        }
+        window.dispatchEvent(new PopStateEvent("popstate"));
+        if (scroll) {
+          window.scrollTo(0, 0);
+        }
       }
-      window.dispatchEvent(new PopStateEvent("popstate"));
-    }
-
-    // App Router: scroll is handled inside navigateClientSide (called above).
-    // Pages Router: scroll manually since pushState/popstate doesn't auto-scroll.
-    if (!hasAppNavigationRuntime() && scroll) {
-      window.scrollTo(0, 0);
     }
   }
 
   return (
     <form
       ref={ref}
-      action={action}
+      action={actionHref}
       onSubmit={(event) => {
         void handleSubmit(event);
       }}

--- a/tests/form.test.ts
+++ b/tests/form.test.ts
@@ -410,4 +410,151 @@ describe("Form client GET interception", () => {
     expect(event.preventDefault).not.toHaveBeenCalled();
     expect(navigate).not.toHaveBeenCalled();
   });
+
+  it("respects onSubmit calling preventDefault — no client-side navigation", async () => {
+    // Mirrors Next.js's `with-onsubmit-preventdefault` test:
+    // .nextjs-ref/test/e2e/next-form/default/shared-tests.util.ts:235
+    // When the user's onSubmit handler calls preventDefault(), we must NOT
+    // intercept for soft-navigation — let the user's logic own the submit.
+    const { navigate } = installClientGlobals({ supportsSubmitter: true });
+    const userOnSubmit = vi.fn((event: { preventDefault: () => void }) => {
+      event.preventDefault();
+    });
+    const { onSubmit } = renderClientForm({ action: "/search", onSubmit: userOnSubmit });
+    const event = createSubmitEvent({ entries: [["q", "react"]] });
+
+    await onSubmit(event);
+
+    expect(userOnSubmit).toHaveBeenCalledOnce();
+    expect(event.preventDefault).toHaveBeenCalledOnce();
+    // Form's own preventDefault path (and navigate) should be skipped.
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it("uses replace mode when `replace` prop is set", async () => {
+    const { navigate } = installClientGlobals({ supportsSubmitter: true });
+    const { onSubmit } = renderClientForm({ action: "/search", replace: true });
+    const event = createSubmitEvent({ entries: [["q", "react"]] });
+
+    await onSubmit(event);
+
+    expect(navigate).toHaveBeenCalledWith(
+      "/search?q=react",
+      0,
+      "navigate",
+      "replace",
+      undefined,
+      false,
+    );
+  });
+});
+
+describe("Form Pages Router soft navigation", () => {
+  // When no App Router navigation runtime is present, the form must route via
+  // the Pages Router singleton (`next/router`) so it triggers a real soft
+  // navigation rather than a full MPA reload. This is the regression that
+  // sub-issue #1355 calls out.
+  //
+  // We can't realistically boot the full Pages Router singleton inside a unit
+  // test (it depends on `window.__VINEXT_ROOT__` and a Vite-generated route
+  // manifest). Instead, we assert the contract that matters at the shim
+  // boundary: `preventDefault` was called, so the browser's native form
+  // submission (which would be a hard MPA reload) is suppressed.
+
+  function createPagesWindowStub() {
+    const pushState = vi.fn();
+    const replaceState = vi.fn();
+    const scrollTo = vi.fn();
+    const dispatched: Event[] = [];
+
+    return {
+      pushState,
+      replaceState,
+      scrollTo,
+      dispatched,
+      window: {
+        // Intentionally NO `vinext.navigationRuntime` — Pages Router context.
+        history: {
+          pushState,
+          replaceState,
+          state: null,
+        },
+        location: {
+          origin: "http://localhost:3000",
+          href: "http://localhost:3000/current",
+          pathname: "/current",
+          search: "",
+          hash: "",
+          hostname: "localhost",
+        },
+        scrollTo,
+        scrollX: 0,
+        scrollY: 0,
+        addEventListener: () => {},
+        dispatchEvent: (event: Event) => {
+          dispatched.push(event);
+          return true;
+        },
+      },
+    };
+  }
+
+  function installPagesGlobals() {
+    const stub = createPagesWindowStub();
+    vi.stubGlobal("window", stub.window);
+    vi.stubGlobal("Element", FakeElement);
+    vi.stubGlobal("HTMLButtonElement", FakeButtonElement);
+    vi.stubGlobal("HTMLInputElement", FakeInputElement);
+    vi.stubGlobal("FormData", createFormDataClass({ supportsSubmitter: true }));
+    vi.stubGlobal("PopStateEvent", class PopStateEvent extends Event {});
+    return stub;
+  }
+
+  it("calls preventDefault to suppress the browser's hard MPA submit", async () => {
+    // Regression for #1355: without interception, the browser would submit
+    // the form and trigger a full page reload (`didMpaNavigate` -> true).
+    // Calling preventDefault is the only thing that can stop that.
+    installPagesGlobals();
+    const { onSubmit } = renderClientForm({ action: "/results" });
+    const event = createSubmitEvent({ entries: [["q", "react"]] });
+
+    await onSubmit(event);
+
+    expect(event.preventDefault).toHaveBeenCalledOnce();
+  });
+
+  it("does not call preventDefault for non-GET forms (lets native submit run)", async () => {
+    // POST forms (e.g. server actions) must not be intercepted by the Form's
+    // navigation logic — React's own form-action handling owns them.
+    installPagesGlobals();
+    const { onSubmit } = renderClientForm({ action: "/results", method: "POST" });
+    const event = createSubmitEvent({ entries: [["q", "react"]] });
+
+    await onSubmit(event);
+
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+});
+
+describe("Form function action (client/server action)", () => {
+  it("passes a function `action` through to React for action handling", () => {
+    // Mirrors Next.js's `with-function/action-client` test path:
+    // the action function must be wired up to the rendered <form>, not
+    // intercepted as a navigation. The shim's job is just to thread it
+    // through; React owns the FormData dispatch.
+    const actionFn = vi.fn(async (_formData: FormData) => {});
+    const html = ReactDOMServer.renderToString(
+      React.createElement(
+        Form,
+        { action: actionFn as any, id: "search-form" },
+        React.createElement("input", { name: "query" }),
+        React.createElement("button", { type: "submit" }, "Submit"),
+      ),
+    );
+    expect(html).toContain("<form");
+    expect(html).toContain('id="search-form"');
+    // We never invoke the action during SSR — but we did successfully render
+    // a form with the function attached (React will bind it client-side).
+    expect(actionFn).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary

Sub-issue #1355: `next/form` `<Form>` did not properly soft-navigate. Two gaps fixed:

- **basePath not applied** to the form's `action` prop. Next.js wraps the action in `addBasePath(actionProp)` in both [`client/form.tsx`](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/form.tsx) and [`client/app-dir/form.tsx`](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/app-dir/form.tsx); vinext was rendering it raw. This caused `next-form/basepath` to fail and dropped the basePath off both the rendered `action=` attribute and the soft-nav target.
- **Pages Router fallback bypassed the Router singleton**. The shim did `pushState + dispatchEvent(popstate)` directly, which skipped `routeChangeStart`/`routeChangeComplete`, HTML fetch via `performNavigation`, and scroll handling. `next/link` already uses `Router.push` in Pages Router (see `link.tsx:619-623`); the Form shim now does the same. A submitter's `formAction` is still **not** prefixed with basePath, matching the comment in upstream `form.tsx`: \"this should not have basePath added, because we can't add it before hydration.\"

Source references:
- `.nextjs-ref/packages/next/src/client/form.tsx`
- `.nextjs-ref/packages/next/src/client/app-dir/form.tsx`
- `.nextjs-ref/packages/next/src/client/form-shared.tsx`

## Test plan

- [x] `pnpm test tests/form.test.ts` — 17/17 pass (5 new tests covering preventDefault contract, replace mode, function-action passthrough, POST-non-interception, and onSubmit preventDefault).
- [x] `pnpm test tests/shims.test.ts` — 929/929 pass (no regressions in the broader shim surface).
- [x] `pnpm run check` — format + lint + type checks clean.
- [ ] Next.js compat e2e: `test/e2e/next-form/default/app-dir.test.ts`, `pages-dir.test.ts`, `basepath/next-form-basepath.test.ts` (CI runs these).

Closes #1355