### PR TITLE
fix(pages-router): honour `shallow` prop on next/link

### DIFF
--- a/packages/vinext/src/client/pages-router-link-navigation.ts
+++ b/packages/vinext/src/client/pages-router-link-navigation.ts
@@ -1,5 +1,6 @@
 type PagesRouterLinkTransitionOptions = {
   scroll?: boolean;
+  shallow?: boolean;
   locale?: string | false;
 };
 
@@ -14,15 +15,18 @@ export async function navigatePagesRouterLink(
     href,
     replace,
     scroll,
+    shallow,
     locale,
   }: {
     href: string;
     replace: boolean;
     scroll: boolean;
+    shallow?: boolean;
     locale?: string | false;
   },
 ): Promise<void> {
-  const routerOptions = { scroll, locale };
+  const routerOptions: PagesRouterLinkTransitionOptions = { scroll, locale };
+  if (shallow !== undefined) routerOptions.shallow = shallow;
   if (replace) {
     await router.replace(href, undefined, routerOptions);
   } else {

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -84,6 +84,13 @@ type LinkProps = {
   passHref?: boolean;
   /** Scroll to top on navigation (default: true) */
   scroll?: boolean;
+  /**
+   * Pages Router: update the URL without re-running data fetching methods
+   * (getServerSideProps / getStaticProps / getInitialProps). The shallow change
+   * still triggers the route change events and updates `router.query`. Only
+   * applies to navigations within the same page. No-op on the App Router.
+   */
+  shallow?: boolean;
   /** Locale for i18n (used for locale-prefixed URLs) */
   locale?: string | false;
   /** Called before navigation happens (Next.js 16). Return value is ignored. */
@@ -397,6 +404,7 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
     replace = false,
     prefetch: prefetchProp,
     scroll = true,
+    shallow = false,
     children,
     onClick,
     onMouseEnter,
@@ -630,7 +638,13 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
       try {
         const routerModule = await import("next/router");
         const Router = routerModule.default;
-        await navigatePagesRouterLink(Router, { href: absoluteHref, replace, scroll, locale });
+        await navigatePagesRouterLink(Router, {
+          href: absoluteHref,
+          replace,
+          scroll,
+          shallow,
+          locale,
+        });
       } catch {
         // Fallback to hard navigation if router fails
         if (replace) {

--- a/tests/e2e/pages-router/shallow-routing.spec.ts
+++ b/tests/e2e/pages-router/shallow-routing.spec.ts
@@ -186,6 +186,55 @@ test.describe("Shallow routing (Pages Router)", () => {
     );
   });
 
+  test("<Link shallow> click skips GSSP refetch (issue #1332 sub-problem 3)", async ({ page }) => {
+    // Mirrors Next.js test/e2e/middleware-trailing-slash 'allows shallow linking
+    // with middleware' — clicking <Link href="..." shallow> should update the
+    // URL and router.query without triggering a /_next/data fetch.
+    await page.goto(`${BASE}/shallow-test`);
+    await expect(page.locator("h1")).toHaveText("Shallow Routing Test");
+    await waitForHydration(page);
+
+    const initialCallId = await page.locator('[data-testid="gssp-call-id"]').textContent();
+
+    const dataRequests: string[] = [];
+    page.on("request", (req) => {
+      const url = req.url();
+      if (url.includes("/_next/data/")) dataRequests.push(url);
+    });
+
+    await page.click('[data-testid="shallow-link"]');
+
+    await expect(page).toHaveURL(`${BASE}/shallow-test?via=link`);
+
+    // GSSP call ID stays the same — server was not re-hit
+    const afterCallId = await page.locator('[data-testid="gssp-call-id"]').textContent();
+    expect(afterCallId).toBe(initialCallId);
+
+    // router.query reflects the new query
+    const routerQuery = await page.locator('[data-testid="router-query"]').textContent();
+    expect(JSON.parse(routerQuery!)).toEqual({ via: "link" });
+
+    // No _next/data requests fired by the shallow click.
+    expect(dataRequests).toEqual([]);
+  });
+
+  test("<Link> without shallow click triggers GSSP refetch", async ({ page }) => {
+    await page.goto(`${BASE}/shallow-test`);
+    await expect(page.locator("h1")).toHaveText("Shallow Routing Test");
+    await waitForHydration(page);
+
+    const initialCallId = await page.locator('[data-testid="gssp-call-id"]').textContent();
+
+    await page.click('[data-testid="deep-link"]');
+
+    await expect(page).toHaveURL(`${BASE}/shallow-test?via=deep-link`);
+
+    await expect(async () => {
+      const afterCallId = await page.locator('[data-testid="gssp-call-id"]').textContent();
+      expect(afterCallId).not.toBe(initialCallId);
+    }).toPass({ timeout: 5_000 });
+  });
+
   test("router.query preserves catch-all route params as arrays", async ({ page }) => {
     await page.goto(`${BASE}/shallow-test`);
     await expect(page.locator("h1")).toHaveText("Shallow Routing Test");

--- a/tests/fixtures/pages-basic/pages/shallow-test.tsx
+++ b/tests/fixtures/pages-basic/pages/shallow-test.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { useRouter } from "next/router";
 
 interface ShallowTestProps {
@@ -49,6 +50,12 @@ export default function ShallowTestPage({ gsspCallId, serverQuery }: ShallowTest
       >
         Shallow Replace
       </button>
+      <Link href="/shallow-test?via=link" shallow prefetch={false} data-testid="shallow-link">
+        Shallow Link
+      </Link>
+      <Link href="/shallow-test?via=deep-link" prefetch={false} data-testid="deep-link">
+        Deep Link
+      </Link>
     </div>
   );
 }

--- a/tests/link.test.ts
+++ b/tests/link.test.ts
@@ -101,6 +101,16 @@ describe("Link rendering", () => {
     expect(html).not.toContain("locale=");
   });
 
+  it("does not render shallow as an HTML attribute", () => {
+    // Regression for #1332 sub-problem 3: the `shallow` boolean is consumed
+    // by the click handler and must not leak onto the rendered <a>.
+    const html = ReactDOMServer.renderToString(
+      React.createElement(Link, { href: "/test", shallow: true }, "Test"),
+    );
+    expect(html).not.toContain("shallow");
+    expect(html).toContain('href="/test"');
+  });
+
   it("passes through standard anchor attributes", () => {
     const html = ReactDOMServer.renderToString(
       React.createElement(
@@ -515,6 +525,70 @@ describe("Link locale handling", () => {
 
     expect(push).toHaveBeenCalledWith("/fr/about", undefined, { scroll: true, locale: "fr" });
     expect(replace).not.toHaveBeenCalled();
+  });
+
+  // Regression for #1332 sub-problem 3: `<Link shallow>` must reach
+  // Router.push with `shallow: true` so the Pages Router skips the
+  // _next/data fetch and only updates the URL. Mirrors Next.js's
+  // test/e2e/middleware-trailing-slash shallow-link assertion at
+  // packages/next/src/client/link.tsx.
+  it("forwards shallow=true through the Pages Router Link handoff (push)", async () => {
+    const push = vi.fn(async () => true);
+    const replace = vi.fn(async () => true);
+
+    await navigatePagesRouterLink(
+      { push, replace },
+      { href: "/sha?hello=world", replace: false, scroll: true, shallow: true },
+    );
+
+    expect(push).toHaveBeenCalledWith("/sha?hello=world", undefined, {
+      scroll: true,
+      locale: undefined,
+      shallow: true,
+    });
+    expect(replace).not.toHaveBeenCalled();
+  });
+
+  it("forwards shallow=true through the Pages Router Link handoff (replace)", async () => {
+    const push = vi.fn(async () => true);
+    const replace = vi.fn(async () => true);
+
+    await navigatePagesRouterLink(
+      { push, replace },
+      { href: "/sha?hello=world", replace: true, scroll: true, shallow: true },
+    );
+
+    expect(replace).toHaveBeenCalledWith("/sha?hello=world", undefined, {
+      scroll: true,
+      locale: undefined,
+      shallow: true,
+    });
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("forwards shallow=false explicitly when the default is used", async () => {
+    const push = vi.fn(async () => true);
+    const replace = vi.fn(async () => true);
+
+    await navigatePagesRouterLink(
+      { push, replace },
+      { href: "/sha", replace: false, scroll: true, shallow: false },
+    );
+
+    expect(push).toHaveBeenCalledWith("/sha", undefined, {
+      scroll: true,
+      locale: undefined,
+      shallow: false,
+    });
+  });
+
+  it("omits shallow from router options when the caller does not pass it", async () => {
+    const push = vi.fn(async () => true);
+    const replace = vi.fn(async () => true);
+
+    await navigatePagesRouterLink({ push, replace }, { href: "/", replace: false, scroll: true });
+
+    expect(push).toHaveBeenCalledWith("/", undefined, { scroll: true, locale: undefined });
   });
 });
 


### PR DESCRIPTION
## Summary

Closes the last sub-problem of #1332.

The Pages Router `Router.push` / `Router.replace` already short-circuit the `_next/data` fetch when `options.shallow === true`, but `<Link shallow>` never made it that far:

- `shallow` was missing from `LinkProps`, so it fell into `...rest`, was spread onto the underlying `<a>`, and the click handler called `Router.push(href, undefined, { scroll, locale })` with no shallow flag.
- Result: every `<Link href="..." shallow>` did a full server roundtrip and re-ran `getServerSideProps`, which is exactly the symptom Next.js's deploy-suite test was failing on.

### Files touched

- `packages/vinext/src/shims/link.tsx` — add `shallow?: boolean` to `LinkProps`, destructure it in the Link component, forward into the click handler.
- `packages/vinext/src/client/pages-router-link-navigation.ts` — accept `shallow` and include it in the router transition options only when explicitly set, so existing callers that omit it keep the same options shape.

### What this matches

Next.js's deploy-suite fixture `test/e2e/middleware-trailing-slash/app/pages/shallow.js` clicks `<Link href="/sha?hello=world" shallow>` and asserts the GSSP-generated random message stays unchanged afterwards. vinext now passes this scenario.

## Test plan

- [x] New unit tests in `tests/link.test.ts`:
  - `forwards shallow=true through the Pages Router Link handoff (push)`
  - `forwards shallow=true through the Pages Router Link handoff (replace)`
  - `forwards shallow=false explicitly when the default is used`
  - `omits shallow from router options when the caller does not pass it`
  - `does not render shallow as an HTML attribute`
- [x] New e2e specs in `tests/e2e/pages-router/shallow-routing.spec.ts` mirroring the Next.js deploy-suite scenario:
  - `<Link shallow> click skips GSSP refetch (issue #1332 sub-problem 3)`
  - `<Link> without shallow click triggers GSSP refetch`
- [x] Extended `tests/fixtures/pages-basic/pages/shallow-test.tsx` with `<Link shallow>` and a deep `<Link>` to exercise the new path.
- [x] `pnpm test:unit` — 4639 tests, all green.
- [x] `pnpm exec vp check` — format, lint, and type checks all clean.

## Refs

- Closes the Pages Router shallow portion of #1332.
- Next.js test parity: [`test/e2e/middleware-trailing-slash/test/index.test.ts`](https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-trailing-slash/test/index.test.ts) (`allows shallow linking with middleware`).
- Next.js reference: [`packages/next/src/client/link.tsx`](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/link.tsx) (`shallow` is forwarded into `linkClicked` → `router.push`/`router.replace`).