### PR TITLE
fix(after): wire next/after to Workers ctx.waitUntil in deploy mode

### DIFF
--- a/packages/vinext/src/deploy.ts
+++ b/packages/vinext/src/deploy.ts
@@ -790,9 +790,12 @@ export default {
       }
 
       // ── 7. API routes ─────────────────────────────────────────────
+      // Forward ctx so handlePagesApiRoute can wrap the user handler in
+      // runWithExecutionContext, making ctx.waitUntil() reachable from
+      // after() and other shims that schedule deferred work.
       if (resolvedPathname.startsWith("/api/") || resolvedPathname === "/api") {
         const response = typeof handleApiRoute === "function"
-          ? await handleApiRoute(request, resolvedUrl)
+          ? await handleApiRoute(request, resolvedUrl, ctx)
           : new Response("404 - API route not found", { status: 404 });
         return mergeHeaders(response, middlewareHeaders, middlewareRewriteStatus);
       }

--- a/packages/vinext/src/entries/pages-server-entry.ts
+++ b/packages/vinext/src/entries/pages-server-entry.ts
@@ -685,9 +685,10 @@ async function _renderPage(request, url, manifest, middlewareHeaders) {
   });
 }
 
-export async function handleApiRoute(request, url) {
+export async function handleApiRoute(request, url, ctx) {
   const match = matchRoute(url, apiRoutes);
   return __handlePagesApiRoute({
+    ctx,
     match,
     request,
     url,

--- a/packages/vinext/src/server/pages-api-route.ts
+++ b/packages/vinext/src/server/pages-api-route.ts
@@ -11,6 +11,7 @@ import {
 } from "./pages-node-compat.js";
 import { internalServerErrorResponse } from "./http-error-responses.js";
 import { isEdgeApiRuntime } from "./edge-api-runtime.js";
+import { runWithExecutionContext, type ExecutionContextLike } from "vinext/shims/request-context";
 
 type PagesApiRouteConfig = {
   runtime?: string;
@@ -36,6 +37,14 @@ export type PagesApiRouteMatch = {
 };
 
 type HandlePagesApiRouteOptions = {
+  /**
+   * Per-request Cloudflare Workers `ExecutionContext`. When provided, the
+   * API route runs inside `runWithExecutionContext(ctx, ...)` so any
+   * `after()` (or other shim) call inside the handler can reach
+   * `ctx.waitUntil()` via the ALS and keep the isolate alive past the
+   * response. Omit on Node.js dev where no Workers lifecycle exists.
+   */
+  ctx?: ExecutionContextLike;
   match: PagesApiRouteMatch | null;
   reportRequestError?: (error: Error, routePattern: string) => void | Promise<void>;
   request: Request;
@@ -59,6 +68,13 @@ function isNodeApiRouteModule(
 }
 
 export async function handlePagesApiRoute(options: HandlePagesApiRouteOptions): Promise<Response> {
+  if (options.ctx) {
+    return runWithExecutionContext(options.ctx, () => _handlePagesApiRoute(options));
+  }
+  return _handlePagesApiRoute(options);
+}
+
+async function _handlePagesApiRoute(options: HandlePagesApiRouteOptions): Promise<Response> {
   if (!options.match) {
     return new Response("404 - API route not found", { status: 404 });
   }

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -1306,7 +1306,7 @@ function readPagesServerEntryPageRoutes(value: unknown): PagesServerEntryPageRou
  *
  * Uses the server entry (dist/server/entry.js) which exports:
  * - renderPage(request, url, manifest, ctx?, middlewareHeaders?) — SSR rendering (Web Request → Response)
- * - handleApiRoute(request, url) — API route handling (Web Request → Response)
+ * - handleApiRoute(request, url, ctx?) — API route handling (ctx optional; pass for ctx.waitUntil() on Workers)
  * - runMiddleware(request, ctx?) — middleware execution (ctx optional; pass for ctx.waitUntil() on Workers)
  * - vinextConfig — embedded next.config.js settings
  */
@@ -1765,7 +1765,10 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
       if (resolvedPathname.startsWith("/api/") || resolvedPathname === "/api") {
         let response: Response;
         if (typeof handleApi === "function") {
-          response = await handleApi(webRequest, resolvedUrl);
+          // Pass a Node-shaped ExecutionContext so any after() calls in the
+          // API handler still get a working waitUntil (which fires
+          // background work without blocking the response).
+          response = await handleApi(webRequest, resolvedUrl, createNodeExecutionContext());
         } else {
           response = new Response("404 - API route not found", { status: 404 });
         }

--- a/tests/after-deploy.test.ts
+++ b/tests/after-deploy.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Deploy-mode tests for `next/after` (`unstable_after`).
+ *
+ * Verify that the per-request Cloudflare Workers `ExecutionContext` is wired
+ * through to the `after()` shim so callbacks are kept alive past the response
+ * via `ctx.waitUntil()`.
+ *
+ * Ported behavior tests from:
+ * https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/next-after-app-deploy/index.test.ts
+ *
+ * Issue: https://github.com/cloudflare/vinext/issues/1365
+ */
+import { describe, expect, it } from "vite-plus/test";
+import {
+  generateAppRouterWorkerEntry,
+  generatePagesRouterWorkerEntry,
+} from "../packages/vinext/src/deploy.js";
+
+type ExecutionContextLike = {
+  waitUntil(promise: Promise<unknown>): void;
+};
+
+function createMockCtx(): ExecutionContextLike & { promises: Promise<unknown>[] } {
+  const promises: Promise<unknown>[] = [];
+  return {
+    promises,
+    waitUntil(promise: Promise<unknown>) {
+      promises.push(promise);
+    },
+  };
+}
+
+describe("after() in deploy mode — ctx.waitUntil wiring", () => {
+  it("after() forwards its task to ctx.waitUntil when an ExecutionContext is in scope", async () => {
+    const { after } = await import("../packages/vinext/src/shims/server.js");
+    const { runWithExecutionContext } =
+      await import("../packages/vinext/src/shims/request-context.js");
+
+    const ctx = createMockCtx();
+    let observedSideEffect = false;
+
+    await runWithExecutionContext(ctx, () => {
+      after(async () => {
+        // Simulate a real after() workload (e.g. revalidate, analytics) that
+        // resolves after the response would have been sent.
+        await Promise.resolve();
+        observedSideEffect = true;
+      });
+    });
+
+    // ctx.waitUntil must be called synchronously inside after() so the
+    // Workers runtime knows to keep the isolate alive.
+    expect(ctx.promises).toHaveLength(1);
+
+    // Awaiting the queued promise mirrors what the Workers runtime does
+    // after the response is sent. The callback must complete.
+    await ctx.promises[0];
+    expect(observedSideEffect).toBe(true);
+  });
+
+  it("after() preserves ctx across async hops simulating the App Router request lifecycle", async () => {
+    const { after } = await import("../packages/vinext/src/shims/server.js");
+    const { runWithExecutionContext, getRequestExecutionContext } =
+      await import("../packages/vinext/src/shims/request-context.js");
+
+    const ctx = createMockCtx();
+    let observedCtxInsideCallback: unknown = "not-run";
+
+    await runWithExecutionContext(ctx, async () => {
+      // Simulate the chain of async work that happens between worker entry
+      // and a user component / route handler calling after().
+      await Promise.resolve();
+      await new Promise<void>((resolve) => setTimeout(resolve, 1));
+      // The ALS must still surface ctx here — this is what after() relies on.
+      expect(getRequestExecutionContext()).toBe(ctx);
+      after(() => {
+        observedCtxInsideCallback = "ran";
+      });
+    });
+
+    expect(ctx.promises).toHaveLength(1);
+    await ctx.promises[0];
+    expect(observedCtxInsideCallback).toBe("ran");
+  });
+
+  it("after() inside a unified request scope still calls ctx.waitUntil", async () => {
+    // The unified request context replaces the standalone executionContext ALS
+    // for the duration of an App Router request. Verify after() still reads
+    // the ctx via the unified scope so server components / route handlers
+    // can schedule deferred work.
+    const { after } = await import("../packages/vinext/src/shims/server.js");
+    const { createRequestContext, runWithRequestContext } =
+      await import("../packages/vinext/src/shims/unified-request-context.js");
+
+    const ctx = createMockCtx();
+    let ran = false;
+
+    await runWithRequestContext(createRequestContext({ executionContext: ctx }), async () => {
+      after(async () => {
+        await Promise.resolve();
+        ran = true;
+      });
+    });
+
+    expect(ctx.promises).toHaveLength(1);
+    await ctx.promises[0];
+    expect(ran).toBe(true);
+  });
+
+  it("App Router worker entry wraps the RSC handler with runWithExecutionContext when ctx is provided", async () => {
+    // Verify the default vinext/server/app-router-entry hooks ctx.waitUntil
+    // before calling the RSC handler so after() callbacks survive the response.
+    // We can't import the module directly (it pulls in a virtual RSC entry
+    // that's resolved at build time), so we assert its source structure
+    // alongside the runtime behavior of runWithExecutionContext.
+    const { readFile } = await import("node:fs/promises");
+    const { resolve } = await import("node:path");
+    const src = await readFile(
+      resolve(import.meta.dirname, "../packages/vinext/src/server/app-router-entry.ts"),
+      "utf8",
+    );
+
+    expect(src).toContain("runWithExecutionContext(ctx, handleFn) : handleFn()");
+
+    // Sanity-check the underlying primitive: with a ctx in scope,
+    // getRequestExecutionContext() must surface it for after().
+    const { runWithExecutionContext, getRequestExecutionContext } =
+      await import("../packages/vinext/src/shims/request-context.js");
+    const ctx = createMockCtx();
+    let observedCtx: unknown = "missing";
+    void runWithExecutionContext(ctx, () => {
+      observedCtx = getRequestExecutionContext();
+    });
+    expect(observedCtx).toBe(ctx);
+  });
+});
+
+describe("after() in deploy mode — Pages Router worker entry", () => {
+  it("forwards ctx to handleApiRoute so api routes can call after()", () => {
+    // Regression for #1365: handleApiRoute previously ignored ctx, leaving
+    // after() inside Pages Router api routes without a way to call
+    // ctx.waitUntil(). The generated worker entry must thread ctx through.
+    const content = generatePagesRouterWorkerEntry();
+    expect(content).toContain("handleApiRoute(request, resolvedUrl, ctx)");
+  });
+
+  it("forwards ctx to renderPage so page renders can call after()", () => {
+    const content = generatePagesRouterWorkerEntry();
+    expect(content).toContain("renderPage(request, resolvedUrl, null, ctx)");
+  });
+});
+
+describe("after() in deploy mode — App Router worker entry", () => {
+  it("delegates to handler.fetch with ctx so vinext/server/app-router-entry can wrap with runWithExecutionContext", () => {
+    const content = generateAppRouterWorkerEntry();
+    expect(content).toContain("handler.fetch(request, env, ctx)");
+  });
+});
+
+describe("after() in deploy mode — Pages Router API handler", () => {
+  it("handlePagesApiRoute wraps the user handler in runWithExecutionContext when ctx is provided", async () => {
+    const { handlePagesApiRoute } =
+      await import("../packages/vinext/src/server/pages-api-route.js");
+    const { getRequestExecutionContext } =
+      await import("../packages/vinext/src/shims/request-context.js");
+
+    const ctx = createMockCtx();
+    let observedCtx: unknown = "missing";
+
+    const route = {
+      pattern: "/api/test",
+      module: {
+        async default(_req: unknown, res: { end: (body?: string) => void; statusCode: number }) {
+          observedCtx = getRequestExecutionContext();
+          res.statusCode = 200;
+          res.end("ok");
+        },
+      },
+    };
+
+    await handlePagesApiRoute({
+      match: { params: {}, route },
+      request: new Request("https://example.test/api/test"),
+      url: "/api/test",
+      ctx,
+    });
+
+    expect(observedCtx).toBe(ctx);
+  });
+
+  it("handlePagesApiRoute works without ctx (Node dev parity)", async () => {
+    const { handlePagesApiRoute } =
+      await import("../packages/vinext/src/server/pages-api-route.js");
+
+    let ran = false;
+    const route = {
+      pattern: "/api/test",
+      module: {
+        default(_req: unknown, res: { end: (body?: string) => void; statusCode: number }) {
+          ran = true;
+          res.statusCode = 200;
+          res.end("ok");
+        },
+      },
+    };
+
+    const response = await handlePagesApiRoute({
+      match: { params: {}, route },
+      request: new Request("https://example.test/api/test"),
+      url: "/api/test",
+    });
+
+    expect(ran).toBe(true);
+    expect(response.status).toBe(200);
+  });
+});

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -624,10 +624,13 @@ describe("generatePagesRouterWorkerEntry", () => {
     expect(content).toContain('from "vinext/server/request-pipeline"');
   });
 
-  it("routes /api/ to handleApiRoute using resolved URL", () => {
+  it("routes /api/ to handleApiRoute using resolved URL and forwards ctx", () => {
     const content = generatePagesRouterWorkerEntry();
     expect(content).toContain('resolvedPathname.startsWith("/api/")');
-    expect(content).toContain("handleApiRoute(request, resolvedUrl)");
+    // Forwarding ctx lets handlePagesApiRoute wrap the handler in
+    // runWithExecutionContext so after() and other shims can reach
+    // ctx.waitUntil(). See #1365.
+    expect(content).toContain("handleApiRoute(request, resolvedUrl, ctx)");
   });
 
   it("includes error handling", () => {


### PR DESCRIPTION
## Summary

- Threads the Cloudflare Workers `ExecutionContext` through Pages Router API
  routes so `after()` (and any other shim relying on `ctx.waitUntil`) can keep
  the isolate alive past the response in deploy mode.
- `handlePagesApiRoute` now wraps the user handler in
  `runWithExecutionContext(ctx, ...)` when ctx is provided, mirroring the
  existing App Router and Pages Router page-render wiring.
- The generated Pages Router worker entry and `vinext start` both forward ctx
  (or a Node-shaped equivalent) to `handleApiRoute` for dev/start/deploy
  parity.

Previously, calls like:

```ts
// pages/api/foo.ts
import { after } from "next/server";
export default function handler(_req, res) {
  after(async () => { /* never ran on Workers */ });
  res.json({ ok: true });
}
```

silently dropped their deferred work because `getRequestExecutionContext()`
returned `null` inside the API route handler.

Closes #1365

## Test plan

- [x] `pnpm test tests/after-deploy.test.ts` (new file — 9 tests, all pass)
- [x] `pnpm test tests/shims.test.ts tests/deploy.test.ts tests/pages-api-route.test.ts tests/pages-router.test.ts`
- [x] `pnpm run check` (format + lint + types clean)
- [ ] CI green

The new test file (`tests/after-deploy.test.ts`) ports the behavioral
guarantees of Next.js's [`test/e2e/app-dir/next-after-app-deploy/index.test.ts`](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/next-after-app-deploy/index.test.ts)
as targeted unit tests over the vinext wiring — verifying that ctx flows from
the worker entry, through the ALS, through the unified request context, and
into `after()` callbacks.