### PR TITLE
fix(pages-router): render loading shell for unlisted `fallback: true` paths

### DIFF
--- a/packages/vinext/src/entries/pages-server-entry.ts
+++ b/packages/vinext/src/entries/pages-server-entry.ts
@@ -609,6 +609,24 @@ async function _renderPage(request, url, manifest, middlewareHeaders, options) {
       let pageProps = pageDataResult.pageProps;
       var gsspRes = pageDataResult.gsspRes;
       let isrRevalidateSeconds = pageDataResult.isrRevalidateSeconds;
+      const isFallbackRender = pageDataResult.isFallback === true;
+
+      // Republish the SSR context with isFallback flipped on so the page's
+      // \`useRouter().isFallback\` returns true during render, matching Next.js's
+      // \`render.tsx\` fallback shell. Without this, the page would still see
+      // \`isFallback: false\` and run the non-fallback branch.
+      if (isFallbackRender && typeof setSSRContext === "function") {
+        setSSRContext({
+          pathname: routePattern,
+          query,
+          asPath: routeUrl,
+          locale: locale,
+          locales: i18nConfig ? i18nConfig.locales : undefined,
+          defaultLocale: currentDefaultLocale,
+          domainLocales: domainLocales,
+          isFallback: true,
+        });
+      }
 
       // ── _next/data JSON envelope short-circuit ───────────────────────
       // For client-side navigations Next.js fetches /_next/data/<buildId>/<page>.json
@@ -689,6 +707,7 @@ async function _renderPage(request, url, manifest, middlewareHeaders, options) {
           defaultLocale: currentDefaultLocale,
           domainLocales: domainLocales,
         },
+        isFallback: isFallbackRender,
         pageProps,
         params,
         renderDocumentToString(element) {

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -415,9 +415,15 @@ export function createSSRHandler(
         // Collect page props via data fetching methods
         let pageProps: Record<string, unknown> = {};
         let isrRevalidateSeconds: number | null = null;
+        // Set when `getStaticPaths: { fallback: true }` is configured and the
+        // requested path is NOT in the pre-rendered list. Triggers the loading
+        // shell render below: `getStaticProps`/`getServerSideProps` are skipped
+        // and `useRouter().isFallback === true`, matching Next.js render.tsx.
+        let isFallbackRender = false;
 
-        // Handle getStaticPaths for dynamic routes: validate the path
-        // and respect fallback: false (return 404 for unlisted paths).
+        // Handle getStaticPaths for dynamic routes: validate the path,
+        // respect `fallback: false` (return 404 for unlisted paths), and
+        // render the loading shell for unlisted paths under `fallback: true`.
         if (typeof pageModule.getStaticPaths === "function" && route.isDynamic) {
           const pathsResult = await pageModule.getStaticPaths({
             locales: i18nConfig?.locales ?? [],
@@ -425,59 +431,71 @@ export function createSSRHandler(
           });
           const fallback = pathsResult?.fallback ?? false;
 
-          if (fallback === false) {
-            // Only allow paths explicitly listed in getStaticPaths. Next.js
-            // accepts `paths` as Array<string | { params, locale? }>; the
-            // shared `StaticPathsEntry` type and `normalizeStaticPathname`
-            // helper in `../routing/route-pattern.ts` reference the upstream
-            // implementation.
-            type DevStaticPathsEntry = Exclude<StaticPathsEntry, null | undefined>;
-            const paths: Array<DevStaticPathsEntry> = pathsResult?.paths ?? [];
-            const currentPathname = normalizeStaticPathname(url);
-            const isValidPath = paths.some((p) => {
-              if (typeof p === "string") {
-                return normalizeStaticPathname(p) === currentPathname;
+          // Only allow paths explicitly listed in getStaticPaths. Next.js
+          // accepts `paths` as Array<string | { params, locale? }>; the
+          // shared `StaticPathsEntry` type and `normalizeStaticPathname`
+          // helper in `../routing/route-pattern.ts` reference the upstream
+          // implementation.
+          type DevStaticPathsEntry = Exclude<StaticPathsEntry, null | undefined>;
+          const paths: Array<DevStaticPathsEntry> = pathsResult?.paths ?? [];
+          const currentPathname = normalizeStaticPathname(url);
+          const isValidPath = paths.some((p) => {
+            if (typeof p === "string") {
+              return normalizeStaticPathname(p) === currentPathname;
+            }
+            const entryParams = p.params;
+            if (entryParams === undefined || entryParams === null) {
+              return false;
+            }
+            return Object.entries(entryParams).every(([key, val]) => {
+              const actual = params[key];
+              if (Array.isArray(val)) {
+                return Array.isArray(actual) && val.join("/") === actual.join("/");
               }
-              const entryParams = p.params;
-              if (entryParams === undefined || entryParams === null) {
-                return false;
-              }
-              return Object.entries(entryParams).every(([key, val]) => {
-                const actual = params[key];
-                if (Array.isArray(val)) {
-                  return Array.isArray(actual) && val.join("/") === actual.join("/");
-                }
-                return String(val) === String(actual);
-              });
+              return String(val) === String(actual);
             });
+          });
 
-            if (!isValidPath) {
-              if (isDataReq) {
-                // Data requests get a JSON 404 so the client router can
-                // hard-navigate instead of trying to parse HTML as JSON.
-                res.writeHead(404, { "Content-Type": "application/json" });
-                res.end("{}");
-                return;
-              }
-              await renderErrorPage(
-                server,
-                runner,
-                req,
-                res,
-                url,
-                pagesDir,
-                404,
-                routerShim.wrapWithRouterContext,
-                matcher,
-              );
+          if (fallback === false && !isValidPath) {
+            if (isDataReq) {
+              // Data requests get a JSON 404 so the client router can
+              // hard-navigate instead of trying to parse HTML as JSON.
+              res.writeHead(404, { "Content-Type": "application/json" });
+              res.end("{}");
               return;
             }
+            await renderErrorPage(
+              server,
+              runner,
+              req,
+              res,
+              url,
+              pagesDir,
+              404,
+              routerShim.wrapWithRouterContext,
+              matcher,
+            );
+            return;
           }
-          // fallback: true or "blocking" — always SSR on-demand.
-          // In dev mode, Next.js does the same (no fallback shell).
-          // In production, both modes SSR on-demand with caching.
-          // The difference is that fallback:true could serve a shell first,
-          // but since we always have data available via SSR, we render fully.
+
+          // Render the loading shell for `fallback: true` when the path
+          // wasn't pre-rendered. Data requests still resolve real props so
+          // the client can swap in after the shell ships.
+          if (fallback === true && !isValidPath && !isDataReq) {
+            isFallbackRender = true;
+            if (typeof routerShim.setSSRContext === "function") {
+              routerShim.setSSRContext({
+                pathname: patternToNextFormat(route.pattern),
+                query,
+                asPath: url,
+                locale: locale ?? currentDefaultLocale,
+                locales: i18nConfig?.locales,
+                defaultLocale: currentDefaultLocale,
+                domainLocales,
+                isFallback: true,
+              });
+            }
+          }
         }
 
         // Headers set by getServerSideProps for explicit forwarding to
@@ -486,7 +504,7 @@ export function createSSRHandler(
         // would silently break if streamPageToResponse is refactored.
         const gsspExtraHeaders: Record<string, string | string[]> = {};
 
-        if (typeof pageModule.getServerSideProps === "function") {
+        if (typeof pageModule.getServerSideProps === "function" && !isFallbackRender) {
           // Snapshot existing headers so we can detect what gSSP adds.
           const headersBeforeGSSP = new Set(Object.keys(res.getHeaders()));
 
@@ -591,7 +609,7 @@ export function createSSRHandler(
           // Font modules not loaded yet — skip
         }
 
-        if (typeof pageModule.getStaticProps === "function") {
+        if (typeof pageModule.getStaticProps === "function" && !isFallbackRender) {
           // Check ISR cache before calling getStaticProps
           const cacheKey = isrCacheKey(
             "pages",
@@ -1001,7 +1019,7 @@ hydrate();
             page: patternToNextFormat(route.pattern),
             query: params,
             buildId: process.env.__VINEXT_BUILD_ID,
-            isFallback: false,
+            isFallback: isFallbackRender,
             locale: locale ?? currentDefaultLocale,
             locales: i18nConfig?.locales,
             defaultLocale: currentDefaultLocale,

--- a/packages/vinext/src/server/pages-page-data.ts
+++ b/packages/vinext/src/server/pages-page-data.ts
@@ -144,6 +144,13 @@ type ResolvePagesPageDataRenderResult = {
   gsspRes: PagesGsspResponse | null;
   isrRevalidateSeconds: number | null;
   pageProps: Record<string, unknown>;
+  /**
+   * True when `getStaticPaths` returned `fallback: true` AND the requested path
+   * is not in the pre-rendered list. The caller renders a loading shell with
+   * empty props and `useRouter().isFallback === true` (matching Next.js's
+   * `render.tsx` — `getStaticProps` is skipped on the fallback render).
+   */
+  isFallback: boolean;
 };
 
 type ResolvePagesPageDataResponseResult = {
@@ -307,35 +314,58 @@ export async function resolvePagesPageData(
     ? options.params
     : null;
 
+  // Set when `getStaticPaths: { fallback: true }` is configured and the
+  // requested path is NOT in the pre-rendered list. When true, we render the
+  // loading shell with empty props and `useRouter().isFallback === true`,
+  // skipping `getStaticProps`. Matches Next.js `render.tsx`'s
+  // `if (isSSG && !isFallback)` gate around `getStaticProps`. Data requests
+  // (`/_next/data/...json`) still call `getStaticProps` so the client can
+  // hydrate the page after the fallback shell ships.
+  let isFallback = false;
+
   if (typeof options.pageModule.getStaticPaths === "function" && options.route.isDynamic) {
     const pathsResult = await options.pageModule.getStaticPaths({
       locales: options.i18n.locales ?? [],
       defaultLocale: options.i18n.defaultLocale ?? "",
     });
     const fallback = pathsResult?.fallback ?? false;
+    const paths = pathsResult?.paths ?? [];
+    const isValidPath = paths.some((pathEntry) =>
+      matchesPagesStaticPath(pathEntry, options.params, options.routeUrl),
+    );
 
-    if (fallback === false) {
-      const paths = pathsResult?.paths ?? [];
-      const isValidPath = paths.some((pathEntry) =>
-        matchesPagesStaticPath(pathEntry, options.params, options.routeUrl),
-      );
+    if (fallback === false && !isValidPath) {
+      // For data requests (`/_next/data/...json`), return a JSON-shaped 404
+      // so the client router can `res.json()` without blowing up — matches
+      // Next.js' behavior. HTML navigations still get the HTML 404 page.
+      return {
+        kind: "response",
+        response: options.isDataReq
+          ? buildPagesDataNotFoundResponse()
+          : buildPagesNotFoundResponse(),
+      };
+    }
 
-      if (!isValidPath) {
-        // For data requests (`/_next/data/...json`), return a JSON-shaped 404
-        // so the client router can `res.json()` without blowing up — matches
-        // Next.js' behavior. HTML navigations still get the HTML 404 page.
-        return {
-          kind: "response",
-          response: options.isDataReq
-            ? buildPagesDataNotFoundResponse()
-            : buildPagesNotFoundResponse(),
-        };
-      }
+    // Render the fallback shell for unlisted paths under `fallback: true`.
+    // Data requests resolve props normally so the client can fill in after
+    // the loading shell ships (`fallback: 'blocking'` keeps SSRing as before).
+    if (fallback === true && !isValidPath && !options.isDataReq) {
+      isFallback = true;
     }
   }
 
   let pageProps: Record<string, unknown> = {};
   let gsspRes: PagesMutableGsspResponse | null = null;
+
+  if (isFallback) {
+    return {
+      kind: "render",
+      gsspRes: null,
+      isrRevalidateSeconds: null,
+      pageProps,
+      isFallback: true,
+    };
+  }
 
   if (typeof options.pageModule.getServerSideProps === "function") {
     const { req, res, responsePromise } = options.createGsspReqRes();
@@ -517,5 +547,6 @@ export async function resolvePagesPageData(
     gsspRes,
     isrRevalidateSeconds,
     pageProps,
+    isFallback: false,
   };
 }

--- a/packages/vinext/src/server/pages-page-response.ts
+++ b/packages/vinext/src/server/pages-page-response.ts
@@ -54,6 +54,13 @@ type RenderPagesPageResponseOptions = {
     expireSeconds?: number,
   ) => Promise<void>;
   i18n: PagesI18nRenderContext;
+  /**
+   * True when rendering a `getStaticPaths` fallback shell for a path that
+   * isn't pre-rendered (`fallback: true` + unlisted path). Forwarded to
+   * `buildPagesNextDataScript` so the client serialises `isFallback: true`
+   * into `__NEXT_DATA__`, then later hydrates by fetching the data URL.
+   */
+  isFallback?: boolean;
   pageProps: Record<string, unknown>;
   params: Record<string, unknown>;
   renderDocumentToString: (element: ReactNode) => Promise<string>;
@@ -94,6 +101,7 @@ export function buildPagesNextDataScript(
     RenderPagesPageResponseOptions,
     | "buildId"
     | "i18n"
+    | "isFallback"
     | "pageProps"
     | "params"
     | "routePattern"
@@ -108,7 +116,7 @@ export function buildPagesNextDataScript(
     page: options.routePattern,
     query: options.params,
     buildId: options.buildId,
-    isFallback: false,
+    isFallback: options.isFallback === true,
   };
 
   if (options.i18n.locales) {
@@ -304,6 +312,7 @@ export async function renderPagesPageResponse(
   const nextDataScript = buildPagesNextDataScript({
     buildId: options.buildId,
     i18n: options.i18n,
+    isFallback: options.isFallback,
     pageProps: options.pageProps,
     params: options.params,
     routePattern: options.routePattern,

--- a/packages/vinext/src/shims/router-state.ts
+++ b/packages/vinext/src/shims/router-state.ts
@@ -27,6 +27,7 @@ export type SSRContext = {
   locale?: string;
   locales?: string[];
   defaultLocale?: string;
+  isFallback?: boolean;
 };
 
 export type RouterState = {

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -297,6 +297,14 @@ type SSRContext = {
   locales?: string[];
   defaultLocale?: string;
   domainLocales?: VinextNextData["domainLocales"];
+  /**
+   * True when rendering a `getStaticPaths` fallback shell for a path that
+   * hasn't been pre-rendered yet (`fallback: true` + unlisted path). Mirrors
+   * `renderContext.isFallback` in Next.js's `render.tsx`: `getStaticProps`
+   * is skipped, the page renders with empty props, and `useRouter().isFallback`
+   * returns `true` so user code can show a loading state.
+   */
+  isFallback?: boolean;
 };
 
 // ---------------------------------------------------------------------------
@@ -796,7 +804,10 @@ function buildRouterValue(
     domainLocales,
     isReady: true,
     isPreview: false,
-    isFallback: typeof window !== "undefined" && nextData?.isFallback === true,
+    isFallback:
+      typeof window !== "undefined"
+        ? nextData?.isFallback === true
+        : _ssrState?.isFallback === true,
     ...methods,
     events: routerEvents,
   };
@@ -1268,7 +1279,7 @@ const Router: typeof RouterMethods & Omit<NextRouter, keyof typeof RouterMethods
     isFallback: {
       enumerable: true,
       get(): boolean {
-        if (typeof window === "undefined") return false;
+        if (typeof window === "undefined") return _getSSRContext()?.isFallback === true;
         return (window.__NEXT_DATA__ as VinextNextData | undefined)?.isFallback === true;
       },
     },

--- a/tests/fixtures/pages-basic/middleware.ts
+++ b/tests/fixtures/pages-basic/middleware.ts
@@ -69,6 +69,40 @@ export function middleware(request: NextRequest) {
     return NextResponse.rewrite(target, { status: 403 });
   }
 
+  // Ported from Next.js: test/e2e/middleware-rewrites/app/middleware.js
+  // ('/middleware-external-rewrite-body') — POST body must reach upstream.
+  if (url.pathname === "/external-middleware-rewrite-body") {
+    const target =
+      request.headers.get("x-middleware-test-rewrite-target") ??
+      "https://api.example.com/echo-body";
+    return NextResponse.rewrite(target);
+  }
+
+  // Ported from Next.js: test/e2e/middleware-rewrites/app/middleware.js
+  // ('/middleware-external-rewrite-body-headers-return-headers') — request
+  // header overrides from `NextResponse.rewrite(url, { request: { headers } })`
+  // must propagate to the proxied upstream request.
+  if (url.pathname === "/external-middleware-rewrite-with-headers") {
+    const target =
+      request.headers.get("x-middleware-test-rewrite-target") ??
+      "https://api.example.com/echo-headers";
+    const tmpHeaders = new Headers(request.headers);
+    tmpHeaders.set("x-hello-from-middleware1", "hello");
+    return NextResponse.rewrite(target, {
+      request: { headers: tmpHeaders },
+    });
+  }
+
+  // Ported from Next.js: test/e2e/middleware-rewrites/test/index.test.ts
+  // ('should rewrite to the external url for incoming data request
+  //  externally rewritten') — `_next/data/<page>.json` requests rewritten
+  // to an external host must proxy through and surface the upstream body.
+  if (url.pathname === "/data-external-rewrite") {
+    const target =
+      request.headers.get("x-middleware-test-rewrite-target") ?? "https://api.example.com/data";
+    return NextResponse.rewrite(target);
+  }
+
   if (url.pathname === "/middleware-bad-content-length") {
     const res = NextResponse.rewrite(new URL("/streaming-ssr", request.url));
     res.headers.set("content-length", "1");

--- a/tests/pages-page-data.test.ts
+++ b/tests/pages-page-data.test.ts
@@ -295,6 +295,7 @@ describe("pages page data", () => {
       gsspRes: null,
       isrRevalidateSeconds: 30,
       pageProps: { title: "hello" },
+      isFallback: false,
     });
   });
 

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -3333,6 +3333,102 @@ describe("Production server middleware (Pages Router)", () => {
   });
 
   // Ported from Next.js: test/e2e/middleware-rewrites/test/index.test.ts
+  // ('should handle middleware rewrite with body correctly').
+  // Refs #1331: POST bodies must reach the upstream when middleware
+  // externally rewrites the request.
+  it("forwards the POST body to the upstream on external middleware rewrites", async () => {
+    const { createServer: createHttpServer } = await import("node:http");
+    const upstream = createHttpServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (chunk: Buffer) => chunks.push(chunk));
+      req.on("end", () => {
+        const received = Buffer.concat(chunks);
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(received);
+      });
+    });
+
+    try {
+      await new Promise<void>((resolve) => upstream.listen(0, "127.0.0.1", resolve));
+      const addr = upstream.address();
+      if (typeof addr === "string" || addr === null) throw new Error("Expected upstream port");
+
+      const body = JSON.stringify({ hello: "world" });
+      const res = await fetch(`${prodUrl}/external-middleware-rewrite-body`, {
+        method: "POST",
+        body,
+        headers: {
+          "content-type": "application/json",
+          "x-middleware-test-rewrite-target": `http://127.0.0.1:${addr.port}/echo-body`,
+        },
+      });
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe(body);
+    } finally {
+      await new Promise<void>((resolve) => upstream.close(() => resolve()));
+    }
+  });
+
+  // Ported from Next.js: test/e2e/middleware-rewrites/test/index.test.ts
+  // ('should handle middleware rewrite with body and headers correctly').
+  // Refs #1331: `NextResponse.rewrite(url, { request: { headers } })` request
+  // header overrides must propagate to the proxied upstream request.
+  it("forwards middleware-overridden request headers on external middleware rewrites", async () => {
+    const { createServer: createHttpServer } = await import("node:http");
+    const upstream = createHttpServer((req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ headers: req.headers }));
+    });
+
+    try {
+      await new Promise<void>((resolve) => upstream.listen(0, "127.0.0.1", resolve));
+      const addr = upstream.address();
+      if (typeof addr === "string" || addr === null) throw new Error("Expected upstream port");
+
+      const res = await fetch(`${prodUrl}/external-middleware-rewrite-with-headers`, {
+        headers: {
+          "x-middleware-test-rewrite-target": `http://127.0.0.1:${addr.port}/echo-headers`,
+        },
+      });
+      expect(res.status).toBe(200);
+      const json = (await res.json()) as { headers: Record<string, string> };
+      expect(json.headers["x-hello-from-middleware1"]).toBe("hello");
+    } finally {
+      await new Promise<void>((resolve) => upstream.close(() => resolve()));
+    }
+  });
+
+  // Ported from Next.js: test/e2e/middleware-rewrites/test/index.test.ts
+  // ('should rewrite to the external url for incoming data request
+  //  externally rewritten'). Refs #1331: a `_next/data/<buildId>/<page>.json`
+  // request whose middleware rewrites to an external URL must proxy through
+  // — the data-request path is not allowed to short-circuit external rewrites.
+  it("proxies through to upstream when an external middleware rewrite hits a data request", async () => {
+    const { createServer: createHttpServer } = await import("node:http");
+    const upstream = createHttpServer((_, res) => {
+      res.writeHead(200, { "content-type": "text/html" });
+      res.end("<!doctype html><html><body>External Domain</body></html>");
+    });
+
+    try {
+      await new Promise<void>((resolve) => upstream.listen(0, "127.0.0.1", resolve));
+      const addr = upstream.address();
+      if (typeof addr === "string" || addr === null) throw new Error("Expected upstream port");
+
+      const res = await fetch(`${prodUrl}/_next/data/test-build-id/data-external-rewrite.json`, {
+        headers: {
+          "x-nextjs-data": "1",
+          "x-middleware-test-rewrite-target": `http://127.0.0.1:${addr.port}/data`,
+        },
+      });
+      expect(res.status).toBe(200);
+      expect(await res.text()).toContain("External Domain");
+    } finally {
+      await new Promise<void>((resolve) => upstream.close(() => resolve()));
+    }
+  });
+
+  // Ported from Next.js: test/e2e/middleware-rewrites/test/index.test.ts
   // https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-rewrites/test/index.test.ts
   it("preserves upstream status for external middleware rewrites in production", async () => {
     const { createServer: createHttpServer } = await import("node:http");

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -1273,16 +1273,35 @@ describe("Pages Router integration", () => {
     expect(html).toMatch(/isFallback:.*false/);
   });
 
-  it("SSR renders unlisted path with getStaticPaths fallback: true (on-demand)", async () => {
-    // In dev/SSR mode, fallback: true still renders fully (same as blocking)
-    // because data is always available via on-demand SSR.
+  it("renders fallback shell for unlisted path with getStaticPaths fallback: true", async () => {
+    // Next.js parity: when `fallback: true` and the path isn't pre-rendered,
+    // skip getStaticProps, render with `useRouter().isFallback === true`, and
+    // ship a loading shell that the client later swaps for the full data.
+    // See: .nextjs-ref/packages/next/src/server/render.tsx — `if (isSSG && !isFallback)`.
     const res = await fetch(`${baseUrl}/products/unknown`);
     expect(res.status).toBe(200);
     const html = await res.text();
-    expect(html).toMatch(/Product\s*(<!-- -->)?\s*unknown/);
-    expect(html).toMatch(/Product ID:.*unknown/);
-    // isFallback should be false since we always SSR fully
-    expect(html).toMatch(/isFallback:.*false/);
+    expect(html).toContain("Loading product...");
+    // The full-content branch must NOT render — getStaticProps was skipped.
+    expect(html).not.toMatch(/Product ID:.*unknown/);
+    const match = html.match(/__NEXT_DATA__\s*=\s*(\{.*?\})\s*[;<]/);
+    expect(match).toBeTruthy();
+    const nextData = JSON.parse(match![1]);
+    expect(nextData.isFallback).toBe(true);
+    // Empty pageProps on the fallback shell — client fetches them later.
+    expect(nextData.props).toEqual({ pageProps: {} });
+  });
+
+  it("resolves real props for the data URL of an unlisted fallback: true path", async () => {
+    // Counterpart to the fallback-shell test: the page HTML ships empty props,
+    // but the client follows up with `/_next/data/<buildId>/products/unknown.json`
+    // to fetch the actual props. That request must invoke getStaticProps.
+    const res = await fetch(`${baseUrl}/_next/data/test-build-id/products/unknown.json`, {
+      headers: { "x-nextjs-data": "1" },
+    });
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.pageProps).toMatchObject({ pid: "unknown" });
   });
 
   it("includes isFallback: false in __NEXT_DATA__", async () => {
@@ -3293,6 +3312,24 @@ describe("Production server middleware (Pages Router)", () => {
     const html = await res.text();
     // /rewritten should serve the content of /ssr page
     expect(html).toContain("Server-Side Rendered");
+  });
+
+  // Ported from Next.js: test/e2e/middleware-rewrites/test/index.test.ts
+  // ('should rewrite to fallback: true page successfully').
+  // Refs #1331: post-rewrite fallback: true must render the loading shell.
+  it("renders the loading shell when middleware/route targets an unlisted fallback: true path", async () => {
+    const res = await fetch(`${prodUrl}/products/never-built`);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    // Page renders its fallback branch (the slug is not in getStaticPaths).
+    expect(html).toContain("Loading product...");
+    // Full-data branch must not have rendered — getStaticProps was skipped.
+    expect(html).not.toMatch(/Product ID:.*never-built/);
+    const match = html.match(/__NEXT_DATA__\s*=\s*(\{.*?\})\s*[;<]/);
+    expect(match).toBeTruthy();
+    const nextData = JSON.parse(match![1]);
+    expect(nextData.isFallback).toBe(true);
+    expect(nextData.props).toEqual({ pageProps: {} });
   });
 
   // Ported from Next.js: test/e2e/middleware-rewrites/test/index.test.ts


### PR DESCRIPTION
## Summary

PR #1394 fixed the post-rewrite static-vs-dynamic priority sub-problem of #1331 and explicitly tracked `fallback: true` rewrite behaviour as a separate follow-up. This PR addresses it.

When `getStaticPaths` returns `fallback: true` and a request hits a path that isn't pre-rendered, vinext was SSRing the page fully — running `getStaticProps` and emitting `isFallback: false` in `__NEXT_DATA__`. Next.js instead ships a loading shell with empty props and `useRouter().isFallback === true`, then the client hydrates by fetching the data URL. The upstream regression test [`should rewrite to fallback: true page successfully`](https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-rewrites/test/index.test.ts) asserts `Loading...` in the SSR HTML, which vinext couldn't produce.

This change threads an `isFallback` signal through `resolvePagesPageData`, `buildPagesNextDataScript`, the Pages Router SSR context, and both the prod (`pages-server-entry.ts`) and dev (`dev-server.ts`) renderers:

- `getStaticProps` and `getServerSideProps` are skipped on the fallback render — matches Next.js [`render.tsx`'s `if (isSSG && !isFallback)`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/render.tsx) gate around `getStaticProps`.
- Data requests (`/_next/data/<buildId>/<page>.json`) still resolve real props so the client can swap in after the shell ships.
- `useRouter().isFallback` reads from the SSR context server-side and from `__NEXT_DATA__.isFallback` client-side — both flip to true on the shell render.

The previous dev-server comment that claimed Next.js dev "also renders fully" was incorrect; Next.js's [`pages-handler.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/route-modules/pages/pages-handler.ts) invokes `doRender` with `isFallback: true` for dev fallback responses, so dev now serves the shell too.

## Scope

`fallback: true` only. External URL proxying for middleware rewrites (the other #1331 follow-up) already works in current `prod-server.ts` / `deploy.ts` / `index.ts` — see the existing `preserves upstream status for external middleware rewrites in production` test.

Refs #1331

## Test plan

- [x] Updated `tests/pages-router.test.ts` "SSR renders unlisted path with getStaticPaths fallback: true" — previously documented the deviation; now asserts the loading shell, empty props, and `isFallback: true`.
- [x] Added a counterpart test that the data URL for the same unlisted path still returns real props from `getStaticProps`.
- [x] Added a production-side regression test mirroring the upstream `should rewrite to fallback: true page successfully` expectation.
- [x] `pnpm test tests/pages-router.test.ts tests/app-router.test.ts tests/middleware-runtime.test.ts tests/middleware-runtime-trailing-slash.test.ts tests/request-pipeline.test.ts tests/route-sorting.test.ts tests/routing.test.ts tests/shims.test.ts tests/deploy.test.ts` — 1998 tests pass.
- [x] `pnpm run check` — clean.