### PR TITLE
fix(parallel-routes): resolve nested slot pages over default.tsx

### DIFF
--- a/packages/vinext/src/routing/app-route-graph.ts
+++ b/packages/vinext/src/routing/app-route-graph.ts
@@ -844,6 +844,12 @@ export async function buildAppRouteGraph(
   // segment has no children page. Next.js uses this for modal/feed patterns
   // like app/user/[id]/layout + @feed/page + @modal/default.
   const routePatterns = new Set(routes.map((route) => route.pattern));
+  // Ghost parents are layout-only routes whose URL pattern collides with an
+  // existing route (e.g. sibling route groups like (group-a)/layout.tsx and
+  // (group-b)/page.tsx both anchored at "/"). Their slot directories still
+  // contribute synthetic sub-routes (e.g. @parallel/[...catcher]/page.tsx →
+  // /:catcher+), but the ghost itself is not added to the routes table.
+  const ghostParentRoutes: AppRouteGraphRoute[] = [];
   for await (const file of scanWithExtensions(
     "**/layout",
     appDir,
@@ -856,7 +862,11 @@ export async function buildAppRouteGraph(
     if (discoverParallelSlots(routeDir, appDir, matcher).length === 0) continue;
 
     const route = directoryToAppRoute(dir, appDir, matcher, null, null);
-    if (!route || routePatterns.has(route.pattern)) continue;
+    if (!route) continue;
+    if (routePatterns.has(route.pattern)) {
+      ghostParentRoutes.push(route);
+      continue;
+    }
 
     routes.push(route);
     routePatterns.add(route.pattern);
@@ -866,7 +876,7 @@ export async function buildAppRouteGraph(
   // In Next.js, pages nested inside @slot directories create additional URL routes.
   // For example, @audience/demographics/page.tsx at app/parallel-routes/ creates
   // a route at /parallel-routes/demographics.
-  const slotSubRoutes = discoverSlotSubRoutes(routes, matcher);
+  const slotSubRoutes = discoverSlotSubRoutes(routes, matcher, ghostParentRoutes);
   routes.push(...slotSubRoutes);
 
   validatePageRouteConflicts(routes, appDir);
@@ -954,6 +964,7 @@ function formatAppFilePath(filePath: string, appDir: string): string {
 function discoverSlotSubRoutes(
   routes: AppRouteGraphRoute[],
   matcher: ValidFileMatcher,
+  ghostParents: readonly AppRouteGraphRoute[] = [],
 ): AppRouteGraphRoute[] {
   const syntheticRoutes: AppRouteGraphRoute[] = [];
 
@@ -975,7 +986,10 @@ function discoverSlotSubRoutes(
     });
   };
 
-  for (const parentRoute of routes) {
+  // Iterate real routes first so that later ghost-parent passes can detect
+  // synthetic conflicts against routes the real pass minted.
+  const allParents: AppRouteGraphRoute[] = [...routes, ...ghostParents];
+  for (const parentRoute of allParents) {
     if (parentRoute.parallelSlots.length === 0) continue;
 
     // Only page-bearing routes or layout-only UI routes (not route handlers)

--- a/tests/app-route-graph.test.ts
+++ b/tests/app-route-graph.test.ts
@@ -175,6 +175,47 @@ describe("App Router route graph builder", () => {
     });
   });
 
+  it("materializes synthetic routes from a sibling route-group's parallel slot", async () => {
+    // Two sibling route groups share the same URL pattern at the root:
+    //   (group-a) provides a layout-only route with a catch-all parallel slot
+    //   (group-b) provides the children page at the same URL pattern
+    // The (group-a) layout cannot become a route on its own (collision), but
+    // its slot's nested catch-all page must still materialize a synthetic
+    // route so that URLs not matched by (group-b) fall through to the slot.
+    await withTempApp(async (appDir) => {
+      await writeAppFile(appDir, "(group-a)/layout.tsx", EMPTY_LAYOUT);
+      await writeAppFile(appDir, "(group-a)/@parallel/default.tsx", EMPTY_PAGE);
+      await writeAppFile(appDir, "(group-a)/@parallel/[...catcher]/page.tsx", EMPTY_PAGE);
+      await writeAppFile(appDir, "(group-b)/layout.tsx", EMPTY_LAYOUT);
+      await writeAppFile(appDir, "(group-b)/page.tsx", EMPTY_PAGE);
+      await writeAppFile(appDir, "(group-b)/foo/page.tsx", EMPTY_PAGE);
+
+      const graph = await buildAppRouteGraph(appDir, createValidFileMatcher());
+      const patterns = graph.routes.map((r) => r.pattern).sort();
+      // Real page routes from (group-b)
+      expect(patterns).toContain("/");
+      expect(patterns).toContain("/foo");
+      // Synthetic catch-all from (group-a)'s @parallel slot
+      expect(patterns).toContain("/:catcher+");
+
+      const catcher = findRoute(graph.routes, "/:catcher+");
+      // The layout-only ghost parent is not added to routes, but the synthetic
+      // sub-route inherits (group-a)'s layout chain.
+      expect(catcher.layouts).toEqual([path.join(appDir, "(group-a)/layout.tsx")]);
+      expect(catcher.parallelSlots).toHaveLength(1);
+      expect(catcher.parallelSlots[0]).toMatchObject({
+        name: "parallel",
+        pagePath: path.join(appDir, "(group-a)/@parallel/[...catcher]/page.tsx"),
+        routeSegments: ["[...catcher]"],
+      });
+
+      // The real /foo route belongs to (group-b) only — it must not pick up
+      // slots from the sibling group.
+      const foo = findRoute(graph.routes, "/foo");
+      expect(foo.parallelSlots).toHaveLength(0);
+    });
+  });
+
   it("skips synthetic routes that structurally conflict with existing page routes", async () => {
     // A slot sub-page like @feed/[name]/page.tsx under /shop would create /shop/:name,
     // but if /shop/[id]/page.tsx already exists (route /shop/:id), the synthetic route

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -568,6 +568,21 @@ describe("App Router integration", () => {
   // catch-all slot in (group-a) must take over instead of falling back to
   // default.tsx / not-found.
 
+  it("renders the explicit page at the shared root URL of two sibling route groups", async () => {
+    // /parallel-group-catchall has an explicit page in (group-b) and a
+    // layout-only sibling in (group-a). The explicit page must win.
+    const res = await fetch(`${baseUrl}/parallel-group-catchall`);
+    expect(res.status).toBe(200);
+
+    const html = await res.text();
+    expect(html).toContain('data-testid="group-b-layout"');
+    expect(html).toContain('data-testid="group-b-home"');
+    expect(html).toContain("Group B Home");
+    // No catch-all takeover at the explicit page URL.
+    expect(html).not.toContain('data-testid="parallel-catcher"');
+    expect(html).not.toContain('data-testid="group-a-layout"');
+  });
+
   it("matches an explicit sibling page when both route groups define the same URL space", async () => {
     const res = await fetch(`${baseUrl}/parallel-group-catchall/foo`);
     expect(res.status).toBe(200);

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -555,6 +555,44 @@ describe("App Router integration", () => {
     expect(html).toContain("Hello from nested parallel page!");
   });
 
+  // --- Sibling route-group with catch-all parallel slot ---
+  // Ported from Next.js: test/e2e/app-dir/parallel-routes-catchall-groups/parallel-routes-catchall-groups.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/parallel-routes-catchall-groups/parallel-routes-catchall-groups.test.ts
+  //
+  // Two sibling route groups share the same URL pattern (/parallel-group-catchall):
+  //   (group-b) owns the children-rendering layout, page.tsx, and foo/page.tsx
+  //   (group-a) owns a layout that only renders a `parallel` slot plus
+  //             @parallel/[...catcher]/page.tsx as a catch-all fallback
+  // Navigating to /parallel-group-catchall/foo matches the explicit (group-b) page.
+  // Navigating to /parallel-group-catchall/bar has no explicit page, so the
+  // catch-all slot in (group-a) must take over instead of falling back to
+  // default.tsx / not-found.
+
+  it("matches an explicit sibling page when both route groups define the same URL space", async () => {
+    const res = await fetch(`${baseUrl}/parallel-group-catchall/foo`);
+    expect(res.status).toBe(200);
+
+    const html = await res.text();
+    expect(html).toContain('data-testid="group-b-layout"');
+    expect(html).toContain('data-testid="group-b-foo"');
+    expect(html).toContain("Foo Page");
+    // The (group-a) catch-all must not steal an explicitly matched URL.
+    expect(html).not.toContain('data-testid="parallel-catcher"');
+  });
+
+  it("falls back to a catch-all parallel slot in a sibling route group", async () => {
+    // /parallel-group-catchall/bar has no own page anywhere — only
+    // (group-a)/@parallel/[...catcher]/page.tsx can render it.
+    const res = await fetch(`${baseUrl}/parallel-group-catchall/bar`);
+    expect(res.status).toBe(200);
+
+    const html = await res.text();
+    expect(html).toContain('data-testid="group-a-layout"');
+    expect(html).toContain('data-testid="group-a-parallel-slot"');
+    expect(html).toContain('data-testid="parallel-catcher"');
+    expect(html).toContain("Catcher");
+  });
+
   // --- useSelectedLayoutSegment(s) ---
 
   it("useSelectedLayoutSegments returns segments relative to dashboard layout", async () => {

--- a/tests/fixtures/app-basic/app/parallel-group-catchall/(group-a)/@parallel/[...catcher]/page.tsx
+++ b/tests/fixtures/app-basic/app/parallel-group-catchall/(group-a)/@parallel/[...catcher]/page.tsx
@@ -1,0 +1,3 @@
+export default function Catcher() {
+  return <div data-testid="parallel-catcher">Catcher</div>;
+}

--- a/tests/fixtures/app-basic/app/parallel-group-catchall/(group-a)/@parallel/default.tsx
+++ b/tests/fixtures/app-basic/app/parallel-group-catchall/(group-a)/@parallel/default.tsx
@@ -1,0 +1,5 @@
+import { notFound } from "next/navigation";
+
+export default function ParallelDefault() {
+  notFound();
+}

--- a/tests/fixtures/app-basic/app/parallel-group-catchall/(group-a)/layout.tsx
+++ b/tests/fixtures/app-basic/app/parallel-group-catchall/(group-a)/layout.tsx
@@ -1,0 +1,7 @@
+export default function GroupALayout({ parallel }: { parallel: React.ReactNode }) {
+  return (
+    <div data-testid="group-a-layout">
+      <div data-testid="group-a-parallel-slot">{parallel}</div>
+    </div>
+  );
+}

--- a/tests/fixtures/app-basic/app/parallel-group-catchall/(group-b)/foo/page.tsx
+++ b/tests/fixtures/app-basic/app/parallel-group-catchall/(group-b)/foo/page.tsx
@@ -1,0 +1,3 @@
+export default function FooPage() {
+  return <div data-testid="group-b-foo">Foo Page</div>;
+}

--- a/tests/fixtures/app-basic/app/parallel-group-catchall/(group-b)/layout.tsx
+++ b/tests/fixtures/app-basic/app/parallel-group-catchall/(group-b)/layout.tsx
@@ -1,0 +1,3 @@
+export default function GroupBLayout({ children }: { children: React.ReactNode }) {
+  return <div data-testid="group-b-layout">{children}</div>;
+}

--- a/tests/fixtures/app-basic/app/parallel-group-catchall/(group-b)/page.tsx
+++ b/tests/fixtures/app-basic/app/parallel-group-catchall/(group-b)/page.tsx
@@ -1,0 +1,3 @@
+export default function GroupBHome() {
+  return <div data-testid="group-b-home">Group B Home</div>;
+}


### PR DESCRIPTION
## Summary

When two sibling route groups occupy the same URL pattern (e.g. `(group-a)/layout.tsx` next to `(group-b)/page.tsx`), the layout-only sibling was dropped entirely because its pattern collided with the page route, taking its parallel slots with it. Nested pages inside its `@slot` directories were never materialized, so URLs that only the catch-all slot could handle returned 404 / not-found instead of rendering the matched slot page.

This change keeps the dropped layout-only routes as "ghost parents" that participate in `discoverSlotSubRoutes`. Their slot sub-pages still mint synthetic sub-routes (carrying the ghost's layout chain and slot metadata), but the ghost itself is not added to the route table — preserving the existing single-route-per-pattern invariant.

### Example layout

```
app/
  (group-a)/
    layout.tsx                          # renders {parallel} only
    @parallel/
      default.tsx                       # notFound()
      [...catcher]/page.tsx             # "Catcher"
  (group-b)/
    layout.tsx                          # renders {children}
    page.tsx                            # /
    foo/page.tsx                        # /foo
```

Before this fix, `(group-a)/layout.tsx` collided with `(group-b)/page.tsx` at `/`, so the entire `(group-a)` subtree (including `@parallel/[...catcher]/page.tsx`) was discarded. Requests for `/bar` returned 404 because no route matched. With this fix, the `@parallel/[...catcher]/page.tsx` is materialized as a synthetic route at pattern `/:catcher+` carrying `(group-a)/layout.tsx`, so `/bar` correctly renders the catch-all slot.

## Test plan

- [x] New unit test in `tests/app-route-graph.test.ts` covering the sibling-route-group / catch-all-slot interaction in `discoverSlotSubRoutes`.
- [x] New e2e tests in `tests/app-router.test.ts` against a fresh `parallel-group-catchall` fixture verifying both branches:
  - `/parallel-group-catchall/foo` → matched `(group-b)/foo/page.tsx`
  - `/parallel-group-catchall/bar` → caught by `(group-a)/@parallel/[...catcher]/page.tsx`
- [x] Verified the e2e tests fail on `main` (404 for `/bar`) and pass with the fix.
- [x] `pnpm test tests/app-route-graph.test.ts tests/route-sorting.test.ts tests/routing.test.ts tests/slot.test.ts tests/intercepting-routes-build.test.ts tests/app-rsc-route-matching.test.ts tests/route-classification-manifest.test.ts tests/navigation-planner.test.ts tests/app-router.test.ts tests/entry-templates.test.ts tests/build-report.test.ts` — all green.
- [x] `pnpm run check` clean.

Closes #1339

### References

Ported from Next.js:
- https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/parallel-routes-catchall-groups/parallel-routes-catchall-groups.test.ts
- Related: https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/parallel-routes-layouts/parallel-routes-layouts.test.ts
- Related: https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/parallel-routes-catchall-default/parallel-routes-catchall-default.test.ts