### PR TITLE
fix(metadata): emit metadata from parallel route slots

### DIFF
--- a/packages/vinext/src/server/app-page-head.ts
+++ b/packages/vinext/src/server/app-page-head.ts
@@ -368,12 +368,23 @@ async function resolveAppPageHeadInner<TModule extends AppPageHeadModule>(
   const parallelViewportResults = parallelRouteHeads.flatMap((head) => head.viewportResults);
   const parallelMetadataSources = parallelRouteHeads.flatMap((head) => head.metadataSources);
 
+  // Active parallel slot metadata is suppressed from contributing the primary
+  // <title> when the matched page already provides one. This preserves Next.js
+  // behavior where slot pages (typically modals/sidebars rendered alongside the
+  // main page) don't clobber the page title. When the route has no children
+  // page providing a title (e.g. a parallel layout that doesn't render
+  // `{children}`, or a parent that only has `default.tsx`), the slot page's
+  // title is the most specific signal and is allowed to contribute — matching
+  // Next.js's loader-tree walk which appends slot metadata items in tree order
+  // with no title suppression.
+  // Reference: https://github.com/vercel/next.js/blob/canary/packages/next/src/lib/metadata/resolve-metadata.ts
+  const primaryPageHasTitle = pageMetadata != null && pageMetadata.title !== undefined;
   const metadataEntries: MetadataMergeEntry[] = [
     ...layoutMetadataResults.filter(isPresent).map((metadata) => ({ metadata })),
     ...(pageMetadata ? [{ isPage: true, metadata: pageMetadata }] : []),
     ...parallelMetadataResults
       .filter(isPresent)
-      .map((metadata) => ({ contributesTitle: false, metadata })),
+      .map((metadata) => ({ contributesTitle: !primaryPageHasTitle, metadata })),
   ];
   const viewportList = [
     ...layoutViewportResults.filter(isPresent),

--- a/tests/app-page-head.test.ts
+++ b/tests/app-page-head.test.ts
@@ -392,6 +392,100 @@ describe("app page head resolution", () => {
     });
   });
 
+  it("uses parallel route slot page title when no primary page module is present", async () => {
+    // Ported from Next.js: test/e2e/app-dir/metadata-streaming-parallel-routes/metadata-streaming-parallel-routes.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/metadata-streaming-parallel-routes/metadata-streaming-parallel-routes.test.ts
+    //
+    // Reproduces:
+    //   "should change metadata when navigating between two pages under a slot
+    //   when children is not rendered"
+    //
+    // The route has no `pageModule` (the layout doesn't render children and there
+    // is no children-slot default to fill in). The active title must come from
+    // the parallel slot's page metadata.
+    const rootLayout = {
+      metadata: {
+        title: "Root",
+      },
+    };
+    const parallelLayout = {
+      metadata: {
+        title: "parallel-routes-no-children layout title",
+      },
+    };
+    const slotPage = {
+      metadata: {
+        title: "first page - @bar",
+      },
+    };
+
+    const result = await resolveAppPageHead<Record<string, unknown>>({
+      layoutModules: [rootLayout, parallelLayout],
+      layoutTreePositions: [0, 1],
+      metadataRoutes: [],
+      pageModule: null,
+      parallelRoutes: [
+        {
+          layoutModules: [],
+          pageModule: slotPage,
+          routeSegments: ["parallel-routes-no-children", "@bar", "first"],
+        },
+      ],
+      params: {},
+      routePath: "/parallel-routes-no-children/first",
+      routeSegments: ["parallel-routes-no-children", "first"],
+    });
+
+    expect(result.metadata?.title).toBe("first page - @bar");
+  });
+
+  it("uses parallel layout title when neither primary page nor slot page set a title", async () => {
+    // Ported from Next.js: test/e2e/app-dir/metadata-streaming-parallel-routes/metadata-streaming-parallel-routes.test.ts
+    //
+    // Reproduces:
+    //   "should still render metadata if children is not rendered in parallel
+    //   routes layout"
+    //
+    // The route has only a `default.tsx` (no `metadata`) at the children slot and
+    // the parallel slots render their default fallbacks (no `metadata`). The
+    // active title must come from the parallel layout's metadata.
+    const rootLayout = {
+      metadata: {
+        title: "Root",
+      },
+    };
+    const parallelLayout = {
+      metadata: {
+        title: "parallel-routes-default layout title",
+      },
+    };
+    const defaultPage = {
+      // default.tsx with no metadata
+    };
+    const slotDefault = {
+      // @bar/default.tsx with no metadata
+    };
+
+    const result = await resolveAppPageHead<Record<string, unknown>>({
+      layoutModules: [rootLayout, parallelLayout],
+      layoutTreePositions: [0, 1],
+      metadataRoutes: [],
+      pageModule: defaultPage,
+      parallelRoutes: [
+        {
+          layoutModules: [],
+          pageModule: slotDefault,
+          routeSegments: ["parallel-routes-default"],
+        },
+      ],
+      params: {},
+      routePath: "/parallel-routes-default",
+      routeSegments: ["parallel-routes-default"],
+    });
+
+    expect(result.metadata?.title).toBe("parallel-routes-default layout title");
+  });
+
   it("bubbles active parallel page metadata errors", async () => {
     await expect(
       resolveAppPageHead<Record<string, unknown>>({


### PR DESCRIPTION
## Summary

- When a route has no children page providing a title (e.g. a parallel-routes layout that doesn't render `{children}`, or a parent directory with only `default.tsx`), allow the active parallel slot's page metadata to contribute the primary `<title>`. Previously every slot entry was forced with `contributesTitle: false`, suppressing the slot title even when no primary title existed — producing an empty title or a stale layout title.
- Slots keep the existing suppression when the matched page already provides a title, preserving the modal/sidebar case where slot metadata must not clobber the page title.

This addresses the server-side metadata-resolution piece of #1341 (sub-problems 1 and 2 — empty `<title>` when a parallel layout doesn't render `children`, and missing title on routes that resolve through slot sub-pages). The missing `<meta charset>` on root not-found (sub-problem 3) is a separate not-found rendering concern and is not addressed here.

## Test plan

- [x] New unit tests in `tests/app-page-head.test.ts` covering:
  - Slot page contributes title when no `pageModule` is present (ported from Next.js `metadata-streaming-parallel-routes` — navigating between sub-pages under a slot).
  - Parallel layout title still wins when no slot metadata exists (ported from the same suite — "still render metadata if children is not rendered in parallel routes layout").
- [x] Confirmed the first new test fails on `main` (received the parallel-layout title instead of the slot page title), passes with the fix.
- [x] Existing test "keeps primary page title handling independent from active parallel route metadata" still passes — slot metadata is still suppressed when the primary page provides a title.
- [x] `pnpm test tests/app-page-head.test.ts tests/app-page-element-builder.test.ts tests/app-page-boundary.test.ts tests/app-page-boundary-render.test.ts tests/file-based-metadata.test.ts tests/head.test.ts tests/metadata-routes.test.ts tests/metadata-route-build-data.test.ts tests/metadata-route-response.test.ts tests/slot.test.ts` — all green.
- [x] `pnpm test tests/app-router.test.ts tests/app-rsc-route-matching.test.ts tests/app-route-graph.test.ts` — all green.
- [x] `pnpm run check` clean.

Refs #1341

### References

Ported from Next.js:
- https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/metadata-streaming-parallel-routes/metadata-streaming-parallel-routes.test.ts
- https://github.com/vercel/next.js/blob/canary/packages/next/src/lib/metadata/resolve-metadata.ts (loader-tree walk treats slot metadata items in tree order with no title suppression)