### PR TITLE
fix(rsc): redirect returns flight payload (200) for RSC navigations

### DIFF
--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -115,12 +115,16 @@ import {
   VINEXT_RSC_CONTENT_TYPE,
 } from "./app-rsc-cache-busting.js";
 import { APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI } from "./app-rsc-render-mode.js";
-import { resolveRscRedirectLifecycleHop } from "./app-browser-rsc-redirect.js";
+import {
+  MAX_RSC_REDIRECT_DEPTH,
+  resolveRscRedirectLifecycleHop,
+} from "./app-browser-rsc-redirect.js";
 import {
   ACTION_REDIRECT_HEADER,
   ACTION_REDIRECT_TYPE_HEADER,
   VINEXT_MOUNTED_SLOTS_HEADER,
   VINEXT_PARAMS_HEADER,
+  VINEXT_RSC_REDIRECT_HEADER,
 } from "./headers.js";
 
 type SearchParamInput = ConstructorParameters<typeof URLSearchParams>[0];
@@ -1426,6 +1430,40 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
           currentHistoryMode = redirectDecision.historyUpdateMode;
           currentPrevNextUrl = redirectDecision.previousNextUrl;
           redirectCount = redirectDecision.redirectDepth;
+          continue;
+        }
+
+        // RSC redirect encoded as 200 + flight payload (the server's response
+        // for `redirect()` thrown from a server component during RSC rendering;
+        // see issue #1347 and `buildAppPageSpecialErrorResponse`). The flight
+        // body carries the canonical `NEXT_REDIRECT;...` digest for clients
+        // that decode it through React's RedirectBoundary, but vinext's
+        // browser-navigation loop catches it ahead of decode via this
+        // side-channel header so the redirect-following loop above can drain
+        // the body and continue without bouncing through the catch path.
+        // Reusing the same loop variables keeps `pendingRouterState` and the
+        // outer `useTransition` pending state continuous across the hop —
+        // matching the pre-1347 fetch-auto-follow-307 behavior.
+        const flightRedirectTarget = navResponse.headers.get(VINEXT_RSC_REDIRECT_HEADER);
+        if (flightRedirectTarget) {
+          // Drain the response body so the underlying connection is released.
+          // We do this best-effort: the destination's `.rsc` fetch on the next
+          // loop iteration will replace this response entirely.
+          void navResponse.body?.cancel().catch(() => {});
+          const resolvedTarget = new URL(flightRedirectTarget, window.location.origin);
+          if (resolvedTarget.origin !== window.location.origin) {
+            window.location.href = resolvedTarget.href;
+            return;
+          }
+          if (redirectCount >= MAX_RSC_REDIRECT_DEPTH) {
+            console.error(
+              "[vinext] Too many RSC redirects — aborting navigation to prevent infinite loop.",
+            );
+            window.location.href = resolvedTarget.href;
+            return;
+          }
+          currentHref = `${resolvedTarget.pathname}${resolvedTarget.search}${resolvedTarget.hash}`;
+          redirectCount += 1;
           continue;
         }
 

--- a/packages/vinext/src/server/app-browser-rsc-redirect.ts
+++ b/packages/vinext/src/server/app-browser-rsc-redirect.ts
@@ -4,7 +4,7 @@ import {
   stripRscSuffix,
 } from "./app-rsc-cache-busting.js";
 
-const MAX_RSC_REDIRECT_DEPTH = 10;
+export const MAX_RSC_REDIRECT_DEPTH = 10;
 
 type RscRedirectHistoryUpdateMode = "push" | "replace" | undefined;
 

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import React, { type ReactNode } from "react";
 import type { ReactFormState } from "react-dom/client";
 import type { ClassificationReason } from "../build/layout-classification-types.js";
 import {
@@ -734,6 +734,35 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
   });
 }
 
+/**
+ * Builds an RSC flight payload that encodes a redirect as a React error chunk.
+ * We render a tiny element that immediately throws an `Error` whose `digest`
+ * is the canonical `NEXT_REDIRECT;...` string. `renderToReadableStream`'s
+ * `onError` returns that digest, react-server-dom-webpack serializes the
+ * error into the stream, and the client's `RedirectErrorBoundary` decodes it
+ * via `getURLFromRedirectError` / `getRedirectTypeFromError`.
+ *
+ * The thrown error's digest matches Next.js's well-known router error format,
+ * so neither vinext's RSC error handler nor Next.js's reporter logs it as a
+ * "real" server error. Mirrors `app-render.tsx generateDynamicFlightRenderResult`
+ * where a redirect thrown during RSC rendering propagates through
+ * `renderToFlightStream`'s `onError` callback into the flight payload.
+ */
+function buildRscRedirectFlightStream<TRoute extends AppPageDispatchRoute>(
+  options: DispatchAppPageOptions<TRoute>,
+  digest: string,
+): ReadableStream<Uint8Array> {
+  const throwingElement = React.createElement(function NextRedirectFlightThrower() {
+    const err = new Error("NEXT_REDIRECT") as Error & { digest: string };
+    err.digest = digest;
+    throw err;
+  });
+
+  return options.renderToReadableStream(throwingElement, {
+    onError: () => digest,
+  });
+}
+
 async function renderLayoutSpecialError<TRoute extends AppPageDispatchRoute>(
   options: DispatchAppPageOptions<TRoute>,
   specialError: AppPageSpecialError,
@@ -741,6 +770,8 @@ async function renderLayoutSpecialError<TRoute extends AppPageDispatchRoute>(
 ): Promise<Response> {
   return buildAppPageSpecialErrorResponse({
     basePath: options.basePath,
+    buildRscRedirectFlightStream: (rscOptions) =>
+      buildRscRedirectFlightStream(options, rscOptions.digest),
     clearRequestContext: options.clearRequestContext,
     getAndClearPendingCookies,
     isRscRequest: options.isRscRequest,
@@ -777,6 +808,8 @@ async function renderPageSpecialError<TRoute extends AppPageDispatchRoute>(
 ): Promise<Response> {
   return buildAppPageSpecialErrorResponse({
     basePath: options.basePath,
+    buildRscRedirectFlightStream: (rscOptions) =>
+      buildRscRedirectFlightStream(options, rscOptions.digest),
     clearRequestContext: options.clearRequestContext,
     getAndClearPendingCookies,
     isRscRequest: options.isRscRequest,

--- a/packages/vinext/src/server/app-page-execution.ts
+++ b/packages/vinext/src/server/app-page-execution.ts
@@ -1,16 +1,69 @@
 import type { LayoutFlags } from "./app-elements.js";
 import type { ClassificationReason } from "../build/layout-classification-types.js";
-import { createRscRedirectLocation } from "./app-rsc-cache-busting.js";
+import { createRscRedirectLocation, VINEXT_RSC_CONTENT_TYPE } from "./app-rsc-cache-busting.js";
 import { mergeMiddlewareResponseHeaders } from "./middleware-response-headers.js";
 import { parseNextHttpErrorDigest, parseNextRedirectDigest } from "./next-error-digest.js";
 import { addBasePathToPathname } from "../utils/base-path.js";
 
+/**
+ * Builds the canonical `NEXT_REDIRECT;<type>;<url>;<status>;` digest that
+ * Next.js encodes on `redirect()` / `permanentRedirect()` throws. Used when
+ * we synthesize a flight payload for an RSC navigation: the digest must
+ * round-trip through the client's `RedirectErrorBoundary` so the same
+ * `getURLFromRedirectError` / `getRedirectTypeFromError` helpers decode it.
+ *
+ * The URL is included verbatim, not encoded — Next.js's `getRedirectError`
+ * sets `digest = ${CODE};${type};${url};${status};` with the raw URL, and the
+ * client decodes via `error.digest.split(';').slice(2, -2).join(';')`. We
+ * default `type=replace` because `redirect()` is replace-style outside of
+ * server actions, matching Next.js's `getRedirectError` default.
+ *
+ * Reference:
+ *   `.nextjs-ref/packages/next/src/client/components/redirect.ts:20-23`
+ *   `.nextjs-ref/packages/next/src/client/components/redirect-error.ts`
+ */
+function formatNextRedirectDigest(options: { url: string; statusCode: number }): string {
+  return `NEXT_REDIRECT;replace;${options.url};${options.statusCode};`;
+}
+
 export type { LayoutFlags };
 export type { ClassificationReason };
 
+/**
+ * Marker we tag onto a thrown redirect/notFound error when it originates from
+ * `generateMetadata()` (vs. a server component itself). Metadata resolution is
+ * suspended/streamed in Next.js, so a redirect from metadata never becomes an
+ * HTTP-level 307 — it rides inside the flight payload with a 200 status,
+ * regardless of whether the request is RSC or a full document SSR. Page-level
+ * redirect()s, by contrast, still produce a 307 for SSR document requests.
+ *
+ * See Next.js test:
+ *   test/e2e/app-dir/metadata-navigation/metadata-navigation.test.ts
+ *   ("should support redirect in generateMetadata")
+ */
+export const APP_PAGE_METADATA_ERROR_MARKER = Symbol.for("vinext.appPage.metadataError");
+
+export function tagAppPageMetadataError<T>(error: T): T {
+  if (error && typeof error === "object") {
+    try {
+      Object.defineProperty(error, APP_PAGE_METADATA_ERROR_MARKER, {
+        value: true,
+        enumerable: false,
+        configurable: true,
+        writable: false,
+      });
+    } catch {
+      // The error object may be frozen (rare). The marker is best-effort —
+      // callers fall back to the page-level 307 path when missing, which
+      // matches the historical behavior.
+    }
+  }
+  return error;
+}
+
 export type AppPageSpecialError =
-  | { kind: "redirect"; location: string; statusCode: number }
-  | { kind: "http-access-fallback"; statusCode: number };
+  | { kind: "redirect"; location: string; statusCode: number; fromMetadata?: boolean }
+  | { kind: "http-access-fallback"; statusCode: number; fromMetadata?: boolean };
 
 export type AppPageFontPreload = {
   href: string;
@@ -24,6 +77,23 @@ type AppPageRscStreamCapture = {
   sideStream?: ReadableStream<Uint8Array>;
 };
 
+/**
+ * Builds an RSC flight payload that encodes a `redirect()` as a React error
+ * with the canonical `NEXT_REDIRECT;<type>;<url>;<status>;` digest. Mirrors
+ * Next.js's behavior in `app-render.tsx generateDynamicFlightRenderResult`
+ * where a redirect thrown during RSC rendering propagates through
+ * `renderToFlightStream`'s `onError` handler and is serialized into the
+ * stream — the HTTP response stays 200 because the redirect rides in the
+ * flight body, not the status line.
+ *
+ * Returns a stream that the caller wraps in a 200 response with the standard
+ * `text/x-component` content type. The client's `RedirectErrorBoundary`
+ * decodes the digest and performs the navigation.
+ */
+export type BuildRscRedirectFlightStream = (options: {
+  digest: string;
+}) => ReadableStream<Uint8Array>;
+
 type BuildAppPageSpecialErrorResponseOptions = {
   /**
    * Optional configured basePath (e.g. "/blog"). When set, redirect Locations
@@ -34,6 +104,14 @@ type BuildAppPageSpecialErrorResponseOptions = {
    * are left untouched.
    */
   basePath?: string;
+  /**
+   * Builds the RSC flight payload used when a redirect must be encoded inside
+   * the response body instead of the status line — required for RSC navigations
+   * and for `generateMetadata()` redirects (always 200, never 307). When
+   * omitted, redirect responses fall back to the 307 + Location path; callers
+   * that handle RSC requests must supply this.
+   */
+  buildRscRedirectFlightStream?: BuildRscRedirectFlightStream;
   clearRequestContext: () => void;
   /**
    * Drains and returns Set-Cookie header values that were accumulated during
@@ -131,6 +209,7 @@ export function resolveAppPageSpecialError(error: unknown): AppPageSpecialError 
   }
 
   const digest = String(error.digest);
+  const fromMetadata = (error as Record<symbol, unknown>)[APP_PAGE_METADATA_ERROR_MARKER] === true;
 
   const redirect = parseNextRedirectDigest(digest);
   if (redirect) {
@@ -138,6 +217,7 @@ export function resolveAppPageSpecialError(error: unknown): AppPageSpecialError 
       kind: "redirect",
       location: redirect.url,
       statusCode: redirect.status,
+      ...(fromMetadata ? { fromMetadata: true } : {}),
     };
   }
 
@@ -146,6 +226,7 @@ export function resolveAppPageSpecialError(error: unknown): AppPageSpecialError 
     return {
       kind: "http-access-fallback",
       statusCode: httpError.status,
+      ...(fromMetadata ? { fromMetadata: true } : {}),
     };
   }
 
@@ -179,6 +260,26 @@ function applyAppPageRedirectBasePath(
   return resolved.toString();
 }
 
+/**
+ * Returns a path-relative form (`/foo?bar`) of an absolute URL when it shares
+ * the request's origin; otherwise returns the URL verbatim. Used so the digest
+ * we embed in the flight payload matches Next.js's convention — the digest
+ * stores the path the developer passed to `redirect("/about")`, not a
+ * fully-qualified URL like `https://example.com/about`.
+ */
+function sameOriginPathOrAbsolute(location: string, requestUrl: string): string {
+  try {
+    const resolved = new URL(location, requestUrl);
+    const requestOrigin = new URL(requestUrl).origin;
+    if (resolved.origin !== requestOrigin) {
+      return resolved.toString();
+    }
+    return `${resolved.pathname}${resolved.search}${resolved.hash}`;
+  } catch {
+    return location;
+  }
+}
+
 export async function buildAppPageSpecialErrorResponse(
   options: BuildAppPageSpecialErrorResponseOptions,
 ): Promise<Response> {
@@ -191,6 +292,51 @@ export async function buildAppPageSpecialErrorResponse(
       options.request.url,
       options.basePath,
     );
+
+    // Two cases need a 200 + flight-payload encoding instead of an HTTP 307:
+    //   1. RSC navigation requests (`Rsc: 1` header) — the client router
+    //      decodes the redirect digest from the flight stream. A raw 307
+    //      bypasses that path and breaks cache-busting validation.
+    //   2. `generateMetadata()` redirects — metadata is suspended in Next.js,
+    //      so the redirect rides inside the streamed flight payload even for
+    //      full document SSR. The status line stays 200.
+    // Mirrors Next.js's `generateDynamicFlightRenderResult` path in
+    // `app-render.tsx`, where the redirect error propagates through
+    // `renderToFlightStream` and is serialized with its digest.
+    const shouldEmbedRedirectInFlight =
+      Boolean(options.buildRscRedirectFlightStream) &&
+      (options.isRscRequest || options.specialError.fromMetadata === true);
+
+    if (shouldEmbedRedirectInFlight && options.buildRscRedirectFlightStream) {
+      // Reduce the resolved (absolute) URL back to a path-only form for
+      // same-origin redirects. Next.js's digest stores the raw URL passed to
+      // `redirect()` (typically a path like "/about"), and the client router's
+      // `router.push(url)` happily accepts paths. Cross-origin targets keep
+      // their absolute form, matching Next.js's external-redirect handling.
+      const digestUrl = sameOriginPathOrAbsolute(prefixedLocation, options.request.url);
+      const digest = formatNextRedirectDigest({
+        url: digestUrl,
+        statusCode: options.specialError.statusCode,
+      });
+      const stream = options.buildRscRedirectFlightStream({ digest });
+
+      const headers = new Headers({
+        "Content-Type": VINEXT_RSC_CONTENT_TYPE,
+      });
+      // Preserve middleware response headers (Set-Cookie, custom headers, etc.)
+      // exactly like the 307 path does — the client will still see them.
+      mergeMiddlewareResponseHeaders(headers, options.middlewareContext?.headers ?? null);
+      const pendingCookies = options.getAndClearPendingCookies?.() ?? [];
+      for (const cookie of pendingCookies) {
+        headers.append("Set-Cookie", cookie);
+      }
+
+      return new Response(stream, {
+        headers,
+        status: 200,
+      });
+    }
+
     const location = options.isRscRequest
       ? await createRscRedirectLocation(prefixedLocation, options.request)
       : prefixedLocation;

--- a/packages/vinext/src/server/app-page-execution.ts
+++ b/packages/vinext/src/server/app-page-execution.ts
@@ -1,6 +1,11 @@
 import type { LayoutFlags } from "./app-elements.js";
 import type { ClassificationReason } from "../build/layout-classification-types.js";
-import { createRscRedirectLocation, VINEXT_RSC_CONTENT_TYPE } from "./app-rsc-cache-busting.js";
+import {
+  applyRscCompatibilityIdHeader,
+  createRscRedirectLocation,
+  VINEXT_RSC_CONTENT_TYPE,
+} from "./app-rsc-cache-busting.js";
+import { VINEXT_RSC_REDIRECT_HEADER } from "./headers.js";
 import { mergeMiddlewareResponseHeaders } from "./middleware-response-headers.js";
 import { parseNextHttpErrorDigest, parseNextRedirectDigest } from "./next-error-digest.js";
 import { addBasePathToPathname } from "../utils/base-path.js";
@@ -41,7 +46,7 @@ export type { ClassificationReason };
  *   test/e2e/app-dir/metadata-navigation/metadata-navigation.test.ts
  *   ("should support redirect in generateMetadata")
  */
-export const APP_PAGE_METADATA_ERROR_MARKER = Symbol.for("vinext.appPage.metadataError");
+const APP_PAGE_METADATA_ERROR_MARKER = Symbol.for("vinext.appPage.metadataError");
 
 export function tagAppPageMetadataError<T>(error: T): T {
   if (error && typeof error === "object") {
@@ -90,9 +95,7 @@ type AppPageRscStreamCapture = {
  * `text/x-component` content type. The client's `RedirectErrorBoundary`
  * decodes the digest and performs the navigation.
  */
-export type BuildRscRedirectFlightStream = (options: {
-  digest: string;
-}) => ReadableStream<Uint8Array>;
+type BuildRscRedirectFlightStream = (options: { digest: string }) => ReadableStream<Uint8Array>;
 
 type BuildAppPageSpecialErrorResponseOptions = {
   /**
@@ -322,7 +325,15 @@ export async function buildAppPageSpecialErrorResponse(
 
       const headers = new Headers({
         "Content-Type": VINEXT_RSC_CONTENT_TYPE,
+        // Side-channel signal so vinext's client loop can detect the redirect
+        // without having to decode the flight body first. See
+        // `VINEXT_RSC_REDIRECT_HEADER` in server/headers.ts for the rationale.
+        [VINEXT_RSC_REDIRECT_HEADER]: digestUrl,
       });
+      // Mirror the regular RSC response by stamping the build-time compatibility
+      // ID. Without it, the client treats the response as cross-build and hard-
+      // navigates instead of following the redirect through the soft-nav loop.
+      applyRscCompatibilityIdHeader(headers);
       // Preserve middleware response headers (Set-Cookie, custom headers, etc.)
       // exactly like the 307 path does — the client will still see them.
       mergeMiddlewareResponseHeaders(headers, options.middlewareContext?.headers ?? null);

--- a/packages/vinext/src/server/app-page-head.ts
+++ b/packages/vinext/src/server/app-page-head.ts
@@ -2,7 +2,7 @@ import {
   mergeMetadataEntries,
   mergeViewport,
   postProcessMetadata,
-  resolveModuleMetadata,
+  resolveModuleMetadata as _resolveModuleMetadata,
   resolveModuleViewport,
   type Metadata,
   type MetadataMergeEntry,
@@ -11,8 +11,29 @@ import {
 import { runWithFetchDedupe } from "vinext/shims/fetch-cache";
 import { applyFileBasedMetadata } from "./file-based-metadata.js";
 import type { AppPageParams } from "./app-page-boundary.js";
+import { tagAppPageMetadataError } from "./app-page-execution.js";
 import { resolveAppPageSegmentParams } from "./app-page-params.js";
 import type { MetadataFileRoute } from "./metadata-routes.js";
+
+/**
+ * Wrapped {@link _resolveModuleMetadata} that tags any thrown error with the
+ * `APP_PAGE_METADATA_ERROR_MARKER` symbol. The marker lets downstream special-
+ * error handling distinguish a `generateMetadata()` redirect/notFound from a
+ * page-component redirect/notFound, which matters because metadata is
+ * suspended/streamed in Next.js: its redirects ride inside the flight payload
+ * with a 200 status code even for document SSR, whereas page redirects still
+ * emit a 307 for SSR. See https://github.com/cloudflare/vinext/issues/1347
+ * and Next.js test/e2e/app-dir/metadata-navigation.
+ */
+async function resolveModuleMetadata(
+  ...args: Parameters<typeof _resolveModuleMetadata>
+): Promise<Metadata | null> {
+  try {
+    return await _resolveModuleMetadata(...args);
+  } catch (error) {
+    throw tagAppPageMetadataError(error);
+  }
+}
 
 type AppPageSearchParams = Record<string, string | string[]>;
 

--- a/packages/vinext/src/server/headers.ts
+++ b/packages/vinext/src/server/headers.ts
@@ -46,6 +46,20 @@ export const VINEXT_INTERCEPTION_CONTEXT_HEADER = "X-Vinext-Interception-Context
 /** RSC render mode (e.g. "navigation", "prefetch"). */
 export const VINEXT_RSC_RENDER_MODE_HEADER = "X-Vinext-Rsc-Render-Mode";
 
+/**
+ * Side-channel signal that an RSC response (HTTP 200) encodes a `redirect()`
+ * thrown during render. The header value is the redirect target (path-only
+ * for same-origin, absolute for cross-origin). The flight body still carries
+ * the canonical `NEXT_REDIRECT;...` digest so Next.js's own tests can read it
+ * via response.body; this header is purely for vinext's own client
+ * (`navigateRsc` in app-browser-entry.ts) to follow the redirect inside the
+ * same navigation transaction — keeping `useTransition`'s pending state
+ * continuous across the hop. Pre-1347 vinext relied on `fetch`'s auto-follow
+ * of a 307 for that, but the new 200 + flight format leaves it without a
+ * cheap way to detect the redirect ahead of stream decode.
+ */
+export const VINEXT_RSC_REDIRECT_HEADER = "X-Vinext-Rsc-Redirect";
+
 // ---------------------------------------------------------------------------
 // RSC protocol headers
 // ---------------------------------------------------------------------------

--- a/tests/app-page-execution.test.ts
+++ b/tests/app-page-execution.test.ts
@@ -322,6 +322,123 @@ describe("app page execution helpers", () => {
     expect(clearRequestContext).toHaveBeenCalledTimes(1);
   });
 
+  it("encodes redirect digest in flight payload + 200 when buildRscRedirectFlightStream is provided (RSC request)", async () => {
+    // Mirrors Next.js's `generateDynamicFlightRenderResult` path: when a
+    // server component throws redirect() during RSC rendering, the redirect
+    // digest is serialized into the flight stream and the response stays
+    // 200. The status line never carries the redirect.
+    //
+    // See: https://github.com/cloudflare/vinext/issues/1347
+    const buildRscRedirectFlightStream = vi.fn(
+      (options: { digest: string }) =>
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode(`E:${options.digest}`));
+            controller.close();
+          },
+        }),
+    );
+
+    const response = await buildAppPageSpecialErrorResponse({
+      buildRscRedirectFlightStream,
+      clearRequestContext: vi.fn(),
+      isRscRequest: true,
+      request: new Request("https://example.com/start.rsc"),
+      specialError: {
+        kind: "redirect",
+        location: "/redirected",
+        statusCode: 307,
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toMatch(/^text\/x-component/);
+    expect(response.headers.get("location")).toBeNull();
+    expect(buildRscRedirectFlightStream).toHaveBeenCalledTimes(1);
+    expect(buildRscRedirectFlightStream).toHaveBeenCalledWith({
+      digest: "NEXT_REDIRECT;replace;/redirected;307;",
+    });
+    await expect(response.text()).resolves.toBe("E:NEXT_REDIRECT;replace;/redirected;307;");
+  });
+
+  it("always emits 200 + flight payload for metadata-originated redirects (even on document SSR)", async () => {
+    // generateMetadata() redirects are streamed inside the flight payload
+    // because metadata resolution is suspended in Next.js. The HTTP status
+    // stays 200 for both RSC and full document requests. Mirrors Next.js
+    // test/e2e/app-dir/metadata-navigation:
+    //   "should support redirect in generateMetadata"
+    const buildRscRedirectFlightStream = vi.fn(
+      () =>
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode("flight-payload"));
+            controller.close();
+          },
+        }),
+    );
+
+    const response = await buildAppPageSpecialErrorResponse({
+      buildRscRedirectFlightStream,
+      clearRequestContext: vi.fn(),
+      isRscRequest: false,
+      request: new Request("https://example.com/start"),
+      specialError: {
+        kind: "redirect",
+        location: "/redirected",
+        statusCode: 307,
+        fromMetadata: true,
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(buildRscRedirectFlightStream).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves the 307/308 status code in the encoded digest (permanentRedirect)", async () => {
+    const captured: { digest: string }[] = [];
+    const buildRscRedirectFlightStream = (opts: { digest: string }) => {
+      captured.push(opts);
+      return new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.close();
+        },
+      });
+    };
+
+    await buildAppPageSpecialErrorResponse({
+      buildRscRedirectFlightStream,
+      clearRequestContext: vi.fn(),
+      isRscRequest: true,
+      request: new Request("https://example.com/start.rsc"),
+      specialError: {
+        kind: "redirect",
+        location: "/permanent-target",
+        statusCode: 308,
+      },
+    });
+
+    expect(captured).toEqual([{ digest: "NEXT_REDIRECT;replace;/permanent-target;308;" }]);
+  });
+
+  it("falls back to 307 when buildRscRedirectFlightStream is absent (backward compat)", async () => {
+    // Callers that don't yet plumb the flight-stream builder keep the legacy
+    // behavior: HTTP 307 with a Location header. Keeps non-app-router callers
+    // (and any test helpers) working without changes.
+    const response = await buildAppPageSpecialErrorResponse({
+      clearRequestContext: vi.fn(),
+      isRscRequest: true,
+      request: new Request("https://example.com/start.rsc"),
+      specialError: {
+        kind: "redirect",
+        location: "/redirected",
+        statusCode: 307,
+      },
+    });
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toMatch(/redirected\.rsc/);
+  });
+
   it("canonicalizes same-origin RSC redirect locations to .rsc URLs", async () => {
     const response = await buildAppPageSpecialErrorResponse({
       clearRequestContext: vi.fn(),

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -1105,6 +1105,80 @@ describe("App Router integration", () => {
     expect(location).toContain("/about");
   });
 
+  // Ported from Next.js: test/e2e/app-dir/rsc-redirect/rsc-redirect.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/rsc-redirect/rsc-redirect.test.ts
+  //
+  // When a server component calls `redirect()` and the client makes an RSC
+  // navigation request, Next.js returns HTTP 200 with the redirect instruction
+  // encoded in the RSC flight payload. The status code must be 200 because the
+  // client uses `redirect: 'manual'` fetch semantics when validating
+  // cache-busting; a raw 307 would break that flow. vinext addresses RSC
+  // payloads via the `.rsc` suffix (not the `Rsc` header — see
+  // app-rsc-request-normalization.ts), so we hit `.rsc` directly here.
+  //
+  // See: https://github.com/cloudflare/vinext/issues/1347
+  it("redirect() from Server Component returns 200 + flight payload for RSC navigations", async () => {
+    const res = await fetch(`${baseUrl}/redirect-test.rsc`, {
+      redirect: "manual",
+      headers: { Accept: "text/x-component" },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/x-component");
+    const text = await res.text();
+    // The redirect must be embedded in the flight payload so the client router
+    // can detect it and navigate. Match Next.js's encoding: the NEXT_REDIRECT
+    // digest is serialized as part of the React error chunk.
+    expect(text).toContain("NEXT_REDIRECT");
+    expect(text).toContain("/about");
+  });
+
+  it("permanentRedirect() from Server Component returns 200 + flight payload for RSC navigations", async () => {
+    const res = await fetch(`${baseUrl}/permanent-redirect-test.rsc`, {
+      redirect: "manual",
+      headers: { Accept: "text/x-component" },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/x-component");
+    const text = await res.text();
+    expect(text).toContain("NEXT_REDIRECT");
+    expect(text).toContain("/about");
+    // The digest preserves the 308 status code so the client knows it's a
+    // permanent redirect. Mirrors Next.js's `redirect()` vs
+    // `permanentRedirect()` distinction in the flight payload encoding.
+    expect(text).toContain("308");
+  });
+
+  // Ported from Next.js:
+  // test/e2e/app-dir/metadata-navigation/metadata-navigation.test.ts
+  // ("should support redirect in generateMetadata"). When generateMetadata
+  // throws redirect(), Next.js still returns 200 — metadata is suspended in
+  // SSR so the redirect rides inside the streamed flight payload rather than
+  // becoming an HTTP-level 307. See:
+  //   https://github.com/cloudflare/vinext/issues/1347
+  it("redirect() from generateMetadata returns 200 with flight redirect payload (RSC)", async () => {
+    const res = await fetch(`${baseUrl}/metadata-redirect-test.rsc`, {
+      redirect: "manual",
+      headers: { Accept: "text/x-component" },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/x-component");
+    const text = await res.text();
+    expect(text).toContain("NEXT_REDIRECT");
+    expect(text).toContain("/about");
+  });
+
+  it("redirect() from generateMetadata returns 200 for SSR document request", async () => {
+    const res = await fetch(`${baseUrl}/metadata-redirect-test`, {
+      redirect: "manual",
+    });
+    // Metadata is suspended in SSR — the redirect surfaces via the inlined
+    // flight payload, not as an HTTP-level redirect.
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toContain("NEXT_REDIRECT");
+    expect(text).toContain("/about");
+  });
+
   // ── probePage() with Next.js 15+ async params/searchParams ──
   // Regression tests: probePage() passed raw null-prototype params instead of
   // thenable params, so pages using `await params` threw TypeError during probe,

--- a/tests/fixtures/app-basic/app/metadata-redirect-test/page.tsx
+++ b/tests/fixtures/app-basic/app/metadata-redirect-test/page.tsx
@@ -1,0 +1,15 @@
+import { redirect } from "next/navigation";
+
+// generateMetadata throws redirect(). In Next.js, metadata resolution is
+// suspended/streamed, so the SSR response stays 200 (the redirect is encoded
+// in the streamed flight payload). Same behavior for the RSC navigation
+// request — see https://github.com/cloudflare/vinext/issues/1347 and Next.js's
+// test/e2e/app-dir/metadata-navigation/metadata-navigation.test.ts
+// ("should support redirect in generateMetadata").
+export async function generateMetadata() {
+  redirect("/about");
+}
+
+export default function MetadataRedirectTestPage() {
+  return <div data-testid="metadata-redirect-page">metadata redirect page</div>;
+}


### PR DESCRIPTION
## Summary

- For `.rsc` navigation requests, encode `redirect()` from a server component as a `NEXT_REDIRECT;<type>;<url>;<status>;` digest inside the flight stream and return HTTP 200. A raw 307 breaks the client router's cache-busting validation path (it uses `redirect: 'manual'` semantics).
- For `generateMetadata()` redirects, always return 200 with a flight payload — both RSC and document SSR. Metadata is suspended in Next.js, so its redirects ride inside the flight body, never the HTTP status line.
- Page-component `redirect()` on SSR document requests still emits a 307, unchanged.

### Payload shape

```
"Content-Type: text/x-component"
Status: 200
Body: <flight stream containing an error chunk with digest "NEXT_REDIRECT;replace;/about;307;">
```

The digest format matches Next.js's `getRedirectError` in `client/components/redirect.ts:20-23`:
```
${REDIRECT_ERROR_CODE};${type};${url};${statusCode};
```

Same-origin URLs are reduced to path form (matching how `redirect("/about")` was called) so the client's `router.push(url)` accepts them unchanged.

### Implementation

- `app-page-execution.ts`:
  - New `tagAppPageMetadataError` helper marks errors thrown from `resolveModuleMetadata` so the special-error handler can distinguish metadata-origin redirects from page-origin ones.
  - `buildAppPageSpecialErrorResponse` now accepts an optional `buildRscRedirectFlightStream` callback. When the request is RSC, or when the error is tagged as metadata-origin, the callback is invoked to produce a flight stream and the response status is 200.
- `app-page-dispatch.ts`: wires up `buildRscRedirectFlightStream` by rendering a tiny throwing element via the existing `renderToReadableStream` — `onError` returns the digest, react-server-dom-webpack serializes the error chunk.
- `app-page-head.ts`: wraps `resolveModuleMetadata` to tag thrown errors.

### References

- Next.js test: `test/e2e/app-dir/rsc-redirect/rsc-redirect.test.ts` (expects 200 for RSC, 307 for document)
- Next.js test: `test/e2e/app-dir/metadata-navigation/metadata-navigation.test.ts` ("should support redirect in generateMetadata", expects 200)
- Next.js source: `packages/next/src/server/app-render/app-render.tsx` (`generateDynamicFlightRenderResult` lets redirects propagate through `renderToFlightStream`)
- Next.js source: `packages/next/src/client/components/redirect.ts` (`getRedirectError` digest format)
- Next.js source: `packages/next/src/client/components/redirect-boundary.tsx` (client-side decoder)

Closes #1347

## Test plan

- [x] `pnpm test tests/app-page-execution.test.ts` — 26/26 pass (4 new unit tests cover the flight-payload encoding, metadata-origin tagging, status-code preservation, and 307 fallback).
- [x] `pnpm test --project integration tests/app-router.test.ts` — 322/322 pass (4 new integration tests cover `redirect()` and `permanentRedirect()` via `.rsc`, plus `generateMetadata` redirect for both RSC and document SSR).
- [x] `pnpm test --project integration tests/features.test.ts tests/entry-templates.test.ts tests/prerender.test.ts tests/nextjs-compat/` — 687/687 pass (regression coverage for adjacent app-router behavior).
- [x] `pnpm run check` — formatting + lint + type-check clean.