### PR TITLE
fix(deploy): match Next.js Cache-Control in deploy mode

### DIFF
--- a/packages/vinext/src/server/app-page-response.ts
+++ b/packages/vinext/src/server/app-page-response.ts
@@ -1,8 +1,10 @@
 import {
   buildRevalidateCacheControl,
+  DEPLOY_CACHE_CONTROL,
   NO_STORE_CACHE_CONTROL,
   STATIC_CACHE_CONTROL,
 } from "./cache-control.js";
+import { isDeployRuntime } from "./deploy-runtime.js";
 import {
   VINEXT_CACHE_HEADER,
   VINEXT_MOUNTED_SLOTS_HEADER,
@@ -115,7 +117,7 @@ export function resolveAppPageRscResponsePolicy(
     options.revalidateSeconds === Infinity
   ) {
     return {
-      cacheControl: STATIC_CACHE_CONTROL,
+      cacheControl: isDeployRuntime() ? DEPLOY_CACHE_CONTROL : STATIC_CACHE_CONTROL,
       cacheState: "STATIC",
     };
   }
@@ -178,7 +180,7 @@ export function resolveAppPageHtmlResponsePolicy(
 
   if ((options.isForceStatic || options.isDynamicError) && options.revalidateSeconds === null) {
     return {
-      cacheControl: STATIC_CACHE_CONTROL,
+      cacheControl: isDeployRuntime() ? DEPLOY_CACHE_CONTROL : STATIC_CACHE_CONTROL,
       cacheState: "STATIC",
       shouldWriteToCache: false,
     };
@@ -205,7 +207,7 @@ export function resolveAppPageHtmlResponsePolicy(
 
   if (options.revalidateSeconds === Infinity) {
     return {
-      cacheControl: STATIC_CACHE_CONTROL,
+      cacheControl: isDeployRuntime() ? DEPLOY_CACHE_CONTROL : STATIC_CACHE_CONTROL,
       cacheState: "STATIC",
       shouldWriteToCache: false,
     };

--- a/packages/vinext/src/server/app-route-handler-response.ts
+++ b/packages/vinext/src/server/app-route-handler-response.ts
@@ -1,9 +1,11 @@
 import type { CachedRouteValue, CacheControlMetadata } from "vinext/shims/cache";
 import {
   buildCachedRevalidateCacheControl,
+  DEPLOY_CACHE_CONTROL,
   NEVER_CACHE_CONTROL,
   STATIC_CACHE_CONTROL,
 } from "./cache-control.js";
+import { isDeployRuntime } from "./deploy-runtime.js";
 import {
   MIDDLEWARE_HEADER_PREFIX,
   MIDDLEWARE_NEXT_HEADER,
@@ -60,7 +62,9 @@ function buildRouteHandlerCacheControl(
   if (revalidateSeconds === Infinity) {
     // revalidate = false / Infinity means "cache indefinitely" — emit the
     // same static Cache-Control used by pages, not a dynamic SWR value.
-    return STATIC_CACHE_CONTROL;
+    // In deploy mode, Next.js collapses static cache headers to the deploy
+    // header too; cache-tag invalidation governs freshness at the edge.
+    return isDeployRuntime() ? DEPLOY_CACHE_CONTROL : STATIC_CACHE_CONTROL;
   }
 
   return buildCachedRevalidateCacheControl(cacheState, revalidateSeconds, expireSeconds);

--- a/packages/vinext/src/server/cache-control.ts
+++ b/packages/vinext/src/server/cache-control.ts
@@ -1,3 +1,5 @@
+import { DEPLOY_CACHE_CONTROL, isDeployRuntime } from "./deploy-runtime.js";
+
 export const NEVER_CACHE_CONTROL = "private, no-cache, no-store, max-age=0, must-revalidate";
 
 export const STATIC_CACHE_CONTROL = "s-maxage=31536000, stale-while-revalidate";
@@ -6,10 +8,18 @@ const STALE_REVALIDATE_CACHE_CONTROL = "s-maxage=0, stale-while-revalidate";
 
 export const NO_STORE_CACHE_CONTROL = "no-store, must-revalidate";
 
+export { DEPLOY_CACHE_CONTROL };
+
 /**
  * Matches Next.js's `getCacheControlHeader` stale window semantics while
  * preserving vinext's legacy unbounded SWR header when no expire ceiling is
  * available yet.
+ *
+ * When running in deploy mode (Cloudflare Workers), the per-revalidate
+ * `s-maxage` output is replaced with `public, max-age=0, must-revalidate` to
+ * match Next.js' deploy adapters. ISR freshness is then governed by cache
+ * tags + the in-Worker cache handler, not by the HTTP cache header. See
+ * `deploy-runtime.ts` for rationale.
  *
  * Next.js source:
  * https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/cache-control.ts
@@ -17,7 +27,18 @@ export const NO_STORE_CACHE_CONTROL = "no-store, must-revalidate";
 export function buildRevalidateCacheControl(
   revalidateSeconds: number,
   expireSeconds?: number,
+  /**
+   * Override the runtime deploy-mode detection. Defaults to
+   * `isDeployRuntime()` so production behavior is automatic; unit tests pass
+   * `true`/`false` explicitly to exercise both modes without manipulating
+   * global state.
+   */
+  isDeploy: boolean = isDeployRuntime(),
 ): string {
+  if (isDeploy) {
+    return DEPLOY_CACHE_CONTROL;
+  }
+
   if (expireSeconds === undefined) {
     return `s-maxage=${revalidateSeconds}, stale-while-revalidate`;
   }
@@ -39,12 +60,24 @@ export function buildRevalidateCacheControl(
  * this header from cache-control metadata, not from the cache hit/stale state.
  * STALE entries without expire metadata keep vinext's legacy `s-maxage=0`
  * fallback so older cache entries are not treated as newly fresh downstream.
+ *
+ * In deploy mode (Cloudflare Workers), every cacheable output (including
+ * `revalidate === Infinity` "static" pages) collapses to
+ * `public, max-age=0, must-revalidate` — see `buildRevalidateCacheControl`.
+ * Cache-tag invalidation and the in-Worker cache handler govern freshness,
+ * not the HTTP cache header. Next.js' `test/e2e/prerender.test.ts` asserts
+ * this for both `revalidate: 2` pages and no-revalidate static pages.
  */
 export function buildCachedRevalidateCacheControl(
   cacheState: "HIT" | "STALE",
   revalidateSeconds: number,
   expireSeconds?: number,
+  isDeploy: boolean = isDeployRuntime(),
 ): string {
+  if (isDeploy) {
+    return DEPLOY_CACHE_CONTROL;
+  }
+
   if (revalidateSeconds === Infinity) {
     return STATIC_CACHE_CONTROL;
   }
@@ -57,5 +90,5 @@ export function buildCachedRevalidateCacheControl(
     return STALE_REVALIDATE_CACHE_CONTROL;
   }
 
-  return buildRevalidateCacheControl(revalidateSeconds, expireSeconds);
+  return buildRevalidateCacheControl(revalidateSeconds, expireSeconds, false);
 }

--- a/packages/vinext/src/server/deploy-runtime.ts
+++ b/packages/vinext/src/server/deploy-runtime.ts
@@ -1,0 +1,47 @@
+/**
+ * Detects whether vinext is running in "deploy" mode — i.e. inside a Cloudflare
+ * Workers runtime served from a deployed Worker. This is distinct from
+ * standalone production mode (`vinext start`, served by `prod-server.ts` on
+ * Node), where vinext is the only cache layer in front of the user.
+ *
+ * Why this matters for `Cache-Control`:
+ *
+ *   - Standalone: vinext itself is the cache. Emitting `s-maxage=<n>,
+ *     stale-while-revalidate=<m>` is the right value to honor because nothing
+ *     else interprets it before reaching the browser.
+ *
+ *   - Deploy (Cloudflare Workers): the deployed Worker sits behind Cloudflare's
+ *     edge network and the user's own Workers Cache API usage. Cache freshness
+ *     is governed by cache tags (`revalidateTag`) and the in-Worker cache
+ *     handler, not by HTTP `s-maxage`. Next.js' deploy adapters (Vercel,
+ *     OpenNext, etc.) collapse all ISR-style cache controls to
+ *     `public, max-age=0, must-revalidate` — the browser revalidates on every
+ *     request and the edge layer serves the cached payload based on tags.
+ *     vinext's Next.js compatibility test suite (`NEXT_TEST_MODE=deploy`)
+ *     asserts this exact header value, so vinext must match.
+ *
+ * Detection uses `navigator.userAgent === "Cloudflare-Workers"`, the standard
+ * way to identify the Workers runtime. `prod-server.ts` (Node) does not
+ * provide a `navigator` object with this value, so it correctly reports
+ * `false` and preserves the standalone cache-control output.
+ */
+
+export const DEPLOY_CACHE_CONTROL = "public, max-age=0, must-revalidate";
+
+/**
+ * Returns `true` when the current process is running inside a Cloudflare
+ * Workers runtime (the deploy target). Returns `false` for the Node-backed
+ * standalone production server, dev server, and unit tests.
+ *
+ * The check is intentionally a simple `globalThis` lookup so it can run from
+ * any module without coupling to a config object. Call sites can pass an
+ * explicit `isDeploy` override (e.g. for tests) to avoid relying on this.
+ */
+export function isDeployRuntime(): boolean {
+  // `navigator` is present in Workers, but `globalThis.navigator?.userAgent`
+  // may also exist in unrelated runtimes (browsers, Deno) with a different
+  // value. The exact string `"Cloudflare-Workers"` is the Workers contract:
+  // https://developers.cloudflare.com/workers/runtime-apis/web-standards/#navigatoruseragent
+  const ua = (globalThis as { navigator?: { userAgent?: string } }).navigator?.userAgent;
+  return ua === "Cloudflare-Workers";
+}

--- a/tests/cache-control.test.ts
+++ b/tests/cache-control.test.ts
@@ -2,46 +2,99 @@ import { describe, expect, it } from "vite-plus/test";
 import {
   buildCachedRevalidateCacheControl,
   buildRevalidateCacheControl,
+  DEPLOY_CACHE_CONTROL,
 } from "../packages/vinext/src/server/cache-control.js";
 
 describe("cache-control helpers", () => {
   it("uses Next.js expire minus revalidate for finite SWR windows", () => {
-    expect(buildRevalidateCacheControl(60, 300)).toBe("s-maxage=60, stale-while-revalidate=240");
+    expect(buildRevalidateCacheControl(60, 300, false)).toBe(
+      "s-maxage=60, stale-while-revalidate=240",
+    );
   });
 
   it("omits stale-while-revalidate when expire does not exceed revalidate", () => {
-    expect(buildRevalidateCacheControl(300, 300)).toBe("s-maxage=300");
+    expect(buildRevalidateCacheControl(300, 300, false)).toBe("s-maxage=300");
   });
 
   it("preserves vinext's legacy unbounded SWR header when expire is unknown", () => {
-    expect(buildRevalidateCacheControl(60)).toBe("s-maxage=60, stale-while-revalidate");
+    expect(buildRevalidateCacheControl(60, undefined, false)).toBe(
+      "s-maxage=60, stale-while-revalidate",
+    );
   });
 
   it("uses route policy for STALE cached responses when expire is known", () => {
-    expect(buildCachedRevalidateCacheControl("STALE", 60, 300)).toBe(
+    expect(buildCachedRevalidateCacheControl("STALE", 60, 300, false)).toBe(
       "s-maxage=60, stale-while-revalidate=240",
     );
   });
 
   it("uses route policy for HIT cached responses when expire is known", () => {
-    expect(buildCachedRevalidateCacheControl("HIT", 60, 300)).toBe(
+    expect(buildCachedRevalidateCacheControl("HIT", 60, 300, false)).toBe(
       "s-maxage=60, stale-while-revalidate=240",
     );
   });
 
   it("uses static cache-control for cached indefinite responses", () => {
-    expect(buildCachedRevalidateCacheControl("HIT", Infinity)).toBe(
+    expect(buildCachedRevalidateCacheControl("HIT", Infinity, undefined, false)).toBe(
       "s-maxage=31536000, stale-while-revalidate",
     );
   });
 
   it("preserves legacy STALE cached response headers when expire is unknown", () => {
-    expect(buildCachedRevalidateCacheControl("STALE", 60)).toBe(
+    expect(buildCachedRevalidateCacheControl("STALE", 60, undefined, false)).toBe(
       "s-maxage=0, stale-while-revalidate",
     );
   });
 
   it("keeps the full expire window when revalidate is zero", () => {
-    expect(buildRevalidateCacheControl(0, 300)).toBe("s-maxage=0, stale-while-revalidate=300");
+    expect(buildRevalidateCacheControl(0, 300, false)).toBe(
+      "s-maxage=0, stale-while-revalidate=300",
+    );
+  });
+
+  // ─── Deploy mode (Cloudflare Workers) ────────────────────────────────────
+  // Next.js' deploy adapters collapse cacheable HTTP cache-control headers
+  // to `public, max-age=0, must-revalidate`. The browser revalidates on
+  // every request and the edge/Worker cache layer governs freshness via
+  // cache tags. vinext's Next.js compat suite (NEXT_TEST_MODE=deploy)
+  // asserts this header for ISR pages, fallback ISR re-renders, and the
+  // "no-revalidate static" branch.
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/prerender.test.ts
+
+  describe("deploy mode", () => {
+    it("emits the deploy header instead of s-maxage/SWR for a fresh ISR render", () => {
+      expect(buildRevalidateCacheControl(2, 31536000, true)).toBe(DEPLOY_CACHE_CONTROL);
+    });
+
+    it("emits the deploy header for ISR pages without an expire ceiling", () => {
+      expect(buildRevalidateCacheControl(60, undefined, true)).toBe(DEPLOY_CACHE_CONTROL);
+    });
+
+    it("emits the deploy header for HIT cached ISR responses", () => {
+      expect(buildCachedRevalidateCacheControl("HIT", 2, 31536000, true)).toBe(
+        DEPLOY_CACHE_CONTROL,
+      );
+    });
+
+    it("emits the deploy header for STALE cached ISR responses", () => {
+      expect(buildCachedRevalidateCacheControl("STALE", 2, 31536000, true)).toBe(
+        DEPLOY_CACHE_CONTROL,
+      );
+    });
+
+    it("emits the deploy header for indefinite (revalidate === Infinity) responses", () => {
+      expect(buildCachedRevalidateCacheControl("HIT", Infinity, undefined, true)).toBe(
+        DEPLOY_CACHE_CONTROL,
+      );
+    });
+
+    it("emits the deploy header for STALE entries with no expire metadata", () => {
+      // Standalone falls back to `s-maxage=0, stale-while-revalidate`. Deploy
+      // mode must not leak that fallback because the edge layer handles
+      // staleness via cache tags.
+      expect(buildCachedRevalidateCacheControl("STALE", 60, undefined, true)).toBe(
+        DEPLOY_CACHE_CONTROL,
+      );
+    });
   });
 });

--- a/tests/deploy-runtime.test.ts
+++ b/tests/deploy-runtime.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import {
+  DEPLOY_CACHE_CONTROL,
+  isDeployRuntime,
+} from "../packages/vinext/src/server/deploy-runtime.js";
+
+// Node 24's `globalThis.navigator` is defined as a getter-only property, so
+// the override has to use Object.defineProperty rather than direct assignment.
+// We always restore the original descriptor after each test to avoid leaking
+// the stub into adjacent suites running in the same worker.
+function setNavigator(value: { userAgent?: string } | undefined): void {
+  if (value === undefined) {
+    Object.defineProperty(globalThis, "navigator", {
+      configurable: true,
+      enumerable: true,
+      writable: true,
+      value: undefined,
+    });
+    delete (globalThis as { navigator?: unknown }).navigator;
+    return;
+  }
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    enumerable: true,
+    writable: true,
+    value,
+  });
+}
+
+describe("deploy-runtime", () => {
+  const originalDescriptor = Object.getOwnPropertyDescriptor(globalThis, "navigator");
+
+  afterEach(() => {
+    if (originalDescriptor) {
+      Object.defineProperty(globalThis, "navigator", originalDescriptor);
+    } else {
+      delete (globalThis as { navigator?: unknown }).navigator;
+    }
+  });
+
+  it("exposes the Next.js deploy Cache-Control header constant", () => {
+    expect(DEPLOY_CACHE_CONTROL).toBe("public, max-age=0, must-revalidate");
+  });
+
+  it("returns false under the Node test runtime (no navigator.userAgent match)", () => {
+    setNavigator(undefined);
+    expect(isDeployRuntime()).toBe(false);
+  });
+
+  it("returns true when navigator.userAgent === 'Cloudflare-Workers'", () => {
+    setNavigator({ userAgent: "Cloudflare-Workers" });
+    expect(isDeployRuntime()).toBe(true);
+  });
+
+  it("returns false when navigator.userAgent does not match", () => {
+    setNavigator({ userAgent: "Mozilla/5.0" });
+    expect(isDeployRuntime()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

When vinext is deployed to Cloudflare Workers, ISR/static pages now emit `public, max-age=0, must-revalidate` instead of the raw `s-maxage=<n>, stale-while-revalidate=<m>` header. Standalone production (`vinext start`) is unchanged. This matches Next.js' own deploy adapters and the assertions in [`test/e2e/prerender.test.ts`](https://github.com/vercel/next.js/blob/canary/test/e2e/prerender.test.ts#L679-L748) which the nightly Next.js Deploy Suite runs against vinext.

**Why this is correct on Workers.** The Worker sits behind Cloudflare's edge and the user's own Workers Cache API usage. Freshness is governed by cache tags (`revalidateTag` / `revalidatePath`) and the in-Worker cache handler, not by HTTP `s-maxage` — which the browser ignores anyway, since it only consumes `max-age`. Collapsing to `public, max-age=0, must-revalidate` tells the browser to always revalidate while keeping the cached payload usable downstream. See [Next.js `getCacheControlHeader`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/cache-control.ts) for the standalone derivation that vinext already mirrored.

**How the runtime is detected.** A new `isDeployRuntime()` helper checks `globalThis.navigator?.userAgent === "Cloudflare-Workers"` ([Workers UA contract](https://developers.cloudflare.com/workers/runtime-apis/web-standards/#navigatoruseragent)). The Node-backed `prod-server.ts` does not set this UA, so standalone deployments keep their existing headers.

**Scope.** This PR addresses the ISR / `revalidate: 2` and static-page (`revalidate: Infinity`) paths called out in #1358. Other deploy-mode header mismatches (e.g. the fallback-true initial render currently emitting `private, no-cache, no-store, max-age=0, must-revalidate` rather than the deploy header) can be addressed in follow-ups — they're orthogonal to the headline failure mode and would broaden the blast radius of this change.

Closes #1358

## Test plan

- [x] `pnpm test tests/cache-control.test.ts tests/deploy-runtime.test.ts` — covers both standalone and deploy branches of `buildRevalidateCacheControl` / `buildCachedRevalidateCacheControl`, plus the `navigator.userAgent` detection.
- [x] `pnpm test tests/app-page-cache.test.ts tests/app-route-handler-cache.test.ts tests/isr-cache.test.ts tests/page-cache-tags.test.ts tests/fetch-cache.test.ts tests/prefetch-cache.test.ts` — adjacent cache code still passes.
- [x] `pnpm test tests/pages-router.test.ts tests/app-router.test.ts` — broader Pages/App Router integration tests still green.
- [x] `pnpm run check` — fmt, lint, types.
- [ ] Nightly Next.js Deploy Suite picks up the prerender.test.ts ISR cache-header assertions.