### PR TITLE
Return null params for non-dynamic routes

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -645,6 +645,7 @@ export default __createAppRscHandler({
       params,
       request,
       route: {
+        isDynamic: route.isDynamic,
         pattern: route.pattern,
         routeHandler: route.routeHandler,
         routeSegments: route.routeSegments,

--- a/packages/vinext/src/server/app-route-handler-cache.ts
+++ b/packages/vinext/src/server/app-route-handler-cache.ts
@@ -46,6 +46,7 @@ type ReadAppRouteHandlerCacheOptions = {
   revalidateSearchParams: URLSearchParams;
   expireSeconds?: number;
   revalidateSeconds: number;
+  routeIsDynamic?: boolean;
   routePattern: string;
   runInRevalidationContext: RouteHandlerRevalidationContextRunner;
   scheduleBackgroundRegeneration: RouteHandlerBackgroundRegenerator;
@@ -61,6 +62,10 @@ type ReadAppRouteHandlerCacheOptions = {
 
 function getCachedAppRouteValue(entry: ISRCacheEntry | null) {
   return entry?.value.value && entry.value.value.kind === "APP_ROUTE" ? entry.value.value : null;
+}
+
+function hasPublicRouteParams(params: AppRouteParams, routeIsDynamic?: boolean): boolean {
+  return routeIsDynamic ?? Object.keys(params).length > 0;
 }
 
 export async function readAppRouteHandlerCacheResponse(
@@ -106,7 +111,9 @@ export async function readAppRouteHandlerCacheResponse(
             handlerFn: options.handlerFn,
             i18n: options.i18n,
             markDynamicUsage: options.markDynamicUsage,
-            params: makeThenableParams(options.params),
+            params: hasPublicRouteParams(options.params, options.routeIsDynamic)
+              ? makeThenableParams(options.params)
+              : null,
             request: new Request(options.requestUrl, { method: "GET" }),
             routePattern: options.routePattern,
             setHeadersAccessPhase: options.setHeadersAccessPhase,

--- a/packages/vinext/src/server/app-route-handler-dispatch.ts
+++ b/packages/vinext/src/server/app-route-handler-dispatch.ts
@@ -41,6 +41,7 @@ import { makeThenableParams } from "vinext/shims/thenable-params";
 import { reportRequestError } from "./instrumentation.js";
 
 type AppRouteHandlerDispatchRoute = {
+  isDynamic?: boolean;
   pattern: string;
   routeHandler: AppRouteHandlerModule;
   routeSegments: string[];
@@ -81,6 +82,13 @@ type DispatchAppRouteHandlerOptions = {
 
 function isAppRouteHandlerFunction(value: unknown): value is AppRouteHandlerFunction {
   return typeof value === "function";
+}
+
+function hasPublicRouteParams(
+  params: AppRouteParams,
+  route: AppRouteHandlerDispatchRoute,
+): boolean {
+  return route.isDynamic ?? Object.keys(params).length > 0;
 }
 
 function buildRouteHandlerPageCacheTags(
@@ -202,6 +210,7 @@ export async function dispatchAppRouteHandler(
       revalidateSearchParams: options.searchParams,
       expireSeconds: options.expireSeconds,
       revalidateSeconds,
+      routeIsDynamic: route.isDynamic,
       routePattern: route.pattern,
       runInRevalidationContext(renderFn) {
         return runInRouteHandlerRevalidationContext(
@@ -230,6 +239,10 @@ export async function dispatchAppRouteHandler(
   }
 
   if (resolvedHandlerFn) {
+    const publicParams = hasPublicRouteParams(options.params, route)
+      ? makeThenableParams(options.params)
+      : null;
+
     return executeAppRouteHandler({
       basePath: options.basePath,
       buildPageCacheTags(pathname, extraTags) {
@@ -254,7 +267,7 @@ export async function dispatchAppRouteHandler(
       method,
       middlewareContext: options.middlewareContext,
       middlewareRequestHeaders: options.middlewareRequestHeaders,
-      params: makeThenableParams(options.params),
+      params: publicParams,
       reportRequestError(error, request, context) {
         void reportRequestError(error, request, context);
       },

--- a/packages/vinext/src/server/app-route-handler-execution.ts
+++ b/packages/vinext/src/server/app-route-handler-execution.ts
@@ -29,11 +29,12 @@ import {
 } from "./app-route-handler-runtime.js";
 
 export type AppRouteParams = Record<string, string | string[]>;
+export type AppRouteHandlerParams = AppRouteParams | null;
 export type AppRouteDynamicUsageFn = () => boolean;
 export type MarkAppRouteDynamicUsageFn = () => void;
 export type AppRouteHandlerFunction = (
   request: NextRequest,
-  context: { params: AppRouteParams },
+  context: { params: AppRouteHandlerParams },
 ) => Response | Promise<Response>;
 export type RouteHandlerCacheSetter = (
   key: string,
@@ -57,7 +58,7 @@ type RunAppRouteHandlerOptions = {
   i18n?: NextI18nConfig | null;
   markDynamicUsage: MarkAppRouteDynamicUsageFn;
   middlewareRequestHeaders?: Headers | null;
-  params: AppRouteParams;
+  params: AppRouteHandlerParams;
   request: Request;
   routePattern?: string;
   setHeadersAccessPhase?: (phase: HeadersAccessPhase) => HeadersAccessPhase;

--- a/packages/vinext/src/server/pages-page-data.ts
+++ b/packages/vinext/src/server/pages-page-data.ts
@@ -31,6 +31,9 @@ type PagesStaticPathsResult = {
   paths?: PagesStaticPathsEntry[];
 };
 
+type PagesRouteParams = Record<string, unknown>;
+type PagesPublicRouteParams = PagesRouteParams | null;
+
 type PagesPagePropsResult = {
   props?: Record<string, unknown>;
   redirect?: PagesRedirectResult;
@@ -55,7 +58,7 @@ export type PagesPageModule = {
     defaultLocale: string;
   }) => Promise<PagesStaticPathsResult> | PagesStaticPathsResult;
   getServerSideProps?: (context: {
-    params: Record<string, unknown>;
+    params: PagesPublicRouteParams;
     req: unknown;
     res: PagesMutableGsspResponse;
     query: Record<string, unknown>;
@@ -148,6 +151,13 @@ function buildPagesDataNotFoundResponse(): Response {
 
 function resolvePagesRedirectStatus(redirect: PagesRedirectResult): number {
   return redirect.statusCode != null ? redirect.statusCode : redirect.permanent ? 308 : 307;
+}
+
+function resolvePagesPublicParams(
+  params: PagesRouteParams,
+  route: Pick<Route, "isDynamic">,
+): PagesPublicRouteParams {
+  return route.isDynamic ? params : null;
 }
 
 /**
@@ -300,7 +310,7 @@ export async function resolvePagesPageData(
   if (typeof options.pageModule.getServerSideProps === "function") {
     const { req, res, responsePromise } = options.createGsspReqRes();
     const result = await options.pageModule.getServerSideProps({
-      params: options.params,
+      params: resolvePagesPublicParams(options.params, options.route),
       req,
       res,
       query: options.query,

--- a/tests/app-route-handler-dispatch.test.ts
+++ b/tests/app-route-handler-dispatch.test.ts
@@ -25,6 +25,45 @@ function buildISRCacheEntry(value: CachedRouteValue, isStale = false): ISRCacheE
 }
 
 describe("app route handler dispatch", () => {
+  it("passes null params to non-dynamic route handlers", async () => {
+    let seenParams: unknown = "unset";
+
+    const response = await dispatchAppRouteHandler({
+      cleanPathname: "/api/status",
+      clearRequestContext() {},
+      i18n: null,
+      isDevelopment: false,
+      isProduction: false,
+      async isrGet() {
+        return null;
+      },
+      isrRouteKey(pathname) {
+        return "route:" + pathname;
+      },
+      async isrSet() {},
+      middlewareContext: { headers: null, status: null },
+      middlewareRequestHeaders: null,
+      params: {},
+      request: new Request("https://example.com/api/status"),
+      route: {
+        isDynamic: false,
+        pattern: "/api/status",
+        routeHandler: {
+          async GET(_request: Request, context: { params: unknown }) {
+            seenParams = await context.params;
+            return Response.json({ ok: true });
+          },
+        },
+        routeSegments: ["api", "status"],
+      },
+      scheduleBackgroundRegeneration() {},
+      searchParams: new URLSearchParams(),
+    });
+
+    expect(response.status).toBe(200);
+    expect(seenParams).toBeNull();
+  });
+
   it("rejects invalid HTTP methods with 400 before auto-OPTIONS/405 logic", async () => {
     // Ported from Next.js: test/e2e/app-dir/app-routes/app-custom-routes.test.ts
     // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/app-routes/app-custom-routes.test.ts#L531-L538

--- a/tests/pages-page-data.test.ts
+++ b/tests/pages-page-data.test.ts
@@ -159,6 +159,31 @@ describe("pages page data", () => {
     await expect(result.response.text()).resolves.toBe('{"ok":true}');
   });
 
+  it("passes null params to getServerSideProps for non-dynamic pages", async () => {
+    let seenParams: unknown = "unset";
+
+    const result = await resolvePagesPageData(
+      createOptions({
+        params: {},
+        query: {},
+        route: { isDynamic: false },
+        routePattern: "/status",
+        routeUrl: "/status",
+        pageModule: {
+          async getServerSideProps(context) {
+            seenParams = context.params;
+            return {
+              props: { ok: true },
+            };
+          },
+        },
+      }),
+    );
+
+    expect(result.kind).toBe("render");
+    expect(seenParams).toBeNull();
+  });
+
   it("serves stale ISR entries immediately and regenerates them through typed helpers", async () => {
     let regenPromise: Promise<void> | null = null;
     const applyRequestContexts = vi.fn();


### PR DESCRIPTION
Fixes #1350.

This keeps Vinext's internal route params object, but normalizes the public Next.js contexts for routes that do not have dynamic segments. App route handlers and Pages Router getServerSideProps now see params as null for static routes, while dynamic routes still get the existing params behavior.

I added small regression tests for both paths.

Checked locally:
- pnpm.cmd exec vp test run tests/app-route-handler-dispatch.test.ts tests/app-route-handler-cache.test.ts tests/pages-page-data.test.ts
- pnpm.cmd exec vp test run tests/app-route-handler-execution.test.ts
- pnpm.cmd exec vp fmt --check packages/vinext/src/server/app-route-handler-execution.ts packages/vinext/src/server/app-route-handler-dispatch.ts packages/vinext/src/server/app-route-handler-cache.ts packages/vinext/src/server/pages-page-data.ts packages/vinext/src/entries/app-rsc-entry.ts tests/app-route-handler-dispatch.test.ts tests/pages-page-data.test.ts
- pnpm.cmd run build