### PR TITLE
fix(app-router): parse interception route markers in route scanner

### DIFF
--- a/packages/vinext/src/routing/app-route-graph.ts
+++ b/packages/vinext/src/routing/app-route-graph.ts
@@ -823,9 +823,20 @@ export async function buildAppRouteGraph(
   // Find all page.tsx and route.ts files, excluding @slot directories
   // (slot pages are not standalone routes — they're rendered as props of their parent layout)
   // and _private folders (Next.js convention for colocated non-route files).
+  //
+  // Interception marker directories (e.g. `(.)photo`, `(..)showcase`,
+  // `(..)(..)hoge`, `(...)photos`) are also excluded from the global page
+  // scan because the marker is not a real URL segment — Next.js treats these
+  // as a separate route family resolved via interception rewrites. Without
+  // this exclusion the scanner would register patterns like
+  // `/templates/(..)showcase` as standalone routes, breaking the build (and
+  // any URL containing the marker).
+  //
+  // See https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/router/utils/interception-routes.ts
   const routes: AppRouteGraphRoute[] = [];
 
-  const excludeDir = (name: string) => name.startsWith("@") || name.startsWith("_");
+  const excludeDir = (name: string) =>
+    name.startsWith("@") || name.startsWith("_") || isInterceptionMarkerDir(name);
 
   // Process page files in a single pass
   // Use function form of exclude for Node < 22.14 compatibility (string arrays require >= 22.14)
@@ -1885,6 +1896,19 @@ const INTERCEPT_PATTERNS = [
   { prefix: "(..)", convention: ".." },
   { prefix: "(.)", convention: "." },
 ] as const;
+
+/**
+ * Check whether a directory name begins with an interception route marker.
+ *
+ * Matches the prefixes listed in {@link INTERCEPT_PATTERNS}: `(.)`, `(..)`,
+ * `(...)`, `(..)(..)"`. The marker is not a real URL segment, so the global
+ * page/route scanner must skip these directories to avoid materialising
+ * literal patterns like `/templates/(..)showcase`. Interception target
+ * registration happens separately via {@link discoverInterceptingRoutes}.
+ */
+function isInterceptionMarkerDir(name: string): boolean {
+  return matchInterceptConvention(name) !== null;
+}
 
 /**
  * Discover intercepting routes inside a parallel slot directory.

--- a/packages/vinext/src/routing/app-route-graph.ts
+++ b/packages/vinext/src/routing/app-route-graph.ts
@@ -1901,7 +1901,7 @@ const INTERCEPT_PATTERNS = [
  * Check whether a directory name begins with an interception route marker.
  *
  * Matches the prefixes listed in {@link INTERCEPT_PATTERNS}: `(.)`, `(..)`,
- * `(...)`, `(..)(..)"`. The marker is not a real URL segment, so the global
+ * `(...)`, `(..)(..)`. The marker is not a real URL segment, so the global
  * page/route scanner must skip these directories to avoid materialising
  * literal patterns like `/templates/(..)showcase`. Interception target
  * registration happens separately via {@link discoverInterceptingRoutes}.

--- a/tests/app-route-graph.test.ts
+++ b/tests/app-route-graph.test.ts
@@ -1082,5 +1082,42 @@ describe("App Router route graph builder", () => {
         }
       });
     });
+
+    it("ignores `(.)` same-level interception marker outside a parallel slot", async () => {
+      // Coverage for the same-level marker — sibling of a regular route,
+      // not inside a `@slot`. Must not register `/gallery/(.)photo` as a page.
+      await withTempApp(async (appDir) => {
+        await writeAppFile(appDir, "layout.tsx", EMPTY_LAYOUT);
+        await writeAppFile(appDir, "page.tsx", EMPTY_PAGE);
+        await writeAppFile(appDir, "gallery/photo/page.tsx", EMPTY_PAGE);
+        await writeAppFile(appDir, "gallery/(.)photo/page.tsx", EMPTY_PAGE);
+
+        const graph = await buildAppRouteGraph(appDir, createValidFileMatcher());
+        const patterns = graph.routes.map((route) => route.pattern);
+
+        for (const pattern of patterns) {
+          expect(pattern).not.toMatch(/\(\.{1,3}\)/);
+        }
+      });
+    });
+
+    it("ignores `(...)` root interception marker outside a parallel slot", async () => {
+      // Coverage for the root marker — `(...)` always resolves against the
+      // app root, so the marker must be stripped even when buried deep in
+      // the filesystem tree.
+      await withTempApp(async (appDir) => {
+        await writeAppFile(appDir, "layout.tsx", EMPTY_LAYOUT);
+        await writeAppFile(appDir, "page.tsx", EMPTY_PAGE);
+        await writeAppFile(appDir, "target/page.tsx", EMPTY_PAGE);
+        await writeAppFile(appDir, "deep/path/(...)target/page.tsx", EMPTY_PAGE);
+
+        const graph = await buildAppRouteGraph(appDir, createValidFileMatcher());
+        const patterns = graph.routes.map((route) => route.pattern);
+
+        for (const pattern of patterns) {
+          expect(pattern).not.toMatch(/\(\.{1,3}\)/);
+        }
+      });
+    });
   });
 });

--- a/tests/app-route-graph.test.ts
+++ b/tests/app-route-graph.test.ts
@@ -1034,5 +1034,53 @@ describe("App Router route graph builder", () => {
         expect(interceptionsBySlotId).toEqual([["slot:modal:/[locale]/feed", interceptions]]);
       });
     });
+
+    it("ignores interception marker directories that live outside a parallel slot", async () => {
+      // Ported from Next.js: test/e2e/app-dir/interception-routes-multiple-catchall
+      // and test/e2e/app-dir/interception-segments-two-levels-above. Next.js
+      // allows interception marker directories anywhere — they should not be
+      // treated as standalone routes (the marker is not a real URL segment),
+      // so the build must not register `/templates/(..)showcase` as a page
+      // and must not throw while validating its pattern.
+      await withTempApp(async (appDir) => {
+        await writeAppFile(appDir, "layout.tsx", EMPTY_LAYOUT);
+        await writeAppFile(appDir, "page.tsx", EMPTY_PAGE);
+        await writeAppFile(appDir, "showcase/page.tsx", EMPTY_PAGE);
+        await writeAppFile(appDir, "templates/layout.tsx", EMPTY_LAYOUT);
+        await writeAppFile(appDir, "templates/[...catchAll]/page.tsx", EMPTY_PAGE);
+        await writeAppFile(appDir, "templates/(..)showcase/page.tsx", EMPTY_PAGE);
+        await writeAppFile(appDir, "templates/(..)showcase/[...catchAll]/page.tsx", EMPTY_PAGE);
+
+        const graph = await buildAppRouteGraph(appDir, createValidFileMatcher());
+        const patterns = graph.routes.map((route) => route.pattern);
+
+        // The marker directory itself is not a route — it must never surface
+        // as `/templates/(..)showcase` or similar.
+        for (const pattern of patterns) {
+          expect(pattern).not.toMatch(/\(\.{1,3}\)/);
+        }
+      });
+    });
+
+    it("ignores `(..)(..)` interception marker outside a parallel slot", async () => {
+      // Ported from Next.js: test/e2e/app-dir/interception-segments-two-levels-above
+      // app/foo/bar/(..)(..)hoge/page.tsx is a sibling-style interception
+      // marker (no @slot). Build must not throw and must not register a
+      // route with the literal marker in its pattern.
+      await withTempApp(async (appDir) => {
+        await writeAppFile(appDir, "layout.tsx", EMPTY_LAYOUT);
+        await writeAppFile(appDir, "page.tsx", EMPTY_PAGE);
+        await writeAppFile(appDir, "hoge/page.tsx", EMPTY_PAGE);
+        await writeAppFile(appDir, "foo/bar/page.tsx", EMPTY_PAGE);
+        await writeAppFile(appDir, "foo/bar/(..)(..)hoge/page.tsx", EMPTY_PAGE);
+
+        const graph = await buildAppRouteGraph(appDir, createValidFileMatcher());
+        const patterns = graph.routes.map((route) => route.pattern);
+
+        for (const pattern of patterns) {
+          expect(pattern).not.toMatch(/\(\.{1,3}\)/);
+        }
+      });
+    });
   });
 });


### PR DESCRIPTION
## Summary

Interception route markers (`(.)`, `(..)`, `(...)`, `(..)(..)`) can be placed anywhere under `app/` — not only inside `@slot` directories. Previously, the App Router scanner only excluded `@*` and `_*` directories from the global `**/page` and `**/route` scan, so markers used as siblings of regular routes (e.g. `templates/(..)showcase/page.tsx`, `foo/bar/(..)(..)hoge/page.tsx`) were materialised as literal URL patterns like `/templates/(..)showcase`, breaking the build pipeline and producing unreachable routes.

This change makes the scanner skip directories whose names begin with an interception marker, matching Next.js' behaviour (`INTERCEPTION_ROUTE_MARKERS` in `packages/next/src/shared/lib/router/utils/interception-routes.ts`). Markers inside `@slot` directories continue to be discovered by the existing `discoverInterceptingRoutes` walk.

## Scope

Sub-issue #1364 covers 22 failing tests across five Next.js E2E suites. This PR addresses the build-time failure (route scanner producing malformed patterns) that blocked the suites from running. Runtime interception-rewrite behaviour for non-slot markers (where the intercepting page lives at `foo/bar/(..)(..)hoge/page.tsx` and renders the modal at `/hoge`) is intentionally **not** wired up here — it requires expanding the interception facts beyond the current `@slot`-scoped model and is best landed in a follow-up that can address it across all five suites. Marked draft and `Refs #1364` since not all sub-suites pass.

## Test plan

- [x] `pnpm test tests/app-route-graph.test.ts` — new tests for non-slot interception markers (`(..)`, `(..)(..)`) pass
- [x] `pnpm test tests/intercepting-routes-build.test.ts tests/app-browser-interception-context.test.ts tests/app-router.test.ts tests/routing.test.ts tests/route-sorting.test.ts` — 472 tests pass
- [x] `pnpm run check` — format, lint, types clean
- [ ] CI green