### PR TITLE
Guard Pages Router navigation during SSR

### DIFF
--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -840,6 +840,8 @@ async function performNavigation(
   mode: "push" | "replace",
   onStateUpdate?: () => void,
 ): Promise<boolean> {
+  if (typeof window === "undefined") return false;
+
   const navigationLocale = resolveTransitionLocale(options?.locale);
   let resolved = resolveNavigationTarget(url, as, navigationLocale);
 

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -1731,6 +1731,28 @@ describe("next/router withRouter HOC", () => {
     expect(receivedRouter.events).toBeDefined();
   });
 
+  it("withRouter router.push is safe during server rendering", async () => {
+    delete (globalThis as any).window;
+    vi.resetModules();
+
+    const { withRouter, wrapWithRouterContext } =
+      await import("../packages/vinext/src/shims/router.js");
+    const React = await import("react");
+    const { renderToStaticMarkup } = await import("react-dom/server");
+
+    let navigation: Promise<boolean> | null = null;
+    const Inner: React.ComponentType<{ router: NextRouter }> = ({ router }) => {
+      navigation = router.push("/ssr-target");
+      return React.createElement("span", null, "ok");
+    };
+
+    const Wrapped = withRouter(Inner);
+    expect(() => {
+      renderToStaticMarkup(wrapWithRouterContext(React.createElement(Wrapped)));
+    }).not.toThrow();
+    await expect(navigation).resolves.toBe(false);
+  });
+
   // Regression guard for Next.js spread order:
   // packages/next/src/client/with-router.tsx renders
   //   `<ComposedComponent router={useRouter()} {...props} />`


### PR DESCRIPTION
﻿Fixes #1353.

`performNavigation()` now returns early on the server before touching `window`, so Pages Router `router.push()` / `router.replace()` calls during SSR or prerender do not crash with `window is not defined`.

I added a regression test that renders a `withRouter` component on the server and calls `router.push()` during render. It should not throw, and the no-op navigation resolves to `false`.

Tested:
- pnpm exec vp test run tests/shims.test.ts -t "withRouter router.push is safe during server rendering"
- pnpm exec vp fmt --check packages/vinext/src/shims/router.ts tests/shims.test.ts
- pnpm run build

Note: `pnpm run check` reports formatting issues across many untouched files on my Windows checkout, so I verified formatting on the changed files directly.
