### PR TITLE
fix(pages-router): wrap edge API request in NextRequest, support bare runtime export

### DIFF
--- a/packages/vinext/src/server/api-handler.ts
+++ b/packages/vinext/src/server/api-handler.ts
@@ -16,6 +16,7 @@ import { reportRequestError, importModule, type ModuleImporter } from "./instrum
 import { mergeRouteParamsIntoQuery, parseQueryString } from "../utils/query.js";
 import { PagesBodyParseError, getMediaType, isJsonMediaType } from "./pages-media-type.js";
 import { isEdgeApiRuntime } from "./edge-api-runtime.js";
+import { NextRequest } from "vinext/shims/server";
 
 /**
  * Extend the Node.js request with Next.js-style helpers.
@@ -37,9 +38,18 @@ type NextApiResponse = {
 } & ServerResponse;
 
 type EdgeApiRouteModule = {
+  /**
+   * `export const config = { runtime: 'edge' }` — historical Pages Router form.
+   */
   config?: {
     runtime?: string;
   };
+  /**
+   * `export const runtime = 'edge'` — bare export form. Next.js resolves the
+   * effective runtime as `config.runtime ?? config.config?.runtime`, so a
+   * top-level `runtime` export takes precedence over the nested config form.
+   */
+  runtime?: string;
   default: (request: Request) => Response | Promise<Response>;
 };
 
@@ -121,12 +131,16 @@ function parseCookies(req: IncomingMessage): Record<string, string> {
 }
 
 function isEdgeApiRouteModule(module: Record<string, unknown>): module is EdgeApiRouteModule {
+  if (typeof module.default !== "function") return false;
+  // Bare `export const runtime = 'edge'` takes precedence over the nested config
+  // form, matching Next.js (`config.runtime ?? config.config?.runtime` in
+  // packages/next/src/build/analysis/get-page-static-info.ts).
+  const bare = module.runtime;
+  if (typeof bare === "string") return isEdgeApiRuntime(bare);
   const config = module.config;
   if (!config || typeof config !== "object") return false;
-  const runtime = "runtime" in config ? config.runtime : undefined;
-  return (
-    typeof module.default === "function" && typeof runtime === "string" && isEdgeApiRuntime(runtime)
-  );
+  const runtime = "runtime" in config ? (config as { runtime?: unknown }).runtime : undefined;
+  return typeof runtime === "string" && isEdgeApiRuntime(runtime);
 }
 
 function readEdgeRequestBody(req: IncomingMessage): ReadableStream<Uint8Array> | undefined {
@@ -304,7 +318,11 @@ export async function handleApiRoute(
     // Load the API route module through the ModuleRunner
     const apiModule = await importModule(runner, route.filePath);
     if (isEdgeApiRouteModule(apiModule)) {
-      const response = await apiModule.default(createEdgeApiRequest(req, url));
+      // Next.js wraps the incoming Request in a NextRequest before invoking
+      // edge API handlers, so handlers can use `req.nextUrl.searchParams`,
+      // `req.cookies`, etc. (Cf. NextRequestHint in next/src/server/web/adapter.ts.)
+      const nextRequest = new NextRequest(createEdgeApiRequest(req, url));
+      const response = await apiModule.default(nextRequest);
       if (!(response instanceof Response)) {
         throw new Error("Edge API route did not return a Response");
       }

--- a/packages/vinext/src/server/pages-api-route.ts
+++ b/packages/vinext/src/server/pages-api-route.ts
@@ -11,6 +11,7 @@ import {
 } from "./pages-node-compat.js";
 import { internalServerErrorResponse } from "./http-error-responses.js";
 import { isEdgeApiRuntime } from "./edge-api-runtime.js";
+import { NextRequest } from "vinext/shims/server";
 
 type PagesApiRouteConfig = {
   runtime?: string;
@@ -24,9 +25,24 @@ type PagesNodeApiRouteHandler = (
 type PagesEdgeApiRouteHandler = (request: Request) => Response | Promise<Response>;
 
 type PagesApiRouteModule = {
+  /**
+   * `export const config = { runtime: 'edge' }` — historical Pages Router form.
+   */
   config?: PagesApiRouteConfig;
+  /**
+   * `export const runtime = 'edge'` — bare export form. Next.js resolves the
+   * effective runtime as `config.runtime ?? config.config?.runtime`, so a
+   * top-level `runtime` export takes precedence over the nested config form.
+   *
+   * @see https://github.com/vercel/next.js/blob/canary/packages/next/src/build/analysis/get-page-static-info.ts
+   */
+  runtime?: string;
   default?: PagesNodeApiRouteHandler | PagesEdgeApiRouteHandler;
 };
+
+function resolveModuleRuntime(module: PagesApiRouteModule): string | undefined {
+  return module.runtime ?? module.config?.runtime;
+}
 
 export type PagesApiRouteMatch = {
   params: PagesRequestQuery;
@@ -49,13 +65,13 @@ function buildPagesApiQuery(url: string, params: PagesRequestQuery): PagesReques
 function isEdgeApiRouteModule(
   module: PagesApiRouteModule,
 ): module is PagesApiRouteModule & { default: PagesEdgeApiRouteHandler } {
-  return typeof module.default === "function" && isEdgeApiRuntime(module.config?.runtime);
+  return typeof module.default === "function" && isEdgeApiRuntime(resolveModuleRuntime(module));
 }
 
 function isNodeApiRouteModule(
   module: PagesApiRouteModule,
 ): module is PagesApiRouteModule & { default: PagesNodeApiRouteHandler } {
-  return typeof module.default === "function" && !isEdgeApiRuntime(module.config?.runtime);
+  return typeof module.default === "function" && !isEdgeApiRuntime(resolveModuleRuntime(module));
 }
 
 export async function handlePagesApiRoute(options: HandlePagesApiRouteOptions): Promise<Response> {
@@ -67,7 +83,11 @@ export async function handlePagesApiRoute(options: HandlePagesApiRouteOptions): 
 
   try {
     if (isEdgeApiRouteModule(route.module)) {
-      const response = await route.module.default(options.request);
+      // Next.js wraps the incoming Request in a NextRequest before invoking
+      // edge API handlers, so handlers can use `req.nextUrl.searchParams`,
+      // `req.cookies`, etc. (Cf. NextRequestHint in next/src/server/web/adapter.ts.)
+      const nextRequest = new NextRequest(options.request);
+      const response = await route.module.default(nextRequest);
       if (response instanceof Response) {
         return response;
       }

--- a/tests/api-handler.test.ts
+++ b/tests/api-handler.test.ts
@@ -947,6 +947,62 @@ describe("handleApiRoute", () => {
       }
     });
 
+    it("passes a NextRequest with nextUrl.searchParams to edge handlers", async () => {
+      // Ported from Next.js: test/e2e/edge-pages-support/app/pages/api/hello.js
+      // https://github.com/vercel/next.js/blob/canary/test/e2e/edge-pages-support/app/pages/api/hello.js
+      // Next.js wraps the incoming Request in a NextRequest before invoking
+      // edge API handlers, so handlers can use `req.nextUrl.searchParams`.
+      const handler = vi.fn((request: Request) => {
+        const nextUrl = (request as { nextUrl?: URL }).nextUrl;
+        if (!nextUrl) return new Response("missing nextUrl", { status: 500 });
+        return Response.json({
+          hello: "world",
+          query: Object.fromEntries(nextUrl.searchParams),
+        });
+      });
+      const server = mockServer({
+        config: { runtime: "edge" },
+        default: handler,
+      });
+      const req = mockReq("GET", "/api/hello?a=b", undefined, {
+        host: "example.com",
+      });
+      const res = mockRes();
+
+      await handleApiRoute(server, req, res, "/api/hello?a=b", [route("/api/hello")]);
+
+      expect(res._statusCode).toBe(200);
+      expect(JSON.parse(res._body.toString())).toEqual({
+        hello: "world",
+        query: { a: "b" },
+      });
+    });
+
+    it("recognises bare \"export const runtime = 'edge'\" as an edge API route", async () => {
+      // Ported from Next.js: packages/next/src/build/analysis/get-page-static-info.ts
+      // Both `export const runtime = "edge"` and `export const config = { runtime: "edge" }`
+      // are valid ways to mark a Pages Router API route as edge. Next.js resolves
+      // via `config.runtime ?? config.config?.runtime`, so a bare `runtime` export
+      // takes precedence over the nested config form.
+      const handler = vi.fn((request: Request) =>
+        Response.json({ id: request.headers.get("req-id") }),
+      );
+      const server = mockServer({
+        runtime: "edge",
+        default: handler,
+      });
+      const req = mockReq("GET", "/api/users", undefined, {
+        host: "example.com",
+        "req-id": "req-7",
+      });
+      const res = mockRes();
+
+      await handleApiRoute(server, req, res, "/api/users", [route("/api/users")]);
+
+      expect(res._statusCode).toBe(200);
+      expect(JSON.parse(res._body.toString())).toEqual({ id: "req-7" });
+    });
+
     it("streams edge API request bodies into the handler before the client finishes sending", async () => {
       const decoder = new TextDecoder();
       const handler = vi.fn(async (request: Request) => {

--- a/tests/pages-api-route.test.ts
+++ b/tests/pages-api-route.test.ts
@@ -282,6 +282,61 @@ describe("pages api route", () => {
     await expect(response.json()).resolves.toEqual({ id: "req-42" });
   });
 
+  it("passes a NextRequest with nextUrl.searchParams to edge API handlers", async () => {
+    // Ported from Next.js: test/e2e/edge-pages-support/app/pages/api/hello.js
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/edge-pages-support/app/pages/api/hello.js
+    // Next.js wraps the request in a NextRequest before invoking the user's
+    // edge API handler, so handlers can use `req.nextUrl.searchParams`.
+    const response = await handlePagesApiRoute({
+      match: createMatch(
+        (request: Request) => {
+          const nextUrl = (request as Request & { nextUrl?: URL }).nextUrl;
+          if (!nextUrl) {
+            return new Response("missing nextUrl", { status: 500 });
+          }
+          return Response.json({
+            hello: "world",
+            query: Object.fromEntries(nextUrl.searchParams),
+          });
+        },
+        {},
+        { runtime: "edge" },
+      ),
+      request: new Request("https://example.com/api/hello?a=b"),
+      url: "/api/hello?a=b",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      hello: "world",
+      query: { a: "b" },
+    });
+  });
+
+  it("recognises bare \"export const runtime = 'edge'\" as an edge API route", async () => {
+    // Ported from Next.js: packages/next/src/build/analysis/get-page-static-info.ts
+    // Both `export const runtime = "edge"` and `export const config = { runtime: "edge" }`
+    // are valid ways to mark a Pages Router API route as edge. Next.js resolves
+    // via `config.runtime ?? config.config?.runtime`.
+    const response = await handlePagesApiRoute({
+      match: {
+        params: {},
+        route: {
+          pattern: "/api/edge-bare",
+          module: {
+            runtime: "edge",
+            default: (request: Request) => Response.json({ ok: true, kind: typeof request }),
+          } as unknown as PagesApiRouteModule,
+        },
+      },
+      request: new Request("https://example.com/api/edge-bare"),
+      url: "/api/edge-bare",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ok: true, kind: "object" });
+  });
+
   it("preserves nested AsyncLocalStorage state across concurrent edge API requests", async () => {
     // Ported from Next.js: test/e2e/edge-async-local-storage/index.test.ts
     // https://github.com/vercel/next.js/blob/canary/test/e2e/edge-async-local-storage/index.test.ts


### PR DESCRIPTION
## Summary

Refs #1338.

Pages Router edge API routes were returning 500 in vinext when a handler used the idiomatic `req.nextUrl.searchParams` pattern, or when the route used the bare `export const runtime = 'edge'` form. Two parity gaps with Next.js were responsible:

- **Edge API handlers received a plain `Request`.** Next.js wraps the incoming request in a `NextRequest` (`NextRequestHint` in `packages/next/src/server/web/adapter.ts`) before invoking the user handler, so handlers can use `req.nextUrl`, `req.cookies`, etc. vinext was passing a plain `Request`, causing `Cannot read properties of undefined (reading 'searchParams')` to be raised inside the handler.
- **Only `export const config = { runtime: 'edge' }` was recognised.** Next.js also accepts a bare `export const runtime = 'edge'` and resolves the effective runtime as `config.runtime ?? config.config?.runtime` (`packages/next/src/build/analysis/get-page-static-info.ts`). vinext's `isEdgeApiRouteModule` checks only consulted `module.config.runtime`, so the bare form was silently dispatched through the Node code path.

Fixed in both:
- `packages/vinext/src/server/api-handler.ts` (dev server)
- `packages/vinext/src/server/pages-api-route.ts` (production server)

so the two stay in parity per AGENTS.md.

## What is deferred

Issue #1338 also covers OG `ImageResponse` routes (Pages Router `/api/og` returning 404, App Router custom-font OG returning 500), edge document/streaming SSR edge support, and edge-runtime node-compat tests. Those are separate sub-problems with different root causes (JSX-in-`.js` transform, `@vercel/og` font loading on Workers, edge document wiring) and are intentionally left for follow-up PRs.

## Test plan

- [x] `pnpm test tests/pages-api-route.test.ts` — new test asserts `req.nextUrl.searchParams` is reachable in an edge API handler.
- [x] `pnpm test tests/api-handler.test.ts` — new tests cover bare `export const runtime = 'edge'` recognition and `NextRequest` wrapping in dev.
- [x] `pnpm test tests/entry-templates.test.ts` — generated entry wiring unaffected.
- [x] `vp check --fix` — format/lint/type checks pass.
- [ ] Next.js deploy suite: `test/e2e/edge-pages-support/index.test.ts` should now pass `/api/hello` and `/api/[id]` cases.