### PR TITLE
fix(config): warn on deprecated experimental.rootParams

### DIFF
--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -1059,6 +1059,14 @@ export async function resolveNextConfig(
     );
   }
 
+  // `next/root-params` is now stable — no longer requires an experimental flag.
+  if (experimental?.rootParams !== undefined) {
+    console.warn(
+      "[vinext] `experimental.rootParams` is no longer needed, because `next/root-params` is available by default. " +
+        "You can remove it from next.config.(js|mjs|ts).",
+    );
+  }
+
   // Warn about unsupported webpack usage. We preserve alias injection and
   // extract MDX settings, but all other webpack customization is still ignored.
   if (config.webpack !== undefined) {

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -1340,6 +1340,68 @@ describe("resolveNextConfig swcEnvOptions warning", () => {
   });
 });
 
+describe("resolveNextConfig rootParams deprecation warning", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("emits a warning when experimental.rootParams is true", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await resolveNextConfig({
+      experimental: { rootParams: true },
+    });
+
+    const rootParamsWarning = warn.mock.calls.find(
+      (call) => typeof call[0] === "string" && call[0].includes("rootParams"),
+    );
+
+    expect(rootParamsWarning).toBeDefined();
+    expect(rootParamsWarning![0]).toContain("experimental.rootParams");
+    expect(rootParamsWarning![0]).toContain("no longer needed");
+    expect(rootParamsWarning![0]).toContain("next/root-params");
+    expect(rootParamsWarning![0]).toContain("available by default");
+  });
+
+  it("emits a warning when experimental.rootParams is false", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await resolveNextConfig({
+      experimental: { rootParams: false },
+    });
+
+    const rootParamsWarning = warn.mock.calls.find(
+      (call) => typeof call[0] === "string" && call[0].includes("rootParams"),
+    );
+
+    expect(rootParamsWarning).toBeDefined();
+  });
+
+  it("does not warn when experimental.rootParams is not set", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await resolveNextConfig({
+      experimental: {},
+    });
+
+    const rootParamsWarning = warn.mock.calls.find(
+      (call) => typeof call[0] === "string" && call[0].includes("rootParams"),
+    );
+    expect(rootParamsWarning).toBeUndefined();
+  });
+
+  it("does not warn when experimental is not set", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await resolveNextConfig({});
+
+    const rootParamsWarning = warn.mock.calls.find(
+      (call) => typeof call[0] === "string" && call[0].includes("rootParams"),
+    );
+    expect(rootParamsWarning).toBeUndefined();
+  });
+});
+
 describe("resolveNextConfig cacheHandler", () => {
   it("resolves file:// URLs to filesystem paths", async () => {
     const resolved = await resolveNextConfig({


### PR DESCRIPTION
`next/root-params` has been stable since Next.js stabilized the feature upstream ([vercel/next.js@079df0f](https://github.com/vercel/next.js/commit/079df0f6f4bb242cd92b2c64c4a76d10986373ac)).

- Emit a deprecation warning when users still set `experimental.rootParams` in `next.config`
- Matches Next.js upstream wording for parity

Closes #1325
