### PR TITLE
fix(middleware): preserve route priority on rewrite target resolution

### DIFF
--- a/packages/vinext/src/config/config-matchers.ts
+++ b/packages/vinext/src/config/config-matchers.ts
@@ -683,6 +683,18 @@ export function matchConfigPattern(
   pathname: string,
   pattern: string,
 ): Record<string, string> | null {
+  // Trailing slashes on the incoming pathname don't carry meaning for config
+  // source matching. Next.js makes its source regex tolerate them
+  // (`source + '(/)?'`) under `trailingSlash: true`; equivalently we strip a
+  // single trailing slash from the pathname before matching so that, for
+  // example, a source `/rewrite-1` still matches a request `/rewrite-1/`. The
+  // source pattern itself is left unchanged because catch-all patterns
+  // (`:param*` / `:param+`) and the root `/` already consume any trailing
+  // slash; stripping the pattern would change those semantics.
+  if (pathname.length > 1 && pathname.endsWith("/")) {
+    pathname = pathname.slice(0, -1);
+  }
+
   // If the pattern contains regex groups like (\d+) or (.*), use regex matching.
   // Also enter this branch when a catch-all parameter (:param* or :param+) is
   // followed by a literal suffix (e.g. "/:path*.md"). Without this, the suffix

--- a/packages/vinext/src/config/config-matchers.ts
+++ b/packages/vinext/src/config/config-matchers.ts
@@ -1200,6 +1200,11 @@ export function matchHeaders(
   headers: NextHeader[],
   ctx: RequestContext,
 ): Array<{ key: string; value: string }> {
+  // Header source regexes are compiled without a trailing-slash tolerance,
+  // so the incoming pathname must be normalized the same way config rewrites
+  // and redirects are. See `stripTrailingSlashForConfigMatch`.
+  pathname = stripTrailingSlashForConfigMatch(pathname);
+
   const result: Array<{ key: string; value: string }> = [];
   for (const rule of headers) {
     // Cache the compiled source regex — escapeHeaderSource() + safeRegExp() are

--- a/packages/vinext/src/config/config-matchers.ts
+++ b/packages/vinext/src/config/config-matchers.ts
@@ -679,21 +679,36 @@ function extractConstraint(str: string, re: RegExp): string | null {
  *   (regex)    - inline regex patterns in the source
  *   :param(constraint) - named param with inline regex constraint
  */
+/**
+ * Strip a single trailing slash from a pathname for config-source matching.
+ *
+ * Next.js conditionally appends `(/)?` to rewrite/redirect/header source
+ * regexes when `trailingSlash: true` (see Next.js
+ * `resolve-rewrites.ts` and `server-utils.ts:checkRewrite`). Rather than
+ * threading the trailingSlash flag through every matcher, we unconditionally
+ * strip a trailing slash from the incoming pathname. When `trailingSlash: false`
+ * the request pipeline emits a normalizing redirect (step 3) before config
+ * rewrites/redirects (step 6) ever run, so the pathname is already slash-free;
+ * the unconditional strip is defense-in-depth for that ordering. When
+ * `trailingSlash: true` it bridges the gap between the canonicalized request
+ * path (`/rewrite-1/`) and source patterns written without a trailing slash
+ * (`/rewrite-1`).
+ *
+ * The root path `"/"` is preserved as-is.
+ */
+function stripTrailingSlashForConfigMatch(pathname: string): string {
+  return pathname.length > 1 && pathname.endsWith("/") ? pathname.slice(0, -1) : pathname;
+}
+
 export function matchConfigPattern(
   pathname: string,
   pattern: string,
 ): Record<string, string> | null {
-  // Trailing slashes on the incoming pathname don't carry meaning for config
-  // source matching. Next.js makes its source regex tolerate them
-  // (`source + '(/)?'`) under `trailingSlash: true`; equivalently we strip a
-  // single trailing slash from the pathname before matching so that, for
-  // example, a source `/rewrite-1` still matches a request `/rewrite-1/`. The
-  // source pattern itself is left unchanged because catch-all patterns
-  // (`:param*` / `:param+`) and the root `/` already consume any trailing
-  // slash; stripping the pattern would change those semantics.
-  if (pathname.length > 1 && pathname.endsWith("/")) {
-    pathname = pathname.slice(0, -1);
-  }
+  // See `stripTrailingSlashForConfigMatch` — the source pattern itself is left
+  // unchanged because catch-all patterns (`:param*` / `:param+`) and the root
+  // `/` already consume any trailing slash; stripping the pattern would change
+  // those semantics.
+  pathname = stripTrailingSlashForConfigMatch(pathname);
 
   // If the pattern contains regex groups like (\d+) or (.*), use regex matching.
   // Also enter this branch when a catch-all parameter (:param* or :param+) is
@@ -847,6 +862,12 @@ export function matchRedirect(
   ctx: RequestContext,
 ): { destination: string; permanent: boolean } | null {
   if (redirects.length === 0) return null;
+
+  // Strip trailing slash so the locale-static fast path (Map.get on the
+  // pathname) matches keys derived from slash-free source patterns. The
+  // linear fallback also passes through `matchConfigPattern` which strips
+  // again, but normalizing once here keeps both paths consistent.
+  pathname = stripTrailingSlashForConfigMatch(pathname);
 
   const index = _getRedirectIndex(redirects);
 

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -989,6 +989,9 @@ describe("Pages Router integration", () => {
       const res = await fetch(`${started.baseUrl}/rewrite-me/`);
       expect(res.status).toBe(200);
       const html = await res.text();
+      // `id="home"` is unique to `pages/index.tsx`; ssr-page also says
+      // "Hello World" so this disambiguates that the index rendered.
+      expect(html).toContain('id="home"');
       expect(html).toContain("Hello World");
       expect(html).not.toContain("Dynamic route");
     } finally {
@@ -1034,6 +1037,10 @@ describe("Pages Router integration", () => {
       const res = await fetch(`${started.baseUrl}/rewrite-1/`);
       expect(res.status).toBe(200);
       const html = await res.text();
+      // `id="ssr"` only lives on the rewrite target (`pages/ssr-page.tsx`) —
+      // `pages/index.tsx` also says "Hello World" so this disambiguates that
+      // the rewrite target is what rendered.
+      expect(html).toContain('id="ssr"');
       expect(html).toContain("Hello World");
       expect(html).not.toContain("Dynamic route");
     } finally {
@@ -2939,6 +2946,9 @@ describe("Production server middleware (Pages Router)", () => {
       const indexRes = await fetch(`${tempProdUrl}/rewrite-me/`);
       expect(indexRes.status).toBe(200);
       const indexHtml = await indexRes.text();
+      // `id="home"` is unique to `pages/index.tsx`; ssr-page also says
+      // "Hello World" so this disambiguates that the index rendered.
+      expect(indexHtml).toContain('id="home"');
       expect(indexHtml).toContain("Hello World");
       expect(indexHtml).not.toContain("Dynamic route");
 
@@ -2955,6 +2965,10 @@ describe("Production server middleware (Pages Router)", () => {
       const cfgRes = await fetch(`${tempProdUrl}/rewrite-1/`);
       expect(cfgRes.status).toBe(200);
       const cfgHtml = await cfgRes.text();
+      // `id="ssr"` is unique to `pages/ssr-page.tsx`; `pages/index.tsx`
+      // also says "Hello World" so this disambiguates that the rewrite
+      // target rendered (not the index, not the dynamic [id]).
+      expect(cfgHtml).toContain('id="ssr"');
       expect(cfgHtml).toContain("Hello World");
       expect(cfgHtml).not.toContain("Dynamic route");
     } finally {

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -31,6 +31,99 @@ function getBuildBundlerOptions(result: any) {
   return result.build?.rolldownOptions ?? result.build?.rollupOptions;
 }
 
+/**
+ * Fixture: a Pages Router app with both `pages/index.tsx` (static) and
+ * `pages/[id].tsx` (dynamic root catch). Models the
+ * `test/e2e/middleware-trailing-slash` Next.js fixture: a static `ssr-page`
+ * route, a `[id]` dynamic root, plus next.config.js afterFiles rewrites
+ * (`/rewrite-1` → `/ssr-page?from=config`) and a middleware that rewrites
+ * `/rewrite-me` to `/`. After any rewrite the rewrite target must go
+ * through full route resolution — static routes must beat the `[id]`
+ * dynamic root.
+ */
+function writeMiddlewareRewritePriorityFixture(rootDir: string): void {
+  fs.mkdirSync(path.join(rootDir, "pages"), { recursive: true });
+  const nmLink = path.join(rootDir, "node_modules");
+  if (!fs.existsSync(nmLink)) {
+    fs.symlinkSync(path.join(process.cwd(), "node_modules"), nmLink);
+  }
+  fs.writeFileSync(path.join(rootDir, "pages", "_app.tsx"), PAGES_APP_COMPONENT);
+  fs.writeFileSync(
+    path.join(rootDir, "pages", "index.tsx"),
+    `export default function Home() {
+  return <p id="home">Hello World</p>;
+}
+`,
+  );
+  fs.writeFileSync(
+    path.join(rootDir, "pages", "[id].tsx"),
+    `export const getServerSideProps = ({ params, query }) => ({
+  props: { id: params.id ?? null, q: query.id ?? null },
+});
+export default function Dynamic({ id, q }: { id: string | null; q: string | null }) {
+  return (
+    <div>
+      <p id="dynamic">Dynamic route</p>
+      <p id="id">{id}</p>
+      <p id="q">{q}</p>
+    </div>
+  );
+}
+`,
+  );
+  fs.writeFileSync(
+    path.join(rootDir, "pages", "about.tsx"),
+    `export default function About() {
+  return <p id="about">About Page</p>;
+}
+`,
+  );
+  fs.writeFileSync(
+    path.join(rootDir, "pages", "ssr-page.tsx"),
+    `export const getServerSideProps = ({ query }) => ({
+  props: { from: query.from ?? null },
+});
+export default function SsrPage({ from }: { from: string | null }) {
+  return (
+    <div>
+      <p id="ssr">Hello World</p>
+      <p id="from">{from ?? ""}</p>
+    </div>
+  );
+}
+`,
+  );
+  fs.writeFileSync(
+    path.join(rootDir, "next.config.js"),
+    `module.exports = {
+  trailingSlash: true,
+  rewrites() {
+    return [
+      { source: "/rewrite-1", destination: "/ssr-page?from=config" },
+    ];
+  },
+};
+`,
+  );
+  fs.writeFileSync(
+    path.join(rootDir, "middleware.ts"),
+    `import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+export default function middleware(request: NextRequest) {
+  const url = new URL(request.url);
+  if (url.pathname === "/rewrite-me" || url.pathname === "/rewrite-me/") {
+    return NextResponse.rewrite(new URL("/", request.url));
+  }
+  if (url.pathname === "/rewrite-to-about" || url.pathname === "/rewrite-to-about/") {
+    return NextResponse.rewrite(new URL("/about", request.url));
+  }
+  return NextResponse.next();
+}
+`,
+  );
+}
+
 function writeEncodedSlashPagesFixture(rootDir: string): void {
   fs.mkdirSync(path.join(rootDir, "pages", "a"), { recursive: true });
   const nmLink = path.join(rootDir, "node_modules");
@@ -878,6 +971,75 @@ describe("Pages Router integration", () => {
     const res = await fetch(`${baseUrl}/old-page`, { redirect: "manual" });
     expect(res.status).toBe(307);
     expect(res.headers.get("location")).toContain("/about");
+  });
+
+  // Regression for #1331: after a middleware rewrite, the rewrite target
+  // must go through full route resolution where static routes win over
+  // dynamic catch-alls. Without the fix the `[id]` dynamic page captures
+  // the rewrite target and renders "Dynamic route" with id="rewrite-me".
+  it("middleware rewrite to / resolves to static index over [id] dynamic route (dev)", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-mw-rewrite-priority-dev-"));
+    writeMiddlewareRewritePriorityFixture(tmpDir);
+
+    let tempServer: ViteDevServer | undefined;
+    try {
+      const started = await startFixtureServer(tmpDir);
+      tempServer = started.server;
+
+      const res = await fetch(`${started.baseUrl}/rewrite-me/`);
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      expect(html).toContain("Hello World");
+      expect(html).not.toContain("Dynamic route");
+    } finally {
+      await tempServer?.close();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("middleware rewrite to /about resolves to static about over [id] dynamic route (dev)", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-mw-rewrite-priority-dev-about-"));
+    writeMiddlewareRewritePriorityFixture(tmpDir);
+
+    let tempServer: ViteDevServer | undefined;
+    try {
+      const started = await startFixtureServer(tmpDir);
+      tempServer = started.server;
+
+      const res = await fetch(`${started.baseUrl}/rewrite-to-about/`);
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      expect(html).toContain("About Page");
+      expect(html).not.toContain("Dynamic route");
+    } finally {
+      await tempServer?.close();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  // Regression for #1331: next.config.js rewrites with `trailingSlash: true`
+  // and a `[id].tsx` dynamic root catch — the `[id]` route is also matched
+  // by the rewrite source, so afterFiles rewrites must still be considered
+  // (the matched route is dynamic), and the rewrite target must resolve to
+  // the static page, not back into `[id]`.
+  it("config afterFiles rewrite target resolves static page over [id] dynamic root (dev)", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-mw-rewrite-priority-dev-cfg-"));
+    writeMiddlewareRewritePriorityFixture(tmpDir);
+
+    let tempServer: ViteDevServer | undefined;
+    try {
+      const started = await startFixtureServer(tmpDir);
+      tempServer = started.server;
+
+      const res = await fetch(`${started.baseUrl}/rewrite-1/`);
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      expect(html).toContain("Hello World");
+      expect(html).not.toContain("Dynamic route");
+    } finally {
+      await tempServer?.close();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 
   it("middleware rewrites /rewritten to /ssr", async () => {
@@ -2727,6 +2889,78 @@ describe("Production server middleware (Pages Router)", () => {
     const res = await fetch(`${prodUrl}/old-page`, { redirect: "manual" });
     expect(res.status).toBe(307);
     expect(res.headers.get("location")).toContain("/about");
+  });
+
+  // Regression for #1331: after a middleware rewrite, the rewrite target
+  // must go through full route resolution where static routes win over
+  // dynamic catch-alls. Without the fix the `[id]` dynamic page captures
+  // the rewrite target and renders "Dynamic route" with id="rewrite-me".
+  it("middleware rewrite resolves static index over [id] dynamic route in production", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-mw-rewrite-priority-prod-"));
+    writeMiddlewareRewritePriorityFixture(tmpDir);
+
+    let prodServer: import("node:http").Server | undefined;
+    try {
+      await build({
+        root: tmpDir,
+        configFile: false,
+        plugins: [vinext()],
+        logLevel: "silent",
+        build: {
+          outDir: path.join(tmpDir, "dist", "server"),
+          ssr: "virtual:vinext-server-entry",
+          rollupOptions: { output: { entryFileNames: "entry.js" } },
+        },
+      });
+      await build({
+        root: tmpDir,
+        configFile: false,
+        plugins: [vinext()],
+        logLevel: "silent",
+        build: {
+          outDir: path.join(tmpDir, "dist", "client"),
+          manifest: true,
+          ssrManifest: true,
+          rollupOptions: { input: "virtual:vinext-client-entry" },
+        },
+      });
+
+      const { startProdServer } = await import("../packages/vinext/src/server/prod-server.js");
+      prodServer = unwrapStartedProdServer(
+        await startProdServer({
+          port: 0,
+          host: "127.0.0.1",
+          outDir: path.join(tmpDir, "dist"),
+        }),
+      );
+      const addr = prodServer.address() as { port: number };
+      const tempProdUrl = `http://127.0.0.1:${addr.port}`;
+
+      const indexRes = await fetch(`${tempProdUrl}/rewrite-me/`);
+      expect(indexRes.status).toBe(200);
+      const indexHtml = await indexRes.text();
+      expect(indexHtml).toContain("Hello World");
+      expect(indexHtml).not.toContain("Dynamic route");
+
+      const aboutRes = await fetch(`${tempProdUrl}/rewrite-to-about/`);
+      expect(aboutRes.status).toBe(200);
+      const aboutHtml = await aboutRes.text();
+      expect(aboutHtml).toContain("About Page");
+      expect(aboutHtml).not.toContain("Dynamic route");
+
+      // Next.js parity: with trailingSlash: true and a [id] dynamic root,
+      // `/rewrite-1/` matches `[id]` but afterFiles config rewrites must
+      // still rewrite it to /ssr-page, and the rewrite target must resolve
+      // to the static ssr-page rather than back into [id].
+      const cfgRes = await fetch(`${tempProdUrl}/rewrite-1/`);
+      expect(cfgRes.status).toBe(200);
+      const cfgHtml = await cfgRes.text();
+      expect(cfgHtml).toContain("Hello World");
+      expect(cfgHtml).not.toContain("Dynamic route");
+    } finally {
+      await new Promise<void>((resolve) => prodServer?.close(() => resolve()) ?? resolve());
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 
   it("does not collapse encoded slashes onto nested routes in production", async () => {

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -7771,6 +7771,40 @@ describe("matchConfigPattern", () => {
     expect(matchConfigPattern("/foo", "/foo/:path*")).toEqual({ path: "" });
     expect(matchConfigPattern("/foo", "/foo/:path+")).toBeNull();
   });
+
+  // Regression for #1331: a trailing slash on the request pathname must not
+  // hide a config rewrite/redirect/header source written without one. This
+  // mirrors Next.js's conditional `source + '(/)?'` suffix under
+  // `trailingSlash: true` — see `stripTrailingSlashForConfigMatch`.
+  it("strips a trailing slash on the incoming pathname before matching", async () => {
+    const { matchConfigPattern } = await import("../packages/vinext/src/config/config-matchers.js");
+    // Exact match: trailing slash on the pathname is ignored.
+    expect(matchConfigPattern("/about/", "/about")).toEqual({});
+    // :param match across the segment with a trailing slash on the pathname.
+    expect(matchConfigPattern("/blog/hello-world/", "/blog/:slug")).toEqual({
+      slug: "hello-world",
+    });
+    // Multi-segment :param with a trailing slash.
+    expect(matchConfigPattern("/blog/2024/my-post/", "/blog/:year/:slug")).toEqual({
+      year: "2024",
+      slug: "my-post",
+    });
+    // Regex-group pattern with a trailing slash.
+    expect(matchConfigPattern("/123/", "/:id(\\d+)")).toEqual({ id: "123" });
+  });
+
+  it("preserves the root path and catch-all semantics under trailing slash", async () => {
+    const { matchConfigPattern } = await import("../packages/vinext/src/config/config-matchers.js");
+    // The root pathname "/" stays "/" — never stripped to "".
+    expect(matchConfigPattern("/", "/")).toEqual({});
+    // Catch-alls already consume the trailing slash; the strip must not turn
+    // `/docs/` into `/docs` in a way that breaks zero-segment matching.
+    expect(matchConfigPattern("/docs/", "/docs/:path*")).toEqual({ path: "" });
+    // One-segment catch-all with trailing slash on the pathname.
+    expect(matchConfigPattern("/docs/intro/", "/docs/:path*")).toEqual({ path: "intro" });
+    // :path+ still requires at least one segment when the only "extra" was a slash.
+    expect(matchConfigPattern("/api/", "/api/:path+")).toBeNull();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -8567,6 +8567,29 @@ describe("matchHeaders", () => {
     const matched = matchHeaders("/about", rules, makeCtx());
     expect(matched).toEqual([]);
   });
+
+  // Regression for #1331: under `trailingSlash: true` the incoming pathname
+  // arrives as `/about/`, but header source patterns are written without a
+  // trailing slash. `matchHeaders` must strip the slash before matching.
+  it("matches when the request pathname has a trailing slash", async () => {
+    const { matchHeaders } = await import("../packages/vinext/src/config/config-matchers.js");
+    const rules: any[] = [
+      {
+        source: "/about",
+        headers: [{ key: "x-static-header", value: "1" }],
+      },
+      {
+        source: "/api/:path*",
+        headers: [{ key: "x-api-header", value: "1" }],
+      },
+    ];
+
+    const aboutMatched = matchHeaders("/about/", rules, makeCtx());
+    expect(aboutMatched).toEqual([{ key: "x-static-header", value: "1" }]);
+
+    const apiMatched = matchHeaders("/api/users/", rules, makeCtx());
+    expect(apiMatched).toEqual([{ key: "x-api-header", value: "1" }]);
+  });
 });
 
 describe("matchHeaders compiled source cache", () => {


### PR DESCRIPTION
## Summary

When `trailingSlash: true` is set in `next.config.js`, requests like `/rewrite-1/` were matched against rewrite sources like `/rewrite-1` *literally* — including the trailing slash. The match failed, so the request fell through to the dynamic `[id]` route and rendered the dynamic page with `id="rewrite-1"` instead of being rewritten to the static target. This is the post-rewrite static-vs-dynamic priority regression described in #1331.

The fix strips a single trailing slash from the incoming pathname before matching against `next.config.js` rewrite / redirect / header sources, mirroring Next.js's `source + '(/)?'` source-regex behavior under `trailingSlash: true`. The source pattern itself is left unchanged so catch-all (`:param*` / `:param+`) and root (`/`) semantics are unaffected.

## Test plan

- [x] New regression tests in `tests/pages-router.test.ts` covering both dev and prod servers:
  - Middleware rewrite from `/rewrite-me/` → `/` resolves to static `pages/index.tsx`, not the dynamic `pages/[id].tsx` root catch.
  - Middleware rewrite from `/rewrite-to-about/` → `/about` resolves to static `pages/about.tsx`, not `[id]`.
  - `next.config.js` afterFiles rewrite `/rewrite-1` → `/ssr-page?from=config` with `trailingSlash: true` resolves to the static `ssr-page.tsx` from a `/rewrite-1/` request — the original failing case.
- [x] `pnpm test tests/pages-router.test.ts tests/route-sorting.test.ts tests/routing.test.ts tests/request-pipeline.test.ts` — 455 tests pass.
- [x] `pnpm test tests/app-router.test.ts` — 318 tests pass.
- [x] `pnpm test tests/deploy.test.ts tests/shims.test.ts` — 1149 tests pass.
- [x] `pnpm run check` — clean.

## Related upstream

- Next.js source: `packages/next/src/shared/lib/router/utils/resolve-rewrites.ts:40` — `rewrite.source + (process.env.__NEXT_TRAILING_SLASH ? '(/)?' : '')`.
- Ported Next.js tests:
  - `test/e2e/middleware-trailing-slash/test/index.test.ts`
  - `test/e2e/middleware-rewrites/test/index.test.ts`

## Scope

This PR addresses the primary post-rewrite static-vs-dynamic priority sub-problem only. External URL proxying and `fallback: true` rewrite behavior are listed in the issue but are independent concerns; they will be tracked separately.

Refs #1331