### PR TITLE
feat: add disabled ClientReuseManifest protocol

### DIFF
--- a/packages/vinext/src/server/app-rsc-request-normalization.ts
+++ b/packages/vinext/src/server/app-rsc-request-normalization.ts
@@ -3,10 +3,15 @@ import { normalizePathnameForRouteMatchStrict } from "../routing/utils.js";
 import { guardProtocolRelativeUrl } from "./request-pipeline.js";
 import { hasBasePath, stripBasePath } from "../utils/base-path.js";
 import {
+  VINEXT_CLIENT_REUSE_MANIFEST_HEADER,
   VINEXT_INTERCEPTION_CONTEXT_HEADER,
   VINEXT_MOUNTED_SLOTS_HEADER,
   VINEXT_RSC_RENDER_MODE_HEADER,
 } from "./headers.js";
+import {
+  parseClientReuseManifestHeader,
+  type ClientReuseManifestParseResult,
+} from "./client-reuse-manifest.js";
 import { normalizeMountedSlotsHeader } from "./app-mounted-slots-header.js";
 import { stripRscSuffix } from "./app-rsc-cache-busting.js";
 import {
@@ -33,6 +38,8 @@ export type NormalizedRscRequest = {
   mountedSlotsHeader: string | null;
   /** Semantic RSC payload mode. HTML requests always normalize to "navigation". */
   renderMode: AppRscRenderMode;
+  /** Disabled ClientReuseManifest hint. Never authorizes skip transport in this stage. */
+  clientReuseManifest: ClientReuseManifestParseResult;
 };
 
 /**
@@ -59,6 +66,7 @@ export type NormalizedRscRequest = {
  *   8. Sanitize X-Vinext-Interception-Context — strip null bytes (header injection)
  *   9. Normalize x-vinext-mounted-slots — dedup and sort for canonical cache keys
  *   10. Read semantic render mode for refresh/action payload rendering
+ *   11. Parse disabled ClientReuseManifest hints on canonical RSC payload requests
  *
  * @returns A 400 or 404 Response for invalid or out-of-scope inputs,
  *          or a NormalizedRscRequest for valid requests.
@@ -115,8 +123,12 @@ export function normalizeRscRequest(
   const renderMode = isRscRequest
     ? parseAppRscRenderMode(request.headers.get(VINEXT_RSC_RENDER_MODE_HEADER))
     : APP_RSC_RENDER_MODE_NAVIGATION;
+  const clientReuseManifest = isRscRequest
+    ? parseClientReuseManifestHeader(request.headers.get(VINEXT_CLIENT_REUSE_MANIFEST_HEADER))
+    : ({ kind: "absent" } satisfies ClientReuseManifestParseResult);
 
   return {
+    clientReuseManifest,
     url,
     pathname,
     cleanPathname,

--- a/packages/vinext/src/server/client-reuse-manifest.ts
+++ b/packages/vinext/src/server/client-reuse-manifest.ts
@@ -97,6 +97,8 @@ export type ClientReuseManifestRejectionCode =
   | "SKIP_VISIBLE_COMMIT_VERSION_INVALID"
   | "SKIP_VISIBLE_COMMIT_VERSION_MISMATCH";
 
+export type ClientReuseManifestDispositionCode = "SKIP_MODEL_DISABLED";
+
 export type ClientReuseManifestTraceFieldValue =
   | string
   | number
@@ -119,7 +121,7 @@ export type ClientReuseManifestEntryRejection = ClientReuseManifestRejection &
   }>;
 
 export type ClientReuseManifestSkipDisposition = Readonly<{
-  code: "SKIP_MODEL_DISABLED";
+  code: ClientReuseManifestDispositionCode;
   enabled: false;
   mode: "renderAndSend";
 }>;
@@ -141,6 +143,10 @@ type ParseClientReuseManifestOptions = Readonly<{
 
 const HASH_DIGEST_PATTERN = /^[0-9a-z]+$/;
 const textEncoder = new TextEncoder();
+
+type ParseReplayWindowResult =
+  | Readonly<{ kind: "parsed"; replayWindow: ClientReuseManifestReplayWindow }>
+  | Readonly<{ kind: "rejected"; rejection: ClientReuseManifestRejection }>;
 
 function createRejection(
   code: ClientReuseManifestRejectionCode,
@@ -183,11 +189,10 @@ function createCanonicalWireEntries(
     }
   }
 
-  return Array.from(entriesById.values())
-    .sort(compareManifestEntries)
-    .map((entry) => ({ ...entry }));
+  return Array.from(entriesById.values()).sort(compareManifestEntries);
 }
 
+// The manifest byte budget is enforced once at the untrusted header boundary.
 function countUtf8Bytes(input: string): number {
   return textEncoder.encode(input).length;
 }
@@ -196,12 +201,12 @@ function isVisibleCommitVersion(value: unknown): value is number {
   return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
 }
 
-function parseReplayWindow(
-  value: unknown,
-  visibleCommitVersion: number,
-): ClientReuseManifestReplayWindow | ClientReuseManifestRejection {
+function parseReplayWindow(value: unknown, visibleCommitVersion: number): ParseReplayWindowResult {
   if (!isUnknownRecord(value)) {
-    return createRejection("SKIP_REPLAY_WINDOW_INVALID", { field: "replayWindow" });
+    return {
+      kind: "rejected",
+      rejection: createRejection("SKIP_REPLAY_WINDOW_INVALID", { field: "replayWindow" }),
+    };
   }
 
   const validFromVisibleCommitVersion = value.validFromVisibleCommitVersion;
@@ -213,20 +218,26 @@ function parseReplayWindow(
     visibleCommitVersion < validFromVisibleCommitVersion ||
     visibleCommitVersion > validUntilVisibleCommitVersion
   ) {
-    return createRejection("SKIP_REPLAY_WINDOW_INVALID", {
-      validFromVisibleCommitVersion: isVisibleCommitVersion(validFromVisibleCommitVersion)
-        ? validFromVisibleCommitVersion
-        : null,
-      validUntilVisibleCommitVersion: isVisibleCommitVersion(validUntilVisibleCommitVersion)
-        ? validUntilVisibleCommitVersion
-        : null,
-      visibleCommitVersion,
-    });
+    return {
+      kind: "rejected",
+      rejection: createRejection("SKIP_REPLAY_WINDOW_INVALID", {
+        validFromVisibleCommitVersion: isVisibleCommitVersion(validFromVisibleCommitVersion)
+          ? validFromVisibleCommitVersion
+          : null,
+        validUntilVisibleCommitVersion: isVisibleCommitVersion(validUntilVisibleCommitVersion)
+          ? validUntilVisibleCommitVersion
+          : null,
+        visibleCommitVersion,
+      }),
+    };
   }
 
   return {
-    validFromVisibleCommitVersion,
-    validUntilVisibleCommitVersion,
+    kind: "parsed",
+    replayWindow: {
+      validFromVisibleCommitVersion,
+      validUntilVisibleCommitVersion,
+    },
   };
 }
 
@@ -400,10 +411,11 @@ export function parseClientReuseManifestHeader(
     });
   }
 
-  const replayWindow = parseReplayWindow(decoded.replayWindow, visibleCommitVersion);
-  if ("code" in replayWindow) {
-    return { kind: "rejected", rejection: replayWindow };
+  const replayWindowResult = parseReplayWindow(decoded.replayWindow, visibleCommitVersion);
+  if (replayWindowResult.kind === "rejected") {
+    return { kind: "rejected", rejection: replayWindowResult.rejection };
   }
+  const { replayWindow } = replayWindowResult;
   if (!currentCommitVersionMatchesReplayWindow(options.currentVisibleCommitVersion, replayWindow)) {
     return rejectManifest("SKIP_VISIBLE_COMMIT_VERSION_MISMATCH", {
       currentVisibleCommitVersion: options.currentVisibleCommitVersion ?? null,

--- a/packages/vinext/src/server/client-reuse-manifest.ts
+++ b/packages/vinext/src/server/client-reuse-manifest.ts
@@ -61,6 +61,8 @@ export type ClientReuseManifest = Readonly<{
   visibleCommitVersion: number;
 }>;
 
+// Wire manifests preserve client-declared private entries; parsing decides which
+// entries can participate in future reuse.
 type ClientReuseManifestWire = Readonly<{
   entries: readonly ClientReuseManifestWireEntry[];
   hashAlgorithm: ClientReuseManifestHashAlgorithm;
@@ -87,7 +89,6 @@ export type ClientReuseManifestRejectionCode =
   | "SKIP_MANIFEST_MALFORMED"
   | "SKIP_MANIFEST_SCHEMA_UNSUPPORTED"
   | "SKIP_MANIFEST_TOO_LARGE"
-  | "SKIP_MODEL_DISABLED"
   | "SKIP_PRIVATE_ENTRY"
   | "SKIP_REPLAY_WINDOW_INVALID"
   | "SKIP_UNKNOWN_ENTRY"
@@ -139,6 +140,7 @@ type ParseClientReuseManifestOptions = Readonly<{
 }>;
 
 const HASH_DIGEST_PATTERN = /^[0-9a-z]+$/;
+const textEncoder = new TextEncoder();
 
 function createRejection(
   code: ClientReuseManifestRejectionCode,
@@ -172,7 +174,7 @@ function compareManifestEntries(
 }
 
 function countUtf8Bytes(input: string): number {
-  return new TextEncoder().encode(input).length;
+  return textEncoder.encode(input).length;
 }
 
 function isVisibleCommitVersion(value: unknown): value is number {
@@ -414,6 +416,8 @@ export function parseClientReuseManifestHeader(
   for (let index = 0; index < entriesValue.length; index++) {
     const value = entriesValue[index];
     if (isUnknownRecord(value) && typeof value.id === "string") {
+      // <= rejects both out-of-order and duplicate IDs; malformed entries are
+      // rejected below and cannot advance the last valid ID checkpoint.
       if (previousEntryId !== null && value.id <= previousEntryId) {
         return rejectManifest("SKIP_ENTRY_ORDER_NON_CANONICAL", {
           entryIdHash: createClientReusePayloadHash(value.id),

--- a/packages/vinext/src/server/client-reuse-manifest.ts
+++ b/packages/vinext/src/server/client-reuse-manifest.ts
@@ -179,7 +179,7 @@ function countUtf8Bytes(input: string): number {
 }
 
 function isVisibleCommitVersion(value: unknown): value is number {
-  return typeof value === "number" && Number.isInteger(value) && value >= 0;
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
 }
 
 function parseReplayWindow(

--- a/packages/vinext/src/server/client-reuse-manifest.ts
+++ b/packages/vinext/src/server/client-reuse-manifest.ts
@@ -61,8 +61,8 @@ export type ClientReuseManifest = Readonly<{
   visibleCommitVersion: number;
 }>;
 
-// Wire manifests preserve client-declared private entries; parsing decides which
-// entries can participate in future reuse.
+// Internal: createClientReuseManifest returns wire shape while parsing decides
+// which client-declared entries can participate in future reuse.
 type ClientReuseManifestWire = Readonly<{
   entries: readonly ClientReuseManifestWireEntry[];
   hashAlgorithm: ClientReuseManifestHashAlgorithm;
@@ -171,6 +171,21 @@ function compareManifestEntries(
   if (left.id < right.id) return -1;
   if (left.id > right.id) return 1;
   return 0;
+}
+
+function createCanonicalWireEntries(
+  entries: readonly ClientReuseManifestWireEntry[],
+): ClientReuseManifestWireEntry[] {
+  const entriesById = new Map<string, ClientReuseManifestWireEntry>();
+  for (const entry of entries) {
+    if (!entriesById.has(entry.id)) {
+      entriesById.set(entry.id, entry);
+    }
+  }
+
+  return Array.from(entriesById.values())
+    .sort(compareManifestEntries)
+    .map((entry) => ({ ...entry }));
 }
 
 function countUtf8Bytes(input: string): number {
@@ -324,7 +339,7 @@ export function createClientReuseManifest(
     } satisfies ClientReuseManifestReplayWindow);
 
   return {
-    entries: [...input.entries].sort(compareManifestEntries).map((entry) => ({ ...entry })),
+    entries: createCanonicalWireEntries(input.entries),
     hashAlgorithm: CLIENT_REUSE_MANIFEST_HASH_ALGORITHM,
     replayWindow,
     schemaVersion: CLIENT_REUSE_MANIFEST_SCHEMA_VERSION,

--- a/packages/vinext/src/server/client-reuse-manifest.ts
+++ b/packages/vinext/src/server/client-reuse-manifest.ts
@@ -431,8 +431,10 @@ export function parseClientReuseManifestHeader(
   for (let index = 0; index < entriesValue.length; index++) {
     const value = entriesValue[index];
     if (isUnknownRecord(value) && typeof value.id === "string") {
-      // <= rejects both out-of-order and duplicate IDs; malformed entries are
-      // rejected below and cannot advance the last valid ID checkpoint.
+      // Canonical ordering is enforced over entries with string IDs. Malformed
+      // entries cannot advance previousEntryId, so interleaving them cannot hide
+      // an ordering violation between valid checkpoints. <= rejects both
+      // out-of-order and duplicate IDs.
       if (previousEntryId !== null && value.id <= previousEntryId) {
         return rejectManifest("SKIP_ENTRY_ORDER_NON_CANONICAL", {
           entryIdHash: createClientReusePayloadHash(value.id),

--- a/packages/vinext/src/server/client-reuse-manifest.ts
+++ b/packages/vinext/src/server/client-reuse-manifest.ts
@@ -1,0 +1,453 @@
+import {
+  parseArtifactCompatibilityEnvelope,
+  type ArtifactCompatibilityEnvelope,
+} from "./artifact-compatibility.js";
+import { AppElementsWire } from "./app-elements-wire.js";
+import { fnv1a64 } from "../utils/hash.js";
+
+export const CLIENT_REUSE_MANIFEST_SCHEMA_VERSION = 1;
+export type ClientReuseManifestSchemaVersion = 1;
+
+export const CLIENT_REUSE_MANIFEST_HASH_ALGORITHM = "fnv1a64";
+export type ClientReuseManifestHashAlgorithm = typeof CLIENT_REUSE_MANIFEST_HASH_ALGORITHM;
+
+type ClientReuseManifestLimits = Readonly<{
+  maxEntryCount: number;
+  maxEntryIdLength: number;
+  maxManifestBytes: number;
+  maxPayloadHashLength: number;
+  maxVariantCacheKeyLength: number;
+}>;
+
+export const DEFAULT_CLIENT_REUSE_MANIFEST_LIMITS = {
+  maxEntryCount: 64,
+  maxEntryIdLength: 512,
+  maxManifestBytes: 4096,
+  maxPayloadHashLength: 16,
+  maxVariantCacheKeyLength: 256,
+} satisfies ClientReuseManifestLimits;
+
+export type ClientReuseManifestEntryKind = "layout" | "page" | "route" | "slot" | "template";
+type ClientReuseManifestEntryPrivacy = "private" | "public";
+
+export type ClientReuseManifestReplayWindow = Readonly<{
+  validFromVisibleCommitVersion: number;
+  validUntilVisibleCommitVersion: number;
+}>;
+
+export type ClientReuseManifestEntry = Readonly<{
+  artifactCompatibility: ArtifactCompatibilityEnvelope;
+  id: string;
+  kind: ClientReuseManifestEntryKind;
+  payloadHash: string;
+  privacy: "public";
+  variantCacheKey: string;
+}>;
+
+type ClientReuseManifestWireEntry = Readonly<{
+  artifactCompatibility: ArtifactCompatibilityEnvelope;
+  id: string;
+  payloadHash: string;
+  privacy: ClientReuseManifestEntryPrivacy;
+  variantCacheKey: string;
+}>;
+
+export type ClientReuseManifest = Readonly<{
+  entries: readonly ClientReuseManifestEntry[];
+  hashAlgorithm: ClientReuseManifestHashAlgorithm;
+  replayWindow: ClientReuseManifestReplayWindow;
+  schemaVersion: ClientReuseManifestSchemaVersion;
+  visibleCommitVersion: number;
+}>;
+
+type ClientReuseManifestWire = Readonly<{
+  entries: readonly ClientReuseManifestWireEntry[];
+  hashAlgorithm: ClientReuseManifestHashAlgorithm;
+  replayWindow: ClientReuseManifestReplayWindow;
+  schemaVersion: ClientReuseManifestSchemaVersion;
+  visibleCommitVersion: number;
+}>;
+
+type CreateClientReuseManifestInput = Readonly<{
+  entries: readonly ClientReuseManifestWireEntry[];
+  replayWindow?: ClientReuseManifestReplayWindow;
+  visibleCommitVersion: number;
+}>;
+
+export type ClientReuseManifestRejectionCode =
+  | "SKIP_ARTIFACT_COMPATIBILITY_INVALID"
+  | "SKIP_ENTRY_COUNT_EXCEEDED"
+  | "SKIP_ENTRY_HASH_INVALID"
+  | "SKIP_ENTRY_ID_INVALID"
+  | "SKIP_ENTRY_ID_TOO_LONG"
+  | "SKIP_ENTRY_MALFORMED"
+  | "SKIP_ENTRY_ORDER_NON_CANONICAL"
+  | "SKIP_HASH_ALGORITHM_UNSUPPORTED"
+  | "SKIP_MANIFEST_MALFORMED"
+  | "SKIP_MANIFEST_SCHEMA_UNSUPPORTED"
+  | "SKIP_MANIFEST_TOO_LARGE"
+  | "SKIP_MODEL_DISABLED"
+  | "SKIP_PRIVATE_ENTRY"
+  | "SKIP_REPLAY_WINDOW_INVALID"
+  | "SKIP_UNKNOWN_ENTRY"
+  | "SKIP_VARIANT_CACHE_KEY_INVALID"
+  | "SKIP_VARIANT_CACHE_KEY_TOO_LONG"
+  | "SKIP_VISIBLE_COMMIT_VERSION_INVALID"
+  | "SKIP_VISIBLE_COMMIT_VERSION_MISMATCH";
+
+export type ClientReuseManifestTraceFieldValue =
+  | string
+  | number
+  | boolean
+  | null
+  | readonly string[];
+
+export type ClientReuseManifestTraceFields = Readonly<
+  Record<string, ClientReuseManifestTraceFieldValue>
+>;
+
+export type ClientReuseManifestRejection = Readonly<{
+  code: ClientReuseManifestRejectionCode;
+  fields: ClientReuseManifestTraceFields;
+}>;
+
+export type ClientReuseManifestEntryRejection = ClientReuseManifestRejection &
+  Readonly<{
+    entryId: string | null;
+  }>;
+
+export type ClientReuseManifestSkipDisposition = Readonly<{
+  code: "SKIP_MODEL_DISABLED";
+  enabled: false;
+  mode: "renderAndSend";
+}>;
+
+export type ClientReuseManifestParseResult =
+  | Readonly<{ kind: "absent" }>
+  | Readonly<{ kind: "rejected"; rejection: ClientReuseManifestRejection }>
+  | Readonly<{
+      entryRejections: readonly ClientReuseManifestEntryRejection[];
+      kind: "parsed";
+      manifest: ClientReuseManifest;
+      skipDisposition: ClientReuseManifestSkipDisposition;
+    }>;
+
+type ParseClientReuseManifestOptions = Readonly<{
+  currentVisibleCommitVersion?: number;
+  limits?: ClientReuseManifestLimits;
+}>;
+
+const HASH_DIGEST_PATTERN = /^[0-9a-z]+$/;
+
+function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function createRejection(
+  code: ClientReuseManifestRejectionCode,
+  fields: ClientReuseManifestTraceFields = {},
+): ClientReuseManifestRejection {
+  return { code, fields };
+}
+
+function rejectManifest(
+  code: ClientReuseManifestRejectionCode,
+  fields: ClientReuseManifestTraceFields = {},
+): ClientReuseManifestParseResult {
+  return { kind: "rejected", rejection: createRejection(code, fields) };
+}
+
+function rejectEntry(
+  code: ClientReuseManifestRejectionCode,
+  entryId: string | null,
+  fields: ClientReuseManifestTraceFields = {},
+): ClientReuseManifestEntryRejection {
+  return { code, entryId, fields };
+}
+
+function compareManifestEntries(
+  left: Pick<ClientReuseManifestWireEntry, "id">,
+  right: Pick<ClientReuseManifestWireEntry, "id">,
+): number {
+  if (left.id < right.id) return -1;
+  if (left.id > right.id) return 1;
+  return 0;
+}
+
+function countUtf8Bytes(input: string): number {
+  return new TextEncoder().encode(input).length;
+}
+
+function isVisibleCommitVersion(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0;
+}
+
+function parseReplayWindow(
+  value: unknown,
+  visibleCommitVersion: number,
+): ClientReuseManifestReplayWindow | ClientReuseManifestRejection {
+  if (!isRecord(value)) {
+    return createRejection("SKIP_REPLAY_WINDOW_INVALID", { field: "replayWindow" });
+  }
+
+  const validFromVisibleCommitVersion = value.validFromVisibleCommitVersion;
+  const validUntilVisibleCommitVersion = value.validUntilVisibleCommitVersion;
+  if (
+    !isVisibleCommitVersion(validFromVisibleCommitVersion) ||
+    !isVisibleCommitVersion(validUntilVisibleCommitVersion) ||
+    validFromVisibleCommitVersion > validUntilVisibleCommitVersion ||
+    visibleCommitVersion < validFromVisibleCommitVersion ||
+    visibleCommitVersion > validUntilVisibleCommitVersion
+  ) {
+    return createRejection("SKIP_REPLAY_WINDOW_INVALID", {
+      validFromVisibleCommitVersion: isVisibleCommitVersion(validFromVisibleCommitVersion)
+        ? validFromVisibleCommitVersion
+        : null,
+      validUntilVisibleCommitVersion: isVisibleCommitVersion(validUntilVisibleCommitVersion)
+        ? validUntilVisibleCommitVersion
+        : null,
+      visibleCommitVersion,
+    });
+  }
+
+  return {
+    validFromVisibleCommitVersion,
+    validUntilVisibleCommitVersion,
+  };
+}
+
+function currentCommitVersionMatchesReplayWindow(
+  currentVisibleCommitVersion: number | undefined,
+  replayWindow: ClientReuseManifestReplayWindow,
+): boolean {
+  if (currentVisibleCommitVersion === undefined) return true;
+  return (
+    currentVisibleCommitVersion >= replayWindow.validFromVisibleCommitVersion &&
+    currentVisibleCommitVersion <= replayWindow.validUntilVisibleCommitVersion
+  );
+}
+
+function parseEntryKind(id: string): ClientReuseManifestEntryKind | null {
+  const parsed = AppElementsWire.parseElementKey(id);
+  if (parsed === null) return null;
+  return parsed.kind;
+}
+
+function isValidPayloadHash(value: unknown, limits: ClientReuseManifestLimits): value is string {
+  return (
+    typeof value === "string" &&
+    value.length > 0 &&
+    value.length <= limits.maxPayloadHashLength &&
+    HASH_DIGEST_PATTERN.test(value)
+  );
+}
+
+function parseManifestEntry(
+  value: unknown,
+  limits: ClientReuseManifestLimits,
+  index: number,
+): ClientReuseManifestEntry | ClientReuseManifestEntryRejection {
+  if (!isRecord(value)) {
+    return rejectEntry("SKIP_ENTRY_MALFORMED", null, { index });
+  }
+
+  const id = value.id;
+  if (typeof id !== "string" || id.length === 0) {
+    return rejectEntry("SKIP_ENTRY_ID_INVALID", null, { index });
+  }
+  if (id.length > limits.maxEntryIdLength) {
+    return rejectEntry("SKIP_ENTRY_ID_TOO_LONG", id, {
+      idHash: createClientReusePayloadHash(id),
+      maxEntryIdLength: limits.maxEntryIdLength,
+    });
+  }
+
+  const kind = parseEntryKind(id);
+  if (kind === null) {
+    return rejectEntry("SKIP_UNKNOWN_ENTRY", id, { idHash: createClientReusePayloadHash(id) });
+  }
+
+  const privacy = value.privacy;
+  if (privacy === "private") {
+    return rejectEntry("SKIP_PRIVATE_ENTRY", id, { privacy });
+  }
+  if (privacy !== "public") {
+    return rejectEntry("SKIP_ENTRY_MALFORMED", id, { field: "privacy" });
+  }
+
+  const payloadHash = value.payloadHash;
+  if (!isValidPayloadHash(payloadHash, limits)) {
+    return rejectEntry("SKIP_ENTRY_HASH_INVALID", id, {
+      maxPayloadHashLength: limits.maxPayloadHashLength,
+    });
+  }
+
+  const variantCacheKey = value.variantCacheKey;
+  if (typeof variantCacheKey !== "string" || variantCacheKey.length === 0) {
+    return rejectEntry("SKIP_VARIANT_CACHE_KEY_INVALID", id, { field: "variantCacheKey" });
+  }
+  if (variantCacheKey.length > limits.maxVariantCacheKeyLength) {
+    return rejectEntry("SKIP_VARIANT_CACHE_KEY_TOO_LONG", id, {
+      maxVariantCacheKeyLength: limits.maxVariantCacheKeyLength,
+      variantCacheKeyHash: createClientReusePayloadHash(variantCacheKey),
+    });
+  }
+
+  const artifactCompatibility = parseArtifactCompatibilityEnvelope(value.artifactCompatibility);
+  if (artifactCompatibility === null) {
+    return rejectEntry("SKIP_ARTIFACT_COMPATIBILITY_INVALID", id, {
+      field: "artifactCompatibility",
+    });
+  }
+
+  return {
+    artifactCompatibility,
+    id,
+    kind,
+    payloadHash,
+    privacy,
+    variantCacheKey,
+  };
+}
+
+export function createClientReusePayloadHash(input: string): string {
+  return fnv1a64(input);
+}
+
+export function createClientReuseManifest(
+  input: CreateClientReuseManifestInput,
+): ClientReuseManifestWire {
+  const replayWindow =
+    input.replayWindow ??
+    ({
+      validFromVisibleCommitVersion: input.visibleCommitVersion,
+      validUntilVisibleCommitVersion: input.visibleCommitVersion,
+    } satisfies ClientReuseManifestReplayWindow);
+
+  return {
+    entries: [...input.entries].sort(compareManifestEntries).map((entry) => ({ ...entry })),
+    hashAlgorithm: CLIENT_REUSE_MANIFEST_HASH_ALGORITHM,
+    replayWindow,
+    schemaVersion: CLIENT_REUSE_MANIFEST_SCHEMA_VERSION,
+    visibleCommitVersion: input.visibleCommitVersion,
+  };
+}
+
+export function serializeClientReuseManifest(input: CreateClientReuseManifestInput): string {
+  return JSON.stringify(createClientReuseManifest(input));
+}
+
+export function parseClientReuseManifestHeader(
+  rawHeader: string | null | undefined,
+  options: ParseClientReuseManifestOptions = {},
+): ClientReuseManifestParseResult {
+  const header = rawHeader?.trim();
+  if (!header) return { kind: "absent" };
+
+  const limits = options.limits ?? DEFAULT_CLIENT_REUSE_MANIFEST_LIMITS;
+  const manifestBytes = countUtf8Bytes(header);
+  if (manifestBytes > limits.maxManifestBytes) {
+    return rejectManifest("SKIP_MANIFEST_TOO_LARGE", {
+      manifestBytes,
+      maxManifestBytes: limits.maxManifestBytes,
+    });
+  }
+
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(header);
+  } catch {
+    return rejectManifest("SKIP_MANIFEST_MALFORMED");
+  }
+
+  if (!isRecord(decoded)) {
+    return rejectManifest("SKIP_MANIFEST_MALFORMED", { field: "manifest" });
+  }
+
+  if (decoded.schemaVersion !== CLIENT_REUSE_MANIFEST_SCHEMA_VERSION) {
+    return rejectManifest("SKIP_MANIFEST_SCHEMA_UNSUPPORTED", {
+      schemaVersion:
+        typeof decoded.schemaVersion === "number" || typeof decoded.schemaVersion === "string"
+          ? decoded.schemaVersion
+          : null,
+    });
+  }
+
+  if (decoded.hashAlgorithm !== CLIENT_REUSE_MANIFEST_HASH_ALGORITHM) {
+    return rejectManifest("SKIP_HASH_ALGORITHM_UNSUPPORTED", {
+      hashAlgorithm: typeof decoded.hashAlgorithm === "string" ? decoded.hashAlgorithm : null,
+    });
+  }
+
+  const visibleCommitVersion = decoded.visibleCommitVersion;
+  if (!isVisibleCommitVersion(visibleCommitVersion)) {
+    return rejectManifest("SKIP_VISIBLE_COMMIT_VERSION_INVALID", {
+      visibleCommitVersion: null,
+    });
+  }
+
+  const replayWindow = parseReplayWindow(decoded.replayWindow, visibleCommitVersion);
+  if ("code" in replayWindow) {
+    return { kind: "rejected", rejection: replayWindow };
+  }
+  if (!currentCommitVersionMatchesReplayWindow(options.currentVisibleCommitVersion, replayWindow)) {
+    return rejectManifest("SKIP_VISIBLE_COMMIT_VERSION_MISMATCH", {
+      currentVisibleCommitVersion: options.currentVisibleCommitVersion ?? null,
+      validFromVisibleCommitVersion: replayWindow.validFromVisibleCommitVersion,
+      validUntilVisibleCommitVersion: replayWindow.validUntilVisibleCommitVersion,
+      visibleCommitVersion,
+    });
+  }
+
+  const entriesValue = decoded.entries;
+  if (!Array.isArray(entriesValue)) {
+    return rejectManifest("SKIP_MANIFEST_MALFORMED", { field: "entries" });
+  }
+  if (entriesValue.length > limits.maxEntryCount) {
+    return rejectManifest("SKIP_ENTRY_COUNT_EXCEEDED", {
+      entryCount: entriesValue.length,
+      maxEntryCount: limits.maxEntryCount,
+    });
+  }
+
+  const entries: ClientReuseManifestEntry[] = [];
+  const entryRejections: ClientReuseManifestEntryRejection[] = [];
+  let previousEntryId: string | null = null;
+
+  for (let index = 0; index < entriesValue.length; index++) {
+    const value = entriesValue[index];
+    if (isRecord(value) && typeof value.id === "string") {
+      if (previousEntryId !== null && value.id <= previousEntryId) {
+        return rejectManifest("SKIP_ENTRY_ORDER_NON_CANONICAL", {
+          entryIdHash: createClientReusePayloadHash(value.id),
+          previousEntryIdHash: createClientReusePayloadHash(previousEntryId),
+        });
+      }
+      previousEntryId = value.id;
+    }
+
+    const parsedEntry = parseManifestEntry(value, limits, index);
+    if ("code" in parsedEntry) {
+      entryRejections.push(parsedEntry);
+    } else {
+      entries.push(parsedEntry);
+    }
+  }
+
+  return {
+    entryRejections,
+    kind: "parsed",
+    manifest: {
+      entries,
+      hashAlgorithm: CLIENT_REUSE_MANIFEST_HASH_ALGORITHM,
+      replayWindow,
+      schemaVersion: CLIENT_REUSE_MANIFEST_SCHEMA_VERSION,
+      visibleCommitVersion,
+    },
+    skipDisposition: {
+      code: "SKIP_MODEL_DISABLED",
+      enabled: false,
+      mode: "renderAndSend",
+    },
+  };
+}

--- a/packages/vinext/src/server/client-reuse-manifest.ts
+++ b/packages/vinext/src/server/client-reuse-manifest.ts
@@ -4,6 +4,7 @@ import {
 } from "./artifact-compatibility.js";
 import { AppElementsWire } from "./app-elements-wire.js";
 import { fnv1a64 } from "../utils/hash.js";
+import { isUnknownRecord } from "../utils/record.js";
 
 export const CLIENT_REUSE_MANIFEST_SCHEMA_VERSION = 1;
 export type ClientReuseManifestSchemaVersion = 1;
@@ -139,10 +140,6 @@ type ParseClientReuseManifestOptions = Readonly<{
 
 const HASH_DIGEST_PATTERN = /^[0-9a-z]+$/;
 
-function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
 function createRejection(
   code: ClientReuseManifestRejectionCode,
   fields: ClientReuseManifestTraceFields = {},
@@ -186,7 +183,7 @@ function parseReplayWindow(
   value: unknown,
   visibleCommitVersion: number,
 ): ClientReuseManifestReplayWindow | ClientReuseManifestRejection {
-  if (!isRecord(value)) {
+  if (!isUnknownRecord(value)) {
     return createRejection("SKIP_REPLAY_WINDOW_INVALID", { field: "replayWindow" });
   }
 
@@ -247,7 +244,7 @@ function parseManifestEntry(
   limits: ClientReuseManifestLimits,
   index: number,
 ): ClientReuseManifestEntry | ClientReuseManifestEntryRejection {
-  if (!isRecord(value)) {
+  if (!isUnknownRecord(value)) {
     return rejectEntry("SKIP_ENTRY_MALFORMED", null, { index });
   }
 
@@ -360,7 +357,7 @@ export function parseClientReuseManifestHeader(
     return rejectManifest("SKIP_MANIFEST_MALFORMED");
   }
 
-  if (!isRecord(decoded)) {
+  if (!isUnknownRecord(decoded)) {
     return rejectManifest("SKIP_MANIFEST_MALFORMED", { field: "manifest" });
   }
 
@@ -416,7 +413,7 @@ export function parseClientReuseManifestHeader(
 
   for (let index = 0; index < entriesValue.length; index++) {
     const value = entriesValue[index];
-    if (isRecord(value) && typeof value.id === "string") {
+    if (isUnknownRecord(value) && typeof value.id === "string") {
       if (previousEntryId !== null && value.id <= previousEntryId) {
         return rejectManifest("SKIP_ENTRY_ORDER_NON_CANONICAL", {
           entryIdHash: createClientReusePayloadHash(value.id),

--- a/packages/vinext/src/server/headers.ts
+++ b/packages/vinext/src/server/headers.ts
@@ -46,6 +46,9 @@ export const VINEXT_INTERCEPTION_CONTEXT_HEADER = "X-Vinext-Interception-Context
 /** RSC render mode (e.g. "navigation", "prefetch"). */
 export const VINEXT_RSC_RENDER_MODE_HEADER = "X-Vinext-Rsc-Render-Mode";
 
+/** Disabled-by-default client hint describing already-held App Router payload entries. */
+export const VINEXT_CLIENT_REUSE_MANIFEST_HEADER = "X-Vinext-Client-Reuse-Manifest";
+
 /**
  * Side-channel signal that an RSC response (HTTP 200) encodes a `redirect()`
  * thrown during render. The header value is the redirect target (path-only

--- a/tests/app-rsc-request-normalization.test.ts
+++ b/tests/app-rsc-request-normalization.test.ts
@@ -22,6 +22,12 @@ import {
   APP_RSC_RENDER_MODE_NAVIGATION,
   APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI,
 } from "../packages/vinext/src/server/app-rsc-render-mode.js";
+import {
+  createClientReuseManifest,
+  createClientReusePayloadHash,
+} from "../packages/vinext/src/server/client-reuse-manifest.js";
+import { createArtifactCompatibilityEnvelope } from "../packages/vinext/src/server/artifact-compatibility.js";
+import { VINEXT_CLIENT_REUSE_MANIFEST_HEADER } from "../packages/vinext/src/server/headers.js";
 
 function req(path: string, headers: Record<string, string> = {}): Request {
   return new Request(`http://localhost${path}`, { headers });
@@ -332,6 +338,69 @@ describe("normalizeRscRequest — mounted slots normalization", () => {
     expect(refresh.renderMode).toBe(APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI);
     expect(normal.renderMode).toBe(APP_RSC_RENDER_MODE_NAVIGATION);
     expect(html.renderMode).toBe(APP_RSC_RENDER_MODE_NAVIGATION);
+  });
+});
+
+// ── Client reuse manifest normalization ─────────────────────────────────────
+
+describe("normalizeRscRequest — ClientReuseManifest boundary", () => {
+  it("parses ClientReuseManifest only for canonical RSC payload requests", () => {
+    const manifest = createClientReuseManifest({
+      entries: [
+        {
+          artifactCompatibility: createArtifactCompatibilityEnvelope({
+            deploymentVersion: "deploy-a",
+            graphVersion: "graph-a",
+            renderEpoch: "epoch-a",
+            rootBoundaryId: "layout:/",
+          }),
+          id: "layout:/",
+          payloadHash: createClientReusePayloadHash("root"),
+          privacy: "public",
+          variantCacheKey: "cp1:root",
+        },
+      ],
+      visibleCommitVersion: 1,
+    });
+    const header = JSON.stringify(manifest);
+
+    const rsc = normalized(
+      normalizeRscRequest(req("/page.rsc", { [VINEXT_CLIENT_REUSE_MANIFEST_HEADER]: header }), ""),
+    );
+    const html = normalized(
+      normalizeRscRequest(req("/page", { [VINEXT_CLIENT_REUSE_MANIFEST_HEADER]: header }), ""),
+    );
+
+    expect(rsc.clientReuseManifest.kind).toBe("parsed");
+    expect(html.clientReuseManifest).toEqual({ kind: "absent" });
+  });
+
+  it("keeps rejected ClientReuseManifest hints as disabled metadata instead of failing routing", () => {
+    const result = normalized(
+      normalizeRscRequest(
+        req("/page.rsc", {
+          [VINEXT_CLIENT_REUSE_MANIFEST_HEADER]: JSON.stringify({
+            entries: [],
+            hashAlgorithm: "sha512",
+            replayWindow: {
+              validFromVisibleCommitVersion: 1,
+              validUntilVisibleCommitVersion: 1,
+            },
+            schemaVersion: 1,
+            visibleCommitVersion: 1,
+          }),
+        }),
+        "",
+      ),
+    );
+
+    expect(result.clientReuseManifest).toEqual({
+      kind: "rejected",
+      rejection: {
+        code: "SKIP_HASH_ALGORITHM_UNSUPPORTED",
+        fields: { hashAlgorithm: "sha512" },
+      },
+    });
   });
 });
 

--- a/tests/client-reuse-manifest.test.ts
+++ b/tests/client-reuse-manifest.test.ts
@@ -9,6 +9,7 @@ import {
   serializeClientReuseManifest,
 } from "../packages/vinext/src/server/client-reuse-manifest.js";
 import { createArtifactCompatibilityEnvelope } from "../packages/vinext/src/server/artifact-compatibility.js";
+import { AppElementsWire } from "../packages/vinext/src/server/app-elements-wire.js";
 
 const artifactCompatibility = createArtifactCompatibilityEnvelope({
   deploymentVersion: "deploy-a",
@@ -89,6 +90,56 @@ describe("ClientReuseManifest protocol", () => {
       enabled: false,
       mode: "renderAndSend",
     });
+  });
+
+  it("serializes duplicate entry IDs once so helper output round-trips", () => {
+    const parsed = parseManifest(
+      serializeClientReuseManifest({
+        entries: [
+          {
+            artifactCompatibility,
+            id: "layout:/",
+            payloadHash: createClientReusePayloadHash("root-a"),
+            privacy: "public",
+            variantCacheKey: "cp1:root-a",
+          },
+          {
+            artifactCompatibility,
+            id: "layout:/",
+            payloadHash: createClientReusePayloadHash("root-b"),
+            privacy: "public",
+            variantCacheKey: "cp1:root-b",
+          },
+          {
+            artifactCompatibility,
+            id: "layout:/shop",
+            payloadHash: createClientReusePayloadHash("shop"),
+            privacy: "public",
+            variantCacheKey: "cp1:shop",
+          },
+        ],
+        visibleCommitVersion: 1,
+      }),
+    );
+
+    expect(parsed.manifest.entries).toEqual([
+      {
+        artifactCompatibility,
+        id: "layout:/",
+        kind: "layout",
+        payloadHash: createClientReusePayloadHash("root-a"),
+        privacy: "public",
+        variantCacheKey: "cp1:root-a",
+      },
+      {
+        artifactCompatibility,
+        id: "layout:/shop",
+        kind: "layout",
+        payloadHash: createClientReusePayloadHash("shop"),
+        privacy: "public",
+        variantCacheKey: "cp1:shop",
+      },
+    ]);
   });
 
   it("rejects oversized manifests before they can become an IO amplifier", () => {
@@ -346,29 +397,78 @@ describe("ClientReuseManifest protocol", () => {
     ]);
   });
 
+  it("accepts intercepted AppElements page and route IDs as public manifest entries", () => {
+    const pageId = AppElementsWire.encodePageId("/photos/42", "/feed");
+    const routeId = AppElementsWire.encodeRouteId("/api/photos/42", "/feed");
+    const parsed = parseManifest(
+      serializeClientReuseManifest({
+        entries: [
+          {
+            artifactCompatibility,
+            id: pageId,
+            payloadHash: createClientReusePayloadHash("page"),
+            privacy: "public",
+            variantCacheKey: "cp1:page",
+          },
+          {
+            artifactCompatibility,
+            id: routeId,
+            payloadHash: createClientReusePayloadHash("route"),
+            privacy: "public",
+            variantCacheKey: "cp1:route",
+          },
+        ],
+        visibleCommitVersion: 1,
+      }),
+    );
+
+    expect(parsed.manifest.entries).toEqual([
+      {
+        artifactCompatibility,
+        id: pageId,
+        kind: "page",
+        payloadHash: createClientReusePayloadHash("page"),
+        privacy: "public",
+        variantCacheKey: "cp1:page",
+      },
+      {
+        artifactCompatibility,
+        id: routeId,
+        kind: "route",
+        payloadHash: createClientReusePayloadHash("route"),
+        privacy: "public",
+        variantCacheKey: "cp1:route",
+      },
+    ]);
+  });
+
   it("rejects duplicate entry IDs as non-canonical ordering", () => {
     const result = parseClientReuseManifestHeader(
-      JSON.stringify(
-        createClientReuseManifest({
-          entries: [
-            {
-              artifactCompatibility,
-              id: "layout:/",
-              payloadHash: createClientReusePayloadHash("root-a"),
-              privacy: "public",
-              variantCacheKey: "cp1:root-a",
-            },
-            {
-              artifactCompatibility,
-              id: "layout:/",
-              payloadHash: createClientReusePayloadHash("root-b"),
-              privacy: "public",
-              variantCacheKey: "cp1:root-b",
-            },
-          ],
-          visibleCommitVersion: 1,
-        }),
-      ),
+      JSON.stringify({
+        entries: [
+          {
+            artifactCompatibility,
+            id: "layout:/",
+            payloadHash: createClientReusePayloadHash("root-a"),
+            privacy: "public",
+            variantCacheKey: "cp1:root-a",
+          },
+          {
+            artifactCompatibility,
+            id: "layout:/",
+            payloadHash: createClientReusePayloadHash("root-b"),
+            privacy: "public",
+            variantCacheKey: "cp1:root-b",
+          },
+        ],
+        hashAlgorithm: CLIENT_REUSE_MANIFEST_HASH_ALGORITHM,
+        replayWindow: {
+          validFromVisibleCommitVersion: 1,
+          validUntilVisibleCommitVersion: 1,
+        },
+        schemaVersion: CLIENT_REUSE_MANIFEST_SCHEMA_VERSION,
+        visibleCommitVersion: 1,
+      }),
     );
 
     expect(result).toEqual({

--- a/tests/client-reuse-manifest.test.ts
+++ b/tests/client-reuse-manifest.test.ts
@@ -1,0 +1,277 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  CLIENT_REUSE_MANIFEST_HASH_ALGORITHM,
+  CLIENT_REUSE_MANIFEST_SCHEMA_VERSION,
+  createClientReuseManifest,
+  createClientReusePayloadHash,
+  DEFAULT_CLIENT_REUSE_MANIFEST_LIMITS,
+  parseClientReuseManifestHeader,
+  serializeClientReuseManifest,
+} from "../packages/vinext/src/server/client-reuse-manifest.js";
+import { createArtifactCompatibilityEnvelope } from "../packages/vinext/src/server/artifact-compatibility.js";
+
+const artifactCompatibility = createArtifactCompatibilityEnvelope({
+  deploymentVersion: "deploy-a",
+  graphVersion: "graph-a",
+  renderEpoch: "epoch-a",
+  rootBoundaryId: "layout:/",
+});
+
+function parseManifest(header: string) {
+  const result = parseClientReuseManifestHeader(header);
+  expect(result.kind).toBe("parsed");
+  if (result.kind !== "parsed") {
+    throw new Error("Expected ClientReuseManifest to parse");
+  }
+  return result;
+}
+
+describe("ClientReuseManifest protocol", () => {
+  it("serializes entries in canonical element-id order", () => {
+    const serialized = serializeClientReuseManifest({
+      entries: [
+        {
+          artifactCompatibility,
+          id: "layout:/shop",
+          payloadHash: createClientReusePayloadHash("shop-layout"),
+          privacy: "public",
+          variantCacheKey: "cp1:shop",
+        },
+        {
+          artifactCompatibility,
+          id: "layout:/",
+          payloadHash: createClientReusePayloadHash("root-layout"),
+          privacy: "public",
+          variantCacheKey: "cp1:root",
+        },
+      ],
+      visibleCommitVersion: 7,
+    });
+
+    const parsed = parseManifest(serialized);
+
+    expect(parsed.manifest).toMatchObject({
+      hashAlgorithm: CLIENT_REUSE_MANIFEST_HASH_ALGORITHM,
+      schemaVersion: CLIENT_REUSE_MANIFEST_SCHEMA_VERSION,
+      visibleCommitVersion: 7,
+    });
+    expect(parsed.manifest.replayWindow).toEqual({
+      validFromVisibleCommitVersion: 7,
+      validUntilVisibleCommitVersion: 7,
+    });
+    expect(parsed.manifest.entries.map((entry) => entry.id)).toEqual(["layout:/", "layout:/shop"]);
+    expect(parsed.entryRejections).toEqual([]);
+    expect(parsed.skipDisposition).toEqual({
+      code: "SKIP_MODEL_DISABLED",
+      enabled: false,
+      mode: "renderAndSend",
+    });
+  });
+
+  it("rejects oversized manifests before they can become an IO amplifier", () => {
+    const result = parseClientReuseManifestHeader('{"entries":[]}', {
+      limits: { ...DEFAULT_CLIENT_REUSE_MANIFEST_LIMITS, maxManifestBytes: 8 },
+    });
+
+    expect(result).toEqual({
+      kind: "rejected",
+      rejection: {
+        code: "SKIP_MANIFEST_TOO_LARGE",
+        fields: {
+          maxManifestBytes: 8,
+          manifestBytes: 14,
+        },
+      },
+    });
+  });
+
+  it("rejects manifests whose entry count exceeds the protocol budget", () => {
+    const result = parseClientReuseManifestHeader(
+      JSON.stringify({
+        entries: [
+          {
+            artifactCompatibility,
+            id: "layout:/",
+            payloadHash: createClientReusePayloadHash("root"),
+            privacy: "public",
+            variantCacheKey: "cp1:root",
+          },
+          {
+            artifactCompatibility,
+            id: "layout:/shop",
+            payloadHash: createClientReusePayloadHash("shop"),
+            privacy: "public",
+            variantCacheKey: "cp1:shop",
+          },
+        ],
+        hashAlgorithm: CLIENT_REUSE_MANIFEST_HASH_ALGORITHM,
+        replayWindow: {
+          validFromVisibleCommitVersion: 1,
+          validUntilVisibleCommitVersion: 1,
+        },
+        schemaVersion: CLIENT_REUSE_MANIFEST_SCHEMA_VERSION,
+        visibleCommitVersion: 1,
+      }),
+      {
+        limits: { ...DEFAULT_CLIENT_REUSE_MANIFEST_LIMITS, maxEntryCount: 1 },
+      },
+    );
+
+    expect(result).toEqual({
+      kind: "rejected",
+      rejection: {
+        code: "SKIP_ENTRY_COUNT_EXCEEDED",
+        fields: {
+          entryCount: 2,
+          maxEntryCount: 1,
+        },
+      },
+    });
+  });
+
+  it("rejects unsupported hash algorithms instead of accepting unbounded digest work", () => {
+    const result = parseClientReuseManifestHeader(
+      JSON.stringify({
+        entries: [],
+        hashAlgorithm: "sha512",
+        replayWindow: {
+          validFromVisibleCommitVersion: 1,
+          validUntilVisibleCommitVersion: 1,
+        },
+        schemaVersion: CLIENT_REUSE_MANIFEST_SCHEMA_VERSION,
+        visibleCommitVersion: 1,
+      }),
+    );
+
+    expect(result).toEqual({
+      kind: "rejected",
+      rejection: {
+        code: "SKIP_HASH_ALGORITHM_UNSUPPORTED",
+        fields: { hashAlgorithm: "sha512" },
+      },
+    });
+  });
+
+  it("rejects replayed manifests outside the visible commit version window", () => {
+    const manifest = createClientReuseManifest({
+      entries: [],
+      replayWindow: {
+        validFromVisibleCommitVersion: 3,
+        validUntilVisibleCommitVersion: 3,
+      },
+      visibleCommitVersion: 3,
+    });
+
+    const result = parseClientReuseManifestHeader(JSON.stringify(manifest), {
+      currentVisibleCommitVersion: 4,
+    });
+
+    expect(result).toEqual({
+      kind: "rejected",
+      rejection: {
+        code: "SKIP_VISIBLE_COMMIT_VERSION_MISMATCH",
+        fields: {
+          currentVisibleCommitVersion: 4,
+          validFromVisibleCommitVersion: 3,
+          validUntilVisibleCommitVersion: 3,
+          visibleCommitVersion: 3,
+        },
+      },
+    });
+  });
+
+  it("ignores unknown entries and rejects private entries without rejecting known public entries", () => {
+    const manifest = createClientReuseManifest({
+      entries: [
+        {
+          artifactCompatibility,
+          id: "layout:/",
+          payloadHash: createClientReusePayloadHash("root"),
+          privacy: "public",
+          variantCacheKey: "cp1:root",
+        },
+        {
+          artifactCompatibility,
+          id: "opaque:future-entry",
+          payloadHash: createClientReusePayloadHash("future"),
+          privacy: "public",
+          variantCacheKey: "cp1:future",
+        },
+        {
+          artifactCompatibility,
+          id: "layout:/account",
+          payloadHash: createClientReusePayloadHash("account"),
+          privacy: "private",
+          variantCacheKey: "cp1:account",
+        },
+      ],
+      visibleCommitVersion: 5,
+    });
+
+    const parsed = parseManifest(JSON.stringify(manifest));
+
+    expect(parsed.manifest.entries).toEqual([
+      {
+        artifactCompatibility,
+        id: "layout:/",
+        kind: "layout",
+        payloadHash: createClientReusePayloadHash("root"),
+        privacy: "public",
+        variantCacheKey: "cp1:root",
+      },
+    ]);
+    expect(parsed.entryRejections).toEqual([
+      {
+        code: "SKIP_PRIVATE_ENTRY",
+        entryId: "layout:/account",
+        fields: { privacy: "private" },
+      },
+      {
+        code: "SKIP_UNKNOWN_ENTRY",
+        entryId: "opaque:future-entry",
+        fields: { idHash: createClientReusePayloadHash("opaque:future-entry") },
+      },
+    ]);
+  });
+
+  it("rejects non-canonical entry ordering at the manifest boundary", () => {
+    const result = parseClientReuseManifestHeader(
+      JSON.stringify({
+        entries: [
+          {
+            artifactCompatibility,
+            id: "layout:/shop",
+            payloadHash: createClientReusePayloadHash("shop"),
+            privacy: "public",
+            variantCacheKey: "cp1:shop",
+          },
+          {
+            artifactCompatibility,
+            id: "layout:/",
+            payloadHash: createClientReusePayloadHash("root"),
+            privacy: "public",
+            variantCacheKey: "cp1:root",
+          },
+        ],
+        hashAlgorithm: CLIENT_REUSE_MANIFEST_HASH_ALGORITHM,
+        replayWindow: {
+          validFromVisibleCommitVersion: 1,
+          validUntilVisibleCommitVersion: 1,
+        },
+        schemaVersion: CLIENT_REUSE_MANIFEST_SCHEMA_VERSION,
+        visibleCommitVersion: 1,
+      }),
+    );
+
+    expect(result).toEqual({
+      kind: "rejected",
+      rejection: {
+        code: "SKIP_ENTRY_ORDER_NON_CANONICAL",
+        fields: {
+          entryIdHash: createClientReusePayloadHash("layout:/"),
+          previousEntryIdHash: createClientReusePayloadHash("layout:/shop"),
+        },
+      },
+    });
+  });
+});

--- a/tests/client-reuse-manifest.test.ts
+++ b/tests/client-reuse-manifest.test.ts
@@ -383,6 +383,7 @@ describe("ClientReuseManifest protocol", () => {
         variantCacheKey: "cp1:root",
       },
     ]);
+    // Rejections preserve their canonical wire position after serialization.
     expect(parsed.entryRejections).toEqual([
       {
         code: "SKIP_PRIVATE_ENTRY",
@@ -395,6 +396,47 @@ describe("ClientReuseManifest protocol", () => {
         fields: { idHash: createClientReusePayloadHash("opaque:future-entry") },
       },
     ]);
+  });
+
+  it("rejects duplicate IDs even when the first copy is rejected per-entry", () => {
+    const result = parseClientReuseManifestHeader(
+      JSON.stringify({
+        entries: [
+          {
+            artifactCompatibility,
+            id: "layout:/account",
+            payloadHash: createClientReusePayloadHash("account-private"),
+            privacy: "private",
+            variantCacheKey: "cp1:account-private",
+          },
+          {
+            artifactCompatibility,
+            id: "layout:/account",
+            payloadHash: createClientReusePayloadHash("account-public"),
+            privacy: "public",
+            variantCacheKey: "cp1:account-public",
+          },
+        ],
+        hashAlgorithm: CLIENT_REUSE_MANIFEST_HASH_ALGORITHM,
+        replayWindow: {
+          validFromVisibleCommitVersion: 1,
+          validUntilVisibleCommitVersion: 1,
+        },
+        schemaVersion: CLIENT_REUSE_MANIFEST_SCHEMA_VERSION,
+        visibleCommitVersion: 1,
+      }),
+    );
+
+    expect(result).toEqual({
+      kind: "rejected",
+      rejection: {
+        code: "SKIP_ENTRY_ORDER_NON_CANONICAL",
+        fields: {
+          entryIdHash: createClientReusePayloadHash("layout:/account"),
+          previousEntryIdHash: createClientReusePayloadHash("layout:/account"),
+        },
+      },
+    });
   });
 
   it("accepts intercepted AppElements page and route IDs as public manifest entries", () => {

--- a/tests/client-reuse-manifest.test.ts
+++ b/tests/client-reuse-manifest.test.ts
@@ -152,6 +152,56 @@ describe("ClientReuseManifest protocol", () => {
     });
   });
 
+  it("rejects unsafe visible commit versions from the client boundary", () => {
+    const result = parseClientReuseManifestHeader(
+      JSON.stringify({
+        entries: [],
+        hashAlgorithm: CLIENT_REUSE_MANIFEST_HASH_ALGORITHM,
+        replayWindow: {
+          validFromVisibleCommitVersion: 1,
+          validUntilVisibleCommitVersion: 1,
+        },
+        schemaVersion: CLIENT_REUSE_MANIFEST_SCHEMA_VERSION,
+        visibleCommitVersion: Number.MAX_SAFE_INTEGER + 1,
+      }),
+    );
+
+    expect(result).toEqual({
+      kind: "rejected",
+      rejection: {
+        code: "SKIP_VISIBLE_COMMIT_VERSION_INVALID",
+        fields: { visibleCommitVersion: null },
+      },
+    });
+  });
+
+  it("rejects unsafe replay window bounds from the client boundary", () => {
+    const result = parseClientReuseManifestHeader(
+      JSON.stringify({
+        entries: [],
+        hashAlgorithm: CLIENT_REUSE_MANIFEST_HASH_ALGORITHM,
+        replayWindow: {
+          validFromVisibleCommitVersion: 1,
+          validUntilVisibleCommitVersion: Number.MAX_SAFE_INTEGER + 1,
+        },
+        schemaVersion: CLIENT_REUSE_MANIFEST_SCHEMA_VERSION,
+        visibleCommitVersion: 1,
+      }),
+    );
+
+    expect(result).toEqual({
+      kind: "rejected",
+      rejection: {
+        code: "SKIP_REPLAY_WINDOW_INVALID",
+        fields: {
+          validFromVisibleCommitVersion: 1,
+          validUntilVisibleCommitVersion: null,
+          visibleCommitVersion: 1,
+        },
+      },
+    });
+  });
+
   it("rejects replayed manifests outside the visible commit version window", () => {
     const manifest = createClientReuseManifest({
       entries: [],

--- a/tests/client-reuse-manifest.test.ts
+++ b/tests/client-reuse-manifest.test.ts
@@ -27,6 +27,29 @@ function parseManifest(header: string) {
 }
 
 describe("ClientReuseManifest protocol", () => {
+  it("treats absent and blank headers as absent manifests", () => {
+    for (const header of [null, undefined, "", "   "]) {
+      expect(parseClientReuseManifestHeader(header)).toEqual({ kind: "absent" });
+    }
+  });
+
+  it("parses an empty manifest without enabling skip transport", () => {
+    const parsed = parseManifest(
+      serializeClientReuseManifest({
+        entries: [],
+        visibleCommitVersion: 1,
+      }),
+    );
+
+    expect(parsed.manifest.entries).toEqual([]);
+    expect(parsed.entryRejections).toEqual([]);
+    expect(parsed.skipDisposition).toEqual({
+      code: "SKIP_MODEL_DISABLED",
+      enabled: false,
+      mode: "renderAndSend",
+    });
+  });
+
   it("serializes entries in canonical element-id order", () => {
     const serialized = serializeClientReuseManifest({
       entries: [
@@ -80,6 +103,45 @@ describe("ClientReuseManifest protocol", () => {
         fields: {
           maxManifestBytes: 8,
           manifestBytes: 14,
+        },
+      },
+    });
+  });
+
+  it("counts manifest size in UTF-8 bytes instead of JavaScript string length", () => {
+    const header = JSON.stringify({
+      entries: [
+        {
+          artifactCompatibility,
+          id: "opaque:😀",
+          payloadHash: createClientReusePayloadHash("emoji"),
+          privacy: "public",
+          variantCacheKey: "cp1:emoji",
+        },
+      ],
+      hashAlgorithm: CLIENT_REUSE_MANIFEST_HASH_ALGORITHM,
+      replayWindow: {
+        validFromVisibleCommitVersion: 1,
+        validUntilVisibleCommitVersion: 1,
+      },
+      schemaVersion: CLIENT_REUSE_MANIFEST_SCHEMA_VERSION,
+      visibleCommitVersion: 1,
+    });
+
+    const manifestBytes = new TextEncoder().encode(header).length;
+    expect(manifestBytes).toBeGreaterThan(header.length);
+
+    const result = parseClientReuseManifestHeader(header, {
+      limits: { ...DEFAULT_CLIENT_REUSE_MANIFEST_LIMITS, maxManifestBytes: header.length },
+    });
+
+    expect(result).toEqual({
+      kind: "rejected",
+      rejection: {
+        code: "SKIP_MANIFEST_TOO_LARGE",
+        fields: {
+          manifestBytes,
+          maxManifestBytes: header.length,
         },
       },
     });
@@ -282,6 +344,43 @@ describe("ClientReuseManifest protocol", () => {
         fields: { idHash: createClientReusePayloadHash("opaque:future-entry") },
       },
     ]);
+  });
+
+  it("rejects duplicate entry IDs as non-canonical ordering", () => {
+    const result = parseClientReuseManifestHeader(
+      JSON.stringify(
+        createClientReuseManifest({
+          entries: [
+            {
+              artifactCompatibility,
+              id: "layout:/",
+              payloadHash: createClientReusePayloadHash("root-a"),
+              privacy: "public",
+              variantCacheKey: "cp1:root-a",
+            },
+            {
+              artifactCompatibility,
+              id: "layout:/",
+              payloadHash: createClientReusePayloadHash("root-b"),
+              privacy: "public",
+              variantCacheKey: "cp1:root-b",
+            },
+          ],
+          visibleCommitVersion: 1,
+        }),
+      ),
+    );
+
+    expect(result).toEqual({
+      kind: "rejected",
+      rejection: {
+        code: "SKIP_ENTRY_ORDER_NON_CANONICAL",
+        fields: {
+          entryIdHash: createClientReusePayloadHash("layout:/"),
+          previousEntryIdHash: createClientReusePayloadHash("layout:/"),
+        },
+      },
+    });
   });
 
   it("rejects non-canonical entry ordering at the manifest boundary", () => {


### PR DESCRIPTION
## Summary

Implements the `#726-SKIP-01/03` roadmap slice from #726: a disabled-by-default `ClientReuseManifest` protocol boundary for future App Router skip transport work.

This PR adds:

- A typed server-side `ClientReuseManifest` parser/serializer with schema/hash/replay/visible-commit compatibility fields.
- Abuse limits for manifest bytes, entry count, entry IDs, payload hashes, and variant cache keys.
- Canonical entry ordering enforcement and bounded `fnv1a64` payload hashes.
- Per-entry rejection for malformed, private, unknown, incompatible, and over-budget entries while preserving accepted public entries.
- RSC request-boundary parsing for canonical `.rsc` payload requests only; HTML requests remain unaffected.
- Disabled skip disposition metadata (`SKIP_MODEL_DISABLED`) so this slice cannot alter rendering, routing, cache reads, or response shape.

## Contract

This is intentionally a protocol definition slice, not an enablement slice. The manifest is an untrusted client hint only:

- No client-held artifact is treated as proof.
- A rejected manifest never fails routing or rendering.
- Unknown entries are ignored through entry-level rejection metadata.
- Private entries are explicitly rejected.
- Skip transport remains disabled and always falls back to render-and-send behavior.

I searched the local Next.js reference clone for an equivalent public behavior and did not find a matching protocol; the oracle for this work is the vinext architecture described in #726.

## Validation

- `vp check`
- `vp test run tests/client-reuse-manifest.test.ts tests/app-rsc-request-normalization.test.ts tests/cache-proof.test.ts tests/app-elements.test.ts tests/navigation-planner.test.ts tests/app-rsc-handler.test.ts`
  - 6 files passed, 221 tests passed
- `pnpm knip --no-progress`
- `vp run vinext#build`
  - Build succeeded; existing package build warnings for virtual/private imports were unchanged.

## Review note for Bonk

Bonk: please read #726 before reviewing this PR. The architectural big picture matters here: `ClientReuseManifest` is only an untrusted, disabled client hint in this slice, and the design must preserve the future proof boundary between "client claims it already has bytes" and "server is allowed to skip sending bytes."

Refs #726.
