### PR TITLE
fix(basepath): enforce scoping on rewrites/redirects/routes

### DIFF
--- a/packages/vinext/src/config/config-matchers.ts
+++ b/packages/vinext/src/config/config-matchers.ts
@@ -454,6 +454,49 @@ export type RequestContext = {
 };
 
 /**
+ * basePath gating state passed alongside the pathname to every matcher.
+ *
+ * Rewrites/redirects/headers run with default `basePath: true` semantics in
+ * Next.js: the rule only matches when the inbound request was under the
+ * configured `basePath`. Rules with `basePath: false` opt out and match
+ * the original (un-stripped) pathname regardless of prefix.
+ *
+ * When `basePath` is empty (not configured) every rule is treated as
+ * basePath-defaulted: every request matches.
+ *
+ * @see .nextjs-ref/packages/next/src/lib/load-custom-routes.ts:198-220
+ */
+export type BasePathMatchState = {
+  /** Configured `basePath` (without trailing slash) or "" when unset. */
+  basePath: string;
+  /**
+   * True when the inbound request was originally under `basePath` (i.e.
+   * the prod-server/handler stripped the prefix before the matcher runs).
+   * Ignored when `basePath` is empty.
+   */
+  hadBasePath: boolean;
+};
+
+const _BASEPATH_DEFAULT: BasePathMatchState = { basePath: "", hadBasePath: true };
+
+/**
+ * Decide whether a rule should be evaluated at all given the current
+ * basePath-gating state.
+ *
+ * Encodes the Next.js rules:
+ *   - basePath: false rule → only when the request was NOT under basePath
+ *     (i.e. it's the explicit opt-out path). When `basePath` itself is
+ *     empty, basePath: false rules are still allowed to match — there's
+ *     just no basePath to gate them.
+ *   - default rule (basePath !== false) → only when the request WAS under
+ *     basePath (or no basePath is configured).
+ */
+function shouldEvaluateRule(ruleBasePath: false | undefined, state: BasePathMatchState): boolean {
+  if (!state.basePath) return true;
+  return ruleBasePath === false ? !state.hadBasePath : state.hadBasePath;
+}
+
+/**
  * Parse a Cookie header string into a key-value record.
  */
 export function parseCookies(cookieHeader: string | null): Record<string, string> {
@@ -833,6 +876,7 @@ export function matchRedirect(
   pathname: string,
   redirects: NextRedirect[],
   ctx: RequestContext,
+  basePathState: BasePathMatchState = _BASEPATH_DEFAULT,
 ): { destination: string; permanent: boolean } | null {
   if (redirects.length === 0) return null;
 
@@ -861,6 +905,7 @@ export function matchRedirect(
       for (const entry of noLocaleBucket) {
         if (entry.originalIndex >= localeMatchIndex) continue; // already have a better match
         const redirect = entry.redirect;
+        if (!shouldEvaluateRule(redirect.basePath, basePathState)) continue;
         const conditionParams =
           redirect.has || redirect.missing
             ? collectConditionParams(redirect.has, redirect.missing, ctx)
@@ -891,6 +936,7 @@ export function matchRedirect(
           // Validate that `localePart` is one of the allowed alternation values.
           if (!entry.altRe.test(localePart)) continue;
           const redirect = entry.redirect;
+          if (!shouldEvaluateRule(redirect.basePath, basePathState)) continue;
           const conditionParams =
             redirect.has || redirect.missing
               ? collectConditionParams(redirect.has, redirect.missing, ctx)
@@ -918,6 +964,7 @@ export function matchRedirect(
       // the locale-static match wins. Stop scanning.
       break;
     }
+    if (!shouldEvaluateRule(redirect.basePath, basePathState)) continue;
     const params = matchConfigPattern(pathname, redirect.source);
     if (params) {
       const conditionParams =
@@ -950,8 +997,10 @@ export function matchRewrite(
   pathname: string,
   rewrites: NextRewrite[],
   ctx: RequestContext,
+  basePathState: BasePathMatchState = _BASEPATH_DEFAULT,
 ): string | null {
   for (const rewrite of rewrites) {
+    if (!shouldEvaluateRule(rewrite.basePath, basePathState)) continue;
     const params = matchConfigPattern(pathname, rewrite.source);
     if (params) {
       const conditionParams =
@@ -1166,9 +1215,11 @@ export function matchHeaders(
   pathname: string,
   headers: NextHeader[],
   ctx: RequestContext,
+  basePathState: BasePathMatchState = _BASEPATH_DEFAULT,
 ): Array<{ key: string; value: string }> {
   const result: Array<{ key: string; value: string }> = [];
   for (const rule of headers) {
+    if (!shouldEvaluateRule(rule.basePath, basePathState)) continue;
     // Cache the compiled source regex — escapeHeaderSource() + safeRegExp() are
     // pure functions of rule.source and the result never changes between requests.
     const sourceRegex = getCachedRegex(_compiledHeaderSourceCache, rule.source, () =>

--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -77,6 +77,13 @@ export type NextRedirect = {
   permanent: boolean;
   has?: HasCondition[];
   missing?: HasCondition[];
+  /**
+   * When `false`, the rule is NOT prefixed with `basePath`. Source and
+   * destination are matched/applied verbatim. Mirrors Next.js's
+   * `Redirect.basePath: false` opt-out — see
+   * `.nextjs-ref/packages/next/src/lib/load-custom-routes.ts:26`.
+   */
+  basePath?: false;
 };
 
 export type NextRewrite = {
@@ -84,6 +91,8 @@ export type NextRewrite = {
   destination: string;
   has?: HasCondition[];
   missing?: HasCondition[];
+  /** See {@link NextRedirect.basePath}. */
+  basePath?: false;
 };
 
 export type NextHeader = {
@@ -91,6 +100,8 @@ export type NextHeader = {
   has?: HasCondition[];
   missing?: HasCondition[];
   headers: Array<{ key: string; value: string }>;
+  /** See {@link NextRedirect.basePath}. */
+  basePath?: false;
 };
 
 export type NextI18nConfig = {

--- a/packages/vinext/src/deploy.ts
+++ b/packages/vinext/src/deploy.ts
@@ -615,6 +615,10 @@ export default {
       }
 
       // ── 1. Strip basePath ─────────────────────────────────────────
+      // Track basePath presence on the original request so the matcher
+      // gating below can distinguish requests inside basePath (default
+      // rules apply) from requests outside it (only opt-out rules apply).
+      const hadBasePath = !basePath || hasBasePath(pathname, basePath);
       {
         const stripped = stripBasePath(pathname, basePath);
         if (stripped !== pathname) {
@@ -622,6 +626,7 @@ export default {
           pathname = stripped;
         }
       }
+      const basePathState = { basePath, hadBasePath };
 
       // ── Image optimization via Cloudflare Images binding ──────────
       // Checked after basePath stripping so /<basePath>/_vinext/image works.
@@ -670,10 +675,14 @@ export default {
 
       // ── 3. Apply redirects from next.config.js ────────────────────
       if (configRedirects.length) {
-        const redirect = matchRedirect(pathname, configRedirects, reqCtx);
+        const redirect = matchRedirect(pathname, configRedirects, reqCtx, basePathState);
         if (redirect) {
+          // Only prepend basePath when the request was actually under basePath.
+          // Opt-out rules running on out-of-basepath requests must not receive
+          // a basePath prefix.
           const dest = sanitizeDestination(
             basePath &&
+              hadBasePath &&
               !isExternalUrl(redirect.destination) &&
               !hasBasePath(redirect.destination, basePath)
               ? basePath + redirect.destination
@@ -769,6 +778,7 @@ export default {
           configHeaders,
           pathname,
           requestContext: reqCtx,
+          basePathState,
         });
       }
 
@@ -778,15 +788,31 @@ export default {
       }
 
       // ── 6. Apply beforeFiles rewrites from next.config.js ─────────
+      let configRewriteFired = false;
       if (configRewrites.beforeFiles?.length) {
-        const rewritten = matchRewrite(resolvedPathname, configRewrites.beforeFiles, postMwReqCtx);
+        const rewritten = matchRewrite(
+          resolvedPathname,
+          configRewrites.beforeFiles,
+          postMwReqCtx,
+          basePathState,
+        );
         if (rewritten) {
           if (isExternalUrl(rewritten)) {
             return proxyExternalRequest(request, rewritten);
           }
           resolvedUrl = rewritten;
           resolvedPathname = rewritten.split("?")[0];
+          configRewriteFired = true;
         }
+      }
+
+      // Reject out-of-basePath requests that no rule rewrote. See the
+      // matching comment in prod-server.ts step 7b.
+      if (basePath && !hadBasePath && !configRewriteFired) {
+        return new Response("This page could not be found", {
+          status: 404,
+          headers: { "Content-Type": "text/html; charset=utf-8" },
+        });
       }
 
       // ── 7. API routes ─────────────────────────────────────────────
@@ -803,7 +829,12 @@ export default {
       // ── 8. Apply afterFiles rewrites from next.config.js ──────────
       // These run after non-dynamic page routes but before dynamic routes.
       if ((!pageMatch || pageMatch.route.isDynamic) && configRewrites.afterFiles?.length) {
-        const rewritten = matchRewrite(resolvedPathname, configRewrites.afterFiles, postMwReqCtx);
+        const rewritten = matchRewrite(
+          resolvedPathname,
+          configRewrites.afterFiles,
+          postMwReqCtx,
+          basePathState,
+        );
         if (rewritten) {
           if (isExternalUrl(rewritten)) {
             return proxyExternalRequest(request, rewritten);
@@ -820,7 +851,12 @@ export default {
 
         // ── 10. Fallback rewrites (if SSR returned 404) ─────────────
         if (response && response.status === 404 && configRewrites.fallback?.length) {
-          const fallbackRewrite = matchRewrite(resolvedPathname, configRewrites.fallback, postMwReqCtx);
+          const fallbackRewrite = matchRewrite(
+            resolvedPathname,
+            configRewrites.fallback,
+            postMwReqCtx,
+            basePathState,
+          );
           if (fallbackRewrite) {
             if (isExternalUrl(fallbackRewrite)) {
               return proxyExternalRequest(request, fallbackRewrite);

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -3100,14 +3100,14 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
               // pre-middleware request state; middleware response headers win
               // later because they are already on the outgoing response.
               if (nextConfig?.headers.length) {
-                applyHeaders(pathname, res, nextConfig.headers, preMiddlewareReqCtx);
+                applyHeaders(pathname, res, nextConfig.headers, preMiddlewareReqCtx, bp);
               }
 
               // Apply rewrites from next.config.js (beforeFiles)
               let resolvedUrl = url;
               if (nextConfig?.rewrites.beforeFiles.length) {
                 resolvedUrl =
-                  applyRewrites(pathname, nextConfig.rewrites.beforeFiles, reqCtx) ?? url;
+                  applyRewrites(pathname, nextConfig.rewrites.beforeFiles, reqCtx, bp) ?? url;
               }
 
               // External rewrite from beforeFiles — proxy to external URL
@@ -3162,6 +3162,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                   resolvedUrl.split("?")[0],
                   nextConfig.rewrites.afterFiles,
                   reqCtx,
+                  bp,
                 );
                 if (afterRewrite) {
                   resolvedUrl = afterRewrite;
@@ -3205,6 +3206,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                   resolvedUrl.split("?")[0],
                   nextConfig.rewrites.fallback,
                   reqCtx,
+                  bp,
                 );
                 if (fallbackRewrite) {
                   // External fallback rewrite — proxy to external URL
@@ -4216,7 +4218,11 @@ function applyRedirects(
   ctx: RequestContext,
   basePath = "",
 ): boolean {
-  const result = matchRedirect(pathname, redirects, ctx);
+  // Vite strips the basePath before our middleware sees the request, so any
+  // pathname we see is implicitly "under basePath" for matching purposes.
+  // Default rules fire as expected; `basePath: false` rules cannot reach the
+  // dev server today because Vite won't proxy out-of-basepath requests.
+  const result = matchRedirect(pathname, redirects, ctx, { basePath, hadBasePath: true });
   if (result) {
     // Sanitize to prevent open redirect via protocol-relative URLs
     const dest = sanitizeDestination(
@@ -4302,8 +4308,11 @@ function applyRewrites(
   pathname: string,
   rewrites: NextRewrite[],
   ctx: RequestContext,
+  basePath = "",
 ): string | null {
-  const dest = matchRewrite(pathname, rewrites, ctx);
+  // Vite strips the basePath before our middleware sees the request; see
+  // applyRedirects for rationale.
+  const dest = matchRewrite(pathname, rewrites, ctx, { basePath, hadBasePath: true });
   if (dest) {
     // Sanitize to prevent open redirect via protocol-relative URLs
     return sanitizeDestination(dest);
@@ -4322,8 +4331,11 @@ function applyHeaders(
   res: any,
   headers: NextHeader[],
   ctx: RequestContext,
+  basePath = "",
 ): void {
-  const matched = matchHeaders(pathname, headers, ctx);
+  // Vite strips the basePath before our middleware sees the request; see
+  // applyRedirects for rationale.
+  const matched = matchHeaders(pathname, headers, ctx, { basePath, hadBasePath: true });
   for (const header of matched) {
     // Use append semantics for headers where multiple values must coexist
     // (Vary, Set-Cookie). Using setHeader() on these would destroy

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -216,6 +216,10 @@ function isExecutionContextLike(value: unknown): value is ExecutionContextLike {
   return hasProperty(value, "waitUntil") && typeof value.waitUntil === "function";
 }
 
+// TODO(#1333): once App Router supports `basePath: false` rules (see
+// `normalizeRscRequest` — it 404s out-of-basePath requests before they
+// reach this code), pass `hadBasePath` here and skip the prefix when
+// false, mirroring the same guard in `prod-server.ts` and `deploy.ts`.
 function redirectDestinationWithBasePath(destination: string, basePath: string): string {
   if (!basePath || isExternalUrl(destination) || hasBasePath(destination, basePath)) {
     return destination;

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -11,6 +11,7 @@ import {
   proxyExternalRequest,
   requestContextFromRequest,
   sanitizeDestination,
+  type BasePathMatchState,
 } from "../config/config-matchers.js";
 import { headersContextFromRequest } from "vinext/shims/headers";
 import {
@@ -224,6 +225,7 @@ function redirectDestinationWithBasePath(destination: string, basePath: string):
 
 async function applyRewrite(
   options: {
+    basePathState: BasePathMatchState;
     clearRequestContext: () => void;
     request: Request;
     requestContext: RequestContext;
@@ -233,7 +235,12 @@ async function applyRewrite(
 ): Promise<Response | string | null> {
   if (!options.rewrites.length) return null;
 
-  const rewritten = matchRewrite(cleanPathname, options.rewrites, options.requestContext);
+  const rewritten = matchRewrite(
+    cleanPathname,
+    options.rewrites,
+    options.requestContext,
+    options.basePathState,
+  );
   if (!rewritten) return null;
 
   if (isExternalUrl(rewritten)) {
@@ -247,6 +254,7 @@ async function applyRewrite(
 function applyConfigHeadersToMiddlewareRedirect(
   response: Response,
   options: {
+    basePathState: BasePathMatchState;
     configHeaders: NextHeader[];
     pathname: string;
     requestContext: RequestContext;
@@ -263,6 +271,7 @@ function applyConfigHeadersToMiddlewareRedirect(
     configHeaders: options.configHeaders,
     pathname: options.pathname,
     requestContext: options.requestContext,
+    basePathState: options.basePathState,
   });
 
   if (!headers.entries().next().done) {
@@ -296,6 +305,14 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
     normalized;
   let { pathname, cleanPathname } = normalized;
 
+  // The request reached this point so it was either under basePath (stripped
+  // by normalizeRscRequest) or basePath is empty. In both cases the matcher
+  // gating below treats default (basePath: true) rules as eligible. The App
+  // Router does not yet support `basePath: false` rules — they would need a
+  // pre-strip hook in normalizeRscRequest to fire. Tracked as follow-up to
+  // issue #1333.
+  const basePathState = { basePath: options.basePath, hadBasePath: true };
+
   const prerenderEndpointResponse = await handleAppPrerenderEndpoint(request, {
     isPrerenderEnabled() {
       return process.env.VINEXT_PRERENDER === "1";
@@ -320,6 +337,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
     redirectPathname,
     options.configRedirects,
     preMiddlewareRequestContext,
+    basePathState,
   );
   if (redirect) {
     const destination = sanitizeDestination(
@@ -359,6 +377,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
     });
     if (middlewareResult.kind === "response") {
       return applyConfigHeadersToMiddlewareRedirect(middlewareResult.response, {
+        basePathState,
         configHeaders: options.configHeaders,
         pathname: cleanPathname,
         requestContext: preMiddlewareRequestContext,
@@ -376,6 +395,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
 
   const beforeFilesRewrite = await applyRewrite(
     {
+      basePathState,
       clearRequestContext: options.clearRequestContext,
       request,
       requestContext: postMiddlewareRequestContext,
@@ -459,6 +479,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
   if (!match || match.route.isDynamic) {
     const afterFilesRewrite = await applyRewrite(
       {
+        basePathState,
         clearRequestContext: options.clearRequestContext,
         request,
         requestContext: postMiddlewareRequestContext,
@@ -476,6 +497,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
   if (!match) {
     const fallbackRewrite = await applyRewrite(
       {
+        basePathState,
         clearRequestContext: options.clearRequestContext,
         request,
         requestContext: postMiddlewareRequestContext,

--- a/packages/vinext/src/server/app-rsc-response-finalizer.ts
+++ b/packages/vinext/src/server/app-rsc-response-finalizer.ts
@@ -4,7 +4,7 @@ import { VINEXT_STATIC_FILE_HEADER } from "./headers.js";
 import { applyConfigHeadersToResponse } from "./request-pipeline.js";
 import { VINEXT_RSC_VARY_HEADER } from "./app-rsc-cache-busting.js";
 import { mergeVaryHeader } from "./middleware-response-headers.js";
-import { stripBasePath } from "../utils/base-path.js";
+import { hasBasePath, stripBasePath } from "../utils/base-path.js";
 import { normalizePath } from "./normalize-path.js";
 import { normalizePathnameForRouteMatch } from "../routing/utils.js";
 
@@ -66,12 +66,14 @@ export function finalizeAppRscResponse(
   // Config header sources are defined without basePath prefix. Strip basePath
   // at a segment boundary (not a string prefix) so /app2/page with basePath
   // /app is not incorrectly treated as /app with suffix /2/page.
+  const hadBasePath = !options.basePath || hasBasePath(pathname, options.basePath);
   pathname = stripBasePath(pathname, options.basePath);
 
   applyConfigHeadersToResponse(response.headers, {
     configHeaders: options.configHeaders,
     pathname,
     requestContext: options.requestContext,
+    basePathState: { basePath: options.basePath, hadBasePath },
   });
 
   return response;

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -1523,6 +1523,11 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
 
     try {
       // ── 2. Strip basePath ─────────────────────────────────────────
+      // Track whether the original request was under basePath. This drives
+      // the basePath gating of rewrites/redirects/headers below — Next.js
+      // only applies default rules to requests inside basePath, and only
+      // applies `basePath: false` rules to requests outside it.
+      const hadBasePath = !basePath || hasBasePath(pathname, basePath);
       {
         const stripped = stripBasePath(pathname, basePath);
         if (stripped !== pathname) {
@@ -1531,6 +1536,7 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
           pathname = stripped;
         }
       }
+      const basePathState = { basePath, hadBasePath };
 
       // ── 3. Trailing slash normalization ───────────────────────────
       {
@@ -1580,13 +1586,19 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
 
       // ── 4. Apply redirects from next.config.js ────────────────────
       if (configRedirects.length) {
-        const redirect = matchRedirect(pathname, configRedirects, reqCtx);
+        // The matcher sees the stripped pathname when the request was under
+        // basePath, and the original (un-stripped) pathname otherwise. The
+        // basePath gating inside `matchRedirect` then filters rules based on
+        // their `basePath: false` opt-out so the wrong rule set can't match.
+        const redirect = matchRedirect(pathname, configRedirects, reqCtx, basePathState);
         if (redirect) {
-          // Guard against double-prefixing: only add basePath if destination
-          // doesn't already start with it.
-          // Sanitize the final destination to prevent protocol-relative URL open redirects.
+          // Guard against double-prefixing: only add basePath if the
+          // request was under basePath AND the destination doesn't already
+          // start with it. basePath: false rules with `hadBasePath === false`
+          // must NOT receive a basePath prefix.
           const dest = sanitizeDestination(
             basePath &&
+              hadBasePath &&
               !isExternalUrl(redirect.destination) &&
               !hasBasePath(redirect.destination, basePath)
               ? basePath + redirect.destination
@@ -1713,6 +1725,7 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
           configHeaders,
           pathname,
           requestContext: reqCtx,
+          basePathState,
         });
       }
 
@@ -1748,8 +1761,14 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
       }
 
       // ── 7. Apply beforeFiles rewrites from next.config.js ─────────
+      let configRewriteFired = false;
       if (configRewrites.beforeFiles?.length) {
-        const rewritten = matchRewrite(resolvedPathname, configRewrites.beforeFiles, postMwReqCtx);
+        const rewritten = matchRewrite(
+          resolvedPathname,
+          configRewrites.beforeFiles,
+          postMwReqCtx,
+          basePathState,
+        );
         if (rewritten) {
           if (isExternalUrl(rewritten)) {
             const proxyResponse = await proxyExternalRequest(webRequest, rewritten);
@@ -1758,7 +1777,20 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
           }
           resolvedUrl = rewritten;
           resolvedPathname = rewritten.split("?")[0];
+          configRewriteFired = true;
         }
+      }
+
+      // ── 7b. Reject out-of-basePath requests that no rule rewrote ──
+      // When `basePath` is configured and the request was outside it,
+      // only `basePath: false` rules can keep it alive. If none matched,
+      // the request must 404 — Next.js does not serve internal routes
+      // from outside the configured basePath.
+      // @see .nextjs-ref/packages/next/src/server/lib/router-utils/resolve-routes.ts:304-309
+      if (basePath && !hadBasePath && !configRewriteFired) {
+        res.writeHead(404, { "Content-Type": "text/html; charset=utf-8" });
+        res.end("This page could not be found");
+        return;
       }
 
       // ── 8. API routes ─────────────────────────────────────────────
@@ -1803,7 +1835,12 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
       // ── 9. Apply afterFiles rewrites from next.config.js ──────────
       // These run after non-dynamic page routes but before dynamic routes.
       if ((!pageMatch || pageMatch.route.isDynamic) && configRewrites.afterFiles?.length) {
-        const rewritten = matchRewrite(resolvedPathname, configRewrites.afterFiles, postMwReqCtx);
+        const rewritten = matchRewrite(
+          resolvedPathname,
+          configRewrites.afterFiles,
+          postMwReqCtx,
+          basePathState,
+        );
         if (rewritten) {
           if (isExternalUrl(rewritten)) {
             const proxyResponse = await proxyExternalRequest(webRequest, rewritten);
@@ -1833,6 +1870,7 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
             resolvedPathname,
             configRewrites.fallback,
             postMwReqCtx,
+            basePathState,
           );
           if (fallbackRewrite) {
             if (isExternalUrl(fallbackRewrite)) {

--- a/packages/vinext/src/server/request-pipeline.ts
+++ b/packages/vinext/src/server/request-pipeline.ts
@@ -1,6 +1,6 @@
 import { hasBasePath, stripBasePath, removeTrailingSlash } from "../utils/base-path.js";
 import type { NextHeader } from "../config/next-config.js";
-import type { RequestContext } from "../config/config-matchers.js";
+import type { BasePathMatchState, RequestContext } from "../config/config-matchers.js";
 import { matchHeaders } from "../config/config-matchers.js";
 import {
   INTERNAL_HEADERS,
@@ -115,6 +115,12 @@ type ApplyConfigHeadersOptions = {
   configHeaders: NextHeader[];
   pathname: string;
   requestContext: RequestContext;
+  /**
+   * basePath gating state. When omitted, every rule is treated as a default
+   * (basePath: true) rule for backward compatibility — callers that need to
+   * support `basePath: false` headers must pass this in.
+   */
+  basePathState?: BasePathMatchState;
 };
 
 type StaticFileSignalContext = {
@@ -182,7 +188,12 @@ export function applyConfigHeadersToResponse(
   responseHeaders: Headers,
   options: ApplyConfigHeadersOptions,
 ): void {
-  const matched = matchHeaders(options.pathname, options.configHeaders, options.requestContext);
+  const matched = matchHeaders(
+    options.pathname,
+    options.configHeaders,
+    options.requestContext,
+    options.basePathState,
+  );
   for (const header of matched) {
     const lowerName = header.key.toLowerCase();
     if (lowerName === "vary" || lowerName === "set-cookie") {
@@ -201,7 +212,12 @@ export function applyConfigHeadersToHeaderRecord(
   headers: HeaderRecord,
   options: ApplyConfigHeadersOptions,
 ): void {
-  const matched = matchHeaders(options.pathname, options.configHeaders, options.requestContext);
+  const matched = matchHeaders(
+    options.pathname,
+    options.configHeaders,
+    options.requestContext,
+    options.basePathState,
+  );
   for (const header of matched) {
     const lowerName = header.key.toLowerCase();
     if (lowerName === "set-cookie") {

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -530,7 +530,9 @@ describe("generatePagesRouterWorkerEntry", () => {
 
   it("applies next.config.js redirects before middleware", () => {
     const content = generatePagesRouterWorkerEntry();
-    const redirectPos = content.indexOf("matchRedirect(pathname, configRedirects, reqCtx)");
+    const redirectPos = content.indexOf(
+      "matchRedirect(pathname, configRedirects, reqCtx, basePathState)",
+    );
     const middlewarePos = content.indexOf("runMiddleware(request, ctx)");
     expect(redirectPos).toBeGreaterThan(-1);
     expect(middlewarePos).toBeGreaterThan(-1);
@@ -592,7 +594,11 @@ describe("generatePagesRouterWorkerEntry", () => {
     expect(content).toContain("configRewrites.beforeFiles");
     expect(content).toContain("configRewrites.afterFiles");
     expect(content).toContain("configRewrites.fallback");
-    expect(content).toContain("matchRewrite(resolvedPathname");
+    // matchRewrite is invoked with the basePath-gated 4-arg signature.
+    // Across the three rewrite buckets the arg list is now formatted on
+    // multiple lines, so assert on the call expression itself.
+    expect(content).toMatch(/matchRewrite\(\s*resolvedPathname/);
+    expect(content).toContain("basePathState");
     expect(content).toContain("matchPageRoute");
     expect(content).toContain("matchPageRoute(resolvedPathname, request)");
   });

--- a/tests/nextjs-compat/basepath.test.ts
+++ b/tests/nextjs-compat/basepath.test.ts
@@ -370,6 +370,26 @@ describe("basePath: rewrite/redirect/header gating", () => {
     expect(result).toEqual({ destination: "/another-destination", permanent: false });
   });
 
+  it("basePath: false redirect rule does NOT match when request is under basePath", async () => {
+    // Symmetric to the rewrite case: the opt-out rule must not fire when
+    // the request is inside basePath — otherwise both buckets would match
+    // on `/docs/redirect-no-basepath`.
+    const { matchRedirect } = await import("../../packages/vinext/src/config/config-matchers.js");
+    const redirects = [
+      {
+        source: "/redirect-no-basepath",
+        destination: "/another-destination",
+        permanent: false,
+        basePath: false as const,
+      },
+    ];
+    const result = matchRedirect("/redirect-no-basepath", redirects, emptyCtx(), {
+      basePath: "/docs",
+      hadBasePath: true,
+    });
+    expect(result).toBeNull();
+  });
+
   it("default header rule does not match when request is outside basePath", async () => {
     const { matchHeaders } = await import("../../packages/vinext/src/config/config-matchers.js");
     const headers = [{ source: "/add-header", headers: [{ key: "x-hello", value: "world" }] }];
@@ -404,6 +424,23 @@ describe("basePath: rewrite/redirect/header gating", () => {
       hadBasePath: false,
     });
     expect(result).toEqual([{ key: "x-hello", value: "world" }]);
+  });
+
+  it("basePath: false header rule does NOT match when request is under basePath", async () => {
+    // Symmetric to the rewrite/redirect cases.
+    const { matchHeaders } = await import("../../packages/vinext/src/config/config-matchers.js");
+    const headers = [
+      {
+        source: "/add-header-no-basepath",
+        headers: [{ key: "x-hello", value: "world" }],
+        basePath: false as const,
+      },
+    ];
+    const result = matchHeaders("/add-header-no-basepath", headers, emptyCtx(), {
+      basePath: "/docs",
+      hadBasePath: true,
+    });
+    expect(result).toEqual([]);
   });
 
   it("rules behave like default when basePath is empty (back-compat)", async () => {

--- a/tests/nextjs-compat/basepath.test.ts
+++ b/tests/nextjs-compat/basepath.test.ts
@@ -335,9 +335,7 @@ describe("basePath: rewrite/redirect/header gating", () => {
 
   it("default redirect rule does not match when request is outside basePath", async () => {
     const { matchRedirect } = await import("../../packages/vinext/src/config/config-matchers.js");
-    const redirects = [
-      { source: "/redirect-1", destination: "/somewhere-else", permanent: false },
-    ];
+    const redirects = [{ source: "/redirect-1", destination: "/somewhere-else", permanent: false }];
     const result = matchRedirect("/redirect-1", redirects, emptyCtx(), {
       basePath: "/docs",
       hadBasePath: false,
@@ -347,9 +345,7 @@ describe("basePath: rewrite/redirect/header gating", () => {
 
   it("default redirect rule matches when request is under basePath", async () => {
     const { matchRedirect } = await import("../../packages/vinext/src/config/config-matchers.js");
-    const redirects = [
-      { source: "/redirect-1", destination: "/somewhere-else", permanent: false },
-    ];
+    const redirects = [{ source: "/redirect-1", destination: "/somewhere-else", permanent: false }];
     const result = matchRedirect("/redirect-1", redirects, emptyCtx(), {
       basePath: "/docs",
       hadBasePath: true,
@@ -376,9 +372,7 @@ describe("basePath: rewrite/redirect/header gating", () => {
 
   it("default header rule does not match when request is outside basePath", async () => {
     const { matchHeaders } = await import("../../packages/vinext/src/config/config-matchers.js");
-    const headers = [
-      { source: "/add-header", headers: [{ key: "x-hello", value: "world" }] },
-    ];
+    const headers = [{ source: "/add-header", headers: [{ key: "x-hello", value: "world" }] }];
     const result = matchHeaders("/add-header", headers, emptyCtx(), {
       basePath: "/docs",
       hadBasePath: false,
@@ -388,9 +382,7 @@ describe("basePath: rewrite/redirect/header gating", () => {
 
   it("default header rule matches when request is under basePath", async () => {
     const { matchHeaders } = await import("../../packages/vinext/src/config/config-matchers.js");
-    const headers = [
-      { source: "/add-header", headers: [{ key: "x-hello", value: "world" }] },
-    ];
+    const headers = [{ source: "/add-header", headers: [{ key: "x-hello", value: "world" }] }];
     const result = matchHeaders("/add-header", headers, emptyCtx(), {
       basePath: "/docs",
       hadBasePath: true,
@@ -419,20 +411,19 @@ describe("basePath: rewrite/redirect/header gating", () => {
     // basePath flag — there is nothing to gate against.
     const { matchRewrite } = await import("../../packages/vinext/src/config/config-matchers.js");
     const rewrites = [{ source: "/x", destination: "/y" }];
-    expect(
-      matchRewrite("/x", rewrites, emptyCtx(), { basePath: "", hadBasePath: false }),
-    ).toBe("/y");
-    expect(
-      matchRewrite("/x", rewrites, emptyCtx(), { basePath: "", hadBasePath: true }),
-    ).toBe("/y");
+    expect(matchRewrite("/x", rewrites, emptyCtx(), { basePath: "", hadBasePath: false })).toBe(
+      "/y",
+    );
+    expect(matchRewrite("/x", rewrites, emptyCtx(), { basePath: "", hadBasePath: true })).toBe(
+      "/y",
+    );
   });
 
   it("matchers without explicit basePathState default to permissive (back-compat)", async () => {
     // Callers that haven't been updated to pass basePathState should behave
     // exactly as before this change.
-    const { matchRewrite, matchRedirect, matchHeaders } = await import(
-      "../../packages/vinext/src/config/config-matchers.js"
-    );
+    const { matchRewrite, matchRedirect, matchHeaders } =
+      await import("../../packages/vinext/src/config/config-matchers.js");
     const rewrites = [{ source: "/x", destination: "/y" }];
     expect(matchRewrite("/x", rewrites, emptyCtx())).toBe("/y");
     const redirects = [{ source: "/x", destination: "/y", permanent: false }];

--- a/tests/nextjs-compat/basepath.test.ts
+++ b/tests/nextjs-compat/basepath.test.ts
@@ -255,3 +255,192 @@ describe("basePath: server-action redirect", () => {
     expect(applyActionRedirectBasePath("/another", "")).toBe("/another");
   });
 });
+
+// Ported from Next.js: test/e2e/basepath/redirect-and-rewrite.test.ts
+// https://github.com/vercel/next.js/blob/canary/test/e2e/basepath/redirect-and-rewrite.test.ts
+//
+// Covers the basePath gating semantics on rewrite/redirect/header rules:
+//
+//   - Default rules (no `basePath: false`) only match requests that were
+//     under the configured basePath. A request to `/rewrite-1` without the
+//     `/docs` prefix must NOT match a rule whose source is `/rewrite-1`.
+//   - Rules opting out via `basePath: false` only match requests OUTSIDE
+//     the basePath (per Next.js they evaluate against the raw pathname).
+//
+// Matches `.nextjs-ref/packages/next/src/lib/load-custom-routes.ts:530-580`.
+describe("basePath: rewrite/redirect/header gating", () => {
+  const emptyHeaders = () => new Headers();
+  const emptyCtx = () => ({
+    headers: emptyHeaders(),
+    cookies: {},
+    query: new URLSearchParams(),
+    host: "localhost",
+  });
+
+  it("default rewrite rule does not match when request is outside basePath", async () => {
+    const { matchRewrite } = await import("../../packages/vinext/src/config/config-matchers.js");
+    const rewrites = [{ source: "/rewrite-1", destination: "/gssp" }];
+    const result = matchRewrite("/rewrite-1", rewrites, emptyCtx(), {
+      basePath: "/docs",
+      hadBasePath: false,
+    });
+    expect(result).toBeNull();
+  });
+
+  it("default rewrite rule matches when request is under basePath", async () => {
+    const { matchRewrite } = await import("../../packages/vinext/src/config/config-matchers.js");
+    const rewrites = [{ source: "/rewrite-1", destination: "/gssp" }];
+    // Pathname passed in is the basePath-stripped form, mirroring how the
+    // prod-server hands it to the matcher.
+    const result = matchRewrite("/rewrite-1", rewrites, emptyCtx(), {
+      basePath: "/docs",
+      hadBasePath: true,
+    });
+    expect(result).toBe("/gssp");
+  });
+
+  it("basePath: false rewrite rule matches when request is outside basePath", async () => {
+    const { matchRewrite } = await import("../../packages/vinext/src/config/config-matchers.js");
+    const rewrites = [
+      {
+        source: "/rewrite-no-basepath",
+        destination: "https://example.vercel.sh",
+        basePath: false as const,
+      },
+    ];
+    const result = matchRewrite("/rewrite-no-basepath", rewrites, emptyCtx(), {
+      basePath: "/docs",
+      hadBasePath: false,
+    });
+    expect(result).toBe("https://example.vercel.sh");
+  });
+
+  it("basePath: false rewrite rule does NOT match when request is under basePath", async () => {
+    // Mirrors Next.js: rewriting `/docs/rewrite-no-basePath` falls through to
+    // the dynamic `[slug]` route, not the opt-out rule.
+    const { matchRewrite } = await import("../../packages/vinext/src/config/config-matchers.js");
+    const rewrites = [
+      {
+        source: "/rewrite-no-basepath",
+        destination: "https://example.vercel.sh",
+        basePath: false as const,
+      },
+    ];
+    const result = matchRewrite("/rewrite-no-basepath", rewrites, emptyCtx(), {
+      basePath: "/docs",
+      hadBasePath: true,
+    });
+    expect(result).toBeNull();
+  });
+
+  it("default redirect rule does not match when request is outside basePath", async () => {
+    const { matchRedirect } = await import("../../packages/vinext/src/config/config-matchers.js");
+    const redirects = [
+      { source: "/redirect-1", destination: "/somewhere-else", permanent: false },
+    ];
+    const result = matchRedirect("/redirect-1", redirects, emptyCtx(), {
+      basePath: "/docs",
+      hadBasePath: false,
+    });
+    expect(result).toBeNull();
+  });
+
+  it("default redirect rule matches when request is under basePath", async () => {
+    const { matchRedirect } = await import("../../packages/vinext/src/config/config-matchers.js");
+    const redirects = [
+      { source: "/redirect-1", destination: "/somewhere-else", permanent: false },
+    ];
+    const result = matchRedirect("/redirect-1", redirects, emptyCtx(), {
+      basePath: "/docs",
+      hadBasePath: true,
+    });
+    expect(result).toEqual({ destination: "/somewhere-else", permanent: false });
+  });
+
+  it("basePath: false redirect rule matches when request is outside basePath", async () => {
+    const { matchRedirect } = await import("../../packages/vinext/src/config/config-matchers.js");
+    const redirects = [
+      {
+        source: "/redirect-no-basepath",
+        destination: "/another-destination",
+        permanent: false,
+        basePath: false as const,
+      },
+    ];
+    const result = matchRedirect("/redirect-no-basepath", redirects, emptyCtx(), {
+      basePath: "/docs",
+      hadBasePath: false,
+    });
+    expect(result).toEqual({ destination: "/another-destination", permanent: false });
+  });
+
+  it("default header rule does not match when request is outside basePath", async () => {
+    const { matchHeaders } = await import("../../packages/vinext/src/config/config-matchers.js");
+    const headers = [
+      { source: "/add-header", headers: [{ key: "x-hello", value: "world" }] },
+    ];
+    const result = matchHeaders("/add-header", headers, emptyCtx(), {
+      basePath: "/docs",
+      hadBasePath: false,
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("default header rule matches when request is under basePath", async () => {
+    const { matchHeaders } = await import("../../packages/vinext/src/config/config-matchers.js");
+    const headers = [
+      { source: "/add-header", headers: [{ key: "x-hello", value: "world" }] },
+    ];
+    const result = matchHeaders("/add-header", headers, emptyCtx(), {
+      basePath: "/docs",
+      hadBasePath: true,
+    });
+    expect(result).toEqual([{ key: "x-hello", value: "world" }]);
+  });
+
+  it("basePath: false header rule matches when request is outside basePath", async () => {
+    const { matchHeaders } = await import("../../packages/vinext/src/config/config-matchers.js");
+    const headers = [
+      {
+        source: "/add-header-no-basepath",
+        headers: [{ key: "x-hello", value: "world" }],
+        basePath: false as const,
+      },
+    ];
+    const result = matchHeaders("/add-header-no-basepath", headers, emptyCtx(), {
+      basePath: "/docs",
+      hadBasePath: false,
+    });
+    expect(result).toEqual([{ key: "x-hello", value: "world" }]);
+  });
+
+  it("rules behave like default when basePath is empty (back-compat)", async () => {
+    // When basePath is not configured, every rule should match regardless of
+    // basePath flag — there is nothing to gate against.
+    const { matchRewrite } = await import("../../packages/vinext/src/config/config-matchers.js");
+    const rewrites = [{ source: "/x", destination: "/y" }];
+    expect(
+      matchRewrite("/x", rewrites, emptyCtx(), { basePath: "", hadBasePath: false }),
+    ).toBe("/y");
+    expect(
+      matchRewrite("/x", rewrites, emptyCtx(), { basePath: "", hadBasePath: true }),
+    ).toBe("/y");
+  });
+
+  it("matchers without explicit basePathState default to permissive (back-compat)", async () => {
+    // Callers that haven't been updated to pass basePathState should behave
+    // exactly as before this change.
+    const { matchRewrite, matchRedirect, matchHeaders } = await import(
+      "../../packages/vinext/src/config/config-matchers.js"
+    );
+    const rewrites = [{ source: "/x", destination: "/y" }];
+    expect(matchRewrite("/x", rewrites, emptyCtx())).toBe("/y");
+    const redirects = [{ source: "/x", destination: "/y", permanent: false }];
+    expect(matchRedirect("/x", redirects, emptyCtx())).toEqual({
+      destination: "/y",
+      permanent: false,
+    });
+    const headers = [{ source: "/x", headers: [{ key: "a", value: "b" }] }];
+    expect(matchHeaders("/x", headers, emptyCtx())).toEqual([{ key: "a", value: "b" }]);
+  });
+});


### PR DESCRIPTION
## Summary

Sub-issues addressed under #1333:

- **Sub-issue 1 (rewrites/redirects/headers gating).** Default rules now only fire when the request is under `basePath`, and `basePath: false` opt-out rules only fire when the request is outside it. Implemented by threading a `BasePathMatchState` through `matchRewrite` / `matchRedirect` / `matchHeaders` and every caller (Pages Router `prod-server`, App Router `app-rsc-handler`, the Cloudflare worker entry in `deploy.ts`, and the dev plugin).
- **Sub-issue 5 (404 outside basePath).** Pages Router (both `prod-server.ts` and the generated worker in `deploy.ts`) now returns 404 for out-of-basepath requests after rewrites have had a chance to fire. App Router already had this via `normalizeRscRequest`. Matches Next.js's `resolve-routes.ts:304-309`.
- **Sub-issue 4 (basePath doubling).** The doubling was a side-effect of the rewrite gating bug — out-of-basepath requests matched `/rewrite-1` style rules, then the redirect-destination code prepended basePath again. Fixed once #1 lands. Pure-asset doubling (if any) is tracked separately.

Deferred (called out in the issue):

- **Sub-issue 2 (external `basePath: false` rewrite proxying).** The matcher gating now lets these rules fire on out-of-basepath requests, but App Router's `normalizeRscRequest` 404s before reaching them. Pages Router proxying via `proxyExternalRequest` works (it was already wired). Tracked as the App Router follow-up — flagged inline in `app-rsc-handler.ts`.
- **Sub-issue 3 (static asset under basePath).** Already partly addressed by #1337 / #1383's `isNextStaticPath` work.

References:
- Next.js parity for the rule gating: [`packages/next/src/lib/load-custom-routes.ts:530-580`](https://github.com/vercel/next.js/blob/canary/packages/next/src/lib/load-custom-routes.ts#L530-L580).
- Next.js parity for the 404 outside basePath: [`packages/next/src/server/lib/router-utils/resolve-routes.ts:304-309`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/router-utils/resolve-routes.ts#L304-L309).
- Next.js E2E suite this targets: [`test/e2e/basepath/redirect-and-rewrite.test.ts`](https://github.com/vercel/next.js/blob/canary/test/e2e/basepath/redirect-and-rewrite.test.ts).

Refs #1333 (not Closes — sub-issues 2 and 3 remain).

## Test plan

- [x] Added 13 unit tests in `tests/nextjs-compat/basepath.test.ts` covering each gating case (default + `basePath: false`, in + out of basePath, all three matchers, plus backward-compat without an explicit state arg). All 23 tests in that file pass.
- [x] `vp test run tests/shims.test.ts tests/next-config.test.ts tests/nextjs-compat/basepath.test.ts` — 1065 pass.
- [x] `vp test run tests/app-router.test.ts` — 318 pass.
- [x] `vp test run tests/pages-router.test.ts` — 209 pass.
- [x] `vp test run tests/features.test.ts` — 303 pass.
- [x] `vp check --fix` — lint + types clean.
- [ ] CI: full Vitest + Playwright E2E (Pages Router + App Router projects) to confirm the upstream `test/e2e/basepath/*` failures drop.