### PR TITLE
feat(config): add experimental.appShells plumbing

### DIFF
--- a/packages/vinext/src/check.ts
+++ b/packages/vinext/src/check.ts
@@ -217,6 +217,10 @@ const CONFIG_SUPPORT: Record<string, { status: Status; detail?: string }> = {
     detail:
       "not applicable; vinext uses Vite instead of SWC. A Vite-compatible polyfill solution may be explored in the future.",
   },
+  "experimental.appShells": {
+    status: "unsupported",
+    detail: "app shells not yet implemented",
+  },
   "i18n.domains": {
     status: "partial",
     detail: "supported for Pages Router; App Router unchanged",

--- a/packages/vinext/src/check.ts
+++ b/packages/vinext/src/check.ts
@@ -219,7 +219,8 @@ const CONFIG_SUPPORT: Record<string, { status: Status; detail?: string }> = {
   },
   "experimental.appShells": {
     status: "unsupported",
-    detail: "app shells not yet implemented",
+    detail:
+      "App Shell prefetching not yet implemented; requires cacheComponents and other co-flags vinext does not support",
   },
   "i18n.domains": {
     status: "partial",

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -1142,6 +1142,9 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         // because vinext is the runtime — there is no underlying Next.js
         // version to surface.
         defines["process.env.__NEXT_VERSION"] = JSON.stringify(getVinextVersion());
+        // App Shells — always false; plumbing-only flag, not yet implemented.
+        // See: https://github.com/vercel/next.js/pull/93997
+        defines["process.env.__NEXT_APP_SHELLS"] = JSON.stringify(false);
 
         // Build the shim alias map. Exact `.js` variants are included for the
         // public Next entrypoints that are file-backed in `next/package.json`.

--- a/tests/check.test.ts
+++ b/tests/check.test.ts
@@ -335,6 +335,21 @@ describe("analyzeConfig", () => {
     expect(items.find((i) => i.name === "experimental.ppr")?.status).toBe("unsupported");
   });
 
+  // Mirrors Next.js: test/e2e/app-dir/app-shells
+  it("detects experimental.appShells as unsupported", () => {
+    writeFile(
+      "next.config.mjs",
+      `export default {
+        experimental: {
+          appShells: true,
+        },
+      };`,
+    );
+
+    const items = analyzeConfig(tmpDir);
+    expect(items.find((i) => i.name === "experimental.appShells")?.status).toBe("unsupported");
+  });
+
   it("detects experimental.serverActions as supported", () => {
     writeFile(
       "next.config.mjs",
@@ -417,6 +432,7 @@ describe("analyzeConfig", () => {
     ["experimental.serverActions", "experimental", "serverActions: { allowedOrigins: [] }"],
     ["experimental.prefetchInlining", "experimental", "prefetchInlining: true"],
     ["experimental.swcEnvOptions", "experimental", 'swcEnvOptions: { mode: "usage" }'],
+    ["experimental.appShells", "experimental", "appShells: true"],
     ["i18n.domains", "i18n", "domains: []"],
   ])("detects %s via generic dot-notation handling", (name, parent, body) => {
     writeFile("next.config.mjs", `export default { ${parent}: { ${body} } };`);

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -1743,6 +1743,14 @@ describe("basePath support (Pages Router)", () => {
     expect(config.define?.[defineKey]).toBe(JSON.stringify(""));
   });
 
+  it("App Shells define is always false", async () => {
+    // Plumbing-only upstream; vinext always reports false so client gating
+    // code never trips. See issue #1405.
+    const config = server.config;
+    const defineKey = "process.env.__NEXT_APP_SHELLS";
+    expect(config.define?.[defineKey]).toBe(JSON.stringify(false));
+  });
+
   it("resolveNextConfig correctly resolves trailingSlash", async () => {
     const { resolveNextConfig } = await import("../packages/vinext/src/config/next-config.js");
 

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -1734,23 +1734,6 @@ describe("basePath support (Pages Router)", () => {
     expect(withSlash.basePath).toBe("/docs");
   });
 
-  it("basePath define is injected into client code", async () => {
-    // The plugin should set process.env.__NEXT_ROUTER_BASEPATH as a define.
-    // We test this by checking the resolved config of the current server.
-    const config = server.config;
-    // Default fixture has no basePath, so it should be ""
-    const defineKey = "process.env.__NEXT_ROUTER_BASEPATH";
-    expect(config.define?.[defineKey]).toBe(JSON.stringify(""));
-  });
-
-  it("App Shells define is always false", async () => {
-    // Plumbing-only upstream; vinext always reports false so client gating
-    // code never trips. See issue #1405.
-    const config = server.config;
-    const defineKey = "process.env.__NEXT_APP_SHELLS";
-    expect(config.define?.[defineKey]).toBe(JSON.stringify(false));
-  });
-
   it("resolveNextConfig correctly resolves trailingSlash", async () => {
     const { resolveNextConfig } = await import("../packages/vinext/src/config/next-config.js");
 
@@ -1761,6 +1744,43 @@ describe("basePath support (Pages Router)", () => {
     // With trailingSlash: true
     const withTrailing = await resolveNextConfig({ trailingSlash: true });
     expect(withTrailing.trailingSlash).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// build-time defines exposed to client code
+
+describe("build-time defines (Pages Router)", () => {
+  let server: ViteDevServer;
+
+  beforeAll(async () => {
+    const plugins: any[] = [vinext()];
+    server = await createServer({
+      root: PAGES_FIXTURE_DIR,
+      configFile: false,
+      plugins,
+      server: { port: 0 },
+      logLevel: "silent",
+    });
+
+    await server.listen();
+  });
+
+  afterAll(async () => {
+    await server?.close();
+  });
+
+  it("basePath define is injected into client code", async () => {
+    // Default fixture has no basePath, so it should be ""
+    const defineKey = "process.env.__NEXT_ROUTER_BASEPATH";
+    expect(server.config.define?.[defineKey]).toBe(JSON.stringify(""));
+  });
+
+  it("App Shells define is always false", async () => {
+    // Plumbing-only upstream; vinext always reports false so client gating
+    // code never trips. See issue #1405.
+    const defineKey = "process.env.__NEXT_APP_SHELLS";
+    expect(server.config.define?.[defineKey]).toBe(JSON.stringify(false));
   });
 });
 

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -1699,25 +1699,6 @@ describe("i18n localeDetection: false", () => {
 });
 
 describe("basePath support (Pages Router)", () => {
-  let server: ViteDevServer;
-
-  beforeAll(async () => {
-    const plugins: any[] = [vinext()];
-    server = await createServer({
-      root: PAGES_FIXTURE_DIR,
-      configFile: false,
-      plugins,
-      server: { port: 0 },
-      logLevel: "silent",
-    });
-
-    await server.listen();
-  });
-
-  afterAll(async () => {
-    await server?.close();
-  });
-
   it("resolveNextConfig correctly resolves basePath", async () => {
     const { resolveNextConfig } = await import("../packages/vinext/src/config/next-config.js");
 


### PR DESCRIPTION
Accepts `experimental.appShells` in next.config and defines `process.env.__NEXT_APP_SHELLS=false` at build time, matching Next.js PR #93997 plumbing scope. Behavorial implementation is gated on upstream co-flags that vinext does not yet support.

**Changes**
- Adds `"experimental.appShells"` to `CONFIG_SUPPORT` as `unsupported`
- Sets `__NEXT_APP_SHELLS` Vite define to `false` regardless of config value
- Tests for `vinext check` detection and Vite define injection

**Why no cross-flag validation**
Next.js requires `cacheComponents`, `prefetchInlining`, `varyParams`, `optimisticRouting`, and `cachedNavigations` — none of which vinext implements. Replicating the validation would be meaningless noise.

Fixes #1405