### PR TITLE
fix(i18n): strip locale prefix for API routes

### DIFF
--- a/packages/vinext/package.json
+++ b/packages/vinext/package.json
@@ -33,6 +33,10 @@
       "types": "./dist/server/prod-server.d.ts",
       "import": "./dist/server/prod-server.js"
     },
+    "./server/pages-i18n": {
+      "types": "./dist/server/pages-i18n.d.ts",
+      "import": "./dist/server/pages-i18n.js"
+    },
     "./cloudflare": {
       "types": "./dist/cloudflare/index.d.ts",
       "import": "./dist/cloudflare/index.js"

--- a/packages/vinext/src/deploy.ts
+++ b/packages/vinext/src/deploy.ts
@@ -547,6 +547,7 @@ import {
   normalizeTrailingSlash,
 } from "vinext/server/request-pipeline";
 import { mergeRewriteQuery } from "vinext/utils/query";
+import { stripI18nLocaleForApiRoute } from "vinext/server/pages-i18n";
 
 // @ts-expect-error -- virtual module resolved by vinext at build time
 import { renderPage, handleApiRoute, runMiddleware, vinextConfig, matchPageRoute } from "virtual:vinext-server-entry";
@@ -800,9 +801,15 @@ export default {
       // Forward ctx so handlePagesApiRoute can wrap the user handler in
       // runWithExecutionContext, making ctx.waitUntil() reachable from
       // after() and other shims that schedule deferred work.
-      if (resolvedPathname.startsWith("/api/") || resolvedPathname === "/api") {
+      //
+      // Strip the i18n locale prefix before the /api/ check so
+      // /fr/api/ok resolves to the pages/api/ok handler (Next.js
+      // parity -- see base-server.ts's normalizeLocalePath call).
+      const apiLookupUrl = stripI18nLocaleForApiRoute(resolvedUrl, vinextConfig?.i18n ?? null);
+      const apiLookupPathname = apiLookupUrl.split("?")[0];
+      if (apiLookupPathname.startsWith("/api/") || apiLookupPathname === "/api") {
         const response = typeof handleApiRoute === "function"
-          ? await handleApiRoute(request, resolvedUrl, ctx)
+          ? await handleApiRoute(request, apiLookupUrl, ctx)
           : new Response("404 - API route not found", { status: 404 });
         return mergeHeaders(response, middlewareHeaders, middlewareRewriteStatus);
       }

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -13,6 +13,7 @@ import type { NitroRouteRuleConfig } from "./build/nitro-route-rules.js";
 import { createValidFileMatcher } from "./routing/file-matcher.js";
 import { createSSRHandler } from "./server/dev-server.js";
 import { handleApiRoute } from "./server/api-handler.js";
+import { stripI18nLocaleForApiRoute } from "./server/pages-i18n.js";
 import { installSocketErrorBackstop } from "./server/socket-error-backstop.js";
 import { shouldInvalidateAppRouteFile } from "./server/dev-route-files.js";
 import { createDirectRunner } from "./server/dev-module-runner.js";
@@ -3149,15 +3150,19 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                 return;
               }
 
-              // Handle API routes first (pages/api/*)
-              const resolvedPathname = resolvedUrl.split("?")[0];
+              // Handle API routes first (pages/api/*).
+              // Strip the i18n locale prefix before the `/api/` check so
+              // `/fr/api/ok` resolves to the `pages/api/ok` handler (Next.js
+              // parity — see base-server.ts's normalizeLocalePath call).
+              const apiLookupUrl = stripI18nLocaleForApiRoute(resolvedUrl, nextConfig?.i18n);
+              const resolvedPathname = apiLookupUrl.split("?")[0];
               if (resolvedPathname.startsWith("/api/") || resolvedPathname === "/api") {
                 const apiRoutes = await apiRouter(
                   pagesDir,
                   nextConfig?.pageExtensions,
                   fileMatcher,
                 );
-                const apiMatch = matchRoute(resolvedUrl, apiRoutes);
+                const apiMatch = matchRoute(apiLookupUrl, apiRoutes);
                 if (apiMatch) {
                   applyDeferredMwHeaders();
                   if (middlewareRequestHeaders) {
@@ -3168,7 +3173,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                   getPagesRunner(),
                   req,
                   res,
-                  resolvedUrl,
+                  apiLookupUrl,
                   apiRoutes,
                 );
                 if (handled) return;

--- a/packages/vinext/src/server/pages-i18n.ts
+++ b/packages/vinext/src/server/pages-i18n.ts
@@ -71,6 +71,30 @@ export function extractLocaleFromUrl(
 }
 
 /**
+ * Strip a leading i18n locale segment from a URL so the result can be used for
+ * API route matching. Mirrors Next.js's base-server behaviour for Pages
+ * Router API routes: `normalizeLocalePath(pathname, i18n.locales).pathname`
+ * runs before the `/api/*` check so `/fr/api/ok` resolves to the
+ * `pages/api/ok` handler instead of 404'ing.
+ *
+ * Returns the original URL untouched when:
+ * - `i18nConfig` is null/undefined (no i18n configured)
+ * - the URL does not start with a configured locale
+ *
+ * The query string is preserved verbatim — only the path segment is stripped.
+ *
+ * Reference: packages/next/src/shared/lib/i18n/normalize-locale-path.ts.
+ */
+export function stripI18nLocaleForApiRoute(
+  url: string,
+  i18nConfig: NextI18nConfig | null | undefined,
+): string {
+  if (!i18nConfig) return url;
+  const { url: stripped, hadPrefix } = extractLocaleFromUrl(url, i18nConfig);
+  return hadPrefix ? stripped : url;
+}
+
+/**
  * Detect the preferred locale from the Accept-Language header.
  * Returns the best matching locale or null.
  */

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -67,6 +67,7 @@ import { readPrerenderSecret } from "../build/server-manifest.js";
 import { VINEXT_PRERENDER_SECRET_HEADER, VINEXT_STATIC_FILE_HEADER } from "./headers.js";
 import { seedMemoryCacheFromPrerender } from "./seed-cache.js";
 import { installSocketErrorBackstop } from "./socket-error-backstop.js";
+import { stripI18nLocaleForApiRoute } from "./pages-i18n.js";
 
 /** Convert a Node.js IncomingMessage into a ReadableStream for Web Request body. */
 function readNodeStream(req: IncomingMessage): ReadableStream<Uint8Array> {
@@ -1769,13 +1770,18 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
       }
 
       // ── 8. API routes ─────────────────────────────────────────────
-      if (resolvedPathname.startsWith("/api/") || resolvedPathname === "/api") {
+      // Strip the i18n locale prefix before the `/api/` check so
+      // `/fr/api/ok` resolves to the `pages/api/ok` handler (Next.js
+      // parity — see base-server.ts's normalizeLocalePath call).
+      const apiLookupUrl = stripI18nLocaleForApiRoute(resolvedUrl, vinextConfig?.i18n ?? null);
+      const apiLookupPathname = apiLookupUrl.split("?")[0];
+      if (apiLookupPathname.startsWith("/api/") || apiLookupPathname === "/api") {
         let response: Response;
         if (typeof handleApi === "function") {
           // Pass a Node-shaped ExecutionContext so any after() calls in the
           // API handler still get a working waitUntil (which fires
           // background work without blocking the response).
-          response = await handleApi(webRequest, resolvedUrl, createNodeExecutionContext());
+          response = await handleApi(webRequest, apiLookupUrl, createNodeExecutionContext());
         } else {
           response = new Response("404 - API route not found", { status: 404 });
         }

--- a/tests/after-deploy.test.ts
+++ b/tests/after-deploy.test.ts
@@ -140,8 +140,11 @@ describe("after() in deploy mode — Pages Router worker entry", () => {
     // Regression for #1365: handleApiRoute previously ignored ctx, leaving
     // after() inside Pages Router api routes without a way to call
     // ctx.waitUntil(). The generated worker entry must thread ctx through.
+    //
+    // After #1336 item 3 the dispatch URL is `apiLookupUrl` (the locale-
+    // stripped form of `resolvedUrl`), but `ctx` is still threaded through.
     const content = generatePagesRouterWorkerEntry();
-    expect(content).toContain("handleApiRoute(request, resolvedUrl, ctx)");
+    expect(content).toContain("handleApiRoute(request, apiLookupUrl, ctx)");
   });
 
   it("forwards ctx to renderPage so page renders can call after()", () => {

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -520,9 +520,12 @@ describe("generatePagesRouterWorkerEntry", () => {
 
   it("runs middleware before routing", () => {
     const content = generatePagesRouterWorkerEntry();
-    // Middleware should appear before API route check
+    // Middleware should appear before API route check.
+    // The API check now uses apiLookupPathname (post-locale-strip), but the
+    // ordering invariant still holds (issue #1336 item 3 only changes the
+    // variable name, not the relative position).
     const middlewarePos = content.indexOf("runMiddleware(request, ctx, { isDataRequest })");
-    const apiRoutePos = content.indexOf('resolvedPathname.startsWith("/api/")');
+    const apiRoutePos = content.indexOf('apiLookupPathname.startsWith("/api/")');
     expect(middlewarePos).toBeGreaterThan(-1);
     expect(apiRoutePos).toBeGreaterThan(-1);
     expect(middlewarePos).toBeLessThan(apiRoutePos);
@@ -566,7 +569,8 @@ describe("generatePagesRouterWorkerEntry", () => {
     const content = generatePagesRouterWorkerEntry();
     const middlewareRewritePos = content.indexOf("resolvedUrl = result.rewriteUrl");
     const externalCheckPos = content.indexOf("isExternalUrl(resolvedUrl)", middlewareRewritePos);
-    const localApiRoutePos = content.indexOf('resolvedPathname.startsWith("/api/")');
+    // API check uses apiLookupPathname (post-locale-strip) since #1336 item 3.
+    const localApiRoutePos = content.indexOf('apiLookupPathname.startsWith("/api/")');
 
     expect(middlewareRewritePos).toBeGreaterThan(-1);
     expect(externalCheckPos).toBeGreaterThan(middlewareRewritePos);
@@ -626,11 +630,15 @@ describe("generatePagesRouterWorkerEntry", () => {
 
   it("routes /api/ to handleApiRoute using resolved URL and forwards ctx", () => {
     const content = generatePagesRouterWorkerEntry();
-    expect(content).toContain('resolvedPathname.startsWith("/api/")');
+    // Locale prefix is stripped before the /api/ check so /fr/api/ok matches
+    // pages/api/ok (issue #1336 item 3). The resulting URL (apiLookupUrl) is
+    // then used both for the prefix check and for the handleApiRoute call.
+    expect(content).toContain("stripI18nLocaleForApiRoute");
+    expect(content).toContain('apiLookupPathname.startsWith("/api/")');
     // Forwarding ctx lets handlePagesApiRoute wrap the handler in
     // runWithExecutionContext so after() and other shims can reach
     // ctx.waitUntil(). See #1365.
-    expect(content).toContain("handleApiRoute(request, resolvedUrl, ctx)");
+    expect(content).toContain("handleApiRoute(request, apiLookupUrl, ctx)");
   });
 
   it("includes error handling", () => {

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -1403,6 +1403,37 @@ describe("i18n domain routing (Pages Router)", () => {
       '"domainLocales":[{"domain":"example.com","defaultLocale":"en"},{"domain":"example.fr","defaultLocale":"fr","http":true}]',
     );
   });
+
+  // Issue #1336 item 3: locale prefix must be stripped before API route matching.
+  //
+  // Ported from Next.js: test/e2e/middleware-redirects/test/index.test.ts
+  // (the "should redirect to api route with locale" case, which exercises
+  // /fr/api/ok hitting pages/api/ok.js)
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-redirects/test/index.test.ts
+  it("matches /api/ok without a locale prefix (dev)", async () => {
+    const res = await requestNodeServerWithHost(domainPort, "/api/ok", "example.com");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toBe("ok");
+  });
+
+  it("matches /fr/api/ok by stripping the locale prefix in dev (issue #1336)", async () => {
+    const res = await requestNodeServerWithHost(domainPort, "/fr/api/ok", "example.com");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toBe("ok");
+  });
+
+  it("preserves query parameters when stripping the locale prefix from an API path (dev)", async () => {
+    const res = await requestNodeServerWithHost(
+      domainPort,
+      "/fr/api/ok?foo=bar&baz=qux",
+      "example.com",
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body).toBe("ok");
+  });
 });
 
 describe("i18n domain routing with basePath (Pages Router)", () => {

--- a/tests/fixtures/pages-i18n-domains/pages/api/ok.ts
+++ b/tests/fixtures/pages-i18n-domains/pages/api/ok.ts
@@ -1,0 +1,7 @@
+// API route used by i18n locale-prefix tests.
+// Mirrors Next.js test/e2e/middleware-redirects/app/pages/api/ok.js.
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export default function handler(_req: NextApiRequest, res: NextApiResponse) {
+  res.status(200).send("ok");
+}

--- a/tests/pages-i18n-prod.test.ts
+++ b/tests/pages-i18n-prod.test.ts
@@ -144,6 +144,37 @@ describe("Pages i18n domain routing (production)", () => {
       '"domainLocales":[{"domain":"example.com","defaultLocale":"en"},{"domain":"example.fr","defaultLocale":"fr","http":true}]',
     );
   });
+
+  // Issue #1336 item 3: locale prefix must be stripped before API route matching.
+  //
+  // Ported from Next.js: test/e2e/middleware-redirects/test/index.test.ts
+  // (the "should redirect to api route with locale" case, which exercises
+  // /fr/api/ok hitting pages/api/ok.js)
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-redirects/test/index.test.ts
+  it("matches /api/ok without a locale prefix", async () => {
+    const res = await requestNodeServerWithHost(prodPort, "/api/ok", "example.com");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toBe("ok");
+  });
+
+  it("matches /fr/api/ok by stripping the locale prefix (issue #1336)", async () => {
+    const res = await requestNodeServerWithHost(prodPort, "/fr/api/ok", "example.com");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toBe("ok");
+  });
+
+  it("preserves query parameters when stripping the locale prefix from an API path", async () => {
+    const res = await requestNodeServerWithHost(
+      prodPort,
+      "/fr/api/ok?foo=bar&baz=qux",
+      "example.com",
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body).toBe("ok");
+  });
 });
 
 describe("Pages i18n domain routing with basePath (production)", () => {

--- a/tests/pages-i18n.test.ts
+++ b/tests/pages-i18n.test.ts
@@ -121,3 +121,62 @@ describe("Pages i18n domain helpers", () => {
     ).toBe("http://example.fr/?utm=campaign&next=%2Fcheckout");
   });
 });
+
+// Ported from Next.js: test/e2e/middleware-redirects/test/index.test.ts
+// (the "should redirect to api route with locale" case)
+// https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-redirects/test/index.test.ts
+//
+// Reference Next.js implementation:
+// https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/i18n/normalize-locale-path.ts
+// https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/router/utils/get-next-pathname-info.ts
+describe("stripI18nLocaleForApiRoute (issue #1336 item 3)", () => {
+  const i18n = {
+    locales: ["en", "fr", "nl-NL"],
+    defaultLocale: "en",
+    localeDetection: true,
+  };
+  let stripI18nLocaleForApiRoute: typeof import("../packages/vinext/src/server/pages-i18n.js").stripI18nLocaleForApiRoute;
+
+  beforeAll(async () => {
+    ({ stripI18nLocaleForApiRoute } = await import("../packages/vinext/src/server/pages-i18n.js"));
+  });
+
+  it("strips a single-segment locale prefix from an API path", () => {
+    expect(stripI18nLocaleForApiRoute("/fr/api/ok", i18n)).toBe("/api/ok");
+  });
+
+  it("strips a region-tagged locale prefix from an API path", () => {
+    expect(stripI18nLocaleForApiRoute("/nl-NL/api/ok", i18n)).toBe("/api/ok");
+  });
+
+  it("preserves the query string when stripping the locale prefix", () => {
+    expect(stripI18nLocaleForApiRoute("/fr/api/ok?id=1&tag=a&tag=b", i18n)).toBe(
+      "/api/ok?id=1&tag=a&tag=b",
+    );
+  });
+
+  it("returns the URL unchanged when no locale prefix is present", () => {
+    expect(stripI18nLocaleForApiRoute("/api/ok", i18n)).toBe("/api/ok");
+  });
+
+  it("returns the URL unchanged when the first segment is not a configured locale", () => {
+    // "es" is NOT in locales; this must NOT be treated as a locale prefix.
+    expect(stripI18nLocaleForApiRoute("/es/api/ok", i18n)).toBe("/es/api/ok");
+  });
+
+  it("returns the URL unchanged when i18nConfig is null/undefined", () => {
+    expect(stripI18nLocaleForApiRoute("/fr/api/ok", null)).toBe("/fr/api/ok");
+    expect(stripI18nLocaleForApiRoute("/fr/api/ok", undefined)).toBe("/fr/api/ok");
+  });
+
+  it("strips locale even on non-API paths (caller decides what to do with the result)", () => {
+    // The helper is locale-strip only; callers branch on the resulting
+    // pathname's /api/ prefix. This isolates the helper's behaviour from
+    // any caller-specific routing decisions.
+    expect(stripI18nLocaleForApiRoute("/fr/about", i18n)).toBe("/about");
+  });
+
+  it("leaves the root path untouched", () => {
+    expect(stripI18nLocaleForApiRoute("/", i18n)).toBe("/");
+  });
+});


### PR DESCRIPTION
## Summary

Sub-issue #1336 item 3 — strip the i18n locale prefix before Pages Router API route matching so requests like `/fr/api/ok` reach the `pages/api/ok` handler instead of 404'ing.

### What changed

- **New helper.** `stripI18nLocaleForApiRoute(url, i18nConfig)` in `packages/vinext/src/server/pages-i18n.ts`. Mirrors Next.js's [`normalizeLocalePath().pathname`](https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/i18n/normalize-locale-path.ts): if `url`'s first path segment matches a configured locale, return the URL without that segment (query preserved); otherwise return the URL unchanged. Returns the URL unchanged when `i18nConfig` is null/undefined.

- **Wired into all three Pages Router request pipelines** so dev/prod parity holds (per AGENTS.md — dev, prod-node, and prod-Workers all handle requests directly):
  - `packages/vinext/src/index.ts` — dev plugin
  - `packages/vinext/src/server/prod-server.ts` — Node prod server
  - `packages/vinext/src/deploy.ts` — generated Cloudflare worker entry (`generatePagesRouterWorkerEntry`)

  Each site computes `apiLookupUrl = stripI18nLocaleForApiRoute(resolvedUrl, i18n)` and uses that for both the `/api/` startsWith check and the `handleApiRoute(...)` dispatch.

- **Package export.** Added `./server/pages-i18n` to `packages/vinext/package.json#exports` so the generated worker entry can import the helper from `vinext/server/pages-i18n`.

### Out of scope

- **App Router (`app/*/route.ts`).** Next.js does not support the `i18n` config field with App Router (the field is Pages-Router-only — App Router users are expected to use middleware-based i18n), so App Router route handlers never see a locale prefix to strip. No App Router files are touched.
- **Items 2 and 4 of #1336** (sticky locale on client navigations, default-locale path normalisation) are being handled in parallel PRs. This PR's diff is scoped strictly to API-route locale handling.

### Tests

New tests:
- `tests/pages-i18n.test.ts` — `stripI18nLocaleForApiRoute (issue #1336 item 3)` block, 8 unit tests covering: single-segment locale, regional locale (`nl-NL`), query-string preservation, no-prefix passthrough, unconfigured-prefix passthrough, null/undefined i18n config, non-API paths, root path.
- `tests/features.test.ts` — 3 new dev integration tests in the `i18n domain routing (Pages Router)` block: `/api/ok` baseline, `/fr/api/ok` (the regression), and query-param preservation on `/fr/api/ok?...`.
- `tests/pages-i18n-prod.test.ts` — 3 matching prod integration tests in the `Pages i18n domain routing (production)` block.
- `tests/fixtures/pages-i18n-domains/pages/api/ok.ts` — minimal API handler that returns `"ok"` (mirrors Next.js's `test/e2e/middleware-redirects/app/pages/api/ok.js`).

Updates to existing assertions:
- `tests/deploy.test.ts` — three assertions that searched for `resolvedPathname.startsWith("/api/")` in the generated worker-entry template string are updated to search for the new `apiLookupPathname.startsWith("/api/")` variable name plus the `stripI18nLocaleForApiRoute` import.

Test reproduction confirmed: with the implementation reverted but the new integration tests in place, both `features.test.ts` and `pages-i18n-prod.test.ts` fail with `expected 404 to be 200`. With the implementation restored, all tests pass.

### Test plan

- [x] `vp test run tests/pages-i18n.test.ts tests/pages-i18n-prod.test.ts tests/deploy.test.ts` — 250 tests pass
- [x] `vp test run tests/features.test.ts` — 306 tests pass (includes the 3 new dev tests)
- [x] `vp test run tests/pages-router.test.ts tests/api-handler.test.ts` — 653 tests pass (regression sanity check)
- [x] `vp check packages/vinext/src/{index.ts,deploy.ts,server/prod-server.ts,server/pages-i18n.ts} packages/vinext/package.json tests/{pages-i18n,pages-i18n-prod,features,deploy}.test.ts` — formatter + linter + type-check green
- [ ] CI green (waiting)
- [ ] `/bigbonk review` feedback addressed

### References

- Ported from Next.js: [`test/e2e/middleware-redirects/test/index.test.ts`](https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-redirects/test/index.test.ts) — the `should redirect to api route with locale` case exercises `/fr/api/ok` against `pages/api/ok.js`.
- Implementation reference: [`packages/next/src/shared/lib/i18n/normalize-locale-path.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/i18n/normalize-locale-path.ts) — `normalizeLocalePath` is what Next.js's base-server uses to strip the locale before the `/api/*` check.
- Also reviewed: [`packages/next/src/shared/lib/router/utils/get-next-pathname-info.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/router/utils/get-next-pathname-info.ts) — wraps `normalizeLocalePath` for the same purpose in the routing utilities.

Refs #1336 (item 3)
