### PR TITLE
fix(error): match Next.js default error page UI

### DIFF
--- a/packages/vinext/src/server/app-fallback-renderer.ts
+++ b/packages/vinext/src/server/app-fallback-renderer.ts
@@ -5,6 +5,7 @@ import {
   renderAppPageHttpAccessFallback,
   type AppPageBoundaryRoute,
 } from "./app-page-boundary-render.js";
+import { DEFAULT_GLOBAL_ERROR_MODULE } from "./default-global-error-module.js";
 import type { AppPageFontPreload } from "./app-page-execution.js";
 import type { AppPageMiddlewareContext } from "./app-page-response.js";
 import type { AppPageSsrHandler } from "./app-page-stream.js";
@@ -130,6 +131,15 @@ export function createAppFallbackRenderer<TModule extends AppPageModule>(
   const { rootForbiddenModule, rootLayouts, rootNotFoundModule, rootUnauthorizedModule } =
     rootBoundaries;
 
+  // When the app does not define `app/global-error.tsx`, fall back to vinext's
+  // built-in default global error component so that uncaught render errors
+  // produce the same UI Next.js ships out of the box (matching markup, inline
+  // styles, theme CSS, and the "ERROR <digest>" footer for server errors).
+  // See packages/vinext/src/shims/default-global-error.tsx and
+  // packages/vinext/src/server/default-global-error-module.ts.
+  const effectiveGlobalErrorModule: TModule | null =
+    globalErrorModule ?? (DEFAULT_GLOBAL_ERROR_MODULE as unknown as TModule);
+
   return {
     renderHttpAccessFallback(
       route,
@@ -165,7 +175,7 @@ export function createAppFallbackRenderer<TModule extends AppPageModule>(
             getFontPreloads: fontProviders.getFontPreloads,
             getFontStyles: fontProviders.getFontStyles,
             getNavigationContext,
-            globalErrorModule,
+            globalErrorModule: effectiveGlobalErrorModule,
             isRscRequest,
             layoutModules: [],
             loadSsrHandler: ssrLoader,
@@ -200,7 +210,7 @@ export function createAppFallbackRenderer<TModule extends AppPageModule>(
         getFontPreloads: fontProviders.getFontPreloads,
         getFontStyles: fontProviders.getFontStyles,
         getNavigationContext,
-        globalErrorModule,
+        globalErrorModule: effectiveGlobalErrorModule,
         isRscRequest,
         layoutModules: opts?.layouts ?? null,
         loadSsrHandler: ssrLoader,
@@ -254,7 +264,7 @@ export function createAppFallbackRenderer<TModule extends AppPageModule>(
         getFontPreloads: fontProviders.getFontPreloads,
         getFontStyles: fontProviders.getFontStyles,
         getNavigationContext,
-        globalErrorModule,
+        globalErrorModule: effectiveGlobalErrorModule,
         isRscRequest,
         loadSsrHandler: ssrLoader,
         makeThenableParams,

--- a/packages/vinext/src/server/app-page-element-builder.ts
+++ b/packages/vinext/src/server/app-page-element-builder.ts
@@ -12,6 +12,7 @@ import {
 } from "./app-page-route-wiring.js";
 import { AppElementsWire, type AppElements, type AppElementsInterception } from "./app-elements.js";
 import type { AppPageParams } from "./app-page-boundary.js";
+import { DEFAULT_GLOBAL_ERROR_MODULE } from "./default-global-error-module.js";
 import { matchRoutePattern } from "../routing/route-pattern.js";
 import { normalizePathnameForRouteMatch } from "../routing/utils.js";
 import type { MetadataFileRoute } from "./metadata-routes.js";
@@ -197,7 +198,12 @@ export async function buildPageElements<
 
   return buildAppPageElements({
     element: PageComponent ? createElement(PageComponent, pageProps) : null,
-    globalErrorModule: globalErrorModule ?? null,
+    // Fall back to vinext's built-in default global error module so that
+    // uncaught client render errors are caught by the route-level
+    // <ErrorBoundary> wrapper in app-page-route-wiring.tsx, mirroring
+    // Next.js's behavior when the user has not defined app/global-error.tsx.
+    globalErrorModule:
+      globalErrorModule ?? (DEFAULT_GLOBAL_ERROR_MODULE as unknown as TErrorModule),
     isRscRequest,
     mountedSlotIds,
     makeThenableParams,

--- a/packages/vinext/src/server/default-global-error-module.ts
+++ b/packages/vinext/src/server/default-global-error-module.ts
@@ -1,0 +1,18 @@
+import DefaultGlobalError from "vinext/shims/default-global-error";
+
+/**
+ * Module-shaped wrapper around vinext's built-in default global error
+ * component. Used as the fallback when an app does not define its own
+ * `app/global-error.tsx`. The runtime treats any `{ default: Component }`
+ * record as a "global error module", so wrapping the component this way lets
+ * us thread the default through the existing `globalErrorModule` plumbing
+ * without introducing a parallel code path.
+ *
+ * Mirrors Next.js's `defaultGlobalErrorPath`
+ * (`next/dist/client/components/builtin/global-error.js`), which is selected
+ * automatically when the user has not supplied a custom global error file:
+ * https://github.com/vercel/next.js/blob/canary/packages/next/src/build/webpack/loaders/next-app-loader/index.ts
+ */
+export const DEFAULT_GLOBAL_ERROR_MODULE = {
+  default: DefaultGlobalError,
+} as const;

--- a/packages/vinext/src/shims/default-global-error.tsx
+++ b/packages/vinext/src/shims/default-global-error.tsx
@@ -1,0 +1,205 @@
+"use client";
+
+import React from "react";
+
+/**
+ * Ported from Next.js's built-in default global error component:
+ * https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/builtin/global-error.tsx
+ *
+ * Rendered when an unhandled error reaches the root error boundary and the
+ * user has not supplied their own `app/global-error.tsx`. Matches the
+ * markup, inline styles, and theme CSS that Next.js's
+ * `test/e2e/app-dir/default-error-page-ui/default-error-page-ui.test.ts`
+ * exercises:
+ *   - `<h1>` reads "This page couldn't load"
+ *   - `<p>` contains "Reload to try again, or go back" (client error) or
+ *     "A server error occurred. Reload to try again." (server error)
+ *   - First `<button>` is "Reload" (form submit triggers a page reload)
+ *   - Second `<button>` is "Back" (only for client errors)
+ *   - Server errors render an "ERROR <digest>" footer
+ *   - SVG warning icon is 32x32
+ */
+
+type DefaultGlobalErrorProps = {
+  error: { digest?: string } | null | undefined;
+  reset?: () => void;
+};
+
+const errorStyles = {
+  container: {
+    fontFamily:
+      'system-ui,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji"',
+    height: "100vh",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  card: {
+    marginTop: "-32px",
+    maxWidth: "325px",
+    padding: "32px 28px",
+    textAlign: "left" as const,
+  },
+  icon: {
+    marginBottom: "24px",
+  },
+  title: {
+    fontSize: "24px",
+    fontWeight: 500,
+    letterSpacing: "-0.02em",
+    lineHeight: "32px",
+    margin: "0 0 12px 0",
+    color: "var(--next-error-title)",
+  },
+  message: {
+    fontSize: "14px",
+    fontWeight: 400,
+    lineHeight: "21px",
+    margin: "0 0 20px 0",
+    color: "var(--next-error-message)",
+  },
+  form: {
+    margin: 0,
+  },
+  buttonGroup: {
+    display: "flex",
+    gap: "8px",
+    alignItems: "center",
+  },
+  button: {
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    height: "32px",
+    padding: "0 12px",
+    fontSize: "14px",
+    fontWeight: 500,
+    lineHeight: "20px",
+    borderRadius: "6px",
+    cursor: "pointer",
+    color: "var(--next-error-btn-text)",
+    background: "var(--next-error-btn-bg)",
+    border: "var(--next-error-btn-border)",
+  },
+  buttonSecondary: {
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    height: "32px",
+    padding: "0 12px",
+    fontSize: "14px",
+    fontWeight: 500,
+    lineHeight: "20px",
+    borderRadius: "6px",
+    cursor: "pointer",
+    color: "var(--next-error-btn-secondary-text)",
+    background: "var(--next-error-btn-secondary-bg)",
+    border: "var(--next-error-btn-secondary-border)",
+  },
+  digestFooter: {
+    position: "fixed" as const,
+    bottom: "32px",
+    left: "0",
+    right: "0",
+    textAlign: "center" as const,
+    fontFamily: 'ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,monospace',
+    fontSize: "12px",
+    lineHeight: "18px",
+    fontWeight: 400,
+    margin: "0",
+    color: "var(--next-error-digest)",
+  },
+} as const;
+
+const errorThemeCss = `
+:root {
+  --next-error-bg: #fff;
+  --next-error-text: #171717;
+  --next-error-title: #171717;
+  --next-error-message: #171717;
+  --next-error-digest: #666666;
+  --next-error-btn-text: #fff;
+  --next-error-btn-bg: #171717;
+  --next-error-btn-border: none;
+  --next-error-btn-secondary-text: #171717;
+  --next-error-btn-secondary-bg: transparent;
+  --next-error-btn-secondary-border: 1px solid rgba(0,0,0,0.08);
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --next-error-bg: #0a0a0a;
+    --next-error-text: #ededed;
+    --next-error-title: #ededed;
+    --next-error-message: #ededed;
+    --next-error-digest: #a0a0a0;
+    --next-error-btn-text: #0a0a0a;
+    --next-error-btn-bg: #ededed;
+    --next-error-btn-border: none;
+    --next-error-btn-secondary-text: #ededed;
+    --next-error-btn-secondary-bg: transparent;
+    --next-error-btn-secondary-border: 1px solid rgba(255,255,255,0.14);
+  }
+}
+body { margin: 0; color: var(--next-error-text); background: var(--next-error-bg); }
+`.replace(/\n\s*/g, "");
+
+function WarningIcon() {
+  return (
+    <svg width="32" height="32" viewBox="-0.2 -1.5 32 32" fill="none" style={errorStyles.icon}>
+      <path
+        d="M16.9328 0C18.0839 0.000116771 19.1334 0.658832 19.634 1.69531L31.4299 26.1309C32.0708 27.4588 31.1036 28.9999 29.6291 29H2.00215C0.527541 29 -0.439628 27.4588 0.201371 26.1309L11.9973 1.69531C12.4979 0.658823 13.5474 7.75066e-05 14.6984 0H16.9328ZM3.59493 26H28.0363L16.9328 3H14.6984L3.59493 26ZM15.8156 19C16.9202 19.0001 17.8156 19.8955 17.8156 21C17.8156 22.1045 16.9202 22.9999 15.8156 23C14.7111 23 13.8156 22.1046 13.8156 21C13.8156 19.8954 14.7111 19 15.8156 19ZM17.3156 16.5H14.3156V8.5H17.3156V16.5Z"
+        fill="var(--next-error-title)"
+      />
+    </svg>
+  );
+}
+
+function handleBackClick() {
+  if (typeof window === "undefined") return;
+  if (window.history.length > 1) {
+    window.history.back();
+  } else {
+    window.location.href = "/";
+  }
+}
+
+function DefaultGlobalError({ error }: DefaultGlobalErrorProps) {
+  const digest: string | undefined = error?.digest;
+  const isServerError = !!digest;
+
+  const message = isServerError
+    ? "A server error occurred. Reload to try again."
+    : "Reload to try again, or go back.";
+
+  return (
+    <html id="__next_error__">
+      <head>
+        <style dangerouslySetInnerHTML={{ __html: errorThemeCss }} />
+      </head>
+      <body>
+        <div style={errorStyles.container}>
+          <div style={errorStyles.card}>
+            <WarningIcon />
+            <h1 style={errorStyles.title}>This page couldn&#x2019;t load</h1>
+            <p style={errorStyles.message}>{message}</p>
+            <div style={errorStyles.buttonGroup}>
+              <form style={errorStyles.form}>
+                <button type="submit" style={errorStyles.button}>
+                  Reload
+                </button>
+              </form>
+              {!isServerError && (
+                <button type="button" style={errorStyles.buttonSecondary} onClick={handleBackClick}>
+                  Back
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
+        {digest && <p style={errorStyles.digestFooter}>ERROR {digest}</p>}
+      </body>
+    </html>
+  );
+}
+
+export default DefaultGlobalError;

--- a/tests/app-fallback-renderer.test.ts
+++ b/tests/app-fallback-renderer.test.ts
@@ -324,6 +324,173 @@ describe("app fallback renderer factory", () => {
   });
 });
 
+// Ported from Next.js: test/e2e/app-dir/default-error-page-ui/default-error-page-ui.test.ts
+// https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/default-error-page-ui/default-error-page-ui.test.ts
+//
+// When the app does not define `error.tsx`, `global-error.tsx`, etc., vinext
+// must still render the same default error UI Next.js ships, including the
+// 32x32 warning icon, the "This page couldn't load" heading, a "Reload"
+// button, a "Back" button (client errors only), and an "ERROR <digest>"
+// footer (server errors only). Without this, the renderer used to return
+// null and the request bubbled up as a generic 500.
+describe("app fallback renderer default global error UI", () => {
+  it("renders the built-in default global error UI for client errors", async () => {
+    const { renderer } = createRenderer();
+    const request = new Request("https://example.com/trigger-error");
+
+    const response = await renderer.renderErrorBoundary(
+      {
+        // No `error` module on the route — falls back to the default global error.
+        layouts: [],
+        params: {},
+        pattern: "/trigger-error",
+      },
+      new Error("Test client error"),
+      false,
+      request,
+      {},
+      undefined,
+      { headers: null, status: null },
+    );
+
+    expect(response?.status).toBe(200);
+    const html = await response?.text();
+
+    // 32x32 SVG warning icon (matches the test's `expect width/height === 32`).
+    expect(html).toContain('width="32"');
+    expect(html).toContain('height="32"');
+    // Heading + curly apostrophe ("couldn’t").
+    expect(html).toContain("<h1");
+    expect(html).toContain("This page couldn’t load");
+    // Client error message + "Reload" + "Back" buttons.
+    expect(html).toContain("Reload to try again, or go back");
+    expect(html).toContain(">Reload<");
+    expect(html).toContain(">Back<");
+    // Theme CSS is inlined so the test's color assertions still resolve.
+    expect(html).toContain("--next-error-title");
+    // No digest -> no "ERROR <digest>" footer.
+    expect(html).not.toMatch(/ERROR\s+\w+/);
+  });
+
+  it("renders the server error variant with an ERROR <digest> footer", async () => {
+    const { renderer } = createRenderer();
+    const request = new Request("https://example.com/server-error");
+
+    // Use a sanitizer that preserves the digest so the footer is emitted.
+    const serverError = Object.assign(new Error("Test server error"), {
+      digest: "1234567890",
+    });
+
+    const response = await renderer.renderErrorBoundary(
+      {
+        layouts: [],
+        params: {},
+        pattern: "/server-error",
+      },
+      serverError,
+      false,
+      request,
+      {},
+      undefined,
+      { headers: null, status: null },
+    );
+
+    expect(response?.status).toBe(200);
+    const html = await response?.text();
+    // Server errors still render the same heading.
+    expect(html).toContain("This page couldn’t load");
+    // Server error variant of the message.
+    expect(html).toContain("A server error occurred");
+    // Server errors do not render the "Back" button.
+    expect(html).not.toContain(">Back<");
+    // Digest footer "ERROR <digest>" — the test uses /ERROR \w+/.
+    expect(html).toMatch(/ERROR\s+1234567890/);
+  });
+
+  it("prefers a user-defined global error module over the default", async () => {
+    function UserGlobalError({ error }: { error: { message?: string } }) {
+      return React.createElement(
+        "html",
+        null,
+        React.createElement(
+          "body",
+          null,
+          React.createElement(
+            "h1",
+            { "data-user-global-error": "true" },
+            `user-global-error:${error.message ?? ""}`,
+          ),
+        ),
+      );
+    }
+    const userGlobalErrorModule = { default: UserGlobalError } satisfies TestModule;
+
+    const { renderer } = createRenderer();
+    // Re-create the renderer with a user-supplied global error module. The
+    // createRenderer helper does not expose globalErrorModule directly, so
+    // call createAppFallbackRenderer here instead via the same overrides path.
+    // We instead test by inspecting that the default UI is replaced when a
+    // user module is configured. Since the helper does not currently allow
+    // overriding globalErrorModule, this assertion is encoded by re-creating
+    // the renderer locally.
+    const { createAppFallbackRenderer } =
+      await import("../packages/vinext/src/server/app-fallback-renderer.js");
+    const localRenderer = createAppFallbackRenderer({
+      basePath: "",
+      clearRequestContext() {},
+      createRscOnErrorHandler: () => () => null,
+      fontProviders: {
+        buildFontLinkHeader: () => "",
+        getFontLinks: () => [],
+        getFontPreloads: () => [],
+        getFontStyles: () => [],
+      },
+      getNavigationContext: () => ({ pathname: "/server-error" }),
+      globalErrorModule: userGlobalErrorModule,
+      globalNotFoundModule: null,
+      makeThenableParams: (p) => p,
+      metadataRoutes: [],
+      resolveChildSegments: () => [],
+      rootBoundaries: {
+        rootForbiddenModule: null,
+        rootLayouts: [],
+        rootNotFoundModule: null,
+        rootUnauthorizedModule: null,
+      },
+      rscRenderer: renderElementToStream,
+      sanitizer: (error) => error,
+      ssrLoader: async () => ({
+        async handleSsr(rscStream: ReadableStream<Uint8Array>) {
+          return rscStream;
+        },
+      }),
+    });
+
+    void renderer;
+
+    const request = new Request("https://example.com/server-error");
+    const response = await localRenderer.renderErrorBoundary(
+      {
+        layouts: [],
+        params: {},
+        pattern: "/server-error",
+      },
+      new Error("from-user"),
+      false,
+      request,
+      {},
+      undefined,
+      { headers: null, status: null },
+    );
+
+    const html = await response?.text();
+    expect(html).toContain('data-user-global-error="true"');
+    expect(html).toContain("user-global-error:from-user");
+    // The default UI must NOT leak through.
+    expect(html).not.toContain("This page couldn’t load");
+  });
+});
+
 // Mirrors Next.js 16 experimental.globalNotFound behavior.
 // Ported from Next.js: test/e2e/app-dir/global-not-found/{basic,both-present,not-present}.
 // Source: https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/global-not-found


### PR DESCRIPTION
## Summary

- Port Next.js's built-in default global error component to `vinext/shims/default-global-error.tsx`, including the 32x32 warning icon, the "This page couldn't load" heading, theme CSS, the Reload form button, the Back button (client errors only), and the `ERROR <digest>` footer (server errors only).
- Wire it in through a small `server/default-global-error-module.ts` wrapper so both the runtime error boundary fallback (`app-fallback-renderer.ts`) and the route-level client `<ErrorBoundary>` wrapper (via `app-page-element-builder.ts`) fall back to it whenever no `app/global-error.tsx` is defined. User-defined global error modules continue to take precedence.
- Before this fix, vinext's runtime returned `null` from the error boundary fallback when no `global-error.tsx` existed, causing the request to bubble up as a generic 500 instead of the styled default error page Next.js ships.

Mirrors the behavior of Next.js's `defaultGlobalErrorPath` in [`next/dist/client/components/builtin/global-error.js`](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/builtin/global-error.tsx).

## Test plan

- [x] `pnpm test tests/app-fallback-renderer.test.ts` (14 tests, including 3 new tests covering the default UI, the digest footer for server errors, and user-module precedence).
- [x] `pnpm test tests/app-page-boundary.test.ts tests/app-page-boundary-render.test.ts tests/app-page-element-builder.test.ts tests/app-page-route-wiring.test.ts` (61 tests).
- [x] `pnpm test tests/error-boundary.test.ts tests/app-rsc-errors.test.ts tests/app-rsc-error-handler.test.ts` (51 tests).
- [x] `pnpm run check` (formatting + lint + type checks pass).
- [ ] CI: full Vitest + Playwright E2E green.

Closes #1362