### PR TITLE
fix(css): compile SCSS before LightningCSS minification

### DIFF
--- a/packages/vinext/package.json
+++ b/packages/vinext/package.json
@@ -69,6 +69,7 @@
     "image-size": "catalog:",
     "ipaddr.js": "catalog:",
     "magic-string": "catalog:",
+    "postcss": "catalog:",
     "vite-plugin-commonjs": "catalog:",
     "vite-tsconfig-paths": "catalog:",
     "web-vitals": "catalog:"

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -1299,6 +1299,26 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         // Reference: packages/next/src/build/webpack/config/blocks/css/index.ts
         const sassPreprocessorOptions = buildSassPreprocessorOptions(nextConfig.sassOptions);
 
+        // Only install our `css.modules.Loader` (which fixes #1343) when the
+        // user has not supplied their own. Vite's config merge does a shallow
+        // merge on `css.modules`, so an explicit user Loader would otherwise
+        // be silently overridden. Detect the `false` form (CSS modules
+        // disabled) too — wiring up a Loader in that case is pointless.
+        const userCssModules = config.css?.modules;
+        // oxlint-disable-next-line typescript/no-explicit-any
+        const userSuppliedLoader = !!(userCssModules && (userCssModules as any).Loader);
+        const installCssModulesLoader = userCssModules !== false && !userSuppliedLoader;
+        if (userSuppliedLoader) {
+          // Warn so users who set a custom Loader know they have opted out
+          // of the SCSS `composes` preprocessor fix. (See #1343.) We avoid
+          // throwing because power-user setups may deliberately want to
+          // bring their own postcss-modules Loader.
+          console.warn(
+            "[vinext] css.modules.Loader is set in your config — vinext's SCSS preprocessor for `composes ... from './x.module.scss'` is disabled. " +
+              "If you import .scss CSS modules via composes, ensure your Loader preprocesses them or you will hit lightningcss minify errors. See https://github.com/cloudflare/vinext/issues/1343.",
+          );
+        }
+
         // Auto-inject @mdx-js/rollup when MDX files exist and no MDX plugin is
         // already configured. Applies remark/rehype plugins from next.config.
         hasUserMdxPlugin = pluginsFlat.some(
@@ -1637,27 +1657,39 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                   // environment default) with "Invalid empty selector".
                   // See packages/vinext/src/plugins/css-modules-preprocess.ts.
                   //
+                  // We skip this when the user has supplied their own
+                  // `css.modules.Loader` or disabled CSS modules entirely
+                  // (`css.modules: false`). See `installCssModulesLoader`
+                  // above.
+                  //
                   // `Loader` is a documented postcss-modules option that
                   // Vite passes through verbatim, but Vite's TypeScript
                   // `CSSModulesOptions` interface doesn't declare it. The
                   // cast tells TS the extra key is intentional.
-                  modules: {
-                    Loader: createCssModulesPreprocessingLoader(getResolvedConfig),
-                    // oxlint-disable-next-line typescript/no-explicit-any
-                  } as any,
+                  ...(installCssModulesLoader
+                    ? {
+                        modules: {
+                          Loader: createCssModulesPreprocessingLoader(getResolvedConfig),
+                          // oxlint-disable-next-line typescript/no-explicit-any
+                        } as any,
+                      }
+                    : {}),
                 },
               }
-            : {
-                // No PostCSS/sass overrides — still install our Loader so
-                // SCSS `composes` works for projects that don't otherwise
-                // customise CSS preprocessing. See note above on the cast.
-                css: {
-                  modules: {
-                    Loader: createCssModulesPreprocessingLoader(getResolvedConfig),
-                    // oxlint-disable-next-line typescript/no-explicit-any
-                  } as any,
-                },
-              }),
+            : installCssModulesLoader
+              ? {
+                  // No PostCSS/sass overrides — still install our Loader
+                  // so SCSS `composes` works for projects that don't
+                  // otherwise customise CSS preprocessing. See note above
+                  // on the cast and the user-supplied-Loader guard.
+                  css: {
+                    modules: {
+                      Loader: createCssModulesPreprocessingLoader(getResolvedConfig),
+                      // oxlint-disable-next-line typescript/no-explicit-any
+                    } as any,
+                  },
+                }
+              : {}),
         };
 
         // Collect user-provided ssr.external so we can propagate it into

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -110,6 +110,7 @@ import { hasWranglerConfig, formatMissingCloudflarePluginError } from "./deploy.
 import { computeLazyChunks } from "./utils/lazy-chunks.js";
 import { resolvePostcssStringPlugins } from "./plugins/postcss.js";
 import { buildSassPreprocessorOptions } from "./plugins/sass.js";
+import { createCssModulesPreprocessingLoader } from "./plugins/css-modules-preprocess.js";
 import {
   createClientManualChunks,
   createClientOutputConfig,
@@ -638,6 +639,16 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
   let warnedInlineNextConfigOverride = false;
   let hasNitroPlugin = false;
   let rscCompatibilityId: string | undefined;
+
+  // Resolved Vite config, captured in `configResolved`. Read at runtime
+  // by the custom `postcss-modules` Loader (see
+  // `createCssModulesPreprocessingLoader`) so it can invoke Vite's
+  // `preprocessCSS` with the same preprocessor options as the rest of
+  // the pipeline. Lives in the plugin closure so the Loader class can
+  // be constructed up front in `config()` and still pick up the
+  // resolved config later.
+  let resolvedViteConfig: import("vite").ResolvedConfig | undefined;
+  const getResolvedConfig = () => resolvedViteConfig;
 
   // Build-time layout classification manifest, captured in the RSC virtual
   // module's load hook and consumed in generateBundle to patch the generated
@@ -1617,9 +1628,36 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                         },
                       }
                     : {}),
+                  // Custom Loader that preprocesses .scss/.sass/.less/.styl
+                  // files before postcss-modules sees them. Fixes #1343:
+                  // without it, the default `FileSystemLoader` reads raw
+                  // SCSS for `composes: foo from './other.module.scss'`
+                  // and lets Sass variables leak into the final bundle,
+                  // breaking Vite 8's lightningcss minifier (the server-
+                  // environment default) with "Invalid empty selector".
+                  // See packages/vinext/src/plugins/css-modules-preprocess.ts.
+                  //
+                  // `Loader` is a documented postcss-modules option that
+                  // Vite passes through verbatim, but Vite's TypeScript
+                  // `CSSModulesOptions` interface doesn't declare it. The
+                  // cast tells TS the extra key is intentional.
+                  modules: {
+                    Loader: createCssModulesPreprocessingLoader(getResolvedConfig),
+                    // oxlint-disable-next-line typescript/no-explicit-any
+                  } as any,
                 },
               }
-            : {}),
+            : {
+                // No PostCSS/sass overrides — still install our Loader so
+                // SCSS `composes` works for projects that don't otherwise
+                // customise CSS preprocessing. See note above on the cast.
+                css: {
+                  modules: {
+                    Loader: createCssModulesPreprocessingLoader(getResolvedConfig),
+                    // oxlint-disable-next-line typescript/no-explicit-any
+                  } as any,
+                },
+              }),
         };
 
         // Collect user-provided ssr.external so we can propagate it into
@@ -1926,6 +1964,14 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
       },
 
       configResolved(config) {
+        // Capture the resolved Vite config for the custom
+        // `css.modules.Loader` (see `createCssModulesPreprocessingLoader`).
+        // The Loader needs access to `css.preprocessorOptions` /
+        // `sassOptions` when invoking `preprocessCSS`, but it's
+        // constructed during `config()` (before this hook fires), so we
+        // hand it a getter that closes over this variable.
+        resolvedViteConfig = config;
+
         // When the user sets `ssr.external: true`, strip React entries from
         // `environments.ssr.resolve.noExternal`. @vitejs/plugin-rsc populates
         // this list via crawlFrameworkPkgs, but `noExternal` overrides

--- a/packages/vinext/src/plugins/css-modules-preprocess.ts
+++ b/packages/vinext/src/plugins/css-modules-preprocess.ts
@@ -60,6 +60,7 @@
 
 import path from "node:path";
 import fs from "node:fs/promises";
+import { createRequire } from "node:module";
 import postcss from "postcss";
 import type { ResolvedConfig } from "vite";
 // `vite` re-exports `preprocessCSS` (see `vite/dist/node/index.d.ts`).
@@ -67,6 +68,14 @@ import type { ResolvedConfig } from "vite";
 // many minor versions and is the canonical way to invoke Vite's CSS
 // preprocessor pipeline from outside a transform hook.
 import { preprocessCSS } from "vite";
+
+// vinext ships as ESM (`"type": "module"`), so bare `require` is not
+// available at runtime. Build a real CommonJS `require` anchored at this
+// module's URL so we can call `require.resolve()` for bare specifiers
+// (e.g. `composes: foo from 'shared/styles.module.css'`). Matches the
+// pattern used by the rest of the vinext source (see uses of
+// `createRequire` in src/index.ts).
+const nodeRequire = createRequire(import.meta.url);
 
 /** File extensions Vite's `preprocessCSS` knows how to handle. */
 const PREPROCESSOR_EXT_RE = /\.(scss|sass|less|styl|stylus)$/i;
@@ -158,7 +167,7 @@ export function createCssModulesPreprocessingLoader(
       // `composes: foo from 'shared/styles.module.css'`).
       if (unquoted[0] !== "." && !path.isAbsolute(unquoted)) {
         try {
-          return require.resolve(unquoted);
+          return nodeRequire.resolve(unquoted);
         } catch {
           // Fall through to the path.resolve below — matches the
           // built-in loader's behaviour of swallowing the require
@@ -223,6 +232,15 @@ export function createCssModulesPreprocessingLoader(
       // Recurse into each import, capturing exported tokens, then
       // build the local→imported translation table from the rule's
       // declarations (`localKey: exportedKey`).
+      //
+      // Intentional divergence from the built-in `FileSystemLoader`,
+      // which fetches imports sequentially via `fetchAllImports` →
+      // `Promise.all`. Each import's `depTrace` is pre-assigned from
+      // the declaration's index, and each import writes to distinct
+      // `translations[decl.prop]` keys, so parallel fetches are safe
+      // and let independent file reads / preprocessor invocations
+      // overlap. The per-file token cache (`#tokensByFile`) ensures
+      // we still de-duplicate transitive imports.
       await Promise.all(
         importRules.map(async ({ node, importPath, depNr }) => {
           const depTrace = trace + String.fromCharCode(depNr);
@@ -262,13 +280,21 @@ export function createCssModulesPreprocessingLoader(
       // got renamed by the import-translation pass above, so we apply
       // translations one more time (matching the built-in Parser's
       // `handleExport` loop).
+      //
+      // We use `replaceAll` with a function replacement so that:
+      //   1. Every occurrence of `key` is substituted (string-pattern
+      //      `replace` only handles the first match).
+      //   2. `$&` / `$1` / etc. in `translations[key]` (which can contain
+      //      `$` after Sass processing) are NOT interpreted as
+      //      replacement-string special patterns — function replacements
+      //      bypass that escaping.
       root.each((node) => {
         if (node.type === "rule" && node.selector === ":export") {
           node.each((decl) => {
             if (decl.type === "decl") {
               let value = decl.value;
               for (const key of Object.keys(translations)) {
-                value = value.replace(key, translations[key]!);
+                value = value.replaceAll(key, () => translations[key]!);
               }
               exportTokens[decl.prop] = value;
             }

--- a/packages/vinext/src/plugins/css-modules-preprocess.ts
+++ b/packages/vinext/src/plugins/css-modules-preprocess.ts
@@ -1,0 +1,351 @@
+/**
+ * Custom `postcss-modules` Loader that preprocesses CSS preprocessor files
+ * (SCSS, Sass, Less, Stylus) BEFORE PostCSS reads them.
+ *
+ * ── Why this exists ────────────────────────────────────────────────────
+ *
+ * When a CSS module uses `composes: foo from './other.module.scss'`,
+ * postcss-modules' built-in `FileSystemLoader` resolves the imported file
+ * with `fs.readFile` and feeds the raw text directly into PostCSS Core.
+ * It does NOT know about the Vite pipeline, so `.scss`/`.sass`/`.less`/
+ * `.styl` files are loaded as-is — Sass variables (`$var: red;`),
+ * `@use`/`@forward` directives, Less variables (`@var: red;`), Stylus
+ * indentation, etc. all leak through verbatim.
+ *
+ * The downstream `vite:css-post` plugin then concatenates that raw
+ * preprocessor source into the final bundle and hands it to the CSS
+ * minifier. In Vite 8, server environments default `cssMinify` to
+ * `'lightningcss'` (see `resolveBuildOptions` in the Vite source),
+ * which then fails with:
+ *
+ *   SyntaxError: [lightningcss minify] Invalid empty selector
+ *   1  |  $var: red;._className_10j3d_2 {
+ *
+ * Webpack + Next.js avoids this because the `composes ... from` import
+ * goes through the full webpack loader chain (sass-loader → css-loader),
+ * which preprocesses before css-modules runs. Vite's
+ * `postcss-modules`-based pipeline doesn't have that integration, so we
+ * supply our own `Loader` class via `css.modules.Loader` to bridge the gap.
+ *
+ * ── How it works ───────────────────────────────────────────────────────
+ *
+ * postcss-modules accepts a `Loader` constructor in its options
+ * (`opts.Loader`). The class must implement
+ * `fetch(file, relativeTo, trace) → Promise<exportTokens>` and expose a
+ * `finalSource` getter that returns the concatenated CSS to be prepended
+ * to the resulting output.
+ *
+ * `postcss-modules` is bundled inside the Vite distribution (not exposed
+ * as its own package), so we cannot import `FileSystemLoader` and
+ * delegate. Instead we reimplement the file-load + recursive-import +
+ * token-extraction flow from scratch using `postcss` (which IS a
+ * regular package we depend on), and run Vite's `preprocessCSS` on
+ * the source before feeding it to PostCSS.
+ *
+ * The plugin pipeline that `postcss-modules` builds (its
+ * `getDefaultPluginsList` output: postcss-modules-local-by-default →
+ * postcss-modules-extract-imports → postcss-modules-scope →
+ * postcss-modules-values) is passed to our constructor unchanged via
+ * the `plugins` argument. Those plugins emit the `:import` and
+ * `:export` AST rules we walk below.
+ *
+ * ── Related ────────────────────────────────────────────────────────────
+ *
+ * - Issue: https://github.com/cloudflare/vinext/issues/1343
+ * - Ported behaviour from Next.js:
+ *   .nextjs-ref/packages/next/src/build/webpack/config/blocks/css/loaders/modules.ts
+ *   .nextjs-ref/test/e2e/app-dir/scss/composes-external/composes-external.test.ts
+ *   .nextjs-ref/test/e2e/app-dir/scss/nm-module-nested/nm-module-nested.test.ts
+ */
+
+import path from "node:path";
+import fs from "node:fs/promises";
+import postcss from "postcss";
+import type { ResolvedConfig } from "vite";
+// `vite` re-exports `preprocessCSS` (see `vite/dist/node/index.d.ts`).
+// It is marked `@experimental` in Vite's source but has been stable for
+// many minor versions and is the canonical way to invoke Vite's CSS
+// preprocessor pipeline from outside a transform hook.
+import { preprocessCSS } from "vite";
+
+/** File extensions Vite's `preprocessCSS` knows how to handle. */
+const PREPROCESSOR_EXT_RE = /\.(scss|sass|less|styl|stylus)$/i;
+
+/** `:import("relative/path")` selector matcher used by postcss-modules. */
+const IMPORT_RE = /^:import\((.+)\)$/;
+
+/**
+ * Constructor signature postcss-modules passes to a custom Loader.
+ *
+ *   new opts.Loader(root, plugins, opts.resolve)
+ *
+ * `plugins` is the array of PostCSS plugins postcss-modules built via
+ * `getDefaultPluginsList(opts, inputFile)` — they emit the `:import`
+ * and `:export` rules we walk below. We treat them as opaque values to
+ * avoid pulling postcss type machinery into our plugin's public API.
+ */
+type LoaderPlugins = unknown[];
+type ResolveFn = ((id: string, importer: string) => string | Promise<string>) | undefined;
+
+/** Minimal interface postcss-modules expects from a Loader instance. */
+type PostcssModulesLoader = {
+  fetch(newPath: string, relativeTo: string, trace?: string): Promise<Record<string, string>>;
+  readonly finalSource: string;
+};
+
+/**
+ * Sort trace keys exactly the way postcss-modules' built-in
+ * `FileSystemLoader` does (see `traceKeySorter`). The order determines
+ * the relative position of each composed file's CSS in the final
+ * concatenated output. Shorter (= earlier) traces come first, with
+ * lexical fallback for equal lengths.
+ */
+function traceKeySorter(a: string, b: string): number {
+  if (a.length < b.length) {
+    return a < b.substring(0, a.length) ? -1 : 1;
+  }
+  if (a.length > b.length) {
+    return a.substring(0, b.length) <= b ? -1 : 1;
+  }
+  return a < b ? -1 : 1;
+}
+
+/**
+ * Build a `Loader` class suitable for `css.modules.Loader`.
+ *
+ * The Vite `ResolvedConfig` is captured in the closure via `getConfig`
+ * (rather than being passed to the constructor) because postcss-modules
+ * instantiates the Loader with a fixed signature `(root, plugins,
+ * resolve)`. We need extra state, and a closure is the clean way to
+ * thread it.
+ */
+export function createCssModulesPreprocessingLoader(
+  getConfig: () => ResolvedConfig | undefined,
+): new (root: string, plugins: LoaderPlugins, resolve?: ResolveFn) => PostcssModulesLoader {
+  return class PreprocessingLoader implements PostcssModulesLoader {
+    #root: string;
+    #plugins: LoaderPlugins;
+    #resolve: ResolveFn;
+    /** Per-file injectable CSS, keyed by absolute file path. */
+    #sources: Record<string, string> = {};
+    /** Map from trace key (load order) to absolute file path. */
+    #traces: Record<string, string> = {};
+    /** Tokens per absolute file path, for cache + recursion. */
+    #tokensByFile: Record<string, Record<string, string>> = {};
+    #importNr = 0;
+
+    constructor(root: string, plugins: LoaderPlugins, resolve?: ResolveFn) {
+      this.#root = root;
+      this.#plugins = plugins;
+      this.#resolve = resolve;
+    }
+
+    /**
+     * Resolve the requested path the same way postcss-modules' default
+     * FileSystemLoader does (see `FileSystemLoader.fetch` in
+     * `vite/dist/node/chunks/build.js`, postcss-modules @6.0.1).
+     */
+    async #resolveImportPath(newPath: string, relativeTo: string): Promise<string> {
+      const unquoted = newPath.replace(/^["']|["']$/g, "");
+      const useResolve = typeof this.#resolve === "function";
+      const resolved = useResolve ? await this.#resolve!(unquoted, relativeTo) : undefined;
+      if (resolved && !path.isAbsolute(resolved)) {
+        throw new Error('The returned path from the "fileResolve" option must be absolute.');
+      }
+      const relativeDir = path.dirname(relativeTo);
+      if (resolved) return resolved;
+      // Bare module specifiers go through Node's resolver (e.g.
+      // `composes: foo from 'shared/styles.module.css'`).
+      if (unquoted[0] !== "." && !path.isAbsolute(unquoted)) {
+        try {
+          return require.resolve(unquoted);
+        } catch {
+          // Fall through to the path.resolve below — matches the
+          // built-in loader's behaviour of swallowing the require
+          // error and trying a path-relative resolve.
+        }
+      }
+      return path.resolve(path.resolve(this.#root, relativeDir), unquoted);
+    }
+
+    /**
+     * Read the file from disk and run Vite's CSS preprocessor on it if
+     * the extension calls for it. Returns plain CSS ready for PostCSS.
+     */
+    async #readSource(filePath: string): Promise<string> {
+      const raw = await fs.readFile(filePath, "utf-8");
+      if (!PREPROCESSOR_EXT_RE.test(filePath)) return raw;
+
+      const config = getConfig();
+      if (!config) return raw; // Should not happen post-configResolved.
+
+      // `preprocessCSS` picks sass/less/stylus from the filename
+      // extension and applies the user's `css.preprocessorOptions`
+      // (including any `sassOptions` forwarded from `next.config`).
+      const { code } = await preprocessCSS(raw, filePath, config);
+      return code;
+    }
+
+    /**
+     * Walk a parsed CSS root and process `:import(...)` and `:export`
+     * rules the same way postcss-modules' Parser does:
+     *
+     *  - `:import('relative/path') { localKey: exportedKey }` rules
+     *    name the file to recurse into and the symbols to alias.
+     *  - `:export { localKey: scopedClass }` rules are the public
+     *    output of the module.
+     *
+     * Both rule types are removed from the AST after processing —
+     * matching `linkImportedSymbols` + `extractExports` behaviour.
+     */
+    async #processImportsAndExports(
+      root: postcss.Root,
+      relativeTo: string,
+      trace: string,
+    ): Promise<Record<string, string>> {
+      const translations: Record<string, string> = {};
+      const exportTokens: Record<string, string> = {};
+
+      // Collect `:import` rules in declaration order so the trace keys
+      // we generate match the order downstream PostCSS sees them.
+      const importRules: { node: postcss.Rule; importPath: string; depNr: number }[] = [];
+      let depNr = 0;
+      root.each((node) => {
+        if (node.type === "rule") {
+          const match = node.selector.match(IMPORT_RE);
+          if (match) {
+            importRules.push({ node, importPath: match[1]!, depNr });
+            depNr += 1;
+          }
+        }
+      });
+
+      // Recurse into each import, capturing exported tokens, then
+      // build the local→imported translation table from the rule's
+      // declarations (`localKey: exportedKey`).
+      await Promise.all(
+        importRules.map(async ({ node, importPath, depNr }) => {
+          const depTrace = trace + String.fromCharCode(depNr);
+          const imported = await this.fetch(importPath, relativeTo, depTrace);
+          node.walkDecls((decl) => {
+            translations[decl.prop] = imported[decl.value]!;
+          });
+          node.remove();
+        }),
+      );
+
+      // Substitute translations into the rest of the AST. Declarations,
+      // rule selectors, and at-rule params all may reference imported
+      // symbols. Mirrors `icss-utils` `replaceValueSymbols`.
+      const tokenRe = /[$]?[\w-]+/g;
+      const substitute = (value: string): string => {
+        let out = value;
+        let m: RegExpExecArray | null;
+        tokenRe.lastIndex = 0;
+        while ((m = tokenRe.exec(out))) {
+          const replacement = translations[m[0]];
+          if (replacement) {
+            out = out.slice(0, m.index) + replacement + out.slice(tokenRe.lastIndex);
+            tokenRe.lastIndex -= m[0].length - replacement.length;
+          }
+        }
+        return out;
+      };
+      root.walk((node) => {
+        if (node.type === "decl" && node.value) node.value = substitute(node.value);
+        else if (node.type === "rule" && node.selector) node.selector = substitute(node.selector);
+        else if (node.type === "atrule" && node.params) node.params = substitute(node.params);
+      });
+
+      // Extract `:export` rules into our exportTokens map. The export
+      // rule's declarations may still reference local class names that
+      // got renamed by the import-translation pass above, so we apply
+      // translations one more time (matching the built-in Parser's
+      // `handleExport` loop).
+      root.each((node) => {
+        if (node.type === "rule" && node.selector === ":export") {
+          node.each((decl) => {
+            if (decl.type === "decl") {
+              let value = decl.value;
+              for (const key of Object.keys(translations)) {
+                value = value.replace(key, translations[key]!);
+              }
+              exportTokens[decl.prop] = value;
+            }
+          });
+          node.remove();
+        }
+      });
+
+      return exportTokens;
+    }
+
+    /**
+     * Build a small PostCSS plugin that drives `processImportsAndExports`
+     * on the AST. We use a plugin (rather than walking the result
+     * directly) because the upstream plugins postcss-modules supplies
+     * to us — local-by-default, scope, extract-imports, values — run
+     * via PostCSS's normal pipeline. We need them to mutate the AST
+     * BEFORE we walk for `:import` / `:export`, and the cleanest way
+     * to enforce ordering is to append our own plugin.
+     */
+    #parserPlugin(
+      relativeTo: string,
+      trace: string,
+      exportSink: Record<string, string>,
+    ): postcss.Plugin {
+      // oxlint-disable-next-line typescript/no-this-alias
+      const self = this;
+      return {
+        postcssPlugin: "vinext-css-modules-parser",
+        async OnceExit(root) {
+          const tokens = await self.#processImportsAndExports(root, relativeTo, trace);
+          for (const [k, v] of Object.entries(tokens)) exportSink[k] = v;
+        },
+      };
+    }
+
+    async fetch(
+      newPath: string,
+      relativeTo: string,
+      trace?: string,
+    ): Promise<Record<string, string>> {
+      const effectiveTrace = trace ?? String.fromCharCode(this.#importNr++);
+      const fileAbsPath = await this.#resolveImportPath(newPath, relativeTo);
+
+      // Return cached tokens if this file has already been fetched.
+      // Matches `tokensByFile` short-circuit in the built-in loader.
+      const cached = this.#tokensByFile[fileAbsPath];
+      if (cached) return cached;
+
+      const sourceString = await this.#readSource(fileAbsPath);
+      const exportSink: Record<string, string> = {};
+      // postcss-modules-* plugins arrive opaquely typed; postcss accepts
+      // any AcceptedPlugin shape at runtime.
+      const plugins = [
+        ...(this.#plugins as postcss.AcceptedPlugin[]),
+        this.#parserPlugin(fileAbsPath, effectiveTrace, exportSink),
+      ];
+      const result = await postcss(plugins).process(sourceString, { from: fileAbsPath });
+
+      this.#sources[fileAbsPath] = result.css;
+      this.#traces[effectiveTrace] = fileAbsPath;
+      this.#tokensByFile[fileAbsPath] = exportSink;
+      return exportSink;
+    }
+
+    get finalSource(): string {
+      // Concatenate per-file injectable sources in trace order, skipping
+      // files we've already emitted. Mirrors `FileSystemLoader.finalSource`.
+      const written = new Set<string>();
+      const parts: string[] = [];
+      for (const key of Object.keys(this.#traces).sort(traceKeySorter)) {
+        const filename = this.#traces[key]!;
+        if (written.has(filename)) continue;
+        written.add(filename);
+        parts.push(this.#sources[filename] ?? "");
+      }
+      return parts.join("");
+    }
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -902,6 +902,9 @@ importers:
       magic-string:
         specifier: 'catalog:'
         version: 0.30.21
+      postcss:
+        specifier: 'catalog:'
+        version: 8.5.10
       vite:
         specifier: npm:@voidzero-dev/vite-plus-core@0.1.21
         version: '@voidzero-dev/vite-plus-core@0.1.21(@types/node@25.2.3)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.8.3)'

--- a/tests/scss-composes.test.ts
+++ b/tests/scss-composes.test.ts
@@ -158,22 +158,26 @@ async function buildFixture(root: string): Promise<string> {
 }
 
 /**
- * Recursively scan the build output for the bundled CSS file. The exact
- * filename is hashed and varies per Vite version; finding the first
- * `.css` under the outDir is enough.
+ * Recursively collect every `.css` file under `outDir` and return their
+ * concatenated content. Vite's filename hash + future code-splitting
+ * changes can produce multiple CSS files per build, so we concatenate
+ * to make the assertions robust to either layout.
  */
-async function findBundledCss(outDir: string): Promise<string> {
-  const entries = await fs.readdir(outDir, { withFileTypes: true });
-  for (const entry of entries) {
-    const full = path.join(outDir, entry.name);
-    if (entry.isDirectory()) {
-      const nested = await findBundledCss(full).catch(() => "");
-      if (nested) return nested;
-      continue;
+async function readAllBundledCss(outDir: string): Promise<string> {
+  const out: string[] = [];
+  const walk = async (dir: string): Promise<void> => {
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        await walk(full);
+      } else if (entry.name.endsWith(".css")) {
+        out.push(await fs.readFile(full, "utf-8"));
+      }
     }
-    if (entry.name.endsWith(".css")) return full;
-  }
-  return "";
+  };
+  await walk(outDir);
+  return out.join("\n");
 }
 
 describeIfSass("SCSS composes through CSS modules (#1343)", () => {
@@ -182,9 +186,8 @@ describeIfSass("SCSS composes through CSS modules (#1343)", () => {
     let outDir = "";
     try {
       outDir = await buildFixture(root);
-      const cssPath = await findBundledCss(outDir);
-      expect(cssPath, "expected bundled CSS file in build output").not.toBe("");
-      const css = await fs.readFile(cssPath, "utf-8");
+      const css = await readAllBundledCss(outDir);
+      expect(css, "expected bundled CSS file in build output").not.toBe("");
 
       // Sass must have resolved before LightningCSS saw the source —
       // no `$var` may remain.
@@ -211,9 +214,8 @@ describeIfSass("SCSS composes through CSS modules (#1343)", () => {
     let outDir = "";
     try {
       outDir = await buildFixture(root);
-      const cssPath = await findBundledCss(outDir);
-      expect(cssPath).not.toBe("");
-      const css = await fs.readFile(cssPath, "utf-8");
+      const css = await readAllBundledCss(outDir);
+      expect(css).not.toBe("");
 
       // No leakage of either the partial's `$var` or the composing
       // module's `$bg`. The `@import` of `other3.scss` must also have

--- a/tests/scss-composes.test.ts
+++ b/tests/scss-composes.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Regression test for #1343 — SCSS variables leaking through to
+ * LightningCSS via the CSS-modules `composes` pipeline.
+ *
+ * The Next.js test suite covers two flavours of this bug:
+ *
+ *  - `test/e2e/app-dir/scss/composes-external/` — `composes: foo from
+ *    './other.module.scss'` (a sibling .module.scss with `$var` variables).
+ *  - `test/e2e/app-dir/scss/nm-module-nested/` — same shape but with
+ *    `@import` inside the composed file pulling in another partial.
+ *
+ * Both fail on `main` because Vite's `vite:css-post` plugin reads the
+ * raw `.scss` content for `composes ... from` via postcss-modules'
+ * built-in FileSystemLoader (which does not know about Sass), passes
+ * it through to PostCSS modules, then hands the resulting CSS — which
+ * STILL contains `$var: red;` because Sass never ran — to
+ * LightningCSS. The minifier rejects it with:
+ *
+ *   SyntaxError: [lightningcss minify] Invalid empty selector
+ *   1  |  $var: red;._className_10j3d_2 {
+ *
+ * The fix installs a custom `css.modules.Loader` that preprocesses
+ * `.scss` / `.sass` / `.less` / `.styl` files via Vite's
+ * `preprocessCSS()` before PostCSS modules sees them. After the fix
+ * the production build succeeds and the resolved `background` /
+ * `color` declarations end up in the bundled CSS.
+ *
+ * Ported from:
+ *   test/e2e/app-dir/scss/composes-external/composes-external.test.ts
+ *   https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/scss/composes-external/composes-external.test.ts
+ *   test/e2e/app-dir/scss/nm-module-nested/nm-module-nested.test.ts
+ *   https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/scss/nm-module-nested/nm-module-nested.test.ts
+ *
+ * The fixtures live in tmpdir rather than under `tests/fixtures/` so
+ * the test is silently skipped on machines that don't have `sass`
+ * installed (matching tests/scss.test.ts).
+ */
+
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, it, expect } from "vite-plus/test";
+import { build } from "vite-plus";
+import vinext from "../packages/vinext/src/index.js";
+
+const ROOT_NODE_MODULES = path.resolve(import.meta.dirname, "../node_modules");
+
+// Skip the suite when `sass` is not installed. SCSS preprocessing is a
+// peer-dependency contract: vinext relies on Vite's built-in handling
+// which requires the user to install `sass` (or `sass-embedded`).
+let sassAvailable = false;
+try {
+  // @ts-ignore Optional peer dependency, not declared in this repo.
+  await import("sass");
+  sassAvailable = true;
+} catch {
+  sassAvailable = false;
+}
+
+const describeIfSass = sassAvailable ? describe : describe.skip;
+
+/**
+ * Materialize a fixture mirroring Next.js's `composes-external` test:
+ *
+ *   pages/
+ *     index.module.scss  // composes from ./other.module.scss
+ *     other.module.scss  // declares the actual className with $var
+ *     index.tsx          // imports index.module.scss
+ *
+ * Both .scss files use SCSS variables. Without preprocessing those
+ * variables leak through to LightningCSS and break the build.
+ */
+async function makeComposesExternalFixture(): Promise<string> {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "vinext-scss-composes-"));
+  await fs.symlink(ROOT_NODE_MODULES, path.join(tmpDir, "node_modules"), "junction");
+
+  const pagesDir = path.join(tmpDir, "pages");
+  await fs.mkdir(pagesDir, { recursive: true });
+
+  await fs.writeFile(
+    path.join(pagesDir, "other.module.scss"),
+    "$var: red;\n.className {\n  background: $var;\n  color: yellow;\n}\n",
+  );
+  await fs.writeFile(
+    path.join(pagesDir, "index.module.scss"),
+    "$var: blue;\n.subClass {\n  composes: className from './other.module.scss';\n  background: $var;\n}\n",
+  );
+  await fs.writeFile(
+    path.join(pagesDir, "index.tsx"),
+    'import { subClass } from "./index.module.scss";\n' +
+      "export default function Home() {\n" +
+      '  return <div id="verify-yellow" className={subClass}>Hello</div>;\n' +
+      "}\n",
+  );
+  return tmpDir;
+}
+
+/**
+ * Mirrors Next.js's `nm-module-nested` test: an `@import` of a plain
+ * `.scss` partial inside a `.module.scss` that is then composed from.
+ * Exercises the same code path but adds an extra layer of Sass
+ * processing before the variables are resolved.
+ */
+async function makeNestedImportFixture(): Promise<string> {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "vinext-scss-nested-"));
+  await fs.symlink(ROOT_NODE_MODULES, path.join(tmpDir, "node_modules"), "junction");
+
+  const pagesDir = path.join(tmpDir, "pages");
+  await fs.mkdir(pagesDir, { recursive: true });
+
+  // Partial SCSS imported by the .module.scss. Sass must resolve the
+  // @import before PostCSS modules sees the file.
+  await fs.writeFile(path.join(pagesDir, "other3.scss"), "$var: red;\n");
+  await fs.writeFile(
+    path.join(pagesDir, "other.module.scss"),
+    "@import 'other3.scss';\n.className {\n  background: $var;\n  color: yellow;\n}\n",
+  );
+  await fs.writeFile(
+    path.join(pagesDir, "index.module.scss"),
+    "$bg: blue;\n.subClass {\n  composes: className from './other.module.scss';\n  background: $bg;\n}\n",
+  );
+  await fs.writeFile(
+    path.join(pagesDir, "index.tsx"),
+    'import { subClass } from "./index.module.scss";\n' +
+      "export default function Home() {\n" +
+      '  return <div id="verify-yellow" className={subClass}>Hello</div>;\n' +
+      "}\n",
+  );
+  return tmpDir;
+}
+
+/**
+ * Drive a production-style SSR build of the fixture. We run only the
+ * SSR build (skipping the client bundle) because the bug reproduces in
+ * EVERY environment whose `cssMinify` defaults to LightningCSS — and
+ * for server environments that is the Vite 8 default. Keeping the test
+ * to one `build()` call keeps the run time tight.
+ */
+async function buildFixture(root: string): Promise<string> {
+  const outDir = await fs.mkdtemp(path.join(os.tmpdir(), "vinext-scss-build-"));
+  await build({
+    root,
+    configFile: false,
+    plugins: [vinext({ disableAppRouter: true })],
+    logLevel: "silent",
+    build: {
+      outDir,
+      ssr: "virtual:vinext-server-entry",
+      rollupOptions: { output: { entryFileNames: "entry.js" } },
+      // Force lightningcss minify so the test exercises the exact code
+      // path that fails on `main` (Vite defaults to it on server
+      // environments anyway, but pinning makes the regression explicit
+      // even if Vite changes its default later).
+      cssMinify: "lightningcss",
+    },
+  });
+  return outDir;
+}
+
+/**
+ * Recursively scan the build output for the bundled CSS file. The exact
+ * filename is hashed and varies per Vite version; finding the first
+ * `.css` under the outDir is enough.
+ */
+async function findBundledCss(outDir: string): Promise<string> {
+  const entries = await fs.readdir(outDir, { withFileTypes: true });
+  for (const entry of entries) {
+    const full = path.join(outDir, entry.name);
+    if (entry.isDirectory()) {
+      const nested = await findBundledCss(full).catch(() => "");
+      if (nested) return nested;
+      continue;
+    }
+    if (entry.name.endsWith(".css")) return full;
+  }
+  return "";
+}
+
+describeIfSass("SCSS composes through CSS modules (#1343)", () => {
+  it("builds when composes points at a .module.scss with SCSS variables", async () => {
+    const root = await makeComposesExternalFixture();
+    let outDir = "";
+    try {
+      outDir = await buildFixture(root);
+      const cssPath = await findBundledCss(outDir);
+      expect(cssPath, "expected bundled CSS file in build output").not.toBe("");
+      const css = await fs.readFile(cssPath, "utf-8");
+
+      // Sass must have resolved before LightningCSS saw the source —
+      // no `$var` may remain.
+      expect(css).not.toContain("$var");
+
+      // The composed class must contribute its `background: red` and
+      // `color: yellow` declarations to the final bundle, which means
+      // PostCSS-modules saw the *preprocessed* `.className { ... }`.
+      expect(css.toLowerCase()).toMatch(/background\s*:\s*(red|#f00\b)/);
+      // LightningCSS may minify `yellow` to `#ff0`. Either is fine —
+      // what matters is the colour value made it into the bundle.
+      expect(css.toLowerCase()).toMatch(/color\s*:\s*(yellow|#ff0\b|#ffff00\b)/);
+      // The composing class contributes `background: blue` AFTER the
+      // composed declaration, so blue wins per CSS cascade.
+      expect(css.toLowerCase()).toMatch(/background\s*:\s*(blue|#00f\b|#0000ff\b)/);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true }).catch(() => {});
+      if (outDir) await fs.rm(outDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }, 60_000);
+
+  it("builds when the composed .module.scss @imports a partial with variables", async () => {
+    const root = await makeNestedImportFixture();
+    let outDir = "";
+    try {
+      outDir = await buildFixture(root);
+      const cssPath = await findBundledCss(outDir);
+      expect(cssPath).not.toBe("");
+      const css = await fs.readFile(cssPath, "utf-8");
+
+      // No leakage of either the partial's `$var` or the composing
+      // module's `$bg`. The `@import` of `other3.scss` must also have
+      // been resolved by Sass — its statement should not survive.
+      expect(css).not.toContain("$var");
+      expect(css).not.toContain("$bg");
+      expect(css).not.toContain("@import");
+
+      expect(css.toLowerCase()).toMatch(/background\s*:\s*(red|#f00\b)/);
+      expect(css.toLowerCase()).toMatch(/color\s*:\s*(yellow|#ff0\b|#ffff00\b)/);
+      expect(css.toLowerCase()).toMatch(/background\s*:\s*(blue|#00f\b|#0000ff\b)/);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true }).catch(() => {});
+      if (outDir) await fs.rm(outDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }, 60_000);
+});


### PR DESCRIPTION
## Summary

- When a CSS module uses `composes: foo from './other.module.scss'`, postcss-modules' built-in `FileSystemLoader` reads the raw `.scss` text and feeds it straight into PostCSS, bypassing Vite's Sass preprocessor.
- The unprocessed source (with `$var: red;` declarations) then reaches Vite 8's lightningcss minifier — the default for server environments — which rejects it with `SyntaxError: [lightningcss minify] Invalid empty selector` and fails the build.
- This wires up a custom `css.modules.Loader` that runs Vite's `preprocessCSS` over `.scss`/`.sass`/`.less`/`.styl` files before postcss-modules sees them. The Loader reimplements the small `FileSystemLoader` + Parser logic from postcss-modules (which Vite bundles internally and we cannot import directly), but interposes a preprocessor step between the file read and the PostCSS pipeline.
- Mirrors how Next.js' webpack pipeline sequences sass-loader before css-modules. See the source comments and the ported test fixtures from `test/e2e/app-dir/scss/composes-external` and `test/e2e/app-dir/scss/nm-module-nested`.

## Test plan

- [x] `pnpm test tests/scss-composes.test.ts` — new regression tests for both the `composes-external` and `nm-module-nested` patterns (skipped if `sass` not installed locally; install with `pnpm add -D sass -w` to exercise them).
- [x] `pnpm test tests/scss.test.ts tests/sass-options.test.ts tests/nextjs-compat/app-css.test.ts tests/ssr-css-assets.test.ts` — existing CSS suite still passes.
- [x] `vp check` clean on the new files.
- [ ] CI green (Check, Vitest, Playwright E2E).

Closes #1343