### PR TITLE
fix(build): strip CSS imports from SSR bundle

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -125,6 +125,7 @@ import {
   type BundleBackfillChunk,
 } from "./build/ssr-manifest.js";
 import { stripServerExports } from "./plugins/strip-server-exports.js";
+import { createStripSsrCssPlugin } from "./plugins/strip-ssr-css.js";
 import { hasMdxFiles } from "./utils/mdx-scan.js";
 import { scanPublicFileRoutes } from "./utils/public-routes.js";
 import tsconfigPaths from "vite-tsconfig-paths";
@@ -2269,6 +2270,11 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
     },
     // Stub node:async_hooks in client builds — see src/plugins/async-hooks-stub.ts
     asyncHooksStubPlugin,
+    // Strip CSS references (static `import "./x.css"` and `new URL("./x.css",
+    // import.meta.url)`) from SSR/RSC chunks — see plugins/strip-ssr-css.ts.
+    // Without this, Node's ESM loader crashes resolving the dangling CSS
+    // module the first time the SSR entry is imported during prerender.
+    createStripSsrCssPlugin(),
     createInstrumentationClientTransformPlugin(() => instrumentationClientPath),
     // Dedup client references from RSC proxy modules — see src/plugins/client-reference-dedup.ts
     ...(options.experimental?.clientReferenceDedup ? [clientReferenceDedupPlugin()] : []),

--- a/packages/vinext/src/plugins/strip-ssr-css.ts
+++ b/packages/vinext/src/plugins/strip-ssr-css.ts
@@ -43,11 +43,14 @@ import MagicString from "magic-string";
  */
 
 // Matches `new URL("./x.css", import.meta.url)` with optional whitespace and
-// trailing comma. Captures the full call (group 0) and the quoted specifier
-// (group 1) including its surrounding quotes so we can replace only the
-// specifier without touching anything else.
+// trailing comma. Captures the full call (group 0), the quoted specifier
+// including its surrounding quotes (group 1), and the bare specifier text
+// without quotes or any trailing `?query` (group 2). An optional `?…`
+// query suffix is allowed on the specifier so callers like
+// `new URL("./style.css?foo", import.meta.url)` are matched symmetrically
+// with the side-effect import regex below.
 const NEW_URL_CSS_RE =
-  /\bnew\s+URL\s*\(\s*(["'`][^"'`]+\.css["'`])\s*,\s*import\.meta\.url\s*(?:,\s*)?\)/g;
+  /\bnew\s+URL\s*\(\s*(["'`]([^"'`]+\.css)(?:\?[^"'`]*)?["'`])\s*,\s*import\.meta\.url\s*(?:,\s*)?\)/g;
 
 // Matches side-effect CSS imports, including a trailing `?…` query so that
 // the handler can decide whether the specifier carries a `?url`/`?raw`/
@@ -71,17 +74,17 @@ function mightHaveCssReference(code: string): boolean {
 }
 
 /**
- * Pure transform that powers the plugin's `transform` hook. Exposed for
- * direct unit testing — call this with `{ id, code }` and assert against
- * the rewritten code without spinning up a Vite build.
- *
- * Returns `null` when no rewrites apply, mirroring the Vite contract.
+ * Apply CSS-stripping rewrites to a single module. Returns the MagicString
+ * instance when at least one rewrite ran, or `null` if the module is a
+ * no-op. The caller decides whether to call `.toString()` / `.generateMap()`
+ * — this keeps the unit-test helper cheap (no source-map work) while
+ * letting the Vite plugin emit hires maps.
  */
-export function transformSsrCssReferences(id: string, code: string): { code: string } | null {
+function applyStripSsrCss(id: string, code: string): MagicString | null {
   if (!mightHaveCssReference(code)) return null;
   // Honor explicit `?url`/`?raw`/`?inline`/`?no-inline` queries on the
-  // module ID itself — those modules are intentionally string-typed
-  // and we must not touch them.
+  // module ID itself — those modules are intentionally string-typed and
+  // we must not touch them.
   if (ALLOWED_QUERY_RE.test(id)) return null;
 
   let s: MagicString | null = null;
@@ -89,8 +92,13 @@ export function transformSsrCssReferences(id: string, code: string): { code: str
   NEW_URL_CSS_RE.lastIndex = 0;
   let m: RegExpExecArray | null;
   while ((m = NEW_URL_CSS_RE.exec(code))) {
-    const specStart = m.index + m[0].indexOf(m[1]!);
-    const specEnd = specStart + m[1]!.length;
+    // Skip new URL("./x.css?url", ...) for the same reason we skip the
+    // side-effect form: the user explicitly asked for a string value, so
+    // rewriting to `data:,` would lose information they intend to consume.
+    const fullQuoted = m[1]!;
+    if (ALLOWED_QUERY_RE.test(fullQuoted)) continue;
+    const specStart = m.index + m[0].indexOf(fullQuoted);
+    const specEnd = specStart + fullQuoted.length;
     if (!s) s = new MagicString(code);
     s.overwrite(specStart, specEnd, '"data:,"');
   }
@@ -105,6 +113,18 @@ export function transformSsrCssReferences(id: string, code: string): { code: str
     s.overwrite(m.index, m.index + m[0].length, "");
   }
 
+  return s;
+}
+
+/**
+ * Pure transform that powers the plugin's `transform` hook. Exposed for
+ * direct unit testing — call this with `{ id, code }` and assert against
+ * the rewritten code without spinning up a Vite build.
+ *
+ * Returns `null` when no rewrites apply, mirroring the Vite contract.
+ */
+export function transformSsrCssReferences(id: string, code: string): { code: string } | null {
+  const s = applyStripSsrCss(id, code);
   if (!s) return null;
   return { code: s.toString() };
 }
@@ -130,28 +150,7 @@ export function createStripSsrCssPlugin(): Plugin {
         id: { exclude: /\.css(?:$|\?)/ },
       },
       handler(code, id) {
-        if (!mightHaveCssReference(code)) return null;
-        if (ALLOWED_QUERY_RE.test(id)) return null;
-
-        let s: MagicString | null = null;
-
-        NEW_URL_CSS_RE.lastIndex = 0;
-        let m: RegExpExecArray | null;
-        while ((m = NEW_URL_CSS_RE.exec(code))) {
-          const specStart = m.index + m[0].indexOf(m[1]!);
-          const specEnd = specStart + m[1]!.length;
-          if (!s) s = new MagicString(code);
-          s.overwrite(specStart, specEnd, '"data:,"');
-        }
-
-        SIDE_EFFECT_CSS_IMPORT_RE.lastIndex = 0;
-        while ((m = SIDE_EFFECT_CSS_IMPORT_RE.exec(code))) {
-          const spec = m[2]!;
-          if (ALLOWED_QUERY_RE.test(spec)) continue;
-          if (!s) s = new MagicString(code);
-          s.overwrite(m.index, m.index + m[0].length, "");
-        }
-
+        const s = applyStripSsrCss(id, code);
         if (!s) return null;
         return {
           code: s.toString(),

--- a/packages/vinext/src/plugins/strip-ssr-css.ts
+++ b/packages/vinext/src/plugins/strip-ssr-css.ts
@@ -1,0 +1,129 @@
+import type { Plugin } from "vite";
+import MagicString from "magic-string";
+
+/**
+ * Strip CSS references from modules in the SSR / server environment.
+ *
+ * Vite's `vite:asset-import-meta-url` plugin only runs when
+ * `environment.config.consumer === "client"` (see
+ * `packages/vite/src/node/plugins/assetImportMetaUrl.ts` upstream). In a
+ * server consumer the source-level `new URL("./style.css", import.meta.url)`
+ * therefore survives the bundler verbatim. Rolldown then resolves the URL
+ * against the SSR chunk's location at runtime — but the referenced CSS asset
+ * was never emitted into the SSR output directory, so Node's ESM loader
+ * crashes the first time the entry module evaluates:
+ *
+ *   Error [ERR_MODULE_NOT_FOUND]: Cannot find module
+ *     '/.../dist/server/ssr/style.css'
+ *     imported from '/.../dist/server/ssr/index.js'
+ *
+ * The same surface exists for static `import "./style.css"` statements that
+ * Rolldown preserves into the SSR chunk when the CSS code-split plugin
+ * tree-shakes the asset side-effect (the import survives, the asset does
+ * not).
+ *
+ * CSS is a strictly client-side concern — there is no SSR path that consumes
+ * it. The cleanest fix is to neutralize both forms in the SSR environment:
+ *
+ *  - `import "./x.css"`             →  removed
+ *  - `new URL("./x.css", import.meta.url)` →  `new URL("data:,",
+ *                                              import.meta.url)`
+ *
+ * Replacing the URL specifier with `data:,` (an empty data URL) keeps the
+ * expression syntactically identical (still a `URL` instance) for any code
+ * that incidentally inspects the result, but is a no-op the runtime can
+ * always resolve without a file on disk.
+ *
+ * Mirrors the behavior implicit in Next.js's webpack pipeline, where CSS
+ * imports in SSR/edge bundles are stripped to a side-effect-free shim.
+ *
+ * Relates to deploy-suite failure surfaced by
+ * `test/e2e/react-version/pages/api/pages-api-edge-url-dep.js`, which
+ * exercises this exact pattern.
+ */
+
+// Matches `new URL("./x.css", import.meta.url)` with optional whitespace and
+// trailing comma. Captures the full call (group 0) and the quoted specifier
+// (group 1) including its surrounding quotes so we can replace only the
+// specifier without touching anything else.
+const NEW_URL_CSS_RE =
+  /\bnew\s+URL\s*\(\s*(["'`][^"'`]+\.css["'`])\s*,\s*import\.meta\.url\s*(?:,\s*)?\)/g;
+
+// Matches side-effect CSS imports:
+//   import "./x.css";
+//   import './x.css'
+// Does NOT match `import x from "./x.css"` — those are intentionally rare
+// in user code and removing the binding would break the module syntactically.
+// We also skip module IDs containing `?url` or `?raw` since those carry an
+// explicit user contract that the import resolves to a string, not a side
+// effect.
+const SIDE_EFFECT_CSS_IMPORT_RE = /^\s*import\s+(["'])([^"']+\.css)\1\s*;?\s*$/gm;
+
+const ALLOWED_QUERY_RE = /\?(?:url|raw|inline|no-inline)\b/;
+
+/**
+ * Cheap pre-filter to avoid AST work on the majority of modules that have
+ * nothing to strip. False positives are harmless; the real regexes still
+ * gate any rewrites.
+ */
+function mightHaveCssReference(code: string): boolean {
+  return code.includes(".css");
+}
+
+export function createStripSsrCssPlugin(): Plugin {
+  return {
+    name: "vinext:strip-ssr-css",
+    applyToEnvironment(environment) {
+      // Run for any server-consumer environment (Vite sets this automatically
+      // for `ssr` and for the RSC plugin's `rsc` env). The RSC environment
+      // already routes CSS through `@vitejs/plugin-rsc`'s code-split path
+      // which emits real files, but the static-import branch of this plugin
+      // is a no-op there because the CSS imports have already been rewritten
+      // to hashed names by the time we see them. We still want the `new URL`
+      // branch to apply, since the asset-import-meta-url plugin upstream
+      // does not run for server consumers.
+      return environment.config.consumer === "server";
+    },
+    transform: {
+      filter: {
+        // CSS files themselves still need to pass through Vite's CSS
+        // pipeline. Only transform JS/TS modules.
+        id: { exclude: /\.css(?:$|\?)/ },
+      },
+      handler(code, id) {
+        if (!mightHaveCssReference(code)) return null;
+        // Honor explicit `?url`/`?raw`/`?inline`/`?no-inline` queries on the
+        // module ID itself — those modules are intentionally string-typed
+        // and we must not touch them.
+        if (ALLOWED_QUERY_RE.test(id)) return null;
+
+        let s: MagicString | null = null;
+
+        NEW_URL_CSS_RE.lastIndex = 0;
+        let m: RegExpExecArray | null;
+        while ((m = NEW_URL_CSS_RE.exec(code))) {
+          const specStart = m.index + m[0].indexOf(m[1]!);
+          const specEnd = specStart + m[1]!.length;
+          if (!s) s = new MagicString(code);
+          s.overwrite(specStart, specEnd, '"data:,"');
+        }
+
+        SIDE_EFFECT_CSS_IMPORT_RE.lastIndex = 0;
+        while ((m = SIDE_EFFECT_CSS_IMPORT_RE.exec(code))) {
+          const spec = m[2]!;
+          // Skip explicit url/raw/inline queries — those imports return a
+          // string and the module body may rely on the binding's value.
+          if (ALLOWED_QUERY_RE.test(spec)) continue;
+          if (!s) s = new MagicString(code);
+          s.overwrite(m.index, m.index + m[0].length, "");
+        }
+
+        if (!s) return null;
+        return {
+          code: s.toString(),
+          map: s.generateMap({ hires: true }),
+        };
+      },
+    },
+  };
+}

--- a/packages/vinext/src/plugins/strip-ssr-css.ts
+++ b/packages/vinext/src/plugins/strip-ssr-css.ts
@@ -49,15 +49,15 @@ import MagicString from "magic-string";
 const NEW_URL_CSS_RE =
   /\bnew\s+URL\s*\(\s*(["'`][^"'`]+\.css["'`])\s*,\s*import\.meta\.url\s*(?:,\s*)?\)/g;
 
-// Matches side-effect CSS imports:
+// Matches side-effect CSS imports, including a trailing `?…` query so that
+// the handler can decide whether the specifier carries a `?url`/`?raw`/
+// `?inline`/`?no-inline` contract before stripping:
 //   import "./x.css";
-//   import './x.css'
-// Does NOT match `import x from "./x.css"` — those are intentionally rare
-// in user code and removing the binding would break the module syntactically.
-// We also skip module IDs containing `?url` or `?raw` since those carry an
-// explicit user contract that the import resolves to a string, not a side
-// effect.
-const SIDE_EFFECT_CSS_IMPORT_RE = /^\s*import\s+(["'])([^"']+\.css)\1\s*;?\s*$/gm;
+//   import "./x.css?url";
+// Does NOT match `import x from "./x.css"` — bound imports are intentionally
+// rare in user code and removing the binding would break the module
+// syntactically.
+const SIDE_EFFECT_CSS_IMPORT_RE = /^\s*import\s+(["'])([^"']+\.css(?:\?[^"']*)?)\1\s*;?\s*$/gm;
 
 const ALLOWED_QUERY_RE = /\?(?:url|raw|inline|no-inline)\b/;
 
@@ -68,6 +68,45 @@ const ALLOWED_QUERY_RE = /\?(?:url|raw|inline|no-inline)\b/;
  */
 function mightHaveCssReference(code: string): boolean {
   return code.includes(".css");
+}
+
+/**
+ * Pure transform that powers the plugin's `transform` hook. Exposed for
+ * direct unit testing — call this with `{ id, code }` and assert against
+ * the rewritten code without spinning up a Vite build.
+ *
+ * Returns `null` when no rewrites apply, mirroring the Vite contract.
+ */
+export function transformSsrCssReferences(id: string, code: string): { code: string } | null {
+  if (!mightHaveCssReference(code)) return null;
+  // Honor explicit `?url`/`?raw`/`?inline`/`?no-inline` queries on the
+  // module ID itself — those modules are intentionally string-typed
+  // and we must not touch them.
+  if (ALLOWED_QUERY_RE.test(id)) return null;
+
+  let s: MagicString | null = null;
+
+  NEW_URL_CSS_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = NEW_URL_CSS_RE.exec(code))) {
+    const specStart = m.index + m[0].indexOf(m[1]!);
+    const specEnd = specStart + m[1]!.length;
+    if (!s) s = new MagicString(code);
+    s.overwrite(specStart, specEnd, '"data:,"');
+  }
+
+  SIDE_EFFECT_CSS_IMPORT_RE.lastIndex = 0;
+  while ((m = SIDE_EFFECT_CSS_IMPORT_RE.exec(code))) {
+    const spec = m[2]!;
+    // Skip explicit url/raw/inline queries — those imports return a
+    // string and the module body may rely on the binding's value.
+    if (ALLOWED_QUERY_RE.test(spec)) continue;
+    if (!s) s = new MagicString(code);
+    s.overwrite(m.index, m.index + m[0].length, "");
+  }
+
+  if (!s) return null;
+  return { code: s.toString() };
 }
 
 export function createStripSsrCssPlugin(): Plugin {
@@ -92,9 +131,6 @@ export function createStripSsrCssPlugin(): Plugin {
       },
       handler(code, id) {
         if (!mightHaveCssReference(code)) return null;
-        // Honor explicit `?url`/`?raw`/`?inline`/`?no-inline` queries on the
-        // module ID itself — those modules are intentionally string-typed
-        // and we must not touch them.
         if (ALLOWED_QUERY_RE.test(id)) return null;
 
         let s: MagicString | null = null;
@@ -111,8 +147,6 @@ export function createStripSsrCssPlugin(): Plugin {
         SIDE_EFFECT_CSS_IMPORT_RE.lastIndex = 0;
         while ((m = SIDE_EFFECT_CSS_IMPORT_RE.exec(code))) {
           const spec = m[2]!;
-          // Skip explicit url/raw/inline queries — those imports return a
-          // string and the module body may rely on the binding's value.
           if (ALLOWED_QUERY_RE.test(spec)) continue;
           if (!s) s = new MagicString(code);
           s.overwrite(m.index, m.index + m[0].length, "");

--- a/tests/ssr-css-assets.test.ts
+++ b/tests/ssr-css-assets.test.ts
@@ -199,7 +199,6 @@ describe("SSR build emits CSS assets referenced by SSR chunks", () => {
   // failure surfaces as ~5 broken assertions in `test/e2e/react-version/`.
   it("Pages Router API route URL-dependency CSS is emitted to dist/server/", async () => {
     const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "vinext-ssr-css-pages-url-"));
-    const outDir = await fs.mkdtemp(path.join(os.tmpdir(), "vinext-ssr-css-pages-url-out-"));
     try {
       await fs.symlink(ROOT_NODE_MODULES, path.join(tmpDir, "node_modules"), "junction");
       const pagesApiDir = path.join(tmpDir, "pages", "api");
@@ -287,7 +286,6 @@ export default async function handler(_req, res) {
       ).toEqual([]);
     } finally {
       await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
-      await fs.rm(outDir, { recursive: true, force: true }).catch(() => {});
     }
   }, 180_000);
 });

--- a/tests/ssr-css-assets.test.ts
+++ b/tests/ssr-css-assets.test.ts
@@ -187,4 +187,107 @@ describe("SSR build emits CSS assets referenced by SSR chunks", () => {
       await fs.rm(outDir, { recursive: true, force: true }).catch(() => {});
     }
   }, 180_000);
+
+  // Mirrors Next.js `test/e2e/react-version/pages/api/pages-api-edge-url-dep.js`,
+  // which uses `import(new URL('./style.css', import.meta.url).href)` to declare
+  // a URL dependency on a CSS file from a Pages Router API route. Vite/Rolldown
+  // picks up the `new URL('./style.css', import.meta.url)` pattern, emits the
+  // CSS as an asset, and rewrites the JS to reference it. Without
+  // `emitAssets: true` on the Pages Router SSR environment, the asset is
+  // silently stripped from `dist/server/`, leaving a dangling import that
+  // crashes `vinext start` with ERR_MODULE_NOT_FOUND. The full deploy-suite
+  // failure surfaces as ~5 broken assertions in `test/e2e/react-version/`.
+  it("Pages Router API route URL-dependency CSS is emitted to dist/server/", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "vinext-ssr-css-pages-url-"));
+    const outDir = await fs.mkdtemp(path.join(os.tmpdir(), "vinext-ssr-css-pages-url-out-"));
+    try {
+      await fs.symlink(ROOT_NODE_MODULES, path.join(tmpDir, "node_modules"), "junction");
+      const pagesApiDir = path.join(tmpDir, "pages", "api");
+      await fs.mkdir(pagesApiDir, { recursive: true });
+      await fs.writeFile(path.join(pagesApiDir, "style.css"), ".foo { color: red; }\n");
+      await fs.writeFile(
+        path.join(pagesApiDir, "url-dep.js"),
+        `// URL-dependency on a CSS file. Vite picks this up, emits the CSS
+// as an asset, and rewrites the JS to point at the emitted file.
+console.log('TEST_URL_DEPENDENCY', new URL('./style.css', import.meta.url).href);
+export default async function handler(_req, res) {
+  res.json({ ok: true });
+}
+`,
+      );
+      await fs.writeFile(
+        path.join(tmpDir, "pages", "index.tsx"),
+        "export default function Home() { return <div>Hello</div>; }\n",
+      );
+
+      // Pages Router SSR env writes to `<root>/dist/server` (the
+      // ssrOutDir option only applies to the App Router build path).
+      const ssrOutDir = path.join(tmpDir, "dist", "server");
+
+      const builder = await createBuilder({
+        root: tmpDir,
+        configFile: false,
+        plugins: [vinext({ disableAppRouter: true })],
+        logLevel: "silent",
+      });
+      await builder.buildApp();
+
+      const allFiles: string[] = [];
+      async function walk(dir: string): Promise<void> {
+        const entries = await fs.readdir(dir, { withFileTypes: true });
+        for (const e of entries) {
+          const full = path.join(dir, e.name);
+          if (e.isDirectory()) await walk(full);
+          else allFiles.push(full);
+        }
+      }
+      await walk(ssrOutDir);
+
+      const jsFiles = allFiles.filter((f) => f.endsWith(".js") || f.endsWith(".mjs"));
+      expect(jsFiles.length, `expected SSR chunks under ${ssrOutDir}`).toBeGreaterThan(0);
+
+      // Every `new URL("X.css", import.meta.url)` or `import "X.css"` /
+      // `from "X.css"` reference must point at a file that exists on disk.
+      const importRe = /(?:import|from)\s+["']([^"']+\.css)["']/g;
+      const urlRe = /new\s+URL\(\s*["']([^"']+\.css)["']\s*,\s*import\.meta\.url\s*\)/g;
+
+      const missing: { from: string; spec: string; resolved: string; kind: string }[] = [];
+      for (const file of jsFiles) {
+        const code = await fs.readFile(file, "utf8");
+        for (const [re, kind] of [
+          [importRe, "import"],
+          [urlRe, "new URL"],
+        ] as const) {
+          re.lastIndex = 0;
+          let m: RegExpExecArray | null;
+          while ((m = re.exec(code))) {
+            const spec = m[1]!;
+            if (/^[a-z]+:/i.test(spec)) continue;
+            const resolved = path.resolve(path.dirname(file), spec);
+            const exists = await fs
+              .stat(resolved)
+              .then(() => true)
+              .catch(() => false);
+            // Debug helper: log all SSR files when an assertion is about
+            // to fail, so the failure message captures what was emitted.
+            if (!exists) {
+              missing.push({ from: path.relative(ssrOutDir, file), spec, resolved, kind });
+            }
+          }
+        }
+      }
+
+      expect(
+        missing,
+        `Pages Router SSR chunks reference CSS files that were not emitted:\n${JSON.stringify(
+          missing,
+          null,
+          2,
+        )}`,
+      ).toEqual([]);
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+      await fs.rm(outDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }, 180_000);
 });

--- a/tests/strip-ssr-css.test.ts
+++ b/tests/strip-ssr-css.test.ts
@@ -129,6 +129,22 @@ export default styles;
     expect(result).toBeNull();
   });
 
+  it("preserves new URL specifiers that carry a ?url/?raw/?inline query", () => {
+    // Symmetric with the side-effect import path: a `?url`-suffixed CSS
+    // specifier in `new URL` is the user explicitly asking for the resolved
+    // URL string. Rewriting it to `data:,` would lose information the
+    // module body intends to consume.
+    for (const query of ["?url", "?raw", "?inline", "?no-inline"]) {
+      const code = `const u = new URL("./styles.css${query}", import.meta.url);
+`;
+      const result = transformSsrCssReferences("/app/page.tsx", code);
+      if (result !== null) {
+        expect(result.code).toContain(`./styles.css${query}`);
+        expect(result.code).not.toContain("data:,");
+      }
+    }
+  });
+
   it("only matches `.css` extensions, not other asset URLs", () => {
     const result = transformSsrCssReferences(
       "/app/page.tsx",

--- a/tests/strip-ssr-css.test.ts
+++ b/tests/strip-ssr-css.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Focused unit tests for the `vinext:strip-ssr-css` transform.
+ *
+ * These tests exercise the pure transform helper directly, independent of
+ * Vite/Rolldown. The integration coverage lives in `tests/ssr-css-assets.test.ts`
+ * (which asserts the end-to-end "no dangling CSS references in SSR output"
+ * invariant). The two layers are intentionally complementary: the integration
+ * test catches regressions in either the plugin OR the `ssrEmitAssets: true`
+ * config, while these unit tests pin down exactly which surface forms the
+ * transform handles.
+ */
+
+import { describe, it, expect } from "vite-plus/test";
+import { transformSsrCssReferences } from "../packages/vinext/src/plugins/strip-ssr-css.js";
+
+describe("transformSsrCssReferences", () => {
+  it("rewrites new URL('./x.css', import.meta.url) to a no-op data URL", () => {
+    const result = transformSsrCssReferences(
+      "/app/pages/api/url-dep.js",
+      `console.log(new URL("./style.css", import.meta.url).href);
+export default function handler(_req, res) { res.json({ ok: true }); }
+`,
+    );
+    expect(result).not.toBeNull();
+    expect(result!.code).toContain('new URL("data:,", import.meta.url)');
+    expect(result!.code).not.toContain("./style.css");
+  });
+
+  it("handles single-quoted and template-string specifiers", () => {
+    const result = transformSsrCssReferences(
+      "/app/pages/api/url-dep.js",
+      `const a = new URL('./a.css', import.meta.url);
+const b = new URL(\`./b.css\`, import.meta.url);
+`,
+    );
+    expect(result).not.toBeNull();
+    expect(result!.code).not.toContain("./a.css");
+    expect(result!.code).not.toContain("./b.css");
+    // Both calls should be rewritten to the same `data:,` form.
+    const matches = result!.code.match(/new URL\("data:,", import\.meta\.url\)/g);
+    expect(matches?.length).toBe(2);
+  });
+
+  it("strips side-effect CSS imports", () => {
+    const result = transformSsrCssReferences(
+      "/app/components/server-component.tsx",
+      `import "./styles.css";
+export default function Component() { return null; }
+`,
+    );
+    expect(result).not.toBeNull();
+    expect(result!.code).not.toContain('"./styles.css"');
+    expect(result!.code).not.toContain("import");
+  });
+
+  it('preserves `import "./x.css?url"` because it carries a string contract', () => {
+    // `?url` imports return the resolved URL as a string. Removing the
+    // import would break any module that subsequently reads from it via
+    // side effects (or — in the bound form — by its binding).
+    const code = `import "./styles.css?url";
+export const X = 1;
+`;
+    const result = transformSsrCssReferences("/app/page.tsx", code);
+    // No-op: returning null is also acceptable. Either way the `?url`
+    // specifier must survive.
+    if (result !== null) {
+      expect(result.code).toContain("./styles.css?url");
+    }
+  });
+
+  it("preserves `?raw`, `?inline`, and `?no-inline` query CSS imports", () => {
+    for (const query of ["?raw", "?inline", "?no-inline"]) {
+      const code = `import "./styles.css${query}";
+`;
+      const result = transformSsrCssReferences("/app/page.tsx", code);
+      if (result !== null) {
+        expect(result.code).toContain(`./styles.css${query}`);
+      }
+    }
+  });
+
+  it("does not rewrite modules whose own id carries a ?url/?raw/?inline query", () => {
+    // The module being transformed is itself a `?url`-suffixed import. We
+    // must not touch its body at all because the importer expects the raw
+    // text content.
+    const result = transformSsrCssReferences(
+      "/app/components/server-component.tsx?url",
+      `import "./styles.css";
+new URL("./other.css", import.meta.url);
+`,
+    );
+    expect(result).toBeNull();
+  });
+
+  it("returns null when the code contains no .css references", () => {
+    const result = transformSsrCssReferences(
+      "/app/components/server-component.tsx",
+      `import { something } from "./helper.js";
+export default function X() { return null; }
+`,
+    );
+    expect(result).toBeNull();
+  });
+
+  it("rewrites both new URL and side-effect import in the same module", () => {
+    const result = transformSsrCssReferences(
+      "/app/page.tsx",
+      `import "./globals.css";
+const u = new URL("./fonts.css", import.meta.url);
+export default function Page() { return null; }
+`,
+    );
+    expect(result).not.toBeNull();
+    expect(result!.code).not.toContain("./globals.css");
+    expect(result!.code).not.toContain("./fonts.css");
+    expect(result!.code).toContain('new URL("data:,", import.meta.url)');
+  });
+
+  it('does not touch bound imports like `import x from "./x.css"`', () => {
+    // The side-effect regex is anchored to bare specifier imports only.
+    // A bound default import would syntactically break if we removed it
+    // (any subsequent reference to `styles` would fail). The bound form
+    // is also very unusual in user code — Vite/Next.js libraries return a
+    // CSS-modules object, not a default export.
+    const code = `import styles from "./styles.css";
+export default styles;
+`;
+    const result = transformSsrCssReferences("/app/page.tsx", code);
+    expect(result).toBeNull();
+  });
+
+  it("only matches `.css` extensions, not other asset URLs", () => {
+    const result = transformSsrCssReferences(
+      "/app/page.tsx",
+      `const a = new URL("./logo.png", import.meta.url);
+const b = new URL("./worker.js", import.meta.url);
+`,
+    );
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Vite's `vite:asset-import-meta-url` plugin only runs for client-consumer environments, so `new URL('./style.css', import.meta.url)` survives verbatim into SSR/RSC chunks. Rolldown then resolves it against the SSR chunk at runtime, but the CSS asset is never emitted to the SSR output directory — Node's ESM loader crashes the first time the SSR entry is imported during prerender (`ERR_MODULE_NOT_FOUND: '/.../dist/server/ssr/style.css' imported from '/.../dist/server/ssr/index.js'`). The same surface exists for static `import './x.css'` side-effect imports the CSS code-split plugin preserves into SSR JS.
- Add a `vinext:strip-ssr-css` Vite plugin that runs only in server-consumer environments (Vite's `ssr` env + plugin-rsc's `rsc` env) and neutralizes both forms: side-effect `import './x.css'` statements are removed, and `new URL('./x.css', import.meta.url)` is rewritten to `new URL('data:,', import.meta.url)` so the expression still resolves syntactically but the runtime never touches a missing file. Explicit `?url`/`?raw`/`?inline`/`?no-inline` queries are preserved since those imports carry a string contract the module body may rely on.
- Mirrors the deploy-suite failure surfaced by `test/e2e/react-version/pages/api/pages-api-edge-url-dep.js` (which deliberately puts `import(new URL('./style.css', import.meta.url).href)` in a Pages Router API route).

## Test plan

- [x] `pnpm test tests/ssr-css-assets.test.ts` — new Pages Router URL-dependency test reproduces the failure on `main` and passes with the fix; existing App Router and Pages Router `emitAssets`/`every CSS import resolves` tests still pass.
- [x] `pnpm test tests/css-media-query-target.test.ts tests/node-modules-css.test.ts tests/scss.test.ts tests/postcss-resolve.test.ts` — CSS pipeline regressions stay green.
- [x] `pnpm test tests/pages-router.test.ts tests/app-router.test.ts tests/app-ssr-stream.test.ts` — 538 / 538 tests pass.
- [x] `pnpm run check` — format, lint, and typecheck all clean.

Closes #1346